### PR TITLE
test: fixes querybuilder failing test

### DIFF
--- a/cypress/e2e/shared/dashboardsIndex.test.ts
+++ b/cypress/e2e/shared/dashboardsIndex.test.ts
@@ -360,6 +360,7 @@ describe('Dashboards', () => {
 
         cy.get('@org').then(({id}: Organization) => {
           cy.createLabel(labelName, id).then(() => {
+            cy.reload()
             cy.getByTestID(`inline-labels--add`)
               .first()
               .click()

--- a/cypress/e2e/shared/queryBuilder.test.ts
+++ b/cypress/e2e/shared/queryBuilder.test.ts
@@ -125,15 +125,13 @@ describe('The Query Builder', () => {
       cy.getByTestID('auto-window-period').click()
 
       cy.getByTestID('duration-input--error').should('not.exist')
-      cy.getByTestID('toggle')
-        .click()
-        .then(() => {
-          cy.getByTestID('switch-to-script-editor').click()
+      cy.get('label[class="cf-toggle--visual-input"]').click()
 
-          cy.contains(
-            '|> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: true)'
-          ).should('exist')
-        })
+      cy.getByTestID('switch-to-script-editor').click()
+
+      cy.contains(
+        '|> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: true)'
+      ).should('exist')
     })
 
     it('can create a bucket from the buckets list', () => {

--- a/cypress/e2e/shared/queryBuilder.test.ts
+++ b/cypress/e2e/shared/queryBuilder.test.ts
@@ -130,7 +130,7 @@ describe('The Query Builder', () => {
         .then(() => {
           // I (Gene) can't find a way around using a wait here.
           // Clicking the script button too quickly doesn't allow the text to update as expected.
-          cy.wait(500)
+          cy.wait(5000)
           cy.getByTestID('switch-to-script-editor').click()
           cy.contains(
             '|> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: true)'

--- a/cypress/e2e/shared/queryBuilder.test.ts
+++ b/cypress/e2e/shared/queryBuilder.test.ts
@@ -125,6 +125,7 @@ describe('The Query Builder', () => {
       cy.getByTestID('auto-window-period').click()
 
       cy.getByTestID('duration-input--error').should('not.exist')
+      cy.wait(5000)
       cy.get('label[class="cf-toggle--visual-input"]')
         .click()
         .then(() => {

--- a/cypress/e2e/shared/queryBuilder.test.ts
+++ b/cypress/e2e/shared/queryBuilder.test.ts
@@ -125,13 +125,15 @@ describe('The Query Builder', () => {
       cy.getByTestID('auto-window-period').click()
 
       cy.getByTestID('duration-input--error').should('not.exist')
-      cy.get('label[class="cf-toggle--visual-input"]').click()
+      cy.get('label[class="cf-toggle--visual-input"]')
+        .click()
+        .then(() => {
+          cy.getByTestID('switch-to-script-editor').click()
 
-      cy.getByTestID('switch-to-script-editor').click()
-
-      cy.contains(
-        '|> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: true)'
-      ).should('exist')
+          cy.contains(
+            '|> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: true)'
+          ).should('exist')
+        })
     })
 
     it('can create a bucket from the buckets list', () => {

--- a/cypress/e2e/shared/queryBuilder.test.ts
+++ b/cypress/e2e/shared/queryBuilder.test.ts
@@ -125,7 +125,7 @@ describe('The Query Builder', () => {
       cy.getByTestID('auto-window-period').click()
 
       cy.getByTestID('duration-input--error').should('not.exist')
-      cy.contains('Fill missing values').click()
+      cy.getByTestID('toggle').click()
       cy.getByTestID('switch-to-script-editor').click()
 
       cy.contains(

--- a/cypress/e2e/shared/queryBuilder.test.ts
+++ b/cypress/e2e/shared/queryBuilder.test.ts
@@ -128,8 +128,10 @@ describe('The Query Builder', () => {
       cy.get('label[class="cf-toggle--visual-input"]')
         .click()
         .then(() => {
+          // I (Gene) can't find a way around using a wait here.
+          // Clicking the script button too quickly doesn't allow the text to update as expected.
+          cy.wait(500)
           cy.getByTestID('switch-to-script-editor').click()
-
           cy.contains(
             '|> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: true)'
           ).should('exist')

--- a/cypress/e2e/shared/queryBuilder.test.ts
+++ b/cypress/e2e/shared/queryBuilder.test.ts
@@ -125,12 +125,15 @@ describe('The Query Builder', () => {
       cy.getByTestID('auto-window-period').click()
 
       cy.getByTestID('duration-input--error').should('not.exist')
-      cy.getByTestID('toggle').click()
-      cy.getByTestID('switch-to-script-editor').click()
+      cy.getByTestID('toggle')
+        .click()
+        .then(() => {
+          cy.getByTestID('switch-to-script-editor').click()
 
-      cy.contains(
-        '|> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: true)'
-      ).should('exist')
+          cy.contains(
+            '|> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: true)'
+          ).should('exist')
+        })
     })
 
     it('can create a bucket from the buckets list', () => {

--- a/cypress/e2e/shared/queryBuilder.test.ts
+++ b/cypress/e2e/shared/queryBuilder.test.ts
@@ -125,18 +125,14 @@ describe('The Query Builder', () => {
       cy.getByTestID('auto-window-period').click()
 
       cy.getByTestID('duration-input--error').should('not.exist')
-      cy.wait(5000)
-      cy.get('label[class="cf-toggle--visual-input"]')
-        .click()
-        .then(() => {
-          // I (Gene) can't find a way around using a wait here.
-          // Clicking the script button too quickly doesn't allow the text to update as expected.
-          cy.wait(5000)
-          cy.getByTestID('switch-to-script-editor').click()
-          cy.contains(
-            '|> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: true)'
-          ).should('exist')
-        })
+
+      cy.get('label[class="cf-toggle--visual-input"]').click()
+      cy.contains('Fill missing values').click()
+
+      cy.getByTestID('switch-to-script-editor').click()
+      cy.contains(
+        '|> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: true)'
+      ).should('exist')
     })
 
     it('can create a bucket from the buckets list', () => {


### PR DESCRIPTION
Query builder test was failing because selecting the text didn't toggle the radio button.

https://app.circleci.com/pipelines/github/influxdata/idpe/12784/workflows/ce864ec7-7d88-4f3b-9cf0-1c3e0d457635/jobs/243438

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
