### PR TITLE
feat: integrated public flags without negating the getFlags condition

### DIFF
--- a/src/Signin.tsx
+++ b/src/Signin.tsx
@@ -17,7 +17,7 @@ import {
   setToLocalStorage,
 } from 'src/localStorage'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
-import {getPublicFlags} from 'src/shared/actions/flags'
+import {getPublicFlags} from 'src/shared/thunks/flags'
 
 // Actions
 import {notify as notifyAction} from 'src/shared/actions/notifications'

--- a/src/Signin.tsx
+++ b/src/Signin.tsx
@@ -57,7 +57,7 @@ export class Signin extends PureComponent<Props, State> {
   public async componentDidMount() {
     this.hasMounted = true
     this.setState({loading: RemoteDataState.Loading})
-    this.props.onGetPublicFlags()
+    await this.props.onGetPublicFlags()
 
     await this.checkForLogin()
 

--- a/src/Signin.tsx
+++ b/src/Signin.tsx
@@ -17,6 +17,7 @@ import {
   setToLocalStorage,
 } from 'src/localStorage'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import {getPublicFlags} from 'src/shared/actions/flags'
 
 // Actions
 import {notify as notifyAction} from 'src/shared/actions/notifications'
@@ -56,6 +57,7 @@ export class Signin extends PureComponent<Props, State> {
   public async componentDidMount() {
     this.hasMounted = true
     this.setState({loading: RemoteDataState.Loading})
+    this.props.onGetPublicFlags()
 
     await this.checkForLogin()
 
@@ -139,6 +141,7 @@ export class Signin extends PureComponent<Props, State> {
 
 const mdtp = {
   notify: notifyAction,
+  onGetPublicFlags: getPublicFlags,
 }
 
 const connector = connect(null, mdtp)

--- a/src/shared/actions/flags.ts
+++ b/src/shared/actions/flags.ts
@@ -4,12 +4,14 @@ import {FlagMap} from 'src/shared/reducers/flags'
 import {getAPIBasepath} from 'src/utils/basepath'
 import {RemoteDataState} from 'src/types'
 export const SET_FEATURE_FLAGS = 'SET_FEATURE_FLAGS'
+export const SET_PUBLIC_FEATURE_FLAGS = 'SET_PUBLIC_FEATURE_FLAGS'
 export const RESET_FEATURE_FLAGS = 'RESET_FEATURE_FLAGS'
 export const CLEAR_FEATURE_FLAG_OVERRIDES = 'CLEAR_FEATURE_FLAG_OVERRIDES'
 export const SET_FEATURE_FLAG_OVERRIDE = 'SET_FEATURE_FLAG_OVERRIDE'
 
 export type Actions =
   | ReturnType<typeof setFlags>
+  | ReturnType<typeof setPublicFlags>
   | ReturnType<typeof reset>
   | ReturnType<typeof clearOverrides>
   | ReturnType<typeof setOverride>
@@ -22,6 +24,14 @@ export const setFlags = (status: RemoteDataState, flags?: FlagMap) =>
     type: SET_FEATURE_FLAGS,
     payload: {
       status,
+      flags,
+    },
+  } as const)
+
+export const setPublicFlags = (flags?: FlagMap) =>
+  ({
+    type: SET_PUBLIC_FEATURE_FLAGS,
+    payload: {
       flags,
     },
   } as const)
@@ -66,7 +76,6 @@ export const getFlags = () => async (
 
 export const getPublicFlags = () => async (dispatch: Dispatch<Actions>) => {
   try {
-    dispatch(setFlags(RemoteDataState.Loading))
     const url = `${getAPIBasepath()}/api/v2private/flags`
     const response = await fetch(url)
     const flags = await response.json()
@@ -75,9 +84,8 @@ export const getPublicFlags = () => async (dispatch: Dispatch<Actions>) => {
       throw new Error(flags.message)
     }
 
-    dispatch(setFlags(RemoteDataState.Done, flags))
+    dispatch(setPublicFlags(flags))
   } catch (error) {
     console.error(error)
-    dispatch(setFlags(RemoteDataState.Error, null))
   }
 }

--- a/src/shared/actions/flags.ts
+++ b/src/shared/actions/flags.ts
@@ -1,6 +1,7 @@
 import {Dispatch} from 'redux'
 import {getFlags as getFlagsRequest} from 'src/client'
 import {FlagMap} from 'src/shared/reducers/flags'
+import {getAPIBasepath} from 'src/utils/basepath'
 import {RemoteDataState} from 'src/types'
 export const SET_FEATURE_FLAGS = 'SET_FEATURE_FLAGS'
 export const RESET_FEATURE_FLAGS = 'RESET_FEATURE_FLAGS'
@@ -57,6 +58,24 @@ export const getFlags = () => async (
     dispatch(setFlags(RemoteDataState.Done, resp.data))
 
     return resp.data
+  } catch (error) {
+    console.error(error)
+    dispatch(setFlags(RemoteDataState.Error, null))
+  }
+}
+
+export const getPublicFlags = () => async (dispatch: Dispatch<Actions>) => {
+  try {
+    dispatch(setFlags(RemoteDataState.Loading))
+    const url = `${getAPIBasepath()}/api/v2private/flags`
+    const response = await fetch(url)
+    const flags = await response.json()
+
+    if (flags?.status && flags?.status !== 200) {
+      throw new Error(flags.message)
+    }
+
+    dispatch(setFlags(RemoteDataState.Done, flags))
   } catch (error) {
     console.error(error)
     dispatch(setFlags(RemoteDataState.Error, null))

--- a/src/shared/actions/flags.ts
+++ b/src/shared/actions/flags.ts
@@ -1,10 +1,13 @@
-import {FlagMap} from 'src/shared/reducers/flags'
 import {RemoteDataState} from 'src/types'
 export const SET_FEATURE_FLAGS = 'SET_FEATURE_FLAGS'
 export const SET_PUBLIC_FEATURE_FLAGS = 'SET_PUBLIC_FEATURE_FLAGS'
 export const RESET_FEATURE_FLAGS = 'RESET_FEATURE_FLAGS'
 export const CLEAR_FEATURE_FLAG_OVERRIDES = 'CLEAR_FEATURE_FLAG_OVERRIDES'
 export const SET_FEATURE_FLAG_OVERRIDE = 'SET_FEATURE_FLAG_OVERRIDE'
+
+export interface FlagMap {
+  [key: string]: string | boolean
+}
 
 export type Actions =
   | ReturnType<typeof setFlags>

--- a/src/shared/actions/flags.ts
+++ b/src/shared/actions/flags.ts
@@ -1,7 +1,4 @@
-import {Dispatch} from 'redux'
-import {getFlags as getFlagsRequest} from 'src/client'
 import {FlagMap} from 'src/shared/reducers/flags'
-import {getAPIBasepath} from 'src/utils/basepath'
 import {RemoteDataState} from 'src/types'
 export const SET_FEATURE_FLAGS = 'SET_FEATURE_FLAGS'
 export const SET_PUBLIC_FEATURE_FLAGS = 'SET_PUBLIC_FEATURE_FLAGS'
@@ -53,39 +50,3 @@ export const setOverride = (flag: string, value: string | boolean) =>
       [flag]: value,
     },
   } as const)
-
-export const getFlags = () => async (
-  dispatch: Dispatch<Actions>
-): Promise<FlagMap> => {
-  try {
-    dispatch(setFlags(RemoteDataState.Loading))
-    const resp = await getFlagsRequest({})
-
-    if (resp.status !== 200) {
-      throw new Error(resp.data.message)
-    }
-
-    dispatch(setFlags(RemoteDataState.Done, resp.data))
-
-    return resp.data
-  } catch (error) {
-    console.error(error)
-    dispatch(setFlags(RemoteDataState.Error, null))
-  }
-}
-
-export const getPublicFlags = () => async (dispatch: Dispatch<Actions>) => {
-  try {
-    const url = `${getAPIBasepath()}/api/v2private/flags`
-    const response = await fetch(url)
-    const flags = await response.json()
-
-    if (flags?.status && flags?.status !== 200) {
-      throw new Error(flags.message)
-    }
-
-    dispatch(setPublicFlags(flags))
-  } catch (error) {
-    console.error(error)
-  }
-}

--- a/src/shared/containers/GetFlags.tsx
+++ b/src/shared/containers/GetFlags.tsx
@@ -11,7 +11,7 @@ import {SpinnerContainer, TechnoSpinner} from '@influxdata/clockface'
 import {RemoteDataState, AppState} from 'src/types'
 
 // Actions
-import {getFlags} from 'src/shared/actions/flags'
+import {getFlags} from 'src/shared/thunks/flags'
 
 // Utils
 import {activeFlags} from 'src/shared/selectors/flags'

--- a/src/shared/reducers/flags.ts
+++ b/src/shared/reducers/flags.ts
@@ -5,12 +5,9 @@ import {
   RESET_FEATURE_FLAGS,
   CLEAR_FEATURE_FLAG_OVERRIDES,
   SET_FEATURE_FLAG_OVERRIDE,
+  FlagMap,
 } from 'src/shared/actions/flags'
 import {RemoteDataState} from 'src/types'
-
-export interface FlagMap {
-  [key: string]: string | boolean
-}
 
 export interface FlagState {
   status: RemoteDataState

--- a/src/shared/reducers/flags.ts
+++ b/src/shared/reducers/flags.ts
@@ -1,6 +1,7 @@
 import {
   Actions,
   SET_FEATURE_FLAGS,
+  SET_PUBLIC_FEATURE_FLAGS,
   RESET_FEATURE_FLAGS,
   CLEAR_FEATURE_FLAG_OVERRIDES,
   SET_FEATURE_FLAG_OVERRIDE,
@@ -42,6 +43,23 @@ export default (state = defaultState, action: Actions): FlagState => {
       return {
         ...state,
         status: action.payload.status,
+        original: action.payload.flags,
+      }
+    case SET_PUBLIC_FEATURE_FLAGS:
+      // just setting the loading state
+      if (!action.payload.flags) {
+        const newState = {
+          ...state,
+        }
+
+        if (!state.hasOwnProperty('original')) {
+          newState.original = defaultState.original
+        }
+
+        return newState
+      }
+      return {
+        ...state,
         original: action.payload.flags,
       }
     case RESET_FEATURE_FLAGS:

--- a/src/shared/selectors/flags.ts
+++ b/src/shared/selectors/flags.ts
@@ -1,5 +1,5 @@
 import {AppState} from 'src/types'
-import {FlagMap} from 'src/shared/reducers/flags'
+import {FlagMap} from 'src/shared/actions/flags'
 import {CLOUD, CLOUD_BILLING_VISIBLE} from 'src/shared/constants'
 
 export const OSS_FLAGS = {

--- a/src/shared/thunks/flags.ts
+++ b/src/shared/thunks/flags.ts
@@ -1,0 +1,38 @@
+import {Dispatch} from 'redux'
+import {getFlags as getFlagsRequest} from 'src/client'
+import {FlagMap} from 'src/shared/reducers/flags'
+import {getAPIBasepath} from 'src/utils/basepath'
+import {RemoteDataState} from 'src/types'
+import {Actions, setFlags, setPublicFlags} from 'src/shared/actions/flags'
+
+export const getFlags = () => async (
+  dispatch: Dispatch<Actions>
+): Promise<FlagMap> => {
+  try {
+    dispatch(setFlags(RemoteDataState.Loading))
+    const resp = await getFlagsRequest({})
+
+    if (resp.status !== 200) {
+      throw new Error(resp.data.message)
+    }
+
+    dispatch(setFlags(RemoteDataState.Done, resp.data))
+
+    return resp.data
+  } catch (error) {
+    console.error(error)
+    dispatch(setFlags(RemoteDataState.Error, null))
+  }
+}
+
+export const getPublicFlags = () => async (dispatch: Dispatch<Actions>) => {
+  const url = `${getAPIBasepath()}/api/v2private/flags`
+  const response = await fetch(url)
+  const flags = await response.json()
+
+  if (flags?.status && flags?.status !== 200) {
+    throw new Error(flags.message)
+  }
+
+  dispatch(setPublicFlags(flags))
+}

--- a/src/shared/thunks/flags.ts
+++ b/src/shared/thunks/flags.ts
@@ -1,6 +1,6 @@
 import {Dispatch} from 'redux'
 import {getFlags as getFlagsRequest} from 'src/client'
-import {FlagMap} from 'src/shared/reducers/flags'
+import {FlagMap} from 'src/shared/actions/flags'
 import {getAPIBasepath} from 'src/utils/basepath'
 import {RemoteDataState} from 'src/types'
 import {Actions, setFlags, setPublicFlags} from 'src/shared/actions/flags'


### PR DESCRIPTION
This PR aims to integrate the pre-authenticated feature flagged routes for the UI. Yesterday, a similar PR caused our feature flags to fall apart. The reason for this was because the thunk I had developed was using the existing `getFlags` as a basis for comparison. This ended up causing an incident whereby the initial setting of the public flags was setting the status of the flags to loading, thereby bypassing the original authenticated `getFlags` request, which is only requested when the `status` of the `flags` are `RemoteDataState.NotStarted`. Since the `getFlags` were never called, the authenticated feature flags were never being set. I'd be happy to go over this in more detail and would be happy to pair with anyone who knows / can think of a way to test this out before merging it in