### PR TITLE
feat: TimeZone aware DateTime formatter component

### DIFF
--- a/src/tasks/components/RunLogRow.tsx
+++ b/src/tasks/components/RunLogRow.tsx
@@ -1,13 +1,15 @@
 // Libraries
-import React, {PureComponent} from 'react'
+import React, {PureComponent, ReactElement} from 'react'
 
 // Components
 import {IndexList} from '@influxdata/clockface'
 
 // Types
 import {LogEvent} from 'src/types'
+
+// DateTime
 import {DEFAULT_TIME_FORMAT} from 'src/shared/constants'
-import {createDateTimeFormatter} from 'src/utils/datetime/formatters'
+import {FormattedDateTime} from 'src/utils/datetime/FormattedDateTime'
 
 interface Props {
   log: LogEvent
@@ -35,17 +37,14 @@ class RunLogRow extends PureComponent<Props> {
     )
   }
 
-  private dateTimeString(dt: string): string {
+  private dateTimeString(dt: string): ReactElement {
     if (!dt) {
-      return ''
+      return null
     }
 
-    const newdate = new Date(dt)
-    const formatted = createDateTimeFormatter(DEFAULT_TIME_FORMAT).format(
-      newdate
+    return (
+      <FormattedDateTime format={DEFAULT_TIME_FORMAT} date={new Date(dt)} />
     )
-
-    return formatted
   }
 }
 

--- a/src/tasks/components/TaskRunsRow.tsx
+++ b/src/tasks/components/TaskRunsRow.tsx
@@ -1,12 +1,12 @@
 // Libraries
-import React, {PureComponent} from 'react'
+import React, {PureComponent, ReactElement} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import moment from 'moment'
 
 // Components
 import {Overlay, IndexList, FlexBox} from '@influxdata/clockface'
 import RunLogsOverlay from 'src/tasks/components/RunLogsList'
+import {FormattedDateTime} from 'src/utils/datetime/FormattedDateTime'
 
 // Actions
 import {getLogs, retryTask} from 'src/tasks/actions/thunks'
@@ -70,20 +70,13 @@ class TaskRunsRow extends PureComponent<Props, State> {
     )
   }
 
