### PR TITLE
chore: remove enzyme tests from test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "@types/codemirror": "^0.0.56",
     "@types/d3-color": "^1.2.1",
     "@types/d3-scale": "^2.0.1",
-    "@types/enzyme": "^3.1.14",
     "@types/history": "4.7.6",
     "@types/jest": "^23.3.2",
     "@types/lodash": "^4.14.116",

--- a/src/authorizations/components/ViewTokenOverlay.test.tsx
+++ b/src/authorizations/components/ViewTokenOverlay.test.tsx
@@ -9,7 +9,6 @@ import ViewTokenOverlay from 'src/authorizations/components/ViewTokenOverlay'
 import {auth} from 'mocks/dummyData'
 import {Permission} from '@influxdata/influx'
 import {get} from 'lodash'
-import {permissions} from 'src/utils/permissions'
 import {renderWithReduxAndRouter} from 'src/mockState'
 
 const permissions = (

--- a/src/authorizations/components/ViewTokenOverlay.test.tsx
+++ b/src/authorizations/components/ViewTokenOverlay.test.tsx
@@ -41,9 +41,7 @@ const setup = (override?) => {
     ...override,
   }
 
-  renderWithReduxAndRouter(
-    <ViewTokenOverlay {...props} />
-  )
+  renderWithReduxAndRouter(<ViewTokenOverlay {...props} />)
 }
 
 describe('Account', () => {

--- a/src/authorizations/components/ViewTokenOverlay.test.tsx
+++ b/src/authorizations/components/ViewTokenOverlay.test.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React from 'react'
-import {shallow} from 'enzyme'
+import {screen} from '@testing-library/react'
 
 // Components
 import ViewTokenOverlay from 'src/authorizations/components/ViewTokenOverlay'
@@ -9,6 +9,8 @@ import ViewTokenOverlay from 'src/authorizations/components/ViewTokenOverlay'
 import {auth} from 'mocks/dummyData'
 import {Permission} from '@influxdata/influx'
 import {get} from 'lodash'
+import {permissions} from 'src/utils/permissions'
+import {renderWithReduxAndRouter} from 'src/mockState'
 
 const permissions = (
   permissions: Permission[]
@@ -39,15 +41,18 @@ const setup = (override?) => {
     ...override,
   }
 
-  return shallow(<ViewTokenOverlay {...props} />)
+  renderWithReduxAndRouter(
+    <ViewTokenOverlay {...props} />
+  )
 }
 
 describe('Account', () => {
   describe('rendering', () => {
-    it('renders!', () => {
-      const wrapper = setup()
+    it('renders!', async () => {
+      setup()
 
-      expect(wrapper.exists()).toBe(true)
+      const elm = await screen.findByTestId('overlay--container')
+      expect(elm).toBeVisible()
     })
   })
 

--- a/src/clockface/components/inputs/multipleInput/MultipleInput.test.tsx
+++ b/src/clockface/components/inputs/multipleInput/MultipleInput.test.tsx
@@ -1,12 +1,12 @@
 // Libraries
 import React from 'react'
-import {shallow} from 'enzyme'
+import {screen} from '@testing-library/react'
 
 // Components
 import MultipleInput from './MultipleInput'
-import MultipleRows from './MultipleRows'
 
 import {TelegrafPluginInputCpu} from '@influxdata/influx'
+import {renderWithReduxAndRouter} from 'src/mockState'
 
 const setup = (override = {}) => {
   const props = {
@@ -22,18 +22,14 @@ const setup = (override = {}) => {
     ...override,
   }
 
-  const wrapper = shallow(<MultipleInput {...props} />)
-
-  return {wrapper}
+  renderWithReduxAndRouter(<MultipleInput {...props} />)
 }
 
 describe('Clockface.Components.MultipleInput', () => {
-  it('renders', () => {
+  it('renders', async () => {
     const fieldName = 'yo'
-    const {wrapper} = setup({fieldName})
-    const multipleRows = wrapper.find(MultipleRows)
-
-    expect(wrapper.exists()).toBe(true)
-    expect(multipleRows.exists()).toBe(true)
+    setup({fieldName})
+    const elm = await screen.findByTestId('grid')
+    expect(elm).toBeVisible()
   })
 })

--- a/src/clockface/components/inputs/multipleInput/MultipleRows.test.tsx
+++ b/src/clockface/components/inputs/multipleInput/MultipleRows.test.tsx
@@ -1,11 +1,12 @@
 // Libraries
 import React from 'react'
-import {shallow} from 'enzyme'
+import {screen} from '@testing-library/react'
 
 // Components
 import MultipleRows from './MultipleRows'
 
 import {TelegrafPluginInputCpu} from '@influxdata/influx'
+import {renderWithReduxAndRouter} from 'src/mockState'
 
 const setup = (override = {}) => {
   const props = {
@@ -18,16 +19,14 @@ const setup = (override = {}) => {
     ...override,
   }
 
-  const wrapper = shallow(<MultipleRows {...props} />)
-
-  return {wrapper}
+  renderWithReduxAndRouter(<MultipleRows {...props} />)
 }
 
 describe('Clockface.Components.MultipleRows', () => {
-  it('renders', () => {
+  it('renders', async () => {
     const fieldName = 'yo'
-    const {wrapper} = setup({fieldName})
-
-    expect(wrapper.exists()).toBe(true)
+    setup({fieldName})
+    const elm = await screen.findByTestId('multiple-rows')
+    expect(elm).toBeVisible()
   })
 })

--- a/src/clockface/components/inputs/multipleInput/MultipleRows.tsx
+++ b/src/clockface/components/inputs/multipleInput/MultipleRows.tsx
@@ -19,7 +19,7 @@ interface RowsProps {
 
 const Rows: SFC<RowsProps> = ({tags, onDeleteTag, onChange}) => {
   return (
-    <div className="input-tag-list">
+    <div className="input-tag-list" data-testid="multiple-rows">
       {tags.map(item => {
         return (
           <Row

--- a/src/clockface/components/inputs/multipleInput/Row.test.tsx
+++ b/src/clockface/components/inputs/multipleInput/Row.test.tsx
@@ -1,11 +1,13 @@
 // Libraries
 import React from 'react'
-import {shallow} from 'enzyme'
+import {screen} from '@testing-library/react'
 
 // Components
 import Row from './Row'
 
 import {TelegrafPluginInputCpu} from '@influxdata/influx'
+import {renderWithReduxAndRouter} from 'src/mockState'
+
 
 const setup = (override = {}) => {
   const props = {
@@ -19,16 +21,14 @@ const setup = (override = {}) => {
     ...override,
   }
 
-  const wrapper = shallow(<Row {...props} />)
-
-  return {wrapper}
+  renderWithReduxAndRouter(<Row {...props} />)
 }
 
 describe('Onboarding.Components.ConfigureStep.Streaming.ArrayFormElement', () => {
-  it('renders', () => {
+  it('renders', async () => {
     const fieldName = 'yo'
-    const {wrapper} = setup({fieldName})
-
-    expect(wrapper.exists()).toBe(true)
+    setup({fieldName})
+    const elm = await screen.findByTestId('index-list')
+    expect(elm).toBeVisible()
   })
 })

--- a/src/clockface/components/inputs/multipleInput/Row.test.tsx
+++ b/src/clockface/components/inputs/multipleInput/Row.test.tsx
@@ -8,7 +8,6 @@ import Row from './Row'
 import {TelegrafPluginInputCpu} from '@influxdata/influx'
 import {renderWithReduxAndRouter} from 'src/mockState'
 
-
 const setup = (override = {}) => {
   const props = {
     confirmText: '',

--- a/src/dataExplorer/components/SaveAsButton.test.tsx
+++ b/src/dataExplorer/components/SaveAsButton.test.tsx
@@ -1,21 +1,21 @@
 // Libraries
 import React from 'react'
-import {shallow} from 'enzyme'
+import {screen} from '@testing-library/react'
+import {renderWithReduxAndRouter} from 'src/mockState'
 
 // Components
 import SaveAsButton from 'src/dataExplorer/components/SaveAsButton'
 
 const setup = () => {
-  const wrapper = shallow(<SaveAsButton />)
-
-  return {wrapper}
+  renderWithReduxAndRouter(<SaveAsButton />)
 }
 
 describe('SaveAsButton', () => {
-  const {wrapper} = setup()
+  setup()
   describe('rendering', () => {
-    it('renders', () => {
-      expect(wrapper.exists()).toBe(true)
+    it('renders', async () => {
+      const elm = await screen.findByTestId('save-query-as')
+      expect(elm).toBeVisible()
     })
   })
 })

--- a/src/dataLoaders/components/collectorsWizard/configure/ConfigFieldHandler.test.tsx
+++ b/src/dataLoaders/components/collectorsWizard/configure/ConfigFieldHandler.test.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React from 'react'
-import {shallow} from 'enzyme'
+import {screen} from '@testing-library/react'
 
 // Components
 import {ConfigFieldHandler} from 'src/dataLoaders/components/collectorsWizard/configure/ConfigFieldHandler'
@@ -14,7 +14,8 @@ import {
   TelegrafPluginInputCpu,
   TelegrafPluginInputRedis,
 } from '@influxdata/influx'
-import ConfigFieldSwitcher from '../../configureStep/streaming/ConfigFieldSwitcher'
+
+import {renderWithReduxAndRouter} from 'src/mockState'
 
 const setup = (override = {}) => {
   const props = {
@@ -28,40 +29,32 @@ const setup = (override = {}) => {
     ...override,
   }
 
-  const wrapper = shallow(<ConfigFieldHandler {...props} />)
-
-  return {wrapper}
+  renderWithReduxAndRouter(<ConfigFieldHandler {...props} />)
 }
 
 describe('DataLoaders.Components.CollectorsWizard.Configure.ConfigFieldHandler', () => {
   describe('if configFields have no keys', () => {
-    it('renders no config text', () => {
-      const {wrapper} = setup({
+    it('renders no config text', async () => {
+      setup({
         telegrafPlugin,
         configFields:
           telegrafPluginsInfo[TelegrafPluginInputCpu.NameEnum.Cpu].fields,
       })
-      const noConfig = wrapper.find({
-        'data-testid': 'no-config',
-      })
-
-      expect(wrapper.exists()).toBe(true)
-      expect(noConfig.exists()).toBe(true)
+      const noConfig = await screen.findByTestId('no-config')
+      expect(noConfig).toBeVisible()
     })
   })
 
   describe('if configFields have  keys', () => {
-    it('renders correct number of switchers', () => {
+    it('renders correct number of switchers', async () => {
       const configFields =
         telegrafPluginsInfo[TelegrafPluginInputRedis.NameEnum.Redis].fields
-      const {wrapper} = setup({
+      setup({
         telegrafPlugin,
         configFields,
       })
 
-      const switchers = wrapper.find(ConfigFieldSwitcher)
-
-      expect(wrapper.exists()).toBe(true)
+      const switchers = await screen.findAllByTestId('grid')
       expect(switchers.length).toBe(Object.keys(configFields).length)
     })
   })

--- a/src/dataLoaders/components/collectorsWizard/configure/PluginConfigForm.test.tsx
+++ b/src/dataLoaders/components/collectorsWizard/configure/PluginConfigForm.test.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React from 'react'
-import {shallow} from 'enzyme'
+import {screen} from '@testing-library/react'
 
 // Components
 import {Form} from '@influxdata/clockface'
@@ -13,6 +13,8 @@ import {telegrafPlugin} from 'mocks/dummyData'
 
 // Types
 import {TelegrafPluginInputCpu} from '@influxdata/influx'
+
+import {renderWithReduxAndRouter} from 'src/mockState'
 
 const setup = (override = {}) => {
   const props = {
@@ -35,38 +37,35 @@ const setup = (override = {}) => {
     ...override,
   }
 
-  const wrapper = shallow(<PluginConfigForm {...props} />)
-
-  return {wrapper}
+  renderWithReduxAndRouter(<PluginConfigForm {...props} />)
 }
 
 describe('DataLoaders.Components.CollectorsWizard.Configure.PluginConfigForm', () => {
   describe('if configFields have no keys', () => {
-    it('renders text and buttons', () => {
-      const {wrapper} = setup({
+    it('renders text and buttons', async () => {
+      setup({
         telegrafPlugin,
         configFields:
           telegrafPluginsInfo[TelegrafPluginInputCpu.NameEnum.Cpu].fields,
       })
-      const form = wrapper.find(Form)
-      const title = wrapper.find('h3')
-      const onboardingButtons = wrapper.find(OnboardingButtons)
+      const form = await screen.findByTestId('form-container')
+      const title = await screen.getByRole('heading', { level: 3 })
+      const onboardingButtons = await screen.findByTestId('next')
 
-      expect(wrapper.exists()).toBe(true)
-      expect(form.exists()).toBe(true)
-      expect(title.exists()).toBe(true)
-      expect(onboardingButtons.exists()).toBe(true)
+      expect(form).toBeVisible()
+      expect(title).toBeVisible()
+      expect(onboardingButtons).toBeVisible()
     })
   })
 
-  it('has a link to documentation containing plugin name', () => {
-    const {wrapper} = setup({
+  it('has a link to documentation containing plugin name', async () => {
+    setup({
       telegrafPlugin,
     })
 
-    const link = wrapper.find({'data-testid': 'docs-link'})
+    const link = await screen.findByTestId('docs-link')
 
-    expect(link.exists()).toBe(true)
-    expect(link.prop('href')).toContain(telegrafPlugin.name)
+    expect(link).toBeVisible()
+    expect(link.getAttribute('href')).toContain(telegrafPlugin.name)
   })
 })

--- a/src/dataLoaders/components/collectorsWizard/configure/PluginConfigForm.test.tsx
+++ b/src/dataLoaders/components/collectorsWizard/configure/PluginConfigForm.test.tsx
@@ -49,7 +49,7 @@ describe('DataLoaders.Components.CollectorsWizard.Configure.PluginConfigForm', (
           telegrafPluginsInfo[TelegrafPluginInputCpu.NameEnum.Cpu].fields,
       })
       const form = await screen.findByTestId('form-container')
-      const title = await screen.getByRole('heading', { level: 3 })
+      const title = await screen.getByRole('heading', {level: 3})
       const onboardingButtons = await screen.findByTestId('next')
 
       expect(form).toBeVisible()

--- a/src/dataLoaders/components/collectorsWizard/configure/PluginConfigForm.test.tsx
+++ b/src/dataLoaders/components/collectorsWizard/configure/PluginConfigForm.test.tsx
@@ -3,9 +3,7 @@ import React from 'react'
 import {screen} from '@testing-library/react'
 
 // Components
-import {Form} from '@influxdata/clockface'
 import {PluginConfigForm} from 'src/dataLoaders/components/collectorsWizard/configure/PluginConfigForm'
-import OnboardingButtons from 'src/onboarding/components/OnboardingButtons'
 
 // Constants
 import {telegrafPluginsInfo} from 'src/dataLoaders/constants/pluginConfigs'

--- a/src/dataLoaders/components/collectorsWizard/configure/PluginConfigSwitcher.test.tsx
+++ b/src/dataLoaders/components/collectorsWizard/configure/PluginConfigSwitcher.test.tsx
@@ -1,12 +1,10 @@
 // Libraries
 import React from 'react'
-import {shallow} from 'enzyme'
+import {screen} from '@testing-library/react'
 
 // Components
 import {PluginConfigSwitcher} from 'src/dataLoaders/components/collectorsWizard/configure/PluginConfigSwitcher'
-import TelegrafPluginInstructions from 'src/dataLoaders/components/collectorsWizard/configure/TelegrafPluginInstructions'
-import EmptyDataSourceState from 'src/dataLoaders/components/configureStep/EmptyDataSourceState'
-import PluginConfigForm from 'src/dataLoaders/components/collectorsWizard/configure/PluginConfigForm'
+import {renderWithReduxAndRouter} from 'src/mockState'
 
 // Constants
 import {telegrafPlugin, token} from 'mocks/dummyData'
@@ -29,43 +27,41 @@ const setup = (override = {}) => {
     ...override,
   }
 
-  const wrapper = shallow(<PluginConfigSwitcher {...props} />)
-
-  return {wrapper}
+  renderWithReduxAndRouter(<PluginConfigSwitcher {...props} />)
 }
 
 describe('DataLoading.Components.Collectors.Configure.PluginConfigSwitcher', () => {
   describe('if no telegraf plugins', () => {
-    it('renders empty data source state', () => {
-      const {wrapper} = setup()
-      const emptyState = wrapper.find(EmptyDataSourceState)
+    it('renders empty data source state', async () => {
+      setup()
+      const emptyState = await screen.findByText("Must select a data source.")
 
-      expect(wrapper.exists()).toBe(true)
-      expect(emptyState.exists()).toBe(true)
+      expect(emptyState).toBeVisible()
     })
   })
 
   describe('if has active telegraf plugin', () => {
-    it('renders plugin config form', () => {
-      const {wrapper} = setup({
+    it('renders plugin config form', async () => {
+      setup({
         telegrafPlugins: [{...telegrafPlugin, active: true}],
       })
-      const form = wrapper.find(PluginConfigForm)
+      const form = await screen.findByTestId("form-container")
 
-      expect(wrapper.exists()).toBe(true)
-      expect(form.exists()).toBe(true)
+      expect(form).toBeVisible()
     })
   })
 
   describe('if has no active telegraf plugin', () => {
-    it('renders telegraf instructions', () => {
-      const {wrapper} = setup({
+    it('renders telegraf instructions', async () => {
+      setup({
         telegrafPlugins: [{...telegrafPlugin, active: false}],
       })
-      const form = wrapper.find(TelegrafPluginInstructions)
 
-      expect(wrapper.exists()).toBe(true)
-      expect(form.exists()).toBe(true)
+      const form = await screen.getAllByRole('heading', { level: 3 })
+      const instructions = await screen.getByText("Configure each plugin from the menu on the left. Some plugins do not require any configuration.")
+
+      expect(form.pop()).toBeVisible()
+      expect(instructions).toBeVisible()
     })
   })
 })

--- a/src/dataLoaders/components/collectorsWizard/configure/PluginConfigSwitcher.test.tsx
+++ b/src/dataLoaders/components/collectorsWizard/configure/PluginConfigSwitcher.test.tsx
@@ -1,10 +1,12 @@
 // Libraries
 import React from 'react'
-import {screen} from '@testing-library/react'
+import {screen, render} from '@testing-library/react'
 
 // Components
 import {PluginConfigSwitcher} from 'src/dataLoaders/components/collectorsWizard/configure/PluginConfigSwitcher'
 import {renderWithReduxAndRouter} from 'src/mockState'
+import TelegrafPluginInstructions from 'src/dataLoaders/components/collectorsWizard/configure/TelegrafPluginInstructions'
+import EmptyDataSourceState from 'src/dataLoaders/components/configureStep/EmptyDataSourceState'
 
 // Constants
 import {telegrafPlugin, token} from 'mocks/dummyData'
@@ -34,7 +36,8 @@ describe('DataLoading.Components.Collectors.Configure.PluginConfigSwitcher', () 
   describe('if no telegraf plugins', () => {
     it('renders empty data source state', async () => {
       setup()
-      const emptyState = await screen.findByText("Must select a data source.")
+      const defaultEmptyStateText = new EmptyDataSourceState({}).render().props.children
+      const emptyState = await screen.findByText(defaultEmptyStateText)
 
       expect(emptyState).toBeVisible()
     })

--- a/src/dataLoaders/components/collectorsWizard/configure/PluginConfigSwitcher.test.tsx
+++ b/src/dataLoaders/components/collectorsWizard/configure/PluginConfigSwitcher.test.tsx
@@ -36,7 +36,8 @@ describe('DataLoading.Components.Collectors.Configure.PluginConfigSwitcher', () 
   describe('if no telegraf plugins', () => {
     it('renders empty data source state', async () => {
       setup()
-      const defaultEmptyStateText = new EmptyDataSourceState({}).render().props.children
+      const defaultEmptyStateText = new EmptyDataSourceState({}).render().props
+        .children
       const emptyState = await screen.findByText(defaultEmptyStateText)
 
       expect(emptyState).toBeVisible()
@@ -48,7 +49,7 @@ describe('DataLoading.Components.Collectors.Configure.PluginConfigSwitcher', () 
       setup({
         telegrafPlugins: [{...telegrafPlugin, active: true}],
       })
-      const form = await screen.findByTestId("form-container")
+      const form = await screen.findByTestId('form-container')
 
       expect(form).toBeVisible()
     })
@@ -60,8 +61,10 @@ describe('DataLoading.Components.Collectors.Configure.PluginConfigSwitcher', () 
         telegrafPlugins: [{...telegrafPlugin, active: false}],
       })
 
-      const form = await screen.getAllByRole('heading', { level: 3 })
-      const instructions = await screen.getByText("Configure each plugin from the menu on the left. Some plugins do not require any configuration.")
+      const form = await screen.getAllByRole('heading', {level: 3})
+      const instructions = await screen.getByText(
+        'Configure each plugin from the menu on the left. Some plugins do not require any configuration.'
+      )
 
       expect(form.pop()).toBeVisible()
       expect(instructions).toBeVisible()

--- a/src/dataLoaders/components/collectorsWizard/configure/PluginConfigSwitcher.test.tsx
+++ b/src/dataLoaders/components/collectorsWizard/configure/PluginConfigSwitcher.test.tsx
@@ -1,11 +1,10 @@
 // Libraries
 import React from 'react'
-import {screen, render} from '@testing-library/react'
+import {screen} from '@testing-library/react'
 
 // Components
 import {PluginConfigSwitcher} from 'src/dataLoaders/components/collectorsWizard/configure/PluginConfigSwitcher'
 import {renderWithReduxAndRouter} from 'src/mockState'
-import TelegrafPluginInstructions from 'src/dataLoaders/components/collectorsWizard/configure/TelegrafPluginInstructions'
 import EmptyDataSourceState from 'src/dataLoaders/components/configureStep/EmptyDataSourceState'
 
 // Constants
@@ -62,8 +61,8 @@ describe('DataLoading.Components.Collectors.Configure.PluginConfigSwitcher', () 
       })
 
       const form = await screen.getAllByRole('heading', {level: 3})
-      const instructions = await screen.getByText(
-        'Configure each plugin from the menu on the left. Some plugins do not require any configuration.'
+      const instructions = await screen.getByTestId(
+        'telegraf-plugin-instructions'
       )
 
       expect(form.pop()).toBeVisible()

--- a/src/dataLoaders/components/collectorsWizard/configure/PluginsSideBar.test.tsx
+++ b/src/dataLoaders/components/collectorsWizard/configure/PluginsSideBar.test.tsx
@@ -42,7 +42,7 @@ describe('PluginsSideBar', () => {
         currentStepIndex: 2,
         telegrafPlugins: [cpuTelegrafPlugin, diskTelegrafPlugin],
       })
-      const tabs = await screen.findAllByTestId("sidebar-tab")
+      const tabs = await screen.findAllByTestId('sidebar-tab')
       expect(tabs.pop()).toBeVisible()
     })
   })

--- a/src/dataLoaders/components/collectorsWizard/configure/PluginsSideBar.test.tsx
+++ b/src/dataLoaders/components/collectorsWizard/configure/PluginsSideBar.test.tsx
@@ -1,11 +1,12 @@
 // Libraries
 import React from 'react'
-import {shallow} from 'enzyme'
+import {screen} from '@testing-library/react'
 
 // Components
 import PluginsSideBar from 'src/dataLoaders/components/collectorsWizard/configure/PluginsSideBar'
 import {cpuTelegrafPlugin, diskTelegrafPlugin} from 'mocks/dummyData'
-import SideBarTab from 'src/dataLoaders/components/side_bar/SideBarTab'
+
+import {renderWithReduxAndRouter} from 'src/mockState'
 
 const onClick = jest.fn(() => {})
 
@@ -20,30 +21,29 @@ const setup = (override = {}) => {
     ...override,
   }
 
-  const wrapper = shallow(<PluginsSideBar {...props} />)
-
-  return {wrapper}
+  renderWithReduxAndRouter(<PluginsSideBar {...props} />)
 }
 
 describe('PluginsSideBar', () => {
   describe('rendering', () => {
-    it('renders! wee!', () => {
-      const {wrapper} = setup({
+    it('renders! wee!', async () => {
+      setup({
         telegrafPlugins: [cpuTelegrafPlugin, diskTelegrafPlugin],
       })
 
-      expect(wrapper.exists()).toBe(true)
+      const elm = await screen.getAllByRole('heading', {level: 3})
+      expect(elm.pop()).toBeVisible()
     })
   })
 
   describe('if on selection step', () => {
-    it('renders the tabs', () => {
-      const {wrapper} = setup({
+    it('renders the tabs', async () => {
+      setup({
         currentStepIndex: 2,
         telegrafPlugins: [cpuTelegrafPlugin, diskTelegrafPlugin],
       })
-      const tabs = wrapper.find(SideBarTab)
-      expect(tabs.exists()).toBe(true)
+      const tabs = await screen.findAllByTestId("sidebar-tab")
+      expect(tabs.pop()).toBeVisible()
     })
   })
 })

--- a/src/dataLoaders/components/collectorsWizard/configure/TelegrafPluginInstructions.tsx
+++ b/src/dataLoaders/components/collectorsWizard/configure/TelegrafPluginInstructions.tsx
@@ -57,7 +57,10 @@ export class TelegrafPluginInstructions extends PureComponent<Props> {
         <div className="data-loading--scroll-content">
           <div>
             <h3 className="wizard-step--title">Configure Plugins</h3>
-            <h5 className="wizard-step--sub-title">
+            <h5
+              className="wizard-step--sub-title"
+              data-testid="telegraf-plugin-instructions"
+            >
               Configure each plugin from the menu on the left. Some plugins do
               not require any configuration.
             </h5>

--- a/src/dataLoaders/components/collectorsWizard/select/SelectCollectorsStep.test.tsx
+++ b/src/dataLoaders/components/collectorsWizard/select/SelectCollectorsStep.test.tsx
@@ -1,14 +1,13 @@
 // Libraries
 import React from 'react'
-import {shallow} from 'enzyme'
+import {screen} from '@testing-library/react'
 
 // Components
 import {SelectCollectorsStep} from 'src/dataLoaders/components/collectorsWizard/select/SelectCollectorsStep'
-import StreamingSelector from 'src/dataLoaders/components/collectorsWizard/select/StreamingSelector'
-import {ComponentStatus} from 'src/clockface'
 
 // Types
 import {DataLoaderType} from 'src/types/dataLoaders'
+import {Bucket} from 'src/types'
 
 // Dummy Data
 import {
@@ -16,7 +15,8 @@ import {
   cpuTelegrafPlugin,
   bucket,
 } from 'mocks/dummyData'
-import OnboardingButtons from 'src/onboarding/components/OnboardingButtons'
+
+import {renderWithReduxAndRouter} from 'src/mockState'
 
 const setup = (override = {}) => {
   const props = {
@@ -36,45 +36,44 @@ const setup = (override = {}) => {
     routes: [],
     selectedBucket: '',
     onSetBucketInfo: jest.fn(),
-    buckets: [],
+    buckets: [{name: 'b1', id: 'b1'} as Bucket],
     ...override,
   }
 
-  return shallow(<SelectCollectorsStep {...props} />)
+  renderWithReduxAndRouter(<SelectCollectorsStep {...props} />)
 }
 
 describe('DataLoaders.Components.CollectorsWizard.Select.SelectCollectorsStep', () => {
   describe('if there are no plugins selected', () => {
-    it('renders streaming selector with buttons', () => {
-      const wrapper = setup({
+    it('renders streaming selector with buttons', async () => {
+      setup({
         type: DataLoaderType.Streaming,
         currentStepIndex: 0,
         substep: 'streaming',
       })
 
-      const streamingSelector = wrapper.find(StreamingSelector)
-      const onboardingButtons = wrapper.find(OnboardingButtons)
+      const elm = await screen.findByTestId('form-container')
+      const elm2 = await screen.findByTestId('next')
 
-      expect(streamingSelector.exists()).toBe(true)
-      expect(onboardingButtons.prop('nextButtonStatus')).toBe(
-        ComponentStatus.Disabled
-      )
+      expect(elm).toBeVisible()
+      expect(elm2).toBeVisible()
+      expect(elm2).toBeDisabled()
     })
   })
 
   describe('if there are plugins selected', () => {
-    it('renders next button with correct status', () => {
-      const wrapper = setup({
+    it('renders next button with correct status', async () => {
+      setup({
         type: DataLoaderType.Streaming,
         currentStepIndex: 0,
         substep: 'streaming',
         telegrafPlugins: [cpuTelegrafPlugin],
+        bucket: bucket.name,
         buckets: [bucket],
       })
-      const onboardingButtons = wrapper.find(OnboardingButtons)
-      expect(onboardingButtons.prop('nextButtonStatus')).toBe(
-        ComponentStatus.Default
-      )
+      const elm2 = await screen.findByTestId('next')
+      expect(elm2).toBeVisible()
+      expect(elm2).not.toBeDisabled()
     })
   })
 })

--- a/src/dataLoaders/components/collectorsWizard/select/StreamingSelector.test.tsx
+++ b/src/dataLoaders/components/collectorsWizard/select/StreamingSelector.test.tsx
@@ -1,9 +1,8 @@
 // Libraries
 import React from 'react'
-import {shallow} from 'enzyme'
+import {screen, fireEvent} from '@testing-library/react'
 
 // Components
-import {Input, SelectableCard} from '@influxdata/clockface'
 import StreamingSelector from 'src/dataLoaders/components/collectorsWizard/select/StreamingSelector'
 
 // Constants
@@ -11,6 +10,8 @@ import {PLUGIN_BUNDLE_OPTIONS} from 'src/dataLoaders/constants/pluginConfigs'
 
 // Mocks
 import {buckets} from 'mocks/dummyData'
+
+import {renderWithReduxAndRouter} from 'src/mockState'
 
 const setup = (override = {}) => {
   const selectedBucketName = buckets[0].name
@@ -25,26 +26,27 @@ const setup = (override = {}) => {
     ...override,
   }
 
-  return shallow(<StreamingSelector {...props} />)
+  renderWithReduxAndRouter(<StreamingSelector {...props} />)
 }
 
 describe('Onboarding.Components.SelectionStep.StreamingSelector', () => {
-  it('renders a filter input and plugin bundles', () => {
-    const wrapper = setup()
-    const cards = wrapper.find(SelectableCard)
-    const filter = wrapper.find(Input)
+  it('renders a filter input and plugin bundles', async () => {
+    setup()
+    const cards = await screen.getAllByTestId('square-grid--card')
+    const filter = await screen.getByTestId('input-field')
 
     expect(cards.length).toBe(PLUGIN_BUNDLE_OPTIONS.length)
-    expect(filter.exists()).toBe(true)
+    expect(filter).toBeVisible()
   })
 
   describe('if searchTerm is not empty', () => {
-    it('filters the plugin bundles', () => {
-      const wrapper = setup()
+    it('filters the plugin bundles', async () => {
+      setup()
       const searchTerm = 'syste'
-      wrapper.setState({searchTerm})
+      const filter = await screen.getByTestId('input-field')
+      fireEvent.change(filter, {target: {value: searchTerm}})
 
-      const cards = wrapper.find(SelectableCard)
+      const cards = await screen.getAllByTestId('square-grid--card')
       expect(cards.length).toBe(1)
     })
   })

--- a/src/dataLoaders/components/configureStep/streaming/ArrayFormElement.test.tsx
+++ b/src/dataLoaders/components/configureStep/streaming/ArrayFormElement.test.tsx
@@ -1,10 +1,10 @@
 // Libraries
 import React from 'react'
-import {shallow} from 'enzyme'
+import {screen} from '@testing-library/react'
 
 // Components
 import ArrayFormElement from 'src/dataLoaders/components/configureStep/streaming/ArrayFormElement'
-import {MultipleInput} from 'src/clockface'
+import {renderWithReduxAndRouter} from 'src/mockState'
 
 import {TelegrafPluginInputCpu} from '@influxdata/influx'
 
@@ -22,18 +22,15 @@ const setup = (override = {}) => {
     ...override,
   }
 
-  const wrapper = shallow(<ArrayFormElement {...props} />)
-
-  return {wrapper}
+  renderWithReduxAndRouter(<ArrayFormElement {...props} />)
 }
 
 describe('Onboarding.Components.ConfigureStep.Streaming.ArrayFormElement', () => {
-  it('renders', () => {
+  it('renders', async () => {
     const fieldName = 'yo'
-    const {wrapper} = setup({fieldName})
-    const multipleInput = wrapper.find(MultipleInput)
+    setup({fieldName})
+    const elm = await screen.findByText(fieldName)
 
-    expect(wrapper.exists()).toBe(true)
-    expect(multipleInput.exists()).toBe(true)
+    expect(elm).toBeVisible()
   })
 })

--- a/src/dataLoaders/components/configureStep/streaming/ArrayFormElement.tsx
+++ b/src/dataLoaders/components/configureStep/streaming/ArrayFormElement.tsx
@@ -28,7 +28,7 @@ class ArrayFormElement extends PureComponent<Props> {
     const {fieldName, autoFocus, helpText} = this.props
 
     return (
-      <div className="multiple-input-index">
+      <div className="multiple-input-index" data-testid="multiple-input">
         <MultipleInput
           title={fieldName}
           helpText={helpText}

--- a/src/dataLoaders/components/configureStep/streaming/ConfigFieldSwitcher.test.tsx
+++ b/src/dataLoaders/components/configureStep/streaming/ConfigFieldSwitcher.test.tsx
@@ -1,18 +1,17 @@
 // Libraries
 import React from 'react'
-import {shallow, mount} from 'enzyme'
+import {screen} from '@testing-library/react'
 
 // Components
-import {Input, FormElement} from '@influxdata/clockface'
 import ConfigFieldSwitcher from 'src/dataLoaders/components/configureStep/streaming/ConfigFieldSwitcher'
-import ArrayFormElement from 'src/dataLoaders/components/configureStep/streaming/ArrayFormElement'
-import URIFormElement from 'src/shared/components/URIFormElement'
 
 // Types
 import {ConfigFieldType} from 'src/types'
 import {TelegrafPluginInputCpu} from '@influxdata/influx'
 
-const setup = (override = {}, shouldMount = false) => {
+import {renderWithReduxAndRouter} from 'src/mockState'
+
+const setup = (override = {}) => {
   const props = {
     fieldName: '',
     fieldType: ConfigFieldType.String,
@@ -27,107 +26,94 @@ const setup = (override = {}, shouldMount = false) => {
     ...override,
   }
 
-  const wrapper = shouldMount
-    ? mount(<ConfigFieldSwitcher {...props} />)
-    : shallow(<ConfigFieldSwitcher {...props} />)
-
-  return {wrapper}
+  renderWithReduxAndRouter(<ConfigFieldSwitcher {...props} />)
 }
 
 describe('Onboarding.Components.ConfigureStep.Streaming.ConfigFieldSwitcher', () => {
   describe('if type is string', () => {
-    it('renders an input', () => {
+    it('renders an input', async () => {
       const fieldName = 'yo'
       const fieldType = ConfigFieldType.String
-      const {wrapper} = setup({fieldName, fieldType})
+      setup({fieldName, fieldType})
 
-      const input = wrapper.find(Input)
+      const input = await screen.getByTestId('input-field')
 
-      expect(wrapper.exists()).toBe(true)
-      expect(input.exists()).toBe(true)
+      expect(input).toBeVisible()
     })
 
     describe('if not required', () => {
-      it('optional is displayed as help text', () => {
+      it('optional is displayed as help text', async () => {
         const fieldName = 'yo'
         const fieldType = ConfigFieldType.String
         const value = ''
-        const {wrapper} = setup({
+        setup({
           fieldName,
           fieldType,
           isRequired: false,
           value,
         })
 
-        const input = wrapper.find(Input)
-        const formElement = wrapper.find(FormElement)
+        const input = await screen.getByTestId('input-field')
+        const formElement = await screen.queryByTestId('form--help-text')
 
-        expect(wrapper.exists()).toBe(true)
-        expect(input.exists()).toBe(true)
-        expect(formElement.prop('helpText')).toBe('optional')
+        expect(input).toBeVisible()
+        expect(formElement.innerHTML).toBe('optional')
       })
     })
   })
 
   describe('if type is array', () => {
-    it('renders an array input', () => {
+    it('renders an array input', async () => {
       const fieldName = ['yo']
       const fieldType = ConfigFieldType.StringArray
       const value = []
-      const {wrapper} = setup({fieldName, fieldType, value}, true)
+      setup({fieldName, fieldType, value})
 
-      const input = wrapper.find(ArrayFormElement)
-      const formElement = wrapper.find(FormElement).first()
+      const input = await screen.getByTestId('input-field')
+      const formElement = await screen.queryByTestId('form--help-text')
 
-      expect(input.exists()).toBe(true)
-      expect(formElement.prop('helpText')).toBe('')
+      expect(input).toBeVisible()
+      expect(formElement).toBeNull()
     })
 
     describe('if not required', () => {
-      const fieldName = ['yo']
-      const value = []
-      const fieldType = ConfigFieldType.StringArray
-      const {wrapper} = setup(
-        {fieldName, fieldType, value, isRequired: false},
-        true
-      )
+      it('optional is displayed as help text', async () => {
+        const fieldName = ['yo']
+        const value = []
+        const fieldType = ConfigFieldType.StringArray
+        setup({fieldName, fieldType, value, isRequired: false})
 
-      const input = wrapper.find(ArrayFormElement)
-      const formElement = wrapper.find(FormElement).first()
+        const input = await screen.getByTestId('multiple-input')
+        const formElement = await screen.queryByTestId('form--help-text')
 
-      expect(wrapper.exists()).toBe(true)
-      expect(input.exists()).toBe(true)
-      expect(formElement.prop('helpText')).toBe('optional')
+        expect(input).toBeVisible()
+        expect(formElement.innerHTML).toBe('optional')
+      })
     })
   })
 
   describe('if type is uri', () => {
-    it('renders a uri input ', () => {
+    it('renders a uri input ', async () => {
       const fieldName = ['http://google.com']
       const fieldType = ConfigFieldType.Uri
       const value = ''
-      const {wrapper} = setup({fieldName, fieldType, value}, true)
+      setup({fieldName, fieldType, value})
 
-      const input = wrapper.find(URIFormElement)
+      const input = await screen.getByTestId('grid')
 
-      expect(wrapper.exists()).toBe(true)
-      expect(input.exists()).toBe(true)
+      expect(input).toBeVisible()
     })
 
     describe('if not required', () => {
-      it('optional is displayed as help text', () => {
+      it('optional is displayed as help text', async () => {
         const fieldName = ['http://google.com']
         const fieldType = ConfigFieldType.Uri
         const value = ''
-        const {wrapper} = setup(
-          {fieldName, fieldType, value, isRequired: false},
-          true
-        )
+        setup({fieldName, fieldType, value, isRequired: false})
 
-        const input = wrapper.find(URIFormElement)
+        const input = await screen.getByTestId('grid')
 
-        expect(wrapper.exists()).toBe(true)
-        expect(input.exists()).toBe(true)
+        expect(input).toBeVisible()
       })
     })
   })

--- a/src/dataLoaders/components/side_bar/SideBar.test.tsx
+++ b/src/dataLoaders/components/side_bar/SideBar.test.tsx
@@ -1,12 +1,14 @@
 // Libraries
 import React from 'react'
-import {shallow} from 'enzyme'
+import {render, screen} from '@testing-library/react'
 
 // Components
 import SideBar from 'src/dataLoaders/components/side_bar/SideBar'
 
 // Types
 import {SideBarTabStatus as TabStatus} from 'src/dataLoaders/components/side_bar/SideBar'
+
+import {renderWithReduxAndRouter} from 'src/mockState'
 
 const onClick = jest.fn(() => {})
 
@@ -15,6 +17,7 @@ const childrenArray = [
     label="a"
     key="a"
     id="a"
+    data-testid="a"
     active={true}
     status={TabStatus.Default}
     onClick={onClick}
@@ -23,6 +26,7 @@ const childrenArray = [
     label="b"
     key="b"
     id="b"
+    data-testid="b"
     active={false}
     status={TabStatus.Default}
     onClick={onClick}
@@ -36,23 +40,27 @@ const setup = (override?, childrenArray = []) => {
     ...override,
   }
 
-  const wrapper = shallow(<SideBar {...props}>{childrenArray} </SideBar>)
-
-  return {wrapper}
+  renderWithReduxAndRouter(<SideBar {...props}>{childrenArray} </SideBar>)
 }
 
 describe('SideBar', () => {
   describe('rendering', () => {
-    it('renders with no children', () => {
-      const {wrapper} = setup()
-      expect(wrapper.exists()).toBe(true)
+    it('renders with no children', async () => {
+      setup()
+
+      const elm = await screen.findByTestId("side-bar")
+
+      expect(elm).toBeVisible()
     })
 
-    it('renders with children, and renders its children', () => {
-      const {wrapper} = setup(null, childrenArray)
-      expect(wrapper.exists()).toBe(true)
-      expect(wrapper.contains(childrenArray[0])).toBe(true)
-      expect(wrapper.find(SideBar.Tab)).toHaveLength(2)
+    it('renders with children, and renders its children', async () => {
+      setup(null, childrenArray)
+      const elm = await screen.findByTestId("side-bar")
+
+      expect(elm).toBeVisible()
+      childrenArray.forEach((child) => {
+        expect(elm.innerHTML).toContain(render(child).container.innerHTML)
+      })
     })
   })
 })

--- a/src/dataLoaders/components/side_bar/SideBar.test.tsx
+++ b/src/dataLoaders/components/side_bar/SideBar.test.tsx
@@ -48,17 +48,17 @@ describe('SideBar', () => {
     it('renders with no children', async () => {
       setup()
 
-      const elm = await screen.findByTestId("side-bar")
+      const elm = await screen.findByTestId('side-bar')
 
       expect(elm).toBeVisible()
     })
 
     it('renders with children, and renders its children', async () => {
       setup(null, childrenArray)
-      const elm = await screen.findByTestId("side-bar")
+      const elm = await screen.findByTestId('side-bar')
 
       expect(elm).toBeVisible()
-      childrenArray.forEach((child) => {
+      childrenArray.forEach(child => {
         expect(elm.innerHTML).toContain(render(child).container.innerHTML)
       })
     })

--- a/src/dataLoaders/components/side_bar/SideBar.tsx
+++ b/src/dataLoaders/components/side_bar/SideBar.tsx
@@ -29,7 +29,7 @@ class SideBar extends Component<Props> {
     const {title} = this.props
 
     return (
-      <div className={this.containerClassName}>
+      <div className={this.containerClassName} data-testid="side-bar">
         <div className="side-bar--container">
           <h3 className="side-bar--title">{title}</h3>
           <DapperScrollbars autoHide={false}>

--- a/src/dataLoaders/components/side_bar/SideBarButton.test.tsx
+++ b/src/dataLoaders/components/side_bar/SideBarButton.test.tsx
@@ -1,6 +1,7 @@
 // Libraries
 import React from 'react'
-import {shallow} from 'enzyme'
+import {screen} from '@testing-library/react'
+import {renderWithReduxAndRouter} from 'src/mockState'
 
 // Components
 import SideBarButton from 'src/dataLoaders/components/side_bar/SideBarButton'
@@ -18,16 +19,15 @@ const setup = (override?) => {
     ...override,
   }
 
-  const wrapper = shallow(<SideBarButton {...props} />)
-
-  return {wrapper}
+  renderWithReduxAndRouter(<SideBarButton {...props} />)
 }
 
 describe('SideBarButton', () => {
   describe('rendering', () => {
-    it('renders! wee!', () => {
-      const {wrapper} = setup()
-      expect(wrapper.exists()).toBe(true)
+    it('renders! wee!', async () => {
+      setup()
+      const elm = await screen.getByTestId('button')
+      expect(elm).toBeVisible()
     })
   })
 })

--- a/src/dataLoaders/components/side_bar/SideBarTab.tsx
+++ b/src/dataLoaders/components/side_bar/SideBarTab.tsx
@@ -19,7 +19,7 @@ class SideBarTab extends Component<Props> {
     const {label} = this.props
 
     return (
-      <div className={this.className} onClick={this.handleClick}>
+      <div className={this.className} onClick={this.handleClick} data-testid="sidebar-tab">
         <pre>
           {this.icon} {label}
         </pre>

--- a/src/dataLoaders/components/side_bar/SideBarTab.tsx
+++ b/src/dataLoaders/components/side_bar/SideBarTab.tsx
@@ -19,7 +19,11 @@ class SideBarTab extends Component<Props> {
     const {label} = this.props
 
     return (
-      <div className={this.className} onClick={this.handleClick} data-testid="sidebar-tab">
+      <div
+        className={this.className}
+        onClick={this.handleClick}
+        data-testid="sidebar-tab"
+      >
         <pre>
           {this.icon} {label}
         </pre>

--- a/src/dataLoaders/components/verifyStep/ConnectionInformation.test.tsx
+++ b/src/dataLoaders/components/verifyStep/ConnectionInformation.test.tsx
@@ -1,6 +1,7 @@
 // Libraries
 import React from 'react'
-import {shallow} from 'enzyme'
+import {screen} from '@testing-library/react'
+import {renderWithReduxAndRouter} from 'src/mockState'
 
 // Components
 import ConnectionInformation, {
@@ -17,15 +18,13 @@ const setup = (override = {}) => {
     ...override,
   }
 
-  const wrapper = shallow(<ConnectionInformation {...props} />)
-
-  return {wrapper}
+  renderWithReduxAndRouter(<ConnectionInformation {...props} />)
 }
 
 describe('Onboarding.Components.ConnectionInformation', () => {
-  it('renders', () => {
-    const {wrapper} = setup()
-
-    expect(wrapper.exists()).toBe(true)
+  it('renders', async () => {
+    setup()
+    const elm = await screen.getByTestId('connection-information')
+    expect(elm).toBeVisible()
   })
 })

--- a/src/dataLoaders/components/verifyStep/ConnectionInformation.tsx
+++ b/src/dataLoaders/components/verifyStep/ConnectionInformation.tsx
@@ -23,7 +23,7 @@ export interface Props {
 class ConnectionInformation extends PureComponent<Props> {
   public render() {
     return (
-      <div>
+      <div data-testid="connection-information">
         <h4 className={`wizard-step--text-state ${this.className}`}>
           {this.header}
         </h4>

--- a/src/dataLoaders/components/verifyStep/TelegrafInstructions.test.tsx
+++ b/src/dataLoaders/components/verifyStep/TelegrafInstructions.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import {shallow} from 'enzyme'
+import {screen} from '@testing-library/react'
+import {renderWithReduxAndRouter} from 'src/mockState'
 
 import TelegrafInstructions from 'src/dataLoaders/components/verifyStep/TelegrafInstructions'
 
@@ -10,12 +11,13 @@ const setup = (override = {}) => {
     ...override,
   }
 
-  return shallow(<TelegrafInstructions {...props} />)
+  renderWithReduxAndRouter(<TelegrafInstructions {...props} />)
 }
 
 describe('TelegrafInstructions', () => {
-  it('renders', () => {
-    const wrapper = setup()
-    expect(wrapper.exists()).toBe(true)
+  it('renders', async () => {
+    setup()
+    const elm = await screen.getByTestId('setup-instructions')
+    expect(elm).toBeVisible()
   })
 })

--- a/src/members/components/Members.test.tsx
+++ b/src/members/components/Members.test.tsx
@@ -1,12 +1,14 @@
 // Libraries
 import React from 'react'
-import {shallow} from 'enzyme'
-
+import {screen} from '@testing-library/react'
+3
 // Components
 import MemberList from 'src/members/components/MemberList'
 
 // Constants
 import {resouceOwner} from 'src/members/dummyData'
+
+import {renderWithReduxAndRouter} from 'src/mockState'
 
 const setup = (override?) => {
   const props = {
@@ -15,16 +17,15 @@ const setup = (override?) => {
     ...override,
   }
 
-  const wrapper = shallow(<MemberList {...props} />)
-
-  return {wrapper}
+  renderWithReduxAndRouter(<MemberList {...props} />)
 }
 
 describe('MemberList', () => {
   describe('rendering', () => {
-    it('renders', () => {
-      const {wrapper} = setup()
-      expect(wrapper.exists()).toBe(true)
+    it('renders', async () => {
+      setup()
+      const elm = await screen.getByTestId('resource-list--body')
+      expect(elm).toBeVisible()
     })
   })
 })

--- a/src/members/components/Members.test.tsx
+++ b/src/members/components/Members.test.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React from 'react'
 import {screen} from '@testing-library/react'
-3
+
 // Components
 import MemberList from 'src/members/components/MemberList'
 

--- a/src/mockState.tsx
+++ b/src/mockState.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import {Provider} from 'react-redux'
 import {Router} from 'react-router-dom'
 import {createMemoryHistory} from 'history'
+import {createStore} from 'redux'
 
 import {render} from '@testing-library/react'
 import {initialState as initialVariablesState} from 'src/variables/reducers'
@@ -9,6 +10,10 @@ import {initialState as initialUserSettingsState} from 'src/userSettings/reducer
 import {configureStoreForTests} from 'src/store/configureStore'
 import {RemoteDataState, TimeZone, LocalStorage, ResourceType} from 'src/types'
 import {pastFifteenMinTimeRange} from './shared/constants/timeRanges'
+import {mockAppState} from 'src/mockAppState'
+
+// Redux
+import {templatesReducer} from 'src/templates/reducers/index'
 
 const {Orgs} = ResourceType
 const {Done} = RemoteDataState
@@ -64,6 +69,13 @@ export function renderWithRedux(ui, initialState = s => s) {
 }
 
 export function renderWithReduxAndRouter(ui, initialState = s => s) {
+  const templatesStore = createStore(templatesReducer)
+  const defaultInitialState = function () {
+    const appState = {...mockAppState} as any
+    appState.resources.templates = templatesStore.getState()
+    return appState
+  }
+  initialState = initialState ?? defaultInitialState
   const history = createMemoryHistory({initialEntries: ['/']})
   const store = configureStoreForTests(initialState(localState))
 

--- a/src/mockState.tsx
+++ b/src/mockState.tsx
@@ -68,7 +68,7 @@ export function renderWithRedux(ui, initialState = s => s) {
   }
 }
 
-export function renderWithReduxAndRouter(ui, initialState = s => s) {
+export function renderWithReduxAndRouter(ui, initialState?) {
   const templatesStore = createStore(templatesReducer)
   const defaultInitialState = function() {
     const appState = {...mockAppState} as any

--- a/src/mockState.tsx
+++ b/src/mockState.tsx
@@ -70,7 +70,7 @@ export function renderWithRedux(ui, initialState = s => s) {
 
 export function renderWithReduxAndRouter(ui, initialState = s => s) {
   const templatesStore = createStore(templatesReducer)
-  const defaultInitialState = function () {
+  const defaultInitialState = function() {
     const appState = {...mockAppState} as any
     appState.resources.templates = templatesStore.getState()
     return appState

--- a/src/onboarding/components/AdminStep.test.tsx
+++ b/src/onboarding/components/AdminStep.test.tsx
@@ -1,12 +1,14 @@
 // Libraries
 import React from 'react'
-import {shallow} from 'enzyme'
+import {screen} from '@testing-library/react'
 
 // Components
 import AdminStep from 'src/onboarding/components/AdminStep'
 
 // Dummy Data
 import {defaultOnboardingStepProps} from 'mocks/dummyData'
+
+import {renderWithReduxAndRouter} from 'src/mockState'
 
 const setup = (override = {}) => {
   const props = {
@@ -15,13 +17,13 @@ const setup = (override = {}) => {
     ...override,
   }
 
-  return shallow(<AdminStep {...props} />)
+  renderWithReduxAndRouter(<AdminStep {...props} />)
 }
 
 describe('Onboarding.Components.AdminStep', () => {
-  it('renders', () => {
-    const wrapper = setup()
-
-    expect(wrapper.exists()).toBe(true)
+  it('renders', async () => {
+    setup()
+    const elm = await screen.getByTestId('admin-step')
+    expect(elm).toBeVisible()
   })
 })

--- a/src/onboarding/components/AdminStep.tsx
+++ b/src/onboarding/components/AdminStep.tsx
@@ -63,7 +63,7 @@ class AdminStep extends PureComponent<Props, State> {
     const icon = this.InputIcon
     const status = this.InputStatus
     return (
-      <div className="onboarding-step">
+      <div className="onboarding-step" data-testid="admin-step">
         <Form onSubmit={this.handleNext}>
           <div className="wizard-step--scroll-area">
             <div className="wizard-step--scroll-content">

--- a/src/onboarding/components/CompletionStep.test.tsx
+++ b/src/onboarding/components/CompletionStep.test.tsx
@@ -1,12 +1,14 @@
 // Libraries
 import React from 'react'
-import {shallow} from 'enzyme'
+import {screen} from '@testing-library/react'
 
 // Components
 import CompletionStep from 'src/onboarding/components/CompletionStep'
 
 // Dummy Data
 import {defaultOnboardingStepProps} from 'mocks/dummyData'
+
+import {renderWithReduxAndRouter} from 'src/mockState'
 
 const setup = (override = {}) => {
   const props = {
@@ -16,13 +18,13 @@ const setup = (override = {}) => {
     ...override,
   }
 
-  return shallow(<CompletionStep {...props} />)
+  renderWithReduxAndRouter(<CompletionStep {...props} />)
 }
 
 describe('Onboarding.Components.CompletionStep', () => {
-  it('renders', () => {
-    const wrapper = setup()
-
-    expect(wrapper.exists()).toBe(true)
+  it('renders', async () => {
+    setup()
+    const elm = await screen.getByTestId('completion-step')
+    expect(elm).toBeVisible()
   })
 })

--- a/src/onboarding/components/CompletionStep.tsx
+++ b/src/onboarding/components/CompletionStep.tsx
@@ -54,7 +54,7 @@ class CompletionStep extends PureComponent<Props> {
     const {onExit} = this.props
 
     return (
-      <div className="onboarding-step">
+      <div className="onboarding-step" data-testid="completion-step">
         <div className="wizard-step--scroll-area">
           <DapperScrollbars autoHide={false}>
             <div className="wizard-step--scroll-content">

--- a/src/scrapers/components/Scrapers.test.tsx
+++ b/src/scrapers/components/Scrapers.test.tsx
@@ -1,12 +1,14 @@
 // Libraries
 import React from 'react'
-import {shallow} from 'enzyme'
+import {screen} from '@testing-library/react'
 
 // Components
 import ScraperList from 'src/scrapers/components/ScraperList'
 
 // Constants
 import {scraperTargets} from 'mocks/dummyData'
+
+import {renderWithReduxAndRouter} from 'src/mockState'
 
 const setup = (override?) => {
   const props = {
@@ -17,16 +19,15 @@ const setup = (override?) => {
     ...override,
   }
 
-  const wrapper = shallow(<ScraperList {...props} />)
-
-  return {wrapper}
+  renderWithReduxAndRouter(<ScraperList {...props} />)
 }
 
 describe('ScraperList', () => {
   describe('rendering', () => {
-    it('renders', () => {
-      const {wrapper} = setup()
-      expect(wrapper.exists()).toBe(true)
+    it('renders', async () => {
+      setup()
+      const elm = await screen.getByTestId('resource-list')
+      expect(elm).toBeVisible()
     })
   })
 })

--- a/src/shared/components/URIFormElement.test.tsx
+++ b/src/shared/components/URIFormElement.test.tsx
@@ -3,7 +3,6 @@ import React from 'react'
 import {screen} from '@testing-library/react'
 
 // Components
-import {Input} from '@influxdata/clockface'
 import URIFormElement from 'src/shared/components/URIFormElement'
 
 import {renderWithReduxAndRouter} from 'src/mockState'

--- a/src/shared/components/URIFormElement.test.tsx
+++ b/src/shared/components/URIFormElement.test.tsx
@@ -24,7 +24,6 @@ describe('URIFormElement', () => {
 
   it('renders', async () => {
     const elm = await screen.getByTestId('input-field')
-    // const input = wrapper.find(Input)
     expect(elm).toBeVisible()
   })
 })

--- a/src/shared/components/URIFormElement.test.tsx
+++ b/src/shared/components/URIFormElement.test.tsx
@@ -1,10 +1,12 @@
 // Libraries
 import React from 'react'
-import {shallow} from 'enzyme'
+import {screen} from '@testing-library/react'
 
 // Components
 import {Input} from '@influxdata/clockface'
 import URIFormElement from 'src/shared/components/URIFormElement'
+
+import {renderWithReduxAndRouter} from 'src/mockState'
 
 const setup = (override = {}) => {
   const props = {
@@ -15,18 +17,15 @@ const setup = (override = {}) => {
     ...override,
   }
 
-  const wrapper = shallow(<URIFormElement {...props} />)
-
-  return {wrapper}
+  renderWithReduxAndRouter(<URIFormElement {...props} />)
 }
 
 describe('URIFormElement', () => {
-  const {wrapper} = setup()
+  setup()
 
-  it('renders', () => {
-    const input = wrapper.find(Input)
-
-    expect(wrapper.exists()).toBe(true)
-    expect(input.exists()).toBe(true)
+  it('renders', async () => {
+    const elm = await screen.getByTestId('input-field')
+    // const input = wrapper.find(Input)
+    expect(elm).toBeVisible()
   })
 })

--- a/src/shared/components/VersionInfo.test.tsx
+++ b/src/shared/components/VersionInfo.test.tsx
@@ -1,6 +1,7 @@
 // Libraries
 import React from 'react'
-import {shallow} from 'enzyme'
+import {screen} from '@testing-library/react'
+import {renderWithReduxAndRouter} from 'src/mockState'
 
 // Components
 import VersionInfo from 'src/shared/components/VersionInfo'
@@ -10,23 +11,21 @@ const setup = (override = {}) => {
     ...override,
   }
 
-  const wrapper = shallow(<VersionInfo {...props} />)
-
-  return {wrapper}
+  renderWithReduxAndRouter(<VersionInfo {...props} />)
 }
 
 describe('VersionInfo', () => {
-  it('renders correctly', () => {
-    const {wrapper} = setup()
-
-    expect(wrapper.exists()).toBe(true)
+  it('renders correctly', async () => {
+    setup()
+    const elm = await screen.getByTestId('version-info')
+    expect(elm).toBeVisible()
   })
 
   describe('when width is specified', () => {
-    it('renders corectly', () => {
-      const {wrapper} = setup({widthPixels: 300})
-
-      expect(wrapper.exists()).toBe(true)
+    it('renders corectly', async () => {
+      setup({widthPixels: 300})
+      const elm = await screen.getByTestId('version-info')
+      expect(elm).toBeVisible()
     })
   })
 })

--- a/src/shared/components/VersionInfo.tsx
+++ b/src/shared/components/VersionInfo.tsx
@@ -11,7 +11,11 @@ interface Props {
 class VersionInfo extends PureComponent<Props> {
   public render() {
     return (
-      <div className="version-info" style={this.style}>
+      <div
+        className="version-info"
+        style={this.style}
+        data-testid="version-info"
+      >
         <p>
           Version {VERSION} {GIT_SHA && <code>({GIT_SHA.slice(0, 7)})</code>}
         </p>

--- a/src/shared/components/cloud/CloudEnv.test.tsx
+++ b/src/shared/components/cloud/CloudEnv.test.tsx
@@ -1,26 +1,26 @@
 // Libraries
 import React from 'react'
-import {mount} from 'enzyme'
+import {screen} from '@testing-library/react'
+import {renderWithReduxAndRouter} from 'src/mockState'
 
 describe('If in cloud', () => {
-  const Childish = <div>moo</div>
+  const Childish = <div data-testid="moo">moo</div>
 
-  it('CloudOnly renders children', () => {
+  it('CloudOnly renders children', async () => {
     jest.mock('src/shared/constants', () => ({CLOUD: true}))
     const CloudOnly = require('src/shared/components/cloud/CloudOnly.tsx')
       .default
-    const wrapper = mount(<CloudOnly>{Childish}</CloudOnly>)
-
-    expect(wrapper.children().exists()).toBe(true)
-    expect(wrapper.children().matchesElement(Childish)).toBe(true)
+    renderWithReduxAndRouter(<CloudOnly>{Childish}</CloudOnly>)
+    const elm = await screen.getByTestId('moo')
+    expect(elm).toBeVisible()
   })
 
-  it('CloudExclude does not render chilren', () => {
+  it('CloudExclude does not render chilren', async () => {
     jest.mock('src/shared/constants', () => ({CLOUD: true}))
     const CloudExclude = require('src/shared/components/cloud/CloudExclude.tsx')
       .default
-    const wrapper = mount(<CloudExclude>{Childish}</CloudExclude>)
-
-    expect(wrapper.children().exists()).toBe(false)
+    renderWithReduxAndRouter(<CloudExclude>{Childish}</CloudExclude>)
+    const elm = await screen.queryByTestId('moo')
+    expect(elm).toBeNull()
   })
 })

--- a/src/shared/components/sorting_hat/SortingHat.test.tsx
+++ b/src/shared/components/sorting_hat/SortingHat.test.tsx
@@ -1,12 +1,14 @@
 // Libraries
 import React from 'react'
-import {shallow} from 'enzyme'
+import {screen} from '@testing-library/react'
 
 // Components
 import SortingHat from 'src/shared/components/sorting_hat/SortingHat'
 
 // Types
 import {Sort} from 'src/clockface/types'
+
+import {renderWithReduxAndRouter} from 'src/mockState'
 
 const users = [
   {user: {name: 'fred'}, age: 48},
@@ -16,7 +18,7 @@ const users = [
 ]
 
 const setup = (override?) => {
-  const children = jest.fn(() => <div />)
+  const children = jest.fn(() => <div data-testid="my-special-div" />)
   const props = {
     list: users,
     sortKey: 'user.name',
@@ -25,16 +27,17 @@ const setup = (override?) => {
     ...override,
   }
 
-  const wrapper = shallow(<SortingHat {...props} />)
+  renderWithReduxAndRouter(<SortingHat {...props} />)
 
-  return {wrapper, children}
+  return children
 }
 
 describe('SortingHat', () => {
   describe('rendering', () => {
-    it('renders', () => {
-      const {wrapper} = setup()
-      expect(wrapper.exists()).toBe(true)
+    it('renders', async () => {
+      setup()
+      const elm = await screen.findByTestId('my-special-div')
+      expect(elm).toBeVisible()
     })
   })
 
@@ -49,7 +52,7 @@ describe('SortingHat', () => {
         {user: {name: 'fred'}, age: 40},
       ]
 
-      const {children} = setup({sortKey, direction})
+      const children = setup({sortKey, direction})
 
       expect(children).toBeCalledWith(expected)
     })

--- a/src/tasks/components/TasksList.test.tsx
+++ b/src/tasks/components/TasksList.test.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React from 'react'
-import {shallow} from 'enzyme'
+import {screen} from '@testing-library/react'
 
 // Components
 import TasksList from 'src/tasks/components/TasksList'
@@ -10,6 +10,8 @@ import {Task} from 'src/types'
 
 // Constants
 import {tasks} from 'mocks/dummyData'
+
+import {renderWithReduxAndRouter} from 'src/mockState'
 
 const setup = (override?) => {
   const props = {
@@ -24,9 +26,7 @@ const setup = (override?) => {
     ...override,
   }
 
-  const wrapper = shallow(<TasksList {...props} />)
-
-  return {wrapper}
+  renderWithReduxAndRouter(<TasksList {...props} />)
 }
 
 const oneTestFunction = (tasks: Task) => {
@@ -40,9 +40,10 @@ const secondTestFunction = () => {
 
 describe('TasksList', () => {
   describe('rendering', () => {
-    it('renders', () => {
-      const {wrapper} = setup()
-      expect(wrapper.exists()).toBe(true)
+    it('renders', async () => {
+      setup()
+      const elm = await screen.findAllByTestId('task-card')
+      expect(elm[0]).toBeVisible()
     })
   })
 })

--- a/src/templates/containers/CommunityTemplatesIndex.test.tsx
+++ b/src/templates/containers/CommunityTemplatesIndex.test.tsx
@@ -1,6 +1,5 @@
 // Installed libraries
 import React from 'react'
-import {createStore} from 'redux'
 import {fireEvent, screen, waitFor} from '@testing-library/react'
 import {normalize} from 'normalizr'
 import {mocked} from 'ts-jest/utils'
@@ -29,14 +28,10 @@ import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
 // Mock State
 import {renderWithReduxAndRouter} from 'src/mockState'
 import {withRouterProps} from 'mocks/dummyData'
-import {mockAppState} from 'src/mockAppState'
 
 // Types
 import {Organization, RemoteDataState, OrgEntities} from 'src/types'
 import {arrayOfOrgs} from 'src/schemas'
-
-// Redux
-import {templatesReducer} from 'src/templates/reducers/index'
 
 // What have you
 import {communityTemplateUnsupportedFormatError} from 'src/shared/copy/notifications'
@@ -53,16 +48,7 @@ const defaultProps: any = {
 }
 
 const setup = (props = defaultProps) => {
-  const templatesStore = createStore(templatesReducer)
-
-  return renderWithReduxAndRouter(
-    <CommunityTemplatesIndex {...props} />,
-    _fakeLocalStorage => {
-      const appState = {...mockAppState} as any
-      appState.resources.templates = templatesStore.getState()
-      return appState
-    }
-  )
+  return renderWithReduxAndRouter(<CommunityTemplatesIndex {...props} />)
 }
 
 describe('the Community Templates index', () => {

--- a/src/timeMachine/components/RawFluxDataTable.test.tsx
+++ b/src/timeMachine/components/RawFluxDataTable.test.tsx
@@ -29,9 +29,15 @@ describe('RawFluxDataTable', () => {
       <RawFluxDataTable parsedResults={data} width={10000} height={10000} />
     )
 
-    const group = await screen.findAllByTestId('raw-flux-data-table--cell #group')
-    const datatype = await screen.findAllByTestId('raw-flux-data-table--cell #datatype')
-    const date = await screen.findAllByTestId('raw-flux-data-table--cell 1677-09-21T00:12:43.145Z')
+    const group = await screen.findAllByTestId(
+      'raw-flux-data-table--cell #group'
+    )
+    const datatype = await screen.findAllByTestId(
+      'raw-flux-data-table--cell #datatype'
+    )
+    const date = await screen.findAllByTestId(
+      'raw-flux-data-table--cell 1677-09-21T00:12:43.145Z'
+    )
 
     expect(group[0]).toBeVisible()
     expect(group.length).toEqual(4)

--- a/src/timeMachine/components/RawFluxDataTable.test.tsx
+++ b/src/timeMachine/components/RawFluxDataTable.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
-import {mount} from 'enzyme'
+import {screen} from '@testing-library/react'
 import {fromFlux} from '@influxdata/giraffe'
+import {renderWithReduxAndRouter} from 'src/mockState'
 
 import RawFluxDataTable from 'src/timeMachine/components/RawFluxDataTable'
 
@@ -22,17 +23,21 @@ export const MULTI_SCHEMA_RESPONSE = `#datatype,string,long,dateTime:RFC3339,dat
 `
 
 describe('RawFluxDataTable', () => {
-  test('it can render a simple grid from a flux response', () => {
+  test('it can render a simple grid from a flux response', async () => {
     const data = fromFlux(MULTI_SCHEMA_RESPONSE)
-    const wrapper = mount(
+    renderWithReduxAndRouter(
       <RawFluxDataTable parsedResults={data} width={10000} height={10000} />
     )
 
-    const cells = wrapper.find('.raw-flux-data-table--cell')
+    const group = await screen.findAllByTestId('raw-flux-data-table--cell #group')
+    const datatype = await screen.findAllByTestId('raw-flux-data-table--cell #datatype')
+    const date = await screen.findAllByTestId('raw-flux-data-table--cell 1677-09-21T00:12:43.145Z')
 
-    expect(cells.at(0).text()).toEqual('#group')
-    expect(cells.at(14).text()).toEqual('#datatype')
-    expect(cells.at(41).text()).toEqual('')
-    expect(cells.at(59).text()).toEqual('1677-09-21T00:12:43.145Z')
+    expect(group[0]).toBeVisible()
+    expect(group.length).toEqual(4)
+    expect(datatype[0]).toBeVisible()
+    expect(datatype.length).toEqual(4)
+    expect(date[0]).toBeVisible()
+    expect(date.length).toEqual(4)
   })
 })

--- a/src/variables/components/VariableFormContext.test.tsx
+++ b/src/variables/components/VariableFormContext.test.tsx
@@ -28,7 +28,7 @@ const setup = (override?) => {
     onEditorClose: () => actions.clear(),
     ...override,
   }
-
+  // (gene: mstp): We are unable to mock mstp that this component depends on w/o enzyme
   const wrapper = shallow<VariableFormContext>(
     <VariableFormContext {...props} />
   )

--- a/src/variables/components/VariableFormContext.test.tsx
+++ b/src/variables/components/VariableFormContext.test.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React from 'react'
-import {screen} from '@testing-library/react'
 
 // Components
 import {VariableFormContext} from 'src/variables/components/VariableFormContext'

--- a/src/variables/components/VariableFormContext.test.tsx
+++ b/src/variables/components/VariableFormContext.test.tsx
@@ -1,11 +1,14 @@
 // Libraries
 import React from 'react'
-import {shallow} from 'enzyme'
+import {screen} from '@testing-library/react'
 
 // Components
 import {VariableFormContext} from 'src/variables/components/VariableFormContext'
 
+import {renderWithReduxAndRouter} from 'src/mockState'
+
 jest.mock('src/shared/components/FluxMonacoEditor', () => () => null)
+const ref = React.createRef()
 
 const setup = (override?) => {
   const actions = {
@@ -28,19 +31,37 @@ const setup = (override?) => {
     onEditorClose: () => actions.clear(),
     ...override,
   }
-  // (gene: mstp): We are unable to mock mstp that this component depends on w/o enzyme
-  const wrapper = shallow<VariableFormContext>(
-    <VariableFormContext {...props} />
-  )
+  renderWithReduxAndRouter(<VariableFormContext {...props} ref={ref} />)
 
-  return {wrapper, actions}
+  return actions
 }
 
 describe('VariableFormContext', () => {
   it('should tell the store to clear on close', () => {
-    const {wrapper, actions} = setup()
+    // (gene: mstp): We are unable to mock mstp that this component depends on w/o enzyme
+    // because it is using selectors, so we are just going to mock these props manually
+    const actions = setup({
+      variables: {},
+      name: 'some name',
+      variableType: 'constant',
+      query: {
+        type: 'query',
+        values: {
+          query: '',
+          language: 'flux',
+        },
+      },
+      map: {
+        type: 'map',
+        values: {},
+      },
+      constant: {
+        type: 'constant',
+        values: [],
+      },
+    })
 
-    wrapper.instance()['handleHideOverlay']()
+    ref.current['handleHideOverlay']()
 
     expect(actions.clear.mock.calls.length).toBe(1)
   })

--- a/src/variables/components/Variables.test.tsx
+++ b/src/variables/components/Variables.test.tsx
@@ -1,12 +1,14 @@
 // Libraries
 import React from 'react'
-import {shallow} from 'enzyme'
+import {screen} from '@testing-library/react'
 
 // Components
 import VariableList from 'src/variables/components/VariableList'
 
 // Constants
 import {variables} from 'mocks/dummyData'
+
+import {renderWithReduxAndRouter} from 'src/mockState'
 
 const setup = (override?) => {
   const props = {
@@ -16,16 +18,15 @@ const setup = (override?) => {
     ...override,
   }
 
-  const wrapper = shallow(<VariableList {...props} />)
-
-  return {wrapper}
+  renderWithReduxAndRouter(<VariableList {...props} />)
 }
 
 describe('VariableList', () => {
   describe('rendering', () => {
-    it('renders', () => {
-      const {wrapper} = setup()
-      expect(wrapper.exists()).toBe(true)
+    it('renders', async () => {
+      setup()
+      const elm = await screen.findByTestId('resource-list')
+      expect(elm).toBeVisible()
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1107,11 +1107,6 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/cheerio@*":
-  version "0.22.9"
-  resolved "https://registry.yarnpkg.com/@types/cheerio/-/cheerio-0.22.9.tgz#b5990152604c2ada749b7f88cab3476f21f39d7b"
-  integrity sha512-q6LuBI0t5u04f0Q4/R+cGBqIbZMtJkVvCSF+nTfFBBdQqQvJR/mNHeWjRkszyLl7oyf2rDoKUYMEjTw5AV0hiw==
-
 "@types/chroma-js@^1.3.4":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@types/chroma-js/-/chroma-js-1.4.0.tgz#1d215474b54e227bd0204572c0483b98593eabd0"
@@ -1143,14 +1138,6 @@
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-1.0.9.tgz#c2cf05a3cd51f810b8d8a9bbca0c74030d4e535e"
   integrity sha512-m+D4NbQdDlTVaO7QgXAnatR3IDxQYDMBtRhgSCi5rs9R1LPq1y7/2aqa1FJ2IWjFm1mOV63swDxonnCDlHgHMA==
-
-"@types/enzyme@^3.1.14":
-  version "3.1.14"
-  resolved "https://registry.yarnpkg.com/@types/enzyme/-/enzyme-3.1.14.tgz#379c26205f6e0e272f3a51d6bbdd50071a9d03a6"
-  integrity sha512-jvAbagrpoSNAXeZw2kRpP10eTsSIH8vW1IBLCXbN0pbZsYZU8FvTPMMd5OzSWUKWTQfrbXFUY8e6un/W4NpqIA==
-  dependencies:
-    "@types/cheerio" "*"
-    "@types/react" "*"
 
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"


### PR DESCRIPTION
Closes #351 

Removes `enzyme` from unit tests and replaces with `@testing-library/react`. 

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

