### PR TITLE
feat: standalone query context

### DIFF
--- a/src/flows/components/Flow.tsx
+++ b/src/flows/components/Flow.tsx
@@ -2,20 +2,17 @@ import React from 'react'
 
 // Components
 import PipeList from 'src/flows/components/PipeList'
-import QueryProvider from 'src/flows/context/query'
 import {RefProvider} from 'src/flows/context/refs'
 import {PopupDrawer, PopupProvider} from 'src/flows/context/popup'
 
 // NOTE: requires a FlowProvider and ResultsProvider
 const Flow = () => (
-  <QueryProvider>
-    <RefProvider>
-      <PopupProvider>
-        <PipeList />
-        <PopupDrawer />
-      </PopupProvider>
-    </RefProvider>
-  </QueryProvider>
+  <RefProvider>
+    <PopupProvider>
+      <PipeList />
+      <PopupDrawer />
+    </PopupProvider>
+  </RefProvider>
 )
 
 export default Flow

--- a/src/flows/components/FlowPage.tsx
+++ b/src/flows/components/FlowPage.tsx
@@ -5,6 +5,8 @@ import {useParams} from 'react-router-dom'
 // Components
 import CurrentFlowProvider from 'src/flows/context/flow.current'
 import {RunModeProvider} from 'src/flows/context/runMode'
+import QueryProvider from 'src/flows/context/query'
+import {FlowQueryProvider} from 'src/flows/context/flow.query'
 import {FlowListContext} from 'src/flows/context/flow.list'
 import Flow from 'src/flows/components/Flow'
 import {Page} from '@influxdata/clockface'
