### PR TITLE
fix: circle and heatmap options

### DIFF
--- a/src/visualization/types/Map/GeoOptions.tsx
+++ b/src/visualization/types/Map/GeoOptions.tsx
@@ -41,8 +41,8 @@ export const GeoOptions: FC<Props> = ({properties, update}) => {
           layers: [
             {
               type: 'pointMap',
-              colorDimension: {label: 'Duration'},
-              colorField: 'duration',
+              colorDimension: {label: 'Value'},
+              colorField: '_value',
               colors: [
                 {type: 'min', hex: '#ff0000'},
                 {value: 50, hex: '#343aeb'},
@@ -60,8 +60,8 @@ export const GeoOptions: FC<Props> = ({properties, update}) => {
               type: 'heatmap',
               radius: 20,
               blur: 10,
-              intensityDimension: {label: 'Value'},
-              intensityField: '_value',
+              intensityDimension: {label: 'Lat'},
+              intensityField: 'lat',
               colors: [
                 {type: 'min', hex: '#00ff00'},
                 {value: 50, hex: '#ffae42'},
@@ -95,10 +95,10 @@ export const GeoOptions: FC<Props> = ({properties, update}) => {
           layers: [
             {
               type: 'circleMap',
-              radiusField: 'magnitude',
-              radiusDimension: {label: 'Magnitude'},
-              colorDimension: {label: 'Duration'},
-              colorField: 'duration',
+              radiusField: 'lat',
+              radiusDimension: {label: 'lat'},
+              colorDimension: {label: 'lon'},
+              colorField: 'lon',
               colors: [
                 {type: 'min', hex: '#ff00b3'},
                 {value: 50, hex: '#343aeb'},


### PR DESCRIPTION
Closes #1001 
Upon testing in Tools, I came across an issue, where the circle and heat maps are not loading the data points in map. Turns out my change in giraffe pr has broken this since the columns/tag values are pivoted and changed to `lat` and `lon`. So, updating the fields used in the options fixed this issue.

![Screen Shot 2021-03-26 at 1 47 45 PM](https://user-images.githubusercontent.com/26464594/112691242-40b84e80-8e3a-11eb-8219-cf9a68578117.png)

![Screen Shot 2021-03-26 at 1 48 01 PM](https://user-images.githubusercontent.com/26464594/112691292-575ea580-8e3a-11eb-9f8f-f54b2a4d8405.png)


<!-- Describe your proposed changes here. -->
