### PR TITLE
feat: resets flags state after the URL is set

### DIFF
--- a/src/Logout.tsx
+++ b/src/Logout.tsx
@@ -24,19 +24,27 @@ const Logout: FC<Props> = ({history}) => {
   const dispatch = useDispatch()
 
   useEffect(() => {
-    const handleSignOut = async () => {
-      if (CLOUD && isFlagEnabled('authSessionCookieOn')) {
-        const url = new URL(
-          `${window.location.origin}${CLOUD_SIGNOUT_PATHNAME}`
-        )
-        window.location.href = url.href
-        return
-      }
+    const handleReset = () => {
+      dispatch(reset())
+      dispatch({type: 'USER_LOGGED_OUT'})
+    }
 
+    const handleSignOut = async () => {
       if (CLOUD) {
-        window.location.href = `${CLOUD_URL}${CLOUD_LOGOUT_PATH}`
+        const url = isFlagEnabled('authSessionCookieOn')
+          ? new URL(`${window.location.origin}${CLOUD_SIGNOUT_PATHNAME}`).href
+          : `${CLOUD_URL}${CLOUD_LOGOUT_PATH}`
+
+        if (isFlagEnabled('authSessionCookieOn')) {
+          handleReset()
+        }
+
+        window.location.href = url
         return
       } else {
+        if (isFlagEnabled('authSessionCookieOn')) {
+          handleReset()
+        }
         const resp = await postSignout({})
 
         if (resp.status !== 204) {
@@ -46,8 +54,9 @@ const Logout: FC<Props> = ({history}) => {
         history.push(`/signin`)
       }
     }
-    dispatch(reset())
-    dispatch({type: 'USER_LOGGED_OUT'})
+    if (!isFlagEnabled('authSessionCookieOn')) {
+      handleReset()
+    }
     handleSignOut()
   }, [dispatch, history])
 


### PR DESCRIPTION
This PR closes the issue where users logging out using the shared session cookie were undergoing the original logout loop. This issue presented itself because the feature flag and local storage were being reset prior to hitting the condition of checking the feature flag. As such, we are now checking to see if the flag is enabled prior to resetting it