### PR TITLE
feat(unity): add cancel route to swagger

### DIFF
--- a/src/client/swagger/unity.yml
+++ b/src/client/swagger/unity.yml
@@ -756,7 +756,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-
+  '/cancel':
+    post:
+      operationId: PostCancel
+      tags:
+        - Account
+      responses:
+        '204':
+          description: Account cancelled
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 components:
   parameters:
     TraceSpan:


### PR DESCRIPTION
Adds a cancellation route to the swagger for cancelling an account.
