### PR TITLE
fix: no buckets when opening telegraf config modal error

### DIFF
--- a/src/dataLoaders/components/collectorsWizard/CollectorsStepSwitcher.tsx
+++ b/src/dataLoaders/components/collectorsWizard/CollectorsStepSwitcher.tsx
@@ -11,21 +11,19 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 // Types
 import {CollectorsStep} from 'src/types/dataLoaders'
 import {CollectorsStepProps} from 'src/dataLoaders/components/collectorsWizard/CollectorsWizard'
-import {Bucket} from 'src/types'
 
 interface Props {
   stepProps: CollectorsStepProps
-  buckets: Bucket[]
 }
 
 @ErrorHandling
 class StepSwitcher extends PureComponent<Props> {
   public render() {
-    const {stepProps, buckets} = this.props
+    const {stepProps} = this.props
 
     switch (stepProps.currentStepIndex) {
       case CollectorsStep.Select:
-        return <SelectCollectorsStep {...stepProps} buckets={buckets} />
+        return <SelectCollectorsStep {...stepProps} />
       case CollectorsStep.Configure:
         return <PluginConfigSwitcher />
       case CollectorsStep.Verify:

--- a/src/dataLoaders/components/collectorsWizard/CollectorsWizard.tsx
+++ b/src/dataLoaders/components/collectorsWizard/CollectorsWizard.tsx
@@ -64,8 +64,6 @@ class CollectorsWizard extends PureComponent<Props> {
   }
 
   public render() {
-    const {buckets} = this.props
-
     return (
       <Overlay visible={true}>
         <Overlay.Container maxWidth={1200}>
@@ -74,10 +72,7 @@ class CollectorsWizard extends PureComponent<Props> {
             onDismiss={this.handleDismiss}
           />
           <Overlay.Body className="data-loading--overlay">
-            <CollectorsStepSwitcher
-              stepProps={this.stepProps}
-              buckets={buckets}
-            />
+            <CollectorsStepSwitcher stepProps={this.stepProps} />
           </Overlay.Body>
         </Overlay.Container>
       </Overlay>

--- a/src/dataLoaders/components/collectorsWizard/select/StreamingSelector.test.tsx
+++ b/src/dataLoaders/components/collectorsWizard/select/StreamingSelector.test.tsx
@@ -50,4 +50,12 @@ describe('Onboarding.Components.SelectionStep.StreamingSelector', () => {
       expect(cards.length).toBe(1)
     })
   })
+
+  describe('buckets selection list', () => {
+    it('can handle if bucket prop is initially unset', async () => {
+      setup({bucket: ''})
+      const cards = await screen.getAllByTestId('square-grid--card')
+      expect(cards.length).toBe(PLUGIN_BUNDLE_OPTIONS.length)
+    })
+  })
 })

--- a/src/telegrafs/components/Collectors.test.tsx
+++ b/src/telegrafs/components/Collectors.test.tsx
@@ -1,0 +1,41 @@
+// Libraries
+import React from 'react'
+import {screen} from '@testing-library/react'
+
+// Components
+import {Collectors} from 'src/telegrafs/components/Collectors'
+
+import {renderWithReduxAndRouter} from 'src/mockState'
+import {withRouterProps} from 'mocks/dummyData'
+
+jest.mock('src/resources/components/GetResources')
+
+const setup = (override = {}) => {
+  const props = {
+    ...withRouterProps,
+    hasTelegrafs: false,
+    orgName: 'orgName',
+    buckets: [],
+    onSetTelegrafConfigID: jest.fn(),
+    onSetTelegrafConfigName: jest.fn(),
+    onClearDataLoaders: jest.fn(),
+    onUpdateTelegraf: jest.fn(),
+    onDeleteTelegraf: jest.fn(),
+    ...override,
+  }
+
+  renderWithReduxAndRouter(<Collectors {...props} />)
+}
+
+describe('Collectors page', () => {
+  it('does not allow clicking on create configuration button if buckets are empty', async () => {
+    setup()
+
+    const createConfigButton = await screen.getAllByTestId(
+      'create-telegraf-configuration-button'
+    )
+
+    expect(createConfigButton[0]).toBeDisabled()
+    expect(createConfigButton[1]).toBeDisabled()
+  })
+})

--- a/src/telegrafs/components/Collectors.tsx
+++ b/src/telegrafs/components/Collectors.tsx
@@ -58,7 +58,7 @@ interface State {
 }
 
 @ErrorHandling
-class Collectors extends PureComponent<Props, State> {
+export class Collectors extends PureComponent<Props, State> {
   constructor(props: Props) {
     super(props)
 
@@ -187,6 +187,7 @@ class Collectors extends PureComponent<Props, State> {
         onClick={this.handleAddCollector}
         status={status}
         titleText={titleText}
+        testID="create-telegraf-configuration-button"
       />
     )
   }


### PR DESCRIPTION
Closes #20727

<!-- Describe your proposed changes here. -->
This PR addresses the bug in the ticket above by removing some prop drilling and localizing where buckets are pulled from. Also adds some tests. 
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

