### PR TITLE
feat: adding the operator link to the navbar behind a feature flag

### DIFF
--- a/src/pageLayout/constants/navigationHierarchy.ts
+++ b/src/pageLayout/constants/navigationHierarchy.ts
@@ -218,5 +218,18 @@ export const generateNavItems = (orgID: string): NavItem[] => {
       activeKeywords: ['functions'],
       featureFlag: 'managed-functions',
     },
+    {
+      id: 'operator',
+      testID: 'nav-item-operator',
+      icon: IconFont.Shield,
+      label: 'Operator',
+      featureFlag: 'unityOperator',
+      shortLabel: 'Operator',
+      link: {
+        type: 'link',
+        location: `/operator`,
+      },
+      activeKeywords: ['operator'],
+    },
   ]
 }

--- a/src/pageLayout/constants/navigationHierarchy.ts
+++ b/src/pageLayout/constants/navigationHierarchy.ts
@@ -223,6 +223,7 @@ export const generateNavItems = (orgID: string): NavItem[] => {
       testID: 'nav-item-operator',
       icon: IconFont.Shield,
       label: 'Operator',
+      cloudOnly: true,
       featureFlag: 'unityOperator',
       shortLabel: 'Operator',
       link: {


### PR DESCRIPTION
Closes #1677 

This is a precursor to some more operator work that should be rolling out soon regarding the way we're allowing internal users to access the operator page. 

![operator-nav](https://user-images.githubusercontent.com/19984220/121747394-37936100-cabc-11eb-8edc-f58dc1e03a02.gif)

