### PR TITLE
chore: clean up usage of process.env

### DIFF
--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -13,6 +13,13 @@ import {InfluxColors} from '@influxdata/clockface'
 
 import {AutoRefreshStatus} from 'src/types'
 
+function formatConstant(constant: string) {
+  if (!constant) {
+    return ''
+  }
+  return constant.trim()
+}
+
 export const DEFAULT_TIME_FORMAT = 'YYYY-MM-DD HH:mm:ss ZZ'
 
 export const DROPDOWN_MENU_MAX_HEIGHT = 240
@@ -52,15 +59,17 @@ export const MIN_HANDLE_PIXELS = 20
 export const MAX_SIZE = 1
 export const MIN_SIZE = 0
 
-export const VERSION = process.env.npm_package_version
-export const GIT_SHA = process.env.GIT_SHA
-export const BASE_PATH = process.env.STATIC_PREFIX
-export const API_BASE_PATH = process.env.API_PREFIX
+export const VERSION = formatConstant(process.env.npm_package_version)
+export const GIT_SHA = formatConstant(process.env.GIT_SHA)
+export const BASE_PATH = formatConstant(process.env.STATIC_PREFIX)
+export const API_BASE_PATH = formatConstant(process.env.API_PREFIX)
+export const HONEYBADGER_KEY = formatConstant(process.env.HONEYBADGER_KEY)
+export const HONEYBADGER_ENV = formatConstant(process.env.HONEYBADGER_ENV)
 
 export const CLOUD = !!process.env.CLOUD_URL
 export const CLOUD_SIGNIN_PATHNAME = '/api/v2/signin'
 export const CLOUD_BILLING_VISIBLE = CLOUD
-export const CLOUD_URL = process.env.CLOUD_URL
+export const CLOUD_URL = formatConstant(process.env.CLOUD_URL)
 export const CLOUD_CHECKOUT_PATH = '/checkout'
 export const CLOUD_BILLING_PATH = '/billing'
 export const CLOUD_USAGE_PATH = '/usage'

--- a/src/shared/utils/errors.ts
+++ b/src/shared/utils/errors.ts
@@ -1,15 +1,20 @@
 import {ErrorInfo} from 'react'
 import HoneyBadger from 'honeybadger-js'
-import {CLOUD, GIT_SHA} from 'src/shared/constants'
+import {
+  CLOUD,
+  GIT_SHA,
+  HONEYBADGER_KEY,
+  HONEYBADGER_ENV,
+} from 'src/shared/constants'
 
 import {getUserFlags} from 'src/shared/utils/featureFlag'
 import {event} from 'src/cloud/utils/reporting'
 
 if (CLOUD) {
   HoneyBadger.configure({
-    apiKey: process.env.HONEYBADGER_KEY,
+    apiKey: HONEYBADGER_KEY,
     revision: GIT_SHA,
-    environment: process.env.HONEYBADGER_ENV,
+    environment: HONEYBADGER_ENV,
   })
 }
 


### PR DESCRIPTION
Usages of process.env are now reduced to two files - the constants file and an env.ts.

Added and used a constants formatting function to trim whitespace from all string constants that weren't hard coded to a value otherwise.

The process.env usage in env.ts is not easily removed - that file uses a module.exports to export a lambda function and I could not find a way to have that function import information from the general constants file. Given that there are a number of comments about webpack, it seems that file is build time related and thus process.env usage may be appropriate.

Assuming there are no issues with the env.ts remaining in its current state, this closes ticket #237 .