### PR TITLE
fix: resolves notebook duplication bug

### DIFF
--- a/src/flows/context/flow.list.tsx
+++ b/src/flows/context/flow.list.tsx
@@ -291,7 +291,7 @@ export const FlowListProvider: FC = ({children}) => {
         serialize,
         dispatch
       )
-      setFlows(_flows)
+      setFlows({..._flows})
       if (currentID && currentID.includes('local')) {
         // if we migrated the local currentID flow, reset currentID
         setCurrentID(Object.keys(_flows)[0])


### PR DESCRIPTION
fixes notebook duplication bug. When migration completed, state was mutated and ids from API were not saved in state. Next time the user navigates to the page, the migration occurs again. The GET call will return all of these notebooks that were created and re-created from the failed migrations, making it look like there are duplicates.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

