### PR TITLE
feat: added monospace font to simple table

### DIFF
--- a/src/visualization/types/SimpleTable/style.scss
+++ b/src/visualization/types/SimpleTable/style.scss
@@ -7,6 +7,7 @@
   display: flex;
   flex-direction: column;
   user-select: text;
+  font-family: $cf-code-font;
 
   .cf-dapper-scrollbars {
     border-bottom: $cf-border solid $g2-kevlar;

--- a/src/visualization/types/SimpleTable/style.scss
+++ b/src/visualization/types/SimpleTable/style.scss
@@ -6,8 +6,8 @@
 
   display: flex;
   flex-direction: column;
-  user-select: text;
   font-family: $cf-code-font;
+  user-select: text;
 
   .cf-dapper-scrollbars {
     border-bottom: $cf-border solid $g2-kevlar;


### PR DESCRIPTION
Closes #1949 

**Issue** 
With the flag simpleTable on:
The raw data view doesn't use a monospace font and so it's hard to quickly read which number is large down a column.
For example:
<img width="1678" alt="Before Monospace" src="https://user-images.githubusercontent.com/66275100/125175710-62440880-e193-11eb-9ded-340bd5b30dec.png">

**Fix**
Raw data view displays table in monospace font.
<img width="1676" alt="After Monopace" src="https://user-images.githubusercontent.com/66275100/125175730-97505b00-e193-11eb-83e6-ee7e8418f199.png">

