### PR TITLE
feat: annotationsControlBarButton only controls the control bar

### DIFF
--- a/src/annotations/components/AnnotationsControlBarToggleButton.tsx
+++ b/src/annotations/components/AnnotationsControlBarToggleButton.tsx
@@ -11,7 +11,7 @@ import {toggleShowAnnotationsControls} from 'src/userSettings/actions'
 // Components
 import {Button, ComponentColor, IconFont} from '@influxdata/clockface'
 
-export const AnnotationsToggleButton: FC = () => {
+export const AnnotationsControlBarToggleButton: FC = () => {
   const dispatch = useDispatch()
   const isVisible = useSelector(getAnnotationControlsVisibility)
 

--- a/src/dashboards/components/DashboardHeader.tsx
+++ b/src/dashboards/components/DashboardHeader.tsx
@@ -12,7 +12,7 @@ import GraphTips from 'src/shared/components/graph_tips/GraphTips'
 import RenamablePageTitle from 'src/pageLayout/components/RenamablePageTitle'
 import TimeZoneDropdown from 'src/shared/components/TimeZoneDropdown'
 import {Button, IconFont, ComponentColor, Page} from '@influxdata/clockface'
-import {AnnotationsToggleButton} from 'src/annotations/components/AnnotationsToggleButton'
+import {AnnotationsControlBarToggleButton} from 'src/annotations/components/AnnotationsControlBarToggleButton'
 import {FeatureFlag} from 'src/shared/utils/featureFlag'
 
 // Actions
@@ -172,7 +172,7 @@ const DashboardHeader: FC<Props> = ({
             }
           />
           <FeatureFlag name="annotations">
-            <AnnotationsToggleButton />
+            <AnnotationsControlBarToggleButton />
           </FeatureFlag>
           <DashboardLightModeToggle />
           <PresentationModeToggle />

--- a/src/dataExplorer/components/DataExplorerPage.tsx
+++ b/src/dataExplorer/components/DataExplorerPage.tsx
@@ -14,7 +14,7 @@ import RateLimitAlert from 'src/cloud/components/RateLimitAlert'
 import SaveAsOverlay from 'src/dataExplorer/components/SaveAsOverlay'
 import DEDeleteDataOverlay from 'src/dataExplorer/components/DeleteDataOverlay'
 import ViewTypeDropdown from 'src/timeMachine/components/ViewTypeDropdown'
-import {AnnotationsToggleButton} from 'src/annotations/components/AnnotationsToggleButton'
+import {AnnotationsControlBarToggleButton} from 'src/annotations/components/AnnotationsControlBarToggleButton'
 import {FeatureFlag} from 'src/shared/utils/featureFlag'
 import {AnnotationsControlBar} from 'src/annotations/components/controlBar/AnnotationsControlBar'
 import {AddAnnotationDEOverlay} from 'src/overlays/components/index'
@@ -65,7 +65,7 @@ const DataExplorerPage: FC = () => {
             <ViewTypeDropdown />
             <VisOptionsButton />
             <FeatureFlag name="annotations">
-              <AnnotationsToggleButton />
+              <AnnotationsControlBarToggleButton />
             </FeatureFlag>
           </Page.ControlBarLeft>
           <Page.ControlBarRight>

--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -31,7 +31,7 @@ import {DEFAULT_LINE_COLORS} from 'src/shared/constants/graphColorPalettes'
 import {INVALID_DATA_COPY} from 'src/visualization/constants'
 
 // Types
-import {AppState, XYViewProperties} from 'src/types'
+import {XYViewProperties} from 'src/types'
 import {VisualizationProps} from 'src/visualization'
 
 // Utils
@@ -77,9 +77,6 @@ const XYPlot: FC<Props> = ({properties, result, timeRange, annotations}) => {
   // would need to add the annotation control bar to the VEOHeader to get access to the controls,
   // which are currently global values, not per dashboard
 
-  const annotationsModeIsActive = useSelector(
-    (state: AppState) => state.userSettings.showAnnotationsControls
-  )
   const inAnnotationWriteMode = useSelector(isSingleClickAnnotationsEnabled)
 
   const visibleAnnotationStreams = useSelector(getVisibleAnnotationStreams)
@@ -241,7 +238,7 @@ const XYPlot: FC<Props> = ({properties, result, timeRange, annotations}) => {
     ],
   }
 
-  if (isFlagEnabled('annotations') && annotationsModeIsActive) {
+  if (isFlagEnabled('annotations')) {
     if (inAnnotationWriteMode) {
       config.interactionHandlers = {
         singleClick: makeSingleClickHandler(),


### PR DESCRIPTION
Closes #819

`AnnotationsToggleButton` is now refactored to be named `AnnotationsControlBarToggleButton` and it is only responsible for toggling the visibility of the control bar. 

--

Comment for future reference:
Should we add a toggle to hide / show annotations inside the control bar? It would be nice to be able to disable/enable the visibility of the annotations without having to 'x' out the streams in the control bar.

Also, not sure if this was intended but the annotations toggle does nothing in the data-explorer page. The control bar is always visible regardless.

--

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
