### PR TITLE
feat(flows-index): redesigned the flows index page to include helper text

### DIFF
--- a/src/flows/components/EmptyPipeList.scss
+++ b/src/flows/components/EmptyPipeList.scss
@@ -32,6 +32,7 @@
   background-repeat: no-repeat;
 }
 
+.flow-empty--description-text,
 .flow-empty--buttons {
   margin-top: $cf-marg-c;
 }

--- a/src/flows/components/FlowsExplainer.tsx
+++ b/src/flows/components/FlowsExplainer.tsx
@@ -1,0 +1,27 @@
+// Libraries
+import React, {FC} from 'react'
+
+// Components
+import {Panel, Gradients} from '@influxdata/clockface'
+
+const FlowsExplainer: FC = () => (
+  <Panel gradient={Gradients.PolarExpress} border={true}>
+    <Panel.Header>
+      <h5>What is Flows?</h5>
+    </Panel.Header>
+    <Panel.Body>
+      <p>
+        Flows is a tool to help you explore, visualize, and process your data.
+        Learn how to downsample data and other handy tutorials in the{' '}
+        <a
+          href="https://v2.docs.influxdata.com/v2.0/write-data/"
+          target="_blank"
+        >
+          Flows Documentation
+        </a>
+      </p>
+    </Panel.Body>
+  </Panel>
+)
+
+export default FlowsExplainer

--- a/src/flows/components/FlowsExplainer.tsx
+++ b/src/flows/components/FlowsExplainer.tsx
@@ -13,10 +13,7 @@ const FlowsExplainer: FC = () => (
       <p>
         Flows is a tool to help you explore, visualize, and process your data.
         Learn how to downsample data and other handy tutorials in the{' '}
-        <a
-          href="https://v2.docs.influxdata.com/v2.0/write-data/"
-          target="_blank"
-        >
+        <a href="" target="_blank">
           Flows Documentation
         </a>
       </p>

--- a/src/flows/components/FlowsIndex.test.tsx
+++ b/src/flows/components/FlowsIndex.test.tsx
@@ -4,28 +4,26 @@ import userEvent from '@testing-library/user-event'
 import {renderWithReduxAndRouter} from 'src/mockState'
 
 // Components
-import FlowCards from 'src/flows/components/FlowCards'
+import FlowsIndex from 'src/flows/components/FlowsIndex'
 import FlowListProvider from 'src/flows/context/flow.list'
 
 const setup = (override = {}) => {
   const wrapper = renderWithReduxAndRouter(
     <FlowListProvider {...override}>
-      <FlowCards />
+      <FlowsIndex />
     </FlowListProvider>
   )
 
   return {wrapper}
 }
 
-describe('FlowCards', () => {
+describe('FlowsIndex', () => {
   test('empty state', () => {
     const {wrapper} = setup()
-
     const emptyState = wrapper.findByTestId('empty-state')
 
     expect(emptyState).toBeTruthy()
   })
-
   test('create a flow', () => {
     const {wrapper} = setup()
 

--- a/src/flows/components/FlowsIndexEmpty.tsx
+++ b/src/flows/components/FlowsIndexEmpty.tsx
@@ -1,15 +1,40 @@
 import React from 'react'
-import {ComponentSize, EmptyState} from '@influxdata/clockface'
-import FlowCreateButton from './FlowCreateButton'
+import {Grid, Columns, ComponentSize, EmptyState} from '@influxdata/clockface'
+import FlowsExplainer from 'src/flows/components/FlowsExplainer'
 
 const FlowsIndexEmpty = () => {
   return (
-    <EmptyState size={ComponentSize.Large}>
-      <EmptyState.Text>
-        Looks like there aren't any <b>Flows</b>, why not create one?
-      </EmptyState.Text>
-      <FlowCreateButton />
-    </EmptyState>
+    <Grid>
+      <Grid.Row>
+        <Grid.Column
+          widthXS={Columns.Twelve}
+          widthSM={Columns.Eight}
+          widthMD={Columns.Ten}
+        >
+          <EmptyState size={ComponentSize.Large}>
+            <div className="flow-empty">
+              <div className="flow-empty--graphic" />
+              <EmptyState.Text>
+                You haven't created any Flows yet
+              </EmptyState.Text>
+              <div className="flow-empty--description-text">
+                <p>
+                  Click <strong>Create Flow</strong> in the top right to get
+                  started
+                </p>
+              </div>
+            </div>
+          </EmptyState>
+        </Grid.Column>
+        <Grid.Column
+          widthXS={Columns.Twelve}
+          widthSM={Columns.Four}
+          widthMD={Columns.Two}
+        >
+          <FlowsExplainer />
+        </Grid.Column>
+      </Grid.Row>
+    </Grid>
   )
 }
 


### PR DESCRIPTION
Closes #144 

This PR adds the redesigned UI for the empty state of the flows index page:

https://www.figma.com/file/8S8IH8mimYIwanZ6keIQ6U/Notebooks-Prototype?node-id=934%3A354

![empty-flows-index](https://user-images.githubusercontent.com/19984220/96512944-1d97cc00-1216-11eb-93ef-916787ddf891.gif)
