### PR TITLE
chore: updating clockface version

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "webpack-merge": "^4.2.1"
   },
   "dependencies": {
-    "@influxdata/clockface": "^2.6.9",
+    "@influxdata/clockface": "^2.8.0",
     "@influxdata/flux": "^0.5.1",
     "@influxdata/flux-lsp-browser": "^0.5.46",
     "@influxdata/giraffe": "^2.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -710,10 +710,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@influxdata/clockface@^2.6.9":
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-2.6.9.tgz#ec18cabdc9a07f56e788270db4027b3985ac5316"
-  integrity sha512-6pzFuysWsIh+eXD81JsZMRwCRhlBLvi1wrbhwvXcv+2vytZ8UtcDocp1GF2bZ457caWkdMG+DMunv9/AV0OxDg==
+"@influxdata/clockface@^2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-2.8.0.tgz#92327287aeced602ff20819b10cb23380b8fec0e"
+  integrity sha512-EQ/t4OX6pq2LvNhc/ba0wAT0enfH165+Ih/86g3nwk0BFNmRIoNmZ2osuCgw/pyslX+5xxdPaEfMe3lsXmXriw==
 
 "@influxdata/flux-lsp-browser@^0.5.46":
   version "0.5.46"


### PR DESCRIPTION
Closes #

>The only thing it affects is it will change the way the draggable handle looks in data explorer but it won't change any functionality.
>I added things that aren't in use yet as welll (like full-screen overlay)

See: https://github.com/influxdata/clockface/releases/tag/v2.8.0