### PR TITLE
feat: remove feature flag for Mosaic

### DIFF
--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -1065,7 +1065,6 @@ describe('DataExplorer', () => {
     describe('static legend', () => {
       it('turns off static legend flag, so static legend option should not exist', () => {
         cy.window().then(win => {
-          win.influx.set('mosaicGraphType', true)
           win.influx.set('bandPlotType', true)
           win.influx.set('staticLegend', false)
           VIS_TYPES.forEach(type => {
@@ -1079,7 +1078,6 @@ describe('DataExplorer', () => {
 
       it('turns on static legend flag, so static legend option should exist for line graph, line graph plus single stat, and band plot', () => {
         cy.window().then(win => {
-          win.influx.set('mosaicGraphType', true)
           win.influx.set('bandPlotType', true)
           win.influx.set('staticLegend', true)
           VIS_TYPES.forEach(type => {

--- a/src/visualization/types/Mosaic/index.tsx
+++ b/src/visualization/types/Mosaic/index.tsx
@@ -8,7 +8,6 @@ export default register => {
     type: 'mosaic',
     name: 'Mosaic',
     graphic: icon,
-    featureFlag: 'mosaicGraphType',
     component: view,
     initial: properties,
     options,


### PR DESCRIPTION
Closes #1460 

Removes the feature flag `mosaicGraphType` and makes this feature permanent.
