### PR TITLE
fix: handle submit bug for the checkout page

### DIFF
--- a/src/checkout/context/checkout.tsx
+++ b/src/checkout/context/checkout.tsx
@@ -252,10 +252,12 @@ export const CheckoutProvider: FC<Props> = React.memo(({children}) => {
               inputs.country === 'United States'
                 ? inputs.usSubdivision
                 : inputs.intlSubdivision,
+            isNotify: inputs.shouldNotify,
           }
 
           delete formData.usSubdivision
           delete formData.intlSubdivision
+          delete formData.shouldNotify
 
           const paymentInformation = {...formData, paymentMethodId}
 

--- a/src/checkout/context/checkout.tsx
+++ b/src/checkout/context/checkout.tsx
@@ -234,52 +234,55 @@ export const CheckoutProvider: FC<Props> = React.memo(({children}) => {
     return errs.length
   }
 
-  const handleSubmit = async (paymentMethodId: string) => {
-    if (isDirty === false) {
-      setIsDirty(true)
-    }
-    setIsSubmitting(true)
-
-    // Check to see if the form is valid using the validate form
-    const errs = getInvalidFields()
-
-    try {
-      if (errs.length === 0) {
-        const formData = {
-          ...inputs,
-          subdivision:
-            inputs.country === 'United States'
-              ? inputs.usSubdivision
-              : inputs.intlSubdivision,
-        }
-
-        delete formData.usSubdivision
-        delete formData.intlSubdivision
-
-        const paymentInformation = {...formData, paymentMethodId}
-
-        const response = await postCheckout({data: paymentInformation})
-
-        if (response.status !== 201) {
-          throw new Error(response.data.message)
-        }
-
-        setCheckoutStatus(RemoteDataState.Done)
-        // Call the `quartz/me` endpoint to update the existing user metadata
-        dispatch(getQuartzMeThunk())
-      } else {
-        const errorFields = errs?.flatMap(([err]) => err)
-        setCheckoutStatus(RemoteDataState.Error)
-        handleSetErrors(errorFields)
+  const handleSubmit = useCallback(
+    async (paymentMethodId: string) => {
+      if (isDirty === false) {
+        setIsDirty(true)
       }
-    } catch (error) {
-      console.error(error)
+      setIsSubmitting(true)
 
-      dispatch(notify(submitError()))
-    }
+      // Check to see if the form is valid using the validate form
+      const errs = getInvalidFields()
 
-    setIsSubmitting(false)
-  }
+      try {
+        if (errs.length === 0) {
+          const formData = {
+            ...inputs,
+            subdivision:
+              inputs.country === 'United States'
+                ? inputs.usSubdivision
+                : inputs.intlSubdivision,
+          }
+
+          delete formData.usSubdivision
+          delete formData.intlSubdivision
+
+          const paymentInformation = {...formData, paymentMethodId}
+
+          const response = await postCheckout({data: paymentInformation})
+
+          if (response.status !== 201) {
+            throw new Error(response.data.message)
+          }
+
+          setCheckoutStatus(RemoteDataState.Done)
+          // Call the `quartz/me` endpoint to update the existing user metadata
+          dispatch(getQuartzMeThunk())
+        } else {
+          const errorFields = errs?.flatMap(([err]) => err)
+          setCheckoutStatus(RemoteDataState.Error)
+          handleSetErrors(errorFields)
+        }
+      } catch (error) {
+        console.error(error)
+
+        dispatch(notify(submitError()))
+      }
+
+      setIsSubmitting(false)
+    },
+    [dispatch, getInvalidFields, handleSetErrors, inputs, isDirty]
+  )
 
   const history = useHistory()
 

--- a/src/checkout/context/checkout.tsx
+++ b/src/checkout/context/checkout.tsx
@@ -244,44 +244,48 @@ export const CheckoutProvider: FC<Props> = React.memo(({children}) => {
       // Check to see if the form is valid using the validate form
       const errs = getInvalidFields()
 
+      if (errs.length > 0) {
+        const errorFields = errs?.flatMap(([err]) => err)
+
+        setCheckoutStatus(RemoteDataState.Error)
+        handleSetErrors(errorFields)
+        setIsSubmitting(false)
+
+        return
+      }
+
       try {
-        if (errs.length === 0) {
-          const formData = {
-            ...inputs,
-            subdivision:
-              inputs.country === 'United States'
-                ? inputs.usSubdivision
-                : inputs.intlSubdivision,
-            isNotify: inputs.shouldNotify,
-          }
-
-          delete formData.usSubdivision
-          delete formData.intlSubdivision
-          delete formData.shouldNotify
-
-          const paymentInformation = {...formData, paymentMethodId}
-
-          const response = await postCheckout({data: paymentInformation})
-
-          if (response.status !== 201) {
-            throw new Error(response.data.message)
-          }
-
-          setCheckoutStatus(RemoteDataState.Done)
-          // Call the `quartz/me` endpoint to update the existing user metadata
-          dispatch(getQuartzMeThunk())
-        } else {
-          const errorFields = errs?.flatMap(([err]) => err)
-          setCheckoutStatus(RemoteDataState.Error)
-          handleSetErrors(errorFields)
+        const formData = {
+          ...inputs,
+          subdivision:
+            inputs.country === 'United States'
+              ? inputs.usSubdivision
+              : inputs.intlSubdivision,
+          isNotify: inputs.shouldNotify,
         }
+
+        delete formData.usSubdivision
+        delete formData.intlSubdivision
+        delete formData.shouldNotify
+
+        const paymentInformation = {...formData, paymentMethodId}
+
+        const response = await postCheckout({data: paymentInformation})
+
+        if (response.status !== 201) {
+          throw new Error(response.data.message)
+        }
+
+        setCheckoutStatus(RemoteDataState.Done)
+        // Call the `quartz/me` endpoint to update the existing user metadata
+        dispatch(getQuartzMeThunk())
       } catch (error) {
         console.error(error)
 
         dispatch(notify(submitError()))
+      } finally {
+        setIsSubmitting(false)
       }
-
-      setIsSubmitting(false)
     },
     [dispatch, getInvalidFields, handleSetErrors, inputs, isDirty]
   )


### PR DESCRIPTION
This wraps the submit function in a useCallback to ensure that we are capturing the latest `inputs` when the user hits the submit button. Also updating the way we are setting the `isNotify` field so that it actually sends `isNotify` and not `shouldNotify`. 