### PR TITLE
chore: improve url visibility with stars

### DIFF
--- a/scripts/run-monitor-ci-tests.bash
+++ b/scripts/run-monitor-ci-tests.bash
@@ -209,8 +209,10 @@ do
 					fi
 				done
 
-				printf "\n\nFAILURE: monitor-ci workflow with id ${workflow_id} failed:\n"
-				printf "https://app.circleci.com/pipelines/github/influxdata/monitor-ci/${pipeline_number}/workflows/${workflow_id}"
+				printf "\n\nFAILURE: monitor-ci workflow with id ${workflow_id} failed.\n"
+				printf "\n********************************************************\n"
+				printf "monitor-ci pipeline link: https://app.circleci.com/pipelines/github/influxdata/monitor-ci/${pipeline_number}/workflows/${workflow_id}"
+				printf "\n********************************************************\n"
 			fi
 		done
 


### PR DESCRIPTION
Adds some `********` around the monitor-ci pipeline link to draw attention to it.
