### PR TITLE
fix(annotations): make create and edit forms match

### DIFF
--- a/cypress/e2e/cloud/annotations.test.ts
+++ b/cypress/e2e/cloud/annotations.test.ts
@@ -62,7 +62,7 @@ describe('The Annotations UI functionality', () => {
       cy.getByTestID('giraffe-inner-plot').click()
     })
     cy.getByTestID('overlay--container').within(() => {
-      cy.getByTestID('textarea')
+      cy.getByTestID('edit-annotation-message')
         .should('be.visible')
         .click()
         .focused()
@@ -87,7 +87,7 @@ describe('The Annotations UI functionality', () => {
       cy.getByTestID('giraffe-inner-plot').click()
     })
     cy.getByTestID('overlay--container').within(() => {
-      cy.getByTestID('textarea')
+      cy.getByTestID('edit-annotation-message')
         .should('be.visible')
         .click()
         .focused()
@@ -124,7 +124,7 @@ describe('The Annotations UI functionality', () => {
       cy.getByTestID('giraffe-inner-plot').click()
     })
     cy.getByTestID('overlay--container').within(() => {
-      cy.getByTestID('textarea')
+      cy.getByTestID('edit-annotation-message')
         .should('be.visible')
         .click()
         .focused()
@@ -144,7 +144,7 @@ describe('The Annotations UI functionality', () => {
       cy.getByTestID('giraffe-inner-plot').click()
     })
     cy.getByTestID('overlay--container').within(() => {
-      cy.getByTestID('textarea')
+      cy.getByTestID('edit-annotation-message')
         .should('be.visible')
         .click()
         .focused()
@@ -174,7 +174,7 @@ describe('The Annotations UI functionality', () => {
       cy.getByTestID('giraffe-inner-plot').click()
     })
     cy.getByTestID('overlay--container').within(() => {
-      cy.getByTestID('textarea')
+      cy.getByTestID('edit-annotation-message')
         .should('be.visible')
         .click()
         .focused()
@@ -190,7 +190,7 @@ describe('The Annotations UI functionality', () => {
         .click()
     })
 
-    cy.getByTestID('edit-annotation-summary-inputfield')
+    cy.getByTestID('edit-annotation-message')
       .clear()
       .type('lets edit this annotation...')
 
@@ -211,7 +211,7 @@ describe('The Annotations UI functionality', () => {
       cy.getByTestID('giraffe-inner-plot').click()
     })
     cy.getByTestID('overlay--container').within(() => {
-      cy.getByTestID('textarea')
+      cy.getByTestID('edit-annotation-message')
         .should('be.visible')
         .click()
         .focused()
@@ -227,7 +227,7 @@ describe('The Annotations UI functionality', () => {
         .click()
     })
 
-    cy.getByTestID('edit-annotation-summary-inputfield')
+    cy.getByTestID('edit-annotation-message')
       .clear()
       .type('lets edit this annotation...')
 
@@ -276,7 +276,7 @@ describe('The Annotations UI functionality', () => {
     })
 
     cy.getByTestID('overlay--container').within(() => {
-      cy.getByTestID('textarea')
+      cy.getByTestID('edit-annotation-message')
         .should('be.visible')
         .click()
         .focused()

--- a/src/annotations/components/EditAnnotationForm.tsx
+++ b/src/annotations/components/EditAnnotationForm.tsx
@@ -1,19 +1,19 @@
 // Libraries
-import React, {FC, useState, ChangeEvent} from 'react'
+import React, {FC, useState} from 'react'
 import {useDispatch} from 'react-redux'
 import {
   Button,
   Columns,
   ComponentColor,
-  ComponentSize,
   ComponentStatus,
-  Form,
   Grid,
-  InfluxColors,
-  Input,
   Overlay,
-  Panel,
 } from '@influxdata/clockface'
+import {AnnotationMessageInput} from 'src/annotations/components/annotationForm/AnnotationMessageInput'
+import {AnnotationStartTimeInput} from 'src/annotations/components/annotationForm/AnnotationStartTimeInput'
+
+// Constants
+import {ANNOTATION_FORM_WIDTH} from 'src/annotations/constants'
 
 // Actions
 import {deleteAnnotations} from 'src/annotations/actions/thunks'
@@ -34,96 +34,84 @@ import {
 } from 'src/shared/copy/notifications'
 import {notify} from 'src/shared/actions/notifications'
 
-interface EditAnnotationProps {
+interface Props {
   handleSubmit: (editedAnnotation: EditAnnotation) => void
   annotation: Annotation
   handleClose: () => void
 }
 
-export const EditAnnotationForm: FC<EditAnnotationProps> = ({
-  handleClose,
-  handleSubmit,
-  annotation,
-}) => {
+export const EditAnnotationForm: FC<Props> = (props: Props) => {
   const [editedAnnotation, updateAnnotation] = useState<EditAnnotation>({
-    id: annotation.id,
-    message: annotation.message ?? '',
-    startTime: new Date(annotation.startTime).toISOString(),
-    stream: annotation.stream,
-    summary: annotation.summary,
+    id: props.annotation.id,
+    message: props.annotation.message ?? '',
+    startTime: new Date(props.annotation.startTime).toISOString(),
+    stream: props.annotation.stream,
+    summary: props.annotation.summary,
   })
+
+  const dispatch = useDispatch()
 
   const isValidAnnotationForm = ({summary, startTime}): boolean => {
     return summary.length && startTime
   }
 
-  const handleChange = (
-    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-  ) => {
-    const {name, value} = event.target
-
-    updateAnnotation(annotationToUpdate => {
+  const updateStartTime = (newStartTime: string) => {
+    updateAnnotation(annotation => {
       return {
-        ...annotationToUpdate,
-        [name]: value,
+        ...annotation,
+        startTime: newStartTime,
       }
     })
+  }
+
+  const updateMessage = (newMessage: string) => {
+    updateAnnotation(annotation => {
+      return {
+        ...annotation,
+        summary: newMessage,
+      }
+    })
+  }
+
+  const handleSubmit = () => {
+    props.handleSubmit(editedAnnotation)
+  }
+
+  const handleKeyboardSubmit = () => {
+    props.handleSubmit(editedAnnotation)
   }
 
   const handleDelete = () => {
     try {
       dispatch(deleteAnnotations(editedAnnotation))
-      dispatch(notify(deleteAnnotationSuccess(editedAnnotation.message)))
       event('xyplot.annotations.delete_annotation.success')
-      handleClose()
+      dispatch(notify(deleteAnnotationSuccess(editedAnnotation.message)))
+      props.handleClose()
     } catch (err) {
       event('xyplot.annotations.delete_annotation.failure')
       dispatch(notify(deleteAnnotationFailed(err)))
     }
   }
 
-  const dispatch = useDispatch()
   return (
-    <Overlay.Container maxWidth={800}>
+    <Overlay.Container maxWidth={ANNOTATION_FORM_WIDTH}>
       <Overlay.Header
         title="Edit Annotation"
-        onDismiss={handleClose}
+        onDismiss={props.handleClose}
         className="edit-annotation-head"
       />
       <Grid className="edit-annotation-grid">
         <Grid.Column widthSM={Columns.Twelve} widthXS={Columns.Twelve}>
-          <h3 className="edit-annotation-header-text">Details</h3>
-          <Panel
-            backgroundColor={InfluxColors.Onyx}
-            className="edit-annotation-panel"
-          >
-            <Form.Element
-              label="Timestamp"
-              className="edit-annotation-form-label"
-            >
-              <Input
-                name="startTime"
-                placeholder="2020-10-10 05:00:00 PDT"
-                value={editedAnnotation.startTime}
-                onChange={handleChange}
-                status={ComponentStatus.Default}
-                size={ComponentSize.Medium}
-              />
-            </Form.Element>
-            <Form.Element
-              label="Message"
-              className="edit-annotation-form-label"
-            >
-              <Input
-                name="summary"
-                value={editedAnnotation.summary}
-                onChange={handleChange}
-                status={ComponentStatus.Default}
-                size={ComponentSize.Medium}
-                testID="edit-annotation-summary-inputfield"
-              />
-            </Form.Element>
-          </Panel>
+          <AnnotationStartTimeInput
+            onChange={updateStartTime}
+            onSubmit={handleKeyboardSubmit}
+            startTime={editedAnnotation.startTime}
+          />
+          <AnnotationMessageInput
+            message={editedAnnotation.summary}
+            onChange={updateMessage}
+            onSubmit={handleKeyboardSubmit}
+          />
         </Grid.Column>
       </Grid>
       <Overlay.Footer className="edit-annotation-form-footer">
@@ -137,14 +125,14 @@ export const EditAnnotationForm: FC<EditAnnotationProps> = ({
         <div className="edit-annotation-buttons">
           <Button
             text="Cancel"
-            onClick={handleClose}
+            onClick={props.handleClose}
             color={ComponentColor.Default}
             className="edit-annotation-cancel"
             testID="edit-annotation-cancel-button"
           />
           <Button
             text="Save Changes"
-            onClick={() => handleSubmit(editedAnnotation)}
+            onClick={handleSubmit}
             color={ComponentColor.Primary}
             status={
               isValidAnnotationForm({

--- a/src/annotations/components/EditAnnotationOverlay.tsx
+++ b/src/annotations/components/EditAnnotationOverlay.tsx
@@ -36,8 +36,8 @@ export const EditAnnotationOverlay: FC = () => {
   const handleSubmit = (editedAnnotation: EditAnnotation): void => {
     try {
       dispatch(editAnnotation(editedAnnotation))
-      dispatch(notify(editAnnotationSuccess()))
       event('xyplot.annotations.edit_annotation.success')
+      dispatch(notify(editAnnotationSuccess()))
       onClose()
     } catch (err) {
       event('xyplot.annotations.edit_annotation.failure')

--- a/src/annotations/components/annotationForm/AnnotationForm.tsx
+++ b/src/annotations/components/annotationForm/AnnotationForm.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FC, ChangeEvent, FormEvent, useState} from 'react'
+import React, {FC, FormEvent, useState} from 'react'
 
 // Components
 import {
@@ -13,6 +13,9 @@ import {
 } from '@influxdata/clockface'
 import {AnnotationMessageInput} from 'src/annotations/components/annotationForm/AnnotationMessageInput'
 import {AnnotationStartTimeInput} from 'src/annotations/components/annotationForm/AnnotationStartTimeInput'
+
+// Constants
+import {ANNOTATION_FORM_WIDTH} from 'src/annotations/constants'
 
 interface Annotation {
   message: string
@@ -43,16 +46,20 @@ export const AnnotationForm: FC<Props> = (props: Props) => {
     props.onSubmit({message, startTime})
   }
 
-  const updateMessage = (event: ChangeEvent<HTMLTextAreaElement>): void => {
-    setMessage(event.target.value)
+  const updateMessage = (newMessage: string): void => {
+    setMessage(newMessage)
   }
 
-  const updateStartTime = (event: ChangeEvent<HTMLInputElement>): void => {
-    setStartTime(event.target.value)
+  const updateStartTime = (newTime: string): void => {
+    setStartTime(newTime)
+  }
+
+  const handleKeyboardSubmit = () => {
+    props.onSubmit({message, startTime})
   }
 
   return (
-    <Overlay.Container maxWidth={560}>
+    <Overlay.Container maxWidth={ANNOTATION_FORM_WIDTH}>
       <Overlay.Header
         title={`${props.title} Annotation`}
         onDismiss={props.onClose}
@@ -63,6 +70,7 @@ export const AnnotationForm: FC<Props> = (props: Props) => {
             <Grid.Row>
               <AnnotationStartTimeInput
                 onChange={updateStartTime}
+                onSubmit={handleKeyboardSubmit}
                 startTime={startTime}
               />
             </Grid.Row>
@@ -70,6 +78,7 @@ export const AnnotationForm: FC<Props> = (props: Props) => {
               <AnnotationMessageInput
                 message={message}
                 onChange={updateMessage}
+                onSubmit={handleKeyboardSubmit}
               />
             </Grid.Row>
           </Grid>

--- a/src/annotations/components/annotationForm/AnnotationMessageInput.tsx
+++ b/src/annotations/components/annotationForm/AnnotationMessageInput.tsx
@@ -1,36 +1,67 @@
 // Libraries
-import React, {FC, ChangeEvent, useEffect, useRef} from 'react'
+import React, {
+  FC,
+  ChangeEvent,
+  KeyboardEvent,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
 
 // Components
 import {Columns, Form, Grid, TextArea} from '@influxdata/clockface'
 
 interface Props {
-  onChange: (event: ChangeEvent<HTMLTextAreaElement>) => void
   message: string
+  onChange: (newMessage: string) => void
+  onSubmit: () => void
 }
+
+const characterLimit = 255
 
 export const AnnotationMessageInput: FC<Props> = (props: Props) => {
   const textArea = useRef(null)
   const validationMessage = props.message ? '' : 'This field is required'
+  const [characterCount, setCharacterCount] = useState(
+    props.message.length ?? 0
+  )
+
+  const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    setCharacterCount(event.target.value.length)
+    props.onChange(event.target.value)
+  }
+
+  const handleKeyPress = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === 'Enter') {
+      props.onSubmit()
+      return
+    }
+  }
 
   useEffect(() => {
     textArea.current.focus()
+    // place the cursor at the end of the text when editing
+    if (textArea.current.textLength) {
+      textArea.current.selectionStart = textArea.current.textLength
+      textArea.current.selectionEnd = textArea.current.textLength
+    }
   }, [])
 
   return (
     <Grid.Column widthXS={Columns.Twelve}>
       <Form.Element
-        label="Message (max: 255 characters)"
+        label={`Message (${characterCount} / ${characterLimit})`}
         required={true}
         errorMessage={validationMessage}
       >
         <TextArea
           name="message"
           value={props.message}
-          onChange={props.onChange}
+          onChange={handleChange}
+          onKeyPress={handleKeyPress}
           style={{height: '80px', minHeight: '80px'}}
           ref={textArea}
-          maxLength={255}
+          maxLength={characterLimit}
         />
       </Form.Element>
     </Grid.Column>

--- a/src/annotations/components/annotationForm/AnnotationMessageInput.tsx
+++ b/src/annotations/components/annotationForm/AnnotationMessageInput.tsx
@@ -62,6 +62,7 @@ export const AnnotationMessageInput: FC<Props> = (props: Props) => {
           style={{height: '80px', minHeight: '80px'}}
           ref={textArea}
           maxLength={characterLimit}
+          testID="edit-annotation-message"
         />
       </Form.Element>
     </Grid.Column>

--- a/src/annotations/components/annotationForm/AnnotationStartTimeInput.tsx
+++ b/src/annotations/components/annotationForm/AnnotationStartTimeInput.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FC, ChangeEvent} from 'react'
+import React, {FC, ChangeEvent, KeyboardEvent} from 'react'
 
 // Components
 import {
@@ -11,12 +11,24 @@ import {
 } from '@influxdata/clockface'
 
 interface Props {
-  onChange: (event: ChangeEvent<HTMLInputElement>) => void
+  onChange: (newTime: string) => void
+  onSubmit: () => void
   startTime: string
 }
 
 export const AnnotationStartTimeInput: FC<Props> = (props: Props) => {
   const validationMessage = props.startTime ? '' : 'This field is required'
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    props.onChange(event.target.value)
+  }
+
+  const handleKeyPress = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      props.onSubmit()
+      return
+    }
+  }
 
   return (
     <Grid.Column widthXS={Columns.Twelve}>
@@ -28,7 +40,8 @@ export const AnnotationStartTimeInput: FC<Props> = (props: Props) => {
         <Input
           name="startTime"
           value={new Date(props.startTime).toString()}
-          onChange={props.onChange}
+          onChange={handleChange}
+          onKeyPress={handleKeyPress}
           status={ComponentStatus.Default}
         />
       </Form.Element>

--- a/src/annotations/constants.ts
+++ b/src/annotations/constants.ts
@@ -1,0 +1,1 @@
+export const ANNOTATION_FORM_WIDTH = 560


### PR DESCRIPTION
Closes #1229

- Makes the edit annotation form match the create annotation form
- Adds a live character counter showing how close you are to the 255 character limit
- Allows the form to be submitted by pressing `enter`

https://user-images.githubusercontent.com/146112/115093887-911e4b80-9ed0-11eb-96ea-d297d5facf30.mov


