### PR TITLE
chore: add events for edit and delete; remove double-fired event

### DIFF
--- a/src/annotations/components/EditAnnotationForm.tsx
+++ b/src/annotations/components/EditAnnotationForm.tsx
@@ -21,6 +21,9 @@ import {deleteAnnotations} from 'src/annotations/actions/thunks'
 // Types
 import {Annotation, EditAnnotation} from 'src/types'
 
+// Utils
+import {event} from 'src/cloud/utils/reporting'
+
 // Style
 import 'src/annotations/components/editAnnotationForm.scss'
 
@@ -71,8 +74,10 @@ export const EditAnnotationForm: FC<EditAnnotationProps> = ({
     try {
       dispatch(deleteAnnotations(editedAnnotation))
       dispatch(notify(deleteAnnotationSuccess(editedAnnotation.message)))
+      event('xyplot.annotations.delete_annotation.success')
       handleClose()
     } catch (err) {
+      event('xyplot.annotations.delete_annotation.failure')
       dispatch(notify(deleteAnnotationFailed(err)))
     }
   }

--- a/src/annotations/components/EditAnnotationOverlay.tsx
+++ b/src/annotations/components/EditAnnotationOverlay.tsx
@@ -25,6 +25,9 @@ import {
 
 import {notify} from 'src/shared/actions/notifications'
 
+// Utils
+import {event} from 'src/cloud/utils/reporting'
+
 export const EditAnnotationOverlay: FC = () => {
   const {onClose} = useContext(OverlayContext)
   const dispatch = useDispatch()
@@ -34,8 +37,10 @@ export const EditAnnotationOverlay: FC = () => {
     try {
       dispatch(editAnnotation(editedAnnotation))
       dispatch(notify(editAnnotationSuccess()))
+      event('xyplot.annotations.edit_annotation.success')
       onClose()
     } catch (err) {
+      event('xyplot.annotations.edit_annotation.failure')
       dispatch(notify(editAnnotationFailed(err)))
     }
   }

--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -183,7 +183,6 @@ const XYPlot: FC<Props> = ({
   const makeSingleClickHandler = () => {
     const createAnnotation = userModifiedAnnotation => {
       const {message, startTime} = userModifiedAnnotation
-      event('xyplot.annotations.create_annotation.create')
       try {
         dispatch(
           writeThenFetchAndSetAnnotations([


### PR DESCRIPTION
Closes #1211


Adds the following four events:

```
xyplot.annotations.edit_annotation.success
xyplot.annotations.edit_annotation.failure

xyplot.annotations.delete_annotation.success
xyplot.annotations.delete_annotation.failure
```

Removes extra create event that was called twice.