### PR TITLE
chore: update giraffe to v2.7.6

### DIFF
--- a/cypress/e2e/cloud/annotations.test.ts
+++ b/cypress/e2e/cloud/annotations.test.ts
@@ -138,7 +138,7 @@ describe('The Annotations UI functionality', () => {
     cy.getByTestID('giraffe-annotation-tooltip').contains('im a hippopotamus')
   })
 
-  it.only('can delete an annotation by clicking on the annotation line', () => {
+  it('can delete an annotation by clicking on the annotation line', () => {
     // add the annotation
     cy.getByTestID('cell blah').within(() => {
       cy.getByTestID('giraffe-inner-plot').click()

--- a/cypress/e2e/cloud/annotations.test.ts
+++ b/cypress/e2e/cloud/annotations.test.ts
@@ -155,7 +155,9 @@ describe('The Annotations UI functionality', () => {
     // should have the annotation created , lets click it to show the modal.
     cy.getByTestID('cell blah').within(() => {
       // we have 2 line layers by the same id, we only want to click on the first
-      cy.get('line').first().click()
+      cy.get('line')
+        .first()
+        .click()
     })
 
     cy.getByTestID('delete-annotation-button').click()
@@ -183,7 +185,9 @@ describe('The Annotations UI functionality', () => {
     // should have the annotation created , lets click it to show the modal.
     cy.getByTestID('cell blah').within(() => {
       // we have 2 line layers by the same id, we only want to click on the first
-      cy.get('line').first().click()
+      cy.get('line')
+        .first()
+        .click()
     })
 
     cy.getByTestID('edit-annotation-summary-inputfield')
@@ -218,7 +222,9 @@ describe('The Annotations UI functionality', () => {
     // should have the annotation created , lets click it to show the modal.
     cy.getByTestID('cell blah').within(() => {
       // we have 2 line layers by the same id, we only want to click on the first
-      cy.get('line').first().click()
+      cy.get('line')
+        .first()
+        .click()
     })
 
     cy.getByTestID('edit-annotation-summary-inputfield')

--- a/cypress/e2e/cloud/annotations.test.ts
+++ b/cypress/e2e/cloud/annotations.test.ts
@@ -138,7 +138,7 @@ describe('The Annotations UI functionality', () => {
     cy.getByTestID('giraffe-annotation-tooltip').contains('im a hippopotamus')
   })
 
-  it('can delete an annotation by clicking on the annotation line', () => {
+  it.only('can delete an annotation by clicking on the annotation line', () => {
     // add the annotation
     cy.getByTestID('cell blah').within(() => {
       cy.getByTestID('giraffe-inner-plot').click()
@@ -154,7 +154,8 @@ describe('The Annotations UI functionality', () => {
 
     // should have the annotation created , lets click it to show the modal.
     cy.getByTestID('cell blah').within(() => {
-      cy.get('line').click()
+      // we have 2 line layers by the same id, we only want to click on the first
+      cy.get('line').first().click()
     })
 
     cy.getByTestID('delete-annotation-button').click()
@@ -181,7 +182,8 @@ describe('The Annotations UI functionality', () => {
 
     // should have the annotation created , lets click it to show the modal.
     cy.getByTestID('cell blah').within(() => {
-      cy.get('line').click()
+      // we have 2 line layers by the same id, we only want to click on the first
+      cy.get('line').first().click()
     })
 
     cy.getByTestID('edit-annotation-summary-inputfield')
@@ -215,7 +217,8 @@ describe('The Annotations UI functionality', () => {
 
     // should have the annotation created , lets click it to show the modal.
     cy.getByTestID('cell blah').within(() => {
-      cy.get('line').click()
+      // we have 2 line layers by the same id, we only want to click on the first
+      cy.get('line').first().click()
     })
 
     cy.getByTestID('edit-annotation-summary-inputfield')

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "@influxdata/clockface": "^2.6.9",
     "@influxdata/flux": "^0.5.1",
     "@influxdata/flux-lsp-browser": "^0.5.40",
-    "@influxdata/giraffe": "^2.7.5",
+    "@influxdata/giraffe": "^2.7.6",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -797,10 +797,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/flux/-/flux-0.5.1.tgz#e39e7a7af9163fc9494422c8fed77f3ae1b68f56"
   integrity sha512-GHlkXBhSdJ2m56JzDkbnKPAqLj3/lexPooacu14AWTO4f2sDGLmzM7r0AxgdtU1M2x7EXNBwgGOI5EOAdN6mkw==
 
-"@influxdata/giraffe@^2.7.5":
-  version "2.7.5"
-  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.7.5.tgz#66203dc30a05a92d84b1685c05beb7544b26fbc8"
-  integrity sha512-PgyyUCpDxRIBBWqdhQcyiAVT+MUkXQrkf0JYkws6ixxbEJjqb/VHIZ04K3XIg1x6IsCVHJcbwdPAJBVdEqBgxQ==
+"@influxdata/giraffe@^2.7.6":
+  version "2.7.6"
+  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.7.6.tgz#3d1b94eed7d2183d7a5affda853de2696399379f"
+  integrity sha512-OJdwKC+6SyOlfDeVJ4yUSkGSl+mGHVdG/oPIMpWH7RpvlLKgLD8AlqA1WQXB4saDIZ3qeqls/t2Pr1C6m6HASw==
   dependencies:
     merge-images "^2.0.0"
 


### PR DESCRIPTION
Closes #1206

Brings in the change from the Giraffe [v2.7.6](https://github.com/influxdata/giraffe/releases/tag/v2.7.6) release to make annotations less intrusive on the plot with a smaller caret and a dashed line. 