### PR TITLE
chore: ignore network errors during cypress tests

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -12,7 +12,8 @@ Cypress.on('uncaught:exception', (err, _) => {
   // we also can ignore AbortErrors for when network requests are terminated early.
   return !(
     err.message.includes('Request failed with status code 401') ||
-    err.message.includes('AbortError')
+    err.message.includes('AbortError') ||
+    err.message.includes('NetworkError')
   )
 })
 


### PR DESCRIPTION
I noticed some flakes where the tests fail during the beforeEach because ingress doesn't respond. And when the beforeEach fails, the entire test suite stops and is not retried. These failures are happening because of "NetworkErrors". This change makes it so that cypress ignores these errors and does not fail the tests immediately. 