### PR TITLE
feat: adding task events

### DIFF
--- a/src/dataExplorer/components/SaveAsCellForm.tsx
+++ b/src/dataExplorer/components/SaveAsCellForm.tsx
@@ -42,6 +42,7 @@ import {
 
 // Utils
 import {initialStateHelper} from 'src/timeMachine/reducers'
+import {event} from 'src/cloud/utils/reporting'
 
 interface State {
   targetDashboardIDs: string[]
@@ -171,6 +172,7 @@ class SaveAsCellForm extends PureComponent<Props, State> {
     } = this.props
     const {targetDashboardIDs} = this.state
 
+    event('Data Explorer Save as Dashboard Submitted')
     const cellName = this.state.cellName || DEFAULT_CELL_NAME
     const newDashboardName =
       this.state.newDashboardName || DEFAULT_DASHBOARD_NAME

--- a/src/dataExplorer/components/SaveAsOverlay.tsx
+++ b/src/dataExplorer/components/SaveAsOverlay.tsx
@@ -1,5 +1,5 @@
-import React, {PureComponent} from 'react'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
+import React, {FC, useEffect, useState, useCallback} from 'react'
+import {useHistory} from 'react-router-dom'
 
 // Components
 import SaveAsCellForm from 'src/dataExplorer/components/SaveAsCellForm'
@@ -13,84 +13,73 @@ import {
   Orientation,
 } from '@influxdata/clockface'
 
+// Utils
+import {event} from 'src/cloud/utils/reporting'
+
 enum SaveAsOption {
   Dashboard = 'dashboard',
   Task = 'task',
   Variable = 'variable',
 }
 
-interface State {
-  saveAsOption: SaveAsOption
+const SaveAsOverlay: FC = () => {
+  const history = useHistory()
+  const [saveAsOption, setSaveAsOption] = useState(SaveAsOption.Dashboard)
+  const hide = useCallback(() => {
+    history.goBack()
+  }, [history])
+
+  useEffect(() => {
+    event('Data Explorer Save as Menu Changed', {menu: saveAsOption})
+  }, [saveAsOption])
+
+  let saveAsForm = <SaveAsCellForm dismiss={hide} />
+
+  if (saveAsOption === SaveAsOption.Task) {
+    saveAsForm = <SaveAsTaskForm dismiss={hide} />
+  } else if (saveAsOption === SaveAsOption.Variable) {
+    saveAsForm = <SaveAsVariable onHideOverlay={hide} />
+  }
+
+  return (
+    <Overlay visible={true}>
+      <Overlay.Container maxWidth={600}>
+        <Overlay.Header
+          title="Save As"
+          onDismiss={hide}
+          testID="save-as-overlay--header"
+        />
+        <Overlay.Body>
+          <Tabs.Container orientation={Orientation.Horizontal}>
+            <Tabs alignment={Alignment.Center} size={ComponentSize.Medium}>
+              <Tabs.Tab
+                id={SaveAsOption.Dashboard}
+                text="Dashboard Cell"
+                testID="cell--radio-button"
+                onClick={() => setSaveAsOption(SaveAsOption.Dashboard)}
+                active={saveAsOption === SaveAsOption.Dashboard}
+              />
+              <Tabs.Tab
+                id={SaveAsOption.Task}
+                text="Task"
+                testID="task--radio-button"
+                onClick={() => setSaveAsOption(SaveAsOption.Task)}
+                active={saveAsOption === SaveAsOption.Task}
+              />
+              <Tabs.Tab
+                id={SaveAsOption.Variable}
+                text="Variable"
+                testID="variable--radio-button"
+                onClick={() => setSaveAsOption(SaveAsOption.Variable)}
+                active={saveAsOption === SaveAsOption.Variable}
+              />
+            </Tabs>
+            <Tabs.TabContents>{saveAsForm}</Tabs.TabContents>
+          </Tabs.Container>
+        </Overlay.Body>
+      </Overlay.Container>
+    </Overlay>
+  )
 }
 
-class SaveAsOverlay extends PureComponent<RouteComponentProps, State> {
-  public state: State = {
-    saveAsOption: SaveAsOption.Dashboard,
-  }
-
-  render() {
-    const {saveAsOption} = this.state
-
-    return (
-      <Overlay visible={true}>
-        <Overlay.Container maxWidth={600}>
-          <Overlay.Header
-            title="Save As"
-            onDismiss={this.handleHideOverlay}
-            testID="save-as-overlay--header"
-          />
-          <Overlay.Body>
-            <Tabs.Container orientation={Orientation.Horizontal}>
-              <Tabs alignment={Alignment.Center} size={ComponentSize.Medium}>
-                <Tabs.Tab
-                  id={SaveAsOption.Dashboard}
-                  text="Dashboard Cell"
-                  testID="cell--radio-button"
-                  onClick={this.handleSetSaveAsOption}
-                  active={saveAsOption === SaveAsOption.Dashboard}
-                />
-                <Tabs.Tab
-                  id={SaveAsOption.Task}
-                  text="Task"
-                  testID="task--radio-button"
-                  onClick={this.handleSetSaveAsOption}
-                  active={saveAsOption === SaveAsOption.Task}
-                />
-                <Tabs.Tab
-                  id={SaveAsOption.Variable}
-                  text="Variable"
-                  testID="variable--radio-button"
-                  onClick={this.handleSetSaveAsOption}
-                  active={saveAsOption === SaveAsOption.Variable}
-                />
-              </Tabs>
-              <Tabs.TabContents>{this.saveAsForm}</Tabs.TabContents>
-            </Tabs.Container>
-          </Overlay.Body>
-        </Overlay.Container>
-      </Overlay>
-    )
-  }
-
-  private get saveAsForm(): JSX.Element {
-    const {saveAsOption} = this.state
-
-    if (saveAsOption === SaveAsOption.Dashboard) {
-      return <SaveAsCellForm dismiss={this.handleHideOverlay} />
-    } else if (saveAsOption === SaveAsOption.Task) {
-      return <SaveAsTaskForm dismiss={this.handleHideOverlay} />
-    } else if (saveAsOption === SaveAsOption.Variable) {
-      return <SaveAsVariable onHideOverlay={this.handleHideOverlay} />
-    }
-  }
-
-  private handleHideOverlay = () => {
-    this.props.history.goBack()
-  }
-
-  private handleSetSaveAsOption = (saveAsOption: SaveAsOption) => {
-    this.setState({saveAsOption})
-  }
-}
-
-export default withRouter(SaveAsOverlay)
+export default SaveAsOverlay

--- a/src/dataExplorer/components/SaveAsTaskForm.tsx
+++ b/src/dataExplorer/components/SaveAsTaskForm.tsx
@@ -23,6 +23,7 @@ import {
 import {getAllVariables, asAssignment} from 'src/variables/selectors'
 import {getOrg} from 'src/organizations/selectors'
 import {getActiveQuery} from 'src/timeMachine/selectors'
+import {event} from 'src/cloud/utils/reporting'
 
 // Types
 import {AppState, TaskSchedule, TaskOptionKeys} from 'src/types'
@@ -89,6 +90,8 @@ class SaveAsTaskForm extends PureComponent<
 
   private handleSubmit = () => {
     const {saveNewScript, newScript, taskOptions, goToTasks} = this.props
+
+    event('Data Explorer Save as Task Submitted')
 
     // Don't embed variables that are not used in the script
     const vars = [...this.props.userDefinedVars].filter(assignment =>

--- a/src/flows/pipes/Visualization/index.ts
+++ b/src/flows/pipes/Visualization/index.ts
@@ -21,7 +21,7 @@ export default register => {
         return
       }
 
-      if (!pipe.functions.length) {
+      if (!pipe.functions || !pipe.functions.length) {
         append('__CURRENT_RESULT__')
         return
       }

--- a/src/tasks/components/TasksHeader.tsx
+++ b/src/tasks/components/TasksHeader.tsx
@@ -16,6 +16,9 @@ import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
 import ResourceSortDropdown from 'src/shared/components/resource_sort_dropdown/ResourceSortDropdown'
 import RateLimitAlert from 'src/cloud/components/RateLimitAlert'
 
+// Utils
+import {event} from 'src/cloud/utils/reporting'
+
 // Types
 import {LimitStatus} from 'src/cloud/actions/limits'
 import {setSearchTerm as setSearchTermAction} from 'src/tasks/actions/creators'
@@ -57,6 +60,15 @@ export default class TasksHeader extends PureComponent<Props> {
       limitStatus,
     } = this.props
 
+    const creater = () => {
+      event('Task Created From Dropdown', {source: 'header'})
+      onCreateTask()
+    }
+    const importer = () => {
+      event('Task Imported From Dropdown', {source: 'header'})
+      onImportTask()
+    }
+
     return (
       <>
         <Page.Header fullWidth={false} testID="tasks-page--header">
@@ -91,8 +103,8 @@ export default class TasksHeader extends PureComponent<Props> {
               />
             </FlexBox>
             <AddResourceDropdown
-              onSelectNew={onCreateTask}
-              onSelectImport={onImportTask}
+              onSelectNew={creater}
+              onSelectImport={importer}
               resourceName="Task"
               limitStatus={limitStatus}
             />

--- a/src/tasks/components/TasksList.tsx
+++ b/src/tasks/components/TasksList.tsx
@@ -16,6 +16,9 @@ import {TaskSortKey} from 'src/shared/components/resource_sort_dropdown/generate
 // Selectors
 import {getSortedResources} from 'src/shared/utils/sort'
 
+// Utils
+import {event} from 'src/cloud/utils/reporting'
+
 interface Props {
   tasks: Task[]
   searchTerm: string
@@ -61,6 +64,15 @@ export default class TasksList extends PureComponent<Props, State> {
   public render() {
     const {searchTerm, onCreate, totalCount, onImportTask} = this.props
 
+    const creater = () => {
+      event('Task Created From Dropdown', {source: 'list'})
+      onCreate()
+    }
+    const importer = () => {
+      event('Task Imported From Dropdown', {source: 'list'})
+      onImportTask()
+    }
+
     return (
       <>
         <ResourceList>
@@ -68,9 +80,9 @@ export default class TasksList extends PureComponent<Props, State> {
             emptyState={
               <EmptyTasksList
                 searchTerm={searchTerm}
-                onCreate={onCreate}
+                onCreate={creater}
                 totalCount={totalCount}
-                onImportTask={onImportTask}
+                onImportTask={importer}
               />
             }
           >


### PR DESCRIPTION
there were a couple of questions we couldn't answer about how the current task interfaces are being used within the ui, so this fills in a few gaps for us. the main new events are:

`Task Created From Dropdown`: this event shows up when you click "create task -> new task" on the task list page and should help answer questions about how many users both enter through the tasks page and demonstrate the intent to create a task, while isolating the intent from the success/failures of the individual task editing interface.

`Data Explorer Save as Task Submitted`: this event is fired when we create a task from the data explorer page through the "save as" button in the top. This should allow us to quantify how many users are viewing tasks as an end state for their current query.