### PR TITLE
fix: empty columns message

### DIFF
--- a/src/flows/pipes/Columns/view.tsx
+++ b/src/flows/pipes/Columns/view.tsx
@@ -66,8 +66,16 @@ const View: FC<PipeProp> = ({Context}) => {
     }))
   }
 
-  if (!Object.values(tableColumnKeys)) {
-    return <h1>No Columns To Show. Preview To See Results.</h1>
+  if (!Object.values(tableColumnKeys).length) {
+    return (
+      <Context>
+        <div className="columns-panel--grid">
+          <div className="panel-resizer--empty">
+            No Columns To Show. Preview To See Results.
+          </div>
+        </div>
+      </Context>
+    )
   }
 
   return (

--- a/src/flows/pipes/Columns/view.tsx
+++ b/src/flows/pipes/Columns/view.tsx
@@ -66,7 +66,7 @@ const View: FC<PipeProp> = ({Context}) => {
     }))
   }
 
-  if (!Object.values(tableColumnKeys).length) {
+  if (!Object.values(tableColumnKeys)?.length) {
     return (
       <Context>
         <div className="columns-panel--grid">


### PR DESCRIPTION
Closes #

<!-- Describe your proposed changes here. -->
Fixes issue where empty columns table did not show message that its empty, potentially confusing
<img width="1344" alt="Screen Shot 2021-07-19 at 4 30 49 PM" src="https://user-images.githubusercontent.com/29473622/126230239-42544b45-c597-4fc1-b5d2-96a8523b43c7.png">
