### PR TITLE
feat: adds selector method to return the user's preferred time format for a view

### DIFF
--- a/src/annotations/components/AddAnnotationOverlay.tsx
+++ b/src/annotations/components/AddAnnotationOverlay.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC, useContext} from 'react'
-import {useSelector} from 'react-redux'
+import {connect, useSelector} from 'react-redux'
 
 // Components
 import {AnnotationForm} from 'src/annotations/components/annotationForm/AnnotationForm'
@@ -10,6 +10,8 @@ import {OverlayContext} from 'src/overlays/components/OverlayController'
 
 // Selectors
 import {getOverlayParams} from 'src/overlays/selectors'
+import {getTimeFormatForView} from 'src/views/selectors'
+import {AppState} from 'src/types'
 
 export const AddAnnotationOverlay: FC = () => {
   const {onClose} = useContext(OverlayContext)
@@ -19,7 +21,11 @@ export const AddAnnotationOverlay: FC = () => {
     endTime,
     range,
     eventPrefix,
+    cellID,
   } = useSelector(getOverlayParams)
+
+  const timeFormat =  useSelector((state: AppState) => getTimeFormatForView(state, cellID))
+
 
   const handleSubmit = (modifiedAnnotation): void => {
     createAnnotation(modifiedAnnotation)
@@ -37,6 +43,7 @@ export const AddAnnotationOverlay: FC = () => {
       startTime={startTime}
       endTime={endTime}
       eventPrefix={eventPrefix}
+      timeFormat= {timeFormat}
     />
   )
 }

--- a/src/annotations/components/AddAnnotationOverlay.tsx
+++ b/src/annotations/components/AddAnnotationOverlay.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC, useContext} from 'react'
-import {connect, useSelector} from 'react-redux'
+import {useSelector} from 'react-redux'
 
 // Components
 import {AnnotationForm} from 'src/annotations/components/annotationForm/AnnotationForm'
@@ -10,8 +10,6 @@ import {OverlayContext} from 'src/overlays/components/OverlayController'
 
 // Selectors
 import {getOverlayParams} from 'src/overlays/selectors'
