### PR TITLE
feat: redirect away from the login page when a user has a valid session

### DIFF
--- a/cypress/e2e/cloud/home.test.ts
+++ b/cypress/e2e/cloud/home.test.ts
@@ -10,8 +10,15 @@ describe('Home Page Tests', () => {
         cy.setFeatureFlags({
           alertsActivity: true,
           notebooks: true,
+          loginRedirectBack: true,
         }).then(() => cy.getByTestID('nav-item-flows').should('be.visible'))
       })
+    })
+  })
+
+  it.only('should redirect the user back home when trying to access the /login route directly with a valid session', () => {
+    cy.location().should(loc => {
+      expect(loc.pathname).to.not.eq('/login')
     })
   })
 

--- a/cypress/e2e/cloud/home.test.ts
+++ b/cypress/e2e/cloud/home.test.ts
@@ -17,6 +17,7 @@ describe('Home Page Tests', () => {
   })
 
   it.only('should redirect the user back home when trying to access the /login route directly with a valid session', () => {
+    cy.visit('/login')
     cy.location().should(loc => {
       expect(loc.pathname).to.not.eq('/login')
     })

--- a/cypress/e2e/cloud/home.test.ts
+++ b/cypress/e2e/cloud/home.test.ts
@@ -16,7 +16,7 @@ describe('Home Page Tests', () => {
     })
   })
 
-  it.only('should redirect the user back home when trying to access the /login route directly with a valid session', () => {
+  it('should redirect the user back home when trying to access the /login route directly with a valid session', () => {
     cy.visit('/login')
     cy.location().should(loc => {
       expect(loc.pathname).to.not.eq('/login')

--- a/src/onboarding/containers/LoginPage.tsx
+++ b/src/onboarding/containers/LoginPage.tsx
@@ -18,6 +18,8 @@ import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
 import LoginPageContents from 'src/onboarding/containers/LoginPageContents'
 
+const EMPTY_HISTORY_STACK_LENGTH = 2
+
 export const LoginPage: FC = () => {
   const [hasValidSession, setHasValidSession] = useState(false)
 
@@ -39,7 +41,12 @@ export const LoginPage: FC = () => {
   const history = useHistory()
 
   if (hasValidSession && isFlagEnabled('loginRedirectBack')) {
-    history.goBack()
+    if (history.length <= EMPTY_HISTORY_STACK_LENGTH) {
+      // If the user directly navigates to the login page after having a session but no stack
+      history.push('/')
+    } else {
+      history.goBack()
+    }
     return null
   }
 

--- a/src/onboarding/containers/LoginPage.tsx
+++ b/src/onboarding/containers/LoginPage.tsx
@@ -31,7 +31,9 @@ export const LoginPage: FC = () => {
   }, [])
 
   useEffect(() => {
-    getSessionValidity()
+    if (isFlagEnabled('loginRedirectBack')) {
+      getSessionValidity()
+    }
   }, [getSessionValidity])
 
   const history = useHistory()

--- a/src/onboarding/containers/LoginPage.tsx
+++ b/src/onboarding/containers/LoginPage.tsx
@@ -12,6 +12,7 @@ import {
 import {useHistory} from 'react-router-dom'
 import Notifications from 'src/shared/components/notifications/Notifications'
 import {client} from 'src/utils/api'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Components
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
@@ -35,7 +36,7 @@ export const LoginPage: FC = () => {
 
   const history = useHistory()
 
-  if (hasValidSession) {
+  if (hasValidSession && isFlagEnabled('loginRedirectBack')) {
     history.goBack()
     return null
   }

--- a/src/onboarding/containers/LoginPage.tsx
+++ b/src/onboarding/containers/LoginPage.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FC} from 'react'
+import React, {FC, useCallback, useEffect, useState} from 'react'
 import {
   AppWrapper,
   FontWeight,
@@ -9,30 +9,56 @@ import {
   InfluxDBCloudLogo,
   Typeface,
 } from '@influxdata/clockface'
+import {useHistory} from 'react-router-dom'
 import Notifications from 'src/shared/components/notifications/Notifications'
+import {client} from 'src/utils/api'
 
 // Components
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
 import LoginPageContents from 'src/onboarding/containers/LoginPageContents'
 
-export const LoginPage: FC = () => (
-  <ErrorBoundary>
-    <AppWrapper>
-      <Notifications />
-      <FunnelPage
-        enableGraphic={true}
-        logo={<InfluxDBCloudLogo cloud={true} className="login-page--logo" />}
-      >
-        <Heading
-          element={HeadingElement.H1}
-          type={Typeface.Rubik}
-          weight={FontWeight.Regular}
-          className="cf-funnel-page--title"
+export const LoginPage: FC = () => {
+  const [hasValidSession, setHasValidSession] = useState(false)
+
+  const getSessionValidity = useCallback(async () => {
+    try {
+      await client.users.me()
+      setHasValidSession(true)
+    } catch {
+      setHasValidSession(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    getSessionValidity()
+  }, [getSessionValidity])
+
+  const history = useHistory()
+
+  if (hasValidSession) {
+    history.goBack()
+    return null
+  }
+
+  return (
+    <ErrorBoundary>
+      <AppWrapper>
+        <Notifications />
+        <FunnelPage
+          enableGraphic={true}
+          logo={<InfluxDBCloudLogo cloud={true} className="login-page--logo" />}
         >
-          Log in to your InfluxDB Account
-        </Heading>
-        <LoginPageContents />
-      </FunnelPage>
-    </AppWrapper>
-  </ErrorBoundary>
-)
+          <Heading
+            element={HeadingElement.H1}
+            type={Typeface.Rubik}
+            weight={FontWeight.Regular}
+            className="cf-funnel-page--title"
+          >
+            Log in to your InfluxDB Account
+          </Heading>
+          <LoginPageContents />
+        </FunnelPage>
+      </AppWrapper>
+    </ErrorBoundary>
+  )
+}


### PR DESCRIPTION
Closes #https://github.com/influxdata/influxdb/issues/18362

This one's been on my mind. We shouldn't allow the user to access the login page once a valid session has been established since that can be a confusing state to be in, both for the user and for the browser in terms of establishing a session. This PR basically utilizes the existing session management for pre-auth users and makes a request to check whether a user has an established session prior to displaying the login page. If the user already has an established session, we just return them to whichever route they came from