### PR TITLE
feat: isoString is now the default for selected time ranges and is a valid format

### DIFF
--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -350,7 +350,7 @@ describe('DataExplorer', () => {
           .clear()
           .type('2019-10-29T08:00:00.000Z')
 
-        // button should be disabled
+        // button should not be disabled
         cy.getByTestID('daterange--apply-btn').should('not.be.disabled')
       })
     })

--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -342,16 +342,16 @@ describe('DataExplorer', () => {
         // invalid date errors
         cy.getByTestID('form--element-error').should('exist')
 
-        // Validate that ISO String formatted texts are valid
-        cy.get('input[title="Stop"]')
-          .clear()
-          .type('2019-10-29T08:00:00.000Z')
-
-        // invalid date errors
-        cy.getByTestID('form--element-error').should('not.exist')
-
         // button should be disabled
         cy.getByTestID('daterange--apply-btn').should('be.disabled')
+
+        // Validate that ISO String formatted texts are valid
+        cy.get('input[title="Stop"]')
+        .clear()
+        .type('2019-10-29T08:00:00.000Z')
+
+        // button should be disabled
+        cy.getByTestID('daterange--apply-btn').should('not.be.disabled')
       })
     })
   })

--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -303,7 +303,7 @@ describe('DataExplorer', () => {
         cy.getByTestID('timerange-popover--dialog').should('have.length', 1)
       })
 
-      it('should error when submitting stop dates that are before start dates', () => {
+      it('should error when submitting stop dates that are before start dates and should error when invalid dates are input', () => {
         cy.get('input[title="Start"]')
           .should('have.length', 1)
           .clear()
@@ -316,15 +316,12 @@ describe('DataExplorer', () => {
 
         // button should be disabled
         cy.getByTestID('daterange--apply-btn').should('be.disabled')
-      })
 
-      it('should error when invalid dates are input', () => {
         // default inputs should be valid
         cy.getByTestID('input-error').should('not.exist')
 
         // type incomplete input
         cy.get('input[title="Start"]')
-          .should('have.length', 1)
           .clear()
           .type('2019-10')
 
@@ -339,12 +336,19 @@ describe('DataExplorer', () => {
 
         // type invalid stop date
         cy.get('input[title="Stop"]')
-          .should('have.length', 1)
           .clear()
           .type('2019-10-')
 
         // invalid date errors
         cy.getByTestID('form--element-error').should('exist')
+
+        // Validate that ISO String formatted texts are valid
+        cy.get('input[title="Stop"]')
+          .clear()
+          .type('2019-10-29T08:00:00.000Z')
+
+        // invalid date errors
+        cy.getByTestID('form--element-error').should('not.exist')
 
         // button should be disabled
         cy.getByTestID('daterange--apply-btn').should('be.disabled')

--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -347,8 +347,8 @@ describe('DataExplorer', () => {
 
         // Validate that ISO String formatted texts are valid
         cy.get('input[title="Stop"]')
-        .clear()
-        .type('2019-10-29T08:00:00.000Z')
+          .clear()
+          .type('2019-10-29T08:00:00.000Z')
 
         // button should be disabled
         cy.getByTestID('daterange--apply-btn').should('not.be.disabled')

--- a/src/shared/components/dateRangePicker/DatePicker.tsx
+++ b/src/shared/components/dateRangePicker/DatePicker.tsx
@@ -31,7 +31,8 @@ const isValidRTC3339 = (d: string): boolean => {
     moment(d, 'YYYY-MM-DD HH:mm', true).isValid() ||
     moment(d, 'YYYY-MM-DD HH:mm:ss', true).isValid() ||
     moment(d, 'YYYY-MM-DD HH:mm:ss.SSS', true).isValid() ||
-    moment(d, 'YYYY-MM-DD', true).isValid()
+    moment(d, 'YYYY-MM-DD', true).isValid() ||
+    moment(d).toISOString() === d
   )
 }
 
@@ -117,7 +118,7 @@ export default class DatePicker extends PureComponent<Props, State> {
       return moment(dateTime).format(inputFormat)
     }
 
-    return moment(dateTime).format('YYYY-MM-DD HH:mm:ss.SSS')
+    return moment(dateTime).toISOString()
   }
 
   private get isInputValueInvalid(): boolean {
@@ -162,7 +163,7 @@ export default class DatePicker extends PureComponent<Props, State> {
     const {dateTime} = this.props
     const {inputFormat} = this.state
 
-    let value = moment(dateTime).format('YYYY-MM-DD HH:mm:ss.SSS')
+    let value = moment(dateTime).toISOString()
     if (inputFormat) {
       value = moment(dateTime).format(inputFormat)
     }

--- a/src/usage/context/usage.tsx
+++ b/src/usage/context/usage.tsx
@@ -122,9 +122,9 @@ export const UsageProvider: FC<Props> = React.memo(({children}) => {
 
       // TODO(ariel): keeping this in for testing purposes in staging
       // This will need to be removed for flipping the feature flag on
-      console.warn({resp})
+      console.warn(resp.data)
 
-      const csvs = resp.data?.split('\n\n')
+      const csvs = resp.data?.split('\r\n')
 
       // TODO(ariel): keeping this in for testing purposes in staging
       // This will need to be removed for flipping the feature flag on


### PR DESCRIPTION
Closes #448 

This PR updates the validation mechanism to allow for ISOString formatted inputs to be valid. It also sets the default format to ISOString

![iso_string](https://user-images.githubusercontent.com/19984220/120385794-b7f7dc00-c2dc-11eb-84d2-c663e2ac674a.gif)

