### PR TITLE
refactor: changed relative paths to absolute paths

### DIFF
--- a/src/alerting/components/AlertHistoryIndex.tsx
+++ b/src/alerting/components/AlertHistoryIndex.tsx
@@ -33,7 +33,7 @@ import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 import {ResourceIDs} from 'src/checks/reducers'
 import {ResourceType, AlertHistoryType, AppState} from 'src/types'
 import {RouteComponentProps} from 'react-router-dom'
-import TimeZoneDropdown from '../../shared/components/TimeZoneDropdown'
+import TimeZoneDropdown from 'src/shared/components/TimeZoneDropdown'
 
 export const ResourceIDsContext = createContext<ResourceIDs>(null)
 

--- a/src/alerting/components/TimeTableField.tsx
+++ b/src/alerting/components/TimeTableField.tsx
@@ -6,7 +6,7 @@ import {DEFAULT_TIME_FORMAT} from 'src/shared/constants'
 
 // Types
 import {StatusRow, NotificationRow} from 'src/types'
-import {FormattedDateTime} from '../../utils/datetime/FormattedDateTime'
+import {FormattedDateTime} from 'src/utils/datetime/FormattedDateTime'
 
 interface Props {
   row: StatusRow | NotificationRow


### PR DESCRIPTION
The IDE auto-import was a relative path for this PR: https://github.com/influxdata/ui/pull/1877, we need to change it to absolute with the base at `src` to make it consistent across. 

