### PR TITLE
fix(de): add condition to return empty string for empty values

### DIFF
--- a/src/timeMachine/reducers/index.ts
+++ b/src/timeMachine/reducers/index.ts
@@ -1173,7 +1173,7 @@ export const buildActiveQuery = (draftState: TimeMachineState) => {
 
   if (isConfigValid(draftQuery.builderConfig)) {
     draftQuery.text = buildQuery(draftQuery.builderConfig)
-  } else if (!draftQuery.text) {
+  } else {
     draftQuery.text = ''
   }
 }

--- a/src/timeMachine/reducers/index.ts
+++ b/src/timeMachine/reducers/index.ts
@@ -779,7 +779,6 @@ export const timeMachineReducer = (
         const {index, builderAggregateFunctionType} = action.payload
         const draftQuery = draftState.draftQueries[draftState.activeQueryIndex]
 
-        buildActiveQuery(draftState)
         if (
           draftQuery &&
           draftQuery.builderConfig &&
@@ -793,6 +792,7 @@ export const timeMachineReducer = (
             index
           ].aggregateFunctionType = builderAggregateFunctionType
         }
+        buildActiveQuery(draftState)
       })
     }
 
@@ -1173,7 +1173,7 @@ export const buildActiveQuery = (draftState: TimeMachineState) => {
 
   if (isConfigValid(draftQuery.builderConfig)) {
     draftQuery.text = buildQuery(draftQuery.builderConfig)
-  } else {
+  } else if (!draftQuery.text) {
     draftQuery.text = ''
   }
 }

--- a/src/timeMachine/utils/queryBuilder.ts
+++ b/src/timeMachine/utils/queryBuilder.ts
@@ -165,6 +165,10 @@ const convertTagsToFluxFunctionString = function convertTagsToFluxFunctionString
   }
 
   if (tag.aggregateFunctionType === 'group') {
+    if (!tag.values.length) {
+      return ''
+    }
+
     const quotedValues = tag.values.map(value => `"${value}"`) // wrap the value in double quotes
 
     if (quotedValues.length) {

--- a/src/timeMachine/utils/queryBuilder.ts
+++ b/src/timeMachine/utils/queryBuilder.ts
@@ -18,10 +18,7 @@ import {AGG_WINDOW_AUTO} from 'src/timeMachine/constants/queryBuilder'
 export function isConfigValid(builderConfig: BuilderConfig): boolean {
   const {buckets, tags} = builderConfig
 
-  const isConfigValid =
-    buckets.length >= 1 &&
-    tags.length >= 1 &&
-    tags.some(({key, values}) => key && values.length > 0)
+  const isConfigValid = buckets.length >= 1 && tags.length >= 1
 
   return isConfigValid
 }


### PR DESCRIPTION
Closes #19216
The issue of when group  unselection happens, our queryBuidler doesn't update the flux query stored in the state. The same issue was occurring for the selection from filter to group. Now in the video below: we have updated the code where the flux query in the editor corresponds to the exact selections in the ui.

![Kapture 2020-11-19 at 14 23 32](https://user-images.githubusercontent.com/26464594/99734681-131c5c80-2a78-11eb-87c9-3720a047c592.gif)
