### PR TITLE
fix: handles undefined fillValues prop

### DIFF
--- a/src/timeMachine/components/FillValues.tsx
+++ b/src/timeMachine/components/FillValues.tsx
@@ -63,13 +63,10 @@ const FillValues: FunctionComponent<Props> = ({
 
 const mstp = (state: AppState) => {
   const {builderConfig} = getActiveQuery(state)
-  const {
-    aggregateWindow: {fillValues},
-  } = builderConfig
 
   return {
     isInCheckOverlay: getIsInCheckOverlay(state),
-    fillValues,
+    fillValues: builderConfig?.aggregateWindow?.fillValues ?? false,
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/influxdata/idpe/issues/9585

See https://github.com/influxdata/ui/pull/529

> When coming from Alerts to DE the viewType is switched via dispatch from 'alerting' to
'de' and while this change occurs, we need to handle undefined props

I found one more instance where this was occurring - `fillValues`

![image](https://user-images.githubusercontent.com/6411855/105258488-ba804300-5b3e-11eb-95b0-5612e4b81442.png)


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass



