### PR TITLE
feat: redesigned tokens resource card

### DIFF
--- a/src/authorizations/components/redesigned/TokenList.tsx
+++ b/src/authorizations/components/redesigned/TokenList.tsx
@@ -14,6 +14,9 @@ import {Sort} from '@influxdata/clockface'
 
 // Utils
 import {getSortedResources} from 'src/shared/utils/sort'
+import {incrementCloneName} from 'src/utils/naming'
+
+import { createAuthorization } from 'src/authorizations/apis';
 
 type SortKey = keyof Authorization
 
@@ -83,9 +86,30 @@ export default class TokenList extends PureComponent<Props, State> {
         key={auth.id}
         auth={auth}
         onClickDescription={this.handleClickDescription}
+        onClone={this.handleClone}
       />
     ))
   }
+
+  //
+  private handleClone = async (id: string) => {
+      const { auths } = this.props;
+
+      const authFound = auths.find((auth) => auth.id === id);
+
+      if (!authFound) return null;
+
+      const authsDescriptions = auths.map((auth) => auth.description);
+
+      const clonedAuth = {
+          ...authFound,
+          description: incrementCloneName(authsDescriptions, authFound.description),
+      };
+
+      console.log('Cloning results', clonedAuth);
+
+      await createAuthorization(clonedAuth);
+  };
 
   private handleDismissOverlay = () => {
     this.setState({isTokenOverlayVisible: false})

--- a/src/authorizations/components/redesigned/TokenList.tsx
+++ b/src/authorizations/components/redesigned/TokenList.tsx
@@ -1,0 +1,98 @@
+// Libraries
+import React, {PureComponent} from 'react'
+import memoizeOne from 'memoize-one'
+
+// Components
+import {Overlay, ResourceList} from '@influxdata/clockface'
+import TokenRow from 'src/authorizations/components/redesigned/TokenRow'
+import ViewTokenOverlay from 'src/authorizations/components/ViewTokenOverlay'
+
+// Types
+import {Authorization} from 'src/types'
+import {SortTypes} from 'src/shared/utils/sort'
+import {Sort} from '@influxdata/clockface'
+
+// Utils
+import {getSortedResources} from 'src/shared/utils/sort'
+
+type SortKey = keyof Authorization
+
+interface Props {
+  auths: Authorization[]
+  emptyState: JSX.Element
+  searchTerm: string
+  sortKey: string
+  sortDirection: Sort
+  sortType: SortTypes
+  onClickColumn: (nextSort: Sort, sortKey: SortKey) => void
+}
+
+interface State {
+  isTokenOverlayVisible: boolean
+  authInView: Authorization
+}
+
+export default class TokenList extends PureComponent<Props, State> {
+  private memGetSortedResources = memoizeOne<typeof getSortedResources>(
+    getSortedResources
+  )
+
+  constructor(props) {
+    super(props)
+    this.state = {
+      isTokenOverlayVisible: false,
+      authInView: null,
+    }
+  }
+
+  public render() {
+    const {isTokenOverlayVisible, authInView} = this.state
+
+    return (
+      <>
+        <ResourceList>
+          <ResourceList.Body
+            emptyState={this.props.emptyState}
+            testID="token-list"
+          >
+            {this.rows}
+          </ResourceList.Body>
+        </ResourceList>
+
+        <Overlay visible={isTokenOverlayVisible}>
+          <ViewTokenOverlay
+            auth={authInView}
+            onDismissOverlay={this.handleDismissOverlay}
+          />
+        </Overlay>
+      </>
+    )
+  }
+
+  private get rows(): JSX.Element[] {
+    const {auths, sortDirection, sortKey, sortType} = this.props
+    const sortedAuths = this.memGetSortedResources(
+      auths,
+      sortKey,
+      sortDirection,
+      sortType
+    )
+
+    return sortedAuths.map(auth => (
+      <TokenRow
+        key={auth.id}
+        auth={auth}
+        onClickDescription={this.handleClickDescription}
+      />
+    ))
+  }
+
+  private handleDismissOverlay = () => {
+    this.setState({isTokenOverlayVisible: false})
+  }
+
+  private handleClickDescription = (authID: string): void => {
+    const authInView = this.props.auths.find(a => a.id === authID)
+    this.setState({isTokenOverlayVisible: true, authInView})
+  }
+}

--- a/src/authorizations/components/redesigned/TokenList.tsx
+++ b/src/authorizations/components/redesigned/TokenList.tsx
@@ -4,7 +4,7 @@ import memoizeOne from 'memoize-one'
 
 // Components
 import {Overlay, ResourceList} from '@influxdata/clockface'
-import TokenRow from 'src/authorizations/components/redesigned/TokenRow'
+import {TokenRow} from 'src/authorizations/components/redesigned/TokenRow'
 import ViewTokenOverlay from 'src/authorizations/components/ViewTokenOverlay'
 
 // Types
@@ -32,7 +32,7 @@ interface State {
   authInView: Authorization
 }
 
-export default class TokenList extends PureComponent<Props, State> {
+export class TokenList extends PureComponent<Props, State> {
   private memGetSortedResources = memoizeOne<typeof getSortedResources>(
     getSortedResources
   )
@@ -88,14 +88,16 @@ export default class TokenList extends PureComponent<Props, State> {
     ))
   }
 
-  private handleClone = () => {}
+  private handleClone = () => {
+    // clone functionality coming soon!
+  }
 
   private handleDismissOverlay = () => {
     this.setState({isTokenOverlayVisible: false})
   }
 
   private handleClickDescription = (authID: string): void => {
-    const authInView = this.props.auths.find(a => a.id === authID)
+    const authInView = this.props.auths.find(auth => auth.id === authID)
     this.setState({isTokenOverlayVisible: true, authInView})
   }
 }

