### PR TITLE
chore: add additional cypress login flow for monitor-ci

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -37,6 +37,8 @@ export const signin = (): Cypress.Chainable<Cypress.Response> => {
                   (defaultPassword: string) => {
                     if (Cypress.env(DEX_URL_VAR) === 'OSS') {
                       return loginViaOSS(username, defaultPassword)
+                    } else if (Cypress.env(DEX_URL_VAR) === 'CLOUD') {
+                      return loginViaDexUI(username, defaultPassword)
                     } else {
                       return loginViaDex(username, defaultPassword)
                     }
@@ -49,6 +51,13 @@ export const signin = (): Cypress.Chainable<Cypress.Response> => {
         })
       })
   })
+}
+
+export const loginViaDexUI = (username: string, password: string) => {
+  cy.get('#login').type(username)
+  cy.get('#password').type(password)
+  cy.get('#submit-login').click()
+  cy.get('.theme-btn--success').click()
 }
 
 // login via the purple OSS screen by typing in username/password

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "tsc": "tsc -p ./tsconfig.json --noEmit --pretty --skipLibCheck",
     "tsc:watch": "yarn tsc --watch",
     "cy": "CYPRESS_dexUrl=https://$INGRESS_HOST:$PORT_HTTPS CYPRESS_baseUrl=http://localhost:9999 cypress open",
-    "cy:dev": "source ../monitor-ci/.env && CYPRESS_dexUrl=https://$INGRESS_HOST:$PORT_HTTPS CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{cloud,shared}/**/*.*'",
+    "cy:dev": "source ../monitor-ci/.env && CYPRESS_dexUrl=CLOUD CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{cloud,shared}/**/*.*'",
     "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_dexUrl=OSS CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{oss,shared}/**/*.*'",
     "generate": "export SHA=dd6be1fe6c836a5fe3f979a9107f5b8b531d3a2e && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",


### PR DESCRIPTION
Should resolve the cloud-e2e issue I think. Adds an additional login flow that uses Dex's UI. This will be used for when monitor-ci is run in cloud mode.