### PR TITLE
test: fix flaky delete token test

### DIFF
--- a/cypress/e2e/shared/tokens.test.ts
+++ b/cypress/e2e/shared/tokens.test.ts
@@ -153,13 +153,17 @@ describe('tokens', () => {
   it('can delete a token', () => {
     cy.get('.cf-resource-card').should('have.length', 4)
 
+    cy.intercept('**/authorizations/*').as('deleteToken')
+
     cy.getByTestID('token-card token test 03').within(() => {
-      cy.getByTestID('context-menu').click()
+      cy.getByTestID('context-menu').click({force: true})
 
       cy.getByTestID('delete-token')
         .contains('Delete')
         .click()
     })
+
+    cy.wait('@deleteToken')
 
     cy.get('.cf-resource-card').should('have.length', 3)
 
@@ -169,27 +173,29 @@ describe('tokens', () => {
     cy.get('.cf-resource-card')
       .first()
       .within(() => {
-        cy.getByTestID('context-menu').click()
+        cy.getByTestID('context-menu').click({force: true})
 
         cy.getByTestID('delete-token')
           .contains('Delete')
           .click()
       })
 
+    cy.wait('@deleteToken')
     cy.get('.cf-resource-card')
       .first()
       .within(() => {
-        cy.getByTestID('context-menu').click()
+        cy.getByTestID('context-menu').click({force: true})
 
         cy.getByTestID('delete-token')
           .contains('Delete')
           .click()
       })
 
+    cy.wait('@deleteToken')
     cy.get('.cf-resource-card')
       .first()
       .within(() => {
-        cy.getByTestID('context-menu').click()
+        cy.getByTestID('context-menu').click({force: true})
 
         cy.getByTestID('delete-token')
           .contains('Delete')


### PR DESCRIPTION
Closes #1701 

I think this will help with the flaky token test. The issue was that it was attempting to get the `.first()` card before the delete API had returned and when the API did return, the card was removed and the element it grabbed became detached. 

I also added the `{force:true}` to the click because sometimes it was failing because the button was hidden. I've tried to fix this before but cypress just doesn't work well with mouseover events.

I was able to run it 10 times in a row successfully after this change. Before the change I could only get it to run 3 times without failing. 
