### PR TITLE
fix(client-lib): fix client library redirect bug

### DIFF
--- a/cypress/e2e/buckets.test.ts
+++ b/cypress/e2e/buckets.test.ts
@@ -295,10 +295,7 @@ describe('Buckets', () => {
         // writing a well-formed line is accepted
         cy.getByTestID('add-data--button').click()
         cy.getByTestID('bucket-add-client-library').click()
-        cy.location('pathname').should(
-          'be',
-          `/orgs/${orgID}/load-data/client-libraries`
-        )
+        cy.location('pathname').should('be', `/orgs/${orgID}/load-data/`)
         cy.go('back')
         cy.getByTestID('add-data--button').click()
 

--- a/src/buckets/components/BucketCardActions.tsx
+++ b/src/buckets/components/BucketCardActions.tsx
@@ -82,7 +82,7 @@ const BucketCardActions: FC<Props> = ({
     onSetDataLoadersBucket(orgID, bucket.name, bucket.id)
     onSetDataLoadersType(DataLoaderType.ClientLibrary)
 
-    history.push(`/orgs/${orgID}/load-data/client-libraries`)
+    history.push(`/orgs/${orgID}/load-data/`)
   }
 
   const handleAddScraper = () => {


### PR DESCRIPTION
Updated the redirect so that clicking on the load data client libraries redirects to the new load data page rather than the old client libraries

![client-lib-fix](https://user-images.githubusercontent.com/19984220/92041768-b9847b80-ed2d-11ea-9e96-d49fa847c2d2.gif)
