### PR TITLE
chore: update clockface

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "webpack-merge": "^4.2.1"
   },
   "dependencies": {
-    "@influxdata/clockface": "^2.6.6",
+    "@influxdata/clockface": "^2.6.7",
     "@influxdata/flux": "^0.5.1",
     "@influxdata/flux-lsp-browser": "^0.5.37",
     "@influxdata/giraffe": "^2.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -782,10 +782,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@influxdata/clockface@^2.6.6":
-  version "2.6.6"
-  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-2.6.6.tgz#5eeb42110da8e967eb8199a337e9923935d49fe1"
-  integrity sha512-bbEwkwWHFQvxrWa3yOWn65Th+/JdNVJp5Nzx55v93tIWa93O1H/q3sFp96lZbMA1WH8eO5mz1qvNDVAkqF4crw==
+"@influxdata/clockface@^2.6.7":
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-2.6.7.tgz#1baddd86e95328b8f747819705b7e486ebcedbad"
+  integrity sha512-LGIMEN2gXTYtS7Z4OiZgKkqWAbA6p6tTakouFgUTuPj/naT84sqni6xyZ92THrdJRpNSZ9Ez3xLOu3xK0j2E5g==
 
 "@influxdata/flux-lsp-browser@^0.5.37":
   version "0.5.37"


### PR DESCRIPTION
Closes #

chore: update clockface to 2.6.7 from 2.6.6