### PR TITLE
fix: redux state clear after logout

### DIFF
--- a/src/Logout.tsx
+++ b/src/Logout.tsx
@@ -33,6 +33,7 @@ const Logout: FC<Props> = ({history}) => {
       }
     }
     dispatch(reset())
+    dispatch({type: 'USER_LOGGED_OUT'})
     handleSignOut()
   }, [dispatch, history])
 

--- a/src/store/configureStore.ts
+++ b/src/store/configureStore.ts
@@ -65,8 +65,12 @@ type ReducerState = Pick<AppState, Exclude<keyof AppState, 'timeRange'>>
 
 import {history} from 'src/store/history'
 
-export const rootReducer = (history: History) =>
-  combineReducers<ReducerState>({
+export const rootReducer = (history: History) => (state, action) => {
+  if (action.type === 'USER_LOGGED_OUT') {
+    state = undefined
+  }
+
+  return combineReducers<ReducerState>({
     router: connectRouter(history),
     ...sharedReducers,
     autoRefresh: autoRefreshReducer,
@@ -119,7 +123,8 @@ export const rootReducer = (history: History) =>
     userSettings: userSettingsReducer,
     variableEditor: variableEditorReducer,
     VERSION: () => '',
-  })
+  })(state, action)
+}
 
 const composeEnhancers =
   (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose


### PR DESCRIPTION
closes https://github.com/influxdata/influxdb/issues/19648

this fixes influxdb/19648 where the tokens persist to the next user after logout, this clears the redux store on logout in both cloud and non cloud cases to the tokens and other data will not continue to be stored after logout. 