### PR TITLE
fix: bring tables alive in notebooks

### DIFF
--- a/src/visualization/types/Table/properties.ts
+++ b/src/visualization/types/Table/properties.ts
@@ -30,7 +30,11 @@ export default {
       },
     },
   ],
-
+  tableOptions: {
+    verticalTimeAxis: true,
+    sortBy: null,
+    fixFirstColumn: false,
+  },
   colors: DEFAULT_THRESHOLDS_TABLE_COLORS as Color[],
   fieldOptions: [],
   decimalPlaces: {


### PR DESCRIPTION
Closes #1190

the default table view property was missing a required option that was handled by the default redux populator over in data explorer. no clue why typescript didn't catch this or why it hasn't come up since the visualization refactor, but this fixes it none the less