### PR TITLE
feat: add cross network communication

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -396,7 +396,7 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run:
           name: Grab compose files
-          command: git clone --branch story132 git@github.com:influxdata/monitor-ci.git
+          command: git clone git@github.com:influxdata/monitor-ci.git
       - run:
           name: Copy over the lighthouse variables
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -396,15 +396,20 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run:
           name: Grab compose files
-          command: git clone git@github.com:influxdata/monitor-ci.git
+          command: git clone --branch story132 git@github.com:influxdata/monitor-ci.git
       - run:
           name: Copy over the lighthouse variables
           command: |
             cp ./monitor-ci/env.lighthouse ./monitor-ci/.env;
       - run:
+          name: Add Ingress Host to /etc/hosts File
+          command: |
+            INGRESS_HOST=$(cat ./monitor-ci/.env | grep INGRESS_HOST= | cut -d '=' -f2);
+            grep -qxF "127.0.0.1 ${INGRESS_HOST}" /etc/hosts || sudo -- sh -c "echo \"127.0.0.1 ${INGRESS_HOST}\"" >> /etc/hosts";
+      - run:
           name: Update the images we're using
           command: |
-            cd ./monitor-ci && make update && make build NODE=ingress
+            cd ./monitor-ci && sudo rm -rf .persist/certs/ && make update && make build NODE=ingress
             docker load < ~/docker-cache/image.tar
             docker tag quay.io/influxdb/ui-acceptance:${CIRCLE_SHA1} quay.io/influxdb/ui-acceptance:latest
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -404,7 +404,7 @@ jobs:
       - run:
           name: Add Ingress Host to /etc/hosts File
           command: |
-            INGRESS_HOST=$(cat ./monitor-ci/.env | grep INGRESS_HOST= | cut -d '=' -f2);
+            INGRESS_HOST=$(grep "INGRESS_HOST=" ./monitor-ci/.env | cut -d '=' -f2);
             grep -qxF "127.0.0.1 ${INGRESS_HOST}" /etc/hosts || sudo -- sh -c "echo \"127.0.0.1 ${INGRESS_HOST}\" >> /etc/hosts";
       - run:
           name: Update the images we're using

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -405,7 +405,7 @@ jobs:
           name: Add Ingress Host to /etc/hosts File
           command: |
             INGRESS_HOST=$(cat ./monitor-ci/.env | grep INGRESS_HOST= | cut -d '=' -f2);
-            grep -qxF "127.0.0.1 ${INGRESS_HOST}" /etc/hosts || sudo -- sh -c "echo \"127.0.0.1 ${INGRESS_HOST}\"" >> /etc/hosts";
+            grep -qxF "127.0.0.1 ${INGRESS_HOST}" /etc/hosts || sudo -- sh -c "echo \"127.0.0.1 ${INGRESS_HOST}\" >> /etc/hosts";
       - run:
           name: Update the images we're using
           command: |


### PR DESCRIPTION
Part 1: We have some existing weirdness where we load Lighthouse and Cypress images into the compose cloud cluster network and tell it to run things using the internal network routing.

It would be super cool to have these service images built and run outside of the cluster, but point to the cloud cluster (kubernetes.docker.internal or equivalent) when running the tests. Seems pedantic, but the testing infrastructure shouldnt be defined within the "cloud infrastructure" definition and we now have the ability to separate them.

**Story: ** https://app.zenhub.com/workspaces/applicationui-5e3b05772922e316b3a210a4/issues/influxdata/monitor-ci/132