### PR TITLE
fix: csv parser escapes special characters

### DIFF
--- a/cypress/fixtures/good-csv.csv
+++ b/cypress/fixtures/good-csv.csv
@@ -17,12 +17,12 @@
 #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string,string,string,string,string,string
 #default,last,,,,,,,,,,,,,,
 ,result,table,_start,_stop,_time,_value,_field,_measurement,host,lat,lon,name,region_id,short_name,station_id
-,,10,2021-01-19T20:58:58.549310588Z,2021-01-21T20:58:58.549310588Z,2021-01-21T20:50:00Z,19,capacity,baywheels_meta,ip-192-168-1-6.ec2.internal,37.7692005,-122.4338119,Duboce Park,3,SF-L19,84
-,,10,2021-01-19T20:58:58.549310588Z,2021-01-21T20:58:58.549310588Z,2021-01-21T20:58:58.549310588Z,19,capacity,baywheels_meta,ip-192-168-1-6.ec2.internal,37.7692005,-122.4338119,Duboce Park,3,SF-L19,84
+,,10,2021-01-19T20:58:58.549310588Z,2021-01-21T20:58:58.549310588Z,2021-01-21T20:50:00Z,19,some capacity,baywheels meta,ip-192-168-1-6.ec2.internal,37.7692005,-122.4338119,Duboce Park,3,SF-L19,84
+,,10,2021-01-19T20:58:58.549310588Z,2021-01-21T20:58:58.549310588Z,2021-01-21T20:58:58.549310588Z,19,some capacity,baywheels meta,ip-192-168-1-6.ec2.internal,37.7692005,-122.4338119,Duboce Park,3,SF-L19,84
 
 #group,false,false,true,true,false,false,true,true,true,true,true,true,true,true,true
 #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,string,string,string,string,string,string
 #default,last,,,,,,,,,,,,,,
 ,result,table,_start,_stop,_time,_value,_field,_measurement,host,lat,lon,name,region_id,short_name,station_id
-,,11,2021-01-19T20:58:58.549310588Z,2021-01-21T20:58:58.549310588Z,2021-01-21T20:50:00Z,73295cf1-c5e1-41dd-8cd7-eab6512e8a34,external_id,baywheels_meta,ip-192-168-1-6.ec2.internal,37.82669558640968,-122.27179706096648,37th St at West St,12,OK-G3,192
-,,11,2021-01-19T20:58:58.549310588Z,2021-01-21T20:58:58.549310588Z,2021-01-21T20:58:58.549310588Z,73295cf1-c5e1-41dd-8cd7-eab6512e8a34,external_id,baywheels_meta,ip-192-168-1-6.ec2.internal,37.82669558640968,-122.27179706096648,37th St at West St,12,OK-G3,192
+,,11,2021-01-19T20:58:58.549310588Z,2021-01-21T20:58:58.549310588Z,2021-01-21T20:50:00Z,73295cf1-c5e1-41dd-8cd7-eab6512e8a34,external=id,baywheels_meta,ip-192-168-1-6.ec2.internal,37.82669558640968,-122.27179706096648,37th St at West St,12,OK-G3,192
+,,11,2021-01-19T20:58:58.549310588Z,2021-01-21T20:58:58.549310588Z,2021-01-21T20:58:58.549310588Z,73295cf1-c5e1-41dd-8cd7\eab6512e8a34,external=id,baywheels_meta,ip-192-168-1-6.ec2.internal,37.82669558640968,-122.27179706096648,37th St at West St,12,OK-G3,192


### PR DESCRIPTION
Closes #1189

Escapes special characters according to https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol/#special-characters

Adds special characters in valid csv used for e2e tests so we can test these scenarios.
