### PR TITLE
docs: remove k8s-idpe checkbox

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,3 @@
 Closes #
 
 <!-- Describe your proposed changes here. -->
-
-- [ ] [E2E Tests pass in K8S-IDPE](https://docs.influxdata.io/development/guides/local-development/#three-ways-to-run-the-ui-e2e-tests-against-the-kind-cluster) (applicable only if you edited Cypress tests)


### PR DESCRIPTION
We're running the e2e tests via k8s-idpe in our CI now so we don't need this manual step in our pull template anymore.
