### PR TITLE
fix: docker requires envs to have a value

### DIFF
--- a/docker/Dockerfile.chronograf
+++ b/docker/Dockerfile.chronograf
@@ -23,8 +23,8 @@ ENV API_BASE_PATH=/
 ENV UI_SHA=local_dev_mode
 
 # Global Search ENV vars
-ENV GLOBALSEARCH_API_KEY
-ENV GLOBALSEARCH_APP_ID
+ENV GLOBALSEARCH_API_KEY=
+ENV GLOBALSEARCH_APP_ID=
 
 # This is the origin of the URL needed to access the running container (optional)
 # ENV PUBLIC=http://foobar


### PR DESCRIPTION
noticed that docker was complaining when building the chronograf image for me locally. Docker wants the env vars to have a value. Setting the defaults to be empty seems to do the trick

https://github.com/moby/moby/issues/34806#issuecomment-620678422
