### PR TITLE
feat(export-to): allow queries to be exported as tasks from flows

### DIFF
--- a/src/flows/components/ExportTaskOverlay/CreateTaskBody.tsx
+++ b/src/flows/components/ExportTaskOverlay/CreateTaskBody.tsx
@@ -1,0 +1,70 @@
+import React, {ChangeEvent, FC, useContext} from 'react'
+import {
+  Columns,
+  ComponentStatus,
+  Form,
+  Grid,
+  Input,
+  InputType,
+} from '@influxdata/clockface'
+import QueryTextPreview from 'src/flows/components/ExportTaskOverlay/QueryTextPreview'
+import {OverlayContext} from 'src/flows/context/overlay'
+
+type Props = {
+  formattedQueryText: string
+}
+
+const CreateTaskBody: FC<Props> = ({formattedQueryText}) => {
+  const {
+    interval,
+    handleSetEveryInterval,
+    handleSetTaskName,
+    hasError,
+    taskName,
+  } = useContext(OverlayContext)
+
+  return (
+    <>
+      <Grid.Column widthXS={Columns.Nine}>
+        <Form.Element
+          label="Name"
+          errorMessage={hasError && 'This field cannot be empty'}
+        >
+          <Input
+            name="name"
+            placeholder="Name your task"
+            onChange={(event: ChangeEvent<HTMLInputElement>) =>
+              handleSetTaskName(event.target.value)
+            }
+            value={taskName}
+            testID="task-form-name"
+            status={hasError ? ComponentStatus.Error : ComponentStatus.Default}
+          />
+        </Form.Element>
+      </Grid.Column>
+      <Grid.Column widthXS={Columns.Three}>
+        <Form.Element
+          label="Run Every"
+          errorMessage={hasError && 'Invalid Time'}
+        >
+          <Input
+            name="schedule"
+            type={InputType.Text}
+            placeholder="3h30s"
+            value={interval}
+            onChange={(event: ChangeEvent<HTMLInputElement>) =>
+              handleSetEveryInterval(event.target.value)
+            }
+            testID="task-form-schedule-input"
+            status={hasError ? ComponentStatus.Error : ComponentStatus.Default}
+          />
+        </Form.Element>
+      </Grid.Column>
+      <Grid.Column>
+        <QueryTextPreview formattedQueryText={formattedQueryText} />
+      </Grid.Column>
+    </>
+  )
+}
+
+export default CreateTaskBody

--- a/src/flows/components/ExportTaskOverlay/ExportTaskButtons.tsx
+++ b/src/flows/components/ExportTaskOverlay/ExportTaskButtons.tsx
@@ -1,0 +1,35 @@
+import React, {FC} from 'react'
+import {
+  Button,
+  ButtonType,
+  ComponentColor,
+  ComponentStatus,
+  Form,
+} from '@influxdata/clockface'
+
+type Props = {
+  canSubmit: () => boolean
+  onDismiss: () => void
+  onSubmit: () => void
+}
+
+const ExportTaskButtons: FC<Props> = ({canSubmit, onDismiss, onSubmit}) => (
+  <Form.Footer>
+    <Button
+      text="Cancel"
+      onClick={onDismiss}
+      titleText="Cancel"
+      type={ButtonType.Button}
+    />
+    <Button
+      text="Export Task"
+      color={ComponentColor.Success}
+      type={ButtonType.Submit}
+      onClick={onSubmit}
+      status={canSubmit() ? ComponentStatus.Default : ComponentStatus.Disabled}
+      testID="task-form-export"
+    />
+  </Form.Footer>
+)
+
+export default ExportTaskButtons

--- a/src/flows/components/ExportTaskOverlay/ExportTaskButtons.tsx
+++ b/src/flows/components/ExportTaskOverlay/ExportTaskButtons.tsx
@@ -1,4 +1,5 @@
-import React, {FC} from 'react'
+import React, {FC, useContext} from 'react'
+import {useHistory} from 'react-router-dom'
 import {
   Button,
   ButtonType,
@@ -6,30 +7,36 @@ import {
   ComponentStatus,
   Form,
 } from '@influxdata/clockface'
+import {OverlayContext} from 'src/flows/context/overlay'
 
 type Props = {
-  canSubmit: () => boolean
-  onDismiss: () => void
   onSubmit: () => void
 }
 
-const ExportTaskButtons: FC<Props> = ({canSubmit, onDismiss, onSubmit}) => (
-  <Form.Footer>
-    <Button
-      text="Cancel"
-      onClick={onDismiss}
-      titleText="Cancel"
-      type={ButtonType.Button}
-    />
-    <Button
-      text="Export Task"
-      color={ComponentColor.Success}
-      type={ButtonType.Submit}
-      onClick={onSubmit}
-      status={canSubmit() ? ComponentStatus.Default : ComponentStatus.Disabled}
-      testID="task-form-export"
-    />
-  </Form.Footer>
-)
+const ExportTaskButtons: FC<Props> = ({onSubmit}) => {
+  const history = useHistory()
+  const {canSubmit} = useContext(OverlayContext)
+
+  return (
+    <Form.Footer>
+      <Button
+        text="Cancel"
+        onClick={() => history.goBack()}
+        titleText="Cancel"
+        type={ButtonType.Button}
+      />
+      <Button
+        text="Export Task"
+        color={ComponentColor.Success}
+        type={ButtonType.Submit}
+        onClick={onSubmit}
+        status={
+          canSubmit() ? ComponentStatus.Default : ComponentStatus.Disabled
+        }
+        testID="task-form-export"
+      />
+    </Form.Footer>
+  )
+}
 
 export default ExportTaskButtons

--- a/src/flows/components/ExportTaskOverlay/ExportTaskOverlay.tsx
+++ b/src/flows/components/ExportTaskOverlay/ExportTaskOverlay.tsx
@@ -1,0 +1,192 @@
+// Libraries
+import React, {ChangeEvent, FC, useEffect, useState} from 'react'
+import {useDispatch, useSelector} from 'react-redux'
+import {useHistory} from 'react-router-dom'
+
+// Components
+import {
+  Form,
+  InputType,
+  Input,
+  Button,
+  Grid,
+  JustifyContent,
+  AlignItems,
+  Alignment,
+  Columns,
+  ComponentSize,
+  ButtonType,
+  ComponentColor,
+  ComponentStatus,
+  Overlay,
+  Panel,
+  Gradients,
+  Tabs,
+  Orientation,
+  IconFont,
+} from '@influxdata/clockface'
+
+// Utils
+import {saveNewScript} from 'src/tasks/actions/thunks'
+import {getOrg} from 'src/organizations/selectors'
+import {getTasks} from 'src/tasks/actions/thunks'
+import {getAllTasks as getAllTasksSelector} from 'src/resources/selectors'
+
+enum ExportAsTask {
+  Create = 'create',
+  Update = 'update',
+}
+
+const ExportTaskOverlay: FC = () => {
+  const [activeTab, setActiveTab] = useState(ExportAsTask.Create)
+  const [taskName, setTaskName] = useState('')
+  const [interval, setInterval] = useState('')
+  const history = useHistory()
+  const tasks = useSelector(getAllTasksSelector)
+  const org = useSelector(getOrg)
+
+  const dispatch = useDispatch()
+  useEffect(() => {
+    dispatch(getTasks())
+  }, [dispatch])
+
+  const onDismiss = () => {
+    history.goBack()
+  }
+
+  const onSubmit = () => {
+    const task: string = `option task = { \n  name: "${taskName}",\n   every: ${interval},\n offset: 0s\n`
+    const trimmedOrgName = org.name.trim()
+    const trimmedBucketName = org.name.trim()
+    const script: string = `${task}\n  |> to(bucket: "${trimmedBucketName}", org: "${trimmedOrgName}")`
+    const preamble = `${task}`
+
+    dispatch(saveNewScript(script, preamble))
+  }
+  const canSubmit = true
+
+  return (
+    <Overlay visible={true}>
+      <Overlay.Container maxWidth={600}>
+        <Overlay.Header
+          title="Export As Task"
+          onDismiss={onDismiss}
+          testID="export-as-overlay--header"
+        />
+        <Overlay.Body>
+          <Tabs.Container orientation={Orientation.Horizontal}>
+            <Tabs alignment={Alignment.Left} size={ComponentSize.Small}>
+              <Tabs.Tab
+                id={ExportAsTask.Create}
+                text="Create New"
+                testID="task--radio-button"
+                onClick={() => setActiveTab(ExportAsTask.Create)}
+                active={activeTab === ExportAsTask.Create}
+              />
+              <Tabs.Tab
+                id={ExportAsTask.Update}
+                text="Update Existing"
+                testID="variable-radio-button"
+                onClick={() => setActiveTab(ExportAsTask.Update)}
+                active={activeTab === ExportAsTask.Update}
+              />
+            </Tabs>
+            <Tabs.TabContents>
+              <Form>
+                <Grid>
+                  <Grid.Row>
+                    <Grid.Column widthXS={Columns.Nine}>
+                      <Form.Element label="Name">
+                        <Input
+                          name="name"
+                          placeholder="Name your task"
+                          onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                            setTaskName(event.target.value)
+                          }
+                          value={taskName}
+                          testID="task-form-name"
+                        />
+                      </Form.Element>
+                    </Grid.Column>
+                    <Grid.Column widthXS={Columns.Three}>
+                      <Form.Element label="Run Every">
+                        <Input
+                          name="schedule"
+                          type={InputType.Text}
+                          placeholder="3h30s"
+                          value={interval}
+                          onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                            setInterval(event.target.value)
+                          }
+                          testID="task-form-schedule-input"
+                        />
+                      </Form.Element>
+                    </Grid.Column>
+                    {activeTab === ExportAsTask.Update && (
+                      <Grid.Column widthXS={Columns.Twelve}>
+                        <Panel
+                          gradient={Gradients.LostGalaxy}
+                          testID="panel"
+                          style={{border: '1px #513CC6 solid'}}
+                        >
+                          <Panel.Body
+                            justifyContent={JustifyContent.FlexStart}
+                            alignItems={AlignItems.Center}
+                          >
+                            <Grid.Row>
+                              <Grid.Column widthXS={Columns.One}>
+                                <Button
+                                  status={ComponentStatus.Disabled}
+                                  size={ComponentSize.ExtraSmall}
+                                  color={ComponentColor.Secondary}
+                                  icon={IconFont.AlertTriangle}
+                                />
+                              </Grid.Column>
+                              <Grid.Column widthXS={Columns.Eleven}>
+                                <p>
+                                  Note: changes made to an existing task cannot
+                                  be undone
+                                </p>
+                              </Grid.Column>
+                            </Grid.Row>
+                          </Panel.Body>
+                        </Panel>
+                      </Grid.Column>
+                    )}
+                    <Grid.Column widthXS={Columns.Twelve}>
+                      <code>Hello world |> this feels weird</code>
+                    </Grid.Column>
+                    <Grid.Column widthXS={Columns.Twelve}>
+                      <Form.Footer>
+                        <Button
+                          text="Cancel"
+                          onClick={onDismiss}
+                          titleText="Cancel"
+                          type={ButtonType.Button}
+                        />
+                        <Button
+                          text="Export Task"
+                          color={ComponentColor.Success}
+                          type={ButtonType.Submit}
+                          onClick={onSubmit}
+                          status={
+                            canSubmit
+                              ? ComponentStatus.Default
+                              : ComponentStatus.Disabled
+                          }
+                          testID="task-form-export"
+                        />
+                      </Form.Footer>
+                    </Grid.Column>
+                  </Grid.Row>
+                </Grid>
+              </Form>
+            </Tabs.TabContents>
+          </Tabs.Container>
+        </Overlay.Body>
+      </Overlay.Container>
+    </Overlay>
+  )
+}
+
+export default ExportTaskOverlay

