### PR TITLE
chore: rename reportError => reportErrorThroughHoneyBadger

### DIFF
--- a/src/checks/actions/thunks.ts
+++ b/src/checks/actions/thunks.ts
@@ -14,7 +14,7 @@ import {checkSchema, arrayOfChecks} from 'src/schemas/checks'
 
 // Utils
 import {incrementCloneName} from 'src/utils/naming'
-import {reportError} from 'src/shared/utils/errors'
+import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
 import {createView} from 'src/views/helpers'
 import {getOrg} from 'src/organizations/selectors'
 import {toPostCheck, builderToPostCheck} from 'src/checks/utils'
@@ -178,7 +178,7 @@ export const createCheckFromTimeMachine = () => async (
     const message = getErrorMessage(error)
     dispatch(notify(copy.createCheckFailed(message)))
     if (!message.includes(rename)) {
-      reportError(error, {
+      reportErrorThroughHoneyBadger(error, {
         context: {state: getState()},
         name: 'saveCheckFromTimeMachine function',
       })
@@ -222,7 +222,7 @@ export const updateCheckFromTimeMachine = () => async (
   } catch (error) {
     console.error(error)
     dispatch(notify(copy.updateCheckFailed(error.message)))
-    reportError(error, {
+    reportErrorThroughHoneyBadger(error, {
       context: {state: getState()},
       name: 'saveCheckFromTimeMachine function',
     })

--- a/src/cloud/actions/demodata.ts
+++ b/src/cloud/actions/demodata.ts
@@ -24,7 +24,7 @@ import {
 } from 'src/shared/copy/notifications'
 
 // Utils
-import {reportError} from 'src/shared/utils/errors'
+import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
 import {getErrorMessage} from 'src/utils/api'
 import {event} from 'src/cloud/utils/reporting'
 
@@ -65,7 +65,7 @@ export const getDemoDataBuckets = () => async (
   } catch (error) {
     console.error(error)
 
-    reportError(error, {
+    reportErrorThroughHoneyBadger(error, {
       name: 'getDemoDataBuckets function',
     })
 
@@ -92,7 +92,7 @@ export const getDemoDataBucketMembership = ({
       notify(demoDataAddBucketFailed(bucketName, getErrorMessage(error)))
     )
 
-    reportError(error, {
+    reportErrorThroughHoneyBadger(error, {
       name: 'addDemoDataBucket failed in getDemoDataBucketMembership',
     })
 
@@ -119,7 +119,7 @@ export const getDemoDataBucketMembership = ({
     dispatch(notify(demoDataAddBucketFailed(bucketName, errorMessage)))
 
     if (errorMessage != 'creating dashboard would exceed quota') {
-      reportError(error, {
+      reportErrorThroughHoneyBadger(error, {
         name: 'addDemoDataDashboard failed in getDemoDataBucketMembership',
       })
     }
@@ -144,7 +144,7 @@ export const deleteDemoDataBucketMembership = (
   } catch (error) {
     dispatch(notify(demoDataDeleteBucketFailed(bucket.name, error)))
 
-    reportError(error, {
+    reportErrorThroughHoneyBadger(error, {
       name: 'deleteDemoDataBucket failed in deleteDemoDataBucketMembership',
     })
   }

--- a/src/shared/components/ErrorBoundary.tsx
+++ b/src/shared/components/ErrorBoundary.tsx
@@ -5,7 +5,10 @@ import React, {Component, ErrorInfo} from 'react'
 import DefaultErrorMessage from 'src/shared/components/DefaultErrorMessage'
 
 // Utils
-import {reportError, parseComponentName} from 'src/shared/utils/errors'
+import {
+  reportErrorThroughHoneyBadger,
+  parseComponentName,
+} from 'src/shared/utils/errors'
 
 // Types
 import {ErrorMessageComponent} from 'src/types'
@@ -28,7 +31,9 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   }
 
   public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    reportError(error, {component: parseComponentName(errorInfo)})
+    reportErrorThroughHoneyBadger(error, {
+      component: parseComponentName(errorInfo),
+    })
   }
 
   public render() {

--- a/src/shared/decorators/errors.tsx
+++ b/src/shared/decorators/errors.tsx
@@ -1,5 +1,5 @@
-/* 
-tslint:disable no-console 
+/*
+tslint:disable no-console
 tslint:disable max-classes-per-file
 */
 
@@ -10,7 +10,10 @@ import React, {Component, ErrorInfo} from 'react'
 import DefaultErrorMessage from 'src/shared/components/DefaultErrorMessage'
 
 // Utils
-import {reportError, parseComponentName} from 'src/shared/utils/errors'
+import {
+  reportErrorThroughHoneyBadger,
+  parseComponentName,
+} from 'src/shared/utils/errors'
 
 // Types
 import {ErrorMessageComponent} from 'src/types'
@@ -30,7 +33,9 @@ export function ErrorHandlingWith(Error: ErrorMessageComponent) {
         this.error = error
         this.forceUpdate()
 
-        reportError(error, {component: parseComponentName(errorInfo)})
+        reportErrorThroughHoneyBadger(error, {
+          component: parseComponentName(errorInfo),
+        })
       }
 
       public render() {

--- a/src/shared/utils/errors.ts
+++ b/src/shared/utils/errors.ts
@@ -22,7 +22,7 @@ interface HoneyBadgerAdditionalOptions {
   params?: {[key: string]: any}
 }
 
-export const reportError = (
+export const reportErrorThroughHoneyBadger = (
   error: Error,
   additionalOptions?: HoneyBadgerAdditionalOptions
 ): void => {

--- a/src/templates/actions/thunks.ts
+++ b/src/templates/actions/thunks.ts
@@ -49,7 +49,7 @@ import {
 import {templateToExport} from 'src/shared/utils/resourceToTemplate'
 import {getOrg} from 'src/organizations/selectors'
 import {getLabels, getStatus} from 'src/resources/selectors'
-import {reportError} from 'src/shared/utils/errors'
+import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
 
 type Action = TemplateAction | NotifyAction
 
@@ -285,7 +285,7 @@ export const fetchAndSetReadme = (name: string, directory: string) => async (
     const response = await fetchReadMe(directory)
     dispatch(setTemplateReadMe(name, response))
   } catch (error) {
-    reportError(error, {
+    reportErrorThroughHoneyBadger(error, {
       name: `The community template github readme fetch failed for ${name}`,
     })
     dispatch(

--- a/src/templates/components/CommunityTemplateImportOverlay.tsx
+++ b/src/templates/components/CommunityTemplateImportOverlay.tsx
@@ -22,7 +22,7 @@ import {ComponentStatus} from '@influxdata/clockface'
 // Utils
 import {getByID} from 'src/resources/selectors'
 import {getTemplateNameFromUrl} from 'src/templates/utils'
-import {reportError} from 'src/shared/utils/errors'
+import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
 
 import {
   installTemplate,
@@ -93,7 +93,7 @@ class UnconnectedTemplateImportOverlay extends PureComponent<Props> {
       return summary
     } catch (err) {
       this.props.notify(communityTemplateInstallFailed(err.message))
-      reportError(err, {
+      reportErrorThroughHoneyBadger(err, {
         name: 'The community template fetch for preview failed',
       })
     }
@@ -117,7 +117,9 @@ class UnconnectedTemplateImportOverlay extends PureComponent<Props> {
       )
     } catch (err) {
       this.props.notify(communityTemplateInstallFailed(err.message))
-      reportError(err, {name: 'Failed to install community template'})
+      reportErrorThroughHoneyBadger(err, {
+        name: 'Failed to install community template',
+      })
       return
     }
 
@@ -133,7 +135,9 @@ class UnconnectedTemplateImportOverlay extends PureComponent<Props> {
       this.props.setStagedTemplateUrl('')
     } catch (err) {
       this.props.notify(communityTemplateRenameFailed())
-      reportError(err, {name: 'The community template rename failed'})
+      reportErrorThroughHoneyBadger(err, {
+        name: 'The community template rename failed',
+      })
     } finally {
       this.props.fetchAndSetStacks(this.props.org.id)
       this.onDismiss()

--- a/src/templates/components/CommunityTemplatesInstalledList.tsx
+++ b/src/templates/components/CommunityTemplatesInstalledList.tsx
@@ -34,7 +34,7 @@ import {TemplateKind} from 'src/client'
 import {deleteStack} from 'src/templates/api'
 
 //Utils
-import {reportError} from 'src/shared/utils/errors'
+import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
 
 import {event} from 'src/cloud/utils/reporting'
 
@@ -63,7 +63,9 @@ class CommunityTemplatesInstalledListUnconnected extends PureComponent<Props> {
       this.props.fetchAndSetStacks(this.props.orgID)
     } catch (err) {
       this.props.notify(communityTemplateFetchStackFailed(err.message))
-      reportError(err, {name: 'The community template fetch stack failed'})
+      reportErrorThroughHoneyBadger(err, {
+        name: 'The community template fetch stack failed',
+      })
     }
   }
 
@@ -90,7 +92,9 @@ class CommunityTemplatesInstalledListUnconnected extends PureComponent<Props> {
         this.props.notify(communityTemplateDeleteSucceeded(stackName))
       } catch (err) {
         this.props.notify(communityTemplateDeleteFailed(err.message))
-        reportError(err, {name: 'The community template delete failed'})
+        reportErrorThroughHoneyBadger(err, {
+          name: 'The community template delete failed',
+        })
       } finally {
         this.props.fetchAndSetStacks(this.props.orgID)
       }

--- a/src/templates/containers/CommunityTemplatesIndex.tsx
+++ b/src/templates/containers/CommunityTemplatesIndex.tsx
@@ -43,7 +43,7 @@ import {
   getGithubUrlFromTemplateDetails,
   getTemplateNameFromUrl,
 } from 'src/templates/utils'
-import {reportError} from 'src/shared/utils/errors'
+import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
 
 import {communityTemplateUnsupportedFormatError} from 'src/shared/copy/notifications'
 
@@ -191,7 +191,7 @@ class UnconnectedTemplatesIndex extends Component<Props> {
       )
     } catch (err) {
       this.props.notify(communityTemplateUnsupportedFormatError())
-      reportError(err, {
+      reportErrorThroughHoneyBadger(err, {
         name: 'The community template getTemplateDetails failed',
       })
     }


### PR DESCRIPTION
### What

Renames `reportError` to `reportErrorThroughHoneyBadger` since that's what it's doing.

### Why

Work ahead of adding a `reportError` function which will only write an error point, not alert HoneyBadger.

### Future Usage
`reportErrorThroughHoneyBadger`: there has been an error that affects the user's experience, and they're aware of it. We should likely look into these kinds of errors immediately.

`reportError`: an error has been triggered, most likely by user interaction, but it's not worth addressing at the moment. We want to measure it and track it and look at it as part of a larger trend, not something to respond to in the moment.