### PR TITLE
feat: add label mentioning time is in UTC

### DIFF
--- a/src/annotations/components/annotationForm/AnnotationStartTimeInput.tsx
+++ b/src/annotations/components/annotationForm/AnnotationStartTimeInput.tsx
@@ -66,7 +66,7 @@ export const AnnotationStartTimeInput: FC<Props> = (props: Props) => {
   return (
     <Grid.Column widthXS={Columns.Twelve}>
       <Form.Element
-        label="Start Time"
+        label="Start Time (UTC)"
         required={true}
         errorMessage={validationMessage}
       >


### PR DESCRIPTION
Connects #1328

Adds a label to the annotations date input that says `UTC`

![Screen Shot 2021-04-30 at 9 37 02 AM](https://user-images.githubusercontent.com/146112/116726223-d7c37980-a997-11eb-9009-9e18454bb66f.png)
