### PR TITLE
docs: adds check for k8s-idpe tests passing

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,3 +5,4 @@ Closes #
 - [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
 - [ ] Rebased/mergeable
 - [ ] Tests pass
+- [ ] E2E Tests pass in k8s-idpe (applicable only if you edited Cypress tests)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,4 +5,4 @@ Closes #
 - [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
 - [ ] Rebased/mergeable
 - [ ] Tests pass
-- [ ] E2E Tests pass in k8s-idpe (applicable only if you edited Cypress tests)
+- [ ] [E2E Tests pass in k8s-idpe](https://docs.influxdata.io/development/guides/local-development/#three-ways-to-run-the-ui-e2e-tests-against-the-kind-cluster) (applicable only if you edited Cypress tests)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,4 @@ Closes #
 
 <!-- Describe your proposed changes here. -->
 
-- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
-- [ ] Rebased/mergeable
-- [ ] Tests pass
 - [ ] [E2E Tests pass in k8s-idpe](https://docs.influxdata.io/development/guides/local-development/#three-ways-to-run-the-ui-e2e-tests-against-the-kind-cluster) (applicable only if you edited Cypress tests)


### PR DESCRIPTION
Adds a check for k8s-idpe test passing and removes redundant checkboxes from the template. Github won't let you merge the PR without a semantic PR title and commit messages, mergeable code, and passing tests.

Old:

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

New:

- [x] [E2E Tests pass in k8s-idpe](https://docs.influxdata.io/development/guides/local-development/#three-ways-to-run-the-ui-e2e-tests-against-the-kind-cluster) (applicable only if you edited Cypress tests)