### PR TITLE
feat: colorize row toggle

### DIFF
--- a/src/shared/components/BandPlot.tsx
+++ b/src/shared/components/BandPlot.tsx
@@ -12,7 +12,7 @@ import {useAxisTicksGenerator} from 'src/shared/utils/useAxisTicksGenerator'
 import {
   useLegendOpacity,
   useLegendOrientationThreshold,
-    useLegendColorizeRows,
+  useLegendColorizeRows,
 } from 'src/shared/utils/useLegendOrientation'
 import {
   useVisXDomainSettings,
@@ -81,7 +81,7 @@ const BandPlot: FC<Props> = ({
     mainColumn,
     hoverDimension,
     legendOpacity,
-      legendColorizeRows,
+    legendColorizeRows,
     legendOrientationThreshold,
     generateXAxisTicks,
     xTotalTicks,
@@ -146,7 +146,7 @@ const BandPlot: FC<Props> = ({
   const tooltipOrientationThreshold = useLegendOrientationThreshold(
     legendOrientationThreshold
   )
-  const tooltipColorize = useLegendColorizeRows(legendColorizeRows);
+  const tooltipColorize = useLegendColorizeRows(legendColorizeRows)
 
   const storedXDomain = useMemo(() => parseXBounds(xBounds), [xBounds])
   const storedYDomain = useMemo(() => parseYBounds(yBounds), [yBounds])

--- a/src/shared/components/BandPlot.tsx
+++ b/src/shared/components/BandPlot.tsx
@@ -12,6 +12,7 @@ import {useAxisTicksGenerator} from 'src/shared/utils/useAxisTicksGenerator'
 import {
   useLegendOpacity,
   useLegendOrientationThreshold,
+    useLegendColorizeRows,
 } from 'src/shared/utils/useLegendOrientation'
 import {
   useVisXDomainSettings,
@@ -80,6 +81,7 @@ const BandPlot: FC<Props> = ({
     mainColumn,
     hoverDimension,
     legendOpacity,
+      legendColorizeRows,
     legendOrientationThreshold,
     generateXAxisTicks,
     xTotalTicks,
@@ -144,6 +146,7 @@ const BandPlot: FC<Props> = ({
   const tooltipOrientationThreshold = useLegendOrientationThreshold(
     legendOrientationThreshold
   )
+  const tooltipColorize = useLegendColorizeRows(legendColorizeRows);
 
   const storedXDomain = useMemo(() => parseXBounds(xBounds), [xBounds])
   const storedYDomain = useMemo(() => parseYBounds(yBounds), [yBounds])
@@ -223,6 +226,7 @@ const BandPlot: FC<Props> = ({
     legendColumns,
     legendOpacity: tooltipOpacity,
     legendOrientationThreshold: tooltipOrientationThreshold,
+    legendColorizeRows: tooltipColorize,
     valueFormatters: {
       [xColumn]: xFormatter,
       [yColumn]: yFormatter,

--- a/src/shared/components/HeatmapPlot.tsx
+++ b/src/shared/components/HeatmapPlot.tsx
@@ -10,7 +10,7 @@ import {useAxisTicksGenerator} from 'src/shared/utils/useAxisTicksGenerator'
 import {
   useLegendOpacity,
   useLegendOrientationThreshold,
-    useLegendColorizeRows,
+  useLegendColorizeRows,
 } from 'src/shared/utils/useLegendOrientation'
 import {
   useVisXDomainSettings,
@@ -55,7 +55,7 @@ const HeatmapPlot: FunctionComponent<Props> = ({
     timeFormat,
     legendOpacity,
     legendOrientationThreshold,
-      legendColorizeRows,
+    legendColorizeRows,
     generateXAxisTicks,
     xTotalTicks,
     xTickStart,

--- a/src/shared/components/HeatmapPlot.tsx
+++ b/src/shared/components/HeatmapPlot.tsx
@@ -10,6 +10,7 @@ import {useAxisTicksGenerator} from 'src/shared/utils/useAxisTicksGenerator'
 import {
   useLegendOpacity,
   useLegendOrientationThreshold,
+    useLegendColorizeRows,
 } from 'src/shared/utils/useLegendOrientation'
 import {
   useVisXDomainSettings,
@@ -54,6 +55,7 @@ const HeatmapPlot: FunctionComponent<Props> = ({
     timeFormat,
     legendOpacity,
     legendOrientationThreshold,
+      legendColorizeRows,
     generateXAxisTicks,
     xTotalTicks,
     xTickStart,
@@ -82,6 +84,7 @@ const HeatmapPlot: FunctionComponent<Props> = ({
   const tooltipOrientationThreshold = useLegendOrientationThreshold(
     legendOrientationThreshold
   )
+  const tooltipColorize = useLegendColorizeRows(legendColorizeRows)
 
   const [xDomain, onSetXDomain, onResetXDomain] = useVisXDomainSettings(
     storedXDomain,
@@ -139,6 +142,7 @@ const HeatmapPlot: FunctionComponent<Props> = ({
     ...axisTicksOptions,
     legendOpacity: tooltipOpacity,
     legendOrientationThreshold: tooltipOrientationThreshold,
+    legendColorizeRows: tooltipColorize,
     valueFormatters: {
       [xColumn]: xFormatter,
       [yColumn]: yFormatter,

--- a/src/shared/components/HistogramPlot.tsx
+++ b/src/shared/components/HistogramPlot.tsx
@@ -9,6 +9,7 @@ import EmptyGraphMessage from 'src/shared/components/EmptyGraphMessage'
 import {
   useLegendOpacity,
   useLegendOrientationThreshold,
+  useLegendColorizeRows,
 } from 'src/shared/utils/useLegendOrientation'
 import {useVisXDomainSettings} from 'src/shared/utils/useVisDomainSettings'
 import {getFormatter} from 'src/shared/utils/vis'
@@ -43,6 +44,7 @@ const HistogramPlot: FunctionComponent<Props> = ({
     xDomain: storedXDomain,
     legendOpacity,
     legendOrientationThreshold,
+    legendColorizeRows,
   },
   theme,
 }) => {
@@ -52,6 +54,7 @@ const HistogramPlot: FunctionComponent<Props> = ({
   const tooltipOrientationThreshold = useLegendOrientationThreshold(
     legendOrientationThreshold
   )
+  const tooltipColorize = useLegendColorizeRows(legendColorizeRows)
 
   const [xDomain, onSetXDomain, onResetXDomain] = useVisXDomainSettings(
     storedXDomain,
@@ -86,6 +89,7 @@ const HistogramPlot: FunctionComponent<Props> = ({
     valueFormatters: {[xColumn]: xFormatter},
     legendOpacity: tooltipOpacity,
     legendOrientationThreshold: tooltipOrientationThreshold,
+    legendColorizeRows: tooltipColorize,
     layers: [
       {
         type: 'histogram',

--- a/src/shared/components/MosaicPlot.tsx
+++ b/src/shared/components/MosaicPlot.tsx
@@ -8,6 +8,7 @@ import EmptyGraphMessage from 'src/shared/components/EmptyGraphMessage'
 // Utils
 import {useAxisTicksGenerator} from 'src/shared/utils/useAxisTicksGenerator'
 import {
+  useLegendColorizeRows,
   useLegendOpacity,
   useLegendOrientationThreshold,
 } from 'src/shared/utils/useLegendOrientation'
@@ -52,6 +53,7 @@ const MosaicPlot: FunctionComponent<Props> = ({
     timeFormat,
     legendOpacity,
     legendOrientationThreshold,
+    legendColorizeRows,
     generateXAxisTicks,
     xTotalTicks,
     xTickStart,
@@ -83,6 +85,7 @@ const MosaicPlot: FunctionComponent<Props> = ({
   const tooltipOrientationThreshold = useLegendOrientationThreshold(
     legendOrientationThreshold
   )
+  const tooltipColorize = useLegendColorizeRows(legendColorizeRows)
 
   const [xDomain, onSetXDomain, onResetXDomain] = useVisXDomainSettings(
     storedXDomain,
@@ -136,6 +139,7 @@ const MosaicPlot: FunctionComponent<Props> = ({
     ...axisTicksOptions,
     legendOpacity: tooltipOpacity,
     legendOrientationThreshold: tooltipOrientationThreshold,
+    legendColorizeRows: tooltipColorize,
     valueFormatters: {
       [xColumn]: xFormatter,
       [yColumn]: yFormatter,

--- a/src/shared/components/ScatterPlot.tsx
+++ b/src/shared/components/ScatterPlot.tsx
@@ -10,7 +10,7 @@ import {useAxisTicksGenerator} from 'src/shared/utils/useAxisTicksGenerator'
 import {
   useLegendOpacity,
   useLegendOrientationThreshold,
-    useLegendColorizeRows,
+  useLegendColorizeRows,
 } from 'src/shared/utils/useLegendOrientation'
 import {
   useVisXDomainSettings,
@@ -93,7 +93,9 @@ const ScatterPlot: FunctionComponent<Props> = ({
     yTickStep,
   })
   const tooltipOpacity = useLegendOpacity(legendOpacity)
-  const tooltipOrientationThreshold = useLegendOrientationThreshold(legendOrientationThreshold)
+  const tooltipOrientationThreshold = useLegendOrientationThreshold(
+    legendOrientationThreshold
+  )
   const tooltipColorize = useLegendColorizeRows(legendColorizeRows)
 
   let timerange

--- a/src/shared/components/ScatterPlot.tsx
+++ b/src/shared/components/ScatterPlot.tsx
@@ -10,6 +10,7 @@ import {useAxisTicksGenerator} from 'src/shared/utils/useAxisTicksGenerator'
 import {
   useLegendOpacity,
   useLegendOrientationThreshold,
+    useLegendColorizeRows,
 } from 'src/shared/utils/useLegendOrientation'
 import {
   useVisXDomainSettings,
@@ -61,6 +62,7 @@ const ScatterPlot: FunctionComponent<Props> = ({
     timeFormat,
     legendOpacity,
     legendOrientationThreshold,
+    legendColorizeRows,
     generateXAxisTicks,
     xTotalTicks,
     xTickStart,
@@ -91,9 +93,8 @@ const ScatterPlot: FunctionComponent<Props> = ({
     yTickStep,
   })
   const tooltipOpacity = useLegendOpacity(legendOpacity)
-  const tooltipOrientationThreshold = useLegendOrientationThreshold(
-    legendOrientationThreshold
-  )
+  const tooltipOrientationThreshold = useLegendOrientationThreshold(legendOrientationThreshold)
+  const tooltipColorize = useLegendColorizeRows(legendColorizeRows)
 
   let timerange
 
@@ -157,6 +158,7 @@ const ScatterPlot: FunctionComponent<Props> = ({
     ...axisTicksOptions,
     legendOpacity: tooltipOpacity,
     legendOrientationThreshold: tooltipOrientationThreshold,
+    legendColorizeRows: tooltipColorize,
     valueFormatters: {
       [xColumn]: xFormatter,
       [yColumn]: yFormatter,

--- a/src/shared/components/ViewSwitcher.tsx
+++ b/src/shared/components/ViewSwitcher.tsx
@@ -94,6 +94,8 @@ const ViewSwitcher: FunctionComponent<Props> = ({
         </LatestValueTransform>
       )
     case 'xy':
+      console.log('setting props to the xy plot...', properties)
+
       return (
         <XYPlot
           timeRange={timeRange}

--- a/src/shared/components/ViewSwitcher.tsx
+++ b/src/shared/components/ViewSwitcher.tsx
@@ -94,8 +94,6 @@ const ViewSwitcher: FunctionComponent<Props> = ({
         </LatestValueTransform>
       )
     case 'xy':
-      console.log('setting props to the xy plot...', properties)
-
       return (
         <XYPlot
           timeRange={timeRange}

--- a/src/shared/components/XYPlot.tsx
+++ b/src/shared/components/XYPlot.tsx
@@ -106,7 +106,9 @@ const XYPlot: FC<Props> = ({
     yTickStep,
   })
   const tooltipOpacity = useLegendOpacity(legendOpacity)
-  const tooltipOrientationThreshold = useLegendOrientationThreshold(legendOrientationThreshold)
+  const tooltipOrientationThreshold = useLegendOrientationThreshold(
+    legendOrientationThreshold
+  )
   const tooltipColorize = useLegendColorizeRows(legendColorizeRows)
 
   const storedXDomain = useMemo(() => parseXBounds(xBounds), [xBounds])
@@ -181,8 +183,6 @@ const XYPlot: FC<Props> = ({
   })
 
   const currentTheme = theme === 'light' ? VIS_THEME_LIGHT : VIS_THEME
-
-  console.log('in xy plot, in config; tooltipColorize?', tooltipColorize)
 
   const config: Config = {
     ...currentTheme,

--- a/src/shared/components/XYPlot.tsx
+++ b/src/shared/components/XYPlot.tsx
@@ -106,10 +106,7 @@ const XYPlot: FC<Props> = ({
     yTickStep,
   })
   const tooltipOpacity = useLegendOpacity(legendOpacity)
-  const tooltipOrientationThreshold = useLegendOrientationThreshold(
-    legendOrientationThreshold
-  )
-
+  const tooltipOrientationThreshold = useLegendOrientationThreshold(legendOrientationThreshold)
   const tooltipColorize = useLegendColorizeRows(legendColorizeRows)
 
   const storedXDomain = useMemo(() => parseXBounds(xBounds), [xBounds])

--- a/src/shared/components/XYPlot.tsx
+++ b/src/shared/components/XYPlot.tsx
@@ -16,6 +16,7 @@ import {useAxisTicksGenerator} from 'src/shared/utils/useAxisTicksGenerator'
 import {
   useLegendOpacity,
   useLegendOrientationThreshold,
+  useLegendColorizeRows,
 } from 'src/shared/utils/useLegendOrientation'
 import {
   useVisXDomainSettings,
@@ -64,6 +65,7 @@ const XYPlot: FC<Props> = ({
     hoverDimension,
     legendOpacity,
     legendOrientationThreshold,
+    legendColorizeRows,
     generateXAxisTicks,
     xTotalTicks,
     xTickStart,
@@ -107,6 +109,8 @@ const XYPlot: FC<Props> = ({
   const tooltipOrientationThreshold = useLegendOrientationThreshold(
     legendOrientationThreshold
   )
+
+  const tooltipColorize = useLegendColorizeRows(legendColorizeRows)
 
   const storedXDomain = useMemo(() => parseXBounds(xBounds), [xBounds])
   const storedYDomain = useMemo(() => parseYBounds(yBounds), [yBounds])
@@ -181,6 +185,8 @@ const XYPlot: FC<Props> = ({
 
   const currentTheme = theme === 'light' ? VIS_THEME_LIGHT : VIS_THEME
 
+  console.log('in xy plot, in config; tooltipColorize?', tooltipColorize)
+
   const config: Config = {
     ...currentTheme,
     table,
@@ -196,6 +202,7 @@ const XYPlot: FC<Props> = ({
     legendColumns,
     legendOpacity: tooltipOpacity,
     legendOrientationThreshold: tooltipOrientationThreshold,
+    legendColorizeRows: tooltipColorize,
     valueFormatters: {
       [xColumn]: xFormatter,
       [yColumn]: yFormatter,

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -130,6 +130,8 @@ export const LEGEND_OPACITY_DEFAULT = LEGEND_OPACITY_MAXIMUM
 export const LEGEND_OPACITY_STEP = 0.01
 export const LEGEND_ORIENTATION_THRESHOLD_DEFAULT = 10
 
+export const LEGEND_COLORIZE_ROWS_DEFAULT = true
+
 export const QUERY_BUILDER_MODE = 'builder'
 export const SCRIPT_EDITOR_MODE = 'advanced'
 

--- a/src/shared/utils/useLegendOrientation.ts
+++ b/src/shared/utils/useLegendOrientation.ts
@@ -4,6 +4,7 @@ import {
   LEGEND_OPACITY_DEFAULT,
   LEGEND_OPACITY_MINIMUM,
   LEGEND_ORIENTATION_THRESHOLD_DEFAULT,
+  LEGEND_COLORIZE_ROWS_DEFAULT,
 } from 'src/shared/constants'
 
 export const useLegendOpacity = (legendOpacity: number) =>
@@ -26,3 +27,11 @@ export const useLegendOrientationThreshold = (
     }
     return legendOrientationThreshold
   }, [legendOrientationThreshold])
+
+export const useLegendColorizeRows = (legendColorizeRows: boolean) =>
+  useMemo(() => {
+    if (!isFlagEnabled('legendOrientation')) {
+      return LEGEND_COLORIZE_ROWS_DEFAULT
+    }
+    return legendColorizeRows
+  }, [legendColorizeRows])

--- a/src/timeMachine/actions/index.ts
+++ b/src/timeMachine/actions/index.ts
@@ -90,6 +90,7 @@ export type Action =
   | ReturnType<typeof setLowerColumn>
   | ReturnType<typeof setLegendOpacity>
   | ReturnType<typeof setLegendOrientationThreshold>
+  | ReturnType<typeof setLegendColorizeRows>
   | ReturnType<typeof setGenerateXAxisTicks>
   | ReturnType<typeof setGenerateYAxisTicks>
   | ReturnType<typeof setXTotalTicks>
@@ -703,6 +704,11 @@ export const setLegendOrientationThreshold = (
 ) => ({
   type: 'SET_LEGEND_ORIENTATION_THRESHOLD' as 'SET_LEGEND_ORIENTATION_THRESHOLD',
   payload: {legendOrientationThreshold},
+})
+
+export const setLegendColorizeRows = (legendColorizeRows: boolean) => ({
+  type: 'SET_LEGEND_COLORIZE_ROWS' as 'SET_LEGEND_COLORIZE_ROWS',
+  payload: {legendColorizeRows},
 })
 
 export const setGenerateXAxisTicks = (generateXAxisTicks: string[]) => ({

--- a/src/timeMachine/components/view_options/BandOptions.tsx
+++ b/src/timeMachine/components/view_options/BandOptions.tsx
@@ -41,6 +41,7 @@ import {
   setLowerColumn,
   setLegendOpacity,
   setLegendOrientationThreshold,
+  setLegendColorizeRows,
   setGenerateXAxisTicks,
   setXTotalTicks,
   setXTickStart,
@@ -132,6 +133,7 @@ class BandOptions extends PureComponent<Props, State> {
       lowerColumn,
       onSetLegendOpacity,
       onSetLegendOrientationThreshold,
+      onSetLegendColorizeRows,
       onSetGenerateXAxisTicks,
       onSetXTotalTicks,
       onSetXTickStart,
@@ -141,6 +143,8 @@ class BandOptions extends PureComponent<Props, State> {
       onSetYTickStart,
       onSetYTickStep,
     } = this.props
+
+    console.log('a1:  in bandoptions (j-1)');
 
     const upperAndLowerColumnOptions = [
       REMOVE_COLUMN_TEXT,
@@ -332,6 +336,7 @@ class BandOptions extends PureComponent<Props, State> {
         <LegendOrientation
           onLegendOpacityChange={onSetLegendOpacity}
           onLegendOrientationThresholdChange={onSetLegendOrientationThreshold}
+          onLegendColorizeRowsChange={onSetLegendColorizeRows}
         />
       </>
     )
@@ -448,6 +453,7 @@ const mdtp = {
   onSetLowerColumn: setLowerColumn,
   onSetLegendOpacity: setLegendOpacity,
   onSetLegendOrientationThreshold: setLegendOrientationThreshold,
+  onSetLegendColorizeRows: setLegendColorizeRows,
   onSetGenerateXAxisTicks: setGenerateXAxisTicks,
   onSetXTotalTicks: setXTotalTicks,
   onSetXTickStart: setXTickStart,

--- a/src/timeMachine/components/view_options/BandOptions.tsx
+++ b/src/timeMachine/components/view_options/BandOptions.tsx
@@ -144,8 +144,6 @@ class BandOptions extends PureComponent<Props, State> {
       onSetYTickStep,
     } = this.props
 
-    console.log('a1:  in bandoptions (j-1)');
-
     const upperAndLowerColumnOptions = [
       REMOVE_COLUMN_TEXT,
       ...selectedFunctions,

--- a/src/timeMachine/components/view_options/HeatmapOptions.tsx
+++ b/src/timeMachine/components/view_options/HeatmapOptions.tsx
@@ -24,28 +24,28 @@ import AxisTicksGenerator from 'src/shared/components/axisTicks/AxisTicksGenerat
 
 // Actions
 import {
-    setXColumn,
-    setYColumn,
-    setBinSize,
-    setColorHexes,
-    setXDomain,
-    setYDomain,
-    setXAxisLabel,
-    setYAxisLabel,
-    setAxisPrefix,
-    setAxisSuffix,
-    setTimeFormat,
-    setLegendOpacity,
-    setLegendOrientationThreshold,
-    setLegendColorizeRows,
-    setGenerateXAxisTicks,
-    setXTotalTicks,
-    setXTickStart,
-    setXTickStep,
-    setGenerateYAxisTicks,
-    setYTotalTicks,
-    setYTickStart,
-    setYTickStep,
+  setXColumn,
+  setYColumn,
+  setBinSize,
+  setColorHexes,
+  setXDomain,
+  setYDomain,
+  setXAxisLabel,
+  setYAxisLabel,
+  setAxisPrefix,
+  setAxisSuffix,
+  setTimeFormat,
+  setLegendOpacity,
+  setLegendOrientationThreshold,
+  setLegendColorizeRows,
+  setGenerateXAxisTicks,
+  setXTotalTicks,
+  setXTickStart,
+  setXTickStep,
+  setGenerateYAxisTicks,
+  setYTotalTicks,
+  setYTickStart,
+  setYTickStep,
 } from 'src/timeMachine/actions'
 
 // Utils
@@ -229,7 +229,9 @@ const HeatmapOptions: FunctionComponent<Props> = props => {
       />
       <LegendOrientation
         onLegendOpacityChange={props.onSetLegendOpacity}
-        onLegendOrientationThresholdChange={props.onSetLegendOrientationThreshold}
+        onLegendOrientationThresholdChange={
+          props.onSetLegendOrientationThreshold
+        }
         onLegendColorizeRowsChange={props.onSetLegendColorizeRows}
       />
     </Grid.Column>
@@ -261,7 +263,7 @@ const mdtp = {
   onSetTimeFormat: setTimeFormat,
   onSetLegendOpacity: setLegendOpacity,
   onSetLegendOrientationThreshold: setLegendOrientationThreshold,
-    onSetLegendColorizeRows: setLegendColorizeRows,
+  onSetLegendColorizeRows: setLegendColorizeRows,
   onSetGenerateXAxisTicks: setGenerateXAxisTicks,
   onSetXTotalTicks: setXTotalTicks,
   onSetXTickStart: setXTickStart,

--- a/src/timeMachine/components/view_options/HeatmapOptions.tsx
+++ b/src/timeMachine/components/view_options/HeatmapOptions.tsx
@@ -24,27 +24,28 @@ import AxisTicksGenerator from 'src/shared/components/axisTicks/AxisTicksGenerat
 
 // Actions
 import {
-  setXColumn,
-  setYColumn,
-  setBinSize,
-  setColorHexes,
-  setXDomain,
-  setYDomain,
-  setXAxisLabel,
-  setYAxisLabel,
-  setAxisPrefix,
-  setAxisSuffix,
-  setTimeFormat,
-  setLegendOpacity,
-  setLegendOrientationThreshold,
-  setGenerateXAxisTicks,
-  setXTotalTicks,
-  setXTickStart,
-  setXTickStep,
-  setGenerateYAxisTicks,
-  setYTotalTicks,
-  setYTickStart,
-  setYTickStep,
+    setXColumn,
+    setYColumn,
+    setBinSize,
+    setColorHexes,
+    setXDomain,
+    setYDomain,
+    setXAxisLabel,
+    setYAxisLabel,
+    setAxisPrefix,
+    setAxisSuffix,
+    setTimeFormat,
+    setLegendOpacity,
+    setLegendOrientationThreshold,
+    setLegendColorizeRows,
+    setGenerateXAxisTicks,
+    setXTotalTicks,
+    setXTickStart,
+    setXTickStep,
+    setGenerateYAxisTicks,
+    setYTotalTicks,
+    setYTickStart,
+    setYTickStep,
 } from 'src/timeMachine/actions'
 
 // Utils
@@ -228,9 +229,8 @@ const HeatmapOptions: FunctionComponent<Props> = props => {
       />
       <LegendOrientation
         onLegendOpacityChange={props.onSetLegendOpacity}
-        onLegendOrientationThresholdChange={
-          props.onSetLegendOrientationThreshold
-        }
+        onLegendOrientationThresholdChange={props.onSetLegendOrientationThreshold}
+        onLegendColorizeRowsChange={props.onSetLegendColorizeRows}
       />
     </Grid.Column>
   )
@@ -261,6 +261,7 @@ const mdtp = {
   onSetTimeFormat: setTimeFormat,
   onSetLegendOpacity: setLegendOpacity,
   onSetLegendOrientationThreshold: setLegendOrientationThreshold,
+    onSetLegendColorizeRows: setLegendColorizeRows,
   onSetGenerateXAxisTicks: setGenerateXAxisTicks,
   onSetXTotalTicks: setXTotalTicks,
   onSetXTickStart: setXTickStart,

--- a/src/timeMachine/components/view_options/HistogramOptions.tsx
+++ b/src/timeMachine/components/view_options/HistogramOptions.tsx
@@ -27,7 +27,7 @@ import {
   setXAxisLabel,
   setLegendOpacity,
   setLegendOrientationThreshold,
-    setLegendColorizeRows,
+  setLegendColorizeRows,
 } from 'src/timeMachine/actions'
 
 // Utils
@@ -76,7 +76,7 @@ const HistogramOptions: FunctionComponent<Props> = props => {
     onSetXAxisLabel,
     onSetLegendOpacity,
     onSetLegendOrientationThreshold,
-      onSetLegendColorizeRows,
+    onSetLegendColorizeRows,
   } = props
 
   const groupDropdownStatus = availableGroupColumns.length
@@ -190,7 +190,7 @@ const mdtp = {
   onSetXAxisLabel: setXAxisLabel,
   onSetLegendOpacity: setLegendOpacity,
   onSetLegendOrientationThreshold: setLegendOrientationThreshold,
-    onSetLegendColorizeRows: setLegendColorizeRows,
+  onSetLegendColorizeRows: setLegendColorizeRows,
 }
 
 const connector = connect(mstp, mdtp)

--- a/src/timeMachine/components/view_options/HistogramOptions.tsx
+++ b/src/timeMachine/components/view_options/HistogramOptions.tsx
@@ -27,6 +27,7 @@ import {
   setXAxisLabel,
   setLegendOpacity,
   setLegendOrientationThreshold,
+    setLegendColorizeRows,
 } from 'src/timeMachine/actions'
 
 // Utils
@@ -75,6 +76,7 @@ const HistogramOptions: FunctionComponent<Props> = props => {
     onSetXAxisLabel,
     onSetLegendOpacity,
     onSetLegendOrientationThreshold,
+      onSetLegendColorizeRows,
   } = props
 
   const groupDropdownStatus = availableGroupColumns.length
@@ -163,6 +165,7 @@ const HistogramOptions: FunctionComponent<Props> = props => {
       <LegendOrientation
         onLegendOpacityChange={onSetLegendOpacity}
         onLegendOrientationThresholdChange={onSetLegendOrientationThreshold}
+        onLegendColorizeRowsChange={onSetLegendColorizeRows}
       />
     </Grid.Column>
   )
@@ -187,6 +190,7 @@ const mdtp = {
   onSetXAxisLabel: setXAxisLabel,
   onSetLegendOpacity: setLegendOpacity,
   onSetLegendOrientationThreshold: setLegendOrientationThreshold,
+    onSetLegendColorizeRows: setLegendColorizeRows,
 }
 
 const connector = connect(mstp, mdtp)

--- a/src/timeMachine/components/view_options/LegendOrientation.tsx
+++ b/src/timeMachine/components/view_options/LegendOrientation.tsx
@@ -45,8 +45,6 @@ interface OwnProps {
 type ReduxProps = ConnectedProps<typeof connector>
 type Props = OwnProps & ReduxProps
 
-
-
 const LegendOrientation: FC<Props> = props => {
   const {
     legendOpacity,
@@ -56,8 +54,6 @@ const LegendOrientation: FC<Props> = props => {
     legendColorizeRows,
     onLegendColorizeRowsChange,
   } = props
-
-  console.log('type Props (a1-1)', props);
 
   const [thresholdInputStatus, setThresholdInputStatus] = useState(
     ComponentStatus.Default
@@ -101,8 +97,7 @@ const LegendOrientation: FC<Props> = props => {
 
   const toggleStyle = {marginTop: 4}
 
-  const toggleLabelStyle={color: '#999dab',
-  }
+  const toggleLabelStyle = {color: '#999dab'}
 
   return (
     <Grid.Column>
@@ -130,23 +125,20 @@ const LegendOrientation: FC<Props> = props => {
           onChange={handleSetOpacity}
         />
       </Form.Element>
-
-      <Form.Element>
-        <FlexBox
-          direction={FlexDirection.Row}
-          alignItems={AlignItems.Center}
-          margin={ComponentSize.Medium}
-          stretchToFitWidth={true}
-          style={toggleStyle}
-        >
-          <SlideToggle
-            active={colorizeRowsInput}
-            size={ComponentSize.ExtraSmall}
-            onChange={handleSetColorization}
-          />
-          <InputLabel style={toggleLabelStyle}>Colorize Rows</InputLabel>
-        </FlexBox>
-      </Form.Element>
+      <FlexBox
+        direction={FlexDirection.Row}
+        alignItems={AlignItems.Center}
+        margin={ComponentSize.Medium}
+        stretchToFitWidth={true}
+        style={toggleStyle}
+      >
+        <SlideToggle
+          active={colorizeRowsInput}
+          size={ComponentSize.ExtraSmall}
+          onChange={handleSetColorization}
+        />
+        <InputLabel style={toggleLabelStyle}>Colorize Rows</InputLabel>
+      </FlexBox>
     </Grid.Column>
   )
 }

--- a/src/timeMachine/components/view_options/LegendOrientation.tsx
+++ b/src/timeMachine/components/view_options/LegendOrientation.tsx
@@ -99,7 +99,10 @@ const LegendOrientation: FC<Props> = props => {
     onLegendColorizeRowsChange(value)
   }
 
-  const sliderStyle = {marginTop: 4}
+  const toggleStyle = {marginTop: 4}
+
+  const toggleLabelStyle={color: '#999dab',
+  }
 
   return (
     <Grid.Column>
@@ -134,14 +137,14 @@ const LegendOrientation: FC<Props> = props => {
           alignItems={AlignItems.Center}
           margin={ComponentSize.Medium}
           stretchToFitWidth={true}
-          style={sliderStyle}
+          style={toggleStyle}
         >
           <SlideToggle
             active={colorizeRowsInput}
             size={ComponentSize.ExtraSmall}
             onChange={handleSetColorization}
           />
-          <InputLabel>Colorize Rows</InputLabel>
+          <InputLabel style={toggleLabelStyle}>Colorize Rows</InputLabel>
         </FlexBox>
       </Form.Element>
     </Grid.Column>

--- a/src/timeMachine/components/view_options/LegendOrientation.tsx
+++ b/src/timeMachine/components/view_options/LegendOrientation.tsx
@@ -10,12 +10,18 @@ import {getActiveTimeMachine} from 'src/timeMachine/selectors'
 
 // Components
 import {
+  ComponentSize,
   ComponentStatus,
   Form,
   Grid,
   Input,
+  InputLabel,
   InputType,
   RangeSlider,
+  SlideToggle,
+  FlexBox,
+  FlexDirection,
+  AlignItems,
 } from '@influxdata/clockface'
 
 // Types
@@ -27,15 +33,19 @@ import {
   LEGEND_OPACITY_MAXIMUM,
   LEGEND_OPACITY_MINIMUM,
   LEGEND_OPACITY_STEP,
+  LEGEND_COLORIZE_ROWS_DEFAULT,
 } from 'src/shared/constants'
 
 interface OwnProps {
   onLegendOpacityChange: (opacity: number) => void
   onLegendOrientationThresholdChange: (threshold: number) => void
+  onLegendColorizeRowsChange: (colorize: boolean) => void
 }
 
 type ReduxProps = ConnectedProps<typeof connector>
 type Props = OwnProps & ReduxProps
+
+
 
 const LegendOrientation: FC<Props> = props => {
   const {
@@ -43,7 +53,11 @@ const LegendOrientation: FC<Props> = props => {
     onLegendOpacityChange,
     legendOrientationThreshold,
     onLegendOrientationThresholdChange,
+    legendColorizeRows,
+    onLegendColorizeRowsChange,
   } = props
+
+  console.log('type Props (a1-1)', props);
 
   const [thresholdInputStatus, setThresholdInputStatus] = useState(
     ComponentStatus.Default
@@ -51,6 +65,7 @@ const LegendOrientation: FC<Props> = props => {
   const [thresholdInput, setThresholdInput] = useState(
     legendOrientationThreshold
   )
+  const [colorizeRowsInput, setColorizeRowsInput] = useState(legendColorizeRows)
 
   if (!isFlagEnabled('legendOrientation')) {
     return null
@@ -78,6 +93,14 @@ const LegendOrientation: FC<Props> = props => {
     }
   }
 
+  const handleSetColorization = (): void => {
+    const value = !colorizeRowsInput
+    setColorizeRowsInput(value)
+    onLegendColorizeRowsChange(value)
+  }
+
+  const sliderStyle = {marginTop: 4}
+
   return (
     <Grid.Column>
       <h5 className="view-options--header">Legend</h5>
@@ -104,6 +127,23 @@ const LegendOrientation: FC<Props> = props => {
           onChange={handleSetOpacity}
         />
       </Form.Element>
+
+      <Form.Element>
+        <FlexBox
+          direction={FlexDirection.Row}
+          alignItems={AlignItems.Center}
+          margin={ComponentSize.Medium}
+          stretchToFitWidth={true}
+          style={sliderStyle}
+        >
+          <SlideToggle
+            active={colorizeRowsInput}
+            size={ComponentSize.ExtraSmall}
+            onChange={handleSetColorization}
+          />
+          <InputLabel>Colorize Rows</InputLabel>
+        </FlexBox>
+      </Form.Element>
     </Grid.Column>
   )
 }
@@ -120,7 +160,13 @@ const mstp = (state: AppState) => {
     'view.properties.legendOpacity',
     LEGEND_OPACITY_DEFAULT
   )
-  return {legendOpacity, legendOrientationThreshold}
+  const legendColorizeRows: boolean = get(
+    timeMachine,
+    'view.properties.legendColorizeRows',
+    LEGEND_COLORIZE_ROWS_DEFAULT
+  )
+
+  return {legendOpacity, legendOrientationThreshold, legendColorizeRows}
 }
 
 const connector = connect(mstp)

--- a/src/timeMachine/components/view_options/LineOptions.tsx
+++ b/src/timeMachine/components/view_options/LineOptions.tsx
@@ -109,8 +109,6 @@ class LineOptions extends PureComponent<Props> {
       onSetLegendOpacity,
       onSetLegendOrientationThreshold,
         onSetLegendColorizeRows,
-
-
         onSetGenerateXAxisTicks,
       onSetXTotalTicks,
       onSetXTickStart,
@@ -121,7 +119,7 @@ class LineOptions extends PureComponent<Props> {
       onSetYTickStep,
     } = this.props
 
-    console.log('is this defined? a1:', onSetLegendColorizeRows)
+    console.log('in LineOptions.....is this defined? a1:', onSetLegendColorizeRows)
     return (
       <>
         <Grid.Column>

--- a/src/timeMachine/components/view_options/LineOptions.tsx
+++ b/src/timeMachine/components/view_options/LineOptions.tsx
@@ -108,8 +108,8 @@ class LineOptions extends PureComponent<Props> {
       onSetHoverDimension,
       onSetLegendOpacity,
       onSetLegendOrientationThreshold,
-        onSetLegendColorizeRows,
-        onSetGenerateXAxisTicks,
+      onSetLegendColorizeRows,
+      onSetGenerateXAxisTicks,
       onSetXTotalTicks,
       onSetXTickStart,
       onSetXTickStep,
@@ -119,7 +119,6 @@ class LineOptions extends PureComponent<Props> {
       onSetYTickStep,
     } = this.props
 
-    console.log('in LineOptions.....is this defined? a1:', onSetLegendColorizeRows)
     return (
       <>
         <Grid.Column>

--- a/src/timeMachine/components/view_options/LineOptions.tsx
+++ b/src/timeMachine/components/view_options/LineOptions.tsx
@@ -34,6 +34,7 @@ import {
   setHoverDimension,
   setLegendOpacity,
   setLegendOrientationThreshold,
+  setLegendColorizeRows,
   setGenerateXAxisTicks,
   setXTotalTicks,
   setXTickStart,
@@ -107,7 +108,10 @@ class LineOptions extends PureComponent<Props> {
       onSetHoverDimension,
       onSetLegendOpacity,
       onSetLegendOrientationThreshold,
-      onSetGenerateXAxisTicks,
+        onSetLegendColorizeRows,
+
+
+        onSetGenerateXAxisTicks,
       onSetXTotalTicks,
       onSetXTickStart,
       onSetXTickStep,
@@ -117,6 +121,7 @@ class LineOptions extends PureComponent<Props> {
       onSetYTickStep,
     } = this.props
 
+    console.log('is this defined? a1:', onSetLegendColorizeRows)
     return (
       <>
         <Grid.Column>
@@ -278,6 +283,7 @@ class LineOptions extends PureComponent<Props> {
         <LegendOrientation
           onLegendOpacityChange={onSetLegendOpacity}
           onLegendOrientationThresholdChange={onSetLegendOrientationThreshold}
+          onLegendColorizeRowsChange={onSetLegendColorizeRows}
         />
       </>
     )
@@ -330,6 +336,7 @@ const mdtp = {
   onSetHoverDimension: setHoverDimension,
   onSetLegendOpacity: setLegendOpacity,
   onSetLegendOrientationThreshold: setLegendOrientationThreshold,
+  onSetLegendColorizeRows: setLegendColorizeRows,
   onSetGenerateXAxisTicks: setGenerateXAxisTicks,
   onSetXTotalTicks: setXTotalTicks,
   onSetXTickStart: setXTickStart,

--- a/src/timeMachine/components/view_options/MosaicOptions.tsx
+++ b/src/timeMachine/components/view_options/MosaicOptions.tsx
@@ -20,6 +20,7 @@ import {
   setTimeFormat,
   setLegendOpacity,
   setLegendOrientationThreshold,
+  setLegendColorizeRows,
   setGenerateXAxisTicks,
   setXTotalTicks,
   setXTickStart,
@@ -80,6 +81,7 @@ const MosaicOptions: FunctionComponent<Props> = props => {
     timeFormat,
     onSetLegendOpacity,
     onSetLegendOrientationThreshold,
+    onSetLegendColorizeRows,
     onSetGenerateXAxisTicks,
     onSetXTotalTicks,
     onSetXTickStart,
@@ -157,6 +159,7 @@ const MosaicOptions: FunctionComponent<Props> = props => {
       <LegendOrientation
         onLegendOpacityChange={onSetLegendOpacity}
         onLegendOrientationThresholdChange={onSetLegendOrientationThreshold}
+        onLegendColorizeRowsChange={onSetLegendColorizeRows}
       />
     </Grid.Column>
   )
@@ -194,6 +197,7 @@ const mdtp = {
   onSetTimeFormat: setTimeFormat,
   onSetLegendOpacity: setLegendOpacity,
   onSetLegendOrientationThreshold: setLegendOrientationThreshold,
+  onSetLegendColorizeRows: setLegendColorizeRows,
   onSetGenerateXAxisTicks: setGenerateXAxisTicks,
   onSetXTotalTicks: setXTotalTicks,
   onSetXTickStart: setXTickStart,

--- a/src/timeMachine/components/view_options/ScatterOptions.tsx
+++ b/src/timeMachine/components/view_options/ScatterOptions.tsx
@@ -25,6 +25,7 @@ import {
   setTimeFormat,
   setLegendOpacity,
   setLegendOrientationThreshold,
+  setLegendColorizeRows,
   setGenerateXAxisTicks,
   setXTotalTicks,
   setXTickStart,
@@ -108,6 +109,7 @@ const ScatterOptions: FunctionComponent<Props> = props => {
     timeFormat,
     onSetLegendOpacity,
     onSetLegendOrientationThreshold,
+    onSetLegendColorizeRows,
     onSetGenerateXAxisTicks,
     onSetXTotalTicks,
     onSetXTickStart,
@@ -256,6 +258,7 @@ const ScatterOptions: FunctionComponent<Props> = props => {
       <LegendOrientation
         onLegendOpacityChange={onSetLegendOpacity}
         onLegendOrientationThresholdChange={onSetLegendOrientationThreshold}
+        onLegendColorizeRowsChange={onSetLegendColorizeRows}
       />
     </Grid.Column>
   )
@@ -299,6 +302,7 @@ const mdtp = {
   onSetTimeFormat: setTimeFormat,
   onSetLegendOpacity: setLegendOpacity,
   onSetLegendOrientationThreshold: setLegendOrientationThreshold,
+  onSetLegendColorizeRows: setLegendColorizeRows,
   onSetGenerateXAxisTicks: setGenerateXAxisTicks,
   onSetXTotalTicks: setXTotalTicks,
   onSetXTickStart: setXTickStart,

--- a/src/timeMachine/reducers/index.ts
+++ b/src/timeMachine/reducers/index.ts
@@ -464,6 +464,12 @@ export const timeMachineReducer = (
       return setViewProperties(state, {legendOrientationThreshold})
     }
 
+    case 'SET_LEGEND_COLORIZE_ROWS': {
+      const {legendColorizeRows} = action.payload
+
+      return setViewProperties(state, {legendColorizeRows})
+    }
+
     case 'SET_BIN_COUNT': {
       const {binCount} = action.payload
 

--- a/src/views/helpers/index.ts
+++ b/src/views/helpers/index.ts
@@ -5,6 +5,7 @@ import {DEFAULT_CELL_NAME} from 'src/dashboards/constants'
 import {
   LEGEND_OPACITY_DEFAULT,
   LEGEND_ORIENTATION_THRESHOLD_DEFAULT,
+  LEGEND_COLORIZE_ROWS_DEFAULT,
 } from 'src/shared/constants'
 import {
   DEFAULT_GAUGE_COLORS,
@@ -70,8 +71,15 @@ export function defaultBuilderConfig(): BuilderConfig {
   }
 }
 
+const legendProps = {
+  legendOpacity: LEGEND_OPACITY_DEFAULT,
+  legendOrientationThreshold: LEGEND_ORIENTATION_THRESHOLD_DEFAULT,
+  legendColorizeRows: LEGEND_COLORIZE_ROWS_DEFAULT,
+}
+
 export function defaultLineViewProperties() {
   return {
+    ...legendProps,
     queries: [defaultViewQuery()],
     colors: DEFAULT_LINE_COLORS as Color[],
     legend: {},
@@ -85,8 +93,6 @@ export function defaultLineViewProperties() {
     yTotalTicks: null,
     yTickStart: null,
     yTickStep: null,
-    legendOpacity: LEGEND_OPACITY_DEFAULT,
-    legendOrientationThreshold: LEGEND_ORIENTATION_THRESHOLD_DEFAULT,
     axes: {
       x: {
         bounds: ['', ''],
@@ -111,6 +117,7 @@ export function defaultLineViewProperties() {
 
 export function defaultBandViewProperties() {
   return {
+    ...legendProps,
     queries: [defaultViewQuery()],
     colors: DEFAULT_LINE_COLORS as Color[],
     legend: {},
@@ -124,8 +131,6 @@ export function defaultBandViewProperties() {
     yTotalTicks: null,
     yTickStart: null,
     yTickStep: null,
-    legendOpacity: LEGEND_OPACITY_DEFAULT,
-    legendOrientationThreshold: LEGEND_ORIENTATION_THRESHOLD_DEFAULT,
     axes: {
       x: {
         bounds: ['', ''],
@@ -211,6 +216,7 @@ const NEW_VIEW_CREATORS = {
   histogram: (): NewView<HistogramViewProperties> => ({
     ...defaultView(),
     properties: {
+      ...legendProps,
       queries: [],
       type: 'histogram',
       shape: 'chronograf-v2',
@@ -223,13 +229,12 @@ const NEW_VIEW_CREATORS = {
       colors: DEFAULT_LINE_COLORS as Color[],
       note: '',
       showNoteWhenEmpty: false,
-      legendOpacity: LEGEND_OPACITY_DEFAULT,
-      legendOrientationThreshold: LEGEND_ORIENTATION_THRESHOLD_DEFAULT,
     },
   }),
   heatmap: (): NewView<HeatmapViewProperties> => ({
     ...defaultView(),
     properties: {
+      ...legendProps,
       queries: [],
       type: 'heatmap',
       shape: 'chronograf-v2',
@@ -255,8 +260,6 @@ const NEW_VIEW_CREATORS = {
       yTotalTicks: null,
       yTickStart: null,
       yTickStep: null,
-      legendOpacity: LEGEND_OPACITY_DEFAULT,
-      legendOrientationThreshold: LEGEND_ORIENTATION_THRESHOLD_DEFAULT,
     },
   }),
   'single-stat': (): NewView<SingleStatViewProperties> => ({
@@ -322,6 +325,7 @@ const NEW_VIEW_CREATORS = {
   scatter: (): NewView<ScatterViewProperties> => ({
     ...defaultView(),
     properties: {
+      ...legendProps,
       type: 'scatter',
       shape: 'chronograf-v2',
       queries: [defaultViewQuery()],
@@ -348,13 +352,12 @@ const NEW_VIEW_CREATORS = {
       xSuffix: '',
       yPrefix: '',
       ySuffix: '',
-      legendOpacity: LEGEND_OPACITY_DEFAULT,
-      legendOrientationThreshold: LEGEND_ORIENTATION_THRESHOLD_DEFAULT,
     },
   }),
   mosaic: (): NewView<MosaicViewProperties> => ({
     ...defaultView(),
     properties: {
+      ...legendProps,
       type: 'mosaic',
       shape: 'chronograf-v2',
       queries: [defaultViewQuery()],
@@ -376,8 +379,6 @@ const NEW_VIEW_CREATORS = {
       xSuffix: '',
       yPrefix: '',
       ySuffix: '',
-      legendOpacity: LEGEND_OPACITY_DEFAULT,
-      legendOrientationThreshold: LEGEND_ORIENTATION_THRESHOLD_DEFAULT,
     },
   }),
   threshold: (): NewView<CheckViewProperties> => ({


### PR DESCRIPTION
Closes #388 

Describe your proposed changes here.

- [ ] feat:  added a toggle button to turn colorized rows off; it is on by default (was on all the time without a toggle before this feature was added)
- [ ] Rebased to most recent master
- [ ] Tests pass

unselected (toggle off)
![Screen Shot 2021-01-06 at 2 02 25 PM](https://user-images.githubusercontent.com/3900960/103810014-7f531f80-5028-11eb-8d8f-18def0da34d3.png)

selected (toggle on)
![Screen Shot 2021-01-06 at 2 02 17 PM](https://user-images.githubusercontent.com/3900960/103810058-91cd5900-5028-11eb-9adb-ec25489a652d.png)


