### PR TITLE
fix: add line wrapping to flux editor in notebooks

### DIFF
--- a/src/flows/pipes/RawFluxEditor/view.tsx
+++ b/src/flows/pipes/RawFluxEditor/view.tsx
@@ -161,6 +161,7 @@ const Query: FC<PipeProp> = ({Context}) => {
           onSubmitScript={() => {}}
           setEditorInstance={setEditorInstance}
           autogrow
+          wrapLines="on"
         />
       </Suspense>
       {!isFlagEnabled('flow-sidebar') && showFn && (

--- a/src/shared/components/FluxMonacoEditor.tsx
+++ b/src/shared/components/FluxMonacoEditor.tsx
@@ -30,6 +30,7 @@ export interface EditorProps {
   onSubmitScript?: () => void
   autogrow?: boolean
   readOnly?: boolean
+  wrapLines?: 'off' | 'on' | 'bounded'
 }
 
 interface Props extends EditorProps {
@@ -43,6 +44,7 @@ const FluxEditorMonaco: FC<Props> = ({
   setEditorInstance,
   autogrow,
   readOnly,
+  wrapLines,
 }) => {
   const lspServer = useRef<LSPServer>(null)
   const [editorInst, seteditorInst] = useState<EditorType | null>(null)
@@ -133,6 +135,7 @@ const FluxEditorMonaco: FC<Props> = ({
           overviewRulerBorder: false,
           automaticLayout: true,
           readOnly: readOnly || false,
+          wordWrap: wrapLines ?? 'off',
         }}
         editorDidMount={editorDidMount}
       />


### PR DESCRIPTION
Closes #1789

<!-- Describe your proposed changes here. -->
Wrap lines in flux editor in notebook cell