### PR TITLE
feat: free user account self-deletion

### DIFF
--- a/cypress/e2e/cloud/about.test.ts
+++ b/cypress/e2e/cloud/about.test.ts
@@ -1,0 +1,101 @@
+import {Organization} from '../../../src/types'
+
+describe('About Page for free users with only 1 user', () => {
+  beforeEach(() => {
+    cy.flush()
+
+    cy.signin().then(() => {
+      cy.get('@org').then(({id}: Organization) => {
+        cy.setFeatureFlags({unityUsers: true, selfDeletion: true}).then(() => {
+          cy.quartzProvision({
+            accountType: 'free',
+            hasUsers: false,
+          }).then(() => {
+            cy.visit(`/orgs/${id}/about`)
+            cy.getByTestID('about-page--header').should('be.visible')
+          })
+        })
+      })
+    })
+  })
+
+  it('should allow the delete account functionality', () => {
+    cy.intercept('DELETE', '/api/v2/quartz/account', {
+      status: 204,
+      data: 'ok',
+    }).as('deleteAccount')
+    cy.getByTestID('delete-org--button')
+      .should('exist')
+      .click()
+    cy.getByTestID('Warning').should('not.exist')
+    cy.getByTestID('delete-org--overlay').should('exist')
+
+    cy.getByTestID('delete-org--button').should('be.disabled')
+
+    cy.getByTestID('agree-terms--input').click()
+    cy.getByTestID('agree-terms--checkbox').should('be.checked')
+    cy.getByTestID('delete-org--button')
+      .should('not.be.disabled')
+      .click()
+
+    cy.wait('@deleteAccount')
+  })
+})
+
+describe('About Page for free users with multiple users', () => {
+  beforeEach(() => {
+    cy.flush()
+
+    cy.signin().then(() => {
+      cy.get('@org').then(({id}: Organization) => {
+        cy.setFeatureFlags({unityUsers: true, selfDeletion: true}).then(() => {
+          cy.quartzProvision({
+            accountType: 'free',
+            hasUsers: true,
+          }).then(() => {
+            cy.visit(`/orgs/${id}/about`)
+            cy.getByTestID('about-page--header').should('be.visible')
+          })
+        })
+      })
+    })
+  })
+
+  it('should display the warning and allow users to navigate to the users page when trying to delete when the user has multiple users', () => {
+    cy.getByTestID('delete-org--button')
+      .should('exist')
+      .click()
+    cy.getByTestID('Warning')
+      .should('exist')
+      .within(() => {
+        cy.getByTestID('go-to-users--link').click()
+      })
+
+    cy.location().should(loc => {
+      expect(loc.pathname).to.include(`/users`)
+    })
+  })
+})
+
+describe('About Page for PAYG users', () => {
+  beforeEach(() => {
+    cy.flush()
+
+    cy.signin().then(() => {
+      cy.get('@org').then(({id}: Organization) => {
+        cy.setFeatureFlags({unityUsers: true, selfDeletion: true}).then(() => {
+          cy.quartzProvision({
+            accountType: 'pay_as_you_go',
+          }).then(() => {
+            cy.visit(`/orgs/${id}/about`)
+            cy.getByTestID('about-page--header').should('be.visible')
+          })
+        })
+      })
+    })
+  })
+
+  it('should not display the delete button', () => {
+    cy.getByTestID('delete-org--button').should('not.exist')
+  })
+})

