### PR TITLE
refactor(notes): remove side effects from notes action creator

### DIFF
--- a/src/dashboards/actions/notes.ts
+++ b/src/dashboards/actions/notes.ts
@@ -1,25 +1,4 @@
-// Libraries
-import {get} from 'lodash'
-
-// Actions
-import {createCellWithView} from 'src/cells/actions/thunks'
-import {updateView} from 'src/views/actions/thunks'
-
-// Utils
-import {createView} from 'src/views/helpers'
-import {getByID} from 'src/resources/selectors'
-
-// Types
-import {
-  GetState,
-  MarkdownViewProperties,
-  NoteEditorMode,
-  ResourceType,
-  Dashboard,
-  View,
-} from 'src/types'
 import {NoteEditorState} from 'src/dashboards/reducers/notes'
-import {Dispatch} from 'react'
 
 export type Action =
   | CloseNoteEditorAction
@@ -67,28 +46,6 @@ export const setNote = (note: string): SetNoteAction => ({
   payload: {note},
 })
 
-export const createNoteCell = (dashboardID: string) => (
-  dispatch: Dispatch<Action | ReturnType<typeof createCellWithView>>,
-  getState: GetState
-) => {
-  const dashboard = getByID<Dashboard>(
-    getState(),
-    ResourceType.Dashboards,
-    dashboardID
-  )
-
-  if (!dashboard) {
-    throw new Error(`could not find dashboard with id "${dashboardID}"`)
-  }
-
-  const {note} = getState().noteEditor
-  const view = createView<MarkdownViewProperties>('markdown')
-
-  view.properties.note = note
-
-  return dispatch(createCellWithView(dashboard.id, view))
-}
-
 export interface ResetNoteStateAction {
   type: 'RESET_NOTE_STATE'
 }
@@ -108,55 +65,3 @@ export const setNoteState = (
   type: 'SET_NOTE_STATE',
   payload: noteState,
 })
-
-export const loadNote = (id: string) => (
-  dispatch: Dispatch<Action>,
-  getState: GetState
-) => {
-  const state = getState()
-  const currentViewState = getByID<View>(state, ResourceType.Views, id)
-
-  if (!currentViewState) {
-    return
-  }
-
-  const view = currentViewState
-
-  const note: string = get(view, 'properties.note', '')
-  const showNoteWhenEmpty: boolean = get(
-    view,
-    'properties.showNoteWhenEmpty',
-    false
-  )
-
-  const initialState = {
-    viewID: view.id,
-    note,
-    showNoteWhenEmpty,
-    mode: NoteEditorMode.Editing,
-  }
-
-  dispatch(setNoteState(initialState))
-}
-
-export const updateViewNote = (id: string) => (
-  dispatch: Dispatch<Action | ReturnType<typeof updateView>>,
-  getState: GetState
-) => {
-  const state = getState()
-  const {note, showNoteWhenEmpty} = state.noteEditor
-  const view = getByID<View>(state, ResourceType.Views, id)
-
-  if (view.properties.type === 'check') {
-    throw new Error(
-      `view type "${view.properties.type}" does not support notes`
-    )
-  }
-
-  const updatedView = {
-    ...view,
-    properties: {...view.properties, note, showNoteWhenEmpty},
-  }
-
-  return dispatch(updateView(view.dashboardID, updatedView))
-}

--- a/src/dashboards/components/NoteEditorOverlay.tsx
+++ b/src/dashboards/components/NoteEditorOverlay.tsx
@@ -19,8 +19,8 @@ import {
   createNoteCell,
   updateViewNote,
   loadNote,
-  resetNoteState,
-} from 'src/dashboards/actions/notes'
+} from 'src/dashboards/actions/thunks'
+import {resetNoteState} from 'src/dashboards/actions/notes'
 import {notify} from 'src/shared/actions/notifications'
 
 // Utils


### PR DESCRIPTION
Closes #136 

Moves the side effects of the notes action creator to the dashboard thunk. This resolves the circular dependencies between configureStore and this module.

#### How does this break dependencies?
- `configureStore` builds the empty store based off the initial state the reducers describe
- to do this, `configureStore` imports all the reducers.
- reducers pull in the action creator functions and the name of the actions
  - if the actions have outside dependencies (say on `event`, which indirectly depends on `featureFlag`), those are imported and executed before `configureStore` is executed
- by moving the side effects (and more importantly, their dependencies) outside the dependency chain of reducers and action creators,  circular dependencies that flow back to `configureStore` are removed.

#### Old dependency graph
![old](https://user-images.githubusercontent.com/146112/94868034-366f4780-03f7-11eb-812d-7cd4ac34255a.png)

#### New dependency graph (notes no longer has outside circular dependencies)
![new](https://user-images.githubusercontent.com/146112/94868051-3f601900-03f7-11eb-863e-dfc6f750885a.png)

```sh
madge --webpack-config webpack.common.ts src/store/configureStore.ts --image graph.svg --circular
```

