### PR TITLE
fix: validate variables and flag when renaming is required

### DIFF
--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -1332,7 +1332,7 @@ describe('DataExplorer', () => {
     })
 
     describe('as variable', () => {
-      const variableName = 'var 1'
+      const variableName = 'var1'
 
       const visitVariables = () => {
         cy.fixture('routes').then(({orgs}) => {

--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -1367,6 +1367,23 @@ describe('DataExplorer', () => {
         visitVariables()
         cy.getByTestID(`variable-card--name ${variableName}`).should('exist')
       })
+
+      it('can prevent saving variable names with hyphens or spaces', () => {
+        cy.getByTestID('overlay--container').within(() => {
+          cy.getByTestID('variable-form-save').should('be.disabled')
+          cy.getByTestID('flux-editor').should('be.visible')
+          cy.getByTestID('flux-editor').click()
+          cy.getByTestID('variable-name-input')
+            .click()
+            .type('bad name')
+          cy.getByTestID('variable-form-save').should('be.disabled')
+
+          cy.getByTestID('variable-name-input')
+            .clear()
+            .type('bad-name')
+          cy.getByTestID('variable-form-save').should('be.disabled')
+        })
+      })
     })
   })
 

--- a/cypress/e2e/shared/variables.test.ts
+++ b/cypress/e2e/shared/variables.test.ts
@@ -258,6 +258,82 @@ describe('Variables', () => {
     cy.getByTestID('import-overlay--textarea').contains('this is invalid')
   })
 
+  it('can prevent variable names with hyphens or spaces from being saved', () => {
+    // Prevent creation of a CSV variable with hyphens or spaces
+    cy.getByTestID('add-resource-dropdown--button').should('be.visible')
+    cy.getByTestID('add-resource-dropdown--button').click()
+
+    cy.getByTestID('add-resource-dropdown--new').should('be.visible')
+    cy.getByTestID('add-resource-dropdown--new').click()
+
+    cy.getByTestID('variable-type-dropdown--button').should('be.visible')
+    cy.getByTestID('variable-type-dropdown--button').click()
+
+    cy.getByTestID('variable-type-dropdown--button').should('be.visible')
+    cy.getByTestID('variable-type-dropdown-constant').click()
+
+    cy.get('textarea').type('1,2,3,4,5,6')
+
+    cy.getByTestID('csv-value-select-dropdown')
+      .click()
+      .contains('6')
+      .click()
+
+    cy.getByInputName('name').type('bad name')
+    cy.getByTestID('variable-form-save').should('be.disabled')
+
+    cy.getByInputName('name')
+      .clear()
+      .type('bad-name')
+    cy.getByTestID('variable-form-save').should('be.disabled')
+
+    // Prevent creation of a Query variable with hyphens or spaces
+    cy.getByTestID('variable-type-dropdown--button').click()
+    cy.getByTestID('variable-type-dropdown-query').click()
+
+    cy.getByTestID('flux-editor').within(() => {
+      cy.get('.react-monaco-editor-container')
+        .click()
+        .focused()
+        .type('filter(fn: (r) => r._field == "cpu")', {
+          force: true,
+        })
+    })
+
+    cy.getByInputName('name')
+      .clear()
+      .type('bad name')
+    cy.getByTestID('variable-form-save').should('be.disabled')
+
+    cy.getByInputName('name')
+      .clear()
+      .type('bad-name')
+    cy.getByTestID('variable-form-save').should('be.disabled')
+
+    // Prevent creation of a Map variable with hyphens or spaces
+    cy.getByTestID('variable-type-dropdown--button').click()
+    cy.getByTestID('variable-type-dropdown-map').click()
+
+    const lastMapItem = 'Mila Emile,"o61AhpOGr5aO3cYVArC0"'
+    cy.get('textarea').type(`Juanito MacNeil,"5TKl6l8i4idg15Fxxe4P"
+    Astrophel Chaudhary,"bDhZbuVj5RV94NcFXZPm"
+    Ochieng Benes,"YIhg6SoMKRUH8FMlHs3V"
+    ${lastMapItem}`)
+
+    cy.getByTestID('map-variable-dropdown--button').click()
+    cy.contains(lastMapItem).click()
+
+    cy.getByInputName('name')
+      .clear()
+      .type('bad name')
+    cy.getByTestID('variable-form-save').should('be.disabled')
+
+    cy.getByInputName('name')
+      .clear()
+      .type('bad-name')
+    cy.getByTestID('variable-form-save').should('be.disabled')
+  })
+
   it('can create and delete a label and sort by variable name', () => {
     cy.getByTestID('inline-labels--add').should('be.visible')
 

--- a/cypress/e2e/shared/variables.test.ts
+++ b/cypress/e2e/shared/variables.test.ts
@@ -144,7 +144,7 @@ describe('Variables', () => {
 
     cy.getByTestID('danger-confirmation-button').click()
 
-    cy.getByInputName('name').type('-renamed')
+    cy.getByInputName('name').type('Renamed')
 
     cy.getByTestID('rename-variable-submit').click()
 
@@ -152,7 +152,7 @@ describe('Variables', () => {
     cy.getByTestID('notification-success--dismiss').click()
 
     cy.getByTestID(`variable-card--name Little Variable-renamed`).contains(
-      '-renamed'
+      'Renamed'
     )
 
     // Create a Map variable from scratch

--- a/cypress/e2e/shared/variables.test.ts
+++ b/cypress/e2e/shared/variables.test.ts
@@ -133,7 +133,7 @@ describe('Variables', () => {
 
     cy.getByTestID('resource-card variable')
       .should('have.length', 1)
-      .contains('Little Variable')
+      .contains('LittleVariable')
 
     // Rename the variable
     cy.getByTestID('context-menu')
@@ -151,7 +151,7 @@ describe('Variables', () => {
     cy.getByTestID('notification-success--dismiss').should('exist')
     cy.getByTestID('notification-success--dismiss').click()
 
-    cy.getByTestID(`variable-card--name Little Variable-renamed`).contains(
+    cy.getByTestID(`variable-card--name LittleVariableRenamed`).contains(
       'Renamed'
     )
 

--- a/cypress/e2e/shared/variables.test.ts
+++ b/cypress/e2e/shared/variables.test.ts
@@ -46,7 +46,7 @@ describe('Variables', () => {
     cy.getByTestID('variable-type-dropdown-constant').click()
 
     // Create a CSV variable
-    const variableName = 'a Second Variable'
+    const variableName = 'AnotherVariable'
     cy.getByInputName('name').type(variableName)
 
     cy.get('textarea').type('1,2,3,4,5,6')
@@ -163,7 +163,7 @@ describe('Variables', () => {
     cy.getByTestID('variable-type-dropdown--button').click()
     cy.getByTestID('variable-type-dropdown-map').click()
 
-    const mapVariableName = 'Map Variable'
+    const mapVariableName = 'MapVariable'
     cy.getByInputName('name').type(mapVariableName)
 
     cy.get('textarea').type(`Astrophel Chaudhary,"bDhZbuVj5RV94NcFXZPm"
@@ -190,7 +190,7 @@ describe('Variables', () => {
     cy.getByTestID('variable-type-dropdown--button').click()
     cy.getByTestID('variable-type-dropdown-map').click()
 
-    const queryVariableName = 'Query Variable'
+    const queryVariableName = 'QueryVariable'
     cy.getByInputName('name').type(queryVariableName)
 
     cy.getByTestID('variable-type-dropdown--button').click()
@@ -284,8 +284,8 @@ describe('Variables', () => {
     cy.getByTestID('variable-type-dropdown-constant').click()
 
     // Create a CSV variable
-    const variableName = 'a Second Variable'
-    const defaultVar = 'Little Variable'
+    const variableName = 'SecondVariable'
+    const defaultVar = 'LittleVariable'
     cy.getByInputName('name').type(variableName)
 
     cy.get('textarea').type('1,2,3,4,5,6')

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -248,7 +248,7 @@ export const createTask = (
 
 export const createQueryVariable = (
   orgID?: string,
-  name: string = 'Little Variable',
+  name: string = 'LittleVariable',
   query?: string
 ): Cypress.Chainable<Cypress.Response> => {
   const argumentsObj = {

--- a/mocks/dummyData.ts
+++ b/mocks/dummyData.ts
@@ -271,7 +271,7 @@ export const tasks: Task[] = [
 
 export const variables: Variable[] = [
   {
-    name: 'a little variable',
+    name: 'LittleVariable',
     orgID: '0',
     arguments: {
       type: 'query',

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "webpack-merge": "^4.2.1"
   },
   "dependencies": {
-    "@influxdata/clockface": "^2.6.3",
+    "@influxdata/clockface": "^2.6.4",
     "@influxdata/flux": "^0.5.1",
     "@influxdata/flux-lsp-browser": "^0.5.35",
     "@influxdata/giraffe": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "webpack-merge": "^4.2.1"
   },
   "dependencies": {
-    "@influxdata/clockface": "^2.6.4",
+    "@influxdata/clockface": "^2.6.6",
     "@influxdata/flux": "^0.5.1",
     "@influxdata/flux-lsp-browser": "^0.5.35",
     "@influxdata/giraffe": "^2.4.0",

--- a/src/variables/components/RenameVariableForm.tsx
+++ b/src/variables/components/RenameVariableForm.tsx
@@ -49,12 +49,13 @@ class RenameVariableOverlayForm extends PureComponent<Props, State> {
       <Form onSubmit={this.handleSubmit}>
         <Grid>
           <Grid.Row>
-            <Grid.Column widthXS={Columns.Six}>
+            <Grid.Column>
               <div className="overlay-flux-editor--spacing">
                 <Form.ValidationElement
                   label="Name"
                   value={workingVariable.name}
                   required={true}
+                  prevalidate={true}
                   validationFunc={this.handleNameValidation}
                 >
                   {status => (
@@ -110,7 +111,8 @@ class RenameVariableOverlayForm extends PureComponent<Props, State> {
 
   private handleNameValidation = (name: string) => {
     const {variables} = this.props
-    const {error} = validateVariableName(name, variables)
+    const {workingVariable} = this.state
+    const {error} = validateVariableName(variables, name, workingVariable.id)
 
     this.setState({isNameValid: !error})
 

--- a/src/variables/components/RenameVariableForm.tsx
+++ b/src/variables/components/RenameVariableForm.tsx
@@ -5,7 +5,7 @@ import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
-import {Form, Input, Button, Grid, Columns} from '@influxdata/clockface'
+import {Form, Input, Button, Grid} from '@influxdata/clockface'
 
 // Utils
 import {validateVariableName} from 'src/variables/utils/validation'

--- a/src/variables/components/VariableCard.tsx
+++ b/src/variables/components/VariableCard.tsx
@@ -4,7 +4,12 @@ import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
-import {ResourceCard} from '@influxdata/clockface'
+import {
+  Alert,
+  ComponentColor,
+  IconFont,
+  ResourceCard,
+} from '@influxdata/clockface'
 import InlineLabels from 'src/shared/components/inlineLabels/InlineLabels'
 import VariableContextMenu from 'src/variables/components/VariableContextMenu'
 
@@ -20,8 +25,8 @@ import ErrorBoundary from 'src/shared/components/ErrorBoundary'
 
 interface OwnProps {
   variable: Variable
+  description?: string
   onDeleteVariable: (variable: Variable) => void
-  onEditVariable: (variable: Variable) => void
   onFilterChange: (searchTerm: string) => void
 }
 
@@ -32,7 +37,7 @@ class VariableCard extends PureComponent<
   Props & RouteComponentProps<{orgID: string}>
 > {
   public render() {
-    const {variable, onDeleteVariable} = this.props
+    const {variable, description, onDeleteVariable} = this.props
 
     return (
       <ErrorBoundary>
@@ -52,6 +57,16 @@ class VariableCard extends PureComponent<
             name={variable.name}
             testID={`variable-card--name ${variable.name}`}
           />
+          {description ? (
+            <>
+              <Alert
+                icon={IconFont.AlertTriangle}
+                color={ComponentColor.Warning}
+              >
+                {description}
+              </Alert>
+            </>
+          ) : null}
           <ResourceCard.Meta>
             <>Type: {variable.arguments.type}</>
           </ResourceCard.Meta>

--- a/src/variables/components/VariableCard.tsx
+++ b/src/variables/components/VariableCard.tsx
@@ -4,17 +4,16 @@ import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
-import {
-  Alert,
-  ComponentColor,
-  IconFont,
-  ResourceCard,
-} from '@influxdata/clockface'
+import {ComponentStatus, ResourceCard} from '@influxdata/clockface'
 import InlineLabels from 'src/shared/components/inlineLabels/InlineLabels'
 import VariableContextMenu from 'src/variables/components/VariableContextMenu'
 
 // Types
-import {Label, Variable} from 'src/types'
+import {AppState, Label, Variable} from 'src/types'
+
+// Utils
+import {getVariables} from 'src/variables/selectors'
+import {validateVariableName} from 'src/variables/utils/validation'
 
 // Actions
 import {
@@ -25,7 +24,6 @@ import ErrorBoundary from 'src/shared/components/ErrorBoundary'
 
 interface OwnProps {
   variable: Variable
-  description?: string
   onDeleteVariable: (variable: Variable) => void
   onFilterChange: (searchTerm: string) => void
 }
@@ -37,7 +35,11 @@ class VariableCard extends PureComponent<
   Props & RouteComponentProps<{orgID: string}>
 > {
   public render() {
-    const {variable, description, onDeleteVariable} = this.props
+    const {variable, variables, onDeleteVariable} = this.props
+
+    const {error} = validateVariableName(variables, variable.name, variable.id)
+    const errorMessage = (error && `Rename required. ${error}`) ?? null
+    const status = error ? ComponentStatus.Error : ComponentStatus.Default
 
     return (
       <ErrorBoundary>
@@ -56,17 +58,9 @@ class VariableCard extends PureComponent<
             onClick={this.handleNameClick}
             name={variable.name}
             testID={`variable-card--name ${variable.name}`}
+            errorMessage={errorMessage}
+            status={status}
           />
-          {description ? (
-            <>
-              <Alert
-                icon={IconFont.AlertTriangle}
-                color={ComponentColor.Warning}
-              >
-                {description}
-              </Alert>
-            </>
-          ) : null}
           <ResourceCard.Meta>
             <>Type: {variable.arguments.type}</>
           </ResourceCard.Meta>
@@ -126,11 +120,17 @@ class VariableCard extends PureComponent<
   }
 }
 
+const mstp = (state: AppState) => {
+  const variables = getVariables(state)
+
+  return {variables}
+}
+
 const mdtp = {
   onAddVariableLabel: addVariableLabelAsync,
   onRemoveVariableLabel: removeVariableLabelAsync,
 }
 
-const connector = connect(null, mdtp)
+const connector = connect(mstp, mdtp)
 
 export default connector(withRouter(VariableCard))

--- a/src/variables/components/VariableForm.tsx
+++ b/src/variables/components/VariableForm.tsx
@@ -61,6 +61,7 @@ export default class VariableForm extends PureComponent<Props, State> {
                   label="Name"
                   value={name}
                   required={true}
+                  prevalidate={true}
                   validationFunc={this.handleNameValidation}
                 >
                   {status => (
@@ -248,7 +249,7 @@ export default class VariableForm extends PureComponent<Props, State> {
 
   private handleNameValidation = (name: string) => {
     const {variables} = this.props
-    const {error} = validateVariableName(name, variables)
+    const {error} = validateVariableName(variables, name)
 
     this.setState({isNameValid: !error})
 

--- a/src/variables/components/VariableFormContext.test.tsx
+++ b/src/variables/components/VariableFormContext.test.tsx
@@ -41,7 +41,7 @@ describe('VariableFormContext', () => {
     // because it is using selectors, so we are just going to mock these props manually
     const actions = setup({
       variables: {},
-      name: 'some name',
+      name: 'someName',
       variableType: 'constant',
       query: {
         type: 'query',

--- a/src/variables/components/VariableFormContext.test.tsx
+++ b/src/variables/components/VariableFormContext.test.tsx
@@ -40,7 +40,7 @@ describe('VariableFormContext', () => {
     // (gene: mstp): We are unable to mock mstp that this component depends on w/o enzyme
     // because it is using selectors, so we are just going to mock these props manually
     const actions = setup({
-      variables: {},
+      variables: [],
       name: 'someName',
       variableType: 'constant',
       query: {

--- a/src/variables/components/VariableList.tsx
+++ b/src/variables/components/VariableList.tsx
@@ -12,12 +12,6 @@ import {Sort} from '@influxdata/clockface'
 
 // Selectors
 import {getSortedResources} from 'src/shared/utils/sort'
-import {validateVariableName} from '../utils/validation'
-
-interface ValidatedVariable {
-  description: string
-  variable: Variable
-}
 
 interface Props {
   variables: Variable[]
@@ -45,35 +39,14 @@ const VariableList: FC<Props> = props => {
     [variables, sortKey, sortDirection, sortType]
   )
 
-  const validatedVariables = useMemo(
-    () =>
-      sortedVariables.map(variable => {
-        const validated: ValidatedVariable = {
-          description: '',
-          variable,
-        }
-        const {error} = validateVariableName(
-          sortedVariables,
-          variable.name,
-          variable.id
-        )
-        if (error) {
-          validated.description = `Please rename. ${error}`
-        }
-        return validated
-      }),
-    [sortedVariables]
-  )
-
   return (
     <>
       <ResourceList>
         <ResourceList.Body emptyState={emptyState}>
-          {validatedVariables.map(({description, variable}, index) => (
+          {sortedVariables.map((variable, index) => (
             <VariableCard
               key={variable.id || `variable-${index}`}
               variable={variable}
-              description={description}
               onDeleteVariable={onDeleteVariable}
               onFilterChange={onFilterChange}
             />

--- a/src/variables/components/VariablesTab.test.tsx
+++ b/src/variables/components/VariablesTab.test.tsx
@@ -199,7 +199,7 @@ describe('the variables ui functionality', () => {
       fireEvent.click(queryTypeOption)
 
       const variableName = getByTestId('variable-name-input')
-      fireEvent.change(variableName, {target: {value: 'Test variable name'}})
+      fireEvent.change(variableName, {target: {value: 'TestVariableName'}})
 
       const mapQueryTextArea = getByTestId('map-variable-textarea')
       fireEvent.change(mapQueryTextArea, {target: {value: 'sample,value'}})
@@ -243,7 +243,7 @@ describe('the variables ui functionality', () => {
       fireEvent.click(queryTypeOption)
 
       const variableName = getByTestId('variable-name-input')
-      fireEvent.change(variableName, {target: {value: 'Test variable name'}})
+      fireEvent.change(variableName, {target: {value: 'TestVariableName'}})
 
       const csvQueryTextArea = getByTestId('csv-variable-textarea')
       fireEvent.change(csvQueryTextArea, {target: {value: 'sample,value'}})
@@ -288,7 +288,7 @@ describe('the variables ui functionality', () => {
       fireEvent.click(queryTypeOption)
 
       const variableName = getByTestId('variable-name-input')
-      fireEvent.change(variableName, {target: {value: 'Test variable name'}})
+      fireEvent.change(variableName, {target: {value: 'TestVariableName'}})
 
       store.dispatch({
         type: 'UPDATE_VARIABLE_EDITOR_QUERY',

--- a/src/variables/components/VariablesTab.test.tsx
+++ b/src/variables/components/VariablesTab.test.tsx
@@ -222,7 +222,7 @@ describe('the variables ui functionality', () => {
 
       const [notifyCallArguments] = mocked(notify).mock.calls
       const [notifyMessage] = notifyCallArguments
-      expect(notifyMessage).toEqual(createVariableSuccess('Test variable name'))
+      expect(notifyMessage).toEqual(createVariableSuccess('TestVariableName'))
     })
     it('can create a Variable of CSV type', async () => {
       const dropdownCreateButton = getByTestId('add-resource-dropdown--button')
@@ -267,7 +267,7 @@ describe('the variables ui functionality', () => {
 
       const [notifyCallArguments] = mocked(notify).mock.calls
       const [notifyMessage] = notifyCallArguments
-      expect(notifyMessage).toEqual(createVariableSuccess('Test variable name'))
+      expect(notifyMessage).toEqual(createVariableSuccess('TestVariableName'))
     })
     it('can create a Variable of Query type', async () => {
       const dropdownCreateButton = getByTestId('add-resource-dropdown--button')
@@ -309,7 +309,7 @@ describe('the variables ui functionality', () => {
 
       const [notifyCallArguments] = mocked(notify).mock.calls
       const [notifyMessage] = notifyCallArguments
-      expect(notifyMessage).toEqual(createVariableSuccess('Test variable name'))
+      expect(notifyMessage).toEqual(createVariableSuccess('TestVariableName'))
     })
   })
   describe('the variable editing process', () => {

--- a/src/variables/utils/validation.ts
+++ b/src/variables/utils/validation.ts
@@ -7,9 +7,15 @@ import {
 
 const reservedVarNames = [TIME_RANGE_START, TIME_RANGE_STOP, WINDOW_PERIOD]
 
+// Two ways to use:
+//   1) varName is a new variable being created and must pass validation
+//      - id is not needed since it does not exist yet
+//   2) varName is an existing variable and must pass validation
+//      - must also include the variable's id as third argument
 export const validateVariableName = (
+  variables: Variable[],
   varName: string,
-  variables: Variable[]
+  id?: string
 ): {error: string | null} => {
   if ((varName || '').match(/^\s*$/)) {
     return {error: 'Variable name cannot be empty'}
@@ -27,9 +33,12 @@ export const validateVariableName = (
     }
   }
 
-  const matchingName = variables.find(
-    v => v.name.toLocaleLowerCase() === lowerName
-  )
+  const matchingName = variables.find(v => {
+    if (!id) {
+      return v.name.toLocaleLowerCase() === lowerName
+    }
+    return v.id !== id && v.name.toLocaleLowerCase() === lowerName // this prevents triggering a match on a Variable's own name
+  })
 
   if (!!matchingName) {
     return {
@@ -45,7 +54,7 @@ export const validateVariableName = (
 
   if (/[-\s]+/g.test(varName)) {
     return {
-      error: `Variable name must not contain any hyphens or spaces`,
+      error: `Variable name must not have any hyphens or spaces`,
     }
   }
 

--- a/src/variables/utils/validation.ts
+++ b/src/variables/utils/validation.ts
@@ -43,5 +43,11 @@ export const validateVariableName = (
     }
   }
 
+  if (/[-\s]+/g.test(varName)) {
+    return {
+      error: `Variable name must not contain any hyphens or spaces`,
+    }
+  }
+
   return {error: null}
 }

--- a/src/variables/utils/validation.ts
+++ b/src/variables/utils/validation.ts
@@ -33,7 +33,7 @@ export const validateVariableName = (
     }
   }
 
-  const matchingName = variables.find(v => {
+  const matchingName = variables?.find(v => {
     if (!id) {
       return v.name.toLocaleLowerCase() === lowerName
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -782,10 +782,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@influxdata/clockface@^2.6.3":
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-2.6.3.tgz#836519591dac9a90449e4c55cfb475031bff0a02"
-  integrity sha512-44B6whe0wOZsscwvwfngyoZALQtbQzvtT6vgu/yPw88XMa1eVbtfQMJ00zf3YBuD4d2qAzzmBBF0ymdPQPS9Kg==
+"@influxdata/clockface@^2.6.4":
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-2.6.4.tgz#dd3534b0506de31fc98928c1f5232e61971f7559"
+  integrity sha512-PzWg2ovcVXL3rL/hNZRVue+kPTduOL99VKN4PK4Zh5070cpmzFzQhZJ+s2go2zyW1xZVGyypT355SNkJLx5wRA==
 
 "@influxdata/flux-lsp-browser@^0.5.35":
   version "0.5.35"

--- a/yarn.lock
+++ b/yarn.lock
@@ -782,10 +782,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@influxdata/clockface@^2.6.4":
-  version "2.6.4"
-  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-2.6.4.tgz#dd3534b0506de31fc98928c1f5232e61971f7559"
-  integrity sha512-PzWg2ovcVXL3rL/hNZRVue+kPTduOL99VKN4PK4Zh5070cpmzFzQhZJ+s2go2zyW1xZVGyypT355SNkJLx5wRA==
+"@influxdata/clockface@^2.6.6":
+  version "2.6.6"
+  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-2.6.6.tgz#5eeb42110da8e967eb8199a337e9923935d49fe1"
+  integrity sha512-bbEwkwWHFQvxrWa3yOWn65Th+/JdNVJp5Nzx55v93tIWa93O1H/q3sFp96lZbMA1WH8eO5mz1qvNDVAkqF4crw==
 
 "@influxdata/flux-lsp-browser@^0.5.35":
   version "0.5.35"


### PR DESCRIPTION
Closes #611 

Help the user create proper names for variables so that Flux does not complain with squiggly lines in the Script Editor. We do this in two ways:
- validate the variable names when manually creating or renaming
- flag the variables on the Variables tab (in Settings) that have bad names to let the user know to rename them

<img width="1680" alt="Screen Shot 2021-03-23 at 4 02 59 PM" src="https://user-images.githubusercontent.com/10736577/112229999-4a02aa80-8bf1-11eb-820e-9eb25628d0b6.png">

