### PR TITLE
feat: better version info for oss

### DIFF
--- a/src/dashboards/selectors/index.test.ts
+++ b/src/dashboards/selectors/index.test.ts
@@ -103,6 +103,7 @@ describe('Dashboards.Selector', () => {
         navBarState: 'expanded',
         timeZone: 'Local' as TimeZone,
         theme: 'dark',
+        versionInfo: {version: '', commit: ''},
       },
     }
 
@@ -125,6 +126,7 @@ describe('Dashboards.Selector', () => {
         navBarState: 'expanded',
         timeZone: 'UTC' as TimeZone,
         theme: 'dark',
+        versionInfo: {version: '', commit: ''},
       },
     }
 
@@ -155,6 +157,7 @@ describe('Dashboards.Selector', () => {
         navBarState: 'expanded',
         timeZone: 'UTC' as TimeZone,
         theme: 'dark',
+        versionInfo: {version: '', commit: ''},
       },
     }
 
@@ -185,6 +188,7 @@ describe('Dashboards.Selector', () => {
         navBarState: 'expanded',
         timeZone: 'UTC' as TimeZone,
         theme: 'dark',
+        versionInfo: {version: '', commit: ''},
       },
     }
 

--- a/src/mockState.tsx
+++ b/src/mockState.tsx
@@ -30,6 +30,10 @@ export const localState: LocalStorage = {
       navBarState: 'expanded',
       timeZone: 'Local' as TimeZone,
       theme: 'dark',
+      versionInfo: {
+        version: '',
+        commit: '',
+      },
     },
   },
   flags: {

--- a/src/shared/actions/app.ts
+++ b/src/shared/actions/app.ts
@@ -1,4 +1,4 @@
-import {TimeZone, Theme, NavBarState} from 'src/types'
+import {TimeZone, Theme, NavBarState, VersionInfo} from 'src/types'
 
 export enum ActionTypes {
   EnablePresentationMode = 'ENABLE_PRESENTATION_MODE',
@@ -8,6 +8,7 @@ export enum ActionTypes {
   SetNavBarState = 'SET_NAV_BAR_STATE',
   SetAutoRefresh = 'SET_AUTOREFRESH',
   SetTimeZone = 'SET_APP_TIME_ZONE',
+  SetVersionInfo = 'SET_VERSION_INFO',
   TemplateControlBarVisibilityToggled = 'TemplateControlBarVisibilityToggledAction',
   Noop = 'NOOP',
 }
@@ -21,6 +22,7 @@ export type Action =
   | ReturnType<typeof setAutoRefresh>
   | ReturnType<typeof setTimeZone>
   | ReturnType<typeof setTheme>
+  | ReturnType<typeof setVersionInfo>
 
 // ephemeral state action creators
 
@@ -66,4 +68,10 @@ export const setTimeZone = (timeZone: TimeZone) =>
   ({
     type: ActionTypes.SetTimeZone,
     payload: {timeZone},
+  } as const)
+
+export const setVersionInfo = (versionInfo: VersionInfo) =>
+  ({
+    type: ActionTypes.SetVersionInfo,
+    payload: {versionInfo},
   } as const)

--- a/src/shared/components/VersionInfo.tsx
+++ b/src/shared/components/VersionInfo.tsx
@@ -1,8 +1,11 @@
 // Libraries
 import React, {PureComponent} from 'react'
 
+// Components
+import VersionInfoOSS from 'src/shared/components/VersionInfoOSS'
+
 // Constants
-import {VERSION, GIT_SHA} from 'src/shared/constants'
+import {VERSION, GIT_SHA, CLOUD} from 'src/shared/constants'
 
 interface Props {
   widthPixels?: number
@@ -17,7 +20,14 @@ class VersionInfo extends PureComponent<Props> {
         data-testid="version-info"
       >
         <p>
-          Version {VERSION} {GIT_SHA && <code>({GIT_SHA.slice(0, 7)})</code>}
+          {CLOUD ? (
+            <>
+              Version {VERSION}{' '}
+              {GIT_SHA && <code>({GIT_SHA.slice(0, 7)})</code>}
+            </>
+          ) : (
+            <VersionInfoOSS />
+          )}
         </p>
       </div>
     )

--- a/src/shared/components/VersionInfoOSS.tsx
+++ b/src/shared/components/VersionInfoOSS.tsx
@@ -1,0 +1,50 @@
+// Libraries
+import React, {FC, useEffect} from 'react'
+import {useSelector, useDispatch} from 'react-redux'
+
+// Constants
+import {GIT_SHA} from 'src/shared/constants'
+
+// Thunks
+import {fetchVersionInfo} from 'src/shared/thunks/app'
+
+// Selectors
+import {getVersionInfo} from 'src/shared/selectors/app'
+
+const VersionInfoOSS: FC = () => {
+  const dispatch = useDispatch()
+
+  const versionInfo = useSelector(getVersionInfo)
+
+  useEffect(() => {
+    if (!versionInfo.version || !versionInfo.commit) {
+      dispatch(fetchVersionInfo())
+    }
+  })
+
+  return (
+    <>
+      InfluxDB {versionInfo.version}
+      <br />
+      Server:{' '}
+      <code>
+        <a
+          href={`https://github.com/influxdata/influxdb/tree/${versionInfo.commit}`}
+        >
+          {versionInfo.commit && versionInfo.commit.slice(0, 7)}
+        </a>
+      </code>
+      <br />
+      Frontend:{' '}
+      <code>
+        <a
+          href={`https://github.com/influxdata/ui/tree/${GIT_SHA.slice(0, 7)}`}
+        >
+          {GIT_SHA.slice(0, 7)}
+        </a>
+      </code>
+    </>
+  )
+}
+
+export default VersionInfoOSS

--- a/src/shared/reducers/app.test.ts
+++ b/src/shared/reducers/app.test.ts
@@ -5,6 +5,7 @@ import {
   setTheme,
   setNavBarState,
   setAutoRefresh,
+  setVersionInfo,
 } from 'src/shared/actions/app'
 import {TimeZone} from 'src/types'
 import {AppState as AppPresentationState} from 'src/shared/reducers/app'
@@ -21,6 +22,7 @@ describe('Shared.Reducers.appReducer', () => {
       navBarState: 'expanded',
       timeZone: 'Local' as TimeZone,
       theme: 'dark',
+      versionInfo: {version: '', commit: ''},
     },
   }
 
@@ -72,5 +74,19 @@ describe('Shared.Reducers.appReducer', () => {
     const reducedState = appReducer(initialState, setAutoRefresh(expectedMs))
 
     expect(reducedState.persisted.autoRefresh).toBe(expectedMs)
+  })
+
+  it('should handle SET_VERSION_INFO', () => {
+    const expectedVersionInfo = {
+      version: '2.0.0',
+      commit: '1234123',
+    }
+
+    const reducedState = appReducer(
+      initialState,
+      setVersionInfo(expectedVersionInfo)
+    )
+
+    expect(reducedState.persisted.versionInfo).toBe(expectedVersionInfo)
   })
 })

--- a/src/shared/reducers/app.ts
+++ b/src/shared/reducers/app.ts
@@ -3,7 +3,7 @@ import {combineReducers} from 'redux'
 // Types
 import {ActionTypes, Action} from 'src/shared/actions/app'
 import {AUTOREFRESH_DEFAULT_INTERVAL} from 'src/shared/constants'
-import {TimeZone, NavBarState, Theme} from 'src/types'
+import {TimeZone, NavBarState, Theme, VersionInfo} from 'src/types'
 
 export interface AppState {
   ephemeral: {
@@ -16,6 +16,7 @@ export interface AppState {
     timeZone: TimeZone
     navBarState: NavBarState
     theme: Theme
+    versionInfo: VersionInfo
   }
 }
 
@@ -30,6 +31,7 @@ const initialState: AppState = {
     showTemplateControlBar: false,
     timeZone: 'Local',
     navBarState: 'collapsed',
+    versionInfo: {version: '', commit: ''},
   },
 }
 
@@ -89,6 +91,13 @@ const appPersistedReducer = (
       return {
         ...state,
         autoRefresh: action.payload.milliseconds,
+      }
+    }
+
+    case ActionTypes.SetVersionInfo: {
+      return {
+        ...state,
+        versionInfo: action.payload.versionInfo,
       }
     }
 

--- a/src/shared/selectors/app.ts
+++ b/src/shared/selectors/app.ts
@@ -1,4 +1,4 @@
-import {AppState, TimeZone, Theme, NavBarState} from 'src/types'
+import {AppState, TimeZone, Theme, NavBarState, VersionInfo} from 'src/types'
 
 export const timeZone = (state: AppState): TimeZone =>
   state.app.persisted.timeZone || ('Local' as TimeZone)
@@ -8,6 +8,9 @@ export const theme = (state: AppState): Theme =>
 
 export const navbarMode = (state: AppState): NavBarState =>
   state.app.persisted.navBarState || ('collapsed' as NavBarState)
+
+export const getVersionInfo = (state: AppState): VersionInfo =>
+  state.app.persisted.versionInfo || ({} as VersionInfo)
 
 export const hasUpdatedTimeRangeInVEO = (state: AppState): boolean =>
   state.app.ephemeral.hasUpdatedTimeRangeInVEO || false

--- a/src/shared/thunks/app.ts
+++ b/src/shared/thunks/app.ts
@@ -1,0 +1,34 @@
+import {Dispatch} from 'redux'
+import {getAPIBasepath} from 'src/utils/basepath'
+import {VersionInfo} from 'src/types'
+import {Action, setVersionInfo} from 'src/shared/actions/app'
+
+export const fetchVersionInfo = () => async (
+  dispatch: Dispatch<Action>
+): Promise<VersionInfo> => {
+  try {
+    const url = `${getAPIBasepath()}/health`
+    // Have to use fetch here since the oats client doesn't work with the servers option in the oss swagger
+    // Ex: https://github.com/influxdata/openapi/blob/35d734671d05ba9337dd6fbd8bb5c6085482011b/contracts/oss.yml#L5887
+    // The "/health" endpoint is actually not prefixed by "api/v2", but the oats client has the prefix
+    const response = await fetch(url)
+    const info = await response.json()
+
+    dispatch(
+      setVersionInfo({
+        version: info.version,
+        commit: info.commit,
+      })
+    )
+
+    return info
+  } catch (err) {
+    console.error(err)
+    dispatch(
+      setVersionInfo({
+        version: 'n/a',
+        commit: 'n/a',
+      })
+    )
+  }
+}

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -1,3 +1,8 @@
 export type CurrentPage = 'dashboard' | 'not set'
 export type Theme = 'light' | 'dark'
 export type NavBarState = 'expanded' | 'collapsed'
+
+export interface VersionInfo {
+  version: string
+  commit: string
+}

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -4,6 +4,7 @@ module.exports = (() => {
     require('child_process')
       .execSync('git rev-parse --sq HEAD')
       .toString()
+      .replace(/^'/, '')
 
   // Webpack has some specific rules about formatting
   // lets protect our developers from that!

--- a/webpack.dev.ts
+++ b/webpack.dev.ts
@@ -29,6 +29,7 @@ module.exports = merge(common, {
       '/api/v2': 'http://localhost:8086',
       '/debug/flush': 'http://localhost:8086',
       '/oauth': 'http://localhost:8086',
+      '/health': 'http://localhost:8086',
     },
     disableHostCheck: true,
     host: '0.0.0.0',


### PR DESCRIPTION
Backports #1418

Closes #1330
Closes [influxdb#20007](https://github.com/influxdata/influxdb/issues/20007)
Closes [influxdata-docker#484](https://github.com/influxdata/influxdata-docker/issues/484)

Clean cherry-pick of #1418 into the `OSS-2.0` branch.