### PR TITLE
fix: non-numeric checks should render table on history page

### DIFF
--- a/cypress/e2e/shared/checks.test.ts
+++ b/cypress/e2e/shared/checks.test.ts
@@ -319,6 +319,19 @@ describe('Checks', () => {
 
         // make sure the plot is visible
         cy.getByTestID('giraffe-inner-plot').should('be.visible')
+
+        // change back to string field
+        cy.getByTestID(`selector-list ${stringField}`).click()
+
+        // save the check
+        cy.getByTestID('save-cell--button').click()
+
+        // go to the history page
+        cy.getByTestID('context-history-menu').click({force: true})
+        cy.getByTestID('context-history-task').click({force: true})
+
+        // make sure table is present
+        cy.getByTestID('raw-data-table').should('exist')
       }
     )
   })

--- a/src/checks/components/CheckHistory.scss
+++ b/src/checks/components/CheckHistory.scss
@@ -5,7 +5,7 @@
   width: 100%;
 
   .time-series-container {
-    background-color: $g3-castle;
+    background-color: $g0-obsidian;
     border-radius: $cf-radius;
   }
 }

--- a/src/checks/components/CheckHistoryVisualization.tsx
+++ b/src/checks/components/CheckHistoryVisualization.tsx
@@ -1,10 +1,12 @@
 // Libraries
 import React, {FC, useContext} from 'react'
+import {AutoSizer} from 'react-virtualized'
 
 // Components
 import TimeSeries from 'src/shared/components/TimeSeries'
 import {View, SUPPORTED_VISUALIZATIONS} from 'src/visualization'
 import {CheckContext} from 'src/checks/utils/context'
+import RawFluxDataTable from 'src/timeMachine/components/RawFluxDataTable'
 
 const CheckHistoryVisualization: FC = () => {
   const properties = SUPPORTED_VISUALIZATIONS['check'].initial
@@ -21,6 +23,27 @@ const CheckHistoryVisualization: FC = () => {
     <TimeSeries submitToken={0} queries={[query]} key={0} check={{id: id}}>
       {({giraffeResult, loading, errorMessage, isInitialFetch, statuses}) => {
         updateStatuses(statuses)
+
+        // handle edge case where deadman check has non-numeric value
+        if (
+          giraffeResult &&
+          !!giraffeResult.table.length &&
+          giraffeResult.table.getColumnType('_value') !== 'number'
+        ) {
+          return (
+            <AutoSizer>
+              {({width, height}) => {
+                return (
+                  <RawFluxDataTable
+                    parsedResults={giraffeResult}
+                    width={width}
+                    height={height}
+                  />
+                )
+              }}
+            </AutoSizer>
+          )
+        }
 
         return (
           <View


### PR DESCRIPTION
Closes influxdata/idpe#9590

Deadman checks with non-numeric values should render the raw data table on the check history page instead of the line chart.

![image](https://user-images.githubusercontent.com/6411855/111219410-3920bc00-8595-11eb-871a-607cbb16166d.png)


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
