### PR TITLE
fix: add default so colorschemedropdown doesnt error if no color

### DIFF
--- a/src/visualization/types/Graph/options.tsx
+++ b/src/visualization/types/Graph/options.tsx
@@ -193,7 +193,7 @@ const GraphViewOptions: FC<Props> = ({properties, results, update}) => {
           )}
           <Form.Element label="Line Colors">
             <ColorSchemeDropdown
-              value={properties.colors.filter(c => c.type === 'scale')}
+              value={properties.colors?.filter(c => c.type === 'scale') ?? []}
               onChange={colors => {
                 update({colors})
               }}


### PR DESCRIPTION
Closes #1445

<!-- Describe your proposed changes here. -->
Adds a default array to the colorschemedropdown value prop so that if there is not color defined, it will not error. 