### PR TITLE
feat: csv uploader for the UI

### DIFF
--- a/src/buckets/components/BucketAddDataButton.tsx
+++ b/src/buckets/components/BucketAddDataButton.tsx
@@ -16,6 +16,7 @@ import {
 
 interface Props {
   onAddCollector: () => void
+  onAddCsv: () => void
   onAddLineProtocol: () => void
   onAddClientLibrary: () => void
   onAddScraper: () => void
@@ -27,6 +28,7 @@ export default class BucketAddDataButton extends PureComponent<Props> {
   public render() {
     const {
       onAddCollector,
+      onAddCsv,
       onAddLineProtocol,
       onAddClientLibrary,
       onAddScraper,
@@ -62,6 +64,17 @@ export default class BucketAddDataButton extends PureComponent<Props> {
                 </div>
                 <div className="bucket-add-data--option-desc">
                   Quickly load an existing line protocol file.
+                </div>
+              </div>
+              <div className="bucket-add-data--option" onClick={onAddCsv}>
+                <div
+                  className="bucket-add-data--option-header"
+                  data-testid="bucket-add-line-protocol"
+                >
+                  CSV Upload
+                </div>
+                <div className="bucket-add-data--option-desc">
+                  Quickly load an existing csv file.
                 </div>
               </div>
               <div

--- a/src/buckets/components/BucketAddDataButton.tsx
+++ b/src/buckets/components/BucketAddDataButton.tsx
@@ -1,5 +1,6 @@
 // Libraries
 import React, {PureComponent, createRef, RefObject} from 'react'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Components
 import CloudExclude from 'src/shared/components/cloud/CloudExclude'
@@ -66,17 +67,19 @@ export default class BucketAddDataButton extends PureComponent<Props> {
                   Quickly load an existing line protocol file.
                 </div>
               </div>
-              <div className="bucket-add-data--option" onClick={onAddCsv}>
-                <div
-                  className="bucket-add-data--option-header"
-                  data-testid="bucket-add-line-protocol"
-                >
-                  CSV Upload
+              {isFlagEnabled('csvUploader') && (
+                <div className="bucket-add-data--option" onClick={onAddCsv}>
+                  <div
+                    className="bucket-add-data--option-header"
+                    data-testid="bucket-add-line-protocol"
+                  >
+                    CSV Upload
+                  </div>
+                  <div className="bucket-add-data--option-desc">
+                    Quickly load an existing csv file.
+                  </div>
                 </div>
-                <div className="bucket-add-data--option-desc">
-                  Quickly load an existing csv file.
-                </div>
-              </div>
+              )}
               <div
                 className="bucket-add-data--option"
                 onClick={onAddClientLibrary}

--- a/src/buckets/components/BucketCardActions.tsx
+++ b/src/buckets/components/BucketCardActions.tsx
@@ -78,6 +78,14 @@ const BucketCardActions: FC<Props> = ({
     )
   }
 
+  const handleCSVUploader = () => {
+    onSetDataLoadersBucket(orgID, bucket.name, bucket.id)
+
+    history.push(
+      `/orgs/${orgID}/load-data/buckets/${bucket.id}/csv-uploader/new`
+    )
+  }
+
   const handleAddClientLibrary = (): void => {
     onSetDataLoadersBucket(orgID, bucket.name, bucket.id)
     onSetDataLoadersType(DataLoaderType.ClientLibrary)
@@ -107,6 +115,7 @@ const BucketCardActions: FC<Props> = ({
       <BucketAddDataButton
         onAddCollector={handleAddCollector}
         onAddLineProtocol={handleAddLineProtocol}
+        onAddCsv={handleCSVUploader}
         onAddClientLibrary={handleAddClientLibrary}
         onAddScraper={handleAddScraper}
       />

--- a/src/buckets/components/csvUploader/CsvUploaderBody.tsx
+++ b/src/buckets/components/csvUploader/CsvUploaderBody.tsx
@@ -1,0 +1,18 @@
+import React, {FC} from 'react'
+import DragAndDrop from 'src/buckets/components/csvUploader/DragAndDrop'
+import {ProgressBar} from '@influxdata/clockface'
+
+type Props = {
+  handleDrop: (csv: string) => void
+  hasFile: boolean
+  value: number
+}
+
+const CsvUploaderBody: FC<Props> = ({handleDrop, hasFile, value}) => (
+  <>
+    <div>{hasFile && <ProgressBar value={value} max={100} />}</div>
+    <DragAndDrop className="line-protocol--content" onSetBody={handleDrop} />
+  </>
+)
+
+export default CsvUploaderBody

--- a/src/buckets/components/csvUploader/CsvUploaderSuccess.tsx
+++ b/src/buckets/components/csvUploader/CsvUploaderSuccess.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import {SparkleSpinner} from '@influxdata/clockface'
+import {RemoteDataState} from 'src/types'
+
+const CsvUploaderSuccess = () => (
+  <div className="line-protocol--spinner">
+    <p
+      data-testid="line-protocol--status"
+      className="line-protocol--status done"
+    >
+      Data Written Successfully
+    </p>
+    <SparkleSpinner loading={RemoteDataState.Done} sizePixels={220} />
+    <p className="line-protocol--status done">Hooray!</p>
+  </div>
+)
+
+export default CsvUploaderSuccess

--- a/src/buckets/components/csvUploader/CsvUploaderWizard.tsx
+++ b/src/buckets/components/csvUploader/CsvUploaderWizard.tsx
@@ -48,7 +48,6 @@ const MAX_CHUNK_SIZE = 1750
 const CsvUploaderWizard = () => {
   const history = useHistory()
   const {bucketID, orgID} = useParams()
-  const [_, setMax] = useState(0)
   const [value, setValue] = useState(0)
   const [hasFile, setHasFile] = useState(false)
   const [uploadFinished, setUploadFinished] = useState(false)
@@ -132,7 +131,6 @@ const CsvUploaderWizard = () => {
           pendingWrites.push(resp)
           counter++
         }
-        setMax(counter)
         chunk = ''
         Promise.all(pendingWrites).finally(() => {
           setUploadFinished(true)

--- a/src/buckets/components/csvUploader/CsvUploaderWizard.tsx
+++ b/src/buckets/components/csvUploader/CsvUploaderWizard.tsx
@@ -1,0 +1,112 @@
+// Libraries
+import React, {useReducer, useState, Dispatch} from 'react'
+import {useHistory, useParams} from 'react-router-dom'
+import {useSelector} from 'react-redux'
+import {
+  Button,
+  ButtonType,
+  ComponentColor,
+  ComponentSize,
+  Form,
+  Overlay,
+  OverlayFooter,
+} from '@influxdata/clockface'
+
+// Components
+import {getByID} from 'src/resources/selectors'
+import DragAndDrop from 'src/buckets/components/lineProtocol/configure/DragAndDrop'
+
+// Actions
+import {writeLineProtocolAction} from 'src/buckets/components/lineProtocol/LineProtocol.thunks'
+import {runQuery} from 'src/shared/apis/query'
+
+// Reducers
+import reducer, {
+  initialState,
+  LineProtocolState,
+} from 'src/buckets/components/lineProtocol/LineProtocol.reducer'
+
+// Types
+import {ResourceType, AppState, Bucket} from 'src/types'
+import {Action} from 'src/buckets/components/lineProtocol/LineProtocol.creators'
+
+// Selectors
+import {getOrg} from 'src/organizations/selectors'
+
+type LineProtocolContext = [LineProtocolState, Dispatch<Action>]
+export const Context = React.createContext<LineProtocolContext>(null)
+
+const getState = (bucketID: string) => (state: AppState) => {
+  const bucket = getByID<Bucket>(state, ResourceType.Buckets, bucketID)
+  const org = getOrg(state).name
+  return {bucket: bucket?.name || '', org}
+}
+
+const CsvUploaderWizard = () => {
+  const history = useHistory()
+  const {bucketID, orgID} = useParams()
+  const [query, setQuery] = useState('')
+  const {bucket, org} = useSelector(getState(bucketID))
+
+  const [state, dispatch] = useReducer(reducer, initialState())
+  const {body, precision} = state
+
+  const handleDismiss = () => {
+    history.push(`/orgs/${orgID}/load-data/buckets`)
+  }
+
+  const handleSubmit = () => {
+    console.log('query: ', query)
+    const result = runQuery(orgID, query)
+    result.promise
+      .then(res => {
+        console.log('res: ', res)
+      })
+      .catch(error => console.error('error: ', error))
+      .then(() => handleDismiss())
+    // writeLineProtocolAction(dispatch, org, bucket, body, precision)
+  }
+
+  const handleDrop = (csv: string) => {
+    console.log('csv: ', csv)
+    const text = `import "csv"
+  csv.from(csv: ${JSON.stringify(csv)})
+  |> to(bucket: "${bucket.trim()}")`
+    console.log('text: ', text)
+    setQuery(text)
+  }
+
+  return (
+    <Context.Provider value={[state, dispatch]}>
+      <Overlay visible={true}>
+        <Overlay.Container maxWidth={800}>
+          <Overlay.Header
+            title="Add Data Using CSV Drag and Drop"
+            onDismiss={handleDismiss}
+          />
+          <Form>
+            <Overlay.Body style={{textAlign: 'center'}}>
+              <DragAndDrop
+                className="line-protocol--content"
+                onSubmit={handleSubmit}
+                onSetBody={handleDrop}
+              />
+            </Overlay.Body>
+          </Form>
+          <OverlayFooter>
+            <Button
+              color={ComponentColor.Default}
+              text="Close"
+              size={ComponentSize.Medium}
+              type={ButtonType.Button}
+              onClick={handleDismiss}
+              testID="lp-close--button"
+            />
+          </OverlayFooter>
+        </Overlay.Container>
+      </Overlay>
+    </Context.Provider>
+  )
+}
+
+export default CsvUploaderWizard

--- a/src/buckets/components/csvUploader/DragAndDrop.tsx
+++ b/src/buckets/components/csvUploader/DragAndDrop.tsx
@@ -1,0 +1,165 @@
+import React, {PureComponent, ChangeEvent, RefObject} from 'react'
+import classnames from 'classnames'
+
+// Components
+import DragAndDropHeader from 'src/buckets/components/csvUploader/DragAndDropHeader'
+import DragInfo from 'src/buckets/components/csvUploader/DragInfo'
+
+interface Props {
+  className: string
+  onSetBody: (body: string) => void
+}
+
+interface State {
+  fileSize: number
+  inputContent: string
+  uploadContent: string
+  fileName: string
+  dragClass: string
+}
+
+let dragCounter = 0
+class DragAndDrop extends PureComponent<Props, State> {
+  private fileInput: RefObject<HTMLInputElement>
+
+  constructor(props: Props) {
+    super(props)
+
+    this.fileInput = React.createRef()
+
+    this.state = {
+      fileSize: -Infinity,
+      inputContent: null,
+      uploadContent: '',
+      fileName: '',
+      dragClass: 'drag-none',
+    }
+  }
+
+  public componentDidMount() {
+    window.addEventListener('dragover', this.handleWindowDragOver)
+    window.addEventListener('drop', this.handleFileDrop)
+    window.addEventListener('dragenter', this.handleDragEnter)
+    window.addEventListener('dragleave', this.handleDragLeave)
+  }
+
+  public componentWillUnmount() {
+    window.removeEventListener('dragover', this.handleWindowDragOver)
+    window.removeEventListener('drop', this.handleFileDrop)
+    window.removeEventListener('dragenter', this.handleDragEnter)
+    window.removeEventListener('dragleave', this.handleDragLeave)
+  }
+
+  public render() {
+    const {uploadContent, fileName} = this.state
+
+    return (
+      <div className={this.containerClass}>
+        <div className={this.dragAreaClass} onClick={this.handleFileOpen}>
+          <DragAndDropHeader
+            uploadContent={uploadContent}
+            fileName={fileName}
+          />
+          <DragInfo uploadContent={uploadContent} />
+          <input
+            type="file"
+            data-testid="drag-and-drop--input"
+            ref={this.fileInput}
+            className="drag-and-drop--input"
+            accept="*"
+            onChange={this.handleFileClick}
+          />
+        </div>
+      </div>
+    )
+  }
+
+  private handleWindowDragOver = (event: DragEvent) => {
+    event.preventDefault()
+  }
+
+  private get containerClass(): string {
+    const {dragClass} = this.state
+    const {className} = this.props
+
+    return classnames('drag-and-drop', {
+      [dragClass]: true,
+      [className]: className,
+    })
+  }
+
+  private get dragAreaClass(): string {
+    const {uploadContent} = this.state
+
+    return classnames('drag-and-drop--form', {active: !uploadContent})
+  }
+
+  private handleFileClick = (e: ChangeEvent<HTMLInputElement>): void => {
+    const file: File = e.currentTarget.files[0]
+    const fileSize = file.size
+
+    this.setState({
+      fileName: file.name,
+      fileSize,
+    })
+
+    e.preventDefault()
+    e.stopPropagation()
+
+    this.uploadFile(file)
+  }
+
+  private handleFileDrop = (e: DragEvent): void => {
+    const file: File = e.dataTransfer.files[0]
+
+    this.setState({
+      fileName: file.name,
+      fileSize: file.size,
+      dragClass: 'drag-none',
+    })
+
+    e.preventDefault()
+    e.stopPropagation()
+
+    this.uploadFile(file)
+  }
+
+  private uploadFile = (file: File) => {
+    const reader = new FileReader()
+    reader.onload = () => {
+      this.setState(
+        {
+          uploadContent: reader.result as string,
+          fileName: file.name,
+        },
+        () => {
+          this.props.onSetBody(this.state.uploadContent)
+        }
+      )
+    }
+    reader.readAsText(file)
+  }
+
+  private handleFileOpen = (): void => {
+    const {uploadContent} = this.state
+    if (uploadContent === '') {
+      this.fileInput.current.click()
+    }
+  }
+
+  private handleDragEnter = (e: DragEvent): void => {
+    dragCounter += 1
+    e.preventDefault()
+    this.setState({dragClass: 'drag-over'})
+  }
+
+  private handleDragLeave = (e: DragEvent): void => {
+    dragCounter -= 1
+    e.preventDefault()
+    if (dragCounter === 0) {
+      this.setState({dragClass: 'drag-none'})
+    }
+  }
+}
+
+export default DragAndDrop

--- a/src/buckets/components/csvUploader/DragAndDropHeader.tsx
+++ b/src/buckets/components/csvUploader/DragAndDropHeader.tsx
@@ -1,0 +1,21 @@
+// Libraries
+import React, {FC} from 'react'
+
+interface Props {
+  uploadContent: string
+  fileName: string
+}
+
+const DragAndDropHeader: FC<Props> = ({uploadContent, fileName}) => {
+  if (uploadContent) {
+    return <div className="drag-and-drop--header selected">{fileName}</div>
+  }
+
+  return (
+    <div className="drag-and-drop--header empty">
+      Drop a file here or click to upload.
+    </div>
+  )
+}
+
+export default DragAndDropHeader

--- a/src/buckets/components/csvUploader/DragInfo.tsx
+++ b/src/buckets/components/csvUploader/DragInfo.tsx
@@ -1,0 +1,15 @@
+// Libraries
+import React, {FC} from 'react'
+import cn from 'classnames'
+
+interface Props {
+  uploadContent: string
+}
+
+const DragInfo: FC<Props> = ({uploadContent}) => {
+  const className = cn('drag-and-drop--graphic', {success: uploadContent})
+
+  return <div className={className} />
+}
+
+export default DragInfo

--- a/src/buckets/containers/BucketsIndex.tsx
+++ b/src/buckets/containers/BucketsIndex.tsx
@@ -21,6 +21,7 @@ import {Page} from '@influxdata/clockface'
 
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Constants
 import {ORGS, ORG_ID, BUCKETS, BUCKET_ID} from 'src/shared/constants/routes'
@@ -58,10 +59,12 @@ class BucketsIndex extends Component {
             path={`${bucketsPath}/line-protocols/new`}
             component={LineProtocolWizard}
           />
-          <Route
-            path={`${bucketsPath}/csv-uploader/new`}
-            component={CsvUploaderWizard}
-          />
+          {isFlagEnabled('csvUploader') && (
+            <Route
+              path={`${bucketsPath}/csv-uploader/new`}
+              component={CsvUploaderWizard}
+            />
+          )}
           <Route
             path={`${bucketsPath}/telegrafs/new`}
             component={CollectorsWizard}

--- a/src/buckets/containers/BucketsIndex.tsx
+++ b/src/buckets/containers/BucketsIndex.tsx
@@ -11,6 +11,7 @@ import GetResources from 'src/resources/components/GetResources'
 import GetAssetLimits from 'src/cloud/components/GetAssetLimits'
 import LimitChecker from 'src/cloud/components/LimitChecker'
 import LineProtocolWizard from 'src/buckets/components/lineProtocol/LineProtocolWizard'
+import CsvUploaderWizard from 'src/buckets/components/csvUploader/CsvUploaderWizard'
 import CollectorsWizard from 'src/dataLoaders/components/collectorsWizard/CollectorsWizard'
 import UpdateBucketOverlay from 'src/buckets/components/UpdateBucketOverlay'
 import RenameBucketOverlay from 'src/buckets/components/RenameBucketOverlay'
@@ -56,6 +57,10 @@ class BucketsIndex extends Component {
           <Route
             path={`${bucketsPath}/line-protocols/new`}
             component={LineProtocolWizard}
+          />
+          <Route
+            path={`${bucketsPath}/csv-uploader/new`}
+            component={CsvUploaderWizard}
           />
           <Route
             path={`${bucketsPath}/telegrafs/new`}


### PR DESCRIPTION
### Problem 

The UI allows users to download CSVs of their data, but they can't upload that data. New users with existing data might not want to go through the configuration process of setting up a telegraf in order to write existing data onto a bucket.

### Solution

Add a CSV uploader to the UI

![csv-uploader](https://user-images.githubusercontent.com/19984220/101842036-0da4b600-3afc-11eb-8059-ee34756de902.gif)

### TODOs

- Needs a link to CSV format documentation
- Update the `time` to be deterministic based on the data rather than set to MS
