### PR TITLE
chore: have monitor-ci-tests wait on unit/lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -607,7 +607,10 @@ workflows:
             - cloud-e2e
             # TODO: uncomment this when we disable cloud-e2e
             # - cloud-e2e-k8s-idpe
-      - monitor-ci-tests
+      - monitor-ci-tests:
+          requires:
+            - unit
+            - lint
 commands:
   install_jsonnet_binary:
     description: >


### PR DESCRIPTION
We really shouldn't start the rest of the pipeline if the unit tests are failing. And also waiting on unit tests gives the user some time to open a PR before monitor-ci-tests starts so lighthouse won't complain about not getting a PR url.