### PR TITLE
chore: remove walkme from the UI

### DIFF
--- a/src/cloud/components/RateLimitOverlay.tsx
+++ b/src/cloud/components/RateLimitOverlay.tsx
@@ -36,7 +36,7 @@ const RateLimitOverlay: FC<Props> = ({onClose, orgID}) => {
   const [showForm, toggleShowForm] = useState<boolean>(false)
 
   const handleOptimizeClick = (): void => {
-    history.push(`/orgs/${orgID}/settings/templates?walkme=19-880913`)
+    history.push(`/orgs/${orgID}/settings/templates`)
     onClose()
   }
 


### PR DESCRIPTION
Closes #1269 

This PR removes UI references to `walkme`. We'll need to remove the CSP headers from the `csp` file as well
