### PR TITLE
fix: edit annotation wait for response from API

### DIFF
--- a/src/annotations/components/EditAnnotationOverlay.tsx
+++ b/src/annotations/components/EditAnnotationOverlay.tsx
@@ -33,7 +33,7 @@ export const EditAnnotationOverlay: FC = () => {
   const dispatch = useDispatch()
   const {clickedAnnotation} = useSelector(getOverlayParams)
 
-  const handleSubmit = (editedAnnotation: EditAnnotation): void => {
+  const handleSubmit = async (editedAnnotation: EditAnnotation): Promise<void> => {
     try {
       dispatch(editAnnotation(editedAnnotation))
       event('xyplot.annotations.edit_annotation.success')

--- a/src/annotations/components/EditAnnotationOverlay.tsx
+++ b/src/annotations/components/EditAnnotationOverlay.tsx
@@ -33,7 +33,9 @@ export const EditAnnotationOverlay: FC = () => {
   const dispatch = useDispatch()
   const {clickedAnnotation} = useSelector(getOverlayParams)
 
-  const handleSubmit = async (editedAnnotation: EditAnnotation): Promise<void> => {
+  const handleSubmit = async (
+    editedAnnotation: EditAnnotation
+  ): Promise<void> => {
     try {
       dispatch(editAnnotation(editedAnnotation))
       event('xyplot.annotations.edit_annotation.success')


### PR DESCRIPTION
Addresses https://github.com/influxdata/ui/issues/1230

On an invalid response from the API, we were not waiting for the API call to finish, this caused a premature success notification even when the request failed in the API. This PR adds an `await` so that the API call is waited for to complete.

On editing the annotation message to more than 255 characters and pressing submit, we now see an error message and the form is not submitted. 

_Perhaps, the new form is a better solution to address the API issue, i.e not allowing more than 255 characters in the first place._

<img width="1440" alt="Screen Shot 2021-04-19 at 2 29 59 PM" src="https://user-images.githubusercontent.com/18511823/115306261-6d4f4580-a11c-11eb-9694-57758e61ecc9.png">


