### PR TITLE
chore(experiment): end experiment and change icon

### DIFF
--- a/src/shared/components/CloudUpgradeButton.tsx
+++ b/src/shared/components/CloudUpgradeButton.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FC, useEffect, useState} from 'react'
+import React, {FC} from 'react'
 import {connect} from 'react-redux'
 import {get, find} from 'lodash'
 import classnames from 'classnames'
@@ -24,9 +24,6 @@ import {
 // Types
 import {AppState, OrgSetting} from 'src/types'
 
-// Utils
-import {getExperimentVariantId} from 'src/cloud/utils/experiments'
-
 interface StateProps {
   inView: boolean
 }
@@ -47,26 +44,11 @@ const CloudUpgradeButton: FC<StateProps & OwnProps> = ({
     [`${className}`]: className,
   })
 
-  const [assignedIconVariant, setAssignedIconVariant] = useState<IconFont>(
-    IconFont.Upgrade
-  )
-
-  useEffect(() => {
-    const variantID = getExperimentVariantId('e44rY7GjQN-ASmGeWLs_pA')
-
-    if (variantID) {
-      setAssignedIconVariant(
-        [IconFont.Upgrade, IconFont.CrownSolid, IconFont.Star][variantID] ||
-          IconFont.Upgrade
-      )
-    }
-  }, [setAssignedIconVariant])
-
   return (
     <CloudOnly>
       {inView && (
         <LinkButton
-          icon={assignedIconVariant}
+          icon={IconFont.CrownSolid}
           className={cloudUpgradeButtonClass}
           color={ComponentColor.Success}
           size={size}

--- a/src/shared/components/CloudUpgradeNavBanner.tsx
+++ b/src/shared/components/CloudUpgradeNavBanner.tsx
@@ -63,9 +63,7 @@ const CloudUpgradeNavBanner: FC<StateProps> = ({inView}) => {
             href={`${CLOUD_URL}${CLOUD_CHECKOUT_PATH}`}
             target="_self"
           >
-            <Icon
-              glyph={IconFont.CrownSolid}
-            />
+            <Icon glyph={IconFont.CrownSolid} />
             <Heading element={HeadingElement.H5}>Upgrade Now</Heading>
           </a>
         </CloudOnly>

--- a/src/shared/components/CloudUpgradeNavBanner.tsx
+++ b/src/shared/components/CloudUpgradeNavBanner.tsx
@@ -15,7 +15,6 @@ import {
   IconFont,
 } from '@influxdata/clockface'
 import CloudOnly from 'src/shared/components/cloud/CloudOnly'
-import {GoogleOptimizeExperiment} from 'src/cloud/components/experiments/GoogleOptimizeExperiment'
 
 // Constants
 import {CLOUD_URL, CLOUD_CHECKOUT_PATH} from 'src/shared/constants'

--- a/src/shared/components/CloudUpgradeNavBanner.tsx
+++ b/src/shared/components/CloudUpgradeNavBanner.tsx
@@ -63,21 +63,8 @@ const CloudUpgradeNavBanner: FC<StateProps> = ({inView}) => {
             href={`${CLOUD_URL}${CLOUD_CHECKOUT_PATH}`}
             target="_self"
           >
-            <GoogleOptimizeExperiment
-              experimentID="e44rY7GjQN-ASmGeWLs_pA"
-              original={
-                <Icon
-                  key="e44rY7GjQN-ASmGeWLs_pA--v0"
-                  glyph={IconFont.Upgrade}
-                />
-              }
-              variants={[
-                <Icon
-                  key="e44rY7GjQN-ASmGeWLs_pA--v1"
-                  glyph={IconFont.CrownSolid}
-                />,
-                <Icon key="e44rY7GjQN-ASmGeWLs_pA--v2" glyph={IconFont.Star} />,
-              ]}
+            <Icon
+              glyph={IconFont.CrownSolid}
             />
             <Heading element={HeadingElement.H5}>Upgrade Now</Heading>
           </a>


### PR DESCRIPTION
This PR ends the "Collapsed Nav Upgrade Prompt" experiment. It cleans up the experiment code and implements the winning icon variant.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

