### PR TITLE
fix: make git rev-parse head into single line

### DIFF
--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -2,7 +2,7 @@ module.exports = (() => {
   const GIT_SHA =
     process.env.UI_SHA ||
     require('child_process')
-      .execSync('git rev-parse HEAD')
+      .execSync('git rev-parse --sq HEAD')
       .toString()
 
   // Webpack has some specific rules about formatting


### PR DESCRIPTION
connects idpe #9047. Read the comments on that ticket for more information about how to reproduce. Not sharing here on a public channel.

**`--sq`**
>Usually the output is made one line per flag and parameter. This option makes output a single line, properly quoted for consumption by shell. 

https://git-scm.com/docs/git-rev-parse#Documentation/git-rev-parse.txt---sq

