### PR TITLE
fix: add missing css import

### DIFF
--- a/src/flows/components/FlowsIndexEmpty.tsx
+++ b/src/flows/components/FlowsIndexEmpty.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import {ComponentSize, EmptyState} from '@influxdata/clockface'
 import {PROJECT_NAME_PLURAL} from 'src/flows'
 import FlowCreateButton from 'src/flows/components/FlowCreateButton'
+import 'src/flows/components/EmptyPipeList.scss'
 
 const FlowsIndexEmpty = () => {
   return (


### PR DESCRIPTION
Closes #984 

Adds missing CSS import so we don't have to wait for the user to create a new notebook for the stylesheet to be imported.
