### PR TITLE
fix(notebooks): run preview only when presentation mode is on

### DIFF
--- a/src/flows/components/PipeList.tsx
+++ b/src/flows/components/PipeList.tsx
@@ -15,7 +15,9 @@ const PipeList: FC = () => {
   const {queryAll} = useContext(FlowQueryContext)
 
   useEffect(() => {
-    queryAll()
+    if (flow.readOnly) {
+      queryAll()
+    }
   }, [])
 
   if (!flow.data || !flow.data.allIDs.length) {

--- a/src/flows/context/flow.list.tsx
+++ b/src/flows/context/flow.list.tsx
@@ -82,6 +82,7 @@ export function serialize(flow) {
       if (meta) {
         return {
           ...flow.data.byID[id],
+          id,
           title: meta.title,
           visible: meta.visible,
         }


### PR DESCRIPTION
Closes https://github.com/influxdata/idpe/issues/10960

If presentation mode is on, run preview when entering the notebook and display the visualizations.

If presentation mode is off, do not run preview when entering the notebook.

Adds cypress tests for these two scenarios.

https://user-images.githubusercontent.com/6411855/124320574-fdeccd80-db30-11eb-9a0d-31be02d98f97.mov


