### PR TITLE
fix: trim url and add error for spaces in between characters in url

### DIFF
--- a/src/templates/containers/CommunityTemplatesIndex.tsx
+++ b/src/templates/containers/CommunityTemplatesIndex.tsx
@@ -245,7 +245,9 @@ class UnconnectedCommunityTemplatesIndex extends Component<Props, State> {
 
     try {
       event('template_click_lookup', {
-        templateName: getTemplateNameFromUrl(this.props.stagedTemplateUrl).name,
+        templateName: getTemplateNameFromUrl(
+          this.props.stagedTemplateUrl.trim()
+        ).name,
       })
       this.props.history.push(
         `/orgs/${this.props.org.id}/settings/templates/import`
@@ -262,7 +264,7 @@ class UnconnectedCommunityTemplatesIndex extends Component<Props, State> {
     const validationMessage = validateTemplateURL(event.target.value)
 
     this.setValidationMessage(validationMessage)
-    this.props.setStagedTemplateUrl(event.target.value)
+    this.props.setStagedTemplateUrl(event.target.value.trim())
   }
 
   private handleInputKeyPress = event => {

--- a/src/templates/containers/CommunityTemplatesIndex.tsx
+++ b/src/templates/containers/CommunityTemplatesIndex.tsx
@@ -259,10 +259,11 @@ class UnconnectedCommunityTemplatesIndex extends Component<Props, State> {
   }
 
   private handleTemplateChange = event => {
-    const validationMessage = validateTemplateURL(event.target.value)
+    const trimmedValue = event.target.value.trim()
+    const validationMessage = validateTemplateURL(trimmedValue)
 
     this.setValidationMessage(validationMessage)
-    this.props.setStagedTemplateUrl(event.target.value.trim())
+    this.props.setStagedTemplateUrl(trimmedValue)
   }
 
   private handleInputKeyPress = event => {

--- a/src/templates/containers/CommunityTemplatesIndex.tsx
+++ b/src/templates/containers/CommunityTemplatesIndex.tsx
@@ -245,9 +245,7 @@ class UnconnectedCommunityTemplatesIndex extends Component<Props, State> {
 
     try {
       event('template_click_lookup', {
-        templateName: getTemplateNameFromUrl(
-          this.props.stagedTemplateUrl.trim()
-        ).name,
+        templateName: getTemplateNameFromUrl(this.props.stagedTemplateUrl).name,
       })
       this.props.history.push(
         `/orgs/${this.props.org.id}/settings/templates/import`

--- a/src/templates/utils/index.test.ts
+++ b/src/templates/utils/index.test.ts
@@ -212,7 +212,7 @@ describe('validating template URLs', () => {
     })
 
     it('notifies the user when the URL is invalid due to spaces', () => {
-      const errorMessage = 'URL cannot contain spaces'
+      const errorMessage = `Your URL can't contain spaces`
       expect(
         validateTemplateURL(
           'https://github.com/influxdata/community-templates/  blob/master/linux_system/linux_system.yml'

--- a/src/templates/utils/index.test.ts
+++ b/src/templates/utils/index.test.ts
@@ -212,7 +212,7 @@ describe('validating template URLs', () => {
     })
 
     it('notifies the user when the URL is invalid due to spaces', () => {
-      const errorMessage = `Your URL can't contain spaces`
+      const errorMessage = "Your URL can't contain spaces"
       expect(
         validateTemplateURL(
           'https://github.com/influxdata/community-templates/  blob/master/linux_system/linux_system.yml'
@@ -224,9 +224,6 @@ describe('validating template URLs', () => {
       const errorMessage = "We can't use that URL"
       expect(validateTemplateURL('http://www.example.com')).toBe(errorMessage)
       expect(validateTemplateURL('http://www.example.com/template.toml')).toBe(
-        errorMessage
-      )
-      expect(validateTemplateURL('Jackdaws love my big sphinx of quartz')).toBe(
         errorMessage
       )
     })

--- a/src/templates/utils/index.test.ts
+++ b/src/templates/utils/index.test.ts
@@ -211,6 +211,15 @@ describe('validating template URLs', () => {
       )
     })
 
+    it('notifies the user when the URL is invalid due to spaces', () => {
+      const errorMessage = 'URL cannot contain spaces'
+      expect(
+        validateTemplateURL(
+          'https://github.com/influxdata/community-templates/  blob/master/linux_system/linux_system.yml'
+        )
+      ).toBe(errorMessage)
+    })
+
     it("notifies the user when it's neither a correct community template nor a correct file type", () => {
       const errorMessage = "We can't use that URL"
       expect(validateTemplateURL('http://www.example.com')).toBe(errorMessage)

--- a/src/templates/utils/index.ts
+++ b/src/templates/utils/index.ts
@@ -169,6 +169,10 @@ export const validateTemplateURL = (url): string => {
     return "We can't use that URL"
   }
 
+  if (cleanUrl.includes(' ')) {
+    return 'URL cannot contain spaces'
+  }
+
   return TEMPLATE_URL_VALID
 }
 

--- a/src/templates/utils/index.ts
+++ b/src/templates/utils/index.ts
@@ -147,7 +147,7 @@ export const validateTemplateURL = (url): string => {
   const cleanUrl = url.trim().split('?')[0]
 
   if (cleanUrl.includes(' ')) {
-    return `Your URL can't contain spaces`
+    return "Your URL can't contain spaces"
   }
 
   const isCommunityTemplates =

--- a/src/templates/utils/index.ts
+++ b/src/templates/utils/index.ts
@@ -146,6 +146,10 @@ export const validateTemplateURL = (url): string => {
   */
   const cleanUrl = url.trim().split('?')[0]
 
+  if (cleanUrl.includes(' ')) {
+    return `Your URL can't contain spaces`
+  }
+
   const isCommunityTemplates =
     cleanUrl.startsWith('https://github.com/influxdata/community-templates') ||
     cleanUrl.startsWith(
@@ -167,10 +171,6 @@ export const validateTemplateURL = (url): string => {
 
   if (!isCommunityTemplates && !isCorrectFileType) {
     return "We can't use that URL"
-  }
-
-  if (cleanUrl.includes(' ')) {
-    return 'URL cannot contain spaces'
   }
 
   return TEMPLATE_URL_VALID


### PR DESCRIPTION
Closes #697 

<!-- Describe your proposed changes here. -->
This PR introduces an error message for the template url uploader when there is a space in between characters in the url and it also trims the url before submission.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
