### PR TITLE
fix: prevent time field names from being formatted

### DIFF
--- a/src/visualization/types/Table/TableCell.tsx
+++ b/src/visualization/types/Table/TableCell.tsx
@@ -259,7 +259,7 @@ class TableCell extends PureComponent<Props> {
     const {properties, data, dataType, timeFormatter} = this.props
     const {decimalPlaces} = properties
 
-    if (data && dataType.includes('dateTime')) {
+    if (data && dataType.includes('dateTime') && !this.isFieldName) {
       return timeFormatter(data)
     }
 


### PR DESCRIPTION
Closes #815 

Follow-up to https://github.com/influxdata/ui/pull/780 - don't format the time column headers

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

<img width="1680" alt="Screen Shot 2021-03-12 at 11 11 15 AM" src="https://user-images.githubusercontent.com/10736577/110987473-f86e3c00-8323-11eb-9a63-fbb32f3fbb45.png">
