### PR TITLE
fix(notebooks): make panel header & metric selector controls responsive

### DIFF
--- a/src/flows/components/panel/FlowPanel.tsx
+++ b/src/flows/components/panel/FlowPanel.tsx
@@ -11,13 +11,7 @@ import React, {
 import classnames from 'classnames'
 
 // Components
-import {
-  FlexBox,
-  ComponentSize,
-  AlignItems,
-  JustifyContent,
-  ClickOutside,
-} from '@influxdata/clockface'
+import {ClickOutside} from '@influxdata/clockface'
 import RemovePanelButton from 'src/flows/components/panel/RemovePanelButton'
 import InsertCellButton from 'src/flows/components/panel/InsertCellButton'
 import PanelVisibilityToggle from 'src/flows/components/panel/PanelVisibilityToggle'
@@ -83,38 +77,30 @@ const FlowPanelHeader: FC<HeaderProps> = ({
       <div className="flow-panel--node-wrapper">
         <div className="flow-panel--node" />
       </div>
-      <FlexBox
-        className="flow-panel--header-left"
-        alignItems={AlignItems.Center}
-        margin={ComponentSize.Small}
-        justifyContent={JustifyContent.FlexStart}
-      >
-        {title}
-      </FlexBox>
+      {title}
       {!flow.readOnly && (
-        <FlexBox
-          className="flow-panel--header-right"
-          alignItems={AlignItems.Center}
-          margin={ComponentSize.Small}
-          justifyContent={JustifyContent.FlexEnd}
-        >
-          {controls}
-          <FeatureFlag name="flow-move-cells">
-            <MovePanelButton
-              direction="up"
-              onClick={moveUp}
-              active={canBeMovedUp}
-            />
-            <MovePanelButton
-              direction="down"
-              onClick={moveDown}
-              active={canBeMovedDown}
-            />
-          </FeatureFlag>
-          <PanelVisibilityToggle id={id} />
-          <RemovePanelButton onRemove={remove} />
-          {persistentControl}
-        </FlexBox>
+        <>
+          <div className="flow-panel--hover-control">
+            {controls}
+            <FeatureFlag name="flow-move-cells">
+              <MovePanelButton
+                direction="up"
+                onClick={moveUp}
+                active={canBeMovedUp}
+              />
+              <MovePanelButton
+                direction="down"
+                onClick={moveDown}
+                active={canBeMovedDown}
+              />
+            </FeatureFlag>
+          </div>
+          <div className="flow-panel--persistent-control">
+            <PanelVisibilityToggle id={id} />
+            <RemovePanelButton onRemove={remove} />
+            {persistentControl}
+          </div>
+        </>
       )}
     </div>
   )

--- a/src/flows/pipes/MetricSelector/AggregateWindowSelector.tsx
+++ b/src/flows/pipes/MetricSelector/AggregateWindowSelector.tsx
@@ -81,6 +81,7 @@ const AggregateFunctionSelector: FC = () => {
 
   return (
     <Dropdown
+      className="data-source--aggregate"
       button={button}
       menu={menu}
       style={{width: '180px', flex: '0 0 180px'}}

--- a/src/flows/pipes/MetricSelector/style.scss
+++ b/src/flows/pipes/MetricSelector/style.scss
@@ -2,13 +2,24 @@
 
 .data-source--controls {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   margin-bottom: $cf-marg-b;
+  flex-wrap: wrap;
+}
+
+.data-source--bucket {
+  flex: 1 0 0;
+  order: 1;
+}
+
+.data-source--aggregate {
+  order: 2;
 }
 
 .data-source--filters {
-  flex: 1 0 0;
-  margin-right: $cf-marg-a;
+  order: 3;
+  flex: 1 0 100%;
+  margin-top: $cf-marg-a;
   display: flex;
   align-items: center;
 }
@@ -17,11 +28,18 @@
   height: $cf-form-sm-height;
   line-height: $cf-form-sm-height;
   font-weight: $cf-font-weight--medium;
-  margin: 0 $cf-marg-b;
+  margin: 0;
+  margin-right: $cf-marg-b;
 }
 
 .data-source--filter {
-  margin: $cf-marg-a;
+  margin: $cf-border;
+
+  & > .cf-label--name {
+    max-width: 50vw;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }
 
 .data-source--filters-list {
@@ -125,5 +143,33 @@
     display: inline-block;
     margin-right: $cf-marg-a;
     line-height: 1em;
+  }
+}
+
+// Responsive Layout
+// The 1200px number is somewhat arbitrary but works with the current design
+// Adjust as needed
+@media screen and (min-width: 1200px) {
+  .data-source--controls {
+    flex-wrap: nowrap;
+  }
+
+  .data-source--bucket {
+    flex: initial;
+  }
+
+  .data-source--filters-label {
+    margin-left: $cf-marg-b;
+  }
+
+  .data-source--aggregate {
+    order: 3;
+  }
+
+  .data-source--filters {
+    order: 2;
+    flex: 1 0 100px;
+    margin-top: 0;
+    margin-right: $cf-marg-a;
   }
 }

--- a/src/flows/pipes/MetricSelector/view.tsx
+++ b/src/flows/pipes/MetricSelector/view.tsx
@@ -19,7 +19,9 @@ const DataSource: FC<PipeProp> = ({Context}) => (
     <SchemaProvider>
       <Context>
         <div className="data-source--controls">
-          <BucketSelector />
+          <div className="data-source--bucket">
+            <BucketSelector />
+          </div>
           <FilterTags />
           <AggregateWindowSelector />
         </div>

--- a/src/flows/shared/Resizer.scss
+++ b/src/flows/shared/Resizer.scss
@@ -4,7 +4,6 @@ $panel-resizer--header: 47px;
 $panel-resizer--drag-handle: 30px;
 
 .panel-resizer {
-  margin-top: $cf-marg-a;
   display: flex;
   flex-direction: row;
   align-items: stretch;

--- a/src/flows/style.scss
+++ b/src/flows/style.scss
@@ -58,29 +58,54 @@
 
 .flow-panel--header {
   border-radius: $cf-radius $cf-radius 0 0;
-  height: $flow-header-height;
-  flex: 0 0 $flow-header-height;
-  padding-right: $cf-marg-b;
+  padding: $cf-marg-b;
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
 }
 
-.flow-panel--header-left,
-.flow-panel--header-right {
-  flex: 1 0 $flow-header-height;
+.flow-panel--hover-control,
+.flow-panel--persistent-control {
+  display: flex;
+  align-items: center;
+
+  > * {
+    margin-left: $cf-marg-a;
+  }
 }
 
-.flow-panel--header-right > * {
-  opacity: 0;
+.flow-panel--hover-control {
+  order: 4;
+  flex: 1 0 100%;
+  padding-left: 28px;
+
+  & > * {
+    margin-top: $cf-marg-a;
+  }
+}
+
+.flow-panel__focus,
+.flow-panel:hover {
+  .flow-panel--hover-control > * {
+    opacity: 1;
+  }
+}
+
+.flow-panel--persistent-control {
+  justify-content: flex-end;
+  order: 3;
+  flex-grow: 1;
 }
 
 .flow-panel--node-wrapper {
+  order: 1;
   display: flex;
   justify-content: center;
   align-items: center;
   align-content: center;
-  width: $flow-panel--node-gap;
+  flex-basis: 24px;
+  width: 24px;
   position: relative;
   z-index: 2;
 }
@@ -102,18 +127,18 @@
   margin-right: $cf-marg-b !important;
 }
 
-.flow-panel--title {
-  color: $g15-platinum;
-}
-
 .flow-panel--data-source {
   color: $c-laser;
 }
 
 .flow-panel--title {
-  width: 350px;
+  order: 2;
+  color: $g15-platinum;
+  width: 230px;
+  flex: 0 0 230px;
   height: $cf-form-sm-height;
   position: relative;
+  margin-left: $cf-marg-b;
 }
 
 .flow-panel--title-input {
@@ -159,14 +184,6 @@
 
 .flow-panel--title:hover .flow-panel--title-icon {
   opacity: 1;
-}
-
-// Focus state
-.flow-panel__focus,
-.flow-panel:hover {
-  .flow-panel--header-right > * {
-    opacity: 1;
-  }
 }
 
 .flow-panel--data-caret {
@@ -268,4 +285,26 @@
   font-size: 1.25em;
   font-weight: $cf-font-weight--medium;
   margin-left: $cf-marg-b;
+}
+
+// Responsive Layout
+// The 1200px number is somewhat arbitrary but works with the current design
+// Adjust as needed
+@media screen and (min-width: 1200px) {
+  .flow-panel--hover-control {
+    flex: 1 0 0;
+    order: 3;
+    justify-content: flex-end;
+    padding-left: 0;
+
+    & > * {
+      margin-top: 0;
+      opacity: 0;
+    }
+  }
+
+  .flow-panel--persistent-control {
+    flex: initial;
+    order: 4;
+  }
 }


### PR DESCRIPTION
Closes #452

- Refactor panel header and metric selector controls to stack vertically on small displays
- Limit metric selector filters width to an arbitrary 50% of viewport width

![Screen Shot 2021-01-07 at 11 31 52 AM](https://user-images.githubusercontent.com/2433762/103936093-fa294280-50db-11eb-8fe7-a847109f717e.png)


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

