### PR TITLE
feat: add profiler toggle to data explorer

### DIFF
--- a/src/external/monaco.flux.server.ts
+++ b/src/external/monaco.flux.server.ts
@@ -20,7 +20,7 @@ import {
 import {registerCompletion} from 'src/external/monaco.flux.lsp'
 import {AppState, LocalStorage} from 'src/types'
 import {getAllVariables, asAssignment} from 'src/variables/selectors'
-import {buildVarsOption} from 'src/variables/utils/buildVarsOption'
+import {buildExtern} from 'src/variables/utils/buildVarsOption'
 import {runQuery} from 'src/shared/apis/query'
 import {getOrg} from 'src/organizations/selectors'
 import {fetchAllBuckets} from 'src/buckets/actions/thunks'
@@ -316,7 +316,7 @@ export class LSPServer {
       .map(v => asAssignment(v))
       .filter(v => !!v)
 
-    const file = buildVarsOption(variables)
+    const file = buildExtern(variables, false)
 
     const parts = uri.split('/')
     parts.pop()

--- a/src/flows/context/query.tsx
+++ b/src/flows/context/query.tsx
@@ -2,7 +2,7 @@ import React, {FC, useEffect} from 'react'
 import {useDispatch, useSelector} from 'react-redux'
 import {parse} from 'src/external/parser'
 import {runQuery} from 'src/shared/apis/query'
-import {buildVarsOption} from 'src/variables/utils/buildVarsOption'
+import {buildExtern} from 'src/variables/utils/buildVarsOption'
 import {asAssignment} from 'src/variables/selectors'
 import {getOrg} from 'src/organizations/selectors'
 import {getBuckets} from 'src/buckets/actions/thunks'
@@ -223,10 +223,11 @@ export const QueryProvider: FC = ({children}) => {
     // Some preamble for setting the stage
     const baseAST = parse(text)
     const usedVars = _getVars(baseAST, vars)
-    const optionAST = buildVarsOption(
+    const optionAST = buildExtern(
       Object.values(usedVars)
         .filter(v => !!v)
-        .map(v => asAssignment(v))
+        .map(v => asAssignment(v)),
+      false
     )
 
     // Make a version of the query with the variables loaded

--- a/src/shared/actions/predicatesThunks.ts
+++ b/src/shared/actions/predicatesThunks.ts
@@ -26,7 +26,7 @@ import {notify} from 'src/shared/actions/notifications'
 // selectors
 import {getOrg} from 'src/organizations/selectors'
 import {getVariables, asAssignment} from 'src/variables/selectors'
-import {buildVarsOption} from 'src/variables/utils/buildVarsOption'
+import {buildExtern} from 'src/variables/utils/buildVarsOption'
 import {getWindowVars} from 'src/variables/utils/getWindowVars'
 
 // constants
@@ -107,7 +107,7 @@ export const executePreviewQuery = (query: string) => async (
       .map(v => asAssignment(v))
       .filter(v => !!v)
     const windowVars = getWindowVars(query, variableAssignments)
-    const extern = buildVarsOption([...variableAssignments, ...windowVars])
+    const extern = buildExtern([...variableAssignments, ...windowVars], false)
     const result = await runQuery(orgID, query, extern).promise
 
     if (result.type === 'UNKNOWN_ERROR') {

--- a/src/shared/components/TimeSeries.tsx
+++ b/src/shared/components/TimeSeries.tsx
@@ -21,7 +21,7 @@ import {getVariables, asAssignment} from 'src/variables/selectors'
 import {getRangeVariable} from 'src/variables/utils/getTimeRangeVars'
 import {isInQuery} from 'src/variables/utils/hydrateVars'
 import {getWindowVars} from 'src/variables/utils/getWindowVars'
-import {buildVarsOption} from 'src/variables/utils/buildVarsOption'
+import {buildExtern} from 'src/variables/utils/buildVarsOption'
 import 'intersection-observer'
 import {getAll} from 'src/resources/selectors'
 import {getOrgIDFromBuckets} from 'src/timeMachine/actions/queries'
@@ -242,7 +242,7 @@ class TimeSeries extends Component<Props, State> {
           getOrgIDFromBuckets(text, buckets) || this.props.match.params.orgID
 
         const windowVars = getWindowVars(text, vars)
-        const extern = buildVarsOption([...vars, ...windowVars])
+        const extern = buildExtern([...vars, ...windowVars], false)
         event('runQuery', {context: 'TimeSeries'})
         if (isCurrentPageDashboard) {
           return onGetCachedResultsThunk(orgID, text)
@@ -261,7 +261,7 @@ class TimeSeries extends Component<Props, State> {
 
       let statuses = [] as StatusRow[][]
       if (check) {
-        const extern = buildVarsOption(vars)
+        const extern = buildExtern(vars, false)
         this.pendingCheckStatuses = runStatusesQuery(
           this.props.match.params.orgID,
           check.id,

--- a/src/shared/selectors/flags.ts
+++ b/src/shared/selectors/flags.ts
@@ -31,6 +31,7 @@ export const OSS_FLAGS = {
   'molly-first': false,
   'managed-functions': false,
   'simple-table': false,
+  'profile-query': false,
 }
 
 export const CLOUD_FLAGS = {
@@ -64,6 +65,7 @@ export const CLOUD_FLAGS = {
   'molly-first': false,
   'managed-functions': false,
   'simple-table': false,
+  'profile-query': false,
 }
 
 export const activeFlags = (state: AppState): FlagMap => {

--- a/src/timeMachine/actions/index.ts
+++ b/src/timeMachine/actions/index.ts
@@ -52,6 +52,8 @@ export type Action =
   | SetActiveQueryText
   | SetIsViewingRawDataAction
   | SetIsDisabledViewRawData
+  | SetIsProfilingQueryAction
+  | SetIsDisabledProfilingQuery
   | SetGeomAction
   | SetDecimalPlaces
   | SetBackgroundThresholdColoringAction
@@ -234,6 +236,30 @@ export const setIsDisabledViewRawData = (
 ): SetIsDisabledViewRawData => ({
   type: 'SET_IS_DISABLED_VIEW_RAW_DATA',
   payload: {isDisabledViewRawData},
+})
+
+interface SetIsProfilingQueryAction {
+  type: 'SET_IS_PROFILING_QUERY'
+  payload: {isProfilingQuery: boolean}
+}
+
+export const setIsProfilingQuery = (
+  isProfilingQuery: boolean
+): SetIsProfilingQueryAction => ({
+  type: 'SET_IS_PROFILING_QUERY',
+  payload: {isProfilingQuery},
+})
+
+interface SetIsDisabledProfilingQuery {
+  type: 'SET_IS_DISABLED_PROFILING_QUERY'
+  payload: {isDisabledProfilingQuery: boolean}
+}
+
+export const setIsDisabledProfilingQuery = (
+  isDisabledProfilingQuery: boolean
+): SetIsDisabledProfilingQuery => ({
+  type: 'SET_IS_DISABLED_PROFILING_QUERY',
+  payload: {isDisabledProfilingQuery},
 })
 
 interface SetGeomAction {

--- a/src/timeMachine/components/ProfileQueryToggle.tsx
+++ b/src/timeMachine/components/ProfileQueryToggle.tsx
@@ -1,0 +1,59 @@
+// Libraries
+import React, {PureComponent} from 'react'
+import {connect, ConnectedProps} from 'react-redux'
+
+// Components
+import {SlideToggle, InputLabel, ComponentSize} from '@influxdata/clockface'
+
+// Actions
+import {setIsProfilingQuery} from 'src/timeMachine/actions'
+
+// Utils
+import {getActiveTimeMachine} from 'src/timeMachine/selectors'
+
+// Types
+import {AppState} from 'src/types'
+
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
+
+class TimeMachineQueries extends PureComponent<Props> {
+  public render() {
+    const {isProfilingQuery, isDisabledProfilingQuery} = this.props
+
+    return (
+      <div className="profile-query-toggle">
+        <InputLabel>Profile Query</InputLabel>
+        <SlideToggle
+          active={isProfilingQuery}
+          onChange={this.handleToggleIsProfilingQuery}
+          size={ComponentSize.ExtraSmall}
+          testID="profile-query--toggle"
+          disabled={isDisabledProfilingQuery}
+        />
+      </div>
+    )
+  }
+
+  private handleToggleIsProfilingQuery = () => {
+    const {isProfilingQuery, onSetIsProfilingQuery} = this.props
+
+    onSetIsProfilingQuery(!isProfilingQuery)
+  }
+}
+
+const mstp = (state: AppState) => {
+  const {isProfilingQuery, isDisabledProfilingQuery} = getActiveTimeMachine(
+    state
+  )
+
+  return {isProfilingQuery, isDisabledProfilingQuery}
+}
+
+const mdtp = {
+  onSetIsProfilingQuery: setIsProfilingQuery,
+}
+
+const connector = connect(mstp, mdtp)
+
+export default connector(TimeMachineQueries)

--- a/src/timeMachine/components/Queries.scss
+++ b/src/timeMachine/components/Queries.scss
@@ -77,6 +77,17 @@
   }
 }
 
+.profile-query-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-right: $cf-marg-b;
+
+  .cf-slide-toggle {
+    margin-left: $cf-marg-a;
+  }
+}
+
 @media screen and (min-width: $cf-grid--breakpoint-sm) {
   .time-machine-queries--controls {
     flex-direction: row;

--- a/src/timeMachine/components/Queries.tsx
+++ b/src/timeMachine/components/Queries.tsx
@@ -12,6 +12,7 @@ import TimeRangeDropdown from 'src/shared/components/TimeRangeDropdown'
 import TimeMachineQueryBuilder from 'src/timeMachine/components/QueryBuilder'
 import SubmitQueryButton from 'src/timeMachine/components/SubmitQueryButton'
 import RawDataToggle from 'src/timeMachine/components/RawDataToggle'
+import ProfleQueryToggle from 'src/timeMachine/components/ProfileQueryToggle'
 import QueryTabs from 'src/timeMachine/components/QueryTabs'
 import EditorShortcutsToolTip from 'src/timeMachine/components/EditorShortcutsTooltip'
 import {
@@ -20,6 +21,7 @@ import {
   FlexDirection,
   JustifyContent,
 } from '@influxdata/clockface'
+import {FeatureFlag} from 'src/shared/utils/featureFlag'
 
 // Actions
 import {
@@ -63,6 +65,13 @@ class TimeMachineQueries extends PureComponent<Props> {
             className="time-machine-queries--buttons"
           >
             {activeQuery.editMode === 'advanced' && <EditorShortcutsToolTip />}
+            {!isInCheckOverlay && (
+              <>
+                <FeatureFlag name="profile-query">
+                  <ProfleQueryToggle />
+                </FeatureFlag>
+              </>
+            )}
             <RawDataToggle />
             {!isInCheckOverlay && (
               <>

--- a/src/timeMachine/components/TimeMachineCheckQuery.tsx
+++ b/src/timeMachine/components/TimeMachineCheckQuery.tsx
@@ -12,6 +12,8 @@ import {
   FlexDirection,
   JustifyContent,
 } from '@influxdata/clockface'
+import {FeatureFlag} from 'src/shared/utils/featureFlag'
+import ProfleQueryToggle from 'src/timeMachine/components/ProfileQueryToggle'
 
 const TimeMachineCheckQuery: FC = () => {
   return (
@@ -24,6 +26,9 @@ const TimeMachineCheckQuery: FC = () => {
             justifyContent={JustifyContent.FlexEnd}
             margin={ComponentSize.Small}
           >
+            <FeatureFlag name="profile-query">
+              <ProfleQueryToggle />
+            </FeatureFlag>
             <RawDataToggle />
             <SubmitCheckQueryButton />
           </FlexBox>

--- a/src/timeMachine/components/Vis.tsx
+++ b/src/timeMachine/components/Vis.tsx
@@ -29,6 +29,7 @@ import {getTimeRangeWithTimezone} from 'src/dashboards/selectors'
 import {
   setIsDisabledViewRawData,
   setIsViewingRawData,
+  setIsProfilingQuery,
 } from 'src/timeMachine/actions'
 
 // Types
@@ -36,6 +37,7 @@ import {RemoteDataState, AppState, ViewProperties} from 'src/types'
 
 // Selectors
 import {getActiveTimeRange} from 'src/timeMachine/selectors/index'
+import {setIsDisabledProfilingQuery} from '../actions/index'
 
 type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps
@@ -159,6 +161,7 @@ const mstp = (state: AppState) => {
   const activeTimeMachine = getActiveTimeMachine(state)
   const {
     isViewingRawData,
+    isProfilingQuery,
     view: {properties: viewProperties},
     queryResults: {status: loading, errorMessage, isInitialFetch, files},
   } = activeTimeMachine
@@ -179,6 +182,7 @@ const mstp = (state: AppState) => {
     files,
     viewProperties,
     isViewingRawData,
+    isProfilingQuery,
     giraffeResult,
     xColumn,
     yColumn,
@@ -193,6 +197,8 @@ const mstp = (state: AppState) => {
 const mdtp = {
   setViewRawData: setIsViewingRawData,
   setDisableRawData: setIsDisabledViewRawData,
+  setProfilingQuery: setIsProfilingQuery,
+  setDisableProfilingQuery: setIsDisabledProfilingQuery,
 }
 
 const connector = connect(mstp, mdtp)

--- a/src/timeMachine/reducers/index.ts
+++ b/src/timeMachine/reducers/index.ts
@@ -73,8 +73,10 @@ export interface TimeMachineState {
   autoRefresh: AutoRefresh
   draftQueries: DashboardDraftQuery[]
   isViewingRawData: boolean
+  isProfilingQuery: boolean
   isViewingVisOptions: boolean
   isDisabledViewRawData: boolean
+  isDisabledProfilingQuery: boolean
   activeTab: TimeMachineTab
   activeQueryIndex: number | null
   queryBuilder: QueryBuilderState
@@ -98,8 +100,10 @@ export const initialStateHelper = (): TimeMachineState => {
     view: createView(),
     draftQueries: [{...defaultViewQuery(), hidden: false}],
     isViewingRawData: false,
+    isProfilingQuery: false,
     isViewingVisOptions: false,
     isDisabledViewRawData: false,
+    isDisabledProfilingQuery: false,
     activeTab: 'queries',
     activeQueryIndex: 0,
     queryResults: initialQueryResultsState(),
@@ -328,6 +332,18 @@ export const timeMachineReducer = (
       const {isDisabledViewRawData} = action.payload
 
       return {...state, isDisabledViewRawData}
+    }
+
+    case 'SET_IS_PROFILING_QUERY': {
+      const {isProfilingQuery} = action.payload
+
+      return {...state, isProfilingQuery}
+    }
+
+    case 'SET_IS_DISABLED_PROFILING_QUERY': {
+      const {isDisabledProfilingQuery} = action.payload
+
+      return {...state, isDisabledProfilingQuery}
     }
 
     case 'SET_ACTIVE_TAB': {

--- a/src/types/ast.ts
+++ b/src/types/ast.ts
@@ -127,7 +127,7 @@ export interface VariableAssignment extends BaseNode {
 export interface MemberAssignment extends BaseNode {
   member: MemberExpression
   init: Expression
-  type: 'MemberExpression'
+  type: 'MemberAssignment'
 }
 
 export type Expression =

--- a/src/variables/utils/ValueFetcher.ts
+++ b/src/variables/utils/ValueFetcher.ts
@@ -5,7 +5,7 @@ import {fromFlux} from '@influxdata/giraffe'
 // Utils
 import {resolveSelectedKey} from 'src/variables/utils/resolveSelectedValue'
 import {formatVarsOption} from 'src/variables/utils/formatVarsOption'
-import {buildVarsOption} from 'src/variables/utils/buildVarsOption'
+import {buildExtern} from 'src/variables/utils/buildVarsOption'
 import {event} from 'src/cloud/utils/reporting'
 
 // Types
@@ -93,7 +93,7 @@ export class DefaultValueFetcher implements ValueFetcher {
       }
     }
 
-    const extern = buildVarsOption(variables)
+    const extern = buildExtern(variables, false)
     const request = runQuery(orgID, query, extern, abortController)
     event('runQuery', {context: 'variables'})
 

--- a/src/variables/utils/buildVarsOption.ts
+++ b/src/variables/utils/buildVarsOption.ts
@@ -5,12 +5,19 @@ import {OPTION_NAME} from 'src/variables/constants'
 import {File, Property} from 'src/types/ast'
 import {VariableAssignment} from 'src/types/ast'
 
-export const buildVarsOption = (variables: VariableAssignment[]): File => ({
-  type: 'File',
-  package: null,
-  imports: null,
-  body: [
-    {
+export const buildExtern = (
+  variables: VariableAssignment[],
+  isProfilingQuery: boolean
+): File => {
+  const extern = {
+    type: 'File',
+    package: null,
+    imports: null,
+    body: [],
+  } as File
+
+  if (variables && variables.length > 0) {
+    extern.body.push({
       type: 'OptionStatement',
       assignment: {
         type: 'VariableAssignment',
@@ -23,9 +30,52 @@ export const buildVarsOption = (variables: VariableAssignment[]): File => ({
           properties: variables.filter(v => !!v).map(assignmentToProperty),
         },
       },
-    },
-  ],
-})
+    })
+  }
+  if (isProfilingQuery) {
+    extern.imports = [
+      {
+        type: 'ImportDeclaration',
+        path: {
+          type: 'StringLiteral',
+          value: 'profiler',
+        },
+        as: null,
+      },
+    ]
+    extern.body.push({
+      assignment: {
+        member: {
+          object: {
+            name: 'profiler',
+            type: 'Identifier',
+          },
+          property: {
+            name: 'enabledProfilers',
+            type: 'Identifier',
+          },
+          type: 'MemberExpression',
+        },
+        init: {
+          type: 'ArrayExpression',
+          elements: [
+            {
+              type: 'StringLiteral',
+              value: 'query',
+            },
+            {
+              type: 'StringLiteral',
+              value: 'operator',
+            },
+          ],
+        },
+        type: 'MemberAssignment',
+      },
+      type: 'OptionStatement',
+    })
+  }
+  return extern
+}
 
 const assignmentToProperty = (variable: VariableAssignment): Property => {
   return {

--- a/src/variables/utils/getWindowVars.ts
+++ b/src/variables/utils/getWindowVars.ts
@@ -3,7 +3,7 @@ import {parse} from 'src/external/parser'
 
 // Utils
 import {getMinDurationFromAST} from 'src/shared/utils/getMinDurationFromAST'
-import {buildVarsOption} from 'src/variables/utils/buildVarsOption'
+import {buildExtern} from 'src/variables/utils/buildVarsOption'
 // Constants
 import {WINDOW_PERIOD} from 'src/variables/constants'
 
@@ -63,7 +63,7 @@ export const getWindowPeriod = (
     const substitutedAST: Package = {
       package: '',
       type: 'Package',
-      files: [ast, buildVarsOption(variables)],
+      files: [ast, buildExtern(variables, false)],
     }
 
     const queryDuration = getMinDurationFromAST(substitutedAST) // in ms

--- a/src/views/actions/thunks.ts
+++ b/src/views/actions/thunks.ts
@@ -133,7 +133,7 @@ export const getViewAndResultsForVEO = (
     }
     const {id: orgID} = getOrg(state)
     const pendingResults = queries.map(({text}) =>
-      getCachedResultsOrRunQuery(orgID, text, getAllVariables(state))
+      getCachedResultsOrRunQuery(orgID, text, getAllVariables(state), false)
     )
 
     // Wait for new queries to complete


### PR DESCRIPTION
#831 but for data explorer

This adds a profiler toggle option to the data explorer and cell editor overlay. Attempts to put it behind a `profile-query` feature flag, but i probably did that wrong.

BUG: for some reason, this disables the raw data toggle when editing a check, and i can't figure out why.

![Kapture 2021-04-06 at 11 31 50](https://user-images.githubusercontent.com/4805997/114096017-08216780-9873-11eb-9366-30948ee94d86.gif)
