### PR TITLE
chore: bump openapi sha

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -518,7 +518,7 @@ jobs:
       - checkout
       - run:
           name: Run monitor-ci tests
-          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="master" UI_BRANCH=${CIRCLE_BRANCH} SHA=${CIRCLE_SHA1} ./scripts/run-monitor-ci-tests.bash
+          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="genehynson/test-old-oss-acceptance" UI_BRANCH=${CIRCLE_BRANCH} SHA=${CIRCLE_SHA1} ./scripts/run-monitor-ci-tests.bash
       - store_artifacts:
           path: monitor-ci/test-artifacts/results/build-oss-image
           destination: test_artifacts/results/build-oss-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -518,7 +518,7 @@ jobs:
       - checkout
       - run:
           name: Run monitor-ci tests
-          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="genehynson/test-old-oss-acceptance" UI_BRANCH=${CIRCLE_BRANCH} SHA=${CIRCLE_SHA1} ./scripts/run-monitor-ci-tests.bash
+          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="master" UI_BRANCH=${CIRCLE_BRANCH} SHA=${CIRCLE_SHA1} ./scripts/run-monitor-ci-tests.bash
       - store_artifacts:
           path: monitor-ci/test-artifacts/results/build-oss-image
           destination: test_artifacts/results/build-oss-image

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "cy": "CYPRESS_dexUrl=https://$INGRESS_HOST:$PORT_HTTPS CYPRESS_baseUrl=http://localhost:9999 cypress open",
     "cy:dev": "source ../monitor-ci/.env && CYPRESS_dexUrl=https://$INGRESS_HOST:$PORT_HTTPS CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{cloud,shared}/**/*.*'",
     "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_dexUrl=OSS CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{oss,shared}/**/*.*'",
-    "generate": "export SHA=af4e3efa496c8adcd2838145652fdd8d63a90702 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
+    "generate": "export SHA=4f62aa6175c6f8e9a425ea8e3e143c8c93f2c652 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-meta": "yarn currentApi && yarn notebooks && yarn unity && yarn flows && yarn managedFunctions",
     "oss": "oats ${REMOTE}contracts/oss-diff.yml > ./src/client/ossRoutes.ts",


### PR DESCRIPTION
updates the sha to latest