### PR TITLE
fix: maps in notebooks

### DIFF
--- a/src/visualization/types/Map/view.tsx
+++ b/src/visualization/types/Map/view.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FC, useEffect, useState} from 'react'
 import {Plot} from '@influxdata/giraffe'
-import {RemoteDataState} from '@influxdata/clockface'
+import {RemoteDataState, InfluxColors} from '@influxdata/clockface'
 
 // Types
 import {GeoViewProperties} from 'src/types'
@@ -87,7 +87,7 @@ const GeoPlot: FC<Props> = ({result, properties}) => {
 
   if (mapServiceError === RemoteDataState.Error) {
     error =
-      'Map type is having issues connecting to the server. Please try again later.'
+      'We are having issues connecting to the Maps Server. Please try again later'
 
     return (
       <div className="panel-resizer--error" data-testid="geoplot-error">
@@ -96,7 +96,7 @@ const GeoPlot: FC<Props> = ({result, properties}) => {
     )
   } else if (coordinateError === RemoteDataState.Error) {
     error =
-      'Map type is not supported with the data provided: Missing latitude/longitude values (field values must be specified to lat or lon)'
+      'Map type is not supported with the data provided. Map type only supports latitude/longitude values (field values must be specified to either lat or lon)'
 
     return (
       <div className="panel-resizer--error" data-testid="geoplot-error">
@@ -109,6 +109,28 @@ const GeoPlot: FC<Props> = ({result, properties}) => {
     bingKey: '',
   }
 
+  let layersOpts = layers
+  if (!layers.length) {
+    layersOpts = [
+      {
+        type: 'pointMap',
+        colorDimension: {label: 'Value'},
+        colorField: '_value',
+        colors: [
+          {type: 'min', hex: InfluxColors.Star},
+          {value: 50, hex: InfluxColors.Star},
+          {type: 'max', hex: InfluxColors.Star},
+        ],
+        isClustered: false,
+      },
+    ]
+  }
+
+  let zoomOpt = zoom
+  if (zoom === 0) {
+    zoomOpt = 6
+  }
+
   return (
     <Plot
       config={{
@@ -119,11 +141,11 @@ const GeoPlot: FC<Props> = ({result, properties}) => {
             type: 'geo',
             lat: geoCoordinates.lat,
             lon: geoCoordinates.lon,
-            zoom,
+            zoom: zoomOpt,
             allowPanAndZoom,
             detectCoordinateFields: coordinateFieldsFlag,
             mapStyle,
-            layers,
+            layers: layersOpts,
             tileServerConfiguration: tileServerConfiguration,
           },
         ],


### PR DESCRIPTION
Closes #866 #1228

<!-- Describe your proposed changes here. -->
When viewing maps for visualization on Notebooks/Flows, the maps weren't rendering because the properties we were sending to giraffe are the defaults (with empty layers) and not the ones we use in Data explorer.
