### PR TITLE
fix: make community template error messages more generic

### DIFF
--- a/src/shared/copy/notifications.ts
+++ b/src/shared/copy/notifications.ts
@@ -1164,12 +1164,10 @@ export const communityTemplateInstallSucceeded = (
   message: `We've successfully installed: ${templateName}`,
 })
 
-export const communityTemplateInstallFailed = (
-  errorMessage: string = ''
-): Notification => ({
+export const communityTemplateInstallFailed = (): Notification => ({
   ...defaultErrorNotification,
   duration: INDEFINITE,
-  message: `There was a problem installing the template: ${errorMessage}`,
+  message: 'There was a problem installing the template. Please try again.',
 })
 
 export const communityTemplateDeleteSucceeded = (
@@ -1179,18 +1177,15 @@ export const communityTemplateDeleteSucceeded = (
   message: `We've successfully deleted: ${templateName}`,
 })
 
-export const communityTemplateDeleteFailed = (
-  message: string
-): Notification => ({
+export const communityTemplateDeleteFailed = (): Notification => ({
   ...defaultErrorNotification,
-  message: `Delete failed, please check error message: ${message}`,
+  message: 'We were unable to delete the template. Please try again.',
 })
 
-export const communityTemplateFetchStackFailed = (
-  message: string
-): Notification => ({
+export const communityTemplateFetchStackFailed = (): Notification => ({
   ...defaultErrorNotification,
-  message: `We could not fetch your installed resources, please reload the page: ${message}`,
+  message:
+    'We could not fetch your installed resources. Please reload the page to try again.',
 })
 
 export const communityTemplateUnsupportedFormatError = (): Notification => ({

--- a/src/templates/components/CommunityTemplateInstallOverlay.tsx
+++ b/src/templates/components/CommunityTemplateInstallOverlay.tsx
@@ -99,7 +99,7 @@ class CommunityTemplateInstallOverlayUnconnected extends PureComponent<Props> {
       this.props.setStagedCommunityTemplate(summary)
       return summary
     } catch (err) {
-      this.props.notify(communityTemplateInstallFailed(err.message))
+      this.props.notify(communityTemplateInstallFailed())
       if (
         err.message.includes('mapping values are not allowed in this context')
       ) {
@@ -130,7 +130,7 @@ class CommunityTemplateInstallOverlayUnconnected extends PureComponent<Props> {
       )
       event('template_install', {templateUrl: this.props.stagedTemplateUrl})
     } catch (err) {
-      this.props.notify(communityTemplateInstallFailed(err.message))
+      this.props.notify(communityTemplateInstallFailed())
       reportErrorThroughHoneyBadger(err, {
         name: 'Failed to install community template',
       })

--- a/src/templates/components/CommunityTemplatesInstalledList.test.tsx
+++ b/src/templates/components/CommunityTemplatesInstalledList.test.tsx
@@ -163,7 +163,7 @@ describe('the Community Templates installed List', () => {
       })
       const [notifyCallArguments] = mocked(notify).mock.calls
       const [notifyMessage] = notifyCallArguments
-      expect(notifyMessage).toEqual(communityTemplateDeleteFailed('fake error'))
+      expect(notifyMessage).toEqual(communityTemplateDeleteFailed())
 
       const [honeyBadgerCallArguments] = mocked(
         reportErrorThroughHoneyBadger

--- a/src/templates/components/CommunityTemplatesInstalledList.tsx
+++ b/src/templates/components/CommunityTemplatesInstalledList.tsx
@@ -64,7 +64,7 @@ class CommunityTemplatesInstalledListUnconnected extends PureComponent<Props> {
     try {
       this.props.fetchAndSetStacks(this.props.orgID)
     } catch (err) {
-      this.props.notify(communityTemplateFetchStackFailed(err.message))
+      this.props.notify(communityTemplateFetchStackFailed())
       reportErrorThroughHoneyBadger(err, {
         name: 'The community template fetch stack failed',
       })
@@ -94,7 +94,7 @@ class CommunityTemplatesInstalledListUnconnected extends PureComponent<Props> {
         this.props.notify(communityTemplateDeleteSucceeded(stackName))
         this.props.getBuckets()
       } catch (err) {
-        this.props.notify(communityTemplateDeleteFailed(err.message))
+        this.props.notify(communityTemplateDeleteFailed())
         reportErrorThroughHoneyBadger(err, {
           name: 'The community template delete failed',
         })


### PR DESCRIPTION
Closes https://github.com/influxdata/idpe/issues/11155

Makes Community Template error messages more generic.
