### PR TITLE
fix: e2e test works with axisTicksGenerator on or off

### DIFF
--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -799,7 +799,7 @@ describe('DataExplorer', () => {
 
         cy.getByTestID('time-machine-submit-button').click()
         cy.getByTestID('cog-cell--button').click()
-        cy.getByTestID('select-group--option')
+        cy.get('.auto-domain-input')
           .contains('Custom')
           .click()
         cy.getByTestID('auto-domain--min')


### PR DESCRIPTION
Closes #1271

Changed the cypress selector in the `can set min or max y-axis values` test to be more specific so that the test works if the `axisTicksGenerator` flag is `true` on the backend.
