### PR TITLE
feat: add lhr support for master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -414,14 +414,14 @@ jobs:
             cd monitor-ci;
             echo "${CIRCLE_BRANCH} :: ${HERCULES_TOKEN} :: ${CIRCLE_PULL_REQUEST}";
             if [ "${CIRCLE_BRANCH}" = "master" ]; then
-                    echo 'Quick Fix: Not running Lighthouse Reporting...'
+                    make lhr MASTER_BRANCH=1 GITHUB_TOKEN="${HERCULES_TOKEN}";
             else
                     make lhr PR="${CIRCLE_PULL_REQUEST}" GITHUB_TOKEN="${HERCULES_TOKEN}";
             fi
       - store_artifacts:
-          path: monitor-ci/services/lighthouse/artifacts/results.html
+          path: /tmp/results.html
       - store_artifacts:
-          path: monitor-ci/services/lighthouse/artifacts/results.json
+          path: /tmp/results.json
 workflows:
   version: 2
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -412,7 +412,6 @@ jobs:
           no_output_timeout: 10m
           command: |
             cd monitor-ci;
-            echo "${CIRCLE_BRANCH} :: ${HERCULES_TOKEN} :: ${CIRCLE_PULL_REQUEST}";
             if [ "${CIRCLE_BRANCH}" = "master" ]; then
                     make lhr MASTER_BRANCH=1 GITHUB_TOKEN="${HERCULES_TOKEN}";
             else


### PR DESCRIPTION
Closes # https://github.com/influxdata/ui/issues/476

Add master flag to make PR flag mutually exclusive. The issue was that LHR service was failing CircleCI checks on master because lhr service expects a PR but on master, there's no PR. So, adding a flag so that the artifacts still get generated and uploaded but the non-existant PR doesn't get updated.

- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass

