### PR TITLE
fix: saving a query shouldnt leave query state around

### DIFF
--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -1199,17 +1199,12 @@ describe('DataExplorer', () => {
 
         cy.getByTestID('save-as-dashboard-cell--submit').click()
 
-        // wait some time for save
-        cy.wait(2000)
-        // ensure dashboard created with cell
-        // cy.get('@org').then(({id: orgID}: Organization) => {
-        //   cy.fixture('routes').then(({orgs}) => {
-        //     cy.visit(`${orgs}/${orgID}/dashboards/`)
+        cy.location('pathname').should(
+          'match',
+          /^(?=.*dashboards)(?:(?!cell).)+$/
+        )
 
-        //   })
-        // })
-        cy.getByTestID('dashboard-card--name')
-          .contains(dashboardCreateName)
+        cy.getByTestID(`cell--draggable ${cellName}`)
           .should('exist')
           .click()
         cy.getByTestID(`cell ${cellName}`).should('exist')

--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -1186,7 +1186,7 @@ describe('DataExplorer', () => {
         })
       })
 
-      it('can create new dashboard as saving target', () => {
+      it.only('can create new dashboard as saving target', () => {
         // select and input new dashboard name and cell name
         cy.getByTestID('save-as-dashboard-cell--dropdown').click()
         cy.getByTestID('save-as-dashboard-cell--create-new-dash').click()
@@ -1200,8 +1200,9 @@ describe('DataExplorer', () => {
         cy.getByTestID('save-as-dashboard-cell--submit').click()
 
         // wait some time for save
-        cy.wait(200)
+        cy.wait(2000)
         // ensure dashboard created with cell
+<<<<<<< HEAD
         cy.get('@org').then(({id: orgID}: Organization) => {
           cy.fixture('routes').then(({orgs}) => {
             cy.visit(`${orgs}/${orgID}/dashboards/`)
@@ -1213,6 +1214,19 @@ describe('DataExplorer', () => {
             cy.getByTestID(`cell ${cellName}`).should('exist')
           })
         })
+=======
+        // cy.get('@org').then(({id: orgID}: Organization) => {
+        //   cy.fixture('routes').then(({orgs}) => {
+        //     cy.visit(`${orgs}/${orgID}/dashboards/`)
+
+        //   })
+        // })
+        cy.getByTestID('dashboard-card--name')
+          .contains(dashboardCreateName)
+          .should('exist')
+          .click()
+        cy.getByTestID(`cell ${cellName}`).should('exist')
+>>>>>>> fix: working with create and update, testing in progress
       })
     })
 

--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -1221,8 +1221,7 @@ describe('DataExplorer', () => {
 
         //   })
         // })
-        cy.getByTestID('dashboard-card--name')
-          .contains(dashboardCreateName)
+        cy.getByTestID(`cell--draggable ${cellName}`)
           .should('exist')
           .click()
         cy.getByTestID(`cell ${cellName}`).should('exist')

--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -1186,7 +1186,7 @@ describe('DataExplorer', () => {
         })
       })
 
-      it.only('can create new dashboard as saving target', () => {
+      it('can create new dashboard as saving target', () => {
         // select and input new dashboard name and cell name
         cy.getByTestID('save-as-dashboard-cell--dropdown').click()
         cy.getByTestID('save-as-dashboard-cell--create-new-dash').click()

--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -1160,13 +1160,12 @@ describe('DataExplorer', () => {
 
       it('can save as cell into multiple dashboards', () => {
         // input dashboards and cell name
-        cy.getByTestID('save-as-dashboard-cell--dropdown').click()
-        cy.getByTestID('save-as-dashboard-cell--dropdown-menu').within(() => {
-          dashboardNames.forEach(d => {
-            cy.contains(d).click()
+        dashboardNames.forEach(name => {
+          cy.getByTestID('save-as-dashboard-cell--dropdown').click()
+          cy.getByTestID('save-as-dashboard-cell--dropdown-menu').within(() => {
+            cy.contains(name).click()
           })
         })
-        cy.getByTestID('save-as-dashboard-cell--dropdown').click()
         cy.getByTestID('save-as-dashboard-cell--cell-name').type(cellName)
 
         cy.getByTestID('save-as-dashboard-cell--submit').click()
@@ -1189,8 +1188,9 @@ describe('DataExplorer', () => {
       it('can create new dashboard as saving target', () => {
         // select and input new dashboard name and cell name
         cy.getByTestID('save-as-dashboard-cell--dropdown').click()
-        cy.getByTestID('save-as-dashboard-cell--create-new-dash').click()
-        cy.getByTestID('save-as-dashboard-cell--dropdown').click()
+        cy.getByTestID('save-as-dashboard-cell--dropdown-menu').within(() => {
+          cy.getByTestID('save-as-dashboard-cell--create-new-dash').click()
+        })
         cy.getByTestID('save-as-dashboard-cell--dashboard-name')
           .should('be.visible')
           .clear()

--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -1202,30 +1202,17 @@ describe('DataExplorer', () => {
         // wait some time for save
         cy.wait(2000)
         // ensure dashboard created with cell
-<<<<<<< HEAD
-        cy.get('@org').then(({id: orgID}: Organization) => {
-          cy.fixture('routes').then(({orgs}) => {
-            cy.visit(`${orgs}/${orgID}/dashboards/`)
-            cy.getByTestID('tree-nav')
-            cy.getByTestID('dashboard-card--name')
-              .contains(dashboardCreateName)
-              .should('exist')
-              .click()
-            cy.getByTestID(`cell ${cellName}`).should('exist')
-          })
-        })
-=======
         // cy.get('@org').then(({id: orgID}: Organization) => {
         //   cy.fixture('routes').then(({orgs}) => {
         //     cy.visit(`${orgs}/${orgID}/dashboards/`)
 
         //   })
         // })
-        cy.getByTestID(`cell--draggable ${cellName}`)
+        cy.getByTestID('dashboard-card--name')
+          .contains(dashboardCreateName)
           .should('exist')
           .click()
         cy.getByTestID(`cell ${cellName}`).should('exist')
->>>>>>> fix: working with create and update, testing in progress
       })
     })
 

--- a/src/cells/actions/thunks.ts
+++ b/src/cells/actions/thunks.ts
@@ -25,7 +25,7 @@ import {notify} from 'src/shared/actions/notifications'
 import {setDashboard} from 'src/dashboards/actions/creators'
 import {setCells, setCell, removeCell} from 'src/cells/actions/creators'
 import {removeView} from 'src/views/actions/creators'
-
+import {setDashboardTimeRange} from 'src/dashboards/actions/ranges'
 // Constants
 import * as copy from 'src/shared/copy/notifications'
 
@@ -42,6 +42,7 @@ import {
   CellEntities,
   View,
   ViewEntities,
+  TimeRange,
 } from 'src/types'
 
 // Utils
@@ -70,7 +71,8 @@ export const createCellWithView = (
   dashboardID: string,
   view: NewView,
   clonedCell?: Cell,
-  redirect?: (destinationId: string) => void
+  redirect?: (destinationId: string) => void,
+  timeRange?: TimeRange
 ) => async (dispatch, getState: GetState): Promise<void> => {
   const state = getState()
   let workingView = view
@@ -113,6 +115,9 @@ export const createCellWithView = (
       workingView = {...workingView, name: `${view.name} (Clone)`}
     }
 
+    if (timeRange) {
+      dispatch(setDashboardTimeRange(dashboardID, timeRange))
+    }
     // Create the view and associate it with the cell
     const newView = await updateView(dashboardID, cellID, workingView)
 
@@ -140,7 +145,8 @@ export const createDashboardWithView = (
   orgID: string,
   dashboardName: string,
   view: View,
-  redirect?: (destinationId: string) => void
+  redirect?: (destinationId: string) => void,
+  timeRange?: TimeRange
 ) => async (dispatch): Promise<void> => {
   try {
     const newDashboard = {
@@ -162,7 +168,9 @@ export const createDashboardWithView = (
 
     await dispatch(setDashboard(resp.data.id, RemoteDataState.Done, normDash))
 
-    await dispatch(createCellWithView(resp.data.id, view))
+    await dispatch(
+      createCellWithView(resp.data.id, view, null, null, timeRange)
+    )
     dispatch(notify(copy.dashboardCreateSuccess()))
     if (redirect) {
       redirect(resp.data.id)

--- a/src/cells/actions/thunks.ts
+++ b/src/cells/actions/thunks.ts
@@ -70,7 +70,7 @@ export const createCellWithView = (
   dashboardID: string,
   view: NewView,
   clonedCell?: Cell,
-  redirect: (id: string) => void | undefined
+  redirect?: (id: string) => void | undefined
 ) => async (dispatch, getState: GetState): Promise<void> => {
   const state = getState()
   let workingView = view

--- a/src/cells/actions/thunks.ts
+++ b/src/cells/actions/thunks.ts
@@ -69,7 +69,8 @@ export const deleteCellAndView = (
 export const createCellWithView = (
   dashboardID: string,
   view: NewView,
-  clonedCell?: Cell
+  clonedCell?: Cell,
+  redirect: (id: string) => void | undefined
 ) => async (dispatch, getState: GetState): Promise<void> => {
   const state = getState()
   let workingView = view
@@ -125,6 +126,10 @@ export const createCellWithView = (
 
     dispatch(setCell(cellID, RemoteDataState.Done, normCell))
     dispatch(setView(cellID, RemoteDataState.Done, normView))
+
+    if (redirect) {
+      redirect(dashboardID)
+    }
   } catch (error) {
     dispatch(notify(copy.cellAddFailed(error.message)))
     throw error
@@ -134,7 +139,8 @@ export const createCellWithView = (
 export const createDashboardWithView = (
   orgID: string,
   dashboardName: string,
-  view: View
+  view: View,
+  redirect: (id: string) => void | undefined
 ) => async (dispatch): Promise<void> => {
   try {
     const newDashboard = {
@@ -158,6 +164,9 @@ export const createDashboardWithView = (
 
     await dispatch(createCellWithView(resp.data.id, view))
     dispatch(notify(copy.dashboardCreateSuccess()))
+    if (redirect) {
+      redirect(resp.data.id)
+    }
   } catch (error) {
     console.error(error)
     dispatch(notify(copy.cellAddFailed(error.message)))

--- a/src/cells/actions/thunks.ts
+++ b/src/cells/actions/thunks.ts
@@ -140,7 +140,7 @@ export const createDashboardWithView = (
   orgID: string,
   dashboardName: string,
   view: View,
-  redirect?: (destinationId: string) => void | undefined
+  redirect?: (destinationId: string) => void
 ) => async (dispatch): Promise<void> => {
   try {
     const newDashboard = {

--- a/src/cells/actions/thunks.ts
+++ b/src/cells/actions/thunks.ts
@@ -140,7 +140,7 @@ export const createDashboardWithView = (
   orgID: string,
   dashboardName: string,
   view: View,
-  redirect: (id: string) => void | undefined
+  redirect: (destinationId: string) => void | undefined
 ) => async (dispatch): Promise<void> => {
   try {
     const newDashboard = {

--- a/src/cells/actions/thunks.ts
+++ b/src/cells/actions/thunks.ts
@@ -70,7 +70,7 @@ export const createCellWithView = (
   dashboardID: string,
   view: NewView,
   clonedCell?: Cell,
-  redirect?: (destinationId: string) => void | undefined
+  redirect?: (destinationId: string) => void
 ) => async (dispatch, getState: GetState): Promise<void> => {
   const state = getState()
   let workingView = view

--- a/src/cells/actions/thunks.ts
+++ b/src/cells/actions/thunks.ts
@@ -70,7 +70,7 @@ export const createCellWithView = (
   dashboardID: string,
   view: NewView,
   clonedCell?: Cell,
-  redirect?: (id: string) => void | undefined
+  redirect?: (destinationId: string) => void | undefined
 ) => async (dispatch, getState: GetState): Promise<void> => {
   const state = getState()
   let workingView = view
@@ -140,7 +140,7 @@ export const createDashboardWithView = (
   orgID: string,
   dashboardName: string,
   view: View,
-  redirect: (destinationId: string) => void | undefined
+  redirect?: (destinationId: string) => void | undefined
 ) => async (dispatch): Promise<void> => {
   try {
     const newDashboard = {

--- a/src/dataExplorer/components/DashboardsDropdown.tsx
+++ b/src/dataExplorer/components/DashboardsDropdown.tsx
@@ -32,8 +32,11 @@ class DashboardsDropdown extends PureComponent<Props> {
             {this.dropdownLabel}
           </Dropdown.Button>
         )}
-        menu={() => (
-          <Dropdown.Menu testID="save-as-dashboard-cell--dropdown-menu">
+        menu={onCollapse => (
+          <Dropdown.Menu
+            onCollapse={onCollapse}
+            testID="save-as-dashboard-cell--dropdown-menu"
+          >
             {this.dropdownItems}
           </Dropdown.Menu>
         )}

--- a/src/dataExplorer/components/SaveAsCellForm.tsx
+++ b/src/dataExplorer/components/SaveAsCellForm.tsx
@@ -166,6 +166,7 @@ class SaveAsCellForm extends PureComponent<Props, State> {
       view,
       dismiss,
       orgID,
+      history,
     } = this.props
     const {targetDashboardIDs} = this.state
 
@@ -175,20 +176,20 @@ class SaveAsCellForm extends PureComponent<Props, State> {
 
     const viewWithProps: View = {...view, name: cellName}
 
-    const {history} = this.props
     let succeeded = false
-    const redirect = (id: string) =>
+    const redirectHandler = (id: string): void =>
       history.push(`/orgs/${orgID}/dashboards/${id}`)
+
     try {
       targetDashboardIDs.forEach((dashID, idx) => {
-        const toRedirectProp =
-          idx === targetDashboardIDs.length - 1 ? redirect : undefined
+        const toRedirect =
+          idx === targetDashboardIDs.length - 1 ? redirectHandler : undefined
         if (dashID === DashboardTemplate.id) {
           onCreateDashboardWithView(
             orgID,
             newDashboardName,
             viewWithProps,
-            toRedirectProp
+            toRedirect
           )
           return
         }
@@ -198,7 +199,7 @@ class SaveAsCellForm extends PureComponent<Props, State> {
           selectedDashboard.id,
           viewWithProps,
           null,
-          toRedirectProp
+          toRedirect
         )
       })
       succeeded = true

--- a/src/dataExplorer/components/SaveAsCellForm.tsx
+++ b/src/dataExplorer/components/SaveAsCellForm.tsx
@@ -174,19 +174,32 @@ class SaveAsCellForm extends PureComponent<Props, State> {
       this.state.newDashboardName || DEFAULT_DASHBOARD_NAME
 
     const viewWithProps: View = {...view, name: cellName}
-    let targetDashboard
+
+    const {history} = this.props
     let succeeded = false
+    const redirect = (id: string) =>
+      history.push(`/orgs/${orgID}/dashboards/${id}`)
     try {
-      targetDashboardIDs.forEach(dashID => {
+      targetDashboardIDs.forEach((dashID, idx) => {
+        const toRedirectProp =
+          idx === targetDashboardIDs.length - 1 ? redirect : undefined
         if (dashID === DashboardTemplate.id) {
-          targetDashboard = dashID
-          onCreateDashboardWithView(orgID, newDashboardName, viewWithProps)
+          onCreateDashboardWithView(
+            orgID,
+            newDashboardName,
+            viewWithProps,
+            toRedirectProp
+          )
           return
         }
 
         const selectedDashboard = dashboards.find(d => d.id === dashID)
-        targetDashboard = selectedDashboard.id
-        onCreateCellWithView(selectedDashboard.id, viewWithProps)
+        onCreateCellWithView(
+          selectedDashboard.id,
+          viewWithProps,
+          null,
+          toRedirectProp
+        )
       })
       succeeded = true
     } catch (error) {
@@ -195,7 +208,6 @@ class SaveAsCellForm extends PureComponent<Props, State> {
       this.resetForm()
       if (succeeded) {
         this.props.setTimeMachine('de', initialStateHelper())
-        this.props.history.push(`/orgs/${orgID}/dashboards/${targetDashboard}`)
       } else {
         dismiss()
       }

--- a/src/dataExplorer/components/SaveAsCellForm.tsx
+++ b/src/dataExplorer/components/SaveAsCellForm.tsx
@@ -5,7 +5,7 @@ import {connect, ConnectedProps} from 'react-redux'
 import {get, isEmpty} from 'lodash'
 
 // Selectors
-import {getSaveableView} from 'src/timeMachine/selectors'
+import {getActiveTimeMachine, getSaveableView} from 'src/timeMachine/selectors'
 import {getOrg} from 'src/organizations/selectors'
 import {getAll} from 'src/resources/selectors'
 import {sortDashboardByName} from 'src/dashboards/selectors'
@@ -53,7 +53,7 @@ interface State {
 interface OwnProps {
   dismiss: () => void
 }
-type RouterProps = RouteComponentProps<{orgID: string}>
+type RouterProps = RouteComponentProps
 type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps & OwnProps & RouterProps
 
@@ -167,6 +167,7 @@ class SaveAsCellForm extends PureComponent<Props, State> {
       dismiss,
       orgID,
       history,
+      timeRange,
     } = this.props
     const {targetDashboardIDs} = this.state
 
@@ -188,7 +189,8 @@ class SaveAsCellForm extends PureComponent<Props, State> {
             orgID,
             newDashboardName,
             viewWithProps,
-            toRedirect
+            toRedirect,
+            timeRange
           )
           return
         }
@@ -198,7 +200,8 @@ class SaveAsCellForm extends PureComponent<Props, State> {
           selectedDashboard.id,
           viewWithProps,
           null,
-          toRedirect
+          toRedirect,
+          timeRange
         )
       })
       this.props.setActiveTimeMachine('de', initialStateHelper())
@@ -244,11 +247,12 @@ const mstp = (state: AppState) => {
   const view = getSaveableView(state)
   const org = getOrg(state)
   const dashboards = getAll<Dashboard>(state, ResourceType.Dashboards)
-
+  const timeRange = getActiveTimeMachine(state).timeRange
   return {
     dashboards: sortDashboardByName(dashboards),
     view,
     orgID: get(org, 'id', ''),
+    timeRange,
   }
 }
 

--- a/src/dataExplorer/components/SaveAsCellForm.tsx
+++ b/src/dataExplorer/components/SaveAsCellForm.tsx
@@ -177,8 +177,8 @@ class SaveAsCellForm extends PureComponent<Props, State> {
     const viewWithProps: View = {...view, name: cellName}
 
     let succeeded = false
-    const redirectHandler = (id: string): void =>
-      history.push(`/orgs/${orgID}/dashboards/${id}`)
+    const redirectHandler = (dashboardId: string): void =>
+      history.push(`/orgs/${orgID}/dashboards/${dashboardId}`)
 
     try {
       targetDashboardIDs.forEach((dashID, idx) => {

--- a/src/dataExplorer/components/SaveAsCellForm.tsx
+++ b/src/dataExplorer/components/SaveAsCellForm.tsx
@@ -176,7 +176,6 @@ class SaveAsCellForm extends PureComponent<Props, State> {
 
     const viewWithProps: View = {...view, name: cellName}
 
-    let succeeded = false
     const redirectHandler = (dashboardId: string): void =>
       history.push(`/orgs/${orgID}/dashboards/${dashboardId}`)
 
@@ -202,16 +201,12 @@ class SaveAsCellForm extends PureComponent<Props, State> {
           toRedirect
         )
       })
-      succeeded = true
+      this.props.setActiveTimeMachine('de', initialStateHelper())
     } catch (error) {
       console.error(error)
+      dismiss()
     } finally {
       this.resetForm()
-      if (succeeded) {
-        this.props.setTimeMachine('de', initialStateHelper())
-      } else {
-        dismiss()
-      }
     }
   }
 
@@ -261,7 +256,7 @@ const mdtp = {
   onGetDashboards: getDashboards,
   onCreateCellWithView: createCellWithView,
   onCreateDashboardWithView: createDashboardWithView,
-  setTimeMachine: setActiveTimeMachine,
+  setActiveTimeMachine,
   notify,
 }
 

--- a/src/dataExplorer/components/SaveAsCellForm.tsx
+++ b/src/dataExplorer/components/SaveAsCellForm.tsx
@@ -181,9 +181,9 @@ class SaveAsCellForm extends PureComponent<Props, State> {
       history.push(`/orgs/${orgID}/dashboards/${dashboardId}`)
 
     try {
-      targetDashboardIDs.forEach((dashID, idx) => {
+      targetDashboardIDs.forEach((dashID, i) => {
         const toRedirect =
-          idx === targetDashboardIDs.length - 1 ? redirectHandler : undefined
+          i === targetDashboardIDs.length - 1 ? redirectHandler : undefined
         if (dashID === DashboardTemplate.id) {
           onCreateDashboardWithView(
             orgID,

--- a/src/timeMachine/actions/index.ts
+++ b/src/timeMachine/actions/index.ts
@@ -1,6 +1,6 @@
 // Libraries
 import {Dispatch} from 'react'
-
+import {isEqual} from 'lodash'
 // Actions
 import {loadBuckets} from 'src/timeMachine/actions/queryBuilder'
 import {saveAndExecuteQueries} from 'src/timeMachine/actions/queries'
@@ -108,6 +108,7 @@ export type Action =
   | ReturnType<typeof toggleVisOptions>
   | ReturnType<typeof resetActiveQueryWithBuilder>
   | ReturnType<typeof setViewProperties>
+  | ReturnType<typeof setTimeMachineTimeRange>
 
 type ExternalActions =
   | ReturnType<typeof loadBuckets>
@@ -155,13 +156,22 @@ export const setName = (name: string): SetNameAction => ({
   payload: {name},
 })
 
+export const setTimeMachineTimeRange = (timeRange: TimeRange) =>
+  ({
+    type: 'SET_TIME_MACHINE_TIME_RANGE',
+    timeRange,
+  } as const)
+
 export const setTimeRange = (timeRange: TimeRange) => (dispatch, getState) => {
   const state = getState()
   const contextID = currentContext(state)
   const activeQuery = getActiveQuery(state)
 
-  dispatch(setDashboardTimeRange(contextID, timeRange))
-  dispatch(saveAndExecuteQueries())
+  if (!isEqual(timeRange, state.ranges[contextID])) {
+    dispatch(setDashboardTimeRange(contextID, timeRange))
+    dispatch(saveAndExecuteQueries())
+  }
+
   if (activeQuery.editMode === 'builder') {
     dispatch(reloadTagSelectors())
   }

--- a/src/timeMachine/components/Queries.tsx
+++ b/src/timeMachine/components/Queries.tsx
@@ -22,8 +22,11 @@ import {
 } from '@influxdata/clockface'
 
 // Actions
-import {setAutoRefresh} from 'src/timeMachine/actions'
-import {setTimeRange} from 'src/timeMachine/actions'
+import {
+  setAutoRefresh,
+  setTimeMachineTimeRange,
+  setTimeRange,
+} from 'src/timeMachine/actions'
 import {enableUpdatedTimeRangeInVEO} from 'src/shared/actions/app'
 
 // Utils
@@ -87,6 +90,7 @@ class TimeMachineQueries extends PureComponent<Props> {
       onEnableUpdatedTimeRangeInVEO,
       onSetAutoRefresh,
       onSetTimeRange,
+      setTimeMachineTimeRange,
       match: {
         params: {cellID, dashboardID, orgID},
       },
@@ -98,7 +102,7 @@ class TimeMachineQueries extends PureComponent<Props> {
       onEnableUpdatedTimeRangeInVEO()
     }
     onSetTimeRange(timeRange)
-
+    setTimeMachineTimeRange(timeRange)
     if (timeRange.type === 'custom') {
       onSetAutoRefresh({...autoRefresh, status: AutoRefreshStatus.Disabled})
       return
@@ -142,6 +146,7 @@ const mstp = (state: AppState) => {
 }
 
 const mdtp = {
+  setTimeMachineTimeRange,
   onSetTimeRange: setTimeRange,
   onEnableUpdatedTimeRangeInVEO: enableUpdatedTimeRangeInVEO,
   onSetAutoRefresh: setAutoRefresh,

--- a/src/timeMachine/reducers/index.ts
+++ b/src/timeMachine/reducers/index.ts
@@ -242,6 +242,12 @@ export const timeMachineReducer = (
   action: Action
 ): TimeMachineState => {
   switch (action.type) {
+    case 'SET_TIME_MACHINE_TIME_RANGE': {
+      return produce(state, draftState => {
+        draftState.timeRange = action.timeRange
+      })
+    }
+
     case 'SET_VIEW_NAME': {
       const {name} = action.payload
       const view = {...state.view, name}


### PR DESCRIPTION
Closes #617 

<!-- Describe your proposed changes here. -->
Under the changes proposed in this PR, saving a query as a dashboard cell will redirect to the dashboard with the cell after saving it. If multiple dashboards are chosen, it will navigate to the last dashboard saved to. When returning to the query builder, it will now be reset. 

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

