### PR TITLE
fix: show error message when value for a variable name does not exist in dashboard queryURL

### DIFF
--- a/src/shared/copy/notifications.ts
+++ b/src/shared/copy/notifications.ts
@@ -329,6 +329,15 @@ export const invalidTimeRangeValueInURLQuery = (): Notification => ({
   message: `Invalid URL query value supplied for lower or upper time range.`,
 })
 
+export const invalidVariableNameValuePairInURLQuery = (
+  name: string,
+  value: string
+): Notification => ({
+  ...defaultErrorNotification,
+  icon: IconFont.Cube,
+  message: `Invalid URL query value "${value}" supplied for variable name "${name}".`,
+})
+
 export const getVariablesFailed = (): Notification => ({
   ...defaultErrorNotification,
   message: 'Failed to fetch variables',

--- a/src/variables/actions/thunks.ts
+++ b/src/variables/actions/thunks.ts
@@ -485,6 +485,11 @@ export const selectValue = (variableID: string, selected: string) => async (
   if (!vals.includes(selected)) {
     // TODO: there is an issue that's causing non-state set values to
     // return with no results and not respect query params
+    dispatch(
+      notify(
+        copy.invalidVariableNameValuePairInURLQuery(variable.name, selected)
+      )
+    )
     return
   }
 


### PR DESCRIPTION
Closes #1093

Shows an error message when the value for the variable name, provided as part of the query URL in the dashboard, doesn't exist.

Video :

https://user-images.githubusercontent.com/18511823/113470865-77c7ca80-940d-11eb-9e67-0226d220eafc.mov
