### PR TITLE
fix(performance): prevents unneeded renders on identical props

### DIFF
--- a/src/shared/components/ErrorBoundary.tsx
+++ b/src/shared/components/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 // Libraries
 import React, {Component, ErrorInfo} from 'react'
+import _ from 'lodash'
 
 // Components
 import DefaultErrorMessage from 'src/shared/components/DefaultErrorMessage'
@@ -35,6 +36,8 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
       component: parseComponentName(errorInfo),
     })
   }
+
+  public shouldComponentUpdate = next => !_.isEqual(this.props, next)
 
   public render() {
     const {error} = this.state

--- a/src/shared/components/ErrorBoundary.tsx
+++ b/src/shared/components/ErrorBoundary.tsx
@@ -1,6 +1,6 @@
 // Libraries
-import React, {Component, ErrorInfo} from 'react'
-import _ from 'lodash'
+import React, {Component, ErrorInfo, memo} from 'react'
+import {isEqual} from 'lodash'
 
 // Components
 import DefaultErrorMessage from 'src/shared/components/DefaultErrorMessage'
@@ -37,8 +37,6 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
     })
   }
 
-  public shouldComponentUpdate = next => !_.isEqual(this.props, next)
-
   public render() {
     const {error} = this.state
 
@@ -50,4 +48,4 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   }
 }
 
-export default ErrorBoundary
+export default memo(ErrorBoundary, (prev, next) => isEqual(prev, next))

--- a/src/shared/components/ErrorBoundary.tsx
+++ b/src/shared/components/ErrorBoundary.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {Component, ErrorInfo, memo} from 'react'
+import React, {Component, ErrorInfo, memo, ReactChild} from 'react'
 import {isEqual} from 'lodash'
 
 // Components
