### PR TITLE
test: turn off TypeScript warnOnly

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -24,7 +24,6 @@ module.exports = {
       tsConfig: 'tsconfig.test.json',
       diagnostics: {
         ignoreCodes: [6133, 6192], // ignore unused variable errors
-        warnOnly: true
       },
     },
   },

--- a/jestSetup.ts
+++ b/jestSetup.ts
@@ -23,7 +23,7 @@ window.flushAllPromises = async () => {
 
 // mocks and stuff
 fetchMock.enableMocks()
-jest.mock('honeybadger-js', () => () => null)
+jest.mock('src/shared/utils/errors')
 
 // cleans up state between @testing-library/react tests
 afterEach(() => {

--- a/src/templates/components/CommunityTemplateInstallOverlay.test.tsx
+++ b/src/templates/components/CommunityTemplateInstallOverlay.test.tsx
@@ -9,7 +9,6 @@ import {mocked} from 'ts-jest/utils'
 jest.mock('src/cloud/utils/reporting')
 jest.mock('src/resources/components/GetResources')
 jest.mock('src/shared/actions/notifications')
-jest.mock('src/shared/utils/errors')
 
 jest.mock('src/templates/selectors/index.ts', () => {
   return {

--- a/src/templates/containers/CommunityTemplatesIndex.test.tsx
+++ b/src/templates/containers/CommunityTemplatesIndex.test.tsx
@@ -9,7 +9,6 @@ import {mocked} from 'ts-jest/utils'
 jest.mock('src/cloud/utils/reporting')
 jest.mock('src/resources/components/GetResources')
 jest.mock('src/shared/actions/notifications')
-jest.mock('src/shared/utils/errors')
 
 jest.mock('src/templates/api', () => {
   return {

--- a/src/variables/reducers/index.test.ts
+++ b/src/variables/reducers/index.test.ts
@@ -5,7 +5,7 @@ import {variablesReducer} from 'src/variables/reducers'
 import {moveVariable} from 'src/variables/actions/creators'
 
 // Types
-import {RemoteDataState, VariablesState} from 'src/types'
+import {RemoteDataState, VariablesState, VariableValues} from 'src/types'
 
 const contextID = '123123'
 const initialState = (): VariablesState => ({
@@ -18,10 +18,10 @@ const initialState = (): VariablesState => ({
       values: {
         '123': {
           a: 1,
-        },
+        } as VariableValues,
         '456': {
           a: 2,
-        },
+        } as VariableValues,
       },
       order: ['123', '456'],
     },


### PR DESCRIPTION
closes idpe 9623

TypeScript errors were temporarily turned to warnings. After reversing this back, some of the tests written since `warnOnly` was on have failed. This goes through and fixes the errors in those tests.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

