### PR TITLE
fix: hide the static legend explicitly when feature flag is off

### DIFF
--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -1063,18 +1063,6 @@ describe('DataExplorer', () => {
     })
 
     describe('static legend', () => {
-      it('turns off static legend flag, so static legend option should not exist', () => {
-        cy.window().then(win => {
-          win.influx.set('staticLegend', false)
-          VIS_TYPES.forEach(type => {
-            cy.getByTestID('cog-cell--button').click()
-            cy.getByTestID('view-type--dropdown').click()
-            cy.getByTestID(`view-type--${type}`).click()
-            cy.getByTestID('static-legend-options').should('not.exist')
-          })
-        })
-      })
-
       it('turns on static legend flag, so static legend option should exist for line graph, line graph plus single stat, and band plot', () => {
         cy.window().then(win => {
           win.influx.set('staticLegend', true)
@@ -1095,8 +1083,19 @@ describe('DataExplorer', () => {
         })
       })
 
-      it('should allow user to render and remove the static legend', () => {
-        // write some data
+      it('turns off static legend flag so that static legend option should not exist', () => {
+        cy.window().then(win => {
+          win.influx.set('staticLegend', false)
+          VIS_TYPES.forEach(type => {
+            cy.getByTestID('cog-cell--button').click()
+            cy.getByTestID('view-type--dropdown').click()
+            cy.getByTestID(`view-type--${type}`).click()
+            cy.getByTestID('static-legend-options').should('not.exist')
+          })
+        })
+      })
+
+      it('turns on static legend flag to allow user to render and remove the static legend', () => {
         cy.writeData(lines(100))
 
         // set the flag, build the query, adjust the view options
@@ -1140,6 +1139,55 @@ describe('DataExplorer', () => {
               cy.get('[for="radio_static_legend_hide"]').click()
               cy.getByTestID('giraffe-static-legend').should('not.exist')
               cy.getByTestID('static-legend-height-slider').should('not.exist')
+            }
+          )
+        })
+      })
+
+      it('turns off static legend flag so that static legend box should not exist', () => {
+        cy.writeData(lines(100))
+
+        // set the flag, build the query, and select the graph type
+        cy.window().then(win => {
+          win.influx.set('staticLegend', false)
+          cy.get<string>('@defaultBucketListSelector').then(
+            (defaultBucketListSelector: string) => {
+              cy.getByTestID('query-builder').should('exist')
+              cy.getByTestID('selector-list _monitoring').should('be.visible')
+              cy.getByTestID('selector-list _monitoring').click()
+
+              cy.getByTestID(defaultBucketListSelector).should('be.visible')
+              cy.getByTestID(defaultBucketListSelector).click()
+
+              cy.getByTestID('selector-list m').should('be.visible')
+              cy.getByTestID('selector-list m').clickAttached()
+
+              cy.getByTestID('selector-list v').should('be.visible')
+              cy.getByTestID('selector-list v').clickAttached()
+
+              cy.getByTestID('selector-list tv1').clickAttached()
+
+              cy.getByTestID('selector-list last')
+                .scrollIntoView()
+                .should('be.visible')
+                .click({force: true})
+
+              cy.getByTestID('time-machine-submit-button').click()
+
+              // Select line graph
+              cy.getByTestID('view-type--dropdown').click()
+              cy.getByTestID(`view-type--xy`).click()
+              cy.getByTestID('giraffe-static-legend').should('not.exist')
+
+              // Select line plus single stat graph
+              cy.getByTestID('view-type--dropdown').click()
+              cy.getByTestID(`view-type--line-plus-single-stat`).click()
+              cy.getByTestID('giraffe-static-legend').should('not.exist')
+
+              // Select band plot
+              cy.getByTestID('view-type--dropdown').click()
+              cy.getByTestID(`view-type--band`).click()
+              cy.getByTestID('giraffe-static-legend').should('not.exist')
             }
           )
         })

--- a/src/visualization/components/internal/StaticLegend.tsx
+++ b/src/visualization/components/internal/StaticLegend.tsx
@@ -34,9 +34,11 @@ import {
 
 // Constants
 import {
+  STATIC_LEGEND_HEIGHT_RATIO_DEFAULT,
   STATIC_LEGEND_HEIGHT_RATIO_MAXIMUM,
   STATIC_LEGEND_HEIGHT_RATIO_MINIMUM,
   STATIC_LEGEND_HEIGHT_RATIO_STEP,
+  STATIC_LEGEND_HIDE_DEFAULT,
 } from 'src/visualization/constants'
 
 interface Props extends VisualizationOptionProps {
@@ -49,9 +51,19 @@ interface Props extends VisualizationOptionProps {
 const StaticLegend: FC<Props> = ({properties, update}) => {
   const {staticLegend} = properties
   const {valueAxis} = staticLegend
-  const {heightRatio, hide} = staticLegend ? staticLegend : ({} as StaticLegend)
+  const {heightRatio = STATIC_LEGEND_HEIGHT_RATIO_DEFAULT, hide} = staticLegend
+    ? staticLegend
+    : ({
+        hide: STATIC_LEGEND_HIDE_DEFAULT,
+      } as StaticLegend)
   const [showOptions, setShowOptions] = useState<boolean>(!hide)
   if (!isFlagEnabled('staticLegend')) {
+    update({
+      staticLegend: {
+        ...staticLegend,
+        hide: true,
+      },
+    })
     return null
   }
 

--- a/src/visualization/components/internal/StaticLegend.tsx
+++ b/src/visualization/components/internal/StaticLegend.tsx
@@ -49,21 +49,16 @@ interface Props extends VisualizationOptionProps {
 }
 
 const StaticLegend: FC<Props> = ({properties, update}) => {
-  const {staticLegend} = properties
+  const {
+    staticLegend = {
+      hide: STATIC_LEGEND_HIDE_DEFAULT,
+    } as StaticLegend,
+  } = properties
   const {valueAxis} = staticLegend
   const {heightRatio = STATIC_LEGEND_HEIGHT_RATIO_DEFAULT, hide} = staticLegend
-    ? staticLegend
-    : ({
-        hide: STATIC_LEGEND_HIDE_DEFAULT,
-      } as StaticLegend)
   const [showOptions, setShowOptions] = useState<boolean>(!hide)
+
   if (!isFlagEnabled('staticLegend')) {
-    update({
-      staticLegend: {
-        ...staticLegend,
-        hide: true,
-      },
-    })
     return null
   }
 

--- a/src/visualization/types/Band/view.tsx
+++ b/src/visualization/types/Band/view.tsx
@@ -21,6 +21,7 @@ import {
   defaultXColumn,
   defaultYColumn,
 } from 'src/shared/utils/vis'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Constants
 import {VIS_THEME, VIS_THEME_LIGHT} from 'src/shared/constants'
@@ -66,6 +67,9 @@ const BandPlot: FC<Props> = ({properties, result, timeRange}) => {
   }, [activeQueryIndex, properties.queries, properties.upperColumn, properties.mainColumn, properties.lowerColumn])
    */
   const {staticLegend} = properties
+  if (!isFlagEnabled('staticLegend')) {
+    staticLegend.hide = true
+  }
   const {theme, timeZone} = useContext(AppSettingContext)
 
   const axisTicksOptions = useAxisTicksGenerator(properties)

--- a/src/visualization/types/Band/view.tsx
+++ b/src/visualization/types/Band/view.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC, useMemo, useContext} from 'react'
-import {Plot, StaticLegend as StaticLegendConfig} from '@influxdata/giraffe'
+import {Plot} from '@influxdata/giraffe'
 
 // Components
 import EmptyGraphMessage from 'src/shared/components/EmptyGraphMessage'
@@ -9,6 +9,7 @@ import EmptyGraphMessage from 'src/shared/components/EmptyGraphMessage'
 import {useAxisTicksGenerator} from 'src/visualization/utils/useAxisTicksGenerator'
 import {getFormatter} from 'src/visualization/utils/getFormatter'
 import {useLegendOpacity} from 'src/visualization/utils/useLegendOrientation'
+import {useStaticLegend} from 'src/visualization/utils/useStaticLegend'
 import {
   useVisXDomainSettings,
   useVisYDomainSettings,
@@ -21,7 +22,6 @@ import {
   defaultXColumn,
   defaultYColumn,
 } from 'src/shared/utils/vis'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Constants
 import {VIS_THEME, VIS_THEME_LIGHT} from 'src/shared/constants'
@@ -31,7 +31,6 @@ import {
   BAND_LINE_WIDTH,
   BAND_SHADE_OPACITY,
   INVALID_DATA_COPY,
-  STATIC_LEGEND_STYLING,
 } from 'src/visualization/constants'
 import {AppSettingContext} from 'src/shared/contexts/app'
 
@@ -66,10 +65,7 @@ const BandPlot: FC<Props> = ({properties, result, timeRange}) => {
     )
   }, [activeQueryIndex, properties.queries, properties.upperColumn, properties.mainColumn, properties.lowerColumn])
    */
-  const {staticLegend} = properties
-  if (!isFlagEnabled('staticLegend')) {
-    staticLegend.hide = true
-  }
+  const staticLegend = useStaticLegend(properties)
   const {theme, timeZone} = useContext(AppSettingContext)
 
   const axisTicksOptions = useAxisTicksGenerator(properties)
@@ -168,10 +164,7 @@ const BandPlot: FC<Props> = ({properties, result, timeRange}) => {
         legendOpacity: tooltipOpacity,
         legendOrientationThreshold: tooltipOrientationThreshold,
         legendColorizeRows: tooltipColorize,
-        staticLegend: {
-          ...staticLegend,
-          ...STATIC_LEGEND_STYLING,
-        } as StaticLegendConfig,
+        staticLegend,
         valueFormatters: {
           [xColumn]: xFormatter,
           [yColumn]: yFormatter,

--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -76,6 +76,9 @@ const XYPlot: FC<Props> = ({
   const tooltipColorize = properties.legendColorizeRows
   const tooltipOrientationThreshold = properties.legendOrientationThreshold
   const {staticLegend} = properties
+  if (!isFlagEnabled('staticLegend')) {
+    staticLegend.hide = true
+  }
   const dispatch = useDispatch()
 
   // these two values are set in the dashboard, and used whether or not this view

--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -6,7 +6,6 @@ import {
   Config,
   DomainLabel,
   Plot,
-  StaticLegend as StaticLegendConfig,
   getDomainDataFromLines,
   lineTransform,
 } from '@influxdata/giraffe'
@@ -26,10 +25,7 @@ import {
 // Constants
 import {VIS_THEME, VIS_THEME_LIGHT} from 'src/shared/constants'
 import {DEFAULT_LINE_COLORS} from 'src/shared/constants/graphColorPalettes'
-import {
-  INVALID_DATA_COPY,
-  STATIC_LEGEND_STYLING,
-} from 'src/visualization/constants'
+import {INVALID_DATA_COPY} from 'src/visualization/constants'
 
 // Types
 import {XYViewProperties} from 'src/types'
@@ -39,6 +35,7 @@ import {VisualizationProps} from 'src/visualization'
 import {useAxisTicksGenerator} from 'src/visualization/utils/useAxisTicksGenerator'
 import {getFormatter} from 'src/visualization/utils/getFormatter'
 import {useLegendOpacity} from 'src/visualization/utils/useLegendOrientation'
+import {useStaticLegend} from 'src/visualization/utils/useStaticLegend'
 import {
   useVisXDomainSettings,
   useVisYDomainSettings,
@@ -75,10 +72,7 @@ const XYPlot: FC<Props> = ({
   const tooltipOpacity = useLegendOpacity(properties.legendOpacity)
   const tooltipColorize = properties.legendColorizeRows
   const tooltipOrientationThreshold = properties.legendOrientationThreshold
-  const {staticLegend} = properties
-  if (!isFlagEnabled('staticLegend')) {
-    staticLegend.hide = true
-  }
+  const staticLegend = useStaticLegend(properties)
   const dispatch = useDispatch()
 
   // these two values are set in the dashboard, and used whether or not this view
@@ -193,10 +187,7 @@ const XYPlot: FC<Props> = ({
     legendOpacity: tooltipOpacity,
     legendOrientationThreshold: tooltipOrientationThreshold,
     legendColorizeRows: tooltipColorize,
-    staticLegend: {
-      ...staticLegend,
-      ...STATIC_LEGEND_STYLING,
-    } as StaticLegendConfig,
+    staticLegend,
     valueFormatters: {
       [xColumn]: xFormatter,
       [yColumn]: yFormatter,

--- a/src/visualization/types/SingleStatWithLine/view.tsx
+++ b/src/visualization/types/SingleStatWithLine/view.tsx
@@ -9,7 +9,6 @@ import {
   getLatestValues,
   Plot,
   SingleStatLayerConfig,
-  StaticLegend as StaticLegendConfig,
 } from '@influxdata/giraffe'
 
 // Redux
@@ -26,6 +25,7 @@ import LatestValueTransform from 'src/visualization/components/LatestValueTransf
 import {useAxisTicksGenerator} from 'src/visualization/utils/useAxisTicksGenerator'
 import {getFormatter} from 'src/visualization/utils/getFormatter'
 import {useLegendOpacity} from 'src/visualization/utils/useLegendOrientation'
+import {useStaticLegend} from 'src/visualization/utils/useStaticLegend'
 import {
   useVisXDomainSettings,
   useVisYDomainSettings,
@@ -48,10 +48,7 @@ import {
   VIS_THEME_LIGHT,
 } from 'src/shared/constants'
 import {DEFAULT_LINE_COLORS} from 'src/shared/constants/graphColorPalettes'
-import {
-  INVALID_DATA_COPY,
-  STATIC_LEGEND_STYLING,
-} from 'src/visualization/constants'
+import {INVALID_DATA_COPY} from 'src/visualization/constants'
 
 // Types
 import {LinePlusSingleStatProperties} from 'src/types'
@@ -82,10 +79,7 @@ const SingleStatWithLine: FC<Props> = ({
   const tooltipOpacity = useLegendOpacity(properties.legendOpacity)
   const tooltipColorize = properties.legendColorizeRows
   const tooltipOrientationThreshold = properties.legendOrientationThreshold
-  const {staticLegend} = properties
-  if (!isFlagEnabled('staticLegend')) {
-    staticLegend.hide = true
-  }
+  const staticLegend = useStaticLegend(properties)
 
   // these two values are set in the dashboard, and used whether or not this view
   // is in a dashboard or in configuration/single cell popout mode
@@ -210,10 +204,7 @@ const SingleStatWithLine: FC<Props> = ({
     legendOpacity: tooltipOpacity,
     legendOrientationThreshold: tooltipOrientationThreshold,
     legendColorizeRows: tooltipColorize,
-    staticLegend: {
-      ...staticLegend,
-      ...STATIC_LEGEND_STYLING,
-    } as StaticLegendConfig,
+    staticLegend,
     valueFormatters: {
       [xColumn]: xFormatter,
       [yColumn]: yFormatter,

--- a/src/visualization/types/SingleStatWithLine/view.tsx
+++ b/src/visualization/types/SingleStatWithLine/view.tsx
@@ -83,6 +83,9 @@ const SingleStatWithLine: FC<Props> = ({
   const tooltipColorize = properties.legendColorizeRows
   const tooltipOrientationThreshold = properties.legendOrientationThreshold
   const {staticLegend} = properties
+  if (!isFlagEnabled('staticLegend')) {
+    staticLegend.hide = true
+  }
 
   // these two values are set in the dashboard, and used whether or not this view
   // is in a dashboard or in configuration/single cell popout mode

--- a/src/visualization/utils/useStaticLegend.ts
+++ b/src/visualization/utils/useStaticLegend.ts
@@ -1,0 +1,26 @@
+import {useMemo} from 'react'
+
+// Types
+import {StaticLegend as StaticLegendConfig} from '@influxdata/giraffe'
+
+// Utils
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+
+// Constants
+import {
+  STATIC_LEGEND_HIDE_DEFAULT,
+  STATIC_LEGEND_STYLING,
+} from 'src/visualization/constants'
+
+export const useStaticLegend = (properties): StaticLegendConfig =>
+  useMemo(() => {
+    const {
+      staticLegend = {
+        hide: STATIC_LEGEND_HIDE_DEFAULT,
+      },
+    } = properties
+    if (!isFlagEnabled('staticLegend')) {
+      return {...staticLegend, ...STATIC_LEGEND_STYLING, hide: true}
+    }
+    return {...staticLegend, ...STATIC_LEGEND_STYLING}
+  }, [properties])


### PR DESCRIPTION
Closes #1498 

- Since we can't tell from the backend api whether `hide` is deliberately `false` or not yet defined by the user, we need to be more explicit when the feature flag is off
- Set the `heightRatio` to be the default value when not defined
