### PR TITLE
chore: fixed replace statement, this should work

### DIFF
--- a/src/usage/context/usage.tsx
+++ b/src/usage/context/usage.tsx
@@ -120,7 +120,7 @@ export const UsageProvider: FC<Props> = React.memo(({children}) => {
         throw new Error(resp.data.message)
       }
 
-      const csv = resp.data?.trim().replace('\r\n', '\n')
+      const csv = resp.data?.trim().replace(/\r\n/g, '\n')
       // TODO(ariel): keeping this in for testing purposes in staging
       // This will need to be removed for flipping the feature flag on
       console.warn({csv, json: JSON.stringify(resp.data)})


### PR DESCRIPTION
OK, so I think this is the solution. The previous implementation only replaced the first instance of the return and newline, this one replaces all of em. I validated it in a JS Fiddle. REALLY HOPING THIS IS IT

https://jsfiddle.net/Asalem1/mjzdph43/1/