### PR TITLE
refactor: replace moment.subtract in selectors/index.ts 

### DIFF
--- a/src/timeMachine/selectors/index.ts
+++ b/src/timeMachine/selectors/index.ts
@@ -271,17 +271,21 @@ export const getStartTime = (timeRange: TimeRange) => {
   switch (timeRange.type) {
     case 'custom':
       return moment(timeRange.lower).valueOf()
-    case 'selectable-duration':
-      return moment()
-        .subtract(timeRange.seconds, 'seconds')
-        .valueOf()
-    case 'duration':
+    case 'selectable-duration': {
+      const startTime = new Date()
+      startTime.setSeconds(new Date().getSeconds() - timeRange.seconds)
+      return startTime.getTime()
+    }
+    case 'duration': {
       const millisecondDuration = durationToMilliseconds(
         parseDuration(timeRangeToDuration(timeRange))
       )
-      return moment()
-        .subtract(millisecondDuration, 'milliseconds')
-        .valueOf()
+      const startTime = new Date()
+      startTime.setMilliseconds(
+        new Date().getMilliseconds() - millisecondDuration
+      )
+      return startTime.getTime()
+    }
     default:
       throw new Error(
         'unknown timeRange type ${timeRange.type} provided to getStartTime'

--- a/src/timeMachine/selectors/index.ts
+++ b/src/timeMachine/selectors/index.ts
@@ -273,7 +273,7 @@ export const getStartTime = (timeRange: TimeRange) => {
       return moment(timeRange.lower).valueOf()
     case 'selectable-duration': {
       const startTime = new Date()
-      startTime.setSeconds(new Date().getSeconds() - timeRange.seconds)
+      startTime.setSeconds(startTime.getSeconds() - timeRange.seconds)
       return startTime.getTime()
     }
     case 'duration': {
@@ -282,7 +282,7 @@ export const getStartTime = (timeRange: TimeRange) => {
       )
       const startTime = new Date()
       startTime.setMilliseconds(
-        new Date().getMilliseconds() - millisecondDuration
+        startTime.getMilliseconds() - millisecondDuration
       )
       return startTime.getTime()
     }


### PR DESCRIPTION
completes part of #1844

This PR deletes the `moment` library's subtract usage and redoes the logic using the vanilla `Date` library, in the selectors/index.ts
