### PR TITLE
feat: annotation write mode toggle

### DIFF
--- a/src/annotations/actions/creators.ts
+++ b/src/annotations/actions/creators.ts
@@ -4,11 +4,13 @@ export const ENABLE_ANNOTATION_STREAM = 'ENABLE_ANNOTATION_STREAM'
 export const DISABLE_ANNOTATION_STREAM = 'DISABLE_ANNOTATION_STREAM'
 
 export const SET_ANNOTATIONS = 'SET_ANNOTATIONS'
+export const TOGGLE_SINGLE_CLICK_ANNOTATIONS = 'TOGGLE_SINGLE_CLICK_ANNOTATIONS'
 
 export type Action =
   | ReturnType<typeof enableAnnotationStream>
   | ReturnType<typeof disableAnnotationStream>
   | ReturnType<typeof setAnnotations>
+  | ReturnType<typeof toggleSingleClickAnnotations>
 
 export const enableAnnotationStream = (streamID: string) =>
   ({
@@ -26,4 +28,9 @@ export const setAnnotations = (annotations: AnnotationStream[]) =>
   ({
     type: SET_ANNOTATIONS,
     annotations,
+  } as const)
+
+export const toggleSingleClickAnnotations = () =>
+  ({
+    type: TOGGLE_SINGLE_CLICK_ANNOTATIONS,
   } as const)

--- a/src/annotations/components/controlBar/AnnotationsControlBar.tsx
+++ b/src/annotations/components/controlBar/AnnotationsControlBar.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {useState, FC} from 'react'
-import {useSelector} from 'react-redux'
+import {useDispatch, useSelector} from 'react-redux'
 import {useHistory, useParams} from 'react-router-dom'
 
 // Components
@@ -18,11 +18,15 @@ import {
 } from '@influxdata/clockface'
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
 import Toolbar from 'src/shared/components/toolbar/Toolbar'
+import {toggleSingleClickAnnotations} from 'src/annotations/actions/creators'
 import {AnnotationPills} from 'src/annotations/components/controlBar/AnnotationPills'
 import {AnnotationsSearchBar} from 'src/annotations/components/controlBar/AnnotationsSearchBar'
 
 // Selectors
-import {getAnnotationControlsVisibility} from 'src/annotations/selectors'
+import {
+  getAnnotationControlsVisibility,
+  isSingleClickAnnotationsEnabled,
+} from 'src/annotations/selectors'
 
 // Constants
 import {ORGS, SETTINGS, ANNOTATIONS} from 'src/shared/constants/routes'
@@ -32,14 +36,19 @@ export const AnnotationsControlBar: FC = () => {
   const isVisible = useSelector(getAnnotationControlsVisibility)
   const {orgID} = useParams<{orgID: string; dashboardID: string}>()
 
-  const [annotationWriteMode, setAnnotationWriteMode] = useState(false)
+  const [annotationWriteMode, setAnnotationWriteMode] = useState(
+    useSelector(isSingleClickAnnotationsEnabled)
+  )
 
   if (!isVisible) {
     return null
   }
+  const dispatch = useDispatch()
 
   const onModeChange = () => {
     //todo:  call prop method to change the state
+    dispatch(toggleSingleClickAnnotations())
+
     setAnnotationWriteMode(!annotationWriteMode)
   }
 

--- a/src/annotations/components/controlBar/AnnotationsControlBar.tsx
+++ b/src/annotations/components/controlBar/AnnotationsControlBar.tsx
@@ -33,22 +33,15 @@ import {ORGS, SETTINGS, ANNOTATIONS} from 'src/shared/constants/routes'
 
 export const AnnotationsControlBar: FC = () => {
   const history = useHistory()
-  const isVisible = useSelector(getAnnotationControlsVisibility)
   const {orgID} = useParams<{orgID: string; dashboardID: string}>()
 
-  const [annotationWriteMode, setAnnotationWriteMode] = useState(
-    useSelector(isSingleClickAnnotationsEnabled)
-  )
+  const inWriteMode = useSelector(isSingleClickAnnotationsEnabled)
+  const [annotationWriteMode, setAnnotationWriteMode] = useState(inWriteMode)
 
-  if (!isVisible) {
-    return null
-  }
   const dispatch = useDispatch()
 
   const onModeChange = () => {
-    //todo:  call prop method to change the state
     dispatch(toggleSingleClickAnnotations())
-
     setAnnotationWriteMode(!annotationWriteMode)
   }
 
@@ -79,7 +72,6 @@ export const AnnotationsControlBar: FC = () => {
             color={ComponentColor.Primary}
             size={ComponentSize.ExtraSmall}
           >
-            {' '}
             <InputLabel>Enable 1-Click Annotations</InputLabel>
           </Toggle>
           <SquareButton

--- a/src/annotations/components/controlBar/AnnotationsControlBar.tsx
+++ b/src/annotations/components/controlBar/AnnotationsControlBar.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {useState, FC} from 'react'
+import React, {FC} from 'react'
 import {useDispatch, useSelector} from 'react-redux'
 import {useHistory, useParams} from 'react-router-dom'
 
@@ -23,10 +23,7 @@ import {AnnotationPills} from 'src/annotations/components/controlBar/AnnotationP
 import {AnnotationsSearchBar} from 'src/annotations/components/controlBar/AnnotationsSearchBar'
 
 // Selectors
-import {
-  getAnnotationControlsVisibility,
-  isSingleClickAnnotationsEnabled,
-} from 'src/annotations/selectors'
+import {isSingleClickAnnotationsEnabled} from 'src/annotations/selectors'
 
 // Constants
 import {ORGS, SETTINGS, ANNOTATIONS} from 'src/shared/constants/routes'
@@ -36,13 +33,11 @@ export const AnnotationsControlBar: FC = () => {
   const {orgID} = useParams<{orgID: string; dashboardID: string}>()
 
   const inWriteMode = useSelector(isSingleClickAnnotationsEnabled)
-  const [annotationWriteMode, setAnnotationWriteMode] = useState(inWriteMode)
 
   const dispatch = useDispatch()
 
-  const onModeChange = () => {
+  const changeWriteMode = () => {
     dispatch(toggleSingleClickAnnotations())
-    setAnnotationWriteMode(!annotationWriteMode)
   }
 
   const handleSettingsClick = (): void => {
@@ -67,8 +62,8 @@ export const AnnotationsControlBar: FC = () => {
             style={{marginRight: 20}}
             id="enableAnnotationMode"
             type={InputToggleType.Checkbox}
-            checked={annotationWriteMode}
-            onChange={onModeChange}
+            checked={inWriteMode}
+            onChange={changeWriteMode}
             color={ComponentColor.Primary}
             size={ComponentSize.ExtraSmall}
           >

--- a/src/annotations/components/controlBar/AnnotationsControlBar.tsx
+++ b/src/annotations/components/controlBar/AnnotationsControlBar.tsx
@@ -1,16 +1,20 @@
 // Libraries
-import React, {FC} from 'react'
+import React, {useState, FC} from 'react'
 import {useSelector} from 'react-redux'
 import {useHistory, useParams} from 'react-router-dom'
 
 // Components
 import {
+  ComponentColor,
   ComponentSize,
   FlexBox,
   FlexBoxChild,
   IconFont,
+  InputLabel,
+  InputToggleType,
   JustifyContent,
   SquareButton,
+  Toggle,
 } from '@influxdata/clockface'
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
 import Toolbar from 'src/shared/components/toolbar/Toolbar'
@@ -28,8 +32,15 @@ export const AnnotationsControlBar: FC = () => {
   const isVisible = useSelector(getAnnotationControlsVisibility)
   const {orgID} = useParams<{orgID: string; dashboardID: string}>()
 
+  const [annotationWriteMode, setAnnotationWriteMode] = useState(false)
+
   if (!isVisible) {
     return null
+  }
+
+  const onModeChange = () => {
+    //todo:  call prop method to change the state
+    setAnnotationWriteMode(!annotationWriteMode)
   }
 
   const handleSettingsClick = (): void => {
@@ -50,6 +61,18 @@ export const AnnotationsControlBar: FC = () => {
           <AnnotationPills />
         </FlexBoxChild>
         <FlexBox margin={ComponentSize.Small}>
+          <Toggle
+            style={{marginRight: 20}}
+            id="enableAnnotationMode"
+            type={InputToggleType.Checkbox}
+            checked={annotationWriteMode}
+            onChange={onModeChange}
+            color={ComponentColor.Primary}
+            size={ComponentSize.ExtraSmall}
+          >
+            {' '}
+            <InputLabel>Enable 1-Click Annotations</InputLabel>
+          </Toggle>
           <SquareButton
             testID="annotations-control-bar--settings"
             icon={IconFont.CogThick}

--- a/src/annotations/reducers/index.test.ts
+++ b/src/annotations/reducers/index.test.ts
@@ -50,6 +50,7 @@ describe('the annotations reducer', () => {
           },
         ],
       },
+      enableSingleClickAnnotations: true,
       visibleStreamsByID: [],
     })
   })

--- a/src/annotations/reducers/index.ts
+++ b/src/annotations/reducers/index.ts
@@ -4,7 +4,6 @@ import {
   DISABLE_ANNOTATION_STREAM,
   SET_ANNOTATIONS,
   TOGGLE_SINGLE_CLICK_ANNOTATIONS,
-  enableAnnotationStream,
 } from 'src/annotations/actions/creators'
 
 import {Annotation, AnnotationsList} from 'src/types'

--- a/src/annotations/reducers/index.ts
+++ b/src/annotations/reducers/index.ts
@@ -3,6 +3,8 @@ import {
   ENABLE_ANNOTATION_STREAM,
   DISABLE_ANNOTATION_STREAM,
   SET_ANNOTATIONS,
+  TOGGLE_SINGLE_CLICK_ANNOTATIONS,
+  enableAnnotationStream,
 } from 'src/annotations/actions/creators'
 
 import {Annotation, AnnotationsList} from 'src/types'
@@ -10,6 +12,7 @@ import {Annotation, AnnotationsList} from 'src/types'
 export interface AnnotationsState {
   annotations: AnnotationsList
   visibleStreamsByID: string[]
+  enableSingleClickAnnotations: boolean
 }
 
 export const initialState = (): AnnotationsState => ({
@@ -17,6 +20,7 @@ export const initialState = (): AnnotationsState => ({
     default: [] as Annotation[],
   },
   visibleStreamsByID: [],
+  enableSingleClickAnnotations: true,
 })
 
 // TODO: use immer
@@ -47,6 +51,15 @@ export const annotationsReducer = (
       return {
         ...state,
         annotations,
+      }
+    }
+
+    case TOGGLE_SINGLE_CLICK_ANNOTATIONS: {
+      const newVal = !state.enableSingleClickAnnotations
+
+      return {
+        ...state,
+        enableSingleClickAnnotations: newVal,
       }
     }
     default:

--- a/src/annotations/selectors/index.ts
+++ b/src/annotations/selectors/index.ts
@@ -33,3 +33,7 @@ export const getHiddenAnnotationStreams = (
 
   return sortBy(filtered, stream => stream.name)
 }
+
+export const isSingleClickAnnotationsEnabled = (state: AppState): boolean => {
+  return state.annotations.enableSingleClickAnnotations
+}

--- a/src/dashboards/components/DashboardPage.tsx
+++ b/src/dashboards/components/DashboardPage.tsx
@@ -150,7 +150,7 @@ const mstp = (state: AppState) => {
     state.currentDashboard.id
   )
 
-  const showAnnotationBar = state.userSettings.showAnnotationsControls || false
+  const showAnnotationBar = state.userSettings.showAnnotationsControls
 
   return {
     startVisitMs: state.perf.dashboard.byID[dashboard.id]?.startVisitMs,

--- a/src/dashboards/components/DashboardPage.tsx
+++ b/src/dashboards/components/DashboardPage.tsx
@@ -72,6 +72,8 @@ class DashboardPage extends Component<Props> {
   public render() {
     const {autoRefresh, manualRefresh, onManualRefresh} = this.props
 
+    console.log('inside my dash....', this.props)
+
     return (
       <>
         <ErrorBoundary>

--- a/src/dashboards/components/DashboardPage.tsx
+++ b/src/dashboards/components/DashboardPage.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {Component} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
+import {connect, ConnectedProps, useSelector} from 'react-redux'
 import {Switch, Route} from 'react-router-dom'
 
 // Components
@@ -70,9 +70,12 @@ class DashboardPage extends Component<Props> {
   }
 
   public render() {
-    const {autoRefresh, manualRefresh, onManualRefresh} = this.props
-
-    console.log('inside my dash....', this.props)
+    const {
+      autoRefresh,
+      manualRefresh,
+      onManualRefresh,
+      showAnnotationBar,
+    } = this.props
 
     return (
       <>
@@ -87,7 +90,7 @@ class DashboardPage extends Component<Props> {
                 <RateLimitAlert alertOnly={true} />
                 <VariablesControlBar />
                 <FeatureFlag name="annotations">
-                  <AnnotationsControlBar />
+                  {showAnnotationBar && <AnnotationsControlBar />}
                 </FeatureFlag>
                 <ErrorBoundary>
                   <DashboardComponent manualRefresh={manualRefresh} />
@@ -146,10 +149,12 @@ const mstp = (state: AppState) => {
     ResourceType.Dashboards,
     state.currentDashboard.id
   )
+  const showAnnotationBar = state.userSettings.showAnnotationsControls || false
 
   return {
     startVisitMs: state.perf.dashboard.byID[dashboard.id]?.startVisitMs,
     dashboard,
+    showAnnotationBar,
   }
 }
 

--- a/src/dashboards/components/DashboardPage.tsx
+++ b/src/dashboards/components/DashboardPage.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {Component} from 'react'
-import {connect, ConnectedProps, useSelector} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {Switch, Route} from 'react-router-dom'
 
 // Components
@@ -149,6 +149,7 @@ const mstp = (state: AppState) => {
     ResourceType.Dashboards,
     state.currentDashboard.id
   )
+
   const showAnnotationBar = state.userSettings.showAnnotationsControls || false
 
   return {

--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -65,20 +65,19 @@ const XYPlot: FC<Props> = ({properties, result, timeRange, annotations}) => {
   const tooltipOrientationThreshold = useLegendOrientationThreshold(
     properties.legendOrientationThreshold
   )
-  //it doesn't know that it is even *in* a dashboard, much less which dashboard it is in.
-  //so having annotations on per dashboard is not supported yet
-  console.log(
-    'in xy plot/graph view....props??',
-    properties,
-    result,
-    timeRange,
-    annotations
-  )
-
   const dispatch = useDispatch()
+
+  // it doesn't know that it is even *in* a dashboard, much less which dashboard it is in.
+  // so having annotations on per dashboard is not supported yet
+  // these next two values are set in the dashboard, and used whether or not this view is in a dashboard
+  // or in configuration/single cell popout mode
+  // would need to add the annotation control bar to the VEOHeader to get access to the controls,
+  // which are currently global values, not per dashboard
+
   const annotationsModeIsActive = useSelector(
     (state: AppState) => state.userSettings.showAnnotationsControls
   )
+  const inAnnotationWriteMode = useSelector(isSingleClickAnnotationsEnabled)
 
   const storedXDomain = useMemo(() => parseXBounds(properties.axes.x.bounds), [
     properties.axes.x.bounds,
@@ -237,14 +236,10 @@ const XYPlot: FC<Props> = ({properties, result, timeRange, annotations}) => {
     ],
   }
 
-  // TODO: address this tech debt
-  // see https://github.com/influxdata/ui/issues/725
   if (isFlagEnabled('annotations') && annotationsModeIsActive) {
-    if (useSelector(isSingleClickAnnotationsEnabled)) {
-      const singleClickHandler = makeSingleClickHandler()
-
+    if (inAnnotationWriteMode) {
       config.interactionHandlers = {
-        singleClick: singleClickHandler,
+        singleClick: makeSingleClickHandler(),
       }
     }
     // everything is under the 'default' category for now:


### PR DESCRIPTION
Closes #730
Closes #725 

adds a toggle/checkbox button to the annotations bar, to enable 1-click annotations (double click still works too; since a double click has a single click in it)

annotations can only be written when the toggle is enabled.
