### PR TITLE
refactor: remove moment.subtract() from duration.ts

### DIFF
--- a/src/shared/utils/duration.test.tsx
+++ b/src/shared/utils/duration.test.tsx
@@ -5,8 +5,11 @@ import {
   millisecondsToDuration,
   isDurationWithNowParseable,
   isDurationParseable,
+  convertTimeRangeToCustom,
 } from 'src/shared/utils/duration'
 import {SELECTABLE_TIME_RANGES} from 'src/shared/constants/timeRanges'
+
+import {CustomTimeRange, SelectableDurationTimeRange} from 'src/types'
 
 const TEST_CASES = [
   ['1d', [{magnitude: 1, unit: 'd'}]],
@@ -117,4 +120,30 @@ describe('isDurationParseable', () => {
       expect(isDurationParseable(input)).toEqual(true)
     }
   )
+})
+
+describe('convertTimeRangeToCustom', () => {
+  test('conversion of SelectableDurationTimeRange to custom ', () => {
+    const pastHourTimeRange: SelectableDurationTimeRange = {
+      seconds: 3600,
+      lower: 'now() - 1h',
+      upper: null,
+      label: 'Past 1h',
+      duration: '1h',
+      type: 'selectable-duration',
+      windowPeriod: 10000, // 10s
+    }
+    const mockTimestamp = new Date().getTime()
+    jest.spyOn(Date, 'now').mockReturnValue(mockTimestamp)
+
+    const lowerDate = new Date(mockTimestamp)
+    lowerDate.setHours(new Date().getHours() - 1)
+
+    const expected: CustomTimeRange = {
+      lower: lowerDate.toISOString(),
+      upper: new Date().toISOString(),
+      type: 'custom',
+    }
+    expect(convertTimeRangeToCustom(pastHourTimeRange)).toStrictEqual(expected)
+  })
 })

--- a/src/shared/utils/duration.test.tsx
+++ b/src/shared/utils/duration.test.tsx
@@ -5,7 +5,6 @@ import {
   millisecondsToDuration,
   isDurationWithNowParseable,
   isDurationParseable,
-  convertTimeRangeToCustom,
 } from 'src/shared/utils/duration'
 import {SELECTABLE_TIME_RANGES} from 'src/shared/constants/timeRanges'
 
@@ -123,7 +122,7 @@ describe('isDurationParseable', () => {
 })
 
 describe('convertTimeRangeToCustom', () => {
-  test('conversion of SelectableDurationTimeRange to custom ', () => {
+  test('conversion of SelectableDurationTimeRange to custom ', async () => {
     const pastHourTimeRange: SelectableDurationTimeRange = {
       seconds: 3600,
       lower: 'now() - 1h',
@@ -133,17 +132,22 @@ describe('convertTimeRangeToCustom', () => {
       type: 'selectable-duration',
       windowPeriod: 10000, // 10s
     }
-    const mockTimestamp = new Date().getTime()
-    jest.spyOn(Date, 'now').mockReturnValue(mockTimestamp)
 
-    const lowerDate = new Date(mockTimestamp)
-    lowerDate.setHours(new Date().getHours() - 1)
+    const lowerDate = new Date(1466424490000)
+    lowerDate.setHours(lowerDate.getHours() - 1)
+
+    const mockDate = new Date(1466424490000)
+
+    const spy = jest.spyOn(global, 'Date').mockImplementation(() => mockDate)
 
     const expected: CustomTimeRange = {
       lower: lowerDate.toISOString(),
       upper: new Date().toISOString(),
       type: 'custom',
     }
+    const {convertTimeRangeToCustom} = await import('src/shared/utils/duration')
+
     expect(convertTimeRangeToCustom(pastHourTimeRange)).toStrictEqual(expected)
+    spy.mockRestore()
   })
 })

--- a/src/shared/utils/duration.ts
+++ b/src/shared/utils/duration.ts
@@ -136,16 +136,16 @@ export const convertTimeRangeToCustom = (
   let lower = ''
 
   if (timeRange.type === 'selectable-duration') {
-    lower = moment()
-      .subtract(timeRange.seconds, 's')
-      .toISOString()
+    const lowerDate = new Date()
+    lowerDate.setSeconds(new Date().getSeconds() - timeRange.seconds)
+    lower = lowerDate.toISOString()
   } else if (timeRange.type === 'duration') {
     const millisecondDuration = durationToMilliseconds(
       parseDuration(timeRangeToDuration(timeRange))
     )
-    lower = moment()
-      .subtract(millisecondDuration, 'milliseconds')
-      .toISOString()
+    const lowerDate = new Date()
+    lowerDate.setMilliseconds(new Date().getMilliseconds() - millisecondDuration)
+    lower = lowerDate.toISOString()
   }
 
   return {

--- a/src/shared/utils/duration.ts
+++ b/src/shared/utils/duration.ts
@@ -144,7 +144,9 @@ export const convertTimeRangeToCustom = (
       parseDuration(timeRangeToDuration(timeRange))
     )
     const lowerDate = new Date()
-    lowerDate.setMilliseconds(new Date().getMilliseconds() - millisecondDuration)
+    lowerDate.setMilliseconds(
+      new Date().getMilliseconds() - millisecondDuration
+    )
     lower = lowerDate.toISOString()
   }
 

--- a/src/shared/utils/duration.ts
+++ b/src/shared/utils/duration.ts
@@ -137,7 +137,7 @@ export const convertTimeRangeToCustom = (
 
   if (timeRange.type === 'selectable-duration') {
     const lowerDate = new Date()
-    lowerDate.setSeconds(new Date().getSeconds() - timeRange.seconds)
+    lowerDate.setSeconds(lowerDate.getSeconds() - timeRange.seconds)
     lower = lowerDate.toISOString()
   } else if (timeRange.type === 'duration') {
     const millisecondDuration = durationToMilliseconds(
@@ -145,7 +145,7 @@ export const convertTimeRangeToCustom = (
     )
     const lowerDate = new Date()
     lowerDate.setMilliseconds(
-      new Date().getMilliseconds() - millisecondDuration
+      lowerDate.getMilliseconds() - millisecondDuration
     )
     lower = lowerDate.toISOString()
   }

--- a/src/shared/utils/duration.ts
+++ b/src/shared/utils/duration.ts
@@ -144,9 +144,7 @@ export const convertTimeRangeToCustom = (
       parseDuration(timeRangeToDuration(timeRange))
     )
     const lowerDate = new Date()
-    lowerDate.setMilliseconds(
-      lowerDate.getMilliseconds() - millisecondDuration
-    )
+    lowerDate.setMilliseconds(lowerDate.getMilliseconds() - millisecondDuration)
     lower = lowerDate.toISOString()
   }
 


### PR DESCRIPTION
Completes part of #1844 

This PR deletes the `moment` library's subtract usage and redoes the logic using the vanilla `Date` library.