### PR TITLE
fix: Notebook maps error

### DIFF
--- a/src/visualization/types/Map/view.tsx
+++ b/src/visualization/types/Map/view.tsx
@@ -28,9 +28,6 @@ type GeoCoordinates = {
 const GeoPlot: FC<Props> = ({result, properties}) => {
   const {layers, zoom, allowPanAndZoom, mapStyle} = properties
   const {lat, lon} = properties.center
-  const tooltipColumns = _.isEmpty(properties.layers[0].tooltipColumns)
-    ? result.fluxGroupKeyUnion
-    : properties.layers[0].tooltipColumns
 
   const [mapServiceError, setMapServiceError] = useState<RemoteDataState>(
     RemoteDataState.NotStarted
@@ -117,6 +114,7 @@ const GeoPlot: FC<Props> = ({result, properties}) => {
     tileServerUrl: getMapboxUrl(),
     bingKey: '',
   }
+
   let layersOpts = layers
   if (!layers.length) {
     layersOpts = [
@@ -126,16 +124,23 @@ const GeoPlot: FC<Props> = ({result, properties}) => {
         colorField: '_value',
         colors: DEFAULT_THRESHOLDS_GEO_COLORS,
         isClustered: false,
-        tooltipColumns: tooltipColumns,
+        tooltipColumns: [],
       },
     ]
+    properties.layers = layersOpts
   }
 
+  const tooltipColumns = _.isEmpty(properties.layers[0].tooltipColumns)
+    ? result.fluxGroupKeyUnion
+    : properties.layers[0].tooltipColumns
+
+  const colorChoice = _.isEmpty(properties.layers[0].colors)
+    ? DEFAULT_THRESHOLDS_GEO_COLORS
+    : properties.layers[0].colors
+
+  // auto assign these variables
   layersOpts[0].tooltipColumns = tooltipColumns
-
-  if (!layers[0].colors[0].id) {
-    layersOpts[0].colors = DEFAULT_THRESHOLDS_GEO_COLORS
-  }
+  layersOpts[0].colors = colorChoice
 
   let zoomOpt = zoom
   if (zoom === 0) {
@@ -159,6 +164,8 @@ const GeoPlot: FC<Props> = ({result, properties}) => {
       },
     ],
   }
+
+  console.log(config)
   return <Plot config={config} />
 }
 

--- a/src/visualization/types/Map/view.tsx
+++ b/src/visualization/types/Map/view.tsx
@@ -131,7 +131,7 @@ const GeoPlot: FC<Props> = ({result, properties}) => {
 
   const tooltipColumns = _.isEmpty(layersOpts[0].tooltipColumns)
     ? result.fluxGroupKeyUnion
-    :layersOpts[0].tooltipColumns
+    : layersOpts[0].tooltipColumns
 
   const colorChoice = _.isEmpty(layersOpts[0].colors)
     ? DEFAULT_THRESHOLDS_GEO_COLORS

--- a/src/visualization/types/Map/view.tsx
+++ b/src/visualization/types/Map/view.tsx
@@ -165,7 +165,6 @@ const GeoPlot: FC<Props> = ({result, properties}) => {
     ],
   }
 
-  console.log(config)
   return <Plot config={config} />
 }
 

--- a/src/visualization/types/Map/view.tsx
+++ b/src/visualization/types/Map/view.tsx
@@ -122,21 +122,20 @@ const GeoPlot: FC<Props> = ({result, properties}) => {
         type: 'pointMap',
         colorDimension: {label: 'Value'},
         colorField: '_value',
-        colors: DEFAULT_THRESHOLDS_GEO_COLORS,
+        colors: [],
         isClustered: false,
         tooltipColumns: [],
       },
     ]
-    properties.layers = layersOpts
   }
 
-  const tooltipColumns = _.isEmpty(properties.layers[0].tooltipColumns)
+  const tooltipColumns = _.isEmpty(layersOpts[0].tooltipColumns)
     ? result.fluxGroupKeyUnion
-    : properties.layers[0].tooltipColumns
+    :layersOpts[0].tooltipColumns
 
-  const colorChoice = _.isEmpty(properties.layers[0].colors)
+  const colorChoice = _.isEmpty(layersOpts[0].colors)
     ? DEFAULT_THRESHOLDS_GEO_COLORS
-    : properties.layers[0].colors
+    : layersOpts[0].colors
 
   // auto assign these variables
   layersOpts[0].tooltipColumns = tooltipColumns


### PR DESCRIPTION
Closes #1615 

<!-- Describe your proposed changes here. -->
Okay so this fixes the color issue by auto assigning the color similar to our logic for the tooltipColumns and this has layer opts be above all code calling for layer properties. I was finding that the code was crashing because it was look for layer.properties.blah and finding nothing. So i moved all the code underneath and i set layerOpts = layers, which was missing so things were still crashing when they checked the properties. 