### PR TITLE
fix: only get public flags if cloud

### DIFF
--- a/src/Signin.tsx
+++ b/src/Signin.tsx
@@ -57,7 +57,9 @@ export class Signin extends PureComponent<Props, State> {
   public async componentDidMount() {
     this.hasMounted = true
     this.setState({loading: RemoteDataState.Loading})
-    await this.props.onGetPublicFlags()
+    if (CLOUD) {
+      await this.props.onGetPublicFlags()
+    }
 
     await this.checkForLogin()
 


### PR DESCRIPTION
Closes #1368

Adds the conditional to only get the public flags `IF (CLOUD)`
