### PR TITLE
chore: update giraffe

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "@influxdata/clockface": "2.3.5",
     "@influxdata/flux": "^0.5.1",
     "@influxdata/flux-lsp-browser": "^0.5.23",
-    "@influxdata/giraffe": "1.0.1",
+    "@influxdata/giraffe": "1.0.2",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -790,10 +790,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/flux/-/flux-0.5.1.tgz#e39e7a7af9163fc9494422c8fed77f3ae1b68f56"
   integrity sha512-GHlkXBhSdJ2m56JzDkbnKPAqLj3/lexPooacu14AWTO4f2sDGLmzM7r0AxgdtU1M2x7EXNBwgGOI5EOAdN6mkw==
 
-"@influxdata/giraffe@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-1.0.1.tgz#2bf145df46218f06548419ef4f155c7df82e7b74"
-  integrity sha512-VaWHRcaza9qjxmkG/87c/xj79MJtHQhSNuF8di3JNnOuFrWyMxIo3cYBwNUGrtAVJcjJ/QigjtUP25ofMBmnig==
+"@influxdata/giraffe@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-1.0.2.tgz#a49c5cfbdb2b8fcbd34ab86118faa08bb238a885"
+  integrity sha512-153NFBRMdBICKk6LX4zqIUa8iwe0sbvEMuG2XM8q6FkvVpK7qzTvsOYBiI566bettWCpU8E3viKSfFm5n6lIZA==
 
 "@influxdata/influx@0.5.5":
   version "0.5.5"


### PR DESCRIPTION
Closes https://github.com/influxdata/giraffe/issues/394

Updates giraffe to restore hover point calculation on all data. Limit will instead be placed visually on the `<Tooltip>`