### PR TITLE
chore(remove-flag): removing cancelQueryUiExpansion flag after being on for two weeks

### DIFF
--- a/src/flows/context/query.tsx
+++ b/src/flows/context/query.tsx
@@ -17,7 +17,6 @@ import {
   generateHashedQueryID,
   setQueryByHashID,
 } from 'src/timeMachine/actions/queries'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 interface Stage {
   text: string
@@ -115,9 +114,7 @@ export const QueryProvider: FC<Props> = ({children, variables, org}) => {
 
     event('runQuery', {context: 'flows'})
     const result = runQuery(org.id, text, extern)
-    if (isFlagEnabled('cancelQueryUiExpansion')) {
-      setQueryByHashID(queryID, result)
-    }
+    setQueryByHashID(queryID, result)
     return result.promise
       .then(raw => {
         if (raw.type !== 'SUCCESS') {


### PR DESCRIPTION
The feature flag for cancelQueryUiExpansion has been enabled on production and tools for two weeks without any complaints. This is just a clean-up to remove it from the UI. Once the UI has been updated, I'll remove the flag from IDPE, followed by config cat