### PR TITLE
fix: simple table handles NaN

### DIFF
--- a/src/visualization/types/SimpleTable/InnerTable.tsx
+++ b/src/visualization/types/SimpleTable/InnerTable.tsx
@@ -30,10 +30,10 @@ const InnerTable: FC<InnerProps> = ({table}) => {
       const cells = Object.values(table.cols).map(c => {
         let val = c.data[idx]
 
-        if (c.type === 'time') {
+        if (val && c.type === 'time') {
           val = new Date(val).toISOString()
         }
-        if (c.type === 'boolean') {
+        if (val && c.type === 'boolean') {
           val = val ? 'true' : 'false'
         }
 
@@ -42,7 +42,7 @@ const InnerTable: FC<InnerProps> = ({table}) => {
             key={`h${c.name}:r${idx}`}
             testID={`table-cell ${c.data[idx]}`}
           >
-            {val}
+            {val?.toString()}
           </Table.Cell>
         )
       })


### PR DESCRIPTION
Closes #1838 

Simple table can now handle receiving NaN values. I tested it by exporting the dataset from tools and importing it into my local env. I ran the same query and was able to reproduce it locally. This fix does the trick

![image](https://user-images.githubusercontent.com/6411855/123718091-23c55a00-d833-11eb-9c86-381c2a3b5e10.png)
