### PR TITLE
chore: update visual design for view options of Hover Legend and Static Legend

### DIFF
--- a/src/visualization/components/internal/HoverLegend.tsx
+++ b/src/visualization/components/internal/HoverLegend.tsx
@@ -96,7 +96,7 @@ const HoverLegendToggle: FC<HoverLegendToggleProps> = ({
   }
 
   return (
-    <Form.Element label="Hover Legend" className="legend-options">
+    <Form.Element label="Display Hover Legend" className="legend-options">
       <Grid>
         <Grid.Row>
           <Grid.Column widthXS={Columns.Twelve}>

--- a/src/visualization/components/internal/StaticLegend.scss
+++ b/src/visualization/components/internal/StaticLegend.scss
@@ -1,9 +1,5 @@
 @import '@influxdata/clockface/dist/variables.scss';
 
-.static-legend-options {
-  margin-top: $cf-marg-c;
-}
-
 .latest-y-axis {
   margin-top: $cf-marg-c;
   margin-bottom: $cf-marg-b;
@@ -12,4 +8,10 @@
 .latest-x-axis,
 .static-legend-height-slider {
   margin-bottom: $cf-marg-c;
+}
+
+.static-legend-options--show {
+  .latest-axis-label {
+    color: $g11-sidewalk;
+  }
 }

--- a/src/visualization/components/internal/StaticLegend.scss
+++ b/src/visualization/components/internal/StaticLegend.scss
@@ -1,5 +1,11 @@
 @import '@influxdata/clockface/dist/variables.scss';
 
+.static-legend-options {
+  .latest-axis-label {
+    color: $g11-sidewalk;
+  }
+}
+
 .latest-y-axis {
   margin-top: $cf-marg-c;
   margin-bottom: $cf-marg-b;
@@ -8,10 +14,4 @@
 .latest-x-axis,
 .static-legend-height-slider {
   margin-bottom: $cf-marg-c;
-}
-
-.static-legend-options--show {
-  .latest-axis-label {
-    color: $g11-sidewalk;
-  }
 }

--- a/src/visualization/components/internal/StaticLegend.tsx
+++ b/src/visualization/components/internal/StaticLegend.tsx
@@ -182,7 +182,7 @@ const StaticLegend: FC<Props> = ({properties, update}) => {
 
   return (
     <Form.Element
-      label="Static Legend"
+      label="Display Static Legend"
       className="static-legend-options"
       testID="static-legend-options"
     >
@@ -219,6 +219,27 @@ const StaticLegend: FC<Props> = ({properties, update}) => {
               widthXS={Columns.Twelve}
               className="static-legend-options--show"
             >
+              <OrientationToggle
+                eventName={`${eventPrefix}.orientation`}
+                graphType={properties.type}
+                legendOrientation={orientationThreshold}
+                parentName="static-legend"
+                handleSetOrientation={handleSetOrientation}
+                testID="static-legend-orientation-toggle"
+              />
+              <OpacitySlider
+                legendOpacity={opacity}
+                handleSetOpacity={handleSetOpacity}
+                testID="static-legend-opacity-slider"
+              />
+              <ColorizeRowsToggle
+                legendColorizeRows={colorizeRows}
+                handleSetColorization={handleSetColorization}
+                testID="static-legend-colorize-rows-toggle"
+              />
+              <InputLabel className="latest-axis-label">
+                Displayed Value
+              </InputLabel>
               <Toggle
                 tabIndex={1}
                 value="y"
@@ -265,24 +286,6 @@ const StaticLegend: FC<Props> = ({properties, update}) => {
                   testID="static-legend-height-slider"
                 />
               </Form.Element>
-              <OrientationToggle
-                eventName={`${eventPrefix}.orientation`}
-                graphType={properties.type}
-                legendOrientation={orientationThreshold}
-                parentName="static-legend"
-                handleSetOrientation={handleSetOrientation}
-                testID="static-legend-orientation-toggle"
-              />
-              <OpacitySlider
-                legendOpacity={opacity}
-                handleSetOpacity={handleSetOpacity}
-                testID="static-legend-opacity-slider"
-              />
-              <ColorizeRowsToggle
-                legendColorizeRows={colorizeRows}
-                handleSetColorization={handleSetColorization}
-                testID="static-legend-colorize-rows-toggle"
-              />
             </Grid.Column>
           </Grid.Row>
         )}

--- a/src/visualization/types/Band/options.tsx
+++ b/src/visualization/types/Band/options.tsx
@@ -420,12 +420,13 @@ const BandViewOptions: FC<Props> = ({properties, results, update}) => {
           widthMD={Columns.Six}
           widthLG={Columns.Four}
         >
-          <h5 className="view-options--header">Legend</h5>
+          <h5 className="view-options--header">Hover Legend</h5>
           <HoverLegend
             properties={properties}
             results={results}
             update={update}
           />
+          <h5 className="view-options--header">Static Legend</h5>
           <StaticLegend
             properties={properties}
             results={results}

--- a/src/visualization/types/Graph/options.tsx
+++ b/src/visualization/types/Graph/options.tsx
@@ -399,12 +399,13 @@ const GraphViewOptions: FC<Props> = ({properties, results, update}) => {
           widthMD={Columns.Six}
           widthLG={Columns.Four}
         >
-          <h5 className="view-options--header">Legend</h5>
+          <h5 className="view-options--header">Hover Legend</h5>
           <HoverLegend
             properties={properties}
             results={results}
             update={update}
           />
+          <h5 className="view-options--header">Static Legend</h5>
           <StaticLegend
             properties={properties}
             results={results}

--- a/src/visualization/types/Heatmap/options.tsx
+++ b/src/visualization/types/Heatmap/options.tsx
@@ -246,7 +246,7 @@ const HeatmapOptions: FC<Props> = ({properties, results, update}) => {
           widthMD={Columns.Six}
           widthLG={Columns.Four}
         >
-          <h5 className="view-options--header">Legend</h5>
+          <h5 className="view-options--header">Hover Legend</h5>
           <HoverLegend
             properties={properties}
             results={results}

--- a/src/visualization/types/Histogram/options.tsx
+++ b/src/visualization/types/Histogram/options.tsx
@@ -225,7 +225,7 @@ const HistogramOptions: FC<Props> = ({properties, results, update}) => {
           widthMD={Columns.Six}
           widthLG={Columns.Four}
         >
-          <h5 className="view-options--header">Legend</h5>
+          <h5 className="view-options--header">Hover Legend</h5>
           <HoverLegend
             properties={properties}
             results={results}

--- a/src/visualization/types/Mosaic/options.tsx
+++ b/src/visualization/types/Mosaic/options.tsx
@@ -247,7 +247,7 @@ const MosaicOptions: FC<Props> = props => {
           widthMD={Columns.Six}
           widthLG={Columns.Four}
         >
-          <h5 className="view-options--header">Legend</h5>
+          <h5 className="view-options--header">Hover Legend</h5>
           <HoverLegend
             properties={properties}
             results={results}

--- a/src/visualization/types/Scatter/options.tsx
+++ b/src/visualization/types/Scatter/options.tsx
@@ -282,7 +282,7 @@ const ScatterOptions: FC<Props> = ({properties, results, update}) => {
           widthMD={Columns.Six}
           widthLG={Columns.Four}
         >
-          <h5 className="view-options--header">Legend</h5>
+          <h5 className="view-options--header">Hover Legend</h5>
           <HoverLegend
             properties={properties}
             results={results}

--- a/src/visualization/types/SingleStatWithLine/options.tsx
+++ b/src/visualization/types/SingleStatWithLine/options.tsx
@@ -501,12 +501,13 @@ const SingleStatWithLineOptions: FC<Props> = ({
           widthMD={Columns.Six}
           widthLG={Columns.Four}
         >
-          <h5 className="view-options--header">Legend</h5>
+          <h5 className="view-options--header">Hover Legend</h5>
           <HoverLegend
             properties={properties}
             results={results}
             update={update}
           />
+          <h5 className="view-options--header">Static Legend</h5>
           <StaticLegend
             properties={properties}
             results={results}


### PR DESCRIPTION
As part of #1773 

Make the view options clearer to distinguish between Hover Legend and Static Legend

<img width="1680" alt="Screen Shot 2021-06-25 at 1 59 51 PM" src="https://user-images.githubusercontent.com/10736577/123484845-e1dfae00-d5bd-11eb-975a-4572ef81cb30.png">

<img width="1680" alt="Screen Shot 2021-06-25 at 1 59 58 PM" src="https://user-images.githubusercontent.com/10736577/123484865-e7d58f00-d5bd-11eb-97fe-31da7d5d2460.png">

<img width="1680" alt="Screen Shot 2021-06-25 at 2 00 05 PM" src="https://user-images.githubusercontent.com/10736577/123484879-ec9a4300-d5bd-11eb-89d6-dad0ee037617.png">

