### PR TITLE
chore: change annotations color from red to green

### DIFF
--- a/src/annotations/reducers/index.test.ts
+++ b/src/annotations/reducers/index.test.ts
@@ -1,8 +1,4 @@
-import {
-  annotationsReducer,
-  initialState,
-  STREAM_COLOR_LIST,
-} from 'src/annotations/reducers'
+import {annotationsReducer, initialState} from 'src/annotations/reducers'
 
 const mockAnnotations = [
   {
@@ -56,13 +52,8 @@ describe('the annotations reducer', () => {
       },
       annotationsAreVisible: true,
       enableSingleClickAnnotations: false,
-      visibleStreamsByID: ['default'],
-      streams: [
-        {
-          stream: 'default',
-          color: STREAM_COLOR_LIST[0],
-        },
-      ],
+      visibleStreamsByID: [],
+      streams: [],
     })
   })
 })

--- a/src/annotations/reducers/index.ts
+++ b/src/annotations/reducers/index.ts
@@ -10,8 +10,6 @@ import {
 
 import {Annotation, AnnotationsList, AnnotationStream} from 'src/types'
 
-import {InfluxColors} from '@influxdata/clockface'
-
 export interface AnnotationsState {
   streams: AnnotationStream[]
   annotations: AnnotationsList
@@ -20,23 +18,14 @@ export interface AnnotationsState {
   enableSingleClickAnnotations: boolean
 }
 
-export const FALLBACK_COLOR = InfluxColors.Curacao
-
-export const STREAM_COLOR_LIST = [InfluxColors.Potassium]
-
 export const initialState = (): AnnotationsState => ({
   annotations: {
     default: [] as Annotation[],
   },
   annotationsAreVisible: true,
   enableSingleClickAnnotations: false,
-  streams: [
-    {
-      stream: 'default',
-      color: InfluxColors.Potassium,
-    },
-  ],
-  visibleStreamsByID: ['default'],
+  streams: [],
+  visibleStreamsByID: [],
 })
 
 export const annotationsReducer = (
@@ -47,12 +36,7 @@ export const annotationsReducer = (
     case SET_ANNOTATION_STREAMS: {
       return {
         ...state,
-        streams: action.streams.map((stream, i) => {
-          return {
-            ...stream,
-            color: STREAM_COLOR_LIST[i],
-          }
-        }),
+        streams: action.streams,
       }
     }
     case DELETE_ANNOTATION: {

--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -5,6 +5,7 @@ import {
   AnnotationLayerConfig,
   Config,
   DomainLabel,
+  InfluxColors,
   InteractionHandlerArguments,
   Plot,
   getDomainDataFromLines,
@@ -19,7 +20,6 @@ import {AppSettingContext} from 'src/shared/contexts/app'
 
 // Redux
 import {writeThenFetchAndSetAnnotations} from 'src/annotations/actions/thunks'
-import {FALLBACK_COLOR} from 'src/annotations/reducers/index'
 import {
   isSingleClickAnnotationsEnabled,
   selectAreAnnotationsVisible,
@@ -266,7 +266,7 @@ const XYPlot: FC<Props> = ({
     const annotationsToRender: any[] = cellAnnotations.map(annotation => {
       return {
         ...annotation,
-        color: FALLBACK_COLOR,
+        color: InfluxColors.Honeydew,
       }
     })
 


### PR DESCRIPTION
Closes #1074

Makes the annotation lines green instead of red.

The great honeydewing of 2021 is upon us!

![Screen Shot 2021-04-01 at 3 10 26 PM](https://user-images.githubusercontent.com/146112/113359901-95a60a00-92fd-11eb-8c9d-f7a5608ab7c7.png)
