### PR TITLE
fix: FileUploadSection returns null instead of undefined

### DIFF
--- a/src/writeData/components/FileUploadSection.tsx
+++ b/src/writeData/components/FileUploadSection.tsx
@@ -21,7 +21,7 @@ const FileUploadSection = () => {
   const items = search(searchTerm)
 
   if (!items.length) {
-    return
+    return null
   }
 
   return (


### PR DESCRIPTION
Closes #1397 

React doesn't like when you return undefined apparently
