### PR TITLE
fix: disable writing annotation in dataExplorer

### DIFF
--- a/src/timeMachine/components/Vis.tsx
+++ b/src/timeMachine/components/Vis.tsx
@@ -57,6 +57,7 @@ const TimeMachineVis: FC<Props> = ({
   fillColumns,
   symbolColumns,
   annotations,
+  cellID,
 }) => {
   const {type} = viewProperties
   // If the current selections for `xColumn`/`yColumn`/ etc. are invalid given
@@ -150,6 +151,7 @@ const TimeMachineVis: FC<Props> = ({
         result={giraffeResult}
         timeRange={timeRange}
         annotations={annotations}
+        cellID={cellID}
       />
     </div>
   )
@@ -171,6 +173,7 @@ const mstp = (state: AppState) => {
   const fillColumns = getFillColumnsSelection(state)
   const symbolColumns = getSymbolColumnsSelection(state)
   const annotations = getAnnotations(state)
+  const cellID = activeTimeMachine.view.cellID
 
   return {
     loading,
@@ -187,6 +190,7 @@ const mstp = (state: AppState) => {
     symbolColumns,
     timeRange: getActiveTimeRange(timeRange, viewProperties.queries),
     annotations,
+    cellID,
   }
 }
 

--- a/src/timeMachine/components/Vis.tsx
+++ b/src/timeMachine/components/Vis.tsx
@@ -16,6 +16,7 @@ import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Utils
 import {
+  getActiveCellID,
   getActiveTimeMachine,
   getAnnotations,
   getFillColumnsSelection,
@@ -173,7 +174,7 @@ const mstp = (state: AppState) => {
   const fillColumns = getFillColumnsSelection(state)
   const symbolColumns = getSymbolColumnsSelection(state)
   const annotations = getAnnotations(state)
-  const cellID = activeTimeMachine.view.cellID
+  const cellID = getActiveCellID(state)
 
   return {
     loading,

--- a/src/timeMachine/selectors/index.ts
+++ b/src/timeMachine/selectors/index.ts
@@ -53,7 +53,7 @@ export const getActiveTimeMachine = (state: AppState) => {
 }
 
 export const getActiveCellID = (state: AppState) => {
-  return getActiveTimeMachine(state).view.cellID
+  return getActiveTimeMachine(state)?.view.cellID
 }
 
 export const getActiveGraphType = (state: AppState): string => {

--- a/src/timeMachine/selectors/index.ts
+++ b/src/timeMachine/selectors/index.ts
@@ -52,6 +52,10 @@ export const getActiveTimeMachine = (state: AppState) => {
   return timeMachine
 }
 
+export const getActiveCellID = (state: AppState) => {
+  return get(getActiveTimeMachine(state), 'view.cellID')
+}
+
 export const getActiveGraphType = (state: AppState): string => {
   return get(getActiveTimeMachine(state), 'view.properties.type', 'xy')
 }

--- a/src/timeMachine/selectors/index.ts
+++ b/src/timeMachine/selectors/index.ts
@@ -53,7 +53,7 @@ export const getActiveTimeMachine = (state: AppState) => {
 }
 
 export const getActiveCellID = (state: AppState) => {
-  return get(getActiveTimeMachine(state), 'view.cellID')
+  return getActiveTimeMachine(state).view.cellID
 }
 
 export const getActiveGraphType = (state: AppState): string => {

--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -270,7 +270,8 @@ const XYPlot: FC<Props> = ({
       }
     })
 
-    if (inAnnotationWriteMode) {
+    // only pass interaction handler to giraffe if annotations write mode is enabled and cellID is present
+    if (inAnnotationWriteMode && cellID) {
       config.interactionHandlers = {
         singleClick: makeSingleClickHandler(),
       }

--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -270,7 +270,6 @@ const XYPlot: FC<Props> = ({
       }
     })
 
-    // only pass interaction handler to giraffe if annotations write mode is enabled and cellID is present
     if (inAnnotationWriteMode && cellID) {
       config.interactionHandlers = {
         singleClick: makeSingleClickHandler(),


### PR DESCRIPTION
Closes #1091

We want to disable on-click-to-add-annotation behavior in the data explorer because it doesn't make sense anymore. We also  want to show the annotations in the VEO, the popover that lets you edit queries. 

This PR does that. Screen recording:


https://user-images.githubusercontent.com/18511823/113462506-13d5df80-93d6-11eb-9ab6-84982ff2c04d.mov

