### PR TITLE
fix(flows-ui-pagination): fixed the UI pagination for flows and feature flagged it

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "@influxdata/clockface": "2.3.5",
     "@influxdata/flux": "^0.5.1",
     "@influxdata/flux-lsp-browser": "^0.5.11",
-    "@influxdata/giraffe": "0.36.0",
+    "@influxdata/giraffe": "0.40.0",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",

--- a/src/flows/components/panel/Results.tsx
+++ b/src/flows/components/panel/Results.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FC, useEffect, useState, useContext, useMemo} from 'react'
 import {AutoSizer} from 'react-virtualized'
-import memoizeOne from 'memoize-one'
+import {fromFlux} from '@influxdata/giraffe'
 
 // Components
 import RawFluxDataTable from 'src/timeMachine/components/RawFluxDataTable'
@@ -14,11 +14,6 @@ import {PipeContext} from 'src/flows/context/pipe'
 import {MINIMUM_RESIZER_HEIGHT} from 'src/flows/shared/Resizer'
 
 // Utils
-import {
-  parseFiles,
-  parseFilesWithObjects,
-  parseFilesWithFromFlux,
-} from 'src/timeMachine/utils/rawFluxDataTable'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {event} from 'src/cloud/utils/reporting'
 
@@ -107,30 +102,14 @@ const Results: FC = () => {
                 return false
               }
 
-              const memoizeParseFilesWithFromFlux = memoizeOne(
-                parseFilesWithFromFlux
-              )
-              const memoizeParseFiles = memoizeOne(parseFiles)
-              const memoizeParseFilesWithObjects = memoizeOne(
-                parseFilesWithObjects
-              )
-
               const page = Math.floor(height / ROW_HEIGHT)
               setPageSize(page)
 
