### PR TITLE
fix: cypress abort error message

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -12,7 +12,7 @@ Cypress.on('uncaught:exception', (err, _) => {
   // we also can ignore AbortErrors for when network requests are terminated early.
   return !(
     err.message.includes('Request failed with status code 401') ||
-    err.message.includes('AbortError') ||
+    err.message.includes('The operation was aborted') ||
     err.message.includes('NetworkError')
   )
 })


### PR DESCRIPTION
Change the abort error message cypress is looking for.

Noticed that "AbortError" wasn't doing the trick. See [this pipeline](https://app.circleci.com/pipelines/github/influxdata/monitor-ci/2215/workflows/a1ec8753-f8b6-4271-8bbf-11548e066615/jobs/18921/tests#failed-test-0) as an example. The error message actually is "The operation was aborted". 