### PR TITLE
fix: format the operator max duration policy for limits on an org to display hours and not ns

### DIFF
--- a/src/operator/OrgOverlay.tsx
+++ b/src/operator/OrgOverlay.tsx
@@ -149,7 +149,7 @@ const OrgOverlay: FC = () => {
                     />
                   </Grid.Column>
                   <Grid.Column widthMD={Columns.Three}>
-                    <Form.Label label="Max Retention Duration (hours)"></Form.Label>
+                    <Form.Label label="Max Retention Duration (hours)" />
                     <LimitsInput
                       type={InputType.Number}
                       name="bucket.maxRetentionDuration"

--- a/src/operator/context/overlay.tsx
+++ b/src/operator/context/overlay.tsx
@@ -79,7 +79,6 @@ export const OverlayProvider: FC<Props> = React.memo(({children}) => {
         setLimitsStatus(RemoteDataState.Done)
         const displayLimits = toDisplayLimits(resp.data)
         setLimits(displayLimits)
-        setLimits(resp.data)
       } catch (error) {
         setLimitsStatus(RemoteDataState.Error)
         console.error({error})

--- a/src/operator/utils.test.ts
+++ b/src/operator/utils.test.ts
@@ -1,0 +1,52 @@
+import {OrgLimits} from 'src/types'
+import {fromDisplayLimits, toDisplayLimits} from 'src/operator/utils'
+
+describe('converting limits for display', () => {
+  const limits: OrgLimits = {
+    bucket: {
+      maxBuckets: 2,
+      maxRetentionDuration: 86400000000000,
+    },
+    check: {
+      maxChecks: 5,
+    },
+    dashboard: {
+      maxDashboards: 3,
+    },
+    notificationEndpoint: {
+      blockedNotificationEndpoints: '',
+    },
+    notificationRule: {
+      blockedNotificationRules: '',
+      maxNotifications: 4,
+    },
+    orgID: 'ID',
+    rate: {
+      cardinality: 10000,
+      readKBs: 100000,
+      writeKBs: 1000,
+    },
+    task: {
+      maxTasks: 7,
+    },
+  }
+
+  it('converts max retention duration from ns to hours', () => {
+    const actual = toDisplayLimits(limits)
+    const expected = {
+      ...limits,
+      bucket: {
+        ...limits.bucket,
+        maxRetentionDuration: 24,
+      },
+    }
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('converts max retention duration from hours to ns', () => {
+    const displayLimits = toDisplayLimits(limits)
+
+    expect(fromDisplayLimits(displayLimits)).toEqual(limits)
+  })
+})

--- a/src/operator/utils.ts
+++ b/src/operator/utils.ts
@@ -6,7 +6,7 @@ import {OrgLimits} from 'src/types'
 const updateMaxRetentionWithCallback = (
   limits: OrgLimits,
   cb: typeof nsToHours | typeof hoursToNs
-) => ({
+): OrgLimits => ({
   ...limits,
   bucket: {
     ...limits?.bucket,
@@ -14,8 +14,8 @@ const updateMaxRetentionWithCallback = (
   },
 })
 
-export const toDisplayLimits = (limits: OrgLimits) =>
+export const toDisplayLimits = (limits: OrgLimits): OrgLimits =>
   updateMaxRetentionWithCallback(limits, nsToHours)
 
-export const fromDisplayLimits = (displayLimits: OrgLimits) =>
+export const fromDisplayLimits = (displayLimits: OrgLimits): OrgLimits =>
   updateMaxRetentionWithCallback(displayLimits, hoursToNs)


### PR DESCRIPTION
Closes #1977 

Fixes the issue where the displayed limits for a max duration were in nanoseconds and not hours