### PR TITLE
chore: bump the docker cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
           command: cd ./monitor-ci && make update
       - run:
           name: Busting the cache
-          command: cd ./monitor-ci && make build NODE=ingress && make build NODE=cypress
+          command: cd ./monitor-ci && make build NODE=debug && make build NODE=cypress
       - run:
           name: Build the new UI (for idpe run make rebuild NODE=influxdb)
           command: cd ./monitor-ci; cp ./conf/chronograf/nginx.conf ../ui/; make rebuild NODE=chronograf

--- a/cypress/e2e/tasks.test.ts
+++ b/cypress/e2e/tasks.test.ts
@@ -39,7 +39,7 @@ from(bucket: "${name}"{rightarrow}
 
     cy.getByTestID('notification-error').should(
       'contain',
-      'error calling function "to": missing required keyword argument "bucketID"'
+      'missing required keyword argument "bucketID"'
     )
   })
 

--- a/cypress/e2e/telegrafs.test.ts
+++ b/cypress/e2e/telegrafs.test.ts
@@ -1,7 +1,7 @@
 import {Organization} from '../../src/types'
 
 // a generous commitment to delivering this page in a loaded state
-const PAGE_LOAD_SLA = 10000
+const PAGE_LOAD_SLA = 20000
 
 describe('Collectors', () => {
   beforeEach(() => {


### PR DESCRIPTION
turns out "waiting for the cache to expire" would take months. SO. doing it explicitly here. I think the "build ingress on every test" if more of a hold over to the last time we had to bump the cache, and just forgot about it, but the next coarse of action after this would be to remove the debug bump as well.... and maybe just creating this PR will fix it