### PR TITLE
fix(notificationRule): add operator dropdown value for TagRuleDropdown

### DIFF
--- a/src/notifications/rules/components/TagRuleOperatorDropdown.tsx
+++ b/src/notifications/rules/components/TagRuleOperatorDropdown.tsx
@@ -16,6 +16,7 @@ export type Operator = TagRuleDraft['value']['operator']
 
 const operators: {operator: Operator; display: string}[] = [
   {operator: 'equal', display: '=='},
+  {operator: 'notequal', display: '!='},
 ]
 
 const TagRuleOperatorDropdown: FC<Props> = ({selectedOperator, onSelect}) => {


### PR DESCRIPTION
Closes EAR#1932

Describe your proposed changes here.
TagRuleDropdown didn't include `notequal` text in the dropdown. So, when an api is used to update notificationRule to have a tagRule with `notEqual`, ui was erroring out because the dropdown couldn't find `!=` operator in the operators array.

- [x] Well-formatted commit messages
- [x] Rebased/mergeable
- [x] Tests pass
