### PR TITLE
chore: make annotation mode off by default, add note explaining xy plots only

### DIFF
--- a/src/annotations/components/controlBar/AnnotationsControlBar.test.tsx
+++ b/src/annotations/components/controlBar/AnnotationsControlBar.test.tsx
@@ -234,8 +234,8 @@ describe('the annotations control bar ui functionality', () => {
     const enableSingleClickAnnotations = store.getState().annotations
       .enableSingleClickAnnotations
 
-    // by default the annotations single click to add is enabled, above toggle disables it
-    expect(enableSingleClickAnnotations).toBeFalsy()
+    // by default the annotations single click to add is disabled, above toggle enables it
+    expect(enableSingleClickAnnotations).toBeTruthy()
   })
 
   it('can toggle the visibility of annotations (which are on by default)', async () => {

--- a/src/annotations/components/controlBar/AnnotationsControlBar.tsx
+++ b/src/annotations/components/controlBar/AnnotationsControlBar.tsx
@@ -7,9 +7,11 @@ import {
   ComponentColor,
   ComponentSize,
   FlexBoxChild,
+  InfluxColors,
   InputLabel,
   InputToggleType,
   JustifyContent,
+  TextBlock,
   Toggle,
 } from '@influxdata/clockface'
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
@@ -55,6 +57,10 @@ export const AnnotationsControlBar: FC = () => {
         justifyContent={JustifyContent.FlexEnd}
         margin={ComponentSize.Large}
       >
+        <FlexBoxChild grow={0}>
+          <TextBlock backgroundColor={InfluxColors.Obsidian} text="*Currently, we only support annotations on XY Plots" />
+        </FlexBoxChild>
+        <FlexBoxChild grow={1} />
         <FlexBoxChild grow={0}>
           <Toggle
             style={{marginRight: 20}}

--- a/src/annotations/components/controlBar/AnnotationsControlBar.tsx
+++ b/src/annotations/components/controlBar/AnnotationsControlBar.tsx
@@ -60,6 +60,7 @@ export const AnnotationsControlBar: FC = () => {
         <FlexBoxChild grow={0}>
           <TextBlock
             backgroundColor={InfluxColors.Obsidian}
+            textColor={InfluxColors.Mist}
             text="*Currently, we only support annotations on XY Plots"
           />
         </FlexBoxChild>

--- a/src/annotations/components/controlBar/AnnotationsControlBar.tsx
+++ b/src/annotations/components/controlBar/AnnotationsControlBar.tsx
@@ -58,7 +58,10 @@ export const AnnotationsControlBar: FC = () => {
         margin={ComponentSize.Large}
       >
         <FlexBoxChild grow={0}>
-          <TextBlock backgroundColor={InfluxColors.Obsidian} text="*Currently, we only support annotations on XY Plots" />
+          <TextBlock
+            backgroundColor={InfluxColors.Obsidian}
+            text="*Currently, we only support annotations on XY Plots"
+          />
         </FlexBoxChild>
         <FlexBoxChild grow={1} />
         <FlexBoxChild grow={0}>

--- a/src/annotations/reducers/index.test.ts
+++ b/src/annotations/reducers/index.test.ts
@@ -55,7 +55,7 @@ describe('the annotations reducer', () => {
         ],
       },
       annotationsAreVisible: true,
-      enableSingleClickAnnotations: true,
+      enableSingleClickAnnotations: false,
       visibleStreamsByID: ['default'],
       streams: [
         {

--- a/src/annotations/reducers/index.ts
+++ b/src/annotations/reducers/index.ts
@@ -31,7 +31,7 @@ export const initialState = (): AnnotationsState => ({
     default: [] as Annotation[],
   },
   annotationsAreVisible: true,
-  enableSingleClickAnnotations: true,
+  enableSingleClickAnnotations: false,
   streams: [
     {
       stream: 'default',


### PR DESCRIPTION
- annotation write mode is toggled off by default
- shows a message saying we only support annotations on XY graphs

![Screen Shot 2021-03-26 at 9 52 05 AM](https://user-images.githubusercontent.com/146112/112666643-a1835f00-8e19-11eb-8deb-5ec8ed5b2476.png)
