### PR TITLE
chore: fix case of prettierignore to match source control

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,1 @@
-.GITHUB
+.github/*


### PR DESCRIPTION
I've run into crazy git hell issues due to inconsistent case of files. This is to keep the case consistent with what we have in source control, which is `.github`. https://github.com/influxdata/ui/tree/master/.github

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
