### PR TITLE
fix: update default webpack port

### DIFF
--- a/webpack.dev.ts
+++ b/webpack.dev.ts
@@ -26,9 +26,9 @@ module.exports = merge(common, {
     },
     compress: true,
     proxy: {
-      '/api/v2': 'http://localhost:9999',
-      '/debug/flush': 'http://localhost:9999',
-      '/oauth': 'http://localhost:9999',
+      '/api/v2': 'http://localhost:8086',
+      '/debug/flush': 'http://localhost:8086',
+      '/oauth': 'http://localhost:8086',
     },
     disableHostCheck: true,
     host: '0.0.0.0',


### PR DESCRIPTION
InfluxDB OSS switched it's default port to 8086 when it went GA.

<!-- Describe your proposed changes here. -->

- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
