### PR TITLE
fix: update page titles

### DIFF
--- a/src/alerting/components/AlertHistoryIndex.tsx
+++ b/src/alerting/components/AlertHistoryIndex.tsx
@@ -27,6 +27,7 @@ import {
 import {getCheckIDs} from 'src/checks/selectors'
 import {getEndpointIDs} from 'src/notifications/endpoints/selectors'
 import {getRuleIDs} from 'src/notifications/rules/selectors'
+import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 
 // Types
 import {ResourceIDs} from 'src/checks/reducers'
@@ -72,7 +73,7 @@ const AlertHistoryIndex: FC<Props> = ({
         <EventViewer loadRows={loadRows} initialState={getInitialState()}>
           {props => (
             <Page
-              titleTag="Check Statuses | InfluxDB 2.0"
+              titleTag={pageTitleSuffixer(['Check Statuses'])}
               className="alert-history-page"
             >
               <Page.Header fullWidth={true}>

--- a/src/checks/components/CheckHistory.tsx
+++ b/src/checks/components/CheckHistory.tsx
@@ -24,6 +24,7 @@ import {STATUS_FIELDS} from 'src/alerting/constants/history'
 import {loadStatuses, getInitialState} from 'src/alerting/utils/history'
 import {getCheckIDs} from 'src/checks/selectors'
 import {getOrg} from 'src/organizations/selectors'
+import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 
 // Types
 import {AppState, ResourceType} from 'src/types'
@@ -48,7 +49,7 @@ const CheckHistory: FC = () => {
         <EventViewer loadRows={loadRows} initialState={getInitialState()}>
           {props => (
             <Page
-              titleTag="Check Statuses | InfluxDB 2.0"
+              titleTag={pageTitleSuffixer(['Check Statuses'])}
               className="alert-history-page"
             >
               <Page.Header fullWidth={true}>


### PR DESCRIPTION
noticed these pages didn't use the standard pageTitleSuffixer function