### PR TITLE
fix: clean localstorage event lifecycles

### DIFF
--- a/src/flows/components/header/Submit.tsx
+++ b/src/flows/components/header/Submit.tsx
@@ -69,11 +69,16 @@ export const Submit: FC = () => {
       .join('')
   }, [flow.data])
 
+  const _range = useMemo(() => (
+      `${flow.range.lower} to ${flow.range.upper || 'now'}`
+  ), [flow.range])
+
   useEffect(() => {
     if (hasQueries) {
+        console.log('damn use effect')
       submit()
     }
-  }, [flow.range, hasQueries, aggregateOfAggregates]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [_range, hasQueries, aggregateOfAggregates]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const forceUpdate = (id, data) => {
     try {
@@ -84,6 +89,10 @@ export const Submit: FC = () => {
   }
 
   const submit = () => {
+    if (isLoading === RemoteDataState.Loading) {
+        return
+    }
+
     const map = generateMap(runMode === RunMode.Run)
 
     if (!map.length) {
@@ -102,8 +111,8 @@ export const Submit: FC = () => {
         return query(stage.text)
           .then(response => {
             stage.instances.forEach(pipeID => {
-              forceUpdate(pipeID, response)
               flow.meta.update(pipeID, {loading: RemoteDataState.Done})
+              forceUpdate(pipeID, response)
             })
           })
           .catch(e => {

--- a/src/flows/components/header/Submit.tsx
+++ b/src/flows/components/header/Submit.tsx
@@ -69,13 +69,13 @@ export const Submit: FC = () => {
       .join('')
   }, [flow.data])
 
-  const _range = useMemo(() => (
-      `${flow.range.lower} to ${flow.range.upper || 'now'}`
-  ), [flow.range])
+  const _range = useMemo(
+    () => `${flow.range.lower} to ${flow.range.upper || 'now'}`,
+    [flow.range]
+  )
 
   useEffect(() => {
     if (hasQueries) {
-        console.log('damn use effect')
       submit()
     }
   }, [_range, hasQueries, aggregateOfAggregates]) // eslint-disable-line react-hooks/exhaustive-deps
@@ -90,7 +90,7 @@ export const Submit: FC = () => {
 
   const submit = () => {
     if (isLoading === RemoteDataState.Loading) {
-        return
+      return
     }
 
     const map = generateMap(runMode === RunMode.Run)

--- a/src/flows/components/panel/Results.tsx
+++ b/src/flows/components/panel/Results.tsx
@@ -29,15 +29,14 @@ const Results: FC = () => {
   const meta = flow.meta.get(id)
   const resultsExist =
     !!results && !!results.raw && !!results.parsed.table.length
-  const raw = (results || {}).raw || ''
 
-  const rows = useMemo(() => raw.split('\n'), [raw])
+  const rows = useMemo(() => results.raw.split('\n'), [results.raw])
   const [startRow, setStartRow] = useState<number>(0)
   const [pageSize, setPageSize] = useState<number>(0)
 
   useEffect(() => {
     setStartRow(0)
-  }, [raw])
+  }, [results.parsed])
 
   const prevDisabled = startRow <= 0
   const nextDisabled = startRow + pageSize >= rows.length
@@ -74,6 +73,7 @@ const Results: FC = () => {
     emptyText = 'No Data Returned'
   }
 
+
   return (
     <Resizer
       loading={meta.loading}
@@ -105,12 +105,14 @@ const Results: FC = () => {
               }
 
               const page = Math.floor(height / ROW_HEIGHT)
-              setPageSize(page)
 
-              const parsedResults = fromFlux(raw)
+              if (page !== pageSize) {
+                  setPageSize(page)
+              }
+
               return (
                 <RawFluxDataTable
-                  parsedResults={parsedResults}
+                  parsedResults={results.parsed}
                   startRow={startRow}
                   width={width}
                   height={page * ROW_HEIGHT}

--- a/src/flows/components/panel/Results.tsx
+++ b/src/flows/components/panel/Results.tsx
@@ -1,7 +1,6 @@
 // Libraries
 import React, {FC, useEffect, useState, useContext, useMemo} from 'react'
 import {AutoSizer} from 'react-virtualized'
-import {fromFlux} from '@influxdata/giraffe'
 
 // Components
 import RawFluxDataTable from 'src/timeMachine/components/RawFluxDataTable'

--- a/src/flows/components/panel/Results.tsx
+++ b/src/flows/components/panel/Results.tsx
@@ -73,7 +73,6 @@ const Results: FC = () => {
     emptyText = 'No Data Returned'
   }
 
-
   return (
     <Resizer
       loading={meta.loading}
@@ -107,7 +106,7 @@ const Results: FC = () => {
               const page = Math.floor(height / ROW_HEIGHT)
 
               if (page !== pageSize) {
-                  setPageSize(page)
+                setPageSize(page)
               }
 
               return (

--- a/src/flows/context/flow.current.tsx
+++ b/src/flows/context/flow.current.tsx
@@ -75,21 +75,21 @@ export const FlowProvider: FC = ({children}) => {
   }
 
   if (!flows || !flows.hasOwnProperty(currentID)) {
-      return null
+    return null
   }
 
   return (
-      <FlowContext.Provider
-          value={{
-              id: currentID,
-              name,
-              flow: flows[currentID],
-              add: addPipe,
-              update: updateCurrent,
-          }}
-      >
-          {children}
-      </FlowContext.Provider>
+    <FlowContext.Provider
+      value={{
+        id: currentID,
+        name,
+        flow: flows[currentID],
+        add: addPipe,
+        update: updateCurrent,
+      }}
+    >
+      {children}
+    </FlowContext.Provider>
   )
 }
 

--- a/src/flows/context/flow.current.tsx
+++ b/src/flows/context/flow.current.tsx
@@ -54,7 +54,7 @@ export const FlowProvider: FC = ({children}) => {
         ...flow,
       })
     },
-    [currentID]
+    [currentID, flows[currentID]]
   )
 
   const addPipe = (initial: PipeData, index?: number) => {
@@ -74,25 +74,23 @@ export const FlowProvider: FC = ({children}) => {
     return id
   }
 
-  return useMemo(() => {
-    if (!flows || !flows.hasOwnProperty(currentID)) {
+  if (!flows || !flows.hasOwnProperty(currentID)) {
       return null
-    }
+  }
 
-    return (
+  return (
       <FlowContext.Provider
-        value={{
-          id: currentID,
-          name,
-          flow: flows[currentID],
-          add: addPipe,
-          update: updateCurrent,
-        }}
+          value={{
+              id: currentID,
+              name,
+              flow: flows[currentID],
+              add: addPipe,
+              update: updateCurrent,
+          }}
       >
-        {children}
+          {children}
       </FlowContext.Provider>
-    )
-  }, [currentID, (flows || {})[currentID]])
+  )
 }
 
 const CurrentFlow: FC = ({children}) => {

--- a/src/flows/context/flow.current.tsx
+++ b/src/flows/context/flow.current.tsx
@@ -1,4 +1,4 @@
-import React, {FC, useContext, useCallback, useMemo} from 'react'
+import React, {FC, useContext, useCallback} from 'react'
 import {Flow, PipeData} from 'src/types/flows'
 import {FlowListContext, FlowListProvider} from 'src/flows/context/flow.list'
 import {v4 as UUID} from 'uuid'

--- a/src/flows/context/flow.list.tsx
+++ b/src/flows/context/flow.list.tsx
@@ -114,8 +114,6 @@ export const FlowListProvider: FC = ({children}) => {
   const [flows, setFlows] = useFlowListState(DEFAULT_CONTEXT.flows)
   const [currentID, setCurrentID] = useFlowCurrentState(null)
 
-  //console.log(flows[currentID].meta.byID['local_87978d33-d27b-4de1-8dc4-59cac25c3883'])
-
   const add = (flow?: Flow): Promise<string> => {
     let _flow
 
@@ -188,13 +186,6 @@ export const FlowListProvider: FC = ({children}) => {
       readOnly: flow.readOnly,
     }
 
-    if (id === 'local_b68fa287-e81d-454a-ae25-f79147a9696d') {
-        console.log(data)
-    }
-    if (data.meta.byID['local_87978d33-d27b-4de1-8dc4-59cac25c3883'].loading === RemoteDataState.Loading) {
-        debugger
-    }
-
     setFlows({
       ...flows,
       [id]: data,
@@ -229,9 +220,6 @@ export const FlowListProvider: FC = ({children}) => {
 
   const flowList = Object.keys(flows).reduce((acc, curr) => {
     const stateUpdater = (field, data) => {
-        if (field === 'meta') {
-        console.log('neat', field, data.byID['local_87978d33-d27b-4de1-8dc4-59cac25c3883'], flows[curr].meta.byID['local_87978d33-d27b-4de1-8dc4-59cac25c3883'])
-        }
       const _flow = {
         ...flows[curr],
       }

--- a/src/flows/context/flow.list.tsx
+++ b/src/flows/context/flow.list.tsx
@@ -114,6 +114,8 @@ export const FlowListProvider: FC = ({children}) => {
   const [flows, setFlows] = useFlowListState(DEFAULT_CONTEXT.flows)
   const [currentID, setCurrentID] = useFlowCurrentState(null)
 
+  //console.log(flows[currentID].meta.byID['local_87978d33-d27b-4de1-8dc4-59cac25c3883'])
+
   const add = (flow?: Flow): Promise<string> => {
     let _flow
 
@@ -186,6 +188,13 @@ export const FlowListProvider: FC = ({children}) => {
       readOnly: flow.readOnly,
     }
 
+    if (id === 'local_b68fa287-e81d-454a-ae25-f79147a9696d') {
+        console.log(data)
+    }
+    if (data.meta.byID['local_87978d33-d27b-4de1-8dc4-59cac25c3883'].loading === RemoteDataState.Loading) {
+        debugger
+    }
+
     setFlows({
       ...flows,
       [id]: data,
@@ -220,6 +229,9 @@ export const FlowListProvider: FC = ({children}) => {
 
   const flowList = Object.keys(flows).reduce((acc, curr) => {
     const stateUpdater = (field, data) => {
+        if (field === 'meta') {
+        console.log('neat', field, data.byID['local_87978d33-d27b-4de1-8dc4-59cac25c3883'], flows[curr].meta.byID['local_87978d33-d27b-4de1-8dc4-59cac25c3883'])
+        }
       const _flow = {
         ...flows[curr],
       }

--- a/src/flows/context/pipe.tsx
+++ b/src/flows/context/pipe.tsx
@@ -59,7 +59,7 @@ export const PipeProvider: FC<PipeContextProps> = ({id, children}) => {
     _result = {...DEFAULT_CONTEXT.results}
   }
 
-  return (
+  return useMemo(() => (
     <PipeContext.Provider
       value={{
         id: id,
@@ -73,5 +73,5 @@ export const PipeProvider: FC<PipeContextProps> = ({id, children}) => {
     >
       {children}
     </PipeContext.Provider>
-  )
+  ), [flow, results, flow.meta.get(id).loading])
 }

--- a/src/flows/context/pipe.tsx
+++ b/src/flows/context/pipe.tsx
@@ -59,19 +59,22 @@ export const PipeProvider: FC<PipeContextProps> = ({id, children}) => {
     _result = {...DEFAULT_CONTEXT.results}
   }
 
-  return useMemo(() => (
-    <PipeContext.Provider
-      value={{
-        id: id,
-        data: flow.data.get(id),
-        queryText,
-        update: updater,
-        results: _result,
-        loading: flow.meta.get(id).loading,
-        readOnly: flow.readOnly,
-      }}
-    >
-      {children}
-    </PipeContext.Provider>
-  ), [flow, results, flow.meta.get(id).loading])
+  return useMemo(
+    () => (
+      <PipeContext.Provider
+        value={{
+          id: id,
+          data: flow.data.get(id),
+          queryText,
+          update: updater,
+          results: _result,
+          loading: flow.meta.get(id).loading,
+          readOnly: flow.readOnly,
+        }}
+      >
+        {children}
+      </PipeContext.Provider>
+    ),
+    [flow, results, flow.meta.get(id).loading]
+  )
 }

--- a/src/flows/pipes/RawFluxEditor/view.tsx
+++ b/src/flows/pipes/RawFluxEditor/view.tsx
@@ -40,7 +40,7 @@ const Query: FC<PipeProp> = ({Context}) => {
         />
       </Context>
     ),
-    [query.text, updateText, Context]
+    [query.text, updateText]
   )
 }
 

--- a/src/flows/pipes/Visualization/view.tsx
+++ b/src/flows/pipes/Visualization/view.tsx
@@ -45,7 +45,6 @@ const Visualization: FC<PipeProp> = ({Context}) => {
     setOptionsVisibility(!optionsVisibility)
   }, [optionsVisibility, setOptionsVisibility])
 
-  console.log('lame', loading)
   const updateProperties = useCallback(
     properties => {
       update({

--- a/src/flows/pipes/Visualization/view.tsx
+++ b/src/flows/pipes/Visualization/view.tsx
@@ -44,6 +44,8 @@ const Visualization: FC<PipeProp> = ({Context}) => {
   const toggleOptions = useCallback(() => {
     setOptionsVisibility(!optionsVisibility)
   }, [optionsVisibility, setOptionsVisibility])
+
+  console.log('lame', loading)
   const updateProperties = useCallback(
     properties => {
       update({


### PR DESCRIPTION
if you open the same flow in two tabs, the page starts refreshing until your browser runs out of memory and crashes. 
the fixes to the lifecycle events are here:
https://github.com/influxdata/ui/compare/alex_break_localstorage?expand=1#diff-92d15362f0fc7f6974a7c37272055303d39845a30d049580e8ecda19cfd1c227R81
https://github.com/influxdata/ui/compare/alex_break_localstorage?expand=1#diff-52d3ae4e913057fdba995356a366de14e201ffd609ba6761558e354baec7d8aaR109

this one added a lot of slowness to the system:
https://github.com/influxdata/ui/compare/alex_break_localstorage?expand=1#diff-52d3ae4e913057fdba995356a366de14e201ffd609ba6761558e354baec7d8aaL110

there are still some notable outstanding issues:
dont try and edit a markdown panel while two tabs are open
dragging the visualization in one side doesn't update the height in the other
there's a double refresh on visualization when either tab loads