### PR TITLE
chore: send lighthouse scores to tools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -428,9 +428,9 @@ jobs:
           command: |
             cd monitor-ci;
             if [ "${CIRCLE_BRANCH}" = "master" ]; then
-                    make lhr MASTER_BRANCH=1 GITHUB_TOKEN="${HERCULES_TOKEN}" INFLUXDB_TOKEN="${INFLUXDB_TOKEN}" ORG_ID="${ORG_ID}";
+                    make lhr MASTER_BRANCH=1 GITHUB_TOKEN="${HERCULES_TOKEN}" INFLUXDB_TOKEN="${INFLUXDB_TOKEN}" INFLUXDB_ORGID="${INFLUXDB_ORGID}" INFLUXDB_URL="${INFLUXDB_URL}" DASHBOARD_URL="${DASHBOARD_URL}";
             else
-                    make lhr PR="${CIRCLE_PULL_REQUEST}" GITHUB_TOKEN="${HERCULES_TOKEN}" INFLUXDB_TOKEN="${INFLUXDB_TOKEN}" ORG_ID="${ORG_ID}";
+                    make lhr PR="${CIRCLE_PULL_REQUEST}" GITHUB_TOKEN="${HERCULES_TOKEN}" INFLUXDB_TOKEN="${INFLUXDB_TOKEN}" INFLUXDB_ORGID="${INFLUXDB_ORGID}" INFLUXDB_URL="${INFLUXDB_URL}" DASHBOARD_URL="${DASHBOARD_URL}";
             fi
       - store_artifacts:
           path: /tmp/results.html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run:
           name: Grab compose files
-          command: git clone git@github.com:influxdata/monitor-ci.git
+          command: git clone git@github.com:influxdata/monitor-ci.git --branch genehynson/lighthouse-scores-tools
       - run:
           name: Copy over the testing variables
           command: cp ./monitor-ci/env.testing ./monitor-ci/.env
@@ -46,7 +46,7 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run:
           name: Grab compose files
-          command: git clone git@github.com:influxdata/monitor-ci.git
+          command: git clone git@github.com:influxdata/monitor-ci.git --branch genehynson/lighthouse-scores-tools
       - run:
           name: Copy over the testing variables
           command: cp ./monitor-ci/env.testing.oss ./monitor-ci/.env
@@ -78,7 +78,7 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run:
           name: Grab compose files
-          command: git clone git@github.com:influxdata/monitor-ci.git
+          command: git clone git@github.com:influxdata/monitor-ci.git --branch genehynson/lighthouse-scores-tools
       - run:
           name: Build the ui docker image
           command: |
@@ -112,7 +112,7 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run:
           name: Grab deploy files
-          command: git clone git@github.com:influxdata/monitor-ci.git
+          command: git clone git@github.com:influxdata/monitor-ci.git --branch genehynson/lighthouse-scores-tools
       - run:
           name: Load the prod image
           command: |
@@ -167,7 +167,7 @@ jobs:
       - run:
           name: Grab compose files
           command: |
-            git clone git@github.com:influxdata/monitor-ci.git
+            git clone git@github.com:influxdata/monitor-ci.git --branch genehynson/lighthouse-scores-tools
       - run:
           name: Copy over the testing variables
           command: cp ./monitor-ci/env.testing.cloud ./monitor-ci/.env
@@ -218,7 +218,7 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run:
           name: Grab compose files
-          command: git clone git@github.com:influxdata/monitor-ci.git
+          command: git clone git@github.com:influxdata/monitor-ci.git --branch genehynson/lighthouse-scores-tools
       - run:
           name: Copy over the testing variables
           command: cp ./monitor-ci/env.testing.oss ./monitor-ci/.env
@@ -263,7 +263,7 @@ jobs:
       - run:
           name: Grab compose files
           command: |
-            git clone git@github.com:influxdata/monitor-ci.git
+            git clone git@github.com:influxdata/monitor-ci.git --branch genehynson/lighthouse-scores-tools
       - run:
           name: Copy over the testing variables
           command: cp ./monitor-ci/env.testing.cloud ./monitor-ci/.env
@@ -304,7 +304,7 @@ jobs:
       - run:
           name: Grab compose files
           command: |
-            git clone git@github.com:influxdata/monitor-ci.git
+            git clone git@github.com:influxdata/monitor-ci.git --branch genehynson/lighthouse-scores-tools
       - run:
           name: Copy over the testing variables
           command: cp ./monitor-ci/env.testing.cloud ./monitor-ci/.env
@@ -406,7 +406,7 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run:
           name: Grab compose files
