### PR TITLE
chore: allow for running OSS pipeline from monitor-ci script

### DIFF
--- a/scripts/run-monitor-ci-tests.bash
+++ b/scripts/run-monitor-ci-tests.bash
@@ -85,28 +85,26 @@ if [[ -z "${OSS_SHA:-}" ]]; then
 		printf "\nno passing monitor-ci pipelines found for this SHA, starting a new one\n"
 	fi
 
-	# start the monitor-ci pipeline from the UI repo
+	# set the parameters for starting the monitor-ci pipeline from the UI repo
 	DEPLOY_PROD=false
 	if [[ "${UI_BRANCH}" == "master" ]]; then
 		DEPLOY_PROD=false # TODO: change this to true when we're ready to depend on this script
 	fi
-	printf "\nstarting monitor-ci pipeline targeting monitor-ci branch ${MONITOR_CI_BRANCH}, UI branch ${UI_BRANCH} and using UI SHA ${SHA}\n"
-	pipeline=$(curl -s --fail --request POST \
-		--url https://circleci.com/api/v2/project/gh/influxdata/monitor-ci/pipeline \
-		--header "Circle-Token: ${API_KEY}" \
-		--header 'content-type: application/json' \
-		--header 'Accept: application/json'    \
-		--data "{\"branch\":\"${MONITOR_CI_BRANCH}\", \"parameters\":{ \"ui-sha\":\"${SHA}\", \"ui-branch\":\"${UI_BRANCH}\", \"ui-pull-request\":\"${PULL_REQUEST}\", \"deploy-prod\":${DEPLOY_PROD}}}")
+	pipelineStartMsg="starting monitor-ci pipeline targeting monitor-ci branch ${MONITOR_CI_BRANCH}, UI branch ${UI_BRANCH} and using UI SHA ${SHA}"
+	reqData="{\"branch\":\"${MONITOR_CI_BRANCH}\", \"parameters\":{ \"ui-sha\":\"${SHA}\", \"ui-branch\":\"${UI_BRANCH}\", \"ui-pull-request\":\"${PULL_REQUEST}\", \"deploy-prod\":${DEPLOY_PROD}}}"
 else
-	# start the monitor-ci pipeline from the influxdb repo
-	printf "\nstarting monitor-ci pipeline targeting monitor-ci branch ${MONITOR_CI_BRANCH} using OSS SHA ${OSS_SHA}\n"
-	pipeline=$(curl -s --fail --request POST \
-		--url https://circleci.com/api/v2/project/gh/influxdata/monitor-ci/pipeline \
-		--header "Circle-Token: ${API_KEY}" \
-		--header 'content-type: application/json' \
-		--header 'Accept: application/json'    \
-		--data "{\"branch\":\"${MONITOR_CI_BRANCH}\", \"parameters\":{ \"oss-sha\":\"${OSS_SHA}\" }}")
+	# set the parameters for starting the monitor-ci pipeline from the influxdb repo
+	pipelineStartMsg="starting monitor-ci pipeline targeting monitor-ci branch ${MONITOR_CI_BRANCH} using OSS SHA ${OSS_SHA}"
+	reqData="{\"branch\":\"${MONITOR_CI_BRANCH}\", \"parameters\":{ \"oss-sha\":\"${OSS_SHA}\" }}"
 fi
+
+printf "\n${pipelineStartMsg}\n"
+pipeline=$(curl -s --fail --request POST \
+	--url https://circleci.com/api/v2/project/gh/influxdata/monitor-ci/pipeline \
+	--header "Circle-Token: ${API_KEY}" \
+	--header 'content-type: application/json' \
+	--header 'Accept: application/json'    \
+	--data "${reqData}")
 
 if [ $? != 0 ]; then
 	echo "failed to start the monitor-ci pipeline, quitting"

--- a/scripts/run-monitor-ci-tests.bash
+++ b/scripts/run-monitor-ci-tests.bash
@@ -4,87 +4,110 @@ set -eu -o pipefail
 
 ########################
 # --- Script Summary ---
-# This script is the junction between the UI CI (public) and the monitor-ci CI (private).
+# This script is the junction between the CIs of the public UI and influxdb OSS repos and the monitor-ci CI (private).
 # When the public CI is started, this script kicks off the private CI and waits for it to complete.
 # This script uses the CircleCI APIs to make this magic happen.
 #
 # If the private CI fails, this script will collect the names and artifacts of the failed jobs and report them.
