### PR TITLE
fix: simple table 0 of undefined and pagination bugs

### DIFF
--- a/cypress/e2e/shared/simpleTable.test.ts
+++ b/cypress/e2e/shared/simpleTable.test.ts
@@ -87,4 +87,70 @@ describe('simple table interactions', () => {
       .last()
       .contains('10')
   })
+
+  it('should render correctly after switching from a dataset with fewer pages to one with more', () => {
+    cy.getByTestID('query-builder').should('exist')
+
+    // show raw data view of data with 10 pages
+    cy.getByTestID(`selector-list ${simpleSmall}`).should('be.visible')
+    cy.getByTestID(`selector-list ${simpleSmall}`).click()
+
+    cy.getByTestID('selector-list m').should('be.visible')
+    cy.getByTestID('selector-list m').clickAttached()
+
+    cy.getByTestID('selector-list v').should('be.visible')
+    cy.getByTestID('selector-list v').clickAttached()
+
+    cy.getByTestID('selector-list tv1').clickAttached()
+
+    cy.getByTestID('time-machine-submit-button').click()
+
+    cy.getByTestID('raw-data--toggle').click()
+    cy.getByTestID('simple-table').should('exist')
+
+    // click last page
+    cy.getByTestID('pagination-item')
+      .last()
+      .should('be.visible')
+    cy.getByTestID('pagination-item')
+      .last()
+      .click()
+    // verify correct number of pages
+    cy.getByTestID('pagination-item')
+      .last()
+      .contains('10')
+
+    // show raw data view of data with 100 pages
+    cy.getByTestID(`selector-list ${simpleLarge}`).should('be.visible')
+    cy.getByTestID(`selector-list ${simpleLarge}`).click()
+
+    cy.getByTestID('selector-list m').should('be.visible')
+    cy.getByTestID('selector-list m').clickAttached()
+
+    cy.getByTestID('selector-list v').should('be.visible')
+    cy.getByTestID('selector-list v').clickAttached()
+
+    cy.getByTestID('selector-list tv1').clickAttached()
+
+    cy.getByTestID('time-machine-submit-button').click()
+
+    // verify table still exists
+    cy.getByTestID('simple-table').should('exist')
+    // verify page 1 is selected
+    cy.getByTestID('pagination-item')
+      .first()
+      .within(() => {
+        cy.getByTestID('button').should(
+          'have.class',
+          'cf-button cf-button-md cf-button-tertiary cf-button-square active'
+        )
+      })
+    // verify correct number of pages
+    cy.getByTestID('pagination-item')
+      .last()
+      .should('be.visible')
+    cy.getByTestID('pagination-item')
+      .last()
+      .contains('100')
+  })
 })

