### PR TITLE
chore: updated unification pages to have pageTitleSuffixers, and added filter to treenav to remove operator for non-operators

### DIFF
--- a/src/billing/components/BillingPage.tsx
+++ b/src/billing/components/BillingPage.tsx
@@ -8,9 +8,12 @@ import RateLimitAlert from 'src/cloud/components/RateLimitAlert'
 import LimitChecker from 'src/cloud/components/LimitChecker'
 import BillingProvider from 'src/billing/context/billing'
 
+// Utils
+import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
+
 const BillingPage: FC = () => (
   <BillingProvider>
-    <Page titleTag="Billing">
+    <Page titleTag={pageTitleSuffixer(['Billing'])}>
       <Page.Header fullWidth={false} testID="billing-page--header">
         <Page.Title title="Billing" />
         <LimitChecker>

--- a/src/pageLayout/constants/navigationHierarchy.ts
+++ b/src/pageLayout/constants/navigationHierarchy.ts
@@ -223,7 +223,6 @@ export const generateNavItems = (orgID: string): NavItem[] => {
       testID: 'nav-item-operator',
       icon: IconFont.Shield,
       label: 'Operator',
-      cloudOnly: true,
       featureFlag: 'unityOperator',
       shortLabel: 'Operator',
       link: {

--- a/src/pageLayout/constants/navigationHierarchy.ts
+++ b/src/pageLayout/constants/navigationHierarchy.ts
@@ -1,20 +1,20 @@
 import {IconFont} from '@influxdata/clockface'
 import {PROJECT_NAME_PLURAL, PROJECT_NAME_SHORT} from 'src/flows'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import {getStore} from 'src/store/configureStore'
 
-export interface NavItemLink {
-  type: 'link' | 'href'
-  location: string
-}
+// Constants
+import {CLOUD} from 'src/shared/constants'
+
+// Types
+import {AppState} from 'src/types'
 
 export interface NavSubItem {
   id: string
   testID: string
   label: string
-  link: NavItemLink
-  cloudExclude?: boolean
-  cloudOnly?: boolean
-  featureFlag?: string
-  featureFlagValue?: boolean
+  link: string
+  enabled?: () => boolean
 }
 
 export interface NavItem {
@@ -22,77 +22,60 @@ export interface NavItem {
   testID: string
   label: string
   shortLabel?: string
-  link: NavItemLink
+  link: string
   icon: IconFont
-  cloudExclude?: boolean
-  cloudOnly?: boolean
-  featureFlag?: string
-  featureFlagValue?: boolean
+  enabled?: () => boolean
   menu?: NavSubItem[]
   activeKeywords: string[]
 }
 
-export const generateNavItems = (orgID: string): NavItem[] => {
+export const generateNavItems = (): NavItem[] => {
+  const state: AppState = getStore().getState()
+  const orgID = state?.resources?.orgs?.org?.id ?? ''
+  const quartzMe = state?.me?.quartzMe ?? null
+
   const orgPrefix = `/orgs/${orgID}`
 
-  return [
+  let navItems = [
     {
       id: 'load-data',
       testID: 'nav-item-load-data',
       icon: IconFont.DisksNav,
       label: 'Load Data',
       shortLabel: 'Data',
-      link: {
-        type: 'link',
-        location: `${orgPrefix}/load-data/sources`,
-      },
+      link: `${orgPrefix}/load-data/sources`,
       activeKeywords: ['load-data'],
       menu: [
         {
           id: 'sources',
           testID: 'nav-subitem-sources',
           label: 'Sources',
-          link: {
-            type: 'link',
-            location: `${orgPrefix}/load-data/sources`,
-          },
+          link: `${orgPrefix}/load-data/sources`,
         },
         {
           id: 'buckets',
           testID: 'nav-subitem-buckets',
           label: 'Buckets',
-          link: {
-            type: 'link',
-            location: `${orgPrefix}/load-data/buckets`,
-          },
+          link: `${orgPrefix}/load-data/buckets`,
         },
         {
           id: 'telegrafs',
           testID: 'nav-subitem-telegrafs',
           label: 'Telegraf',
-          link: {
-            type: 'link',
-            location: `${orgPrefix}/load-data/telegrafs`,
-          },
+          link: `${orgPrefix}/load-data/telegrafs`,
         },
         {
           id: 'scrapers',
           testID: 'nav-subitem-scrapers',
           label: 'Scrapers',
-          link: {
-            type: 'link',
-            location: `${orgPrefix}/load-data/scrapers`,
-          },
-          cloudExclude: true,
+          link: `${orgPrefix}/load-data/scrapers`,
+          enabled: () => !CLOUD,
         },
         {
           id: 'tokens',
           testID: 'nav-subitem-tokens',
           label: 'Tokens',
-          link: {
-            type: 'link',
-            location: `${orgPrefix}/load-data/tokens`,
-          },
+          link: `${orgPrefix}/load-data/tokens`,
         },
       ],
     },
@@ -102,10 +85,7 @@ export const generateNavItems = (orgID: string): NavItem[] => {
       icon: IconFont.GraphLine,
       label: 'Data Explorer',
       shortLabel: 'Explore',
-      link: {
-        type: 'link',
-        location: `${orgPrefix}/data-explorer`,
-      },
+      link: `${orgPrefix}/data-explorer`,
       activeKeywords: ['data-explorer'],
     },
     {
@@ -113,12 +93,9 @@ export const generateNavItems = (orgID: string): NavItem[] => {
       testID: 'nav-item-flows',
       icon: IconFont.BookPencil,
       label: PROJECT_NAME_PLURAL,
-      featureFlag: 'notebooks',
+      enabled: () => isFlagEnabled('notebooks'),
       shortLabel: PROJECT_NAME_SHORT,
-      link: {
-        type: 'link',
-        location: `${orgPrefix}/${PROJECT_NAME_PLURAL.toLowerCase()}`,
-      },
+      link: `${orgPrefix}/${PROJECT_NAME_PLURAL.toLowerCase()}`,
       activeKeywords: [PROJECT_NAME_PLURAL.toLowerCase()],
     },
     {
@@ -127,10 +104,7 @@ export const generateNavItems = (orgID: string): NavItem[] => {
       icon: IconFont.Dashboards,
       label: 'Dashboards',
       shortLabel: 'Boards',
-      link: {
-        type: 'link',
-        location: `${orgPrefix}/dashboards-list`,
-      },
+      link: `${orgPrefix}/dashboards-list`,
       activeKeywords: ['dashboards', 'dashboards-list'],
     },
     {
@@ -138,10 +112,7 @@ export const generateNavItems = (orgID: string): NavItem[] => {
       testID: 'nav-item-tasks',
       icon: IconFont.Calendar,
       label: 'Tasks',
-      link: {
-        type: 'link',
-        location: `${orgPrefix}/tasks`,
-      },
+      link: `${orgPrefix}/tasks`,
       activeKeywords: ['tasks'],
     },
     {
@@ -149,20 +120,14 @@ export const generateNavItems = (orgID: string): NavItem[] => {
       testID: 'nav-item-alerting',
       icon: IconFont.Bell,
       label: 'Alerts',
-      link: {
-        type: 'link',
-        location: `${orgPrefix}/alerting`,
-      },
+      link: `${orgPrefix}/alerting`,
       activeKeywords: ['alerting'],
       menu: [
         {
           id: 'history',
           testID: 'nav-subitem-history',
           label: 'Alert History',
-          link: {
-            type: 'link',
-            location: `${orgPrefix}/alert-history`,
-          },
+          link: `${orgPrefix}/alert-history`,
         },
       ],
     },
@@ -171,65 +136,67 @@ export const generateNavItems = (orgID: string): NavItem[] => {
       testID: 'nav-item-settings',
       icon: IconFont.WrenchNav,
       label: 'Settings',
-      link: {
-        type: 'link',
-        location: `${orgPrefix}/settings/variables`,
-      },
+      link: `${orgPrefix}/settings/variables`,
       activeKeywords: ['settings'],
       menu: [
         {
           id: 'variables',
           testID: 'nav-subitem-variables',
           label: 'Variables',
-          link: {
-            type: 'link',
-            location: `${orgPrefix}/settings/variables`,
-          },
+          link: `${orgPrefix}/settings/variables`,
         },
         {
           id: 'templates',
           testID: 'nav-subitem-templates',
           label: 'Templates',
-          link: {
-            type: 'link',
-            location: `${orgPrefix}/settings/templates`,
-          },
+          link: `${orgPrefix}/settings/templates`,
         },
         {
           id: 'labels',
           testID: 'nav-subitem-labels',
           label: 'Labels',
-          link: {
-            type: 'link',
-            location: `${orgPrefix}/settings/labels`,
-          },
+          link: `${orgPrefix}/settings/labels`,
         },
       ],
     },
     {
       id: 'functions',
+      enabled: () => isFlagEnabled('managed-functions'),
       testID: 'nav-item-functions',
       icon: IconFont.Function,
       label: 'Function',
-      link: {
-        type: 'link',
-        location: `${orgPrefix}/functions/`,
-      },
+      link: `${orgPrefix}/functions/`,
       activeKeywords: ['functions'],
-      featureFlag: 'managed-functions',
     },
     {
       id: 'operator',
+      enabled: () =>
+        CLOUD &&
+        quartzMe?.isOperator === true &&
+        isFlagEnabled('unityOperator'),
       testID: 'nav-item-operator',
       icon: IconFont.Shield,
       label: 'Operator',
-      featureFlag: 'unityOperator',
       shortLabel: 'Operator',
-      link: {
-        type: 'link',
-        location: `/operator`,
-      },
+      link: `/operator`,
       activeKeywords: ['operator'],
     },
   ]
+
+  navItems = navItems.filter(item => {
+    if (item?.menu) {
+      item.menu = item.menu.filter(sub => {
+        if (sub?.enabled) {
+          return sub.enabled()
+        }
+        return true
+      })
+    }
+    if (item?.enabled) {
+      return item.enabled()
+    }
+    return true
+  })
+
+  return navItems
 }

--- a/src/pageLayout/containers/TreeNav.tsx
+++ b/src/pageLayout/containers/TreeNav.tsx
@@ -15,14 +15,17 @@ import {FeatureFlag} from 'src/shared/utils/featureFlag'
 
 // Constants
 import {generateNavItems} from 'src/pageLayout/constants/navigationHierarchy'
+import {CLOUD} from 'src/shared/constants'
 
 // Utils
 import {getNavItemActivation} from 'src/pageLayout/utils'
 import {getOrg} from 'src/organizations/selectors'
 import {AppSettingContext} from 'src/shared/contexts/app'
+import {getQuartzMe} from 'src/me/selectors'
 
 const TreeSidebar: FC = () => {
   const org = useSelector(getOrg)
+  const me = useSelector(getQuartzMe)
   const {presentationMode, navbarMode, setNavbarMode} = useContext(
     AppSettingContext
   )
@@ -121,7 +124,28 @@ const TreeSidebar: FC = () => {
                       )
                     }
 
-                    if (menuItem.featureFlag) {
+                    if (
+                      CLOUD &&
+                      item.featureFlag === 'unityOperator' &&
+                      me?.isOperator
+                    ) {
+                      navItemElement = (
+                        <FeatureFlag
+                          key={item.id}
+                          name={item.featureFlag}
+                          equals={item.featureFlagValue}
+                        >
+                          {navItemElement}
+                        </FeatureFlag>
+                      )
+                    }
+
+                    // TODO(ariel): sort this out for the operator to render for operators and not to render for non operators
+
+                    if (
+                      item.featureFlag &&
+                      item.featureFlag !== 'unityOperator'
+                    ) {
                       navSubItemElement = (
                         <FeatureFlag
                           key={menuItem.id}
@@ -152,7 +176,19 @@ const TreeSidebar: FC = () => {
             )
           }
 
-          if (item.featureFlag) {
+          if (CLOUD && item.featureFlag === 'unityOperator' && me?.isOperator) {
+            navItemElement = (
+              <FeatureFlag
+                key={item.id}
+                name={item.featureFlag}
+                equals={item.featureFlagValue}
+              >
+                {navItemElement}
+              </FeatureFlag>
+            )
+          }
+
+          if (item.featureFlag && item.featureFlag !== 'unityOperator') {
             navItemElement = (
               <FeatureFlag
                 key={item.id}

--- a/src/pageLayout/containers/TreeNav.tsx
+++ b/src/pageLayout/containers/TreeNav.tsx
@@ -51,157 +51,147 @@ const TreeSidebar: FC = () => {
         onToggleClick={handleToggleNavExpansion}
         bannerElement={<CloudUpgradeNavBanner />}
       >
-        {generateNavItems(org.id).map(item => {
-          const linkElement = (className: string): JSX.Element => {
-            if (item.link.type === 'href') {
-              return <a href={item.link.location} className={className} />
+        {generateNavItems(org.id)
+          .filter(item => {
+            if (item.id === 'operator') {
+              return CLOUD && me?.isOperator
             }
+            return true
+          })
+          .map(item => {
+            const linkElement = (className: string): JSX.Element => {
+              if (item.link.type === 'href') {
+                return <a href={item.link.location} className={className} />
+              }
 
-            return <Link to={item.link.location} className={className} />
-          }
-          let navItemElement = (
-            <TreeNav.Item
-              key={item.id}
-              id={item.id}
-              testID={item.testID}
-              icon={<Icon glyph={item.icon} />}
-              label={item.label}
-              shortLabel={item.shortLabel}
-              active={getNavItemActivation(
-                item.activeKeywords,
-                location.pathname
-              )}
-              linkElement={linkElement}
-            >
-              {Boolean(item.menu) && (
-                <TreeNav.SubMenu>
-                  {item.menu.map(menuItem => {
-                    const linkElement = (className: string): JSX.Element => {
-                      if (menuItem.link.type === 'href') {
+              return <Link to={item.link.location} className={className} />
+            }
+            let navItemElement = (
+              <TreeNav.Item
+                key={item.id}
+                id={item.id}
+                testID={item.testID}
+                icon={<Icon glyph={item.icon} />}
+                label={item.label}
+                shortLabel={item.shortLabel}
+                active={getNavItemActivation(
+                  item.activeKeywords,
+                  location.pathname
+                )}
+                linkElement={linkElement}
+              >
+                {Boolean(item.menu) && (
+                  <TreeNav.SubMenu>
+                    {item.menu.map(menuItem => {
+                      const linkElement = (className: string): JSX.Element => {
+                        if (menuItem.link.type === 'href') {
+                          return (
+                            <a
+                              href={menuItem.link.location}
+                              className={className}
+                            />
+                          )
+                        }
+
                         return (
-                          <a
-                            href={menuItem.link.location}
+                          <Link
+                            to={menuItem.link.location}
                             className={className}
                           />
                         )
                       }
 
-                      return (
-                        <Link
-                          to={menuItem.link.location}
-                          className={className}
+                      let navSubItemElement = (
+                        <TreeNav.SubItem
+                          key={menuItem.id}
+                          id={menuItem.id}
+                          testID={menuItem.testID}
+                          active={getNavItemActivation(
+                            [menuItem.id],
+                            location.pathname
+                          )}
+                          label={menuItem.label}
+                          linkElement={linkElement}
                         />
                       )
-                    }
 
-                    let navSubItemElement = (
-                      <TreeNav.SubItem
-                        key={menuItem.id}
-                        id={menuItem.id}
-                        testID={menuItem.testID}
-                        active={getNavItemActivation(
-                          [menuItem.id],
-                          location.pathname
-                        )}
-                        label={menuItem.label}
-                        linkElement={linkElement}
-                      />
-                    )
+                      if (menuItem.cloudExclude) {
+                        navSubItemElement = (
+                          <CloudExclude key={menuItem.id}>
+                            {navSubItemElement}
+                          </CloudExclude>
+                        )
+                      }
 
-                    if (menuItem.cloudExclude) {
-                      navSubItemElement = (
-                        <CloudExclude key={menuItem.id}>
-                          {navSubItemElement}
-                        </CloudExclude>
-                      )
-                    }
+                      if (menuItem.cloudOnly) {
+                        navSubItemElement = (
+                          <CloudOnly key={menuItem.id}>
+                            {navSubItemElement}
+                          </CloudOnly>
+                        )
+                      }
 
-                    if (menuItem.cloudOnly) {
-                      navSubItemElement = (
-                        <CloudOnly key={menuItem.id}>
-                          {navSubItemElement}
-                        </CloudOnly>
-                      )
-                    }
+                      if (item.featureFlag) {
+                        navItemElement = (
+                          <FeatureFlag
+                            key={item.id}
+                            name={item.featureFlag}
+                            equals={item.featureFlagValue}
+                          >
+                            {navItemElement}
+                          </FeatureFlag>
+                        )
+                      }
 
-                    if (
-                      CLOUD &&
-                      item.featureFlag === 'unityOperator' &&
-                      me?.isOperator
-                    ) {
-                      navItemElement = (
-                        <FeatureFlag
-                          key={item.id}
-                          name={item.featureFlag}
-                          equals={item.featureFlagValue}
-                        >
-                          {navItemElement}
-                        </FeatureFlag>
-                      )
-                    }
-
-                    // TODO(ariel): sort this out for the operator to render for operators and not to render for non operators
-
-                    if (
-                      item.featureFlag &&
-                      item.featureFlag !== 'unityOperator'
-                    ) {
-                      navSubItemElement = (
-                        <FeatureFlag
-                          key={menuItem.id}
-                          name={menuItem.featureFlag}
-                          equals={menuItem.featureFlagValue}
-                        >
-                          {navSubItemElement}
-                        </FeatureFlag>
-                      )
-                    }
-
-                    return navSubItemElement
-                  })}
-                </TreeNav.SubMenu>
-              )}
-            </TreeNav.Item>
-          )
-
-          if (item.cloudExclude) {
-            navItemElement = (
-              <CloudExclude key={item.id}>{navItemElement}</CloudExclude>
+                      return navSubItemElement
+                    })}
+                  </TreeNav.SubMenu>
+                )}
+              </TreeNav.Item>
             )
-          }
 
-          if (item.cloudOnly) {
-            navItemElement = (
-              <CloudOnly key={item.id}>{navItemElement}</CloudOnly>
-            )
-          }
+            if (item.cloudExclude) {
+              navItemElement = (
+                <CloudExclude key={item.id}>{navItemElement}</CloudExclude>
+              )
+            }
 
-          if (CLOUD && item.featureFlag === 'unityOperator' && me?.isOperator) {
-            navItemElement = (
-              <FeatureFlag
-                key={item.id}
-                name={item.featureFlag}
-                equals={item.featureFlagValue}
-              >
-                {navItemElement}
-              </FeatureFlag>
-            )
-          }
+            if (item.cloudOnly) {
+              navItemElement = (
+                <CloudOnly key={item.id}>{navItemElement}</CloudOnly>
+              )
+            }
 
-          if (item.featureFlag && item.featureFlag !== 'unityOperator') {
-            navItemElement = (
-              <FeatureFlag
-                key={item.id}
-                name={item.featureFlag}
-                equals={item.featureFlagValue}
-              >
-                {navItemElement}
-              </FeatureFlag>
-            )
-          }
+            if (
+              CLOUD &&
+              item.featureFlag === 'unityOperator' &&
+              me?.isOperator
+            ) {
+              navItemElement = (
+                <FeatureFlag
+                  key={item.id}
+                  name={item.featureFlag}
+                  equals={item.featureFlagValue}
+                >
+                  {navItemElement}
+                </FeatureFlag>
+              )
+            }
 
-          return navItemElement
-        })}
+            if (item.featureFlag && item.featureFlag !== 'unityOperator') {
+              navItemElement = (
+                <FeatureFlag
+                  key={item.id}
+                  name={item.featureFlag}
+                  equals={item.featureFlagValue}
+                >
+                  {navItemElement}
+                </FeatureFlag>
+              )
+            }
+
+            return navItemElement
+          })}
       </TreeNav>
     </OrgSettings>
   )

--- a/src/pageLayout/containers/TreeNav.tsx
+++ b/src/pageLayout/containers/TreeNav.tsx
@@ -8,24 +8,21 @@ import {Icon, TreeNav} from '@influxdata/clockface'
 import UserWidget from 'src/pageLayout/components/UserWidget'
 import NavHeader from 'src/pageLayout/components/NavHeader'
 import CloudUpgradeNavBanner from 'src/shared/components/CloudUpgradeNavBanner'
-import CloudExclude from 'src/shared/components/cloud/CloudExclude'
-import CloudOnly from 'src/shared/components/cloud/CloudOnly'
 import OrgSettings from 'src/cloud/components/OrgSettings'
-import {FeatureFlag} from 'src/shared/utils/featureFlag'
 
 // Constants
 import {generateNavItems} from 'src/pageLayout/constants/navigationHierarchy'
-import {CLOUD} from 'src/shared/constants'
 
 // Utils
 import {getNavItemActivation} from 'src/pageLayout/utils'
 import {getOrg} from 'src/organizations/selectors'
 import {AppSettingContext} from 'src/shared/contexts/app'
-import {getQuartzMe} from 'src/me/selectors'
+
+// Types
+import {NavItem, NavSubItem} from 'src/pageLayout/constants/navigationHierarchy'
 
 const TreeSidebar: FC = () => {
   const org = useSelector(getOrg)
-  const me = useSelector(getQuartzMe)
   const {presentationMode, navbarMode, setNavbarMode} = useContext(
     AppSettingContext
   )
@@ -51,131 +48,50 @@ const TreeSidebar: FC = () => {
         onToggleClick={handleToggleNavExpansion}
         bannerElement={<CloudUpgradeNavBanner />}
       >
-        {generateNavItems(org.id)
-          .filter(item => {
-            if (item.id === 'operator') {
-              return CLOUD && me?.isOperator === true
-            }
-            return true
-          })
-          .map(item => {
-            const linkElement = (className: string): JSX.Element => {
-              if (item.link.type === 'href') {
-                return <a href={item.link.location} className={className} />
-              }
+        {generateNavItems().map((item: NavItem) => {
+          const linkElement = (className: string): JSX.Element => (
+            <Link to={item.link} className={className} />
+          )
+          return (
+            <TreeNav.Item
+              key={item.id}
+              id={item.id}
+              testID={item.testID}
+              icon={<Icon glyph={item.icon} />}
+              label={item.label}
+              shortLabel={item.shortLabel}
+              active={getNavItemActivation(
+                item.activeKeywords,
+                location.pathname
+              )}
+              linkElement={linkElement}
+            >
+              {Boolean(item.menu) && (
+                <TreeNav.SubMenu>
+                  {item.menu.map((menuItem: NavSubItem) => {
+                    const linkElement = (className: string): JSX.Element => (
+                      <Link to={menuItem.link} className={className} />
+                    )
 
-              return <Link to={item.link.location} className={className} />
-            }
-            let navItemElement = (
-              <TreeNav.Item
-                key={item.id}
-                id={item.id}
-                testID={item.testID}
-                icon={<Icon glyph={item.icon} />}
-                label={item.label}
-                shortLabel={item.shortLabel}
-                active={getNavItemActivation(
-                  item.activeKeywords,
-                  location.pathname
-                )}
-                linkElement={linkElement}
-              >
-                {Boolean(item.menu) && (
-                  <TreeNav.SubMenu>
-                    {item.menu.map(menuItem => {
-                      const linkElement = (className: string): JSX.Element => {
-                        if (menuItem.link.type === 'href') {
-                          return (
-                            <a
-                              href={menuItem.link.location}
-                              className={className}
-                            />
-                          )
-                        }
-
-                        return (
-                          <Link
-                            to={menuItem.link.location}
-                            className={className}
-                          />
-                        )
-                      }
-
-                      let navSubItemElement = (
-                        <TreeNav.SubItem
-                          key={menuItem.id}
-                          id={menuItem.id}
-                          testID={menuItem.testID}
-                          active={getNavItemActivation(
-                            [menuItem.id],
-                            location.pathname
-                          )}
-                          label={menuItem.label}
-                          linkElement={linkElement}
-                        />
-                      )
-
-                      if (menuItem.cloudExclude) {
-                        navSubItemElement = (
-                          <CloudExclude key={menuItem.id}>
-                            {navSubItemElement}
-                          </CloudExclude>
-                        )
-                      }
-
-                      if (menuItem.cloudOnly) {
-                        navSubItemElement = (
-                          <CloudOnly key={menuItem.id}>
-                            {navSubItemElement}
-                          </CloudOnly>
-                        )
-                      }
-
-                      if (item.featureFlag) {
-                        navItemElement = (
-                          <FeatureFlag
-                            key={item.id}
-                            name={item.featureFlag}
-                            equals={item.featureFlagValue}
-                          >
-                            {navItemElement}
-                          </FeatureFlag>
-                        )
-                      }
-
-                      return navSubItemElement
-                    })}
-                  </TreeNav.SubMenu>
-                )}
-              </TreeNav.Item>
-            )
-
-            if (item.cloudExclude) {
-              navItemElement = (
-                <CloudExclude key={item.id}>{navItemElement}</CloudExclude>
-              )
-            }
-
-            if (item.cloudOnly) {
-              navItemElement = (
-                <CloudOnly key={item.id}>{navItemElement}</CloudOnly>
-              )
-            }
-
-            if (item.featureFlag) {
-              navItemElement = (
-                <FeatureFlag
-                  key={item.id}
-                  name={item.featureFlag}
-                  equals={item.featureFlagValue}
-                >
-                  {navItemElement}
-                </FeatureFlag>
-              )
-            }
-
-            return navItemElement
-          })}
+                    return (
+                      <TreeNav.SubItem
+                        key={menuItem.id}
+                        id={menuItem.id}
+                        testID={menuItem.testID}
+                        active={getNavItemActivation(
+                          [menuItem.id],
+                          location.pathname
+                        )}
+                        label={menuItem.label}
+                        linkElement={linkElement}
+                      />
+                    )
+                  })}
+                </TreeNav.SubMenu>
+              )}
+            </TreeNav.Item>
+          )
+        })}
       </TreeNav>
     </OrgSettings>
   )

--- a/src/pageLayout/containers/TreeNav.tsx
+++ b/src/pageLayout/containers/TreeNav.tsx
@@ -54,7 +54,7 @@ const TreeSidebar: FC = () => {
         {generateNavItems(org.id)
           .filter(item => {
             if (item.id === 'operator') {
-              return CLOUD && me?.isOperator
+              return CLOUD && me?.isOperator === true
             }
             return true
           })

--- a/src/pageLayout/containers/TreeNav.tsx
+++ b/src/pageLayout/containers/TreeNav.tsx
@@ -162,23 +162,7 @@ const TreeSidebar: FC = () => {
               )
             }
 
-            if (
-              CLOUD &&
-              item.featureFlag === 'unityOperator' &&
-              me?.isOperator
-            ) {
-              navItemElement = (
-                <FeatureFlag
-                  key={item.id}
-                  name={item.featureFlag}
-                  equals={item.featureFlagValue}
-                >
-                  {navItemElement}
-                </FeatureFlag>
-              )
-            }
-
-            if (item.featureFlag && item.featureFlag !== 'unityOperator') {
+            if (item.featureFlag) {
               navItemElement = (
                 <FeatureFlag
                   key={item.id}

--- a/src/usage/UsagePage.tsx
+++ b/src/usage/UsagePage.tsx
@@ -8,9 +8,12 @@ import RateLimitAlert from 'src/cloud/components/RateLimitAlert'
 import LimitChecker from 'src/cloud/components/LimitChecker'
 import UsageProvider from 'src/usage/context/usage'
 
+// Utils
+import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
+
 const Usage: FC = () => (
   <UsageProvider>
-    <Page titleTag="Usage">
+    <Page titleTag={pageTitleSuffixer(['Usage'])}>
       <Page.Header fullWidth={false} testID="usage-page--header">
         <Page.Title title="Usage" />
         <LimitChecker>

--- a/src/users/components/UserListContainer.tsx
+++ b/src/users/components/UserListContainer.tsx
@@ -2,19 +2,21 @@
 import React, {FC} from 'react'
 import {useParams} from 'react-router'
 import {Link} from 'react-router-dom'
-
 import {Page, Tabs, Orientation, ComponentSize} from '@influxdata/clockface'
 
 // Components
-import UserList from './UserList'
-import UserListInviteForm from './UserListInviteForm'
+import UserList from 'src/users/components/UserList'
+import UserListInviteForm from 'src/users/components/UserListInviteForm'
 import RateLimitAlert from 'src/cloud/components/RateLimitAlert'
+
+// Utils
+import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 
 const UserListContainer: FC = () => {
   const {orgID} = useParams<{orgID: string}>()
 
   return (
-    <Page titleTag="Users">
+    <Page titleTag={pageTitleSuffixer(['Users', 'Organization'])}>
       <Page.Header fullWidth={true} testID="users-page--header">
         <Page.Title title="Organization" />
         <RateLimitAlert />


### PR DESCRIPTION
This PR updates the unifications pages to standardize the page titles based on the current UI conventions of adding a pageTitleSuffixer. It also adds a filter to the TreeNav prior to mapping out the results so that we can filter out the operator link for all users that are not operators