### PR TITLE
fix: deadman checks render table for non-numeric fields

### DIFF
--- a/cypress/e2e/shared/checks.test.ts
+++ b/cypress/e2e/shared/checks.test.ts
@@ -282,7 +282,7 @@ describe('Checks', () => {
     )
   })
 
-  it('checks only allow numeric fields', () => {
+  it('deadman checks should render a table for non-numeric fields', () => {
     cy.get<string>('@defaultBucketListSelector').then(
       (defaultBucketListSelector: string) => {
         // create deadman check
@@ -305,8 +305,8 @@ describe('Checks', () => {
         cy.getByTestID('empty-graph--no-queries')
         cy.getByTestID('time-machine-submit-button').click()
 
-        // check for error message
-        cy.getByTestID('empty-graph--numeric').should('exist')
+        // check for table
+        cy.getByTestID('_value-table-header').should('exist')
       }
     )
   })

--- a/cypress/e2e/shared/checks.test.ts
+++ b/cypress/e2e/shared/checks.test.ts
@@ -306,7 +306,19 @@ describe('Checks', () => {
         cy.getByTestID('time-machine-submit-button').click()
 
         // check for table
-        cy.getByTestID('_value-table-header').should('exist')
+        cy.getByTestID('raw-data-table').should('exist')
+        cy.getByTestID('raw-data--toggle').should('have.class', 'disabled')
+
+        // change field to numeric value
+        cy.getByTestID(`selector-list ${field}`).click()
+        cy.get('.query-checklist--popover').should('not.exist')
+        cy.getByTestID('save-cell--button').should('be.enabled')
+
+        // submit the graph
+        cy.getByTestID('time-machine-submit-button').click()
+
+        // make sure the plot is visible
+        cy.getByTestID('giraffe-inner-plot').should('be.visible')
       }
     )
   })

--- a/src/timeMachine/actions/index.ts
+++ b/src/timeMachine/actions/index.ts
@@ -51,6 +51,7 @@ export type Action =
   | SetTypeAction
   | SetActiveQueryText
   | SetIsViewingRawDataAction
+  | SetIsDisabledViewRawData
   | SetGeomAction
   | SetDecimalPlaces
   | SetBackgroundThresholdColoringAction
@@ -221,6 +222,18 @@ export const setIsViewingRawData = (
 ): SetIsViewingRawDataAction => ({
   type: 'SET_IS_VIEWING_RAW_DATA',
   payload: {isViewingRawData},
+})
+
+interface SetIsDisabledViewRawData {
+  type: 'SET_IS_DISABLED_VIEW_RAW_DATA'
+  payload: {isDisabledViewRawData: boolean}
+}
+
+export const setIsDisabledViewRawData = (
+  isDisabledViewRawData: boolean
+): SetIsDisabledViewRawData => ({
+  type: 'SET_IS_DISABLED_VIEW_RAW_DATA',
+  payload: {isDisabledViewRawData},
 })
 
 interface SetGeomAction {

--- a/src/timeMachine/components/RawDataToggle.tsx
+++ b/src/timeMachine/components/RawDataToggle.tsx
@@ -19,7 +19,7 @@ type Props = ReduxProps
 
 class TimeMachineQueries extends PureComponent<Props> {
   public render() {
-    const {isViewingRawData} = this.props
+    const {isViewingRawData, isDisabledViewRawData} = this.props
 
     return (
       <div className="view-raw-data-toggle">
@@ -29,6 +29,7 @@ class TimeMachineQueries extends PureComponent<Props> {
           onChange={this.handleToggleIsViewingRawData}
           size={ComponentSize.ExtraSmall}
           testID="raw-data--toggle"
+          disabled={isDisabledViewRawData}
         />
       </div>
     )
@@ -42,9 +43,9 @@ class TimeMachineQueries extends PureComponent<Props> {
 }
 
 const mstp = (state: AppState) => {
-  const {isViewingRawData} = getActiveTimeMachine(state)
+  const {isViewingRawData, isDisabledViewRawData} = getActiveTimeMachine(state)
 
-  return {isViewingRawData}
+  return {isViewingRawData, isDisabledViewRawData}
 }
 
 const mdtp = {

--- a/src/timeMachine/reducers/index.ts
+++ b/src/timeMachine/reducers/index.ts
@@ -74,6 +74,7 @@ export interface TimeMachineState {
   draftQueries: DashboardDraftQuery[]
   isViewingRawData: boolean
   isViewingVisOptions: boolean
+  isDisabledViewRawData: boolean
   activeTab: TimeMachineTab
   activeQueryIndex: number | null
   queryBuilder: QueryBuilderState
@@ -98,6 +99,7 @@ export const initialStateHelper = (): TimeMachineState => {
     draftQueries: [{...defaultViewQuery(), hidden: false}],
     isViewingRawData: false,
     isViewingVisOptions: false,
+    isDisabledViewRawData: false,
     activeTab: 'queries',
     activeQueryIndex: 0,
     queryResults: initialQueryResultsState(),
@@ -320,6 +322,12 @@ export const timeMachineReducer = (
       const {isViewingRawData} = action.payload
 
       return {...state, isViewingRawData}
+    }
+
+    case 'SET_IS_DISABLED_VIEW_RAW_DATA': {
+      const {isDisabledViewRawData} = action.payload
+
+      return {...state, isDisabledViewRawData}
     }
 
     case 'SET_ACTIVE_TAB': {

--- a/src/visualization/components/View.tsx
+++ b/src/visualization/components/View.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {FC, createElement} from 'react'
-import {useDispatch} from 'react-redux'
 
 import EmptyQueryView, {ErrorFormat} from 'src/shared/components/EmptyQueryView'
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
@@ -15,7 +14,6 @@ import {
   TimeRange,
   ViewProperties,
 } from 'src/types'
-import {setType} from 'src/timeMachine/actions'
 
 interface Props {
   properties: ViewProperties
@@ -40,20 +38,11 @@ const InnerView: FC<Props> = ({
     throw new Error('Unknown view type in <View /> ')
   }
 
-  const dispatch = useDispatch()
-
   const fallbackNote =
     properties.type !== 'check' && properties['showNoteWhenEmpty']
       ? properties.note
       : null
   const hasResults = !!(result?.table?.length || 0)
-
-  if (
-    properties.type === 'check' &&
-    result.table.getColumnType('_value') !== 'number'
-  ) {
-    dispatch(setType('table'))
-  }
 
   return (
     <EmptyQueryView

--- a/src/visualization/components/View.tsx
+++ b/src/visualization/components/View.tsx
@@ -1,5 +1,6 @@
 // Libraries
 import React, {FC, createElement} from 'react'
+import {useDispatch} from 'react-redux'
 
 import EmptyQueryView, {ErrorFormat} from 'src/shared/components/EmptyQueryView'
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
@@ -14,6 +15,7 @@ import {
   TimeRange,
   ViewProperties,
 } from 'src/types'
+import {setType} from 'src/timeMachine/actions'
 
 interface Props {
   properties: ViewProperties
@@ -38,11 +40,20 @@ const InnerView: FC<Props> = ({
     throw new Error('Unknown view type in <View /> ')
   }
 
+  const dispatch = useDispatch()
+
   const fallbackNote =
     properties.type !== 'check' && properties['showNoteWhenEmpty']
       ? properties.note
       : null
   const hasResults = !!(result?.table?.length || 0)
+
+  if (
+    properties.type === 'check' &&
+    result.table.getColumnType('_value') !== 'number'
+  ) {
+    dispatch(setType('table'))
+  }
 
   return (
     <EmptyQueryView

--- a/src/visualization/types/Check/view.tsx
+++ b/src/visualization/types/Check/view.tsx
@@ -45,19 +45,9 @@ const CheckPlot: FC<Props> = ({properties, result}) => {
   const columnKeys = result.table.columnKeys
   const isValidView =
     columnKeys.includes(X_COLUMN) && columnKeys.includes(Y_COLUMN)
-  const isYNumeric = result.table.getColumnType(Y_COLUMN) === 'number'
 
   if (!isValidView) {
     return <EmptyGraphMessage message={INVALID_DATA_COPY} />
-  }
-
-  if (!isYNumeric) {
-    return (
-      <EmptyGraphMessage
-        message="Checks only support numeric values. Please try choosing another field."
-        testID="empty-graph--numeric"
-      />
-    )
   }
 
   const groupKey = [...result.fluxGroupKeyUnion, 'result']


### PR DESCRIPTION
Closes https://github.com/influxdata/idpe/issues/9590

Deadman checks should render the raw data view for non-numeric fields rather than showing an error message.


https://user-images.githubusercontent.com/6411855/110879006-13dc3700-8291-11eb-8743-0153f77927e7.mov

Test changes pass IDPE CI ✅ 

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