--- a/src/authorizations/components/redesigned/TokenList.tsx
+++ b/src/authorizations/components/redesigned/TokenList.tsx
@@ -88,10 +88,7 @@ export default class TokenList extends PureComponent<Props, State> {
     ))
   }
 
-  
-  private handleClone =  () => {
-      
-  };
+  private handleClone = () => {}
 
   private handleDismissOverlay = () => {
     this.setState({isTokenOverlayVisible: false})

--- a/src/authorizations/components/redesigned/TokenList.tsx
+++ b/src/authorizations/components/redesigned/TokenList.tsx
@@ -91,24 +91,9 @@ export default class TokenList extends PureComponent<Props, State> {
     ))
   }
 
-  //
+  
   private handleClone = async (id: string) => {
-      const { auths } = this.props;
-
-      const authFound = auths.find((auth) => auth.id === id);
-
-      if (!authFound) return null;
-
-      const authsDescriptions = auths.map((auth) => auth.description);
-
-      const clonedAuth = {
-          ...authFound,
-          description: incrementCloneName(authsDescriptions, authFound.description),
-      };
-
-      console.log('Cloning results', clonedAuth);
-
-      await createAuthorization(clonedAuth);
+      
   };
 
   private handleDismissOverlay = () => {

--- a/src/authorizations/components/redesigned/TokenList.tsx
+++ b/src/authorizations/components/redesigned/TokenList.tsx
@@ -14,9 +14,6 @@ import {Sort} from '@influxdata/clockface'
 
 // Utils
 import {getSortedResources} from 'src/shared/utils/sort'
-import {incrementCloneName} from 'src/utils/naming'
-
-import { createAuthorization } from 'src/authorizations/apis';
 
 type SortKey = keyof Authorization
 
@@ -92,7 +89,7 @@ export default class TokenList extends PureComponent<Props, State> {
   }
 
   
-  private handleClone = async (id: string) => {
+  private handleClone =  () => {
       
   };
 

--- a/src/authorizations/components/redesigned/TokenRow.test.tsx
+++ b/src/authorizations/components/redesigned/TokenRow.test.tsx
@@ -1,0 +1,70 @@
+// Libraries
+import {fireEvent, waitFor} from '@testing-library/react'
+import React from 'react'
+
+// Fixtures
+import TokenRow  from './TokenRow'
+import {auth} from 'mocks/dummyData'
+import {renderWithRedux} from 'src/mockState'
+
+// Actions
+import {deleteAuthorization} from 'src/client'
+
+
+
+
+jest.mock('src/client', () => ({
+    deleteAuthorization: jest.fn(() => 
+        ({
+            headers: {},
+            status: 201,
+        })
+    )
+    
+}));
+
+const setup = (override?) => {
+    const authorization = {
+        ...auth,
+        description: 'XYZ',
+        createdAt: '2020-08-19T23:13:44.514Z',
+        updatedAt: '2020-08-19T23:13:44.514Z',
+    }
+    
+    const props = {
+        auth: authorization,
+        onClickDescription: jest.fn(),
+        onClone: jest.fn(),
+        ...override,
+    }
+    return renderWithRedux(<TokenRow {...props}/>)
+}
+
+describe('TokenRowResourceCard', () => {
+    it('should render', () => {
+        const {getByTestId} = setup();
+        expect(getByTestId('token-card XYZ')).toBeDefined();
+        expect(getByTestId('token-name XYZ')).toBeDefined();
+    });
+    
+
+    it('displays delete button', () => {
+
+        const {getByTestId} = setup()
+  
+      expect(getByTestId('delete-token')).toBeVisible()
+      
+    })
+
+    it('executes the delete method', async () => {
+        const { getByTestId } = setup();
+
+
+        fireEvent.click(getByTestId('delete-token'));
+        await waitFor(() => expect(deleteAuthorization).toBeCalled())
+        expect(deleteAuthorization).toBeCalledTimes(1)
+  
+      
+    })
+    
+})

--- a/src/authorizations/components/redesigned/TokenRow.test.tsx
+++ b/src/authorizations/components/redesigned/TokenRow.test.tsx
@@ -3,68 +3,55 @@ import {fireEvent, waitFor} from '@testing-library/react'
 import React from 'react'
 
 // Fixtures
-import TokenRow  from './TokenRow'
+import TokenRow from './TokenRow'
 import {auth} from 'mocks/dummyData'
 import {renderWithRedux} from 'src/mockState'
 
 // Actions
 import {deleteAuthorization} from 'src/client'
 
-
-
-
 jest.mock('src/client', () => ({
-    deleteAuthorization: jest.fn(() => 
-        ({
-            headers: {},
-            status: 201,
-        })
-    )
-    
-}));
+  deleteAuthorization: jest.fn(() => ({
+    headers: {},
+    status: 201,
+  })),
+}))
 
 const setup = (override?) => {
-    const authorization = {
-        ...auth,
-        description: 'XYZ',
-        createdAt: '2020-08-19T23:13:44.514Z',
-        updatedAt: '2020-08-19T23:13:44.514Z',
-    }
-    
-    const props = {
-        auth: authorization,
-        onClickDescription: jest.fn(),
-        onClone: jest.fn(),
-        ...override,
-    }
-    return renderWithRedux(<TokenRow {...props}/>)
+  const authorization = {
+    ...auth,
+    description: 'XYZ',
+    createdAt: '2020-08-19T23:13:44.514Z',
+    updatedAt: '2020-08-19T23:13:44.514Z',
+  }
+
+  const props = {
+    auth: authorization,
+    onClickDescription: jest.fn(),
+    onClone: jest.fn(),
+    ...override,
+  }
+  return renderWithRedux(<TokenRow {...props} />)
 }
 
 describe('TokenRowResourceCard', () => {
-    it('should render', () => {
-        const {getByTestId} = setup();
-        expect(getByTestId('token-card XYZ')).toBeDefined();
-        expect(getByTestId('token-name XYZ')).toBeDefined();
-    });
-    
+  it('should render', () => {
+    const {getByTestId} = setup()
+    expect(getByTestId('token-card XYZ')).toBeDefined()
+    expect(getByTestId('token-name XYZ')).toBeDefined()
+  })
 
-    it('displays delete button', () => {
+  it('displays delete button', () => {
+    const {getByTestId} = setup()
 
-        const {getByTestId} = setup()
-  
-      expect(getByTestId('delete-token')).toBeVisible()
-      
-    })
+    expect(getByTestId('delete-token')).toBeVisible()
+  })
 
-    it('executes the delete method', async () => {
-        const { getByTestId } = setup();
+  it('executes the delete method', async () => {
+    const {getByTestId} = setup()
 
-
-        fireEvent.click(getByTestId('delete-token'));
-        await waitFor(() => expect(deleteAuthorization).toBeCalled())
-        expect(deleteAuthorization).toBeCalledTimes(1)
-  
-      
-    })
-    
+    fireEvent.click(getByTestId('delete-token'))
+    await waitFor(() => expect(deleteAuthorization).toBeCalled())
+    expect(deleteAuthorization).toBeCalledTimes(1)
+  })
 })

