### PR TITLE
fix: remove export as template option from export overlay

### DIFF
--- a/src/shared/components/ExportOverlay.tsx
+++ b/src/shared/components/ExportOverlay.tsx
@@ -1,5 +1,4 @@
 import React, {PureComponent} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
 import {get} from 'lodash'
 
 // Components
@@ -12,9 +11,6 @@ import {
 } from '@influxdata/clockface'
 import {Controlled as ReactCodeMirror} from 'react-codemirror2'
 import CopyButton from 'src/shared/components/CopyButton'
-
-// Actions
-import {createTemplateFromResource} from 'src/templates/actions/thunks'
 
 // Utils
 import {downloadTextFile} from 'src/shared/utils/download'
@@ -33,10 +29,9 @@ interface OwnProps {
   isVisible: boolean
 }
 
-type ReduxProps = ConnectedProps<typeof connector>
-type Props = OwnProps & ReduxProps
+type Props = OwnProps
 
-class ExportOverlay extends PureComponent<Props> {
+export default class ExportOverlay extends PureComponent<Props> {
   public static defaultProps = {
     isVisible: true,
   }
@@ -62,7 +57,6 @@ class ExportOverlay extends PureComponent<Props> {
             </Overlay.Body>
             <Overlay.Footer>
               {this.downloadButton}
-              {this.toTemplateButton}
               {this.copyButton}
             </Overlay.Footer>
           </Form>
@@ -126,40 +120,10 @@ class ExportOverlay extends PureComponent<Props> {
     )
   }
 
-  private get toTemplateButton(): JSX.Element {
-    return (
-      <Button
-        text="Save as template"
-        onClick={this.handleConvertToTemplate}
-        color={ComponentColor.Primary}
-      />
-    )
-  }
-
   private handleExport = (): void => {
     const {resource, resourceName, onDismissOverlay} = this.props
     const name = get(resource, 'content.data.attributes.name', resourceName)
     downloadTextFile(JSON.stringify(resource, null, 1), name, '.json')
     onDismissOverlay()
   }
-
-  private handleConvertToTemplate = () => {
-    const {
-      resource,
-      onDismissOverlay,
-      resourceName,
-      onCreateTemplateFromResource,
-    } = this.props
-
-    onCreateTemplateFromResource(resource, resourceName)
-    onDismissOverlay()
-  }
 }
-
-const mdtp = {
-  onCreateTemplateFromResource: createTemplateFromResource,
-}
-
-const connector = connect(null, mdtp)
-
-export default connector(ExportOverlay)

--- a/src/templates/actions/thunks.ts
+++ b/src/templates/actions/thunks.ts
@@ -96,20 +96,6 @@ export const createTemplate = (template: DocumentCreate) => async (
   }
 }
 
-export const createTemplateFromResource = (
-  resource: DocumentCreate,
-  resourceName: string
-) => async (dispatch: Dispatch<Action>, getState: GetState) => {
-  try {
-    const org = getOrg(getState())
-    await client.templates.create({...resource, orgID: org.id})
-    dispatch(notify(copy.resourceSavedAsTemplate(resourceName)))
-  } catch (error) {
-    console.error(error)
-    dispatch(notify(copy.saveResourceAsTemplateFailed(resourceName, error)))
-  }
-}
-
 export const updateTemplate = (id: string, props: TemplateSummary) => async (
   dispatch: Dispatch<Action>,
   getState: GetState


### PR DESCRIPTION
Connects https://github.com/influxdata/influxdb/issues/19447

First part of the above ticket:

- Removes Save as Template button from the export overlay

Related to: https://github.com/influxdata/influxdb/pull/19300

### Previously:
![Screen Shot 2020-09-03 at 10 18 12 AM](https://user-images.githubusercontent.com/146112/92148995-38cb8b00-edd2-11ea-96ea-c8c889dae579.png)

### Now:
![Screen Shot 2020-09-03 at 10 42 31 AM](https://user-images.githubusercontent.com/146112/92149002-3bc67b80-edd2-11ea-87c0-16a69aba1851.png)
