### PR TITLE
chore: remove unused acorn package

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "@types/webpack-env": "^1.15.2",
     "@typescript-eslint/eslint-plugin": "^2.6.0",
     "@typescript-eslint/parser": "^2.6.0",
-    "acorn": "^6.0.6",
     "ajv": "^6.7.0",
     "autoprefixer": "^6.3.1",
     "babel-loader": "^8.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1718,11 +1718,6 @@ acorn@^6.0.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.2.1.tgz#3ed8422d6dec09e6121cc7a843ca86a330a86b51"
   integrity sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==
 
-acorn@^6.0.6:
-  version "6.0.6"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.0.6.tgz#cd75181670d5b99bdb1b1c993941d3a239ab1f56"
-  integrity sha512-5M3G/A4uBSMIlfJ+h9W125vJvPFH/zirISsW5qfxF5YzEvXJCtolLoQvM5yZft0DvMcUrPGKPOlgEu55I6iUtA==
-
 acorn@^6.0.7:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.3.0.tgz#0087509119ffa4fc0a0041d1e93a417e68cb856e"


### PR DESCRIPTION
Issue https://github.com/influxdata/idpe/issues/10138

Removes `acorn` from dev dependency list. It's not used anywhere and it's out of date with a vulnerability: https://github.com/influxdata/ui/pull/1140
