### PR TITLE
chore: upgrade clockface dependency to 2.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "webpack-merge": "^4.2.1"
   },
   "dependencies": {
-    "@influxdata/clockface": "2.3.7",
+    "@influxdata/clockface": "2.4.0",
     "@influxdata/flux": "^0.5.1",
     "@influxdata/flux-lsp-browser": "^0.5.26",
     "@influxdata/giraffe": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -782,10 +782,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@influxdata/clockface@2.3.7":
-  version "2.3.7"
-  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-2.3.7.tgz#a06ac309e845893d1aa7e18096cbec375e3c3723"
-  integrity sha512-GJH+btBpvMgn+FjdC3Ee49iyfcrRgDo+B29/gU3z1S+WaKJCpaAIIhLuaAZQGM/4TbTZlPID+/vAVrdNolxKGQ==
+"@influxdata/clockface@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-2.4.0.tgz#e937f20fdd9151cea5eb3b886c4c4786279976ef"
+  integrity sha512-l8ORP+ymmSMvigmqCKBnpjPodLVvhYBQtzkF/mwgob5fl13PvCS1Paep4yuj45qB05W88eFnRYcdG46xO9Kbsg==
 
 "@influxdata/flux-lsp-browser@^0.5.26":
   version "0.5.26"


### PR DESCRIPTION
Introduces the ability to close an overlay via the escape key

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass

