### PR TITLE
WIP: checkout dex monitor-ci branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run:
           name: Grab compose files
-          command: git clone git@github.com:influxdata/monitor-ci.git
+          command: git clone git@github.com:influxdata/monitor-ci.git --branch genehynson/bump-dex-golang
       - run:
           name: Copy over the testing variables
           command: cp ./monitor-ci/env.testing ./monitor-ci/.env
@@ -46,7 +46,7 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run:
           name: Grab compose files
-          command: git clone git@github.com:influxdata/monitor-ci.git
+          command: git clone git@github.com:influxdata/monitor-ci.git --branch genehynson/bump-dex-golang
       - run:
           name: Copy over the testing variables
           command: cp ./monitor-ci/env.testing.oss ./monitor-ci/.env
@@ -78,7 +78,7 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run:
           name: Grab compose files
-          command: git clone git@github.com:influxdata/monitor-ci.git
+          command: git clone git@github.com:influxdata/monitor-ci.git --branch genehynson/bump-dex-golang
       - run:
           name: Build the ui docker image
           command: |
@@ -112,7 +112,7 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run:
           name: Grab deploy files
-          command: git clone git@github.com:influxdata/monitor-ci.git
+          command: git clone git@github.com:influxdata/monitor-ci.git --branch genehynson/bump-dex-golang
       - run:
           name: Load the prod image
           command: |
@@ -167,7 +167,7 @@ jobs:
       - run:
           name: Grab compose files
           command: |
-            git clone git@github.com:influxdata/monitor-ci.git
+            git clone git@github.com:influxdata/monitor-ci.git --branch genehynson/bump-dex-golang
       - run:
           name: Copy over the testing variables
           command: cp ./monitor-ci/env.testing.cloud ./monitor-ci/.env
@@ -218,7 +218,7 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run:
           name: Grab compose files
-          command: git clone git@github.com:influxdata/monitor-ci.git
+          command: git clone git@github.com:influxdata/monitor-ci.git --branch genehynson/bump-dex-golang
       - run:
           name: Copy over the testing variables
           command: cp ./monitor-ci/env.testing.oss ./monitor-ci/.env
@@ -263,7 +263,7 @@ jobs:
       - run:
           name: Grab compose files
           command: |
-            git clone git@github.com:influxdata/monitor-ci.git
+            git clone git@github.com:influxdata/monitor-ci.git --branch genehynson/bump-dex-golang
       - run:
           name: Copy over the testing variables
           command: cp ./monitor-ci/env.testing.cloud ./monitor-ci/.env
@@ -304,7 +304,7 @@ jobs:
       - run:
           name: Grab compose files
           command: |
-            git clone git@github.com:influxdata/monitor-ci.git
+            git clone git@github.com:influxdata/monitor-ci.git --branch genehynson/bump-dex-golang
       - run:
           name: Copy over the testing variables
           command: cp ./monitor-ci/env.testing.cloud ./monitor-ci/.env
@@ -406,7 +406,7 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run:
           name: Grab compose files
-          command: git clone git@github.com:influxdata/monitor-ci.git
+          command: git clone git@github.com:influxdata/monitor-ci.git --branch genehynson/bump-dex-golang
       - run:
           name: Copy over the lighthouse variables
           command: |


### PR DESCRIPTION
Testing a change to bump dex's golang image to 1.16. Do not merge!

The actual change is here: https://github.com/influxdata/monitor-ci/pull/196