### PR TITLE
fix: visualization crash

### DIFF
--- a/src/flows/pipes/Visualization/view.tsx
+++ b/src/flows/pipes/Visualization/view.tsx
@@ -66,7 +66,7 @@ const Visualization: FC<PipeProp> = ({Context}) => {
     })
   }
 
-  const dataExists = Object.entries(results.parsed).length
+  const dataExists = results.parsed && Object.entries(results.parsed).length
   const configureButtonStatus = dataExists
     ? ComponentStatus.Default
     : ComponentStatus.Disabled


### PR DESCRIPTION
the visualization panel expected not to be rendered by the resizer component unless the results had parsed data. something along the line changed, and it broke, so lets guard against that while we figure out some tests