### PR TITLE
fix: should get id from url before checking if flow exists

### DIFF
--- a/src/flows/components/header/index.tsx
+++ b/src/flows/components/header/index.tsx
@@ -25,6 +25,10 @@ const FlowHeader: FC = () => {
     update({name})
   }
 
+  if (!flow) {
+    return null
+  }
+
   return (
     <>
       <Page.Header fullWidth={FULL_WIDTH}>

--- a/src/flows/context/flow.current.tsx
+++ b/src/flows/context/flow.current.tsx
@@ -5,6 +5,7 @@ import {v4 as UUID} from 'uuid'
 import {RemoteDataState} from 'src/types'
 import {PROJECT_NAME, PIPE_DEFINITIONS} from 'src/flows'
 import {event} from 'src/cloud/utils/reporting'
+import {useParams} from 'react-router-dom'
 
 export interface FlowContextType {
   id: string | null
@@ -27,23 +28,24 @@ export const FlowContext = React.createContext<FlowContextType>(DEFAULT_CONTEXT)
 let GENERATOR_INDEX = 0
 
 export const FlowProvider: FC = ({children}) => {
-  const {flows, update, currentID} = useContext(FlowListContext)
+  const {flows, update} = useContext(FlowListContext)
+  const {id} = useParams<{id: string}>()
 
   const updateCurrent = useCallback(
     (flow: Flow) => {
-      update(currentID, {
-        ...flows[currentID],
+      update(id, {
+        ...flows[id],
         ...flow,
       })
     },
-    [currentID, flows[currentID]]
+    [id, flows[id]]
   )
 
   const addPipe = (initial: PipeData, index?: number) => {
     const id = `local_${UUID()}`
 
-    flows[currentID].data.add(id, initial)
-    flows[currentID].meta.add(id, {
+    flows[id].data.add(id, initial)
+    flows[id].meta.add(id, {
       title: `${PIPE_DEFINITIONS[initial.type].button ||
         'Panel'} ${++GENERATOR_INDEX}`,
       visible: true,
@@ -51,7 +53,7 @@ export const FlowProvider: FC = ({children}) => {
     })
 
     if (typeof index !== 'undefined') {
-      flows[currentID].data.move(id, index + 1)
+      flows[id].data.move(id, index + 1)
     }
 
     event('insert_notebook_cell', {notebooksCellType: initial.type})
@@ -59,16 +61,16 @@ export const FlowProvider: FC = ({children}) => {
     return id
   }
 
-  if (!flows || !flows.hasOwnProperty(currentID)) {
+  if (!flows || !flows.hasOwnProperty(id)) {
     return null
   }
 
   return (
     <FlowContext.Provider
       value={{
-        id: currentID,
+        id,
         name,
-        flow: flows[currentID],
+        flow: flows[id],
         add: addPipe,
         update: updateCurrent,
       }}

--- a/src/flows/context/flow.list.tsx
+++ b/src/flows/context/flow.list.tsx
@@ -280,17 +280,6 @@ export const FlowListProvider: FC = ({children}) => {
     pooledUpdateAPI(apiFlow)
   }
 
-  const change = useCallback(
-    (id: string) => {
-      if (!flows || !flows.hasOwnProperty(id)) {
-        throw new Error(`${PROJECT_NAME} does note exist`)
-      }
-
-      setCurrentID(id)
-    },
-    [setCurrentID, flows]
-  )
-
   const remove = async (id: string) => {
     const _flows = {
       ...flows,
@@ -317,6 +306,16 @@ export const FlowListProvider: FC = ({children}) => {
       setFlows(_flows)
     }
   }, [orgID, setFlows])
+
+  const change = useCallback(
+    (id: string) => {
+      if (!Object.keys(flows).length) {
+        getAll()
+      }
+      setCurrentID(id)
+    },
+    [setCurrentID, flows]
+  )
 
   const migrate = async () => {
     if (isFlagEnabled(FLOWS_API_FLAG)) {

--- a/src/flows/context/query.tsx
+++ b/src/flows/context/query.tsx
@@ -21,6 +21,7 @@ import {
   setQueryByHashID,
 } from 'src/timeMachine/actions/queries'
 import {notify} from 'src/shared/actions/notifications'
+import EmptyGraphMessage from 'src/shared/components/EmptyGraphMessage'
 
 // Constants
 import {
@@ -272,6 +273,15 @@ export const QueryProvider: FC = ({children}) => {
         // NOTE: this shouldn't fire, but lets wrap it for completeness
         throw e
       })
+  }
+
+  if (!flow) {
+    return (
+      <EmptyGraphMessage
+        message="Could not find this notebook"
+        testID="notebook-not-found"
+      />
+    )
   }
 
   if (!flow?.range || bucketsLoadingState !== RemoteDataState.Done) {


### PR DESCRIPTION
Closes #621 

There are three issues:
1. Users were unable to go directly to a shared Notebook url that wasn't in their browser's cache.
2. The FlowProvider expects an id to exist before rendering FlowPage but FlowPage is responsible for getting the id from the url.
3. Going to a notebook directly that doesn't exist throws an error with no message

I fixed (1) by calling `getAll` whenever the `currentID` is changed to pull down the notebooks. I fixed (2) by moving the check for the existence of the down the component tree. If the `flow` prop is undefined, assume it doesn't exist. I fixed (3) by showing an error message that says the notebook couldn't be found.

![image](https://user-images.githubusercontent.com/6411855/107101908-9c1c7780-67cd-11eb-9ffe-d8b882f8d0cf.png)


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

