### PR TITLE
fix: respect 24 hour clock formats and allow more choices

### DIFF
--- a/src/visualization/utils/getFormatter.ts
+++ b/src/visualization/utils/getFormatter.ts
@@ -60,10 +60,14 @@ export const getFormatter = (
   }
 
   if (columnType === 'time') {
-    return timeFormatter({
+    const formatOptions = {
       timeZone: timeZone === 'Local' ? undefined : timeZone,
       format: resolveTimeFormat(timeFormat),
-    })
+    }
+    if (timeFormat.includes('HH')) {
+      formatOptions['hour12'] = false
+    }
+    return timeFormatter(formatOptions)
   }
 
   return null

--- a/src/visualization/utils/getFormatter.ts
+++ b/src/visualization/utils/getFormatter.ts
@@ -64,7 +64,7 @@ export const getFormatter = (
       timeZone: timeZone === 'Local' ? undefined : timeZone,
       format: resolveTimeFormat(timeFormat),
     }
-    if (timeFormat.includes('HH')) {
+    if (timeFormat?.includes('HH')) {
       formatOptions['hour12'] = false
     }
     return timeFormatter(formatOptions)

--- a/src/visualization/utils/timeFormat.ts
+++ b/src/visualization/utils/timeFormat.ts
@@ -1,17 +1,26 @@
 import {DEFAULT_TIME_FORMAT} from 'src/shared/constants'
 
 export const FORMAT_OPTIONS: Array<{text: string}> = [
-  {text: DEFAULT_TIME_FORMAT},
+  {text: DEFAULT_TIME_FORMAT}, // 'YYYY-MM-DD HH:mm:ss ZZ'
+  {text: 'YYYY-MM-DD hh:mm:ss a ZZ'},
   {text: 'DD/MM/YYYY HH:mm:ss.sss'},
+  {text: 'DD/MM/YYYY hh:mm:ss.sss a'},
   {text: 'MM/DD/YYYY HH:mm:ss.sss'},
+  {text: 'MM/DD/YYYY hh:mm:ss.sss a'},
   {text: 'YYYY/MM/DD HH:mm:ss'},
-  {text: 'hh:mm a'},
+  {text: 'YYYY/MM/DD hh:mm:ss a'},
   {text: 'HH:mm'},
+  {text: 'hh:mm a'},
   {text: 'HH:mm:ss'},
+  {text: 'hh:mm:ss a'},
   {text: 'HH:mm:ss ZZ'},
+  {text: 'hh:mm:ss a ZZ'},
   {text: 'HH:mm:ss.sss'},
+  {text: 'hh:mm:ss.sss a'},
   {text: 'MMMM D, YYYY HH:mm:ss'},
+  {text: 'MMMM D, YYYY hh:mm:ss a'},
   {text: 'dddd, MMMM D, YYYY HH:mm:ss'},
+  {text: 'dddd, MMMM D, YYYY hh:mm:ss a'},
 ]
 
 export const resolveTimeFormat = (timeFormat: string) => {


### PR DESCRIPTION
Closes #768 

This fix is the first step in updating time formats. The next step is to implement https://github.com/influxdata/ui/issues/770

- 'HH' triggers 24 hour clock format
- Add more choices to allow users to keep 12 hour formats
- Add meridiem to 12 hour formats

![Kapture 2021-03-03 at 16 11 29](https://user-images.githubusercontent.com/10736577/109889998-4fe11d80-7c3b-11eb-99e0-a90aaf1e028a.gif)




- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
