### PR TITLE
chore: Allow selecting 3 hours in dashboard time range picker.

### DIFF
--- a/src/shared/constants/timeRanges.ts
+++ b/src/shared/constants/timeRanges.ts
@@ -52,6 +52,15 @@ export const SELECTABLE_TIME_RANGES: SelectableDurationTimeRange[] = [
   pastFifteenMinTimeRange,
   pastHourTimeRange,
   {
+    seconds: 10800,
+    lower: 'now() - 3h',
+    upper: null,
+    label: 'Past 3h',
+    duration: '3h',
+    type: 'selectable-duration',
+    windowPeriod: 60000, // 1m
+  },
+  {
     seconds: 21600,
     lower: 'now() - 6h',
     upper: null,

--- a/src/types/queries.ts
+++ b/src/types/queries.ts
@@ -4,6 +4,7 @@ export type SelectableTimeRangeLower =
   | 'now() - 5m'
   | 'now() - 15m'
   | 'now() - 1h'
+  | 'now() - 3h'
   | 'now() - 6h'
   | 'now() - 12h'
   | 'now() - 24h'


### PR DESCRIPTION
Closes # N/A

I often find myself wanting to pick 3 hours for the view of my charts. 6 hours brings in more data than I want and often 1 hour is too little.

<!-- Describe your proposed changes here. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

