### PR TITLE
refactor(redux): move me actions with side effects to meThunks

### DIFF
--- a/src/shared/actions/me.ts
+++ b/src/shared/actions/me.ts
@@ -1,7 +1,4 @@
 import {MeState} from 'src/shared/reducers/me'
-import {client} from 'src/utils/api'
-import HoneyBadger from 'honeybadger-js'
-import {updateReportingContext, gaEvent} from 'src/cloud/utils/reporting'
 
 export const SET_ME = 'SET_ME'
 
@@ -14,28 +11,3 @@ export const setMe = (me: MeState) =>
       me,
     },
   } as const)
-
-export const getMe = () => async dispatch => {
-  try {
-    const user = await client.users.me()
-    updateReportingContext({userID: user.id, userEmail: user.name})
-
-    gaEvent('cloudAppUserDataReady', {
-      identity: {
-        id: user.id,
-        email: user.name,
-      },
-    })
-
-    updateReportingContext({
-      userID: user.id,
-    })
-    HoneyBadger.setContext({
-      user_id: user.id,
-    })
-
-    dispatch(setMe(user as MeState))
-  } catch (error) {
-    console.error(error)
-  }
-}

--- a/src/shared/actions/meThunks.ts
+++ b/src/shared/actions/meThunks.ts
@@ -1,0 +1,39 @@
+// libraries
+import HoneyBadger from 'honeybadger-js'
+
+// api
+import {client} from 'src/utils/api'
+
+// utils
+import {gaEvent, updateReportingContext} from 'src/cloud/utils/reporting'
+
+// actions
+import {setMe} from 'src/shared/actions/me'
+
+//reducers
+import {MeState} from 'src/shared/reducers/me'
+
+export const getMe = () => async dispatch => {
+  try {
+    const user = await client.users.me()
+    updateReportingContext({userID: user.id, userEmail: user.name})
+
+    gaEvent('cloudAppUserDataReady', {
+      identity: {
+        id: user.id,
+        email: user.name,
+      },
+    })
+
+    updateReportingContext({
+      userID: user.id,
+    })
+    HoneyBadger.setContext({
+      user_id: user.id,
+    })
+
+    dispatch(setMe(user as MeState))
+  } catch (error) {
+    console.error(error)
+  }
+}

--- a/src/shared/containers/GetMe.tsx
+++ b/src/shared/containers/GetMe.tsx
@@ -11,7 +11,7 @@ import GetFlags from 'src/shared/containers/GetFlags'
 import {RemoteDataState} from 'src/types'
 
 // Actions
-import {getMe} from 'src/shared/actions/me'
+import {getMe} from 'src/shared/actions/meThunks'
 
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'


### PR DESCRIPTION
closes #140

Makes `me` action creators pure by moving the single function with side effects into a thunk

#### Old dependency graph
![configure_store_new](https://user-images.githubusercontent.com/146112/94870645-ed21f680-03fc-11eb-8fdf-0c4d23374151.png)

#### New dependency graph
![configure_store_new](https://user-images.githubusercontent.com/146112/94945855-2788a380-0490-11eb-8fcb-0291c1bb6f74.png)


```sh
madge --webpack-config webpack.common.ts src/store/configureStore.ts --image graph.svg --circular
```

#### How does this break dependencies?
- `configureStore` builds the empty store based off the initial state the reducers describe
- to do this, `configureStore` imports all the reducers.
- reducers pull in the action creator functions and the name of the actions
  - if the actions have outside dependencies (say on `event`, which indirectly depends on `featureFlag`), those are imported and executed before `configureStore` is executed
- by moving the side effects (and more importantly, their dependencies) outside the dependency chain of reducers and action creators,  circular dependencies that flow back to `configureStore` are removed.