### PR TITLE
 chore: upgrading clockface to 2.6.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "webpack-merge": "^4.2.1"
   },
   "dependencies": {
-    "@influxdata/clockface": "^2.6.3",
+    "@influxdata/clockface": "^2.6.5",
     "@influxdata/flux": "^0.5.1",
     "@influxdata/flux-lsp-browser": "^0.5.35",
     "@influxdata/giraffe": "^2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -782,10 +782,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@influxdata/clockface@^2.6.3":
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-2.6.3.tgz#836519591dac9a90449e4c55cfb475031bff0a02"
-  integrity sha512-44B6whe0wOZsscwvwfngyoZALQtbQzvtT6vgu/yPw88XMa1eVbtfQMJ00zf3YBuD4d2qAzzmBBF0ymdPQPS9Kg==
+"@influxdata/clockface@^2.6.5":
+  version "2.6.5"
+  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-2.6.5.tgz#82c868656166980682d3d6b6827540dcdc9dc497"
+  integrity sha512-jYfqimv1J1S8AB/+YvghiDBDPAyYGKjYteQAW5zYpQavIzHAq3wl6j8+BiVVdgrEIIb/5DhRNf4z01qR436uNw==
 
 "@influxdata/flux-lsp-browser@^0.5.35":
   version "0.5.35"


### PR DESCRIPTION
Closes #

<!-- Describe your proposed changes here. -->

- [ ] [E2E Tests pass in K8S-IDPE](https://docs.influxdata.io/development/guides/local-development/#three-ways-to-run-the-ui-e2e-tests-against-the-kind-cluster) (applicable only if you edited Cypress tests)