+# This script should support multiple workflows if more are added, although it has not been tested.
+# This script waits 40 minutes for the private CI to complete otherwise it fails.
+#
+# **For Running from the UI Repository:**
 # If you retry a failing job in the private CI and it passes, you can safely rerun this job in the public CI.
 #  - This script uses your commit SHA to search for a passing pipeline before starting a new one.
 #  - If you rerun the private CI and it passes, this script will find that pipeline and will not start a new one.
 #  - In this situation the script will exit quickly with success.
-# This script should support multiple workflows if more are added, although it has not been tested.
-# This script waits 40 minutes for the private CI to complete otherwise it fails.
 #
-# Required Env Vars:
+# Required Env Vars for Running from the UI Repository:
 # - SHA: the UI repo commit SHA we're running against
 # - API_KEY: the CircleCI API access key
 # - UI_BRANCH: the branch of the UI repo we're running against
 # - MONITOR_CI_BRANCH: the branch of the monitor-ci repo to start a pipeline with (usually 'master')
 # - PULL_REQUEST: the open pull request, if one exists (used for lighthouse)
+#
+# **For running from the influxdb OSS repository:**
+#	Since the OSS private CI is very simple, retrying a failing job in the private CI is not supported.
+#	Currently, only running e2e tests against the latest from the UI master branch is supported. 
+#
+# Required Env Vars for Running from the influxdb OSS Repository:
+# - OSS_SHA: the influxdb repo commit SHA we're running against
+# - MONITOR_CI_BRANCH: the branch of the monitor-ci repo to start a pipeline with (usually 'master')
 ########################
 
 # make dir for artifacts
 mkdir -p monitor-ci/test-artifacts/results/{build-oss-image,oss-e2e,build-image,cloud-e2e,cloud-e2e-firefox,cloud-e2e-k8s-idpe,cloud-lighthouse,smoke,build-prod-image,deploy}
 
