### PR TITLE
fix: make the dispatch async; add await for create and edit annotation forms

### DIFF
--- a/src/annotations/components/EditAnnotationOverlay.tsx
+++ b/src/annotations/components/EditAnnotationOverlay.tsx
@@ -33,15 +33,15 @@ export const EditAnnotationOverlay: FC = () => {
   const dispatch = useDispatch()
   const {clickedAnnotation} = useSelector(getOverlayParams)
 
-  const handleSubmit = (editedAnnotation: EditAnnotation): void => {
+  const handleSubmit = async (editedAnnotation: EditAnnotation): Promise<void> => {
     try {
-      dispatch(editAnnotation(editedAnnotation))
+      await dispatch(editAnnotation(editedAnnotation))
       event('xyplot.annotations.edit_annotation.success')
       dispatch(notify(editAnnotationSuccess()))
       onClose()
     } catch (err) {
       event('xyplot.annotations.edit_annotation.failure')
-      dispatch(notify(editAnnotationFailed(err)))
+      dispatch(notify(editAnnotationFailed(err.response.data.message)))
     }
   }
 

--- a/src/annotations/components/EditAnnotationOverlay.tsx
+++ b/src/annotations/components/EditAnnotationOverlay.tsx
@@ -33,7 +33,9 @@ export const EditAnnotationOverlay: FC = () => {
   const dispatch = useDispatch()
   const {clickedAnnotation} = useSelector(getOverlayParams)
 
-  const handleSubmit = async (editedAnnotation: EditAnnotation): Promise<void> => {
+  const handleSubmit = async (
+    editedAnnotation: EditAnnotation
+  ): Promise<void> => {
     try {
       await dispatch(editAnnotation(editedAnnotation))
       event('xyplot.annotations.edit_annotation.success')

--- a/src/annotations/components/EditAnnotationOverlay.tsx
+++ b/src/annotations/components/EditAnnotationOverlay.tsx
@@ -33,6 +33,10 @@ export const EditAnnotationOverlay: FC = () => {
   const dispatch = useDispatch()
   const {clickedAnnotation} = useSelector(getOverlayParams)
 
+  const getErrorMessage = (err: any): string | any => {
+    return err.response?.data?.message || err
+  }
+
   const handleSubmit = async (
     editedAnnotation: EditAnnotation
   ): Promise<void> => {
@@ -43,7 +47,7 @@ export const EditAnnotationOverlay: FC = () => {
       onClose()
     } catch (err) {
       event('xyplot.annotations.edit_annotation.failure')
-      dispatch(notify(editAnnotationFailed(err.response?.data?.message || err)))
+      dispatch(notify(editAnnotationFailed(getErrorMessage(err))))
     }
   }
 

--- a/src/annotations/components/EditAnnotationOverlay.tsx
+++ b/src/annotations/components/EditAnnotationOverlay.tsx
@@ -27,15 +27,12 @@ import {notify} from 'src/shared/actions/notifications'
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'
+import {getErrorMessage} from 'src/utils/api'
 
 export const EditAnnotationOverlay: FC = () => {
   const {onClose} = useContext(OverlayContext)
   const dispatch = useDispatch()
   const {clickedAnnotation} = useSelector(getOverlayParams)
-
-  const getErrorMessage = (err: any): string | any => {
-    return err.response?.data?.message || err
-  }
 
   const handleSubmit = async (
     editedAnnotation: EditAnnotation

--- a/src/annotations/components/EditAnnotationOverlay.tsx
+++ b/src/annotations/components/EditAnnotationOverlay.tsx
@@ -43,7 +43,7 @@ export const EditAnnotationOverlay: FC = () => {
       onClose()
     } catch (err) {
       event('xyplot.annotations.edit_annotation.failure')
-      dispatch(notify(editAnnotationFailed(err.response.data.message)))
+      dispatch(notify(editAnnotationFailed(err.response?.data?.message || err)))
     }
   }
 

--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -58,6 +58,7 @@ import {
 } from 'src/shared/utils/vis'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {event} from 'src/cloud/utils/reporting'
+import {getErrorMessage} from 'src/utils/api'
 
 // Notifications
 import {createAnnotationFailed} from 'src/shared/copy/notifications'
@@ -181,10 +182,6 @@ const XYPlot: FC<Props> = ({
   }
 
   const makeSingleClickHandler = () => {
-    const getErrorMessage = (err: any): string | any => {
-      return err.response?.data?.message || err
-    }
-
     const createAnnotation = async userModifiedAnnotation => {
       const {message, startTime} = userModifiedAnnotation
       try {

--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -181,6 +181,10 @@ const XYPlot: FC<Props> = ({
   }
 
   const makeSingleClickHandler = () => {
+    const getErrorMessage = (err: any): string | any => {
+      return err.response?.data?.message || err
+    }
+
     const createAnnotation = async userModifiedAnnotation => {
       const {message, startTime} = userModifiedAnnotation
       try {
@@ -196,7 +200,7 @@ const XYPlot: FC<Props> = ({
         )
         event('xyplot.annotations.create_annotation.create')
       } catch (err) {
-        dispatch(notify(createAnnotationFailed(err.response?.data?.message || err)))
+        dispatch(notify(createAnnotationFailed(getErrorMessage(err))))
         event('xyplot.annotations.create_annotation.failure')
       }
     }

--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -196,7 +196,7 @@ const XYPlot: FC<Props> = ({
         )
         event('xyplot.annotations.create_annotation.create')
       } catch (err) {
-        dispatch(notify(createAnnotationFailed(err.response.data.message)))
+        dispatch(notify(createAnnotationFailed(err.response?.data?.message || err)))
         event('xyplot.annotations.create_annotation.failure')
       }
     }

--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -181,10 +181,10 @@ const XYPlot: FC<Props> = ({
   }
 
   const makeSingleClickHandler = () => {
-    const createAnnotation = userModifiedAnnotation => {
+    const createAnnotation = async userModifiedAnnotation => {
       const {message, startTime} = userModifiedAnnotation
       try {
-        dispatch(
+        await dispatch(
           writeThenFetchAndSetAnnotations([
             {
               summary: message,
@@ -196,7 +196,7 @@ const XYPlot: FC<Props> = ({
         )
         event('xyplot.annotations.create_annotation.create')
       } catch (err) {
-        dispatch(notify(createAnnotationFailed(err)))
+        dispatch(notify(createAnnotationFailed(err.response.data.message)))
         event('xyplot.annotations.create_annotation.failure')
       }
     }


### PR DESCRIPTION
Closes #1230 

With our current state of handling the API call, we ship the call to a `dispatch` and this caused the error handling not possible because there was no catcher when the `dispatch` (making an `async` call) threw an error.

This PR makes that try-catch an async block and makes it so that a useful error message is shown on failure.
