### PR TITLE
feat: overlapping annotations

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "@influxdata/clockface": "^2.10.0",
     "@influxdata/flux": "^0.5.1",
     "@influxdata/flux-lsp-browser": "^0.5.49",
-    "@influxdata/giraffe": "^2.14.0",
+    "@influxdata/giraffe": "^2.14.2",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",

--- a/src/visualization/utils/annotationUtils.test.ts
+++ b/src/visualization/utils/annotationUtils.test.ts
@@ -1,0 +1,75 @@
+import {sortAnnotations} from './annotationUtils'
+
+describe('annotation utils testing', () => {
+  const range1 = {
+    id: 'range1',
+    summary: 'range (4-5)',
+    endTime: '2021-06-15T15:05:30Z',
+    startTime: '2021-06-15T15:04:50Z',
+  }
+  const range2 = {
+    id: 'range2',
+    summary: '67676',
+    endTime: '2021-06-15T19:13:10Z',
+    startTime: '2021-06-15T19:12:20Z',
+  }
+  const point1 = {
+    id: 'point1',
+    summary: 'hi there',
+    endTime: '2021-06-15T15:05:10Z',
+    startTime: '2021-06-15T15:05:10Z',
+  }
+  const point2 = {
+    id: 'point2',
+    summary: '77',
+    endTime: '2021-06-15T19:12:50Z',
+    startTime: '2021-06-15T19:12:50Z',
+  }
+
+  const range3 = {
+    id: 'range3',
+    summary: 'range (4-5a)',
+    endTime: '2021-06-15T15:08:30Z',
+    startTime: '2021-06-15T15:04:50Z',
+  }
+  const range4 = {
+    id: 'range4',
+    summary: '67676',
+    endTime: '2021-06-15T21:13:10Z',
+    startTime: '2021-06-15T19:12:20Z',
+  }
+  const point3 = {
+    id: 'point3',
+    summary: 'hi there',
+    endTime: '2021-06-15T15:05:10Z',
+    startTime: '2021-06-15T15:05:10Z',
+  }
+  const point4 = {
+    id: 'point4',
+    summary: '77',
+    endTime: '2021-06-15T19:12:50Z',
+    startTime: '2021-06-15T19:12:50Z',
+  }
+
+  describe('sorting annotations', () => {
+    test('ranges are sorting before points', () => {
+      const annos = [point1, range1, point2, range2, range3, range4]
+      const expected = [range1, range2, range3, range4, point1, point2]
+
+      // before sorting:
+      expect(annos).not.toEqual(expected)
+
+      const sorted = annos.sort(sortAnnotations)
+      expect(sorted).toEqual(expected)
+      expect(sorted[0].id).toEqual('range1')
+    })
+    test('if only points, no sorting is being done', () => {
+      const annos = [point1, point2, point4, point3]
+      expect(annos.sort(sortAnnotations)).toEqual(annos)
+    })
+    test('if only ranges, no sorting is being done', () => {
+      const annos = [range1, range2, range3, range4]
+      expect(annos.sort(sortAnnotations)).toEqual(annos)
+    })
+  })
+})

--- a/src/visualization/utils/annotationUtils.ts
+++ b/src/visualization/utils/annotationUtils.ts
@@ -146,7 +146,8 @@ const makeAnnotationClickHandler = (
 
 // want all the ranges *before* all the points,
 // so that can click on points that overlap ranges
-const sortAnnotations = (anno1, anno2) => {
+// exporting for testing
+export const sortAnnotations = (anno1, anno2) => {
   // if they are both ranges or both points, return 0
   // if anno1 is a range, and anno2 is a point return -1;
   // else return 1

--- a/src/visualization/utils/annotationUtils.ts
+++ b/src/visualization/utils/annotationUtils.ts
@@ -144,6 +144,18 @@ const makeAnnotationClickHandler = (
   return clickHandler
 }
 
+// want all the ranges *before* all the points,
+// so that can click on points that overlap ranges
+const sortAnnotations = (anno1, anno2) => {
+  // if they are both ranges or both points, return 0
+  // if anno1 is a range, and anno2 is a point return -1;
+  // else return 1
+
+  const anno1Value = anno1.startTime === anno1.endTime ? 1 : 0
+  const anno2Value = anno2.startTime === anno2.endTime ? 1 : 0
+
+  return anno1Value - anno2Value
+}
 const makeAnnotationLayer = (
   cellID: string,
   xColumn: string,
@@ -155,12 +167,15 @@ const makeAnnotationLayer = (
   eventPrefix = 'xyplot'
 ) => {
   const cellAnnotations = annotations ? annotations[cellID] ?? [] : []
-  const annotationsToRender: any[] = cellAnnotations.map(annotation => {
-    return {
-      ...annotation,
-      color: InfluxColors.Honeydew,
-    }
-  })
+
+  const annotationsToRender: any[] = cellAnnotations
+    .sort(sortAnnotations)
+    .map(annotation => {
+      return {
+        ...annotation,
+        color: InfluxColors.Honeydew,
+      }
+    })
 
   const handleAnnotationClick = makeAnnotationClickHandler(
     cellID,

--- a/yarn.lock
+++ b/yarn.lock
@@ -725,10 +725,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/flux/-/flux-0.5.1.tgz#e39e7a7af9163fc9494422c8fed77f3ae1b68f56"
   integrity sha512-GHlkXBhSdJ2m56JzDkbnKPAqLj3/lexPooacu14AWTO4f2sDGLmzM7r0AxgdtU1M2x7EXNBwgGOI5EOAdN6mkw==
 
-"@influxdata/giraffe@^2.14.0":
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.14.0.tgz#347a0b0a1b2a862e256e445ba1111d854fc222e8"
-  integrity sha512-CnnXZme3FNT+aZmy5X6p+zLp0YLIGWGFTxcUwNYtfplz5wRWN2wNAN2bHSr8WbG9CFSXuGVPL6v18zyZsCCw8A==
+"@influxdata/giraffe@^2.14.2":
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.14.2.tgz#1bdd3712adce9aadac89fb9e5756cda582d0e914"
+  integrity sha512-IfuOHa27a6tNK93eWFhAeKDSgSu/1YQstku1c32xTPhWvoCkdXDKp0hl8kWsF3gdnxS0bIzhc8G4F+I0K18acQ==
   dependencies:
     merge-images "^2.0.0"
 


### PR DESCRIPTION
Closes #1501 


sorts the annotations so the ranges render first;
and bumps up the giraffe version to get the new changes so they render correctly
