### PR TITLE
fix: restoring CellEvent performance metrics (Cell Render Cycle)

### DIFF
--- a/src/perf/components/CellEvent.tsx
+++ b/src/perf/components/CellEvent.tsx
@@ -1,0 +1,55 @@
+import {FC, useEffect} from 'react'
+import {useSelector} from 'react-redux'
+import {useParams} from 'react-router-dom'
+
+// Utils
+import {event} from 'src/cloud/utils/reporting'
+
+// Types
+import {AppState} from 'src/types'
+
+interface Props {
+  id: string
+  type: string
+}
+
+const getState = (cellID: string) => (state: AppState) => {
+  const {perf} = state
+  const {dashboard, cells} = perf
+  const {scroll} = dashboard
+
+  return {
+    scroll,
+    cellMountStartMs: cells.byID[cellID]?.mountStartMs,
+  }
+}
+
+const CellEvent: FC<Props> = ({id, type}) => {
+  const params = useParams<{dashboardID?: string}>()
+  const dashboardID = params?.dashboardID
+
+  const {cellMountStartMs} = useSelector(getState(id))
+
+  useEffect(() => {
+    if (!cellMountStartMs) {
+      return
+    }
+
+    const hasIDs = dashboardID && id
+    if (!hasIDs) {
+      return
+    }
+
+    const visRenderedMs = new Date().getTime()
+    const timeToAppearMs = visRenderedMs - cellMountStartMs
+
+    const tags = {dashboardID, cellID: id, type}
+    const fields = {timeToAppearMs}
+
+    event('Cell Render Cycle', tags, fields)
+  }, [cellMountStartMs, dashboardID, id, type])
+
+  return null
+}
+
+export default CellEvent

--- a/src/shared/components/RefreshingView.tsx
+++ b/src/shared/components/RefreshingView.tsx
@@ -7,6 +7,8 @@ import {connect} from 'react-redux'
 import TimeSeries from 'src/shared/components/TimeSeries'
 import {View} from 'src/visualization'
 
+import CellEvent from 'src/perf/components/CellEvent'
+
 // Utils
 import {GlobalAutoRefresher} from 'src/utils/AutoRefresher'
 import {getTimeRangeWithTimezone} from 'src/dashboards/selectors'
@@ -63,6 +65,8 @@ class RefreshingView extends PureComponent<Props, State> {
     const {id, ranges, properties, manualRefresh, annotations} = this.props
     const {submitToken} = this.state
 
+    // DO NOT REMOVE the CellEvent component.  it gathers metrics for performance that management requires.
+
     return (
       <TimeSeries
         cellID={id}
@@ -71,15 +75,18 @@ class RefreshingView extends PureComponent<Props, State> {
         key={manualRefresh}
       >
         {({giraffeResult, loading, errorMessage, isInitialFetch}) => (
-          <View
-            loading={loading}
-            error={errorMessage}
-            isInitial={isInitialFetch}
-            properties={properties}
-            result={giraffeResult}
-            timeRange={ranges}
-            annotations={annotations}
-          />
+          <React.Fragment>
+            <CellEvent id={id} type={properties.type} />
+            <View
+              loading={loading}
+              error={errorMessage}
+              isInitial={isInitialFetch}
+              properties={properties}
+              result={giraffeResult}
+              timeRange={ranges}
+              annotations={annotations}
+            />
+          </React.Fragment>
         )}
       </TimeSeries>
     )


### PR DESCRIPTION
summary:  restored CellEvent.tsx from the grave and put it back into RefreshingView.  

<hr>

details:


restored CellEvent component; via git:
```
  jill@jills-mbp ui % git co 9a6185cdca57b6bc90d125d0fc21557ba4b52e36~1 src/perf/components/CellEvent.tsx
Updated 1 path from 55cdf267d
```

put it back into RefreshingView, this time paired with the View (was the ViewSwitcher before the big refactor by @drdelambre )

here is what the old RefreshingView used to look like:

(the render method)
```
  <>
              <ViewLoadingSpinner loading={loading} />
              <EmptyQueryView
                errorFormat={ErrorFormat.Scroll}
                errorMessage={errorMessage}
                hasResults={checkResultsLength(giraffeResult)}
                loading={loading}
                isInitialFetch={isInitialFetch}
                queries={this.queries}
                fallbackNote={this.fallbackNote}
              >
                <>
                  <CellEvent id={id} type={properties.type} />
                  <ViewSwitcher
                    files={files}
                    giraffeResult={giraffeResult}
                    properties={properties}
                    timeRange={ranges}
                    statuses={statuses}
                    timeZone={timeZone}
                    theme={theme}
                  />
                </>
              </EmptyQueryView>
            </>
```