### PR TITLE
test(community-templates): integration test for startTemplateInstall function

### DIFF
--- a/cypress/e2e/shared/checks.test.ts
+++ b/cypress/e2e/shared/checks.test.ts
@@ -94,13 +94,24 @@ describe('Checks', () => {
 
   it('can create and filter checks', () => {
     cy.log('create first check')
-    cy.getByTestID('create-check').click()
-    cy.getByTestID('create-deadman-check').click()
-
-    cy.log('select measurement and field')
-    cy.getByTestID(`selector-list defbuck`).click()
-    cy.getByTestID(`selector-list ${measurement}`).click()
-    cy.getByTestID(`selector-list ${field}`).click()
+    cy.getByTestID('create-check')
+      .click()
+      .then(() => {
+        cy.getByTestID('create-deadman-check')
+          .click()
+          .then(() => {
+            cy.log('select measurement and field')
+            cy.getByTestID(`selector-list defbuck`)
+              .click()
+              .then(() => {
+                cy.getByTestID(`selector-list ${measurement}`)
+                  .click()
+                  .then(() => {
+                    cy.getByTestID(`selector-list ${field}`).click()
+                  })
+              })
+          })
+      })
 
     cy.log('name the check; save')
     cy.getByTestID('overlay').within(() => {

--- a/jest.config.js
+++ b/jest.config.js
@@ -24,6 +24,7 @@ module.exports = {
       tsConfig: 'tsconfig.test.json',
       diagnostics: {
         ignoreCodes: [6133, 6192], // ignore unused variable errors
+        warnOnly: true
       },
     },
   },

--- a/jestSetup.ts
+++ b/jestSetup.ts
@@ -2,6 +2,7 @@ import {cleanup} from '@testing-library/react'
 import 'intersection-observer'
 import MutationObserver from 'mutation-observer'
 import fetchMock from 'jest-fetch-mock'
+import '@testing-library/jest-dom'
 
 // global vars
 process.env.API_PREFIX = 'http://example.com/'

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@babel/preset-env": "^7.5.5",
     "@influxdata/oats": "0.5.0",
     "@testing-library/dom": "^7.24.2",
+    "@testing-library/jest-dom": "^5.11.6",
     "@testing-library/react": "^11.0.4",
     "@testing-library/user-event": "^12.1.6",
     "@types/chroma-js": "^1.3.4",

--- a/src/cloud/utils/__mocks__/reporting.ts
+++ b/src/cloud/utils/__mocks__/reporting.ts
@@ -1,0 +1,1 @@
+export const event = jest.fn()

--- a/src/mockAppState.tsx
+++ b/src/mockAppState.tsx
@@ -30,11 +30,13 @@ export const mockAppState = {
   },
   resources: {
     orgs: {
+      status: RemoteDataState.Done,
       org: {
         id: '674b23253171ee69',
       },
     },
     variables: {
+      status: RemoteDataState.Done,
       byID: {
         '054b7476389f1000': {
           id: '054b7476389f1000',

--- a/src/resources/components/__mocks__/GetResources.tsx
+++ b/src/resources/components/__mocks__/GetResources.tsx
@@ -1,0 +1,13 @@
+import {PureComponent, ReactNode} from 'react'
+import {ResourceType} from 'src/types'
+
+interface Props {
+  resources: Array<ResourceType>
+  children: ReactNode
+}
+
+export default class GetResources extends PureComponent<Props> {
+  render() {
+    return this.props.children
+  }
+}

--- a/src/shared/actions/__mocks__/notifications.ts
+++ b/src/shared/actions/__mocks__/notifications.ts
@@ -1,0 +1,6 @@
+export const notify = jest.fn(() => {
+  return {
+    type: 'PUBLISH_NOTIFICATION',
+    payload: {notification: 'notification message'},
+  }
+})

--- a/src/shared/utils/__mocks__/errors.ts
+++ b/src/shared/utils/__mocks__/errors.ts
@@ -1,0 +1,3 @@
+export const reportErrorThroughHoneyBadger = jest.fn()
+
+export const parseComponentName = jest.fn()

--- a/src/templates/containers/CommunityTemplatesIndex.test.tsx
+++ b/src/templates/containers/CommunityTemplatesIndex.test.tsx
@@ -1,0 +1,151 @@
+// Installed libraries
+import React from 'react'
+import {createStore} from 'redux'
+import {fireEvent, screen} from '@testing-library/react'
+import {normalize} from 'normalizr'
+import {mocked} from 'ts-jest/utils'
+
+// Manual mocks
+jest.mock('src/cloud/utils/reporting')
+jest.mock('src/resources/components/GetResources')
+jest.mock('src/shared/actions/notifications')
+jest.mock('src/shared/utils/errors')
+
+jest.mock('src/templates/api', () => {
+  return {
+    fetchStacks: jest.fn(() => {
+      return []
+    }),
+    reviewTemplate: jest.fn(() => {
+      return {summary: {}}
+    }),
+  }
+})
+
+// Imported mocks - don't import these until after mocking the functionality contained therein
+import {event} from 'src/cloud/utils/reporting'
+import {notify} from 'src/shared/actions/notifications'
+import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
+
+// Mock State
+import {renderWithReduxAndRouter} from 'src/mockState'
+import {withRouterProps} from 'mocks/dummyData'
+import {mockAppState} from 'src/mockAppState'
+
+// Types
+import {Organization, RemoteDataState, OrgEntities} from 'src/types'
+import {arrayOfOrgs} from 'src/schemas'
+
+// Redux
+import {templatesReducer} from 'src/templates/reducers/index'
+
+// What have you
+import {communityTemplateUnsupportedFormatError} from 'src/shared/copy/notifications'
+
+// The file under test, imported last
+import {CommunityTemplatesIndex} from 'src/templates/containers/CommunityTemplatesIndex'
+
+const defaultProps = {
+  ...withRouterProps,
+  notify: jest.fn(),
+  setStagedTemplateUrl: jest.fn(),
+  org: '',
+  stagedTemplateUrl: '',
+}
+
+const setup = (props = defaultProps) => {
+  const templatesStore = createStore(templatesReducer)
+
+  return renderWithReduxAndRouter(
+    <CommunityTemplatesIndex {...props} />,
+    _fakeLocalStorage => {
+      const appState = {...mockAppState} as any
+      appState.resources.templates = templatesStore.getState()
+      return appState
+    }
+  )
+}
+
+describe('the Community Templates index', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('starting the template install process', () => {
+    it('notifies the user when there is no template url to lookup', () => {
+      const {getByTitle} = setup()
+      const templateButton = getByTitle('Lookup Template')
+
+      fireEvent.click(templateButton)
+
+      const [notifyCallArguments] = mocked(notify).mock.calls
+      const [notifyMessage] = notifyCallArguments
+      expect(notifyMessage).toEqual(communityTemplateUnsupportedFormatError())
+    })
+
+    it('opens the install overlay when the template url is valid', () => {
+      const {getByTitle, store} = setup()
+
+      // This successful call opens the Community Templates Installer overlay which requires orgs to be set
+      const org = {name: 'zoe', id: '12345'}
+      store.dispatch({
+        type: 'SET_ORG',
+        org: org,
+      })
+      const organizations = normalize<Organization, OrgEntities, string[]>(
+        [org],
+        arrayOfOrgs
+      )
+      store.dispatch({
+        type: 'SET_ORGS',
+        schema: organizations,
+        status: RemoteDataState.Done,
+      })
+
+      store.dispatch({
+        type: 'SET_STAGED_TEMPLATE_URL',
+        templateUrl:
+          'https://github.com/influxdata/community-templates/blob/master/fortnite/fn-template.yml',
+      })
+
+      const templateButton = getByTitle('Lookup Template')
+
+      fireEvent.click(templateButton)
+
+      const [eventCallArguments] = mocked(event).mock.calls
+      const [eventName, eventMetaData] = eventCallArguments
+      expect(eventName).toBe('template_click_lookup')
+      expect(eventMetaData).toEqual({templateName: 'fn-template'})
+      expect(screen.getByText('Template Installer')).toBeInTheDocument()
+    })
+
+    it('handles failures', () => {
+      const {getByTitle, store} = setup()
+
+      store.dispatch({
+        type: 'SET_STAGED_TEMPLATE_URL',
+        templateUrl:
+          'https://github.com/influxdata/community-templates/blob/master/fortnite/fn-template.yml',
+      })
+
+      mocked(event).mockImplementation(() => {
+        throw new Error()
+      })
+
+      const templateButton = getByTitle('Lookup Template')
+
+      fireEvent.click(templateButton)
+
+      const [notifyCallArguments] = mocked(notify).mock.calls
+      const [notifyMessage] = notifyCallArguments
+      expect(notifyMessage).toEqual(communityTemplateUnsupportedFormatError())
+
+      const [honeyBadgerCallArguments] = mocked(
+        reportErrorThroughHoneyBadger
+      ).mock.calls
+      expect(honeyBadgerCallArguments[1]).toEqual({
+        name: 'The community template getTemplateDetails failed',
+      })
+    })
+  })
+})

--- a/src/templates/containers/CommunityTemplatesIndex.tsx
+++ b/src/templates/containers/CommunityTemplatesIndex.tsx
@@ -182,7 +182,6 @@ class UnconnectedCommunityTemplatesIndex extends Component<Props, State> {
                 </Panel.Body>
               </Panel>
             </FlexBox>
-
             <GetResources
               resources={[
                 ResourceType.Buckets,
@@ -248,7 +247,6 @@ class UnconnectedCommunityTemplatesIndex extends Component<Props, State> {
       event('template_click_lookup', {
         templateName: getTemplateNameFromUrl(this.props.stagedTemplateUrl).name,
       })
-
       this.props.history.push(
         `/orgs/${this.props.org.id}/settings/templates/import`
       )

--- a/yarn.lock
+++ b/yarn.lock
@@ -681,6 +681,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.9.2":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
+  integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.1.0", "@babel/template@^7.2.2", "@babel/template@^7.4.0", "@babel/template@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.4.tgz#f4b88d1225689a08f5bc3a17483545be9e4ed237"
@@ -992,6 +999,17 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@jest/types@^26.6.2":
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
+  integrity sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
@@ -1011,6 +1029,20 @@
     chalk "^4.1.0"
     dom-accessibility-api "^0.5.1"
     pretty-format "^26.4.2"
+
+"@testing-library/jest-dom@^5.11.6":
+  version "5.11.6"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.11.6.tgz#782940e82e5cd17bc0a36f15156ba16f3570ac81"
+  integrity sha512-cVZyUNRWwUKI0++yepYpYX7uhrP398I+tGz4zOlLVlUYnZS+Svuxv4fwLeCIy7TnBYKXUaOlQr3vopxL8ZfEnA==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    "@types/testing-library__jest-dom" "^5.9.1"
+    aria-query "^4.2.2"
+    chalk "^3.0.0"
+    css "^3.0.0"
+    css.escape "^1.5.1"
+    lodash "^4.17.15"
+    redent "^3.0.0"
 
 "@testing-library/react@^11.0.4":
   version "11.0.4"
@@ -1184,6 +1216,14 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
+"@types/jest@*":
+  version "26.0.16"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.16.tgz#b47abd50f6ed0503f589db8e126fc8eb470cf87c"
+  integrity sha512-Gp12+7tmKCgv9JjtltxUXokohCAEZfpJaEW5tn871SGRp8I+bRWBonQO7vW5NHwnAHe5dd50+Q4zyKuN35i09g==
+  dependencies:
+    jest-diff "^26.0.0"
+    pretty-format "^26.0.0"
+
 "@types/jest@^23.3.2":
   version "23.3.3"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.3.tgz#246ebcc52771d2327bb8e37aa971b412d9dc4237"
@@ -1352,6 +1392,13 @@
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.4.tgz#b4ffc7dc97b498c969b360a41eee247f82616370"
   integrity sha512-78AdXtlhpCHT0K3EytMpn4JNxaf5tbqbLcbIRoQIHzpTIyjpxLQKRoxU55ujBXAtg3Nl2h/XWvfDa9dsMOd0pQ==
+
+"@types/testing-library__jest-dom@^5.9.1":
+  version "5.9.5"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.5.tgz#5bf25c91ad2d7b38f264b12275e5c92a66d849b0"
+  integrity sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==
+  dependencies:
+    "@types/jest" "*"
 
 "@types/text-encoding@^0.0.32":
   version "0.0.32"
@@ -2746,6 +2793,14 @@ chalk@^2.1.0, chalk@^2.3.0, chalk@^2.4.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chalk@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
+  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
@@ -3559,10 +3614,19 @@ css-what@^2.1.2:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
   integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
 
-css.escape@^1.5.0:
+css.escape@^1.5.0, css.escape@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
   integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
+
+css@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css/-/css-3.0.0.tgz#4447a4d58fdd03367c516ca9f64ae365cee4aa5d"
+  integrity sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==
+  dependencies:
+    inherits "^2.0.4"
+    source-map "^0.6.1"
+    source-map-resolve "^0.6.0"
 
 cssesc@^2.0.0:
   version "2.0.0"
@@ -3985,6 +4049,11 @@ diff-sequences@^24.3.0:
   version "24.3.0"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.3.0.tgz#0f20e8a1df1abddaf4d9c226680952e64118b975"
   integrity sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==
+
+diff-sequences@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
+  integrity sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
 
 diff@3.5.0:
   version "3.5.0"
@@ -6035,7 +6104,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -6641,6 +6710,16 @@ jest-diff@^24.8.0:
     jest-get-type "^24.8.0"
     pretty-format "^24.8.0"
 
+jest-diff@^26.0.0:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.6.2.tgz#1aa7468b52c3a68d7d5c5fdcdfcd5e49bd164394"
+  integrity sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^26.6.2"
+    jest-get-type "^26.3.0"
+    pretty-format "^26.6.2"
+
 jest-docblock@^24.3.0:
   version "24.3.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-24.3.0.tgz#b9c32dac70f72e4464520d2ba4aec02ab14db5dd"
@@ -6699,6 +6778,11 @@ jest-get-type@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.9.0.tgz#1684a0c8a50f2e4901b6644ae861f579eed2ef0e"
   integrity sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==
+
+jest-get-type@^26.3.0:
+  version "26.3.0"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"
+  integrity sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==
 
 jest-haste-map@^24.8.0:
   version "24.8.1"
@@ -7752,6 +7836,11 @@ mimic-fn@^2.0.0, mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+
+min-indent@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
+  integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
 mini-create-react-context@^0.4.0:
   version "0.4.0"
@@ -9281,6 +9370,16 @@ pretty-format@^24.9.0:
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
 
+pretty-format@^26.0.0, pretty-format@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
+  integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==
+  dependencies:
+    "@jest/types" "^26.6.2"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^17.0.1"
+
 pretty-format@^26.4.2:
   version "26.4.2"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.4.2.tgz#d081d032b398e801e2012af2df1214ef75a81237"
@@ -9675,6 +9774,11 @@ react-is@^16.8.4:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
+react-is@^17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
+  integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
+
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
@@ -9882,6 +9986,14 @@ realpath-native@^1.1.0:
   integrity sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==
   dependencies:
     util.promisify "^1.0.0"
+
+redent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"
+  integrity sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==
+  dependencies:
+    indent-string "^4.0.0"
+    strip-indent "^3.0.0"
 
 redux-auth-wrapper@^1.0.0:
   version "1.1.0"
@@ -10771,6 +10883,14 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
+source-map-resolve@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.6.0.tgz#3d9df87e236b53f16d01e58150fc7711138e5ed2"
+  integrity sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==
+  dependencies:
+    atob "^2.1.2"
+    decode-uri-component "^0.2.0"
+
 source-map-support@^0.5.6:
   version "0.5.12"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.12.tgz#b4f3b10d51857a5af0138d3ce8003b201613d599"
@@ -11117,6 +11237,13 @@ strip-final-newline@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
+
+strip-indent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
+  integrity sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
+  dependencies:
+    min-indent "^1.0.0"
 
 strip-json-comments@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/19175

* Adds an integration test for the three conditions in `CommunityTemplatesIndex.tsx` function `startTemplateInstall`
* Adds the `testing-library` helper `jest-dom`
* Adds manual mocks for the following functions:
  * `src/cloud/utils/reporting`: `event`
  * `src/resources/components/GetResources`: `GetResources`
  * `src/shared/actions/notifications`: `notify`
  * `src/shared/utils/errors`: `reportErrorThroughHoneyBadger`, `parseComponentName`
* To use the mocks, simply pass the path to the `jest.mock` function:
  * ```ts
    jest.mock('src/cloud/utils/reporting')
    jest.mock('src/resources/components/GetResources')
     ```

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

