### PR TITLE
chore: update the openapi definition to reflect some changes to quartz api

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "cy": "CYPRESS_dexUrl=https://$INGRESS_HOST:$PORT_HTTPS CYPRESS_baseUrl=http://localhost:9999 cypress open",
     "cy:dev": "source ../monitor-ci/.env && CYPRESS_dexUrl=https://$INGRESS_HOST:$PORT_HTTPS CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{cloud,shared}/**/*.*'",
     "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_dexUrl=OSS CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{oss,shared}/**/*.*'",
-    "generate": "export SHA=191ac500c62ddef83b491847840c2f570a2f7630 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
+    "generate": "export SHA=db287c47016e1c3bc4db5346d2b77d33d3147142 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-meta": "yarn currentApi && yarn notebooks && yarn unity && yarn flows && yarn managedFunctions && yarn annotations",
     "oss": "oats ${REMOTE}contracts/oss-diff.yml > ./src/client/ossRoutes.ts",

--- a/src/operator/account/AccountGrid.tsx
+++ b/src/operator/account/AccountGrid.tsx
@@ -65,7 +65,9 @@ const AccountGrid: FC = () => {
         />
         <AccountField
           header="Salesforce ID"
-          body={account?.users?.[0]?.sfdcContactId ?? 'N/A'}
+          body="N/A" // TODO(ariel): update this to account for OperatorAccount type
+          // https://github.com/influxdata/ui/issues/1513
+          // body={account?.users?.[0]?.sfdcContactId ?? 'N/A'}
           testID="salesforce-id"
         />
       </FlexBox>

--- a/src/operator/api/index.ts
+++ b/src/operator/api/index.ts
@@ -40,16 +40,13 @@ export const getAccounts = (
       users: [
         {
           id: 'user1',
-          quartzId: 1,
-          onboardingState: 'complete',
-          sfdcContactId: 'sdfc_u_know_me',
+          // quartzId: 1,
+          // onboardingState: 'complete',
+          // sfdcContactId: 'sdfc_u_know_me',
           firstName: 'jr',
           lastName: 'OG',
           email: 'og@influxdata.com',
           role: 'member',
-          links: {
-            self: 'www.self.com',
-          },
         },
       ],
       type: 'pay_as_you_go',
@@ -229,14 +226,11 @@ export const getAccountById = (
     users: [
       {
         id: '1',
-        sfdcContactId: '12',
+        // sfdcContactId: '12',
         firstName: 'Ariel',
         lastName: 'Salem',
         email: 'asalem@influxdata.com',
         role: 'member',
-        links: {
-          self: 'www.self.com',
-        },
       },
     ],
     type: 'cancelled',

--- a/src/users/components/InviteListContextMenu.tsx
+++ b/src/users/components/InviteListContextMenu.tsx
@@ -42,7 +42,7 @@ function InviteListContextMenu({invite}: Props) {
 
   let componentStatus = ComponentStatus.Default
 
-  if (invite.id === removeInviteStatus.id) {
+  if (invite && invite?.id === removeInviteStatus?.id) {
     componentStatus =
       removeInviteStatus.status === RemoteDataState.Loading
         ? ComponentStatus.Loading

--- a/src/users/context/users.tsx
+++ b/src/users/context/users.tsx
@@ -41,10 +41,10 @@ export interface UsersContextType {
   handleEditDraftInvite: (_: DraftInvite) => void
   handleInviteUser: () => void
   handleRemoveUser: (userId: string) => void
-  handleResendInvite: (inviteId: string) => void
-  handleWithdrawInvite: (inviteId: string) => void
+  handleResendInvite: (inviteId: number) => void
+  handleWithdrawInvite: (inviteId: number) => void
   invites: Invite[]
-  removeInviteStatus: {id: string; status: RemoteDataState}
+  removeInviteStatus: {id: number; status: RemoteDataState}
   removeUserStatus: {id: string; status: RemoteDataState}
   status: RemoteDataState
   users: CloudUser[]
@@ -60,8 +60,8 @@ export const DEFAULT_CONTEXT: UsersContextType = {
   handleEditDraftInvite: (_draftInvite: DraftInvite) => {},
   handleInviteUser: () => {},
   handleRemoveUser: (_userId: string) => {},
-  handleResendInvite: (_inviteId: string) => {},
-  handleWithdrawInvite: (_inviteId: string) => {},
+  handleResendInvite: (_inviteId: number) => {},
+  handleWithdrawInvite: (_inviteId: number) => {},
   invites: [],
   removeInviteStatus: {id: null, status: RemoteDataState.NotStarted},
   removeUserStatus: {id: null, status: RemoteDataState.NotStarted},
@@ -146,9 +146,12 @@ export const UsersProvider: FC<Props> = React.memo(({children}) => {
   )
 
   const handleResendInvite = useCallback(
-    async (inviteId: string) => {
+    async (inviteId: number) => {
       try {
-        const resp = await postOrgsInvitesResend({orgId, inviteId})
+        const resp = await postOrgsInvitesResend({
+          orgId,
+          inviteId,
+        })
 
         if (resp.status !== 200) {
           throw new Error(resp.data.message)
@@ -169,7 +172,7 @@ export const UsersProvider: FC<Props> = React.memo(({children}) => {
   )
 
   const handleWithdrawInvite = useCallback(
-    async (inviteId: string) => {
+    async (inviteId: number) => {
       try {
         setRemoveInviteStatus({id: inviteId, status: RemoteDataState.Loading})
         const resp = await deleteOrgsInvite({orgId, inviteId})


### PR DESCRIPTION
This closes the issue we were seeing where CSRF protections were put in place on the Quartz API that were returning a `415` status code on empty post requests