### PR TITLE
fix: metric selector from populating with previous results

### DIFF
--- a/src/flows/context/results.tsx
+++ b/src/flows/context/results.tsx
@@ -2,6 +2,7 @@ import React, {FC, useContext, useEffect, useState} from 'react'
 import {FluxResult, Resource, ResourceManipulator} from 'src/types/flows'
 import useResource from 'src/flows/context/resource.hook'
 import {FlowContext} from 'src/flows/context/flow.current'
+import {PIPE_DEFINITIONS} from 'src/flows'
 
 export type ResultsContextType = ResourceManipulator<FluxResult>
 
@@ -44,6 +45,9 @@ export const ResultsProvider: FC = ({children}) => {
       try {
         if (result) {
           manipulator.add(id, result)
+          return
+        }
+        if (PIPE_DEFINITIONS[flow.data.get(id).type].family === 'inputs') {
           return
         }
         const ref = flow.data.allIDs


### PR DESCRIPTION
Closes #226 

### Problem

Previously generated raw data results would be passed into the Raw Data View for a metric selector if a previous selector had been run, and the new metric selector had not.

### Solution

Copy pasted some work that Boatie told me would create a separate context for the `results` whenever a new input type was injected, it worked.

![metric-selector](https://user-images.githubusercontent.com/19984220/97489470-cfbd4b00-191c-11eb-8463-98fa1749fe5a.gif)
 