### PR TITLE
fix: csv uploader correctly maps out values

### DIFF
--- a/src/buckets/components/csvUploader/CsvUploaderWizard.tsx
+++ b/src/buckets/components/csvUploader/CsvUploaderWizard.tsx
@@ -26,13 +26,14 @@ import CsvUploaderSuccess from 'src/buckets/components/csvUploader/CsvUploaderSu
 import {RemoteDataState} from 'src/types'
 
 const CsvUploaderWizard = () => {
-  const {uploadState} = useContext(CsvUploaderContext)
+  const {resetUploadState, uploadState} = useContext(CsvUploaderContext)
   const history = useHistory()
 
   const org = useSelector(getOrg)
   const handleDismiss = useCallback(() => {
     history.push(`/orgs/${org.id}/load-data/buckets`)
-  }, [history, org.id])
+    resetUploadState()
+  }, [history, org.id, resetUploadState])
 
   return (
     <Overlay visible={true}>


### PR DESCRIPTION
Closes #461 

###  Purpose

The CSV uploader was incorrectly uploading `_value` data due to the way that the `_value` is derived on writes from the `_field`. This PR fixes that by assigning the `_value` to the `_field`. This PR also addresses some of the performance issues by decreasing the chunk size of the LP being uploaded in order to (hopefully) lower the query run time for a given chunk
