### PR TITLE
chore: Upgrade flux-lsp-browser to v0.5.31

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
   "dependencies": {
     "@influxdata/clockface": "^2.4.1",
     "@influxdata/flux": "^0.5.1",
-    "@influxdata/flux-lsp-browser": "^0.5.30",
+    "@influxdata/flux-lsp-browser": "^0.5.31",
     "@influxdata/giraffe": "^2.0.0",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -787,10 +787,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-2.4.1.tgz#67c61d89782dea07a149dd35e45b9eb13ad63a5f"
   integrity sha512-p1YEnB73wOkzS6PqKr2P3jf0jRLP4mJZBbyOZsDlkYsuy3PrGnGCscshecb/f2XNiTbbbShXy40SzPreM07wQw==
 
-"@influxdata/flux-lsp-browser@^0.5.30":
-  version "0.5.30"
-  resolved "https://registry.yarnpkg.com/@influxdata/flux-lsp-browser/-/flux-lsp-browser-0.5.30.tgz#e94575e8021abf7ca8639d7323a1426f576010eb"
-  integrity sha512-fBSLlvXr9TcO+7VUInI4FaD5Cgolzfy1uRpjOltQyMlC8j21HYQ6+2V2KZXgk7Ov+5yDOrT3CgLued/Atb063w==
+"@influxdata/flux-lsp-browser@^0.5.31":
+  version "0.5.31"
+  resolved "https://registry.yarnpkg.com/@influxdata/flux-lsp-browser/-/flux-lsp-browser-0.5.31.tgz#d95f262c161013229bbac803fd104f97e4ca8e81"
+  integrity sha512-BhZGA19hIpiJ4XOTknWNJvXS1Sqcp/Ni33r5Sgdpeps2y+u9TAx1QY9u9EaoUinz/mtEsxy0B6JjxXY+AwElqQ==
 
 "@influxdata/flux@^0.5.1":
   version "0.5.1"


### PR DESCRIPTION
[Flux LSP v0.5.31](https://github.com/influxdata/flux-lsp/releases/tag/v0.5.31)