### PR TITLE
chore: updating the OpenAPI SHA to test out the getUsageStats API

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "cy": "CYPRESS_dexUrl=https://$INGRESS_HOST:$PORT_HTTPS CYPRESS_baseUrl=http://localhost:9999 cypress open",
     "cy:dev": "source ../monitor-ci/.env && CYPRESS_dexUrl=https://$INGRESS_HOST:$PORT_HTTPS CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{cloud,shared}/**/*.*'",
     "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_dexUrl=OSS CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{oss,shared}/**/*.*'",
-    "generate": "export SHA=db287c47016e1c3bc4db5346d2b77d33d3147142 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
+    "generate": "export SHA=27c725d02cbabaf21be8bcecd43b2871840829bc && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-meta": "yarn currentApi && yarn notebooks && yarn unity && yarn flows && yarn managedFunctions && yarn annotations",
     "oss": "oats ${REMOTE}contracts/oss-diff.yml > ./src/client/ossRoutes.ts",

--- a/src/Logout.tsx
+++ b/src/Logout.tsx
@@ -31,6 +31,10 @@ const Logout: FC<Props> = ({history}) => {
 
     const handleSignOut = async () => {
       if (CLOUD) {
+        /**
+         * We'll need this authSessionCookieOn flag off for tools until
+         * Quartz is integrated into that environment
+         */
         const url = isFlagEnabled('authSessionCookieOn')
           ? new URL(`${window.location.origin}${CLOUD_SIGNOUT_PATHNAME}`).href
           : `${CLOUD_URL}${CLOUD_LOGOUT_PATH}`

--- a/src/Signin.tsx
+++ b/src/Signin.tsx
@@ -108,7 +108,10 @@ export class Signin extends PureComponent<Props, State> {
       } = this.props
 
       clearInterval(this.intervalID)
-
+      /**
+       * We'll need this authSessionCookieOn flag off for tools until
+       * Quartz is integrated into that environment
+       */
       if (CLOUD && isFlagEnabled('authSessionCookieOn')) {
         const url = new URL(
           `${window.location.origin}${CLOUD_LOGIN_PATHNAME}?redirectTo=${window.location.href}`

--- a/src/billing/components/PayAsYouGo/InvoiceHistoryRow.tsx
+++ b/src/billing/components/PayAsYouGo/InvoiceHistoryRow.tsx
@@ -16,12 +16,12 @@ const getPreviousMonth = date => {
 }
 
 const InvoiceHistoryRow: FC<Props> = ({
-  invoice: {status, amount, targetDate, filesId},
+  invoice: {status, amount, targetDate, id},
 }) => {
   const invoiceName = `${getPreviousMonth(new Date(targetDate))} ${new Date(
     targetDate
   ).getFullYear()} Invoice`
-  const link = `/billing/invoices/${filesId}`
+  const link = `/billing/invoices/${id}`
   const statusClassName = classnames('invoice-details invoice-status', {
     ['paid']: status === 'Paid',
   })

--- a/src/billing/context/billing.tsx
+++ b/src/billing/context/billing.tsx
@@ -61,7 +61,7 @@ export const DEFAULT_CONTEXT: BillingContextType = {
   billingInfoStatus: RemoteDataState.NotStarted,
   billingSettings: {
     notifyEmail: '',
-    balanceThreshold: 1,
+    balanceThreshold: 10,
     isNotify: true,
   },
   billingSettingsStatus: RemoteDataState.NotStarted,
@@ -98,7 +98,7 @@ export const BillingProvider: FC<Props> = React.memo(({children}) => {
   const me = useSelector(getQuartzMe)
   const [billingSettings, setBillingSettings] = useState({
     notifyEmail: me?.email ?? '', // sets the default to the user's registered email
-    balanceThreshold: 1, // set the default to the minimum balance threshold
+    balanceThreshold: 10, // set the default to the minimum balance threshold
     isNotify: true,
   })
   const [billingSettingsStatus, setBillingSettingsStatus] = useState(

--- a/src/operator/account/AccountGrid.tsx
+++ b/src/operator/account/AccountGrid.tsx
@@ -16,7 +16,9 @@ const AccountGrid: FC = () => {
     if (!account?.marketplace) {
       return account?.zuoraAccountId ?? 'N/A'
     } else {
-      return account?.marketplace?.subscriberId ?? 'N/A'
+      return 'N/A'
+      // TODO(ariel): get this going when the OperatorAccount is defined in the API
+      // return account?.marketplace?.subscriberId ?? 'N/A'
     }
   }
 
@@ -78,7 +80,9 @@ const AccountGrid: FC = () => {
       >
         <AccountField
           header="Subscription Status"
-          body={account?.marketplace?.status ?? 'N/A'}
+          body="N/A"
+          // TODO(ariel): get this going when the OperatorAccount is going
+          // body={account?.marketplace?.status ?? 'N/A'}
           testID="subscription-status"
         />
         <AccountBillingContact />

--- a/src/shared/containers/GetOrganizations.tsx
+++ b/src/shared/containers/GetOrganizations.tsx
@@ -59,6 +59,10 @@ const GetOrganizations: FunctionComponent = () => {
   return (
     <PageSpinner loading={status}>
       <Suspense fallback={<PageSpinner />}>
+        {/*
+          NOTE: We'll need this here until Tools gets Quartz integrated
+          Since the API request will fail in a tools environment.
+        */}
         {isFlagEnabled('unityMeApi') ? (
           <PageSpinner loading={quartzMeStatus}>
             <Switch>

--- a/src/types/operator.ts
+++ b/src/types/operator.ts
@@ -8,20 +8,6 @@ export {
   User,
 } from 'src/client/unityRoutes'
 
-export interface MarketplaceSubscription {
-  marketplace: string
-  subscriberId: string
-  status: string
-}
-
-export interface TestResource {
-  name: string
-  id: string
-  email: string
-  operator: boolean
-  account: Account
-}
-
 export interface CellInfo {
   path: string
   name: string

--- a/src/usage/context/usage.tsx
+++ b/src/usage/context/usage.tsx
@@ -126,6 +126,9 @@ export const UsageProvider: FC<Props> = React.memo(({children}) => {
 
       const csvs = resp.data?.split('\n\n')
 
+      // TODO(ariel): keeping this in for testing purposes in staging
+      // This will need to be removed for flipping the feature flag on
+      console.warn({csvs})
       setBillingStats(csvs)
     } catch (error) {
       console.error('getBillingStats: ', error)


### PR DESCRIPTION
The primary purpose of this PR is to update the SHA for the OpanAPI reference. Unfortunately, we can't validate whether the change made to OpenAPI will fix the issue with getting the billing_stats since that depends on querying an external bucket that is inaccessible in local development (but is available in staging and production).

Wit the SHA being updated came some changes to some of the type definitions in the API for an account as it relates to the Account type. The current Account type was being used as a nested property of the Operator and contains more information than is necessary for most Account use cases and will therefore be partitioned for the Operator page.

Finally, there was some general house keeping with this PR (bumping the minimum balance threshold from 1 -> 10, adding notes around some feature flags that SHOULD NOT BE REMOVED from the UI) and removing some unused types