### PR TITLE
fix: set default hoverDimension for Line Options to 'auto'

### DIFF
--- a/src/timeMachine/components/view_options/LineOptions.tsx
+++ b/src/timeMachine/components/view_options/LineOptions.tsx
@@ -94,7 +94,7 @@ class LineOptions extends PureComponent<Props> {
       numericColumns,
       onSetTimeFormat,
       timeFormat,
-      hoverDimension = 'auto',
+      hoverDimension,
       onSetHoverDimension,
       onSetLegendOpacity,
       onSetLegendOrientationThreshold,

--- a/src/views/helpers/index.ts
+++ b/src/views/helpers/index.ts
@@ -97,6 +97,7 @@ export function defaultLineViewProperties() {
         scale: 'linear',
       } as Axis,
     },
+    hoverDimension: 'auto' as LineHoverDimension,
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/19178

Previously, hoverDimension as a variable was defaulted to have 'auto as a value. But this doesn't actually set the redux state with the correct default hoverDimension. Default view properties should be set in **src/views/helpers/index.ts** which will reflect in redux state.