### PR TITLE
feat(notebooks): pass org id as query param when getting all notebooks

### DIFF
--- a/src/client/swagger/notebooks.yml
+++ b/src/client/swagger/notebooks.yml
@@ -57,6 +57,11 @@ paths:
   /notebooks:
     get:
       description: get all records
+      parameters:
+        - name: orgID
+          in: query
+          type: string
+          required: true
       produces:
         - application/json
       responses:

--- a/src/client/swagger/notebooks.yml
+++ b/src/client/swagger/notebooks.yml
@@ -57,11 +57,6 @@ paths:
   /notebooks:
     get:
       description: get all records
-      parameters:
-        - name: orgID
-          in: query
-          type: string
-          required: true
       produces:
         - application/json
       responses:

--- a/src/flows/context/notebooks.api.tsx
+++ b/src/flows/context/notebooks.api.tsx
@@ -76,7 +76,7 @@ export const deleteAPI = async (ids: DeleteNotebookParams) => {
 }
 
 export const getAllAPI = async (orgID: string) => {
-  const res = await getNotebooks({orgID})
+  const res = await getNotebooks({query: {orgID}})
   if (res.status != 200) {
     throw new Error(res.data.message)
   }


### PR DESCRIPTION
Closes #1383

This will allow the multi-org-per-user feature of OSS to work with the minimal amount of effort.

We may want to revisit this down the line when InfluxDB cloud implements multi-org-per-user.
