### PR TITLE
fix: perist metrics on refresh

### DIFF
--- a/src/flows/context/schemaProvider.tsx
+++ b/src/flows/context/schemaProvider.tsx
@@ -46,7 +46,7 @@ export const SchemaProvider: FC<Props> = React.memo(({children}) => {
   const {data, update} = useContext(PipeContext)
   const {flow} = useContext(FlowContext)
   const [searchTerm, setSearchTerm] = useState('')
-  const [lastBucket, setLastBucket] = useState(null)
+  const [lastBucket, setLastBucket] = useState(data?.bucket?.id)
   const dispatch = useDispatch()
 
   const loading = useSelector(
@@ -55,32 +55,30 @@ export const SchemaProvider: FC<Props> = React.memo(({children}) => {
   )
 
   useEffect(() => {
-    dispatch(startWatchDog())
-  }, [dispatch])
-
-  useEffect(() => {
-    if (data.bucket === lastBucket) {
+    if (data?.bucket?.id === lastBucket) {
       return
     }
+
+    setLastBucket(data?.bucket?.id)
     setSearchTerm('')
     update({
       field: '',
       tags: {},
       measurement: '',
     })
-    setLastBucket(data.bucket)
-  }, [data.bucket, lastBucket, update])
+  }, [data?.bucket?.id, lastBucket, update])
+
+  useEffect(() => {
+    dispatch(startWatchDog())
+  }, [dispatch])
 
   useEffect(() => {
     if (!data.bucket) {
       return
     }
-    if (data.bucket === lastBucket) {
-      return
-    }
 
     dispatch(getAndSetBucketSchema(data.bucket, flow.range))
-  }, [data.bucket, lastBucket, dispatch, flow.range])
+  }, [data?.bucket, dispatch, flow?.range])
 
   const schema = useSelector(
     (state: AppState) => state.flow.schema[data.bucket?.name]?.schema || {}

--- a/src/shared/actions/schemaThunks.ts
+++ b/src/shared/actions/schemaThunks.ts
@@ -70,8 +70,8 @@ export const fetchSchemaForBucket = async (
 
     const out = fromFlux(raw.csv).table as any
     const len = out.length
-    const measurements = out.columns._measurement.data
-    const fields = out.columns._field.data
+    const measurements = out.columns._measurement?.data
+    const fields = out.columns._field?.data
     const columns = out.columnKeys.filter(key => {
       return filtered.reduce((acc, curr) => {
         return acc && !curr.test(key)


### PR DESCRIPTION
for some reason, refreshing the notebooks page would make the metric selector clear the filters you put on there. undid that.