### PR TITLE
fix: telegraf no buckets overlay now works

### DIFF
--- a/src/dataLoaders/components/collectorsWizard/select/SelectCollectorsStep.tsx
+++ b/src/dataLoaders/components/collectorsWizard/select/SelectCollectorsStep.tsx
@@ -38,6 +38,7 @@ type Props = OwnProps & ReduxProps
 @ErrorHandling
 export class SelectCollectorsStep extends PureComponent<Props> {
   public render() {
+    const selectedBucketName = this.props.bucket ?? this.props.buckets[0]?.name
     return (
       <Form
         onSubmit={this.props.onIncrementCurrentStepIndex}
@@ -59,13 +60,7 @@ export class SelectCollectorsStep extends PureComponent<Props> {
             telegrafPlugins={this.props.telegrafPlugins}
             onTogglePluginBundle={this.handleTogglePluginBundle}
             buckets={this.props.buckets ?? []}
-            selectedBucketName={
-              this.props.bucket
-                ? this.props.bucket
-                : this.props.buckets.length
-                ? this.props.buckets[0].name
-                : 'No Buckets Available'
-            }
+            selectedBucketName={selectedBucketName}
             onSelectBucket={this.handleSelectBucket}
           />
           <h5 className="wizard-step--sub-title">

--- a/src/dataLoaders/components/collectorsWizard/select/SelectCollectorsStep.tsx
+++ b/src/dataLoaders/components/collectorsWizard/select/SelectCollectorsStep.tsx
@@ -54,20 +54,20 @@ export class SelectCollectorsStep extends PureComponent<Props> {
               metrics to a bucket in InfluxDB
             </h5>
           </div>
-          {this.props.buckets.length && (
-            <StreamingSelector
-              pluginBundles={this.props.pluginBundles}
-              telegrafPlugins={this.props.telegrafPlugins}
-              onTogglePluginBundle={this.handleTogglePluginBundle}
-              buckets={this.props.buckets}
-              selectedBucketName={
-                this.props.bucket
-                  ? this.props.bucket
-                  : this.props.buckets[0].name
-              }
-              onSelectBucket={this.handleSelectBucket}
-            />
-          )}
+          <StreamingSelector
+            pluginBundles={this.props.pluginBundles}
+            telegrafPlugins={this.props.telegrafPlugins}
+            onTogglePluginBundle={this.handleTogglePluginBundle}
+            buckets={this.props.buckets ?? []}
+            selectedBucketName={
+              this.props.bucket
+                ? this.props.bucket
+                : this.props.buckets.length
+                ? this.props.buckets[0].name
+                : 'No Buckets Available'
+            }
+            onSelectBucket={this.handleSelectBucket}
+          />
           <h5 className="wizard-step--sub-title">
             Looking for other things to monitor? Check out our 200+ other &nbsp;
             <a

--- a/src/dataLoaders/components/collectorsWizard/select/StreamingSelector.test.tsx
+++ b/src/dataLoaders/components/collectorsWizard/select/StreamingSelector.test.tsx
@@ -58,4 +58,14 @@ describe('Onboarding.Components.SelectionStep.StreamingSelector', () => {
       expect(cards.length).toBe(PLUGIN_BUNDLE_OPTIONS.length)
     })
   })
+
+  describe('user without buckets', () => {
+    it('causes the modal create bucket button and the message prompting the user to create a bucket', async () => {
+      setup({bucket: '', buckets: []})
+      const createButton = await screen.getByTestId('Create Bucket')
+      const promptMessage = await screen.getByTestId('create-bucket-prompt')
+      expect(createButton).toBeVisible()
+      expect(promptMessage).toBeVisible()
+    })
+  })
 })

--- a/src/dataLoaders/components/collectorsWizard/select/StreamingSelector.tsx
+++ b/src/dataLoaders/components/collectorsWizard/select/StreamingSelector.tsx
@@ -14,7 +14,7 @@ import {
   SquareGrid,
 } from '@influxdata/clockface'
 import {ErrorHandling} from 'src/shared/decorators/errors'
-
+import CreateBucketButton from 'src/buckets/components/CreateBucketButton'
 // Constants
 import {
   PLUGIN_BUNDLE_OPTIONS,
@@ -71,52 +71,64 @@ class StreamingSelector extends PureComponent<Props, State> {
     const {searchTerm} = this.state
 
     const cardSize = `${100 / (PLUGIN_BUNDLE_OPTIONS.length + 1)}%`
-
     return (
       <div className="wizard-step--grid-container">
-        <Grid.Row>
-          <Grid.Column widthSM={Columns.Five}>
-            <FormElement label="Bucket">
-              <BucketDropdown
-                selectedBucketID={this.selectedBucketID}
-                buckets={buckets}
-                onSelectBucket={this.handleSelectBucket}
-              />
-            </FormElement>
-          </Grid.Column>
-          <Grid.Column widthSM={Columns.Five} offsetSM={Columns.Two}>
-            <FormElement label="">
-              <Input
-                className="wizard-step--filter"
-                size={ComponentSize.Small}
-                icon={IconFont.Search}
-                value={searchTerm}
-                onBlur={this.handleFilterBlur}
-                onChange={this.handleFilterChange}
-                placeholder="Filter Plugins..."
-              />
-            </FormElement>
-          </Grid.Column>
-        </Grid.Row>
-        <SquareGrid cardSize={cardSize} gutter={ComponentSize.Small}>
-          {this.filteredBundles.map(b => {
-            return (
-              <SquareGrid.Card key={b}>
-                <SelectableCard
-                  id={b}
-                  formName="telegraf-plugins"
-                  label={b}
-                  testID={`telegraf-plugins--${b}`}
-                  selected={this.isCardChecked(b)}
-                  onClick={this.handleToggle}
-                  icon={IconFont.Checkmark}
-                >
-                  {createElement(BUNDLE_LOGOS[b])}
-                </SelectableCard>
-              </SquareGrid.Card>
-            )
-          })}
-        </SquareGrid>
+        {buckets.length ? (
+          <>
+            <Grid.Row>
+              <Grid.Column widthSM={Columns.Five}>
+                <FormElement label="Bucket">
+                  <BucketDropdown
+                    selectedBucketID={this.selectedBucketID}
+                    buckets={buckets}
+                    onSelectBucket={this.handleSelectBucket}
+                  />
+                </FormElement>
+              </Grid.Column>
+              <Grid.Column widthSM={Columns.Five} offsetSM={Columns.Two}>
+                <FormElement label="">
+                  <Input
+                    className="wizard-step--filter"
+                    size={ComponentSize.Small}
+                    icon={IconFont.Search}
+                    value={searchTerm}
+                    onBlur={this.handleFilterBlur}
+                    onChange={this.handleFilterChange}
+                    placeholder="Filter Plugins..."
+                  />
+                </FormElement>
+              </Grid.Column>
+            </Grid.Row>
+            <SquareGrid cardSize={cardSize} gutter={ComponentSize.Small}>
+              {this.filteredBundles.map(b => {
+                return (
+                  <SquareGrid.Card key={b}>
+                    <SelectableCard
+                      id={b}
+                      formName="telegraf-plugins"
+                      label={b}
+                      testID={`telegraf-plugins--${b}`}
+                      selected={this.isCardChecked(b)}
+                      onClick={this.handleToggle}
+                      icon={IconFont.Checkmark}
+                    >
+                      {createElement(BUNDLE_LOGOS[b])}
+                    </SelectableCard>
+                  </SquareGrid.Card>
+                )
+              })}
+            </SquareGrid>
+          </>
+        ) : (
+          <>
+            <Grid.Row style={{width: 'auto'}}>
+              <CreateBucketButton />
+            </Grid.Row>
+            <h3 data-testid="create-bucket-prompt">
+              Create a Bucket To Show Telegraf Plugins
+            </h3>
+          </>
+        )}
         {this.emptyState}
       </div>
     )


### PR DESCRIPTION
Closes #948 

<!-- Describe your proposed changes here. -->
Under this PR, if a user has no buckets the overlay will now prompt the user to create a bucket. When they do, they will then be able to see the regular overlay as was intended. 
- [x] [E2E Tests pass in K8S-IDPE](https://docs.influxdata.io/development/guides/local-development/#three-ways-to-run-the-ui-e2e-tests-against-the-kind-cluster) (applicable only if you edited Cypress tests)
<img width="1195" alt="Screen Shot 2021-03-23 at 4 33 33 PM" src="https://user-images.githubusercontent.com/29473622/112216664-c6948980-8bef-11eb-9086-ba8db4234b3e.png">
