### PR TITLE
fix: remove unused "Legend" to match updated swagger

### DIFF
--- a/cypress/fixtures/view.json
+++ b/cypress/fixtures/view.json
@@ -12,9 +12,7 @@
         "editMode": "builder",
         "name": "",
         "builderConfig": {
-          "buckets": [
-            "defbuck"
-          ],
+          "buckets": ["defbuck"],
           "tags": [
             {
               "key": "",
@@ -31,10 +29,7 @@
     ],
     "axes": {
       "x": {
-        "bounds": [
-          "",
-          ""
-        ],
+        "bounds": ["", ""],
         "label": "",
         "prefix": "",
         "suffix": "",
@@ -42,10 +37,7 @@
         "scale": "linear"
       },
       "y": {
-        "bounds": [
-          "",
-          ""
-        ],
+        "bounds": ["", ""],
         "label": "",
         "prefix": "",
         "suffix": "",
@@ -54,7 +46,6 @@
       }
     },
     "type": "xy",
-    "legend": {},
     "geom": "line",
     "colors": [
       {

--- a/mocks/dummyData.ts
+++ b/mocks/dummyData.ts
@@ -968,7 +968,6 @@ export const viewProperties: ViewProperties = {
     },
   },
   type: 'line-plus-single-stat',
-  legend: {},
   colors: [
     {
       id: 'base',

--- a/src/cloud/constants/websiteMonitoringTemplate.ts
+++ b/src/cloud/constants/websiteMonitoringTemplate.ts
@@ -353,7 +353,6 @@ export default {
               },
             },
             type: 'line-plus-single-stat',
-            legend: {},
             colors: [
               {
                 id: 'base',
@@ -910,7 +909,6 @@ export default {
               },
             },
             type: 'line-plus-single-stat',
-            legend: {},
             colors: [
               {
                 id: 'base',

--- a/src/flows/pipes/TestFlux/index.ts
+++ b/src/flows/pipes/TestFlux/index.ts
@@ -14,7 +14,6 @@ export default register => {
       properties: {
         type: 'xy',
         position: 'overlaid',
-        legend: {},
         note: '',
         showNoteWhenEmpty: false,
         axes: {

--- a/src/mockAppState.tsx
+++ b/src/mockAppState.tsx
@@ -198,7 +198,6 @@ export const mockAppState = {
                 value: 0,
               },
             ],
-            legend: {},
             note: '',
             showNoteWhenEmpty: false,
             axes: {

--- a/src/shared/utils/mocks/resourceToTemplate.ts
+++ b/src/shared/utils/mocks/resourceToTemplate.ts
@@ -75,7 +75,6 @@ export const myView: View = {
       },
     },
     type: 'xy',
-    legend: {},
     geom: 'line',
     colors: [],
     note: '',

--- a/src/shared/utils/resourceToTemplate.test.ts
+++ b/src/shared/utils/resourceToTemplate.test.ts
@@ -391,7 +391,6 @@ describe('resourceToTemplate', () => {
                     },
                   },
                   type: 'xy',
-                  legend: {},
                   geom: 'line',
                   colors: [],
                   note: '',

--- a/src/types/dashboards.ts
+++ b/src/types/dashboards.ts
@@ -90,7 +90,6 @@ export {
   CheckViewProperties,
   GeoViewProperties,
   RenamableField,
-  Legend,
   DecimalPlaces,
   Axes,
   Axis,

--- a/src/usage/GraphTypeSwitcher.tsx
+++ b/src/usage/GraphTypeSwitcher.tsx
@@ -32,7 +32,6 @@ const GENERIC_PROPERTY_DEFAULTS = {
   suffix: '',
   tickPrefix: '',
   tickSuffix: '',
-  legend: undefined,
 }
 
 const GraphTypeSwitcher: FC<OwnProps> = ({graphInfo, csv}) => {
@@ -55,10 +54,6 @@ const GraphTypeSwitcher: FC<OwnProps> = ({graphInfo, csv}) => {
     axes: {
       x: {},
       y: {},
-    },
-    legend: {
-      type: 'static',
-      orientation: 'top',
     },
     position: 'overlaid',
     geom: 'line',

--- a/src/views/helpers/index.ts
+++ b/src/views/helpers/index.ts
@@ -94,7 +94,6 @@ export function defaultLineViewProperties() {
     ...legendProps,
     queries: [defaultViewQuery()],
     colors: DEFAULT_LINE_COLORS as Color[],
-    legend: {},
     note: '',
     showNoteWhenEmpty: false,
     ...tickProps,
@@ -125,7 +124,6 @@ export function defaultBandViewProperties() {
     ...legendProps,
     queries: [defaultViewQuery()],
     colors: DEFAULT_LINE_COLORS as Color[],
-    legend: {},
     note: '',
     showNoteWhenEmpty: false,
     ...tickProps,
@@ -259,7 +257,6 @@ const NEW_VIEW_CREATORS = {
       ...defaultSingleStatViewProperties(),
       type: 'single-stat',
       shape: 'chronograf-v2',
-      legend: {},
     },
   }),
   gauge: (): NewView<GaugeViewProperties> => ({
@@ -268,7 +265,6 @@ const NEW_VIEW_CREATORS = {
       ...defaultGaugeViewProperties(),
       type: 'gauge',
       shape: 'chronograf-v2',
-      legend: {},
     },
   }),
   'line-plus-single-stat': (): NewView<LinePlusSingleStatProperties> => ({

--- a/src/visualization/types/Band/properties.ts
+++ b/src/visualization/types/Band/properties.ts
@@ -38,7 +38,6 @@ export default {
     },
   ],
   colors: DEFAULT_LINE_COLORS as Color[],
-  legend: {},
   note: '',
   showNoteWhenEmpty: false,
   generateXAxisTicks: [],

--- a/src/visualization/types/Check/properties.ts
+++ b/src/visualization/types/Check/properties.ts
@@ -40,7 +40,6 @@ export default {
   ],
 
   colors: DEFAULT_LINE_COLORS as Color[],
-  legend: {},
   note: '',
   showNoteWhenEmpty: false,
   axes: {

--- a/src/visualization/types/Gauge/properties.ts
+++ b/src/visualization/types/Gauge/properties.ts
@@ -8,7 +8,6 @@ import {Color, GaugeViewProperties} from 'src/types'
 export default {
   type: 'gauge',
   shape: 'chronograf-v2',
-  legend: {},
 
   queries: [
     {

--- a/src/visualization/types/Graph/properties.ts
+++ b/src/visualization/types/Graph/properties.ts
@@ -43,7 +43,6 @@ export default {
   ],
 
   colors: DEFAULT_LINE_COLORS as Color[],
-  legend: {},
   legendOpacity: LEGEND_OPACITY_DEFAULT,
   legendOrientationThreshold: LEGEND_ORIENTATION_THRESHOLD_DEFAULT,
 

--- a/src/visualization/types/SingleStat/properties.ts
+++ b/src/visualization/types/SingleStat/properties.ts
@@ -8,7 +8,6 @@ import {Color, SingleStatViewProperties} from 'src/types'
 export default {
   type: 'single-stat',
   shape: 'chronograf-v2',
-  legend: {},
 
   queries: [
     {

--- a/src/visualization/types/SingleStatWithLine/properties.ts
+++ b/src/visualization/types/SingleStatWithLine/properties.ts
@@ -41,7 +41,6 @@ export default {
     },
   ],
 
-  legend: {},
   legendOpacity: LEGEND_OPACITY_DEFAULT,
   legendOrientationThreshold: LEGEND_ORIENTATION_THRESHOLD_DEFAULT,
 


### PR DESCRIPTION
Follow-up on https://github.com/influxdata/influxdb/issues/21154

Remove "Legend" which is not yet a thing in the UI. This will become the "Static Legend" in the near future.
