### PR TITLE
chore: remove references to streams

### DIFF
--- a/src/annotations/actions/creators.ts
+++ b/src/annotations/actions/creators.ts
@@ -52,6 +52,7 @@ export const deleteAnnotation = (annotation: Annotation) =>
     annotation,
   } as const)
 
-export const toggleAnnotationVisibility = () => ({
+export const toggleAnnotationVisibility = () =>
+  ({
     type: TOGGLE_ANNOTATION_VISIBILITY,
   } as const)

--- a/src/annotations/actions/creators.ts
+++ b/src/annotations/actions/creators.ts
@@ -1,20 +1,21 @@
 import {Annotation, AnnotationResponse, AnnotationStream} from 'src/types'
 
-export const ENABLE_ANNOTATION_STREAM = 'ENABLE_ANNOTATION_STREAM'
+export const DELETE_ANNOTATION = 'DELETE_ANNOTATION'
 export const DISABLE_ANNOTATION_STREAM = 'DISABLE_ANNOTATION_STREAM'
-
+export const ENABLE_ANNOTATION_STREAM = 'ENABLE_ANNOTATION_STREAM'
 export const SET_ANNOTATIONS = 'SET_ANNOTATIONS'
 export const SET_ANNOTATION_STREAMS = 'SET_ANNOTATION_STREAMS'
+export const TOGGLE_ANNOTATION_VISIBILITY = 'TOGGLE_ANNOTATION_VISIBILITY'
 export const TOGGLE_SINGLE_CLICK_ANNOTATIONS = 'TOGGLE_SINGLE_CLICK_ANNOTATIONS'
-export const DELETE_ANNOTATION = 'DELETE_ANNOTATION'
 
 export type Action =
-  | ReturnType<typeof enableAnnotationStream>
+  | ReturnType<typeof deleteAnnotation>
   | ReturnType<typeof disableAnnotationStream>
+  | ReturnType<typeof enableAnnotationStream>
   | ReturnType<typeof setAnnotations>
   | ReturnType<typeof setAnnotationStreams>
+  | ReturnType<typeof toggleAnnotationVisibility>
   | ReturnType<typeof toggleSingleClickAnnotations>
-  | ReturnType<typeof deleteAnnotation>
 
 export const enableAnnotationStream = (streamID: string) =>
   ({
@@ -49,4 +50,8 @@ export const deleteAnnotation = (annotation: Annotation) =>
   ({
     type: DELETE_ANNOTATION,
     annotation,
+  } as const)
+
+export const toggleAnnotationVisibility = () => ({
+    type: TOGGLE_ANNOTATION_VISIBILITY,
   } as const)

--- a/src/annotations/components/controlBar/AnnotationsControlBar.test.tsx
+++ b/src/annotations/components/controlBar/AnnotationsControlBar.test.tsx
@@ -123,7 +123,9 @@ describe('the annotations control bar ui functionality', () => {
     cleanup()
   })
 
-  it('can search for streams', async () => {
+  // temporarily removing the notion of streams
+  // see https://github.com/influxdata/ui/issues/901
+  it.skip('can search for streams', async () => {
     const streamSearchBar = getByTestId('annotations-search-input')
 
     expect(streamSearchBar).toBeVisible()
@@ -145,7 +147,10 @@ describe('the annotations control bar ui functionality', () => {
 
     expect(not_default_suggestion).toBeVisible()
   })
-  it('can select stream from the available streams', async () => {
+
+  // temporarily removing the notion of streams
+  // see https://github.com/influxdata/ui/issues/901
+  it.skip('can select stream from the available streams', async () => {
     const streamSearchBar = getByTestId('annotations-search-input')
 
     expect(streamSearchBar).toBeVisible()
@@ -176,7 +181,10 @@ describe('the annotations control bar ui functionality', () => {
     const visibleStreamsByID = store.getState().annotations.visibleStreamsByID
     expect(visibleStreamsByID).toStrictEqual(['default', 'not_default'])
   })
-  it('can close the stream from the annotation pill', async () => {
+
+  // temporarily removing the notion of streams
+  // see https://github.com/influxdata/ui/issues/901
+  it.skip('can close the stream from the annotation pill', async () => {
     const streamSearchBar = getByTestId('annotations-search-input')
 
     expect(streamSearchBar).toBeVisible()
@@ -215,6 +223,7 @@ describe('the annotations control bar ui functionality', () => {
     const visibleStreamsByID = store.getState().annotations.visibleStreamsByID
     expect(visibleStreamsByID).toStrictEqual(['default'])
   })
+
   it('can enable the one click add annotation', async () => {
     const toggleButton = getByTestId('annotations-one-click-toggle')
 
@@ -226,6 +235,16 @@ describe('the annotations control bar ui functionality', () => {
       .enableSingleClickAnnotations
 
     // by default the annotations single click to add is enabled, above toggle disables it
-    expect(enableSingleClickAnnotations).toBe(false)
+    expect(enableSingleClickAnnotations).toBeFalsy()
+  })
+
+  it('can toggle the visibility of annotations (which are on by default)', async () => {
+    const toggleButton = getByTestId('annotations-visibility-toggle')
+
+    await waitFor(() => {
+      fireEvent.click(toggleButton)
+    })
+
+    expect(store.getState().annotations.annotationsAreVisible).toBeFalsy()
   })
 })

--- a/src/annotations/components/controlBar/AnnotationsControlBar.tsx
+++ b/src/annotations/components/controlBar/AnnotationsControlBar.tsx
@@ -1,19 +1,15 @@
 // Libraries
 import React, {FC} from 'react'
 import {useDispatch, useSelector} from 'react-redux'
-import {useHistory, useParams} from 'react-router-dom'
 
 // Components
 import {
   ComponentColor,
   ComponentSize,
-  FlexBox,
   FlexBoxChild,
-  IconFont,
   InputLabel,
   InputToggleType,
   JustifyContent,
-  SquareButton,
   Toggle,
 } from '@influxdata/clockface'
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
@@ -22,8 +18,6 @@ import {
   toggleAnnotationVisibility,
   toggleSingleClickAnnotations,
 } from 'src/annotations/actions/creators'
-import {AnnotationPills} from 'src/annotations/components/controlBar/AnnotationPills'
-import {AnnotationsSearchBar} from 'src/annotations/components/controlBar/AnnotationsSearchBar'
 
 // Selectors
 import {
@@ -35,9 +29,6 @@ import {
 import {event} from 'src/cloud/utils/reporting'
 
 export const AnnotationsControlBar: FC = () => {
-  const history = useHistory()
-  const {orgID} = useParams<{orgID: string; dashboardID: string}>()
-
   const inWriteMode = useSelector(isSingleClickAnnotationsEnabled)
   const annotationsAreVisible = useSelector(selectAreAnnotationsVisible)
 

--- a/src/annotations/components/controlBar/AnnotationsControlBar.tsx
+++ b/src/annotations/components/controlBar/AnnotationsControlBar.tsx
@@ -43,10 +43,6 @@ export const AnnotationsControlBar: FC = () => {
     dispatch(toggleSingleClickAnnotations())
   }
 
-  const handleSettingsClick = (): void => {
-    history.push(`/orgs/${orgID}/settings/annotations`)
-  }
-
   return (
     <ErrorBoundary>
       <Toolbar
@@ -75,11 +71,6 @@ export const AnnotationsControlBar: FC = () => {
               Enable 1-Click Annotations
             </InputLabel>
           </Toggle>
-          <SquareButton
-            testID="annotations-control-bar--settings"
-            icon={IconFont.CogThick}
-            onClick={handleSettingsClick}
-          />
         </FlexBox>
       </Toolbar>
     </ErrorBoundary>

--- a/src/annotations/components/controlBar/AnnotationsControlBar.tsx
+++ b/src/annotations/components/controlBar/AnnotationsControlBar.tsx
@@ -18,12 +18,18 @@ import {
 } from '@influxdata/clockface'
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
 import Toolbar from 'src/shared/components/toolbar/Toolbar'
-import {toggleSingleClickAnnotations} from 'src/annotations/actions/creators'
+import {
+  toggleAnnotationVisibility,
+  toggleSingleClickAnnotations,
+} from 'src/annotations/actions/creators'
 import {AnnotationPills} from 'src/annotations/components/controlBar/AnnotationPills'
 import {AnnotationsSearchBar} from 'src/annotations/components/controlBar/AnnotationsSearchBar'
 
 // Selectors
-import {isSingleClickAnnotationsEnabled} from 'src/annotations/selectors'
+import {
+  isSingleClickAnnotationsEnabled,
+  selectAreAnnotationsVisible,
+} from 'src/annotations/selectors'
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'
@@ -33,6 +39,7 @@ export const AnnotationsControlBar: FC = () => {
   const {orgID} = useParams<{orgID: string; dashboardID: string}>()
 
   const inWriteMode = useSelector(isSingleClickAnnotationsEnabled)
+  const annotationsAreVisible = useSelector(selectAreAnnotationsVisible)
 
   const dispatch = useDispatch()
 
@@ -43,23 +50,40 @@ export const AnnotationsControlBar: FC = () => {
     dispatch(toggleSingleClickAnnotations())
   }
 
+  const changeAnnotationVisibility = () => {
+    event('dashboard.annotations.change_visibility_mode.toggle', {
+      newAnnotationsAreVisible: (!annotationsAreVisible).toString(),
+    })
+    dispatch(toggleAnnotationVisibility())
+  }
+
   return (
     <ErrorBoundary>
       <Toolbar
         testID="annotations-control-bar"
-        justifyContent={JustifyContent.SpaceBetween}
+        justifyContent={JustifyContent.FlexEnd}
         margin={ComponentSize.Large}
       >
-        <FlexBoxChild basis={300} grow={0}>
-          <AnnotationsSearchBar />
-        </FlexBoxChild>
-        <FlexBoxChild grow={1}>
-          <AnnotationPills />
-        </FlexBoxChild>
-        <FlexBox margin={ComponentSize.Small}>
+        <FlexBoxChild grow={0}>
           <Toggle
             style={{marginRight: 20}}
-            id="enableAnnotationMode"
+            id="enable-annotation-visibility"
+            type={InputToggleType.Checkbox}
+            checked={annotationsAreVisible}
+            onChange={changeAnnotationVisibility}
+            color={ComponentColor.Primary}
+            size={ComponentSize.ExtraSmall}
+            testID="annotations-visibility-toggle"
+          >
+            <InputLabel htmlFor="enable-annotation-visibility">
+              Show Annotations
+            </InputLabel>
+          </Toggle>
+        </FlexBoxChild>
+        <FlexBoxChild grow={0}>
+          <Toggle
+            style={{marginRight: 20}}
+            id="enable-annotation-mode"
             type={InputToggleType.Checkbox}
             checked={inWriteMode}
             onChange={changeWriteMode}
@@ -67,11 +91,11 @@ export const AnnotationsControlBar: FC = () => {
             size={ComponentSize.ExtraSmall}
             testID="annotations-one-click-toggle"
           >
-            <InputLabel htmlFor="enableAnnotationMode">
+            <InputLabel htmlFor="enable-annotation-mode">
               Enable 1-Click Annotations
             </InputLabel>
           </Toggle>
-        </FlexBox>
+        </FlexBoxChild>
       </Toolbar>
     </ErrorBoundary>
   )

--- a/src/annotations/reducers/index.test.ts
+++ b/src/annotations/reducers/index.test.ts
@@ -1,4 +1,8 @@
-import {annotationsReducer, initialState} from 'src/annotations/reducers'
+import {
+  annotationsReducer,
+  initialState,
+  STREAM_COLOR_LIST,
+} from 'src/annotations/reducers'
 
 const mockAnnotations = [
   {
@@ -50,9 +54,15 @@ describe('the annotations reducer', () => {
           },
         ],
       },
+      annotationsAreVisible: true,
       enableSingleClickAnnotations: true,
       visibleStreamsByID: ['default'],
-      streams: [],
+      streams: [
+        {
+          stream: 'default',
+          color: STREAM_COLOR_LIST[0],
+        },
+      ],
     })
   })
 })

--- a/src/annotations/reducers/index.ts
+++ b/src/annotations/reducers/index.ts
@@ -1,9 +1,10 @@
 import {
   Action,
-  ENABLE_ANNOTATION_STREAM,
   DISABLE_ANNOTATION_STREAM,
+  ENABLE_ANNOTATION_STREAM,
   SET_ANNOTATIONS,
   SET_ANNOTATION_STREAMS,
+  TOGGLE_ANNOTATION_VISIBILITY,
   TOGGLE_SINGLE_CLICK_ANNOTATIONS,
 } from 'src/annotations/actions/creators'
 
@@ -14,6 +15,7 @@ import {InfluxColors} from '@influxdata/clockface'
 export interface AnnotationsState {
   streams: AnnotationStream[]
   annotations: AnnotationsList
+  annotationsAreVisible: boolean // a temporary (we'll see) measure until we enable streams
   visibleStreamsByID: string[]
   enableSingleClickAnnotations: boolean
 }
@@ -26,9 +28,13 @@ export const initialState = (): AnnotationsState => ({
   annotations: {
     default: [] as Annotation[],
   },
-  visibleStreamsByID: ['default'],
-  streams: [],
+  annotationsAreVisible: true,
   enableSingleClickAnnotations: true,
+  streams: [{
+    stream: 'default',
+    color: InfluxColors.Potassium
+  }],
+  visibleStreamsByID: ['default'],
 })
 
 export const annotationsReducer = (
@@ -69,6 +75,13 @@ export const annotationsReducer = (
       return {
         ...state,
         annotations,
+      }
+    }
+
+    case TOGGLE_ANNOTATION_VISIBILITY: {
+      return {
+        ...state,
+        annotationsAreVisible: !state.annotationsAreVisible
       }
     }
 

--- a/src/annotations/reducers/index.ts
+++ b/src/annotations/reducers/index.ts
@@ -30,10 +30,12 @@ export const initialState = (): AnnotationsState => ({
   },
   annotationsAreVisible: true,
   enableSingleClickAnnotations: true,
-  streams: [{
-    stream: 'default',
-    color: InfluxColors.Potassium
-  }],
+  streams: [
+    {
+      stream: 'default',
+      color: InfluxColors.Potassium,
+    },
+  ],
   visibleStreamsByID: ['default'],
 })
 
@@ -81,7 +83,7 @@ export const annotationsReducer = (
     case TOGGLE_ANNOTATION_VISIBILITY: {
       return {
         ...state,
-        annotationsAreVisible: !state.annotationsAreVisible
+        annotationsAreVisible: !state.annotationsAreVisible,
       }
     }
 

--- a/src/annotations/reducers/index.ts
+++ b/src/annotations/reducers/index.ts
@@ -22,7 +22,7 @@ export interface AnnotationsState {
 
 export const FALLBACK_COLOR = InfluxColors.Curacao
 
-const STREAM_COLOR_LIST = [InfluxColors.Potassium]
+export const STREAM_COLOR_LIST = [InfluxColors.Potassium]
 
 export const initialState = (): AnnotationsState => ({
   annotations: {

--- a/src/annotations/selectors/index.ts
+++ b/src/annotations/selectors/index.ts
@@ -28,3 +28,7 @@ export const getAnnotationStreams = (state: AppState): AnnotationStream[] => {
 export const isSingleClickAnnotationsEnabled = (state: AppState): boolean => {
   return state.annotations.enableSingleClickAnnotations
 }
+
+export const selectAreAnnotationsVisible = (state: AppState): boolean => {
+  return state.annotations.annotationsAreVisible
+}

--- a/src/shared/containers/SetOrg.tsx
+++ b/src/shared/containers/SetOrg.tsx
@@ -5,7 +5,6 @@ import {Route, Switch} from 'react-router-dom'
 
 // Components
 import {CommunityTemplatesIndex} from 'src/templates/containers/CommunityTemplatesIndex'
-import {AnnotationsIndex} from 'src/annotations/containers/AnnotationsIndex'
 import PageSpinner from 'src/perf/components/PageSpinner'
 import {
   MePage,
@@ -50,7 +49,6 @@ import {
   TELEGRAF_PLUGINS,
   CLIENT_LIBS,
   SETTINGS,
-  ANNOTATIONS,
   VARIABLES,
   LABELS,
   BUCKETS,

--- a/src/shared/containers/SetOrg.tsx
+++ b/src/shared/containers/SetOrg.tsx
@@ -207,12 +207,6 @@ const SetOrg: FC<Props> = ({
           />
 
           {/* Settings */}
-          {isFlagEnabled('annotations') && (
-            <Route
-              path={`${orgPath}/${SETTINGS}/${ANNOTATIONS}`}
-              component={AnnotationsIndex}
-            />
-          )}
           <Route
             path={`${orgPath}/${SETTINGS}/${VARIABLES}`}
             component={VariablesIndex}

--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -24,6 +24,7 @@ import {
   getAnnotationStreams,
   getVisibleAnnotationStreams,
   isSingleClickAnnotationsEnabled,
+  selectAreAnnotationsVisible,
 } from 'src/annotations/selectors'
 
 import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
@@ -82,6 +83,7 @@ const XYPlot: FC<Props> = ({properties, result, timeRange, annotations}) => {
   // which are currently global values, not per dashboard
   const inAnnotationWriteMode = useSelector(isSingleClickAnnotationsEnabled)
   const visibleAnnotationStreams = useSelector(getVisibleAnnotationStreams)
+  const annotationsAreVisible = useSelector(selectAreAnnotationsVisible)
 
   const annotationStreams = useSelector(getAnnotationStreams)
 
@@ -276,7 +278,7 @@ const XYPlot: FC<Props> = ({properties, result, timeRange, annotations}) => {
       }
     })
 
-    if (selectedAnnotations.length) {
+    if (annotationsAreVisible && selectedAnnotations.length) {
       const annotationLayer: AnnotationLayerConfig = {
         type: 'annotation',
         x: xColumn,


### PR DESCRIPTION
Closes #901

Removes the following parts from the UI:
- streams search bar (far left arrow)
- gear icon that takes you to the streams homepage (far right arrow)
   - also removed the route to this page

- Adds the `Show Annotations` toggle (middle arrow)

Considerations: show / hide annotations isn't saveable, so on page reload, they'll revert back to default

![Screen Shot 2021-03-22 at 2 49 13 PM](https://user-images.githubusercontent.com/146112/112063108-1f93ed00-8b1e-11eb-8477-963b015c6596.png)




- [ ] [E2E Tests pass in K8S-IDPE](https://docs.influxdata.io/development/guides/local-development/#three-ways-to-run-the-ui-e2e-tests-against-the-kind-cluster) (applicable only if you edited Cypress tests)
