### PR TITLE
feat: complete redirect cycle to login and avoid the signin page

### DIFF
--- a/src/Signin.tsx
+++ b/src/Signin.tsx
@@ -16,13 +16,18 @@ import {
   removeFromLocalStorage,
   setToLocalStorage,
 } from 'src/localStorage'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Actions
 import {notify as notifyAction} from 'src/shared/actions/notifications'
 
 // Constants
 import {sessionTimedOut} from 'src/shared/copy/notifications'
-import {CLOUD, CLOUD_SIGNIN_PATHNAME} from 'src/shared/constants'
+import {
+  CLOUD,
+  CLOUD_LOGIN_PATHNAME,
+  CLOUD_SIGNIN_PATHNAME,
+} from 'src/shared/constants'
 
 // Types
 import {RemoteDataState} from 'src/types'
@@ -97,6 +102,15 @@ export class Signin extends PureComponent<Props, State> {
       } = this.props
 
       clearInterval(this.intervalID)
+
+      if (CLOUD && isFlagEnabled('authSessionCookieOn')) {
+        const url = new URL(
+          `${window.location.origin}${CLOUD_LOGIN_PATHNAME}?redirectTo=${window.location.href}`
+        )
+        setToLocalStorage('redirectTo', window.location.href)
+        window.location.href = url.href
+        throw error
+      }
 
       if (CLOUD) {
         const url = new URL(

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -74,6 +74,7 @@ export const HONEYBADGER_ENV = formatConstant(process.env.HONEYBADGER_ENV)
 
 export const CLOUD = !!process.env.CLOUD_URL
 export const CLOUD_SIGNIN_PATHNAME = '/api/v2/signin'
+export const CLOUD_LOGIN_PATHNAME = '/login'
 export const CLOUD_BILLING_VISIBLE = CLOUD
 export const CLOUD_URL = formatConstant(process.env.CLOUD_URL)
 export const CLOUD_CHECKOUT_PATH = '/checkout'


### PR DESCRIPTION
Closes #1057 

This PR integrates the redirect to login functionality when a cloud user fails the `/me` call. With session sharing allowing for access to both platforms, we want to avoid making a silent request to Auth0 (which is currently done by the `/signin` endpoint). By redirecting the user to the `/login` page, we ensure that the `/signin` endpoint will not be hit and that the user will end up in a state where they can then login to the app
