### PR TITLE
fix: force timeFormat to be DEFAULT_TIME_FORMAT when it is an empty string

### DIFF
--- a/src/visualization/utils/getFormatter.test.ts
+++ b/src/visualization/utils/getFormatter.test.ts
@@ -1,0 +1,113 @@
+import {getFormatter} from './getFormatter'
+import {DEFAULT_TIME_FORMAT} from '../../shared/constants'
+import {Base, TimeZone} from '../../types'
+
+// July 4th, 1983, 20:00:00 UTC
+const timestamp = 426196800000
+
+describe('getFormatter', () => {
+  it("should format correctly for base 10 and 'number' columntype", function() {
+    const formatterOptions = {
+      prefix: 'prefix ',
+      suffix: ' suffix',
+      base: '10' as Base,
+      format: true,
+    }
+
+    const formatter = getFormatter('number', formatterOptions)
+
+    const formattedValue = formatter(100000)
+
+    expect(formattedValue).toBe('prefix 100k suffix')
+  })
+
+  it("should format correctly for base '' 'number' columntype", function() {
+    const formatterOptions = {
+      prefix: 'prefix ',
+      suffix: ' suffix',
+      base: '' as Base,
+    }
+
+    const formatter = getFormatter('number', formatterOptions)
+
+    const formattedValue = formatter(100000)
+
+    expect(formattedValue).toBe('prefix 100k suffix')
+  })
+
+  it("should format correctly for base 2 'number' columntype", function() {
+    const formatterOptions = {
+      prefix: 'prefix ',
+      suffix: ' suffix',
+      base: '2' as Base,
+      format: false,
+    }
+
+    const formatter = getFormatter('number', formatterOptions)
+
+    const formattedValue = formatter(100000)
+
+    expect(formattedValue).toBe('prefix 100000 suffix')
+  })
+
+  // time column type
+  it('should format correctly for columnType = time, timeFormat = DEFAULT_TIME_FORMAT and timeZone = UTC ', () => {
+    const formatterOptions = {
+      timeZone: 'UTC' as TimeZone,
+      timeFormat: DEFAULT_TIME_FORMAT,
+    }
+
+    const formatter = getFormatter('time', formatterOptions)
+
+    const date = new Date(timestamp)
+
+    const formattedTime = formatter(date)
+
+    expect(formattedTime).toBe('1983-07-04 20:00:00')
+  })
+
+  it('should format correctly for columnType = time , timeFormat = YYYY-MM-DD hh:mm:ss a ZZ and timeZone = UTC', () => {
+    const formatterOptions = {
+      timeZone: 'UTC' as TimeZone,
+      timeFormat: 'YYYY-MM-DD hh:mm:ss a ZZ',
+    }
+
+    const formatter = getFormatter('time', formatterOptions)
+
+    const date = new Date(timestamp)
+
+    const formattedTime = formatter(date)
+
+    expect(formattedTime).toBe('1983-07-04  8:00:00 PM UTC')
+  })
+
+  it('should format correctly for columnType = time , timeFormat = YYYY/MM/DD HH:mm:ss and timeZone = UTC', () => {
+    const formatterOptions = {
+      timeZone: 'UTC' as TimeZone,
+      timeFormat: 'YYYY/MM/DD HH:mm:ss',
+    }
+
+    const formatter = getFormatter('time', formatterOptions)
+
+    const date = new Date(timestamp)
+
+    const formattedTime = formatter(date)
+
+    expect(formattedTime).toBe('1983/07/04 20:00:00')
+  })
+
+  it('should format correctly for columnType = time , timeFormat = YYYY/MM/DD HH:mm:ss and timeZone = Local', () => {
+    const formatterOptions = {
+      timeZone: 'Local' as TimeZone,
+      timeFormat: 'YYYY/MM/DD HH:mm:ss',
+    }
+
+    const formatter = getFormatter('time', formatterOptions)
+
+    const date = new Date(timestamp)
+
+    const formattedTime = formatter(date)
+
+    expect(formattedTime).toBe('1983/07/04 13:00:00')
+  })
+})

--- a/src/visualization/utils/getFormatter.test.ts
+++ b/src/visualization/utils/getFormatter.test.ts
@@ -126,7 +126,8 @@ describe('getFormatter', () => {
     expect(formattedTime).toBe('1983/07/04 20:00:00')
   })
 
