### PR TITLE
chore: bumping the provision timeout in e2e tests

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -16,7 +16,7 @@ export const signin = (): Cypress.Chainable<Cypress.Response> => {
     })
   \*/
 
-  return cy.setupUser().then((body) => {
+  return cy.setupUser().then(body => {
     return cy
       .visit('/api/v2/signin')
       .then(() => cy.get('#login').type(Cypress.env('username')))
@@ -68,7 +68,7 @@ export const createView = (
   dbID: string,
   cellID: string
 ): Cypress.Chainable<Cypress.Response> => {
-  return cy.fixture('view').then((view) => {
+  return cy.fixture('view').then(view => {
     return cy.request({
       method: 'PATCH',
       url: `/api/v2/dashboards/${dbID}/cells/${cellID}/view`,
@@ -467,7 +467,7 @@ export const lines = (numLines = 3) => {
     .map((_, i) => i)
     .reverse()
 
-  const incrementingTimes = decendingValues.map((val) => {
+  const incrementingTimes = decendingValues.map(val => {
     return now - offset_ms * val
   })
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -16,7 +16,7 @@ export const signin = (): Cypress.Chainable<Cypress.Response> => {
     })
   \*/
 
-  return cy.setupUser().then(body => {
+  return cy.setupUser().then((body) => {
     return cy
       .visit('/api/v2/signin')
       .then(() => cy.get('#login').type(Cypress.env('username')))
@@ -68,7 +68,7 @@ export const createView = (
   dbID: string,
   cellID: string
 ): Cypress.Chainable<Cypress.Response> => {
-  return cy.fixture('view').then(view => {
+  return cy.fixture('view').then((view) => {
     return cy.request({
       method: 'PATCH',
       url: `/api/v2/dashboards/${dbID}/cells/${cellID}/view`,
@@ -436,9 +436,12 @@ export const createToken = (
 
 // TODO: have to go through setup because we cannot create a user w/ a password via the user API
 export const setupUser = (): Cypress.Chainable<Cypress.Response> => {
-  return cy.request({
-    method: 'GET',
-    url: '/debug/provision',
+  return cy.fixture('user').then(() => {
+    return cy.request({
+      method: 'GET',
+      url: '/debug/provision',
+      timeout: 6000 * 5,
+    })
   })
 }
 
@@ -462,7 +465,7 @@ export const lines = (numLines = 3) => {
     .map((_, i) => i)
     .reverse()
 
-  const incrementingTimes = decendingValues.map(val => {
+  const incrementingTimes = decendingValues.map((val) => {
     return now - offset_ms * val
   })
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -434,13 +434,15 @@ export const createToken = (
   })
 }
 
+const MINUTE_MS = 1000
+
 // TODO: have to go through setup because we cannot create a user w/ a password via the user API
 export const setupUser = (): Cypress.Chainable<Cypress.Response> => {
   return cy.fixture('user').then(() => {
     return cy.request({
       method: 'GET',
       url: '/debug/provision',
-      timeout: 6000 * 5,
+      timeout: 5 * 60 * MINUTE_MS,
     })
   })
 }


### PR DESCRIPTION
our end to end tests are being flakey because of a condition where the storage engine randomly takes longer than 30s to become available. while we wait for https://github.com/influxdata/idpe/issues/8414 to get finished, i'm bumping the timeout on the request to 2m.