### PR TITLE
chore: create queryBuilderThunks to store thunks for query builder

### DIFF
--- a/src/dataExplorer/components/DataExplorer.tsx
+++ b/src/dataExplorer/components/DataExplorer.tsx
@@ -8,7 +8,7 @@ import LimitChecker from 'src/cloud/components/LimitChecker'
 
 // Actions
 import {setActiveTimeMachine} from 'src/timeMachine/actions'
-import {setBuilderBucketIfExists} from 'src/timeMachine/actions/queryBuilder'
+import {setBuilderBucketIfExists} from 'src/timeMachine/actions/queryBuilderThunks'
 
 // Utils
 import {HoverTimeProvider} from 'src/dashboards/utils/hoverTime'

--- a/src/timeMachine/actions/index.ts
+++ b/src/timeMachine/actions/index.ts
@@ -2,12 +2,12 @@
 import {Dispatch} from 'react'
 
 // Actions
-import {loadBuckets} from 'src/timeMachine/actions/queryBuilder'
-import {saveAndExecuteQueries} from 'src/timeMachine/actions/queries'
+import {Action as QueryBuilderAction} from 'src/timeMachine/actions/queryBuilder'
 import {
+  loadBuckets,
   reloadTagSelectors,
-  Action as QueryBuilderAction,
-} from 'src/timeMachine/actions/queryBuilder'
+} from 'src/timeMachine/actions/queryBuilderThunks'
+import {saveAndExecuteQueries} from 'src/timeMachine/actions/queries'
 import {convertCheckToCustom} from 'src/alerting/actions/alertBuilder'
 import {setDashboardTimeRange} from 'src/dashboards/actions/ranges'
 

--- a/src/timeMachine/actions/queryBuilder.ts
+++ b/src/timeMachine/actions/queryBuilder.ts
@@ -1,49 +1,5 @@
-// APIs
-import {normalize} from 'normalizr'
-import {queryBuilderFetcher} from 'src/timeMachine/apis/QueryBuilderFetcher'
-import * as api from 'src/client'
-import {get} from 'lodash'
-import {fetchDemoDataBuckets} from 'src/cloud/apis/demodata'
-
-// Utils
-import {event} from 'src/cloud/utils/reporting'
-
 // Types
-import {
-  Bucket,
-  BucketEntities,
-  BuilderAggregateFunctionType,
-  GetState,
-  RemoteDataState,
-  ResourceType,
-} from 'src/types'
-import {Dispatch} from 'react'
-import {
-  Action as AlertBuilderAction,
-  setEvery,
-} from 'src/alerting/actions/alertBuilder'
-
-// Selectors
-import {getOrg} from 'src/organizations/selectors'
-import {getAll} from 'src/resources/selectors'
-import {getStatus} from 'src/resources/selectors'
-import {getTimeRangeWithTimezone} from 'src/dashboards/selectors'
-import {
-  getActiveQuery,
-  getActiveTimeMachine,
-  getWindowPeriodFromTimeRange,
-} from 'src/timeMachine/selectors'
-
-// Actions
-import {editActiveQueryWithBuilderSync} from 'src/timeMachine/actions'
-import {setBuckets} from 'src/buckets/actions/creators'
-
-// Constants
-import {LIMIT} from 'src/resources/constants'
-import {AGG_WINDOW_AUTO} from 'src/timeMachine/constants/queryBuilder'
-
-// Schemas
-import {arrayOfBuckets} from 'src/schemas'
+import {BuilderAggregateFunctionType, RemoteDataState} from 'src/types'
 
 export type Action =
   | ReturnType<typeof setBuilderAggregateFunctionType>
@@ -73,7 +29,7 @@ export const setBuilderAggregateFunctionType = (
   payload: {builderAggregateFunctionType, index},
 })
 
