### PR TITLE
chore: ci works from fork

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
       - checkout
       - run:
           name: Run monitor-ci tests
-          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="genehynson/add-org-param" UI_GITHUB_ORG=${CIRCLE_PROJECT_USERNAME} UI_BRANCH=${CIRCLE_BRANCH} SHA=${CIRCLE_SHA1} ./scripts/run-monitor-ci-tests.bash
+          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="genehynson/add-org-param" UI_BRANCH=${CIRCLE_BRANCH} SHA=${CIRCLE_SHA1} ./scripts/run-monitor-ci-tests.bash
       - store_artifacts:
           path: monitor-ci/test-artifacts/results/build-oss-image
           destination: test_artifacts/results/build-oss-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
       - checkout
       - run:
           name: Run monitor-ci tests
-          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="genehynson/add-org-param" UI_BRANCH=${CIRCLE_BRANCH} SHA=${CIRCLE_SHA1} ./scripts/run-monitor-ci-tests.bash
+          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="genehynson/add-org-param" UI_GITHUB_ORG=${CIRCLE_PROJECT_USERNAME} UI_BRANCH=${CIRCLE_BRANCH} SHA=${CIRCLE_SHA1} ./scripts/run-monitor-ci-tests.bash
       - store_artifacts:
           path: monitor-ci/test-artifacts/results/build-oss-image
           destination: test_artifacts/results/build-oss-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
       - checkout
       - run:
           name: Run monitor-ci tests
-          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="master" UI_BRANCH=${CIRCLE_BRANCH} SHA=${CIRCLE_SHA1} ./scripts/run-monitor-ci-tests.bash
+          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="genehynson/add-org-param" UI_GITHUB_ORG=${CIRCLE_PROJECT_USERNAME} UI_BRANCH=${CIRCLE_BRANCH} SHA=${CIRCLE_SHA1} ./scripts/run-monitor-ci-tests.bash
       - store_artifacts:
           path: monitor-ci/test-artifacts/results/build-oss-image
           destination: test_artifacts/results/build-oss-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
       - checkout
       - run:
           name: Run monitor-ci tests
-          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="genehynson/add-org-param" UI_GITHUB_ORG=${CIRCLE_PROJECT_USERNAME} UI_BRANCH=${CIRCLE_BRANCH} SHA=${CIRCLE_SHA1} ./scripts/run-monitor-ci-tests.bash
+          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="genehynson/add-org-param" UI_GITHUB_ORG=${CIRCLE_PR_USERNAME} UI_BRANCH=${CIRCLE_BRANCH} SHA=${CIRCLE_SHA1} ./scripts/run-monitor-ci-tests.bash
       - store_artifacts:
           path: monitor-ci/test-artifacts/results/build-oss-image
           destination: test_artifacts/results/build-oss-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
       - checkout
       - run:
           name: Run monitor-ci tests
-          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="genehynson/add-org-param" UI_GITHUB_ORG=${CIRCLE_PR_USERNAME} UI_BRANCH=${CIRCLE_BRANCH} SHA=${CIRCLE_SHA1} ./scripts/run-monitor-ci-tests.bash
+          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="genehynson/add-org-param" UI_BRANCH=${CIRCLE_BRANCH} SHA=${CIRCLE_SHA1} ./scripts/run-monitor-ci-tests.bash
       - store_artifacts:
           path: monitor-ci/test-artifacts/results/build-oss-image
           destination: test_artifacts/results/build-oss-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
       - checkout
       - run:
           name: Run monitor-ci tests
-          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="genehynson/add-org-param" UI_BRANCH=${CIRCLE_BRANCH} SHA=${CIRCLE_SHA1} ./scripts/run-monitor-ci-tests.bash
+          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="master" UI_BRANCH=${CIRCLE_BRANCH} SHA=${CIRCLE_SHA1} ./scripts/run-monitor-ci-tests.bash
       - store_artifacts:
           path: monitor-ci/test-artifacts/results/build-oss-image
           destination: test_artifacts/results/build-oss-image

--- a/scripts/run-monitor-ci-tests.bash
+++ b/scripts/run-monitor-ci-tests.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eu -o pipefail
+set -eux -o pipefail
 
 ########################
 # --- Script Summary ---

