### PR TITLE
build(lsp): Upgrade flux-lsp-browser to v0.5.47

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
   "dependencies": {
     "@influxdata/clockface": "^2.6.6",
     "@influxdata/flux": "^0.5.1",
-    "@influxdata/flux-lsp-browser": "^0.5.41",
+    "@influxdata/flux-lsp-browser": "^0.5.47",
     "@influxdata/giraffe": "^2.7.0",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -715,10 +715,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-2.6.6.tgz#5eeb42110da8e967eb8199a337e9923935d49fe1"
   integrity sha512-bbEwkwWHFQvxrWa3yOWn65Th+/JdNVJp5Nzx55v93tIWa93O1H/q3sFp96lZbMA1WH8eO5mz1qvNDVAkqF4crw==
 
-"@influxdata/flux-lsp-browser@^0.5.41":
-  version "0.5.41"
-  resolved "https://registry.yarnpkg.com/@influxdata/flux-lsp-browser/-/flux-lsp-browser-0.5.41.tgz#abf6c5ad253317f34a9217ecfd250d78fe625a83"
-  integrity sha512-5xjHb0Skk2vhPMWMUpi1XKRtUfHzeG/yxz3IkxMZ8x+RACo2GbO+vdvGbAz9L+5mmt7iNy+lY1/vwuuuOasJYg==
+"@influxdata/flux-lsp-browser@^0.5.47":
+  version "0.5.47"
+  resolved "https://registry.yarnpkg.com/@influxdata/flux-lsp-browser/-/flux-lsp-browser-0.5.47.tgz#25b2abc6397e01ad47cc8b1f93cb83d14ba4e76d"
+  integrity sha512-Ejml0Ez4SAf0TE9UVRZS+noY9e73MfG2d+fLu0BNR876ih90205xAdkf3uUvfB3nXOs33Tq2HhfkZHGXkSRP6g==
 
 "@influxdata/flux@^0.5.1":
   version "0.5.1"


### PR DESCRIPTION
Backports #1506 into the `OSS-2.0` branch