### PR TITLE
chore: remove hacky beta region logic

### DIFF
--- a/src/shared/components/CloudUpgradeButton.tsx
+++ b/src/shared/components/CloudUpgradeButton.tsx
@@ -15,11 +15,7 @@ import {
 import CloudOnly from 'src/shared/components/cloud/CloudOnly'
 
 // Constants
-import {
-  BETA_REGIONS,
-  CLOUD_URL,
-  CLOUD_CHECKOUT_PATH,
-} from 'src/shared/constants'
+import {CLOUD_URL, CLOUD_CHECKOUT_PATH} from 'src/shared/constants'
 import {
   HIDE_UPGRADE_CTA_KEY,
   PAID_ORG_HIDE_UPGRADE_SETTING,
@@ -48,21 +44,9 @@ const CloudUpgradeButton: FC<StateProps & OwnProps> = ({
     [`${className}`]: className,
   })
 
-  // TODO(ariel): we need to build out an exception for beta regions
-  // This current hack is being placed to allow a Beta region to be deployed
-  // without allowing users to get navigated to a Quartz 404. This hack is being implemented
-  // to address the following issue:
-  // https://github.com/influxdata/ui/issues/944
-  // The follow up to this issue will address the hack here:
-  // https://github.com/influxdata/ui/issues/930
-
-  const isBetaRegion = BETA_REGIONS.some((pathName: string) =>
-    window.location.hostname.includes(pathName)
-  )
-
   return (
     <CloudOnly>
-      {inView && !isBetaRegion && (
+      {inView && (
         <LinkButton
           icon={IconFont.CrownSolid}
           className={cloudUpgradeButtonClass}

--- a/src/shared/components/CloudUpgradeNavBanner.tsx
+++ b/src/shared/components/CloudUpgradeNavBanner.tsx
@@ -17,11 +17,7 @@ import {
 import CloudOnly from 'src/shared/components/cloud/CloudOnly'
 
 // Constants
-import {
-  BETA_REGIONS,
-  CLOUD_URL,
-  CLOUD_CHECKOUT_PATH,
-} from 'src/shared/constants'
+import {CLOUD_URL, CLOUD_CHECKOUT_PATH} from 'src/shared/constants'
 import {
   HIDE_UPGRADE_CTA_KEY,
   PAID_ORG_HIDE_UPGRADE_SETTING,
@@ -34,58 +30,44 @@ interface StateProps {
   inView: boolean
 }
 
-const CloudUpgradeNavBanner: FC<StateProps> = ({inView}) => {
-  // TODO(ariel): we need to build out an exception for beta regions
-  // This current hack is being placed to allow a Beta region to be deployed
-  // without allowing users to get navigated to a Quartz 404. This hack is being implemented
-  // to address the following issue:
-  // https://github.com/influxdata/ui/issues/944
-  // The follow up to this issue will address the hack here:
-  // https://github.com/influxdata/ui/issues/930
-
-  const isBetaRegion = BETA_REGIONS.some((pathName: string) =>
-    window.location.hostname.includes(pathName)
-  )
-
-  return (
-    <>
-      {inView && !isBetaRegion && (
-        <CloudOnly>
-          <Panel
-            gradient={Gradients.HotelBreakfast}
-            className="cloud-upgrade-banner"
+const CloudUpgradeNavBanner: FC<StateProps> = ({inView}) => (
+  <>
+    {inView && (
+      <CloudOnly>
+        <Panel
+          gradient={Gradients.HotelBreakfast}
+          className="cloud-upgrade-banner"
+        >
+          <Panel.Header
+            size={ComponentSize.ExtraSmall}
+            justifyContent={JustifyContent.Center}
           >
-            <Panel.Header
-              size={ComponentSize.ExtraSmall}
-              justifyContent={JustifyContent.Center}
+            <Heading element={HeadingElement.H5}>
+              Need more wiggle room?
+            </Heading>
+          </Panel.Header>
+          <Panel.Footer size={ComponentSize.ExtraSmall}>
+            <a
+              className="cf-button cf-button-md cf-button-primary cf-button-stretch cloud-upgrade-banner--button upgrade-payg--button__nav"
+              href={`${CLOUD_URL}${CLOUD_CHECKOUT_PATH}`}
+              target="_self"
             >
-              <Heading element={HeadingElement.H5}>
-                Need more wiggle room?
-              </Heading>
-            </Panel.Header>
-            <Panel.Footer size={ComponentSize.ExtraSmall}>
-              <a
-                className="cf-button cf-button-md cf-button-primary cf-button-stretch cloud-upgrade-banner--button upgrade-payg--button__nav"
-                href={`${CLOUD_URL}${CLOUD_CHECKOUT_PATH}`}
-                target="_self"
-              >
-                Upgrade Now
-              </a>
-            </Panel.Footer>
-          </Panel>
-          <a
-            className="cloud-upgrade-banner__collapsed"
-            href={`${CLOUD_URL}${CLOUD_CHECKOUT_PATH}`}
-            target="_self"
-          >
-            <Icon glyph={IconFont.CrownSolid} />
-            <Heading element={HeadingElement.H5}>Upgrade Now</Heading>
-          </a>
-        </CloudOnly>
-      )}
-    </>
-  )
-}
+              Upgrade Now
+            </a>
+          </Panel.Footer>
+        </Panel>
+        <a
+          className="cloud-upgrade-banner__collapsed"
+          href={`${CLOUD_URL}${CLOUD_CHECKOUT_PATH}`}
+          target="_self"
+        >
+          <Icon glyph={IconFont.CrownSolid} />
+          <Heading element={HeadingElement.H5}>Upgrade Now</Heading>
+        </a>
+      </CloudOnly>
+    )}
+  </>
+)
 
 const mstp = (state: AppState) => {
   const settings = get(state, 'cloud.orgSettings.settings', [])

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -17,8 +17,6 @@ import {AutoRefreshStatus} from 'src/types'
 // Once the Beta region API is built out by Quartz:
 // influxdata/quartz#4369
 // Beta Regions contain the hostname of the beta regions
-export const BETA_REGIONS = ['europe-west1-1.gcp.cloud2.influxdata.com']
-
 function formatConstant(constant: string) {
   if (!constant) {
     return ''


### PR DESCRIPTION
This PR is intended to remove the hacky beta region logic that was used to write in a UI exception to showing the `upgrade now` button when a user in a beta region was navigating our site