### PR TITLE
chore: remove generic & unused lodash imports

### DIFF
--- a/src/authorizations/components/TokenList.tsx
+++ b/src/authorizations/components/TokenList.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import _ from 'lodash'
 import memoizeOne from 'memoize-one'
 
 // Components

--- a/src/buckets/components/BucketCard.tsx
+++ b/src/buckets/components/BucketCard.tsx
@@ -1,7 +1,6 @@
 // Libraries
 import React, {FC} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import _ from 'lodash'
 
 // Components
 import {ResourceCard} from '@influxdata/clockface'

--- a/src/buckets/components/RenameBucketOverlay.tsx
+++ b/src/buckets/components/RenameBucketOverlay.tsx
@@ -1,7 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import _ from 'lodash'
 
 // Components
 import DangerConfirmationOverlay from 'src/shared/components/dangerConfirmation/DangerConfirmationOverlay'

--- a/src/clockface/components/inputs/multipleInput/MultipleInput.tsx
+++ b/src/clockface/components/inputs/multipleInput/MultipleInput.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent, ChangeEvent} from 'react'
-import _ from 'lodash'
+import {debounce, isEmpty} from 'lodash'
 
 // Components
 import {Button, Form, Input, Grid} from '@influxdata/clockface'
@@ -62,7 +62,7 @@ class MultipleInput extends PureComponent<Props, State> {
 
     this.inputRef = React.createRef()
 
-    this.debouncedValidate = _.debounce(
+    this.debouncedValidate = debounce(
       this.handleValidateURI,
       VALIDATE_DEBOUNCE_MS
     )
@@ -160,7 +160,7 @@ class MultipleInput extends PureComponent<Props, State> {
   }
 
   private shouldAddToList(item: Item, tags: Item[]): boolean {
-    return !_.isEmpty(item) && !tags.find(l => l === item)
+    return !isEmpty(item) && !tags.find(l => l === item)
   }
 
   private handleValidateURI = (value: string): void => {

--- a/src/clockface/components/wizard/ProgressBar.tsx
+++ b/src/clockface/components/wizard/ProgressBar.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import _ from 'lodash'
+import {findIndex} from 'lodash'
 
 // Components
 import {ErrorHandling} from 'src/shared/decorators/errors'
@@ -44,7 +44,7 @@ class ProgressBar extends PureComponent<Props, null> {
 
   private get nextNonSkippableStep(): number {
     const {currentStepIndex, stepSkippable, stepStatuses} = this.props
-    return _.findIndex(stepSkippable, (isSkippable, i) => {
+    return findIndex(stepSkippable, (isSkippable, i) => {
       return (
         !isSkippable &&
         i > currentStepIndex &&

--- a/src/dataLoaders/components/collectorsWizard/CollectorsStepSwitcher.tsx
+++ b/src/dataLoaders/components/collectorsWizard/CollectorsStepSwitcher.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import _ from 'lodash'
 
 // Components
 import SelectCollectorsStep from 'src/dataLoaders/components/collectorsWizard/select/SelectCollectorsStep'

--- a/src/dataLoaders/components/collectorsWizard/configure/ConfigFieldHandler.tsx
+++ b/src/dataLoaders/components/collectorsWizard/configure/ConfigFieldHandler.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {PureComponent, ChangeEvent} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
-import _ from 'lodash'
+import {get} from 'lodash'
 
 // Components
 import ConfigFieldSwitcher from 'src/dataLoaders/components/configureStep/streaming/ConfigFieldSwitcher'
@@ -91,7 +91,7 @@ export class ConfigFieldHandler extends PureComponent<Props> {
     } else {
       defaultEmpty = []
     }
-    return _.get(telegrafPlugin, `plugin.config.${fieldName}`, defaultEmpty)
+    return get(telegrafPlugin, `plugin.config.${fieldName}`, defaultEmpty)
   }
 
   private handleUpdateConfigField = (e: ChangeEvent<HTMLInputElement>) => {

--- a/src/dataLoaders/components/collectorsWizard/configure/PluginConfigForm.tsx
+++ b/src/dataLoaders/components/collectorsWizard/configure/PluginConfigForm.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {PureComponent} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
-import _ from 'lodash'
+import {startCase} from 'lodash'
 
 // Components
 import {Form, DapperScrollbars} from '@influxdata/clockface'
@@ -37,7 +37,7 @@ export class PluginConfigForm extends PureComponent<Props> {
         >
           <div>
             <h3 className="wizard-step--title">
-              {_.startCase(telegrafPlugin.name)}
+              {startCase(telegrafPlugin.name)}
             </h3>
             <h5 className="wizard-step--sub-title">
               For more information about this plugin, see{' '}

--- a/src/dataLoaders/components/collectorsWizard/select/StreamingSelector.tsx
+++ b/src/dataLoaders/components/collectorsWizard/select/StreamingSelector.tsx
@@ -1,7 +1,6 @@
 // Libraries
 import React, {PureComponent, ChangeEvent, createElement} from 'react'
 import uuid from 'uuid'
-import _ from 'lodash'
 
 // Components
 import {

--- a/src/dataLoaders/components/configureStep/streaming/ArrayFormElement.tsx
+++ b/src/dataLoaders/components/configureStep/streaming/ArrayFormElement.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import _ from 'lodash'
 
 // Components
 import {MultipleInput, MultiInputType} from 'src/clockface'

--- a/src/dataLoaders/components/configureStep/streaming/ConfigFieldSwitcher.tsx
+++ b/src/dataLoaders/components/configureStep/streaming/ConfigFieldSwitcher.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {PureComponent, ChangeEvent} from 'react'
-import _ from 'lodash'
 
 // Components
 import {Form, Input, Grid} from '@influxdata/clockface'

--- a/src/dataLoaders/components/verifyStep/ConnectionInformation.tsx
+++ b/src/dataLoaders/components/verifyStep/ConnectionInformation.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import _ from 'lodash'
 
 // Decorator
 import {ErrorHandling} from 'src/shared/decorators/errors'

--- a/src/dataLoaders/components/verifyStep/DataStreaming.tsx
+++ b/src/dataLoaders/components/verifyStep/DataStreaming.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import _ from 'lodash'
 
 // Components
 import TelegrafInstructions from 'src/dataLoaders/components/verifyStep/TelegrafInstructions'

--- a/src/dataLoaders/reducers/dataLoaders.ts
+++ b/src/dataLoaders/reducers/dataLoaders.ts
@@ -1,5 +1,5 @@
 // Libraries
-import _ from 'lodash'
+import {uniqBy, sortBy, get, isEmpty} from 'lodash'
 
 // Utils
 import {
@@ -82,8 +82,8 @@ export default (state = INITIAL_STATE, action: Action): DataLoadersState => {
     case 'ADD_TELEGRAF_PLUGINS':
       return {
         ...state,
-        telegrafPlugins: _.sortBy(
-          _.uniqBy(
+        telegrafPlugins: sortBy(
+          uniqBy(
             [...state.telegrafPlugins, ...action.payload.telegrafPlugins],
             'name'
           ),
@@ -109,7 +109,7 @@ export default (state = INITIAL_STATE, action: Action): DataLoadersState => {
         ...state,
         telegrafPlugins: state.telegrafPlugins.map(tp => {
           if (tp.name === action.payload.name) {
-            const plugin = _.get(tp, 'plugin', createNewPlugin(tp.name))
+            const plugin = get(tp, 'plugin', createNewPlugin(tp.name))
 
             return {
               ...tp,
@@ -128,13 +128,9 @@ export default (state = INITIAL_STATE, action: Action): DataLoadersState => {
         ...state,
         telegrafPlugins: state.telegrafPlugins.map(tp => {
           if (tp.name === action.payload.pluginName) {
-            const plugin = _.get(tp, 'plugin', createNewPlugin(tp.name))
+            const plugin = get(tp, 'plugin', createNewPlugin(tp.name))
 
-            const config = _.get(
-              plugin,
-              ['config', action.payload.fieldName],
-              []
-            )
+            const config = get(plugin, ['config', action.payload.fieldName], [])
 
             const updatedConfigFieldValue: string[] = [
               ...config,
@@ -158,9 +154,9 @@ export default (state = INITIAL_STATE, action: Action): DataLoadersState => {
         ...state,
         telegrafPlugins: state.telegrafPlugins.map(tp => {
           if (tp.name === action.payload.pluginName) {
-            const plugin = _.get(tp, 'plugin', createNewPlugin(tp.name))
+            const plugin = get(tp, 'plugin', createNewPlugin(tp.name))
 
-            const configFieldValues = _.get(
+            const configFieldValues = get(
               plugin,
               `config.${action.payload.fieldName}`,
               []
@@ -186,8 +182,8 @@ export default (state = INITIAL_STATE, action: Action): DataLoadersState => {
         ...state,
         telegrafPlugins: state.telegrafPlugins.map(tp => {
           if (tp.name === action.payload.pluginName) {
-            const plugin = _.get(tp, 'plugin', createNewPlugin(tp.name))
-            const configValues = _.get(
+            const plugin = get(tp, 'plugin', createNewPlugin(tp.name))
+            const configValues = get(
               plugin,
               `config.${action.payload.field}`,
               []
@@ -217,7 +213,7 @@ export default (state = INITIAL_STATE, action: Action): DataLoadersState => {
       return {
         ...state,
         telegrafPlugins: state.telegrafPlugins.map(tp => {
-          const name = _.get(tp, 'name')
+          const name = get(tp, 'name')
           if (name === action.payload.telegrafPlugin) {
             const configFields = getConfigFields(name)
             if (!configFields) {
@@ -225,7 +221,7 @@ export default (state = INITIAL_STATE, action: Action): DataLoadersState => {
             }
 
             const plugin = getDeep<Plugin>(tp, 'plugin', createNewPlugin(name))
-            const config = _.get(plugin, 'config', {})
+            const config = get(plugin, 'config', {})
 
             let isValidConfig = true
 
@@ -254,7 +250,7 @@ export default (state = INITIAL_STATE, action: Action): DataLoadersState => {
               }
             )
 
-            if (!isValidConfig || _.isEmpty(config)) {
+            if (!isValidConfig || isEmpty(config)) {
               return {
                 ...tp,
                 configured: ConfigurationState.InvalidConfiguration,

--- a/src/dataLoaders/utils/pluginConfigs.ts
+++ b/src/dataLoaders/utils/pluginConfigs.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash'
+import {get} from 'lodash'
 
 // Constants
 import {
@@ -26,7 +26,7 @@ export const updateConfigFields = <T extends Plugin>(
   value: string[] | string
 ): T => {
   return Object.assign({}, plugin, {
-    config: Object.assign({}, _.get(plugin, 'config', {}), {
+    config: Object.assign({}, get(plugin, 'config', {}), {
       [fieldName]: value,
     }),
   })

--- a/src/functions/components/FunctionRunLogRow.tsx
+++ b/src/functions/components/FunctionRunLogRow.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {FC} from 'react'
-import _ from 'lodash'
 import moment from 'moment'
 
 // Components

--- a/src/functions/components/FunctionRunLogsOverlay.tsx
+++ b/src/functions/components/FunctionRunLogsOverlay.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {FC} from 'react'
-import _ from 'lodash'
 
 // Components
 import {Overlay, IndexList, DapperScrollbars} from '@influxdata/clockface'

--- a/src/labels/components/CreateLabelOverlay.tsx
+++ b/src/labels/components/CreateLabelOverlay.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {Component, ChangeEvent} from 'react'
-import _ from 'lodash'
 
 // Components
 import LabelOverlayForm from 'src/labels/components/LabelOverlayForm'

--- a/src/me/constants/index.ts
+++ b/src/me/constants/index.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash'
+import {sample} from 'lodash'
 import {Dashboard} from 'src/types'
 
 interface Greeting {
@@ -158,7 +158,7 @@ const randomGreetings: Greeting[] = [
 ]
 
 export const generateRandomGreeting = (): Greeting => {
-  return _.sample(randomGreetings)
+  return sample(randomGreetings)
 }
 
 const sortFunc = (a: Dashboard, b: Dashboard) => {

--- a/src/onboarding/actions/index.ts
+++ b/src/onboarding/actions/index.ts
@@ -1,5 +1,5 @@
 // Libraries
-import _ from 'lodash'
+import {get} from 'lodash'
 
 // Constants
 import {StepStatus} from 'src/clockface/constants/wizard'
@@ -94,7 +94,7 @@ export const setupAdmin = (
     return true
   } catch (err) {
     console.error(err)
-    const message = _.get(err, 'response.data.message', '')
+    const message = get(err, 'response.data.message', '')
     dispatch(notify(SetupError(message)))
     dispatch(setStepStatus(1, StepStatus.Error))
   }

--- a/src/onboarding/components/CompletionQuickStartButton.tsx
+++ b/src/onboarding/components/CompletionQuickStartButton.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {PureComponent} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import _ from 'lodash'
+import {get} from 'lodash'
 
 // Components
 import {Button, ComponentColor, ComponentSize} from '@influxdata/clockface'
@@ -33,7 +33,7 @@ class CompletionQuickStartButton extends PureComponent<Props> {
 
   private handleAdvanced = (): void => {
     const {history, dashboards, onExit} = this.props
-    const id = _.get(dashboards, '[0].id', null)
+    const id = get(dashboards, '[0].id', null)
     if (id) {
       history.push(`/dashboards/${id}`)
     } else {

--- a/src/onboarding/components/OnboardingStepSwitcher.tsx
+++ b/src/onboarding/components/OnboardingStepSwitcher.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import _ from 'lodash'
 
 // Components
 import InitStep from 'src/onboarding/components/InitStep'

--- a/src/organizations/components/OrgNavigation.tsx
+++ b/src/organizations/components/OrgNavigation.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import _ from 'lodash'
 import {Link} from 'react-router-dom'
 
 // Components

--- a/src/organizations/components/OrgTabbedPage.tsx
+++ b/src/organizations/components/OrgTabbedPage.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import _ from 'lodash'
 
 // Components
 import OrgNavigation from 'src/organizations/components/OrgNavigation'

--- a/src/organizations/components/RenameOrgOverlay.tsx
+++ b/src/organizations/components/RenameOrgOverlay.tsx
@@ -2,7 +2,6 @@
 import React, {PureComponent} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 import {Overlay} from '@influxdata/clockface'
-import _ from 'lodash'
 
 // Components
 import DangerConfirmationOverlay from 'src/shared/components/dangerConfirmation/DangerConfirmationOverlay'

--- a/src/scrapers/components/CreateScraperForm.tsx
+++ b/src/scrapers/components/CreateScraperForm.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {PureComponent, ChangeEvent, FormEvent} from 'react'
-import _ from 'lodash'
 
 // Components
 import {Form, Input, Grid, Button, ButtonType} from '@influxdata/clockface'
@@ -135,8 +134,7 @@ export class ScraperTarget extends PureComponent<Props> {
       return 'Target URL cannot be empty'
     }
 
-    const isURLValid =
-      _.startsWith(url, 'http://') || _.startsWith(url, 'https://')
+    const isURLValid = url.startsWith('http://') || url.startsWith('https://')
 
     if (!isURLValid) {
       return 'Target URL must begin with "http://"'

--- a/src/settings/components/LoadDataNavigation.tsx
+++ b/src/settings/components/LoadDataNavigation.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import _ from 'lodash'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components

--- a/src/settings/components/LoadDataTabbedPage.tsx
+++ b/src/settings/components/LoadDataTabbedPage.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {FC, ReactNode} from 'react'
-import _ from 'lodash'
 import {connect, ConnectedProps} from 'react-redux'
 
 // Components

--- a/src/settings/components/SettingsNavigation.tsx
+++ b/src/settings/components/SettingsNavigation.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import _ from 'lodash'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components

--- a/src/settings/components/SettingsTabbedPage.tsx
+++ b/src/settings/components/SettingsTabbedPage.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import _ from 'lodash'
 
 // Components
 import SettingsNavigation from 'src/settings/components/SettingsNavigation'

--- a/src/shared/components/AddResourceDropdown.tsx
+++ b/src/shared/components/AddResourceDropdown.tsx
@@ -1,7 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
-import _ from 'lodash'
 
 // Components
 import {

--- a/src/shared/components/URIFormElement.tsx
+++ b/src/shared/components/URIFormElement.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent, ChangeEvent} from 'react'
-import _ from 'lodash'
+import {debounce} from 'lodash'
 
 // Components
 import {Input, FormElement, Grid} from '@influxdata/clockface'
@@ -34,7 +34,7 @@ class URIFormElement extends PureComponent<Props, State> {
       status: ComponentStatus.Default,
     }
 
-    this.debouncedValidate = _.debounce(
+    this.debouncedValidate = debounce(
       this.handleValidateURI,
       VALIDATE_DEBOUNCE_MS
     )

--- a/src/shared/components/dangerConfirmation/DangerConfirmationOverlay.tsx
+++ b/src/shared/components/dangerConfirmation/DangerConfirmationOverlay.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import _ from 'lodash'
 
 // Components
 import {Overlay} from '@influxdata/clockface'

--- a/src/shared/components/inlineLabels/InlineLabelPopover.tsx
+++ b/src/shared/components/inlineLabels/InlineLabelPopover.tsx
@@ -5,7 +5,7 @@ import React, {
   KeyboardEvent,
   RefObject,
 } from 'react'
-import _ from 'lodash'
+import {findIndex} from 'lodash'
 
 // Components
 import {Input, ButtonBaseRef} from '@influxdata/clockface'
@@ -144,7 +144,7 @@ export default class InlineLabelPopover extends PureComponent<Props> {
       return null
     }
 
-    const selectedItemIndex = _.findIndex(
+    const selectedItemIndex = findIndex(
       filteredLabels,
       label => label.id === selectedItemID
     )

--- a/src/shared/components/inlineLabels/InlineLabelsCreateLabelButton.tsx
+++ b/src/shared/components/inlineLabels/InlineLabelsCreateLabelButton.tsx
@@ -1,7 +1,6 @@
 // Libraries
 import React, {Component, MouseEvent} from 'react'
 import classnames from 'classnames'
-import _ from 'lodash'
 
 import {ErrorHandling} from 'src/shared/decorators/errors'
 

--- a/src/shared/components/inlineLabels/InlineLabelsEditor.tsx
+++ b/src/shared/components/inlineLabels/InlineLabelsEditor.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {Component, ChangeEvent, createRef} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
-import _ from 'lodash'
+import {differenceBy} from 'lodash'
 
 // Components
 import {
@@ -255,7 +255,7 @@ class InlineLabelsEditor extends Component<Props, State> {
   private get availableLabels(): Label[] {
     const {selectedLabels, labels} = this.props
 
-    return _.differenceBy(labels, selectedLabels, label => label.name)
+    return differenceBy(labels, selectedLabels, label => label.name)
   }
 
   private handleCreateLabel = async (label: Label) => {

--- a/src/shared/components/inlineLabels/InlineLabelsList.tsx
+++ b/src/shared/components/inlineLabels/InlineLabelsList.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {Component} from 'react'
-import _ from 'lodash'
 
 // Components
 import {EmptyState, DapperScrollbars} from '@influxdata/clockface'

--- a/src/shared/components/inlineLabels/InlineLabelsListItem.tsx
+++ b/src/shared/components/inlineLabels/InlineLabelsListItem.tsx
@@ -1,7 +1,6 @@
 // Libraries
 import React, {Component, MouseEvent} from 'react'
 import classnames from 'classnames'
-import _ from 'lodash'
 
 // Components
 import {Label} from '@influxdata/clockface'

--- a/src/shared/constants/colorOperations.ts
+++ b/src/shared/constants/colorOperations.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash'
+import {sortBy} from 'lodash'
 import chroma from 'chroma-js'
 
 import {
@@ -21,7 +21,7 @@ const getLegibleTextColor = bgColorHex => {
 }
 
 const findNearestCrossedThreshold = (colors, lastValue) => {
-  const sortedColors = _.sortBy(colors, color => Number(color.value))
+  const sortedColors = sortBy(colors, color => Number(color.value))
 
   // If the value is less than zero, clamp to the lowest value
   // See https://github.com/influxdata/influxdb/issues/20750

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash'
 import {
   Config,
   NINETEEN_EIGHTY_FOUR,

--- a/src/shared/constants/thresholds.ts
+++ b/src/shared/constants/thresholds.ts
@@ -1,5 +1,3 @@
-import _ from 'lodash'
-
 export const MAX_THRESHOLDS = 5
 export const MIN_THRESHOLDS = 2
 

--- a/src/shared/copy/cell.ts
+++ b/src/shared/copy/cell.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash'
+import {sample} from 'lodash'
 
 const emptyFunny = [
   'Looks like you don’t have any queries. Be a lot cooler if you did!',
@@ -6,4 +6,4 @@ const emptyFunny = [
   'Create a query. Have fun!',
 ]
 
-export const emptyGraphCopy = _.sample(emptyFunny)
+export const emptyGraphCopy = sample(emptyFunny)

--- a/src/shared/parsing/flux/response.ts
+++ b/src/shared/parsing/flux/response.ts
@@ -1,5 +1,5 @@
 import Papa from 'papaparse'
-import _ from 'lodash'
+import {get, groupBy, isEmpty} from 'lodash'
 import uuid from 'uuid'
 
 import {FluxTable} from 'src/types'
@@ -58,11 +58,11 @@ export const parseTables = (responseChunk: string): FluxTable[] => {
     .join('\n')
     .trim()
 
-  if (_.isEmpty(annotationLines)) {
+  if (isEmpty(annotationLines)) {
     throw new Error('Unable to extract annotation data')
   }
 
-  if (_.isEmpty(nonAnnotationLines)) {
+  if (isEmpty(nonAnnotationLines)) {
     // A response may be truncated on an arbitrary line. This guards against
     // the case where a response is truncated on annotation data
     return []
@@ -80,10 +80,7 @@ export const parseTables = (responseChunk: string): FluxTable[] => {
 
   // Group rows by their table id
   const tablesData = Object.values(
-    _.groupBy<TableGroup[]>(
-      nonAnnotationData.slice(1),
-      row => row[tableColIndex]
-    )
+    groupBy<TableGroup[]>(nonAnnotationData.slice(1), row => row[tableColIndex])
   )
 
   const groupRow = annotationData.find(row => row[0] === '#group')
@@ -100,14 +97,13 @@ export const parseTables = (responseChunk: string): FluxTable[] => {
   }, [])
 
   const tables = tablesData.map(tableData => {
-    const dataRow = _.get(tableData, '0', defaultsRow)
+    const dataRow = get(tableData, '0', defaultsRow)
 
     const result: string =
-      _.get(dataRow, resultColIndex, '') ||
-      _.get(defaultsRow, resultColIndex, '')
+      get(dataRow, resultColIndex, '') || get(defaultsRow, resultColIndex, '')
 
     const groupKey = groupKeyIndices.reduce((acc, i) => {
-      return {...acc, [headerRow[i]]: _.get(dataRow, i, '')}
+      return {...acc, [headerRow[i]]: get(dataRow, i, '')}
     }, {})
 
     const name = Object.entries(groupKey)

--- a/src/shared/reducers/links.test.ts
+++ b/src/shared/reducers/links.test.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash'
+import {isEqual} from 'lodash'
 
 import linksReducer from 'src/shared/reducers/links'
 import {linksGetCompleted} from 'src/shared/actions/links'
@@ -39,6 +39,6 @@ describe('Shared.Reducers.linksReducer', () => {
   it('can handle LINKS_GET_COMPLETED', () => {
     const actual = linksReducer(undefined, linksGetCompleted(links))
     const expected = links
-    expect(_.isEqual(actual, expected)).toBe(true)
+    expect(isEqual(actual, expected)).toBe(true)
   })
 })

--- a/src/shared/tabbedPage/TabbedPageTabs.tsx
+++ b/src/shared/tabbedPage/TabbedPageTabs.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {FC} from 'react'
-import _ from 'lodash'
 
 // Components
 import {Tabs, Orientation, ComponentSize} from '@influxdata/clockface'

--- a/src/store/persistStateEnhancer.ts
+++ b/src/store/persistStateEnhancer.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash'
+import {throttle} from 'lodash'
 import {saveToLocalStorage} from '../localStorage'
 
 // Types
@@ -20,7 +20,7 @@ export default function persistState() {
     const throttleMs = 1000
 
     store.subscribe(
-      _.throttle(() => {
+      throttle(() => {
         saveToLocalStorage(store.getState())
       }, throttleMs)
     )

--- a/src/tasks/components/RunLogRow.tsx
+++ b/src/tasks/components/RunLogRow.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import _ from 'lodash'
 import moment from 'moment'
 
 // Components

--- a/src/tasks/components/RunLogsList.tsx
+++ b/src/tasks/components/RunLogsList.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import _ from 'lodash'
 
 // Components
 import {Overlay, IndexList, DapperScrollbars} from '@influxdata/clockface'

--- a/src/telegrafs/components/Collectors.tsx
+++ b/src/telegrafs/components/Collectors.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import _ from 'lodash'
+import {isEmpty} from 'lodash'
 import React, {PureComponent} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
@@ -218,7 +218,7 @@ export class Collectors extends PureComponent<Props, State> {
     const {orgName} = this.props
     const {searchTerm} = this.state
 
-    if (_.isEmpty(searchTerm)) {
+    if (isEmpty(searchTerm)) {
       return (
         <EmptyState size={ComponentSize.Medium}>
           <EmptyState.Text>

--- a/src/telegrafs/components/TelegrafConfigOverlay.tsx
+++ b/src/telegrafs/components/TelegrafConfigOverlay.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {FC, useContext} from 'react'
-import _ from 'lodash'
 
 // Components
 import {Overlay} from '@influxdata/clockface'

--- a/src/telegrafs/components/TelegrafConfigOverlayForm.tsx
+++ b/src/telegrafs/components/TelegrafConfigOverlayForm.tsx
@@ -2,7 +2,6 @@
 import React, {FC, useState, useContext} from 'react'
 import {useSelector, useDispatch} from 'react-redux'
 import {useRouteMatch} from 'react-router-dom'
-import _ from 'lodash'
 
 // Components
 import TelegrafConfig from 'src/telegrafs/components/TelegrafConfig'

--- a/src/templates/components/createFromTemplateOverlay/TemplateBrowser.tsx
+++ b/src/templates/components/createFromTemplateOverlay/TemplateBrowser.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import _ from 'lodash'
 
 // Components
 import {TemplateSummary, Template} from 'src/types'

--- a/src/templates/components/createFromTemplateOverlay/TemplateBrowserDetails.tsx
+++ b/src/templates/components/createFromTemplateOverlay/TemplateBrowserDetails.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import _ from 'lodash'
+import {get} from 'lodash'
 
 // Components
 import {
@@ -115,7 +115,7 @@ class TemplateBrowserDetails extends PureComponent<Props> {
 
   private get templateDescription(): JSX.Element {
     const {selectedTemplateSummary} = this.props
-    const description = _.get(selectedTemplateSummary, 'meta.description')
+    const description = get(selectedTemplateSummary, 'meta.description')
 
     if (description) {
       return (
@@ -132,7 +132,7 @@ class TemplateBrowserDetails extends PureComponent<Props> {
 
   private get templateName(): JSX.Element {
     const {selectedTemplateSummary} = this.props
-    const name = _.get(selectedTemplateSummary, 'meta.name')
+    const name = get(selectedTemplateSummary, 'meta.name')
 
     const templateName = name || 'Untitled'
     const className = name

--- a/src/timeMachine/components/RawFluxDataGrid.tsx
+++ b/src/timeMachine/components/RawFluxDataGrid.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent, CSSProperties} from 'react'
-import _ from 'lodash'
+import {reduce, find, range} from 'lodash'
 import {Grid} from 'react-virtualized'
 
 export const ROW_HEIGHT = 27
@@ -23,7 +23,7 @@ interface State {
 
 export default class extends PureComponent<Props, State> {
   public static getDerivedStateFromProps(nextProps: Props): Partial<State> {
-    const headerRows = _.reduce(
+    const headerRows = reduce(
       nextProps.data,
       (acc, row, index) => {
         if (row[0] === '#datatype') {
@@ -69,7 +69,7 @@ export default class extends PureComponent<Props, State> {
   private columnWidth = ({index}): number => {
     const {maxColumnCount, width} = this.props
 
-    const isDateTimeColumn = _.find(this.state.headerRows, i => {
+    const isDateTimeColumn = find(this.state.headerRows, i => {
       return (this.getCellData(i, index) || '').includes('dateTime')
     })
 
@@ -110,8 +110,8 @@ export default class extends PureComponent<Props, State> {
 
   private calculateWidth(): number {
     const {maxColumnCount} = this.props
-    return _.reduce(
-      _.range(0, maxColumnCount),
+    return reduce(
+      range(0, maxColumnCount),
       (acc, index) => acc + this.columnWidth({index}),
       0
     )

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -1,5 +1,3 @@
-import _ from 'lodash'
-
 export interface Duration {
   days: number
   hours: number

--- a/src/utils/wrappers.ts
+++ b/src/utils/wrappers.ts
@@ -1,9 +1,9 @@
-import _ from 'lodash'
+import {get} from 'lodash'
 
 export function getDeep<T = any>(
   obj: any,
   path: string | number,
   fallback: T
 ): T {
-  return _.get<T>(obj, path, fallback)
+  return get<T>(obj, path, fallback)
 }

--- a/src/variables/components/CSVVariableBuilder.tsx
+++ b/src/variables/components/CSVVariableBuilder.tsx
@@ -1,6 +1,6 @@
 import React, {PureComponent, ChangeEvent} from 'react'
 import Papa from 'papaparse'
-import _ from 'lodash'
+import {get} from 'lodash'
 
 // Component
 import {
@@ -73,9 +73,9 @@ export default class CSVTemplateBuilder extends PureComponent<Props, State> {
 
   private get defaultID(): string {
     const {selected, values} = this.props
-    const firstEntry = _.get(values, '0', 'Enter values above')
+    const firstEntry = get(values, '0', 'Enter values above')
 
-    return _.get(selected, '0', firstEntry)
+    return get(selected, '0', firstEntry)
   }
 
   private handleBlur = (): void => {
@@ -94,7 +94,7 @@ export default class CSVTemplateBuilder extends PureComponent<Props, State> {
 
   private getUniqueValuesFromCSV(csv: string): string[] {
     const parsedTVS = Papa.parse(csv)
-    const templateValuesData: string[][] = _.get(parsedTVS, 'data', [[]])
+    const templateValuesData: string[][] = get(parsedTVS, 'data', [[]])
 
     const valueSet: Set<string> = new Set()
     for (const row of templateValuesData) {

--- a/src/variables/components/MapVariableBuilder.tsx
+++ b/src/variables/components/MapVariableBuilder.tsx
@@ -1,5 +1,5 @@
 import React, {PureComponent, ChangeEvent} from 'react'
-import _ from 'lodash'
+import {get} from 'lodash'
 import {connect, ConnectedProps} from 'react-redux'
 
 // Component
@@ -108,9 +108,9 @@ class MapVariableBuilder extends PureComponent<Props, State> {
   private get defaultID(): string {
     const {selected} = this.props
     const {entries} = this
-    const firstEntry = _.get(entries, '0.key', 'Enter values above')
+    const firstEntry = get(entries, '0.key', 'Enter values above')
 
-    return _.get(selected, '0', firstEntry)
+    return get(selected, '0', firstEntry)
   }
 
   private get entries(): {key: string; value: string}[] {

--- a/src/variables/components/RenameVariableForm.tsx
+++ b/src/variables/components/RenameVariableForm.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {PureComponent, ChangeEvent, FormEvent} from 'react'
-import _ from 'lodash'
 import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 

--- a/src/variables/components/RenameVariableOverlay.tsx
+++ b/src/variables/components/RenameVariableOverlay.tsx
@@ -3,8 +3,6 @@ import React, {useContext, FC, memo} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 import {OverlayContext} from 'src/overlays/components/OverlayController'
 
-import _ from 'lodash'
-
 // Components
 import DangerConfirmationOverlay from 'src/shared/components/dangerConfirmation/DangerConfirmationOverlay'
 import RenameVariableForm from 'src/variables/components/RenameVariableForm'

--- a/src/variables/utils/mapBuilder.ts
+++ b/src/variables/utils/mapBuilder.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash'
+import {get, trimEnd} from 'lodash'
 import Papa from 'papaparse'
 
 interface MapResult {
@@ -8,9 +8,9 @@ interface MapResult {
 
 export const csvToMap = (csv: string): MapResult => {
   let errors = []
-  const trimmed = _.trimEnd(csv, '\n')
+  const trimmed = trimEnd(csv, '\n')
   const parsedTVS = Papa.parse(trimmed)
-  const templateValuesData: string[][] = _.get(parsedTVS, 'data', [[]])
+  const templateValuesData: string[][] = get(parsedTVS, 'data', [[]])
 
   if (templateValuesData.length === 0) {
     return {values: {}, errors}

--- a/src/visualization/types/Table/transform.ts
+++ b/src/visualization/types/Table/transform.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash'
+import {get, findIndex, replace, indexOf, orderBy, drop, unzip} from 'lodash'
 import {fastMap, fastReduce, fastFilter} from 'src/utils/fast'
 
 import {CELL_HORIZONTAL_PADDING, DEFAULT_TIME_FIELD} from './constants'
@@ -46,12 +46,12 @@ export const getInvalidDataMessage = (errorType: ErrorTypes): string => {
 
 const calculateTimeColumnWidth = (timeFormat: string): number => {
   // Force usage of longest format names for ideal measurement
-  timeFormat = _.replace(timeFormat, 'MMMM', 'September')
-  timeFormat = _.replace(timeFormat, 'dddd', 'Wednesday')
-  timeFormat = _.replace(timeFormat, 'A', 'AM')
-  timeFormat = _.replace(timeFormat, 'h', '00')
-  timeFormat = _.replace(timeFormat, 'X', '1522286058')
-  timeFormat = _.replace(timeFormat, 'x', '1536106867461')
+  timeFormat = replace(timeFormat, 'MMMM', 'September')
+  timeFormat = replace(timeFormat, 'dddd', 'Wednesday')
+  timeFormat = replace(timeFormat, 'A', 'AM')
+  timeFormat = replace(timeFormat, 'h', '00')
+  timeFormat = replace(timeFormat, 'X', '1522286058')
+  timeFormat = replace(timeFormat, 'x', '1536106867461')
 
   const width = calculateSize(timeFormat)
 
@@ -94,7 +94,7 @@ const updateMaxWidths = (
         : calculateSize(colValue.toString().trim()) + CELL_HORIZONTAL_PADDING
 
       const {widths: Widths} = maxColumnWidths
-      const maxWidth = _.get(Widths, `${columnLabel}`, 0)
+      const maxWidth = get(Widths, `${columnLabel}`, 0)
 
       if (isTopRow || currentWidth > maxWidth) {
         acc.widths[columnLabel] = currentWidth
@@ -188,7 +188,7 @@ export const orderTableColumns = (
   fieldOptions: FieldOption[]
 ): string[][] => {
   const fieldsSortOrder = fieldOptions.map(fieldOption => {
-    return _.findIndex(data[0], dataLabel => {
+    return findIndex(data[0], dataLabel => {
       return dataLabel === fieldOption.internalName
     })
   })
@@ -213,7 +213,7 @@ export const sortTableData = (
   let sortIndex = 0
 
   if (headerSet.has(sort.field)) {
-    sortIndex = _.indexOf(data[0], sort.field)
+    sortIndex = indexOf(data[0], sort.field)
   } else if (!sort.field) {
     return {
       sortedData: [...data],
@@ -221,10 +221,10 @@ export const sortTableData = (
     }
   }
 
-  const dataValues = _.drop(data, 1)
+  const dataValues = drop(data, 1)
   const sortedData = [
     data[0],
-    ..._.orderBy<string[][]>(
+    ...orderBy<string[][]>(
       dataValues,
       row => {
         const sortedValue = row[sortIndex]
@@ -280,7 +280,7 @@ export const transformTableData = (
 
   const orderedData = orderTableColumns(filteredData, resolvedFieldOptions)
 
-  const transformedData = verticalTimeAxis ? orderedData : _.unzip(orderedData)
+  const transformedData = verticalTimeAxis ? orderedData : unzip(orderedData)
 
   const columnWidths = calculateColumnWidths(
     transformedData,
@@ -350,5 +350,5 @@ export const getUnixISODiff = (unixMs: number, isoTime: string | number) => {
 export const findTableNameHeaders = (tables: FluxTable[], name: string) => {
   const foundTable = tables.find(t => t.name === name)
 
-  return _.get(foundTable, 'data.0', [])
+  return get(foundTable, 'data.0', [])
 }


### PR DESCRIPTION
Found a bunch of places where we were importing `import _ from lodash` and weren't using it at all.

In the cases where we were using the generic lodash import, I changed the import to only import the functions from lodash that are in use.

This should make it easier to find and remove usages of lodash functions in the future.