### PR TITLE
chore: enables skipped tests, removes some

### DIFF
--- a/cypress/e2e/cloud/communityTemplates.test.ts
+++ b/cypress/e2e/cloud/communityTemplates.test.ts
@@ -246,12 +246,15 @@ describe('Community Templates', () => {
       cy.go('back')
     })
 
-    // this behavior should be cleaned up
-    it.skip('takes you to github readme when you click on the Community Templates button', () => {
+    it('takes you to github readme when you click on the Community Templates button', () => {
+      // this request will 404 because it doesn't exist, but this will test that we're making the correct request.
+      cy.intercept(
+        'GET',
+        'https://raw.githubusercontent.com/influxdata/community-templates/master/testdata/readme.md'
+      ).as('readme')
       cy.getByTestID('community-template-readme-overlay-button').click()
-      cy.get('.markdown-format').should('contain', 'Setup Instructions')
-
-      // we should confirm the link works
+      cy.getByTestIDSubStr('overlay--child').should('be.visible')
+      cy.wait('@readme')
     })
 
     it('deletes templates', () => {

--- a/cypress/e2e/oss/explorer.test.ts
+++ b/cypress/e2e/oss/explorer.test.ts
@@ -1,0 +1,40 @@
+import {lines, makeGraphSnapshot} from '../../support/commands'
+
+describe('refresh', () => {
+  beforeEach(() => {
+    cy.writeData(lines(10))
+
+    cy.getByTestID(`selector-list m`).click()
+    cy.getByTestID('time-machine-submit-button').click()
+
+    // select short time period to ensure graph changes after short time
+    cy.getByTestID('timerange-dropdown').click()
+    cy.getByTestID('dropdown-item-past5m').click()
+  })
+
+  // TODO: get this test passing for OSS
+  // This feature only exsists in OSS currently.
+  it.skip('auto refresh', () => {
+    const snapshot = makeGraphSnapshot()
+    cy.getByTestID('autorefresh-dropdown--button').click()
+    cy.getByTestID('auto-refresh-5s').click()
+
+    cy.wait(3_000)
+    makeGraphSnapshot().shouldBeSameAs(snapshot)
+
+    cy.wait(3_000)
+    const snapshot2 = makeGraphSnapshot()
+    snapshot2.shouldBeSameAs(snapshot, false)
+
+    cy.getByTestID('autorefresh-dropdown-refresh').should('not.be.visible')
+    cy.getByTestID('autorefresh-dropdown--button')
+      .should('contain.text', '5s')
+      .click()
+    cy.getByTestID('auto-refresh-paused').click()
+    cy.getByTestID('autorefresh-dropdown-refresh').should('be.visible')
+
+    // wait if graph changes after another 6s when autorefresh is paused
+    cy.wait(6_000)
+    makeGraphSnapshot().shouldBeSameAs(snapshot2)
+  })
+})

--- a/cypress/e2e/shared/buckets.test.ts
+++ b/cypress/e2e/shared/buckets.test.ts
@@ -204,22 +204,7 @@ describe('Buckets', () => {
       cy.getByTestID('overlay--container').should('not.exist')
       cy.getByTestID('notification-success').should('have.length', 1)
     })
-    // needs relevant data in order to test functionality
-    it.skip('should require key-value pairs when deleting predicate with filters', () => {
-      // confirm delete is disabled
-      cy.getByTestID('add-filter-btn').click()
-      // checks the consent input
-      cy.getByTestID('delete-checkbox').check({force: true})
-      // cannot delete
-      cy.getByTestID('confirm-delete-btn').should('be.disabled')
-
-      // should display warnings
-      cy.getByTestID('form--element-error').should('have.length', 2)
-
-      // TODO: add filter values based on dropdown selection in key / value
-    })
   })
-
   describe('routing directly to the edit overlay', () => {
     it('reroutes to buckets view if bucket does not exist', () => {
       cy.get('@org').then(({id}: Organization) => {

--- a/cypress/e2e/shared/checks.test.ts
+++ b/cypress/e2e/shared/checks.test.ts
@@ -29,8 +29,7 @@ describe('Checks', () => {
     cy.getByTestID('alerting-tab--checks').click({force: true})
   })
 
-  // TODO(watts): resolve flakeyness caused by detached elements with: https://github.com/influxdata/ui/pull/515
-  it.skip('can validate a threshold check', () => {
+  it('can validate a threshold check', () => {
     cy.log('Create threshold check')
     cy.getByTestID('create-check').click()
     cy.getByTestID('create-threshold-check').click()
@@ -39,11 +38,10 @@ describe('Checks', () => {
       .should('be.disabled')
       .and('not.contain', 'Group')
       .contains('Filter')
+    cy.getByTestID('overlay--children').should('be.visible')
     cy.get<string>('@defaultBucketListSelector').then(
       (defaultBucketListSelector: string) => {
-        cy.getByTestID(defaultBucketListSelector)
-          .wait(1200)
-          .click()
+        cy.getByTestID(defaultBucketListSelector).click()
 
         cy.log(
           'Select measurement and field; assert checklist popover and save button'
@@ -86,7 +84,7 @@ describe('Checks', () => {
         })
 
         cy.log('Name the check; save')
-        cy.getByTestID('overlay--container').within(() => {
+        cy.getByTestID('overlay--children').within(() => {
           cy.getByTestID('page-title')
             .contains('Name this Check')
             .click()
@@ -104,8 +102,7 @@ describe('Checks', () => {
     )
   })
 
-  // TODO(watts): resolve flakeyness caused by detached elements with: https://github.com/influxdata/ui/pull/515
-  it.skip('can create and filter checks', () => {
+  it('can create and filter checks', () => {
     cy.get<string>('@defaultBucketListSelector').then(
       (defaultBucketListSelector: string) => {
         cy.log('create first check')

--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -870,6 +870,7 @@ describe('DataExplorer', () => {
       })
 
       // TODO: make work with annotations
+      // TODO: fix failing test - fails locally and in CI
       it.skip('can zoom and unzoom horizontal axis', () => {
         cy.getByTestID(`selector-list m`).click()
         cy.getByTestID('selector-list v').click()
@@ -902,6 +903,7 @@ describe('DataExplorer', () => {
         makeGraphSnapshot().shouldBeSameAs(snapshot)
       })
 
+      // TODO: fix failing test - fails locally and in CI
       it.skip('can zoom and unzoom vertical axis', () => {
         cy.getByTestID(`selector-list m`).click()
         cy.getByTestID('selector-list v').click()
@@ -1166,31 +1168,6 @@ describe('DataExplorer', () => {
       cy.wait(200)
       cy.get('.autorefresh-dropdown--pause').click()
       makeGraphSnapshot().shouldBeSameAs(snapshot, false)
-    })
-
-    // skip until the auto-refresh feature is added back
-    it.skip('auto refresh', () => {
-      const snapshot = makeGraphSnapshot()
-      cy.getByTestID('autorefresh-dropdown--button').click()
-      cy.getByTestID('auto-refresh-5s').click()
-
-      cy.wait(3_000)
-      makeGraphSnapshot().shouldBeSameAs(snapshot)
-
-      cy.wait(3_000)
-      const snapshot2 = makeGraphSnapshot()
-      snapshot2.shouldBeSameAs(snapshot, false)
-
-      cy.getByTestID('autorefresh-dropdown-refresh').should('not.be.visible')
-      cy.getByTestID('autorefresh-dropdown--button')
-        .should('contain.text', '5s')
-        .click()
-      cy.getByTestID('auto-refresh-paused').click()
-      cy.getByTestID('autorefresh-dropdown-refresh').should('be.visible')
-
-      // wait if graph changes after another 6s when autorefresh is paused
-      cy.wait(6_000)
-      makeGraphSnapshot().shouldBeSameAs(snapshot2)
     })
   })
 

--- a/cypress/e2e/shared/tokens.test.ts
+++ b/cypress/e2e/shared/tokens.test.ts
@@ -438,9 +438,7 @@ describe('tokens', () => {
       })
   })
 
-  // skip until this issue is resolved
-  // https://github.com/influxdata/influxdb/issues/18887
-  it.skip('can Select all buckets in Generate Read/Write token', () => {
+  it('can Select all buckets in Generate Read/Write token', () => {
     // create some extra buckets
     cy.get<Organization>('@org').then(({id, name}: Organization) => {
       cy.createBucket(id, name, 'Magna Carta').then(() => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -677,6 +677,66 @@ export const clickAttached = (subject?: JQuery<HTMLElement>) => {
   })
 }
 
+type GraphSnapshot = {
+  shouldBeSameAs: (
+    other: GraphSnapshot,
+    same?: boolean,
+    part?: 'axes' | 'layer' | 'both'
+  ) => void
+  name: string
+}
+
+export const makeGraphSnapshot = (() => {
+  // local properties for makeGraphSnapshot function
+  let lastGraphSnapsotIndex = 0
+  const getNameAxes = (name: string) => `${name}-axes`
+  const getNameLayer = (name: string) => `${name}-layer`
+
+  return (): GraphSnapshot => {
+    // generate unique name for snapshot for saving as cy var
+    const name = `graph-snapshot-${lastGraphSnapsotIndex++}`
+
+    // wait for drawing done
+    cy.wait(500)
+    cy.get('[data-testid|=giraffe-layer]')
+      .then($layer => ($layer[0] as HTMLCanvasElement).toDataURL('image/jpeg'))
+      .as(getNameLayer(name))
+
+    cy.getByTestID('giraffe-axes')
+      .then($axes => ($axes[0] as HTMLCanvasElement).toDataURL('image/jpeg'))
+      .as(getNameAxes(name))
+
+    return {
+      name,
+      shouldBeSameAs: ({name: nameOther}, same = true, part = 'both') => {
+        const assert = (str: any, str2: any, same: boolean) => {
+          if (same) {
+            expect(str).to.eq(str2)
+          } else {
+            expect(str).to.not.eq(str2)
+          }
+        }
+
+        if (part === 'both' || part === 'axes') {
+          cy.get(`@${getNameAxes(name)}`).then(axes => {
+            cy.get(`@${getNameAxes(nameOther)}`).then(axesOther => {
+              assert(axes, axesOther, same)
+            })
+          })
+        }
+
+        if (part === 'both' || part === 'layer') {
+          cy.get(`@${getNameLayer(name)}`).then(layer => {
+            cy.get(`@${getNameLayer(nameOther)}`).then(layerOther => {
+              assert(layer, layerOther, same)
+            })
+          })
+        }
+      },
+    }
+  }
+})()
+
 /* eslint-disable */
 // notification endpoints
 Cypress.Commands.add('createEndpoint', createEndpoint)


### PR DESCRIPTION
Went through the skipped cypress tests and found some that could be re-enabled. I ran each test that I enabled 20 times with k8s-idpe and saw no failures.

I also removed a couple tests that no longer seem applicable to the product.