-# get monitor-ci pipelines we've already run on this SHA
-found_passing_pipeline=0
-all_pipelines=$(curl -s --request GET \
-		--url "https://circleci.com/api/v2/project/gh/influxdata/monitor-ci/pipeline" \
-		--header "Circle-Token: ${API_KEY}" \
-		--header 'content-type: application/json' \
-		--header 'Accept: application/json')
-
-# check the status of the workflows for each of these pipelines
-all_pipelines_ids=( $(echo ${all_pipelines} | jq -r '.items | .[].id') )
-for pipeline_id in "${all_pipelines_ids[@]}"; do
-
-	config=$(curl -s --request GET \
-		--url "https://circleci.com/api/v2/pipeline/${pipeline_id}/config" \
-		--header "Circle-Token: ${API_KEY}" \
-		--header 'content-type: application/json' \
-		--header 'Accept: application/json')
-
-	# finds the UI SHA parameter used in this pipeline by hunting for the line "export UI_SHA="
-	pipeline_ui_sha=$(echo ${config} | jq '.compiled' | grep -o 'export UI_SHA=[^\]*' | grep -v 'export UI_SHA=${LATEST_SHA}' | head -1 | sed 's/=/\n/g' | tail -1 || true)
-
-	if [[ "${SHA}" == "${pipeline_ui_sha}" ]]; then
-		# check if this pipeline's 'build' workflow is passing
-		workflows=$(curl -s --request GET \
-			--url "https://circleci.com/api/v2/pipeline/${pipeline_id}/workflow" \
+# if we are not running from the OSS repo, OSS_SHA will be unset, so run from the UI repo.
+if [[ -z "${OSS_SHA:-}" ]]; then
+	# get monitor-ci pipelines we've already run on this SHA
+	found_passing_pipeline=0
+	all_pipelines=$(curl -s --request GET \
+			--url "https://circleci.com/api/v2/project/gh/influxdata/monitor-ci/pipeline" \
 			--header "Circle-Token: ${API_KEY}" \
 			--header 'content-type: application/json' \
 			--header 'Accept: application/json')
 
-		number_build_success_workflows=$(echo ${workflows} | jq '.items | map(select(.name == "build" and .status == "success")) | length')
-		if [ $number_build_success_workflows -gt 0 ]; then
-			# we've found a successful run
-			found_passing_pipeline=1
-			break
+	# check the status of the workflows for each of these pipelines
+	all_pipelines_ids=( $(echo ${all_pipelines} | jq -r '.items | .[].id') )
+	for pipeline_id in "${all_pipelines_ids[@]}"; do
+
+		config=$(curl -s --request GET \
+			--url "https://circleci.com/api/v2/pipeline/${pipeline_id}/config" \
+			--header "Circle-Token: ${API_KEY}" \
+			--header 'content-type: application/json' \
+			--header 'Accept: application/json')
+
+		# finds the UI SHA parameter used in this pipeline by hunting for the line "export UI_SHA="
+		pipeline_ui_sha=$(echo ${config} | jq '.compiled' | grep -o 'export UI_SHA=[^\]*' | grep -v 'export UI_SHA=${LATEST_SHA}' | head -1 | sed 's/=/\n/g' | tail -1 || true)
+
+		if [[ "${SHA}" == "${pipeline_ui_sha}" ]]; then
+			# check if this pipeline's 'build' workflow is passing
+			workflows=$(curl -s --request GET \
+				--url "https://circleci.com/api/v2/pipeline/${pipeline_id}/workflow" \
+				--header "Circle-Token: ${API_KEY}" \
+				--header 'content-type: application/json' \
+				--header 'Accept: application/json')
+
+			number_build_success_workflows=$(echo ${workflows} | jq '.items | map(select(.name == "build" and .status == "success")) | length')
+			if [ $number_build_success_workflows -gt 0 ]; then
+				# we've found a successful run
+				found_passing_pipeline=1
+				break
+			fi
 		fi
+	done
+
+	# terminate early if we found a passing pipeline for this SHA
+	if [ $found_passing_pipeline -eq 1 ]; then
+		printf "\nSUCCESS: Found a passing monitor-ci pipeline for this SHA, will not re-run these tests\n"
+		exit 0
+	else
+		printf "\nno passing monitor-ci pipelines found for this SHA, starting a new one\n"
 	fi
-done
 
-# terminate early if we found a passing pipeline for this SHA
-if [ $found_passing_pipeline -eq 1 ]; then
-	printf "\nSUCCESS: Found a passing monitor-ci pipeline for this SHA, will not re-run these tests\n"
-	exit 0
+	# start the monitor-ci pipeline
+	DEPLOY_PROD=false
+	if [[ "${UI_BRANCH}" == "master" ]]; then
+		DEPLOY_PROD=false # TODO: change this to true when we're ready to depend on this script
+	fi
+	printf "\nstarting monitor-ci pipeline targeting monitor-ci branch ${MONITOR_CI_BRANCH}, UI branch ${UI_BRANCH} and using UI SHA ${SHA}\n"
+	pipeline=$(curl -s --fail --request POST \
+		--url https://circleci.com/api/v2/project/gh/influxdata/monitor-ci/pipeline \
+		--header "Circle-Token: ${API_KEY}" \
+		--header 'content-type: application/json' \
+		--header 'Accept: application/json'    \
+		--data "{\"branch\":\"${MONITOR_CI_BRANCH}\", \"parameters\":{ \"ui-sha\":\"${SHA}\", \"ui-branch\":\"${UI_BRANCH}\", \"ui-pull-request\":\"${PULL_REQUEST}\", \"deploy-prod\":${DEPLOY_PROD}}}")
 else
-	printf "\nno passing monitor-ci pipelines found for this SHA, starting a new one\n"
+	# running from the OSS repo.
+	printf "\nstarting monitor-ci pipeline targeting monitor-ci branch ${MONITOR_CI_BRANCH} using OSS SHA ${OSS_SHA}\n"
+	
+	pipeline=$(curl -s --fail --request POST \
+		--url https://circleci.com/api/v2/project/gh/influxdata/monitor-ci/pipeline \
+		--header "Circle-Token: ${API_KEY}" \
+		--header 'content-type: application/json' \
+		--header 'Accept: application/json'    \
+		--data "{\"branch\":\"${MONITOR_CI_BRANCH}\", \"parameters\":{ \"oss-sha\":\"${OSS_SHA}\" }}")
 fi
-
-# start the monitor-ci pipeline
-DEPLOY_PROD=false
-if [[ "${UI_BRANCH}" == "master" ]]; then
-	DEPLOY_PROD=false # TODO: change this to true when we're ready to depend on this script
-fi
-printf "\nstarting monitor-ci pipeline targeting monitor-ci branch ${MONITOR_CI_BRANCH}, UI branch ${UI_BRANCH} and using UI SHA ${SHA}\n"
-pipeline=$(curl -s --fail --request POST \
-  --url https://circleci.com/api/v2/project/gh/influxdata/monitor-ci/pipeline \
-  --header "Circle-Token: ${API_KEY}" \
-  --header 'content-type: application/json' \
-	--header 'Accept: application/json'    \
-  --data "{\"branch\":\"${MONITOR_CI_BRANCH}\", \"parameters\":{ \"ui-sha\":\"${SHA}\", \"ui-branch\":\"${UI_BRANCH}\", \"ui-pull-request\":\"${PULL_REQUEST}\", \"deploy-prod\":${DEPLOY_PROD}}}")
 
 if [ $? != 0 ]; then
 	echo "failed to start the monitor-ci pipeline, quitting"

--- a/scripts/run-monitor-ci-tests.bash
+++ b/scripts/run-monitor-ci-tests.bash
@@ -26,8 +26,8 @@ set -eu -o pipefail
 # - PULL_REQUEST: the open pull request, if one exists (used for lighthouse)
 #
 # **For running from the influxdb OSS repository:**
-#	Since the OSS private CI is very simple, retrying a failing job in the private CI is not supported.
-#	Currently, only running e2e tests against the latest from the UI master branch is supported. 
+# Since the OSS private CI is very simple, retrying a failing job in the private CI is not supported.
+# Currently, only running e2e tests against the latest from the UI master branch is supported. 
 #
 # Required Env Vars for Running from the influxdb OSS Repository:
 # - OSS_SHA: the influxdb repo commit SHA we're running against
@@ -37,7 +37,7 @@ set -eu -o pipefail
 # make dir for artifacts
 mkdir -p monitor-ci/test-artifacts/results/{build-oss-image,oss-e2e,build-image,cloud-e2e,cloud-e2e-firefox,cloud-e2e-k8s-idpe,cloud-lighthouse,smoke,build-prod-image,deploy}
 
-# if we are not running from the OSS repo, OSS_SHA will be unset, so run from the UI repo.
+# if we are not running from the OSS repo, OSS_SHA will be unset, and we must be running from the UI repo.
 if [[ -z "${OSS_SHA:-}" ]]; then
 	# get monitor-ci pipelines we've already run on this SHA
 	found_passing_pipeline=0
@@ -85,7 +85,7 @@ if [[ -z "${OSS_SHA:-}" ]]; then
 		printf "\nno passing monitor-ci pipelines found for this SHA, starting a new one\n"
 	fi
 
-	# start the monitor-ci pipeline
+	# start the monitor-ci pipeline from the UI repo
 	DEPLOY_PROD=false
 	if [[ "${UI_BRANCH}" == "master" ]]; then
 		DEPLOY_PROD=false # TODO: change this to true when we're ready to depend on this script
@@ -98,9 +98,8 @@ if [[ -z "${OSS_SHA:-}" ]]; then
 		--header 'Accept: application/json'    \
 		--data "{\"branch\":\"${MONITOR_CI_BRANCH}\", \"parameters\":{ \"ui-sha\":\"${SHA}\", \"ui-branch\":\"${UI_BRANCH}\", \"ui-pull-request\":\"${PULL_REQUEST}\", \"deploy-prod\":${DEPLOY_PROD}}}")
 else
