### PR TITLE
feat: add 1m time range to dashboards

### DIFF
--- a/src/shared/constants/timeRanges.ts
+++ b/src/shared/constants/timeRanges.ts
@@ -51,6 +51,15 @@ export const CUSTOM_TIME_RANGE: {label: string; type: 'custom'} = {
 
 export const SELECTABLE_TIME_RANGES: SelectableDurationTimeRange[] = [
   {
+    seconds: 60,
+    lower: 'now() - 1m',
+    upper: null,
+    label: 'Past 1m',
+    duration: '1m',
+    type: 'selectable-duration',
+    windowPeriod: 1000, // 1s
+  },
+  {
     seconds: 300,
     lower: 'now() - 5m',
     upper: null,

--- a/src/types/queries.ts
+++ b/src/types/queries.ts
@@ -3,6 +3,7 @@ export {Query, Dialect} from 'src/client'
 type Nullable<T> = T | null
 
 export type SelectableTimeRangeLower =
+  | 'now() - 1m'
   | 'now() - 5m'
   | 'now() - 15m'
   | 'now() - 1h'


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/21721

add's 1m to the time range selector.
