### PR TITLE
feat(annotations): update annotation button ux

### DIFF
--- a/cypress/e2e/cloud/annotations.test.ts
+++ b/cypress/e2e/cloud/annotations.test.ts
@@ -63,7 +63,6 @@ describe('The Annotations UI functionality', () => {
 
     cy.getByTestID('toggle-annotations-controls').click()
     cy.getByTestID('annotations-control-bar').should('be.visible')
-    cy.getByTestID('annotations-one-click-toggle').click()
   }
 
   afterEach(() => {
@@ -153,7 +152,7 @@ describe('The Annotations UI functionality', () => {
     })
   }
 
-  describe('graph + single stat tests here:', () => {
+  describe('annotations on a graph + single stat graph type', () => {
     beforeEach(() => {
       setupData(cy, true)
     })
@@ -168,7 +167,7 @@ describe('The Annotations UI functionality', () => {
     })
   })
 
-  describe('graph (xy line) tests here: ', () => {
+  describe('annotations on a graph (xy line) graph type: ', () => {
     beforeEach(() => {
       setupData(cy)
     })
@@ -206,7 +205,7 @@ describe('The Annotations UI functionality', () => {
 
     it('can disable writing annotations if Enable-Annotations is disabled', () => {
       // turn off one-click annotation
-      cy.getByTestID('annotations-one-click-toggle').click()
+      cy.getByTestID('annotations-write-mode-toggle').click()
 
       // click on the graph
       cy.getByTestID('cell blah').within(() => {

--- a/src/annotations/actions/creators.ts
+++ b/src/annotations/actions/creators.ts
@@ -5,8 +5,8 @@ import {AnnotationEvent} from 'src/client/annotationdRoutes'
 export const DELETE_ANNOTATION = 'DELETE_ANNOTATION'
 export const SET_ANNOTATIONS = 'SET_ANNOTATIONS'
 export const SET_ANNOTATION_STREAMS = 'SET_ANNOTATION_STREAMS'
-export const TOGGLE_ANNOTATION_VISIBILITY = 'TOGGLE_ANNOTATION_VISIBILITY'
-export const TOGGLE_SINGLE_CLICK_ANNOTATIONS = 'TOGGLE_SINGLE_CLICK_ANNOTATIONS'
+export const TOGGLE_ANNOTATIONS_VISIBILITY = 'TOGGLE_ANNOTATIONS_VISIBILITY'
+export const TOGGLE_ANNOTATIONS_WRITE_MODE = 'TOGGLE_ANNOTATIONS_WRITE_MODE'
 export const EDIT_ANNOTATION = 'EDIT_ANNOTATION'
 
 export type Action =
@@ -14,8 +14,8 @@ export type Action =
   | ReturnType<typeof editAnnotation>
   | ReturnType<typeof setAnnotations>
   | ReturnType<typeof setAnnotationStreams>
-  | ReturnType<typeof toggleAnnotationVisibility>
-  | ReturnType<typeof toggleSingleClickAnnotations>
+  | ReturnType<typeof setAnnotationsVisibility>
+  | ReturnType<typeof setAnnotationsWriteMode>
 
 export const setAnnotations = (annotations: AnnotationResponse[]) =>
   ({
@@ -29,9 +29,10 @@ export const setAnnotationStreams = (streams: AnnotationStream[]) =>
     streams,
   } as const)
 
-export const toggleSingleClickAnnotations = () =>
+export const setAnnotationsWriteMode = (isEnabled: boolean) =>
   ({
-    type: TOGGLE_SINGLE_CLICK_ANNOTATIONS,
+    type: TOGGLE_ANNOTATIONS_WRITE_MODE,
+    isEnabled,
   } as const)
 
 export const deleteAnnotation = (annotation: AnnotationEvent) =>
@@ -43,7 +44,8 @@ export const deleteAnnotation = (annotation: AnnotationEvent) =>
 export const editAnnotation = (annotation: AnnotationEvent) =>
   ({type: EDIT_ANNOTATION, annotation} as const)
 
-export const toggleAnnotationVisibility = () =>
+export const setAnnotationsVisibility = (isVisible: boolean) =>
   ({
-    type: TOGGLE_ANNOTATION_VISIBILITY,
+    type: TOGGLE_ANNOTATIONS_VISIBILITY,
+    isVisible,
   } as const)

--- a/src/annotations/components/AnnotationsControlBarToggleButton.tsx
+++ b/src/annotations/components/AnnotationsControlBarToggleButton.tsx
@@ -28,6 +28,7 @@ export const AnnotationsControlBarToggleButton: FC = () => {
 
   const handleClick = (): void => {
     dispatch(toggleShowAnnotationsControls())
+
     event('dashboard.annotations.control_bar_toggle_button.toggle', {
       newIsControlBarVisible: (!isVisible).toString(),
     })

--- a/src/annotations/components/controlBar/AnnotationsControlBar.test.tsx
+++ b/src/annotations/components/controlBar/AnnotationsControlBar.test.tsx
@@ -1,5 +1,6 @@
 // Installed libraries
 import React from 'react'
+import {fireEvent, cleanup, waitFor} from '@testing-library/react'
 
 // Mock State
 import {renderWithReduxAndRouter} from 'src/mockState'
@@ -10,7 +11,6 @@ import {normalize} from 'normalizr'
 import {Organization} from 'src/client'
 import {OrgEntities, RemoteDataState} from 'src/types'
 import {arrayOfOrgs} from 'src/schemas'
-import {fireEvent, cleanup, waitFor} from '@testing-library/react'
 import {AnnotationsControlBar} from './AnnotationsControlBar'
 import {
   setAnnotations,
@@ -224,18 +224,17 @@ describe('the annotations control bar ui functionality', () => {
     expect(visibleStreamsByID).toStrictEqual(['default'])
   })
 
-  it('can enable the one click add annotation', async () => {
-    const toggleButton = getByTestId('annotations-one-click-toggle')
+  it('can toggle write mode (which is on by defaul)', async () => {
+    const toggleButton = getByTestId('annotations-write-mode-toggle')
 
     await waitFor(() => {
       fireEvent.click(toggleButton)
     })
 
-    const enableSingleClickAnnotations = store.getState().annotations
-      .enableSingleClickAnnotations
+    const enableWriteMode = store.getState().annotations.enableWriteMode
 
-    // by default the annotations single click to add is disabled, above toggle enables it
-    expect(enableSingleClickAnnotations).toBeTruthy()
+    // annotation write mode is on by default
+    expect(enableWriteMode).toBeFalsy()
   })
 
   it('can toggle the visibility of annotations (which are on by default)', async () => {

--- a/src/annotations/components/controlBar/AnnotationsControlBar.tsx
+++ b/src/annotations/components/controlBar/AnnotationsControlBar.tsx
@@ -17,13 +17,13 @@ import {
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
 import Toolbar from 'src/shared/components/toolbar/Toolbar'
 import {
-  toggleAnnotationVisibility,
-  toggleSingleClickAnnotations,
+  setAnnotationsVisibility,
+  setAnnotationsWriteMode,
 } from 'src/annotations/actions/creators'
 
 // Selectors
 import {
-  isSingleClickAnnotationsEnabled,
+  isWriteModeEnabled,
   selectAreAnnotationsVisible,
 } from 'src/annotations/selectors'
 
@@ -31,8 +31,8 @@ import {
 import {event} from 'src/cloud/utils/reporting'
 
 export const AnnotationsControlBar: FC = () => {
-  const inWriteMode = useSelector(isSingleClickAnnotationsEnabled)
   const annotationsAreVisible = useSelector(selectAreAnnotationsVisible)
+  const inWriteMode = useSelector(isWriteModeEnabled)
 
   const dispatch = useDispatch()
 
@@ -40,14 +40,14 @@ export const AnnotationsControlBar: FC = () => {
     event('dashboard.annotations.change_write_mode.toggle', {
       newIsWriteModeEnabled: (!inWriteMode).toString(),
     })
-    dispatch(toggleSingleClickAnnotations())
+    dispatch(setAnnotationsWriteMode(!inWriteMode))
   }
 
   const changeAnnotationVisibility = () => {
     event('dashboard.annotations.change_visibility_mode.toggle', {
       newAnnotationsAreVisible: (!annotationsAreVisible).toString(),
     })
-    dispatch(toggleAnnotationVisibility())
+    dispatch(setAnnotationsVisibility(!annotationsAreVisible))
   }
 
   return (
@@ -90,10 +90,10 @@ export const AnnotationsControlBar: FC = () => {
             onChange={changeWriteMode}
             color={ComponentColor.Primary}
             size={ComponentSize.ExtraSmall}
-            testID="annotations-one-click-toggle"
+            testID="annotations-write-mode-toggle"
           >
             <InputLabel htmlFor="enable-annotation-mode">
-              Enable 1-Click Annotations
+              Enable Write Mode
             </InputLabel>
           </Toggle>
         </FlexBoxChild>

--- a/src/annotations/reducers/index.test.ts
+++ b/src/annotations/reducers/index.test.ts
@@ -51,7 +51,7 @@ describe('the annotations reducer', () => {
         ],
       },
       annotationsAreVisible: true,
-      enableSingleClickAnnotations: false,
+      enableWriteMode: true,
       visibleStreamsByID: [],
       streams: [],
     })

--- a/src/annotations/reducers/index.ts
+++ b/src/annotations/reducers/index.ts
@@ -4,8 +4,8 @@ import {
   EDIT_ANNOTATION,
   SET_ANNOTATIONS,
   SET_ANNOTATION_STREAMS,
-  TOGGLE_ANNOTATION_VISIBILITY,
-  TOGGLE_SINGLE_CLICK_ANNOTATIONS,
+  TOGGLE_ANNOTATIONS_VISIBILITY,
+  TOGGLE_ANNOTATIONS_WRITE_MODE,
 } from 'src/annotations/actions/creators'
 
 import {Annotation, AnnotationsList, AnnotationStream} from 'src/types'
@@ -15,7 +15,7 @@ export interface AnnotationsState {
   annotations: AnnotationsList
   annotationsAreVisible: boolean // a temporary (we'll see) measure until we enable streams
   visibleStreamsByID: string[]
-  enableSingleClickAnnotations: boolean
+  enableWriteMode: boolean
 }
 
 export const initialState = (): AnnotationsState => ({
@@ -23,7 +23,7 @@ export const initialState = (): AnnotationsState => ({
     default: [] as Annotation[],
   },
   annotationsAreVisible: true,
-  enableSingleClickAnnotations: false,
+  enableWriteMode: true,
   streams: [],
   visibleStreamsByID: [],
 })
@@ -81,19 +81,17 @@ export const annotationsReducer = (
       }
     }
 
-    case TOGGLE_ANNOTATION_VISIBILITY: {
+    case TOGGLE_ANNOTATIONS_VISIBILITY: {
       return {
         ...state,
-        annotationsAreVisible: !state.annotationsAreVisible,
+        annotationsAreVisible: action.isVisible,
       }
     }
 
-    case TOGGLE_SINGLE_CLICK_ANNOTATIONS: {
-      const newVal = !state.enableSingleClickAnnotations
-
+    case TOGGLE_ANNOTATIONS_WRITE_MODE: {
       return {
         ...state,
-        enableSingleClickAnnotations: newVal,
+        enableWriteMode: action.isEnabled,
       }
     }
     default:

--- a/src/annotations/selectors/index.ts
+++ b/src/annotations/selectors/index.ts
@@ -25,8 +25,8 @@ export const getAnnotationStreams = (state: AppState): AnnotationStream[] => {
   return state.annotations.streams
 }
 
-export const isSingleClickAnnotationsEnabled = (state: AppState): boolean => {
-  return state.annotations.enableSingleClickAnnotations
+export const isWriteModeEnabled = (state: AppState): boolean => {
+  return state.annotations.enableWriteMode
 }
 
 export const selectAreAnnotationsVisible = (state: AppState): boolean => {

--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -18,7 +18,7 @@ import {AppSettingContext} from 'src/shared/contexts/app'
 
 // Redux
 import {
-  isSingleClickAnnotationsEnabled,
+  isWriteModeEnabled,
   selectAreAnnotationsVisible,
 } from 'src/annotations/selectors'
 
@@ -83,7 +83,7 @@ const XYPlot: FC<Props> = ({
   // is in a dashboard or in configuration/single cell popout mode
   // would need to add the annotation control bar to the VEOHeader to get access to the controls,
   // which are currently global values, not per dashboard
-  const inAnnotationWriteMode = useSelector(isSingleClickAnnotationsEnabled)
+  const inAnnotationWriteMode = useSelector(isWriteModeEnabled)
   const annotationsAreVisible = useSelector(selectAreAnnotationsVisible)
 
   const storedXDomain = useMemo(() => parseXBounds(properties.axes.x.bounds), [

--- a/src/visualization/types/SingleStatWithLine/view.tsx
+++ b/src/visualization/types/SingleStatWithLine/view.tsx
@@ -13,7 +13,7 @@ import {
 
 // Redux
 import {
-  isSingleClickAnnotationsEnabled,
+  isWriteModeEnabled,
   selectAreAnnotationsVisible,
 } from 'src/annotations/selectors'
 
@@ -89,7 +89,7 @@ const SingleStatWithLine: FC<Props> = ({
   // is in a dashboard or in configuration/single cell popout mode
   // would need to add the annotation control bar to the VEOHeader to get access to the controls,
   // which are currently global values, not per dashboard
-  const inAnnotationWriteMode = useSelector(isSingleClickAnnotationsEnabled)
+  const inAnnotationWriteMode = useSelector(isWriteModeEnabled)
   const annotationsAreVisible = useSelector(selectAreAnnotationsVisible)
   const dispatch = useDispatch()
 


### PR DESCRIPTION
Closes #1320

- Change `1-click annotations` to `Write mode`
- Write mode is on by default