### PR TITLE
fix: reenable strings for single stat

### DIFF
--- a/src/visualization/types/SingleStat/view.tsx
+++ b/src/visualization/types/SingleStat/view.tsx
@@ -20,7 +20,7 @@ const SingleStat: FC<Props> = ({properties, result}) => {
   const {prefix, suffix, colors, decimalPlaces} = properties
 
   return (
-    <LatestValueTransform table={result.table} allowString={false}>
+    <LatestValueTransform table={result.table} allowString={true}>
       {latestValue => {
         const {
           bgColor: backgroundColor,

--- a/src/visualization/types/SingleStatWithLine/view.tsx
+++ b/src/visualization/types/SingleStatWithLine/view.tsx
@@ -189,7 +189,7 @@ const SingleStatWithLine: FC<Props> = ({
         ],
       }}
     >
-      <LatestValueTransform table={result.table} allowString={false}>
+      <LatestValueTransform table={result.table} allowString={true}>
         {latestValue => {
           const {
             bgColor: backgroundColor,


### PR DESCRIPTION
hotfix for single stat graphs not rendering on prod.

companion to #648 
