### PR TITLE
chore: setAutoFreeze(false)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,7 +48,7 @@ const App: FC = () => {
     if (CLOUD && isFlagEnabled('rudderstackReporting')) {
       load(RUDDERSTACK_WRITE_KEY, RUDDERSTACK_DATA_PLANE_URL)
     }
-    setAutoFreeze(process.env.NODE_ENV !== 'production')
+    setAutoFreeze(false)
   }, [RUDDERSTACK_WRITE_KEY, RUDDERSTACK_DATA_PLANE_URL])
 
   return (


### PR DESCRIPTION
Changes `setAutoFreeze(false)` to remove `immer` console errors when developing locally. We plan to fix these errors at a later time
