### PR TITLE
fix: Default time format update

### DIFF
--- a/cypress/e2e/shared/dashboardsView.test.ts
+++ b/cypress/e2e/shared/dashboardsView.test.ts
@@ -1154,7 +1154,7 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
         })
       })
     })
-    const timeFormatOriginal = 'YYYY-MM-DD HH:mm:ss a'
+    const timeFormatOriginal = 'YYYY-MM-DD HH:mm:ss'
     const timeFormatNew = 'hh:mm a'
 
     cy.log('creating new dashboard cell')

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -41,7 +41,7 @@ export const EMPTY_ZUORA_PARAMS: CreditCardParams = {
 export const BALANCE_THRESHOLD_DEFAULT = 10
 export const MINIMUM_BALANCE_THRESHOLD = 1
 
-export const DEFAULT_TIME_FORMAT = 'YYYY-MM-DD HH:mm:ss a'
+export const DEFAULT_TIME_FORMAT = 'YYYY-MM-DD HH:mm:ss'
 
 export const DROPDOWN_MENU_MAX_HEIGHT = 240
 

--- a/src/utils/datetime/formatters.test.ts
+++ b/src/utils/datetime/formatters.test.ts
@@ -68,7 +68,7 @@ describe('the DateTime formatter', () => {
 
     it('formats DateTimes in the format, YYYY-MM-DD hh:mm:ss a in UTC', () => {
       const date = new Date(timestamp)
-      let formatter = createDateTimeFormatter('YYYY-MM-DD hh:mm:ss a', 'UTC')
+      const formatter = createDateTimeFormatter('YYYY-MM-DD hh:mm:ss a', 'UTC')
       expect(formatter.format(date)).toBe(`1983-07-04 ${hourUTC}:00:00 PM`)
     })
 

--- a/src/utils/datetime/formatters.test.ts
+++ b/src/utils/datetime/formatters.test.ts
@@ -60,13 +60,16 @@ describe('the DateTime formatter', () => {
   }
 
   describe('formatting DateTimes in UTC', () => {
-    it('formats DateTimes in the default time, YYYY-MM-DD hh:mm:ss a in UTC', () => {
+    it('formats DateTimes in the default time YYYY-MM-DD HH:mm:ss in UTC', () => {
+      const date = new Date(timestamp)
+      const formatter = createDateTimeFormatter('YYYY-MM-DD HH:mm:ss', 'UTC')
+      expect(formatter.format(date)).toBe(`1983-07-04 ${hourUTC24}:00:00`)
+    })
+
+    it('formats DateTimes in the format, YYYY-MM-DD hh:mm:ss a in UTC', () => {
       const date = new Date(timestamp)
       let formatter = createDateTimeFormatter('YYYY-MM-DD hh:mm:ss a', 'UTC')
       expect(formatter.format(date)).toBe(`1983-07-04 ${hourUTC}:00:00 PM`)
-
-      formatter = createDateTimeFormatter('YYYY-MM-DD HH:mm:ss', 'UTC')
-      expect(formatter.format(date)).toBe(`1983-07-04 ${hourUTC}:00:00`)
     })
 
     it('formats DateTimes in the format YYYY-MM-DD hh:mm:ss a ZZ in UTC', () => {
@@ -76,12 +79,6 @@ describe('the DateTime formatter', () => {
         'UTC'
       )
       expect(formatter.format(date)).toBe(`1983-07-04 ${hourUTC}:00:00 PM UTC`)
-    })
-
-    it('formats DateTimes in the format YYYY-MM-DD HH:mm:ss in UTC', () => {
-      const date = new Date(timestamp)
-      const formatter = createDateTimeFormatter('YYYY-MM-DD HH:mm:ss', 'UTC')
-      expect(formatter.format(date)).toBe(`1983-07-04 ${hourUTC24}:00:00`)
     })
 
     it('formats DateTimes in the format YYYY-MM-DD HH:mm in UTC', () => {

--- a/src/utils/datetime/formatters.test.ts
+++ b/src/utils/datetime/formatters.test.ts
@@ -65,8 +65,8 @@ describe('the DateTime formatter', () => {
       let formatter = createDateTimeFormatter('YYYY-MM-DD hh:mm:ss a', 'UTC')
       expect(formatter.format(date)).toBe(`1983-07-04 ${hourUTC}:00:00 PM`)
 
-      formatter = createDateTimeFormatter('YYYY-MM-DD HH:mm:ss a', 'UTC')
-      expect(formatter.format(date)).toBe(`1983-07-04 ${hourUTC}:00:00 PM`)
+      formatter = createDateTimeFormatter('YYYY-MM-DD HH:mm:ss', 'UTC')
+      expect(formatter.format(date)).toBe(`1983-07-04 ${hourUTC}:00:00`)
     })
 
     it('formats DateTimes in the format YYYY-MM-DD hh:mm:ss a ZZ in UTC', () => {

--- a/src/utils/datetime/formatters.ts
+++ b/src/utils/datetime/formatters.ts
@@ -21,7 +21,7 @@ export const createDateTimeFormatter = (format, timeZone = 'local') => {
   switch (format) {
     default:
     case 'YYYY-MM-DD hh:mm:ss a':
-    case 'YYYY-MM-DD HH:mm:ss a': {
+    case 'YYYY-MM-DD HH:mm:ss': {
       const options = {
         ...dateTimeOptions,
       }

--- a/src/utils/datetime/formatters.ts
+++ b/src/utils/datetime/formatters.ts
@@ -20,8 +20,7 @@ const timeOptions: any = {
 export const createDateTimeFormatter = (format, timeZone = 'local') => {
   switch (format) {
     default:
-    case 'YYYY-MM-DD hh:mm:ss a':
-    case 'YYYY-MM-DD HH:mm:ss': {
+    case 'YYYY-MM-DD hh:mm:ss a': {
       const options = {
         ...dateTimeOptions,
       }

--- a/src/visualization/utils/timeFormat.ts
+++ b/src/visualization/utils/timeFormat.ts
@@ -1,7 +1,7 @@
 import {DEFAULT_TIME_FORMAT} from 'src/shared/constants'
 
 export const FORMAT_OPTIONS: Array<{text: string}> = [
-  {text: DEFAULT_TIME_FORMAT},
+  {text: DEFAULT_TIME_FORMAT}, // 'YYYY-MM-DD HH:mm:ss'
   {text: 'YYYY-MM-DD hh:mm:ss a ZZ'},
   {text: 'DD/MM/YYYY HH:mm:ss.sss'},
   {text: 'DD/MM/YYYY hh:mm:ss.sss a'},

--- a/src/visualization/utils/timeFormat.ts
+++ b/src/visualization/utils/timeFormat.ts
@@ -1,7 +1,7 @@
 import {DEFAULT_TIME_FORMAT} from 'src/shared/constants'
 
 export const FORMAT_OPTIONS: Array<{text: string}> = [
-  {text: DEFAULT_TIME_FORMAT}, // 'YYYY-MM-DD HH:mm:ss a'
+  {text: DEFAULT_TIME_FORMAT},
   {text: 'YYYY-MM-DD hh:mm:ss a ZZ'},
   {text: 'DD/MM/YYYY HH:mm:ss.sss'},
   {text: 'DD/MM/YYYY hh:mm:ss.sss a'},


### PR DESCRIPTION
Closes #1834 

changed DEFAULT_TIME_FORMAT from `YYYY-MM-DD HH:mm:ss a` to ->  `YYYY-MM-DD HH:mm:ss` (no a). This change assures 24 hour time format doesn't contain a AM/PM 
Before: 
<img width="1609" alt="Screen Shot 2021-06-28 at 2 53 05 PM" src="https://user-images.githubusercontent.com/66275100/123700493-2a010980-d826-11eb-9ba2-c594a8288b4c.png">

After: 
<img width="1679" alt="Screen Shot 2021-06-28 at 3 16 42 PM" src="https://user-images.githubusercontent.com/66275100/123700548-3e450680-d826-11eb-8624-cbbb6d8ac36c.png">
