### PR TITLE
feat: integration with notebooksd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ src/client/generatedRoutes.ts
 src/client/unityRoutes.ts
 src/client/flowsRoutes.ts
 src/client/managedFunctionsRoutes.ts
+src/client/notebooksRoutes.ts

--- a/package.json
+++ b/package.json
@@ -50,9 +50,10 @@
     "cy": "CYPRESS_baseUrl=http://localhost:9999 cypress open",
     "cy:dev": "source ../monitor-ci/.env && CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{cloud,shared}/**/*.*'",
     "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{oss,shared}/**/*.*'",
-    "generate": "oats https://raw.githubusercontent.com/influxdata/influxdb/master/http/swagger.yml > ./src/client/generatedRoutes.ts && yarn unity && yarn flows && yarn managedFunctions",
+    "generate": "oats https://raw.githubusercontent.com/influxdata/influxdb/master/http/swagger.yml > ./src/client/generatedRoutes.ts && yarn unity && yarn flows && yarn notebooks && yarn managedFunctions",
     "unity": "oats ./src/client/swagger/unity.yml > ./src/client/unityRoutes.ts",
     "flows": "oats ./src/client/swagger/flows.yml > ./src/client/flowsRoutes.ts",
+    "notebooks": "oats ./src/client/swagger/notebooks.yml > ./src/client/notebooksRoutes.ts",
     "managedFunctions": "oats ./src/client/swagger/managedFunctions.yml > ./src/client/managedFunctionsRoutes.ts"
   },
   "author": "",

--- a/src/client/swagger/notebooks.yml
+++ b/src/client/swagger/notebooks.yml
@@ -1,0 +1,200 @@
+openapi: 3.0.0
+info:
+  title: notebooksd
+  version: 1.0.0
+servers:
+  - url: http://localhost:8618
+    description: local development server
+  - url: https://https://twodotoh.a.influxcloud.dev.local:8618
+    description: k8s-idpe local development server
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  requestBodies:
+    NotebookParams:
+      description: Notebook record
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/NotebookParams'
+  schemas:
+    NotebookParams:
+      properties:
+        name:
+          type: string
+        orgID:
+          type: string
+        spec:
+          type: object
+    Notebook:
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        orgID:
+          type: string
+        spec:
+          type: object
+        createdAt:
+          type: date-time
+        updatedAt:
+          type: date-time
+    NotebookArray:
+      type: array
+      items:
+        $ref: '#/components/schemas/Notebook'
+    Notebooks:
+      properties:
+        flows:
+          type: array
+          items:
+            $ref: '#/components/schemas/Notebook'
+security:
+  - bearerAuth: []
+paths:
+  /notebooks:
+    get:
+      description: get all records
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: all records
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Notebooks'
+        '401':
+          description: unauthorized, no token or invalid token provided
+        '403':
+          description: unauthorized, token with invalid permissions provided
+        '500':
+          description: an internal error has occured
+    post:
+      description: creates a record
+      requestBody:
+        $ref: '#/components/requestBodies/NotebookParams'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: returns the id of the new record
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Notebook'
+        '401':
+          description: unauthorized, no token or invalid token provided
+        '403':
+          description: unauthorized, token with invalid permissions provided
+        '500':
+          description: an internal error has occured
+  '/notebooks/{id}':
+    get:
+      description: get single record by its ID
+      parameters:
+        - name: id
+          in: path
+          type: string
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: returns the record
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Notebook'
+        '401':
+          description: unauthorized, no token or invalid token provided
+        '403':
+          description: unauthorized, token with invalid permissions provided
+        '500':
+          description: an internal error has occured
+    delete:
+      description: deletes a single record by its ID
+      parameters:
+        - name: id
+          in: path
+          type: string
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: record deleted
+        '401':
+          description: unauthorized, no token or invalid token provided
+        '403':
+          description: unauthorized, token with invalid permissions provided
+        '500':
+          description: an internal error has occured
+    put:
+      description: update a single record by its ID
+      parameters:
+        - name: id
+          in: path
+          type: string
+      requestBody:
+        $ref: '#/components/requestBodies/NotebookParams'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: returns the record
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Notebook'
+        '401':
+          description: unauthorized, no token or invalid token provided
+        '403':
+          description: unauthorized, token with invalid permissions provided
+        '500':
+          description: an internal error has occured
+    patch:
+      description: update a single record by its ID
+      parameters:
+        - name: id
+          in: path
+          type: string
+      requestBody:
+        $ref: '#/components/requestBodies/NotebookParams'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: returns the record
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Notebook'
+        '401':
+          description: unauthorized, no token or invalid token provided
+        '403':
+          description: unauthorized, token with invalid permissions provided
+        '500':
+          description: an internal error has occured
+  /health:
+    get:
+      description: get the health of this service
+      security: []
+      responses:
+        '200':
+          description: service is up
+  /ready:
+    get:
+      description: returns whether the cluster of services are ready to rock 'n roll
+      security: []
+      responses:
+        '200':
+          description: services are ready
+        '500':
+          description: db reporting not ready
+        '503':
+          description: pm2 reporting services are not ready
+tags: []

