### PR TITLE
fix: remove geo options behind static flag and add message

### DIFF
--- a/cypress/e2e/cloud/geoOptions.test.ts
+++ b/cypress/e2e/cloud/geoOptions.test.ts
@@ -1,5 +1,5 @@
 import {Organization} from '../../../src/types'
-describe('DataExplorer - Geo Map Type Customization Options', () => {
+describe.skip('DataExplorer - Geo Map Type Customization Options', () => {
   beforeEach(() => {
     cy.flush()
 

--- a/src/visualization/types/Map/GeoOptions.tsx
+++ b/src/visualization/types/Map/GeoOptions.tsx
@@ -12,6 +12,7 @@ interface Props extends VisualizationOptionProps {
   properties: GeoViewProperties
 }
 
+const SHOW_GEO_OPTIONS = false
 const mapTypeOptions = ['Point', 'Circle', 'Heat', 'Track']
 enum LatRangeSlider {
   Min = -90,
@@ -141,7 +142,7 @@ export const GeoOptions: FC<Props> = ({properties, update}) => {
     })
   }
 
-  return (
+  return SHOW_GEO_OPTIONS ? (
     <>
       <SelectGroup className="mapTypeOptions">
         {mapTypeOptions.map((mapTypeOption: string, index: number) => (
@@ -213,5 +214,21 @@ export const GeoOptions: FC<Props> = ({properties, update}) => {
         )}
       </Grid.Column>
     </>
+  ) : (
+    <Grid.Column>
+      <h4 className="view-options--header">Customize Geo Options</h4>
+      <p>
+        To display properly, your data will need to contain fields named 'lat'
+        and 'lon' or a tag named 's2_cell_id'. For help customizing your query,
+        please see our{' '}
+        <a
+          href="https://docs.influxdata.com/influxdb/cloud/visualize-data/visualization-types/map/"
+          rel="noreferrer"
+          target="_blank"
+        >
+          documentation
+        </a>
+      </p>
+    </Grid.Column>
   )
 }


### PR DESCRIPTION
Closes #1005 
Closes #1061  
<!-- Describe your proposed changes here. -->
This PR hides the customization options behind a flag that currently is set to false (its just a variable that we can remove when we work on these again) and shows the message listed in #1061. 

<img width="975" alt="Screen Shot 2021-04-01 at 4 37 14 PM" src="https://user-images.githubusercontent.com/29473622/113356840-8a0c1080-9308-11eb-9d84-761bf6c3ea4b.png">
