### PR TITLE
feat: adding missing flux functions

### DIFF
--- a/src/shared/constants/fluxFunctions.ts
+++ b/src/shared/constants/fluxFunctions.ts
@@ -44,7 +44,7 @@ export const FROM: FluxToolbarFunction = {
   example: 'from(bucket: "example-bucket")',
   category: 'Inputs',
   link:
-    'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/inputs/from/',
+    'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/inputs/from/',
 }
 
 export const RANGE: FluxToolbarFunction = {
@@ -67,7 +67,7 @@ export const RANGE: FluxToolbarFunction = {
   example: 'range(start: -15m, stop: now())',
   category: 'Transformations',
   link:
-    'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/range/',
+    'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/range/',
 }
 
 export const MEAN: FluxToolbarFunction = {
@@ -84,7 +84,7 @@ export const MEAN: FluxToolbarFunction = {
   example: 'mean(column: "_value")',
   category: 'Aggregates',
   link:
-    'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/aggregates/mean/',
+    'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/aggregates/mean/',
 }
 
 export const UNION: FluxToolbarFunction = {
@@ -103,7 +103,7 @@ export const UNION: FluxToolbarFunction = {
   example: 'union(tables: [table1, table2])',
   category: 'Transformations',
   link:
-    'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/union/',
+    'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/union/',
 }
 
 export const MATH_ABS: FluxToolbarFunction = {
@@ -120,7 +120,7 @@ export const MATH_ABS: FluxToolbarFunction = {
   example: 'math.abs(x: r._value)',
   category: 'Transformations',
   link:
-    'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/abs/',
+    'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/abs/',
 }
 
 export const MATH_FLOOR: FluxToolbarFunction = {
@@ -137,7 +137,7 @@ export const MATH_FLOOR: FluxToolbarFunction = {
   example: 'math.floor(x: r._value)',
   category: 'Transformations',
   link:
-    'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/floor/',
+    'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/floor/',
 }
 
 export const STRINGS_TITLE: FluxToolbarFunction = {
@@ -154,7 +154,7 @@ export const STRINGS_TITLE: FluxToolbarFunction = {
   example: 'strings.title(v: r._value)',
   category: 'Transformations',
   link:
-    'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/strings/title/',
+    'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/strings/title/',
 }
 
 export const STRINGS_TRIM: FluxToolbarFunction = {
@@ -177,7 +177,7 @@ export const STRINGS_TRIM: FluxToolbarFunction = {
   example: 'strings.trim(v: r._value, cutset: "_")',
   category: 'Transformations',
   link:
-    'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/strings/trim/',
+    'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/strings/trim/',
 }
 
 export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
@@ -206,7 +206,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'aggregate.rate(every: 1m, unit: 1s)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/aggregate/rate/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/aggregate/rate/',
   },
   {
     name: 'aggregateWindow',
@@ -250,7 +250,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'aggregateWindow(every: v.windowPeriod, fn: mean)',
     category: 'Aggregates',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/aggregates/aggregatewindow/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/aggregates/aggregatewindow/',
   },
   {
     name: 'alerta.alert',
@@ -353,7 +353,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Alerting',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/alerta/alert/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/contrib/alerta/alert/',
   },
   {
     name: 'alerta.endpoint',
@@ -391,7 +391,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Alerting',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/alerta/endpoint/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/contrib/alerta/endpoint/',
   },
   {
     name: 'array.from',
@@ -408,7 +408,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'array.from(rows: [{_time: 2020-01-01T00:00:00Z, _value: "foo"},{_time: 2020-01-02T00:00:00Z, _value: "bar"}])',
     category: 'Inputs',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/array/from/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/array/from/',
   },
   {
     name: 'bigpanda.endpoint',
@@ -439,7 +439,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Alerting',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/bigpanda/endpoint/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/contrib/bigpanda/endpoint/',
   },
   {
     name: 'bigpanda.sendAlert',
@@ -483,7 +483,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Alerting',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/bigpanda/sendalert/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/contrib/bigpanda/sendalert/',
   },
   {
     name: 'bigpanda.statusFromLevel',
@@ -499,7 +499,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'bigpanda.statusFromLevel(level: "crit")',
     category: 'Alerting',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/bigpanda/statusfromlevel/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/contrib/bigpanda/statusfromlevel/',
   },
   {
     name: 'bigtable.from',
@@ -534,7 +534,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'bigtable.from(token: "mySuPeRseCretTokEn", project: "exampleProjectID", instance: "exampleInstanceID", table: "example-table")',
     category: 'Inputs',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/bigtable/from/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/bigtable/from/',
   },
   {
     name: 'bool',
@@ -550,7 +550,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'bool(v: r._value)',
     category: 'Type Conversions',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/type-conversions/bool/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/type-conversions/bool/',
   },
   {
     name: 'bottom',
@@ -572,7 +572,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'bottom(n:10, columns: ["_value"])',
     category: 'Selectors',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/selectors/bottom/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/selectors/bottom/',
   },
   {
     name: 'buckets',
@@ -582,7 +582,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'buckets()',
     category: 'Inputs',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/inputs/buckets/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/inputs/buckets/',
   },
   {
     name: 'bytes',
@@ -598,7 +598,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'bytes(t: r._value)',
     category: 'Type Conversions',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/type-conversions/bytes/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/type-conversions/bytes/',
   },
   {
     name: 'chandeMomentumOscillator',
@@ -620,7 +620,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'chandeMomentumOscillator(n: 10)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/chandemomentumoscillator/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/chandemomentumoscillator/',
   },
   {
     name: 'columns',
@@ -637,7 +637,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'columns(column: "_value")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/columns/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/columns/',
   },
   {
     name: 'contains',
@@ -658,7 +658,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'contains(value: 1, set: [1,2,3])',
     category: 'Tests',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/tests/contains/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/tests/contains/',
   },
   {
     name: 'count',
@@ -674,7 +674,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'count(column: "_value")',
     category: 'Aggregates',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/aggregates/count/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/aggregates/count/',
   },
   {
     name: 'cov',
@@ -708,7 +708,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'cov(x: table1, y: table2, on: ["_time", "_field"], pearsonr: false)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/cov/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/cov/',
   },
   {
     name: 'covariance',
@@ -738,7 +738,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'covariance(columns: ["column_x", "column_y"], pearsonr: false, valueDst: "_value")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/covariance/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/covariance/',
   },
   {
     name: 'csv.from',
@@ -760,7 +760,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'csv.from(csv: csvData)',
     category: 'Inputs',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/csv/from/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/csv/from/',
   },
   {
     name: 'csv.from',
@@ -776,7 +776,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'csv.from(url: "http://example.com/data.csv")',
     category: 'Inputs',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/csv/from/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/csv/from/',
   },
   {
     name: 'cumulativeSum',
@@ -794,7 +794,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'cumulativeSum(columns: ["_value"])',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/cumulativesum/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/cumulativesum/',
   },
   {
     name: 'date.hour',
@@ -810,7 +810,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'date.hour(t: 2019-07-17T12:05:21.012Z)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/date/hour/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/date/hour/',
   },
   {
     name: 'date.microsecond',
@@ -827,7 +827,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'date.microsecond(t: 2019-07-17T12:05:21.012934584Z)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/date/microsecond/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/date/microsecond/',
   },
   {
     name: 'date.millisecond',
@@ -844,7 +844,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'date.millisecond(t: 2019-07-17T12:05:21.012934584Z)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/date/millisecond/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/date/millisecond/',
   },
   {
     name: 'date.minute',
@@ -861,7 +861,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'date.minute(t: 2019-07-17T12:05:21.012Z)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/date/minute/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/date/minute/',
   },
   {
     name: 'date.month',
@@ -877,7 +877,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'date.month(t: 2019-07-17T12:05:21.012Z)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/date/month/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/date/month/',
   },
   {
     name: 'date.monthDay',
@@ -894,7 +894,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'date.monthDay(t: 2019-07-17T12:05:21.012Z)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/date/monthday/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/date/monthday/',
   },
   {
     name: 'date.nanosecond',
@@ -911,7 +911,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'date.nanosecond(t: 2019-07-17T12:05:21.012934584Z)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/date/nanosecond/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/date/nanosecond/',
   },
   {
     name: 'date.quarter',
@@ -928,7 +928,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'date.quarter(t: 2019-07-17T12:05:21.012Z)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/date/quarter/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/date/quarter/',
   },
   {
     name: 'date.second',
@@ -945,7 +945,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'date.second(t: 2019-07-17T12:05:21.012Z)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/date/second/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/date/second/',
   },
   {
     name: 'date.truncate',
@@ -968,7 +968,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'date.truncate(t: 2019-07-17T12:05:21.012Z, unit: 1s)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/date/truncate/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/date/truncate/',
   },
   {
     name: 'date.week',
@@ -985,7 +985,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'date.week(t: 2019-07-17T12:05:21.012Z)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/date/week/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/date/week/',
   },
   {
     name: 'date.weekDay',
@@ -1002,7 +1002,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'date.weekDay(t: 2019-07-17T12:05:21.012Z)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/date/weekday/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/date/weekday/',
   },
   {
     name: 'date.year',
@@ -1018,7 +1018,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'date.year(t: 2019-07-17T12:05:21.012Z)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/date/year/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/date/year/',
   },
   {
     name: 'date.yearDay',
@@ -1035,7 +1035,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'date.yearDay(t: 2019-07-17T12:05:21.012Z)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/date/yearday/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/date/yearday/',
   },
   {
     name: 'derivative',
@@ -1070,7 +1070,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'derivative(unit: 1s, nonNegative: true, columns: ["_value"], timeColumn: "_time")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/derivative/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/derivative/',
   },
   {
     name: 'dict.fromList',
@@ -1092,7 +1092,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/dict/fromlist/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/dict/fromlist/',
   },
   {
     name: 'dict.get',
@@ -1124,7 +1124,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/dict/get/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/dict/get/',
   },
   {
     name: 'dict.insert',
@@ -1157,7 +1157,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/dict/insert/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/dict/insert/',
   },
   {
     name: 'dict.remove',
@@ -1183,7 +1183,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/dict/remove/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/dict/remove/',
   },
   {
     name: 'difference',
@@ -1213,7 +1213,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'difference(nonNegative: false, columns: ["_value"])',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/difference/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/difference/',
   },
   {
     name: 'discord.endpoint',
@@ -1249,7 +1249,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Alerting',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/discord/endpoint/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/contrib/discord/endpoint/',
   },
   {
     name: 'discord.send',
@@ -1292,7 +1292,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Alerting',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/discord/send/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/contrib/discord/send/',
   },
   {
     name: 'distinct',
@@ -1308,7 +1308,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'distinct(column: "host")',
     category: 'Selectors',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/selectors/distinct/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/selectors/distinct/',
   },
   {
     name: 'doubleEMA',
@@ -1325,7 +1325,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'doubleEMA(n: 5)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/doubleema/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/doubleema/',
   },
   {
     name: 'drop',
@@ -1349,7 +1349,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'drop(columns: ["col1", "col2"])',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/drop/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/drop/',
   },
   {
     name: 'duplicate',
@@ -1370,7 +1370,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'duplicate(column: "column-name", as: "duplicate-name")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/duplicate/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/duplicate/',
   },
   {
     name: 'duration',
@@ -1386,7 +1386,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'duration(v: r._value)',
     category: 'Type Conversions',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/type-conversions/duration/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/type-conversions/duration/',
   },
   {
     name: 'elapsed',
@@ -1413,7 +1413,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'elapsed(unit: 1s)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/elapsed/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/elapsed/',
   },
   {
     name: 'events.duration',
@@ -1458,7 +1458,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/events/duration/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/contrib/events/duration/',
   },
   {
     name: 'experimental.addDuration',
@@ -1480,7 +1480,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'experimental.addDuration(d: 12h, to: now())',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/addduration/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/addduration/',
   },
   {
     name: 'experimental.alignTime',
@@ -1496,7 +1496,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'experimental.alignTime(alignTo: v.timeRangeStart)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/aligntime/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/aligntime/',
   },
   {
     name: 'experimental.chain',
@@ -1518,7 +1518,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'experimental.chain(first: query1, second: query2)',
     category: 'Inputs',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/chain/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/chain/',
   },
   {
     name: 'experimental.count',
@@ -1529,7 +1529,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'experimental.count()',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/count/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/count/',
   },
   {
     name: 'experimental.distinct',
@@ -1540,7 +1540,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'experimental.distinct()',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/distinct/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/distinct/',
   },
   {
     name: 'experimental.fill',
@@ -1564,7 +1564,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'experimental.fill(value: 0.0)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/fill/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/fill/',
   },
   {
     name: 'experimental.first',
@@ -1575,7 +1575,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'experimental.first()',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/first/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/first/',
   },
   {
     name: 'experimental.group',
@@ -1599,7 +1599,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'experimental.group(columns: ["host", "_measurement"], mode: "extend")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/group/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/group/',
   },
   {
     name: 'experimental.histogram',
@@ -1626,7 +1626,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/histogram/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/histogram/',
   },
   {
     name: 'experimental.histogramQuantile',
@@ -1652,7 +1652,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/histogramquantile/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/histogramquantile/',
   },
   {
     name: 'experimental.integral',
@@ -1677,7 +1677,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/integral/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/integral/',
   },
   {
     name: 'experimental.join',
@@ -1706,7 +1706,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'experimental.join(left: left, right: right, fn: (left, right) => ({left with lv: left._value, rv: right._value }))',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/join/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/join/',
   },
   {
     name: 'experimental.kaufmansAMA',
@@ -1723,7 +1723,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'experimental.kaufmansAMA(n: 10)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/kaufmansama/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/kaufmansama/',
   },
   {
     name: 'experimental.last',
@@ -1734,7 +1734,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'experimental.last()',
     category: 'Aggregates',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/last/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/last/',
   },
   {
     name: 'experimental.max',
@@ -1745,7 +1745,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'experimental.max()',
     category: 'Aggregates',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/max/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/max/',
   },
   {
     name: 'experimental.mean',
@@ -1756,7 +1756,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'experimental.mean()',
     category: 'Aggregates',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/mean/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/mean/',
   },
   {
     name: 'experimental.min',
@@ -1767,7 +1767,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'experimental.min()',
     category: 'Aggregates',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/min/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/min/',
   },
   {
     name: 'experimental.mode',
@@ -1778,7 +1778,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'experimental.mode()',
     category: 'Aggregates',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/mode/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/mode/',
   },
   {
     name: 'experimental.objectKeys',
@@ -1794,7 +1794,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'experimental.objectKeys(o: {key1: "value1", key2: "value2"})',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/objectkeys/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/objectkeys/',
   },
   {
     name: 'experimental.quantile',
@@ -1827,7 +1827,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/quantile/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/quantile/',
   },
   {
     name: 'experimental.set',
@@ -1843,7 +1843,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'experimental.set(o: {column1: "value1", column2: "value2"})',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/set/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/set/',
   },
   {
     name: 'experimental.skew',
@@ -1854,7 +1854,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'experimental.skew()',
     category: 'Transformation',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/skew/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/skew/',
   },
   {
     name: 'experimental.spread',
@@ -1865,7 +1865,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'experimental.spread()',
     category: 'Transformation',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/spread/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/spread/',
   },
   {
     name: 'experimental.stddev',
@@ -1883,7 +1883,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'experimental.stddev(mode: "sample")',
     category: 'Aggregates',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/stddev/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/stddev/',
   },
   {
     name: 'experimental.subDuration',
@@ -1905,7 +1905,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'experimental.subDuration(d: 12h, from: now())',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/subduration/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/subduration/',
   },
   {
     name: 'experimental.sum',
@@ -1916,7 +1916,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'experimental.sum()',
     category: 'Aggregates',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/sum/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/sum/',
   },
   {
     name: 'experimental.to',
@@ -1952,7 +1952,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'experimental.to(bucket: "example-bucket", org: "example-org")',
     category: 'Outputs',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/to/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/to/',
   },
   {
     name: 'exponentialMovingAverage',
@@ -1969,7 +1969,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'exponentialMovingAverage(n: 5)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/exponentialmovingaverage/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/exponentialmovingaverage/',
   },
   {
     name: 'fill',
@@ -1998,7 +1998,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'fill(column: "_value", usePrevious: true)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/fill/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/fill/',
   },
   {
     name: 'filter',
@@ -2022,7 +2022,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'filter(fn: (r) => r._measurement == "cpu")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/filter/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/filter/',
   },
   {
     name: 'findColumn',
@@ -2044,7 +2044,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'findColumn(fn: (key) => key.host == "host1", column: "_value")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/stream-table/findcolumn/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/stream-table/findcolumn/',
   },
   {
     name: 'findRecord',
@@ -2066,7 +2066,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'findRecord(fn: (key) => key.host == "host1", idx: 0)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/stream-table/findrecord/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/stream-table/findrecord/',
   },
   {
     name: 'first',
@@ -2076,7 +2076,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'first()',
     category: 'Selectors',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/selectors/first/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/selectors/first/',
   },
   {
     name: 'float',
@@ -2092,7 +2092,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'float(v: r._value)',
     category: 'Type Conversions',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/type-conversions/float/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/type-conversions/float/',
   },
   FROM,
   {
@@ -2115,7 +2115,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'geo.asTracks(groupBy: ["id","tid"], orderBy: ["_time"])',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/geo/astracks/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/geo/astracks/',
   },
   {
     name: 'geo.filterRows',
@@ -2160,7 +2160,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'geo.filterRows(region: {lat: 37.7858229, lon: -122.4058124, radius: 20.0}, strict: true)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/geo/filterrows/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/geo/filterrows/',
   },
   {
     name: 'geo.gridFilter',
@@ -2200,7 +2200,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'geo.gridFilter(region: {lat: 37.7858229, lon: -122.4058124, radius: 20.0})',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/geo/gridfilter/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/geo/gridfilter/',
   },
   {
     name: 'geo.groupByArea',
@@ -2228,7 +2228,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'geo.groupByArea(newColumn: "geoArea", level: 10)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/geo/groupbyarea/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/geo/groupbyarea/',
   },
   {
     name: 'geo.s2CellIDToken',
@@ -2256,7 +2256,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'geo.s2CellIDToken(point: {lat: 37.7858229, lon: -122.4058124}, level: 10)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/geo/s2cellidtoken/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/geo/s2cellidtoken/',
   },
   {
     name: 'geo.s2CellLatLon',
@@ -2272,7 +2272,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'geo.s2CellLatLon(token: "89c284")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/geo/s2celllatlon/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/geo/s2celllatlon/',
   },
   {
     name: 'geo.shapeData',
@@ -2300,7 +2300,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'geo.shapeData(latField: "latitude", lonField: "longitude", level: 10)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/geo/shapedata/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/geo/shapedata/',
   },
   {
     name: 'geo.ST_Contains',
@@ -2323,7 +2323,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'geo.ST_Contains(region: {lat: 40.7, lon: -73.3, radius: 20.0}, geometry: {lon: 39.7515, lat: 15.08433})',
     category: 'Tests',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/geo/st_contains/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/geo/st_contains/',
   },
   {
     name: 'geo.ST_Distance',
@@ -2346,7 +2346,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'geo.ST_Distance(region: {lat: 40.7, lon: -73.3, radius: 20.0}, geometry: {lon: 39.7515, lat: 15.08433})',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/geo/st_distance/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/geo/st_distance/',
   },
   {
     name: 'geo.ST_DWithin',
@@ -2374,7 +2374,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'geo.ST_DWithin(region: {lat: 40.7, lon: -73.3, radius: 20.0}, geometry: {lon: 39.7515, lat: 15.08433}, distance: 1000.0)',
     category: 'Tests',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/geo/st_dwithin/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/geo/st_dwithin/',
   },
   {
     name: 'geo.ST_Intersects',
@@ -2397,7 +2397,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'geo.ST_Intersects(region: {lat: 40.7, lon: -73.3, radius: 20.0}, geometry: {linestring: "39.7515 14.01433, 38.3527 13.9228, 36.9978 15.08433"})',
     category: 'Tests',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/geo/st_intersects/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/geo/st_intersects/',
   },
   {
     name: 'geo.ST_Length',
@@ -2415,7 +2415,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'geo.ST_Length(geometry: {linestring: "39.7515 14.01433, 38.3527 13.9228, 36.9978 15.08433"})',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/geo/st_length/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/geo/st_length/',
   },
   {
     name: 'geo.ST_LineString',
@@ -2425,7 +2425,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'geo.ST_LineString()',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/geo/st_linestring/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/geo/st_linestring/',
   },
   {
     name: 'geo.strictFilter',
@@ -2442,7 +2442,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'geo.strictFilter(region: {lat: 37.7858229, lon: -122.4058124, radius: 20.0})',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/geo/strictfilter/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/geo/strictfilter/',
   },
   {
     name: 'geo.toRows',
@@ -2453,7 +2453,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'geo.toRows(correlationKey: ["_time"])',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/geo/torows/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/geo/torows/',
   },
   {
     name: 'getColumn',
@@ -2470,7 +2470,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'getColumn(column: "_value")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/stream-table/getcolumn/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/stream-table/getcolumn/',
   },
   {
     name: 'getRecord',
@@ -2487,7 +2487,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'getRecord(idx: 0)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/stream-table/getrecord/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/stream-table/getrecord/',
   },
   {
     name: 'group',
@@ -2511,7 +2511,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'group(columns: ["host", "_measurement"], mode:"by")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/group/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/group/',
   },
   {
     name: 'highestAverage',
@@ -2539,7 +2539,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'highestAverage(n:10, groupColumns: ["host"])',
     category: 'Selectors',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/selectors/highestaverage/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/selectors/highestaverage/',
   },
   {
     name: 'highestCurrent',
@@ -2567,7 +2567,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'highestCurrent(n:10, groupColumns: ["host"])',
     category: 'Selectors',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/selectors/highestcurrent/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/selectors/highestcurrent/',
   },
   {
     name: 'highestMax',
@@ -2595,7 +2595,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'highestMax(n:10, groupColumns: ["host"])',
     category: 'Selectors',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/selectors/highestmax/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/selectors/highestmax/',
   },
   {
     name: 'histogram',
@@ -2638,7 +2638,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'histogram(column: "_value", upperBoundColumn: "le", countColumn: "_value", bins: [50.0, 75.0, 90.0], normalize: false)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/histogram/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/histogram/',
   },
   {
     name: 'histogramQuantile',
@@ -2681,7 +2681,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'histogramQuantile(quantile: 0.5, countColumn: "_value", upperBoundColumn: "le", valueColumn: "_value", minValue: 0.0)',
     category: 'Aggregates',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/aggregates/histogramquantile/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/aggregates/histogramquantile/',
   },
   {
     name: 'holtWinters',
@@ -2724,7 +2724,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'holtWinters(n: 10, interval: 1d)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/holtwinters/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/holtwinters/',
   },
   {
     name: 'hourSelection',
@@ -2753,7 +2753,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'hourSelection(start: 9, stop: 17)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/hourselection/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/hourselection/',
   },
   {
     name: 'http.basicAuth',
@@ -2778,7 +2778,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Miscellaneous',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/http/basicauth/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/http/basicauth/',
   },
   {
     name: 'http.endpoint',
@@ -2797,7 +2797,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Alerting',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/http/endpoint/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/http/endpoint/',
   },
   {
     name: 'http.get',
@@ -2825,7 +2825,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'http.get(url: "https://docs.influxdata.com/influxdb/v2.0/", headers: {foo: "bar"})',
     category: 'Miscellaneous',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/http/get/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/http/get/',
   },
   {
     name: 'http.pathEscape',
@@ -2842,7 +2842,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'http.pathEscape(inputString: "/this/is/an/example-path.html")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/http/pathescape/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/http/pathescape/',
   },
   {
     name: 'http.post',
@@ -2870,7 +2870,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'http.post(url: "http://localhost:8086/", headers: {x:"a", y:"b"}, data: bytes(v: "body"))',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/http/post/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/http/post/',
   },
   {
     name: 'increase',
@@ -2888,7 +2888,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'increase(columns: ["_value"])',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/increase/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/increase/',
   },
   {
     name: 'influxdb.api',
@@ -2951,7 +2951,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Outputs',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/influxdb/api/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/influxdb/api/',
   },
   {
     name: 'influxdb.cardinality',
@@ -3008,7 +3008,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'influxdb.cardinality(bucket: "example-bucket", start: -1h)',
     category: 'Miscellaneous',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/influxdb/cardinality/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/influxdb/cardinality/',
   },
   {
     name: 'influxdb.select',
@@ -3079,7 +3079,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Miscellaneous',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/influxdb/select/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/contrib/influxdb/select/',
   },
   {
     name: 'int',
@@ -3095,7 +3095,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'int(v: r._value)',
     category: 'Type Conversions',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/type-conversions/int/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/type-conversions/int/',
   },
   {
     name: 'integral',
@@ -3128,7 +3128,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'integral(unit: 10s, column: "_value")',
     category: 'Aggregates',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/aggregates/integral/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/aggregates/integral/',
   },
   {
     name: 'interpolate.linear',
@@ -3145,7 +3145,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'interpolate.linear(every: 1m)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/interpolate/linear/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/interpolate/linear/',
   },
   {
     name: 'join',
@@ -3174,7 +3174,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'join(tables: {key1: table1, key2: table2}, on: ["_time", "_field"], method: "inner")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/join/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/join/',
   },
   {
     name: 'json.encode',
@@ -3190,7 +3190,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'json.encode(v: r._value)',
     category: 'Type Conversions',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/json/encode/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/json/encode/',
   },
   {
     name: 'json.parse',
@@ -3206,7 +3206,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'json.parse(data: bytes(v: "{"a":1,"b":2,"c":3}"))',
     category: 'Miscellaneous',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/json/parse/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/json/parse/',
   },
   {
     name: 'kaufmansAMA',
@@ -3228,7 +3228,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'kaufmansAMA(n: 5)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/kaufmansama/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/kaufmansama/',
   },
   {
     name: 'kaufmansER',
@@ -3245,7 +3245,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'kaufmansER(n: 5)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/kaufmanser/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/kaufmanser/',
   },
   {
     name: 'keep',
@@ -3269,7 +3269,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'keep(columns: ["col1", "col2"])',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/keep/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/keep/',
   },
   {
     name: 'keys',
@@ -3287,7 +3287,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'keys(column: "_value")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/keys/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/keys/',
   },
   {
     name: 'keyValues',
@@ -3305,7 +3305,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'keyValues(keyColumns: ["usage_idle", "usage_user"])',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/keyvalues/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/keyvalues/',
   },
   {
     name: 'last',
@@ -3315,7 +3315,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'last()',
     category: 'Selectors',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/selectors/last/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/selectors/last/',
   },
   {
     name: 'length',
@@ -3331,7 +3331,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'length(arr: ["john"])',
     category: 'Miscellaneous',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/misc/length/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/misc/length/',
   },
   {
     name: 'limit',
@@ -3354,7 +3354,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'limit(n:10, offset: 0)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/limit/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/limit/',
   },
   {
     name: 'linearBins',
@@ -3386,7 +3386,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'linearBins(start: 0.0, width: 5.0, count: 20, infinity: true)',
     category: 'Miscellaneous',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/misc/linearbins/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/misc/linearbins/',
   },
   {
     name: 'logarithmicBins',
@@ -3419,7 +3419,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'logarithmicBins(start: 1.0, factor: 2.0, count: 10, infinity: true)',
     category: 'Miscellaneous',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/misc/logarithmicbins/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/misc/logarithmicbins/',
   },
   {
     name: 'lowestAverage',
@@ -3447,7 +3447,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'lowestAverage(n:10, groupColumns: ["host"])',
     category: 'Selectors',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/selectors/lowestaverage/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/selectors/lowestaverage/',
   },
   {
     name: 'lowestCurrent',
@@ -3475,7 +3475,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'lowestCurrent(n:10, groupColumns: ["host"])',
     category: 'Selectors',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/selectors/lowestcurrent/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/selectors/lowestcurrent/',
   },
   {
     name: 'lowestMin',
@@ -3503,7 +3503,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'lowestMin(n:10, groupColumns: ["host"])',
     category: 'Selectors',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/selectors/lowestmin/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/selectors/lowestmin/',
   },
   {
     name: 'map',
@@ -3520,7 +3520,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'map(fn: (r) => ({ r with _value: r._value * r._value }))',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/map/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/map/',
   },
   MATH_ABS,
   {
@@ -3537,7 +3537,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.acos(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/acos/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/acos/',
   },
   {
     name: 'math.acosh',
@@ -3553,7 +3553,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.acosh(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/acosh/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/acosh/',
   },
   {
     name: 'math.asin',
@@ -3570,7 +3570,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.asin(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/asin/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/asin/',
   },
   {
     name: 'math.asinh',
@@ -3586,7 +3586,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.asinh(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/asinh/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/asinh/',
   },
   {
     name: 'math.atan',
@@ -3602,7 +3602,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.atan(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/atan/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/atan/',
   },
   {
     name: 'math.atan2',
@@ -3624,7 +3624,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.atan2(y: r.y_coord, x: r.x_coord)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/atan2/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/atan2/',
   },
   {
     name: 'math.atanh',
@@ -3641,7 +3641,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.atanh(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/atanh/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/atanh/',
   },
   {
     name: 'math.cbrt',
@@ -3657,7 +3657,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.cbrt(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/cbrt/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/cbrt/',
   },
   {
     name: 'math.ceil',
@@ -3673,7 +3673,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.ceil(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/ceil/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/ceil/',
   },
   {
     name: 'math.copysign',
@@ -3694,7 +3694,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.copysign(x: r._magnitude, r._sign)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/copysign/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/copysign/',
   },
   {
     name: 'math.cos',
@@ -3710,7 +3710,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.cos(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/cos/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/cos/',
   },
   {
     name: 'math.cosh',
@@ -3726,7 +3726,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.cosh(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/cosh/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/cosh/',
   },
   {
     name: 'math.dim',
@@ -3747,7 +3747,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.dim(x: r._value1, y: r._value2)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/dim/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/dim/',
   },
   {
     name: 'math.erf',
@@ -3763,7 +3763,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.erf(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/erf/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/erf/',
   },
   {
     name: 'math.erfc',
@@ -3779,7 +3779,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.erfc(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/erfc/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/erfc/',
   },
   {
     name: 'math.erfcinv',
@@ -3796,7 +3796,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.erfcinv(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/erfcinv/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/erfcinv/',
   },
   {
     name: 'math.erfinv',
@@ -3813,7 +3813,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.erfinv(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/erfinv/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/erfinv/',
   },
   {
     name: 'math.exp',
@@ -3829,7 +3829,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.exp(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/exp/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/exp/',
   },
   {
     name: 'math.exp2',
@@ -3845,7 +3845,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.exp2(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/exp2/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/exp2/',
   },
   {
     name: 'math.expm1',
@@ -3861,7 +3861,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.expm1(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/expm1/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/expm1/',
   },
   {
     name: 'math.float64bits',
@@ -3878,7 +3878,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.float64bits(f: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/float64bits/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/float64bits/',
   },
   MATH_FLOOR,
   {
@@ -3895,7 +3895,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.frexp(f: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/frexp/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/frexp/',
   },
   {
     name: 'math.gamma',
@@ -3911,7 +3911,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.gamma(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/gamma/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/gamma/',
   },
   {
     name: 'math.hypot',
@@ -3933,7 +3933,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.hypot(p: r.opp, p: r.adj)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/hypot/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/hypot/',
   },
   {
     name: 'math.ilogb',
@@ -3949,7 +3949,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.ilogb(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/ilogb/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/ilogb/',
   },
   {
     name: 'math.isInf',
@@ -3970,7 +3970,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.isInf(f: r._value, sign: r.sign)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/isinf/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/isinf/',
   },
   {
     name: 'math.isNaN',
@@ -3986,7 +3986,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.isNaN(f: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/isnan/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/isnan/',
   },
   {
     name: 'math.j0',
@@ -4002,7 +4002,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.j0(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/j0/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/j0/',
   },
   {
     name: 'math.j1',
@@ -4018,7 +4018,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.j1(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/j1/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/j1/',
   },
   {
     name: 'math.jn',
@@ -4039,7 +4039,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.jn(n: 2, x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/jn/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/jn/',
   },
   {
     name: 'math.ldexp',
@@ -4060,7 +4060,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.ldexp(frac: r.frac, exp: r.exp)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/ldexp/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/ldexp/',
   },
   {
     name: 'math.lgamma',
@@ -4077,7 +4077,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.lgamma(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/lgamma/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/lgamma/',
   },
   {
     name: 'math.log',
@@ -4093,7 +4093,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.log(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/log/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/log/',
   },
   {
     name: 'math.log10',
@@ -4109,7 +4109,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.log10(x: 3.14)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/log10/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/log10/',
   },
   {
     name: 'math.log1p',
@@ -4125,7 +4125,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.log1p(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/log1p/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/log1p/',
   },
   {
     name: 'math.log2',
@@ -4141,7 +4141,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.log2(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/log2/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/log2/',
   },
   {
     name: 'math.logb',
@@ -4157,7 +4157,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.logb(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/logb/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/logb/',
   },
   {
     name: 'math.mInf',
@@ -4174,7 +4174,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.mInf(sign: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/minf/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/minf/',
   },
   {
     name: 'math.mMax',
@@ -4195,7 +4195,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.mMax(x: r.x_value, y: r.y_value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/mmax/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/mmax/',
   },
   {
     name: 'math.mMin',
@@ -4216,7 +4216,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.mMin(x: r.x_value, y: r.y_value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/mmin/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/mmin/',
   },
   {
     name: 'math.mod',
@@ -4237,7 +4237,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.mod(x: r.x_value, y: r.y_value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/mod/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/mod/',
   },
   {
     name: 'math.modf',
@@ -4254,7 +4254,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.modf(f: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/modf/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/modf/',
   },
   {
     name: 'math.NaN',
@@ -4264,7 +4264,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.NaN()',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/nan/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/nan/',
   },
   {
     name: 'math.nextafter',
@@ -4285,7 +4285,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.nextafter(x: r.x_value, y: r.y_value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/nextafter/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/nextafter/',
   },
   {
     name: 'math.pow',
@@ -4306,7 +4306,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.pow(x: r.x_value, y: r.y_value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/pow/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/pow/',
   },
   {
     name: 'math.pow10',
@@ -4322,7 +4322,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.pow10(n: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/pow10/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/pow10/',
   },
   {
     name: 'math.remainder',
@@ -4343,7 +4343,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.remainder(x: r.numerator, y: r.denominator)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/remainder/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/remainder/',
   },
   {
     name: 'math.round',
@@ -4359,7 +4359,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.round(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/round/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/round/',
   },
   {
     name: 'math.roundtoeven',
@@ -4375,7 +4375,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.roundtoeven(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/roundtoeven/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/roundtoeven/',
   },
   {
     name: 'math.signbit',
@@ -4391,7 +4391,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.signbit(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/signbit/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/signbit/',
   },
   {
     name: 'math.sin',
@@ -4407,7 +4407,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.sin(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/sin/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/sin/',
   },
   {
     name: 'math.sincos',
@@ -4423,7 +4423,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.sincos(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/sincos/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/sincos/',
   },
   {
     name: 'math.sinh',
@@ -4439,7 +4439,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.sinh(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/sinh/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/sinh/',
   },
   {
     name: 'math.sqrt',
@@ -4455,7 +4455,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.sqrt(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/sqrt/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/sqrt/',
   },
   {
     name: 'math.tan',
@@ -4471,7 +4471,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.tan(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/tan/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/tan/',
   },
   {
     name: 'math.tanh',
@@ -4487,7 +4487,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.tanh(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/tanh/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/tanh/',
   },
   {
     name: 'math.trunc',
@@ -4503,7 +4503,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.trunc(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/trunc/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/trunc/',
   },
   {
     name: 'math.y0',
@@ -4519,7 +4519,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.y0(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/y0/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/y0/',
   },
   {
     name: 'math.y1',
@@ -4535,7 +4535,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.y1(x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/y1/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/y1/',
   },
   {
     name: 'math.yn',
@@ -4556,7 +4556,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'math.yn(n: 3, x: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/yn/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/math/yn/',
   },
   {
     name: 'max',
@@ -4566,7 +4566,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'max()',
     category: 'Selectors',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/selectors/max/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/selectors/max/',
   },
   MEAN,
   {
@@ -4584,7 +4584,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'median(column: "_value")',
     category: 'Aggregates',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/aggregates/median/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/aggregates/median/',
   },
   {
     name: 'min',
@@ -4594,7 +4594,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'min()',
     category: 'Selectors',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/selectors/min/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/selectors/min/',
   },
   {
     name: 'mode',
@@ -4611,7 +4611,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'mode(column: "_value")',
     category: 'Aggregates',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/aggregates/mode/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/aggregates/mode/',
   },
   {
     name: 'monitor.check',
@@ -4665,7 +4665,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Transformation',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/monitor/check/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/monitor/check/',
   },
   {
     name: 'monitor.deadman',
@@ -4682,7 +4682,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: `monitor.deadman(t: 2019-08-30T12:30:00Z)`,
     category: 'Transformation',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/monitor/deadman/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/monitor/deadman/',
   },
   {
     name: 'monitor.from',
@@ -4714,7 +4714,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Inputs',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/monitor/from/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/monitor/from/',
   },
   {
     name: 'monitor.logs',
@@ -4746,7 +4746,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Inputs',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/monitor/logs/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/monitor/logs/',
   },
   {
     name: 'monitor.notify',
@@ -4772,7 +4772,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Alerting',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/monitor/notify/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/monitor/notify/',
   },
   {
     name: 'monitor.stateChanges',
@@ -4798,7 +4798,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Transformation',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/monitor/statechanges/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/monitor/statechanges/',
   },
   {
     name: 'monitor.stateChangesOnly',
@@ -4809,7 +4809,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: `monitor.stateChangesOnly()`,
     category: 'Transformation',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/monitor/statechangesonly/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/monitor/statechangesonly/',
   },
   {
     name: 'movingAverage',
@@ -4825,7 +4825,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'movingAverage(n: 5)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/movingaverage/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/movingaverage/',
   },
   {
     name: 'mqtt.to',
@@ -4902,7 +4902,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'mqtt.to(broker: "tcp://localhost:8883", topic: "example-topic", clientid: "exampleID", tagColumns: ["exampleTagKey"], valueColumns: ["_value"])',
     category: 'Outputs',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/mqtt/to/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/mqtt/to/',
   },
   {
     name: 'now',
@@ -4913,7 +4913,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'now()',
     category: 'Miscellaneous',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/misc/now/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/misc/now/',
   },
   {
     name: 'oee.APQ',
@@ -4944,7 +4944,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/oee/apq/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/oee/apq/',
   },
   {
     name: 'oee.computeAPQ',
@@ -4989,7 +4989,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/oee/computeapq/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/oee/computeapq/',
   },
   {
     name: 'opsgenie.endpoint',
@@ -5021,7 +5021,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Alerting',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/opsgenie/endpoint/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/contrib/opsgenie/endpoint/',
   },
   {
     name: 'opsgenie.sendAlert',
@@ -5111,7 +5111,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Alerting',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/opsgenie/sendalert/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/contrib/opsgenie/sendalert/',
   },
   {
     name: 'pagerduty.actionFromSeverity',
@@ -5128,7 +5128,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'pagerduty.actionFromSeverity(severity: "ok")',
     category: 'Alerting',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/pagerduty/actionfromseverity/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/pagerduty/actionfromseverity/',
   },
   {
     name: 'pagerduty.dedupKey',
@@ -5139,7 +5139,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'pagerduty.dedupKey()',
     category: 'Alerting',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/pagerduty/dedupkey/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/pagerduty/dedupkey/',
   },
   {
     name: 'pagerduty.endpoint',
@@ -5159,7 +5159,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Alerting',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/pagerduty/endpoint/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/pagerduty/endpoint/',
   },
   {
     name: 'pagerduty.sendEvent',
@@ -5249,7 +5249,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Alerting',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/pagerduty/sendevent/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/pagerduty/sendevent/',
   },
   {
     name: 'pagerduty.severityFromLevel',
@@ -5265,7 +5265,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'pagerduty.severityFromLevel(level: "crit")',
     category: 'Alerting',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/pagerduty/severityfromlevel/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/pagerduty/severityfromlevel/',
   },
   {
     name: 'pearsonr',
@@ -5292,7 +5292,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'pearsonr(x: table1, y: table2, on: ["_time", "_field"])',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/pearsonr/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/pearsonr/',
   },
   {
     name: 'pivot',
@@ -5322,7 +5322,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/pivot/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/pivot/',
   },
   {
     name: 'prometheus.histogramQuantile',
@@ -5339,7 +5339,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'prometheus.histogramQuantile(quantile: 0.99)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/prometheus/histogramquantile/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/prometheus/histogramquantile/',
   },
   {
     name: 'prometheus.scrape',
@@ -5355,7 +5355,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'prometheus.scrape(url: "http://localhost:9999/metrics")',
     category: 'Inputs',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/prometheus/scrape/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/prometheus/scrape/',
   },
   {
     name: 'pushbullet.endpoint',
@@ -5382,7 +5382,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Alerting',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/pushbullet/endpoint/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/pushbullet/endpoint/',
   },
   {
     name: 'pushbullet.pushData',
@@ -5420,7 +5420,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Alerting',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/pushbullet/pushdata/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/pushbullet/pushdata/',
   },
   {
     name: 'pushbullet.pushData',
@@ -5458,7 +5458,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Outputs',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/pushbullet/pushnote/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/pushbullet/pushnote/',
   },
   {
     name: 'quantile',
@@ -5494,7 +5494,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'quantile(column: "_value", q: 0.99, method: "estimate_tdigest", compression: 1000.0)',
     category: 'Aggregates',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/aggregates/quantile/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/aggregates/quantile/',
   },
   {
     name: 'query.filterFields',
@@ -5510,7 +5510,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'query.filterFields(fields: ["field_name"])',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/query/filterfields/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/query/filterfields/',
   },
   {
     name: 'query.filterMeasurement',
@@ -5526,7 +5526,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'query.filterMeasurement(measurement: "measurement_name")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/query/filtermeasurement/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/query/filtermeasurement/',
   },
   {
     name: 'query.fromRange',
@@ -5553,7 +5553,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'query.fromRange(bucket: "example-bucket", start: v.timeRangeStart)',
     category: 'Inputs',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/query/fromrange/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/query/fromrange/',
   },
   {
     name: 'query.inBucket',
@@ -5596,7 +5596,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'query.inBucket(bucket: "example-bucket", start: v.timeRangeStart, measurement: "measurement_name", fields: ["field_name"], predicate: (r) => r.host == "host1")',
     category: 'Inputs',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/query/inbucket/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/query/inbucket/',
   },
   RANGE,
   {
@@ -5621,7 +5621,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'reduce(fn: (r, accumulator) => ({ sum: r._value + accumulator.sum }), identity: {sum: 0.0})',
     category: 'Aggregates',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/aggregates/reduce/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/aggregates/reduce/',
   },
   {
     name: 'regexp.compile',
@@ -5638,7 +5638,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'regexp.compile(v: "[a-zA-Z]")',
     category: 'Type Conversions',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/regexp/compile/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/regexp/compile/',
   },
   {
     name: 'regexp.findString',
@@ -5659,7 +5659,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'regexp.findString(r: /foo.?/, v: "seafood fool")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/regexp/findstring/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/regexp/findstring/',
   },
   {
     name: 'regexp.findStringIndex',
@@ -5681,7 +5681,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'regexp.findStringIndex(r: /ab?/, v: "tablet")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/regexp/findstringindex/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/regexp/findstringindex/',
   },
   {
     name: 'regexp.getString',
@@ -5697,7 +5697,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'regexp.getString(r: /[a-zA-Z]/)',
     category: 'Type Conversions',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/regexp/getstring/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/regexp/getstring/',
   },
   {
     name: 'regexp.matchRegexpString',
@@ -5718,7 +5718,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'regexp.matchRegexpString(r: /(go){2}/, v: "gogogopher")',
     category: 'Tests',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/regexp/matchregexpstring/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/regexp/matchregexpstring/',
   },
   {
     name: 'regexp.quoteMeta',
@@ -5735,7 +5735,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'regexp.quoteMeta(v: ".+*?()|[]{}^$")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/regexp/quotemeta/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/regexp/quotemeta/',
   },
   {
     name: 'regexp.replaceAllString',
@@ -5762,7 +5762,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'regexp.replaceAllString(r: /a(x*)b/, v: "-ab-axxb-", t: "T")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/regexp/replaceallstring/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/regexp/replaceallstring/',
   },
   {
     name: 'regexp.splitRegexp',
@@ -5789,7 +5789,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'regexp.splitRegexp(r: /a*/, v: "abaabaccadaaae", i: 5)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/regexp/splitregexp/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/regexp/splitregexp/',
   },
   {
     name: 'relativeStrengthIndex',
@@ -5811,7 +5811,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'relativeStrengthIndex(n: 5)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/relativestrengthindex/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/relativestrengthindex/',
   },
   {
     name: 'rename',
@@ -5835,7 +5835,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'rename(columns: {host: "server", _field: "my_field"})',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/rename/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/rename/',
   },
   {
     name: 'rows.map',
@@ -5853,7 +5853,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'rows.map( fn: (r) => ({_value: r._value * 100.0}))',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/rows/map/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/contrib/rows/map/',
   },
   {
     name: 'runtime.version',
@@ -5863,7 +5863,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'runtime.version()',
     category: 'Miscellaneous',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/runtime/version/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/runtime/version/',
   },
   {
     name: 'sample',
@@ -5885,7 +5885,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'sample(n:5, pos: -1)',
     category: 'Selectors',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/selectors/sample/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/selectors/sample/',
   },
   {
     name: 'schema.fieldKeys',
@@ -5912,7 +5912,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'schema.fieldKeys(bucket: "example-bucket")',
     category: 'Inputs',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/influxdb-schema/measurementfieldkeys/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/influxdb-schema/measurementfieldkeys/',
   },
   {
     name: 'schema.fieldsAsCols',
@@ -5922,7 +5922,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'schema.fieldsAsCols()',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/influxdb-schema/fieldsascols/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/influxdb-schema/fieldsascols/',
   },
   {
     name: 'schema.measurementFieldKeys',
@@ -5949,7 +5949,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'schema.measurementFieldKeys(bucket: "example-bucket", measurement: "example-measurement")',
     category: 'Inputs',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/influxdb-schema/measurementfieldkeys/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/influxdb-schema/measurementfieldkeys/',
   },
   {
     name: 'schema.measurements',
@@ -5965,7 +5965,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'schema.measurements(bucket: "example-bucket")',
     category: 'Inputs',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/influxdb-schema/measurements/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/influxdb-schema/measurements/',
   },
   {
     name: 'schema.measurementTagKeys',
@@ -5988,7 +5988,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'schema.measurementTagKeys(bucket: "example-bucket", measurement: "mem")',
     category: 'Inputs',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/influxdb-schema/measurementtagkeys/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/influxdb-schema/measurementtagkeys/',
   },
   {
     name: 'schema.measurementTagValues',
@@ -6016,7 +6016,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'schema.measurementTagValues(bucket: "example-bucket", measurement: "mem", tag: "host")',
     category: 'Inputs',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/influxdb-schema/measurementtagvalues/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/influxdb-schema/measurementtagvalues/',
   },
   {
     name: 'schema.tagKeys',
@@ -6044,7 +6044,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'schema.tagKeys(bucket: "example-bucket")',
     category: 'Inputs',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/influxdb-schema/tagkeys/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/influxdb-schema/tagkeys/',
   },
   {
     name: 'schema.tagValues',
@@ -6077,7 +6077,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'schema.tagValues(bucket: "example-bucket", tag: "example-tag")',
     category: 'Inputs',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/influxdb-schema/tagvalues/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/influxdb-schema/tagvalues/',
   },
   {
     name: 'secrets.get',
@@ -6093,7 +6093,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'secrets.get(key: "KEY_NAME")',
     category: 'Miscellaneous',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/secrets/get/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/secrets/get/',
   },
   {
     name: 'sensu.endpoint',
@@ -6138,7 +6138,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Alerting',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/sensu/endpoint/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/contrib/sensu/endpoint/',
   },
   {
     name: 'sensu.event',
@@ -6208,7 +6208,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Alerting',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/sensu/event/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/contrib/sensu/event/',
   },
   {
     name: 'set',
@@ -6230,7 +6230,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'set(key: "_field", value: "my_field")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/set/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/set/',
   },
   {
     name: 'skew',
@@ -6246,7 +6246,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'skew(column: "_value")',
     category: 'Aggregates',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/aggregates/skew/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/aggregates/skew/',
   },
   {
     name: 'slack.endpoint',
@@ -6273,7 +6273,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Alerting',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/slack/endpoint/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/slack/endpoint/',
   },
   {
     name: 'slack.message',
@@ -6317,7 +6317,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Alerting',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/slack/message/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/slack/message/',
   },
   {
     name: 'sleep',
@@ -6338,7 +6338,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'sleep(duration: 5s)',
     category: 'Miscellaneous',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/misc/sleep/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/misc/sleep/',
   },
   {
     name: 'sort',
@@ -6361,7 +6361,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'sort(columns: ["_value"], desc: false)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/sort/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/sort/',
   },
   {
     name: 'spread',
@@ -6378,7 +6378,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'spread(column: "_value")',
     category: 'Aggregates',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/aggregates/spread/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/aggregates/spread/',
   },
   {
     name: 'sql.from',
@@ -6406,7 +6406,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'sql.from(driverName: "postgres", dataSourceName: "postgresql://user:password@localhost", query:"SELECT * FROM example_table")',
     category: 'Inputs',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/sql/from/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/sql/from/',
   },
   {
     name: 'sql.to',
@@ -6440,7 +6440,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'sql.to(driverName: "postgres", dataSourceName: "postgresql://user:password@localhost", table: "example_table")',
     category: 'Outputs',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/sql/to/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/sql/to/',
   },
   {
     name: 'stateCount',
@@ -6464,7 +6464,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'stateCount(fn: (r) => r._field == "state", column: "stateCount")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/statecount/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/statecount/',
   },
   {
     name: 'stateDuration',
@@ -6494,7 +6494,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'stateDuration(fn: (r) => r._measurement == "state", column: "stateDuration", unit: 1s)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/stateduration/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/stateduration/',
   },
   {
     name: 'stddev',
@@ -6517,7 +6517,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'stddev(column: "_value", mode: "sample")',
     category: 'Aggregates',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/aggregates/stddev/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/aggregates/stddev/',
   },
   {
     name: 'string',
@@ -6533,7 +6533,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'string(v: r._value)',
     category: 'Type Conversions',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/type-conversions/string/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/type-conversions/string/',
   },
   {
     name: 'strings.compare',
@@ -6554,7 +6554,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'strings.compare(v: "a", t: "b")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/strings/compare/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/strings/compare/',
   },
   {
     name: 'strings.containsAny',
@@ -6576,7 +6576,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'strings.containsAny(v: "abc", chars: "and")',
     category: 'Tests',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/strings/containsany/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/strings/containsany/',
   },
   {
     name: 'strings.containsStr',
@@ -6597,7 +6597,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'strings.containsStr(v: "This and that", substr: "and")',
     category: 'Tests',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/strings/containsstr/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/strings/containsstr/',
   },
   {
     name: 'strings.countStr',
@@ -6619,7 +6619,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'strings.countStr(v: "Hello mellow fellow", substr: "ello")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/strings/countstr/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/strings/countstr/',
   },
   {
     name: 'strings.equalFold',
@@ -6641,7 +6641,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'strings.equalFold(v: "Go", t: "go")',
     category: 'Tests',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/strings/equalfold/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/strings/equalfold/',
   },
   {
     name: 'strings.hasPrefix',
@@ -6662,7 +6662,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'strings.hasPrefix(v: "go gopher", prefix: "go")',
     category: 'Tests',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/strings/hasprefix/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/strings/hasprefix/',
   },
   {
     name: 'strings.hasSuffix',
@@ -6683,7 +6683,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'strings.hasSuffix(v: "gopher go", suffix: "go")',
     category: 'Tests',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/strings/hassuffix/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/strings/hassuffix/',
   },
   {
     name: 'strings.index',
@@ -6705,7 +6705,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'strings.index(v: "go gopher", substr: "go")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/strings/index-func/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/strings/index-func/',
   },
   {
     name: 'strings.indexAny',
@@ -6727,7 +6727,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'strings.indexAny(v: "chicken", chars: "aeiouy")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/strings/indexany/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/strings/indexany/',
   },
   {
     name: 'strings.isDigit',
@@ -6743,7 +6743,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'strings.isDigit(v: "7")',
     category: 'Tests',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/strings/isdigit/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/strings/isdigit/',
   },
   {
     name: 'strings.isLetter',
@@ -6759,7 +6759,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'strings.isLetter(v: "A")',
     category: 'Tests',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/strings/isletter/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/strings/isletter/',
   },
   {
     name: 'strings.isLower',
@@ -6775,7 +6775,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'strings.isLower(v: "a")',
     category: 'Tests',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/strings/islower/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/strings/islower/',
   },
   {
     name: 'strings.isUpper',
@@ -6791,7 +6791,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'strings.isUpper(v: "A")',
     category: 'Tests',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/strings/isupper/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/strings/isupper/',
   },
   {
     name: 'strings.joinStr',
@@ -6813,7 +6813,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'strings.joinStr(arr: ["a", "b", "c"], v: ",")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/strings/joinstr/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/strings/joinstr/',
   },
   {
     name: 'strings.lastIndex',
@@ -6835,7 +6835,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'strings.lastIndex(v: "go gopher", substr: "go")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/strings/lastindex/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/strings/lastindex/',
   },
   {
     name: 'strings.lastIndexAny',
@@ -6857,7 +6857,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'strings.lastIndexAny(v: "chicken", chars: "aeiouy")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/strings/lastindexany/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/strings/lastindexany/',
   },
   {
     name: 'strings.repeat',
@@ -6878,7 +6878,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'strings.repeat(v: "ha", i: 3)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/strings/repeat/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/strings/repeat/',
   },
   {
     name: 'strings.replace',
@@ -6910,7 +6910,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'strings.replace(v: "oink oink oink", t: "oink", u: "moo", i: 2)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/strings/replace/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/strings/replace/',
   },
   {
     name: 'strings.replaceAll',
@@ -6937,7 +6937,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'strings.replaceAll(v: "oink oink oink", t: "oink", u: "moo")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/strings/replaceall/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/strings/replaceall/',
   },
   {
     name: 'strings.split',
@@ -6959,7 +6959,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'strings.split(v: "a flux of foxes", t: " ")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/strings/split/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/strings/split/',
   },
   {
     name: 'strings.splitAfter',
@@ -6981,7 +6981,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'strings.splitAfter(v: "a flux of foxes", t: " ")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/strings/splitafter/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/strings/splitafter/',
   },
   {
     name: 'strings.splitAfterN',
@@ -7008,7 +7008,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'strings.splitAfterN(v: "a flux of foxes", t: " ", i: 2)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/strings/splitaftern/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/strings/splitaftern/',
   },
   {
     name: 'strings.splitN',
@@ -7035,7 +7035,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'strings.splitN(v: "a flux of foxes", t: " ", i: 2)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/strings/splitn/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/strings/splitn/',
   },
   {
     name: 'strings.strlen',
@@ -7051,7 +7051,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'strings.strlen(v: "a flux of foxes")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/strings/strlen/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/strings/strlen/',
   },
   {
     name: 'strings.substring',
@@ -7077,7 +7077,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'strings.substring(v: "influx", start: 0, end: 3)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/strings/substring/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/strings/substring/',
   },
   STRINGS_TITLE,
   {
@@ -7094,7 +7094,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'strings.toLower(v: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/strings/tolower/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/strings/tolower/',
   },
   {
     name: 'strings.toTitle',
@@ -7110,7 +7110,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'strings.toTitle(v: "a flux of foxes")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/strings/totitle/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/strings/totitle/',
   },
   {
     name: 'strings.toUpper',
@@ -7126,7 +7126,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'strings.toUpper(v: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/strings/toupper/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/strings/toupper/',
   },
   STRINGS_TRIM,
   {
@@ -7148,7 +7148,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'strings.trimLeft(v: ".abc", cutset: ".")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/strings/trimleft/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/strings/trimleft/',
   },
   {
     name: 'strings.trimPrefix',
@@ -7170,7 +7170,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'strings.trimPrefix(v: r._value, prefix: "abc_")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/strings/trimprefix/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/strings/trimprefix/',
   },
   {
     name: 'strings.trimRight',
@@ -7191,7 +7191,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'strings.trimRight(v: "abc.", cutset: ".")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/strings/trimright/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/strings/trimright/',
   },
   {
     name: 'strings.trimSpace',
@@ -7207,7 +7207,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'strings.trimSpace(v: r._value)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/strings/trimspace/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/strings/trimspace/',
   },
   {
     name: 'strings.trimSuffix',
@@ -7229,7 +7229,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'strings.trimSuffix(v: r._value, suffix: "_123")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/strings/trimsuffix/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/strings/trimsuffix/',
   },
   {
     name: 'sum',
@@ -7245,7 +7245,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'sum(column: "_value")',
     category: 'Aggregates',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/aggregates/sum/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/aggregates/sum/',
   },
   {
     name: 'system.time',
@@ -7255,7 +7255,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'system.time()',
     category: 'Miscellaneous',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/system/time/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/system/time/',
   },
   {
     name: 'table.fill',
@@ -7265,7 +7265,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'table.fill()',
     category: 'Miscellaneous',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/table/fill/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/table/fill/',
   },
   {
     name: 'tableFind',
@@ -7282,7 +7282,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'tableFind(fn: (key) => key._field == "fieldName")',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/stream-table/tablefind/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/stream-table/tablefind/',
   },
   {
     name: 'tail',
@@ -7305,7 +7305,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'tail(n: 10)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/tail/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/tail/',
   },
   {
     name: 'tasks.lastSuccess',
@@ -7323,7 +7323,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'tasks.lastSuccess(orTime: 2020-10-01T00:00:00Z)',
     category: 'Miscellaneous',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/influxdb-tasks/lastsuccess/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/influxdb-tasks/lastsuccess/',
   },
   {
     name: 'teams.endpoint',
@@ -7342,7 +7342,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Alerting',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/teams/endpoint/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/contrib/teams/endpoint/',
   },
   {
     name: 'teams.message',
@@ -7380,7 +7380,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Alerting',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/teams/message/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/contrib/teams/message/',
   },
   {
     name: 'telegram.endpoint',
@@ -7419,7 +7419,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Alerting',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/telegram/endpoint/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/contrib/telegram/endpoint/',
   },
   {
     name: 'telegram.message',
@@ -7476,7 +7476,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Alerting',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/telegram/message/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/contrib/telegram/message/',
   },
   {
     name: 'testing.assertEmpty',
@@ -7486,7 +7486,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'testing.assertEmpty()',
     category: 'Tests',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/testing/assertempty/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/testing/assertempty/',
   },
   {
     name: 'testing.assertEquals',
@@ -7512,7 +7512,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'testing.assertEquals(got: got, want: want)',
     category: 'Tests',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/testing/assertequals/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/testing/assertequals/',
   },
   {
     name: 'testing.benchmark',
@@ -7529,7 +7529,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'testing.benchmark(case: exampleTestCase)',
     category: 'Tests',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/testing/benchmark/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/testing/benchmark/',
   },
   {
     name: 'testing.diff',
@@ -7556,7 +7556,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'testing.assertEquals(got: got, want: want)',
     category: 'Tests',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/testing/diff/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/testing/diff/',
   },
   {
     name: 'testing.inspect',
@@ -7572,7 +7572,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'testing.inspect(case: exampleTestCase)',
     category: 'Tests',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/testing/inspect/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/testing/inspect/',
   },
   {
     name: 'testing.load',
@@ -7582,7 +7582,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'testing.load()',
     category: 'Tests',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/testing/inspect/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/testing/inspect/',
   },
   {
     name: 'testing.loadMem',
@@ -7599,7 +7599,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'testing.loadMem(csv: csvData)',
     category: 'Tests',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/testing/loadmem/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/testing/loadmem/',
   },
   {
     name: 'testing.loadStorage',
@@ -7615,7 +7615,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'testing.loadStorage(csv: csvData)',
     category: 'Tests',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/testing/loadstorage/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/testing/loadstorage/',
   },
   {
     name: 'testing.run',
@@ -7631,7 +7631,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'testing.run(case: exampleTestCase)',
     category: 'Tests',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/testing/run/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/testing/run/',
   },
   {
     name: 'tickscript.alert',
@@ -7705,7 +7705,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Alerting',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/tickscript/alert/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/contrib/tickscript/alert/',
   },
   {
     name: 'tickscript.compute',
@@ -7736,7 +7736,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Outputs',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/tickscript/compute/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/contrib/tickscript/compute/',
   },
   {
     name: 'tickscript.deadman',
@@ -7788,7 +7788,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Alerting',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/tickscript/deadman/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/contrib/tickscript/deadman/',
   },
   {
     name: 'tickscript.defineCheck',
@@ -7820,7 +7820,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Outputs',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/tickscript/definecheck/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/contrib/tickscript/definecheck/',
   },
   {
     name: 'tickscript.groupBy',
@@ -7839,7 +7839,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/tickscript/groupby/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/contrib/tickscript/groupby/',
   },
   {
     name: 'tickscript.join',
@@ -7870,7 +7870,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/tickscript/join/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/contrib/tickscript/join/',
   },
   {
     name: 'tickscript.select',
@@ -7901,7 +7901,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/tickscript/select/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/contrib/tickscript/select/',
   },
   {
     name: 'tickscript.selectWindow',
@@ -7945,7 +7945,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/tickscript/selectwindow/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/contrib/tickscript/selectwindow/',
   },
   {
     name: 'time',
@@ -7961,7 +7961,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'time(v: r._value)',
     category: 'Type Conversions',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/type-conversions/time/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/type-conversions/time/',
   },
   {
     name: 'timedMovingAverage',
@@ -7989,7 +7989,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'timedMovingAverage(every: 1d, period: 5d)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/timedmovingaverage/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/timedmovingaverage/',
   },
   {
     name: 'timeShift',
@@ -8013,7 +8013,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'timeShift(duration: 10h, columns: ["_start", "_stop", "_time"])',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/shift/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/shift/',
   },
   {
     name: 'timeWeightedAvg',
@@ -8031,7 +8031,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'timeWeightedAvg(unit: 1m)',
     category: 'Aggregates',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/aggregates/timeweightedavg/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/aggregates/timeweightedavg/',
   },
   {
     name: 'to',
@@ -8095,7 +8095,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'to(bucket: "example-bucket", org: "example-org")',
     category: 'Outputs',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/outputs/to/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/outputs/to/',
   },
   {
     name: 'toBool',
@@ -8105,7 +8105,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'toBool()',
     category: 'Type Conversions',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/type-conversions/tobool',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/type-conversions/tobool',
   },
   {
     name: 'today',
@@ -8115,7 +8115,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'today()',
     category: 'Miscellaneous',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/misc/today/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/misc/today/',
   },
   {
     name: 'toFloat',
@@ -8125,7 +8125,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'toFloat()',
     category: 'Type Conversions',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/type-conversions/tofloat/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/type-conversions/tofloat/',
   },
   {
     name: 'toInt',
@@ -8135,7 +8135,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'toInt()',
     category: 'Type Conversions',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/type-conversions/toint/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/type-conversions/toint/',
   },
   {
     name: 'top',
@@ -8157,7 +8157,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'top(n:10, columns: ["_value"])',
     category: 'Selectors',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/selectors/top/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/selectors/top/',
   },
   {
     name: 'toString',
@@ -8167,7 +8167,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'toString()',
     category: 'Type Conversions',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/type-conversions/tostring/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/type-conversions/tostring/',
   },
   {
     name: 'toTime',
@@ -8177,7 +8177,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'toTime()',
     category: 'Type Conversions',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/type-conversions/totime/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/type-conversions/totime/',
   },
   {
     name: 'toUInt',
@@ -8187,7 +8187,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'toUInt()',
     category: 'Type Conversions',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/type-conversions/touint/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/type-conversions/touint/',
   },
   {
     name: 'tripleEMA',
@@ -8204,7 +8204,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'tripleEMA(n: 5)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/tripleema/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/tripleema/',
   },
   {
     name: 'tripleExponentialDerivative',
@@ -8221,7 +8221,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'tripleExponentialDerivative(n: 5)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/tripleexponentialderivative/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/tripleexponentialderivative/',
   },
   {
     name: 'truncateTimeColumn',
@@ -8237,7 +8237,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'truncateTimeColumn(unit: 1m)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/truncatetimecolumn/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/truncatetimecolumn/',
   },
   {
     name: 'uint',
@@ -8253,7 +8253,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'uint(v: r._value)',
     category: 'Type Conversions',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/type-conversions/uint/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/type-conversions/uint/',
   },
   UNION,
   {
@@ -8270,7 +8270,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'unique(column: "_value")',
     category: 'Selectors',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/selectors/unique/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/selectors/unique/',
   },
   {
     name: 'usage.from',
@@ -8322,7 +8322,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Inputs',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/usage/from/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/usage/from/',
   },
   {
     name: 'usage.limits',
@@ -8356,7 +8356,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Inputs',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/usage/limits/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/usage/limits/',
   },
   {
     name: 'victorops.endpoint',
@@ -8375,7 +8375,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Alerting',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/victorops/endpoint/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/contrib/victorops/endpoint/',
   },
   {
     name: 'victorops.event',
@@ -8430,7 +8430,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Alerting',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/victorops/event/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/contrib/victorops/event/',
   },
   {
     name: 'window',
@@ -8488,7 +8488,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'window(every: v.windowPeriod)',
     category: 'Transformations',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/window/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/window/',
   },
   {
     name: 'yield',
@@ -8505,7 +8505,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'yield(name: "custom-name")',
     category: 'Outputs',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/outputs/yield/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/outputs/yield/',
   },
   {
     name: 'zenoss.endpoint',
@@ -8562,7 +8562,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Alerting',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/zenoss/endpoint/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/contrib/zenoss/endpoint/',
   },
   {
     name: 'zenoss.event',
@@ -8667,6 +8667,6 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
 )`,
     category: 'Alerting',
     link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/zenoss/event/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/contrib/zenoss/event/',
   },
 ]

--- a/src/shared/constants/fluxFunctions.ts
+++ b/src/shared/constants/fluxFunctions.ts
@@ -253,6 +253,147 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/aggregates/aggregatewindow/',
   },
   {
+    name: 'alerta.alert',
+    args: [
+      {
+        name: 'url',
+        desc: 'Alerta URL.',
+        type: 'String',
+      },
+      {
+        name: 'apiKey',
+        desc: 'Alerta API key.',
+        type: 'String',
+      },
+      {
+        name: 'resource',
+        desc: 'Resource associated with the alert.',
+        type: 'String',
+      },
+      {
+        name: 'event',
+        desc: 'Event name.',
+        type: 'String',
+      },
+      {
+        name: 'environment',
+        desc:
+          'Alert environment. Default is `""`. Valid values are `""`, `"Production"`, or `"Development"`.',
+        type: 'String',
+      },
+      {
+        name: 'severity',
+        desc: 'Event severity.',
+        type: 'String',
+      },
+      {
+        name: 'service',
+        desc: 'List of affected services. Default is `[]`.',
+        type: 'Array of strings',
+      },
+      {
+        name: 'group',
+        desc: 'Alerta event group. Default is `""`.',
+        type: 'String',
+      },
+      {
+        name: 'value',
+        desc: 'Event value. Default is `""`.',
+        type: 'String',
+      },
+      {
+        name: 'text',
+        desc: 'Alert text description. Default is `""`.',
+        type: 'String',
+      },
+      {
+        name: 'tags',
+        desc: 'List of event tags. Default is `[]`.',
+        type: 'Array of strings',
+      },
+      {
+        name: 'attributes',
+        desc: 'Alert attributes.',
+        type: 'Record',
+      },
+      {
+        name: 'origin',
+        desc: 'Alert origin. Default is `"InfluxDB"`.',
+        type: 'String',
+      },
+      {
+        name: 'type',
+        desc: 'Event type. Default is `""`.',
+        type: 'String',
+      },
+      {
+        name: 'timestamp',
+        desc: 'time alert was generated. Default is `now()`.',
+        type: 'Time',
+      },
+    ],
+    package: 'contrib/bonitoo-io/alerta',
+    desc: 'Sends an alert to Alerta.',
+    example: `alerta.alert(
+    url: "https://alerta.io:8080/alert",
+    apiKey: "0Xx00xxXx00Xxx0x0X",
+    resource: "example-resource",
+    event: "Example event",
+    environment: "",
+    severity: "critical",
+    service: [],
+    group: "",
+    value: "",
+    text: "",
+    tags: [],
+    attributes: {},
+    origin: "InfluxDB",
+    type: "",
+    timestamp: now()
+)`,
+    category: 'Alerting',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/alerta/alert/',
+  },
+  {
+    name: 'alerta.endpoint',
+    args: [
+      {
+        name: 'url',
+        desc: 'Alerta URL.',
+        type: 'String',
+      },
+      {
+        name: 'apiKey',
+        desc: 'Alerta API key.',
+        type: 'String',
+      },
+      {
+        name: 'environment',
+        desc:
+          'Alert environment. Default is `""`. Valid values are `""`, `"Production"`, or `"Development"`.',
+        type: 'String',
+      },
+      {
+        name: 'origin',
+        desc: 'Alert origin. Default is `"InfluxDB"`.',
+        type: 'String',
+      },
+    ],
+    package: 'contrib/bonitoo-io/alerta',
+    desc:
+      'A factory function that outputs another function. The output function requires a `mapFn` parameter. See the documentation link for a full example.',
+    example: `endpoint = alerta.endpoint(
+    url: "https://alerta.io:8080/alert",
+    apiKey: apiKey,
+    environment: "Production",
+    origin: "InfluxDB"
+)`,
+    category: 'Alerting',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/alerta/endpoint/',
+  },
+  {
     name: 'array.from',
     args: [
       {
@@ -268,6 +409,97 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     category: 'Inputs',
     link:
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/array/from/',
+  },
+  {
+    name: 'bigpanda.endpoint',
+    args: [
+      {
+        name: 'url',
+        desc:
+          'BigPanda alerts API URL. Default is the value of the `bigpanda.defaultURL` option.',
+        type: 'String',
+      },
+      {
+        name: 'token',
+        desc: 'BigPanda API Authorization token (API key).',
+        type: 'String',
+      },
+      {
+        name: 'appKey',
+        desc: 'BigPanda App Key.',
+        type: 'String',
+      },
+    ],
+    package: 'contrib/rhajek/bigpanda',
+    desc:
+      'A factory function that outputs another function. The output function requires a `mapFn` parameter. See the documentation link for a full example.',
+    example: `endpoint = bigpanda.endpoint(
+    token: token,
+    appKey: "example-app-key"
+)`,
+    category: 'Alerting',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/bigpanda/endpoint/',
+  },
+  {
+    name: 'bigpanda.sendAlert',
+    args: [
+      {
+        name: 'url',
+        desc:
+          'BigPanda alerts API URL. Default is the value of the `bigpanda.defaultURL` option.',
+        type: 'String',
+      },
+      {
+        name: 'token',
+        desc: 'BigPanda API Authorization token (API key).',
+        type: 'String',
+      },
+      {
+        name: 'appKey',
+        desc: 'BigPanda App Key.',
+        type: 'String',
+      },
+      {
+        name: 'status',
+        desc:
+          'BigPanda alert status. Supported statuses are `"ok"`, `"critical"`, `"warning"`, `"acknowledged"`.',
+        type: 'String',
+      },
+      {
+        name: 'rec',
+        desc: 'Additional alert parameters to send to the BigPanda alert API.',
+        type: 'Record',
+      },
+    ],
+    package: 'contrib/rhajek/bigpanda',
+    desc: 'Sends an alert to BigPanda.',
+    example: `bigpanda.sendAlert(
+    url: "https://api.bigpanda.io/data/v2/alerts",
+    token: "my5uP3rS3cRe7t0k3n",
+    appKey: "example-app-key",
+    status: "critical",
+    rec: {},
+)`,
+    category: 'Alerting',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/bigpanda/sendalert/',
+  },
+  {
+    name: 'bigpanda.statusFromLevel',
+    args: [
+      {
+        name: 'level',
+        desc: 'Alert level.',
+        type: 'String',
+      },
+    ],
+    package: 'contrib/rhajek/bigpanda',
+    desc: 'Converts an alert level into a BigPanda status.',
+    example: 'bigpanda.statusFromLevel(level: "crit")',
+    category: 'Alerting',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/bigpanda/statusfromlevel/',
   },
   {
     name: 'bigtable.from',
@@ -841,6 +1073,119 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/derivative/',
   },
   {
+    name: 'dict.fromList',
+    args: [
+      {
+        name: 'pairs',
+        desc: 'List of records, each containing `key` and `value` properties.',
+        type: 'Array of records',
+      },
+    ],
+    package: 'dict',
+    desc:
+      'Creates a dictionary from a list of records with `key` and `value` properties.',
+    example: `dict.fromList(
+    pairs: [
+        {key: 1, value: "foo"},
+        {key: 2, value: "bar"}
+    ]
+)`,
+    category: 'Transformations',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/dict/fromlist/',
+  },
+  {
+    name: 'dict.get',
+    args: [
+      {
+        name: 'dict',
+        desc: 'Dictionary to return a value from.',
+        type: 'Dictionary',
+      },
+      {
+        name: 'key',
+        desc: 'Key to return from the dictionary.',
+        type: 'String | Boolean | Integer | Uinteger | Float | Time | Bytes',
+      },
+      {
+        name: 'default',
+        desc:
+          'Default value to return if the key does not exist in the dictionary. Must be the same type as values in the dictionary.',
+        type: 'String | Boolean | Integer | Uinteger | Float | Time | Bytes',
+      },
+    ],
+    package: 'dict',
+    desc:
+      'Returns the value of a specified key in a dictionary or a default value if the key does not exist.',
+    example: `dict.get(
+    dict: [1: "foo", 2: "bar"],
+    key: 1,
+    default: ""
+)`,
+    category: 'Transformations',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/dict/get/',
+  },
+  {
+    name: 'dict.insert',
+    args: [
+      {
+        name: 'dict',
+        desc: 'Dictionary to update.',
+        type: 'Dictionary',
+      },
+      {
+        name: 'key',
+        desc:
+          'Key to insert into the dictionary. Must be the same type as existing keys in the dictionary.',
+        type: 'String | Boolean | Integer | Uinteger | Float | Time | Bytes',
+      },
+      {
+        name: 'default',
+        desc:
+          'Value to insert into the dictionary. Must be the same type as existing values in the dictionary.',
+        type: 'String | Boolean | Integer | Uinteger | Float | Time | Bytes',
+      },
+    ],
+    package: 'dict',
+    desc:
+      'Inserts a key value pair into a dictionary and returns a new, updated dictionary. If the key already exists in the dictionary, the function overwrites the existing value.',
+    example: `dict.insert(
+    dict: [1: "foo", 2: "bar"],
+    key: 3,
+    value: "baz"
+)`,
+    category: 'Transformations',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/dict/insert/',
+  },
+  {
+    name: 'dict.remove',
+    args: [
+      {
+        name: 'dict',
+        desc: 'Dictionary to remove a key-value pair from.',
+        type: 'Dictionary',
+      },
+      {
+        name: 'key',
+        desc:
+          'Key to remove from the dictionary. Must be the same type as existing keys in the dictionary.',
+        type: 'String | Boolean | Integer | Uinteger | Float | Time | Bytes',
+      },
+    ],
+    package: 'dict',
+    desc:
+      'Removes a key value pair from a dictionary and returns an updated dictionary.',
+    example: `dict.remove(
+    dict: [1: "foo", 2: "bar"],
+    key: 1
+)`,
+    category: 'Transformations',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/dict/remove/',
+  },
+  {
     name: 'difference',
     args: [
       {
@@ -869,6 +1214,85 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     category: 'Transformations',
     link:
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/difference/',
+  },
+  {
+    name: 'discord.endpoint',
+    args: [
+      {
+        name: 'webhookToken',
+        desc: 'Discord webhook token.',
+        type: 'String',
+      },
+      {
+        name: 'webhookID',
+        desc: 'Discord webhook ID.',
+        type: 'String',
+      },
+      {
+        name: 'username',
+        desc: 'Override the Discord webhook’s default username.',
+        type: 'String',
+      },
+      {
+        name: 'avatar_url',
+        desc: 'Override the Discord webhook’s default avatar.',
+        type: 'String',
+      },
+    ],
+    package: 'contrib/chobbs/discord',
+    desc:
+      'A factory function that outputs another function. The output function requires a `mapFn` parameter. See the documentation link for a full example.',
+    example: `endpoint = telegram.endpoint(
+    webhookToken: discordToken,
+    webhookID: "123456789",
+    username: "critBot"
+)`,
+    category: 'Alerting',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/discord/endpoint/',
+  },
+  {
+    name: 'discord.send',
+    args: [
+      {
+        name: 'webhookToken',
+        desc: 'Discord webhook token.',
+        type: 'String',
+      },
+      {
+        name: 'webhookID',
+        desc: 'Discord webhook ID.',
+        type: 'String',
+      },
+      {
+        name: 'username',
+        desc: 'Override the Discord webhook’s default username.',
+        type: 'String',
+      },
+      {
+        name: 'content',
+        desc: 'Message to send to Discord (2000 character limit).',
+        type: 'String',
+      },
+      {
+        name: 'avatar_url',
+        desc: 'Override the Discord webhook’s default avatar.',
+        type: 'String',
+      },
+    ],
+    package: 'contrib/chobbs/discord',
+    desc:
+      'Sends a single message to a Discord channel using a Discord webhook.',
+    example: `discord.send(
+    webhookToken: "mySuPerSecRetTokEn",
+    webhookID: "123456789",
+    username: "username",
+    content: "This is an example message",
+    avatar_url: "https://example.com/avatar_pic.jpg"
+)`,
+    category: 'Alerting',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/discord/send/',
   },
   {
     name: 'distinct',
@@ -965,6 +1389,78 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/type-conversions/duration/',
   },
   {
+    name: 'elapsed',
+    args: [
+      {
+        name: 'unit',
+        desc: 'The unit time to return. Defaults to `1s`.',
+        type: 'Duration',
+      },
+      {
+        name: 'timeColumn',
+        desc:
+          'The column to use to compute the elapsed time. Defaults to `"_time"`.',
+        type: 'String`',
+      },
+      {
+        name: 'columnName',
+        desc: 'The column to store elapsed times. Defaults to `"elapsed"`.',
+        type: 'String',
+      },
+    ],
+    package: '',
+    desc: 'Returns the time between subsequent records.',
+    example: 'elapsed(unit: 1s)',
+    category: 'Transformations',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/elapsed/',
+  },
+  {
+    name: 'events.duration',
+    args: [
+      {
+        name: 'unit',
+        desc:
+          'Duration unit of the calculated state duration. Default is `1ns`.',
+        type: 'Duration',
+      },
+      {
+        name: 'columnName',
+        desc: 'Name of the result column. Default is `"duration"`.',
+        type: 'String',
+      },
+      {
+        name: 'timeColumn',
+        desc: 'Name of the time column. Default is `"_time"`.',
+        type: 'String',
+      },
+      {
+        name: 'stopColumn',
+        desc: 'Name of the stop column. Default is `"_stop"`.',
+        type: 'String',
+      },
+      {
+        name: 'stop',
+        desc:
+          'The latest time to use when calculating results. If provided, `stop` overrides the time value in the `stopColumn`.',
+        type: 'Time',
+      },
+    ],
+    package: 'contrib/tomhollingworth/events',
+    desc:
+      'Calculates the duration of events. The function determines the time between a record and the subsequent record and associates the duration with the first record (start of the event).',
+    example: `events.duration(
+    unit: 1ns,
+    columnName: "duration",
+    timeColumn: "_time",
+    stopColumn: "_stop",
+    stop: 2020-01-01T00:00:00Z
+)`,
+    category: 'Transformations',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/events/duration/',
+  },
+  {
     name: 'experimental.addDuration',
     args: [
       {
@@ -1025,6 +1521,63 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/chain/',
   },
   {
+    name: 'experimental.count',
+    args: [],
+    package: 'experimental',
+    desc:
+      'Outputs the number of records in each input table and returns the count in the `_value` column. This function counts both null and non-null records.',
+    example: 'experimental.count()',
+    category: 'Transformations',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/count/',
+  },
+  {
+    name: 'experimental.distinct',
+    args: [],
+    package: 'experimental',
+    desc:
+      'Returns unique values from the `_value` column. The `_value` of each output record is set to a distinct value in the specified column. `null` is considered a distinct value.',
+    example: 'experimental.distinct()',
+    category: 'Transformations',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/distinct/',
+  },
+  {
+    name: 'experimental.fill',
+    args: [
+      {
+        name: 'value',
+        desc:
+          'Value to replace null values with. Data type must match the type of the `_value` column.',
+        type: 'Boolean | Integer | UInteger | Float | String | Time | Duration',
+      },
+      {
+        name: 'usePrevious',
+        desc:
+          'When `true`, replaces null values with the value of the previous non-null row.',
+        type: 'Boolean',
+      },
+    ],
+    package: 'experimental',
+    desc:
+      'Replaces all null values in the `_value` column with a non-null value.',
+    example: 'experimental.fill(value: 0.0)',
+    category: 'Transformations',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/fill/',
+  },
+  {
+    name: 'experimental.first',
+    args: [],
+    package: 'experimental',
+    desc:
+      'Returns the first record with a non-null value in the `_value` column.',
+    example: 'experimental.first()',
+    category: 'Transformations',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/first/',
+  },
+  {
     name: 'experimental.group',
     args: [
       {
@@ -1047,6 +1600,84 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     category: 'Transformations',
     link:
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/group/',
+  },
+  {
+    name: 'experimental.histogram',
+    args: [
+      {
+        name: 'bins',
+        desc:
+          'A list of upper bounds to use when computing the histogram frequencies, including the maximum value of the data set. This value can be set to positive infinity if no maximum is known.',
+        type: 'Array of floats',
+      },
+      {
+        name: 'normalize',
+        desc:
+          'Convert count values into frequency values between 0 and 1. Default is `false`.',
+        type: 'Boolean',
+      },
+    ],
+    package: 'experimental',
+    desc:
+      'Approximates the cumulative distribution of a dataset by counting data frequencies for a list of bins.',
+    example: `experimental.histogram(
+    bins: [50.0, 75.0, 90.0],
+    normalize: false
+)`,
+    category: 'Transformations',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/histogram/',
+  },
+  {
+    name: 'experimental.histogramQuantile',
+    args: [
+      {
+        name: 'quantile',
+        desc:
+          'A value between 0 and 1 indicating the desired quantile to compute.',
+        type: 'Float',
+      },
+      {
+        name: 'minValue',
+        desc: 'The assumed minimum value of the dataset.',
+        type: 'Float',
+      },
+    ],
+    package: 'experimental',
+    desc:
+      'Approximates a quantile given a histogram with the cumulative distribution of the dataset.',
+    example: `experimental.histogramQuantile(
+    quantile: 0.5,
+    minValue: 0.0
+)`,
+    category: 'Transformations',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/histogramquantile/',
+  },
+  {
+    name: 'experimental.integral',
+    args: [
+      {
+        name: 'unit',
+        desc: 'Time duration used to compute the integral.',
+        type: 'Duration',
+      },
+      {
+        name: 'interpolate',
+        desc: 'Type of interpolation to use. Defaults to `""`.',
+        type: 'String',
+      },
+    ],
+    package: 'experimental',
+    desc:
+      'Computes the area under the curve per `unit` of time of subsequent non-null records.',
+    example: `integral(
+    unit: 10s,
+    interpolate: ""
+)`,
+    category: 'Transformations',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/integral/',
   },
   {
     name: 'experimental.join',
@@ -1078,6 +1709,78 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/join/',
   },
   {
+    name: 'experimental.kaufmansAMA',
+    args: [
+      {
+        name: 'n',
+        desc: 'The period or number of points to use in the calculation.',
+        type: 'Integer',
+      },
+    ],
+    package: 'experimental',
+    desc:
+      'Calculates the Kaufman’s Adaptive Moving Average (KAMA) of input tables using the `_value` column in each table.',
+    example: 'experimental.kaufmansAMA(n: 10)',
+    category: 'Transformations',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/kaufmansama/',
+  },
+  {
+    name: 'experimental.last',
+    args: [],
+    package: 'experimental',
+    desc:
+      'Returns the last record with a non-null value in the `_value` column.',
+    example: 'experimental.last()',
+    category: 'Aggregates',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/last/',
+  },
+  {
+    name: 'experimental.max',
+    args: [],
+    package: 'experimental',
+    desc:
+      'Returns the record with the highest value in the `_value` column for each input table.',
+    example: 'experimental.max()',
+    category: 'Aggregates',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/max/',
+  },
+  {
+    name: 'experimental.mean',
+    args: [],
+    package: 'experimental',
+    desc:
+      'Computes the mean or average of non-null values in the `_value` column of each input table.',
+    example: 'experimental.mean()',
+    category: 'Aggregates',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/mean/',
+  },
+  {
+    name: 'experimental.min',
+    args: [],
+    package: 'experimental',
+    desc:
+      'Returns the record with the lowest value in the `_value` column for each input table.',
+    example: 'experimental.min()',
+    category: 'Aggregates',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/min/',
+  },
+  {
+    name: 'experimental.mode',
+    args: [],
+    package: 'experimental',
+    desc:
+      'Computes the mode or value that occurs most often in the `_value` column in each input table.',
+    example: 'experimental.mode()',
+    category: 'Aggregates',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/mode/',
+  },
+  {
     name: 'experimental.objectKeys',
     args: [
       {
@@ -1094,6 +1797,39 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/objectkeys/',
   },
   {
+    name: 'experimental.quantile',
+    args: [
+      {
+        name: 'q',
+        desc: 'A value between 0 and 1 thats specifies the quantile.',
+        type: 'Float',
+      },
+      {
+        name: 'method',
+        desc:
+          'Computation method. Default is `estimate_tdigest`. Available options are `estimate_tdigest`, `exact_mean`, or `exact_selector`.',
+        type: 'String',
+      },
+      {
+        name: 'compression',
+        desc:
+          'Indicates how many centroids to use when compressing the dataset.',
+        type: 'Float',
+      },
+    ],
+    package: 'experimental',
+    desc:
+      'Outputs non-null records with values in the `_value` column that fall within the specified quantile or represent the specified quantile.',
+    example: `experimental.quantile(
+    q: 0.99,
+    method: "estimate_tdigest",
+    compression: 1000.0
+)`,
+    category: 'Transformations',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/quantile/',
+  },
+  {
     name: 'experimental.set',
     args: [
       {
@@ -1108,6 +1844,46 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     category: 'Transformations',
     link:
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/set/',
+  },
+  {
+    name: 'experimental.skew',
+    args: [],
+    package: 'experimental',
+    desc:
+      'Outputs the skew of non-null values in the `_value` column for each input table as a float.',
+    example: 'experimental.skew()',
+    category: 'Transformation',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/skew/',
+  },
+  {
+    name: 'experimental.spread',
+    args: [],
+    package: 'experimental',
+    desc:
+      'Outputs the difference between the minimum and maximum values in the `_value` column for each input table.',
+    example: 'experimental.spread()',
+    category: 'Transformation',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/spread/',
+  },
+  {
+    name: 'experimental.stddev',
+    args: [
+      {
+        name: 'mode',
+        desc:
+          'The standard deviation mode or type of standard deviation to calculate. Defaults to `"sample"`. Available options are `sample` and `population`.',
+        type: 'String',
+      },
+    ],
+    package: 'experimental',
+    desc:
+      'Computes the standard deviation of non-null values in the `_value` column for each input table.',
+    example: 'experimental.stddev(mode: "sample")',
+    category: 'Aggregates',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/stddev/',
   },
   {
     name: 'experimental.subDuration',
@@ -1130,6 +1906,17 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     category: 'Transformations',
     link:
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/subduration/',
+  },
+  {
+    name: 'experimental.sum',
+    args: [],
+    package: 'experimental',
+    desc:
+      'Computes the sum of non-null values in the `_value` column for each input table.',
+    example: 'experimental.sum()',
+    category: 'Aggregates',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/sum/',
   },
   {
     name: 'experimental.to',
@@ -1166,33 +1953,6 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     category: 'Outputs',
     link:
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/to/',
-  },
-  {
-    name: 'elapsed',
-    args: [
-      {
-        name: 'unit',
-        desc: 'The unit time to return. Defaults to `1s`.',
-        type: 'Duration',
-      },
-      {
-        name: 'timeColumn',
-        desc:
-          'The column to use to compute the elapsed time. Defaults to `"_time"`.',
-        type: 'String`',
-      },
-      {
-        name: 'columnName',
-        desc: 'The column to store elapsed times. Defaults to `"elapsed"`.',
-        type: 'String',
-      },
-    ],
-    package: '',
-    desc: 'Returns the time between subsequent records.',
-    example: 'elapsed(unit: 1s)',
-    category: 'Transformations',
-    link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/elapsed/',
   },
   {
     name: 'exponentialMovingAverage',
@@ -1996,6 +2756,50 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/hourselection/',
   },
   {
+    name: 'http.basicAuth',
+    args: [
+      {
+        name: 'u',
+        desc: 'The username to use in the basic authentication header.',
+        type: 'String',
+      },
+      {
+        name: 'p',
+        desc: 'The password to use in the basic authentication header.',
+        type: 'String',
+      },
+    ],
+    package: 'http',
+    desc:
+      'Returns a Base64-encoded basic authentication header using a specified username and password combination.',
+    example: `http.basicAuth(
+    u: "username",
+    p: "passw0rd"
+)`,
+    category: 'Miscellaneous',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/http/basicauth/',
+  },
+  {
+    name: 'http.endpoint',
+    args: [
+      {
+        name: 'url',
+        desc: 'The URL to POST to.',
+        type: 'String',
+      },
+    ],
+    package: 'http',
+    desc:
+      'A factory function that outputs another function. The output function requires a `mapFn` parameter. See the documentation link for a full example.',
+    example: `endpoint = http.endpoint(
+    url: "http://localhost:1234/"
+)`,
+    category: 'Alerting',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/http/endpoint/',
+  },
+  {
     name: 'http.get',
     args: [
       {
@@ -2063,7 +2867,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     desc:
       'Submits an HTTP POST request to the specified URL with headers and data and returns the HTTP status code.',
     example:
-      'http.post(url: "http://localhost:9999/", headers: {x:"a", y:"b"}, data: bytes(v: "body"))',
+      'http.post(url: "http://localhost:8086/", headers: {x:"a", y:"b"}, data: bytes(v: "body"))',
     category: 'Transformations',
     link:
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/http/post/',
@@ -2085,6 +2889,69 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     category: 'Transformations',
     link:
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/increase/',
+  },
+  {
+    name: 'influxdb.api',
+    args: [
+      {
+        name: 'method',
+        desc: 'HTTP request method.',
+        type: 'String',
+      },
+      {
+        name: 'path',
+        desc: 'InfluxDB API path.',
+        type: 'String',
+      },
+      {
+        name: 'host',
+        desc:
+          'InfluxDB host URL (Required when executed outside of InfluxDB). Default is `""`.',
+        type: 'String',
+      },
+      {
+        name: 'token',
+        desc:
+          'InfluxDB host URL (Required when executed outside of InfluxDB). Default is `""`.',
+        type: 'String',
+      },
+      {
+        name: 'headers',
+        desc: 'HTTP request headers.',
+        type: 'Dictionary',
+      },
+      {
+        name: 'query',
+        desc: 'URL query parameters.',
+        type: 'Dictionary',
+      },
+      {
+        name: 'timeout',
+        desc: 'HTTP request timeout. Default is `30s`.',
+        type: 'Duration',
+      },
+      {
+        name: 'body',
+        desc: 'HTTP request body as bytes.',
+        type: 'Bytes',
+      },
+    ],
+    package: 'experimental/influxdb',
+    desc:
+      'Submits an HTTP request to the specified InfluxDB API path and returns a record containing the HTTP status code, response headers, and response body as a byte array.',
+    example: `influxdb.api(
+    method: "get",
+    path: "/example",
+    host: "http://localhost:8086",
+    token: "mySupeR53cre7t0k3n",
+    headers: ["header1": "header1Value", "header2": "header2Value"],
+    query: ["ex1": "example1", "ex2": "example2"],
+    timeout: 30s,
+    body: bytes(v: "Example body")
+)`,
+    category: 'Outputs',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/influxdb/api/',
   },
   {
     name: 'influxdb.cardinality',
@@ -2144,6 +3011,77 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/influxdb/cardinality/',
   },
   {
+    name: 'influxdb.select',
+    args: [
+      {
+        name: 'from',
+        desc: 'Name of the bucket to query.',
+        type: 'String',
+      },
+      {
+        name: 'start',
+        desc:
+          'Earliest time to include in results. Results include points that match the specified start time.',
+        type: 'Duration | Time | Integer',
+      },
+      {
+        name: 'stop',
+        desc:
+          'Latest time to include in results. Results exclude points that match the specified stop time.',
+        type: 'Duration | Time | Integer',
+      },
+      {
+        name: 'm',
+        desc: 'Name of the measurement to query.',
+        type: 'String',
+      },
+      {
+        name: 'fields',
+        desc:
+          'List of fields to query. Returns all fields when list is empty or unspecified. Defaults to `[]`.',
+        type: 'Array of Strings',
+      },
+      {
+        name: 'where',
+        desc:
+          'A single argument predicate function that evaluates true or false and filters results based on tag values. Defaults to `(r) => true`.',
+        type: 'Function',
+      },
+      {
+        name: 'host',
+        desc: 'URL of the InfluxDB instance to query. See InfluxDB URLs.',
+        type: 'String',
+      },
+      {
+        name: 'org',
+        desc: 'Organization name.',
+        type: 'String',
+      },
+      {
+        name: 'token',
+        desc: 'InfluxDB authentication token.',
+        type: 'String',
+      },
+    ],
+    package: 'contrib/jsternberg/influxdb',
+    desc:
+      'an alternate implementation of `from()`, `range()`, `filter()` and `pivot()` that returns pivoted query results and masks the `_measurement`, `_start`, and `_stop` columns.',
+    example: `influxdb.select(
+    from: "example-bucket",
+    start: -1d,
+    stop: now(),
+    m: "example-measurement",
+    fields: [],
+    where: (r) => true,
+    host: "https://example.com",
+    org: "example-org",
+    token: "MySuP3rSecr3Tt0k3n"
+)`,
+    category: 'Miscellaneous',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/influxdb/select/',
+  },
+  {
     name: 'int',
     args: [
       {
@@ -2193,6 +3131,23 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/aggregates/integral/',
   },
   {
+    name: 'interpolate.linear',
+    args: [
+      {
+        name: 'every',
+        desc: 'Duration of time between interpolated points.',
+        type: 'Duration',
+      },
+    ],
+    package: 'interpolate',
+    desc:
+      'Inserts rows at regular intervals using linear interpolation to determine values for inserted rows.',
+    example: 'interpolate.linear(every: 1m)',
+    category: 'Transformations',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/interpolate/linear/',
+  },
+  {
     name: 'join',
     args: [
       {
@@ -2236,6 +3191,22 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     category: 'Type Conversions',
     link:
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/json/encode/',
+  },
+  {
+    name: 'json.parse',
+    args: [
+      {
+        name: 'data',
+        desc: 'JSON data to parse.',
+        type: 'Bytes',
+      },
+    ],
+    package: 'experimental/json',
+    desc: 'Takes JSON data as bytes and returns a value.',
+    example: 'json.parse(data: bytes(v: "{"a":1,"b":2,"c":3}"))',
+    category: 'Miscellaneous',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/json/parse/',
   },
   {
     name: 'kaufmansAMA',
@@ -3125,6 +4096,22 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/log/',
   },
   {
+    name: 'math.log10',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns the decimal logarithm of `x`.',
+    example: 'math.log10(x: 3.14)',
+    category: 'Transformations',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/math/log10/',
+  },
+  {
     name: 'math.log1p',
     args: [
       {
@@ -3627,6 +4614,204 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/aggregates/mode/',
   },
   {
+    name: 'monitor.check',
+    args: [
+      {
+        name: 'crit',
+        desc:
+          'Predicate function that determines `crit` status. Default is `(r) => false`.',
+        type: 'Function',
+      },
+      {
+        name: 'warn',
+        desc:
+          'Predicate function that determines `warn` status. Default is `(r) => false`.',
+        type: 'Function',
+      },
+      {
+        name: 'info',
+        desc:
+          'Predicate function that determines `info` status. Default is `(r) => false`.',
+        type: 'Function',
+      },
+      {
+        name: 'ok',
+        desc:
+          'Predicate function that determines `ok` status. Default is `(r) => false`.',
+        type: 'Function',
+      },
+      {
+        name: 'messageFn',
+        desc:
+          'A function that constructs a message to append to each row. The message is stored in the `_message` column.',
+        type: 'Function',
+      },
+      {
+        name: 'data',
+        desc: 'Meta data used to identify this check.',
+        type: 'Record',
+      },
+    ],
+    package: 'influxdata/influxdb/monitor',
+    desc:
+      'Checks input data and assigns a level (`ok`, `info`, `warn`, or `crit`) to each row based on predicate functions.',
+    example: `monitor.check(
+    crit: (r) => r._value > 90.0,
+    warn: (r) => r._value > 80.0,
+    info: (r) => r._value > 60.0,
+    ok:   (r) => r._value <= 20.0,
+    messageFn: (r) => "The current level is \${r._level}",
+    data: {}
+)`,
+    category: 'Transformation',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/monitor/check/',
+  },
+  {
+    name: 'monitor.deadman',
+    args: [
+      {
+        name: 't',
+        desc: 'The time threshold for the deadman check.',
+        type: 'Time',
+      },
+    ],
+    package: 'influxdata/influxdb/monitor',
+    desc:
+      'Detects when a group stops reporting data. It takes a stream of tables and reports if groups have been observed since time `t`.',
+    example: `monitor.deadman(t: 2019-08-30T12:30:00Z)`,
+    category: 'Transformation',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/monitor/deadman/',
+  },
+  {
+    name: 'monitor.from',
+    args: [
+      {
+        name: 'start',
+        desc: 'The earliest time to include in results.',
+        type: 'Duration | Time | Integer',
+      },
+      {
+        name: 'stop',
+        desc: 'The latest time to include in results.',
+        type: 'Duration | Time | Integer',
+      },
+      {
+        name: 'fn',
+        desc:
+          'A single argument predicate function that evaluates `true` or `false`.',
+        type: 'Function',
+      },
+    ],
+    package: 'influxdata/influxdb/monitor',
+    desc:
+      'Detects when a group stops reporting data. It takes a stream of tables and reports if groups have been observed since time `t`.',
+    example: `monitor.from(
+    start: -1h,
+    stop: now(),
+    fn: (r) => true
+)`,
+    category: 'Inputs',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/monitor/from/',
+  },
+  {
+    name: 'monitor.logs',
+    args: [
+      {
+        name: 'start',
+        desc: 'The earliest time to include in results.',
+        type: 'Duration | Time | Integer',
+      },
+      {
+        name: 'stop',
+        desc: 'The latest time to include in results.',
+        type: 'Duration | Time | Integer',
+      },
+      {
+        name: 'fn',
+        desc:
+          'A single argument predicate function that evaluates `true` or `false`.',
+        type: 'Function',
+      },
+    ],
+    package: 'influxdata/influxdb/monitor',
+    desc:
+      'Retrieves notification events stored in the notifications measurement in the `_monitoring` bucket.',
+    example: `monitor.from(
+    start: -1h,
+    stop: now(),
+    fn: (r) => true
+)`,
+    category: 'Inputs',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/monitor/logs/',
+  },
+  {
+    name: 'monitor.notify',
+    args: [
+      {
+        name: 'endpoint',
+        desc:
+          'A function that constructs and sends the notification to an endpoint.',
+        type: 'Function',
+      },
+      {
+        name: 'data',
+        desc: 'Notification data to append to the output.',
+        type: 'Record',
+      },
+    ],
+    package: 'influxdata/influxdb/monitor',
+    desc:
+      'Sends a notification to an endpoint and logs it in the notifications measurement in the `_monitoring` bucket.',
+    example: `monitor.notify(
+    endpoint: endpoint,
+    data: {}
+)`,
+    category: 'Alerting',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/monitor/notify/',
+  },
+  {
+    name: 'monitor.stateChanges',
+    args: [
+      {
+        name: 'fromLevel',
+        desc: 'The level to detect a change from. Defaults to `"any"`.',
+        type: 'String',
+      },
+      {
+        name: 'toLevel',
+        desc:
+          'The level to detect a change to. The function output records that change to this level. Defaults to `"any"`.',
+        type: 'String',
+      },
+    ],
+    package: 'influxdata/influxdb/monitor',
+    desc:
+      'Detects state changes in a stream of data with a `_level` column and outputs records that change from `fromLevel` to `toLevel`.',
+    example: `monitor.stateChanges(
+    fromLevel: "any",
+    toLevel: "any"
+)`,
+    category: 'Transformation',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/monitor/statechanges/',
+  },
+  {
+    name: 'monitor.stateChangesOnly',
+    args: [],
+    package: 'influxdata/influxdb/monitor',
+    desc:
+      'Takes a stream of tables that contains a `_level` column and returns a stream of tables where each record represents a state change.',
+    example: `monitor.stateChangesOnly()`,
+    category: 'Transformation',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/monitor/statechangesonly/',
+  },
+  {
     name: 'movingAverage',
     args: [
       {
@@ -3720,6 +4905,369 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/mqtt/to/',
   },
   {
+    name: 'now',
+    args: [],
+    package: '',
+    desc:
+      'Returns the current time (UTC) or the time defined in the `now` option.',
+    example: 'now()',
+    category: 'Miscellaneous',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/misc/now/',
+  },
+  {
+    name: 'oee.APQ',
+    args: [
+      {
+        name: 'runningState',
+        desc: 'State value that represents a running state.',
+        type: 'String',
+      },
+      {
+        name: 'plannedTime',
+        desc: 'Total time that equipment is expected to produce parts.',
+        type: 'Duration | Integer',
+      },
+      {
+        name: 'idealCycleTime',
+        desc: 'Ideal minimum time to produce one part.',
+        type: 'Duration | Integer',
+      },
+    ],
+    package: 'experimental/oee',
+    desc:
+      'Computes availability, performance, quality (APQ) and overall equipment effectiveness (OEE) in producing parts.',
+    example: `oee.APQ(
+    runningState: "running",
+    plannedTime: 8h,
+    idealCycleTime: 2m
+)`,
+    category: 'Transformations',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/oee/apq/',
+  },
+  {
+    name: 'oee.computeAPQ',
+    args: [
+      {
+        name: 'productionEvents',
+        desc:
+          'Production events stream that contains the production state or start and stop events.',
+        type: 'Stream of Tables',
+      },
+      {
+        name: 'partEvents',
+        desc:
+          'Part events that contains the running totals of parts produced and parts that do not meet quality standards.',
+        type: 'Stream of Tables',
+      },
+      {
+        name: 'runningState',
+        desc: 'State value that represents a running state.',
+        type: 'String',
+      },
+      {
+        name: 'plannedTime',
+        desc: 'Total time that equipment is expected to produce parts.',
+        type: 'Duration | Integer',
+      },
+      {
+        name: 'idealCycleTime',
+        desc: 'Ideal minimum time to produce one part.',
+        type: 'Duration | Integer',
+      },
+    ],
+    package: 'experimental/oee',
+    desc:
+      'Computes availability, performance, and quality (APQ) and overall equipment effectiveness (OEE) using two separate input streams—production events and part events.',
+    example: `oee.computeAPQ(
+    productionEvents: exampleProductionScheme,
+    partEvents: examplePartsStream,
+    runningState: "running",
+    plannedTime: 8h,
+    idealCycleTime: 2m,
+)`,
+    category: 'Transformations',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/oee/computeapq/',
+  },
+  {
+    name: 'opsgenie.endpoint',
+    args: [
+      {
+        name: 'url',
+        desc:
+          'Opsgenie API URL. Defaults to `https://api.opsgenie.com/v2/alerts`.',
+        type: 'String',
+      },
+      {
+        name: 'apiKey',
+        desc: 'Opsgenie API authorization key.',
+        type: 'String',
+      },
+      {
+        name: 'entity',
+        desc: 'Alert entity used to specify the alert domain.',
+        type: 'String',
+      },
+    ],
+    package: 'contrib/sranka/opsgenie',
+    desc:
+      'A factory function that outputs another function. The output function requires a `mapFn` parameter. See the documentation link for a full example.',
+    example: `endpoint = opsgenie.endpoint(
+    url: "https://api.opsgenie.com/v2/alerts",
+    apiKey: "YoUrSup3R5ecR37AuThK3y",
+    entity: "example-entity"
+)`,
+    category: 'Alerting',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/opsgenie/endpoint/',
+  },
+  {
+    name: 'opsgenie.sendAlert',
+    args: [
+      {
+        name: 'url',
+        desc:
+          'Opsgenie API URL. Defaults to `https://api.opsgenie.com/v2/alerts`.',
+        type: 'String',
+      },
+      {
+        name: 'apiKey',
+        desc: 'Opsgenie API authorization key.',
+        type: 'String',
+      },
+      {
+        name: 'message',
+        desc: 'Alert message text. 130 characters or less.',
+        type: 'String',
+      },
+      {
+        name: 'alias',
+        desc:
+          'Opsgenie alias usee to de-deduplicate alerts. 250 characters or less. Defaults to `message`.',
+        type: 'String',
+      },
+      {
+        name: 'description',
+        desc: 'Alert description. 15,000 characters or less.',
+        type: 'String',
+      },
+      {
+        name: 'priority',
+        desc:
+          'Opsgenie alert priority. Valid values include: P1, P2, P3 (default), P4, and P5.',
+        type: 'String',
+      },
+      {
+        name: 'responders',
+        desc:
+          'List of responder teams or users. Use the `user:` prefix for users and `teams:` prefix for teams.',
+        type: 'Array of Strings',
+      },
+      {
+        name: 'tags',
+        desc: 'Alert tags.',
+        type: 'String',
+      },
+      {
+        name: 'entity',
+        desc: 'Alert entity used to specify the alert domain.',
+        type: 'String',
+      },
+      {
+        name: 'actions',
+        desc: 'List of actions available for the alert.',
+        type: 'Array of strings',
+      },
+      {
+        name: 'details',
+        desc:
+          'Additional alert details. Must be a JSON-encoded map of key-value string pairs.',
+        type: 'String',
+      },
+      {
+        name: 'visibleTo',
+        desc:
+          'List of teams and users the alert will be visible to without sending notifications. Use the `user:` prefix for users and `teams:` prefix for teams.',
+        type: 'Array of strings',
+      },
+    ],
+    package: 'contrib/sranka/opsgenie',
+    desc: 'Sends an alert to Opsgenie.',
+    example: `opsgenie.sendAlert(
+    url: "https://api.opsgenie.com/v2/alerts",
+    apiKey: "YoUrSup3R5ecR37AuThK3y",
+    message: "Example message",
+    alias: "Example alias",
+    description: "Example description",
+    priority: "P3",
+    responders: ["user:john@example.com", "team:itcrowd"],
+    tags: ["tag1", "tag2"],
+    entity: "example-entity",
+    actions: ["action1", "action2"],
+    details: "{}",
+    visibleTo: []
+)`,
+    category: 'Alerting',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/opsgenie/sendalert/',
+  },
+  {
+    name: 'pagerduty.actionFromSeverity',
+    args: [
+      {
+        name: 'severity',
+        desc: 'The severity to convert to a PagerDuty action.',
+        type: 'String',
+      },
+    ],
+    package: 'pagerduty',
+    desc:
+      'Converts a severity to a PagerDuty action. `ok` converts to `resolve`. All other severities convert to `trigger`.',
+    example: 'pagerduty.actionFromSeverity(severity: "ok")',
+    category: 'Alerting',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/pagerduty/actionfromseverity/',
+  },
+  {
+    name: 'pagerduty.dedupKey',
+    args: [],
+    package: 'pagerduty',
+    desc:
+      'uses the group key of an input table to generate and store a deduplication key in the `_pagerdutyDedupKey` column.',
+    example: 'pagerduty.dedupKey()',
+    category: 'Alerting',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/pagerduty/dedupkey/',
+  },
+  {
+    name: 'pagerduty.endpoint',
+    args: [
+      {
+        name: 'url',
+        desc:
+          'The PagerDuty v2 Events API URL. Defaults to `https://events.pagerduty.com/v2/enqueue`.',
+        type: 'String',
+      },
+    ],
+    package: 'pagerduty',
+    desc:
+      'A factory function that outputs another function. The output function requires a `mapFn` parameter. See the documentation link for a full example.',
+    example: `endpoint = pagerduty.endpoint(
+    url: "https://events.pagerduty.com/v2/enqueue"
+)`,
+    category: 'Alerting',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/pagerduty/endpoint/',
+  },
+  {
+    name: 'pagerduty.sendEvent',
+    args: [
+      {
+        name: 'pagerdutyURL',
+        desc:
+          'The URL of the PagerDuty endpoint. Defaults to `https://events.pagerduty.com/v2/enqueue`.',
+        type: 'String',
+      },
+      {
+        name: 'routingKey',
+        desc: 'The routing key generated from your PagerDuty integration.',
+        type: 'String',
+      },
+      {
+        name: 'client',
+        desc: 'The name of the client sending the alert.',
+        type: 'String',
+      },
+      {
+        name: 'clientURL',
+        desc: 'The URL of the client sending the alert.',
+        type: 'String',
+      },
+      {
+        name: 'dedupkey',
+        desc:
+          'A per-alert ID that acts as deduplication key and allows you to acknowledge or change the severity of previous messages. Supports a maximum of 255 characters.',
+        type: 'String',
+      },
+      {
+        name: 'class',
+        desc: 'The class or type of the event. Classes are user-defined.',
+        type: 'String',
+      },
+      {
+        name: 'group',
+        desc: 'A logical grouping used by PagerDuty. Groups are user-defined.',
+        type: 'String',
+      },
+      {
+        name: 'severity',
+        desc:
+          'The severity of the event. Supported severities are `"critical"`, `"error"`, `"warning"`, `"info"`.',
+        type: 'String',
+      },
+      {
+        name: 'eventAction',
+        desc:
+          'Event type to send to PagerDuty. Valid values include `"trigger"`, `"resolve"`, `"acknowledge"`.',
+        type: 'String',
+      },
+      {
+        name: 'source',
+        desc:
+          'The unique location of the affected system. For example, the hostname or fully qualified domain name (FQDN).',
+        type: 'String',
+      },
+      {
+        name: 'summary',
+        desc:
+          'A brief text summary of the event used as the summaries or titles of associated alerts. The maximum permitted length is 1024 characters.',
+        type: 'String',
+      },
+      {
+        name: 'timestamp',
+        desc: 'The time the detected event occurred in RFC3339nano format.',
+        type: 'String',
+      },
+    ],
+    package: 'pagerduty',
+    desc: 'Sends an alert to PagerDuty.',
+    example: `pagerduty.sendEvent(
+    pagerdutyURL: "https://events.pagerduty.com/v2/enqueue",
+    routingKey: "ExampleRoutingKey",
+    client: "ExampleClient",
+    clientURL: "http://examplepagerdutyclient.com",
+    dedupkey: "ExampleDedupKey",
+    class: "cpu usage",
+    group: "app-stack",
+    severity: "ok",
+    eventAction: "trigger",
+    source: "monitoringtool:vendor:region",
+    summary: "This is an example summary.",
+    timestamp: "2016-07-17T08:42:58.315+0000"
+)`,
+    category: 'Alerting',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/pagerduty/sendevent/',
+  },
+  {
+    name: 'pagerduty.severityFromLevel',
+    args: [
+      {
+        name: 'level',
+        desc: 'The level to convert to a PagerDuty severity.',
+        type: 'String',
+      },
+    ],
+    package: 'pagerduty',
+    desc: 'Converts an InfluxDB status level to a PagerDuty severity.',
+    example: 'pagerduty.severityFromLevel(level: "crit")',
+    category: 'Alerting',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/pagerduty/severityfromlevel/',
+  },
+  {
     name: 'pearsonr',
     args: [
       {
@@ -3808,6 +5356,109 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     category: 'Inputs',
     link:
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/prometheus/scrape/',
+  },
+  {
+    name: 'pushbullet.endpoint',
+    args: [
+      {
+        name: 'url',
+        desc:
+          'Pushbullet API URL. Defaults to `https://api.pushbullet.com/v2/pushes`.',
+        type: 'String',
+      },
+      {
+        name: 'token',
+        desc:
+          'Pushbullet API token to use when interacting with Pushbullet. Defaults to `""`.',
+        type: 'String',
+      },
+    ],
+    package: 'pushbullet',
+    desc:
+      'A factory function that outputs another function. The output function requires a `mapFn` parameter. See the documentation link for a full example.',
+    example: `endpoint = pushbullet.endpoint(
+    url: "https://api.pushbullet.com/v2/pushes",
+    token: ""
+)`,
+    category: 'Alerting',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/pushbullet/endpoint/',
+  },
+  {
+    name: 'pushbullet.pushData',
+    args: [
+      {
+        name: 'url',
+        desc:
+          'Pushbullet API URL. Defaults to `https://api.pushbullet.com/v2/pushes`.',
+        type: 'String',
+      },
+      {
+        name: 'token',
+        desc:
+          'Pushbullet API token to use when interacting with Pushbullet. Defaults to `""`.',
+        type: 'String',
+      },
+      {
+        name: 'data',
+        desc:
+          'Data to send to the Pushbullet API. The function JSON-encodes data before sending it to Pushbullet.',
+        type: 'Record',
+      },
+    ],
+    package: 'pushbullet',
+    desc: 'Sends a push notification to the Pushbullet API.',
+    example: `pushbullet.pushData(
+    url: "https://api.pushbullet.com/v2/pushes",
+    token: "",
+    data: {
+        "type": "link",
+        "title": "This is a notification!",
+        "body": "This notification came from Flux.",
+        "url": "http://example.com"
+    }
+)`,
+    category: 'Alerting',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/pushbullet/pushdata/',
+  },
+  {
+    name: 'pushbullet.pushData',
+    args: [
+      {
+        name: 'url',
+        desc:
+          'Pushbullet API URL. Defaults to `https://api.pushbullet.com/v2/pushes`.',
+        type: 'String',
+      },
+      {
+        name: 'token',
+        desc:
+          'Pushbullet API token to use when interacting with Pushbullet. Defaults to `""`.',
+        type: 'String',
+      },
+      {
+        name: 'title',
+        desc: 'Title of the notification.',
+        type: 'String',
+      },
+      {
+        name: 'text',
+        desc: 'Text to display in the notification.',
+        type: 'String',
+      },
+    ],
+    package: 'pushbullet',
+    desc: 'Sends a push notification of type `note` to the Pushbullet API.',
+    example: `pushbullet.pushNote(
+    url: "https://api.pushbullet.com/v2/pushes",
+    token: "",
+    title: "This is a push notification!",
+    text: "This push notification came from Flux."
+)`,
+    category: 'Outputs',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/pushbullet/pushnote/',
   },
   {
     name: 'quantile',
@@ -4187,6 +5838,24 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/rename/',
   },
   {
+    name: 'rows.map',
+    args: [
+      {
+        name: 'fn',
+        desc:
+          'A single argument function to apply to each record. The return value must be a record.',
+        type: 'Function',
+      },
+    ],
+    package: 'contrib/jsternberg/rows',
+    desc:
+      'An alternate implementation of `map()` that is faster, but more limited than `map()`.',
+    example: 'rows.map( fn: (r) => ({_value: r._value * 100.0}))',
+    category: 'Transformations',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/rows/map/',
+  },
+  {
     name: 'runtime.version',
     args: [],
     package: 'runtime',
@@ -4283,6 +5952,22 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/influxdb-schema/measurementfieldkeys/',
   },
   {
+    name: 'schema.measurements',
+    args: [
+      {
+        name: 'bucket',
+        desc: 'The bucket from which to list measurements.',
+        type: 'String',
+      },
+    ],
+    package: 'influxdata/influxdb/schema',
+    desc: 'Returns a list of measurements in a specific bucket.',
+    example: 'schema.measurements(bucket: "example-bucket")',
+    category: 'Inputs',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/influxdb-schema/measurements/',
+  },
+  {
     name: 'schema.measurementTagKeys',
     args: [
       {
@@ -4332,22 +6017,6 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     category: 'Inputs',
     link:
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/influxdb-schema/measurementtagvalues/',
-  },
-  {
-    name: 'schema.measurements',
-    args: [
-      {
-        name: 'bucket',
-        desc: 'The bucket from which to list measurements.',
-        type: 'String',
-      },
-    ],
-    package: 'influxdata/influxdb/schema',
-    desc: 'Returns a list of measurements in a specific bucket.',
-    example: 'schema.measurements(bucket: "example-bucket")',
-    category: 'Inputs',
-    link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/influxdb-schema/measurements/',
   },
   {
     name: 'schema.tagKeys',
@@ -4427,6 +6096,121 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/secrets/get/',
   },
   {
+    name: 'sensu.endpoint',
+    args: [
+      {
+        name: 'url',
+        desc:
+          'Base URL of Sensu API without a trailing slash. Example: `http://localhost:8080`.',
+        type: 'String',
+      },
+      {
+        name: 'apiKey',
+        desc: 'Sensu API Key.',
+        type: 'String',
+      },
+      {
+        name: 'handlers',
+        desc: 'Sensu handlers to execute. Default is `[]`.',
+        type: 'Array of Strings',
+      },
+      {
+        name: 'namespace',
+        desc: 'Sensu namespace. Default is `default`.',
+        type: 'String',
+      },
+      {
+        name: 'entityName',
+        desc:
+          'Event source. Use alphanumeric characters, underscores (`_`), periods (`.`), and hyphens (`-`).',
+        type: 'String',
+      },
+    ],
+    package: 'contrib/sranka/sensu',
+    desc:
+      'A factory function that outputs another function. The output function requires a `mapFn` parameter. See the documentation link for a full example.',
+    example: `endpoint = sensu.endpoint(
+    url: "http://localhost:8080",
+    apiKey: "mYSuP3rs3cREtApIK3Y",
+    handlers: [],
+    namespace: "default",
+    entityName: "influxdb"
+)`,
+    category: 'Alerting',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/sensu/endpoint/',
+  },
+  {
+    name: 'sensu.event',
+    args: [
+      {
+        name: 'url',
+        desc:
+          'Base URL of Sensu API without a trailing slash. Example: `http://localhost:8080`.',
+        type: 'String',
+      },
+      {
+        name: 'apiKey',
+        desc: 'Sensu API Key.',
+        type: 'String',
+      },
+      {
+        name: 'checkName',
+        desc:
+          'Check name. Use alphanumeric characters, underscores (`_`), periods (`.`), and hyphens (`-`).',
+        type: 'String',
+      },
+      {
+        name: 'text',
+        desc: 'Event text. Mapped to `output` in the Sensu Events API request.',
+        type: 'String',
+      },
+      {
+        name: 'handlers',
+        desc: 'Sensu handlers to execute. Default is `[]`.',
+        type: 'Array of Strings',
+      },
+      {
+        name: 'status',
+        desc: 'Event status code that indicates state. Default is `0`.',
+        type: 'Integer',
+      },
+      {
+        name: 'state',
+        desc:
+          'Event state. Default is "passing" for 0 status and "failing" for other statuses.',
+        type: 'String',
+      },
+      {
+        name: 'namespace',
+        desc: 'Sensu namespace. Default is `default`.',
+        type: 'String',
+      },
+      {
+        name: 'entityName',
+        desc:
+          'Event source. Use alphanumeric characters, underscores (`_`), periods (`.`), and hyphens (`-`).',
+        type: 'String',
+      },
+    ],
+    package: 'contrib/sranka/sensu',
+    desc: 'Sends a single event to the Sensu Events API.',
+    example: `sensu.event(
+    url: "http://localhost:8080",
+    apiKey: "mYSuP3rs3cREtApIK3Y",
+    checkName: "checkName",
+    text: "Event output text",
+    handlers: [],
+    status: 0,
+    state: "passing",
+    namespace: "default",
+    entityName: "influxdb"
+)`,
+    category: 'Alerting',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/sensu/event/',
+  },
+  {
     name: 'set',
     args: [
       {
@@ -4463,6 +6247,77 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     category: 'Aggregates',
     link:
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/aggregates/skew/',
+  },
+  {
+    name: 'slack.endpoint',
+    args: [
+      {
+        name: 'url',
+        desc:
+          'The Slack API URL. Defaults to `https://slack.com/api/chat.postMessage`.',
+        type: 'String',
+      },
+      {
+        name: 'token',
+        desc:
+          'The Slack API token used to interact with Slack. Defaults to `""`.',
+        type: 'String',
+      },
+    ],
+    package: 'slack',
+    desc:
+      'A factory function that outputs another function. The output function requires a `mapFn` parameter. See the documentation link for a full example.',
+    example: `endpoint = slack.endpoint(
+    url: "https://slack.com/api/chat.postMessage",
+    token: "mySuPerSecRetTokEn"
+)`,
+    category: 'Alerting',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/slack/endpoint/',
+  },
+  {
+    name: 'slack.message',
+    args: [
+      {
+        name: 'url',
+        desc:
+          'The Slack API URL. Defaults to `https://slack.com/api/chat.postMessage`.',
+        type: 'String',
+      },
+      {
+        name: 'token',
+        desc:
+          'The Slack API token used to interact with Slack. Defaults to `""`.',
+        type: 'String',
+      },
+      {
+        name: 'channel',
+        desc: 'The name of channel to post the message to.',
+        type: 'String',
+      },
+      {
+        name: 'text',
+        desc: 'The text to display in the Slack message.',
+        type: 'String',
+      },
+      {
+        name: 'color',
+        desc: 'The color to include with the message.',
+        type: 'String',
+      },
+    ],
+    package: 'slack',
+    desc: 'Sends a single message to a Slack channel.',
+    example: `slack.message(
+    url: "https://slack.com/api/chat.postMessage",
+    token: "mySuPerSecRetTokEn",
+    channel: "#flux",
+    text: "This is a message from the Flux slack.message() function.",
+    color: "good"
+)`,
+    category: 'Alerting',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/slack/message/',
   },
   {
     name: 'sleep',
@@ -5403,6 +7258,16 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/system/time/',
   },
   {
+    name: 'table.fill',
+    args: [],
+    package: 'experimental/table',
+    desc: 'Adds a single row to empty tables in a stream of tables.',
+    example: 'table.fill()',
+    category: 'Miscellaneous',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/table/fill/',
+  },
+  {
     name: 'tableFind',
     args: [
       {
@@ -5461,6 +7326,159 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/influxdb-tasks/lastsuccess/',
   },
   {
+    name: 'teams.endpoint',
+    args: [
+      {
+        name: 'url',
+        desc: 'Incoming webhook URL.',
+        type: 'String',
+      },
+    ],
+    package: 'contrib/sranka/teams',
+    desc:
+      'A factory function that outputs another function. The output function requires a `mapFn` parameter. See the documentation link for a full example.',
+    example: `endpoint = teams.endpoint(
+    url: "https://outlook.office.com/webhook/example-webhook"
+)`,
+    category: 'Alerting',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/teams/endpoint/',
+  },
+  {
+    name: 'teams.message',
+    args: [
+      {
+        name: 'url',
+        desc: 'Incoming webhook URL.',
+        type: 'String',
+      },
+      {
+        name: 'title',
+        desc: 'Message card title.',
+        type: 'String',
+      },
+      {
+        name: 'text',
+        desc: 'Message card text.',
+        type: 'String',
+      },
+      {
+        name: 'summary',
+        desc:
+          'Message card summary. Default is `""`. If no summary is provided, Flux generates the summary from the message text.',
+        type: 'String',
+      },
+    ],
+    package: 'contrib/sranka/teams',
+    desc:
+      'Sends a single message to a Microsoft Teams channel using an incoming webhook.',
+    example: `teams.message(
+    url: "https://outlook.office.com/webhook/example-webhook",
+    title: "Example message title",
+    text: "Example message text",
+    summary: "",
+)`,
+    category: 'Alerting',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/teams/message/',
+  },
+  {
+    name: 'telegram.endpoint',
+    args: [
+      {
+        name: 'url',
+        desc:
+          'URL of the Telegram bot endpoint. Default is `https://api.telegram.org/bot`.',
+        type: 'String',
+      },
+      {
+        name: 'token',
+        desc: 'Telegram bot token.',
+        type: 'String',
+      },
+      {
+        name: 'parseMode',
+        desc: 'Parse mode of the message text. Default is `"MarkdownV2"`.',
+        type: 'String',
+      },
+      {
+        name: 'disableWebPagePreview',
+        desc:
+          'Disable preview of web links in the sent message. Default is `false`.',
+        type: 'Boolean',
+      },
+    ],
+    package: 'contrib/sranka/telegram',
+    desc:
+      'A factory function that outputs another function. The output function requires a `mapFn` parameter. See the documentation link for a full example.',
+    example: `endpoint = telegram.endpoint(
+    url: "https://api.telegram.org/bot",
+    token: "S3crEtTel3gRamT0k3n",
+    parseMode: "MarkdownV2",
+    disableWebPagePreview: false,
+)`,
+    category: 'Alerting',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/telegram/endpoint/',
+  },
+  {
+    name: 'telegram.message',
+    args: [
+      {
+        name: 'url',
+        desc:
+          'URL of the Telegram bot endpoint. Default is `https://api.telegram.org/bot`.',
+        type: 'String',
+      },
+      {
+        name: 'token',
+        desc: 'Telegram bot token.',
+        type: 'String',
+      },
+      {
+        name: 'channel',
+        desc: 'Telegram channel ID.',
+        type: 'String',
+      },
+      {
+        name: 'text',
+        desc: 'Message text.',
+        type: 'String',
+      },
+      {
+        name: 'parseMode',
+        desc: 'Parse mode of the message text. Default is `"MarkdownV2"`.',
+        type: 'String',
+      },
+      {
+        name: 'disableWebPagePreview',
+        desc:
+          'Disable preview of web links in the sent message. Default is `false`.',
+        type: 'Boolean',
+      },
+      {
+        name: 'silent',
+        desc: 'Send message silently. Default is `true`.',
+        type: 'Boolean',
+      },
+    ],
+    package: 'contrib/sranka/telegram',
+    desc:
+      'Sends a single message to a Telegram channel using the sendMessage method of the Telegram Bot API.',
+    example: `telegram.message(
+    url: "https://api.telegram.org/bot",
+    token: "S3crEtTel3gRamT0k3n",
+    channel: "-12345",
+    text: "Example message text",
+    parseMode: "MarkdownV2",
+    disableWebPagePreview: false,
+    silent: true
+)`,
+    category: 'Alerting',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/telegram/message/',
+  },
+  {
     name: 'testing.assertEmpty',
     args: [],
     package: 'testing',
@@ -5497,6 +7515,23 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/testing/assertequals/',
   },
   {
+    name: 'testing.benchmark',
+    args: [
+      {
+        name: 'case',
+        desc: 'Test case to benchmark.',
+        type: 'Function',
+      },
+    ],
+    package: 'testing',
+    desc:
+      'Executes a test case without comparing test output with the expected test output.',
+    example: 'testing.benchmark(case: exampleTestCase)',
+    category: 'Tests',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/testing/benchmark/',
+  },
+  {
     name: 'testing.diff',
     args: [
       {
@@ -5522,6 +7557,395 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     category: 'Tests',
     link:
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/testing/diff/',
+  },
+  {
+    name: 'testing.inspect',
+    args: [
+      {
+        name: 'case',
+        desc: 'Test case to inspect.',
+        type: 'Function',
+      },
+    ],
+    package: 'testing',
+    desc: 'Returns information about a test case.',
+    example: 'testing.inspect(case: exampleTestCase)',
+    category: 'Tests',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/testing/inspect/',
+  },
+  {
+    name: 'testing.load',
+    args: [],
+    package: 'testing',
+    desc: 'Loads tests data from a stream of tables.',
+    example: 'testing.load()',
+    category: 'Tests',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/testing/inspect/',
+  },
+  {
+    name: 'testing.loadMem',
+    args: [
+      {
+        name: 'csv',
+        desc: 'Annotated CSV data to load.',
+        type: 'String',
+      },
+    ],
+    package: 'testing',
+    desc:
+      'Loads annotated CSV test data from memory to emulate query results returned by Flux.',
+    example: 'testing.loadMem(csv: csvData)',
+    category: 'Tests',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/testing/loadmem/',
+  },
+  {
+    name: 'testing.loadStorage',
+    args: [
+      {
+        name: 'csv',
+        desc: 'Annotated CSV data to load.',
+        type: 'String',
+      },
+    ],
+    package: 'testing',
+    desc: 'Loads annotated CSV test data as if it were queried from InfluxDB.',
+    example: 'testing.loadStorage(csv: csvData)',
+    category: 'Tests',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/testing/loadstorage/',
+  },
+  {
+    name: 'testing.run',
+    args: [
+      {
+        name: 'case',
+        desc: 'Test case to run.',
+        type: 'Function',
+      },
+    ],
+    package: 'testing',
+    desc: 'Executes a specified test case.',
+    example: 'testing.run(case: exampleTestCase)',
+    category: 'Tests',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/testing/run/',
+  },
+  {
+    name: 'tickscript.alert',
+    args: [
+      {
+        name: 'check',
+        desc: 'InfluxDB check data. See `tickscript.defineCheck()`.',
+        type: 'Record',
+      },
+      {
+        name: 'id',
+        desc:
+          'Function that returns the InfluxDB check ID provided by the check record. Default is `(r) => "${r._check_id}"`.',
+        type: 'Function',
+      },
+      {
+        name: 'details',
+        desc:
+          'Function to return the InfluxDB check details using data from input rows. Default is `(r) => ""`.',
+        type: 'Function',
+      },
+      {
+        name: 'message',
+        desc:
+          'Function to return the InfluxDB check message using data from input rows. Default is `(r) => "Threshold Check: ${r._check_name} is: ${r._level}"`.',
+        type: 'Function',
+      },
+      {
+        name: 'crit',
+        desc:
+          'Predicate function to determine crit status. Default is `(r) => false`.',
+        type: 'Function',
+      },
+      {
+        name: 'warn',
+        desc:
+          'Predicate function to determine warn status. Default is `(r) => false`.',
+        type: 'Function',
+      },
+      {
+        name: 'info',
+        desc:
+          'Predicate function to determine info status. Default is `(r) => false`.',
+        type: 'Function',
+      },
+      {
+        name: 'ok',
+        desc:
+          'Predicate function to determine ok status. Default is `(r) => false`.',
+        type: 'Function',
+      },
+      {
+        name: 'topic',
+        desc: 'Check topic. Default is `""`.',
+        type: 'String',
+      },
+    ],
+    package: 'contrib/bonitoo-io/tickscript',
+    desc:
+      'Identifies events of varying severity levels and writes them to the statuses measurement in the InfluxDB `_monitoring` system bucket.',
+    example: `tickscript.alert(
+    check,
+    id: (r) => "\${r._check_id}",
+    details: (r) => "",
+    message: (r) => "Threshold Check: \${r._check_name} is: \${r._level}",
+    crit: (r) => false,
+    warn: (r) => false,
+    info: (r) => false,
+    ok: (r) => true,
+    topic: ""
+)`,
+    category: 'Alerting',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/tickscript/alert/',
+  },
+  {
+    name: 'tickscript.compute',
+    args: [
+      {
+        name: 'column',
+        desc: 'Column to operate on. Default is `_value`.',
+        type: 'String',
+      },
+      {
+        name: 'fn',
+        desc: 'Aggregate or selector function to apply.',
+        type: 'Function',
+      },
+      {
+        name: 'as',
+        desc: 'New column name.',
+        type: 'String',
+      },
+    ],
+    package: 'contrib/bonitoo-io/tickscript',
+    desc:
+      'An alias for `tickscript.select()` that changes a column’s name and optionally applies an aggregate or selector function.',
+    example: `tickscript.compute(
+    column: "_value",
+    fn: sum,
+    as: "example-name"
+)`,
+    category: 'Outputs',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/tickscript/compute/',
+  },
+  {
+    name: 'tickscript.deadman',
+    args: [
+      {
+        name: 'check',
+        desc: 'InfluxDB check data. See `tickscript.defineCheck()`.',
+        type: 'Record',
+      },
+      {
+        name: 'measurement',
+        desc: 'Measurement name. Should match the queried measurement.',
+        type: 'String',
+      },
+      {
+        name: 'threshold',
+        desc:
+          'Count threshold. The function assigns a `crit` status to input tables with a number of rows less than or equal to the threshold. Default is `0`.',
+        type: 'Integer',
+      },
+      {
+        name: 'id',
+        desc:
+          'Function that returns the InfluxDB check ID provided by the check record. Default is `(r) => "${r._check_id}"`.',
+        type: 'Function',
+      },
+      {
+        name: 'message',
+        desc:
+          'Function that returns the InfluxDB check message using data from input rows. Default is `(r) => "Deadman Check: ${r._check_name} is: " + (if r.dead then "dead" else "alive")`.',
+        type: 'Function',
+      },
+      {
+        name: 'topic',
+        desc: 'Check topic. Default is `""`.',
+        type: 'String',
+      },
+    ],
+    package: 'contrib/bonitoo-io/tickscript',
+    desc:
+      'Detects low data throughput and writes a point with a critical status to the InfluxDB `_monitoring` system bucket.',
+    example: `tickscript.deadman(
+    check: {},
+    measurement: "example-measurement",
+    threshold: 0,
+    id: (r)=>"\${r._check_id}",
+    message: (r) => "Deadman Check: \${r._check_name} is: " + (if r.dead then "dead" else "alive"),
+    topic: ""
+)`,
+    category: 'Alerting',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/tickscript/deadman/',
+  },
+  {
+    name: 'tickscript.defineCheck',
+    args: [
+      {
+        name: 'id',
+        desc: 'InfluxDB check ID.',
+        type: 'String',
+      },
+      {
+        name: 'name',
+        desc: 'InfluxDB check name.',
+        type: 'String',
+      },
+      {
+        name: 'type',
+        desc:
+          'InfluxDB check type. Default is `custom`. Valid types are `thresold`, `deadman`, and `custom`.',
+        type: 'String',
+      },
+    ],
+    package: 'contrib/bonitoo-io/tickscript',
+    desc:
+      'Creates and returns a record with custom check data required by `tickscript.alert()` and `tickscript.deadman()`.',
+    example: `tickscript.defineCheck(
+    id: "000000000000",
+    name: "Example check name",
+    type: "custom"
+)`,
+    category: 'Outputs',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/tickscript/definecheck/',
+  },
+  {
+    name: 'tickscript.groupBy',
+    args: [
+      {
+        name: 'columns',
+        desc: 'List of columns to group by.',
+        type: 'Array of Strings',
+      },
+    ],
+    package: 'contrib/bonitoo-io/tickscript',
+    desc:
+      'Groups results by the _measurement column and other specified columns.',
+    example: `tickscript.groupBy(
+    columns: ["exampleColumn"]
+)`,
+    category: 'Transformations',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/tickscript/groupby/',
+  },
+  {
+    name: 'tickscript.join',
+    args: [
+      {
+        name: 'tables',
+        desc: 'Map of two streams to join.',
+        type: 'Record',
+      },
+      {
+        name: 'on',
+        desc: 'List of columns to join on. Default is `["_time"]`.',
+        type: 'Array of Strings',
+      },
+      {
+        name: 'measurement',
+        desc: 'Measurement name to use in results.',
+        type: 'String',
+      },
+    ],
+    package: 'contrib/bonitoo-io/tickscript',
+    desc:
+      'Merges two input streams into a single output stream based on specified columns with equal values and appends a new measurement name.',
+    example: `tickscript.join(
+    tables: {t1: example1, t2: example2}
+    on: ["_time"],
+    measurement: "example-measurement"
+)`,
+    category: 'Transformations',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/tickscript/join/',
+  },
+  {
+    name: 'tickscript.select',
+    args: [
+      {
+        name: 'column',
+        desc: 'Column to operate on. Default is `_value`.',
+        type: 'String',
+      },
+      {
+        name: 'fn',
+        desc: 'Aggregate or selector function to apply.',
+        type: 'Function',
+      },
+      {
+        name: 'as',
+        desc: 'New column name.',
+        type: 'String',
+      },
+    ],
+    package: 'contrib/bonitoo-io/tickscript',
+    desc:
+      'Changes a column’s name and optionally applies an aggregate or selector function to values in the column.',
+    example: `tickscript.select(
+    column: "_value",
+    fn: sum,
+    as: "example-name"
+)`,
+    category: 'Transformations',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/tickscript/select/',
+  },
+  {
+    name: 'tickscript.selectWindow',
+    args: [
+      {
+        name: 'column',
+        desc: 'Column to operate on. Default is `_value`.',
+        type: 'String',
+      },
+      {
+        name: 'fn',
+        desc: 'Aggregate or selector function to apply.',
+        type: 'Function',
+      },
+      {
+        name: 'as',
+        desc: 'New column name.',
+        type: 'String',
+      },
+      {
+        name: 'every',
+        desc: 'Duration of windows.',
+        type: 'Duration',
+      },
+      {
+        name: 'defaultValue',
+        desc:
+          'Default fill value for null values in `column`. Must be the same data type as `column`.',
+        type: 'String | Boolean | Float | Integer | Uinteger | Bytes',
+      },
+    ],
+    package: 'contrib/bonitoo-io/tickscript',
+    desc:
+      'Changes a column’s name, windows rows by time, and applies an aggregate or selector function the specified column for each window of time.',
+    example: `tickscript.selectWindow(
+    column: "_value",
+    fn: sum,
+    as: "example-name",
+    every: 1m,
+    defaultValue: 0.0,
+)`,
+    category: 'Transformations',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/tickscript/selectwindow/',
   },
   {
     name: 'time',
@@ -5684,6 +8108,16 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/type-conversions/tobool',
   },
   {
+    name: 'today',
+    args: [],
+    package: '',
+    desc: 'Returns the `now()` timestamp truncated to the day unit.',
+    example: 'today()',
+    category: 'Miscellaneous',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/misc/today/',
+  },
+  {
     name: 'toFloat',
     args: [],
     package: '',
@@ -5702,6 +8136,28 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     category: 'Type Conversions',
     link:
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/type-conversions/toint/',
+  },
+  {
+    name: 'top',
+    args: [
+      {
+        name: 'n',
+        desc: 'Number of rows to return.',
+        type: 'Integer',
+      },
+      {
+        name: 'columns',
+        desc:
+          'List of columns by which to sort. Sort precedence is determined by list order (left to right). Default is `["_value"]`.',
+        type: 'Array of Strings',
+      },
+    ],
+    package: '',
+    desc: 'Sorts a table by columns and keeps only the top n rows.',
+    example: 'top(n:10, columns: ["_value"])',
+    category: 'Selectors',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/selectors/top/',
   },
   {
     name: 'toString',
@@ -5732,28 +8188,6 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     category: 'Type Conversions',
     link:
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/type-conversions/touint/',
-  },
-  {
-    name: 'top',
-    args: [
-      {
-        name: 'n',
-        desc: 'Number of rows to return.',
-        type: 'Integer',
-      },
-      {
-        name: 'columns',
-        desc:
-          'List of columns by which to sort. Sort precedence is determined by list order (left to right). Default is `["_value"]`.',
-        type: 'Array of Strings',
-      },
-    ],
-    package: '',
-    desc: 'Sorts a table by columns and keeps only the top n rows.',
-    example: 'top(n:10, columns: ["_value"])',
-    category: 'Selectors',
-    link:
-      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/selectors/top/',
   },
   {
     name: 'tripleEMA',
@@ -5839,6 +8273,166 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/selectors/unique/',
   },
   {
+    name: 'usage.from',
+    args: [
+      {
+        name: 'start',
+        desc: 'Earliest time to include in results.',
+        type: 'Time | Duration',
+      },
+      {
+        name: 'stop',
+        desc: 'Latest time to include in results.',
+        type: 'Time | Duration',
+      },
+      {
+        name: 'host',
+        desc:
+          'InfluxDB Cloud region URL (Required if executed outside of your InfluxDB Cloud organization or region). Default is `""`.',
+        type: 'String',
+      },
+      {
+        name: 'orgID',
+        desc:
+          'InfluxDB Cloud organization ID (Required if executed outside of your InfluxDB Cloud organization or region). Default is `""`.',
+        type: 'String',
+      },
+      {
+        name: 'token',
+        desc:
+          'InfluxDB Cloud authentication token (Required if executed outside of your InfluxDB Cloud organization or region). Default is `""`.',
+        type: 'String',
+      },
+      {
+        name: 'raw',
+        desc:
+          'Return raw, high resolution usage data instead of downsampled usage data. Default is `false`.',
+        type: 'Boolean',
+      },
+    ],
+    package: 'experimental/usage',
+    desc: 'Returns usage data from an InfluxDB Cloud organization.',
+    example: `usage.from(
+    start: -30d,
+    stop: now(),
+    host: "",
+    orgID: "",
+    token: "",
+    raw: false
+)`,
+    category: 'Inputs',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/usage/from/',
+  },
+  {
+    name: 'usage.limits',
+    args: [
+      {
+        name: 'host',
+        desc:
+          'InfluxDB Cloud region URL (Required if executed outside of your InfluxDB Cloud organization or region). Default is `""`.',
+        type: 'String',
+      },
+      {
+        name: 'orgID',
+        desc:
+          'InfluxDB Cloud organization ID (Required if executed outside of your InfluxDB Cloud organization or region). Default is `""`.',
+        type: 'String',
+      },
+      {
+        name: 'token',
+        desc:
+          'InfluxDB Cloud authentication token (Required if executed outside of your InfluxDB Cloud organization or region). Default is `""`.',
+        type: 'String',
+      },
+    ],
+    package: 'experimental/usage',
+    desc:
+      'Returns a record containing usage limits for an InfluxDB Cloud organization.',
+    example: `usage.limits(
+    host: "",
+    orgID: "",
+    token: ""
+)`,
+    category: 'Inputs',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/experimental/usage/limits/',
+  },
+  {
+    name: 'victorops.endpoint',
+    args: [
+      {
+        name: 'url',
+        desc: 'VictorOps REST endpoint integration URL.',
+        type: 'String',
+      },
+    ],
+    package: 'contrib/bonitoo-io/victorops',
+    desc:
+      'A factory function that outputs another function. The output function requires a `mapFn` parameter. See the documentation link for a full example.',
+    example: `endpoint = victorops.endpoint(
+    url: "https://alert.victorops.com/integrations/generic/00000000/alert\${apiKey}/\${routingKey}",
+)`,
+    category: 'Alerting',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/victorops/endpoint/',
+  },
+  {
+    name: 'victorops.event',
+    args: [
+      {
+        name: 'url',
+        desc: 'VictorOps REST endpoint integration URL.',
+        type: 'String',
+      },
+      {
+        name: 'monitoringTool',
+        desc: 'Monitoring agent name. Default is `""`.',
+        type: 'String',
+      },
+      {
+        name: 'messageType',
+        desc:
+          'VictorOps message type (alert behavior). Valid values are `CRITICAL`, `WARNING`, and `INFO`.',
+        type: 'String',
+      },
+      {
+        name: 'entityID',
+        desc: 'Incident ID. Default is `""`.',
+        type: 'String',
+      },
+      {
+        name: 'entityDisplayName',
+        desc: 'Incident display name or summary. Default is `""`.',
+        type: 'String',
+      },
+      {
+        name: 'stateMessage',
+        desc: 'Verbose incident message. Default is `""`.',
+        type: 'String',
+      },
+      {
+        name: 'timestamp',
+        desc: 'Incident start time. Default is `now()`.',
+        type: 'Time',
+      },
+    ],
+    package: 'contrib/bonitoo-io/victorops',
+    desc: 'Sends an alert to VictorOps (Now Splunk On-Call).',
+    example: `victorops.event(
+    url: "https://alert.victorops.com/integrations/generic/00000000/alert/\${api_key}/\${routing_key}",
+    monitoringTool: "",
+    messageType: "CRITICAL",
+    entityID: "",
+    entityDisplayName: "",
+    stateMessage: "",
+    timestamp: now()
+)`,
+    category: 'Alerting',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/victorops/event/',
+  },
+  {
     name: 'window',
     args: [
       {
@@ -5912,5 +8506,167 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     category: 'Outputs',
     link:
       'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/outputs/yield/',
+  },
+  {
+    name: 'zenoss.endpoint',
+    args: [
+      {
+        name: 'url',
+        desc: 'Zenoss router endpoint URL.',
+        type: 'String',
+      },
+      {
+        name: 'username',
+        desc:
+          'Zenoss username to use for HTTP BASIC authentication. Default is "" (no authentication).',
+        type: 'String',
+      },
+      {
+        name: 'password',
+        desc:
+          'Zenoss password to use for HTTP BASIC authentication. Default is "" (no authentication).',
+        type: 'String',
+      },
+      {
+        name: 'action',
+        desc: 'Zenoss router name. Default is `"EventsRouter"`.',
+        type: 'String',
+      },
+      {
+        name: 'method',
+        desc: 'EventsRouter method. Default is `"add_event"`.',
+        type: 'String',
+      },
+      {
+        name: 'type',
+        desc: 'Event type. Default is `"rpc"`.',
+        type: 'String',
+      },
+      {
+        name: 'tid',
+        desc: 'Temporary request transaction ID. Default is `1`.',
+        type: 'Integer',
+      },
+    ],
+    package: 'contrib/bonitoo-io/zenoss',
+    desc:
+      'A factory function that outputs another function. The output function requires a `mapFn` parameter. See the documentation link for a full example.',
+    example: `endpoint = zenoss.endpoint(
+    url: "https://example.zenoss.io:8080/zport/dmd/evconsole_router",
+    username: "example-user",
+    password: "example-password",
+    action: "EventsRouter",
+    method: "add_event",
+    type: "rpc",
+    tid: 1
+)`,
+    category: 'Alerting',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/zenoss/endpoint/',
+  },
+  {
+    name: 'zenoss.event',
+    args: [
+      {
+        name: 'url',
+        desc: 'Zenoss router endpoint URL.',
+        type: 'String',
+      },
+      {
+        name: 'username',
+        desc:
+          'Zenoss username to use for HTTP BASIC authentication. Default is "" (no authentication).',
+        type: 'String',
+      },
+      {
+        name: 'password',
+        desc:
+          'Zenoss password to use for HTTP BASIC authentication. Default is "" (no authentication).',
+        type: 'String',
+      },
+      {
+        name: 'action',
+        desc: 'Zenoss router name. Default is `"EventsRouter"`.',
+        type: 'String',
+      },
+      {
+        name: 'method',
+        desc: 'EventsRouter method. Default is `"add_event"`.',
+        type: 'String',
+      },
+      {
+        name: 'type',
+        desc: 'Event type. Default is `"rpc"`.',
+        type: 'String',
+      },
+      {
+        name: 'tid',
+        desc: 'Temporary request transaction ID. Default is `1`.',
+        type: 'Integer',
+      },
+      {
+        name: 'summary',
+        desc: 'Event summary. Default is `""`.',
+        type: 'String',
+      },
+      {
+        name: 'device',
+        desc: 'Related device. Default is `""`.',
+        type: 'String',
+      },
+      {
+        name: 'component',
+        desc: 'Related component. Default is `""`.',
+        type: 'String',
+      },
+      {
+        name: 'severity',
+        desc:
+          'Event severity level. Supported values are `Critical`, `Warning`, `Info`, and `Clear`.',
+        type: 'String',
+      },
+      {
+        name: 'eventClass',
+        desc: 'Event class. Default is `""`.',
+        type: 'String',
+      },
+      {
+        name: 'eventClassKey',
+        desc: 'Event class key. Default is `""`.',
+        type: 'String',
+      },
+      {
+        name: 'collector',
+        desc: 'Zenoss collector. Default is `""`.',
+        type: 'String',
+      },
+      {
+        name: 'message',
+        desc: 'Related message. Default is `""`.',
+        type: 'String',
+      },
+    ],
+    package: 'contrib/bonitoo-io/zenoss',
+    desc: 'Sends an alert to Zenoss.',
+    example: `zenoss.event(
+    url: "https://example.zenoss.io:8080/zport/dmd/evconsole_router",
+    username: "example-user",
+    password: "example-password",
+    action: "EventsRouter",
+    method: "add_event",
+    type: "rpc",
+    tid: 1,
+    summary: "",
+    device: "",
+    component: "",
+    severity: "Critical",
+    eventClass: "",
+    eventClassKey: "",
+    collector: "",
+    message: ""
+)`,
+    category: 'Alerting',
+    link:
+      'https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/contrib/zenoss/event/',
   },
 ]

--- a/src/shared/constants/fluxFunctions.ts
+++ b/src/shared/constants/fluxFunctions.ts
@@ -402,13 +402,13 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Array of Objects',
       },
     ],
-    package: 'experimental/array',
+    package: 'array',
     desc: 'Constructs a table from an array of objects.',
     example:
       'array.from(rows: [{_time: 2020-01-01T00:00:00Z, _value: "foo"},{_time: 2020-01-02T00:00:00Z, _value: "bar"}])',
     category: 'Inputs',
     link:
-      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/experimental/array/from/',
+      'https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/array/from/',
   },
   {
     name: 'bigpanda.endpoint',
@@ -1393,7 +1393,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     args: [
       {
         name: 'unit',
-        desc: 'The unit time to return. Defaults to `1s`.',
+        desc: 'The unit of time to return. Defaults to `1s`.',
         type: 'Duration',
       },
       {

--- a/src/shared/constants/fluxFunctions.ts
+++ b/src/shared/constants/fluxFunctions.ts
@@ -542,7 +542,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       {
         name: 'v',
         desc: 'The value to convert.',
-        type: 'String, Integer, UInteger, Float',
+        type: 'String | Integer | UInteger | Float',
       },
     ],
     package: '',
@@ -590,7 +590,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       {
         name: 'v',
         desc: 'The value to convert.',
-        type: 'String, Integer, UInteger, Float, Boolean',
+        type: 'String | Integer | UInteger | Float | Boolean',
       },
     ],
     package: '',
@@ -645,12 +645,12 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       {
         name: 'value',
         desc: 'The value to search for.',
-        type: 'Boolean, Integer, UInteger, Float, String, Time',
+        type: 'Boolean | Integer | UInteger | Float | String | Time',
       },
       {
         name: 'set',
         desc: 'The set of values in which to search.',
-        type: 'Boolean, Integer, UInteger, Float, String, Time',
+        type: 'Boolean | Integer | UInteger | Float | String | Time',
       },
     ],
     package: '',
@@ -2084,7 +2084,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       {
         name: 'v',
         desc: 'The value to convert.',
-        type: 'String, Integer, UInteger, Boolean',
+        type: 'String | Integer | UInteger | Boolean',
       },
     ],
     package: '',
@@ -3087,7 +3087,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       {
         name: 'v',
         desc: 'The value to convert.',
-        type: 'String, Integer, UInteger, Float, Boolean',
+        type: 'String | Integer | UInteger | Float | Boolean',
       },
     ],
     package: '',
@@ -3182,7 +3182,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       {
         name: 'v',
         desc: 'The value to encode.',
-        type: 'Boolean, Duration, Float, Integer, String, Time, UInteger',
+        type: 'Boolean | Duration | Float | Integer | String | Time | UInteger',
       },
     ],
     package: 'json',
@@ -6525,7 +6525,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       {
         name: 'v',
         desc: 'The value to convert.',
-        type: 'Integer, UInteger, Float, Boolean, Duration, Time',
+        type: 'Integer | UInteger | Float | Boolean | Duration | Time',
       },
     ],
     package: '',
@@ -7953,7 +7953,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       {
         name: 'v',
         desc: 'The value to convert.',
-        type: 'String, Integer, UInteger',
+        type: 'String | Integer | UInteger',
       },
     ],
     package: '',
@@ -8245,7 +8245,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       {
         name: 'v',
         desc: 'The value to convert.',
-        type: 'String, Integer, Boolean',
+        type: 'String | Integer | Boolean',
       },
     ],
     package: '',


### PR DESCRIPTION
Closes #

Adds the missing flux functions from https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/all-functions/