-	# running from the OSS repo.
+	# start the monitor-ci pipeline from the influxdb repo
 	printf "\nstarting monitor-ci pipeline targeting monitor-ci branch ${MONITOR_CI_BRANCH} using OSS SHA ${OSS_SHA}\n"
-	
 	pipeline=$(curl -s --fail --request POST \
 		--url https://circleci.com/api/v2/project/gh/influxdata/monitor-ci/pipeline \
 		--header "Circle-Token: ${API_KEY}" \


### PR DESCRIPTION
Partially closes #1007

Related: [monitor-ci PR#228](https://github.com/influxdata/monitor-ci/pull/228)

Updates the `run-monitor-ci-tests` bash script to have a different behavior if it is executed with the intent of testing changes in the OSS backend from `influxdb` with the latest UI from the `ui` repository.

If the script is executed with the env var `OSS_SHA` set, the API call to start the pipeline in `monitor-ci` will be what is required by the config updates in [monitor-ci PR#228](https://github.com/influxdata/monitor-ci/pull/228). If `OSS_SHA` is not set, the script will execute the same as before. The diff is a little misleading - basically all that is changing in the script is some updates to the comments at the beginning, and a conditional wrapping the existing pipeline API call for running from the `ui` repo, and the new logic for running with a set OSS backend commit sha against the latest UI.

We'll need to merge [monitor-ci PR#228](https://github.com/influxdata/monitor-ci/pull/228) first so that it can accept and act on the new `OSS_SHA` parameter. After this script update is merged, we can then update the `influxdb` CI to pull the script and execute it to run the e2e tests.