### PR TITLE
chore: point circleci at master again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run:
           name: Grab compose files
-          command: git clone --branch alex_no_ssl git@github.com:influxdata/monitor-ci.git
+          command: git clone git@github.com:influxdata/monitor-ci.git
       - run:
           name: Copy over the testing variables
           command: cp ./monitor-ci/env.testing ./monitor-ci/.env
@@ -46,7 +46,7 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run:
           name: Grab compose files
-          command: git clone --branch alex_no_ssl git@github.com:influxdata/monitor-ci.git
+          command: git clone git@github.com:influxdata/monitor-ci.git
       - run:
           name: Copy over the testing variables
           command: cp ./monitor-ci/env.testing.oss ./monitor-ci/.env
@@ -78,7 +78,7 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run:
           name: Grab compose files
-          command: git clone --branch alex_no_ssl git@github.com:influxdata/monitor-ci.git
+          command: git clone git@github.com:influxdata/monitor-ci.git
       - run:
           name: Build the ui docker image
           command: |
@@ -112,7 +112,7 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run:
           name: Grab deploy files
-          command: git clone --branch alex_no_ssl git@github.com:influxdata/monitor-ci.git
+          command: git clone git@github.com:influxdata/monitor-ci.git
       - run:
           name: Load the prod image
           command: |
@@ -167,7 +167,7 @@ jobs:
       - run:
           name: Grab compose files
           command: |
-            git clone --branch alex_no_ssl git@github.com:influxdata/monitor-ci.git
+            git clone git@github.com:influxdata/monitor-ci.git
       - run:
           name: Copy over the testing variables
           command: cp ./monitor-ci/env.testing.cloud ./monitor-ci/.env
@@ -208,7 +208,7 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run:
           name: Grab compose files
-          command: git clone --branch alex_no_ssl git@github.com:influxdata/monitor-ci.git
+          command: git clone git@github.com:influxdata/monitor-ci.git
       - run:
           name: Copy over the testing variables
           command: cp ./monitor-ci/env.testing.oss ./monitor-ci/.env
@@ -253,7 +253,7 @@ jobs:
       - run:
           name: Grab compose files
           command: |
-            git clone --branch alex_no_ssl git@github.com:influxdata/monitor-ci.git
+            git clone git@github.com:influxdata/monitor-ci.git
       - run:
           name: Copy over the testing variables
           command: cp ./monitor-ci/env.testing.cloud ./monitor-ci/.env
@@ -294,7 +294,7 @@ jobs:
       - run:
           name: Grab compose files
           command: |
-            git clone --branch alex_no_ssl git@github.com:influxdata/monitor-ci.git
+            git clone git@github.com:influxdata/monitor-ci.git
       - run:
           name: Copy over the testing variables
           command: cp ./monitor-ci/env.testing.cloud ./monitor-ci/.env


### PR DESCRIPTION
This will get circleci to use the master branch of monitor-ci again.