@@ -16,6 +16,7 @@ import {ErrorMessageComponent} from 'src/types'
 
 interface ErrorBoundaryProps {
   errorComponent: ErrorMessageComponent
+  children: ReactChild | ReactChild[]
 }
 
 interface ErrorBoundaryState {

--- a/src/timeMachine/components/Vis.tsx
+++ b/src/timeMachine/components/Vis.tsx
@@ -1,9 +1,10 @@
 // Libraries
-import React, {FC} from 'react'
+import React, {Component} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
 import {AutoSizer} from 'react-virtualized'
 import classnames from 'classnames'
 import {fromFlux} from '@influxdata/giraffe'
+import _ from 'lodash'
 
 // Components
 import EmptyQueryView, {ErrorFormat} from 'src/shared/components/EmptyQueryView'
@@ -33,85 +34,90 @@ import {getActiveTimeRange} from 'src/timeMachine/selectors/index'
 type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps
 
-const TimeMachineVis: FC<Props> = ({
-  loading,
-  errorMessage,
-  timeRange,
-  isInitialFetch,
-  isViewingRawData,
-  files,
-  checkType,
-  checkThresholds,
-  viewProperties,
-  giraffeResult,
-  xColumn,
-  yColumn,
-  fillColumns,
-  symbolColumns,
-  timeZone,
-  statuses,
-}) => {
-  // If the current selections for `xColumn`/`yColumn`/ etc. are invalid given
-  // the current Flux response, attempt to make a valid selection instead. This
-  // fallback logic is contained within the selectors that supply each of these
-  // props. Note that in a dashboard context, we display an error instead of
-  // attempting to fall back to an valid selection.
-  const resolvedViewProperties = {
-    ...viewProperties,
-    xColumn,
-    yColumn,
-    fillColumns,
-    symbolColumns,
+class TimeMachineVis extends Component<Props> {
+  shouldComponentUpdate = next => !_.isEqual(this.props, next)
+
+  render() {
+    const {
+      loading,
+      errorMessage,
+      timeRange,
+      isInitialFetch,
+      isViewingRawData,
+      files,
+      checkType,
+      checkThresholds,
+      viewProperties,
+      giraffeResult,
+      xColumn,
+      yColumn,
+      fillColumns,
+      symbolColumns,
+      timeZone,
+      statuses,
+    } = this.props
+    // If the current selections for `xColumn`/`yColumn`/ etc. are invalid given
+    // the current Flux response, attempt to make a valid selection instead. This
+    // fallback logic is contained within the selectors that supply each of these
+    // props. Note that in a dashboard context, we display an error instead of
+    // attempting to fall back to an valid selection.
+    const resolvedViewProperties = {
+      ...viewProperties,
+      xColumn,
+      yColumn,
+      fillColumns,
+      symbolColumns,
+    }
+
+    const noQueries =
+      loading === RemoteDataState.NotStarted || !viewProperties.queries.length
+    const timeMachineViewClassName = classnames('time-machine--view', {
+      'time-machine--view__empty': noQueries,
+    })
+
+    return (
+      <div className={timeMachineViewClassName}>
+        <ErrorBoundary>
+          <ViewLoadingSpinner loading={loading} />
+          <EmptyQueryView
+            loading={loading}
+            errorFormat={ErrorFormat.Scroll}
+            errorMessage={errorMessage}
+            isInitialFetch={isInitialFetch}
+            queries={viewProperties.queries}
+            hasResults={checkResultsLength(giraffeResult)}
+          >
+            {isViewingRawData ? (
+              <AutoSizer>
+                {({width, height}) => {
+                  const [parsedResults] = files.flatMap(fromFlux)
+                  return (
+                    <RawFluxDataTable
+                      parsedResults={parsedResults}
+                      width={width}
+                      height={height}
+                    />
+                  )
+                }}
+              </AutoSizer>
+            ) : (
+              <ViewSwitcher
+                giraffeResult={giraffeResult}
+                timeRange={timeRange}
+                files={files}
+                properties={resolvedViewProperties}
+                checkType={checkType}
+                checkThresholds={checkThresholds}
+                timeZone={timeZone}
+                statuses={statuses}
+                theme="dark"
+              />
+            )}
+          </EmptyQueryView>
+        </ErrorBoundary>
+      </div>
+    )
   }
-
-  const noQueries =
-    loading === RemoteDataState.NotStarted || !viewProperties.queries.length
-  const timeMachineViewClassName = classnames('time-machine--view', {
-    'time-machine--view__empty': noQueries,
-  })
-
-  return (
-    <div className={timeMachineViewClassName}>
-      <ErrorBoundary>
-        <ViewLoadingSpinner loading={loading} />
-        <EmptyQueryView
-          loading={loading}
-          errorFormat={ErrorFormat.Scroll}
-          errorMessage={errorMessage}
-          isInitialFetch={isInitialFetch}
-          queries={viewProperties.queries}
-          hasResults={checkResultsLength(giraffeResult)}
-        >
-          {isViewingRawData ? (
-            <AutoSizer>
-              {({width, height}) => {
-                const [parsedResults] = files.flatMap(fromFlux)
-                return (
-                  <RawFluxDataTable
-                    parsedResults={parsedResults}
-                    width={width}
-                    height={height}
-                  />
-                )
-              }}
-            </AutoSizer>
-          ) : (
-            <ViewSwitcher
-              giraffeResult={giraffeResult}
-              timeRange={timeRange}
-              files={files}
-              properties={resolvedViewProperties}
-              checkType={checkType}
-              checkThresholds={checkThresholds}
-              timeZone={timeZone}
-              statuses={statuses}
-              theme="dark"
-            />
-          )}
-        </EmptyQueryView>
-      </ErrorBoundary>
-    </div>
-  )
 }
 
 const mstp = (state: AppState) => {


### PR DESCRIPTION
Closes https://github.com/influxdata/idpe/issues/9584

ErrorBoundary and Vis components were re-rendering on every interaction, even though their
props were identical. This caused performance issues with query editor. 

I added React.memo to both of these components and provided a custom comparison function that uses Lodash's `isEqual` to perform a deep comparison between the props. Shallow comparisons provided by `PureComponent` or simply `===` does not do the trick in this case.

To verify the improvement, upload the attached CSV to a bucket, query data from the last 30 days and show the "raw data view". There will be 120k rows. Start typing in the flux query editor and you shouldn't notice any slow down over time. 

Without this improvement, the table was being re-rendered on every keystroke and caused noticeable performance issues when typing in the query editor over time.

[very large dataset.csv.zip](https://github.com/influxdata/ui/files/5869088/very.large.dataset.csv.zip)

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass