### PR TITLE
fix: data explorer tab visibility edge case bug

### DIFF
--- a/src/timeMachine/components/QueryTab.tsx
+++ b/src/timeMachine/components/QueryTab.tsx
@@ -144,7 +144,8 @@ class TimeMachineQueryTab extends PureComponent<Props, State> {
 
   private get showHideButton(): JSX.Element {
     const {query} = this.props
-    if (this.state.isEditingName || !this.isRemovable) {
+
+    if (this.state.isEditingName || (!this.isRemovable && !query?.hidden)) {
       return null
     }
 


### PR DESCRIPTION
Closes #1520

Updated the visibility logic to allow already hidden tabs to display the visibility icon

![visibility-toggle](https://user-images.githubusercontent.com/19984220/125696351-e386b55f-9390-4e09-b7dd-35b312a18732.gif)

