### PR TITLE
chore: allow setting PUBLIC env variable for yarn start:kind

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "start:dev": "webpack-dev-server --config ./webpack.dev.ts --progress false",
     "start:dev-cloud": "cross-env CLOUD_LOGOUT_URL=http://localhost:8080/api/v2/signout CLOUD_URL=http://localhost:4000 webpack-dev-server --config ./webpack.dev.ts",
     "start:docker": "yarn generate && yarn build:vendor && yarn run start:dev",
-    "start:kind": "yarn build:vendor && NODE_ENV=development UI_SHA=local_dev_mode BASE_PATH=/ API_BASE_PATH=/ PORT=8080 PUBLIC=https://twodotoh.a.influxcloud.dev.local/ CLOUD_URL=/auth yarn start",
+    "start:kind": "yarn build:vendor && NODE_ENV=development UI_SHA=local_dev_mode BASE_PATH=/ API_BASE_PATH=/ PORT=8080 PUBLIC=${PUBLIC:-https://twodotoh.a.influxcloud.dev.local/} CLOUD_URL=/auth yarn start",
     "build": "yarn install --silent && yarn build:ci",
     "build:ci": "yarn generate && yarn build:vendor && webpack --config webpack.prod.ts --bail",
     "build:fast": "webpack --config webpack.fast.ts --bail",


### PR DESCRIPTION
Allow configuring `PUBLIC` environment variable for `yarn start:kind` to enable hot reload when the UI is running under a different domain name.
