### PR TITLE
chore: upgrade to giraffe 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "@influxdata/clockface": "^2.6.1",
     "@influxdata/flux": "^0.5.1",
     "@influxdata/flux-lsp-browser": "^0.5.32",
-    "@influxdata/giraffe": "^2.0.1",
+    "@influxdata/giraffe": "^2.2.0",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",

--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -2,6 +2,7 @@
 import React, {FC, useMemo, useContext} from 'react'
 import {useDispatch} from 'react-redux'
 import {
+  InteractionHandlerArguments,
   Plot,
   DomainLabel,
   lineTransform,
@@ -145,7 +146,7 @@ const XYPlot: FC<Props> = ({properties, result, timeRange}) => {
 
   const currentTheme = theme === 'light' ? VIS_THEME_LIGHT : VIS_THEME
 
-  const doubleClickHandler = plotInteraction => {
+  const doubleClickHandler = (plotInteraction: InteractionHandlerArguments) => {
     const annotationTime = new Date(plotInteraction.valueX).getTime()
     dispatch(
       writeThenFetchAndSetAnnotations([

--- a/yarn.lock
+++ b/yarn.lock
@@ -797,10 +797,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/flux/-/flux-0.5.1.tgz#e39e7a7af9163fc9494422c8fed77f3ae1b68f56"
   integrity sha512-GHlkXBhSdJ2m56JzDkbnKPAqLj3/lexPooacu14AWTO4f2sDGLmzM7r0AxgdtU1M2x7EXNBwgGOI5EOAdN6mkw==
 
-"@influxdata/giraffe@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.0.1.tgz#243b5b420feadb0588fdc87c1d87935071efc16e"
-  integrity sha512-o0LhrVjeHr0Z0NmwGDK9SToi79RGUQ/4c136x5KAbNpDtM4zby13aqFDLPA/zV8WLQ2SUcX2p3PhdH1HwAOujA==
+"@influxdata/giraffe@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.2.0.tgz#a4a563560aa7f3c625f1d27c4ab0d680da5a9949"
+  integrity sha512-HRL/Nlqk2lDiI6aO5VdkVBuzHse64heaX+/kSxAwdqX+OkFMwqYXY9FCSQslot5WCabRUJKkcp0RHnJsYzGfMg==
 
 "@influxdata/influx@0.5.5":
   version "0.5.5"


### PR DESCRIPTION
Upgrades to [giraffe 2.2.0](https://github.com/influxdata/giraffe/releases/tag/v2.2.0) which gives us a new type definition. Very exciting stuff!

See [Giraffe #477](https://github.com/influxdata/giraffe/pull/477)

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