--- a/src/client/swagger/notebooks.yml
+++ b/src/client/swagger/notebooks.yml
@@ -3,10 +3,7 @@ info:
   title: notebooksd
   version: 1.0.0
 servers:
-  - url: http://localhost:8618
-    description: local development server
-  - url: https://https://twodotoh.a.influxcloud.dev.local:8618
-    description: k8s-idpe local development server
+  - url: /api/v2
 components:
   securitySchemes:
     bearerAuth:

--- a/src/flows/context/notebooks.api.tsx
+++ b/src/flows/context/notebooks.api.tsx
@@ -1,0 +1,115 @@
+import {
+  PatchNotebookParams,
+  patchNotebook,
+  PostNotebookParams,
+  postNotebook,
+  DeleteNotebookParams,
+  deleteNotebook,
+  getNotebooks,
+} from 'src/client/notebooksRoutes'
+import {notebookUpdateFail} from 'src/shared/copy/notifications'
+import {notify} from 'src/shared/actions/notifications'
+
+const DEFAULT_API_FLOW: PatchNotebookParams = {
+  id: '',
+  data: {},
+}
+let stagedFlow: PatchNotebookParams = DEFAULT_API_FLOW
+let reportDecayTimeout = null
+let reportMaxTimeout = null
+
+const REPORT_DECAY = 500 // number of miliseconds to wait after last event before sending
+const REPORT_MAX_WAIT = 5000 // max number of miliseconds to wait between sends
+
+export const pooledUpdateAPI = (flow: PatchNotebookParams) => {
+  stagedFlow = flow
+
+  if (!!reportDecayTimeout) {
+    clearTimeout(reportDecayTimeout)
+    reportDecayTimeout = null
+  }
+
+  if (!reportMaxTimeout) {
+    reportMaxTimeout = setTimeout(() => {
+      reportMaxTimeout = null
+
+      // flow already synced
+      if (stagedFlow === DEFAULT_API_FLOW) {
+        return
+      }
+
+      clearTimeout(reportDecayTimeout)
+      reportDecayTimeout = null
+      updateAPI(stagedFlow)
+
+      stagedFlow = DEFAULT_API_FLOW
+    }, REPORT_MAX_WAIT)
+  }
+
+  reportDecayTimeout = setTimeout(() => {
+    updateAPI(stagedFlow)
+
+    stagedFlow = DEFAULT_API_FLOW
+  }, REPORT_DECAY)
+}
+
+export const updateAPI = async (flow: PatchNotebookParams) => {
+  const res = await patchNotebook(flow)
+  if (res.status != 200) {
+    throw new Error(res.data.message)
+  }
+}
+
+export const createAPI = async (flow: PostNotebookParams) => {
+  const res = await postNotebook(flow)
+  if (res.status != 200) {
+    throw new Error(res.data.message)
+  }
+  return res.data.id
+}
+
+export const deleteAPI = async (ids: DeleteNotebookParams) => {
+  const res = await deleteNotebook(ids)
+  if (res.status != 200) {
+    throw new Error(res.data.message)
+  }
+}
+
+export const getAllAPI = async (orgID: string) => {
+  const res = await getNotebooks({orgID})
+  if (res.status != 200) {
+    throw new Error(res.data.message)
+  }
+  return res.data
+}
+
+export const migrateLocalFlowsToAPI = async (
+  orgID: string,
+  flows: {},
+  serialize: Function,
+  dispatch: Function
+) => {
+  const localFlows = Object.keys(flows).filter(id => id.includes('local'))
+  if (localFlows.length) {
+    await Promise.all(
+      localFlows.map(async localID => {
+        const flow = flows[localID]
+        const apiFlow: PostNotebookParams = {
+          data: {
+            orgID: orgID,
+            name: flow.name,
+            spec: serialize(flow),
+          },
+        }
+        const id = await createAPI(apiFlow)
+        delete flows[localID]
+        flows[id] = flow
+      })
+    ).catch(() => {
+      // do not throw the error because some flows might have saved and we
+      // need to save the new IDs to avoid creating duplicates next time.
+      dispatch(notify(notebookUpdateFail()))
+    })
+  }
+  return flows
+}


### PR DESCRIPTION
https://github.com/influxdata/idpe/issues/9806

Adds integration with `notebooksd` behind an unofficial feature flag called `notebooks-api`.

- adds `notebooks.yml` swagger
- adds `notebooks.api.tsx` which is identical to `api.tsx` for flows, but uses `notebooks.yml` swagger

To use this flag you'll first need to enable `notebooksd` in k8s-idpe locally by flipping this flag: https://github.com/influxdata/k8s-idpe/blob/3f0b5eb24b144802b62e425caae1dfd7706993a7/env/test/local/twodotoh-dev/conf.libsonnet#L221