### PR TITLE
feat: add timezone dropdown to the alert history page 

### DIFF
--- a/src/alerting/components/AlertHistoryIndex.tsx
+++ b/src/alerting/components/AlertHistoryIndex.tsx
@@ -33,6 +33,7 @@ import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 import {ResourceIDs} from 'src/checks/reducers'
 import {ResourceType, AlertHistoryType, AppState} from 'src/types'
 import {RouteComponentProps} from 'react-router-dom'
+import TimeZoneDropdown from '../../shared/components/TimeZoneDropdown'
 
 export const ResourceIDsContext = createContext<ResourceIDs>(null)
 
@@ -84,15 +85,18 @@ const AlertHistoryIndex: FC<Props> = ({
                 <RateLimitAlert />
               </Page.Header>
               <Page.ControlBar fullWidth={true}>
-                <AlertHistoryQueryParams
-                  searchInput={props.state.searchInput}
-                  historyType={historyType}
-                />
-                <AlertHistoryControls
-                  historyType={historyType}
-                  onSetHistoryType={setHistoryType}
-                  eventViewerProps={props}
-                />
+                <Page.ControlBarRight>
+                  <AlertHistoryQueryParams
+                    searchInput={props.state.searchInput}
+                    historyType={historyType}
+                  />
+                  <AlertHistoryControls
+                    historyType={historyType}
+                    onSetHistoryType={setHistoryType}
+                    eventViewerProps={props}
+                  />
+                  <TimeZoneDropdown />
+                </Page.ControlBarRight>
               </Page.ControlBar>
               <Page.Contents
                 fullWidth={true}

--- a/src/alerting/components/TimeTableField.tsx
+++ b/src/alerting/components/TimeTableField.tsx
@@ -1,12 +1,12 @@
 // Libraries
 import React, {FC} from 'react'
-import moment from 'moment'
 
 // Constants
 import {DEFAULT_TIME_FORMAT} from 'src/shared/constants'
 
 // Types
 import {StatusRow, NotificationRow} from 'src/types'
+import {FormattedDateTime} from '../../utils/datetime/FormattedDateTime'
 
 interface Props {
   row: StatusRow | NotificationRow
@@ -15,7 +15,7 @@ interface Props {
 const TimeTableField: FC<Props> = ({row: {time}}) => {
   return (
     <div className="time-table-field">
-      {moment.utc(time).format(DEFAULT_TIME_FORMAT)}
+      <FormattedDateTime format={DEFAULT_TIME_FORMAT} date={new Date(time)} />
     </div>
   )
 }


### PR DESCRIPTION
Closes #1419

Adds the timezone dropdown to the Alert History page and uses the new Date-time formatter since we are now moving away from using MomentJs.

https://user-images.githubusercontent.com/18511823/124179660-ff9e8e80-da67-11eb-9a0d-d40083179027.mov


