### PR TITLE
feat: only show range annotation information when the feature flag is on

### DIFF
--- a/src/annotations/components/annotationForm/AnnotationForm.tsx
+++ b/src/annotations/components/annotationForm/AnnotationForm.tsx
@@ -5,6 +5,7 @@ import {useDispatch} from 'react-redux'
 // Utils
 import {event} from 'src/cloud/utils/reporting'
 import classnames from 'classnames'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Components
 import {
@@ -33,11 +34,6 @@ import {ANNOTATION_FORM_WIDTH} from 'src/annotations/constants'
 
 // Style
 import 'src/annotations/components/annotationForm/annotationForm.scss'
-
-interface Annotation {
-  message: string
-  startTime: number | string
-}
 
 type AnnotationType = 'point' | 'range'
 
@@ -159,6 +155,36 @@ export const AnnotationForm: FC<Props> = (props: Props) => {
 
   const buttonClasses = classnames({'edit-annotation-buttons': isEditing})
 
+  const annoTypePicker = (
+    <React.Fragment>
+      <Form.Label label="Type" />
+      <SelectGroup
+        size={ComponentSize.Small}
+        style={{marginBottom: 8}}
+        color={ComponentColor.Default}
+      >
+        <SelectGroup.Option
+          onClick={changeToPointType}
+          active={'point' === annotationType}
+          id="annotation-form-point-type"
+          testID="annotation-form-point-type-option"
+          value="point"
+        >
+          Point
+        </SelectGroup.Option>
+        <SelectGroup.Option
+          onClick={changeToRangeType}
+          value="range"
+          active={'range' === annotationType}
+          id="annotation-form-range-type"
+          testID="annotation-form-range-type-option"
+        >
+          Range
+        </SelectGroup.Option>
+      </SelectGroup>
+    </React.Fragment>
+  )
+
   return (
     <Overlay.Container maxWidth={ANNOTATION_FORM_WIDTH}>
       <Overlay.Header
@@ -168,31 +194,7 @@ export const AnnotationForm: FC<Props> = (props: Props) => {
       />
       <Form onSubmit={handleSubmit}>
         <Overlay.Body>
-          <Form.Label label="Type" />
-          <SelectGroup
-            size={ComponentSize.Small}
-            style={{marginBottom: 8}}
-            color={ComponentColor.Default}
-          >
-            <SelectGroup.Option
-              onClick={changeToPointType}
-              active={'point' === annotationType}
-              id="annotation-form-point-type"
-              testID="annotation-form-point-type-option"
-              value="point"
-            >
-              Point
-            </SelectGroup.Option>
-            <SelectGroup.Option
-              onClick={changeToRangeType}
-              value="range"
-              active={'range' === annotationType}
-              id="annotation-form-range-type"
-              testID="annotation-form-range-type-option"
-            >
-              Range
-            </SelectGroup.Option>
-          </SelectGroup>
+          {isFlagEnabled('rangeAnnotations') && annoTypePicker}
           <div className="annotation-type-option-line">
             <AnnotationTimeInput
               onChange={updateStartTime}

--- a/src/annotations/components/annotationForm/AnnotationForm.tsx
+++ b/src/annotations/components/annotationForm/AnnotationForm.tsx
@@ -65,6 +65,22 @@ export const AnnotationForm: FC<Props> = (props: Props) => {
     // they are strings, so the simple compare is non-trivial.
     // plus, the backend checks if the startTime is before or equals the endTime
     // so, letting the backend do that check for now.
+
+    //an actual time check:
+    /**
+     * if point annotation, do nothing
+     *
+     * if range:
+     * a) make sure times are not the same; if so; tell the user!
+     * (times are the same, so you are creating a point and not a range annotation.  please adjust the times and try again, else
+     * change the type to a point annotation)
+     *
+     * b) convert them to numbers (if not already)
+     *     -> make sure that 'end' is after 'start'
+     *         --> if not, tell the user:  'stopTime is not after start time.  please adjust the times accordingly and try again'
+     *         TODO:  look up/adjust actual error messages
+     * */
+
     if (annotationType === 'range') {
       return Boolean(isValidPointAnnotation && endTime)
     }

--- a/src/annotations/components/annotationForm/AnnotationForm.tsx
+++ b/src/annotations/components/annotationForm/AnnotationForm.tsx
@@ -65,22 +65,6 @@ export const AnnotationForm: FC<Props> = (props: Props) => {
     // they are strings, so the simple compare is non-trivial.
     // plus, the backend checks if the startTime is before or equals the endTime
     // so, letting the backend do that check for now.
-
-    //an actual time check:
-    /**
-     * if point annotation, do nothing
-     *
-     * if range:
-     * a) make sure times are not the same; if so; tell the user!
-     * (times are the same, so you are creating a point and not a range annotation.  please adjust the times and try again, else
-     * change the type to a point annotation)
-     *
-     * b) convert them to numbers (if not already)
-     *     -> make sure that 'end' is after 'start'
-     *         --> if not, tell the user:  'stopTime is not after start time.  please adjust the times accordingly and try again'
-     *         TODO:  look up/adjust actual error messages
-     * */
-
     if (annotationType === 'range') {
       return Boolean(isValidPointAnnotation && endTime)
     }

--- a/src/annotations/components/controlBar/AnnotationsControlBar.tsx
+++ b/src/annotations/components/controlBar/AnnotationsControlBar.tsx
@@ -16,7 +16,6 @@ export const AnnotationsControlBar: FC = () => {
 
   const infoText1 = `Shift + click on a graph to create a point annotation${rangeText}.`
 
-
   const infoText2 =
     'Press the annotations button again to turn off annotation mode'
 

--- a/src/annotations/components/controlBar/AnnotationsControlBar.tsx
+++ b/src/annotations/components/controlBar/AnnotationsControlBar.tsx
@@ -2,11 +2,7 @@
 import React, {FC} from 'react'
 
 // Components
-import {
-  ComponentSize,
-  InfluxColors,
-  TextBlock,
-} from '@influxdata/clockface'
+import {ComponentSize, InfluxColors, TextBlock} from '@influxdata/clockface'
 
 import {useSelector} from 'react-redux'
 import {isAnnotationsModeEnabled} from 'src/annotations/selectors'

--- a/src/annotations/components/controlBar/AnnotationsControlBar.tsx
+++ b/src/annotations/components/controlBar/AnnotationsControlBar.tsx
@@ -4,19 +4,21 @@ import React, {FC} from 'react'
 // Components
 import {
   ComponentSize,
-  FlexBox,
-  FlexBoxChild,
   InfluxColors,
-  JustifyContent,
   TextBlock,
 } from '@influxdata/clockface'
 
 import {useSelector} from 'react-redux'
 import {isAnnotationsModeEnabled} from 'src/annotations/selectors'
+import Toolbar from 'src/shared/components/toolbar/Toolbar'
+import {isFlagEnabled} from '../../../shared/utils/featureFlag'
 
 export const AnnotationsControlBar: FC = () => {
-  const infoText1 =
-    'Click on a graph to create a point annotation, click + shift + drag to create a range annotation.'
+  const rangeText = isFlagEnabled('rangeAnnotations')
+    ? ', click + shift + drag to create a range annotation'
+    : ''
+
+  const infoText1 = `Shift + click on a graph to create a point annotation${rangeText}.`
 
   const infoText2 =
     'Press the annotations button again to turn off annotation mode'
@@ -29,25 +31,23 @@ export const AnnotationsControlBar: FC = () => {
   // make both textblocks have 'inline' style to get them on the same line; else there is a line break.
   // using two elements to put space between them.
   return (
-    <FlexBox
+    <Toolbar
       testID="annotations-control-bar"
-      justifyContent={JustifyContent.FlexStart}
       margin={ComponentSize.Large}
+      style={{justifyContent: 'center', padding: '0 32px', width: '100%'}}
     >
-      <FlexBoxChild grow={0}>
-        <TextBlock
-          backgroundColor={InfluxColors.Obsidian}
-          textColor={InfluxColors.Mist}
-          text={infoText1}
-          style={{display: 'inline'}}
-        />
-        <TextBlock
-          backgroundColor={InfluxColors.Obsidian}
-          textColor={InfluxColors.Mist}
-          text={infoText2}
-          style={{display: 'inline'}}
-        />
-      </FlexBoxChild>
-    </FlexBox>
+      <TextBlock
+        backgroundColor={InfluxColors.Obsidian}
+        textColor={InfluxColors.Mist}
+        text={infoText1}
+        style={{marginRight: 8, paddingRight: 0}}
+      />
+      <TextBlock
+        backgroundColor={InfluxColors.Obsidian}
+        textColor={InfluxColors.Mist}
+        text={infoText2}
+        style={{paddingLeft: 0}}
+      />
+    </Toolbar>
   )
 }


### PR DESCRIPTION
Closes #1750 

*  hides the range/point toggle when range annotations are off
*  hides the informational text on the annotations bar when range annotations are off
*  adding e2e tests to test this.
