### PR TITLE
chore: update error condition on csv uploader to quiet things down

### DIFF
--- a/src/buckets/components/context/csvUploader.tsx
+++ b/src/buckets/components/context/csvUploader.tsx
@@ -79,7 +79,10 @@ export const CsvUploaderProvider: FC<Props> = React.memo(({children}) => {
     if (error.name === 'AbortError') {
       event('Aborting_CSV_Upload')
     }
-    if (message.includes('incorrectly formatted') || message.includes('The CSV could not be parsed')) {
+    if (
+      message.includes('incorrectly formatted') ||
+      message.includes('The CSV could not be parsed')
+    ) {
       event('CSV_Upload_Format_Error')
     } else {
       reportErrorThroughHoneyBadger(error, {

--- a/src/buckets/components/context/csvUploader.tsx
+++ b/src/buckets/components/context/csvUploader.tsx
@@ -74,18 +74,18 @@ export const CsvUploaderProvider: FC<Props> = React.memo(({children}) => {
   }
 
   const handleError = (error: Error): void => {
+    const message = getErrorMessage(error)
     setUploadState(RemoteDataState.Error)
     if (error.name === 'AbortError') {
       event('Aborting_CSV_Upload')
     }
-    if (error.message.includes('incorrectly formatted')) {
+    if (message.includes('incorrectly formatted') || message.includes('The CSV could not be parsed')) {
       event('CSV_Upload_Format_Error')
     } else {
       reportErrorThroughHoneyBadger(error, {
         name: 'uploadCsv function',
       })
     }
-    const message = getErrorMessage(error)
     dispatch(notify(csvUploaderErrorNotification(message)))
   }
 
@@ -97,7 +97,7 @@ export const CsvUploaderProvider: FC<Props> = React.memo(({children}) => {
           const {table, error} = fromFlux(csv)
           if (!table.length || error) {
             throw new Error(
-              `The CSV could not be parsed. Please make sure that CSV was in Annotated Format`
+              `The CSV could not be parsed. Please make sure that the CSV was in Annotated Format`
             )
           }
           const filtered = [


### PR DESCRIPTION
The CSV uploader isn't perfect, but the HB reporting makes it seems like things are failing apart regularly. This PR updates the condition when we report an error to HB so that we don't get spammed with a million emails