### PR TITLE
fix: type ahead drop down fixes

### DIFF
--- a/cypress/e2e/shared/dashboardsView.test.ts
+++ b/cypress/e2e/shared/dashboardsView.test.ts
@@ -283,7 +283,7 @@ describe('Dashboard', () => {
       })
     })
 
-    it('can manage variable state with a lot of pointing and clicking', () => {
+    it.only('can manage variable state with a lot of pointing and clicking', () => {
       const bucketOne = 'b1'
       const bucketThree = 'b3'
       const bucketVarName = 'bucketsCSV'
@@ -329,19 +329,19 @@ describe('Dashboard', () => {
 
               // TESTING CSV VARIABLE
               // selected value in dashboard is 1st value
-              cy.getByTestID(`variable-dropdown--${bucketVarName}`).should(
-                'contain',
-                bucketOne
-              )
+              cy.getByTestID(
+                `variable-dropdown-input-typeAhead--${bucketVarName}`
+              ).should('have.value', bucketOne)
+
               cy.window()
                 .pipe(getSelectedVariable(dashboard.id, 0))
                 .should('equal', bucketOne)
 
               // testing variable controls
-              cy.getByTestID(`variable-dropdown--${bucketVarName}`).should(
-                'contain',
-                bucketOne
-              )
+              cy.getByTestID(
+                `variable-dropdown-input-typeAhead--${bucketVarName}`
+              ).should('have.value', bucketOne)
+
               cy.getByTestID('variables--button').click()
               cy.getByTestID(`variable-dropdown--${bucketVarName}`).should(
                 'not.exist'
@@ -361,10 +361,10 @@ describe('Dashboard', () => {
               cy.get(`#${bucketThree}`).click()
 
               // selected value in dashboard is 3rd value
-              cy.getByTestID(`variable-dropdown--${bucketVarName}`).should(
-                'contain',
-                bucketThree
-              )
+              cy.getByTestID(
+                `variable-dropdown-input-typeAhead--${bucketVarName}`
+              ).should('have.value', bucketThree)
+
               cy.window()
                 .pipe(getSelectedVariable(dashboard.id, 0))
                 .should('equal', bucketThree)
@@ -421,22 +421,22 @@ describe('Dashboard', () => {
               cy.window()
                 .pipe(getSelectedVariable(dashboard.id, 0))
                 .should('equal', bucketOne)
+              cy.pause()
 
               // selected value in dashboard is 1st value
-              cy.getByTestID(`variable-dropdown--${bucketVarName}`).should(
-                'contain',
-                bucketOne
-              )
+              cy.getByTestID(
+                `variable-dropdown-input-typeAhead--${bucketVarName}`
+              ).should('have.value', bucketOne)
+
               cy.window()
                 .pipe(getSelectedVariable(dashboard.id, 0))
                 .should('equal', bucketOne)
 
               // TESTING MAP VARIABLE
               // selected value in dashboard is 1st value
-              cy.getByTestID(`variable-dropdown--${mapTypeVarName}`).should(
-                'contain',
-                'k1'
-              )
+              cy.getByTestID(
+                `variable-dropdown-input-typeAhead--${mapTypeVarName}`
+              ).should('have.value', 'k1')
               cy.window()
                 .pipe(getSelectedVariable(dashboard.id, 2))
                 .should('equal', 'v1')
@@ -448,10 +448,9 @@ describe('Dashboard', () => {
               cy.get(`#k2`).click()
 
               // selected value in dashboard is 2nd value
-              cy.getByTestID(`variable-dropdown--${mapTypeVarName}`).should(
-                'contain',
-                'k2'
-              )
+              cy.getByTestID(
+                `variable-dropdown-input-typeAhead--${mapTypeVarName}`
+              ).should('have.value', 'k2')
               cy.window()
                 .pipe(getSelectedVariable(dashboard.id, 2))
                 .should('equal', 'v2')
@@ -487,10 +486,9 @@ describe('Dashboard', () => {
                 .should('equal', 'v1')
 
               // selected value in dashboard is 1st value
-              cy.getByTestID(`variable-dropdown--${mapTypeVarName}`).should(
-                'contain',
-                'k1'
-              )
+              cy.getByTestID(
+                `variable-dropdown-input-typeAhead--${mapTypeVarName}`
+              ).should('have.value', 'k1')
               cy.window()
                 .pipe(getSelectedVariable(dashboard.id, 2))
                 .should('equal', 'v1')

--- a/cypress/e2e/shared/dashboardsView.test.ts
+++ b/cypress/e2e/shared/dashboardsView.test.ts
@@ -732,7 +732,7 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
                 .clear()
                 .type('b3789')
 
-              //now click away
+              // now click away
               cy.getByTestID('variable-dropdown--button')
                 .eq(1)
                 .click()
@@ -748,7 +748,7 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
                 .clear()
                 .type('b3')
 
-              //now click away
+              // now click away
               cy.getByTestID('variable-dropdown--button')
                 .eq(1)
                 .click()

--- a/cypress/e2e/shared/dashboardsView.test.ts
+++ b/cypress/e2e/shared/dashboardsView.test.ts
@@ -1,6 +1,8 @@
 import {Organization, AppState, Dashboard} from '../../../src/types'
 import {lines} from '../../support/commands'
 
+const typeAheadFlag = 'typeAheadVariableDropdown'
+
 describe('Dashboard', () => {
   beforeEach(() => {
     cy.flush()
@@ -293,310 +295,314 @@ describe('Dashboard', () => {
       const mapTypeVarName = 'mapTypeVar'
       const bucketVarIndex = 0
       const mapTypeVarIndex = 2
-      cy.get('@org').then(({id: orgID}: Organization) => {
-        cy.get<Dashboard>('@dashboard').then(({dashboard}) => {
-          cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
-            cy.createCSVVariable(orgID, bucketVarName, [
-              bucketOne,
-              defaultBucket,
-              bucketThree,
-              bucket4,
-              bucket5,
-            ])
+      cy.window().then(win => {
+        win.influx.set(typeAheadFlag, true)
 
-            cy.createQueryVariable(orgID)
-            cy.createMapVariable(orgID).then(() => {
-              cy.fixture('routes').then(({orgs}) => {
-                cy.visit(`${orgs}/${orgID}/dashboards/${dashboard.id}`)
-                cy.getByTestID('tree-nav')
-              })
-              // add cell with variable in its query
-              cy.getByTestID('add-cell--button').click()
-              cy.getByTestID('switch-to-script-editor').should('be.visible')
-              cy.getByTestID('switch-to-script-editor').click()
-              cy.getByTestID('toolbar-tab').click()
+        cy.get('@org').then(({id: orgID}: Organization) => {
+          cy.get<Dashboard>('@dashboard').then(({dashboard}) => {
+            cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
+              cy.createCSVVariable(orgID, bucketVarName, [
+                bucketOne,
+                defaultBucket,
+                bucketThree,
+                bucket4,
+                bucket5,
+              ])
 
-              // check to see if the default timeRange variables are available
-              cy.get('.flux-toolbar--list-item').contains('timeRangeStart')
-              cy.get('.flux-toolbar--list-item').contains('timeRangeStop')
-
-              cy.getByTestID('flux-editor')
-                .should('be.visible')
-                .click()
-                .focused()
-                .type(' ')
-              cy.get('.flux-toolbar--list-item')
-                .eq(bucketVarIndex)
-                .within(() => {
-                  cy.get('.cf-button').click()
+              cy.createQueryVariable(orgID)
+              cy.createMapVariable(orgID).then(() => {
+                cy.fixture('routes').then(({orgs}) => {
+                  cy.visit(`${orgs}/${orgID}/dashboards/${dashboard.id}`)
+                  cy.getByTestID('tree-nav')
                 })
-              cy.getByTestID('save-cell--button').click()
+                // add cell with variable in its query
+                cy.getByTestID('add-cell--button').click()
+                cy.getByTestID('switch-to-script-editor').should('be.visible')
+                cy.getByTestID('switch-to-script-editor').click()
+                cy.getByTestID('toolbar-tab').click()
 
-              // TESTING CSV VARIABLE
-              // selected value in dashboard is 1st value
-              cy.getByTestID(
-                `variable-dropdown-input-typeAhead--${bucketVarName}`
-              ).should('have.value', bucketOne)
+                // check to see if the default timeRange variables are available
+                cy.get('.flux-toolbar--list-item').contains('timeRangeStart')
+                cy.get('.flux-toolbar--list-item').contains('timeRangeStop')
 
-              cy.window()
-                .pipe(getSelectedVariable(dashboard.id, 0))
-                .should('equal', bucketOne)
+                cy.getByTestID('flux-editor')
+                  .should('be.visible')
+                  .click()
+                  .focused()
+                  .type(' ')
+                cy.get('.flux-toolbar--list-item')
+                  .eq(bucketVarIndex)
+                  .within(() => {
+                    cy.get('.cf-button').click()
+                  })
+                cy.getByTestID('save-cell--button').click()
 
-              // testing variable controls
-              cy.getByTestID(
-                `variable-dropdown-input-typeAhead--${bucketVarName}`
-              ).should('have.value', bucketOne)
+                // TESTING CSV VARIABLE
+                // selected value in dashboard is 1st value
+                cy.getByTestID(
+                  `variable-dropdown-input-typeAhead--${bucketVarName}`
+                ).should('have.value', bucketOne)
 
-              cy.getByTestID('variables--button').click()
-              cy.getByTestID(`variable-dropdown--${bucketVarName}`).should(
-                'not.exist'
-              )
-              cy.getByTestID('variables--button').click()
-              cy.getByTestID(`variable-dropdown--${bucketVarName}`).should(
-                'exist'
-              )
+                cy.window()
+                  .pipe(getSelectedVariable(dashboard.id, 0))
+                  .should('equal', bucketOne)
 
-              // sanity check on the url before beginning
-              cy.location('search').should('eq', '?lower=now%28%29%20-%201h')
+                // testing variable controls
+                cy.getByTestID(
+                  `variable-dropdown-input-typeAhead--${bucketVarName}`
+                ).should('have.value', bucketOne)
 
-              // select 3rd value in dashboard
-              cy.getByTestID('variable-dropdown--button')
-                .first()
-                .click()
-              cy.get(`#${bucketThree}`).click()
+                cy.getByTestID('variables--button').click()
+                cy.getByTestID(`variable-dropdown--${bucketVarName}`).should(
+                  'not.exist'
+                )
+                cy.getByTestID('variables--button').click()
+                cy.getByTestID(`variable-dropdown--${bucketVarName}`).should(
+                  'exist'
+                )
 
-              // selected value in dashboard is 3rd value
-              cy.getByTestID(
-                `variable-dropdown-input-typeAhead--${bucketVarName}`
-              ).should('have.value', bucketThree)
+                // sanity check on the url before beginning
+                cy.location('search').should('eq', '?lower=now%28%29%20-%201h')
 
-              cy.window()
-                .pipe(getSelectedVariable(dashboard.id, 0))
-                .should('equal', bucketThree)
-
-              // and that it updates the variable in the URL
-              cy.location('search').should(
-                'eq',
-                `?lower=now%28%29%20-%201h&vars%5BbucketsCSV%5D=${bucketThree}`
-              )
-
-              // select 2nd value in dashboard
-              cy.getByTestID('variable-dropdown--button')
-                .first()
-                .click()
-              cy.get(`#${defaultBucket}`).click()
-
-              // and that it updates the variable in the URL without breaking stuff
-              cy.location('search').should(
-                'eq',
-                `?lower=now%28%29%20-%201h&vars%5BbucketsCSV%5D=${defaultBucket}`
-              )
-
-              //start new stuff for typeAheadDropdown here!
-
-              //type in the input!
-              cy.getByTestID(
-                `variable-dropdown-input-typeAhead--${bucketVarName}`
-              ).clear()
-
-              cy.getByTestID(
-                `variable-dropdown-input-typeAhead--${bucketVarName}`
-              ).type('an')
-
-              //dropdown should  be showing: anotherBucket', 'randomBucket'
-
-              //hit down arrow once:
-
-              cy.getByTestID(
-                `variable-dropdown-input-typeAhead--${bucketVarName}`
-              ).type('{downarrow}')
-
-              //first element should be active (highlighted)
-              cy.get(`#anotherBucket`).should('have.class', 'active')
-
-              //hit down arrow again
-              cy.getByTestID(
-                `variable-dropdown-input-typeAhead--${bucketVarName}`
-              ).type('{downarrow}')
-
-              //next one should be active (first should NOT be active)
-              cy.get(`#anotherBucket`).should('not.have.class', 'active')
-              cy.get(`#randomBucket`).should('have.class', 'active')
-
-              //now; press return/enter to set it:
-              cy.getByTestID(
-                `variable-dropdown-input-typeAhead--${bucketVarName}`
-              ).type('{enter}')
-
-              // selected value in dashboard is 'randomBucket' value
-              cy.getByTestID(
-                `variable-dropdown-input-typeAhead--${bucketVarName}`
-              ).should('have.value', 'randomBucket')
-
-              //now:  clear the text area, write some text that doesn't match anything,
-              //then click outside; it should revert back to 'randomBucket'
-
-              //type in the input!
-              cy.getByTestID(
-                `variable-dropdown-input-typeAhead--${bucketVarName}`
-              ).clear()
-
-              cy.getByTestID(
-                `variable-dropdown-input-typeAhead--${bucketVarName}`
-              ).type('nothingM')
-
-              //end typeAhead section; rest is normal behavoir
-
-              // open VEO
-              cy.getByTestID('cell-context--toggle').click()
-              cy.getByTestID('cell-context--configure').click()
-
-              // selected value in cell context is 2nd value (making sure it reverts back!)
-              cy.window()
-                .pipe(getSelectedVariable(dashboard.id, 0))
-                .should('equal', bucket5)
-
-              cy.getByTestID('toolbar-tab').click()
-              cy.get('.flux-toolbar--list-item')
-                .first()
-                .trigger('mouseover')
-              // toggle the variable dropdown in the VEO cell dashboard
-              cy.getByTestID('toolbar-popover--contents').within(() => {
-                cy.getByTestID('variable-dropdown--button').click()
-                // select 1st value in cell
-                cy.getByTestID('variable-dropdown--item')
+                // select 3rd value in dashboard
+                cy.getByTestID('variable-dropdown--button')
                   .first()
                   .click()
-              })
-              // injecting mapTypeVar into query
-              cy.get('.flux-toolbar--list-item')
-                .eq(mapTypeVarIndex)
-                .within(() => {
-                  cy.get('.cf-button').click()
-                })
-              // save cell
-              cy.getByTestID('save-cell--button').click()
+                cy.get(`#${bucketThree}`).click()
 
-              // selected value in cell context is 1st value
-              cy.window()
-                .pipe(getSelectedVariable(dashboard.id, 0))
-                .should('equal', bucketOne)
+                // selected value in dashboard is 3rd value
+                cy.getByTestID(
+                  `variable-dropdown-input-typeAhead--${bucketVarName}`
+                ).should('have.value', bucketThree)
 
-              // selected value in dashboard is 1st value
-              cy.getByTestID(
-                `variable-dropdown-input-typeAhead--${bucketVarName}`
-              ).should('have.value', bucketOne)
+                cy.window()
+                  .pipe(getSelectedVariable(dashboard.id, 0))
+                  .should('equal', bucketThree)
 
-              cy.window()
-                .pipe(getSelectedVariable(dashboard.id, 0))
-                .should('equal', bucketOne)
+                // and that it updates the variable in the URL
+                cy.location('search').should(
+                  'eq',
+                  `?lower=now%28%29%20-%201h&vars%5BbucketsCSV%5D=${bucketThree}`
+                )
 
-              // TESTING MAP VARIABLE
-              // selected value in dashboard is 1st value
-              cy.getByTestID(
-                `variable-dropdown-input-typeAhead--${mapTypeVarName}`
-              ).should('have.value', 'k1')
-              cy.window()
-                .pipe(getSelectedVariable(dashboard.id, 2))
-                .should('equal', 'v1')
-
-              // select 2nd value in dashboard
-              cy.getByTestID('variable-dropdown--button')
-                .eq(1)
-                .click()
-              cy.get(`#k2`).click()
-
-              // selected value in dashboard is 2nd value
-              cy.getByTestID(
-                `variable-dropdown-input-typeAhead--${mapTypeVarName}`
-              ).should('have.value', 'k2')
-              cy.window()
-                .pipe(getSelectedVariable(dashboard.id, 2))
-                .should('equal', 'v2')
-
-              // open VEO
-              cy.getByTestID('cell-context--toggle').click()
-              cy.getByTestID('cell-context--configure').click()
-              cy.getByTestID('toolbar-tab').should('be.visible')
-
-              // selected value in cell context is 2nd value
-              cy.window()
-                .pipe(getSelectedVariable(dashboard.id, 2))
-                .should('equal', 'v2')
-
-              cy.getByTestID('toolbar-tab').click()
-              cy.get('.flux-toolbar--list-item')
-                .eq(2)
-                .trigger('mouseover')
-              // toggle the variable dropdown in the VEO cell dashboard
-              cy.getByTestID('toolbar-popover--contents').within(() => {
-                cy.getByTestID('variable-dropdown--button').click()
-                // select 1st value in cell
-                cy.getByTestID('variable-dropdown--item')
+                // select 2nd value in dashboard
+                cy.getByTestID('variable-dropdown--button')
                   .first()
                   .click()
-              })
-              // save cell
-              cy.getByTestID('save-cell--button').click()
+                cy.get(`#${defaultBucket}`).click()
 
-              // selected value in cell context is 1st value
-              cy.window()
-                .pipe(getSelectedVariable(dashboard.id, 2))
-                .should('equal', 'v1')
+                // and that it updates the variable in the URL without breaking stuff
+                cy.location('search').should(
+                  'eq',
+                  `?lower=now%28%29%20-%201h&vars%5BbucketsCSV%5D=${defaultBucket}`
+                )
 
-              // selected value in dashboard is 1st value
-              cy.getByTestID(
-                `variable-dropdown-input-typeAhead--${mapTypeVarName}`
-              ).should('have.value', 'k1')
-              cy.window()
-                .pipe(getSelectedVariable(dashboard.id, 2))
-                .should('equal', 'v1')
+                // start new stuff for typeAheadDropdown here:
 
-              cy.getByTestID('cell-context--toggle').click()
-              cy.getByTestID('cell-context--delete').click()
-              cy.getByTestID('cell-context--delete-confirm').click()
+                // type in the input!
+                cy.getByTestID(
+                  `variable-dropdown-input-typeAhead--${bucketVarName}`
+                ).clear()
 
-              // create a new cell
-              cy.getByTestID('add-cell--button').click()
-              cy.getByTestID('switch-to-script-editor').should('be.visible')
-              cy.getByTestID('switch-to-script-editor').click()
+                cy.getByTestID(
+                  `variable-dropdown-input-typeAhead--${bucketVarName}`
+                ).type('an')
 
-              // query for data
-              cy.getByTestID('flux-editor')
-                .should('be.visible')
-                .click()
-                .focused()
-                .clear()
-                .type(
-                  `from(bucket: v.bucketsCSV)
+                // dropdown should  be showing: anotherBucket', 'randomBucket'
+
+                // hit down arrow once:
+
+                cy.getByTestID(
+                  `variable-dropdown-input-typeAhead--${bucketVarName}`
+                ).type('{downarrow}')
+
+                // first element should be active (highlighted)
+                cy.get(`#anotherBucket`).should('have.class', 'active')
+
+                // hit down arrow again
+                cy.getByTestID(
+                  `variable-dropdown-input-typeAhead--${bucketVarName}`
+                ).type('{downarrow}')
+
+                // next one should be active (first should NOT be active)
+                cy.get(`#anotherBucket`).should('not.have.class', 'active')
+                cy.get(`#randomBucket`).should('have.class', 'active')
+
+                // now; press return/enter to set it:
+                cy.getByTestID(
+                  `variable-dropdown-input-typeAhead--${bucketVarName}`
+                ).type('{enter}')
+
+                // selected value in dashboard is 'randomBucket' value
+                cy.getByTestID(
+                  `variable-dropdown-input-typeAhead--${bucketVarName}`
+                ).should('have.value', 'randomBucket')
+
+                // now:  clear the text area, write some text that doesn't match anything,
+                // then click outside; it should revert back to 'randomBucket'
+
+                // type in the input!
+                cy.getByTestID(
+                  `variable-dropdown-input-typeAhead--${bucketVarName}`
+                ).clear()
+
+                cy.getByTestID(
+                  `variable-dropdown-input-typeAhead--${bucketVarName}`
+                ).type('nothingM')
+
+                // end typeAhead section; rest is normal behavoir
+
+                // open VEO
+                cy.getByTestID('cell-context--toggle').click()
+                cy.getByTestID('cell-context--configure').click()
+
+                // selected value in cell context is 2nd value (making sure it reverts back!)
+                cy.window()
+                  .pipe(getSelectedVariable(dashboard.id, 0))
+                  .should('equal', bucket5)
+
+                cy.getByTestID('toolbar-tab').click()
+                cy.get('.flux-toolbar--list-item')
+                  .first()
+                  .trigger('mouseover')
+                // toggle the variable dropdown in the VEO cell dashboard
+                cy.getByTestID('toolbar-popover--contents').within(() => {
+                  cy.getByTestID('variable-dropdown--button').click()
+                  // select 1st value in cell
+                  cy.getByTestID('variable-dropdown--item')
+                    .first()
+                    .click()
+                })
+                // injecting mapTypeVar into query
+                cy.get('.flux-toolbar--list-item')
+                  .eq(mapTypeVarIndex)
+                  .within(() => {
+                    cy.get('.cf-button').click()
+                  })
+                // save cell
+                cy.getByTestID('save-cell--button').click()
+
+                // selected value in cell context is 1st value
+                cy.window()
+                  .pipe(getSelectedVariable(dashboard.id, 0))
+                  .should('equal', bucketOne)
+
+                // selected value in dashboard is 1st value
+                cy.getByTestID(
+                  `variable-dropdown-input-typeAhead--${bucketVarName}`
+                ).should('have.value', bucketOne)
+
+                cy.window()
+                  .pipe(getSelectedVariable(dashboard.id, 0))
+                  .should('equal', bucketOne)
+
+                // TESTING MAP VARIABLE
+                // selected value in dashboard is 1st value
+                cy.getByTestID(
+                  `variable-dropdown-input-typeAhead--${mapTypeVarName}`
+                ).should('have.value', 'k1')
+                cy.window()
+                  .pipe(getSelectedVariable(dashboard.id, 2))
+                  .should('equal', 'v1')
+
+                // select 2nd value in dashboard
+                cy.getByTestID('variable-dropdown--button')
+                  .eq(1)
+                  .click()
+                cy.get(`#k2`).click()
+
+                // selected value in dashboard is 2nd value
+                cy.getByTestID(
+                  `variable-dropdown-input-typeAhead--${mapTypeVarName}`
+                ).should('have.value', 'k2')
+                cy.window()
+                  .pipe(getSelectedVariable(dashboard.id, 2))
+                  .should('equal', 'v2')
+
+                // open VEO
+                cy.getByTestID('cell-context--toggle').click()
+                cy.getByTestID('cell-context--configure').click()
+                cy.getByTestID('toolbar-tab').should('be.visible')
+
+                // selected value in cell context is 2nd value
+                cy.window()
+                  .pipe(getSelectedVariable(dashboard.id, 2))
+                  .should('equal', 'v2')
+
+                cy.getByTestID('toolbar-tab').click()
+                cy.get('.flux-toolbar--list-item')
+                  .eq(2)
+                  .trigger('mouseover')
+                // toggle the variable dropdown in the VEO cell dashboard
+                cy.getByTestID('toolbar-popover--contents').within(() => {
+                  cy.getByTestID('variable-dropdown--button').click()
+                  // select 1st value in cell
+                  cy.getByTestID('variable-dropdown--item')
+                    .first()
+                    .click()
+                })
+                // save cell
+                cy.getByTestID('save-cell--button').click()
+
+                // selected value in cell context is 1st value
+                cy.window()
+                  .pipe(getSelectedVariable(dashboard.id, 2))
+                  .should('equal', 'v1')
+
+                // selected value in dashboard is 1st value
+                cy.getByTestID(
+                  `variable-dropdown-input-typeAhead--${mapTypeVarName}`
+                ).should('have.value', 'k1')
+                cy.window()
+                  .pipe(getSelectedVariable(dashboard.id, 2))
+                  .should('equal', 'v1')
+
+                cy.getByTestID('cell-context--toggle').click()
+                cy.getByTestID('cell-context--delete').click()
+                cy.getByTestID('cell-context--delete-confirm').click()
+
+                // create a new cell
+                cy.getByTestID('add-cell--button').click()
+                cy.getByTestID('switch-to-script-editor').should('be.visible')
+                cy.getByTestID('switch-to-script-editor').click()
+
+                // query for data
+                cy.getByTestID('flux-editor')
+                  .should('be.visible')
+                  .click()
+                  .focused()
+                  .clear()
+                  .type(
+                    `from(bucket: v.bucketsCSV)
 |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
 |> filter(fn: (r) => r["_measurement"] == "m")
 |> filter(fn: (r) => r["_field"] == "v")
 |> filter(fn: (r) => r["tk1"] == "tv1")
 |> aggregateWindow(every: v.windowPeriod, fn: max)
 |> yield(name: "max")`,
-                  {force: true, delay: 1}
-                )
+                    {force: true, delay: 1}
+                  )
 
-              // `bucketOne` should not exist nor have data written to it
-              cy.getByTestID('save-cell--button').click()
-              cy.getByTestID('empty-graph-error').contains(`${bucketOne}`)
+                // `bucketOne` should not exist nor have data written to it
+                cy.getByTestID('save-cell--button').click()
+                cy.getByTestID('empty-graph-error').contains(`${bucketOne}`)
 
-              // select default bucket that has data
-              cy.getByTestID('variable-dropdown--button')
-                .eq(0)
-                .click()
-              cy.get(`#${defaultBucket}`).click()
+                // select default bucket that has data
+                cy.getByTestID('variable-dropdown--button')
+                  .eq(0)
+                  .click()
+                cy.get(`#${defaultBucket}`).click()
 
-              // assert visualization appears
-              cy.getByTestID('giraffe-layer-line').should('exist')
+                // assert visualization appears
+                cy.getByTestID('giraffe-layer-line').should('exist')
+              })
             })
           })
         })
       })
     })
 
-    it.only('dependent variables reload properly', () => {
+    it('dependent variables reload properly', () => {
       const bucketOne = 'b1'
       const bucketThree = 'b3'
       const bucketVarName = 'bucketsCSV'
@@ -606,21 +612,24 @@ describe('Dashboard', () => {
       const dependentTypeVarName = 'greeting'
       const bucketVarIndex = 0
 
-      cy.get('@org').then(({id: orgID}: Organization) => {
-        cy.get<Dashboard>('@dashboard').then(({dashboard}) => {
-          cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
-            cy.createCSVVariable(orgID, bucketVarName, [
-              bucketOne,
-              defaultBucket,
-              bucketThree,
-              bucket4,
-              bucket5,
-            ])
+      cy.window().then(win => {
+        win.influx.set(typeAheadFlag, true)
 
-            cy.createQueryVariable(
-              orgID,
-              'greeting',
-              `import "csv"
+        cy.get('@org').then(({id: orgID}: Organization) => {
+          cy.get<Dashboard>('@dashboard').then(({dashboard}) => {
+            cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
+              cy.createCSVVariable(orgID, bucketVarName, [
+                bucketOne,
+                defaultBucket,
+                bucketThree,
+                bucket4,
+                bucket5,
+              ])
+
+              cy.createQueryVariable(
+                orgID,
+                'greeting',
+                `import "csv"
 data = "#group,false,false,false,false
 #datatype,string,long,string,string
 #default,_result,,,
@@ -633,279 +642,283 @@ data = "#group,false,false,false,false
 ,,0,seeya,b3
 "
 csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
-            )
+              )
 
-            cy.fixture('routes').then(({orgs}) => {
-              cy.visit(`${orgs}/${orgID}/dashboards/${dashboard.id}`)
-              cy.getByTestID('tree-nav')
-            })
-            // add cell with variable in its query
-            cy.getByTestID('add-cell--button').click()
-            cy.getByTestID('switch-to-script-editor').should('be.visible')
-            cy.getByTestID('switch-to-script-editor').click()
-            cy.getByTestID('toolbar-tab').click()
+              cy.fixture('routes').then(({orgs}) => {
+                cy.visit(`${orgs}/${orgID}/dashboards/${dashboard.id}`)
+                cy.getByTestID('tree-nav')
+              })
+              // add cell with variable in its query
+              cy.getByTestID('add-cell--button').click()
+              cy.getByTestID('switch-to-script-editor').should('be.visible')
+              cy.getByTestID('switch-to-script-editor').click()
+              cy.getByTestID('toolbar-tab').click()
 
-            cy.getByTestID('flux-editor')
-              .should('be.visible')
-              .click()
-              .focused()
-              .clear()
-              .type(
-                `from(bucket: v.bucketsCSV)
+              cy.getByTestID('flux-editor')
+                .should('be.visible')
+                .click()
+                .focused()
+                .clear()
+                .type(
+                  `from(bucket: v.bucketsCSV)
 |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
 |> filter(fn: (r) => r["_field"] == v.greeting)
 |> aggregateWindow(every: v.windowPeriod, fn: max)
 |> yield(name: "max")`,
-                {force: true, delay: 1}
+                  {force: true, delay: 1}
+                )
+              cy.get('.flux-toolbar--list-item')
+                .eq(bucketVarIndex)
+                .within(() => {
+                  cy.get('.cf-button').click()
+                })
+              cy.getByTestID('save-cell--button').click()
+
+              //ok; now check that 'b1' is selected and 'greeting' has 'adios' selected
+              cy.getByTestID(
+                `variable-dropdown-input-typeAhead--${bucketVarName}`
+              ).should('have.value', bucketOne)
+
+              cy.getByTestID(
+                `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
+              ).should('have.value', 'adios')
+
+              //hit downarrow in the second dropdown:
+              cy.getByTestID(
+                `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
+              ).type('{downarrow}')
+
+              //check that both 'adios' and 'hola' are showing: (and with correct classes)
+              cy.get(`#hola`).should('not.have.class', 'active')
+              cy.get(`#adios`).should('have.class', 'active')
+
+              //hit the down arrow again:
+              cy.getByTestID(
+                `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
+              ).type('{downarrow}')
+
+              //check that both 'adios' and 'hola' are showing: (and with correct classes)
+              cy.get(`#hola`).should('have.class', 'active')
+
+              //'adios' is still active b/c it is selected.....
+              cy.get(`#adios`).should('have.class', 'active')
+
+              //press enter to select:
+              cy.getByTestID(
+                `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
+              ).type('{enter}')
+
+              //'hola' should now be selected:
+              cy.getByTestID(
+                `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
+              ).should('have.value', 'hola')
+
+              //ok!  now;  pick a different bucket:
+
+              //but first test that it only allows valid values:
+              cy.getByTestID(
+                `variable-dropdown-input-typeAhead--${bucketVarName}`
               )
-            cy.get('.flux-toolbar--list-item')
-              .eq(bucketVarIndex)
-              .within(() => {
-                cy.get('.cf-button').click()
-              })
-            cy.getByTestID('save-cell--button').click()
+                .type('b3789')
+                .type('{enter}')
+                .should('have.value', 'b1')
 
-            //ok; now check that 'b1' is selected and 'greeting' has 'adios' selected
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${bucketVarName}`
-            ).should('have.value', bucketOne)
+              //now clear it first and do it right:
+              cy.getByTestID(
+                `variable-dropdown-input-typeAhead--${bucketVarName}`
+              )
+                .clear()
+                .type('b3')
+                .type('{enter}')
+                .should('have.value', 'b3')
 
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
-            ).should('have.value', 'adios')
+              //now the 'greeting' should be empty
+              cy.getByTestID(
+                `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
+              ).should('have.value', '')
 
-            //hit downarrow in the second dropdown:
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
-            ).type('{downarrow}')
+              //click the dropdownbutton:
+              // select 2nd value in dashboard
+              cy.getByTestID('variable-dropdown--button')
+                .eq(1)
+                .click()
 
-            //check that both 'adios' and 'hola' are showing: (and with correct classes)
-            cy.get(`#hola`).should('not.have.class', 'active')
-            cy.get(`#adios`).should('have.class', 'active')
+              //verify they are all there and with no active class:
+              cy.get(`#hello`).should('not.have.class', 'active')
+              cy.get(`#goodbye`).should('not.have.class', 'active')
+              cy.get(`#seeya`).should('not.have.class', 'active')
 
-            //hit the down arrow again:
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
-            ).type('{downarrow}')
+              cy.getByTestID(
+                `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
+              )
+                .type('el')
+                .type('{downarrow}')
+                .type('{enter}')
 
-            //check that both 'adios' and 'hola' are showing: (and with correct classes)
-            cy.get(`#hola`).should('have.class', 'active')
+              cy.getByTestID(
+                `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
+              ).should('have.value', 'hello')
 
-            //'adios' is still active b/c it is selected.....
-            cy.get(`#adios`).should('have.class', 'active')
+              //ok; now switch to a bucket with NO greeting vars; test that:
 
-            //press enter to select:
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
-            ).type('{enter}')
+              cy.getByTestID(
+                `variable-dropdown-input-typeAhead--${bucketVarName}`
+              )
+                .clear()
+                .type('random')
+                .type('{downarrow}')
+                .type('{enter}')
+                .should('have.value', bucket5)
 
-            //'hola' should now be selected:
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
-            ).should('have.value', 'hola')
+              //the greeting vars should NOT be there
+              cy.getByTestID(
+                `variable-dropdown--${dependentTypeVarName}`
+              ).should('contain', 'No Values')
 
-            //ok!  now;  pick a different bucket:
+              //now, go back to b3; 'hello' should be th eselected greeting
+              cy.getByTestID(
+                `variable-dropdown-input-typeAhead--${bucketVarName}`
+              )
+                .clear()
+                .type('b3')
+                .type('{downarrow}')
+                .type('{enter}')
+                .should('have.value', bucketThree)
 
-            //but first test that it only allows valid values:
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${bucketVarName}`
-            )
-              .type('b3')
-              .type('{enter}')
-              .should('have.value', 'b1')
-
-            //now clear it first and do it right:
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${bucketVarName}`
-            )
-              .clear()
-              .type('b3')
-              .type('{downarrow}')
-              .type('{enter}')
-              .should('have.value', 'b3')
-
-            //now the 'greeting' should be empty
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
-            ).should('have.value', '')
-
-            //click the dropdownbutton:
-            // select 2nd value in dashboard
-            cy.getByTestID('variable-dropdown--button')
-              .eq(1)
-              .click()
-
-            //verify they are all there and with no active class:
-            cy.get(`#hello`).should('not.have.class', 'active')
-            cy.get(`#goodbye`).should('not.have.class', 'active')
-            cy.get(`#seeya`).should('not.have.class', 'active')
-
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
-            )
-              .type('el')
-              .type('{downarrow}')
-              .type('{enter}')
-
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
-            ).should('have.value', 'hello')
-
-            //ok; now switch to a bucket with NO greeting vars; test that:
-
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${bucketVarName}`
-            )
-              .clear()
-              .type('random')
-              .type('{downarrow}')
-              .type('{enter}')
-              .should('have.value', bucket5)
-
-            //the greeting vars should NOT be there
-            cy.getByTestID(`variable-dropdown--${dependentTypeVarName}`).should(
-              'contain',
-              'No Values'
-            )
-
-            //now, go back to b3; 'hello' should be th eselected greeting
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${bucketVarName}`
-            )
-              .clear()
-              .type('b3')
-              .type('{downarrow}')
-              .type('{enter}')
-              .should('have.value', bucketThree)
-
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
-            ).should('have.value', 'hello')
+              cy.getByTestID(
+                `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
+              ).should('have.value', 'hello')
+            })
           })
         })
       })
     })
 
     it('ensures that dependent variables load one another accordingly, even with reload and cleared local storage', () => {
-      cy.get('@org').then(({id: orgID}: Organization) => {
-        cy.createDashboard(orgID).then(({body: dashboard}) => {
-          cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
-            const now = Date.now()
-            cy.writeData([
-              `test,container_name=cool dopeness=12 ${now - 1000}000000`,
-              `test,container_name=beans dopeness=18 ${now - 1200}000000`,
-              `test,container_name=cool dopeness=14 ${now - 1400}000000`,
-              `test,container_name=beans dopeness=10 ${now - 1600}000000`,
-            ])
-            cy.createCSVVariable(orgID, 'static', ['beans', defaultBucket])
-            cy.createQueryVariable(
-              orgID,
-              'dependent',
-              `import "influxdata/influxdb/v1"
+      cy.window().then(win => {
+        win.influx.set(typeAheadFlag, true)
+
+        cy.get('@org').then(({id: orgID}: Organization) => {
+          cy.createDashboard(orgID).then(({body: dashboard}) => {
+            cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
+              const now = Date.now()
+              cy.writeData([
+                `test,container_name=cool dopeness=12 ${now - 1000}000000`,
+                `test,container_name=beans dopeness=18 ${now - 1200}000000`,
+                `test,container_name=cool dopeness=14 ${now - 1400}000000`,
+                `test,container_name=beans dopeness=10 ${now - 1600}000000`,
+              ])
+              cy.createCSVVariable(orgID, 'static', ['beans', defaultBucket])
+              cy.createQueryVariable(
+                orgID,
+                'dependent',
+                `import "influxdata/influxdb/v1"
             v1.tagValues(bucket: v.static, tag: "container_name") |> keep(columns: ["_value"])`
-            )
-            cy.createQueryVariable(
-              orgID,
-              'build',
-              `import "influxdata/influxdb/v1"
+              )
+              cy.createQueryVariable(
+                orgID,
+                'build',
+                `import "influxdata/influxdb/v1"
             import "strings"
             v1.tagValues(bucket: v.static, tag: "container_name") |> filter(fn: (r) => strings.hasSuffix(v: r._value, suffix: v.dependent))`
-            )
+              )
 
-            cy.fixture('routes').then(({orgs}) => {
-              cy.visit(`${orgs}/${orgID}/dashboards/${dashboard.id}`)
-              cy.getByTestID('tree-nav')
-            })
+              cy.fixture('routes').then(({orgs}) => {
+                cy.visit(`${orgs}/${orgID}/dashboards/${dashboard.id}`)
+                cy.getByTestID('tree-nav')
+              })
 
-            cy.getByTestID('add-cell--button').click()
-            cy.getByTestID('switch-to-script-editor').should('be.visible')
-            cy.getByTestID('switch-to-script-editor').click()
-            cy.getByTestID('toolbar-tab').click()
+              cy.getByTestID('add-cell--button').click()
+              cy.getByTestID('switch-to-script-editor').should('be.visible')
+              cy.getByTestID('switch-to-script-editor').click()
+              cy.getByTestID('toolbar-tab').click()
 
-            cy
-              .getByTestID('flux-editor')
-              .should('be.visible')
-              .click()
-              .focused().type(`from(bucket: v.static)
+              cy
+                .getByTestID('flux-editor')
+                .should('be.visible')
+                .click()
+                .focused().type(`from(bucket: v.static)
 |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
 |> filter(fn: (r) => r["_measurement"] == "test")
 |> filter(fn: (r) => r["_field"] == "dopeness")
 |> filter(fn: (r) => r["container_name"] == v.build)`)
 
-            cy.getByTestID('save-cell--button').click()
+              cy.getByTestID('save-cell--button').click()
 
-            // the default bucket selection should have no results and load all three variables
-            // even though only two variables are being used (because 1 is dependent upon another)
-            cy.getByTestID('variable-dropdown--static').should(
-              'contain',
-              'beans'
-            )
+              // the default bucket selection should have no results and load all three variables
+              // even though only two variables are being used (because 1 is dependent upon another)
+              cy.getByTestID(
+                'variable-dropdown-input-typeAhead--static'
+              ).should('have.value', 'beans')
 
-            // and cause the rest to exist in loading states
-            cy.getByTestIDSubStr('variable-dropdown--build').should(
-              'contain',
-              'Loading'
-            )
+              // and cause the rest to exist in loading states
+              cy.getByTestIDSubStr('variable-dropdown--build').should(
+                'contain',
+                'Loading'
+              )
 
-            cy.getByTestIDSubStr('cell--view-empty')
+              cy.getByTestIDSubStr('cell--view-empty')
 
-            // But selecting a nonempty bucket should load some data
-            cy.getByTestID('variable-dropdown--button')
-              .eq(0)
-              .click()
-            cy.get(`#${defaultBucket}`).click()
+              // But selecting a nonempty bucket should load some data
+              cy.getByTestID('variable-dropdown--button')
+                .eq(0)
+                .click()
+              cy.get(`#${defaultBucket}`).click()
 
-            // default select the first result
-            cy.getByTestIDSubStr('variable-dropdown--build').should(
-              'contain',
-              'beans'
-            )
+              // default select the first result
+              cy.getByTestID('variable-dropdown-input-typeAhead--build').should(
+                'have.value',
+                'beans'
+              )
 
-            // and also load the third result
-            cy.getByTestID('variable-dropdown--button')
-              .eq(2)
-              .should('contain', 'beans')
-              .click()
-            cy.get(`#cool`).click()
+              cy.getByTestID(
+                'variable-dropdown-input-typeAhead--dependent'
+              ).should('have.value', 'beans')
 
-            // and also load the second result
-            cy.getByTestIDSubStr('variable-dropdown--dependent').should(
-              'contain',
-              'cool'
-            )
+              // and also load the third result
+              cy.getByTestID('variable-dropdown--button')
+                .eq(2)
+                .click()
+              cy.get(`#cool`).click()
 
-            // updating the third variable should update the second
-            cy.getByTestID('variable-dropdown--button')
-              .eq(2)
-              .click()
-            cy.get(`#beans`).click()
-            cy.getByTestIDSubStr('variable-dropdown--build').should(
-              'contain',
-              'beans'
-            )
-          })
-          cy.clearLocalStorage()
-          cy.reload()
-          cy.get<string>('@defaultBucket').then(() => {
-            // the default bucket selection should have no results and load all three variables
-            // even though only two variables are being used (because 1 is dependent upon another)
-            cy.getByTestID('variable-dropdown--static').should(
-              'contain',
-              'defbuck'
-            )
+              // and also load the second result
+              cy.getByTestID(
+                'variable-dropdown-input-typeAhead--dependent'
+              ).should('have.value', 'cool')
 
-            // and cause the rest to exist in loading states
-            cy.getByTestIDSubStr('variable-dropdown--build').should(
-              'contain',
-              'beans'
-            )
+              // updating the third variable should update the second
+              cy.getByTestID('variable-dropdown--button')
+                .eq(2)
+                .click()
+              cy.get(`#beans`).click()
+              cy.getByTestID('variable-dropdown-input-typeAhead--build').should(
+                'have.value',
+                'beans'
+              )
+            })
+            cy.clearLocalStorage()
+            cy.reload()
+            cy.get<string>('@defaultBucket').then(() => {
+              // the default bucket selection should have no results and load all three variables
+              // even though only two variables are being used (because 1 is dependent upon another)
+              cy.getByTestID(
+                'variable-dropdown-input-typeAhead--static'
+              ).should('have.value', 'defbuck')
 
-            // and also load the second result
+              //todo:  verify comment....JILL
+              // and cause the rest to exist in loading states
+              cy.getByTestID('variable-dropdown-input-typeAhead--build').should(
+                'have.value',
+                'beans'
+              )
 
-            cy.getByTestIDSubStr('variable-dropdown--build').should(
-              'contain',
-              'beans'
-            )
+              // and also load the second result
+
+              cy.getByTestID('variable-dropdown-input-typeAhead--build').should(
+                'have.value',
+                'beans'
+              )
+            })
           })
         })
       })
@@ -942,82 +955,86 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
     with only 4 api queries being sent to fulfill it all
   \*/
     it('can load dependent queries without much fuss', () => {
-      cy.get('@org').then(({id: orgID}: Organization) => {
-        cy.createDashboard(orgID).then(({body: dashboard}) => {
-          cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
-            const now = Date.now()
-            cy.writeData([
-              `test,container_name=cool dopeness=12 ${now - 1000}000000`,
-              `test,container_name=beans dopeness=18 ${now - 1200}000000`,
-              `test,container_name=cool dopeness=14 ${now - 1400}000000`,
-              `test,container_name=beans dopeness=10 ${now - 1600}000000`,
-            ])
-            cy.createCSVVariable(orgID, 'static', ['beans', defaultBucket])
-            cy.createQueryVariable(
-              orgID,
-              'dependent',
-              `from(bucket: v.static)
+      cy.window().then(win => {
+        win.influx.set(typeAheadFlag, true)
+        cy.get('@org').then(({id: orgID}: Organization) => {
+          cy.createDashboard(orgID).then(({body: dashboard}) => {
+            cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
+              const now = Date.now()
+              cy.writeData([
+                `test,container_name=cool dopeness=12 ${now - 1000}000000`,
+                `test,container_name=beans dopeness=18 ${now - 1200}000000`,
+                `test,container_name=cool dopeness=14 ${now - 1400}000000`,
+                `test,container_name=beans dopeness=10 ${now - 1600}000000`,
+              ])
+              cy.createCSVVariable(orgID, 'static', ['beans', defaultBucket])
+              cy.createQueryVariable(
+                orgID,
+                'dependent',
+                `from(bucket: v.static)
   |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
   |> filter(fn: (r) => r["_measurement"] == "test")
   |> keep(columns: ["container_name"])
   |> rename(columns: {"container_name": "_value"})
   |> last()
   |> group()`
-            )
+              )
 
-            cy.fixture('routes').then(({orgs}) => {
-              cy.visit(`${orgs}/${orgID}/dashboards/${dashboard.id}`)
+              cy.fixture('routes').then(({orgs}) => {
+                cy.visit(`${orgs}/${orgID}/dashboards/${dashboard.id}`)
+              })
             })
           })
         })
-      })
-      cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
-        cy.getByTestID('add-cell--button').click()
-        cy.getByTestID('switch-to-script-editor').should('be.visible')
-        cy.getByTestID('switch-to-script-editor').click()
-        cy.getByTestID('toolbar-tab').click()
+        cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
+          cy.getByTestID('add-cell--button').click()
+          cy.getByTestID('switch-to-script-editor').should('be.visible')
+          cy.getByTestID('switch-to-script-editor').click()
+          cy.getByTestID('toolbar-tab').click()
 
-        cy
-          .getByTestID('flux-editor')
-          .should('be.visible')
-          .click()
-          .focused().type(`from(bucket: v.static)
+          cy
+            .getByTestID('flux-editor')
+            .should('be.visible')
+            .click()
+            .focused().type(`from(bucket: v.static)
 |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
 |> filter(fn: (r) => r["_measurement"] == "test")
 |> filter(fn: (r) => r["_field"] == "dopeness")
 |> filter(fn: (r) => r["container_name"] == v.dependent)`)
-        cy.getByTestID('save-cell--button').click()
+          cy.getByTestID('save-cell--button').click()
 
-        // the default bucket selection should have no results
-        cy.getByTestIDSubStr('variable-dropdown')
-          .eq(0)
-          .should('contain', 'beans')
+          // the default bucket selection should have no results
+          cy.getByTestID('variable-dropdown-input-typeAhead--static').should(
+            'have.value',
+            'beans'
+          )
 
-        // and cause the rest to exist in loading states
-        cy.getByTestIDSubStr('variable-dropdown--dependent').should(
-          'contain',
-          'Loading'
-        )
+          // and cause the rest to exist in loading states
+          cy.getByTestIDSubStr('variable-dropdown--dependent').should(
+            'contain',
+            'Loading'
+          )
 
-        cy.getByTestIDSubStr('cell--view-empty')
+          cy.getByTestIDSubStr('cell--view-empty')
 
-        // But selecting a nonempty bucket should load some data
-        cy.getByTestID('variable-dropdown--button')
-          .eq(0)
-          .click()
-        cy.get(`#${defaultBucket}`).click()
+          // But selecting a nonempty bucket should load some data
+          cy.getByTestID('variable-dropdown--button')
+            .eq(0)
+            .click()
+          cy.get(`#${defaultBucket}`).click()
 
-        // default select the first result
-        cy.getByTestID('variable-dropdown--dependent').should(
-          'contain',
-          'beans'
-        )
+          // default select the first result
+          cy.getByTestID('variable-dropdown-input-typeAhead--dependent').should(
+            'have.value',
+            'beans'
+          )
 
-        // and also load the second result
-        cy.getByTestID('variable-dropdown--button')
-          .eq(1)
-          .click()
-        cy.get(`#cool`).click()
+          // and also load the second result
+          cy.getByTestID('variable-dropdown--button')
+            .eq(1)
+            .click()
+          cy.get(`#cool`).click()
+        })
       })
     })
   })

--- a/cypress/e2e/shared/dashboardsView.test.ts
+++ b/cypress/e2e/shared/dashboardsView.test.ts
@@ -450,7 +450,7 @@ describe('Dashboard', () => {
                   `variable-dropdown-input-typeAhead--${bucketVarName}`
                 ).type('nothingM')
 
-                // end typeAhead section; rest is normal behavoir
+                // end typeAhead section; rest is normal behavior
 
                 // open VEO
                 cy.getByTestID('cell-context--toggle').click()
@@ -602,7 +602,7 @@ describe('Dashboard', () => {
       })
     })
 
-    it('dependent variables reload properly', () => {
+    it('reloads dependent variables properly', () => {
       const bucketOne = 'b1'
       const bucketThree = 'b3'
       const bucketVarName = 'bucketsCSV'
@@ -716,6 +716,48 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
               // ok!  now;  pick a different bucket:
 
               // but first test that it only allows valid values:
+              cy.getByTestID(
+                `variable-dropdown-input-typeAhead--${bucketVarName}`
+              )
+                .type('b3789')
+                .type('{enter}')
+                .should('have.value', 'b1')
+
+              // while it still has the `b1' value, test the clickAwayHere functionality:
+
+              // type in a fake value, then click away, the prev value should be showing
+              cy.getByTestID(
+                `variable-dropdown-input-typeAhead--${bucketVarName}`
+              )
+                .clear()
+                .type('b3789')
+
+              //now click away
+              cy.getByTestID('variable-dropdown--button')
+                .eq(1)
+                .click()
+
+              cy.getByTestID(
+                `variable-dropdown-input-typeAhead--${bucketVarName}`
+              ).should('have.value', 'b1')
+
+              // type in a real value, then click away, the prev value should be showing
+              cy.getByTestID(
+                `variable-dropdown-input-typeAhead--${bucketVarName}`
+              )
+                .clear()
+                .type('b3')
+
+              //now click away
+              cy.getByTestID('variable-dropdown--button')
+                .eq(1)
+                .click()
+
+              cy.getByTestID(
+                `variable-dropdown-input-typeAhead--${bucketVarName}`
+              ).should('have.value', 'b1')
+
+              // now back to testing that only valid values work:
               cy.getByTestID(
                 `variable-dropdown-input-typeAhead--${bucketVarName}`
               )

--- a/cypress/e2e/shared/dashboardsView.test.ts
+++ b/cypress/e2e/shared/dashboardsView.test.ts
@@ -674,7 +674,7 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
                 })
               cy.getByTestID('save-cell--button').click()
 
-              //ok; now check that 'b1' is selected and 'greeting' has 'adios' selected
+              // ok; now check that 'b1' is selected and 'greeting' has 'adios' selected
               cy.getByTestID(
                 `variable-dropdown-input-typeAhead--${bucketVarName}`
               ).should('have.value', bucketOne)
@@ -683,39 +683,39 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
                 `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
               ).should('have.value', 'adios')
 
-              //hit downarrow in the second dropdown:
+              // hit downarrow in the second dropdown:
               cy.getByTestID(
                 `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
               ).type('{downarrow}')
 
-              //check that both 'adios' and 'hola' are showing: (and with correct classes)
+              // check that both 'adios' and 'hola' are showing: (and with correct classes)
               cy.get(`#hola`).should('not.have.class', 'active')
               cy.get(`#adios`).should('have.class', 'active')
 
-              //hit the down arrow again:
+              // hit the down arrow again:
               cy.getByTestID(
                 `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
               ).type('{downarrow}')
 
-              //check that both 'adios' and 'hola' are showing: (and with correct classes)
+              // check that both 'adios' and 'hola' are showing: (and with correct classes)
               cy.get(`#hola`).should('have.class', 'active')
 
-              //'adios' is still active b/c it is selected.....
+              // 'adios' is still active b/c it is selected.....
               cy.get(`#adios`).should('have.class', 'active')
 
-              //press enter to select:
+              // press enter to select:
               cy.getByTestID(
                 `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
               ).type('{enter}')
 
-              //'hola' should now be selected:
+              // 'hola' should now be selected:
               cy.getByTestID(
                 `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
               ).should('have.value', 'hola')
 
-              //ok!  now;  pick a different bucket:
+              // ok!  now;  pick a different bucket:
 
-              //but first test that it only allows valid values:
+              // but first test that it only allows valid values:
               cy.getByTestID(
                 `variable-dropdown-input-typeAhead--${bucketVarName}`
               )
@@ -723,7 +723,7 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
                 .type('{enter}')
                 .should('have.value', 'b1')
 
-              //now clear it first and do it right:
+              // now clear it first and do it right:
               cy.getByTestID(
                 `variable-dropdown-input-typeAhead--${bucketVarName}`
               )
@@ -732,18 +732,18 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
                 .type('{enter}')
                 .should('have.value', 'b3')
 
-              //now the 'greeting' should be empty
+              // now the 'greeting' should be empty
               cy.getByTestID(
                 `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
               ).should('have.value', '')
 
-              //click the dropdownbutton:
+              // click the dropdownbutton:
               // select 2nd value in dashboard
               cy.getByTestID('variable-dropdown--button')
                 .eq(1)
                 .click()
 
-              //verify they are all there and with no active class:
+              // verify they are all there and with no active class:
               cy.get(`#hello`).should('not.have.class', 'active')
               cy.get(`#goodbye`).should('not.have.class', 'active')
               cy.get(`#seeya`).should('not.have.class', 'active')
@@ -759,7 +759,7 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
                 `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
               ).should('have.value', 'hello')
 
-              //ok; now switch to a bucket with NO greeting vars; test that:
+              // ok; now switch to a bucket with NO greeting vars; test that:
 
               cy.getByTestID(
                 `variable-dropdown-input-typeAhead--${bucketVarName}`
@@ -770,12 +770,12 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
                 .type('{enter}')
                 .should('have.value', bucket5)
 
-              //the greeting vars should NOT be there
+              // the greeting vars should NOT be there
               cy.getByTestID(
                 `variable-dropdown--${dependentTypeVarName}`
               ).should('contain', 'No Values')
 
-              //now, go back to b3; 'hello' should be th eselected greeting
+              // now, go back to b3; 'hello' should be th eselected greeting
               cy.getByTestID(
                 `variable-dropdown-input-typeAhead--${bucketVarName}`
               )
@@ -794,9 +794,14 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
       })
     })
 
+    // leaving this test to test the non-type ahead dropdown.  with all the reloads the flag setting
+    // is not functional.  plus we need to test the normal one anyone until the typeahead flag is gone.
+    // when that flag goes away, need to update this test!
+
+    // explicitly setting flag to false tho; because previous tests have set it to true.
     it('ensures that dependent variables load one another accordingly, even with reload and cleared local storage', () => {
       cy.window().then(win => {
-        win.influx.set(typeAheadFlag, true)
+        win.influx.set(typeAheadFlag, false)
 
         cy.get('@org').then(({id: orgID}: Organization) => {
           cy.createDashboard(orgID).then(({body: dashboard}) => {
@@ -847,12 +852,13 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
 
               // the default bucket selection should have no results and load all three variables
               // even though only two variables are being used (because 1 is dependent upon another)
-              cy.getByTestID(
-                'variable-dropdown-input-typeAhead--static'
-              ).should('have.value', 'beans')
+              cy.getByTestID('variable-dropdown--static').should(
+                'contain',
+                'beans'
+              )
 
               // and cause the rest to exist in loading states
-              cy.getByTestIDSubStr('variable-dropdown--build').should(
+              cy.getByTestID('variable-dropdown--build').should(
                 'contain',
                 'Loading'
               )
@@ -866,33 +872,31 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
               cy.get(`#${defaultBucket}`).click()
 
               // default select the first result
-              cy.getByTestID('variable-dropdown-input-typeAhead--build').should(
-                'have.value',
+              cy.getByTestID('variable-dropdown--build').should(
+                'contain',
                 'beans'
               )
-
-              cy.getByTestID(
-                'variable-dropdown-input-typeAhead--dependent'
-              ).should('have.value', 'beans')
 
               // and also load the third result
               cy.getByTestID('variable-dropdown--button')
                 .eq(2)
+                .should('contain', 'beans')
                 .click()
               cy.get(`#cool`).click()
 
               // and also load the second result
-              cy.getByTestID(
-                'variable-dropdown-input-typeAhead--dependent'
-              ).should('have.value', 'cool')
+              cy.getByTestID('variable-dropdown--dependent').should(
+                'contain',
+                'cool'
+              )
 
               // updating the third variable should update the second
               cy.getByTestID('variable-dropdown--button')
                 .eq(2)
                 .click()
               cy.get(`#beans`).click()
-              cy.getByTestID('variable-dropdown-input-typeAhead--build').should(
-                'have.value',
+              cy.getByTestID('variable-dropdown--build').should(
+                'contain',
                 'beans'
               )
             })
@@ -901,21 +905,21 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
             cy.get<string>('@defaultBucket').then(() => {
               // the default bucket selection should have no results and load all three variables
               // even though only two variables are being used (because 1 is dependent upon another)
-              cy.getByTestID(
-                'variable-dropdown-input-typeAhead--static'
-              ).should('have.value', 'defbuck')
+              cy.getByTestID('variable-dropdown--static').should(
+                'contain',
+                'defbuck'
+              )
 
-              //todo:  verify comment....JILL
               // and cause the rest to exist in loading states
-              cy.getByTestID('variable-dropdown-input-typeAhead--build').should(
-                'have.value',
+              cy.getByTestID('variable-dropdown--build').should(
+                'contain',
                 'beans'
               )
 
               // and also load the second result
 
-              cy.getByTestID('variable-dropdown-input-typeAhead--build').should(
-                'have.value',
+              cy.getByTestID('variable-dropdown--build').should(
+                'contain',
                 'beans'
               )
             })

--- a/src/variables/components/TypeAheadVariableDropdown.test.tsx
+++ b/src/variables/components/TypeAheadVariableDropdown.test.tsx
@@ -83,7 +83,7 @@ const setInitialState = (state: AppState): AppState => {
 }
 
 describe('Dashboards.Components.VariablesControlBar.TypeAheadVariableDropdown', () => {
-  describe('if map type', () => {
+  describe('variable map type', () => {
     it('renders dropdown with keys as dropdown items', () => {
       const {getByTestId, getAllByTestId} = renderWithRedux(
         <TypeAheadVariableDropdown variableID="03cbdc8a53a63000" />,

--- a/src/variables/components/TypeAheadVariableDropdown.test.tsx
+++ b/src/variables/components/TypeAheadVariableDropdown.test.tsx
@@ -8,7 +8,6 @@ import TypeAheadVariableDropdown from 'src/variables/components/TypeAheadVariabl
 // Utils
 import {renderWithRedux} from 'src/mockState'
 import {AppState, RemoteDataState} from 'src/types'
-import {Input} from '@influxdata/clockface'
 
 const values = {
   def: 'defbuck',
@@ -107,7 +106,9 @@ describe('Dashboards.Components.VariablesControlBar.TypeAheadVariableDropdown', 
       setInitialState
     )
 
-    const filterInput = getByTestId('variable-dropdown--input-typeAhead')
+    const filterInput = getByTestId(
+      'variable-dropdown-input-typeAhead--map_buckets'
+    )
 
     const checkDropdown = (filterText, expectedList) => {
       fireEvent.change(filterInput, {target: {value: filterText}})
@@ -133,28 +134,4 @@ describe('Dashboards.Components.VariablesControlBar.TypeAheadVariableDropdown', 
     const items = screen.queryByTestId('variable-dropdown--item')
     expect(items).toBeNull() // it doesn't exist
   })
-  //
-  // it('arrow buttons work to activate prior to selection', () => {
-  //   const {getByTestId, getAllByTestId} = renderWithRedux(
-  //       <TypeAheadVariableDropdown variableID="03cbdc8a53a63000" />,
-  //       setInitialState
-  //   )
-  //
-  //   const filterInput = getByTestId('variable-dropdown--input-typeAhead')
-  //
-  //   fireEvent.change(filterInput, {target: {value: 'f'}})
-  //   fireEvent.keyDown(filterInput, { key: 'ArrowDown', which: 40, code: 'ArrowDown' })
-  //     it's not getting the keydown event properly
-  //   //the first one (  def: 'defbuck',) should be 'activated'
-  //
-  //   const defBuckItem = getAllByTestId('variable-dropdown--item').filter(node =>
-  //       node.id === 'def'
-  //   )
-  //
-  //   console.log("defBuckitem??", defBuckItem);
-  //
-  //
-  //
-  //
-  // })
 })

--- a/src/variables/components/TypeAheadVariableDropdown.test.tsx
+++ b/src/variables/components/TypeAheadVariableDropdown.test.tsx
@@ -1,0 +1,160 @@
+// Libraries
+import React from 'react'
+import {fireEvent, screen} from '@testing-library/react'
+
+// Components
+import TypeAheadVariableDropdown from 'src/variables/components/TypeAheadVariableDropdown'
+
+// Utils
+import {renderWithRedux} from 'src/mockState'
+import {AppState, RemoteDataState} from 'src/types'
+import {Input} from '@influxdata/clockface'
+
+const values = {
+  def: 'defbuck',
+  def2: 'defbuck2',
+  foo: 'foobuck',
+  goo: 'goobuck',
+  new: 'newBuck',
+  always: 'always',
+  really: 'reallyYes',
+  REALLy2: 'anotherReally',
+}
+const fvalues = {
+  def: 'defbuck',
+  def2: 'defbuck2',
+  foo: 'foobuck',
+}
+
+const evalues = {
+  def: 'defbuck',
+  def2: 'defbuck2',
+  new: 'newBuck',
+  really: 'reallyYes',
+  REALLy2: 'anotherReally',
+}
+
+const alvalues = {
+  always: 'always',
+  really: 'reallyYes',
+  REALLy2: 'anotherReally',
+}
+
+const setInitialState = (state: AppState): AppState => {
+  return {
+    ...state,
+    currentDashboard: {
+      id: '03c8070355fbd000',
+    },
+    resources: {
+      ...state.resources,
+      variables: {
+        allIDs: ['03cbdc8a53a63000'],
+        status: RemoteDataState.Done,
+        byID: {
+          '03cbdc8a53a63000': {
+            id: '03cbdc8a53a63000',
+            orgID: '03c02466515c1000',
+            name: 'map_buckets',
+            description: '',
+            selected: null,
+            arguments: {
+              type: 'map',
+              values,
+            },
+            labels: [],
+            status: RemoteDataState.Done,
+          },
+        },
+        values: {
+          '03c8070355fbd000': {
+            status: RemoteDataState.Done,
+            values: {
+              '03cbdc8a53a63000': {
+                values,
+                selected: ['defbuck'],
+              },
+            },
+            order: ['03cbdc8a53a63000'],
+          },
+        },
+      },
+    },
+  }
+}
+
+describe('Dashboards.Components.VariablesControlBar.TypeAheadVariableDropdown', () => {
+  describe('if map type', () => {
+    it('renders dropdown with keys as dropdown items', () => {
+      const {getByTestId, getAllByTestId} = renderWithRedux(
+        <TypeAheadVariableDropdown variableID="03cbdc8a53a63000" />,
+        setInitialState
+      )
+
+      const dropdownButton = getByTestId('variable-dropdown--button')
+      fireEvent.click(dropdownButton)
+      const dropdownItems = getAllByTestId('variable-dropdown--item').map(
+        node => node.id
+      )
+
+      expect(dropdownItems).toEqual(Object.keys(values))
+    })
+  })
+
+  it('filters properly while typing in the input', () => {
+    const {getByTestId, getAllByTestId} = renderWithRedux(
+      <TypeAheadVariableDropdown variableID="03cbdc8a53a63000" />,
+      setInitialState
+    )
+
+    const filterInput = getByTestId('variable-dropdown--input-typeAhead')
+
+    const checkDropdown = (filterText, expectedList) => {
+      fireEvent.change(filterInput, {target: {value: filterText}})
+      const dropdownItems = getAllByTestId('variable-dropdown--item').map(
+        node => node.id
+      )
+      expect(dropdownItems).toEqual(Object.keys(expectedList))
+    }
+
+    // filter on the string 'f':
+    checkDropdown('f', fvalues)
+
+    // clear input, should see everything:
+    checkDropdown('', values)
+
+    // filter again by text:
+    checkDropdown('e', evalues)
+    checkDropdown('al', alvalues)
+
+    // something that won't match anything
+    // (see: https://testing-library.com/docs/guide-disappearance/#asserting-elements-are-not-present)
+    fireEvent.change(filterInput, {target: {value: 'def23'}})
+    const items = screen.queryByTestId('variable-dropdown--item')
+    expect(items).toBeNull() // it doesn't exist
+  })
+  //
+  // it('arrow buttons work to activate prior to selection', () => {
+  //   const {getByTestId, getAllByTestId} = renderWithRedux(
+  //       <TypeAheadVariableDropdown variableID="03cbdc8a53a63000" />,
+  //       setInitialState
+  //   )
+  //
+  //   const filterInput = getByTestId('variable-dropdown--input-typeAhead')
+  //
+  //   fireEvent.change(filterInput, {target: {value: 'f'}})
+  //   fireEvent.keyDown(filterInput, { key: 'ArrowDown', which: 40, code: 'ArrowDown' })
+  //     it's not getting the keydown event properly
+  //   //the first one (  def: 'defbuck',) should be 'activated'
+  //
+  //   const defBuckItem = getAllByTestId('variable-dropdown--item').filter(node =>
+  //       node.id === 'def'
+  //   )
+  //
+  //   console.log("defBuckitem??", defBuckItem);
+  //
+  //
+  //
+  //
+  // })
+})

--- a/src/variables/components/TypeAheadVariableDropdown.tsx
+++ b/src/variables/components/TypeAheadVariableDropdown.tsx
@@ -1,6 +1,7 @@
 // Libraries
 import React, {PureComponent} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
+import classnames from 'classnames'
 
 // Components
 import {
@@ -260,7 +261,7 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
     const widthStyle = this.getWidth(placeHolderText)
 
     const getInnerComponent = () => {
-      if (status === RemoteDataState.Loading || this.noValuesPresent(true)) {
+      if (status === RemoteDataState.Loading || this.noValuesPresent()) {
         return placeHolderText
       } else {
         return (
@@ -300,12 +301,11 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
             theme={DropdownMenuTheme.Amethyst}
           >
             {shownValues.map((value, index) => {
-              let classN = 'variable-dropdown--item'
+              // add the 'active' class to highlight when arrowing; like a hover
+              const classN = classnames('variable-dropdown--item', {
+                active: index === selectIndex,
+              })
 
-              // highlight when arrowing; like a hover
-              if (index === selectIndex) {
-                classN += ' active'
-              }
               return (
                 <Dropdown.Item
                   key={value}
@@ -378,17 +378,25 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
     if (status === RemoteDataState.Loading) {
       return 'Loading...'
     }
-    if (this.noValuesPresent(false)) {
+    if (this.noFilteredValuesPresent()) {
       return 'No Values'
     }
 
     return defaultText
   }
 
-  noValuesPresent = useAllValues => {
-    const {status, values} = this.props
+  noFilteredValuesPresent = () => {
     const {shownValues} = this.state
-    const valsToUse = useAllValues ? values : shownValues
+    return this.internalNoValuesPresent(shownValues)
+  }
+
+  noValuesPresent = () => {
+    const {values} = this.props
+    return this.internalNoValuesPresent(values)
+  }
+
+  internalNoValuesPresent = valsToUse => {
+    const {status} = this.props
 
     return (
       status === RemoteDataState.Done && (!valsToUse || valsToUse.length === 0)

--- a/src/variables/components/TypeAheadVariableDropdown.tsx
+++ b/src/variables/components/TypeAheadVariableDropdown.tsx
@@ -70,9 +70,8 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
   // set the 'shownValues' after loading, and
   // resets the menuOpen variable
   componentDidUpdate(prevProps, prevState) {
-    const prevVals = prevProps.values
     const {values, selectedValue, status} = this.props
-    const {status: prevStatus} = prevProps
+    const {values: prevVals, status: prevStatus} = prevProps
     const {actualVal, loaded, selectHappened, menuOpen} = this.state
     const {
       actualVal: prevActualVal,
@@ -214,7 +213,7 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
         // but:  if the value they typed is LEGAL (in the list/dropdown values), set it;
         // else: reset to the previous real/legal value:
         if (values.includes(typedValue)) {
-          // is is a real legal value
+          // is a real legal value
           this.handleSelect(typedValue, true)
         } else {
           const newState = {
@@ -276,10 +275,6 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
         )
       }
     }
-    // binding this b/c can't use arrow functions in the map below (shownValues.map)
-    // because need the index for highlighting the selectIndex for when using arrows
-    // to select the value
-    const thisHandleSelect = this.handleSelect.bind(this)
 
     return (
       <Dropdown
@@ -304,8 +299,9 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
             onCollapse={onCollapse}
             theme={DropdownMenuTheme.Amethyst}
           >
-            {shownValues.map(function(value, index) {
+            {shownValues.map((value, index) => {
               let classN = 'variable-dropdown--item'
+
               // highlight when arrowing; like a hover
               if (index === selectIndex) {
                 classN += ' active'
@@ -315,7 +311,7 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
                   key={value}
                   id={value}
                   value={value}
-                  onClick={thisHandleSelect}
+                  onClick={this.handleSelect}
                   selected={value === selectedValue}
                   testID="variable-dropdown--item"
                   className={classN}
@@ -394,10 +390,9 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
     const {shownValues} = this.state
     const valsToUse = useAllValues ? values : shownValues
 
-    const result =
+    return (
       status === RemoteDataState.Done && (!valsToUse || valsToUse.length === 0)
-
-    return result
+    )
   }
 }
 

--- a/src/variables/components/TypeAheadVariableDropdown.tsx
+++ b/src/variables/components/TypeAheadVariableDropdown.tsx
@@ -65,7 +65,7 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
     }
 
     this.state = defaultState
-    // console.log(`vars-1a (${props.name}: `, props)
+    console.log(`in constructor, props:  (${props.name}: `, props)
   }
 
   // set the 'shownValues' after loading, and

--- a/src/variables/components/TypeAheadVariableDropdown.tsx
+++ b/src/variables/components/TypeAheadVariableDropdown.tsx
@@ -107,7 +107,14 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
       }
     }
 
-    // unset the menuOpen; it should be set to closed (or open) only once; then undone
+    /**
+     * unset the menuOpen; it should be set to closed (or open) only once; then undone
+     * this is needed because: (from clockface Dropdown.tsx documentation):
+     * if the string is set to 'open', and then the user closes it, and the code sets it to open again,
+     * unless the code sets it to something else in between (like null or 'close'),
+     * then nothing will happen- the menu will not open)
+     */
+
     if (menuOpen !== prevMenuOpen && menuOpen !== null) {
       newState['menuOpen'] = null
     }
@@ -126,10 +133,10 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
 
   getInitialValuesAfterLoading() {
     const {values, selectedValue} = this.props
-    // it reloaded; maybe because a dependent var
+    // it reloaded; maybe because of a dependent var
     // want to re-init
 
-    // if selectedValue is present in the values, set it; else zero it out (TODO)
+    // if selectedValue is present in the values, set it; else zero it out
     let newSelectedValue = ''
     if (values.includes(selectedValue)) {
       newSelectedValue = selectedValue
@@ -143,8 +150,10 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
     }
   }
 
-  filterVals = needle => {
+  filterVals = event => {
     const {values} = this.props
+
+    const needle = event?.target?.value
 
     // if there is no value, set the shownValues to everything
     // and set the typedValue to nothing (zero it out)
@@ -259,7 +268,7 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
           <Input
             style={widthStyle}
             placeholder={placeHolderText}
-            onChange={e => this.filterVals(e.target.value)}
+            onChange={this.filterVals}
             value={typedValue}
             onKeyDown={this.maybeSelectNextItem}
             testID={`variable-dropdown-input-typeAhead--${name}`}
@@ -267,8 +276,11 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
         )
       }
     }
-
+    // binding this b/c can't use arrow functions in the map below (shownValues.map)
+    // because need the index for highlighting the selectIndex for when using arrows
+    // to select the value
     const thisHandleSelect = this.handleSelect.bind(this)
+
     return (
       <Dropdown
         style={{width: '140px'}}

--- a/src/variables/components/TypeAheadVariableDropdown.tsx
+++ b/src/variables/components/TypeAheadVariableDropdown.tsx
@@ -226,19 +226,19 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
   // only want to show valid values when the component is not actively being used
   onClickAwayHere = () => {
     //  reset:
-    console.log('in click away here for ' + this.props.name)
+    // console.log('in click away here for ' + this.props.name)
     this.setState(this.getRealValue())
   }
 
   getRealValue = () => {
     const {actualVal, typedValue} = this.state
-    const {selectedValue, name} = this.props
+    const {selectedValue} = this.props
 
     if (actualVal || selectedValue) {
       const realValue = actualVal ?? selectedValue
-      console.log(`foo-123 (setting typedValue) d for ${name} to ${realValue}`)
+      //  console.log(`foo-123 (setting typedValue) d for ${name} to ${realValue}`)
       if (typedValue !== realValue) {
-        console.log('actually setting it...... (foo-d-ack)')
+        // console.log('actually setting it...... (foo-d-ack)')
         return {typedValue: realValue}
       }
     }
@@ -269,6 +269,7 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
             onChange={e => this.filterVals(e.target.value)}
             value={typedValue}
             onKeyDown={this.maybeSelectNextItem}
+            testID={`variable-dropdown-input-typeAhead--${name}`}
           />
         )
       }
@@ -387,7 +388,7 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
   }
 
   noValuesPresent = useAllValues => {
-    const {status, name, values} = this.props
+    const {status, values} = this.props
     const {shownValues} = this.state
     // console.log(`in no values present....${name}`, shownValues)
     // console.log('status: ', status)

--- a/src/variables/components/TypeAheadVariableDropdown.tsx
+++ b/src/variables/components/TypeAheadVariableDropdown.tsx
@@ -131,7 +131,7 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
 
     // if selectedValue is present in the values, set it; else zero it out (TODO)
     let newSelectedValue = ''
-    if (values.indexOf(selectedValue) >= 0) {
+    if (values.includes(selectedValue)) {
       newSelectedValue = selectedValue
     }
 
@@ -204,7 +204,7 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
 
         // but:  if the value they typed is LEGAL (in the list/dropdown values), set it;
         // else: reset to the previous real/legal value:
-        if (values.indexOf(typedValue) >= 0) {
+        if (values.includes(typedValue)) {
           // is is a real legal value
           this.handleSelect(typedValue, true)
         } else {
@@ -244,7 +244,6 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
   render() {
     const {selectedValue, values, name, status} = this.props
     const {typedValue, shownValues, menuOpen, selectIndex} = this.state
-    const that = this
     const dropdownStatus =
       values.length === 0 ? ComponentStatus.Disabled : ComponentStatus.Default
 
@@ -269,6 +268,7 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
       }
     }
 
+    const thisHandleSelect = this.handleSelect.bind(this)
     return (
       <Dropdown
         style={{width: '140px'}}
@@ -294,7 +294,7 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
           >
             {shownValues.map(function(value, index) {
               let classN = 'variable-dropdown--item'
-              //this works!  need to use it for highlighting when arrowing; like a hover
+              // highlight when arrowing; like a hover
               if (index === selectIndex) {
                 classN += ' active'
               }
@@ -303,7 +303,7 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
                   key={value}
                   id={value}
                   value={value}
-                  onClick={that.handleSelect}
+                  onClick={thisHandleSelect}
                   selected={value === selectedValue}
                   testID="variable-dropdown--item"
                   className={classN}
@@ -337,7 +337,6 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
       variableID,
       onSelectValue,
       onSelect,
-      name,
       selectedValue: prevSelectedValue,
     } = this.props
 


### PR DESCRIPTION
Closes #21020 in influxdb
https://app.zenhub.com/workspaces/applicationui-5e3b05772922e316b3a210a4/issues/influxdata/influxdb/21020

addressing bucky's comments
the arrow buttons do NOT select the next one, they just hover like a mouse would; selection happens on return
if you type in a matching valid selection and press return, that selects the value as well
dependent variables now re-load correctly

added unit tests
added e2e tests

still testing original variable dropdown too

