### PR TITLE
chore: allow raw table selection.

### DIFF
--- a/src/timeMachine/components/RawFluxDataTable.scss
+++ b/src/timeMachine/components/RawFluxDataTable.scss
@@ -25,6 +25,9 @@
     text-overflow:  ellipsis;
     white-space: nowrap;
     overflow: hidden;
+    -webkit-user-select: text;
+    -moz-user-select: text;
+    -ms-user-select: text;
     user-select: text;
     cursor: text;
   }


### PR DESCRIPTION
Closes #

Modifies the raw table css element to include the `user-select` attribute that other browsers than chrome support. This will allow selecting the text in safari for one.

see https://developer.mozilla.org/en-US/docs/Web/CSS/user-select
and
https://caniuse.com/?search=user-select

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

