### PR TITLE
feat: update Mosaic visualization

### DIFF
--- a/src/shared/utils/vis.ts
+++ b/src/shared/utils/vis.ts
@@ -254,12 +254,27 @@ export const defaultYSeriesColumns = (
     )
   }
   if (ySeriesColumns.length === 0) {
-    ySeriesColumns.push(
-      validColumnKeys.find(columnKey => columnKey.startsWith('_') === false)
+    const defaultKey = validColumnKeys.find(
+      columnKey => columnKey.startsWith('_') === false
     )
+    if (defaultKey) {
+      ySeriesColumns.push(defaultKey)
+    }
   }
 
   return ySeriesColumns
+}
+
+export const defaultYLabelColumns = (
+  preferredYSeriesColumns: Array<string>,
+  validYSeriesColumns: Array<string>
+): Array<string> => {
+  return Array.isArray(preferredYSeriesColumns) &&
+    Array.isArray(validYSeriesColumns)
+    ? preferredYSeriesColumns.filter(columnKey =>
+        validYSeriesColumns.includes(columnKey)
+      )
+    : []
 }
 
 export const isInDomain = (value: number, domain: number[]) =>

--- a/src/shared/utils/vis.ts
+++ b/src/shared/utils/vis.ts
@@ -250,12 +250,7 @@ export const mosaicYColumn = (
     return preferredColumnKey
   }
 
-  const invalidMosaicYColumns = new Set([
-    '_value',
-    'status',
-    '_field',
-    '_measurement',
-  ])
+  const invalidMosaicYColumns = new Set(['_value', 'status', '_field'])
   const preferredValidColumnKeys = validColumnKeys.filter(
     name => !invalidMosaicYColumns.has(name)
   )

--- a/src/shared/utils/vis.ts
+++ b/src/shared/utils/vis.ts
@@ -241,27 +241,25 @@ export const defaultYColumn = (
   return null
 }
 
