### PR TITLE
feat(ui-e2e): Add package.json shortcut to run e2e cypress tests against KinD

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "test:e2e:report": "junit-viewer --results=junit-results --save-file=cypress/site/junit-report.html",
     "test:e2e:clean": "rm junit-results/*.xml",
     "test:e2e:all": "yarn test:e2e:clean && yarn test:e2e; yarn test:e2e:report;",
+    "test:e2e:kind": "CYPRESS_baseUrl=https://twodotoh.a.influxcloud.dev.local CYPRESS_password=password cypress open --browser chrome --config chromeWebSecurity=false",
     "test:circleci": "yarn run test:ci --maxWorkers=2",
     "test:ci": "JEST_JUNIT_OUTPUT_DIR=\"./coverage\" jest --ci --coverage",
     "lint": "yarn tsc && yarn prettier && yarn eslint",


### PR DESCRIPTION
I added a shortcut to package.json to run the e2e cypress tests with baseURL and password set to what it needs to be to run against a local KinD cluster. 
This change is accompanied by changes to documentation that is coming up!