### PR TITLE
fix: re-enable feature flags for dashboard query cache

### DIFF
--- a/src/dashboards/components/DashboardHeader.tsx
+++ b/src/dashboards/components/DashboardHeader.tsx
@@ -30,6 +30,7 @@ import {
 // Utils
 import {event} from 'src/cloud/utils/reporting'
 import {resetQueryCache} from 'src/shared/apis/queryCache'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Selectors
 import {getTimeRange} from 'src/dashboards/selectors'
@@ -107,7 +108,9 @@ const DashboardHeader: FC<Props> = ({
   }
 
   const handleChooseTimeRange = (timeRange: TimeRange) => {
-    resetQueryCache()
+    if (isFlagEnabled('queryCacheForDashboards')) {
+      resetQueryCache()
+    }
     setDashboardTimeRange(dashboard.id, timeRange)
     updateQueryParams({
       lower: timeRange.lower,
@@ -131,7 +134,9 @@ const DashboardHeader: FC<Props> = ({
 
   const resetCacheAndRefresh = (): void => {
     // We want to invalidate the existing cache when a user manually refreshes the dashboard
-    resetQueryCache()
+    if (isFlagEnabled('queryCacheForDashboards')) {
+      resetQueryCache()
+    }
     onManualRefresh()
   }
 

--- a/src/dashboards/components/DashboardPage.tsx
+++ b/src/dashboards/components/DashboardPage.tsx
@@ -59,7 +59,9 @@ const dashRoute = `/${ORGS}/${ORG_ID}/${DASHBOARDS}/${DASHBOARD_ID}`
 @ErrorHandling
 class DashboardPage extends Component<Props> {
   public componentDidMount() {
-    resetQueryCache()
+    if (isFlagEnabled('queryCacheForDashboards')) {
+      resetQueryCache()
+    }
 
     this.emitRenderCycleEvent()
 
@@ -69,7 +71,9 @@ class DashboardPage extends Component<Props> {
   }
 
   public componentWillUnmount() {
-    resetQueryCache()
+    if (isFlagEnabled('queryCacheForDashboards')) {
+      resetQueryCache()
+    }
   }
 
   public render() {

--- a/src/shared/components/TimeSeries.tsx
+++ b/src/shared/components/TimeSeries.tsx
@@ -244,7 +244,10 @@ class TimeSeries extends Component<Props, State> {
         const windowVars = getWindowVars(text, vars)
         const extern = buildVarsOption([...vars, ...windowVars])
         event('runQuery', {context: 'TimeSeries'})
-        if (isCurrentPageDashboard) {
+        if (
+          isCurrentPageDashboard &&
+          isFlagEnabled('queryCacheForDashboards')
+        ) {
           return onGetCachedResultsThunk(orgID, text)
         }
         const queryID = hashCode(text)

--- a/src/timeMachine/actions/queries.ts
+++ b/src/timeMachine/actions/queries.ts
@@ -294,9 +294,11 @@ export const executeQueries = (abortController?: AbortController) => async (
       const extern = buildVarsOption(variableAssignments)
 
       event('runQuery', {context: 'timeMachine'})
-
       const queryID = generateHashedQueryID(text, allVariables, orgID)
-      if (isCurrentPageDashboard(state)) {
+      if (
+        isCurrentPageDashboard(state) &&
+        isFlagEnabled('queryCacheForDashboards')
+      ) {
         // reset any existing matching query in the cache
         resetQueryCacheByQuery(text)
         const result = getCachedResultsOrRunQuery(

--- a/src/views/actions/thunks.ts
+++ b/src/views/actions/thunks.ts
@@ -1,5 +1,6 @@
 // Libraries
 import {normalize} from 'normalizr'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // APIs
 import {
@@ -127,22 +128,24 @@ export const getViewAndResultsForVEO = (
       })
     )
 
-    const queries = view.properties.queries.filter(({text}) => !!text.trim())
-    if (!queries.length) {
-      dispatch(setQueryResults(RemoteDataState.Done, [], null))
-    }
-    const {id: orgID} = getOrg(state)
-    const pendingResults = queries.map(({text}) =>
-      getCachedResultsOrRunQuery(orgID, text, getAllVariables(state))
-    )
+    if (isFlagEnabled('queryCacheForDashboards')) {
+      const queries = view.properties.queries.filter(({text}) => !!text.trim())
+      if (!queries.length) {
+        dispatch(setQueryResults(RemoteDataState.Done, [], null))
+      }
+      const {id: orgID} = getOrg(state)
+      const pendingResults = queries.map(({text}) => {
+        return getCachedResultsOrRunQuery(orgID, text, getAllVariables(state))
+      })
 
-    // Wait for new queries to complete
-    const results = await Promise.all(pendingResults.map(r => r.promise))
-    const files = (results as RunQuerySuccessResult[]).map(r => r.csv)
+      // Wait for new queries to complete
+      const results = await Promise.all(pendingResults.map(r => r.promise))
+      const files = (results as RunQuerySuccessResult[]).map(r => r.csv)
 
-    if (files) {
-      dispatch(setQueryResults(RemoteDataState.Done, files, null, null))
-      return
+      if (files) {
+        dispatch(setQueryResults(RemoteDataState.Done, files, null, null))
+        return
+      }
     }
 
     dispatch(executeQueries())


### PR DESCRIPTION
Closes [influxdb#21447](https://github.com/influxdata/influxdb/issues/21447)

The dashboard autorefresh stopped working with for OSS #146, which removed the feature flags around the dashboard query cache. Since this version of the UI was not used with OSS until much more recently, the problem went undiscovered until now.

Since we don't want to bring in the new dashboard autorefresh feature with the next OSS patch release and still want to restore functionality of the dashboard autorefresh, this PR effectively reverts #146 and adds the feature flag back in, so that the query cache is not enabled for OSS.
