### PR TITLE
fix(markdown): update Markdown Renderer Library to render the components correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "intersection-observer": "^0.7.0",
     "jsonlint-mod": "^1.7.5",
     "lodash": "^4.3.0",
+    "marked": "^1.2.2",
     "memoize-one": "^4.0.2",
     "moment": "^2.13.0",
     "monaco-editor": "^0.19.2",

--- a/src/dashboards/components/NoteEditorPreview.tsx
+++ b/src/dashboards/components/NoteEditorPreview.tsx
@@ -9,7 +9,7 @@ interface Props {
   onScroll: (e: MouseEvent) => void
 }
 
-const cloudImageRenderer = (): any =>
+const cloudImageRenderer =
   "We don't support images in markdown for security purposes"
 
 const NoteEditorPreview: SFC<Props> = props => {
@@ -26,7 +26,6 @@ const NoteEditorPreview: SFC<Props> = props => {
             className="markdown-format"
             cloudRenderers={{
               image: cloudImageRenderer,
-              imageReference: cloudImageRenderer,
             }}
           />
         </div>

--- a/src/shared/components/views/MarkdownRenderer.test.tsx
+++ b/src/shared/components/views/MarkdownRenderer.test.tsx
@@ -2,30 +2,46 @@ import React from 'react'
 
 import {render} from '@testing-library/react'
 
+function setup(
+  override = {CLOUD: true, text: '\n![](https://i.imgur.com/k3wIaNU.gif)\n'}
+) {
+  const {CLOUD, text} = override
+  jest.mock('src/shared/constants', () => ({CLOUD}))
+  const {
+    MarkdownRenderer,
+  } = require('src/shared/components/views/MarkdownRenderer.tsx')
+
+  const wrapper = render(<MarkdownRenderer text={text} />)
+
+  return wrapper
+}
+
 describe('the MarkdownRenderer wrapper around ReactMarkdown', () => {
   describe('image rendering behavior', () => {
-    const text = '\n![](https://i.imgur.com/k3wIaNU.gif)\n'
-
     describe('in cloud contexts', () => {
       it('renders the image markdown literal, rather than rendering the image', () => {
-        jest.mock('src/shared/constants', () => ({CLOUD: true}))
-        const {
-          MarkdownRenderer,
-        } = require('src/shared/components/views/MarkdownRenderer.tsx')
-
-        const {getByText} = render(<MarkdownRenderer text={text} />)
+        const {getByText} = setup()
         expect(getByText('![](https://i.imgur.com/k3wIaNU.gif)'))
+      })
+
+      it('renders the image markdown literal, when given image html tag', () => {
+        const {getByText} = setup({
+          CLOUD: true,
+          text: '<img src="https://i.random.com/k3wIaNU.gif" />',
+        })
+
+        const markdown = getByText(/gif/)
+        expect(markdown).toBeTruthy()
       })
     })
 
     describe('in oss contexts', () => {
       it('renders the image', () => {
-        jest.mock('src/shared/constants', () => ({CLOUD: false}))
-        const {
-          MarkdownRenderer,
-        } = require('src/shared/components/views/MarkdownRenderer.tsx')
+        const {container} = setup({
+          CLOUD: false,
+          text: '\n![](https://i.imgur.com/k3wIaNU.gif)\n',
+        })
 
-        const {container} = render(<MarkdownRenderer text={text} />)
         expect(
           container.querySelector('img[src*="https://i.imgur.com/k3wIaNU.gif"]')
         )

--- a/src/shared/components/views/MarkdownRenderer.tsx
+++ b/src/shared/components/views/MarkdownRenderer.tsx
@@ -28,7 +28,8 @@ export const MarkdownRenderer: FC<Props> = ({
           if (cloudRenderers?.image) {
             return cloudRenderers.image
           }
-          return `${html.match(/"([^"]+)"/)[0]}`
+          const url = html.match(/"([^"]+)"/)[0]
+          return `![](${url})`
         }
         return html
       },

--- a/src/shared/components/views/MarkdownRenderer.tsx
+++ b/src/shared/components/views/MarkdownRenderer.tsx
@@ -1,24 +1,19 @@
 // Libraries
 import React, {FC} from 'react'
-import ReactMarkdown, {Renderer, Renderers} from 'react-markdown'
+const marked = require('marked')
 
 import {CLOUD} from 'src/shared/constants/index'
 
 interface Props {
   className?: string
-  cloudRenderers?: Renderers
+  cloudRenderers?: any
   text: string
 }
 
 // In cloud environments, we want to render the literal markdown image tag
-// but ReactMarkdown expects a React element wrapping an image to be returned,
-// so we use any
-// see: https://github.com/rexxars/react-markdown/blob/master/index.d.ts#L101
-const imageRenderer: Renderer<HTMLImageElement> = (
-  props: HTMLImageElement
-): any => {
-  return `![](${props.src})`
-}
+// but marked JS expects a React element wrapping an image to be returned,
+// so we use return literal image string for renderer
+// see: https://marked.js.org/using_pro#renderer
 
 export const MarkdownRenderer: FC<Props> = ({
   className = '',
@@ -27,16 +22,42 @@ export const MarkdownRenderer: FC<Props> = ({
 }) => {
   // don't parse images in cloud environments to prevent arbitrary script execution via images
   if (CLOUD) {
-    const renderers = {image: imageRenderer, imageReference: imageRenderer}
+    const renderer = {
+      html(html) {
+        if (html.includes('<img')) {
+          if (cloudRenderers?.image) {
+            return cloudRenderers.image
+          }
+          return `${html.match(/"([^"]+)"/)[0]}`
+        }
+        return html
+      },
+      image(href) {
+        if (cloudRenderers?.image) {
+          return cloudRenderers.image
+        }
+        return `![](${href})`
+      },
+    }
+
+    marked.use({renderer})
+
     return (
-      <ReactMarkdown
-        source={text}
+      <div
         className={className}
-        renderers={{...renderers, ...cloudRenderers}}
-      />
+        dangerouslySetInnerHTML={{
+          __html: marked(text),
+        }}
+      ></div>
     )
   }
 
-  // load images locally to your heart's content. caveat emptor
-  return <ReactMarkdown source={text} className={className} />
+  return (
+    <div
+      className={className}
+      dangerouslySetInnerHTML={{
+        __html: marked(text),
+      }}
+    ></div>
+  )
 }

--- a/src/templates/components/CommunityTemplateReadme.tsx
+++ b/src/templates/components/CommunityTemplateReadme.tsx
@@ -14,7 +14,7 @@ interface OwnProps {
 type ReduxProps = ConnectedProps<typeof connector>
 type Props = OwnProps & ReduxProps
 
-const cloudImageRenderer = (): any =>
+const cloudImageRenderer =
   "We don't support images in markdown for security purposes"
 
 class CommunityTemplateReadmeUnconnected extends Component<Props> {
@@ -34,11 +34,10 @@ class CommunityTemplateReadmeUnconnected extends Component<Props> {
     return (
       <MarkdownRenderer
         text={readme}
-        className="markdown-format community-templates--readme"
         cloudRenderers={{
           image: cloudImageRenderer,
-          imageReference: cloudImageRenderer,
         }}
+        className="markdown-format community-templates--readme"
       />
     )
   }

--- a/src/writeData/components/WriteDataDetailsView.tsx
+++ b/src/writeData/components/WriteDataDetailsView.tsx
@@ -27,6 +27,10 @@ interface Props {
   children?: ReactNode
 }
 
+// marked JS is the new library we are using to render markdown in order to fix idpe#8810.
+// This new issue (ui#257) tracks the work that needs to be done in order to update the plugins
+// to use the new library instead of React markdown: ui#257.
+
 const codeRenderer: Renderer<HTMLPreElement> = (props: any): any => {
   return <WriteDataCodeSnippet code={props.value} language={props.language} />
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7580,6 +7580,11 @@ markdown-escapes@^1.0.0:
   resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.2.tgz#e639cbde7b99c841c0bacc8a07982873b46d2122"
   integrity sha512-lbRZ2mE3Q9RtLjxZBZ9+IMl68DKIXaVAhwvwn9pmjnPLS0h/6kyBMgNhqi1xFJ/2yv6cSyv0jbiZavZv93JkkA==
 
+marked@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-1.2.2.tgz#5d77ffb789c4cb0ae828bfe76250f7140b123f70"
+  integrity sha512-5jjKHVl/FPo0Z6ocP3zYhKiJLzkwJAw4CZoLjv57FkvbUuwOX4LIBBGGcXjAY6ATcd1q9B8UTj5T9Umauj0QYQ==
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
@@ -7609,6 +7614,11 @@ mdn-data@~1.1.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-1.1.4.tgz#50b5d4ffc4575276573c4eedb8780812a8419f01"
   integrity sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA==
+
+"mdurl@~ 1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
+  integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
 
 media-typer@0.3.0:
   version "0.3.0"


### PR DESCRIPTION
Closes influxdata/idpe#8810
- Updated from `ReactMarkdown` to `marked` library
- Updated the renderer code to render literal string with image url if the markdown contains `<img>` tag
- Created a test for markdown renderer when markdown has an img tag it should render literal string