### PR TITLE
fix: these guards fix an error that crashes notebooks when the raw data is undefined

### DIFF
--- a/src/flows/components/panel/Results.tsx
+++ b/src/flows/components/panel/Results.tsx
@@ -29,7 +29,7 @@ const Results: FC = () => {
   const resultsExist =
     !!results && !!results.raw && !!results.parsed.table.length
 
-  const rows = useMemo(() => results.raw.split('\n'), [results.raw])
+  const rows = useMemo(() => results?.raw?.split('\n') ?? '', [results?.raw])
   const [startRow, setStartRow] = useState<number>(0)
   const [pageSize, setPageSize] = useState<number>(0)
 


### PR DESCRIPTION
Moving this out of the schema reducer PR to address the concern separately