### PR TITLE
fix(flow-deletion-issue): moved the current flow context to the list

### DIFF
--- a/src/flows/components/Flow.tsx
+++ b/src/flows/components/Flow.tsx
@@ -5,13 +5,14 @@ import {useParams} from 'react-router-dom'
 // Components
 import {ResultsProvider} from 'src/flows/context/results'
 import {RefProvider} from 'src/flows/context/refs'
-import CurrentFlowProvider, {FlowContext} from 'src/flows/context/flow.current'
+import CurrentFlowProvider from 'src/flows/context/flow.current'
+import {FlowListContext} from 'src/flows/context/flow.list'
 import {ScrollProvider} from 'src/flows/context/scroll'
 import FlowPage from 'src/flows/components/FlowPage'
 
 const FlowFromRoute = () => {
   const {id} = useParams()
-  const {change} = useContext(FlowContext)
+  const {change} = useContext(FlowListContext)
 
   useEffect(() => {
     change(id)

--- a/src/flows/context/flow.current.tsx
+++ b/src/flows/context/flow.current.tsx
@@ -1,20 +1,15 @@
-import React, {FC, useContext, useEffect, useCallback, useMemo} from 'react'
-import createPersistedState from 'use-persisted-state'
+import React, {FC, useContext, useCallback, useMemo} from 'react'
 import {Flow, PipeData} from 'src/types/flows'
 import {FlowListContext, FlowListProvider} from 'src/flows/context/flow.list'
 import {v4 as UUID} from 'uuid'
 import {RemoteDataState} from 'src/types'
 
-const useFlowCurrentState = createPersistedState('current-flow')
-
 export interface FlowContextType {
   id: string | null
   name: string
   flow: Flow | null
-  change: (id: string) => void
   add: (data: Partial<PipeData>, index?: number) => string
   update: (flow: Partial<Flow>) => void
-  remove: () => void
 }
 
 export const DEFAULT_CONTEXT: FlowContextType = {
@@ -22,9 +17,7 @@ export const DEFAULT_CONTEXT: FlowContextType = {
   name: 'Name this Flow',
   flow: null,
   add: () => '',
-  change: () => {},
   update: () => {},
-  remove: () => {},
 }
 
 export const FlowContext = React.createContext<FlowContextType>(DEFAULT_CONTEXT)
@@ -53,19 +46,7 @@ const getHumanReadableName = (type: string): string => {
 }
 
 export const FlowProvider: FC = ({children}) => {
-  const [currentID, setCurrentID] = useFlowCurrentState(null)
-  const {flows, add, update, remove} = useContext(FlowListContext)
-
-  const change = useCallback(
-    (id: string) => {
-      if (!flows || !flows.hasOwnProperty(id)) {
-        throw new Error('Flow does note exist')
-      }
-
-      setCurrentID(id)
-    },
-    [currentID]
-  )
+  const {flows, update, currentID} = useContext(FlowListContext)
 
   const updateCurrent = useCallback(
     (flow: Flow) => {
@@ -76,10 +57,6 @@ export const FlowProvider: FC = ({children}) => {
     },
     [currentID]
   )
-
-  const removeCurrent = useCallback(() => {
-    remove(currentID)
-  }, [currentID])
 
   const addPipe = (initial: PipeData, index?: number) => {
     const id = UUID()
@@ -98,14 +75,6 @@ export const FlowProvider: FC = ({children}) => {
     return id
   }
 
-  useEffect(() => {
-    if (!currentID) {
-      const id = add()
-      setCurrentID(id)
-      return
-    }
-  }, [currentID])
-
   return useMemo(() => {
     if (!flows || !flows.hasOwnProperty(currentID)) {
       return null
@@ -119,8 +88,6 @@ export const FlowProvider: FC = ({children}) => {
           flow: flows[currentID],
           add: addPipe,
           update: updateCurrent,
-          remove: removeCurrent,
-          change,
         }}
       >
         {children}


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/19709

### Solution

As outlined in the issue, deleting a flow from the flows list was not removing the ID from the persisted flow state. This was resolved by moving the current-flow state into the flow list and moving some things around

![flows-bug-fix](https://user-images.githubusercontent.com/19984220/95521624-d3ddf480-097e-11eb-8c5a-30ec235df127.gif)
