### PR TITLE
fix: correct default cell height for static legend and cap lower bounds

### DIFF
--- a/src/dashboards/utils/cellGetters.ts
+++ b/src/dashboards/utils/cellGetters.ts
@@ -55,7 +55,14 @@ export const getNewDashboardCell = (
     id: uuid.v4(),
     x: 0,
     y: 0,
-    h: isStaticLegendType ? STATIC_LEGEND_CELL_HEIGHT_DEFAULT : 4,
+    h:
+      isStaticLegendType &&
+      (viewProperties as
+        | XYViewProperties
+        | LinePlusSingleStatProperties
+        | BandViewProperties)?.staticLegend?.show
+        ? STATIC_LEGEND_CELL_HEIGHT_DEFAULT
+        : 4,
     w: 4,
     links: {
       self: '',

--- a/src/dashboards/utils/cellGetters.ts
+++ b/src/dashboards/utils/cellGetters.ts
@@ -48,11 +48,14 @@ export const getNewDashboardCell = (
   clonedCell: Cell,
   viewProperties: ViewProperties
 ): NewCell => {
+  const staticLegendTypes = new Set(['xy', 'line-plus-single-stat', 'band'])
+  const isStaticLegendType = staticLegendTypes.has(viewProperties?.type)
+
   const defaultCell = {
     id: uuid.v4(),
     x: 0,
     y: 0,
-    h: 4,
+    h: isStaticLegendType ? STATIC_LEGEND_CELL_HEIGHT_DEFAULT : 4,
     w: 4,
     links: {
       self: '',
@@ -76,8 +79,7 @@ export const getNewDashboardCell = (
   const mostCommonCellWidth = getMostCommonValue(existingCellWidths)
   let mostCommonCellHeight = getMostCommonValue(existingCellHeights)
 
-  const staticLegendTypes = new Set(['xy', 'line-plus-single-stat', 'band'])
-  if (staticLegendTypes.has(viewProperties?.type)) {
+  if (isStaticLegendType) {
     const {staticLegend} = viewProperties as
       | XYViewProperties
       | LinePlusSingleStatProperties

--- a/src/visualization/utils/useStaticLegend.ts
+++ b/src/visualization/utils/useStaticLegend.ts
@@ -131,6 +131,9 @@ export const useStaticLegend = (properties): StaticLegendConfig => {
           if (heightRatio < STATIC_LEGEND_HEIGHT_RATIO_MINIMUM) {
             heightRatio = STATIC_LEGEND_HEIGHT_RATIO_MINIMUM
           }
+          if (typeof heightRatio !== 'number' || heightRatio !== heightRatio) {
+            heightRatio = STATIC_LEGEND_HEIGHT_RATIO_DEFAULT
+          }
 
           update({
             heightRatio,

--- a/src/visualization/utils/useStaticLegend.ts
+++ b/src/visualization/utils/useStaticLegend.ts
@@ -123,13 +123,12 @@ export const useStaticLegend = (properties): StaticLegendConfig => {
             estimatedHeight = length * sampleMaxHeight + padding
           }
 
-          const updatedRatio = estimatedHeight / totalHeight
+          let heightRatio = estimatedHeight / totalHeight
 
-          let heightRatio = updatedRatio
-          if (updatedRatio > STATIC_LEGEND_HEIGHT_RATIO_MAXIMUM) {
+          if (heightRatio > STATIC_LEGEND_HEIGHT_RATIO_MAXIMUM) {
             heightRatio = STATIC_LEGEND_HEIGHT_RATIO_MAXIMUM
           }
-          if (updatedRatio < STATIC_LEGEND_HEIGHT_RATIO_MINIMUM) {
+          if (heightRatio < STATIC_LEGEND_HEIGHT_RATIO_MINIMUM) {
             heightRatio = STATIC_LEGEND_HEIGHT_RATIO_MINIMUM
           }
 

--- a/src/visualization/utils/useStaticLegend.ts
+++ b/src/visualization/utils/useStaticLegend.ts
@@ -135,11 +135,11 @@ export const useStaticLegend = (properties): StaticLegendConfig => {
             heightRatio = STATIC_LEGEND_HEIGHT_RATIO_DEFAULT
           }
 
-          update({
-            heightRatio,
-          })
           event(`${eventPrefix}.heightRatio.autoAdjust`, {
             type: properties.type,
+            heightRatio,
+          })
+          update({
             heightRatio,
           })
         }

--- a/src/visualization/utils/useStaticLegend.ts
+++ b/src/visualization/utils/useStaticLegend.ts
@@ -16,6 +16,7 @@ import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {
   STATIC_LEGEND_HEIGHT_RATIO_DEFAULT,
   STATIC_LEGEND_HEIGHT_RATIO_MAXIMUM,
+  STATIC_LEGEND_HEIGHT_RATIO_MINIMUM,
   STATIC_LEGEND_HEIGHT_RATIO_NOT_SET,
   STATIC_LEGEND_SHOW_DEFAULT,
   STATIC_LEGEND_STYLING,
@@ -123,10 +124,14 @@ export const useStaticLegend = (properties): StaticLegendConfig => {
           }
 
           const updatedRatio = estimatedHeight / totalHeight
-          const heightRatio =
-            updatedRatio <= STATIC_LEGEND_HEIGHT_RATIO_MAXIMUM
-              ? updatedRatio
-              : STATIC_LEGEND_HEIGHT_RATIO_MAXIMUM
+
+          let heightRatio = updatedRatio
+          if (updatedRatio > STATIC_LEGEND_HEIGHT_RATIO_MAXIMUM) {
+            heightRatio = STATIC_LEGEND_HEIGHT_RATIO_MAXIMUM
+          }
+          if (updatedRatio < STATIC_LEGEND_HEIGHT_RATIO_MINIMUM) {
+            heightRatio = STATIC_LEGEND_HEIGHT_RATIO_MINIMUM
+          }
 
           update({
             heightRatio,


### PR DESCRIPTION
Part of #1523 

- Previously, i capped the upper bounds of static legend height. The lower bounds should also be capped. This is just for thoroughness, as the static legend height should come back as positive number from Giraffe's renderEffect options.
- Fix the default cell height when user creates a cell through the Data Explorer rather than "Add Cell"
