### PR TITLE
feat: replaced usage of getting limits with IDPE one for billing free, also conditionally rendering functionality for CTA free billing button and fixed usage page query bug

### DIFF
--- a/src/billing/api/index.ts
+++ b/src/billing/api/index.ts
@@ -1,6 +1,5 @@
 import {
   getBilling,
-  getOrgsLimits as apiGetOrgLimits,
   getMarketplace as genGetMarketplace,
   getPaymentForm,
   getBillingInvoices,
@@ -14,7 +13,6 @@ import {
   CreditCardParams,
   BillingInfo,
   BillingNotifySettings,
-  OrgLimits,
   Marketplace,
 } from 'src/types/billing'
 
@@ -85,40 +83,6 @@ export const getMarketplace = (): ReturnType<typeof genGetMarketplace> => {
   }
 
   return makeResponse(200, marketplace, 'getMarketplace')
-}
-
-export const getOrgsLimits = (): ReturnType<typeof apiGetOrgLimits> => {
-  const limits: OrgLimits = {
-    orgID: 'org123',
-    rate: {
-      readKBs: 100,
-      writeKBs: 100,
-      cardinality: 1,
-    },
-    bucket: {
-      maxRetentionDuration: 3,
-      maxBuckets: 2,
-    },
-    task: {
-      maxTasks: 10,
-    },
-    dashboard: {
-      maxDashboards: 7,
-    },
-    check: {
-      maxChecks: 4,
-    },
-    notificationEndpoint: {
-      blockedNotificationEndpoints: 'slack',
-    },
-    notificationRule: {
-      maxNotifications: 9,
-      blockedNotificationRules: 'cancelled',
-    },
-    status: RemoteDataState.Done,
-  }
-
-  return makeResponse(200, limits, 'getOrgsLimits')
 }
 
 export const updateBillingNotificationSettings = (

--- a/src/billing/components/Free/Free.tsx
+++ b/src/billing/components/Free/Free.tsx
@@ -1,40 +1,23 @@
 // Libraries
-import React, {FC, useEffect} from 'react'
+import React, {FC} from 'react'
 import {Grid, Columns} from '@influxdata/clockface'
 import FreePanel from 'src/billing/components/Free/FreePanel'
 import PAYGConversion from 'src/billing/components/Free/PAYGConversion'
-import {SpinnerContainer, TechnoSpinner} from '@influxdata/clockface'
 
-// Utils
-import {getOrgLimits} from 'src/billing/thunks'
-import {useBilling} from 'src/billing/components/BillingPage'
+// Components
+import GetAssetLimits from 'src/cloud/components/GetAssetLimits'
 
-// Types
-import {RemoteDataState} from 'src/types'
-
-const BillingFree: FC = () => {
-  const [{orgLimits}, dispatch] = useBilling()
-
-  useEffect(() => {
-    getOrgLimits(dispatch)
-  }, [dispatch])
-
-  const loading = orgLimits?.status ?? RemoteDataState.NotStarted
-  return (
-    <Grid>
-      <Grid.Row>
-        <Grid.Column widthXS={Columns.Twelve}>
-          <SpinnerContainer
-            spinnerComponent={<TechnoSpinner />}
-            loading={loading}
-          >
-            <FreePanel />
-          </SpinnerContainer>
-        </Grid.Column>
-      </Grid.Row>
-      <PAYGConversion />
-    </Grid>
-  )
-}
+const BillingFree: FC = () => (
+  <Grid>
+    <Grid.Row>
+      <Grid.Column widthXS={Columns.Twelve}>
+        <GetAssetLimits>
+          <FreePanel />
+        </GetAssetLimits>
+      </Grid.Column>
+    </Grid.Row>
+    <PAYGConversion />
+  </Grid>
+)
 
 export default BillingFree

--- a/src/billing/components/Free/OrgLimitStat.tsx
+++ b/src/billing/components/Free/OrgLimitStat.tsx
@@ -2,7 +2,7 @@ import React, {FC} from 'react'
 import {startCase, floor} from 'lodash'
 
 import {ComponentSize, InfluxColors, Panel} from '@influxdata/clockface'
-import {nsToDays, minToSeconds} from 'src/billing/utils/timeHelpers'
+import {secondsToDays, minToSeconds} from 'src/billing/utils/timeHelpers'
 import {kbToMb} from 'src/billing/utils/unitHelpers'
 
 interface Props {
@@ -18,8 +18,12 @@ const getName = (name: string): string => {
       return 'Reads'
     case 'cardinality':
       return 'Series Cardinality'
-    default:
+    case 'rules':
+      return 'Max Notifications'
+    case 'maxRetentionSeconds':
       return `${startCase(name)}`
+    default:
+      return `Max ${startCase(name)}`
   }
 }
 
@@ -31,26 +35,24 @@ const getStat = (name: string, value: any) => {
       const mbPerSecond = kbToMb(value)
       const mb5Min = floor(mbPerSecond * sIn5Min)
       return `${mb5Min} MB / 5 min`
-    case 'bucket':
-      return `${nsToDays(value)} days`
+    case 'maxRetentionSeconds':
+      return `${secondsToDays(value)} days`
     default:
       return value
   }
 }
 
