### PR TITLE
test: e2e tests now pass in KinD environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run:
           name: Grab compose files
-          command: git clone git@github.com:influxdata/monitor-ci.git
+          command: git clone --branch genehynson/cypress_bump git@github.com:influxdata/monitor-ci.git
       - run:
           name: Copy over the testing variables
           command: cp ./monitor-ci/env.testing ./monitor-ci/.env
@@ -46,7 +46,7 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run:
           name: Grab compose files
-          command: git clone git@github.com:influxdata/monitor-ci.git
+          command: git clone --branch genehynson/cypress_bump git@github.com:influxdata/monitor-ci.git
       - run:
           name: Copy over the testing variables
           command: cp ./monitor-ci/env.testing.oss ./monitor-ci/.env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run:
           name: Grab compose files
-          command: git clone --branch genehynson/cypress_bump git@github.com:influxdata/monitor-ci.git
+          command: git clone git@github.com:influxdata/monitor-ci.git
       - run:
           name: Copy over the testing variables
           command: cp ./monitor-ci/env.testing ./monitor-ci/.env
@@ -46,7 +46,7 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run:
           name: Grab compose files
-          command: git clone --branch genehynson/cypress_bump git@github.com:influxdata/monitor-ci.git
+          command: git clone git@github.com:influxdata/monitor-ci.git
       - run:
           name: Copy over the testing variables
           command: cp ./monitor-ci/env.testing.oss ./monitor-ci/.env

--- a/cypress/e2e/cloud/buckets.test.ts
+++ b/cypress/e2e/cloud/buckets.test.ts
@@ -8,6 +8,7 @@ describe('Buckets', () => {
       cy.get('@org').then(({id}: Organization) =>
         cy.fixture('routes').then(({orgs, buckets}) => {
           cy.visit(`${orgs}/${id}${buckets}`)
+          cy.getByTestID('tree-nav')
         })
       )
     })

--- a/cypress/e2e/cloud/communityTemplates.test.ts
+++ b/cypress/e2e/cloud/communityTemplates.test.ts
@@ -8,6 +8,7 @@ describe('Community Templates', () => {
       cy.get('@org').then(({id}: Organization) =>
         cy.fixture('routes').then(({orgs}) => {
           cy.visit(`${orgs}/${id}/settings/templates`)
+          cy.getByTestID('tree-nav')
         })
       )
     })

--- a/cypress/e2e/cloud/dashboardsView.test.ts
+++ b/cypress/e2e/cloud/dashboardsView.test.ts
@@ -17,6 +17,7 @@ describe('Dashboard', () => {
       cy.createDashboard(orgID).then(({body}) => {
         cy.fixture('routes').then(({orgs}) => {
           cy.visit(`${orgs}/${orgID}/dashboards/${body.id}`)
+          cy.getByTestID('tree-nav')
         })
       })
     })

--- a/cypress/e2e/cloud/dashboardsView.test.ts
+++ b/cypress/e2e/cloud/dashboardsView.test.ts
@@ -6,6 +6,7 @@ describe('Dashboard', () => {
       cy.fixture('routes').then(({orgs}) => {
         cy.get('@org').then(({id: orgID}: any) => {
           cy.visit(`${orgs}/${orgID}/dashboards-list`)
+          cy.getByTestID('tree-nav')
         })
       })
     )

--- a/cypress/e2e/cloud/geoOptions.test.ts
+++ b/cypress/e2e/cloud/geoOptions.test.ts
@@ -8,6 +8,7 @@ describe('DataExplorer - Geo Map Type Customization Options', () => {
         cy.createMapVariable(id)
         cy.fixture('routes').then(({orgs, explorer}) => {
           cy.visit(`${orgs}/${id}${explorer}`)
+          cy.getByTestID('tree-nav')
         })
       })
     })

--- a/cypress/e2e/oss/buckets.test.ts
+++ b/cypress/e2e/oss/buckets.test.ts
@@ -8,6 +8,7 @@ describe('Buckets', () => {
       cy.get('@org').then(({id}: Organization) =>
         cy.fixture('routes').then(({orgs, buckets}) => {
           cy.visit(`${orgs}/${id}${buckets}`)
+          cy.getByTestID('tree-nav')
         })
       )
     })

