### PR TITLE
fix: gauge needle at zero when value is zero

### DIFF
--- a/src/visualization/types/Gauge/Gauge.tsx
+++ b/src/visualization/types/Gauge/Gauge.tsx
@@ -363,7 +363,7 @@ class Gauge extends Component<Props> {
 
     let needleRotation: number
 
-    if (gaugePosition <= minValue) {
+    if (gaugePosition < minValue) {
       needleRotation = 0 - overflowDelta
     } else if (gaugePosition >= maxValue) {
       needleRotation = 1 + overflowDelta


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/1177

The UI implementation had a minor bug that led to the needle fall below zero when the gauge value was 0. This PR fixes that.

Screenshot Before vs After

<div>
<img width="282" alt="Screen Shot 2021-04-12 at 8 43 37 AM" src="https://user-images.githubusercontent.com/18511823/114423085-b0814580-9b6b-11eb-8503-db6ca033727e.png">
<img width="282" alt="Screen Shot 2021-04-12 at 8 43 37 AM" src="https://user-images.githubusercontent.com/18511823/114423375-fb9b5880-9b6b-11eb-9ebf-4fbb451c8705.png">
</div>


Of gaugePosition being below minValue:

![image](https://user-images.githubusercontent.com/18511823/114586944-06bcba00-9c3a-11eb-8879-85ae7ecd3494.png)
