### PR TITLE
fix: single stats with thresholds won't crash with negative values

### DIFF
--- a/src/shared/constants/colorOperations.ts
+++ b/src/shared/constants/colorOperations.ts
@@ -22,6 +22,13 @@ const getLegibleTextColor = bgColorHex => {
 
 const findNearestCrossedThreshold = (colors, lastValue) => {
   const sortedColors = _.sortBy(colors, color => Number(color.value))
+
+  // If the value is less than zero, clamp to the lowest value
+  // See https://github.com/influxdata/influxdb/issues/20750
+  if (lastValue < 0) {
+    return sortedColors[0]
+  }
+
   const nearestCrossedThreshold = sortedColors
     .filter(color => lastValue >= color.value)
     .pop()


### PR DESCRIPTION
Connects https://github.com/influxdata/influxdb/issues/20750

See: https://github.com/influxdata/influxdb/pull/20819

If the value of a single stat with a threshold is negative, it clamps the color value to the nearest positive value, which will be the lowest value for thresholds.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
