### PR TITLE
chore(queryCache): remove dashboard queryCache from the UI

### DIFF
--- a/src/dashboards/components/DashboardHeader.tsx
+++ b/src/dashboards/components/DashboardHeader.tsx
@@ -28,7 +28,6 @@ import {
 // Utils
 import {event} from 'src/cloud/utils/reporting'
 import {resetQueryCache} from 'src/shared/apis/queryCache'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Selectors
 import {getTimeRange} from 'src/dashboards/selectors'
@@ -106,9 +105,7 @@ const DashboardHeader: FC<Props> = ({
   }
 
   const handleChooseTimeRange = (timeRange: TimeRange) => {
-    if (isFlagEnabled('queryCacheForDashboards')) {
-      resetQueryCache()
-    }
+    resetQueryCache()
     setDashboardTimeRange(dashboard.id, timeRange)
     updateQueryParams({
       lower: timeRange.lower,
@@ -132,9 +129,7 @@ const DashboardHeader: FC<Props> = ({
 
   const resetCacheAndRefresh = (): void => {
     // We want to invalidate the existing cache when a user manually refreshes the dashboard
-    if (isFlagEnabled('queryCacheForDashboards')) {
-      resetQueryCache()
-    }
+    resetQueryCache()
     onManualRefresh()
   }
 

--- a/src/dashboards/components/DashboardPage.tsx
+++ b/src/dashboards/components/DashboardPage.tsx
@@ -21,7 +21,6 @@ import {AddNoteOverlay, EditNoteOverlay} from 'src/overlays/components'
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 import {event} from 'src/cloud/utils/reporting'
 import {resetQueryCache} from 'src/shared/apis/queryCache'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Selectors
 import {getByID} from 'src/resources/selectors'
@@ -49,17 +48,13 @@ const dashRoute = `/${ORGS}/${ORG_ID}/${DASHBOARDS}/${DASHBOARD_ID}`
 @ErrorHandling
 class DashboardPage extends Component<Props> {
   public componentDidMount() {
-    if (isFlagEnabled('queryCacheForDashboards')) {
-      resetQueryCache()
-    }
+    resetQueryCache()
 
     this.emitRenderCycleEvent()
   }
 
   public componentWillUnmount() {
-    if (isFlagEnabled('queryCacheForDashboards')) {
-      resetQueryCache()
-    }
+    resetQueryCache()
   }
 
   public render() {

--- a/src/shared/components/TimeSeries.tsx
+++ b/src/shared/components/TimeSeries.tsx
@@ -242,10 +242,7 @@ class TimeSeries extends Component<Props, State> {
         const windowVars = getWindowVars(text, vars)
         const extern = buildVarsOption([...vars, ...windowVars])
         event('runQuery', {context: 'TimeSeries'})
-        if (
-          isCurrentPageDashboard &&
-          isFlagEnabled('queryCacheForDashboards')
-        ) {
+        if (isCurrentPageDashboard) {
           return onGetCachedResultsThunk(orgID, text)
         }
         const queryID = hashCode(text)

--- a/src/timeMachine/actions/queries.ts
+++ b/src/timeMachine/actions/queries.ts
@@ -232,9 +232,7 @@ export const executeQueries = (abortController?: AbortController) => async (
       const extern = buildVarsOption(variableAssignments)
 
       event('runQuery', {context: 'timeMachine'})
-      if (
-        isCurrentPageDashboard(state)
-      ) {
+      if (isCurrentPageDashboard(state)) {
         // reset any existing matching query in the cache
         resetQueryCacheByQuery(text)
         return getCachedResultsOrRunQuery(orgID, text, state)

--- a/src/timeMachine/actions/queries.ts
+++ b/src/timeMachine/actions/queries.ts
@@ -233,8 +233,7 @@ export const executeQueries = (abortController?: AbortController) => async (
 
       event('runQuery', {context: 'timeMachine'})
       if (
-        isCurrentPageDashboard(state) &&
-        isFlagEnabled('queryCacheForDashboards')
+        isCurrentPageDashboard(state)
       ) {
         // reset any existing matching query in the cache
         resetQueryCacheByQuery(text)

--- a/src/views/actions/thunks.ts
+++ b/src/views/actions/thunks.ts
@@ -1,6 +1,5 @@
 // Libraries
 import {normalize} from 'normalizr'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // APIs
 import {
@@ -127,24 +126,22 @@ export const getViewAndResultsForVEO = (
       })
     )
 
-    if (isFlagEnabled('queryCacheForDashboards')) {
-      const queries = view.properties.queries.filter(({text}) => !!text.trim())
-      if (!queries.length) {
-        dispatch(setQueryResults(RemoteDataState.Done, [], null))
-      }
-      const {id: orgID} = getOrg(state)
-      const pendingResults = queries.map(({text}) => {
-        return getCachedResultsOrRunQuery(orgID, text, state)
-      })
+    const queries = view.properties.queries.filter(({text}) => !!text.trim())
+    if (!queries.length) {
+      dispatch(setQueryResults(RemoteDataState.Done, [], null))
+    }
+    const {id: orgID} = getOrg(state)
+    const pendingResults = queries.map(({text}) => {
+      return getCachedResultsOrRunQuery(orgID, text, state)
+    })
 
-      // Wait for new queries to complete
-      const results = await Promise.all(pendingResults.map(r => r.promise))
-      const files = (results as RunQuerySuccessResult[]).map(r => r.csv)
+    // Wait for new queries to complete
+    const results = await Promise.all(pendingResults.map(r => r.promise))
+    const files = (results as RunQuerySuccessResult[]).map(r => r.csv)
 
-      if (files) {
-        dispatch(setQueryResults(RemoteDataState.Done, files, null, null))
-        return
-      }
+    if (files) {
+      dispatch(setQueryResults(RemoteDataState.Done, files, null, null))
+      return
     }
 
     dispatch(executeQueries())


### PR DESCRIPTION
The Dashboard Query Cache has been on for a few weeks without any reported issues. This is just some clean-up to remove the feature flag from the UI and establish this cache as the norm