### PR TITLE
chore: don't re-render functions on every keystroke

### DIFF
--- a/src/flows/pipes/RawFluxEditor/functions.tsx
+++ b/src/flows/pipes/RawFluxEditor/functions.tsx
@@ -48,57 +48,59 @@ const Functions: FC<Props> = ({onSelect}) => {
     [search]
   )
 
-  let fnComponent
+  return useMemo(() => {
+    let fnComponent
 
-  if (!Object.keys(filteredFunctions).length) {
-    fnComponent = (
-      <EmptyState size={ComponentSize.ExtraSmall}>
-        <EmptyState.Text>No functions match your search</EmptyState.Text>
-      </EmptyState>
-    )
-  } else {
-    fnComponent = Object.entries(filteredFunctions).map(([category, fns]) => (
-      <dl className="flux-toolbar--category" key={category}>
-        <dt className="flux-toolbar--heading">{category}</dt>
-        {fns.map(fn => (
-          <Fn
-            onClickFunction={onSelect}
-            key={`${fn.name}_${fn.desc}`}
-            func={fn}
-            testID={fn.name}
-          />
-        ))}
-      </dl>
-    ))
-  }
+    if (!Object.keys(filteredFunctions).length) {
+      fnComponent = (
+        <EmptyState size={ComponentSize.ExtraSmall}>
+          <EmptyState.Text>No functions match your search</EmptyState.Text>
+        </EmptyState>
+      )
+    } else {
+      fnComponent = Object.entries(filteredFunctions).map(([category, fns]) => (
+        <dl className="flux-toolbar--category" key={category}>
+          <dt className="flux-toolbar--heading">{category}</dt>
+          {fns.map(fn => (
+            <Fn
+              onClickFunction={onSelect}
+              key={`${fn.name}_${fn.desc}`}
+              func={fn}
+              testID={fn.name}
+            />
+          ))}
+        </dl>
+      ))
+    }
 
-  const body = isFlagEnabled('flow-sidebar') ? (
-    <div className="flux-toolbar--list" data-testid="flux-toolbar--list">
-      {fnComponent}
-    </div>
-  ) : (
-    <DapperScrollbars className="flux-toolbar--scroll-area">
+    const body = isFlagEnabled('flow-sidebar') ? (
       <div className="flux-toolbar--list" data-testid="flux-toolbar--list">
         {fnComponent}
       </div>
-    </DapperScrollbars>
-  )
+    ) : (
+      <DapperScrollbars className="flux-toolbar--scroll-area">
+        <div className="flux-toolbar--list" data-testid="flux-toolbar--list">
+          {fnComponent}
+        </div>
+      </DapperScrollbars>
+    )
 
-  return (
-    <div className="flux-toolbar">
-      <div className="flux-toolbar--search">
-        <Input
-          type={InputType.Text}
-          icon={IconFont.Search}
-          placeholder="Filter Functions..."
-          onChange={updateSearch}
-          value={search}
-          testID="flux-toolbar-search--input"
-        />
+    return (
+      <div className="flux-toolbar">
+        <div className="flux-toolbar--search">
+          <Input
+            type={InputType.Text}
+            icon={IconFont.Search}
+            placeholder="Filter Functions..."
+            onChange={updateSearch}
+            value={search}
+            testID="flux-toolbar-search--input"
+          />
+        </div>
+        {body}
       </div>
-      {body}
-    </div>
-  )
+    )
+  }, [search])
 }
 
 export default Functions

--- a/src/flows/pipes/RawFluxEditor/functions.tsx
+++ b/src/flows/pipes/RawFluxEditor/functions.tsx
@@ -100,7 +100,7 @@ const Functions: FC<Props> = ({onSelect}) => {
         {body}
       </div>
     )
-  }, [search])
+  }, [search, onSelect])
 }
 
 export default Functions

--- a/src/flows/pipes/RawFluxEditor/view.tsx
+++ b/src/flows/pipes/RawFluxEditor/view.tsx
@@ -7,6 +7,7 @@ import React, {
   useState,
   useContext,
   useCallback,
+  useMemo,
 } from 'react'
 import {
   RemoteDataState,
@@ -145,32 +146,34 @@ const Query: FC<PipeProp> = ({Context}) => {
     ])
   }, [id, inject])
 
