### PR TITLE
fix: allow multi line annotations

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "@influxdata/clockface": "^2.10.0",
     "@influxdata/flux": "^0.5.1",
     "@influxdata/flux-lsp-browser": "^0.5.53",
-    "@influxdata/giraffe": "^2.16.0",
+    "@influxdata/giraffe": "^2.16.1",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",

--- a/src/annotations/components/annotationForm/AnnotationForm.tsx
+++ b/src/annotations/components/annotationForm/AnnotationForm.tsx
@@ -325,10 +325,7 @@ export const AnnotationForm: FC<Props> = (props: Props) => {
               />
             )}
           </div>
-          <AnnotationMessageInput
-            message={summary}
-            onChange={updateSummary}
-          />
+          <AnnotationMessageInput message={summary} onChange={updateSummary} />
         </Overlay.Body>
         <Overlay.Footer className={footerClasses}>
           {isEditing && (

--- a/src/annotations/components/annotationForm/AnnotationForm.tsx
+++ b/src/annotations/components/annotationForm/AnnotationForm.tsx
@@ -56,6 +56,10 @@ export const END_TIME_IN_FUTURE_MESSAGE = 'Stop Time cannot be in the future'
 export const TIMES_ARE_SAME_MESSAGE = 'Stop Time must be after the start time'
 export const START_TIME_IN_FUTURE_MESSAGE = 'Start Time cannot be in the future'
 
+/**
+ *  Form for editing and creating annotations.
+ *  It does support multi-line annotations, but the tradeoff is that the user cannot then press 'return' to submit the form.
+ * */
 export const AnnotationForm: FC<Props> = (props: Props) => {
   const [startTime, setStartTime] = useState(props.startTime)
   const [endTime, setEndTime] = useState(props.endTime)
@@ -324,7 +328,6 @@ export const AnnotationForm: FC<Props> = (props: Props) => {
           <AnnotationMessageInput
             message={summary}
             onChange={updateSummary}
-            onSubmit={handleKeyboardSubmit}
           />
         </Overlay.Body>
         <Overlay.Footer className={footerClasses}>

--- a/src/annotations/components/annotationForm/AnnotationMessageInput.tsx
+++ b/src/annotations/components/annotationForm/AnnotationMessageInput.tsx
@@ -7,7 +7,6 @@ import {Form, TextArea} from '@influxdata/clockface'
 interface Props {
   message: string
   onChange: (newMessage: string) => void
-  onSubmit: () => void
 }
 
 const characterLimit = 255

--- a/src/annotations/components/annotationForm/AnnotationMessageInput.tsx
+++ b/src/annotations/components/annotationForm/AnnotationMessageInput.tsx
@@ -2,7 +2,6 @@
 import React, {
   FC,
   ChangeEvent,
-  KeyboardEvent,
   useEffect,
   useRef,
   useState,
@@ -21,6 +20,7 @@ const characterLimit = 255
 
 export const AnnotationMessageInput: FC<Props> = (props: Props) => {
   const textArea = useRef(null)
+  console.log('ack! a ')
   const validationMessage = props.message ? '' : 'This field is required'
   const [characterCount, setCharacterCount] = useState(
     props.message?.length ?? 0
@@ -29,13 +29,6 @@ export const AnnotationMessageInput: FC<Props> = (props: Props) => {
   const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
     setCharacterCount(event.target.value.length)
     props.onChange(event.target.value)
-  }
-
-  const handleKeyPress = (event: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (event.key === 'Enter') {
-      props.onSubmit()
-      return
-    }
   }
 
   useEffect(() => {
@@ -57,7 +50,6 @@ export const AnnotationMessageInput: FC<Props> = (props: Props) => {
         name="message"
         value={props.message}
         onChange={handleChange}
-        onKeyPress={handleKeyPress}
         style={{height: '80px', minHeight: '80px'}}
         ref={textArea}
         maxLength={characterLimit}

--- a/src/annotations/components/annotationForm/AnnotationMessageInput.tsx
+++ b/src/annotations/components/annotationForm/AnnotationMessageInput.tsx
@@ -1,11 +1,5 @@
 // Libraries
-import React, {
-  FC,
-  ChangeEvent,
-  useEffect,
-  useRef,
-  useState,
-} from 'react'
+import React, {FC, ChangeEvent, useEffect, useRef, useState} from 'react'
 
 // Components
 import {Form, TextArea} from '@influxdata/clockface'

--- a/src/annotations/components/annotationForm/AnnotationMessageInput.tsx
+++ b/src/annotations/components/annotationForm/AnnotationMessageInput.tsx
@@ -20,7 +20,6 @@ const characterLimit = 255
 
 export const AnnotationMessageInput: FC<Props> = (props: Props) => {
   const textArea = useRef(null)
-  console.log('ack! a ')
   const validationMessage = props.message ? '' : 'This field is required'
   const [characterCount, setCharacterCount] = useState(
     props.message?.length ?? 0

--- a/yarn.lock
+++ b/yarn.lock
@@ -863,10 +863,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/flux/-/flux-0.5.1.tgz#e39e7a7af9163fc9494422c8fed77f3ae1b68f56"
   integrity sha512-GHlkXBhSdJ2m56JzDkbnKPAqLj3/lexPooacu14AWTO4f2sDGLmzM7r0AxgdtU1M2x7EXNBwgGOI5EOAdN6mkw==
 
-"@influxdata/giraffe@^2.16.0":
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.16.0.tgz#90a436e3487cca0b501401a795b932d90ccee4bc"
-  integrity sha512-WgR9jpPQjsA2p9/MASAlu2Zj41rlitIZhlgrpBQNd7iGWLLQrUFAqWfjeCJ6pfQDgnAf82vB5Me8HNHd2aRcAA==
+"@influxdata/giraffe@^2.16.1":
+  version "2.16.1"
+  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.16.1.tgz#a8cfaaec8d4993437162f084d9489389bc771937"
+  integrity sha512-pGask5y9ypqJmAof/F+7CABHPGlszaM0K2LkqVfMhJOK7P25cjcWG7cKRXbB2+s8bHq1ZGoT7G9XD7iduszZYg==
   dependencies:
     merge-images "^2.0.0"
 


### PR DESCRIPTION
Closes #1124

removed 'enter' as the submit shortcut in the annotations form, thus allowing carriage returns to be entered into the textarea.

requires giraffe 2.16.1 for display of multi-line annotation tooltips
