### PR TITLE
chore: updated route and feature flag names

### DIFF
--- a/cypress/e2e/cloud/billing.test.ts
+++ b/cypress/e2e/cloud/billing.test.ts
@@ -10,10 +10,10 @@ describe('Billing Page', () => {
         cy.window().then(w => {
           // I hate to add this, but the influx object isn't ready yet
           cy.wait(1000)
-          w.influx.set('unity-billing', true)
+          w.influx.set('unityBilling', true)
         })
 
-        cy.visit(`/orgs/${id}/unity-billing`)
+        cy.visit(`/orgs/${id}/billing`)
       })
     })
 

--- a/cypress/e2e/cloud/checkout.test.ts
+++ b/cypress/e2e/cloud/checkout.test.ts
@@ -29,8 +29,8 @@ describe('Checkout Page', () => {
       cy.get('@org').then(() => {
         cy.getByTestID('home-page--header').should('be.visible')
         cy.window().then(w => {
-          w.influx.set('unity-me-api', true)
-          w.influx.set('unity-checkout', true)
+          w.influx.set('unityMeApi', true)
+          w.influx.set('unityCheckout', true)
           cy.wait(1000)
         })
 

--- a/cypress/e2e/cloud/usage.test.ts
+++ b/cypress/e2e/cloud/usage.test.ts
@@ -10,10 +10,10 @@ describe('Usage Page', () => {
         cy.window().then(w => {
           // I hate to add this, but the influx object isn't ready yet
           cy.wait(1000)
-          w.influx.set('unity-usage', true)
+          w.influx.set('unityUsage', true)
         })
 
-        cy.visit(`/orgs/${id}/unity-usage`)
+        cy.visit(`/orgs/${id}/usage`)
       })
     })
 

--- a/cypress/e2e/cloud/users.test.ts
+++ b/cypress/e2e/cloud/users.test.ts
@@ -10,10 +10,10 @@ describe('Users Page', () => {
         cy.window().then(w => {
           // I hate to add this, but the influx object isn't ready yet
           cy.wait(1000)
-          w.influx.set('unity', true)
+          w.influx.set('unityUsers', true)
         })
 
-        cy.visit(`/orgs/${id}/unity-users`)
+        cy.visit(`/orgs/${id}/users`)
       })
     })
 

