### PR TITLE
feat: remove feature flag for legendOrientation

### DIFF
--- a/src/visualization/components/internal/LegendOrientation.tsx
+++ b/src/visualization/components/internal/LegendOrientation.tsx
@@ -3,7 +3,6 @@ import React, {ChangeEvent, FC} from 'react'
 
 // Utils
 import {convertUserInputToNumOrNaN} from 'src/shared/utils/convertUserInput'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Components
 import {
@@ -79,10 +78,6 @@ interface Props extends VisualizationOptionProps {
 const LegendOrientation: FC<Props> = ({properties, update}) => {
   const legendOpacity = properties?.legendOpacity
   const legendOrientation = properties?.legendOrientationThreshold
-
-  if (!isFlagEnabled('legendOrientation')) {
-    return null
-  }
 
   const handleSetOrientation = (threshold: number): void => {
     update({

--- a/src/visualization/types/Band/view.tsx
+++ b/src/visualization/types/Band/view.tsx
@@ -8,11 +8,7 @@ import EmptyGraphMessage from 'src/shared/components/EmptyGraphMessage'
 // Utils
 import {useAxisTicksGenerator} from 'src/visualization/utils/useAxisTicksGenerator'
 import {getFormatter} from 'src/visualization/utils/getFormatter'
-import {
-  useLegendOpacity,
-  useLegendOrientationThreshold,
-  useLegendColorizeRows,
-} from 'src/visualization/utils/useLegendOrientation'
+import {useLegendOpacity} from 'src/visualization/utils/useLegendOrientation'
 import {
   useVisXDomainSettings,
   useVisYDomainSettings,
@@ -72,10 +68,9 @@ const BandPlot: FC<Props> = ({properties, result, timeRange}) => {
 
   const axisTicksOptions = useAxisTicksGenerator(properties)
   const tooltipOpacity = useLegendOpacity(properties.legendOpacity)
-  const tooltipOrientationThreshold = useLegendOrientationThreshold(
-    properties.legendOrientationThreshold
-  )
-  const tooltipColorize = useLegendColorizeRows(properties.legendColorizeRows)
+  const tooltipOrientationThreshold = properties.legendOrientationThreshold
+
+  const tooltipColorize = properties.legendColorizeRows
 
   const storedXDomain = useMemo(() => parseXBounds(properties.axes.x.bounds), [
     properties.axes.x.bounds,

--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -34,11 +34,7 @@ import {VisualizationProps} from 'src/visualization'
 // Utils
 import {useAxisTicksGenerator} from 'src/visualization/utils/useAxisTicksGenerator'
 import {getFormatter} from 'src/visualization/utils/getFormatter'
-import {
-  useLegendOpacity,
-  useLegendOrientationThreshold,
-  useLegendColorizeRows,
-} from 'src/visualization/utils/useLegendOrientation'
+import {useLegendOpacity} from 'src/visualization/utils/useLegendOrientation'
 import {
   useVisXDomainSettings,
   useVisYDomainSettings,
@@ -73,10 +69,8 @@ const XYPlot: FC<Props> = ({
   const {theme, timeZone} = useContext(AppSettingContext)
   const axisTicksOptions = useAxisTicksGenerator(properties)
   const tooltipOpacity = useLegendOpacity(properties.legendOpacity)
-  const tooltipColorize = useLegendColorizeRows(properties.legendColorizeRows)
-  const tooltipOrientationThreshold = useLegendOrientationThreshold(
-    properties.legendOrientationThreshold
-  )
+  const tooltipColorize = properties.legendColorizeRows
+  const tooltipOrientationThreshold = properties.legendOrientationThreshold
   const dispatch = useDispatch()
 
   // these two values are set in the dashboard, and used whether or not this view

--- a/src/visualization/types/Heatmap/view.tsx
+++ b/src/visualization/types/Heatmap/view.tsx
@@ -8,11 +8,7 @@ import EmptyGraphMessage from 'src/shared/components/EmptyGraphMessage'
 // Utils
 import {useAxisTicksGenerator} from 'src/visualization/utils/useAxisTicksGenerator'
 import {getFormatter} from 'src/visualization/utils/getFormatter'
-import {
-  useLegendOpacity,
-  useLegendOrientationThreshold,
-  useLegendColorizeRows,
-} from 'src/visualization/utils/useLegendOrientation'
+import {useLegendOpacity} from 'src/visualization/utils/useLegendOrientation'
 import {
   useVisXDomainSettings,
   useVisYDomainSettings,
@@ -52,10 +48,8 @@ const HeatmapPlot: FunctionComponent<Props> = ({
 
   const axisTicksOptions = useAxisTicksGenerator(properties)
   const tooltipOpacity = useLegendOpacity(properties.legendOpacity)
-  const tooltipColorize = useLegendColorizeRows(properties.legendColorizeRows)
-  const tooltipOrientationThreshold = useLegendOrientationThreshold(
-    properties.legendOrientationThreshold
-  )
+  const tooltipColorize = properties.legendColorizeRows
+  const tooltipOrientationThreshold = properties.legendOrientationThreshold
 
   const [xDomain, onSetXDomain, onResetXDomain] = useVisXDomainSettings(
     properties.xDomain,

--- a/src/visualization/types/Histogram/view.tsx
+++ b/src/visualization/types/Histogram/view.tsx
@@ -6,11 +6,7 @@ import {Plot} from '@influxdata/giraffe'
 import EmptyGraphMessage from 'src/shared/components/EmptyGraphMessage'
 
 // Utils
-import {
-  useLegendOpacity,
-  useLegendOrientationThreshold,
-  useLegendColorizeRows,
-} from 'src/visualization/utils/useLegendOrientation'
+import {useLegendOpacity} from 'src/visualization/utils/useLegendOrientation'
 import {useVisXDomainSettings} from 'src/visualization/utils/useVisDomainSettings'
 import {getFormatter} from 'src/visualization/utils/getFormatter'
 import {AppSettingContext} from 'src/shared/contexts/app'
@@ -34,10 +30,8 @@ const HistogramPlot: FunctionComponent<Props> = ({result, properties}) => {
   const fillColumns = properties.fillColumns || result.fluxGroupKeyUnion
 
   const tooltipOpacity = useLegendOpacity(properties.legendOpacity)
-  const tooltipColorize = useLegendColorizeRows(properties.legendColorizeRows)
-  const tooltipOrientationThreshold = useLegendOrientationThreshold(
-    properties.legendOrientationThreshold
-  )
+  const tooltipColorize = properties.legendColorizeRows
+  const tooltipOrientationThreshold = properties.legendOrientationThreshold
 
   const [xDomain, onSetXDomain, onResetXDomain] = useVisXDomainSettings(
     properties.xDomain,

--- a/src/visualization/types/Mosaic/view.tsx
+++ b/src/visualization/types/Mosaic/view.tsx
@@ -8,11 +8,7 @@ import EmptyGraphMessage from 'src/shared/components/EmptyGraphMessage'
 // Utils
 import {useAxisTicksGenerator} from 'src/visualization/utils/useAxisTicksGenerator'
 import {getFormatter} from 'src/visualization/utils/getFormatter'
-import {
-  useLegendOpacity,
-  useLegendOrientationThreshold,
-  useLegendColorizeRows,
-} from 'src/visualization/utils/useLegendOrientation'
+import {useLegendOpacity} from 'src/visualization/utils/useLegendOrientation'
 import {
   useVisXDomainSettings,
   useVisYDomainSettings,
@@ -46,10 +42,8 @@ const MosaicPlot: FunctionComponent<Props> = ({
 
   const axisTicksOptions = useAxisTicksGenerator(properties)
   const tooltipOpacity = useLegendOpacity(properties.legendOpacity)
-  const tooltipColorize = useLegendColorizeRows(properties.legendColorizeRows)
-  const tooltipOrientationThreshold = useLegendOrientationThreshold(
-    properties.legendOrientationThreshold
-  )
+  const tooltipColorize = properties.legendColorizeRows
+  const tooltipOrientationThreshold = properties.legendOrientationThreshold
 
   const [xDomain, onSetXDomain, onResetXDomain] = useVisXDomainSettings(
     properties.xDomain,

--- a/src/visualization/types/Scatter/view.tsx
+++ b/src/visualization/types/Scatter/view.tsx
@@ -8,11 +8,7 @@ import EmptyGraphMessage from 'src/shared/components/EmptyGraphMessage'
 // Utils
 import {useAxisTicksGenerator} from 'src/visualization/utils/useAxisTicksGenerator'
 import {getFormatter} from 'src/visualization/utils/getFormatter'
-import {
-  useLegendOpacity,
-  useLegendOrientationThreshold,
-  useLegendColorizeRows,
-} from 'src/visualization/utils/useLegendOrientation'
+import {useLegendOpacity} from 'src/visualization/utils/useLegendOrientation'
 import {
   useVisXDomainSettings,
   useVisYDomainSettings,
@@ -50,10 +46,8 @@ const ScatterPlot: FunctionComponent<Props> = ({
 
   const axisTicksOptions = useAxisTicksGenerator(properties)
   const tooltipOpacity = useLegendOpacity(properties.legendOpacity)
-  const tooltipColorize = useLegendColorizeRows(properties.legendColorizeRows)
-  const tooltipOrientationThreshold = useLegendOrientationThreshold(
-    properties.legendOrientationThreshold
-  )
+  const tooltipColorize = properties.legendColorizeRows
+  const tooltipOrientationThreshold = properties.legendOrientationThreshold
 
   let timerange
 

--- a/src/visualization/types/SingleStatWithLine/view.tsx
+++ b/src/visualization/types/SingleStatWithLine/view.tsx
@@ -24,11 +24,7 @@ import LatestValueTransform from 'src/visualization/components/LatestValueTransf
 // Utils
 import {useAxisTicksGenerator} from 'src/visualization/utils/useAxisTicksGenerator'
 import {getFormatter} from 'src/visualization/utils/getFormatter'
-import {
-  useLegendOpacity,
-  useLegendOrientationThreshold,
-  useLegendColorizeRows,
-} from 'src/visualization/utils/useLegendOrientation'
+import {useLegendOpacity} from 'src/visualization/utils/useLegendOrientation'
 import {
   useVisXDomainSettings,
   useVisYDomainSettings,
@@ -80,10 +76,8 @@ const SingleStatWithLine: FC<Props> = ({
   const {theme, timeZone} = useContext(AppSettingContext)
   const axisTicksOptions = useAxisTicksGenerator(properties)
   const tooltipOpacity = useLegendOpacity(properties.legendOpacity)
-  const tooltipColorize = useLegendColorizeRows(properties.legendColorizeRows)
-  const tooltipOrientationThreshold = useLegendOrientationThreshold(
-    properties.legendOrientationThreshold
-  )
+  const tooltipColorize = properties.legendColorizeRows
+  const tooltipOrientationThreshold = properties.legendOrientationThreshold
 
   // these two values are set in the dashboard, and used whether or not this view
   // is in a dashboard or in configuration/single cell popout mode

--- a/src/visualization/utils/useLegendOrientation.ts
+++ b/src/visualization/utils/useLegendOrientation.ts
@@ -1,37 +1,13 @@
 import {useMemo} from 'react'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {
   LEGEND_OPACITY_DEFAULT,
   LEGEND_OPACITY_MINIMUM,
-  LEGEND_ORIENTATION_THRESHOLD_DEFAULT,
-  LEGEND_COLORIZE_ROWS_DEFAULT,
 } from 'src/shared/constants'
 
 export const useLegendOpacity = (legendOpacity: number) =>
   useMemo(() => {
-    if (
-      !isFlagEnabled('legendOrientation') ||
-      legendOpacity < LEGEND_OPACITY_MINIMUM
-    ) {
+    if (legendOpacity < LEGEND_OPACITY_MINIMUM) {
       return LEGEND_OPACITY_DEFAULT
     }
     return legendOpacity
   }, [legendOpacity])
-
-export const useLegendOrientationThreshold = (
-  legendOrientationThreshold: number
-) =>
-  useMemo(() => {
-    if (!isFlagEnabled('legendOrientation')) {
-      return LEGEND_ORIENTATION_THRESHOLD_DEFAULT
-    }
-    return legendOrientationThreshold
-  }, [legendOrientationThreshold])
-
-export const useLegendColorizeRows = (legendColorizeRows: boolean) =>
-  useMemo(() => {
-    if (!isFlagEnabled('legendOrientation')) {
-      return LEGEND_COLORIZE_ROWS_DEFAULT
-    }
-    return legendColorizeRows
-  }, [legendColorizeRows])


### PR DESCRIPTION
Closes #1464 

Removes the feature flag `legendOrientation` and makes this feature permanent.