### PR TITLE
feat: changed moment with date formatter in Run log row 

### DIFF
--- a/src/tasks/components/RunLogRow.tsx
+++ b/src/tasks/components/RunLogRow.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import moment from 'moment'
 
 // Components
 import {IndexList} from '@influxdata/clockface'
@@ -8,6 +7,8 @@ import {IndexList} from '@influxdata/clockface'
 // Types
 import {LogEvent} from 'src/types'
 import {DEFAULT_TIME_FORMAT} from 'src/shared/constants'
+import {resolveTimeFormat} from 'src/visualization/utils/timeFormat'
+import {createDateTimeFormatter} from 'src/utils/datetime/formatters'
 
 interface Props {
   log: LogEvent
@@ -41,7 +42,7 @@ class RunLogRow extends PureComponent<Props> {
     }
 
     const newdate = new Date(dt)
-    const formatted = moment(newdate).format(DEFAULT_TIME_FORMAT)
+    const formatted = createDateTimeFormatter(resolveTimeFormat(DEFAULT_TIME_FORMAT)).format(newdate)
 
     return formatted
   }

--- a/src/tasks/components/RunLogRow.tsx
+++ b/src/tasks/components/RunLogRow.tsx
@@ -42,7 +42,9 @@ class RunLogRow extends PureComponent<Props> {
     }
 
     const newdate = new Date(dt)
-    const formatted = createDateTimeFormatter(resolveTimeFormat(DEFAULT_TIME_FORMAT)).format(newdate)
+    const formatted = createDateTimeFormatter(
+      resolveTimeFormat(DEFAULT_TIME_FORMAT)
+    ).format(newdate)
 
     return formatted
   }

--- a/src/tasks/components/RunLogRow.tsx
+++ b/src/tasks/components/RunLogRow.tsx
@@ -7,7 +7,6 @@ import {IndexList} from '@influxdata/clockface'
 // Types
 import {LogEvent} from 'src/types'
 import {DEFAULT_TIME_FORMAT} from 'src/shared/constants'
-import {resolveTimeFormat} from 'src/visualization/utils/timeFormat'
 import {createDateTimeFormatter} from 'src/utils/datetime/formatters'
 
 interface Props {
@@ -42,9 +41,9 @@ class RunLogRow extends PureComponent<Props> {
     }
 
     const newdate = new Date(dt)
-    const formatted = createDateTimeFormatter(
-      resolveTimeFormat(DEFAULT_TIME_FORMAT)
-    ).format(newdate)
+    const formatted = createDateTimeFormatter(DEFAULT_TIME_FORMAT).format(
+      newdate
+    )
 
     return formatted
   }


### PR DESCRIPTION
see #1768

replaces moment.js in the RunLogRow component with date formatter. 
<img width="1679" alt="Screen Shot 2021-06-28 at 3 16 42 PM" src="https://user-images.githubusercontent.com/66275100/123698545-e60d0500-d823-11eb-876e-d42bbca9c38a.png">

