### PR TITLE
feat(community-templates): telegraf now links to setup instructions

### DIFF
--- a/cypress/e2e/communityTemplates.test.ts
+++ b/cypress/e2e/communityTemplates.test.ts
@@ -168,7 +168,10 @@ describe('Community Templates', () => {
         .contains('Telegraf')
         .siblings('td')
         .click('left')
-      cy.url().should('include', 'load-data/telegrafs')
+      cy.url().should(
+        'match',
+        /.*\/load-data\/telegrafs\/[\w\d]+\/instructions/
+      )
       cy.go('back')
 
       cy.getByTestID('template-resource-link').click()

--- a/src/templates/components/CommunityTemplatesResourceSummary.tsx
+++ b/src/templates/components/CommunityTemplatesResourceSummary.tsx
@@ -155,7 +155,7 @@ export const CommunityTemplatesResourceSummary: FC<Props> = ({
             <td>{resource.kind}</td>
             <td>
               <CommunityTemplateHumanReadableResource
-                link={`/orgs/${orgID}/load-data/telegrafs/${resource.resourceID}/view`}
+                link={`/orgs/${orgID}/load-data/telegrafs/${resource.resourceID}/instructions`}
                 metaName={resource.templateMetaName}
                 resourceID={resource.resourceID}
               />


### PR DESCRIPTION
Quick fix, there's no ticket associated with this. Changes where the telegraf link goes to in the installed templates list.

### Previously:
![Screen Shot 2020-09-08 at 4 33 19 PM](https://user-images.githubusercontent.com/146112/92537483-14681800-f1f1-11ea-9c01-128bdfce9ca5.png)

### Now:
![Screen Shot 2020-09-08 at 4 33 14 PM](https://user-images.githubusercontent.com/146112/92537469-0e723700-f1f1-11ea-99d4-e85ff771cf77.png)
