### PR TITLE
chore: Clean up unity.yml to remove circular dependencies

### DIFF
--- a/cypress/e2e/cloud/checkout.test.ts
+++ b/cypress/e2e/cloud/checkout.test.ts
@@ -29,6 +29,7 @@ describe('Checkout Page', () => {
       cy.get('@org').then(() => {
         cy.getByTestID('home-page--header').should('be.visible')
         cy.window().then(w => {
+          w.influx.set('unity-me-api', true)
           w.influx.set('unity-checkout', true)
           cy.wait(1000)
         })

--- a/src/client/swagger/unity.yml
+++ b/src/client/swagger/unity.yml
@@ -840,7 +840,7 @@ components:
           type: string
           description: account id
         quartzId:
-          type: string
+          type: number
           description: account id in quartz
         onboardingState:
           type: string
@@ -1133,7 +1133,7 @@ components:
         quartzId:
           description: the quartz id of the user
           readOnly: true
-          type: string
+          type: number
         onboardingState:
           description: onboarding state of the user
           type: string
@@ -1232,7 +1232,7 @@ components:
           type: string
           description: ID of the org
         quartzId:
-          type: string
+          type: number
           description: quartz ID of the org
         name:
           type: string

--- a/src/client/swagger/unity.yml
+++ b/src/client/swagger/unity.yml
@@ -844,7 +844,6 @@ components:
           description: account id in quartz
         onboardingState:
           type: string
-          # TODO(ariel): get clarity on this
           description: stage of onboarding the account is in
         marketplace:
           $ref: '#/components/schemas/Marketplace'
@@ -1166,28 +1165,21 @@ components:
     Me:
       properties:
         id:
+          type: string
           description: the idpe id of the user
-          type: string
-        # TODO(ariel): find out if these are account or user specific
-        firstName:
-          type: string
-        # TODO(ariel): find out if these are account or user specific
-        lastName:
-          type: string
         email:
-          # TODO(ariel): find out about this one
-          description: Not sure if this is the billing account email or the account email, but this might be unnecessary since that should be included in the Account or nested in the Account
           type: string
+          description: the email associated with the user
         account:
           $ref: '#/components/schemas/Account'
           description: User Account for the account
-        isBeta:
+        isRegionBeta:
           type: boolean
           description: whether the region associated with the account is a beta region
         isOperator:
           type: boolean
           description: whether the user is an operator
-      required: [id, account, email, firstName, lastName, isOperator, isBeta]
+      required: [id, account, email, isOperator, isRegionBeta]
     Users:
       type: object
       properties:
@@ -1254,39 +1246,35 @@ components:
         date:
           type: string
           description: date org was created
-        accountType:
+        relatedAccount:
+          $ref: '#/components/schemas/RelatedAccount'
+          description: subset of related account information
+      required: [id, quartzId, name, region, provider, date]
+    Organizations:
+      type: array
+      items:
+        $ref: '#/components/schemas/Organization'
+    RelatedAccount:
+      description: Subset of Account data related to the organization
+      type: object
+      properties:
+        id:
+          type: string
+          description: account id
+        email:
+          type: string
+          description: email associated with the account
+        type:
           type: string
           description: type of the account
           enum:
             - free
             - cancelled
             - pay_as_you_go
-        accountBalance:
+        balance:
           type: number
-          description: balance of the account
-        accountEmail:
-          type: string
-          description: billing contact email
-        accountId:
-          type: string
-          description: id of the account associated with the org
-      required:
-        [
-          id,
-          quartzId,
-          name,
-          accountType,
-          accountBalance,
-          accountEmail,
-          accountId,
-          region,
-          provider,
-          date,
-        ]
-    Organizations:
-      type: array
-      items:
-        $ref: '#/components/schemas/Organization'
+          description: remaining balance on the account, nil if none
+      required: [id, email, type, balance]
     RateLimits:
       description: Usage rate limits
       type: object

--- a/src/client/swagger/unity.yml
+++ b/src/client/swagger/unity.yml
@@ -1162,55 +1162,26 @@ components:
         id:
           description: the idpe id of the user
           type: string
+        # TODO(ariel): find out if these are account or user specific
         firstName:
           type: string
+        # TODO(ariel): find out if these are account or user specific
         lastName:
           type: string
         email:
+          # TODO(ariel): find out about this one
+          description: Not sure if this is the billing account email or the account email, but this might be unnecessary since that should be included in the Account or nested in the Account
           type: string
-        orgId:
-          type: string
-        accountId:
-          type: string
+        account:
+          $ref: '#/components/schemas/Account'
+          description: User Account for the account
         isBeta:
           type: boolean
           description: whether the region associated with the account is a beta region
         isOperator:
           type: boolean
           description: whether the user is an operator
-        marketplace:
-          $ref: '#/components/schemas/Marketplace'
-          description: which marketplace, nil if none
-        balance:
-          type: number
-          description: remaining balance on the account, nil if none
-        billingContact:
-          $ref: '#/components/schemas/BillingContact'
-          description: billing contact for the account
-        users:
-          type: array
-          items:
-            $ref: '#/components/schemas/User'
-        type:
-          type: string
-          description: type of the account
-          enum:
-            - free
-            - cancelled
-            - pay_as_you_go
-      required:
-        [
-          id,
-          accountId,
-          email,
-          firstName,
-          lastName,
-          isOperator,
-          isBeta,
-          orgId,
-          marketplace,
-          type,
-        ]
+      required: [id, account, email, firstName, lastName, isOperator, isBeta]
     Users:
       type: object
       properties:

--- a/src/client/swagger/unity.yml
+++ b/src/client/swagger/unity.yml
@@ -1254,6 +1254,15 @@ components:
             - free
             - cancelled
             - pay_as_you_go
+        accountBalance:
+          type: number
+          description: balance of the account
+        accountEmail:
+          type: string
+          description: billing contact email
+        accountId:
+          type: string
+          description: id of the account associated with the org
       required: [id, quartzId, name, accountType, region, provider, date]
     Organizations:
       type: array

--- a/src/client/swagger/unity.yml
+++ b/src/client/swagger/unity.yml
@@ -849,7 +849,6 @@ components:
             - free
             - cancelled
             - pay_as_you_go
-        # TODO(ariel): this seems cyclical since accounts and orgs are subsets of one another
         organizations:
           $ref: '#/components/schemas/Organizations'
         zuoraAccountId:
@@ -1233,9 +1232,9 @@ components:
         id:
           type: string
           description: ID of the org
-        idpeID:
+        quartzId:
           type: string
-          description: idpe ID of the org
+          description: quartz ID of the org
         name:
           type: string
           description: name of the org
@@ -1248,10 +1247,14 @@ components:
         date:
           type: string
           description: date org was created
-        # TODO(ariel): this seems cyclical since accounts and orgs are subsets of one another
-        account:
-          $ref: '#/components/schemas/Account'
-      required: [id, idpeID, name, account, region, provider, date]
+        accountType:
+          type: string
+          description: type of the account
+          enum:
+            - free
+            - cancelled
+            - pay_as_you_go
+      required: [id, quartzId, name, accountType, region, provider, date]
     Organizations:
       type: array
       items:

--- a/src/client/swagger/unity.yml
+++ b/src/client/swagger/unity.yml
@@ -839,6 +839,13 @@ components:
         id:
           type: string
           description: account id
+        quartzId:
+          type: string
+          description: account id in quartz
+        onboardingState:
+          type: string
+          # TODO(ariel): get clarity on this
+          description: stage of onboarding the account is in
         marketplace:
           $ref: '#/components/schemas/Marketplace'
           description: which marketplace, nil if none
@@ -1263,7 +1270,19 @@ components:
         accountId:
           type: string
           description: id of the account associated with the org
-      required: [id, quartzId, name, accountType, region, provider, date]
+      required:
+        [
+          id,
+          quartzId,
+          name,
+          accountType,
+          accountBalance,
+          accountEmail,
+          accountId,
+          region,
+          provider,
+          date,
+        ]
     Organizations:
       type: array
       items:

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,7 @@ import 'abortcontroller-polyfill/dist/polyfill-patch-fetch'
 import React, {PureComponent, Suspense} from 'react'
 import {render} from 'react-dom'
 import {Provider} from 'react-redux'
-import {Route, Switch} from 'react-router-dom'
+import {Route} from 'react-router-dom'
 import {ConnectedRouter} from 'connected-react-router'
 
 // Stores
@@ -13,20 +13,15 @@ import {getStore} from 'src/store/configureStore'
 import {history} from 'src/store/history'
 
 // Components
-import {CheckoutPage, OperatorPage} from 'src/shared/containers'
 import Setup from 'src/Setup'
 import PageSpinner from 'src/perf/components/PageSpinner'
 
 // Utilities
 import {getRootNode} from 'src/utils/nodes'
 import {updateReportingContext} from 'src/cloud/utils/reporting'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Actions
 import {disablePresentationMode} from 'src/shared/actions/app'
-
-// Constants
-import {CLOUD} from 'src/shared/constants'
 
 // Styles
 import 'src/style/chronograf.scss'
@@ -75,19 +70,7 @@ class Root extends PureComponent {
       <Provider store={getStore()}>
         <ConnectedRouter history={history}>
           <Suspense fallback={<PageSpinner />}>
-            <Switch>
-              {/* TODO(ariel): we need to restrict access to the checkout and operator pages based on specific critera:
-                https://github.com/influxdata/ui/issues/848
-               */}
-              {CLOUD && isFlagEnabled('unity-checkout') && (
-                <Route path="/checkout" component={CheckoutPage} />
-              )}
-              {/* Operator Routes */}
-              {CLOUD && isFlagEnabled('unity-operator') && (
-                <Route path="/operator" component={OperatorPage} />
-              )}
-              <Route component={Setup} />
-            </Switch>
+            <Route component={Setup} />
           </Suspense>
         </ConnectedRouter>
       </Provider>

--- a/src/me/actions/creators/index.ts
+++ b/src/me/actions/creators/index.ts
@@ -1,11 +1,31 @@
 import {MeState} from 'src/me/reducers'
+import {Me} from 'src/client/unityRoutes'
+import {RemoteDataState} from 'src/types'
 
 export const SET_ME = 'SET_ME'
+export const SET_QUARTZ_ME = 'SET_QUARTZ_ME'
+export const SET_QUARTZ_ME_STATUS = 'SET_QUARTZ_ME_STATUS'
 
-export type Actions = ReturnType<typeof setMe>
+export type Actions =
+  | ReturnType<typeof setMe>
+  | ReturnType<typeof setQuartzMe>
+  | ReturnType<typeof setQuartzMeStatus>
 
 export const setMe = (me: MeState) =>
   ({
     type: SET_ME,
     me,
+  } as const)
+
+export const setQuartzMe = (me: Me, status: RemoteDataState) =>
+  ({
+    type: SET_QUARTZ_ME,
+    quartzMe: me,
+    status,
+  } as const)
+
+export const setQuartzMeStatus = (status: RemoteDataState) =>
+  ({
+    type: SET_QUARTZ_ME_STATUS,
+    status,
   } as const)

--- a/src/me/actions/thunks/index.ts
+++ b/src/me/actions/thunks/index.ts
@@ -2,7 +2,7 @@
 import HoneyBadger from 'honeybadger-js'
 
 // API
-import {client, getMeQuartz} from 'src/utils/api'
+import {client, getMeQuartz as apiGetQuartzMe} from 'src/utils/api'
 
 // Utils
 import {gaEvent, updateReportingContext} from 'src/cloud/utils/reporting'
@@ -44,7 +44,7 @@ export const getMe = () => async dispatch => {
 export const getQuartzMe = () => async dispatch => {
   try {
     dispatch(setQuartzMeStatus(RemoteDataState.Loading))
-    const resp = await getMeQuartz()
+    const resp = await apiGetQuartzMe()
 
     if (resp.status !== 200) {
       throw new Error(resp.data.message)

--- a/src/me/actions/thunks/index.ts
+++ b/src/me/actions/thunks/index.ts
@@ -2,16 +2,19 @@
 import HoneyBadger from 'honeybadger-js'
 
 // API
-import {client} from 'src/utils/api'
+import {client, getMeQuartz} from 'src/utils/api'
 
 // Utils
 import {gaEvent, updateReportingContext} from 'src/cloud/utils/reporting'
 
 // Actions
-import {setMe} from 'src/me/actions/creators'
+import {setMe, setQuartzMe, setQuartzMeStatus} from 'src/me/actions/creators'
 
 // Reducers
 import {MeState} from 'src/me/reducers'
+
+// Types
+import {RemoteDataState} from 'src/types'
 
 export const getMe = () => async dispatch => {
   try {
@@ -35,5 +38,21 @@ export const getMe = () => async dispatch => {
     dispatch(setMe(user as MeState))
   } catch (error) {
     console.error(error)
+  }
+}
+
+export const getQuartzMe = () => async dispatch => {
+  try {
+    dispatch(setQuartzMeStatus(RemoteDataState.Loading))
+    const resp = await getMeQuartz()
+
+    if (resp.status !== 200) {
+      throw new Error(resp.data.message)
+    }
+
+    dispatch(setQuartzMe(resp.data, RemoteDataState.Done))
+  } catch (error) {
+    console.error(error)
+    dispatch(setQuartzMeStatus(RemoteDataState.Error))
   }
 }

--- a/src/me/mockUserData.ts
+++ b/src/me/mockUserData.ts
@@ -1,5 +1,5 @@
 // Types
-import {AppState} from 'src/types'
+import {AppState, RemoteDataState} from 'src/types'
 
 const LeroysTokens = [
   {
@@ -21,6 +21,8 @@ export const me: AppState['me'] = {
     self: '/api/v2/users/id-of-groot',
     log: '/api/v2/users/id-of-groot/log',
   },
+  quartzMeStatus: RemoteDataState.NotStarted,
+  quartzMe: null,
 }
 
 export const LeroyJenkins = {

--- a/src/me/reducers/index.ts
+++ b/src/me/reducers/index.ts
@@ -2,8 +2,16 @@
 import produce from 'immer'
 
 // Actions
-import {Actions, SET_ME} from 'src/me/actions/creators'
+import {
+  Actions,
+  SET_ME,
+  SET_QUARTZ_ME,
+  SET_QUARTZ_ME_STATUS,
+} from 'src/me/actions/creators'
 
+// Types
+import {Me} from 'src/client/unityRoutes'
+import {RemoteDataState} from 'src/types'
 export interface MeLinks {
   self: string
   log: string
@@ -13,6 +21,8 @@ export interface MeState {
   id: string
   name: string
   links: MeLinks
+  quartzMe?: Me
+  quartzMeStatus: RemoteDataState
 }
 
 export const initialState: MeState = {
@@ -22,6 +32,8 @@ export const initialState: MeState = {
     self: '',
     log: '',
   },
+  quartzMe: null,
+  quartzMeStatus: RemoteDataState.NotStarted,
 }
 
 export default (state = initialState, action: Actions): MeState =>
@@ -31,6 +43,17 @@ export default (state = initialState, action: Actions): MeState =>
         draftState.id = action.me.id
         draftState.name = action.me.name
         draftState.links = action.me.links
+
+        return
+      }
+      case SET_QUARTZ_ME: {
+        draftState.quartzMe = action.quartzMe
+        draftState.quartzMeStatus = action.status
+
+        return
+      }
+      case SET_QUARTZ_ME_STATUS: {
+        draftState.quartzMeStatus = action.status
 
         return
       }

--- a/src/operator/OperatorNav.tsx
+++ b/src/operator/OperatorNav.tsx
@@ -1,4 +1,5 @@
-import React, {FC, useContext} from 'react'
+import React, {FC} from 'react'
+import {useSelector} from 'react-redux'
 import {
   ReflessPopover,
   PopoverPosition,
@@ -8,10 +9,12 @@ import {
   PopoverInteraction,
 } from '@influxdata/clockface'
 import {Link} from 'react-router-dom'
-import {OperatorContext} from './context/operator'
+
+// Types
+import {AppState} from 'src/types'
 
 const OperatorNav: FC = () => {
-  const {operator} = useContext(OperatorContext)
+  const operator = useSelector((state: AppState) => state.me.quartzMe)
   return (
     <ReflessPopover
       position={PopoverPosition.ToTheLeft}

--- a/src/operator/OperatorTabs.tsx
+++ b/src/operator/OperatorTabs.tsx
@@ -3,7 +3,7 @@ import {Tabs, ComponentSize} from '@influxdata/clockface'
 import {Link} from 'react-router-dom'
 
 // Components
-import {OperatorContext} from './context/operator'
+import {OperatorContext} from 'src/operator/context/operator'
 
 // Types
 import {OperatorRoutes} from 'src/operator/constants'

--- a/src/operator/OrgOverlay.tsx
+++ b/src/operator/OrgOverlay.tsx
@@ -76,7 +76,7 @@ const OrgOverlay: FC = () => {
                 </Grid.Column>
                 <Grid.Column widthMD={4}>
                   <label>Account Type</label>
-                  <p>{organization?.account?.type ?? ''}</p>
+                  <p>{organization?.accountType ?? ''}</p>
                 </Grid.Column>
                 <Grid.Column widthMD={4}>
                   <LinkButton

--- a/src/operator/OrgOverlay.tsx
+++ b/src/operator/OrgOverlay.tsx
@@ -76,7 +76,7 @@ const OrgOverlay: FC = () => {
                 </Grid.Column>
                 <Grid.Column widthMD={4}>
                   <label>Account Type</label>
-                  <p>{organization?.accountType ?? ''}</p>
+                  <p>{organization?.relatedAccount?.type ?? ''}</p>
                 </Grid.Column>
                 <Grid.Column widthMD={4}>
                   <LinkButton

--- a/src/operator/ResourcesTable.tsx
+++ b/src/operator/ResourcesTable.tsx
@@ -41,7 +41,7 @@ const ResourcesTable: FC = () => {
     : accounts
   const headers = isOrgsTab ? organizationColumnHeaders : accountHeaderInfo
   const infos = isOrgsTab ? organizationColumnInfo : accountColumnInfo
-  console.log({organizations})
+
   return (
     <Tabs.Container orientation={Orientation.Horizontal}>
       <OperatorTabs />

--- a/src/operator/ResourcesTable.tsx
+++ b/src/operator/ResourcesTable.tsx
@@ -41,7 +41,7 @@ const ResourcesTable: FC = () => {
     : accounts
   const headers = isOrgsTab ? organizationColumnHeaders : accountHeaderInfo
   const infos = isOrgsTab ? organizationColumnInfo : accountColumnInfo
-
+  console.log({organizations})
   return (
     <Tabs.Container orientation={Orientation.Horizontal}>
       <OperatorTabs />

--- a/src/operator/api/index.ts
+++ b/src/operator/api/index.ts
@@ -115,95 +115,36 @@ export const getOrgs = (
   const organizations: Organization[] = [
     {
       id: '123',
-      idpeID: '123',
+      quartzId: '123',
       name: 'Best Org',
       region: 'us-west',
       provider: 'Zuora',
       date: '01/01/2010',
-      account: {
-        id: '123',
-        marketplace: null,
-        balance: 0,
-        billingContact: {
-          companyName: 'Influx',
-          email: 'asalem@influxdata.com',
-          firstName: 'Ariel',
-          lastName: 'Salem',
-          country: 'USA',
-          street1: '123 Main St',
-          city: 'New York',
-          subdivision: 'NY',
-          postalCode: 30000,
-        },
-        users: [],
-        type: 'pay_as_you_go',
-      },
+      accountType: 'pay_as_you_go',
     },
     {
       id: '345',
-      idpeID: '345',
+      quartzId: '345',
       name: 'Second_best_org',
       region: 'eu-central',
       provider: 'aws',
       date: '01/01/2011',
-      account: {
-        id: '345',
-        marketplace: {
-          name: 'Amazon Web Services',
-          url: 'smile.amazon.com',
-          shortName: 'aws',
-        },
-        balance: 10,
-        billingContact: {
-          companyName: 'Data',
-          email: 'watts@influxdata.com',
-          firstName: 'Andrew',
-          lastName: 'Watkins',
-          country: 'USA',
-          street1: '345 Main St',
-          city: 'Austin',
-          subdivision: 'TX',
-          postalCode: 50000,
-        },
-        users: [],
-        type: 'cancelled',
-      },
+      accountType: 'cancelled',
     },
     {
       id: '678',
-      idpeID: '678',
+      quartzId: '678',
       name: 'Lucky 3',
       region: 'gcp-west',
       provider: 'gcm',
       date: '01/01/2012',
-      account: {
-        id: '678',
-        marketplace: {
-          shortName: 'gcm',
-          name: 'Google Cloud Marketplace',
-          url: 'www.google.com',
-        },
-        balance: 20,
-        billingContact: {
-          companyName: 'Pineapple',
-          email: 'desa@influxdata.com',
-          firstName: 'Michael',
-          lastName: 'De Sa',
-          country: 'USA',
-          street1: '678 Main St',
-          city: 'Seattle',
-          subdivision: 'WA',
-          postalCode: 80000,
-        },
-        users: [],
-        type: 'free',
-      },
+      accountType: 'free',
     },
   ]
 
   const filtered = organizations.filter(org => {
     if (searchTerm) {
-      return org.id.includes(searchTerm) || org.idpeID.includes(searchTerm)
+      return org.id.includes(searchTerm) || org.quartzId.includes(searchTerm)
     }
     return true
   })
@@ -213,29 +154,12 @@ export const getOrgs = (
 export const getOrgById = (_id: string): ReturnType<typeof getOrg> => {
   const organization: Organization = {
     id: '123',
-    idpeID: '123',
+    quartzId: '123',
     name: 'Best Org',
     region: 'us-west',
     provider: 'Zuora',
     date: '01/01/2010',
-    account: {
-      id: '123',
-      marketplace: null,
-      balance: 0,
-      billingContact: {
-        companyName: 'Influx',
-        email: 'asalem@influxdata.com',
-        firstName: 'Ariel',
-        lastName: 'Salem',
-        country: 'USA',
-        street1: '123 Main St',
-        city: 'New York',
-        subdivision: 'NY',
-        postalCode: 30000,
-      },
-      users: [],
-      type: 'pay_as_you_go',
-    },
+    accountType: 'pay_as_you_go',
   }
 
   return makeResponse(200, organization)
@@ -255,12 +179,12 @@ export const getAccountById = (
     organizations: [
       {
         id: 'orgid',
-        idpeID: 'idpeID',
+        quartzId: 'quartzId',
         name: 'name',
         region: 'region',
         provider: 'provider',
         date: '01/01/2021',
-        account: null,
+        accountType: 'free',
       },
     ],
     billingContact: {

--- a/src/operator/api/index.ts
+++ b/src/operator/api/index.ts
@@ -201,7 +201,7 @@ export const getAccountById = (
     organizations: [
       {
         id: 'orgid',
-        quartzId: 001,
+        quartzId: 1001,
         name: 'name',
         region: 'region',
         provider: 'provider',

--- a/src/operator/api/index.ts
+++ b/src/operator/api/index.ts
@@ -121,6 +121,9 @@ export const getOrgs = (
       provider: 'Zuora',
       date: '01/01/2010',
       accountType: 'pay_as_you_go',
+      accountBalance: 0,
+      accountId: 'account123',
+      accountEmail: 'account@account.com',
     },
     {
       id: '345',
@@ -130,6 +133,9 @@ export const getOrgs = (
       provider: 'aws',
       date: '01/01/2011',
       accountType: 'cancelled',
+      accountBalance: 0,
+      accountId: 'cancelled1',
+      accountEmail: 'cancelled@account.com',
     },
     {
       id: '678',
@@ -139,6 +145,9 @@ export const getOrgs = (
       provider: 'gcm',
       date: '01/01/2012',
       accountType: 'free',
+      accountBalance: 0,
+      accountId: 'free123',
+      accountEmail: 'free@account.com',
     },
   ]
 
@@ -160,6 +169,9 @@ export const getOrgById = (_id: string): ReturnType<typeof getOrg> => {
     provider: 'Zuora',
     date: '01/01/2010',
     accountType: 'pay_as_you_go',
+    accountBalance: 10,
+    accountId: 'pay123',
+    accountEmail: 'paid@account.com',
   }
 
   return makeResponse(200, organization)
@@ -185,6 +197,9 @@ export const getAccountById = (
         provider: 'provider',
         date: '01/01/2021',
         accountType: 'free',
+        accountBalance: 0,
+        accountId: 'freeme1',
+        accountEmail: 'free1@account.com',
       },
     ],
     billingContact: {

--- a/src/operator/api/index.ts
+++ b/src/operator/api/index.ts
@@ -160,7 +160,7 @@ export const getOrgs = (
   const filtered = organizations.filter(org => {
     if (searchTerm) {
       return (
-        org.id.includes(searchTerm) || org.quartzId.includes(Number(searchTerm))
+        org.id.includes(searchTerm) || `${org.quartzId}`.includes(searchTerm)
       )
     }
     return true

--- a/src/operator/api/index.ts
+++ b/src/operator/api/index.ts
@@ -1,7 +1,6 @@
 import {
   deleteOperatorAccount,
   deleteOperatorAccountUser,
-  getMe as apiGetMe,
   getOperatorAccount,
   getOperatorAccounts,
   getOperatorOrgs,
@@ -9,7 +8,7 @@ import {
   getOrgsLimits,
   putOrgsLimits,
 } from 'src/client/unityRoutes'
-import {Account, Me, Organization, OrgLimits} from 'src/types/operator'
+import {Account, Organization, OrgLimits} from 'src/types/operator'
 
 const makeResponse = (status, data) => {
   return Promise.resolve({
@@ -240,36 +239,6 @@ export const getOrgById = (_id: string): ReturnType<typeof getOrg> => {
   }
 
   return makeResponse(200, organization)
-}
-
-export const getMe = (): ReturnType<typeof apiGetMe> => {
-  const me: Me = {
-    id: '123',
-    firstName: 'ariel',
-    lastName: 'salem',
-    email: 'asalem@influxdata.com',
-    orgId: 'org123',
-    accountId: 'account123',
-    isBeta: false,
-    isOperator: true,
-    marketplace: null,
-    balance: 0,
-    billingContact: {
-      companyName: 'Influx',
-      email: 'asalem@influxdata.com',
-      firstName: 'Ariel',
-      lastName: 'Salem',
-      country: 'USA',
-      street1: '123 Main St',
-      city: 'New York',
-      subdivision: 'NY',
-      postalCode: 30000,
-    },
-    users: [],
-    type: 'pay_as_you_go',
-  }
-
-  return makeResponse(200, me)
 }
 
 export const getAccountById = (

--- a/src/operator/api/index.ts
+++ b/src/operator/api/index.ts
@@ -120,10 +120,12 @@ export const getOrgs = (
       region: 'us-west',
       provider: 'Zuora',
       date: '01/01/2010',
-      accountType: 'pay_as_you_go',
-      accountBalance: 0,
-      accountId: 'account123',
-      accountEmail: 'account@account.com',
+      relatedAccount: {
+        type: 'pay_as_you_go',
+        balance: 0,
+        id: 'account123',
+        email: 'account@account.com',
+      },
     },
     {
       id: '345',
@@ -132,10 +134,12 @@ export const getOrgs = (
       region: 'eu-central',
       provider: 'aws',
       date: '01/01/2011',
-      accountType: 'cancelled',
-      accountBalance: 0,
-      accountId: 'cancelled1',
-      accountEmail: 'cancelled@account.com',
+      relatedAccount: {
+        type: 'cancelled',
+        balance: 0,
+        id: 'cancelled1',
+        email: 'cancelled@account.com',
+      },
     },
     {
       id: '678',
@@ -144,10 +148,12 @@ export const getOrgs = (
       region: 'gcp-west',
       provider: 'gcm',
       date: '01/01/2012',
-      accountType: 'free',
-      accountBalance: 0,
-      accountId: 'free123',
-      accountEmail: 'free@account.com',
+      relatedAccount: {
+        type: 'free',
+        balance: 0,
+        id: 'free123',
+        email: 'free@account.com',
+      },
     },
   ]
 
@@ -168,10 +174,12 @@ export const getOrgById = (_id: string): ReturnType<typeof getOrg> => {
     region: 'us-west',
     provider: 'Zuora',
     date: '01/01/2010',
-    accountType: 'pay_as_you_go',
-    accountBalance: 10,
-    accountId: 'pay123',
-    accountEmail: 'paid@account.com',
+    relatedAccount: {
+      type: 'pay_as_you_go',
+      balance: 10,
+      id: 'pay123',
+      email: 'paid@account.com',
+    },
   }
 
   return makeResponse(200, organization)
@@ -196,10 +204,12 @@ export const getAccountById = (
         region: 'region',
         provider: 'provider',
         date: '01/01/2021',
-        accountType: 'free',
-        accountBalance: 0,
-        accountId: 'freeme1',
-        accountEmail: 'free1@account.com',
+        relatedAccount: {
+          type: 'free',
+          balance: 0,
+          id: 'freeme1',
+          email: 'free1@account.com',
+        },
       },
     ],
     billingContact: {

--- a/src/operator/api/index.ts
+++ b/src/operator/api/index.ts
@@ -40,7 +40,7 @@ export const getAccounts = (
       users: [
         {
           id: 'user1',
-          quartzId: 'q1',
+          quartzId: 1,
           onboardingState: 'complete',
           sfdcContactId: 'sdfc_u_know_me',
           firstName: 'jr',
@@ -115,7 +115,7 @@ export const getOrgs = (
   const organizations: Organization[] = [
     {
       id: '123',
-      quartzId: '123',
+      quartzId: 12,
       name: 'Best Org',
       region: 'us-west',
       provider: 'Zuora',
@@ -129,7 +129,7 @@ export const getOrgs = (
     },
     {
       id: '345',
-      quartzId: '345',
+      quartzId: 345,
       name: 'Second_best_org',
       region: 'eu-central',
       provider: 'aws',
@@ -143,7 +143,7 @@ export const getOrgs = (
     },
     {
       id: '678',
-      quartzId: '678',
+      quartzId: 678,
       name: 'Lucky 3',
       region: 'gcp-west',
       provider: 'gcm',
@@ -159,7 +159,9 @@ export const getOrgs = (
 
   const filtered = organizations.filter(org => {
     if (searchTerm) {
-      return org.id.includes(searchTerm) || org.quartzId.includes(searchTerm)
+      return (
+        org.id.includes(searchTerm) || org.quartzId.includes(Number(searchTerm))
+      )
     }
     return true
   })
@@ -169,7 +171,7 @@ export const getOrgs = (
 export const getOrgById = (_id: string): ReturnType<typeof getOrg> => {
   const organization: Organization = {
     id: '123',
-    quartzId: '123',
+    quartzId: 123,
     name: 'Best Org',
     region: 'us-west',
     provider: 'Zuora',
@@ -199,7 +201,7 @@ export const getAccountById = (
     organizations: [
       {
         id: 'orgid',
-        quartzId: 'quartzId',
+        quartzId: 001,
         name: 'name',
         region: 'region',
         provider: 'provider',

--- a/src/operator/constants.tsx
+++ b/src/operator/constants.tsx
@@ -72,13 +72,13 @@ export const organizationColumnInfo: CellInfo[] = [
     defaultValue: '',
   },
   {
-    path: 'idpeID',
+    path: 'quartzId',
     name: 'org-id',
     defaultValue: '',
     renderValue: value => <Link to={`/operator/orgs/${value}`}>{value}</Link>,
   },
   {
-    path: 'account.billingContact.email',
+    path: 'accountEmail',
     name: 'email',
     defaultValue: '',
   },
@@ -93,7 +93,7 @@ export const organizationColumnInfo: CellInfo[] = [
     defaultValue: '',
   },
   {
-    path: 'account.type',
+    path: 'accountType',
     name: 'acct-type',
     defaultValue: '',
   },
@@ -171,7 +171,7 @@ export const acctOrgColumnInfo: CellInfo[] = [
     defaultValue: '',
   },
   {
-    path: 'idpeID',
+    path: 'quartzId',
     name: 'org-id',
     defaultValue: '',
     renderValue: value => <Link to={`/operator/orgs/${value}`}>{value}</Link>,

--- a/src/operator/constants.tsx
+++ b/src/operator/constants.tsx
@@ -78,22 +78,22 @@ export const organizationColumnInfo: CellInfo[] = [
     renderValue: value => <Link to={`/operator/orgs/${value}`}>{value}</Link>,
   },
   {
-    path: 'accountEmail',
+    path: 'relatedAccount.email',
     name: 'email',
     defaultValue: '',
   },
   {
-    path: 'accountId',
+    path: 'relatedAccount.id',
     name: 'account-id',
     defaultValue: '',
   },
   {
-    path: 'accountBalance',
+    path: 'relatedAccount.balance',
     name: 'acct-balance',
     defaultValue: '',
   },
   {
-    path: 'accountType',
+    path: 'relatedAccount.type',
     name: 'acct-type',
     defaultValue: '',
   },
@@ -179,7 +179,7 @@ export const acctOrgColumnInfo: CellInfo[] = [
   {path: 'provider', name: 'provider', defaultValue: ''},
   {path: 'region', name: 'region', defaultValue: ''},
   {
-    path: 'accountBalance',
+    path: 'relatedAccount.balance',
     name: 'acct-balance',
     defaultValue: '',
   },

--- a/src/operator/constants.tsx
+++ b/src/operator/constants.tsx
@@ -83,12 +83,12 @@ export const organizationColumnInfo: CellInfo[] = [
     defaultValue: '',
   },
   {
-    path: 'account.id',
+    path: 'accountId',
     name: 'account-id',
     defaultValue: '',
   },
   {
-    path: 'account.balance',
+    path: 'accountBalance',
     name: 'acct-balance',
     defaultValue: '',
   },
@@ -171,7 +171,7 @@ export const acctOrgColumnInfo: CellInfo[] = [
     defaultValue: '',
   },
   {
-    path: 'quartzId',
+    path: 'id',
     name: 'org-id',
     defaultValue: '',
     renderValue: value => <Link to={`/operator/orgs/${value}`}>{value}</Link>,
@@ -179,7 +179,7 @@ export const acctOrgColumnInfo: CellInfo[] = [
   {path: 'provider', name: 'provider', defaultValue: ''},
   {path: 'region', name: 'region', defaultValue: ''},
   {
-    path: 'account.balance',
+    path: 'accountBalance',
     name: 'acct-balance',
     defaultValue: '',
   },

--- a/src/operator/context/operator.tsx
+++ b/src/operator/context/operator.tsx
@@ -5,11 +5,11 @@ import {useLocation} from 'react-router-dom'
 
 // Utils
 import {notify} from 'src/shared/actions/notifications'
-import {getMe, getAccounts, getOrgs} from 'src/operator/api'
+import {getAccounts, getOrgs} from 'src/operator/api'
 import {getAccountsError, getOrgsError} from 'src/shared/copy/notifications'
 
 // Types
-import {Account, Me, Organization} from 'src/types/operator'
+import {Account, Organization} from 'src/types/operator'
 import {RemoteDataState} from 'src/types'
 import {OperatorRoutes} from 'src/operator/constants'
 
@@ -21,8 +21,6 @@ export interface OperatorContextType {
   accounts: Account[]
   handleGetAccounts: () => void
   handleGetOrgs: () => void
-  operator: Me
-  operatorStatus: RemoteDataState
   organizations: Organization[]
   pathname: string
   searchTerm: string
@@ -34,8 +32,6 @@ export const DEFAULT_CONTEXT: OperatorContextType = {
   accounts: [],
   handleGetAccounts: () => {},
   handleGetOrgs: () => {},
-  operator: null,
-  operatorStatus: RemoteDataState.NotStarted,
   organizations: [],
   pathname: OperatorRoutes.default,
   searchTerm: '',
@@ -49,12 +45,8 @@ export const OperatorContext = React.createContext<OperatorContextType>(
 
 export const OperatorProvider: FC<Props> = React.memo(({children}) => {
   const [accounts, setAccounts] = useState([])
-  const [operator, setOperator] = useState(null)
   const [accountStatus, setAccountStatus] = useState(RemoteDataState.NotStarted)
   const [orgsStatus, setOrgsStatus] = useState(RemoteDataState.NotStarted)
-  const [operatorStatus, setOperatorStatus] = useState(
-    RemoteDataState.NotStarted
-  )
   const [searchTerm, setSearchTerm] = useState('')
   const dispatch = useDispatch()
 
@@ -66,7 +58,6 @@ export const OperatorProvider: FC<Props> = React.memo(({children}) => {
       const resp = await getAccounts(searchTerm)
 
       if (resp.status !== 200) {
-        setAccountStatus(RemoteDataState.Error)
         throw new Error(resp.data.message)
       }
 
@@ -85,7 +76,6 @@ export const OperatorProvider: FC<Props> = React.memo(({children}) => {
       const resp = await getOrgs(searchTerm)
 
       if (resp.status !== 200) {
-        setOrgsStatus(RemoteDataState.Error)
         throw new Error(resp.data.message)
       }
 
@@ -116,29 +106,6 @@ export const OperatorProvider: FC<Props> = React.memo(({children}) => {
     }
   }, [pathname, handleGetAccounts, handleGetOrgs])
 
-  const handleGetMe = useCallback(async () => {
-    try {
-      setOperatorStatus(RemoteDataState.Loading)
-      const resp = await getMe()
-
-      if (resp.status !== 200) {
-        setOperatorStatus(RemoteDataState.Error)
-        throw new Error(resp.data.message)
-      }
-
-      setOperatorStatus(RemoteDataState.Done)
-      setOperator(resp.data)
-    } catch (error) {
-      console.error({error})
-      setOperatorStatus(RemoteDataState.Error)
-      dispatch(notify(getOrgsError()))
-    }
-  }, [dispatch])
-
-  useEffect(() => {
-    handleGetMe()
-  }, [handleGetMe])
-
   let status = RemoteDataState.Done
 
   const statuses = [accountStatus, orgsStatus]
@@ -157,8 +124,6 @@ export const OperatorProvider: FC<Props> = React.memo(({children}) => {
         accounts,
         handleGetAccounts,
         handleGetOrgs,
-        operator,
-        operatorStatus,
         organizations,
         pathname,
         searchTerm,

--- a/src/shared/containers/GetOrganizations.tsx
+++ b/src/shared/containers/GetOrganizations.tsx
@@ -28,13 +28,10 @@ import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {Me} from 'src/client/unityRoutes'
 
 const canAccessCheckout = (me: Me): boolean => {
-  if (me?.account?.type === 'pay_as_you_go') {
+  if (!!me?.isRegionBeta) {
     return false
   }
-  if (me?.account?.type === 'free' && !!me?.isBeta) {
-    return false
-  }
-  return true
+  return me?.account?.type !== 'pay_as_you_go'
 }
 
 const GetOrganizations: FunctionComponent = () => {

--- a/src/shared/containers/GetOrganizations.tsx
+++ b/src/shared/containers/GetOrganizations.tsx
@@ -9,7 +9,6 @@ import {CheckoutPage, OperatorPage} from 'src/shared/containers'
 const NoOrgsPage = lazy(() => import('src/organizations/containers/NoOrgsPage'))
 const App = lazy(() => import('src/App'))
 const NotFound = lazy(() => import('src/shared/components/NotFound'))
-import {FeatureFlag} from 'src/shared/utils/featureFlag'
 
 // Types
 import {RemoteDataState, AppState} from 'src/types'

--- a/src/shared/containers/GetOrganizations.tsx
+++ b/src/shared/containers/GetOrganizations.tsx
@@ -1,25 +1,49 @@
 // Libraries
 import React, {useEffect, FunctionComponent, lazy, Suspense} from 'react'
-import {connect, ConnectedProps, useDispatch} from 'react-redux'
+import {useDispatch, useSelector} from 'react-redux'
 import {Route, Switch} from 'react-router-dom'
 
 // Components
 import PageSpinner from 'src/perf/components/PageSpinner'
+import {CheckoutPage, OperatorPage} from 'src/shared/containers'
 const NoOrgsPage = lazy(() => import('src/organizations/containers/NoOrgsPage'))
 const App = lazy(() => import('src/App'))
 const NotFound = lazy(() => import('src/shared/components/NotFound'))
+import {FeatureFlag} from 'src/shared/utils/featureFlag'
 
 // Types
 import {RemoteDataState, AppState} from 'src/types'
 
 // Actions
 import {getOrganizations} from 'src/organizations/actions/thunks'
-import RouteToOrg from './RouteToOrg'
+import {getQuartzMe} from 'src/me/actions/thunks'
+import RouteToOrg from 'src/shared/containers/RouteToOrg'
 
-type ReduxProps = ConnectedProps<typeof connector>
-type Props = ReduxProps
+// Constants
+import {CLOUD} from 'src/shared/constants'
 
-const GetOrganizations: FunctionComponent<Props> = ({status}) => {
+// Utils
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+
+// Types
+import {Me} from 'src/client/unityRoutes'
+
+const canAccessCheckout = (me: Me): boolean => {
+  if (me?.account?.type === 'pay_as_you_go') {
+    return false
+  }
+  if (me?.account?.type === 'free' && !!me?.isBeta) {
+    return false
+  }
+  return true
+}
+
+const GetOrganizations: FunctionComponent = () => {
+  const status = useSelector((state: AppState) => state.resources.orgs.status)
+  const quartzMeStatus = useSelector(
+    (state: AppState) => state.me.quartzMeStatus
+  )
+  const me = useSelector((state: AppState) => state.me.quartzMe)
   const dispatch = useDispatch()
   useEffect(() => {
     if (status === RemoteDataState.NotStarted) {
@@ -27,24 +51,48 @@ const GetOrganizations: FunctionComponent<Props> = ({status}) => {
     }
   }, [dispatch, status])
 
+  useEffect(() => {
+    if (quartzMeStatus === RemoteDataState.NotStarted) {
+      dispatch(getQuartzMe())
+    }
+  }, [dispatch, quartzMeStatus])
+
   return (
     <PageSpinner loading={status}>
       <Suspense fallback={<PageSpinner />}>
-        <Switch>
+        <FeatureFlag name="unity-me-api">
+          <PageSpinner loading={quartzMeStatus}>
+            <Switch>
+              <Route path="/no-orgs" component={NoOrgsPage} />
+              <Route path="/orgs" component={App} />
+              <Route exact path="/" component={RouteToOrg} />
+              {CLOUD &&
+                isFlagEnabled('unity-checkout') &&
+                canAccessCheckout(me) && (
+                  <Route path="/checkout" component={CheckoutPage} />
+                )}
+              {CLOUD && isFlagEnabled('unity-operator') && me?.isOperator && (
+                <Route path="/operator" component={OperatorPage} />
+              )}
+              <Route component={NotFound} />
+            </Switch>
+          </PageSpinner>
+        </FeatureFlag>
+        {/* <Switch>
           <Route path="/no-orgs" component={NoOrgsPage} />
           <Route path="/orgs" component={App} />
           <Route exact path="/" component={RouteToOrg} />
+          {CLOUD && isFlagEnabled('unity-checkout') && (
+            <Route path="/checkout" component={CheckoutPage} />
+          )}
+          {CLOUD && isFlagEnabled('unity-operator') && (
+            <Route path="/operator" component={OperatorPage} />
+          )}
           <Route component={NotFound} />
-        </Switch>
+        </Switch> */}
       </Suspense>
     </PageSpinner>
   )
 }
 
-const mstp = ({resources}: AppState) => ({
-  status: resources.orgs.status,
-})
-
-const connector = connect(mstp)
-
-export default connector(GetOrganizations)
+export default GetOrganizations

--- a/src/shared/containers/GetOrganizations.tsx
+++ b/src/shared/containers/GetOrganizations.tsx
@@ -60,7 +60,7 @@ const GetOrganizations: FunctionComponent = () => {
   return (
     <PageSpinner loading={status}>
       <Suspense fallback={<PageSpinner />}>
-        <FeatureFlag name="unity-me-api">
+        {isFlagEnabled('unity-me-api') ? (
           <PageSpinner loading={quartzMeStatus}>
             <Switch>
               <Route path="/no-orgs" component={NoOrgsPage} />
@@ -77,19 +77,14 @@ const GetOrganizations: FunctionComponent = () => {
               <Route component={NotFound} />
             </Switch>
           </PageSpinner>
-        </FeatureFlag>
-        {/* <Switch>
-          <Route path="/no-orgs" component={NoOrgsPage} />
-          <Route path="/orgs" component={App} />
-          <Route exact path="/" component={RouteToOrg} />
-          {CLOUD && isFlagEnabled('unity-checkout') && (
-            <Route path="/checkout" component={CheckoutPage} />
-          )}
-          {CLOUD && isFlagEnabled('unity-operator') && (
-            <Route path="/operator" component={OperatorPage} />
-          )}
-          <Route component={NotFound} />
-        </Switch> */}
+        ) : (
+          <Switch>
+            <Route path="/no-orgs" component={NoOrgsPage} />
+            <Route path="/orgs" component={App} />
+            <Route exact path="/" component={RouteToOrg} />
+            <Route component={NotFound} />
+          </Switch>
+        )}
       </Suspense>
     </PageSpinner>
   )

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -47,10 +47,8 @@ export const getMeQuartz = (): ReturnType<typeof getMe> => {
   // TODO(ariel): remove this once the API is connected
   const me: Me = {
     id: '123',
-    firstName: 'ariel',
-    lastName: 'salem',
     email: 'asalem@influxdata.com',
-    isBeta: false,
+    isRegionBeta: false,
     isOperator: true,
     account: {
       id: 'account123',

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -2,6 +2,7 @@
 import {Client} from '@influxdata/influx'
 import {get} from 'lodash'
 import {getAPIBasepath} from 'src/utils/basepath'
+import {getMe, Me} from 'src/client/unityRoutes'
 
 const basePath = `${getAPIBasepath()}/api/v2`
 
@@ -32,3 +33,52 @@ export const getErrorMessage = (e: any) => {
 }
 
 export const client = new Client(basePath)
+
+// TODO(ariel): remove this once the API is integrated
+const makeResponse = (status, data) => {
+  return Promise.resolve({
+    status,
+    headers: new Headers({'Content-Type': 'application/json'}),
+    data,
+  })
+}
+
+export const getMeQuartz = (): ReturnType<typeof getMe> => {
+  // TODO(ariel): remove this once the API is connected
+  const me: Me = {
+    id: '123',
+    firstName: 'ariel',
+    lastName: 'salem',
+    email: 'asalem@influxdata.com',
+    isBeta: false,
+    isOperator: true,
+    account: {
+      id: 'account123',
+      marketplace: {
+        name: 'Google Cloud Marketplace',
+        shortName: 'gcm',
+        subscriberId: '123',
+        status: 'subscribed',
+        url: 'www.google.com',
+      },
+      type: 'pay_as_you_go',
+      organizations: null,
+      deletable: false,
+      balance: 0,
+      users: [],
+      billingContact: {
+        companyName: 'Influx',
+        email: 'asalem@influxdata.com',
+        firstName: 'Ariel',
+        lastName: 'Salem',
+        country: 'USA',
+        street1: '123 Main St',
+        city: 'New York',
+        subdivision: 'NY',
+        postalCode: 30000,
+      },
+    },
+  }
+
+  return makeResponse(200, me)
+}

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -52,14 +52,8 @@ export const getMeQuartz = (): ReturnType<typeof getMe> => {
     isOperator: true,
     account: {
       id: 'account123',
-      marketplace: {
-        name: 'Google Cloud Marketplace',
-        shortName: 'gcm',
-        subscriberId: '123',
-        status: 'subscribed',
-        url: 'www.google.com',
-      },
-      type: 'pay_as_you_go',
+      marketplace: null,
+      type: 'free',
       organizations: null,
       deletable: false,
       balance: 0,


### PR DESCRIPTION
This PR addresses a couple of nagging UI issues that are lingering around the `/me` endpoint, namely that:

- the checkout & operator page should be authenticated routes
- the checkout & operator page should only be accessible with specific credentials
- the yml file had some potentially cyclical dependencies between orgs and accounts that were simplified by flattening account props onto the org

This PR does not address:

- Adding conditional rendering logic for the `upgrade now` button with meta data that should be available with the `/me` endpoint

