### PR TITLE
chore: change api flag to not have hyphens

### DIFF
--- a/src/flows/context/flow.list.tsx
+++ b/src/flows/context/flow.list.tsx
@@ -38,7 +38,7 @@ import {
 } from 'src/shared/copy/notifications'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
-const notebookAPIFlag = 'notebooks-api'
+const notebookAPIFlag = 'notebooksApi'
 export interface FlowListContextType extends FlowList {
   add: (flow?: Flow) => Promise<string>
   update: (id: string, flow: Flow) => void


### PR DESCRIPTION
Some of the backend flag systems can't handle hyphens, so changing it to `notebooksApi`
