### PR TITLE
fix: allow the user to run a visualization without aggregate window

### DIFF
--- a/src/flows/pipes/Visualization/Controls.tsx
+++ b/src/flows/pipes/Visualization/Controls.tsx
@@ -46,7 +46,7 @@ const Controls: FC<Props> = ({toggle, visible}) => {
 
   const options = useMemo(() => {
     if (!data.functions || !data.functions.length) {
-      return [{name: 'mean'}].map(f => f.name)
+      return []
     }
     return data.functions.map(f => f.name)
   }, [data.functions])

--- a/src/flows/pipes/Visualization/index.ts
+++ b/src/flows/pipes/Visualization/index.ts
@@ -18,12 +18,12 @@ export default register => {
       properties: SUPPORTED_VISUALIZATIONS['xy'].initial,
     },
     generateFlux: (pipe, _, append) => {
-      if (!pipe.functions || !pipe.functions.length) {
-        // this is just for migration
-        pipe.functions = [{name: 'mean'}]
+      if (!pipe.functions.length) {
+        append('__CURRENT_RESULT__')
+        return
       }
 
-      if (!pipe.functions.length || !pipe.period) {
+      if (!pipe.period) {
         return
       }
 


### PR DESCRIPTION
part of #1083 

not all visualizations work well with aggregate window. while we map those out.. at least allow the user to opt out of the functionality