### PR TITLE
chore: push ui-e2e image to quay tagged with commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -451,6 +451,11 @@ jobs:
           command: |
             cd ./monitor-ci && make build NODE=cypress
       - run:
+          name: Push ui-e2e image tagged with this commit
+          command: |
+            docker tag local/cypress:latest quay.io/influxdb/ui-e2e:${CIRCLE_SHA1}
+            docker push quay.io/influxdb/ui-e2e:${CIRCLE_SHA1}
+      - run:
           name: Run E2e test
           command: cd ./idpe/ && export QUAY_CD_USER=$QUAY_USER && export QUAY_CD_PASSWORD=$QUAY_PASS && ./scripts/ci/cd-app-e2e-test.bash | tee /tmp/artifacts/e2e-test.log
           no_output_timeout: '15m' # Sometimes gathering the images takes too long. Go 50% over the default 10m timeout.
@@ -474,9 +479,7 @@ jobs:
       #     steps:
       #       # The cypress image used within the ui-e2e image is a non-standard slim image and its definition and versions are
       #       # maintained here: https://github.com/influxdata/cypress-slim
-      #       - run: docker tag local/cypress:latest quay.io/influxdb/ui-e2e:${CIRCLE_SHA1}
       #       - run: docker tag quay.io/influxdb/ui-e2e:${CIRCLE_SHA1} quay.io/influxdb/ui-e2e:latest
-      #       - run: docker push quay.io/influxdb/ui-e2e:${CIRCLE_SHA1}
       #       - run: docker push quay.io/influxdb/ui-e2e:latest
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -457,7 +457,7 @@ jobs:
             docker push quay.io/influxdb/ui-e2e:${CIRCLE_SHA1}
       - run:
           name: Run E2e test
-          command: cd ./idpe/ && export QUAY_CD_USER=$QUAY_USER && export QUAY_CD_PASSWORD=$QUAY_PASS && ./scripts/ci/cd-app-e2e-test.bash | tee /tmp/artifacts/e2e-test.log
+          command: cd ./idpe/ && export QUAY_CD_USER=$QUAY_USER && export QUAY_CD_PASSWORD=$QUAY_PASS && export UI_E2E_TESTS_IMAGE="quay.io/influxdb/ui-e2e:${CIRCLE_SHA1}" && ./scripts/ci/cd-app-e2e-test.bash | tee /tmp/artifacts/e2e-test.log
           no_output_timeout: '15m' # Sometimes gathering the images takes too long. Go 50% over the default 10m timeout.
           environment:
             USE_K8SIDPE_LOCAL_TOOLS: '1' # this is needed as otherwise kubecfg is not able to talk to kind API server via localhost


### PR DESCRIPTION
Push the built ui-e2e image to quay tagged with the current commit. Then pass the image name and commit tag to k8s-idpe via env var `UI_E2E_TESTS_IMAGE` so it can be used for testing.

See related k8s-idpe PR: https://github.com/influxdata/k8s-idpe/pull/2736