### PR TITLE
fix: renamable page title throwing react error

### DIFF
--- a/src/pageLayout/components/RenamablePageTitle.tsx
+++ b/src/pageLayout/components/RenamablePageTitle.tsx
@@ -33,6 +33,10 @@ const RenamablePageTitle: FC<Props> = ({
 
   useEffect(() => {
     setWorkingName(name)
+
+    return function cleanUp() {
+      setEditingState(false)
+    }
   }, [name])
 
   const handleStartEditing = (): void => {
@@ -41,10 +45,13 @@ const RenamablePageTitle: FC<Props> = ({
 
   const handleStopEditing = (e: MouseEvent<any>): void => {
     onRename(workingName)
-
     if (onClickOutside) {
       onClickOutside(e)
     }
+  }
+
+  const handleOnBlur = (): void => {
+    setEditingState(false)
   }
 
   const handleInputChange = (e: ChangeEvent<InputRef>): void => {
@@ -72,6 +79,7 @@ const RenamablePageTitle: FC<Props> = ({
   const renamablePageTitleClass = classnames('renamable-page-title', {
     untitled: nameIsUntitled,
   })
+
   if (isEditing) {
     return (
       <ClickOutside onClickOutside={handleStopEditing}>
@@ -84,6 +92,7 @@ const RenamablePageTitle: FC<Props> = ({
             autoFocus={true}
             spellCheck={false}
             placeholder={placeholder}
+            onBlur={handleOnBlur}
             onFocus={handleInputFocus}
             onChange={handleInputChange}
             onKeyDown={handleKeyDown}

--- a/src/pageLayout/components/RenamablePageTitle.tsx
+++ b/src/pageLayout/components/RenamablePageTitle.tsx
@@ -34,7 +34,7 @@ const RenamablePageTitle: FC<Props> = ({
   useEffect(() => {
     setWorkingName(name)
   }, [name])
-
+  
   const handleStartEditing = (): void => {
     setEditingState(true)
   }
@@ -45,10 +45,8 @@ const RenamablePageTitle: FC<Props> = ({
     if (onClickOutside) {
       onClickOutside(e)
     }
-
-    setEditingState(false)
   }
-
+  
   const handleInputChange = (e: ChangeEvent<InputRef>): void => {
     setWorkingName(e.target.value)
   }
@@ -74,7 +72,6 @@ const RenamablePageTitle: FC<Props> = ({
   const renamablePageTitleClass = classnames('renamable-page-title', {
     untitled: nameIsUntitled,
   })
-
   if (isEditing) {
     return (
       <ClickOutside onClickOutside={handleStopEditing}>

--- a/src/pageLayout/components/RenamablePageTitle.tsx
+++ b/src/pageLayout/components/RenamablePageTitle.tsx
@@ -34,7 +34,7 @@ const RenamablePageTitle: FC<Props> = ({
   useEffect(() => {
     setWorkingName(name)
   }, [name])
-  
+
   const handleStartEditing = (): void => {
     setEditingState(true)
   }
@@ -46,7 +46,7 @@ const RenamablePageTitle: FC<Props> = ({
       onClickOutside(e)
     }
   }
-  
+
   const handleInputChange = (e: ChangeEvent<InputRef>): void => {
     setWorkingName(e.target.value)
   }


### PR DESCRIPTION
Closes #1487 

On saving the updated title, the function was making a component state change after unmounting RenamablePageTitle which was throwing a react error to use cleanUp in useEffect hook. Instead we removed the state change as it is not needed after the component has been unmounted.


