### PR TITLE
chore: update github metadata stuff

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+Closes #
+
+### Testing Steps
+
+### Merge Checklist
+- [ ] User facing change?
+  - [ ] CHANGELOG.md is updated and links to this PR

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,3 +1,4 @@
 # docs: https://github.com/probot/semantic-pull-requests#configuration
-titleAndCommits: true
 allowMergeCommits: true
+allowRevertCommits: true
+titleOnly: true


### PR DESCRIPTION
#### Semantic Commit Changes:
- allows revert commits (`"Revert "feat: ride unicorns""`)
- allows any commit to have a semantic commit
  - the idea behind this is if you have three or four commits on a branch, and those commits are going to be squash merged into a single semantic commit, it's not really worth making someone force pushing commit changes to be semantic if they're going to be squashed anyway. it's causing more frustration than it's solving

- adds a github pull request template