### PR TITLE
fix: added guarding for async rendering of the usage dropdown data

### DIFF
--- a/src/usage/UsageToday.tsx
+++ b/src/usage/UsageToday.tsx
@@ -27,14 +27,25 @@ const UsageToday: FC = () => {
 
   const getUsageSparkline = () => {
     const usage = usageVectors.find(vector => selectedUsage === vector.name)
-
-    return (
-      <GraphTypeSwitcher
-        fromFluxResult={usageStats}
-        usageVector={usage}
-        type="xy"
-      />
-    )
+    if (usage) {
+      return (
+        <GraphTypeSwitcher
+          fromFluxResult={usageStats}
+          usageVector={usage}
+          type="xy"
+        />
+      )
+    }
+    if (usageVectors.length > 0) {
+      return (
+        <GraphTypeSwitcher
+          fromFluxResult={usageStats}
+          usageVector={usageVectors[0]}
+          type="xy"
+        />
+      )
+    }
+    return null
   }
 
   return (


### PR DESCRIPTION
this PR adds some checks prior to getting the usage data to render the dropdown since the code is async but isn't dependent upon the usageVectors for rendering. This caused the usage page to break so now we're adding to checks to ensure that something exists prior to rendering it. This is the only place that should be affected since it the other places that make use of the GraphTypeSwitcher are:

- Only being generated when the data is mapped (so it won't generated without any data)
- Has the usageVector hard-coded so there is not concern about async code