### PR TITLE
test: Adds the ability to test clockface and giraffe locally

### DIFF
--- a/cypress/e2e/shared/checks.test.ts
+++ b/cypress/e2e/shared/checks.test.ts
@@ -94,27 +94,15 @@ describe('Checks', () => {
 
   it('can create and filter checks', () => {
     cy.log('create first check')
-    cy.getByTestID('create-check')
-      .click()
-      .then(() => {
-        cy.getByTestID('create-deadman-check')
-          .click()
-          .then(() => {
-            cy.log('select measurement and field')
-            cy.getByTestID(`selector-list defbuck`)
-              .click()
-              .then(() => {
-                cy.getByTestID(`selector-list ${measurement}`)
-                  .should('be.visible')
-                  .click()
-                  .then(() => {
-                    cy.getByTestID(`selector-list ${field}`)
-                      .should('be.visible')
-                      .click()
-                  })
-              })
-          })
-      })
+    cy.getByTestID('create-check').click()
+    cy.getByTestID('create-deadman-check').click()
+
+    cy.log('select measurement and field')
+    cy.getByTestID(`selector-list defbuck`).click()
+    cy.getByTestID(`selector-list ${measurement}`).should('be.visible')
+    cy.getByTestID(`selector-list ${measurement}`).click()
+    cy.getByTestID(`selector-list ${field}`).should('be.visible')
+    cy.getByTestID(`selector-list ${field}`).click()
 
     cy.log('name the check; save')
     cy.getByTestID('overlay').within(() => {

--- a/cypress/e2e/shared/checks.test.ts
+++ b/cypress/e2e/shared/checks.test.ts
@@ -108,9 +108,9 @@ describe('Checks', () => {
                   .should('be.visible')
                   .click()
                   .then(() => {
-                    cy.getByTestID(`selector-list ${field}`).click({
-                      force: true,
-                    })
+                    cy.getByTestID(`selector-list ${field}`)
+                      .should('be.visible')
+                      .click()
                   })
               })
           })

--- a/cypress/e2e/shared/checks.test.ts
+++ b/cypress/e2e/shared/checks.test.ts
@@ -105,6 +105,7 @@ describe('Checks', () => {
               .click()
               .then(() => {
                 cy.getByTestID(`selector-list ${measurement}`)
+                  .should('be.visible')
                   .click()
                   .then(() => {
                     cy.getByTestID(`selector-list ${field}`).click({

--- a/cypress/e2e/shared/dashboardsView.test.ts
+++ b/cypress/e2e/shared/dashboardsView.test.ts
@@ -299,11 +299,6 @@ describe('Dashboard', () => {
             cy.getByTestID('switch-to-script-editor').click()
             cy.getByTestID('toolbar-tab').click()
 
-            // Assert that the lazy loading state should exist
-            cy.getByTestID('spinner-container').should('exist')
-            // Wait for monaco editor to load after lazy loading
-            cy.wait(500)
-
             // check to see if the default timeRange variables are available
             cy.get('.flux-toolbar--list-item').contains('timeRangeStart')
             cy.get('.flux-toolbar--list-item').contains('timeRangeStop')

--- a/cypress/e2e/shared/dashboardsView.test.ts
+++ b/cypress/e2e/shared/dashboardsView.test.ts
@@ -280,9 +280,13 @@ describe('Dashboard', () => {
     it('can manage variable state with a lot of pointing and clicking', () => {
       const bucketOne = 'b1'
       const bucketThree = 'b3'
+      const bucketVarName = 'bucketsCSV'
+      const mapTypeVarName = 'mapTypeVar'
+      const bucketVarIndex = 0
+      const mapTypeVarIndex = 2
       cy.get('@org').then(({id: orgID}: Organization) => {
         cy.get<Dashboard>('@dashboard').then(({dashboard}) => {
-          cy.createCSVVariable(orgID, 'bucketsCSV', [
+          cy.createCSVVariable(orgID, bucketVarName, [
             bucketOne,
             Cypress.env('bucket'),
             bucketThree,
@@ -302,11 +306,6 @@ describe('Dashboard', () => {
             // check to see if the default timeRange variables are available
             cy.get('.flux-toolbar--list-item').contains('timeRangeStart')
             cy.get('.flux-toolbar--list-item').contains('timeRangeStop')
-            cy.get('.flux-toolbar--list-item')
-              .first()
-              .within(() => {
-                cy.get('.cf-button').click()
-              })
 
             cy.getByTestID('flux-editor')
               .should('be.visible')
@@ -314,7 +313,7 @@ describe('Dashboard', () => {
               .focused()
               .type(' ')
             cy.get('.flux-toolbar--list-item')
-              .eq(2)
+              .eq(bucketVarIndex)
               .within(() => {
                 cy.get('.cf-button').click()
               })
@@ -322,35 +321,42 @@ describe('Dashboard', () => {
 
             // TESTING CSV VARIABLE
             // selected value in dashboard is 1st value
-            cy.getByTestID('variable-dropdown')
-              .eq(0)
-              .should('contain', bucketOne)
+            cy.getByTestID(`variable-dropdown--${bucketVarName}`).should(
+              'contain',
+              bucketOne
+            )
             cy.window()
               .pipe(getSelectedVariable(dashboard.id, 0))
               .should('equal', bucketOne)
 
             // testing variable controls
-            cy.getByTestID('variable-dropdown')
-              .eq(0)
-              .should('contain', bucketOne)
+            cy.getByTestID(`variable-dropdown--${bucketVarName}`).should(
+              'contain',
+              bucketOne
+            )
             cy.getByTestID('variables--button').click()
-            cy.getByTestID('variable-dropdown').should('not.exist')
+            cy.getByTestID(`variable-dropdown--${bucketVarName}`).should(
+              'not.exist'
+            )
             cy.getByTestID('variables--button').click()
-            cy.getByTestID('variable-dropdown').should('exist')
+            cy.getByTestID(`variable-dropdown--${bucketVarName}`).should(
+              'exist'
+            )
 
             // sanity check on the url before beginning
             cy.location('search').should('eq', '?lower=now%28%29%20-%201h')
 
             // select 3rd value in dashboard
             cy.getByTestID('variable-dropdown--button')
-              .eq(0)
+              .first()
               .click()
             cy.get(`#${bucketThree}`).click()
 
             // selected value in dashboard is 3rd value
-            cy.getByTestID('variable-dropdown')
-              .eq(0)
-              .should('contain', bucketThree)
+            cy.getByTestID(`variable-dropdown--${bucketVarName}`).should(
+              'contain',
+              bucketThree
+            )
             cy.window()
               .pipe(getSelectedVariable(dashboard.id, 0))
               .should('equal', bucketThree)
@@ -363,7 +369,7 @@ describe('Dashboard', () => {
 
             // select 2nd value in dashboard
             cy.getByTestID('variable-dropdown--button')
-              .eq(0)
+              .first()
               .click()
             cy.get(`#${Cypress.env('bucket')}`).click()
 
@@ -396,6 +402,12 @@ describe('Dashboard', () => {
                 .first()
                 .click()
             })
+            // injecting mapTypeVar into query
+            cy.get('.flux-toolbar--list-item')
+              .eq(mapTypeVarIndex)
+              .within(() => {
+                cy.get('.cf-button').click()
+              })
             // save cell
             cy.getByTestID('save-cell--button').click()
 
@@ -405,16 +417,20 @@ describe('Dashboard', () => {
               .should('equal', bucketOne)
 
             // selected value in dashboard is 1st value
-            cy.getByTestID('variable-dropdown').should('contain', bucketOne)
+            cy.getByTestID(`variable-dropdown--${bucketVarName}`).should(
+              'contain',
+              bucketOne
+            )
             cy.window()
               .pipe(getSelectedVariable(dashboard.id, 0))
               .should('equal', bucketOne)
 
             // TESTING MAP VARIABLE
             // selected value in dashboard is 1st value
-            cy.getByTestID('variable-dropdown')
-              .eq(1)
-              .should('contain', 'k1')
+            cy.getByTestID(`variable-dropdown--${mapTypeVarName}`).should(
+              'contain',
+              'k1'
+            )
             cy.window()
               .pipe(getSelectedVariable(dashboard.id, 2))
               .should('equal', 'v1')
@@ -426,9 +442,10 @@ describe('Dashboard', () => {
             cy.get(`#k2`).click()
 
             // selected value in dashboard is 2nd value
-            cy.getByTestID('variable-dropdown')
-              .eq(1)
-              .should('contain', 'k2')
+            cy.getByTestID(`variable-dropdown--${mapTypeVarName}`).should(
+              'contain',
+              'k2'
+            )
             cy.window()
               .pipe(getSelectedVariable(dashboard.id, 2))
               .should('equal', 'v2')
@@ -464,7 +481,10 @@ describe('Dashboard', () => {
               .should('equal', 'v1')
 
             // selected value in dashboard is 1st value
-            cy.getByTestID('variable-dropdown').should('contain', 'k1')
+            cy.getByTestID(`variable-dropdown--${mapTypeVarName}`).should(
+              'contain',
+              'k1'
+            )
             cy.window()
               .pipe(getSelectedVariable(dashboard.id, 2))
               .should('equal', 'v1')
@@ -561,15 +581,13 @@ describe('Dashboard', () => {
 
         // the default bucket selection should have no results and load all three variables
         // even though only two variables are being used (because 1 is dependent upon another)
-        cy.getByTestID('variable-dropdown')
-          .should('have.length', 3)
-          .eq(0)
-          .should('contain', 'beans')
+        cy.getByTestID('variable-dropdown--static').should('contain', 'beans')
 
         // and cause the rest to exist in loading states
-        cy.getByTestID('variable-dropdown')
-          .eq(1)
-          .should('contain', 'Loading')
+        cy.getByTestIDSubStr('variable-dropdown--build').should(
+          'contain',
+          'Loading'
+        )
 
         cy.getByTestIDSubStr('cell--view-empty')
 
@@ -580,9 +598,10 @@ describe('Dashboard', () => {
         cy.get(`#defbuck`).click()
 
         // default select the first result
-        cy.getByTestID('variable-dropdown')
-          .eq(1)
-          .should('contain', 'beans')
+        cy.getByTestIDSubStr('variable-dropdown--build').should(
+          'contain',
+          'beans'
+        )
 
         // and also load the third result
         cy.getByTestID('variable-dropdown--button')
@@ -592,18 +611,20 @@ describe('Dashboard', () => {
         cy.get(`#cool`).click()
 
         // and also load the second result
-        cy.getByTestID('variable-dropdown')
-          .eq(1)
-          .should('contain', 'cool')
+        cy.getByTestIDSubStr('variable-dropdown--dependent').should(
+          'contain',
+          'cool'
+        )
 
         // updating the third variable should update the second
         cy.getByTestID('variable-dropdown--button')
           .eq(2)
           .click()
         cy.get(`#beans`).click()
-        cy.getByTestID('variable-dropdown')
-          .eq(1)
-          .should('contain', 'beans')
+        cy.getByTestIDSubStr('variable-dropdown--build').should(
+          'contain',
+          'beans'
+        )
       })
     })
 
@@ -683,12 +704,12 @@ describe('Dashboard', () => {
       cy.getByTestID('save-cell--button').click()
 
       // the default bucket selection should have no results
-      cy.getByTestID('variable-dropdown')
+      cy.getByTestIDSubStr('variable-dropdown')
         .eq(0)
         .should('contain', 'beans')
 
       // and cause the rest to exist in loading states
-      cy.getByTestID('variable-dropdown')
+      cy.getByTestIDSubStr('variable-dropdown')
         .eq(1)
         .should('contain', 'Loading')
 
@@ -701,7 +722,7 @@ describe('Dashboard', () => {
       cy.get(`#defbuck`).click()
 
       // default select the first result
-      cy.getByTestID('variable-dropdown')
+      cy.getByTestIDSubStr('variable-dropdown')
         .eq(1)
         .should('contain', 'beans')
 

--- a/cypress/e2e/shared/dashboardsView.test.ts
+++ b/cypress/e2e/shared/dashboardsView.test.ts
@@ -709,9 +709,10 @@ describe('Dashboard', () => {
         .should('contain', 'beans')
 
       // and cause the rest to exist in loading states
-      cy.getByTestIDSubStr('variable-dropdown')
-        .eq(1)
-        .should('contain', 'Loading')
+      cy.getByTestIDSubStr('variable-dropdown--dependent').should(
+        'contain',
+        'Loading'
+      )
 
       cy.getByTestIDSubStr('cell--view-empty')
 
@@ -722,9 +723,7 @@ describe('Dashboard', () => {
       cy.get(`#defbuck`).click()
 
       // default select the first result
-      cy.getByTestIDSubStr('variable-dropdown')
-        .eq(1)
-        .should('contain', 'beans')
+      cy.getByTestID('variable-dropdown--dependent').should('contain', 'beans')
 
       // and also load the second result
       cy.getByTestID('variable-dropdown--button')

--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -410,24 +410,22 @@ describe('DataExplorer', () => {
       cy.getByTestID('time-machine-submit-button').should('be.disabled')
 
       cy.getByTestID('time-machine--bottom').then(() => {
-        // Assert that the lazy loading state should exist
-        cy.getByTestID('spinner-container').should('exist')
-        // Wait for monaco editor to load after lazy loading
-        cy.wait(500)
-        cy.getByTestID('flux-editor').within(() => {
-          cy.get('textarea').type('foo |> bar', {force: true})
+        cy.getByTestID('flux-editor', {timeout: 30000})
+          .should('be.visible')
+          .within(() => {
+            cy.get('textarea').type('foo |> bar', {force: true})
 
-          cy.get('.squiggly-error').should('be.visible')
+            cy.get('.squiggly-error').should('be.visible')
 
-          cy.get('textarea').type('{selectall} {backspace}', {force: true})
+            cy.get('textarea').type('{selectall} {backspace}', {force: true})
 
-          cy.get('textarea').type('from(bucket: )', {force: true})
+            cy.get('textarea').type('from(bucket: )', {force: true})
 
-          // error signature from lsp
-          // TODO(ariel): need to resolve this test. The issue for it is here:
-          // https://github.com/influxdata/ui/issues/481
-          // cy.get('.signature').should('be.visible')
-        })
+            // error signature from lsp
+            // TODO(ariel): need to resolve this test. The issue for it is here:
+            // https://github.com/influxdata/ui/issues/481
+            // cy.get('.signature').should('be.visible')
+          })
       })
 
       cy.getByTestID('time-machine-submit-button').should('not.be.disabled')
@@ -448,11 +446,7 @@ describe('DataExplorer', () => {
     })
 
     it('imports the appropriate packages to build a query', () => {
-      // Assert that the lazy loading state should exist
-      cy.getByTestID('spinner-container').should('exist')
-      // Wait for monaco editor to load after lazy loading
-      cy.wait(300)
-      cy.getByTestID('flux-editor').should('exist')
+      cy.getByTestID('flux-editor', {timeout: 30000}).should('be.visible')
       cy.getByTestID('functions-toolbar-contents--functions').should('exist')
       cy.getByTestID('flux--from--inject').click({force: true})
       cy.getByTestID('flux--range--inject').click({force: true})
@@ -524,11 +518,7 @@ describe('DataExplorer', () => {
 
     it('shows the empty state when the query returns no results', () => {
       cy.getByTestID('time-machine--bottom').within(() => {
-        // Assert that the lazy loading state should exist
-        cy.getByTestID('spinner-container').should('exist')
-        // Wait for monaco editor to load after lazy loading
-        cy.wait(300)
-        cy.get('.react-monaco-editor-container')
+        cy.getByTestID('flux-editor')
           .should('be.visible')
           .click()
           .focused()

--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -1326,15 +1326,17 @@ describe('DataExplorer', () => {
 
       it('can save and enable/disable submit button', () => {
         cy.getByTestID('overlay--container').within(() => {
-          cy.get('.cf-button-success').should('be.disabled')
-          cy.get('[placeholder="Give your variable a name"]').type(variableName)
-          cy.get('.cf-button-success').should('be.enabled')
-          cy.get('[placeholder="Give your variable a name"]').clear()
-          cy.get('.cf-button-success').should('be.disabled')
-          cy.get('[placeholder="Give your variable a name"]').type(variableName)
-          cy.get('.cf-button-success').should('be.enabled')
+          cy.getByTestID('variable-form-save').should('be.disabled')
+          cy.getByTestID('flux-editor').should('be.visible')
+          cy.getByTestID('variable-name-input').type(variableName)
+          cy.getByTestID('variable-form-save').should('be.enabled')
+          cy.getByTestID('variable-name-input').clear()
+          cy.getByTestID('variable-form-save').should('be.disabled')
+          cy.getByTestID('flux-editor').should('be.visible')
+          cy.getByTestID('variable-name-input').type(variableName)
+          cy.getByTestID('variable-form-save').should('be.enabled')
 
-          cy.get('.cf-button-success').click()
+          cy.getByTestID('variable-form-save').click()
         })
         visitVariables()
         cy.getByTestID(`variable-card--name ${variableName}`).should('exist')

--- a/cypress/e2e/shared/tasks.test.ts
+++ b/cypress/e2e/shared/tasks.test.ts
@@ -325,17 +325,16 @@ http.post(
         .eq(1)
         .click()
         .then(() => {
-          // Assert that the lazy loading state should exist
-          cy.getByTestID('spinner-container').should('exist')
           // Wait for monaco editor to load after lazy loading
-          cy.wait(1000)
-          cy.getByTestID('flux-editor')
+          cy.getByTestID('flux-editor', {timeout: 30000})
+            .should('be.visible')
             .contains('option task = {')
             .then(() => {
               cy.getByTestID('task-form-name')
                 .should('have.value', '🦄ask')
                 .then(() => {
                   cy.getByTestID('task-form-name')
+                    .should('be.visible')
                     .focus()
                     .clear()
                     .type('Copy task test')

--- a/cypress/e2e/shared/tasks.test.ts
+++ b/cypress/e2e/shared/tasks.test.ts
@@ -325,8 +325,9 @@ http.post(
         .eq(1)
         .click()
         .then(() => {
-          // Wait for monaco editor to load after lazy loading
-          cy.getByTestID('flux-editor', {timeout: 30000})
+          // focused() waits for monoco editor to get input focus
+          cy.focused()
+          cy.getByTestID('flux-editor')
             .should('be.visible')
             .contains('option task = {')
             .then(() => {
@@ -335,7 +336,6 @@ http.post(
                 .then(() => {
                   cy.getByTestID('task-form-name')
                     .should('be.visible')
-                    .focus()
                     .clear()
                     .type('Copy task test')
                     .then(() => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -18,7 +18,10 @@ export const signin = (): Cypress.Chainable<Cypress.Response> => {
   return cy
     .setupUser()
     .then(resp => {
-      cy.log('user setup response', JSON.stringify(resp, null, 2))
+      Object.entries(resp.body).forEach(([k, v]) => {
+        cy.log(k, JSON.stringify(v))
+      })
+      // cy.log('user setup response', JSON.stringify(resp, null, 2))
       cy.visit('/api/v2/signin')
     })
     .then(() => cy.get('#login').type(Cypress.env('username')))

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -18,7 +18,7 @@ export const signin = (): Cypress.Chainable<Cypress.Response> => {
   return cy
     .setupUser()
     .then(resp => {
-      cy.log('user setup response', resp)
+      cy.log('user setup response', JSON.stringify(resp, null, 2))
       cy.visit('/api/v2/signin')
     })
     .then(() => cy.get('#login').type(Cypress.env('username')))

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -476,8 +476,13 @@ export const writeData = (
 }
 
 // DOM node getters
-export const getByTestID = (dataTest: string): Cypress.Chainable => {
-  return cy.get(`[data-testid="${dataTest}"]`)
+export const getByTestID = (
+  dataTest: string,
+  options?: Partial<
+    Cypress.Loggable & Cypress.Timeoutable & Cypress.Withinable & Cypress.Shadow
+  >
+): Cypress.Chainable => {
+  return cy.get(`[data-testid="${dataTest}"]`, options)
 }
 
 export const getByTestIDSubStr = (dataTest: string): Cypress.Chainable => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -17,7 +17,10 @@ export const signin = (): Cypress.Chainable<Cypress.Response> => {
   \*/
   return cy
     .setupUser()
-    .then(() => cy.visit('/api/v2/signin'))
+    .then(resp => {
+      cy.log('user setup response', resp)
+      cy.visit('/api/v2/signin')
+    })
     .then(() => cy.get('#login').type(Cypress.env('username')))
     .then(() => cy.get('#password').type(Cypress.env('password')))
     .then(() => cy.get('#submit-login').click())

--- a/scripts/start_docker.sh
+++ b/scripts/start_docker.sh
@@ -1,0 +1,22 @@
+#! /bin/bash
+
+echo "Starting with DEV_MODE_CLOCKFACE=${1} DEV_MODE_GIRAFFE=${2}"
+
+if [[ "$1" -eq 1 ]]; then
+    echo "Linking clockface..."
+    pushd /clockface
+    yarn link
+    popd
+    yarn link @influxdata/clockface
+fi
+
+if [[ "$2" -eq 1 ]]; then
+    echo "Linking giraffe..."
+    pushd /giraffe/giraffe
+    yarn link
+    popd
+    yarn link @influxdata/giraffe
+fi
+
+echo "Starting UI"
+yarn start:docker

--- a/src/timeMachine/components/TimeMachineFluxEditor.tsx
+++ b/src/timeMachine/components/TimeMachineFluxEditor.tsx
@@ -37,8 +37,10 @@ const TimeMachineFluxEditor: FC<Props> = ({
   activeTab,
 }) => {
   const [editorInstance, setEditorInstance] = useState<EditorType>(null)
-
   const handleInsertVariable = (variableName: string): void => {
+    if (!editorInstance) {
+      return null
+    }
     const p = editorInstance.getPosition()
     editorInstance.executeEdits('', [
       {
@@ -73,6 +75,9 @@ const TimeMachineFluxEditor: FC<Props> = ({
   const getFluxTextAndRange = (
     func: FluxToolbarFunction
   ): {text: string; range: monacoEditor.Range} => {
+    if (!editorInstance) {
+      return null
+    }
     const p = editorInstance.getPosition()
     const insertLineNumber = getInsertLineNumber(p.lineNumber)
 
@@ -111,6 +116,9 @@ const TimeMachineFluxEditor: FC<Props> = ({
   }
 
   const handleInsertFluxFunction = (func: FluxToolbarFunction): void => {
+    if (!editorInstance) {
+      return
+    }
     const {text, range} = getFluxTextAndRange(func)
 
     const edits = [

--- a/src/variables/components/VariableDropdown.tsx
+++ b/src/variables/components/VariableDropdown.tsx
@@ -29,7 +29,7 @@ type Props = OwnProps & ReduxProps
 
 class VariableDropdown extends PureComponent<Props> {
   render() {
-    const {selectedValue, values} = this.props
+    const {selectedValue, values, name} = this.props
 
     const dropdownStatus =
       values.length === 0 ? ComponentStatus.Disabled : ComponentStatus.Default
@@ -46,7 +46,7 @@ class VariableDropdown extends PureComponent<Props> {
       <Dropdown
         style={{width: '140px'}}
         className="variable-dropdown--dropdown"
-        testID={this.props.testID || 'variable-dropdown'}
+        testID={this.props.testID || `variable-dropdown--${name}`}
         button={(active, onClick) => (
           <Dropdown.Button
             active={active}
@@ -125,6 +125,7 @@ const mstp = (state: AppState, props: OwnProps) => {
     status: variable.status,
     values: normalizeValues(variable),
     selectedValue: selected,
+    name: variable.name,
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/influxdata/monitor-ci/issues/124, https://github.com/influxdata/influxdb/issues/20482

Adds a script that has the ability to link clockface and giraffe repos before running `yarn start:docker` when starting the project with monitor-ci.

--> Also fixes broken e2e tests! <--

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

See monitor-ci PR for more details: https://github.com/influxdata/monitor-ci/pull/156