### PR TITLE
fix: fixes missing configuration for Export Variable Overlay

### DIFF
--- a/src/overlays/components/index.tsx
+++ b/src/overlays/components/index.tsx
@@ -151,3 +151,11 @@ export const UpdateVariableOverlay = RouteOverlay(
     history.push(`/orgs/${params.orgID}/settings/variables`)
   }
 )
+
+export const ExportVariableOverlay = RouteOverlay(
+  OverlayHandler,
+  'export-variable',
+  (history, params) => {
+    history.push(`/orgs/${params.orgID}/settings/variables`)
+  }
+)

--- a/src/variables/containers/VariablesIndex.tsx
+++ b/src/variables/containers/VariablesIndex.tsx
@@ -10,13 +10,13 @@ import SettingsHeader from 'src/settings/components/SettingsHeader'
 import {Page} from '@influxdata/clockface'
 import VariablesTab from 'src/variables/components/VariablesTab'
 import GetResources from 'src/resources/components/GetResources'
-import ExportVariableOverlay from 'src/variables/components/VariableExportOverlay'
 
 import {
   CreateVariableOverlay,
   VariableImportOverlay,
   RenameVariableOverlay,
   UpdateVariableOverlay,
+  ExportVariableOverlay,
 } from 'src/overlays/components'
 
 // Utils


### PR DESCRIPTION
The Export Variable overlay wasn't working because it was missing the right configuration. This PR attempts to fix it. 

What it was doing: 

<img width="868" alt="Screen Shot 2021-03-01 at 1 02 24 PM" src="https://user-images.githubusercontent.com/18511823/109551926-68600500-7a8e-11eb-95ae-e669e8df1b82.png">

after clicking export variable, it just shows `null`


After the fix:

<img width="870" alt="Screen Shot 2021-03-01 at 1 04 03 PM" src="https://user-images.githubusercontent.com/18511823/109552065-9a716700-7a8e-11eb-969a-e3683843d61c.png">

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
