### PR TITLE
fix: map getLatLon function returns correct error

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "@influxdata/clockface": "^2.6.6",
     "@influxdata/flux": "^0.5.1",
     "@influxdata/flux-lsp-browser": "^0.5.37",
-    "@influxdata/giraffe": "^2.6.2",
+    "@influxdata/giraffe": "^2.6.3",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",

--- a/package.json
+++ b/package.json
@@ -209,7 +209,6 @@
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0",
     "rome": "^2.1.22",
-    "s2-geometry": "^1.2.10",
     "seamless-immutable": "^7.1.3",
     "unraw": "2.0.0",
     "use-local-storage-state": "^9.0.2",

--- a/src/shared/utils/vis.test.ts
+++ b/src/shared/utils/vis.test.ts
@@ -4,7 +4,6 @@ import {
   defaultYColumn,
   getMainColumnName,
   parseYBounds,
-  HEX_DIGIT_PRECISION,
   getGeoCoordinates,
 } from 'src/shared/utils/vis'
 import {Table} from '@influxdata/giraffe'
@@ -150,7 +149,7 @@ describe('getGeoCoordinates - retrieve latitude and longitude values for map geo
     const table = {
       getColumn: () => [0, 1, 2, '2323'],
     } as any
-    const geoCoordinates = getGeoCoordinates(table, 3)
+    const geoCoordinates = getGeoCoordinates(table)
 
     expect(geoCoordinates).toEqual(
       expect.objectContaining({
@@ -158,31 +157,5 @@ describe('getGeoCoordinates - retrieve latitude and longitude values for map geo
         lat: expect.any(Number),
       })
     )
-  })
-
-  it('throws an error if cellId is not a proper string value', () => {
-    const table = {
-      getColumn: () => [0, 1, 2, 8],
-    } as any
-
-    try {
-      getGeoCoordinates(table, 3)
-    } catch (err) {
-      expect(err.message).toEqual(
-        'invalid s2_cell_id column value - value must be a string'
-      )
-    }
-  })
-
-  it('throws an error if cellId length is greater than the hex precision value allows for', () => {
-    const table = {
-      getColumn: () => [0, 1, 2, new Array(HEX_DIGIT_PRECISION + 1).join('1')],
-    } as any
-
-    try {
-      getGeoCoordinates(table, 3)
-    } catch (err) {
-      expect(err.message).toEqual('invalid cellId length')
-    }
   })
 })

--- a/src/shared/utils/vis.ts
+++ b/src/shared/utils/vis.ts
@@ -1,5 +1,4 @@
 // Libraries
-import {S2} from 's2-geometry'
 import {Table, LineInterpolation, FromFluxResult} from '@influxdata/giraffe'
 
 // Types
@@ -335,7 +334,7 @@ export const getGeoCoordinates = (table: Table) => {
   const lonCoordinate = getColumnValue(table, 'lon')
 
   return {
-    lat: parseInt(latCoordinate.toString()),
-    lon: parseInt(lonCoordinate.toString()),
+    lat: parseInt(latCoordinate.toString(), 10),
+    lon: parseInt(lonCoordinate.toString(), 10),
   }
 }

--- a/src/shared/utils/vis.ts
+++ b/src/shared/utils/vis.ts
@@ -323,6 +323,9 @@ const getColumnValue = (table: Table, field: string) => {
     )
   }
   const index = fieldColumn.findIndex(val => val === field)
+  if (index < 0) {
+    throw new Error('Map type requires the fields to be either lat or lon')
+  }
   const valueColumn = table.getColumn('_value')
   const value = valueColumn[index]
 

--- a/src/visualization/types/Map/view.tsx
+++ b/src/visualization/types/Map/view.tsx
@@ -41,7 +41,7 @@ const GeoPlot: FC<Props> = ({result, properties}) => {
       }
     }
     getToken()
-  })
+  }, [])
 
   let error = ''
 
@@ -52,7 +52,7 @@ const GeoPlot: FC<Props> = ({result, properties}) => {
     lon,
   }
   try {
-    calculatedGeoCoordinates = getGeoCoordinates(result.table, 0)
+    calculatedGeoCoordinates = getGeoCoordinates(result.table)
   } catch (err) {
     setErrorCode(MapErrorStates.InvalidCoordinates)
   }

