### PR TITLE
fix: 404 not rendering

### DIFF
--- a/cypress/e2e/nav.test.ts
+++ b/cypress/e2e/nav.test.ts
@@ -38,6 +38,16 @@ describe('navigation', () => {
     cy.getByTestID('tree-nav--header').click()
     cy.getByTestID('home-page--header').should('exist')
 
+    // 404
+    cy.visit('/not-a-route')
+    cy.getByTestID('404').should('exist')
+    cy.visit('/')
+    cy.getByTestID('user-nav').should('exist')
+    cy.get('@orgID').then(orgID => {
+      cy.visit(`/orgs/${orgID}/not-a-route`)
+      cy.getByTestID('404').should('exist')
+    })
+
     /**\
 
       OSS Only Feature

--- a/cypress/e2e/nav.test.ts
+++ b/cypress/e2e/nav.test.ts
@@ -40,12 +40,13 @@ describe('navigation', () => {
 
     // 404
     cy.visit('/not-a-route')
-    cy.getByTestID('404').should('exist')
+    cy.getByTestID('not-found').should('exist')
     cy.visit('/')
+
     cy.getByTestID('user-nav').should('exist')
     cy.get('@orgID').then(orgID => {
       cy.visit(`/orgs/${orgID}/not-a-route`)
-      cy.getByTestID('404').should('exist')
+      cy.getByTestID('not-found').should('exist')
     })
 
     /**\

--- a/cypress/e2e/telegrafs.test.ts
+++ b/cypress/e2e/telegrafs.test.ts
@@ -1,7 +1,7 @@
 import {Organization} from '../../src/types'
 
 // a generous commitment to delivering this page in a loaded state
-const PAGE_LOAD_SLA = 20000
+const PAGE_LOAD_SLA = 80000
 
 describe('Collectors', () => {
   beforeEach(() => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -447,6 +447,7 @@ export const flush = () => {
     method: 'GET',
     url: '/debug/flush',
   })
+
   cy.wait(500)
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,7 @@ import 'abortcontroller-polyfill/dist/polyfill-patch-fetch'
 import React, {PureComponent} from 'react'
 import {render} from 'react-dom'
 import {Provider} from 'react-redux'
-import {Route, Switch} from 'react-router-dom'
+import {Route} from 'react-router-dom'
 import {ConnectedRouter} from 'connected-react-router'
 
 // Stores

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -73,10 +73,8 @@ class Root extends PureComponent {
       <Provider store={store}>
         <ConnectedRouter history={history}>
           <Route component={GetLinks} />
-          <Switch>
-            <Route component={Setup} />
-            <Route component={NotFound} />
-          </Switch>
+          <Route component={Setup} />
+          <Route component={NotFound} />
         </ConnectedRouter>
       </Provider>
     )

--- a/src/shared/components/NotFound.tsx
+++ b/src/shared/components/NotFound.tsx
@@ -1,7 +1,7 @@
 import React, {FC} from 'react'
 
 const NotFound: FC = () => (
-  <div className="container-fluid" data-testid="404">
+  <div className="container-fluid" data-testid="not-found">
     <div className="panel">
       <div className="panel-heading text-center">
         <h1 className="deluxe">404</h1>

--- a/src/shared/components/NotFound.tsx
+++ b/src/shared/components/NotFound.tsx
@@ -1,7 +1,7 @@
-import React, {SFC} from 'react'
+import React, {FC} from 'react'
 
-const NotFound: SFC = () => (
-  <div className="container-fluid">
+const NotFound: FC = () => (
+  <div className="container-fluid" data-testid="404">
     <div className="panel">
       <div className="panel-heading text-center">
         <h1 className="deluxe">404</h1>


### PR DESCRIPTION
Closes influxdata/influxdb#19283

### The Problem
When navigating to a non-existing route a blank page displayed.  

### The Solution
Remove the top level `react-router` `<Switch/>` component that returns the first matching component.   In this case that would be `<Setup/>`.  Didn't think it would be this easy but seems to not interfere with `/onboarding` and works with root and nested routes.

![Kapture 2020-09-21 at 14 56 27](https://user-images.githubusercontent.com/7582765/93825751-be489b00-fc1a-11ea-8afd-ceacdb02cdb5.gif)
