### PR TITLE
feat(experiment): add Customer Success link to home & load data

### DIFF
--- a/src/cloud/components/RateLimitAlert.tsx
+++ b/src/cloud/components/RateLimitAlert.tsx
@@ -15,6 +15,8 @@ import {
   BannerPanel,
 } from '@influxdata/clockface'
 import CloudUpgradeButton from 'src/shared/components/CloudUpgradeButton'
+import {GoogleOptimizeExperiment} from './experiments/GoogleOptimizeExperiment'
+import {CustomerSuccessLinkHeader} from './experiments/variants/CustomerSuccessLinkHeader'
 
 // Utils
 import {
@@ -76,7 +78,15 @@ const RateLimitAlert: FC<Props> = ({
   }
 
   if (CLOUD && !alertOnly) {
-    return <CloudUpgradeButton className="upgrade-payg--button__header" />
+    return (
+      <GoogleOptimizeExperiment
+        experimentID="hABJwA89QlyQFi6QGBIysg"
+        original={
+          <CloudUpgradeButton className="upgrade-payg--button__header" />
+        }
+        variants={[<CustomerSuccessLinkHeader />]}
+      />
+    )
   }
 
   return null

--- a/src/cloud/components/experiments/variants/CustomerSuccessLinkHeader.tsx
+++ b/src/cloud/components/experiments/variants/CustomerSuccessLinkHeader.tsx
@@ -1,0 +1,36 @@
+// Libraries
+import React, {FC} from 'react'
+
+// Components
+import {
+  ButtonShape,
+  ComponentColor,
+  ComponentSize,
+  FlexBox,
+  Heading,
+  HeadingElement,
+  IconFont,
+  JustifyContent,
+  LinkButton,
+} from '@influxdata/clockface'
+
+export const CustomerSuccessLinkHeader: FC<{}> = () => {
+  return (
+    <FlexBox
+      justifyContent={JustifyContent.FlexEnd}
+      margin={ComponentSize.Medium}
+    >
+      <Heading element={HeadingElement.H5}>Need help loading data?</Heading>
+      <LinkButton
+        className="load-data--contact-button"
+        color={ComponentColor.Primary}
+        icon={IconFont.Chat}
+        shape={ButtonShape.Default}
+        size={ComponentSize.Small}
+        text="Speak with an Expert"
+        href="https://calendly.com/c/EDCUW4IQ7Z4ZWYSB"
+        target="_blank"
+      />
+    </FlexBox>
+  )
+}

--- a/src/cloud/components/experiments/variants/CustomerSuccessLinkPanel.tsx
+++ b/src/cloud/components/experiments/variants/CustomerSuccessLinkPanel.tsx
@@ -1,0 +1,33 @@
+// Libraries
+import React, {FC} from 'react'
+
+// Components
+import {
+  Panel,
+  LinkButton,
+  ComponentColor,
+  ComponentSize,
+  ButtonShape,
+} from '@influxdata/clockface'
+
+export const CustomerSuccessLinkPanel: FC<{}> = () => {
+  return (
+    <Panel>
+      <Panel.Header>
+        <h4>Need help getting started?</h4>
+      </Panel.Header>
+      <Panel.Body>
+        <LinkButton
+          style={{textAlign: 'center'}}
+          className="home-page--contact-button"
+          color={ComponentColor.Primary}
+          shape={ButtonShape.Default}
+          size={ComponentSize.Small}
+          text="Speak with an Expert"
+          href="https://calendly.com/c/EDCUW4IQ7Z4ZWYSB"
+          target="_blank"
+        />
+      </Panel.Body>
+    </Panel>
+  )
+}

--- a/src/me/components/Resources.tsx
+++ b/src/me/components/Resources.tsx
@@ -14,6 +14,8 @@ import {
   AlignItems,
 } from '@influxdata/clockface'
 import VersionInfo from 'src/shared/components/VersionInfo'
+import {GoogleOptimizeExperiment} from 'src/cloud/components/experiments/GoogleOptimizeExperiment'
+import {CustomerSuccessLinkPanel} from 'src/cloud/components/experiments/variants/CustomerSuccessLinkPanel'
 
 // Types
 import {AppState, ResourceType} from 'src/types'
@@ -58,6 +60,10 @@ class ResourceLists extends PureComponent<Props> {
             <VersionInfo />
           </Panel.Footer>
         </Panel>
+        <GoogleOptimizeExperiment
+          experimentID="hABJwA89QlyQFi6QGBIysg"
+          variants={[<CustomerSuccessLinkPanel />]}
+        />
       </FlexBox>
     )
   }


### PR DESCRIPTION
A Google Optimize experiment that adds a Customer Success link to the home page and the Load Data page.