### PR TITLE
feat: pause cell feature

### DIFF
--- a/src/shared/components/cells/Cell.tsx
+++ b/src/shared/components/cells/Cell.tsx
@@ -2,7 +2,6 @@
 import React, {Component} from 'react'
 import {connect} from 'react-redux'
 import {get} from 'lodash'
-
 // Components
 import CellHeader from 'src/shared/components/cells/CellHeader'
 import CellContext from 'src/shared/components/cells/CellContext'
@@ -13,9 +12,19 @@ import EmptyGraphMessage from 'src/shared/components/EmptyGraphMessage'
 
 // Utils
 import {getByID} from 'src/resources/selectors'
+import {resetQueryCacheByQuery} from 'src/shared/apis/queryCache'
 
 // Types
-import {RemoteDataState, AppState, View, Cell, ResourceType} from 'src/types'
+
+import {
+  RemoteDataState,
+  AppState,
+  View,
+  Cell,
+  ResourceType,
+  ViewProperties,
+  MarkdownViewProperties,
+} from 'src/types'
 
 interface StateProps {
   view: View
@@ -38,7 +47,23 @@ class CellComponent extends Component<Props, State> {
     submitToken: 0,
   }
 
+  private handleRefreshProcess = (): void => {
+    const viewWithQueries = this.props.view as View<
+      Exclude<ViewProperties, MarkdownViewProperties>
+    >
+    const foundQueries =
+      Array.isArray(viewWithQueries?.properties?.queries) &&
+      viewWithQueries?.properties?.queries.length
+
+    if (foundQueries) {
+      for (const query of viewWithQueries.properties.queries) {
+        resetQueryCacheByQuery(query.text)
+      }
+    }
+  }
+
   private handleIncrementToken = (): void => {
+    this.handleRefreshProcess()
     this.setState(s => ({...s, submitToken: s.submitToken + 1}))
   }
 

--- a/src/shared/components/cells/Cell.tsx
+++ b/src/shared/components/cells/Cell.tsx
@@ -16,15 +16,7 @@ import {resetQueryCacheByQuery} from 'src/shared/apis/queryCache'
 
 // Types
 
-import {
-  RemoteDataState,
-  AppState,
-  View,
-  Cell,
-  ResourceType,
-  ViewProperties,
-  MarkdownViewProperties,
-} from 'src/types'
+import {RemoteDataState, AppState, View, Cell, ResourceType} from 'src/types'
 
 interface StateProps {
   view: View
@@ -48,18 +40,12 @@ class CellComponent extends Component<Props, State> {
   }
 
   private handleRefreshProcess = (): void => {
-    const viewWithQueries = this.props.view as View<
-      Exclude<ViewProperties, MarkdownViewProperties>
-    >
-    const foundQueries =
-      Array.isArray(viewWithQueries?.properties?.queries) &&
-      viewWithQueries?.properties?.queries.length
-
-    if (foundQueries) {
-      for (const query of viewWithQueries.properties.queries) {
-        resetQueryCacheByQuery(query.text)
-      }
+    const {view} = this.props
+    if (view.properties.type === 'markdown') {
+      return
     }
+
+    view.properties.queries.forEach(query => resetQueryCacheByQuery(query.text))
   }
 
   private handleIncrementToken = (): void => {
@@ -103,7 +89,7 @@ class CellComponent extends Component<Props, State> {
   private get viewNote(): string {
     const {view} = this.props
 
-    if (!view || !view.properties || !view.properties.type) {
+    if (!view?.properties?.type) {
       return ''
     }
 

--- a/src/shared/components/cells/CellContext.tsx
+++ b/src/shared/components/cells/CellContext.tsx
@@ -7,7 +7,10 @@ import classnames from 'classnames'
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'
-import {resetQueryCacheByQuery} from 'src/shared/apis/queryCache'
+import {
+  getFromQueryCacheByQuery,
+  togglePauseQuery,
+} from 'src/shared/apis/queryCache'
 
 // Components
 import {
@@ -24,14 +27,24 @@ import {FeatureFlag} from 'src/shared/utils/featureFlag'
 // Actions
 import {deleteCellAndView, createCellWithView} from 'src/cells/actions/thunks'
 
+// Selectors
+import {getAllVariables} from 'src/variables/selectors'
+
 // Types
-import {Cell, View, ViewProperties, MarkdownViewProperties} from 'src/types'
+import {
+  Cell,
+  View,
+  ViewProperties,
+  MarkdownViewProperties,
+  AppState,
+} from 'src/types'
 
 interface OwnProps {
   cell: Cell
   view: View
   onCSVDownload: () => void
   onRefresh: () => void
+  variables: string
 }
 
 type ReduxProps = ConnectedProps<typeof connector>
@@ -42,11 +55,19 @@ const CellContext: FC<Props> = ({
   history,
   location,
   cell,
+  variables,
   onCloneCell,
   onDeleteCell,
   onCSVDownload,
   onRefresh,
 }) => {
+  const viewWithQueries = view as View<
+    Exclude<ViewProperties, MarkdownViewProperties>
+  >
+  const foundQueries =
+    Array.isArray(viewWithQueries?.properties?.queries) &&
+    viewWithQueries?.properties?.queries.length
+  const [isPaused, setIsPaused] = useState<boolean>(false)
   const [popoverVisible, setPopoverVisibility] = useState<boolean>(false)
   const editNoteText = !!get(view, 'properties.note') ? 'Edit Note' : 'Add Note'
   const triggerRef: RefObject<HTMLButtonElement> = useRef<HTMLButtonElement>(
@@ -80,19 +101,16 @@ const CellContext: FC<Props> = ({
     event('editCell button Click')
   }
 
-  const refreshCell = (): void => {
-    const viewWithQueries = view as View<
-      Exclude<ViewProperties, MarkdownViewProperties>
-    >
-    if (
-      Array.isArray(viewWithQueries.properties?.queries) &&
-      viewWithQueries.properties.queries.length
-    ) {
+  const togglePauseCell = (): void => {
+    if (foundQueries) {
       for (const query of viewWithQueries.properties.queries) {
-        resetQueryCacheByQuery(query.text)
+        const returnedQuery = getFromQueryCacheByQuery(query.text, variables)
+        if (returnedQuery) {
+          togglePauseQuery(returnedQuery)
+          setIsPaused(!isPaused)
+        }
       }
     }
-    onRefresh()
   }
 
   const popoverContents = (onHide): JSX.Element => {
@@ -159,10 +177,21 @@ const CellContext: FC<Props> = ({
         <FeatureFlag name="refreshSingleCell">
           <CellContextItem
             label="Refresh"
-            onClick={refreshCell}
+            onClick={onRefresh}
             icon={IconFont.Refresh}
             onHide={onHide}
             testID="cell-context--refresh"
+          />
+        </FeatureFlag>
+        <FeatureFlag name="pauseCell">
+          <CellContextItem
+            label={isPaused ? 'Resume' : 'Pause'}
+            onClick={() => {
+              togglePauseCell()
+            }}
+            icon={isPaused ? IconFont.Play : IconFont.Pause}
+            onHide={onHide}
+            testID="cell-context--pause"
           />
         </FeatureFlag>
       </div>
@@ -171,6 +200,15 @@ const CellContext: FC<Props> = ({
 
   return (
     <>
+      {isPaused && (
+        <button
+          className={buttonClass}
+          onClick={togglePauseCell}
+          data-testid="cell-context--pause-resume"
+        >
+          <Icon glyph={IconFont.Pause} />
+        </button>
+      )}
       <button
         className={buttonClass}
         ref={triggerRef}
@@ -196,11 +234,14 @@ const CellContext: FC<Props> = ({
   )
 }
 
+const mstp = (state: AppState) => ({
+  variables: getAllVariables(state),
+})
 const mdtp = {
   onDeleteCell: deleteCellAndView,
   onCloneCell: createCellWithView,
 }
 
-const connector = connect(null, mdtp)
+const connector = connect(mstp, mdtp)
 
 export default withRouter(connector(CellContext))


### PR DESCRIPTION
Closes #


### Note
As per discussion with, and approval from, @kristinarobinson , this is one half of the implementation for the epic surrounding Auto Refresh Dashboard  - see #1207. The work is split into two parts, with the Pause Cell feature here and the auto refresh feature in the other PR (#1220). The tests will be added under a separate ticket. 
<!-- Describe your proposed changes here. -->
Please see the epic for Dashboard Auto Refresh for context about this feature. Introduces ability to pause cells, will be integrated with broader dashboard auto refresh work. 

Implements:
 - pause cell icon
 - configure menu pause / resume icon
 - query cache pause flag that monitors for paused cells before deletion

### Feature flag
Under feature flag: `pauseCell`