### PR TITLE
fix(annotations): change annotation event structure so cancel metric isn't fired so often

### DIFF
--- a/src/annotations/components/EditAnnotationForm.tsx
+++ b/src/annotations/components/EditAnnotationForm.tsx
@@ -9,6 +9,7 @@ import {
   Grid,
   Overlay,
 } from '@influxdata/clockface'
+
 import {AnnotationMessageInput} from 'src/annotations/components/annotationForm/AnnotationMessageInput'
 import {AnnotationStartTimeInput} from 'src/annotations/components/annotationForm/AnnotationStartTimeInput'
 
@@ -81,6 +82,11 @@ export const EditAnnotationForm: FC<Props> = (props: Props) => {
     props.handleSubmit(editedAnnotation)
   }
 
+  const handleCancel = () => {
+    event('dashboards.annotations.create_annotation.cancel')
+    props.handleClose()
+  }
+
   const handleDelete = () => {
     try {
       dispatch(deleteAnnotations(editedAnnotation))
@@ -97,7 +103,7 @@ export const EditAnnotationForm: FC<Props> = (props: Props) => {
     <Overlay.Container maxWidth={ANNOTATION_FORM_WIDTH}>
       <Overlay.Header
         title="Edit Annotation"
-        onDismiss={props.handleClose}
+        onDismiss={handleCancel}
         className="edit-annotation-head"
       />
       <Grid className="edit-annotation-grid">
@@ -125,7 +131,7 @@ export const EditAnnotationForm: FC<Props> = (props: Props) => {
         <div className="edit-annotation-buttons">
           <Button
             text="Cancel"
-            onClick={props.handleClose}
+            onClick={handleCancel}
             color={ComponentColor.Default}
             className="edit-annotation-cancel"
             testID="edit-annotation-cancel-button"

--- a/src/annotations/components/annotationForm/AnnotationForm.tsx
+++ b/src/annotations/components/annotationForm/AnnotationForm.tsx
@@ -1,6 +1,9 @@
 // Libraries
 import React, {FC, FormEvent, useState} from 'react'
 
+// Utils
+import {event} from 'src/cloud/utils/reporting'
+
 // Components
 import {
   Overlay,
@@ -58,11 +61,16 @@ export const AnnotationForm: FC<Props> = (props: Props) => {
     props.onSubmit({message, startTime})
   }
 
+  const handleCancel = () => {
+    event('dashboards.annotations.create_annotation.cancel')
+    props.onClose()
+  }
+
   return (
     <Overlay.Container maxWidth={ANNOTATION_FORM_WIDTH}>
       <Overlay.Header
         title={`${props.title} Annotation`}
-        onDismiss={props.onClose}
+        onDismiss={handleCancel}
       />
       <Form onSubmit={handleSubmit}>
         <Overlay.Body>
@@ -84,7 +92,7 @@ export const AnnotationForm: FC<Props> = (props: Props) => {
           </Grid>
         </Overlay.Body>
         <Overlay.Footer>
-          <Button text="Cancel" onClick={props.onClose} />
+          <Button text="Cancel" onClick={handleCancel} />
           <Button
             text="Save Annotation"
             color={ComponentColor.Primary}

--- a/src/visualization/components/annotationUtils.ts
+++ b/src/visualization/components/annotationUtils.ts
@@ -54,7 +54,6 @@ export const makeAnnotationClickListener = (
           startTime: plotInteraction?.clampedValueX ?? plotInteraction.valueX,
         },
         () => {
-          event(`${eventPrefix}.annotations.create_annotation.cancel`)
           dismissOverlay()
         }
       )
@@ -81,7 +80,6 @@ const makeAnnotationClickHandler = (
           'edit-annotation',
           {clickedAnnotation: {...annotationToEdit, stream: cellID}},
           () => {
-            event(`${eventPrefix}.annotations.edit_annotation.cancel`)
             dismissOverlay()
           }
         )


### PR DESCRIPTION
Closes #1403

Moves cancel events lower down the stack so that they're not always called when the overlay is closed. They're now only fired when the cancel button is clicked.

<!-- Describe your proposed changes here. -->
