### PR TITLE
fix: delete notebooks accepts 200 or 204

### DIFF
--- a/src/flows/context/api.tsx
+++ b/src/flows/context/api.tsx
@@ -71,7 +71,7 @@ export const createAPI = async (flow: PostFlowsOrgsFlowParams) => {
 
 export const deleteAPI = async (ids: DeleteFlowsOrgsFlowParams) => {
   const res = await deleteFlowsOrgsFlow(ids)
-  if (res.status != 200) {
+  if (res.status < 200 || res.status >= 300) {
     throw new Error(res.data.message)
   }
 }


### PR DESCRIPTION
flowd returned a 200 on successful deletion, notebooksd returns a 204 (which is the correct code to return since we do not return the entity in the response)

This change makes the UI code more flexible so that it accepts both statuses in the 200 range as success. I couldn't change the 200 to a 204 because we're still in the process of deploying notebooksd so the UI code needs to be flexible for now. 