### PR TITLE
fix: show tag name as title when hovering in query builder

### DIFF
--- a/cypress/e2e/shared/tokens.test.ts
+++ b/cypress/e2e/shared/tokens.test.ts
@@ -250,13 +250,13 @@ describe('tokens', () => {
       cy.getByTestID('list--contents')
         .eq(0)
         .within(() => {
-          cy.getByTitle('Click to filter by Sicilsky Bull').click()
-          cy.getByTitle('Click to filter by A la Carta').click()
+          cy.getByTitle('Sicilsky Bull').click()
+          cy.getByTitle('A la Carta').click()
         })
       cy.getByTestID('list--contents')
         .eq(1)
         .within(() => {
-          cy.getByTitle('Click to filter by Sicilsky Bull').click()
+          cy.getByTitle('Sicilsky Bull').click()
         })
 
       cy.getByTestID('button--save').click()

--- a/src/timeMachine/components/SelectorList.tsx
+++ b/src/timeMachine/components/SelectorList.tsx
@@ -35,10 +35,6 @@ const SelectorList: SFC<Props> = props => {
       {items.map(item => {
         const selected = selectedItems.includes(item)
 
-        const title = selected
-          ? 'Click to remove this filter'
-          : `Click to filter by ${item}`
-
         const indicator = multiSelect && <List.Indicator type="checkbox" />
 
         return (
@@ -48,7 +44,7 @@ const SelectorList: SFC<Props> = props => {
             key={item}
             value={item}
             onClick={onSelectItem}
-            title={title}
+            title={item}
             selected={selected}
             size={ComponentSize.ExtraSmall}
             gradient={Gradients.GundamPilot}


### PR DESCRIPTION
Closes influxdata/idpe#10551

Updates the title when hovering over query builder elements. The title now shows the item's name with no instructions in both cases. This is a very quick fix - I looked into using `DraggableResizer` but it wasn't possible to get it working quickly.

![Screen Shot 2021-05-03 at 11 43 45 AM](https://user-images.githubusercontent.com/146112/116918608-fa0dff00-ac04-11eb-8ab3-88958c00a889.png)

![Screen Shot 2021-05-03 at 11 43 57 AM](https://user-images.githubusercontent.com/146112/116918686-14e07380-ac05-11eb-9865-c5c8851f67da.png)
