### PR TITLE
feat: update resize icon for notebooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "webpack-merge": "^4.2.1"
   },
   "dependencies": {
-    "@influxdata/clockface": "^2.6.2",
+    "@influxdata/clockface": "^2.6.3",
     "@influxdata/flux": "^0.5.1",
     "@influxdata/flux-lsp-browser": "^0.5.34",
     "@influxdata/giraffe": "^2.4.0",

--- a/src/flows/shared/Resizer.scss
+++ b/src/flows/shared/Resizer.scss
@@ -139,19 +139,18 @@ body.panel-resizer-dragging:hover {
 }
 
 .panel-resizer--drag-icon {
-  width: $panel-resizer--drag-handle / 2;
-  height: $cf-border;
-  background-color: $c-honeydew;
+  font-size: 2em;
+  color: $c-honeydew;
   transition: background-color 0.25s ease;
   margin: $cf-border 0;
 }
 
 .panel-resizer--drag-handle:hover .panel-resizer--drag-icon {
-  background-color: $c-honeydew;
+  color: $c-honeydew;
 }
 
 .panel-resizer--drag-handle__dragging .panel-resizer--drag-icon {
-  background-color: $c-rainforest;
+  color: $c-rainforest;
 }
 
 /*

--- a/src/flows/shared/ResizerHeader.tsx
+++ b/src/flows/shared/ResizerHeader.tsx
@@ -93,9 +93,10 @@ const ResizerHeader: FC<Props> = ({
         ref={dragHandleRef}
         title="Drag to resize results table"
       >
-        <div className="panel-resizer--drag-icon" />
-        <div className="panel-resizer--drag-icon" />
-        <div className="panel-resizer--drag-icon" />
+        <Icon
+          className="panel-resizer--drag-icon"
+          glyph={IconFont.DragToExpand}
+        />
       </div>
     </div>
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -782,10 +782,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@influxdata/clockface@^2.6.2":
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-2.6.2.tgz#5d3bc8addd0c07366afb5cc7b56c25772204f41d"
-  integrity sha512-30v47i1A0/BI9p0qfhiq69+xkDSXdlXJzAfvn9LWGSxHmOpw21ZFW3bIptdBEIya+SJbYtFp8SvVxMg6V6mPIA==
+"@influxdata/clockface@^2.6.3":
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-2.6.3.tgz#836519591dac9a90449e4c55cfb475031bff0a02"
+  integrity sha512-44B6whe0wOZsscwvwfngyoZALQtbQzvtT6vgu/yPw88XMa1eVbtfQMJ00zf3YBuD4d2qAzzmBBF0ymdPQPS9Kg==
 
 "@influxdata/flux-lsp-browser@^0.5.34":
   version "0.5.34"


### PR DESCRIPTION
Update resize results pane icon to "DragToExpand" and updates clockface to 2.6.3



https://user-images.githubusercontent.com/6411855/111200476-0a97e680-857f-11eb-8fb0-f562a1df575a.mov




- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