--- a/src/visualization/types/Map/view.tsx
+++ b/src/visualization/types/Map/view.tsx
@@ -20,13 +20,7 @@ enum MapErrorStates {
 }
 
 const GeoPlot: FC<Props> = ({result, properties}) => {
-  const {
-    layers,
-    zoom,
-    allowPanAndZoom,
-    detectCoordinateFields,
-    mapStyle,
-  } = properties
+  const {layers, zoom, allowPanAndZoom, mapStyle} = properties
 
   const [errorCode, setErrorCode] = useState<string>('')
   const [mapToken, setMapToken] = useState<string>('')

--- a/src/visualization/types/Map/view.tsx
+++ b/src/visualization/types/Map/view.tsx
@@ -43,19 +43,22 @@ const GeoPlot: FC<Props> = ({result, properties}) => {
     getToken()
   }, [])
 
-  let error = ''
-
   const {lat, lon} = properties.center
 
   let calculatedGeoCoordinates = {
     lat,
     lon,
   }
-  try {
-    calculatedGeoCoordinates = getGeoCoordinates(result.table)
-  } catch (err) {
-    setErrorCode(MapErrorStates.InvalidCoordinates)
-  }
+
+  useEffect(() => {
+    try {
+      calculatedGeoCoordinates = getGeoCoordinates(result.table)
+    } catch (err) {
+      setErrorCode(MapErrorStates.InvalidCoordinates)
+    }
+  }, [])
+
+  let error = ''
 
   const getMapboxUrl = () => {
     if (mapToken) {
@@ -101,7 +104,7 @@ const GeoPlot: FC<Props> = ({result, properties}) => {
                 lon: calculatedGeoCoordinates.lon,
                 zoom,
                 allowPanAndZoom,
-                detectCoordinateFields,
+                detectCoordinateFields: true,
                 mapStyle,
                 layers,
                 tileServerConfiguration: tileServerConfiguration,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7669,11 +7669,6 @@ loglevel@^1.6.6:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.7.tgz#b3e034233188c68b889f5b862415306f565e2c56"
   integrity sha512-cY2eLFrQSAfVPhCgH1s7JI73tMbg9YC3v3+ZHVW67sBS7UxWzNEk/ZBbSfLykBWHp33dqqtOv82gjhKEi81T/A==
 
-long@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/long/-/long-3.2.0.tgz#d821b7138ca1cb581c172990ef14db200b5c474b"
-  integrity sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s=
-
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
@@ -10587,13 +10582,6 @@ rxjs@^6.4.0:
   integrity sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==
   dependencies:
     tslib "^1.9.0"
-
-s2-geometry@^1.2.10:
-  version "1.2.10"
-  resolved "https://registry.yarnpkg.com/s2-geometry/-/s2-geometry-1.2.10.tgz#c6ff22f3eccafd0eea491b60b44c141b9887acab"
-  integrity sha1-xv8i8+zK/Q7qSRtgtEwUG5iHrKs=
-  dependencies:
-    long "^3.2.0"
 
 safe-buffer@5.1.1:
   version "5.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -797,10 +797,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/flux/-/flux-0.5.1.tgz#e39e7a7af9163fc9494422c8fed77f3ae1b68f56"
   integrity sha512-GHlkXBhSdJ2m56JzDkbnKPAqLj3/lexPooacu14AWTO4f2sDGLmzM7r0AxgdtU1M2x7EXNBwgGOI5EOAdN6mkw==
 
-"@influxdata/giraffe@^2.6.2":
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.6.2.tgz#3c5b7c565d1c046782efcb3ea740eb5ee6d430ea"
-  integrity sha512-hZS3E8Mh8E8eSbgr7ztkGwPX/lDdP1SVJhJbyzW3InzOR8swYPQwozkQpdAsXDroLCzWlB68ZBpheyIpOJxOIQ==
+"@influxdata/giraffe@^2.6.3":
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.6.3.tgz#6de51d52dd0e4e5ec2f0d8ed5163872e2f9ec2bd"
+  integrity sha512-ZFMZxUDPoWqt3KASYeFXmuv12DzPgTNcUkMjEDlb3GpCqoyTErpXJMXpTXTaQ4LBOLNzx8govoG1w1aXA/hSiA==
   dependencies:
     merge-images "^2.0.0"
 


### PR DESCRIPTION
Closes #963 

Maps in Data Explorer breaks if the user provides lat lon data without `s2_cell_id`. This change is so that our check if coordinates exist is no longer dependent on `s2_cell_id`.

<!-- Describe your proposed changes here. -->