--- a/src/authorizations/components/redesigned/TokenRow.test.tsx
+++ b/src/authorizations/components/redesigned/TokenRow.test.tsx
@@ -1,5 +1,4 @@
 // Libraries
-import {fireEvent, waitFor} from '@testing-library/react'
 import React from 'react'
 
 // Fixtures

--- a/src/authorizations/components/redesigned/TokenRow.test.tsx
+++ b/src/authorizations/components/redesigned/TokenRow.test.tsx
@@ -7,7 +7,6 @@ import {TokenRow} from './TokenRow'
 import {auth} from 'mocks/dummyData'
 import {renderWithRedux} from 'src/mockState'
 
-
 const setup = (override?) => {
   const authorization = {
     ...auth,

--- a/src/authorizations/components/redesigned/TokenRow.test.tsx
+++ b/src/authorizations/components/redesigned/TokenRow.test.tsx
@@ -3,19 +3,10 @@ import {fireEvent, waitFor} from '@testing-library/react'
 import React from 'react'
 
 // Fixtures
-import TokenRow from './TokenRow'
+import {TokenRow} from './TokenRow'
 import {auth} from 'mocks/dummyData'
 import {renderWithRedux} from 'src/mockState'
 
-// Actions
-import {deleteAuthorization} from 'src/client'
-
-jest.mock('src/client', () => ({
-  deleteAuthorization: jest.fn(() => ({
-    headers: {},
-    status: 201,
-  })),
-}))
 
 const setup = (override?) => {
   const authorization = {
@@ -45,13 +36,5 @@ describe('TokenRowResourceCard', () => {
     const {getByTestId} = setup()
 
     expect(getByTestId('delete-token')).toBeVisible()
-  })
-
-  it('executes the delete method', async () => {
-    const {getByTestId} = setup()
-
-    fireEvent.click(getByTestId('delete-token'))
-    await waitFor(() => expect(deleteAuthorization).toBeCalled())
-    expect(deleteAuthorization).toBeCalledTimes(1)
   })
 })

--- a/src/authorizations/components/redesigned/TokenRow.tsx
+++ b/src/authorizations/components/redesigned/TokenRow.tsx
@@ -15,8 +15,6 @@ import {
   FlexBox,
   AlignItems,
   FlexDirection,
-//   InputLabel,
-//   SlideToggle,
   JustifyContent,
   ComponentColor,
   Button,
@@ -37,8 +35,8 @@ import {relativeTimestampFormatter} from 'src/shared/utils/relativeTimestampForm
 
 interface OwnProps {
   auth: Authorization
-  onClickDescription: (authID: string) => void,
-  onClone: (authID: string) => void,
+  onClickDescription: (authID: string) => void
+  onClone: (authID: string) => void
 }
 
 type ReduxProps = ConnectedProps<typeof connector>
@@ -51,7 +49,7 @@ class TokenRow extends PureComponent<Props> {
     const {description} = this.props.auth
     const {auth} = this.props
     const date = new Date(auth.createdAt)
-    
+
     return (
       <ResourceCard
         contextMenu={this.contextMenu}
@@ -66,22 +64,18 @@ class TokenRow extends PureComponent<Props> {
           direction={FlexDirection.Column}
           margin={ComponentSize.Large}
         >
-            <ResourceCard.EditableName
+          <ResourceCard.EditableName
             onUpdate={this.handleUpdateName}
             onClick={this.handleClickDescription}
             name={description}
             noNameString={DEFAULT_TOKEN_DESCRIPTION}
             testID={`token-name ${auth.description}`}
-            />
-            <ResourceCard.Meta>
-           
-                
-                <>Created at: {formatter.format(date)}</>
-                <>Created by: {auth.user}</>
-                <>Last Used: {relativeTimestampFormatter(auth.updatedAt)}</>
-                
-            
-            </ResourceCard.Meta>
+          />
+          <ResourceCard.Meta>
+            <>Created at: {formatter.format(date)}</>
+            <>Created by: {auth.user}</>
+            <>Last Used: {relativeTimestampFormatter(auth.updatedAt)}</>
+          </ResourceCard.Meta>
         </FlexBox>
       </ResourceCard>
     )
@@ -90,25 +84,22 @@ class TokenRow extends PureComponent<Props> {
   private get contextMenu(): JSX.Element {
     return (
       <Context>
-        
-        <FlexBox margin={ComponentSize.Medium}  >
-            <Button
-                icon={IconFont.Duplicate}
-                color={ComponentColor.Secondary}
-                text="Clone"
-                onClick={this.handleClone}
-                testID="clone-token"
-            />
-            <Button
-                icon={IconFont.Trash}
-                color={ComponentColor.Danger}
-                text="Delete"
-                onClick={this.handleDelete}
-                testID="delete-token"
-            />
-            
+        <FlexBox margin={ComponentSize.Medium}>
+          <Button
+            icon={IconFont.Duplicate}
+            color={ComponentColor.Secondary}
+            text="Clone"
+            onClick={this.handleClone}
+            testID="clone-token"
+          />
+          <Button
+            icon={IconFont.Trash}
+            color={ComponentColor.Danger}
+            text="Delete"
+            onClick={this.handleDelete}
+            testID="delete-token"
+          />
         </FlexBox>
-        
       </Context>
     )
   }
@@ -119,7 +110,7 @@ class TokenRow extends PureComponent<Props> {
   }
 
   private handleClone = () => {
-      this.props.onClone(this.props.auth.id);
+    this.props.onClone(this.props.auth.id)
   }
 
   private handleClickDescription = () => {

--- a/src/authorizations/components/redesigned/TokenRow.tsx
+++ b/src/authorizations/components/redesigned/TokenRow.tsx
@@ -37,7 +37,8 @@ import {relativeTimestampFormatter} from 'src/shared/utils/relativeTimestampForm
 
 interface OwnProps {
   auth: Authorization
-  onClickDescription: (authID: string) => void
+  onClickDescription: (authID: string) => void,
+  onClone: (authID: string) => void,
 }
 
 type ReduxProps = ConnectedProps<typeof connector>
@@ -168,7 +169,7 @@ class TokenRow extends PureComponent<Props> {
   }
 
   private handleClone = () => {
-      
+      this.props.onClone(this.props.auth.id);
   }
 
   private handleClickDescription = () => {

--- a/src/authorizations/components/redesigned/TokenRow.tsx
+++ b/src/authorizations/components/redesigned/TokenRow.tsx
@@ -44,7 +44,7 @@ type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps & OwnProps
 
 const formatter = createDateTimeFormatter(UPDATED_AT_TIME_FORMAT)
-class TokenRow extends PureComponent<Props> {
+class TokenRow_ extends PureComponent<Props> {
   public render() {
     const {description} = this.props.auth
     const {auth} = this.props
@@ -131,4 +131,4 @@ const mdtp = {
 
 const connector = connect(null, mdtp)
 
-export default connector(TokenRow)
+export const TokenRow = connector(TokenRow_)

--- a/src/authorizations/components/redesigned/TokenRow.tsx
+++ b/src/authorizations/components/redesigned/TokenRow.tsx
@@ -50,10 +50,8 @@ class TokenRow extends PureComponent<Props> {
   public render() {
     const {description} = this.props.auth
     const {auth} = this.props
-    // const labelText = this.isTokenEnabled ? 'Active' : 'Inactive'
     const date = new Date(auth.createdAt)
-
-    // console.log(auth)
+    
     return (
       <ResourceCard
         contextMenu={this.contextMenu}
@@ -85,31 +83,6 @@ class TokenRow extends PureComponent<Props> {
             
             </ResourceCard.Meta>
         </FlexBox>
-        {/* <FlexBox margin={ComponentSize.Small}>
-          <SlideToggle
-            active={this.isTokenEnabled}
-            size={ComponentSize.ExtraSmall}
-            onChange={this.changeToggle}
-          />
-          <InputLabel active={this.isTokenEnabled}>{labelText}</InputLabel>
-        </FlexBox> */}
-        {/* <FlexBox margin={ComponentSize.Medium} direction={FlexDirection.Row}>
-            <Button
-                icon={IconFont.Duplicate}
-                color={ComponentColor.Secondary}
-                text="Clone"
-                onClick={this.handleClone}
-                testID="clone-token"
-            />
-            <Button
-                icon={IconFont.Trash}
-                color={ComponentColor.Danger}
-                text="Delete"
-                onClick={this.handleDelete}
-                testID="delete-token"
-            />
-            
-        </FlexBox> */}
       </ResourceCard>
     )
   }
@@ -117,14 +90,6 @@ class TokenRow extends PureComponent<Props> {
   private get contextMenu(): JSX.Element {
     return (
       <Context>
-        {/* <Context.Menu icon={IconFont.Trash} color={ComponentColor.Danger}>
-          <Context.Item
-            label="Delete"
-            action={this.handleDelete}
-            testID="delete-token"
-          />
-          <Context.Item label="Clone" action={this.handleClone} />
-        </Context.Menu> */}
         
         <FlexBox margin={ComponentSize.Medium}  >
             <Button
@@ -147,21 +112,6 @@ class TokenRow extends PureComponent<Props> {
       </Context>
     )
   }
-
-//   private get isTokenEnabled(): boolean {
-//     const {auth} = this.props
-//     return auth.status === 'active'
-//   }
-
-//   private changeToggle = () => {
-//     const {auth, onUpdate} = this.props
-//     if (auth.status === 'active') {
-//       auth.status = 'inactive'
-//     } else {
-//       auth.status = 'active'
-//     }
-//     onUpdate(auth)
-//   }
 
   private handleDelete = () => {
     const {id, description} = this.props.auth

--- a/src/authorizations/components/redesigned/TokenRow.tsx
+++ b/src/authorizations/components/redesigned/TokenRow.tsx
@@ -44,7 +44,7 @@ type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps & OwnProps
 
 const formatter = createDateTimeFormatter(UPDATED_AT_TIME_FORMAT)
-class TokenRow_ extends PureComponent<Props> {
+class TokensRow extends PureComponent<Props> {
   public render() {
     const {description} = this.props.auth
     const {auth} = this.props
@@ -131,4 +131,4 @@ const mdtp = {
 
 const connector = connect(null, mdtp)
 
-export const TokenRow = connector(TokenRow_)
+export const TokenRow = connector(TokensRow)

--- a/src/authorizations/components/redesigned/TokenRow.tsx
+++ b/src/authorizations/components/redesigned/TokenRow.tsx
@@ -1,0 +1,192 @@
+// Libraries
+import React, {PureComponent} from 'react'
+import {connect, ConnectedProps} from 'react-redux'
+import {createDateTimeFormatter} from 'src/utils/datetime/formatters'
+
+// Actions
+import {
+  deleteAuthorization,
+  updateAuthorization,
+} from 'src/authorizations/actions/thunks'
+
+// Components
+import {
+  ComponentSize,
+  FlexBox,
+  AlignItems,
+  FlexDirection,
+//   InputLabel,
+//   SlideToggle,
+  JustifyContent,
+  ComponentColor,
+  Button,
+  ResourceCard,
+  IconFont,
+} from '@influxdata/clockface'
+
+import {Context} from 'src/clockface'
+
+// Types
+import {Authorization} from 'src/types'
+import {
+  DEFAULT_TOKEN_DESCRIPTION,
+  UPDATED_AT_TIME_FORMAT,
+} from 'src/dashboards/constants'
+
+import {relativeTimestampFormatter} from 'src/shared/utils/relativeTimestampFormatter'
+
+interface OwnProps {
+  auth: Authorization
+  onClickDescription: (authID: string) => void
+}
+
+type ReduxProps = ConnectedProps<typeof connector>
+
+type Props = ReduxProps & OwnProps
+
+const formatter = createDateTimeFormatter(UPDATED_AT_TIME_FORMAT)
+class TokenRow extends PureComponent<Props> {
+  public render() {
+    const {description} = this.props.auth
+    const {auth} = this.props
+    // const labelText = this.isTokenEnabled ? 'Active' : 'Inactive'
+    const date = new Date(auth.createdAt)
+
+    // console.log(auth)
+    return (
+      <ResourceCard
+        contextMenu={this.contextMenu}
+        testID={`token-card ${auth.description}`}
+        direction={FlexDirection.Row}
+        justifyContent={JustifyContent.SpaceBetween}
+        alignItems={AlignItems.Center}
+        margin={ComponentSize.Large}
+      >
+        <FlexBox
+          alignItems={AlignItems.FlexStart}
+          direction={FlexDirection.Column}
+          margin={ComponentSize.Large}
+        >
+            <ResourceCard.EditableName
+            onUpdate={this.handleUpdateName}
+            onClick={this.handleClickDescription}
+            name={description}
+            noNameString={DEFAULT_TOKEN_DESCRIPTION}
+            testID={`token-name ${auth.description}`}
+            />
+            <ResourceCard.Meta>
+           
+                
+                <>Created at: {formatter.format(date)}</>
+                <>Created by: {auth.user}</>
+                <>Last Used: {relativeTimestampFormatter(auth.updatedAt)}</>
+                
+            
+            </ResourceCard.Meta>
+        </FlexBox>
+        {/* <FlexBox margin={ComponentSize.Small}>
+          <SlideToggle
+            active={this.isTokenEnabled}
+            size={ComponentSize.ExtraSmall}
+            onChange={this.changeToggle}
+          />
+          <InputLabel active={this.isTokenEnabled}>{labelText}</InputLabel>
+        </FlexBox> */}
+        {/* <FlexBox margin={ComponentSize.Medium} direction={FlexDirection.Row}>
+            <Button
+                icon={IconFont.Duplicate}
+                color={ComponentColor.Secondary}
+                text="Clone"
+                onClick={this.handleClone}
+                testID="clone-token"
+            />
+            <Button
+                icon={IconFont.Trash}
+                color={ComponentColor.Danger}
+                text="Delete"
+                onClick={this.handleDelete}
+                testID="delete-token"
+            />
+            
+        </FlexBox> */}
+      </ResourceCard>
+    )
+  }
+
+  private get contextMenu(): JSX.Element {
+    return (
+      <Context>
+        {/* <Context.Menu icon={IconFont.Trash} color={ComponentColor.Danger}>
+          <Context.Item
+            label="Delete"
+            action={this.handleDelete}
+            testID="delete-token"
+          />
+          <Context.Item label="Clone" action={this.handleClone} />
+        </Context.Menu> */}
+        
+        <FlexBox margin={ComponentSize.Medium}  >
+            <Button
+                icon={IconFont.Duplicate}
+                color={ComponentColor.Secondary}
+                text="Clone"
+                onClick={this.handleClone}
+                testID="clone-token"
+            />
+            <Button
+                icon={IconFont.Trash}
+                color={ComponentColor.Danger}
+                text="Delete"
+                onClick={this.handleDelete}
+                testID="delete-token"
+            />
+            
+        </FlexBox>
+        
+      </Context>
+    )
+  }
+
+//   private get isTokenEnabled(): boolean {
+//     const {auth} = this.props
+//     return auth.status === 'active'
+//   }
+
+//   private changeToggle = () => {
+//     const {auth, onUpdate} = this.props
+//     if (auth.status === 'active') {
+//       auth.status = 'inactive'
+//     } else {
+//       auth.status = 'active'
+//     }
+//     onUpdate(auth)
+//   }
+
+  private handleDelete = () => {
+    const {id, description} = this.props.auth
+    this.props.onDelete(id, description)
+  }
+
+  private handleClone = () => {
+      
+  }
+
+  private handleClickDescription = () => {
+    const {onClickDescription, auth} = this.props
+    onClickDescription(auth.id)
+  }
+
+  private handleUpdateName = (value: string) => {
+    const {auth, onUpdate} = this.props
+    onUpdate({...auth, description: value})
+  }
+}
+
+const mdtp = {
+  onDelete: deleteAuthorization,
+  onUpdate: updateAuthorization,
+}
+
+const connector = connect(null, mdtp)
+
+export default connector(TokenRow)

--- a/src/authorizations/components/redesigned/TokensTab.tsx
+++ b/src/authorizations/components/redesigned/TokensTab.tsx
@@ -7,7 +7,7 @@ import {isEmpty} from 'lodash'
 // Components
 import {Sort, ComponentSize, EmptyState} from '@influxdata/clockface'
 import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
-import TokenList from 'src/authorizations/components/redesigned/TokenList'
+import {TokenList} from 'src/authorizations/components/redesigned/TokenList'
 import FilterList from 'src/shared/components/FilterList'
 import TabbedPageHeader from 'src/shared/components/tabbed_page/TabbedPageHeader'
 import GenerateTokenDropdown from 'src/authorizations/components/redesigned/GenerateTokenDropdown'

--- a/src/authorizations/components/redesigned/TokensTab.tsx
+++ b/src/authorizations/components/redesigned/TokensTab.tsx
@@ -7,7 +7,7 @@ import {isEmpty} from 'lodash'
 // Components
 import {Sort, ComponentSize, EmptyState} from '@influxdata/clockface'
 import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
-import TokenList from 'src/authorizations/components/TokenList'
+import TokenList from 'src/authorizations/components/redesigned/TokenList'
 import FilterList from 'src/shared/components/FilterList'
 import TabbedPageHeader from 'src/shared/components/tabbed_page/TabbedPageHeader'
 import GenerateTokenDropdown from 'src/authorizations/components/redesigned/GenerateTokenDropdown'

--- a/src/utils/datetime/formatters.ts
+++ b/src/utils/datetime/formatters.ts
@@ -45,8 +45,10 @@ export const createRelativeFormatter = (
 
     for (const {scale, ms} of relativeDivisions) {
       if (Math.abs(millisecondsAgo) >= ms || scale === 'seconds') {
+        
         return formatter.format(Math.round(millisecondsAgo / ms), scale)
       }
+      
     }
   }
 

--- a/src/utils/datetime/formatters.ts
+++ b/src/utils/datetime/formatters.ts
@@ -45,10 +45,8 @@ export const createRelativeFormatter = (
 
     for (const {scale, ms} of relativeDivisions) {
       if (Math.abs(millisecondsAgo) >= ms || scale === 'seconds') {
-        
         return formatter.format(Math.round(millisecondsAgo / ms), scale)
       }
-      
     }
   }
 


### PR DESCRIPTION
Closes #2102 

With token redesign feature flag on (influx.toggle('tokenUIRedesign')), the resource card looks like this. 

<img width="1148" alt="Screen Shot 2021-07-30 at 12 42 01 PM" src="https://user-images.githubusercontent.com/66275100/127691645-9e7246d9-1f4b-4049-afd4-c5e08e4bc8b6.png">
