### PR TITLE
feat: export a notebook

### DIFF
--- a/src/flows/components/header/index.tsx
+++ b/src/flows/components/header/index.tsx
@@ -60,7 +60,7 @@ const FlowHeader: FC = () => {
           <TimeRangeDropdown />
           <FeatureFlag name="flow-snapshot">
             <SquareButton
-              icon={IconFont.Polaroid}
+              icon={IconFont.Export}
               onClick={printJSON}
               color={ComponentColor.Default}
               titleText="Export Notebook"

--- a/src/flows/components/header/index.tsx
+++ b/src/flows/components/header/index.tsx
@@ -6,13 +6,20 @@ import {FlowContext} from 'src/flows/context/flow.current'
 import {AppSettingProvider} from 'src/shared/contexts/app'
 
 // Components
-import {Page} from '@influxdata/clockface'
+import {
+  Page,
+  SquareButton,
+  IconFont,
+  ComponentColor,
+} from '@influxdata/clockface'
 import TimeZoneDropdown from 'src/shared/components/TimeZoneDropdown'
 import TimeRangeDropdown from 'src/flows/components/header/TimeRangeDropdown'
 import Submit from 'src/flows/components/header/Submit'
 import PresentationMode from 'src/flows/components/header/PresentationMode'
 import RenamablePageTitle from 'src/pageLayout/components/RenamablePageTitle'
 import {PROJECT_NAME} from 'src/flows'
+import {serialize} from 'src/flows/context/flow.list'
+import {FeatureFlag} from 'src/shared/utils/featureFlag'
 
 const FULL_WIDTH = true
 
@@ -21,6 +28,10 @@ const FlowHeader: FC = () => {
 
   const handleRename = (name: string) => {
     update({name})
+  }
+
+  const printJSON = () => {
+    console.log(JSON.stringify(serialize(flow), null, 2))
   }
 
   if (!flow) {
@@ -45,6 +56,14 @@ const FlowHeader: FC = () => {
           <PresentationMode />
           <TimeZoneDropdown />
           <TimeRangeDropdown />
+          <FeatureFlag name="flow-snapshot">
+            <SquareButton
+              icon={IconFont.Polaroid}
+              onClick={printJSON}
+              color={ComponentColor.Default}
+              titleText="Export Notebook"
+            />
+          </FeatureFlag>
         </Page.ControlBarRight>
       </Page.ControlBar>
     </>

--- a/src/flows/components/header/index.tsx
+++ b/src/flows/components/header/index.tsx
@@ -31,7 +31,9 @@ const FlowHeader: FC = () => {
   }
 
   const printJSON = () => {
+    /* eslint-disable no-console */
     console.log(JSON.stringify(serialize(flow), null, 2))
+    /* eslint-enable no-console */
   }
 
   if (!flow) {


### PR DESCRIPTION
a debug tool to allow someone to click a button and see the internal notebook representation

`influx.set('flow-snapshot', true)`

![Peek 2021-05-19 17-15](https://user-images.githubusercontent.com/1434802/118900754-90f5df00-b8c6-11eb-9def-36a4c52160a8.gif)
