### PR TITLE
fix: show table column options

### DIFF
--- a/src/visualization/types/Table/options.tsx
+++ b/src/visualization/types/Table/options.tsx
@@ -320,7 +320,7 @@ const TableViewOptions: FC<Props> = ({properties, results, update}) => {
           <Form.Element label="Table Columns">
             <DndProvider backend={HTML5Backend}>
               <div>
-                {draggableColumns.length || (
+                {!draggableColumns.length ? (
                   <Form.Box>
                     <EmptyState size={ComponentSize.Small}>
                       <EmptyState.Text>
@@ -328,7 +328,7 @@ const TableViewOptions: FC<Props> = ({properties, results, update}) => {
                       </EmptyState.Text>
                     </EmptyState>
                   </Form.Box>
-                )}
+                ): draggableColumns}
               </div>
             </DndProvider>
           </Form.Element>

--- a/src/visualization/types/Table/options.tsx
+++ b/src/visualization/types/Table/options.tsx
@@ -328,7 +328,9 @@ const TableViewOptions: FC<Props> = ({properties, results, update}) => {
                       </EmptyState.Text>
                     </EmptyState>
                   </Form.Box>
-                ): draggableColumns}
+                ) : (
+                  draggableColumns
+                )}
               </div>
             </DndProvider>
           </Form.Element>


### PR DESCRIPTION
table columns weren't showing up in the table vis options. now they are