-  return (
-    <Context controls={controls} resizes>
-      <Suspense
-        fallback={
-          <SpinnerContainer
-            loading={RemoteDataState.Loading}
-            spinnerComponent={<TechnoSpinner />}
+  return useMemo(() => {
+    return (
+      <Context controls={controls} resizes>
+        <Suspense
+          fallback={
+            <SpinnerContainer
+              loading={RemoteDataState.Loading}
+              spinnerComponent={<TechnoSpinner />}
+            />
+          }
+        >
+          <FluxMonacoEditor
+            script={query.text}
+            onChangeScript={updateText}
+            onSubmitScript={() => {}}
+            setEditorInstance={setEditorInstance}
+            autogrow
+            wrapLines="on"
           />
-        }
-      >
-        <FluxMonacoEditor
-          script={query.text}
-          onChangeScript={updateText}
-          onSubmitScript={() => {}}
-          setEditorInstance={setEditorInstance}
-          autogrow
-          wrapLines="on"
-        />
-      </Suspense>
-      {!isFlagEnabled('flow-sidebar') && showFn && (
-        <div className="flow-nonsidebar">
-          <Functions onSelect={inject} />
-        </div>
-      )}
-    </Context>
-  )
+        </Suspense>
+        {!isFlagEnabled('flow-sidebar') && showFn && (
+          <div className="flow-nonsidebar">
+            <Functions onSelect={inject} />
+          </div>
+        )}
+      </Context>
+    )
+  }, [editorInstance, showFn])
 }
 
 export default Query

