### PR TITLE
feat: add metrics to annotations rendering code

### DIFF
--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -58,6 +58,7 @@ import {
   defaultYColumn,
 } from 'src/shared/utils/vis'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import {event} from 'src/cloud/utils/reporting'
 
 interface Props extends VisualizationProps {
   properties: XYViewProperties
@@ -176,6 +177,7 @@ const XYPlot: FC<Props> = ({properties, result, timeRange, annotations}) => {
   const makeSingleClickHandler = () => {
     const createAnnotation = userModifiedAnnotation => {
       const {message, startTime} = userModifiedAnnotation
+      event('xyplot.annotations.create_annotation.create')
       dispatch(
         writeThenFetchAndSetAnnotations([
           {
@@ -190,6 +192,7 @@ const XYPlot: FC<Props> = ({properties, result, timeRange, annotations}) => {
     const singleClickHandler = (
       plotInteraction: InteractionHandlerArguments
     ) => {
+      event('xyplot.annotations.create_annotation.show_overlay')
       dispatch(
         showOverlay(
           'add-annotation',
@@ -197,7 +200,10 @@ const XYPlot: FC<Props> = ({properties, result, timeRange, annotations}) => {
             createAnnotation,
             startTime: plotInteraction.valueX,
           },
-          dismissOverlay
+          () => {
+            event('xyplot.annotations.create_annotation.cancel')
+            dismissOverlay()
+          }
         )
       )
     }


### PR DESCRIPTION
connects #728

- [x] A graph is clicked to start the add annotation process
- [x] An annotation is created (Annotation form is submitted)
- [x] An annotation overlay is canceled without being created

- [ ] [E2E Tests pass in k8s-idpe](https://docs.influxdata.io/development/guides/local-development/#three-ways-to-run-the-ui-e2e-tests-against-the-kind-cluster) (applicable only if you edited Cypress tests)
