### PR TITLE
chore: creating a custom query for the usage stats to see if the results populate correctly when the results are received and handled correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   "devDependencies": {
     "@babel/core": "^7.5.5",
     "@babel/preset-env": "^7.5.5",
-    "@influxdata/oats": "0.5.0",
+    "@influxdata/oats": "0.5.3",
     "@testing-library/dom": "^7.24.2",
     "@testing-library/jest-dom": "^5.11.6",
     "@testing-library/react": "^11.0.4",

--- a/src/shared/apis/query.ts
+++ b/src/shared/apis/query.ts
@@ -75,7 +75,9 @@ export const runQuery = (
   }
 }
 
-const processResponse = async (response: Response): Promise<RunQueryResult> => {
+export const processResponse = async (
+  response: Response
+): Promise<RunQueryResult> => {
   switch (response.status) {
     case 200:
       return processSuccessResponse(response)

--- a/src/usage/context/usage.tsx
+++ b/src/usage/context/usage.tsx
@@ -5,17 +5,18 @@ import React, {FC, useCallback, useEffect, useState} from 'react'
 import {
   getBillingStartDate,
   getUsage,
-  getUsageBillingStats,
+  // getUsageBillingStats,
   getUsageVectors,
   getUsageRateLimits,
 } from 'src/client/unityRoutes'
+import {processResponse} from 'src/shared/apis/query'
 
 // Constants
 import {DEFAULT_USAGE_TIME_RANGE} from 'src/shared/constants/timeRanges'
+import {API_BASE_PATH} from 'src/shared/constants'
 
 // Types
-import {SelectableDurationTimeRange} from 'src/types'
-import {UsageVector} from 'src/types/billing'
+import {SelectableDurationTimeRange, UsageVector} from 'src/types'
 
 export type Props = {
   children: JSX.Element
@@ -114,22 +115,44 @@ export const UsageProvider: FC<Props> = React.memo(({children}) => {
 
   const handleGetBillingStats = useCallback(async () => {
     try {
-      const resp = await getUsageBillingStats({})
+      // TODO(ariel): making a custom function here because oats can't handle CSV responses?
+      const request = fetch(
+        `${API_BASE_PATH}api/v2/quartz/usage/billing_stats`,
+        {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept-Encoding': 'gzip',
+          },
+        }
+      )
 
-      if (resp.status !== 200) {
-        throw new Error(resp.data.message)
-      }
+      const result = await request.then(processResponse)
 
       // TODO(ariel): keeping this in for testing purposes in staging
       // This will need to be removed for flipping the feature flag on
-      console.warn({resp})
+      console.warn({result})
 
-      const csvs = resp.data?.split('\n\n')
+      if (result.type !== 'SUCCESS') {
+        throw new Error(result.message)
+      }
 
+      const csvs = result?.csv?.split('\n\n')
       // TODO(ariel): keeping this in for testing purposes in staging
       // This will need to be removed for flipping the feature flag on
       console.warn({csvs})
-      setBillingStats(csvs)
+
+      setBillingStats(csvs ?? [''])
+
+      // const resp = await getUsageBillingStats({})
+
+      // if (resp.status !== 200) {
+      //   throw new Error(resp.data.message)
+      // }
+
+      // const csvs = result?.csv?.split('\n\n')
+
+      // setBillingStats(csvs)
     } catch (error) {
       console.error('getBillingStats: ', error)
     }

--- a/src/usage/context/usage.tsx
+++ b/src/usage/context/usage.tsx
@@ -5,7 +5,6 @@ import React, {FC, useCallback, useEffect, useState} from 'react'
 import {
   getBillingStartDate,
   getUsage,
-  // getUsageBillingStats,
   getUsageVectors,
   getUsageRateLimits,
 } from 'src/client/unityRoutes'
@@ -143,16 +142,6 @@ export const UsageProvider: FC<Props> = React.memo(({children}) => {
       console.warn({csvs})
 
       setBillingStats(csvs ?? [''])
-
-      // const resp = await getUsageBillingStats({})
-
-      // if (resp.status !== 200) {
-      //   throw new Error(resp.data.message)
-      // }
-
-      // const csvs = result?.csv?.split('\n\n')
-
-      // setBillingStats(csvs)
     } catch (error) {
       console.error('getBillingStats: ', error)
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -744,10 +744,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/influxdb-templates/-/influxdb-templates-0.9.0.tgz#d4b1f727c8949147d2ade63f5754425a0d1a0e9d"
   integrity sha512-R/QhYJz+nNPGT8LkWHXKOLYYUROavDPfIFoGP7sIrxhStjm+hb0TzHYeQ75HLPQqKh54zCB8cv/TINwRgijYBw==
 
-"@influxdata/oats@0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@influxdata/oats/-/oats-0.5.0.tgz#0fdd308524fa407303ffa6a3d60fe959777dcfcb"
-  integrity sha512-oBlSB5ROM6JMqsVBDLlJzkBiMvAom+b4dszH83LPdM9H+pUtj2SeUoMpQhj9/4ioCnUVZx8HFN58/a/pkmADAQ==
+"@influxdata/oats@0.5.3":
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/@influxdata/oats/-/oats-0.5.3.tgz#eacedf71c802396d981fac447274a5cc34f5d932"
+  integrity sha512-OG3kr6p5U+wpa2qny+Cu8CBqHJne9mKEC5ux4JJTnk1eQnfAtNv+DGdz0QH+Ouz/8cqjl2erkPx6RPMGmUYMeA==
   dependencies:
     commander "^2.20.0"
     humps "^2.0.1"


### PR DESCRIPTION
this PR is a sanity check to try and see if handling the response correctly will actually render the usage stats data on the Usage Page. This should be a temporary thing since we'd want to lean on oats as the ultimate tool for processing queries and their responses. Currently, this is utilizing the querying mechanism that the UI uses to issue queries to the `/query` endpoint, which handles `csv` responses