### PR TITLE
fix: inject escaped vars

### DIFF
--- a/src/timeMachine/components/TimeMachineFluxEditor.tsx
+++ b/src/timeMachine/components/TimeMachineFluxEditor.tsx
@@ -50,7 +50,7 @@ const TimeMachineFluxEditor: FC<Props> = ({
           p.lineNumber,
           p.column
         ),
-        text: `v.${variableName}`,
+        text: `v["${variableName}"]`,
       },
     ])
     onSetActiveQueryText(editorInstance.getValue())


### PR DESCRIPTION
this one addresses the suggested ui fix as part of https://github.com/influxdata/idpe/issues/9771