### PR TITLE
chore: update giraffe

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "@influxdata/clockface": "^2.10.0",
     "@influxdata/flux": "^0.5.1",
     "@influxdata/flux-lsp-browser": "^0.5.51",
-    "@influxdata/giraffe": "^2.15.7",
+    "@influxdata/giraffe": "^2.15.8",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -725,10 +725,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/flux/-/flux-0.5.1.tgz#e39e7a7af9163fc9494422c8fed77f3ae1b68f56"
   integrity sha512-GHlkXBhSdJ2m56JzDkbnKPAqLj3/lexPooacu14AWTO4f2sDGLmzM7r0AxgdtU1M2x7EXNBwgGOI5EOAdN6mkw==
 
-"@influxdata/giraffe@^2.15.7":
-  version "2.15.7"
-  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.15.7.tgz#d807be8e3fa3fad911c97948c3ca00fc8010a83d"
-  integrity sha512-Mr46o8XBYS7jnZ/TpZ8KI3ogGDGiCG++VKhamhS/CC1Z3qIkrEqfqOix1ZCfeeN3EBjlfrCBXyq4KdQd5F0sPg==
+"@influxdata/giraffe@^2.15.8":
+  version "2.15.8"
+  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.15.8.tgz#eab031306b17a4db569e2b5e5479dd9d8f6017ed"
+  integrity sha512-WJurUFNgRb1wmKmknfFqBI9bgenV+WAVKn9wnUoln01l5fD/L4f3TLnLCDMCsdlZVKXaGLTVk6Hkh9nz3JFRhA==
   dependencies:
     merge-images "^2.0.0"
 


### PR DESCRIPTION
This pulls in the version of giraffe that addresses the conditional hook previously seen in `useTooltipElement`