### PR TITLE
fix: remove the buttons "import task from template"

### DIFF
--- a/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
@@ -33,7 +33,6 @@ import {Sort} from '@influxdata/clockface'
 import {SortTypes} from 'src/shared/utils/sort'
 import {DashboardSortKey} from 'src/shared/components/resource_sort_dropdown/generateSortItems'
 
-import {ALLOW_IMPORT_FROM_TEMPLATE} from 'src/shared/constants' // spoiler alert: you can't import from templates
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
 
 type ReduxProps = ConnectedProps<typeof connector>
@@ -89,7 +88,6 @@ class DashboardIndex extends PureComponent<Props, State> {
                   onSelectImport={this.summonImportOverlay}
                   onSelectTemplate={this.summonImportFromTemplateOverlay}
                   resourceName="Dashboard"
-                  canImportFromTemplate={ALLOW_IMPORT_FROM_TEMPLATE}
                   limitStatus={limitStatus}
                 />
               </Page.ControlBarRight>

--- a/src/dashboards/components/dashboard_index/DashboardsTableEmpty.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardsTableEmpty.tsx
@@ -11,7 +11,6 @@ import GetResources from 'src/resources/components/GetResources'
 // Actions
 import {createDashboard} from 'src/dashboards/actions/thunks'
 
-import {ALLOW_IMPORT_FROM_TEMPLATE} from 'src/shared/constants' // spoiler alert: you can't import from templates
 import {ResourceType} from 'src/types'
 
 interface ComponentProps {
@@ -48,7 +47,6 @@ const DashboardsTableEmpty: FC<ComponentProps> = ({
             onSelectImport={summonImportOverlay}
             onSelectTemplate={summonImportFromTemplateOverlay}
             resourceName="Dashboard"
-            canImportFromTemplate={ALLOW_IMPORT_FROM_TEMPLATE}
           />
         </EmptyState>
       }
@@ -68,7 +66,6 @@ const DashboardsTableEmpty: FC<ComponentProps> = ({
                 onSelectImport={summonImportOverlay}
                 onSelectTemplate={summonImportFromTemplateOverlay}
                 resourceName="Dashboard"
-                canImportFromTemplate={ALLOW_IMPORT_FROM_TEMPLATE}
               />
             </EmptyState>
           </DatalessEmptyState>

--- a/src/shared/components/AddResourceDropdown.tsx
+++ b/src/shared/components/AddResourceDropdown.tsx
@@ -30,7 +30,6 @@ interface OwnProps {
 }
 
 interface DefaultProps {
-  canImportFromTemplate: boolean
   status: ComponentStatus
   titleText: string
 }
@@ -41,7 +40,6 @@ type Props = OwnProps & DefaultProps & ReduxProps
 
 class AddResourceDropdown extends PureComponent<Props> {
   public static defaultProps: DefaultProps = {
-    canImportFromTemplate: false,
     status: ComponentStatus.Default,
     titleText: null,
   }

--- a/src/shared/components/AddResourceDropdown.tsx
+++ b/src/shared/components/AddResourceDropdown.tsx
@@ -105,20 +105,6 @@ class AddResourceDropdown extends PureComponent<Props> {
       </Dropdown.Item>,
     ]
 
-    if (!!this.props.canImportFromTemplate) {
-      items.push(
-        <Dropdown.Item
-          id={templateOption}
-          key={templateOption}
-          onClick={this.handleSelect}
-          value={templateOption}
-          testID="add-resource-dropdown--template"
-        >
-          {templateOption}
-        </Dropdown.Item>
-      )
-    }
-
     return items
   }
 

--- a/src/shared/components/AddResourceDropdown.tsx
+++ b/src/shared/components/AddResourceDropdown.tsx
@@ -82,7 +82,6 @@ class AddResourceDropdown extends PureComponent<Props> {
   private get optionItems(): JSX.Element[] {
     const importOption = this.importOption
     const newOption = this.newOption
-    const templateOption = this.templateOption
 
     const items = [
       <Dropdown.Item

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -36,8 +36,6 @@ export const HTTP_UNAUTHORIZED = 401
 export const HTTP_FORBIDDEN = 403
 export const HTTP_NOT_FOUND = 404
 
-export const ALLOW_IMPORT_FROM_TEMPLATE = false
-
 export const AUTOREFRESH_DEFAULT_INTERVAL = 0 // in milliseconds
 export const AUTOREFRESH_DEFAULT_STATUS = AutoRefreshStatus.Paused
 export const AUTOREFRESH_DEFAULT = {

--- a/src/tasks/components/EmptyTasksList.tsx
+++ b/src/tasks/components/EmptyTasksList.tsx
@@ -41,7 +41,6 @@ export default class EmptyTasksLists extends PureComponent<Props> {
                 Looks like you don't have any <b>Tasks</b>, why not create one?
               </EmptyState.Text>
               <AddResourceDropdown
-                canImportFromTemplate
                 onSelectNew={onCreate}
                 onSelectImport={onImportTask}
                 resourceName="Task"
@@ -60,7 +59,6 @@ export default class EmptyTasksLists extends PureComponent<Props> {
                     one?
                   </EmptyState.Text>
                   <AddResourceDropdown
-                    canImportFromTemplate
                     onSelectNew={onCreate}
                     onSelectImport={onImportTask}
                     resourceName="Task"

--- a/src/tasks/components/TasksHeader.tsx
+++ b/src/tasks/components/TasksHeader.tsx
@@ -91,7 +91,6 @@ export default class TasksHeader extends PureComponent<Props> {
               />
             </FlexBox>
             <AddResourceDropdown
-              canImportFromTemplate
               onSelectNew={onCreateTask}
               onSelectImport={onImportTask}
               resourceName="Task"


### PR DESCRIPTION
Closes #1164

<!-- Describe your proposed changes here. -->
I forgot to remove the buttons for import task from template while removing the underlying code