### PR TITLE
fix: moved the useEffect to get org info into the view layer

### DIFF
--- a/src/operator/OrgOverlay.tsx
+++ b/src/operator/OrgOverlay.tsx
@@ -1,4 +1,4 @@
-import React, {FC, useContext} from 'react'
+import React, {FC, useContext, useEffect} from 'react'
 import {useHistory, useParams} from 'react-router-dom'
 
 import {
@@ -28,6 +28,8 @@ const OrgOverlay: FC = () => {
   const {
     limits,
     limitsStatus,
+    handleGetLimits,
+    handleGetOrg,
     handleUpdateLimits,
     organization,
     orgStatus,
@@ -38,10 +40,18 @@ const OrgOverlay: FC = () => {
   const {orgID} = useParams<{orgID: string}>()
   const history = useHistory()
 
+  useEffect(() => {
+    handleGetLimits(orgID)
+  }, [handleGetLimits, orgID])
+
+  useEffect(() => {
+    handleGetOrg(orgID)
+  }, [handleGetOrg, orgID])
+
   const updateLimits = async () => {
     try {
       const backendLimits = fromDisplayLimits(limits)
-      await handleUpdateLimits(backendLimits)
+      await handleUpdateLimits(orgID, backendLimits)
       history.goBack()
     } catch {
       // We want to keep the operator on the overlay if an error occurred

--- a/src/operator/context/overlay.tsx
+++ b/src/operator/context/overlay.tsx
@@ -1,6 +1,5 @@
 // Libraries
-import React, {FC, useCallback, useEffect, useState} from 'react'
-import {useParams} from 'react-router-dom'
+import React, {FC, useCallback, useState} from 'react'
 import {useDispatch} from 'react-redux'
 
 // Utils
@@ -31,7 +30,7 @@ export interface OverlayContextType {
   limitsStatus: RemoteDataState
   handleGetLimits: (id: string) => void
   handleGetOrg: (id: string) => void
-  handleUpdateLimits: (limits: OrgLimits) => void
+  handleUpdateLimits: (id: string, limits: OrgLimits) => void
   organization: OperatorOrg
   orgStatus: RemoteDataState
   setLimits: (_: OrgLimits) => void
@@ -41,7 +40,7 @@ export interface OverlayContextType {
 export const DEFAULT_CONTEXT: OverlayContextType = {
   handleGetLimits: (_: string) => {},
   handleGetOrg: (_: string) => {},
-  handleUpdateLimits: (_: OrgLimits) => {},
+  handleUpdateLimits: (_id: string, _limits: OrgLimits) => {},
   limits: null,
   limitsStatus: RemoteDataState.NotStarted,
   organization: null,
@@ -61,9 +60,6 @@ export const OverlayProvider: FC<Props> = React.memo(({children}) => {
     RemoteDataState.NotStarted
   )
   const [orgStatus, setOrgStatus] = useState(RemoteDataState.NotStarted)
-
-  // Getting the orgID here since the parameter is only available in the overlay path
-  const {orgID} = useParams<{orgID: string}>()
 
   const dispatch = useDispatch()
 
@@ -93,10 +89,6 @@ export const OverlayProvider: FC<Props> = React.memo(({children}) => {
     [dispatch]
   )
 
-  useEffect(() => {
-    handleGetLimits(orgID)
-  }, [handleGetLimits, orgID])
-
   const handleGetOrg = useCallback(
     async (id: string) => {
       try {
@@ -119,23 +111,19 @@ export const OverlayProvider: FC<Props> = React.memo(({children}) => {
     [dispatch]
   )
 
-  useEffect(() => {
-    handleGetOrg(orgID)
-  }, [handleGetOrg, handleGetLimits, orgID])
-
   const handleUpdateLimits = useCallback(
-    async (updatedLimits: OrgLimits) => {
+    async (id: string, updatedLimits: OrgLimits) => {
       try {
         setUpdateLimitStatus(RemoteDataState.Loading)
-        await putOperatorOrgsLimits({orgId: orgID, data: updatedLimits})
+        await putOperatorOrgsLimits({orgId: id, data: updatedLimits})
         setUpdateLimitStatus(RemoteDataState.Done)
-        dispatch(notify(updateLimitsSuccess(orgID)))
+        dispatch(notify(updateLimitsSuccess(id)))
       } catch (error) {
         console.error({error})
-        dispatch(notify(updateLimitsError(orgID)))
+        dispatch(notify(updateLimitsError(id)))
       }
     },
-    [dispatch, orgID]
+    [dispatch]
   )
 
   return (


### PR DESCRIPTION
Straightforward bug fix. Moved the useEffect for the overlay context into the org overlay view layer. This move ensures that the orgId will be set prior to getting the info, whereas making it a concern of the context was making the orgID undefined in certain situations. This ensures that the orgID will always be defined.