### PR TITLE
chore: upgrading to clockface 2.6.1

### DIFF
--- a/cypress/e2e/shared/queryBuilder.test.ts
+++ b/cypress/e2e/shared/queryBuilder.test.ts
@@ -123,8 +123,9 @@ describe('The Query Builder', () => {
       cy.getByTestID('auto-window-period').click()
 
       cy.getByTestID('duration-input--error').should('not.exist')
-      cy.getByTestID('toggle').click()
+      cy.contains('Fill missing values').click()
       cy.getByTestID('switch-to-script-editor').click()
+
       cy.contains(
         '|> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: true)'
       ).should('exist')

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "webpack-merge": "^4.2.1"
   },
   "dependencies": {
-    "@influxdata/clockface": "^2.4.1",
+    "@influxdata/clockface": "^2.6.1",
     "@influxdata/flux": "^0.5.1",
     "@influxdata/flux-lsp-browser": "^0.5.32",
     "@influxdata/giraffe": "^2.0.1",

--- a/src/timeMachine/components/FillValues.tsx
+++ b/src/timeMachine/components/FillValues.tsx
@@ -4,13 +4,15 @@ import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {
-  InputLabel,
-  FlexBox,
-  ComponentSize,
+  AlignItems,
   ComponentColor,
-  Toggle,
+  ComponentSize,
+  FlexBox,
+  FlexDirection,
+  InputLabel,
   InputToggleType,
   QuestionMarkTooltip,
+  Toggle,
 } from '@influxdata/clockface'
 
 // Actions
@@ -38,7 +40,11 @@ const FillValues: FunctionComponent<Props> = ({
   }
 
   return (
-    <>
+    <FlexBox
+      direction={FlexDirection.Column}
+      margin={ComponentSize.Large}
+      alignItems={AlignItems.FlexStart}
+    >
       <Toggle
         id="isFillValues"
         type={InputToggleType.Checkbox}
@@ -46,18 +52,18 @@ const FillValues: FunctionComponent<Props> = ({
         onChange={onChangeFillValues}
         color={ComponentColor.Primary}
         size={ComponentSize.ExtraSmall}
-      />
-      <FlexBox.Child grow={1}>
+      >
         <InputLabel className="fill-values-checkbox--label">
           Fill missing values
         </InputLabel>
-      </FlexBox.Child>
-      <QuestionMarkTooltip
-        diameter={16}
-        tooltipContents="For windows without data, create an empty window and fill it with a null aggregate value"
-        tooltipStyle={{fontSize: '13px', padding: '8px'}}
-      />
-    </>
+        <QuestionMarkTooltip
+          style={{marginLeft: 6}}
+          diameter={16}
+          tooltipContents="For windows without data, create an empty window and fill it with a null aggregate value"
+          tooltipStyle={{fontSize: '13px', padding: '8px'}}
+        />
+      </Toggle>
+    </FlexBox>
   )
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -782,10 +782,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@influxdata/clockface@^2.4.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-2.4.1.tgz#67c61d89782dea07a149dd35e45b9eb13ad63a5f"
-  integrity sha512-p1YEnB73wOkzS6PqKr2P3jf0jRLP4mJZBbyOZsDlkYsuy3PrGnGCscshecb/f2XNiTbbbShXy40SzPreM07wQw==
+"@influxdata/clockface@^2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-2.6.1.tgz#3b39a11cfdc2570e9bad6bbdf967d5afd34fdc35"
+  integrity sha512-RNsUbMCwojb96z6nu59sHeh/Xtv905/ec04/JEhsPUaMaXMAOuGkZe8sQ6zdg119mfMNU/XkNL3meR4Yy6ev/g==
 
 "@influxdata/flux-lsp-browser@^0.5.32":
   version "0.5.32"


### PR DESCRIPTION
 * also: changing test as needed for clockface 2.6.1;
     This necessitated:
         - improving the component as well (you can now click on the label)
	 - the test now accesses the togglebutton via the label text; which is what the user would do (click on the label)

The FillValue's label is now a child of the togglebutton; so the component hierarchy has changed to be consistent with what the togglebutton is expecting; which takes advantage of the fact that the entire togglebutton (including the children) are now clickable in 2.6.1 

the togglebutton changed just enough to break the querybuilder test, which highlighted/took advantage of  a problem with the test (and/or the togglebutton), so it is now fixed.  

having just one PR with *just* the upgrade and the changes needed for the upgrade.

