### PR TITLE
chore: use react suspense to lazy load components by route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,7 +40,7 @@ const App: FC<Props> = ({inPresentationMode, currentPage, theme}) => {
       <NotesPortal />
       <OverlayController />
       <TreeNav />
-      <Suspense fallback={<PageSpinner/>}>
+      <Suspense fallback={<PageSpinner />}>
         <Switch>
           <Route path="/orgs/new" component={CreateOrgOverlay} />
           <Route path="/orgs/:orgID" component={SetOrg} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {SFC} from 'react'
+import React, {FC, Suspense, lazy} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 import {connect, ConnectedProps} from 'react-redux'
 import classnames from 'classnames'
@@ -12,8 +12,10 @@ import TooltipPortal from 'src/portals/TooltipPortal'
 import NotesPortal from 'src/portals/NotesPortal'
 import Notifications from 'src/shared/components/notifications/Notifications'
 import OverlayController from 'src/overlays/components/OverlayController'
-import SetOrg from 'src/shared/containers/SetOrg'
-import CreateOrgOverlay from './organizations/components/CreateOrgOverlay'
+const SetOrg = lazy(() => import('src/shared/containers/SetOrg'))
+const CreateOrgOverlay = lazy(() =>
+  import('src/organizations/components/CreateOrgOverlay')
+)
 
 // Types
 import {AppState} from 'src/types'
@@ -22,7 +24,7 @@ type ReduxProps = ConnectedProps<typeof connector>
 type RouterProps = RouteComponentProps
 type Props = ReduxProps & RouterProps
 
-const App: SFC<Props> = ({inPresentationMode, currentPage, theme}) => {
+const App: FC<Props> = ({inPresentationMode, currentPage, theme}) => {
   const appWrapperClass = classnames('', {
     'dashboard-light-mode': currentPage === 'dashboard' && theme === 'light',
   })
@@ -37,10 +39,12 @@ const App: SFC<Props> = ({inPresentationMode, currentPage, theme}) => {
       <NotesPortal />
       <OverlayController />
       <TreeNav />
-      <Switch>
-        <Route path="/orgs/new" component={CreateOrgOverlay} />
-        <Route path="/orgs/:orgID" component={SetOrg} />
-      </Switch>
+      <Suspense fallback={<div>Loading...</div>}>
+        <Switch>
+          <Route path="/orgs/new" component={CreateOrgOverlay} />
+          <Route path="/orgs/:orgID" component={SetOrg} />
+        </Switch>
+      </Suspense>
     </AppWrapper>
   )
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import TooltipPortal from 'src/portals/TooltipPortal'
 import NotesPortal from 'src/portals/NotesPortal'
 import Notifications from 'src/shared/components/notifications/Notifications'
 import OverlayController from 'src/overlays/components/OverlayController'
+import PageSpinner from 'src/perf/components/PageSpinner'
 const SetOrg = lazy(() => import('src/shared/containers/SetOrg'))
 const CreateOrgOverlay = lazy(() =>
   import('src/organizations/components/CreateOrgOverlay')
@@ -39,7 +40,7 @@ const App: FC<Props> = ({inPresentationMode, currentPage, theme}) => {
       <NotesPortal />
       <OverlayController />
       <TreeNav />
-      <Suspense fallback={<div>Loading...</div>}>
+      <Suspense fallback={<PageSpinner/>}>
         <Switch>
           <Route path="/orgs/new" component={CreateOrgOverlay} />
           <Route path="/orgs/:orgID" component={SetOrg} />

--- a/src/Setup.tsx
+++ b/src/Setup.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {ReactElement, PureComponent, Suspense} from 'react'
+import React, {ReactElement, PureComponent, Suspense, lazy} from 'react'
 import {Switch, Route, RouteComponentProps} from 'react-router-dom'
 
 // APIs
@@ -7,12 +7,14 @@ import {client} from 'src/utils/api'
 
 // Components
 import {ErrorHandling} from 'src/shared/decorators/errors'
-import Signin from 'src/Signin'
-import OnboardingWizardPage from 'src/onboarding/containers/OnboardingWizardPage'
-import SigninPage from 'src/onboarding/containers/SigninPage'
-import {LoginPage} from 'src/onboarding/containers/LoginPage'
-import Logout from 'src/Logout'
 import PageSpinner from 'src/perf/components/PageSpinner'
+import {LoginPage} from 'src/onboarding/containers/LoginPage'
+const Signin = lazy(() => import('src/Signin'))
+const OnboardingWizardPage = lazy(() =>
+  import('src/onboarding/containers/OnboardingWizardPage')
+)
+const SigninPage = lazy(() => import('src/onboarding/containers/SigninPage'))
+const Logout = lazy(() => import('src/Logout'))
 
 // Constants
 import {LOGIN, SIGNIN, LOGOUT} from 'src/shared/constants/routes'

--- a/src/Setup.tsx
+++ b/src/Setup.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {ReactElement, PureComponent} from 'react'
+import React, {ReactElement, PureComponent, Suspense} from 'react'
 import {Switch, Route, RouteComponentProps} from 'react-router-dom'
 
 // APIs
@@ -7,12 +7,12 @@ import {client} from 'src/utils/api'
 
 // Components
 import {ErrorHandling} from 'src/shared/decorators/errors'
-import {SpinnerContainer, TechnoSpinner} from '@influxdata/clockface'
 import Signin from 'src/Signin'
 import OnboardingWizardPage from 'src/onboarding/containers/OnboardingWizardPage'
 import SigninPage from 'src/onboarding/containers/SigninPage'
 import {LoginPage} from 'src/onboarding/containers/LoginPage'
 import Logout from 'src/Logout'
+import PageSpinner from 'src/perf/components/PageSpinner'
 
 // Constants
 import {LOGIN, SIGNIN, LOGOUT} from 'src/shared/constants/routes'
@@ -84,23 +84,28 @@ export class Setup extends PureComponent<Props, State> {
     const {loading, allowed} = this.state
 
     return (
-      <SpinnerContainer loading={loading} spinnerComponent={<TechnoSpinner />}>
-        {allowed && (
-          <Route path="/onboarding/:stepID" component={OnboardingWizardPage} />
-        )}
-        {!allowed && (
-          <Switch>
+      <PageSpinner loading={loading}>
+        <Suspense fallback={<PageSpinner />}>
+          {allowed && (
             <Route
               path="/onboarding/:stepID"
               component={OnboardingWizardPage}
             />
-            <Route path={LOGIN} component={LoginPage} />
-            <Route path={SIGNIN} component={SigninPage} />
-            <Route path={LOGOUT} component={Logout} />
-            <Route component={Signin} />
-          </Switch>
-        )}
-      </SpinnerContainer>
+          )}
+          {!allowed && (
+            <Switch>
+              <Route
+                path="/onboarding/:stepID"
+                component={OnboardingWizardPage}
+              />
+              <Route path={LOGIN} component={LoginPage} />
+              <Route path={SIGNIN} component={SigninPage} />
+              <Route path={LOGOUT} component={Logout} />
+              <Route component={Signin} />
+            </Switch>
+          )}
+        </Suspense>
+      </PageSpinner>
     )
   }
 }

--- a/src/perf/components/PageSpinner.tsx
+++ b/src/perf/components/PageSpinner.tsx
@@ -1,0 +1,24 @@
+import React, {FC} from 'react'
+import {
+  SpinnerContainer,
+  TechnoSpinner,
+  RemoteDataState,
+} from '@influxdata/clockface'
+
+interface Props {
+  loading?: RemoteDataState
+  children?: React.ReactChild
+}
+
+const PageSpinner: FC<Props> = ({loading, children}) => {
+  return (
+    <SpinnerContainer
+      loading={loading ?? RemoteDataState.Loading}
+      spinnerComponent={<TechnoSpinner />}
+    >
+      {children}
+    </SpinnerContainer>
+  )
+}
+
+export default PageSpinner

--- a/src/shared/containers/SetOrg.tsx
+++ b/src/shared/containers/SetOrg.tsx
@@ -1,15 +1,10 @@
 // Libraries
-import React, {useEffect, useState, FC} from 'react'
+import React, {useEffect, useState, FC, Suspense, lazy} from 'react'
 import {connect, ConnectedProps, useDispatch} from 'react-redux'
 import {Route, Switch} from 'react-router-dom'
 
 // Components
 import {MePage} from 'src/me'
-import TasksPage from 'src/tasks/containers/TasksPage'
-import TaskPage from 'src/tasks/containers/TaskPage'
-import TaskRunsPage from 'src/tasks/components/TaskRunsPage'
-import TaskEditPage from 'src/tasks/containers/TaskEditPage'
-import DataExplorerPage from 'src/dataExplorer/components/DataExplorerPage'
 import DashboardsIndex from 'src/dashboards/components/dashboard_index/DashboardsIndex'
 import DashboardContainer from 'src/dashboards/components/DashboardContainer'
 import FlowPage from 'src/flows/components/FlowPage'
@@ -21,9 +16,6 @@ import WriteDataPage from 'src/writeData/containers/WriteDataPage'
 import VariablesIndex from 'src/variables/containers/VariablesIndex'
 import LabelsIndex from 'src/labels/containers/LabelsIndex'
 import OrgProfilePage from 'src/organizations/containers/OrgProfilePage'
-import AlertingIndex from 'src/alerting/components/AlertingIndex'
-import AlertHistoryIndex from 'src/alerting/components/AlertHistoryIndex'
-import CheckHistory from 'src/checks/components/CheckHistory'
 import MembersIndex from 'src/members/containers/MembersIndex'
 import RouteToDashboardList from 'src/dashboards/components/RouteToDashboardList'
 import ClientLibrariesPage from 'src/writeData/containers/ClientLibrariesPage'
@@ -33,6 +25,21 @@ import NotFound from 'src/shared/components/NotFound'
 import UsersPage from 'src/unity/components/users/UsersPage'
 import {CommunityTemplatesIndex} from 'src/templates/containers/CommunityTemplatesIndex'
 import {AnnotationsIndex} from 'src/annotations/containers/AnnotationsIndex'
+import PageSpinner from 'src/perf/components/PageSpinner'
+const AlertingIndex = lazy(() =>
+  import('src/alerting/components/AlertingIndex')
+)
+const AlertHistoryIndex = lazy(() =>
+  import('src/alerting/components/AlertHistoryIndex')
+)
+const CheckHistory = lazy(() => import('src/checks/components/CheckHistory'))
+const TaskRunsPage = lazy(() => import('src/tasks/components/TaskRunsPage'))
+const TaskEditPage = lazy(() => import('src/tasks/containers/TaskEditPage'))
+const TaskPage = lazy(() => import('src/tasks/containers/TaskPage'))
+const TasksPage = lazy(() => import('src/tasks/containers/TasksPage'))
+const DataExplorerPage = lazy(() =>
+  import('src/dataExplorer/components/DataExplorerPage')
+)
 
 // Types
 import {AppState, Organization, ResourceType} from 'src/types'
@@ -64,11 +71,7 @@ import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Decorators
 import {RouteComponentProps} from 'react-router-dom'
-import {
-  RemoteDataState,
-  SpinnerContainer,
-  TechnoSpinner,
-} from '@influxdata/clockface'
+import {RemoteDataState} from '@influxdata/clockface'
 
 // Selectors
 import {getAll} from 'src/resources/selectors'
@@ -114,137 +117,142 @@ const SetOrg: FC<Props> = ({
   const orgPath = '/orgs/:orgID'
 
   return (
-    <SpinnerContainer loading={loading} spinnerComponent={<TechnoSpinner />}>
-      <Switch>
-        {/* Alerting */}
-        <Route path={`${orgPath}/alerting`} component={AlertingIndex} />
-        <Route
-          path={`${orgPath}/alert-history`}
-          component={AlertHistoryIndex}
-        />
-        <Route path={`${orgPath}/checks/:checkID`} component={CheckHistory} />
-
-        {/* Tasks */}
-        <Route path={`${orgPath}/tasks/:id/runs`} component={TaskRunsPage} />
-        <Route path={`${orgPath}/tasks/:id/edit`} component={TaskEditPage} />
-        <Route path={`${orgPath}/tasks/new`} component={TaskPage} />
-        <Route path={`${orgPath}/tasks`} component={TasksPage} />
-
-        {/* Data Explorer */}
-        <Route path={`${orgPath}/data-explorer`} component={DataExplorerPage} />
-
-        {/* Dashboards */}
-        <Route
-          path={`${orgPath}/dashboards-list`}
-          component={DashboardsIndex}
-        />
-        <Route
-          path={`${orgPath}/dashboards/:dashboardID`}
-          component={DashboardContainer}
-        />
-        <Route
-          exact
-          path={`${orgPath}/dashboards`}
-          component={RouteToDashboardList}
-        />
-
-        {/* Flows  */}
-        {isFlagEnabled('notebooks') && (
+    <Suspense fallback={<PageSpinner />}>
+      <PageSpinner loading={loading}>
+        <Switch>
+          {/* Alerting */}
+          <Route path={`${orgPath}/alerting`} component={AlertingIndex} />
           <Route
-            path={`${orgPath}/${PROJECT_NAME_PLURAL.toLowerCase()}/:id`}
-            component={FlowPage}
+            path={`${orgPath}/alert-history`}
+            component={AlertHistoryIndex}
           />
-        )}
+          <Route path={`${orgPath}/checks/:checkID`} component={CheckHistory} />
 
-        {isFlagEnabled('notebooks') && (
+          {/* Tasks */}
+          <Route path={`${orgPath}/tasks/:id/runs`} component={TaskRunsPage} />
+          <Route path={`${orgPath}/tasks/:id/edit`} component={TaskEditPage} />
+          <Route path={`${orgPath}/tasks/new`} component={TaskPage} />
+          <Route path={`${orgPath}/tasks`} component={TasksPage} />
+
+          {/* Data Explorer */}
           <Route
-            path={`${orgPath}/${PROJECT_NAME_PLURAL.toLowerCase()}`}
-            component={FlowsIndex}
+            path={`${orgPath}/data-explorer`}
+            component={DataExplorerPage}
           />
-        )}
 
-        {/* Write Data */}
-        <Route
-          path={`${orgPath}/${LOAD_DATA}/sources`}
-          component={WriteDataPage}
-        />
-        <Route
-          path={`${orgPath}/${LOAD_DATA}/${CLIENT_LIBS}`}
-          component={ClientLibrariesPage}
-        />
-        <Route
-          path={`${orgPath}/${LOAD_DATA}/${TELEGRAF_PLUGINS}`}
-          component={TelegrafPluginsPage}
-        />
-
-        {/* Load Data */}
-        <Route
-          exact
-          path={`${orgPath}/${LOAD_DATA}`}
-          component={WriteDataPage}
-        />
-        <Route
-          path={`${orgPath}/${LOAD_DATA}/${SCRAPERS}`}
-          component={ScrapersIndex}
-        />
-        <Route
-          path={`${orgPath}/${LOAD_DATA}/${TELEGRAFS}`}
-          component={TelegrafsPage}
-        />
-        <Route
-          path={`${orgPath}/${LOAD_DATA}/${TOKENS}`}
-          component={TokensIndex}
-        />
-        <Route
-          path={`${orgPath}/${LOAD_DATA}/${BUCKETS}`}
-          component={BucketsIndex}
-        />
-
-        {/* Settings */}
-        {isFlagEnabled('annotations') && (
+          {/* Dashboards */}
           <Route
-            path={`${orgPath}/${SETTINGS}/${ANNOTATIONS}`}
-            component={AnnotationsIndex}
+            path={`${orgPath}/dashboards-list`}
+            component={DashboardsIndex}
           />
-        )}
-        <Route
-          path={`${orgPath}/${SETTINGS}/${VARIABLES}`}
-          component={VariablesIndex}
-        />
-        <Route
-          path={`${orgPath}/${SETTINGS}/${TEMPLATES}`}
-          component={CommunityTemplatesIndex}
-        />
-        <Route
-          exact
-          path={`${orgPath}/${SETTINGS}/${LABELS}`}
-          component={LabelsIndex}
-        />
-        <Route
-          exact
-          path={`${orgPath}/${SETTINGS}`}
-          component={VariablesIndex}
-        />
+          <Route
+            path={`${orgPath}/dashboards/:dashboardID`}
+            component={DashboardContainer}
+          />
+          <Route
+            exact
+            path={`${orgPath}/dashboards`}
+            component={RouteToDashboardList}
+          />
 
-        {/* Users */}
-        {CLOUD && isFlagEnabled('unity') && (
-          <Route path={`${orgPath}/unity-users`} component={UsersPage} />
-        )}
+          {/* Flows  */}
+          {isFlagEnabled('notebooks') && (
+            <Route
+              path={`${orgPath}/${PROJECT_NAME_PLURAL.toLowerCase()}/:id`}
+              component={FlowPage}
+            />
+          )}
 
-        {/* Members */}
-        {!CLOUD && (
-          <Route path={`${orgPath}/members`} component={MembersIndex} />
-        )}
+          {isFlagEnabled('notebooks') && (
+            <Route
+              path={`${orgPath}/${PROJECT_NAME_PLURAL.toLowerCase()}`}
+              component={FlowsIndex}
+            />
+          )}
 
-        {/* About */}
-        <Route path={`${orgPath}/about`} component={OrgProfilePage} />
+          {/* Write Data */}
+          <Route
+            path={`${orgPath}/${LOAD_DATA}/sources`}
+            component={WriteDataPage}
+          />
+          <Route
+            path={`${orgPath}/${LOAD_DATA}/${CLIENT_LIBS}`}
+            component={ClientLibrariesPage}
+          />
+          <Route
+            path={`${orgPath}/${LOAD_DATA}/${TELEGRAF_PLUGINS}`}
+            component={TelegrafPluginsPage}
+          />
 
-        {/* Getting Started */}
-        <Route exact path="/orgs/:orgID" component={MePage} />
+          {/* Load Data */}
+          <Route
+            exact
+            path={`${orgPath}/${LOAD_DATA}`}
+            component={WriteDataPage}
+          />
+          <Route
+            path={`${orgPath}/${LOAD_DATA}/${SCRAPERS}`}
+            component={ScrapersIndex}
+          />
+          <Route
+            path={`${orgPath}/${LOAD_DATA}/${TELEGRAFS}`}
+            component={TelegrafsPage}
+          />
+          <Route
+            path={`${orgPath}/${LOAD_DATA}/${TOKENS}`}
+            component={TokensIndex}
+          />
+          <Route
+            path={`${orgPath}/${LOAD_DATA}/${BUCKETS}`}
+            component={BucketsIndex}
+          />
 
-        <Route component={NotFound} />
-      </Switch>
-    </SpinnerContainer>
+          {/* Settings */}
+          {isFlagEnabled('annotations') && (
+            <Route
+              path={`${orgPath}/${SETTINGS}/${ANNOTATIONS}`}
+              component={AnnotationsIndex}
+            />
+          )}
+          <Route
+            path={`${orgPath}/${SETTINGS}/${VARIABLES}`}
+            component={VariablesIndex}
+          />
+          <Route
+            path={`${orgPath}/${SETTINGS}/${TEMPLATES}`}
+            component={CommunityTemplatesIndex}
+          />
+          <Route
+            exact
+            path={`${orgPath}/${SETTINGS}/${LABELS}`}
+            component={LabelsIndex}
+          />
+          <Route
+            exact
+            path={`${orgPath}/${SETTINGS}`}
+            component={VariablesIndex}
+          />
+
+          {/* Users */}
+          {CLOUD && isFlagEnabled('unity') && (
+            <Route path={`${orgPath}/unity-users`} component={UsersPage} />
+          )}
+
+          {/* Members */}
+          {!CLOUD && (
+            <Route path={`${orgPath}/members`} component={MembersIndex} />
+          )}
+
+          {/* About */}
+          <Route path={`${orgPath}/about`} component={OrgProfilePage} />
+
+          {/* Getting Started */}
+          <Route exact path="/orgs/:orgID" component={MePage} />
+
+          <Route component={NotFound} />
+        </Switch>
+      </PageSpinner>
+    </Suspense>
   )
 }
 

--- a/src/shared/containers/SetOrg.tsx
+++ b/src/shared/containers/SetOrg.tsx
@@ -1,45 +1,41 @@
 // Libraries
-import React, {useEffect, useState, FC, Suspense, lazy} from 'react'
+import React, {useEffect, useState, FC, Suspense} from 'react'
 import {connect, ConnectedProps, useDispatch} from 'react-redux'
 import {Route, Switch} from 'react-router-dom'
 
 // Components
-import {MePage} from 'src/me'
-import DashboardsIndex from 'src/dashboards/components/dashboard_index/DashboardsIndex'
-import DashboardContainer from 'src/dashboards/components/DashboardContainer'
-import FlowPage from 'src/flows/components/FlowPage'
-import BucketsIndex from 'src/buckets/containers/BucketsIndex'
-import TokensIndex from 'src/authorizations/containers/TokensIndex'
-import TelegrafsPage from 'src/telegrafs/containers/TelegrafsPage'
-import ScrapersIndex from 'src/scrapers/containers/ScrapersIndex'
-import WriteDataPage from 'src/writeData/containers/WriteDataPage'
-import VariablesIndex from 'src/variables/containers/VariablesIndex'
-import LabelsIndex from 'src/labels/containers/LabelsIndex'
-import OrgProfilePage from 'src/organizations/containers/OrgProfilePage'
-import MembersIndex from 'src/members/containers/MembersIndex'
-import RouteToDashboardList from 'src/dashboards/components/RouteToDashboardList'
-import ClientLibrariesPage from 'src/writeData/containers/ClientLibrariesPage'
-import TelegrafPluginsPage from 'src/writeData/containers/TelegrafPluginsPage'
-import FlowsIndex from 'src/flows/components/FlowsIndex'
-import NotFound from 'src/shared/components/NotFound'
-import UsersPage from 'src/unity/components/users/UsersPage'
 import {CommunityTemplatesIndex} from 'src/templates/containers/CommunityTemplatesIndex'
 import {AnnotationsIndex} from 'src/annotations/containers/AnnotationsIndex'
 import PageSpinner from 'src/perf/components/PageSpinner'
-const AlertingIndex = lazy(() =>
-  import('src/alerting/components/AlertingIndex')
-)
-const AlertHistoryIndex = lazy(() =>
-  import('src/alerting/components/AlertHistoryIndex')
-)
-const CheckHistory = lazy(() => import('src/checks/components/CheckHistory'))
-const TaskRunsPage = lazy(() => import('src/tasks/components/TaskRunsPage'))
-const TaskEditPage = lazy(() => import('src/tasks/containers/TaskEditPage'))
-const TaskPage = lazy(() => import('src/tasks/containers/TaskPage'))
-const TasksPage = lazy(() => import('src/tasks/containers/TasksPage'))
-const DataExplorerPage = lazy(() =>
-  import('src/dataExplorer/components/DataExplorerPage')
-)
+import {
+  MePage,
+  TasksPage,
+  TaskPage,
+  TaskRunsPage,
+  TaskEditPage,
+  DashboardsIndex,
+  DataExplorerPage,
+  DashboardContainer,
+  FlowPage,
+  BucketsIndex,
+  TokensIndex,
+  TelegrafsPage,
+  ScrapersIndex,
+  WriteDataPage,
+  VariablesIndex,
+  LabelsIndex,
+  OrgProfilePage,
+  AlertingIndex,
+  AlertHistoryIndex,
+  CheckHistory,
+  MembersIndex,
+  RouteToDashboardList,
+  ClientLibrariesPage,
+  TelegrafPluginsPage,
+  FlowsIndex,
+  NotFound,
+  UsersPage,
+} from 'src/shared/containers'
 
 // Types
 import {AppState, Organization, ResourceType} from 'src/types'
@@ -117,8 +113,8 @@ const SetOrg: FC<Props> = ({
   const orgPath = '/orgs/:orgID'
 
   return (
-    <Suspense fallback={<PageSpinner />}>
-      <PageSpinner loading={loading}>
+    <PageSpinner loading={loading}>
+      <Suspense fallback={<PageSpinner />}>
         <Switch>
           {/* Alerting */}
           <Route path={`${orgPath}/alerting`} component={AlertingIndex} />
@@ -251,8 +247,8 @@ const SetOrg: FC<Props> = ({
 
           <Route component={NotFound} />
         </Switch>
-      </PageSpinner>
-    </Suspense>
+      </Suspense>
+    </PageSpinner>
   )
 }
 

--- a/src/shared/containers/index.tsx
+++ b/src/shared/containers/index.tsx
@@ -1,0 +1,71 @@
+import {lazy} from 'react'
+
+export const DataExplorerPage = lazy(() =>
+  import('src/dataExplorer/components/DataExplorerPage')
+)
+export const MePage = lazy(() => import('src/me/containers/MePage'))
+export const TasksPage = lazy(() => import('src/tasks/containers/TasksPage'))
+export const TaskPage = lazy(() => import('src/tasks/containers/TaskPage'))
+export const TaskRunsPage = lazy(() =>
+  import('src/tasks/components/TaskRunsPage')
+)
+export const TaskEditPage = lazy(() =>
+  import('src/tasks/containers/TaskEditPage')
+)
+export const DashboardsIndex = lazy(() =>
+  import('src/dashboards/components/dashboard_index/DashboardsIndex')
+)
+export const DashboardContainer = lazy(() =>
+  import('src/dashboards/components/DashboardContainer')
+)
+export const FlowPage = lazy(() => import('src/flows/components/Flow'))
+export const BucketsIndex = lazy(() =>
+  import('src/buckets/containers/BucketsIndex')
+)
+export const TokensIndex = lazy(() =>
+  import('src/authorizations/containers/TokensIndex')
+)
+export const TelegrafsPage = lazy(() =>
+  import('src/telegrafs/containers/TelegrafsPage')
+)
+export const ScrapersIndex = lazy(() =>
+  import('src/scrapers/containers/ScrapersIndex')
+)
+export const WriteDataPage = lazy(() =>
+  import('src/writeData/containers/WriteDataPage')
+)
+export const VariablesIndex = lazy(() =>
+  import('src/variables/containers/VariablesIndex')
+)
+export const LabelsIndex = lazy(() =>
+  import('src/labels/containers/LabelsIndex')
+)
+export const OrgProfilePage = lazy(() =>
+  import('src/organizations/containers/OrgProfilePage')
+)
+export const AlertingIndex = lazy(() =>
+  import('src/alerting/components/AlertingIndex')
+)
+export const AlertHistoryIndex = lazy(() =>
+  import('src/alerting/components/AlertHistoryIndex')
+)
+export const CheckHistory = lazy(() =>
+  import('src/checks/components/CheckHistory')
+)
+export const MembersIndex = lazy(() =>
+  import('src/members/containers/MembersIndex')
+)
+export const RouteToDashboardList = lazy(() =>
+  import('src/dashboards/components/RouteToDashboardList')
+)
+export const ClientLibrariesPage = lazy(() =>
+  import('src/writeData/containers/ClientLibrariesPage')
+)
+export const TelegrafPluginsPage = lazy(() =>
+  import('src/writeData/containers/TelegrafPluginsPage')
+)
+export const FlowsIndex = lazy(() => import('src/flows/components/FlowsIndex'))
+export const NotFound = lazy(() => import('src/shared/components/NotFound'))
+export const UsersPage = lazy(() =>
+  import('src/unity/components/users/UsersPage')
+)


### PR DESCRIPTION
Closes #509

Use React Suspense to code split based on routes - improves performance scores by 20 points!

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

