### PR TITLE
chore: increase timeout to 50min

### DIFF
--- a/scripts/run-monitor-ci-tests.bash
+++ b/scripts/run-monitor-ci-tests.bash
@@ -10,7 +10,7 @@ set -eu -o pipefail
 #
 # If the private CI fails, this script will collect the names and artifacts of the failed jobs and report them.
 # This script should support multiple workflows if more are added, although it has not been tested.
-# This script waits 40 minutes for the private CI to complete otherwise it fails.
+# This script waits 50 minutes for the private CI to complete otherwise it fails.
 #
 # **For Running from the UI Repository:**
 # If you want to retry failed jobs in the private CI, simply retry this job from the public CI.
@@ -193,7 +193,7 @@ fi
 # poll the status of the monitor-ci pipeline
 is_failure=0
 attempts=0
-max_attempts=40 # minutes
+max_attempts=50 # minutes
 required_workflows=( "build" )
 while [ $attempts -le $max_attempts ];
 do


### PR DESCRIPTION
Noticed a lot of pipelines hitting the timeout marker but the pipelines end up succeeding over in monitor-ci. Checked out the "Insights" page in CircleCI and it looks like there has been an increase in the average time it takes `cloud-e2e-k8s-idpe` to complete. This is probably because there are new pods & services being added to k8s-idpe. I would look into it more, but we're already planning to move to a remocal CI where we won't be standing up the cluster locally every time which will eliminate this issue.

So, for now, I'm increasing the timeout to 50min.

Slack convo: https://influxdata.slack.com/archives/CLHATC50E/p1624576883002000