### PR TITLE
fix(community-templates): cleanup how we handle installation errors

### DIFF
--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -37,6 +37,7 @@ export const NOTIFICATION_TRANSITION = 250
 export const FIVE_SECONDS = 5000
 export const TEN_SECONDS = 10000
 export const FIFTEEN_SECONDS = 15000
+export const INDEFINITE = Infinity
 
 export const HOMEPAGE_PATHNAME = 'me'
 

--- a/src/shared/copy/notifications.ts
+++ b/src/shared/copy/notifications.ts
@@ -9,6 +9,7 @@ import {
   FIVE_SECONDS,
   TEN_SECONDS,
   FIFTEEN_SECONDS,
+  INDEFINITE,
 } from 'src/shared/constants/index'
 import {QUICKSTART_SCRAPER_TARGET_URL} from 'src/dataLoaders/constants/pluginConfigs'
 import {QUICKSTART_DASHBOARD_NAME} from 'src/onboarding/constants/index'
@@ -974,6 +975,7 @@ export const communityTemplateInstallFailed = (
   errorMessage: string
 ): Notification => ({
   ...defaultErrorNotification,
+  duration: INDEFINITE,
   message: `There was a problem installing the template: ${errorMessage}`,
 })
 

--- a/src/templates/components/CommunityTemplateImportOverlay.tsx
+++ b/src/templates/components/CommunityTemplateImportOverlay.tsx
@@ -116,6 +116,7 @@ class UnconnectedTemplateImportOverlay extends PureComponent<Props> {
     } catch (err) {
       this.props.notify(communityTemplateInstallFailed(err.message))
       reportError(err, {name: 'Failed to install community template'})
+      return
     }
 
     try {

--- a/src/templates/components/CommunityTemplateImportOverlay.tsx
+++ b/src/templates/components/CommunityTemplateImportOverlay.tsx
@@ -6,7 +6,10 @@ import {connect, ConnectedProps} from 'react-redux'
 import {CommunityTemplateOverlay} from 'src/templates/components/CommunityTemplateOverlay'
 
 // Actions
-import {setStagedCommunityTemplate} from 'src/templates/actions/creators'
+import {
+  setStagedCommunityTemplate,
+  setStagedTemplateUrl,
+} from 'src/templates/actions/creators'
 import {createTemplate, fetchAndSetStacks} from 'src/templates/actions/thunks'
 import {notify} from 'src/shared/actions/notifications'
 
@@ -128,6 +131,7 @@ class UnconnectedTemplateImportOverlay extends PureComponent<Props> {
       event('template_install', {templateName: templateDetails.name})
 
       this.props.notify(communityTemplateInstallSucceeded(templateDetails.name))
+      this.props.setStagedTemplateUrl('')
     } catch (err) {
       this.props.notify(communityTemplateRenameFailed())
       reportError(err, {name: 'The community template rename failed'})
@@ -187,9 +191,10 @@ const mstp = (state: AppState, props: RouterProps) => {
 
 const mdtp = {
   createTemplate,
+  fetchAndSetStacks,
   notify,
   setStagedCommunityTemplate,
-  fetchAndSetStacks,
+  setStagedTemplateUrl,
 }
 
 const connector = connect(mstp, mdtp)

--- a/src/templates/containers/CommunityTemplatesIndex.tsx
+++ b/src/templates/containers/CommunityTemplatesIndex.tsx
@@ -64,10 +64,6 @@ type Props = ReduxProps & RouteComponentProps<{templateName: string}>
 
 @ErrorHandling
 class UnconnectedTemplatesIndex extends Component<Props> {
-  state = {
-    templateUrl: '',
-  }
-
   public componentDidMount() {
     // if this component mounts, and the install template is on the screen
     // (i.e. the user reloaded the page with the install template active)
@@ -81,13 +77,13 @@ class UnconnectedTemplatesIndex extends Component<Props> {
       match?.params?.templateName &&
       match?.params?.templateExtension
     ) {
-      this.setState({
-        templateUrl: getGithubUrlFromTemplateDetails(
+      this.props.setStagedTemplateUrl(
+        getGithubUrlFromTemplateDetails(
           match.params.directory,
           match.params.templateName,
           match.params.templateExtension
-        ),
-      })
+        )
+      )
     }
   }
 
@@ -139,7 +135,7 @@ class UnconnectedTemplatesIndex extends Component<Props> {
                     onChange={this.handleTemplateChange}
                     placeholder="Enter the URL of an InfluxDB Template..."
                     style={{flex: '1 0 0'}}
-                    value={this.state.templateUrl}
+                    value={this.props.stagedTemplateUrl}
                     testID="lookup-template-input"
                     size={ComponentSize.Large}
                   />
@@ -180,16 +176,14 @@ class UnconnectedTemplatesIndex extends Component<Props> {
   }
 
   private startTemplateInstall = () => {
-    if (!this.state.templateUrl) {
+    if (!this.props.stagedTemplateUrl) {
       this.props.notify(communityTemplateUnsupportedFormatError())
       return false
     }
 
     try {
-      this.props.setStagedTemplateUrl(this.state.templateUrl)
-
       event('template_click_lookup', {
-        templateName: getTemplateNameFromUrl(this.state.templateUrl).name,
+        templateName: getTemplateNameFromUrl(this.props.stagedTemplateUrl).name,
       })
 
       this.props.history.push(
@@ -203,8 +197,8 @@ class UnconnectedTemplatesIndex extends Component<Props> {
     }
   }
 
-  private handleTemplateChange = evt => {
-    this.setState({templateUrl: evt.target.value})
+  private handleTemplateChange = event => {
+    this.props.setStagedTemplateUrl(event.target.value)
   }
 
   private onClickBrowseCommunityTemplates = () => {
@@ -217,6 +211,7 @@ class UnconnectedTemplatesIndex extends Component<Props> {
 const mstp = (state: AppState) => {
   return {
     org: getOrg(state),
+    stagedTemplateUrl: state.resources.templates.stagedTemplateUrl,
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/19051

- If the template fails installation, it stops installation, rather than attempting to rename the uninstalled template and showing two weird error messages
- Installation messages are shown in the notification indefinitely, and must be closed by the user or navigated away from the page.

- Added a small bit: after a template is successfully installed, it clears the input