### PR TITLE
chore: integrate logout functionality for logout in dropdown

### DIFF
--- a/src/pageLayout/components/UserWidget.tsx
+++ b/src/pageLayout/components/UserWidget.tsx
@@ -14,10 +14,12 @@ import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Constants
 import {
+  CLOUD,
   CLOUD_URL,
   CLOUD_USAGE_PATH,
   CLOUD_BILLING_PATH,
   CLOUD_USERS_PATH,
+  CLOUD_SIGNOUT_PATHNAME,
 } from 'src/shared/constants'
 
 // Types
@@ -141,7 +143,16 @@ const UserWidget: FC<Props> = ({
         id="logout"
         label="Logout"
         testID="user-nav-item-logout"
-        linkElement={className => <Link className={className} to="/logout" />}
+        linkElement={className => (
+          <Link
+            className={className}
+            to={
+              CLOUD && isFlagEnabled('authSessionCookieOn')
+                ? CLOUD_SIGNOUT_PATHNAME
+                : '/logout'
+            }
+          />
+        )}
       />
     </TreeNav.User>
   )


### PR DESCRIPTION
This PR updates the logout path for the logout button in the avatar dropdown menu to route the user to the signout path in IDPE, rather than hit the `/logout` endpoint. I think this should resolve the issue that Randy was having with logging out