### PR TITLE
fix: task runs card's created by shows creator of task

### DIFF
--- a/mocks/dummyData.ts
+++ b/mocks/dummyData.ts
@@ -244,6 +244,7 @@ export const tasks: Task[] = [
     cron: '2 0 * * *',
     org: 'default',
     labels: [],
+    createdAt: '2021-06-08T00:25:17.501582756Z'
   },
   {
     id: '02f12c50dba72000',
@@ -255,6 +256,7 @@ export const tasks: Task[] = [
     every: '1m0s',
     org: 'default',
     labels: labelIDs,
+    createdAt: '2021-06-08T00:25:17.501582756Z'
   },
 ]
 

--- a/mocks/dummyData.ts
+++ b/mocks/dummyData.ts
@@ -244,7 +244,7 @@ export const tasks: Task[] = [
     cron: '2 0 * * *',
     org: 'default',
     labels: [],
-    createdAt: '2021-06-08T00:25:17.501582756Z'
+    createdAt: '2021-06-08T00:25:17.501582756Z',
     latestCompleted: '2021-06-08T02:25:52.118899855Z',
   },
   {
@@ -257,7 +257,7 @@ export const tasks: Task[] = [
     every: '1m0s',
     org: 'default',
     labels: labelIDs,
-    createdAt: '2021-06-08T00:25:17.501582756Z'
+    createdAt: '2021-06-08T00:25:17.501582756Z',
     latestCompleted: '2021-06-08T02:25:52.118899855Z',
   },
 ]

--- a/src/tasks/components/TaskRunsCard.tsx
+++ b/src/tasks/components/TaskRunsCard.tsx
@@ -94,7 +94,9 @@ class UnconnectedTaskRunsCard extends PureComponent<
   private get ownerName(): string {
     const {task, members} = this.props
 
-    if (members[task.ownerID]) return members[task.ownerID].name
+    if (members[task.ownerID]) {
+      return members[task.ownerID].name
+    }
     return ''
   }
 

--- a/src/tasks/components/TaskRunsCard.tsx
+++ b/src/tasks/components/TaskRunsCard.tsx
@@ -55,6 +55,7 @@ class UnconnectedTaskRunsCard extends PureComponent<
     if (!task) {
       return null
     }
