### PR TITLE
fix: change default bucket for scraper

### DIFF
--- a/src/scrapers/components/CreateScraperOverlay.tsx
+++ b/src/scrapers/components/CreateScraperOverlay.tsx
@@ -42,7 +42,8 @@ class CreateScraperOverlay extends PureComponent<Props, State> {
       buckets,
     } = this.props
 
-    const firstBucketID = get(buckets, '0.id', '')
+    // The first two buckets are system buckets
+    const firstBucketID = get(buckets, '2.id', '')
 
     this.state = {
       scraper: {


### PR DESCRIPTION
Closes #1622 

Attempts to fix an issue where the _monitoring bucket is selected by default for new scrapers.

old behavior:
![Kapture 2021-06-03 at 15 12 47](https://user-images.githubusercontent.com/4805997/120718520-43f53980-c47e-11eb-8a9e-df52cccd58b7.gif)

new behavior:
![Kapture 2021-06-03 at 15 13 18](https://user-images.githubusercontent.com/4805997/120718543-49eb1a80-c47e-11eb-8e7b-4257a9facc8f.gif)
