### PR TITLE
feat: create bucket and token from client lib page

### DIFF
--- a/src/authorizations/components/GenerateTokenDropdown.tsx
+++ b/src/authorizations/components/GenerateTokenDropdown.tsx
@@ -17,13 +17,9 @@ type GenerateTokenProps = RouteComponentProps
 const GenerateTokenDropdown: FC<GenerateTokenProps> = ({history}) => {
   const org = useSelector(getOrg)
 
-  const bucketReadWriteOption = (): string => {
-    return 'Read/Write Token'
-  }
+  const bucketReadWriteOption = 'Read/Write Token'
 
-  const allAccessOption = (): string => {
-    return 'All Access Token'
-  }
+  const allAccessOption = 'All Access Token'
 
   const handleAllAccess = () => {
     history.push(`/orgs/${org.id}/load-data/tokens/generate/all-access`)
@@ -33,34 +29,11 @@ const GenerateTokenDropdown: FC<GenerateTokenProps> = ({history}) => {
     history.push(`/orgs/${org.id}/load-data/tokens/generate/buckets`)
   }
   const handleSelect = (selection: string): void => {
-    if (selection === allAccessOption()) {
+    if (selection === allAccessOption) {
       handleAllAccess()
-    } else if (selection === bucketReadWriteOption()) {
+    } else if (selection === bucketReadWriteOption) {
       handleReadWrite()
     }
-  }
-
-  const getOptionItems = () => {
-    return [
-      <Dropdown.Item
-        testID="dropdown-item generate-token--read-write"
-        id={bucketReadWriteOption()}
-        key={bucketReadWriteOption()}
-        value={bucketReadWriteOption()}
-        onClick={handleSelect}
-      >
-        {bucketReadWriteOption()}
-      </Dropdown.Item>,
-      <Dropdown.Item
-        testID="dropdown-item generate-token--all-access"
-        id={allAccessOption()}
-        key={allAccessOption()}
-        value={allAccessOption()}
-        onClick={handleSelect}
-      >
-        {allAccessOption()}
-      </Dropdown.Item>,
-    ]
   }
 
   return (
@@ -80,7 +53,26 @@ const GenerateTokenDropdown: FC<GenerateTokenProps> = ({history}) => {
       )}
       menu={onCollapse => (
         <Dropdown.Menu onCollapse={onCollapse}>
-          {getOptionItems()}
+          {[
+            <Dropdown.Item
+              testID="dropdown-item generate-token--read-write"
+              id={bucketReadWriteOption}
+              key={bucketReadWriteOption}
+              value={bucketReadWriteOption}
+              onClick={handleSelect}
+            >
+              {bucketReadWriteOption}
+            </Dropdown.Item>,
+            <Dropdown.Item
+              testID="dropdown-item generate-token--all-access"
+              id={allAccessOption}
+              key={allAccessOption}
+              value={allAccessOption}
+              onClick={handleSelect}
+            >
+              {allAccessOption}
+            </Dropdown.Item>,
+          ]}
         </Dropdown.Menu>
       )}
     />

--- a/src/authorizations/components/GenerateTokenDropdown.tsx
+++ b/src/authorizations/components/GenerateTokenDropdown.tsx
@@ -1,5 +1,6 @@
 // Libraries
-import React, {PureComponent} from 'react'
+import React, {FC} from 'react'
+import {useSelector} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
@@ -8,94 +9,82 @@ import {Dropdown} from '@influxdata/clockface'
 // Types
 import {IconFont, ComponentColor} from '@influxdata/clockface'
 
-type Props = RouteComponentProps<{orgID: string}>
+// Selectors
+import {getOrg} from 'src/organizations/selectors'
 
-class GenerateTokenDropdown extends PureComponent<Props> {
-  public render() {
-    return (
-      <Dropdown
-        testID="dropdown--gen-token"
-        style={{width: '160px'}}
-        button={(active, onClick) => (
-          <Dropdown.Button
-            active={active}
-            onClick={onClick}
-            icon={IconFont.Plus}
-            color={ComponentColor.Primary}
-            testID="dropdown-button--gen-token"
-          >
-            Generate
-          </Dropdown.Button>
-        )}
-        menu={onCollapse => (
-          <Dropdown.Menu onCollapse={onCollapse}>
-            {this.optionItems}
-          </Dropdown.Menu>
-        )}
-      />
-    )
+type GenerateTokenProps = RouteComponentProps
+
+const GenerateTokenDropdown: FC<GenerateTokenProps> = ({history}) => {
+  const org = useSelector(getOrg)
+
+  const bucketReadWriteOption = (): string => {
+    return 'Read/Write Token'
   }
 
-  private get optionItems(): JSX.Element[] {
+  const allAccessOption = (): string => {
+    return 'All Access Token'
+  }
+
+  const handleAllAccess = () => {
+    history.push(`/orgs/${org.id}/load-data/tokens/generate/all-access`)
+  }
+
+  const handleReadWrite = () => {
+    history.push(`/orgs/${org.id}/load-data/tokens/generate/buckets`)
+  }
+  const handleSelect = (selection: string): void => {
+    if (selection === allAccessOption()) {
+      handleAllAccess()
+    } else if (selection === bucketReadWriteOption()) {
+      handleReadWrite()
+    }
+  }
+
+  const getOptionItems = () => {
     return [
       <Dropdown.Item
         testID="dropdown-item generate-token--read-write"
-        id={this.bucketReadWriteOption}
-        key={this.bucketReadWriteOption}
-        value={this.bucketReadWriteOption}
-        onClick={this.handleSelect}
+        id={bucketReadWriteOption()}
+        key={bucketReadWriteOption()}
+        value={bucketReadWriteOption()}
+        onClick={handleSelect}
       >
-        {this.bucketReadWriteOption}
+        {bucketReadWriteOption()}
       </Dropdown.Item>,
       <Dropdown.Item
         testID="dropdown-item generate-token--all-access"
-        id={this.allAccessOption}
-        key={this.allAccessOption}
-        value={this.allAccessOption}
-        onClick={this.handleSelect}
+        id={allAccessOption()}
+        key={allAccessOption()}
+        value={allAccessOption()}
+        onClick={handleSelect}
       >
-        {this.allAccessOption}
+        {allAccessOption()}
       </Dropdown.Item>,
     ]
   }
 
-  private get bucketReadWriteOption(): string {
-    return 'Read/Write Token'
-  }
-
-  private get allAccessOption(): string {
-    return 'All Access Token'
-  }
-
-  private handleSelect = (selection: string): void => {
-    if (selection === this.allAccessOption) {
-      this.handleAllAccess()
-    } else if (selection === this.bucketReadWriteOption) {
-      this.handleReadWrite()
-    }
-  }
-
-  private handleAllAccess = () => {
-    const {
-      history,
-      match: {
-        params: {orgID},
-      },
-    } = this.props
-
-    history.push(`/orgs/${orgID}/load-data/tokens/generate/all-access`)
-  }
-
-  private handleReadWrite = () => {
-    const {
-      history,
-      match: {
-        params: {orgID},
-      },
-    } = this.props
-
-    history.push(`/orgs/${orgID}/load-data/tokens/generate/buckets`)
-  }
+  return (
+    <Dropdown
+      testID="dropdown--gen-token"
+      style={{width: '160px'}}
+      button={(active, onClick) => (
+        <Dropdown.Button
+          active={active}
+          onClick={onClick}
+          icon={IconFont.Plus}
+          color={ComponentColor.Primary}
+          testID="dropdown-button--gen-token"
+        >
+          Generate
+        </Dropdown.Button>
+      )}
+      menu={onCollapse => (
+        <Dropdown.Menu onCollapse={onCollapse}>
+          {getOptionItems()}
+        </Dropdown.Menu>
+      )}
+    />
+  )
 }
 
 export default withRouter(GenerateTokenDropdown)

--- a/src/authorizations/components/GenerateTokenDropdown.tsx
+++ b/src/authorizations/components/GenerateTokenDropdown.tsx
@@ -75,7 +75,7 @@ const GenerateTokenDropdown: FC<GenerateTokenProps> = ({history}) => {
           color={ComponentColor.Primary}
           testID="dropdown-button--gen-token"
         >
-          Generate
+          Generate Token
         </Dropdown.Button>
       )}
       menu={onCollapse => (

--- a/src/authorizations/components/GenerateTokenDropdown.tsx
+++ b/src/authorizations/components/GenerateTokenDropdown.tsx
@@ -53,26 +53,24 @@ const GenerateTokenDropdown: FC<GenerateTokenProps> = ({history}) => {
       )}
       menu={onCollapse => (
         <Dropdown.Menu onCollapse={onCollapse}>
-          {[
-            <Dropdown.Item
-              testID="dropdown-item generate-token--read-write"
-              id={bucketReadWriteOption}
-              key={bucketReadWriteOption}
-              value={bucketReadWriteOption}
-              onClick={handleSelect}
-            >
-              {bucketReadWriteOption}
-            </Dropdown.Item>,
-            <Dropdown.Item
-              testID="dropdown-item generate-token--all-access"
-              id={allAccessOption}
-              key={allAccessOption}
-              value={allAccessOption}
-              onClick={handleSelect}
-            >
-              {allAccessOption}
-            </Dropdown.Item>,
-          ]}
+          <Dropdown.Item
+            testID="dropdown-item generate-token--read-write"
+            id={bucketReadWriteOption}
+            key={bucketReadWriteOption}
+            value={bucketReadWriteOption}
+            onClick={handleSelect}
+          >
+            {bucketReadWriteOption}
+          </Dropdown.Item>
+          <Dropdown.Item
+            testID="dropdown-item generate-token--all-access"
+            id={allAccessOption}
+            key={allAccessOption}
+            value={allAccessOption}
+            onClick={handleSelect}
+          >
+            {allAccessOption}
+          </Dropdown.Item>
         </Dropdown.Menu>
       )}
     />

--- a/src/writeData/components/WriteDataDetailsContext.tsx
+++ b/src/writeData/components/WriteDataDetailsContext.tsx
@@ -66,10 +66,10 @@ const WriteDataDetailsContextProvider: FC<Props> = ({
     origin,
     bucket,
     buckets: userBuckets,
-    changeBucket,
+    changeBucket: (toChangeBucket: Bucket) => changeBucket(toChangeBucket),
     token,
     tokens,
-    changeToken,
+    changeToken: (toChangeToken: Authorization) => changeToken(toChangeToken),
   }
 
   return (

--- a/src/writeData/components/WriteDataDetailsView.scss
+++ b/src/writeData/components/WriteDataDetailsView.scss
@@ -36,7 +36,17 @@
 .write-data--details-widget-title {
   margin-bottom: $cf-marg-b;
   padding-left: $cf-marg-b + $cf-marg-a;
-  padding-right: $cf-marg-b + $cf-marg-a;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.write-data--details-empty-state {
+  height: 200px;
+  background-color: #0f0e15;
+  display: grid;
+  align-items: center;
+  justify-items: center;
 }
 
 .markdown-format .code-snippet--text {

--- a/src/writeData/components/WriteDataHelperBuckets.tsx
+++ b/src/writeData/components/WriteDataHelperBuckets.tsx
@@ -3,7 +3,7 @@ import React, {FC, useContext} from 'react'
 
 // Contexts
 import {WriteDataDetailsContext} from 'src/writeData/components/WriteDataDetailsContext'
-
+import CreateBucketButton from 'src/buckets/components/CreateBucketButton'
 // Components
 import {
   List,
@@ -19,8 +19,17 @@ const WriteDataHelperBuckets: FC = () => {
   const {bucket, buckets, changeBucket} = useContext(WriteDataDetailsContext)
 
   let body = (
-    <EmptyState size={ComponentSize.Small}>
-      <p>You don't have any Buckets</p>
+    <EmptyState className="write-data--details-empty-state">
+      <span>
+        You don't have any{' '}
+        <a
+          href="https://docs.influxdata.com/influxdb/cloud/organizations/buckets/"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Buckets
+        </a>
+      </span>
     </EmptyState>
   )
 
@@ -63,6 +72,7 @@ const WriteDataHelperBuckets: FC = () => {
         className="write-data--details-widget-title"
       >
         Bucket
+        <CreateBucketButton />
       </Heading>
       {body}
     </>

--- a/src/writeData/components/WriteDataHelperTokens.test.tsx
+++ b/src/writeData/components/WriteDataHelperTokens.test.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React from 'react'
-import {render} from '@testing-library/react'
+import {renderWithReduxAndRouter} from 'src/mockState'
 
 // Components
 import WriteDataHelperTokens from 'src/writeData/components/WriteDataHelperTokens'
@@ -28,7 +28,7 @@ const setup = (override?) => {
 
   const contextValue = {...mockContextValue, ...override}
 
-  const wrapper = render(
+  const wrapper = renderWithReduxAndRouter(
     <WriteDataDetailsContext.Provider value={contextValue}>
       <WriteDataHelperTokens />
     </WriteDataDetailsContext.Provider>
@@ -83,7 +83,7 @@ describe('WriteDataHelperTokens', () => {
       const {wrapper} = setup({tokens: []})
       const {getByTestId} = wrapper
 
-      const emptyText = getByTestId('write-data-tokens-list-empty')
+      const emptyText = getByTestId('write-data--details-empty-state')
 
       expect(emptyText).toBeTruthy()
     })

--- a/src/writeData/components/WriteDataHelperTokens.test.tsx
+++ b/src/writeData/components/WriteDataHelperTokens.test.tsx
@@ -51,11 +51,13 @@ describe('WriteDataHelperTokens', () => {
 
       expect(list).toBeTruthy()
 
-      const token = getByTestId(auth.description)
+      const renderedToken = getByTestId(auth.description)
 
-      expect(token).toBeTruthy()
+      expect(renderedToken).toBeTruthy()
 
-      expect(token.classList.contains('cf-list-item__active')).toBeTruthy()
+      expect(
+        renderedToken.classList.contains('cf-list-item__active')
+      ).toBeTruthy()
     })
   })
 

--- a/src/writeData/components/WriteDataHelperTokens.tsx
+++ b/src/writeData/components/WriteDataHelperTokens.tsx
@@ -15,14 +15,26 @@ import {
   EmptyState,
 } from '@influxdata/clockface'
 
+import GenerateTokenDropdown from 'src/authorizations/components/GenerateTokenDropdown'
+
 const WriteDataHelperTokens: FC = () => {
   const {token, tokens, changeToken} = useContext(WriteDataDetailsContext)
 
   let body = (
-    <EmptyState size={ComponentSize.Small}>
-      <p data-testid="write-data-tokens-list-empty">
-        You don't have any Tokens
-      </p>
+    <EmptyState
+      className="write-data--details-empty-state"
+      testID="write-data--details-empty-state"
+    >
+      <span>
+        You don't have any{' '}
+        <a
+          href="https://docs.influxdata.com/influxdb/cloud/security/tokens/"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Tokens
+        </a>
+      </span>
     </EmptyState>
   )
 
@@ -67,6 +79,7 @@ const WriteDataHelperTokens: FC = () => {
         className="write-data--details-widget-title"
       >
         Token
+        <GenerateTokenDropdown />
       </Heading>
       {body}
     </>


### PR DESCRIPTION
Closes #598 

<!-- Describe your proposed changes here. -->
This PR introduces the ability to create a bucket and/or a token in the client libraries page. Previously, the page would display an empty list and the user would be forced to go to the tokens/buckets overlays in their respective tabs and create them, then navigate back to the current page. 


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
![Screen Shot 2021-03-08 at 1 17 26 PM](https://user-images.githubusercontent.com/29473622/110494696-7549ad80-80b9-11eb-8d06-a33930826893.png)
![Screen Shot 2021-03-08 at 1 20 01 PM](https://user-images.githubusercontent.com/29473622/110494701-75e24400-80b9-11eb-80c3-87280978e451.png)
