### PR TITLE
fix: default error message new github issue no longer puts hash as bug title

### DIFF
--- a/src/shared/components/DefaultErrorMessage.tsx
+++ b/src/shared/components/DefaultErrorMessage.tsx
@@ -3,19 +3,15 @@ import React from 'react'
 
 // Types
 import {ErrorMessageComponent} from 'src/types'
-import {GIT_SHA} from 'src/shared/constants'
 
 const DefaultErrorMessage: ErrorMessageComponent = () => {
-  const SHA_PARAM: string = `Version=${GIT_SHA}`
   return (
     <p
       className="default-error-message"
       style={{display: 'flex', placeContent: 'center'}}
     >
       An InfluxDB error has occurred. Please report the issue&nbsp;
-      <a
-        href={`https://github.com/influxdata/ui/issues/new?template=bug_report.md&version=${SHA_PARAM}`}
-      >
+      <a href="https://github.com/influxdata/ui/issues/new?template=bug_report.md">
         here
       </a>
       .

--- a/src/shared/components/DefaultErrorMessage.tsx
+++ b/src/shared/components/DefaultErrorMessage.tsx
@@ -14,7 +14,7 @@ const DefaultErrorMessage: ErrorMessageComponent = () => {
     >
       An InfluxDB error has occurred. Please report the issue&nbsp;
       <a
-        href={`https://github.com/influxdata/ui/issues/new?template=bug_report.md&title=${SHA_PARAM}`}
+        href={`https://github.com/influxdata/ui/issues/new?template=bug_report.md&version=${SHA_PARAM}`}
       >
         here
       </a>


### PR DESCRIPTION
Clicking on the link to create a bug from the error boundary created a bug with a non descriptive hash in the title. This puts it back to the way it used to be. It keeps the hash in the url, but it's not possible to do anything with it, yet.

<!-- Describe your proposed changes here. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
