### PR TITLE
fix: CSV uploader reports failures and parses special characters

### DIFF
--- a/src/buckets/components/context/csvUploaderProvider.tsx
+++ b/src/buckets/components/context/csvUploaderProvider.tsx
@@ -164,6 +164,12 @@ export const CsvUploaderProvider: FC<Props> = React.memo(({children}) => {
             }
             time = table.getColumn('_time')?.[i] ?? Date.now()
             value = table.getColumn('_value')?.[i] ?? field ?? ''
+            // Adds quotes to values if _value is of string type
+            // https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol/#quotes
+            value =
+              table.getColumnType('_value') === 'string' && value
+                ? '"' + value + '"'
+                : value
             tags = columns
               .filter(col => !!table.getColumn(col)[i])
               .map(

--- a/src/buckets/components/csvUploader/CsvUploaderError.tsx
+++ b/src/buckets/components/csvUploader/CsvUploaderError.tsx
@@ -12,7 +12,14 @@ const CsvUploaderError = () => (
     </p>
     <SparkleSpinner loading={RemoteDataState.Error} sizePixels={220} />
     <p className="line-protocol--status error">
-      Make sure your CSV is properly formatted and try again
+      Make sure your CSV is{' '}
+      <a
+        target="_blank"
+        href="https://docs.influxdata.com/influxdb/v2.0/write-data/developer-tools/csv/"
+      >
+        properly formatted
+      </a>{' '}
+      and try again
     </p>
   </div>
 )

--- a/src/buckets/components/csvUploader/CsvUploaderError.tsx
+++ b/src/buckets/components/csvUploader/CsvUploaderError.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import {SparkleSpinner} from '@influxdata/clockface'
+import {RemoteDataState} from 'src/types'
+
+const CsvUploaderError = () => (
+  <div className="line-protocol--spinner">
+    <p
+      data-testid="line-protocol--status"
+      className="line-protocol--status error"
+    >
+      Failed to Write Data
+    </p>
+    <SparkleSpinner loading={RemoteDataState.Error} sizePixels={220} />
+    <p className="line-protocol--status error">
+      Make sure your CSV is properly formatted and try again
+    </p>
+  </div>
+)
+
+export default CsvUploaderError

--- a/src/buckets/components/csvUploader/CsvUploaderError.tsx
+++ b/src/buckets/components/csvUploader/CsvUploaderError.tsx
@@ -12,13 +12,13 @@ const CsvUploaderError = () => (
     </p>
     <SparkleSpinner loading={RemoteDataState.Error} sizePixels={220} />
     <p className="line-protocol--status error">
-      Make sure your CSV is{' '}
+      Please make sure that CSV was in
       <a
         target="_blank"
-        href="https://docs.influxdata.com/influxdb/v2.0/write-data/developer-tools/csv/"
+        href="https://docs.influxdata.com/influxdb/v2.0/write-data/developer-tools/csv/#csv-annotations"
       >
-        properly formatted
-      </a>{' '}
+        &nbsp;Annotated Format&nbsp;
+      </a>
       and try again
     </p>
   </div>

--- a/src/buckets/components/csvUploader/CsvUploaderWizard.tsx
+++ b/src/buckets/components/csvUploader/CsvUploaderWizard.tsx
@@ -21,9 +21,21 @@ import {CsvUploaderContext} from 'src/buckets/components/context/csvUploaderProv
 // Components
 import CsvUploaderBody from 'src/buckets/components/csvUploader/CsvUploaderBody'
 import CsvUploaderSuccess from 'src/buckets/components/csvUploader/CsvUploaderSuccess'
+import CsvUploaderError from 'src/buckets/components/csvUploader/CsvUploaderError'
 
 // Types
 import {RemoteDataState} from 'src/types'
+
+const getCsvBody = uploadState => {
+  switch (uploadState) {
+    case RemoteDataState.Done:
+      return <CsvUploaderSuccess />
+    case RemoteDataState.Error:
+      return <CsvUploaderError />
+    default:
+      return <CsvUploaderBody />
+  }
+}
 
 const CsvUploaderWizard = () => {
   const {resetUploadState, uploadState} = useContext(CsvUploaderContext)
@@ -44,11 +56,7 @@ const CsvUploaderWizard = () => {
         />
         <Form>
           <Overlay.Body style={{textAlign: 'center'}}>
-            {uploadState === RemoteDataState.Done ? (
-              <CsvUploaderSuccess />
-            ) : (
-              <CsvUploaderBody />
-            )}
+            {getCsvBody(uploadState)}
           </Overlay.Body>
         </Form>
         <OverlayFooter>


### PR DESCRIPTION
Closes #525, #524

Some improvements to the CSV uploader:

1) If the upload fails, the wizard will report the failure. This includes async failures like if the write API requests fails. Some explanation for the failure is provided in the notification.
2) If csv data contains special characters in tag values, these characters are escaped (this only applies to tag columns of string type). 
3) If csv _value column is of string type, it adds quotes around the values

See these example CSVs for trying this out:
[example csv.zip](https://github.com/influxdata/ui/files/5845370/example.csv.zip)


![special_chars](https://user-images.githubusercontent.com/6411855/105247943-6ff4cb80-5b2a-11eb-91ec-912799b80b2f.gif)

![error_message](https://user-images.githubusercontent.com/6411855/105248109-b518fd80-5b2a-11eb-8ff1-8479dfbefbbc.gif)


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

