### PR TITLE
test(e2e): checks - visiting documentation through external link

### DIFF
--- a/cypress/e2e/shared/checks.test.ts
+++ b/cypress/e2e/shared/checks.test.ts
@@ -342,22 +342,24 @@ describe('Checks', () => {
     })
   })
 
-  describe('Invoke external links', () => {
-    it('can visit documentation through a link on the checks page', () => {
+  describe('External links', () => {
+    it('can assert the link on the checks page points to "Create checks" article in documentation ', () => {
       cy.getByTestID('Checks--question-mark')
         .trigger('mouseover')
         .then(() => {
-          cy.getByTestID('Checks--question-mark--tooltip--contents').within(
-            () => {
-              cy.get('a')
-                .invoke('removeAttr', 'target')
-                .click()
-              cy.url().should(
-                'include',
-                'https://docs.influxdata.com/influxdb/v2.0/monitor-alert/checks/create/'
-              )
-            }
-          )
+          cy.getByTestID('Checks--question-mark--tooltip--contents')
+            .should('be.visible')
+            .within(() => {
+              cy.get('a').then($a => {
+                const url = $a.prop('href')
+                cy.request(url)
+                  .its('body')
+                  .should(
+                    'include',
+                    'https://docs.influxdata.com/influxdb/v2.0/monitor-alert/checks/create/'
+                  )
+              })
+            })
         })
     })
   })

--- a/cypress/e2e/shared/checks.test.ts
+++ b/cypress/e2e/shared/checks.test.ts
@@ -341,4 +341,24 @@ describe('Checks', () => {
       cy.getByTestID('inline-labels--empty').should('exist')
     })
   })
+
+  describe('Invoke external links', () => {
+    it('can visit documentation through a link on the checks page', () => {
+      cy.getByTestID('Checks--question-mark')
+        .trigger('mouseover')
+        .then(() => {
+          cy.getByTestID('Checks--question-mark--tooltip--contents').within(
+            () => {
+              cy.get('a')
+                .invoke('removeAttr', 'target')
+                .click()
+              cy.url().should(
+                'include',
+                'https://docs.influxdata.com/influxdb/v2.0/monitor-alert/checks/create/'
+              )
+            }
+          )
+        })
+    })
+  })
 })


### PR DESCRIPTION
New test for asserting an external link on the checks page points to a specific page in the documentation.