### PR TITLE
docs: make Describe your proposed changes text a comment

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 Closes #
 
-Describe your proposed changes here.
+<!-- Describe your proposed changes here. -->
 
 - [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
 - [ ] Rebased/mergeable


### PR DESCRIPTION
Makes `Describe your proposed changes text` a comment so it doesn't show up in the PR description.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

