### PR TITLE
fix: fix cancel query issue in #1935

### DIFF
--- a/src/shared/apis/singleQuery.ts
+++ b/src/shared/apis/singleQuery.ts
@@ -49,6 +49,7 @@ export function RunQueryPromiseMutex<T>() {
             })
             .catch((error: Error) => {
               ret.reject(error)
+              reject(error)
             })
         }),
         cancel: ret.cancel,


### PR DESCRIPTION
![c3a8af4f-9eaf-4293-942a-22ece1e4222d](https://user-images.githubusercontent.com/1637395/125508154-586ed0ae-0854-4553-9660-5caf35aa3f70.gif)

The issue was that when you click on `Submit` and before the query finishes, you click on `Save`, the query still gets cancelled but due to the discrepancy in syncing of the 2 states the loading spinner keeps on going.

I dug deeper into the issue and found that we aren't really rejecting when we need to reject a promise. Instead, we are calling a reject function which we created. So, I am adding a fix which we may or may not end up keeping. The fix is to actually reject after running our custom reject function. This actually acknowleges that the promise is finished and is not in lingering state. Makes sure a resolve or a reject has happened. There's a side effect(maybe?) which is kind of unexpected but below is the gif showing that. Basically, the cell we were trying to edit(save) will error out but when you reload it will show the data correctly.

![Kapture 2021-07-13 at 14 54 28](https://user-images.githubusercontent.com/1637395/125509284-d02d4bbe-8ec8-4ebd-b3b8-7dd2a2c6e545.gif)


@Asalem1 @drdelambre  Please let me know what you think of this solution.