### PR TITLE
refactor(redux): remove side effects from predicates actions

### DIFF
--- a/src/dataExplorer/components/DeleteDataOverlay.tsx
+++ b/src/dataExplorer/components/DeleteDataOverlay.tsx
@@ -17,11 +17,8 @@ import {convertTimeRangeToCustom} from 'src/shared/utils/duration'
 import {AppState, ResourceType} from 'src/types'
 
 // Actions
-import {
-  resetPredicateState,
-  setTimeRange,
-  setBucketAndKeys,
-} from 'src/shared/actions/predicates'
+import {resetPredicateState, setTimeRange} from 'src/shared/actions/predicates'
+import {setBucketAndKeys} from 'src/shared/actions/predicatesThunks'
 
 type ReduxProps = ConnectedProps<typeof connector>
 type Props = RouteComponentProps<{orgID: string}> & ReduxProps

--- a/src/shared/actions/predicates.ts
+++ b/src/shared/actions/predicates.ts
@@ -1,31 +1,5 @@
-// Libraries
-import {Dispatch} from 'react'
-import {extractBoxedCol} from 'src/timeMachine/apis/queryBuilder'
-import moment from 'moment'
-
-// Utils
-import {postDelete} from 'src/client'
-import {runQuery} from 'src/shared/apis/query'
-import {getWindowVars} from 'src/variables/utils/getWindowVars'
-import {buildVarsOption} from 'src/variables/utils/buildVarsOption'
-import {getVariables, asAssignment} from 'src/variables/selectors'
-import fromFlux from 'src/shared/utils/fromFlux'
-import {getOrg} from 'src/organizations/selectors'
-
-// Actions
-import {notify} from 'src/shared/actions/notifications'
-
-// Constants
-import {
-  predicateDeleteFailed,
-  predicateDeleteSucceeded,
-  setFilterKeyFailed,
-  setFilterValueFailed,
-} from 'src/shared/copy/notifications'
-import {rateLimitReached, resultTooLarge} from 'src/shared/copy/notifications'
-
 // Types
-import {RemoteDataState, Filter, CustomTimeRange, GetState} from 'src/types'
+import {RemoteDataState, Filter, CustomTimeRange} from 'src/types'
 import {Action as NotifyAction} from 'src/shared/actions/notifications'
 
 export type Action =
@@ -124,16 +98,6 @@ export const setIsSerious = (isSerious: boolean): SetIsSerious => ({
   payload: {isSerious},
 })
 
