### PR TITLE
feat(cancel-btn): cancel button can now cancel queries no matter how they are issued

### DIFF
--- a/src/flows/components/header/Submit.tsx
+++ b/src/flows/components/header/Submit.tsx
@@ -93,6 +93,7 @@ export const Submit: FC = () => {
       queryStatus={isLoading}
       onSubmit={submit}
       onNotify={fakeNotify}
+      queryID=""
     />
   )
 }

--- a/src/flows/context/query.tsx
+++ b/src/flows/context/query.tsx
@@ -13,6 +13,7 @@ import {fromFlux as parse} from '@influxdata/giraffe'
 import {event} from 'src/cloud/utils/reporting'
 import {FluxResult} from 'src/types/flows'
 import {PIPE_DEFINITIONS} from 'src/flows'
+import {generateHashedQueryID, setQueryByHashID} from 'src/timeMachine/actions/queries'
 
 interface Stage {
   text: string
@@ -106,9 +107,12 @@ export const QueryProvider: FC<Props> = ({children, variables, org}) => {
   const query = (text: string) => {
     const windowVars = getWindowVars(text, vars)
     const extern = buildVarsOption([...vars, ...windowVars])
+    const queryID = generateHashedQueryID(text, variables, org.id)
 
     event('runQuery', {context: 'flows'})
-    return runQuery(org.id, text, extern)
+    const result = runQuery(org.id, text, extern)
+    setQueryByHashID(queryID, result)
+    return result
       .promise.then(raw => {
         if (raw.type !== 'SUCCESS') {
           throw new Error(raw.message)

--- a/src/flows/context/query.tsx
+++ b/src/flows/context/query.tsx
@@ -13,7 +13,10 @@ import {fromFlux as parse} from '@influxdata/giraffe'
 import {event} from 'src/cloud/utils/reporting'
 import {FluxResult} from 'src/types/flows'
 import {PIPE_DEFINITIONS} from 'src/flows'
-import {generateHashedQueryID, setQueryByHashID} from 'src/timeMachine/actions/queries'
+import {
+  generateHashedQueryID,
+  setQueryByHashID,
+} from 'src/timeMachine/actions/queries'
 
 interface Stage {
   text: string
@@ -112,8 +115,8 @@ export const QueryProvider: FC<Props> = ({children, variables, org}) => {
     event('runQuery', {context: 'flows'})
     const result = runQuery(org.id, text, extern)
     setQueryByHashID(queryID, result)
-    return result
-      .promise.then(raw => {
+    return result.promise
+      .then(raw => {
         if (raw.type !== 'SUCCESS') {
           throw new Error(raw.message)
         }

--- a/src/flows/context/query.tsx
+++ b/src/flows/context/query.tsx
@@ -17,6 +17,7 @@ import {
   generateHashedQueryID,
   setQueryByHashID,
 } from 'src/timeMachine/actions/queries'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 interface Stage {
   text: string
@@ -114,7 +115,9 @@ export const QueryProvider: FC<Props> = ({children, variables, org}) => {
 
     event('runQuery', {context: 'flows'})
     const result = runQuery(org.id, text, extern)
-    setQueryByHashID(queryID, result)
+    if (isFlagEnabled('cancelQueryUiExpansion')) {
+      setQueryByHashID(queryID, result)
+    }
     return result.promise
       .then(raw => {
         if (raw.type !== 'SUCCESS') {

--- a/src/shared/apis/queryCache.ts
+++ b/src/shared/apis/queryCache.ts
@@ -19,7 +19,7 @@ import {WINDOW_PERIOD} from 'src/variables/constants'
 
 export const TIME_INVALIDATION = 1000 * 60 * 10 // 10 minutes
 
-const asSimplyKeyValueVariables = (vari: Variable) => {
+export const asSimplyKeyValueVariables = (vari: Variable) => {
   if (vari.arguments?.type === 'system') {
     return {[vari.name]: vari.arguments.values || []}
   }

--- a/src/timeMachine/actions/queries.ts
+++ b/src/timeMachine/actions/queries.ts
@@ -1,13 +1,9 @@
 // Libraries
 import {parse} from 'src/external/parser'
-import {get} from 'lodash'
+import {get, sortBy} from 'lodash'
 
 // API
-import {
-  runQuery,
-  RunQueryResult,
-  RunQuerySuccessResult,
-} from 'src/shared/apis/query'
+import {runQuery, RunQuerySuccessResult} from 'src/shared/apis/query'
 import {
   getCachedResultsOrRunQuery,
   resetQueryCacheByQuery,
@@ -42,6 +38,8 @@ import {
   isAggregateTypeError,
 } from 'src/utils/aggregateTypeErrors'
 import {event} from 'src/cloud/utils/reporting'
+import {asSimplyKeyValueVariables, hashCode} from 'src/shared/apis/queryCache'
+import {filterUnusedVarsBasedOnQuery} from 'src/shared/utils/filterUnusedVars'
 
 // Types
 import {CancelBox} from 'src/types/promises'
@@ -54,6 +52,7 @@ import {
   Bucket,
   QueryEditMode,
   BuilderTagsType,
+  Variable,
 } from 'src/types'
 
 // Selectors
@@ -91,7 +90,6 @@ export const setQueryResults = (
   },
 })
 
-let pendingResults: Array<CancelBox<RunQueryResult>> = []
 let pendingCheckStatuses: CancelBox<StatusRow[][]> = null
 
 export const getOrgIDFromBuckets = (
@@ -186,6 +184,76 @@ const isFromTag = (node: Node) => {
   )
 }
 
+export const generateHashedQueryID = (
+  query: string,
+  vars: Variable[],
+  orgID: string
+): string => {
+  const hashedQuery = `${hashCode(query)}`
+  const usedVars = filterUnusedVarsBasedOnQuery(vars, [query])
+  const variables = sortBy(usedVars, ['name'])
+  const simplifiedVariables = variables.map(v => asSimplyKeyValueVariables(v))
+  const stringifiedVars = JSON.stringify(simplifiedVariables)
+  // create the queryID based on the query & vars
+  const hashedVariables = `${hashCode(stringifiedVars)}`
+
+  return `${hashedQuery}_${hashedVariables}_${hashCode(orgID)}`
+}
+
+const queryReference = {}
+
+export const cancelQueryByHashID = (queryID: string): void => {
+  if (queryID in queryReference) {
+    queryReference[queryID].cancel()
+    delete queryReference[queryID]
+  }
+}
+
+const cancelQuerysByHashIDs = (queryIDs?: string[]): void => {
+  if (queryIDs.length > 0) {
+    queryIDs.forEach(queryID => cancelQueryByHashID(queryID))
+  }
+  Object.keys(queryReference).forEach((queryID: string) => {
+    cancelQueryByHashID(queryID)
+  })
+}
+
+export const cancelAllRunningQueries = (): void => {
+  cancelQuerysByHashIDs(Object.keys(queryReference))
+}
+
+export const setQueryByHashID = (queryID: string, result: any): void => {
+  queryReference[queryID] = {
+    cancel: result.cancel,
+    issuedAt: Date.now(),
+    promise: result.promise,
+    status: RemoteDataState.Loading,
+  }
+  result.promise
+    .then(() => {
+      queryReference[queryID].status = RemoteDataState.Done
+    })
+    .catch(error => {
+      if (error.name === 'CancellationError' || error.name === 'AbortError') {
+        queryReference[queryID].status = RemoteDataState.Done
+        return
+      }
+      queryReference[queryID].status = RemoteDataState.Error
+    })
+}
+
+export const getQueryStatusByID = (queryID: string): any => {
+  if (queryID in queryReference) {
+    return queryReference[queryID]
+  }
+  return {
+    cancel: new AbortController(),
+    issuedAt: Date.now(),
+    promise: Promise.resolve(),
+    status: RemoteDataState.NotStarted,
+  }
+}
+
 export const executeQueries = (abortController?: AbortController) => async (
   dispatch,
   getState: GetState
@@ -206,20 +274,23 @@ export const executeQueries = (abortController?: AbortController) => async (
   }
 
   try {
+    // Cancel pending queries before issuing new ones
+    cancelAllRunningQueries()
+
     dispatch(setQueryResults(RemoteDataState.Loading, [], null))
 
     await dispatch(hydrateVariables())
 
-    const variableAssignments = getAllVariables(state)
+    const allVariables = getAllVariables(state)
+
+    const variableAssignments = allVariables
       .map(v => asAssignment(v))
       .filter(v => !!v)
 
     const startTime = window.performance.now()
     const startDate = Date.now()
 
-    pendingResults.forEach(({cancel}) => cancel())
-
-    pendingResults = queries.map(({text}) => {
+    const pendingResults = queries.map(({text}) => {
       event('executeQueries query', {}, {query: text})
       const orgID = getOrgIDFromBuckets(text, allBuckets) || getOrg(state).id
 
@@ -232,12 +303,20 @@ export const executeQueries = (abortController?: AbortController) => async (
       const extern = buildVarsOption(variableAssignments)
 
       event('runQuery', {context: 'timeMachine'})
+
+      const queryID = generateHashedQueryID(text, allVariables, orgID)
       if (isCurrentPageDashboard(state)) {
         // reset any existing matching query in the cache
         resetQueryCacheByQuery(text)
-        return getCachedResultsOrRunQuery(orgID, text, state)
+        const result = getCachedResultsOrRunQuery(orgID, text, state)
+        setQueryByHashID(queryID, result)
+
+        return result
       }
-      return runQuery(orgID, text, extern, abortController)
+      const result = runQuery(orgID, text, extern, abortController)
+      setQueryByHashID(queryID, result)
+
+      return result
     })
     const results = await Promise.all(pendingResults.map(r => r.promise))
 

--- a/src/timeMachine/components/SubmitQueryButton.tsx
+++ b/src/timeMachine/components/SubmitQueryButton.tsx
@@ -77,6 +77,10 @@ class SubmitQueryButton extends PureComponent<Props> {
     }
   }
 
+  componentWillUnmount() {
+    cancelAllRunningQueries()
+  }
+
   public render() {
     const {text, queryStatus, icon, testID, className} = this.props
     if (queryStatus === RemoteDataState.Loading && this.state.timer) {


### PR DESCRIPTION
Closes https://github.com/influxdata/idpe/issues/8328

### Problem

The cancel query button was previously being toggled onClick, making it not cancellable if a query is triggered some other way

### Solution

Created a cache to store queryIDs and abortControllers that can be referenced by the cancel button.

![cancel-btn](https://user-images.githubusercontent.com/19984220/95391270-a6744680-08ab-11eb-97c8-b7e2595c523b.gif)
