### PR TITLE
fix: reverts ssl changes to open up deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run:
           name: Grab compose files
-          command: git --branch alex_no_ssl clone git@github.com:influxdata/monitor-ci.git
+          command: git clone --branch alex_no_ssl git@github.com:influxdata/monitor-ci.git
       - run:
           name: Copy over the testing variables
           command: cp ./monitor-ci/env.testing.oss ./monitor-ci/.env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,7 +174,7 @@ jobs:
       - run:
           name: Update the images we're using
           command: |
-            cd ./monitor-ci && make update && make build NODE=cypress && make build NODE=ingress
+            cd ./monitor-ci && make update && make build NODE=cypress && make build NODE=ingress && make build NODE=dex
             docker load < ~/docker-cache/image.tar
             docker tag quay.io/influxdb/ui-acceptance:${CIRCLE_SHA1} quay.io/influxdb/ui-acceptance:latest
       - run:
@@ -215,7 +215,7 @@ jobs:
       - run:
           name: Update the images we're using
           command: |
-            cd ./monitor-ci && make update && make build NODE=cypress
+            cd ./monitor-ci && make update && make build NODE=cypress && make build NODE=ingress
             docker load < ~/docker-cache-oss/image.tar
             docker tag quay.io/influxdb/ui-acceptance:${CIRCLE_SHA1} quay.io/influxdb/ui-acceptance:latest
       - run:
@@ -257,7 +257,7 @@ jobs:
       - run:
           name: Update the images we're using
           command: |
-            cd ./monitor-ci && make update && make build NODE=cypress && make build NODE=ingress
+            cd ./monitor-ci && make update && make build NODE=cypress && make build NODE=ingress && make build NODE=dex
             docker load < ~/docker-cache/image.tar
             docker tag quay.io/influxdb/ui-acceptance:${CIRCLE_SHA1} quay.io/influxdb/ui-acceptance:latest
       - run:
@@ -298,7 +298,7 @@ jobs:
       - run:
           name: Update the images we're using
           command: |
-            cd ./monitor-ci && make update && make build NODE=ingress
+            cd ./monitor-ci && make update && make build NODE=ingress && make build NODE=dex
             docker load < ~/docker-cache/image.tar
             docker tag quay.io/influxdb/ui-acceptance:${CIRCLE_SHA1} quay.io/influxdb/ui-acceptance:latest
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run:
           name: Grab compose files
-          command: git clone git@github.com:influxdata/monitor-ci.git
+          command: git clone --branch alex_no_ssl git@github.com:influxdata/monitor-ci.git
       - run:
           name: Copy over the testing variables
           command: cp ./monitor-ci/env.testing ./monitor-ci/.env
@@ -46,7 +46,7 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run:
           name: Grab compose files
-          command: git clone git@github.com:influxdata/monitor-ci.git
+          command: git --branch alex_no_ssl clone git@github.com:influxdata/monitor-ci.git
       - run:
           name: Copy over the testing variables
           command: cp ./monitor-ci/env.testing.oss ./monitor-ci/.env
@@ -78,7 +78,7 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run:
           name: Grab compose files
-          command: git clone git@github.com:influxdata/monitor-ci.git
+          command: git clone --branch alex_no_ssl git@github.com:influxdata/monitor-ci.git
       - run:
           name: Build the ui docker image
           command: |
@@ -112,7 +112,7 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run:
           name: Grab deploy files
-          command: git clone git@github.com:influxdata/monitor-ci.git
+          command: git clone --branch alex_no_ssl git@github.com:influxdata/monitor-ci.git
       - run:
           name: Load the prod image
           command: |
@@ -167,7 +167,7 @@ jobs:
       - run:
           name: Grab compose files
           command: |
-            git clone git@github.com:influxdata/monitor-ci.git
+            git clone --branch alex_no_ssl git@github.com:influxdata/monitor-ci.git
       - run:
           name: Copy over the testing variables
           command: cp ./monitor-ci/env.testing.cloud ./monitor-ci/.env
@@ -208,7 +208,7 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run:
           name: Grab compose files
-          command: git clone git@github.com:influxdata/monitor-ci.git
+          command: git clone --branch alex_no_ssl git@github.com:influxdata/monitor-ci.git
       - run:
           name: Copy over the testing variables
           command: cp ./monitor-ci/env.testing.oss ./monitor-ci/.env
@@ -250,7 +250,7 @@ jobs:
       - run:
           name: Grab compose files
           command: |
-            git clone git@github.com:influxdata/monitor-ci.git
+            git clone --branch alex_no_ssl git@github.com:influxdata/monitor-ci.git
       - run:
           name: Copy over the testing variables
           command: cp ./monitor-ci/env.testing.cloud ./monitor-ci/.env
@@ -291,7 +291,7 @@ jobs:
       - run:
           name: Grab compose files
           command: |
-            git clone git@github.com:influxdata/monitor-ci.git
+            git clone --branch alex_no_ssl git@github.com:influxdata/monitor-ci.git
       - run:
           name: Copy over the testing variables
           command: cp ./monitor-ci/env.testing.cloud ./monitor-ci/.env

--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -47,7 +47,7 @@ const makeGraphSnapshot = (() => {
     const name = `graph-snapshot-${lastGraphSnapsotIndex++}`
 
     // wait for drawing done
-    cy.wait(150)
+    cy.wait(500)
     cy.get('[data-testid|=giraffe-layer]')
       .then($layer => ($layer[0] as HTMLCanvasElement).toDataURL('image/jpeg'))
       .as(getNameLayer(name))


### PR DESCRIPTION
doing this just in case there is an emergency over the holidays, and someone has to deploy to fix it (kind of our only trick right now)

temporarily points to a version of monitor-ci  on a branch with reverts applied to it. the idea is to remove when we unblock the pipeline