### PR TITLE
feat: display time as formatted value in single stat graph

### DIFF
--- a/src/visualization/types/SingleStat/view.tsx
+++ b/src/visualization/types/SingleStat/view.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FC} from 'react'
+import React, {FC, useContext} from 'react'
 
 // Utils
 import LatestValueTransform from 'src/visualization/components/LatestValueTransform'
@@ -18,6 +18,9 @@ import {
 
 import './style.scss'
 import {isFlagEnabled} from '../../../shared/utils/featureFlag'
+import {DEFAULT_TIME_FORMAT} from '../../../shared/constants'
+import {getFormatter} from '../../utils/getFormatter'
+import {AppSettingContext} from '../../../shared/contexts/app'
 
 interface Props extends VisualizationProps {
   properties: SingleStatViewProperties
@@ -25,6 +28,7 @@ interface Props extends VisualizationProps {
 
 const SingleStat: FC<Props> = ({properties, result}) => {
   const {prefix, suffix, colors, decimalPlaces} = properties
+  const {timeZone} = useContext(AppSettingContext)
 
   if (isFlagEnabled('useGiraffeGraphs')) {
     const latestValues = getLatestValues(result.table)
@@ -74,11 +78,20 @@ const SingleStat: FC<Props> = ({properties, result}) => {
             cellType: 'single-stat',
           })
 
-          const formattedValue = formatStatValue(latestValue, {
-            decimalPlaces,
-            prefix,
-            suffix,
+          const timeFormatter = getFormatter('time', {
+            timeZone: timeZone === 'Local' ? undefined : timeZone,
+            timeFormat: DEFAULT_TIME_FORMAT,
           })
+
+          const formattedValue =
+            result.table.getColumnType('_value') == 'time'
+              ? timeFormatter(latestValue)
+              : formatStatValue(latestValue, {
+                decimalPlaces,
+                prefix,
+                suffix,
+              })
+
           return (
             <div
               className="single-stat"

--- a/src/visualization/types/SingleStat/view.tsx
+++ b/src/visualization/types/SingleStat/view.tsx
@@ -84,7 +84,7 @@ const SingleStat: FC<Props> = ({properties, result}) => {
           })
 
           const formattedValue =
-            result.table.getColumnType('_value') == 'time'
+            result.table.getColumnType('_value') === 'time'
               ? timeFormatter(latestValue)
               : formatStatValue(latestValue, {
                   decimalPlaces,

--- a/src/visualization/types/SingleStat/view.tsx
+++ b/src/visualization/types/SingleStat/view.tsx
@@ -87,10 +87,10 @@ const SingleStat: FC<Props> = ({properties, result}) => {
             result.table.getColumnType('_value') == 'time'
               ? timeFormatter(latestValue)
               : formatStatValue(latestValue, {
-                decimalPlaces,
-                prefix,
-                suffix,
-              })
+                  decimalPlaces,
+                  prefix,
+                  suffix,
+                })
 
           return (
             <div

--- a/src/visualization/types/SingleStat/view.tsx
+++ b/src/visualization/types/SingleStat/view.tsx
@@ -4,6 +4,7 @@ import React, {FC, useContext} from 'react'
 // Utils
 import LatestValueTransform from 'src/visualization/components/LatestValueTransform'
 import {generateThresholdsListHexs} from 'src/shared/constants/colorOperations'
+import {getFormatter} from 'src/visualization/utils/getFormatter'
 
 // Types
 import {SingleStatViewProperties} from 'src/types/dashboards'
@@ -18,9 +19,8 @@ import {
 
 import './style.scss'
 import {isFlagEnabled} from '../../../shared/utils/featureFlag'
-import {DEFAULT_TIME_FORMAT} from '../../../shared/constants'
-import {getFormatter} from '../../utils/getFormatter'
-import {AppSettingContext} from '../../../shared/contexts/app'
+import {AppSettingContext} from 'src/shared/contexts/app'
+import {DEFAULT_TIME_FORMAT} from 'src/shared/constants'
 
 interface Props extends VisualizationProps {
   properties: SingleStatViewProperties

--- a/src/visualization/types/SingleStatWithLine/view.tsx
+++ b/src/visualization/types/SingleStatWithLine/view.tsx
@@ -276,7 +276,7 @@ const SingleStatWithLine: FC<Props> = ({properties, result, timeRange}) => {
             })
 
             const formattedValue =
-              result.table.getColumnType('_value') == 'time'
+              result.table.getColumnType('_value') === 'time'
                 ? timeFormatter(latestValue)
                 : formatStatValue(latestValue, {
                     decimalPlaces: properties.decimalPlaces,

--- a/src/visualization/types/SingleStatWithLine/view.tsx
+++ b/src/visualization/types/SingleStatWithLine/view.tsx
@@ -37,7 +37,11 @@ import {generateThresholdsListHexs} from 'src/shared/constants/colorOperations'
 import {AppSettingContext} from 'src/shared/contexts/app'
 
 // Constants
-import {VIS_THEME, VIS_THEME_LIGHT} from 'src/shared/constants'
+import {
+  DEFAULT_TIME_FORMAT,
+  VIS_THEME,
+  VIS_THEME_LIGHT,
+} from 'src/shared/constants'
 import {DEFAULT_LINE_COLORS} from 'src/shared/constants/graphColorPalettes'
 import {INVALID_DATA_COPY} from 'src/visualization/constants'
 
@@ -266,11 +270,20 @@ const SingleStatWithLine: FC<Props> = ({properties, result, timeRange}) => {
               cellType: 'single-stat',
             })
 
-            const formattedValue = formatStatValue(latestValue, {
-              decimalPlaces: properties.decimalPlaces,
-              prefix: properties.prefix,
-              suffix: properties.suffix,
+            const timeFormatter = getFormatter('time', {
+              timeZone: timeZone === 'Local' ? undefined : timeZone,
+              timeFormat: DEFAULT_TIME_FORMAT,
             })
+
+            const formattedValue =
+              result.table.getColumnType('_value') == 'time'
+                ? timeFormatter(latestValue)
+                : formatStatValue(latestValue, {
+                    decimalPlaces: properties.decimalPlaces,
+                    prefix: properties.prefix,
+                    suffix: properties.suffix,
+                  })
+
             return (
               <div
                 className="single-stat"


### PR DESCRIPTION
Closes #https://github.com/influxdata/influxdb/issues/18837

Our current single stat graph and single stat with line would show a time value dataType as epoch time but the numerical value. This PR enables it to display a much more user-friendly string representation of time in the globally configured timeZone.

**The code has been updated in the UI to display time in the timeFormat, now how do we fix it in the giraffe, is the current question.** 

Screen shots:

<img width="1440" alt="Screen Shot 2021-04-06 at 1 51 01 PM" src="https://user-images.githubusercontent.com/18511823/113777001-61f12880-96df-11eb-9f8c-722d71b3902e.png">

respects the timezone selector: 

<img width="1440" alt="Screen Shot 2021-04-06 at 1 53 19 PM" src="https://user-images.githubusercontent.com/18511823/113777048-72a19e80-96df-11eb-8937-e4e4325be79b.png">

for singleStatWithLine:

<img width="1440" alt="Screen Shot 2021-04-06 at 1 58 09 PM" src="https://user-images.githubusercontent.com/18511823/113777649-36bb0900-96e0-11eb-8946-b6c09f7612eb.png">

