### PR TITLE
feat: send identiers to userpilot onboarding tool

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import {
   OverlayController,
 } from 'src/overlays/components/OverlayController'
 import PageSpinner from 'src/perf/components/PageSpinner'
+import EngagementLink from './cloud/components/onboarding/EngagementLink'
 const SetOrg = lazy(() => import('src/shared/containers/SetOrg'))
 const CreateOrgOverlay = lazy(() =>
   import('src/organizations/components/CreateOrgOverlay')
@@ -41,6 +42,7 @@ const App: FC = () => {
       <OverlayProviderComp>
         <OverlayController />
       </OverlayProviderComp>
+      <EngagementLink />
       <TreeNav />
       <Suspense fallback={<PageSpinner />}>
         <Switch>

--- a/src/cloud/components/onboarding/EngagementLink.tsx
+++ b/src/cloud/components/onboarding/EngagementLink.tsx
@@ -15,16 +15,19 @@ type Props = ReduxProps
 
 const EngagementLink: FC<Props> = ({org, me}) => {
   const pathname = useLocation().pathname
+  const userpilot = get(window, 'userpilot')
 
   useEffect(() => {
-    sendToUserPilot()
+    if (userpilot) {
+      sendToUserPilot()
+      userpilot.reload()
+    }
   }, [pathname, org, me])
 
   const sendToUserPilot = (): void => {
-    const userpilot = get(window, 'userpilot')
     const host = window.location.hostname.split('.')
 
-    if (userpilot && org && me) {
+    if (org && me) {
       userpilot.identify(me.name, {
         email: me.name, // User Email address
         orgID: org.id, // Organization ID

--- a/src/cloud/components/onboarding/EngagementLink.tsx
+++ b/src/cloud/components/onboarding/EngagementLink.tsx
@@ -14,17 +14,17 @@ type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps
 
 const EngagementLink: FC<Props> = ({org, me}) => {
-  if (!org || !me) {
-    return null
-  }
+  const pathname = useLocation().pathname
 
-  const host = window.location.hostname.split('.')
-  const pathname = useLocation()
+  useEffect(() => {
+    sendToUserPilot()
+  }, [pathname, org, me])
 
   const sendToUserPilot = (): void => {
-    const userpilot = get(window, 'userpilot', null)
+    const userpilot = get(window, 'userpilot')
+    const host = window.location.hostname.split('.')
 
-    if (userpilot) {
+    if (userpilot && org && me) {
       userpilot.identify(me.name, {
         email: me.name, // User Email address
         orgID: org.id, // Organization ID
@@ -33,10 +33,6 @@ const EngagementLink: FC<Props> = ({org, me}) => {
       })
     }
   }
-
-  useEffect(() => {
-    sendToUserPilot()
-  }, [pathname, org, me])
 
   return null
 }

--- a/src/cloud/components/onboarding/EngagementLink.tsx
+++ b/src/cloud/components/onboarding/EngagementLink.tsx
@@ -1,8 +1,7 @@
 // Libraries
 import {FC, useEffect} from 'react'
 import {useLocation} from 'react-router-dom'
-import {connect, ConnectedProps} from 'react-redux'
-import {get} from 'lodash'
+import {useSelector} from 'react-redux'
 
 // Utils
 import {getOrg} from 'src/organizations/selectors'
@@ -10,12 +9,11 @@ import {getOrg} from 'src/organizations/selectors'
 // Types
 import {AppState} from 'src/types'
 
-type ReduxProps = ConnectedProps<typeof connector>
-type Props = ReduxProps
-
-const EngagementLink: FC<Props> = ({org, me}) => {
+const EngagementLink: FC = () => {
   const pathname = useLocation().pathname
-  const userpilot = get(window, 'userpilot')
+  const userpilot = window['userpilot']
+  const org = useSelector(getOrg)
+  const me = useSelector((state: AppState) => state.me)
 
   useEffect(() => {
     if (userpilot) {
@@ -25,7 +23,7 @@ const EngagementLink: FC<Props> = ({org, me}) => {
   }, [pathname, org, me])
 
   const sendToUserPilot = (): void => {
-    const host = window.location.hostname.split('.')
+    const host = window?.location?.hostname.split('.')
 
     if (org && me) {
       userpilot.identify(me.name, {
@@ -40,11 +38,4 @@ const EngagementLink: FC<Props> = ({org, me}) => {
   return null
 }
 
-const mstp = (state: AppState) => {
-  const org = getOrg(state)
-  const me = state.me
-  return {org, me}
-}
-
-const connector = connect(mstp)
-export default connector(EngagementLink)
+export default EngagementLink

--- a/src/cloud/components/onboarding/EngagementLink.tsx
+++ b/src/cloud/components/onboarding/EngagementLink.tsx
@@ -20,20 +20,17 @@ const EngagementLink: FC<Props> = ({org, me}) => {
 
   const host = window.location.hostname.split('.')
   const pathname = useLocation()
-  
+
   const sendToUserPilot = (): void => {
     const userpilot = get(window, 'userpilot', null)
 
     if (userpilot) {
-      userpilot.identify( 
-        me.name,
-        {
-          email: me.name, // User Email address
-          orgID: org.id, // Organization ID
-          region: host[0], // Cloud provider region
-          provider: host[1], // Cloud provider
-        }
-      )
+      userpilot.identify(me.name, {
+        email: me.name, // User Email address
+        orgID: org.id, // Organization ID
+        region: host[0], // Cloud provider region
+        provider: host[1], // Cloud provider
+      })
     }
   }
 

--- a/src/cloud/components/onboarding/EngagementLink.tsx
+++ b/src/cloud/components/onboarding/EngagementLink.tsx
@@ -1,0 +1,54 @@
+// Libraries
+import {FC, useEffect} from 'react'
+import {useLocation} from 'react-router-dom'
+import {connect, ConnectedProps} from 'react-redux'
+import {get} from 'lodash'
+
+// Utils
+import {getOrg} from 'src/organizations/selectors'
+
+// Types
+import {AppState} from 'src/types'
+
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
+
+const EngagementLink: FC<Props> = ({org, me}) => {
+  if (!org || !me) {
+    return null
+  }
+
+  const host = window.location.hostname.split('.')
+  const pathname = useLocation()
+  
+  const sendToUserPilot = (): void => {
+    const userpilot = get(window, 'userpilot', null)
+
+    if (userpilot) {
+      userpilot.identify( 
+        me.name,
+        {
+          email: me.name, // User Email address
+          orgID: org.id, // Organization ID
+          region: host[0], // Cloud provider region
+          provider: host[1], // Cloud provider
+        }
+      )
+    }
+  }
+
+  useEffect(() => {
+    sendToUserPilot()
+  }, [pathname, org, me])
+
+  return null
+}
+
+const mstp = (state: AppState) => {
+  const org = getOrg(state)
+  const me = state.me
+  return {org, me}
+}
+
+const connector = connect(mstp)
+export default connector(EngagementLink)


### PR DESCRIPTION
This PR adds a component to App.tsx which sends user/org identifiers to Userpilot. This first stage only sends email, orgID, region, and provider to create records and dynamically build URLs in Userpilot. Future changes will send engagement state and other useful data for segmentation and displaying the correct onboarding experience.