### PR TITLE
fix: single source of truth for accessing the current org

### DIFF
--- a/src/buckets/components/RenameBucketForm.tsx
+++ b/src/buckets/components/RenameBucketForm.tsx
@@ -25,13 +25,14 @@ import {AppState, Bucket, ResourceType, OwnBucket} from 'src/types'
 
 // Selectors
 import {getAll, getByID} from 'src/resources/selectors'
+import {getOrg} from 'src/organizations/selectors'
 
 interface State {
   bucket: OwnBucket
 }
 
 type ReduxProps = ConnectedProps<typeof connector>
-type RouterProps = RouteComponentProps<{bucketID: string; orgID: string}>
+type RouterProps = RouteComponentProps<{bucketID: string}>
 type Props = ReduxProps & RouterProps
 
 class RenameBucketForm extends PureComponent<Props, State> {
@@ -126,9 +127,9 @@ class RenameBucketForm extends PureComponent<Props, State> {
   }
 
   private handleClose = () => {
-    const {history, match} = this.props
+    const {history, org} = this.props
 
-    history.push(`/orgs/${match.params.orgID}/load-data/buckets`)
+    history.push(`/orgs/${org.id}/load-data/buckets`)
   }
 }
 
@@ -139,10 +140,12 @@ const mstp = (state: AppState, props: RouterProps) => {
   const buckets = getAll<Bucket>(state, ResourceType.Buckets).filter(
     b => b.id !== bucketID
   )
+  const org = getOrg(state)
 
   return {
     startBucket,
     buckets,
+    org,
   }
 }
 

--- a/src/buckets/components/RenameBucketOverlay.tsx
+++ b/src/buckets/components/RenameBucketOverlay.tsx
@@ -1,54 +1,46 @@
 // Libraries
-import React, {PureComponent} from 'react'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
-
-import _ from 'lodash'
+import React, {FC, useCallback} from 'react'
+import {useHistory} from 'react-router-dom'
+import {useSelector} from 'react-redux'
 
 // Components
 import DangerConfirmationOverlay from 'src/shared/components/dangerConfirmation/DangerConfirmationOverlay'
 import RenameBucketForm from 'src/buckets/components/RenameBucketForm'
+import {getOrg} from 'src/organizations/selectors'
 
 // Decorators
-import {ErrorHandling} from 'src/shared/decorators/errors'
 import {Overlay} from '@influxdata/clockface'