+
     return (
       <ResourceCard
         testID="task-runs-task-card"

--- a/src/tasks/components/TaskRunsCard.tsx
+++ b/src/tasks/components/TaskRunsCard.tsx
@@ -76,7 +76,13 @@ class UnconnectedTaskRunsCard extends PureComponent<
           <ResourceCard.Name name={task.name} testID="task-card--name" />
           <ResourceCard.Meta>
             {this.activeToggle}
-            <>Created at: <FormattedDateTime format={DEFAULT_TIME_FORMAT} date={new Date(task.createdAt)}/></>
+            <>
+              Created at:{' '}
+              <FormattedDateTime
+                format={DEFAULT_TIME_FORMAT}
+                date={new Date(task.createdAt)}
+              />
+            </>
             <>Created by: {this.ownerName}</>
             <>Last Used: {moment(task.latestCompleted).fromNow()}</>
             <>{task.org}</>

--- a/src/tasks/components/TaskRunsCard.tsx
+++ b/src/tasks/components/TaskRunsCard.tsx
@@ -16,13 +16,19 @@ import {
   JustifyContent,
 } from '@influxdata/clockface'
 
-// Actions
+// Actions For Tasks
 import {
   addTaskLabel,
   deleteTaskLabel,
   runTask,
   getRuns,
 } from 'src/tasks/actions/thunks'
+
+// Actions For Members
+import {
+  getMembers,
+} from 'src/members/actions/thunks'
+
 import {TaskPage, setCurrentTasksPage} from 'src/tasks/actions/creators'
 
 // Types
@@ -41,13 +47,16 @@ type Props = PassedProps & ReduxProps
 class UnconnectedTaskRunsCard extends PureComponent<
   Props & RouteComponentProps<{orgID: string; id: string}>
 > {
+  componentDidMount() {
+    this.props.getMembers();
+  }
+
   public render() {
     const {task} = this.props
 
     if (!task) {
       return null
     }
-
     return (
       <ResourceCard
         testID="task-runs-task-card"
@@ -66,7 +75,7 @@ class UnconnectedTaskRunsCard extends PureComponent<
           <ResourceCard.Meta>
             {this.activeToggle}
             <>Created at: {task.createdAt}</>
-            <>Created by: {task.name}</>
+            <>Created by: {this.ownerName}</>
             <>Last Used: {moment(task.latestCompleted).fromNow()}</>
             <>{task.org}</>
           </ResourceCard.Meta>
@@ -82,6 +91,13 @@ class UnconnectedTaskRunsCard extends PureComponent<
         </FlexBox>
       </ResourceCard>
     )
+  }
+
+  private get ownerName(): string {
+    const { task, members } = this.props;
+
+    if (members[task.ownerID]) return members[task.ownerID].name;
+    return '';
   }
 
   private get activeToggle(): JSX.Element {
@@ -137,10 +153,12 @@ class UnconnectedTaskRunsCard extends PureComponent<
 
 const mstp = (state: AppState) => {
   const {runs, runStatus} = state.resources.tasks
+  const {byID} = state.resources.members
 
   return {
     runs,
     runStatus,
+    members: byID,
   }
 }
 
@@ -150,6 +168,7 @@ const mdtp = {
   onRunTask: runTask,
   getRuns,
   setCurrentTasksPage,
+  getMembers,
 }
 
 const connector = connect(mstp, mdtp)

--- a/src/tasks/components/TaskRunsCard.tsx
+++ b/src/tasks/components/TaskRunsCard.tsx
@@ -58,7 +58,6 @@ class UnconnectedTaskRunsCard extends PureComponent<
     if (!task) {
       return null
     }
-
     return (
       <ResourceCard
         testID="task-runs-task-card"

--- a/src/tasks/components/TaskRunsCard.tsx
+++ b/src/tasks/components/TaskRunsCard.tsx
@@ -15,7 +15,6 @@ import {
   JustifyContent,
 } from '@influxdata/clockface'
 
-
 // Actions For Tasks
 import {relativeTimestampFormatter} from 'src/shared/utils/relativeTimestampFormatter'
 

--- a/src/tasks/components/TaskRunsCard.tsx
+++ b/src/tasks/components/TaskRunsCard.tsx
@@ -25,9 +25,7 @@ import {
 } from 'src/tasks/actions/thunks'
 
 // Actions For Members
-import {
-  getMembers,
-} from 'src/members/actions/thunks'
+import {getMembers} from 'src/members/actions/thunks'
 
 import {TaskPage, setCurrentTasksPage} from 'src/tasks/actions/creators'
 
@@ -48,7 +46,7 @@ class UnconnectedTaskRunsCard extends PureComponent<
   Props & RouteComponentProps<{orgID: string; id: string}>
 > {
   componentDidMount() {
-    this.props.getMembers();
+    this.props.getMembers()
   }
 
   public render() {
@@ -94,10 +92,10 @@ class UnconnectedTaskRunsCard extends PureComponent<
   }
 
   private get ownerName(): string {
-    const { task, members } = this.props;
+    const {task, members} = this.props
 
-    if (members[task.ownerID]) return members[task.ownerID].name;
-    return '';
+    if (members[task.ownerID]) return members[task.ownerID].name
+    return ''
   }
 
   private get activeToggle(): JSX.Element {

--- a/src/tasks/components/TaskRunsCard.tsx
+++ b/src/tasks/components/TaskRunsCard.tsx
@@ -33,6 +33,9 @@ import {TaskPage, setCurrentTasksPage} from 'src/tasks/actions/creators'
 import {ComponentColor, Button} from '@influxdata/clockface'
 import {Task, AppState} from 'src/types'
 
+// DateTime
+import {DEFAULT_TIME_FORMAT} from 'src/shared/constants'
+import {FormattedDateTime} from 'src/utils/datetime/FormattedDateTime'
 interface PassedProps {
   task: Task
   onActivate: (task: Task) => void
@@ -73,7 +76,7 @@ class UnconnectedTaskRunsCard extends PureComponent<
           <ResourceCard.Name name={task.name} testID="task-card--name" />
           <ResourceCard.Meta>
             {this.activeToggle}
-            <>Created at: {task.createdAt}</>
+            <>Created at: <FormattedDateTime format={DEFAULT_TIME_FORMAT} date={new Date(task.createdAt)}/></>
             <>Created by: {this.ownerName}</>
             <>Last Used: {moment(task.latestCompleted).fromNow()}</>
             <>{task.org}</>

--- a/src/tasks/components/TaskRunsPage.test.tsx
+++ b/src/tasks/components/TaskRunsPage.test.tsx
@@ -18,10 +18,6 @@ import {RemoteDataState} from 'src/types'
 import {DEFAULT_TIME_FORMAT} from 'src/shared/constants'
 import {createDateTimeFormatter} from 'src/utils/datetime/formatters'
 
-// DateTime
-import {DEFAULT_TIME_FORMAT} from 'src/shared/constants'
-import {createDateTimeFormatter} from 'src/utils/datetime/formatters'
-
 const runIDs = [
   '07a7f99e81cf2000',
   '07a7f99e81cf3000',

--- a/src/tasks/components/TaskRunsPage.test.tsx
+++ b/src/tasks/components/TaskRunsPage.test.tsx
@@ -168,45 +168,45 @@ const dummyTaskRuns: Array<Run> = [
 ]
 
 const dummyMembers = {
-	"links": {
-		"self": "/api/v2/orgs/c407211f02faa1ef/members"
-	},
-	"users": []
+  links: {
+    self: '/api/v2/orgs/c407211f02faa1ef/members',
+  },
+  users: [],
 }
 
 const dummyOwners = {
-	"links": {
-		"self": "/api/v2/orgs/c407211f02faa1ef/owners"
-	},
-	"users": [
-		{
-			"role": "owner",
-			"links": {
-				"self": "/api/v2/users/07aee60ba0658000"
-			},
-			"id": "07aee60ba0658000",
-			"name": "idpe-admin",
-			"status": "active"
-		},
-		{
-			"role": "owner",
-			"links": {
-				"self": "/api/v2/users/07aee61007a58000"
-			},
-			"id": "07aee61007a58000",
-			"name": "mcfly@influxdata.com",
-			"status": "active"
-		},
-		{
-			"role": "owner",
-			"links": {
-				"self": "/api/v2/users/07aee6106d658000"
-			},
-			"id": "07aee6106d658000",
-			"name": "orgc407211f02faa1ef-user-20070",
-			"status": "active"
-		}
-	]
+  links: {
+    self: '/api/v2/orgs/c407211f02faa1ef/owners',
+  },
+  users: [
+    {
+      role: 'owner',
+      links: {
+        self: '/api/v2/users/07aee60ba0658000',
+      },
+      id: '07aee60ba0658000',
+      name: 'idpe-admin',
+      status: 'active',
+    },
+    {
+      role: 'owner',
+      links: {
+        self: '/api/v2/users/07aee61007a58000',
+      },
+      id: '07aee61007a58000',
+      name: 'mcfly@influxdata.com',
+      status: 'active',
+    },
+    {
+      role: 'owner',
+      links: {
+        self: '/api/v2/users/07aee6106d658000',
+      },
+      id: '07aee6106d658000',
+      name: 'orgc407211f02faa1ef-user-20070',
+      status: 'active',
+    },
+  ],
 }
 
 jest.mock('src/client', () => ({
@@ -234,16 +234,16 @@ jest.mock('src/client', () => ({
     return {
       data: dummyOwners,
       headers: {},
-      status: 200
+      status: 200,
     }
   }),
   getOrgsMembers: jest.fn(() => {
     return {
       data: dummyMembers,
       headers: {},
-      status: 200
+      status: 200,
     }
-  })
+  }),
 }))
 
 jest.mock('src/resources/selectors', () => {
@@ -253,7 +253,7 @@ jest.mock('src/resources/selectors', () => {
     }),
     getStatus: jest.fn(() => {
       return RemoteDataState.NotStarted
-    })
+    }),
   }
 })
 
@@ -305,12 +305,16 @@ const setup = () => {
 const verifyRowMetaData = (row: HTMLElement, run: Run) => {
   const cells = row.querySelectorAll('[data-testid=table-cell]')
   expect(cells[0].textContent.trim()).toEqual(run.status)
-  const formattedDate = createDateTimeFormatter(DEFAULT_TIME_FORMAT).format(new Date(run.scheduledFor))
+  const formattedDate = createDateTimeFormatter(DEFAULT_TIME_FORMAT).format(
+    new Date(run.scheduledFor)
+  )
 
   expect(cells[1].textContent.trim()).toMatch(formattedDate)
 
   if (run.startedAt) {
-    const formattedDate = createDateTimeFormatter(DEFAULT_TIME_FORMAT).format(new Date(run.startedAt))
+    const formattedDate = createDateTimeFormatter(DEFAULT_TIME_FORMAT).format(
+      new Date(run.startedAt)
+    )
 
     expect(cells[2].textContent.trim()).toMatch(formattedDate)
   }

--- a/src/types/tasks.ts
+++ b/src/types/tasks.ts
@@ -2,6 +2,7 @@ import {Task as ITask} from 'src/client'
 import {NormalizedState, Run, RemoteDataState, LogEvent} from 'src/types'
 
 export interface Task extends Omit<ITask, 'labels'> {
+  ownerID: any
   labels?: string[]
 }
 export interface TaskOptions {

--- a/src/types/tasks.ts
+++ b/src/types/tasks.ts
@@ -2,7 +2,7 @@ import {Task as ITask} from 'src/client'
 import {NormalizedState, Run, RemoteDataState, LogEvent} from 'src/types'
 
 export interface Task extends Omit<ITask, 'labels'> {
-  ownerID: any
+  ownerID?: any
   labels?: string[]
 }
 export interface TaskOptions {

--- a/src/types/tasks.ts
+++ b/src/types/tasks.ts
@@ -2,7 +2,6 @@ import {Task as ITask} from 'src/client'
 import {NormalizedState, Run, RemoteDataState, LogEvent} from 'src/types'
 
 export interface Task extends Omit<ITask, 'labels'> {
-  ownerID?: any
   labels?: string[]
 }
 export interface TaskOptions {


### PR DESCRIPTION
Closes #1864 

**Before** 
The `created by` section of task runs card shows the task name 

<img width="1679" alt="Screen Shot 2021-06-28 at 3 16 42 PM" src="https://user-images.githubusercontent.com/66275100/124143587-dcb4b000-da50-11eb-9526-c437d4bc1aa5.png">

**After**
`Created by` shows the creator of the task.

![Screen Shot 2021-06-30 at 9 00 32 PM](https://user-images.githubusercontent.com/66275100/124143913-22717880-da51-11eb-948b-8117ddb886ac.png)



