### PR TITLE
feat: generate notebook from template

### DIFF
--- a/src/flows/components/FromTemplatePage.tsx
+++ b/src/flows/components/FromTemplatePage.tsx
@@ -70,7 +70,7 @@ const FromTemplatePage: FC = () => {
     <FlowListProvider>
       <div />
       <Switch>
-        <Route path={`/notebook/from/:template`} component={Template} />
+        <Route path="/notebook/from/:template" component={Template} />
         <Route component={NotFound} />
       </Switch>
     </FlowListProvider>

--- a/src/flows/components/FromTemplatePage.tsx
+++ b/src/flows/components/FromTemplatePage.tsx
@@ -1,0 +1,80 @@
+import React, {FC, useEffect, useContext, useState} from 'react'
+import {useSelector} from 'react-redux'
+import {Route, Switch, useHistory, useParams} from 'react-router-dom'
+
+import {DEFAULT_TIME_RANGE} from 'src/shared/constants/timeRanges'
+import {AUTOREFRESH_DEFAULT} from 'src/shared/constants'
+
+import {getOrg} from 'src/organizations/selectors'
+import NotFound from 'src/shared/components/NotFound'
+import {
+  FlowListProvider,
+  FlowListContext,
+  hydrate,
+} from 'src/flows/context/flow.list'
+
+// TODO: decouple this to make it more universal like visualizations and flow panels
+
+// NOTE: Add your templates here. the object key is going to turn into the route suffix
+// (ie: `/notebook/from/${key}`) and the value of the entry is going to be the notebook
+// that is generated
+const TEMPLATE_MAP = {
+  intro: {
+    name: 'Welcome to Notebooks',
+    readOnly: false,
+    range: DEFAULT_TIME_RANGE,
+    refresh: AUTOREFRESH_DEFAULT,
+    pipes: [
+      {
+        title: 'Welcome',
+        visible: true,
+        type: 'youtube',
+        uri: 'Rs16uhxK0h8',
+      },
+    ],
+  },
+}
+
+const Template: FC = () => {
+  const {add} = useContext(FlowListContext)
+  const [loading, setLoading] = useState(false)
+  const org = useSelector(getOrg)
+  const history = useHistory()
+  const {template} = useParams()
+
+  useEffect(() => {
+    setLoading(false)
+  }, [template, setLoading])
+
+  useEffect(() => {
+    if (!TEMPLATE_MAP[template]) {
+      return
+    }
+
+    if (loading) {
+      return
+    }
+
+    setLoading(true)
+
+    add(hydrate(TEMPLATE_MAP[template])).then(id => {
+      history.push(`/orgs/${org.id}/notebooks/${id}`)
+    })
+  }, [add, history, org.id, loading, setLoading, template])
+
+  return <div />
+}
+
+const FromTemplatePage: FC = () => {
+  return (
+    <FlowListProvider>
+      <div />
+      <Switch>
+        <Route path={`/notebook/from/:template`} component={Template} />
+        <Route component={NotFound} />
+      </Switch>
+    </FlowListProvider>
+  )
+}
+
+export default FromTemplatePage

--- a/src/flows/components/FromTemplatePage.tsx
+++ b/src/flows/components/FromTemplatePage.tsx
@@ -68,7 +68,6 @@ const Template: FC = () => {
 const FromTemplatePage: FC = () => {
   return (
     <FlowListProvider>
-      <div />
       <Switch>
         <Route path="/notebook/from/:template" component={Template} />
         <Route component={NotFound} />

--- a/src/flows/context/flow.list.tsx
+++ b/src/flows/context/flow.list.tsx
@@ -1,6 +1,5 @@
 import React, {FC, useCallback, useEffect, useState} from 'react'
-import {useDispatch} from 'react-redux'
-import {useParams} from 'react-router-dom'
+import {useDispatch, useSelector} from 'react-redux'
 import useLocalStorageState from 'use-local-storage-state'
 import {v4 as UUID} from 'uuid'
 import {
@@ -11,6 +10,7 @@ import {
   PipeData,
   PipeMeta,
 } from 'src/types/flows'
+import {getOrg} from 'src/organizations/selectors'
 import {default as _asResource} from 'src/flows/context/resource.hook'
 import {PIPE_DEFINITIONS} from 'src/flows'
 import {DEFAULT_TIME_RANGE} from 'src/shared/constants/timeRanges'
@@ -137,7 +137,7 @@ export function hydrate(data) {
 export const FlowListProvider: FC = ({children}) => {
   const [flows, setFlows] = useLocalStorageState('flows', DEFAULT_CONTEXT.flows)
   const [currentID, setCurrentID] = useState(DEFAULT_CONTEXT.currentID)
-  const {orgID} = useParams<{orgID: string}>()
+  const org = useSelector(getOrg)
   const dispatch = useDispatch()
   useEffect(() => {
     migrate()
@@ -206,9 +206,9 @@ export const FlowListProvider: FC = ({children}) => {
     }
 
     const apiFlow = {
-      orgID,
+      orgID: org.id,
       data: {
-        orgID: orgID,
+        orgID: org.id,
         name: _flow.name,
         spec: serialize(_flow),
       },
@@ -258,10 +258,10 @@ export const FlowListProvider: FC = ({children}) => {
 
     const apiFlow = {
       id,
-      orgID,
+      orgID: org.id,
       data: {
         id,
-        orgID,
+        orgID: org.id,
         name: flow.name,
         spec: serialize(data),
       },
@@ -278,7 +278,7 @@ export const FlowListProvider: FC = ({children}) => {
     try {
       isFlagEnabled(notebookAPIFlag)
         ? await deleteAPINotebooks({id})
-        : await deleteAPI({orgID, id})
+        : await deleteAPI({orgID: org.id, id})
     } catch (error) {
       dispatch(notify(notebookDeleteFail()))
     }
@@ -293,14 +293,14 @@ export const FlowListProvider: FC = ({children}) => {
 
   const getAll = useCallback(async (): Promise<void> => {
     const data = isFlagEnabled(notebookAPIFlag)
-      ? await getAllAPINotebooks(orgID)
-      : await getAllAPI(orgID)
+      ? await getAllAPINotebooks(org.id)
+      : await getAllAPI(org.id)
     if (data && data.flows) {
       const _flows = {}
       data.flows.forEach(f => (_flows[f.id] = hydrate(f.spec)))
       setFlows(_flows)
     }
-  }, [orgID, setFlows])
+  }, [org.id, setFlows])
 
   const change = useCallback(
     (id: string) => {
@@ -314,8 +314,13 @@ export const FlowListProvider: FC = ({children}) => {
 
   const migrate = async () => {
     const _flows = isFlagEnabled(notebookAPIFlag)
-      ? await migrateLocalFlowsToAPINotebooks(orgID, flows, serialize, dispatch)
-      : await migrateLocalFlowsToAPI(orgID, flows, serialize, dispatch)
+      ? await migrateLocalFlowsToAPINotebooks(
+          org.id,
+          flows,
+          serialize,
+          dispatch
+        )
+      : await migrateLocalFlowsToAPI(org.id, flows, serialize, dispatch)
     setFlows({..._flows})
     if (currentID && currentID.includes('local')) {
       // if we migrated the local currentID flow, reset currentID

--- a/src/shared/containers/GetOrganizations.tsx
+++ b/src/shared/containers/GetOrganizations.tsx
@@ -7,6 +7,9 @@ import {Route, Switch} from 'react-router-dom'
 import PageSpinner from 'src/perf/components/PageSpinner'
 import {CheckoutPage, OperatorPage} from 'src/shared/containers'
 const NoOrgsPage = lazy(() => import('src/organizations/containers/NoOrgsPage'))
+const NotebookTemplates = lazy(() =>
+  import('src/flows/components/FromTemplatePage')
+)
 const App = lazy(() => import('src/App'))
 const NotFound = lazy(() => import('src/shared/components/NotFound'))
 
@@ -63,6 +66,7 @@ const GetOrganizations: FunctionComponent = () => {
           <PageSpinner loading={quartzMeStatus}>
             <Switch>
               <Route path="/no-orgs" component={NoOrgsPage} />
+              <Route path="/notebook/from" component={NotebookTemplates} />
               <Route path="/orgs" component={App} />
               <Route exact path="/" component={RouteToOrg} />
               {CLOUD &&
@@ -79,6 +83,7 @@ const GetOrganizations: FunctionComponent = () => {
         ) : (
           <Switch>
             <Route path="/no-orgs" component={NoOrgsPage} />
+            <Route path="/notebook/from" component={NotebookTemplates} />
             <Route path="/orgs" component={App} />
             <Route exact path="/" component={RouteToOrg} />
             <Route component={NotFound} />


### PR DESCRIPTION
This allows us to generate any number of random notebooks from a template. You just add the template to the giant object, and it registers a route you can reference with a link (no user info in there like orgs or what not). should be able to deeplink from docs as well, but try it as a signed out user before shipping

![Peek 2021-05-20 11-32](https://user-images.githubusercontent.com/1434802/119031136-97846500-b95f-11eb-9e8f-65cfb20a7df2.gif)


turns out there's a bug with the youtube component where autoplay doesnt fire when we deeplink to the page, so please ignore