### PR TITLE
feat: give notebooks default names

### DIFF
--- a/src/flows/context/flow.list.tsx
+++ b/src/flows/context/flow.list.tsx
@@ -158,9 +158,17 @@ export const FlowListProvider: FC = ({children}) => {
     let _flow
     let _flowData
 
+    let {name} = org
+
+    if (name.includes('@')) {
+      name = name.split('@')[0]
+    }
+
+    name = `${name}-${PROJECT_NAME.toLowerCase()}-${new Date().toISOString()}`
+
     if (!flow) {
       _flowData = hydrate({
-        name: `Name this ${PROJECT_NAME}`,
+        name,
         readOnly: false,
         range: DEFAULT_TIME_RANGE,
         refresh: AUTOREFRESH_DEFAULT,

--- a/src/writeData/components/fileUploads/CsvMethod.tsx
+++ b/src/writeData/components/fileUploads/CsvMethod.tsx
@@ -18,6 +18,7 @@ import StatusIndicator from 'src/buckets/components/csvUploader/StatusIndicator'
 
 // Utils
 import {getOrg} from 'src/organizations/selectors'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Types
 import {RemoteDataState} from 'src/types'
@@ -48,7 +49,11 @@ const CsvMethod: FC = () => {
   }
 
   const handleSeeUploadedData = () => {
-    history.push(`/orgs/${orgId}/data-explorer?bucket=${bucket.name}`)
+    if (isFlagEnabled('exploreWithFlows')) {
+      history.push(`/notebook/from/bucket/${bucket.name}`)
+    } else {
+      history.push(`/orgs/${orgId}/data-explorer?bucket=${bucket.name}`)
+    }
   }
 
   return (


### PR DESCRIPTION
Closes #https://github.com/influxdata/influxdb/issues/20692

I think this pattern might not be more helpful than the previous implementation in a case like tools where there's 1 org and the only difference will be the timestamp? 🤷🏽 

![serialize-notebook-names](https://user-images.githubusercontent.com/19984220/125699844-3676e3b5-6b08-40b4-99d1-f1f0cd646500.gif)

