### PR TITLE
feat: display more task runs on the page

### DIFF
--- a/src/tasks/components/TaskRunsList.tsx
+++ b/src/tasks/components/TaskRunsList.tsx
@@ -6,8 +6,6 @@ import memoizeOne from 'memoize-one'
 import {EmptyState, IndexList} from '@influxdata/clockface'
 import TaskRunsRow from 'src/tasks/components/TaskRunsRow'
 
-import {TASK_RUNS_LIMIT} from 'src/tasks/constants'
-
 // Types
 import {Sort, ComponentSize} from '@influxdata/clockface'
 import {Run} from 'src/types'
@@ -97,9 +95,7 @@ export default class TaskRunsList extends PureComponent<Props> {
       sortType
     )
 
-    const mostRecentRuns = sortedRuns.slice(0, TASK_RUNS_LIMIT)
-
-    return mostRecentRuns.map(run => (
+    return sortedRuns.map(run => (
       <TaskRunsRow key={`run-id==${run.id}`} taskID={taskID} run={run} />
     ))
   }

--- a/src/tasks/components/TaskRunsList.tsx
+++ b/src/tasks/components/TaskRunsList.tsx
@@ -6,6 +6,8 @@ import memoizeOne from 'memoize-one'
 import {EmptyState, IndexList} from '@influxdata/clockface'
 import TaskRunsRow from 'src/tasks/components/TaskRunsRow'
 
+import {TASK_RUNS_LIMIT} from 'src/tasks/constants'
+
 // Types
 import {Sort, ComponentSize} from '@influxdata/clockface'
 import {Run} from 'src/types'
@@ -95,7 +97,7 @@ export default class TaskRunsList extends PureComponent<Props> {
       sortType
     )
 
-    const mostRecentRuns = sortedRuns.slice(0, 20)
+    const mostRecentRuns = sortedRuns.slice(0, TASK_RUNS_LIMIT)
 
     return mostRecentRuns.map(run => (
       <TaskRunsRow key={`run-id==${run.id}`} taskID={taskID} run={run} />

--- a/src/tasks/constants/index.ts
+++ b/src/tasks/constants/index.ts
@@ -1,1 +1,0 @@
-export const TASK_RUNS_LIMIT = 100

--- a/src/tasks/constants/index.ts
+++ b/src/tasks/constants/index.ts
@@ -1,0 +1,1 @@
+export const TASK_RUNS_LIMIT = 100


### PR DESCRIPTION
We fetch 100 task runs from the API (https://docs.influxdata.com/influxdb/v2.0/api/#operation/GetTasksIDRuns), then only show 20 of them for some reason. this updates to show all 100 task runs if they are available.