### PR TITLE
feat(managed-functions): Add styles to functions response

### DIFF
--- a/src/functions/components/FunctionResponse.tsx
+++ b/src/functions/components/FunctionResponse.tsx
@@ -26,7 +26,10 @@ const FunctionResponse: FC<Props> = ({
     if (response && response.data) {
       return (
         <>
-          <pre>{JSON.stringify(response.data)}</pre> <p></p>
+          <pre style={{maxWidth: '200px'}}>
+            {JSON.stringify(response.data, null, '\t')}
+          </pre>{' '}
+          <p></p>
         </>
       )
     }
@@ -54,6 +57,7 @@ const FunctionResponse: FC<Props> = ({
             status == 'ok' ? Gradients.TropicalTourist : Gradients.DangerLight
           }
           border={true}
+          style={{overflow: 'scroll'}}
         >
           <Panel.Header>
             <h5>{statusText}</h5>


### PR DESCRIPTION
When managed function responses were large, the panel would enlarge to contain them. 
I gave a max width to panel, and scrolling.


![Screen Shot 2021-04-06 at 12 54 17 AM](https://user-images.githubusercontent.com/10937678/113677695-b6aa8a00-9672-11eb-80f5-4169822dc1cb.jpg)

