### PR TITLE
feat: send org id parameter for annotations requests to support OSS multi-org

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "generate": "export SHA=f4424fc69ad29e31110d711310df644a57fee314 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-meta": "if [ -z \"${CLOUD_URL}\" ]; then yarn generate-meta-oss; else yarn generate-meta-cloud; fi",
-    "generate-meta-oss": "yarn oss-api && yarn notebooks && yarn unity && yarn flows && yarn managedFunctions && yarn annotations",
+    "generate-meta-oss": "yarn oss-api && yarn notebooks && yarn unity && yarn flows && yarn managedFunctions && yarn annotations-oss",
     "generate-meta-cloud": "yarn cloud-api && yarn notebooks && yarn unity && yarn flows && yarn managedFunctions && yarn annotations",
     "oss": "oats ${REMOTE}contracts/oss-diff.yml > ./src/client/ossRoutes.ts",
     "cloud": "oats ${REMOTE}contracts/cloud-diff.yml > ./src/client/cloudRoutes.ts",
@@ -65,6 +65,7 @@
     "flows": "oats ${REMOTE}contracts/priv/flowd.yml > ./src/client/flowsRoutes.ts",
     "notebooks": "oats ${REMOTE}contracts/priv/notebooksd.yml > ./src/client/notebooksRoutes.ts",
     "annotations": "oats ${REMOTE}contracts/priv/annotationd.yml > ./src/client/annotationdRoutes.ts",
+    "annotations-oss": "oats ${REMOTE}contracts/priv/annotationd-oss.yml > ./src/client/annotationdRoutes.ts",
     "mapsd": "oats ${REMOTE}contracts/mapsd.yml > ./src/client/mapsdRoutes.ts",
     "managedFunctions": "oats ${REMOTE}contracts/managed-functions.yml > ./src/client/managedFunctionsRoutes.ts"
   },

--- a/src/annotations/actions/thunks.ts
+++ b/src/annotations/actions/thunks.ts
@@ -14,7 +14,15 @@ import {
   deleteAnnotation as deleteAnnotationAction,
 } from 'src/annotations/actions/creators'
 
-import {Annotation, AnnotationStream, NotificationAction} from 'src/types'
+import {
+  Annotation,
+  AnnotationStream,
+  NotificationAction,
+  GetState,
+} from 'src/types'
+
+// Selectors
+import {getOrg} from 'src/organizations/selectors'
 
 export const fetchAndSetAnnotationStreams = async (
   dispatch: Dispatch<AnnotationAction>
@@ -25,9 +33,11 @@ export const fetchAndSetAnnotationStreams = async (
 }
 
 export const fetchAndSetAnnotations = () => async (
-  dispatch: Dispatch<AnnotationAction>
+  dispatch: Dispatch<AnnotationAction>,
+  getState: GetState
 ): Promise<void> => {
-  const annotations = await getAnnotations()
+  const org = getOrg(getState())
+  const annotations = await getAnnotations(org.id)
 
   dispatch(setAnnotations(annotations))
 }
@@ -35,11 +45,13 @@ export const fetchAndSetAnnotations = () => async (
 export const writeThenFetchAndSetAnnotations = (
   annotations: Annotation[]
 ) => async (
-  dispatch: Dispatch<AnnotationAction | NotificationAction>
+  dispatch: Dispatch<AnnotationAction | NotificationAction>,
+  getState: GetState
 ): Promise<void> => {
-  await writeAnnotation(annotations)
+  const org = getOrg(getState())
+  await writeAnnotation(annotations, org.id)
 
-  fetchAndSetAnnotations()(dispatch)
+  fetchAndSetAnnotations()(dispatch, getState)
 }
 
 export const deleteAnnotations = annotation => async (

--- a/src/annotations/api/index.ts
+++ b/src/annotations/api/index.ts
@@ -12,7 +12,6 @@ import {
   postAnnotation,
   putAnnotation,
   AnnotationEvent,
-  GetAnnotationsParams,
 } from 'src/client/annotationdRoutes'
 
 // Utils
@@ -23,7 +22,8 @@ export const getAnnotationStreams = (): Promise<AnnotationStream[]> => {
 }
 
 export const writeAnnotation = async (
-  annotations: Annotation[]
+  annotations: Annotation[],
+  orgID: string
 ): Promise<Annotation[]> => {
   // RFC 3339 is the standard serialization format for dates across the wire for annotations
   const annotationsRequestConverted = annotations.map(annotation => {
@@ -33,7 +33,7 @@ export const writeAnnotation = async (
       endTime: new Date(annotation.endTime).toISOString(),
     }
   })
-  const params = {data: annotationsRequestConverted}
+  const params = {data: annotationsRequestConverted, query: {orgID}}
   const res = await postAnnotation(params)
 
   if (res.status >= 300) {
@@ -55,10 +55,11 @@ export const writeAnnotation = async (
 }
 
 export const getAnnotations = async (
+  orgID: string,
   stream?: string
 ): Promise<AnnotationResponse[]> => {
-  const params: GetAnnotationsParams = {
-    query: {AnnotationListFilter: formatAnnotationQueryString({stream})},
+  const params = {
+    query: {AnnotationListFilter: formatAnnotationQueryString({stream}), orgID},
   }
   const res = await getAnnotationsApi(params)
   if (res.status >= 300) {


### PR DESCRIPTION
Closes #1645

Also see https://github.com/influxdata/openapi/pull/135

This PR will pull in the API definition for the OSS annotations API, which requires an org ID parameter for certain requests where required due to the multi-org-per-user behavior of OSS. The `openapi` SHA will be updated to the commit which added this API definition.

The actual requests which use these endpoints in the UI are being updated to send the org ID parameter where needed as well. The org ID parameter is not required for cloud and sending it should not have any impact on those requests since the annotations service for cloud derives the org ID for the token. This is a similar approach as was taken for Notebooks on OSS, see: https://github.com/influxdata/ui/pull/1390

An alternative for sending the org ID parameter on requests to cloud where it is not needed would be to have some branching logic based on the `CLOUD` constant around where the request parameters are initialized to determine if the org ID should be included or not. This wouldn't be extremely complicated since there are _currently_ only a couple of places where it would be needed, but it might be more difficult to sustain. Happy to discuss this (and all aspects of this PR) further and open to considering other options!

