### PR TITLE
test: enables notification tests, fixes failures

### DIFF
--- a/cypress/e2e/shared/notificationEndpoints.test.ts
+++ b/cypress/e2e/shared/notificationEndpoints.test.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../src/types'
 
 // skipping these tests until we have a local vault instance working
-describe.skip('Notification Endpoints', () => {
+describe('Notification Endpoints', () => {
   const endpoint: NotificationEndpoint = {
     orgID: '',
     name: 'Pre-Created Endpoint',

--- a/cypress/e2e/shared/notificationRules.test.ts
+++ b/cypress/e2e/shared/notificationRules.test.ts
@@ -1,7 +1,7 @@
 import {SlackNotificationEndpoint, Organization} from '../../../src/types'
 
 // skipping these tests until we have a local vault instance running
-describe.skip('NotificationRules', () => {
+describe('NotificationRules', () => {
   const name1 = 'Slack 1'
   const name2 = 'Slack 2'
   const name3 = 'Slack 3'
@@ -61,20 +61,20 @@ describe.skip('NotificationRules', () => {
         cy.getByTestID('add-threshold-condition-CRIT').click()
         cy.getByTestID('builder-conditions').within(() => {
           cy.getByTestID('panel').within(() => {
-            cy.getByTestID('input-field')
+            cy.getByTestID('input-field-CRIT')
               .click()
               .type('{backspace}{backspace}')
               .invoke('attr', 'type')
               .should('equal', 'text')
-              .getByTestID('input-field--error')
+              .getByTestID('input-field-CRIT--error')
               .should('have.length', 1)
               .and('have.value', '')
-            cy.getByTestID('input-field')
+            cy.getByTestID('input-field-CRIT')
               .click()
               .type('somerangetext')
               .invoke('val')
               .should('equal', '')
-              .getByTestID('input-field--error')
+              .getByTestID('input-field-CRIT--error')
               .should('have.length', 1)
           })
         })
@@ -85,7 +85,7 @@ describe.skip('NotificationRules', () => {
         cy.getByTestID('add-threshold-condition-CRIT').click()
         cy.getByTestID('builder-conditions').within(() => {
           cy.getByTestID('panel').within(() => {
-            cy.getByTestID('input-field')
+            cy.getByTestID('input-field-CRIT')
               .click()
               .type('{backspace}{backspace}9')
               .invoke('val')


### PR DESCRIPTION
Closes #153 

Enables notification e2e tests and changes test ids to correctly identify input fields.

![Screen Shot 2020-12-15 at 11 38 26 AM](https://user-images.githubusercontent.com/6411855/102280341-d3635c00-3ee1-11eb-9e9b-293cbf07f76a.png)
![Screen Shot 2020-12-15 at 1 55 56 PM](https://user-images.githubusercontent.com/6411855/102280344-d52d1f80-3ee1-11eb-91e3-968d16433ba7.png)

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

