### PR TITLE
fix: Pagination jump

### DIFF
--- a/cypress/e2e/shared/simpleTable.test.ts
+++ b/cypress/e2e/shared/simpleTable.test.ts
@@ -192,4 +192,89 @@ describe('simple table interactions', () => {
     cy.getByTestID('table-cell 30').should('not.exist')
     cy.getByTestID('table-cell 31').should('be.visible')
   })
+
+  it('should not jump to an incorrect page when going from the last page to any other page via clicking the page number or left button.', () => {
+    cy.getByTestID('query-builder').should('exist')
+
+    // show raw data view of data with 10 pages
+    cy.getByTestID(`selector-list ${simpleOverflow}`).should('be.visible')
+    cy.getByTestID(`selector-list ${simpleOverflow}`).click()
+
+    cy.getByTestID('selector-list m').should('be.visible')
+    cy.getByTestID('selector-list m').clickAttached()
+
+    cy.getByTestID('selector-list v').should('be.visible')
+    cy.getByTestID('selector-list v').clickAttached()
+
+    cy.getByTestID('selector-list tv1').clickAttached()
+
+    cy.getByTestID('time-machine-submit-button').click()
+
+    cy.getByTestID('raw-data--toggle').click()
+    cy.getByTestID('simple-table').should('exist')
+
+    // click last page
+    cy.getByTestID('pagination-item')
+      .last()
+      .should('be.visible')
+    cy.getByTestID('pagination-item')
+      .last()
+      .click()
+
+    // doing 10-7 to be exhaustive
+    // click page 10
+    cy.getByTestID('pagination-item')
+      .eq(4)
+      .click()
+    cy.getByTestID('table-cell 28').should('be.visible')
+    cy.getByTestID('table-cell 29').should('be.visible')
+    cy.getByTestID('table-cell 30').should('be.visible')
+    cy.getByTestID('pagination-item')
+      .last()
+      .click()
+
+    // click page 9
+    cy.getByTestID('pagination-item')
+      .eq(3)
+      .click()
+    cy.getByTestID('table-cell 25').should('be.visible')
+    cy.getByTestID('table-cell 26').should('be.visible')
+    cy.getByTestID('table-cell 27').should('be.visible')
+    cy.getByTestID('pagination-item')
+      .last()
+      .click()
+
+    // click page 8
+    cy.getByTestID('pagination-item')
+      .eq(2)
+      .click()
+    cy.getByTestID('table-cell 22').should('be.visible')
+    cy.getByTestID('table-cell 23').should('be.visible')
+    cy.getByTestID('table-cell 24').should('be.visible')
+    cy.getByTestID('pagination-item')
+      .last()
+      .click()
+
+    // click page 7
+    cy.getByTestID('pagination-item')
+      .eq(1)
+      .click()
+    cy.getByTestID('table-cell 19').should('be.visible')
+    cy.getByTestID('table-cell 20').should('be.visible')
+    cy.getByTestID('table-cell 21').should('be.visible')
+    cy.getByTestID('pagination-item')
+      .last()
+      .click()
+
+    // click left button
+    cy.getByTestID('pagination-direction-item')
+      .eq(0)
+      .click()
+    cy.getByTestID('table-cell 28').should('be.visible')
+    cy.getByTestID('table-cell 29').should('be.visible')
+    cy.getByTestID('table-cell 30').should('be.visible')
+    cy.getByTestID('pagination-item')
+      .last()
+      .click()
+  })
 })

