### PR TITLE
fix: add reference to ResizeObserver for typescript

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,7 +29,7 @@ module.exports = {
     },
   },
   rules: {
-    'spaced-comment': ['error', 'always'],
+    'spaced-comment': ['error', 'always', {markers: ['/']}],
     curly: ['error', 'all'],
     'no-console': ['error', {allow: ['warn', 'error']}],
     'no-empty': 'off',

--- a/src/visualization/types/SimpleTable/PagedTable.tsx
+++ b/src/visualization/types/SimpleTable/PagedTable.tsx
@@ -1,3 +1,4 @@
+/// <reference types="resize-observer-browser" />
 import React, {FC, useContext, useRef, useEffect, useState} from 'react'
 import {DapperScrollbars} from '@influxdata/clockface'
 import {SubsetTable} from 'src/visualization/types/SimpleTable'


### PR DESCRIPTION
TypeScript is complaining about ResizeObserver in `PagedTable`. This is a suggested fix from [this thread.](https://github.com/Microsoft/TypeScript/issues/28502#issuecomment-739996219)

<!-- Describe your proposed changes here. -->

- [ ] [E2E Tests pass in k8s-idpe](https://docs.influxdata.io/development/guides/local-development/#three-ways-to-run-the-ui-e2e-tests-against-the-kind-cluster) (applicable only if you edited Cypress tests)
