### PR TITLE
feat: single cell dashboard refresh

### DIFF
--- a/cypress/e2e/shared/dashboardsView.test.ts
+++ b/cypress/e2e/shared/dashboardsView.test.ts
@@ -918,7 +918,7 @@ describe('Dashboard', () => {
   })
 
   it('can refresh a cell without refreshing the entire dashboard', () => {
-    cy.get('@org').then(({id: orgID}: Organization) => {
+    cy.get('@org').then(({id: orgID, name}: Organization) => {
       cy.createDashboard(orgID).then(({body}) => {
         cy.fixture('routes').then(({orgs}) => {
           cy.visit(`${orgs}/${orgID}/dashboards/${body.id}`)
@@ -928,24 +928,18 @@ describe('Dashboard', () => {
       cy.window().then(win => {
         win.influx.set('refreshSingleCell', true)
       })
-      cy.createQueryVariable(
-        orgID,
-        'depbuck',
-        `from(bucket: v.buckets)
-      |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
-      |> filter(fn: (r) => r["_measurement"] == "docker_container_cpu")
-      |> keep(columns: ["container_name"])
-      |> rename(columns: {"container_name": "_value"})
-      |> last()
-      |> group()`
-      )
-      cy.createQueryVariable(
-        orgID,
-        'buckets',
-        `buckets()
-        |> filter(fn: (r) => r.name !~ /^_/)
-        |> rename(columns: {name: "_value"})
-        |> keep(columns: ["_value"])`
+
+      cy.createBucket(orgID, name, 'schmucket')
+
+      const now = Date.now()
+      cy.writeData(
+        [
+          `test,container_name=cool dopeness=12 ${now - 1000}000000`,
+          `test,container_name=beans dopeness=18 ${now - 1200}000000`,
+          `test,container_name=cool dopeness=14 ${now - 1400}000000`,
+          `test,container_name=beans dopeness=10 ${now - 1600}000000`,
+        ],
+        'schmucket'
       )
     })
 
@@ -954,16 +948,13 @@ describe('Dashboard', () => {
     cy.getByTestID('switch-to-script-editor').click()
     cy.getByTestID('toolbar-tab').click()
 
-    const query1 = `from(bucket: v.buckets)
+    const query1 = `from(bucket: "schmucket")
 |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
-|> filter(fn: (r) => r["_measurement"] == "docker_container_cpu")
-|> filter(fn: (r) => r["_field"] == "usage_percent")`
+|> filter(fn: (r) => r["container_name"] == "cool")`
 
-    const query2 = `from(bucket: v.buckets)
+    const query2 = `from(bucket: "schmucket")
 |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
-|> filter(fn: (r) => r["_measurement"] == "docker_container_cpu")
-|> filter(fn: (r) => r["_field"] == "usage_percent")
-|> filter(fn: (r) => r["container_name"] == v.depbuck)`
+|> filter(fn: (r) => r["container_name"] == "beans")`
 
     cy.getByTestID('flux-editor')
       .should('be.visible')
@@ -984,12 +975,18 @@ describe('Dashboard', () => {
     cy.getByTestID('switch-to-script-editor').click()
     cy.getByTestID('toolbar-tab').click()
 
-    cy.getByTestID('flux-editor')
-      .should('be.visible')
-      .click()
-      .focused()
-      .type(query2)
-    cy.getByTestID('save-cell--button').click()
+    cy.getByTestID('overlay').within(() => {
+      cy.getByTestID('flux-editor')
+        .should('be.visible')
+        .click()
+        .focused()
+        .type(query2)
+      cy.getByTestID('save-cell--button').click()
+    })
+
+    cy.getByTestID('cell Name this Cell').within(() => {
+      cy.getByTestID('giraffe-inner-plot')
+    })
 
     cy.intercept('POST', 'query', req => {
       if (req.body.query === query1) {
@@ -999,7 +996,6 @@ describe('Dashboard', () => {
         throw new Error('Refreshed the wrong cell')
       }
     })
-
     cy.getByTestID('cell blah').within(() => {
       cy.getByTestID('cell-context--toggle').click()
     })

--- a/cypress/e2e/shared/dashboardsView.test.ts
+++ b/cypress/e2e/shared/dashboardsView.test.ts
@@ -1002,4 +1002,89 @@ describe('Dashboard', () => {
     cy.getByTestID('cell-context--refresh').click()
     cy.wait('@refreshCellQuery')
   })
+
+  it('can refresh the dashboard, which refreshes both cells', () => {
+    cy.get('@org').then(({id: orgID, name}: Organization) => {
+      cy.createDashboard(orgID).then(({body}) => {
+        cy.fixture('routes').then(({orgs}) => {
+          cy.visit(`${orgs}/${orgID}/dashboards/${body.id}`)
+          cy.getByTestID('tree-nav')
+        })
+      })
+      cy.window().then(win => {
+        win.influx.set('refreshSingleCell', true)
+      })
+
+      cy.createBucket(orgID, name, 'schmucket')
+
+      const now = Date.now()
+      cy.writeData(
+        [
+          `test,container_name=cool dopeness=12 ${now - 1000}000000`,
+          `test,container_name=beans dopeness=18 ${now - 1200}000000`,
+          `test,container_name=cool dopeness=14 ${now - 1400}000000`,
+          `test,container_name=beans dopeness=10 ${now - 1600}000000`,
+        ],
+        'schmucket'
+      )
+    })
+
+    cy.getByTestID('button').click()
+    cy.getByTestID('switch-to-script-editor').should('be.visible')
+    cy.getByTestID('switch-to-script-editor').click()
+    cy.getByTestID('toolbar-tab').click()
+
+    const query1 = `from(bucket: "schmucket")
+|> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+|> filter(fn: (r) => r["container_name"] == "cool")`
+
+    const query2 = `from(bucket: "schmucket")
+|> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+|> filter(fn: (r) => r["container_name"] == "beans")`
+
+    cy.getByTestID('flux-editor')
+      .should('be.visible')
+      .click()
+      .focused()
+      .type(query1)
+
+    cy.getByTestID('overlay').within(() => {
+      cy.getByTestID('page-title').click()
+      cy.getByTestID('renamable-page-title--input')
+        .clear()
+        .type('blah')
+      cy.getByTestID('save-cell--button').click()
+    })
+
+    cy.getByTestID('button').click()
+    cy.getByTestID('switch-to-script-editor').should('be.visible')
+    cy.getByTestID('switch-to-script-editor').click()
+    cy.getByTestID('toolbar-tab').click()
+
+    cy.getByTestID('overlay').within(() => {
+      cy.getByTestID('flux-editor')
+        .should('be.visible')
+        .click()
+        .focused()
+        .type(query2)
+      cy.getByTestID('save-cell--button').click()
+    })
+
+    cy.getByTestID('cell Name this Cell').within(() => {
+      cy.getByTestID('giraffe-inner-plot')
+    })
+
+    cy.intercept('POST', 'query', req => {
+      if (req.body.query === query1) {
+        req.alias = 'refreshCellQuery'
+      }
+      if (req.body.query === query2) {
+        req.alias = 'refreshSecondQuery'
+      }
+    })
+
+    cy.getByTestID('autorefresh-dropdown-refresh').click()
+    cy.wait('@refreshCellQuery')
+    cy.wait('@refreshSecondQuery')
+  })
 })

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -531,13 +531,16 @@ export const lines = (numLines = 3) => {
 }
 
 export const writeData = (
-  lines: string[]
+  lines: string[],
+  namedBucket?: string
 ): Cypress.Chainable<Cypress.Response> => {
   return cy.get<Organization>('@org').then((org: Organization) => {
     return cy.get<Bucket>('@bucket').then((bucket: Bucket) => {
       return cy.request({
         method: 'POST',
-        url: '/api/v2/write?org=' + org.name + '&bucket=' + bucket.name,
+        url:
+          '/api/v2/write?org=' + org.name + '&bucket=' + namedBucket ??
+          bucket.name,
         body: lines.join('\n'),
       })
     })

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -536,11 +536,10 @@ export const writeData = (
 ): Cypress.Chainable<Cypress.Response> => {
   return cy.get<Organization>('@org').then((org: Organization) => {
     return cy.get<Bucket>('@bucket').then((bucket: Bucket) => {
+      const bucketToUse = namedBucket ?? bucket.name
       return cy.request({
         method: 'POST',
-        url:
-          '/api/v2/write?org=' + org.name + '&bucket=' + namedBucket ??
-          bucket.name,
+        url: '/api/v2/write?org=' + org.name + '&bucket=' + bucketToUse,
         body: lines.join('\n'),
       })
     })

--- a/src/shared/components/RefreshingView.tsx
+++ b/src/shared/components/RefreshingView.tsx
@@ -25,6 +25,8 @@ interface OwnProps {
   id: string
   manualRefresh: number
   properties: QueryViewProperties
+  incrementSubmitToken: () => void
+  submitToken: number
 }
 
 interface StateProps {
@@ -33,13 +35,9 @@ interface StateProps {
   ranges: TimeRange | null
 }
 
-interface State {
-  submitToken: number
-}
-
 type Props = OwnProps & StateProps & RouteComponentProps<{orgID: string}>
 
-class RefreshingView extends PureComponent<Props, State> {
+class RefreshingView extends PureComponent<Props> {
   public static defaultProps = {
     inView: true,
     manualRefresh: 0,
@@ -47,21 +45,25 @@ class RefreshingView extends PureComponent<Props, State> {
 
   constructor(props) {
     super(props)
-
-    this.state = {submitToken: 0}
   }
 
   public componentDidMount() {
-    GlobalAutoRefresher.subscribe(this.incrementSubmitToken)
+    GlobalAutoRefresher.subscribe(this.props.incrementSubmitToken)
   }
 
   public componentWillUnmount() {
-    GlobalAutoRefresher.unsubscribe(this.incrementSubmitToken)
+    GlobalAutoRefresher.unsubscribe(this.props.incrementSubmitToken)
   }
 
   public render() {
-    const {id, ranges, properties, manualRefresh, annotations} = this.props
-    const {submitToken} = this.state
+    const {
+      id,
+      ranges,
+      properties,
+      manualRefresh,
+      annotations,
+      submitToken,
+    } = this.props
 
     return (
       <TimeSeries

--- a/src/shared/components/RefreshingView.tsx
+++ b/src/shared/components/RefreshingView.tsx
@@ -98,10 +98,6 @@ class RefreshingView extends PureComponent<Props> {
         return properties.queries
     }
   }
-
-  private incrementSubmitToken = () => {
-    this.setState({submitToken: Date.now()})
-  }
 }
 
 const mstp = (state: AppState, ownProps: OwnProps) => {

--- a/src/shared/components/cells/Cell.tsx
+++ b/src/shared/components/cells/Cell.tsx
@@ -27,13 +27,21 @@ interface OwnProps {
 }
 
 interface State {
-  inView: boolean
+  submitToken: number
 }
 
 type Props = StateProps & OwnProps
 
 @ErrorHandling
 class CellComponent extends Component<Props, State> {
+  state = {
+    submitToken: 0,
+  }
+
+  private handleIncrementToken = (): void => {
+    this.setState(s => ({...s, submitToken: s.submitToken + 1}))
+  }
+
   public render() {
     const {cell, view} = this.props
 
@@ -44,6 +52,7 @@ class CellComponent extends Component<Props, State> {
             cell={cell}
             view={view}
             onCSVDownload={this.handleCSVDownload}
+            onRefresh={this.handleIncrementToken}
           />
         </CellHeader>
         <div
@@ -103,6 +112,8 @@ class CellComponent extends Component<Props, State> {
         id={view.id}
         properties={view.properties}
         manualRefresh={manualRefresh}
+        incrementSubmitToken={this.handleIncrementToken}
+        submitToken={this.state.submitToken}
       />
     )
   }

--- a/src/shared/components/cells/CellContext.tsx
+++ b/src/shared/components/cells/CellContext.tsx
@@ -88,7 +88,9 @@ const CellContext: FC<Props> = ({
       Array.isArray(viewWithQueries.properties?.queries) &&
       viewWithQueries.properties.queries.length
     ) {
-      resetQueryCacheByQuery(viewWithQueries.properties.queries[0].text)
+      for (const query of viewWithQueries.properties.queries) {
+        resetQueryCacheByQuery(query.text)
+      }
     }
     onRefresh()
   }

--- a/src/shared/components/cells/CellContext.tsx
+++ b/src/shared/components/cells/CellContext.tsx
@@ -7,6 +7,7 @@ import classnames from 'classnames'
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'
+import {resetQueryCacheByQuery} from 'src/shared/apis/queryCache'
 
 // Components
 import {
@@ -24,12 +25,13 @@ import {FeatureFlag} from 'src/shared/utils/featureFlag'
 import {deleteCellAndView, createCellWithView} from 'src/cells/actions/thunks'
 
 // Types
-import {Cell, View} from 'src/types'
+import {Cell, View, ViewProperties, MarkdownViewProperties} from 'src/types'
 
 interface OwnProps {
   cell: Cell
   view: View
   onCSVDownload: () => void
+  onRefresh: () => void
 }
 
 type ReduxProps = ConnectedProps<typeof connector>
@@ -43,6 +45,7 @@ const CellContext: FC<Props> = ({
   onCloneCell,
   onDeleteCell,
   onCSVDownload,
+  onRefresh,
 }) => {
   const [popoverVisible, setPopoverVisibility] = useState<boolean>(false)
   const editNoteText = !!get(view, 'properties.note') ? 'Edit Note' : 'Add Note'
@@ -75,6 +78,20 @@ const CellContext: FC<Props> = ({
   const handleEditCell = (): void => {
     history.push(`${location.pathname}/cells/${cell.id}/edit`)
     event('editCell button Click')
+  }
+
+  const refreshCell = (): void => {
+    const viewWithQueries = view as View<
+      Exclude<ViewProperties, MarkdownViewProperties>
+    >
+    if (
+      Array.isArray(viewWithQueries.properties?.queries) &&
+      viewWithQueries.properties.queries.length
+    ) {
+      resetQueryCacheByQuery(viewWithQueries.properties.queries[0].text)
+    }
+    console.log('here')
+    onRefresh()
   }
 
   const popoverContents = (onHide): JSX.Element => {
@@ -138,6 +155,15 @@ const CellContext: FC<Props> = ({
           onHide={onHide}
           testID="cell-context--delete"
         />
+        <FeatureFlag name="refreshSingleCell">
+          <CellContextItem
+            label="Refresh"
+            onClick={refreshCell}
+            icon={IconFont.Refresh}
+            onHide={onHide}
+            testID="cell-context--refresh"
+          />
+        </FeatureFlag>
       </div>
     )
   }

--- a/src/shared/components/cells/CellContext.tsx
+++ b/src/shared/components/cells/CellContext.tsx
@@ -90,7 +90,6 @@ const CellContext: FC<Props> = ({
     ) {
       resetQueryCacheByQuery(viewWithQueries.properties.queries[0].text)
     }
-    console.log('here')
     onRefresh()
   }
 


### PR DESCRIPTION
Closes #

<!-- Describe your proposed changes here. -->
This PR introduces the ability to refresh a single dashboard cell, as opposed to the old behavior of having to refresh the entire dashboard. This should allow users to use up less queries. 


- [x] [E2E Tests pass in k8s-idpe](https://docs.influxdata.io/development/guides/local-development/#three-ways-to-run-the-ui-e2e-tests-against-the-kind-cluster) (applicable only if you edited Cypress tests)
