### PR TITLE
fix: Replaced all instances of the format YYYY-MM-DD HH:MM:ss to YYYY-MM-DD HH:mm:ss

### DIFF
--- a/src/dashboards/constants/index.ts
+++ b/src/dashboards/constants/index.ts
@@ -86,4 +86,4 @@ export const DYNAMIC_SOURCE_INFO = {
   link: '',
 }
 
-export const UPDATED_AT_TIME_FORMAT = 'YYYY-MM-DD HH:MM:ss'
+export const UPDATED_AT_TIME_FORMAT = 'YYYY-MM-DD HH:mm:ss'

--- a/src/utils/datetime/formatters.test.ts
+++ b/src/utils/datetime/formatters.test.ts
@@ -8,7 +8,7 @@ const timestamp = 426196800000
   YYYY-MM-DD hh:mm:ss a
   YYYY-MM-DD HH:mm:ss a
   YYYY-MM-DD hh:mm:ss a ZZ
-  YYYY-MM-DD HH:MM:ss - UPDATED_AT_TIME_FORMAT
+  YYYY-MM-DD HH:mm:ss - UPDATED_AT_TIME_FORMAT
   YYYY-MM-DD HH:mm - TIME_RANGE_FORMAT
 
   YYYY/MM/DD HH:mm:ss
@@ -78,9 +78,9 @@ describe('the DateTime formatter', () => {
       expect(formatter.format(date)).toBe(`1983-07-04 ${hourUTC}:00:00 PM UTC`)
     })
 
-    it('formats DateTimes in the format YYYY-MM-DD HH:MM:ss in UTC', () => {
+    it('formats DateTimes in the format YYYY-MM-DD HH:mm:ss in UTC', () => {
       const date = new Date(timestamp)
-      const formatter = createDateTimeFormatter('YYYY-MM-DD HH:MM:ss', 'UTC')
+      const formatter = createDateTimeFormatter('YYYY-MM-DD HH:mm:ss', 'UTC')
       expect(formatter.format(date)).toBe(`1983-07-04 ${hourUTC24}:00:00`)
     })
 

--- a/src/utils/datetime/formatters.ts
+++ b/src/utils/datetime/formatters.ts
@@ -79,7 +79,6 @@ export const createDateTimeFormatter = (format, timeZone = 'local') => {
       }
     }
 
-    case 'YYYY-MM-DD HH:MM:ss':
     case 'YYYY-MM-DD HH:mm:ss': {
       const options = {
         ...dateTimeOptions,


### PR DESCRIPTION
Closes #1823

Removed `case 'YYYY-MM-DD HH:MM:ss':` from formatter.ts because `YYYY-MM-DD HH:MM:ss` is not equivalent to `YYYY-MM-DD HH:mm:ss` (again, MM for months and mm for minutes)

Modified formatters.test.ts to test `YYYY-MM-DD HH:mm:ss` instead of `YYYY-MM-DD HH:MM:ss` because the latter is not a valid format and test file did not cover `YYYY-MM-DD HH:mm:ss`