--- a/cypress/e2e/oss/dashboardsView.test.ts
+++ b/cypress/e2e/oss/dashboardsView.test.ts
@@ -17,6 +17,7 @@ describe('Dashboard', () => {
       cy.createDashboard(orgID).then(({body}) => {
         cy.fixture('routes').then(({orgs}) => {
           cy.visit(`${orgs}/${orgID}/dashboards/${body.id}`)
+          cy.getByTestID('tree-nav')
         })
       })
     })

--- a/cypress/e2e/oss/dashboardsView.test.ts
+++ b/cypress/e2e/oss/dashboardsView.test.ts
@@ -6,6 +6,7 @@ describe('Dashboard', () => {
       cy.fixture('routes').then(({orgs}) => {
         cy.get('@org').then(({id: orgID}: any) => {
           cy.visit(`${orgs}/${orgID}/dashboards-list`)
+          cy.getByTestID('tree-nav')
         })
       })
     )

--- a/cypress/e2e/oss/scrapers.test.ts
+++ b/cypress/e2e/oss/scrapers.test.ts
@@ -11,6 +11,7 @@ describe('Scrapers', () => {
       cy.get('@org').then(({id}: Organization) =>
         cy.fixture('routes').then(({orgs}) => {
           cy.visit(`${orgs}/${id}/load-data/scrapers`)
+          cy.getByTestID('tree-nav')
         })
       )
     })
@@ -74,6 +75,7 @@ describe('Scrapers', () => {
         cy.fixture('routes').then(({orgs}) => {
           cy.get<Organization>('@org').then(({id}: Organization) => {
             cy.visit(`${orgs}/${id}/load-data/scrapers`)
+            cy.getByTestID('tree-nav')
           })
         })
         cy.get('[data-testid="resource-list--body"]', {timeout: PAGE_LOAD_SLA})

--- a/cypress/e2e/shared/buckets.test.ts
+++ b/cypress/e2e/shared/buckets.test.ts
@@ -241,6 +241,7 @@ describe('Buckets', () => {
               'contain',
               `${orgs}/${orgID}${buckets}/${bucketID}/edit`
             )
+            cy.getByTestID('tree-nav')
           })
           cy.getByTestID(`overlay`).should('exist')
         })

--- a/cypress/e2e/shared/checks.test.ts
+++ b/cypress/e2e/shared/checks.test.ts
@@ -19,6 +19,7 @@ describe('Checks', () => {
         ])
         cy.fixture('routes').then(({orgs, alerting}) => {
           cy.visit(`${orgs}/${orgID}${alerting}`)
+          cy.getByTestID('tree-nav')
         })
       })
     })

--- a/cypress/e2e/shared/dashboardsIndex.test.ts
+++ b/cypress/e2e/shared/dashboardsIndex.test.ts
@@ -51,6 +51,7 @@ describe('Dashboards', () => {
         cy.fixture('routes').then(({orgs}) => {
           cy.get('@org').then(({id}: Organization) => {
             cy.visit(`${orgs}/${id}/dashboards-list`)
+            cy.getByTestID('tree-nav')
           })
         })
       })
