### PR TITLE
feat: persist data across refreshes in data explorer

### DIFF
--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -670,6 +670,9 @@ describe('DataExplorer', () => {
       it('can view time-series data', () => {
         cy.get<string>('@defaultBucketListSelector').then(
           (defaultBucketListSelector: string) => {
+            cy.window().then(win => {
+              win.influx.set('persistRefresh', true)
+            })
             cy.log('can switch between editor modes')
             cy.getByTestID('selector-list _monitoring').should('be.visible')
             cy.getByTestID('selector-list _monitoring').click()
@@ -769,6 +772,16 @@ describe('DataExplorer', () => {
             cy.getByTestID('raw-data-table').should('exist')
             cy.getByTestID('raw-data--toggle').click()
             cy.getByTestID('giraffe-axes').should('exist')
+
+            cy.reload()
+
+            cy.wait(2000)
+
+            cy.getByTestID('selector-list defbuck').should('be.visible')
+
+            cy.getByTestID('selector-list m').should('be.visible')
+
+            cy.getByTestID('selector-list v').should('be.visible')
           }
         )
       })

--- a/src/dataExplorer/components/DataExplorer.tsx
+++ b/src/dataExplorer/components/DataExplorer.tsx
@@ -1,6 +1,6 @@
 // Libraries
-import React, {FC, useEffect} from 'react'
-import {useDispatch} from 'react-redux'
+import React, {FC, useEffect, useCallback} from 'react'
+import {useDispatch, useSelector} from 'react-redux'
 
 // Components
 import TimeMachine from 'src/timeMachine/components/TimeMachine'
@@ -16,15 +16,54 @@ import {queryBuilderFetcher} from 'src/timeMachine/apis/QueryBuilderFetcher'
 import {readQueryParams} from 'src/shared/utils/queryParams'
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
 
+import {getActiveTimeMachine} from 'src/timeMachine/selectors'
+
+import {getStore} from 'src/store/configureStore'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+;(() => {
+  if (isFlagEnabled('persistRefresh')) {
+    const fromLocalStorageState = JSON.parse(
+      window.localStorage.getItem('timeMachineState')
+    )
+
+    if (!fromLocalStorageState) {
+      return null
+    }
+
+    const store = getStore()
+    // set the state in redux
+    store.dispatch(setActiveTimeMachine('de', fromLocalStorageState))
+  }
+})()
+
 const DataExplorer: FC = () => {
   const dispatch = useDispatch()
-
+  const timeMachineState = useSelector(getActiveTimeMachine)
   useEffect(() => {
     const bucketQP = readQueryParams()['bucket']
     dispatch(setActiveTimeMachine('de'))
     queryBuilderFetcher.clearCache()
     dispatch(setBuilderBucketIfExists(bucketQP))
   }, [dispatch])
+
+  const setLocalStorageWithReduxState = useCallback(() => {
+    const {
+      queryBuilder: _a,
+      queryResults: _b,
+      ...timeMachineToSave
+    } = timeMachineState
+
+    window.localStorage.setItem(
+      'timeMachineState',
+      JSON.stringify(timeMachineToSave)
+    )
+  }, [timeMachineState])
+
+  useEffect(() => {
+    if (isFlagEnabled('persistRefresh')) {
+      setLocalStorageWithReduxState()
+    }
+  }, [timeMachineState, setLocalStorageWithReduxState])
 
   return (
     <ErrorBoundary>


### PR DESCRIPTION
Closes #5664

<!-- Describe your proposed changes here. -->
This PR introduces the ability to persist the query state across refreshes in data explorer, even when leaving the page and refreshing in between. 

Im currently investigating whether the cypress test will be able to pick up the IIFE outside of the React component, so that test may need to be adjusted, which is why im leaving the "tests passing" section blank for now, until i can be sure. Wanted to get eyes on the change itself to get peoples thoughts. 

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass

