### PR TITLE
feat: add x axis domain manipulation to scatter plot

### DIFF
--- a/src/shared/components/ScatterPlot.tsx
+++ b/src/shared/components/ScatterPlot.tsx
@@ -22,12 +22,11 @@ import {DEFAULT_LINE_COLORS} from 'src/shared/constants/graphColorPalettes'
 import {INVALID_DATA_COPY} from 'src/shared/copy/cell'
 
 // Types
-import {ScatterViewProperties, TimeZone, TimeRange, Theme} from 'src/types'
+import {ScatterViewProperties, TimeZone, Theme} from 'src/types'
 
 interface Props {
   children: (config: Config) => JSX.Element
   fluxGroupKeyUnion?: string[]
-  timeRange: TimeRange | null
   table: Table
   timeZone: TimeZone
   viewProperties: ScatterViewProperties
@@ -36,7 +35,6 @@ interface Props {
 
 const ScatterPlot: FunctionComponent<Props> = ({
   children,
-  timeRange,
   timeZone,
   table,
   viewProperties: {
@@ -67,8 +65,7 @@ const ScatterPlot: FunctionComponent<Props> = ({
 
   const [xDomain, onSetXDomain, onResetXDomain] = useVisXDomainSettings(
     storedXDomain,
-    table.getColumn(xColumn, 'number'),
-    timeRange
+    table.getColumn(xColumn, 'number')
   )
 
   const [yDomain, onSetYDomain, onResetYDomain] = useVisYDomainSettings(

--- a/src/shared/components/ViewSwitcher.tsx
+++ b/src/shared/components/ViewSwitcher.tsx
@@ -206,7 +206,6 @@ const ViewSwitcher: FunctionComponent<Props> = ({
     case 'scatter':
       return (
         <ScatterPlot
-          timeRange={timeRange}
           table={table}
           viewProperties={properties}
           timeZone={timeZone}

--- a/src/timeMachine/components/view_options/ScatterOptions.tsx
+++ b/src/timeMachine/components/view_options/ScatterOptions.tsx
@@ -16,6 +16,7 @@ import {
   setAxisPrefix,
   setAxisSuffix,
   setColorHexes,
+  setXDomain,
   setYDomain,
   setXColumn,
   setYColumn,
@@ -76,10 +77,14 @@ const ScatterOptions: SFC<Props> = props => {
     onSetColors,
     onSetYAxisLabel,
     onSetXAxisLabel,
+    xPrefix,
+    xSuffix,
     yPrefix,
     ySuffix,
     onUpdateAxisSuffix,
     onUpdateAxisPrefix,
+    xDomain,
+    onSetXDomain,
     yDomain,
     onSetYDomain,
     xColumn,
@@ -173,6 +178,20 @@ const ScatterOptions: SFC<Props> = props => {
           onChange={e => onSetXAxisLabel(e.target.value)}
         />
       </Form.Element>
+      <Grid.Row>
+        <AxisAffixes
+          prefix={xPrefix}
+          suffix={xSuffix}
+          axisName="x"
+          onUpdateAxisPrefix={prefix => onUpdateAxisPrefix(prefix, 'x')}
+          onUpdateAxisSuffix={suffix => onUpdateAxisSuffix(suffix, 'x')}
+        />
+      </Grid.Row>
+      <AutoDomainInput
+        domain={xDomain as [number, number]}
+        onSetDomain={onSetXDomain}
+        label="X Axis Domain"
+      />
       <h5 className="view-options--header">Y Axis</h5>
       <Form.Element label="Y Axis Label">
         <Input
@@ -229,6 +248,7 @@ const mdtp = {
   onSetXAxisLabel: setXAxisLabel,
   onUpdateAxisPrefix: setAxisPrefix,
   onUpdateAxisSuffix: setAxisSuffix,
+  onSetXDomain: setXDomain,
   onSetYDomain: setYDomain,
   onSetXColumn: setXColumn,
   onSetYColumn: setYColumn,


### PR DESCRIPTION
https://github.com/influxdata/influxdb/issues/18981

was a bit unsure about the acceptance criteria for this one, but it seems like we wanted to add the ability to manually set the domain on the x axis for histograms and scatter plots. it exists on histograms, so i just added it onto the scatter plots. also went through and fixed whatever was making the giant auto domain range as well. Problem seemed rooted in mimicking the XYPlot interface to giraffe and assuming that time was significant on the scatter plot, when it's not (more of an explicit declaration of the requirement, whereas XY is more implicit)