### PR TITLE
refactor(redux): remove side effects from alertBuilder actions

### DIFF
--- a/src/alerting/actions/alertBuilder.ts
+++ b/src/alerting/actions/alertBuilder.ts
@@ -1,6 +1,3 @@
-// Actions
-import {executeQueries} from 'src/timeMachine/actions/queries'
-
 // Types
 import {
   RemoteDataState,
@@ -121,8 +118,3 @@ export const updateName = (name: string) => ({
   type: 'UPDATE_ALERT_BUILDER_NAME' as 'UPDATE_ALERT_BUILDER_NAME',
   payload: {name},
 })
-
-export const selectCheckEvery = (every: string) => dispatch => {
-  dispatch(setEvery(every))
-  dispatch(executeQueries())
-}

--- a/src/alerting/actions/thunks.ts
+++ b/src/alerting/actions/thunks.ts
@@ -1,0 +1,8 @@
+// Actions
+import {executeQueries} from 'src/timeMachine/actions/queries'
+import {setEvery} from 'src/alerting/actions/alertBuilder'
+
+export const selectCheckEvery = (every: string) => dispatch => {
+  dispatch(setEvery(every))
+  dispatch(executeQueries())
+}

--- a/src/checks/components/CheckMetaCard.tsx
+++ b/src/checks/components/CheckMetaCard.tsx
@@ -13,9 +13,10 @@ import DurationInput from 'src/shared/components/DurationInput'
 import {
   setOffset,
   removeTagSet,
-  selectCheckEvery,
   editTagSetByIndex,
 } from 'src/alerting/actions/alertBuilder'
+
+import {selectCheckEvery} from 'src/alerting/actions/thunks'
 
 // Constants
 import {CHECK_OFFSET_OPTIONS} from 'src/alerting/constants'


### PR DESCRIPTION
closes #139 

Moves the single action with side effects of alertBuilder's action creator into a newly minted thunk.

#### Old dependency graph
![new](https://user-images.githubusercontent.com/146112/94868051-3f601900-03f7-11eb-863e-dfc6f750885a.png)

#### New dependency graph
![configure_store_new](https://user-images.githubusercontent.com/146112/94870645-ed21f680-03fc-11eb-8fdf-0c4d23374151.png)

```sh
madge --webpack-config webpack.common.ts src/store/configureStore.ts --image graph.svg --circular
```

#### How does this break dependencies?
- `configureStore` builds the empty store based off the initial state the reducers describe
- to do this, `configureStore` imports all the reducers.
- reducers pull in the action creator functions and the name of the actions
  - if the actions have outside dependencies (say on `event`, which indirectly depends on `featureFlag`), those are imported and executed before `configureStore` is executed
- by moving the side effects (and more importantly, their dependencies) outside the dependency chain of reducers and action creators,  circular dependencies that flow back to `configureStore` are removed.