### PR TITLE
refactor(notebooks): improve export task form validation

### DIFF
--- a/src/flows/pipes/ToBucket/ExportTaskOverlay/CreateTaskBody.tsx
+++ b/src/flows/pipes/ToBucket/ExportTaskOverlay/CreateTaskBody.tsx
@@ -1,4 +1,7 @@
-import React, {ChangeEvent, FC, useContext} from 'react'
+// Libraries
+import React, {FC, useContext} from 'react'
+
+// Components
 import {
   Columns,
   ComponentStatus,
@@ -6,58 +9,63 @@ import {
   Grid,
   Input,
   InputType,
+  ComponentSize,
 } from '@influxdata/clockface'
 import QueryTextPreview from 'src/flows/components/QueryTextPreview'
+
+// Contexts
 import {Context} from 'src/flows/pipes/ToBucket/ExportTaskOverlay/context'
 
 const CreateTaskBody: FC = () => {
   const {
-    handleSetEveryInterval,
-    handleSetTaskName,
-    hasError,
+    handleInputChange,
     interval,
+    intervalError,
     taskName,
+    taskNameError,
   } = useContext(Context)
 
   return (
     <>
       <Grid.Column widthXS={Columns.Nine}>
-        <Form.Element
-          label="Name"
-          errorMessage={hasError && 'This field cannot be empty'}
-        >
+        <Form.Element label="Name" required={true} errorMessage={taskNameError}>
           <Input
-            name="name"
+            name="taskName"
             placeholder="Name your task"
-            onChange={(event: ChangeEvent<HTMLInputElement>) =>
-              handleSetTaskName(event.target.value)
-            }
+            onChange={handleInputChange}
             value={taskName}
             testID="task-form-name"
-            status={hasError ? ComponentStatus.Error : ComponentStatus.Default}
+            status={
+              taskNameError ? ComponentStatus.Error : ComponentStatus.Default
+            }
+            size={ComponentSize.Medium}
           />
         </Form.Element>
       </Grid.Column>
       <Grid.Column widthXS={Columns.Three}>
         <Form.Element
           label="Run Every"
-          errorMessage={hasError && 'Invalid Time'}
+          required={true}
+          errorMessage={intervalError}
         >
           <Input
-            name="schedule"
+            name="interval"
             type={InputType.Text}
-            placeholder="3h30s"
+            placeholder="ex: 3h30s"
             value={interval}
-            onChange={(event: ChangeEvent<HTMLInputElement>) =>
-              handleSetEveryInterval(event.target.value)
-            }
+            onChange={handleInputChange}
             testID="task-form-schedule-input"
-            status={hasError ? ComponentStatus.Error : ComponentStatus.Default}
+            status={
+              intervalError ? ComponentStatus.Error : ComponentStatus.Default
+            }
+            size={ComponentSize.Medium}
           />
         </Form.Element>
       </Grid.Column>
       <Grid.Column>
-        <QueryTextPreview />
+        <Form.Element label="Preview">
+          <QueryTextPreview />
+        </Form.Element>
       </Grid.Column>
     </>
   )

--- a/src/flows/pipes/ToBucket/ExportTaskOverlay/ExportTaskButtons.tsx
+++ b/src/flows/pipes/ToBucket/ExportTaskOverlay/ExportTaskButtons.tsx
@@ -1,75 +1,16 @@
+// Libraries
 import React, {FC, useContext} from 'react'
-import {useDispatch} from 'react-redux'
-import {
-  Button,
-  ButtonType,
-  ComponentColor,
-  ComponentStatus,
-  Form,
-} from '@influxdata/clockface'
-import {
-  ExportAsTask,
-  Context,
-} from 'src/flows/pipes/ToBucket/ExportTaskOverlay/context'
+
+// Components
+import {Button, ButtonType, ComponentColor, Form} from '@influxdata/clockface'
+
+// Contexts
+import {Context} from 'src/flows/pipes/ToBucket/ExportTaskOverlay/context'
 import {PopupContext} from 'src/flows/context/popup'
 
-// Utils
-import {saveNewScript, updateTask} from 'src/tasks/actions/thunks'
-import {event} from 'src/cloud/utils/reporting'
-import {formatQueryText} from 'src/flows/shared/utils'
-
 const ExportTaskButtons: FC = () => {
-  const {
-    activeTab,
-    canSubmit,
-    handleSetError,
-    interval,
-    selectedTask,
-    taskName,
-  } = useContext(Context)
-  const {data, closeFn} = useContext(PopupContext)
-
-  const script = formatQueryText(data.query)
-
-  const dispatch = useDispatch()
-
-  const onCreate = () => {
-    if (!/\d/.test(interval)) {
-      handleSetError(true)
-      return
-    }
-    event('Save Flow as Task')
-
-    const taskOption: string = `option task = { \n  name: "${taskName}",\n  every: ${interval},\n  offset: 0s\n}`
-    const variable: string = `option v = {\n  timeRangeStart: -${interval},\n  timeRangeStop: now()\n}`
-    const preamble = `${variable}\n\n${taskOption}`
-
-    dispatch(saveNewScript(script, preamble))
-  }
-
-  const onUpdate = () => {
-    if (!/\d/.test(interval) || !selectedTask?.name) {
-      handleSetError(true)
-      return
-    }
-
-    event('Update Task from Flow')
-
-    const taskOption: string = `option task = { \n  name: "${selectedTask.name}",\n  every: ${interval},\n  offset: 0s\n}`
-    const variable: string = `option v = {\n  timeRangeStart: -${interval},\n  timeRangeStop: now()\n}`
-    const preamble = `${variable}\n\n${taskOption}`
-
-    dispatch(
-      updateTask({
-        script,
-        preamble,
-        interval,
-        task: selectedTask,
-      })
-    )
-  }
-
-  const onSubmit = activeTab === ExportAsTask.Create ? onCreate : onUpdate
+  const {submit} = useContext(Context)
+  const {closeFn} = useContext(PopupContext)
 
   return (
     <Form.Footer>
@@ -83,10 +24,7 @@ const ExportTaskButtons: FC = () => {
         text="Export Task"
         color={ComponentColor.Success}
         type={ButtonType.Submit}
-        onClick={onSubmit}
-        status={
-          canSubmit() ? ComponentStatus.Default : ComponentStatus.Disabled
-        }
+        onClick={submit}
         testID="task-form-export"
       />
     </Form.Footer>

--- a/src/flows/pipes/ToBucket/ExportTaskOverlay/TaskDropdown.tsx
+++ b/src/flows/pipes/ToBucket/ExportTaskOverlay/TaskDropdown.tsx
@@ -48,7 +48,12 @@ const TaskDropdown: FC = () => {
   }
 
   const button = (active, onClick) => (
-    <Dropdown.Button onClick={onClick} active={active} icon={IconFont.Disks}>
+    <Dropdown.Button
+      onClick={onClick}
+      active={active}
+      icon={IconFont.Calendar}
+      size={ComponentSize.Medium}
+    >
       {buttonText}
     </Dropdown.Button>
   )

--- a/src/flows/pipes/ToBucket/ExportTaskOverlay/UpdateTaskBody.tsx
+++ b/src/flows/pipes/ToBucket/ExportTaskOverlay/UpdateTaskBody.tsx
@@ -1,4 +1,4 @@
-import React, {ChangeEvent, FC, useContext} from 'react'
+import React, {FC, useContext} from 'react'
 import {useSelector} from 'react-redux'
 
 import {
@@ -20,7 +20,12 @@ import QueryTextPreview from 'src/flows/components/QueryTextPreview'
 import {hasNoTasks as hasNoTasksSelector} from 'src/resources/selectors'
 
 const UpdateTaskBody: FC = () => {
-  const {interval, handleSetEveryInterval, hasError} = useContext(Context)
+  const {
+    interval,
+    intervalError,
+    handleInputChange,
+    selectedTaskError,
+  } = useContext(Context)
 
   const hasNoTasks = useSelector(hasNoTasksSelector)
 
@@ -36,7 +41,8 @@ const UpdateTaskBody: FC = () => {
       <Grid.Column widthXS={Columns.Nine}>
         <Form.Element
           label="Name"
-          errorMessage={hasError && 'This field cannot be empty'}
+          required={true}
+          errorMessage={selectedTaskError}
         >
           <TaskDropdown />
         </Form.Element>
@@ -44,26 +50,28 @@ const UpdateTaskBody: FC = () => {
       <Grid.Column widthXS={Columns.Three}>
         <Form.Element
           label="Run Every"
-          errorMessage={hasError && 'Invalid Time'}
+          required={true}
+          errorMessage={intervalError}
         >
           <Input
-            name="schedule"
+            name="interval"
             type={InputType.Text}
-            placeholder="3h30s"
+            placeholder="ex: 3h30s"
             value={interval}
-            onChange={(event: ChangeEvent<HTMLInputElement>) =>
-              handleSetEveryInterval(event.target.value)
-            }
+            onChange={handleInputChange}
             testID="task-form-schedule-input"
-            status={hasError ? ComponentStatus.Error : ComponentStatus.Default}
+            size={ComponentSize.Medium}
+            status={
+              intervalError ? ComponentStatus.Error : ComponentStatus.Default
+            }
           />
         </Form.Element>
       </Grid.Column>
       <Grid.Column>
         <WarningPanel />
-      </Grid.Column>
-      <Grid.Column>
-        <QueryTextPreview />
+        <Form.Element label="Preview">
+          <QueryTextPreview />
+        </Form.Element>
       </Grid.Column>
     </>
   )

--- a/src/flows/pipes/ToBucket/ExportTaskOverlay/WarningPanel.tsx
+++ b/src/flows/pipes/ToBucket/ExportTaskOverlay/WarningPanel.tsx
@@ -11,17 +11,23 @@ import {
 } from '@influxdata/clockface'
 
 const WarningPanel: FC = () => (
-  <Panel gradient={Gradients.LostGalaxy} testID="panel" border={true}>
+  <Panel
+    gradient={Gradients.DocScott}
+    testID="panel"
+    border={true}
+    style={{marginBottom: '8px'}}
+  >
     <Panel.Body
       justifyContent={JustifyContent.FlexStart}
       alignItems={AlignItems.Center}
       direction={FlexDirection.Row}
       margin={ComponentSize.Large}
       size={ComponentSize.ExtraSmall}
+      style={{padding: '8px 12px'}}
     >
       <Icon glyph={IconFont.AlertTriangle} />
       <p className="margin-zero">
-        &nbsp;Note: changes made to an existing task cannot be undone
+        <strong>NOTE:</strong> Changes made to an existing task cannot be undone
       </p>
     </Panel.Body>
   </Panel>

--- a/src/flows/pipes/ToBucket/ExportTaskOverlay/WarningPanel.tsx
+++ b/src/flows/pipes/ToBucket/ExportTaskOverlay/WarningPanel.tsx
@@ -12,7 +12,7 @@ import {
 
 const WarningPanel: FC = () => (
   <Panel
-    gradient={Gradients.DocScott}
+    gradient={Gradients.LostGalaxy}
     testID="panel"
     border={true}
     style={{marginBottom: '8px'}}

--- a/src/flows/pipes/ToBucket/ExportTaskOverlay/context.tsx
+++ b/src/flows/pipes/ToBucket/ExportTaskOverlay/context.tsx
@@ -1,7 +1,29 @@
-import React, {FC, useState, useCallback, useEffect} from 'react'
+// Libraries
+import React, {
+  FC,
+  useState,
+  useCallback,
+  useEffect,
+  useContext,
+  ChangeEvent,
+} from 'react'
 import {useDispatch} from 'react-redux'
+
+// Components
+import {InputRef} from '@influxdata/clockface'
+
+// Types
 import {Task} from 'src/types'
-import {getTasks} from 'src/tasks/actions/thunks'
+
+// Actions
+import {getTasks, saveNewScript, updateTask} from 'src/tasks/actions/thunks'
+
+// Utils
+import {event} from 'src/cloud/utils/reporting'
+import {formatQueryText} from 'src/flows/shared/utils'
+
+// Contexts
+import {PopupContext} from 'src/flows/context/popup'
 
 export enum ExportAsTask {
   Create = 'create',
@@ -9,107 +31,196 @@ export enum ExportAsTask {
 }
 
 interface ContextType {
+  submit: () => void
   activeTab: ExportAsTask
-  canSubmit: () => boolean
   handleSetActiveTab: (tab: ExportAsTask) => void
-  handleSetError: (value: boolean) => void
-  handleSetEveryInterval: (value: string) => void
   handleSetTask: (task: Task) => void
-  handleSetTaskName: (value: string) => void
-  hasError: boolean
+  handleInputChange: (e: ChangeEvent<InputRef>) => void
   interval: string
+  intervalError: string
   selectedTask: Task | undefined
+  selectedTaskError: string
   taskName: string
+  taskNameError: string
 }
 
 const DEFAULT_CONTEXT: ContextType = {
+  submit: () => {},
   activeTab: ExportAsTask.Create,
-  canSubmit: () => false,
   handleSetActiveTab: () => {},
-  handleSetError: () => {},
-  handleSetEveryInterval: () => {},
   handleSetTask: () => {},
-  handleSetTaskName: () => {},
-  hasError: false,
+  handleInputChange: () => {},
   interval: '',
+  intervalError: '',
   selectedTask: undefined,
+  selectedTaskError: '',
   taskName: '',
+  taskNameError: '',
 }
 
 export const Context = React.createContext<ContextType>(DEFAULT_CONTEXT)
 
 export const Provider: FC = ({children}) => {
-  const [activeTab, setActiveTab] = useState(ExportAsTask.Create)
-  const [selectedTask, setTask] = useState<Task>(undefined)
-  const [hasError, setHasError] = useState(false)
-  const [taskName, setTaskName] = useState('')
-  const [interval, setEveryInterval] = useState('')
-
   const dispatch = useDispatch()
+  const [activeTab, setActiveTab] = useState(ExportAsTask.Create)
+  const [selectedTask, setSelectedTask] = useState<Task>(undefined)
+  const [selectedTaskError, setSelectedTaskError] = useState<string>('')
+  const [taskName, setTaskName] = useState<string>('')
+  const [taskNameError, setTaskNameError] = useState<string>('')
+  const [interval, setInterval] = useState<string>('')
+  const [intervalError, setIntervalError] = useState<string>('')
+  const {data} = useContext(PopupContext)
+
+  const script = formatQueryText(data.query)
 
   useEffect(() => {
     dispatch(getTasks())
   }, [dispatch])
 
+  const handleCreateTask = () => {
+    event('Save Flow as Task')
+
+    const taskOption: string = `option task = { \n  name: "${taskName}",\n  every: ${interval},\n  offset: 0s\n}`
+    const variable: string = `option v = {\n  timeRangeStart: -${interval},\n  timeRangeStop: now()\n}`
+    const preamble = `${variable}\n\n${taskOption}`
+
+    dispatch(saveNewScript(script, preamble))
+  }
+
+  const handleUpdateTask = () => {
+    event('Update Task from Flow')
+
+    const taskOption: string = `option task = { \n  name: "${selectedTask.name}",\n  every: ${interval},\n  offset: 0s\n}`
+    const variable: string = `option v = {\n  timeRangeStart: -${interval},\n  timeRangeStop: now()\n}`
+    const preamble = `${variable}\n\n${taskOption}`
+
+    dispatch(
+      updateTask({
+        script,
+        preamble,
+        interval,
+        task: selectedTask,
+      })
+    )
+  }
+
   const handleSetActiveTab = useCallback((tab: ExportAsTask): void => {
     setActiveTab(tab)
+    setTaskNameError('')
+    setIntervalError('')
   }, [])
 
-  const handleSetError = useCallback((value: boolean): void => {
-    setHasError(value)
+  const handleSetTask = useCallback((task: Task): void => {
+    setSelectedTask(task)
+    setSelectedTaskError('')
   }, [])
 
-  const handleSetEveryInterval = useCallback(
-    (value: string): void => {
-      if (hasError) {
-        setHasError(false)
-      }
-      setEveryInterval(value)
-    },
-    [hasError]
-  )
+  const handleInputChange = (e: ChangeEvent<InputRef>): void => {
+    const {name, value} = e.target
 
-  const handleSetTaskName = useCallback(
-    (value: string): void => {
-      if (hasError) {
-        setHasError(false)
+    if (name === 'interval') {
+      setInterval(value)
+      if (value === '') {
+        setIntervalError('Cannot be empty')
+      } else if (!/\d/.test(value)) {
+        setIntervalError('Invalid format')
+      } else {
+        setIntervalError('')
       }
-      setTaskName(value)
-    },
-    [hasError]
-  )
-
-  const handleSetTask = useCallback(
-    (task: Task): void => {
-      if (hasError) {
-        setHasError(false)
-      }
-      setTask(task)
-    },
-    [hasError]
-  )
-
-  const canSubmit = useCallback(() => {
-    if (activeTab === ExportAsTask.Create) {
-      return !!taskName && interval !== ''
     }
-    return interval !== '' && !!selectedTask?.name
-  }, [activeTab, taskName, interval, selectedTask])
+
+    if (name === 'taskName') {
+      setTaskName(value)
+
+      if (value === '') {
+        setTaskNameError('Cannot be empty')
+      } else {
+        setTaskNameError('')
+      }
+    }
+  }
+
+  const validateCreateForm = (): boolean => {
+    let formIsValid = true
+    if (taskName === '') {
+      setTaskNameError('Cannot be empty')
+      formIsValid = false
+    } else {
+      setTaskNameError('')
+    }
+
+    if (interval === '') {
+      setIntervalError('Cannot be empty')
+      formIsValid = false
+    } else if (!/\d/.test(interval)) {
+      setIntervalError('Invalid format')
+      formIsValid = false
+    } else {
+      setIntervalError('')
+    }
+
+    return formIsValid
+  }
+
+  const validateUpdateForm = (): boolean => {
+    let formIsValid = true
+
+    if (interval === '') {
+      setIntervalError('Cannot be empty')
+      formIsValid = false
+    } else if (!/\d/.test(interval)) {
+      setIntervalError('Invalid format')
+      formIsValid = false
+    } else {
+      setIntervalError('')
+    }
+
+    if (!selectedTask?.name) {
+      setSelectedTaskError('Please choose a task')
+      formIsValid = false
+    } else {
+      setSelectedTaskError('')
+    }
+
+    return formIsValid
+  }
+
+  const validateForm = (): boolean => {
+    if (activeTab === ExportAsTask.Create) {
+      return validateCreateForm()
+    }
+
+    return validateUpdateForm()
+  }
+
+  const submit = (): void => {
+    const formIsValid = validateForm()
+
+    if (!formIsValid) {
+      return
+    }
+
+    if (activeTab === ExportAsTask.Create) {
+      handleCreateTask()
+    } else {
+      handleUpdateTask()
+    }
+  }
 
   return (
     <Context.Provider
       value={{
+        submit,
         activeTab,
-        canSubmit,
         handleSetActiveTab,
-        handleSetError,
-        handleSetEveryInterval,
         handleSetTask,
-        handleSetTaskName,
-        hasError,
+        handleInputChange,
         interval,
+        intervalError,
         selectedTask,
+        selectedTaskError,
         taskName,
+        taskNameError,
       }}
     >
       {children}

--- a/src/flows/pipes/ToBucket/ExportTaskOverlay/context.tsx
+++ b/src/flows/pipes/ToBucket/ExportTaskOverlay/context.tsx
@@ -115,6 +115,16 @@ export const Provider: FC = ({children}) => {
     setSelectedTaskError('')
   }, [])
 
+  const validateTimeValue = (value: string): boolean => {
+    if (value === '') {
+      return false
+    }
+
+    const cleanValue = value.match(/(?:(\d+(mo|s|m|w|h){1}))/g)?.join('')
+
+    return value !== cleanValue
+  }
+
   const handleInputChange = (e: ChangeEvent<InputRef>): void => {
     const {name, value} = e.target
 
@@ -122,8 +132,8 @@ export const Provider: FC = ({children}) => {
       setInterval(value)
       if (value === '') {
         setIntervalError('Cannot be empty')
-      } else if (!/\d/.test(value)) {
-        setIntervalError('Invalid format')
+      } else if (validateTimeValue(value)) {
+        setIntervalError('Invalid time')
       } else {
         setIntervalError('')
       }
@@ -152,8 +162,8 @@ export const Provider: FC = ({children}) => {
     if (interval === '') {
       setIntervalError('Cannot be empty')
       formIsValid = false
-    } else if (!/\d/.test(interval)) {
-      setIntervalError('Invalid format')
+    } else if (validateTimeValue(interval)) {
+      setIntervalError('Invalid time')
       formIsValid = false
     } else {
       setIntervalError('')
@@ -168,8 +178,8 @@ export const Provider: FC = ({children}) => {
     if (interval === '') {
       setIntervalError('Cannot be empty')
       formIsValid = false
-    } else if (!/\d/.test(interval)) {
-      setIntervalError('Invalid format')
+    } else if (validateTimeValue(interval)) {
+      setIntervalError('Invalid time')
       formIsValid = false
     } else {
       setIntervalError('')

--- a/src/flows/pipes/ToBucket/ExportTaskOverlay/context.tsx
+++ b/src/flows/pipes/ToBucket/ExportTaskOverlay/context.tsx
@@ -120,7 +120,7 @@ export const Provider: FC = ({children}) => {
       return false
     }
 
-    const cleanValue = value.match(/(?:(\d+(mo|s|m|w|h){1}))/g)?.join('')
+    const cleanValue = value.match(/(?:(\d+(y|mo|s|m|w|h){1}))/g)?.join('')
 
     return value !== cleanValue
   }

--- a/src/flows/pipes/ToBucket/ExportTaskOverlay/context.tsx
+++ b/src/flows/pipes/ToBucket/ExportTaskOverlay/context.tsx
@@ -69,7 +69,7 @@ export const Provider: FC = ({children}) => {
   const [taskNameError, setTaskNameError] = useState<string>('')
   const [interval, setInterval] = useState<string>('')
   const [intervalError, setIntervalError] = useState<string>('')
-  const {data} = useContext(PopupContext)
+  const {data, closeFn} = useContext(PopupContext)
 
   const script = formatQueryText(data.query)
 
@@ -215,6 +215,8 @@ export const Provider: FC = ({children}) => {
     } else {
       handleUpdateTask()
     }
+
+    closeFn()
   }
 
   return (

--- a/src/flows/pipes/ToBucket/ExportTaskOverlay/index.tsx
+++ b/src/flows/pipes/ToBucket/ExportTaskOverlay/index.tsx
@@ -29,7 +29,7 @@ const ExportTaskOverlay: FC = () => {
 
   return (
     <Overlay visible={true}>
-      <Overlay.Container maxWidth={600}>
+      <Overlay.Container maxWidth={700}>
         <Overlay.Header
           title="Export As Task"
           onDismiss={closeFn}


### PR DESCRIPTION
- Centralize form logic in context provider
- Submit button always enabled
- Validates entire form when `Submit` is clicked
- Validate inputs when they are changed
- Strengthen `schedule` input validation
- Close overlay on submit (courtesy of @drdelambre)

![export-task-create-validation](https://user-images.githubusercontent.com/2433762/101104633-687c6180-3580-11eb-9841-fcce542b8308.gif)
![export-task-update-validation](https://user-images.githubusercontent.com/2433762/101104654-7500ba00-3580-11eb-9cab-a57f603e31bd.gif)
![time-validation](https://user-images.githubusercontent.com/2433762/101104662-7a5e0480-3580-11eb-99e5-a2002fde20ad.gif)

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