-const OrgLimitStat: FC<Props> = ({name, value}) => {
-  return (
-    <Panel backgroundColor={InfluxColors.Onyx} className="org-limit">
-      <Panel.Header size={ComponentSize.ExtraSmall}>
-        <h5 data-testid="title-header--name">{getName(name)}</h5>
-      </Panel.Header>
-      <Panel.Body size={ComponentSize.ExtraSmall}>
-        <div className="org-limit--stat" data-testid="title-header--value">
-          {getStat(name, value)}
-        </div>
-      </Panel.Body>
-    </Panel>
-  )
-}
+const OrgLimitStat: FC<Props> = ({name, value}) => (
+  <Panel backgroundColor={InfluxColors.Onyx} className="org-limit">
+    <Panel.Header size={ComponentSize.ExtraSmall}>
+      <h5 data-testid="title-header--name">{getName(name)}</h5>
+    </Panel.Header>
+    <Panel.Body size={ComponentSize.ExtraSmall}>
+      <div className="org-limit--stat" data-testid="title-header--value">
+        {getStat(name, value)}
+      </div>
+    </Panel.Body>
+  </Panel>
+)
 
 export default OrgLimitStat

--- a/src/billing/components/Free/PAYGConversion.tsx
+++ b/src/billing/components/Free/PAYGConversion.tsx
@@ -9,13 +9,26 @@ import {
   Heading,
   HeadingElement,
   FontWeight,
-  CTALinkButton,
+  Button,
 } from '@influxdata/clockface'
