### PR TITLE
fix: add specific error message to token creation failure

### DIFF
--- a/src/authorizations/actions/thunks.ts
+++ b/src/authorizations/actions/thunks.ts
@@ -108,8 +108,8 @@ export const createAuthorization = (auth: Authorization) => async (
     dispatch(addAuthorization(newAuth))
     dispatch(notify(authorizationCreateSuccess()))
   } catch (error) {
-    console.error(error.message)
-    dispatch(notify(authorizationCreateFailed()))
+    console.error(error.data.message)
+    dispatch(notify(authorizationCreateFailed(error.data.message)))
     throw error
   }
 }

--- a/src/authorizations/actions/thunks.ts
+++ b/src/authorizations/actions/thunks.ts
@@ -108,8 +108,9 @@ export const createAuthorization = (auth: Authorization) => async (
     dispatch(addAuthorization(newAuth))
     dispatch(notify(authorizationCreateSuccess()))
   } catch (error) {
-    console.error(error.data.message)
-    dispatch(notify(authorizationCreateFailed(error.data.message)))
+    const message = error.data ? error.data.message : null
+    console.error(message)
+    dispatch(notify(authorizationCreateFailed(message)))
     throw error
   }
 }

--- a/src/shared/copy/notifications.ts
+++ b/src/shared/copy/notifications.ts
@@ -780,10 +780,14 @@ export const passwordResetSuccessfully = (message: string): Notification => ({
 
 export const authorizationCreateFailed = (
   errorMessage?: string
-): Notification => ({
-  ...defaultErrorNotification,
-  message: `Failed to create tokens: ${errorMessage}`,
-})
+): Notification => {
+  const defaultMsg = 'Failed to create tokens'
+  const message = errorMessage ? `${defaultMsg}: ${errorMessage}` : defaultMsg
+  return {
+    ...defaultErrorNotification,
+    message,
+  }
+}
 
 export const authorizationUpdateSuccess = (): Notification => ({
   ...defaultSuccessNotification,

--- a/src/shared/copy/notifications.ts
+++ b/src/shared/copy/notifications.ts
@@ -778,9 +778,11 @@ export const passwordResetSuccessfully = (message: string): Notification => ({
   If you haven't received an email, please ensure that the email you provided is correct.`,
 })
 
-export const authorizationCreateFailed = (): Notification => ({
+export const authorizationCreateFailed = (
+  errorMessage?: string
+): Notification => ({
   ...defaultErrorNotification,
-  message: 'Failed to create tokens',
+  message: `Failed to create tokens: ${errorMessage}`,
 })
 
 export const authorizationUpdateSuccess = (): Notification => ({


### PR DESCRIPTION
Closes #637 

<!-- Describe your proposed changes here. -->
Adds a specific error message to the failed token creation process for website monitoring bucket
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass

