### PR TITLE
test: another attempt at the flaky token test

### DIFF
--- a/cypress/e2e/shared/tokens.test.ts
+++ b/cypress/e2e/shared/tokens.test.ts
@@ -157,10 +157,10 @@ describe('tokens', () => {
 
     cy.getByTestID('token-card token test 03').within(() => {
       cy.getByTestID('context-menu').click({force: true})
+    })
 
-      cy.getByTestID('delete-token')
-        .contains('Delete')
-        .click()
+    cy.getByTestID('token-card token test 03').within(() => {
+      cy.getByTestID('delete-token').click({force: true})
     })
 
     cy.wait('@deleteToken')
@@ -174,10 +174,12 @@ describe('tokens', () => {
       .first()
       .within(() => {
         cy.getByTestID('context-menu').click({force: true})
+      })
 
-        cy.getByTestID('delete-token')
-          .contains('Delete')
-          .click()
+    cy.get('.cf-resource-card')
+      .first()
+      .within(() => {
+        cy.getByTestID('delete-token').click({force: true})
       })
 
     cy.wait('@deleteToken')
@@ -185,10 +187,12 @@ describe('tokens', () => {
       .first()
       .within(() => {
         cy.getByTestID('context-menu').click({force: true})
+      })
 
-        cy.getByTestID('delete-token')
-          .contains('Delete')
-          .click()
+    cy.get('.cf-resource-card')
+      .first()
+      .within(() => {
+        cy.getByTestID('delete-token').click({force: true})
       })
 
     cy.wait('@deleteToken')
@@ -196,10 +200,12 @@ describe('tokens', () => {
       .first()
       .within(() => {
         cy.getByTestID('context-menu').click({force: true})
+      })
 
-        cy.getByTestID('delete-token')
-          .contains('Delete')
-          .click()
+    cy.get('.cf-resource-card')
+      .first()
+      .within(() => {
+        cy.getByTestID('delete-token').click({force: true})
       })
 
     // Assert empty state


### PR DESCRIPTION
Closes #1701 

Another attempt at fixing the flakiness of this test. I was able to reproduce the issue from CI locally. It failed 1 out of 10 runs for me. 

The solution was to 1) only run a single command inside the `.within(() =>` to avoid the "element has been detached from dom" error and 2) to add `{force:true}` when clicking the Delete button. I also got rid of the `.contains('Delete')` because that seems like a silly assertion. 

Now it succeeds 20 out of 20 runs locally for me.