### PR TITLE
feat(ui): Add GA tracking and calendly contact

### DIFF
--- a/src/checks/components/CheckHistory.tsx
+++ b/src/checks/components/CheckHistory.tsx
@@ -10,7 +10,7 @@ import CheckHistoryVisualization from 'src/checks/components/CheckHistoryVisuali
 import AlertHistoryQueryParams from 'src/alerting/components/AlertHistoryQueryParams'
 import EventTable from 'src/eventViewer/components/EventTable'
 import GetResources from 'src/resources/components/GetResources'
-import CloudUpgradeButton from 'src/shared/components/CloudUpgradeButton'
+import RateLimitAlert from 'src/cloud/components/RateLimitAlert'
 
 //Context
 import {ResourceIDsContext} from 'src/alerting/components/AlertHistoryIndex'
@@ -64,7 +64,7 @@ const CheckHistory: FC<Props> = ({
                   title="Check Statuses"
                   testID="alert-history-title"
                 />
-                <CloudUpgradeButton />
+                <RateLimitAlert />
               </Page.Header>
               <Page.ControlBar fullWidth={true}>
                 <Page.ControlBarLeft>

--- a/src/cloud/components/AssetLimitAlert.tsx
+++ b/src/cloud/components/AssetLimitAlert.tsx
@@ -47,7 +47,10 @@ const AssetLimitAlert: FC<Props> = ({limitStatus, resourceName, className}) => {
               alignItems={AlignItems.FlexEnd}
               stretchToFitHeight={true}
             >
-              <CloudUpgradeButton buttonText={`Get more ${resourceName}`} />
+              <CloudUpgradeButton
+                buttonText={`Get more ${resourceName}`}
+                className="upgrade-payg--button__asset-alert"
+              />
             </FlexBox>
           </Panel.Body>
         </Panel>

--- a/src/cloud/components/AssetLimitOverlay.tsx
+++ b/src/cloud/components/AssetLimitOverlay.tsx
@@ -54,7 +54,10 @@ const AssetLimitOverlay: FC<OwnProps & StateProps> = ({assetName, onClose}) => {
             </p>
           </Overlay.Body>
           <Overlay.Footer>
-            <CloudUpgradeButton size={ComponentSize.Large} />
+            <CloudUpgradeButton
+              size={ComponentSize.Large}
+              className="upgrade-payg--button__asset-create"
+            />
           </Overlay.Footer>
         </div>
       </GradientBox>

--- a/src/cloud/components/RateLimitAlert.tsx
+++ b/src/cloud/components/RateLimitAlert.tsx
@@ -28,7 +28,7 @@ import {CLOUD} from 'src/shared/constants'
 // Types
 import {AppState} from 'src/types'
 import {LimitStatus} from 'src/cloud/actions/limits'
-import RateLimitAlertContent from './RateLimitAlertContent'
+import RateLimitAlertContent from 'src/cloud/components/RateLimitAlertContent'
 
 interface StateProps {
   resources: string[]
@@ -76,7 +76,7 @@ const RateLimitAlert: FC<Props> = ({
   }
 
   if (CLOUD && !alertOnly) {
-    return <CloudUpgradeButton />
+    return <CloudUpgradeButton className="upgrade-payg--button__header" />
   }
 
   return null

--- a/src/cloud/components/RateLimitAlertContent.tsx
+++ b/src/cloud/components/RateLimitAlertContent.tsx
@@ -10,7 +10,6 @@ import {
   JustifyContent,
   LinkButton,
   ComponentColor,
-  ButtonShape,
   ComponentSize,
 } from '@influxdata/clockface'
 import CloudUpgradeButton from 'src/shared/components/CloudUpgradeButton'
@@ -40,51 +39,54 @@ const RateLimitAlertContent: FC<Props> = ({showUpgrade, className}) => {
 
   if (showUpgrade) {
     return (
-      <div className={`${rateLimitAlertContentClass} rate-alert--content_free`}>
+      <div
+        className={`${rateLimitAlertContentClass} rate-alert--content__free`}
+      >
         <span>
-          You've reached the maximum{' '}
+          Oh no! You hit the{' '}
           <a
             href="https://v2.docs.influxdata.com/v2.0/reference/glossary/#series-cardinality"
+            data-trackid="rate-alert--docs-link"
             target="_blank"
           >
             series cardinality
           </a>{' '}
-          available in your plan. Need to write more data?
+          limit and your data stopped writing. Don’t lose important metrics.
         </span>
         <FlexBox
           justifyContent={JustifyContent.Center}
           className="rate-alert--button"
         >
-          <CloudUpgradeButton />
+          <CloudUpgradeButton className="upgrade-payg--button__rate-alert" />
         </FlexBox>
       </div>
     )
   }
 
   return (
-    <div className={`${rateLimitAlertContentClass} rate-alert--content_payg`}>
+    <div className={`${rateLimitAlertContentClass} rate-alert--content__payg`}>
       <span>
-        You've reached the maximum{' '}
+        Data in has stopped because you've hit the{' '}
         <a
           href="https://v2.docs.influxdata.com/v2.0/reference/glossary/#series-cardinality"
+          data-trackid="rate-alert--docs-link"
           target="_blank"
         >
           series cardinality
         </a>{' '}
-        available in your plan. Need to write more data?
+        limit. Need some guidance?
       </span>
       <FlexBox
         justifyContent={JustifyContent.Center}
         className="rate-alert--button"
       >
         <LinkButton
-          className="contact-support--button"
+          className="rate-alert--contact-button"
           color={ComponentColor.Primary}
           size={ComponentSize.Small}
-          shape={ButtonShape.Default}
-          href="https://support.influxdata.com/s/"
+          text="Speak with an Expert"
+          href="https://calendly.com/c/CBCTLOTDNVLFUTZO"
           target="_blank"
-          text="Contact Support"
         />
       </FlexBox>
     </div>

--- a/src/cloud/components/RateLimitAlertContent.tsx
+++ b/src/cloud/components/RateLimitAlertContent.tsx
@@ -46,7 +46,7 @@ const RateLimitAlertContent: FC<Props> = ({showUpgrade, className}) => {
           Oh no! You hit the{' '}
           <a
             href="https://v2.docs.influxdata.com/v2.0/reference/glossary/#series-cardinality"
-            data-trackid="rate-alert--docs-link"
+            className="rate-alert--docs-link"
             target="_blank"
           >
             series cardinality
@@ -69,7 +69,7 @@ const RateLimitAlertContent: FC<Props> = ({showUpgrade, className}) => {
         Data in has stopped because you've hit the{' '}
         <a
           href="https://v2.docs.influxdata.com/v2.0/reference/glossary/#series-cardinality"
-          data-trackid="rate-alert--docs-link"
+          className="rate-alert--docs-link"
           target="_blank"
         >
           series cardinality

--- a/src/organizations/components/OrgHeader.tsx
+++ b/src/organizations/components/OrgHeader.tsx
@@ -2,14 +2,14 @@ import React, {Component} from 'react'
 
 // Components
 import {Page} from '@influxdata/clockface'
-import CloudUpgradeButton from 'src/shared/components/CloudUpgradeButton'
+import RateLimitAlert from 'src/cloud/components/RateLimitAlert'
 
 class OrgHeader extends Component {
   public render() {
     return (
       <Page.Header fullWidth={false} testID="member-page--header">
         <Page.Title title="Organization" />
-        <CloudUpgradeButton />
+        <RateLimitAlert />
       </Page.Header>
     )
   }

--- a/src/settings/components/LoadDataHeader.tsx
+++ b/src/settings/components/LoadDataHeader.tsx
@@ -8,7 +8,7 @@ const LoadDataHeader: FC = () => {
   return (
     <Page.Header fullWidth={false} testID="load-data--header">
       <Page.Title title="Load Data" />
-      <RateLimitAlert className="load-data--rate-alert" />
+      <RateLimitAlert />
     </Page.Header>
   )
 }

--- a/src/shared/components/CloudUpgradeNavBanner.tsx
+++ b/src/shared/components/CloudUpgradeNavBanner.tsx
@@ -49,7 +49,7 @@ const CloudUpgradeNavBanner: FC<StateProps> = ({inView}) => {
             </Panel.Header>
             <Panel.Footer size={ComponentSize.ExtraSmall}>
               <a
-                className="cf-button cf-button-md cf-button-primary cf-button-stretch cloud-upgrade-banner--button"
+                className="cf-button cf-button-md cf-button-primary cf-button-stretch cloud-upgrade-banner--button upgrade-payg--button__nav"
                 href={`${CLOUD_URL}${CLOUD_CHECKOUT_PATH}`}
                 target="_self"
               >

--- a/src/tasks/components/TaskHeader.tsx
+++ b/src/tasks/components/TaskHeader.tsx
@@ -8,7 +8,7 @@ import {
   ComponentStatus,
   Page,
 } from '@influxdata/clockface'
-import CloudUpgradeButton from 'src/shared/components/CloudUpgradeButton'
+import RateLimitAlert from 'src/cloud/components/RateLimitAlert'
 
 interface Props {
   title: string
@@ -24,7 +24,7 @@ export default class TaskHeader extends PureComponent<Props> {
       <>
         <Page.Header fullWidth={true}>
           <Page.Title title={title} />
-          <CloudUpgradeButton />
+          <RateLimitAlert />
         </Page.Header>
         <Page.ControlBar fullWidth={true}>
           <Page.ControlBarRight>

--- a/src/tasks/components/TaskRunsPage.tsx
+++ b/src/tasks/components/TaskRunsPage.tsx
@@ -6,7 +6,7 @@ import {withRouter, RouteComponentProps} from 'react-router-dom'
 // Components
 import {Page, IconFont, Sort} from '@influxdata/clockface'
 import TaskRunsList from 'src/tasks/components/TaskRunsList'
-import CloudUpgradeButton from 'src/shared/components/CloudUpgradeButton'
+import RateLimitAlert from 'src/cloud/components/RateLimitAlert'
 
 // Types
 import {AppState, Run} from 'src/types'
@@ -59,7 +59,7 @@ class TaskRunsPage extends PureComponent<Props, State> {
         <Page titleTag={pageTitleSuffixer(['Task Runs'])}>
           <Page.Header fullWidth={false}>
             <Page.Title title={this.title} />
-            <CloudUpgradeButton />
+            <RateLimitAlert />
           </Page.Header>
           <Page.ControlBar fullWidth={false}>
             <Page.ControlBarLeft>


### PR DESCRIPTION
- Changes the messaging for free and PAYG series cardinality limit alerts
- Adds an option for PAYG users to schedule a call in Calendly to resolve series cardinality rate limit breaches
- Adds class names for GA tracking which upgrade CTA buttons were clicked

**FREE**
![image](https://user-images.githubusercontent.com/11937365/93555619-56990400-f92b-11ea-9e00-0609db066ceb.png)

**PAYG**
![image](https://user-images.githubusercontent.com/11937365/93555602-48e37e80-f92b-11ea-8cfa-c0df4e3bc9df.png)

