### PR TITLE
feat: remove feature flag for Band Plot

### DIFF
--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -1065,7 +1065,6 @@ describe('DataExplorer', () => {
     describe('static legend', () => {
       it('turns off static legend flag, so static legend option should not exist', () => {
         cy.window().then(win => {
-          win.influx.set('bandPlotType', true)
           win.influx.set('staticLegend', false)
           VIS_TYPES.forEach(type => {
             cy.getByTestID('cog-cell--button').click()
@@ -1078,7 +1077,6 @@ describe('DataExplorer', () => {
 
       it('turns on static legend flag, so static legend option should exist for line graph, line graph plus single stat, and band plot', () => {
         cy.window().then(win => {
-          win.influx.set('bandPlotType', true)
           win.influx.set('staticLegend', true)
           VIS_TYPES.forEach(type => {
             cy.getByTestID('cog-cell--button').click()

--- a/src/visualization/types/Band/index.tsx
+++ b/src/visualization/types/Band/index.tsx
@@ -8,7 +8,6 @@ export default register => {
     type: 'band',
     name: 'Band',
     graphic: icon,
-    featureFlag: 'bandPlotType',
     initial: properties,
     component: view,
     options,


### PR DESCRIPTION
Closes #1463 

Removes the feature flag `bandPlotType` and makes this feature permanent.
