### PR TITLE
fix: change to setup instructions rendering only

### DIFF
--- a/cypress/e2e/communityTemplates.test.ts
+++ b/cypress/e2e/communityTemplates.test.ts
@@ -231,7 +231,7 @@ describe('Community Templates', () => {
 
     it('takes you to github readme when you click on the Community Templates button', () => {
       cy.getByTestID('community-template-readme-overlay-button').click()
-      cy.get('.markdown-format').should('contain', 'Docker Monitoring template')
+      cy.get('.markdown-format').should('contain', 'Setup Instructions')
     })
 
     it('Can delete template', () => {

--- a/cypress/e2e/communityTemplates.test.ts
+++ b/cypress/e2e/communityTemplates.test.ts
@@ -73,7 +73,7 @@ describe('Community Templates', () => {
 
     //check that valid read me appears
     cy.getByTestID('community-templates-readme-tab').click()
-    cy.get('.markdown-format').should('contain', 'Downsampling Template')
+    cy.get('.markdown-format').should('contain', 'Setup Instructions')
   })
 
   describe('Opening the install overlay', () => {

--- a/src/templates/actions/thunks.ts
+++ b/src/templates/actions/thunks.ts
@@ -283,7 +283,13 @@ export const fetchAndSetReadme = (name: string, directory: string) => async (
 ): Promise<void> => {
   try {
     const response = await fetchReadMe(directory)
-    dispatch(setTemplateReadMe(name, response))
+    const setupInstuctions =
+      '## Setup Instructions' + response.split('Setup Instructions')[1]
+    setupInstuctions.replace(
+      'screenshot.png',
+      `https://raw.githubusercontent.com/influxdata/community-templates/master/${directory}/screenshot.png`
+    )
+    dispatch(setTemplateReadMe(name, setupInstuctions))
   } catch (error) {
     reportError(error, {
       name: `The community template github readme fetch failed for ${name}`,

--- a/src/templates/actions/thunks.ts
+++ b/src/templates/actions/thunks.ts
@@ -284,11 +284,7 @@ export const fetchAndSetReadme = (name: string, directory: string) => async (
   try {
     const response = await fetchReadMe(directory)
     const setupInstuctions =
-      '## Setup Instructions' + response.split('Setup Instructions')[1]
-    setupInstuctions.replace(
-      'screenshot.png',
-      `https://raw.githubusercontent.com/influxdata/community-templates/master/${directory}/screenshot.png`
-    )
+      '## Setup Instructions' + response.split('## Setup Instructions')[1]
     dispatch(setTemplateReadMe(name, setupInstuctions))
   } catch (error) {
     reportError(error, {


### PR DESCRIPTION
And add the proper url for screenshots. Which i am assuming any photos in setup instructions are named screenshot, we might need to make a change to this code. This means any text below setup instructions in rendered, all other code discarded.

Closes #19502

