### PR TITLE
feat: fix label popup close on esc key 

### DIFF
--- a/src/shared/components/inlineLabels/InlineLabelPopover.tsx
+++ b/src/shared/components/inlineLabels/InlineLabelPopover.tsx
@@ -42,6 +42,7 @@ interface Props {
   onInputChange: (e: ChangeEvent<HTMLInputElement>) => void
   filteredLabels: Label[]
   onAddLabel: (labelID: string) => void
+  onEscapePress : () => void
   visible: boolean
 }
 
@@ -59,7 +60,7 @@ export default class InlineLabelPopover extends PureComponent<Props> {
       onInputChange,
       filteredLabels,
       visible,
-    } = this.props
+    } = this.props;
 
     return (
       <Popover
@@ -102,29 +103,32 @@ export default class InlineLabelPopover extends PureComponent<Props> {
   }
 
   private handleKeyDown = (e: KeyboardEvent<HTMLInputElement>): void => {
-    const {selectedItemID, onAddLabel, onStartCreatingLabel} = this.props
+    const {selectedItemID, onAddLabel, onStartCreatingLabel, onEscapePress} = this.props;
 
     switch (e.key) {
       case 'Enter':
-        e.preventDefault()
-        e.stopPropagation()
+        e.preventDefault();
+        e.stopPropagation();
         if (selectedItemID === ADD_NEW_LABEL_ITEM_ID) {
-          onStartCreatingLabel()
-          break
+          onStartCreatingLabel();
+          break;
         }
 
         if (selectedItemID) {
-          onAddLabel(selectedItemID)
-          break
+          onAddLabel(selectedItemID);
+          break;
         }
       case 'ArrowUp':
-        this.handleHighlightAdjacentItem(ArrowDirection.Up)
-        break
+        this.handleHighlightAdjacentItem(ArrowDirection.Up);
+        break;
       case 'ArrowDown':
-        this.handleHighlightAdjacentItem(ArrowDirection.Down)
-        break
+        this.handleHighlightAdjacentItem(ArrowDirection.Down);
+        break;
+      case 'Escape':
+        onEscapePress();
+        break;
       default:
-        break
+        break;
     }
   }
 

--- a/src/shared/components/inlineLabels/InlineLabelPopover.tsx
+++ b/src/shared/components/inlineLabels/InlineLabelPopover.tsx
@@ -42,7 +42,7 @@ interface Props {
   onInputChange: (e: ChangeEvent<HTMLInputElement>) => void
   filteredLabels: Label[]
   onAddLabel: (labelID: string) => void
-  onEscapePress : () => void
+  onEscapePress: () => void
   visible: boolean
 }
 
@@ -60,7 +60,7 @@ export default class InlineLabelPopover extends PureComponent<Props> {
       onInputChange,
       filteredLabels,
       visible,
-    } = this.props;
+    } = this.props
 
     return (
       <Popover
@@ -103,32 +103,37 @@ export default class InlineLabelPopover extends PureComponent<Props> {
   }
 
   private handleKeyDown = (e: KeyboardEvent<HTMLInputElement>): void => {
-    const {selectedItemID, onAddLabel, onStartCreatingLabel, onEscapePress} = this.props;
+    const {
+      selectedItemID,
+      onAddLabel,
+      onStartCreatingLabel,
+      onEscapePress,
+    } = this.props
 
     switch (e.key) {
       case 'Enter':
-        e.preventDefault();
-        e.stopPropagation();
+        e.preventDefault()
+        e.stopPropagation()
         if (selectedItemID === ADD_NEW_LABEL_ITEM_ID) {
-          onStartCreatingLabel();
-          break;
+          onStartCreatingLabel()
+          break
         }
 
         if (selectedItemID) {
-          onAddLabel(selectedItemID);
-          break;
+          onAddLabel(selectedItemID)
+          break
         }
       case 'ArrowUp':
-        this.handleHighlightAdjacentItem(ArrowDirection.Up);
-        break;
+        this.handleHighlightAdjacentItem(ArrowDirection.Up)
+        break
       case 'ArrowDown':
-        this.handleHighlightAdjacentItem(ArrowDirection.Down);
-        break;
+        this.handleHighlightAdjacentItem(ArrowDirection.Down)
+        break
       case 'Escape':
-        onEscapePress();
-        break;
+        onEscapePress()
+        break
       default:
-        break;
+        break
     }
   }
 

--- a/src/shared/components/inlineLabels/InlineLabelsEditor.tsx
+++ b/src/shared/components/inlineLabels/InlineLabelsEditor.tsx
@@ -111,16 +111,17 @@ class InlineLabelsEditor extends Component<Props, State> {
     return (
       <ClickOutside onClickOutside={this.onClickOutside}>
         <InlineLabelPopover
-          searchTerm={searchTerm}
-          triggerRef={this.popoverTrigger}
-          selectedItemID={selectedItemID}
-          onUpdateSelectedItemID={this.handleUpdateSelectedItemID}
-          allLabelsUsed={labelsUsed}
-          onStartCreatingLabel={this.handleStartCreatingLabel}
-          onInputChange={this.handleInputChange}
-          filteredLabels={this.filterLabels(searchTerm)}
-          onAddLabel={this.handleAddLabel}
-          visible={isPopoverVisible}
+            searchTerm={searchTerm}
+            triggerRef={this.popoverTrigger}
+            selectedItemID={selectedItemID}
+            onUpdateSelectedItemID={this.handleUpdateSelectedItemID}
+            allLabelsUsed={labelsUsed}
+            onStartCreatingLabel={this.handleStartCreatingLabel}
+            onInputChange={this.handleInputChange}
+            filteredLabels={this.filterLabels(searchTerm)}
+            onAddLabel={this.handleAddLabel}
+            visible={isPopoverVisible}
+            onEscapePress={this.hidePopover}
         />
       </ClickOutside>
     )
@@ -166,9 +167,7 @@ class InlineLabelsEditor extends Component<Props, State> {
       return
     }
 
-    this.setState({
-      isPopoverVisible: false,
-    })
+    this.hidePopover();
   }
 
   private handleAddLabel = async (labelID: string) => {
@@ -270,6 +269,10 @@ class InlineLabelsEditor extends Component<Props, State> {
 
   private handleStartCreatingLabel = (): void => {
     this.setState({isCreatingLabel: OverlayState.Open, isPopoverVisible: false})
+  }
+
+  private hidePopover = (): void => {
+    this.setState({isPopoverVisible: false});
   }
 
   private handleStopCreatingLabel = (): void => {

--- a/src/shared/components/inlineLabels/InlineLabelsEditor.tsx
+++ b/src/shared/components/inlineLabels/InlineLabelsEditor.tsx
@@ -111,17 +111,17 @@ class InlineLabelsEditor extends Component<Props, State> {
     return (
       <ClickOutside onClickOutside={this.onClickOutside}>
         <InlineLabelPopover
-            searchTerm={searchTerm}
-            triggerRef={this.popoverTrigger}
-            selectedItemID={selectedItemID}
-            onUpdateSelectedItemID={this.handleUpdateSelectedItemID}
-            allLabelsUsed={labelsUsed}
-            onStartCreatingLabel={this.handleStartCreatingLabel}
-            onInputChange={this.handleInputChange}
-            filteredLabels={this.filterLabels(searchTerm)}
-            onAddLabel={this.handleAddLabel}
-            visible={isPopoverVisible}
-            onEscapePress={this.hidePopover}
+          searchTerm={searchTerm}
+          triggerRef={this.popoverTrigger}
+          selectedItemID={selectedItemID}
+          onUpdateSelectedItemID={this.handleUpdateSelectedItemID}
+          allLabelsUsed={labelsUsed}
+          onStartCreatingLabel={this.handleStartCreatingLabel}
+          onInputChange={this.handleInputChange}
+          filteredLabels={this.filterLabels(searchTerm)}
+          onAddLabel={this.handleAddLabel}
+          visible={isPopoverVisible}
+          onEscapePress={this.hidePopover}
         />
       </ClickOutside>
     )
@@ -167,7 +167,7 @@ class InlineLabelsEditor extends Component<Props, State> {
       return
     }
 
-    this.hidePopover();
+    this.hidePopover()
   }
 
   private handleAddLabel = async (labelID: string) => {
@@ -272,7 +272,7 @@ class InlineLabelsEditor extends Component<Props, State> {
   }
 
   private hidePopover = (): void => {
-    this.setState({isPopoverVisible: false});
+    this.setState({isPopoverVisible: false})
   }
 
   private handleStopCreatingLabel = (): void => {


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/17853

fix for popups not closing when esc is pressed.  

clockface will close the popover on the esc key if it is not controlled; but in this case it is controlled by the InlineLabelPopover.

 since the input takes all the focus and all the keys, listen on the input for the escape,  and the container of the inline labelpopover controls the popover visible state, so added another handler there to hide it.
