### PR TITLE
chore: updated the CSV uploader to have helpful links to annotation docs, added eventing and removed HB notifications for most errors

### DIFF
--- a/src/buckets/components/context/csvUploaderProvider.tsx
+++ b/src/buckets/components/context/csvUploaderProvider.tsx
@@ -5,6 +5,7 @@ import {useSelector, useDispatch} from 'react-redux'
 
 // Utils
 import {postWrite} from 'src/client'
+import {event} from 'src/cloud/utils/reporting'
 import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
 
 // Selectors
@@ -74,9 +75,16 @@ export const CsvUploaderProvider: FC<Props> = React.memo(({children}) => {
 
   const handleError = (error: Error): void => {
     setUploadState(RemoteDataState.Error)
-    reportErrorThroughHoneyBadger(error, {
-      name: 'uploadCsv function',
-    })
+    if (error.name === 'AbortError') {
+      event('Aborting_CSV_Upload')
+    }
+    if (error.message.includes('incorrectly formatted')) {
+      event('CSV_Upload_Format_Error')
+    } else {
+      reportErrorThroughHoneyBadger(error, {
+        name: 'uploadCsv function',
+      })
+    }
     const message = getErrorMessage(error)
     dispatch(notify(csvUploaderErrorNotification(message)))
   }

--- a/src/buckets/components/csvUploader/CsvUploaderBody.tsx
+++ b/src/buckets/components/csvUploader/CsvUploaderBody.tsx
@@ -12,6 +12,7 @@ import {CsvUploaderContext} from 'src/buckets/components/context/csvUploaderProv
 
 // Utils
 import {getByID} from 'src/resources/selectors'
+import {event} from 'src/cloud/utils/reporting'
 
 // Types
 import {AppState, Bucket, RemoteDataState, ResourceType} from 'src/types'
@@ -26,6 +27,7 @@ const CsvUploaderBody: FC = () => {
     )?.name ?? ''
 
   const handleUploadCsv = (csv: string) => {
+    event('Uploading_CSV')
     uploadCsv(csv, bucket)
   }
 

--- a/src/buckets/components/csvUploader/CsvUploaderHelperText.tsx
+++ b/src/buckets/components/csvUploader/CsvUploaderHelperText.tsx
@@ -1,0 +1,19 @@
+// Libraries
+import React, {FC} from 'react'
+
+const CsvUploaderHelperText: FC<{}> = () => {
+  return (
+    <p>
+      Need help writing InfluxDB Annotated CSV ?{' '}
+      <a
+        href="https://docs.influxdata.com/influxdb/v2.0/reference/syntax/annotated-csv/"
+        target="_blank"
+        rel="noreferrer"
+      >
+        See Documentation
+      </a>
+    </p>
+  )
+}
+
+export default CsvUploaderHelperText

--- a/src/buckets/components/csvUploader/CsvUploaderWizard.tsx
+++ b/src/buckets/components/csvUploader/CsvUploaderWizard.tsx
@@ -14,6 +14,7 @@ import {
 
 // Utils
 import {getOrg} from 'src/organizations/selectors'
+import {event} from 'src/cloud/utils/reporting'
 
 // Context
 import {CsvUploaderContext} from 'src/buckets/components/context/csvUploaderProvider'
@@ -22,6 +23,7 @@ import {CsvUploaderContext} from 'src/buckets/components/context/csvUploaderProv
 import CsvUploaderBody from 'src/buckets/components/csvUploader/CsvUploaderBody'
 import CsvUploaderSuccess from 'src/buckets/components/csvUploader/CsvUploaderSuccess'
 import CsvUploaderError from 'src/buckets/components/csvUploader/CsvUploaderError'
+import CsvUploaderHelperText from 'src/buckets/components/csvUploader/CsvUploaderHelperText'
 
 // Types
 import {RemoteDataState} from 'src/types'
@@ -43,6 +45,9 @@ const CsvUploaderWizard = () => {
 
   const org = useSelector(getOrg)
   const handleDismiss = useCallback(() => {
+    if (uploadState === RemoteDataState.Loading) {
+      event('CSV_Upload_Cancelled')
+    }
     history.push(`/orgs/${org.id}/load-data/buckets`)
     resetUploadState()
   }, [history, org.id, resetUploadState])
@@ -57,6 +62,7 @@ const CsvUploaderWizard = () => {
         <Form>
           <Overlay.Body style={{textAlign: 'center'}}>
             {getCsvBody(uploadState)}
+            <CsvUploaderHelperText />
           </Overlay.Body>
         </Form>
         <OverlayFooter>


### PR DESCRIPTION
This PR adds a link to the docs to describe what Annotation CSV format is. It also differentiates between actual errors and abort & incorrectly formatted CSV errors to reduce HB noise. Lastly, it adds events in places so we can get an idea of how people are using the uploader

Closes #893 

<!-- Describe your proposed changes here. -->

- [ ] [E2E Tests pass in k8s-idpe](https://docs.influxdata.io/development/guides/local-development/#three-ways-to-run-the-ui-e2e-tests-against-the-kind-cluster) (applicable only if you edited Cypress tests)
