### PR TITLE
fix: updates default values and sets explict values where appropriate for Hover and Static Legends

### DIFF
--- a/src/visualization/components/internal/HoverLegend.tsx
+++ b/src/visualization/components/internal/HoverLegend.tsx
@@ -181,11 +181,11 @@ const HoverLegend: FC<HoverLegendProps> = ({properties, update}) => {
   }
 
   const handleSetOrientation = (threshold: number): void => {
-    let validThreshold = threshold
+    let validThreshold: number
     if (
-      typeof validThreshold !== 'number' ||
-      validThreshold !== validThreshold ||
-      validThreshold > 0
+      typeof threshold !== 'number' ||
+      threshold !== threshold ||
+      threshold > 0
     ) {
       validThreshold = LEGEND_ORIENTATION_THRESHOLD_HORIZONTAL
     } else {

--- a/src/visualization/components/internal/HoverLegend.tsx
+++ b/src/visualization/components/internal/HoverLegend.tsx
@@ -38,6 +38,8 @@ import {
   LEGEND_OPACITY_MAXIMUM,
   LEGEND_OPACITY_MINIMUM,
   LEGEND_ORIENTATION_THRESHOLD_DEFAULT,
+  LEGEND_ORIENTATION_THRESHOLD_HORIZONTAL,
+  LEGEND_ORIENTATION_THRESHOLD_VERTICAL,
   LegendDisplayStatus,
 } from 'src/visualization/constants'
 
@@ -179,8 +181,18 @@ const HoverLegend: FC<HoverLegendProps> = ({properties, update}) => {
   }
 
   const handleSetOrientation = (threshold: number): void => {
+    let validThreshold = threshold
+    if (
+      typeof validThreshold !== 'number' ||
+      validThreshold !== validThreshold ||
+      validThreshold > 0
+    ) {
+      validThreshold = LEGEND_ORIENTATION_THRESHOLD_HORIZONTAL
+    } else {
+      validThreshold = LEGEND_ORIENTATION_THRESHOLD_VERTICAL
+    }
     update({
-      legendOrientationThreshold: threshold,
+      legendOrientationThreshold: validThreshold,
     })
     // eventing is done by <OrientationToggle> because
     // UI's definition of orientation is either horizontal or vertical

--- a/src/visualization/components/internal/LegendOptions.tsx
+++ b/src/visualization/components/internal/LegendOptions.tsx
@@ -138,14 +138,14 @@ export const OpacitySlider: FC<OpacitySliderProps> = ({
   handleSetOpacity,
   testID = 'opacity-slider',
 }) => {
-  let validOpacity = legendOpacity
+  let validOpacity = LEGEND_OPACITY_DEFAULT
   if (
-    typeof validOpacity !== 'number' ||
-    validOpacity !== validOpacity ||
-    validOpacity < LEGEND_OPACITY_MINIMUM ||
-    validOpacity > LEGEND_OPACITY_MAXIMUM
+    typeof validOpacity === 'number' &&
+    validOpacity === validOpacity &&
+    validOpacity >= LEGEND_OPACITY_MINIMUM &&
+    validOpacity <= LEGEND_OPACITY_MAXIMUM
   ) {
-    validOpacity = LEGEND_OPACITY_DEFAULT
+    validOpacity = legendOpacity
   }
   const percentLegendOpacity = (validOpacity * 100).toFixed(0)
 

--- a/src/visualization/components/internal/LegendOptions.tsx
+++ b/src/visualization/components/internal/LegendOptions.tsx
@@ -20,6 +20,7 @@ import {
 
 // Constants
 import {
+  LEGEND_OPACITY_DEFAULT,
   LEGEND_OPACITY_MAXIMUM,
   LEGEND_OPACITY_MINIMUM,
   LEGEND_OPACITY_STEP,
@@ -114,7 +115,7 @@ export const OrientationToggle: FC<OrientationToggleProps> = ({
         className="legend-orientation--vertical"
         id={`${parentName}-orientation--vertical`}
         name={`${parentName}-orientation--vertical`}
-        checked={legendOrientation === LEGEND_ORIENTATION_THRESHOLD_VERTICAL}
+        checked={legendOrientation <= 0}
         onChange={setOrientation}
         type={InputToggleType.Radio}
         size={ComponentSize.ExtraSmall}
@@ -122,7 +123,7 @@ export const OrientationToggle: FC<OrientationToggleProps> = ({
         appearance={Appearance.Outline}
       >
         <InputLabel
-          active={legendOrientation === LEGEND_ORIENTATION_THRESHOLD_VERTICAL}
+          active={legendOrientation <= 0}
           htmlFor={`${parentName}-orientation--vertical`}
         >
           Vertical
@@ -137,9 +138,17 @@ export const OpacitySlider: FC<OpacitySliderProps> = ({
   handleSetOpacity,
   testID = 'opacity-slider',
 }) => {
-  // without the toFixed(0) sometimes you
-  // can get numbers like 45.000009% which we want to avoid
-  const percentLegendOpacity = (legendOpacity * 100).toFixed(0)
+  let validOpacity = legendOpacity
+  if (
+    typeof validOpacity !== 'number' ||
+    validOpacity !== validOpacity ||
+    validOpacity < LEGEND_OPACITY_MINIMUM ||
+    validOpacity > LEGEND_OPACITY_MAXIMUM
+  ) {
+    validOpacity = LEGEND_OPACITY_DEFAULT
+  }
+  const percentLegendOpacity = (validOpacity * 100).toFixed(0)
+
   return (
     <Form.Element
       className="legend-opacity-slider"
@@ -150,7 +159,7 @@ export const OpacitySlider: FC<OpacitySliderProps> = ({
         max={LEGEND_OPACITY_MAXIMUM}
         min={LEGEND_OPACITY_MINIMUM}
         step={LEGEND_OPACITY_STEP}
-        value={legendOpacity}
+        value={validOpacity}
         onChange={handleSetOpacity}
         hideLabels={true}
       />

--- a/src/visualization/components/internal/StaticLegend.tsx
+++ b/src/visualization/components/internal/StaticLegend.tsx
@@ -140,11 +140,11 @@ const StaticLegend: FC<Props> = ({properties, update}) => {
   }
 
   const handleSetOrientation = (threshold: number): void => {
-    let validThreshold = threshold
+    let validThreshold: number
     if (
-      typeof validThreshold !== 'number' ||
-      validThreshold !== validThreshold ||
-      validThreshold > 0
+      typeof threshold !== 'number' ||
+      threshold !== threshold ||
+      threshold > 0
     ) {
       validThreshold = LEGEND_ORIENTATION_THRESHOLD_HORIZONTAL
     } else {

--- a/src/visualization/components/internal/StaticLegend.tsx
+++ b/src/visualization/components/internal/StaticLegend.tsx
@@ -41,6 +41,8 @@ import {
   LEGEND_OPACITY_MAXIMUM,
   LEGEND_OPACITY_MINIMUM,
   LEGEND_ORIENTATION_THRESHOLD_DEFAULT,
+  LEGEND_ORIENTATION_THRESHOLD_HORIZONTAL,
+  LEGEND_ORIENTATION_THRESHOLD_VERTICAL,
   LegendDisplayStatus,
   STATIC_LEGEND_HEIGHT_RATIO_MAXIMUM,
   STATIC_LEGEND_HEIGHT_RATIO_MINIMUM,
@@ -138,8 +140,18 @@ const StaticLegend: FC<Props> = ({properties, update}) => {
   }
 
   const handleSetOrientation = (threshold: number): void => {
+    let validThreshold = threshold
+    if (
+      typeof validThreshold !== 'number' ||
+      validThreshold !== validThreshold ||
+      validThreshold > 0
+    ) {
+      validThreshold = LEGEND_ORIENTATION_THRESHOLD_HORIZONTAL
+    } else {
+      validThreshold = LEGEND_ORIENTATION_THRESHOLD_VERTICAL
+    }
     update({
-      staticLegend: {...staticLegend, orientationThreshold: threshold},
+      staticLegend: {...staticLegend, orientationThreshold: validThreshold},
     })
     // eventing is done by <OrientationToggle> because
     // UI's definition of orientation is either horizontal or vertical

--- a/src/visualization/utils/useLegendOpacity.ts
+++ b/src/visualization/utils/useLegendOpacity.ts
@@ -6,7 +6,10 @@ import {
 
 export const useLegendOpacity = (legendOpacity: number) =>
   useMemo(() => {
-    if (legendOpacity < LEGEND_OPACITY_MINIMUM) {
+    if (
+      legendOpacity < LEGEND_OPACITY_MINIMUM ||
+      legendOpacity !== legendOpacity
+    ) {
       return LEGEND_OPACITY_DEFAULT
     }
     return legendOpacity

--- a/src/visualization/utils/useStaticLegend.ts
+++ b/src/visualization/utils/useStaticLegend.ts
@@ -97,6 +97,7 @@ export const useStaticLegend = (properties): StaticLegendConfig => {
     const {
       colorizeRows = false, // undefined is false because of omitempty
       heightRatio = STATIC_LEGEND_HEIGHT_RATIO_NOT_SET,
+      opacity = LEGEND_OPACITY_DEFAULT,
       orientationThreshold = legendOrientationThreshold,
       show = STATIC_LEGEND_SHOW_DEFAULT,
       ...config
@@ -115,6 +116,7 @@ export const useStaticLegend = (properties): StaticLegendConfig => {
       colorizeRows,
       heightRatio,
       hide: isFlagEnabled('staticLegend') ? convertShowToHide(show) : true,
+      opacity,
       orientationThreshold,
       ...STATIC_LEGEND_STYLING,
       renderEffect: options => {

--- a/src/visualization/utils/useStaticLegend.ts
+++ b/src/visualization/utils/useStaticLegend.ts
@@ -1,6 +1,6 @@
 // Libraries
 import {useMemo, useCallback} from 'react'
-import {useDispatch} from 'react-redux'
+import {useDispatch, useSelector} from 'react-redux'
 
 // Actions
 import {setStaticLegend} from 'src/timeMachine/actions'
@@ -11,6 +11,7 @@ import {StaticLegend as StaticLegendAPI} from 'src/types'
 
 // Utils
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import {getActiveTimeMachine} from 'src/timeMachine/selectors'
 
 // Constants
 import {
@@ -64,6 +65,7 @@ const convertShowToHide = (showState: boolean): boolean => !showState
 const eventPrefix = 'visualization.customize.staticlegend'
 
 export const useStaticLegend = (properties): StaticLegendConfig => {
+  const {isViewingVisOptions} = useSelector(getActiveTimeMachine)
   const dispatch = useDispatch()
   const update = useCallback(
     (staticLegend: StaticLegendAPI) => {
@@ -103,7 +105,12 @@ export const useStaticLegend = (properties): StaticLegendConfig => {
       ...config
     } = staticLegend
 
-    if (!show && heightRatio === STATIC_LEGEND_HEIGHT_RATIO_NOT_SET) {
+    if (
+      isFlagEnabled('staticLegend') &&
+      isViewingVisOptions &&
+      !show &&
+      heightRatio === STATIC_LEGEND_HEIGHT_RATIO_NOT_SET
+    ) {
       update({
         colorizeRows: legendColorizeRows,
         opacity: legendOpacity,
@@ -177,5 +184,5 @@ export const useStaticLegend = (properties): StaticLegendConfig => {
         }
       },
     }
-  }, [properties, update])
+  }, [properties, isViewingVisOptions, update])
 }


### PR DESCRIPTION
Closes #1855 

orientation:
- added checks for 0 and -1 for vertical into the orientation toggle component
- updates will explicitly use -1 for vertical

opacity:
- added checks for valid opacity into the opacity slider component
- static legend will explicitly set a default opacity
