### PR TITLE
fix: escape the text from tag selectors before using as RegEx

### DIFF
--- a/src/timeMachine/apis/queryBuilder.ts
+++ b/src/timeMachine/apis/queryBuilder.ts
@@ -166,12 +166,18 @@ export function formatTagKeyFilterCall(tagsSelections: BuilderConfig['tags']) {
   return `\n  |> filter(fn: (r) => ${fnBody})`
 }
 
+export function escapeRegExSpecialCharacters(characters: string) {
+  return characters.replace(/[.*+?^${}()|\/[\]\\]/g, '\\$&')
+}
+
 export function formatSearchFilterCall(searchTerm: string) {
   if (!searchTerm) {
     return ''
   }
 
-  return `\n  |> filter(fn: (r) => r._value =~ /(?i:${searchTerm})/)`
+  return `\n  |> filter(fn: (r) => r._value =~ /(?i:${escapeRegExSpecialCharacters(
+    searchTerm
+  )})/)`
 }
 
 export function formatTimeRangeArguments(timeRange: TimeRange): string {


### PR DESCRIPTION
Closes #798 

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass


![Kapture 2021-03-08 at 18 00 05](https://user-images.githubusercontent.com/10736577/110407262-6c64c780-8038-11eb-870a-246eff95aefe.gif)
