### PR TITLE
fix: scroll the SelectorList to the selected bucket

### DIFF
--- a/src/timeMachine/components/SelectorList.tsx
+++ b/src/timeMachine/components/SelectorList.tsx
@@ -26,7 +26,12 @@ const SelectorList: SFC<Props> = props => {
   } = props
 
   return (
-    <List autoHideScrollbars={true} testID={testID} style={{flex: '1 0 0'}}>
+    <List
+      autoHideScrollbars={true}
+      testID={testID}
+      style={{flex: '1 0 0'}}
+      scrollToSelected={true}
+    >
       {items.map(item => {
         const selected = selectedItems.includes(item)
 


### PR DESCRIPTION
Closes #1094 

We need to scroll to the selected item in the selector list for the query builder so that when long list of buckets are present, it is obvious what bucket is currently selected.

Video in action:

https://user-images.githubusercontent.com/18511823/113468655-4f83a000-93fc-11eb-9d70-121547071a62.mov

