### PR TITLE
feat: improve ui image build time, size, and security

### DIFF
--- a/docker/Dockerfile.chronograf.prod
+++ b/docker/Dockerfile.chronograf.prod
@@ -1,14 +1,5 @@
-FROM ubuntu:bionic AS base
-
-RUN apt-get update -y && \
-    apt-get install -y \
-        nginx \
-        build-essential \
-        curl \
-        git
-
-FROM base AS repo
-WORKDIR /repo
+# from node latest alpine 3.12
+FROM node:alpine3.12 AS repo
 
 # env vars to configure the system
 
@@ -38,17 +29,20 @@ ARG INJECT_HEADER
 # Injecting strings into the html never went wrong. we use this for google tag manager
 ARG INJECT_BODY
 
-ENV PATH="/node/bin:${PATH}"
-RUN mkdir /node && \
-    curl -sL https://git.io/n-install | N_PREFIX=/node bash -s -- -q
-
 COPY . /repo/ui
 WORKDIR /repo/ui
 
+RUN apk \
+    --update \
+    --no-cache \
+    --virtual build-dependencies \
+    add \
+    git
+
 # these are all run together as docker's caching mechanism
 # makes big steps like yarn install expensive
-RUN npx yarn install --production=false && \
-    npx yarn generate && \
+RUN yarn install --production=false && \
+    yarn generate && \
     $(npm bin)/webpack --config ./webpack.${WEBPACK_FILE}.ts --bail && \
     rm -rf ./node_modules
 


### PR DESCRIPTION
Currently the `Dockerfile.chronograf.docker` file uses an unnecessarily large base image, installs unneeded packages, and insecurely runs a downloaded script. This pr uses a slimmer base image and saves ~475MB per base image, speeds up required dependency installs by ~38 seconds, and doesn't require insecurely running downloaded scripts.

```
$ time docker build -t test/ui -f ./originalDockerfilePreReq .
...
Successfully tagged test/ui:latest

real    0m44.174s
user    0m0.138s
sys     0m0.082s

$ time docker build -t test/ui2 -f ./newDockerfilePreReq .
...
Successfully tagged test/ui2:latest

real    0m6.009s
user    0m0.588s
sys     0m0.685s

$ docker images --format "table {{.Repository}}\t{{.Size}}"
REPOSITORY                       SIZE
test/ui2                         129MB
test/ui                          604MB
```
