### PR TITLE
chore: Annotations-fix metric tags

### DIFF
--- a/src/annotations/components/AddAnnotationOverlay.tsx
+++ b/src/annotations/components/AddAnnotationOverlay.tsx
@@ -13,9 +13,13 @@ import {getOverlayParams} from 'src/overlays/selectors'
 
 export const AddAnnotationOverlay: FC = () => {
   const {onClose} = useContext(OverlayContext)
-  const {createAnnotation, startTime, endTime, range} = useSelector(
-    getOverlayParams
-  )
+  const {
+    createAnnotation,
+    startTime,
+    endTime,
+    range,
+    eventPrefix,
+  } = useSelector(getOverlayParams)
 
   const handleSubmit = (modifiedAnnotation): void => {
     createAnnotation(modifiedAnnotation)
@@ -32,6 +36,7 @@ export const AddAnnotationOverlay: FC = () => {
       onSubmit={handleSubmit}
       startTime={startTime}
       endTime={endTime}
+      eventPrefix={eventPrefix}
     />
   )
 }

--- a/src/annotations/components/EditAnnotationOverlay.tsx
+++ b/src/annotations/components/EditAnnotationOverlay.tsx
@@ -38,11 +38,15 @@ export const EditAnnotationOverlay: FC = () => {
   ): Promise<void> => {
     try {
       await dispatch(editAnnotation(editedAnnotation))
-      event('annotations.edit_annotation.success')
+      event(
+        `${clickedAnnotation.eventPrefix}.annotations.edit_annotation.success`
+      )
       dispatch(notify(editAnnotationSuccess()))
       onClose()
     } catch (err) {
-      event('annotations.edit_annotation.failure')
+      event(
+        `${clickedAnnotation.eventPrefix}.annotations.edit_annotation.failure`
+      )
       dispatch(notify(editAnnotationFailed(getErrorMessage(err))))
     }
   }
@@ -63,6 +67,7 @@ export const EditAnnotationOverlay: FC = () => {
       stream={clickedAnnotation.stream}
       onClose={onClose}
       title="Edit"
+      eventPrefix={clickedAnnotation.eventPrefix}
     />
   )
 }

--- a/src/annotations/components/annotationForm/AnnotationForm.tsx
+++ b/src/annotations/components/annotationForm/AnnotationForm.tsx
@@ -37,7 +37,6 @@ import 'src/annotations/components/annotationForm/annotationForm.scss'
 
 type AnnotationType = 'point' | 'range'
 