--- a/scripts/run-monitor-ci-tests.bash
+++ b/scripts/run-monitor-ci-tests.bash
@@ -97,7 +97,7 @@ if [[ -z "${OSS_SHA:-}" ]]; then
 	if [ -n $PULL_REQUEST ]; then
 		# if running from pull request, use github api to get source branch.
 		# this is needed to support forks of the UI repo.
-		pr=$($PULL_REQUEST | grep -oE "[^/]+$")
+		pr=$(echo ${PULL_REQUEST} | grep -oE "[^/]+$")
 		github=$(curl -s --fail --request GET \
 			--url https://api.github.com/repos/influxdata/ui/pulls/${pr})
 		UI_BRANCH=$(echo ${github} | jq -r '.head.ref')

--- a/scripts/run-monitor-ci-tests.bash
+++ b/scripts/run-monitor-ci-tests.bash
@@ -22,6 +22,7 @@ set -eux -o pipefail
 # - SHA: the UI repo commit SHA we're running against
 # - API_KEY: the CircleCI API access key
 # - UI_BRANCH: the branch of the UI repo we're running against
+# - UI_GITHUB_ORG: the github org of the UI repo (e.g. influxdata)
 # - MONITOR_CI_BRANCH: the branch of the monitor-ci repo to start a pipeline with (usually 'master')
 # - PULL_REQUEST: the open pull request, if one exists (used for lighthouse)
 #

--- a/scripts/run-monitor-ci-tests.bash
+++ b/scripts/run-monitor-ci-tests.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eux -o pipefail
+set -eu -o pipefail
 
 ########################
 # --- Script Summary ---
@@ -22,7 +22,6 @@ set -eux -o pipefail
 # - SHA: the UI repo commit SHA we're running against
 # - API_KEY: the CircleCI API access key
 # - UI_BRANCH: the branch of the UI repo we're running against
-# - UI_GITHUB_ORG: the github org of the UI repo (e.g. influxdata)
 # - MONITOR_CI_BRANCH: the branch of the monitor-ci repo to start a pipeline with (usually 'master')
 # - PULL_REQUEST: the open pull request, if one exists (used for lighthouse)
 #

--- a/scripts/run-monitor-ci-tests.bash
+++ b/scripts/run-monitor-ci-tests.bash
@@ -102,7 +102,7 @@ if [[ -z "${OSS_SHA:-}" ]]; then
 		github=$(curl -s --fail --request GET \
 			--url https://api.github.com/repos/influxdata/ui/pulls/${pr})
 		UI_BRANCH=$(echo ${github} | jq -r '.head.ref')
-		UI_GITHUB_ORG=$(echo ${github} | jq -r '.repo.owner.login')
+		UI_GITHUB_ORG=$(echo ${github} | jq -r '.head.repo.owner.login')
 	fi
 
 	pipelineStartMsg="starting monitor-ci pipeline targeting monitor-ci branch ${MONITOR_CI_BRANCH}, UI branch ${UI_BRANCH} and using UI SHA ${SHA}"

--- a/scripts/run-monitor-ci-tests.bash
+++ b/scripts/run-monitor-ci-tests.bash
@@ -22,6 +22,7 @@ set -eux -o pipefail
 # - SHA: the UI repo commit SHA we're running against
 # - API_KEY: the CircleCI API access key
 # - UI_BRANCH: the branch of the UI repo we're running against
+# - UI_GITHUB_ORG: the github org of the UI repo (e.g. influxdata)
 # - MONITOR_CI_BRANCH: the branch of the monitor-ci repo to start a pipeline with (usually 'master')
 # - PULL_REQUEST: the open pull request, if one exists (used for lighthouse)
 #
@@ -95,7 +96,7 @@ if [[ -z "${OSS_SHA:-}" ]]; then
 		DEPLOY_PROD=true
 	fi
 	pipelineStartMsg="starting monitor-ci pipeline targeting monitor-ci branch ${MONITOR_CI_BRANCH}, UI branch ${UI_BRANCH} and using UI SHA ${SHA}"
-	reqData="{\"branch\":\"${MONITOR_CI_BRANCH}\", \"parameters\":{ \"ui-sha\":\"${SHA}\", \"ui-branch\":\"${UI_BRANCH}\", \"ui-pull-request\":\"${PULL_REQUEST}\", \"deploy-prod\":${DEPLOY_PROD}}}"
+	reqData="{\"branch\":\"${MONITOR_CI_BRANCH}\", \"parameters\":{ \"ui-sha\":\"${SHA}\", \"ui-github-org\":\"${UI_GITHUB_ORG}\", \"ui-branch\":\"${UI_BRANCH}\", \"ui-pull-request\":\"${PULL_REQUEST}\", \"deploy-prod\":${DEPLOY_PROD}}}"
 else
 	# set the parameters for starting the monitor-ci pipeline from the influxdb repo
 	pipelineStartMsg="starting monitor-ci pipeline targeting monitor-ci branch ${MONITOR_CI_BRANCH} using OSS SHA ${OSS_SHA}"

--- a/scripts/run-monitor-ci-tests.bash
+++ b/scripts/run-monitor-ci-tests.bash
@@ -96,13 +96,13 @@ if [[ -z "${OSS_SHA:-}" ]]; then
 		DEPLOY_PROD=true
 	fi
 	if [ -n $PULL_REQUEST ]; then
-		# if running from pull request, use github api to get source branch.
+		# if running from pull request, use github api to get source org and branch.
 		# this is needed to support forks of the UI repo.
 		pr=$(echo ${PULL_REQUEST} | grep -oE "[^/]+$")
 		github=$(curl -s --fail --request GET \
 			--url https://api.github.com/repos/influxdata/ui/pulls/${pr})
 		UI_BRANCH=$(echo ${github} | jq -r '.head.ref')
-		UI_GITHUB_ORG=$(echo ${github} | jq -r '.owner.login')
+		UI_GITHUB_ORG=$(echo ${github} | jq -r '.repo.owner.login')
 	fi
 
 	pipelineStartMsg="starting monitor-ci pipeline targeting monitor-ci branch ${MONITOR_CI_BRANCH}, UI branch ${UI_BRANCH} and using UI SHA ${SHA}"

--- a/scripts/run-monitor-ci-tests.bash
+++ b/scripts/run-monitor-ci-tests.bash
@@ -102,10 +102,11 @@ if [[ -z "${OSS_SHA:-}" ]]; then
 		github=$(curl -s --fail --request GET \
 			--url https://api.github.com/repos/influxdata/ui/pulls/${pr})
 		UI_BRANCH=$(echo ${github} | jq -r '.head.ref')
+		UI_GITHUB_ORG=$(echo ${github} | jq -r '.owner.login')
 	fi
 
 	pipelineStartMsg="starting monitor-ci pipeline targeting monitor-ci branch ${MONITOR_CI_BRANCH}, UI branch ${UI_BRANCH} and using UI SHA ${SHA}"
-	reqData="{\"branch\":\"${MONITOR_CI_BRANCH}\", \"parameters\":{ \"ui-sha\":\"${SHA}\", \"ui-github-org\":\"${UI_GITHUB_ORG}\", \"ui-branch\":\"${UI_BRANCH}\", \"ui-pull-request\":\"${PULL_REQUEST}\", \"deploy-prod\":${DEPLOY_PROD}}}"
+	reqData="{\"branch\":\"${MONITOR_CI_BRANCH}\", \"parameters\":{ \"ui-sha\":\"${SHA}\", \"ui-github-org\":\"${UI_GITHUB_ORG:-influxdata}\", \"ui-branch\":\"${UI_BRANCH}\", \"ui-pull-request\":\"${PULL_REQUEST}\", \"deploy-prod\":${DEPLOY_PROD}}}"
 else
 	# set the parameters for starting the monitor-ci pipeline from the influxdb repo
 	pipelineStartMsg="starting monitor-ci pipeline targeting monitor-ci branch ${MONITOR_CI_BRANCH} using OSS SHA ${OSS_SHA}"


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/1461

Modifies monitor CI tests script to support forks of the UI repo. Uses github's APIs to get the org and branch of the fork. We can't depend on Circle's env vars for this because they don't set them to the values of the org/branch of the fork, but instead it creates some sort of local branch and use `influxdata` as the org. Not sure why it behaves that way, but github's APIs are a decent work around.

And obviously this works...but this PR is opened from a fork! 😄 