### PR TITLE
fix: simple table no longer vanishes

### DIFF
--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -1592,4 +1592,92 @@ describe('DataExplorer', () => {
       // TODO: add filter values based on dropdown selection in key / value
     })
   })
+
+  describe('simple table interactions', () => {
+    const simpleSmall = 'simple-small'
+    const simpleLarge = 'simple-large'
+    beforeEach(() => {
+      cy.window().then(win => {
+        win.influx.set('simpleTable', true)
+      })
+
+      cy.get('@org').then(({id: orgID}: Organization) => {
+        cy.createDashboard(orgID).then(({body}) => {
+          cy.getByTestID('tree-nav')
+          cy.createBucket(orgID, name, simpleLarge)
+          cy.writeData(lines(300), simpleLarge)
+          cy.createBucket(orgID, name, simpleSmall)
+          cy.writeData(lines(30), simpleSmall)
+          cy.reload()
+        })
+      })
+    })
+
+    it('should render correctly after switching from a dataset with more pages to one with fewer', () => {
+      cy.getByTestID('query-builder').should('exist')
+
+      // show raw data view of data with 100 pages
+      cy.getByTestID(`selector-list ${simpleLarge}`).should('be.visible')
+      cy.getByTestID(`selector-list ${simpleLarge}`).click()
+
+      cy.getByTestID('selector-list m').should('be.visible')
+      cy.getByTestID('selector-list m').clickAttached()
+
+      cy.getByTestID('selector-list v').should('be.visible')
+      cy.getByTestID('selector-list v').clickAttached()
+
+      cy.getByTestID('selector-list tv1').clickAttached()
+
+      cy.getByTestID('time-machine-submit-button').click()
+
+      cy.getByTestID('raw-data--toggle').click()
+      cy.getByTestID('table').should('exist')
+
+      // click last page
+      cy.getByTestID('pagination-item')
+        .last()
+        .should('be.visible')
+      cy.getByTestID('pagination-item')
+        .last()
+        .click()
+      // verify correct number of pages
+      cy.getByTestID('pagination-item')
+        .last()
+        .contains('100')
+
+      // show raw data view of data with 10 pages
+      cy.getByTestID(`selector-list ${simpleSmall}`).should('be.visible')
+      cy.getByTestID(`selector-list ${simpleSmall}`).click()
+
+      cy.getByTestID('selector-list m').should('be.visible')
+      cy.getByTestID('selector-list m').clickAttached()
+
+      cy.getByTestID('selector-list v').should('be.visible')
+      cy.getByTestID('selector-list v').clickAttached()
+
+      cy.getByTestID('selector-list tv1').clickAttached()
+
+      cy.getByTestID('time-machine-submit-button').click()
+
+      // verify table still exists
+      cy.getByTestID('table').should('exist')
+      // TODO: uncomment when this bug in clockface is fixed: https://github.com/influxdata/clockface/pull/634
+      // verify page 1 is selected
+      // cy.getByTestID('pagination-item')
+      //   .first()
+      //   .within(() => {
+      //     cy.getByTestID('button').should(
+      //       'have.class',
+      //       'cf-button cf-button-md cf-button-tertiary cf-button-square active'
+      //     )
+      //   })
+      // verify correct number of pages
+      cy.getByTestID('pagination-item')
+        .last()
+        .should('be.visible')
+      cy.getByTestID('pagination-item')
+        .last()
+        .contains('10')
+    })
+  })
 })

