### PR TITLE
fix: prevent DashboardPage from crashing due to the lack of updated redux store keys

### DIFF
--- a/src/dashboards/components/DashboardPage.tsx
+++ b/src/dashboards/components/DashboardPage.tsx
@@ -150,7 +150,7 @@ const mstp = (state: AppState) => {
     state.currentDashboard.id
   )
 
-  const showAnnotationBar = state.userSettings.showAnnotationsControls || false
+  const showAnnotationBar = state.userSettings.showAnnotationsControls ?? false
 
   return {
     startVisitMs: state.perf.dashboard.byID[dashboard.id]?.startVisitMs,

--- a/src/dashboards/components/DashboardPage.tsx
+++ b/src/dashboards/components/DashboardPage.tsx
@@ -150,7 +150,7 @@ const mstp = (state: AppState) => {
     state.currentDashboard.id
   )
 
-  const showAnnotationBar = state.userSettings.showAnnotationsControls
+  const showAnnotationBar = state.userSettings.showAnnotationsControls || false
 
   return {
     startVisitMs: state.perf.dashboard.byID[dashboard.id]?.startVisitMs,


### PR DESCRIPTION
I'm able to reproduce the error in #1018 by doing the following:

1. clearing my localStorage in the browser console: `localStorage.clear()`
2. going to `src/userSettings/reducers/index.ts` and commenting out code that adds the new `showAnnotationsControl` key to the local storage.
3. reload the dashboard, it won't load. The screen displays a similar error, the console has a React Invariant Violation error as well.

Why it's happening?

I hypothesize: We have a variable that controls the visibility of the AnnotationContolBar, the variable's state is stored in the redux. When we shipped Annotation to our new users, the new key wasn't present in their localStorage, hence the value of the `AnnotationsControlBar`'s visibility variable was `undefined`, not `false`. Using a default `false` when key isn't found in the local storage fixes this crash.


After speaking to Bucky, we concluded that _this is a bandaid solution_

Ideally we would want to value the redux store as the source of truth not the `localStorage`, like we are doing now. A good solution would be to check the local storage, use it as a cache but invalidate it when there are mismatches between keys, indicating that the `localStorage` isn't usable anymore and that it needs to update. 


