### PR TITLE
fix: change-bug-fix-template

### DIFF
--- a/src/shared/components/DefaultErrorMessage.tsx
+++ b/src/shared/components/DefaultErrorMessage.tsx
@@ -3,15 +3,22 @@ import React from 'react'
 
 // Types
 import {ErrorMessageComponent} from 'src/types'
+import {GIT_SHA} from 'src/shared/constants'
 
 const DefaultErrorMessage: ErrorMessageComponent = () => {
+  const SHA_PARAM: string = `Version=${GIT_SHA}`
   return (
     <p
       className="default-error-message"
       style={{display: 'flex', placeContent: 'center'}}
     >
       An InfluxDB error has occurred. Please report the issue&nbsp;
-      <a href="https://github.com/influxdata/influxdb/issues">here</a>.
+      <a
+        href={`https://github.com/influxdata/ui/issues/new?template=bug_report.md&title=${SHA_PARAM}`}
+      >
+        here
+      </a>
+      .
     </p>
   )
 }


### PR DESCRIPTION
Problem: 
   After addressing the problem of not having a bug report template for the UI repo, it is now necessary to address the need for the git_sha (version number) to be added to the bug ticket github page in order to provide greater levels of details for bug submissions. 

This PR attempts to address this issue. See screenshot below for proposed resolution. 

![image](https://user-images.githubusercontent.com/29473622/100028815-5ac32100-2db5-11eb-96a4-e8b62ca67346.png)

