### PR TITLE
fix: for #19216

### DIFF
--- a/src/timeMachine/utils/queryBuilder.test.ts
+++ b/src/timeMachine/utils/queryBuilder.test.ts
@@ -50,6 +50,62 @@ describe('buildQuery', () => {
     expect(actual).toEqual(expected)
   })
 
+  test('group tag present', () => {
+    const config: BuilderConfig = {
+      buckets: ['b0'],
+      tags: [
+        {
+          key: '_measurement',
+          values: ['m0', 'm1'],
+          aggregateFunctionType: 'filter',
+        },
+        {key: '_field', values: ['f0', 'f1'], aggregateFunctionType: 'filter'},
+        {key: '_group', values: ['a0, a1'], aggregateFunctionType: 'group'},
+      ],
+      functions: [{name: 'mean'}],
+      aggregateWindow: {period: 'auto', fillValues: false},
+    }
+
+    const actual = buildQuery(config)
+
+    const expected = `from(bucket: "b0")
+  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+  |> filter(fn: (r) => r["_measurement"] == "m0" or r["_measurement"] == "m1")
+  |> filter(fn: (r) => r["_field"] == "f0" or r["_field"] == "f1")
+  |> group(columns: ["a0, a1"])
+  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)
+  |> yield(name: "mean")`
+
+    expect(actual).toEqual(expected)
+  })
+
+  test('group Tag empty', () => {
+    const config: BuilderConfig = {
+      buckets: ['b0'],
+      tags: [
+        {
+          key: '_measurement',
+          values: ['m0', 'm1'],
+          aggregateFunctionType: 'filter',
+        },
+        {key: '_field', values: ['f0', 'f1'], aggregateFunctionType: 'filter'},
+        {key: '_group', values: [], aggregateFunctionType: 'group'},
+      ],
+      functions: [{name: 'mean'}],
+      aggregateWindow: {period: 'auto', fillValues: false},
+    }
+
+    const actual = buildQuery(config)
+    const expected = `from(bucket: "b0")
+  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+  |> filter(fn: (r) => r["_measurement"] == "m0" or r["_measurement"] == "m1")
+  |> filter(fn: (r) => r["_field"] == "f0" or r["_field"] == "f1")
+  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)
+  |> yield(name: "mean")`
+
+    expect(actual).toEqual(expected)
+  })
+
   test('single tag, multiple functions', () => {
     const config: BuilderConfig = {
       buckets: ['b0'],

--- a/src/timeMachine/utils/queryBuilder.ts
+++ b/src/timeMachine/utils/queryBuilder.ts
@@ -165,6 +165,12 @@ const convertTagsToFluxFunctionString = function convertTagsToFluxFunctionString
   }
 
   if (tag.aggregateFunctionType === 'group') {
+    // if group is selected, but there are no values, don't return anything.
+    // same behavior as when 'filter' is selected but no values are chosen
+    if (!tag.values.length) {
+      return ''
+    }
+
     const quotedValues = tag.values.map(value => `"${value}"`) // wrap the value in double quotes
 
     if (quotedValues.length) {


### PR DESCRIPTION
took part of palak's fix;  just needed the part that  zeroed out the group clause if values are absent.

Closes https://github.com/influxdata/influxdb/issues/19216

- [ ] Rebased to most recent master
- [ ] Tests pass; they passed on the earlier commit and circle-ci had a problem on the most recent rebase; but they should pass.