@@ -28,23 +30,27 @@ const FlowFromRoute = () => {
 import 'src/flows/style.scss'
 
 const FlowContainer: FC = () => (
-  <CurrentFlowProvider>
-    <RunModeProvider>
-      <FlowFromRoute />
-      <ResultsProvider>
-        <Page titleTag={PROJECT_NAME_PLURAL}>
-          <FlowHeader />
-          <Page.Contents
-            fullWidth={true}
-            scrollable={true}
-            className="flow-page"
-          >
-            <Flow />
-          </Page.Contents>
-        </Page>
-      </ResultsProvider>
-    </RunModeProvider>
-  </CurrentFlowProvider>
+  <QueryProvider>
+    <CurrentFlowProvider>
+      <RunModeProvider>
+        <FlowFromRoute />
+        <ResultsProvider>
+          <FlowQueryProvider>
+            <Page titleTag={PROJECT_NAME_PLURAL}>
+              <FlowHeader />
+              <Page.Contents
+                fullWidth={true}
+                scrollable={true}
+                className="flow-page"
+              >
+                <Flow />
+              </Page.Contents>
+            </Page>
+          </FlowQueryProvider>
+        </ResultsProvider>
+      </RunModeProvider>
+    </CurrentFlowProvider>
+  </QueryProvider>
 )
 
 export default FlowContainer

--- a/src/flows/components/header/Submit.tsx
+++ b/src/flows/components/header/Submit.tsx
@@ -11,7 +11,7 @@ import {
 } from '@influxdata/clockface'
 
 import {SubmitQueryButton} from 'src/timeMachine/components/SubmitQueryButton'
-import {QueryContext} from 'src/flows/context/query'
+import {FlowQueryContext} from 'src/flows/context/flow.query'
 import {RunModeContext, RunMode} from 'src/flows/context/runMode'
 import {notify} from 'src/shared/actions/notifications'
 import {FlowContext} from 'src/flows/context/flow.current'
@@ -31,7 +31,7 @@ const fakeNotify = notify
 export const Submit: FC = () => {
   const {flow} = useContext(FlowContext)
   const {runMode, setRunMode} = useContext(RunModeContext)
-  const {generateMap, queryAll} = useContext(QueryContext)
+  const {generateMap, queryAll} = useContext(FlowQueryContext)
 
   const hasQueries = useMemo(() => generateMap().length > 0, [generateMap])
 

--- a/src/flows/components/header/TimeRangeDropdown.tsx
+++ b/src/flows/components/header/TimeRangeDropdown.tsx
@@ -1,7 +1,7 @@
 import React, {FC, useEffect, useState, useCallback, useContext} from 'react'
 import {default as StatelessTimeRangeDropdown} from 'src/shared/components/TimeRangeDropdown'
 import {FlowContext} from 'src/flows/context/flow.current'
-import {QueryContext} from 'src/flows/context/query'
+import {FlowQueryContext} from 'src/flows/context/flow.query'
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'
@@ -9,7 +9,7 @@ import {event} from 'src/cloud/utils/reporting'
 const TimeRangeDropdown: FC = () => {
   const {update, flow} = useContext(FlowContext)
   const [range, setRange] = useState(null)
-  const {queryAll} = useContext(QueryContext)
+  const {queryAll} = useContext(FlowQueryContext)
 
   const updateRange = useCallback(
     range => {

--- a/src/flows/components/header/index.tsx
+++ b/src/flows/components/header/index.tsx
@@ -4,7 +4,6 @@ import React, {FC, useContext} from 'react'
 // Contexts
 import {FlowContext} from 'src/flows/context/flow.current'
 import {AppSettingProvider} from 'src/shared/contexts/app'
-import QueryProvider from 'src/flows/context/query'
 
 // Components
 import {Page} from '@influxdata/clockface'
@@ -41,16 +40,12 @@ const FlowHeader: FC = () => {
       </Page.Header>
       <Page.ControlBar fullWidth={FULL_WIDTH}>
         <Page.ControlBarLeft>
-          <QueryProvider>
-            <Submit />
-          </QueryProvider>
+          <Submit />
         </Page.ControlBarLeft>
         <Page.ControlBarRight>
           <PresentationMode />
           <TimeZoneDropdown />
-          <QueryProvider>
-            <TimeRangeDropdown />
-          </QueryProvider>
+          <TimeRangeDropdown />
           <AutoRefreshDropdown />
         </Page.ControlBarRight>
       </Page.ControlBar>

--- a/src/flows/context/flow.query.tsx
+++ b/src/flows/context/flow.query.tsx
@@ -1,0 +1,258 @@
+import React, {FC, useContext, useMemo} from 'react'
+import {useDispatch, useSelector} from 'react-redux'
+import {getVariables} from 'src/variables/selectors'
+import {FlowContext} from 'src/flows/context/flow.current'
+import {RunModeContext, RunMode} from 'src/flows/context/runMode'
+import {ResultsContext} from 'src/flows/context/results'
+import {QueryContext} from 'src/flows/context/query'
+import {event} from 'src/cloud/utils/reporting'
+import {FluxResult} from 'src/types/flows'
+import {PIPE_DEFINITIONS} from 'src/flows'
+import {notify} from 'src/shared/actions/notifications'
+import EmptyGraphMessage from 'src/shared/components/EmptyGraphMessage'
+import {parseDuration, timeRangeToDuration} from 'src/shared/utils/duration'
+
+// Constants
+import {
+  notebookRunSuccess,
+  notebookRunFail,
+} from 'src/shared/copy/notifications'
+import {TIME_RANGE_START, TIME_RANGE_STOP} from 'src/variables/constants'
+import {PROJECT_NAME} from 'src/flows'
+
+// Types
+import {AppState, RemoteDataState, Variable} from 'src/types'
+
+interface Stage {
+  text: string
+  instances: string[]
+}
+
+export interface FlowQueryContextType {
+  generateMap: (withSideEffects?: boolean) => Stage[]
+  query: (text: string) => Promise<FluxResult>
+  queryAll: () => void
+}
+
+export const DEFAULT_CONTEXT: FlowQueryContextType = {
+  generateMap: () => [],
+  query: (_: string) => Promise.resolve({} as FluxResult),
+  queryAll: () => {},
+}
+
+export const FlowQueryContext = React.createContext<FlowQueryContextType>(
+  DEFAULT_CONTEXT
+)
+
+const PREVIOUS_REGEXP = /__PREVIOUS_RESULT__/g
+
+const generateTimeVar = (which, value): Variable =>
+  ({
+    orgID: '',
+    id: which,
+    name: which,
+    arguments: {
+      type: 'system',
+      values: [value],
+    },
+    status: RemoteDataState.Done,
+    labels: [],
+  } as Variable)
+
+export const FlowQueryProvider: FC = ({children}) => {
+  const {flow} = useContext(FlowContext)
+  const {runMode} = useContext(RunModeContext)
+  const {add, update} = useContext(ResultsContext)
+  const {query: queryAPI} = useContext(QueryContext)
+
+  const dispatch = useDispatch()
+
+  const variables = useSelector((state: AppState) => getVariables(state))
+
+  const vars = useMemo(() => {
+    const _vars = [...variables]
+
+    if (!flow?.range) {
+      return _vars.reduce((acc, curr) => {
+        acc[curr.name] = curr
+        return acc
+      }, {})
+    }
+
+    // Here we add in those optional time range variables if we have them
+    if (!flow.range.upper) {
+      _vars.push(generateTimeVar(TIME_RANGE_STOP, 'now()'))
+    } else if (isNaN(Date.parse(flow.range.upper))) {
+      _vars.push(generateTimeVar(TIME_RANGE_STOP, null))
+    } else {
+      _vars.push(generateTimeVar(TIME_RANGE_STOP, flow.range.upper))
+    }
+
+    if ((flow.range.type as any) !== 'custom') {
+      const duration = parseDuration(timeRangeToDuration(flow.range))
+
+      _vars.push(generateTimeVar(TIME_RANGE_START, duration))
+    } else if (isNaN(Date.parse(flow.range.lower))) {
+      _vars.push(generateTimeVar(TIME_RANGE_START, null))
+    } else {
+      _vars.push(generateTimeVar(TIME_RANGE_START, flow.range.lower))
+    }
+
+    return _vars.reduce((acc, curr) => {
+      acc[curr.name] = curr
+      return acc
+    }, {})
+  }, [variables, flow?.range])
+
+  const generateMap = (withSideEffects?: boolean): Stage[] => {
+    return flow.data.allIDs
+      .reduce((stages, pipeID) => {
+        const pipe = flow.data.get(pipeID)
+
+        const stage = {
+          text: '',
+          instances: [pipeID],
+          requirements: {},
+        }
+
+        const create = text => {
+          if (text && PREVIOUS_REGEXP.test(text) && stages.length) {
+            stage.text = text.replace(
+              PREVIOUS_REGEXP,
+              stages[stages.length - 1].text
+            )
+          } else {
+            stage.text = text
+          }
+
+          stages.push(stage)
+        }
+
+        const append = () => {
+          if (stages.length) {
+            stages[stages.length - 1].instances.push(pipeID)
+          }
+        }
+
+        if (
+          PIPE_DEFINITIONS[pipe.type] &&
+          PIPE_DEFINITIONS[pipe.type].generateFlux
+        ) {
+          PIPE_DEFINITIONS[pipe.type].generateFlux(
+            pipe,
+            create,
+            append,
+            withSideEffects
+          )
+        } else {
+          append()
+        }
+
+        return stages
+      }, [])
+      .map(queryStruct => {
+        const queryText =
+          Object.entries(queryStruct.requirements)
+            .map(([key, value]) => `${key} = (\n${value}\n)\n\n`)
+            .join('') + queryStruct.text
+
+        return {
+          text: queryText,
+          instances: queryStruct.instances,
+        }
+      })
+  }
+
+  const query = (text: string): Promise<FluxResult> => {
+    event('runQuery', {context: 'flows'})
+
+    return queryAPI(text, vars)
+  }
+
+  const forceUpdate = (id, data) => {
+    try {
+      update(id, data)
+    } catch (_e) {
+      add(id, data)
+    }
+  }
+
+  const statuses = flow ? flow.meta.all.map(({loading}) => loading) : []
+
+  let status = RemoteDataState.Done
+
+  if (statuses.every(s => s === RemoteDataState.NotStarted)) {
+    status = RemoteDataState.NotStarted
+  } else if (statuses.includes(RemoteDataState.Error)) {
+    status = RemoteDataState.Error
+  } else if (statuses.includes(RemoteDataState.Loading)) {
+    status = RemoteDataState.Loading
+  }
+
+  const queryAll = () => {
+    if (status === RemoteDataState.Loading) {
+      return
+    }
+
+    const map = generateMap(runMode === RunMode.Run)
+
+    if (!map.length) {
+      return
+    }
+
+    event('Running Notebook QueryAll')
+
+    Promise.all(
+      map.map(stage => {
+        stage.instances.forEach(pipeID => {
+          flow.meta.update(pipeID, {loading: RemoteDataState.Loading})
+        })
+        return query(stage.text)
+          .then(response => {
+            stage.instances.forEach(pipeID => {
+              flow.meta.update(pipeID, {loading: RemoteDataState.Done})
+              forceUpdate(pipeID, response)
+            })
+          })
+          .catch(e => {
+            stage.instances.forEach(pipeID => {
+              forceUpdate(pipeID, {
+                error: e.message,
+              })
+              flow.meta.update(pipeID, {loading: RemoteDataState.Error})
+            })
+          })
+      })
+    )
+      .then(() => {
+        event('run_notebook_success', {runMode})
+        dispatch(notify(notebookRunSuccess(runMode, PROJECT_NAME)))
+      })
+      .catch(e => {
+        event('run_notebook_fail', {runMode})
+        dispatch(notify(notebookRunFail(runMode, PROJECT_NAME)))
+
+        // NOTE: this shouldn't fire, but lets wrap it for completeness
+        throw e
+      })
+  }
+
+  if (!flow) {
+    return (
+      <EmptyGraphMessage
+        message="Could not find this notebook"
+        testID="notebook-not-found"
+      />
+    )
+  }
+
+  if (!flow?.range) {
+    return null
+  }
+
+  return (
+    <FlowQueryContext.Provider value={{query, generateMap, queryAll}}>
+      {children}
+    </FlowQueryContext.Provider>
+  )
+}

--- a/src/flows/context/pipe.tsx
+++ b/src/flows/context/pipe.tsx
@@ -2,7 +2,7 @@ import React, {FC, useContext, useMemo} from 'react'
 import {PipeData, FluxResult} from 'src/types/flows'
 import {FlowContext} from 'src/flows/context/flow.current'
 import {ResultsContext} from 'src/flows/context/results'
-import {QueryContext} from './query'
+import {FlowQueryContext} from 'src/flows/context/flow.query'
 import {RemoteDataState, SelectableDurationTimeRange} from 'src/types'
 
 export interface PipeContextType {
@@ -40,7 +40,7 @@ interface PipeContextProps {
 export const PipeProvider: FC<PipeContextProps> = ({id, children}) => {
   const {flow} = useContext(FlowContext)
   const results = useContext(ResultsContext)
-  const {generateMap} = useContext(QueryContext)
+  const {generateMap} = useContext(FlowQueryContext)
 
   const stages = useMemo(() => generateMap(true), [
     generateMap,

--- a/src/flows/context/query.tsx
+++ b/src/flows/context/query.tsx
@@ -100,6 +100,7 @@ export const QueryProvider: FC = ({children}) => {
   const bucketsLoadingState = useSelector((state: AppState) =>
     getStatus(state, ResourceType.Buckets)
   )
+  const org = useSelector(getOrg)
 
   const dispatch = useDispatch()
 
@@ -136,8 +137,7 @@ export const QueryProvider: FC = ({children}) => {
         node?.arguments[0]?.properties[0]?.key?.name === 'bucket'
     ).map(node => node?.arguments[0]?.properties[0]?.value.value)
     const orgID =
-      buckets.find(buck => queryBuckets.includes(buck.name))?.orgID ||
-      useSelector(getOrg).id
+      buckets.find(buck => queryBuckets.includes(buck.name))?.orgID || org.id
 
     // This is all for trying to tease out a window period
     if (usedVars.hasOwnProperty('windowPeriod')) {
@@ -166,7 +166,7 @@ export const QueryProvider: FC = ({children}) => {
       )
 
       if (!queryRanges.length) {
-        ;(((optionAST.body[0] as OptionStatement)
+        ;(((optionAST.body[0] as OptionStatement) // eslint-disable-line no-extra-semi
           .assignment as VariableAssignment)
           .init as ObjectExpression).properties.push({
           type: 'Property',
@@ -197,7 +197,7 @@ export const QueryProvider: FC = ({children}) => {
         )
 
         if (foundDuration) {
-          ;(((optionAST.body[0] as OptionStatement)
+          ;(((optionAST.body[0] as OptionStatement) // eslint-disable-line no-extra-semi
             .assignment as VariableAssignment)
             .init as ObjectExpression).properties.push({
             type: 'Property',
@@ -211,7 +211,7 @@ export const QueryProvider: FC = ({children}) => {
             },
           })
         } else {
-          ;(((optionAST.body[0] as OptionStatement)
+          ;(((optionAST.body[0] as OptionStatement) // eslint-disable-line no-extra-semi
             .assignment as VariableAssignment)
             .init as ObjectExpression).properties.push({
             type: 'Property',

--- a/src/flows/context/query.tsx
+++ b/src/flows/context/query.tsx
@@ -1,33 +1,19 @@
-import React, {FC, useContext, useMemo, useEffect} from 'react'
+import React, {FC, useEffect} from 'react'
 import {useDispatch, useSelector} from 'react-redux'
 import {parse} from 'src/external/parser'
 import {runQuery} from 'src/shared/apis/query'
 import {buildVarsOption} from 'src/variables/utils/buildVarsOption'
-import {getVariables, asAssignment} from 'src/variables/selectors'
+import {asAssignment} from 'src/variables/selectors'
 import {getOrg} from 'src/organizations/selectors'
 import {getBuckets} from 'src/buckets/actions/thunks'
 import {getSortedBuckets} from 'src/buckets/selectors'
 import {getStatus} from 'src/resources/selectors'
-import {FlowContext} from 'src/flows/context/flow.current'
-import {RunModeContext, RunMode} from 'src/flows/context/runMode'
-import {ResultsContext} from 'src/flows/context/results'
 import {fromFlux} from '@influxdata/giraffe'
-import {event} from 'src/cloud/utils/reporting'
 import {FluxResult} from 'src/types/flows'
-import {PIPE_DEFINITIONS} from 'src/flows'
 import {propertyTime} from 'src/shared/utils/getMinDurationFromAST'
-import {notify} from 'src/shared/actions/notifications'
-import EmptyGraphMessage from 'src/shared/components/EmptyGraphMessage'
-import {parseDuration, timeRangeToDuration} from 'src/shared/utils/duration'
 
 // Constants
-import {
-  notebookRunSuccess,
-  notebookRunFail,
-} from 'src/shared/copy/notifications'
-import {TIME_RANGE_START, TIME_RANGE_STOP} from 'src/variables/constants'
 import {SELECTABLE_TIME_RANGES} from 'src/shared/constants/timeRanges'
-import {PROJECT_NAME} from 'src/flows'
 
 // Types
 import {
@@ -40,25 +26,16 @@ import {
   ObjectExpression,
 } from 'src/types'
 
-interface Stage {
-  text: string
-  instances: string[]
-}
-
 interface VariableMap {
   [key: string]: Variable
 }
 
 export interface QueryContextType {
-  generateMap: (withSideEffects?: boolean) => Stage[]
-  query: (text: string) => Promise<FluxResult>
-  queryAll: () => void
+  query: (text: string, vars?: VariableMap) => Promise<FluxResult>
 }
 
 export const DEFAULT_CONTEXT: QueryContextType = {
-  generateMap: () => [],
-  query: (_: string) => Promise.resolve({} as FluxResult),
-  queryAll: () => {},
+  query: (_: string, __?: VariableMap) => Promise.resolve({} as FluxResult),
 }
 
 export const QueryContext = React.createContext<QueryContextType>(
@@ -68,15 +45,57 @@ export const QueryContext = React.createContext<QueryContextType>(
 const DESIRED_POINTS_PER_GRAPH = 360
 const FALLBACK_WINDOW_PERIOD = 15000
 
-const PREVIOUS_REGEXP = /__PREVIOUS_RESULT__/g
+const _walk = (node, test, acc = []) => {
+  if (!node) {
+    return acc
+  }
+
+  if (test(node)) {
+    acc.push(node)
+  }
+
+  Object.values(node).forEach(val => {
+    if (Array.isArray(val)) {
+      val.forEach(_val => {
+        _walk(_val, test, acc)
+      })
+    } else if (typeof val === 'object') {
+      _walk(val, test, acc)
+    }
+  })
+
+  return acc
+}
+
+const _getVars = (
+  ast,
+  allVars: VariableMap = {},
+  acc: VariableMap = {}
+): VariableMap =>
+  _walk(
+    ast,
+    node => node?.type === 'MemberExpression' && node?.object?.name === 'v'
+  )
+    .map(node => node.property.name)
+    .reduce((tot, curr) => {
+      if (tot.hasOwnProperty(curr)) {
+        return tot
+      }
+
+      if (!allVars[curr]) {
+        tot[curr] = null
+        return tot
+      }
+      tot[curr] = allVars[curr]
+
+      if (tot[curr].arguments.type === 'query') {
+        _getVars(parse(tot[curr].arguments.values.query), allVars, tot)
+      }
+
+      return tot
+    }, acc)
 
 export const QueryProvider: FC = ({children}) => {
-  const {flow} = useContext(FlowContext)
-  const {runMode} = useContext(RunModeContext)
-  const {add, update} = useContext(ResultsContext)
-
-  const variables = useSelector((state: AppState) => getVariables(state))
-
   const buckets = useSelector((state: AppState) => getSortedBuckets(state))
   const bucketsLoadingState = useSelector((state: AppState) =>
     getStatus(state, ResourceType.Buckets)
@@ -90,212 +109,17 @@ export const QueryProvider: FC = ({children}) => {
     }
   }, [bucketsLoadingState, dispatch])
 
-  const vars = useMemo(() => {
-    const _vars = [...variables]
-
-    if (!flow?.range) {
-      return _vars.reduce((acc, curr) => {
-        acc[curr.name] = curr
-        return acc
-      }, {})
-    }
-
-    if (!flow.range.upper) {
-      _vars.push({
-        orgID: '',
-        id: TIME_RANGE_STOP,
-        name: TIME_RANGE_STOP,
-        arguments: {
-          type: 'system',
-          values: ['now()'],
-        },
-        status: RemoteDataState.Done,
-        labels: [],
-      })
-    } else if (isNaN(Date.parse(flow.range.upper))) {
-      _vars.push({
-        orgID: '',
-        id: TIME_RANGE_STOP,
-        name: TIME_RANGE_STOP,
-        arguments: {
-          type: 'system',
-          values: [null],
-        },
-        status: RemoteDataState.Done,
-        labels: [],
-      })
-    } else {
-      _vars.push({
-        orgID: '',
-        id: TIME_RANGE_STOP,
-        name: TIME_RANGE_STOP,
-        arguments: {
-          type: 'system',
-          values: [flow.range.upper],
-        },
-        status: RemoteDataState.Done,
-        labels: [],
-      })
-    }
-
-    if ((flow.range.type as any) !== 'custom') {
-      const duration = parseDuration(timeRangeToDuration(flow.range))
-
-      _vars.push({
-        orgID: '',
-        id: TIME_RANGE_START,
-        name: TIME_RANGE_START,
-        arguments: {
-          type: 'system',
-          values: [duration],
-        },
-        status: RemoteDataState.Done,
-        labels: [],
-      })
-    } else if (isNaN(Date.parse(flow.range.lower))) {
-      _vars.push({
-        orgID: '',
-        id: TIME_RANGE_START,
-        name: TIME_RANGE_START,
-        arguments: {
-          type: 'system',
-          values: [null],
-        },
-        status: RemoteDataState.Done,
-        labels: [],
-      })
-    } else {
-      _vars.push({
-        orgID: '',
-        id: TIME_RANGE_START,
-        name: TIME_RANGE_START,
-        arguments: {
-          type: 'system',
-          values: [flow.range.lower],
-        },
-        status: RemoteDataState.Done,
-        labels: [],
-      })
-    }
-
-    return _vars.reduce((acc, curr) => {
-      acc[curr.name] = curr
-      return acc
-    }, {})
-  }, [variables, flow?.range])
-
-  const generateMap = (withSideEffects?: boolean): Stage[] => {
-    return flow.data.allIDs
-      .reduce((stages, pipeID) => {
-        const pipe = flow.data.get(pipeID)
-
-        const stage = {
-          text: '',
-          instances: [pipeID],
-          requirements: {},
-        }
-
-        const create = text => {
-          if (text && PREVIOUS_REGEXP.test(text) && stages.length) {
-            stage.text = text.replace(
-              PREVIOUS_REGEXP,
-              stages[stages.length - 1].text
-            )
-          } else {
-            stage.text = text
-          }
-
-          stages.push(stage)
-        }
-
-        const append = () => {
-          if (stages.length) {
-            stages[stages.length - 1].instances.push(pipeID)
-          }
-        }
-
-        if (
-          PIPE_DEFINITIONS[pipe.type] &&
-          PIPE_DEFINITIONS[pipe.type].generateFlux
-        ) {
-          PIPE_DEFINITIONS[pipe.type].generateFlux(
-            pipe,
-            create,
-            append,
-            withSideEffects
-          )
-        } else {
-          append()
-        }
-
-        return stages
-      }, [])
-      .map(queryStruct => {
-        const queryText =
-          Object.entries(queryStruct.requirements)
-            .map(([key, value]) => `${key} = (\n${value}\n)\n\n`)
-            .join('') + queryStruct.text
-
-        return {
-          text: queryText,
-          instances: queryStruct.instances,
-        }
-      })
-  }
-
-  const _walk = (node, test, acc = []) => {
-    if (!node) {
-      return acc
-    }
-
-    if (test(node)) {
-      acc.push(node)
-    }
-
-    Object.values(node).forEach(val => {
-      if (Array.isArray(val)) {
-        val.forEach(_val => {
-          _walk(_val, test, acc)
-        })
-      } else if (typeof val === 'object') {
-        _walk(val, test, acc)
-      }
-    })
-
-    return acc
-  }
-
-  const _getVars = (ast, acc: VariableMap = {}): VariableMap =>
-    _walk(
-      ast,
-      node => node?.type === 'MemberExpression' && node?.object?.name === 'v'
-    )
-      .map(node => node.property.name)
-      .reduce((tot, curr) => {
-
-        if (tot.hasOwnProperty(curr)) {
-          return tot
-        }
-
-          if (!vars[curr]) {
-              tot[curr] = null
-              return tot
-          }
-        tot[curr] = vars[curr]
-
-        if (tot[curr].arguments.type === 'query') {
-          _getVars(parse(tot[curr].arguments.values.query), tot)
-        }
-
-        return tot
-      }, acc)
-
-  const query = (text: string): Promise<FluxResult> => {
+  const query = (text: string, vars: VariableMap = {}): Promise<FluxResult> => {
     // Some preamble for setting the stage
     const baseAST = parse(text)
-    const usedVars = _getVars(baseAST)
-    const optionAST = buildVarsOption(Object.values(usedVars).filter(v => !!v).map(v => asAssignment(v)))
+    const usedVars = _getVars(baseAST, vars)
+    const optionAST = buildVarsOption(
+      Object.values(usedVars)
+        .filter(v => !!v)
+        .map(v => asAssignment(v))
+    )
 
+    // Make a version of the query with the variables loaded
     const ast = {
       package: '',
       type: 'Package',
@@ -411,8 +235,6 @@ export const QueryProvider: FC = ({children}) => {
       }
     }
 
-    event('runQuery', {context: 'flows'})
-
     const result = runQuery(orgID, text, optionAST)
 
     return result.promise
@@ -433,91 +255,12 @@ export const QueryProvider: FC = ({children}) => {
       })
   }
 
-  const forceUpdate = (id, data) => {
-    try {
-      update(id, data)
-    } catch (_e) {
-      add(id, data)
-    }
-  }
-
-  const statuses = flow ? flow.meta.all.map(({loading}) => loading) : []
-
-  let status = RemoteDataState.Done
-
-  if (statuses.every(s => s === RemoteDataState.NotStarted)) {
-    status = RemoteDataState.NotStarted
-  } else if (statuses.includes(RemoteDataState.Error)) {
-    status = RemoteDataState.Error
-  } else if (statuses.includes(RemoteDataState.Loading)) {
-    status = RemoteDataState.Loading
-  }
-
-  const queryAll = () => {
-    if (status === RemoteDataState.Loading) {
-      return
-    }
-
-    const map = generateMap(runMode === RunMode.Run)
-
-    if (!map.length) {
-      return
-    }
-
-    event('Running Notebook QueryAll')
-
-    Promise.all(
-      map.map(stage => {
-        stage.instances.forEach(pipeID => {
-          flow.meta.update(pipeID, {loading: RemoteDataState.Loading})
-        })
-        return query(stage.text)
-          .then(response => {
-            stage.instances.forEach(pipeID => {
-              flow.meta.update(pipeID, {loading: RemoteDataState.Done})
-              forceUpdate(pipeID, response)
-            })
-          })
-          .catch(e => {
-            stage.instances.forEach(pipeID => {
-              forceUpdate(pipeID, {
-                error: e.message,
-              })
-              flow.meta.update(pipeID, {loading: RemoteDataState.Error})
-            })
-          })
-      })
-    )
-      .then(() => {
-        event('run_notebook_success', {runMode})
-        dispatch(notify(notebookRunSuccess(runMode, PROJECT_NAME)))
-      })
-      .catch(e => {
-        event('run_notebook_fail', {runMode})
-        dispatch(notify(notebookRunFail(runMode, PROJECT_NAME)))
-
-        // NOTE: this shouldn't fire, but lets wrap it for completeness
-        throw e
-      })
-  }
-
-  if (!flow) {
-    return (
-      <EmptyGraphMessage
-        message="Could not find this notebook"
-        testID="notebook-not-found"
-      />
-    )
-  }
-
-  if (!flow?.range || bucketsLoadingState !== RemoteDataState.Done) {
+  if (bucketsLoadingState !== RemoteDataState.Done) {
     return null
   }
 
   return (
-    <QueryContext.Provider value={{query, generateMap, queryAll}}>
-      {children}
-    </QueryContext.Provider>
+    <QueryContext.Provider value={{query}}>{children}</QueryContext.Provider>
   )
 }
 

--- a/src/flows/pipes/MetricSelector/AggregateWindowSelector.tsx
+++ b/src/flows/pipes/MetricSelector/AggregateWindowSelector.tsx
@@ -7,7 +7,7 @@ import {Dropdown, IconFont, Icon} from '@influxdata/clockface'
 // Contexts
 import {PipeContext} from 'src/flows/context/pipe'
 import {FlowContext} from 'src/flows/context/flow.current'
-import {QueryContext} from 'src/flows/context/query'
+import {FlowQueryContext} from 'src/flows/context/flow.query'
 
 // Constants
 import {FUNCTIONS, QueryFn} from 'src/timeMachine/constants/queryBuilder'
@@ -18,7 +18,7 @@ import {millisecondsToDuration} from 'src/shared/utils/duration'
 const AggregateFunctionSelector: FC = () => {
   const {flow} = useContext(FlowContext)
   const {data, update} = useContext(PipeContext)
-  const {queryAll} = useContext(QueryContext)
+  const {queryAll} = useContext(FlowQueryContext)
 
   const selectedFunction = data?.aggregateFunction || FUNCTIONS[0]
 

--- a/src/flows/pipes/QueryBuilder/context.tsx
+++ b/src/flows/pipes/QueryBuilder/context.tsx
@@ -11,7 +11,6 @@ import React, {
 // Contexts
 import {PipeContext} from 'src/flows/context/pipe'
 import {QueryContext} from 'src/flows/context/query'
-import {FlowContext} from 'src/flows/context/flow.current'
 
 import {formatTimeRangeArguments} from 'src/timeMachine/apis/queryBuilder'
 
@@ -92,9 +91,8 @@ const fromBuilderConfig = (tags: BuilderTagsType[]): QueryBuilderCard[] =>
   })
 
 export const QueryBuilderProvider: FC = ({children}) => {
-  const {data, update} = useContext(PipeContext)
+  const {data, range, update} = useContext(PipeContext)
   const {query} = useContext(QueryContext)
-  const {flow} = useContext(FlowContext)
 
   const [cards, setCards] = useState(fromBuilderConfig(data.tags))
 
@@ -151,7 +149,7 @@ export const QueryBuilderProvider: FC = ({children}) => {
       // TODO: Use the `v1.tagKeys` function from the Flux standard library once
       // this issue is resolved: https://github.com/influxdata/flux/issues/1071
       query(`from(bucket: "${buckets[0]}")
-              |> range(${formatTimeRangeArguments(flow.range)})
+              |> range(${formatTimeRangeArguments(range)})
               |> filter(fn: (r) => ${tagString})
               |> keys()
               |> keep(columns: ["_value"])
@@ -226,7 +224,7 @@ export const QueryBuilderProvider: FC = ({children}) => {
       // TODO: Use the `v1.tagValues` function from the Flux standard library once
       // this issue is resolved: https://github.com/influxdata/flux/issues/1071
       query(`from(bucket: "${data.buckets[0]}")
-              |> range(${formatTimeRangeArguments(flow.range)})
+              |> range(${formatTimeRangeArguments(range)})
               |> filter(fn: (r) => ${tagString})
               |> keep(columns: ["${cards[idx].keys.selected[0]}"])
               |> group()

--- a/src/flows/pipes/ToBucket/ExportTaskButton.tsx
+++ b/src/flows/pipes/ToBucket/ExportTaskButton.tsx
@@ -11,23 +11,21 @@ import {
 import {Button} from '@influxdata/clockface'
 import {PipeContext} from 'src/flows/context/pipe'
 import {PopupContext} from 'src/flows/context/popup'
-import {FlowContext} from 'src/flows/context/flow.current'
 import ExportTaskOverlay from 'src/flows/pipes/ToBucket/ExportTaskOverlay'
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'
 
 const ExportTaskButton: FC = () => {
-  const {data, queryText} = useContext(PipeContext)
+  const {data, range, queryText} = useContext(PipeContext)
   const {launch} = useContext(PopupContext)
-  const {flow} = useContext(FlowContext)
 
   const onClick = () => {
     event('Export Task Clicked')
     launch(<ExportTaskOverlay />, {
       bucket: data.bucket,
       query: queryText,
-      range: flow.range,
+      range,
     })
   }
 

--- a/src/flows/pipes/Visualization/ExportDashboardOverlay/Visualization.tsx
+++ b/src/flows/pipes/Visualization/ExportDashboardOverlay/Visualization.tsx
@@ -2,7 +2,8 @@
 import React, {FC, useCallback, useContext, useEffect, useState} from 'react'
 
 // Components
-import QueryProvider, {QueryContext} from 'src/flows/context/query'
+import QueryProvider from 'src/flows/context/query'
+import {FlowQueryProvider, FlowQueryContext} from 'src/flows/context/flow.query'
 import {PopupContext} from 'src/flows/context/popup'
 import {View} from 'src/visualization'
 
@@ -14,7 +15,7 @@ const Visualization: FC = () => {
   const [results, setResults] = useState<FluxResult>(null)
   const [loading, setLoading] = useState(RemoteDataState.NotStarted)
   const {data} = useContext(PopupContext)
-  const {query} = useContext(QueryContext)
+  const {query} = useContext(FlowQueryContext)
 
   const queryAndSetResults = useCallback(
     async text => {
@@ -47,6 +48,8 @@ const Visualization: FC = () => {
 
 export default () => (
   <QueryProvider>
-    <Visualization />
+    <FlowQueryProvider>
+      <Visualization />
+    </FlowQueryProvider>
   </QueryProvider>
 )

--- a/src/flows/shared/ResizerHeader.tsx
+++ b/src/flows/shared/ResizerHeader.tsx
@@ -7,7 +7,7 @@ import {Icon, IconFont} from '@influxdata/clockface'
 
 // Context
 import {PipeContext} from 'src/flows/context/pipe'
-import {QueryContext} from 'src/flows/context/query'
+import {FlowQueryContext} from 'src/flows/context/flow.query'
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'
@@ -40,7 +40,7 @@ const ResizerHeader: FC<Props> = ({
   toggleVisibilityEnabled,
 }) => {
   const {readOnly} = useContext(PipeContext)
-  const {queryAll} = useContext(QueryContext)
+  const {queryAll} = useContext(FlowQueryContext)
   const glyph = visibility === 'visible' ? IconFont.EyeOpen : IconFont.EyeClosed
   const className = classnames('panel-resizer--header', {
     'panel-resizer--header__multiple-controls':

--- a/src/shared/utils/getMinDurationFromAST.ts
+++ b/src/shared/utils/getMinDurationFromAST.ts
@@ -84,7 +84,7 @@ function rangeTimes(ast: any, rangeNode: CallExpression): [number, number] {
   return [start, end]
 }
 
-function propertyTime(ast: any, value: Expression, now: number): number {
+export function propertyTime(ast: any, value: Expression, now: number): number {
   switch (value.type) {
     case 'UnaryExpression':
       return (


### PR DESCRIPTION
The query context that exists in flows was way too coupled with the generateMap pipeline. Took some time this morning to decouple those concepts. This also consolidates all AST node manipulation for this query path to a single file in order to keep that craziness contained. There might be some more work to do there, but less than before.

Hopefully we can move the caching layer stuff into this context as well, to help detangle that bit from time machine and allow all interfaces to use it effectively.

This also brought up the fact that any variables will be set to the selection you made at the last dashboard you visited. There's no current plans on supporting that interface on a notebook yet, just a fun fact that might bite us later.

closes #543 