### PR TITLE
fix: simple data tweaks

### DIFF
--- a/src/flows/components/panel/Results.tsx
+++ b/src/flows/components/panel/Results.tsx
@@ -48,6 +48,7 @@ const Results: FC = () => {
         <View
           properties={{
             type: 'simple-table',
+            showAll: false,
           }}
           result={results.parsed}
         />

--- a/src/timeMachine/components/Vis.tsx
+++ b/src/timeMachine/components/Vis.tsx
@@ -76,6 +76,7 @@ const TimeMachineVis: FC<Props> = ({
   if (isViewingRawData && isFlagEnabled('simple-table')) {
     resolvedViewProperties = {
       type: 'simple-table',
+      showAll: true,
     }
   }
 

--- a/src/visualization/types/SimpleTable/index.tsx
+++ b/src/visualization/types/SimpleTable/index.tsx
@@ -5,6 +5,7 @@ import icon from './icon'
 
 export interface SimpleTableViewProperties {
   type: 'simple-table'
+  showAll: boolean
 }
 
 interface SubsetTableColumn {
@@ -29,7 +30,7 @@ export default register => {
     type: 'simple-table',
     name: 'Simple Table',
     graphic: icon,
-    initial: {type: 'simple-table'},
+    initial: {type: 'simple-table', showAll: false},
     component: view,
   })
 }

--- a/src/visualization/types/SimpleTable/style.scss
+++ b/src/visualization/types/SimpleTable/style.scss
@@ -43,11 +43,13 @@
 .visualization--simple-table--results {
   flex: 1 0 0;
   position: relative;
+  margin-top: 8px;
 }
 
 .visualization--simple-table--paging {
   display: flex;
   align-items: center;
+  height: 48px;
 }
 
 .visualization--simple-table--paging-label {

--- a/src/visualization/types/SimpleTable/view.tsx
+++ b/src/visualization/types/SimpleTable/view.tsx
@@ -16,12 +16,12 @@ interface Props extends VisualizationProps {
   result: FluxResult['parsed']
 }
 
-const SimpleTable: FC<Props> = ({result}) => {
+const SimpleTable: FC<Props> = ({properties, result}) => {
   return (
     <div className="visualization--simple-table">
       <PaginationProvider total={result?.table?.length || 0}>
+        <PagedTable properties={properties} result={result} />
         <PageControl />
-        <PagedTable result={result} />
       </PaginationProvider>
     </div>
   )


### PR DESCRIPTION
Closes #1011 

moves the page interface to the bottom of the interaction at the request of design

also stops filtering of the _start and _stop columns... in data explorer