### PR TITLE
fix: sort dashboards in dropdown

### DIFF
--- a/src/flows/pipes/Visualization/ExportDashboardOverlay/DashboardDropdown.tsx
+++ b/src/flows/pipes/Visualization/ExportDashboardOverlay/DashboardDropdown.tsx
@@ -23,18 +23,20 @@ const DashboardDropdown: FC = () => {
   if (dashboards.length) {
     menuItems = (
       <>
-        {dashboards.map((dashboard, i) => (
-          <Dropdown.Item
-            key={`${dashboard.name}${i}`}
-            value={dashboard}
-            onClick={dashboard => handleSetDashboard(dashboard)}
-            selected={dashboard.name === selectedDashboard?.name}
-            title={dashboard.name}
-            wrapText={true}
-          >
-            {dashboard.name}
-          </Dropdown.Item>
-        ))}
+        {dashboards
+          .sort((a, b) => a.name.localeCompare(b.name))
+          .map((dashboard, i) => (
+            <Dropdown.Item
+              key={`${dashboard.name}${i}`}
+              value={dashboard}
+              onClick={dashboard => handleSetDashboard(dashboard)}
+              selected={dashboard.name === selectedDashboard?.name}
+              title={dashboard.name}
+              wrapText={true}
+            >
+              {dashboard.name}
+            </Dropdown.Item>
+          ))}
       </>
     )
   }


### PR DESCRIPTION
Closes #1116

Sorts the dashboards when exporting.

<img width="732" alt="Screen Shot 2021-07-06 at 4 43 33 PM" src="https://user-images.githubusercontent.com/6411855/124679604-95c42180-de79-11eb-92ef-1fceeee56642.png">
