### PR TITLE
fix: remove outdated graph tips

### DIFF
--- a/src/shared/components/graph_tips/GraphTips.tsx
+++ b/src/shared/components/graph_tips/GraphTips.tsx
@@ -5,31 +5,21 @@ import React, {FC} from 'react'
 import {ComponentColor, QuestionMarkTooltip} from '@influxdata/clockface'
 
 const GraphTips: FC = () => (
-  <>
-    <QuestionMarkTooltip
-      diameter={18}
-      color={ComponentColor.Primary}
-      testID="graphtips-question-mark"
-      tooltipContents={
-        <>
-          <h1>Graph Tips:</h1>
-          <p>
-            <code>Click + Drag</code> Zoom in (X or Y)
-            <br />
-            <code>Shift + Click</code> Pan Graph Window
-            <br />
-            <code>Double Click</code> Reset Graph Window
-          </p>
-          <h1>Static Legend Tips:</h1>
-          <p>
-            <code>Click</code> Focus on single Series
-            <br />
-            <code>Shift + Click</code> Show/Hide single Series
-          </p>
-        </>
-      }
-    />
-  </>
+  <QuestionMarkTooltip
+    diameter={18}
+    color={ComponentColor.Primary}
+    testID="graphtips-question-mark"
+    tooltipContents={
+      <>
+        <h1>Graph Tips:</h1>
+        <p>
+          <code>Click + Drag</code> Zoom in (X or Y)
+          <br />
+          <code>Double Click</code> Reset Graph Window
+        </p>
+      </>
+    }
+  />
 )
 
 export default GraphTips


### PR DESCRIPTION
Closes #435

This was never implemented in giraffe, but the text from Dygraphs was copied over

![Screen Shot 2020-12-15 at 4 06 29 PM](https://user-images.githubusercontent.com/146112/102287769-f7c63500-3eef-11eb-85bd-251f52dd77c4.png)

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

