### PR TITLE
fix: task run retry no longer opening editor

### DIFF
--- a/src/tasks/components/TaskRunsRow.tsx
+++ b/src/tasks/components/TaskRunsRow.tsx
@@ -9,7 +9,7 @@ import RunLogsOverlay from 'src/tasks/components/RunLogsList'
 import {FormattedDateTime} from 'src/utils/datetime/FormattedDateTime'
 
 // Actions
-import {getLogs, retryTask} from 'src/tasks/actions/thunks'
+import {getLogs, retryTask, getRuns} from 'src/tasks/actions/thunks'
 
 // Types
 import {ComponentSize, ComponentColor, Button} from '@influxdata/clockface'
@@ -87,18 +87,10 @@ class TaskRunsRow extends PureComponent<Props, State> {
   }
 
   private handleRetry = async () => {
-    const {
-      retryTask,
-      taskID,
-      run,
-      history,
-      match: {
-        params: {orgID},
-      },
-    } = this.props
+    const {retryTask, taskID, run, getRuns} = this.props
 
     await retryTask(taskID, run.id)
-    history.push(`/orgs/${orgID}/tasks/${taskID}/edit`)
+    await getRuns(taskID)
   }
 
   private get renderLogOverlay(): JSX.Element {
@@ -123,7 +115,7 @@ const mstp = (state: AppState) => {
   return {logs, timeZone}
 }
 
-const mdtp = {getLogs: getLogs, retryTask: retryTask}
+const mdtp = {getLogs: getLogs, retryTask: retryTask, getRuns}
 
 const connector = connect(mstp, mdtp)
 export default connector(withRouter(TaskRunsRow))


### PR DESCRIPTION
Closes #2067

Use of `getRuns(taskID)` is following approach from the function `handleRunTask()` in `TaskRunsCard.tsx`

## Before 
https://user-images.githubusercontent.com/39343323/126373776-cfa4bfe6-27ca-4914-b8d3-799c9580e532.mov

## After
https://user-images.githubusercontent.com/39343323/126374199-8977d8a5-c1e4-4889-a970-1a02064e69ad.mov
