### PR TITLE
fix(dashboard-var-hydration): limiting variable hydration of the dashboard to those within the view

### DIFF
--- a/src/dashboards/actions/thunks.ts
+++ b/src/dashboards/actions/thunks.ts
@@ -366,9 +366,6 @@ export const getDashboard = (
       throw new Error(resp.data.message)
     }
 
-    const skipCache = true
-    dispatch(hydrateVariables(skipCache, controller))
-
     const normDash = normalize<Dashboard, DashboardEntities, string>(
       resp.data,
       dashboardSchema
@@ -394,6 +391,8 @@ export const getDashboard = (
         creators.setDashboard(dashboardID, RemoteDataState.Done, normDash)
       )
       dispatch(updateTimeRangeFromQueryParams(dashboardID))
+      const skipCache = true
+      dispatch(hydrateVariables(skipCache, controller))
     }, 0)
   } catch (error) {
     if (error.name === 'AbortError') {

--- a/src/dashboards/actions/thunks.ts
+++ b/src/dashboards/actions/thunks.ts
@@ -391,8 +391,12 @@ export const getDashboard = (
         creators.setDashboard(dashboardID, RemoteDataState.Done, normDash)
       )
       dispatch(updateTimeRangeFromQueryParams(dashboardID))
-      const skipCache = true
-      dispatch(hydrateVariables(skipCache, controller))
+
+      // prevent all the variables from being hydrated if the dashboard is empty
+      if (cellViews.length > 0) {
+        const skipCache = true
+        dispatch(hydrateVariables(skipCache, controller))
+      }
     }, 0)
   } catch (error) {
     if (error.name === 'AbortError') {


### PR DESCRIPTION
Closes #53 

### Problem

Variable hydration is currently only context aware when the view has been set. If no view has been set, then all of the variables will be hydrated. 

### Solution

This issue stems from the fact that the way we are limiting variable hydration is dependent upon the view. Since this current implementation depends on the concept of a view to limit variable hydration, simply changing the order with which things are dispatched (i.e. first the view, then the variables) allows the dashboard to limit variable hydration based on its current implementation. 

Below is an example of three different dashboards:

![dashboard-var-hydration](https://user-images.githubusercontent.com/19984220/92649853-80ee2000-f2a0-11ea-901b-9b99567d8ad9.gif)

The first example shows 2 queries being issued (1 for the cell, 1 for the buckets query variable)
The second example shows 3 queries being issued (1 for each cell, none for the query variables since none are used)
The final example shows 5 queries being issues (1 for each cell, 1 for each query variable being used / nested)

The last example also shows the impact of variable caching, since cell 1 and cell 2 each depend upon overlapping variables