### PR TITLE
feat: different page title for cloud vs OSS sign-in page

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -7,7 +7,7 @@
       name="description"
       content="InfluxDB Cloud provides the fastest way to access the most powerful time series database as a service. InfluxDB Cloud is much more than just a database."
     />
-    <title>InfluxDB Cloud</title>
+    <title><%= htmlWebpackPlugin.options.title %></title>
     <base href="/" />
     <%= htmlWebpackPlugin.options.header %>
   </head>

--- a/assets/index.html
+++ b/assets/index.html
@@ -7,7 +7,7 @@
       name="description"
       content="InfluxDB Cloud provides the fastest way to access the most powerful time series database as a service. InfluxDB Cloud is much more than just a database."
     />
-    <title><%= htmlWebpackPlugin.options.title %></title>
+    <title>InfluxDB<%= htmlWebpackPlugin.options.titleAdd %></title>
     <base href="/" />
     <%= htmlWebpackPlugin.options.header %>
   </head>

--- a/webpack.common.ts
+++ b/webpack.common.ts
@@ -4,6 +4,7 @@ const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin')
 const {CleanWebpackPlugin} = require('clean-webpack-plugin')
+
 const webpack = require('webpack')
 const {
   GIT_SHA,
@@ -126,6 +127,7 @@ module.exports = {
       base: BASE_PATH.slice(0, -1),
       header: process.env.INJECT_HEADER || '',
       body: process.env.INJECT_BODY || '',
+      title: !!process.env.CLOUD_URL ? 'InfluxDB Cloud' : 'InfluxDB 2.0',
     }),
     new MiniCssExtractPlugin({
       filename: `${STATIC_DIRECTORY}[contenthash:10].css`,

--- a/webpack.common.ts
+++ b/webpack.common.ts
@@ -127,7 +127,7 @@ module.exports = {
       base: BASE_PATH.slice(0, -1),
       header: process.env.INJECT_HEADER || '',
       body: process.env.INJECT_BODY || '',
-      title: !!process.env.CLOUD_URL ? 'InfluxDB Cloud' : 'InfluxDB 2.0',
+      titleAdd: !!process.env.CLOUD_URL ? ' Cloud' : '',
     }),
     new MiniCssExtractPlugin({
       filename: `${STATIC_DIRECTORY}[contenthash:10].css`,


### PR DESCRIPTION
Closes #1273

Also see: Relevant [slack thread](https://influxdata.slack.com/archives/CLHATC50E/p1619031531035500)

This PR will set the title of the sign-in page based on the environment that the UI is built in. By default, the title will be "InfluxDB" - this will be the title displayed for OSS & other environments where the `CLOUD_URL` environment variable is not set. If the `CLOUD_URL` environment variable is set, the title will be "InfluxDB Cloud".