### PR TITLE
fix: handles undefined props while switching viewTypes

### DIFF
--- a/src/shared/visualization/ViewTypeDropdown.tsx
+++ b/src/shared/visualization/ViewTypeDropdown.tsx
@@ -47,10 +47,10 @@ const ViewTypeDropdown: FC<Props> = ({viewType, onUpdateType}) => {
           }
         >
           <div className="view-type-dropdown--graphic">
-            {TYPE_DEFINITIONS[viewType].graphic}
+            {TYPE_DEFINITIONS[viewType]?.graphic}
           </div>
           <div className="view-type-dropdown--name">
-            {TYPE_DEFINITIONS[viewType].name}
+            {TYPE_DEFINITIONS[viewType]?.name}
           </div>
         </Dropdown.Button>
       )}

--- a/src/timeMachine/components/WindowPeriod.tsx
+++ b/src/timeMachine/components/WindowPeriod.tsx
@@ -114,13 +114,9 @@ const WindowPeriod: FunctionComponent<Props> = ({
 
 const mstp = (state: AppState) => {
   const {builderConfig} = getActiveQuery(state)
-  const {
-    aggregateWindow: {period},
-  } = builderConfig
   const everyWindowPeriod = state.alertBuilder.every
-
   return {
-    period,
+    period: builderConfig?.aggregateWindow?.period ?? '',
     isInCheckOverlay: getIsInCheckOverlay(state),
     autoWindowPeriod: getWindowPeriodFromTimeRange(state),
     everyWindowPeriod,


### PR DESCRIPTION
Closes https://github.com/influxdata/idpe/issues/9585

When coming from Alerts to DE the viewType is switched via dispatch from 'alerting' to
'de' and while this change occurs, we need to handle undefined props

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

