### PR TITLE
chore(lsp): Upgrade flux-lsp-browser to v0.5.29

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
   "dependencies": {
     "@influxdata/clockface": "^2.4.1",
     "@influxdata/flux": "^0.5.1",
-    "@influxdata/flux-lsp-browser": "^0.5.28",
+    "@influxdata/flux-lsp-browser": "^0.5.29",
     "@influxdata/giraffe": "^2.0.0",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -787,10 +787,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-2.4.1.tgz#67c61d89782dea07a149dd35e45b9eb13ad63a5f"
   integrity sha512-p1YEnB73wOkzS6PqKr2P3jf0jRLP4mJZBbyOZsDlkYsuy3PrGnGCscshecb/f2XNiTbbbShXy40SzPreM07wQw==
 
-"@influxdata/flux-lsp-browser@^0.5.28":
-  version "0.5.28"
-  resolved "https://registry.yarnpkg.com/@influxdata/flux-lsp-browser/-/flux-lsp-browser-0.5.28.tgz#a8af6474c7ee5dbcc156722755ea44d286dd3803"
-  integrity sha512-J1iH0cBmqiQZPDnASQQj/m7L/aPbDqwfgtD2gB2PodF7NBRbOQHYWjbYQU38n+8ZNb6/rAOdPJIH6WHKfBxvSw==
+"@influxdata/flux-lsp-browser@^0.5.29":
+  version "0.5.29"
+  resolved "https://registry.yarnpkg.com/@influxdata/flux-lsp-browser/-/flux-lsp-browser-0.5.29.tgz#41d12069bda9b5c4d88c95c2f57f865ef153f9dc"
+  integrity sha512-RPwJXmGWJDEUr/HiXyt6uc3a2myBZ+rTse8I3JjG6poCOuD+MwuIG3r9P9CV1gvKrvj/sXaUwzZ+gNGS03xNAQ==
 
 "@influxdata/flux@^0.5.1":
   version "0.5.1"


### PR DESCRIPTION
[Flux LSP v0.5.29](https://github.com/influxdata/flux-lsp/releases/tag/v0.5.29)
