### PR TITLE
feat: adding task ids to the list page

### DIFF
--- a/src/style/chronograf.scss
+++ b/src/style/chronograf.scss
@@ -121,6 +121,7 @@
 @import 'src/dashboards/components/DashboardLightMode.scss';
 @import 'src/buckets/components/DemoDataDropdown.scss';
 @import 'src/buckets/components/BucketCardMeta.scss';
+@import 'src/tasks/components/TaskCardMeta.scss';
 @import 'src/cloud/components/RateLimitOverlay.scss';
 @import 'src/cloud/components/experiments/DatalessEmptyState.scss';
 @import 'src/shared/components/notifications/Notification.scss';

--- a/src/tasks/components/TaskCard.tsx
+++ b/src/tasks/components/TaskCard.tsx
@@ -16,6 +16,7 @@ import {
 } from '@influxdata/clockface'
 import {Context} from 'src/clockface'
 import InlineLabels from 'src/shared/components/inlineLabels/InlineLabels'
+import TaskCardMeta from 'src/tasks/components/TaskCardMeta'
 import LastRunTaskStatus from 'src/shared/components/lastRunTaskStatus/LastRunTaskStatus'
 
 // Actions
@@ -78,6 +79,9 @@ export class TaskCard extends PureComponent<
             {this.activeToggle}
             <>Last completed at {task.latestCompleted}</>
             <>{`Scheduled to run ${this.schedule}`}</>
+            <>
+              <TaskCardMeta task={task} />
+            </>
           </ResourceCard.Meta>
           {this.labels}
         </FlexBox>

--- a/src/tasks/components/TaskCardMeta.scss
+++ b/src/tasks/components/TaskCardMeta.scss
@@ -1,0 +1,20 @@
+.copy-task-id {
+  transition: color 0.25s ease;
+
+  &:hover {
+    cursor: pointer;
+    color: $c-pool;
+  }
+}
+
+.copy-task-id--helper {
+  color: $g13-mist;
+  transition: opacity 0.25s ease;
+  opacity: 0;
+  display: inline-block;
+  margin-left: $cf-marg-b;
+}
+
+.copy-task-id:hover .copy-task-id--helper {
+  opacity: 1;
+}

--- a/src/tasks/components/TaskCardMeta.tsx
+++ b/src/tasks/components/TaskCardMeta.tsx
@@ -1,0 +1,61 @@
+// Libraries
+import React, {FC} from 'react'
+import CopyToClipboard from 'react-copy-to-clipboard'
+import {connect, ConnectedProps} from 'react-redux'
+
+// Constants
+import {
+  copyToClipboardSuccess,
+  copyToClipboardFailed,
+} from 'src/shared/copy/notifications'
+
+// Actions
+import {notify as notifyAction} from 'src/shared/actions/notifications'
+
+// Components
+import {ResourceCard} from '@influxdata/clockface'
+
+// Types
+import {Task} from 'src/types'
+
+interface OwnProps {
+  task: Task
+}
+
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps
+
+const TaskCardMeta: FC<Props> = ({task, notify}) => {
+  const handleCopyAttempt = (
+    copiedText: string,
+    isSuccessful: boolean
+  ): void => {
+    const text = copiedText.slice(0, 30).trimRight()
+    const truncatedText = `${text}...`
+
+    if (isSuccessful) {
+      notify(copyToClipboardSuccess(truncatedText, 'Task ID'))
+    } else {
+      notify(copyToClipboardFailed(truncatedText, 'Task ID'))
+    }
+  }
+
+  return (
+    <ResourceCard.Meta>
+      <CopyToClipboard text={task.id} onCopy={handleCopyAttempt}>
+        <span className="copy-task-id" title="Click to Copy to Clipboard">
+          ID: {task.id}
+          <span className="copy-task-id--helper">Copy to Clipboard</span>
+        </span>
+      </CopyToClipboard>
+    </ResourceCard.Meta>
+  )
+}
+
+const mdtp = {
+  notify: notifyAction,
+}
+
+const connector = connect(null, mdtp)
+
+export default connector(TaskCardMeta)

--- a/src/tasks/components/TaskCardMeta.tsx
+++ b/src/tasks/components/TaskCardMeta.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FC} from 'react'
 import CopyToClipboard from 'react-copy-to-clipboard'
-import {connect, ConnectedProps} from 'react-redux'
+import {useDispatch} from 'react-redux'
 
 // Constants
 import {
@@ -10,7 +10,7 @@ import {
 } from 'src/shared/copy/notifications'
 
 // Actions
-import {notify as notifyAction} from 'src/shared/actions/notifications'
+import {notify} from 'src/shared/actions/notifications'
 
 // Components
 import {ResourceCard} from '@influxdata/clockface'
@@ -22,10 +22,8 @@ interface OwnProps {
   task: Task
 }
 
-type ReduxProps = ConnectedProps<typeof connector>
-type Props = OwnProps & ReduxProps
-
-const TaskCardMeta: FC<Props> = ({task, notify}) => {
+const TaskCardMeta: FC<OwnProps> = ({task}) => {
+  const dispatch = useDispatch()
   const handleCopyAttempt = (
     copiedText: string,
     isSuccessful: boolean
@@ -34,9 +32,9 @@ const TaskCardMeta: FC<Props> = ({task, notify}) => {
     const truncatedText = `${text}...`
 
     if (isSuccessful) {
-      notify(copyToClipboardSuccess(truncatedText, 'Task ID'))
+      dispatch(notify(copyToClipboardSuccess(truncatedText, 'Task ID')))
     } else {
-      notify(copyToClipboardFailed(truncatedText, 'Task ID'))
+      dispatch(notify(copyToClipboardFailed(truncatedText, 'Task ID')))
     }
   }
 
@@ -52,10 +50,4 @@ const TaskCardMeta: FC<Props> = ({task, notify}) => {
   )
 }
 
-const mdtp = {
-  notify: notifyAction,
-}
-
-const connector = connect(null, mdtp)
-
-export default connector(TaskCardMeta)
+export default TaskCardMeta


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/660

adds the task id to the task list page for easy copying. same code as the buckets page.

![Kapture 2021-03-08 at 16 04 07](https://user-images.githubusercontent.com/4805997/110399564-e55d2280-802a-11eb-8831-abb5ce252673.gif)


- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
