### PR TITLE
feat: show task ids on alerts + notifications

### DIFF
--- a/cypress/e2e/shared/checks.test.ts
+++ b/cypress/e2e/shared/checks.test.ts
@@ -400,24 +400,6 @@ describe('Checks', () => {
         .trigger('mouseup', {force: true})
     })
 
-    describe('test tabbing behavior with wide screen', () => {
-      beforeEach(() => {
-        // have to make the viewport huge to get it not to switch to tablet size
-        cy.viewport(1800, 980)
-        cy.getByTestID('select-group').should('not.be.visible')
-      })
-      it('accepts keyboard tabs as navigation', () => {
-        cy.get('body').tab()
-        cy.getByTestID('filter--input checks').should('have.focus')
-
-        cy.focused().tab()
-        cy.getByTestID('filter--input endpoints').should('have.focus')
-
-        cy.focused().tab()
-        cy.getByTestID('filter--input rules').should('have.focus')
-      })
-    })
-
     describe('test tabbing behavior with small screen', () => {
       beforeEach(() => {
         // have to make the viewport small to use tablet size

--- a/src/alerting/components/AlertingIndex.scss
+++ b/src/alerting/components/AlertingIndex.scss
@@ -45,34 +45,6 @@
 }
 
 /*
-  Large Screen Layout
-  ------------------------------------------------------------------------------
-
-  if the screen is larger than the threshold, hide the tab buttons (only needed if it is
-  a small screen; to help you navigate between the tabs.  if the screen is large enough,
-  all the tabs/columns are visible so don't need the buttons).
-
-  clockface has the pattern to put our provided className after the internal classnames.
-  So our styles will always be lower ranking than the styles within clockface.
-  therefore, putting !important here is valid.
-*/
-
-@media screen and (min-width: $cf-grid--breakpoint-lg) {
-  .alerting-index--selector {
-    display: none !important;
-  }
-  .alerting-index--column {
-    display: flex;
-    margin-bottom: $cf-marg-d;
-    margin-right: $cf-marg-b;
-
-    &:last-child {
-      margin-right: 0;
-    }
-  }
-}
-
-/*
   First time widget
   ------------------------------------------------------------------------------
 */

--- a/src/checks/components/CheckCard.tsx
+++ b/src/checks/components/CheckCard.tsx
@@ -16,7 +16,7 @@ import {
 import CheckCardContext from 'src/checks/components/CheckCardContext'
 import InlineLabels from 'src/shared/components/inlineLabels/InlineLabels'
 import LastRunTaskStatus from 'src/shared/components/lastRunTaskStatus/LastRunTaskStatus'
-import {CopyResourceID} from 'src/shared/components/CopyResourceID'
+import {CopyResourceID, CopyTaskID} from 'src/shared/components/CopyResourceID'
 
 // Constants
 import {DEFAULT_CHECK_NAME} from 'src/alerting/constants'
@@ -62,7 +62,7 @@ const CheckCard: FC<Props> = ({
   },
   history,
 }) => {
-  const {id, activeStatus, name, description} = check
+  const {activeStatus, description, id, name, taskID} = check
 
   const onUpdateName = (name: string) => {
     try {
@@ -177,6 +177,7 @@ const CheckCard: FC<Props> = ({
             <>Last completed at {check.latestCompleted}</>
             <>{relativeTimestampFormatter(check.updatedAt, 'Last updated ')}</>
             <CopyResourceID resource={check} resourceName="Check" />
+            <CopyTaskID taskID={taskID} />
           </ResourceCard.Meta>
           <InlineLabels
             selectedLabelIDs={check.labels}

--- a/src/notifications/rules/components/RuleCard.tsx
+++ b/src/notifications/rules/components/RuleCard.tsx
@@ -16,7 +16,7 @@ import {
 import NotificationRuleCardContext from 'src/notifications/rules/components/RuleCardContext'
 import InlineLabels from 'src/shared/components/inlineLabels/InlineLabels'
 import LastRunTaskStatus from 'src/shared/components/lastRunTaskStatus/LastRunTaskStatus'
-import {CopyResourceID} from 'src/shared/components/CopyResourceID'
+import {CopyResourceID, CopyTaskID} from 'src/shared/components/CopyResourceID'
 
 // Constants
 import {DEFAULT_NOTIFICATION_RULE_NAME} from 'src/alerting/constants'
@@ -61,13 +61,14 @@ const RuleCard: FC<Props> = ({
   history,
 }) => {
   const {
-    id,
     activeStatus,
-    name,
+    description,
+    id,
     lastRunError,
     lastRunStatus,
-    description,
     latestCompleted,
+    name,
+    taskID,
   } = rule
 
   const onUpdateName = (name: string) => {
@@ -174,6 +175,7 @@ const RuleCard: FC<Props> = ({
             <>Last completed at {latestCompleted}</>
             <>{relativeTimestampFormatter(rule.updatedAt, 'Last updated ')}</>
             <CopyResourceID resource={rule} resourceName="Rule" />
+            <CopyTaskID taskID={taskID} />
           </ResourceCard.Meta>
           <InlineLabels
             selectedLabelIDs={rule.labels}

--- a/src/shared/components/CopyResourceID.tsx
+++ b/src/shared/components/CopyResourceID.tsx
@@ -13,12 +13,12 @@ interface ResourceWithID {
   id?: string
 }
 
-interface Props {
+interface ResourceProps {
   resource: ResourceWithID
   resourceName: string
 }
 
-export const CopyResourceID: FC<Props> = ({resource, resourceName}) => {
+export const CopyResourceID: FC<ResourceProps> = ({resource, resourceName}) => {
   const dispatch = useDispatch()
 
   const handleCopy = (copiedText: string, copyWasSuccessful: boolean): void => {
@@ -34,6 +34,34 @@ export const CopyResourceID: FC<Props> = ({resource, resourceName}) => {
     <CopyToClipboard text={resource.id} onCopy={handleCopy}>
       <span className="copy-resource-id" title="Click to Copy to Clipboard">
         ID: {resource.id}
+        <span className="copy-resource-id--click-target">
+          Copy to Clipboard
+        </span>
+      </span>
+    </CopyToClipboard>
+  )
+}
+
+interface TaskProps {
+  taskID: string
+}
+
+export const CopyTaskID: FC<TaskProps> = ({taskID}) => {
+  const dispatch = useDispatch()
+
+  const handleCopy = (copiedText: string, copyWasSuccessful: boolean): void => {
+    if (!copyWasSuccessful) {
+      dispatch(notify(copyToClipboardFailed(copiedText, `Task ID`)))
+      return
+    }
+
+    dispatch(notify(copyToClipboardSuccess(copiedText, `Task ID`)))
+  }
+
+  return (
+    <CopyToClipboard text={taskID} onCopy={handleCopy}>
+      <span className="copy-resource-id" title="Click to Copy to Clipboard">
+        Task ID: {taskID}
         <span className="copy-resource-id--click-target">
           Copy to Clipboard
         </span>

--- a/src/types/alerting.ts
+++ b/src/types/alerting.ts
@@ -77,6 +77,7 @@ export type NotificationRuleBaseDraft = Overwrite<
     statusRules: StatusRuleDraft[]
     tagRules: TagRuleDraft[]
     labels?: string[]
+    taskID?: string
   }
 >
 
@@ -138,6 +139,7 @@ type CheckOverrides = {
   status: RemoteDataState
   activeStatus: TaskStatusType
   labels: string[]
+  taskID?: string
 }
 export type CheckBase = Omit<GenCheckBase, 'status'> & CheckOverrides
 


### PR DESCRIPTION
Closes #1169

- Shows underlying task id on the alerts page and notification rules page.
- Removes responsive css from Alerts page. Previously at sizes of 1500+ px it would expand to three columns. Now it is always tabbed. David and I chatted and we both agreed it was way easier to use in the larger format

https://user-images.githubusercontent.com/146112/116447179-8aff6780-a80c-11eb-9eb4-ff540c6c3a9b.mov