-  it('should format correctly for columnType = time , timeFormat = YYYY/MM/DD HH:mm:ss and timeZone = Local', () => {
+  // we will have to skip this test because our CI pipeline is always in UTC
+  it.skip('should format correctly for columnType = time , timeFormat = YYYY/MM/DD HH:mm:ss and timeZone = Local', () => {
     const formatterOptions = {
       timeZone: 'Local' as TimeZone,
       timeFormat: 'YYYY/MM/DD HH:mm:ss',

--- a/src/visualization/utils/getFormatter.test.ts
+++ b/src/visualization/utils/getFormatter.test.ts
@@ -66,6 +66,36 @@ describe('getFormatter', () => {
     expect(formattedTime).toBe('1983-07-04 20:00:00')
   })
 
+  it("should format correctly for columnType = time, timeFormat = '' (empty string) and timeZone = UTC ", () => {
+    const formatterOptions = {
+      timeZone: 'UTC' as TimeZone,
+      timeFormat: '',
+    }
+
+    const formatter = getFormatter('time', formatterOptions)
+
+    const date = new Date(timestamp)
+
+    const formattedTime = formatter(date)
+
+    expect(formattedTime).toBe('1983-07-04 20:00:00')
+  })
+
+  it('should format correctly for columnType = time, timeFormat = undefined and timeZone = UTC ', () => {
+    const formatterOptions = {
+      timeZone: 'UTC' as TimeZone,
+      timeFormat: undefined,
+    }
+
+    const formatter = getFormatter('time', formatterOptions)
+
+    const date = new Date(timestamp)
+
+    const formattedTime = formatter(date)
+
+    expect(formattedTime).toBe('1983-07-04 20:00:00')
+  })
+
   it('should format correctly for columnType = time , timeFormat = YYYY-MM-DD hh:mm:ss a ZZ and timeZone = UTC', () => {
     const formatterOptions = {
       timeZone: 'UTC' as TimeZone,

--- a/src/visualization/utils/getFormatter.ts
+++ b/src/visualization/utils/getFormatter.ts
@@ -30,12 +30,6 @@ export const getFormatter = (
     format,
   }: GetFormatterOptions = {}
 ): null | ((x: any) => string) => {
-  // timeFormat was being passed in an empty string, which meant TypeScript will not
-  // replace it with the default, so we need to do it here with a check.
-  if (timeFormat === '') {
-    timeFormat = DEFAULT_TIME_FORMAT
-  }
-
   if (columnType === 'number' && base === '2') {
     return binaryPrefixFormatter({
       prefix,

--- a/src/visualization/utils/getFormatter.ts
+++ b/src/visualization/utils/getFormatter.ts
@@ -30,6 +30,12 @@ export const getFormatter = (
     format,
   }: GetFormatterOptions = {}
 ): null | ((x: any) => string) => {
+  // timeFormat was being returned a empty string, which meant TypeScript will not
+  // replace it with the default, so we need to do it here with a check.
+  if (timeFormat === '') {
+    timeFormat = DEFAULT_TIME_FORMAT
+  }
+
   if (columnType === 'number' && base === '2') {
     return binaryPrefixFormatter({
       prefix,
@@ -64,7 +70,7 @@ export const getFormatter = (
       timeZone: timeZone === 'Local' ? undefined : timeZone,
       format: resolveTimeFormat(timeFormat),
     }
-    if (timeFormat?.includes('HH')) {
+    if (formatOptions.format.includes('HH')) {
       formatOptions['hour12'] = false
     }
     return timeFormatter(formatOptions)

--- a/src/visualization/utils/getFormatter.ts
+++ b/src/visualization/utils/getFormatter.ts
@@ -30,7 +30,7 @@ export const getFormatter = (
     format,
   }: GetFormatterOptions = {}
 ): null | ((x: any) => string) => {
-  // timeFormat was being returned a empty string, which meant TypeScript will not
+  // timeFormat was being passed in an empty string, which meant TypeScript will not
   // replace it with the default, so we need to do it here with a check.
   if (timeFormat === '') {
     timeFormat = DEFAULT_TIME_FORMAT


### PR DESCRIPTION
Closes #2123

Just a small bug fix, for when the API returns an empty string, not `undefined` for the timeFormat, we need to force it to be `DEFAULT_TIME_FORMAT`
