### PR TITLE
feat: add more information to about page

### DIFF
--- a/src/organizations/components/OrgProfileTab.tsx
+++ b/src/organizations/components/OrgProfileTab.tsx
@@ -59,7 +59,9 @@ class OrgProfileTab extends PureComponent<Props> {
                       justifyContent={JustifyContent.SpaceBetween}
                     >
                       <div>
-                        <h5 style={{marginBottom: '0'}}>Rename Organization</h5>
+                        <h5 style={{marginBottom: '0'}}>
+                          Rename Organization {this.props.org.name}
+                        </h5>
                         <p style={{marginTop: '2px'}}>
                           This action can have wide-reaching unintended
                           consequences.
@@ -86,12 +88,12 @@ class OrgProfileTab extends PureComponent<Props> {
             <Panel.Body>
               <CodeSnippet
                 copyText={this.props.me.id}
-                label="My User Id"
+                label={`${this.props.me.name} | User Id`}
                 onCopyText={this.generateCopyText('User Id')}
               />
               <CodeSnippet
                 copyText={this.props.org.id}
-                label="Organization Id"
+                label={`${this.props.org.name} | Organization Id`}
                 onCopyText={this.generateCopyText('Organization Id')}
               />
             </Panel.Body>


### PR DESCRIPTION
Adds a few bits of information to the about page to make it more useful.

#### Before
![Screen Shot 2020-11-30 at 9 57 33 AM](https://user-images.githubusercontent.com/146112/100647589-9e0d1a80-32f4-11eb-9397-802b6f0f4f0e.png)


#### After
![Screen Shot 2020-11-30 at 9 54 09 AM](https://user-images.githubusercontent.com/146112/100647577-9a799380-32f4-11eb-9d63-5426910234a4.png)


- [x] Well-formatted commit messages
- [x] Rebased/mergeable
- [x] Tests pass