-export const mosaicYColumn = (
+export const defaultYSeriesColumns = (
   table: Table,
-  preferredColumnKey?: string
-): string | null => {
-  const validColumnKeys = getStringColumns(table)
-  if (validColumnKeys.includes(preferredColumnKey)) {
-    return preferredColumnKey
+  preferredYSeriesColumns: Array<string>
+): Array<string> => {
+  const validColumnKeys = [...getStringColumns(table)]
+  let ySeriesColumns = []
+
+  if (Array.isArray(preferredYSeriesColumns)) {
+    ySeriesColumns = preferredYSeriesColumns.filter(columnKey =>
+      validColumnKeys.includes(columnKey)
+    )
+  }
+  if (ySeriesColumns.length === 0) {
+    ySeriesColumns.push(
+      validColumnKeys.find(columnKey => columnKey.startsWith('_') === false)
+    )
   }
 
-  const invalidMosaicYColumns = new Set(['_value', 'status', '_field'])
-  const preferredValidColumnKeys = validColumnKeys.filter(
-    name => !invalidMosaicYColumns.has(name)
-  )
-  if (preferredValidColumnKeys.length) {
-    return preferredValidColumnKeys[0]
-  }
-
-  if (validColumnKeys.length) {
-    return validColumnKeys[0]
-  }
-  return null
+  return ySeriesColumns
 }
 
 export const isInDomain = (value: number, domain: number[]) =>

--- a/src/timeMachine/actions/index.ts
+++ b/src/timeMachine/actions/index.ts
@@ -79,6 +79,8 @@ export type Action =
   | SetXColumnAction
   | SetYColumnAction
   | SetYSeriesColumnsAction
+  | SetYLabelColumnsAction
+  | SetYLabelColumnSeparatorAction
   | SetBinSizeAction
   | SetColorHexesAction
   | SetFillColumnsAction
@@ -556,6 +558,30 @@ export const setYSeriesColumns = (
 ): SetYSeriesColumnsAction => ({
   type: 'SET_Y_SERIES_COLUMNS',
   payload: {ySeriesColumns},
+})
+
+interface SetYLabelColumnsAction {
+  type: 'SET_Y_LABEL_COLUMNS'
+  payload: {yLabelColumns: string[]}
+}
+
+export const setYLabelColumns = (
+  yLabelColumns: string[]
+): SetYLabelColumnsAction => ({
+  type: 'SET_Y_LABEL_COLUMNS',
+  payload: {yLabelColumns},
+})
+
+interface SetYLabelColumnSeparatorAction {
+  type: 'SET_Y_LABEL_COLUMN_SEPARATOR'
+  payload: {yLabelColumnSeparator: string}
+}
+
+export const setYLabelColumnSeparator = (
+  yLabelColumnSeparator: string
+): SetYLabelColumnSeparatorAction => ({
+  type: 'SET_Y_LABEL_COLUMN_SEPARATOR',
+  payload: {yLabelColumnSeparator},
 })
 
 interface SetShadeBelowAction {

--- a/src/timeMachine/components/FunctionModeSelector.tsx
+++ b/src/timeMachine/components/FunctionModeSelector.tsx
@@ -50,7 +50,7 @@ const FunctionSelector: FunctionComponent<Props> = ({
   savedFunctions,
 }) => {
   const autoFunctions = getDefaultAutoFunctions(activeGraphType).map(
-    f => f.name
+    autoFunction => autoFunction.name
   )
 
   const [isAutoFunction, setIsAutoFunction] = useState(
@@ -84,7 +84,9 @@ const FunctionSelector: FunctionComponent<Props> = ({
       handleSetAutoFunction(false)
       return
     }
-    const newFunctions = savedFunctions.filter(f => autoFunctions.includes(f))
+    const newFunctions = savedFunctions.filter(savedFunction =>
+      autoFunctions.includes(savedFunction)
+    )
     if (newFunctions.length === 0) {
       onSetFunctions([autoFunctions[0]])
     } else if (newFunctions.length > 1) {

--- a/src/timeMachine/components/Vis.tsx
+++ b/src/timeMachine/components/Vis.tsx
@@ -25,7 +25,7 @@ import {
 import {getTimeRangeWithTimezone} from 'src/dashboards/selectors'
 
 // Types
-import {RemoteDataState, AppState} from 'src/types'
+import {RemoteDataState, AppState, ViewProperties} from 'src/types'
 
 // Selectors
 import {getActiveTimeRange} from 'src/timeMachine/selectors/index'
@@ -48,6 +48,7 @@ const TimeMachineVis: FC<Props> = ({
   symbolColumns,
   annotations,
 }) => {
+  const {type} = viewProperties
   // If the current selections for `xColumn`/`yColumn`/ etc. are invalid given
   // the current Flux response, attempt to make a valid selection instead. This
   // fallback logic is contained within the selectors that supply each of these
@@ -56,10 +57,11 @@ const TimeMachineVis: FC<Props> = ({
   const resolvedViewProperties = {
     ...viewProperties,
     xColumn,
-    yColumn,
+    [`${type === 'mosaic' ? 'ySeriesColumns' : 'yColumn'}`]:
+      type === 'mosaic' ? [yColumn] : yColumn,
     fillColumns,
     symbolColumns,
-  }
+  } as ViewProperties
 
   const noQueries =
     loading === RemoteDataState.NotStarted || !viewProperties.queries.length

--- a/src/timeMachine/components/Vis.tsx
+++ b/src/timeMachine/components/Vis.tsx
@@ -13,14 +13,15 @@ import ErrorBoundary from 'src/shared/components/ErrorBoundary'
 import EmptyQueryView, {ErrorFormat} from 'src/shared/components/EmptyQueryView'
 
 // Utils
-import {getActiveTimeMachine} from 'src/timeMachine/selectors'
 import {
+  getActiveTimeMachine,
   getAnnotations,
   getFillColumnsSelection,
   getSymbolColumnsSelection,
   getVisTable,
   getXColumnSelection,
   getYColumnSelection,
+  getYSeriesColumns,
 } from 'src/timeMachine/selectors'
 import {getTimeRangeWithTimezone} from 'src/dashboards/selectors'
 
@@ -44,6 +45,7 @@ const TimeMachineVis: FC<Props> = ({
   giraffeResult,
   xColumn,
   yColumn,
+  ySeriesColumns,
   fillColumns,
   symbolColumns,
   annotations,
@@ -58,7 +60,7 @@ const TimeMachineVis: FC<Props> = ({
     ...viewProperties,
     xColumn,
     [`${type === 'mosaic' ? 'ySeriesColumns' : 'yColumn'}`]:
-      type === 'mosaic' ? [yColumn] : yColumn,
+      type === 'mosaic' ? ySeriesColumns : yColumn,
     fillColumns,
     symbolColumns,
   } as ViewProperties
@@ -125,6 +127,7 @@ const mstp = (state: AppState) => {
   const giraffeResult = getVisTable(state)
   const xColumn = getXColumnSelection(state)
   const yColumn = getYColumnSelection(state)
+  const ySeriesColumns = getYSeriesColumns(state)
   const fillColumns = getFillColumnsSelection(state)
   const symbolColumns = getSymbolColumnsSelection(state)
   const annotations = getAnnotations(state)
@@ -139,6 +142,7 @@ const mstp = (state: AppState) => {
     giraffeResult,
     xColumn,
     yColumn,
+    ySeriesColumns,
     fillColumns,
     symbolColumns,
     timeRange: getActiveTimeRange(timeRange, viewProperties.queries),

--- a/src/timeMachine/constants/queryBuilder.ts
+++ b/src/timeMachine/constants/queryBuilder.ts
@@ -72,6 +72,18 @@ export const AUTO_FUNCTIONS: QueryFn[] = [
   },
 ]
 
+export const getDefaultAutoFunctions = (activeGraphType: string): QueryFn[] => {
+  if (activeGraphType === 'mosaic') {
+    return [
+      {
+        name: 'last',
+        flux: (period, fillValues) => genFlux('last', period, fillValues),
+      },
+    ]
+  }
+  return AUTO_FUNCTIONS
+}
+
 export const FUNCTIONS: QueryFn[] = [
   AUTO_FUNCTIONS[0],
   AUTO_FUNCTIONS[1],

--- a/src/timeMachine/reducers/index.ts
+++ b/src/timeMachine/reducers/index.ts
@@ -391,6 +391,16 @@ export const timeMachineReducer = (
       return setViewProperties(state, {ySeriesColumns})
     }
 
+    case 'SET_Y_LABEL_COLUMNS': {
+      const {yLabelColumns} = action.payload
+      return setViewProperties(state, {yLabelColumns})
+    }
+
+    case 'SET_Y_LABEL_COLUMN_SEPARATOR': {
+      const {yLabelColumnSeparator} = action.payload
+      return setViewProperties(state, {yLabelColumnSeparator})
+    }
+
     case 'SET_X_AXIS_LABEL': {
       const {xAxisLabel} = action.payload
 

--- a/src/timeMachine/selectors/index.ts
+++ b/src/timeMachine/selectors/index.ts
@@ -166,10 +166,10 @@ export const getYColumnSelection = (state: AppState): string => {
 export const getYSeriesColumns = (state: AppState): Array<string> => {
   const {table} = getVisTable(state)
   const tm = getActiveTimeMachine(state)
-  const preferredYSeriesColumnss = get(tm, 'view.properties.ySeriesColumns')
+  const preferredYSeriesColumns = get(tm, 'view.properties.ySeriesColumns')
 
   if (tm.view.properties.type === 'mosaic') {
-    return defaultYSeriesColumns(table, preferredYSeriesColumnss)
+    return defaultYSeriesColumns(table, preferredYSeriesColumns)
   }
   return []
 }

--- a/src/timeMachine/selectors/index.ts
+++ b/src/timeMachine/selectors/index.ts
@@ -8,7 +8,7 @@ import {fromFlux, Table} from '@influxdata/giraffe'
 import {
   defaultXColumn,
   defaultYColumn,
-  mosaicYColumn,
+  defaultYSeriesColumns,
   getNumericColumns as getNumericColumnsUtil,
   getGroupableColumns as getGroupableColumnsUtil,
   getStringColumns as getStringColumnsUtil,
@@ -155,17 +155,23 @@ export const getXColumnSelection = (state: AppState): string => {
 export const getYColumnSelection = (state: AppState): string => {
   const {table} = getVisTable(state)
   const tm = getActiveTimeMachine(state)
-  let preferredYColumnKey
+  const preferredYColumnKey = get(tm, 'view.properties.yColumn')
 
   if (tm.view.properties.type === 'mosaic') {
-    preferredYColumnKey = get(tm, 'view.properties.ySeriesColumns')
-
-    return mosaicYColumn(table, preferredYColumnKey)
+    return ''
   }
-
-  preferredYColumnKey = get(tm, 'view.properties.yColumn')
-
   return defaultYColumn(table, preferredYColumnKey)
+}
+
+export const getYSeriesColumns = (state: AppState): Array<string> => {
+  const {table} = getVisTable(state)
+  const tm = getActiveTimeMachine(state)
+  const preferredYSeriesColumnss = get(tm, 'view.properties.ySeriesColumns')
+
+  if (tm.view.properties.type === 'mosaic') {
+    return defaultYSeriesColumns(table, preferredYSeriesColumnss)
+  }
+  return []
 }
 
 const getGroupableColumnSelection = (

--- a/src/timeMachine/selectors/index.ts
+++ b/src/timeMachine/selectors/index.ts
@@ -52,6 +52,10 @@ export const getActiveTimeMachine = (state: AppState) => {
   return timeMachine
 }
 
+export const getActiveGraphType = (state: AppState): string => {
+  return get(getActiveTimeMachine(state), 'view.properties.type', 'xy')
+}
+
 export const getIsInCheckOverlay = (state: AppState): boolean => {
   return state.timeMachines.activeTimeMachineID === 'alerting'
 }
@@ -154,18 +158,12 @@ export const getYColumnSelection = (state: AppState): string => {
   let preferredYColumnKey
 
   if (tm.view.properties.type === 'mosaic') {
-    preferredYColumnKey = get(
-      getActiveTimeMachine(state),
-      'view.properties.ySeriesColumns[0]'
-    )
+    preferredYColumnKey = get(tm, 'view.properties.ySeriesColumns')
 
     return mosaicYColumn(table, preferredYColumnKey)
   }
 
-  preferredYColumnKey = get(
-    getActiveTimeMachine(state),
-    'view.properties.yColumn'
-  )
+  preferredYColumnKey = get(tm, 'view.properties.yColumn')
 
   return defaultYColumn(table, preferredYColumnKey)
 }

--- a/src/views/helpers/index.ts
+++ b/src/views/helpers/index.ts
@@ -356,6 +356,8 @@ const NEW_VIEW_CREATORS = {
       xColumn: null,
       xDomain: null,
       ySeriesColumns: null,
+      yLabelColumns: null,
+      yLabelColumnSeparator: '',
       yDomain: null,
       xAxisLabel: '',
       yAxisLabel: '',

--- a/src/visualization/types/Mosaic/options.tsx
+++ b/src/visualization/types/Mosaic/options.tsx
@@ -18,7 +18,7 @@ import {
   FORMAT_OPTIONS,
   resolveTimeFormat,
 } from 'src/visualization/utils/timeFormat'
-import {defaultXColumn} from 'src/shared/utils/vis'
+import {defaultXColumn, defaultYSeriesColumns} from 'src/shared/utils/vis'
 
 // Types
 import {MosaicViewProperties, Color} from 'src/types'
@@ -31,7 +31,6 @@ interface Props extends VisualizationOptionProps {
 const MosaicOptions: FC<Props> = props => {
   const {properties, results, update} = props
   let fillColumns = []
-  let ySeriesColumns = []
   const stringColumns = results.table.columnKeys.filter(k => {
     if (k === 'result' || k === 'table') {
       return false
@@ -59,20 +58,10 @@ const MosaicOptions: FC<Props> = props => {
   }
 
   const xColumn = defaultXColumn(results.table, properties.xColumn)
-
-  if (
-    Array.isArray(properties.ySeriesColumns) &&
-    properties.ySeriesColumns.every(col => stringColumns.includes(col))
-  ) {
-    ySeriesColumns = properties.ySeriesColumns
-  } else {
-    for (const key of stringColumns) {
-      if (key === '_measurement') {
-        ySeriesColumns.push(key)
-        break
-      }
-    }
-  }
+  const ySeriesColumns = defaultYSeriesColumns(
+    results.table,
+    properties.ySeriesColumns
+  )
 
   // TODO: make this normal DashboardColor[] and not string[]
   const colors = properties.colors.map(color => {
@@ -135,7 +124,7 @@ const MosaicOptions: FC<Props> = props => {
               }
             />
           </Form.Element>
-          <Form.Element label="Y Column">
+          <Form.Element label="Y Columns">
             <MultiSelectDropdown
               options={stringColumns}
               selectedOptions={ySeriesColumns}

--- a/src/visualization/types/Mosaic/options.tsx
+++ b/src/visualization/types/Mosaic/options.tsx
@@ -18,7 +18,11 @@ import {
   FORMAT_OPTIONS,
   resolveTimeFormat,
 } from 'src/visualization/utils/timeFormat'
-import {defaultXColumn, defaultYSeriesColumns} from 'src/shared/utils/vis'
+import {
+  defaultXColumn,
+  defaultYLabelColumns,
+  defaultYSeriesColumns,
+} from 'src/shared/utils/vis'
 
 // Types
 import {MosaicViewProperties, Color} from 'src/types'
@@ -63,24 +67,63 @@ const MosaicOptions: FC<Props> = props => {
     properties.ySeriesColumns
   )
 
+  const yLabelColumns = defaultYLabelColumns(
+    properties.yLabelColumns,
+    ySeriesColumns
+  )
+
   // TODO: make this normal DashboardColor[] and not string[]
   const colors = properties.colors.map(color => {
     return {hex: color} as Color
   })
 
-  const onSelectYSeriesColumn = (option: string) => {
+  const updateYLabelColumns = (
+    validYSeriesColumns: Array<string>,
+    currentYLabelColumns: Array<string>,
+    option: string
+  ): Array<string> => {
+    const columnExists = Array.isArray(currentYLabelColumns)
+      ? currentYLabelColumns.find(col => col === option)
+      : false
+    let updatedYLabelColumns = currentYLabelColumns || []
+
+    if (columnExists) {
+      updatedYLabelColumns = currentYLabelColumns.filter(fc => fc !== option)
+    } else {
+      updatedYLabelColumns = validYSeriesColumns.includes(option)
+        ? [...updatedYLabelColumns, option]
+        : updatedYLabelColumns
+    }
+    return updatedYLabelColumns
+  }
+
+  const onSelectYSeriesColumns = (option: string) => {
     const columnExists = Array.isArray(ySeriesColumns)
       ? ySeriesColumns.find(col => col === option)
       : false
-    let updatedColumns = ySeriesColumns || []
+    let updatedYSeriesColumns = ySeriesColumns || []
 
     if (columnExists) {
-      updatedColumns = ySeriesColumns.filter(fc => fc !== option)
+      updatedYSeriesColumns = ySeriesColumns.filter(fc => fc !== option)
     } else {
-      updatedColumns = [...updatedColumns, option]
+      updatedYSeriesColumns = [...updatedYSeriesColumns, option]
     }
 
-    update({ySeriesColumns: updatedColumns})
+    const updatedYLabelColumns = updateYLabelColumns(
+      updatedYSeriesColumns,
+      yLabelColumns,
+      option
+    )
+    update({
+      yLabelColumns: updatedYLabelColumns,
+      ySeriesColumns: updatedYSeriesColumns,
+    })
+  }
+
+  const onSelectYLabelColumns = (option: string) => {
+    update({
+      yLabelColumns: updateYLabelColumns(ySeriesColumns, yLabelColumns, option),
+    })
   }
 
   return (
@@ -128,7 +171,7 @@ const MosaicOptions: FC<Props> = props => {
             <MultiSelectDropdown
               options={stringColumns}
               selectedOptions={ySeriesColumns}
-              onSelect={onSelectYSeriesColumn}
+              onSelect={onSelectYSeriesColumns}
               buttonStatus={ComponentStatus.Default}
             />
           </Form.Element>
@@ -176,6 +219,20 @@ const MosaicOptions: FC<Props> = props => {
             <Input
               value={properties.yAxisLabel}
               onChange={e => update({yAxisLabel: e.target.value})}
+            />
+          </Form.Element>
+          <Form.Element label="Y Label Separator">
+            <Input
+              value={properties.yLabelColumnSeparator}
+              onChange={e => update({yLabelColumnSeparator: e.target.value})}
+            />
+          </Form.Element>
+          <Form.Element label="Y Labels">
+            <MultiSelectDropdown
+              options={ySeriesColumns}
+              selectedOptions={yLabelColumns}
+              onSelect={onSelectYLabelColumns}
+              buttonStatus={ComponentStatus.Default}
             />
           </Form.Element>
         </Grid.Column>

--- a/src/visualization/types/Mosaic/options.tsx
+++ b/src/visualization/types/Mosaic/options.tsx
@@ -45,7 +45,9 @@ const MosaicOptions: FC<Props> = props => {
 
   // Mosaic graphs are currently limited to always using _time on the x-axis
   //   future enhancements will depend on the visualization library
-  const xDataColumn = results.table.columnKeys.filter(key => key === '_time')
+  const xDataColumn = (results?.table?.columnKeys || []).filter(
+    key => key === '_time'
+  )
 
   if (
     Array.isArray(properties.fillColumns) &&
@@ -88,7 +90,9 @@ const MosaicOptions: FC<Props> = props => {
     let updatedYLabelColumns = currentYLabelColumns || []
 
     if (columnExists) {
-      updatedYLabelColumns = currentYLabelColumns.filter(fc => fc !== option)
+      updatedYLabelColumns = currentYLabelColumns.filter(
+        currentYLabelColumn => currentYLabelColumn !== option
+      )
     } else {
       updatedYLabelColumns = validYSeriesColumns.includes(option)
         ? [...updatedYLabelColumns, option]
@@ -104,7 +108,9 @@ const MosaicOptions: FC<Props> = props => {
     let updatedYSeriesColumns = ySeriesColumns || []
 
     if (columnExists) {
-      updatedYSeriesColumns = ySeriesColumns.filter(fc => fc !== option)
+      updatedYSeriesColumns = ySeriesColumns.filter(
+        ySeriesColumn => ySeriesColumn !== option
+      )
     } else {
       updatedYSeriesColumns = [...updatedYSeriesColumns, option]
     }
@@ -161,7 +167,7 @@ const MosaicOptions: FC<Props> = props => {
               }}
               testID="dropdown-x"
               buttonStatus={
-                xDataColumn.length == 0
+                xDataColumn.length === 0
                   ? ComponentStatus.Disabled
                   : ComponentStatus.Default
               }

--- a/src/visualization/types/Mosaic/properties.ts
+++ b/src/visualization/types/Mosaic/properties.ts
@@ -46,6 +46,8 @@ export default {
   xColumn: null,
   xDomain: null,
   ySeriesColumns: [],
+  yLabelColumns: [],
+  yLabelColumnSeparator: '',
   yDomain: null,
   xAxisLabel: '',
   yAxisLabel: '',

--- a/src/visualization/types/Mosaic/properties.ts
+++ b/src/visualization/types/Mosaic/properties.ts
@@ -27,7 +27,7 @@ export default {
             aggregateFunctionType: 'filter',
           },
         ],
-        functions: [{name: 'mean'}],
+        functions: [{name: 'last'}],
         aggregateWindow: {
           period: AGG_WINDOW_AUTO,
           fillValues: DEFAULT_FILLVALUES,
@@ -45,7 +45,7 @@ export default {
   fillColumns: null,
   xColumn: null,
   xDomain: null,
-  ySeriesColumns: null,
+  ySeriesColumns: [],
   yDomain: null,
   xAxisLabel: '',
   yAxisLabel: '',

--- a/src/visualization/types/Mosaic/view.tsx
+++ b/src/visualization/types/Mosaic/view.tsx
@@ -65,9 +65,9 @@ const MosaicPlot: FunctionComponent<Props> = ({
   const isValidView =
     xColumn &&
     columnKeys.includes(xColumn) &&
-    ySeriesColumns.every(col => columnKeys.includes(col)) &&
+    ySeriesColumns.every(ySeriesColumn => columnKeys.includes(ySeriesColumn)) &&
     fillColumns.length !== 0 &&
-    fillColumns.every(col => columnKeys.includes(col))
+    fillColumns.every(fillColumn => columnKeys.includes(fillColumn))
 
   if (!isValidView) {
     return <EmptyGraphMessage message={INVALID_DATA_COPY} />

--- a/src/visualization/types/Mosaic/view.tsx
+++ b/src/visualization/types/Mosaic/view.tsx
@@ -110,6 +110,8 @@ const MosaicPlot: FunctionComponent<Props> = ({
             type: 'mosaic',
             x: xColumn,
             y: ySeriesColumns,
+            yLabelColumns: properties.yLabelColumns,
+            yLabelColumnSeparator: properties.yLabelColumnSeparator,
             colors: colorHexes,
             fill: fillColumns,
           },


### PR DESCRIPTION
Closes #510 

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

Mosaic updated with options to select the data columns, labels, and separator for the y-axis.
<img width="1680" alt="Screen Shot 2021-02-28 at 9 08 17 PM" src="https://user-images.githubusercontent.com/10736577/109454515-3d7f9d80-7a09-11eb-9543-11a845c30698.png">