--- a/src/timeMachine/components/TimeMachineFluxEditor.tsx
+++ b/src/timeMachine/components/TimeMachineFluxEditor.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FC, lazy, Suspense, useState} from 'react'
+import React, {FC, lazy, Suspense, useState, useMemo} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
 import {
   RemoteDataState,
@@ -35,6 +35,7 @@ const TimeMachineFluxEditor: FC<Props> = ({
   onSubmitQueries,
   onSetActiveQueryText,
   activeTab,
+  activeQueryIndex,
 }) => {
   const [editorInstance, setEditorInstance] = useState<EditorType>(null)
   const handleInsertVariable = (variableName: string): void => {
@@ -141,43 +142,45 @@ const TimeMachineFluxEditor: FC<Props> = ({
     onSetActiveQueryText(editorInstance.getValue())
   }
 
-  return (
-    <div className="flux-editor">
-      <div className="flux-editor--left-panel">
-        <Suspense
-          fallback={
-            <SpinnerContainer
-              loading={RemoteDataState.Loading}
-              spinnerComponent={<TechnoSpinner />}
+  return useMemo(() => {
+    return (
+      <div className="flux-editor">
+        <div className="flux-editor--left-panel">
+          <Suspense
+            fallback={
+              <SpinnerContainer
+                loading={RemoteDataState.Loading}
+                spinnerComponent={<TechnoSpinner />}
+              />
+            }
+          >
+            <FluxEditor
+              script={activeQueryText}
+              onChangeScript={onSetActiveQueryText}
+              onSubmitScript={onSubmitQueries}
+              setEditorInstance={setEditorInstance}
             />
-          }
-        >
-          <FluxEditor
-            script={activeQueryText}
-            onChangeScript={onSetActiveQueryText}
-            onSubmitScript={onSubmitQueries}
-            setEditorInstance={setEditorInstance}
+          </Suspense>
+        </div>
+        <div className="flux-editor--right-panel">
+          <FluxToolbar
+            activeQueryBuilderTab={activeTab}
+            onInsertFluxFunction={handleInsertFluxFunction}
+            onInsertVariable={handleInsertVariable}
           />
-        </Suspense>
+        </div>
       </div>
-      <div className="flux-editor--right-panel">
-        <FluxToolbar
-          activeQueryBuilderTab={activeTab}
-          onInsertFluxFunction={handleInsertFluxFunction}
-          onInsertVariable={handleInsertVariable}
-        />
-      </div>
-    </div>
-  )
+    )
+  }, [editorInstance, activeQueryIndex])
 }
 
 export {TimeMachineFluxEditor}
 
 const mstp = (state: AppState) => {
   const activeQueryText = getActiveQuery(state).text
-  const {activeTab} = getActiveTimeMachine(state)
+  const {activeTab, activeQueryIndex} = getActiveTimeMachine(state)
 
-  return {activeQueryText, activeTab}
+  return {activeQueryText, activeTab, activeQueryIndex}
 }
 
 const mdtp = {

--- a/src/timeMachine/components/fluxFunctionsToolbar/FluxFunctionsToolbar.tsx
+++ b/src/timeMachine/components/fluxFunctionsToolbar/FluxFunctionsToolbar.tsx
@@ -12,11 +12,14 @@ import ErrorBoundary from 'src/shared/components/ErrorBoundary'
 // Actions
 import {setActiveQueryText} from 'src/timeMachine/actions'
 
+// Utils
+import {getActiveQuery} from 'src/timeMachine/selectors'
+
 // Constants
 import {FLUX_FUNCTIONS} from 'src/shared/constants/fluxFunctions'
 
 // Types
-import {FluxToolbarFunction} from 'src/types'
+import {AppState, FluxToolbarFunction} from 'src/types'
 
 interface OwnProps {
   onInsertFluxFunction: (func: FluxToolbarFunction) => void
@@ -64,10 +67,16 @@ const FluxFunctionsToolbar: FC<Props> = (props: Props) => {
   }, [searchTerm])
 }
 
+const mstp = (state: AppState) => {
+  const activeQueryText = getActiveQuery(state).text
+
+  return {activeQueryText}
+}
+
 const mdtp = {
   onSetActiveQueryText: setActiveQueryText,
 }
 
-const connector = connect(null, mdtp)
+const connector = connect(mstp, mdtp)
 
 export default connector(FluxFunctionsToolbar)

--- a/src/timeMachine/components/fluxFunctionsToolbar/FluxFunctionsToolbar.tsx
+++ b/src/timeMachine/components/fluxFunctionsToolbar/FluxFunctionsToolbar.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {FC, useMemo, useState, useCallback} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import TransformToolbarFunctions from 'src/timeMachine/components/fluxFunctionsToolbar/TransformToolbarFunctions'
@@ -8,9 +7,6 @@ import FunctionCategory from 'src/timeMachine/components/fluxFunctionsToolbar/Fu
 import FluxToolbarSearch from 'src/timeMachine/components/FluxToolbarSearch'
 import {DapperScrollbars} from '@influxdata/clockface'
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
-
-// Actions
-import {setActiveQueryText} from 'src/timeMachine/actions'
 
 // Constants
 import {FLUX_FUNCTIONS} from 'src/shared/constants/fluxFunctions'
@@ -22,10 +18,7 @@ interface OwnProps {
   onInsertFluxFunction: (func: FluxToolbarFunction) => void
 }
 
-type ReduxProps = ConnectedProps<typeof connector>
-type Props = OwnProps & ReduxProps
-
-const FluxFunctionsToolbar: FC<Props> = (props: Props) => {
+const FluxFunctionsToolbar: FC<OwnProps> = (props: OwnProps) => {
   const [searchTerm, setSearchTerm] = useState('')
 
   const handleSearch = (searchTerm: string): void => {
@@ -67,10 +60,4 @@ const FluxFunctionsToolbar: FC<Props> = (props: Props) => {
   }, [searchTerm, handleClickFunction])
 }
 
-const mdtp = {
-  onSetActiveQueryText: setActiveQueryText,
-}
-
-const connector = connect(null, mdtp)
-
-export default connector(FluxFunctionsToolbar)
+export default FluxFunctionsToolbar

--- a/src/timeMachine/components/fluxFunctionsToolbar/FluxFunctionsToolbar.tsx
+++ b/src/timeMachine/components/fluxFunctionsToolbar/FluxFunctionsToolbar.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FC, useMemo, useState} from 'react'
+import React, {FC, useMemo, useState, useCallback} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
 
 // Components
@@ -32,9 +32,12 @@ const FluxFunctionsToolbar: FC<Props> = (props: Props) => {
     setSearchTerm(searchTerm)
   }
 
-  const handleClickFunction = (func: FluxToolbarFunction) => {
-    props.onInsertFluxFunction(func)
-  }
+  const handleClickFunction = useCallback(
+    (func: FluxToolbarFunction) => {
+      props.onInsertFluxFunction(func)
+    },
+    [props.onInsertFluxFunction]
+  )
 
   return useMemo(() => {
     return (
@@ -61,7 +64,7 @@ const FluxFunctionsToolbar: FC<Props> = (props: Props) => {
         </DapperScrollbars>
       </ErrorBoundary>
     )
-  }, [searchTerm, props.onInsertFluxFunction])
+  }, [searchTerm, handleClickFunction])
 }
 
 const mdtp = {

--- a/src/timeMachine/components/fluxFunctionsToolbar/FluxFunctionsToolbar.tsx
+++ b/src/timeMachine/components/fluxFunctionsToolbar/FluxFunctionsToolbar.tsx
@@ -12,14 +12,11 @@ import ErrorBoundary from 'src/shared/components/ErrorBoundary'
 // Actions
 import {setActiveQueryText} from 'src/timeMachine/actions'
 
-// Utils
-import {getActiveQuery} from 'src/timeMachine/selectors'
-
 // Constants
 import {FLUX_FUNCTIONS} from 'src/shared/constants/fluxFunctions'
 
 // Types
-import {AppState, FluxToolbarFunction} from 'src/types'
+import {FluxToolbarFunction} from 'src/types'
 
 interface OwnProps {
   onInsertFluxFunction: (func: FluxToolbarFunction) => void
@@ -64,19 +61,13 @@ const FluxFunctionsToolbar: FC<Props> = (props: Props) => {
         </DapperScrollbars>
       </ErrorBoundary>
     )
-  }, [searchTerm])
-}
-
-const mstp = (state: AppState) => {
-  const activeQueryText = getActiveQuery(state).text
-
-  return {activeQueryText}
+  }, [searchTerm, props.onInsertFluxFunction])
 }
 
 const mdtp = {
   onSetActiveQueryText: setActiveQueryText,
 }
 
