### PR TITLE
fix: better error message for failed line protocol upload

### DIFF
--- a/src/buckets/components/lineProtocol/LineProtocol.thunks.ts
+++ b/src/buckets/components/lineProtocol/LineProtocol.thunks.ts
@@ -41,7 +41,16 @@ export const writeLineProtocolAction = async (
       dispatch(setWriteStatus(RemoteDataState.Error, resp.data.message))
     } else {
       const message = resp?.data?.message || 'Failed to write data'
-      dispatch(setWriteStatus(RemoteDataState.Error, message))
+      if (resp?.data?.code === 'invalid') {
+        dispatch(
+          setWriteStatus(
+            RemoteDataState.Error,
+            'Failed to write data - invalid line protocol submitted'
+          )
+        )
+      } else {
+        dispatch(setWriteStatus(RemoteDataState.Error, message))
+      }
       throw new Error(message)
     }
   } catch (error) {


### PR DESCRIPTION
Closes #677

<!-- Describe your proposed changes here. -->
Under this PR, the error message will now be displayed under the red influx sign, and the full error message is still in the console in case someone really has a case of the scrollies and wants to see that bad boy. 


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
![Screen Shot 2021-02-16 at 9 29 18 AM](https://user-images.githubusercontent.com/29473622/108118457-fdf99e80-7063-11eb-9ef7-9a25c6b16478.png)
