### PR TITLE
fix(parsing-NaN): fixed NaN time conversion bug

### DIFF
--- a/src/shared/parsing/flux/response.test.ts
+++ b/src/shared/parsing/flux/response.test.ts
@@ -114,7 +114,7 @@ describe('parseResponseWithFromFlux', () => {
 ,,0,gauge,kube_pod_container_resource_requests_cpu_cores,2020-10-16T15:41:21.798083141Z,2020-10-16T16:41:21.798083141Z,,0.1
 `.trim()
 
-    const expectedData = [
+    const expected = [
       [
         '',
         'result',
@@ -149,11 +149,6 @@ describe('parseResponseWithFromFlux', () => {
         '0.1',
       ],
     ]
-
-    const expected = {
-      data: expectedData,
-      maxColumnCount: 16,
-    }
 
     const result = parseResponseWithFromFlux(CSV)
     expect(result[0].data).toEqual(expected)

--- a/src/shared/parsing/flux/response.test.ts
+++ b/src/shared/parsing/flux/response.test.ts
@@ -104,6 +104,60 @@ describe('parseResponseWithFromFlux', () => {
     const result = parseResponseWithFromFlux(MULTI_SCHEMA_RESPONSE)
     expect(result).toHaveLength(4)
   })
+  test('should not convert NaN timestamps', () => {
+    const CSV = `
+#group,false,false,false,false,false,false,false,false
+#datatype,string,long,string,string,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double
+#default,_result,,,,,,,,,,,,,,
+,result,table,_field_key2,_measurement_key2,_start_key2,_stop_key2,_time,_value_key2
+,,0,gauge,kube_pod_container_resource_requests_cpu_cores,2020-10-16T15:41:21.798083141Z,2020-10-16T16:41:21.798083141Z,2020-10-16T15:41:57Z,0.1
+,,0,gauge,kube_pod_container_resource_requests_cpu_cores,2020-10-16T15:41:21.798083141Z,2020-10-16T16:41:21.798083141Z,,0.1
+`.trim()
+
+    const expectedData = [
+      [
+        '',
+        'result',
+        'table',
+        '_field_key2',
+        '_measurement_key2',
+        '_start_key2',
+        '_stop_key2',
+        '_time',
+        '_value_key2',
+      ],
+      [
+        '',
+        '',
+        '0',
+        'gauge',
+        'kube_pod_container_resource_requests_cpu_cores',
+        '2020-10-16T15:41:21.798Z',
+        '2020-10-16T16:41:21.798Z',
+        '2020-10-16T15:41:57.000Z',
+        '0.1',
+      ],
+      [
+        '',
+        '',
+        '0',
+        'gauge',
+        'kube_pod_container_resource_requests_cpu_cores',
+        '2020-10-16T15:41:21.798Z',
+        '2020-10-16T16:41:21.798Z',
+        'NaN',
+        '0.1',
+      ],
+    ]
+
+    const expected = {
+      data: expectedData,
+      maxColumnCount: 16,
+    }
+
+    const result = parseResponseWithFromFlux(CSV)
+    expect(result[0].data).toEqual(expected)
+  })
   test('parseResponseWithFromFlux can properly handle nested error objects in CSVs', () => {
     const result = parseResponseWithFromFlux(CSV_WITH_OBJECTS)
     const expected = [

--- a/src/shared/parsing/flux/response.ts
+++ b/src/shared/parsing/flux/response.ts
@@ -203,7 +203,8 @@ export const parseResponseWithFromFlux = (response: string): FluxTable[] => {
     currentValue = columnValues[valueIndex]
     if (
       originalType === 'dateTime:RFC3339' &&
-      typeof currentValue === 'number'
+      typeof currentValue === 'number' &&
+      !isNaN(currentValue)
     ) {
       currentValue = new Date(currentValue).toISOString()
     }
@@ -267,7 +268,8 @@ export const parseResponseWithFromFlux = (response: string): FluxTable[] => {
         currentValue = columnValues[i]
         if (
           originalType === 'dateTime:RFC3339' &&
-          typeof currentValue === 'number'
+          typeof currentValue === 'number' &&
+          !isNaN(currentValue)
         ) {
           currentValue = new Date(currentValue).toISOString()
         }
@@ -314,7 +316,8 @@ export const parseResponseWithFromFlux = (response: string): FluxTable[] => {
 
       if (
         rowOriginalType === 'dateTime:RFC3339' &&
-        typeof columnData === 'number'
+        typeof columnData === 'number' &&
+        !isNaN(columnData)
       ) {
         columnData = new Date(columnData).toISOString()
       }

--- a/src/timeMachine/utils/rawFluxDataTable.test.ts
+++ b/src/timeMachine/utils/rawFluxDataTable.test.ts
@@ -192,6 +192,83 @@ describe('parseFilesWithFromFlux', () => {
     const result = parseFilesWithFromFlux([CSV])
     expect(result).toEqual(expected)
   })
+  test('should not convert NaN timestamps', () => {
+    const CSV = `
+#group,false,false,false,false,false,false,false,false
+#datatype,string,long,string,string,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double
+#default,_result,,,,,,,,,,,,,,
+,result,table,_field_key2,_measurement_key2,_start_key2,_stop_key2,_time,_value_key2
+,,0,gauge,kube_pod_container_resource_requests_cpu_cores,2020-10-16T15:41:21.798083141Z,2020-10-16T16:41:21.798083141Z,2020-10-16T15:41:57Z,0.1
+,,0,gauge,kube_pod_container_resource_requests_cpu_cores,2020-10-16T15:41:21.798083141Z,2020-10-16T16:41:21.798083141Z,,0.1
+`.trim()
+
+    const expectedData = [
+      [
+        '#group',
+        'false',
+        'false',
+        'false',
+        'false',
+        'false',
+        'false',
+        'false',
+        'false',
+      ],
+      [
+        '#datatype',
+        'string',
+        'long',
+        'string',
+        'string',
+        'dateTime:RFC3339',
+        'dateTime:RFC3339',
+        'dateTime:RFC3339',
+        'double',
+      ],
+      ['#default', '_result'],
+      [
+        '',
+        'result',
+        'table',
+        '_field_key2',
+        '_measurement_key2',
+        '_start_key2',
+        '_stop_key2',
+        '_time',
+        '_value_key2',
+      ],
+      [
+        '',
+        '',
+        '0',
+        'gauge',
+        'kube_pod_container_resource_requests_cpu_cores',
+        '2020-10-16T15:41:21.798Z',
+        '2020-10-16T16:41:21.798Z',
+        '2020-10-16T15:41:57.000Z',
+        '0.1',
+      ],
+      [
+        '',
+        '',
+        '0',
+        'gauge',
+        'kube_pod_container_resource_requests_cpu_cores',
+        '2020-10-16T15:41:21.798Z',
+        '2020-10-16T16:41:21.798Z',
+        'NaN',
+        '0.1',
+      ],
+    ]
+
+    const expected = {
+      data: expectedData,
+      maxColumnCount: 9,
+    }
+
+    const result = parseFilesWithFromFlux([CSV])
+    expect(result).toEqual(expected)
+  })
   test('splits the csv chunks based on results', () => {
     const CSV = `
 #group,false,false,false,false

--- a/src/timeMachine/utils/rawFluxDataTable.ts
+++ b/src/timeMachine/utils/rawFluxDataTable.ts
@@ -105,13 +105,11 @@ export const fromFluxTableTransformer = (
       rowType = table.getColumnType(column)
       originalType = table.getOriginalColumnType(column)
       columnData = table.getColumn(column, rowType)[i]
-      console.log('columnDataOutside: ', columnData)
       if (
         originalType === 'dateTime:RFC3339' &&
-        typeof columnData === 'number'
-        && !isNaN(columnData)
+        typeof columnData === 'number' &&
+        !isNaN(columnData)
       ) {
-        console.log('columnData: ', columnData)
         columnData = new Date(columnData).toISOString()
       }
       if (column === 'result') {

--- a/src/timeMachine/utils/rawFluxDataTable.ts
+++ b/src/timeMachine/utils/rawFluxDataTable.ts
@@ -105,10 +105,13 @@ export const fromFluxTableTransformer = (
       rowType = table.getColumnType(column)
       originalType = table.getOriginalColumnType(column)
       columnData = table.getColumn(column, rowType)[i]
+      console.log('columnDataOutside: ', columnData)
       if (
         originalType === 'dateTime:RFC3339' &&
         typeof columnData === 'number'
+        && !isNaN(columnData)
       ) {
+        console.log('columnData: ', columnData)
         columnData = new Date(columnData).toISOString()
       }
       if (column === 'result') {


### PR DESCRIPTION
Closes https://github.com/influxdata/idpe/issues/8927

### Problem

NaN is still a `typeof === number` so parsing a NaN was causing the parser to crash.

### Solution

Make sure that the value is also not `NaN` 