### PR TITLE
fix: unify view property initialization

### DIFF
--- a/src/views/helpers/index.ts
+++ b/src/views/helpers/index.ts
@@ -1,23 +1,5 @@
 // Constants
-import {INFERNO, NINETEEN_EIGHTY_FOUR} from '@influxdata/giraffe'
-import {DEFAULT_LINE_COLORS} from 'src/shared/constants/graphColorPalettes'
 import {DEFAULT_CELL_NAME} from 'src/dashboards/constants'
-import {
-  LEGEND_OPACITY_DEFAULT,
-  LEGEND_ORIENTATION_THRESHOLD_DEFAULT,
-  LEGEND_COLORIZE_ROWS_DEFAULT,
-  LEGEND_HIDE_DEFAULT,
-  STATIC_LEGEND_HEIGHT_RATIO_NOT_SET,
-  STATIC_LEGEND_SHOW_DEFAULT,
-  STATIC_LEGEND_WIDTH_RATIO_DEFAULT,
-} from 'src/visualization/constants'
-import {
-  DEFAULT_GAUGE_COLORS,
-  DEFAULT_THRESHOLDS_LIST_COLORS,
-  DEFAULT_THRESHOLDS_GEO_COLORS,
-  DEFAULT_THRESHOLDS_TABLE_COLORS,
-} from 'src/shared/constants/thresholds'
-import {DEFAULT_CHECK_EVERY} from 'src/alerting/constants'
 import {
   DEFAULT_FILLVALUES,
   AGG_WINDOW_AUTO,
@@ -26,32 +8,23 @@ import {
 
 // Types
 import {
-  Axis,
-  BandViewProperties,
-  Base,
   BuilderConfig,
   CheckType,
   CheckViewProperties,
   Color,
   DashboardQuery,
-  GaugeViewProperties,
-  GeoViewProperties,
-  HeatmapViewProperties,
-  HistogramViewProperties,
-  LinePlusSingleStatProperties,
-  MarkdownViewProperties,
-  MosaicViewProperties,
   NewView,
   RemoteDataState,
-  ScatterViewProperties,
-  SingleStatViewProperties,
-  StaticLegend,
   TableViewProperties,
   ViewProperties,
   ViewType,
-  XYViewProperties,
 } from 'src/types'
-import {LineHoverDimension} from '@influxdata/giraffe/dist/types'
+
+import {DEFAULT_THRESHOLDS_LIST_COLORS} from 'src/shared/constants/thresholds'
+import {DEFAULT_CHECK_EVERY} from 'src/alerting/constants'
+import {DEFAULT_LINE_COLORS} from 'src/shared/constants/graphColorPalettes'
+
+import {SUPPORTED_VISUALIZATIONS} from 'src/visualization'
 
 export const defaultView = (name: string = DEFAULT_CELL_NAME) => {
   return {
@@ -78,343 +51,7 @@ export function defaultBuilderConfig(): BuilderConfig {
   }
 }
 
-const legendProps = {
-  legendColorizeRows: LEGEND_COLORIZE_ROWS_DEFAULT,
-  legendHide: LEGEND_HIDE_DEFAULT,
-  legendOpacity: LEGEND_OPACITY_DEFAULT,
-  legendOrientationThreshold: LEGEND_ORIENTATION_THRESHOLD_DEFAULT,
-}
-
-const staticLegend = {
-  colorizeRows: LEGEND_COLORIZE_ROWS_DEFAULT,
-  heightRatio: STATIC_LEGEND_HEIGHT_RATIO_NOT_SET,
-  opacity: LEGEND_OPACITY_DEFAULT,
-  orientationThreshold: LEGEND_ORIENTATION_THRESHOLD_DEFAULT,
-  show: STATIC_LEGEND_SHOW_DEFAULT,
-  widthRatio: STATIC_LEGEND_WIDTH_RATIO_DEFAULT,
-} as StaticLegend
-
-const tickProps = {
-  generateXAxisTicks: [],
-  generateYAxisTicks: [],
-  xTotalTicks: null,
-  xTickStart: null,
-  xTickStep: null,
-  yTotalTicks: null,
-  yTickStart: null,
-  yTickStep: null,
-}
-
-export function defaultLineViewProperties() {
-  return {
-    ...legendProps,
-    staticLegend,
-    queries: [defaultViewQuery()],
-    colors: DEFAULT_LINE_COLORS as Color[],
-    note: '',
-    showNoteWhenEmpty: false,
-    ...tickProps,
-    axes: {
-      x: {
-        bounds: ['', ''],
-        label: '',
-        prefix: '',
-        suffix: '',
-        base: '10',
-        scale: 'linear',
-      } as Axis,
-      y: {
-        bounds: ['', ''],
-        label: '',
-        prefix: '',
-        suffix: '',
-        base: '10' as Base,
-        scale: 'linear',
-      } as Axis,
-    },
-    hoverDimension: 'auto' as LineHoverDimension,
-  }
-}
-
-export function defaultBandViewProperties() {
-  return {
-    ...legendProps,
-    staticLegend,
-    queries: [defaultViewQuery()],
-    colors: DEFAULT_LINE_COLORS as Color[],
-    note: '',
-    showNoteWhenEmpty: false,
-    ...tickProps,
-    axes: {
-      x: {
-        bounds: ['', ''],
-        label: '',
-        prefix: '',
-        suffix: '',
-        scale: 'linear',
-      } as Axis,
-      y: {
-        bounds: ['', ''],
-        label: '',
-        prefix: '',
-        suffix: '',
-        scale: 'linear',
-      } as Axis,
-    },
-    hoverDimension: 'auto' as LineHoverDimension,
-    upperColumn: '',
-    mainColumn: DEFAULT_AGGREGATE_FUNCTION,
-    lowerColumn: '',
-  }
-}
-
-function defaultGaugeViewProperties() {
-  return {
-    queries: [defaultViewQuery()],
-    colors: DEFAULT_GAUGE_COLORS as Color[],
-    prefix: '',
-    tickPrefix: '',
-    suffix: '',
-    tickSuffix: '',
-    note: '',
-    showNoteWhenEmpty: false,
-    decimalPlaces: {
-      isEnforced: true,
-      digits: 2,
-    },
-  }
-}
-
-function defaultSingleStatViewProperties() {
-  return {
-    queries: [defaultViewQuery()],
-    colors: DEFAULT_THRESHOLDS_LIST_COLORS as Color[],
-    prefix: '',
-    tickPrefix: '',
-    suffix: '',
-    tickSuffix: '',
-    note: '',
-    showNoteWhenEmpty: false,
-    decimalPlaces: {
-      isEnforced: true,
-      digits: 2,
-    },
-  }
-}
-
-// Defines the zero values of the various view types
-const NEW_VIEW_CREATORS = {
-  xy: (): NewView<XYViewProperties> => ({
-    ...defaultView(),
-    properties: {
-      ...defaultLineViewProperties(),
-      type: 'xy',
-      shape: 'chronograf-v2',
-      geom: 'line',
-      xColumn: null,
-      yColumn: null,
-      position: 'overlaid',
-    },
-  }),
-  band: (): NewView<BandViewProperties> => ({
-    ...defaultView(),
-    properties: {
-      ...defaultBandViewProperties(),
-      type: 'band',
-      shape: 'chronograf-v2',
-      geom: 'line',
-      xColumn: null,
-      yColumn: null,
-    },
-  }),
-  histogram: (): NewView<HistogramViewProperties> => ({
-    ...defaultView(),
-    properties: {
-      ...legendProps,
-      queries: [],
-      type: 'histogram',
-      shape: 'chronograf-v2',
-      xColumn: '_value',
-      xDomain: null,
-      xAxisLabel: '',
-      fillColumns: null,
-      position: 'stacked',
-      binCount: 30,
-      colors: DEFAULT_LINE_COLORS as Color[],
-      note: '',
-      showNoteWhenEmpty: false,
-    },
-  }),
-  heatmap: (): NewView<HeatmapViewProperties> => ({
-    ...defaultView(),
-    properties: {
-      ...legendProps,
-      queries: [],
-      type: 'heatmap',
-      shape: 'chronograf-v2',
-      xColumn: null,
-      yColumn: null,
-      xDomain: null,
-      yDomain: null,
-      xAxisLabel: '',
-      yAxisLabel: '',
-      xPrefix: '',
-      xSuffix: '',
-      yPrefix: '',
-      ySuffix: '',
-      colors: INFERNO,
-      binSize: 10,
-      note: '',
-      showNoteWhenEmpty: false,
-      ...tickProps,
-    },
-  }),
-  'single-stat': (): NewView<SingleStatViewProperties> => ({
-    ...defaultView(),
-    properties: {
-      ...defaultSingleStatViewProperties(),
-      type: 'single-stat',
-      shape: 'chronograf-v2',
-    },
-  }),
-  gauge: (): NewView<GaugeViewProperties> => ({
-    ...defaultView(),
-    properties: {
-      ...defaultGaugeViewProperties(),
-      type: 'gauge',
-      shape: 'chronograf-v2',
-    },
-  }),
-  'line-plus-single-stat': (): NewView<LinePlusSingleStatProperties> => ({
-    ...defaultView(),
-    properties: {
-      ...defaultLineViewProperties(),
-      ...defaultSingleStatViewProperties(),
-      type: 'line-plus-single-stat',
-      shape: 'chronograf-v2',
-      xColumn: null,
-      yColumn: null,
-      position: 'overlaid',
-    },
-  }),
-  table: (): NewView<TableViewProperties> => ({
-    ...defaultView(),
-    properties: {
-      type: 'table',
-      shape: 'chronograf-v2',
-      queries: [defaultViewQuery()],
-      colors: DEFAULT_THRESHOLDS_TABLE_COLORS as Color[],
-      tableOptions: {
-        verticalTimeAxis: true,
-        sortBy: null,
-        fixFirstColumn: false,
-      },
-      fieldOptions: [],
-      decimalPlaces: {
-        isEnforced: false,
-        digits: 2,
-      },
-      timeFormat: 'YYYY-MM-DD HH:mm:ss',
-      note: '',
-      showNoteWhenEmpty: false,
-    },
-  }),
-  markdown: (): NewView<MarkdownViewProperties> => ({
-    ...defaultView(),
-    properties: {
-      type: 'markdown',
-      shape: 'chronograf-v2',
-      note: '',
-    },
-  }),
-  scatter: (): NewView<ScatterViewProperties> => ({
-    ...defaultView(),
-    properties: {
-      ...legendProps,
-      type: 'scatter',
-      shape: 'chronograf-v2',
-      queries: [defaultViewQuery()],
-      colors: NINETEEN_EIGHTY_FOUR,
-      note: '',
-      showNoteWhenEmpty: false,
-      ...tickProps,
-      fillColumns: null,
-      symbolColumns: null,
-      xColumn: null,
-      xDomain: null,
-      yColumn: null,
-      yDomain: null,
-      xAxisLabel: '',
-      yAxisLabel: '',
-      xPrefix: '',
-      xSuffix: '',
-      yPrefix: '',
-      ySuffix: '',
-    },
-  }),
-  mosaic: (): NewView<MosaicViewProperties> => ({
-    ...defaultView(),
-    properties: {
-      ...legendProps,
-      type: 'mosaic',
-      shape: 'chronograf-v2',
-      queries: [defaultViewQuery()],
-      colors: NINETEEN_EIGHTY_FOUR,
-      note: '',
-      showNoteWhenEmpty: false,
-      generateXAxisTicks: [],
-      xTotalTicks: null,
-      xTickStart: null,
-      xTickStep: null,
-      fillColumns: null,
-      xColumn: null,
-      xDomain: null,
-      ySeriesColumns: null,
-      yLabelColumns: null,
-      yLabelColumnSeparator: '',
-      yDomain: null,
-      xAxisLabel: '',
-      yAxisLabel: '',
-      xPrefix: '',
-      xSuffix: '',
-      yPrefix: '',
-      ySuffix: '',
-    },
-  }),
-  geo: (): NewView<GeoViewProperties> => ({
-    ...defaultView(),
-    properties: {
-      type: 'geo',
-      shape: 'chronograf-v2',
-      queries: [defaultViewQuery()],
-      note: '',
-      showNoteWhenEmpty: false,
-      center: {
-        lat: 0,
-        lon: 0,
-      },
-      zoom: 6,
-      allowPanAndZoom: true,
-      detectCoordinateFields: false,
-      mapStyle: '',
-      useS2CellID: true,
-      s2Column: 's2_cell_id',
-      latLonColumns: {
-        lat: {key: '', column: ''},
-        lon: {key: '', column: ''},
-      },
-      layers: [
-        {
-          type: 'pointMap',
-          colorDimension: {label: 'Value'},
-          colorField: '_value',
-          colors: DEFAULT_THRESHOLDS_GEO_COLORS,
-          isClustered: false,
-          tooltipColumns: [],
-        },
-      ],
-    },
-  }),
+const SPECIAL_TYPES = {
   threshold: (): NewView<CheckViewProperties> => ({
     ...defaultView('check'),
     properties: {
@@ -502,11 +139,21 @@ type CreateViewType = ViewType | CheckType
 export function createView<T extends ViewProperties = ViewProperties>(
   viewType: CreateViewType = 'xy'
 ): NewView<T> {
-  const creator = NEW_VIEW_CREATORS[viewType]
+  //these aren't currently supported visualizations
+  if (SPECIAL_TYPES[viewType]) {
+    return SPECIAL_TYPES[viewType]() as NewView<T>
+  }
 
-  if (!creator) {
+  if (!SUPPORTED_VISUALIZATIONS[viewType]) {
     throw new Error(`no view creator implemented for view of type ${viewType}`)
   }
 
-  return creator() as NewView<T>
+  const creator = {
+    ...defaultView(),
+    properties: JSON.parse(
+      JSON.stringify(SUPPORTED_VISUALIZATIONS[viewType].initial)
+    ),
+  }
+
+  return creator as NewView<T>
 }

--- a/src/views/helpers/index.ts
+++ b/src/views/helpers/index.ts
@@ -139,7 +139,7 @@ type CreateViewType = ViewType | CheckType
 export function createView<T extends ViewProperties = ViewProperties>(
   viewType: CreateViewType = 'xy'
 ): NewView<T> {
-  //these aren't currently supported visualizations
+  // these aren't currently supported visualizations
   if (SPECIAL_TYPES[viewType]) {
     return SPECIAL_TYPES[viewType]() as NewView<T>
   }

--- a/src/visualization/types/Map/GeoOptions.tsx
+++ b/src/visualization/types/Map/GeoOptions.tsx
@@ -26,7 +26,6 @@ interface Props extends VisualizationOptionProps {
   properties: GeoViewProperties
 }
 
-const SHOW_GEO_OPTIONS = isFlagEnabled('mapGeoOptions')
 // const mapTypeOptions = ['Point', 'Circle', 'Heat', 'Track']
 export enum MapType {
   Point = 'pointMap',
@@ -51,7 +50,7 @@ export const GeoOptions: FC<Props> = ({properties, update, results}) => {
     return {color: InfluxColors.Sidewalk}
   }
 
-  return SHOW_GEO_OPTIONS ? (
+  return isFlagEnabled('mapGeoOptions') ? (
     <>
       <Grid.Column>
         <Grid.Row>


### PR DESCRIPTION
simple table is broken as a visualization in data explorer, and in looking into that, i found the reason that maps and static legend efforts have kept breaking visualizations in notebooks. in essence, the visualization registration mechanism has a property `initial` that was used to depreciate the `src/views/helpers/index` file and allow default view properties to be defined next to the definition of their view component and stuff. only problem is that we never depreciated the `src/views/helpers/index` file! so people would be making edits there, which would work only for time machine, but not in notebooks. this is that work