### PR TITLE
fix: comment spacing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,7 +29,8 @@ module.exports = {
     },
   },
   rules: {
-    'curly': ['error', 'all'],
+    'spaced-comment': ['error', 'always'],
+    curly: ['error', 'all'],
     'no-console': ['error', {allow: ['warn', 'error']}],
     'no-empty': 'off',
     'getter-return': 'off',

--- a/cypress/e2e/buckets.test.ts
+++ b/cypress/e2e/buckets.test.ts
@@ -417,7 +417,7 @@ describe.skip('Buckets', () => {
 
       cy.getByTestID('daterange--apply-btn').click()
 
-      //TODO replace this with proper health checks
+      // TODO replace this with proper health checks
       cy.wait(1000)
       cy.getByTestID(`selector-list ${Cypress.env('bucket')}`).click()
       // mymeasurement comes from fixtures/data.txt

--- a/cypress/e2e/buckets.test.ts
+++ b/cypress/e2e/buckets.test.ts
@@ -53,7 +53,7 @@ describe.skip('Buckets', () => {
       const newBucket = '🅱️ucket'
       cy.getByTestID(`bucket-card ${newBucket}`).should('not.exist')
 
-      //create bucket with retention
+      // create bucket with retention
       cy.getByTestID('Create Bucket').click()
       cy.getByTestID('overlay--container').within(() => {
         cy.getByInputName('name').type(newBucket)
@@ -66,7 +66,7 @@ describe.skip('Buckets', () => {
           })
       })
 
-      //assert bucket with retention
+      // assert bucket with retention
       cy.getByTestID(`bucket-card ${newBucket}`)
         .should('exist')
         .within(() => {
@@ -157,16 +157,16 @@ describe.skip('Buckets', () => {
             })
           })
 
-        //assert buckets amount
+        // assert buckets amount
         cy.get('.cf-resource-card').should('have.length', 4)
 
-        //filter a bucket
+        // filter a bucket
         cy.getByTestID('search-widget').type('def')
         cy.get('.cf-resource-card')
           .should('have.length', 1)
           .should('contain', 'defbuck')
 
-        //clear filter and assert all buckets are visible
+        // clear filter and assert all buckets are visible
         cy.getByTestID('search-widget').clear()
         cy.get('.cf-resource-card').should('have.length', 4)
       })
@@ -425,16 +425,16 @@ describe.skip('Buckets', () => {
     })
 
     it('configure telegraf agent', () => {
-      //click "add data" and choose Configure Telegraf Agent
+      // click "add data" and choose Configure Telegraf Agent
       cy.getByTestID('add-data--button').click()
       cy.get('.bucket-add-data--option')
         .contains('Configure Telegraf Agent')
         .click()
 
-      //assert default bucket
+      // assert default bucket
       cy.getByTestID('bucket-dropdown--button').should('contain', 'defbuck')
 
-      //filter plugins and choose system
+      // filter plugins and choose system
       cy.getByTestID('input-field')
         .type('sys')
         .then(() => {
@@ -448,7 +448,7 @@ describe.skip('Buckets', () => {
       cy.getByTestID('telegraf-plugins--System').click()
       cy.getByTestID('next').click()
 
-      //add telegraf name and description
+      // add telegraf name and description
       cy.getByTitle('Telegraf Configuration Name')
         .clear()
         .type('Telegraf from bucket')
@@ -457,7 +457,7 @@ describe.skip('Buckets', () => {
         .type('This is a telegraf description')
       cy.getByTestID('next').click()
 
-      //assert notifications
+      // assert notifications
       cy.getByTestID('notification-success').should(
         'contain',
         'Your configurations have been saved'
@@ -468,7 +468,7 @@ describe.skip('Buckets', () => {
       )
       cy.getByTestID('next').click()
 
-      //assert telegraf card parameters
+      // assert telegraf card parameters
       cy.getByTestID('collector-card--name').should(
         'contain',
         'Telegraf from bucket'

--- a/cypress/e2e/checks.test.ts
+++ b/cypress/e2e/checks.test.ts
@@ -112,15 +112,15 @@ describe('Checks', () => {
   })
 
   it('can validate a deadman check', () => {
-    //create deadman check
+    // create deadman check
     cy.getByTestID('create-check').click()
     cy.getByTestID('create-deadman-check').click()
 
-    //checklist popover and save button check
+    // checklist popover and save button check
     cy.get('.query-checklist--popover').should('be.visible')
     cy.getByTestID('save-cell--button').should('be.disabled')
 
-    //select measurement and field - checklist popover should disappear, save button should activate
+    // select measurement and field - checklist popover should disappear, save button should activate
     cy.getByTestID(`selector-list defbuck`).click()
     cy.getByTestID(`selector-list ${measurement}`).click()
     cy.getByTestID('save-cell--button').should('be.disabled')
@@ -128,15 +128,15 @@ describe('Checks', () => {
     cy.get('.query-checklist--popover').should('not.exist')
     cy.getByTestID('save-cell--button').should('be.enabled')
 
-    //submit the graph
+    // submit the graph
     cy.getByTestID('empty-graph--no-queries')
     cy.getByTestID('time-machine-submit-button').click()
     cy.getByTestID('giraffe-axes').should('exist')
 
-    //navigate to configure check tab
+    // navigate to configure check tab
     cy.getByTestID('checkeo--header alerting-tab').click()
 
-    //conditions inputs check
+    // conditions inputs check
     cy.getByTestID('builder-conditions')
       .should('contain', 'Deadman')
       .within(() => {
@@ -172,7 +172,7 @@ describe('Checks', () => {
         cy.get('.color-dropdown--name').should('have.text', 'OK')
       })
 
-    //name the check; save
+    // name the check; save
     cy.getByTestID('overlay').within(() => {
       cy.getByTestID('page-title')
         .contains('Name this Check')
@@ -184,7 +184,7 @@ describe('Checks', () => {
 
     cy.getByTestID('save-cell--button').click()
 
-    //assert the check card
+    // assert the check card
     cy.getByTestID('check-card--name')
       .contains('Deadman check test')
       .should('exist')

--- a/cypress/e2e/communityTemplates.test.ts
+++ b/cypress/e2e/communityTemplates.test.ts
@@ -28,7 +28,7 @@ describe('Community Templates', () => {
   })
 
   it('displays an error when invalid data is submitted through the field', () => {
-    //on empty
+    // on empty
     cy.getByTestID('lookup-template-button').click()
     cy.getByTestID('notification-error').should('be.visible')
     cy.getByTestID('notification-error--dismiss').click()
@@ -36,7 +36,7 @@ describe('Community Templates', () => {
     cy.getByTestID('notification-error').should('be.visible')
     cy.getByTestID('notification-error--dismiss').click()
 
-    //lookup template errors on github folder
+    // lookup template errors on github folder
     cy.getByTestID('lookup-template-input').type(
       'https://github.com/influxdata/community-templates/tree/master/kafka'
     )
@@ -50,14 +50,14 @@ describe('Community Templates', () => {
 
   describe('installing a community template from the web', () => {
     it('accepts raw github and pluralizes resources properly', () => {
-      //The lookup template accepts github raw link
+      // The lookup template accepts github raw link
       cy.getByTestID('lookup-template-input').type(
         'https://raw.githubusercontent.com/influxdata/influxdb/master/pkger/testdata/dashboard_gauge.yml'
       )
       cy.getByTestID('lookup-template-button').click()
       cy.getByTestID('template-install-overlay').should('be.visible')
 
-      //check that with 1 resource pluralization is correct
+      // check that with 1 resource pluralization is correct
       cy.getByTestID('template-install-title').should(
         'contain',
         'will create 1 resource'
@@ -67,13 +67,13 @@ describe('Community Templates', () => {
         'resources'
       )
 
-      //check that no resources check lead to disabled install button
+      // check that no resources check lead to disabled install button
       cy.getByTestID('heading-Dashboards').click()
       cy.getByTestID('template-install-button').should('exist')
       cy.getByTestID('templates-toggle--dash-1').click()
       cy.getByTestID('template-install-button').should('not.exist')
 
-      //and check that 0 resources pluralization is correct
+      // and check that 0 resources pluralization is correct
       cy.getByTestID('template-install-title').should(
         'contain',
         'will create 0 resources'
@@ -81,14 +81,14 @@ describe('Community Templates', () => {
     })
 
     it('can install using the keyboard "Enter" key and without clicking "Lookup Template"', () => {
-      //The lookup template accepts github raw link
+      // The lookup template accepts github raw link
       cy.getByTestID('lookup-template-input').type(
         'https://raw.githubusercontent.com/influxdata/influxdb/master/pkger/testdata/dashboard_band.yml'
       )
       cy.getByTestID('lookup-template-input').type('{enter}')
       cy.getByTestID('template-install-overlay').should('be.visible')
 
-      //check that with 1 resource pluralization is correct
+      // check that with 1 resource pluralization is correct
       cy.getByTestID('template-install-title').should(
         'contain',
         'will create 1 resource'
@@ -98,13 +98,13 @@ describe('Community Templates', () => {
         'resources'
       )
 
-      //check that no resources check lead to disabled install button
+      // check that no resources check lead to disabled install button
       cy.getByTestID('heading-Dashboards').click()
       cy.getByTestID('template-install-button').should('exist')
       cy.getByTestID('templates-toggle--dash-1').click()
       cy.getByTestID('template-install-button').should('not.exist')
 
-      //and check that 0 resources pluralization is correct
+      // and check that 0 resources pluralization is correct
       cy.getByTestID('template-install-title').should(
         'contain',
         'will create 0 resources'
@@ -251,7 +251,7 @@ describe('Community Templates', () => {
       cy.getByTestID('community-template-readme-overlay-button').click()
       cy.get('.markdown-format').should('contain', 'Setup Instructions')
 
-      //we should confirm the link works
+      // we should confirm the link works
     })
 
     it('deletes templates', () => {

--- a/cypress/e2e/dashboardsIndex.test.ts
+++ b/cypress/e2e/dashboardsIndex.test.ts
@@ -187,11 +187,11 @@ describe('Dashboards', () => {
         cy.contains(
           "Looks like there aren't any Variables, why not create one?"
         )
-        //return to dashboards page
+        // return to dashboards page
         cy.contains('Boards').click()
       })
 
-      //assert dashboard order remains the same
+      // assert dashboard order remains the same
       cy.get('span[data-testid*="dashboard-card--name"]').each((val, index) => {
         cy.wrap(val).contains(expectedDashboardOrder[index])
       })

--- a/cypress/e2e/dashboardsView.test.ts
+++ b/cypress/e2e/dashboardsView.test.ts
@@ -790,7 +790,7 @@ describe('Dashboard', () => {
       })
     })
 
-    //creating new dashboard cell
+    // creating new dashboard cell
     cy.getByTestID('add-cell--button')
       .click()
       .then(() => {
@@ -805,7 +805,7 @@ describe('Dashboard', () => {
           })
       })
 
-    //change to table graph type
+    // change to table graph type
     cy.getByTestID('view-type--dropdown')
       .click()
       .then(() => {
@@ -813,7 +813,7 @@ describe('Dashboard', () => {
       })
     cy.getByTestID(`save-cell--button`).click()
 
-    //assert sorting
+    // assert sorting
     cy.getByTestID(`cell Name this Cell`).then(() => {
       cy.getByTestID('_value-table-header')
         .should('have.class', 'table-graph-cell')

--- a/cypress/e2e/dashboardsView.test.ts
+++ b/cypress/e2e/dashboardsView.test.ts
@@ -107,7 +107,7 @@ describe('Dashboard', () => {
       cy.getByTestID('save-note--button').click()
     })
 
-    //Note Cell controls
+    // Note Cell controls
     cy.getByTestID('add-note--button').click()
     cy.getByTestID('note-editor--overlay').should('be.visible')
     cy.getByTestID('cancel-note--button').click()
@@ -302,7 +302,7 @@ describe('Dashboard', () => {
               .pipe(getSelectedVariable(dashboard.id, 0))
               .should('equal', bucketOne)
 
-            //testing variable controls
+            // testing variable controls
             cy.getByTestID('variable-dropdown')
               .eq(0)
               .should('contain', bucketOne)
@@ -580,7 +580,7 @@ describe('Dashboard', () => {
       })
     })
 
-    /*\
+    /* \
     built to approximate an instance with docker metrics,
     operating with the variables:
         depbuck:

--- a/cypress/e2e/explorer.test.ts
+++ b/cypress/e2e/explorer.test.ts
@@ -495,7 +495,7 @@ describe('DataExplorer', () => {
       cy.getByTestID('variable--timeRangeStart')
       cy.getByTestID('variable--timeRangeStop')
       cy.getByTestID('variable--windowPeriod')
-      //insert variable name by clicking on variable
+      // insert variable name by clicking on variable
       cy.get('.flux-toolbar--variable')
         .first()
         .within(() => {
@@ -545,7 +545,7 @@ describe('DataExplorer', () => {
         'cf-right-click--menu-item__disabled'
       )
 
-      //rename the first tab
+      // rename the first tab
       cy.get('.query-tab')
         .first()
         .trigger('contextmenu')
@@ -686,7 +686,7 @@ describe('DataExplorer', () => {
         // cycle through all the visualizations of the data
         VIS_TYPES.forEach(({type}) => {
           if (type !== 'mosaic' && type !== 'band') {
-            //mosaic graph is behind feature flag
+            // mosaic graph is behind feature flag
             cy.getByTestID('view-type--dropdown').click()
             cy.getByTestID(`view-type--${type}`).click()
             cy.getByTestID(`vis-graphic--${type}`).should('exist')

--- a/cypress/e2e/nav.test.ts
+++ b/cypress/e2e/nav.test.ts
@@ -49,7 +49,7 @@ describe('navigation', () => {
       cy.getByTestID('not-found').should('exist')
     })
 
-    /**\
+    /** \
 
       OSS Only Feature
 
@@ -67,7 +67,7 @@ describe('navigation', () => {
     cy.getByTestID('member-page--header').should('exist')
     cy.url().should('contain', 'about')
 
-    /**\
+    /** \
 
       OSS Only Feature
 
@@ -79,7 +79,7 @@ describe('navigation', () => {
 
     \**/
 
-    /**\
+    /** \
 
       OSS Only Feature
 
@@ -91,7 +91,7 @@ describe('navigation', () => {
 
     \**/
 
-    /**\
+    /** \
 
       OSS Only Feature
 

--- a/cypress/e2e/onboarding.test.ts
+++ b/cypress/e2e/onboarding.test.ts
@@ -21,31 +21,31 @@ describe.skip('Onboarding', () => {
   it('Can Onboard to Quick Start', () => {
     cy.server()
 
-    //Will want to capture response from this
+    // Will want to capture response from this
     cy.route('POST', 'api/v2/setup').as('orgSetup')
 
-    //Check and visit splash page
+    // Check and visit splash page
     cy.getByTestID('init-step--head-main').contains('Welcome to InfluxDB 2.0')
     cy.getByTestID('credits').contains('Powered by')
     cy.getByTestID('credits').contains('InfluxData')
 
-    //Continue
+    // Continue
     cy.getByTestID('onboarding-get-started').click()
 
     cy.location('pathname').should('include', 'onboarding/1')
 
-    //Check navigation bar
+    // Check navigation bar
     cy.getByTestID('nav-step--welcome').click()
 
-    //Check splash page
+    // Check splash page
     cy.getByTestID('init-step--head-main').contains('Welcome to InfluxDB 2.0')
     cy.getByTestID('credits').contains('Powered by')
     cy.getByTestID('credits').contains('InfluxData')
 
-    //Continue
+    // Continue
     cy.getByTestID('onboarding-get-started').click()
 
-    //Check onboarding page - nav bar
+    // Check onboarding page - nav bar
     cy.getByTestID('nav-step--welcome').contains('Welcome')
     cy.getByTestID('nav-step--welcome')
       .parent()
@@ -65,7 +65,7 @@ describe.skip('Onboarding', () => {
         expect($el).to.have.class('unclickable')
       })
 
-    //Check onboarding page headers and controls
+    // Check onboarding page headers and controls
     cy.getByTestID('admin-step--head-main').contains('Setup Initial User')
 
     cy.getByTestID('next').should('be.disabled')
@@ -74,7 +74,7 @@ describe.skip('Onboarding', () => {
       .children('.cf-button--label')
       .contains('Continue')
 
-    //Input fields
+    // Input fields
     cy.getByTestID('input-field--username').type(Cypress.env('username'))
     cy.getByTestID('input-field--password').type(Cypress.env('password'))
     cy.getByTestID('input-field--password-chk').type(Cypress.env('password'))
@@ -94,10 +94,10 @@ describe.skip('Onboarding', () => {
     cy.get('@orgSetup').then(xhr => {
       const orgId: string = xhr.responseBody.org.id
 
-      //wait for new page to load
+      // wait for new page to load
       cy.location('pathname').should('include', 'onboarding/2')
 
-      //check navbar
+      // check navbar
       cy.getByTestID('nav-step--complete').should('have.class', 'current')
 
       cy.getByTestID('nav-step--welcome').should('have.class', 'checkmark')
@@ -107,7 +107,7 @@ describe.skip('Onboarding', () => {
 
       cy.getByTestID('button--conf-later').should('be.visible')
 
-      //advance to Quick Start
+      // advance to Quick Start
       cy.getByTestID('button--quick-start').click()
 
       cy.location('pathname').should('equal', '/orgs/' + orgId)
@@ -119,11 +119,11 @@ describe.skip('Onboarding', () => {
 
     cy.route('POST', 'api/v2/setup').as('orgSetup')
 
-    //Continue
+    // Continue
     cy.getByTestID('onboarding-get-started').click()
     cy.location('pathname').should('include', 'onboarding/1')
 
-    //Input fields
+    // Input fields
     cy.getByTestID('input-field--username').type(Cypress.env('username'))
     cy.getByTestID('input-field--password').type(Cypress.env('password'))
     cy.getByTestID('input-field--password-chk').type(Cypress.env('password'))
@@ -137,13 +137,13 @@ describe.skip('Onboarding', () => {
     cy.get('@orgSetup').then(xhr => {
       const orgId: string = xhr.responseBody.org.id
 
-      //wait for new page to load
+      // wait for new page to load
       cy.location('pathname').should('include', 'onboarding/2')
 
-      //advance to Advanced
+      // advance to Advanced
       cy.getByTestID('button--advanced').click()
 
-      //wait for new page to load
+      // wait for new page to load
 
       cy.location('pathname').should('match', /orgs\/.*\/buckets/)
 
@@ -156,11 +156,11 @@ describe.skip('Onboarding', () => {
 
     cy.route('POST', 'api/v2/setup').as('orgSetup')
 
-    //Continue
+    // Continue
     cy.getByTestID('onboarding-get-started').click()
     cy.location('pathname').should('include', 'onboarding/1')
 
-    //Input fields
+    // Input fields
     cy.getByTestID('input-field--username').type(Cypress.env('username'))
     cy.getByTestID('input-field--password').type(Cypress.env('password'))
     cy.getByTestID('input-field--password-chk').type(Cypress.env('password'))
@@ -173,11 +173,11 @@ describe.skip('Onboarding', () => {
 
     cy.get('@orgSetup').then(xhr => {
       const orgId: string = xhr.responseBody.org.id
-      //wait for new page to load
+      // wait for new page to load
 
       cy.location('pathname').should('include', 'onboarding/2')
 
-      //advance to Advanced
+      // advance to Advanced
       cy.getByTestID('button--conf-later').click()
 
       cy.location('pathname').should('include', orgId)
@@ -185,7 +185,7 @@ describe.skip('Onboarding', () => {
   })
 
   it('respects field requirements', () => {
-    //Continue
+    // Continue
     cy.getByTestID('onboarding-get-started').click()
 
     cy.getByTestID('input-field--username').type(Cypress.env('username'))
@@ -204,7 +204,7 @@ describe.skip('Onboarding', () => {
 
     cy.getByTestID('input-field--password-chk').type('drowssap')
 
-    //check password mismatch
+    // check password mismatch
     cy.getByTestID('form--element-error').should(
       'have.text',
       'Passwords do not match'
@@ -249,7 +249,7 @@ describe.skip('Onboarding', () => {
       .children('.cf-button--label')
       .contains('Continue')
 
-    //check cleared username
+    // check cleared username
     cy.getByTestID('input-field--username').clear()
 
     cy.getByTestID('next')
@@ -264,7 +264,7 @@ describe.skip('Onboarding', () => {
       .children('.cf-button--label')
       .contains('Continue')
 
-    //check cleared password
+    // check cleared password
     cy.getByTestID('input-field--password').clear()
 
     cy.getByTestID('form--element-error').should(
@@ -290,7 +290,7 @@ describe.skip('Onboarding', () => {
       .children('.cf-button--label')
       .contains('Continue')
 
-    //check cleared org name
+    // check cleared org name
     cy.getByTestID('input-field--orgname').clear()
 
     cy.getByTestID('next')
@@ -305,7 +305,7 @@ describe.skip('Onboarding', () => {
       .children('.cf-button--label')
       .contains('Continue')
 
-    //check cleared bucket name
+    // check cleared bucket name
     cy.getByTestID('input-field--bucketname').clear()
 
     cy.getByTestID('next')

--- a/cypress/e2e/orgs.test.ts
+++ b/cypress/e2e/orgs.test.ts
@@ -44,7 +44,7 @@ describe('Orgs', () => {
         .contains(extraText)
         .should('have.length', 1)
 
-      /**\
+      /** \
 
           TODO: translate this test to cloud mode
 

--- a/cypress/e2e/tasks.test.ts
+++ b/cypress/e2e/tasks.test.ts
@@ -138,8 +138,8 @@ http.post(
       })
   })
 
-  //skip until this issue is resolved
-  //https://github.com/influxdata/ui/issues/96
+  // skip until this issue is resolved
+  // https://github.com/influxdata/ui/issues/96
   it.skip('can create a task with an option parameter', () => {
     cy.getByTestID('empty-tasks-list').within(() => {
       cy.getByTestID('add-resource-dropdown--button')
@@ -257,8 +257,8 @@ http.post(
         })
     })
 
-    //skipping until this issue is resolved
-    //https://github.com/influxdata/influxdb/issues/18478
+    // skipping until this issue is resolved
+    // https://github.com/influxdata/influxdb/issues/18478
     it.skip('can clone a task and activate just the cloned one', () => {
       cy.getByTestID('task-card').then(() => {
         cy.get('.context-menu--container')
@@ -290,7 +290,7 @@ http.post(
     })
 
     it('can clone a task and edit it', () => {
-      //clone a task
+      // clone a task
       cy.getByTestID('task-card')
         .first()
         .trigger('mouseover')
@@ -310,7 +310,7 @@ http.post(
 
       cy.getByTestID('task-card').should('have.length', 2)
 
-      //assert the values of the task and change them
+      // assert the values of the task and change them
       cy.getByTestID('task-card--name')
         .eq(1)
         .click()
@@ -338,18 +338,18 @@ http.post(
             })
         })
 
-      //assert changed task name
+      // assert changed task name
       cy.getByTestID('task-card--name').contains('Copy task test')
     })
 
-    //skip until this issue is resolved
-    //https://github.com/influxdata/ui/issues/97
+    // skip until this issue is resolved
+    // https://github.com/influxdata/ui/issues/97
     it.skip('can add a comment into a task', () => {
       cy.getByTestID('task-card--name')
         .first()
         .click()
 
-      //assert textarea and write a comment
+      // assert textarea and write a comment
       cy.getByTestID('flux-editor').within(() => {
         cy.get('textarea.inputarea')
           .should(
@@ -380,7 +380,7 @@ http.post(
           })
       })
 
-      //save and assert notification
+      // save and assert notification
       cy.getByTestID('task-save-btn')
         .click()
         .then(() => {
@@ -393,7 +393,7 @@ http.post(
         .first()
         .click()
 
-      //assert the comment
+      // assert the comment
       cy.getByTestID('flux-editor').within(() => {
         cy.get('textarea.inputarea').should(
           'have.value',

--- a/cypress/e2e/telegrafs.test.ts
+++ b/cypress/e2e/telegrafs.test.ts
@@ -83,7 +83,7 @@ describe('Collectors', () => {
             const text = $el.text()
 
             expect(text.includes('[[outputs.influxdb_v2]]')).to.be.true
-            //expect a default sort to be applied
+            // expect a default sort to be applied
             expect(text.includes(`bucket = "${buckets[0]}"`)).to.be.true
           })
 

--- a/cypress/e2e/tokens.test.ts
+++ b/cypress/e2e/tokens.test.ts
@@ -212,7 +212,7 @@ describe('tokens', () => {
     cy.getByTestID('dropdown-item generate-token--all-access').click()
     cy.getByTestID('overlay--container').should('be.visible')
 
-    //create token
+    // create token
     cy.getByTestID('all-access-token-input').type(all_access_token_name)
     cy.getByTestID('button--save').click()
 

--- a/cypress/e2e/tokens.test.ts
+++ b/cypress/e2e/tokens.test.ts
@@ -440,8 +440,8 @@ describe('tokens', () => {
       })
   })
 
-  //skip until this issue is resolved
-  //https://github.com/influxdata/influxdb/issues/18887
+  // skip until this issue is resolved
+  // https://github.com/influxdata/influxdb/issues/18887
   it.skip('can Select all buckets in Generate Read/Write token', () => {
     // create some extra buckets
     cy.get<Organization>('@org').then(({id, name}: Organization) => {
@@ -452,20 +452,20 @@ describe('tokens', () => {
       })
     })
 
-    //"Select all" button function test
+    // "Select all" button function test
     // open overlay
     cy.getByTestID('dropdown-button--gen-token').click()
     cy.getByTestIDSubStr('dropdown-item').should('have.length', 2)
     cy.getByTestID('dropdown-item generate-token--read-write').click()
     cy.getByTestID('overlay--container').should('be.visible')
 
-    //input token description
+    // input token description
     cy.getByTestID('input-field--descr')
       .clear()
       .type('Select all test')
       .should('have.value', 'Select all test')
 
-    //select all buckets and save
+    // select all buckets and save
     cy.getByTestID('grid--column')
       .eq(0)
       .within(() => {
@@ -482,7 +482,7 @@ describe('tokens', () => {
         })
       })
 
-    //save and assert the notification
+    // save and assert the notification
     cy.getByTestID('button--save')
       .click()
       .then(() => {
@@ -493,19 +493,19 @@ describe('tokens', () => {
 
     cy.getByTestID('token-card Select all test')
 
-    //"All buckets" button function test
+    // "All buckets" button function test
     // open overlay
     cy.getByTestID('dropdown-button--gen-token').click()
     cy.getByTestID('dropdown-item generate-token--read-write').click()
     cy.getByTestID('overlay--container').should('be.visible')
 
-    //input token description
+    // input token description
     cy.getByTestID('input-field--descr')
       .clear()
       .type('All buckets test')
       .should('have.value', 'All buckets test')
 
-    //select all buckets with "All buckets" button and save
+    // select all buckets with "All buckets" button and save
     cy.getByTestID('select-group')
       .eq(0)
       .within(() => {
@@ -522,7 +522,7 @@ describe('tokens', () => {
           .click()
       })
 
-    //save and assert the notification
+    // save and assert the notification
     cy.getByTestID('button--save')
       .click()
       .then(() => {
@@ -533,7 +533,7 @@ describe('tokens', () => {
 
     cy.getByTestID('token-name All buckets test').click()
 
-    //assert that there is read and write permission
+    // assert that there is read and write permission
     cy.getByTestID('permissions-section')
       .eq(0)
       .contains('write')
@@ -543,20 +543,20 @@ describe('tokens', () => {
 
     cy.get('.cf-overlay--dismiss').click()
 
-    //select all - only write permission
+    // select all - only write permission
     // open overlay
     cy.getByTestID('dropdown-button--gen-token').click()
     cy.getByTestIDSubStr('dropdown-item').should('have.length', 2)
     cy.getByTestID('dropdown-item generate-token--read-write').click()
     cy.getByTestID('overlay--container').should('be.visible')
 
-    //input token description
+    // input token description
     cy.getByTestID('input-field--descr')
       .clear()
       .type('Write only test')
       .should('have.value', 'Write only test')
 
-    //select all buckets
+    // select all buckets
     cy.getByTestID('grid--column')
       .eq(0)
       .within(() => {
@@ -573,7 +573,7 @@ describe('tokens', () => {
         })
       })
 
-    //deselect buckets in the read column
+    // deselect buckets in the read column
     cy.getByTestID('grid--column')
       .eq(0)
       .within(() => {
@@ -582,7 +582,7 @@ describe('tokens', () => {
         })
       })
 
-    //save and assert the notification
+    // save and assert the notification
     cy.getByTestID('button--save')
       .click()
       .then(() => {
@@ -593,7 +593,7 @@ describe('tokens', () => {
 
     cy.getByTestID('token-name Write only test').click()
 
-    //assert that there is only write permission
+    // assert that there is only write permission
     cy.getByTestID('permissions-section')
       .eq(0)
       .contains('write')
@@ -609,20 +609,20 @@ describe('tokens', () => {
 
     cy.get('.cf-overlay--dismiss').click()
 
-    //select all - only read permission
+    // select all - only read permission
     // open overlay
     cy.getByTestID('dropdown-button--gen-token').click()
     cy.getByTestIDSubStr('dropdown-item').should('have.length', 2)
     cy.getByTestID('dropdown-item generate-token--read-write').click()
     cy.getByTestID('overlay--container').should('be.visible')
 
-    //input token description
+    // input token description
     cy.getByTestID('input-field--descr')
       .clear()
       .type('Read only test')
       .should('have.value', 'Read only test')
 
-    //select all buckets
+    // select all buckets
     cy.getByTestID('grid--column')
       .eq(0)
       .within(() => {
@@ -639,7 +639,7 @@ describe('tokens', () => {
         })
       })
 
-    //deselect buckets in the read column
+    // deselect buckets in the read column
     cy.getByTestID('grid--column')
       .eq(1)
       .within(() => {
@@ -648,7 +648,7 @@ describe('tokens', () => {
         })
       })
 
-    //save and assert the notification
+    // save and assert the notification
     cy.getByTestID('button--save')
       .click()
       .then(() => {
@@ -659,7 +659,7 @@ describe('tokens', () => {
 
     cy.getByTestID('token-name Read only test').click()
 
-    //assert that there is only write permission
+    // assert that there is only write permission
     cy.getByTestID('permissions-section')
       .eq(0)
       .contains('read')

--- a/cypress/e2e/variables.test.ts
+++ b/cypress/e2e/variables.test.ts
@@ -204,7 +204,7 @@ describe('Variables', () => {
       queryVariableName
     )
 
-    //create variable by uploader
+    // create variable by uploader
     cy.getByTestID('add-resource-dropdown--button').click()
 
     cy.getByTestID('add-resource-dropdown--import').click()

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -2,7 +2,7 @@ import {NotificationEndpoint} from '../../src/types'
 import 'cypress-file-upload'
 
 export const signin = (): Cypress.Chainable<Cypress.Response> => {
-  /*\ OSS login
+  /* \ OSS login
     return cy.setupUser().then(body => {
       return cy
         .request({

--- a/src/alerting/components/AlertingIndex.tsx
+++ b/src/alerting/components/AlertingIndex.tsx
@@ -2,7 +2,7 @@
 import React, {FunctionComponent, useState} from 'react'
 import {Switch, Route} from 'react-router-dom'
 
-//Components
+// Components
 import {Page, SelectGroup, ButtonShape} from '@influxdata/clockface'
 import ChecksColumn from 'src/checks/components/ChecksColumn'
 import RulesColumn from 'src/notifications/rules/components/RulesColumn'

--- a/src/buckets/components/UpdateBucketOverlay.tsx
+++ b/src/buckets/components/UpdateBucketOverlay.tsx
@@ -31,7 +31,7 @@ import * as api from 'src/client'
 import {DEFAULT_SECONDS} from 'src/buckets/components/Retention'
 import {getBucketFailed} from 'src/shared/copy/notifications'
 
-//Types
+// Types
 import {OwnBucket} from 'src/types'
 
 interface DispatchProps {

--- a/src/checks/components/CheckCards.tsx
+++ b/src/checks/components/CheckCards.tsx
@@ -1,7 +1,7 @@
-//Libraries
+// Libraries
 import React, {FunctionComponent} from 'react'
 
-//Components
+// Components
 import CheckCard from 'src/checks/components/CheckCard'
 import FilterList from 'src/shared/components/FilterList'
 import {

--- a/src/checks/components/CheckHistory.tsx
+++ b/src/checks/components/CheckHistory.tsx
@@ -12,7 +12,7 @@ import EventTable from 'src/eventViewer/components/EventTable'
 import GetResources from 'src/resources/components/GetResources'
 import RateLimitAlert from 'src/cloud/components/RateLimitAlert'
 
-//Context
+// Context
 import {ResourceIDsContext} from 'src/alerting/components/AlertHistoryIndex'
 
 // Constants

--- a/src/checks/components/CheckMatchingRulesCard.tsx
+++ b/src/checks/components/CheckMatchingRulesCard.tsx
@@ -21,7 +21,7 @@ import {ruleToDraftRule} from 'src/notifications/rules/utils'
 // API
 import {getNotificationRules as apiGetNotificationRules} from 'src/client'
 
-//Types
+// Types
 import {
   NotificationRule,
   AppState,

--- a/src/cloud/apis/demodata.ts
+++ b/src/cloud/apis/demodata.ts
@@ -3,10 +3,10 @@ import {get} from 'lodash'
 import {getBuckets, getBucket} from 'src/client'
 import AJAX from 'src/utils/ajax'
 
-//Utils
+// Utils
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
-//Types
+// Types
 import {Bucket, DemoBucket, BucketEntities} from 'src/types'
 import {LIMIT} from 'src/resources/constants'
 import {normalize} from 'normalizr'
@@ -16,7 +16,7 @@ import {NormalizedSchema} from 'normalizr'
 const baseURL = '/api/v2/experimental/sampledata'
 
 export const getDemoDataBuckets = async (): Promise<Bucket[]> => {
-  //todo (deniz) convert to fetch
+  // todo (deniz) convert to fetch
   const {data} = await AJAX({
     method: 'GET',
     url: `${baseURL}/buckets`,

--- a/src/cloud/reducers/demodata.ts
+++ b/src/cloud/reducers/demodata.ts
@@ -1,4 +1,4 @@
-//Types
+// Types
 import {Actions} from 'src/cloud/actions/demodata'
 import {RemoteDataState, Bucket} from 'src/types'
 

--- a/src/cloud/reducers/limits.ts
+++ b/src/cloud/reducers/limits.ts
@@ -1,6 +1,6 @@
 import {produce} from 'immer'
 
-//Types
+// Types
 import {Actions, ActionTypes} from 'src/cloud/actions/limits'
 import {RemoteDataState} from 'src/types'
 import {LimitStatus} from 'src/cloud/actions/limits'

--- a/src/cloud/utils/reporting.test.ts
+++ b/src/cloud/utils/reporting.test.ts
@@ -4,7 +4,7 @@ describe('cleaning tags before sending to app-metrics', () => {
   // this throws a typescript error because tags cannot have boolean values. Is checking for boolean values necessary?
   describe.skip('tags with boolean values', () => {
     it('casts booleans as strings', () => {
-      /*const point = {measurement: 'Minus the Bear', fields: {songTitle: 'Pantsuit, ugghhh'}, tags: {truthy: true}}
+      /* const point = {measurement: 'Minus the Bear', fields: {songTitle: 'Pantsuit, ugghhh'}, tags: {truthy: true}}
 
     expect(cleanTags(point).tags).toEqual({truthy: 'true'})
 

--- a/src/members/components/SelectUsers.tsx
+++ b/src/members/components/SelectUsers.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {PureComponent} from 'react'
 
-//Components
+// Components
 import {Dropdown} from '@influxdata/clockface'
 
 // Types

--- a/src/resources/components/GetResources.tsx
+++ b/src/resources/components/GetResources.tsx
@@ -18,7 +18,7 @@ import {getTelegrafs} from 'src/telegrafs/actions/thunks'
 import {getTemplates} from 'src/templates/actions/thunks'
 import {getVariables} from 'src/variables/actions/thunks'
 
-//Utils
+// Utils
 import {event} from 'src/cloud/utils/reporting'
 
 // Types

--- a/src/shared/actions/meThunks.ts
+++ b/src/shared/actions/meThunks.ts
@@ -10,7 +10,7 @@ import {gaEvent, updateReportingContext} from 'src/cloud/utils/reporting'
 // actions
 import {setMe} from 'src/shared/actions/me'
 
-//reducers
+// reducers
 import {MeState} from 'src/shared/reducers/me'
 
 export const getMe = () => async dispatch => {

--- a/src/shared/apis/singleQuery.ts
+++ b/src/shared/apis/singleQuery.ts
@@ -1,7 +1,7 @@
 import {File, CancelBox} from 'src/types'
 import {runQuery} from 'src/shared/apis/query'
 
-/*\
+/* \
 
     Declare this at the module level to create a CancelBox mutex
     for runQuery. this will allow only one query to be run at a time, and

--- a/src/shared/components/EventMarker.tsx
+++ b/src/shared/components/EventMarker.tsx
@@ -8,7 +8,7 @@ import {isInDomain} from 'src/shared/utils/vis'
 // Components
 import BoxTooltip from './BoxTooltip'
 
-//Types
+// Types
 import {StatusRow, LowercaseCheckStatusLevel} from 'src/types'
 import EventMarkerTooltip from './EventMarkerTooltip'
 

--- a/src/shared/components/notifications/Notifications.tsx
+++ b/src/shared/components/notifications/Notifications.tsx
@@ -13,7 +13,7 @@ import {
 import {setFunctions} from 'src/timeMachine/actions/queryBuilder'
 import {dismissNotification as dismissNotificationAction} from 'src/shared/actions/notifications'
 
-//Types
+// Types
 import {AppState, NotificationStyle} from 'src/types'
 
 type ReduxProps = ConnectedProps<typeof connector>

--- a/src/shared/utils/fromFlux.legacy.ts
+++ b/src/shared/utils/fromFlux.legacy.ts
@@ -1,7 +1,7 @@
 import fromFlux from 'src/shared/utils/fromFlux'
 import {newTable, FluxDataType, FromFluxResult} from '@influxdata/giraffe'
 
-/*\
+/* \
 
   This module translates interfaces between giraffe and influxdb
   as we migrate the flux parsing over from the vis library, closer

--- a/src/shared/utils/fromFlux.test.ts
+++ b/src/shared/utils/fromFlux.test.ts
@@ -94,9 +94,9 @@ describe('fromFlux', () => {
 
     expect(actual.table.columns['table'].data).toEqual([0, 1, 2, 3])
 
-    //expect(actual.table.getColumnName('_value (number)')).toEqual('_value')
+    // expect(actual.table.getColumnName('_value (number)')).toEqual('_value')
 
-    //expect(actual.table.getColumnName('_value (string)')).toEqual('_value')
+    // expect(actual.table.getColumnName('_value (string)')).toEqual('_value')
 
     expect(actual.fluxGroupKeyUnion).toEqual([
       '_value (number)',

--- a/src/tasks/components/RunLogsList.tsx
+++ b/src/tasks/components/RunLogsList.tsx
@@ -2,7 +2,7 @@
 import React, {PureComponent} from 'react'
 import _ from 'lodash'
 
-//Components
+// Components
 import {Overlay, IndexList, DapperScrollbars} from '@influxdata/clockface'
 import RunLogRow from 'src/tasks/components/RunLogRow'
 

--- a/src/templates/components/CommunityTemplatesInstalledList.tsx
+++ b/src/templates/components/CommunityTemplatesInstalledList.tsx
@@ -35,7 +35,7 @@ import {TemplateKind} from 'src/client'
 // API
 import {deleteStack} from 'src/templates/api'
 
-//Utils
+// Utils
 import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
 
 import {event} from 'src/cloud/utils/reporting'

--- a/src/timeMachine/actions/queries.ts
+++ b/src/timeMachine/actions/queries.ts
@@ -107,7 +107,7 @@ export const getOrgIDFromBuckets = (
   return get(bucketMatch, 'orgID', null)
 }
 
-//We only need a minimum of one bucket, function, and tag,
+// We only need a minimum of one bucket, function, and tag,
 export const getQueryFromFlux = (text: string) => {
   const ast = parse(text)
 

--- a/src/timeMachine/actions/queryBuilder.ts
+++ b/src/timeMachine/actions/queryBuilder.ts
@@ -34,7 +34,7 @@ import {
   getWindowPeriodFromTimeRange,
 } from 'src/timeMachine/selectors'
 
-//Actions
+// Actions
 import {editActiveQueryWithBuilderSync} from 'src/timeMachine/actions'
 import {setBuckets} from 'src/buckets/actions/creators'
 

--- a/src/timeMachine/selectors/index.ts
+++ b/src/timeMachine/selectors/index.ts
@@ -25,7 +25,7 @@ import {
   millisecondsToDuration,
 } from 'src/shared/utils/duration'
 
-//Selectors
+// Selectors
 import {getAllVariables, asAssignment} from 'src/variables/selectors'
 import {getTimeRange} from 'src/dashboards/selectors'
 
@@ -204,15 +204,15 @@ export const getFillColumnsSelection = (state: AppState): string[] => {
   )
 
   if (graphType === 'mosaic') {
-    //user hasn't selected a fill column yet
+    // user hasn't selected a fill column yet
     if (preference === null) {
-      //check if value is a string[]
+      // check if value is a string[]
       for (const key of validFillColumns) {
         if (key.startsWith('_value')) {
           return [key]
         }
       }
-      //check if value is a numeric column
+      // check if value is a numeric column
       if (table.columnKeys.includes('_value')) {
         return []
       }

--- a/src/utils/autoAggregateRequirements.ts
+++ b/src/utils/autoAggregateRequirements.ts
@@ -1,4 +1,4 @@
-//Utils
+// Utils
 import {buildQuery} from 'src/timeMachine/utils/queryBuilder'
 import {get, isNull} from 'lodash'
 


### PR DESCRIPTION
adds a rule enforcing whitespace after starting a comment line:
`// this is a comment`
vs
`//this is a comment`

99% of the time we used the former.  the 1% of the time I saw the latter it bugged me.  a computer should be enforcing this.  