@@ -83,6 +84,7 @@ describe('Dashboards', () => {
     cy.fixture('routes').then(({orgs}) => {
       cy.get('@org').then(({id}: Organization) => {
         cy.visit(`${orgs}/${id}/dashboards-list`)
+        cy.getByTestID('tree-nav')
       })
     })
 
@@ -158,6 +160,7 @@ describe('Dashboards', () => {
       cy.fixture('routes').then(({orgs}) => {
         cy.get('@org').then(({id}: Organization) => {
           cy.visit(`${orgs}/${id}/dashboards-list`)
+          cy.getByTestID('tree-nav')
         })
       })
     }
@@ -264,6 +267,7 @@ describe('Dashboards', () => {
       cy.fixture('routes').then(({orgs}) => {
         cy.get('@org').then(({id}: Organization) => {
           cy.visit(`${orgs}/${id}/dashboards-list`)
+          cy.getByTestID('tree-nav')
         })
       })
 

--- a/cypress/e2e/shared/dashboardsIndex.test.ts
+++ b/cypress/e2e/shared/dashboardsIndex.test.ts
@@ -343,6 +343,7 @@ describe('Dashboards', () => {
 
         cy.get('@org').then(({id}: Organization) => {
           cy.createLabel(labelName, id).then(() => {
+            cy.reload()
             cy.getByTestID(`inline-labels--add`)
               .first()
               .click()

--- a/cypress/e2e/shared/dashboardsIndex.test.ts
+++ b/cypress/e2e/shared/dashboardsIndex.test.ts
@@ -13,6 +13,7 @@ describe('Dashboards', () => {
       cy.fixture('routes').then(({orgs}) => {
         cy.get('@org').then(({id}: Organization) => {
           cy.visit(`${orgs}/${id}/dashboards-list`)
+          cy.getByTestID('tree-nav')
         })
       })
     )
@@ -247,6 +248,7 @@ describe('Dashboards', () => {
       cy.fixture('routes').then(({orgs}) => {
         cy.get('@org').then(({id}: Organization) => {
           cy.visit(`${orgs}/${id}/dashboards-list`)
+          cy.getByTestID('tree-nav')
         })
       })
     })

--- a/cypress/e2e/shared/dashboardsView.test.ts
+++ b/cypress/e2e/shared/dashboardsView.test.ts
@@ -9,6 +9,7 @@ describe('Dashboard', () => {
       cy.fixture('routes').then(({orgs}) => {
         cy.get('@org').then(({id: orgID}: Organization) => {
           cy.visit(`${orgs}/${orgID}/dashboards-list`)
+          cy.getByTestID('tree-nav')
         })
       })
     )

--- a/cypress/e2e/shared/dashboardsView.test.ts
+++ b/cypress/e2e/shared/dashboardsView.test.ts
@@ -20,6 +20,7 @@ describe('Dashboard', () => {
       cy.createDashboard(orgID).then(({body}) => {
         cy.fixture('routes').then(({orgs}) => {
           cy.visit(`${orgs}/${orgID}/dashboards/${body.id}`)
+          cy.getByTestID('tree-nav')
         })
       })
     })
@@ -34,6 +35,7 @@ describe('Dashboard', () => {
     cy.fixture('routes').then(({orgs}) => {
       cy.get('@org').then(({id: orgID}: Organization) => {
         cy.visit(`${orgs}/${orgID}/dashboards-list`)
+        cy.getByTestID('tree-nav')
       })
     })
 
@@ -45,6 +47,7 @@ describe('Dashboard', () => {
       cy.createDashboard(orgID).then(({body}) => {
         cy.fixture('routes').then(({orgs}) => {
           cy.visit(`${orgs}/${orgID}/dashboards/${body.id}`)
+          cy.getByTestID('tree-nav')
         })
       })
     })
@@ -211,6 +214,7 @@ describe('Dashboard', () => {
       cy.createDashboard(orgID).then(({body}) => {
         cy.fixture('routes').then(({orgs}) => {
           cy.visit(`${orgs}/${orgID}/dashboards/${body.id}`)
+          cy.getByTestID('tree-nav')
         })
       })
     })
@@ -300,6 +304,7 @@ describe('Dashboard', () => {
             cy.createMapVariable(orgID).then(() => {
               cy.fixture('routes').then(({orgs}) => {
                 cy.visit(`${orgs}/${orgID}/dashboards/${dashboard.id}`)
+                cy.getByTestID('tree-nav')
               })
               // add cell with variable in its query
               cy.getByTestID('add-cell--button').click()
@@ -563,6 +568,7 @@ describe('Dashboard', () => {
 
             cy.fixture('routes').then(({orgs}) => {
               cy.visit(`${orgs}/${orgID}/dashboards/${dashboard.id}`)
+              cy.getByTestID('tree-nav')
             })
 
             cy.getByTestID('add-cell--button').click()
@@ -752,6 +758,7 @@ describe('Dashboard', () => {
       cy.createDashWithViewAndVar(orgID).then(() => {
         cy.fixture('routes').then(({orgs}) => {
           cy.visit(`${orgs}/${orgID}/dashboards-list`)
+          cy.getByTestID('tree-nav')
           cy.getByTestID('dashboard-card--name').click()
           cy.get('.cell--view').should('have.length', 1)
         })
@@ -764,6 +771,7 @@ describe('Dashboard', () => {
       cy.createDashboard(orgID).then(({body}) => {
         cy.fixture('routes').then(({orgs}) => {
           cy.visit(`${orgs}/${orgID}/dashboards/${body.id}`)
+          cy.getByTestID('tree-nav')
         })
       })
     })
@@ -801,6 +809,7 @@ describe('Dashboard', () => {
       cy.createDashboard(orgID).then(({body}) => {
         cy.fixture('routes').then(({orgs}) => {
           cy.visit(`${orgs}/${orgID}/dashboards/${body.id}`)
+          cy.getByTestID('tree-nav')
         })
       })
     })
@@ -847,6 +856,7 @@ describe('Dashboard', () => {
       cy.createDashboard(orgID).then(({body}) => {
         cy.fixture('routes').then(({orgs}) => {
           cy.visit(`${orgs}/${orgID}/dashboards/${body.id}`)
+          cy.getByTestID('tree-nav')
         })
       })
     })

--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -109,6 +109,7 @@ describe('DataExplorer', () => {
         cy.createMapVariable(id)
         cy.fixture('routes').then(({orgs, explorer}) => {
           cy.visit(`${orgs}/${id}${explorer}`)
+          cy.getByTestID('tree-nav')
         })
       })
     })

--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -1178,6 +1178,7 @@ describe('DataExplorer', () => {
             dashboardNames.forEach((_, i) => {
               cy.get(`@dasboard${i}-id`).then(id => {
                 cy.visit(`${orgs}/${orgID}/dashboards/${id}`)
+                cy.getByTestID('tree-nav')
                 cy.getByTestID(`cell ${cellName}`).should('exist')
               })
             })
@@ -1204,6 +1205,7 @@ describe('DataExplorer', () => {
         cy.get('@org').then(({id: orgID}: Organization) => {
           cy.fixture('routes').then(({orgs}) => {
             cy.visit(`${orgs}/${orgID}/dashboards/`)
+            cy.getByTestID('tree-nav')
             cy.getByTestID('dashboard-card--name')
               .contains(dashboardCreateName)
               .should('exist')
@@ -1247,6 +1249,7 @@ describe('DataExplorer', () => {
         cy.fixture('routes').then(({orgs}) => {
           cy.get('@org').then(({id}: Organization) => {
             cy.visit(`${orgs}/${id}/tasks`)
+            cy.getByTestID('tree-nav')
           })
         })
       }
@@ -1340,6 +1343,7 @@ describe('DataExplorer', () => {
         cy.fixture('routes').then(({orgs}) => {
           cy.get('@org').then(({id}: Organization) => {
             cy.visit(`${orgs}/${id}/settings/variables`)
+            cy.getByTestID('tree-nav')
           })
         })
       }

--- a/cypress/e2e/shared/labels.test.ts
+++ b/cypress/e2e/shared/labels.test.ts
@@ -8,6 +8,7 @@ describe('labels', () => {
       cy.get('@org').then(({id}: Organization) =>
         cy.fixture('routes').then(({orgs}) => {
           cy.visit(`${orgs}/${id}/settings/labels`)
+          cy.getByTestID('tree-nav')
         })
       )
     })
@@ -175,6 +176,7 @@ describe('labels', () => {
 
       cy.get<Organization>('@org').then(({id}) => {
         cy.visit(`orgs/${id}/settings/labels`)
+        cy.getByTestID('tree-nav')
       })
     })
 

--- a/cypress/e2e/shared/labels.test.ts
+++ b/cypress/e2e/shared/labels.test.ts
@@ -432,7 +432,9 @@ describe('labels', () => {
       })
     })
 
-    it('can delete a label', () => {
+    it.only('can delete a label', () => {
+      cy.reload()
+
       cy.getByTestID('label-card').should('have.length', 1)
       cy.getByTestID('empty-state').should('not.exist')
 

--- a/cypress/e2e/shared/labels.test.ts
+++ b/cypress/e2e/shared/labels.test.ts
@@ -432,7 +432,7 @@ describe('labels', () => {
       })
     })
 
-    it.only('can delete a label', () => {
+    it('can delete a label', () => {
       cy.reload()
 
       cy.getByTestID('label-card').should('have.length', 1)

--- a/cypress/e2e/shared/loadDataSources.test.ts
+++ b/cypress/e2e/shared/loadDataSources.test.ts
@@ -8,6 +8,7 @@ describe('Load Data Sources', () => {
       cy.get('@org').then(({id}: Organization) =>
         cy.fixture('routes').then(({orgs}) => {
           cy.visit(`${orgs}/${id}/load-data/sources`)
+          cy.getByTestID('tree-nav')
         })
       )
     })

--- a/cypress/e2e/shared/notificationEndpoints.test.ts
+++ b/cypress/e2e/shared/notificationEndpoints.test.ts
@@ -26,6 +26,7 @@ describe('Notification Endpoints', () => {
             cy.wrap(body).as('endpoint')
           })
           cy.visit(`${orgs}/${id}${alerting}`)
+          cy.getByTestID('tree-nav')
 
           // User can only see all panels at once on large screens
           cy.getByTestID('alerting-tab--endpoints').click({force: true})

--- a/cypress/e2e/shared/notificationRules.test.ts
+++ b/cypress/e2e/shared/notificationRules.test.ts
@@ -25,6 +25,7 @@ describe('NotificationRules', () => {
         // visit the alerting index
         cy.fixture('routes').then(({orgs, alerting}) => {
           cy.visit(`${orgs}/${id}${alerting}`)
+          cy.getByTestID('tree-nav')
         })
       })
     })

--- a/cypress/e2e/shared/queryBuilder.test.ts
+++ b/cypress/e2e/shared/queryBuilder.test.ts
@@ -94,6 +94,7 @@ describe('The Query Builder', () => {
     it('when it creates a query, the query has an aggregate window, clicking around aggregate window selections work', () => {
       cy.get('@org').then((org: Organization) => {
         cy.visit(`orgs/${org.id}/data-explorer`)
+        cy.getByTestID('tree-nav')
       })
 
       cy.contains('mem').click('right') // users sometimes click in random spots

--- a/cypress/e2e/shared/queryBuilder.test.ts
+++ b/cypress/e2e/shared/queryBuilder.test.ts
@@ -32,6 +32,7 @@ describe('The Query Builder', () => {
     it('creates a query, edits it to add another field, then views its results with pride and satisfaction', () => {
       cy.get('@org').then((org: Organization) => {
         cy.visit(`orgs/${org.id}/data-explorer`)
+        cy.getByTestID('tree-nav')
       })
 
       cy.contains('mem').click('right') // users sometimes click in random spots
@@ -134,6 +135,7 @@ describe('The Query Builder', () => {
     it('can create a bucket from the buckets list', () => {
       cy.get('@org').then((org: Organization) => {
         cy.visit(`orgs/${org.id}/data-explorer`)
+        cy.getByTestID('tree-nav')
       })
 
       const newBucketName = '٩(｡•́‿•̀｡)۶'
@@ -156,6 +158,7 @@ describe('The Query Builder', () => {
     it('creates a query that has a group() function in it', () => {
       cy.get('@org').then((org: Organization) => {
         cy.visit(`orgs/${org.id}/data-explorer`)
+        cy.getByTestID('tree-nav')
       })
 
       cy.contains('mem').click('left')
@@ -206,6 +209,7 @@ describe('The Query Builder', () => {
     it("creates a query, edits the query, edits the cell's default name, edits it again, submits with the keyboard, then chills", () => {
       cy.get<ResourceIDs>('@resourceIDs').then(({orgID, dbID, cellID}) => {
         cy.visit(`orgs/${orgID}/dashboards/${dbID}/cells/${cellID}/edit`)
+        cy.getByTestID('tree-nav')
       })
 
       // build query
@@ -226,6 +230,7 @@ describe('The Query Builder', () => {
 
       cy.get<ResourceIDs>('@resourceIDs').then(({orgID, dbID, cellID}) => {
         cy.visit(`orgs/${orgID}/dashboards/${dbID}/cells/${cellID}/edit`)
+        cy.getByTestID('tree-nav')
       })
 
       cy.getByTestID('giraffe-layer-line').should('exist')

--- a/cypress/e2e/shared/tasks.test.ts
+++ b/cypress/e2e/shared/tasks.test.ts
@@ -435,6 +435,7 @@ http.post(
       cy.fixture('routes').then(({orgs}) => {
         cy.get('@org').then(({id}: Organization) => {
           cy.visit(`${orgs}/${id}/tasks`)
+          cy.getByTestID('tree-nav')
         })
       })
     })
@@ -551,6 +552,7 @@ http.post(
       cy.fixture('routes').then(({orgs}) => {
         cy.get('@org').then(({id}: Organization) => {
           cy.visit(`${orgs}/${id}/tasks`)
+          cy.getByTestID('tree-nav')
         })
       })
     })

--- a/cypress/e2e/shared/tasks.test.ts
+++ b/cypress/e2e/shared/tasks.test.ts
@@ -21,6 +21,7 @@ describe('Tasks', () => {
     cy.fixture('routes').then(({orgs}) => {
       cy.get('@org').then(({id}: Organization) => {
         cy.visit(`${orgs}/${id}/tasks`)
+        cy.getByTestID('tree-nav')
       })
     })
   })

--- a/cypress/e2e/shared/telegrafs.test.ts
+++ b/cypress/e2e/shared/telegrafs.test.ts
@@ -11,6 +11,7 @@ describe('Collectors', () => {
       cy.get('@org').then(({id}: Organization) =>
         cy.fixture('routes').then(({orgs, telegrafs}) => {
           cy.visit(`${orgs}/${id}${telegrafs}`)
+          cy.getByTestID('tree-nav')
         })
       )
     })

--- a/cypress/e2e/shared/tokens.test.ts
+++ b/cypress/e2e/shared/tokens.test.ts
@@ -49,6 +49,7 @@ describe('tokens', () => {
 
           cy.fixture('routes').then(({orgs}) => {
             cy.visit(`${orgs}/${id}/load-data/tokens`)
+            cy.getByTestID('tree-nav')
           })
           cy.get('[data-testid="resource-list"]', {timeout: PAGE_LOAD_SLA})
         })

--- a/cypress/e2e/shared/tokens.test.ts
+++ b/cypress/e2e/shared/tokens.test.ts
@@ -20,7 +20,7 @@ describe('tokens', () => {
     cy.signin().then(() => {
       cy.get('@org').then(({id}: Organization) => {
         // check out array.reduce for the nested calls here
-        cy.request('api/v2/authorizations').then(resp => {
+        cy.request(`api/v2/authorizations?orgID=${id}`).then(resp => {
           expect(resp.body).to.exist
           authData.push({
             description: resp.body.authorizations[0].description,

--- a/cypress/e2e/shared/tokens.test.ts
+++ b/cypress/e2e/shared/tokens.test.ts
@@ -30,7 +30,7 @@ describe('tokens', () => {
 
           cy.fixture('tokens.json').then(({tokens}) => {
             tokens.forEach(token => {
-              token.permissions.forEach(p => p.resource.orgID = id)
+              token.permissions.forEach(p => (p.resource.orgID = id))
               cy.createToken(
                 id,
                 token.description,

--- a/cypress/e2e/shared/tokens.test.ts
+++ b/cypress/e2e/shared/tokens.test.ts
@@ -30,6 +30,7 @@ describe('tokens', () => {
 
           cy.fixture('tokens.json').then(({tokens}) => {
             tokens.forEach(token => {
+              token.permissions.forEach(p => p.resource.orgID = id)
               cy.createToken(
                 id,
                 token.description,

--- a/cypress/e2e/shared/tokens.test.ts
+++ b/cypress/e2e/shared/tokens.test.ts
@@ -20,7 +20,7 @@ describe('tokens', () => {
     cy.signin().then(() => {
       cy.get('@org').then(({id}: Organization) => {
         // check out array.reduce for the nested calls here
-        cy.request(`api/v2/authorizations?orgID=${id}`).then(resp => {
+        cy.request('api/v2/authorizations').then(resp => {
           expect(resp.body).to.exist
           authData.push({
             description: resp.body.authorizations[0].description,

--- a/cypress/e2e/shared/variables.test.ts
+++ b/cypress/e2e/shared/variables.test.ts
@@ -8,6 +8,7 @@ describe('Variables', () => {
       cy.get('@org').then(({id}: Organization) => {
         cy.createQueryVariable(id)
         cy.visit(`orgs/${id}/settings/variables`)
+        cy.getByTestID('tree-nav')
       })
     })
 

--- a/cypress/fixtures/tokens.json
+++ b/cypress/fixtures/tokens.json
@@ -4,7 +4,6 @@
       "description":"token test ॐ",
       "status":"active",
       "permissions":[
-        {"action":"write","resource":{"type":"documents"}},
         {"action":"write","resource":{"type":"dashboards"}},
         {"action":"write","resource":{"type":"buckets"}}
       ]
@@ -13,7 +12,6 @@
       "description":"token test 02",
       "status":"inactive",
       "permissions":[
-        {"action":"write","resource":{"type":"documents"}},
         {"action":"write","resource":{"type":"dashboards"}},
         {"action":"write","resource":{"type":"buckets"}}
       ]
@@ -22,7 +20,6 @@
       "description":"token test 03",
       "status":"inactive",
       "permissions":[
-        {"action":"read","resource":{"type":"documents"}},
         {"action":"read","resource":{"type":"dashboards"}},
         {"action":"read","resource":{"type":"buckets"}}
       ]

--- a/cypress/fixtures/tokens.json
+++ b/cypress/fixtures/tokens.json
@@ -4,7 +4,6 @@
       "description":"token test ॐ",
       "status":"active",
       "permissions":[
-        {"action":"write","resource":{"type":"views"}},
         {"action":"write","resource":{"type":"documents"}},
         {"action":"write","resource":{"type":"dashboards"}},
         {"action":"write","resource":{"type":"buckets"}}
@@ -14,7 +13,6 @@
       "description":"token test 02",
       "status":"inactive",
       "permissions":[
-        {"action":"write","resource":{"type":"views"}},
         {"action":"write","resource":{"type":"documents"}},
         {"action":"write","resource":{"type":"dashboards"}},
         {"action":"write","resource":{"type":"buckets"}}
@@ -24,7 +22,6 @@
       "description":"token test 03",
       "status":"inactive",
       "permissions":[
-        {"action":"read","resource":{"type":"views"}},
         {"action":"read","resource":{"type":"documents"}},
         {"action":"read","resource":{"type":"dashboards"}},
         {"action":"read","resource":{"type":"buckets"}}

--- a/cypress/fixtures/tokens.json
+++ b/cypress/fixtures/tokens.json
@@ -4,6 +4,8 @@
       "description":"token test ॐ",
       "status":"active",
       "permissions":[
+        {"action":"write","resource":{"type":"views"}},
+        {"action":"write","resource":{"type":"documents"}},
         {"action":"write","resource":{"type":"dashboards"}},
         {"action":"write","resource":{"type":"buckets"}}
       ]
@@ -12,6 +14,8 @@
       "description":"token test 02",
       "status":"inactive",
       "permissions":[
+        {"action":"write","resource":{"type":"views"}},
+        {"action":"write","resource":{"type":"documents"}},
         {"action":"write","resource":{"type":"dashboards"}},
         {"action":"write","resource":{"type":"buckets"}}
       ]
@@ -20,6 +24,8 @@
       "description":"token test 03",
       "status":"inactive",
       "permissions":[
+        {"action":"read","resource":{"type":"views"}},
+        {"action":"read","resource":{"type":"documents"}},
         {"action":"read","resource":{"type":"dashboards"}},
         {"action":"read","resource":{"type":"buckets"}}
       ]

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -31,6 +31,7 @@ export const signin = (): Cypress.Chainable<Cypress.Response> => {
                 defaultUser
               )
               cy.get('#login').type(username)
+              cy.wrap(username).as('defaultUser')
             })
           })
           .then(() => {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "tsc:cypress": "tsc -p ./cypress/tsconfig.json --noEmit --pretty --skipLibCheck",
     "cy": "CYPRESS_baseUrl=http://localhost:9999 cypress open",
     "cy:dev": "source ../monitor-ci/.env && CYPRESS_baseUrl=https://twodotoh.a.influxcloud.dev.local cypress open --config testFiles='{cloud,shared}/**/*.*'",
-    "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_baseUrl=hhttps://twodotoh.a.influxcloud.dev.local cypress open --config testFiles='{oss,shared}/**/*.*'",
+    "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_baseUrl=https://twodotoh.a.influxcloud.dev.local cypress open --config testFiles='{oss,shared}/**/*.*'",
     "generate": "oats https://raw.githubusercontent.com/influxdata/influxdb/master/http/swagger.yml > ./src/client/generatedRoutes.ts && yarn unity && yarn flows",
     "unity": "oats ./src/client/swagger/unity.yml > ./src/client/unityRoutes.ts",
     "flows": "oats ./src/client/swagger/flows.yml > ./src/client/flowsRoutes.ts"

--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
     "tsc:watch": "yarn tsc --watch",
     "tsc:cypress": "tsc -p ./cypress/tsconfig.json --noEmit --pretty --skipLibCheck",
     "cy": "CYPRESS_baseUrl=http://localhost:9999 cypress open",
-    "cy:dev": "source ../monitor-ci/.env && CYPRESS_baseUrl=https://kubernetes.docker.internal:$PORT_HTTPS cypress open --config testFiles='{cloud,shared}/**/*.*'",
-    "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_baseUrl=https://kubernetes.docker.internal:$PORT_HTTPS cypress open --config testFiles='{oss,shared}/**/*.*'",
+    "cy:dev": "source ../monitor-ci/.env && CYPRESS_baseUrl=https://twodotoh.a.influxcloud.dev.local cypress open --config testFiles='{cloud,shared}/**/*.*'",
+    "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_baseUrl=hhttps://twodotoh.a.influxcloud.dev.local cypress open --config testFiles='{oss,shared}/**/*.*'",
     "generate": "oats https://raw.githubusercontent.com/influxdata/influxdb/master/http/swagger.yml > ./src/client/generatedRoutes.ts && yarn unity && yarn flows",
     "unity": "oats ./src/client/swagger/unity.yml > ./src/client/unityRoutes.ts",
     "flows": "oats ./src/client/swagger/flows.yml > ./src/client/flowsRoutes.ts"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "start:dev": "webpack-dev-server --config ./webpack.dev.ts --progress false",
     "start:dev-cloud": "cross-env CLOUD_LOGOUT_URL=http://localhost:8080/api/v2/signout CLOUD_URL=http://localhost:4000 webpack-dev-server --config ./webpack.dev.ts",
     "start:docker": "yarn generate && yarn build:vendor && yarn run start:dev",
+    "start:kind": "yarn build:vendor && NODE_ENV=development UI_SHA=local_dev_mode BASE_PATH=/ API_BASE_PATH=/ PORT=8080 PUBLIC=https://twodotoh.a.influxcloud.dev.local/ CLOUD_URL=/auth yarn start",
     "build": "yarn install --silent && yarn build:ci",
     "build:ci": "yarn generate && yarn build:vendor && webpack --config webpack.prod.ts --bail",
     "build:fast": "webpack --config webpack.fast.ts --bail",
@@ -47,8 +48,8 @@
     "tsc:watch": "yarn tsc --watch",
     "tsc:cypress": "tsc -p ./cypress/tsconfig.json --noEmit --pretty --skipLibCheck",
     "cy": "CYPRESS_baseUrl=http://localhost:9999 cypress open",
-    "cy:dev": "source ../monitor-ci/.env && CYPRESS_baseUrl=https://twodotoh.a.influxcloud.dev.local cypress open --config testFiles='{cloud,shared}/**/*.*'",
-    "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_baseUrl=https://twodotoh.a.influxcloud.dev.local cypress open --config testFiles='{oss,shared}/**/*.*'",
+    "cy:dev": "source ../monitor-ci/.env && CYPRESS_baseUrl=https://kubernetes.docker.internal:$PORT_HTTPS cypress open --config testFiles='{cloud,shared}/**/*.*'",
+    "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_baseUrl=https://kubernetes.docker.internal:$PORT_HTTPS cypress open --config testFiles='{oss,shared}/**/*.*'",
     "generate": "oats https://raw.githubusercontent.com/influxdata/influxdb/master/http/swagger.yml > ./src/client/generatedRoutes.ts && yarn unity && yarn flows",
     "unity": "oats ./src/client/swagger/unity.yml > ./src/client/unityRoutes.ts",
     "flows": "oats ./src/client/swagger/flows.yml > ./src/client/flowsRoutes.ts"


### PR DESCRIPTION
Issue: https://github.com/influxdata/idpe/issues/9547

Explanation of changes:
- Add `cy.getByTestID('tree-nav')` after every `cy.visit` in a `beforeEach`. Why: The app seems to run slower in the cluster and this causes a race condition. Basically the tests start execution before the page fully loads. Waiting on the tree-nav element forces the beforeEach to wait for the page to load before starting the tests. 
- Add `orgID` property to the `resource` object for each permission of each token we create during the token tests. The McFly user used in the kind tests isn't a "super user" like monitor-ci's "dev_user". McFly goes through the typical onboarding process and the IDPE authorization service requires that you provide the `orgID` property unless you have these super permissions.
- Set the `defaultUser` fixture every time after we sign in. This is required because we're creating a new user for every test and need to update this fixture accordingly.
- Reloads before running the "can delete label" test because there is a race condition between how fast the API responds to creating the label and how fast the app is rendering.

Also adds a `yarn start:kind` command for starting up the dev server to be compatible with k8s-idpe

IDPE PR: https://github.com/influxdata/idpe/pull/9813 🚫 
K8S-IDPE PR: https://github.com/influxdata/k8s-idpe/pull/2375
Monitor-CI PR: https://github.com/influxdata/monitor-ci/pull/164 ✅ 

Merge this 2nd