### PR TITLE
chore: remove code sample options from export to client library modal

### DIFF
--- a/src/writeData/components/ClientCodeCopyPage/index.tsx
+++ b/src/writeData/components/ClientCodeCopyPage/index.tsx
@@ -17,7 +17,6 @@ import {ResourceType} from 'src/types'
 import 'src/writeData/components/WriteDataDetailsView.scss'
 
 // Utils
-import WriteDataHelper from '../WriteDataHelper'
 import GetResources from 'src/resources/components/GetResources'
 
 const codeRenderer: Renderer<HTMLPreElement> = (props: any): any => {
@@ -40,7 +39,6 @@ const ClientCodeCopyPage: FC<Props> = ({contentID}) => {
           className="write-data--details-content markdown-format"
           data-testid="load-data-details-content"
         >
-          <WriteDataHelper collapsed={true} />
           {!!def.description && (
             <InstallPackageHelper
               text={def.description}


### PR DESCRIPTION
Closes #2076 

Now looks like this:

![image](https://user-images.githubusercontent.com/22055730/126801173-f3ea4b76-6c40-4158-88a0-05160fbe6501.png)