-//TODO:  make the prefix required!
 interface Props {
   startTime: string
   endTime?: string
@@ -48,7 +47,7 @@ interface Props {
   type: AnnotationType
   onSubmit: (Annotation) => void
   onClose: () => void
-  eventPrefix?: string
+  eventPrefix: string
 }
 
 export const AnnotationForm: FC<Props> = (props: Props) => {
@@ -56,8 +55,6 @@ export const AnnotationForm: FC<Props> = (props: Props) => {
   const [endTime, setEndTime] = useState(props.endTime)
   const [summary, setSummary] = useState(props.summary)
   const [annotationType, setAnnotationType] = useState(props.type)
-
-  console.log('in annotation form; props??', props)
 
   const dispatch = useDispatch()
 

--- a/src/annotations/components/annotationForm/AnnotationForm.tsx
+++ b/src/annotations/components/annotationForm/AnnotationForm.tsx
@@ -37,6 +37,7 @@ import 'src/annotations/components/annotationForm/annotationForm.scss'
 
 type AnnotationType = 'point' | 'range'
 
+//TODO:  make the prefix required!
 interface Props {
   startTime: string
   endTime?: string
@@ -47,6 +48,7 @@ interface Props {
   type: AnnotationType
   onSubmit: (Annotation) => void
   onClose: () => void
+  eventPrefix?: string
 }
 
 export const AnnotationForm: FC<Props> = (props: Props) => {
@@ -54,6 +56,8 @@ export const AnnotationForm: FC<Props> = (props: Props) => {
   const [endTime, setEndTime] = useState(props.endTime)
   const [summary, setSummary] = useState(props.summary)
   const [annotationType, setAnnotationType] = useState(props.type)
+
+  console.log('in annotation form; props??', props)
 
   const dispatch = useDispatch()
 
@@ -107,7 +111,6 @@ export const AnnotationForm: FC<Props> = (props: Props) => {
     })
   }
 
-  // TODO:  get the correct prefix in there, multiple plot types have annotations now
   const handleDelete = () => {
     const editedAnnotation = {
       summary,
@@ -120,17 +123,20 @@ export const AnnotationForm: FC<Props> = (props: Props) => {
 
     try {
       dispatch(deleteAnnotations(editedAnnotation))
-      event('annotations.delete_annotation.success')
+      event(`${props.eventPrefix}.annotations.delete_annotation.success`)
       dispatch(notify(deleteAnnotationSuccess(editedAnnotation.summary)))
       props.onClose()
     } catch (err) {
-      event('annotations.delete_annotation.failure')
+      event(`${props.eventPrefix}.annotations.delete_annotation.failure`)
       dispatch(notify(deleteAnnotationFailed(err)))
     }
   }
 
   const handleCancel = () => {
-    event('dashboards.annotations.create_annotation.cancel')
+    const annoMode = isEditing ? 'edit' : 'create'
+    event(
+      `${props.eventPrefix}.dashboards.annotations.${annoMode}_annotation.cancel`
+    )
     props.onClose()
   }
 

--- a/src/visualization/utils/annotationUtils.ts
+++ b/src/visualization/utils/annotationUtils.ts
@@ -54,6 +54,8 @@ const makeCreateMethod = (
   return createAnnotation
 }
 
+// for point annotations only:
+// (initially, the user can then change to a range once the dialog is up)
 const makeAnnotationClickListener = (
   dispatch: Dispatch<any>,
   cellID: string,
@@ -70,6 +72,7 @@ const makeAnnotationClickListener = (
         {
           createAnnotation,
           startTime: plotInteraction?.clampedValueX ?? plotInteraction.valueX,
+          eventPrefix,
         },
         () => {
           dismissOverlay()
@@ -98,6 +101,7 @@ const makeAnnotationRangeListener = (
           startTime: start,
           endTime: end,
           range: true,
+          eventPrefix,
         },
         () => {
           dismissOverlay()
@@ -110,6 +114,8 @@ const makeAnnotationRangeListener = (
 }
 
 /**
+ *  For editing annotations
+ *
  *  This handles both point and range annotations
  *  Point annotations have an stop time, it just is equal to the start time
  *
@@ -133,7 +139,13 @@ const makeAnnotationClickHandler = (
       dispatch(
         showOverlay(
           'edit-annotation',
-          {clickedAnnotation: {...annotationToEdit, stream: cellID}},
+          {
+            clickedAnnotation: {
+              ...annotationToEdit,
+              stream: cellID,
+              eventPrefix,
+            },
+          },
           () => {
             dismissOverlay()
           }


### PR DESCRIPTION
Closes #1752 


changes:

note:  prefixes are either:
<ul>
<li>xyplot
<li>band
<li>singleStatWline
</ul>

<table>
<tr><th> original </th><th> changed</th></tr>
<tr><td>annotations.edit_annotation.success </td><td>${eventPrefix}.annotations.edit_annotation.success</td></tr>
<tr><td>annotations.edit_annotation.failure</td><td>${eventPrefix}.annotations.edit_annotation.failure</td></tr>
<tr><td>annotations.delete_annotation.success </td><td>${eventPrefix}.annotations.delete_annotation.success</td></tr>
<tr><td>annotations.delete_annotation.failure </td><td>${eventPrefix}.annotations.delete_annotation.failure</td></tr>
</table>


<div>special case for: dashboards.annotations.create_annotation.cancel</div>
<table><tr><th>creation</th><th>editing</th></tr>
<tr><td>${eventPrefix}.dashboards.annotations.create_annotation.cancel</td>
<td>${eventPrefix}.dashboards.annotations.edit_annotation.cancel</td></tr>
</table>
