### PR TITLE
fix: show an error message when queries with broken variables fail to hydrate

### DIFF
--- a/src/types/variables.ts
+++ b/src/types/variables.ts
@@ -45,6 +45,7 @@ export interface Variable
   status: RemoteDataState // Loading status of an individual variable
   labels: string[]
   arguments: VariableProperties
+  errorMessage?: string // For variables that fail to load
 }
 
 export interface PostVariable extends GenVariable {

--- a/src/variables/actions/creators.ts
+++ b/src/variables/actions/creators.ts
@@ -14,6 +14,7 @@ export const SET_VARIABLE = 'SET_VARIABLE'
 export const REMOVE_VARIABLE = 'REMOVE_VARIABLE'
 export const MOVE_VARIABLE = 'MOVE_VARIABLE'
 export const SELECT_VARIABLE_VALUE = 'SELECT_VARIABLE_VALUE'
+export const SET_VARIABLE_HYDRATION_ERROR = 'SET_VARIABLE_HYDRATION_ERROR'
 
 export type Action =
   | ReturnType<typeof setVariables>
@@ -21,6 +22,7 @@ export type Action =
   | ReturnType<typeof removeVariable>
   | ReturnType<typeof moveVariable>
   | ReturnType<typeof selectValue>
+  | ReturnType<typeof setVariableHydrationError>
 
 // R is the type of the value of the "result" key in normalizr's normalization
 type VariablesSchema<R extends string | string[]> = NormalizedSchema<
@@ -73,6 +75,13 @@ export const selectValue = (
     contextID,
     variableID,
     selectedValue,
+  } as const)
+
+export const setVariableHydrationError = (id: string, errorMessage: string) =>
+  ({
+    type: SET_VARIABLE_HYDRATION_ERROR,
+    id,
+    errorMessage,
   } as const)
 
 // Variable Editor Action Creators

--- a/src/variables/reducers/index.ts
+++ b/src/variables/reducers/index.ts
@@ -11,11 +11,12 @@ import {
 } from 'src/types'
 import {
   Action,
-  SET_VARIABLES,
-  SET_VARIABLE,
-  REMOVE_VARIABLE,
   MOVE_VARIABLE,
+  REMOVE_VARIABLE,
   SELECT_VARIABLE_VALUE,
+  SET_VARIABLE,
+  SET_VARIABLES,
+  SET_VARIABLE_HYDRATION_ERROR,
 } from 'src/variables/actions/creators'
 
 // Utils
@@ -102,6 +103,14 @@ export const variablesReducer = (
           order: newVariableOrder,
         }
 
+        return
+      }
+
+      case SET_VARIABLE_HYDRATION_ERROR: {
+        const {id, errorMessage} = action
+
+        draftState.byID[id].status = RemoteDataState.Error
+        draftState.byID[id].errorMessage = errorMessage
         return
       }
     }

--- a/src/variables/utils/hydrateVars.ts
+++ b/src/variables/utils/hydrateVars.ts
@@ -572,8 +572,8 @@ export const hydrateVars = (
       on.fire('status', node.variable, node.status)
 
       return Promise.all(node.parents.filter(readyToResolve).map(resolve))
-    } catch (e) {
-      if (e.name === 'CancellationError') {
+    } catch (error) {
+      if (error.name === 'CancellationError') {
         return
       }
 
@@ -581,6 +581,8 @@ export const hydrateVars = (
       node.variable.arguments.values.results = []
 
       invalidateAncestors(node)
+
+      on.fire('status', node.variable, node.status, error)
     }
   }
 


### PR DESCRIPTION
Closes idpe #9772

Dashboard cells with queries with broken variables in them will spin forever. This shows the error message the broken query throws.

![Screen Shot 2021-03-04 at 3 01 08 PM](https://user-images.githubusercontent.com/146112/110042334-7e71fd80-7cfa-11eb-9df7-ced9400b7922.png)


### Reproduction steps:
1. Create a variable with a broken query
   1. settings -> variables -> create
   1. put garbage into the query
1. Go to explore, write a query that uses that a broken variable.
    Assuming you named the variable `broken_variable`:
    ```
      from(bucket: "defbuck")
        |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
        |> filter(fn: (r) => r["_measurement"] == "system")
        |> filter(fn: (r) => r["_measurement"] == v.broken_variable)
        |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)
        |> yield(name: "mean")
    ```
1. Save the query and reload the page. It'll spin forever.
2. Apply this branch. Reload the page. There's an error message.

---

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
