### PR TITLE
build(lsp): Upgrade flux-lsp-browser to v0.5.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
   "dependencies": {
     "@influxdata/clockface": "2.3.7",
     "@influxdata/flux": "^0.5.1",
-    "@influxdata/flux-lsp-browser": "^0.5.24",
+    "@influxdata/flux-lsp-browser": "^0.5.25",
     "@influxdata/giraffe": "1.0.2",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -780,10 +780,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-2.3.7.tgz#a06ac309e845893d1aa7e18096cbec375e3c3723"
   integrity sha512-GJH+btBpvMgn+FjdC3Ee49iyfcrRgDo+B29/gU3z1S+WaKJCpaAIIhLuaAZQGM/4TbTZlPID+/vAVrdNolxKGQ==
 
-"@influxdata/flux-lsp-browser@^0.5.24":
-  version "0.5.24"
-  resolved "https://registry.yarnpkg.com/@influxdata/flux-lsp-browser/-/flux-lsp-browser-0.5.24.tgz#1f93a59f0a99792810fe2594df5188ab6ea39240"
-  integrity sha512-9AfcEMnhkvw7IG6/YgTQCyZXLVPr+vy5+iy6+zeN5zlHRLbAKxsXl+D38DnF9o3VRdxvI9RZfaPeHAOz4tgopg==
+"@influxdata/flux-lsp-browser@^0.5.25":
+  version "0.5.25"
+  resolved "https://registry.yarnpkg.com/@influxdata/flux-lsp-browser/-/flux-lsp-browser-0.5.25.tgz#28d1b50348077e0aea16cf0655967c2f319a48f6"
+  integrity sha512-LE+dqp2JMz3MmrFQI7h/eIY76ASvN6VrK50jlbMYLm0Z00VoAgkfLFT44ACv29FFVdx6/zDZp/npQWHNGTYUbA==
 
 "@influxdata/flux@^0.5.1":
   version "0.5.1"


### PR DESCRIPTION
Upgrade `flux-lsp-browser` to [flux-lsp v0.5.25](https://github.com/influxdata/flux-lsp/releases/tag/v0.5.25)

Note: This will disable callbacks for user data and any auto-complete functionality that relies on them. This should not require any change to the ui code. See https://github.com/influxdata/flux-lsp/pull/194 for details.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

