### PR TITLE
fix(csvexport): rename downloaded file to influxdb

### DIFF
--- a/src/shared/components/CSVExportButton.tsx
+++ b/src/shared/components/CSVExportButton.tsx
@@ -54,7 +54,7 @@ class CSVExportButton extends PureComponent<StateProps, {}> {
     const {files} = this.props
     const csv = files.join('\n\n')
     const now = moment().format('YYYY-MM-DD-HH-mm')
-    const filename = `${now} Chronograf Data`
+    const filename = `${now} InfluxDB Data`
 
     downloadTextFile(csv, filename, '.csv', 'text/csv')
   }


### PR DESCRIPTION
What is chronograf? This renames the downloaded csv file to be `<date>_influxdb_data.csv`

<!-- Describe your proposed changes here. -->

- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
