### PR TITLE
chore: remove moment.fromNow calls

### DIFF
--- a/mocks/dummyData.ts
+++ b/mocks/dummyData.ts
@@ -244,6 +244,7 @@ export const tasks: Task[] = [
     cron: '2 0 * * *',
     org: 'default',
     labels: [],
+    latestCompleted: '2021-06-08T02:25:52.118899855Z',
   },
   {
     id: '02f12c50dba72000',
@@ -255,6 +256,7 @@ export const tasks: Task[] = [
     every: '1m0s',
     org: 'default',
     labels: labelIDs,
+    latestCompleted: '2021-06-08T02:25:52.118899855Z',
   },
 ]
 

--- a/src/shared/utils/relativeTimestampFormatter.ts
+++ b/src/shared/utils/relativeTimestampFormatter.ts
@@ -1,10 +1,11 @@
-import moment from 'moment'
+import {createRelativeFormatter} from 'src/utils/datetime/formatters'
 
 export const relativeTimestampFormatter = (
   time: string,
   prefix?: string
 ): string => {
-  const timeFromNow = moment(time).fromNow()
+  const formatter = createRelativeFormatter()
+  const timeFromNow = formatter.formatRelative(new Date(time))
 
   if (prefix) {
     return `${prefix}${timeFromNow}`

--- a/src/tasks/components/TaskRunsCard.tsx
+++ b/src/tasks/components/TaskRunsCard.tsx
@@ -2,7 +2,6 @@
 import React, {PureComponent} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import moment from 'moment'
 
 // Components
 import {
@@ -15,6 +14,8 @@ import {
   FlexDirection,
   JustifyContent,
 } from '@influxdata/clockface'
+
+import {relativeTimestampFormatter} from 'src/shared/utils/relativeTimestampFormatter'
 
 // Actions
 import {
@@ -67,7 +68,7 @@ class UnconnectedTaskRunsCard extends PureComponent<
             {this.activeToggle}
             <>Created at: {task.createdAt}</>
             <>Created by: {task.name}</>
-            <>Last Used: {moment(task.latestCompleted).fromNow()}</>
+            <>Last Used: {relativeTimestampFormatter(task.latestCompleted)}</>
             <>{task.org}</>
           </ResourceCard.Meta>
         </FlexBox>

--- a/src/tasks/components/TaskRunsPage.test.tsx
+++ b/src/tasks/components/TaskRunsPage.test.tsx
@@ -14,6 +14,10 @@ import {mockAppState} from 'src/mockAppState'
 import {RemoteDataState} from 'src/types'
 import {mocked} from 'ts-jest/utils'
 
+// DateTime
+import {DEFAULT_TIME_FORMAT} from 'src/shared/constants'
+import {createDateTimeFormatter} from 'src/utils/datetime/formatters'
+
 const runIDs = [
   '07a7f99e81cf2000',
   '07a7f99e81cf3000',
@@ -239,27 +243,21 @@ const setup = () => {
   return renderWithReduxAndRouter(<TaskRunsPage {...props} />, () => testState)
 }
 
-const verifyRecStatus = (rec: HTMLElement, run: Run) => {
-  const cells = rec.querySelectorAll('[data-testid=table-cell]')
+const verifyRowMetaData = (row: HTMLElement, run: Run) => {
+  const cells = row.querySelectorAll('[data-testid=table-cell]')
   expect(cells[0].textContent.trim()).toEqual(run.status)
-  let testString = run.scheduledFor.replace('T', ' ').replace('Z', '')
+  const formattedDate = createDateTimeFormatter(DEFAULT_TIME_FORMAT).format(
+    new Date(run.scheduledFor)
+  )
 
-  // ignore adjustment for local time zone but check the rest
-  testString =
-    '^' + testString.substring(0, 11) + '\\d\\d' + testString.substring(13)
-
-  expect(cells[1].textContent.trim()).toMatch(new RegExp(testString))
+  expect(cells[1].textContent.trim()).toMatch(formattedDate)
 
   if (run.startedAt) {
-    testString = run.startedAt.replace('T', ' ').replace('Z', '')
-    // ignore adjustment for local time zone but check the rest
-    testString = (
-      '^' +
-      testString.substring(0, 11) +
-      '\\d\\d' +
-      testString.substring(13)
-    ).split('.')[0]
-    expect(cells[2].textContent.trim()).toMatch(new RegExp(testString))
+    const formattedDate = createDateTimeFormatter(DEFAULT_TIME_FORMAT).format(
+      new Date(run.startedAt)
+    )
+
+    expect(cells[2].textContent.trim()).toMatch(formattedDate)
   }
 }
 
@@ -283,7 +281,7 @@ describe('Tasks.Components.TaskRunsPage', () => {
 
     // default sort is reverse of dummyTaskRuns declaration above
     for (let i = 0; i < rows.length; i++) {
-      verifyRecStatus(rows[i], dummyTaskRuns[rows.length - (i + 1)])
+      verifyRowMetaData(rows[i], dummyTaskRuns[rows.length - (i + 1)])
     }
 
     const cells = rows[4].querySelectorAll('[data-testid=table-cell]')

--- a/src/utils/datetime/formatters.ts
+++ b/src/utils/datetime/formatters.ts
@@ -40,7 +40,7 @@ export const createRelativeFormatter = (
     numeric,
   })
 
-  const formatDateRelative = date => {
+  const formatDateRelative = (date: Date) => {
     const millisecondsAgo = date.getTime() - Date.now()
 
     for (const {scale, ms} of relativeDivisions) {


### PR DESCRIPTION
Connects #1844

removes [`fromNow`](https://momentjs.com/docs/#/displaying/fromnow/) calls to moment and uses our [relative formatter.](https://github.com/influxdata/ui/pull/1944)

![Screen Shot 2021-07-08 at 10 01 31 AM](https://user-images.githubusercontent.com/146112/124963332-873e4d00-dfd4-11eb-8305-b0b7106f6155.png)
![Screen Shot 2021-07-08 at 10 01 34 AM](https://user-images.githubusercontent.com/146112/124963337-87d6e380-dfd4-11eb-9973-56d70c50d03e.png)
