### PR TITLE
feat: graph tips shows annotation tip if feature flag enabled

### DIFF
--- a/src/shared/components/graph_tips/GraphTips.tsx
+++ b/src/shared/components/graph_tips/GraphTips.tsx
@@ -3,6 +3,7 @@ import React, {FC} from 'react'
 
 // Components
 import {ComponentColor, QuestionMarkTooltip} from '@influxdata/clockface'
+import {FeatureFlag} from '../../utils/featureFlag'
 
 const GraphTips: FC = () => (
   <QuestionMarkTooltip
@@ -16,6 +17,10 @@ const GraphTips: FC = () => (
           <code>Click + Drag</code> Zoom in (X or Y)
           <br />
           <code>Double Click</code> Reset Graph Window
+          <br />
+          <FeatureFlag name="annotations">
+            <code>Single Click</code> Annotate the Graph
+          </FeatureFlag>
         </p>
       </>
     }


### PR DESCRIPTION
Closes #760 

explanation of Single Click mechanics added to the Graph Tips overlay, only visible when feature flag is enabled.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
