### PR TITLE
feat(functions): Route requests to api/v2/poc-functions until the api/v2/functions EP is available

### DIFF
--- a/src/client/swagger/managedFunctions.yml
+++ b/src/client/swagger/managedFunctions.yml
@@ -5,7 +5,7 @@ info:
 servers:
   - url: ''
 paths:
-  '/api/v2/functions':
+  '/api/v2/poc-functions':
     get:
       operationId: GetFunctions
       tags:
@@ -72,7 +72,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  '/api/v2/functions/trigger':
+  '/api/v2/poc-functions/trigger':
     post:
       operationId: PostFunctionsTrigger
       tags:
@@ -98,7 +98,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  '/api/v2/functions/{functionID}':
+  '/api/v2/poc-functions/{functionID}':
     get:
       operationId: GetFunctionsID
       tags:
@@ -179,7 +179,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  '/api/v2/functions/{functionID}/invoke':
+  '/api/v2/poc-functions/{functionID}/invoke':
     get:
       operationId: GetFunctionsIDInvoke
       tags:
@@ -228,7 +228,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FunctionHTTPResponseData'
-  '/api/v2/functions/{functionID}/runs':
+  '/api/v2/poc-functions/{functionID}/runs':
     get:
       operationId: GetFunctionsIDRuns
       tags:
@@ -266,7 +266,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  '/api/v2/functions/{functionID}/runs/{runID}':
+  '/api/v2/poc-functions/{functionID}/runs/{runID}':
     get:
       operationId: GetFunctionsIDRunsID
       tags:

--- a/src/functions/context/api.tsx
+++ b/src/functions/context/api.tsx
@@ -1,17 +1,17 @@
 import {
-  getApiV2Functions,
-  deleteApiV2Function,
-  postApiV2Function,
+  getApiV2PocFunctions,
+  deleteApiV2PocFunction,
+  postApiV2PocFunction,
   FunctionCreateRequest,
-  postApiV2FunctionsTrigger,
+  postApiV2PocFunctionsTrigger,
   FunctionTriggerRequest,
-  patchApiV2Function,
+  patchApiV2PocFunction,
   FunctionUpdateRequest,
-  getApiV2FunctionsRuns,
+  getApiV2PocFunctionsRuns,
 } from 'src/client/managedFunctionsRoutes'
 
 export const createAPI = async (functionCreate: FunctionCreateRequest) => {
-  const res = await postApiV2Function({data: functionCreate})
+  const res = await postApiV2PocFunction({data: functionCreate})
 
   if (res.status != 201) {
     throw new Error(res.data.message)
@@ -20,7 +20,7 @@ export const createAPI = async (functionCreate: FunctionCreateRequest) => {
 }
 
 export const deleteAPI = async (id: string) => {
-  const res = await deleteApiV2Function({functionID: id})
+  const res = await deleteApiV2PocFunction({functionID: id})
 
   if (res.status != 204) {
     throw new Error(res.data.message)
@@ -28,7 +28,7 @@ export const deleteAPI = async (id: string) => {
 }
 
 export const getAllAPI = async (orgID: string) => {
-  const res = await getApiV2Functions({query: {orgID}})
+  const res = await getApiV2PocFunctions({query: {orgID}})
   if (res.status != 200) {
     throw new Error(res.data.message)
   }
@@ -36,7 +36,7 @@ export const getAllAPI = async (orgID: string) => {
 }
 
 export const triggerAPI = async (triggerRequest: FunctionTriggerRequest) => {
-  const res = await postApiV2FunctionsTrigger({
+  const res = await postApiV2PocFunctionsTrigger({
     data: triggerRequest,
   })
 
@@ -50,7 +50,7 @@ export const updateAPI = async (
   functionID: string,
   updateRequest: FunctionUpdateRequest
 ) => {
-  const res = await patchApiV2Function({functionID, data: updateRequest})
+  const res = await patchApiV2PocFunction({functionID, data: updateRequest})
 
   if (res.status != 200) {
     throw new Error(res.data.message)
@@ -59,7 +59,7 @@ export const updateAPI = async (
 }
 
 export const getRunsAPI = async (functionID: string) => {
-  const res = await getApiV2FunctionsRuns({functionID})
+  const res = await getApiV2PocFunctionsRuns({functionID})
 
   if (res.status != 200) {
     throw new Error(res.data.message)


### PR DESCRIPTION
The `/functions/...` endpoints will be used for named functions(flux) only, until the managed functions (python) functionality is in place. This routes the UI endpoints to `api/v2/poc-functions` instead for now so that we can continue demoing managed functions until we decide to devote resources to building out managed functions 