### PR TITLE
fix: error message for incompatible check column types

### DIFF
--- a/src/shared/components/CheckPlot.tsx
+++ b/src/shared/components/CheckPlot.tsx
@@ -72,7 +72,10 @@ const CheckPlot: FunctionComponent<Props> = ({
 
   if (!isYNumeric) {
     return (
-      <EmptyGraphMessage message="Checks only support numeric values. Please try choosing another field." />
+      <EmptyGraphMessage
+        message="Checks only support numeric values. Please try choosing another field."
+        testID="empty-graph--numeric"
+      />
     )
   }
 

--- a/src/shared/components/CheckPlot.tsx
+++ b/src/shared/components/CheckPlot.tsx
@@ -64,9 +64,16 @@ const CheckPlot: FunctionComponent<Props> = ({
   const columnKeys = table.columnKeys
   const isValidView =
     columnKeys.includes(X_COLUMN) && columnKeys.includes(Y_COLUMN)
+  const isYNumeric = table.getColumnType(Y_COLUMN) === 'number'
 
   if (!isValidView) {
     return <EmptyGraphMessage message={INVALID_DATA_COPY} />
+  }
+
+  if (!isYNumeric) {
+    return (
+      <EmptyGraphMessage message="Checks only support numeric values. Please try choosing another field." />
+    )
   }
 
   const groupKey = [...fluxGroupKeyUnion, 'result']


### PR DESCRIPTION
Closes https://github.com/influxdata/idpe/issues/9590

Checks are only compatible with numeric fields. Currently if a non-numeric field is chosen, the page crashes with a runtime error. This change shows the user a friendly error message instead, asking them to choose a numeric field.

Adds e2e test to cover this

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

![numeric](https://user-images.githubusercontent.com/6411855/105417609-b7458f80-5bf0-11eb-8449-00b4878c0add.gif)
