### PR TITLE
feat: prefix locally generated ids

### DIFF
--- a/src/flows/context/flow.current.tsx
+++ b/src/flows/context/flow.current.tsx
@@ -58,7 +58,7 @@ export const FlowProvider: FC = ({children}) => {
   )
 
   const addPipe = (initial: PipeData, index?: number) => {
-    const id = UUID()
+    const id = `local_${UUID()}`
 
     flows[currentID].data.add(id, initial)
     flows[currentID].meta.add(id, {

--- a/src/flows/context/flow.list.tsx
+++ b/src/flows/context/flow.list.tsx
@@ -89,7 +89,7 @@ export function hydrate(data) {
   }
 
   data.pipes.forEach(pipe => {
-    const id = pipe.id || UUID()
+    const id = pipe.id || `local_${UUID()}`
 
     flow.data.allIDs.push(id)
     flow.meta.allIDs.push(id)
@@ -158,7 +158,7 @@ export const FlowListProvider: FC = ({children}) => {
     // console.log('add to the api', serialize(data))
     return new Promise(resolve => {
       setTimeout(() => {
-        const id = UUID()
+        const id = `local_${UUID()}`
 
         setFlows({
           ...flows,


### PR DESCRIPTION
this one puts `local_` in front of all locally generated ids used when creating notebooks / panels on the frontend for the local storage mechanism. hopefully this will give us enough of a signal to segment them from api generated ids for when it comes time to migrate them out of local storage and on to the backend, all without changing too much of the internal routing.