### PR TITLE
feat: connect pin target on annotation to the edit/delete modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "@influxdata/clockface": "^2.6.6",
     "@influxdata/flux": "^0.5.1",
     "@influxdata/flux-lsp-browser": "^0.5.37",
-    "@influxdata/giraffe": "^2.6.3",
+    "@influxdata/giraffe": "^2.7.0",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",

--- a/src/annotations/components/EditAnnotationForm.tsx
+++ b/src/annotations/components/EditAnnotationForm.tsx
@@ -77,7 +77,7 @@ export const EditAnnotationForm: FC<EditAnnotationProps> = ({
   const handleDeleteAnnotation = () => {
     try {
       dispatch(deleteAnnotations(editAnnotationState))
-      dispatch(notify(deleteAnnotationSuccess()))
+      dispatch(notify(deleteAnnotationSuccess(editAnnotationState.message)))
       handleClose()
     } catch (err) {
       dispatch(notify(deleteAnnotationFailed(err)))

--- a/src/annotations/components/EditAnnotationForm.tsx
+++ b/src/annotations/components/EditAnnotationForm.tsx
@@ -1,24 +1,19 @@
 // Libraries
 import React, {FC, useState, ChangeEvent} from 'react'
-import {useDispatch, useSelector} from 'react-redux'
+import {useDispatch} from 'react-redux'
 import {
   Button,
   Columns,
   ComponentColor,
   ComponentSize,
   ComponentStatus,
-  Dropdown,
   Form,
   Grid,
   InfluxColors,
   Input,
   Overlay,
   Panel,
-  TextArea,
 } from '@influxdata/clockface'
-
-// Selectors
-import {getAnnotationStreams} from 'src/annotations/selectors'
 
 // Actions
 import {deleteAnnotations} from 'src/annotations/actions/thunks'
@@ -84,7 +79,6 @@ export const EditAnnotationForm: FC<EditAnnotationProps> = ({
     }
   }
 
-  const annotationStreams = useSelector(getAnnotationStreams)
   const dispatch = useDispatch()
   return (
     <Overlay.Container maxWidth={800}>
@@ -92,9 +86,9 @@ export const EditAnnotationForm: FC<EditAnnotationProps> = ({
         title="Edit Annotation"
         onDismiss={handleClose}
         className="edit-annotation-head"
-      ></Overlay.Header>
+      />
       <Grid className="edit-annotation-grid">
-        <Grid.Column widthSM={Columns.Six} widthXS={Columns.Twelve}>
+        <Grid.Column widthSM={Columns.Twelve} widthXS={Columns.Twelve}>
           <h3 className="edit-annotation-header-text">Details</h3>
           <Panel
             backgroundColor={InfluxColors.Onyx}
@@ -123,51 +117,6 @@ export const EditAnnotationForm: FC<EditAnnotationProps> = ({
                 onChange={handleEditAnnotationChange}
                 status={ComponentStatus.Default}
                 size={ComponentSize.Medium}
-              />
-            </Form.Element>
-            <Form.Element
-              label="Message"
-              className="edit-annotation-form-label"
-            >
-              <TextArea
-                name="message"
-                placeholder="Try writing markdown here..."
-                value={editAnnotationState.message}
-                onChange={handleEditAnnotationChange}
-                status={ComponentStatus.Default}
-                className="edit-annotation-form-textarea"
-              />
-            </Form.Element>
-          </Panel>
-        </Grid.Column>
-        <Grid.Column widthSM={Columns.Six} widthXS={Columns.Twelve}>
-          <h3 className="edit-annotation-header-text">Store Annotation</h3>
-          <Panel
-            backgroundColor={InfluxColors.Onyx}
-            className="edit-annotation-panel"
-          >
-            <Form.Element
-              label="Annotation Stream"
-              className="edit-annotation-form-label"
-            >
-              <Dropdown
-                button={(active, onClick) => (
-                  <Dropdown.Button
-                    active={active}
-                    onClick={onClick}
-                    testID="stream-selector--dropdown"
-                  >
-                    {annotationStreams[0].stream}
-                  </Dropdown.Button>
-                )}
-                menu={onCollapse => (
-                  <Dropdown.Menu
-                    onCollapse={onCollapse}
-                    testID="stream-selector--dropdown-menu"
-                  >
-                    {annotationStreams.map(stream => stream.stream)}
-                  </Dropdown.Menu>
-                )}
               />
             </Form.Element>
           </Panel>

--- a/src/shared/copy/notifications.ts
+++ b/src/shared/copy/notifications.ts
@@ -1090,10 +1090,12 @@ export const copyFunctionURL = (): Notification => ({
   duration: 2000,
 })
 
-export const deleteAnnotationSuccess = (): Notification => ({
+export const deleteAnnotationSuccess = (message: string): Notification => ({
   ...defaultSuccessNotification,
   icon: IconFont.Cube,
-  message: 'Successfully deleted the annotation',
+  message: message
+    ? `Successfully deleted the annotation: ${message}`
+    : 'Successfully deleted the annotation',
 })
 
 export const deleteAnnotationFailed = (error: string): Notification => ({

--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -287,15 +287,15 @@ const XYPlot: FC<Props> = ({properties, result, timeRange, annotations}) => {
         singleClick: makeSingleClickHandler(),
       }
     }
-    const clickedAnnotationHandler = (id: string) => {
-      const toEditAnnotation = annotations['default'].find(
+    const handleAnnotationClick = (id: string) => {
+      const annotationToEdit = annotations['default'].find(
         annotation => annotation.id === id
       )
       event('xyplot.annotations.edit_annotation.show_overlay')
       dispatch(
         showOverlay(
           'edit-annotation',
-          {clickedAnnotation: toEditAnnotation},
+          {clickedAnnotation: annotationToEdit},
           () => {
             event('xyplot.annotations.edit_annotation.cancel')
             dismissOverlay()
@@ -309,7 +309,7 @@ const XYPlot: FC<Props> = ({properties, result, timeRange, annotations}) => {
         x: xColumn,
         y: yColumn,
         fill: groupKey,
-        handleAnnotationClick: clickedAnnotationHandler,
+        handleAnnotationClick,
         annotations: selectedAnnotations.map(annotation => {
           return {
             id: annotation.id,

--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -287,13 +287,29 @@ const XYPlot: FC<Props> = ({properties, result, timeRange, annotations}) => {
         singleClick: makeSingleClickHandler(),
       }
     }
-
+    const clickedAnnotationHandler = (id: string) => {
+      const toEditAnnotation = annotations['default'].find(
+        annotation => annotation.id === id
+      )
+      event('xyplot.annotations.edit_annotation.show_overlay')
+      dispatch(
+        showOverlay(
+          'edit-annotation',
+          {clickedAnnotation: toEditAnnotation},
+          () => {
+            event('xyplot.annotations.edit_annotation.cancel')
+            dismissOverlay()
+          }
+        )
+      )
+    }
     if (annotationsAreVisible && selectedAnnotations.length) {
       const annotationLayer: AnnotationLayerConfig = {
         type: 'annotation',
         x: xColumn,
         y: yColumn,
         fill: groupKey,
+        handleAnnotationClick: clickedAnnotationHandler,
         annotations: selectedAnnotations.map(annotation => {
           return {
             id: annotation.id,

--- a/yarn.lock
+++ b/yarn.lock
@@ -797,10 +797,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/flux/-/flux-0.5.1.tgz#e39e7a7af9163fc9494422c8fed77f3ae1b68f56"
   integrity sha512-GHlkXBhSdJ2m56JzDkbnKPAqLj3/lexPooacu14AWTO4f2sDGLmzM7r0AxgdtU1M2x7EXNBwgGOI5EOAdN6mkw==
 
-"@influxdata/giraffe@^2.6.3":
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.6.3.tgz#6de51d52dd0e4e5ec2f0d8ed5163872e2f9ec2bd"
-  integrity sha512-ZFMZxUDPoWqt3KASYeFXmuv12DzPgTNcUkMjEDlb3GpCqoyTErpXJMXpTXTaQ4LBOLNzx8govoG1w1aXA/hSiA==
+"@influxdata/giraffe@^2.7.0":
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.7.0.tgz#ce93da5581875530d612eae9489eebfe66b710c5"
+  integrity sha512-rLbIHgk3gg6A0kjStkyJ85BUNWn5EzIUJzNG+uM82J0qIB5nVOqPvqfNtwyw3avkc8LCwbDjW1hJF3xaSMgqcA==
   dependencies:
     merge-images "^2.0.0"
 


### PR DESCRIPTION
Closes #896
Closes #374 

This PR connects the upside-down triangle annotation pin introduced in https://github.com/influxdata/giraffe/pull/511 to the edit/delete modal https://github.com/influxdata/ui/pull/976. 