-import {getTimeFormatForView} from 'src/views/selectors'
-import {AppState} from 'src/types'
 
 export const AddAnnotationOverlay: FC = () => {
   const {onClose} = useContext(OverlayContext)
@@ -21,11 +19,7 @@ export const AddAnnotationOverlay: FC = () => {
     endTime,
     range,
     eventPrefix,
-    cellID,
   } = useSelector(getOverlayParams)
-
-  const timeFormat =  useSelector((state: AppState) => getTimeFormatForView(state, cellID))
-
 
   const handleSubmit = (modifiedAnnotation): void => {
     createAnnotation(modifiedAnnotation)
@@ -43,7 +37,6 @@ export const AddAnnotationOverlay: FC = () => {
       startTime={startTime}
       endTime={endTime}
       eventPrefix={eventPrefix}
-      timeFormat= {timeFormat}
     />
   )
 }

--- a/src/views/selectors/index.test.ts
+++ b/src/views/selectors/index.test.ts
@@ -56,7 +56,7 @@ const MOCK_APP_STATE = ({
 
 describe('Views.Selectors', () => {
   describe('getTimeFormatForView', () => {
-    it("should return the default timeFormat for a cell when cell's format is the constant DEFAULT_TIME_FORMAT", () => {
+    it("should return the default time format for a cell when cell's format is the constant DEFAULT_TIME_FORMAT", () => {
       const timeFormat = getTimeFormatForView(
         MOCK_APP_STATE,
         'mock_cell_id_with_DEFAULT_TIME_FORMAT'

--- a/src/views/selectors/index.test.ts
+++ b/src/views/selectors/index.test.ts
@@ -35,8 +35,8 @@ const MOCK_APP_STATE = ({
           },
           dashboardID: 'mock_dashboard_id',
         },
-        'mock_cell_id_with_YYYY-MM-DD HH:mm:ss': {
-          id: 'mock_cell_id_with_YYYY-MM-DD HH:mm:ss',
+        'mock_cell_id_with_YYYY-MM-DD HH:mm:ss.sss': {
+          id: 'mock_cell_id_with_YYYY-MM-DD HH:mm:ss.sss',
           name: 'dummy cell',
           status: 'Done',
           cellID: 'mock_cell_id_with_YYYY-MM-DD HH:mm:ss.sss',
@@ -59,7 +59,7 @@ describe('Views.Selectors', () => {
     it("should return the default timeFormat for a cell when cell's format is the constant DEFAULT_TIME_FORMAT", () => {
       const timeFormat = getTimeFormatForView(
         MOCK_APP_STATE,
-        'mock_cell_id_with_NO_TIME_FORMAT'
+        'mock_cell_id_with_DEFAULT_TIME_FORMAT'
       )
       expect(timeFormat).toBe(DEFAULT_TIME_FORMAT)
     })
@@ -75,7 +75,7 @@ describe('Views.Selectors', () => {
     it("should return the correct time format for a cell when cell's format is YYYY-MM-DD HH:mm:ss.sss", () => {
       const timeFormat = getTimeFormatForView(
         MOCK_APP_STATE,
-        'mock_cell_id_with_NO_TIME_FORMAT'
+        'mock_cell_id_with_YYYY-MM-DD HH:mm:ss.sss'
       )
       expect(timeFormat).toBe('YYYY-MM-DD HH:mm:ss.sss')
     })

--- a/src/views/selectors/index.test.ts
+++ b/src/views/selectors/index.test.ts
@@ -1,0 +1,83 @@
+import {AppState} from 'src/types'
+import {DEFAULT_TIME_FORMAT} from 'src/shared/constants'
+import {getTimeFormatForView} from 'src/views/selectors/index'
+
+const MOCK_APP_STATE = ({
+  app: {
+    persisted: {
+      timeZone: 'UTC',
+    },
+  },
+  currentDashboard: {
+    id: '',
+  },
+  resources: {
+    views: {
+      status: 'Done',
+      byID: {
+        mock_cell_id_with_DEFAULT_TIME_FORMAT: {
+          id: 'mock_cell_id_with_DEFAULT_TIME_FORMAT',
+          name: 'dummy cell',
+          status: 'Done',
+          cellID: 'mock_cell_id_with_DEFAULT_TIME_FORMAT',
+          properties: {
+            timeFormat: DEFAULT_TIME_FORMAT,
+          },
+          dashboardID: 'mock_dashboard_id',
+        },
+        mock_cell_id_with_NO_TIME_FORMAT: {
+          id: 'mock_cell_id_with_NO_TIME_FORMAT',
+          name: 'dummy cell',
+          status: 'Done',
+          cellID: 'mock_cell_id_with_NO_TIME_FORMAT',
+          properties: {
+            timeFormat: '',
+          },
+          dashboardID: 'mock_dashboard_id',
+        },
+        'mock_cell_id_with_YYYY-MM-DD HH:mm:ss': {
+          id: 'mock_cell_id_with_YYYY-MM-DD HH:mm:ss',
+          name: 'dummy cell',
+          status: 'Done',
+          cellID: 'mock_cell_id_with_YYYY-MM-DD HH:mm:ss',
+          properties: {
+            timeFormat: '',
+          },
+          dashboardID: 'mock_dashboard_id',
+        },
+      },
+      allIDs: [
+        'mock_cell_id_with_DEFAULT_TIME_FORMAT',
+        'mock_cell_id_with_NO_TIME_FORMAT',
+      ],
+    },
+  },
+} as any) as AppState
+
+describe('Views.Selectors', () => {
+  describe('getTimeFormatForView', () => {
+    it("should return the default timeFormat for a cell when cell's format is the constant DEFAULT_TIME_FORMAT", () => {
+      const timeFormat = getTimeFormatForView(
+        MOCK_APP_STATE,
+        'mock_cell_id_with_NO_TIME_FORMAT'
+      )
+      expect(timeFormat).toBe(DEFAULT_TIME_FORMAT)
+    })
+
+    it("should return the default time format for a cell when cell's format is an empty string", () => {
+      const timeFormat = getTimeFormatForView(
+        MOCK_APP_STATE,
+        'mock_cell_id_with_NO_TIME_FORMAT'
+      )
+      expect(timeFormat).toBe(DEFAULT_TIME_FORMAT)
+    })
+
+    it("should return the correct time format for a cell when cell's format is YYYY-MM-DD HH:mm:ss", () => {
+      const timeFormat = getTimeFormatForView(
+        MOCK_APP_STATE,
+        'mock_cell_id_with_NO_TIME_FORMAT'
+      )
+      expect(timeFormat).toBe('YYYY-MM-DD HH:mm:ss')
+    })
+  })
+})

--- a/src/views/selectors/index.test.ts
+++ b/src/views/selectors/index.test.ts
@@ -39,9 +39,9 @@ const MOCK_APP_STATE = ({
           id: 'mock_cell_id_with_YYYY-MM-DD HH:mm:ss',
           name: 'dummy cell',
           status: 'Done',
-          cellID: 'mock_cell_id_with_YYYY-MM-DD HH:mm:ss',
+          cellID: 'mock_cell_id_with_YYYY-MM-DD HH:mm:ss.sss',
           properties: {
-            timeFormat: '',
+            timeFormat: 'YYYY-MM-DD HH:mm:ss.sss',
           },
           dashboardID: 'mock_dashboard_id',
         },
@@ -72,12 +72,12 @@ describe('Views.Selectors', () => {
       expect(timeFormat).toBe(DEFAULT_TIME_FORMAT)
     })
 
-    it("should return the correct time format for a cell when cell's format is YYYY-MM-DD HH:mm:ss", () => {
+    it("should return the correct time format for a cell when cell's format is YYYY-MM-DD HH:mm:ss.sss", () => {
       const timeFormat = getTimeFormatForView(
         MOCK_APP_STATE,
         'mock_cell_id_with_NO_TIME_FORMAT'
       )
-      expect(timeFormat).toBe('YYYY-MM-DD HH:mm:ss')
+      expect(timeFormat).toBe('YYYY-MM-DD HH:mm:ss.sss')
     })
   })
 })

--- a/src/views/selectors/index.test.ts
+++ b/src/views/selectors/index.test.ts
@@ -45,6 +45,21 @@ const MOCK_APP_STATE = ({
           },
           dashboardID: 'mock_dashboard_id',
         },
+        mock_cell_id_with_NO_PROPERTIES: {
+          id: 'mock_cell_id_with_NO_PROPERTIES',
+          name: 'dummy cell',
+          status: 'Done',
+          cellID: 'mock_cell_id_with_NO_PROPERTIES',
+          dashboardID: 'mock_dashboard_id',
+        },
+        mock_cell_id_with_EMPTY_PROPERTIES : {
+          id: 'mock_cell_id_with_EMPTY_PROPERTIES',
+          name: 'dummy cell',
+          status: 'Done',
+          cellID: 'mock_cell_id_with_EMPTY_PROPERTIES',
+          properties: {},
+          dashboardID: 'mock_dashboard_id',
+        },
       },
       allIDs: [
         'mock_cell_id_with_DEFAULT_TIME_FORMAT',
@@ -78,6 +93,22 @@ describe('Views.Selectors', () => {
         'mock_cell_id_with_YYYY-MM-DD HH:mm:ss.sss'
       )
       expect(timeFormat).toBe('YYYY-MM-DD HH:mm:ss.sss')
+    })
+
+    it("should return the default time format for a cell when cell's view.properties is absent", () => {
+      const timeFormat = getTimeFormatForView(
+        MOCK_APP_STATE,
+        'mock_cell_id_with_NO_PROPERTIES'
+      )
+      expect(timeFormat).toBe(DEFAULT_TIME_FORMAT)
+    })
+
+    it("should return the default time format for a cell when cell's view.properties is {} (empty, but not absent)", () => {
+      const timeFormat = getTimeFormatForView(
+        MOCK_APP_STATE,
+        'mock_cell_id_with_EMPTY_PROPERTIES'
+      )
+      expect(timeFormat).toBe(DEFAULT_TIME_FORMAT)
     })
   })
 })

--- a/src/views/selectors/index.test.ts
+++ b/src/views/selectors/index.test.ts
@@ -52,7 +52,7 @@ const MOCK_APP_STATE = ({
           cellID: 'mock_cell_id_with_NO_PROPERTIES',
           dashboardID: 'mock_dashboard_id',
         },
-        mock_cell_id_with_EMPTY_PROPERTIES : {
+        mock_cell_id_with_EMPTY_PROPERTIES: {
           id: 'mock_cell_id_with_EMPTY_PROPERTIES',
           name: 'dummy cell',
           status: 'Done',

--- a/src/views/selectors/index.ts
+++ b/src/views/selectors/index.ts
@@ -3,6 +3,7 @@ import {AppState, View, ResourceType, Dashboard} from 'src/types'
 
 // Selectors
 import {getByID} from 'src/resources/selectors'
+import {DEFAULT_TIME_FORMAT} from 'src/shared/constants'
 
 export const getViewsForDashboard = (
   state: AppState,
@@ -21,4 +22,22 @@ export const getViewsForDashboard = (
   )
 
   return views
+}
+
+export const getTimeFormatForView = (
+  state: AppState,
+  viewID: string
+): string => {
+  const view = getByID<View>(state, ResourceType.Views, viewID)
+
+  let timeFormat = ''
+  if ('timeFormat' in view.properties) {
+    timeFormat = view.properties.timeFormat
+  }
+
+  if (timeFormat === '') {
+    return DEFAULT_TIME_FORMAT
+  }
+
+  return timeFormat
 }

--- a/src/views/selectors/index.ts
+++ b/src/views/selectors/index.ts
@@ -30,7 +30,6 @@ export const getTimeFormatForView = (
 ): string => {
   const view = getByID<View>(state, ResourceType.Views, viewID)
 
-  let timeFormat = ''
   if ('timeFormat' in view.properties) {
     return view.properties.timeFormat
   }

--- a/src/views/selectors/index.ts
+++ b/src/views/selectors/index.ts
@@ -30,10 +30,14 @@ export const getTimeFormatForView = (
 ): string => {
   const view = getByID<View>(state, ResourceType.Views, viewID)
 
-  if (view.properties && 'timeFormat' in view.properties) {
-    if (view.properties.timeFormat !== '') {
-      return view.properties.timeFormat
-    }
+  // some types in the ViewProperties union do not have the timeFormat in view.properties (ex. GaugeViewProperties)
+  // hence typescript complains, and the following complicated if-statement.
+  if (
+    view.properties &&
+    'timeFormat' in view.properties &&
+    view.properties.timeFormat !== ''
+  ) {
+    return view.properties.timeFormat
   }
 
   return DEFAULT_TIME_FORMAT

--- a/src/views/selectors/index.ts
+++ b/src/views/selectors/index.ts
@@ -30,8 +30,10 @@ export const getTimeFormatForView = (
 ): string => {
   const view = getByID<View>(state, ResourceType.Views, viewID)
 
-  if ('timeFormat' in view.properties) {
-    return view.properties.timeFormat
+  if (view.properties && 'timeFormat' in view.properties) {
+    if (view.properties.timeFormat !== '') {
+      return view.properties.timeFormat
+    }
   }
 
   return DEFAULT_TIME_FORMAT


### PR DESCRIPTION
Closes #2122

Notes for the reviewer:

* the issue we made (#2122) asks for a method called `getTimeFormatFromCell`, but since we were putting that method in the `views/selector`, I thought we should name it as `getTimeFormatFromView`. Not sure what the hierarchy is, is `Cell` a `View`? i noticed that the `cellID` and the view's `id` were the same. 

Also since the `timeFormat` was in `resources.views.view.properties.timeFormat` 

Added the unit tests to test the function as well.  


