### PR TITLE
fix: prevent infinite re-render in stacked line graphs

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "@influxdata/clockface": "^2.8.0",
     "@influxdata/flux": "^0.5.1",
     "@influxdata/flux-lsp-browser": "^0.5.48",
-    "@influxdata/giraffe": "^2.10.6",
+    "@influxdata/giraffe": "^2.12.0",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -725,10 +725,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/flux/-/flux-0.5.1.tgz#e39e7a7af9163fc9494422c8fed77f3ae1b68f56"
   integrity sha512-GHlkXBhSdJ2m56JzDkbnKPAqLj3/lexPooacu14AWTO4f2sDGLmzM7r0AxgdtU1M2x7EXNBwgGOI5EOAdN6mkw==
 
-"@influxdata/giraffe@^2.10.6":
-  version "2.10.6"
-  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.10.6.tgz#9b0deb506caac7ef4b002924e13da3a3edac533c"
-  integrity sha512-xrhg4K4yuQAfsZlVNX6Wd7YwTCQbF+8mCDPHYxvMUsUsd7h8rlVOPUWs2j3DVHbbd1Ps7KDwgtmEAfsC9fv38Q==
+"@influxdata/giraffe@^2.12.0":
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.12.0.tgz#5eb7fcda226896504d02c068f7810b8eed0887d2"
+  integrity sha512-yN7hSKCHlGKRKpBtqAqnaP1Lk5vBPTNIJUtwtGFUS2niCR+K83s02oNzgHz4Jk1JNExeZmEOtg9uzeRsDT9csg==
   dependencies:
     merge-images "^2.0.0"
 


### PR DESCRIPTION
Closes #1603 

- Prevents infinite re-renders on stacked lines by memoizing dependencies used by stacked lines
- Brings back the additional legend columns used by stacked lines


https://user-images.githubusercontent.com/10736577/120587114-99cbd200-c3e9-11eb-9866-437e008a8538.mp4


