### PR TITLE
fix: improved annotation start time input behavior

### DIFF
--- a/src/annotations/components/annotationForm/AnnotationStartTimeInput.tsx
+++ b/src/annotations/components/annotationForm/AnnotationStartTimeInput.tsx
@@ -18,7 +18,6 @@ interface Props {
 }
 
 export const AnnotationStartTimeInput: FC<Props> = (props: Props) => {
-  // initial input value is the startTime passed
   const [startTimeValue, setStartTimeValue] = useState<string>(
     moment(props.startTime).format('YYYY-MM-DD HH:mm:ss.SSS')
   )

--- a/src/annotations/components/annotationForm/AnnotationStartTimeInput.tsx
+++ b/src/annotations/components/annotationForm/AnnotationStartTimeInput.tsx
@@ -18,7 +18,6 @@ interface Props {
 }
 
 export const AnnotationStartTimeInput: FC<Props> = (props: Props) => {
-
   // initial input value is the startTime passed
   const [inputValue, setInputValue] = useState<string>(
     moment(props.startTime).format('YYYY-MM-DD HH:mm:ss.SSS')

--- a/src/annotations/components/annotationForm/AnnotationStartTimeInput.tsx
+++ b/src/annotations/components/annotationForm/AnnotationStartTimeInput.tsx
@@ -45,7 +45,7 @@ export const AnnotationStartTimeInput: FC<Props> = (props: Props) => {
     }
   }
 
-  const isInputValueValid = (inputValue: string): boolean => {
+  const isValidInputValue = (inputValue: string): boolean => {
     if (inputValue === null) {
       return true
     }
@@ -54,7 +54,7 @@ export const AnnotationStartTimeInput: FC<Props> = (props: Props) => {
   }
 
   const getInputValidationMessage = (): string => {
-    if (!isInputValueValid(startTimeValue)) {
+    if (!isValidInputValue(startTimeValue)) {
       return 'Format must be YYYY-MM-DD [HH:mm:ss.SSS]'
     }
 

--- a/src/annotations/components/annotationForm/AnnotationStartTimeInput.tsx
+++ b/src/annotations/components/annotationForm/AnnotationStartTimeInput.tsx
@@ -23,8 +23,8 @@ export const AnnotationStartTimeInput: FC<Props> = (props: Props) => {
     moment(props.startTime).format('YYYY-MM-DD HH:mm:ss.SSS')
   )
 
-  const isValidTimeFormat = (d: string): boolean => {
-    return moment(d, 'YYYY-MM-DD HH:mm:ss.SSS', true).isValid()
+  const isValidTimeFormat = (inputValue: string): boolean => {
+    return moment(inputValue, 'YYYY-MM-DD HH:mm:ss.SSS', true).isValid()
   }
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {

--- a/src/annotations/components/annotationForm/AnnotationStartTimeInput.tsx
+++ b/src/annotations/components/annotationForm/AnnotationStartTimeInput.tsx
@@ -19,7 +19,7 @@ interface Props {
 
 export const AnnotationStartTimeInput: FC<Props> = (props: Props) => {
   // initial input value is the startTime passed
-  const [inputValue, setInputValue] = useState<string>(
+  const [startTimeValue, setStartTimeValue] = useState<string>(
     moment(props.startTime).format('YYYY-MM-DD HH:mm:ss.SSS')
   )
 
@@ -28,7 +28,7 @@ export const AnnotationStartTimeInput: FC<Props> = (props: Props) => {
   }
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setInputValue(event.target.value)
+    setStartTimeValue(event.target.value)
 
     if (isValidTimeFormat(event.target.value)) {
       props.onChange(
@@ -46,23 +46,23 @@ export const AnnotationStartTimeInput: FC<Props> = (props: Props) => {
     }
   }
 
-  const isInputValueInvalid = (): boolean => {
+  const isInputValueValid = (inputValue: string): boolean => {
     if (inputValue === null) {
-      return false
+      return true
     }
 
-    return !isValidTimeFormat(inputValue)
+    return isValidTimeFormat(inputValue)
   }
 
-  const inputErrorMessage = (): string | undefined => {
-    if (isInputValueInvalid()) {
+  const getInputValidationMessage = (): string => {
+    if (!isInputValueValid(startTimeValue)) {
       return 'Format must be YYYY-MM-DD [HH:mm:ss.SSS]'
     }
 
-    return '\u00a0\u00a0'
+    return ''
   }
 
-  const validationMessage = inputErrorMessage()
+  const validationMessage = getInputValidationMessage()
 
   return (
     <Grid.Column widthXS={Columns.Twelve}>
@@ -73,7 +73,7 @@ export const AnnotationStartTimeInput: FC<Props> = (props: Props) => {
       >
         <Input
           name="startTime"
-          value={inputValue}
+          value={startTimeValue}
           onChange={handleChange}
           onKeyPress={handleKeyPress}
           status={ComponentStatus.Default}

--- a/src/annotations/components/annotationForm/AnnotationStartTimeInput.tsx
+++ b/src/annotations/components/annotationForm/AnnotationStartTimeInput.tsx
@@ -1,5 +1,6 @@
 // Libraries
-import React, {FC, ChangeEvent, KeyboardEvent} from 'react'
+import React, {FC, ChangeEvent, KeyboardEvent, useState} from 'react'
+import moment from 'moment'
 
 // Components
 import {
@@ -17,10 +18,26 @@ interface Props {
 }
 
 export const AnnotationStartTimeInput: FC<Props> = (props: Props) => {
-  const validationMessage = props.startTime ? '' : 'This field is required'
+
+  // initial input value is the startTime passed
+  const [inputValue, setInputValue] = useState<string>(
+    moment(props.startTime).format('YYYY-MM-DD HH:mm:ss.SSS')
+  )
+
+  const isValidTimeFormat = (d: string): boolean => {
+    return moment(d, 'YYYY-MM-DD HH:mm:ss.SSS', true).isValid()
+  }
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    props.onChange(event.target.value)
+    setInputValue(event.target.value)
+
+    if (isValidTimeFormat(event.target.value)) {
+      props.onChange(
+        moment(event.target.value)
+          .toDate()
+          .toISOString()
+      )
+    }
   }
 
   const handleKeyPress = (event: KeyboardEvent<HTMLInputElement>) => {
@@ -29,6 +46,24 @@ export const AnnotationStartTimeInput: FC<Props> = (props: Props) => {
       return
     }
   }
+
+  const isInputValueInvalid = (): boolean => {
+    if (inputValue === null) {
+      return false
+    }
+
+    return !isValidTimeFormat(inputValue)
+  }
+
+  const inputErrorMessage = (): string | undefined => {
+    if (isInputValueInvalid()) {
+      return 'Format must be YYYY-MM-DD [HH:mm:ss.SSS]'
+    }
+
+    return '\u00a0\u00a0'
+  }
+
+  const validationMessage = inputErrorMessage()
 
   return (
     <Grid.Column widthXS={Columns.Twelve}>
@@ -39,7 +74,7 @@ export const AnnotationStartTimeInput: FC<Props> = (props: Props) => {
       >
         <Input
           name="startTime"
-          value={new Date(props.startTime).toString()}
+          value={inputValue}
           onChange={handleChange}
           onKeyPress={handleKeyPress}
           status={ComponentStatus.Default}


### PR DESCRIPTION
To address https://github.com/influxdata/ui/issues/1266, I propose that we make the input field behave similar to the one we have in the date picker. It adds consistency across the app. This PR introduces that.

The behavior is as follows:

The input field makes sure that the time entered is in the format: `YYYY-MM-DD HH:mm:ss.SSS`. If it isn't, it shows an error with a message that shows what the format needs to be. 

Notes for the reviewer: 

* I am using the `moment` library to achieve formatting, we're already using it for the date picker component. If that is something we want to move away from, I can explore ways to achieve it using the default `Date` library.

* I can also add the form validation behavior, i.e. the save button is only enabled when the format in the input field is valid, if this is a way we want to move forward. 

Video:

https://user-images.githubusercontent.com/18511823/115783064-42a9fa80-a371-11eb-8b72-d91d3a4c2b83.mov


