### PR TITLE
fix: dashboard header when removing name is back to default

### DIFF
--- a/src/dashboards/components/DashboardPage.tsx
+++ b/src/dashboards/components/DashboardPage.tsx
@@ -114,7 +114,8 @@ class DashboardPage extends Component<Props> {
 
   private get pageTitle(): string {
     const {dashboard} = this.props
-    const title = dashboard && dashboard.name ? dashboard.name : 'Loading...'
+    const title =
+      dashboard && dashboard.name ? dashboard.name : 'Name this Dashboard'
 
     return pageTitleSuffixer([title])
   }


### PR DESCRIPTION
Closes #18998

<!-- Describe your proposed changes here. -->
Makes the fallback option for dashboard title "Name this Dashboard" so it matches the default name