--- a/src/visualization/context/pagination.tsx
+++ b/src/visualization/context/pagination.tsx
@@ -52,7 +52,7 @@ export const PaginationProvider: FC<PaginationProviderProps> = ({
   const [size, setSize] = useState(DEFAULT_CONTEXT.size)
   const [maxSize, setMaxSize] = useState(DEFAULT_CONTEXT.maxSize)
   const [totalPages, setTotalPages] = useState(DEFAULT_CONTEXT.totalPages)
-    
+
   const next = useCallback(() => {
     if (total) {
       setOffset(calcNextPageOffset(offset, size, total))

--- a/src/visualization/context/pagination.tsx
+++ b/src/visualization/context/pagination.tsx
@@ -7,6 +7,7 @@ import {
 interface PaginationContextType {
   offset: number // the start index
   size: number // the size of the page
+  maxSize: number // the max size of the page
   total: number // the total number of entries
   totalPages: number // the total number of pages
 
@@ -14,6 +15,7 @@ interface PaginationContextType {
   previous: () => void
 
   setSize: (size: number) => void
+  setMaxSize: (page: number) => void
   setPage: (page: number) => void
   setTotalPages: (totalPages: number) => void
 }
@@ -21,6 +23,7 @@ interface PaginationContextType {
 const DEFAULT_CONTEXT: PaginationContextType = {
   offset: 0,
   size: 0,
+  maxSize: 0,
   total: 0,
   totalPages: 0,
 
@@ -28,6 +31,7 @@ const DEFAULT_CONTEXT: PaginationContextType = {
   previous: () => {},
 
   setSize: (_size: number) => {},
+  setMaxSize: (_maxSize: number) => {},
   setPage: (_page: number) => {},
   setTotalPages: (_totalPages: number) => {},
 }
@@ -46,8 +50,9 @@ export const PaginationProvider: FC<PaginationProviderProps> = ({
 }) => {
   const [offset, setOffset] = useState(DEFAULT_CONTEXT.offset)
   const [size, setSize] = useState(DEFAULT_CONTEXT.size)
+  const [maxSize, setMaxSize] = useState(DEFAULT_CONTEXT.maxSize)
   const [totalPages, setTotalPages] = useState(DEFAULT_CONTEXT.totalPages)
-
+    
   const next = useCallback(() => {
     if (total) {
       setOffset(calcNextPageOffset(offset, size, total))
@@ -62,9 +67,9 @@ export const PaginationProvider: FC<PaginationProviderProps> = ({
 
   const setPage = useCallback(
     (page: number) => {
-      setOffset(calcOffset(page, size, total))
+      setOffset(calcOffset(page, maxSize, total))
     },
-    [offset, size, setOffset]
+    [offset, maxSize, setOffset]
   )
 
   return (
@@ -72,11 +77,13 @@ export const PaginationProvider: FC<PaginationProviderProps> = ({
       value={{
         offset,
         size,
+        maxSize,
         total,
         totalPages,
         next,
         previous,
         setSize,
+        setMaxSize,
         setPage,
         setTotalPages,
       }}

--- a/src/visualization/types/SimpleTable/PagedTable.tsx
+++ b/src/visualization/types/SimpleTable/PagedTable.tsx
@@ -221,9 +221,14 @@ interface Props {
 }
 
 const PagedTable: FC<Props> = ({result, properties}) => {
-  const {offset, setSize, maxSize, setMaxSize, setPage, setTotalPages} = useContext(
-    PaginationContext
-  )
+  const {
+    offset,
+    setSize,
+    maxSize,
+    setMaxSize,
+    setPage,
+    setTotalPages,
+  } = useContext(PaginationContext)
   const [height, setHeight] = useState(0)
   const ref = useRef()
 

--- a/src/visualization/types/SimpleTable/PagedTable.tsx
+++ b/src/visualization/types/SimpleTable/PagedTable.tsx
@@ -42,7 +42,7 @@ const measurePage = (
   let lastSignature
   let signature
 
-  while (rowIdx <= result.table.length) {
+  while (rowIdx < result.table.length) {
     if (result.table.columns.table.data[rowIdx] !== currentTable) {
       signature = Object.values(result.table.columns)
         .map(
@@ -221,7 +221,7 @@ interface Props {
 }
 
 const PagedTable: FC<Props> = ({result, properties}) => {
-  const {offset, setSize, setPage, setTotalPages} = useContext(
+  const {offset, setSize, maxSize, setMaxSize, setPage, setTotalPages} = useContext(
     PaginationContext
   )
   const [height, setHeight] = useState(0)
@@ -273,6 +273,12 @@ const PagedTable: FC<Props> = ({result, properties}) => {
 
   useEffect(() => {
     setSize(size)
+  }, [size])
+
+  useEffect(() => {
+    if (size > maxSize) {
+      setMaxSize(size)
+    }
   }, [size])
 
   useEffect(() => {

--- a/src/visualization/utils/paginationUtils.ts
+++ b/src/visualization/utils/paginationUtils.ts
@@ -1,5 +1,5 @@
-export const calcOffset = (page: number, size: number, total: number) =>
-  Math.min(Math.max(0, (page - 1) * size), total - 1)
+export const calcOffset = (page: number, maxSize: number, total: number) =>
+  Math.min(Math.max(0, (page - 1) * maxSize), total - 1)
 
 export const calcNextPageOffset = (
   offset: number,


### PR DESCRIPTION
Closes #1884

Pagination jumping bug fixed. Solution involves calculating the size, comparing it to the maxSize, and replacing it if it is bigger. 

Also, so small calculation for size (line 45 in PagedTable.tsx). Fix does not change anything, but fixes the math in case it is important in the future.

#### Before
<img width="127" alt="Screen Shot 2021-07-02 at 1 29 58 PM" src="https://user-images.githubusercontent.com/39343323/124311311-88d2c580-db3b-11eb-8222-10ed96bd3c26.png">

**101 should be 100**

#### After
<img width="121" alt="Screen Shot 2021-07-02 at 1 30 56 PM" src="https://user-images.githubusercontent.com/39343323/124311395-ab64de80-db3b-11eb-9771-2e86b2b5a3c7.png">

## Example
https://slack-files.com/T02GAR81Y-F027BGXJD4Z-41e69a30a6