-const connector = connect(mstp, mdtp)
+const connector = connect(null, mdtp)
 
 export default connector(FluxFunctionsToolbar)


### PR DESCRIPTION
Closes #1754 

Functions were being rendered multiple times on every keystroke and was causing a slow typing experience. I wrapped it in `useMemo` and now it only renders when the Function's search box is used. 

### Notebooks:

Before: 1 keystroke = 2 renders = 40ms render time
After: 1 keystroke = 0 renders = 16ms render time

![Screen Shot 2021-07-09 at 1 47 17 PM](https://user-images.githubusercontent.com/6411855/125134543-618c7300-e0bc-11eb-8c9a-20eb55fdcb66.png)
![Screen Shot 2021-07-09 at 1 44 25 PM](https://user-images.githubusercontent.com/6411855/125134548-63563680-e0bc-11eb-8a1d-1e67197aef64.png)

### Data Explorer:

Before: 1 keystroke = 10 renders = 47ms render time
After: 1 keystroke = 0 renders = 5ms render time

![image](https://user-images.githubusercontent.com/6411855/125136603-05c3e900-e0c0-11eb-8250-e9ed07683d8c.png)
![image](https://user-images.githubusercontent.com/6411855/125136547-e2993980-e0bf-11eb-98c7-7aba4496a041.png)


### Example typing speed improvement

Before:

https://user-images.githubusercontent.com/6411855/125136684-28560200-e0c0-11eb-8b90-ac102ba1d21c.mov

After:

https://user-images.githubusercontent.com/6411855/125136787-53d8ec80-e0c0-11eb-85c3-86c86d4d7dc5.mov

