### PR TITLE
feat: Automatically link urls found in check and notification status messages

### DIFF
--- a/src/eventViewer/components/TableRow.tsx
+++ b/src/eventViewer/components/TableRow.tsx
@@ -1,54 +1,12 @@
 import React, {FC, CSSProperties} from 'react'
 
 import {Row, Fields} from 'src/types'
+import {asLink} from 'src/visualization/types/Table/TableCell'
 
 interface Props {
   row: Row
   style: CSSProperties
   fields: Fields
-}
-
-const URL_REGEXP = /((http|https)?:\/\/[^\s]+)/g
-
-// NOTE: rip this out if you spend time any here as per:
-// https://stackoverflow.com/questions/1500260/detect-urls-in-text-with-javascript/1500501#1500501
-function asLink(str) {
-  const isURL = `${str}`.includes('http://') || `${str}`.includes('https://')
-  if (isURL === false) {
-    return str
-  }
-
-  const regex = RegExp(URL_REGEXP.source, URL_REGEXP.flags),
-    out = []
-  let idx = 0,
-    link,
-    m
-
-  do {
-    m = regex.exec(str)
-
-    if (m) {
-      if (m.index - idx > 0) {
-        out.push(str.slice(idx, m.index))
-      }
-
-      link = str.slice(m.index, m.index + m[1].length)
-      out.push(
-        <a
-          href={link}
-          target="_blank"
-          rel="noreferrer"
-          data-testid="table-row--link"
-        >
-          {link}
-        </a>
-      )
-
-      idx = m.index + m[1].length
-    }
-  } while (m)
-
-  return out
 }
 
 const TableRow: FC<Props> = ({row, style, fields}) => {

--- a/src/eventViewer/components/TableRow.tsx
+++ b/src/eventViewer/components/TableRow.tsx
@@ -8,6 +8,49 @@ interface Props {
   fields: Fields
 }
 
+const URL_REGEXP = /((http|https)?:\/\/[^\s]+)/g
+
+// NOTE: rip this out if you spend time any here as per:
+// https://stackoverflow.com/questions/1500260/detect-urls-in-text-with-javascript/1500501#1500501
+function asLink(str) {
+  const isURL = `${str}`.includes('http://') || `${str}`.includes('https://')
+  if (isURL === false) {
+    return str
+  }
+
+  const regex = RegExp(URL_REGEXP.source, URL_REGEXP.flags),
+    out = []
+  let idx = 0,
+    link,
+    m
+
+  do {
+    m = regex.exec(str)
+
+    if (m) {
+      if (m.index - idx > 0) {
+        out.push(str.slice(idx, m.index))
+      }
+
+      link = str.slice(m.index, m.index + m[1].length)
+      out.push(
+        <a
+          href={link}
+          target="_blank"
+          rel="noreferrer"
+          data-testid="table-row--link"
+        >
+          {link}
+        </a>
+      )
+
+      idx = m.index + m[1].length
+    }
+  } while (m)
+
+  return out
+}
+
 const TableRow: FC<Props> = ({row, style, fields}) => {
   return (
     <div style={style}>
@@ -22,7 +65,7 @@ const TableRow: FC<Props> = ({row, style, fields}) => {
           } else if (Component) {
             content = <Component key={rowKey} row={row} />
           } else {
-            content = String(row[rowKey])
+            content = asLink(row[rowKey])
           }
 
           return (

--- a/src/visualization/types/Table/TableCell.test.ts
+++ b/src/visualization/types/Table/TableCell.test.ts
@@ -1,0 +1,108 @@
+import {asLink} from './TableCell'
+
+describe('TableCell.asLink', () => {
+  it('Properly handles various base data types', () => {
+    expect(asLink('a regular string')).toEqual('a regular string')
+    expect(asLink(NaN)).toEqual(NaN)
+    expect(asLink(true)).toEqual(true)
+    expect(asLink(42)).toEqual(42)
+    expect(asLink(undefined)).toEqual(undefined)
+    expect(asLink(null)).toEqual(null)
+  })
+
+  it('Handles basic links', () => {
+    const insecureLink = asLink('http://www.google.com')
+    expect(insecureLink).toHaveLength(1)
+    expect(insecureLink[0].props.href).toEqual('http://www.google.com')
+    expect(insecureLink[0].props.target).toEqual('_blank')
+    expect(insecureLink[0].props.rel).toEqual('noreferrer')
+    expect(insecureLink[0].props.children).toEqual('http://www.google.com')
+
+    const secureLink = asLink('https://www.influxdata.com')
+    expect(secureLink).toHaveLength(1)
+    expect(secureLink[0].props.href).toEqual('https://www.influxdata.com')
+    expect(secureLink[0].props.children).toEqual('https://www.influxdata.com')
+  })
+
+  it('Handles text and link combinations appropriately', () => {
+    const textBeforeLink = asLink(
+      'Make it do what it do at https://www.influxdata.com'
+    )
+    expect(textBeforeLink).toHaveLength(2)
+    expect(textBeforeLink[0]).toEqual('Make it do what it do at ')
+    expect(textBeforeLink[1].props.href).toEqual('https://www.influxdata.com')
+    expect(textBeforeLink[1].props.children).toEqual(
+      'https://www.influxdata.com'
+    )
+
+    const linkBeforeText = asLink(
+      'https://www.influxdata.com Make it do what it do'
+    )
+    expect(linkBeforeText).toHaveLength(2)
+    expect(linkBeforeText[0].props.href).toEqual('https://www.influxdata.com')
+    expect(linkBeforeText[0].props.children).toEqual(
+      'https://www.influxdata.com'
+    )
+    expect(linkBeforeText[1]).toEqual(' Make it do what it do')
+
+    const linkSandwich = asLink(
+      'Hungry? Why wait? https://www.snickers.com today'
+    )
+    expect(linkSandwich).toHaveLength(3)
+    expect(linkSandwich[0]).toEqual('Hungry? Why wait? ')
+    expect(linkSandwich[1].props.href).toEqual('https://www.snickers.com')
+    expect(linkSandwich[1].props.children).toEqual('https://www.snickers.com')
+    expect(linkSandwich[2]).toEqual(' today')
+
+    const doubleLinks = asLink(
+      'https://www.google.com https://www.influxdata.com'
+    )
+    expect(doubleLinks).toHaveLength(3)
+    expect(doubleLinks[0].props.href).toEqual('https://www.google.com')
+    expect(doubleLinks[0].props.children).toEqual('https://www.google.com')
+    expect(doubleLinks[1]).toEqual(' ')
+    expect(doubleLinks[2].props.href).toEqual('https://www.influxdata.com')
+    expect(doubleLinks[2].props.children).toEqual('https://www.influxdata.com')
+
+    const textSandwich = asLink(
+      'https://www.google.com or perhaps https://www.influxdata.com'
+    )
+    expect(textSandwich).toHaveLength(3)
+    expect(textSandwich[0].props.href).toEqual('https://www.google.com')
+    expect(textSandwich[0].props.children).toEqual('https://www.google.com')
+    expect(textSandwich[1]).toEqual(' or perhaps ')
+    expect(textSandwich[2].props.href).toEqual('https://www.influxdata.com')
+    expect(textSandwich[2].props.children).toEqual('https://www.influxdata.com')
+
+    const linkTextLinkText = asLink(
+      'https://www.google.com or perhaps https://www.influxdata.com or not'
+    )
+    expect(linkTextLinkText).toHaveLength(4)
+    expect(linkTextLinkText[0]).toEqual(textSandwich[0])
+    expect(linkTextLinkText[1]).toEqual(' or perhaps ')
+    expect(linkTextLinkText[2]).toEqual(textSandwich[2])
+    expect(linkTextLinkText[3]).toEqual(' or not')
+
+    const textLinkTextLink = asLink(
+      'oh no not https://www.google.com or perhaps https://www.influxdata.com'
+    )
+    expect(textLinkTextLink).toHaveLength(4)
+    expect(textLinkTextLink[0]).toEqual('oh no not ')
+    expect(textLinkTextLink[1]).toEqual(textSandwich[0])
+    expect(textLinkTextLink[2]).toEqual(' or perhaps ')
+    expect(textLinkTextLink[3]).toEqual(textSandwich[2])
+  })
+
+  it('Handles almost links with aplomb', () => {
+    const gopher = asLink('gopher://www.notathinganymore.com')
+    expect(gopher).toEqual('gopher://www.notathinganymore.com')
+    const ftp = asLink('ftp://www.hiiminsecure.com')
+    expect(ftp).toEqual('ftp://www.hiiminsecure.com')
+    const soclose = asLink('htt://www.google.com')
+    expect(soclose).toEqual('htt://www.google.com')
+    const soclose2 = asLink('http:/www.google.com')
+    expect(soclose2).toEqual('http:/www.google.com')
+    const backwards = asLink('http:\\\\www.google.com')
+    expect(backwards).toEqual('http:\\\\www.google.com')
+  })
+})

--- a/src/visualization/types/Table/TableCell.tsx
+++ b/src/visualization/types/Table/TableCell.tsx
@@ -44,7 +44,7 @@ const URL_REGEXP = /((http|https)?:\/\/[^\s]+)/g
 
 // NOTE: rip this out if you spend time any here as per:
 // https://stackoverflow.com/questions/1500260/detect-urls-in-text-with-javascript/1500501#1500501
-function asLink(str) {
+export function asLink(str) {
   const isURL = `${str}`.includes('http://') || `${str}`.includes('https://')
   if (isURL === false) {
     return str

--- a/src/visualization/types/Table/TableCell.tsx
+++ b/src/visualization/types/Table/TableCell.tsx
@@ -75,6 +75,11 @@ export function asLink(str) {
     }
   } while (m)
 
+  // Add leftover non link string if it exists
+  if (str.slice(idx).length > 0) {
+    out.push(str.slice(idx))
+  }
+
   return out
 }
 


### PR DESCRIPTION
Closes #1420 

Automatically adds links to the TableRow component (used by both the checks and notifications status pages) so that any link in a TableRow gets built into a link identically to the way it's done in EventTable.

Looks like this in action:
![Checks-link](https://user-images.githubusercontent.com/22055730/120550996-8dcd1980-c3c3-11eb-8d45-d8f3ee671ca7.gif)

