### PR TITLE
feat: open buckets in notebooks

### DIFF
--- a/src/buckets/components/BucketCard.tsx
+++ b/src/buckets/components/BucketCard.tsx
@@ -11,6 +11,9 @@ import BucketCardActions from 'src/buckets/components/BucketCardActions'
 // Constants
 import {isSystemBucket} from 'src/buckets/constants/index'
 
+// Utils
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+
 // Types
 import {OwnBucket} from 'src/types'
 
@@ -33,7 +36,11 @@ const BucketCard: FC<Props & RouteComponentProps<{orgID: string}>> = ({
   },
 }) => {
   const handleNameClick = () => {
-    history.push(`/orgs/${orgID}/data-explorer?bucket=${bucket.name}`)
+    if (isFlagEnabled('exploreWithFlows')) {
+      history.push(`/notebook/from/bucket/${bucket.name}`)
+    } else {
+      history.push(`/orgs/${orgID}/data-explorer?bucket=${bucket.name}`)
+    }
   }
 
   return (

--- a/src/buckets/components/DemoDataBucketCard.tsx
+++ b/src/buckets/components/DemoDataBucketCard.tsx
@@ -29,6 +29,9 @@ import {Context} from 'src/clockface'
 import {deleteDemoDataBucketMembership} from 'src/cloud/actions/thunks'
 import {notify as notifyAction} from 'src/shared/actions/notifications'
 
+// Utils
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+
 // Types
 import {DemoBucket} from 'src/types'
 
@@ -49,7 +52,11 @@ const DemoDataBucketCard: FC<Props> = ({
   notify,
 }) => {
   const handleNameClick = () => {
-    history.push(`/orgs/${orgID}/data-explorer?bucket=${bucket.name}`)
+    if (isFlagEnabled('exploreWithFlows')) {
+      history.push(`/notebook/from/bucket/${bucket.name}`)
+    } else {
+      history.push(`/orgs/${orgID}/data-explorer?bucket=${bucket.name}`)
+    }
   }
 
   const handleCopyAttempt = (

--- a/src/flows/components/FromTemplatePage.tsx
+++ b/src/flows/components/FromTemplatePage.tsx
@@ -19,7 +19,7 @@ import {
 // (ie: `/notebook/from/${key}`) and the value of the entry is going to be the notebook
 // that is generated
 const TEMPLATE_MAP = {
-  intro: {
+  intro: () => ({
     name: 'Welcome to Notebooks',
     readOnly: false,
     range: DEFAULT_TIME_RANGE,
@@ -32,8 +32,8 @@ const TEMPLATE_MAP = {
         uri: 'Rs16uhxK0h8',
       },
     ],
-  },
-  downsample: {
+  }),
+  downsample: () => ({
     name: 'Example: Demo Data Notebook',
     readOnly: false,
     range: {
@@ -248,6 +248,140 @@ const TEMPLATE_MAP = {
         visible: true,
       },
     ],
+  }),
+  bucket: name => {
+    return {
+      name: `Explore the ${name} bucket`,
+      readOnly: false,
+      range: DEFAULT_TIME_RANGE,
+      refresh: AUTOREFRESH_DEFAULT,
+      pipes: [
+        {
+          tags: {},
+          type: 'metricSelector',
+          field: '',
+          measurement: '',
+          aggregateFunction: {
+            name: 'mean',
+          },
+          bucket: {
+            name: name,
+          },
+          title: 'Select a Metric',
+          visible: true,
+        },
+        {
+          type: 'visualization',
+          properties: {
+            type: 'simple-table',
+            showAll: false,
+          },
+          period: '10s',
+          title: 'Validate the Data',
+          visible: true,
+        },
+        {
+          type: 'visualization',
+          period: '10s',
+          functions: [{name: 'mean'}],
+          properties: {
+            axes: {
+              x: {
+                base: '10',
+                bounds: ['', ''],
+                label: '',
+                prefix: '',
+                scale: 'linear',
+                suffix: '',
+              },
+              y: {
+                base: '10',
+                bounds: ['', ''],
+                label: '',
+                prefix: '',
+                scale: 'linear',
+                suffix: '',
+              },
+            },
+            colors: [
+              {
+                hex: '#31C0F6',
+                id: 'd001b766-bf5c-4ae3-a867-9a3774849cc1',
+                name: 'Nineteen Eighty Four',
+                type: 'scale',
+                value: 0,
+              },
+              {
+                hex: '#A500A5',
+                id: '547f5c28-4e2a-4c06-af49-a02e6fd11c5f',
+                name: 'Nineteen Eighty Four',
+                type: 'scale',
+                value: 0,
+              },
+              {
+                hex: '#FF7E27',
+                id: '3c0dadaf-f8aa-45a4-ba1a-3597b685b76f',
+                name: 'Nineteen Eighty Four',
+                type: 'scale',
+                value: 0,
+              },
+            ],
+            generateXAxisTicks: [],
+            generateYAxisTicks: [],
+            geom: 'line',
+            hoverDimension: 'auto',
+            legendOpacity: 1,
+            legendOrientationThreshold: 100000000,
+            note: '',
+            position: 'overlaid',
+            queries: [
+              {
+                builderConfig: {
+                  aggregateWindow: {
+                    fillValues: false,
+                    period: 'auto',
+                  },
+                  buckets: [],
+                  functions: [
+                    {
+                      name: 'mean',
+                    },
+                  ],
+                  tags: [
+                    {
+                      aggregateFunctionType: 'filter',
+                      key: '_measurement',
+                      values: [],
+                    },
+                  ],
+                },
+                editMode: 'builder',
+                name: '',
+                text: '',
+              },
+            ],
+            shape: 'chronograf-v2',
+            showNoteWhenEmpty: false,
+            staticLegend: {
+              heightRatio: 0.2,
+              hide: true,
+              widthRatio: 1,
+            },
+            type: 'xy',
+            xColumn: null,
+            xTickStart: null,
+            xTickStep: null,
+            xTotalTicks: null,
+            yColumn: null,
+            yTickStart: null,
+            yTickStep: null,
+            yTotalTicks: null,
+          },
+          title: 'Visualize the Result',
+          visible: true,
+        },
+      ],
+    }
   },
 }
 
@@ -256,14 +390,10 @@ const Template: FC = () => {
   const [loading, setLoading] = useState(false)
   const org = useSelector(getOrg)
   const history = useHistory()
-  const {template} = useParams()
+  const params = useParams()[0].split('/')
 
   useEffect(() => {
-    setLoading(false)
-  }, [template, setLoading])
-
-  useEffect(() => {
-    if (!TEMPLATE_MAP[template]) {
+    if (!TEMPLATE_MAP[params[0]]) {
       return
     }
 
@@ -273,10 +403,12 @@ const Template: FC = () => {
 
     setLoading(true)
 
-    add(hydrate(TEMPLATE_MAP[template])).then(id => {
-      history.push(`/orgs/${org.id}/notebooks/${id}`)
-    })
-  }, [add, history, org.id, loading, setLoading, template])
+    add(hydrate(TEMPLATE_MAP[params[0]].apply(this, params.slice(1)))).then(
+      id => {
+        history.push(`/orgs/${org.id}/notebooks/${id}`)
+      }
+    )
+  }, [add, history, org.id, loading, setLoading, params])
 
   return <div />
 }
@@ -285,7 +417,7 @@ const FromTemplatePage: FC = () => {
   return (
     <FlowListProvider>
       <Switch>
-        <Route path="/notebook/from/:template" component={Template} />
+        <Route path="/notebook/from/*" component={Template} />
         <Route component={NotFound} />
       </Switch>
     </FlowListProvider>

--- a/src/shared/selectors/flags.ts
+++ b/src/shared/selectors/flags.ts
@@ -46,6 +46,7 @@ export const OSS_FLAGS = {
   'molly-first': false,
   'managed-functions': false,
   simpleTable: false,
+  exploreWithFlows: false,
 }
 
 export const CLOUD_FLAGS = {
@@ -94,6 +95,7 @@ export const CLOUD_FLAGS = {
   'molly-first': false,
   'managed-functions': false,
   simpleTable: false,
+  exploreWithFlows: false,
 }
 
 export const activeFlags = (state: AppState): FlagMap => {


### PR DESCRIPTION
@Asalem1 had the best idea this morning and i couldn't wait to see it made, so i made it. when you click on a bucket, instead of opening up in crummy old data explorer, it makes a new notebook for you with the bucket selected in the metric selector. This specific link accounts for ~25% of the unique traffic to data explorer, so we should expect it to move the adoption needle a bit more organically.

check it out with `influx.set('exploreWithFlows', true)`

![Peek 2021-07-14 15-07](https://user-images.githubusercontent.com/1434802/125699589-c905eafd-56e4-4ee4-a4c0-04827738dc5f.gif)
