### PR TITLE
chore(remove-fromFluxParseReponse): removed parser feature flag

### DIFF
--- a/src/external/monaco.flux.server.ts
+++ b/src/external/monaco.flux.server.ts
@@ -22,7 +22,6 @@ import {AppState, LocalStorage} from 'src/types'
 import {getAllVariables, asAssignment} from 'src/variables/selectors'
 import {buildVarsOption} from 'src/variables/utils/buildVarsOption'
 import {runQuery} from 'src/shared/apis/query'
-import {parseResponse as parse} from 'src/shared/parsing/flux/response'
 import {getOrg} from 'src/organizations/selectors'
 import {fetchAllBuckets} from 'src/buckets/actions/thunks'
 import {event} from 'src/cloud/utils/reporting'
@@ -43,7 +42,6 @@ import {
   TextEdit,
 } from 'monaco-languageclient/lib/services'
 import {Server} from '@influxdata/flux-lsp-browser'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 type BucketCallback = () => Promise<string[]>
 type MeasurementsCallback = (bucket: string) => Promise<string[]>
@@ -59,12 +57,8 @@ import {format_from_js_file} from '@influxdata/flux'
 
 // NOTE: parses table then select measurements from the _value column
 const parseQueryResponse = response => {
-  if (isFlagEnabled('fromFluxParseResponse')) {
-    const {table} = fromFlux(response.csv)
-    return table.getColumn('_value', 'string') || []
-  }
-  const data = (parse(response.csv) || [{data: [{}]}])[0].data
-  return data.slice(1).map(r => r[3])
+  const {table} = fromFlux(response.csv)
+  return table.getColumn('_value', 'string') || []
 }
 
 const queryMeasurements = async (orgID, bucket) => {

--- a/src/timeMachine/apis/queryBuilder.ts
+++ b/src/timeMachine/apis/queryBuilder.ts
@@ -1,17 +1,14 @@
 // Libraries
-import {get} from 'lodash'
 import {fromFlux} from '@influxdata/giraffe'
 
 // APIs
 import {runQuery, RunQueryResult} from 'src/shared/apis/query'
-import {parseResponse} from 'src/shared/parsing/flux/response'
 
 // Utils
 import {getTimeRangeVars} from 'src/variables/utils/getTimeRangeVars'
 import {formatExpression} from 'src/variables/utils/formatExpression'
 import {tagToFlux} from 'src/timeMachine/utils/queryBuilder'
 import {event} from 'src/cloud/utils/reporting'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Types
 import {TimeRange, BuilderConfig} from 'src/types'
@@ -137,30 +134,8 @@ export function extractBoxedCol(
 }
 
 export function extractCol(csv: string, colName: string): string[] {
-  if (isFlagEnabled('fromFluxParseResponse')) {
-    const {table} = fromFlux(csv)
-    return table.getColumn(colName, 'string') || []
-  }
-  const tables = parseResponse(csv)
-  const data = get(tables, '0.data', [])
-
-  if (!data.length) {
-    return []
-  }
-
-  const colIndex = data[0].findIndex(d => d === colName)
-
-  if (colIndex === -1) {
-    throw new Error(`could not find column "${colName}" in response`)
-  }
-
-  const colValues: string[] = []
-
-  for (let i = 1; i < data.length; i++) {
-    colValues.push(data[i][colIndex])
-  }
-
-  return colValues
+  const {table} = fromFlux(csv)
+  return table.getColumn(colName, 'string') || []
 }
 
 export function formatTagFilterPredicate(


### PR DESCRIPTION
This PR is part of a series of PRs aim to reduce the number of parsers in use in the UI. In particular, this PR aims to remove a parser that has been in use on tools and in production behind a feature flag for the past week without raising any red flags