### PR TITLE
chore: template parameterization bucket follow up

### DIFF
--- a/src/dataLoaders/components/BucketsDropdown.tsx
+++ b/src/dataLoaders/components/BucketsDropdown.tsx
@@ -14,6 +14,7 @@ interface Props {
   selectedBucketID: string
   buckets: Bucket[]
   onSelectBucket: (bucket: Bucket) => void
+  style?: {[key: string]: string}
 }
 
 class BucketsDropdown extends PureComponent<Props> {
@@ -36,6 +37,7 @@ class BucketsDropdown extends PureComponent<Props> {
             {this.dropdownBuckets}
           </Dropdown.Menu>
         )}
+        style={this.props.style}
       />
     )
   }

--- a/src/templates/components/CommunityTemplateEnvReferences.tsx
+++ b/src/templates/components/CommunityTemplateEnvReferences.tsx
@@ -107,6 +107,7 @@ class CommunityTemplateEnvReferencesUnconnected extends PureComponent<
                       selectedBucketID={this.state.selectedBucketID}
                       buckets={[defaultValueAsBucket, ...this.props.buckets]}
                       onSelectBucket={this.createRefBucketSelectHandler(ref)}
+                      style={{width: '225px'}}
                     />
                   </Table.Cell>
                 </Table.Row>

--- a/src/templates/components/CommunityTemplateImportOverlay.tsx
+++ b/src/templates/components/CommunityTemplateImportOverlay.tsx
@@ -10,8 +10,11 @@ import {
   setStagedCommunityTemplate,
   setStagedTemplateUrl,
 } from 'src/templates/actions/creators'
-import {createTemplate, fetchAndSetStacks} from 'src/templates/actions/thunks'
+
 import {notify} from 'src/shared/actions/notifications'
+
+import {createTemplate, fetchAndSetStacks} from 'src/templates/actions/thunks'
+import {getBuckets} from 'src/buckets/actions/thunks'
 
 import {getTotalResourceCount} from 'src/templates/selectors'
 
@@ -135,9 +138,11 @@ class UnconnectedTemplateImportOverlay extends PureComponent<Props> {
 
       event('template_install', {templateName: templateDetails.name})
 
-      this.props.notify(communityTemplateInstallSucceeded(templateDetails.name))
       this.props.setStagedTemplateUrl('')
       this.props.setTemplateUrlValidationMessage('')
+
+      this.props.getBuckets()
+      this.props.notify(communityTemplateInstallSucceeded(templateDetails.name))
     } catch (err) {
       this.props.notify(communityTemplateRenameFailed())
       reportErrorThroughHoneyBadger(err, {
@@ -201,6 +206,7 @@ const mstp = (state: AppState, props: RouterProps) => {
 
 const mdtp = {
   createTemplate,
+  getBuckets,
   fetchAndSetStacks,
   notify,
   setStagedCommunityTemplate,

--- a/src/templates/components/CommunityTemplatesInstalledList.tsx
+++ b/src/templates/components/CommunityTemplatesInstalledList.tsx
@@ -24,7 +24,9 @@ import {
   communityTemplateDeleteFailed,
   communityTemplateFetchStackFailed,
 } from 'src/shared/copy/notifications'
+
 import {fetchAndSetStacks} from 'src/templates/actions/thunks'
+import {getBuckets} from 'src/buckets/actions/thunks'
 
 // Types
 import {AppState} from 'src/types'
@@ -90,6 +92,7 @@ class CommunityTemplatesInstalledListUnconnected extends PureComponent<Props> {
         event('template_delete', {templateName: stackName})
 
         this.props.notify(communityTemplateDeleteSucceeded(stackName))
+        this.props.getBuckets()
       } catch (err) {
         this.props.notify(communityTemplateDeleteFailed(err.message))
         reportErrorThroughHoneyBadger(err, {
@@ -206,6 +209,7 @@ const mstp = (state: AppState) => {
 }
 
 const mdtp = {
+  getBuckets,
   fetchAndSetStacks,
   notify,
 }


### PR DESCRIPTION
- Adds a width, style property to the bucket dropdown
- When installing a template or removing a template, re-fetch buckets.
  - This might cause performance issues on installs with lots of buckets