### PR TITLE
refactor: remove moment from dashboards/selectors/index.ts 

### DIFF
--- a/src/dashboards/selectors/index.test.ts
+++ b/src/dashboards/selectors/index.test.ts
@@ -208,7 +208,7 @@ describe('Dashboards.Selector', () => {
 })
 
 describe('Dashboards.Selector helper method(s)', () => {
-  it('should swap the time zone with UTC without affecting the hours', () => {
+  it('should swap the time zone with UTC without affecting the hours when local timezone is GMT-7', () => {
     // Example: user selected 10-11:00am and sets the dropdown to UTC
     // Query should run against 10-11:00am UTC rather than querying
     // 10-11:00am local time (offset depending on timezone)
@@ -218,6 +218,34 @@ describe('Dashboards.Selector helper method(s)', () => {
 
     // mock the time zone offset for GMT-7
     mocked(getTimezoneOffset).mockImplementation(() => 420)
+
+    expect(setTimeToUTC(localTimeString)).toEqual(expectedUTCTime)
+  })
+
+  it('should swap the time zone with UTC without affecting the hours when local timezone is GMT-5', () => {
+    // Example: user selected 10-11:00am and sets the dropdown to UTC
+    // Query should run against 10-11:00am UTC rather than querying
+    // 10-11:00am local time (offset depending on timezone)
+
+    const localTimeString = '2021-07-04 12:00:00 GMT-5'
+    const expectedUTCTime = '2021-07-04T12:00:00Z'
+
+    // mock the time zone offset for GMT-5
+    mocked(getTimezoneOffset).mockImplementation(() => 300)
+
+    expect(setTimeToUTC(localTimeString)).toEqual(expectedUTCTime)
+  })
+
+  it('should swap the time zone with UTC without affecting the hours when local timezone is GMT', () => {
+    // Example: user selected 10-11:00am and sets the dropdown to UTC
+    // Query should run against 10-11:00am UTC rather than querying
+    // 10-11:00am local time (offset depending on timezone)
+
+    const localTimeString = '2021-07-04 12:00:00 GMT'
+    const expectedUTCTime = '2021-07-04T12:00:00Z'
+
+    // mock the time zone offset for GMT
+    mocked(getTimezoneOffset).mockImplementation(() => 0)
 
     expect(setTimeToUTC(localTimeString)).toEqual(expectedUTCTime)
   })

--- a/src/dashboards/selectors/index.test.ts
+++ b/src/dashboards/selectors/index.test.ts
@@ -3,6 +3,7 @@ import {mocked} from 'ts-jest/utils'
 import {
   getTimeRange,
   getTimeRangeWithTimezone,
+  setTimeToUTC,
 } from 'src/dashboards/selectors/index'
 import {getTimezoneOffset} from 'src/dashboards/utils/getTimezoneOffset'
 
@@ -203,5 +204,21 @@ describe('Dashboards.Selector', () => {
     expect(
       untypedGetTimeRangeWithTimeZone({ranges, currentDashboard, app})
     ).toEqual(expected)
+  })
+})
+
+describe('Dashboards.Selector helper method(s)', () => {
+  it('should swap the time zone with UTC without affecting the hours', () => {
+    // Example: user selected 10-11:00am and sets the dropdown to UTC
+    // Query should run against 10-11:00am UTC rather than querying
+    // 10-11:00am local time (offset depending on timezone)
+
+    const localTimeString = '2021-07-04 12:00:00 GMT-7'
+    const expectedUTCTime = '2021-07-04T12:00:00Z'
+
+    // mock the time zone offset for GMT-7
+    mocked(getTimezoneOffset).mockImplementation(() => 420)
+
+    expect(setTimeToUTC(localTimeString)).toEqual(expectedUTCTime)
   })
 })

--- a/src/dashboards/selectors/index.ts
+++ b/src/dashboards/selectors/index.ts
@@ -1,6 +1,5 @@
 // Libraries
 import {get} from 'lodash'
-import moment from 'moment'
 
 // Types
 import {
@@ -64,11 +63,13 @@ export const isCurrentPageDashboard = (state: AppState): boolean =>
 // Example: user selected 10-11:00am and sets the dropdown to UTC
 // Query should run against 10-11:00am UTC rather than querying
 // 10-11:00am local time (offset depending on timezone)
-export const setTimeToUTC = (date: string): string =>
-  moment
-    .utc(date)
-    .subtract(getTimezoneOffset(), 'minutes')
-    .format()
+export const setTimeToUTC = (date: string): string => {
+  const utcTime = new Date(date)
+  utcTime.setUTCMinutes(utcTime.getUTCMinutes() - getTimezoneOffset())
+
+  return utcTime.toISOString().split('.')[0]+"Z"
+}
+
 
 export const getTimeZone = (state: AppState): TimeZone => {
   return state.app.persisted.timeZone || 'Local'

--- a/src/dashboards/selectors/index.ts
+++ b/src/dashboards/selectors/index.ts
@@ -67,9 +67,8 @@ export const setTimeToUTC = (date: string): string => {
   const utcTime = new Date(date)
   utcTime.setUTCMinutes(utcTime.getUTCMinutes() - getTimezoneOffset())
 
-  return utcTime.toISOString().split('.')[0]+"Z"
+  return utcTime.toISOString().split('.')[0] + 'Z'
 }
-
 
 export const getTimeZone = (state: AppState): TimeZone => {
   return state.app.persisted.timeZone || 'Local'

--- a/src/dashboards/selectors/index.ts
+++ b/src/dashboards/selectors/index.ts
@@ -67,7 +67,7 @@ export const setTimeToUTC = (date: string): string => {
   const utcTime = new Date(date)
   utcTime.setUTCMinutes(utcTime.getUTCMinutes() - getTimezoneOffset())
 
-  return utcTime.toISOString().split('.')[0] + 'Z'
+  return `${utcTime.toISOString().split('.')[0]}Z`
 }
 
 export const getTimeZone = (state: AppState): TimeZone => {


### PR DESCRIPTION
Closes #2019

part of : #1844

This PR removes `moment` from `dashboards/selectors/index.ts`
