### PR TITLE
fix: link to repo opens in new tab

### DIFF
--- a/src/writeData/components/clientLibraries/Arduino.md
+++ b/src/writeData/components/clientLibraries/Arduino.md
@@ -1,4 +1,4 @@
-For more detailed and up to date information check out the [GitHub Repository](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino)
+For more detailed and up to date information check out the <a href="https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino" target="_blank">GitHub Repository</a>
 
 ##### Install Library
 

--- a/src/writeData/components/clientLibraries/CSharp.md
+++ b/src/writeData/components/clientLibraries/CSharp.md
@@ -1,4 +1,4 @@
-For more detailed and up to date information check out the [GitHub Repository](https://github.com/influxdata/influxdb-client-csharp)
+For more detailed and up to date information check out the <a href="https://github.com/influxdata/influxdb-client-csharp" target="_blank">GitHub Repository</a>
 
 ##### Install Package
 

--- a/src/writeData/components/clientLibraries/Go.md
+++ b/src/writeData/components/clientLibraries/Go.md
@@ -1,4 +1,4 @@
-For more detailed and up to date information check out the [GitHub Repository](https://github.com/influxdata/influxdb-client-go)
+For more detailed and up to date information check out the <a href="https://github.com/influxdata/influxdb-client-go" target="_blank">GitHub Repository</a>
 
 ##### Initialize the Client
 

--- a/src/writeData/components/clientLibraries/Java.md
+++ b/src/writeData/components/clientLibraries/Java.md
@@ -1,4 +1,4 @@
-For more detailed and up to date information check out the [GitHub Repository](https://github.com/influxdata/influxdb-client-java)
+For more detailed and up to date information check out the <a href="https://github.com/influxdata/influxdb-client-java" target="_blank">GitHub Repository</a>
 
 ##### Add Dependency
 

--- a/src/writeData/components/clientLibraries/Kotlin.md
+++ b/src/writeData/components/clientLibraries/Kotlin.md
@@ -1,4 +1,4 @@
-For more detailed and up to date information check out the [GitHub Repository](https://github.com/influxdata/influxdb-client-java/tree/master/client-kotlin)
+For more detailed and up to date information check out the <a href="https://github.com/influxdata/influxdb-client-java/tree/master/client-kotlin" target="_blank">GitHub Repository</a>
 
 ##### Add Dependency
 

--- a/src/writeData/components/clientLibraries/Node.md
+++ b/src/writeData/components/clientLibraries/Node.md
@@ -1,4 +1,4 @@
-For more detailed and up to date information check out the [GitHub Repository](https://github.com/influxdata/influxdb-client-js)
+For more detailed and up to date information check out the <a href="https://github.com/influxdata/influxdb-client-js" target="_blank">GitHub Repository</a>
 
 ##### Install via NPM
 

--- a/src/writeData/components/clientLibraries/PHP.md
+++ b/src/writeData/components/clientLibraries/PHP.md
@@ -1,4 +1,4 @@
-For more detailed and up to date information check out the [GitHub Repository](https://github.com/influxdata/influxdb-client-php)
+For more detailed and up to date information check out the <a href="https://github.com/influxdata/influxdb-client-php" target="_blank">GitHub Repository</a>
 
 ##### Install via Composer
 

--- a/src/writeData/components/clientLibraries/Python.md
+++ b/src/writeData/components/clientLibraries/Python.md
@@ -1,4 +1,4 @@
-For more detailed and up to date information check out the [GitHub Repository](https://github.com/influxdata/influxdb-client-python)
+For more detailed and up to date information check out the <a href="https://github.com/influxdata/influxdb-client-python" target="_blank">GitHub Repository</a>
 
 ##### Install Package
 

--- a/src/writeData/components/clientLibraries/Ruby.md
+++ b/src/writeData/components/clientLibraries/Ruby.md
@@ -1,4 +1,4 @@
-For more detailed and up to date information check out the [GitHub Repository](https://github.com/influxdata/influxdb-client-ruby)
+For more detailed and up to date information check out the <a href="https://github.com/influxdata/influxdb-client-ruby" target="_blank">GitHub Repository</a>
 
 ##### Install the Gem
 

--- a/src/writeData/components/clientLibraries/Scala.md
+++ b/src/writeData/components/clientLibraries/Scala.md
@@ -1,4 +1,4 @@
-For more detailed and up to date information check out the [GitHub Repository](https://github.com/influxdata/influxdb-client-java/tree/master/client-scala)
+For more detailed and up to date information check out the <a href="https://github.com/influxdata/influxdb-client-java/tree/master/client-scala" target="_blank">GitHub Repository</a>
 
 ##### Add Dependency
 

--- a/src/writeData/components/clientLibraries/Swift.md
+++ b/src/writeData/components/clientLibraries/Swift.md
@@ -1,4 +1,4 @@
-For more detailed and up to date information check out the [GitHub Repository](https://github.com/influxdata/influxdb-client-swift/)
+For more detailed and up to date information check out the <a href="https://github.com/influxdata/influxdb-client-swift/" target="_blank">GitHub Repository</a>
 
 ##### Install via Swift Package Manager
 


### PR DESCRIPTION
Closes #628 

<!-- Describe your proposed changes here. -->
Links to the respective github repository for a given client library now open in new tabs, which should prevent redirect and go-back related issues seen by users up until now. 

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
