### PR TITLE
chore: add test:e2e:remocal target

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "test:e2e:clean": "rm junit-results/*.xml",
     "test:e2e:all": "yarn test:e2e:clean && yarn test:e2e; yarn test:e2e:report;",
     "test:e2e:kind": "CYPRESS_dexUrl=http://dex-twodotoh.a.influxcloud.dev.local CYPRESS_baseUrl=https://twodotoh.a.influxcloud.dev.local CYPRESS_password=password cypress open --browser chrome --config chromeWebSecurity=false",
+    "test:e2e:remocal": "CYPRESS_dexUrl=https://dex-twodotoh-dev-${NS}.a.influxcloud.dev.local CYPRESS_baseUrl=https://twodotoh-dev-${NS}.a.influxcloud.dev.local CYPRESS_password=password cypress open --browser chrome --config chromeWebSecurity=false",
     "test:circleci": "yarn run test:ci --maxWorkers=2",
     "test:ci": "JEST_JUNIT_OUTPUT_DIR=\"./coverage\" jest --ci --coverage",
     "lint": "yarn tsc && yarn prettier && yarn eslint",


### PR DESCRIPTION
Adds the `test:e2e:remocal` target which requires providing the `NS` variable which is the namespace of your remote cluster. 

So it is invoked like `NS=gene20210622081511 yarn test:e2e:remocal`.

Docs PR: https://github.com/influxdata/docs.influxdata.io/pull/210
