### PR TITLE
fix: usage page issue with mismatched data

### DIFF
--- a/src/usage/BillingStatsPanel.tsx
+++ b/src/usage/BillingStatsPanel.tsx
@@ -18,40 +18,6 @@ import {FromFluxResult} from '@influxdata/giraffe'
 // Types
 import {UsageVector, InternalFromFluxResult} from 'src/types'
 
-const graphInfo = [
-  {
-    title: 'Data In',
-    groupColumns: [],
-    column: 'writes_mb',
-    units: 'MB',
-    isGrouped: false,
-    type: 'stat',
-  },
-  {
-    title: 'Query Count',
-    groupColumns: [],
-    column: 'query_count',
-    units: '',
-    isGrouped: false,
-    type: 'stat',
-  },
-  {
-    title: 'Storage',
-    groupColumns: [],
-    column: 'storage_gb',
-    units: 'GB-hr',
-    isGrouped: false,
-    type: 'stat',
-  },
-  {
-    title: 'Data Out',
-    groupColumns: [],
-    column: 'reads_gb',
-    units: 'GB',
-    isGrouped: false,
-    type: 'stat',
-  },
-]
 const BillingStatsPanel: FC = () => {
   const {billingDateTime, billingStats, usageVectors} = useContext(UsageContext)
 
@@ -106,8 +72,6 @@ const BillingStatsPanel: FC = () => {
         className="billing-stats--graph-body"
       >
         {usageVectors?.map((vector: UsageVector) => {
-          // Find the matching graphInfo for the usage vector
-          const graph = graphInfo.find(g => g.column === vector.fluxKey)
           // Find the matching CSV for the usageVector
           const fromFluxResult = (billingStats?.find(
             (result: FromFluxResult) => {
@@ -128,7 +92,8 @@ const BillingStatsPanel: FC = () => {
           return (
             <GraphTypeSwitcher
               key={vector.fluxKey}
-              graphInfo={graph}
+              usageVector={vector}
+              type="stat"
               fromFluxResult={fromFluxResult}
               length={usageVectors.length}
             />

--- a/src/usage/GraphTypeSwitcher.tsx
+++ b/src/usage/GraphTypeSwitcher.tsx
@@ -15,11 +15,13 @@ import {
   RemoteDataState,
   XYViewProperties,
   InternalFromFluxResult,
+  UsageVector,
 } from 'src/types'
 
 interface OwnProps {
-  graphInfo: any
+  usageVector: UsageVector
   fromFluxResult: InternalFromFluxResult
+  type: 'xy' | 'stat'
   length?: number
 }
 
@@ -35,8 +37,9 @@ const GENERIC_PROPERTY_DEFAULTS = {
 }
 
 const GraphTypeSwitcher: FC<OwnProps> = ({
-  graphInfo,
+  usageVector,
   fromFluxResult,
+  type,
   length = 1,
 }) => {
   const timeRange = useSelector(getTimeRangeWithTimezone)
@@ -45,7 +48,7 @@ const GraphTypeSwitcher: FC<OwnProps> = ({
     ...GENERIC_PROPERTY_DEFAULTS,
     type: 'single-stat',
     shape: 'chronograf-v2',
-    suffix: ` ${graphInfo?.units ?? ''}`,
+    suffix: ` ${usageVector?.unit ?? ''}`,
     decimalPlaces: {isEnforced: false, digits: 0},
   }
 
@@ -58,10 +61,11 @@ const GraphTypeSwitcher: FC<OwnProps> = ({
       y: {},
     },
     position: 'overlaid',
+    yColumn: usageVector.fluxKey,
     geom: 'line',
   }
 
-  const isXy = graphInfo?.type === 'xy'
+  const isXy = type === 'xy'
 
   const error = fromFluxResult?.table?.columns?.error?.data?.[0]
 
@@ -72,7 +76,9 @@ const GraphTypeSwitcher: FC<OwnProps> = ({
       testID="graph-type--panel"
     >
       <Panel.Header size={ComponentSize.ExtraSmall}>
-        <h5>{graphInfo?.title}</h5>
+        <h5>{`${usageVector.name} ${
+          usageVector.unit !== '' ? `(${usageVector.unit})` : ''
+        }`}</h5>
       </Panel.Header>
       <Panel.Body
         className="panel-body--size"

--- a/src/usage/UsageToday.tsx
+++ b/src/usage/UsageToday.tsx
@@ -15,54 +15,6 @@ import UsageTimeRangeDropdown from 'src/usage/UsageTimeRangeDropdown'
 import GraphTypeSwitcher from 'src/usage/GraphTypeSwitcher'
 import {UsageContext} from 'src/usage/context/usage'
 
-const usageGraphInfo = [
-  {
-    title: 'Data In (MB)',
-    groupColumns: [],
-    column: 'write_mb',
-    units: 'MB',
-    isGrouped: true,
-    type: 'xy',
-    pricingVersions: [3, 4],
-  },
-  {
-    title: 'Query Count',
-    groupColumns: [],
-    column: 'query_count',
-    units: '',
-    isGrouped: false,
-    type: 'xy',
-    pricingVersions: [4],
-  },
-  {
-    title: 'Storage (GB-hr)',
-    groupColumns: [],
-    column: 'storage_gb',
-    units: 'GB',
-    isGrouped: false,
-    type: 'xy',
-    pricingVersions: [3, 4],
-  },
-  {
-    title: 'Data Out (GB)',
-    groupColumns: [],
-    column: 'reads_gb',
-    units: 'GB',
-    isGrouped: false,
-    type: 'xy',
-    pricingVersions: [4],
-  },
-]
-
-const rateLimitGraphInfo = {
-  title: 'Limit Events',
-  groupColumns: ['_field'],
-  column: '_value',
-  units: '',
-  isGrouped: true,
-  type: 'xy',
-}
-
 const UsageToday: FC = () => {
   const {
     handleSetTimeRange,
@@ -75,12 +27,13 @@ const UsageToday: FC = () => {
 
   const getUsageSparkline = () => {
     const usage = usageVectors.find(vector => selectedUsage === vector.name)
-    const graphInfo =
-      usageGraphInfo.find(stat => stat.column === usage?.fluxKey) ??
-      usageGraphInfo[0]
 
     return (
-      <GraphTypeSwitcher fromFluxResult={usageStats} graphInfo={graphInfo} />
+      <GraphTypeSwitcher
+        fromFluxResult={usageStats}
+        usageVector={usage}
+        type="xy"
+      />
     )
   }
 
@@ -119,8 +72,12 @@ const UsageToday: FC = () => {
         >
           <GraphTypeSwitcher
             fromFluxResult={rateLimits}
-            graphInfo={rateLimitGraphInfo}
-            key={rateLimitGraphInfo.title}
+            usageVector={{
+              name: 'Limit Events',
+              fluxKey: '_value',
+              unit: '',
+            }}
+            type="xy"
           />
         </Panel.Body>
       </Panel>


### PR DESCRIPTION
This resolves an issue with some customer reported usage page wonkiness where the data that was being mapped was the csv `_value` rather than the `fluxKey`. It also reconciles the source of truth for mapping column data based on the usage vectors that are being returned by the API and simplifies some of the logic surrounding all that.