### PR TITLE
fix: only add v vars and not func vars

### DIFF
--- a/src/variables/utils/astim.ts
+++ b/src/variables/utils/astim.ts
@@ -12,7 +12,7 @@ export interface ASTIM {
 }
 
 const parseAllVariables = (ast: File): MemberExpression[] => {
-  return findNodes(ast, node => node?.property?.type === 'Identifier')
+  return findNodes(ast, node => node?.property?.type === 'Identifier' && node?.object?.name === 'v')
 }
 
 export const parseASTIM = (query: string): ASTIM => {

--- a/src/variables/utils/astim.ts
+++ b/src/variables/utils/astim.ts
@@ -12,7 +12,10 @@ export interface ASTIM {
 }
 
 const parseAllVariables = (ast: File): MemberExpression[] => {
-  return findNodes(ast, node => node?.property?.type === 'Identifier' && node?.object?.name === 'v')
+  return findNodes(
+    ast,
+    node => node?.property?.type === 'Identifier' && node?.object?.name === 'v'
+  )
 }
 
 export const parseASTIM = (query: string): ASTIM => {


### PR DESCRIPTION
Closes #2084

**Problem**
As described in #2084, ASTIM has been including all the variables found in the query regardless of their source object.

**Proposed Solution**
ASTIM only reads variables from the system object(`v`). There's a caveat that if someone renames `v` to something else, for example: `x=v`, then this fix is going to ignore all the `x.VARS`.
