### PR TITLE
chore: remove most string references of defbuck and add wrapped aliases instead

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -12,7 +12,6 @@
   "env": {
     "username": "dev_user",
     "password": "CHECKMEOUTASUPERSECRETPASSWORD",
-    "org": "InfluxData",
-    "bucket": "defbuck"
+    "org": "InfluxData"
   }
 }

--- a/cypress/e2e/cloud/buckets.test.ts
+++ b/cypress/e2e/cloud/buckets.test.ts
@@ -79,9 +79,12 @@ describe('Buckets', () => {
 
     // filter a bucket
     cy.getByTestID('search-widget').type('def')
-    cy.get('.cf-resource-card')
-      .should('have.length', 1)
-      .should('contain', 'defbuck')
+
+    cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
+      cy.get('.cf-resource-card')
+        .should('have.length', 1)
+        .should('contain', defaultBucket)
+    })
 
     // clear filter and assert all buckets are visible
     cy.getByTestID('search-widget').clear()

--- a/cypress/e2e/oss/onboarding.test.ts
+++ b/cypress/e2e/oss/onboarding.test.ts
@@ -79,7 +79,9 @@ describe('Onboarding', () => {
     cy.getByTestID('input-field--password').type(Cypress.env('password'))
     cy.getByTestID('input-field--password-chk').type(Cypress.env('password'))
     cy.getByTestID('input-field--orgname').type(Cypress.env('org'))
-    cy.getByTestID('input-field--bucketname').type(Cypress.env('bucket'))
+    cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
+      cy.getByTestID('input-field--bucketname').type(defaultBucket)
+    })
 
     cy.getByTestID('next')
       .children('.cf-button--label')
@@ -128,7 +130,9 @@ describe('Onboarding', () => {
     cy.getByTestID('input-field--password').type(Cypress.env('password'))
     cy.getByTestID('input-field--password-chk').type(Cypress.env('password'))
     cy.getByTestID('input-field--orgname').type(Cypress.env('org'))
-    cy.getByTestID('input-field--bucketname').type(Cypress.env('bucket'))
+    cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
+      cy.getByTestID('input-field--bucketname').type(defaultBucket)
+    })
 
     cy.getByTestID('next').click()
 
@@ -165,7 +169,10 @@ describe('Onboarding', () => {
     cy.getByTestID('input-field--password').type(Cypress.env('password'))
     cy.getByTestID('input-field--password-chk').type(Cypress.env('password'))
     cy.getByTestID('input-field--orgname').type(Cypress.env('org'))
-    cy.getByTestID('input-field--bucketname').type(Cypress.env('bucket'))
+
+    cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
+      cy.getByTestID('input-field--bucketname').type(defaultBucket)
+    })
 
     cy.getByTestID('next').click()
 
@@ -227,93 +234,95 @@ describe('Onboarding', () => {
       .contains('Continue')
 
     cy.getByTestID('input-field--orgname').type(Cypress.env('org'))
-    cy.getByTestID('input-field--bucketname').type(Cypress.env('bucket'))
+    cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
+      cy.getByTestID('input-field--bucketname').type(defaultBucket)
 
-    cy.getByTestID('next')
-      .should('be.disabled')
-      .children('.cf-button--label')
-      .contains('Continue')
+      cy.getByTestID('next')
+          .should('be.disabled')
+          .children('.cf-button--label')
+          .contains('Continue')
 
-    cy.getByTestID('input-field--password')
-      .clear()
-      .type(Cypress.env('password'))
+      cy.getByTestID('input-field--password')
+          .clear()
+          .type(Cypress.env('password'))
 
-    cy.getByTestID('input-field--password-chk')
-      .clear()
-      .type(Cypress.env('password'))
+      cy.getByTestID('input-field--password-chk')
+          .clear()
+          .type(Cypress.env('password'))
 
-    cy.getByTestID('input-error').should('not.exist')
+      cy.getByTestID('input-error').should('not.exist')
 
-    cy.getByTestID('next')
-      .should('be.enabled')
-      .children('.cf-button--label')
-      .contains('Continue')
+      cy.getByTestID('next')
+          .should('be.enabled')
+          .children('.cf-button--label')
+          .contains('Continue')
 
-    // check cleared username
-    cy.getByTestID('input-field--username').clear()
+      // check cleared username
+      cy.getByTestID('input-field--username').clear()
 
-    cy.getByTestID('next')
-      .should('be.disabled')
-      .children('.cf-button--label')
-      .contains('Continue')
+      cy.getByTestID('next')
+          .should('be.disabled')
+          .children('.cf-button--label')
+          .contains('Continue')
 
-    cy.getByTestID('input-field--username').type(Cypress.env('username'))
+      cy.getByTestID('input-field--username').type(Cypress.env('username'))
 
-    cy.getByTestID('next')
-      .should('be.enabled')
-      .children('.cf-button--label')
-      .contains('Continue')
+      cy.getByTestID('next')
+          .should('be.enabled')
+          .children('.cf-button--label')
+          .contains('Continue')
 
-    // check cleared password
-    cy.getByTestID('input-field--password').clear()
+      // check cleared password
+      cy.getByTestID('input-field--password').clear()
 
-    cy.getByTestID('form--element-error').should(
-      'have.text',
-      'Passwords do not match'
-    )
+      cy.getByTestID('form--element-error').should(
+          'have.text',
+          'Passwords do not match'
+      )
 
-    cy.getByTestID('next')
-      .should('be.disabled')
-      .children('.cf-button--label')
-      .contains('Continue')
+      cy.getByTestID('next')
+          .should('be.disabled')
+          .children('.cf-button--label')
+          .contains('Continue')
 
-    cy.getByTestID('input-field--password')
-      .clear()
-      .type(Cypress.env('password'))
+      cy.getByTestID('input-field--password')
+          .clear()
+          .type(Cypress.env('password'))
 
-    cy.getByTestID('input-field--password-chk')
-      .clear()
-      .type(Cypress.env('password'))
+      cy.getByTestID('input-field--password-chk')
+          .clear()
+          .type(Cypress.env('password'))
 
-    cy.getByTestID('next')
-      .should('be.enabled')
-      .children('.cf-button--label')
-      .contains('Continue')
+      cy.getByTestID('next')
+          .should('be.enabled')
+          .children('.cf-button--label')
+          .contains('Continue')
 
-    // check cleared org name
-    cy.getByTestID('input-field--orgname').clear()
+      // check cleared org name
+      cy.getByTestID('input-field--orgname').clear()
 
-    cy.getByTestID('next')
-      .should('be.disabled')
-      .children('.cf-button--label')
-      .contains('Continue')
+      cy.getByTestID('next')
+          .should('be.disabled')
+          .children('.cf-button--label')
+          .contains('Continue')
 
-    cy.getByTestID('input-field--orgname').type(Cypress.env('org'))
+      cy.getByTestID('input-field--orgname').type(Cypress.env('org'))
 
-    cy.getByTestID('next')
-      .should('be.enabled')
-      .children('.cf-button--label')
-      .contains('Continue')
+      cy.getByTestID('next')
+          .should('be.enabled')
+          .children('.cf-button--label')
+          .contains('Continue')
 
-    // check cleared bucket name
-    cy.getByTestID('input-field--bucketname').clear()
+      // check cleared bucket name
+      cy.getByTestID('input-field--bucketname').clear()
 
-    cy.getByTestID('next')
-      .should('be.disabled')
-      .children('.cf-button--label')
-      .contains('Continue')
+      cy.getByTestID('next')
+          .should('be.disabled')
+          .children('.cf-button--label')
+          .contains('Continue')
 
-    cy.getByTestID('input-field--bucketname').type(Cypress.env('bucket'))
+      cy.getByTestID('input-field--bucketname').type(defaultBucket)
+    })
 
     cy.getByTestID('next')
       .should('be.enabled')

--- a/cypress/e2e/shared/buckets.test.ts
+++ b/cypress/e2e/shared/buckets.test.ts
@@ -155,16 +155,18 @@ describe('Buckets', () => {
                   el.text((index, currentContent) => {
                     results[index] = currentContent
                   })
-                  const expectedOrder = [
-                    'ABC',
-                    'defbuck',
-                    'Funky Town',
-                    'Jimmy Mack',
-                    '_monitoring',
-                    '_tasks',
-                  ]
-                  // check the order
-                  expect(results).to.deep.equal(expectedOrder)
+                  cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
+                    const expectedOrder = [
+                      'ABC',
+                      defaultBucket,
+                      'Funky Town',
+                      'Jimmy Mack',
+                      '_monitoring',
+                      '_tasks',
+                    ]
+                    // check the order
+                    expect(results).to.deep.equal(expectedOrder)
+                  })
                 })
             })
         })
@@ -340,7 +342,9 @@ describe('Buckets', () => {
 
       // TODO replace this with proper health checks
       cy.wait(1000)
-      cy.getByTestID(`selector-list ${Cypress.env('bucket')}`).click()
+      cy.get<string>('@defaultBucketListSelector').then((defaultBucketListSelector: string) => {
+        cy.getByTestID(defaultBucketListSelector).click()
+      })
       // mymeasurement comes from fixtures/data.txt
       cy.getByTestID('selector-list mymeasurement').should('exist')
     })
@@ -353,7 +357,9 @@ describe('Buckets', () => {
         .click()
 
       // assert default bucket
-      cy.getByTestID('bucket-dropdown--button').should('contain', 'defbuck')
+      cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
+        cy.getByTestID('bucket-dropdown--button').should('contain', defaultBucket)
+      })
 
       // filter plugins and choose system
       cy.getByTestID('input-field')
