### PR TITLE
chore: annotations requests send proper content-type header

### DIFF
--- a/src/annotations/api/index.test.ts
+++ b/src/annotations/api/index.test.ts
@@ -1,15 +1,27 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 
 import {mocked} from 'ts-jest/utils'
+import axios from 'axios'
+
+const fakeAxios = {
+  get: jest.fn(),
+  post: jest.fn(),
+  put: jest.fn(),
+  delete: jest.fn(),
+}
+
+jest.doMock('axios', () => {
+  return {
+    create: () => fakeAxios
+  }
+})
+
 import {
   writeAnnotation,
   getAnnotation,
   deleteAnnotation,
   updateAnnotation,
 } from 'src/annotations/api'
-import axios from 'axios'
-
-jest.mock('axios')
 
 describe('annotations api calls', () => {
   describe('POST - write annotations api calls', () => {
@@ -23,13 +35,13 @@ describe('annotations api calls', () => {
         },
       ]
 
-      mocked(axios.post).mockImplementationOnce(() =>
+      mocked(fakeAxios.post).mockImplementationOnce(() =>
         Promise.resolve({status: 200, data: annotationResponse})
       )
 
       const response = await writeAnnotation(annotationResponse)
 
-      expect(axios.post).toHaveBeenCalledTimes(1)
+      expect(fakeAxios.post).toHaveBeenCalledTimes(1)
 
       expect(response).toEqual(annotationResponse)
     })
@@ -45,7 +57,7 @@ describe('annotations api calls', () => {
       ]
       const message = 'OOPS YOU DONE MESSED UP SON'
 
-      mocked(axios.post).mockImplementationOnce(() =>
+      mocked(fakeAxios.post).mockImplementationOnce(() =>
         Promise.reject(new Error(message))
       )
 
@@ -79,7 +91,7 @@ describe('annotations api calls', () => {
 
     it('retrieves annotations and returns them categorized by annotation stream', async () => {
       const [lambeau] = annotationResponse
-      mocked(axios.get).mockImplementationOnce(() =>
+      mocked(fakeAxios.get).mockImplementationOnce(() =>
         Promise.resolve({data: [lambeau]})
       )
       const response = await getAnnotation({
@@ -99,7 +111,7 @@ describe('annotations api calls', () => {
       }
       const message = 'OOPS YOU DONE MESSED UP SON'
 
-      mocked(axios.get).mockImplementationOnce(() =>
+      mocked(fakeAxios.get).mockImplementationOnce(() =>
         Promise.reject(new Error(message))
       )
 
@@ -117,7 +129,7 @@ describe('annotations api calls', () => {
     }
 
     it('returns an updated annotation if correct parameters are passed', async () => {
-      mocked(axios.put).mockImplementationOnce(() =>
+      mocked(fakeAxios.put).mockImplementationOnce(() =>
         Promise.resolve({data: newAnnotation})
       )
 
@@ -135,7 +147,7 @@ describe('annotations api calls', () => {
     }
 
     it('returns a 204 upon successful deletion of annotation', async () => {
-      mocked(axios.delete).mockImplementationOnce(() =>
+      mocked(fakeAxios.delete).mockImplementationOnce(() =>
         Promise.resolve({status: 204})
       )
 
@@ -147,7 +159,7 @@ describe('annotations api calls', () => {
     it('handles an error and returns the error message', async () => {
       const message = 'OOPS YOU DONE MESSED UP SON'
 
-      mocked(axios.delete).mockImplementationOnce(() =>
+      mocked(fakeAxios.delete).mockImplementationOnce(() =>
         Promise.reject(new Error(message))
       )
 

--- a/src/annotations/api/index.test.ts
+++ b/src/annotations/api/index.test.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 
 import {mocked} from 'ts-jest/utils'
-import axios from 'axios'
 
 const fakeAxios = {
   get: jest.fn(),
@@ -12,7 +11,7 @@ const fakeAxios = {
 
 jest.doMock('axios', () => {
   return {
-    create: () => fakeAxios
+    create: () => fakeAxios,
   }
 })
 

--- a/src/annotations/api/index.ts
+++ b/src/annotations/api/index.ts
@@ -18,11 +18,17 @@ import {API_BASE_PATH} from 'src/shared/constants'
 const url = `${API_BASE_PATH}api/v2private/annotations`
 const streamsURL = `${API_BASE_PATH}api/v2private/streams`
 
+const annotationsProxy = axios.create({
+  headers: {
+    'Content-Type': 'application/json',
+  },
+})
+
 // Utils
 import {formatAnnotationQueryString} from 'src/annotations/utils/formatQueryString'
 
 export const getAnnotationStreams = async (): Promise<AnnotationStream[]> => {
-  const annotationStreamResponse = await axios.get(streamsURL)
+  const annotationStreamResponse = await annotationsProxy.get(streamsURL)
   if (annotationStreamResponse.status >= 300) {
     throw new Error(
       annotationStreamResponse.data?.message ??
@@ -44,7 +50,7 @@ export const writeAnnotation = async (
     }
   })
 
-  const res = await axios.post(url, annotationsRequestConverted)
+  const res = await annotationsProxy.post(url, annotationsRequestConverted)
 
   if (res.status >= 300) {
     throw new Error(res.data?.message)
@@ -67,7 +73,9 @@ export const writeAnnotation = async (
 export const getAnnotations = async (
   stream?: string
 ): Promise<AnnotationResponse[]> => {
-  const res = await axios.get(`${url}?${formatAnnotationQueryString({stream})}`)
+  const res = await annotationsProxy.get(
+    `${url}?${formatAnnotationQueryString({stream})}`
+  )
 
   if (res.status >= 300) {
     throw new Error(res.data?.message)
@@ -85,7 +93,7 @@ export const getAnnotation = async (
   const formattedQueryString = formatAnnotationQueryString(annotation)
   const appendedURL = `${url}?${formattedQueryString}`
 
-  const res = await axios.get(appendedURL)
+  const res = await annotationsProxy.get(appendedURL)
 
   if (res.status >= 300) {
     throw new Error(res.data?.message)
@@ -100,7 +108,10 @@ export const getAnnotation = async (
 export const updateAnnotation = async (
   newAnnotation: Annotation
 ): Promise<Annotation> => {
-  const res = await axios.put(`${url}/${newAnnotation.id}`, newAnnotation)
+  const res = await annotationsProxy.put(
+    `${url}/${newAnnotation.id}`,
+    newAnnotation
+  )
 
   if (res.status >= 300) {
     throw new Error(res.data?.message)
@@ -126,7 +137,7 @@ export const deleteAnnotation = async (
 
   const appendedURL = `${url}?${formattedQueryString}`
 
-  const res = await axios.delete(appendedURL)
+  const res = await annotationsProxy.delete(appendedURL)
 
   if (res.status >= 300) {
     throw new Error(res.data?.message)

--- a/src/annotations/components/AnnotationsControlBarToggleButton.tsx
+++ b/src/annotations/components/AnnotationsControlBarToggleButton.tsx
@@ -11,6 +11,9 @@ import {toggleShowAnnotationsControls} from 'src/userSettings/actions'
 // Components
 import {Button, ComponentColor, IconFont} from '@influxdata/clockface'
 
+// Utils
+import {event} from 'src/cloud/utils/reporting'
+
 export const AnnotationsControlBarToggleButton: FC = () => {
   const dispatch = useDispatch()
   const isVisible = useSelector(getAnnotationControlsVisibility)
@@ -25,6 +28,9 @@ export const AnnotationsControlBarToggleButton: FC = () => {
 
   const handleClick = (): void => {
     dispatch(toggleShowAnnotationsControls())
+    event('dashboard.annotations.control_bar_toggle_button.toggle', {
+      newIsControlBarVisible: (!isVisible).toString(),
+    })
   }
 
   return (


### PR DESCRIPTION
Closes #985
Closes #728 

- Sends `content-type` header of `application/json`
- Finishes last metrics call on annotations control bar toggle
