### PR TITLE
fix: flag the GET request to annotations

### DIFF
--- a/src/dashboards/components/DashboardPage.tsx
+++ b/src/dashboards/components/DashboardPage.tsx
@@ -62,7 +62,10 @@ class DashboardPage extends Component<Props> {
     resetQueryCache()
 
     this.emitRenderCycleEvent()
-    this.props.fetchAndSetAnnotations()
+
+    if (isFlagEnabled('annotations')) {
+      this.props.fetchAndSetAnnotations()
+    }
   }
 
   public componentWillUnmount() {


### PR DESCRIPTION
Closes #1051

Don't make GET requests to annotations if the flag is off
