### PR TITLE
chore: lazy load svgs

### DIFF
--- a/src/perf/components/LazySVG.tsx
+++ b/src/perf/components/LazySVG.tsx
@@ -1,0 +1,11 @@
+import React, {FC} from 'react'
+
+interface Props {
+  image: string
+}
+
+const LazySVG: FC<Props> = ({image}) => {
+  return <img src={image} />
+}
+
+export default LazySVG

--- a/src/writeData/components/WriteDataItem.tsx
+++ b/src/writeData/components/WriteDataItem.tsx
@@ -1,10 +1,11 @@
 // Libraries
-import React, {FC} from 'react'
+import React, {FC, Suspense} from 'react'
 import {connect} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
 import {SelectableCard, SquareGrid, ComponentSize} from '@influxdata/clockface'
+const LazySVG = React.lazy(() => import('src/perf/components/LazySVG'))
 
 // Utils
 import {getOrg} from 'src/organizations/selectors'
@@ -36,7 +37,11 @@ const WriteDataItem: FC<Props> = ({id, name, url, image, history, orgID}) => {
   let thumb = <img src={placeholderLogo} />
 
   if (image) {
-    thumb = <img src={image} />
+    thumb = (
+      <Suspense fallback="Loading...">
+        <LazySVG image={image} />
+      </Suspense>
+    )
   }
 
   return (


### PR DESCRIPTION
Improves performance of `load-data/sources` page by using React Suspense/lazy to load each SVG independently of the rest of the page.


https://user-images.githubusercontent.com/6411855/107820498-be634780-6d2f-11eb-8973-f685903c7123.mov



- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
