### PR TITLE
chore: mop up an openapi change that was made without consultation

### DIFF
--- a/src/dataLoaders/reducers/telegrafEditor.ts
+++ b/src/dataLoaders/reducers/telegrafEditor.ts
@@ -104,7 +104,7 @@ hostname = ""
 ## If set to true, do no set the "host" tag in the telegraf agent.
   omit_hostname = false
 `,
-  },
+  } as TelegrafEditorBasicPlugin,
   {
     name: '__default__',
     type: 'bundle',


### PR DESCRIPTION
Mopping up after this change: https://github.com/influxdata/openapi/pull/116
