### PR TITLE
fix: wasm download failures due to lazy loading signin

### DIFF
--- a/src/Setup.tsx
+++ b/src/Setup.tsx
@@ -9,7 +9,8 @@ import {client} from 'src/utils/api'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 import PageSpinner from 'src/perf/components/PageSpinner'
 import {LoginPage} from 'src/onboarding/containers/LoginPage'
-const Signin = lazy(() => import('src/Signin'))
+// lazy loading the signin component causes wasm issues
+import Signin from 'src/Signin'
 const OnboardingWizardPage = lazy(() =>
   import('src/onboarding/containers/OnboardingWizardPage')
 )

--- a/src/shared/containers/GetOrganizations.tsx
+++ b/src/shared/containers/GetOrganizations.tsx
@@ -1,13 +1,13 @@
 // Libraries
-import React, {useEffect, FunctionComponent} from 'react'
+import React, {useEffect, FunctionComponent, lazy, Suspense} from 'react'
 import {connect, ConnectedProps, useDispatch} from 'react-redux'
 import {Route, Switch} from 'react-router-dom'
 
 // Components
-import {SpinnerContainer, TechnoSpinner} from '@influxdata/clockface'
-import NoOrgsPage from 'src/organizations/containers/NoOrgsPage'
-import App from 'src/App'
-import NotFound from 'src/shared/components/NotFound'
+import PageSpinner from 'src/perf/components/PageSpinner'
+const NoOrgsPage = lazy(() => import('src/organizations/containers/NoOrgsPage'))
+const App = lazy(() => import('src/App'))
+const NotFound = lazy(() => import('src/shared/components/NotFound'))
 
 // Types
 import {RemoteDataState, AppState} from 'src/types'
@@ -28,14 +28,16 @@ const GetOrganizations: FunctionComponent<Props> = ({status}) => {
   }, [dispatch, status])
 
   return (
-    <SpinnerContainer loading={status} spinnerComponent={<TechnoSpinner />}>
-      <Switch>
-        <Route path="/no-orgs" component={NoOrgsPage} />
-        <Route path="/orgs" component={App} />
-        <Route exact path="/" component={RouteToOrg} />
-        <Route component={NotFound} />
-      </Switch>
-    </SpinnerContainer>
+    <PageSpinner loading={status}>
+      <Suspense fallback={<PageSpinner />}>
+        <Switch>
+          <Route path="/no-orgs" component={NoOrgsPage} />
+          <Route path="/orgs" component={App} />
+          <Route exact path="/" component={RouteToOrg} />
+          <Route component={NotFound} />
+        </Switch>
+      </Suspense>
+    </PageSpinner>
   )
 }
 


### PR DESCRIPTION
Fixes "Could not download wasm module" error. Turns out lazy loading the signin component is a bad idea. 

![image](https://user-images.githubusercontent.com/6411855/106968769-593f9e80-66fe-11eb-8c5f-74c4226c12d7.png)


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

