### PR TITLE
chore: enhanced monitor-ci-tests retry from failure

### DIFF
--- a/scripts/run-monitor-ci-tests.bash
+++ b/scripts/run-monitor-ci-tests.bash
@@ -97,6 +97,7 @@ mkdir -p monitor-ci/test-artifacts/results/{build-oss-image,oss-e2e,build-image,
 if [[ -z "${OSS_SHA:-}" ]]; then
 	# get monitor-ci pipelines we've already run on this SHA
 	found_passing_pipeline=0
+	found_failed_pipeline=0
 	all_pipelines=$(curl -s --request GET \
 			--url "https://circleci.com/api/v2/project/gh/influxdata/monitor-ci/pipeline" \
 			--header "Circle-Token: ${API_KEY}" \
@@ -183,7 +184,7 @@ else
 fi
 
 # start a new pipeline if we didn't find an existing one to retry
-if [ -z $found_failed_pipeline ]; then
+if [ $found_failed_pipeline -eq 0 ]; then
 	startNewPipeline $pipelineStartMsg $reqData
 else
 	retryFailedPipeline $failed_pipeline_workflow_id $failed_pipeline_id $failed_pipeline_number

--- a/scripts/run-monitor-ci-tests.bash
+++ b/scripts/run-monitor-ci-tests.bash
@@ -185,9 +185,9 @@ fi
 
 # start a new pipeline if we didn't find an existing one to retry
 if [ $found_failed_pipeline -eq 0 ]; then
-	startNewPipeline $pipelineStartMsg $reqData
+	startNewPipeline "${pipelineStartMsg}" "${reqData}"
 else
-	retryFailedPipeline $failed_pipeline_workflow_id $failed_pipeline_id $failed_pipeline_number
+	retryFailedPipeline ${failed_pipeline_workflow_id} ${failed_pipeline_id} ${failed_pipeline_number}
 fi
 
 # poll the status of the monitor-ci pipeline


### PR DESCRIPTION
Closes #1538

Adds logic to `run-monitor-ci-tests.bash` script to look for failed pipelines with the same commit SHA and re-run them from failure using the CircleCI API instead of starting a brand new monitor-ci pipeline.

https://user-images.githubusercontent.com/6411855/120549612-ad0a7d80-c3a8-11eb-81e6-2767d32a6428.mov

