### PR TITLE
fix: overlays render properly and can close with onEscape

### DIFF
--- a/src/buckets/components/RenameBucketOverlay.tsx
+++ b/src/buckets/components/RenameBucketOverlay.tsx
@@ -10,22 +10,37 @@ import RenameBucketForm from 'src/buckets/components/RenameBucketForm'
 
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
-
+import {Overlay} from '@influxdata/clockface'
 @ErrorHandling
 class RenameBucketOverlay extends PureComponent<
   RouteComponentProps<{orgID: string}>
 > {
+  state = {
+    visible: false,
+  }
+
+  componentDidMount() {
+    this.setState({visible: true})
+  }
+
+  private closeOverlay = () => {
+    this.setState({visible: false})
+    this.handleClose()
+  }
+
   public render() {
     return (
-      <DangerConfirmationOverlay
-        title="Rename Bucket"
-        message={this.message}
-        effectedItems={this.effectedItems}
-        onClose={this.handleClose}
-        confirmButtonText="I understand, let's rename my Bucket"
-      >
-        <RenameBucketForm />
-      </DangerConfirmationOverlay>
+      <Overlay visible={this.state.visible} onEscape={this.closeOverlay}>
+        <DangerConfirmationOverlay
+          title="Rename Bucket"
+          message={this.message}
+          effectedItems={this.effectedItems}
+          onClose={this.handleClose}
+          confirmButtonText="I understand, let's rename my Bucket"
+        >
+          <RenameBucketForm />
+        </DangerConfirmationOverlay>
+      </Overlay>
     )
   }
 
@@ -45,7 +60,6 @@ class RenameBucketOverlay extends PureComponent<
 
   private handleClose = () => {
     const {history, match} = this.props
-
     history.push(`/orgs/${match.params.orgID}/load-data/buckets`)
   }
 }

--- a/src/buckets/components/RenameBucketOverlay.tsx
+++ b/src/buckets/components/RenameBucketOverlay.tsx
@@ -15,22 +15,9 @@ import {Overlay} from '@influxdata/clockface'
 class RenameBucketOverlay extends PureComponent<
   RouteComponentProps<{orgID: string}>
 > {
-  state = {
-    visible: false,
-  }
-
-  componentDidMount() {
-    this.setState({visible: true})
-  }
-
-  private closeOverlay = () => {
-    this.setState({visible: false})
-    this.handleClose()
-  }
-
   public render() {
     return (
-      <Overlay visible={this.state.visible} onEscape={this.closeOverlay}>
+      <Overlay visible={true}>
         <DangerConfirmationOverlay
           title="Rename Bucket"
           message={this.message}

--- a/src/organizations/components/RenameOrgOverlay.tsx
+++ b/src/organizations/components/RenameOrgOverlay.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {PureComponent} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-
+import {Overlay} from '@influxdata/clockface'
 import _ from 'lodash'
 
 // Components
@@ -15,17 +15,31 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 class RenameOrgOverlay extends PureComponent<
   RouteComponentProps<{orgID: string}>
 > {
+  state = {
+    visible: false,
+  }
+  componentDidMount() {
+    this.setState({visible: true})
+  }
+
+  private closeOverlay = () => {
+    this.setState({visible: false})
+    this.handleClose()
+  }
+
   public render() {
     return (
-      <DangerConfirmationOverlay
-        title="Rename Organization"
-        message={this.message}
-        effectedItems={this.effectedItems}
-        onClose={this.handleClose}
-        confirmButtonText="I understand, let's rename my Organization"
-      >
-        <RenameOrgForm />
-      </DangerConfirmationOverlay>
+      <Overlay visible={this.state.visible} onEscape={this.closeOverlay}>
+        <DangerConfirmationOverlay
+          title="Rename Organization"
+          message={this.message}
+          effectedItems={this.effectedItems}
+          onClose={this.handleClose}
+          confirmButtonText="I understand, let's rename my Organization"
+        >
+          <RenameOrgForm />
+        </DangerConfirmationOverlay>
+      </Overlay>
     )
   }
 

--- a/src/organizations/components/RenameOrgOverlay.tsx
+++ b/src/organizations/components/RenameOrgOverlay.tsx
@@ -15,21 +15,9 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 class RenameOrgOverlay extends PureComponent<
   RouteComponentProps<{orgID: string}>
 > {
-  state = {
-    visible: false,
-  }
-  componentDidMount() {
-    this.setState({visible: true})
-  }
-
-  private closeOverlay = () => {
-    this.setState({visible: false})
-    this.handleClose()
-  }
-
   public render() {
     return (
-      <Overlay visible={this.state.visible} onEscape={this.closeOverlay}>
+      <Overlay visible={true}>
         <DangerConfirmationOverlay
           title="Rename Organization"
           message={this.message}


### PR DESCRIPTION
Closes #672 

<!-- Describe your proposed changes here. -->
This fixes the bug where overlays were rendering off to the side instead of as overlays
It also adds onEscape functionality, which is nice
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

