### PR TITLE
fix: dashboard naming boundaries

### DIFF
--- a/cypress/e2e/cloud/geoOptions.test.ts
+++ b/cypress/e2e/cloud/geoOptions.test.ts
@@ -1,5 +1,5 @@
 import {Organization} from '../../../src/types'
-describe('DataExplorer - Geo Map Type Customization Options', () => {
+describe.skip('DataExplorer - Geo Map Type Customization Options', () => {
   beforeEach(() => {
     cy.flush()
 

--- a/src/dashboards/components/DashboardsCardGrid.scss
+++ b/src/dashboards/components/DashboardsCardGrid.scss
@@ -36,7 +36,7 @@ $dashboard-grid-gap: $cf-marg-a;
 
   .cf-resource-editable-name {
     position: absolute;
-    min-width: 60%;
+    max-width: 65%;
 
     .cf-resource-name--text {
       overflow: hidden;

--- a/src/visualization/types/Map/GeoOptions.tsx
+++ b/src/visualization/types/Map/GeoOptions.tsx
@@ -12,6 +12,7 @@ interface Props extends VisualizationOptionProps {
   properties: GeoViewProperties
 }
 
+const SHOW_GEO_OPTIONS = false
 const mapTypeOptions = ['Point', 'Circle', 'Heat', 'Track']
 enum LatRangeSlider {
   Min = -90,
@@ -141,7 +142,7 @@ export const GeoOptions: FC<Props> = ({properties, update}) => {
     })
   }
 
-  return (
+  return SHOW_GEO_OPTIONS ? (
     <>
       <SelectGroup className="mapTypeOptions">
         {mapTypeOptions.map((mapTypeOption: string, index: number) => (
@@ -213,5 +214,21 @@ export const GeoOptions: FC<Props> = ({properties, update}) => {
         )}
       </Grid.Column>
     </>
+  ) : (
+    <Grid.Column>
+      <h4 className="view-options--header">Customize Geo Options</h4>
+      <p>
+        To display properly, your data will need to contain fields named 'lat'
+        and 'lon' or a tag named 's2_cell_id'. For help customizing your query,
+        please see our{' '}
+        <a
+          href="https://docs.influxdata.com/influxdb/cloud/visualize-data/visualization-types/map/"
+          rel="noreferrer"
+          target="_blank"
+        >
+          documentation
+        </a>
+      </p>
+    </Grid.Column>
   )
 }


### PR DESCRIPTION
Closes #1070 

<!-- Describe your proposed changes here. -->
This addresses the issue of the names for dashboards running out of the boundaries if they are too wide.
<img width="975" alt="Screen Shot 2021-04-01 at 4 47 32 PM" src="https://user-images.githubusercontent.com/29473622/113357670-fa676180-9309-11eb-8171-6987d0885c59.png">