--- a/cypress/e2e/cloud/billing.test.ts
+++ b/cypress/e2e/cloud/billing.test.ts
@@ -217,7 +217,7 @@ describe('Billing Page PAYG Users', () => {
     // check that the button is disabled
     cy.getByTestID('cancel-service-confirmation--button').should('be.disabled')
     cy.getByTestID('agree-terms--checkbox').should('not.be.checked')
-    // TODO(ariel): fix this so that it checks the box, check() didn't work
+
     cy.getByTestID('agree-terms--input').click()
     cy.getByTestID('agree-terms--checkbox').should('be.checked')
     cy.getByTestID('cancel-service-confirmation--button')

--- a/cypress/e2e/cloud/users.test.ts
+++ b/cypress/e2e/cloud/users.test.ts
@@ -7,8 +7,12 @@ describe('Users Page', () => {
     cy.signin().then(() => {
       cy.get('@org').then(({id}: Organization) => {
         cy.setFeatureFlags({unityUsers: true}).then(() => {
-          cy.visit(`/orgs/${id}/users`)
-          cy.getByTestID('users-page--header').should('be.visible')
+          cy.quartzProvision({
+            hasUsers: true,
+          }).then(() => {
+            cy.visit(`/orgs/${id}/users`)
+            cy.getByTestID('users-page--header').should('be.visible')
+          })
         })
       })
     })
@@ -53,8 +57,8 @@ describe('Users Page', () => {
 
     cy.getByTestID('notification-success--dismiss').click()
 
-    cy.getByTestIDSubStr('invite-list-item').should('have.length', 0)
-    cy.getByTestIDSubStr('user-list-item').should('have.length', 1)
+    cy.getByTestIDSubStr('invite-list-item').should('not.exist')
+    cy.getByTestIDSubStr('user-list-item').should('have.length', 2)
 
     cy.getByTestID(`user-list-item user@influxdata.com`).within(() => {
       cy.getByTestID('delete-user--button').trigger('mouseover')
@@ -68,6 +72,6 @@ describe('Users Page', () => {
 
     cy.getByTestID('notification-success--dismiss').click()
 
-    cy.getByTestIDSubStr('user-list-item').should('have.length', 0)
+    cy.getByTestIDSubStr('user-list-item').should('have.length', 1)
   })
 })

--- a/cypress/e2e/shared/about.test.ts
+++ b/cypress/e2e/shared/about.test.ts
@@ -35,14 +35,22 @@ describe('About Page', () => {
       .contains('Name is required')
     cy.getByTestID('rename-org-submit--button').should('be.disabled')
 
-    const newOrgName = 'hard@knock.life'
+    const newOrgName = `hard@knock.life${Math.random()}`
+
+    cy.intercept('PATCH', 'api/v2/orgs/*').as('patchOrg')
+
     cy.getByTestID('create-org-name-input').type(newOrgName)
     cy.getByTestID('rename-org-submit--button')
       .should('not.be.disabled')
       .click()
 
+    cy.wait('@patchOrg')
+
     cy.getByTestID('notification-success')
       .should('be.visible')
       .contains(newOrgName)
+
+    cy.getByTestID('org-profile--name').contains(newOrgName)
+    cy.getByTestID('danger-zone--org-name').contains(newOrgName)
   })
 })

--- a/cypress/e2e/shared/about.test.ts
+++ b/cypress/e2e/shared/about.test.ts
@@ -1,0 +1,48 @@
+import {Organization} from '../../../src/types'
+
+describe('About Page', () => {
+  beforeEach(() => {
+    cy.flush()
+
+    cy.signin().then(() => {
+      cy.get('@org').then(({id}: Organization) => {
+        cy.visit(`/orgs/${id}/about`)
+        cy.getByTestID('about-page--header').should('be.visible')
+      })
+    })
+  })
+
+  it('should display everything correctly', () => {
+    cy.getByTestID('common-ids--panel').within(() => {
+      cy.getByTestID('code-snippet--userid').should('exist')
+      cy.getByTestID('copy-btn--userid').should('not.be.disabled')
+
+      cy.getByTestID('code-snippet--orgid').should('exist')
+      cy.getByTestID('copy-btn--orgid').should('not.be.disabled')
+    })
+
+    cy.getByTestID('organization-profile--panel').within(() => {
+      cy.getByTestID('rename-org--button').click()
+    })
+
+    cy.getByTestID('danger-confirmation--button').click()
+    cy.getByTestID('form--element-error').should('not.exist')
+    cy.getByTestID('create-org-name-input').clear()
+
+    // check the error state
+    cy.getByTestID('form--element-error')
+      .should('exist')
+      .contains('Name is required')
+    cy.getByTestID('rename-org-submit--button').should('be.disabled')
+
+    const newOrgName = 'hard@knock.life'
+    cy.getByTestID('create-org-name-input').type(newOrgName)
+    cy.getByTestID('rename-org-submit--button')
+      .should('not.be.disabled')
+      .click()
+
+    cy.getByTestID('notification-success')
+      .should('be.visible')
+      .contains(newOrgName)
+  })
+})

--- a/cypress/e2e/shared/nav.test.ts
+++ b/cypress/e2e/shared/nav.test.ts
@@ -61,7 +61,7 @@ describe('navigation', () => {
     // User Nav -- About
     cy.getByTestID('user-nav').click()
     cy.getByTestID('user-nav-item-about').click()
-    cy.getByTestID('member-page--header').should('exist')
+    cy.getByTestID('about-page--header').should('exist')
     cy.url().should('contain', 'about')
 
     /** \

--- a/cypress/e2e/shared/orgs.test.ts
+++ b/cypress/e2e/shared/orgs.test.ts
@@ -16,7 +16,7 @@ describe('Orgs', () => {
       cy.getByTestID('user-nav-item-about').click()
       cy.get('span:contains("About")').click()
       cy.getByTestID('rename-org--button').click()
-      cy.getByTestID('danger-confirmation-button').click()
+      cy.getByTestID('danger-confirmation--button').click()
       cy.getByTestID('create-org-name-input')
         .click()
         .type(extraText)

--- a/cypress/e2e/shared/variables.test.ts
+++ b/cypress/e2e/shared/variables.test.ts
@@ -142,7 +142,7 @@ describe('Variables', () => {
 
     cy.getByTestID('context-rename-variable').click({force: true})
 
-    cy.getByTestID('danger-confirmation-button').click()
+    cy.getByTestID('danger-confirmation--button').click()
 
     cy.getByInputName('name').type('Renamed')
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -106,7 +106,6 @@ export const loginViaDex = (username: string, password: string) => {
               body: {req: req, approval: 'approve'},
             }).then(() => {
               cy.visit('/')
-              cy.getCookie('session').should('exist')
               cy.location('pathname').should('not.eq', '/signin')
             })
           })
@@ -578,6 +577,7 @@ export const flush = () => {
 export type ProvisionData = {
   accountType?: AccountType
   hasData?: boolean
+  hasUsers?: boolean
   isOperator?: boolean
   isRegionBeta?: boolean
 }
@@ -588,6 +588,7 @@ export type ProvisionData = {
   allows us to test scenarios when a user is:
   - pay_as_you_go vs free
   - is an operator
+  - has users
   - is in a beta region
   - has usage data vs has no usage data
 
@@ -595,6 +596,7 @@ export type ProvisionData = {
 
   - accountType = free
   - hasData = false
+  - hasUsers = false
   - isOperator = false
   - isRegionBeta = false
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -106,6 +106,7 @@ export const loginViaDex = (username: string, password: string) => {
               body: {req: req, approval: 'approve'},
             }).then(() => {
               cy.visit('/')
+              // cy.getCookie('session').should('exist')
               cy.location('pathname').should('not.eq', '/signin')
             })
           })

--- a/src/members/containers/MembersIndex.tsx
+++ b/src/members/containers/MembersIndex.tsx
@@ -1,9 +1,6 @@
-import React, {Component} from 'react'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect, ConnectedProps} from 'react-redux'
+import React, {FC} from 'react'
 
 // Components
-import {ErrorHandling} from 'src/shared/decorators/errors'
 import OrgTabbedPage from 'src/organizations/components/OrgTabbedPage'
 import OrgHeader from 'src/organizations/components/OrgHeader'
 import {Page} from '@influxdata/clockface'
@@ -12,52 +9,22 @@ import Members from 'src/members/components/Members'
 
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
-import {getByID} from 'src/resources/selectors'
 
 // Types
-import {AppState, Organization, ResourceType} from 'src/types'
+import {ResourceType} from 'src/types'
 
-type ReduxProps = ConnectedProps<typeof connector>
-type RouterProps = RouteComponentProps<{orgID: string}>
-type Props = RouterProps & ReduxProps
+const MembersIndex: FC = ({children}) => (
+  <>
+    <Page titleTag={pageTitleSuffixer(['Members', 'Organization'])}>
+      <OrgHeader />
+      <OrgTabbedPage activeTab="members">
+        <GetResources resources={[ResourceType.Members]}>
+          <Members />
+        </GetResources>
+      </OrgTabbedPage>
+    </Page>
+    {children}
+  </>
+)
 
-@ErrorHandling
-class MembersIndex extends Component<Props> {
-  constructor(props) {
-    super(props)
-  }
-
-  public render() {
-    const {org, children} = this.props
-
-    return (
-      <>
-        <Page titleTag={pageTitleSuffixer(['Members', 'Organization'])}>
-          <OrgHeader />
-          <OrgTabbedPage activeTab="members" orgID={org.id}>
-            <GetResources resources={[ResourceType.Members]}>
-              <Members />
-            </GetResources>
-          </OrgTabbedPage>
-        </Page>
-        {children}
-      </>
-    )
-  }
-}
-
-const mstp = (state: AppState, props: RouterProps) => {
-  const org = getByID<Organization>(
-    state,
-    ResourceType.Orgs,
-    props.match.params.orgID
-  )
-
-  return {
-    org,
-  }
-}
-
-const connector = connect(mstp)
-
-export default connector(withRouter(MembersIndex))
+export default MembersIndex

--- a/src/organizations/components/DeleteOrgOverlay.tsx
+++ b/src/organizations/components/DeleteOrgOverlay.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FC, useState} from 'react'
 import {useHistory} from 'react-router-dom'
-import {useSelector} from 'react-redux'
+import {useSelector, useDispatch} from 'react-redux'
 import {
   Alert,
   AlignItems,
@@ -21,14 +21,33 @@ import {
 
 // Utils
 import {getOrg} from 'src/organizations/selectors'
+import {deleteAccount} from 'src/client/unityRoutes'
+import {notify} from 'src/shared/actions/notifications'
+import {accountSelfDeletionFailed} from 'src/shared/copy/notifications'
 
 const DelteOrgOverlay: FC = () => {
   const history = useHistory()
   const [hasAgreedToTerms, setHasAgreedToTerms] = useState(false)
   const org = useSelector(getOrg)
+  const dispatch = useDispatch()
 
   const handleClose = () => {
     history.push(`/orgs/${org.id}/about`)
+  }
+
+  const handleDeleteAccount = async () => {
+    try {
+      const resp = await deleteAccount({})
+
+      if (resp.status !== 204) {
+        throw new Error(resp.data.message)
+      }
+
+      // TODO(arieL): redirect to offboarding page
+      window.location.href = `https://www.influxdata.com/free_cancel/`
+    } catch {
+      dispatch(notify(accountSelfDeletionFailed()))
+    }
   }
 
   return (
@@ -85,7 +104,7 @@ const DelteOrgOverlay: FC = () => {
                 ? ComponentStatus.Default
                 : ComponentStatus.Disabled
             }
-            onClick={() => console.log('do stuff')}
+            onClick={handleDeleteAccount}
           />
         </Overlay.Footer>
       </Overlay.Container>

--- a/src/organizations/components/DeleteOrgOverlay.tsx
+++ b/src/organizations/components/DeleteOrgOverlay.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FC, useState} from 'react'
 import {useHistory} from 'react-router-dom'
-import {useSelector, useDispatch} from 'react-redux'
+import {useDispatch} from 'react-redux'
 import {
   Alert,
   AlignItems,
@@ -20,19 +20,17 @@ import {
 } from '@influxdata/clockface'
 
 // Utils
-import {getOrg} from 'src/organizations/selectors'
 import {deleteAccount} from 'src/client/unityRoutes'
 import {notify} from 'src/shared/actions/notifications'
 import {accountSelfDeletionFailed} from 'src/shared/copy/notifications'
 
-const DelteOrgOverlay: FC = () => {
+const DeleteOrgOverlay: FC = () => {
   const history = useHistory()
   const [hasAgreedToTerms, setHasAgreedToTerms] = useState(false)
-  const org = useSelector(getOrg)
   const dispatch = useDispatch()
 
   const handleClose = () => {
-    history.push(`/orgs/${org.id}/about`)
+    history.goBack()
   }
 
   const handleDeleteAccount = async () => {
@@ -50,7 +48,7 @@ const DelteOrgOverlay: FC = () => {
   }
 
   return (
-    <Overlay visible={true}>
+    <Overlay visible={true} testID="delete-org--overlay">
       <Overlay.Container maxWidth={400}>
         <Overlay.Header title="Delete Organization" onDismiss={handleClose} />
         <Overlay.Body>
@@ -97,7 +95,7 @@ const DelteOrgOverlay: FC = () => {
           <Button
             color={ComponentColor.Danger}
             text="Delete Organization"
-            testID="danger-confirmation-button"
+            testID="delete-org--button"
             status={
               hasAgreedToTerms
                 ? ComponentStatus.Default
@@ -111,4 +109,4 @@ const DelteOrgOverlay: FC = () => {
   )
 }
 
-export default DelteOrgOverlay
+export default DeleteOrgOverlay

--- a/src/organizations/components/DeleteOrgOverlay.tsx
+++ b/src/organizations/components/DeleteOrgOverlay.tsx
@@ -43,7 +43,6 @@ const DelteOrgOverlay: FC = () => {
         throw new Error(resp.data.message)
       }
 
-      // TODO(arieL): redirect to offboarding page
       window.location.href = `https://www.influxdata.com/free_cancel/`
     } catch {
       dispatch(notify(accountSelfDeletionFailed()))

--- a/src/organizations/components/DeleteOrgOverlay.tsx
+++ b/src/organizations/components/DeleteOrgOverlay.tsx
@@ -95,7 +95,7 @@ const DeleteOrgOverlay: FC = () => {
           <Button
             color={ComponentColor.Danger}
             text="Delete Organization"
-            testID="delete-org--button"
+            testID="delete-organization--button"
             status={
               hasAgreedToTerms
                 ? ComponentStatus.Default

--- a/src/organizations/components/DeleteOrgOverlay.tsx
+++ b/src/organizations/components/DeleteOrgOverlay.tsx
@@ -1,0 +1,96 @@
+// Libraries
+import React, {FC, useState} from 'react'
+import {useHistory} from 'react-router-dom'
+import {useSelector} from 'react-redux'
+import {
+  Alert,
+  AlignItems,
+  Button,
+  ComponentColor,
+  ComponentSize,
+  ComponentStatus,
+  FlexBox,
+  FlexDirection,
+  IconFont,
+  Input,
+  InputLabel,
+  InputType,
+  JustifyContent,
+  Overlay,
+} from '@influxdata/clockface'
+
+// Utils
+import {getOrg} from 'src/organizations/selectors'
+
+const DelteOrgOverlay: FC = () => {
+  const history = useHistory()
+  const [hasAgreedToTerms, setHasAgreedToTerms] = useState(false)
+  const org = useSelector(getOrg)
+
+  const handleClose = () => {
+    history.push(`/orgs/${org.id}/about`)
+  }
+
+  return (
+    <Overlay visible={true}>
+      <Overlay.Container maxWidth={400}>
+        <Overlay.Header title="Delete Organization" onDismiss={handleClose} />
+        <Overlay.Body>
+          <Alert color={ComponentColor.Danger} icon={IconFont.AlertTriangle}>
+            This action cannot be undone
+          </Alert>
+          <ul>
+            <li>
+              The account for this Organization will be deleted immediately.
+              This is irreversible and cannot be undone.
+            </li>
+            <li>
+              Before continuing, you are responsible for exporting any data or
+              content - including dashboards, tasks and variable - from the user
+              interface.
+            </li>
+          </ul>
+          <span
+            onClick={() => setHasAgreedToTerms(prev => !prev)}
+            data-testid="agree-terms--input"
+          >
+            <FlexBox
+              alignItems={AlignItems.Center}
+              direction={FlexDirection.Row}
+              justifyContent={JustifyContent.FlexStart}
+              margin={ComponentSize.Medium}
+            >
+              <Input
+                className="agree-terms-input"
+                checked={hasAgreedToTerms}
+                onChange={() => setHasAgreedToTerms(prev => !prev)}
+                size={ComponentSize.Small}
+                titleText="I understand and agree to these conditions"
+                type={InputType.Checkbox}
+                testID="agree-terms--checkbox"
+              />
+              <InputLabel active={hasAgreedToTerms} size={ComponentSize.Small}>
+                I understand and agree to these conditions
+              </InputLabel>
+            </FlexBox>
+          </span>
+        </Overlay.Body>
+        <Overlay.Footer>
+          <Button
+            color={ComponentColor.Danger}
+            text="Delete Organization"
+            testID="danger-confirmation-button"
+            status={
+              hasAgreedToTerms
+                ? ComponentStatus.Default
+                : ComponentStatus.Disabled
+            }
+            onClick={() => console.log('do stuff')}
+          />
+        </Overlay.Footer>
+      </Overlay.Container>
+    </Overlay>
+  )
+}
+
+export default DelteOrgOverlay

--- a/src/organizations/components/OrgHeader.tsx
+++ b/src/organizations/components/OrgHeader.tsx
@@ -1,18 +1,18 @@
-import React, {Component} from 'react'
+import React, {FC} from 'react'
 
 // Components
 import {Page} from '@influxdata/clockface'
 import RateLimitAlert from 'src/cloud/components/RateLimitAlert'
 
-class OrgHeader extends Component {
-  public render() {
-    return (
-      <Page.Header fullWidth={false} testID="member-page--header">
-        <Page.Title title="Organization" />
-        <RateLimitAlert />
-      </Page.Header>
-    )
-  }
+type Props = {
+  testID?: string
 }
+
+const OrgHeader: FC<Props> = ({testID = 'member-page--header'}) => (
+  <Page.Header fullWidth={false} testID={testID}>
+    <Page.Title title="Organization" />
+    <RateLimitAlert />
+  </Page.Header>
+)
 
 export default OrgHeader

--- a/src/organizations/components/OrgNavigation.tsx
+++ b/src/organizations/components/OrgNavigation.tsx
@@ -1,128 +1,80 @@
 // Libraries
-import React, {PureComponent} from 'react'
+import React, {FC} from 'react'
+import {useSelector} from 'react-redux'
 import {Link} from 'react-router-dom'
 
 // Components
 import {Tabs, Orientation, ComponentSize} from '@influxdata/clockface'
-import CloudExclude from 'src/shared/components/cloud/CloudExclude'
-import CloudOnly from 'src/shared/components/cloud/CloudOnly'
-import {FeatureFlag} from 'src/shared/utils/featureFlag'
 
 // Constants
-import {CLOUD_USERS_PATH, CLOUD_URL} from 'src/shared/constants'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import {CLOUD} from 'src/shared/constants'
 
-// Decorators
-import {ErrorHandling} from 'src/shared/decorators/errors'
+// Utils
+import {getOrg} from 'src/organizations/selectors'
 
 interface Props {
   activeTab: string
-  orgID: string
 }
 
 interface OrgPageTab {
   text: string
   id: string
-  cloudExclude?: boolean
-  cloudOnly?: boolean
-  href?: string
-  link?: string
-  featureFlag?: string
-  featureFlagValue?: boolean
+  enabled?: () => boolean
+  link: string
 }
 
-@ErrorHandling
-class OrgNavigation extends PureComponent<Props> {
-  public render() {
-    const {activeTab, orgID} = this.props
+const OrgNavigation: FC<Props> = ({activeTab}) => {
+  const orgID = useSelector(getOrg)?.id
 
-    // TODO(ariel): once the `unityUsers` flag goes live we won't need any of the href logic:
-    // https://github.com/influxdata/ui/issues/1405
-    const tabs: OrgPageTab[] = [
-      {
-        text: 'Members',
-        id: 'members-oss',
-        cloudExclude: true,
-        link: `/orgs/${orgID}/members`,
-      },
-      {
-        text: 'Users',
-        id: 'members-quartz',
-        cloudOnly: true,
-        link: isFlagEnabled('unityUsers') ? `/orgs/${orgID}/users` : null,
-        href: isFlagEnabled('unityUsers')
-          ? null
-          : `${CLOUD_URL}/organizations/${orgID}${CLOUD_USERS_PATH}`,
-      },
-      {
-        text: 'About',
-        id: 'about',
-        link: `/orgs/${orgID}/about`,
-      },
-    ]
+  const tabs: OrgPageTab[] = [
+    {
+      text: 'Members',
+      id: 'members-oss',
+      enabled: () => !CLOUD,
+      link: `/orgs/${orgID}/members`,
+    },
+    {
+      text: 'Users',
+      id: 'users',
+      enabled: () => CLOUD,
+      link: `/orgs/${orgID}/users`,
+    },
+    {
+      text: 'About',
+      id: 'about',
+      link: `/orgs/${orgID}/about`,
+    },
+  ]
 
-    return (
-      <Tabs orientation={Orientation.Horizontal} size={ComponentSize.Large}>
-        {tabs.map(t => {
+  return (
+    <Tabs orientation={Orientation.Horizontal} size={ComponentSize.Large}>
+      {tabs
+        .filter(t => {
+          if (t?.enabled) {
+            return t.enabled()
+          }
+          return true
+        })
+        .map(t => {
           let isActive = t.id === activeTab
-          let tab = <></>
-          if (t.id === 'members-oss' || t.id === 'members-cloud') {
-            if (activeTab === 'members') {
-              isActive = true
-            }
+          if (t.id === 'members-oss' && activeTab === 'members') {
+            isActive = true
           }
 
-          if (t.href) {
-            tab = (
-              <Tabs.Tab
-                key={t.id}
-                text={t.text}
-                id={t.id}
-                linkElement={className => (
-                  <a href={t.href} className={className} />
-                )}
-                active={isActive}
-              />
-            )
-          } else if (t.link) {
-            tab = (
-              <Tabs.Tab
-                key={t.id}
-                text={t.text}
-                id={t.id}
-                linkElement={className => (
-                  <Link to={t.link} className={className} />
-                )}
-                active={isActive}
-              />
-            )
-          }
-
-          if (t.cloudExclude) {
-            tab = <CloudExclude key={t.id}>{tab}</CloudExclude>
-          }
-
-          if (t.cloudOnly) {
-            tab = <CloudOnly key={t.id}>{tab}</CloudOnly>
-          }
-
-          if (t.featureFlag) {
-            tab = (
-              <FeatureFlag
-                key={t.id}
-                name={t.featureFlag}
-                equals={t.featureFlagValue}
-              >
-                {tab}
-              </FeatureFlag>
-            )
-          }
-
-          return tab
+          return (
+            <Tabs.Tab
+              key={t.id}
+              text={t.text}
+              id={t.id}
+              linkElement={className => (
+                <Link to={t.link} className={className} />
+              )}
+              active={isActive}
+            />
+          )
         })}
-      </Tabs>
-    )
-  }
+    </Tabs>
+  )
 }
 
 export default OrgNavigation

--- a/src/organizations/components/OrgNavigation.tsx
+++ b/src/organizations/components/OrgNavigation.tsx
@@ -23,25 +23,31 @@ interface OrgPageTab {
   link: string
 }
 
+enum Tab {
+  Members = 'members-oss',
+  Users = 'users',
+  About = 'about',
+}
+
 const OrgNavigation: FC<Props> = ({activeTab}) => {
   const orgID = useSelector(getOrg)?.id
 
   const tabs: OrgPageTab[] = [
     {
       text: 'Members',
-      id: 'members-oss',
+      id: Tab.Members,
       enabled: () => !CLOUD,
       link: `/orgs/${orgID}/members`,
     },
     {
       text: 'Users',
-      id: 'users',
+      id: Tab.Users,
       enabled: () => CLOUD,
       link: `/orgs/${orgID}/users`,
     },
     {
       text: 'About',
-      id: 'about',
+      id: Tab.About,
       link: `/orgs/${orgID}/about`,
     },
   ]
@@ -57,7 +63,7 @@ const OrgNavigation: FC<Props> = ({activeTab}) => {
         })
         .map(t => {
           let isActive = t.id === activeTab
-          if (t.id === 'members-oss' && activeTab === 'members') {
+          if (t.id === Tab.Members && activeTab === 'members') {
             isActive = true
           }
 

--- a/src/organizations/components/OrgProfileDeletePanel.tsx
+++ b/src/organizations/components/OrgProfileDeletePanel.tsx
@@ -1,0 +1,88 @@
+// Libraries
+import React, {FC, useContext} from 'react'
+import {useSelector, useDispatch} from 'react-redux'
+import {useHistory} from 'react-router-dom'
+
+// Components
+import {
+  Button,
+  ComponentSize,
+  Panel,
+  IconFont,
+  FlexBox,
+  AlignItems,
+  FlexDirection,
+  JustifyContent,
+} from '@influxdata/clockface'
+import PageSpinner from 'src/perf/components/PageSpinner'
+import {UsersContext} from 'src/users/context/users'
+import {getDeleteAccountWarningButton} from 'src/shared/components/notifications/NotificationButtons'
+
+// Utils
+import {getOrg} from 'src/organizations/selectors'
+import {notify} from 'src/shared/actions/notifications'
+import {deleteAccountWarning} from 'src/shared/copy/notifications'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+
+// Types
+import {getQuartzMe} from 'src/me/selectors'
+import {NotificationButtonElement} from 'src/types'
+
+const OrgProfileTab: FC = () => {
+  const quartzMe = useSelector(getQuartzMe)
+  const org = useSelector(getOrg)
+  const history = useHistory()
+  const {status, users} = useContext(UsersContext)
+  const dispatch = useDispatch()
+
+  const handleShowDeleteOverlay = () => {
+    history.push(`/orgs/${org.id}/about/delete`)
+  }
+
+  const handleShowWarning = () => {
+    const buttonElement: NotificationButtonElement = onDismiss =>
+      getDeleteAccountWarningButton(`/orgs/${org.id}/users`, onDismiss)
+    dispatch(notify(deleteAccountWarning(buttonElement)))
+  }
+
+  let handleDeleteClick = handleShowDeleteOverlay
+
+  if (users.length > 1) {
+    handleDeleteClick = handleShowWarning
+  }
+
+  return (
+    <PageSpinner loading={status}>
+      <>
+        {isFlagEnabled('selfDeletion') && quartzMe?.accountType === 'free' && (
+          <Panel.Body size={ComponentSize.ExtraSmall}>
+            <FlexBox
+              stretchToFitWidth={true}
+              alignItems={AlignItems.Center}
+              direction={FlexDirection.Row}
+              justifyContent={JustifyContent.SpaceBetween}
+            >
+              <div>
+                <h5 style={{marginBottom: '0'}}>
+                  Delete Organization {org.name}
+                </h5>
+                <p style={{marginTop: '2px'}}>
+                  Delete your Free InfluxDB Cloud account and remove any data
+                  that you have loaded.
+                </p>
+              </div>
+              <Button
+                testID="delete-org--button"
+                text="Delete"
+                icon={IconFont.Trash}
+                onClick={handleDeleteClick}
+              />
+            </FlexBox>
+          </Panel.Body>
+        )}
+      </>
+    </PageSpinner>
+  )
+}
+
+export default OrgProfileTab

--- a/src/organizations/components/OrgProfileTab.tsx
+++ b/src/organizations/components/OrgProfileTab.tsx
@@ -70,7 +70,10 @@ const OrgProfileTab: FC = () => {
                   justifyContent={JustifyContent.SpaceBetween}
                 >
                   <div>
-                    <h5 style={{marginBottom: '0'}}>
+                    <h5
+                      style={{marginBottom: '0'}}
+                      data-testid="danger-zone--org-name"
+                    >
                       Rename Organization {org.name}
                     </h5>
                     <p style={{marginTop: '2px'}}>
@@ -131,7 +134,10 @@ const OrgProfileTab: FC = () => {
                   onCopy={generateCopyText('Organization ID', org.id)}
                   testID="copy-btn--orgid"
                 />
-                <label className="code-snippet--label">{`${org.name} | Organization ID`}</label>
+                <label
+                  className="code-snippet--label"
+                  data-testid="org-profile--name"
+                >{`${org.name} | Organization ID`}</label>
               </div>
             </div>
           </Panel.Body>

--- a/src/organizations/components/OrgProfileTab.tsx
+++ b/src/organizations/components/OrgProfileTab.tsx
@@ -21,6 +21,7 @@ import {
 import CopyButton from 'src/shared/components/CopyButton'
 import PageSpinner from 'src/perf/components/PageSpinner'
 import {UsersContext} from 'src/users/context/users'
+import {getDeleteAccountWarningButton} from 'src/shared/components/notifications/NotificationButtons'
 
 // Utils
 import {getOrg} from 'src/organizations/selectors'
@@ -30,6 +31,7 @@ import {deleteAccountWarning} from 'src/shared/copy/notifications'
 
 // Types
 import {getMe, getQuartzMe} from 'src/me/selectors'
+import {NotificationButtonElement} from 'src/types'
 
 const OrgProfileTab: FC = () => {
   const me = useSelector(getMe)
@@ -48,7 +50,9 @@ const OrgProfileTab: FC = () => {
   }
 
   const handleShowWarning = () => {
-    dispatch(notify(deleteAccountWarning()))
+    const buttonElement: NotificationButtonElement = onDismiss =>
+      getDeleteAccountWarningButton(`/users`, onDismiss)
+    dispatch(notify(deleteAccountWarning(buttonElement)))
   }
 
   const generateCopyText = (title, text) => () => {

--- a/src/organizations/components/OrgProfileTab.tsx
+++ b/src/organizations/components/OrgProfileTab.tsx
@@ -1,6 +1,6 @@
 // Libraries
-import React, {FC} from 'react'
-import {useSelector} from 'react-redux'
+import React, {FC, useContext} from 'react'
+import {useSelector, useDispatch} from 'react-redux'
 import {useHistory} from 'react-router-dom'
 
 // Components
@@ -19,17 +19,25 @@ import {
   Columns,
 } from '@influxdata/clockface'
 import CopyButton from 'src/shared/components/CopyButton'
+import PageSpinner from 'src/perf/components/PageSpinner'
+import {UsersContext} from 'src/users/context/users'
 
+// Utils
 import {getOrg} from 'src/organizations/selectors'
 import {copyToClipboardSuccess} from 'src/shared/copy/notifications'
+import {notify} from 'src/shared/actions/notifications'
+import {deleteAccountWarning} from 'src/shared/copy/notifications'
 
 // Types
-import {getMe} from 'src/me/selectors'
+import {getMe, getQuartzMe} from 'src/me/selectors'
 
 const OrgProfileTab: FC = () => {
   const me = useSelector(getMe)
+  const quartzMe = useSelector(getQuartzMe)
   const org = useSelector(getOrg)
   const history = useHistory()
+  const {status, users} = useContext(UsersContext)
+  const dispatch = useDispatch()
 
   const handleShowEditOverlay = () => {
     history.push(`/orgs/${org.id}/about/rename`)
@@ -39,114 +47,126 @@ const OrgProfileTab: FC = () => {
     history.push(`/orgs/${org.id}/about/delete`)
   }
 
+  const handleShowWarning = () => {
+    dispatch(notify(deleteAccountWarning()))
+  }
+
   const generateCopyText = (title, text) => () => {
     return copyToClipboardSuccess(text, title)
   }
 
+  let handleDeleteClick = handleShowDeleteOverlay
+
+  if (users.length > 1) {
+    handleDeleteClick = handleShowWarning
+  }
+
   return (
-    <>
-      <Grid.Column widthXS={Columns.Twelve} widthSM={Columns.Six}>
-        <Panel backgroundColor={InfluxColors.Onyx}>
-          <Panel.Header size={ComponentSize.Small}>
-            <h4>Organization Profile</h4>
-          </Panel.Header>
-          <Panel.Body size={ComponentSize.Small}>
-            <Panel gradient={Gradients.DocScott}>
-              <Panel.Header size={ComponentSize.ExtraSmall}>
-                <h5>Danger Zone!</h5>
-              </Panel.Header>
-              <Panel.Body size={ComponentSize.ExtraSmall}>
-                <FlexBox
-                  stretchToFitWidth={true}
-                  alignItems={AlignItems.Center}
-                  direction={FlexDirection.Row}
-                  justifyContent={JustifyContent.SpaceBetween}
-                >
-                  <div>
-                    <h5 style={{marginBottom: '0'}}>
-                      Rename Organization {org.name}
-                    </h5>
-                    <p style={{marginTop: '2px'}}>
-                      This action can have wide-reaching unintended
-                      consequences.
-                    </p>
-                  </div>
-                  <Button
-                    testID="rename-org--button"
-                    text="Rename"
-                    icon={IconFont.Pencil}
-                    onClick={handleShowEditOverlay}
+    <PageSpinner loading={status}>
+      <>
+        <Grid.Column widthXS={Columns.Twelve} widthSM={Columns.Six}>
+          <Panel backgroundColor={InfluxColors.Onyx}>
+            <Panel.Header size={ComponentSize.Small}>
+              <h4>Organization Profile</h4>
+            </Panel.Header>
+            <Panel.Body size={ComponentSize.Small}>
+              <Panel gradient={Gradients.DocScott}>
+                <Panel.Header size={ComponentSize.ExtraSmall}>
+                  <h5>Danger Zone!</h5>
+                </Panel.Header>
+                <Panel.Body size={ComponentSize.ExtraSmall}>
+                  <FlexBox
+                    stretchToFitWidth={true}
+                    alignItems={AlignItems.Center}
+                    direction={FlexDirection.Row}
+                    justifyContent={JustifyContent.SpaceBetween}
+                  >
+                    <div>
+                      <h5 style={{marginBottom: '0'}}>
+                        Rename Organization {org.name}
+                      </h5>
+                      <p style={{marginTop: '2px'}}>
+                        This action can have wide-reaching unintended
+                        consequences.
+                      </p>
+                    </div>
+                    <Button
+                      testID="rename-org--button"
+                      text="Rename"
+                      icon={IconFont.Pencil}
+                      onClick={handleShowEditOverlay}
+                    />
+                  </FlexBox>
+                </Panel.Body>
+                {quartzMe?.accountType === 'free' && (
+                  <Panel.Body size={ComponentSize.ExtraSmall}>
+                    <FlexBox
+                      stretchToFitWidth={true}
+                      alignItems={AlignItems.Center}
+                      direction={FlexDirection.Row}
+                      justifyContent={JustifyContent.SpaceBetween}
+                    >
+                      <div>
+                        <h5 style={{marginBottom: '0'}}>
+                          Delete Organization {org.name}
+                        </h5>
+                        <p style={{marginTop: '2px'}}>
+                          Delete your Free InfluxDB Cloud account and remove any
+                          data that you have loaded.
+                        </p>
+                      </div>
+                      <Button
+                        testID="delete-org--button"
+                        text="Delete"
+                        icon={IconFont.Trash}
+                        onClick={handleDeleteClick}
+                      />
+                    </FlexBox>
+                  </Panel.Body>
+                )}
+              </Panel>
+            </Panel.Body>
+          </Panel>
+        </Grid.Column>
+        <Grid.Column widthXS={Columns.Twelve} widthSM={Columns.Six}>
+          <Panel>
+            <Panel.Header size={ComponentSize.ExtraSmall}>
+              <h4>Common Ids</h4>
+            </Panel.Header>
+            <Panel.Body>
+              <div className="code-snippet" data-testid="code-snippet">
+                <div className="code-snippet--text">
+                  <pre>
+                    <code>{me.id}</code>
+                  </pre>
+                </div>
+                <div className="code-snippet--footer">
+                  <CopyButton
+                    text={me.id}
+                    onCopy={generateCopyText('User ID', me.id)}
                   />
-                </FlexBox>
-              </Panel.Body>
-              {/* TODO(ariel): conditionally render this */}
-              <Panel.Body size={ComponentSize.ExtraSmall}>
-                <FlexBox
-                  stretchToFitWidth={true}
-                  alignItems={AlignItems.Center}
-                  direction={FlexDirection.Row}
-                  justifyContent={JustifyContent.SpaceBetween}
-                >
-                  <div>
-                    <h5 style={{marginBottom: '0'}}>
-                      Delete Organization {org.name}
-                    </h5>
-                    <p style={{marginTop: '2px'}}>
-                      Delete Organization Delete your Free InfluxDB Cloud
-                      account and remove any data that you have loaded.
-                    </p>
-                  </div>
-                  <Button
-                    testID="delete-org--button"
-                    text="Delete"
-                    icon={IconFont.Trash}
-                    onClick={handleShowDeleteOverlay}
-                    // TODO(ariel): disable this button if there are more than one users for the account
+                  <label className="code-snippet--label">{`${me.name} | User ID`}</label>
+                </div>
+              </div>
+              <div className="code-snippet" data-testid="code-snippet">
+                <div className="code-snippet--text">
+                  <pre>
+                    <code>{org.id}</code>
+                  </pre>
+                </div>
+                <div className="code-snippet--footer">
+                  <CopyButton
+                    text={org.id}
+                    onCopy={generateCopyText('Organization ID', org.id)}
                   />
-                </FlexBox>
-              </Panel.Body>
-            </Panel>
-          </Panel.Body>
-        </Panel>
-      </Grid.Column>
-      <Grid.Column widthXS={Columns.Twelve} widthSM={Columns.Six}>
-        <Panel>
-          <Panel.Header size={ComponentSize.ExtraSmall}>
-            <h4>Common Ids</h4>
-          </Panel.Header>
-          <Panel.Body>
-            <div className="code-snippet" data-testid="code-snippet">
-              <div className="code-snippet--text">
-                <pre>
-                  <code>{me.id}</code>
-                </pre>
+                  <label className="code-snippet--label">{`${org.name} | Organization ID`}</label>
+                </div>
               </div>
-              <div className="code-snippet--footer">
-                <CopyButton
-                  text={me.id}
-                  onCopy={generateCopyText('User ID', me.id)}
-                />
-                <label className="code-snippet--label">{`${me.name} | User ID`}</label>
-              </div>
-            </div>
-            <div className="code-snippet" data-testid="code-snippet">
-              <div className="code-snippet--text">
-                <pre>
-                  <code>{org.id}</code>
-                </pre>
-              </div>
-              <div className="code-snippet--footer">
-                <CopyButton
-                  text={org.id}
-                  onCopy={generateCopyText('Organization ID', org.id)}
-                />
-                <label className="code-snippet--label">{`${org.name} | Organization ID`}</label>
-              </div>
-            </div>
-          </Panel.Body>
-        </Panel>
-      </Grid.Column>
-    </>
+            </Panel.Body>
+          </Panel>
+        </Grid.Column>
+      </>
+    </PageSpinner>
   )
 }
 

--- a/src/organizations/components/OrgProfileTab.tsx
+++ b/src/organizations/components/OrgProfileTab.tsx
@@ -1,11 +1,10 @@
 // Libraries
-import React, {PureComponent} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
-import {RouteComponentProps, withRouter} from 'react-router-dom'
+import React, {FC} from 'react'
+import {useSelector} from 'react-redux'
+import {useHistory} from 'react-router-dom'
 
 // Components
 import {
-  Form,
   Button,
   ComponentSize,
   Panel,
@@ -19,131 +18,136 @@ import {
   Grid,
   Columns,
 } from '@influxdata/clockface'
-import {ErrorHandling} from 'src/shared/decorators/errors'
 import CopyButton from 'src/shared/components/CopyButton'
 
 import {getOrg} from 'src/organizations/selectors'
 import {copyToClipboardSuccess} from 'src/shared/copy/notifications'
 
 // Types
-import {ButtonType} from 'src/clockface'
-import {AppState} from 'src/types'
+import {getMe} from 'src/me/selectors'
 
-type ReduxProps = ConnectedProps<typeof connector>
-type Props = ReduxProps & RouteComponentProps<{orgID: string}>
+const OrgProfileTab: FC = () => {
+  const me = useSelector(getMe)
+  const org = useSelector(getOrg)
+  const history = useHistory()
 
-@ErrorHandling
-class OrgProfileTab extends PureComponent<Props> {
-  public render() {
-    return (
-      <>
-        <Grid.Column widthXS={Columns.Twelve} widthSM={Columns.Six}>
-          <Panel backgroundColor={InfluxColors.Onyx}>
-            <Panel.Header size={ComponentSize.Small}>
-              <h4>Organization Profile</h4>
-            </Panel.Header>
-            <Panel.Body size={ComponentSize.Small}>
-              <Form onSubmit={this.handleShowEditOverlay}>
-                <Panel gradient={Gradients.DocScott}>
-                  <Panel.Header size={ComponentSize.ExtraSmall}>
-                    <h5>Danger Zone!</h5>
-                  </Panel.Header>
-                  <Panel.Body size={ComponentSize.ExtraSmall}>
-                    <FlexBox
-                      stretchToFitWidth={true}
-                      alignItems={AlignItems.Center}
-                      direction={FlexDirection.Row}
-                      justifyContent={JustifyContent.SpaceBetween}
-                    >
-                      <div>
-                        <h5 style={{marginBottom: '0'}}>
-                          Rename Organization {this.props.org.name}
-                        </h5>
-                        <p style={{marginTop: '2px'}}>
-                          This action can have wide-reaching unintended
-                          consequences.
-                        </p>
-                      </div>
-                      <Button
-                        testID="rename-org--button"
-                        text="Rename"
-                        icon={IconFont.Pencil}
-                        type={ButtonType.Submit}
-                      />
-                    </FlexBox>
-                  </Panel.Body>
-                </Panel>
-              </Form>
-            </Panel.Body>
-          </Panel>
-        </Grid.Column>
-        <Grid.Column widthXS={Columns.Twelve} widthSM={Columns.Six}>
-          <Panel>
-            <Panel.Header size={ComponentSize.ExtraSmall}>
-              <h4>Common Ids</h4>
-            </Panel.Header>
-            <Panel.Body>
-              <div className="code-snippet" data-testid="code-snippet">
-                <div className="code-snippet--text">
-                  <pre>
-                    <code>{this.props.me.id}</code>
-                  </pre>
-                </div>
-                <div className="code-snippet--footer">
-                  <CopyButton
-                    text={this.props.me.id}
-                    onCopy={this.generateCopyText('User ID', this.props.me.id)}
-                  />
-                  <label className="code-snippet--label">{`${this.props.me.name} | User ID`}</label>
-                </div>
-              </div>
-              <div className="code-snippet" data-testid="code-snippet">
-                <div className="code-snippet--text">
-                  <pre>
-                    <code>{this.props.org.id}</code>
-                  </pre>
-                </div>
-                <div className="code-snippet--footer">
-                  <CopyButton
-                    text={this.props.org.id}
-                    onCopy={this.generateCopyText(
-                      'Organization ID',
-                      this.props.org.id
-                    )}
-                  />
-                  <label className="code-snippet--label">{`${this.props.org.name} | Organization ID`}</label>
-                </div>
-              </div>
-            </Panel.Body>
-          </Panel>
-        </Grid.Column>
-      </>
-    )
+  const handleShowEditOverlay = () => {
+    history.push(`/orgs/${org.id}/about/rename`)
   }
 
-  private handleShowEditOverlay = () => {
-    const {
-      match: {
-        params: {orgID},
-      },
-      history,
-    } = this.props
-
-    history.push(`/orgs/${orgID}/about/rename`)
+  const handleShowDeleteOverlay = () => {
+    history.push(`/orgs/${org.id}/about/delete`)
   }
 
-  private generateCopyText = (title, text) => () => {
+  const generateCopyText = (title, text) => () => {
     return copyToClipboardSuccess(text, title)
   }
+
+  return (
+    <>
+      <Grid.Column widthXS={Columns.Twelve} widthSM={Columns.Six}>
+        <Panel backgroundColor={InfluxColors.Onyx}>
+          <Panel.Header size={ComponentSize.Small}>
+            <h4>Organization Profile</h4>
+          </Panel.Header>
+          <Panel.Body size={ComponentSize.Small}>
+            <Panel gradient={Gradients.DocScott}>
+              <Panel.Header size={ComponentSize.ExtraSmall}>
+                <h5>Danger Zone!</h5>
+              </Panel.Header>
+              <Panel.Body size={ComponentSize.ExtraSmall}>
+                <FlexBox
+                  stretchToFitWidth={true}
+                  alignItems={AlignItems.Center}
+                  direction={FlexDirection.Row}
+                  justifyContent={JustifyContent.SpaceBetween}
+                >
+                  <div>
+                    <h5 style={{marginBottom: '0'}}>
+                      Rename Organization {org.name}
+                    </h5>
+                    <p style={{marginTop: '2px'}}>
+                      This action can have wide-reaching unintended
+                      consequences.
+                    </p>
+                  </div>
+                  <Button
+                    testID="rename-org--button"
+                    text="Rename"
+                    icon={IconFont.Pencil}
+                    onClick={handleShowEditOverlay}
+                  />
+                </FlexBox>
+              </Panel.Body>
+              {/* TODO(ariel): conditionally render this */}
+              <Panel.Body size={ComponentSize.ExtraSmall}>
+                <FlexBox
+                  stretchToFitWidth={true}
+                  alignItems={AlignItems.Center}
+                  direction={FlexDirection.Row}
+                  justifyContent={JustifyContent.SpaceBetween}
+                >
+                  <div>
+                    <h5 style={{marginBottom: '0'}}>
+                      Delete Organization {org.name}
+                    </h5>
+                    <p style={{marginTop: '2px'}}>
+                      Delete Organization Delete your Free InfluxDB Cloud
+                      account and remove any data that you have loaded.
+                    </p>
+                  </div>
+                  <Button
+                    testID="delete-org--button"
+                    text="Delete"
+                    icon={IconFont.Trash}
+                    onClick={handleShowDeleteOverlay}
+                    // TODO(ariel): disable this button if there are more than one users for the account
+                  />
+                </FlexBox>
+              </Panel.Body>
+            </Panel>
+          </Panel.Body>
+        </Panel>
+      </Grid.Column>
+      <Grid.Column widthXS={Columns.Twelve} widthSM={Columns.Six}>
+        <Panel>
+          <Panel.Header size={ComponentSize.ExtraSmall}>
+            <h4>Common Ids</h4>
+          </Panel.Header>
+          <Panel.Body>
+            <div className="code-snippet" data-testid="code-snippet">
+              <div className="code-snippet--text">
+                <pre>
+                  <code>{me.id}</code>
+                </pre>
+              </div>
+              <div className="code-snippet--footer">
+                <CopyButton
+                  text={me.id}
+                  onCopy={generateCopyText('User ID', me.id)}
+                />
+                <label className="code-snippet--label">{`${me.name} | User ID`}</label>
+              </div>
+            </div>
+            <div className="code-snippet" data-testid="code-snippet">
+              <div className="code-snippet--text">
+                <pre>
+                  <code>{org.id}</code>
+                </pre>
+              </div>
+              <div className="code-snippet--footer">
+                <CopyButton
+                  text={org.id}
+                  onCopy={generateCopyText('Organization ID', org.id)}
+                />
+                <label className="code-snippet--label">{`${org.name} | Organization ID`}</label>
+              </div>
+            </div>
+          </Panel.Body>
+        </Panel>
+      </Grid.Column>
+    </>
+  )
 }
 
-const mstp = (state: AppState) => {
-  return {
-    org: getOrg(state),
-    me: state.me,
-  }
-}
-
-const connector = connect(mstp)
-
-export default connector(withRouter(OrgProfileTab))
+export default OrgProfileTab

--- a/src/organizations/components/OrgProfileTab.tsx
+++ b/src/organizations/components/OrgProfileTab.tsx
@@ -1,6 +1,6 @@
 // Libraries
-import React, {FC, useContext} from 'react'
-import {useSelector, useDispatch} from 'react-redux'
+import React, {FC} from 'react'
+import {useSelector} from 'react-redux'
 import {useHistory} from 'react-router-dom'
 
 // Components
@@ -19,158 +19,125 @@ import {
   Columns,
 } from '@influxdata/clockface'
 import CopyButton from 'src/shared/components/CopyButton'
-import PageSpinner from 'src/perf/components/PageSpinner'
-import {UsersContext} from 'src/users/context/users'
-import {getDeleteAccountWarningButton} from 'src/shared/components/notifications/NotificationButtons'
+import UsersProvider from 'src/users/context/users'
+import OrgProfileDeletePanel from 'src/organizations/components/OrgProfileDeletePanel'
 
 // Utils
 import {getOrg} from 'src/organizations/selectors'
 import {copyToClipboardSuccess} from 'src/shared/copy/notifications'
-import {notify} from 'src/shared/actions/notifications'
-import {deleteAccountWarning} from 'src/shared/copy/notifications'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import {CLOUD} from 'src/shared/constants'
 
 // Types
-import {getMe, getQuartzMe} from 'src/me/selectors'
-import {NotificationButtonElement} from 'src/types'
+import {getMe} from 'src/me/selectors'
 
 const OrgProfileTab: FC = () => {
   const me = useSelector(getMe)
-  const quartzMe = useSelector(getQuartzMe)
   const org = useSelector(getOrg)
   const history = useHistory()
-  const {status, users} = useContext(UsersContext)
-  const dispatch = useDispatch()
 
   const handleShowEditOverlay = () => {
     history.push(`/orgs/${org.id}/about/rename`)
-  }
-
-  const handleShowDeleteOverlay = () => {
-    history.push(`/orgs/${org.id}/about/delete`)
-  }
-
-  const handleShowWarning = () => {
-    const buttonElement: NotificationButtonElement = onDismiss =>
-      getDeleteAccountWarningButton(`/orgs/${org.id}/users`, onDismiss)
-    dispatch(notify(deleteAccountWarning(buttonElement)))
   }
 
   const generateCopyText = (title, text) => () => {
     return copyToClipboardSuccess(text, title)
   }
 
-  let handleDeleteClick = handleShowDeleteOverlay
-
-  if (users.length > 1) {
-    handleDeleteClick = handleShowWarning
-  }
-
   return (
-    <PageSpinner loading={status}>
-      <>
-        <Grid.Column widthXS={Columns.Twelve} widthSM={Columns.Six}>
-          <Panel backgroundColor={InfluxColors.Onyx}>
-            <Panel.Header size={ComponentSize.Small}>
-              <h4>Organization Profile</h4>
-            </Panel.Header>
-            <Panel.Body size={ComponentSize.Small}>
-              <Panel gradient={Gradients.DocScott}>
-                <Panel.Header size={ComponentSize.ExtraSmall}>
-                  <h5>Danger Zone!</h5>
-                </Panel.Header>
-                <Panel.Body size={ComponentSize.ExtraSmall}>
-                  <FlexBox
-                    stretchToFitWidth={true}
-                    alignItems={AlignItems.Center}
-                    direction={FlexDirection.Row}
-                    justifyContent={JustifyContent.SpaceBetween}
-                  >
-                    <div>
-                      <h5 style={{marginBottom: '0'}}>
-                        Rename Organization {org.name}
-                      </h5>
-                      <p style={{marginTop: '2px'}}>
-                        This action can have wide-reaching unintended
-                        consequences.
-                      </p>
-                    </div>
-                    <Button
-                      testID="rename-org--button"
-                      text="Rename"
-                      icon={IconFont.Pencil}
-                      onClick={handleShowEditOverlay}
-                    />
-                  </FlexBox>
-                </Panel.Body>
-                {quartzMe?.accountType === 'free' && (
-                  <Panel.Body size={ComponentSize.ExtraSmall}>
-                    <FlexBox
-                      stretchToFitWidth={true}
-                      alignItems={AlignItems.Center}
-                      direction={FlexDirection.Row}
-                      justifyContent={JustifyContent.SpaceBetween}
-                    >
-                      <div>
-                        <h5 style={{marginBottom: '0'}}>
-                          Delete Organization {org.name}
-                        </h5>
-                        <p style={{marginTop: '2px'}}>
-                          Delete your Free InfluxDB Cloud account and remove any
-                          data that you have loaded.
-                        </p>
-                      </div>
-                      <Button
-                        testID="delete-org--button"
-                        text="Delete"
-                        icon={IconFont.Trash}
-                        onClick={handleDeleteClick}
-                      />
-                    </FlexBox>
-                  </Panel.Body>
-                )}
-              </Panel>
-            </Panel.Body>
-          </Panel>
-        </Grid.Column>
-        <Grid.Column widthXS={Columns.Twelve} widthSM={Columns.Six}>
-          <Panel>
-            <Panel.Header size={ComponentSize.ExtraSmall}>
-              <h4>Common Ids</h4>
-            </Panel.Header>
-            <Panel.Body>
-              <div className="code-snippet" data-testid="code-snippet">
-                <div className="code-snippet--text">
-                  <pre>
-                    <code>{me.id}</code>
-                  </pre>
-                </div>
-                <div className="code-snippet--footer">
-                  <CopyButton
-                    text={me.id}
-                    onCopy={generateCopyText('User ID', me.id)}
+    <>
+      <Grid.Column widthXS={Columns.Twelve} widthSM={Columns.Six}>
+        <Panel
+          backgroundColor={InfluxColors.Onyx}
+          testID="organization-profile--panel"
+        >
+          <Panel.Header size={ComponentSize.Small}>
+            <h4>Organization Profile</h4>
+          </Panel.Header>
+          <Panel.Body size={ComponentSize.Small}>
+            <Panel gradient={Gradients.DocScott}>
+              <Panel.Header
+                size={ComponentSize.ExtraSmall}
+                testID="danger-zone--header"
+              >
+                <h5>Danger Zone!</h5>
+              </Panel.Header>
+              <Panel.Body size={ComponentSize.ExtraSmall}>
+                <FlexBox
+                  stretchToFitWidth={true}
+                  alignItems={AlignItems.Center}
+                  direction={FlexDirection.Row}
+                  justifyContent={JustifyContent.SpaceBetween}
+                >
+                  <div>
+                    <h5 style={{marginBottom: '0'}}>
+                      Rename Organization {org.name}
+                    </h5>
+                    <p style={{marginTop: '2px'}}>
+                      This action can have wide-reaching unintended
+                      consequences.
+                    </p>
+                  </div>
+                  <Button
+                    testID="rename-org--button"
+                    text="Rename"
+                    icon={IconFont.Pencil}
+                    onClick={handleShowEditOverlay}
                   />
-                  <label className="code-snippet--label">{`${me.name} | User ID`}</label>
-                </div>
+                </FlexBox>
+              </Panel.Body>
+              {CLOUD && isFlagEnabled('unityUsers') && (
+                <UsersProvider>
+                  <OrgProfileDeletePanel />
+                </UsersProvider>
+              )}
+            </Panel>
+          </Panel.Body>
+        </Panel>
+      </Grid.Column>
+      <Grid.Column widthXS={Columns.Twelve} widthSM={Columns.Six}>
+        <Panel testID="common-ids--panel">
+          <Panel.Header
+            size={ComponentSize.ExtraSmall}
+            testID="common-ids--header"
+          >
+            <h4>Common Ids</h4>
+          </Panel.Header>
+          <Panel.Body>
+            <div className="code-snippet" data-testid="code-snippet--userid">
+              <div className="code-snippet--text">
+                <pre>
+                  <code>{me.id}</code>
+                </pre>
               </div>
-              <div className="code-snippet" data-testid="code-snippet">
-                <div className="code-snippet--text">
-                  <pre>
-                    <code>{org.id}</code>
-                  </pre>
-                </div>
-                <div className="code-snippet--footer">
-                  <CopyButton
-                    text={org.id}
-                    onCopy={generateCopyText('Organization ID', org.id)}
-                  />
-                  <label className="code-snippet--label">{`${org.name} | Organization ID`}</label>
-                </div>
+              <div className="code-snippet--footer">
+                <CopyButton
+                  text={me.id}
+                  testID="copy-btn--userid"
+                  onCopy={generateCopyText('User ID', me.id)}
+                />
+                <label className="code-snippet--label">{`${me.name} | User ID`}</label>
               </div>
-            </Panel.Body>
-          </Panel>
-        </Grid.Column>
-      </>
-    </PageSpinner>
+            </div>
+            <div className="code-snippet" data-testid="code-snippet--orgid">
+              <div className="code-snippet--text">
+                <pre>
+                  <code>{org.id}</code>
+                </pre>
+              </div>
+              <div className="code-snippet--footer">
+                <CopyButton
+                  text={org.id}
+                  onCopy={generateCopyText('Organization ID', org.id)}
+                  testID="copy-btn--orgid"
+                />
+                <label className="code-snippet--label">{`${org.name} | Organization ID`}</label>
+              </div>
+            </div>
+          </Panel.Body>
+        </Panel>
+      </Grid.Column>
+    </>
   )
 }
 

--- a/src/organizations/components/OrgProfileTab.tsx
+++ b/src/organizations/components/OrgProfileTab.tsx
@@ -51,7 +51,7 @@ const OrgProfileTab: FC = () => {
 
   const handleShowWarning = () => {
     const buttonElement: NotificationButtonElement = onDismiss =>
-      getDeleteAccountWarningButton(`/users`, onDismiss)
+      getDeleteAccountWarningButton(`/orgs/${org.id}/users`, onDismiss)
     dispatch(notify(deleteAccountWarning(buttonElement)))
   }
 

--- a/src/organizations/components/OrgTabbedPage.tsx
+++ b/src/organizations/components/OrgTabbedPage.tsx
@@ -10,18 +10,17 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface Props {
   activeTab: string
-  orgID: string
 }
 
 @ErrorHandling
 class OrgTabbedPage extends PureComponent<Props> {
   public render() {
-    const {activeTab, orgID, children} = this.props
+    const {activeTab, children} = this.props
 
     return (
       <Page.Contents fullWidth={false} scrollable={true}>
         <Tabs.Container orientation={Orientation.Horizontal}>
-          <OrgNavigation activeTab={activeTab} orgID={orgID} />
+          <OrgNavigation activeTab={activeTab} />
           <Tabs.TabContents>{children}</Tabs.TabContents>
         </Tabs.Container>
       </Page.Contents>

--- a/src/organizations/components/RenameOrgOverlay.tsx
+++ b/src/organizations/components/RenameOrgOverlay.tsx
@@ -45,14 +45,9 @@ class RenameOrgOverlay extends PureComponent<
   }
 
   private handleClose = () => {
-    const {
-      history,
-      match: {
-        params: {orgID},
-      },
-    } = this.props
+    const {history} = this.props
 
-    history.push(`/orgs/${orgID}/about`)
+    history.goBack()
   }
 }
 

--- a/src/organizations/containers/OrgProfilePage.tsx
+++ b/src/organizations/containers/OrgProfilePage.tsx
@@ -1,55 +1,32 @@
 // Libraries
-import React, {Component} from 'react'
-import {connect} from 'react-redux'
+import React, {FC} from 'react'
 import {Switch, Route} from 'react-router-dom'
 
 // Components
-import {ErrorHandling} from 'src/shared/decorators/errors'
 import OrgTabbedPage from 'src/organizations/components/OrgTabbedPage'
 import OrgHeader from 'src/organizations/components/OrgHeader'
-import {Grid, Page} from '@influxdata/clockface'
+import {Page} from '@influxdata/clockface'
 import OrgProfileTab from 'src/organizations/components/OrgProfileTab'
 import RenameOrgOverlay from 'src/organizations/components/RenameOrgOverlay'
+import DeleteOrgOverlay from 'src/organizations/components/DeleteOrgOverlay'
 
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
-import {getOrg} from 'src/organizations/selectors'
 
-// Types
-import {AppState, Organization} from 'src/types'
+const OrgProfilePage: FC = () => (
+  <>
+    <Page titleTag={pageTitleSuffixer(['About', 'Organization'])}>
+      <OrgHeader />
+      <OrgTabbedPage activeTab="about">
+        <OrgProfileTab />
+      </OrgTabbedPage>
+    </Page>
+    <Switch>
+      <Route path="/orgs/:orgID/about/rename" component={RenameOrgOverlay} />
+      {/* TODO(ariel): guard against this route for only free users */}
+      <Route path="/orgs/:orgID/about/delete" component={DeleteOrgOverlay} />
+    </Switch>
+  </>
+)
 
-interface StateProps {
-  org: Organization
-}
-
-@ErrorHandling
-class OrgProfilePage extends Component<StateProps> {
-  public render() {
-    const {org} = this.props
-
-    return (
-      <>
-        <Page titleTag={pageTitleSuffixer(['About', 'Organization'])}>
-          <OrgHeader />
-          <OrgTabbedPage activeTab="about" orgID={org.id}>
-            <Grid>
-              <Grid.Row>
-                <OrgProfileTab />
-              </Grid.Row>
-            </Grid>
-          </OrgTabbedPage>
-        </Page>
-        <Switch>
-          <Route
-            path="/orgs/:orgID/about/rename"
-            component={RenameOrgOverlay}
-          />
-        </Switch>
-      </>
-    )
-  }
-}
-
-const mstp = (state: AppState) => ({org: getOrg(state)})
-
-export default connect<StateProps>(mstp)(OrgProfilePage)
+export default OrgProfilePage

--- a/src/organizations/containers/OrgProfilePage.tsx
+++ b/src/organizations/containers/OrgProfilePage.tsx
@@ -10,11 +10,11 @@ import {Page} from '@influxdata/clockface'
 import OrgProfileTab from 'src/organizations/components/OrgProfileTab'
 import RenameOrgOverlay from 'src/organizations/components/RenameOrgOverlay'
 import DeleteOrgOverlay from 'src/organizations/components/DeleteOrgOverlay'
-import UsersProvider from 'src/users/context/users'
 
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 import {getQuartzMe} from 'src/me/selectors'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 const OrgProfilePage: FC = () => {
   const quartzMe = useSelector(getQuartzMe)
@@ -22,16 +22,14 @@ const OrgProfilePage: FC = () => {
   return (
     <>
       <Page titleTag={pageTitleSuffixer(['About', 'Organization'])}>
-        <OrgHeader />
+        <OrgHeader testID="about-page--header" />
         <OrgTabbedPage activeTab="about">
-          <UsersProvider>
-            <OrgProfileTab />
-          </UsersProvider>
+          <OrgProfileTab />
         </OrgTabbedPage>
       </Page>
       <Switch>
         <Route path="/orgs/:orgID/about/rename" component={RenameOrgOverlay} />
-        {quartzMe?.accountType === 'free' && (
+        {isFlagEnabled('selfDeletion') && quartzMe?.accountType === 'free' && (
           <Route
             path="/orgs/:orgID/about/delete"
             component={DeleteOrgOverlay}

--- a/src/organizations/containers/OrgProfilePage.tsx
+++ b/src/organizations/containers/OrgProfilePage.tsx
@@ -1,5 +1,6 @@
 // Libraries
 import React, {FC} from 'react'
+import {useSelector} from 'react-redux'
 import {Switch, Route} from 'react-router-dom'
 
 // Components
@@ -9,24 +10,36 @@ import {Page} from '@influxdata/clockface'
 import OrgProfileTab from 'src/organizations/components/OrgProfileTab'
 import RenameOrgOverlay from 'src/organizations/components/RenameOrgOverlay'
 import DeleteOrgOverlay from 'src/organizations/components/DeleteOrgOverlay'
+import UsersProvider from 'src/users/context/users'
 
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
+import {getQuartzMe} from 'src/me/selectors'
 
-const OrgProfilePage: FC = () => (
-  <>
-    <Page titleTag={pageTitleSuffixer(['About', 'Organization'])}>
-      <OrgHeader />
-      <OrgTabbedPage activeTab="about">
-        <OrgProfileTab />
-      </OrgTabbedPage>
-    </Page>
-    <Switch>
-      <Route path="/orgs/:orgID/about/rename" component={RenameOrgOverlay} />
-      {/* TODO(ariel): guard against this route for only free users */}
-      <Route path="/orgs/:orgID/about/delete" component={DeleteOrgOverlay} />
-    </Switch>
-  </>
-)
+const OrgProfilePage: FC = () => {
+  const quartzMe = useSelector(getQuartzMe)
+
+  return (
+    <>
+      <Page titleTag={pageTitleSuffixer(['About', 'Organization'])}>
+        <OrgHeader />
+        <OrgTabbedPage activeTab="about">
+          <UsersProvider>
+            <OrgProfileTab />
+          </UsersProvider>
+        </OrgTabbedPage>
+      </Page>
+      <Switch>
+        <Route path="/orgs/:orgID/about/rename" component={RenameOrgOverlay} />
+        {quartzMe?.accountType === 'free' && (
+          <Route
+            path="/orgs/:orgID/about/delete"
+            component={DeleteOrgOverlay}
+          />
+        )}
+      </Switch>
+    </>
+  )
+}
 
 export default OrgProfilePage

--- a/src/shared/components/CopyButton.tsx
+++ b/src/shared/components/CopyButton.tsx
@@ -13,12 +13,13 @@ import {
 interface Props {
   text: string
   size?: ComponentSize
+  testID?: string
   onCopy?: () => void
 }
 
 class CopyButton extends PureComponent<Props> {
   public render() {
-    const {text, size} = this.props
+    const {text, testID, size} = this.props
     return (
       <CopyToClipboard text={text} onCopy={this.handleCopyAttempt}>
         <Button
@@ -28,7 +29,7 @@ class CopyButton extends PureComponent<Props> {
           titleText="Copy to Clipboard"
           text="Copy to Clipboard"
           onClick={this.handleClickCopy}
-          testID="button-copy"
+          testID={testID ?? 'button-copy'}
         />
       </CopyToClipboard>
     )

--- a/src/shared/components/dangerConfirmation/DangerConfirmationForm.tsx
+++ b/src/shared/components/dangerConfirmation/DangerConfirmationForm.tsx
@@ -51,7 +51,7 @@ class DangerConfirmationForm extends PureComponent<Props> {
               color={ComponentColor.Danger}
               text={this.props.confirmButtonText}
               type={ButtonType.Submit}
-              testID="danger-confirmation-button"
+              testID="danger-confirmation--button"
             />
           </Form.Footer>
         </FlexBox>

--- a/src/shared/components/notifications/NotificationButtons.tsx
+++ b/src/shared/components/notifications/NotificationButtons.tsx
@@ -28,6 +28,20 @@ export const getDemoDataSuccessButton = (
   )
 }
 
+// TODO(ariel): get this to appear on the bottom of the notification
+export const getDeleteAccountWarningButton = (
+  url: string,
+  onDismiss: NotificationDismiss
+): JSX.Element => {
+  return (
+    <div>
+      <Link to={url} onClick={onDismiss}>
+        Go to Users page
+      </Link>
+    </div>
+  )
+}
+
 interface AggregateTypeErrorButtonProps {
   onDismiss: NotificationDismiss
 }

--- a/src/shared/components/notifications/NotificationButtons.tsx
+++ b/src/shared/components/notifications/NotificationButtons.tsx
@@ -28,17 +28,14 @@ export const getDemoDataSuccessButton = (
   )
 }
 
-// TODO(ariel): get this to appear on the bottom of the notification
 export const getDeleteAccountWarningButton = (
   url: string,
   onDismiss: NotificationDismiss
 ): JSX.Element => {
   return (
-    <div>
-      <Link to={url} onClick={onDismiss}>
-        Go to Users page
-      </Link>
-    </div>
+    <Link to={url} onClick={onDismiss}>
+      Go to Users page
+    </Link>
   )
 }
 

--- a/src/shared/components/notifications/NotificationButtons.tsx
+++ b/src/shared/components/notifications/NotificationButtons.tsx
@@ -33,7 +33,7 @@ export const getDeleteAccountWarningButton = (
   onDismiss: NotificationDismiss
 ): JSX.Element => {
   return (
-    <Link to={url} onClick={onDismiss}>
+    <Link to={url} onClick={onDismiss} data-testID="go-to-users--link">
       Go to Users page
     </Link>
   )

--- a/src/shared/components/notifications/Notifications.tsx
+++ b/src/shared/components/notifications/Notifications.tsx
@@ -31,7 +31,7 @@ const Notifications: FC = () => {
   return (
     <>
       {notifications.map(
-        ({duration, icon, id, message, style, buttonElement}) => {
+        ({duration, icon, id, message, style, styles = {}, buttonElement}) => {
           const gradient = matchGradientToColor(style)
 
           const handleDismiss = (): void => {
@@ -51,8 +51,10 @@ const Notifications: FC = () => {
               testID={`notification-${style}`}
               style={{maxWidth: '600px', alignItems: 'center'}}
             >
-              <span className="notification--message">{message}</span>
-              {buttonElement && buttonElement(handleDismiss)}
+              <span style={styles}>
+                <span className="notification--message">{message}</span>
+                {buttonElement && buttonElement(handleDismiss)}
+              </span>
             </Notification>
           )
         }

--- a/src/shared/copy/notifications.ts
+++ b/src/shared/copy/notifications.ts
@@ -39,6 +39,13 @@ const defaultErrorNotification: NotificationExcludingMessage = {
   duration: TEN_SECONDS,
 }
 
+const defaultWarningNotification: NotificationExcludingMessage = {
+  buttonElement: defaultButtonElement,
+  style: NotificationStyle.Error,
+  icon: IconFont.AlertTriangle,
+  duration: TEN_SECONDS,
+}
+
 const defaultSuccessNotification: NotificationExcludingMessage = {
   buttonElement: defaultButtonElement,
   style: NotificationStyle.Success,
@@ -1385,4 +1392,14 @@ export const removeUserFailed = (): Notification => ({
 export const zuoraParamsGetFailure = (message): Notification => ({
   ...defaultErrorNotification,
   message,
+})
+
+export const accountSelfDeletionFailed = (): Notification => ({
+  ...defaultErrorNotification,
+  message: `There was an error deleting the organization, please try again.`,
+})
+
+export const deleteAccountWarning = (): Notification => ({
+  ...defaultWarningNotification,
+  message: `All additional Users must be removed from the Organization before the account can be deleted.`,
 })

--- a/src/shared/copy/notifications.ts
+++ b/src/shared/copy/notifications.ts
@@ -1403,4 +1403,7 @@ export const deleteAccountWarning = (buttonElement): Notification => ({
   ...defaultWarningNotification,
   message: `All additional users must be removed from the Organization before the account can be deleted.\n`,
   buttonElement,
+  styles: {
+    flexWrap: 'wrap',
+  },
 })

--- a/src/shared/copy/notifications.ts
+++ b/src/shared/copy/notifications.ts
@@ -41,8 +41,8 @@ const defaultErrorNotification: NotificationExcludingMessage = {
 
 const defaultWarningNotification: NotificationExcludingMessage = {
   buttonElement: defaultButtonElement,
-  style: NotificationStyle.Error,
-  icon: IconFont.AlertTriangle,
+  style: NotificationStyle.Warning,
+  icon: IconFont.Group,
   duration: TEN_SECONDS,
 }
 
@@ -1399,7 +1399,8 @@ export const accountSelfDeletionFailed = (): Notification => ({
   message: `There was an error deleting the organization, please try again.`,
 })
 
-export const deleteAccountWarning = (): Notification => ({
+export const deleteAccountWarning = (buttonElement): Notification => ({
   ...defaultWarningNotification,
-  message: `All additional Users must be removed from the Organization before the account can be deleted.`,
+  message: `All additional users must be removed from the Organization before the account can be deleted.\n`,
+  buttonElement,
 })

--- a/src/shared/selectors/flags.ts
+++ b/src/shared/selectors/flags.ts
@@ -92,7 +92,7 @@ export const CLOUD_FLAGS = {
   'client-library--scala': true,
   'client-library--swift': true,
   'notification-endpoint-telegram': false,
-  unity: false,
+  selfDeletion: false,
   'molly-first': false,
   'managed-functions': false,
   simpleTable: false,

--- a/src/types/notifications.ts
+++ b/src/types/notifications.ts
@@ -11,6 +11,7 @@ export type NotificationButtonElement = (
 
 export interface Notification {
   id?: string
+  styles?: object
   style: NotificationStyle
   icon: IconFont
   duration?: number

--- a/src/users/components/UserListContainer.tsx
+++ b/src/users/components/UserListContainer.tsx
@@ -1,54 +1,26 @@
 // Libraries
 import React, {FC} from 'react'
-import {useParams} from 'react-router'
-import {Link} from 'react-router-dom'
-import {Page, Tabs, Orientation, ComponentSize} from '@influxdata/clockface'
+import {Page} from '@influxdata/clockface'
 
 // Components
 import UserList from 'src/users/components/UserList'
 import UserListInviteForm from 'src/users/components/UserListInviteForm'
-import RateLimitAlert from 'src/cloud/components/RateLimitAlert'
+import OrgHeader from 'src/organizations/components/OrgHeader'
+import OrgTabbedPage from 'src/organizations/components/OrgTabbedPage'
 
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 
-const UserListContainer: FC = () => {
-  const {orgID} = useParams<{orgID: string}>()
-
-  return (
-    <Page titleTag={pageTitleSuffixer(['Users', 'Organization'])}>
-      <Page.Header fullWidth={true} testID="users-page--header">
-        <Page.Title title="Organization" />
-        <RateLimitAlert />
-      </Page.Header>
-      <Page.Contents scrollable={true}>
-        <Tabs.Container orientation={Orientation.Horizontal}>
-          <Tabs size={ComponentSize.Large}>
-            <Tabs.Tab
-              id="users"
-              text="Users"
-              active={true}
-              linkElement={className => (
-                <Link className={className} to={`/orgs/${orgID}/users`} />
-              )}
-            />
-            <Tabs.Tab
-              id="about"
-              text="About"
-              active={false}
-              linkElement={className => (
-                <Link className={className} to={`/orgs/${orgID}/about`} />
-              )}
-            />
-          </Tabs>
-          <Tabs.TabContents>
-            <UserListInviteForm />
-            <UserList />
-          </Tabs.TabContents>
-        </Tabs.Container>
-      </Page.Contents>
-    </Page>
-  )
-}
+const UserListContainer: FC = () => (
+  <Page titleTag={pageTitleSuffixer(['Users', 'Organization'])}>
+    <OrgHeader testID="users-page--header" />
+    <OrgTabbedPage activeTab="users">
+      <>
+        <UserListInviteForm />
+        <UserList />
+      </>
+    </OrgTabbedPage>
+  </Page>
+)
 
 export default UserListContainer

--- a/src/users/components/UsersPage.tsx
+++ b/src/users/components/UsersPage.tsx
@@ -2,19 +2,17 @@
 import React, {useContext} from 'react'
 
 // Components
-import {SpinnerContainer, TechnoSpinner} from '@influxdata/clockface'
-import UsersListContainer from './UserListContainer'
-
-// Thunks
+import PageSpinner from 'src/perf/components/PageSpinner'
+import UsersListContainer from 'src/users/components/UserListContainer'
 import {UsersContext} from 'src/users/context/users'
 
 function UsersPage() {
   const {status} = useContext(UsersContext)
 
   return (
-    <SpinnerContainer spinnerComponent={<TechnoSpinner />} loading={status}>
+    <PageSpinner loading={status}>
       <UsersListContainer />
-    </SpinnerContainer>
+    </PageSpinner>
   )
 }
 


### PR DESCRIPTION
Closes #934 

This PR adds the UI self-deletion for free CLOUD users. This PR also consolidates some of the users and about page logic to clean up the current implementation and make things a little more DRY. This PR also updates some of the notification logic to allow for an extra `styles` object to be passed in to allow for custom styling to be applied to the children (that are now being wrapped in a span). This feature should only appear if the feature flag is turned on AND if the user is a free user. In the event that the user has more than one user associated with the organization and they try to delete the account, they will hit this warning:

![self-deletion-warning](https://user-images.githubusercontent.com/19984220/124761572-c9896080-dee6-11eb-8316-e2dcaa83dca5.gif)

If they don't have more than one user on their account they will go through the typical flow:

![self-deletion](https://user-images.githubusercontent.com/19984220/124761629-d6a64f80-dee6-11eb-8340-ad9da03c913b.gif)


