### PR TITLE
feat(community-templates): add notification endpoint description on install

### DIFF
--- a/src/templates/components/CommunityTemplateResourceContent.tsx
+++ b/src/templates/components/CommunityTemplateResourceContent.tsx
@@ -332,6 +332,48 @@ class CommunityTemplateResourceContentUnconnected extends PureComponent<Props> {
               )
             })}
         </CommunityTemplateListGroup>
+
+        <CommunityTemplateListGroup
+          title="Notification Endpoints"
+          count={getResourceInstallCount(summary.notificationEndpoints)}
+        >
+          {Array.isArray(summary.notificationEndpoints) &&
+            summary.notificationEndpoints.map(notificationEndpoint => {
+              return (
+                <FlexBox
+                  margin={ComponentSize.Small}
+                  direction={FlexDirection.Row}
+                  alignItems={AlignItems.Stretch}
+                  key={notificationEndpoint.templateMetaName}
+                >
+                  <FlexBox.Child grow={1}>
+                    <CommunityTemplateListItem
+                      shouldInstall={notificationEndpoint.shouldInstall}
+                      handleToggle={() => {
+                        event('template_resource_uncheck', {
+                          templateResourceType: 'notification rules',
+                        })
+                        this.props.toggleTemplateResourceInstall(
+                          'notificationEndpoints',
+                          notificationEndpoint.templateMetaName,
+                          !notificationEndpoint.shouldInstall
+                        )
+                      }}
+                      key={notificationEndpoint.templateMetaName}
+                      title={notificationEndpoint.notificationEndpoint.name}
+                      description={notificationEndpoint.description}
+                    />
+                  </FlexBox.Child>
+                  {resourceHasEnvRefs(summary) && (
+                    <FlexBox.Child>
+                      <CommunityTemplateParameters resource={summary} />
+                    </FlexBox.Child>
+                  )}
+                </FlexBox>
+              )
+            })}
+        </CommunityTemplateListGroup>
+
         <CommunityTemplateListGroup
           title="Labels"
           count={getResourceInstallCount(summary.labels)}


### PR DESCRIPTION
>i don’t see “Notification Endpoints” displayed in the UI when i try to import a template through the UI. The docker template has one: 

https://influxdata.slack.com/archives/C018NGHFHSM/p1600402190001100

test with [this template](https://github.com/influxdata/community-templates/blob/d4cf430d51ae6d3dfc95ff8faa7c1247ba2a2c64/docker/docker.yml)