### PR TITLE
chore: upgrades immer to 9.0.3 (latest)

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "history": "^4.7.2",
     "honeybadger-js": "^1.0.2",
     "html-to-react": "1.3.4",
-    "immer": "8.0.1",
+    "immer": "^9.0.3",
     "immutable": "^3.8.1",
     "intersection-observer": "^0.7.0",
     "jsonlint-mod": "^1.7.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5482,10 +5482,10 @@ ignore@^5.1.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
-immer@8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.1.tgz#9c73db683e2b3975c424fb0572af5889877ae656"
-  integrity sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==
+immer@^9.0.3:
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.3.tgz#146e2ba8b84d4b1b15378143c2345559915097f4"
+  integrity sha512-mONgeNSMuyjIe0lkQPa9YhdmTv8P19IeHV0biYhcXhbd5dhdB9HSK93zBpyKjp6wersSUgT5QyU0skmejUVP2A==
 
 immutable@^3.8.1:
   version "3.8.2"


### PR DESCRIPTION
The final step on the journey of upgrading immer. This PR bumps it to 9.0.3 which is the latest version.
