### PR TITLE
chore: update giraffe to resolve tooltip z-index issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "@influxdata/clockface": "2.3.5",
     "@influxdata/flux": "^0.5.1",
     "@influxdata/flux-lsp-browser": "^0.5.21",
-    "@influxdata/giraffe": "^0.42.2",
+    "@influxdata/giraffe": "0.43.0",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -790,10 +790,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/flux/-/flux-0.5.1.tgz#e39e7a7af9163fc9494422c8fed77f3ae1b68f56"
   integrity sha512-GHlkXBhSdJ2m56JzDkbnKPAqLj3/lexPooacu14AWTO4f2sDGLmzM7r0AxgdtU1M2x7EXNBwgGOI5EOAdN6mkw==
 
-"@influxdata/giraffe@^0.42.2":
-  version "0.42.2"
-  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-0.42.2.tgz#8185b8c9ef7ed88ad1d8f337d72474c9fdc3a964"
-  integrity sha512-/jIjbt+a5tlgUccm24NENBgjIdYm93FwgiCY+21RmIT/tX2TPrd5a75ma5YH0wtIwLUfZWu4zYIG7WxoTQw2RA==
+"@influxdata/giraffe@0.43.0":
+  version "0.43.0"
+  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-0.43.0.tgz#cb4c72d15a47692e115ea6341666f3f2de99fd56"
+  integrity sha512-LoWZ0TyRTGI6boPLR0jVgE415/aeycxzU6Hc/Xjg906apr0AJxO2G+wfOKCH7TjbaTloZrS56SQlH8dcxcA3/A==
 
 "@influxdata/influx@0.5.5":
   version "0.5.5"
@@ -7614,11 +7614,6 @@ mdn-data@~1.1.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-1.1.4.tgz#50b5d4ffc4575276573c4eedb8780812a8419f01"
   integrity sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA==
-
-"mdurl@~ 1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
-  integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
 
 media-typer@0.3.0:
   version "0.3.0"


### PR DESCRIPTION
Closes https://github.com/influxdata/giraffe/issues/357

`yarn install` also happened to remove an unnecessary entry named `mdurl`. I have confirmed with @Palakp41 that this is not needed and should be removed. I will keep this change because it was automatically made as a result of `yarn install`.