### PR TITLE
feat(rfc): unity swagger.yml Users and Invites draft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ cypress.env.json
 junit.xml
 npm-error.log
 src/client/generatedRoutes.ts
+src/client/unityRoutes.ts

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "tsc:cypress": "tsc -p ./cypress/tsconfig.json --noEmit --pretty --skipLibCheck",
     "cy": "CYPRESS_baseUrl=http://localhost:9999 cypress open",
     "cy:dev": "CYPRESS_baseUrl=http://kubernetes.docker.internal:8080 cypress open",
-    "generate": "oats https://raw.githubusercontent.com/influxdata/influxdb/master/http/swagger.yml > ./src/client/generatedRoutes.ts"
+    "generate": "oats https://raw.githubusercontent.com/influxdata/influxdb/master/http/swagger.yml > ./src/client/generatedRoutes.ts",
+    "unity": "oats ./src/client/unity.yml > ./src/client/unityRoutes.ts"
   },
   "author": "",
   "devDependencies": {

--- a/src/client/unity.yml
+++ b/src/client/unity.yml
@@ -61,6 +61,41 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  "/orgs/{orgID}/invites":
+    post:
+      operationId: PostOrgsIDInvites
+      tags:
+        - Invites
+        - Organizations
+      summary: Creates an invite to an organization
+      parameters:
+        - $ref: "#/components/parameters/TraceSpan"
+        - in: path
+          name: orgID
+          schema:
+            type: string
+          required: true
+          description: The organization ID.
+      requestBody:
+        description: Invite to be sent
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Invite"
+      responses:
+        "201":
+          description: Invite sent
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Invite"
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 components:
   parameters:
     TraceSpan:
@@ -100,6 +135,45 @@ components:
           description: Message is a human-readable message.
           type: string
       required: [code, message]
+    Invite:
+      properties:
+        id:
+          description: the idpe id of the invite
+          readOnly: true
+          type: string
+        email:
+          type: string
+        role:
+          type: string
+          enum:
+            - member
+            - owner
+        expiresAt:
+          format: date-time
+          type: string
+        links:
+          type: object
+          readOnly: true
+          example:
+            self: "/unity/v2/invites/1"
+          properties:
+            self:
+              type: string
+              format: uri
+      required: [id, email, role]
+    Invites:
+      type: object
+      properties:
+        links:
+          type: object
+          properties:
+            self:
+              type: string
+              format: uri
+        invites:
+          type: array
+          items:
+            $ref: "#/components/schemas/Invite"
     User:
       properties:
         id:

--- a/src/client/unity.yml
+++ b/src/client/unity.yml
@@ -1,0 +1,112 @@
+openapi: "3.0.0"
+info:
+  title: Unity API Service
+  version: 0.1.0
+servers:
+  - url: /unity/v2 # to be determined
+paths:
+  "/orgs/{orgID}/users":
+      get:
+        operationId: GetUsers
+        tags:
+          - Users
+        parameters:
+          - $ref: "#/components/parameters/TraceSpan"
+          - in: path
+            name: orgID
+            description: Specifies the organization ID of the User.
+            required: true
+            schema:
+              type: string
+        responses:
+          "200":
+            description: A list of users
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/Users"
+          default:
+            description: Unexpected error
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/Error"
+components:
+  parameters:
+    TraceSpan:
+      in: header
+      name: Zap-Trace-Span
+      description: OpenTracing span context
+      example:
+        trace_id: "1"
+        span_id: "1"
+        baggage:
+          key: value
+      required: false
+      schema:
+        type: string
+  schemas:
+    Error:
+      properties:
+        code:
+          description: Code is the machine-readable error code.
+          readOnly: true
+          type: string
+          # This set of enumerations must remain in sync with the constants defined in errors.go
+          enum:
+            - internal error
+            - not found
+            - conflict
+            - invalid
+            - unprocessable entity
+            - empty value
+            - unavailable
+            - forbidden
+            - too many requests
+            - unauthorized
+            - method not allowed
+        message:
+          readOnly: true
+          description: Message is a human-readable message.
+          type: string
+      required: [code, message]
+    User:
+      properties:
+        id:
+          description: the idpe id of the user
+          readOnly: true
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+        email:
+          type: string
+        role:
+          type: string
+          enum:
+            - member
+            - owner
+        links:
+          type: object
+          readOnly: true
+          example:
+            self: "/unity/v2/users/1"
+          properties:
+            self:
+              type: string
+              format: uri
+      required: [id, email, role]
+    Users:
+      type: object
+      properties:
+        links:
+          type: object
+          properties:
+            self:
+              type: string
+              format: uri
+        users:
+          type: array
+          items:
+            $ref: "#/components/schemas/User"

--- a/src/client/unity.yml
+++ b/src/client/unity.yml
@@ -5,6 +5,71 @@ info:
 servers:
   - url: /unity/v2 # to be determined
 paths:
+  "/orgs/{orgID}/invites":
+    post:
+      operationId: PostOrgsIDInvites
+      tags:
+        - Invites
+        - Organizations
+      summary: Creates an invite to an organization
+      parameters:
+        - $ref: "#/components/parameters/TraceSpan"
+        - in: path
+          name: orgID
+          schema:
+            type: string
+          required: true
+          description: The organization ID.
+      requestBody:
+        description: Invite to be sent
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Invite"
+      responses:
+        "201":
+          description: Invite sent
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Invite"
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  "/orgs/{orgID}/invites/{inviteID}":
+    delete:
+      operationId: DeleteOrgsIDInviteID
+      tags:
+        - Invites
+        - Organizations
+      summary: Remove an invite to an organization
+      parameters:
+        - $ref: "#/components/parameters/TraceSpan"
+        - in: path
+          name: inviteID
+          schema:
+            type: string
+          required: true
+          description: The ID of the invite to remove.
+        - in: path
+          name: orgID
+          schema:
+            type: string
+          required: true
+          description: The organization ID.
+      responses:
+        "204":
+          description: Invite removed
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   "/orgs/{orgID}/users":
       get:
         operationId: GetUsers
@@ -55,41 +120,6 @@ paths:
       responses:
         "204":
           description: User removed
-        default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-  "/orgs/{orgID}/invites":
-    post:
-      operationId: PostOrgsIDInvites
-      tags:
-        - Invites
-        - Organizations
-      summary: Creates an invite to an organization
-      parameters:
-        - $ref: "#/components/parameters/TraceSpan"
-        - in: path
-          name: orgID
-          schema:
-            type: string
-          required: true
-          description: The organization ID.
-      requestBody:
-        description: Invite to be sent
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/Invite"
-      responses:
-        "201":
-          description: Invite sent
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Invite"
         default:
           description: Unexpected error
           content:

--- a/src/client/unity.yml
+++ b/src/client/unity.yml
@@ -70,6 +70,40 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  "/orgs/{orgID}/invites/{inviteID}/resend":
+    post:
+      operationId: DeleteOrgsIDInviteID
+      tags:
+        - Invites
+        - Organizations
+      summary: Re-sends an invite
+      parameters:
+        - $ref: "#/components/parameters/TraceSpan"
+        - in: path
+          name: inviteID
+          schema:
+            type: string
+          required: true
+          description: The ID of the invite to resend.
+        - in: path
+          name: orgID
+          schema:
+            type: string
+          required: true
+          description: The organization ID.
+      responses:
+        "200":
+          description: Invite resent
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Invite"
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   "/orgs/{orgID}/users":
       get:
         operationId: GetUsers

--- a/src/client/unity.yml
+++ b/src/client/unity.yml
@@ -31,6 +31,36 @@ paths:
               application/json:
                 schema:
                   $ref: "#/components/schemas/Error"
+  "/orgs/{orgID}/users/{userID}":
+    delete:
+      operationId: DeleteOrgsIDUserID
+      tags:
+        - Users
+        - Organizations
+      summary: Deletes a user
+      parameters:
+        - $ref: "#/components/parameters/TraceSpan"
+        - in: path
+          name: userID
+          schema:
+            type: string
+          required: true
+          description: The ID of the user to remove.
+        - in: path
+          name: orgID
+          schema:
+            type: string
+          required: true
+          description: The organization ID.
+      responses:
+        "204":
+          description: User removed
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 components:
   parameters:
     TraceSpan:


### PR DESCRIPTION
Closes: #287 

This is a draft for the `Users` and `Invites` unification API client.  If we can knock out a contract between Quartz and the `ui` then e-commerce and ui can start working in parallel 😸 .

   - [x] Delete User
   - [x] Get Users
   - [x] Delete Invitation
   - [x] Resend Invitation
   - [x] Create Invitation

