### PR TITLE
fix: handle creating tasks that work with buckets with import in its name

### DIFF
--- a/src/shared/utils/insertPreambleInScript.ts
+++ b/src/shared/utils/insertPreambleInScript.ts
@@ -26,7 +26,7 @@ export const insertPreambleInScript = async (
 
   const ast = resp.data.ast as Package
 
-  const imports: ImportDeclaration[] = get(ast, 'files.0.imports', [])
+  const imports: ImportDeclaration[] = ast?.files[0]?.imports ?? []
   const body: Statement[] = get(ast, 'files.0.body', [])
 
   const importsText = imports.map(d => d.location.source).join('\n')


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/1521

### Steps to reproduce:
1. Create a bucket with `import` in the name (`devbucket-import` is what I used)
1. Try to create a task that references the bucket with import in the name
    ```flux
    from(bucket: "devbucket-import")
        |> range(start: v.timeRangeStart)
        |> filter(fn: (r) => r._measurement == "system")
        |> filter(fn: (r) => r._field == "load1" or r._field == "load5" or r._field == "load15")
        |> to(bucket: "devbucket-downsampled", org: "dev")
    ```
1. Apply this fix and then retry the above