### PR TITLE
fix: maps lat/lon columns as float should display in dropdown

### DIFF
--- a/src/visualization/types/Map/utils.ts
+++ b/src/visualization/types/Map/utils.ts
@@ -4,7 +4,7 @@ import _ from 'lodash'
 export const findTags = (table: Table, latLon: boolean = false) => {
   return table.columnKeys.reduce((acc, k) => {
     const columnType = table.getColumnType(k)
-    if (columnType === 'number' || columnType === 'time') {
+    if (columnType === 'time') {
       return acc
     }
 


### PR DESCRIPTION
Closes #1817 

<!-- Describe your proposed changes here. -->
For the dropdown, the function was excluding all number types of tags. This pr removes that condition so that when lat/lon as tags are given as floats/numbers, it can be displayed in the dropdown for customization options.