### PR TITLE
fix(metric-selector): fixed metric selector from clearing cached results when selecting a new bucket in a new metric selector

### DIFF
--- a/src/flows/context/schemaProvider.tsx
+++ b/src/flows/context/schemaProvider.tsx
@@ -70,7 +70,7 @@ export const SchemaProvider: FC<Props> = React.memo(({children}) => {
   }, [data.bucket, lastBucket, update])
 
   useEffect(() => {
-    if (loading !== RemoteDataState.NotStarted || !data.bucket) {
+    if (!data.bucket) {
       return
     }
     if (data.bucket === lastBucket) {
@@ -78,7 +78,7 @@ export const SchemaProvider: FC<Props> = React.memo(({children}) => {
     }
 
     dispatch(getAndSetBucketSchema(data.bucket))
-  }, [data.bucket, lastBucket, loading, dispatch])
+  }, [data.bucket, lastBucket, dispatch])
 
   const schema = useSelector(
     (state: AppState) => state.flow.schema[data.bucket?.name]?.schema || {}

--- a/src/shared/actions/schemaCreator.ts
+++ b/src/shared/actions/schemaCreator.ts
@@ -3,11 +3,9 @@ import {RemoteDataState, Schema} from 'src/types'
 
 export const SET_SCHEMA = 'SET_SCHEMA'
 export const RESET_SCHEMA = 'RESET_SCHEMA'
-export const REMOVE_SCHEMA = 'REMOVE_SCHEMA'
 
 export type Action =
   | ReturnType<typeof setSchema>
-  | ReturnType<typeof removeSchema>
   | ReturnType<typeof resetSchema>
 
 export const setSchema = (
@@ -20,12 +18,6 @@ export const setSchema = (
     bucketName,
     schema,
     status,
-  } as const)
-
-export const removeSchema = (bucketName: string) =>
-  ({
-    type: REMOVE_SCHEMA,
-    bucketName,
   } as const)
 
 export const resetSchema = () =>

--- a/src/shared/actions/schemaThunks.ts
+++ b/src/shared/actions/schemaThunks.ts
@@ -86,7 +86,6 @@ export const getAndSetBucketSchema = (bucket: Bucket) => async (
       validCachedResult = getUnexpiredSchema(state, bucket)
     }
     if (validCachedResult !== null) {
-      dispatch(setSchema(RemoteDataState.Done, bucket.name, validCachedResult))
       return
     } else {
       dispatch(setSchema(RemoteDataState.Loading, bucket.name, {}))

--- a/src/shared/reducers/schema.ts
+++ b/src/shared/reducers/schema.ts
@@ -2,7 +2,6 @@ import {
   RESET_SCHEMA,
   SET_SCHEMA,
   Action,
-  REMOVE_SCHEMA,
 } from 'src/shared/actions/schemaCreator'
 // Types
 import {RemoteDataState, Schema} from 'src/types'
@@ -38,6 +37,7 @@ export const schemaReducer = (
       return {
         ...state,
         schema: {
+          ...state.schema,
           [bucketName]: {
             exp: new Date().getTime() + TEN_MINUTES,
             schema,
@@ -47,14 +47,6 @@ export const schemaReducer = (
       }
     }
 
-    case REMOVE_SCHEMA: {
-      const {bucketName} = action
-      const {schema} = state
-      if (bucketName in schema) {
-        delete schema[bucketName]
-      }
-      return state
-    }
     case RESET_SCHEMA: {
       const {schema} = state
       const now = Date.now()

--- a/src/shared/utils/flowSchemaNormalizer.ts
+++ b/src/shared/utils/flowSchemaNormalizer.ts
@@ -60,17 +60,6 @@ const filterTags = (
       }).length !== 0
   )
 
-const dedupeArray = (array: string[]): string[] => {
-  const cache = {}
-  return array.filter(m => {
-    if (m in cache) {
-      return false
-    }
-    cache[m] = true
-    return true
-  })
-}
-
 export const normalizeSchema = (
   schema: Schema,
   data: PipeData,
@@ -130,12 +119,12 @@ export const normalizeSchema = (
 
   const dedupedTags = dedupeTags(tagResults)
   const filteredFields = filterFields(
-    dedupeArray(fieldResults),
+    [...new Set(fieldResults)],
     lowerCasedSearchTerm,
     data?.field
   )
 
-  const dedupedMeasurements = dedupeArray(measurements)
+  const dedupedMeasurements = [...new Set(measurements)]
 
   dedupedMeasurements.sort((a, b) => a.localeCompare(b))
 


### PR DESCRIPTION
Closes #231 

### Problem 

Selecting a new bucket was clearing the cache for the existing fields list

### Solution

Turns out the reducer was clearing the cache, so we just adjusted that