### PR TITLE
chore: remove bundle analyzer plugin to speed up lighthouse builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,6 +113,7 @@ jobs:
             docker build \
               --build-arg UI_SHA=testing \
               --build-arg CLOUD_URL=http://localhost/auth \
+              --build-arg WEBPACK_FILE=lighthouse \
               -t quay.io/influxdb/ui-acceptance:${CIRCLE_SHA1} \
               -f ./ui/docker/Dockerfile.chronograf.prod \
               ./ui

--- a/webpack.lighthouse.ts
+++ b/webpack.lighthouse.ts
@@ -8,8 +8,6 @@ const path = require('path')
 // Plugins
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin')
 const TerserJSPlugin = require('terser-webpack-plugin')
-const BundleAnalyzerPlugin = require('webpack-bundle-analyzer')
-  .BundleAnalyzerPlugin
 
 const {STATIC_DIRECTORY} = require('./src/utils/env')
 
@@ -45,12 +43,4 @@ module.exports = merge(common, {
       chunks: 'all',
     },
   },
-  plugins: [
-    new BundleAnalyzerPlugin({
-      analyzerMode: 'static',
-      reportFilename: 'bundle-report.html',
-      openAnalyzer: false,
-      generateStatsFile: true,
-    }),
-  ],
 })

--- a/webpack.prod.ts
+++ b/webpack.prod.ts
@@ -8,8 +8,6 @@ const path = require('path')
 // Plugins
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin')
 const TerserJSPlugin = require('terser-webpack-plugin')
-const BundleAnalyzerPlugin = require('webpack-bundle-analyzer')
-  .BundleAnalyzerPlugin
 
 const {STATIC_DIRECTORY} = require('./src/utils/env')
 
@@ -45,12 +43,4 @@ module.exports = merge(common, {
       chunks: 'all',
     },
   },
-  plugins: [
-    new BundleAnalyzerPlugin({
-      analyzerMode: 'static',
-      reportFilename: 'bundle-report.html',
-      openAnalyzer: false,
-      generateStatsFile: true,
-    }),
-  ],
 })


### PR DESCRIPTION
There seems to be an issue right now with running lighthouse tests, but by removing the bundle analyzer from the ci chain, we save ~8 minutes off the prod image build.

before:
![image](https://user-images.githubusercontent.com/2653109/117369338-03f06600-ae82-11eb-8af1-0eb4d9693bec.png)
after:
![image](https://user-images.githubusercontent.com/2653109/117369307-faff9480-ae81-11eb-805c-fca0babe5b82.png)