### PR TITLE
fix(de): cancel button cancels all running queries

### DIFF
--- a/src/flows/components/header/Submit.tsx
+++ b/src/flows/components/header/Submit.tsx
@@ -24,6 +24,7 @@ import {notify} from 'src/shared/actions/notifications'
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'
+import {cancelAllRunningQueries} from 'src/timeMachine/actions/queries'
 
 // Types
 import {RemoteDataState} from 'src/types'
@@ -122,6 +123,7 @@ export const Submit: FC = () => {
           onSubmit={submit}
           onNotify={fakeNotify}
           queryID=""
+          cancelAllRunningQueries={cancelAllRunningQueries}
         />
         <SquareButton
           active={active}

--- a/src/timeMachine/actions/queries.ts
+++ b/src/timeMachine/actions/queries.ts
@@ -245,18 +245,6 @@ export const setQueryByHashID = (queryID: string, result: any): void => {
     })
 }
 
-export const getQueryStatusByID = (queryID: string): any => {
-  if (queryID in queryReference) {
-    return queryReference[queryID]
-  }
-  return {
-    cancel: new AbortController(),
-    issuedAt: Date.now(),
-    promise: Promise.resolve(),
-    status: RemoteDataState.NotStarted,
-  }
-}
-
 export const executeQueries = (abortController?: AbortController) => async (
   dispatch,
   getState: GetState

--- a/src/timeMachine/actions/queries.ts
+++ b/src/timeMachine/actions/queries.ts
@@ -220,8 +220,9 @@ const cancelQuerysByHashIDs = (queryIDs?: string[]): void => {
   })
 }
 
-export const cancelAllRunningQueries = (): void => {
+export const cancelAllRunningQueries = () => dispatch => {
   cancelQuerysByHashIDs(Object.keys(queryReference))
+  dispatch(setQueryResults(RemoteDataState.Done, null, null))
 }
 
 export const setQueryByHashID = (queryID: string, result: any): void => {

--- a/src/timeMachine/components/SubmitQueryButton.tsx
+++ b/src/timeMachine/components/SubmitQueryButton.tsx
@@ -20,7 +20,6 @@ import {getActiveTimeMachine, getActiveQuery} from 'src/timeMachine/selectors'
 import {event} from 'src/cloud/utils/reporting'
 import {queryCancelRequest} from 'src/shared/copy/notifications'
 import {
-  cancelQueryByHashID,
   cancelAllRunningQueries,
   generateHashedQueryID,
 } from 'src/timeMachine/actions/queries'
@@ -78,7 +77,7 @@ class SubmitQueryButton extends PureComponent<Props> {
   }
 
   componentWillUnmount() {
-    cancelAllRunningQueries()
+    this.props.cancelAllRunningQueries()
   }
 
   public render() {
@@ -136,11 +135,7 @@ class SubmitQueryButton extends PureComponent<Props> {
     if (this.props.onNotify) {
       this.props.onNotify(queryCancelRequest())
     }
-    if (this.props.queryID) {
-      cancelQueryByHashID(this.props.queryID)
-    } else {
-      cancelAllRunningQueries()
-    }
+    this.props.cancelAllRunningQueries()
   }
 }
 
@@ -162,6 +157,7 @@ const mstp = (state: AppState) => {
 const mdtp = {
   onSubmit: saveAndExecuteQueries,
   onNotify: notify,
+  cancelAllRunningQueries: cancelAllRunningQueries,
 }
 
 const connector = connect(mstp, mdtp)


### PR DESCRIPTION
After clicking the cancel on data explorer, we don't get into the componentDidUpdate life-cycle because we are not updating the state of the query status in redux. The query status in the props is from the redux state query results which connects to all the query. Adding a dispatch to update the query status for query result to done when cancelled is clicked, fixes this issue: #idpe/7683 (https://app.zenhub.com/workspaces/applicationmonitoring-5e3b05772922e316b3a210a4/issues/influxdata/idpe/7683) 

![Kapture 2020-11-10 at 14 02 44](https://user-images.githubusercontent.com/26464594/98739228-d9ec3a00-235d-11eb-8373-22a05e2a1d96.gif)
