### PR TITLE
feat: set a default for legendOrientationThreshold while the feature flag is still off in prod

### DIFF
--- a/src/shared/utils/useLegendOrientation.ts
+++ b/src/shared/utils/useLegendOrientation.ts
@@ -3,6 +3,7 @@ import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {
   LEGEND_OPACITY_DEFAULT,
   LEGEND_OPACITY_MINIMUM,
+  LEGEND_ORIENTATION_THRESHOLD_DEFAULT,
 } from 'src/shared/constants'
 
 export const useLegendOpacity = (legendOpacity: number) =>
@@ -20,8 +21,8 @@ export const useLegendOrientationThreshold = (
   legendOrientationThreshold: number
 ) =>
   useMemo(() => {
-    if (isFlagEnabled('legendOrientation')) {
-      return legendOrientationThreshold
+    if (!isFlagEnabled('legendOrientation')) {
+      return LEGEND_ORIENTATION_THRESHOLD_DEFAULT
     }
-    return undefined
+    return legendOrientationThreshold
   }, [legendOrientationThreshold])


### PR DESCRIPTION
Closes #178 

Set default values for prod users _before_ the feature flag is turned on. The feature flag will be turned on as soon as the docs team has the documentation for these options.

Previously, only opacity had a default set. Threshold needs a default as well. To set a default, we reverse the condition in the hook and return the default when the flag is off.

**_If we don't do this_**, then the zero value from Go for a number is 0 which will cause the threshold to be 0, which will lead to users saying, "How come my legend is turned sideways now?" when the feature flag gets turned on.

But with a default of 10, then fewer of them will have this "problem". Or at least the users who have this problem definitely also have graphs that have a lot of data in the tooltip, and maybe they will be pleasantly surprised at the neat tooltip.

--- EDIT --- Yes, this does change the behavior of the tooltip even with the feature flag off. But only for graphs with a lot of data in the tooltip. The benefit we are getting is that a vast majority of users will have a sensible default. As mentioned in the previous paragraph, users may actually be pleasantly surprised by the neater tooltip. They just can't change the setting while the feature flag is off.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass

