### PR TITLE
fix: reordering variables now working again

### DIFF
--- a/src/variables/actions/creators.ts
+++ b/src/variables/actions/creators.ts
@@ -56,16 +56,11 @@ export const removeVariable = (id: string) =>
     id,
   } as const)
 
-export const moveVariable = (
-  originalIndex: number,
-  newIndex: number,
-  contextID: string
-) =>
+export const moveVariable = (contextID: string, newVariableOrder: string[]) =>
   ({
     type: MOVE_VARIABLE,
-    originalIndex,
-    newIndex,
     contextID,
+    newVariableOrder,
   } as const)
 
 export const selectValue = (

--- a/src/variables/actions/thunks.ts
+++ b/src/variables/actions/thunks.ts
@@ -28,6 +28,7 @@ import {
   getVariables as getVariablesFromState,
   getAllVariables as getAllVariablesFromState,
   normalizeValues,
+  getVariablesForDashboard,
 } from 'src/variables/selectors'
 import {variableToTemplate} from 'src/shared/utils/resourceToTemplate'
 import {findDependentVariables} from 'src/variables/utils/exportVariables'
@@ -339,7 +340,18 @@ export const moveVariable = (originalIndex: number, newIndex: number) => async (
   getState: GetState
 ) => {
   const contextID = currentContext(getState())
-  await dispatch(moveVariableInState(originalIndex, newIndex, contextID))
+  const byDashboardVariables = getVariablesForDashboard(getState())
+
+  const temp = byDashboardVariables[originalIndex]
+  byDashboardVariables[originalIndex] = byDashboardVariables[newIndex]
+  byDashboardVariables[newIndex] = temp
+
+  await dispatch(
+    moveVariableInState(
+      contextID,
+      byDashboardVariables.map((v: Variable) => v.id)
+    )
+  )
 }
 
 export const convertToTemplate = (variableID: string) => async (

--- a/src/variables/reducers/index.test.ts
+++ b/src/variables/reducers/index.test.ts
@@ -1,0 +1,39 @@
+// Reducer
+import {variablesReducer} from 'src/variables/reducers'
+
+// Actions
+import {moveVariable} from 'src/variables/actions/creators'
+
+// Types
+import {RemoteDataState, VariablesState} from 'src/types'
+
+const contextID = '123123'
+const initialState = (): VariablesState => ({
+  status: RemoteDataState.NotStarted,
+  byID: {},
+  allIDs: [],
+  values: {
+    contextID: {
+      status: RemoteDataState.NotStarted,
+      values: {
+        '123': {
+          a: 1,
+        },
+        '456': {
+          a: 2,
+        },
+      },
+      order: ['123', '456'],
+    },
+  },
+})
+
+describe('Variables Reducer', () => {
+  it('can move a variable to the correct order', () => {
+    const reorderedVariableState = variablesReducer(
+      initialState(),
+      moveVariable('123123', ['456', '123'])
+    )
+    expect(reorderedVariableState.values[contextID].order)
+  })
+})

--- a/src/variables/reducers/index.ts
+++ b/src/variables/reducers/index.ts
@@ -92,27 +92,14 @@ export const variablesReducer = (
       }
 
       case MOVE_VARIABLE: {
-        const {originalIndex, newIndex, contextID} = action
-        let newOrder = get(draftState, `values.${contextID}.order`)
-
-        // if no order, take it from allIDs
-        if (!newOrder) {
-          newOrder = get(draftState, `allIDs`)
-        }
-
-        newOrder = newOrder.slice(0)
-
-        // Pull out variable and insert at new location
-        const variable = newOrder[originalIndex]
-        newOrder.splice(originalIndex, 1)
-        newOrder.splice(newIndex, 0, variable)
+        const {contextID, newVariableOrder} = action
 
         draftState.values[contextID] = {
           ...(draftState.values[contextID] || {
             status: RemoteDataState.NotStarted,
             values: {},
           }),
-          order: newOrder,
+          order: newVariableOrder,
         }
 
         return


### PR DESCRIPTION
Closes #275

<!-- Describe your proposed changes here. -->
This PR addresses #275 which concerns variables not being reorderable in the dashboards page

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

![VariableReorder](https://user-images.githubusercontent.com/29473622/105762716-5d0f3c00-5f1a-11eb-84ad-378d811eed4a.gif)
