### PR TITLE
chore(annotations): change edit label from summary to message

### DIFF
--- a/src/annotations/components/EditAnnotationForm.tsx
+++ b/src/annotations/components/EditAnnotationForm.tsx
@@ -102,7 +102,7 @@ export const EditAnnotationForm: FC<EditAnnotationProps> = ({
               />
             </Form.Element>
             <Form.Element
-              label="Summary"
+              label="Message"
               className="edit-annotation-form-label"
             >
               <Input


### PR DESCRIPTION
Closes #1123

Make the app useable again. Change label from `Summary` to `Message`

![Screen Shot 2021-04-05 at 4 03 08 PM](https://user-images.githubusercontent.com/146112/113636996-71616a80-9628-11eb-8d2a-04f0a1a12f0a.png)

