### PR TITLE
chore: increase build image timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
           command: cp ./monitor-ci/env.testing ./monitor-ci/.env
       - run:
           name: Build the ui docker image
+          no_output_timeout: 15m
           command: |
             cp ./monitor-ci/conf/chronograf/nginx.conf ./ui/
             docker build \
@@ -48,6 +49,7 @@ jobs:
           command: cp ./monitor-ci/env.testing.oss ./monitor-ci/.env
       - run:
           name: Build the ui oss docker image
+          no_output_timeout: 15m
           command: |
             cp ./monitor-ci/conf/chronograf/nginx.conf ./ui/
             docker build \
@@ -75,6 +77,7 @@ jobs:
       - checkout_monitor_ci
       - run:
           name: Build the ui docker image
+          no_output_timeout: 15m
           command: |
             cp ./monitor-ci/conf/chronograf/nginx.conf ./ui/
             docker build \
@@ -108,6 +111,7 @@ jobs:
           command: cp ./monitor-ci/env.testing ./monitor-ci/.env
       - run:
           name: Build the ui docker image
+          no_output_timeout: 15m
           command: |
             cp ./monitor-ci/conf/chronograf/nginx.conf ./ui/
             docker build \


### PR DESCRIPTION
Lots of pipelines have been failing because it's taking >10min to install npm packages when building the UI image. Circle kills all jobs that haven't produced output after 10min. I'm increasing that timeout to 15min

Example: https://app.circleci.com/pipelines/github/influxdata/ui/3887/workflows/97789f84-ee33-452d-b87f-ec6970295d65/jobs/30727
