### PR TITLE
chore: update the invoice URL

### DIFF
--- a/src/billing/components/PayAsYouGo/InvoiceHistoryRow.tsx
+++ b/src/billing/components/PayAsYouGo/InvoiceHistoryRow.tsx
@@ -21,7 +21,7 @@ const InvoiceHistoryRow: FC<Props> = ({
   const invoiceName = `${getPreviousMonth(new Date(targetDate))} ${new Date(
     targetDate
   ).getFullYear()} Invoice`
-  const link = `/billing/invoices/${id}`
+  const link = `/api/v2/quartz/billing/invoices/${id}`
   const statusClassName = classnames('invoice-details invoice-status', {
     ['paid']: status === 'Paid',
   })


### PR DESCRIPTION
This resolves an issue where invoice PDFs that are generated in quartz could not be retrieved from the API due to a mismatch in the path.