### PR TITLE
fix: add spacing for telegraf modal

### DIFF
--- a/src/telegrafs/components/TelegrafOutputOverlay.tsx
+++ b/src/telegrafs/components/TelegrafOutputOverlay.tsx
@@ -150,7 +150,7 @@ class TelegrafOutputOverlay extends PureComponent<Props> {
             <Link to={`/orgs/${orgID}/load-data/tokens`}>&nbsp;Tokens tab</Link>
             .
           </p>
-          {bucket_dd}
+          <p>{bucket_dd}</p>
           <div className="output-overlay">
             <TemplateProvider
               variables={{


### PR DESCRIPTION
Adds a little spacing so that this:
![image](https://user-images.githubusercontent.com/4805997/121784779-ca8ad480-cb6a-11eb-861d-c18452f0cf99.png)

turns into this:
![image](https://user-images.githubusercontent.com/4805997/121784814-002fbd80-cb6b-11eb-8715-ecba66384a9a.png)
