### PR TITLE
feat: pass cellID from RefreshingView.tsx all the way down to view 

### DIFF
--- a/src/shared/components/RefreshingView.tsx
+++ b/src/shared/components/RefreshingView.tsx
@@ -87,6 +87,7 @@ class RefreshingView extends PureComponent<Props> {
               result={giraffeResult}
               timeRange={ranges}
               annotations={annotations}
+              cellID={id}
             />
           </React.Fragment>
         )}

--- a/src/visualization/components/View.tsx
+++ b/src/visualization/components/View.tsx
@@ -24,7 +24,7 @@ interface Props {
   isInitial?: boolean
   timeRange?: TimeRange
   annotations?: AnnotationsList
-  cellID: string
+  cellID?: string
 }
 
 const InnerView: FC<Props> = ({

--- a/src/visualization/components/View.tsx
+++ b/src/visualization/components/View.tsx
@@ -24,6 +24,7 @@ interface Props {
   isInitial?: boolean
   timeRange?: TimeRange
   annotations?: AnnotationsList
+  cellID: string
 }
 
 const InnerView: FC<Props> = ({
@@ -34,6 +35,7 @@ const InnerView: FC<Props> = ({
   isInitial,
   timeRange,
   annotations,
+  cellID,
 }) => {
   if (!SUPPORTED_VISUALIZATIONS[properties.type]?.component) {
     throw new Error('Unknown view type in <View /> ')
@@ -59,6 +61,7 @@ const InnerView: FC<Props> = ({
         properties: properties,
         timeRange: timeRange || DEFAULT_TIME_RANGE,
         annotations: annotations,
+        cellID: cellID,
       })}
     </EmptyQueryView>
   )

--- a/src/visualization/index.ts
+++ b/src/visualization/index.ts
@@ -14,6 +14,7 @@ export interface VisualizationProps {
   result: FluxResult['parsed']
   timeRange?: TimeRange
   annotations?: AnnotationsList
+  cellID: string
 }
 
 export interface Visualization {

--- a/src/visualization/index.ts
+++ b/src/visualization/index.ts
@@ -14,7 +14,7 @@ export interface VisualizationProps {
   result: FluxResult['parsed']
   timeRange?: TimeRange
   annotations?: AnnotationsList
-  cellID: string
+  cellID?: string
 }
 
 export interface Visualization {


### PR DESCRIPTION
Closes #1041 

We need to pass in the `cellID` down to the XYplot graphs so we can use them in the new annotations architecture where their scope will be limited by `cellID`
