### PR TITLE
chore: disable chrome security

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -7,6 +7,6 @@
   "integrationFolder": "cypress/e2e",
   "defaultCommandTimeout": 10000,
   "videoUploadOnPasses": false,
-  "chromeWebSecurity": true,
+  "chromeWebSecurity": false,
   "blockHosts": ["www.google-analytics.com", "www.googletagmanager.com"]
 }


### PR DESCRIPTION
Enabling this flag works with monitor-ci but _not_ for k8s-idpe. Gotta turn it off for now.
