### PR TITLE
feat: changed navigation to edit task to view task runs

### DIFF
--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -863,7 +863,7 @@ describe('DataExplorer', () => {
 
       both.forEach(type =>
         [true, false].forEach(withOffset => {
-          it(`can create ${type} task with${
+          it.only(`can create ${type} task with${
             withOffset ? '' : 'out'
           } offset`, () => {
             const time = type === 'every' ? timeEvery : timeCron
@@ -876,23 +876,18 @@ describe('DataExplorer', () => {
               .first()
               .trigger('mouseover')
               .then(() => {
-                cy.getByTestID('context-cog-runs')
-                  .click()
-                  .then(() => {
-                    cy.getByTestID('context-edit-task')
-                      .click()
-                      .then(() => {
-                        cy.getByTestID('task-form-schedule-input').should(
-                          'have.value',
-                          time
-                        )
-                        cy.getByTestID('task-form-offset-input').should(
-                          'have.value',
-                          withOffset ? offset : ''
-                        )
-                      })
-                  })
+                cy.getByTestID('context-cog-runs').click()
+                cy.getByTestID('context-edit-task').click()
               })
+
+            cy.getByTestID('task-form-schedule-input').should(
+              'have.value',
+              time
+            )
+            cy.getByTestID('task-form-offset-input').should(
+              'have.value',
+              withOffset ? offset : ''
+            )
           })
         })
       )

--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -863,7 +863,7 @@ describe('DataExplorer', () => {
 
       both.forEach(type =>
         [true, false].forEach(withOffset => {
-          it.only(`can create ${type} task with${
+          it(`can create ${type} task with${
             withOffset ? '' : 'out'
           } offset`, () => {
             const time = type === 'every' ? timeEvery : timeCron

--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -872,17 +872,27 @@ describe('DataExplorer', () => {
 
             visitTasks()
 
-            cy.getByTestID('task-card--name')
-              .should('exist')
-              .click()
-            cy.getByTestID('task-form-schedule-input').should(
-              'have.value',
-              time
-            )
-            cy.getByTestID('task-form-offset-input').should(
-              'have.value',
-              withOffset ? offset : ''
-            )
+            cy.getByTestID('task-card')
+              .first()
+              .trigger('mouseover')
+              .then(() => {
+                cy.getByTestID('context-cog-runs')
+                  .click()
+                  .then(() => {
+                    cy.getByTestID('context-edit-task')
+                      .click()
+                      .then(() => {
+                        cy.getByTestID('task-form-schedule-input').should(
+                          'have.value',
+                          time
+                        )
+                        cy.getByTestID('task-form-offset-input').should(
+                          'have.value',
+                          withOffset ? offset : ''
+                        )
+                      })
+                  })
+              })
           })
         })
       )

--- a/cypress/e2e/shared/tasks.test.ts
+++ b/cypress/e2e/shared/tasks.test.ts
@@ -126,13 +126,21 @@ http.post(url: "https://foo.bar/baz", data: bytes(v: "body"))`
       .contains('Scheduled to run 0 4 8-14 * *')
 
     cy.getByTestID('task-card')
-      .contains('Cron task test')
-      .click()
+      .first()
+      .trigger('mouseover')
       .then(() => {
-        cy.getByTestID('task-form-schedule-input').should(
-          'have.value',
-          '0 4 8-14 * *'
-        )
+        cy.getByTestID('context-cog-runs')
+          .click()
+          .then(() => {
+            cy.getByTestID('context-edit-task')
+              .click()
+              .then(() => {
+                cy.getByTestID('task-form-schedule-input').should(
+                  'have.value',
+                  '0 4 8-14 * *'
+                )
+              })
+          })
       })
   })
 
@@ -173,7 +181,6 @@ http.post(url: "https://foo.bar/baz", data: bytes(v: "body"))`
     cy.getByTestID('task-save-btn').click()
     cy.getByTestID('notification-success').should('exist')
   })
-
   describe('When tasks already exist', () => {
     beforeEach(() => {
       cy.get('@org').then(({id}: Organization) => {
@@ -254,16 +261,19 @@ http.post(url: "https://foo.bar/baz", data: bytes(v: "body"))`
     it('can clone a task and activate just the cloned one', () => {
       createTask('task1', 'buckets()')
 
-      cy.getByTestID('task-card').then(() => {
-        cy.get('.context-menu--container')
-          .eq(1)
-          .click()
-          .then(() => {
-            cy.getByTestID('context-menu-item')
-              .contains('Clone')
-              .click()
-          })
-      })
+      cy.getByTestID('task-card')
+        .eq(1)
+        .trigger('mouseover')
+        .then(() => {
+          cy.get('.context-menu--container')
+            .eq(1)
+            .click()
+            .then(() => {
+              cy.getByTestID('context-menu-item')
+                .contains('Clone')
+                .click()
+            })
+        })
 
       cy.getByTestID('task-card--slide-toggle')
         .eq(0)
@@ -308,38 +318,50 @@ http.post(url: "https://foo.bar/baz", data: bytes(v: "body"))`
       cy.getByTestID('task-card--name')
         .eq(1)
         .contains('🦄ask (clone 1)')
-        .click()
+
+      cy.getByTestID('task-card')
+        .eq(1)
+        .trigger('mouseover')
         .then(() => {
-          // focused() waits for monoco editor to get input focus
-          cy.focused()
-          cy.getByTestID('flux-editor')
-            .should('be.visible')
-            .contains('option task = {')
+          cy.getByTestID('context-cog-runs')
+            .eq(1)
+            .click()
             .then(() => {
-              cy.getByTestID('task-form-name')
-                .should('have.value', '🦄ask (clone 1)')
+              cy.getByTestID('context-edit-task')
+                .eq(1)
+                .click()
                 .then(() => {
-                  cy.getByTestID('task-form-name')
+                  // focused() waits for monoco editor to get input focus
+                  cy.focused()
+                  cy.getByTestID('flux-editor')
                     .should('be.visible')
-                    .clear()
-                    .type('Copy task test')
+                    .contains('option task = {')
                     .then(() => {
-                      cy.getByTestID('task-form-schedule-input')
-                        .should('have.value', '24h')
-                        .clear()
-                        .type('12h')
-                        .should('have.value', '12h')
-                      cy.getByTestID('task-form-offset-input')
-                        .should('have.value', '20m')
-                        .clear()
-                        .type('10m')
-                        .should('have.value', '10m')
-                      cy.getByTestID('task-save-btn').click()
+                      cy.getByTestID('task-form-name')
+                        .should('have.value', '🦄ask (clone 1)')
+                        .then(() => {
+                          cy.getByTestID('task-form-name')
+                            .should('be.visible')
+                            .clear()
+                            .type('Copy task test')
+                            .then(() => {
+                              cy.getByTestID('task-form-schedule-input')
+                                .should('have.value', '24h')
+                                .clear()
+                                .type('12h')
+                                .should('have.value', '12h')
+                              cy.getByTestID('task-form-offset-input')
+                                .should('have.value', '20m')
+                                .clear()
+                                .type('10m')
+                                .should('have.value', '10m')
+                              cy.getByTestID('task-save-btn').click()
+                            })
+                        })
                     })
                 })
             })
         })
-
       // assert changed task name
       cy.getByTestID('task-card--name').contains('Copy task test')
     })
@@ -472,13 +494,24 @@ http.post(url: "https://foo.bar/baz", data: bytes(v: "body"))`
         .should('have.length', 1)
         .and('contain', taskName)
 
-      cy.getByTestID('task-card--name')
-        .contains(taskName)
-        .click()
-      // verify that the previously input data exists
-      cy.getByInputValue(taskName)
-      cy.getByInputValue(interval)
-      cy.getByInputValue(offset)
+      cy.getByTestID('task-card--name').contains(taskName)
+
+      cy.getByTestID('task-card')
+        .trigger('mouseover')
+        .then(() => {
+          cy.getByTestID('context-cog-runs')
+            .click()
+            .then(() => {
+              cy.getByTestID('context-edit-task')
+                .click()
+                .then(() => {
+                  // verify that the previously input data exists
+                  cy.getByInputValue(taskName)
+                  cy.getByInputValue(interval)
+                  cy.getByInputValue(offset)
+                })
+            })
+        })
     })
 
     it('can update a task', () => {
@@ -528,6 +561,9 @@ http.post(url: "https://foo.bar/baz", data: bytes(v: "body"))`
     // https://github.com/influxdata/influxdb/issues/15552
     const firstTask = 'First_Task'
     const secondTask = 'Second_Task'
+
+    const firstIndex = 0
+    const secondIndex = 1
     beforeEach(() => {
       cy.get('@org').then(({id}: Organization) => {
         cy.get<string>('@token').then(token => {
@@ -546,53 +582,142 @@ http.post(url: "https://foo.bar/baz", data: bytes(v: "body"))`
 
     it('when navigating using the navbar', () => {
       // click on the second task
-      cy.getByTestID('task-card--name')
-        .contains(secondTask)
-        .click()
-      // verify that it is the correct data
-      cy.getByInputValue(secondTask)
+      cy.getByTestID('task-card--name').contains(secondTask)
+
+      cy.getByTestID('task-card')
+        .eq(secondIndex)
+        .trigger('mouseover')
+        .then(() => {
+          cy.getByTestID('context-cog-runs')
+            .eq(secondIndex)
+            .click()
+            .then(() => {
+              cy.getByTestID('context-edit-task')
+                .eq(secondIndex)
+                .click()
+                .then(() => {
+                  // verify that it is the correct data
+                  cy.getByInputValue(secondTask)
+                })
+            })
+        })
 
       cy.get('.cf-tree-nav--item__active').within(() => {
         // Get the element that has a click handler within the nav item
         cy.get('.cf-tree-nav--item-block').click()
       })
       // navigate back to the first one to verify that the name is correct
-      cy.getByTestID('task-card--name')
-        .contains(firstTask)
-        .click()
-      cy.getByInputValue(firstTask)
+      cy.getByTestID('task-card--name').contains(firstTask)
+
+      cy.getByTestID('task-card')
+        .eq(firstIndex)
+        .trigger('mouseover')
+        .then(() => {
+          cy.getByTestID('context-cog-runs')
+            .eq(firstIndex)
+            .click()
+            .then(() => {
+              cy.getByTestID('context-edit-task')
+                .eq(firstIndex)
+                .click()
+                .then(() => {
+                  // verify that it is the correct data
+                  cy.getByInputValue(firstTask)
+                })
+            })
+        })
     })
 
     it('when navigating using the cancel button', () => {
       // click on the second task
-      cy.getByTestID('task-card--name')
-        .contains(secondTask)
-        .click()
-      // verify that it is the correct data
-      cy.getByInputValue(secondTask)
-      cy.getByTestID('task-cancel-btn').click()
+      cy.getByTestID('task-card--name').contains(secondTask)
+
+      cy.getByTestID('task-card')
+        .eq(secondIndex)
+        .trigger('mouseover')
+        .then(() => {
+          cy.getByTestID('context-cog-runs')
+            .eq(secondIndex)
+            .click()
+            .then(() => {
+              cy.getByTestID('context-edit-task')
+                .eq(secondIndex)
+                .click()
+                .then(() => {
+                  // verify that it is the correct data
+                  cy.getByInputValue(secondTask)
+                  cy.getByTestID('task-cancel-btn').click()
+                })
+            })
+        })
+
       // navigate back to the first task again
-      cy.getByTestID('task-card--name')
-        .contains(firstTask)
-        .click()
-      cy.getByInputValue(firstTask)
-      cy.getByTestID('task-cancel-btn').click()
+      cy.getByTestID('task-card--name').contains(firstTask)
+
+      cy.getByTestID('task-card')
+        .eq(firstIndex)
+        .trigger('mouseover')
+        .then(() => {
+          cy.getByTestID('context-cog-runs')
+            .eq(firstIndex)
+            .click()
+            .then(() => {
+              cy.getByTestID('context-edit-task')
+                .eq(firstIndex)
+                .click()
+                .then(() => {
+                  // verify that it is the correct data
+                  cy.getByInputValue(firstTask)
+                  cy.getByTestID('task-cancel-btn').click()
+                })
+            })
+        })
     })
 
     it('when navigating using the save button', () => {
       // click on the second task
-      cy.getByTestID('task-card--name')
-        .contains(secondTask)
-        .click()
-      // verify that it is the correct data
-      cy.getByInputValue(secondTask)
-      cy.getByTestID('task-save-btn').click()
+      cy.getByTestID('task-card--name').contains(secondTask)
+
+      cy.getByTestID('task-card')
+        .eq(secondIndex)
+        .trigger('mouseover')
+        .then(() => {
+          cy.getByTestID('context-cog-runs')
+            .eq(secondIndex)
+            .click()
+            .then(() => {
+              cy.getByTestID('context-edit-task')
+                .eq(secondIndex)
+                .click()
+                .then(() => {
+                  // verify that it is the correct data
+                  cy.getByInputValue(secondTask)
+                  cy.getByTestID('task-save-btn').click()
+                })
+            })
+        })
+
       // navigate back to the first task again
-      cy.getByTestID('task-card--name')
-        .contains(firstTask)
-        .click()
-      cy.getByInputValue(firstTask)
-      cy.getByTestID('task-save-btn').click()
+      cy.getByTestID('task-card--name').contains(firstTask)
+
+      cy.getByTestID('task-card')
+        .eq(firstIndex)
+        .trigger('mouseover')
+        .then(() => {
+          cy.getByTestID('context-cog-runs')
+            .eq(firstIndex)
+            .click()
+            .then(() => {
+              cy.getByTestID('context-edit-task')
+                .eq(firstIndex)
+                .click()
+                .then(() => {
+                  // verify that it is the correct data
+                  cy.getByInputValue(firstTask)
+                  cy.getByTestID('task-save-btn').click()
+                })
+            })
+        })
     })
   })
 
@@ -649,7 +774,9 @@ http.post(url: "https://foo.bar/baz", data: bytes(v: "body"))`
         .click()
 
       // Navigate away from current page back to Tasks List page
-      cy.getByTestID('task-cancel-btn').click()
+      cy.get('.bread-crumb-title')
+        .first()
+        .click()
       cy.getByTestID('search-widget').should('have.value', name)
 
       // Validate that the list has correct search results

--- a/cypress/e2e/shared/tasks.test.ts
+++ b/cypress/e2e/shared/tasks.test.ts
@@ -1,5 +1,12 @@
 import {Organization, Bucket} from '../../../src/types'
 
+// Chains of actions that involve hovering like below
+// cy.getByTestID('task-card')
+//      .trigger('mouseover')
+//      .then(()
+// will pass without this. However, the chain of actions
+// implemented here replicates what would realistically occur.
+
 describe('Tasks', () => {
   beforeEach(() => {
     cy.flush()
@@ -108,15 +115,13 @@ http.post(url: "https://foo.bar/baz", data: bytes(v: "body"))`
     cy.getByTestID('task-form-name')
       .click()
       .type('Cron task test')
-      .then(() => {
-        cy.getByTestID('task-card-cron-btn').click()
-        cy.getByTestID('task-form-schedule-input')
-          .click()
-          .type('0 4 8-14 * *')
-        cy.getByTestID('task-form-offset-input')
-          .click()
-          .type('10m')
-      })
+    cy.getByTestID('task-card-cron-btn').click()
+    cy.getByTestID('task-form-schedule-input')
+      .click()
+      .type('0 4 8-14 * *')
+    cy.getByTestID('task-form-offset-input')
+      .click()
+      .type('10m')
 
     cy.getByTestID('task-save-btn').click()
 
@@ -126,22 +131,16 @@ http.post(url: "https://foo.bar/baz", data: bytes(v: "body"))`
       .contains('Scheduled to run 0 4 8-14 * *')
 
     cy.getByTestID('task-card')
-      .first()
       .trigger('mouseover')
       .then(() => {
-        cy.getByTestID('context-cog-runs')
-          .click()
-          .then(() => {
-            cy.getByTestID('context-edit-task')
-              .click()
-              .then(() => {
-                cy.getByTestID('task-form-schedule-input').should(
-                  'have.value',
-                  '0 4 8-14 * *'
-                )
-              })
-          })
+        cy.getByTestID('context-cog-runs').click()
+        cy.getByTestID('context-edit-task').click()
       })
+
+    cy.getByTestID('task-form-schedule-input').should(
+      'have.value',
+      '0 4 8-14 * *'
+    )
   })
 
   it('can create a task with an option parameter', () => {
@@ -181,6 +180,7 @@ http.post(url: "https://foo.bar/baz", data: bytes(v: "body"))`
     cy.getByTestID('task-save-btn').click()
     cy.getByTestID('notification-success').should('exist')
   })
+
   describe('When tasks already exist', () => {
     beforeEach(() => {
       cy.get('@org').then(({id}: Organization) => {
@@ -268,48 +268,36 @@ http.post(url: "https://foo.bar/baz", data: bytes(v: "body"))`
           cy.get('.context-menu--container')
             .eq(1)
             .click()
-            .then(() => {
-              cy.getByTestID('context-menu-item')
-                .contains('Clone')
-                .click()
-            })
+          cy.getByTestID('context-menu-item')
+            .contains('Clone')
+            .click()
         })
 
       cy.getByTestID('task-card--slide-toggle')
         .eq(0)
         .should('have.class', 'active')
-        .then(() => {
-          cy.getByTestID('task-card--slide-toggle')
-            .eq(0)
-            .click()
-            .then(() => {
-              cy.getByTestID('task-card--slide-toggle')
-                .eq(0)
-                .should('not.have.class', 'active')
-              cy.getByTestID('task-card--slide-toggle')
-                .eq(1)
-                .should('have.class', 'active')
-            })
-        })
+      cy.getByTestID('task-card--slide-toggle')
+        .eq(0)
+        .click()
+      cy.getByTestID('task-card--slide-toggle')
+        .eq(0)
+        .should('not.have.class', 'active')
+      cy.getByTestID('task-card--slide-toggle')
+        .eq(1)
+        .should('have.class', 'active')
     })
 
     it('can clone a task and edit it', () => {
       // clone a task
       cy.getByTestID('task-card')
-        .first()
         .trigger('mouseover')
         .then(() => {
           cy.get('.context-menu--container')
             .eq(1)
-            .within(() => {
-              cy.getByTestID('context-menu')
-                .click()
-                .then(() => {
-                  cy.getByTestID('context-menu-item')
-                    .contains('Clone')
-                    .click()
-                })
-            })
+            .click()
+          cy.getByTestID('context-menu-item')
+            .contains('Clone')
+            .click()
         })
 
       cy.getByTestID('task-card').should('have.length', 2)
@@ -326,42 +314,37 @@ http.post(url: "https://foo.bar/baz", data: bytes(v: "body"))`
           cy.getByTestID('context-cog-runs')
             .eq(1)
             .click()
-            .then(() => {
-              cy.getByTestID('context-edit-task')
-                .eq(1)
-                .click()
-                .then(() => {
-                  // focused() waits for monoco editor to get input focus
-                  cy.focused()
-                  cy.getByTestID('flux-editor')
-                    .should('be.visible')
-                    .contains('option task = {')
-                    .then(() => {
-                      cy.getByTestID('task-form-name')
-                        .should('have.value', '🦄ask (clone 1)')
-                        .then(() => {
-                          cy.getByTestID('task-form-name')
-                            .should('be.visible')
-                            .clear()
-                            .type('Copy task test')
-                            .then(() => {
-                              cy.getByTestID('task-form-schedule-input')
-                                .should('have.value', '24h')
-                                .clear()
-                                .type('12h')
-                                .should('have.value', '12h')
-                              cy.getByTestID('task-form-offset-input')
-                                .should('have.value', '20m')
-                                .clear()
-                                .type('10m')
-                                .should('have.value', '10m')
-                              cy.getByTestID('task-save-btn').click()
-                            })
-                        })
-                    })
-                })
-            })
+          cy.getByTestID('context-edit-task')
+            .eq(1)
+            .click()
         })
+
+      // focused() waits for monoco editor to get input focus
+      cy.focused()
+      cy.getByTestID('flux-editor')
+        .should('be.visible')
+        .contains('option task = {')
+
+      cy.getByTestID('task-form-name').should('have.value', '🦄ask (clone 1)')
+      cy.getByTestID('task-form-name')
+        .clear()
+        .type('Copy task test')
+      cy.getByTestID('task-form-name').should('have.value', 'Copy task test')
+
+      cy.getByTestID('task-form-schedule-input').should('have.value', '24h')
+      cy.getByTestID('task-form-schedule-input')
+        .clear()
+        .type('12h')
+      cy.getByTestID('task-form-schedule-input').should('have.value', '12h')
+
+      cy.getByTestID('task-form-offset-input').should('have.value', '20m')
+      cy.getByTestID('task-form-offset-input')
+        .clear()
+        .type('10m')
+      cy.getByTestID('task-form-offset-input').should('have.value', '10m')
+
+      cy.getByTestID('task-save-btn').click()
+
       // assert changed task name
       cy.getByTestID('task-card--name').contains('Copy task test')
     })
@@ -499,19 +482,13 @@ http.post(url: "https://foo.bar/baz", data: bytes(v: "body"))`
       cy.getByTestID('task-card')
         .trigger('mouseover')
         .then(() => {
-          cy.getByTestID('context-cog-runs')
-            .click()
-            .then(() => {
-              cy.getByTestID('context-edit-task')
-                .click()
-                .then(() => {
-                  // verify that the previously input data exists
-                  cy.getByInputValue(taskName)
-                  cy.getByInputValue(interval)
-                  cy.getByInputValue(offset)
-                })
-            })
+          cy.getByTestID('context-cog-runs').click()
+          cy.getByTestID('context-edit-task').click()
         })
+      // verify that the previously input data exists
+      cy.getByInputValue(taskName)
+      cy.getByInputValue(interval)
+      cy.getByInputValue(offset)
     })
 
     it('can update a task', () => {
@@ -591,16 +568,12 @@ http.post(url: "https://foo.bar/baz", data: bytes(v: "body"))`
           cy.getByTestID('context-cog-runs')
             .eq(secondIndex)
             .click()
-            .then(() => {
-              cy.getByTestID('context-edit-task')
-                .eq(secondIndex)
-                .click()
-                .then(() => {
-                  // verify that it is the correct data
-                  cy.getByInputValue(secondTask)
-                })
-            })
+          cy.getByTestID('context-edit-task')
+            .eq(secondIndex)
+            .click()
         })
+      // verify that it is the correct data
+      cy.getByInputValue(secondTask)
 
       cy.get('.cf-tree-nav--item__active').within(() => {
         // Get the element that has a click handler within the nav item
@@ -616,16 +589,12 @@ http.post(url: "https://foo.bar/baz", data: bytes(v: "body"))`
           cy.getByTestID('context-cog-runs')
             .eq(firstIndex)
             .click()
-            .then(() => {
-              cy.getByTestID('context-edit-task')
-                .eq(firstIndex)
-                .click()
-                .then(() => {
-                  // verify that it is the correct data
-                  cy.getByInputValue(firstTask)
-                })
-            })
+          cy.getByTestID('context-edit-task')
+            .eq(firstIndex)
+            .click()
         })
+      // verify that it is the correct data
+      cy.getByInputValue(firstTask)
     })
 
     it('when navigating using the cancel button', () => {
@@ -639,17 +608,14 @@ http.post(url: "https://foo.bar/baz", data: bytes(v: "body"))`
           cy.getByTestID('context-cog-runs')
             .eq(secondIndex)
             .click()
-            .then(() => {
-              cy.getByTestID('context-edit-task')
-                .eq(secondIndex)
-                .click()
-                .then(() => {
-                  // verify that it is the correct data
-                  cy.getByInputValue(secondTask)
-                  cy.getByTestID('task-cancel-btn').click()
-                })
-            })
+          cy.getByTestID('context-edit-task')
+            .eq(secondIndex)
+            .click()
         })
+
+      // verify that it is the correct data
+      cy.getByInputValue(secondTask)
+      cy.getByTestID('task-cancel-btn').click()
 
       // navigate back to the first task again
       cy.getByTestID('task-card--name').contains(firstTask)
@@ -661,17 +627,13 @@ http.post(url: "https://foo.bar/baz", data: bytes(v: "body"))`
           cy.getByTestID('context-cog-runs')
             .eq(firstIndex)
             .click()
-            .then(() => {
-              cy.getByTestID('context-edit-task')
-                .eq(firstIndex)
-                .click()
-                .then(() => {
-                  // verify that it is the correct data
-                  cy.getByInputValue(firstTask)
-                  cy.getByTestID('task-cancel-btn').click()
-                })
-            })
+          cy.getByTestID('context-edit-task')
+            .eq(firstIndex)
+            .click()
         })
+      // verify that it is the correct data
+      cy.getByInputValue(firstTask)
+      cy.getByTestID('task-cancel-btn').click()
     })
 
     it('when navigating using the save button', () => {
@@ -685,17 +647,13 @@ http.post(url: "https://foo.bar/baz", data: bytes(v: "body"))`
           cy.getByTestID('context-cog-runs')
             .eq(secondIndex)
             .click()
-            .then(() => {
-              cy.getByTestID('context-edit-task')
-                .eq(secondIndex)
-                .click()
-                .then(() => {
-                  // verify that it is the correct data
-                  cy.getByInputValue(secondTask)
-                  cy.getByTestID('task-save-btn').click()
-                })
-            })
+          cy.getByTestID('context-edit-task')
+            .eq(secondIndex)
+            .click()
         })
+      // verify that it is the correct data
+      cy.getByInputValue(secondTask)
+      cy.getByTestID('task-save-btn').click()
 
       // navigate back to the first task again
       cy.getByTestID('task-card--name').contains(firstTask)
@@ -707,17 +665,13 @@ http.post(url: "https://foo.bar/baz", data: bytes(v: "body"))`
           cy.getByTestID('context-cog-runs')
             .eq(firstIndex)
             .click()
-            .then(() => {
-              cy.getByTestID('context-edit-task')
-                .eq(firstIndex)
-                .click()
-                .then(() => {
-                  // verify that it is the correct data
-                  cy.getByInputValue(firstTask)
-                  cy.getByTestID('task-save-btn').click()
-                })
-            })
+          cy.getByTestID('context-edit-task')
+            .eq(firstIndex)
+            .click()
         })
+      // verify that it is the correct data
+      cy.getByInputValue(firstTask)
+      cy.getByTestID('task-save-btn').click()
     })
   })
 

--- a/src/tasks/components/TaskCard.tsx
+++ b/src/tasks/components/TaskCard.tsx
@@ -111,8 +111,8 @@ export class TaskCard extends PureComponent<
         <Context.Menu icon={IconFont.CogThick} testID="context-cog-runs">
           <Context.Item label="Export" action={this.handleExport} />
           <Context.Item
-            label="View Task Runs"
-            action={this.handleViewRuns}
+            label="Edit Run"
+            action={this.handleEditRun}
             testID="context-view-task-runs"
           />
           <Context.Item
@@ -145,15 +145,13 @@ export class TaskCard extends PureComponent<
 
   private handleNameClick = (event: MouseEvent) => {
     const {
+      history,
+      task,
       match: {
         params: {orgID},
       },
-      history,
-      task,
-      setCurrentTasksPage,
     } = this.props
-    const url = `/orgs/${orgID}/tasks/${task.id}/edit`
-    setCurrentTasksPage(TaskPage.TasksPage)
+    const url = `/orgs/${orgID}/tasks/${task.id}/runs`
 
     if (event.metaKey) {
       window.open(url, '_blank')
@@ -178,15 +176,16 @@ export class TaskCard extends PureComponent<
     }
   }
 
-  private handleViewRuns = () => {
+  private handleEditRun = () => {
     const {
-      history,
-      task,
       match: {
         params: {orgID},
       },
+      history,
+      task,
     } = this.props
-    history.push(`/orgs/${orgID}/tasks/${task.id}/runs`)
+
+    history.push(`/orgs/${orgID}/tasks/${task.id}/edit`)
   }
 
   private handleRenameTask = (name: string) => {

--- a/src/tasks/components/TaskCard.tsx
+++ b/src/tasks/components/TaskCard.tsx
@@ -113,7 +113,7 @@ export class TaskCard extends PureComponent<
           <Context.Item
             label="Edit Task"
             action={this.handleEditTask}
-            testID="context-view-task-runs"
+            testID="context-edit-task"
           />
           <Context.Item
             label="Run Task"
@@ -154,7 +154,7 @@ export class TaskCard extends PureComponent<
     const url = `/orgs/${orgID}/tasks/${task.id}/runs`
 
     if (event.metaKey) {
-      window.open(url, '_blank')
+      window.open(url, '_blank', 'noopener')
     } else {
       history.push(url)
     }

--- a/src/tasks/components/TaskCard.tsx
+++ b/src/tasks/components/TaskCard.tsx
@@ -21,7 +21,7 @@ import {CopyResourceID} from 'src/shared/components/CopyResourceID'
 
 // Actions
 import {addTaskLabel, deleteTaskLabel} from 'src/tasks/actions/thunks'
-import {TaskPage, setCurrentTasksPage} from 'src/tasks/actions/creators'
+import {setCurrentTasksPage} from 'src/tasks/actions/creators'
 
 // Types
 import {ComponentColor} from '@influxdata/clockface'

--- a/src/tasks/components/TaskCard.tsx
+++ b/src/tasks/components/TaskCard.tsx
@@ -111,8 +111,8 @@ export class TaskCard extends PureComponent<
         <Context.Menu icon={IconFont.CogThick} testID="context-cog-runs">
           <Context.Item label="Export" action={this.handleExport} />
           <Context.Item
-            label="Edit Run"
-            action={this.handleEditRun}
+            label="Edit Task"
+            action={this.handleEditTask}
             testID="context-view-task-runs"
           />
           <Context.Item
@@ -176,7 +176,7 @@ export class TaskCard extends PureComponent<
     }
   }
 
-  private handleEditRun = () => {
+  private handleEditTask = () => {
     const {
       match: {
         params: {orgID},


### PR DESCRIPTION
Closes #2128

After clicking the task name, user is navigated to the task runs page now instead of the edit task page. `View task runs` from gearbox list also replaced with `Edit run`, which opens up the edit window.

## Before
https://user-images.githubusercontent.com/39343323/127032271-8fcb2548-d332-4095-a0a9-16525e4f00fb.mov

## After
https://user-images.githubusercontent.com/39343323/127031583-baad9376-a500-42f7-8847-7240f0b99c39.mov
