### PR TITLE
fix: prevent annotations crashing XY plot when annotations aren't passed

### DIFF
--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -262,7 +262,7 @@ const XYPlot: FC<Props> = ({
 
   if (isFlagEnabled('annotations')) {
     // annotations and the cellID might or might be provided to this graph view
-    const cellAnnotations = annotations ? annotations[cellID] ?? [] : []
+    const cellAnnotations = annotations?.cellID ?? []
     const annotationsToRender: any[] = cellAnnotations.map(annotation => {
       return {
         ...annotation,

--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -261,8 +261,8 @@ const XYPlot: FC<Props> = ({
   }
 
   if (isFlagEnabled('annotations')) {
-    const cellAnnotations = annotations[cellID] ?? []
-
+    // annotations and the cellID might or might be provided to this graph view
+    const cellAnnotations = annotations ? (annotations[cellID] ?? []) : []
     const annotationsToRender: any[] = cellAnnotations.map(annotation => {
       return {
         ...annotation,

--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -63,6 +63,7 @@ import {event} from 'src/cloud/utils/reporting'
 import {createAnnotationFailed} from 'src/shared/copy/notifications'
 
 import {notify} from 'src/shared/actions/notifications'
+import {cell} from '../../../../mocks/dummyData'
 
 interface Props extends VisualizationProps {
   properties: XYViewProperties

--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -262,7 +262,7 @@ const XYPlot: FC<Props> = ({
 
   if (isFlagEnabled('annotations')) {
     // annotations and the cellID might or might be provided to this graph view
-    const cellAnnotations = annotations ? (annotations[cellID] ?? []) : []
+    const cellAnnotations = annotations ? annotations[cellID] ?? [] : []
     const annotationsToRender: any[] = cellAnnotations.map(annotation => {
       return {
         ...annotation,

--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -63,7 +63,6 @@ import {event} from 'src/cloud/utils/reporting'
 import {createAnnotationFailed} from 'src/shared/copy/notifications'
 
 import {notify} from 'src/shared/actions/notifications'
-import {cell} from '../../../../mocks/dummyData'
 
 interface Props extends VisualizationProps {
   properties: XYViewProperties


### PR DESCRIPTION
Closes #1085

In the view.tsx, `annotations` weren't being checked if they were empty, this caused it to crash when the XY plot was in a notebook context and no annotations were passed in. 

It didn't make sense to me why it didn't happen in the data-explorer, we use XY plot there as well. Did a little digging and found that this is because annotations were shown in data explorer prior to us constraining it to a dashboard-cell. This meant that an empty array was being passed here: [Vis.tsx/L59](https://github.com/influxdata/ui/blob/c03ce296402acd8419d361c0e0835c469cf4ffeb/src/timeMachine/components/Vis.tsx#L59) and not an `undefined` as in the context of the notebooks. 

This raises another point, should we remove annotation code from the data-explorer visualization code? 


Here is the screenshot of it working with the annotation feature flag enabled, and using the notebooks: 


<img width="1440" alt="Screen Shot 2021-04-02 at 7 54 33 AM" src="https://user-images.githubusercontent.com/18511823/113427179-7359ce00-9389-11eb-8bd7-259fb8065118.png">
