### PR TITLE
test(flows): wait on specific patch request

### DIFF
--- a/cypress/e2e/cloud/home.test.ts
+++ b/cypress/e2e/cloud/home.test.ts
@@ -10,7 +10,7 @@ describe('Home Page Tests', () => {
         cy.setFeatureFlags({
           alertsActivity: true,
           notebooks: true,
-        })
+        }).then(() => cy.getByTestID('nav-item-flows').should('be.visible'))
       })
     })
   })

--- a/cypress/e2e/shared/flows.test.ts
+++ b/cypress/e2e/shared/flows.test.ts
@@ -359,8 +359,6 @@ describe('Flows', () => {
 
     // wait for notebook to save
     cy.wait('@notebooksSave')
-      .its('response.statusCode')
-      .should('eq', 200)
 
     // exit the flow, reload, and come back in
     cy.getByTestID('nav-item-flows').click()

--- a/cypress/e2e/shared/flows.test.ts
+++ b/cypress/e2e/shared/flows.test.ts
@@ -348,13 +348,19 @@ describe('Flows', () => {
       .should('be.visible')
     cy.getByTestID('table-cell cool').should('not.exist')
 
-    cy.intercept('PATCH', '**/notebooks/*').as('notebooksSave')
+    cy.intercept('PATCH', '**/notebooks/*', req => {
+      if (req.body.spec.readOnly === true) {
+        req.alias = 'notebooksSave'
+      }
+    })
 
     // enable presentation mode
     cy.getByTestID('slide-toggle').click()
 
     // wait for notebook to save
     cy.wait('@notebooksSave')
+      .its('response.statusCode')
+      .should('eq', 200)
 
     // exit the flow, reload, and come back in
     cy.getByTestID('nav-item-flows').click()


### PR DESCRIPTION
Attempts to fix the flake in this flows test again by waiting on a specific patch request to be successful with a specific body.

Also fixes flake in home tests where we were navigating away before the feature flags were fully set
