### PR TITLE
feat: enable chrome web security for e2e testing.

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -8,5 +8,5 @@
   "defaultCommandTimeout": 10000,
   "videoUploadOnPasses": false,
   "chromeWebSecurity": true,
-  "blockHosts": ["www.google-analytics.com","www.googletagmanager.com"]
+  "blockHosts": ["www.google-analytics.com", "www.googletagmanager.com"]
 }

--- a/cypress.json
+++ b/cypress.json
@@ -7,6 +7,6 @@
   "integrationFolder": "cypress/e2e",
   "defaultCommandTimeout": 10000,
   "videoUploadOnPasses": false,
-  "chromeWebSecurity": false,
+  "chromeWebSecurity": true,
   "blockHosts": ["www.google-analytics.com", "www.googletagmanager.com"]
 }

--- a/cypress.json
+++ b/cypress.json
@@ -8,5 +8,5 @@
   "defaultCommandTimeout": 10000,
   "videoUploadOnPasses": false,
   "chromeWebSecurity": true,
-  "blockHosts": ["www.google-analytics.com", "www.googletagmanager.com"]
+  "blockHosts": ["www.google-analytics.com","www.googletagmanager.com"]
 }


### PR DESCRIPTION
Closes https://app.zenhub.com/workspaces/applicationui-5e3b05772922e316b3a210a4/issues/influxdata/cloud-2-cypress/19
