### PR TITLE
fix: send correct type of value when updating domain for histograms and heat maps

### DIFF
--- a/src/visualization/types/Heatmap/options.tsx
+++ b/src/visualization/types/Heatmap/options.tsx
@@ -74,10 +74,7 @@ const HeatmapOptions: FC<Props> = ({properties, results, update}) => {
 
     if (domain) {
       const [min, max] = domain
-      bounds = [
-        min === null ? null : min,
-        max === null ? null : max,
-      ]
+      bounds = [min === null ? null : min, max === null ? null : max]
     } else {
       bounds = [null, null]
     }

--- a/src/visualization/types/Heatmap/options.tsx
+++ b/src/visualization/types/Heatmap/options.tsx
@@ -74,7 +74,7 @@ const HeatmapOptions: FC<Props> = ({properties, results, update}) => {
 
     if (domain) {
       const [min, max] = domain
-      bounds = [min === null ? null : min, max === null ? null : max]
+      bounds = [min, max]
     } else {
       bounds = [null, null]
     }

--- a/src/visualization/types/Heatmap/options.tsx
+++ b/src/visualization/types/Heatmap/options.tsx
@@ -70,13 +70,13 @@ const HeatmapOptions: FC<Props> = ({properties, results, update}) => {
   })
 
   const setDomain = (axis: string, domain: [number, number]): void => {
-    let bounds: [string | null, string | null]
+    let bounds: [number | null, number | null]
 
     if (domain) {
       const [min, max] = domain
       bounds = [
-        min === null ? null : String(min),
-        max === null ? null : String(max),
+        min === null ? null : min,
+        max === null ? null : max,
       ]
     } else {
       bounds = [null, null]

--- a/src/visualization/types/Histogram/options.tsx
+++ b/src/visualization/types/Histogram/options.tsx
@@ -56,13 +56,13 @@ const HistogramOptions: FC<Props> = ({properties, results, update}) => {
   }
 
   const setDomain = (axis: string, domain: [number, number]): void => {
-    let bounds: [string | null, string | null]
+    let bounds: [number | null, number | null]
 
     if (domain) {
       const [min, max] = domain
       bounds = [
-        min === null ? null : String(min),
-        max === null ? null : String(max),
+        min === null ? null : min,
+        max === null ? null : max,
       ]
     } else {
       bounds = [null, null]

--- a/src/visualization/types/Histogram/options.tsx
+++ b/src/visualization/types/Histogram/options.tsx
@@ -60,7 +60,7 @@ const HistogramOptions: FC<Props> = ({properties, results, update}) => {
 
     if (domain) {
       const [min, max] = domain
-      bounds = [min === null ? null : min, max === null ? null : max]
+      bounds = [min, max]
     } else {
       bounds = [null, null]
     }

--- a/src/visualization/types/Histogram/options.tsx
+++ b/src/visualization/types/Histogram/options.tsx
@@ -60,10 +60,7 @@ const HistogramOptions: FC<Props> = ({properties, results, update}) => {
 
     if (domain) {
       const [min, max] = domain
-      bounds = [
-        min === null ? null : min,
-        max === null ? null : max,
-      ]
+      bounds = [min === null ? null : min, max === null ? null : max]
     } else {
       bounds = [null, null]
     }

--- a/src/visualization/types/Scatter/options.tsx
+++ b/src/visualization/types/Scatter/options.tsx
@@ -99,7 +99,7 @@ const ScatterOptions: FC<Props> = ({properties, results, update}) => {
 
     if (domain) {
       const [min, max] = domain
-      bounds = [min === null ? null : min, max === null ? null : max]
+      bounds = [min, max]
     } else {
       bounds = [null, null]
     }


### PR DESCRIPTION
Closes #2182

Updates the `setDomain` function for histograms and heat maps to correctly set the value as a number rather than a string.

I confirmed this works for saving a histrogram and heatmap on both OSS and remocal.