### PR TITLE
fix: annotation toggle button message fixed

### DIFF
--- a/src/annotations/components/AnnotationsToggleButton.tsx
+++ b/src/annotations/components/AnnotationsToggleButton.tsx
@@ -20,8 +20,8 @@ export const AnnotationsToggleButton: FC = () => {
     : ComponentColor.Default
 
   const titleText = isVisible
-    ? 'Click to reveal annotations controls'
-    : 'Click to hide annotations controls'
+    ? 'Click to hide annotations controls'
+    : 'Click to reveal annotations controls'
 
   const handleClick = (): void => {
     dispatch(toggleShowAnnotationsControls())


### PR DESCRIPTION
Closes #793 

The Annotation toggle button on-hover message was wrong as described in #793. This PR fixes it. 

Screen shots:

<img width="894" alt="Screen Shot 2021-03-08 at 7 13 25 AM" src="https://user-images.githubusercontent.com/18511823/110332650-d69c4e80-7fdd-11eb-9d21-b123453cb39a.png">

<img width="892" alt="Screen Shot 2021-03-08 at 7 13 36 AM" src="https://user-images.githubusercontent.com/18511823/110332655-d8661200-7fdd-11eb-8584-0b755629c1a0.png">

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
