### PR TITLE
feat(unity): Define errors for checkout routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ src/client/generatedRoutes.ts
 src/client/unityRoutes.ts
 src/client/flowsRoutes.ts
 src/client/managedFunctionsRoutes.ts
+src/client/notebooksRoutes.ts

--- a/package.json
+++ b/package.json
@@ -50,9 +50,10 @@
     "cy": "CYPRESS_baseUrl=http://localhost:9999 cypress open",
     "cy:dev": "source ../monitor-ci/.env && CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{cloud,shared}/**/*.*'",
     "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{oss,shared}/**/*.*'",
-    "generate": "oats https://raw.githubusercontent.com/influxdata/influxdb/master/http/swagger.yml > ./src/client/generatedRoutes.ts && yarn unity && yarn flows && yarn managedFunctions",
+    "generate": "oats https://raw.githubusercontent.com/influxdata/influxdb/master/http/swagger.yml > ./src/client/generatedRoutes.ts && yarn unity && yarn flows && yarn notebooks && yarn managedFunctions",
     "unity": "oats ./src/client/swagger/unity.yml > ./src/client/unityRoutes.ts",
     "flows": "oats ./src/client/swagger/flows.yml > ./src/client/flowsRoutes.ts",
+    "notebooks": "oats ./src/client/swagger/notebooks.yml > ./src/client/notebooksRoutes.ts",
     "managedFunctions": "oats ./src/client/swagger/managedFunctions.yml > ./src/client/managedFunctionsRoutes.ts"
   },
   "author": "",

