### PR TITLE
feat: clamp annotation's timestamp to nearest domain timestamp

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "@influxdata/clockface": "^2.6.9",
     "@influxdata/flux": "^0.5.1",
     "@influxdata/flux-lsp-browser": "^0.5.42",
-    "@influxdata/giraffe": "^2.7.6",
+    "@influxdata/giraffe": "^2.8.0",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",

--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -211,7 +211,7 @@ const XYPlot: FC<Props> = ({
           'add-annotation',
           {
             createAnnotation,
-            startTime: plotInteraction.valueX,
+            startTime: plotInteraction?.clampedValueX ?? plotInteraction.valueX,
           },
           () => {
             event('xyplot.annotations.create_annotation.cancel')

--- a/yarn.lock
+++ b/yarn.lock
@@ -725,10 +725,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/flux/-/flux-0.5.1.tgz#e39e7a7af9163fc9494422c8fed77f3ae1b68f56"
   integrity sha512-GHlkXBhSdJ2m56JzDkbnKPAqLj3/lexPooacu14AWTO4f2sDGLmzM7r0AxgdtU1M2x7EXNBwgGOI5EOAdN6mkw==
 
-"@influxdata/giraffe@^2.7.6":
-  version "2.7.6"
-  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.7.6.tgz#3d1b94eed7d2183d7a5affda853de2696399379f"
-  integrity sha512-OJdwKC+6SyOlfDeVJ4yUSkGSl+mGHVdG/oPIMpWH7RpvlLKgLD8AlqA1WQXB4saDIZ3qeqls/t2Pr1C6m6HASw==
+"@influxdata/giraffe@^2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.8.0.tgz#cd134b7ae3fc1b1f3eb39a6fded1a3e9ad24efe0"
+  integrity sha512-1agAUcwquxh0IVK3cV+Vxv8EwpJXM3a6sH9Z2hQcZsO+2F8Em2zkTc0rok4Wff1T4vKvCmx3/WG5dqcvPewGNA==
   dependencies:
     merge-images "^2.0.0"
 


### PR DESCRIPTION
Closes #1265

Previously - the raw timestamp of the position of the mouse would be used for the annotation timestamp. Now the nearest clamped/rounded timestamp will be used
