### PR TITLE
fix: various bug fixes in notebooks

### DIFF
--- a/src/flows/components/panel/Results.tsx
+++ b/src/flows/components/panel/Results.tsx
@@ -149,7 +149,10 @@ const ResultTable: FC<TableProps> = ({
         .fill(null)
         .map((_, idx) => {
           const cells = cols.map(c => (
-            <Table.Cell key={`t${tIdx}:h${c.name}:r${idx}`}>
+            <Table.Cell
+              key={`t${tIdx}:h${c.name}:r${idx}`}
+              testID={`table-cell ${c.data[idx]}`}
+            >
               {c.data[idx]}
             </Table.Cell>
           ))
@@ -171,7 +174,7 @@ const ResultTable: FC<TableProps> = ({
         </Table>
       )
     })
-  }, [height, startRow])
+  }, [height, startRow, results])
 
   return (
     <div className="query-results--container">

--- a/src/flows/context/flow.list.tsx
+++ b/src/flows/context/flow.list.tsx
@@ -297,7 +297,7 @@ export const FlowListProvider: FC = ({children}) => {
 
   const getAll = useCallback(async (): Promise<void> => {
     const data = await getAllAPI(orgID)
-    if (data.flows) {
+    if (data && data.flows) {
       const _flows = {}
       data.flows.forEach(f => (_flows[f.id] = hydrate(f.spec)))
       setFlows(_flows)

--- a/src/flows/context/pipe.tsx
+++ b/src/flows/context/pipe.tsx
@@ -1,4 +1,4 @@
-import React, {FC, useContext, useMemo} from 'react'
+import React, {FC, useContext, useMemo, useCallback} from 'react'
 import {PipeData, FluxResult} from 'src/types/flows'
 import {FlowContext} from 'src/flows/context/flow.current'
 import {ResultsContext} from 'src/flows/context/results'
@@ -50,9 +50,12 @@ export const PipeProvider: FC<PipeContextProps> = ({id, children}) => {
     stages.filter(stage => stage.instances.map(i => i.id).includes(id))[0]
       ?.text || ''
 
-  const updater = (_data: PipeData) => {
-    flow.data.update(id, _data)
-  }
+  const updater = useCallback(
+    (_data: PipeData) => {
+      flow.data.update(id, _data)
+    },
+    [flow, id]
+  )
 
   let _result
 

--- a/src/flows/pipes/MetricSelector/FieldSelectors.tsx
+++ b/src/flows/pipes/MetricSelector/FieldSelectors.tsx
@@ -42,6 +42,7 @@ const FieldSelectors: FC<Props> = ({fields}) => {
           title={field}
           gradient={Gradients.GundamPilot}
           wrapText={true}
+          testID={`field-selector ${field}`}
         >
           <List.Indicator type="dot" />
           <div className="selectors--item-value selectors--item__field">

--- a/src/flows/pipes/MetricSelector/FilterTags.tsx
+++ b/src/flows/pipes/MetricSelector/FilterTags.tsx
@@ -118,7 +118,7 @@ const FilterTags: FC = () => {
           <LabelComponent
             className="data-source--filter"
             id={f.id}
-            key={f.id}
+            key={f.name}
             name={f.name}
             color={f.properties.color}
             description={f.properties.description}

--- a/src/flows/pipes/MetricSelector/MeasurementSelectors.tsx
+++ b/src/flows/pipes/MetricSelector/MeasurementSelectors.tsx
@@ -42,6 +42,7 @@ const MeasurementSelectors: FC<Props> = ({measurements}) => {
           title={measurement}
           gradient={Gradients.GundamPilot}
           wrapText={true}
+          testID={`measurement-selector ${measurement}`}
         >
           <List.Indicator type="dot" />
           <div className="selectors--item-value selectors--item__measurement">

--- a/src/flows/pipes/MetricSelector/TagSelectors.tsx
+++ b/src/flows/pipes/MetricSelector/TagSelectors.tsx
@@ -126,6 +126,7 @@ const TagSelectors: FC<Props> = ({tags}) => {
                         title={tagValue}
                         gradient={Gradients.GundamPilot}
                         wrapText={true}
+                        testID={`tag-selector ${tagValue}`}
                       >
                         <List.Indicator type="dot" />
                         <div className="selectors--item-value selectors--item__tag">{`${tagName} = ${tagValue}`}</div>

--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -259,7 +259,7 @@ const XYPlot: FC<Props> = ({properties, result, timeRange, annotations}) => {
 
     // we want to check what annotations are enabled
     visibleAnnotationStreams.forEach(visibleStreamName => {
-      if (annotations[visibleStreamName]) {
+      if (annotations && annotations[visibleStreamName]) {
         const correspondingStream = annotationStreams.find(
           stream => stream.stream === visibleStreamName
         )


### PR DESCRIPTION
Closes #890

- Fixes issue where results table doesn't show results from latest query due to memoization
- Fixes issue where visualization panel shows "an error has occurred" after executing some queries due to recent annotations changes to time machine
- Fixes issue where multiple list items in metric selector had the same key
- Adds e2e test for metric selector
- Adds testIDs to some components to make testing easier

- [x] [E2E Tests pass in k8s-idpe](https://docs.influxdata.io/development/guides/local-development/#three-ways-to-run-the-ui-e2e-tests-against-the-kind-cluster) (applicable only if you edited Cypress tests)
