### PR TITLE
chore: update annotations to match api changes

### DIFF
--- a/src/annotations/api/index.test.ts
+++ b/src/annotations/api/index.test.ts
@@ -59,8 +59,8 @@ describe('annotations api calls', () => {
         stream: 'Lambeau Field',
         annotations: [
           {
-            start: Date.now().toString(),
-            end: Date.now().toString(),
+            startTime: Date.now().toString(),
+            endTime: Date.now().toString(),
             summary: 'Go Pack Go',
           },
         ],
@@ -69,8 +69,8 @@ describe('annotations api calls', () => {
         stream: 'default',
         annotations: [
           {
-            start: '2020-01-12T23:13:47Z',
-            end: Date.now().toString(),
+            startTime: '2020-01-12T23:13:47Z',
+            endTime: Date.now().toString(),
             summary: 'blah blah',
           },
         ],
@@ -83,8 +83,8 @@ describe('annotations api calls', () => {
         Promise.resolve({data: [lambeau]})
       )
       const response = await getAnnotation({
-        start: Date.now().toString(),
-        end: Date.now().toString(),
+        startTime: Date.now().toString(),
+        endTime: Date.now().toString(),
         stream: 'Lambeau Field',
       })
 
@@ -93,8 +93,8 @@ describe('annotations api calls', () => {
 
     it('handles an error and returns the error message', async () => {
       const annotation = {
-        start: Date.now().toString(),
-        end: Date.now().toString(),
+        startTime: Date.now().toString(),
+        endTime: Date.now().toString(),
         stream: 'Lambeau Field',
       }
       const message = 'OOPS YOU DONE MESSED UP SON'
@@ -110,8 +110,8 @@ describe('annotations api calls', () => {
   describe('PUT - annotation update api calls', () => {
     const oldAnnotation = {
       stream: 'default',
-      start: Date.now().toString(),
-      end: Date.now().toString(),
+      startTime: Date.now().toString(),
+      endTime: Date.now().toString(),
     }
 
     const newAnnotation = {
@@ -135,8 +135,8 @@ describe('annotations api calls', () => {
   describe('DELETE = annotation delete api calls', () => {
     const toDelete = {
       stream: 'default',
-      start: Date.now().toString(),
-      end: Date.now().toString(),
+      startTime: Date.now().toString(),
+      endTime: Date.now().toString(),
     }
 
     it('returns a 204 upon successful deletion of annotation', async () => {

--- a/src/annotations/api/index.ts
+++ b/src/annotations/api/index.ts
@@ -22,13 +22,12 @@ import {formatAnnotationQueryString} from 'src/annotations/utils/formatQueryStri
 export const writeAnnotation = async (
   annotations: Annotation[]
 ): Promise<Annotation[]> => {
-  // we need to convert the annotation object's start and end time fields to be
-  // string types so they can be parsed in the backend.
+  // RFC 3339 is the standard serialization format for dates across the wire for annotations
   const annotationsRequestConverted = annotations.map(annotation => {
     return {
       ...annotation,
-      start: new Date(annotation.startTime).toISOString(),
-      end: new Date(annotation.endTime).toISOString(),
+      startTime: new Date(annotation.startTime).toISOString(),
+      endTime: new Date(annotation.endTime).toISOString(),
     }
   })
 

--- a/src/annotations/utils/formatQueryString.ts
+++ b/src/annotations/utils/formatQueryString.ts
@@ -7,12 +7,12 @@ export const formatAnnotationQueryString = (
 ): string => {
   const getAnnotationParams = new URLSearchParams({})
 
-  if (annotation.start) {
-    getAnnotationParams.append('start', annotation.start)
+  if (annotation?.startTime) {
+    getAnnotationParams.append('startTime', annotation.startTime)
   }
 
-  if (annotation.end) {
-    getAnnotationParams.append('end', annotation.end)
+  if (annotation?.endTime) {
+    getAnnotationParams.append('endTime', annotation.endTime)
   }
 
   if (annotation?.stream) {

--- a/src/types/annotation.ts
+++ b/src/types/annotation.ts
@@ -14,15 +14,15 @@ export interface AnnotationStream {
 
 export interface GetAnnotationPayload {
   stream?: string
-  start?: string
-  end?: string
+  startTime?: string
+  endTime?: string
   stickers?: any
 }
 
 export interface DeleteAnnotation {
   stream: string
-  start: string
-  end: string
+  startTime: string
+  endTime: string
   stickers?: any
 }
 

--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -232,7 +232,6 @@ const XYPlot: FC<Props> = ({properties, result, timeRange, annotations}) => {
 
     // everything is under the 'default' category for now:
     const selectedAnnotations: any[] = annotations?.default ?? []
-
     if (selectedAnnotations.length) {
       const colors = ['cyan', 'magenta', 'white']
 
@@ -246,8 +245,8 @@ const XYPlot: FC<Props> = ({properties, result, timeRange, annotations}) => {
             title: annotation.summary,
             description: '',
             color: colors[i % 3],
-            startValue: new Date(annotation.start).getTime(),
-            stopValue: new Date(annotation.end).getTime(),
+            startValue: new Date(annotation.startTime).getTime(),
+            stopValue: new Date(annotation.endTime).getTime(),
             dimension: 'x',
             pin: 'start',
           }


### PR DESCRIPTION
Closes #743

See: https://github.com/influxdata/monitor-ci/pull/173

Some backend changes to annotations were deployed. This makes both systems match. This allows us to turn this out in cloud environments for Influxers.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