--- a/cypress/e2e/shared/simpleTable.test.ts
+++ b/cypress/e2e/shared/simpleTable.test.ts
@@ -4,6 +4,7 @@ import {lines} from '../../support/commands'
 describe('simple table interactions', () => {
   const simpleSmall = 'simple-small'
   const simpleLarge = 'simple-large'
+  const simpleOverflow = 'simple-overflow'
   beforeEach(() => {
     cy.flush()
     cy.signin().then(() => {
@@ -15,6 +16,8 @@ describe('simple table interactions', () => {
           cy.writeData(lines(300), simpleLarge)
           cy.createBucket(orgID, name, simpleSmall)
           cy.writeData(lines(30), simpleSmall)
+          cy.createBucket(orgID, name, simpleOverflow)
+          cy.writeData(lines(31), simpleOverflow)
           cy.reload()
           cy.setFeatureFlags({simpleTable: true})
         })
@@ -152,5 +155,41 @@ describe('simple table interactions', () => {
     cy.getByTestID('pagination-item')
       .last()
       .contains('100')
+  })
+
+  it('should not duplicate records from the n-1 page on the nth page', () => {
+    cy.getByTestID('query-builder').should('exist')
+
+    // show raw data view of data with 10 pages
+    cy.getByTestID(`selector-list ${simpleOverflow}`).should('be.visible')
+    cy.getByTestID(`selector-list ${simpleOverflow}`).click()
+
+    cy.getByTestID('selector-list m').should('be.visible')
+    cy.getByTestID('selector-list m').clickAttached()
+
+    cy.getByTestID('selector-list v').should('be.visible')
+    cy.getByTestID('selector-list v').clickAttached()
+
+    cy.getByTestID('selector-list tv1').clickAttached()
+
+    cy.getByTestID('time-machine-submit-button').click()
+
+    cy.getByTestID('raw-data--toggle').click()
+    cy.getByTestID('simple-table').should('exist')
+
+    // click last page
+    cy.getByTestID('pagination-item')
+      .last()
+      .should('be.visible')
+    cy.getByTestID('pagination-item')
+      .last()
+      .click()
+    // verify correct number of pages
+    cy.getByTestID('pagination-item')
+      .last()
+      .contains('11')
+    // verify only record 31 is on last page
+    cy.getByTestID('table-cell 30').should('not.exist')
+    cy.getByTestID('table-cell 31').should('be.visible')
   })
 })

--- a/src/visualization/context/pagination.tsx
+++ b/src/visualization/context/pagination.tsx
@@ -1,27 +1,35 @@
 import React, {FC, createContext, useState, useCallback} from 'react'
-
+import {
+  calcOffset,
+  calcNextPageOffset,
+  calcPrevPageOffset,
+} from '../utils/paginationUtils'
 interface PaginationContextType {
   offset: number // the start index
   size: number // the size of the page
   total: number // the total number of entries
+  totalPages: number // the total number of pages
 
   next: () => void
   previous: () => void
 
   setSize: (size: number) => void
   setPage: (page: number) => void
+  setTotalPages: (totalPages: number) => void
 }
 
 const DEFAULT_CONTEXT: PaginationContextType = {
   offset: 0,
   size: 0,
   total: 0,
+  totalPages: 0,
 
   next: () => {},
   previous: () => {},
 
   setSize: (_size: number) => {},
   setPage: (_page: number) => {},
+  setTotalPages: (_totalPages: number) => {},
 }
 
 export const PaginationContext = createContext<PaginationContextType>(
@@ -38,24 +46,23 @@ export const PaginationProvider: FC<PaginationProviderProps> = ({
 }) => {
   const [offset, setOffset] = useState(DEFAULT_CONTEXT.offset)
   const [size, setSize] = useState(DEFAULT_CONTEXT.size)
+  const [totalPages, setTotalPages] = useState(DEFAULT_CONTEXT.totalPages)
 
   const next = useCallback(() => {
     if (total) {
-      setOffset(Math.min(offset + size, total - size))
+      setOffset(calcNextPageOffset(offset, size, total))
     } else {
       setOffset(offset + size)
     }
   }, [offset, size, setOffset])
 
   const previous = useCallback(() => {
-    setOffset(Math.max(offset - size, 0))
+    setOffset(calcPrevPageOffset(offset, size))
   }, [offset, size, setOffset])
 
   const setPage = useCallback(
     (page: number) => {
-      setOffset(
-        Math.min(Math.max(0, (page - 1) * size), Math.max(0, total - size))
-      )
+      setOffset(calcOffset(page, size, total))
     },
     [offset, size, setOffset]
   )
@@ -66,10 +73,12 @@ export const PaginationProvider: FC<PaginationProviderProps> = ({
         offset,
         size,
         total,
+        totalPages,
         next,
         previous,
         setSize,
         setPage,
+        setTotalPages,
       }}
     >
       {children}

--- a/src/visualization/context/pagination.tsx
+++ b/src/visualization/context/pagination.tsx
@@ -53,7 +53,9 @@ export const PaginationProvider: FC<PaginationProviderProps> = ({
 
   const setPage = useCallback(
     (page: number) => {
-      setOffset(Math.min(Math.max(0, (page - 1) * size), total - size))
+      setOffset(
+        Math.min(Math.max(0, (page - 1) * size), Math.max(0, total - size))
+      )
     },
     [offset, size, setOffset]
   )

--- a/src/visualization/types/SimpleTable/PageControl.tsx
+++ b/src/visualization/types/SimpleTable/PageControl.tsx
@@ -6,8 +6,9 @@ import {PaginationContext} from 'src/visualization/context/pagination'
 import {PaginationNav} from '@influxdata/clockface'
 
 const PageControl: FC = () => {
-  const {offset, size, total, setPage} = useContext(PaginationContext)
-
+  const {offset, size, total, totalPages, setPage} = useContext(
+    PaginationContext
+  )
   return (
     <div className="visualization--simple-table--paging">
       <span className="visualization--simple-table--paging-label">
@@ -15,8 +16,8 @@ const PageControl: FC = () => {
       </span>
       {total && size && (
         <PaginationNav.PaginationNav
-          totalPages={Math.ceil(total / size)}
-          currentPage={Math.floor(offset / size) + 1}
+          totalPages={totalPages}
+          currentPage={Math.min(Math.floor(offset / size) + 1, totalPages)}
           pageRangeOffset={1}
           onChange={setPage}
         />

--- a/src/visualization/types/SimpleTable/PagedTable.tsx
+++ b/src/visualization/types/SimpleTable/PagedTable.tsx
@@ -221,7 +221,9 @@ interface Props {
 }
 
 const PagedTable: FC<Props> = ({result, properties}) => {
-  const {offset, setSize, setPage} = useContext(PaginationContext)
+  const {offset, setSize, setPage, setTotalPages} = useContext(
+    PaginationContext
+  )
   const [height, setHeight] = useState(0)
   const ref = useRef()
 
@@ -276,6 +278,12 @@ const PagedTable: FC<Props> = ({result, properties}) => {
   useEffect(() => {
     setPage(1)
   }, [result])
+
+  useEffect(() => {
+    if (size) {
+      setTotalPages(Math.ceil((result?.table?.length ?? 0) / size))
+    }
+  }, [height, result])
 
   const inner = tables.map((t, tIdx) => (
     <InnerTable table={t} key={`table${tIdx}`} />

--- a/src/visualization/utils/paginationUtils.test.ts
+++ b/src/visualization/utils/paginationUtils.test.ts
@@ -1,0 +1,45 @@
+import {
+  calcNextPageOffset,
+  calcPrevPageOffset,
+  calcOffset,
+} from './paginationUtils'
+describe('pagination utils tests', () => {
+  describe('calcOffset', () => {
+    it('page: 1, size: 1, total: 1', () => {
+      expect(calcOffset(1, 1, 1)).toBe(0)
+    })
+    it('page: 1, size: 2, total: 3', () => {
+      expect(calcOffset(1, 2, 3)).toBe(0)
+    })
+    it('page: 2, size: 2, total: 3', () => {
+      expect(calcOffset(2, 2, 3)).toBe(2)
+    })
+    it('page: 1, size: 3, total: 2', () => {
+      expect(calcOffset(1, 3, 2)).toBe(0)
+    })
+  })
+
+  describe('calcNextPageOffset', () => {
+    it('offset: 0, size: 1, total: 1', () => {
+      expect(calcNextPageOffset(0, 1, 1)).toBe(0)
+    })
+    it('offset: 2, size: 2, total: 3', () => {
+      expect(calcNextPageOffset(2, 2, 3)).toBe(1)
+    })
+    it('offset: 3, size: 2, total: 6', () => {
+      expect(calcNextPageOffset(3, 2, 6)).toBe(4)
+    })
+  })
+
+  describe('calcPrevPageOffset', () => {
+    it('offset: 0, size: 1', () => {
+      expect(calcPrevPageOffset(0, 1)).toBe(0)
+    })
+    it('offset: 2, size: 2', () => {
+      expect(calcPrevPageOffset(2, 2)).toBe(0)
+    })
+    it('offset: 6, size: 2', () => {
+      expect(calcPrevPageOffset(6, 2)).toBe(4)
+    })
+  })
+})

--- a/src/visualization/utils/paginationUtils.test.ts
+++ b/src/visualization/utils/paginationUtils.test.ts
@@ -24,10 +24,13 @@ describe('pagination utils tests', () => {
       expect(calcNextPageOffset(0, 1, 1)).toBe(0)
     })
     it('offset: 2, size: 2, total: 3', () => {
-      expect(calcNextPageOffset(2, 2, 3)).toBe(1)
+      expect(calcNextPageOffset(2, 2, 3)).toBe(2)
     })
-    it('offset: 3, size: 2, total: 6', () => {
-      expect(calcNextPageOffset(3, 2, 6)).toBe(4)
+    it('offset: 2, size: 2, total: 6', () => {
+      expect(calcNextPageOffset(2, 2, 6)).toBe(4)
+    })
+    it('offset: 4, size: 2, total: 6', () => {
+      expect(calcNextPageOffset(4, 2, 6)).toBe(4)
     })
   })
 

--- a/src/visualization/utils/paginationUtils.ts
+++ b/src/visualization/utils/paginationUtils.ts
@@ -1,0 +1,11 @@
+export const calcOffset = (page: number, size: number, total: number) =>
+  Math.min(Math.max(0, (page - 1) * size), total - 1)
+
+export const calcNextPageOffset = (
+  offset: number,
+  size: number,
+  total: number
+) => Math.min(offset + size, total - size)
+
+export const calcPrevPageOffset = (offset: number, size: number) =>
+  Math.max(offset - size, 0)

--- a/src/visualization/utils/paginationUtils.ts
+++ b/src/visualization/utils/paginationUtils.ts
@@ -5,7 +5,7 @@ export const calcNextPageOffset = (
   offset: number,
   size: number,
   total: number
-) => Math.min(offset + size, total - size)
+) => (total <= offset + size ? offset : offset + size)
 
 export const calcPrevPageOffset = (offset: number, size: number) =>
   Math.max(offset - size, 0)


### PR DESCRIPTION
Closes #1813 and #1714

The original issues are resolved simply by changing the offset calculation to prevent the offset from becoming -1. However, this bug highlighted another issue with simpletable where the records from the `n-1` page were duplicated on the `nth` page. The solution to that was to set the `totalPages` variable whenever the result set changes or the height of the table changes. We cannot calculate the `totalPages` using `size` and `offset` because those numbers change as each page is rendered and not all pages show the same number of records.

I added unit and cypress tests
