### PR TITLE
fix: wrapping raw data view

### DIFF
--- a/src/timeMachine/components/Vis.tsx
+++ b/src/timeMachine/components/Vis.tsx
@@ -10,6 +10,7 @@ import {isEqual} from 'lodash'
 import {View} from 'src/visualization'
 import RawFluxDataTable from 'src/timeMachine/components/RawFluxDataTable'
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
+import EmptyQueryView, {ErrorFormat} from 'src/shared/components/EmptyQueryView'
 
 // Utils
 import {getActiveTimeMachine} from 'src/timeMachine/selectors'
@@ -67,21 +68,29 @@ const TimeMachineVis: FC<Props> = ({
   })
 
   if (isViewingRawData && files && files.length) {
+    const [parsedResults] = files.flatMap(fromFlux)
     return (
       <div className={timeMachineViewClassName}>
         <ErrorBoundary>
-          <AutoSizer>
-            {({width, height}) => {
-              const [parsedResults] = files.flatMap(fromFlux)
-              return (
-                <RawFluxDataTable
-                  parsedResults={parsedResults}
-                  width={width}
-                  height={height}
-                />
-              )
-            }}
-          </AutoSizer>
+          <EmptyQueryView
+            loading={loading}
+            errorMessage={errorMessage}
+            errorFormat={ErrorFormat.Scroll}
+            hasResults={!!parsedResults?.table?.length}
+            isInitialFetch={isInitialFetch}
+          >
+            <AutoSizer>
+              {({width, height}) => {
+                return (
+                  <RawFluxDataTable
+                    parsedResults={parsedResults}
+                    width={width}
+                    height={height}
+                  />
+                )
+              }}
+            </AutoSizer>
+          </EmptyQueryView>
         </ErrorBoundary>
       </div>
     )


### PR DESCRIPTION
Closes #719 

wraps the raw data view in the empty query view to help keep visualizations in line.

ultimate solution is to have raw data view be a visualization type, but we are working on remaking that component as the dataview, so i'm hesitant to handle that migration right now.