@@ -398,7 +404,9 @@ describe('Buckets', () => {
         'contain',
         'This is a telegraf description'
       )
-      cy.getByTestID('bucket-name').should('contain', 'defbuck')
+      cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
+        cy.getByTestID('bucket-name').should('contain', defaultBucket)
+      })
     })
   })
 })

--- a/cypress/e2e/shared/checks.test.ts
+++ b/cypress/e2e/shared/checks.test.ts
@@ -38,256 +38,266 @@ describe('Checks', () => {
       .should('be.disabled')
       .and('not.contain', 'Group')
       .contains('Filter')
-    cy.getByTestID(`selector-list defbuck`)
-      .wait(1200)
-      .click()
+    cy.get<string>('@defaultBucketListSelector').then((defaultBucketListSelector: string) => {
+      cy.getByTestID(defaultBucketListSelector)
+          .wait(1200)
+          .click()
 
-    cy.log(
-      'Select measurement and field; assert checklist popover and save button'
-    )
-    cy.get('.query-checklist--popover').should('be.visible')
-    cy.getByTestID('save-cell--button').should('be.disabled')
-    cy.getByTestID(`selector-list ${measurement}`).click()
-    cy.getByTestID(`selector-list ${field}`).click()
-    cy.get('.query-checklist--popover').should('be.visible')
-    cy.getByTestID('save-cell--button').should('be.disabled')
-
-    cy.log('Assert "Window Period" placeholder')
-    cy.get('.duration-input').within(() => {
-      cy.getByTitle('This input is disabled').should('have.value', 'auto (1m)')
-    })
-
-    cy.log(
-      'Navigate to "Configure Check" tab; add threshold condition; assert checklist popover and save button'
-    )
-    cy.getByTestID('checkeo--header alerting-tab').click()
-    cy.getByTestID('add-threshold-condition-WARN').click()
-    cy.get('.query-checklist--popover').should('not.exist')
-    cy.getByTestID('save-cell--button').should('be.enabled')
-
-    cy.log(
-      'Change "Schedule Every" parameter and assert its change in "Window Period" placeholder'
-    )
-    cy.getByTestID('schedule-check')
-      .clear()
-      .type('135s')
-    cy.getByTestID('select-group--option').click()
-    cy.get('.duration-input').within(() => {
-      cy.getByTitle('This input is disabled').should(
-        'have.value',
-        'auto (135s)'
+      cy.log(
+          'Select measurement and field; assert checklist popover and save button'
       )
-    })
+      cy.get('.query-checklist--popover').should('be.visible')
+      cy.getByTestID('save-cell--button').should('be.disabled')
+      cy.getByTestID(`selector-list ${measurement}`).click()
+      cy.getByTestID(`selector-list ${field}`).click()
+      cy.get('.query-checklist--popover').should('be.visible')
+      cy.getByTestID('save-cell--button').should('be.disabled')
 
-    cy.log('Name the check; save')
-    cy.getByTestID('overlay--container').within(() => {
-      cy.getByTestID('page-title')
-        .contains('Name this Check')
-        .click()
-      cy.getByTestID('renamable-page-title--input')
-        .clear()
-        .type('Threshold check test{enter}')
-    })
-    cy.getByTestID('save-cell--button').click()
+      cy.log('Assert "Window Period" placeholder')
+      cy.get('.duration-input').within(() => {
+        cy.getByTitle('This input is disabled').should('have.value', 'auto (1m)')
+      })
 
-    cy.log('Assert the check card')
-    cy.getByTestID('check-card--name')
-      .contains('Threshold check test')
-      .should('exist')
+      cy.log(
+          'Navigate to "Configure Check" tab; add threshold condition; assert checklist popover and save button'
+      )
+      cy.getByTestID('checkeo--header alerting-tab').click()
+      cy.getByTestID('add-threshold-condition-WARN').click()
+      cy.get('.query-checklist--popover').should('not.exist')
+      cy.getByTestID('save-cell--button').should('be.enabled')
+
+      cy.log(
+          'Change "Schedule Every" parameter and assert its change in "Window Period" placeholder'
+      )
+      cy.getByTestID('schedule-check')
+          .clear()
+          .type('135s')
+      cy.getByTestID('select-group--option').click()
+      cy.get('.duration-input').within(() => {
+        cy.getByTitle('This input is disabled').should(
+            'have.value',
+            'auto (135s)'
+        )
+      })
+
+      cy.log('Name the check; save')
+      cy.getByTestID('overlay--container').within(() => {
+        cy.getByTestID('page-title')
+            .contains('Name this Check')
+            .click()
+        cy.getByTestID('renamable-page-title--input')
+            .clear()
+            .type('Threshold check test{enter}')
+      })
+      cy.getByTestID('save-cell--button').click()
+
+      cy.log('Assert the check card')
+      cy.getByTestID('check-card--name')
+          .contains('Threshold check test')
+          .should('exist')
+    })
   })
 
   // TODO(watts): resolve flakeyness caused by detached elements with: https://github.com/influxdata/ui/pull/515
   it.skip('can create and filter checks', () => {
-    cy.log('create first check')
-    cy.getByTestID('create-check').click()
-    cy.getByTestID('create-deadman-check').click()
+    cy.get<string>('@defaultBucketListSelector').then((defaultBucketListSelector: string) => {
+      cy.log('create first check')
+      cy.getByTestID('create-check').click()
+      cy.getByTestID('create-deadman-check').click()
 
-    cy.log('select measurement and field')
-    cy.intercept('POST', '/query', req => {
-      if (req.body.query.includes('_measurement')) {
-        req.alias = 'measurementQuery'
-      }
+      cy.log('select measurement and field')
+      cy.intercept('POST', '/query', req => {
+        if (req.body.query.includes('_measurement')) {
+          req.alias = 'measurementQuery'
+        }
+      })
+      cy.intercept('POST', '/query', req => {
+        if (req.body.query.includes('distinct(column: "_field")')) {
+          req.alias = 'fieldQuery'
+        }
+      })
+
+      cy.getByTestID(defaultBucketListSelector).click()
+      cy.wait('@measurementQuery')
+      cy.getByTestID(`selector-list ${measurement}`).should('be.visible')
+      cy.getByTestID(`selector-list ${measurement}`).click()
+      cy.wait('@fieldQuery')
+      cy.getByTestID(`selector-list ${field}`).should('be.visible')
+      cy.getByTestID(`selector-list ${field}`).click()
+
+      cy.log('name the check; save')
+      cy.getByTestID('overlay').within(() => {
+        cy.getByTestID('page-title')
+            .contains('Name this Check')
+            .click()
+        cy.getByTestID('renamable-page-title--input')
+            .clear()
+            .type('Alpha{enter}')
+      })
+      cy.getByTestID('save-cell--button').click()
+
+      cy.getByTestID('overlay').should('not.exist')
+      // bust the /query cache
+      cy.reload()
+      cy.intercept('POST', '/query', req => {
+        if (req.body.query.includes('_measurement')) {
+          req.alias = 'measurementQueryBeta'
+        }
+      })
+      cy.intercept('POST', '/query', req => {
+        if (req.body.query.includes('distinct(column: "_field")')) {
+          req.alias = 'fieldQueryBeta'
+        }
+      })
+
+      cy.log('create second check')
+      cy.getByTestID('create-check').click()
+      cy.getByTestID('create-deadman-check').click()
+
+      cy.log('select measurement and field')
+      cy.getByTestID(defaultBucketListSelector).should('be.visible')
+      cy.getByTestID(defaultBucketListSelector).click()
+      cy.wait('@measurementQueryBeta')
+      cy.getByTestID(`selector-list ${measurement}`).should('be.visible')
+      cy.getByTestID(`selector-list ${measurement}`).click()
+      cy.wait('@fieldQueryBeta')
+      cy.getByTestID(`selector-list ${field}`).should('be.visible')
+      cy.getByTestID(`selector-list ${field}`).click()
+
+      cy.log('name the check; save')
+      cy.getByTestID('overlay').within(() => {
+        cy.getByTestID('page-title')
+            .contains('Name this Check')
+            .click()
+        cy.getByTestID('renamable-page-title--input')
+            .clear()
+            .type('Beta{enter}')
+      })
+      cy.getByTestID('save-cell--button').click()
+
+      cy.log('assert the number of check cards')
+      cy.getByTestID('check-card').should('have.length', 2)
+
+      cy.log('filter checks')
+      cy.getByTestID('filter--input checks').type('Al')
+      cy.getByTestID('check-card--name')
+          .contains('Alpha')
+          .should('be.visible')
+      cy.getByTestID('check-card').should('have.length', 1)
+
+      cy.log('clear filter and assert the number of check cards again')
+      cy.getByTestID('filter--input checks').clear()
+      cy.getByTestID('check-card').should('have.length', 2)
     })
-    cy.intercept('POST', '/query', req => {
-      if (req.body.query.includes('distinct(column: "_field")')) {
-        req.alias = 'fieldQuery'
-      }
-    })
-    cy.getByTestID(`selector-list defbuck`).click()
-    cy.wait('@measurementQuery')
-    cy.getByTestID(`selector-list ${measurement}`).should('be.visible')
-    cy.getByTestID(`selector-list ${measurement}`).click()
-    cy.wait('@fieldQuery')
-    cy.getByTestID(`selector-list ${field}`).should('be.visible')
-    cy.getByTestID(`selector-list ${field}`).click()
-
-    cy.log('name the check; save')
-    cy.getByTestID('overlay').within(() => {
-      cy.getByTestID('page-title')
-        .contains('Name this Check')
-        .click()
-      cy.getByTestID('renamable-page-title--input')
-        .clear()
-        .type('Alpha{enter}')
-    })
-    cy.getByTestID('save-cell--button').click()
-
-    cy.getByTestID('overlay').should('not.exist')
-    // bust the /query cache
-    cy.reload()
-    cy.intercept('POST', '/query', req => {
-      if (req.body.query.includes('_measurement')) {
-        req.alias = 'measurementQueryBeta'
-      }
-    })
-    cy.intercept('POST', '/query', req => {
-      if (req.body.query.includes('distinct(column: "_field")')) {
-        req.alias = 'fieldQueryBeta'
-      }
-    })
-
-    cy.log('create second check')
-    cy.getByTestID('create-check').click()
-    cy.getByTestID('create-deadman-check').click()
-
-    cy.log('select measurement and field')
-    cy.getByTestID(`selector-list defbuck`).should('be.visible')
-    cy.getByTestID(`selector-list defbuck`).click()
-    cy.wait('@measurementQueryBeta')
-    cy.getByTestID(`selector-list ${measurement}`).should('be.visible')
-    cy.getByTestID(`selector-list ${measurement}`).click()
-    cy.wait('@fieldQueryBeta')
-    cy.getByTestID(`selector-list ${field}`).should('be.visible')
-    cy.getByTestID(`selector-list ${field}`).click()
-
-    cy.log('name the check; save')
-    cy.getByTestID('overlay').within(() => {
-      cy.getByTestID('page-title')
-        .contains('Name this Check')
-        .click()
-      cy.getByTestID('renamable-page-title--input')
-        .clear()
-        .type('Beta{enter}')
-    })
-    cy.getByTestID('save-cell--button').click()
-
-    cy.log('assert the number of check cards')
-    cy.getByTestID('check-card').should('have.length', 2)
-
-    cy.log('filter checks')
-    cy.getByTestID('filter--input checks').type('Al')
-    cy.getByTestID('check-card--name')
-      .contains('Alpha')
-      .should('be.visible')
-    cy.getByTestID('check-card').should('have.length', 1)
-
-    cy.log('clear filter and assert the number of check cards again')
-    cy.getByTestID('filter--input checks').clear()
-    cy.getByTestID('check-card').should('have.length', 2)
   })
 
   it('can validate a deadman check', () => {
-    // create deadman check
-    cy.getByTestID('create-check').click()
-    cy.getByTestID('create-deadman-check').click()
+    cy.get<string>('@defaultBucketListSelector').then((defaultBucketListSelector: string) => {
+      // create deadman check
+      cy.getByTestID('create-check').click()
+      cy.getByTestID('create-deadman-check').click()
 
-    // checklist popover and save button check
-    cy.get('.query-checklist--popover').should('be.visible')
-    cy.getByTestID('save-cell--button').should('be.disabled')
+      // checklist popover and save button check
+      cy.get('.query-checklist--popover').should('be.visible')
+      cy.getByTestID('save-cell--button').should('be.disabled')
 
-    // select measurement and field - checklist popover should disappear, save button should activate
-    cy.getByTestID(`selector-list defbuck`).click()
-    cy.getByTestID(`selector-list ${measurement}`).click()
-    cy.getByTestID('save-cell--button').should('be.disabled')
-    cy.getByTestID(`selector-list ${field}`).click()
-    cy.get('.query-checklist--popover').should('not.exist')
-    cy.getByTestID('save-cell--button').should('be.enabled')
+      // select measurement and field - checklist popover should disappear, save button should activate
+      cy.getByTestID(defaultBucketListSelector).click()
+      cy.getByTestID(`selector-list ${measurement}`).click()
+      cy.getByTestID('save-cell--button').should('be.disabled')
+      cy.getByTestID(`selector-list ${field}`).click()
+      cy.get('.query-checklist--popover').should('not.exist')
+      cy.getByTestID('save-cell--button').should('be.enabled')
 
-    // submit the graph
-    cy.getByTestID('empty-graph--no-queries')
-    cy.getByTestID('time-machine-submit-button').click()
-    cy.getByTestID('giraffe-axes').should('exist')
+      // submit the graph
+      cy.getByTestID('empty-graph--no-queries')
+      cy.getByTestID('time-machine-submit-button').click()
+      cy.getByTestID('giraffe-axes').should('exist')
 
-    // navigate to configure check tab
-    cy.getByTestID('checkeo--header alerting-tab').click()
+      // navigate to configure check tab
+      cy.getByTestID('checkeo--header alerting-tab').click()
 
-    // conditions inputs check
-    cy.getByTestID('builder-conditions')
-      .should('contain', 'Deadman')
-      .within(() => {
-        cy.getByTestID('duration-input')
-          .first()
-          .click()
-        cy.get('.duration-input--menu').should('exist')
-        cy.getByTestID('duration-input')
-          .first()
-          .clear()
-          .type('60s')
-
-        cy.getByTestID('builder-card--header').click()
-        cy.get('.duration-input--menu').should('not.exist')
-
-        cy.getByTestID('duration-input')
-          .last()
-          .click()
-        cy.get('.duration-input--menu').should('exist')
-        cy.getByTestID('duration-input')
-          .last()
-          .clear()
-          .type('660s')
-        cy.getByTestID('builder-card--header').click()
-        cy.get('.duration-input--menu').should('not.exist')
-
-        cy.getByTestID('check-levels--dropdown--button').click()
-        cy.getByTestID('dropdown-menu')
-          .should('be.visible')
+      // conditions inputs check
+      cy.getByTestID('builder-conditions')
+          .should('contain', 'Deadman')
           .within(() => {
-            cy.getByTestID('check-levels--dropdown-item OK').click()
+            cy.getByTestID('duration-input')
+                .first()
+                .click()
+            cy.get('.duration-input--menu').should('exist')
+            cy.getByTestID('duration-input')
+                .first()
+                .clear()
+                .type('60s')
+
+            cy.getByTestID('builder-card--header').click()
+            cy.get('.duration-input--menu').should('not.exist')
+
+            cy.getByTestID('duration-input')
+                .last()
+                .click()
+            cy.get('.duration-input--menu').should('exist')
+            cy.getByTestID('duration-input')
+                .last()
+                .clear()
+                .type('660s')
+            cy.getByTestID('builder-card--header').click()
+            cy.get('.duration-input--menu').should('not.exist')
+
+            cy.getByTestID('check-levels--dropdown--button').click()
+            cy.getByTestID('dropdown-menu')
+                .should('be.visible')
+                .within(() => {
+                  cy.getByTestID('check-levels--dropdown-item OK').click()
+                })
+            cy.get('.color-dropdown--name').should('have.text', 'OK')
           })
-        cy.get('.color-dropdown--name').should('have.text', 'OK')
+
+      // name the check; save
+      cy.getByTestID('overlay').within(() => {
+        cy.getByTestID('page-title')
+            .contains('Name this Check')
+            .click()
+        cy.getByTestID('renamable-page-title--input')
+            .clear()
+            .type('Deadman check test{enter}')
       })
 
-    // name the check; save
-    cy.getByTestID('overlay').within(() => {
-      cy.getByTestID('page-title')
-        .contains('Name this Check')
-        .click()
-      cy.getByTestID('renamable-page-title--input')
-        .clear()
-        .type('Deadman check test{enter}')
+      cy.getByTestID('save-cell--button').click()
+
+      // assert the check card
+      cy.getByTestID('check-card--name')
+          .contains('Deadman check test')
+          .should('exist')
     })
-
-    cy.getByTestID('save-cell--button').click()
-
-    // assert the check card
-    cy.getByTestID('check-card--name')
-      .contains('Deadman check test')
-      .should('exist')
   })
 
   it('checks only allow numeric fields', () => {
-    // create deadman check
-    cy.getByTestID('create-check').click()
-    cy.getByTestID('create-deadman-check').click()
+    cy.get<string>('@defaultBucketListSelector').then((defaultBucketListSelector: string) => {
 
-    // checklist popover and save button check
-    cy.get('.query-checklist--popover').should('be.visible')
-    cy.getByTestID('save-cell--button').should('be.disabled')
+      // create deadman check
+      cy.getByTestID('create-check').click()
+      cy.getByTestID('create-deadman-check').click()
 
-    // select measurement and field - checklist popover should disappear, save button should activate
-    cy.getByTestID(`selector-list defbuck`).click()
-    cy.getByTestID(`selector-list ${measurement}`).click()
-    cy.getByTestID('save-cell--button').should('be.disabled')
-    cy.getByTestID(`selector-list ${stringField}`).click()
-    cy.get('.query-checklist--popover').should('not.exist')
-    cy.getByTestID('save-cell--button').should('be.enabled')
+      // checklist popover and save button check
+      cy.get('.query-checklist--popover').should('be.visible')
+      cy.getByTestID('save-cell--button').should('be.disabled')
 
-    // submit the graph
-    cy.getByTestID('empty-graph--no-queries')
-    cy.getByTestID('time-machine-submit-button').click()
+      // select measurement and field - checklist popover should disappear, save button should activate
+      cy.getByTestID(defaultBucketListSelector).click()
+      cy.getByTestID(`selector-list ${measurement}`).click()
+      cy.getByTestID('save-cell--button').should('be.disabled')
+      cy.getByTestID(`selector-list ${stringField}`).click()
+      cy.get('.query-checklist--popover').should('not.exist')
+      cy.getByTestID('save-cell--button').should('be.enabled')
 
-    // check for error message
-    cy.getByTestID('empty-graph--numeric').should('exist')
+      // submit the graph
+      cy.getByTestID('empty-graph--no-queries')
+      cy.getByTestID('time-machine-submit-button').click()
+
+      // check for error message
+      cy.getByTestID('empty-graph--numeric').should('exist')
+    })
   })
 
   describe('When a check does not exist', () => {
@@ -307,29 +317,31 @@ describe('Checks', () => {
 
   describe('Check should be viewable once created', () => {
     beforeEach(() => {
-      // creates a check before each iteration
-      // TODO: refactor into a request
-      cy.getByTestID('create-check').click()
-      cy.getByTestID('create-threshold-check').click()
-      cy.getByTestID(`selector-list defbuck`)
-        .wait(1200)
-        .click()
-      cy.getByTestID(`selector-list ${measurement}`).click()
-      cy.getByTestID('save-cell--button').should('be.disabled')
-      cy.getByTestID(`selector-list ${field}`).click()
-      cy.getByTestID('save-cell--button').should('be.disabled')
-      cy.getByTestID('checkeo--header alerting-tab').click()
-      cy.getByTestID('add-threshold-condition-WARN').click()
-      cy.getByTestID('input-field-WARN')
-        .clear()
-        .type('5s')
-      cy.getByTestID('add-threshold-condition-CRIT').click()
-      cy.getByTestID('input-field-CRIT')
-        .clear()
-        .type('0')
-      cy.getByTestID('save-cell--button').click()
-      cy.getByTestID('check-card').should('have.length', 1)
-      cy.getByTestID('notification-error').should('not.exist')
+      cy.get<string>('@defaultBucketListSelector').then((defaultBucketListSelector: string) => {
+        // creates a check before each iteration
+        // TODO: refactor into a request
+        cy.getByTestID('create-check').click()
+        cy.getByTestID('create-threshold-check').click()
+        cy.getByTestID(defaultBucketListSelector)
+            .wait(1200)
+            .click()
+        cy.getByTestID(`selector-list ${measurement}`).click()
+        cy.getByTestID('save-cell--button').should('be.disabled')
+        cy.getByTestID(`selector-list ${field}`).click()
+        cy.getByTestID('save-cell--button').should('be.disabled')
+        cy.getByTestID('checkeo--header alerting-tab').click()
+        cy.getByTestID('add-threshold-condition-WARN').click()
+        cy.getByTestID('input-field-WARN')
+            .clear()
+            .type('5s')
+        cy.getByTestID('add-threshold-condition-CRIT').click()
+        cy.getByTestID('input-field-CRIT')
+            .clear()
+            .type('0')
+        cy.getByTestID('save-cell--button').click()
+        cy.getByTestID('check-card').should('have.length', 1)
+        cy.getByTestID('notification-error').should('not.exist')
+      })
     })
 
     it('after check creation confirm history page has graph', () => {

--- a/cypress/e2e/shared/dashboardsView.test.ts
+++ b/cypress/e2e/shared/dashboardsView.test.ts
@@ -286,247 +286,247 @@ describe('Dashboard', () => {
       const mapTypeVarIndex = 2
       cy.get('@org').then(({id: orgID}: Organization) => {
         cy.get<Dashboard>('@dashboard').then(({dashboard}) => {
-          cy.createCSVVariable(orgID, bucketVarName, [
-            bucketOne,
-            Cypress.env('bucket'),
-            bucketThree,
-          ])
+          cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
+            cy.createCSVVariable(orgID, bucketVarName, [
+              bucketOne,
+              defaultBucket,
+              bucketThree,
+            ])
 
-          cy.createQueryVariable(orgID)
-          cy.createMapVariable(orgID).then(() => {
-            cy.fixture('routes').then(({orgs}) => {
-              cy.visit(`${orgs}/${orgID}/dashboards/${dashboard.id}`)
-            })
-            // add cell with variable in its query
-            cy.getByTestID('add-cell--button').click()
-            cy.getByTestID('switch-to-script-editor').should('be.visible')
-            cy.getByTestID('switch-to-script-editor').click()
-            cy.getByTestID('toolbar-tab').click()
-
-            // check to see if the default timeRange variables are available
-            cy.get('.flux-toolbar--list-item').contains('timeRangeStart')
-            cy.get('.flux-toolbar--list-item').contains('timeRangeStop')
-
-            cy.getByTestID('flux-editor')
-              .should('be.visible')
-              .click()
-              .focused()
-              .type(' ')
-            cy.get('.flux-toolbar--list-item')
-              .eq(bucketVarIndex)
-              .within(() => {
-                cy.get('.cf-button').click()
+            cy.createQueryVariable(orgID)
+            cy.createMapVariable(orgID).then(() => {
+              cy.fixture('routes').then(({orgs}) => {
+                cy.visit(`${orgs}/${orgID}/dashboards/${dashboard.id}`)
               })
-            cy.getByTestID('save-cell--button').click()
+              // add cell with variable in its query
+              cy.getByTestID('add-cell--button').click()
+              cy.getByTestID('switch-to-script-editor').should('be.visible')
+              cy.getByTestID('switch-to-script-editor').click()
+              cy.getByTestID('toolbar-tab').click()
 
-            // TESTING CSV VARIABLE
-            // selected value in dashboard is 1st value
-            cy.getByTestID(`variable-dropdown--${bucketVarName}`).should(
-              'contain',
-              bucketOne
-            )
-            cy.window()
-              .pipe(getSelectedVariable(dashboard.id, 0))
-              .should('equal', bucketOne)
+              // check to see if the default timeRange variables are available
+              cy.get('.flux-toolbar--list-item').contains('timeRangeStart')
+              cy.get('.flux-toolbar--list-item').contains('timeRangeStop')
 
-            // testing variable controls
-            cy.getByTestID(`variable-dropdown--${bucketVarName}`).should(
-              'contain',
-              bucketOne
-            )
-            cy.getByTestID('variables--button').click()
-            cy.getByTestID(`variable-dropdown--${bucketVarName}`).should(
-              'not.exist'
-            )
-            cy.getByTestID('variables--button').click()
-            cy.getByTestID(`variable-dropdown--${bucketVarName}`).should(
-              'exist'
-            )
+              cy.getByTestID('flux-editor')
+                .should('be.visible')
+                .click()
+                .focused()
+                .type(' ')
+              cy.get('.flux-toolbar--list-item')
+                .eq(bucketVarIndex)
+                .within(() => {
+                  cy.get('.cf-button').click()
+                })
+              cy.getByTestID('save-cell--button').click()
 
-            // sanity check on the url before beginning
-            cy.location('search').should('eq', '?lower=now%28%29%20-%201h')
+              // TESTING CSV VARIABLE
+              // selected value in dashboard is 1st value
+              cy.getByTestID(`variable-dropdown--${bucketVarName}`).should(
+                'contain',
+                bucketOne
+              )
+              cy.window()
+                .pipe(getSelectedVariable(dashboard.id, 0))
+                .should('equal', bucketOne)
 
-            // select 3rd value in dashboard
-            cy.getByTestID('variable-dropdown--button')
-              .first()
-              .click()
-            cy.get(`#${bucketThree}`).click()
+              // testing variable controls
+              cy.getByTestID(`variable-dropdown--${bucketVarName}`).should(
+                'contain',
+                bucketOne
+              )
+              cy.getByTestID('variables--button').click()
+              cy.getByTestID(`variable-dropdown--${bucketVarName}`).should(
+                'not.exist'
+              )
+              cy.getByTestID('variables--button').click()
+              cy.getByTestID(`variable-dropdown--${bucketVarName}`).should(
+                'exist'
+              )
 
-            // selected value in dashboard is 3rd value
-            cy.getByTestID(`variable-dropdown--${bucketVarName}`).should(
-              'contain',
-              bucketThree
-            )
-            cy.window()
-              .pipe(getSelectedVariable(dashboard.id, 0))
-              .should('equal', bucketThree)
+              // sanity check on the url before beginning
+              cy.location('search').should('eq', '?lower=now%28%29%20-%201h')
 
-            // and that it updates the variable in the URL
-            cy.location('search').should(
-              'eq',
-              `?lower=now%28%29%20-%201h&vars%5BbucketsCSV%5D=${bucketThree}`
-            )
-
-            // select 2nd value in dashboard
-            cy.getByTestID('variable-dropdown--button')
-              .first()
-              .click()
-            cy.get(`#${Cypress.env('bucket')}`).click()
-
-            // and that it updates the variable in the URL without breaking stuff
-            cy.location('search').should(
-              'eq',
-              `?lower=now%28%29%20-%201h&vars%5BbucketsCSV%5D=${Cypress.env(
-                'bucket'
-              )}`
-            )
-
-            // open VEO
-            cy.getByTestID('cell-context--toggle').click()
-            cy.getByTestID('cell-context--configure').click()
-
-            // selected value in cell context is 2nd value
-            cy.window()
-              .pipe(getSelectedVariable(dashboard.id, 0))
-              .should('equal', Cypress.env('bucket'))
-
-            cy.getByTestID('toolbar-tab').click()
-            cy.get('.flux-toolbar--list-item')
-              .first()
-              .trigger('mouseover')
-            // toggle the variable dropdown in the VEO cell dashboard
-            cy.getByTestID('toolbar-popover--contents').within(() => {
-              cy.getByTestID('variable-dropdown--button').click()
-              // select 1st value in cell
-              cy.getByTestID('variable-dropdown--item')
+              // select 3rd value in dashboard
+              cy.getByTestID('variable-dropdown--button')
                 .first()
                 .click()
-            })
-            // injecting mapTypeVar into query
-            cy.get('.flux-toolbar--list-item')
-              .eq(mapTypeVarIndex)
-              .within(() => {
-                cy.get('.cf-button').click()
-              })
-            // save cell
-            cy.getByTestID('save-cell--button').click()
+              cy.get(`#${bucketThree}`).click()
 
-            // selected value in cell context is 1st value
-            cy.window()
-              .pipe(getSelectedVariable(dashboard.id, 0))
-              .should('equal', bucketOne)
+              // selected value in dashboard is 3rd value
+              cy.getByTestID(`variable-dropdown--${bucketVarName}`).should(
+                'contain',
+                bucketThree
+              )
+              cy.window()
+                .pipe(getSelectedVariable(dashboard.id, 0))
+                .should('equal', bucketThree)
 
-            // selected value in dashboard is 1st value
-            cy.getByTestID(`variable-dropdown--${bucketVarName}`).should(
-              'contain',
-              bucketOne
-            )
-            cy.window()
-              .pipe(getSelectedVariable(dashboard.id, 0))
-              .should('equal', bucketOne)
+              // and that it updates the variable in the URL
+              cy.location('search').should(
+                'eq',
+                `?lower=now%28%29%20-%201h&vars%5BbucketsCSV%5D=${bucketThree}`
+              )
 
-            // TESTING MAP VARIABLE
-            // selected value in dashboard is 1st value
-            cy.getByTestID(`variable-dropdown--${mapTypeVarName}`).should(
-              'contain',
-              'k1'
-            )
-            cy.window()
-              .pipe(getSelectedVariable(dashboard.id, 2))
-              .should('equal', 'v1')
-
-            // select 2nd value in dashboard
-            cy.getByTestID('variable-dropdown--button')
-              .eq(1)
-              .click()
-            cy.get(`#k2`).click()
-
-            // selected value in dashboard is 2nd value
-            cy.getByTestID(`variable-dropdown--${mapTypeVarName}`).should(
-              'contain',
-              'k2'
-            )
-            cy.window()
-              .pipe(getSelectedVariable(dashboard.id, 2))
-              .should('equal', 'v2')
-
-            // open VEO
-            cy.getByTestID('cell-context--toggle').click()
-            cy.getByTestID('cell-context--configure').click()
-            cy.getByTestID('toolbar-tab').should('be.visible')
-
-            // selected value in cell context is 2nd value
-            cy.window()
-              .pipe(getSelectedVariable(dashboard.id, 2))
-              .should('equal', 'v2')
-
-            cy.getByTestID('toolbar-tab').click()
-            cy.get('.flux-toolbar--list-item')
-              .eq(2)
-              .trigger('mouseover')
-            // toggle the variable dropdown in the VEO cell dashboard
-            cy.getByTestID('toolbar-popover--contents').within(() => {
-              cy.getByTestID('variable-dropdown--button').click()
-              // select 1st value in cell
-              cy.getByTestID('variable-dropdown--item')
+              // select 2nd value in dashboard
+              cy.getByTestID('variable-dropdown--button')
                 .first()
                 .click()
-            })
-            // save cell
-            cy.getByTestID('save-cell--button').click()
+              cy.get(`#${defaultBucket}`).click()
 
-            // selected value in cell context is 1st value
-            cy.window()
-              .pipe(getSelectedVariable(dashboard.id, 2))
-              .should('equal', 'v1')
+              // and that it updates the variable in the URL without breaking stuff
+              cy.location('search').should(
+                'eq',
+                `?lower=now%28%29%20-%201h&vars%5BbucketsCSV%5D=${defaultBucket}`
+              )
 
-            // selected value in dashboard is 1st value
-            cy.getByTestID(`variable-dropdown--${mapTypeVarName}`).should(
-              'contain',
-              'k1'
-            )
-            cy.window()
-              .pipe(getSelectedVariable(dashboard.id, 2))
-              .should('equal', 'v1')
+              // open VEO
+              cy.getByTestID('cell-context--toggle').click()
+              cy.getByTestID('cell-context--configure').click()
 
-            cy.getByTestID('cell-context--toggle').click()
-            cy.getByTestID('cell-context--delete').click()
-            cy.getByTestID('cell-context--delete-confirm').click()
+              // selected value in cell context is 2nd value
+              cy.window()
+                .pipe(getSelectedVariable(dashboard.id, 0))
+                .should('equal', defaultBucket)
 
-            // create a new cell
-            cy.getByTestID('add-cell--button').click()
-            cy.getByTestID('switch-to-script-editor').should('be.visible')
-            cy.getByTestID('switch-to-script-editor').click()
+              cy.getByTestID('toolbar-tab').click()
+              cy.get('.flux-toolbar--list-item')
+                .first()
+                .trigger('mouseover')
+              // toggle the variable dropdown in the VEO cell dashboard
+              cy.getByTestID('toolbar-popover--contents').within(() => {
+                cy.getByTestID('variable-dropdown--button').click()
+                // select 1st value in cell
+                cy.getByTestID('variable-dropdown--item')
+                  .first()
+                  .click()
+              })
+              // injecting mapTypeVar into query
+              cy.get('.flux-toolbar--list-item')
+                .eq(mapTypeVarIndex)
+                .within(() => {
+                  cy.get('.cf-button').click()
+                })
+              // save cell
+              cy.getByTestID('save-cell--button').click()
 
-            // query for data
-            cy.getByTestID('flux-editor')
-              .should('be.visible')
-              .click()
-              .focused()
-              .clear()
-              .type(
-                `from(bucket: v.bucketsCSV)
+              // selected value in cell context is 1st value
+              cy.window()
+                .pipe(getSelectedVariable(dashboard.id, 0))
+                .should('equal', bucketOne)
+
+              // selected value in dashboard is 1st value
+              cy.getByTestID(`variable-dropdown--${bucketVarName}`).should(
+                'contain',
+                bucketOne
+              )
+              cy.window()
+                .pipe(getSelectedVariable(dashboard.id, 0))
+                .should('equal', bucketOne)
+
+              // TESTING MAP VARIABLE
+              // selected value in dashboard is 1st value
+              cy.getByTestID(`variable-dropdown--${mapTypeVarName}`).should(
+                'contain',
+                'k1'
+              )
+              cy.window()
+                .pipe(getSelectedVariable(dashboard.id, 2))
+                .should('equal', 'v1')
+
+              // select 2nd value in dashboard
+              cy.getByTestID('variable-dropdown--button')
+                .eq(1)
+                .click()
+              cy.get(`#k2`).click()
+
+              // selected value in dashboard is 2nd value
+              cy.getByTestID(`variable-dropdown--${mapTypeVarName}`).should(
+                'contain',
+                'k2'
+              )
+              cy.window()
+                .pipe(getSelectedVariable(dashboard.id, 2))
+                .should('equal', 'v2')
+
+              // open VEO
+              cy.getByTestID('cell-context--toggle').click()
+              cy.getByTestID('cell-context--configure').click()
+              cy.getByTestID('toolbar-tab').should('be.visible')
+
+              // selected value in cell context is 2nd value
+              cy.window()
+                .pipe(getSelectedVariable(dashboard.id, 2))
+                .should('equal', 'v2')
+
+              cy.getByTestID('toolbar-tab').click()
+              cy.get('.flux-toolbar--list-item')
+                .eq(2)
+                .trigger('mouseover')
+              // toggle the variable dropdown in the VEO cell dashboard
+              cy.getByTestID('toolbar-popover--contents').within(() => {
+                cy.getByTestID('variable-dropdown--button').click()
+                // select 1st value in cell
+                cy.getByTestID('variable-dropdown--item')
+                  .first()
+                  .click()
+              })
+              // save cell
+              cy.getByTestID('save-cell--button').click()
+
+              // selected value in cell context is 1st value
+              cy.window()
+                .pipe(getSelectedVariable(dashboard.id, 2))
+                .should('equal', 'v1')
+
+              // selected value in dashboard is 1st value
+              cy.getByTestID(`variable-dropdown--${mapTypeVarName}`).should(
+                'contain',
+                'k1'
+              )
+              cy.window()
+                .pipe(getSelectedVariable(dashboard.id, 2))
+                .should('equal', 'v1')
+
+              cy.getByTestID('cell-context--toggle').click()
+              cy.getByTestID('cell-context--delete').click()
+              cy.getByTestID('cell-context--delete-confirm').click()
+
+              // create a new cell
+              cy.getByTestID('add-cell--button').click()
+              cy.getByTestID('switch-to-script-editor').should('be.visible')
+              cy.getByTestID('switch-to-script-editor').click()
+
+              // query for data
+              cy.getByTestID('flux-editor')
+                .should('be.visible')
+                .click()
+                .focused()
+                .clear()
+                .type(
+                  `from(bucket: v.bucketsCSV)
 |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
 |> filter(fn: (r) => r["_measurement"] == "m")
 |> filter(fn: (r) => r["_field"] == "v")
 |> filter(fn: (r) => r["tk1"] == "tv1")
 |> aggregateWindow(every: v.windowPeriod, fn: max)
 |> yield(name: "max")`,
-                {force: true, delay: 1}
-              )
+                  {force: true, delay: 1}
+                )
 
-            // `bucketOne` should not exist nor have data written to it
-            cy.getByTestID('save-cell--button').click()
-            cy.getByTestID('empty-graph-error').contains(`${bucketOne}`)
+              // `bucketOne` should not exist nor have data written to it
+              cy.getByTestID('save-cell--button').click()
+              cy.getByTestID('empty-graph-error').contains(`${bucketOne}`)
 
-            // select bucket "defbuck" that has data
-            cy.getByTestID('variable-dropdown--button')
-              .eq(0)
-              .click()
-            cy.get(`#${Cypress.env('bucket')}`).click()
+              // select default bucket that has data
+              cy.getByTestID('variable-dropdown--button')
+                .eq(0)
+                .click()
+              cy.get(`#${defaultBucket}`).click()
 
-            // assert visualization appears
-            cy.getByTestID('giraffe-layer-line').should('exist')
+              // assert visualization appears
+              cy.getByTestID('giraffe-layer-line').should('exist')
+            })
           })
         })
       })
@@ -535,96 +535,98 @@ describe('Dashboard', () => {
     it('ensures that dependent variables load one another accordingly', () => {
       cy.get('@org').then(({id: orgID}: Organization) => {
         cy.createDashboard(orgID).then(({body: dashboard}) => {
-          const now = Date.now()
-          cy.writeData([
-            `test,container_name=cool dopeness=12 ${now - 1000}000000`,
-            `test,container_name=beans dopeness=18 ${now - 1200}000000`,
-            `test,container_name=cool dopeness=14 ${now - 1400}000000`,
-            `test,container_name=beans dopeness=10 ${now - 1600}000000`,
-          ])
-          cy.createCSVVariable(orgID, 'static', ['beans', 'defbuck'])
-          cy.createQueryVariable(
-            orgID,
-            'dependent',
-            `import "influxdata/influxdb/v1"
+          cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
+            const now = Date.now()
+            cy.writeData([
+              `test,container_name=cool dopeness=12 ${now - 1000}000000`,
+              `test,container_name=beans dopeness=18 ${now - 1200}000000`,
+              `test,container_name=cool dopeness=14 ${now - 1400}000000`,
+              `test,container_name=beans dopeness=10 ${now - 1600}000000`,
+            ])
+            cy.createCSVVariable(orgID, 'static', ['beans', defaultBucket])
+            cy.createQueryVariable(
+                orgID,
+                'dependent',
+                `import "influxdata/influxdb/v1"
             v1.tagValues(bucket: v.static, tag: "container_name") |> keep(columns: ["_value"])`
-          )
-          cy.createQueryVariable(
-            orgID,
-            'build',
-            `import "influxdata/influxdb/v1"
+            )
+            cy.createQueryVariable(
+                orgID,
+                'build',
+                `import "influxdata/influxdb/v1"
             import "strings"
             v1.tagValues(bucket: v.static, tag: "container_name") |> filter(fn: (r) => strings.hasSuffix(v: r._value, suffix: v.dependent))`
-          )
+            )
 
-          cy.fixture('routes').then(({orgs}) => {
-            cy.visit(`${orgs}/${orgID}/dashboards/${dashboard.id}`)
-          })
-        })
+            cy.fixture('routes').then(({orgs}) => {
+              cy.visit(`${orgs}/${orgID}/dashboards/${dashboard.id}`)
+            })
 
-        cy.getByTestID('add-cell--button').click()
-        cy.getByTestID('switch-to-script-editor').should('be.visible')
-        cy.getByTestID('switch-to-script-editor').click()
-        cy.getByTestID('toolbar-tab').click()
+          cy.getByTestID('add-cell--button').click()
+          cy.getByTestID('switch-to-script-editor').should('be.visible')
+          cy.getByTestID('switch-to-script-editor').click()
+          cy.getByTestID('toolbar-tab').click()
 
-        cy
-          .getByTestID('flux-editor')
-          .should('be.visible')
-          .click()
-          .focused().type(`from(bucket: v.static)
+          cy
+              .getByTestID('flux-editor')
+              .should('be.visible')
+              .click()
+              .focused().type(`from(bucket: v.static)
 |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
 |> filter(fn: (r) => r["_measurement"] == "test")
 |> filter(fn: (r) => r["_field"] == "dopeness")
 |> filter(fn: (r) => r["container_name"] == v.build)`)
 
-        cy.getByTestID('save-cell--button').click()
+          cy.getByTestID('save-cell--button').click()
 
-        // the default bucket selection should have no results and load all three variables
-        // even though only two variables are being used (because 1 is dependent upon another)
-        cy.getByTestID('variable-dropdown--static').should('contain', 'beans')
+          // the default bucket selection should have no results and load all three variables
+          // even though only two variables are being used (because 1 is dependent upon another)
+          cy.getByTestID('variable-dropdown--static').should('contain', 'beans')
 
-        // and cause the rest to exist in loading states
-        cy.getByTestIDSubStr('variable-dropdown--build').should(
-          'contain',
-          'Loading'
-        )
+          // and cause the rest to exist in loading states
+          cy.getByTestIDSubStr('variable-dropdown--build').should(
+              'contain',
+              'Loading'
+          )
 
-        cy.getByTestIDSubStr('cell--view-empty')
+          cy.getByTestIDSubStr('cell--view-empty')
 
-        // But selecting a nonempty bucket should load some data
-        cy.getByTestID('variable-dropdown--button')
-          .eq(0)
-          .click()
-        cy.get(`#defbuck`).click()
+          // But selecting a nonempty bucket should load some data
+          cy.getByTestID('variable-dropdown--button')
+              .eq(0)
+              .click()
+          cy.get(`#${defaultBucket}`).click()
 
-        // default select the first result
-        cy.getByTestIDSubStr('variable-dropdown--build').should(
-          'contain',
-          'beans'
-        )
+          // default select the first result
+          cy.getByTestIDSubStr('variable-dropdown--build').should(
+              'contain',
+              'beans'
+          )
 
-        // and also load the third result
-        cy.getByTestID('variable-dropdown--button')
-          .eq(2)
-          .should('contain', 'beans')
-          .click()
-        cy.get(`#cool`).click()
+          // and also load the third result
+          cy.getByTestID('variable-dropdown--button')
+              .eq(2)
+              .should('contain', 'beans')
+              .click()
+          cy.get(`#cool`).click()
 
-        // and also load the second result
-        cy.getByTestIDSubStr('variable-dropdown--dependent').should(
-          'contain',
-          'cool'
-        )
+          // and also load the second result
+          cy.getByTestIDSubStr('variable-dropdown--dependent').should(
+              'contain',
+              'cool'
+          )
 
-        // updating the third variable should update the second
-        cy.getByTestID('variable-dropdown--button')
-          .eq(2)
-          .click()
-        cy.get(`#beans`).click()
-        cy.getByTestIDSubStr('variable-dropdown--build').should(
-          'contain',
-          'beans'
-        )
+          // updating the third variable should update the second
+          cy.getByTestID('variable-dropdown--button')
+              .eq(2)
+              .click()
+          cy.get(`#beans`).click()
+          cy.getByTestIDSubStr('variable-dropdown--build').should(
+              'contain',
+              'beans'
+          )
+          })
+        })
       })
     })
 
@@ -661,75 +663,80 @@ describe('Dashboard', () => {
     it('can load dependent queries without much fuss', () => {
       cy.get('@org').then(({id: orgID}: Organization) => {
         cy.createDashboard(orgID).then(({body: dashboard}) => {
-          const now = Date.now()
-          cy.writeData([
-            `test,container_name=cool dopeness=12 ${now - 1000}000000`,
-            `test,container_name=beans dopeness=18 ${now - 1200}000000`,
-            `test,container_name=cool dopeness=14 ${now - 1400}000000`,
-            `test,container_name=beans dopeness=10 ${now - 1600}000000`,
-          ])
-          cy.createCSVVariable(orgID, 'static', ['beans', 'defbuck'])
-          cy.createQueryVariable(
-            orgID,
-            'dependent',
-            `from(bucket: v.static)
+          cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
+
+            const now = Date.now()
+            cy.writeData([
+              `test,container_name=cool dopeness=12 ${now - 1000}000000`,
+              `test,container_name=beans dopeness=18 ${now - 1200}000000`,
+              `test,container_name=cool dopeness=14 ${now - 1400}000000`,
+              `test,container_name=beans dopeness=10 ${now - 1600}000000`,
+            ])
+            cy.createCSVVariable(orgID, 'static', ['beans', defaultBucket])
+            cy.createQueryVariable(
+                orgID,
+                'dependent',
+                `from(bucket: v.static)
   |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
   |> filter(fn: (r) => r["_measurement"] == "test")
   |> keep(columns: ["container_name"])
   |> rename(columns: {"container_name": "_value"})
   |> last()
   |> group()`
-          )
+            )
 
-          cy.fixture('routes').then(({orgs}) => {
-            cy.visit(`${orgs}/${orgID}/dashboards/${dashboard.id}`)
+            cy.fixture('routes').then(({orgs}) => {
+              cy.visit(`${orgs}/${orgID}/dashboards/${dashboard.id}`)
+            })
           })
         })
       })
+      cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
 
-      cy.getByTestID('add-cell--button').click()
-      cy.getByTestID('switch-to-script-editor').should('be.visible')
-      cy.getByTestID('switch-to-script-editor').click()
-      cy.getByTestID('toolbar-tab').click()
+        cy.getByTestID('add-cell--button').click()
+        cy.getByTestID('switch-to-script-editor').should('be.visible')
+        cy.getByTestID('switch-to-script-editor').click()
+        cy.getByTestID('toolbar-tab').click()
 
-      cy
-        .getByTestID('flux-editor')
-        .should('be.visible')
-        .click()
-        .focused().type(`from(bucket: v.static)
+        cy
+            .getByTestID('flux-editor')
+            .should('be.visible')
+            .click()
+            .focused().type(`from(bucket: v.static)
 |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
 |> filter(fn: (r) => r["_measurement"] == "test")
 |> filter(fn: (r) => r["_field"] == "dopeness")
 |> filter(fn: (r) => r["container_name"] == v.dependent)`)
-      cy.getByTestID('save-cell--button').click()
+        cy.getByTestID('save-cell--button').click()
 
-      // the default bucket selection should have no results
-      cy.getByTestIDSubStr('variable-dropdown')
-        .eq(0)
-        .should('contain', 'beans')
+        // the default bucket selection should have no results
+        cy.getByTestIDSubStr('variable-dropdown')
+            .eq(0)
+            .should('contain', 'beans')
 
-      // and cause the rest to exist in loading states
-      cy.getByTestIDSubStr('variable-dropdown--dependent').should(
-        'contain',
-        'Loading'
-      )
+        // and cause the rest to exist in loading states
+        cy.getByTestIDSubStr('variable-dropdown--dependent').should(
+            'contain',
+            'Loading'
+        )
 
-      cy.getByTestIDSubStr('cell--view-empty')
+        cy.getByTestIDSubStr('cell--view-empty')
 
-      // But selecting a nonempty bucket should load some data
-      cy.getByTestID('variable-dropdown--button')
-        .eq(0)
-        .click()
-      cy.get(`#defbuck`).click()
+        // But selecting a nonempty bucket should load some data
+        cy.getByTestID('variable-dropdown--button')
+            .eq(0)
+            .click()
+        cy.get(`#${defaultBucket}`).click()
 
-      // default select the first result
-      cy.getByTestID('variable-dropdown--dependent').should('contain', 'beans')
+        // default select the first result
+        cy.getByTestID('variable-dropdown--dependent').should('contain', 'beans')
 
-      // and also load the second result
-      cy.getByTestID('variable-dropdown--button')
-        .eq(1)
-        .click()
-      cy.get(`#cool`).click()
+        // and also load the second result
+        cy.getByTestID('variable-dropdown--button')
+            .eq(1)
+            .click()
+        cy.get(`#cool`).click()
+      })
     })
   })
 

--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -583,9 +583,10 @@ describe('DataExplorer', () => {
       cy.get<Organization>('@org').then(({id, name}) => {
         cy.createBucket(id, name, 'newBucket')
       })
-
-      cy.getByTestID('selector-list defbuck').should('be.visible')
-      cy.getByTestID('selector-list newBucket').should('be.visible')
+      cy.get<string>('@defaultBucketListSelector').then((defaultBucketListSelector: string) => {
+        cy.getByTestID(defaultBucketListSelector).should('be.visible')
+        cy.getByTestID('selector-list newBucket').should('be.visible')
+      })
     })
 
     it('can delete a second query', () => {
@@ -665,103 +666,105 @@ describe('DataExplorer', () => {
       })
 
       it('can view time-series data', () => {
-        cy.log('can switch between editor modes')
-        cy.getByTestID('selector-list _monitoring').should('be.visible')
-        cy.getByTestID('selector-list _monitoring').click()
+        cy.get<string>('@defaultBucketListSelector').then((defaultBucketListSelector: string) => {
+          cy.log('can switch between editor modes')
+          cy.getByTestID('selector-list _monitoring').should('be.visible')
+          cy.getByTestID('selector-list _monitoring').click()
 
-        cy.getByTestID('selector-list defbuck').should('be.visible')
-        cy.getByTestID('selector-list defbuck').click()
+          cy.getByTestID(defaultBucketListSelector).should('be.visible')
+          cy.getByTestID(defaultBucketListSelector).click()
 
-        cy.getByTestID('selector-list m').should('be.visible')
-        cy.getByTestID('selector-list m').clickAttached()
+          cy.getByTestID('selector-list m').should('be.visible')
+          cy.getByTestID('selector-list m').clickAttached()
 
-        cy.getByTestID('selector-list v').should('be.visible')
-        cy.getByTestID('selector-list v').clickAttached()
+          cy.getByTestID('selector-list v').should('be.visible')
+          cy.getByTestID('selector-list v').clickAttached()
 
-        cy.getByTestID('switch-to-script-editor').click()
-        cy.getByTestID('flux-editor').should('be.visible')
+          cy.getByTestID('switch-to-script-editor').click()
+          cy.getByTestID('flux-editor').should('be.visible')
 
-        cy.log('revert back to query builder mode (without confirmation)')
-        cy.getByTestID('switch-to-query-builder').click()
-        cy.getByTestID('query-builder').should('be.visible')
+          cy.log('revert back to query builder mode (without confirmation)')
+          cy.getByTestID('switch-to-query-builder').click()
+          cy.getByTestID('query-builder').should('be.visible')
 
-        cy.log('can revert back to query builder mode (with confirmation)')
-        cy.getByTestID('switch-to-script-editor')
-          .should('be.visible')
-          .click()
-        cy.getByTestID('flux--aggregate.rate--inject').click()
+          cy.log('can revert back to query builder mode (with confirmation)')
+          cy.getByTestID('switch-to-script-editor')
+              .should('be.visible')
+              .click()
+          cy.getByTestID('flux--aggregate.rate--inject').click()
 
-        cy.log('check to see if import is defaulted to the top')
-        cy.get('.view-line')
-          .first()
-          .contains('import')
+          cy.log('check to see if import is defaulted to the top')
+          cy.get('.view-line')
+              .first()
+              .contains('import')
 
-        cy.log('check to see if new aggregate rate is at the bottom')
-        cy.get('.view-line')
-          .last()
-          .contains('aggregate.')
-        cy.getByTestID('flux-editor').should('exist')
-        cy.getByTestID('flux-editor').within(() => {
-          cy.get('textarea').type('yoyoyoyoyo', {force: true})
-        })
+          cy.log('check to see if new aggregate rate is at the bottom')
+          cy.get('.view-line')
+              .last()
+              .contains('aggregate.')
+          cy.getByTestID('flux-editor').should('exist')
+          cy.getByTestID('flux-editor').within(() => {
+            cy.get('textarea').type('yoyoyoyoyo', {force: true})
+          })
 
-        cy.log('can over over flux functions')
-        cy.getByTestID('flux-docs--aggregateWindow').should('not.exist')
-        cy.getByTestID('flux--aggregateWindow').trigger('mouseover')
-        cy.getByTestID('flux-docs--aggregateWindow').should('exist')
+          cy.log('can over over flux functions')
+          cy.getByTestID('flux-docs--aggregateWindow').should('not.exist')
+          cy.getByTestID('flux--aggregateWindow').trigger('mouseover')
+          cy.getByTestID('flux-docs--aggregateWindow').should('exist')
 
-        cy.getByTestID('switch-query-builder-confirm--button').click()
+          cy.getByTestID('switch-query-builder-confirm--button').click()
 
-        cy.getByTestID(
-          'switch-query-builder-confirm--popover--contents'
-        ).within(() => {
-          cy.getByTestID('switch-query-builder-confirm--confirm-button').click()
-        })
+          cy.getByTestID(
+              'switch-query-builder-confirm--popover--contents'
+          ).within(() => {
+            cy.getByTestID('switch-query-builder-confirm--confirm-button').click()
+          })
 
-        cy.getByTestID('query-builder').should('exist')
-        // build the query to return data from beforeEach
-        cy.getByTestID('selector-list _monitoring').should('be.visible')
-        cy.getByTestID('selector-list _monitoring').click()
+          cy.getByTestID('query-builder').should('exist')
+          // build the query to return data from beforeEach
+          cy.getByTestID('selector-list _monitoring').should('be.visible')
+          cy.getByTestID('selector-list _monitoring').click()
 
-        cy.getByTestID('selector-list defbuck').should('be.visible')
-        cy.getByTestID('selector-list defbuck').click()
+          cy.getByTestID(defaultBucketListSelector).should('be.visible')
+          cy.getByTestID(defaultBucketListSelector).click()
 
-        cy.getByTestID('selector-list m').should('be.visible')
-        cy.getByTestID('selector-list m').clickAttached()
+          cy.getByTestID('selector-list m').should('be.visible')
+          cy.getByTestID('selector-list m').clickAttached()
 
-        cy.getByTestID('selector-list v').should('be.visible')
-        cy.getByTestID('selector-list v').clickAttached()
+          cy.getByTestID('selector-list v').should('be.visible')
+          cy.getByTestID('selector-list v').clickAttached()
 
-        cy.getByTestID('selector-list tv1').clickAttached()
+          cy.getByTestID('selector-list tv1').clickAttached()
 
-        cy.getByTestID('selector-list last')
-          .scrollIntoView()
-          .should('be.visible')
-          .click({force: true})
+          cy.getByTestID('selector-list last')
+              .scrollIntoView()
+              .should('be.visible')
+              .click({force: true})
 
-        cy.getByTestID('time-machine-submit-button').click()
+          cy.getByTestID('time-machine-submit-button').click()
 
-        // cycle through all the visualizations of the data
-        VIS_TYPES.forEach(({type}) => {
-          if (type !== 'mosaic' && type !== 'band') {
-            // mosaic graph is behind feature flag
-            cy.getByTestID('view-type--dropdown').click()
-            cy.getByTestID(`view-type--${type}`).click()
-            cy.getByTestID(`vis-graphic--${type}`).should('exist')
-            if (type.includes('single-stat')) {
-              cy.getByTestID('single-stat--text').should(
-                'contain',
-                `${numLines}`
-              )
+          // cycle through all the visualizations of the data
+          VIS_TYPES.forEach(({type}) => {
+            if (type !== 'mosaic' && type !== 'band') {
+              // mosaic graph is behind feature flag
+              cy.getByTestID('view-type--dropdown').click()
+              cy.getByTestID(`view-type--${type}`).click()
+              cy.getByTestID(`vis-graphic--${type}`).should('exist')
+              if (type.includes('single-stat')) {
+                cy.getByTestID('single-stat--text').should(
+                    'contain',
+                    `${numLines}`
+                )
+              }
             }
-          }
-        })
+          })
 
-        // view raw data table
-        cy.getByTestID('raw-data--toggle').click()
-        cy.getByTestID('raw-data-table').should('exist')
-        cy.getByTestID('raw-data--toggle').click()
-        cy.getByTestID('giraffe-axes').should('exist')
+          // view raw data table
+          cy.getByTestID('raw-data--toggle').click()
+          cy.getByTestID('raw-data-table').should('exist')
+          cy.getByTestID('raw-data--toggle').click()
+          cy.getByTestID('giraffe-axes').should('exist')
+        })
       })
 
       it('can set min or max y-axis values', () => {
@@ -1028,8 +1031,12 @@ describe('DataExplorer', () => {
             .trigger('mousedown', {force: true})
             .trigger('mousemove', {clientY: 5000})
             .trigger('mouseup')
+              .then(() => {
+                cy.get(`[title="${numLines}"]`).should('be.visible')
+                  }
+              )
         })
-        cy.get(`[title="${numLines}"]`).should('be.visible')
+
       })
     })
   })
@@ -1225,12 +1232,13 @@ describe('DataExplorer', () => {
         cy.get<Organization>('@org').then(({id, name}: Organization) => {
           cy.createBucket(id, name, bucketName)
         })
-
-        cy.getByTestID('selector-list defbuck').click()
-        cy.getByTestID('nav-item-data-explorer').click({force: true})
-        cy.getByTestID(`selector-list m`).click()
-        cy.getByTestID('save-query-as').click({force: true})
-        cy.get('[id="task"]').click()
+        cy.get<string>('@defaultBucketListSelector').then((defaultBucketListSelector: string) => {
+          cy.getByTestID(defaultBucketListSelector).click()
+          cy.getByTestID('nav-item-data-explorer').click({force: true})
+          cy.getByTestID(`selector-list m`).click()
+          cy.getByTestID('save-query-as').click({force: true})
+          cy.get('[id="task"]').click()
+        })
       })
 
       // TODO: enable when problem with switching cron/every is fixed
@@ -1287,14 +1295,16 @@ describe('DataExplorer', () => {
           .should('exist')
 
         cy.getByTestID('task-options-bucket-dropdown--button').click()
-        cy.getByTestID('dropdown-item')
-          .contains('defbuck')
-          .click()
-        cy.getByTestID('task-options-bucket-dropdown--button')
-          .contains('defbuck')
-          .should('exist')
+        cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
+          cy.getByTestID('dropdown-item')
+            .contains(defaultBucket)
+            .click()
+          cy.getByTestID('task-options-bucket-dropdown--button')
+            .contains(defaultBucket)
+            .should('exist')
 
-        cy.getByTestID('task-form-save').click()
+          cy.getByTestID('task-form-save').click()
+        })
       })
     })
 
@@ -1355,31 +1365,35 @@ describe('DataExplorer', () => {
     })
 
     it('should set the default bucket in the dropdown to the selected bucket', () => {
-      cy.get('.cf-overlay--dismiss').click()
-      cy.getByTestID('selector-list defbuck').click()
-      cy.getByTestID('delete-data-predicate')
-        .click()
-        .then(() => {
-          cy.getByTestID('dropdown--button').contains('defbuck')
-          cy.get('.cf-overlay--dismiss').click()
-        })
-        .then(() => {
-          cy.getByTestID('selector-list _monitoring').click()
-          cy.getByTestID('delete-data-predicate')
+      cy.get<string>('@defaultBucketListSelector').then((defaultBucketListSelector: string) => {
+        cy.get('.cf-overlay--dismiss').click()
+        cy.getByTestID(defaultBucketListSelector).click()
+        cy.getByTestID('delete-data-predicate')
             .click()
             .then(() => {
-              cy.getByTestID('dropdown--button').contains('_monitoring')
-              cy.get('.cf-overlay--dismiss').click()
+              cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
+                cy.getByTestID('dropdown--button').contains(defaultBucket)
+                cy.get('.cf-overlay--dismiss').click()
+              })
             })
-        })
-        .then(() => {
-          cy.getByTestID('selector-list _tasks').click()
-          cy.getByTestID('delete-data-predicate')
-            .click()
             .then(() => {
-              cy.getByTestID('dropdown--button').contains('_tasks')
+              cy.getByTestID('selector-list _monitoring').click()
+              cy.getByTestID('delete-data-predicate')
+                  .click()
+                  .then(() => {
+                    cy.getByTestID('dropdown--button').contains('_monitoring')
+                    cy.get('.cf-overlay--dismiss').click()
+                  })
             })
-        })
+            .then(() => {
+              cy.getByTestID('selector-list _tasks').click()
+              cy.getByTestID('delete-data-predicate')
+                  .click()
+                  .then(() => {
+                    cy.getByTestID('dropdown--button').contains('_tasks')
+                  })
+            })
+      })
     })
 
     it('closes the overlay upon a successful delete with predicate submission', () => {

--- a/cypress/e2e/shared/telegrafs.test.ts
+++ b/cypress/e2e/shared/telegrafs.test.ts
@@ -47,10 +47,12 @@ describe('Collectors', () => {
           .click()
       })
 
-      cy.getByTestID('resource-card')
-        .should('have.length', 1)
-        .and('contain', newConfig)
-        .and('contain', Cypress.env('bucket'))
+      cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
+        cy.getByTestID('resource-card')
+            .should('have.length', 1)
+            .and('contain', newConfig)
+            .and('contain', defaultBucket)
+      })
     })
 
     it('allows the user to view just the output', () => {
@@ -106,12 +108,9 @@ describe('Collectors', () => {
         const telegrafConfigName = 'New Config'
         const description = 'Config Description'
         cy.get('@org').then(({id}: Organization) => {
-          cy.createTelegraf(
-            telegrafConfigName,
-            description,
-            id,
-            Cypress.env('bucket')
-          )
+          cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
+            cy.createTelegraf(telegrafConfigName, description, id, defaultBucket)
+          })
         })
 
         cy.reload()

--- a/cypress/index.d.ts
+++ b/cypress/index.d.ts
@@ -27,7 +27,7 @@ import {
   createTelegraf,
   createToken,
   writeData,
-  wrapOrgAndBucket,
+  wrapEnvironmentVariables,
   getByTestIDSubStr,
   createEndpoint,
   createDashWithCell,
@@ -73,7 +73,7 @@ declare global {
       createTelegraf: typeof createTelegraf
       createToken: typeof createToken
       writeData: typeof writeData
-      wrapOrgAndBucket: typeof wrapOrgAndBucket
+      wrapOrgAndBucket: typeof wrapEnvironmentVariables
       createEndpoint: typeof createEndpoint
       createRule: typeof createRule
     }

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -49,7 +49,7 @@ export const signin = (): Cypress.Chainable<Cypress.Response> => {
   })
 }
 
-export const wrapOrgAndBucket = (): Cypress.Chainable<Cypress.Response> => {
+export const wrapEnvironmentVariables = (): Cypress.Chainable<Cypress.Response> => {
   return cy
     .request({
       method: 'GET',
@@ -72,6 +72,11 @@ export const wrapOrgAndBucket = (): Cypress.Chainable<Cypress.Response> => {
             b.name !== '_monitoring'
         )
         cy.wrap(bucket).as('bucket')
+
+        const defaultBucket = 'defbuck'
+
+        cy.wrap(defaultBucket).as('defaultBucket')
+        cy.wrap('selector-list '.concat(defaultBucket)).as('defaultBucketListSelector')
       })
     })
 }
@@ -592,7 +597,7 @@ Cypress.Commands.add('signin', signin)
 
 // setup
 Cypress.Commands.add('setupUser', setupUser)
-Cypress.Commands.add('wrapOrgAndBucket', wrapOrgAndBucket)
+Cypress.Commands.add('wrapOrgAndBucket', wrapEnvironmentVariables)
 
 // dashboards
 Cypress.Commands.add('createDashboard', createDashboard)


### PR DESCRIPTION
Makes progress on 521 - going to make one PR per string alias added so as to keep the changes more manageable.

This adds two aliases for e2e tests: cy.get('@defaultBucket') and cy.get('@defaultBucketListSelector').  The former returns "defbuck" and the latter "selector-list defbuck" but is defined so that if we changed the default bucket (in commands.ts) it would flow through.  These two aliases simplify testing code down considerably.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass

