### PR TITLE
fix: remove table threshold crash

### DIFF
--- a/src/visualization/types/Table/options.tsx
+++ b/src/visualization/types/Table/options.tsx
@@ -38,7 +38,7 @@ import {
   MAX_DECIMAL_PLACES,
 } from 'src/visualization/constants'
 import {convertUserInputToNumOrNaN} from 'src/shared/utils/convertUserInput'
-import ThresholdsSettings from 'src/shared/components/ThresholdsSettings'
+import ThresholdsSettings from 'src/visualization/components/internal/ThresholdsSettings'
 import {move} from 'src/shared/utils/move'
 
 import './options.scss'


### PR DESCRIPTION
got some copy pasta in the keys. crazy that this worked at all.