### PR TITLE
fix: dont use stale flow data

### DIFF
--- a/src/flows/context/flow.current.tsx
+++ b/src/flows/context/flow.current.tsx
@@ -54,7 +54,7 @@ export const FlowProvider: FC = ({children}) => {
         ...flow,
       })
     },
-    [currentID]
+    [currentID, flows[currentID]]
   )
 
   const addPipe = (initial: PipeData, index?: number) => {


### PR DESCRIPTION
found an error on the demo in which data was "being lost" when changing the query period dropdown. seems to be that we were reapplying stale state