--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -1598,6 +1598,8 @@ describe('DataExplorer', () => {
     const simpleLarge = 'simple-large'
     beforeEach(() => {
       cy.window().then(win => {
+        // I hate to add this, but the influx object isn't ready yet
+        cy.wait(1000)
         win.influx.set('simpleTable', true)
       })
 
@@ -1629,7 +1631,7 @@ describe('DataExplorer', () => {
       cy.getByTestID('time-machine-submit-button').click()
 
       cy.getByTestID('raw-data--toggle').click()
-      cy.getByTestID('table').should('exist')
+      cy.getByTestID('simple-table').should('exist')
 
       // click last page
       cy.getByTestID('pagination-item')
@@ -1658,17 +1660,16 @@ describe('DataExplorer', () => {
       cy.getByTestID('time-machine-submit-button').click()
 
       // verify table still exists
-      cy.getByTestID('table').should('exist')
-      // TODO: uncomment when this bug in clockface is fixed: https://github.com/influxdata/clockface/pull/635
+      cy.getByTestID('simple-table').should('exist')
       // verify page 1 is selected
-      // cy.getByTestID('pagination-item')
-      //   .first()
-      //   .within(() => {
-      //     cy.getByTestID('button').should(
-      //       'have.class',
-      //       'cf-button cf-button-md cf-button-tertiary cf-button-square active'
-      //     )
-      //   })
+      cy.getByTestID('pagination-item')
+        .first()
+        .within(() => {
+          cy.getByTestID('button').should(
+            'have.class',
+            'cf-button cf-button-md cf-button-tertiary cf-button-square active'
+          )
+        })
       // verify correct number of pages
       cy.getByTestID('pagination-item')
         .last()

--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -1602,14 +1602,12 @@ describe('DataExplorer', () => {
       })
 
       cy.get('@org').then(({id: orgID}: Organization) => {
-        cy.createDashboard(orgID).then(({body}) => {
-          cy.getByTestID('tree-nav')
-          cy.createBucket(orgID, name, simpleLarge)
-          cy.writeData(lines(300), simpleLarge)
-          cy.createBucket(orgID, name, simpleSmall)
-          cy.writeData(lines(30), simpleSmall)
-          cy.reload()
-        })
+        cy.getByTestID('tree-nav')
+        cy.createBucket(orgID, name, simpleLarge)
+        cy.writeData(lines(300), simpleLarge)
+        cy.createBucket(orgID, name, simpleSmall)
+        cy.writeData(lines(30), simpleSmall)
+        cy.reload()
       })
     })
 
@@ -1661,7 +1659,7 @@ describe('DataExplorer', () => {
 
       // verify table still exists
       cy.getByTestID('table').should('exist')
-      // TODO: uncomment when this bug in clockface is fixed: https://github.com/influxdata/clockface/pull/634
+      // TODO: uncomment when this bug in clockface is fixed: https://github.com/influxdata/clockface/pull/635
       // verify page 1 is selected
       // cy.getByTestID('pagination-item')
       //   .first()

--- a/cypress/e2e/shared/flows.test.ts
+++ b/cypress/e2e/shared/flows.test.ts
@@ -11,6 +11,7 @@ describe('Flows', () => {
 
           cy.window().then(win => {
             win.influx.set('notebooks', true)
+            win.influx.set('simpleTable', true)
           })
 
           cy.getByTestID('nav-item-flows').click()
@@ -134,7 +135,7 @@ describe('Flows', () => {
     cy.getByTestID('time-machine-submit-button').click()
 
     // we should only see beans in the table
-    cy.getByTestID('table').should('be.visible')
+    cy.getByTestID('simple-table').should('be.visible')
     cy.getByTestID('table-cell beans')
       .first()
       .should('be.visible')
@@ -145,7 +146,7 @@ describe('Flows', () => {
     cy.getByTestID('time-machine-submit-button').click()
 
     // we should only see cool in the table
-    cy.getByTestID('table').should('be.visible')
+    cy.getByTestID('simple-table').should('be.visible')
     cy.getByTestID('table-cell cool')
       .first()
       .should('be.visible')
@@ -192,7 +193,7 @@ describe('Flows', () => {
     cy.getByTestID('time-machine-submit-button').click()
 
     // we should only see beans in the table
-    cy.getByTestID('table').should('be.visible')
+    cy.getByTestID('simple-table').should('be.visible')
     cy.getByTestID('table-cell beans')
       .first()
       .should('be.visible')

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "webpack-merge": "^4.2.1"
   },
   "dependencies": {
-    "@influxdata/clockface": "^2.8.0",
+    "@influxdata/clockface": "^2.10.0",
     "@influxdata/flux": "^0.5.1",
     "@influxdata/flux-lsp-browser": "^0.5.48",
     "@influxdata/giraffe": "^2.13.1",

--- a/src/visualization/types/SimpleTable/InnerTable.tsx
+++ b/src/visualization/types/SimpleTable/InnerTable.tsx
@@ -51,7 +51,12 @@ const InnerTable: FC<InnerProps> = ({table}) => {
     })
 
   return (
-    <Table fontSize={ComponentSize.Small} striped highlight>
+    <Table
+      fontSize={ComponentSize.Small}
+      striped
+      highlight
+      testID="simple-table"
+    >
       <Table.Header>
         <Table.Row>{headers}</Table.Row>
       </Table.Header>

--- a/src/visualization/types/SimpleTable/PagedTable.tsx
+++ b/src/visualization/types/SimpleTable/PagedTable.tsx
@@ -87,7 +87,7 @@ const measurePage = (
 const subsetResult = (
   result: FluxResult['parsed'],
   offset: number,
-  page: number,
+  size: number,
   disableFilter: boolean
 ): SubsetTable[] => {
   // only look at data within the page
@@ -96,7 +96,7 @@ const subsetResult = (
       (c: Column): ExtendedColumn => ({
         ...c,
         group: result.fluxGroupKeyUnion.includes(c.name),
-        data: c.data.slice(offset, offset + page),
+        data: c.data.slice(offset, offset + size),
       })
     )
     .filter(c => !!c.data.filter(_c => _c !== undefined).length)
@@ -113,7 +113,7 @@ const subsetResult = (
   let lastTable
 
   // group by table id (series)
-  for (let ni = 0; ni < page; ni++) {
+  for (let ni = 0; ni < size; ni++) {
     if (
       `y${subset['result'][0].data[ni]}:t${subset['table'][0].data[ni]}` ===
       lastTable
@@ -138,7 +138,7 @@ const subsetResult = (
   }
 
   if (tables.length) {
-    tables[tables.length - 1].end = page
+    tables[tables.length - 1].end = size
   }
 
   // reorder the column names, filter empty columns, join repeating tables under one header
@@ -221,7 +221,7 @@ interface Props {
 }
 
 const PagedTable: FC<Props> = ({result, properties}) => {
-  const {offset, setSize} = useContext(PaginationContext)
+  const {offset, setSize, setPage} = useContext(PaginationContext)
   const [height, setHeight] = useState(0)
   const ref = useRef()
 
@@ -262,16 +262,20 @@ const PagedTable: FC<Props> = ({result, properties}) => {
     }
   }, [ref?.current])
 
-  const page = useMemo(() => {
+  const size = useMemo(() => {
     return measurePage(result, offset, height)
   }, [result, offset, height])
   const tables = useMemo(() => {
-    return subsetResult(result, offset, page, properties.showAll)
-  }, [result, offset, page])
+    return subsetResult(result, offset, size, properties.showAll)
+  }, [result, offset, size])
 
   useEffect(() => {
-    setSize(page)
-  }, [page])
+    setSize(size)
+  }, [size])
+
+  useEffect(() => {
+    setPage(1)
+  }, [result])
 
   const inner = tables.map((t, tIdx) => (
     <InnerTable table={t} key={`table${tIdx}`} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -710,10 +710,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@influxdata/clockface@^2.8.0":
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-2.8.0.tgz#92327287aeced602ff20819b10cb23380b8fec0e"
-  integrity sha512-EQ/t4OX6pq2LvNhc/ba0wAT0enfH165+Ih/86g3nwk0BFNmRIoNmZ2osuCgw/pyslX+5xxdPaEfMe3lsXmXriw==
+"@influxdata/clockface@^2.10.0":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-2.10.0.tgz#41b915ef8070a95e13eb6e5d8f1b74cc22ae49cc"
+  integrity sha512-DCXi76RP8wgcgaT1V0FdzbPQEAMMrB7KgAjKfDvGXHO/iB/S+RG1Wf43/MLVbEO0QnrTrolvkfh8LnV5SsR+ng==
 
 "@influxdata/flux-lsp-browser@^0.5.48":
   version "0.5.48"


### PR DESCRIPTION
Closes #1548

Adds `useEffect` that sets the page to `1` every time `result` changes. This fixes the unwanted behavior where the table would vanish when you switch from a dataset with more pages to one with fewer. I also renamed the variable `page` to `size`.

Test included.


https://user-images.githubusercontent.com/6411855/120874009-732ca900-c559-11eb-8e45-857936320c38.mov


