### PR TITLE
feat: send orgID as Company ID to Userpilot

### DIFF
--- a/src/cloud/components/onboarding/EngagementLink.tsx
+++ b/src/cloud/components/onboarding/EngagementLink.tsx
@@ -31,6 +31,9 @@ const EngagementLink: FC = () => {
         orgID: org.id, // Organization ID
         region: host[0], // Cloud provider region
         provider: host[1], // Cloud provider
+        company: {
+          id: org.id, // Organization ID
+        },
       })
     }
   }


### PR DESCRIPTION
Send orgID to Userpilot as `company: id` as well as `orgID` (both are needed for different purposes). 