### PR TITLE
fix: address overflowing dashboard name editor

### DIFF
--- a/src/dashboards/components/DashboardsCardGrid.scss
+++ b/src/dashboards/components/DashboardsCardGrid.scss
@@ -36,7 +36,7 @@ $dashboard-grid-gap: $cf-marg-a;
 
   .cf-resource-editable-name {
     position: absolute;
-    width: 100%;
+    min-width: 60%;
 
     .cf-resource-name--text {
       overflow: hidden;
@@ -57,18 +57,25 @@ $dashboard-card-quarter: calc(25% - #{$dashboard-grid-gap});
 
 @media screen and (min-width: $cf-grid--breakpoint-sm) {
   .dashboards-card-grid {
-    grid-template-columns: minmax($dashboard-card-half, 1fr) minmax($dashboard-card-half, 1fr);
+    grid-template-columns: minmax($dashboard-card-half, 1fr) minmax(
+        $dashboard-card-half,
+        1fr
+      );
   }
 }
 
 @media screen and (min-width: $cf-grid--breakpoint-md) {
   .dashboards-card-grid {
-    grid-template-columns: minmax($dashboard-card-third, 1fr) minmax($dashboard-card-third, 1fr) minmax($dashboard-card-third, 1fr);
+    grid-template-columns:
+      minmax($dashboard-card-third, 1fr) minmax($dashboard-card-third, 1fr)
+      minmax($dashboard-card-third, 1fr);
   }
 }
 
 @media screen and (min-width: $cf-grid--breakpoint-lg) {
   .dashboards-card-grid {
-    grid-template-columns: minmax($dashboard-card-quarter, 1fr) minmax($dashboard-card-quarter, 1fr) minmax($dashboard-card-quarter, 1fr) minmax($dashboard-card-quarter, 1fr);
+    grid-template-columns:
+      minmax($dashboard-card-quarter, 1fr) minmax($dashboard-card-quarter, 1fr)
+      minmax($dashboard-card-quarter, 1fr) minmax($dashboard-card-quarter, 1fr);
   }
 }


### PR DESCRIPTION
Closes https://github.com/influxdata/clockface/issues/517

<!-- Describe your proposed changes here. -->
Changes the value of the width of the dashboard card name editor so it doesnt overflow

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

