### PR TITLE
fix: #1830 toggling time fix

### DIFF
--- a/src/dashboards/selectors/index.test.ts
+++ b/src/dashboards/selectors/index.test.ts
@@ -43,6 +43,7 @@ describe('Dashboards.Selector', () => {
     '04c6f3976f4b8002',
     '04c6f3976f4b8003',
     '04c6f3976f4b8004',
+    '04c6f3976f4b8005',
   ]
   const customTimeRangePST = {
     lower: '2020-05-05T10:00:00-07:00',
@@ -59,12 +60,18 @@ describe('Dashboards.Selector', () => {
     upper: '2020-05-05T11:00:00+00:00',
     type: 'custom',
   } as CustomTimeRange
+  const customTimeRangeUTC = {
+    lower: '2021-07-17T14:00:00.000Z',
+    upper: '2021-07-17T16:00:00.000Z',
+    type: 'custom',
+  } as CustomTimeRange
   const ranges: RangeState = {
     [dashboardIDs[0]]: pastFifteenMinTimeRange,
     [dashboardIDs[1]]: pastHourTimeRange,
     [dashboardIDs[2]]: customTimeRangePST,
     [dashboardIDs[3]]: customTimeRangeCET,
     [dashboardIDs[4]]: customTimeRangeGMT,
+    [dashboardIDs[5]]: customTimeRangeUTC,
   }
 
   it('should return the correct range when a matching dashboard ID is found', () => {
@@ -169,6 +176,33 @@ describe('Dashboards.Selector', () => {
     }
     // Offset for CET
     mocked(getTimezoneOffset).mockImplementation(() => -120)
+
+    expect(
+      untypedGetTimeRangeWithTimeZone({ranges, currentDashboard, app})
+    ).toEqual(expected)
+  })
+
+  it('should return the same timeRange when the time is already in UTC', () => {
+    const currentDashboard = {id: dashboardIDs[5]}
+
+    const app: AppPresentationState = {
+      ephemeral: {
+        inPresentationMode: false,
+        hasUpdatedTimeRangeInVEO: false,
+      },
+      persisted: {
+        autoRefresh: 0,
+        showTemplateControlBar: false,
+        navBarState: 'expanded',
+        timeZone: 'UTC' as TimeZone,
+        theme: 'dark',
+        versionInfo: {version: '', commit: ''},
+      },
+    }
+
+    const expected = customTimeRangeUTC
+
+    mocked(getTimezoneOffset).mockImplementation(() => 0)
 
     expect(
       untypedGetTimeRangeWithTimeZone({ranges, currentDashboard, app})

--- a/src/dashboards/selectors/index.ts
+++ b/src/dashboards/selectors/index.ts
@@ -18,6 +18,7 @@ import {getTimezoneOffset} from 'src/dashboards/utils/getTimezoneOffset'
 
 // Constants
 import {DEFAULT_TIME_RANGE} from 'src/shared/constants/timeRanges'
+import {timesNeedConverting} from 'src/shared/utils/dateTimeUtils'
 
 export const getTimeRange = (state: AppState): TimeRange => {
   const contextID = currentContext(state)
@@ -26,25 +27,6 @@ export const getTimeRange = (state: AppState): TimeRange => {
   }
 
   return state.ranges[contextID] || DEFAULT_TIME_RANGE
-}
-
-/**
- *  is the string a valid UTC time without any time zone information?
- *  ie:  "2021-07-17T14:00:00.000Z" is valid
- *  if it has any timezone offset, then it is not a valid UTC time string
- *
- * @param str
- */
-function isUtcTime(str) {
-  const regex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/
-  return regex.test(str)
-}
-
-/** is the time already in utc format?  if so it does not need converting. */
-const timesNeedConverting = newTimeRange => {
-  // if the time range is *already* utc, does not need converting.  check just the first part, as
-  // they will be formatted the same
-  return !isUtcTime(newTimeRange.lower)
 }
 
 /**

--- a/src/shared/utils/dateTimeUtils.ts
+++ b/src/shared/utils/dateTimeUtils.ts
@@ -1,0 +1,18 @@
+/**
+ *  is the string a valid UTC time without any time zone information?
+ *  ie:  "2021-07-17T14:00:00.000Z" is valid
+ *  if it has any timezone offset, then it is not a valid UTC time string
+ *
+ * @param formattedTimeStr
+ */
+function isUtcTime(formattedTimeStr) {
+  const regex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/
+  return regex.test(formattedTimeStr)
+}
+
+/** is the time already in utc format?  if so it does not need converting. */
+export const timesNeedConverting = newTimeRange => {
+  // if the time range is *already* utc, does not need converting.  check just the first part, as
+  // they will be formatted the same
+  return !isUtcTime(newTimeRange.lower)
+}


### PR DESCRIPTION
Closes #1830 
checks if the time string actually needs converting before converting it.

keeping conversion in if necessary for future timezone/flux work.
