### PR TITLE
feat: fixed some bugs and allowed users to query from the pipe icon

### DIFF
--- a/src/flows/components/header/Submit.tsx
+++ b/src/flows/components/header/Submit.tsx
@@ -53,20 +53,17 @@ export const Submit: FC = () => {
     queryAll()
   }
 
-  const status = flow.meta.all.reduce((_, curr) => {
-    switch (curr?.loading) {
-      case RemoteDataState.Error:
-        return RemoteDataState.Error
-      case RemoteDataState.NotStarted:
-        return RemoteDataState.NotStarted
-      case RemoteDataState.Loading:
-        return RemoteDataState.Loading
-      case RemoteDataState.Done:
-        return RemoteDataState.Done
-      default:
-        return RemoteDataState.NotStarted
-    }
-  }, RemoteDataState.NotStarted)
+  const statuses = flow.meta.all.map(({loading}) => loading)
+
+  let status = RemoteDataState.Done
+
+  if (statuses.every(s => s === RemoteDataState.NotStarted)) {
+    status = RemoteDataState.NotStarted
+  } else if (statuses.includes(RemoteDataState.Error)) {
+    status = RemoteDataState.Error
+  } else if (statuses.includes(RemoteDataState.Loading)) {
+    status = RemoteDataState.Loading
+  }
 
   const DropdownButton = (
     active: boolean,

--- a/src/flows/context/query.tsx
+++ b/src/flows/context/query.tsx
@@ -207,9 +207,6 @@ export const QueryProvider: FC = ({children}) => {
           error: null,
         }
       })
-      .catch(error => {
-        console.error('error: ', error)
-      })
   }
 
   const forceUpdate = (id, data) => {
@@ -230,8 +227,6 @@ export const QueryProvider: FC = ({children}) => {
     if (!map.length) {
       return
     }
-
-    console.log('map: ', map)
 
     event('Flow Submit Button Clicked')
     setLoading(RemoteDataState.Loading)

--- a/src/flows/context/query.tsx
+++ b/src/flows/context/query.tsx
@@ -214,20 +214,17 @@ export const QueryProvider: FC = ({children}) => {
     }
   }
 
-  const status = flow.meta.all.reduce((_, curr) => {
-    switch (curr?.loading) {
-      case RemoteDataState.Error:
-        return RemoteDataState.Error
-      case RemoteDataState.NotStarted:
-        return RemoteDataState.NotStarted
-      case RemoteDataState.Loading:
-        return RemoteDataState.Loading
-      case RemoteDataState.Done:
-        return RemoteDataState.Done
-      default:
-        return RemoteDataState.NotStarted
-    }
-  }, RemoteDataState.NotStarted)
+  const statuses = flow.meta.all.map(({loading}) => loading)
+
+  let status = RemoteDataState.Done
+
+  if (statuses.every(s => s === RemoteDataState.NotStarted)) {
+    status = RemoteDataState.NotStarted
+  } else if (statuses.includes(RemoteDataState.Error)) {
+    status = RemoteDataState.Error
+  } else if (statuses.includes(RemoteDataState.Loading)) {
+    status = RemoteDataState.Loading
+  }
 
   const queryAll = () => {
     if (status === RemoteDataState.Loading) {

--- a/src/flows/pipes/MetricSelector/AggregateWindowSelector.tsx
+++ b/src/flows/pipes/MetricSelector/AggregateWindowSelector.tsx
@@ -7,6 +7,7 @@ import {Dropdown, IconFont, Icon} from '@influxdata/clockface'
 // Contexts
 import {PipeContext} from 'src/flows/context/pipe'
 import {FlowContext} from 'src/flows/context/flow.current'
+import {QueryContext} from 'src/flows/context/query'
 
 // Constants
 import {FUNCTIONS, QueryFn} from 'src/timeMachine/constants/queryBuilder'
@@ -17,6 +18,8 @@ import {millisecondsToDuration} from 'src/shared/utils/duration'
 const AggregateFunctionSelector: FC = () => {
   const {flow} = useContext(FlowContext)
   const {data, update} = useContext(PipeContext)
+  const {queryAll} = useContext(QueryContext)
+
   const selectedFunction = data?.aggregateFunction || FUNCTIONS[0]
 
   const windowPeriod = flow?.range?.windowPeriod
@@ -31,8 +34,9 @@ const AggregateFunctionSelector: FC = () => {
         function: aggregateFunction.name,
       })
       update({aggregateFunction})
+      queryAll()
     },
-    [update]
+    [update, queryAll]
   )
 
   const menuItems = (

--- a/src/flows/shared/ResizerHeader.tsx
+++ b/src/flows/shared/ResizerHeader.tsx
@@ -5,9 +5,15 @@ import classnames from 'classnames'
 // Components
 import {Icon, IconFont} from '@influxdata/clockface'
 
+// Context
+import {PipeContext} from 'src/flows/context/pipe'
+import {QueryContext} from 'src/flows/context/query'
+
+// Utils
+import {event} from 'src/cloud/utils/reporting'
+
 // Types
 import {Visibility} from 'src/types/flows'
-import {PipeContext} from 'src/flows/context/pipe'
 
 interface Props {
   visibility: Visibility
@@ -34,6 +40,7 @@ const ResizerHeader: FC<Props> = ({
   toggleVisibilityEnabled,
 }) => {
   const {readOnly} = useContext(PipeContext)
+  const {queryAll} = useContext(QueryContext)
   const glyph = visibility === 'visible' ? IconFont.EyeOpen : IconFont.EyeClosed
   const className = classnames('panel-resizer--header', {
     'panel-resizer--header__multiple-controls':
@@ -41,9 +48,14 @@ const ResizerHeader: FC<Props> = ({
     [`panel-resizer--header__${visibility}`]: resizingEnabled && visibility,
   })
 
+  const handleSubmit = () => {
+    event('Query All button clicked from inside Pipe')
+    queryAll()
+  }
+
   if (!resizingEnabled) {
     return (
-      <div className={className}>
+      <div className={className} onClick={handleSubmit}>
         <Icon glyph={emptyIcon} className="panel-resizer--vis-toggle" />
       </div>
     )


### PR DESCRIPTION
Closes #417

The primary purpose of this PR is to allow users to run queries when clicking the `play` icon in the pipe:

![run-query](https://user-images.githubusercontent.com/19984220/103030063-e690b000-450f-11eb-8470-c9676b31868d.gif)

This PR also addresses some random issues that were causing Notebooks to be wonky, namely:

- The run button never being disabled due to a miscalculation in identifying metric selector queries
- removing aggregateOfAggregates as a hack to run queries explicitly when updating an aggregate type and just running the query when an aggregate type is changed
- Only changes the loading state of pipes that are being run