### PR TITLE
fix: remove capitalized pull request template file

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,0 @@
-Closes #
-
-<!-- Describe your proposed changes here. -->
-
-- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
-- [ ] Rebased/mergeable
-- [ ] Tests pass
-

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 Closes #
 
-### Testing Steps
+<!-- Describe your proposed changes here. -->
 
-### Merge Checklist
-- [ ] User facing change?
-  - [ ] CHANGELOG.md is updated and links to this PR
+- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
+- [ ] Rebased/mergeable
+- [ ] Tests pass


### PR DESCRIPTION
I accidentally committed an upper cased version of the pull request template from an old PR. This removes that and makes the lower cased one have the right content.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

