### PR TITLE
fix: misc notebook bugs

### DIFF
--- a/src/flows/components/AddButtons.tsx
+++ b/src/flows/components/AddButtons.tsx
@@ -11,6 +11,7 @@ import {PIPE_DEFINITIONS} from 'src/flows'
 
 // Utils
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import {event} from 'src/cloud/utils/reporting'
 
 import {TypeRegistration} from 'src/types/flows'
 
@@ -98,6 +99,8 @@ const AddButtons: FC<Props> = ({index, onInsert}) => {
             }
 
             onInsert && onInsert()
+
+            event('insert_notebook_cell', {notebooksCellType: def.type})
 
             add(
               {

--- a/src/flows/components/header/Submit.tsx
+++ b/src/flows/components/header/Submit.tsx
@@ -15,7 +15,6 @@ import {QueryContext} from 'src/flows/context/query'
 import {FlowQueryContext} from 'src/flows/context/flow.query'
 import {RunModeContext, RunMode} from 'src/flows/context/runMode'
 import {notify} from 'src/shared/actions/notifications'
-import {FlowContext} from 'src/flows/context/flow.current'
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'
@@ -29,28 +28,15 @@ import {RemoteDataState} from 'src/types'
 const fakeNotify = notify
 
 export const Submit: FC = () => {
-  const {flow} = useContext(FlowContext)
   const {cancel} = useContext(QueryContext)
   const {runMode, setRunMode} = useContext(RunModeContext)
-  const {generateMap, queryAll} = useContext(FlowQueryContext)
+  const {generateMap, queryAll, status} = useContext(FlowQueryContext)
 
   const hasQueries = useMemo(() => generateMap().length > 0, [generateMap])
 
   const handleSubmit = () => {
     event('Notebook Submit Button Clicked')
     queryAll()
-  }
-
-  const statuses = flow.meta.all.map(({loading}) => loading)
-
-  let status = RemoteDataState.Done
-
-  if (statuses.every(s => s === RemoteDataState.NotStarted)) {
-    status = RemoteDataState.NotStarted
-  } else if (statuses.includes(RemoteDataState.Error)) {
-    status = RemoteDataState.Error
-  } else if (statuses.includes(RemoteDataState.Loading)) {
-    status = RemoteDataState.Loading
   }
 
   const DropdownButton = (

--- a/src/flows/components/panel/FlowPanel.tsx
+++ b/src/flows/components/panel/FlowPanel.tsx
@@ -38,10 +38,6 @@ const FlowPanelHeader: FC<HeaderProps> = ({
 }) => {
   const {flow} = useContext(FlowContext)
   const {generateMap} = useContext(FlowQueryContext)
-  const removePipe = () => {
-    flow.data.remove(id)
-    flow.meta.remove(id)
-  }
   const index = flow.data.indexOf(id)
   const canBeMovedUp = index > 0
   const canBeMovedDown = index < flow.data.allIDs.length - 1
@@ -115,7 +111,6 @@ const FlowPanelHeader: FC<HeaderProps> = ({
     /* eslint-enable no-console */
   }, [id])
 
-  const remove = useCallback(() => removePipe(), [removePipe, id])
   return (
     <div className="flow-panel--header">
       <div className="flow-panel--node-wrapper">
@@ -149,7 +144,7 @@ const FlowPanelHeader: FC<HeaderProps> = ({
               />
             </FeatureFlag>
             <PanelVisibilityToggle id={id} />
-            <RemovePanelButton onRemove={remove} />
+            <RemovePanelButton id={id} />
             {persistentControl}
           </div>
         </>

--- a/src/flows/components/panel/RemovePanelButton.tsx
+++ b/src/flows/components/panel/RemovePanelButton.tsx
@@ -1,25 +1,25 @@
 // Libraries
-import React, {FC} from 'react'
+import React, {FC, useContext} from 'react'
 
 // Components
 import {SquareButton, IconFont} from '@influxdata/clockface'
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'
+import {FlowContext} from 'src/flows/context/flow.current'
 
 interface Props {
-  onRemove?: () => void
+  id: string
 }
 
-const RemoveButton: FC<Props> = ({onRemove}) => {
-  if (!onRemove) {
-    return null
-  }
+const RemoveButton: FC<Props> = ({id}) => {
+  const {flow} = useContext(FlowContext)
+  const remove = () => {
+    const {type} = flow.data.get(id)
+    event('notebook_delete_cell', {notebooksCellType: type})
 
-  const handleClick = (): void => {
-    event('notebook_delete_cell')
-
-    onRemove()
+    flow.data.remove(id)
+    flow.meta.remove(id)
   }
 
   return (
@@ -27,7 +27,7 @@ const RemoveButton: FC<Props> = ({onRemove}) => {
       className="flows-delete-cell"
       testID="flows-delete-cell"
       icon={IconFont.Remove}
-      onClick={handleClick}
+      onClick={remove}
       titleText="Remove this cell"
     />
   )

--- a/src/flows/components/panel/Results.tsx
+++ b/src/flows/components/panel/Results.tsx
@@ -5,7 +5,6 @@ import {Button, ComponentStatus, IconFont} from '@influxdata/clockface'
 // Components
 import Resizer from 'src/flows/shared/Resizer'
 
-import {FlowContext} from 'src/flows/context/flow.current'
 import {PipeContext} from 'src/flows/context/pipe'
 import {FlowQueryContext} from 'src/flows/context/flow.query'
 import {RunModeContext} from 'src/flows/context/runMode'
@@ -18,19 +17,18 @@ import {Visibility} from 'src/types/flows'
 import {View} from 'src/visualization'
 
 const Results: FC = () => {
-  const {flow} = useContext(FlowContext)
   const {id, results, queryText} = useContext(PipeContext)
-  const {basic} = useContext(FlowQueryContext)
+  const {basic, getStatus} = useContext(FlowQueryContext)
   const {runMode} = useContext(RunModeContext)
   const [height, setHeight] = useState(MINIMUM_RESIZER_HEIGHT)
   const [visibility, setVisibility] = useState('visible' as Visibility)
-  const meta = flow.meta.get(id)
   const resultsExist = !!(results?.parsed?.table || []).length
+  const status = getStatus(id)
 
   let emptyText
-  if (meta.loading === RemoteDataState.NotStarted) {
+  if (status === RemoteDataState.NotStarted) {
     emptyText = `Click ${runMode} to see results`
-  } else if (meta.loading === RemoteDataState.Loading) {
+  } else if (status === RemoteDataState.Loading) {
     emptyText = 'Loading...'
   } else {
     emptyText = 'No Data Returned'
@@ -51,7 +49,7 @@ const Results: FC = () => {
 
   return (
     <Resizer
-      loading={meta.loading}
+      loading={status}
       resizingEnabled={resultsExist}
       emptyText={emptyText}
       error={results.error}

--- a/src/flows/context/flow.current.tsx
+++ b/src/flows/context/flow.current.tsx
@@ -3,7 +3,6 @@ import {Flow, PipeData} from 'src/types/flows'
 import {FlowListContext, FlowListProvider} from 'src/flows/context/flow.list'
 import {v4 as UUID} from 'uuid'
 import {PROJECT_NAME, PIPE_DEFINITIONS} from 'src/flows'
-import {event} from 'src/cloud/utils/reporting'
 
 export interface FlowContextType {
   id: string | null
@@ -51,8 +50,6 @@ export const FlowProvider: FC = ({children}) => {
     if (typeof index !== 'undefined') {
       flows[currentID].data.move(id, index + 1)
     }
-
-    event('insert_notebook_cell', {notebooksCellType: initial.type})
 
     return id
   }

--- a/src/flows/context/flow.current.tsx
+++ b/src/flows/context/flow.current.tsx
@@ -2,7 +2,6 @@ import React, {FC, useContext, useCallback} from 'react'
 import {Flow, PipeData} from 'src/types/flows'
 import {FlowListContext, FlowListProvider} from 'src/flows/context/flow.list'
 import {v4 as UUID} from 'uuid'
-import {RemoteDataState} from 'src/types'
 import {PROJECT_NAME, PIPE_DEFINITIONS} from 'src/flows'
 import {event} from 'src/cloud/utils/reporting'
 
@@ -47,7 +46,6 @@ export const FlowProvider: FC = ({children}) => {
       title: `${PIPE_DEFINITIONS[initial.type].button ||
         'Panel'} ${++GENERATOR_INDEX}`,
       visible: true,
-      loading: RemoteDataState.NotStarted,
     })
 
     if (typeof index !== 'undefined') {

--- a/src/flows/context/flow.list.tsx
+++ b/src/flows/context/flow.list.tsx
@@ -11,7 +11,6 @@ import {
   PipeData,
   PipeMeta,
 } from 'src/types/flows'
-import {RemoteDataState} from 'src/types'
 import {default as _asResource} from 'src/flows/context/resource.hook'
 import {PIPE_DEFINITIONS} from 'src/flows'
 import {DEFAULT_TIME_RANGE} from 'src/shared/constants/timeRanges'
@@ -123,7 +122,6 @@ export function hydrate(data) {
     const meta = {
       title: pipe.title,
       visible: pipe.visible,
-      loading: RemoteDataState.NotStarted,
     }
 
     delete pipe.title
@@ -169,38 +167,6 @@ export const FlowListProvider: FC = ({children}) => {
     let _flowData
 
     if (!flow) {
-      if (isFlagEnabled('molly-first') && Object.keys(flows).length === 0) {
-        _flowData = hydrate({
-          name: `Name this ${PROJECT_NAME}`,
-          readOnly: false,
-          range: DEFAULT_TIME_RANGE,
-          refresh: AUTOREFRESH_DEFAULT,
-          pipes: [
-            {
-              title: 'Welcome',
-              visible: true,
-              type: 'youtube',
-              uri: 'Rs16uhxK0h8',
-            },
-            {
-              title: 'Select a Metric',
-              visible: true,
-              type: 'metricSelector',
-              ...JSON.parse(
-                JSON.stringify(PIPE_DEFINITIONS['metricSelector'].initial)
-              ),
-            },
-            {
-              title: 'Visualize the Result',
-              visible: true,
-              type: 'visualization',
-              ...JSON.parse(
-                JSON.stringify(PIPE_DEFINITIONS['visualization'].initial)
-              ),
-            },
-          ],
-        })
-      } else {
         _flowData = hydrate({
           name: `Name this ${PROJECT_NAME}`,
           readOnly: false,
@@ -225,7 +191,6 @@ export const FlowListProvider: FC = ({children}) => {
             },
           ],
         })
-      }
       _flow = {
         ..._flowData,
       }

--- a/src/flows/context/flow.list.tsx
+++ b/src/flows/context/flow.list.tsx
@@ -167,30 +167,30 @@ export const FlowListProvider: FC = ({children}) => {
     let _flowData
 
     if (!flow) {
-        _flowData = hydrate({
-          name: `Name this ${PROJECT_NAME}`,
-          readOnly: false,
-          range: DEFAULT_TIME_RANGE,
-          refresh: AUTOREFRESH_DEFAULT,
-          pipes: [
-            {
-              title: 'Select a Metric',
-              visible: true,
-              type: 'metricSelector',
-              ...JSON.parse(
-                JSON.stringify(PIPE_DEFINITIONS['metricSelector'].initial)
-              ),
-            },
-            {
-              title: 'Visualize the Result',
-              visible: true,
-              type: 'visualization',
-              ...JSON.parse(
-                JSON.stringify(PIPE_DEFINITIONS['visualization'].initial)
-              ),
-            },
-          ],
-        })
+      _flowData = hydrate({
+        name: `Name this ${PROJECT_NAME}`,
+        readOnly: false,
+        range: DEFAULT_TIME_RANGE,
+        refresh: AUTOREFRESH_DEFAULT,
+        pipes: [
+          {
+            title: 'Select a Metric',
+            visible: true,
+            type: 'metricSelector',
+            ...JSON.parse(
+              JSON.stringify(PIPE_DEFINITIONS['metricSelector'].initial)
+            ),
+          },
+          {
+            title: 'Visualize the Result',
+            visible: true,
+            type: 'visualization',
+            ...JSON.parse(
+              JSON.stringify(PIPE_DEFINITIONS['visualization'].initial)
+            ),
+          },
+        ],
+      })
       _flow = {
         ..._flowData,
       }

--- a/src/flows/context/flow.query.tsx
+++ b/src/flows/context/flow.query.tsx
@@ -49,7 +49,7 @@ export const DEFAULT_CONTEXT: FlowQueryContextType = {
   basic: (_: string) => {},
   queryAll: () => {},
   status: RemoteDataState.NotStarted,
-  getStatus: (_: string) => RemoteDataState.NotStarted
+  getStatus: (_: string) => RemoteDataState.NotStarted,
 }
 
 export const FlowQueryContext = React.createContext<FlowQueryContextType>(
@@ -312,7 +312,9 @@ export const FlowQueryProvider: FC = ({children}) => {
   }
 
   return (
-    <FlowQueryContext.Provider value={{query, basic, generateMap, queryAll}}>
+    <FlowQueryContext.Provider
+      value={{query, basic, generateMap, queryAll, status, getStatus}}
+    >
       {children}
     </FlowQueryContext.Provider>
   )

--- a/src/flows/context/flow.query.tsx
+++ b/src/flows/context/flow.query.tsx
@@ -1,4 +1,4 @@
-import React, {FC, useContext, useMemo} from 'react'
+import React, {FC, useContext, useState, useMemo} from 'react'
 import {useDispatch, useSelector} from 'react-redux'
 import {getVariables} from 'src/variables/selectors'
 import {FlowContext} from 'src/flows/context/flow.current'
@@ -39,6 +39,8 @@ export interface FlowQueryContextType {
   query: (text: string) => Promise<FluxResult>
   basic: (text: string) => any
   queryAll: () => void
+  status: RemoteDataState
+  getStatus: (id: string) => RemoteDataState
 }
 
 export const DEFAULT_CONTEXT: FlowQueryContextType = {
@@ -46,6 +48,8 @@ export const DEFAULT_CONTEXT: FlowQueryContextType = {
   query: (_: string) => Promise.resolve({} as FluxResult),
   basic: (_: string) => {},
   queryAll: () => {},
+  status: RemoteDataState.NotStarted,
+  getStatus: (_: string) => RemoteDataState.NotStarted
 }
 
 export const FlowQueryContext = React.createContext<FlowQueryContextType>(
@@ -73,6 +77,7 @@ export const FlowQueryProvider: FC = ({children}) => {
   const {runMode} = useContext(RunModeContext)
   const {add, update} = useContext(ResultsContext)
   const {query: queryAPI, basic: basicAPI} = useContext(QueryContext)
+  const [loading, setLoading] = useState({})
 
   const dispatch = useDispatch()
   const notebookQueryKey = `queryAll-${flow?.name}`
@@ -120,6 +125,14 @@ export const FlowQueryProvider: FC = ({children}) => {
       return acc
     }, {})
   }, [variables, flow?.range])
+
+  const getStatus = (id: string) => {
+    if (!loading.hasOwnProperty(id)) {
+      return RemoteDataState.NotStarted
+    }
+
+    return loading[id]
+  }
 
   const generateMap = (withSideEffects?: boolean): Stage[] => {
     return flow.data.allIDs
@@ -211,7 +224,7 @@ export const FlowQueryProvider: FC = ({children}) => {
     }
   }
 
-  const statuses = flow ? flow.meta.all.map(({loading}) => loading) : []
+  const statuses = Object.values(loading)
 
   let status = RemoteDataState.Done
 
@@ -255,17 +268,20 @@ export const FlowQueryProvider: FC = ({children}) => {
           )
         }, [])
         .map(stage => {
-          flow.meta.update(stage.instance, {loading: RemoteDataState.Loading})
+          loading[stage.instance] = RemoteDataState.Loading
+          setLoading(loading)
           return query(stage.text)
             .then(response => {
-              flow.meta.update(stage.instance, {loading: RemoteDataState.Done})
+              loading[stage.instance] = RemoteDataState.Done
+              setLoading(loading)
               forceUpdate(stage.instance, response)
             })
             .catch(e => {
               forceUpdate(stage.instance, {
                 error: e.message,
               })
-              flow.meta.update(stage.instance, {loading: RemoteDataState.Error})
+              loading[stage.instance] = RemoteDataState.Error
+              setLoading(loading)
             })
         })
     )

--- a/src/flows/context/pipe.tsx
+++ b/src/flows/context/pipe.tsx
@@ -39,7 +39,7 @@ interface PipeContextProps {
 export const PipeProvider: FC<PipeContextProps> = ({id, children}) => {
   const {flow} = useContext(FlowContext)
   const results = useContext(ResultsContext)
-  const {generateMap} = useContext(FlowQueryContext)
+  const {generateMap, getStatus} = useContext(FlowQueryContext)
 
   const stages = useMemo(() => generateMap(true), [
     generateMap,
@@ -66,10 +66,9 @@ export const PipeProvider: FC<PipeContextProps> = ({id, children}) => {
 
   return useMemo(() => {
     let data = null
-    let loading = RemoteDataState.NotStarted
+    const loading = getStatus(id)
     try {
       data = flow.data.get(id)
-      loading = flow.meta.get(id).loading
     } catch {
       return null
     }

--- a/src/flows/context/results.tsx
+++ b/src/flows/context/results.tsx
@@ -52,9 +52,7 @@ export const ResultsProvider: FC = ({children}) => {
         }
         const ref = flow.data.allIDs
         const index = flow.data.indexOf(id)
-        const lastOne = ref[index - 1]
         manipulator.add(id, manipulator.get(ref[index - 1]))
-        flow.meta.update(id, {loading: flow.meta.get(lastOne).loading})
       } catch (_e) {
         // swallow that
       }

--- a/src/flows/pipes/QueryBuilder/AddButton.tsx
+++ b/src/flows/pipes/QueryBuilder/AddButton.tsx
@@ -6,7 +6,7 @@ import {RemoteDataState} from 'src/types'
 import {QueryBuilderContext} from 'src/flows/pipes/QueryBuilder/context'
 
 const AddButton: FC = () => {
-  const {cards, add} = useContext(QueryBuilderContext)
+  const {cards, add, keyLoading} = useContext(QueryBuilderContext)
 
   const onClick = useCallback(() => {
     add()
@@ -17,7 +17,10 @@ const AddButton: FC = () => {
   }
 
   const {keys} = cards[cards.length - 1]
-  if (keys.results.length === 0 && keys.status === RemoteDataState.Done) {
+  if (
+    keys.results.length === 0 &&
+    keyLoading[cards.length - 1] === RemoteDataState.Done
+  ) {
     return null
   }
 

--- a/src/flows/pipes/QueryBuilder/BucketSelector.tsx
+++ b/src/flows/pipes/QueryBuilder/BucketSelector.tsx
@@ -16,6 +16,13 @@ const BucketSelector: FC = () => {
 
   const selectBucket = (item: string): void => {
     data.buckets = [item]
+    data.tags = [
+      {
+        key: '',
+        values: [],
+        aggregateFunctionType: 'filter',
+      },
+    ]
     update(data)
   }
 

--- a/src/flows/pipes/QueryBuilder/CardList.tsx
+++ b/src/flows/pipes/QueryBuilder/CardList.tsx
@@ -127,7 +127,7 @@ const Card: FC<Props> = ({idx}) => {
   useEffect(() => {
     if (
       keyStatus === RemoteDataState.Done &&
-      valueStatus === RemoteDataState.NotStarted
+      valueStatus !== RemoteDataState.Done
     ) {
       loadValues(idx)
     }

--- a/src/flows/pipes/QueryBuilder/CardList.tsx
+++ b/src/flows/pipes/QueryBuilder/CardList.tsx
@@ -1,4 +1,4 @@
-import React, {FC, useContext, useEffect} from 'react'
+import React, {FC, useCallback, useContext, useEffect, useState} from 'react'
 import {
   Input,
   AlignItems,
@@ -36,11 +36,22 @@ interface Props {
 }
 
 const Card: FC<Props> = ({idx}) => {
-  const {cards, add, update, remove, loadKeys, loadValues} = useContext(
-    QueryBuilderContext
-  )
+  const {
+    cards,
+    add,
+    update,
+    remove,
+    loadKeys,
+    loadValues,
+    keyLoading,
+    valueLoading,
+  } = useContext(QueryBuilderContext)
   const {data} = useContext(PipeContext)
   const card = cards[idx]
+  const [keySearches, setKeySearches] = useState([])
+  const [valueSearches, setValueSearches] = useState([])
+  const keyStatus = keyLoading[idx]
+  const valueStatus = valueLoading[idx]
 
   const _remove =
     idx !== 0 &&
@@ -54,18 +65,16 @@ const Card: FC<Props> = ({idx}) => {
     })
   }
 
-  const keySearch = (search: string) => {
-    update(idx, {
-      keys: {
-        ...card.keys,
-        search,
-      },
-    })
-
-    debouncer(idx, () => {
-      loadKeys(idx)
-    })
-  }
+  const keySearch = useCallback(
+    (search: string) => {
+      keySearches[idx] = search
+      setKeySearches([...keySearches])
+      debouncer(idx, () => {
+        loadKeys(idx, search)
+      })
+    },
+    [loadKeys, card.keys, idx]
+  )
 
   const keySelect = val => {
     update(idx, {
@@ -73,23 +82,14 @@ const Card: FC<Props> = ({idx}) => {
         ...card.keys,
         selected: [val],
       },
-      values: {
-        ...card.values,
-        status: RemoteDataState.NotStarted,
-      },
     })
   }
 
   const valueSearch = (search: string) => {
-    update(idx, {
-      values: {
-        ...card.values,
-        search,
-      },
-    })
-
+    valueSearches[idx] = search
+    setValueSearches([...valueSearches])
     debouncer(idx, () => {
-      loadValues(idx)
+      loadValues(idx, search)
     })
   }
 
@@ -119,21 +119,21 @@ const Card: FC<Props> = ({idx}) => {
   }
 
   useEffect(() => {
-    if (data.buckets[0] && card.keys.status === RemoteDataState.NotStarted) {
+    if (data.buckets[0] && keyStatus === RemoteDataState.NotStarted) {
       loadKeys(idx)
     }
-  }, [data.buckets, card.keys.status])
+  }, [data.buckets, keyStatus])
 
   useEffect(() => {
     if (
-      card.keys.status === RemoteDataState.Done &&
-      card.values.status === RemoteDataState.NotStarted
+      keyStatus === RemoteDataState.Done &&
+      valueStatus === RemoteDataState.NotStarted
     ) {
       loadValues(idx)
     }
-  }, [card.keys.status, card.values.status])
+  }, [keyStatus, valueStatus])
 
-  if (card.keys.status === RemoteDataState.NotStarted) {
+  if (keyStatus === RemoteDataState.NotStarted) {
     let emptyText = 'Select a value first'
 
     if (idx === 0) {
@@ -147,7 +147,7 @@ const Card: FC<Props> = ({idx}) => {
     )
   }
 
-  if (card.keys.status === RemoteDataState.Error) {
+  if (keyStatus === RemoteDataState.Error) {
     return (
       <BuilderCard>
         <BuilderCard.Empty>Failed to load tag keys</BuilderCard.Empty>
@@ -155,7 +155,7 @@ const Card: FC<Props> = ({idx}) => {
     )
   }
 
-  if (card.keys.status === RemoteDataState.Done && !card.keys.results.length) {
+  if (keyStatus === RemoteDataState.Done && !card.keys.results.length) {
     return (
       <BuilderCard>
         <BuilderCard.Empty testID="empty-tag-keys">
@@ -167,15 +167,15 @@ const Card: FC<Props> = ({idx}) => {
 
   let _values
 
-  if (card.values.status === RemoteDataState.Error) {
+  if (valueStatus === RemoteDataState.Error) {
     _values = (
       <BuilderCard.Empty>
         {`Failed to load tag values for ${card.keys.selected[0]}`}
       </BuilderCard.Empty>
     )
   } else if (
-    card.values.status === RemoteDataState.Loading ||
-    card.values.status === RemoteDataState.NotStarted
+    valueStatus === RemoteDataState.Loading ||
+    valueStatus === RemoteDataState.NotStarted
   ) {
     _values = (
       <BuilderCard.Empty>
@@ -183,7 +183,7 @@ const Card: FC<Props> = ({idx}) => {
       </BuilderCard.Empty>
     )
   } else if (
-    card.values.status === RemoteDataState.Done &&
+    valueStatus === RemoteDataState.Done &&
     !card.values.results.length
   ) {
     _values = (
@@ -213,7 +213,7 @@ const Card: FC<Props> = ({idx}) => {
         />
         <BuilderCard.Menu>
           <Input
-            value={card.values.search}
+            value={valueSearches[idx] || ''}
             placeholder={`Search ${card.keys.selected[0]} tag values`}
             className="tag-selector--search"
             onChange={evt => {
@@ -241,12 +241,12 @@ const Card: FC<Props> = ({idx}) => {
           margin={ComponentSize.Small}
         >
           <SearchableDropdown
-            searchTerm={card.keys.search}
+            searchTerm={keySearches[idx] || ''}
             emptyText="No Tags Found"
             searchPlaceholder="Search keys..."
             selectedOption={card.keys.selected[0]}
             onSelect={keySelect}
-            buttonStatus={toComponentStatus(card.keys.status)}
+            buttonStatus={toComponentStatus(keyStatus)}
             onChangeSearchTerm={keySearch}
             testID="tag-selector--dropdown"
             buttonTestID="tag-selector--dropdown-button"
@@ -255,7 +255,7 @@ const Card: FC<Props> = ({idx}) => {
           />
         </FlexBox>
         <Input
-          value={card.values.search}
+          value={valueSearches[idx] || ''}
           placeholder={`Search ${card.keys.selected[0]} tag values`}
           className="tag-selector--search"
           onChange={evt => {

--- a/src/types/flows.ts
+++ b/src/types/flows.ts
@@ -15,7 +15,6 @@ export type Visibility = 'visible' | 'hidden'
 export interface PipeMeta {
   title: string
   visible: boolean
-  loading: RemoteDataState
   error?: string
 }
 

--- a/src/types/flows.ts
+++ b/src/types/flows.ts
@@ -1,6 +1,6 @@
 import {FromFluxResult, FluxDataType, Table} from '@influxdata/giraffe'
 import {FunctionComponent, ComponentClass, ReactNode} from 'react'
-import {AutoRefresh, RemoteDataState, TimeRange} from 'src/types'
+import {AutoRefresh, TimeRange} from 'src/types'
 
 export interface PipeContextProps {
   children?: ReactNode


### PR DESCRIPTION
Closes #1414 

notebooks was in bad shape, mostly from stale updates clobbering each other in async calls. I sorted out a few of these by normalizing loading state and results away from source of truth for things like: query state, query builder cards' keys and values, some other things.

Also when i was running some graphs in tools to see how people were using notebooks... i found out that we couldn't see which panels people were deleting, so i added that in

Also, the metric selector filter logic was a bit weird after i touched it last. This one feels a lot better; it shows less stuff, but more accurately, making it more useful to search stuff