### PR TITLE
fix: only escape html for editable markdown

### DIFF
--- a/cypress/e2e/cloud/dashboardsView.test.ts
+++ b/cypress/e2e/cloud/dashboardsView.test.ts
@@ -26,7 +26,7 @@ describe('Dashboard', () => {
     const markdownImageWarning =
       "We don't support images in markdown for security purposes"
     const noteText =
-      "<img src='https://icatcare.org/app/uploads/2018/07/Thinking-of-getting-a-cat.png'/>"
+      '![](https://icatcare.org/app/uploads/2018/07/Thinking-of-getting-a-cat.png)'
 
     cy.getByTestID('add-note--button').click()
     cy.getByTestID('note-editor--overlay').within(() => {
@@ -37,6 +37,31 @@ describe('Dashboard', () => {
       cy.getByTestID('note-editor--preview').should('not.contain', noteText)
       cy.getByTestID('save-note--button').click()
     })
-    cy.getByTestID('markdown-image-unsupported').contains(markdownImageWarning)
+    cy.getByTestID('cell--view-empty markdown').contains(markdownImageWarning)
+  })
+
+  it('escapes html in markdown editor', () => {
+    cy.get('@org').then(({id: orgID}: any) => {
+      cy.createDashboard(orgID).then(({body}) => {
+        cy.fixture('routes').then(({orgs}) => {
+          cy.visit(`${orgs}/${orgID}/dashboards/${body.id}`)
+          cy.getByTestID('tree-nav')
+        })
+      })
+    })
+
+    // Note cell
+    const noteText =
+      "<img src='https://icatcare.org/app/uploads/2018/07/Thinking-of-getting-a-cat.png'/>"
+
+    cy.getByTestID('add-note--button').click()
+    cy.getByTestID('note-editor--overlay').within(() => {
+      cy.getByTestID('markdown-editor').within(() => {
+        cy.get('textarea').type(`${noteText}`, {force: true})
+      })
+      cy.getByTestID('note-editor--preview').contains(noteText)
+      cy.getByTestID('save-note--button').click()
+    })
+    cy.getByTestID('cell--view-empty markdown').contains(noteText)
   })
 })

--- a/src/shared/components/views/MarkdownRenderer.tsx
+++ b/src/shared/components/views/MarkdownRenderer.tsx
@@ -10,6 +10,7 @@ interface Props {
   className?: string
   cloudRenderers?: Renderers
   text: string
+  escapeHtml?: boolean
 }
 
 // In cloud environments, we want to render the literal markdown image tag
@@ -50,6 +51,7 @@ export const MarkdownRenderer: FC<Props> = ({
   className = '',
   cloudRenderers = {},
   text,
+  escapeHtml = true,
 }) => {
   // don't parse images in cloud environments to prevent arbitrary script execution via images
   if (CLOUD) {
@@ -60,7 +62,7 @@ export const MarkdownRenderer: FC<Props> = ({
         className={className}
         renderers={{...renderers, ...cloudRenderers}}
         astPlugins={[parseHtml]}
-        escapeHtml={false}
+        escapeHtml={escapeHtml}
       />
     )
   }

--- a/src/templates/components/CommunityTemplateReadme.tsx
+++ b/src/templates/components/CommunityTemplateReadme.tsx
@@ -32,6 +32,7 @@ class CommunityTemplateReadmeUnconnected extends Component<Props> {
       <MarkdownRenderer
         text={readme}
         className="markdown-format community-templates--readme"
+        escapeHtml={false}
       />
     )
   }

--- a/src/writeData/components/ClientCodeCopyPage/InstallPackageHelper.tsx
+++ b/src/writeData/components/ClientCodeCopyPage/InstallPackageHelper.tsx
@@ -60,6 +60,7 @@ const InstallPackageHelper: FC<Props> = ({text, codeRenderer}) => {
             <MarkdownRenderer
               text={text}
               cloudRenderers={{code: codeRenderer}}
+              escapeHtml={false}
             />
           </Panel.Body>
         )}

--- a/src/writeData/components/fileUploads/UploadDataDetailsView.tsx
+++ b/src/writeData/components/fileUploads/UploadDataDetailsView.tsx
@@ -54,7 +54,11 @@ const UploadDataDetailsView: FC = () => {
 
   if (markdown) {
     pageContent = (
-      <MarkdownRenderer text={markdown} cloudRenderers={{code: codeRenderer}} />
+      <MarkdownRenderer
+        text={markdown}
+        cloudRenderers={{code: codeRenderer}}
+        escapeHtml={false}
+      />
     )
   }
 

--- a/src/writeData/containers/ClientLibrariesPage.tsx
+++ b/src/writeData/containers/ClientLibrariesPage.tsx
@@ -82,6 +82,7 @@ const ClientLibrariesPage: FC = () => {
       <MarkdownRenderer
         text={def.description}
         cloudRenderers={{code: codeRenderer}}
+        escapeHtml={false}
       />
     )
   }

--- a/src/writeData/containers/TelegrafPluginsPage.tsx
+++ b/src/writeData/containers/TelegrafPluginsPage.tsx
@@ -48,7 +48,11 @@ const TelegrafPluginsPage: FC = () => {
 
   if (markdown) {
     pageContent = (
-      <MarkdownRenderer text={markdown} cloudRenderers={{code: codeRenderer}} />
+      <MarkdownRenderer
+        text={markdown}
+        cloudRenderers={{code: codeRenderer}}
+        escapeHtml={false}
+      />
     )
   }
 


### PR DESCRIPTION
Only escape html when rendering editable markdown. For example, community templates should render html but dashboard notes should not. 

This change only applies to when the UI is in cloud mode.

Some examples showing that the markdown renderer works as expected after this change:

<img width="1705" alt="Screen Shot 2021-07-07 at 10 18 22 AM" src="https://user-images.githubusercontent.com/6411855/124803504-0ddc2700-df0e-11eb-8e27-02a7b8877790.png">
<img width="878" alt="Screen Shot 2021-07-07 at 10 16 32 AM" src="https://user-images.githubusercontent.com/6411855/124803515-116fae00-df0e-11eb-8a18-fb36d7502b6a.png">
<img width="1290" alt="Screen Shot 2021-07-07 at 10 17 10 AM" src="https://user-images.githubusercontent.com/6411855/124803518-12a0db00-df0e-11eb-998d-a7ae2d827d70.png">
<img width="1226" alt="Screen Shot 2021-07-07 at 10 17 35 AM" src="https://user-images.githubusercontent.com/6411855/124803520-146a9e80-df0e-11eb-9b03-76e47b10b6b7.png">
<img width="721" alt="Screen Shot 2021-07-07 at 10 07 50 AM" src="https://user-images.githubusercontent.com/6411855/124803528-17658f00-df0e-11eb-8d91-ee3c6f537964.png">
<img width="2054" alt="Screen Shot 2021-07-07 at 10 08 25 AM" src="https://user-images.githubusercontent.com/6411855/124803572-23515100-df0e-11eb-9d91-0a2c0a3f0e35.png">
