### PR TITLE
fix: code samples for client libraries in OSS show correctly

### DIFF
--- a/src/shared/components/views/MarkdownRenderer.tsx
+++ b/src/shared/components/views/MarkdownRenderer.tsx
@@ -70,7 +70,7 @@ export const MarkdownRenderer: FC<Props> = ({
     <ReactMarkdown
       source={text}
       className={className}
-      renderers={{...cloudRenderers}}
+      renderers={cloudRenderers}
       escapeHtml={false}
     />
   )

--- a/src/shared/components/views/MarkdownRenderer.tsx
+++ b/src/shared/components/views/MarkdownRenderer.tsx
@@ -67,6 +67,11 @@ export const MarkdownRenderer: FC<Props> = ({
 
   // load images locally to your heart's content. caveat emptor
   return (
-    <ReactMarkdown source={text} className={className} escapeHtml={false} />
+    <ReactMarkdown
+      source={text}
+      className={className}
+      renderers={{...cloudRenderers}}
+      escapeHtml={false}
+    />
   )
 }


### PR DESCRIPTION
Closes #1194

Updated the `ReactMarkdown` component to pass the prop `renderers` along in the not-cloud case so that the placeholders in the code previews get interpolated with the actual values.