### PR TITLE
feat: write limit overlays

### DIFF
--- a/src/cloud/components/RateLimitAlert.tsx
+++ b/src/cloud/components/RateLimitAlert.tsx
@@ -29,7 +29,7 @@ import {CLOUD} from 'src/shared/constants'
 import {AppState} from 'src/types'
 import {LimitStatus} from 'src/cloud/actions/limits'
 import RateLimitAlertContent from 'src/cloud/components/RateLimitAlertContent'
-
+import WriteLimitAlertContent from 'src/cloud/components/WriteLimitAlertContent'
 interface StateProps {
   resources: string[]
   status: LimitStatus
@@ -50,28 +50,46 @@ const RateLimitAlert: FC<Props> = ({
     [`${className}`]: className,
   })
 
-  if (
-    CLOUD &&
-    status === LimitStatus.EXCEEDED &&
-    resources.includes('cardinality')
-  ) {
+  if (CLOUD && status === LimitStatus.EXCEEDED) {
     return (
-      <FlexBox
-        direction={FlexDirection.Column}
-        alignItems={AlignItems.Center}
-        margin={ComponentSize.Large}
-        className={rateLimitAlertClass}
-      >
-        <BannerPanel
-          size={ComponentSize.ExtraSmall}
-          gradient={Gradients.PolarExpress}
-          icon={IconFont.Cloud}
-          hideMobileIcon={true}
-          textColor={InfluxColors.Yeti}
-        >
-          <RateLimitAlertContent />
-        </BannerPanel>
-      </FlexBox>
+      <>
+        {resources.includes('cardinality') ? (
+          <FlexBox
+            direction={FlexDirection.Column}
+            alignItems={AlignItems.Center}
+            margin={ComponentSize.Large}
+            className={rateLimitAlertClass}
+          >
+            <BannerPanel
+              size={ComponentSize.ExtraSmall}
+              gradient={Gradients.PolarExpress}
+              icon={IconFont.Cloud}
+              hideMobileIcon={true}
+              textColor={InfluxColors.Yeti}
+            >
+              <RateLimitAlertContent />
+            </BannerPanel>
+          </FlexBox>
+        ) : null}
+        {resources.includes('write') ? (
+          <FlexBox
+            direction={FlexDirection.Column}
+            alignItems={AlignItems.Center}
+            margin={ComponentSize.Large}
+            className={rateLimitAlertClass}
+          >
+            <BannerPanel
+              size={ComponentSize.ExtraSmall}
+              gradient={Gradients.PolarExpress}
+              icon={IconFont.Cloud}
+              hideMobileIcon={true}
+              textColor={InfluxColors.Yeti}
+            >
+              <WriteLimitAlertContent />
+            </BannerPanel>
+          </FlexBox>
+        ) : null}
+      </>
     )
   }
 
@@ -89,7 +107,6 @@ const mstp = (state: AppState) => {
 
   const resources = extractRateLimitResources(limits)
   const status = extractRateLimitStatus(limits)
-
   return {
     status,
     resources,

--- a/src/cloud/components/RateLimitAlertContent.tsx
+++ b/src/cloud/components/RateLimitAlertContent.tsx
@@ -58,7 +58,7 @@ const RateLimitAlertContent: FC<Props> = ({className}) => {
   })
 
   const handleShowOverlay = () => {
-    dispatch(showOverlay('rate-limit', null, dispatch(dismissOverlay)))
+    dispatch(showOverlay('rate-limit', null, () => dispatch(dismissOverlay)))
   }
 
   if (showUpgradeButton) {

--- a/src/cloud/components/RateLimitAlertContent.tsx
+++ b/src/cloud/components/RateLimitAlertContent.tsx
@@ -17,8 +17,37 @@ import CloudUpgradeButton from 'src/shared/components/CloudUpgradeButton'
 import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
 import {shouldShowUpgradeButton} from 'src/me/selectors'
 
+// reporting
+import {event} from 'src/cloud/utils/reporting'
+
 interface Props {
   className?: string
+}
+
+export const UpgradeContent = ({type, link, className}) => {
+  event(`user.limits.${type}`)
+  return (
+    <div className={`${className} rate-alert--content__free`}>
+      <span>
+        Oh no! You hit the{' '}
+        <a
+          href={link}
+          className="rate-alert--docs-link"
+          target="_blank"
+          rel="noreferrer"
+        >
+          {type === 'series cardinality' ? 'series cardinality' : 'query write'}
+        </a>{' '}
+        limit and your data stopped writing. Don’t lose important metrics.
+      </span>
+      <FlexBox
+        justifyContent={JustifyContent.Center}
+        className="rate-alert--button"
+      >
+        <CloudUpgradeButton className="upgrade-payg--button__rate-alert" />
+      </FlexBox>
+    </div>
+  )
 }
 
 const RateLimitAlertContent: FC<Props> = ({className}) => {
@@ -34,28 +63,11 @@ const RateLimitAlertContent: FC<Props> = ({className}) => {
 
   if (showUpgradeButton) {
     return (
-      <div
-        className={`${rateLimitAlertContentClass} rate-alert--content__free`}
-      >
-        <span>
-          Oh no! You hit the{' '}
-          <a
-            href="https://docs.influxdata.com/influxdb/v2.0/write-data/best-practices/resolve-high-cardinality/"
-            className="rate-alert--docs-link"
-            target="_blank"
-            rel="noreferrer"
-          >
-            series cardinality
-          </a>{' '}
-          limit and your data stopped writing. Don’t lose important metrics.
-        </span>
-        <FlexBox
-          justifyContent={JustifyContent.Center}
-          className="rate-alert--button"
-        >
-          <CloudUpgradeButton className="upgrade-payg--button__rate-alert" />
-        </FlexBox>
-      </div>
+      <UpgradeContent
+        type="series cardinality"
+        link="https://docs.influxdata.com/influxdb/v2.0/write-data/best-practices/resolve-high-cardinality/"
+        className={rateLimitAlertContentClass}
+      />
     )
   }
 

--- a/src/cloud/components/WriteLimitAlertContent.tsx
+++ b/src/cloud/components/WriteLimitAlertContent.tsx
@@ -1,0 +1,72 @@
+import React, {FC, useState, useEffect} from 'react'
+import {useDispatch, useSelector} from 'react-redux'
+import classnames from 'classnames'
+
+// Actions
+import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
+import {shouldShowUpgradeButton} from 'src/me/selectors'
+
+import {
+  FlexBox,
+  Button,
+  ComponentColor,
+  ComponentSize,
+  JustifyContent,
+} from '@influxdata/clockface'
+import {UpgradeContent} from 'src/cloud/components/RateLimitAlertContent'
+
+interface Props {
+  className?: string
+}
+const WriteLimitAlertContent: FC<Props> = ({className}) => {
+  const dispatch = useDispatch()
+  const showUpgradeButton = useSelector(shouldShowUpgradeButton)
+
+  const rateLimitAlertContentClass = classnames('rate-alert--content', {
+    [`${className}`]: className,
+  })
+
+  const handleShowOverlay = () => {
+    dispatch(showOverlay('write-limit', null, dispatch(dismissOverlay)))
+  }
+
+  if (showUpgradeButton === false) {
+    return (
+      <UpgradeContent
+        type="write"
+        link="https://docs.influxdata.com/influxdb/v2.0/write-data/best-practices/optimize-writes/"
+        className={rateLimitAlertContentClass}
+      />
+    )
+  }
+  return (
+    <div className={`${rateLimitAlertContentClass} rate-alert--content__payg`}>
+      <span>
+        Data in has stopped because you've hit the{' '}
+        <a
+          href="https://docs.influxdata.com/influxdb/v2.0/write-data/best-practices/optimize-writes/"
+          className="rate-alert--docs-link"
+          target="_blank"
+          rel="noreferrer"
+        >
+          query write
+        </a>{' '}
+        limit. Let's get it flowing again.
+      </span>
+      <FlexBox
+        justifyContent={JustifyContent.Center}
+        className="rate-alert--button"
+      >
+        <Button
+          className="rate-alert-overlay-button"
+          color={ComponentColor.Primary}
+          size={ComponentSize.Small}
+          onClick={handleShowOverlay}
+          text="Request Write Limit Increase"
+        />
+      </FlexBox>
+    </div>
+  )
+}
+
+export default WriteLimitAlertContent

--- a/src/cloud/components/WriteLimitAlertContent.tsx
+++ b/src/cloud/components/WriteLimitAlertContent.tsx
@@ -30,7 +30,7 @@ const WriteLimitAlertContent: FC<Props> = ({className}) => {
     dispatch(showOverlay('write-limit', null, dispatch(dismissOverlay)))
   }
 
-  if (showUpgradeButton === false) {
+  if (showUpgradeButton) {
     return (
       <UpgradeContent
         type="write"

--- a/src/cloud/components/WriteLimitAlertContent.tsx
+++ b/src/cloud/components/WriteLimitAlertContent.tsx
@@ -27,7 +27,7 @@ const WriteLimitAlertContent: FC<Props> = ({className}) => {
   })
 
   const handleShowOverlay = () => {
-    dispatch(showOverlay('write-limit', null, dispatch(dismissOverlay)))
+    dispatch(showOverlay('write-limit', null, () => dispatch(dismissOverlay)))
   }
 
   if (showUpgradeButton) {

--- a/src/cloud/components/WriteLimitAlertContent.tsx
+++ b/src/cloud/components/WriteLimitAlertContent.tsx
@@ -1,4 +1,4 @@
-import React, {FC, useState, useEffect} from 'react'
+import React, {FC} from 'react'
 import {useDispatch, useSelector} from 'react-redux'
 import classnames from 'classnames'
 

--- a/src/cloud/components/WriteLimitOverlay.scss
+++ b/src/cloud/components/WriteLimitOverlay.scss
@@ -1,0 +1,10 @@
+.limits-increasewrites--body {
+  display: flex;
+  justify-content: center;
+}
+.limits-increasewrites--form {
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+}

--- a/src/cloud/components/WriteLimitOverlay.tsx
+++ b/src/cloud/components/WriteLimitOverlay.tsx
@@ -1,0 +1,102 @@
+import React, {useState, useContext, FC} from 'react'
+import {useSelector} from 'react-redux'
+
+import {
+  OverlayContainer,
+  Overlay,
+  Form,
+  Heading,
+  Input,
+  HeadingElement,
+  Button,
+  ButtonType,
+  ButtonShape,
+  ComponentSize,
+  ComponentColor,
+  ComponentStatus,
+  InputType,
+} from '@influxdata/clockface'
+
+import {OverlayContext} from 'src/overlays/components/OverlayController'
+
+// Selectors
+import {getOrg} from 'src/organizations/selectors'
+
+// Reporting
+import {event} from 'src/cloud/utils/reporting'
+
+// Design
+import './WriteLimitOverlay.scss'
+
+const WriteLimitOverlay: FC = () => {
+  const [limitReason, setLimitReason] = useState('')
+
+  const {onClose} = useContext(OverlayContext)
+
+  const {id} = useSelector(getOrg)
+
+  const handleSubmit = (): void => {
+    event('limit.requestincrease.writes', {reason: limitReason})
+
+    window.open(
+      `mailto:support@influxdata.com?subject=Request%20Query%20Write%20Limit%20Increase&body=Organization ID%3A%20${id}%0D%0A%0D%0AUse-Case Details:%0D%0A${limitReason}`
+    )
+  }
+  return (
+    <OverlayContainer
+      maxWidth={760}
+      testID="rate-limit-overlay"
+      className="rate-limit-overlay"
+    >
+      <Overlay.Header
+        title={`Let's get your data flowing again.`}
+        onDismiss={onClose}
+        wrapText={true}
+      />
+      <Overlay.Body className="limits-increasewrites--body">
+        <Form onSubmit={handleSubmit} className="limits-increasewrites--form">
+          <Heading element={HeadingElement.H4}>
+            Request Query Write Limit Increase
+          </Heading>
+          <Form.Element label="Request Details" required={true}>
+            <Input
+              name="Write Limit Increase"
+              placeholder="Tell us how much you need your write limit raised"
+              required={true}
+              autoFocus={true}
+              value={limitReason}
+              onChange={e => setLimitReason(e.target.value)}
+              testID="rate-alert-form-amount"
+              type={InputType.Text}
+            />
+          </Form.Element>
+        </Form>
+      </Overlay.Body>
+      <Overlay.Footer>
+        <Button
+          shape={ButtonShape.Default}
+          type={ButtonType.Submit}
+          size={ComponentSize.Medium}
+          color={ComponentColor.Default}
+          text="Cancel"
+          onClick={onClose}
+        />
+        <Button
+          shape={ButtonShape.Default}
+          onClick={handleSubmit}
+          size={ComponentSize.Medium}
+          color={ComponentColor.Primary}
+          className="rate-alert--request-increase-button"
+          text="Submit Request"
+          status={
+            limitReason.length
+              ? ComponentStatus.Default
+              : ComponentStatus.Disabled
+          }
+        />
+      </Overlay.Footer>
+    </OverlayContainer>
+  )
+}
+
+export default WriteLimitOverlay

--- a/src/overlays/components/OverlayController.tsx
+++ b/src/overlays/components/OverlayController.tsx
@@ -23,6 +23,7 @@ import OrgSwitcherOverlay from 'src/pageLayout/components/OrgSwitcherOverlay'
 import CreateBucketOverlay from 'src/buckets/components/CreateBucketOverlay'
 import AssetLimitOverlay from 'src/cloud/components/AssetLimitOverlay'
 import RateLimitOverlay from 'src/cloud/components/RateLimitOverlay'
+import WriteLimitOverlay from 'src/cloud/components/WriteLimitOverlay'
 import {AddAnnotationOverlay} from 'src/annotations/components/AddAnnotationOverlay'
 import {EditAnnotationOverlay} from 'src/annotations/components/EditAnnotationOverlay'
 import CreateVariableOverlay from 'src/variables/components/CreateVariableOverlay'
@@ -87,6 +88,9 @@ export const OverlayController: FunctionComponent = () => {
       case 'rate-limit':
         activeOverlay.current = <RateLimitOverlay onClose={onClose} />
         break
+      case 'write-limit':
+        activeOverlay.current = <WriteLimitOverlay onClose={onClose} />
+        break
       case 'add-annotation':
         activeOverlay.current = <AddAnnotationOverlay />
         break
@@ -150,7 +154,7 @@ const OverlayProvider: FunctionComponent = props => {
 
   const closer = useCallback(() => {
     dispatch(dismissOverlay())
-    if (onClose) {
+    if (onClose && typeof onClose === 'function') {
       onClose()
     }
   }, [onClose, dispatch])

--- a/src/overlays/components/OverlayController.tsx
+++ b/src/overlays/components/OverlayController.tsx
@@ -89,7 +89,7 @@ export const OverlayController: FunctionComponent = () => {
         activeOverlay.current = <RateLimitOverlay onClose={onClose} />
         break
       case 'write-limit':
-        activeOverlay.current = <WriteLimitOverlay onClose={onClose} />
+        activeOverlay.current = <WriteLimitOverlay />
         break
       case 'add-annotation':
         activeOverlay.current = <AddAnnotationOverlay />

--- a/src/overlays/reducers/overlays.ts
+++ b/src/overlays/reducers/overlays.ts
@@ -16,6 +16,7 @@ export type OverlayID =
   | 'create-bucket'
   | 'asset-limit'
   | 'rate-limit'
+  | 'write-limit'
   | 'create-annotation-stream'
   | 'update-annotation-stream'
   | 'add-annotation'


### PR DESCRIPTION
Closes #10955

<!-- Describe your proposed changes here. -->
This introduces more detailed and functional write limit overlays that provide an opportunity for users to upgrade and/or submit requests for increases if they are PAYG. This is a major improvement over our previous implementation, which did.... nothing. 
<img width="1725" alt="Screen Shot 2021-06-28 at 10 40 56 AM" src="https://user-images.githubusercontent.com/29473622/123665785-383b2f80-d7fe-11eb-8851-cc9bb37ebe5b.png">
<img width="1725" alt="Screen Shot 2021-06-28 at 10 42 46 AM" src="https://user-images.githubusercontent.com/29473622/123665796-3b362000-d7fe-11eb-9b04-ac8aa2494949.png">
<img width="1725" alt="Screen Shot 2021-06-28 at 10 39 24 AM" src="https://user-images.githubusercontent.com/29473622/123665814-3ec9a700-d7fe-11eb-9f3f-24e7987e5180.png">
