### PR TITLE
fix: prevent invisible tooltips for the zero value of legendOpacity from the api

### DIFF
--- a/src/shared/components/BandPlot.tsx
+++ b/src/shared/components/BandPlot.tsx
@@ -8,7 +8,10 @@ import {get} from 'lodash'
 import EmptyGraphMessage from 'src/shared/components/EmptyGraphMessage'
 
 // Utils
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import {
+  useLegendOpacity,
+  useLegendOrientationThreshold,
+} from 'src/shared/utils/useLegendOrientation'
 import {
   useVisXDomainSettings,
   useVisYDomainSettings,
@@ -30,8 +33,6 @@ import {
   BAND_LINE_OPACITY,
   BAND_LINE_WIDTH,
   BAND_SHADE_OPACITY,
-  LEGEND_OPACITY_DEFAULT,
-  LEGEND_OPACITY_MINIMUM,
   QUERY_BUILDER_MODE,
   VIS_THEME,
   VIS_THEME_LIGHT,
@@ -120,22 +121,10 @@ const BandPlot: FC<Props> = ({
     )
   }, [activeQueryIndex, queries, upperColumnName, mainColumn, lowerColumnName])
 
-  const tooltipOpacity = Math.max(
-    useMemo(() => {
-      if (isFlagEnabled('legendOrientation')) {
-        return legendOpacity
-      }
-      return LEGEND_OPACITY_DEFAULT
-    }, [legendOpacity]),
-    LEGEND_OPACITY_MINIMUM
+  const tooltipOpacity = useLegendOpacity(legendOpacity)
+  const tooltipOrientationThreshold = useLegendOrientationThreshold(
+    legendOrientationThreshold
   )
-
-  const tooltipOrientationThreshold = useMemo(() => {
-    if (isFlagEnabled('legendOrientation')) {
-      return legendOrientationThreshold
-    }
-    return undefined
-  }, [legendOrientationThreshold])
 
   const storedXDomain = useMemo(() => parseXBounds(xBounds), [xBounds])
   const storedYDomain = useMemo(() => parseYBounds(yBounds), [yBounds])

--- a/src/shared/components/BandPlot.tsx
+++ b/src/shared/components/BandPlot.tsx
@@ -31,6 +31,7 @@ import {
   BAND_LINE_WIDTH,
   BAND_SHADE_OPACITY,
   LEGEND_OPACITY_DEFAULT,
+  LEGEND_OPACITY_MINIMUM,
   QUERY_BUILDER_MODE,
   VIS_THEME,
   VIS_THEME_LIGHT,
@@ -119,12 +120,15 @@ const BandPlot: FC<Props> = ({
     )
   }, [activeQueryIndex, queries, upperColumnName, mainColumn, lowerColumnName])
 
-  const tooltipOpacity = useMemo(() => {
-    if (isFlagEnabled('legendOrientation')) {
-      return legendOpacity
-    }
-    return LEGEND_OPACITY_DEFAULT
-  }, [legendOpacity])
+  const tooltipOpacity = Math.max(
+    useMemo(() => {
+      if (isFlagEnabled('legendOrientation')) {
+        return legendOpacity
+      }
+      return LEGEND_OPACITY_DEFAULT
+    }, [legendOpacity]),
+    LEGEND_OPACITY_MINIMUM
+  )
 
   const tooltipOrientationThreshold = useMemo(() => {
     if (isFlagEnabled('legendOrientation')) {

--- a/src/shared/components/HeatmapPlot.tsx
+++ b/src/shared/components/HeatmapPlot.tsx
@@ -1,12 +1,15 @@
 // Libraries
-import React, {FunctionComponent, useMemo} from 'react'
+import React, {FunctionComponent} from 'react'
 import {Config, Table} from '@influxdata/giraffe'
 
 // Components
 import EmptyGraphMessage from 'src/shared/components/EmptyGraphMessage'
 
 // Utils
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import {
+  useLegendOpacity,
+  useLegendOrientationThreshold,
+} from 'src/shared/utils/useLegendOrientation'
 import {
   useVisXDomainSettings,
   useVisYDomainSettings,
@@ -14,12 +17,7 @@ import {
 import {getFormatter} from 'src/shared/utils/vis'
 
 // Constants
-import {
-  LEGEND_OPACITY_DEFAULT,
-  LEGEND_OPACITY_MINIMUM,
-  VIS_THEME,
-  VIS_THEME_LIGHT,
-} from 'src/shared/constants'
+import {VIS_THEME, VIS_THEME_LIGHT} from 'src/shared/constants'
 import {DEFAULT_LINE_COLORS} from 'src/shared/constants/graphColorPalettes'
 import {INVALID_DATA_COPY} from 'src/shared/copy/cell'
 
@@ -61,22 +59,10 @@ const HeatmapPlot: FunctionComponent<Props> = ({
 }) => {
   const columnKeys = table.columnKeys
 
-  const tooltipOpacity = Math.max(
-    useMemo(() => {
-      if (isFlagEnabled('legendOrientation')) {
-        return legendOpacity
-      }
-      return LEGEND_OPACITY_DEFAULT
-    }, [legendOpacity]),
-    LEGEND_OPACITY_MINIMUM
+  const tooltipOpacity = useLegendOpacity(legendOpacity)
+  const tooltipOrientationThreshold = useLegendOrientationThreshold(
+    legendOrientationThreshold
   )
-
-  const tooltipOrientationThreshold = useMemo(() => {
-    if (isFlagEnabled('legendOrientation')) {
-      return legendOrientationThreshold
-    }
-    return undefined
-  }, [legendOrientationThreshold])
 
   const [xDomain, onSetXDomain, onResetXDomain] = useVisXDomainSettings(
     storedXDomain,

--- a/src/shared/components/HeatmapPlot.tsx
+++ b/src/shared/components/HeatmapPlot.tsx
@@ -16,6 +16,7 @@ import {getFormatter} from 'src/shared/utils/vis'
 // Constants
 import {
   LEGEND_OPACITY_DEFAULT,
+  LEGEND_OPACITY_MINIMUM,
   VIS_THEME,
   VIS_THEME_LIGHT,
 } from 'src/shared/constants'
@@ -60,12 +61,15 @@ const HeatmapPlot: FunctionComponent<Props> = ({
 }) => {
   const columnKeys = table.columnKeys
 
-  const tooltipOpacity = useMemo(() => {
-    if (isFlagEnabled('legendOrientation')) {
-      return legendOpacity
-    }
-    return LEGEND_OPACITY_DEFAULT
-  }, [legendOpacity])
+  const tooltipOpacity = Math.max(
+    useMemo(() => {
+      if (isFlagEnabled('legendOrientation')) {
+        return legendOpacity
+      }
+      return LEGEND_OPACITY_DEFAULT
+    }, [legendOpacity]),
+    LEGEND_OPACITY_MINIMUM
+  )
 
   const tooltipOrientationThreshold = useMemo(() => {
     if (isFlagEnabled('legendOrientation')) {

--- a/src/shared/components/HistogramPlot.tsx
+++ b/src/shared/components/HistogramPlot.tsx
@@ -13,6 +13,7 @@ import {getFormatter} from 'src/shared/utils/vis'
 // Constants
 import {
   LEGEND_OPACITY_DEFAULT,
+  LEGEND_OPACITY_MINIMUM,
   VIS_THEME,
   VIS_THEME_LIGHT,
 } from 'src/shared/constants'
@@ -49,12 +50,15 @@ const HistogramPlot: FunctionComponent<Props> = ({
 }) => {
   const columnKeys = table.columnKeys
 
-  const tooltipOpacity = useMemo(() => {
-    if (isFlagEnabled('legendOrientation')) {
-      return legendOpacity
-    }
-    return LEGEND_OPACITY_DEFAULT
-  }, [legendOpacity])
+  const tooltipOpacity = Math.max(
+    useMemo(() => {
+      if (isFlagEnabled('legendOrientation')) {
+        return legendOpacity
+      }
+      return LEGEND_OPACITY_DEFAULT
+    }, [legendOpacity]),
+    LEGEND_OPACITY_MINIMUM
+  )
 
   const tooltipOrientationThreshold = useMemo(() => {
     if (isFlagEnabled('legendOrientation')) {

--- a/src/shared/components/HistogramPlot.tsx
+++ b/src/shared/components/HistogramPlot.tsx
@@ -1,22 +1,20 @@
 // Libraries
-import React, {FunctionComponent, useMemo} from 'react'
+import React, {FunctionComponent} from 'react'
 import {Config, Table} from '@influxdata/giraffe'
 
 // Components
 import EmptyGraphMessage from 'src/shared/components/EmptyGraphMessage'
 
 // Utils
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import {
+  useLegendOpacity,
+  useLegendOrientationThreshold,
+} from 'src/shared/utils/useLegendOrientation'
 import {useVisXDomainSettings} from 'src/shared/utils/useVisDomainSettings'
 import {getFormatter} from 'src/shared/utils/vis'
 
 // Constants
-import {
-  LEGEND_OPACITY_DEFAULT,
-  LEGEND_OPACITY_MINIMUM,
-  VIS_THEME,
-  VIS_THEME_LIGHT,
-} from 'src/shared/constants'
+import {VIS_THEME, VIS_THEME_LIGHT} from 'src/shared/constants'
 import {DEFAULT_LINE_COLORS} from 'src/shared/constants/graphColorPalettes'
 import {INVALID_DATA_COPY} from 'src/shared/copy/cell'
 
@@ -50,22 +48,10 @@ const HistogramPlot: FunctionComponent<Props> = ({
 }) => {
   const columnKeys = table.columnKeys
 
-  const tooltipOpacity = Math.max(
-    useMemo(() => {
-      if (isFlagEnabled('legendOrientation')) {
-        return legendOpacity
-      }
-      return LEGEND_OPACITY_DEFAULT
-    }, [legendOpacity]),
-    LEGEND_OPACITY_MINIMUM
+  const tooltipOpacity = useLegendOpacity(legendOpacity)
+  const tooltipOrientationThreshold = useLegendOrientationThreshold(
+    legendOrientationThreshold
   )
-
-  const tooltipOrientationThreshold = useMemo(() => {
-    if (isFlagEnabled('legendOrientation')) {
-      return legendOrientationThreshold
-    }
-    return undefined
-  }, [legendOrientationThreshold])
 
   const [xDomain, onSetXDomain, onResetXDomain] = useVisXDomainSettings(
     storedXDomain,

--- a/src/shared/components/MosaicPlot.tsx
+++ b/src/shared/components/MosaicPlot.tsx
@@ -16,6 +16,7 @@ import {getFormatter, defaultXColumn, mosaicYcolumn} from 'src/shared/utils/vis'
 // Constants
 import {
   LEGEND_OPACITY_DEFAULT,
+  LEGEND_OPACITY_MINIMUM,
   VIS_THEME,
   VIS_THEME_LIGHT,
 } from 'src/shared/constants'
@@ -65,12 +66,15 @@ const MosaicPlot: FunctionComponent<Props> = ({
   }
   const columnKeys = table.columnKeys
 
-  const tooltipOpacity = useMemo(() => {
-    if (isFlagEnabled('legendOrientation')) {
-      return legendOpacity
-    }
-    return LEGEND_OPACITY_DEFAULT
-  }, [legendOpacity])
+  const tooltipOpacity = Math.max(
+    useMemo(() => {
+      if (isFlagEnabled('legendOrientation')) {
+        return legendOpacity
+      }
+      return LEGEND_OPACITY_DEFAULT
+    }, [legendOpacity]),
+    LEGEND_OPACITY_MINIMUM
+  )
 
   const tooltipOrientationThreshold = useMemo(() => {
     if (isFlagEnabled('legendOrientation')) {

--- a/src/shared/components/MosaicPlot.tsx
+++ b/src/shared/components/MosaicPlot.tsx
@@ -1,12 +1,15 @@
 // Libraries
-import React, {FunctionComponent, useMemo} from 'react'
+import React, {FunctionComponent} from 'react'
 import {Config, Table} from '@influxdata/giraffe'
 
 // Components
 import EmptyGraphMessage from 'src/shared/components/EmptyGraphMessage'
 
 // Utils
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import {
+  useLegendOpacity,
+  useLegendOrientationThreshold,
+} from 'src/shared/utils/useLegendOrientation'
 import {
   useVisXDomainSettings,
   useVisYDomainSettings,
@@ -14,12 +17,7 @@ import {
 import {getFormatter, defaultXColumn, mosaicYcolumn} from 'src/shared/utils/vis'
 
 // Constants
-import {
-  LEGEND_OPACITY_DEFAULT,
-  LEGEND_OPACITY_MINIMUM,
-  VIS_THEME,
-  VIS_THEME_LIGHT,
-} from 'src/shared/constants'
+import {VIS_THEME, VIS_THEME_LIGHT} from 'src/shared/constants'
 import {DEFAULT_LINE_COLORS} from 'src/shared/constants/graphColorPalettes'
 import {INVALID_DATA_COPY} from 'src/shared/copy/cell'
 
@@ -66,22 +64,10 @@ const MosaicPlot: FunctionComponent<Props> = ({
   }
   const columnKeys = table.columnKeys
 
-  const tooltipOpacity = Math.max(
-    useMemo(() => {
-      if (isFlagEnabled('legendOrientation')) {
-        return legendOpacity
-      }
-      return LEGEND_OPACITY_DEFAULT
-    }, [legendOpacity]),
-    LEGEND_OPACITY_MINIMUM
+  const tooltipOpacity = useLegendOpacity(legendOpacity)
+  const tooltipOrientationThreshold = useLegendOrientationThreshold(
+    legendOrientationThreshold
   )
-
-  const tooltipOrientationThreshold = useMemo(() => {
-    if (isFlagEnabled('legendOrientation')) {
-      return legendOrientationThreshold
-    }
-    return undefined
-  }, [legendOrientationThreshold])
 
   const [xDomain, onSetXDomain, onResetXDomain] = useVisXDomainSettings(
     storedXDomain,

--- a/src/shared/components/ScatterPlot.tsx
+++ b/src/shared/components/ScatterPlot.tsx
@@ -1,12 +1,15 @@
 // Libraries
-import React, {FunctionComponent, useMemo} from 'react'
+import React, {FunctionComponent} from 'react'
 import {Config, Table} from '@influxdata/giraffe'
 
 // Components
 import EmptyGraphMessage from 'src/shared/components/EmptyGraphMessage'
 
 // Utils
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import {
+  useLegendOpacity,
+  useLegendOrientationThreshold,
+} from 'src/shared/utils/useLegendOrientation'
 import {
   useVisXDomainSettings,
   useVisYDomainSettings,
@@ -18,12 +21,7 @@ import {
 } from 'src/shared/utils/vis'
 
 // Constants
-import {
-  LEGEND_OPACITY_DEFAULT,
-  LEGEND_OPACITY_MINIMUM,
-  VIS_THEME,
-  VIS_THEME_LIGHT,
-} from 'src/shared/constants'
+import {VIS_THEME, VIS_THEME_LIGHT} from 'src/shared/constants'
 import {DEFAULT_LINE_COLORS} from 'src/shared/constants/graphColorPalettes'
 import {INVALID_DATA_COPY} from 'src/shared/copy/cell'
 
@@ -71,22 +69,10 @@ const ScatterPlot: FunctionComponent<Props> = ({
 
   const columnKeys = table.columnKeys
 
-  const tooltipOpacity = Math.max(
-    useMemo(() => {
-      if (isFlagEnabled('legendOrientation')) {
-        return legendOpacity
-      }
-      return LEGEND_OPACITY_DEFAULT
-    }, [legendOpacity]),
-    LEGEND_OPACITY_MINIMUM
+  const tooltipOpacity = useLegendOpacity(legendOpacity)
+  const tooltipOrientationThreshold = useLegendOrientationThreshold(
+    legendOrientationThreshold
   )
-
-  const tooltipOrientationThreshold = useMemo(() => {
-    if (isFlagEnabled('legendOrientation')) {
-      return legendOrientationThreshold
-    }
-    return undefined
-  }, [legendOrientationThreshold])
 
   const [xDomain, onSetXDomain, onResetXDomain] = useVisXDomainSettings(
     storedXDomain,

--- a/src/shared/components/ScatterPlot.tsx
+++ b/src/shared/components/ScatterPlot.tsx
@@ -20,6 +20,7 @@ import {
 // Constants
 import {
   LEGEND_OPACITY_DEFAULT,
+  LEGEND_OPACITY_MINIMUM,
   VIS_THEME,
   VIS_THEME_LIGHT,
 } from 'src/shared/constants'
@@ -70,12 +71,15 @@ const ScatterPlot: FunctionComponent<Props> = ({
 
   const columnKeys = table.columnKeys
 
-  const tooltipOpacity = useMemo(() => {
-    if (isFlagEnabled('legendOrientation')) {
-      return legendOpacity
-    }
-    return LEGEND_OPACITY_DEFAULT
-  }, [legendOpacity])
+  const tooltipOpacity = Math.max(
+    useMemo(() => {
+      if (isFlagEnabled('legendOrientation')) {
+        return legendOpacity
+      }
+      return LEGEND_OPACITY_DEFAULT
+    }, [legendOpacity]),
+    LEGEND_OPACITY_MINIMUM
+  )
 
   const tooltipOrientationThreshold = useMemo(() => {
     if (isFlagEnabled('legendOrientation')) {

--- a/src/shared/components/XYPlot.tsx
+++ b/src/shared/components/XYPlot.tsx
@@ -12,7 +12,10 @@ import {
 import EmptyGraphMessage from 'src/shared/components/EmptyGraphMessage'
 
 // Utils
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import {
+  useLegendOpacity,
+  useLegendOrientationThreshold,
+} from 'src/shared/utils/useLegendOrientation'
 import {
   useVisXDomainSettings,
   useVisYDomainSettings,
@@ -28,12 +31,7 @@ import {
 } from 'src/shared/utils/vis'
 
 // Constants
-import {
-  LEGEND_OPACITY_DEFAULT,
-  LEGEND_OPACITY_MINIMUM,
-  VIS_THEME,
-  VIS_THEME_LIGHT,
-} from 'src/shared/constants'
+import {VIS_THEME, VIS_THEME_LIGHT} from 'src/shared/constants'
 import {DEFAULT_LINE_COLORS} from 'src/shared/constants/graphColorPalettes'
 import {INVALID_DATA_COPY} from 'src/shared/copy/cell'
 
@@ -86,22 +84,10 @@ const XYPlot: FC<Props> = ({
   },
   theme,
 }) => {
-  const tooltipOpacity = Math.max(
-    useMemo(() => {
-      if (isFlagEnabled('legendOrientation')) {
-        return legendOpacity
-      }
-      return LEGEND_OPACITY_DEFAULT
-    }, [legendOpacity]),
-    LEGEND_OPACITY_MINIMUM
+  const tooltipOpacity = useLegendOpacity(legendOpacity)
+  const tooltipOrientationThreshold = useLegendOrientationThreshold(
+    legendOrientationThreshold
   )
-
-  const tooltipOrientationThreshold = useMemo(() => {
-    if (isFlagEnabled('legendOrientation')) {
-      return legendOrientationThreshold
-    }
-    return undefined
-  }, [legendOrientationThreshold])
 
   const storedXDomain = useMemo(() => parseXBounds(xBounds), [xBounds])
   const storedYDomain = useMemo(() => parseYBounds(yBounds), [yBounds])

--- a/src/shared/components/XYPlot.tsx
+++ b/src/shared/components/XYPlot.tsx
@@ -30,6 +30,7 @@ import {
 // Constants
 import {
   LEGEND_OPACITY_DEFAULT,
+  LEGEND_OPACITY_MINIMUM,
   VIS_THEME,
   VIS_THEME_LIGHT,
 } from 'src/shared/constants'
@@ -85,12 +86,15 @@ const XYPlot: FC<Props> = ({
   },
   theme,
 }) => {
-  const tooltipOpacity = useMemo(() => {
-    if (isFlagEnabled('legendOrientation')) {
-      return legendOpacity
-    }
-    return LEGEND_OPACITY_DEFAULT
-  }, [legendOpacity])
+  const tooltipOpacity = Math.max(
+    useMemo(() => {
+      if (isFlagEnabled('legendOrientation')) {
+        return legendOpacity
+      }
+      return LEGEND_OPACITY_DEFAULT
+    }, [legendOpacity]),
+    LEGEND_OPACITY_MINIMUM
+  )
 
   const tooltipOrientationThreshold = useMemo(() => {
     if (isFlagEnabled('legendOrientation')) {

--- a/src/shared/utils/useLegendOrientation.ts
+++ b/src/shared/utils/useLegendOrientation.ts
@@ -1,0 +1,27 @@
+import {useMemo} from 'react'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import {
+  LEGEND_OPACITY_DEFAULT,
+  LEGEND_OPACITY_MINIMUM,
+} from 'src/shared/constants'
+
+export const useLegendOpacity = (legendOpacity: number) =>
+  useMemo(() => {
+    if (
+      !isFlagEnabled('legendOrientation') ||
+      legendOpacity < LEGEND_OPACITY_MINIMUM
+    ) {
+      return LEGEND_OPACITY_DEFAULT
+    }
+    return legendOpacity
+  }, [legendOpacity])
+
+export const useLegendOrientationThreshold = (
+  legendOrientationThreshold: number
+) =>
+  useMemo(() => {
+    if (isFlagEnabled('legendOrientation')) {
+      return legendOrientationThreshold
+    }
+    return undefined
+  }, [legendOrientationThreshold])


### PR DESCRIPTION
The initial value from the backend api comes back as 0 for opacity, which doesn't change in props, causing legends to appear invisible. Prevent this by ensuring minimum opacity is always used.