### PR TITLE
fix: tooltip same units

### DIFF
--- a/src/shared/utils/vis.ts
+++ b/src/shared/utils/vis.ts
@@ -48,6 +48,7 @@ interface GetFormatterOptions {
   timeZone?: TimeZone
   trimZeros?: boolean
   timeFormat?: string
+  format?: boolean
 }
 
 export const getFormatter = (
@@ -59,6 +60,7 @@ export const getFormatter = (
     timeZone,
     trimZeros = true,
     timeFormat = DEFAULT_TIME_FORMAT,
+    format,
   }: GetFormatterOptions = {}
 ): null | ((x: any) => string) => {
   if (columnType === 'number' && base === '2') {
@@ -66,6 +68,7 @@ export const getFormatter = (
       prefix,
       suffix,
       significantDigits: VIS_SIG_DIGITS,
+      format,
     })
   }
 
@@ -75,6 +78,7 @@ export const getFormatter = (
       suffix,
       significantDigits: VIS_SIG_DIGITS,
       trimZeros,
+      format,
     })
   }
 

--- a/src/shared/utils/vis.ts
+++ b/src/shared/utils/vis.ts
@@ -82,13 +82,13 @@ export const getFormatter = (
     })
   }
 
-  if(columnType === 'number' && base === ''){
+  if (columnType === 'number' && base === '') {
     return siPrefixFormatter({
       prefix,
       suffix,
       significantDigits: VIS_SIG_DIGITS,
       trimZeros,
-      format:true,
+      format: true,
     })
   }
 

--- a/src/shared/utils/vis.ts
+++ b/src/shared/utils/vis.ts
@@ -72,13 +72,23 @@ export const getFormatter = (
     })
   }
 
-  if (columnType === 'number') {
+  if (columnType === 'number' && base === '10') {
     return siPrefixFormatter({
       prefix,
       suffix,
       significantDigits: VIS_SIG_DIGITS,
       trimZeros,
       format,
+    })
+  }
+
+  if(columnType === 'number' && base === ''){
+    return siPrefixFormatter({
+      prefix,
+      suffix,
+      significantDigits: VIS_SIG_DIGITS,
+      trimZeros,
+      format:true,
     })
   }
 


### PR DESCRIPTION
This is to close #208 

This is not a perfect solution, because we do not currently allow users to truly edit the tooltip and what it displays. This allows giraffe to call the no formatter option that was added. In the XY plot we do allow people to choose a no format option, and that should do no formatting on the tooltip as well. 

We are planning to come up with a more robust solution in the giraffe upgrade project. I dont want to try and shoehorn in a solution when we are going to get a fleshed out solution in a few weeks