### PR TITLE
fix: disable simple table until backend is in there

### DIFF
--- a/src/timeMachine/components/ViewTypeDropdown.tsx
+++ b/src/timeMachine/components/ViewTypeDropdown.tsx
@@ -37,7 +37,11 @@ export const TimeMachineViewTypeDropdown: FC<{}> = () => {
   )
 
   return (
-    <ViewTypeDropdown viewType={viewType} onUpdateType={updateType as any} />
+    <ViewTypeDropdown
+      viewType={viewType}
+      onUpdateType={updateType as any}
+      filter={['simple-table']}
+    />
   )
 }
 

--- a/src/visualization/components/ViewTypeDropdown.tsx
+++ b/src/visualization/components/ViewTypeDropdown.tsx
@@ -11,10 +11,12 @@ import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 export interface Props {
   viewType: string
   onUpdateType: (type: string) => void
+  filter?: string[]
 }
 
-const ViewTypeDropdown: FC<Props> = ({viewType, onUpdateType}) => {
+const ViewTypeDropdown: FC<Props> = ({viewType, onUpdateType, filter = []}) => {
   const items = Object.values(SUPPORTED_VISUALIZATIONS)
+    .filter(def => !filter.includes(def.type))
     .filter(def => !def.disabled)
     .filter(def => !def.featureFlag || isFlagEnabled(def.featureFlag))
     .filter(def => def.options)


### PR DESCRIPTION
everything was working great until i learned that jest needed to be updated in order to run any tests that involve visualizations, and that i had to save to new visualization type through the timemachine endpoints... which currently isn't supported by the api!

while those things get sorted, lets just disable simple table as a visualization for data explorer for now