-          command: git clone git@github.com:influxdata/monitor-ci.git
+          command: git clone git@github.com:influxdata/monitor-ci.git --branch genehynson/lighthouse-scores-tools
       - run:
           name: Copy over the lighthouse variables
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -428,9 +428,9 @@ jobs:
           command: |
             cd monitor-ci;
             if [ "${CIRCLE_BRANCH}" = "master" ]; then
-                    make lhr MASTER_BRANCH=1 GITHUB_TOKEN="${HERCULES_TOKEN}";
+                    make lhr MASTER_BRANCH=1 GITHUB_TOKEN="${HERCULES_TOKEN}" INFLUXDB_TOKEN="${INFLUXDB_TOKEN}" ORG_ID="${ORG_ID}";
             else
-                    make lhr PR="${CIRCLE_PULL_REQUEST}" GITHUB_TOKEN="${HERCULES_TOKEN}";
+                    make lhr PR="${CIRCLE_PULL_REQUEST}" GITHUB_TOKEN="${HERCULES_TOKEN}" INFLUXDB_TOKEN="${INFLUXDB_TOKEN}" ORG_ID="${ORG_ID}";
             fi
       - store_artifacts:
           path: /tmp/results.html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run:
           name: Grab compose files
-          command: git clone git@github.com:influxdata/monitor-ci.git --branch genehynson/lighthouse-scores-tools
+          command: git clone git@github.com:influxdata/monitor-ci.git
       - run:
           name: Copy over the testing variables
           command: cp ./monitor-ci/env.testing ./monitor-ci/.env
@@ -46,7 +46,7 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run:
           name: Grab compose files
-          command: git clone git@github.com:influxdata/monitor-ci.git --branch genehynson/lighthouse-scores-tools
+          command: git clone git@github.com:influxdata/monitor-ci.git
       - run:
           name: Copy over the testing variables
           command: cp ./monitor-ci/env.testing.oss ./monitor-ci/.env
@@ -78,7 +78,7 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run:
           name: Grab compose files
-          command: git clone git@github.com:influxdata/monitor-ci.git --branch genehynson/lighthouse-scores-tools
+          command: git clone git@github.com:influxdata/monitor-ci.git
       - run:
           name: Build the ui docker image
           command: |
@@ -112,7 +112,7 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run:
           name: Grab deploy files
-          command: git clone git@github.com:influxdata/monitor-ci.git --branch genehynson/lighthouse-scores-tools
+          command: git clone git@github.com:influxdata/monitor-ci.git
       - run:
           name: Load the prod image
           command: |
@@ -167,7 +167,7 @@ jobs:
       - run:
           name: Grab compose files
           command: |
-            git clone git@github.com:influxdata/monitor-ci.git --branch genehynson/lighthouse-scores-tools
+            git clone git@github.com:influxdata/monitor-ci.git
       - run:
           name: Copy over the testing variables
           command: cp ./monitor-ci/env.testing.cloud ./monitor-ci/.env
@@ -218,7 +218,7 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run:
           name: Grab compose files
-          command: git clone git@github.com:influxdata/monitor-ci.git --branch genehynson/lighthouse-scores-tools
+          command: git clone git@github.com:influxdata/monitor-ci.git
       - run:
           name: Copy over the testing variables
           command: cp ./monitor-ci/env.testing.oss ./monitor-ci/.env
@@ -263,7 +263,7 @@ jobs:
       - run:
           name: Grab compose files
           command: |
-            git clone git@github.com:influxdata/monitor-ci.git --branch genehynson/lighthouse-scores-tools
+            git clone git@github.com:influxdata/monitor-ci.git
       - run:
           name: Copy over the testing variables
           command: cp ./monitor-ci/env.testing.cloud ./monitor-ci/.env
@@ -304,7 +304,7 @@ jobs:
       - run:
           name: Grab compose files
           command: |
-            git clone git@github.com:influxdata/monitor-ci.git --branch genehynson/lighthouse-scores-tools
+            git clone git@github.com:influxdata/monitor-ci.git
       - run:
           name: Copy over the testing variables
           command: cp ./monitor-ci/env.testing.cloud ./monitor-ci/.env
@@ -406,7 +406,7 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run:
           name: Grab compose files
-          command: git clone git@github.com:influxdata/monitor-ci.git --branch genehynson/lighthouse-scores-tools
+          command: git clone git@github.com:influxdata/monitor-ci.git
       - run:
           name: Copy over the lighthouse variables
           command: |


### PR DESCRIPTION
Adds additional environment variables to `make lhr` command in circle config.

Checkout this monitor-ci PR: https://github.com/influxdata/monitor-ci/pull/186
