### PR TITLE
fix: don't disappear all annotations on delete

### DIFF
--- a/src/annotations/reducers/index.ts
+++ b/src/annotations/reducers/index.ts
@@ -44,6 +44,7 @@ export const annotationsReducer = (
       return {
         ...state,
         annotations: {
+          ...state.annotations,
           [stream]: state.annotations[stream].filter(
             annotation => annotation.id !== action.annotation.id
           ),


### PR DESCRIPTION
Closes #1103

Deleting an annotation in one dashboard cell would cause other annotations to disappear