### PR TITLE
fix: fix flaky test. yet again

### DIFF
--- a/cypress/e2e/cloud/home.test.ts
+++ b/cypress/e2e/cloud/home.test.ts
@@ -117,6 +117,9 @@ from(bucket: "_tasks"{rightArrow}
 
   // Run the Notebook
   cy.getByTestID('time-machine-submit-button').click()
+
+  // FIXME: Temporary wait until we figure out a better solution
+  cy.wait(2000)
 }
 
 const createChecks = () => {


### PR DESCRIPTION
Closes #

`home.test.ts` is flaky again because of the way checks run without a definitive answer to when the runs will be populated. Bumping up the wait until a better alternative is figured out.
