### PR TITLE
fix: Task Page/ Task Runs Page- task editing routing issue 

### DIFF
--- a/src/tasks/actions/creators.ts
+++ b/src/tasks/actions/creators.ts
@@ -148,5 +148,5 @@ export const setCurrentTasksPage = (page: string) =>
   ({
     type: SET_CURRENT_TASKS_PAGE,
     tasksPage: page
-  })
+  } as const)
 

--- a/src/tasks/actions/creators.ts
+++ b/src/tasks/actions/creators.ts
@@ -23,6 +23,7 @@ export const SET_RUNS = 'SET_RUNS'
 export const SET_LOGS = 'SET_LOGS'
 export const REMOVE_TASK = 'REMOVE_TASK'
 export const ADD_TASK = 'ADD_TASK'
+export const SET_CURRENT_TASKS_PAGE = 'SET_CURRENT_TASKS_PAGE'
 
 export type Action =
   | ReturnType<typeof setTasks>
@@ -41,6 +42,7 @@ export type Action =
   | ReturnType<typeof clearCurrentTask>
   | ReturnType<typeof removeTask>
   | ReturnType<typeof addTask>
+  | ReturnType<typeof setCurrentTasksPage>
 
 // R is the type of the value of the "result" key in normalizr's normalization
 type TasksSchema<R extends string | string[]> = NormalizedSchema<
@@ -141,3 +143,10 @@ export const setLogs = (logs: LogEvent[]) =>
     type: SET_LOGS,
     logs,
   } as const)
+
+export const setCurrentTasksPage = (page: string) =>
+  ({
+    type: SET_CURRENT_TASKS_PAGE,
+    tasksPage: page
+  })
+

--- a/src/tasks/actions/creators.ts
+++ b/src/tasks/actions/creators.ts
@@ -147,6 +147,5 @@ export const setLogs = (logs: LogEvent[]) =>
 export const setCurrentTasksPage = (page: string) =>
   ({
     type: SET_CURRENT_TASKS_PAGE,
-    tasksPage: page
+    tasksPage: page,
   } as const)
-

--- a/src/tasks/actions/creators.ts
+++ b/src/tasks/actions/creators.ts
@@ -144,7 +144,11 @@ export const setLogs = (logs: LogEvent[]) =>
     logs,
   } as const)
 
