### PR TITLE
docs(clientLibs): updated Swift examples to reflect actual version of client

### DIFF
--- a/src/writeData/components/clientLibraries/Java.md
+++ b/src/writeData/components/clientLibraries/Java.md
@@ -8,7 +8,7 @@ Build with Maven
 <dependency>
   <groupId>com.influxdb</groupId>
   <artifactId>influxdb-client-java</artifactId>
-  <version>1.8.0</version>
+  <version>2.0.0</version>
 </dependency>
 ```
 
@@ -16,7 +16,7 @@ Build with Gradle
 
 ```
 dependencies {
-  compile "com.influxdb:influxdb-client-java:1.8.0"
+  compile "com.influxdb:influxdb-client-java:2.0.0"
 }
 ```
 

--- a/src/writeData/components/clientLibraries/Kotlin.md
+++ b/src/writeData/components/clientLibraries/Kotlin.md
@@ -8,7 +8,7 @@ Build with Maven
 <dependency>
   <groupId>com.influxdb</groupId>
   <artifactId>influxdb-client-kotlin</artifactId>
-  <version>1.8.0</version>
+  <version>2.0.0</version>
 </dependency>
 ```
 
@@ -16,7 +16,7 @@ Build with Gradle
 
 ```
 dependencies {
-  compile "com.influxdb:influxdb-client-kotlin:1.8.0"
+  compile "com.influxdb:influxdb-client-kotlin:2.0.0"
 }
 ```
 

--- a/src/writeData/components/clientLibraries/Scala.md
+++ b/src/writeData/components/clientLibraries/Scala.md
@@ -5,7 +5,7 @@ For more detailed and up to date information check out the <a href="https://gith
 Build with sbt
 
 ```
-libraryDependencies += "com.influxdb" % "influxdb-client-scala" % "1.8.0"
+libraryDependencies += "com.influxdb" % "influxdb-client-scala" % "2.0.0"
 ```
 
 Build with Maven
@@ -14,7 +14,7 @@ Build with Maven
 <dependency>
   <groupId>com.influxdb</groupId>
   <artifactId>influxdb-client-scala</artifactId>
-  <version>1.8.0</version>
+  <version>2.0.0</version>
 </dependency>
 ```
 
@@ -22,7 +22,7 @@ Build with Gradle
 
 ```
 dependencies {
-  compile "com.influxdb:influxdb-client-scala:1.8.0"
+  compile "com.influxdb:influxdb-client-scala:2.0.0"
 }
 ```
 

--- a/src/writeData/components/clientLibraries/Swift.md
+++ b/src/writeData/components/clientLibraries/Swift.md
@@ -1,4 +1,4 @@
-For more detailed and up to date information check out the <a href="https://github.com/influxdata/influxdb-client-swift/" target="_blank">GitHub Repository</a>
+For more detailed and up to date information check out the [GitHub Repository](https://github.com/influxdata/influxdb-client-swift/)
 
 ##### Install via Swift Package Manager
 
@@ -11,7 +11,7 @@ import PackageDescription
 let package = Package(
     name: "MyPackage",
     dependencies: [
-        .package(name: "influxdb-client-swift", url: "https://github.com/influxdata/influxdb-client-swift", from: "0.1.0"),
+        .package(name: "influxdb-client-swift", url: "https://github.com/influxdata/influxdb-client-swift", from: "0.2.0"),
     ],
     targets: [
         .target(name: "MyModule", dependencies: [
@@ -47,29 +47,8 @@ client.close()
 // Record defined as String
 //
 let recordString = "demo,type=string value=1i"
-//
-// Record defined as Data Point
-//
-let recordPoint = InfluxDBClient
-        .Point("demo")
-        .addTag(key: "type", value: "point")
-        .addField(key: "value", value: 2)
-//
-// Record defined as Data Point with Timestamp
-//
-let recordPointDate = InfluxDBClient
-        .Point("demo")
-        .addTag(key: "type", value: "point-timestamp")
-        .addField(key: "value", value: 2)
-        .time(time: Date())
-//
-// Record defined as Tuple
-//
-let recordTuple = (measurement: "demo", tags: ["type": "tuple"], fields: ["value": 3])
 
-let records: [Any] = [recordString, recordPoint, recordPointDate, recordTuple]
-
-client.getWriteAPI().writeRecords(records: records) { result, error in
+client.makeWriteAPI().write(record: recordString) { result, error in
     // For handle error
     if let error = error {
         print("Error:\n\n\(error)")
@@ -77,7 +56,53 @@ client.getWriteAPI().writeRecords(records: records) { result, error in
 
     // For Success write
     if result != nil {
-        print("Successfully written data:\n\n\(records)")
+        print("Successfully written data:\n\n\(recordString)")
+    }
+}
+
+//
+// Record defined as Data Point
+//
+let recordPoint = InfluxDBClient
+        .Point("demo")
+        .addTag(key: "type", value: "point")
+        .addField(key: "value", value: .int(2))
+//
+// Record defined as Data Point with Timestamp
+//
+let recordPointDate = InfluxDBClient
+        .Point("demo")
+        .addTag(key: "type", value: "point-timestamp")
+        .addField(key: "value", value: .int(2))
+        .time(time: .date(Date()))
+
+client.makeWriteAPI().write(points: [recordPoint, recordPointDate]) { result, error in
+    // For handle error
+    if let error = error {
+        print("Error:\n\n\(error)")
+    }
+
+    // For Success write
+    if result != nil {
+        print("Successfully written data:\n\n\([recordPoint, recordPointDate])")
+    }
+}
+
+//
+// Record defined as Tuple
+//
+let recordTuple: InfluxDBClient.Point.Tuple
+        = (measurement: "demo", tags: ["type": "tuple"], fields: ["value": .int(3)], time: nil)
+
+client.makeWriteAPI().write(tuple: recordTuple) { result, error in
+    // For handle error
+    if let error = error {
+        print("Error:\n\n\(error)")
+    }
+
+    // For Success write
+    if result != nil {
+        print("Successfully written data:\n\n\(recordTuple)")
     }
 }
 ```


### PR DESCRIPTION
Closes #795

Related to https://github.com/influxdata/influxdb-client-swift/pull/25

The API of client was slightly changed, this PR reflects this changes:

![image](https://user-images.githubusercontent.com/455137/109616882-03f88080-7b36-11eb-9da4-a8afb9dbeaf8.png)


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
