### PR TITLE
fix: add title prop to enable toggle to find correct label

### DIFF
--- a/src/templates/components/CommunityTemplateResourceContent.tsx
+++ b/src/templates/components/CommunityTemplateResourceContent.tsx
@@ -405,6 +405,7 @@ class CommunityTemplateResourceContentUnconnected extends PureComponent<Props> {
                         )
                       }}
                       key={label.templateMetaName}
+                      title={label.templateMetaName}
                     >
                       <Label
                         description={label.properties.description}


### PR DESCRIPTION
Closes #1430

<!-- Describe your proposed changes here. -->
Adds a title prop which was coming in as undefined bc it wasn't getting set in the list component, which allows the toggle to select the correct label 

https://user-images.githubusercontent.com/29473622/120361025-02725c00-c2cf-11eb-8cc4-01f08535fd82.mov

