### PR TITLE
fix: set default UI timezone to match default timezone in giraffe

### DIFF
--- a/cypress/e2e/shared/dashboardsView.test.ts
+++ b/cypress/e2e/shared/dashboardsView.test.ts
@@ -1140,7 +1140,7 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
         })
       })
     })
-    const timeFormatOriginal = 'YYYY-MM-DD HH:mm:ss ZZ'
+    const timeFormatOriginal = 'YYYY-MM-DD HH:mm:ss a'
     const timeFormatNew = 'hh:mm a'
 
     cy.log('creating new dashboard cell')

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -24,7 +24,7 @@ function formatConstant(constant: string) {
   return constant.trim()
 }
 
-export const DEFAULT_TIME_FORMAT = 'YYYY-MM-DD HH:mm:ss ZZ'
+export const DEFAULT_TIME_FORMAT = 'YYYY-MM-DD HH:mm:ss a'
 
 export const DROPDOWN_MENU_MAX_HEIGHT = 240
 


### PR DESCRIPTION
Closes #1248 

The default timestamp set in UI was out of sync with the default timezone set in giraffe and resulted in this behavior.  The default in UI is now the same as timeFormats.local12 in giraffe which is set as the final fallback in formatters.ts

fix verification gif:
![Peek 2021-04-29 16-58](https://user-images.githubusercontent.com/22055730/116618241-c84b1e80-a90c-11eb-9c27-6313c15bfc41.gif)
