### PR TITLE
feat: add UTC/Local time dropdown to Task Runs page.

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -7,6 +7,6 @@
   "integrationFolder": "cypress/e2e",
   "defaultCommandTimeout": 10000,
   "videoUploadOnPasses": false,
-  "chromeWebSecurity": true,
+  "chromeWebSecurity": false,
   "blockHosts": ["www.google-analytics.com", "www.googletagmanager.com"]
 }

--- a/src/tasks/components/TaskRunsPage.tsx
+++ b/src/tasks/components/TaskRunsPage.tsx
@@ -25,6 +25,7 @@ import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 
 // Types
 import {SortTypes} from 'src/shared/utils/sort'
+import TimeZoneDropdown from 'src/shared/components/TimeZoneDropdown'
 
 type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps & RouteComponentProps<{id: string; orgID: string}>
@@ -70,6 +71,7 @@ class TaskRunsPage extends PureComponent<Props, State> {
               />
             </Page.ControlBarLeft>
             <Page.ControlBarRight>
+              <TimeZoneDropdown />
               <Button
                 onClick={this.handleRunTask}
                 text="Run Task"

--- a/src/tasks/components/TaskRunsRow.tsx
+++ b/src/tasks/components/TaskRunsRow.tsx
@@ -67,7 +67,13 @@ class TaskRunsRow extends PureComponent<Props, State> {
       return ''
     }
     const newdate = new Date(dt)
-    const formatted = moment(newdate).format(DEFAULT_TIME_FORMAT)
+    const {timeZone} = this.props
+    const formatted =
+      timeZone === 'UTC'
+        ? moment(newdate)
+            .utc()
+            .format(DEFAULT_TIME_FORMAT)
+        : moment(newdate).format(DEFAULT_TIME_FORMAT)
 
     return formatted
   }
@@ -96,8 +102,9 @@ class TaskRunsRow extends PureComponent<Props, State> {
 
 const mstp = (state: AppState) => {
   const {logs} = state.resources.tasks
+  const timeZone = state.app.persisted.timeZone
 
-  return {logs}
+  return {logs, timeZone}
 }
 
 const mdtp = {getLogs: getLogs}


### PR DESCRIPTION
Closes #1055

We want to add a dropdown that allows the user to choose a time zone for time display in the task runs page. This is what it looks like:


https://user-images.githubusercontent.com/18511823/113243464-ec610480-9267-11eb-8285-527db61afaf5.mov