-@ErrorHandling
-class RenameBucketOverlay extends PureComponent<
-  RouteComponentProps<{orgID: string}>
-> {
-  public render() {
-    return (
-      <Overlay visible={true}>
-        <DangerConfirmationOverlay
-          title="Rename Bucket"
-          message={this.message}
-          effectedItems={this.effectedItems}
-          onClose={this.handleClose}
-          confirmButtonText="I understand, let's rename my Bucket"
-        >
-          <RenameBucketForm />
-        </DangerConfirmationOverlay>
-      </Overlay>
-    )
-  }
 
-  private get message(): string {
-    return 'Updating the name of a Bucket can have unintended consequences. Anything that references this Bucket by name will stop working including:'
-  }
+const MESSAGE =
+  'Updating the name of a Bucket can have unintended consequences. Anything that references this Bucket by name will stop working including:'
+const EFFECTED_ITEMS = [
+  'Queries',
+  'Dashboards',
+  'Tasks',
+  'Telegraf Configurations',
+  'Templates',
+]
 
-  private get effectedItems(): string[] {
-    return [
-      'Queries',
-      'Dashboards',
-      'Tasks',
-      'Telegraf Configurations',
-      'Templates',
-    ]
-  }
+const RenameBucketOverlay: FC = () => {
+  const history = useHistory()
+  const org = useSelector(getOrg)
+  const handleClose = useCallback(() => {
+    history.push(`/orgs/${org.id}/load-data/buckets`)
+  }, [history, org])
 
-  private handleClose = () => {
-    const {history, match} = this.props
-    history.push(`/orgs/${match.params.orgID}/load-data/buckets`)
-  }
+  return (
+    <Overlay visible={true}>
+      <DangerConfirmationOverlay
+        title="Rename Bucket"
+        message={MESSAGE}
+        effectedItems={EFFECTED_ITEMS}
+        onClose={handleClose}
+        confirmButtonText="I understand, let's rename my Bucket"
+      >
+        <RenameBucketForm />
+      </DangerConfirmationOverlay>
+    </Overlay>
+  )
 }
 
-export default withRouter(RenameBucketOverlay)
+export default RenameBucketOverlay

--- a/src/dashboards/components/RouteToDashboardList.tsx
+++ b/src/dashboards/components/RouteToDashboardList.tsx
@@ -1,11 +1,13 @@
 import {FC} from 'react'
-import {RouteComponentProps} from 'react-router-dom'
+import {useSelector} from 'react-redux'
+import {useHistory} from 'react-router-dom'
+import {getOrg} from 'src/organizations/selectors'
 
-const RouteToDashboardList: FC<RouteComponentProps<{orgID: string}>> = ({
-  history,
-  match,
-}) => {
-  history.push(`/orgs/${match.params.orgID}/dashboards-list`)
+const RouteToDashboardList: FC = () => {
+  const history = useHistory()
+  const org = useSelector(getOrg)
+
+  history.push(`/orgs/${org.id}/dashboards-list`)
   return null
 }
 

--- a/src/members/containers/MembersIndex.tsx
+++ b/src/members/containers/MembersIndex.tsx
@@ -1,9 +1,7 @@
-import React, {Component} from 'react'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect, ConnectedProps} from 'react-redux'
+import React, {FC} from 'react'
+import {useSelector} from 'react-redux'
 
 // Components
-import {ErrorHandling} from 'src/shared/decorators/errors'
 import OrgTabbedPage from 'src/organizations/components/OrgTabbedPage'
 import OrgHeader from 'src/organizations/components/OrgHeader'
 import {Page} from '@influxdata/clockface'
@@ -12,52 +10,27 @@ import Members from 'src/members/components/Members'
 
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
-import {getByID} from 'src/resources/selectors'
+import {getOrg} from 'src/organizations/selectors'
 
 // Types
-import {AppState, Organization, ResourceType} from 'src/types'
+import {ResourceType} from 'src/types'
 
-type ReduxProps = ConnectedProps<typeof connector>
-type RouterProps = RouteComponentProps<{orgID: string}>
-type Props = RouterProps & ReduxProps
+const MembersIndex: FC = ({children}) => {
+  const org = useSelector(getOrg)
 
-@ErrorHandling
-class MembersIndex extends Component<Props> {
-  constructor(props) {
-    super(props)
-  }
-
-  public render() {
-    const {org, children} = this.props
-
-    return (
-      <>
-        <Page titleTag={pageTitleSuffixer(['Members', 'Organization'])}>
-          <OrgHeader />
-          <OrgTabbedPage activeTab="members" orgID={org.id}>
-            <GetResources resources={[ResourceType.Members]}>
-              <Members />
-            </GetResources>
-          </OrgTabbedPage>
-        </Page>
-        {children}
-      </>
-    )
-  }
-}
-
-const mstp = (state: AppState, props: RouterProps) => {
-  const org = getByID<Organization>(
-    state,
-    ResourceType.Orgs,
-    props.match.params.orgID
+  return (
+    <>
+      <Page titleTag={pageTitleSuffixer(['Members', 'Organization'])}>
+        <OrgHeader />
+        <OrgTabbedPage activeTab="members" orgID={org.id}>
+          <GetResources resources={[ResourceType.Members]}>
+            <Members />
+          </GetResources>
+        </OrgTabbedPage>
+      </Page>
+      {children}
+    </>
   )
-
-  return {
-    org,
-  }
 }
 
-const connector = connect(mstp)
-
-export default connector(withRouter(MembersIndex))
+export default MembersIndex

--- a/src/notifications/endpoints/components/EndpointsColumn.tsx
+++ b/src/notifications/endpoints/components/EndpointsColumn.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FC} from 'react'
-import {connect} from 'react-redux'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
+import {useSelector} from 'react-redux'
+import {useHistory} from 'react-router-dom'
 
 // Components
 import {Button, IconFont, ComponentColor} from '@influxdata/clockface'
@@ -12,20 +12,20 @@ import {AppState, NotificationEndpoint, ResourceType} from 'src/types'
 // Utils
 import {getAll} from 'src/resources/selectors'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import {getOrg} from 'src/organizations/selectors'
 
-interface StateProps {
-  endpoints: NotificationEndpoint[]
-}
-interface OwnProps {
+interface Props {
   tabIndex: number
 }
 
-type Props = OwnProps & RouteComponentProps<{orgID: string}> & StateProps
-
-const EndpointsColumn: FC<Props> = ({history, match, endpoints, tabIndex}) => {
+const EndpointsColumn: FC<Props> = ({tabIndex}) => {
+  const history = useHistory()
+  const org = useSelector(getOrg)
+  const endpoints = useSelector((state: AppState) =>
+    getAll<NotificationEndpoint>(state, ResourceType.NotificationEndpoints)
+  )
   const handleOpenOverlay = () => {
-    const newRuleRoute = `/orgs/${match.params.orgID}/alerting/endpoints/new`
-    history.push(newRuleRoute)
+    history.push(`/orgs/${org.id}/alerting/endpoints/new`)
   }
 
   const conditionalEndpoints: Array<string> = []
@@ -76,13 +76,4 @@ const EndpointsColumn: FC<Props> = ({history, match, endpoints, tabIndex}) => {
   )
 }
 
-const mstp = (state: AppState) => {
-  const endpoints = getAll<NotificationEndpoint>(
-    state,
-    ResourceType.NotificationEndpoints
-  )
-
-  return {endpoints}
-}
-
-export default connect<StateProps>(mstp)(withRouter(EndpointsColumn))
+export default EndpointsColumn

--- a/src/notifications/endpoints/components/NewEndpointOverlay.tsx
+++ b/src/notifications/endpoints/components/NewEndpointOverlay.tsx
@@ -1,10 +1,11 @@
 // Libraries
 import React, {FC, useMemo} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
+import {useDispatch, useSelector} from 'react-redux'
+import {useHistory} from 'react-router-dom'
 
 // Actions
 import {createEndpoint} from 'src/notifications/endpoints/actions/thunks'
+import {getOrg} from 'src/organizations/selectors'
 
 // Components
 import {Overlay} from '@influxdata/clockface'
@@ -16,22 +17,23 @@ import {NEW_ENDPOINT_DRAFT} from 'src/alerting/constants'
 import {NotificationEndpoint} from 'src/types'
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
 
-type ReduxProps = ConnectedProps<typeof connector>
-type Props = RouteComponentProps<{orgID: string}> & ReduxProps
-
-const NewRuleOverlay: FC<Props> = ({match, history, onCreateEndpoint}) => {
-  const {orgID} = match.params
+const NewRuleOverlay: FC = () => {
+  const org = useSelector(getOrg)
+  const history = useHistory()
+  const dispatch = useDispatch()
 
   const handleDismiss = () => {
-    history.push(`/orgs/${orgID}/alerting`)
+    history.push(`/orgs/${org.id}/alerting`)
   }
 
   const handleCreateEndpoint = (endpoint: NotificationEndpoint) => {
-    onCreateEndpoint(endpoint)
+    dispatch(createEndpoint(endpoint))
     handleDismiss()
   }
 
-  const initialState = useMemo(() => ({...NEW_ENDPOINT_DRAFT, orgID}), [orgID])
+  const initialState = useMemo(() => ({...NEW_ENDPOINT_DRAFT, orgID: org.id}), [
+    org.id,
+  ])
 
   return (
     <EndpointOverlayProvider initialState={initialState}>
@@ -54,10 +56,4 @@ const NewRuleOverlay: FC<Props> = ({match, history, onCreateEndpoint}) => {
   )
 }
 
-const mdtp = {
-  onCreateEndpoint: createEndpoint,
-}
-
-const connector = connect(null, mdtp)
-
-export default connector(withRouter(NewRuleOverlay))
+export default NewRuleOverlay

--- a/src/notifications/rules/components/RulesColumn.tsx
+++ b/src/notifications/rules/components/RulesColumn.tsx
@@ -1,7 +1,7 @@
 // Libraries
-import React, {FunctionComponent} from 'react'
-import {connect} from 'react-redux'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
+import React, {FC} from 'react'
+import {useSelector} from 'react-redux'
+import {useHistory} from 'react-router-dom'
 
 // Types
 import {
@@ -23,28 +23,25 @@ import AlertsColumn from 'src/alerting/components/AlertsColumn'
 
 // Selectors
 import {getAll} from 'src/resources/selectors'
+import {getOrg} from 'src/organizations/selectors'
 
-interface OwnProps {
+interface Props {
   tabIndex: number
 }
 
-interface StateProps {
-  rules: NotificationRuleDraft[]
-  endpoints: NotificationEndpoint[]
-}
+const NotificationRulesColumn: FC<Props> = ({tabIndex}) => {
+  const history = useHistory()
+  const org = useSelector(getOrg)
+  const rules = useSelector((state: AppState) =>
+    getAll<NotificationRuleDraft>(state, ResourceType.NotificationRules)
+  )
 
-type Props = OwnProps & StateProps & RouteComponentProps<{orgID: string}>
+  const endpoints = useSelector((state: AppState) =>
+    getAll<NotificationEndpoint>(state, ResourceType.NotificationEndpoints)
+  )
 
-const NotificationRulesColumn: FunctionComponent<Props> = ({
-  rules,
-  history,
-  match,
-  endpoints,
-  tabIndex,
-}) => {
   const handleOpenOverlay = () => {
-    const newRuleRoute = `/orgs/${match.params.orgID}/alerting/rules/new`
-    history.push(newRuleRoute)
+    history.push(`/orgs/${org.id}/alerting/rules/new`)
   }
 
   const tooltipContents = (
@@ -102,21 +99,4 @@ const NotificationRulesColumn: FunctionComponent<Props> = ({
   )
 }
 
-const mstp = (state: AppState) => {
-  const rules = getAll<NotificationRuleDraft>(
-    state,
-    ResourceType.NotificationRules
-  )
-
-  const endpoints = getAll<NotificationEndpoint>(
-    state,
-    ResourceType.NotificationEndpoints
-  )
-
-  return {rules, endpoints}
-}
-
-export default connect<StateProps>(
-  mstp,
-  null
-)(withRouter(NotificationRulesColumn))
+export default NotificationRulesColumn

--- a/src/overlays/components/OverlayController.tsx
+++ b/src/overlays/components/OverlayController.tsx
@@ -10,7 +10,7 @@ import React, {
 import {useDispatch, useSelector} from 'react-redux'
 
 // Types
-import {AppState} from 'src/types'
+import {AppState, OverlayParams} from 'src/types'
 
 // Components
 import {Overlay} from '@influxdata/clockface'
@@ -39,12 +39,14 @@ import {dismissOverlay} from 'src/overlays/actions/overlays'
 
 export interface OverlayContextType {
   onClose: () => void
+  params: OverlayParams['params']
   visibility: boolean
   overlayID: string
 }
 
 export const DEFAULT_OVERLAY_CONTEXT = {
   onClose: () => {},
+  params: {},
   visibility: false,
   overlayID: '',
 }
@@ -135,12 +137,14 @@ export const OverlayController: FunctionComponent = () => {
 }
 
 const OverlayProvider: FunctionComponent = props => {
-  const {overlayID, onClose} = useSelector((state: AppState) => {
+  const {overlayID, onClose, params} = useSelector((state: AppState) => {
     const id = state.overlays.id
+    const params = state.overlays.params
     const onClose = state.overlays.onClose
 
     return {
       overlayID: id,
+      params,
       onClose,
     }
   })
@@ -156,7 +160,7 @@ const OverlayProvider: FunctionComponent = props => {
 
   return (
     <OverlayContext.Provider
-      value={{onClose: closer, visibility: !!overlayID, overlayID}}
+      value={{onClose: closer, params, visibility: !!overlayID, overlayID}}
     >
       {children}
     </OverlayContext.Provider>

--- a/src/shared/components/DashboardRoute.tsx
+++ b/src/shared/components/DashboardRoute.tsx
@@ -23,9 +23,7 @@ interface OwnProps {
   children: React.ReactNode
 }
 
-type Props = ReduxProps &
-  OwnProps &
-  RouteComponentProps<{orgID: string; dashboardID: string}>
+type Props = ReduxProps & OwnProps & RouteComponentProps<{dashboardID: string}>
 
 class DashboardRoute extends PureComponent<Props> {
   pendingVars: [{[key: string]: any}]

--- a/src/shared/components/TimeSeries.tsx
+++ b/src/shared/components/TimeSeries.tsx
@@ -24,6 +24,7 @@ import {getWindowVars} from 'src/variables/utils/getWindowVars'
 import {buildVarsOption} from 'src/variables/utils/buildVarsOption'
 import 'intersection-observer'
 import {getAll} from 'src/resources/selectors'
+import {getOrg} from 'src/organizations/selectors'
 import {getOrgIDFromBuckets} from 'src/timeMachine/actions/queries'
 import {
   isDemoDataAvailabilityError,
@@ -238,8 +239,7 @@ class TimeSeries extends Component<Props, State> {
       const vars = variables.map(v => asAssignment(v))
       // Issue new queries
       this.pendingResults = queries.map(({text}) => {
-        const orgID =
-          getOrgIDFromBuckets(text, buckets) || this.props.match.params.orgID
+        const orgID = getOrgIDFromBuckets(text, buckets) || this.props.org.id
 
         const windowVars = getWindowVars(text, vars)
         const extern = buildVarsOption([...vars, ...windowVars])
@@ -263,7 +263,7 @@ class TimeSeries extends Component<Props, State> {
       if (check) {
         const extern = buildVarsOption(vars)
         this.pendingCheckStatuses = runStatusesQuery(
-          this.props.match.params.orgID,
+          this.props.org.id,
           check.id,
           extern
         )
@@ -384,6 +384,7 @@ const mstp = (state: AppState, props: OwnProps) => {
     getRangeVariable(TIME_RANGE_START, timeRange),
     getRangeVariable(TIME_RANGE_STOP, timeRange),
   ]
+  const org = getOrg(state)
 
   return {
     hasUpdatedTimeRangeInVEO: hasUpdatedTimeRangeInVEO(state),
@@ -391,6 +392,7 @@ const mstp = (state: AppState, props: OwnProps) => {
     queryLink: state.links.query.self,
     buckets: getAll<Bucket>(state, ResourceType.Buckets),
     variables,
+    org,
   }
 }
 

--- a/src/tasks/components/TaskImportFromTemplateOverlay.tsx
+++ b/src/tasks/components/TaskImportFromTemplateOverlay.tsx
@@ -31,6 +31,7 @@ import {
 
 // Selectors
 import {getAll} from 'src/resources/selectors/getAll'
+import {getOrg} from 'src/organizations/selectors'
 
 interface State {
   selectedTemplateSummary: TemplateSummary
@@ -119,8 +120,8 @@ class TaskImportFromTemplateOverlay extends PureComponent<
   }
 
   private onDismiss = () => {
-    const {history, match} = this.props
-    history.push(`/orgs/${match.params.orgID}/tasks`)
+    const {history, org} = this.props
+    history.push(`/orgs/${org.id}/tasks`)
   }
 
   private onSubmit = () => {
@@ -147,9 +148,12 @@ const mstp = (state: AppState) => {
     item.meta.name.toLocaleLowerCase()
   )
 
+  const org = getOrg(state)
+
   return {
     templates,
     templateStatus: status,
+    org,
   }
 }
 

--- a/src/tasks/components/TaskRunsPage.tsx
+++ b/src/tasks/components/TaskRunsPage.tsx
@@ -1,7 +1,7 @@
 // Libraries
-import React, {PureComponent} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
+import React, {FC, useState, useCallback, useEffect} from 'react'
+import {useDispatch, useSelector} from 'react-redux'
+import {useHistory, useParams} from 'react-router-dom'
 
 // Components
 import {Page, IconFont, Sort} from '@influxdata/clockface'
@@ -19,6 +19,7 @@ import {
 
 // Actions
 import {getRuns, runTask} from 'src/tasks/actions/thunks'
+import {getOrg} from 'src/organizations/selectors'
 
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
@@ -26,129 +27,87 @@ import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 // Types
 import {SortTypes} from 'src/shared/utils/sort'
 
-type ReduxProps = ConnectedProps<typeof connector>
-type Props = ReduxProps & RouteComponentProps<{id: string; orgID: string}>
-
-interface State {
-  sortKey: SortKey
-  sortDirection: Sort
-  sortType: SortTypes
-}
-
 type SortKey = keyof Run
 
-class TaskRunsPage extends PureComponent<Props, State> {
-  constructor(props) {
-    super(props)
-    this.state = {
-      sortKey: 'scheduledFor',
-      sortDirection: Sort.Descending,
-      sortType: SortTypes.Date,
-    }
-  }
+const TaskRunsPage: FC = () => {
+  const [sortKey, setSortKey] = useState('scheduledFor')
+  const [sortDirection, setSortDirection] = useState(Sort.Descending)
+  const [sortType, setSortType] = useState(SortTypes.Date)
 
-  public render() {
-    const {match, runs} = this.props
-    const {sortKey, sortDirection, sortType} = this.state
+  const {id} = useParams()
+  const history = useHistory()
 
-    return (
-      <SpinnerContainer
-        loading={this.props.runStatus}
-        spinnerComponent={<TechnoSpinner />}
-      >
-        <Page titleTag={pageTitleSuffixer(['Task Runs'])}>
-          <Page.Header fullWidth={false}>
-            <Page.Title title={this.title} />
-            <RateLimitAlert />
-          </Page.Header>
-          <Page.ControlBar fullWidth={false}>
-            <Page.ControlBarLeft>
-              <Button
-                onClick={this.handleEditTask}
-                text="Edit Task"
-                color={ComponentColor.Primary}
-              />
-            </Page.ControlBarLeft>
-            <Page.ControlBarRight>
-              <Button
-                onClick={this.handleRunTask}
-                text="Run Task"
-                icon={IconFont.Play}
-              />
-            </Page.ControlBarRight>
-          </Page.ControlBar>
-          <Page.Contents fullWidth={false} scrollable={true}>
-            <TaskRunsList
-              taskID={match.params.id}
-              runs={runs}
-              sortKey={sortKey}
-              sortDirection={sortDirection}
-              sortType={sortType}
-              onClickColumn={this.handleClickColumn}
+  const dispatch = useDispatch()
+  const {runs, runStatus, currentTask} = useSelector(
+    (state: AppState) => state.resources.tasks
+  )
+  const org = useSelector(getOrg)
+
+  const title = currentTask ? `${currentTask.name} - Runs` : 'Runs'
+
+  useEffect(() => {
+    dispatch(getRuns(id))
+  }, [id, dispatch])
+
+  const handleClickColumn = useCallback(
+    (nextSort: Sort, sortKey: SortKey) => {
+      setSortKey(sortKey)
+      setSortDirection(nextSort)
+
+      if (sortKey !== 'status') {
+        setSortType(SortTypes.Date)
+      } else {
+        setSortType(SortTypes.String)
+      }
+    },
+    [setSortKey, setSortDirection, setSortType]
+  )
+
+  const handleEditTask = useCallback(() => {
+    history.push(`/orgs/${org.id}/tasks/${currentTask.id}/edit`)
+  }, [history, org?.id, currentTask?.id])
+
+  const handleRunTask = useCallback(() => {
+    dispatch(runTask(id))
+    dispatch(getRuns(id))
+  }, [dispatch, id])
+
+  return (
+    <SpinnerContainer loading={runStatus} spinnerComponent={<TechnoSpinner />}>
+      <Page titleTag={pageTitleSuffixer(['Task Runs'])}>
+        <Page.Header fullWidth={false}>
+          <Page.Title title={title} />
+          <RateLimitAlert />
+        </Page.Header>
+        <Page.ControlBar fullWidth={false}>
+          <Page.ControlBarLeft>
+            <Button
+              onClick={handleEditTask}
+              text="Edit Task"
+              color={ComponentColor.Primary}
             />
-          </Page.Contents>
-        </Page>
-      </SpinnerContainer>
-    )
-  }
-
-  public componentDidMount() {
-    this.props.getRuns(this.props.match.params.id)
-  }
-
-  private handleClickColumn = (nextSort: Sort, sortKey: SortKey) => {
-    let sortType = SortTypes.String
-
-    if (sortKey !== 'status') {
-      sortType = SortTypes.Date
-    }
-
-    this.setState({sortKey, sortDirection: nextSort, sortType})
-  }
-
-  private get title() {
-    const {currentTask} = this.props
-
-    if (currentTask) {
-      return `${currentTask.name} - Runs`
-    }
-    return 'Runs'
-  }
-
-  private handleRunTask = () => {
-    const {onRunTask, match, getRuns} = this.props
-    onRunTask(match.params.id)
-    getRuns(match.params.id)
-  }
-
-  private handleEditTask = () => {
-    const {
-      history,
-      currentTask,
-      match: {
-        params: {orgID},
-      },
-    } = this.props
-
-    history.push(`/orgs/${orgID}/tasks/${currentTask.id}/edit`)
-  }
+          </Page.ControlBarLeft>
+          <Page.ControlBarRight>
+            <Button
+              onClick={handleRunTask}
+              text="Run Task"
+              icon={IconFont.Play}
+            />
+          </Page.ControlBarRight>
+        </Page.ControlBar>
+        <Page.Contents fullWidth={false} scrollable={true}>
+          <TaskRunsList
+            taskID={id}
+            runs={runs}
+            sortKey={sortKey}
+            sortDirection={sortDirection}
+            sortType={sortType}
+            onClickColumn={handleClickColumn}
+          />
+        </Page.Contents>
+      </Page>
+    </SpinnerContainer>
+  )
 }
 
-const mstp = (state: AppState) => {
-  const {runs, runStatus, currentTask} = state.resources.tasks
-
-  return {
-    runs,
-    runStatus,
-    currentTask,
-  }
-}
-
-const mdtp = {
-  getRuns: getRuns,
-  onRunTask: runTask,
-}
-
-const connector = connect(mstp, mdtp)
-
-export default connector(withRouter(TaskRunsPage))
+export default TaskRunsPage

--- a/src/telegrafs/components/Collectors.test.tsx
+++ b/src/telegrafs/components/Collectors.test.tsx
@@ -15,8 +15,8 @@ const setup = (override = {}) => {
     ...withRouterProps,
     hasTelegrafs: false,
     org: {
-        name: 'orgName',
-        id: 12
+      name: 'orgName',
+      id: 12,
     },
     buckets: [],
     onSetTelegrafConfigID: jest.fn(),

--- a/src/telegrafs/components/Collectors.test.tsx
+++ b/src/telegrafs/components/Collectors.test.tsx
@@ -16,7 +16,7 @@ const setup = (override = {}) => {
     hasTelegrafs: false,
     org: {
       name: 'orgName',
-      id: 12,
+      id: '12',
     },
     buckets: [],
     onSetTelegrafConfigID: jest.fn(),

--- a/src/telegrafs/components/Collectors.test.tsx
+++ b/src/telegrafs/components/Collectors.test.tsx
@@ -14,7 +14,10 @@ const setup = (override = {}) => {
   const props = {
     ...withRouterProps,
     hasTelegrafs: false,
-    orgName: 'orgName',
+    org: {
+        name: 'orgName',
+        id: 12
+    },
     buckets: [],
     onSetTelegrafConfigID: jest.fn(),
     onSetTelegrafConfigName: jest.fn(),

--- a/src/telegrafs/components/Collectors.tsx
+++ b/src/telegrafs/components/Collectors.tsx
@@ -45,7 +45,7 @@ import {getOrg} from 'src/organizations/selectors'
 import {getAll} from 'src/resources/selectors'
 
 type ReduxProps = ConnectedProps<typeof connector>
-type Props = ReduxProps & RouteComponentProps<{orgID: string}>
+type Props = ReduxProps & RouteComponentProps
 
 interface State {
   dataLoaderOverlay: OverlayState
@@ -193,36 +193,26 @@ export class Collectors extends PureComponent<Props, State> {
   }
 
   private handleAddCollector = () => {
-    const {
-      history,
-      match: {
-        params: {orgID},
-      },
-    } = this.props
+    const {history, org} = this.props
 
-    history.push(`/orgs/${orgID}/load-data/telegrafs/new`)
+    history.push(`/orgs/${org.id}/load-data/telegrafs/new`)
   }
 
   private handleJustTheOutput = () => {
-    const {
-      history,
-      match: {
-        params: {orgID},
-      },
-    } = this.props
+    const {history, org} = this.props
 
-    history.push(`/orgs/${orgID}/load-data/telegrafs/output`)
+    history.push(`/orgs/${org.id}/load-data/telegrafs/output`)
   }
 
   private get emptyState(): JSX.Element {
-    const {orgName} = this.props
+    const {org} = this.props
     const {searchTerm} = this.state
 
     if (_.isEmpty(searchTerm)) {
       return (
         <EmptyState size={ComponentSize.Medium}>
           <EmptyState.Text>
-            {`${orgName}`} does not own any <b>Telegraf Configurations</b>, why
+            {`${org.name}`} does not own any <b>Telegraf Configurations</b>, why
             not create one?
           </EmptyState.Text>
           {this.createButton}
@@ -256,14 +246,14 @@ export class Collectors extends PureComponent<Props, State> {
 }
 const mstp = (state: AppState) => {
   const {telegrafs} = state.resources
-  const orgName = getOrg(state).name
   const buckets = getAll<Bucket>(state, ResourceType.Buckets)
   const hasTelegrafs = !!telegrafs.allIDs.length
+  const org = getOrg(state)
 
   return {
     hasTelegrafs,
-    orgName,
     buckets,
+    org,
   }
 }
 

--- a/src/telegrafs/components/TelegrafConfigOverlay.tsx
+++ b/src/telegrafs/components/TelegrafConfigOverlay.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {FC, useContext} from 'react'
-import _ from 'lodash'
 
 // Components
 import {Overlay} from '@influxdata/clockface'

--- a/src/telegrafs/components/TelegrafConfigOverlayForm.tsx
+++ b/src/telegrafs/components/TelegrafConfigOverlayForm.tsx
@@ -1,7 +1,6 @@
 // Libraries
 import React, {FC, useState, useContext} from 'react'
 import {useSelector, useDispatch} from 'react-redux'
-import {useParams} from 'react-router-dom'
 
 // Components
 import TelegrafConfig from 'src/telegrafs/components/TelegrafConfig'
@@ -41,13 +40,12 @@ const TelegrafConfigOverlayForm: FC = () => {
     return getAll<Telegraf>(state, ResourceType.Telegrafs)
   }
   const telegrafs = useSelector(getTelegrafs)
-  const {onClose} = useContext(OverlayContext)
-  const {id} = useParams()
+  const {onClose, params} = useContext(OverlayContext)
 
   let telegraf
 
-  if (id) {
-    telegraf = telegrafs.find(tel => tel.id === id)
+  if (params.id) {
+    telegraf = telegrafs.find(tel => tel.id === params.id)
   }
 
   const [workingConfig, updateWorkingConfig] = useState<string>(

--- a/src/telegrafs/components/TelegrafConfigOverlayForm.tsx
+++ b/src/telegrafs/components/TelegrafConfigOverlayForm.tsx
@@ -1,8 +1,7 @@
 // Libraries
 import React, {FC, useState, useContext} from 'react'
 import {useSelector, useDispatch} from 'react-redux'
-import {useRouteMatch} from 'react-router-dom'
-import _ from 'lodash'
+import {useParams} from 'react-router-dom'
 
 // Components
 import TelegrafConfig from 'src/telegrafs/components/TelegrafConfig'
@@ -36,11 +35,6 @@ import {AppState, ResourceType, Telegraf} from 'src/types'
 // Selectors
 import {getAll} from 'src/resources/selectors'
 
-type Params = {orgID: string; id: string}
-interface Match {
-  params: Params
-}
-
 const TelegrafConfigOverlayForm: FC = () => {
   const dispatch = useDispatch()
   const getTelegrafs = (state: AppState): Telegraf[] => {
@@ -48,16 +42,12 @@ const TelegrafConfigOverlayForm: FC = () => {
   }
   const telegrafs = useSelector(getTelegrafs)
   const {onClose} = useContext(OverlayContext)
-  const match: Match = useRouteMatch({
-    path: '/orgs/:orgID/load-data/telegrafs/:id/view',
-    exact: true,
-    strict: false,
-  })
+  const {id} = useParams()
 
   let telegraf
 
-  if (match?.params?.id) {
-    telegraf = telegrafs.find(tel => tel.id === match.params.id)
+  if (id) {
+    telegraf = telegrafs.find(tel => tel.id === id)
   }
 
   const [workingConfig, updateWorkingConfig] = useState<string>(

--- a/src/templates/components/CommunityTemplateInstallOverlay.tsx
+++ b/src/templates/components/CommunityTemplateInstallOverlay.tsx
@@ -19,11 +19,11 @@ import {getBuckets} from 'src/buckets/actions/thunks'
 import {getTotalResourceCount} from 'src/templates/selectors'
 
 // Types
-import {AppState, Organization, ResourceType} from 'src/types'
+import {AppState} from 'src/types'
 import {ComponentStatus} from '@influxdata/clockface'
 
 // Utils
-import {getByID} from 'src/resources/selectors'
+import {getOrg} from 'src/organizations/selectors'
 import {getTemplateNameFromUrl} from 'src/templates/utils'
 import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
 
@@ -50,9 +50,7 @@ interface OwnProps {
 }
 
 type ReduxProps = ConnectedProps<typeof connector>
-type RouterProps = RouteComponentProps<{
-  orgID: string
-}>
+type RouterProps = RouteComponentProps
 
 type Props = OwnProps & ReduxProps & RouterProps
 
@@ -156,12 +154,8 @@ class CommunityTemplateInstallOverlayUnconnected extends PureComponent<Props> {
   }
 }
 
-const mstp = (state: AppState, props: RouterProps) => {
-  const org = getByID<Organization>(
-    state,
-    ResourceType.Orgs,
-    props.match.params.orgID
-  )
+const mstp = (state: AppState) => {
+  const org = getOrg(state)
 
   // convert the env references into a format pkger is happy with
   const stagedTemplateEnvReferences = {}

--- a/src/variables/components/VariableCard.tsx
+++ b/src/variables/components/VariableCard.tsx
@@ -9,7 +9,7 @@ import InlineLabels from 'src/shared/components/inlineLabels/InlineLabels'
 import VariableContextMenu from 'src/variables/components/VariableContextMenu'
 
 // Types
-import {Label, Variable} from 'src/types'
+import {AppState, Label, Variable} from 'src/types'
 
 // Actions
 import {
@@ -17,6 +17,7 @@ import {
   removeVariableLabelAsync,
 } from 'src/variables/actions/thunks'
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
+import {getOrg} from 'src/organizations/selectors'
 
 interface OwnProps {
   variable: Variable
@@ -28,9 +29,7 @@ interface OwnProps {
 type ReduxProps = ConnectedProps<typeof connector>
 type Props = OwnProps & ReduxProps
 
-class VariableCard extends PureComponent<
-  Props & RouteComponentProps<{orgID: string}>
-> {
+class VariableCard extends PureComponent<Props & RouteComponentProps> {
   public render() {
     const {variable, onDeleteVariable} = this.props
 
@@ -62,11 +61,9 @@ class VariableCard extends PureComponent<
   }
 
   private handleNameClick = (): void => {
-    const {variable, match, history} = this.props
+    const {variable, org, history} = this.props
 
-    history.push(
-      `/orgs/${match.params.orgID}/settings/variables/${variable.id}/edit`
-    )
+    history.push(`/orgs/${org.id}/settings/variables/${variable.id}/edit`)
   }
 
   private get labels(): JSX.Element {
@@ -95,20 +92,22 @@ class VariableCard extends PureComponent<
   }
 
   private handleExport = () => {
-    const {history, variable, match} = this.props
+    const {history, variable, org} = this.props
 
-    history.push(
-      `/orgs/${match.params.orgID}/settings/variables/${variable.id}/export`
-    )
+    history.push(`/orgs/${org.id}/settings/variables/${variable.id}/export`)
   }
 
   private handleRenameVariable = () => {
-    const {history, variable, match} = this.props
+    const {history, variable, org} = this.props
 
-    history.push(
-      `/orgs/${match.params.orgID}/settings/variables/${variable.id}/rename`
-    )
+    history.push(`/orgs/${org.id}/settings/variables/${variable.id}/rename`)
   }
+}
+
+const mstp = (state: AppState) => {
+  const org = getOrg(state)
+
+  return {org}
 }
 
 const mdtp = {
@@ -116,6 +115,6 @@ const mdtp = {
   onRemoveVariableLabel: removeVariableLabelAsync,
 }
 
-const connector = connect(null, mdtp)
+const connector = connect(mstp, mdtp)
 
 export default connector(withRouter(VariableCard))

--- a/src/variables/components/VariablesTab.tsx
+++ b/src/variables/components/VariablesTab.tsx
@@ -6,6 +6,7 @@ import {withRouter, RouteComponentProps} from 'react-router-dom'
 // Utils
 import {deleteVariable} from 'src/variables/actions/thunks'
 import {getVariables} from 'src/variables/selectors'
+import {getOrg} from 'src/organizations/selectors'
 
 // Components
 import {EmptyState} from '@influxdata/clockface'
@@ -25,7 +26,7 @@ import {SortTypes} from 'src/shared/utils/sort'
 import {VariableSortKey} from 'src/shared/components/resource_sort_dropdown/generateSortItems'
 
 type ReduxProps = ConnectedProps<typeof connector>
-type Props = RouteComponentProps<{orgID: string}> & ReduxProps
+type Props = RouteComponentProps & ReduxProps
 
 interface State {
   searchTerm: string
@@ -146,15 +147,15 @@ class VariablesTab extends PureComponent<Props, State> {
   }
 
   private handleOpenImportOverlay = (): void => {
-    const {history, match} = this.props
+    const {history, org} = this.props
 
-    history.push(`/orgs/${match.params.orgID}/settings/variables/import`)
+    history.push(`/orgs/${org.id}/settings/variables/import`)
   }
 
   private handleOpenCreateOverlay = (): void => {
-    const {history, match} = this.props
+    const {history, org} = this.props
 
-    history.push(`/orgs/${match.params.orgID}/settings/variables/new`)
+    history.push(`/orgs/${org.id}/settings/variables/new`)
   }
 
   private handleDeleteVariable = (variable: Variable): void => {
@@ -165,8 +166,9 @@ class VariablesTab extends PureComponent<Props, State> {
 
 const mstp = (state: AppState) => {
   const variables = getVariables(state)
+  const org = getOrg(state)
 
-  return {variables}
+  return {variables, org}
 }
 
 const mdtp = {


### PR DESCRIPTION
We have weird support for multi org users right now, and our app routing structure locks us into tightly coupling the concept of a user being within an organizational context, and prevents us from exploring other sharing models on the UX.

This PR decouples the route from the apps understanding of the currently selected organization. from the looks of it, most of this should get removed when we support multi org switching, as many cases just load the org to push it into a history.push command, which should get depreciated as we sort through the multi org / multi region shenanigans, because it'll get removed from the url being pushed.

my current thinking to remove the org from the url is:
 1. move the app to a single source of truth about the currently selected organization, defined in redux with `getOrg`
 2. add a mechanism within the ux for a user to switch their orgs
 3. upon deeplinking to anything `/org/:orgid/_xyz_`, set the current org to `orgid`, and redirect the route to `/_xyz`
 4. clean up anything pushing org.id into the url in the first place.
 
this should seamlessly migrate users with bookmarks, and allow us to take the migration piecemeal as we find enthusiasm for the project, while better supporting our multiorg users.

all of this is required for: https://github.com/influxdata/ui/issues/408