-export const setCurrentTasksPage = (page: string) =>
+export enum TaskPage {
+  TasksPage = 'TasksPage',
+  TaskRunsPage = 'TaskRunsPage',
+}
+export const setCurrentTasksPage = (page: TaskPage) =>
   ({
     type: SET_CURRENT_TASKS_PAGE,
     tasksPage: page,

--- a/src/tasks/actions/thunks.test.ts
+++ b/src/tasks/actions/thunks.test.ts
@@ -103,7 +103,7 @@ describe('Tasks.Actions.Thunks', () => {
 
     await thunks.updateTaskStatus({...sampleTask, status: 'active'})(dispatch)
 
-    expect(dispatch.mock.calls.length).toEqual(2)
+    expect(dispatch.mock.calls.length).toEqual(3)
     expect(dispatch.mock.calls[0][0].type).toBe('EDIT_TASK')
     expect(
       dispatch.mock.calls[0][0].schema.entities.tasks[sampleTask.id]

--- a/src/tasks/actions/thunks.test.ts
+++ b/src/tasks/actions/thunks.test.ts
@@ -103,7 +103,7 @@ describe('Tasks.Actions.Thunks', () => {
 
     await thunks.updateTaskStatus({...sampleTask, status: 'active'})(dispatch)
 
-    expect(dispatch.mock.calls.length).toEqual(3)
+    expect(dispatch.mock.calls.length).toEqual(2)
     expect(dispatch.mock.calls[0][0].type).toBe('EDIT_TASK')
     expect(
       dispatch.mock.calls[0][0].schema.entities.tasks[sampleTask.id]

--- a/src/tasks/actions/thunks.ts
+++ b/src/tasks/actions/thunks.ts
@@ -26,6 +26,7 @@ import {
   removeTask,
   setNewScript,
   clearCurrentTask,
+  setCurrentTasksPage,
   Action as TaskAction,
 } from 'src/tasks/actions/creators'
 
@@ -362,14 +363,29 @@ export const setAllTaskOptionsByID = (taskID: string) => async (
   }
 }
 
-export const goToTasks = () => (
+export const goToTasks = () => (  
   dispatch: Dispatch<Action | RouterAction>,
   getState: GetState
-) => {
+  ) => {
   const org = getOrg(getState())
-
-  dispatch(push(`/orgs/${org.id}/tasks`))
+  
+  dispatch(push(`/orgs/${org.id}/tasks/`))
 }
+
+export const goToTaskRuns = () => (  
+  dispatch: Dispatch<Action | RouterAction>,
+  getState: GetState
+  ) => {
+    const state = getState()
+    const {
+      tasks: {currentTask},
+    } = state.resources
+
+    const org = getOrg(getState())
+
+    dispatch(push(`/orgs/${org.id}/tasks/${currentTask.id}/runs`))
+}
+
 
 export const cancel = () => (dispatch: Dispatch<Action | RouterAction>) => {
   dispatch(clearCurrentTask())
@@ -383,7 +399,7 @@ export const updateScript = () => async (
   try {
     const state = getState()
     const {
-      tasks: {currentScript: script, currentTask: task, taskOptions},
+      tasks: {currentScript: script, currentTask: task, taskOptions, currentPage},
     } = state.resources
 
     const updatedTask: Partial<Task> & {
@@ -411,7 +427,12 @@ export const updateScript = () => async (
       throw new Error(resp.data.message)
     }
 
-    dispatch(goToTasks())
+    if (currentPage === 'TasksPage') {
+      dispatch(goToTasks())
+    } else if (currentPage === 'TaskRunsPage') {
+      dispatch(goToTaskRuns());
+    }
+
     dispatch(clearCurrentTask())
     dispatch(notify(copy.taskUpdateSuccess()))
   } catch (error) {
@@ -591,4 +612,16 @@ export const runDuration = (finishedAt: Date, startedAt: Date): string => {
   }
 
   return diff + ' ' + timeTag
+}
+
+export const setTasksPageAsCurrent = () => async (
+  dispatch: Dispatch<Action>
+) => {
+  dispatch(setCurrentTasksPage('TasksPage'));
+}
+
+export const setTaskRunsPageAsCurrent = () => async (
+  dispatch: Dispatch<Action>
+) => {
+  dispatch(setCurrentTasksPage('TaskRunsPage'));
 }

--- a/src/tasks/actions/thunks.ts
+++ b/src/tasks/actions/thunks.ts
@@ -26,7 +26,7 @@ import {
   removeTask,
   setNewScript,
   clearCurrentTask,
-  setCurrentTasksPage,
+  TaskPage,
   Action as TaskAction,
 } from 'src/tasks/actions/creators'
 
@@ -431,9 +431,9 @@ export const updateScript = () => async (
       throw new Error(resp.data.message)
     }
 
-    if (currentPage === 'TasksPage') {
+    if (currentPage === TaskPage.TasksPage) {
       dispatch(goToTasks())
-    } else if (currentPage === 'TaskRunsPage') {
+    } else if (currentPage === TaskPage.TaskRunsPage) {
       dispatch(goToTaskRuns())
     }
 
@@ -618,14 +618,14 @@ export const runDuration = (finishedAt: Date, startedAt: Date): string => {
   return diff + ' ' + timeTag
 }
 
-export const setTasksPageAsCurrent = () => async (
-  dispatch: Dispatch<Action>
-) => {
-  dispatch(setCurrentTasksPage('TasksPage'))
-}
+// export const setTasksPageAsCurrent = () => async (
+//   dispatch: Dispatch<Action>
+// ) => {
+//   dispatch(setCurrentTasksPage(TaskPage.TasksPage))
+// }
 
-export const setTaskRunsPageAsCurrent = () => async (
-  dispatch: Dispatch<Action>
-) => {
-  dispatch(setCurrentTasksPage('TaskRunsPage'))
-}
+// export const setTaskRunsPageAsCurrent = () => async (
+//   dispatch: Dispatch<Action>
+// ) => {
+//   dispatch(setCurrentTasksPage(TaskPage.TaskRunsPage))
+// }

--- a/src/tasks/actions/thunks.ts
+++ b/src/tasks/actions/thunks.ts
@@ -158,7 +158,7 @@ export const updateTaskStatus = (task: Task) => async (
     if (resp.status !== 200) {
       throw new Error(resp.data.message)
     }
-
+    
     const normTask = normalize<Task, TaskEntities, string>(
       resp.data,
       taskSchema

--- a/src/tasks/actions/thunks.ts
+++ b/src/tasks/actions/thunks.ts
@@ -618,14 +618,4 @@ export const runDuration = (finishedAt: Date, startedAt: Date): string => {
   return diff + ' ' + timeTag
 }
 
-// export const setTasksPageAsCurrent = () => async (
-//   dispatch: Dispatch<Action>
-// ) => {
-//   dispatch(setCurrentTasksPage(TaskPage.TasksPage))
-// }
 
-// export const setTaskRunsPageAsCurrent = () => async (
-//   dispatch: Dispatch<Action>
-// ) => {
-//   dispatch(setCurrentTasksPage(TaskPage.TaskRunsPage))
-// }

--- a/src/tasks/actions/thunks.ts
+++ b/src/tasks/actions/thunks.ts
@@ -617,5 +617,3 @@ export const runDuration = (finishedAt: Date, startedAt: Date): string => {
 
   return diff + ' ' + timeTag
 }
-
-

--- a/src/tasks/actions/thunks.ts
+++ b/src/tasks/actions/thunks.ts
@@ -166,7 +166,6 @@ export const updateTaskStatus = (task: Task) => async (
 
     dispatch(editTask(normTask))
     dispatch(notify(copy.taskUpdateSuccess()))
-    dispatch(setCurrentTask(normTask))
   } catch (e) {
     console.error(e)
     const message = getErrorMessage(e)

--- a/src/tasks/actions/thunks.ts
+++ b/src/tasks/actions/thunks.ts
@@ -363,29 +363,28 @@ export const setAllTaskOptionsByID = (taskID: string) => async (
   }
 }
 
-export const goToTasks = () => (  
+export const goToTasks = () => (
   dispatch: Dispatch<Action | RouterAction>,
   getState: GetState
-  ) => {
+) => {
   const org = getOrg(getState())
-  
+
   dispatch(push(`/orgs/${org.id}/tasks/`))
 }
 
-export const goToTaskRuns = () => (  
+export const goToTaskRuns = () => (
   dispatch: Dispatch<Action | RouterAction>,
   getState: GetState
-  ) => {
-    const state = getState()
-    const {
-      tasks: {currentTask},
-    } = state.resources
+) => {
+  const state = getState()
+  const {
+    tasks: {currentTask},
+  } = state.resources
 
-    const org = getOrg(getState())
+  const org = getOrg(getState())
 
-    dispatch(push(`/orgs/${org.id}/tasks/${currentTask.id}/runs`))
+  dispatch(push(`/orgs/${org.id}/tasks/${currentTask.id}/runs`))
 }
-
 
 export const cancel = () => (dispatch: Dispatch<Action | RouterAction>) => {
   dispatch(clearCurrentTask())
@@ -399,7 +398,12 @@ export const updateScript = () => async (
   try {
     const state = getState()
     const {
-      tasks: {currentScript: script, currentTask: task, taskOptions, currentPage},
+      tasks: {
+        currentScript: script,
+        currentTask: task,
+        taskOptions,
+        currentPage,
+      },
     } = state.resources
 
     const updatedTask: Partial<Task> & {
@@ -430,7 +434,7 @@ export const updateScript = () => async (
     if (currentPage === 'TasksPage') {
       dispatch(goToTasks())
     } else if (currentPage === 'TaskRunsPage') {
-      dispatch(goToTaskRuns());
+      dispatch(goToTaskRuns())
     }
 
     dispatch(clearCurrentTask())
@@ -617,11 +621,11 @@ export const runDuration = (finishedAt: Date, startedAt: Date): string => {
 export const setTasksPageAsCurrent = () => async (
   dispatch: Dispatch<Action>
 ) => {
-  dispatch(setCurrentTasksPage('TasksPage'));
+  dispatch(setCurrentTasksPage('TasksPage'))
 }
 
 export const setTaskRunsPageAsCurrent = () => async (
   dispatch: Dispatch<Action>
 ) => {
-  dispatch(setCurrentTasksPage('TaskRunsPage'));
+  dispatch(setCurrentTasksPage('TaskRunsPage'))
 }

--- a/src/tasks/actions/thunks.ts
+++ b/src/tasks/actions/thunks.ts
@@ -158,14 +158,15 @@ export const updateTaskStatus = (task: Task) => async (
     if (resp.status !== 200) {
       throw new Error(resp.data.message)
     }
-    
+
     const normTask = normalize<Task, TaskEntities, string>(
       resp.data,
       taskSchema
-    )
+      )
 
     dispatch(editTask(normTask))
     dispatch(notify(copy.taskUpdateSuccess()))
+    dispatch(setCurrentTask(normTask));
   } catch (e) {
     console.error(e)
     const message = getErrorMessage(e)

--- a/src/tasks/actions/thunks.ts
+++ b/src/tasks/actions/thunks.ts
@@ -162,11 +162,11 @@ export const updateTaskStatus = (task: Task) => async (
     const normTask = normalize<Task, TaskEntities, string>(
       resp.data,
       taskSchema
-      )
+    )
 
     dispatch(editTask(normTask))
     dispatch(notify(copy.taskUpdateSuccess()))
-    dispatch(setCurrentTask(normTask));
+    dispatch(setCurrentTask(normTask))
   } catch (e) {
     console.error(e)
     const message = getErrorMessage(e)

--- a/src/tasks/components/TaskCard.test.tsx
+++ b/src/tasks/components/TaskCard.test.tsx
@@ -24,6 +24,7 @@ const setup = (override = {}) => {
     onAddTaskLabel: jest.fn(),
     onDeleteTaskLabel: jest.fn(),
     onCreateLabel: jest.fn(),
+    setCurrentTasksPage: jest.fn(),
     labels: [], // all labels
     ...override,
   }

--- a/src/tasks/components/TaskCard.tsx
+++ b/src/tasks/components/TaskCard.tsx
@@ -240,11 +240,10 @@ export class TaskCard extends PureComponent<
   }
 
   private changeToggle = () => {
-    const {task, onActivate} = this.props
-    onActivate({
-      ...task,
-      status: task.status === 'active' ? 'inactive' : 'active',
-    })
+    const {onActivate} = this.props
+    const task = {...this.props.task}
+    task.status = task.status === 'active' ? 'inactive' : 'active'
+    onActivate(task)
   }
 
   private get schedule(): string {

--- a/src/tasks/components/TaskCard.tsx
+++ b/src/tasks/components/TaskCard.tsx
@@ -20,11 +20,8 @@ import LastRunTaskStatus from 'src/shared/components/lastRunTaskStatus/LastRunTa
 import {CopyResourceID} from 'src/shared/components/CopyResourceID'
 
 // Actions
-import {
-  addTaskLabel,
-  deleteTaskLabel,
-  setTasksPageAsCurrent,
-} from 'src/tasks/actions/thunks'
+import {addTaskLabel, deleteTaskLabel} from 'src/tasks/actions/thunks'
+import {TaskPage, setCurrentTasksPage} from 'src/tasks/actions/creators'
 
 // Types
 import {ComponentColor} from '@influxdata/clockface'
@@ -153,10 +150,10 @@ export class TaskCard extends PureComponent<
       },
       history,
       task,
-      setTasksPageAsCurrent,
+      setCurrentTasksPage,
     } = this.props
     const url = `/orgs/${orgID}/tasks/${task.id}/edit`
-    setTasksPageAsCurrent()
+    setCurrentTasksPage(TaskPage.TasksPage)
 
     if (event.metaKey) {
       window.open(url, '_blank')
@@ -268,7 +265,7 @@ export class TaskCard extends PureComponent<
 const mdtp = {
   onAddTaskLabel: addTaskLabel,
   onDeleteTaskLabel: deleteTaskLabel,
-  setTasksPageAsCurrent,
+  setCurrentTasksPage,
 }
 
 const connector = connect(null, mdtp)

--- a/src/tasks/components/TaskCard.tsx
+++ b/src/tasks/components/TaskCard.tsx
@@ -20,7 +20,11 @@ import LastRunTaskStatus from 'src/shared/components/lastRunTaskStatus/LastRunTa
 import {CopyResourceID} from 'src/shared/components/CopyResourceID'
 
 // Actions
-import {addTaskLabel, deleteTaskLabel, setTasksPageAsCurrent} from 'src/tasks/actions/thunks'
+import {
+  addTaskLabel,
+  deleteTaskLabel,
+  setTasksPageAsCurrent,
+} from 'src/tasks/actions/thunks'
 
 // Types
 import {ComponentColor} from '@influxdata/clockface'

--- a/src/tasks/components/TaskCard.tsx
+++ b/src/tasks/components/TaskCard.tsx
@@ -20,7 +20,7 @@ import LastRunTaskStatus from 'src/shared/components/lastRunTaskStatus/LastRunTa
 import {CopyResourceID} from 'src/shared/components/CopyResourceID'
 
 // Actions
-import {addTaskLabel, deleteTaskLabel} from 'src/tasks/actions/thunks'
+import {addTaskLabel, deleteTaskLabel, setTasksPageAsCurrent} from 'src/tasks/actions/thunks'
 
 // Types
 import {ComponentColor} from '@influxdata/clockface'
@@ -149,8 +149,10 @@ export class TaskCard extends PureComponent<
       },
       history,
       task,
+      setTasksPageAsCurrent,
     } = this.props
     const url = `/orgs/${orgID}/tasks/${task.id}/edit`
+    setTasksPageAsCurrent()
 
     if (event.metaKey) {
       window.open(url, '_blank')
@@ -262,6 +264,7 @@ export class TaskCard extends PureComponent<
 const mdtp = {
   onAddTaskLabel: addTaskLabel,
   onDeleteTaskLabel: deleteTaskLabel,
+  setTasksPageAsCurrent,
 }
 
 const connector = connect(null, mdtp)

--- a/src/tasks/components/TaskRunsCard.tsx
+++ b/src/tasks/components/TaskRunsCard.tsx
@@ -22,6 +22,7 @@ import {
   deleteTaskLabel,
   runTask,
   getRuns,
+  setTaskRunsPageAsCurrent,
 } from 'src/tasks/actions/thunks'
 
 // Types
@@ -112,11 +113,12 @@ class UnconnectedTaskRunsCard extends PureComponent<
     const {
       history,
       currentTask,
+      setTaskRunsPageAsCurrent,
       match: {
         params: {orgID},
       },
     } = this.props
-
+    setTaskRunsPageAsCurrent()
     history.push(`/orgs/${orgID}/tasks/${currentTask.id}/edit`)
   }
 
@@ -154,6 +156,7 @@ const mdtp = {
   onDeleteTaskLabel: deleteTaskLabel,
   onRunTask: runTask,
   getRuns,
+  setTaskRunsPageAsCurrent,
 }
 
 const connector = connect(mstp, mdtp)

--- a/src/tasks/components/TaskRunsCard.tsx
+++ b/src/tasks/components/TaskRunsCard.tsx
@@ -132,6 +132,7 @@ class UnconnectedTaskRunsCard extends PureComponent<
 
   private changeToggle = () => {
     const {task, onActivate} = this.props
+    
     if (task.status === 'active') {
       task.status = 'inactive'
     } else {

--- a/src/tasks/components/TaskRunsCard.tsx
+++ b/src/tasks/components/TaskRunsCard.tsx
@@ -123,8 +123,8 @@ class UnconnectedTaskRunsCard extends PureComponent<
   }
 
   private get isTaskActive(): boolean {
-    const {task} = this.props
-    if (task.status === 'active') {
+    const {currentTask} = this.props
+    if (currentTask.status === 'active') {
       return true
     }
     return false
@@ -132,13 +132,8 @@ class UnconnectedTaskRunsCard extends PureComponent<
 
   private changeToggle = () => {
     const {task, onActivate} = this.props
-    
-    if (task.status === 'active') {
-      task.status = 'inactive'
-    } else {
-      task.status = 'active'
-    }
-    onActivate(task)
+    const newStatus = (task.status === 'active') ? 'inactive' : 'active'
+    onActivate({...task, status: newStatus})
   }
 }
 

--- a/src/tasks/components/TaskRunsCard.tsx
+++ b/src/tasks/components/TaskRunsCard.tsx
@@ -128,9 +128,10 @@ class UnconnectedTaskRunsCard extends PureComponent<
   }
 
   private changeToggle = () => {
-    const {task, onActivate} = this.props
-    const newStatus = task.status === 'active' ? 'inactive' : 'active'
-    onActivate({...task, status: newStatus})
+    const {onActivate} = this.props
+    const task = {...this.props.task}
+    task.status = task.status === 'active' ? 'inactive' : 'active'
+    onActivate(task)
   }
 }
 

--- a/src/tasks/components/TaskRunsCard.tsx
+++ b/src/tasks/components/TaskRunsCard.tsx
@@ -132,7 +132,7 @@ class UnconnectedTaskRunsCard extends PureComponent<
 
   private changeToggle = () => {
     const {task, onActivate} = this.props
-    const newStatus = (task.status === 'active') ? 'inactive' : 'active'
+    const newStatus = task.status === 'active' ? 'inactive' : 'active'
     onActivate({...task, status: newStatus})
   }
 }

--- a/src/tasks/components/TaskRunsCard.tsx
+++ b/src/tasks/components/TaskRunsCard.tsx
@@ -112,22 +112,19 @@ class UnconnectedTaskRunsCard extends PureComponent<
   private handleEditTask = () => {
     const {
       history,
-      currentTask,
+      task,
       setCurrentTasksPage,
       match: {
         params: {orgID},
       },
     } = this.props
     setCurrentTasksPage(TaskPage.TaskRunsPage)
-    history.push(`/orgs/${orgID}/tasks/${currentTask.id}/edit`)
+    history.push(`/orgs/${orgID}/tasks/${task.id}/edit`)
   }
 
   private get isTaskActive(): boolean {
-    const {currentTask} = this.props
-    if (currentTask.status === 'active') {
-      return true
-    }
-    return false
+    const {task} = this.props
+    return task.status === 'active'
   }
 
   private changeToggle = () => {
@@ -138,12 +135,11 @@ class UnconnectedTaskRunsCard extends PureComponent<
 }
 
 const mstp = (state: AppState) => {
-  const {runs, runStatus, currentTask} = state.resources.tasks
+  const {runs, runStatus} = state.resources.tasks
 
   return {
     runs,
     runStatus,
-    currentTask,
   }
 }
 

--- a/src/tasks/components/TaskRunsCard.tsx
+++ b/src/tasks/components/TaskRunsCard.tsx
@@ -22,8 +22,8 @@ import {
   deleteTaskLabel,
   runTask,
   getRuns,
-  setTaskRunsPageAsCurrent,
 } from 'src/tasks/actions/thunks'
+import {TaskPage, setCurrentTasksPage} from 'src/tasks/actions/creators'
 
 // Types
 import {ComponentColor, Button} from '@influxdata/clockface'
@@ -113,12 +113,12 @@ class UnconnectedTaskRunsCard extends PureComponent<
     const {
       history,
       currentTask,
-      setTaskRunsPageAsCurrent,
+      setCurrentTasksPage,
       match: {
         params: {orgID},
       },
     } = this.props
-    setTaskRunsPageAsCurrent()
+    setCurrentTasksPage(TaskPage.TaskRunsPage)
     history.push(`/orgs/${orgID}/tasks/${currentTask.id}/edit`)
   }
 
@@ -156,7 +156,7 @@ const mdtp = {
   onDeleteTaskLabel: deleteTaskLabel,
   onRunTask: runTask,
   getRuns,
-  setTaskRunsPageAsCurrent,
+  setCurrentTasksPage,
 }
 
 const connector = connect(mstp, mdtp)

--- a/src/tasks/components/TaskRunsPage.test.tsx
+++ b/src/tasks/components/TaskRunsPage.test.tsx
@@ -12,7 +12,7 @@ import {tasks, orgs, withRouterProps, labels} from 'mocks/dummyData'
 import {renderWithReduxAndRouter} from 'src/mockState'
 import {mockAppState} from 'src/mockAppState'
 import {RemoteDataState} from 'src/types'
-import {mocked} from 'ts-jest'
+import {mocked} from 'ts-jest/utils'
 
 const runIDs = [
   '07a7f99e81cf2000',
@@ -185,6 +185,16 @@ jest.mock('src/client', () => ({
     status: 201,
   })),
 }))
+
+jest.mock('src/resources/selectors', () => {
+  return {
+    getByID: jest.fn(() => {
+      return tasks[0]
+    }),
+  }
+})
+
+jest.mock('src/resources/components/GetResources')
 
 const setup = () => {
   const props: any = {

--- a/src/tasks/components/TaskRunsPage.tsx
+++ b/src/tasks/components/TaskRunsPage.tsx
@@ -7,6 +7,7 @@ import {withRouter, RouteComponentProps} from 'react-router-dom'
 import {Page, Sort} from '@influxdata/clockface'
 import TaskRunsList from 'src/tasks/components/TaskRunsList'
 import RateLimitAlert from 'src/cloud/components/RateLimitAlert'
+import GetResources from 'src/resources/components/GetResources'
 import {TaskRunsCard} from 'src/tasks/components/TaskRunsCard'
 import {PageBreadcrumbs} from 'src/tasks/components/PageBreadcrumbs'
 
@@ -17,12 +18,16 @@ import {SpinnerContainer, TechnoSpinner} from '@influxdata/clockface'
 // Actions
 import {getRuns, runTask, updateTaskStatus} from 'src/tasks/actions/thunks'
 
+// Selectors
+import {getByID} from 'src/resources/selectors'
+
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 
 // Types
 import {SortTypes} from 'src/shared/utils/sort'
 import TimeZoneDropdown from 'src/shared/components/TimeZoneDropdown'
+import {ResourceType, Task} from 'src/types'
 
 type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps & RouteComponentProps<{id: string; orgID: string}>
@@ -82,14 +87,16 @@ class TaskRunsPage extends PureComponent<Props, State> {
             </Page.ControlBarRight>
           </Page.ControlBar>
           <Page.Contents fullWidth={false} scrollable={true}>
-            <TaskRunsList
-              taskID={match.params.id}
-              runs={runs}
-              sortKey={sortKey}
-              sortDirection={sortDirection}
-              sortType={sortType}
-              onClickColumn={this.handleClickColumn}
-            />
+            <GetResources resources={[ResourceType.Tasks]}>
+              <TaskRunsList
+                taskID={match.params.id}
+                runs={runs}
+                sortKey={sortKey}
+                sortDirection={sortDirection}
+                sortType={sortType}
+                onClickColumn={this.handleClickColumn}
+              />
+            </GetResources>
           </Page.Contents>
         </Page>
       </SpinnerContainer>
@@ -133,8 +140,13 @@ class TaskRunsPage extends PureComponent<Props, State> {
   }
 }
 
-const mstp = (state: AppState) => {
-  const {runs, runStatus, currentTask} = state.resources.tasks
+const mstp = (state: AppState, props) => {
+  const {runs, runStatus} = state.resources.tasks
+  const currentTask = getByID<Task>(
+    state,
+    ResourceType.Tasks,
+    props.match.params.id
+  )
 
   return {
     runs,

--- a/src/tasks/reducers/helpers.ts
+++ b/src/tasks/reducers/helpers.ts
@@ -18,6 +18,7 @@ export const initialState = (): ResourceState['tasks'] => ({
   runStatus: RemoteDataState.NotStarted,
   runs: [],
   logs: [],
+  currentPage: '',
 })
 
 export const defaultOptions: TaskOptions = {

--- a/src/tasks/reducers/helpers.ts
+++ b/src/tasks/reducers/helpers.ts
@@ -18,7 +18,7 @@ export const initialState = (): ResourceState['tasks'] => ({
   runStatus: RemoteDataState.NotStarted,
   runs: [],
   logs: [],
-  currentPage: '',
+  currentPage: 'TasksPage',
 })
 
 export const defaultOptions: TaskOptions = {

--- a/src/tasks/reducers/index.ts
+++ b/src/tasks/reducers/index.ts
@@ -169,6 +169,5 @@ export default (
         draftState.currentPage = action.tasksPage
         return
       }
-
     }
   })

--- a/src/tasks/reducers/index.ts
+++ b/src/tasks/reducers/index.ts
@@ -19,6 +19,7 @@ import {
   SET_LOGS,
   EDIT_TASK,
   REMOVE_TASK,
+  SET_CURRENT_TASKS_PAGE,
 } from 'src/tasks/actions/creators'
 import {ResourceType, ResourceState, TaskSchedule, Task} from 'src/types'
 
@@ -163,5 +164,11 @@ export default (
 
         return
       }
+
+      case SET_CURRENT_TASKS_PAGE: {
+        draftState.currentPage = action.tasksPage
+        return
+      }
+
     }
   })

--- a/src/tasks/reducers/index.ts
+++ b/src/tasks/reducers/index.ts
@@ -167,6 +167,7 @@ export default (
 
       case SET_CURRENT_TASKS_PAGE: {
         draftState.currentPage = action.tasksPage
+
         return
       }
     }

--- a/src/types/tasks.ts
+++ b/src/types/tasks.ts
@@ -25,6 +25,7 @@ export interface TasksState extends NormalizedState<Task> {
   runs: Run[]
   runStatus: RemoteDataState
   logs: LogEvent[]
+  currentPage: string
 }
 
 export enum TaskSchedule {


### PR DESCRIPTION
closes #1495 

To make code review/ merging easier, I've split #1655 into smaller portions.
This PR contains the remaining portion of changes implemented by PR #1655.

**Issue**: Whether user is editing task from task list page or task runs page, after clicking save, user is always routed back to task list page. 
PR **solution**:
If user edits task from task list page, after clicking save, they will be routed to task list page. 
if user edits task from task runs page, after clicking save, they will be routed to task runs page. 

https://user-images.githubusercontent.com/66275100/122278032-237ca480-ceac-11eb-9eac-6250d5231f75.mov