### PR TITLE
feat(fromFlux): swaps out parseResponse for fromFlux in most places in the UI

### DIFF
--- a/src/external/monaco.flux.server.ts
+++ b/src/external/monaco.flux.server.ts
@@ -1,4 +1,5 @@
 import Deferred from '../utils/Deferred'
+import {fromFlux} from '@influxdata/giraffe'
 import {
   LSPResponse,
   parseResponse,
@@ -42,6 +43,7 @@ import {
   TextEdit,
 } from 'monaco-languageclient/lib/services'
 import {Server} from '@influxdata/flux-lsp-browser'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 type BucketCallback = () => Promise<string[]>
 type MeasurementsCallback = (bucket: string) => Promise<string[]>
@@ -57,6 +59,10 @@ import {format_from_js_file} from '@influxdata/flux'
 
 // NOTE: parses table then select measurements from the _value column
 const parseQueryResponse = response => {
+  if (isFlagEnabled('fromFluxParseResponse')) {
+    const {table} = fromFlux(response.csv)
+    return table?.columns?.value?.data || []
+  }
   const data = (parse(response.csv) || [{data: [{}]}])[0].data
   return data.slice(1).map(r => r[3])
 }

--- a/src/external/monaco.flux.server.ts
+++ b/src/external/monaco.flux.server.ts
@@ -61,7 +61,7 @@ import {format_from_js_file} from '@influxdata/flux'
 const parseQueryResponse = response => {
   if (isFlagEnabled('fromFluxParseResponse')) {
     const {table} = fromFlux(response.csv)
-    return table?.columns?.value?.data || []
+    return table.getColumn('_value', 'string') || []
   }
   const data = (parse(response.csv) || [{data: [{}]}])[0].data
   return data.slice(1).map(r => r[3])

--- a/src/shared/components/TimeSeries.tsx
+++ b/src/shared/components/TimeSeries.tsx
@@ -3,11 +3,8 @@ import React, {Component, RefObject, CSSProperties} from 'react'
 import {isEqual} from 'lodash'
 import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {
-  default as fromFlux,
-  FromFluxResult,
-} from 'src/shared/utils/fromFlux.legacy'
-import {fromFlux as fromFluxGiraffe} from '@influxdata/giraffe'
+import {default as fromFlux} from 'src/shared/utils/fromFlux.legacy'
+import {fromFlux as fromFluxGiraffe, FromFluxResult} from '@influxdata/giraffe'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // API

--- a/src/shared/parsing/flux/response.ts
+++ b/src/shared/parsing/flux/response.ts
@@ -46,66 +46,6 @@ export const parseResponse = (response: string): FluxTable[] => {
   return tables
 }
 
-// const genericTableCreator = (annotationData, nonAnnotationData): any => {
-//   const headerRow = nonAnnotationData[0]
-//   const tableColIndex = headerRow.findIndex(h => h === 'table')
-//   const resultColIndex = headerRow.findIndex(h => h === 'result')
-//   interface TableGroup {
-//     [tableId: string]: string[]
-//   }
-
-//   const tableGroup: TableGroup = groupBy(
-//     nonAnnotationData.slice(1),
-//     row => row[tableColIndex]
-//   )
-//   // Group rows by their table id
-//   const tablesData = Object.values(tableGroup)
-
-//   const groupRow = annotationData.find(row => row[0] === '#group')
-//   const defaultsRow = annotationData.find(row => row[0] === '#default')
-//   const dataTypeRow = annotationData.find(row => row[0] === '#datatype')
-
-//   const groupKeyIndices = groupRow.reduce((acc, value, i) => {
-//     if (value === 'true') {
-//       return [...acc, i]
-//     }
-
-//     return acc
-//   }, [])
-
-//   const tables = tablesData.map(tableData => {
-//     const dataRow = get(tableData, '0', defaultsRow)
-//     const result: string =
-//       get(dataRow, resultColIndex, '') || get(defaultsRow, resultColIndex, '')
-
-//     const groupKey = groupKeyIndices.reduce((acc, i) => {
-//       return {...acc, [headerRow[i]]: get(dataRow, i, '')}
-//     }, {})
-
-//     const name = Object.entries(groupKey)
-//       .filter(([k]) => !['_start', '_stop'].includes(k))
-//       .map(([k, v]) => `${k}=${v}`)
-//       .join(' ')
-
-//     const dataTypes = dataTypeRow.reduce((acc, dataType, i) => {
-//       return {
-//         ...acc,
-//         [headerRow[i]]: dataType,
-//       }
-//     }, {})
-//     return {
-//       // id: uuid.v4(),
-//       data: [[...headerRow], ...tableData],
-//       name,
-//       result,
-//       groupKey,
-//       dataTypes,
-//     } as FluxTable
-//   })
-
-//   return tables
-// }
-
 export const parseTables = (responseChunk: string): FluxTable[] => {
   const lines = responseChunk.split('\n')
   const annotationLines: string = lines

--- a/src/shared/parsing/flux/response.ts
+++ b/src/shared/parsing/flux/response.ts
@@ -1,23 +1,9 @@
 import Papa from 'papaparse'
 import _ from 'lodash'
 import uuid from 'uuid'
+import {fromFlux} from '@influxdata/giraffe'
 
 import {FluxTable} from 'src/types'
-
-export const parseResponseError = (response: string): FluxTable[] => {
-  const data = Papa.parse(response.trim()).data as string[][]
-
-  return [
-    {
-      id: uuid.v4(),
-      name: 'Error',
-      result: '',
-      groupKey: {},
-      dataTypes: {},
-      data,
-    },
-  ]
-}
 
 /*
   A Flux CSV response can contain multiple CSV files each joined by a newline.
@@ -59,6 +45,71 @@ export const parseResponse = (response: string): FluxTable[] => {
 
   return tables
 }
+
+export const genericResponseParser = (response: string): FluxTable[] => {
+  const parsed = fromFlux(response)
+  console.log('parsed: ', parsed)
+}
+
+// const genericTableCreator = (annotationData, nonAnnotationData): any => {
+//   const headerRow = nonAnnotationData[0]
+//   const tableColIndex = headerRow.findIndex(h => h === 'table')
+//   const resultColIndex = headerRow.findIndex(h => h === 'result')
+//   interface TableGroup {
+//     [tableId: string]: string[]
+//   }
+
+//   const tableGroup: TableGroup = groupBy(
+//     nonAnnotationData.slice(1),
+//     row => row[tableColIndex]
+//   )
+//   // Group rows by their table id
+//   const tablesData = Object.values(tableGroup)
+
+//   const groupRow = annotationData.find(row => row[0] === '#group')
+//   const defaultsRow = annotationData.find(row => row[0] === '#default')
+//   const dataTypeRow = annotationData.find(row => row[0] === '#datatype')
+
+//   const groupKeyIndices = groupRow.reduce((acc, value, i) => {
+//     if (value === 'true') {
+//       return [...acc, i]
+//     }
+
+//     return acc
+//   }, [])
+
+//   const tables = tablesData.map(tableData => {
+//     const dataRow = get(tableData, '0', defaultsRow)
+//     const result: string =
+//       get(dataRow, resultColIndex, '') || get(defaultsRow, resultColIndex, '')
+
+//     const groupKey = groupKeyIndices.reduce((acc, i) => {
+//       return {...acc, [headerRow[i]]: get(dataRow, i, '')}
+//     }, {})
+
+//     const name = Object.entries(groupKey)
+//       .filter(([k]) => !['_start', '_stop'].includes(k))
+//       .map(([k, v]) => `${k}=${v}`)
+//       .join(' ')
+
+//     const dataTypes = dataTypeRow.reduce((acc, dataType, i) => {
+//       return {
+//         ...acc,
+//         [headerRow[i]]: dataType,
+//       }
+//     }, {})
+//     return {
+//       // id: uuid.v4(),
+//       data: [[...headerRow], ...tableData],
+//       name,
+//       result,
+//       groupKey,
+//       dataTypes,
+//     } as FluxTable
+//   })
+
+//   return tables
+// }
 
 export const parseTables = (responseChunk: string): FluxTable[] => {
   const lines = responseChunk.split('\n')

--- a/src/shared/parsing/flux/response.ts
+++ b/src/shared/parsing/flux/response.ts
@@ -1,9 +1,23 @@
 import Papa from 'papaparse'
 import _ from 'lodash'
 import uuid from 'uuid'
-import {fromFlux} from '@influxdata/giraffe'
 
 import {FluxTable} from 'src/types'
+
+export const parseResponseError = (response: string): FluxTable[] => {
+  const data = Papa.parse(response.trim()).data as string[][]
+
+  return [
+    {
+      id: uuid.v4(),
+      name: 'Error',
+      result: '',
+      groupKey: {},
+      dataTypes: {},
+      data,
+    },
+  ]
+}
 
 /*
   A Flux CSV response can contain multiple CSV files each joined by a newline.

--- a/src/shared/parsing/flux/response.ts
+++ b/src/shared/parsing/flux/response.ts
@@ -46,11 +46,6 @@ export const parseResponse = (response: string): FluxTable[] => {
   return tables
 }
 
-export const genericResponseParser = (response: string): FluxTable[] => {
-  const parsed = fromFlux(response)
-  console.log('parsed: ', parsed)
-}
-
 // const genericTableCreator = (annotationData, nonAnnotationData): any => {
 //   const headerRow = nonAnnotationData[0]
 //   const tableColIndex = headerRow.findIndex(h => h === 'table')

--- a/src/shared/utils/fromFlux.legacy.ts
+++ b/src/shared/utils/fromFlux.legacy.ts
@@ -1,5 +1,5 @@
 import fromFlux from 'src/shared/utils/fromFlux'
-import {newTable, Table} from '@influxdata/giraffe'
+import {newTable, FromFluxResult} from '@influxdata/giraffe'
 
 /*\
 
@@ -8,13 +8,6 @@ import {newTable, Table} from '@influxdata/giraffe'
   to the api response layer
 
 \*/
-export interface FromFluxResult {
-  // The single parsed `Table`
-  table: Table
-
-  // The union of unique group keys from all input Flux tables
-  fluxGroupKeyUnion: string[]
-}
 
 export default function fromFluxLegacy(csv: string): FromFluxResult {
   const parsedFlux = fromFlux(csv)

--- a/src/timeMachine/apis/queryBuilder.ts
+++ b/src/timeMachine/apis/queryBuilder.ts
@@ -139,7 +139,7 @@ export function extractBoxedCol(
 export function extractCol(csv: string, colName: string): string[] {
   if (isFlagEnabled('fromFluxParseResponse')) {
     const {table} = fromFlux(csv)
-    return table?.columns[colName]?.data || []
+    return table.getColumn(colName, 'string') || []
   }
   const tables = parseResponse(csv)
   const data = get(tables, '0.data', [])

--- a/src/timeMachine/apis/queryBuilder.ts
+++ b/src/timeMachine/apis/queryBuilder.ts
@@ -1,5 +1,6 @@
 // Libraries
 import {get} from 'lodash'
+import {fromFlux} from '@influxdata/giraffe'
 
 // APIs
 import {runQuery, RunQueryResult} from 'src/shared/apis/query'
@@ -10,6 +11,7 @@ import {getTimeRangeVars} from 'src/variables/utils/getTimeRangeVars'
 import {formatExpression} from 'src/variables/utils/formatExpression'
 import {tagToFlux} from 'src/timeMachine/utils/queryBuilder'
 import {event} from 'src/cloud/utils/reporting'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Types
 import {TimeRange, BuilderConfig} from 'src/types'
@@ -135,6 +137,10 @@ export function extractBoxedCol(
 }
 
 export function extractCol(csv: string, colName: string): string[] {
+  if (isFlagEnabled('fromFluxParseResponse')) {
+    const {table} = fromFlux(csv)
+    return table?.columns[colName]?.data || []
+  }
   const tables = parseResponse(csv)
   const data = get(tables, '0.data', [])
 

--- a/src/variables/utils/ValueFetcher.ts
+++ b/src/variables/utils/ValueFetcher.ts
@@ -1,5 +1,6 @@
 // APIs
 import {runQuery} from 'src/shared/apis/query'
+import {fromFlux} from '@influxdata/giraffe'
 
 // Utils
 import {resolveSelectedKey} from 'src/variables/utils/resolveSelectedValue'
@@ -7,6 +8,7 @@ import {formatVarsOption} from 'src/variables/utils/formatVarsOption'
 import {parseResponse} from 'src/shared/parsing/flux/response'
 import {buildVarsOption} from 'src/variables/utils/buildVarsOption'
 import {event} from 'src/cloud/utils/reporting'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Types
 import {VariableAssignment, VariableValues, FluxColumnType} from 'src/types'
@@ -35,6 +37,25 @@ export const extractValues = (
   prevSelection?: string,
   defaultSelection?: string
 ): VariableValues => {
+  if (isFlagEnabled('fromFluxParseResponse')) {
+    const {table} = fromFlux(csv)
+    if (!table || !table?.columns?._value) {
+      return {
+        values: [],
+        valueType: 'string',
+        selected: [],
+      }
+    }
+    let values = table?.columns?._value?.data || []
+    values = [...new Set(values)]
+    values.sort()
+
+    return {
+      values,
+      valueType: table?.columns?._value?.type as FluxColumnType,
+      selected: [resolveSelectedKey(values, prevSelection, defaultSelection)],
+    }
+  }
   const [table] = parseResponse(csv)
 
   if (!table || !table.data.length) {

--- a/src/variables/utils/ValueFetcher.ts
+++ b/src/variables/utils/ValueFetcher.ts
@@ -39,20 +39,20 @@ export const extractValues = (
 ): VariableValues => {
   if (isFlagEnabled('fromFluxParseResponse')) {
     const {table} = fromFlux(csv)
-    if (!table || !table?.columns?._value) {
+    if (!table || !table.getColumn('_value', 'string')) {
       return {
         values: [],
         valueType: 'string',
         selected: [],
       }
     }
-    let values = table?.columns?._value?.data || []
+    let values = table.getColumn('_value', 'string') || []
     values = [...new Set(values)]
     values.sort()
 
     return {
       values,
-      valueType: table?.columns?._value?.type as FluxColumnType,
+      valueType: table.getColumnType('_value') as FluxColumnType,
       selected: [resolveSelectedKey(values, prevSelection, defaultSelection)],
     }
   }


### PR DESCRIPTION
Closes #72 

### Problem

There are a bunch of parsers, which means maintaining a bunch of code. This PR aims to unify the parsers by replacing the usage of `parseResponse` with `fromFlux`

### Solution

Swapped the places where `parseResponse` was being used with a feature flagged `fromFlux`. The feature flag PR is up in IDPE and the feature flag has been set in configCat