-interface SetKeysByBucket {
-  type: 'SET_KEYS_BY_BUCKET'
-  payload: {keys: string[]}
-}
-
-const setKeys = (keys: string[]): SetKeysByBucket => ({
-  type: 'SET_KEYS_BY_BUCKET',
-  payload: {keys},
-})
-
 interface SetPreviewStatus {
   type: 'SET_PREVIEW_STATUS'
   payload: {previewStatus: RemoteDataState}
@@ -161,144 +125,17 @@ interface SetValuesByKey {
   payload: {values: string[]}
 }
 
-const setValues = (values: string[]): SetValuesByKey => ({
+export const setValues = (values: string[]): SetValuesByKey => ({
   type: 'SET_VALUES_BY_KEY',
   payload: {values},
 })
 
-const formatFilters = (filters: Filter[]) =>
-  filters.map(f => `${f.key} ${f.equality} ${f.value}`).join(' AND ')
-
-export const deleteWithPredicate = () => async (
-  dispatch: Dispatch<Action>,
-  getState: GetState
-) => {
-  dispatch(setDeletionStatus(RemoteDataState.Loading))
-
-  const {
-    predicates: {timeRange, bucketName, filters},
-  } = getState()
-  const orgID = getOrg(getState()).id
-
-  const data = {
-    start: moment(timeRange.lower).toISOString(),
-    stop: moment(timeRange.upper).toISOString(),
-  }
-
-  if (filters.length > 0) {
-    data['predicate'] = formatFilters(filters)
-  }
-
-  try {
-    const resp = await postDelete({
-      data,
-      query: {
-        orgID,
-        bucket: bucketName,
-      },
-    })
-
-    if (resp.status !== 204) {
-      throw new Error(resp.data.message)
-    }
-
-    dispatch(setDeletionStatus(RemoteDataState.Done))
-    dispatch(notify(predicateDeleteSucceeded()))
-    dispatch(resetPredicateState())
-  } catch {
-    dispatch(notify(predicateDeleteFailed()))
-    dispatch(setDeletionStatus(RemoteDataState.Error))
-    dispatch(resetPredicateState())
-  }
+interface SetKeysByBucket {
+  type: 'SET_KEYS_BY_BUCKET'
+  payload: {keys: string[]}
 }
 
-export const executePreviewQuery = (query: string) => async (
-  dispatch,
-  getState: GetState
-) => {
-  dispatch(setPreviewStatus(RemoteDataState.Loading))
-  try {
-    const state = getState()
-    const orgID = getOrg(state).id
-
-    // TODO figure out how to do this better
-    // for some reason we can't use the time range variables
-    // for preview query, which means we can't use getAllVariables
-    // which means we have to drag around all this asAssignment
-    // garbage to be able to run a query instead of just being able
-    // to executeQuery as normal
-    const variableAssignments = getVariables(state)
-      .map(v => asAssignment(v))
-      .filter(v => !!v)
-    const windowVars = getWindowVars(query, variableAssignments)
-    const extern = buildVarsOption([...variableAssignments, ...windowVars])
-    const result = await runQuery(orgID, query, extern).promise
-
-    if (result.type === 'UNKNOWN_ERROR') {
-      throw new Error(result.message)
-    }
-
-    if (result.type === 'RATE_LIMIT_ERROR') {
-      dispatch(notify(rateLimitReached(result.retryAfter)))
-
-      throw new Error(result.message)
-    }
-
-    if (result.didTruncate) {
-      dispatch(notify(resultTooLarge(result.bytesRead)))
-    }
-
-    // TODO: this is just here for validation. since we are already eating
-    // the cost of parsing the results, we should store the output instead
-    // of the raw input
-    fromFlux(result.csv)
-
-    const files = [result.csv]
-    dispatch(setFiles(files))
-  } catch (e) {
-    if (e.name === 'CancellationError') {
-      return
-    }
-
-    console.error(e)
-    dispatch(setPreviewStatus(RemoteDataState.Error))
-  }
-}
-
-export const setBucketAndKeys = (bucketName: string) => async (
-  dispatch: Dispatch<Action>,
-  getState: GetState
-) => {
-  const orgID = getOrg(getState()).id
-
-  try {
-    const query = `import "influxdata/influxdb/v1"
-    v1.tagKeys(bucket: "${bucketName}")
-    |> filter(fn: (r) => r._value != "_stop" and r._value != "_start")`
-    const keys = await extractBoxedCol(runQuery(orgID, query), '_value').promise
-    keys.sort()
-    dispatch(setBucketName(bucketName))
-    dispatch(setKeys(keys))
-  } catch {
-    dispatch(notify(setFilterKeyFailed()))
-    dispatch(setDeletionStatus(RemoteDataState.Error))
-  }
-}
-
-export const setValuesByKey = (bucketName: string, keyName: string) => async (
-  dispatch: Dispatch<Action>,
-  getState: GetState
-) => {
-  const orgID = getOrg(getState()).id
-
-  try {
-    const query = `import "influxdata/influxdb/v1" v1.tagValues(bucket: "${bucketName}", tag: "${keyName}")`
-    const values = await extractBoxedCol(runQuery(orgID, query), '_value')
-      .promise
-    values.sort()
-    dispatch(setValues(values))
-  } catch {
-    dispatch(notify(setFilterValueFailed()))
-    dispatch(setDeletionStatus(RemoteDataState.Error))
-  }
-}
+export const setKeys = (keys: string[]): SetKeysByBucket => ({
+  type: 'SET_KEYS_BY_BUCKET',
+  payload: {keys},
+})

--- a/src/shared/actions/predicatesThunks.test.ts
+++ b/src/shared/actions/predicatesThunks.test.ts
@@ -13,7 +13,7 @@ import {predicateDeleteSucceeded} from 'src/shared/copy/notifications'
 import {pastHourTimeRange} from 'src/shared/constants/timeRanges'
 
 // Actions
-import {deleteWithPredicate} from 'src/shared/actions/predicates'
+import {deleteWithPredicate} from 'src/shared/actions/predicatesThunks'
 import {convertTimeRangeToCustom} from '../utils/duration'
 
 const mockGetState = jest.fn(_ => {

--- a/src/shared/actions/predicatesThunks.ts
+++ b/src/shared/actions/predicatesThunks.ts
@@ -36,7 +36,7 @@ import {
   rateLimitReached,
   resultTooLarge,
   setFilterKeyFailed,
-  setFilterValueFailed
+  setFilterValueFailed,
 } from 'src/shared/copy/notifications'
 
 // types

--- a/src/shared/actions/predicatesThunks.ts
+++ b/src/shared/actions/predicatesThunks.ts
@@ -1,0 +1,180 @@
+// libraries
+import {Dispatch} from 'react'
+import moment from 'moment'
+
+// api
+import {postDelete} from 'src/client'
+import {runQuery} from 'src/shared/apis/query'
+import {extractBoxedCol} from 'src/timeMachine/apis/queryBuilder'
+
+// utils
+import fromFlux from 'src/shared/utils/fromFlux'
+
+// actions
+import {
+  Action,
+  resetPredicateState,
+  setBucketName,
+  setFiles,
+  setDeletionStatus,
+  setKeys,
+  setPreviewStatus,
+  setValues,
+} from 'src/shared/actions/predicates'
+import {notify} from 'src/shared/actions/notifications'
+
+// selectors
+import {getOrg} from 'src/organizations/selectors'
+import {getVariables, asAssignment} from 'src/variables/selectors'
+import {buildVarsOption} from 'src/variables/utils/buildVarsOption'
+import {getWindowVars} from 'src/variables/utils/getWindowVars'
+
+// constants
+import {
+  predicateDeleteFailed,
+  predicateDeleteSucceeded,
+  rateLimitReached,
+  resultTooLarge,
+  setFilterKeyFailed,
+  setFilterValueFailed
+} from 'src/shared/copy/notifications'
+
+// types
+import {Filter, GetState, RemoteDataState} from 'src/types'
+
+const formatFilters = (filters: Filter[]) =>
+  filters.map(f => `${f.key} ${f.equality} ${f.value}`).join(' AND ')
+
+export const deleteWithPredicate = () => async (
+  dispatch: Dispatch<Action>,
+  getState: GetState
+) => {
+  dispatch(setDeletionStatus(RemoteDataState.Loading))
+
+  const {
+    predicates: {timeRange, bucketName, filters},
+  } = getState()
+  const orgID = getOrg(getState()).id
+
+  const data = {
+    start: moment(timeRange.lower).toISOString(),
+    stop: moment(timeRange.upper).toISOString(),
+  }
+
+  if (filters.length > 0) {
+    data['predicate'] = formatFilters(filters)
+  }
+
+  try {
+    const resp = await postDelete({
+      data,
+      query: {
+        orgID,
+        bucket: bucketName,
+      },
+    })
+
+    if (resp.status !== 204) {
+      throw new Error(resp.data.message)
+    }
+
+    dispatch(setDeletionStatus(RemoteDataState.Done))
+    dispatch(notify(predicateDeleteSucceeded()))
+    dispatch(resetPredicateState())
+  } catch {
+    dispatch(notify(predicateDeleteFailed()))
+    dispatch(setDeletionStatus(RemoteDataState.Error))
+    dispatch(resetPredicateState())
+  }
+}
+
+export const executePreviewQuery = (query: string) => async (
+  dispatch,
+  getState: GetState
+) => {
+  dispatch(setPreviewStatus(RemoteDataState.Loading))
+  try {
+    const state = getState()
+    const orgID = getOrg(state).id
+
+    // TODO figure out how to do this better
+    // for some reason we can't use the time range variables
+    // for preview query, which means we can't use getAllVariables
+    // which means we have to drag around all this asAssignment
+    // garbage to be able to run a query instead of just being able
+    // to executeQuery as normal
+    const variableAssignments = getVariables(state)
+      .map(v => asAssignment(v))
+      .filter(v => !!v)
+    const windowVars = getWindowVars(query, variableAssignments)
+    const extern = buildVarsOption([...variableAssignments, ...windowVars])
+    const result = await runQuery(orgID, query, extern).promise
+
+    if (result.type === 'UNKNOWN_ERROR') {
+      throw new Error(result.message)
+    }
+
+    if (result.type === 'RATE_LIMIT_ERROR') {
+      dispatch(notify(rateLimitReached(result.retryAfter)))
+
+      throw new Error(result.message)
+    }
+
+    if (result.didTruncate) {
+      dispatch(notify(resultTooLarge(result.bytesRead)))
+    }
+
+    // TODO: this is just here for validation. since we are already eating
+    // the cost of parsing the results, we should store the output instead
+    // of the raw input
+    fromFlux(result.csv)
+
+    const files = [result.csv]
+    dispatch(setFiles(files))
+  } catch (e) {
+    if (e.name === 'CancellationError') {
+      return
+    }
+
+    console.error(e)
+    dispatch(setPreviewStatus(RemoteDataState.Error))
+  }
+}
+
+export const setBucketAndKeys = (bucketName: string) => async (
+  dispatch: Dispatch<Action>,
+  getState: GetState
+) => {
+  const orgID = getOrg(getState()).id
+
+  try {
+    const query = `import "influxdata/influxdb/v1"
+    v1.tagKeys(bucket: "${bucketName}")
+    |> filter(fn: (r) => r._value != "_stop" and r._value != "_start")`
+    const keys = await extractBoxedCol(runQuery(orgID, query), '_value').promise
+    keys.sort()
+    dispatch(setBucketName(bucketName))
+    dispatch(setKeys(keys))
+  } catch {
+    dispatch(notify(setFilterKeyFailed()))
+    dispatch(setDeletionStatus(RemoteDataState.Error))
+  }
+}
+
+export const setValuesByKey = (bucketName: string, keyName: string) => async (
+  dispatch: Dispatch<Action>,
+  getState: GetState
+) => {
+  const orgID = getOrg(getState()).id
+
+  try {
+    const query = `import "influxdata/influxdb/v1" v1.tagValues(bucket: "${bucketName}", tag: "${keyName}")`
+    const values = await extractBoxedCol(runQuery(orgID, query), '_value')
+      .promise
+    values.sort()
+    dispatch(setValues(values))
+  } catch {
+    dispatch(notify(setFilterValueFailed()))
+    dispatch(setDeletionStatus(RemoteDataState.Error))
+  }
+}

--- a/src/shared/components/DeleteDataForm/DeleteDataForm.tsx
+++ b/src/shared/components/DeleteDataForm/DeleteDataForm.tsx
@@ -34,14 +34,17 @@ import {getOrg} from 'src/organizations/selectors'
 // Actions
 import {
   deleteFilter,
-  deleteWithPredicate,
-  executePreviewQuery,
   resetFilters,
   setFilter,
   setIsSerious,
-  setBucketAndKeys,
   setTimeRange,
 } from 'src/shared/actions/predicates'
+
+import {
+  setBucketAndKeys,
+  deleteWithPredicate,
+  executePreviewQuery,
+} from 'src/shared/actions/predicatesThunks'
 
 interface OwnProps {
   handleDismiss: () => void

--- a/src/shared/components/DeleteDataForm/FilterRow.tsx
+++ b/src/shared/components/DeleteDataForm/FilterRow.tsx
@@ -16,7 +16,7 @@ import SearchableDropdown from 'src/shared/components/SearchableDropdown'
 import {Filter} from 'src/types'
 
 // Actions
-import {setValuesByKey} from 'src/shared/actions/predicates'
+import {setValuesByKey} from 'src/shared/actions/predicatesThunks'
 
 interface OwnProps {
   bucket: string

--- a/src/shared/components/DeleteDataOverlay.tsx
+++ b/src/shared/components/DeleteDataOverlay.tsx
@@ -8,10 +8,8 @@ import {Overlay, SpinnerContainer, TechnoSpinner} from '@influxdata/clockface'
 import DeleteDataForm from 'src/shared/components/DeleteDataForm/DeleteDataForm'
 
 // Actions
-import {
-  resetPredicateState,
-  setBucketAndKeys,
-} from 'src/shared/actions/predicates'
+import {resetPredicateState} from 'src/shared/actions/predicates'
+import {setBucketAndKeys} from 'src/shared/actions/predicatesThunks'
 
 // Types
 import {Bucket, AppState, RemoteDataState, ResourceType} from 'src/types'


### PR DESCRIPTION
closes #131
closes #138

Makes `predicates` action creators pure by moving the functions with side effects into `predicatesThunks`

#### Old dependency graph
![configure_store_new](https://user-images.githubusercontent.com/146112/94945855-2788a380-0490-11eb-8fcb-0291c1bb6f74.png)

#### New (and final) dependency graph - note the lack of `cofingureStore.ts`
![new](https://user-images.githubusercontent.com/146112/94964821-36cb1980-04af-11eb-8687-3922301f313c.png)

```sh
madge --webpack-config webpack.common.ts src/store/configureStore.ts --image graph.svg --circular
```

#### How does this break dependencies?
- `configureStore` builds the empty store based off the initial state the reducers describe
- to do this, `configureStore` imports all the reducers.
- reducers pull in the action creator functions and the name of the actions
  - if the actions have outside dependencies (say on `event`, which indirectly depends on `featureFlag`), those are imported and executed before `configureStore` is executed
- by moving the side effects (and more importantly, their dependencies) outside the dependency chain of reducers and action creators,  circular dependencies that flow back to `configureStore` are removed.