### PR TITLE
chore: bumps immer to 3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     "history": "^4.7.2",
     "honeybadger-js": "^1.0.2",
     "html-to-react": "1.3.4",
-    "immer": "^1.9.3",
+    "immer": "3.3.0",
     "immutable": "^3.8.1",
     "intersection-observer": "^0.7.0",
     "jsonlint-mod": "^1.7.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5567,10 +5567,10 @@ ignore@^5.1.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
-immer@^1.9.3:
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-1.9.3.tgz#e88f8cbea730d2cde0f5e7e763000a8608bccdae"
-  integrity sha512-bUyz3fOHGn82V7h4oVgJGmFglZt53JWwSyVNAT4sO0d7IovHLwLuHbh14uYKY0tewFoDcEdiQW7HuL0NsRVziw==
+immer@3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-3.3.0.tgz#ee7cf3a248d5dd2d4eedfbe7dfc1e9be8c72041d"
+  integrity sha512-vlWRjnZqoTHuEjadquVHK3GxsXe1gNoATffLEA8Qbrdd++Xb+wHEFiWtwAKTscMBoi1AsvEMXhYRzAXA8Ex9FQ==
 
 immutable@^3.8.1:
   version "3.8.2"


### PR DESCRIPTION
Trying to bump immer a couple major versions at a time to eventually get us to latest