### PR TITLE
feat: variables reorder drag and drop saves through logout

### DIFF
--- a/src/dashboards/components/variablesControlBar/VariablesControlBar.tsx
+++ b/src/dashboards/components/variablesControlBar/VariablesControlBar.tsx
@@ -29,7 +29,7 @@ const VariablesControlBar: FC = () => {
   const variables = useSelector(getVariablesForDashboard)
   const variablesStatus = useSelector(getDashboardVariablesStatus)
   const isVisible = useSelector(getControlBarVisibility)
-  console.log(variables)
+
   useEffect(() => {
     if (
       variablesStatus === RemoteDataState.Done &&

--- a/src/dashboards/components/variablesControlBar/VariablesControlBar.tsx
+++ b/src/dashboards/components/variablesControlBar/VariablesControlBar.tsx
@@ -29,7 +29,7 @@ const VariablesControlBar: FC = () => {
   const variables = useSelector(getVariablesForDashboard)
   const variablesStatus = useSelector(getDashboardVariablesStatus)
   const isVisible = useSelector(getControlBarVisibility)
-
+  console.log(variables)
   useEffect(() => {
     if (
       variablesStatus === RemoteDataState.Done &&

--- a/src/dashboards/components/variablesControlBar/VariablesControlBarList.tsx
+++ b/src/dashboards/components/variablesControlBar/VariablesControlBarList.tsx
@@ -21,7 +21,7 @@ interface Props {
 const VariablesControlBarList: FC<Props> = ({variables}) => {
   const dispatch = useDispatch()
 
-  const handleDragEnd = (result): void => {
+  const handleDragEnd = async result => {
     const {destination, source} = result
 
     // Don't do anything if dropdown is dropped outside droppable area
@@ -37,7 +37,7 @@ const VariablesControlBarList: FC<Props> = ({variables}) => {
       return
     }
 
-    dispatch(moveVariable(source.index, destination.index))
+    await dispatch(moveVariable(source.index, destination.index))
   }
 
   const getGridClassName = (isDraggingOver: boolean): CSSProperties =>

--- a/src/shared/copy/notifications.ts
+++ b/src/shared/copy/notifications.ts
@@ -375,6 +375,12 @@ export const updateVariableSuccess = (name: string): Notification => ({
   message: `Successfully updated variable: ${name}.`,
 })
 
+export const moveVariableFailed = (error: string): Notification => ({
+  ...defaultErrorNotification,
+  icon: IconFont.Cube,
+  message: `Failed to move variable: ${error}`,
+})
+
 export const copyToClipboardSuccess = (
   text: string,
   title: string = ''

--- a/src/types/variables.ts
+++ b/src/types/variables.ts
@@ -16,7 +16,9 @@ import {
 } from 'src/types'
 
 // GenVariable is the shape of a variable from the server
-export type GenVariable = GVariable
+export type GenVariable = GVariable & {
+  sort_order?: number
+}
 export interface SystemVariableProperties {
   type?: 'system'
   values?: any

--- a/src/variables/actions/thunks.ts
+++ b/src/variables/actions/thunks.ts
@@ -351,29 +351,43 @@ export const moveVariable = (originalIndex: number, newIndex: number) => async (
 ) => {
   const contextID = currentContext(getState())
   const byDashboardVariables = getVariablesForDashboard(getState())
-
+  const oldDashboardVarOrder = [...byDashboardVariables]
   const temp = byDashboardVariables[originalIndex]
   byDashboardVariables[originalIndex] = byDashboardVariables[newIndex]
   byDashboardVariables[newIndex] = temp
-  console.log('BY DASHBOARD', originalIndex, newIndex)
-  // Move Variable Sort Order Number
-  const firstVar = await api.patchVariable({
-    variableID: temp.id,
-    data: {
-      ...(temp as GenVariable),
-      sort_order: newIndex,
-    } as GenVariable,
-  })
 
-  const secondVar = await api.patchVariable({
-    variableID: byDashboardVariables[newIndex].id,
-    data: {
-      ...(byDashboardVariables[newIndex] as GenVariable),
-      sort_order: originalIndex,
-    } as GenVariable,
-  })
-
-  console.log(firstVar)
+  api
+    .patchVariable({
+      variableID: temp.id,
+      data: {
+        ...(temp as GenVariable),
+        sort_order: newIndex,
+      } as GenVariable,
+    })
+    .then(() => {
+      api.patchVariable({
+        variableID: byDashboardVariables[newIndex].id,
+        data: {
+          ...(byDashboardVariables[newIndex] as GenVariable),
+          sort_order: originalIndex,
+        } as GenVariable,
+      })
+    })
+    .catch(async err => {
+      await dispatch(
+        moveVariableInState(
+          contextID,
+          oldDashboardVarOrder.map((v: Variable) => v.id)
+        )
+      )
+      dispatch(
+        notify(
+          copy.moveVariableFailed(
+            err.message ?? 'Unable to move variable at this time.'
+          )
+        )
+      )
+    })
 
   await dispatch(
     moveVariableInState(

--- a/src/variables/actions/thunks.ts
+++ b/src/variables/actions/thunks.ts
@@ -355,6 +355,25 @@ export const moveVariable = (originalIndex: number, newIndex: number) => async (
   const temp = byDashboardVariables[originalIndex]
   byDashboardVariables[originalIndex] = byDashboardVariables[newIndex]
   byDashboardVariables[newIndex] = temp
+  console.log('BY DASHBOARD', originalIndex, newIndex)
+  // Move Variable Sort Order Number
+  const firstVar = await api.patchVariable({
+    variableID: temp.id,
+    data: {
+      ...(temp as GenVariable),
+      sort_order: newIndex,
+    } as GenVariable,
+  })
+
+  const secondVar = await api.patchVariable({
+    variableID: byDashboardVariables[newIndex].id,
+    data: {
+      ...(byDashboardVariables[newIndex] as GenVariable),
+      sort_order: originalIndex,
+    } as GenVariable,
+  })
+
+  console.log(firstVar)
 
   await dispatch(
     moveVariableInState(

--- a/src/variables/selectors/index.tsx
+++ b/src/variables/selectors/index.tsx
@@ -109,7 +109,11 @@ export const getVariablesForDashboard = (state: AppState): Variable[] => {
     Object.values(state.resources.views.byID).filter(
       variable => variable.dashboardID === state.currentDashboard.id
     )
-  ).sort((a, b) => a.sort_order - b.sort_order)
+  ).sort((a, b) => {
+    if (a.sort_order && b.sort_order) {
+      return a.sort_order - b.sort_order
+    }
+  })
 
   return variablesUsedByDashboard
 }

--- a/src/variables/selectors/index.tsx
+++ b/src/variables/selectors/index.tsx
@@ -109,7 +109,7 @@ export const getVariablesForDashboard = (state: AppState): Variable[] => {
     Object.values(state.resources.views.byID).filter(
       variable => variable.dashboardID === state.currentDashboard.id
     )
-  )
+  ).sort((a, b) => a.sort_order - b.sort_order)
 
   return variablesUsedByDashboard
 }


### PR DESCRIPTION
Closes #667

<!-- Describe your proposed changes here. -->
This PR connects with the backend change that introduces a `sort_order` property on variables. This allows us to save the order when they are moved in the control bar and display them in the correct order once they are saved, or otherwise show an error notification and snap them back to match the API order. 