--- a/src/pageLayout/components/UserWidget.tsx
+++ b/src/pageLayout/components/UserWidget.tsx
@@ -10,6 +10,7 @@ import CloudOnly from 'src/shared/components/cloud/CloudOnly'
 
 // Actions
 import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Constants
 import {
@@ -25,7 +26,6 @@ import {AppState} from 'src/types'
 // Selectors
 import {getOrg} from 'src/organizations/selectors'
 import {getNavItemActivation} from '../utils'
-import {FeatureFlag} from 'src/shared/utils/featureFlag'
 
 type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps
@@ -54,19 +54,16 @@ const UserWidget: FC<Props> = ({
           label="Usage"
           testID="user-nav-item-usage"
           linkElement={className => (
-            <a className={className} href={`${CLOUD_URL}${CLOUD_USAGE_PATH}`} />
+            <a
+              className={className}
+              href={
+                isFlagEnabled('unityUsage')
+                  ? `${orgPrefix}/usage`
+                  : `${CLOUD_URL}${CLOUD_USAGE_PATH}`
+              }
+            />
           )}
         />
-        <FeatureFlag name="unity-usage">
-          <TreeNav.UserItem
-            id="unity-usage"
-            label="Unity Usage"
-            testID="user-nav-item-unity-usage"
-            linkElement={className => (
-              <a className={className} href={`/orgs/${org.id}/unity-usage`} />
-            )}
-          />
-        </FeatureFlag>
         <TreeNav.UserItem
           id="billing"
           label="Billing"
@@ -74,7 +71,11 @@ const UserWidget: FC<Props> = ({
           linkElement={className => (
             <a
               className={className}
-              href={`${CLOUD_URL}${CLOUD_BILLING_PATH}`}
+              href={
+                isFlagEnabled('unityBilling')
+                  ? `${orgPrefix}/billing`
+                  : `${CLOUD_URL}${CLOUD_BILLING_PATH}`
+              }
             />
           )}
         />
@@ -85,30 +86,14 @@ const UserWidget: FC<Props> = ({
           linkElement={className => (
             <a
               className={className}
-              href={`${CLOUD_URL}/organizations/${org.id}${CLOUD_USERS_PATH}`}
+              href={
+                isFlagEnabled('unityUsers')
+                  ? `${orgPrefix}/users`
+                  : `${CLOUD_URL}/organizations/${org.id}${CLOUD_USERS_PATH}`
+              }
             />
           )}
         />
-        <FeatureFlag name="unity">
-          <TreeNav.UserItem
-            id="unity-users"
-            label="Unity Users"
-            testID="user-nav-item-unity-users"
-            linkElement={className => (
-              <a className={className} href={`/orgs/${org.id}/unity-users`} />
-            )}
-          />
-        </FeatureFlag>
-        <FeatureFlag name="unity-billing">
-          <TreeNav.UserItem
-            id="unity-billing"
-            label="Unity billing"
-            testID="user-nav-item-unity-billing"
-            linkElement={className => (
-              <a className={className} href={`/orgs/${org.id}/unity-billing`} />
-            )}
-          />
-        </FeatureFlag>
         <TreeNav.UserItem
           id="about"
           label="About"

--- a/src/shared/containers/GetOrganizations.tsx
+++ b/src/shared/containers/GetOrganizations.tsx
@@ -56,18 +56,18 @@ const GetOrganizations: FunctionComponent = () => {
   return (
     <PageSpinner loading={status}>
       <Suspense fallback={<PageSpinner />}>
-        {isFlagEnabled('unity-me-api') ? (
+        {isFlagEnabled('unityMeApi') ? (
           <PageSpinner loading={quartzMeStatus}>
             <Switch>
               <Route path="/no-orgs" component={NoOrgsPage} />
               <Route path="/orgs" component={App} />
               <Route exact path="/" component={RouteToOrg} />
               {CLOUD &&
-                isFlagEnabled('unity-checkout') &&
+                isFlagEnabled('unityCheckout') &&
                 canAccessCheckout(me) && (
                   <Route path="/checkout" component={CheckoutPage} />
                 )}
-              {CLOUD && isFlagEnabled('unity-operator') && me?.isOperator && (
+              {CLOUD && isFlagEnabled('unityOperator') && me?.isOperator && (
                 <Route path="/operator" component={OperatorPage} />
               )}
               <Route component={NotFound} />

--- a/src/shared/containers/SetOrg.tsx
+++ b/src/shared/containers/SetOrg.tsx
@@ -231,18 +231,18 @@ const SetOrg: FC<Props> = ({
           />
 
           {/* Users */}
-          {CLOUD && isFlagEnabled('unity') && (
-            <Route path={`${orgPath}/unity-users`} component={UsersPage} />
+          {CLOUD && isFlagEnabled('unityUsers') && (
+            <Route path={`${orgPath}/users`} component={UsersPage} />
           )}
 
           {/* Billing */}
-          {CLOUD && isFlagEnabled('unity-billing') && (
-            <Route path={`${orgPath}/unity-billing`} component={BillingPage} />
+          {CLOUD && isFlagEnabled('unityBilling') && (
+            <Route path={`${orgPath}/billing`} component={BillingPage} />
           )}
 
           {/* Usage */}
-          {CLOUD && isFlagEnabled('unity-usage') && (
-            <Route path={`${orgPath}/unity-usage`} component={UsagePage} />
+          {CLOUD && isFlagEnabled('unityUsage') && (
+            <Route path={`${orgPath}/usage`} component={UsagePage} />
           )}
 
           {/* Managed Functions */}


### PR DESCRIPTION
Closes #950

This PR updates the routes for the unity epic to remove a reference to the `unity-` prefix. In addition, the feature flags are updated to a camelcased version, since that is what it is currently set in config cat. Finally, the tree-nav routes are conditionally rendering the href based on whether a feature flag is set for that route or not. That is to say, the route will either direct to the local UI instance or to Quartz depending on whether the feature flag is on or off.
