### PR TITLE
fix: Icon pencil closer to title

### DIFF
--- a/src/pageLayout/components/RenamablePageTitle.scss
+++ b/src/pageLayout/components/RenamablePageTitle.scss
@@ -69,7 +69,7 @@ $renamable-page-title--padding: 0;
   position: absolute;
   font-size: 1.5em;
   top: 50%;
-  // right: $renamable-page-title--height / 2;
+  right: $renamable-page-title--height / 2;
   transform: translate(50%, -50%);
   opacity: 0;
   transition: opacity 0.25s ease;

--- a/src/pageLayout/components/RenamablePageTitle.scss
+++ b/src/pageLayout/components/RenamablePageTitle.scss
@@ -8,7 +8,7 @@ $renamable-page-title--padding: 0;
 
 .renamable-page-title {
   width: 100%;
-  max-width:850px;
+  max-width: 850px;
   position: relative;
   height: $renamable-page-title--height;
   font-size: $cf-body-text;

--- a/src/pageLayout/components/RenamablePageTitle.scss
+++ b/src/pageLayout/components/RenamablePageTitle.scss
@@ -8,6 +8,7 @@ $renamable-page-title--padding: 0;
 
 .renamable-page-title {
   width: 100%;
+  max-width:850px;
   position: relative;
   height: $renamable-page-title--height;
   font-size: $cf-body-text;

--- a/src/pageLayout/components/RenamablePageTitle.scss
+++ b/src/pageLayout/components/RenamablePageTitle.scss
@@ -69,7 +69,7 @@ $renamable-page-title--padding: 0;
   position: absolute;
   font-size: 1.5em;
   top: 50%;
-  right: $renamable-page-title--height / 2;
+  // right: $renamable-page-title--height / 2;
   transform: translate(50%, -50%);
   opacity: 0;
   transition: opacity 0.25s ease;


### PR DESCRIPTION
Closes #918 

<!-- Describe your proposed changes here. -->
Before
<img width="1563" alt="Screen Shot 2021-04-22 at 1 42 08 PM" src="https://user-images.githubusercontent.com/6667389/115768938-31102500-a368-11eb-880a-075a8bb9fa6b.png">


After

<img width="933" alt="Screen Shot 2021-04-22 at 1 40 59 PM" src="https://user-images.githubusercontent.com/6667389/115768932-30778e80-a368-11eb-98de-5ca2857c6cd8.png">

Both are the same for ipad sized devices

<img width="485" alt="Screen Shot 2021-04-22 at 1 43 48 PM" src="https://user-images.githubusercontent.com/6667389/115769238-906e3500-a368-11eb-8d3d-2ca8f53f22cc.png">
<img width="501" alt="Screen Shot 2021-04-22 at 1 44 24 PM" src="https://user-images.githubusercontent.com/6667389/115769242-9106cb80-a368-11eb-9a46-511154ef738c.png">


For squished computer screen
<img width="1362" alt="Screen Shot 2021-04-22 at 1 44 40 PM" src="https://user-images.githubusercontent.com/6667389/115769290-9a903380-a368-11eb-854a-b33b0a4a8445.png">
