### PR TITLE
fix: validateTemplateURL whitespace and optional query

### DIFF
--- a/src/templates/utils/index.test.ts
+++ b/src/templates/utils/index.test.ts
@@ -253,6 +253,11 @@ describe('validating template URLs', () => {
           'https://github.com/influxdata/community-templates/blob/master/airquality/whitespaceQuery.yml?queryAttachedToTheURL      '
         )
       ).toBe(TEMPLATE_URL_VALID)
+      expect(
+        validateTemplateURL(
+          'https://github.com/influxdata/community-templates/blob/master/airquality/EmptyQueryButQuestionMarkPresent.yml?      '
+        )
+      ).toBe(TEMPLATE_URL_VALID)
     })
   })
 

--- a/src/templates/utils/index.test.ts
+++ b/src/templates/utils/index.test.ts
@@ -238,6 +238,16 @@ describe('validating template URLs', () => {
           'https://raw.githubusercontent.com/influxdata/community-templates/master/speedtest/speedtest.yml'
         )
       ).toBe(TEMPLATE_URL_VALID)
+      expect(
+        validateTemplateURL(
+          'https://github.com/influxdata/community-templates/blob/master/airquality/airquality.yml?queryAttachedToTheURL'
+        )
+      ).toBe(TEMPLATE_URL_VALID)
+      expect(
+        validateTemplateURL(
+          'https://github.com/influxdata/community-templates/blob/master/airquality/whitespace.yml      '
+        )
+      ).toBe(TEMPLATE_URL_VALID)
     })
   })
 

--- a/src/templates/utils/index.test.ts
+++ b/src/templates/utils/index.test.ts
@@ -248,6 +248,11 @@ describe('validating template URLs', () => {
           'https://github.com/influxdata/community-templates/blob/master/airquality/whitespace.yml      '
         )
       ).toBe(TEMPLATE_URL_VALID)
+      expect(
+        validateTemplateURL(
+          'https://github.com/influxdata/community-templates/blob/master/airquality/whitespaceQuery.yml?queryAttachedToTheURL      '
+        )
+      ).toBe(TEMPLATE_URL_VALID)
     })
   })
 

--- a/src/templates/utils/index.ts
+++ b/src/templates/utils/index.ts
@@ -136,6 +136,7 @@ export const TEMPLATE_URL_WARN =
   'This URL does not point to our Community Templates repository. It may work but we cannot guarantee quality results.'
 
 export const validateTemplateURL = (url): string => {
+  url = url.trim()
   if (url === '') {
     return ''
   }
@@ -145,6 +146,12 @@ export const validateTemplateURL = (url): string => {
     url.startsWith(
       'https://raw.githubusercontent.com/influxdata/community-templates'
     )
+
+  const hasQueryAttached = url.includes('?')
+
+  if (hasQueryAttached) {
+    url = url.split('?')[0]
+  }
 
   const isCorrectFileType =
     url.endsWith('.yml') || url.endsWith('.json') || url.endsWith('.jsonnet')

--- a/src/templates/utils/index.ts
+++ b/src/templates/utils/index.ts
@@ -136,25 +136,21 @@ export const TEMPLATE_URL_WARN =
   'This URL does not point to our Community Templates repository. It may work but we cannot guarantee quality results.'
 
 export const validateTemplateURL = (url): string => {
-  url = url.trim()
-  if (url === '') {
+  const cleanUrl = url.trim().split('?')[0]
+  if (cleanUrl === '') {
     return ''
   }
 
   const isCommunityTemplates =
-    url.startsWith('https://github.com/influxdata/community-templates') ||
-    url.startsWith(
+    cleanUrl.startsWith('https://github.com/influxdata/community-templates') ||
+    cleanUrl.startsWith(
       'https://raw.githubusercontent.com/influxdata/community-templates'
     )
 
-  const hasQueryAttached = url.includes('?')
-
-  if (hasQueryAttached) {
-    url = url.split('?')[0]
-  }
-
   const isCorrectFileType =
-    url.endsWith('.yml') || url.endsWith('.json') || url.endsWith('.jsonnet')
+    cleanUrl.endsWith('.yml') ||
+    cleanUrl.endsWith('.json') ||
+    cleanUrl.endsWith('.jsonnet')
 
   if (isCommunityTemplates && !isCorrectFileType) {
     return "This URL correctly points to the Community Templates repository but isn't pointing to a YAML or JSON file"

--- a/src/templates/utils/index.ts
+++ b/src/templates/utils/index.ts
@@ -136,6 +136,10 @@ export const TEMPLATE_URL_WARN =
   'This URL does not point to our Community Templates repository. It may work but we cannot guarantee quality results.'
 
 export const validateTemplateURL = (url): string => {
+  /*
+     url may or may not have a query at the end. Either case is a valid url.
+     We need to make sure the url is pointing to a valid template.
+  */
   const cleanUrl = url.trim().split('?')[0]
   if (cleanUrl === '') {
     return ''

--- a/src/templates/utils/index.ts
+++ b/src/templates/utils/index.ts
@@ -136,14 +136,15 @@ export const TEMPLATE_URL_WARN =
   'This URL does not point to our Community Templates repository. It may work but we cannot guarantee quality results.'
 
 export const validateTemplateURL = (url): string => {
+  if (url === '') {
+    return ''
+  }
+
   /*
      url may or may not have a query at the end. Either case is a valid url.
      We need to make sure the url is pointing to a valid template.
   */
   const cleanUrl = url.trim().split('?')[0]
-  if (cleanUrl === '') {
-    return ''
-  }
 
   const isCommunityTemplates =
     cleanUrl.startsWith('https://github.com/influxdata/community-templates') ||


### PR DESCRIPTION
Closes #675 

updated `validateTemplateURL` to ignore trailing whitespace as well as an optional query attached. Also added tests. 

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
