### PR TITLE
fix: update URL for functions to include poc in URL

### DIFF
--- a/src/functions/components/FunctionHeader.tsx
+++ b/src/functions/components/FunctionHeader.tsx
@@ -28,7 +28,7 @@ const FunctionHeader: FC = () => {
     // TODO dont allow routing away if unsaved changes exist
   }
 
-  const functionURL = `https://stag-us-east-1-3.aws.cloud2.influxdata.com/api/v2/functions/${id}/invoke`
+  const functionURL = `https://stag-us-east-1-3.aws.cloud2.influxdata.com/api/v2/poc-functions/${id}/invoke`
   const notifyCopied = () => {
     dispatch(notify(copyFunctionURL()))
   }


### PR DESCRIPTION
As part of changing URLs, we need to change the URL for functions API.
