### PR TITLE
fix: update Tables to get the time formatter like every other graph type

### DIFF
--- a/src/visualization/types/Table/Table.tsx
+++ b/src/visualization/types/Table/Table.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {FC, useMemo, useState, useCallback, useContext} from 'react'
-import {timeFormatter} from '@influxdata/giraffe'
 import classnames from 'classnames'
 import {ColumnSizer, SizedColumnProps, AutoSizer} from 'react-virtualized'
 
@@ -9,6 +8,7 @@ import MultiGrid from 'src/visualization/types/Table/MultiGrid'
 import TableCell from 'src/visualization/types/Table/TableCell'
 
 // Utils
+import {getFormatter} from 'src/visualization/utils/getFormatter'
 import {
   transformTableData,
   findHoverTimeIndex,
@@ -67,9 +67,9 @@ const Table: FC<Props> = ({properties, sort, updateSort, table}) => {
   const tableClassName = classnames('time-machine-table', {
     'time-machine-table__light-mode': theme === 'light',
   })
-  const formatter = timeFormatter({
+  const formatter = getFormatter('time', {
     timeZone: timeZone === 'Local' ? undefined : timeZone,
-    format: resolveTimeFormat(properties.timeFormat),
+    timeFormat: resolveTimeFormat(properties.timeFormat),
   })
   const colCount = transformed?.transformedData[0]?.length || 0
   const rowCount =


### PR DESCRIPTION
Follow-up to #768 just for Tables, because Tables are weird and try to do their own thing. We will not stand for this.

<!-- Describe your proposed changes here. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
