### PR TITLE
chore: update the expected me endpoint

### DIFF
--- a/src/client/swagger/unity.yml
+++ b/src/client/swagger/unity.yml
@@ -1170,16 +1170,20 @@ components:
         email:
           type: string
           description: the email associated with the user
-        account:
-          $ref: '#/components/schemas/Account'
-          description: User Account for the account
+        accountType:
+          type: string
+          description: type of the account
+          enum:
+            - free
+            - cancelled
+            - pay_as_you_go
         isRegionBeta:
           type: boolean
           description: whether the region associated with the account is a beta region
         isOperator:
           type: boolean
           description: whether the user is an operator
-      required: [id, account, email, isOperator, isRegionBeta]
+      required: [id, accountType, email, isOperator, isRegionBeta]
     Users:
       type: object
       properties:

--- a/src/shared/containers/GetOrganizations.tsx
+++ b/src/shared/containers/GetOrganizations.tsx
@@ -31,7 +31,7 @@ const canAccessCheckout = (me: Me): boolean => {
   if (!!me?.isRegionBeta) {
     return false
   }
-  return me?.account?.type !== 'pay_as_you_go'
+  return me?.accountType !== 'pay_as_you_go'
 }
 
 const GetOrganizations: FunctionComponent = () => {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -50,26 +50,7 @@ export const getMeQuartz = (): ReturnType<typeof getMe> => {
     email: 'asalem@influxdata.com',
     isRegionBeta: false,
     isOperator: true,
-    account: {
-      id: 'account123',
-      marketplace: null,
-      type: 'free',
-      organizations: null,
-      deletable: false,
-      balance: 0,
-      users: [],
-      billingContact: {
-        companyName: 'Influx',
-        email: 'asalem@influxdata.com',
-        firstName: 'Ariel',
-        lastName: 'Salem',
-        country: 'USA',
-        street1: '123 Main St',
-        city: 'New York',
-        subdivision: 'NY',
-        postalCode: 30000,
-      },
-    },
+    accountType: 'free',
   }
 
   return makeResponse(200, me)


### PR DESCRIPTION
This PR updates the new `/me` endpoint that's currently being built out. More specifically this PR replaces the entire `account` type that was being returned by the `/me` endpoint to a more narrow `accountType` that is the enum of possible account types associated with an account. The reason being that the UI has no need for all of the account information, just the type of account