### PR TITLE
fix: reload cypress test for edit and delete annotation

### DIFF
--- a/cypress/e2e/cloud/annotations.test.ts
+++ b/cypress/e2e/cloud/annotations.test.ts
@@ -162,6 +162,9 @@ describe('The Annotations UI functionality', () => {
 
     cy.getByTestID('delete-annotation-button').click()
 
+    // reload to make sure the annotation was deleted from the backend as well.
+    cy.reload()
+
     // annotation line should not exist in the dashboard cell
     cy.getByTestID('cell blah').within(() => {
       cy.get('line').should('not.exist')
@@ -195,6 +198,9 @@ describe('The Annotations UI functionality', () => {
       .type('lets edit this annotation...')
 
     cy.getByTestID('edit-annotation-submit-button').click()
+
+    // reload to make sure the annotation was edited in the backend as well.
+    cy.reload()
 
     // annotation tooltip should say the new name
     cy.getByTestID('cell blah').within(() => {

--- a/cypress/e2e/cloud/annotations.test.ts
+++ b/cypress/e2e/cloud/annotations.test.ts
@@ -70,6 +70,9 @@ describe('The Annotations UI functionality', () => {
       cy.getByTestID('add-annotation-submit').click()
     })
 
+    // reload to make sure the annotation was added in the backend as well.
+    cy.reload()
+
     // we need to see if the annotations got created and that the tooltip says "yoho"
     cy.getByTestID('cell blah').within(() => {
       cy.getByTestID('giraffe-inner-plot').trigger('mouseover')
@@ -94,6 +97,9 @@ describe('The Annotations UI functionality', () => {
         .type('im a hippopotamus')
       cy.getByTestID('add-annotation-submit').click()
     })
+
+    // reload to make sure the annotation was added in the backend as well.
+    cy.reload()
 
     // should have the annotation created and the tooltip should says "im a hippopotamus"
     cy.getByTestID('cell blah').within(() => {


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/1193

When the API failed to save our annotations, our tests didn't catch it because they were not checking if the backend actually had the annotation. We add a `cy.reload()` to verify that the change happened in the backend.

### Testing instructions

To test that the test fails when the backend is down / isn't functioning desirably, just do `make stop NODE=postgres` inside the root of `monitor-ci`. This will turn off the server for annotations, and then we can verify that the test fails. 