### PR TITLE
fix: throw error when maps coordiates are NaN

### DIFF
--- a/src/shared/utils/vis.test.ts
+++ b/src/shared/utils/vis.test.ts
@@ -286,4 +286,18 @@ describe('getGeoCoordinate', () => {
 
     expect(() => getGeoCoordinates(table, 0)).toThrow()
   })
+  it('returns an error when Coordinate column is not anumber', () => {
+    const table = ({
+      getColumn: columnName => {
+        if (columnName === '_field') {
+          return ['lat', 'type', 'lat', 'type']
+        } else if (columnName === '_value') {
+          return [5, "random", 7, "string"]
+        }
+        return null
+      },
+    } as unknown) as Table
+
+    expect(() => getGeoCoordinates(table, 0)).toThrow()
+  })
 })

--- a/src/shared/utils/vis.test.ts
+++ b/src/shared/utils/vis.test.ts
@@ -292,7 +292,7 @@ describe('getGeoCoordinate', () => {
         if (columnName === '_field') {
           return ['lat', 'type', 'lat', 'type']
         } else if (columnName === '_value') {
-          return [5, "random", 7, "string"]
+          return [5, 'random', 7, 'string']
         }
         return null
       },

--- a/src/shared/utils/vis.ts
+++ b/src/shared/utils/vis.ts
@@ -527,23 +527,33 @@ export const getGeoCoordinatesFlagged = (
       return getCoordinateFromS2(s2Column, table, index)
     case CoordinateType.Tags:
       const latColumn = table.getColumn(latLonColumns?.lat?.column || 'lat')
+      const latParsed = parseCoordinates(latColumn[index])
       const lonColumn = table.getColumn(latLonColumns?.lon?.column || 'lon')
+      const lonParsed = parseCoordinates(lonColumn[index])
+      if (isNaN(latParsed) || isNaN(lonParsed)) {
+        throw new Error('lat_lon_not_provided')
+      }
       return {
-        lat: parseCoordinates(latColumn[index]),
-        lon: parseCoordinates(lonColumn[index]),
+        lat: latParsed,
+        lon: lonParsed,
       }
     case CoordinateType.Fields:
       const latCoordinate = getColumnValue(
         table,
         latLonColumns?.lat?.column || 'lat'
       )
+      const latCoordinateParsed = parseCoordinates(latCoordinate)
       const lonCoordinate = getColumnValue(
         table,
         latLonColumns?.lon?.column || 'lon'
       )
+      const lonCoordinateParsed = parseCoordinates(lonCoordinate)
+      if (isNaN(latCoordinateParsed) || isNaN(lonCoordinateParsed)) {
+        throw new Error('lat_lon_not_provided')
+      }
       return {
-        lat: parseCoordinates(latCoordinate),
-        lon: parseCoordinates(lonCoordinate),
+        lat: latCoordinateParsed,
+        lon: lonCoordinateParsed,
       }
     default:
       throw new Error('lat_lon_not_provided')


### PR DESCRIPTION
Closes #2096 

<!-- Describe your proposed changes here. -->
The reason maps was failing with `invalid Latlng object` is because we are trying to render Leaflet through giraffe even when lat/lon doesn't match the type of coordinates. So in this pr, I have added if the column chosen by the user is not type number, then throw an error instead of rendering giraffe and failing horrible..