--- a/src/checkout/context/checkout.tsx
+++ b/src/checkout/context/checkout.tsx
@@ -274,7 +274,7 @@ export const CheckoutProvider: FC<Props> = React.memo(({children}) => {
         const response = await postCheckoutInformation(paymentInformation)
 
         handleSetCheckoutStatus(
-          response.status === 204 ? RemoteDataState.Done : RemoteDataState.Error
+          response.status === 201 ? RemoteDataState.Done : RemoteDataState.Error
         )
       } else {
         const errorFields = errs?.flatMap(([err]) => err)

--- a/src/client/swagger/notebooks.yml
+++ b/src/client/swagger/notebooks.yml
@@ -1,0 +1,197 @@
+openapi: 3.0.0
+info:
+  title: notebooksd
+  version: 1.0.0
+servers:
+  - url: /api/v2
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  requestBodies:
+    NotebookParams:
+      description: Notebook record
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/NotebookParams'
+  schemas:
+    NotebookParams:
+      properties:
+        name:
+          type: string
+        orgID:
+          type: string
+        spec:
+          type: object
+    Notebook:
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        orgID:
+          type: string
+        spec:
+          type: object
+        createdAt:
+          type: date-time
+        updatedAt:
+          type: date-time
+    NotebookArray:
+      type: array
+      items:
+        $ref: '#/components/schemas/Notebook'
+    Notebooks:
+      properties:
+        flows:
+          type: array
+          items:
+            $ref: '#/components/schemas/Notebook'
+security:
+  - bearerAuth: []
+paths:
+  /notebooks:
+    get:
+      description: get all records
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: all records
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Notebooks'
+        '401':
+          description: unauthorized, no token or invalid token provided
+        '403':
+          description: unauthorized, token with invalid permissions provided
+        '500':
+          description: an internal error has occured
+    post:
+      description: creates a record
+      requestBody:
+        $ref: '#/components/requestBodies/NotebookParams'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: returns the id of the new record
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Notebook'
+        '401':
+          description: unauthorized, no token or invalid token provided
+        '403':
+          description: unauthorized, token with invalid permissions provided
+        '500':
+          description: an internal error has occured
+  '/notebooks/{id}':
+    get:
+      description: get single record by its ID
+      parameters:
+        - name: id
+          in: path
+          type: string
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: returns the record
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Notebook'
+        '401':
+          description: unauthorized, no token or invalid token provided
+        '403':
+          description: unauthorized, token with invalid permissions provided
+        '500':
+          description: an internal error has occured
+    delete:
+      description: deletes a single record by its ID
+      parameters:
+        - name: id
+          in: path
+          type: string
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: record deleted
+        '401':
+          description: unauthorized, no token or invalid token provided
+        '403':
+          description: unauthorized, token with invalid permissions provided
+        '500':
+          description: an internal error has occured
+    put:
+      description: update a single record by its ID
+      parameters:
+        - name: id
+          in: path
+          type: string
+      requestBody:
+        $ref: '#/components/requestBodies/NotebookParams'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: returns the record
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Notebook'
+        '401':
+          description: unauthorized, no token or invalid token provided
+        '403':
+          description: unauthorized, token with invalid permissions provided
+        '500':
+          description: an internal error has occured
+    patch:
+      description: update a single record by its ID
+      parameters:
+        - name: id
+          in: path
+          type: string
+      requestBody:
+        $ref: '#/components/requestBodies/NotebookParams'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: returns the record
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Notebook'
+        '401':
+          description: unauthorized, no token or invalid token provided
+        '403':
+          description: unauthorized, token with invalid permissions provided
+        '500':
+          description: an internal error has occured
+  /health:
+    get:
+      description: get the health of this service
+      security: []
+      responses:
+        '200':
+          description: service is up
+  /ready:
+    get:
+      description: returns whether the cluster of services are ready to rock 'n roll
+      security: []
+      responses:
+        '200':
+          description: services are ready
+        '500':
+          description: db reporting not ready
+        '503':
+          description: pm2 reporting services are not ready
+tags: []

--- a/src/client/swagger/unity.yml
+++ b/src/client/swagger/unity.yml
@@ -212,6 +212,24 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BillingNotifySettings'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Notification Settings nil or User/Org not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '406':
+          description: Not Acceptable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         default:
           description: Unexpected error
           content:
@@ -236,6 +254,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BillingNotifySettings'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         default:
           description: Unexpected error
           content:

--- a/src/client/swagger/unity.yml
+++ b/src/client/swagger/unity.yml
@@ -832,14 +832,8 @@ paths:
             schema:
               $ref: '#/components/schemas/CheckoutRequest'
       responses:
-        '204':
-          description: Account upgraded
-        default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+        '201':
+          description: Created
         '400':
           description: Bad Request
           content:
@@ -858,6 +852,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   '/cancel':
     post:
       operationId: PostCancel

--- a/src/client/swagger/unity.yml
+++ b/src/client/swagger/unity.yml
@@ -259,13 +259,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
         '401':
           description: Unauthorized
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
         default:
           description: Unexpected error
           content:
@@ -323,25 +323,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
         '401':
           description: Unauthorized
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
         '404':
           description: User or Form not found
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
         '406':
           description: Not Acceptable
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
         default:
           description: Unexpected error
           content:
@@ -902,19 +902,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
         '401':
           description: Unauthorized
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
         '404':
           description: Org/User not found or Beta region
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
         default:
           description: Unexpected error
           content:

--- a/src/client/swagger/unity.yml
+++ b/src/client/swagger/unity.yml
@@ -921,24 +921,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '400':
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-        '401':
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-        '404':
-          description: Org/User not found or Beta region
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
   '/cancel':
     post:
       operationId: PostCancel

--- a/src/client/swagger/unity.yml
+++ b/src/client/swagger/unity.yml
@@ -921,6 +921,24 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        '404':
+          description: Org/User not found or Beta region
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   '/cancel':
     post:
       operationId: PostCancel

--- a/src/client/swagger/unity.yml
+++ b/src/client/swagger/unity.yml
@@ -267,11 +267,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  '/payment/form':
+  '/payment_form/{form}':
     get:
       operationId: GetPaymentForm
       tags:
         - PaymentGateway
+      parameters:
+        - in: path
+          name: form
+          required: true
+          schema:
+            type: string
+            enum: [checkout_form, billing_form]
+          description: The name of the PaymentForm to query.
+          example: 'checkout_form'
       responses:
         '200':
           description: A CreditCard Form parameter object
@@ -279,6 +288,24 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CreditCardParams'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        '404':
+          description: User or Form not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         default:
           description: Unexpected error
           content:

--- a/src/client/swagger/unity.yml
+++ b/src/client/swagger/unity.yml
@@ -278,9 +278,9 @@ paths:
           required: true
           schema:
             type: string
-            enum: [checkout_form, billing_form]
+            enum: [checkout, billing]
           description: The name of the PaymentForm to query.
-          example: 'checkout_form'
+          example: 'checkout'
       responses:
         '200':
           description: A CreditCard Form parameter object
@@ -302,6 +302,12 @@ paths:
                 $ref: "#/components/schemas/Error"
         '404':
           description: User or Form not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        '406':
+          description: Not Acceptable
           content:
             application/json:
               schema:

--- a/src/client/swagger/unity.yml
+++ b/src/client/swagger/unity.yml
@@ -840,6 +840,24 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        '404':
+          description: Org/User not found or Beta region
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   '/cancel':
     post:
       operationId: PostCancel

--- a/src/flows/context/notebooks.api.tsx
+++ b/src/flows/context/notebooks.api.tsx
@@ -1,0 +1,115 @@
+import {
+  PatchNotebookParams,
+  patchNotebook,
+  PostNotebookParams,
+  postNotebook,
+  DeleteNotebookParams,
+  deleteNotebook,
+  getNotebooks,
+} from 'src/client/notebooksRoutes'
+import {notebookUpdateFail} from 'src/shared/copy/notifications'
+import {notify} from 'src/shared/actions/notifications'
+
+const DEFAULT_API_FLOW: PatchNotebookParams = {
+  id: '',
+  data: {},
+}
+let stagedFlow: PatchNotebookParams = DEFAULT_API_FLOW
+let reportDecayTimeout = null
+let reportMaxTimeout = null
+
+const REPORT_DECAY = 500 // number of miliseconds to wait after last event before sending
+const REPORT_MAX_WAIT = 5000 // max number of miliseconds to wait between sends
+
+export const pooledUpdateAPI = (flow: PatchNotebookParams) => {
+  stagedFlow = flow
+
+  if (!!reportDecayTimeout) {
+    clearTimeout(reportDecayTimeout)
+    reportDecayTimeout = null
+  }
+
+  if (!reportMaxTimeout) {
+    reportMaxTimeout = setTimeout(() => {
+      reportMaxTimeout = null
+
+      // flow already synced
+      if (stagedFlow === DEFAULT_API_FLOW) {
+        return
+      }
+
+      clearTimeout(reportDecayTimeout)
+      reportDecayTimeout = null
+      updateAPI(stagedFlow)
+
+      stagedFlow = DEFAULT_API_FLOW
+    }, REPORT_MAX_WAIT)
+  }
+
+  reportDecayTimeout = setTimeout(() => {
+    updateAPI(stagedFlow)
+
+    stagedFlow = DEFAULT_API_FLOW
+  }, REPORT_DECAY)
+}
+
+export const updateAPI = async (flow: PatchNotebookParams) => {
+  const res = await patchNotebook(flow)
+  if (res.status != 200) {
+    throw new Error(res.data.message)
+  }
+}
+
+export const createAPI = async (flow: PostNotebookParams) => {
+  const res = await postNotebook(flow)
+  if (res.status != 200) {
+    throw new Error(res.data.message)
+  }
+  return res.data.id
+}
+
+export const deleteAPI = async (ids: DeleteNotebookParams) => {
+  const res = await deleteNotebook(ids)
+  if (res.status != 200) {
+    throw new Error(res.data.message)
+  }
+}
+
+export const getAllAPI = async (orgID: string) => {
+  const res = await getNotebooks({orgID})
+  if (res.status != 200) {
+    throw new Error(res.data.message)
+  }
+  return res.data
+}
+
+export const migrateLocalFlowsToAPI = async (
+  orgID: string,
+  flows: {},
+  serialize: Function,
+  dispatch: Function
+) => {
+  const localFlows = Object.keys(flows).filter(id => id.includes('local'))
+  if (localFlows.length) {
+    await Promise.all(
+      localFlows.map(async localID => {
+        const flow = flows[localID]
+        const apiFlow: PostNotebookParams = {
+          data: {
+            orgID: orgID,
+            name: flow.name,
+            spec: serialize(flow),
+          },
+        }
+        const id = await createAPI(apiFlow)
+        delete flows[localID]
+        flows[id] = flow
+      })
+    ).catch(() => {
+      // do not throw the error because some flows might have saved and we
+      // need to save the new IDs to avoid creating duplicates next time.
+      dispatch(notify(notebookUpdateFail()))
+    })
+  }
+  return flows
+}

--- a/src/shared/components/CloudUpgradeButton.tsx
+++ b/src/shared/components/CloudUpgradeButton.tsx
@@ -15,11 +15,7 @@ import {
 import CloudOnly from 'src/shared/components/cloud/CloudOnly'
 
 // Constants
-import {
-  BETA_REGIONS,
-  CLOUD_URL,
-  CLOUD_CHECKOUT_PATH,
-} from 'src/shared/constants'
+import {CLOUD_URL, CLOUD_CHECKOUT_PATH} from 'src/shared/constants'
 import {
   HIDE_UPGRADE_CTA_KEY,
   PAID_ORG_HIDE_UPGRADE_SETTING,
@@ -48,21 +44,9 @@ const CloudUpgradeButton: FC<StateProps & OwnProps> = ({
     [`${className}`]: className,
   })
 
-  // TODO(ariel): we need to build out an exception for beta regions
-  // This current hack is being placed to allow a Beta region to be deployed
-  // without allowing users to get navigated to a Quartz 404. This hack is being implemented
-  // to address the following issue:
-  // https://github.com/influxdata/ui/issues/944
-  // The follow up to this issue will address the hack here:
-  // https://github.com/influxdata/ui/issues/930
-
-  const isBetaRegion = BETA_REGIONS.some((pathName: string) =>
-    window.location.hostname.includes(pathName)
-  )
-
   return (
     <CloudOnly>
-      {inView && !isBetaRegion && (
+      {inView && (
         <LinkButton
           icon={IconFont.CrownSolid}
           className={cloudUpgradeButtonClass}

--- a/src/shared/components/CloudUpgradeNavBanner.tsx
+++ b/src/shared/components/CloudUpgradeNavBanner.tsx
@@ -17,11 +17,7 @@ import {
 import CloudOnly from 'src/shared/components/cloud/CloudOnly'
 
 // Constants
-import {
-  BETA_REGIONS,
-  CLOUD_URL,
-  CLOUD_CHECKOUT_PATH,
-} from 'src/shared/constants'
+import {CLOUD_URL, CLOUD_CHECKOUT_PATH} from 'src/shared/constants'
 import {
   HIDE_UPGRADE_CTA_KEY,
   PAID_ORG_HIDE_UPGRADE_SETTING,
@@ -34,58 +30,44 @@ interface StateProps {
   inView: boolean
 }
 
-const CloudUpgradeNavBanner: FC<StateProps> = ({inView}) => {
-  // TODO(ariel): we need to build out an exception for beta regions
-  // This current hack is being placed to allow a Beta region to be deployed
-  // without allowing users to get navigated to a Quartz 404. This hack is being implemented
-  // to address the following issue:
-  // https://github.com/influxdata/ui/issues/944
-  // The follow up to this issue will address the hack here:
-  // https://github.com/influxdata/ui/issues/930
-
-  const isBetaRegion = BETA_REGIONS.some((pathName: string) =>
-    window.location.hostname.includes(pathName)
-  )
-
-  return (
-    <>
-      {inView && !isBetaRegion && (
-        <CloudOnly>
-          <Panel
-            gradient={Gradients.HotelBreakfast}
-            className="cloud-upgrade-banner"
+const CloudUpgradeNavBanner: FC<StateProps> = ({inView}) => (
+  <>
+    {inView && (
+      <CloudOnly>
+        <Panel
+          gradient={Gradients.HotelBreakfast}
+          className="cloud-upgrade-banner"
+        >
+          <Panel.Header
+            size={ComponentSize.ExtraSmall}
+            justifyContent={JustifyContent.Center}
           >
-            <Panel.Header
-              size={ComponentSize.ExtraSmall}
-              justifyContent={JustifyContent.Center}
+            <Heading element={HeadingElement.H5}>
+              Need more wiggle room?
+            </Heading>
+          </Panel.Header>
+          <Panel.Footer size={ComponentSize.ExtraSmall}>
+            <a
+              className="cf-button cf-button-md cf-button-primary cf-button-stretch cloud-upgrade-banner--button upgrade-payg--button__nav"
+              href={`${CLOUD_URL}${CLOUD_CHECKOUT_PATH}`}
+              target="_self"
             >
-              <Heading element={HeadingElement.H5}>
-                Need more wiggle room?
-              </Heading>
-            </Panel.Header>
-            <Panel.Footer size={ComponentSize.ExtraSmall}>
-              <a
-                className="cf-button cf-button-md cf-button-primary cf-button-stretch cloud-upgrade-banner--button upgrade-payg--button__nav"
-                href={`${CLOUD_URL}${CLOUD_CHECKOUT_PATH}`}
-                target="_self"
-              >
-                Upgrade Now
-              </a>
-            </Panel.Footer>
-          </Panel>
-          <a
-            className="cloud-upgrade-banner__collapsed"
-            href={`${CLOUD_URL}${CLOUD_CHECKOUT_PATH}`}
-            target="_self"
-          >
-            <Icon glyph={IconFont.CrownSolid} />
-            <Heading element={HeadingElement.H5}>Upgrade Now</Heading>
-          </a>
-        </CloudOnly>
-      )}
-    </>
-  )
-}
+              Upgrade Now
+            </a>
+          </Panel.Footer>
+        </Panel>
+        <a
+          className="cloud-upgrade-banner__collapsed"
+          href={`${CLOUD_URL}${CLOUD_CHECKOUT_PATH}`}
+          target="_self"
+        >
+          <Icon glyph={IconFont.CrownSolid} />
+          <Heading element={HeadingElement.H5}>Upgrade Now</Heading>
+        </a>
+      </CloudOnly>
+    )}
+  </>
+)
 
 const mstp = (state: AppState) => {
   const settings = get(state, 'cloud.orgSettings.settings', [])

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -17,8 +17,6 @@ import {AutoRefreshStatus} from 'src/types'
 // Once the Beta region API is built out by Quartz:
 // influxdata/quartz#4369
 // Beta Regions contain the hostname of the beta regions
-export const BETA_REGIONS = ['europe-west1-1.gcp.cloud2.influxdata.com']
-
 function formatConstant(constant: string) {
   if (!constant) {
     return ''


### PR DESCRIPTION
Updated the path and params for `payment form` to `/payment_form/{form}` to account for the two different payment forms Zuora can return, and added defined errors for `/checkout`, `/payment_form/{form}`, and `/settings/notifications`. 
