### PR TITLE
chore: improve lighthouse accessibility and practices score

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -1,14 +1,23 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="InfluxDB is a time series database designed to handle high write and query loads.
+      Telegraf. Open source server agent to collect metrics from stacks, sensors and systems.
+      InfluxDB Enterprise. Turns any InfluxData instance into a production-ready cluster that can run anywhere."
+    />
     <title>InfluxDB 2.0</title>
     <base href="/" />
-    <%= htmlWebpackPlugin.options.header  %>
+    <%= htmlWebpackPlugin.options.header %>
   </head>
   <body>
-    <div id="react-root" data-basepath="<%= htmlWebpackPlugin.options.base %>"></div>
-    <%= htmlWebpackPlugin.options.body  %>
+    <div
+      id="react-root"
+      data-basepath="<%= htmlWebpackPlugin.options.base %>"
+    ></div>
+    <%= htmlWebpackPlugin.options.body %>
   </body>
 </html>

--- a/assets/index.html
+++ b/assets/index.html
@@ -5,9 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       name="description"
-      content="InfluxDB is a time series database designed to handle high write and query loads.
-      Telegraf. Open source server agent to collect metrics from stacks, sensors and systems.
-      InfluxDB Enterprise. Turns any InfluxData instance into a production-ready cluster that can run anywhere."
+      content="InfluxDB Cloud provides the fastest way to access the most powerful time series database as a service. InfluxDB Cloud is much more than just a database."
     />
     <title>InfluxDB 2.0</title>
     <base href="/" />

--- a/src/me/components/DashboardsList.tsx
+++ b/src/me/components/DashboardsList.tsx
@@ -89,6 +89,7 @@ const DashboardList: FC<Props> = ({dashboards, org}) => {
         icon={IconFont.Search}
         placeholder="Filter dashboards..."
         onChange={handleInputChange}
+        id="filter-dashboards"
       />
       {dashboardsList}
     </>

--- a/src/me/components/Docs.tsx
+++ b/src/me/components/Docs.tsx
@@ -2,7 +2,7 @@
 import React, {PureComponent} from 'react'
 
 // Components
-import {Panel} from '@influxdata/clockface'
+import {Panel, Heading, HeadingElement, FontWeight} from '@influxdata/clockface'
 
 const supportLinks = [
   {
@@ -28,13 +28,19 @@ export default class SupportLinks extends PureComponent {
     return (
       <Panel>
         <Panel.Header>
-          <h4>Some Handy Guides and Tutorials</h4>
+          <Heading
+            element={HeadingElement.H2}
+            weight={FontWeight.Light}
+            className="cf-heading__h4"
+          >
+            Some Handy Guides and Tutorials
+          </Heading>
         </Panel.Header>
         <Panel.Body>
           <ul className="tutorials-list">
             {supportLinks.map(({link, title}) => (
               <li key={title}>
-                <a href={link} target="_blank">
+                <a href={link} target="_blank" rel="noopener">
                   {title}
                 </a>
               </li>

--- a/src/me/components/Resources.tsx
+++ b/src/me/components/Resources.tsx
@@ -12,6 +12,9 @@ import {
   FlexDirection,
   ComponentSize,
   AlignItems,
+  Heading,
+  HeadingElement,
+  FontWeight,
 } from '@influxdata/clockface'
 import VersionInfo from 'src/shared/components/VersionInfo'
 
@@ -33,13 +36,25 @@ class ResourceLists extends PureComponent<Props> {
       >
         <Panel>
           <Panel.Header>
-            <h4>Account</h4>
+            <Heading
+              element={HeadingElement.H2}
+              weight={FontWeight.Light}
+              className="cf-heading__h4"
+            >
+              Account
+            </Heading>
             <LogoutButton />
           </Panel.Header>
         </Panel>
         <Panel testID="recent-dashboards--panel">
           <Panel.Header>
-            <h4>Recent Dashboards</h4>
+            <Heading
+              element={HeadingElement.H2}
+              weight={FontWeight.Light}
+              className="cf-heading__h4"
+            >
+              <label htmlFor="filter-dashboards">Recent Dashboards</label>
+            </Heading>
           </Panel.Header>
           <Panel.Body>
             <GetResources resources={[ResourceType.Dashboards]}>
@@ -49,7 +64,13 @@ class ResourceLists extends PureComponent<Props> {
         </Panel>
         <Panel>
           <Panel.Header>
-            <h4>Useful Links</h4>
+            <Heading
+              element={HeadingElement.H2}
+              weight={FontWeight.Light}
+              className="cf-heading__h4"
+            >
+              Useful Links
+            </Heading>
           </Panel.Header>
           <Panel.Body>
             <Support />

--- a/src/me/components/Support.tsx
+++ b/src/me/components/Support.tsx
@@ -22,7 +22,7 @@ export default class SupportLinks extends PureComponent {
       <ul className="useful-links">
         {supportLinks.map(({link, title}) => (
           <li key={title}>
-            <a href={link} target="_blank">
+            <a href={link} target="_blank" rel="noopener">
               {title}
             </a>
           </li>

--- a/src/shared/components/VersionInfo.scss
+++ b/src/shared/components/VersionInfo.scss
@@ -4,6 +4,6 @@
 */
 
 .version-info {
-  color: $g9-mountain;
+  color: $g10-wolf;
   text-align: center;
 }


### PR DESCRIPTION
Closes #520

Improves lighthouse accessibility, best practices, and SEO scores by:
1) changing font color of a couple headers to improve contrast
1) adding `lang="en"` to our index.html
1) adding a meta description to our html (used the meta description for influxdata.com)
1) adding `rel="noopener"` to external links
1) changed h4s to h2s with smaller font 

Also see this clockface PR: https://github.com/influxdata/clockface/pull/581

![image](https://user-images.githubusercontent.com/6411855/109731033-5e620300-7b6f-11eb-8723-886f84ea9c4d.png)


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
