### PR TITLE
fix(redux): export store singleton, rather than configureStore factory function

### DIFF
--- a/src/external/monaco.flux.server.ts
+++ b/src/external/monaco.flux.server.ts
@@ -27,7 +27,7 @@ import {getOrg} from 'src/organizations/selectors'
 import {fetchAllBuckets} from 'src/buckets/actions/thunks'
 import {event} from 'src/cloud/utils/reporting'
 
-import {store} from 'src/index'
+import {getStore} from 'src/store/configureStore'
 
 import {Store} from 'redux'
 import {
@@ -124,7 +124,7 @@ export class LSPServer {
   private documentVersions: {[key: string]: number} = {}
   public store: Store<AppState & LocalStorage>
 
-  constructor(server: WASMServer, reduxStore = store) {
+  constructor(server: WASMServer, reduxStore = getStore()) {
     this.server = server
     this.server.register_buckets_callback(this.getBuckets)
     this.server.register_measurements_callback(this.getMeasurements)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,8 +9,7 @@ import {Route} from 'react-router-dom'
 import {ConnectedRouter} from 'connected-react-router'
 
 // Stores
-import configureStore from 'src/store/configureStore'
-import {loadLocalStorage} from 'src/localStorage'
+import {getStore} from 'src/store/configureStore'
 import {history} from 'src/store/history'
 
 // Components
@@ -41,11 +40,10 @@ updateReportingContext({
   session: cookieSession ? cookieSession[2].slice(5) : '',
 })
 
-export const store = configureStore(loadLocalStorage())
-const {dispatch} = store
+const {dispatch} = getStore()
 
 if (window['Cypress']) {
-  window['store'] = store
+  window['store'] = getStore()
 }
 
 history.listen(() => {
@@ -70,7 +68,7 @@ window.addEventListener('keyup', event => {
 class Root extends PureComponent {
   public render() {
     return (
-      <Provider store={store}>
+      <Provider store={getStore()}>
         <ConnectedRouter history={history}>
           <Route component={GetLinks} />
           <Route component={Setup} />

--- a/src/mockState.tsx
+++ b/src/mockState.tsx
@@ -6,7 +6,7 @@ import {createMemoryHistory} from 'history'
 import {render} from '@testing-library/react'
 import {initialState as initialVariablesState} from 'src/variables/reducers'
 import {initialState as initialUserSettingsState} from 'src/userSettings/reducers'
-import {default as configureStore, clearStore} from 'src/store/configureStore'
+import {configureStoreForTests} from 'src/store/configureStore'
 import {RemoteDataState, TimeZone, LocalStorage, ResourceType} from 'src/types'
 import {pastFifteenMinTimeRange} from './shared/constants/timeRanges'
 
@@ -56,11 +56,7 @@ export const localState: LocalStorage = {
 }
 
 export function renderWithRedux(ui, initialState = s => s) {
-  clearStore()
-  const seedStore = configureStore(localState)
-  const seedState = seedStore.getState()
-  clearStore()
-  const store = configureStore(initialState(seedState))
+  const store = configureStoreForTests(initialState(localState))
 
   return {
     ...render(<Provider store={store}>{ui}</Provider>),
@@ -69,12 +65,8 @@ export function renderWithRedux(ui, initialState = s => s) {
 }
 
 export function renderWithReduxAndRouter(ui, initialState = s => s) {
-  clearStore()
   const history = createMemoryHistory({initialEntries: ['/']})
-  const seedStore = configureStore(localState)
-  const seedState = seedStore.getState()
-  clearStore()
-  const store = configureStore(initialState(seedState))
+  const store = configureStoreForTests(initialState(localState))
 
   return {
     ...render(

--- a/src/shared/utils/featureFlag.ts
+++ b/src/shared/utils/featureFlag.ts
@@ -2,12 +2,11 @@ import {FunctionComponent} from 'react'
 import {activeFlags} from 'src/shared/selectors/flags'
 import {clearOverrides, setOverride} from 'src/shared/actions/flags'
 
-import configureStore from 'src/store/configureStore'
+import {getStore} from 'src/store/configureStore'
 
 export const isFlagEnabled = (flagName: string, equals?: string | boolean) => {
   let _equals = equals
-  const store = configureStore()
-  const flags = activeFlags(store.getState())
+  const flags = activeFlags(getStore().getState())
 
   if (_equals === undefined) {
     _equals = true
@@ -32,7 +31,7 @@ export const FeatureFlag: FunctionComponent<{
   return children as any
 }
 
-export const getUserFlags = () => activeFlags(configureStore().getState())
+export const getUserFlags = () => activeFlags(getStore().getState())
 
 /* eslint-disable no-console */
 const list = () => {
@@ -42,13 +41,11 @@ const list = () => {
 /* eslint-enable no-console */
 
 const reset = () => {
-  const store = configureStore()
-  store.dispatch(clearOverrides())
+  getStore().dispatch(clearOverrides())
 }
 
 export const set = (flagName: string, value: string | boolean) => {
-  const store = configureStore()
-  store.dispatch(setOverride(flagName, value))
+  getStore().dispatch(setOverride(flagName, value))
 }
 
 export const toggle = (flagName: string): boolean => {

--- a/src/shared/utils/pageTitles.test.ts
+++ b/src/shared/utils/pageTitles.test.ts
@@ -1,0 +1,50 @@
+jest.mock('src/store/configureStore')
+import {getStore} from 'src/store/configureStore'
+import {mocked} from 'ts-jest/utils'
+
+mocked(getStore)
+  .mockImplementationOnce(() => {
+    return {
+      getState: jest.fn(() => {
+        return {
+          resources: {
+            orgs: {
+              byID: {},
+              allIDs: [],
+              status: 'NotStarted',
+              org: {name: 'Fine Young Cannibals'},
+            },
+          },
+        }
+      }),
+    }
+  })
+  .mockImplementationOnce(() => {
+    return {
+      getState: jest.fn(() => {
+        return {
+          resources: {
+            orgs: {
+              org: null,
+            },
+          },
+        }
+      }),
+    }
+  })
+
+import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
+
+describe('suffixing page titles', () => {
+  it('adds the titles, the org name, and the environment', () => {
+    expect(pageTitleSuffixer(['Templates', 'Settings'])).toBe(
+      'Templates | Settings | Fine Young Cannibals | InfluxDB'
+    )
+  })
+
+  it('does not include blank org names', () => {
+    expect(pageTitleSuffixer(['Templates', 'Settings'])).toBe(
+      'Templates | Settings | InfluxDB'
+    )
+  })
+})

--- a/src/shared/utils/pageTitles.ts
+++ b/src/shared/utils/pageTitles.ts
@@ -1,12 +1,15 @@
 import {getOrg} from 'src/organizations/selectors'
-import {store} from 'src/index'
+import {getStore} from 'src/store/configureStore'
 import {CLOUD} from 'src/shared/constants'
 
 export const pageTitleSuffixer = (pageTitles: string[]): string => {
-  const state = store.getState()
-  const {name} = getOrg(state) || null
-  const title = CLOUD ? 'InfluxDB Cloud' : 'InfluxDB'
-  const titles = [...pageTitles, name, title]
+  const state = getStore().getState()
+  const org = getOrg(state)
+  const environment = CLOUD ? 'InfluxDB Cloud' : 'InfluxDB'
+  const titles =
+    org && org.name
+      ? [...pageTitles, getOrg(state).name, environment]
+      : [...pageTitles, environment]
 
   return titles.join(' | ')
 }

--- a/src/store/configureStore.test.ts
+++ b/src/store/configureStore.test.ts
@@ -1,0 +1,7 @@
+import {getStore} from 'src/store/configureStore'
+
+describe('configuring a store', () => {
+  it('is an idempotent singleton', () => {
+    expect(getStore()).toBe(getStore())
+  })
+})


### PR DESCRIPTION
Closes #124

* Previously, `index.tsx` exported `store` after configuring it. Modules would then import `store` from `index.tsx.`
  * I just want to reiterate here: modules **included the entry point of the app which automatically runs and includes the module that included `index.tsx` as part of the code that runs**
  * Other modules would import `configureStore` and re-configure the store, which overwrote the store willy nilly.
* Now: `store` is a true [singleton.](https://en.wikipedia.org/wiki/Singleton_pattern) It's created exactly once, and the instance of the created `store` is returned via an exported function. Any place that imported `store` from `index.tsx` or the function `configureStore` now imports the `getStore` function.
* This also includes a change to `pageTitles` and a test for it. This PR initially started as change for how `pageTitles` handles there not being an org in store (it crashed before). 

### Testing
I got paranoid that this code would literally ruin everything, so to test it, I updated `configureStore` to look something like:

```ts
export const getStore = () => {
  if (!storeSingleton) {
    console.log('NO SINGLETON')
    storeSingleton = configureStore()
  }

  console.log('configureStore.ts getStore', {...storeSingleton.getState().resources.orgs.org})

  return storeSingleton
}
```
The console does in fact show `NO SINGLETON` only once.