### PR TITLE
feat: usage stats page complete

### DIFF
--- a/src/usage/BillingStatsPanel.tsx
+++ b/src/usage/BillingStatsPanel.tsx
@@ -107,6 +107,7 @@ const BillingStatsPanel: FC = () => {
               key={csv}
               graphInfo={graphInfo[i]}
               csv={csv.trim()}
+              length={billingStats.length}
             />
           )
         })}

--- a/src/usage/BillingStatsPanel.tsx
+++ b/src/usage/BillingStatsPanel.tsx
@@ -110,7 +110,6 @@ const BillingStatsPanel: FC = () => {
           // Find the matching CSV for the usageVector
           const csv =
             billingStats.find((stat: string) => {
-              // get the
               const {table, error} = fromFlux(stat)
               if (!table.length || error) {
                 return false

--- a/src/usage/BillingStatsPanel.tsx
+++ b/src/usage/BillingStatsPanel.tsx
@@ -1,5 +1,5 @@
+// Libraries
 import React, {FC, useContext} from 'react'
-
 import {
   AlignItems,
   Appearance,
@@ -11,9 +11,12 @@ import {
   PopoverPosition,
   QuestionMarkTooltip,
 } from '@influxdata/clockface'
-
 import GraphTypeSwitcher from 'src/usage/GraphTypeSwitcher'
 import {UsageContext} from 'src/usage/context/usage'
+import {fromFlux} from '@influxdata/giraffe'
+
+// Types
+import {UsageVector} from 'src/types'
 
 const graphInfo = [
   {
@@ -50,7 +53,7 @@ const graphInfo = [
   },
 ]
 const BillingStatsPanel: FC = () => {
-  const {billingDateTime, billingStats} = useContext(UsageContext)
+  const {billingDateTime, billingStats, usageVectors} = useContext(UsageContext)
 
   const today = new Date().toISOString()
   const dateRange = `${billingDateTime} UTC to ${today} UTC`
@@ -101,13 +104,26 @@ const BillingStatsPanel: FC = () => {
         alignItems={AlignItems.Stretch}
         testID="billing-stats--graphs"
       >
-        {billingStats?.map((csv: string, i: number) => {
+        {usageVectors?.map((vector: UsageVector) => {
+          // Find the matching graphInfo for the usage vector
+          const graph = graphInfo.find(g => g.column === vector.fluxKey)
+          // Find the matching CSV for the usageVector
+          const csv =
+            billingStats.find((stat: string) => {
+              // get the
+              const {table, error} = fromFlux(stat)
+              if (!table.length || error) {
+                return false
+              }
+              return table.columnKeys.includes(vector.fluxKey)
+            }) ?? ''
+
           return (
             <GraphTypeSwitcher
-              key={csv}
-              graphInfo={graphInfo[i]}
+              key={vector.fluxKey}
+              graphInfo={graph}
               csv={csv.trim()}
-              length={billingStats.length}
+              length={usageVectors.length}
             />
           )
         })}

--- a/src/usage/BillingStatsPanel.tsx
+++ b/src/usage/BillingStatsPanel.tsx
@@ -109,7 +109,7 @@ const BillingStatsPanel: FC = () => {
           const graph = graphInfo.find(g => g.column === vector.fluxKey)
           // Find the matching CSV for the usageVector
           const csv =
-            billingStats.find((stat: string) => {
+            billingStats?.find((stat: string) => {
               const {table, error} = fromFlux(stat)
               if (!table.length || error) {
                 return false

--- a/src/usage/GraphTypeSwitcher.scss
+++ b/src/usage/GraphTypeSwitcher.scss
@@ -1,8 +1,3 @@
 .panel-body--size {
-  height: 50px;
   position: relative;
-}
-
-.panel-body--size.usage-plot {
-  height: 250px;
 }

--- a/src/usage/GraphTypeSwitcher.tsx
+++ b/src/usage/GraphTypeSwitcher.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {FC} from 'react'
-import classnames from 'classnames'
 import {useSelector} from 'react-redux'
 import {Panel, ComponentSize, InfluxColors} from '@influxdata/clockface'
 import {fromFlux} from '@influxdata/giraffe'
@@ -21,6 +20,7 @@ import {
 interface OwnProps {
   graphInfo: any
   csv: string
+  length?: number
 }
 
 const GENERIC_PROPERTY_DEFAULTS = {
@@ -34,7 +34,7 @@ const GENERIC_PROPERTY_DEFAULTS = {
   tickSuffix: '',
 }
 
-const GraphTypeSwitcher: FC<OwnProps> = ({graphInfo, csv}) => {
+const GraphTypeSwitcher: FC<OwnProps> = ({graphInfo, csv, length = 1}) => {
   const giraffeResult = fromFlux(csv)
 
   const timeRange = useSelector(getTimeRangeWithTimezone)
@@ -59,9 +59,7 @@ const GraphTypeSwitcher: FC<OwnProps> = ({graphInfo, csv}) => {
     geom: 'line',
   }
 
-  const graphTypeClassname = classnames('panel-body--size', {
-    'usage-plot': graphInfo?.type === 'sparkline',
-  })
+  const isSparkline = graphInfo?.type === 'sparkline'
 
   return (
     <Panel
@@ -72,14 +70,15 @@ const GraphTypeSwitcher: FC<OwnProps> = ({graphInfo, csv}) => {
       <Panel.Header size={ComponentSize.ExtraSmall}>
         <h5>{graphInfo?.title}</h5>
       </Panel.Header>
-      <Panel.Body className={graphTypeClassname}>
+      <Panel.Body
+        className="panel-body--size"
+        style={{height: isSparkline ? 250 : 200 / length}}
+      >
         <View
           loading={RemoteDataState.Done}
           error=""
           isInitial={false}
-          properties={
-            graphInfo?.type === 'stat' ? singleStatProperties : xyProperties
-          }
+          properties={isSparkline ? xyProperties : singleStatProperties}
           result={giraffeResult}
           timeRange={timeRange}
         />

--- a/src/usage/context/usage.tsx
+++ b/src/usage/context/usage.tsx
@@ -87,7 +87,7 @@ export const UsageProvider: FC<Props> = React.memo(({children}) => {
       setUsageVectors(vectors)
       handleSetSelectedUsage(vectors?.[0]?.name)
     } catch (error) {
-      console.error('handleGetUsageVectors: ', error)
+      console.error(error)
     }
   }, [setUsageVectors, handleSetSelectedUsage])
 
@@ -102,9 +102,10 @@ export const UsageProvider: FC<Props> = React.memo(({children}) => {
       if (resp.status !== 200) {
         throw new Error(resp.data.message)
       }
+
       setBillingDateTime(resp.data.dateTime)
     } catch (error) {
-      console.error('handleGetBillingDate: ', error)
+      console.error(error)
     }
   }, [setBillingDateTime])
 
@@ -121,18 +122,12 @@ export const UsageProvider: FC<Props> = React.memo(({children}) => {
       }
 
       const csv = resp.data?.trim().replace(/\r\n/g, '\n')
-      // TODO(ariel): keeping this in for testing purposes in staging
-      // This will need to be removed for flipping the feature flag on
-      console.warn({csv, json: JSON.stringify(resp.data)})
 
       const csvs = csv.split('\n\n')
 
-      // TODO(ariel): keeping this in for testing purposes in staging
-      // This will need to be removed for flipping the feature flag on
-      console.warn({csvs})
       setBillingStats(csvs)
     } catch (error) {
-      console.error('getBillingStats: ', error)
+      console.error(error)
     }
   }, [setBillingStats])
 
@@ -158,7 +153,7 @@ export const UsageProvider: FC<Props> = React.memo(({children}) => {
 
         setUsageStats(resp.data)
       } catch (error) {
-        console.error('handleGetUsageStats: ', error)
+        console.error(error)
         setUsageStats('')
       }
     }
@@ -180,7 +175,7 @@ export const UsageProvider: FC<Props> = React.memo(({children}) => {
 
       setRateLimits(resp.data)
     } catch (error) {
-      console.error('handleGetRateLimits: ', error)
+      console.error(error)
       setRateLimits('')
     }
   }, [timeRange])

--- a/src/usage/context/usage.tsx
+++ b/src/usage/context/usage.tsx
@@ -14,8 +14,7 @@ import {
 import {DEFAULT_USAGE_TIME_RANGE} from 'src/shared/constants/timeRanges'
 
 // Types
-import {SelectableDurationTimeRange} from 'src/types'
-import {UsageVector} from 'src/types/billing'
+import {SelectableDurationTimeRange, UsageVector} from 'src/types'
 
 export type Props = {
   children: JSX.Element


### PR DESCRIPTION
This PR integrates the final piece of functionality associated with the usage page by using the usage vectors as the source of truth for rendering the usage stats at the top of the usage page. This differs from the original implementation in that it will show all the usage stats even if no data is present (even those that will be empty). This is by design