### PR TITLE
fix: wrap variables on shrinking of screen size

### DIFF
--- a/src/dashboards/components/variablesControlBar/VariablesControlBar.scss
+++ b/src/dashboards/components/variablesControlBar/VariablesControlBar.scss
@@ -8,6 +8,7 @@
   width: 100%;
   display: flex;
   transition: box-shadow 0.25s ease;
+  flex-wrap: wrap;
 }
 
 .variables-control-bar--grid__dragging-over {


### PR DESCRIPTION
Closes #530

<!-- Describe your proposed changes here. -->
Enables wrapping on variable control bar contraction when screen shrinks

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

