### PR TITLE
feat: sso login

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "cy": "CYPRESS_dexUrl=https://$INGRESS_HOST:$PORT_HTTPS CYPRESS_baseUrl=http://localhost:9999 cypress open",
     "cy:dev": "source ../monitor-ci/.env && CYPRESS_dexUrl=https://$INGRESS_HOST:$PORT_HTTPS CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{cloud,shared}/**/*.*'",
     "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_dexUrl=OSS CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{oss,shared}/**/*.*'",
-    "generate": "export SHA=f4424fc69ad29e31110d711310df644a57fee314 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
+    "generate": "export SHA=dd6be1fe6c836a5fe3f979a9107f5b8b531d3a2e && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-meta": "if [ -z \"${CLOUD_URL}\" ]; then yarn generate-meta-oss; else yarn generate-meta-cloud; fi",
     "generate-meta-oss": "yarn oss-api && yarn notebooks && yarn unity && yarn flows && yarn managedFunctions && yarn annotations",

--- a/src/authorizations/apis/index.ts
+++ b/src/authorizations/apis/index.ts
@@ -40,7 +40,9 @@ export const getAuth0Config = async (
 
 export const getConnection = async (email: string): Promise<string | Error> => {
   // FIXME: When Quartz #4824 gets fixed. Change encodeURI to encodeURIComponent
-  const response = await getAuthConnection({query: {email: encodeURI(email)}})
+  const response = await getAuthConnection({
+    query: {email: encodeURIComponent(email)},
+  })
 
   if (response.status >= 500) {
     throw new Error(response.data)

--- a/src/authorizations/apis/index.ts
+++ b/src/authorizations/apis/index.ts
@@ -1,6 +1,7 @@
 import AJAX from 'src/utils/ajax'
 import {Authorization, Auth0Config} from 'src/types'
 import {getAPIBasepath} from 'src/utils/basepath'
+import {getAuthConnection} from 'src/client/unityRoutes'
 
 export const createAuthorization = async (
   authorization
@@ -27,13 +28,25 @@ export const getAuth0Config = async (
     if (redirectTo) {
       url = `${getAPIBasepath()}/api/v2private/oauth/clientConfig?redirectTo=${redirectTo}`
     }
-    console.log({url})
     const response = await fetch(url)
     const data = await response.json()
-    console.log({data})
+
     return data
   } catch (error) {
     console.error(error)
     throw error
+  }
+}
+
+export const getConnection = async (email: string): Promise<string> => {
+  // FIXME: When #4824 gets fixed. Change encodeURI to encodeURIComponent
+  const response = await getAuthConnection({query: {email: encodeURI(email)}})
+
+  if (response.status >= 500) {
+    throw new Error(response.data)
+  }
+
+  if (response.status === 200) {
+    return response.data
   }
 }

--- a/src/authorizations/apis/index.ts
+++ b/src/authorizations/apis/index.ts
@@ -27,8 +27,10 @@ export const getAuth0Config = async (
     if (redirectTo) {
       url = `${getAPIBasepath()}/api/v2private/oauth/clientConfig?redirectTo=${redirectTo}`
     }
+    console.log({url})
     const response = await fetch(url)
     const data = await response.json()
+    console.log({data})
     return data
   } catch (error) {
     console.error(error)

--- a/src/authorizations/apis/index.ts
+++ b/src/authorizations/apis/index.ts
@@ -38,8 +38,8 @@ export const getAuth0Config = async (
   }
 }
 
-export const getConnection = async (email: string): Promise<string> => {
-  // FIXME: When #4824 gets fixed. Change encodeURI to encodeURIComponent
+export const getConnection = async (email: string): Promise<string | Error> => {
+  // FIXME: When Quartz #4824 gets fixed. Change encodeURI to encodeURIComponent
   const response = await getAuthConnection({query: {email: encodeURI(email)}})
 
   if (response.status >= 500) {

--- a/src/authorizations/apis/index.ts
+++ b/src/authorizations/apis/index.ts
@@ -39,7 +39,6 @@ export const getAuth0Config = async (
 }
 
 export const getConnection = async (email: string): Promise<string | Error> => {
-  // FIXME: When Quartz #4824 gets fixed. Change encodeURI to encodeURIComponent
   const response = await getAuthConnection({
     query: {email: encodeURIComponent(email)},
   })

--- a/src/localStorage.ts
+++ b/src/localStorage.ts
@@ -31,7 +31,6 @@ export const loadLocalStorage = (): LocalStorage => {
 
 export const setToLocalStorage = (prop: string, value: any): void => {
   try {
-    console.log({prop, value})
     window.localStorage.setItem(prop, value)
   } catch (error) {
     console.error('unable to setItem onto localStorage: ', error)
@@ -40,7 +39,6 @@ export const setToLocalStorage = (prop: string, value: any): void => {
 
 export const getFromLocalStorage = (prop: string): any => {
   try {
-    console.log({prop})
     return window.localStorage.getItem(prop)
   } catch (error) {
     console.error('unable to getItem onto localStorage: ', error)

--- a/src/localStorage.ts
+++ b/src/localStorage.ts
@@ -31,6 +31,7 @@ export const loadLocalStorage = (): LocalStorage => {
 
 export const setToLocalStorage = (prop: string, value: any): void => {
   try {
+    console.log({prop, value})
     window.localStorage.setItem(prop, value)
   } catch (error) {
     console.error('unable to setItem onto localStorage: ', error)
@@ -39,6 +40,7 @@ export const setToLocalStorage = (prop: string, value: any): void => {
 
 export const getFromLocalStorage = (prop: string): any => {
   try {
+    console.log({prop})
     return window.localStorage.getItem(prop)
   } catch (error) {
     console.error('unable to getItem onto localStorage: ', error)

--- a/src/onboarding/containers/LoginPageContents.tsx
+++ b/src/onboarding/containers/LoginPageContents.tsx
@@ -161,10 +161,7 @@ class LoginPageContents extends PureComponent<Props> {
     const {email, password} = this.state
 
     const emailError = email === '' ? 'Email is required' : ''
-    const passwordError =
-      password === '' && !isFlagEnabled('ssoLogin')
-        ? 'Password is required'
-        : ''
+    const passwordError = password === '' ? 'Password is required' : ''
 
     const errors: ErrorObject = {
       emailError,
@@ -184,15 +181,8 @@ class LoginPageContents extends PureComponent<Props> {
   })
 
   private handleSubmit = async (event: FormEvent) => {
-    const {isValid, errors} = this.validateFieldValues
-    const {email, password} = this.state
-
     event.preventDefault()
-
-    if (!isValid) {
-      this.setState(errors)
-      return
-    }
+    const {email, password} = this.state
 
     if (isFlagEnabled('ssoLogin') && email) {
       try {
@@ -206,6 +196,13 @@ class LoginPageContents extends PureComponent<Props> {
         )}. If this issue persists, please contact support@influxdata.com`
         return this.setState({emailError})
       }
+    }
+
+    const {isValid, errors} = this.validateFieldValues
+
+    if (!isValid) {
+      this.setState(errors)
+      return
     }
 
     this.setState({buttonStatus: ComponentStatus.Loading})


### PR DESCRIPTION
Closes #

We need to be able to login using SSO when a participating domain's email is trying to login. There's a fixme which is depending on #4824. Added feature flag `ssoLogin` temporarily to test in tools as this functionality can't be tested locally because we use dex for auth locally and this change requires Auth0 to redirect us to a callback route.