### PR TITLE
feat: allow any to any in notification rules

### DIFF
--- a/src/notifications/rules/components/RuleLevelsDropdown.tsx
+++ b/src/notifications/rules/components/RuleLevelsDropdown.tsx
@@ -35,7 +35,7 @@ const RuleLevelsDropdown: FC<Props> = ({
     {display: 'OK', hex: InfluxColors.Viridian, value: 'OK'},
     {display: 'ANY', hex: InfluxColors.Sidewalk, value: 'ANY'},
   ]
-  if (otherLevel) {
+  if (otherLevel && otherLevel !== 'ANY') {
     levels = levels.filter(l => l.value !== otherLevel)
   }
 


### PR DESCRIPTION
Closes #

This adds the ability for users to create notification rules that go from any status to any other status (which is a valid rule).

![image](https://user-images.githubusercontent.com/4805997/119910177-6ed60f80-bf0b-11eb-8205-73577c2764a9.png)

```
package main
// dfasdfsdfsdfsdf
import "influxdata/influxdb/monitor"
import "slack"
import "influxdata/influxdb/secrets"
import "experimental"

option task = {name: "dfasdfsdfsdfsdf", every: 10m, offset: 0s}

slack_endpoint = slack["endpoint"](url: "https://hooks.slack.com/services/X/X/X")
notification = {
	_notification_rule_id: "07980c9d253a8000",
	_notification_rule_name: "dfasdfsdfsdfsdf",
	_notification_endpoint_id: "07980c5a8ac8c000",
	_notification_endpoint_name: "Name this Endpoint",
}
statuses = monitor["from"](start: -11m)
any_to_any = statuses
	|> monitor["stateChanges"](fromLevel: "any", toLevel: "any")
all_statuses = any_to_any
	|> filter(fn: (r) =>
		(r["_time"] >= experimental["subDuration"](from: now(), d: 10m)))

all_statuses
	|> monitor["notify"](data: notification, endpoint: slack_endpoint(mapFn: (r) =>
		({channel: "", text: "Notification Rule: ${ r._notification_rule_name } triggered by check: ${ r._check_name }: ${ r._message }", color: if r["_level"] == "crit" then "danger" else if r["_level"] == "warn" then "warning" else "good"})))
```