### PR TITLE
feat: connect timerange to metric selector

### DIFF
--- a/src/flows/context/schemaProvider.tsx
+++ b/src/flows/context/schemaProvider.tsx
@@ -4,6 +4,7 @@ import {useDispatch, useSelector} from 'react-redux'
 
 // Contexts
 import {PipeContext} from 'src/flows/context/pipe'
+import {FlowContext} from 'src/flows/context/flow.current'
 
 // Utils
 import {normalizeSchema} from 'src/shared/utils/flowSchemaNormalizer'
@@ -43,6 +44,7 @@ export const SchemaContext = React.createContext<SchemaContextType>(
 
 export const SchemaProvider: FC<Props> = React.memo(({children}) => {
   const {data, update} = useContext(PipeContext)
+  const {flow} = useContext(FlowContext)
   const [searchTerm, setSearchTerm] = useState('')
   const [lastBucket, setLastBucket] = useState(data.bucket)
   const dispatch = useDispatch()
@@ -77,8 +79,8 @@ export const SchemaProvider: FC<Props> = React.memo(({children}) => {
       return
     }
 
-    dispatch(getAndSetBucketSchema(data.bucket))
-  }, [data.bucket, lastBucket, dispatch])
+    dispatch(getAndSetBucketSchema(data.bucket, flow.range))
+  }, [data.bucket, lastBucket, dispatch, flow.range])
 
   const schema = useSelector(
     (state: AppState) => state.flow.schema[data.bucket?.name]?.schema || {}


### PR DESCRIPTION
Closes #315 

### Problem 

Selecting a bucket with lots of data for the past 4 days makes the metric selector slow

### Solution

Use the time provided within the flow as a basis for the metric selector range