### PR TITLE
fix: fix e2e test chaining issues and clearing local storage

### DIFF
--- a/cypress/e2e/cloud/annotations.test.ts
+++ b/cypress/e2e/cloud/annotations.test.ts
@@ -32,9 +32,15 @@ describe('The Annotations UI functionality', () => {
       .click()
       .then(() => {
         cy.getByTestID('selector-list schmucket').click()
-        cy.getByTestID(`selector-list m`).should('exist').click()
-        cy.getByTestID('selector-list v').should('exist').click()
-        cy.getByTestID(`selector-list tv1`).should('exist').click()
+        cy.getByTestID(`selector-list m`)
+          .should('exist')
+          .click()
+        cy.getByTestID('selector-list v')
+          .should('exist')
+          .click()
+        cy.getByTestID(`selector-list tv1`)
+          .should('exist')
+          .click()
           .then(() => {
             cy.getByTestID('time-machine-submit-button').click()
           })
@@ -58,10 +64,10 @@ describe('The Annotations UI functionality', () => {
     // https://github.com/cypress-io/cypress/issues/2573
     // cy.clearLocalStorage()
 
-    cy.window().then((window) => {
-      window.sessionStorage.clear();
-      window.localStorage.clear();
-    });
+    cy.window().then(window => {
+      window.sessionStorage.clear()
+      window.localStorage.clear()
+    })
   })
 
   it('can create an annotation when the graph is clicked and the control bar is open', () => {
@@ -265,9 +271,14 @@ describe('The Annotations UI functionality', () => {
       .click()
       .then(() => {
         cy.getByTestID('selector-list schmucket').click()
-        cy.getByTestID(`selector-list m`).should('exist').click()
-        cy.getByTestID('selector-list v').should('exist').click()
-        cy.getByTestID(`selector-list tv1`).should('exist')
+        cy.getByTestID(`selector-list m`)
+          .should('exist')
+          .click()
+        cy.getByTestID('selector-list v')
+          .should('exist')
+          .click()
+        cy.getByTestID(`selector-list tv1`)
+          .should('exist')
           .click()
           .then(() => {
             cy.getByTestID('time-machine-submit-button').click()

--- a/cypress/e2e/cloud/annotations.test.ts
+++ b/cypress/e2e/cloud/annotations.test.ts
@@ -59,11 +59,7 @@ describe('The Annotations UI functionality', () => {
   })
 
   afterEach(() => {
-    // cy.clearLocalStorage only clears for current domain/subdomain.
-    // Putting it here so it clears the data at this subdomain consistently.
-    // https://github.com/cypress-io/cypress/issues/2573
-    // cy.clearLocalStorage()
-
+    // clear the local storage after each test.
     cy.window().then(window => {
       window.sessionStorage.clear()
       window.localStorage.clear()

--- a/cypress/e2e/cloud/annotations.test.ts
+++ b/cypress/e2e/cloud/annotations.test.ts
@@ -31,14 +31,10 @@ describe('The Annotations UI functionality', () => {
     cy.getByTestID('add-cell--button')
       .click()
       .then(() => {
-        cy.getByTestID('selector-list schmucket')
-          .click()
-          .getByTestID(`selector-list m`)
-          .click()
-          .getByTestID('selector-list v')
-          .click()
-          .getByTestID(`selector-list tv1`)
-          .click()
+        cy.getByTestID('selector-list schmucket').click()
+        cy.getByTestID(`selector-list m`).should('exist').click()
+        cy.getByTestID('selector-list v').should('exist').click()
+        cy.getByTestID(`selector-list tv1`).should('exist').click()
           .then(() => {
             cy.getByTestID('time-machine-submit-button').click()
           })
@@ -60,7 +56,12 @@ describe('The Annotations UI functionality', () => {
     // cy.clearLocalStorage only clears for current domain/subdomain.
     // Putting it here so it clears the data at this subdomain consistently.
     // https://github.com/cypress-io/cypress/issues/2573
-    cy.clearLocalStorage()
+    // cy.clearLocalStorage()
+
+    cy.window().then((window) => {
+      window.sessionStorage.clear();
+      window.localStorage.clear();
+    });
   })
 
   it('can create an annotation when the graph is clicked and the control bar is open', () => {
@@ -264,9 +265,9 @@ describe('The Annotations UI functionality', () => {
       .click()
       .then(() => {
         cy.getByTestID('selector-list schmucket').click()
-        cy.getByTestID(`selector-list m`).click()
-        cy.getByTestID('selector-list v').click()
-        cy.getByTestID(`selector-list tv1`)
+        cy.getByTestID(`selector-list m`).should('exist').click()
+        cy.getByTestID('selector-list v').should('exist').click()
+        cy.getByTestID(`selector-list tv1`).should('exist')
           .click()
           .then(() => {
             cy.getByTestID('time-machine-submit-button').click()

--- a/cypress/e2e/cloud/annotations.test.ts
+++ b/cypress/e2e/cloud/annotations.test.ts
@@ -60,6 +60,7 @@ describe('The Annotations UI functionality', () => {
 
   afterEach(() => {
     // clear the local storage after each test.
+    // See: https://github.com/cypress-io/cypress/issues/2573
     cy.window().then(window => {
       window.sessionStorage.clear()
       window.localStorage.clear()


### PR DESCRIPTION
This PR fixes the flaky annotations e2e tests. In #1312 we fixed one instance of the chaining issue but we still had issues. Here's why: When the test launches the bucket-measurement selection window, some elements like the measurement values only appear after selecting an element in the selector list. Our test wasn't waiting for it to appear before clicking it. Hence the failure. 

Also fixed the issue with clearing the localstorage in the afterEach block, reliably. 

I ran the tests in the circle CI 3 times, all pass with no flakes.