### PR TITLE
fix: custom aggregate deselection prohibition toast

### DIFF
--- a/src/shared/copy/notifications.ts
+++ b/src/shared/copy/notifications.ts
@@ -56,6 +56,12 @@ const defaultDeletionNotification: NotificationExcludingMessage = {
 //  Misc Notifications
 //  ----------------------------------------------------------------------------
 
+export const prohibitedDeselect = (message?: string): Notification => ({
+  ...defaultErrorNotification,
+  message:
+    message ?? 'You must have at least one custom aggregate function selected',
+})
+
 export const newVersion = (version: string): Notification => ({
   ...defaultSuccessNotification,
   style: NotificationStyle.Info,

--- a/src/shared/reducers/notifications.ts
+++ b/src/shared/reducers/notifications.ts
@@ -18,7 +18,9 @@ export const notificationsReducer = (
           id: uuid.v4(),
         }
         const matchIndex = state.findIndex(
-          n => n.type && notification.type && n.type === notification.type
+          n =>
+            (n.type && notification.type && n.type === notification.type) ||
+            (n.message && n.message === notification.message)
         )
         const isUnique = matchIndex === -1
         if (isUnique) {

--- a/src/timeMachine/actions/queryBuilderThunks.ts
+++ b/src/timeMachine/actions/queryBuilderThunks.ts
@@ -4,7 +4,7 @@ import {queryBuilderFetcher} from 'src/timeMachine/apis/QueryBuilderFetcher'
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'
-
+import {prohibitedDeselect} from 'src/shared/copy/notifications'
 // API
 import {normalize} from 'normalizr'
 import {get} from 'lodash'
@@ -18,6 +18,7 @@ import {
   GetState,
   RemoteDataState,
   ResourceType,
+  NotificationAction,
 } from 'src/types'
 import {
   Action as AlertBuilderAction,
@@ -55,7 +56,7 @@ import {
   setFunctions,
 } from 'src/timeMachine/actions/queryBuilder'
 import {setBuckets} from 'src/buckets/actions/creators'
-
+import {notify} from 'src/shared/actions/notifications'
 // Constants
 import {LIMIT} from 'src/resources/constants'
 import {AGG_WINDOW_AUTO} from 'src/timeMachine/constants/queryBuilder'
@@ -352,7 +353,7 @@ export const selectTagValue = (index: number, value: string) => (
 }
 
 export const multiSelectBuilderFunction = (name: string) => (
-  dispatch: Dispatch<Action>,
+  dispatch: Dispatch<Action | NotificationAction>,
   getState: GetState
 ) => {
   const {draftQueries, activeQueryIndex} = getActiveTimeMachine(getState())
@@ -368,6 +369,8 @@ export const multiSelectBuilderFunction = (name: string) => (
     if (functions.length > 1) {
       // if more than one function is selected, remove clicked from selected
       dispatch(setFunctions(functionNames.filter(n => n != name)))
+    } else {
+      dispatch(notify(prohibitedDeselect()))
     }
   }
 }


### PR DESCRIPTION
Closes #25 

<!-- Describe your proposed changes here. -->
This PR introduces a toast when a user attempts to deselect the only remaining custom aggregate function, as this is a prohibited action and users have mentioned that it feels like a bug without some sort of message clarifying its intended. 

This also addresses something i noticed when working with toasts - the notification is prevented from being duplicated if the type is the same, but not if the message is the same, and it was allowing the notifications for the deselection prohibition to be duplicated. I added a check to ensure we aren't showing a duplicate message, but i'm curious if there was a reason i've failed to see as to why the check was specifically only on type and nothing else. If the reviewer can clarify, i'd appreciate it! 

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

<img width="1344" alt="Screen Shot 2021-03-15 at 9 53 09 AM" src="https://user-images.githubusercontent.com/29473622/111173003-4e392300-8574-11eb-8bd5-23679e01a2d1.png">