### PR TITLE
refactor: use new DateFormatter for FunctionRunLogRow

### DIFF
--- a/src/functions/components/FunctionRunLogRow.tsx
+++ b/src/functions/components/FunctionRunLogRow.tsx
@@ -14,12 +14,14 @@ const FunctionRunLogRow: FC<FunctionRunLog> = ({
   timestamp,
   severity,
 }) => {
-
   return (
     <IndexList.Row>
       <IndexList.Cell>
         <span className="run-logs--list-time">
-          <FormattedDateTime format={DEFAULT_TIME_FORMAT} date={new Date(timestamp)}/>
+          <FormattedDateTime
+            format={DEFAULT_TIME_FORMAT}
+            date={new Date(timestamp)}
+          />
         </span>
       </IndexList.Cell>
       <IndexList.Cell>

--- a/src/functions/components/FunctionRunLogRow.tsx
+++ b/src/functions/components/FunctionRunLogRow.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {FC} from 'react'
-import moment from 'moment'
 
 // Components
 import {IndexList} from '@influxdata/clockface'
@@ -8,27 +7,20 @@ import {IndexList} from '@influxdata/clockface'
 // Types
 import {FunctionRunLog} from 'src/client/managedFunctionsRoutes'
 import {DEFAULT_TIME_FORMAT} from 'src/shared/constants'
+import {FormattedDateTime} from 'src/utils/datetime/FormattedDateTime'
 
 const FunctionRunLogRow: FC<FunctionRunLog> = ({
   message,
   timestamp,
   severity,
 }) => {
-  const dateTimeIfy = (dt: string): string => {
-    if (!dt) {
-      return ''
-    }
-
-    const newdate = new Date(dt)
-    const formatted = moment(newdate).format(DEFAULT_TIME_FORMAT)
-
-    return formatted
-  }
 
   return (
     <IndexList.Row>
       <IndexList.Cell>
-        <span className="run-logs--list-time">{dateTimeIfy(timestamp)}</span>
+        <span className="run-logs--list-time">
+          <FormattedDateTime format={DEFAULT_TIME_FORMAT} date={new Date(timestamp)}/>
+        </span>
       </IndexList.Cell>
       <IndexList.Cell>
         <span className="run-logs--list-time">{severity}</span>


### PR DESCRIPTION
closes: #1905

Replaces the `moment` library with the new `DateFormatter` in `FunctionRunLogRow`.

_Screenshots coming soon_