### PR TITLE
fix: save 'mainColumn' properly and set 'upperColumn' and 'lowerColumn' explicitly

### DIFF
--- a/src/shared/components/BandPlot.tsx
+++ b/src/shared/components/BandPlot.tsx
@@ -32,7 +32,6 @@ import {
   BAND_SHADE_OPACITY,
   LEGEND_OPACITY_DEFAULT,
   QUERY_BUILDER_MODE,
-  SCRIPT_EDITOR_MODE,
   VIS_THEME,
   VIS_THEME_LIGHT,
 } from 'src/shared/constants'
@@ -101,12 +100,8 @@ const BandPlot: FC<Props> = ({
   theme,
 }) => {
   const mainColumnName = useMemo(() => {
-    const editMode = get(
-      queries,
-      `${activeQueryIndex}.editMode`,
-      QUERY_BUILDER_MODE
-    )
-    if (editMode === SCRIPT_EDITOR_MODE) {
+    const editMode = get(queries, `${activeQueryIndex}.editMode`, 'unknown')
+    if (editMode !== QUERY_BUILDER_MODE) {
       return mainColumn
     }
 

--- a/src/shared/components/BandPlot.tsx
+++ b/src/shared/components/BandPlot.tsx
@@ -31,6 +31,8 @@ import {
   BAND_LINE_WIDTH,
   BAND_SHADE_OPACITY,
   LEGEND_OPACITY_DEFAULT,
+  QUERY_BUILDER_MODE,
+  SCRIPT_EDITOR_MODE,
   VIS_THEME,
   VIS_THEME_LIGHT,
 } from 'src/shared/constants'
@@ -99,6 +101,15 @@ const BandPlot: FC<Props> = ({
   theme,
 }) => {
   const mainColumnName = useMemo(() => {
+    const editMode = get(
+      queries,
+      `${activeQueryIndex}.editMode`,
+      QUERY_BUILDER_MODE
+    )
+    if (editMode === SCRIPT_EDITOR_MODE) {
+      return mainColumn
+    }
+
     const aggregateFunctions = get(
       queries,
       `${activeQueryIndex}.builderConfig.functions`,

--- a/src/shared/components/BandPlot.tsx
+++ b/src/shared/components/BandPlot.tsx
@@ -2,6 +2,7 @@
 import React, {FC, useMemo} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
 import {Config, Table} from '@influxdata/giraffe'
+import {get} from 'lodash'
 
 // Components
 import EmptyGraphMessage from 'src/shared/components/EmptyGraphMessage'
@@ -22,7 +23,7 @@ import {
   defaultXColumn,
   defaultYColumn,
 } from 'src/shared/utils/vis'
-import {getActiveQuery} from 'src/timeMachine/selectors'
+import {getActiveQueryIndex} from 'src/timeMachine/selectors'
 
 // Constants
 import {
@@ -59,9 +60,9 @@ type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps & OwnProps
 
 const BandPlot: FC<Props> = ({
+  activeQueryIndex,
   children,
   fluxGroupKeyUnion,
-  selectedFunctions,
   timeRange,
   table,
   timeZone,
@@ -93,19 +94,24 @@ const BandPlot: FC<Props> = ({
       },
     },
     timeFormat,
+    queries,
   },
   theme,
 }) => {
-  const mainColumnName = useMemo(
-    () =>
-      getMainColumnName(
-        selectedFunctions,
-        upperColumnName,
-        mainColumn,
-        lowerColumnName
-      ),
-    [selectedFunctions, upperColumnName, mainColumn, lowerColumnName]
-  )
+  const mainColumnName = useMemo(() => {
+    const aggregateFunctions = get(
+      queries,
+      `${activeQueryIndex}.builderConfig.functions`,
+      []
+    )
+    const selectedFunctions = aggregateFunctions.map(f => f.name)
+    return getMainColumnName(
+      selectedFunctions,
+      upperColumnName,
+      mainColumn,
+      lowerColumnName
+    )
+  }, [activeQueryIndex, queries, upperColumnName, mainColumn, lowerColumnName])
 
   const tooltipOpacity = useMemo(() => {
     if (isFlagEnabled('legendOrientation')) {
@@ -228,11 +234,9 @@ const BandPlot: FC<Props> = ({
   return children(config)
 }
 
-const mstp = (state: AppState) => {
-  const {builderConfig} = getActiveQuery(state)
-  const {functions} = builderConfig
-  return {selectedFunctions: functions.map(f => f.name)}
-}
+const mstp = (state: AppState) => ({
+  activeQueryIndex: getActiveQueryIndex(state),
+})
 
 const connector = connect(mstp)
 export default connector(BandPlot)

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -120,3 +120,6 @@ export const LEGEND_OPACITY_MAXIMUM = 1.0
 export const LEGEND_OPACITY_DEFAULT = LEGEND_OPACITY_MAXIMUM
 export const LEGEND_OPACITY_STEP = 0.01
 export const LEGEND_ORIENTATION_THRESHOLD_DEFAULT = 10
+
+export const QUERY_BUILDER_MODE = 'builder'
+export const SCRIPT_EDITOR_MODE = 'advanced'

--- a/src/timeMachine/components/view_options/BandOptions.tsx
+++ b/src/timeMachine/components/view_options/BandOptions.tsx
@@ -1,9 +1,17 @@
 // Libraries
-import React, {PureComponent} from 'react'
+import React, {ChangeEvent, PureComponent} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
 
 // Components
-import {Grid, Form, Dropdown, SelectDropdown} from '@influxdata/clockface'
+import {
+  ComponentStatus,
+  Dropdown,
+  Form,
+  Grid,
+  Input,
+  InputType,
+  SelectDropdown,
+} from '@influxdata/clockface'
 import Geom from 'src/timeMachine/components/view_options/Geom'
 import YAxisTitle from 'src/timeMachine/components/view_options/YAxisTitle'
 import AxisAffixes from 'src/timeMachine/components/view_options/AxisAffixes'
@@ -55,6 +63,9 @@ import {
   ViewType,
 } from 'src/types'
 
+// Constants
+import {QUERY_BUILDER_MODE} from 'src/shared/constants'
+
 interface OwnProps {
   type: ViewType
   axes: Axes
@@ -66,15 +77,30 @@ interface OwnProps {
 type ReduxProps = ConnectedProps<typeof connector>
 type Props = OwnProps & ReduxProps
 
-const REMOVE_COLUMN_TEXT = '(remove column)'
+interface State {
+  upperColumn: string
+  mainColumn: string
+  lowerColumn: string
+}
 
-class BandOptions extends PureComponent<Props> {
+const REMOVE_COLUMN_TEXT = '(remove column)'
+const UPPER_COLUMN_PLACEHOLDER = `Please enter upper column's function name`
+const MAIN_COLUMN_PLACEHOLDER = `Please enter main column's function name`
+const LOWER_COLUMN_PLACEHOLDER = `Please enter lower column's function name`
+
+class BandOptions extends PureComponent<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = {upperColumn: '', mainColumn: '', lowerColumn: ''}
+  }
+
   public render() {
     const {
       axes: {
         y: {label, prefix, suffix, base},
       },
       colors,
+      editMode,
       geom,
       onUpdateColors,
       onUpdateYAxisLabel,
@@ -128,31 +154,67 @@ class BandOptions extends PureComponent<Props> {
             />
           </Form.Element>
         </Grid.Column>
-        <Grid.Column>
-          <h5 className="view-options--header">Aggregate Functions</h5>
-          <Form.Element label="Upper Column Name">
-            <SelectDropdown
-              selectedOption={upperColumn}
-              options={upperAndLowerColumnOptions}
-              onSelect={this.onChangeUpperColumn}
-            />
-          </Form.Element>
-          <Form.Element label="Main Column Name">
-            <SelectDropdown
-              selectedOption={this.selectedMainColumn}
-              options={selectedFunctions}
-              onSelect={onSetMainColumn}
-            />
-          </Form.Element>
-          <Form.Element label="Lower Column Name">
-            <SelectDropdown
-              selectedOption={lowerColumn}
-              options={upperAndLowerColumnOptions}
-              onSelect={this.onChangeLowerColumn}
-            />
-          </Form.Element>
-          <h5 className="view-options--header">Options</h5>
-        </Grid.Column>
+        {editMode === QUERY_BUILDER_MODE ? (
+          <Grid.Column>
+            <h5 className="view-options--header">Aggregate Functions</h5>
+            <Form.Element label="Upper Column Name">
+              <SelectDropdown
+                selectedOption={upperColumn}
+                options={upperAndLowerColumnOptions}
+                onSelect={this.onChangeUpperColumn}
+              />
+            </Form.Element>
+            <Form.Element label="Main Column Name">
+              <SelectDropdown
+                selectedOption={this.selectedMainColumn}
+                options={selectedFunctions}
+                onSelect={onSetMainColumn}
+              />
+            </Form.Element>
+            <Form.Element label="Lower Column Name">
+              <SelectDropdown
+                selectedOption={lowerColumn}
+                options={upperAndLowerColumnOptions}
+                onSelect={this.onChangeLowerColumn}
+              />
+            </Form.Element>
+            <h5 className="view-options--header">Options</h5>
+          </Grid.Column>
+        ) : (
+          // SCRIPT EDITOR MODE
+          <Grid.Column>
+            <h5 className="view-options--header">Aggregate Functions</h5>
+            <Form.Element label="Upper Column Name">
+              <Input
+                onChange={this.onTextChangeUpperColumn}
+                onFocus={this.onTextChangeUpperColumn}
+                placeholder={UPPER_COLUMN_PLACEHOLDER}
+                type={InputType.Text}
+                value={this.state.upperColumn}
+              />
+            </Form.Element>
+            <Form.Element label="Main Column Name">
+              <Input
+                onChange={this.onTextChangeMainColumn}
+                onFocus={this.onTextChangeMainColumn}
+                placeholder={MAIN_COLUMN_PLACEHOLDER}
+                status={this.mainColumnTextStatus}
+                type={InputType.Text}
+                value={this.state.mainColumn}
+              />
+            </Form.Element>
+            <Form.Element label="Lower Column Name">
+              <Input
+                onChange={this.onTextChangeLowerColumn}
+                onFocus={this.onTextChangeLowerColumn}
+                placeholder={LOWER_COLUMN_PLACEHOLDER}
+                type={InputType.Text}
+                value={this.state.lowerColumn}
+              />
+            </Form.Element>
+            <h5 className="view-options--header">Options</h5>
+          </Grid.Column>
+        )}
         {geom && <Geom geom={geom} onSetGeom={onSetGeom} />}
         <ColorSelector
           colors={colors.filter(c => c.type === 'scale')}
@@ -246,6 +308,13 @@ class BandOptions extends PureComponent<Props> {
     )
   }
 
+  private get mainColumnTextStatus(): ComponentStatus {
+    if (this.state.mainColumn.length > 0) {
+      return ComponentStatus.Default
+    }
+    return ComponentStatus.Error
+  }
+
   private setBoundValues = (value: number | null): string | null => {
     return value === null ? null : String(value)
   }
@@ -278,10 +347,29 @@ class BandOptions extends PureComponent<Props> {
 
   private onChangeLowerColumn = selectedLowerColumnName =>
     this.onChangeColumn(this.props.onSetLowerColumn, selectedLowerColumnName)
+
+  private onTextChangeUpperColumn = (e: ChangeEvent<HTMLInputElement>) => {
+    const {value} = e.target
+    this.setState({upperColumn: value})
+    this.props.onSetUpperColumn(value)
+  }
+
+  private onTextChangeMainColumn = (e: ChangeEvent<HTMLInputElement>) => {
+    const {value} = e.target
+    this.setState({mainColumn: value})
+    this.props.onSetMainColumn(value)
+  }
+
+  private onTextChangeLowerColumn = (e: ChangeEvent<HTMLInputElement>) => {
+    const {value} = e.target
+    this.setState({lowerColumn: value})
+    this.props.onSetLowerColumn(value)
+  }
 }
 
 const mstp = (state: AppState) => {
-  const {builderConfig} = getActiveQuery(state)
+  const activeQuery = getActiveQuery(state)
+  const {builderConfig, editMode} = activeQuery
   const {functions} = builderConfig
   const xColumn = getXColumnSelection(state)
   const yColumn = getYColumnSelection(state)
@@ -289,6 +377,7 @@ const mstp = (state: AppState) => {
   const view = getActiveTimeMachine(state).view as NewView<BandViewProperties>
   const {timeFormat, upperColumn, mainColumn, lowerColumn} = view.properties
   return {
+    editMode,
     numericColumns,
     selectedFunctions: functions.map(f => f.name),
     timeFormat,

--- a/src/timeMachine/components/view_options/BandOptions.tsx
+++ b/src/timeMachine/components/view_options/BandOptions.tsx
@@ -348,20 +348,20 @@ class BandOptions extends PureComponent<Props, State> {
   private onChangeLowerColumn = selectedLowerColumnName =>
     this.onChangeColumn(this.props.onSetLowerColumn, selectedLowerColumnName)
 
-  private onTextChangeUpperColumn = (e: ChangeEvent<HTMLInputElement>) => {
-    const {value} = e.target
+  private onTextChangeUpperColumn = (event: ChangeEvent<HTMLInputElement>) => {
+    const {value} = event.target
     this.setState({upperColumn: value})
     this.props.onSetUpperColumn(value)
   }
 
-  private onTextChangeMainColumn = (e: ChangeEvent<HTMLInputElement>) => {
-    const {value} = e.target
+  private onTextChangeMainColumn = (event: ChangeEvent<HTMLInputElement>) => {
+    const {value} = event.target
     this.setState({mainColumn: value})
     this.props.onSetMainColumn(value)
   }
 
-  private onTextChangeLowerColumn = (e: ChangeEvent<HTMLInputElement>) => {
-    const {value} = e.target
+  private onTextChangeLowerColumn = (event: ChangeEvent<HTMLInputElement>) => {
+    const {value} = event.target
     this.setState({lowerColumn: value})
     this.props.onSetLowerColumn(value)
   }

--- a/src/timeMachine/components/view_options/BandOptions.tsx
+++ b/src/timeMachine/components/view_options/BandOptions.tsx
@@ -93,6 +93,8 @@ class BandOptions extends PureComponent<Props> {
       onSetHoverDimension,
       selectedFunctions,
       onSetMainColumn,
+      upperColumn,
+      lowerColumn,
       onSetLegendOpacity,
       onSetLegendOrientationThreshold,
     } = this.props
@@ -130,7 +132,7 @@ class BandOptions extends PureComponent<Props> {
           <h5 className="view-options--header">Aggregate Functions</h5>
           <Form.Element label="Upper Column Name">
             <SelectDropdown
-              selectedOption={this.selectedUpperColumn}
+              selectedOption={upperColumn}
               options={upperAndLowerColumnOptions}
               onSelect={this.onChangeUpperColumn}
             />
@@ -144,7 +146,7 @@ class BandOptions extends PureComponent<Props> {
           </Form.Element>
           <Form.Element label="Lower Column Name">
             <SelectDropdown
-              selectedOption={this.selectedLowerColumn}
+              selectedOption={lowerColumn}
               options={upperAndLowerColumnOptions}
               onSelect={this.onChangeLowerColumn}
             />
@@ -235,28 +237,13 @@ class BandOptions extends PureComponent<Props> {
     return parseYBounds(this.props.axes.y.bounds)
   }
 
-  private selectedColumn = (columnType: string): string => {
-    const hasSelectedFunction = this.props.selectedFunctions.some(
-      funcName => funcName === this.props[columnType]
-    )
-    return hasSelectedFunction ? this.props[columnType] : ''
-  }
-
-  private get selectedUpperColumn(): string {
-    return this.selectedColumn('upperColumn')
-  }
-
   private get selectedMainColumn(): string {
     return getMainColumnName(
       this.props.selectedFunctions,
-      this.selectedUpperColumn,
+      this.props.upperColumn,
       this.props.mainColumn,
-      this.selectedLowerColumn
+      this.props.lowerColumn
     )
-  }
-
-  private get selectedLowerColumn(): string {
-    return this.selectedColumn('lowerColumn')
   }
 
   private setBoundValues = (value: number | null): string | null => {

--- a/src/timeMachine/selectors/index.ts
+++ b/src/timeMachine/selectors/index.ts
@@ -12,6 +12,7 @@ import {
   getNumericColumns as getNumericColumnsUtil,
   getGroupableColumns as getGroupableColumnsUtil,
   getStringColumns as getStringColumnsUtil,
+  getMainColumnName,
 } from 'src/shared/utils/vis'
 import {
   getWindowPeriod,
@@ -30,10 +31,12 @@ import {getTimeRange} from 'src/dashboards/selectors'
 
 // Types
 import {
-  QueryView,
-  DashboardQuery,
   AppState,
+  BandViewProperties,
   DashboardDraftQuery,
+  DashboardQuery,
+  NewView,
+  QueryView,
   TimeRange,
 } from 'src/types'
 
@@ -63,6 +66,14 @@ export const getActiveQuery = (state: AppState): DashboardDraftQuery => {
 
   const {draftQueries, activeQueryIndex} = tm
   return draftQueries[activeQueryIndex]
+}
+
+export const getActiveQueryIndex = (state: AppState): number => {
+  const activeTimeMachine = getActiveTimeMachine(state)
+  if (activeTimeMachine) {
+    return activeTimeMachine.activeQueryIndex
+  }
+  return 0
 }
 
 /*
@@ -285,6 +296,20 @@ export const getActiveTimeRange = (
   return null
 }
 
+const getMainColumn = (state: AppState) => {
+  const {builderConfig} = getActiveQuery(state)
+  const {functions} = builderConfig
+  const selectedFunctions = functions.map(f => f.name)
+  const view = getActiveTimeMachine(state).view as NewView<BandViewProperties>
+  const {upperColumn, mainColumn, lowerColumn} = view.properties
+  return getMainColumnName(
+    selectedFunctions,
+    upperColumn,
+    mainColumn,
+    lowerColumn
+  )
+}
+
 export const getSaveableView = (state: AppState): QueryView & {id?: string} => {
   const {view, draftQueries} = getActiveTimeMachine(state)
 
@@ -362,6 +387,17 @@ export const getSaveableView = (state: AppState): QueryView & {id?: string} => {
         ...saveableView.properties,
         xColumn: getXColumnSelection(state),
         yColumn: getYColumnSelection(state),
+        mainColumn: getMainColumn(state),
+        // 'upperColumn' should NOT be saved here, see below
+        // 'lowerColumn' should NOT be saved here, see below
+        /*
+          REASON:
+            In the aggregate function selector of the editor,
+            there is no way to tell which aggregate function will be an upper or lower column.
+
+            The only way to tell is to wait until the user explicitly sets
+            upper and lower columns inside the Band Options -- which saves them.
+        */
       },
     }
   }


### PR DESCRIPTION
Part of idpe #8337

- save 'mainColumn' properly so that Dashboards can render something in the cell for Band Charts.
- require the user to explicitly set or remove 'upperColumn' and 'lowerColumn'
- no automatic removal of upper and lower columns from Band Options even when they are not included in the response
- Query Builder mode: user selects from dropdowns
- Script Editor mode: user types into text input field