-  private dateTimeString(dt: string): string {
+  private dateTimeString(dt: string): ReactElement {
     if (!dt) {
-      return ''
+      return null
     }
-    const newdate = new Date(dt)
-    const {timeZone} = this.props
-    const formatted =
-      timeZone === 'UTC'
-        ? moment(newdate)
-            .utc()
-            .format(DEFAULT_TIME_FORMAT)
-        : moment(newdate).format(DEFAULT_TIME_FORMAT)
-
-    return formatted
+    return (
+      <FormattedDateTime format={DEFAULT_TIME_FORMAT} date={new Date(dt)} />
+    )
   }
 
   private handleToggleOverlay = () => {

--- a/src/utils/datetime/FormattedDateTime.test.tsx
+++ b/src/utils/datetime/FormattedDateTime.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react'
+import {screen, waitFor} from '@testing-library/react'
+
+import {renderWithRedux} from 'src/mockState'
+import {FormattedDateTime} from 'src/utils/datetime/FormattedDateTime'
+
+import {setTimeZone} from 'src/shared/actions/app'
+
+import {DEFAULT_TIME_FORMAT} from 'src/shared/constants/index'
+
+const timestamp = 426196800000 // july 4th, 1983
+
+describe('the FormattedDateTime component', () => {
+  describe("being aware of the user's preferred timezone", () => {
+    it('formats dates in UTC times', () => {
+      renderWithRedux(
+        <FormattedDateTime
+          format={DEFAULT_TIME_FORMAT}
+          date={new Date(timestamp)}
+        />,
+        state => {
+          return {
+            ...state,
+            app: {
+              persisted: {
+                timeZone: 'UTC',
+              },
+            },
+          }
+        }
+      )
+      screen.getByText('1983-07-04 20:00:00')
+    })
+
+    it.skip('formats dates in local times and will handle state changes (spec will only work in local tests, not in ci)', async () => {
+      const {store} = renderWithRedux(
+        <FormattedDateTime
+          format={DEFAULT_TIME_FORMAT}
+          date={new Date(timestamp)}
+        />,
+        state => {
+          return {
+            ...state,
+            app: {
+              persisted: {
+                timeZone: 'America/Los_Angeles',
+              },
+            },
+          }
+        }
+      )
+      screen.getByText('1983-07-04 13:00:00')
+      await store.dispatch(setTimeZone('UTC'))
+
+      await waitFor(() => {
+        screen.getByText('1983-07-04 20:00:00')
+      })
+    })
+  })
+})

--- a/src/utils/datetime/FormattedDateTime.tsx
+++ b/src/utils/datetime/FormattedDateTime.tsx
@@ -1,0 +1,21 @@
+import React, {FC, ReactElement} from 'react'
+import {useSelector} from 'react-redux'
+
+import {timeZone} from 'src/shared/selectors/app'
+
+import {createDateTimeFormatter} from 'src/utils/datetime/formatters'
+
+interface Props {
+  format: string
+  date: Date
+}
+
+/*
+ * This component is a higher level wrapper around the core formatting functionality.
+ * It is aware of the user's preference for timezone, either local or UTC
+ */
+export const FormattedDateTime: FC<Props> = (props): ReactElement => {
+  const formatter = createDateTimeFormatter(props.format, useSelector(timeZone))
+
+  return <>{formatter.format(props.date)}</>
+}

--- a/src/utils/datetime/formatters.ts
+++ b/src/utils/datetime/formatters.ts
@@ -1,5 +1,7 @@
 // TODO: handle these any types
 
+import {TimeZone} from 'src/types'
+
 const dateTimeOptions: any = {
   hour12: true,
   day: '2-digit',
@@ -17,7 +19,10 @@ const timeOptions: any = {
   second: 'numeric',
 }
 
-export const createDateTimeFormatter = (format, timeZone = 'local') => {
+export const createDateTimeFormatter = (
+  format: string,
+  timeZone: TimeZone = 'Local'
+) => {
   switch (format) {
     default:
     case 'YYYY-MM-DD hh:mm:ss a': {
@@ -25,7 +30,7 @@ export const createDateTimeFormatter = (format, timeZone = 'local') => {
         ...dateTimeOptions,
       }
 
-      if (timeZone.toLowerCase() === 'utc') {
+      if (timeZone === 'UTC') {
         options.timeZone = 'UTC'
       }
 
@@ -54,7 +59,7 @@ export const createDateTimeFormatter = (format, timeZone = 'local') => {
         timeZoneName: 'short',
       }
 
-      if (timeZone.toLowerCase() === 'utc') {
+      if (timeZone === 'UTC') {
         options.timeZone = 'UTC'
       }
 
@@ -84,7 +89,7 @@ export const createDateTimeFormatter = (format, timeZone = 'local') => {
         hour12: false,
       }
 
-      if (timeZone.toLowerCase() === 'utc') {
+      if (timeZone === 'UTC') {
         options.timeZone = 'UTC'
       }
       const formatter = Intl.DateTimeFormat('en-us', options)
@@ -113,7 +118,7 @@ export const createDateTimeFormatter = (format, timeZone = 'local') => {
         hour12: false,
       }
 
-      if (timeZone.toLowerCase() === 'utc') {
+      if (timeZone === 'UTC') {
         options.timeZone = 'UTC'
       }
       const formatter = Intl.DateTimeFormat('en-us', options)
@@ -143,7 +148,7 @@ export const createDateTimeFormatter = (format, timeZone = 'local') => {
         hour12: false,
       }
 
-      if (timeZone.toLowerCase() === 'utc') {
+      if (timeZone === 'UTC') {
         options.timeZone = 'UTC'
       }
       const formatter = Intl.DateTimeFormat('en-us', options)
@@ -172,7 +177,7 @@ export const createDateTimeFormatter = (format, timeZone = 'local') => {
         fractionalSecondDigits: 3,
       }
 
-      if (timeZone.toLowerCase() === 'utc') {
+      if (timeZone === 'UTC') {
         options.timeZone = 'UTC'
       }
       const formatter = Intl.DateTimeFormat('en-us', options)
@@ -202,7 +207,7 @@ export const createDateTimeFormatter = (format, timeZone = 'local') => {
         fractionalSecondDigits: 3,
       }
 
-      if (timeZone.toLowerCase() === 'utc') {
+      if (timeZone === 'UTC') {
         options.timeZone = 'UTC'
       }
       const formatter = Intl.DateTimeFormat('en-us', options)
@@ -231,7 +236,7 @@ export const createDateTimeFormatter = (format, timeZone = 'local') => {
         fractionalSecondDigits: 3,
       }
 
-      if (timeZone.toLowerCase() === 'utc') {
+      if (timeZone === 'UTC') {
         options.timeZone = 'UTC'
       }
       const formatter = Intl.DateTimeFormat('en-us', options)
@@ -260,7 +265,7 @@ export const createDateTimeFormatter = (format, timeZone = 'local') => {
         hour12: false,
       }
 
-      if (timeZone.toLowerCase() === 'utc') {
+      if (timeZone === 'UTC') {
         options.timeZone = 'UTC'
       }
       const formatter = Intl.DateTimeFormat('en-us', options)
@@ -288,7 +293,7 @@ export const createDateTimeFormatter = (format, timeZone = 'local') => {
         ...dateTimeOptions,
       }
 
-      if (timeZone.toLowerCase() === 'utc') {
+      if (timeZone === 'UTC') {
         options.timeZone = 'UTC'
       }
       const formatter = Intl.DateTimeFormat('en-us', options)
@@ -321,7 +326,7 @@ export const createDateTimeFormatter = (format, timeZone = 'local') => {
         hour12: false,
       }
 
-      if (timeZone.toLowerCase() === 'utc') {
+      if (timeZone === 'UTC') {
         options.timeZone = 'UTC'
       }
       const formatter = Intl.DateTimeFormat('en-us', options)
@@ -351,7 +356,7 @@ export const createDateTimeFormatter = (format, timeZone = 'local') => {
         day: 'numeric',
       }
 
-      if (timeZone.toLowerCase() === 'utc') {
+      if (timeZone === 'UTC') {
         options.timeZone = 'UTC'
       }
       const formatter = Intl.DateTimeFormat('en-us', options)
@@ -383,7 +388,7 @@ export const createDateTimeFormatter = (format, timeZone = 'local') => {
         hour12: false,
       }
 
-      if (timeZone.toLowerCase() === 'utc') {
+      if (timeZone === 'UTC') {
         options.timeZone = 'UTC'
       }
       const formatter = Intl.DateTimeFormat('en-us', options)
@@ -414,7 +419,7 @@ export const createDateTimeFormatter = (format, timeZone = 'local') => {
         weekday: 'long',
       }
 
-      if (timeZone.toLowerCase() === 'utc') {
+      if (timeZone === 'UTC') {
         options.timeZone = 'UTC'
       }
       const formatter = Intl.DateTimeFormat('en-us', options)
@@ -445,7 +450,7 @@ export const createDateTimeFormatter = (format, timeZone = 'local') => {
         hour12: false,
       }
 
-      if (timeZone.toLowerCase() === 'utc') {
+      if (timeZone === 'UTC') {
         options.timeZone = 'UTC'
       }
       const formatter = Intl.DateTimeFormat('en-us', options)
@@ -473,7 +478,7 @@ export const createDateTimeFormatter = (format, timeZone = 'local') => {
         ...timeOptions,
       }
 
-      if (timeZone.toLowerCase() === 'utc') {
+      if (timeZone === 'UTC') {
         options.timeZone = 'UTC'
       }
       const formatter = Intl.DateTimeFormat('en-us', options)
@@ -502,7 +507,7 @@ export const createDateTimeFormatter = (format, timeZone = 'local') => {
         hour12: false,
       }
 
-      if (timeZone.toLowerCase() === 'utc') {
+      if (timeZone === 'UTC') {
         options.timeZone = 'UTC'
       }
       const formatter = Intl.DateTimeFormat('en-us', options)
@@ -530,7 +535,7 @@ export const createDateTimeFormatter = (format, timeZone = 'local') => {
         ...timeOptions,
       }
 
-      if (timeZone.toLowerCase() === 'utc') {
+      if (timeZone === 'UTC') {
         options.timeZone = 'UTC'
       }
       const formatter = Intl.DateTimeFormat('en-us', options)
@@ -560,7 +565,7 @@ export const createDateTimeFormatter = (format, timeZone = 'local') => {
         timeZoneName: 'short',
       }
 
-      if (timeZone.toLowerCase() === 'utc') {
+      if (timeZone === 'UTC') {
         options.timeZone = 'UTC'
       }
       const formatter = Intl.DateTimeFormat('en-us', options)
@@ -589,7 +594,7 @@ export const createDateTimeFormatter = (format, timeZone = 'local') => {
         timeZoneName: 'short',
       }
 
-      if (timeZone.toLowerCase() === 'utc') {
+      if (timeZone === 'UTC') {
         options.timeZone = 'UTC'
       }
       const formatter = Intl.DateTimeFormat('en-us', options)
@@ -619,7 +624,7 @@ export const createDateTimeFormatter = (format, timeZone = 'local') => {
         fractionalSecondDigits: 3,
       }
 
-      if (timeZone.toLowerCase() === 'utc') {
+      if (timeZone === 'UTC') {
         options.timeZone = 'UTC'
       }
       const formatter = Intl.DateTimeFormat('en-us', options)
@@ -648,7 +653,7 @@ export const createDateTimeFormatter = (format, timeZone = 'local') => {
         fractionalSecondDigits: 3,
       }
 
-      if (timeZone.toLowerCase() === 'utc') {
+      if (timeZone === 'UTC') {
         options.timeZone = 'UTC'
       }
       const formatter = Intl.DateTimeFormat('en-us', options)


### PR DESCRIPTION
Closes #1856

* Creates a new component that handles the user's timezone (local | UTC) preference
* Replaces moment instance of this in `TaskRuns`
* Adds this functionality to `TaskRunsLog`
