### PR TITLE
chore: block honeybadger during cypress tests

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -8,5 +8,9 @@
   "defaultCommandTimeout": 10000,
   "videoUploadOnPasses": false,
   "chromeWebSecurity": false,
-  "blockHosts": ["www.google-analytics.com", "www.googletagmanager.com"]
+  "blockHosts": [
+    "www.google-analytics.com",
+    "www.googletagmanager.com",
+    "www.honeybadger.io"
+  ]
 }


### PR DESCRIPTION
Blocks requests to honeybadger while running cypress tests. Should reduce the noise in honeybadger.