--- a/src/flows/components/ExportTaskOverlay/ExportTaskOverlay.tsx
+++ b/src/flows/components/ExportTaskOverlay/ExportTaskOverlay.tsx
@@ -1,19 +1,15 @@
 // Libraries
-import React, {ChangeEvent, FC, useEffect, useState} from 'react'
+import React, {FC, useContext} from 'react'
 import {useDispatch, useSelector} from 'react-redux'
 import {RouteProps, useHistory, useLocation} from 'react-router-dom'
 
 // Components
-import TaskDropdown from './TaskDropdown'
-import QueryTextPreview from './QueryTextPreview'
 import ExportTaskButtons from './ExportTaskButtons'
-import WarningPanel from './WarningPanel'
+import UpdateTaskBody from './UpdateTaskBody'
+import CreateTaskBody from './CreateTaskBody'
+import {OverlayContext, ExportAsTask} from 'src/flows/context/overlay'
 import {
-  ComponentStatus,
-  EmptyState,
   Form,
-  InputType,
-  Input,
   Grid,
   Alignment,
   Columns,
@@ -24,16 +20,9 @@ import {
 } from '@influxdata/clockface'
 
 // Utils
-import {getAllTasks as getAllTasksSelector} from 'src/resources/selectors'
 import {saveNewScript, updateTask} from 'src/tasks/actions/thunks'
 import {getOrg} from 'src/organizations/selectors'
-import {getTasks} from 'src/tasks/actions/thunks'
-import {SelectableDurationTimeRange, TimeRange, Task} from 'src/types'
-
-enum ExportAsTask {
-  Create = 'create',
-  Update = 'update',
-}
+import {SelectableDurationTimeRange, TimeRange} from 'src/types'
 
 const buildOutVariables = (timeRange: TimeRange | null): string => {
   if (timeRange === null) {
@@ -53,204 +42,31 @@ const buildOutVariables = (timeRange: TimeRange | null): string => {
   return `option v = {\n  timeRangeStart: ${lower},\n  timeRangeStop: ${upper},\n  windowPeriod: ${windowPeriod}\n}`
 }
 
-const CreateTask = ({
-  hasError,
-  setTaskName,
-  taskName,
-  interval,
-  setEveryInterval,
-  formattedQueryText,
-}) => {
-  return (
-    <>
-      <Grid.Column widthXS={Columns.Nine}>
-        <Form.Element
-          label="Name"
-          errorMessage={hasError && 'This field cannot be empty'}
-        >
-          <Input
-            name="name"
-            placeholder="Name your task"
-            onChange={(event: ChangeEvent<HTMLInputElement>) =>
-              setTaskName(event.target.value)
-            }
-            value={taskName}
-            testID="task-form-name"
-            status={hasError ? ComponentStatus.Error : ComponentStatus.Default}
-          />
-        </Form.Element>
-      </Grid.Column>
-      <Grid.Column widthXS={Columns.Three}>
-        <Form.Element
-          label="Run Every"
-          errorMessage={hasError && 'Invalid Time'}
-        >
-          <Input
-            name="schedule"
-            type={InputType.Text}
-            placeholder="3h30s"
-            value={interval}
-            onChange={(event: ChangeEvent<HTMLInputElement>) =>
-              setEveryInterval(event.target.value)
-            }
-            testID="task-form-schedule-input"
-            status={hasError ? ComponentStatus.Error : ComponentStatus.Default}
-          />
-        </Form.Element>
-      </Grid.Column>
-      <Grid.Column>
-        <QueryTextPreview formattedQueryText={formattedQueryText} />
-      </Grid.Column>
-    </>
-  )
-}
-
-const UpdateTask = ({
-  interval,
-  setEveryInterval,
-  formattedQueryText,
-  tasks,
-  selectedTask,
-  setTask,
-  hasError,
-}) => {
-  if (tasks.length === 0) {
-    return (
-      <EmptyState size={ComponentSize.Medium}>
-        <EmptyState.Text>You haven’t created any Tasks yet</EmptyState.Text>
-      </EmptyState>
-    )
-  }
-  return (
-    <>
-      <Grid.Column widthXS={Columns.Nine}>
-        <Form.Element
-          label="Name"
-          errorMessage={hasError && 'This field cannot be empty'}
-        >
-          <TaskDropdown
-            tasks={tasks}
-            setTask={setTask}
-            selectedTask={selectedTask}
-          />
-        </Form.Element>
-      </Grid.Column>
-      <Grid.Column widthXS={Columns.Three}>
-        <Form.Element
-          label="Run Every"
-          errorMessage={hasError && 'Invalid Time'}
-        >
-          <Input
-            name="schedule"
-            type={InputType.Text}
-            placeholder="3h30s"
-            value={interval}
-            onChange={(event: ChangeEvent<HTMLInputElement>) =>
-              setEveryInterval(event.target.value)
-            }
-            testID="task-form-schedule-input"
-            status={hasError ? ComponentStatus.Error : ComponentStatus.Default}
-          />
-        </Form.Element>
-      </Grid.Column>
-      <Grid.Column>
-        <WarningPanel />
-      </Grid.Column>
-      <Grid.Column>
-        <QueryTextPreview formattedQueryText={formattedQueryText} />
-      </Grid.Column>
-    </>
-  )
-}
-
-const ExportTaskBody = ({
-  activeTab,
-  hasError,
-  taskName,
-  setTaskName,
-  setEveryInterval,
-  interval,
-  formattedQueryText,
-  tasks,
-  setTask,
-  selectedTask,
-}) => {
-  if (activeTab === ExportAsTask.Create) {
-    return (
-      <CreateTask
-        hasError={hasError}
-        setTaskName={setTaskName}
-        taskName={taskName}
-        setEveryInterval={setEveryInterval}
-        interval={interval}
-        formattedQueryText={formattedQueryText}
-      />
-    )
-  }
-  return (
-    <UpdateTask
-      hasError={hasError}
-      setEveryInterval={setEveryInterval}
-      interval={interval}
-      formattedQueryText={formattedQueryText}
-      tasks={tasks}
-      setTask={setTask}
-      selectedTask={selectedTask}
-    />
-  )
-}
-
 const ExportTaskOverlay: FC = () => {
-  const [activeTab, setActiveTab] = useState(ExportAsTask.Create)
-  const [selectedTask, setTask] = useState<Task>(undefined)
-  const [hasError, setHasError] = useState(false)
-  const tasks = useSelector(getAllTasksSelector)
-  const [taskName, setTaskName] = useState('')
-  const [interval, setEveryInterval] = useState('')
+  const {
+    activeTab,
+    handleSetActiveTab,
+    handleSetError,
+    interval,
+    selectedTask,
+    taskName,
+  } = useContext(OverlayContext)
 
-  const handleSetTaskName = (value: string): void => {
-    if (hasError) {
-      setHasError(false)
-    }
-    setTaskName(value)
-  }
-  const handleSetTask = (task: Task): void => {
-    if (hasError) {
-      setHasError(false)
-    }
-    setTask(task)
-  }
-  const handleSetEveryInterval = (value: string): void => {
-    if (hasError) {
-      setHasError(false)
-    }
-    setEveryInterval(value)
-  }
-
-  const history = useHistory()
   const location: RouteProps['location'] = useLocation()
-
   const params = location.state
   const {bucket, queryText, timeRange} = params[0]
-  const org = useSelector(getOrg)
-
-  const dispatch = useDispatch()
-  useEffect(() => {
-    dispatch(getTasks())
-  }, [dispatch])
-
-  const onDismiss = () => {
-    history.goBack()
-  }
 
   const formattedQueryText = queryText
     .trim()
     .split('|>')
     .join('\n  |>')
 
+  const dispatch = useDispatch()
+  const org = useSelector(getOrg)
+
   const onCreate = () => {
     if (!/\d/.test(interval)) {
-      setHasError(true)
+      handleSetError(true)
       return
     }
     const taskOption: string = `option task = { \n  name: "${taskName}",\n  every: ${interval},\n  offset: 0s\n}`
@@ -262,7 +78,7 @@ const ExportTaskOverlay: FC = () => {
 
   const onUpdate = () => {
     if (!/\d/.test(interval) || !selectedTask?.name) {
-      setHasError(true)
+      handleSetError(true)
       return
     }
     const taskOption: string = `option task = { \n  name: "${selectedTask.name}",\n  every: ${interval},\n  offset: 0s\n}`
@@ -273,20 +89,14 @@ const ExportTaskOverlay: FC = () => {
   }
 
   const onSubmit = activeTab === ExportAsTask.Create ? onCreate : onUpdate
-
-  const canSubmit = () => {
-    if (activeTab === ExportAsTask.Create) {
-      return !!taskName && interval !== ''
-    }
-    return interval !== '' && !!selectedTask?.name
-  }
+  const history = useHistory()
 
   return (
     <Overlay visible={true}>
       <Overlay.Container maxWidth={600}>
         <Overlay.Header
           title="Export As Task"
-          onDismiss={onDismiss}
+          onDismiss={() => history.goBack()}
           testID="export-as-overlay--header"
         />
         <Overlay.Body>
@@ -296,14 +106,14 @@ const ExportTaskOverlay: FC = () => {
                 id={ExportAsTask.Create}
                 text="Create New"
                 testID="task--radio-button"
-                onClick={() => setActiveTab(ExportAsTask.Create)}
+                onClick={() => handleSetActiveTab(ExportAsTask.Create)}
                 active={activeTab === ExportAsTask.Create}
               />
               <Tabs.Tab
                 id={ExportAsTask.Update}
                 text="Update Existing"
                 testID="variable-radio-button"
-                onClick={() => setActiveTab(ExportAsTask.Update)}
+                onClick={() => handleSetActiveTab(ExportAsTask.Update)}
                 active={activeTab === ExportAsTask.Update}
               />
             </Tabs>
@@ -311,24 +121,13 @@ const ExportTaskOverlay: FC = () => {
               <Form>
                 <Grid>
                   <Grid.Row>
-                    <ExportTaskBody
-                      setEveryInterval={handleSetEveryInterval}
-                      activeTab={activeTab}
-                      interval={interval}
-                      setTaskName={handleSetTaskName}
-                      taskName={taskName}
-                      formattedQueryText={formattedQueryText}
-                      tasks={tasks}
-                      selectedTask={selectedTask}
-                      setTask={handleSetTask}
-                      hasError={hasError}
-                    />
+                    {activeTab === ExportAsTask.Create ? (
+                      <CreateTaskBody formattedQueryText={formattedQueryText} />
+                    ) : (
+                      <UpdateTaskBody formattedQueryText={formattedQueryText} />
+                    )}
                     <Grid.Column widthXS={Columns.Twelve}>
-                      <ExportTaskButtons
-                        onDismiss={onDismiss}
-                        canSubmit={canSubmit}
-                        onSubmit={onSubmit}
-                      />
+                      <ExportTaskButtons onSubmit={onSubmit} />
                     </Grid.Column>
                   </Grid.Row>
                 </Grid>

--- a/src/flows/components/ExportTaskOverlay/ExportTaskOverlay.tsx
+++ b/src/flows/components/ExportTaskOverlay/ExportTaskOverlay.tsx
@@ -27,7 +27,7 @@ import {getAllTasks as getAllTasksSelector} from 'src/resources/selectors'
 import {saveNewScript, updateTask} from 'src/tasks/actions/thunks'
 import {getOrg} from 'src/organizations/selectors'
 import {getTasks} from 'src/tasks/actions/thunks'
-import {TimeRange} from 'src/types'
+import {TimeRange, Task} from 'src/types'
 
 enum ExportAsTask {
   Create = 'create',
@@ -211,15 +211,15 @@ const ExportTaskOverlay: FC = () => {
   }
 
   const onUpdate = () => {
-    // TODO(ariel)
-    const taskOption: string = `option task = { \n  name: "${selectedTask.name}",\n  every: ${interval},\n  offset: 0s\n}`
-    const preamble = `${buildOutVariables(timeRange)}\n\n${taskOption}`
-    const trimmedOrgName = org.name.trim()
-    const script: string = `${formattedQueryText}\n  |> to(bucket: "${bucket?.name.trim()}", org: "${trimmedOrgName}")`
-    dispatch(updateTask(script, preamble))
+    if (selectedTask?.name) {
+      const task = selectedTask as Task
+      const taskOption: string = `option task = { \n  name: "${task.name}",\n  every: ${interval},\n  offset: 0s\n}`
+      const preamble = `${buildOutVariables(timeRange)}\n\n${taskOption}`
+      const trimmedOrgName = org.name.trim()
+      const script: string = `${formattedQueryText}\n  |> to(bucket: "${bucket?.name.trim()}", org: "${trimmedOrgName}")`
+      dispatch(updateTask({script, preamble, interval, task}))
+    }
   }
-
-  console.log('selectedTask: ', selectedTask)
 
   const onSubmit = activeTab === ExportAsTask.Create ? onCreate : onUpdate
 

--- a/src/flows/components/ExportTaskOverlay/ExportTaskOverlay.tsx
+++ b/src/flows/components/ExportTaskOverlay/ExportTaskOverlay.tsx
@@ -1,9 +1,10 @@
 // Libraries
-import React, {ChangeEvent, FC, useEffect, useState} from 'react'
+import React, {ChangeEvent, FC, useEffect, useState, Component} from 'react'
 import {useDispatch, useSelector} from 'react-redux'
 import {useHistory} from 'react-router-dom'
 
 // Components
+import FluxEditor from 'src/shared/components/FluxMonacoEditor'
 import {
   Form,
   InputType,
@@ -23,6 +24,8 @@ import {
   Gradients,
   Tabs,
   Orientation,
+  FlexDirection,
+  Icon,
   IconFont,
 } from '@influxdata/clockface'
 
@@ -132,29 +135,33 @@ const ExportTaskOverlay: FC = () => {
                           <Panel.Body
                             justifyContent={JustifyContent.FlexStart}
                             alignItems={AlignItems.Center}
+                            direction={FlexDirection.Row}
+                            margin={ComponentSize.Large}
+                            size={ComponentSize.ExtraSmall}
                           >
-                            <Grid.Row>
-                              <Grid.Column widthXS={Columns.One}>
-                                <Button
-                                  status={ComponentStatus.Disabled}
-                                  size={ComponentSize.ExtraSmall}
-                                  color={ComponentColor.Secondary}
-                                  icon={IconFont.AlertTriangle}
-                                />
-                              </Grid.Column>
-                              <Grid.Column widthXS={Columns.Eleven}>
-                                <p>
-                                  Note: changes made to an existing task cannot
-                                  be undone
-                                </p>
-                              </Grid.Column>
-                            </Grid.Row>
+                            <Icon glyph={IconFont.AlertTriangle} />
+                            <p className="margin-zero">
+                              &nbsp;Note: changes made to an existing task
+                              cannot be undone
+                            </p>
                           </Panel.Body>
                         </Panel>
                       </Grid.Column>
                     )}
-                    <Grid.Column widthXS={Columns.Twelve}>
-                      <code>Hello world |> this feels weird</code>
+                    <Grid.Column>
+                      {/**add in a set height and relative position */}
+                      <Form.Element style={{height: 300, position: 'relative'}}>
+                        <div className="flux-editor">
+                          <div className="flux-editor--left-panel">
+                            <FluxEditor
+                              script={'here is a randoms string'}
+                              onChangeScript={() => {}}
+                              onSubmitScript={() => {}}
+                              setEditorInstance={() => {}}
+                            />
+                          </div>
+                        </div>
+                      </Form.Element>
                     </Grid.Column>
                     <Grid.Column widthXS={Columns.Twelve}>
                       <Form.Footer>

--- a/src/flows/components/ExportTaskOverlay/QueryTextPreview.tsx
+++ b/src/flows/components/ExportTaskOverlay/QueryTextPreview.tsx
@@ -1,8 +1,6 @@
 import React, {FC} from 'react'
 import {Form} from '@influxdata/clockface'
-import MonacoEditor from 'react-monaco-editor'
-import THEME_NAME from 'src/external/monaco.toml.theme'
-import TOMLLANGID from 'src/external/monaco.toml.syntax'
+import FluxEditor from 'src/shared/components/FluxMonacoEditor'
 
 type Props = {
   formattedQueryText?: string
@@ -12,24 +10,10 @@ const QueryTextPreview: FC<Props> = ({formattedQueryText = ''}) => (
   <Form.Element label="" style={{height: 300, position: 'relative'}}>
     <div className="flux-editor">
       <div className="flux-editor--left-panel">
-        <MonacoEditor
-          language={TOMLLANGID}
-          theme={THEME_NAME}
-          value={formattedQueryText}
-          onChange={() => {}}
-          options={{
-            fontSize: 13,
-            fontFamily: '"IBMPlexMono", monospace',
-            cursorWidth: 2,
-            lineNumbersMinChars: 4,
-            lineDecorationsWidth: 0,
-            minimap: {
-              renderCharacters: false,
-            },
-            overviewRulerBorder: false,
-            automaticLayout: true,
-            readOnly: true,
-          }}
+        <FluxEditor
+          script={formattedQueryText}
+          onChangeScript={() => {}}
+          readOnly={true}
         />
       </div>
     </div>

--- a/src/flows/components/ExportTaskOverlay/QueryTextPreview.tsx
+++ b/src/flows/components/ExportTaskOverlay/QueryTextPreview.tsx
@@ -1,0 +1,24 @@
+import React, {FC} from 'react'
+import {Form} from '@influxdata/clockface'
+import FluxEditor from 'src/shared/components/FluxMonacoEditor'
+
+type Props = {
+  formattedQueryText: string
+}
+
+const QueryTextPreview: FC<Props> = ({formattedQueryText}) => (
+  <Form.Element label="" style={{height: 300, position: 'relative'}}>
+    <div className="flux-editor">
+      <div className="flux-editor--left-panel">
+        <FluxEditor
+          script={formattedQueryText}
+          onChangeScript={() => {}}
+          onSubmitScript={() => {}}
+          setEditorInstance={() => {}}
+        />
+      </div>
+    </div>
+  </Form.Element>
+)
+
+export default QueryTextPreview

--- a/src/flows/components/ExportTaskOverlay/QueryTextPreview.tsx
+++ b/src/flows/components/ExportTaskOverlay/QueryTextPreview.tsx
@@ -1,20 +1,35 @@
 import React, {FC} from 'react'
 import {Form} from '@influxdata/clockface'
-import FluxEditor from 'src/shared/components/FluxMonacoEditor'
+import MonacoEditor from 'react-monaco-editor'
+import THEME_NAME from 'src/external/monaco.toml.theme'
+import TOMLLANGID from 'src/external/monaco.toml.syntax'
 
 type Props = {
-  formattedQueryText: string
+  formattedQueryText?: string
 }
 
-const QueryTextPreview: FC<Props> = ({formattedQueryText}) => (
+const QueryTextPreview: FC<Props> = ({formattedQueryText = ''}) => (
   <Form.Element label="" style={{height: 300, position: 'relative'}}>
     <div className="flux-editor">
       <div className="flux-editor--left-panel">
-        <FluxEditor
-          script={formattedQueryText}
-          onChangeScript={() => {}}
-          onSubmitScript={() => {}}
-          setEditorInstance={() => {}}
+        <MonacoEditor
+          language={TOMLLANGID}
+          theme={THEME_NAME}
+          value={formattedQueryText}
+          onChange={() => {}}
+          options={{
+            fontSize: 13,
+            fontFamily: '"IBMPlexMono", monospace',
+            cursorWidth: 2,
+            lineNumbersMinChars: 4,
+            lineDecorationsWidth: 0,
+            minimap: {
+              renderCharacters: false,
+            },
+            overviewRulerBorder: false,
+            automaticLayout: true,
+            readOnly: true,
+          }}
         />
       </div>
     </div>

--- a/src/flows/components/ExportTaskOverlay/TaskDropdown.tsx
+++ b/src/flows/components/ExportTaskOverlay/TaskDropdown.tsx
@@ -1,0 +1,63 @@
+import React, {FC} from 'react'
+import {
+  ComponentSize,
+  IconFont,
+  TechnoSpinner,
+  Dropdown,
+} from '@influxdata/clockface'
+import {Task} from 'src/types'
+
+type Props = {
+  tasks: Task[]
+  selectedTask: Task
+  setTask: (task: Task) => void
+}
+
+const TaskDropdown: FC<Props> = ({tasks, selectedTask, setTask}) => {
+  let buttonText = 'Loading tasks...'
+
+  let menuItems = (
+    <Dropdown.ItemEmpty>
+      <TechnoSpinner strokeWidth={ComponentSize.Small} diameterPixels={32} />
+    </Dropdown.ItemEmpty>
+  )
+
+  if (tasks.length) {
+    menuItems = (
+      <>
+        {tasks.map(task => (
+          <Dropdown.Item
+            key={task.name}
+            value={task}
+            onClick={task => setTask(task)}
+            selected={task.name === selectedTask?.name}
+            title={task.name}
+            wrapText={true}
+          >
+            {task.name}
+          </Dropdown.Item>
+        ))}
+      </>
+    )
+  }
+
+  if (!selectedTask?.name) {
+    buttonText = 'Choose a task'
+  } else if (selectedTask?.name) {
+    buttonText = selectedTask.name
+  }
+
+  const button = (active, onClick) => (
+    <Dropdown.Button onClick={onClick} active={active} icon={IconFont.Disks}>
+      {buttonText}
+    </Dropdown.Button>
+  )
+
+  const menu = onCollapse => (
+    <Dropdown.Menu onCollapse={onCollapse}>{menuItems}</Dropdown.Menu>
+  )
+
+  return <Dropdown button={button} menu={menu} style={{width: '100%'}} />
+}
+
+export default TaskDropdown

--- a/src/flows/components/ExportTaskOverlay/TaskDropdown.tsx
+++ b/src/flows/components/ExportTaskOverlay/TaskDropdown.tsx
@@ -1,4 +1,5 @@
-import React, {FC, useContext} from 'react'
+import React, {FC, useContext, useEffect} from 'react'
+import {useDispatch, useSelector} from 'react-redux'
 import {
   ComponentSize,
   IconFont,
@@ -6,9 +7,14 @@ import {
   Dropdown,
 } from '@influxdata/clockface'
 import {OverlayContext} from 'src/flows/context/overlay'
+import {getTasks} from 'src/tasks/actions/thunks'
+import {getAllTasks as getAllTasksSelector} from 'src/resources/selectors'
 
 const TaskDropdown: FC = () => {
-  const {tasks, handleSetTask, selectedTask} = useContext(OverlayContext)
+  const {handleSetTask, selectedTask} = useContext(OverlayContext)
+
+  const tasks = useSelector(getAllTasksSelector)
+
   let buttonText = 'Loading tasks...'
 
   let menuItems = (
@@ -16,6 +22,11 @@ const TaskDropdown: FC = () => {
       <TechnoSpinner strokeWidth={ComponentSize.Small} diameterPixels={32} />
     </Dropdown.ItemEmpty>
   )
+
+  const dispatch = useDispatch()
+  useEffect(() => {
+    dispatch(getTasks())
+  }, [dispatch])
 
   if (tasks.length) {
     menuItems = (

--- a/src/flows/components/ExportTaskOverlay/TaskDropdown.tsx
+++ b/src/flows/components/ExportTaskOverlay/TaskDropdown.tsx
@@ -1,19 +1,14 @@
-import React, {FC} from 'react'
+import React, {FC, useContext} from 'react'
 import {
   ComponentSize,
   IconFont,
   TechnoSpinner,
   Dropdown,
 } from '@influxdata/clockface'
-import {Task} from 'src/types'
+import {OverlayContext} from 'src/flows/context/overlay'
 
-type Props = {
-  tasks: Task[]
-  selectedTask: Task
-  setTask: (task: Task) => void
-}
-
-const TaskDropdown: FC<Props> = ({tasks, selectedTask, setTask}) => {
+const TaskDropdown: FC = () => {
+  const {tasks, handleSetTask, selectedTask} = useContext(OverlayContext)
   let buttonText = 'Loading tasks...'
 
   let menuItems = (
@@ -29,7 +24,7 @@ const TaskDropdown: FC<Props> = ({tasks, selectedTask, setTask}) => {
           <Dropdown.Item
             key={task.name}
             value={task}
-            onClick={task => setTask(task)}
+            onClick={task => handleSetTask(task)}
             selected={task.name === selectedTask?.name}
             title={task.name}
             wrapText={true}

--- a/src/flows/components/ExportTaskOverlay/UpdateTaskBody.tsx
+++ b/src/flows/components/ExportTaskOverlay/UpdateTaskBody.tsx
@@ -1,0 +1,71 @@
+import React, {ChangeEvent, FC, useContext} from 'react'
+import {
+  Columns,
+  ComponentSize,
+  ComponentStatus,
+  EmptyState,
+  Form,
+  Grid,
+  Input,
+  InputType,
+} from '@influxdata/clockface'
+import TaskDropdown from 'src/flows/components/ExportTaskOverlay/TaskDropdown'
+import WarningPanel from 'src/flows/components/ExportTaskOverlay/WarningPanel'
+import QueryTextPreview from 'src/flows/components/ExportTaskOverlay/QueryTextPreview'
+import {OverlayContext} from 'src/flows/context/overlay'
+
+type Props = {
+  formattedQueryText: string
+}
+
+const UpdateTaskBody: FC<Props> = ({formattedQueryText}) => {
+  const {interval, handleSetEveryInterval, hasError, tasks} = useContext(
+    OverlayContext
+  )
+
+  if (tasks.length === 0) {
+    return (
+      <EmptyState size={ComponentSize.Medium}>
+        <EmptyState.Text>You haven’t created any Tasks yet</EmptyState.Text>
+      </EmptyState>
+    )
+  }
+  return (
+    <>
+      <Grid.Column widthXS={Columns.Nine}>
+        <Form.Element
+          label="Name"
+          errorMessage={hasError && 'This field cannot be empty'}
+        >
+          <TaskDropdown />
+        </Form.Element>
+      </Grid.Column>
+      <Grid.Column widthXS={Columns.Three}>
+        <Form.Element
+          label="Run Every"
+          errorMessage={hasError && 'Invalid Time'}
+        >
+          <Input
+            name="schedule"
+            type={InputType.Text}
+            placeholder="3h30s"
+            value={interval}
+            onChange={(event: ChangeEvent<HTMLInputElement>) =>
+              handleSetEveryInterval(event.target.value)
+            }
+            testID="task-form-schedule-input"
+            status={hasError ? ComponentStatus.Error : ComponentStatus.Default}
+          />
+        </Form.Element>
+      </Grid.Column>
+      <Grid.Column>
+        <WarningPanel />
+      </Grid.Column>
+      <Grid.Column>
+        <QueryTextPreview formattedQueryText={formattedQueryText} />
+      </Grid.Column>
+    </>
+  )
+}
+
+export default UpdateTaskBody

--- a/src/flows/components/ExportTaskOverlay/UpdateTaskBody.tsx
+++ b/src/flows/components/ExportTaskOverlay/UpdateTaskBody.tsx
@@ -1,4 +1,5 @@
 import React, {ChangeEvent, FC, useContext} from 'react'
+import {useSelector} from 'react-redux'
 import {
   Columns,
   ComponentSize,
@@ -13,17 +14,20 @@ import TaskDropdown from 'src/flows/components/ExportTaskOverlay/TaskDropdown'
 import WarningPanel from 'src/flows/components/ExportTaskOverlay/WarningPanel'
 import QueryTextPreview from 'src/flows/components/ExportTaskOverlay/QueryTextPreview'
 import {OverlayContext} from 'src/flows/context/overlay'
+import {hasNoTasks as hasNoTasksSelector} from 'src/resources/selectors'
 
 type Props = {
   formattedQueryText: string
 }
 
 const UpdateTaskBody: FC<Props> = ({formattedQueryText}) => {
-  const {interval, handleSetEveryInterval, hasError, tasks} = useContext(
+  const {interval, handleSetEveryInterval, hasError} = useContext(
     OverlayContext
   )
 
-  if (tasks.length === 0) {
+  const hasNoTasks = useSelector(hasNoTasksSelector)
+
+  if (hasNoTasks) {
     return (
       <EmptyState size={ComponentSize.Medium}>
         <EmptyState.Text>You haven’t created any Tasks yet</EmptyState.Text>

--- a/src/flows/components/ExportTaskOverlay/WarningPanel.tsx
+++ b/src/flows/components/ExportTaskOverlay/WarningPanel.tsx
@@ -1,0 +1,30 @@
+import React, {FC} from 'react'
+import {
+  AlignItems,
+  ComponentSize,
+  FlexDirection,
+  Gradients,
+  Icon,
+  IconFont,
+  JustifyContent,
+  Panel,
+} from '@influxdata/clockface'
+
+const WarningPanel: FC = () => (
+  <Panel gradient={Gradients.LostGalaxy} testID="panel" border={true}>
+    <Panel.Body
+      justifyContent={JustifyContent.FlexStart}
+      alignItems={AlignItems.Center}
+      direction={FlexDirection.Row}
+      margin={ComponentSize.Large}
+      size={ComponentSize.ExtraSmall}
+    >
+      <Icon glyph={IconFont.AlertTriangle} />
+      <p className="margin-zero">
+        &nbsp;Note: changes made to an existing task cannot be undone
+      </p>
+    </Panel.Body>
+  </Panel>
+)
+
+export default WarningPanel

--- a/src/flows/components/Flow.tsx
+++ b/src/flows/components/Flow.tsx
@@ -1,6 +1,7 @@
 // Libraries
 import React, {FC, useContext, useEffect} from 'react'
 import {useParams} from 'react-router-dom'
+import {Switch, Route} from 'react-router-dom'
 
 // Components
 import {ResultsProvider} from 'src/flows/context/results'
@@ -9,6 +10,7 @@ import CurrentFlowProvider from 'src/flows/context/flow.current'
 import {FlowListContext} from 'src/flows/context/flow.list'
 import {ScrollProvider} from 'src/flows/context/scroll'
 import FlowPage from 'src/flows/components/FlowPage'
+import ExportTaskOverlay from 'src/flows/components/ExportTaskOverlay/ExportTaskOverlay'
 
 const FlowFromRoute = () => {
   const {id} = useParams()
@@ -32,6 +34,13 @@ const FlowContainer: FC = () => {
       <ResultsProvider>
         <RefProvider>
           <ScrollProvider>
+            <Switch>
+              {/* wrapping in a switch in anticipation of export to dashboard */}
+              <Route
+                path="/orgs/:orgID/flows/:id/export-task"
+                component={ExportTaskOverlay}
+              />
+            </Switch>
             <FlowPage />
           </ScrollProvider>
         </RefProvider>

--- a/src/flows/components/Flow.tsx
+++ b/src/flows/components/Flow.tsx
@@ -9,6 +9,7 @@ import {RefProvider} from 'src/flows/context/refs'
 import CurrentFlowProvider from 'src/flows/context/flow.current'
 import {FlowListContext} from 'src/flows/context/flow.list'
 import {ScrollProvider} from 'src/flows/context/scroll'
+import OverlayProvider from 'src/flows/context/overlay'
 import FlowPage from 'src/flows/components/FlowPage'
 import ExportTaskOverlay from 'src/flows/components/ExportTaskOverlay/ExportTaskOverlay'
 
@@ -34,13 +35,15 @@ const FlowContainer: FC = () => {
       <ResultsProvider>
         <RefProvider>
           <ScrollProvider>
-            <Switch>
-              {/* wrapping in a switch in anticipation of export to dashboard */}
-              <Route
-                path="/orgs/:orgID/flows/:id/export-task"
-                component={ExportTaskOverlay}
-              />
-            </Switch>
+            <OverlayProvider>
+              <Switch>
+                {/* wrapping in a switch in anticipation of export to dashboard */}
+                <Route
+                  path="/orgs/:orgID/flows/:id/export-task"
+                  component={ExportTaskOverlay}
+                />
+              </Switch>
+            </OverlayProvider>
             <FlowPage />
           </ScrollProvider>
         </RefProvider>

--- a/src/flows/components/FlowPage.tsx
+++ b/src/flows/components/FlowPage.tsx
@@ -5,18 +5,28 @@ import {Page} from '@influxdata/clockface'
 import FlowHeader from 'src/flows/components/header'
 import PipeList from 'src/flows/components/PipeList'
 import MiniMap from 'src/flows/components/minimap/MiniMap'
+import QueryProvider from 'src/flows/context/query'
+import {TimeProvider} from 'src/flows/context/time'
 
 const FlowPage = () => {
   return (
-    <Page titleTag="Flows">
-      <FlowHeader />
-      <Page.Contents fullWidth={true} scrollable={false} className="flow-page">
-        <div className="flow">
-          <MiniMap />
-          <PipeList />
-        </div>
-      </Page.Contents>
-    </Page>
+    <TimeProvider>
+      <Page titleTag="Flows">
+        <FlowHeader />
+        <QueryProvider>
+          <Page.Contents
+            fullWidth={true}
+            scrollable={false}
+            className="flow-page"
+          >
+            <div className="flow">
+              <MiniMap />
+              <PipeList />
+            </div>
+          </Page.Contents>
+        </QueryProvider>
+      </Page>
+    </TimeProvider>
   )
 }
 

--- a/src/flows/components/header/Submit.tsx
+++ b/src/flows/components/header/Submit.tsx
@@ -100,8 +100,4 @@ export const Submit: FC = () => {
   )
 }
 
-export default () => (
-  <QueryProvider>
-    <Submit />
-  </QueryProvider>
-)
+export default Submit

--- a/src/flows/components/header/Submit.tsx
+++ b/src/flows/components/header/Submit.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FC, useContext, useState, useEffect} from 'react'
 import {SubmitQueryButton} from 'src/timeMachine/components/SubmitQueryButton'
-import QueryProvider, {QueryContext} from 'src/flows/context/query'
+import {QueryContext} from 'src/flows/context/query'
 import {FlowContext} from 'src/flows/context/flow.current'
 import {ResultsContext} from 'src/flows/context/results'
 import {TimeContext} from 'src/flows/context/time'

--- a/src/flows/components/header/index.tsx
+++ b/src/flows/components/header/index.tsx
@@ -3,8 +3,9 @@ import React, {FC, useContext, useCallback} from 'react'
 
 // Contexts
 import {FlowContext} from 'src/flows/context/flow.current'
-import {TimeProvider, TimeContext, TimeBlock} from 'src/flows/context/time'
+import {TimeContext, TimeBlock} from 'src/flows/context/time'
 import AppSettingProvider from 'src/flows/context/app'
+import QueryProvider from 'src/flows/context/query'
 
 // Components
 import {Page} from '@influxdata/clockface'
@@ -56,7 +57,9 @@ const FlowHeader: FC = () => {
       </Page.Header>
       <Page.ControlBar fullWidth={FULL_WIDTH}>
         <Page.ControlBarLeft>
-          <Submit />
+          <QueryProvider>
+            <Submit />
+          </QueryProvider>
         </Page.ControlBarLeft>
         <Page.ControlBarRight>
           <PresentationMode />
@@ -70,9 +73,7 @@ const FlowHeader: FC = () => {
 }
 
 export default () => (
-  <TimeProvider>
-    <AppSettingProvider>
-      <FlowHeader />
-    </AppSettingProvider>
-  </TimeProvider>
+  <AppSettingProvider>
+    <FlowHeader />
+  </AppSettingProvider>
 )

--- a/src/flows/components/panel/ExportTaskButton.tsx
+++ b/src/flows/components/panel/ExportTaskButton.tsx
@@ -1,0 +1,35 @@
+// Libraries
+import React, {FC, useContext} from 'react'
+
+// Components
+import {SquareButton, IconFont} from '@influxdata/clockface'
+import {FlowContext} from 'src/flows/context/flow.current'
+
+// Utils
+import {event} from 'src/cloud/utils/reporting'
+
+export interface Props {
+  id: string
+}
+
+const ExportTaskButton: FC<Props> = ({id}) => {
+  const {flow} = useContext(FlowContext)
+  const meta = flow.meta.get(id)
+
+  const icon = meta.visible ? IconFont.EyeOpen : IconFont.EyeClosed
+  const title = meta.visible ? 'Collapse cell' : 'Expand cell'
+
+  const handleClick = (): void => {
+    event('Panel Visibility Toggled', {
+      state: !meta.visible ? 'true' : 'false',
+    })
+
+    flow.meta.update(id, {
+      visible: !meta.visible,
+    })
+  }
+
+  return <SquareButton icon={icon} onClick={handleClick} titleText={title} />
+}
+
+export default ExportTaskButton

--- a/src/flows/components/panel/ExportTaskButton.tsx
+++ b/src/flows/components/panel/ExportTaskButton.tsx
@@ -10,7 +10,6 @@ import {
 // Components
 import {Button} from '@influxdata/clockface'
 import {PipeContext} from 'src/flows/context/pipe'
-import {TimeContext} from 'src/flows/context/time'
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'
@@ -18,13 +17,11 @@ import {event} from 'src/cloud/utils/reporting'
 const ExportTaskButton: FC = () => {
   const history = useHistory()
   const {data, queryText} = useContext(PipeContext)
-  const {timeContext} = useContext(TimeContext)
   const {orgID, id} = useParams<{orgID: string; id: string}>()
-  const timeRange = timeContext[id]
   const onClick = () => {
     event('Export Task Clicked')
     history.push(`/orgs/${orgID}/flows/${id}/export-task`, [
-      {bucket: data.bucket, queryText, timeRange: timeRange.range},
+      {bucket: data.bucket, queryText},
     ])
   }
   return (

--- a/src/flows/components/panel/ExportTaskButton.tsx
+++ b/src/flows/components/panel/ExportTaskButton.tsx
@@ -1,35 +1,43 @@
 // Libraries
 import React, {FC, useContext} from 'react'
+import {useHistory, useParams} from 'react-router-dom'
+import {
+  ButtonType,
+  ComponentColor,
+  ComponentStatus,
+} from '@influxdata/clockface'
 
 // Components
-import {SquareButton, IconFont} from '@influxdata/clockface'
-import {FlowContext} from 'src/flows/context/flow.current'
+import {Button} from '@influxdata/clockface'
+import {PipeContext} from 'src/flows/context/pipe'
+import {TimeContext} from 'src/flows/context/time'
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'
 
-export interface Props {
-  id: string
-}
-
-const ExportTaskButton: FC<Props> = ({id}) => {
-  const {flow} = useContext(FlowContext)
-  const meta = flow.meta.get(id)
-
-  const icon = meta.visible ? IconFont.EyeOpen : IconFont.EyeClosed
-  const title = meta.visible ? 'Collapse cell' : 'Expand cell'
-
-  const handleClick = (): void => {
-    event('Panel Visibility Toggled', {
-      state: !meta.visible ? 'true' : 'false',
-    })
-
-    flow.meta.update(id, {
-      visible: !meta.visible,
-    })
+const ExportTaskButton: FC = () => {
+  const history = useHistory()
+  const {data, queryText} = useContext(PipeContext)
+  const {timeContext} = useContext(TimeContext)
+  const {orgID, id} = useParams<{orgID: string; id: string}>()
+  const timeRange = timeContext[id]
+  const onClick = () => {
+    event('Export Task Clicked')
+    history.push(`/orgs/${orgID}/flows/${id}/export-task`, [
+      {bucket: data.bucket, queryText, timeRange: timeRange.range},
+    ])
   }
-
-  return <SquareButton icon={icon} onClick={handleClick} titleText={title} />
+  return (
+    <Button
+      text="Export as Task"
+      color={ComponentColor.Success}
+      type={ButtonType.Submit}
+      onClick={onClick}
+      status={data.bucket ? ComponentStatus.Default : ComponentStatus.Disabled}
+      testID="task-form-save"
+      style={{opacity: 1}}
+    />
+  )
 }
 
 export default ExportTaskButton

--- a/src/flows/components/panel/ExportTaskButton.tsx
+++ b/src/flows/components/panel/ExportTaskButton.tsx
@@ -36,6 +36,9 @@ const ExportTaskButton: FC = () => {
       status={data.bucket ? ComponentStatus.Default : ComponentStatus.Disabled}
       testID="task-form-save"
       style={{opacity: 1}}
+      titleText={
+        data.bucket ? 'Export As Task' : 'Select a bucket to enable export'
+      }
     />
   )
 }

--- a/src/flows/components/panel/FlowPanel.tsx
+++ b/src/flows/components/panel/FlowPanel.tsx
@@ -18,7 +18,6 @@ import {
   JustifyContent,
   ClickOutside,
 } from '@influxdata/clockface'
-import ExportTaskButton from 'src/flows/components/panel/ExportTaskButton'
 import RemovePanelButton from 'src/flows/components/panel/RemovePanelButton'
 import InsertCellButton from 'src/flows/components/panel/InsertCellButton'
 import PanelVisibilityToggle from 'src/flows/components/panel/PanelVisibilityToggle'
@@ -37,16 +36,20 @@ import {RefContext} from 'src/flows/context/refs'
 
 export interface Props extends PipeContextProps {
   id: string
-  shouldShow?: boolean
+  persistentControl?: ReactNode
 }
 
 export interface HeaderProps {
   id: string
   controls?: ReactNode
-  shouldShow?: boolean
+  persistentControl?: ReactNode
 }
 
-const FlowPanelHeader: FC<HeaderProps> = ({id, controls, shouldShow}) => {
+const FlowPanelHeader: FC<HeaderProps> = ({
+  id,
+  controls,
+  persistentControl,
+}) => {
   const {flow} = useContext(FlowContext)
   const removePipe = () => {
     flow.data.remove(id)
@@ -102,16 +105,16 @@ const FlowPanelHeader: FC<HeaderProps> = ({id, controls, shouldShow}) => {
               active={canBeMovedDown}
             />
           </FeatureFlag>
-          {shouldShow && <ExportTaskButton />}
           <PanelVisibilityToggle id={id} />
           <RemovePanelButton onRemove={remove} />
+          {persistentControl}
         </FlexBox>
       )}
     </div>
   )
 }
 
-const FlowPanel: FC<Props> = ({id, children, controls, shouldShow}) => {
+const FlowPanel: FC<Props> = ({id, children, controls, persistentControl}) => {
   const {flow} = useContext(FlowContext)
   const refs = useContext(RefContext)
   const panelRef = useRef<HTMLDivElement>(null)
@@ -159,7 +162,11 @@ const FlowPanel: FC<Props> = ({id, children, controls, shouldShow}) => {
   return (
     <ClickOutside onClickOutside={handleClickOutside}>
       <div className={panelClassName} onClick={handleClick} ref={panelRef}>
-        <FlowPanelHeader id={id} controls={controls} shouldShow={shouldShow} />
+        <FlowPanelHeader
+          id={id}
+          controls={controls}
+          persistentControl={persistentControl}
+        />
         <div className="flow-panel--body">{children}</div>
         {showResults && (
           <div className="flow-panel--results">

--- a/src/flows/components/panel/FlowPanel.tsx
+++ b/src/flows/components/panel/FlowPanel.tsx
@@ -18,6 +18,7 @@ import {
   JustifyContent,
   ClickOutside,
 } from '@influxdata/clockface'
+import ExportTaskButton from 'src/flows/components/panel/ExportTaskButton'
 import RemovePanelButton from 'src/flows/components/panel/RemovePanelButton'
 import InsertCellButton from 'src/flows/components/panel/InsertCellButton'
 import PanelVisibilityToggle from 'src/flows/components/panel/PanelVisibilityToggle'
@@ -36,14 +37,16 @@ import {RefContext} from 'src/flows/context/refs'
 
 export interface Props extends PipeContextProps {
   id: string
+  shouldShow?: boolean
 }
 
 export interface HeaderProps {
   id: string
   controls?: ReactNode
+  shouldShow?: boolean
 }
 
-const FlowPanelHeader: FC<HeaderProps> = ({id, controls}) => {
+const FlowPanelHeader: FC<HeaderProps> = ({id, controls, shouldShow}) => {
   const {flow} = useContext(FlowContext)
   const removePipe = () => {
     flow.data.remove(id)
@@ -66,7 +69,6 @@ const FlowPanelHeader: FC<HeaderProps> = ({id, controls}) => {
   }, [index, canBeMovedDown, flow.data])
 
   const remove = useCallback(() => removePipe(), [removePipe, id])
-  console.log('flow: ', flow)
   return (
     <div className="flow-panel--header">
       <div className="flow-panel--node-wrapper">
@@ -100,6 +102,7 @@ const FlowPanelHeader: FC<HeaderProps> = ({id, controls}) => {
               active={canBeMovedDown}
             />
           </FeatureFlag>
+          {shouldShow && <ExportTaskButton />}
           <PanelVisibilityToggle id={id} />
           <RemovePanelButton onRemove={remove} />
         </FlexBox>
@@ -108,7 +111,7 @@ const FlowPanelHeader: FC<HeaderProps> = ({id, controls}) => {
   )
 }
 
-const FlowPanel: FC<Props> = ({id, children, controls}) => {
+const FlowPanel: FC<Props> = ({id, children, controls, shouldShow}) => {
   const {flow} = useContext(FlowContext)
   const refs = useContext(RefContext)
   const panelRef = useRef<HTMLDivElement>(null)
@@ -156,7 +159,7 @@ const FlowPanel: FC<Props> = ({id, children, controls}) => {
   return (
     <ClickOutside onClickOutside={handleClickOutside}>
       <div className={panelClassName} onClick={handleClick} ref={panelRef}>
-        <FlowPanelHeader id={id} controls={controls} />
+        <FlowPanelHeader id={id} controls={controls} shouldShow={shouldShow} />
         <div className="flow-panel--body">{children}</div>
         {showResults && (
           <div className="flow-panel--results">

--- a/src/flows/components/panel/FlowPanel.tsx
+++ b/src/flows/components/panel/FlowPanel.tsx
@@ -66,7 +66,7 @@ const FlowPanelHeader: FC<HeaderProps> = ({id, controls}) => {
   }, [index, canBeMovedDown, flow.data])
 
   const remove = useCallback(() => removePipe(), [removePipe, id])
-
+  console.log('flow: ', flow)
   return (
     <div className="flow-panel--header">
       <div className="flow-panel--node-wrapper">

--- a/src/flows/context/overlay.tsx
+++ b/src/flows/context/overlay.tsx
@@ -1,8 +1,5 @@
-import React, {FC, useEffect, useState, useCallback} from 'react'
-import {useDispatch, useSelector} from 'react-redux'
-import {getAllTasks as getAllTasksSelector} from 'src/resources/selectors'
+import React, {FC, useState, useCallback} from 'react'
 import {Task} from 'src/types'
-import {getTasks} from 'src/tasks/actions/thunks'
 
 export enum ExportAsTask {
   Create = 'create',
@@ -21,7 +18,6 @@ export interface OverlayContext {
   interval: string
   selectedTask: Task | undefined
   taskName: string
-  tasks: Task[]
 }
 
 export const DEFAULT_CONTEXT: OverlayContext = {
@@ -36,7 +32,6 @@ export const DEFAULT_CONTEXT: OverlayContext = {
   interval: '',
   selectedTask: undefined,
   taskName: '',
-  tasks: [],
 }
 
 export const OverlayContext = React.createContext<OverlayContext>(
@@ -47,14 +42,8 @@ const OverlayProvider: FC = ({children}) => {
   const [activeTab, setActiveTab] = useState(ExportAsTask.Create)
   const [selectedTask, setTask] = useState<Task>(undefined)
   const [hasError, setHasError] = useState(false)
-  const tasks = useSelector(getAllTasksSelector)
   const [taskName, setTaskName] = useState('')
   const [interval, setEveryInterval] = useState('')
-
-  const dispatch = useDispatch()
-  useEffect(() => {
-    dispatch(getTasks())
-  }, [dispatch])
 
   const handleSetActiveTab = useCallback((tab: ExportAsTask): void => {
     setActiveTab(tab)
@@ -111,7 +100,6 @@ const OverlayProvider: FC = ({children}) => {
         interval,
         selectedTask,
         taskName,
-        tasks,
       }}
     >
       {children}

--- a/src/flows/context/overlay.tsx
+++ b/src/flows/context/overlay.tsx
@@ -1,0 +1,122 @@
+import React, {FC, useEffect, useState, useCallback} from 'react'
+import {useDispatch, useSelector} from 'react-redux'
+import {getAllTasks as getAllTasksSelector} from 'src/resources/selectors'
+import {Task} from 'src/types'
+import {getTasks} from 'src/tasks/actions/thunks'
+
+export enum ExportAsTask {
+  Create = 'create',
+  Update = 'update',
+}
+
+export interface OverlayContext {
+  activeTab: ExportAsTask
+  canSubmit: () => boolean
+  handleSetActiveTab: (tab: ExportAsTask) => void
+  handleSetError: (value: boolean) => void
+  handleSetEveryInterval: (value: string) => void
+  handleSetTask: (task: Task) => void
+  handleSetTaskName: (value: string) => void
+  hasError: boolean
+  interval: string
+  selectedTask: Task | undefined
+  taskName: string
+  tasks: Task[]
+}
+
+export const DEFAULT_CONTEXT: OverlayContext = {
+  activeTab: ExportAsTask.Create,
+  canSubmit: () => false,
+  handleSetActiveTab: () => {},
+  handleSetError: () => {},
+  handleSetEveryInterval: () => {},
+  handleSetTask: () => {},
+  handleSetTaskName: () => {},
+  hasError: false,
+  interval: '',
+  selectedTask: undefined,
+  taskName: '',
+  tasks: [],
+}
+
+export const OverlayContext = React.createContext<OverlayContext>(
+  DEFAULT_CONTEXT
+)
+
+const OverlayProvider: FC = ({children}) => {
+  const [activeTab, setActiveTab] = useState(ExportAsTask.Create)
+  const [selectedTask, setTask] = useState<Task>(undefined)
+  const [hasError, setHasError] = useState(false)
+  const tasks = useSelector(getAllTasksSelector)
+  const [taskName, setTaskName] = useState('')
+  const [interval, setEveryInterval] = useState('')
+
+  const dispatch = useDispatch()
+  useEffect(() => {
+    dispatch(getTasks())
+  }, [dispatch])
+
+  const handleSetActiveTab = useCallback((tab: ExportAsTask): void => {
+    setActiveTab(tab)
+  }, [])
+  const handleSetError = useCallback((value: boolean): void => {
+    setHasError(value)
+  }, [])
+  const handleSetEveryInterval = useCallback(
+    (value: string): void => {
+      if (hasError) {
+        setHasError(false)
+      }
+      setEveryInterval(value)
+    },
+    [hasError]
+  )
+  const handleSetTaskName = useCallback(
+    (value: string): void => {
+      if (hasError) {
+        setHasError(false)
+      }
+      setTaskName(value)
+    },
+    [hasError]
+  )
+  const handleSetTask = useCallback(
+    (task: Task): void => {
+      if (hasError) {
+        setHasError(false)
+      }
+      setTask(task)
+    },
+    [hasError]
+  )
+
+  const canSubmit = useCallback(() => {
+    if (activeTab === ExportAsTask.Create) {
+      return !!taskName && interval !== ''
+    }
+    return interval !== '' && !!selectedTask?.name
+  }, [activeTab, taskName, interval, selectedTask])
+
+  return (
+    <OverlayContext.Provider
+      value={{
+        activeTab,
+        canSubmit,
+        handleSetActiveTab,
+        handleSetError,
+        handleSetEveryInterval,
+        handleSetTask,
+        handleSetTaskName,
+        hasError,
+        interval,
+        selectedTask,
+        taskName,
+        tasks,
+      }}
+    >
+      {children}
+    </OverlayContext.Provider>
+  )
+}
+
+export default OverlayProvider

--- a/src/flows/context/pipe.tsx
+++ b/src/flows/context/pipe.tsx
@@ -1,12 +1,14 @@
-import React, {FC, useContext} from 'react'
+import React, {FC, useContext, useMemo} from 'react'
 import {PipeData, FluxResult} from 'src/types/flows'
 import {FlowContext} from 'src/flows/context/flow.current'
 import {ResultsContext} from 'src/flows/context/results'
 import {RemoteDataState} from 'src/types'
+import {QueryContext} from './query'
 
 export interface PipeContextType {
   id: string
   data: PipeData
+  queryText: string
   update: (data: PipeData) => void
   loading: RemoteDataState
   results: FluxResult
@@ -16,6 +18,7 @@ export interface PipeContextType {
 export const DEFAULT_CONTEXT: PipeContextType = {
   id: '',
   data: {},
+  queryText: '',
   update: () => {},
   loading: RemoteDataState.NotStarted,
   results: {
@@ -35,6 +38,11 @@ interface PipeContextProps {
 export const PipeProvider: FC<PipeContextProps> = ({id, children}) => {
   const {flow} = useContext(FlowContext)
   const results = useContext(ResultsContext)
+  const {generateMap} = useContext(QueryContext)
+
+  const stages = useMemo(() => generateMap(), [generateMap, flow.data.get(id)])
+  const queryText = stages.filter(stage => stage.instances.includes(id))[0].text
+
   const updater = (_data: PipeData) => {
     flow.data.update(id, _data)
   }
@@ -52,6 +60,7 @@ export const PipeProvider: FC<PipeContextProps> = ({id, children}) => {
       value={{
         id: id,
         data: flow.data.get(id),
+        queryText,
         update: updater,
         results: _result,
         loading: flow.meta.get(id).loading,

--- a/src/flows/context/pipe.tsx
+++ b/src/flows/context/pipe.tsx
@@ -41,7 +41,7 @@ export const PipeProvider: FC<PipeContextProps> = ({id, children}) => {
   const {generateMap} = useContext(QueryContext)
 
   const stages = useMemo(() => generateMap(), [generateMap, flow.data.get(id)])
-  const queryText = stages.filter(stage => stage.instances.includes(id))[0].text
+  const queryText = stages.filter(stage => stage.instances.includes(id))[0]?.text || ''
 
   const updater = (_data: PipeData) => {
     flow.data.update(id, _data)

--- a/src/flows/context/pipe.tsx
+++ b/src/flows/context/pipe.tsx
@@ -41,7 +41,8 @@ export const PipeProvider: FC<PipeContextProps> = ({id, children}) => {
   const {generateMap} = useContext(QueryContext)
 
   const stages = useMemo(() => generateMap(), [generateMap, flow.data.get(id)])
-  const queryText = stages.filter(stage => stage.instances.includes(id))[0]?.text || ''
+  const queryText =
+    stages.filter(stage => stage.instances.includes(id))[0]?.text || ''
 
   const updater = (_data: PipeData) => {
     flow.data.update(id, _data)

--- a/src/flows/pipes/Bucket/view.tsx
+++ b/src/flows/pipes/Bucket/view.tsx
@@ -1,5 +1,15 @@
 // Libraries
 import React, {FC} from 'react'
+import {useHistory, useParams} from 'react-router-dom'
+
+// Components
+import {
+  Button,
+  ButtonType,
+  ComponentColor,
+  ComponentStatus,
+} from '@influxdata/clockface'
+
 // Types
 import {PipeProp} from 'src/types/flows'
 
@@ -12,14 +22,31 @@ import BucketSelector from 'src/flows/pipes/Bucket/BucketSelector'
 // Styles
 import 'src/flows/pipes/Query/style.scss'
 
-const BucketSource: FC<PipeProp> = ({Context}) => (
-  <BucketProvider>
-    <Context>
-      <div className="data-source--controls">
-        <BucketSelector />
-      </div>
-    </Context>
-  </BucketProvider>
-)
+const BucketSource: FC<PipeProp> = ({Context}) => {
+  const history = useHistory()
+  const {orgID, id} = useParams<{orgID: string; id: string}>()
+
+  const onClick = () => history.push(`/orgs/${orgID}/flows/${id}/export-task`)
+  const canSubmit = true // TODO(ariel): check if something is selected
+  const controls = (
+    <Button
+      text="Export as Task"
+      color={ComponentColor.Success}
+      type={ButtonType.Submit}
+      onClick={onClick}
+      status={canSubmit ? ComponentStatus.Default : ComponentStatus.Disabled}
+      testID="task-form-save"
+    />
+  )
+  return (
+    <BucketProvider>
+      <Context controls={controls}>
+        <div className="data-source--controls">
+          <BucketSelector />
+        </div>
+      </Context>
+    </BucketProvider>
+  )
+}
 
 export default BucketSource

--- a/src/flows/pipes/Bucket/view.tsx
+++ b/src/flows/pipes/Bucket/view.tsx
@@ -9,13 +9,13 @@ import BucketProvider from 'src/flows/context/buckets'
 
 // Components
 import BucketSelector from 'src/flows/pipes/Bucket/BucketSelector'
-
+import ExportTaskButton from 'src/flows/components/panel/ExportTaskButton'
 // Styles
 import 'src/flows/pipes/Query/style.scss'
 
 const BucketSource: FC<PipeProp> = ({Context}) => (
   <BucketProvider>
-    <Context shouldShow={true}>
+    <Context persistentControl={<ExportTaskButton />}>
       <div className="data-source--controls">
         <BucketSelector />
       </div>

--- a/src/flows/pipes/Bucket/view.tsx
+++ b/src/flows/pipes/Bucket/view.tsx
@@ -1,22 +1,11 @@
 // Libraries
-import React, {FC, useContext} from 'react'
-import {useHistory, useParams} from 'react-router-dom'
-
-// Components
-import {
-  Button,
-  ButtonType,
-  ComponentColor,
-  ComponentStatus,
-} from '@influxdata/clockface'
+import React, {FC} from 'react'
 
 // Types
 import {PipeProp} from 'src/types/flows'
 
 // Contexts
 import BucketProvider from 'src/flows/context/buckets'
-import {PipeContext} from 'src/flows/context/pipe'
-import {TimeContext} from 'src/flows/context/time'
 
 // Components
 import BucketSelector from 'src/flows/pipes/Bucket/BucketSelector'
@@ -24,35 +13,14 @@ import BucketSelector from 'src/flows/pipes/Bucket/BucketSelector'
 // Styles
 import 'src/flows/pipes/Query/style.scss'
 
-const BucketSource: FC<PipeProp> = ({Context}) => {
-  const history = useHistory()
-  const {data, queryText} = useContext(PipeContext)
-  const {timeContext} = useContext(TimeContext)
-  const {orgID, id} = useParams<{orgID: string; id: string}>()
-  const timeRange = timeContext[id]
-  const onClick = () =>
-    history.push(`/orgs/${orgID}/flows/${id}/export-task`, [
-      {bucket: data.bucket, queryText, timeRange: timeRange.range},
-    ])
-  const controls = (
-    <Button
-      text="Export as Task"
-      color={ComponentColor.Success}
-      type={ButtonType.Submit}
-      onClick={onClick}
-      status={data.bucket ? ComponentStatus.Default : ComponentStatus.Disabled}
-      testID="task-form-save"
-    />
-  )
-  return (
-    <BucketProvider>
-      <Context controls={controls}>
-        <div className="data-source--controls">
-          <BucketSelector />
-        </div>
-      </Context>
-    </BucketProvider>
-  )
-}
+const BucketSource: FC<PipeProp> = ({Context}) => (
+  <BucketProvider>
+    <Context shouldShow={true}>
+      <div className="data-source--controls">
+        <BucketSelector />
+      </div>
+    </Context>
+  </BucketProvider>
+)
 
 export default BucketSource

--- a/src/flows/pipes/Bucket/view.tsx
+++ b/src/flows/pipes/Bucket/view.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FC} from 'react'
+import React, {FC, useContext} from 'react'
 import {useHistory, useParams} from 'react-router-dom'
 
 // Components
@@ -15,6 +15,8 @@ import {PipeProp} from 'src/types/flows'
 
 // Contexts
 import BucketProvider from 'src/flows/context/buckets'
+import {PipeContext} from 'src/flows/context/pipe'
+import {TimeContext} from 'src/flows/context/time'
 
 // Components
 import BucketSelector from 'src/flows/pipes/Bucket/BucketSelector'
@@ -24,17 +26,21 @@ import 'src/flows/pipes/Query/style.scss'
 
 const BucketSource: FC<PipeProp> = ({Context}) => {
   const history = useHistory()
+  const {data, queryText} = useContext(PipeContext)
+  const {timeContext} = useContext(TimeContext)
   const {orgID, id} = useParams<{orgID: string; id: string}>()
-
-  const onClick = () => history.push(`/orgs/${orgID}/flows/${id}/export-task`)
-  const canSubmit = true // TODO(ariel): check if something is selected
+  const timeRange = timeContext[id]
+  const onClick = () =>
+    history.push(`/orgs/${orgID}/flows/${id}/export-task`, [
+      {bucket: data.bucket, queryText, timeRange: timeRange.range},
+    ])
   const controls = (
     <Button
       text="Export as Task"
       color={ComponentColor.Success}
       type={ButtonType.Submit}
       onClick={onClick}
-      status={canSubmit ? ComponentStatus.Default : ComponentStatus.Disabled}
+      status={data.bucket ? ComponentStatus.Default : ComponentStatus.Disabled}
       testID="task-form-save"
     />
   )

--- a/src/flows/pipes/Data/index.ts
+++ b/src/flows/pipes/Data/index.ts
@@ -51,8 +51,7 @@ export default register => {
       }
 
       if (aggregateFunction?.name) {
-        text += `  |> aggregateWindow(every: v.windowPeriod, fn: ${aggregateFunction.name}, createEmpty: false)
-            |> yield(name: "${aggregateFunction.name}")`
+        text += `  |> aggregateWindow(every: v.windowPeriod, fn: ${aggregateFunction.name}, createEmpty: false)|> yield(name: "${aggregateFunction.name}")`
       }
 
       create(text)

--- a/src/resources/selectors/index.ts
+++ b/src/resources/selectors/index.ts
@@ -2,13 +2,7 @@
 import {get} from 'lodash'
 
 // Types
-import {
-  AppState,
-  ResourceType,
-  RemoteDataState,
-  Label,
-  TaskOptions,
-} from 'src/types'
+import {AppState, ResourceType, RemoteDataState, Label, Task} from 'src/types'
 
 export const getStatus = (
   {resources}: AppState,
@@ -26,7 +20,7 @@ export const getAll = <R>(
   return allIDs.map(id => byID[id])
 }
 
-export const getAllTasks = (state: AppState): TaskOptions[] =>
+export const getAllTasks = (state: AppState): Task[] =>
   getAll(state, ResourceType.Tasks)
 
 export const getToken = (state: AppState): string =>

--- a/src/resources/selectors/index.ts
+++ b/src/resources/selectors/index.ts
@@ -23,6 +23,9 @@ export const getAll = <R>(
 export const getAllTasks = (state: AppState): Task[] =>
   getAll(state, ResourceType.Tasks) || []
 
+export const hasNoTasks = (state: AppState): boolean =>
+  getAll(state, ResourceType.Tasks).length === 0
+
 export const getToken = (state: AppState): string =>
   get(state, 'dataLoading.dataLoaders.token', '') || ''
 

--- a/src/resources/selectors/index.ts
+++ b/src/resources/selectors/index.ts
@@ -21,7 +21,7 @@ export const getAll = <R>(
 }
 
 export const getAllTasks = (state: AppState): Task[] =>
-  getAll(state, ResourceType.Tasks)
+  getAll(state, ResourceType.Tasks) || []
 
 export const getToken = (state: AppState): string =>
   get(state, 'dataLoading.dataLoaders.token', '') || ''

--- a/src/resources/selectors/index.ts
+++ b/src/resources/selectors/index.ts
@@ -2,7 +2,13 @@
 import {get} from 'lodash'
 
 // Types
-import {AppState, ResourceType, RemoteDataState, Label} from 'src/types'
+import {
+  AppState,
+  ResourceType,
+  RemoteDataState,
+  Label,
+  TaskOptions,
+} from 'src/types'
 
 export const getStatus = (
   {resources}: AppState,
@@ -20,7 +26,7 @@ export const getAll = <R>(
   return allIDs.map(id => byID[id])
 }
 
-export const getAllTasks = <R>(state: AppState): R[] =>
+export const getAllTasks = (state: AppState): TaskOptions[] =>
   getAll(state, ResourceType.Tasks)
 
 export const getToken = (state: AppState): string =>

--- a/src/resources/selectors/index.ts
+++ b/src/resources/selectors/index.ts
@@ -20,6 +20,9 @@ export const getAll = <R>(
   return allIDs.map(id => byID[id])
 }
 
+export const getAllTasks = <R>(state: AppState): R[] =>
+  getAll(state, ResourceType.Tasks)
+
 export const getToken = (state: AppState): string =>
   get(state, 'dataLoading.dataLoaders.token', '') || ''
 

--- a/src/shared/components/FluxMonacoEditor.tsx
+++ b/src/shared/components/FluxMonacoEditor.tsx
@@ -28,6 +28,7 @@ export interface EditorProps {
   onChangeScript: OnChangeScript
   onSubmitScript?: () => void
   autogrow?: boolean
+  readOnly?: boolean
 }
 
 interface Props extends EditorProps {
@@ -40,6 +41,7 @@ const FluxEditorMonaco: FC<Props> = ({
   onSubmitScript,
   setEditorInstance,
   autogrow,
+  readOnly,
 }) => {
   const lspServer = useRef<LSPServer>(null)
   const [editorInst, seteditorInst] = useState<EditorType | null>(null)
@@ -88,7 +90,9 @@ const FluxEditorMonaco: FC<Props> = ({
         })
         editor.focus()
       } else {
-        editor.focus()
+        if (!readOnly) {
+          editor.focus()
+        }
       }
     } catch (e) {
       // TODO: notify user that lsp failed
@@ -124,6 +128,7 @@ const FluxEditorMonaco: FC<Props> = ({
           },
           overviewRulerBorder: false,
           automaticLayout: true,
+          readOnly: readOnly || false,
         }}
         editorDidMount={editorDidMount}
       />

--- a/src/tasks/actions/thunks.ts
+++ b/src/tasks/actions/thunks.ts
@@ -196,14 +196,12 @@ export const updateTaskName = (name: string, taskID: string) => async (
 type UpdateTaskParams = {
   script: string
   preamble: string
-  name: string
   task: Task
   interval: string
 }
 
 export const updateTask = ({
   script,
-  name,
   interval,
   preamble,
   task,
@@ -212,19 +210,14 @@ export const updateTask = ({
     const fluxScript = await insertPreambleInScript(script, preamble)
     const resp = await api.patchTask({
       taskID: task.id,
-      data: {name, offset: '0s', every: interval, flux: fluxScript},
+      data: {...task, offset: '0s', every: interval, flux: fluxScript},
     })
 
     if (resp.status !== 200) {
       throw new Error(resp.data.message)
     }
 
-    const normTask = normalize<Task, TaskEntities, string>(
-      resp.data,
-      taskSchema
-    )
-
-    dispatch(editTask(normTask))
+    dispatch(goToTasks())
     dispatch(notify(copy.taskUpdateSuccess()))
   } catch (e) {
     console.error(e)

--- a/src/tasks/actions/thunks.ts
+++ b/src/tasks/actions/thunks.ts
@@ -193,6 +193,46 @@ export const updateTaskName = (name: string, taskID: string) => async (
   }
 }
 
+type UpdateTaskParams = {
+  script: string
+  preamble: string
+  name: string
+  task: Task
+  interval: string
+}
+
+export const updateTask = ({
+  script,
+  name,
+  interval,
+  preamble,
+  task,
+}: UpdateTaskParams) => async (dispatch: Dispatch<Action>) => {
+  try {
+    const fluxScript = await insertPreambleInScript(script, preamble)
+    const resp = await api.patchTask({
+      taskID: task.id,
+      data: {name, offset: '0s', every: interval, flux: fluxScript},
+    })
+
+    if (resp.status !== 200) {
+      throw new Error(resp.data.message)
+    }
+
+    const normTask = normalize<Task, TaskEntities, string>(
+      resp.data,
+      taskSchema
+    )
+
+    dispatch(editTask(normTask))
+    dispatch(notify(copy.taskUpdateSuccess()))
+  } catch (e) {
+    console.error(e)
+    const message = getErrorMessage(e)
+    dispatch(notify(copy.taskUpdateFailed(message)))
+  }
+}
+
 export const deleteTask = (taskID: string) => async (
   dispatch: Dispatch<Action>
 ) => {

--- a/src/types/flows.ts
+++ b/src/types/flows.ts
@@ -24,7 +24,7 @@ export interface NormalizedSchema {
 export interface PipeContextProps {
   children?: ReactNode
   controls?: ReactNode
-  shouldShow?: boolean
+  persistentControl?: ReactNode
 }
 
 export type PipeData = any

--- a/src/types/flows.ts
+++ b/src/types/flows.ts
@@ -24,6 +24,7 @@ export interface NormalizedSchema {
 export interface PipeContextProps {
   children?: ReactNode
   controls?: ReactNode
+  shouldShow?: boolean
 }
 
 export type PipeData = any


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/19603

This PR adds functionality to the `Output to Bucket` flows pipe option by allowing users to create queries and export them as tasks.

![export-to](https://user-images.githubusercontent.com/19984220/96503487-313c3600-1208-11eb-81ab-1832d82b0cd9.gif)
