### PR TITLE
fix: save the correct column to allow Mosaic cells to render in Dashboards

### DIFF
--- a/src/timeMachine/selectors/index.ts
+++ b/src/timeMachine/selectors/index.ts
@@ -338,7 +338,7 @@ export const getSaveableView = (state: AppState): QueryView & {id?: string} => {
       properties: {
         ...saveableView.properties,
         xColumn: getXColumnSelection(state),
-        ySeriesColumns: [getYColumnSelection(state)],
+        ySeriesColumns: getYSeriesColumns(state),
         fillColumns: getFillColumnsSelection(state),
       },
     }


### PR DESCRIPTION
Closes #789 

Save the correct column. Duh! Otherwise Mosaic won't render in Dashboard cells.

<img width="1680" alt="Screen Shot 2021-03-05 at 3 23 09 PM" src="https://user-images.githubusercontent.com/10736577/110185254-bb0b2b00-7dc6-11eb-9479-c8c0643ba73d.png">


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
