### PR TITLE
fix: fixed the array access method for annotations in view.tsx

### DIFF
--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -262,7 +262,7 @@ const XYPlot: FC<Props> = ({
 
   if (isFlagEnabled('annotations')) {
     // annotations and the cellID might or might be provided to this graph view
-    const cellAnnotations = annotations?.cellID ?? []
+    const cellAnnotations = annotations ? annotations[cellID] ?? [] : []
     const annotationsToRender: any[] = cellAnnotations.map(annotation => {
       return {
         ...annotation,


### PR DESCRIPTION
The last fix in #1088 did stop the plot crash when no annotation were passed but it wasn't rendering any because the array was being accessed as if it was an object. this will fix it. 

