### PR TITLE
feat(alerts): warned user of dangers of editing tasks

### DIFF
--- a/src/checks/components/CheckCard.tsx
+++ b/src/checks/components/CheckCard.tsx
@@ -33,7 +33,10 @@ import {
 
 // Notifications
 import {notify} from 'src/shared/actions/notifications'
-import {updateCheckFailed, editCheckCodeWarning} from 'src/shared/copy/notifications'
+import {
+  updateCheckFailed,
+  editCheckCodeWarning,
+} from 'src/shared/copy/notifications'
 
 // Types
 import {Check, Label} from 'src/types'
@@ -121,7 +124,7 @@ const CheckCard: FC<Props> = ({
   const onEditTask = () => {
     history.push(`/orgs/${orgID}/tasks/${check.taskID}/edit`)
     onNotify(editCheckCodeWarning())
-  };
+  }
 
   return (
     <ErrorBoundary>

--- a/src/checks/components/CheckCard.tsx
+++ b/src/checks/components/CheckCard.tsx
@@ -33,7 +33,7 @@ import {
 
 // Notifications
 import {notify} from 'src/shared/actions/notifications'
-import {updateCheckFailed} from 'src/shared/copy/notifications'
+import {updateCheckFailed, editCheckCodeWarning} from 'src/shared/copy/notifications'
 
 // Types
 import {Check, Label} from 'src/types'
@@ -118,6 +118,11 @@ const CheckCard: FC<Props> = ({
     onRemoveCheckLabel(id, label.id)
   }
 
+  const onEditTask = () => {
+    history.push(`/orgs/${orgID}/tasks/${check.taskID}/edit`)
+    onNotify(editCheckCodeWarning())
+  };
+
   return (
     <ErrorBoundary>
       <ResourceCard
@@ -132,6 +137,7 @@ const CheckCard: FC<Props> = ({
             onView={onView}
             onDelete={onDelete}
             onClone={onClone}
+            onEditTask={onEditTask}
           />
         }
       >

--- a/src/checks/components/CheckCardContext.tsx
+++ b/src/checks/components/CheckCardContext.tsx
@@ -9,20 +9,27 @@ interface Props {
   onView: () => void
   onDelete: () => void
   onClone: () => void
+  onEditTask: () => void
 }
 
 const CheckCardContext: FunctionComponent<Props> = ({
   onDelete,
   onClone,
   onView,
+  onEditTask,
 }) => {
   return (
     <Context>
-      <Context.Menu icon={IconFont.EyeOpen} testID="context-history-menu">
+      <Context.Menu icon={IconFont.CogThick} testID="context-history-menu">
         <Context.Item
           label="View History"
           action={onView}
           testID="context-history-task"
+        />
+        <Context.Item
+          label="Edit Task"
+          action={onEditTask}
+          testID="context-edit-task"
         />
       </Context.Menu>
       <Context.Menu icon={IconFont.Duplicate} color={ComponentColor.Secondary}>

--- a/src/notifications/rules/components/RuleCard.tsx
+++ b/src/notifications/rules/components/RuleCard.tsx
@@ -34,6 +34,10 @@ import {
   cloneRule,
 } from 'src/notifications/rules/actions/thunks'
 
+// Notifications
+import {notify} from 'src/shared/actions/notifications'
+import {editNotificationRuleCodeWarning} from 'src/shared/copy/notifications'
+
 // Types
 import {NotificationRuleDraft, Label, AlertHistoryType} from 'src/types'
 
@@ -53,6 +57,7 @@ const RuleCard: FC<Props> = ({
   onUpdateRuleProperties,
   deleteNotificationRule,
   onCloneRule,
+  onNotify,
   onAddRuleLabel,
   onRemoveRuleLabel,
   match: {
@@ -108,6 +113,11 @@ const RuleCard: FC<Props> = ({
     history.push(`/orgs/${orgID}/alert-history?${queryParams}`)
   }
 
+  const onEditTask = () => {
+    history.push(`/orgs/${orgID}/tasks/${rule.taskID}/edit`)
+    onNotify(editNotificationRuleCodeWarning())
+  }
+
   const handleAddRuleLabel = (label: Label) => {
     onAddRuleLabel(id, label)
   }
@@ -130,6 +140,7 @@ const RuleCard: FC<Props> = ({
             onView={onView}
             onClone={onClone}
             onDelete={onDelete}
+            onEditTask={onEditTask}
           />
         }
       >
@@ -194,6 +205,7 @@ const mdtp = {
   onAddRuleLabel: addRuleLabel,
   onRemoveRuleLabel: deleteRuleLabel,
   onCloneRule: cloneRule,
+  onNotify: notify,
 }
 
 const connector = connect(null, mdtp)

--- a/src/notifications/rules/components/RuleCardContext.tsx
+++ b/src/notifications/rules/components/RuleCardContext.tsx
@@ -9,20 +9,27 @@ interface Props {
   onDelete: () => void
   onClone: () => void
   onView: () => void
+  onEditTask: () => void
 }
 
 const RuleCardContext: FunctionComponent<Props> = ({
   onDelete,
   onClone,
   onView,
+  onEditTask
 }) => {
   return (
     <Context>
-      <Context.Menu icon={IconFont.EyeOpen} testID="context-history-menu">
+      <Context.Menu icon={IconFont.CogThick} testID="context-history-menu">
         <Context.Item
           label="View History"
           action={onView}
           testID="context-history-task"
+        />
+        <Context.Item
+          label="Edit Task"
+          action={onEditTask}
+          testID="context-edit-task"
         />
       </Context.Menu>
       <Context.Menu

--- a/src/notifications/rules/components/RuleCardContext.tsx
+++ b/src/notifications/rules/components/RuleCardContext.tsx
@@ -16,7 +16,7 @@ const RuleCardContext: FunctionComponent<Props> = ({
   onDelete,
   onClone,
   onView,
-  onEditTask
+  onEditTask,
 }) => {
   return (
     <Context>

--- a/src/shared/copy/notifications.ts
+++ b/src/shared/copy/notifications.ts
@@ -1099,13 +1099,13 @@ export const communityTemplateRenameFailed = (): Notification => ({
 export const editCheckCodeWarning = (): Notification => ({
   ...defaultErrorNotification,
   style: NotificationStyle.Info,
-  message: `Changes to Check code may prevent you from editing the Check in the visual editing experience.`,
+  message: 'Changes to Check code may prevent you from editing the Check in the visual editing experience.',
 })
 
 export const editNotificationRuleCodeWarning = (): Notification => ({
   ...defaultErrorNotification,
   style: NotificationStyle.Info,
-  message: `Changes to Notification Rule code may prevent you from editing the Notification Rule in the visual editing experience.`,
+  message: 'Changes to Notification Rule code may prevent you from editing the Notification Rule in the visual editing experience.',
 })
 
 // Notebooks

--- a/src/shared/copy/notifications.ts
+++ b/src/shared/copy/notifications.ts
@@ -18,6 +18,7 @@ import {
 import {QUICKSTART_SCRAPER_TARGET_URL} from 'src/dataLoaders/constants/pluginConfigs'
 import {QUICKSTART_DASHBOARD_NAME} from 'src/onboarding/constants/index'
 import {IconFont} from '@influxdata/clockface'
+import { info } from 'console'
 
 const bytesFormatter = binaryPrefixFormatter({
   suffix: 'B',
@@ -1094,6 +1095,18 @@ export const communityTemplateUnsupportedFormatError = (): Notification => ({
 export const communityTemplateRenameFailed = (): Notification => ({
   ...defaultErrorNotification,
   message: `We've successfully installed your template but weren't able to name it properly. It may appear as a blank template.`,
+})
+
+export const editCheckCodeWarning = (): Notification => ({
+  ...defaultErrorNotification,
+  style: NotificationStyle.Info,
+  message: `Changes to Check code may prevent you from editing the Check in the visual editing experience.`,
+})
+
+export const editNotificationRuleCodeWarning = (): Notification => ({
+  ...defaultErrorNotification,
+  style: NotificationStyle.Info,
+  message: `Changes to Notification Rule code may prevent you from editing the Notification Rule in the visual editing experience.`,
 })
 
 // Notebooks

--- a/src/shared/copy/notifications.ts
+++ b/src/shared/copy/notifications.ts
@@ -18,7 +18,6 @@ import {
 import {QUICKSTART_SCRAPER_TARGET_URL} from 'src/dataLoaders/constants/pluginConfigs'
 import {QUICKSTART_DASHBOARD_NAME} from 'src/onboarding/constants/index'
 import {IconFont} from '@influxdata/clockface'
-import {info} from 'console'
 
 const bytesFormatter = binaryPrefixFormatter({
   suffix: 'B',

--- a/src/shared/copy/notifications.ts
+++ b/src/shared/copy/notifications.ts
@@ -1099,13 +1099,15 @@ export const communityTemplateRenameFailed = (): Notification => ({
 export const editCheckCodeWarning = (): Notification => ({
   ...defaultErrorNotification,
   style: NotificationStyle.Info,
-  message: 'Changes to Check code may prevent you from editing the Check in the visual editing experience.',
+  message:
+    'Changes to Check code may prevent you from editing the Check in the visual editing experience.',
 })
 
 export const editNotificationRuleCodeWarning = (): Notification => ({
   ...defaultErrorNotification,
   style: NotificationStyle.Info,
-  message: 'Changes to Notification Rule code may prevent you from editing the Notification Rule in the visual editing experience.',
+  message:
+    'Changes to Notification Rule code may prevent you from editing the Notification Rule in the visual editing experience.',
 })
 
 // Notebooks

--- a/src/shared/copy/notifications.ts
+++ b/src/shared/copy/notifications.ts
@@ -18,7 +18,7 @@ import {
 import {QUICKSTART_SCRAPER_TARGET_URL} from 'src/dataLoaders/constants/pluginConfigs'
 import {QUICKSTART_DASHBOARD_NAME} from 'src/onboarding/constants/index'
 import {IconFont} from '@influxdata/clockface'
-import { info } from 'console'
+import {info} from 'console'
 
 const bytesFormatter = binaryPrefixFormatter({
   suffix: 'B',


### PR DESCRIPTION
Closes #1421 

Changed the eyeball icon to gearbox and added "Edit Task" to the drop down list of both Check and Notification rule. 
![editTask](https://user-images.githubusercontent.com/66275100/120011057-7f39c900-bfa3-11eb-9bd6-03331b8eae97.png)

When "Edit Task" is clicked, user is directed to edit task page. A warning toast message pops up letting user know editing code might remove the ability to edit task in the UI. 
![Editwarning](https://user-images.githubusercontent.com/66275100/120011065-806af600-bfa3-11eb-9d9e-def4ce646fde.png)
