### PR TITLE
chore: exceptions to when we write to honeybadger

### DIFF
--- a/src/flows/pipes/Schedule/ExportTaskOverlay/context.tsx
+++ b/src/flows/pipes/Schedule/ExportTaskOverlay/context.tsx
@@ -140,7 +140,7 @@ export const Provider: FC = ({children}) => {
     return true
   }
 
-  const submit = async (): void => {
+  const submit = async () => {
     if (!validateForm()) {
       return
     }

--- a/src/templates/actions/thunks.ts
+++ b/src/templates/actions/thunks.ts
@@ -39,6 +39,7 @@ import {getOrg} from 'src/organizations/selectors'
 import {getStatus} from 'src/resources/selectors'
 import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
 import {readMeFormatter} from 'src/templates/utils'
+import {event} from 'src/cloud/utils/reporting'
 
 type Action = TemplateAction | NotifyAction
 
@@ -108,9 +109,13 @@ export const fetchAndSetReadme = (name: string, directory: string) => async (
     const readme = readMeFormatter(response)
     dispatch(setTemplateReadMe(name, readme))
   } catch (error) {
-    reportErrorThroughHoneyBadger(error, {
-      name: `The community template github readme fetch failed for ${name}`,
-    })
+    if (name === 'dashboard') {
+      event('Community template README failed', {context: name})
+    } else {
+      reportErrorThroughHoneyBadger(error, {
+        name: `The community template github readme fetch failed for ${name}`,
+      })
+    }
     dispatch(
       setTemplateReadMe(
         name,

--- a/src/templates/components/CommunityTemplateInstallOverlay.tsx
+++ b/src/templates/components/CommunityTemplateInstallOverlay.tsx
@@ -100,9 +100,15 @@ class CommunityTemplateInstallOverlayUnconnected extends PureComponent<Props> {
       return summary
     } catch (err) {
       this.props.notify(communityTemplateInstallFailed(err.message))
-      reportErrorThroughHoneyBadger(err, {
-        name: 'The community template fetch for preview failed',
-      })
+      if (
+        err.message.includes('mapping values are not allowed in this context')
+      ) {
+        event('review_template', {templateUrl})
+      } else {
+        reportErrorThroughHoneyBadger(err, {
+          name: 'The community template fetch for preview failed',
+        })
+      }
     }
   }
 


### PR DESCRIPTION
For months now I've been getting emails about this error and it doesn't seem like it has any relevance for us as an organization to know that a specific README failed to fetch and set, or that a templateUrl failed to make due to a yaml definition. This morning, I deleted a few hundred honeybadger errors over the last 24 hours, most of which were traced to these two functions with those two consistent errors. This PR aims at reducing the level of noise produced by honeybadger in order to prevent actual issues from falling through the cracks when it comes to getting legitimate notifications through honeybadger