-const setBuilderBucketsStatus = (bucketsStatus: RemoteDataState) => ({
+export const setBuilderBucketsStatus = (bucketsStatus: RemoteDataState) => ({
   type: 'SET_BUILDER_BUCKETS_STATUS' as 'SET_BUILDER_BUCKETS_STATUS',
   payload: {bucketsStatus},
 })
@@ -83,7 +39,7 @@ export const setBuilderBuckets = (buckets: string[]) => ({
   payload: {buckets},
 })
 
-const setBuilderBucket = (bucket: string, resetSelections: boolean) => ({
+export const setBuilderBucket = (bucket: string, resetSelections: boolean) => ({
   type: 'SET_BUILDER_BUCKET_SELECTION' as 'SET_BUILDER_BUCKET_SELECTION',
   payload: {bucket, resetSelections},
 })
@@ -93,7 +49,7 @@ export const setBuilderTagsStatus = (status: RemoteDataState) => ({
   payload: {status},
 })
 
-const setBuilderTagKeys = (index: number, keys: string[]) => ({
+export const setBuilderTagKeys = (index: number, keys: string[]) => ({
   type: 'SET_BUILDER_TAG_KEYS' as 'SET_BUILDER_TAG_KEYS',
   payload: {index, keys},
 })
@@ -106,31 +62,37 @@ export const setBuilderTagKeysStatus = (
   payload: {index, status},
 })
 
-const setBuilderTagValues = (index: number, values: string[]) => ({
+export const setBuilderTagValues = (index: number, values: string[]) => ({
   type: 'SET_BUILDER_TAG_VALUES' as 'SET_BUILDER_TAG_VALUES',
   payload: {index, values},
 })
 
-const setBuilderTagValuesStatus = (index: number, status: RemoteDataState) => ({
+export const setBuilderTagValuesStatus = (
+  index: number,
+  status: RemoteDataState
+) => ({
   type: 'SET_BUILDER_TAG_VALUES_STATUS' as 'SET_BUILDER_TAG_VALUES_STATUS',
   payload: {index, status},
 })
 
-const setBuilderTagKeySelection = (index: number, key: string) => ({
+export const setBuilderTagKeySelection = (index: number, key: string) => ({
   type: 'SET_BUILDER_TAG_KEY_SELECTION' as 'SET_BUILDER_TAG_KEY_SELECTION',
   payload: {index, key},
 })
 
-const setBuilderTagValuesSelection = (index: number, values: string[]) => ({
+export const setBuilderTagValuesSelection = (
+  index: number,
+  values: string[]
+) => ({
   type: 'SET_BUILDER_TAG_VALUES_SELECTION' as 'SET_BUILDER_TAG_VALUES_SELECTION',
   payload: {index, values},
 })
 
-const addTagSelectorSync = () => ({
+export const addTagSelectorSync = () => ({
   type: 'ADD_TAG_SELECTOR' as 'ADD_TAG_SELECTOR',
 })
 
-const removeTagSelectorSync = (index: number) => ({
+export const removeTagSelectorSync = (index: number) => ({
   type: 'REMOVE_TAG_SELECTOR' as 'REMOVE_TAG_SELECTOR',
   payload: {index},
 })
@@ -159,381 +121,3 @@ export const setKeysSearchTerm = (index: number, searchTerm: string) => ({
   type: 'SET_BUILDER_KEYS_SEARCH_TERM' as 'SET_BUILDER_KEYS_SEARCH_TERM',
   payload: {index, searchTerm},
 })
-
-export const setWindowPeriodSelectionMode = (mode: 'custom' | 'auto') => (
-  dispatch: Dispatch<Action | AlertBuilderAction>,
-  getState: GetState
-) => {
-  if (mode === 'custom') {
-    const windowPeriod = getWindowPeriodFromTimeRange(getState())
-
-    dispatch(setAggregateWindow(windowPeriod))
-  }
-  if (mode === 'auto') {
-    dispatch(setAggregateWindow(AGG_WINDOW_AUTO))
-  }
-}
-
-export const selectAggregateWindow = (period: string) => (
-  dispatch: Dispatch<Action | AlertBuilderAction>
-) => {
-  dispatch(setAggregateWindow(period))
-  dispatch(setEvery(period))
-}
-
-export const loadBuckets = () => async (
-  dispatch: Dispatch<
-    Action | ReturnType<typeof selectBucket> | ReturnType<typeof setBuckets>
-  >,
-  getState: GetState
-) => {
-  if (
-    getStatus(getState(), ResourceType.Buckets) === RemoteDataState.NotStarted
-  ) {
-    dispatch(setBuckets(RemoteDataState.Loading))
-  }
-  const startTime = Date.now()
-  const orgID = getOrg(getState()).id
-  dispatch(setBuilderBucketsStatus(RemoteDataState.Loading))
-
-  try {
-    const resp = await api.getBuckets({query: {orgID, limit: LIMIT}})
-
-    if (resp.status !== 200) {
-      throw new Error(resp.data.message)
-    }
-
-    const demoDataBuckets = await fetchDemoDataBuckets()
-
-    const normalizedBuckets = normalize<Bucket, BucketEntities, string[]>(
-      [...resp.data.buckets, ...demoDataBuckets],
-      arrayOfBuckets
-    )
-
-    dispatch(setBuckets(RemoteDataState.Done, normalizedBuckets))
-
-    const allBuckets = [...resp.data.buckets, ...demoDataBuckets].map(
-      b => b.name
-    )
-
-    const systemBuckets = allBuckets.filter(b => b.startsWith('_'))
-    const userBuckets = allBuckets.filter(b => !b.startsWith('_'))
-    const buckets = [...userBuckets, ...systemBuckets]
-
-    const selectedBucket = getActiveQuery(getState()).builderConfig.buckets[0]
-
-    dispatch(setBuilderBuckets(buckets))
-
-    if (selectedBucket && buckets.includes(selectedBucket)) {
-      dispatch(selectBucket(selectedBucket))
-    } else {
-      dispatch(selectBucket(buckets[0], true))
-    }
-    event(
-      'loadBuckets function',
-      {
-        time: startTime,
-      },
-      {duration: Date.now() - startTime}
-    )
-  } catch (e) {
-    if (e.name === 'CancellationError') {
-      return
-    }
-
-    console.error(e)
-    dispatch(setBuilderBucketsStatus(RemoteDataState.Error))
-  }
-}
-
-export const selectBucket = (
-  bucket: string,
-  resetSelections: boolean = false
-) => (dispatch: Dispatch<Action | ReturnType<typeof loadTagSelector>>) => {
-  dispatch(setBuilderBucket(bucket, resetSelections))
-  dispatch(loadTagSelector(0))
-}
-
-export const loadTagSelector = (index: number) => async (
-  dispatch: Dispatch<Action | ReturnType<typeof loadTagSelectorValues>>,
-  getState: GetState
-) => {
-  const startTime = Date.now()
-
-  const {buckets, tags} = getActiveQuery(getState()).builderConfig
-
-  if (!tags[index] || !buckets[0]) {
-    return
-  }
-
-  dispatch(setBuilderTagKeysStatus(index, RemoteDataState.Loading))
-
-  const state = getState()
-  const tagsSelections = tags.slice(0, index)
-  const queryURL = getState().links.query.self
-
-  const bucket = buckets[0]
-
-  const allBuckets = getAll<Bucket>(getState(), ResourceType.Buckets)
-  const foundBucket = allBuckets.find(b => b.name === bucket)
-
-  const orgID = get(foundBucket, 'orgID', getOrg(getState()).id)
-
-  try {
-    const timeRange = getTimeRangeWithTimezone(state)
-
-    const searchTerm = getActiveTimeMachine(state).queryBuilder.tags[index]
-      .keysSearchTerm
-
-    const keys = await queryBuilderFetcher.findKeys(index, {
-      url: queryURL,
-      orgID,
-      bucket,
-      tagsSelections,
-      searchTerm,
-      timeRange,
-    })
-
-    const {key} = tags[index]
-
-    if (!key) {
-      let defaultKey: string
-
-      if (index === 0 && keys.includes('_measurement')) {
-        defaultKey = '_measurement'
-      } else {
-        defaultKey = keys[0]
-      }
-
-      dispatch(setBuilderTagKeySelection(index, defaultKey))
-    } else if (!keys.includes(key)) {
-      // Even if the selected key didn't come back in the results, let it be
-      // selected anyway
-      keys.unshift(key)
-    }
-
-    dispatch(setBuilderTagKeys(index, keys))
-    dispatch(loadTagSelectorValues(index))
-    event(
-      'loadTagSelector function',
-      {
-        time: startTime,
-      },
-      {duration: Date.now() - startTime}
-    )
-  } catch (e) {
-    if (e.name === 'CancellationError') {
-      return
-    }
-
-    console.error(e)
-    dispatch(setBuilderTagKeysStatus(index, RemoteDataState.Error))
-  }
-}
-
-const loadTagSelectorValues = (index: number) => async (
-  dispatch: Dispatch<Action | ReturnType<typeof loadTagSelector>>,
-  getState: GetState
-) => {
-  const startTime = Date.now()
-
-  const state = getState()
-  const {buckets, tags} = getActiveQuery(state).builderConfig
-  const tagsSelections = tags.slice(0, index)
-  const queryURL = state.links.query.self
-
-  if (!buckets[0]) {
-    return
-  }
-
-  const bucket = buckets[0]
-
-  const allBuckets = getAll<Bucket>(state, ResourceType.Buckets)
-  const foundBucket = allBuckets.find(b => b.name === bucket)
-  const orgID = get(foundBucket, 'orgID', getOrg(getState()).id)
-
-  dispatch(setBuilderTagValuesStatus(index, RemoteDataState.Loading))
-
-  try {
-    const timeRange = getTimeRangeWithTimezone(state)
-    const key = getActiveQuery(getState()).builderConfig.tags[index].key
-    const searchTerm = getActiveTimeMachine(getState()).queryBuilder.tags[index]
-      .valuesSearchTerm
-
-    const values = await queryBuilderFetcher.findValues(index, {
-      url: queryURL,
-      orgID,
-      bucket,
-      tagsSelections,
-      key,
-      searchTerm,
-      timeRange,
-    })
-
-    const {values: selectedValues} = tags[index]
-
-    for (const selectedValue of selectedValues) {
-      // Even if the selected values didn't come back in the results, let them
-      // be selected anyway
-      if (!values.includes(selectedValue)) {
-        values.unshift(selectedValue)
-      }
-    }
-
-    dispatch(setBuilderTagValues(index, values))
-    dispatch(loadTagSelector(index + 1))
-    event(
-      'loadTagSelectorValues function',
-      {
-        time: startTime,
-      },
-      {duration: Date.now() - startTime}
-    )
-  } catch (e) {
-    if (e.name === 'CancellationError') {
-      return
-    }
-
-    console.error(e)
-    dispatch(setBuilderTagValuesStatus(index, RemoteDataState.Error))
-  }
-}
-
-export const selectTagValue = (index: number, value: string) => (
-  dispatch: Dispatch<Action | ReturnType<typeof addTagSelector>>,
-  getState: GetState
-) => {
-  const state = getState()
-  const {
-    timeMachines: {activeTimeMachineID},
-  } = state
-  const tags = getActiveQuery(state).builderConfig.tags
-  const currentTag = tags[index]
-  const values = currentTag.values
-
-  let newValues: string[]
-
-  if (values.includes(value)) {
-    newValues = values.filter(v => v !== value)
-  } else if (
-    activeTimeMachineID === 'alerting' &&
-    currentTag.key === '_field'
-  ) {
-    newValues = [value]
-  } else {
-    newValues = [...values, value]
-  }
-
-  dispatch(setBuilderTagValuesSelection(index, newValues))
-
-  // don't add a new tag filter if we're grouping
-  if (currentTag.aggregateFunctionType === 'group') {
-    return
-  }
-
-  if (index === tags.length - 1 && newValues.length) {
-    dispatch(addTagSelector())
-  } else {
-    dispatch(loadTagSelector(index + 1))
-  }
-}
-
-export const multiSelectBuilderFunction = (name: string) => (
-  dispatch: Dispatch<Action>,
-  getState: GetState
-) => {
-  const {draftQueries, activeQueryIndex} = getActiveTimeMachine(getState())
-  const functions = draftQueries[activeQueryIndex].builderConfig.functions
-
-  const functionNames = functions.map(f => f.name)
-  const clickedFunctionAlreadySelected = functionNames.includes(name)
-
-  if (!clickedFunctionAlreadySelected) {
-    // add clicked to selected
-    dispatch(setFunctions([...functionNames, name]))
-  } else {
-    if (functions.length > 1) {
-      // if more than one function is selected, remove clicked from selected
-      dispatch(setFunctions(functionNames.filter(n => n != name)))
-    }
-  }
-}
-
-export const singleSelectBuilderFunction = (name: string) => (
-  dispatch: Dispatch<Action>,
-  getState: GetState
-) => {
-  const {draftQueries, activeQueryIndex} = getActiveTimeMachine(getState())
-  const functions = draftQueries[activeQueryIndex].builderConfig.functions
-
-  const functionNames = functions.map(f => f.name)
-  const clickedFunctionAlreadySelected = functionNames.includes(name)
-
-  if (!clickedFunctionAlreadySelected) {
-    // select clicked function
-    dispatch(setFunctions([name]))
-  } else {
-    if (functions.length > 1) {
-      // if more than one function is selected, remove clicked from selected
-      dispatch(setFunctions(functionNames.filter(n => n != name)))
-    }
-  }
-}
-
-export const selectTagKey = (index: number, key: string) => (
-  dispatch: Dispatch<Action>
-) => {
-  dispatch(setBuilderTagKeySelection(index, key))
-  dispatch(loadTagSelectorValues(index))
-}
-
-export const searchTagValues = (index: number) => (
-  dispatch: Dispatch<Action>
-) => {
-  dispatch(loadTagSelectorValues(index))
-}
-
-export const searchTagKeys = (index: number) => (
-  dispatch: Dispatch<Action>
-) => {
-  dispatch(loadTagSelector(index))
-}
-
-export const addTagSelector = () => (
-  dispatch: Dispatch<Action>,
-  getState: GetState
-) => {
-  dispatch(addTagSelectorSync())
-
-  const newIndex = getActiveQuery(getState()).builderConfig.tags.length - 1
-
-  dispatch(loadTagSelector(newIndex))
-}
-
-export const removeTagSelector = (index: number) => (
-  dispatch: Dispatch<Action>
-) => {
-  queryBuilderFetcher.cancelFindValues(index)
-  queryBuilderFetcher.cancelFindKeys(index)
-
-  dispatch(removeTagSelectorSync(index))
-  dispatch(loadTagSelector(index))
-}
-
-export const reloadTagSelectors = () => (dispatch: Dispatch<Action>) => {
-  dispatch(setBuilderTagsStatus(RemoteDataState.Loading))
-  dispatch(loadTagSelector(0))
-}
-
-export const setBuilderBucketIfExists = (bucketName: string) => (
-  dispatch: Dispatch<
-    Action | ReturnType<typeof editActiveQueryWithBuilderSync>
-  >,
-  getState: GetState
-) => {
-  const buckets = getAll<Bucket>(getState(), ResourceType.Buckets)
-  if (buckets.find(b => b.name === bucketName)) {
-    dispatch(editActiveQueryWithBuilderSync())
-    dispatch(setBuilderBucket(bucketName, true))
-  }
-}

--- a/src/timeMachine/actions/queryBuilderThunks.ts
+++ b/src/timeMachine/actions/queryBuilderThunks.ts
@@ -1,0 +1,442 @@
+import {Dispatch} from 'react'
+
+import {queryBuilderFetcher} from 'src/timeMachine/apis/QueryBuilderFetcher'
+
+// Utils
+import {event} from 'src/cloud/utils/reporting'
+
+// API
+import {normalize} from 'normalizr'
+import {get} from 'lodash'
+import {fetchDemoDataBuckets} from 'src/cloud/apis/demodata'
+import * as api from 'src/client'
+
+// Types
+import {
+  Bucket,
+  BucketEntities,
+  GetState,
+  RemoteDataState,
+  ResourceType,
+} from 'src/types'
+import {
+  Action as AlertBuilderAction,
+  setEvery,
+} from 'src/alerting/actions/alertBuilder'
+
+// Selectors
+import {getOrg} from 'src/organizations/selectors'
+import {getAll} from 'src/resources/selectors'
+import {getStatus} from 'src/resources/selectors'
+import {getTimeRangeWithTimezone} from 'src/dashboards/selectors'
+import {
+  getActiveQuery,
+  getActiveTimeMachine,
+  getWindowPeriodFromTimeRange,
+} from 'src/timeMachine/selectors'
+
+// Actions
+import {editActiveQueryWithBuilderSync} from 'src/timeMachine/actions'
+import {
+  Action,
+  addTagSelectorSync,
+  removeTagSelectorSync,
+  setAggregateWindow,
+  setBuilderBucket,
+  setBuilderBuckets,
+  setBuilderBucketsStatus,
+  setBuilderTagKeys,
+  setBuilderTagKeySelection,
+  setBuilderTagKeysStatus,
+  setBuilderTagsStatus,
+  setBuilderTagValues,
+  setBuilderTagValuesSelection,
+  setBuilderTagValuesStatus,
+  setFunctions,
+} from 'src/timeMachine/actions/queryBuilder'
+import {setBuckets} from 'src/buckets/actions/creators'
+
+// Constants
+import {LIMIT} from 'src/resources/constants'
+import {AGG_WINDOW_AUTO} from 'src/timeMachine/constants/queryBuilder'
+
+// Schemas
+import {arrayOfBuckets} from 'src/schemas'
+
+export const removeTagSelector = (index: number) => (
+  dispatch: Dispatch<Action>
+) => {
+  queryBuilderFetcher.cancelFindValues(index)
+  queryBuilderFetcher.cancelFindKeys(index)
+
+  dispatch(removeTagSelectorSync(index))
+  dispatch(loadTagSelector(index))
+}
+
+const loadTagSelectorValues = (index: number) => async (
+  dispatch: Dispatch<Action | ReturnType<typeof loadTagSelector>>,
+  getState: GetState
+) => {
+  const startTime = Date.now()
+
+  const state = getState()
+  const {buckets, tags} = getActiveQuery(state).builderConfig
+  const tagsSelections = tags.slice(0, index)
+  const queryURL = state.links.query.self
+
+  if (!buckets[0]) {
+    return
+  }
+
+  const bucket = buckets[0]
+
+  const allBuckets = getAll<Bucket>(state, ResourceType.Buckets)
+  const foundBucket = allBuckets.find(b => b.name === bucket)
+  const orgID = get(foundBucket, 'orgID', getOrg(getState()).id)
+
+  dispatch(setBuilderTagValuesStatus(index, RemoteDataState.Loading))
+
+  try {
+    const timeRange = getTimeRangeWithTimezone(state)
+    const key = getActiveQuery(getState()).builderConfig.tags[index].key
+    const searchTerm = getActiveTimeMachine(getState()).queryBuilder.tags[index]
+      .valuesSearchTerm
+
+    const values = await queryBuilderFetcher.findValues(index, {
+      url: queryURL,
+      orgID,
+      bucket,
+      tagsSelections,
+      key,
+      searchTerm,
+      timeRange,
+    })
+
+    const {values: selectedValues} = tags[index]
+
+    for (const selectedValue of selectedValues) {
+      // Even if the selected values didn't come back in the results, let them
+      // be selected anyway
+      if (!values.includes(selectedValue)) {
+        values.unshift(selectedValue)
+      }
+    }
+
+    dispatch(setBuilderTagValues(index, values))
+    dispatch(loadTagSelector(index + 1))
+    event(
+      'loadTagSelectorValues function',
+      {
+        time: startTime,
+      },
+      {duration: Date.now() - startTime}
+    )
+  } catch (e) {
+    if (e.name === 'CancellationError') {
+      return
+    }
+
+    console.error(e)
+    dispatch(setBuilderTagValuesStatus(index, RemoteDataState.Error))
+  }
+}
+
+export const loadTagSelector = (index: number) => async (
+  dispatch: Dispatch<Action | ReturnType<typeof loadTagSelectorValues>>,
+  getState: GetState
+) => {
+  const startTime = Date.now()
+
+  const {buckets, tags} = getActiveQuery(getState()).builderConfig
+
+  if (!tags[index] || !buckets[0]) {
+    return
+  }
+
+  dispatch(setBuilderTagKeysStatus(index, RemoteDataState.Loading))
+
+  const state = getState()
+  const tagsSelections = tags.slice(0, index)
+  const queryURL = getState().links.query.self
+
+  const bucket = buckets[0]
+
+  const allBuckets = getAll<Bucket>(getState(), ResourceType.Buckets)
+  const foundBucket = allBuckets.find(b => b.name === bucket)
+
+  const orgID = get(foundBucket, 'orgID', getOrg(getState()).id)
+
+  try {
+    const timeRange = getTimeRangeWithTimezone(state)
+
+    const searchTerm = getActiveTimeMachine(state).queryBuilder.tags[index]
+      .keysSearchTerm
+
+    const keys = await queryBuilderFetcher.findKeys(index, {
+      url: queryURL,
+      orgID,
+      bucket,
+      tagsSelections,
+      searchTerm,
+      timeRange,
+    })
+
+    const {key} = tags[index]
+
+    if (!key) {
+      let defaultKey: string
+
+      if (index === 0 && keys.includes('_measurement')) {
+        defaultKey = '_measurement'
+      } else {
+        defaultKey = keys[0]
+      }
+
+      dispatch(setBuilderTagKeySelection(index, defaultKey))
+    } else if (!keys.includes(key)) {
+      // Even if the selected key didn't come back in the results, let it be
+      // selected anyway
+      keys.unshift(key)
+    }
+
+    dispatch(setBuilderTagKeys(index, keys))
+    dispatch(loadTagSelectorValues(index))
+    event(
+      'loadTagSelector function',
+      {
+        time: startTime,
+      },
+      {duration: Date.now() - startTime}
+    )
+  } catch (e) {
+    if (e.name === 'CancellationError') {
+      return
+    }
+
+    console.error(e)
+    dispatch(setBuilderTagKeysStatus(index, RemoteDataState.Error))
+  }
+}
+
+export const loadBuckets = () => async (
+  dispatch: Dispatch<
+    Action | ReturnType<typeof selectBucket> | ReturnType<typeof setBuckets>
+  >,
+  getState: GetState
+) => {
+  if (
+    getStatus(getState(), ResourceType.Buckets) === RemoteDataState.NotStarted
+  ) {
+    dispatch(setBuckets(RemoteDataState.Loading))
+  }
+  const startTime = Date.now()
+  const orgID = getOrg(getState()).id
+  dispatch(setBuilderBucketsStatus(RemoteDataState.Loading))
+
+  try {
+    const resp = await api.getBuckets({query: {orgID, limit: LIMIT}})
+
+    if (resp.status !== 200) {
+      throw new Error(resp.data.message)
+    }
+
+    const demoDataBuckets = await fetchDemoDataBuckets()
+
+    const normalizedBuckets = normalize<Bucket, BucketEntities, string[]>(
+      [...resp.data.buckets, ...demoDataBuckets],
+      arrayOfBuckets
+    )
+
+    dispatch(setBuckets(RemoteDataState.Done, normalizedBuckets))
+
+    const allBuckets = [...resp.data.buckets, ...demoDataBuckets].map(
+      b => b.name
+    )
+
+    const systemBuckets = allBuckets.filter(b => b.startsWith('_'))
+    const userBuckets = allBuckets.filter(b => !b.startsWith('_'))
+    const buckets = [...userBuckets, ...systemBuckets]
+
+    const selectedBucket = getActiveQuery(getState()).builderConfig.buckets[0]
+
+    dispatch(setBuilderBuckets(buckets))
+
+    if (selectedBucket && buckets.includes(selectedBucket)) {
+      dispatch(selectBucket(selectedBucket))
+    } else {
+      dispatch(selectBucket(buckets[0], true))
+    }
+    event(
+      'loadBuckets function',
+      {
+        time: startTime,
+      },
+      {duration: Date.now() - startTime}
+    )
+  } catch (e) {
+    if (e.name === 'CancellationError') {
+      return
+    }
+
+    console.error(e)
+    dispatch(setBuilderBucketsStatus(RemoteDataState.Error))
+  }
+}
+
+export const setWindowPeriodSelectionMode = (mode: 'custom' | 'auto') => (
+  dispatch: Dispatch<Action | AlertBuilderAction>,
+  getState: GetState
+) => {
+  if (mode === 'custom') {
+    const windowPeriod = getWindowPeriodFromTimeRange(getState())
+
+    dispatch(setAggregateWindow(windowPeriod))
+  }
+  if (mode === 'auto') {
+    dispatch(setAggregateWindow(AGG_WINDOW_AUTO))
+  }
+}
+
+export const selectAggregateWindow = (period: string) => (
+  dispatch: Dispatch<Action | AlertBuilderAction>
+) => {
+  dispatch(setAggregateWindow(period))
+  dispatch(setEvery(period))
+}
+
+export const selectBucket = (
+  bucket: string,
+  resetSelections: boolean = false
+) => (dispatch: Dispatch<Action | ReturnType<typeof loadTagSelector>>) => {
+  dispatch(setBuilderBucket(bucket, resetSelections))
+  dispatch(loadTagSelector(0))
+}
+
+export const selectTagValue = (index: number, value: string) => (
+  dispatch: Dispatch<Action | ReturnType<typeof addTagSelector>>,
+  getState: GetState
+) => {
+  const state = getState()
+  const {
+    timeMachines: {activeTimeMachineID},
+  } = state
+  const tags = getActiveQuery(state).builderConfig.tags
+  const currentTag = tags[index]
+  const values = currentTag.values
+
+  let newValues: string[]
+
+  if (values.includes(value)) {
+    newValues = values.filter(v => v !== value)
+  } else if (
+    activeTimeMachineID === 'alerting' &&
+    currentTag.key === '_field'
+  ) {
+    newValues = [value]
+  } else {
+    newValues = [...values, value]
+  }
+
+  dispatch(setBuilderTagValuesSelection(index, newValues))
+
+  // don't add a new tag filter if we're grouping
+  if (currentTag.aggregateFunctionType === 'group') {
+    return
+  }
+
+  if (index === tags.length - 1 && newValues.length) {
+    dispatch(addTagSelector())
+  } else {
+    dispatch(loadTagSelector(index + 1))
+  }
+}
+
+export const multiSelectBuilderFunction = (name: string) => (
+  dispatch: Dispatch<Action>,
+  getState: GetState
+) => {
+  const {draftQueries, activeQueryIndex} = getActiveTimeMachine(getState())
+  const functions = draftQueries[activeQueryIndex].builderConfig.functions
+
+  const functionNames = functions.map(f => f.name)
+  const clickedFunctionAlreadySelected = functionNames.includes(name)
+
+  if (!clickedFunctionAlreadySelected) {
+    // add clicked to selected
+    dispatch(setFunctions([...functionNames, name]))
+  } else {
+    if (functions.length > 1) {
+      // if more than one function is selected, remove clicked from selected
+      dispatch(setFunctions(functionNames.filter(n => n != name)))
+    }
+  }
+}
+
+export const singleSelectBuilderFunction = (name: string) => (
+  dispatch: Dispatch<Action>,
+  getState: GetState
+) => {
+  const {draftQueries, activeQueryIndex} = getActiveTimeMachine(getState())
+  const functions = draftQueries[activeQueryIndex].builderConfig.functions
+
+  const functionNames = functions.map(f => f.name)
+  const clickedFunctionAlreadySelected = functionNames.includes(name)
+
+  if (!clickedFunctionAlreadySelected) {
+    // select clicked function
+    dispatch(setFunctions([name]))
+  } else {
+    if (functions.length > 1) {
+      // if more than one function is selected, remove clicked from selected
+      dispatch(setFunctions(functionNames.filter(n => n != name)))
+    }
+  }
+}
+
+export const selectTagKey = (index: number, key: string) => (
+  dispatch: Dispatch<Action>
+) => {
+  dispatch(setBuilderTagKeySelection(index, key))
+  dispatch(loadTagSelectorValues(index))
+}
+
+export const searchTagValues = (index: number) => (
+  dispatch: Dispatch<Action>
+) => {
+  dispatch(loadTagSelectorValues(index))
+}
+
+export const searchTagKeys = (index: number) => (
+  dispatch: Dispatch<Action>
+) => {
+  dispatch(loadTagSelector(index))
+}
+
+export const addTagSelector = () => (
+  dispatch: Dispatch<Action>,
+  getState: GetState
+) => {
+  dispatch(addTagSelectorSync())
+
+  const newIndex = getActiveQuery(getState()).builderConfig.tags.length - 1
+
+  dispatch(loadTagSelector(newIndex))
+}
+
+export const reloadTagSelectors = () => (dispatch: Dispatch<Action>) => {
+  dispatch(setBuilderTagsStatus(RemoteDataState.Loading))
+  dispatch(loadTagSelector(0))
+}
+
+export const setBuilderBucketIfExists = (bucketName: string) => (
+  dispatch: Dispatch<
+    Action | ReturnType<typeof editActiveQueryWithBuilderSync>
+  >,
+  getState: GetState
+) => {
+  const buckets = getAll<Bucket>(getState(), ResourceType.Buckets)
+  if (buckets.find(b => b.name === bucketName)) {
+    dispatch(editActiveQueryWithBuilderSync())
+    dispatch(setBuilderBucket(bucketName, true))
+  }
+}

--- a/src/timeMachine/components/FunctionModeSelector.tsx
+++ b/src/timeMachine/components/FunctionModeSelector.tsx
@@ -18,8 +18,9 @@ import SelectorList from 'src/timeMachine/components/SelectorList'
 import {
   multiSelectBuilderFunction,
   singleSelectBuilderFunction,
-  setFunctions,
-} from 'src/timeMachine/actions/queryBuilder'
+} from 'src/timeMachine/actions/queryBuilderThunks'
+
+import {setFunctions} from 'src/timeMachine/actions/queryBuilder'
 import {setIsAutoFunction} from 'src/shared/actions/currentExplorer'
 import {getActiveQuery, getIsInCheckOverlay} from 'src/timeMachine/selectors'
 

--- a/src/timeMachine/components/QueryBuilder.tsx
+++ b/src/timeMachine/components/QueryBuilder.tsx
@@ -12,7 +12,10 @@ import BucketsSelector from 'src/timeMachine/components/queryBuilder/BucketsSele
 import {DapperScrollbars} from '@influxdata/clockface'
 
 // Actions
-import {loadBuckets, addTagSelector} from 'src/timeMachine/actions/queryBuilder'
+import {
+  loadBuckets,
+  addTagSelector,
+} from 'src/timeMachine/actions/queryBuilderThunks'
 
 // Utils
 import {getActiveQuery, getActiveTimeMachine} from 'src/timeMachine/selectors'

--- a/src/timeMachine/components/TagSelector.tsx
+++ b/src/timeMachine/components/TagSelector.tsx
@@ -25,6 +25,9 @@ import {
   searchTagValues,
   selectTagKey,
   selectTagValue,
+} from 'src/timeMachine/actions/queryBuilderThunks'
+
+import {
   setBuilderAggregateFunctionType,
   setKeysSearchTerm,
   setValuesSearchTerm,

--- a/src/timeMachine/components/WindowPeriod.tsx
+++ b/src/timeMachine/components/WindowPeriod.tsx
@@ -15,7 +15,7 @@ import DurationInput from 'src/shared/components/DurationInput'
 import {
   setWindowPeriodSelectionMode,
   selectAggregateWindow,
-} from 'src/timeMachine/actions/queryBuilder'
+} from 'src/timeMachine/actions/queryBuilderThunks'
 
 // Utils
 import {

--- a/src/timeMachine/components/queryBuilder/BucketsSelector.tsx
+++ b/src/timeMachine/components/queryBuilder/BucketsSelector.tsx
@@ -10,7 +10,7 @@ import SelectorListCreateBucket from 'src/timeMachine/components/SelectorListCre
 import {Input} from '@influxdata/clockface'
 
 // Actions
-import {selectBucket} from 'src/timeMachine/actions/queryBuilder'
+import {selectBucket} from 'src/timeMachine/actions/queryBuilderThunks'
 
 // Utils
 import {getActiveQuery} from 'src/timeMachine/selectors'


### PR DESCRIPTION
Another joint brought to you by Refactor Friday

- Moves all side effects out of the query builder actions into a thunks file
- Fixes imports

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
