### PR TITLE
chore: allow text selection in simple table

### DIFF
--- a/src/visualization/types/SimpleTable/style.scss
+++ b/src/visualization/types/SimpleTable/style.scss
@@ -6,6 +6,7 @@
 
   display: flex;
   flex-direction: column;
+  user-select: text;
 
   .cf-dapper-scrollbars {
     border-bottom: $cf-border solid $g2-kevlar;


### PR DESCRIPTION
Closes #1540 

Adds `user-select: text` to simple table. Previously it was inheriting `user-select: none` from time machine


https://user-images.githubusercontent.com/6411855/120559469-f0b7b400-c3b5-11eb-8ee8-32e78e270d91.mov

