### PR TITLE
chore: updated styling for empty zuora form

### DIFF
--- a/src/checkout/CheckoutForm.scss
+++ b/src/checkout/CheckoutForm.scss
@@ -10,7 +10,7 @@
   position: relative;
 }
 
-.v2-zuora-form iframe {
+.v2-zuora-form {
   min-height: 226px;
 }
 

--- a/src/checkout/CheckoutForm.scss
+++ b/src/checkout/CheckoutForm.scss
@@ -5,3 +5,19 @@
 .powered-by-payment-header {
   width: 100%;
 }
+
+.billing-form--frame {
+  position: relative;
+}
+
+.v2-zuora-form iframe {
+  min-height: 226px;
+}
+
+/* Zuora Payment Widget */
+#zuora_payment {
+  & > iframe {
+    background-color: transparent;
+    width: 100%;
+  }
+}


### PR DESCRIPTION
This PR updates the blank zuora form state by transferring a couple of classes from Quartz that were not being imported into the UI

![checkout-zuora](https://user-images.githubusercontent.com/19984220/121073147-05fe5b00-c787-11eb-83ea-c48e67b9ada6.gif)

