### PR TITLE
chore(lint): no nested ternaries

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,6 +40,7 @@ module.exports = {
     'no-undef': 'off',
     'no-fallthrough': 'off',
     'no-prototype-builtins': 'off',
+    'no-nested-ternary': 'error',
     'require-atomic-updates': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',

--- a/cypress/e2e/shared/telegrafs.test.ts
+++ b/cypress/e2e/shared/telegrafs.test.ts
@@ -76,7 +76,16 @@ describe('Collectors', () => {
           const buckets = bucketz.slice(0).sort((a, b) => {
             const _a = a.toLowerCase()
             const _b = b.toLowerCase()
-            return _a > _b ? 1 : _a < _b ? -1 : 0
+
+            if (_a > _b) {
+              return 1
+            }
+
+            if (_a < _b) {
+              return -1
+            }
+
+            return 0
           })
 
           cy.get('code').should($el => {

--- a/src/telegrafs/components/TelegrafOutputOverlay.tsx
+++ b/src/telegrafs/components/TelegrafOutputOverlay.tsx
@@ -74,7 +74,16 @@ class TelegrafOutputOverlay extends PureComponent<Props> {
       .sort((a, b) => {
         const _a = a.name.toLowerCase()
         const _b = b.name.toLowerCase()
-        return _a > _b ? 1 : _a < _b ? -1 : 0
+
+        if (_a > _b) {
+          return 1
+        }
+
+        if (_a < _b) {
+          return -1
+        }
+
+        return 0
       })
   }
 

--- a/src/timeMachine/components/WindowPeriod.tsx
+++ b/src/timeMachine/components/WindowPeriod.tsx
@@ -49,11 +49,13 @@ const WindowPeriod: FunctionComponent<Props> = ({
   let durationDisplay = period
 
   if (!period || isAutoWindowPeriod) {
-    durationDisplay = autoWindowPeriod
-      ? isInCheckOverlay
-        ? `${AGG_WINDOW_AUTO} (${everyWindowPeriod})`
-        : `${AGG_WINDOW_AUTO} (${autoWindowPeriod})`
-      : AGG_WINDOW_AUTO
+    durationDisplay = AGG_WINDOW_AUTO
+    if (autoWindowPeriod) {
+      durationDisplay = `${AGG_WINDOW_AUTO} (${autoWindowPeriod})`
+      if (isInCheckOverlay) {
+        durationDisplay = `${AGG_WINDOW_AUTO} (${everyWindowPeriod})`
+      }
+    }
   }
 
   const durationInputStatus = isAutoWindowPeriod


### PR DESCRIPTION
Closes #956

Turns on lint checking for nested ternary operators

- [ ] [E2E Tests pass in K8S-IDPE](https://docs.influxdata.io/development/guides/local-development/#three-ways-to-run-the-ui-e2e-tests-against-the-kind-cluster) (applicable only if you edited Cypress tests)
