### PR TITLE
fix: annotations test in firefox

### DIFF
--- a/cypress/e2e/cloud/annotations.test.ts
+++ b/cypress/e2e/cloud/annotations.test.ts
@@ -464,7 +464,9 @@ describe('The Annotations UI functionality', () => {
 
               // should be 10 minutes between them:
               const duration = moment.duration(
-                moment(endTimeValue).diff(moment(startTimeValue))
+                moment(endTimeValue, 'YYYY-MM-DD hh:mm:ss a').diff(
+                  moment(startTimeValue, 'YYYY-MM-DD hh:mm:ss a')
+                )
               )
               const minutes = duration.asMinutes()
 

--- a/cypress/e2e/cloud/annotations.test.ts
+++ b/cypress/e2e/cloud/annotations.test.ts
@@ -425,7 +425,7 @@ describe('The Annotations UI functionality', () => {
               .then(endTimeValue => {
                 expect(endTimeValue).to.equal(startTimeValue)
 
-                const newEndTime = moment(endTimeValue)
+                const newEndTime = moment(endTimeValue, 'YYYY-MM-DD hh:mm:ss a')
                   .add(10, 'minutes')
                   .format('YYYY-MM-DD hh:mm:ss a')
 


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/1808

The test `can add an annotation; that is originally a point and then switch to a range` fails in firefox. When I look at the recording, it's because moment cannot create the date correctly. I think adding this input formatting for the date will fix it 🤞 

JSfiddle illustrating the difference: http://jsfiddle.net/n1e5Lzjs/

![image](https://user-images.githubusercontent.com/6411855/124173307-b8140480-da5f-11eb-8180-c52c934260be.png)

