### PR TITLE
chore: update giraffe to 0.42.0 the one that switched to webpack builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "@influxdata/clockface": "2.3.5",
     "@influxdata/flux": "^0.5.1",
     "@influxdata/flux-lsp-browser": "^0.5.21",
-    "@influxdata/giraffe": "0.40.0",
+    "@influxdata/giraffe": "^0.42.2",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -790,10 +790,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/flux/-/flux-0.5.1.tgz#e39e7a7af9163fc9494422c8fed77f3ae1b68f56"
   integrity sha512-GHlkXBhSdJ2m56JzDkbnKPAqLj3/lexPooacu14AWTO4f2sDGLmzM7r0AxgdtU1M2x7EXNBwgGOI5EOAdN6mkw==
 
-"@influxdata/giraffe@0.40.0":
-  version "0.40.0"
-  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-0.40.0.tgz#7b811b5c470152c3d6c30431c3a156fb4773070b"
-  integrity sha512-gt6QYoqy4f5wiA2IWtcgeVpv2xQxj/gnyEozJbcfpyjw2Kj5GEPEhiej+RJTEIfb1mRKJ3YsGZJosGQdc/DGXA==
+"@influxdata/giraffe@^0.42.2":
+  version "0.42.2"
+  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-0.42.2.tgz#8185b8c9ef7ed88ad1d8f337d72474c9fdc3a964"
+  integrity sha512-/jIjbt+a5tlgUccm24NENBgjIdYm93FwgiCY+21RmIT/tX2TPrd5a75ma5YH0wtIwLUfZWu4zYIG7WxoTQw2RA==
 
 "@influxdata/influx@0.5.5":
   version "0.5.5"


### PR DESCRIPTION
Updates to the latest giraffe. Should be no different to the application.

See: https://github.com/influxdata/giraffe/pull/349