### PR TITLE
feat: add exception for beta region deployment on upgrade now

### DIFF
--- a/src/shared/components/CloudUpgradeButton.tsx
+++ b/src/shared/components/CloudUpgradeButton.tsx
@@ -15,7 +15,11 @@ import {
 import CloudOnly from 'src/shared/components/cloud/CloudOnly'
 
 // Constants
-import {CLOUD_URL, CLOUD_CHECKOUT_PATH} from 'src/shared/constants'
+import {
+  BETA_REGIONS,
+  CLOUD_URL,
+  CLOUD_CHECKOUT_PATH,
+} from 'src/shared/constants'
 import {
   HIDE_UPGRADE_CTA_KEY,
   PAID_ORG_HIDE_UPGRADE_SETTING,
@@ -52,8 +56,8 @@ const CloudUpgradeButton: FC<StateProps & OwnProps> = ({
   // The follow up to this issue will address the hack here:
   // https://github.com/influxdata/ui/issues/930
 
-  const isBetaRegion = window.location.hostname.includes(
-    'europe-west1-1.gcp.cloud2.influxdata.com'
+  const isBetaRegion = BETA_REGIONS.some((pathName: string) =>
+    window.location.hostname.includes(pathName)
   )
 
   return (

--- a/src/shared/components/CloudUpgradeButton.tsx
+++ b/src/shared/components/CloudUpgradeButton.tsx
@@ -44,9 +44,21 @@ const CloudUpgradeButton: FC<StateProps & OwnProps> = ({
     [`${className}`]: className,
   })
 
+  // TODO(ariel): we need to build out an exception for beta regions
+  // This current hack is being placed to allow a Beta region to be deployed
+  // without allowing users to get navigated to a Quartz 404. This hack is being implemented
+  // to address the following issue:
+  // https://github.com/influxdata/ui/issues/944
+  // The follow up to this issue will address the hack here:
+  // https://github.com/influxdata/ui/issues/930
+
+  const isBetaRegion = window.location.hostname.includes(
+    'europe-west1-1.gcp.cloud2.influxdata.com'
+  )
+
   return (
     <CloudOnly>
-      {inView && (
+      {inView && !isBetaRegion && (
         <LinkButton
           icon={IconFont.CrownSolid}
           className={cloudUpgradeButtonClass}

--- a/src/shared/components/CloudUpgradeNavBanner.tsx
+++ b/src/shared/components/CloudUpgradeNavBanner.tsx
@@ -17,7 +17,11 @@ import {
 import CloudOnly from 'src/shared/components/cloud/CloudOnly'
 
 // Constants
-import {CLOUD_URL, CLOUD_CHECKOUT_PATH} from 'src/shared/constants'
+import {
+  BETA_REGIONS,
+  CLOUD_URL,
+  CLOUD_CHECKOUT_PATH,
+} from 'src/shared/constants'
 import {
   HIDE_UPGRADE_CTA_KEY,
   PAID_ORG_HIDE_UPGRADE_SETTING,
@@ -39,9 +43,10 @@ const CloudUpgradeNavBanner: FC<StateProps> = ({inView}) => {
   // The follow up to this issue will address the hack here:
   // https://github.com/influxdata/ui/issues/930
 
-  const isBetaRegion = window.location.hostname.includes(
-    'europe-west1-1.gcp.cloud2.influxdata.com'
+  const isBetaRegion = BETA_REGIONS.some((pathName: string) =>
+    window.location.hostname.includes(pathName)
   )
+
   return (
     <>
       {inView && !isBetaRegion && (

--- a/src/shared/components/CloudUpgradeNavBanner.tsx
+++ b/src/shared/components/CloudUpgradeNavBanner.tsx
@@ -31,9 +31,20 @@ interface StateProps {
 }
 
 const CloudUpgradeNavBanner: FC<StateProps> = ({inView}) => {
+  // TODO(ariel): we need to build out an exception for beta regions
+  // This current hack is being placed to allow a Beta region to be deployed
+  // without allowing users to get navigated to a Quartz 404. This hack is being implemented
+  // to address the following issue:
+  // https://github.com/influxdata/ui/issues/944
+  // The follow up to this issue will address the hack here:
+  // https://github.com/influxdata/ui/issues/930
+
+  const isBetaRegion = window.location.hostname.includes(
+    'europe-west1-1.gcp.cloud2.influxdata.com'
+  )
   return (
     <>
-      {inView && (
+      {inView && !isBetaRegion && (
         <CloudOnly>
           <Panel
             gradient={Gradients.HotelBreakfast}

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -13,6 +13,12 @@ import {InfluxColors} from '@influxdata/clockface'
 
 import {AutoRefreshStatus} from 'src/types'
 
+// This is temporary and should be resolved
+// Once the Beta region API is built out by Quartz:
+// influxdata/quartz#4369
+// Beta Regions contain the hostname of the beta regions
+export const BETA_REGIONS = ['europe-west1-1.gcp.cloud2.influxdata.com']
+
 function formatConstant(constant: string) {
   if (!constant) {
     return ''


### PR DESCRIPTION
Closes #944 

This PR is a brief workaround until we can address the core issues for #930. As such, it's a hack to allow a beta region to be deployed today without needing to develop proper infrastructure for the core issue.
