### PR TITLE
chore: turn on type ahead flag

### DIFF
--- a/cypress/e2e/shared/dashboardsView.test.ts
+++ b/cypress/e2e/shared/dashboardsView.test.ts
@@ -12,12 +12,6 @@ describe('Dashboard', () => {
         })
       })
     )
-
-    cy.window().then(win => {
-      // I hate to add this, but the influx object isn't ready yet
-      cy.wait(1000)
-      win.influx.set(typeAheadFlag, true)
-    })
   })
 
   it("can edit a dashboard's name", () => {

--- a/cypress/e2e/shared/dashboardsView.test.ts
+++ b/cypress/e2e/shared/dashboardsView.test.ts
@@ -841,18 +841,8 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
       })
     })
 
-    // leaving this test to test the non-type ahead dropdown.  with all the reloads the flag setting
-    // is not functional.  plus we need to test the normal one anyone until the typeahead flag is gone.
-    // when that flag goes away, need to update this test!
 
-    // explicitly setting flag to false tho; because previous tests have set it to true.
-    it('ensures that dependent variables load one another accordingly, even with reload and cleared local storage', () => {
-      cy.window().then(win => {
-        // I hate to add this, but the influx object isn't ready yet
-        cy.wait(1000)
-        win.influx.set(typeAheadFlag, false)
-      })
-
+    it.only('ensures that dependent variables load one another accordingly, even with reload and cleared local storage', () => {
       cy.get('@org').then(({id: orgID}: Organization) => {
         cy.createDashboard(orgID).then(({body: dashboard}) => {
           cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
@@ -868,7 +858,7 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
               orgID,
               'dependent',
               `import "influxdata/influxdb/v1"
-          v1.tagValues(bucket: v.static, tag: "container_name") |> keep(columns: ["_value"])`
+            v1.tagValues(bucket: v.static, tag: "container_name") |> keep(columns: ["_value"])`
             )
             cy.createQueryVariable(
               orgID,
@@ -902,8 +892,8 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
 
             // the default bucket selection should have no results and load all three variables
             // even though only two variables are being used (because 1 is dependent upon another)
-            cy.getByTestID('variable-dropdown--static').should(
-              'contain',
+            cy.getByTestID('variable-dropdown-input-typeAhead--static').should(
+              'have.value',
               'beans'
             )
 
@@ -931,22 +921,34 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
             cy.getByTestID('variable-dropdown--button')
               .eq(2)
               .should('contain', 'beans')
+
+            cy.getByTestID('variable-dropdown-input-typeAhead--build').should(
+              'have.value',
+              'beans'
+            )
+
+            cy.getByTestID(
+              'variable-dropdown-input-typeAhead--dependent'
+            ).should('have.value', 'beans')
+            // and also load the third result
+            cy.getByTestID('variable-dropdown--button')
+              .eq(2)
               .click()
             cy.get(`#cool`).click()
 
             // and also load the second result
-            cy.getByTestID('variable-dropdown--dependent').should(
-              'contain',
-              'cool'
-            )
+
+            cy.getByTestID(
+              'variable-dropdown-input-typeAhead--dependent'
+            ).should('have.value', 'cool')
 
             // updating the third variable should update the second
             cy.getByTestID('variable-dropdown--button')
               .eq(2)
               .click()
             cy.get(`#beans`).click()
-            cy.getByTestID('variable-dropdown--build').should(
-              'contain',
+            cy.getByTestID('variable-dropdown-input-typeAhead--build').should(
+              'have.value',
               'beans'
             )
           })
@@ -955,21 +957,23 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
           cy.get<string>('@defaultBucket').then(() => {
             // the default bucket selection should have no results and load all three variables
             // even though only two variables are being used (because 1 is dependent upon another)
-            cy.getByTestID('variable-dropdown--static').should(
-              'contain',
+
+            cy.getByTestID('variable-dropdown-input-typeAhead--static').should(
+              'have.value',
               'defbuck'
             )
 
             // and cause the rest to exist in loading states
-            cy.getByTestID('variable-dropdown--build').should(
-              'contain',
+
+            cy.getByTestID('variable-dropdown-input-typeAhead--build').should(
+              'have.value',
               'beans'
             )
 
             // and also load the second result
 
-            cy.getByTestID('variable-dropdown--build').should(
-              'contain',
+            cy.getByTestID('variable-dropdown-input-typeAhead--build').should(
+              'have.value',
               'beans'
             )
           })

--- a/cypress/e2e/shared/dashboardsView.test.ts
+++ b/cypress/e2e/shared/dashboardsView.test.ts
@@ -839,9 +839,7 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
       })
     })
 
-
     it('ensures that dependent variables load one another accordingly, even with reload and cleared local storage', () => {
-
       cy.get('@org').then(({id: orgID}: Organization) => {
         cy.createDashboard(orgID).then(({body: dashboard}) => {
           cy.get<string>('@defaultBucket').then((defaultBucket: string) => {

--- a/cypress/e2e/shared/dashboardsView.test.ts
+++ b/cypress/e2e/shared/dashboardsView.test.ts
@@ -903,20 +903,15 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
             cy.get(`#${defaultBucket}`).click()
 
             // default select the first result
-            cy.getByTestID('variable-dropdown--build').should(
-              'contain',
-              'beans'
-            )
-
-            // and also load the third result
-            cy.getByTestID('variable-dropdown--button')
-              .eq(2)
-              .should('contain', 'beans')
-
             cy.getByTestID('variable-dropdown-input-typeAhead--build').should(
               'have.value',
               'beans'
             )
+
+            // and also load the third result
+            cy.getByTestID(
+              'variable-dropdown--input-typeAhead-dependent'
+            ).should('have.value', 'beans')
 
             cy.getByTestID(
               'variable-dropdown-input-typeAhead--dependent'

--- a/cypress/e2e/shared/dashboardsView.test.ts
+++ b/cypress/e2e/shared/dashboardsView.test.ts
@@ -1,8 +1,6 @@
 import {Organization, AppState, Dashboard} from '../../../src/types'
 import {lines} from '../../support/commands'
 
-const typeAheadFlag = 'typeAheadVariableDropdown'
-
 describe('Dashboard', () => {
   beforeEach(() => {
     cy.flush()
@@ -842,7 +840,8 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
     })
 
 
-    it.only('ensures that dependent variables load one another accordingly, even with reload and cleared local storage', () => {
+    it('ensures that dependent variables load one another accordingly, even with reload and cleared local storage', () => {
+
       cy.get('@org').then(({id: orgID}: Organization) => {
         cy.createDashboard(orgID).then(({body: dashboard}) => {
           cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
@@ -858,7 +857,7 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
               orgID,
               'dependent',
               `import "influxdata/influxdb/v1"
-            v1.tagValues(bucket: v.static, tag: "container_name") |> keep(columns: ["_value"])`
+          v1.tagValues(bucket: v.static, tag: "container_name") |> keep(columns: ["_value"])`
             )
             cy.createQueryVariable(
               orgID,
@@ -930,6 +929,7 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
             cy.getByTestID(
               'variable-dropdown-input-typeAhead--dependent'
             ).should('have.value', 'beans')
+
             // and also load the third result
             cy.getByTestID('variable-dropdown--button')
               .eq(2)

--- a/cypress/e2e/shared/dashboardsView.test.ts
+++ b/cypress/e2e/shared/dashboardsView.test.ts
@@ -910,7 +910,7 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
 
             // and also load the third result
             cy.getByTestID(
-              'variable-dropdown--input-typeAhead-dependent'
+              'variable-dropdown-input-typeAhead--dependent'
             ).should('have.value', 'beans')
 
             cy.getByTestID(

--- a/src/dashboards/components/variablesControlBar/DraggableDropdown.tsx
+++ b/src/dashboards/components/variablesControlBar/DraggableDropdown.tsx
@@ -3,11 +3,7 @@ import React, {FC, CSSProperties} from 'react'
 import classnames from 'classnames'
 import {Draggable} from 'react-beautiful-dnd'
 
-// Utils
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
-
 // Components
-import VariableDropdown from 'src/variables/components/VariableDropdown'
 import TypeAheadVariableDropdown from 'src/variables/components/TypeAheadVariableDropdown'
 
 interface Props {
@@ -21,10 +17,6 @@ const DraggableDropdown: FC<Props> = ({id, index, name}) => {
     classnames('variable-dropdown', {
       'variable-dropdown__dragging': isDragging,
     })
-
-  const DropdownComponent = isFlagEnabled('typeAheadVariableDropdown')
-    ? TypeAheadVariableDropdown
-    : VariableDropdown
 
   return (
     <Draggable index={index} draggableId={id}>
@@ -43,7 +35,7 @@ const DraggableDropdown: FC<Props> = ({id, index, name}) => {
           <div className="variable-dropdown--label">
             <span>{name}</span>
           </div>
-          <DropdownComponent variableID={id} />
+          <TypeAheadVariableDropdown variableID={id} />
         </div>
       )}
     </Draggable>


### PR DESCRIPTION
removes the typeahead variable dropdown flag, to always use type ahead drop downs

