### PR TITLE
fix: css for dashboard max name width

### DIFF
--- a/src/dashboards/components/DashboardsCardGrid.scss
+++ b/src/dashboards/components/DashboardsCardGrid.scss
@@ -36,7 +36,7 @@ $dashboard-grid-gap: $cf-marg-a;
 
   .cf-resource-editable-name {
     position: absolute;
-    min-width: 60%;
+    max-width: 65%;
 
     .cf-resource-name--text {
       overflow: hidden;


### PR DESCRIPTION
Closes #1070 

<!-- Describe your proposed changes here. -->
Fixes the boundary issue for dashboard names
<img width="975" alt="Screen Shot 2021-04-01 at 4 47 32 PM" src="https://user-images.githubusercontent.com/29473622/113357816-3995b280-930a-11eb-9075-fb0c21f425dc.png">
