### PR TITLE
feat: add button to edit manually entered line protocol data.

### DIFF
--- a/src/buckets/components/context/lineProtocol.tsx
+++ b/src/buckets/components/context/lineProtocol.tsx
@@ -19,6 +19,7 @@ export type Props = {
 export interface LineProtocolContextType {
   body: string
   handleResetLineProtocol: () => void
+  handleTryAgainLineProtocol: () => void
   handleSetBody: (_: string) => void
   handleSetTab: (tab: LineProtocolTab) => void
   precision: WritePrecision
@@ -32,6 +33,7 @@ export interface LineProtocolContextType {
 export const DEFAULT_CONTEXT: LineProtocolContextType = {
   body: '',
   handleResetLineProtocol: () => {},
+  handleTryAgainLineProtocol: () => {},
   handleSetBody: (_: string) => {},
   handleSetTab: (_: LineProtocolTab) => {},
   precision: WritePrecision.Ns,
@@ -57,6 +59,11 @@ export const LineProtocolProvider: FC<Props> = React.memo(({children}) => {
 
   const handleResetLineProtocol = () => {
     setBody('')
+    setWriteStatus(RemoteDataState.NotStarted)
+    setWriteError('')
+  }
+
+  const handleTryAgainLineProtocol = () => {
     setWriteStatus(RemoteDataState.NotStarted)
     setWriteError('')
   }
@@ -120,6 +127,7 @@ export const LineProtocolProvider: FC<Props> = React.memo(({children}) => {
         body,
         handleSetBody,
         handleResetLineProtocol,
+        handleTryAgainLineProtocol,
         handleSetTab,
         precision,
         setPrecision,

--- a/src/buckets/components/lineProtocol/EnterManuallyButtons.tsx
+++ b/src/buckets/components/lineProtocol/EnterManuallyButtons.tsx
@@ -23,6 +23,7 @@ const EnterManuallyButtons: FC = () => {
   const {
     body,
     handleResetLineProtocol,
+    handleTryAgainLineProtocol,
     writeLineProtocol,
     writeStatus,
   } = useContext(LineProtocolContext)
@@ -45,14 +46,24 @@ const EnterManuallyButtons: FC = () => {
 
   if (writeStatus === RemoteDataState.Error) {
     return (
-      <Button
-        color={ComponentColor.Default}
-        text="Cancel"
-        size={ComponentSize.Medium}
-        type={ButtonType.Button}
-        onClick={handleResetLineProtocol}
-        testID="lp-cancel--button"
-      />
+        <>
+          <Button
+              color={ComponentColor.Default}
+              text="Edit"
+              size={ComponentSize.Medium}
+              type={ButtonType.Button}
+              onClick={handleTryAgainLineProtocol}
+              testID="lp-edit--button"
+          />
+          <Button
+              color={ComponentColor.Default}
+              text="Clear"
+              size={ComponentSize.Medium}
+              type={ButtonType.Button}
+              onClick={handleResetLineProtocol}
+              testID="lp-cancel--button"
+          />
+        </>
     )
   }
 

--- a/src/buckets/components/lineProtocol/EnterManuallyButtons.tsx
+++ b/src/buckets/components/lineProtocol/EnterManuallyButtons.tsx
@@ -46,24 +46,24 @@ const EnterManuallyButtons: FC = () => {
 
   if (writeStatus === RemoteDataState.Error) {
     return (
-        <>
-          <Button
-              color={ComponentColor.Default}
-              text="Edit"
-              size={ComponentSize.Medium}
-              type={ButtonType.Button}
-              onClick={handleTryAgainLineProtocol}
-              testID="lp-edit--button"
-          />
-          <Button
-              color={ComponentColor.Default}
-              text="Clear"
-              size={ComponentSize.Medium}
-              type={ButtonType.Button}
-              onClick={handleResetLineProtocol}
-              testID="lp-cancel--button"
-          />
-        </>
+      <>
+        <Button
+          color={ComponentColor.Default}
+          text="Edit"
+          size={ComponentSize.Medium}
+          type={ButtonType.Button}
+          onClick={handleTryAgainLineProtocol}
+          testID="lp-edit--button"
+        />
+        <Button
+          color={ComponentColor.Default}
+          text="Clear"
+          size={ComponentSize.Medium}
+          type={ButtonType.Button}
+          onClick={handleResetLineProtocol}
+          testID="lp-cancel--button"
+        />
+      </>
     )
   }
 


### PR DESCRIPTION
Closes #307 

Adds button to let users edit manually entered line protocol data on error page.

Kept a clear button in case that use case was important for any of our users.

Works like this:
![Peek 2021-04-23 16-48](https://user-images.githubusercontent.com/22055730/115928502-30ed5380-a454-11eb-876d-3198e8243952.gif)

