### PR TITLE
fix: variables show after deletion

### DIFF
--- a/src/resources/reducers/helpers.test.ts
+++ b/src/resources/reducers/helpers.test.ts
@@ -94,8 +94,9 @@ describe('Resources.reducers.helpers', () => {
       const action = {
         schema: {
           entities: {
-            variables: null,
+            variables: {},
           },
+          result: [],
         },
         status: 'Done',
       }

--- a/src/resources/reducers/helpers.test.ts
+++ b/src/resources/reducers/helpers.test.ts
@@ -1,4 +1,4 @@
-import {setRelation} from './helpers'
+import {setRelation, setResource} from './helpers'
 
 import {RemoteDataState, ResourceType} from 'src/types'
 
@@ -21,6 +21,18 @@ const genState = () => {
     },
     childID,
     parentID,
+  }
+}
+
+const genVariableState = (override = {}) => {
+  return {
+    status: RemoteDataState.Done,
+    byID: {
+      foo: {bar: 'baz'},
+    },
+    allIDs: ['foo'],
+    values: {},
+    ...override,
   }
 }
 
@@ -73,6 +85,27 @@ describe('Resources.reducers.helpers', () => {
       }
 
       expect(state).toEqual(expected)
+    })
+  })
+
+  describe('setResource', () => {
+    it('updates resources values to be empty if no resource is found under given type', () => {
+      const toBeDeletedState = genVariableState()
+      const action = {
+        schema: {
+          entities: {
+            variables: null,
+          },
+        },
+        status: 'Done',
+      }
+      setResource(toBeDeletedState, action, ResourceType.Variables)
+      expect(toBeDeletedState).toEqual({
+        status: 'Done',
+        byID: {},
+        allIDs: [],
+        values: {},
+      })
     })
   })
 })

--- a/src/resources/reducers/helpers.ts
+++ b/src/resources/reducers/helpers.ts
@@ -29,10 +29,12 @@ export const setResource = <R>(
   const {status, schema} = action
 
   draftState.status = status
-
   if (get(schema, ['entities', resource])) {
     draftState.byID = schema.entities[resource]
     draftState.allIDs = schema.result
+  } else {
+    draftState.byID = {}
+    draftState.allIDs = schema.result ?? []
   }
 
   return

--- a/src/resources/reducers/helpers.ts
+++ b/src/resources/reducers/helpers.ts
@@ -27,14 +27,10 @@ export const setResource = <R>(
   resource: ResourceType
 ) => {
   const {status, schema} = action
-
   draftState.status = status
   if (get(schema, ['entities', resource])) {
     draftState.byID = schema.entities[resource]
     draftState.allIDs = schema.result
-  } else {
-    draftState.byID = {}
-    draftState.allIDs = schema?.result ?? []
   }
 
   return

--- a/src/resources/reducers/helpers.ts
+++ b/src/resources/reducers/helpers.ts
@@ -34,7 +34,7 @@ export const setResource = <R>(
     draftState.allIDs = schema.result
   } else {
     draftState.byID = {}
-    draftState.allIDs = schema.result ?? []
+    draftState.allIDs = schema?.result ?? []
   }
 
   return

--- a/src/variables/actions/thunks.ts
+++ b/src/variables/actions/thunks.ts
@@ -124,6 +124,10 @@ export const getVariables = (controller?: AbortController) => async (
         variables.entities.variables[v.id].status = RemoteDataState.NotStarted
       })
 
+    if (!variables.entities['variables']) {
+      variables.entities['variables'] = {}
+    }
+
     await dispatch(setVariables(RemoteDataState.Done, variables))
   } catch (error) {
     console.error(error)


### PR DESCRIPTION
Closes #18483

<!-- Describe your proposed changes here. -->
This PR addresses the variables zombie issue mentioned in the above ticket. When a template linked to variables is deleted, associated variables will be removed as well. 
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
![Kapture 2021-02-16 at 12 50 25](https://user-images.githubusercontent.com/29473622/108108278-0b0f9100-7056-11eb-8f1c-a8f91cc5ae80.gif)

