### PR TITLE
feat: added clone naming for tasks

### DIFF
--- a/cypress/e2e/shared/tasks.test.ts
+++ b/cypress/e2e/shared/tasks.test.ts
@@ -290,7 +290,7 @@ http.post(
         })
     })
 
-    it('can clone a task and edit it', () => {
+    it.only('can clone a task and edit it', () => {
       // clone a task
       cy.getByTestID('task-card')
         .first()
@@ -314,7 +314,7 @@ http.post(
       // assert the values of the task and change them
       cy.getByTestID('task-card--name')
         .eq(1)
-        .should('have.value', '🦄ask (clone 1)')
+        .contains('🦄ask (clone 1)')
         .click()
         .then(() => {
           // focused() waits for monoco editor to get input focus
@@ -324,7 +324,7 @@ http.post(
             .contains('option task = {')
             .then(() => {
               cy.getByTestID('task-form-name')
-                .should('have.value', '🦄ask')
+                .should('have.value', '🦄ask (clone 1)')
                 .then(() => {
                   cy.getByTestID('task-form-name')
                     .should('be.visible')

--- a/cypress/e2e/shared/tasks.test.ts
+++ b/cypress/e2e/shared/tasks.test.ts
@@ -311,12 +311,10 @@ http.post(
 
       cy.getByTestID('task-card').should('have.length', 2)
 
-      cy.getByTestID('task-card--name')
-        .last()
-        .should('have.value', '🦄ask (clone 1)')
       // assert the values of the task and change them
       cy.getByTestID('task-card--name')
         .eq(1)
+        .should('have.value', '🦄ask (clone 1)')
         .click()
         .then(() => {
           // focused() waits for monoco editor to get input focus

--- a/cypress/e2e/shared/tasks.test.ts
+++ b/cypress/e2e/shared/tasks.test.ts
@@ -311,6 +311,9 @@ http.post(
 
       cy.getByTestID('task-card').should('have.length', 2)
 
+      cy.getByTestID('task-card--name')
+        .last()
+        .should('have.value', '🦄ask (clone 1)')
       // assert the values of the task and change them
       cy.getByTestID('task-card--name')
         .eq(1)

--- a/cypress/e2e/shared/tasks.test.ts
+++ b/cypress/e2e/shared/tasks.test.ts
@@ -290,7 +290,7 @@ http.post(
         })
     })
 
-    it.only('can clone a task and edit it', () => {
+    it('can clone a task and edit it', () => {
       // clone a task
       cy.getByTestID('task-card')
         .first()

--- a/src/tasks/actions/thunks.ts
+++ b/src/tasks/actions/thunks.ts
@@ -50,7 +50,8 @@ import {taskToTemplate} from 'src/shared/utils/resourceToTemplate'
 import {isLimitError} from 'src/cloud/utils/limits'
 import {checkTaskLimits} from 'src/cloud/actions/limits'
 import {getOrg} from 'src/organizations/selectors'
-import {getStatus} from 'src/resources/selectors'
+import {getAll, getStatus} from 'src/resources/selectors'
+import {incrementCloneName} from 'src/utils/naming'
 
 // Types
 import {TASK_LIMIT} from 'src/resources/constants'
@@ -244,15 +245,27 @@ export const deleteTask = (taskID: string) => async (
   }
 }
 
-export const cloneTask = (task: Task) => async (dispatch: Dispatch<Action>) => {
+export const cloneTask = (task: Task) => async (
+  dispatch: Dispatch<Action>,
+  getState: GetState
+) => {
   try {
+    const state = getState()
     const resp = await api.getTask({taskID: task.id})
 
     if (resp.status !== 200) {
       throw new Error(resp.data.message)
     }
 
-    const newTask = await api.postTask({data: resp.data})
+    const taskName = resp.data.name
+    const tasks = getAll<Task>(state, ResourceType.Tasks)
+    const allTaskNames = tasks.map(d => d.name)
+    const clonedName = incrementCloneName(allTaskNames, taskName)
+    const flux = resp.data.flux
+
+    const newTask = await api.postTask({
+      data: {...resp.data, flux: flux.replace(/".*?"/, `"${clonedName}"`)},
+    })
 
     if (newTask.status !== 201) {
       throw new Error(newTask.data.message)


### PR DESCRIPTION
Closes #883 

This PR adds clone naming conventions to tasks.

![task-clone](https://user-images.githubusercontent.com/19984220/113218113-d46f8d80-9233-11eb-9a67-dfa1a8571d16.gif)


<!-- Describe your proposed changes here. -->
