### PR TITLE
fix(community-templates): don't render unselected task checkmarks

### DIFF
--- a/src/templates/components/CommunityTemplateResourceContent.tsx
+++ b/src/templates/components/CommunityTemplateResourceContent.tsx
@@ -187,7 +187,7 @@ class CommunityTemplateResourceContentUnconnected extends PureComponent<Props> {
                 >
                   <FlexBox.Child grow={1}>
                     <CommunityTemplateListItem
-                      shouldInstall={true}
+                      shouldInstall={task.shouldInstall}
                       handleToggle={() => {
                         event('template_resource_uncheck', {
                           templateResourceType: 'tasks',


### PR DESCRIPTION
minor bug: the check mark indicating the resource shouldn't be installed would always render, even though the underlying behavior was correct.