### PR TITLE
feat(e2e-in-KinD): Remove all references to Cypress.baseUrl

### DIFF
--- a/cypress/e2e/shared/checks.test.ts
+++ b/cypress/e2e/shared/checks.test.ts
@@ -346,9 +346,7 @@ describe('Checks', () => {
             Cypress.minimatch(
               url,
               `
-                ${
-                  Cypress.config().baseUrl
-                }${orgs}/${id}${alerting}${checks}/*/edit
+                *${orgs}/${id}${alerting}${checks}/*/edit
               `
             )
           })

--- a/cypress/e2e/shared/notificationEndpoints.test.ts
+++ b/cypress/e2e/shared/notificationEndpoints.test.ts
@@ -257,10 +257,7 @@ describe('Notification Endpoints', () => {
       cy.get('@org').then(({id}: Organization) => {
         cy.fixture('routes').then(({orgs, alerting, endpoints}) => {
           cy.visit(`${orgs}/${id}${alerting}${endpoints}/${nonexistentID}/edit`)
-          cy.url().should(
-            'eq',
-            `${Cypress.config().baseUrl}${orgs}/${id}${alerting}`
-          )
+          cy.url().should('include', `${orgs}/${id}${alerting}`)
         })
       })
     })

--- a/cypress/e2e/shared/notificationRules.test.ts
+++ b/cypress/e2e/shared/notificationRules.test.ts
@@ -38,10 +38,7 @@ describe('NotificationRules', () => {
       cy.get('@org').then(({id}: Organization) => {
         cy.fixture('routes').then(({orgs, alerting, rules}) => {
           cy.visit(`${orgs}/${id}${alerting}${rules}/${nonexistentID}/edit`)
-          cy.url().should(
-            'eq',
-            `${Cypress.config().baseUrl}${orgs}/${id}${alerting}`
-          )
+          cy.url().should('include', `${orgs}/${id}${alerting}`)
         })
       })
     })


### PR DESCRIPTION
The `cypress/e2e/shared/checks.test.ts`, `cypress/e2e/shared/notificationEndpoints.test.ts`, and `cypress/e2e/shared/notificationRules.test.ts` tests all make assertions that reference `Cypress.config().baseUrl`. 

Cypress deals with routing intelligently and is agnostic to whether or not there is a trailing `/` when routing. But using string interpolation to construct and assert on a url results in a situation where if the baseUrl ends with a `/` the route string asserted on can contain `//` but the url actually contains just one `/`. I've chosen to remove references to `Cypress.config().baseUrl`.  instead asserting the url string include the rest of the route. 