### PR TITLE
refactor: remove dead code from BucketOverlayForm

### DIFF
--- a/src/buckets/components/BucketOverlayForm.tsx
+++ b/src/buckets/components/BucketOverlayForm.tsx
@@ -1,13 +1,11 @@
 // Libraries
 import React, {PureComponent, ChangeEvent, FormEvent} from 'react'
-import moment from 'moment'
 
 // Components
 import {Form, Input, Button, Grid} from '@influxdata/clockface'
 import Retention from 'src/buckets/components/Retention'
 
 // Constants
-import {MIN_RETENTION_SECONDS} from 'src/buckets/constants'
 import {isSystemBucket} from 'src/buckets/constants/index'
 
 // Types
@@ -76,7 +74,6 @@ export default class BucketOverlayForm extends PureComponent<Props> {
               </Form.ValidationElement>
               <Form.Element
                 label="Delete Data"
-                errorMessage={this.ruleErrorMessage}
               >
                 <Retention
                   type={ruleType}
@@ -151,28 +148,10 @@ export default class BucketOverlayForm extends PureComponent<Props> {
     const {name} = this.props
     const nameHasErrors = this.handleNameValidation(name)
 
-    if (nameHasErrors || this.retentionIsTooShort) {
+    if (nameHasErrors) {
       return ComponentStatus.Disabled
     }
 
     return ComponentStatus.Default
-  }
-
-  private get retentionIsTooShort(): boolean {
-    const {retentionSeconds, ruleType} = this.props
-
-    return ruleType === 'expire' && retentionSeconds < MIN_RETENTION_SECONDS
-  }
-
-  private get ruleErrorMessage(): string {
-    if (this.retentionIsTooShort) {
-      const humanDuration = moment
-        .duration(MIN_RETENTION_SECONDS, 'seconds')
-        .humanize()
-
-      return `Retention period must be at least ${humanDuration}`
-    }
-
-    return ''
   }
 }

--- a/src/buckets/components/BucketOverlayForm.tsx
+++ b/src/buckets/components/BucketOverlayForm.tsx
@@ -72,9 +72,7 @@ export default class BucketOverlayForm extends PureComponent<Props> {
                   />
                 )}
               </Form.ValidationElement>
-              <Form.Element
-                label="Delete Data"
-              >
+              <Form.Element label="Delete Data">
                 <Retention
                   type={ruleType}
                   retentionSeconds={retentionSeconds}

--- a/src/buckets/constants/index.ts
+++ b/src/buckets/constants/index.ts
@@ -1,6 +1,5 @@
 import {startsWith} from 'lodash'
 
-
 export const isSystemBucket = (bucketName: string): boolean => {
   return startsWith(bucketName, '_')
 }

--- a/src/buckets/constants/index.ts
+++ b/src/buckets/constants/index.ts
@@ -1,6 +1,5 @@
 import {startsWith} from 'lodash'
 
-export const MIN_RETENTION_SECONDS = 3600
 
 export const isSystemBucket = (bucketName: string): boolean => {
   return startsWith(bucketName, '_')


### PR DESCRIPTION
Closes #2078

Just removing some unnecessary code I came across when trying to remove `moment` from our codebase. (#1844)