+import {useHistory} from 'react-router-dom'
+
+// Utils
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Constants
 import {CLOUD_URL, CLOUD_CHECKOUT_PATH} from 'src/shared/constants'
 
 const PAYGConversion: FC = () => {
+  const history = useHistory()
+
+  const handleClick = () => {
+    if (isFlagEnabled('unityCheckout')) {
+      history.push('/checkout')
+    } else {
+      window.location.href = `${CLOUD_URL}${CLOUD_CHECKOUT_PATH}`
+    }
+  }
   return (
     <>
       <Heading
@@ -57,11 +70,12 @@ const PAYGConversion: FC = () => {
                 size={ComponentSize.Medium}
                 testID="payg-button--upgrade"
               >
-                <CTALinkButton
+                <Button
                   color={ComponentColor.Primary}
+                  size={ComponentSize.Large}
                   text="Upgrade to a Usage-Based Plan"
-                  className="conversion-panel--cta"
-                  href={`${CLOUD_URL}${CLOUD_CHECKOUT_PATH}`}
+                  className="cf-cta-button conversion-panel--cta"
+                  onClick={handleClick}
                 />
               </Panel.Footer>
             </Panel>

--- a/src/billing/reducers/index.ts
+++ b/src/billing/reducers/index.ts
@@ -9,7 +9,6 @@ import {
   Invoice,
   PaymentMethod,
   CreditCardParams,
-  OrgLimits,
   Marketplace,
 } from 'src/types/billing'
 
@@ -21,7 +20,6 @@ export interface BillingState {
   invoices: Invoice[]
   invoicesStatus: RemoteDataState
   marketplace: Marketplace
-  orgLimits: OrgLimits
 }
 
 export const initialState = (): BillingState => ({
@@ -44,7 +42,6 @@ export const initialState = (): BillingState => ({
   invoices: null,
   invoicesStatus: RemoteDataState.NotStarted,
   marketplace: null,
-  orgLimits: null,
 })
 
 export type BillingReducer = React.Reducer<BillingState, Action>
@@ -58,18 +55,6 @@ export const setMarketplace = (marketplace: Marketplace) =>
 export const setMarketplaceStatus = (status: RemoteDataState) =>
   ({
     type: 'SET_MARKETPLACE_STATUS',
-    status,
-  } as const)
-
-export const setOrgLimits = (orgLimits: OrgLimits) =>
-  ({
-    type: 'SET_ORG_LIMITS',
-    orgLimits,
-  } as const)
-
-export const setOrgLimitsStatus = (status: RemoteDataState) =>
-  ({
-    type: 'SET_ORG_LIMITS_STATUS',
     status,
   } as const)
 
@@ -151,8 +136,6 @@ export type Action =
   | ReturnType<typeof setCreditCardStatus>
   | ReturnType<typeof setInvoices>
   | ReturnType<typeof setInvoicesStatus>
-  | ReturnType<typeof setOrgLimits>
-  | ReturnType<typeof setOrgLimitsStatus>
   | ReturnType<typeof setMarketplace>
   | ReturnType<typeof setMarketplaceStatus>
 
@@ -243,24 +226,6 @@ export const billingReducer = (
         }
 
         draftState.marketplace.loadingStatus = action.status
-        return
-      }
-      case 'SET_ORG_LIMITS': {
-        draftState.orgLimits = action.orgLimits
-
-        return
-      }
-      case 'SET_ORG_LIMITS_STATUS': {
-        if (!draftState.orgLimits?.status) {
-          draftState.orgLimits = {
-            ...draftState.orgLimits,
-            status: action.status,
-          }
-
-          return
-        }
-
-        draftState.orgLimits.status = action.status
         return
       }
     }

--- a/src/billing/thunks/index.ts
+++ b/src/billing/thunks/index.ts
@@ -11,8 +11,6 @@ import {
   setInvoicesStatus,
   setMarketplace,
   setMarketplaceStatus,
-  setOrgLimits,
-  setOrgLimitsStatus,
 } from 'src/billing/reducers'
 
 // API
@@ -21,7 +19,6 @@ import {
   getBillingInfo as apiGetBillingInfo,
   updateBillingNotificationSettings,
   getInvoices as apiGetInvoices,
-  getOrgsLimits as apiGetOrgLimits,
 } from 'src/billing/api'
 import {getSettingsNotifications} from 'src/client/unityRoutes'
 
@@ -48,23 +45,6 @@ export const getMarketplace = async (dispatch: Dispatch<Action>) => {
     console.error(error)
 
     dispatch(setMarketplaceStatus(RemoteDataState.Error))
-  }
-}
-
-export const getOrgLimits = async (dispatch: Dispatch<Action>) => {
-  try {
-    dispatch(setOrgLimitsStatus(RemoteDataState.Loading))
-    const resp = await apiGetOrgLimits()
-
-    if (resp.status !== 200) {
-      throw new Error(resp.data.message)
-    }
-
-    dispatch(setOrgLimits({...resp.data, status: RemoteDataState.Done}))
-  } catch (error) {
-    console.error(error)
-
-    dispatch(setOrgLimitsStatus(RemoteDataState.Error))
   }
 }
 

--- a/src/billing/utils/timeHelpers.ts
+++ b/src/billing/utils/timeHelpers.ts
@@ -5,12 +5,10 @@ const secondsPerMinute = 60
 const minutesPerHour = 60
 const hoursPerDay = 24
 
+const secondsPerHour = minutesPerHour * secondsPerMinute
+
 const nanoPerHour =
-  minutesPerHour *
-  secondsPerMinute *
-  milliPerSecond *
-  microPerMilli *
-  nanoPerMicro
+  secondsPerHour * milliPerSecond * microPerMilli * nanoPerMicro
 
 export const nsToHours = (ns: number): number => {
   if (ns === -1) {
@@ -18,6 +16,14 @@ export const nsToHours = (ns: number): number => {
   }
 
   return ns / nanoPerHour
+}
+
+export const secondsToHours = (seconds: number): number => {
+  if (seconds === -1) {
+    return seconds
+  }
+
+  return seconds / secondsPerHour
 }
 
 export const hoursToNs = (hours: number): number => {
@@ -38,6 +44,11 @@ export const hoursToDays = (hours: number) => {
 
 export const nsToDays = (ns: number): number => {
   const hours = nsToHours(ns)
+  return hoursToDays(hours)
+}
+
+export const secondsToDays = (seconds: number): number => {
+  const hours = secondsToHours(seconds)
   return hoursToDays(hours)
 }
 

--- a/src/cloud/reducers/limits.ts
+++ b/src/cloud/reducers/limits.ts
@@ -2,13 +2,8 @@ import {produce} from 'immer'
 
 // Types
 import {Actions, ActionTypes} from 'src/cloud/actions/limits'
-import {RemoteDataState} from 'src/types'
+import {Limit, RemoteDataState} from 'src/types'
 import {LimitStatus} from 'src/cloud/actions/limits'
-
-interface Limit {
-  maxAllowed: number
-  limitStatus: LimitStatus
-}
 
 interface LimitWithBlocked extends Limit {
   blocked: string[]

--- a/src/shared/components/CloudUpgradeButton.tsx
+++ b/src/shared/components/CloudUpgradeButton.tsx
@@ -24,10 +24,10 @@ import {
 
 // Utils
 import {getIsRegionBeta} from 'src/me/selectors'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Types
 import {AppState, OrgSetting} from 'src/types'
-import {isFlagEnabled} from '../utils/featureFlag'
 
 interface StateProps {
   inView: boolean

--- a/src/types/billing.ts
+++ b/src/types/billing.ts
@@ -4,7 +4,6 @@ import {
   BillingDate as GenBillingDate,
   BillingInfo as GenBillingInfo,
   CreditCardParams as GenCreditCardParams,
-  OrgLimits as GenOrgLimits,
   Marketplace as GenMarketplace,
 } from 'src/client/unityRoutes'
 
@@ -34,10 +33,6 @@ export interface BillingInfo extends GenBillingInfo {
 }
 
 export interface CreditCardParams extends GenCreditCardParams {
-  status: RemoteDataState
-}
-
-export interface OrgLimits extends GenOrgLimits {
   status: RemoteDataState
 }
 

--- a/src/types/cloud.ts
+++ b/src/types/cloud.ts
@@ -1,3 +1,4 @@
+import {LimitStatus} from 'src/cloud/actions/limits'
 export interface Limits {
   rate: {
     readKBs: number
@@ -26,6 +27,11 @@ export interface Limits {
   dashboard: {
     maxDashboards: number
   }
+}
+
+export interface Limit {
+  maxAllowed: number
+  limitStatus: LimitStatus
 }
 
 export interface LimitsStatus {

--- a/src/usage/context/usage.tsx
+++ b/src/usage/context/usage.tsx
@@ -139,8 +139,12 @@ export const UsageProvider: FC<Props> = React.memo(({children}) => {
   const handleGetUsageStats = useCallback(async () => {
     if (selectedUsage.length > 0) {
       try {
+        const vector = usageVectors.find(
+          vector => selectedUsage === vector.name
+        )
+
         const resp = await getUsage({
-          vector_name: selectedUsage,
+          vector_name: vector.fluxKey,
           query: {range: timeRange.duration},
         })
 
@@ -154,7 +158,7 @@ export const UsageProvider: FC<Props> = React.memo(({children}) => {
         setUsageStats('')
       }
     }
-  }, [selectedUsage, timeRange])
+  }, [selectedUsage, timeRange, usageVectors])
 
   useEffect(() => {
     handleGetUsageStats()


### PR DESCRIPTION
Related to #902 

This PR doesn't close #902 since that won't be complete until we implement the operator page, but this PR replaces the current mock API for limits to use the current IDPE limit getter. 

This PR also adds in conditionally handle click functionality for the CTAUpgrade button for free billing users and updates the get usage stats query to use the flux_key and not the name
