### PR TITLE
fix: maps getting lat/lon from s2_cell_id or fields/tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,6 +207,7 @@
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0",
     "rome": "^2.1.22",
+    "s2-geometry": "^1.2.10",
     "seamless-immutable": "^7.1.3",
     "unraw": "2.0.0",
     "use-local-storage-state": "^9.0.2",

--- a/package.json
+++ b/package.json
@@ -146,8 +146,8 @@
   "dependencies": {
     "@influxdata/clockface": "^2.6.9",
     "@influxdata/flux": "^0.5.1",
-    "@influxdata/flux-lsp-browser": "^0.5.40",
-    "@influxdata/giraffe": "^2.7.4",
+    "@influxdata/flux-lsp-browser": "^0.5.39",
+    "@influxdata/giraffe": "^2.7.2",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "@influxdata/clockface": "^2.6.9",
     "@influxdata/flux": "^0.5.1",
     "@influxdata/flux-lsp-browser": "^0.5.39",
-    "@influxdata/giraffe": "^2.7.2",
+    "@influxdata/giraffe": "^2.7.4",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
   "dependencies": {
     "@influxdata/clockface": "^2.6.9",
     "@influxdata/flux": "^0.5.1",
-    "@influxdata/flux-lsp-browser": "^0.5.39",
+    "@influxdata/flux-lsp-browser": "^0.5.40",
     "@influxdata/giraffe": "^2.7.4",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.9.0",

--- a/src/shared/utils/vis.test.ts
+++ b/src/shared/utils/vis.test.ts
@@ -149,7 +149,7 @@ describe('getGeoCoordinates - retrieve latitude and longitude values for map geo
     const table = {
       getColumn: () => [0, 1, 2, '2323'],
     } as any
-    const geoCoordinates = getGeoCoordinates(table)
+    const geoCoordinates = getGeoCoordinates(table, 0)
 
     expect(geoCoordinates).toEqual(
       expect.objectContaining({

--- a/src/shared/utils/vis.ts
+++ b/src/shared/utils/vis.ts
@@ -323,25 +323,29 @@ enum CoordinateType {
 }
 
 const getCoordinateColumn = (table: Table): string => {
-  const column = table.getColumn('s2_cell_id')
-  if (column != null) {
-    return CoordinateType.S2
+  try {
+    const column = table.getColumn('s2_cell_id')
+    if (column != null) {
+      return CoordinateType.S2
+    }
+    const lat = table.getColumn('lat')
+    const lon = table.getColumn('lon')
+
+    if (lat !== null && lon !== null) {
+      return CoordinateType.Tags
+    }
+
+    const latCoordinate = getColumnValue(table, 'lat')
+    const lonCoordinate = getColumnValue(table, 'lon')
+
+    if (latCoordinate && lonCoordinate) {
+      return CoordinateType.Fields
+    }
+
+    return CoordinateType.None
+  } catch (e) {
+    throw new Error('lat_lon_not_found')
   }
-  const lat = table.getColumn('lat')
-  const lon = table.getColumn('lon')
-
-  if (lat !== null && lon !== null) {
-    return CoordinateType.Tags
-  }
-
-  const latCoordinate = getColumnValue(table, 'lat')
-  const lonCoordinate = getColumnValue(table, 'lon')
-
-  if (latCoordinate && lonCoordinate) {
-    return CoordinateType.Fields
-  }
-
-  return CoordinateType.None
 }
 
 const getS2CellID = (table: Table, index: number): string => {

--- a/src/shared/utils/vis.ts
+++ b/src/shared/utils/vis.ts
@@ -406,14 +406,14 @@ export const getGeoCoordinates = (
   const coordinateColumn = getCoordinateColumn(table)
 
   switch (coordinateColumn) {
-    case 's2_cell_id': 
+    case 's2_cell_id':
       return getCoordinateFromS2(table, index)
     case 'lat_lon_as_tags':
       const latColumn = table.getColumn('lat')
       const lonColumn = table.getColumn('lon')
       return {
         lat: parseCoordinates(latColumn[index]),
-        lon: parseCoordinates(lonColumn[index])
+        lon: parseCoordinates(lonColumn[index]),
       }
     case 'lat_lon_as_fields':
       const latCoordinate = getColumnValue(table, 'lat')
@@ -422,13 +422,12 @@ export const getGeoCoordinates = (
         lat: parseCoordinates(latCoordinate),
         lon: parseCoordinates(lonCoordinate),
       }
-    default: 
+    default:
       throw new Error('lat_lon_not_provided')
   }
 }
 
-const parseCoordinates = (coordinate) =>
-  parseInt(coordinate.toString(), 10)
+const parseCoordinates = coordinate => parseInt(coordinate.toString(), 10)
 
 export const getDetectCoordinatingFields = (table: Table) => {
   const coordinateColumn = getCoordinateColumn(table)

--- a/src/views/helpers/index.ts
+++ b/src/views/helpers/index.ts
@@ -387,8 +387,8 @@ const NEW_VIEW_CREATORS = {
       layers: [
         {
           type: 'pointMap',
-          colorDimension: {label: 'Duration'},
-          colorField: 'duration',
+          colorDimension: {label: 'Value'},
+          colorField: '_value',
           colors: [
             {type: 'min', hex: '#ff0000'},
             {value: 50, hex: '#343aeb'},

--- a/src/visualization/types/Map/view.tsx
+++ b/src/visualization/types/Map/view.tsx
@@ -84,7 +84,7 @@ const GeoPlot: FC<Props> = ({result, properties}) => {
     )
   } else if (coordinateError === MapErrorStates.InvalidCoordinates) {
     error =
-      'Map type is not supported with the data provided: Missing latitude/longitude values'
+      'Map type is not supported with the data provided: Missing latitude/longitude values (field values must be specified to lat or lon)'
 
     return (
       <div className="panel-resizer--error" data-testid="geoplot-error">

--- a/src/visualization/types/Map/view.tsx
+++ b/src/visualization/types/Map/view.tsx
@@ -91,34 +91,33 @@ const GeoPlot: FC<Props> = ({result, properties}) => {
         {error}
       </div>
     )
-  } else {
-    const tileServerConfiguration = {
-      tileServerUrl: getMapboxUrl(),
-      bingKey: '',
-    }
-
-    return (
-      <Plot
-        config={{
-          table: result.table,
-          showAxes: false,
-          layers: [
-            {
-              type: 'geo',
-              lat: geoCoordinates.lat,
-              lon: geoCoordinates.lon,
-              zoom,
-              allowPanAndZoom,
-              detectCoordinateFields: coordinatingFieldsFlag,
-              mapStyle,
-              layers,
-              tileServerConfiguration: tileServerConfiguration,
-            },
-          ],
-        }}
-      />
-    )
   }
+  const tileServerConfiguration = {
+    tileServerUrl: getMapboxUrl(),
+    bingKey: '',
+  }
+
+  return (
+    <Plot
+      config={{
+        table: result.table,
+        showAxes: false,
+        layers: [
+          {
+            type: 'geo',
+            lat: geoCoordinates.lat,
+            lon: geoCoordinates.lon,
+            zoom,
+            allowPanAndZoom,
+            detectCoordinateFields: coordinatingFieldsFlag,
+            mapStyle,
+            layers,
+            tileServerConfiguration: tileServerConfiguration,
+          },
+        ],
+      }}
+    />
+  )
 }
 
 export default GeoPlot

--- a/yarn.lock
+++ b/yarn.lock
@@ -7650,6 +7650,11 @@ loglevel@^1.6.6:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.7.tgz#b3e034233188c68b889f5b862415306f565e2c56"
   integrity sha512-cY2eLFrQSAfVPhCgH1s7JI73tMbg9YC3v3+ZHVW67sBS7UxWzNEk/ZBbSfLykBWHp33dqqtOv82gjhKEi81T/A==
 
+long@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-3.2.0.tgz#d821b7138ca1cb581c172990ef14db200b5c474b"
+  integrity sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s=
+
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
@@ -10563,6 +10568,13 @@ rxjs@^6.4.0:
   integrity sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==
   dependencies:
     tslib "^1.9.0"
+
+s2-geometry@^1.2.10:
+  version "1.2.10"
+  resolved "https://registry.yarnpkg.com/s2-geometry/-/s2-geometry-1.2.10.tgz#c6ff22f3eccafd0eea491b60b44c141b9887acab"
+  integrity sha1-xv8i8+zK/Q7qSRtgtEwUG5iHrKs=
+  dependencies:
+    long "^3.2.0"
 
 safe-buffer@5.1.1:
   version "5.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -797,10 +797,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/flux/-/flux-0.5.1.tgz#e39e7a7af9163fc9494422c8fed77f3ae1b68f56"
   integrity sha512-GHlkXBhSdJ2m56JzDkbnKPAqLj3/lexPooacu14AWTO4f2sDGLmzM7r0AxgdtU1M2x7EXNBwgGOI5EOAdN6mkw==
 
-"@influxdata/giraffe@^2.7.4":
-  version "2.7.4"
-  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.7.4.tgz#eb2c8cce51c2df0ec303ee575822195f1ecab2a1"
-  integrity sha512-pIEx+EGcG5imgpHjvUgkE0lZDSeTe1JgwWHHIx9X7taEsssQ47dFENP/4MFWWBoyyRDr67bnRMhmcKFJ8ZNRfA==
+"@influxdata/giraffe@^2.7.2":
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.7.2.tgz#649a661e342c70d7391e4b5130d023b4ae0e01cd"
+  integrity sha512-9Obeboh+Lus7DWrCp2anFOKIpZQ7HDEcMXYigo7KIzz+dtMjvdPZRwgP0psiK0F30x/jmNxWNUErFsu3BSUrFA==
   dependencies:
     merge-images "^2.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -797,10 +797,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/flux/-/flux-0.5.1.tgz#e39e7a7af9163fc9494422c8fed77f3ae1b68f56"
   integrity sha512-GHlkXBhSdJ2m56JzDkbnKPAqLj3/lexPooacu14AWTO4f2sDGLmzM7r0AxgdtU1M2x7EXNBwgGOI5EOAdN6mkw==
 
-"@influxdata/giraffe@^2.7.2":
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.7.2.tgz#649a661e342c70d7391e4b5130d023b4ae0e01cd"
-  integrity sha512-9Obeboh+Lus7DWrCp2anFOKIpZQ7HDEcMXYigo7KIzz+dtMjvdPZRwgP0psiK0F30x/jmNxWNUErFsu3BSUrFA==
+"@influxdata/giraffe@^2.7.4":
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.7.4.tgz#eb2c8cce51c2df0ec303ee575822195f1ecab2a1"
+  integrity sha512-pIEx+EGcG5imgpHjvUgkE0lZDSeTe1JgwWHHIx9X7taEsssQ47dFENP/4MFWWBoyyRDr67bnRMhmcKFJ8ZNRfA==
   dependencies:
     merge-images "^2.0.0"
 


### PR DESCRIPTION
Closes #997 Closes #giraffe/523

Updated the function to get Lat Lon such that it will not render giraffe plot if the correct data is not provided. Added a condition to get `s2_cell_id` or `lat`/`lon` as fields/tags and throw an error if none of those exist in the data provided