### PR TITLE
fix(unity) Define errors for checkout and payment form

### DIFF
--- a/src/client/swagger/unity.yml
+++ b/src/client/swagger/unity.yml
@@ -730,14 +730,8 @@ paths:
             schema:
               $ref: '#/components/schemas/CheckoutRequest'
       responses:
-        '204':
-          description: Account upgraded
-        default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+        '201':
+          description: Created
         '400':
           description: Bad Request
           content:
@@ -756,6 +750,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   '/cancel':
     post:
       operationId: PostCancel

--- a/src/client/swagger/unity.yml
+++ b/src/client/swagger/unity.yml
@@ -738,6 +738,24 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        '404':
+          description: Org/User not found or Beta region
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   '/cancel':
     post:
       operationId: PostCancel

--- a/src/client/swagger/unity.yml
+++ b/src/client/swagger/unity.yml
@@ -266,9 +266,9 @@ paths:
           required: true
           schema:
             type: string
-            enum: [checkout_form, billing_form]
+            enum: [checkout, billing]
           description: The name of the PaymentForm to query.
-          example: 'checkout_form'
+          example: 'checkout'
       responses:
         '200':
           description: A CreditCard Form parameter object
@@ -290,6 +290,12 @@ paths:
                 $ref: "#/components/schemas/Error"
         '404':
           description: User or Form not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        '406':
+          description: Not Acceptable
           content:
             application/json:
               schema:

--- a/src/client/swagger/unity.yml
+++ b/src/client/swagger/unity.yml
@@ -255,11 +255,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  '/payment/form':
+  '/payment_form/{form}':
     get:
       operationId: GetPaymentForm
       tags:
         - PaymentGateway
+      parameters:
+        - in: path
+          name: form
+          required: true
+          schema:
+            type: string
+            enum: [checkout_form, billing_form]
+          description: The name of the PaymentForm to query.
+          example: 'checkout_form'
       responses:
         '200':
           description: A CreditCard Form parameter object
@@ -267,6 +276,24 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CreditCardParams'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        '404':
+          description: User or Form not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         default:
           description: Unexpected error
           content:
@@ -364,12 +391,12 @@ paths:
               schema:
                 type: string
                 format: binary
-      default:
-        description: Unexpected error
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Error'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   '/orgs/{orgId}/invites':
     get:
       operationId: GetInvites


### PR DESCRIPTION
- Updated happy path response for `POST /checkout` to `201` 
- Defined errors for `POST /checkout`
- Updated path for `GET /payment_form/{form}` to include `form` parameter
- Defined errors for `GET /payment_form/{form}`