-              let parseFunction = memoizeParseFiles
-              if (isFlagEnabled('parseObjectsInCSV')) {
-                parseFunction = memoizeParseFilesWithObjects
-              }
-              if (isFlagEnabled('rawCsvFromfluxParser')) {
-                parseFunction = memoizeParseFilesWithFromFlux
-              }
-              const {data, maxColumnCount} = parseFunction([raw])
               if (isFlagEnabled('flowsUiPagination')) {
+                const parsedResults = fromFlux(raw)
                 return (
                   <RawFluxDataTable
-                    data={data}
-                    maxColumnCount={maxColumnCount}
+                    parsedResults={parsedResults}
                     startRow={startRow}
                     width={width}
                     height={page * ROW_HEIGHT}

--- a/src/shared/parsing/flux/response.test.ts
+++ b/src/shared/parsing/flux/response.test.ts
@@ -552,10 +552,12 @@ describe('parseResponseWithFromFlux', () => {
   })
 
   describe('headers', () => {
-    test('throws when no metadata is present', () => {
+    test('does not throw when no metadata is present', () => {
       expect(() => {
         parseResponseWithFromFlux(RESPONSE_NO_METADATA)
-      }).toThrow()
+      }).not.toThrow()
+      const actual = parseResponseWithFromFlux(RESPONSE_NO_METADATA)
+      expect(actual).toEqual([])
     })
 
     test('can parse headers when metadata is present', () => {

--- a/src/shared/parsing/flux/response.test.ts
+++ b/src/shared/parsing/flux/response.test.ts
@@ -589,8 +589,7 @@ describe('parseResponseWithFromFlux', () => {
   describe('partial responses', () => {
     test('should discard tables without any non-annotation rows', () => {
       const actual = parseResponseWithFromFlux(TRUNCATED_RESPONSE)
-
-      expect(actual).toHaveLength(2)
+      expect(actual).toHaveLength(0)
     })
   })
 })

--- a/src/shared/parsing/flux/response.ts
+++ b/src/shared/parsing/flux/response.ts
@@ -4,6 +4,7 @@ import uuid from 'uuid'
 
 import {FluxTable} from 'src/types'
 import {fromFlux} from '@influxdata/giraffe'
+import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
 
 export const parseResponseError = (response: string): FluxTable[] => {
   const data = Papa.parse(response.trim()).data as string[][]
@@ -151,11 +152,20 @@ export const parseTables = (responseChunk: string): FluxTable[] => {
 }
 
 export const parseResponseWithFromFlux = (response: string): FluxTable[] => {
+  const parsed = fromFlux(response)
+
+  if (parsed.error) {
+    reportErrorThroughHoneyBadger(parsed.error, {
+      name: 'parseResponseWithFromFlux function',
+    })
+    return []
+  }
+
   const {
     fluxGroupKeyUnion,
     table,
     table: {columnKeys: keys},
-  } = fromFlux(response)
+  } = parsed
 
   const columnKeys = [
     'result',

--- a/src/timeMachine/components/RawFluxDataGrid.tsx
+++ b/src/timeMachine/components/RawFluxDataGrid.tsx
@@ -14,6 +14,7 @@ interface Props {
   height: number
   scrollLeft: number
   scrollTop: number
+  startRow?: number
 }
 
 interface State {
@@ -87,8 +88,9 @@ export default class extends PureComponent<Props, State> {
   }
 
   private renderCell = ({columnIndex, key, rowIndex, style}) => {
-    const datum = this.getCellData(rowIndex, columnIndex)
-
+    const {startRow} = this.props
+    const base = Number(startRow) || 0
+    const datum = this.getCellData(base + rowIndex, columnIndex)
     return (
       <div
         key={key}

--- a/src/timeMachine/components/RawFluxDataTable.tsx
+++ b/src/timeMachine/components/RawFluxDataTable.tsx
@@ -12,11 +12,16 @@ import {
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {DapperScrollbars, FusionScrollEvent} from '@influxdata/clockface'
 
+// TODO(ariel): remove files and make data and maxColumnCount mandatory when
+// turning the flowsUiPagination feature flag off
 interface Props {
-  files: string[]
+  files?: string[]
+  data?: string[][]
+  maxColumnCount?: number
   width: number
   height: number
   disableVerticalScrolling?: boolean
+  startRow?: number
 }
 
 interface State {
@@ -27,14 +32,57 @@ interface State {
 class RawFluxDataTable extends PureComponent<Props, State> {
   public state = {scrollLeft: 0, scrollTop: 0}
 
+  // TODO(ariel): remove all this when flowsUiPagination is lifted
   private parseFilesWithFromFlux = memoizeOne(parseFilesWithFromFlux)
   private parseFiles = memoizeOne(parseFiles)
   private parseFilesWithObjects = memoizeOne(parseFilesWithObjects)
 
   public render() {
-    const {width, height, files, disableVerticalScrolling} = this.props
+    const {
+      width,
+      height,
+      files,
+      disableVerticalScrolling,
+      startRow,
+    } = this.props
+    let {data, maxColumnCount} = this.props
 
     const {scrollTop, scrollLeft} = this.state
+
+    const tableWidth = width
+    const tableHeight = height
+
+    if (isFlagEnabled('flowsUiPagination')) {
+      return (
+        <div className="raw-flux-data-table" data-testid="raw-data-table">
+          <DapperScrollbars
+            style={{
+              overflowY: 'hidden',
+              width: tableWidth,
+              height: tableHeight,
+            }}
+            autoHide={false}
+            scrollTop={scrollTop}
+            scrollLeft={scrollLeft}
+            testID="rawdata-table--scrollbar"
+            onScroll={this.onScrollbarsScroll}
+            noScrollY={disableVerticalScrolling}
+          >
+            <RawFluxDataGrid
+              scrollTop={scrollTop}
+              scrollLeft={scrollLeft}
+              width={tableWidth}
+              height={tableHeight}
+              maxColumnCount={maxColumnCount}
+              data={data}
+              startRow={startRow}
+            />
+          </DapperScrollbars>
+        </div>
+      )
+    }
+
+    // TODO(ariel): remove this when flowsUiPagination is lifted
     let parseFunction = this.parseFiles
     if (isFlagEnabled('parseObjectsInCSV')) {
       parseFunction = this.parseFilesWithObjects
@@ -42,10 +90,9 @@ class RawFluxDataTable extends PureComponent<Props, State> {
     if (isFlagEnabled('rawCsvFromfluxParser')) {
       parseFunction = this.parseFilesWithFromFlux
     }
-    const {data, maxColumnCount} = parseFunction(files)
-
-    const tableWidth = width
-    const tableHeight = height
+    const parsed = parseFunction(files)
+    data = parsed.data
+    maxColumnCount = parsed.maxColumnCount
 
     return (
       <div className="raw-flux-data-table" data-testid="raw-data-table">

--- a/src/timeMachine/components/Vis.tsx
+++ b/src/timeMachine/components/Vis.tsx
@@ -1,8 +1,9 @@
 // Libraries
-import React, {FC, useMemo} from 'react'
+import React, {FC} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
 import {AutoSizer} from 'react-virtualized'
 import classnames from 'classnames'
+import {fromFlux} from '@influxdata/giraffe'
 
 // Components
 import EmptyQueryView, {ErrorFormat} from 'src/shared/components/EmptyQueryView'
@@ -12,12 +13,6 @@ import RawFluxDataTable from 'src/timeMachine/components/RawFluxDataTable'
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
 
 // Utils
-import {
-  parseFiles,
-  parseFilesWithObjects,
-  parseFilesWithFromFlux,
-} from 'src/timeMachine/utils/rawFluxDataTable'
-import {fromFlux} from '@influxdata/giraffe'
 import {getActiveTimeMachine} from 'src/timeMachine/selectors'
 import {checkResultsLength} from 'src/shared/utils/vis'
 import {

--- a/src/timeMachine/components/Vis.tsx
+++ b/src/timeMachine/components/Vis.tsx
@@ -1,6 +1,5 @@
 // Libraries
-import React, {FC} from 'react'
-import memoizeOne from 'memoize-one'
+import React, {FC, useMemo} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
 import {AutoSizer} from 'react-virtualized'
 import classnames from 'classnames'
@@ -18,6 +17,7 @@ import {
   parseFilesWithObjects,
   parseFilesWithFromFlux,
 } from 'src/timeMachine/utils/rawFluxDataTable'
+import {fromFlux} from '@influxdata/giraffe'
 import {getActiveTimeMachine} from 'src/timeMachine/selectors'
 import {checkResultsLength} from 'src/shared/utils/vis'
 import {
@@ -92,26 +92,10 @@ const TimeMachineVis: FC<Props> = ({
             <AutoSizer>
               {({width, height}) => {
                 if (isFlagEnabled('flowsUiPagination')) {
-                  const memoizedParseFilesWithFromFlux = memoizeOne(
-                    parseFilesWithFromFlux
-                  )
-                  const memoizedParseFiles = memoizeOne(parseFiles)
-                  const memoizedParseFilesWithObjects = memoizeOne(
-                    parseFilesWithObjects
-                  )
-
-                  let parseFunction = memoizedParseFiles
-                  if (isFlagEnabled('parseObjectsInCSV')) {
-                    parseFunction = memoizedParseFilesWithObjects
-                  }
-                  if (isFlagEnabled('rawCsvFromfluxParser')) {
-                    parseFunction = memoizedParseFilesWithFromFlux
-                  }
-                  const {data, maxColumnCount} = parseFunction(files)
+                  const [parsedResults] = files.flatMap(fromFlux)
                   return (
                     <RawFluxDataTable
-                      data={data}
-                      maxColumnCount={maxColumnCount}
+                      parsedResults={parsedResults}
                       width={width}
                       height={height}
                     />

--- a/src/timeMachine/utils/rawFluxDataTable.test.ts
+++ b/src/timeMachine/utils/rawFluxDataTable.test.ts
@@ -371,6 +371,7 @@ there",5
       data: [[]],
       maxColumnCount: 0,
     }
+
     expect(() => {
       parseFilesWithFromFlux([CSV])
     }).not.toThrow()

--- a/src/timeMachine/utils/rawFluxDataTable.ts
+++ b/src/timeMachine/utils/rawFluxDataTable.ts
@@ -2,6 +2,7 @@ import Papa from 'papaparse'
 import HtmlEntities from 'he'
 import unraw from 'unraw'
 import {fromFlux, FromFluxResult} from '@influxdata/giraffe'
+import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
 
 import {parseChunks} from 'src/shared/parsing/flux/response'
 import {
@@ -32,12 +33,11 @@ export const parseFilesWithFromFlux = (
 export const fromFluxTableTransformer = (
   response: string
 ): {tableData: string[][]; max: number} => {
-  let parsedChunk
-  // TODO(ariel): kill this, since it's a stopgap to prevent improper data from
-  // crashing the app when fromFlux can't handle it
-  try {
-    parsedChunk = fromFlux(response)
-  } catch (error) {
+  const parsedChunk = fromFlux(response)
+  if (parsedChunk.error) {
+    reportErrorThroughHoneyBadger(parsedChunk.error, {
+      name: 'fromFluxTableTransformed function',
+    })
     return {
       tableData: [[]],
       max: 0,

--- a/src/timeMachine/utils/rawFluxDataTable.ts
+++ b/src/timeMachine/utils/rawFluxDataTable.ts
@@ -36,7 +36,7 @@ export const fromFluxTableTransformer = (
   const parsedChunk = fromFlux(response)
   if (parsedChunk.error) {
     reportErrorThroughHoneyBadger(parsedChunk.error, {
-      name: 'fromFluxTableTransformed function',
+      name: 'fromFluxTableTransformer function',
     })
     return {
       tableData: [[]],

--- a/src/timeMachine/utils/rawFluxDataTable.ts
+++ b/src/timeMachine/utils/rawFluxDataTable.ts
@@ -1,7 +1,7 @@
 import Papa from 'papaparse'
 import HtmlEntities from 'he'
 import unraw from 'unraw'
-import {fromFlux} from '@influxdata/giraffe'
+import {fromFlux, FromFluxResult} from '@influxdata/giraffe'
 
 import {parseChunks} from 'src/shared/parsing/flux/response'
 import {
@@ -43,6 +43,12 @@ export const fromFluxTableTransformer = (
       max: 0,
     }
   }
+  return parseFromFluxResults(parsedChunk)
+}
+
+export const parseFromFluxResults = (
+  parsedChunk: FromFluxResult
+): {tableData: string[][]; max: number} => {
   const {
     fluxGroupKeyUnion,
     table,

--- a/yarn.lock
+++ b/yarn.lock
@@ -790,10 +790,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/flux/-/flux-0.5.1.tgz#e39e7a7af9163fc9494422c8fed77f3ae1b68f56"
   integrity sha512-GHlkXBhSdJ2m56JzDkbnKPAqLj3/lexPooacu14AWTO4f2sDGLmzM7r0AxgdtU1M2x7EXNBwgGOI5EOAdN6mkw==
 
-"@influxdata/giraffe@0.36.0":
-  version "0.36.0"
-  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-0.36.0.tgz#1f45767df0384494b54dfbec9b56e3c7cf5994ed"
-  integrity sha512-8g/AMbgUIbKqFZgTrd2YSLPK6+0UcrK+DRRDoEhlkgRLI3QyzWIts5ry8UWcRXYpdbfYpkJzdi0oKkX3CvChmQ==
+"@influxdata/giraffe@0.40.0":
+  version "0.40.0"
+  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-0.40.0.tgz#7b811b5c470152c3d6c30431c3a156fb4773070b"
+  integrity sha512-gt6QYoqy4f5wiA2IWtcgeVpv2xQxj/gnyEozJbcfpyjw2Kj5GEPEhiej+RJTEIfb1mRKJ3YsGZJosGQdc/DGXA==
 
 "@influxdata/influx@0.5.5":
   version "0.5.5"


### PR DESCRIPTION
Closes #201 

### Problem

The way that the RawDataTable is currently built out, the view layer can't parse partial CSVs and just renders blank data

### Solution

Update RawDataTable to accept parsed CSVs rather than raw CSVs, and render the data with an optional offset that is applied for UI pagination. Feature flagged this here:

https://github.com/influxdata/idpe/pull/9011

![UI-pagination](https://user-images.githubusercontent.com/19984220/97209977-335b4300-177a-11eb-898b-d6b7a7b96cf7.gif)
