### PR TITLE
chore: codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Changes to any file in this repo require approval from a member of the InfluxData ui-team
+*   @influxdata/ui-team


### PR DESCRIPTION
Adds a CODEOWNERS file that makes the github team `ui-team` owners of the UI repo. All future PRs will require approval from someone in the `ui-team` before being merged.