### PR TITLE
chore: for some reason the styling looks different on prod

### DIFF
--- a/src/usage/GraphTypeSwitcher.scss
+++ b/src/usage/GraphTypeSwitcher.scss
@@ -1,3 +1,4 @@
 .panel-body--size {
   position: relative;
+  min-height: 75px;
 }

--- a/src/usage/GraphTypeSwitcher.tsx
+++ b/src/usage/GraphTypeSwitcher.tsx
@@ -76,7 +76,7 @@ const GraphTypeSwitcher: FC<OwnProps> = ({
       </Panel.Header>
       <Panel.Body
         className="panel-body--size"
-        style={{height: isXy ? 250 : 200 / length}}
+        style={{height: isXy ? 250 : 300 / length}}
       >
         <View
           loading={error ? RemoteDataState.Error : RemoteDataState.Done}


### PR DESCRIPTION
Hopefully the final iteration of this styling issue. For some reason applying the styles locally had a different effect on the production image. I don't know what to make of it but it seems like making the height of the panel body a bit bigger allows for the numbers to be more legible. For example, `Data Out` is the older `50px` height, whereas `Storage` and `Query Count` are set to `75px`

<img width="1276" alt="Screen Shot 2021-06-09 at 4 52 42 AM" src="https://user-images.githubusercontent.com/19984220/121349778-c2b70000-c8de-11eb-9d04-7b28d414b000.png">
