### PR TITLE
test: fix e2e dashboard and bucket test flakes

### DIFF
--- a/cypress/e2e/shared/buckets.test.ts
+++ b/cypress/e2e/shared/buckets.test.ts
@@ -99,11 +99,10 @@ describe('Buckets', () => {
 
     it('can delete a bucket', () => {
       const bucket1 = 'newbucket1'
-      cy.intercept('POST', '/buckets').as('createBucket')
       cy.get<Organization>('@org').then(({id, name}: Organization) => {
         cy.createBucket(id, name, bucket1)
       })
-      cy.wait('@createBucket')
+      cy.reload()
       cy.getByTestID(`bucket-card ${bucket1}`).trigger('mouseover')
       cy.getByTestID(`context-delete-menu ${bucket1}`).click()
       cy.intercept('DELETE', '/buckets').as('deleteBucket')

--- a/cypress/e2e/shared/buckets.test.ts
+++ b/cypress/e2e/shared/buckets.test.ts
@@ -99,10 +99,11 @@ describe('Buckets', () => {
 
     it('can delete a bucket', () => {
       const bucket1 = 'newbucket1'
+      cy.intercept('POST', '/buckets').as('createBucket')
       cy.get<Organization>('@org').then(({id, name}: Organization) => {
         cy.createBucket(id, name, bucket1)
       })
-
+      cy.wait('@createBucket')
       cy.getByTestID(`bucket-card ${bucket1}`).trigger('mouseover')
       cy.getByTestID(`context-delete-menu ${bucket1}`).click()
       cy.intercept('DELETE', '/buckets').as('deleteBucket')

--- a/cypress/e2e/shared/dashboardsIndex.test.ts
+++ b/cypress/e2e/shared/dashboardsIndex.test.ts
@@ -379,7 +379,9 @@ describe('Dashboards', () => {
         const labelName = 'banana'
 
         cy.get('@org').then(({id}: Organization) => {
+          cy.intercept('POST', '/labels').as('createLabel')
           cy.createLabel(labelName, id).then(() => {
+            cy.wait('@createLabel')
             cy.getByTestID(`inline-labels--add`)
               .first()
               .click()

--- a/cypress/e2e/shared/dashboardsIndex.test.ts
+++ b/cypress/e2e/shared/dashboardsIndex.test.ts
@@ -379,9 +379,8 @@ describe('Dashboards', () => {
         const labelName = 'banana'
 
         cy.get('@org').then(({id}: Organization) => {
-          cy.intercept('POST', '/labels').as('createLabel')
           cy.createLabel(labelName, id).then(() => {
-            cy.wait('@createLabel')
+            cy.reload()
             cy.getByTestID(`inline-labels--add`)
               .first()
               .click()


### PR DESCRIPTION
Fixes broken e2e tests that are failing on the master branch. Fixes a race condition where the API doesn't respond immediately and cypress continues anyways. 

I tried to user `cy.intercept` but that only intercepts requests made _from_ the app, not _from_ cypress (in this case the tests are making API requests via cypress commands).

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
