### PR TITLE
feat: renaming tokens to API tokens

### DIFF
--- a/cypress/e2e/shared/tokens.test.ts
+++ b/cypress/e2e/shared/tokens.test.ts
@@ -495,7 +495,7 @@ describe('tokens', () => {
       .click()
       .then(() => {
         cy.getByTestID('notification-success--children').contains(
-          'Token was created successfully'
+          'API token was created successfully'
         )
       })
 
@@ -535,7 +535,7 @@ describe('tokens', () => {
       .click()
       .then(() => {
         cy.getByTestID('notification-success--children').contains(
-          'Token was created successfully'
+          'API token was created successfully'
         )
       })
 
@@ -595,7 +595,7 @@ describe('tokens', () => {
       .click()
       .then(() => {
         cy.getByTestID('notification-success--children').contains(
-          'Token was created successfully'
+          'API token was created successfully'
         )
       })
 
@@ -661,7 +661,7 @@ describe('tokens', () => {
       .click()
       .then(() => {
         cy.getByTestID('notification-success--children').contains(
-          'Token was created successfully'
+          'API token was created successfully'
         )
       })
 

--- a/src/authorizations/components/AllAccessTokenOverlay.tsx
+++ b/src/authorizations/components/AllAccessTokenOverlay.tsx
@@ -52,7 +52,7 @@ class AllAccessTokenOverlay extends PureComponent<Props, State> {
     return (
       <Overlay.Container maxWidth={500}>
         <Overlay.Header
-          title="Generate All Access Token"
+          title="Generate All Access API Token"
           onDismiss={this.handleDismiss}
         />
         <Overlay.Body>
@@ -71,7 +71,7 @@ class AllAccessTokenOverlay extends PureComponent<Props, State> {
               </Alert>
               <Form.Element label="Description">
                 <Input
-                  placeholder="Describe this new token"
+                  placeholder="Describe this new API token"
                   value={description}
                   onChange={this.handleInputChange}
                   testID="all-access-token-input"

--- a/src/authorizations/components/BucketsTokenOverlay.tsx
+++ b/src/authorizations/components/BucketsTokenOverlay.tsx
@@ -85,7 +85,7 @@ class BucketsTokenOverlay extends PureComponent<Props, State> {
     return (
       <Overlay.Container maxWidth={700}>
         <Overlay.Header
-          title="Generate Read/Write Token"
+          title="Generate Read/Write API Token"
           onDismiss={this.handleDismiss}
         />
         <Overlay.Body>
@@ -97,7 +97,7 @@ class BucketsTokenOverlay extends PureComponent<Props, State> {
             >
               <Form.Element label="Description">
                 <Input
-                  placeholder="Describe this new token"
+                  placeholder="Describe this new API token"
                   value={description}
                   onChange={this.handleInputChange}
                   testID="input-field--descr"

--- a/src/authorizations/components/GenerateTokenDropdown.test.tsx
+++ b/src/authorizations/components/GenerateTokenDropdown.test.tsx
@@ -22,7 +22,7 @@ describe('GenerateTokenDropdown', () => {
 
     fireEvent.click(screen.getByTestId('dropdown-button--gen-token'))
 
-    expect(queryByText('Read/Write Token')).toBeVisible()
-    expect(queryByText('All Access Token')).toBeVisible()
+    expect(queryByText('Read/Write API Token')).toBeVisible()
+    expect(queryByText('All Access API Token')).toBeVisible()
   })
 })

--- a/src/authorizations/components/GenerateTokenDropdown.tsx
+++ b/src/authorizations/components/GenerateTokenDropdown.tsx
@@ -17,9 +17,9 @@ type GenerateTokenProps = RouteComponentProps
 const GenerateTokenDropdown: FC<GenerateTokenProps> = ({history}) => {
   const org = useSelector(getOrg)
 
-  const bucketReadWriteOption = 'Read/Write Token'
+  const bucketReadWriteOption = 'Read/Write API Token'
 
-  const allAccessOption = 'All Access Token'
+  const allAccessOption = 'All Access API Token'
 
   const handleAllAccess = () => {
     history.push(`/orgs/${org.id}/load-data/tokens/generate/all-access`)
@@ -39,7 +39,7 @@ const GenerateTokenDropdown: FC<GenerateTokenProps> = ({history}) => {
   return (
     <Dropdown
       testID="dropdown--gen-token"
-      style={{width: '160px'}}
+      style={{width: '180px'}}
       button={(active, onClick) => (
         <Dropdown.Button
           active={active}
@@ -48,7 +48,7 @@ const GenerateTokenDropdown: FC<GenerateTokenProps> = ({history}) => {
           color={ComponentColor.Primary}
           testID="dropdown-button--gen-token"
         >
-          Generate Token
+          Generate API Token
         </Dropdown.Button>
       )}
       menu={onCollapse => (

--- a/src/authorizations/components/TokensTab.tsx
+++ b/src/authorizations/components/TokensTab.tsx
@@ -62,7 +62,7 @@ class TokensTab extends PureComponent<Props, State> {
       <>
         <SearchWidget
           searchTerm={searchTerm}
-          placeholderText="Filter Tokens..."
+          placeholderText="Filter API Tokens..."
           onSearch={this.handleChangeSearchTerm}
           testID="input-field--filter"
         />

--- a/src/authorizations/components/TokensTab.tsx
+++ b/src/authorizations/components/TokensTab.tsx
@@ -138,7 +138,7 @@ class TokensTab extends PureComponent<Props, State> {
       return (
         <EmptyState size={ComponentSize.Large}>
           <EmptyState.Text>
-            Looks like there aren't any <b>Tokens</b>, why not generate one?
+            Looks like there aren't any <b>API Tokens</b>, why not generate one?
           </EmptyState.Text>
           <GenerateTokenDropdown />
         </EmptyState>
@@ -147,7 +147,7 @@ class TokensTab extends PureComponent<Props, State> {
 
     return (
       <EmptyState size={ComponentSize.Large}>
-        <EmptyState.Text>No Tokens match your query</EmptyState.Text>
+        <EmptyState.Text>No API Tokens match your query</EmptyState.Text>
       </EmptyState>
     )
   }

--- a/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
@@ -170,7 +170,7 @@ const CustomApiTokenOverlay: FC<Props> = props => {
   return (
     <Overlay.Container maxWidth={800}>
       <Overlay.Header
-        title="Generate a Personal Api Token"
+        title="Generate a Personal API Token"
         onDismiss={onClose}
       />
       <Overlay.Body>

--- a/src/authorizations/components/redesigned/DisplayTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/DisplayTokenOverlay.tsx
@@ -41,8 +41,8 @@ const DisplayTokenOverlay: FC<Props> = props => {
           alignItems={AlignItems.Stretch}
         >
           <Alert icon={IconFont.AlertTriangle} color={ComponentColor.Primary}>
-            Make sure to copy your new personal API token now. You won't be
-            able to see it again!
+            Make sure to copy your new personal API token now. You won't be able
+            to see it again!
           </Alert>
 
           <CodeSnippet text={props.auth.token} type="Token" />

--- a/src/authorizations/components/redesigned/DisplayTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/DisplayTokenOverlay.tsx
@@ -41,7 +41,7 @@ const DisplayTokenOverlay: FC<Props> = props => {
           alignItems={AlignItems.Stretch}
         >
           <Alert icon={IconFont.AlertTriangle} color={ComponentColor.Primary}>
-            Make sure to copy your new personal access token now. You won't be
+            Make sure to copy your new personal API token now. You won't be
             able to see it again!
           </Alert>
 

--- a/src/authorizations/components/redesigned/GenerateTokenDropdown.test.tsx
+++ b/src/authorizations/components/redesigned/GenerateTokenDropdown.test.tsx
@@ -22,7 +22,7 @@ describe('GenerateTokenDropdown', () => {
 
     fireEvent.click(screen.getByTestId('dropdown-button--gen-token'))
 
-    expect(queryByText('All Access Token')).toBeVisible()
+    expect(queryByText('All Access API Token')).toBeVisible()
     expect(queryByText('Custom API Token')).toBeVisible()
   })
 })

--- a/src/authorizations/components/redesigned/GenerateTokenDropdown.tsx
+++ b/src/authorizations/components/redesigned/GenerateTokenDropdown.tsx
@@ -60,7 +60,7 @@ const GenerateTokenDropdown: FC<ReduxProps & GenerateTokenProps> = ({
           color={ComponentColor.Primary}
           testID="dropdown-button--gen-token"
         >
-          Generate Token
+          Generate API Token
         </Dropdown.Button>
       )}
       menu={onCollapse => (

--- a/src/authorizations/components/redesigned/GenerateTokenDropdown.tsx
+++ b/src/authorizations/components/redesigned/GenerateTokenDropdown.tsx
@@ -23,7 +23,7 @@ const GenerateTokenDropdown: FC<ReduxProps & GenerateTokenProps> = ({
   getAllResources,
 }) => {
   const dispatch = useDispatch()
-  const allAccessOption = 'All Access Token'
+  const allAccessOption = 'All Access API Token'
 
   const customApiOption = 'Custom API Token'
 

--- a/src/authorizations/components/redesigned/TokensTab.tsx
+++ b/src/authorizations/components/redesigned/TokensTab.tsx
@@ -62,7 +62,7 @@ class TokensTab extends PureComponent<Props, State> {
       <>
         <SearchWidget
           searchTerm={searchTerm}
-          placeholderText="Filter Tokens..."
+          placeholderText="Filter API Tokens..."
           onSearch={this.handleChangeSearchTerm}
           testID="input-field--filter"
         />
@@ -138,7 +138,7 @@ class TokensTab extends PureComponent<Props, State> {
       return (
         <EmptyState size={ComponentSize.Large}>
           <EmptyState.Text>
-            Looks like there aren't any <b>Tokens</b>, why not generate one?
+            Looks like there aren't any <b>API Tokens</b>, why not generate one?
           </EmptyState.Text>
           <GenerateTokenDropdown />
         </EmptyState>
@@ -147,7 +147,7 @@ class TokensTab extends PureComponent<Props, State> {
 
     return (
       <EmptyState size={ComponentSize.Large}>
-        <EmptyState.Text>No Tokens match your query</EmptyState.Text>
+        <EmptyState.Text>No API Tokens match your query</EmptyState.Text>
       </EmptyState>
     )
   }

--- a/src/authorizations/containers/RedesignedTokensIndex.tsx
+++ b/src/authorizations/containers/RedesignedTokensIndex.tsx
@@ -29,7 +29,7 @@ class TokensIndex extends Component {
   public render() {
     return (
       <>
-        <Page titleTag={pageTitleSuffixer(['Tokens', 'Load Data'])}>
+        <Page titleTag={pageTitleSuffixer(['API Tokens', 'Load Data'])}>
           <LoadDataHeader />
           <LoadDataTabbedPage activeTab="tokens">
             <GetResources resources={[ResourceType.Authorizations]}>

--- a/src/authorizations/containers/TokensIndex.tsx
+++ b/src/authorizations/containers/TokensIndex.tsx
@@ -29,7 +29,7 @@ class TokensIndex extends Component {
   public render() {
     return (
       <>
-        <Page titleTag={pageTitleSuffixer(['Tokens', 'Load Data'])}>
+        <Page titleTag={pageTitleSuffixer(['API Tokens', 'Load Data'])}>
           <LoadDataHeader />
           <LoadDataTabbedPage activeTab="tokens">
             <GetResources resources={[ResourceType.Authorizations]}>

--- a/src/dashboards/constants/index.ts
+++ b/src/dashboards/constants/index.ts
@@ -60,7 +60,7 @@ export const DEFAULT_BUCKET_NAME = 'Name this Bucket'
 export const DEFAULT_COLLECTOR_NAME = 'Name this Collector'
 export const DEFAULT_TASK_NAME = 'Name this Task'
 export const DEFAULT_SCRAPER_NAME = 'Name this Scraper'
-export const DEFAULT_TOKEN_DESCRIPTION = 'Describe this Token'
+export const DEFAULT_TOKEN_DESCRIPTION = 'Describe this API Token'
 
 export const NEW_DASHBOARD: NewDefaultDashboard = {
   name: DEFAULT_DASHBOARD_NAME,

--- a/src/dataLoaders/actions/dataLoaders.ts
+++ b/src/dataLoaders/actions/dataLoaders.ts
@@ -445,7 +445,7 @@ export const generateTelegrafToken = (configID: string) => async (
 
     if (bucketName === '') {
       throw new Error(
-        'A token cannot be generated without a corresponding bucket; no buckets are assigned'
+        'An API token cannot be generated without a corresponding bucket; no buckets are assigned'
       )
     }
 

--- a/src/dataLoaders/components/verifyStep/TelegrafInstructions.tsx
+++ b/src/dataLoaders/components/verifyStep/TelegrafInstructions.tsx
@@ -44,7 +44,7 @@ class TelegrafInstructions extends PureComponent<Props> {
         <p>
           Your API token is required for pushing data into InfluxDB. You can
           copy the following command to your terminal window to set an
-          environment variable with your token.
+          environment variable with your API token.
         </p>
         <TokenCodeSnippet token={exportToken} configID={configID} label="CLI" />
         <h5>3. Start Telegraf</h5>

--- a/src/pageLayout/constants/navigationHierarchy.ts
+++ b/src/pageLayout/constants/navigationHierarchy.ts
@@ -74,7 +74,7 @@ export const generateNavItems = (): NavItem[] => {
         {
           id: 'tokens',
           testID: 'nav-subitem-tokens',
-          label: 'Tokens',
+          label: 'API Tokens',
           link: `${orgPrefix}/load-data/tokens`,
         },
       ],

--- a/src/settings/components/LoadDataNavigation.tsx
+++ b/src/settings/components/LoadDataNavigation.tsx
@@ -52,7 +52,7 @@ class LoadDataNavigation extends PureComponent<Props> {
         featureFlag: null,
       },
       {
-        text: 'Tokens',
+        text: 'API Tokens',
         id: 'tokens',
         cloudExclude: false,
         featureFlag: null,

--- a/src/shared/components/TokenCodeSnippet.tsx
+++ b/src/shared/components/TokenCodeSnippet.tsx
@@ -68,8 +68,8 @@ const TokenCodeSnippet: FC<Props> = ({
                 ? ComponentStatus.Default
                 : ComponentStatus.Disabled
             }
-            text="Generate New Token"
-            titleText="Generate New Token"
+            text="Generate New API Token"
+            titleText="Generate New API Token"
             icon={IconFont.Refresh}
             color={ComponentColor.Success}
             onClick={handleRefreshClick}

--- a/src/shared/copy/notifications.ts
+++ b/src/shared/copy/notifications.ts
@@ -965,12 +965,12 @@ export const removeTelegrafLabelFailed = (): Notification => ({
 
 export const authorizationsGetFailed = (): Notification => ({
   ...defaultErrorNotification,
-  message: 'Failed to get tokens',
+  message: 'Failed to get API tokens',
 })
 
 export const authorizationCreateSuccess = (): Notification => ({
   ...defaultSuccessNotification,
-  message: 'Token was created successfully',
+  message: 'API token was created successfully',
 })
 
 export const passwordResetSuccessfully = (message: string): Notification => ({
@@ -982,7 +982,7 @@ export const passwordResetSuccessfully = (message: string): Notification => ({
 export const authorizationCreateFailed = (
   errorMessage?: string
 ): Notification => {
-  const defaultMsg = 'Failed to create tokens'
+  const defaultMsg = 'Failed to create API tokens'
   const message = errorMessage ? `${defaultMsg}: ${errorMessage}` : defaultMsg
   return {
     ...defaultErrorNotification,
@@ -992,32 +992,32 @@ export const authorizationCreateFailed = (
 
 export const authorizationUpdateSuccess = (): Notification => ({
   ...defaultSuccessNotification,
-  message: 'Token was updated successfully',
+  message: 'API token was updated successfully',
 })
 
 export const authorizationUpdateFailed = (desc: string): Notification => ({
   ...defaultErrorNotification,
-  message: `Failed to update token: "${desc}"`,
+  message: `Failed to update API token: "${desc}"`,
 })
 
 export const authorizationDeleteSuccess = (): Notification => ({
   ...defaultSuccessNotification,
-  message: 'Token was deleted successfully',
+  message: 'API token was deleted successfully',
 })
 
 export const authorizationDeleteFailed = (desc: string): Notification => ({
   ...defaultErrorNotification,
-  message: `Failed to delete token: "${desc}"`,
+  message: `Failed to delete API token: "${desc}"`,
 })
 
 export const authorizationCopySuccess = (): Notification => ({
   ...defaultSuccessNotification,
-  message: 'Token has been copied to clipboard',
+  message: 'API token has been copied to clipboard',
 })
 
 export const authorizationCopyFailed = (): Notification => ({
   ...defaultErrorNotification,
-  message: 'Failed to copy token to clipboard',
+  message: 'Failed to copy API token to clipboard',
 })
 
 export const telegrafDeleteSuccess = (telegrafName: string): Notification => ({

--- a/src/shared/copy/notifications.ts
+++ b/src/shared/copy/notifications.ts
@@ -276,7 +276,7 @@ export const TelegrafConfigCreationError: Notification = {
 
 export const TokenCreationError: Notification = {
   ...defaultErrorNotification,
-  message: `Failed to create a new Telegraf Token`,
+  message: `Failed to create a new Telegraf API Token`,
 }
 
 //  Task Notifications

--- a/src/telegrafs/components/TelegrafOutputOverlay.tsx
+++ b/src/telegrafs/components/TelegrafOutputOverlay.tsx
@@ -40,7 +40,7 @@ const TELEGRAF_OUTPUT = ` [[outputs.influxdb_v2]]
   ##   ex: urls = ["https://us-west-2-1.aws.cloud2.influxdata.com"]
   urls = ["<%= server %>"]
 
-  ## Token for authentication.
+  ## API token for authentication.
   token = "<%= token %>"
 
   ## Organization is the name of the organization you wish to write to; must exist.
@@ -156,7 +156,9 @@ class TelegrafOutputOverlay extends PureComponent<Props> {
         <Overlay.Body>
           <p style={{marginTop: '-18px'}}>
             The $INFLUX_TOKEN can be generated on the
-            <Link to={`/orgs/${orgID}/load-data/tokens`}>&nbsp;Tokens tab</Link>
+            <Link to={`/orgs/${orgID}/load-data/tokens`}>
+              &nbsp;API Tokens tab
+            </Link>
             .
           </p>
           <p>{bucket_dd}</p>

--- a/src/writeData/clients/Arduino/initialize.example
+++ b/src/writeData/clients/Arduino/initialize.example
@@ -17,7 +17,7 @@ ESP8266WiFiMulti wifiMulti;
 #define WIFI_PASSWORD "PASSWORD"
 // InfluxDB v2 server url, e.g. https://eu-central-1-1.aws.cloud2.influxdata.com (Use: InfluxDB UI -> Load Data -> Client Libraries)
 #define INFLUXDB_URL "<%= server %>"
-// InfluxDB v2 server or cloud API authentication token (Use: InfluxDB UI -> Data -> Tokens -> <select token>)
+// InfluxDB v2 server or cloud API token (Use: InfluxDB UI -> Data -> API Tokens -> <select token>)
 #define INFLUXDB_TOKEN "<%= token %>"
 // InfluxDB v2 organization id (Use: InfluxDB UI -> User -> About -> Common Ids )
 #define INFLUXDB_ORG "<%= org %>"

--- a/src/writeData/clients/CSharp/initialize.example
+++ b/src/writeData/clients/CSharp/initialize.example
@@ -12,7 +12,7 @@ namespace Examples
   {
     public static async Task Main(string[] args)
     {
-      // You can generate a Token from the "Tokens Tab" in the UI
+      // You can generate an API token from the "API Tokens Tab" in the UI
       const string token = "<%= token %>";
       const string bucket = "<%= bucket %>";
       const string org = "<%= org %>";

--- a/src/writeData/clients/Go/initialize.example
+++ b/src/writeData/clients/Go/initialize.example
@@ -10,7 +10,7 @@ import (
 
 func main() {
   // Create a client
-  // You can generate a Token from the "Tokens Tab" in the UI
+  // You can generate an API Token from the "API Tokens Tab" in the UI
   client := influxdb2.NewClient("<%= server %>", "<%= token %>")
   // always close client at the end
   defer client.Close()

--- a/src/writeData/clients/Java/initialize.example
+++ b/src/writeData/clients/Java/initialize.example
@@ -15,7 +15,7 @@ import com.influxdb.query.FluxTable;
 public class InfluxDB2Example {
   public static void main(final String[] args) {
 
-    // You can generate a Token from the "Tokens Tab" in the UI
+    // You can generate an API token from the "API Tokens Tab" in the UI
     String token = "<%= token %>";
     String bucket = "<%= bucket %>";
     String org = "<%= org %>";

--- a/src/writeData/clients/Javascript/initialize.example
+++ b/src/writeData/clients/Javascript/initialize.example
@@ -1,6 +1,6 @@
 const {InfluxDB} = require('@influxdata/influxdb-client')
 
-// You can generate a Token from the "Tokens Tab" in the UI
+// You can generate an API token from the "API Tokens Tab" in the UI
 const token = '<%= token %>'
 const org = '<%= org %>'
 const bucket = '<%= bucket %>'

--- a/src/writeData/clients/Kotlin/initialize.example
+++ b/src/writeData/clients/Kotlin/initialize.example
@@ -12,7 +12,7 @@ import java.time.Instant
 
 fun main() = runBlocking {
 
-    // You can generate a Token from the "Tokens Tab" in the UI
+    // You can generate an API token from the "API Tokens Tab" in the UI
     val token = "<%= token %>"
     val org = "<%= org %>"
     val bucket = "<%= bucket %>"

--- a/src/writeData/clients/PHP/initialize.example
+++ b/src/writeData/clients/PHP/initialize.example
@@ -2,7 +2,7 @@ use InfluxDB2\Client;
 use InfluxDB2\Model\WritePrecision;
 use InfluxDB2\Point;
 
-# You can generate a Token from the "Tokens Tab" in the UI
+# You can generate an API token from the "API Tokens Tab" in the UI
 $token = '<%= token %>';
 $org = '<%= org %>';
 $bucket = '<%= bucket %>';

--- a/src/writeData/clients/Python/initialize.example
+++ b/src/writeData/clients/Python/initialize.example
@@ -3,7 +3,7 @@ from datetime import datetime
 from influxdb_client import InfluxDBClient, Point, WritePrecision
 from influxdb_client.client.write_api import SYNCHRONOUS
 
-# You can generate a Token from the "Tokens Tab" in the UI
+# You can generate an API token from the "API Tokens Tab" in the UI
 token = "<%= token %>"
 org = "<%= org %>"
 bucket = "<%= bucket %>"

--- a/src/writeData/clients/R/initialize.example
+++ b/src/writeData/clients/R/initialize.example
@@ -1,7 +1,7 @@
 library("influxdbclient")
 
-# You can generate a Token from the "Tokens Tab" in the UI
-token <- "<%= token %>"
+# You can generate an API token from the "API Tokens Tab" in the UI
+token = "<%= token %>"
 
 client <- InfluxDBClient$new(url = "<%= server %>",
     token = token,

--- a/src/writeData/clients/Ruby/initialize.example
+++ b/src/writeData/clients/Ruby/initialize.example
@@ -1,6 +1,6 @@
 require 'influxdb-client'
 
-# You can generate a Token from the "Tokens Tab" in the UI
+# You can generate an API token from the "API Tokens Tab" in the UI
 token = '<%= token %>'
 org = '<%= org %>'
 bucket = '<%= bucket %>'

--- a/src/writeData/clients/Scala/initialize.example
+++ b/src/writeData/clients/Scala/initialize.example
@@ -14,7 +14,7 @@ object InfluxDB2ScalaExample {
 
   def main(args: Array[String]): Unit = {
 
-    // You can generate a Token from the "Tokens Tab" in the UI
+    // You can generate an API token from the "API Tokens Tab" in the UI
     val token = "<%= token %>"
     val org = "<%= org %>"
 

--- a/src/writeData/components/WriteDataHelperBuckets.tsx
+++ b/src/writeData/components/WriteDataHelperBuckets.tsx
@@ -59,8 +59,8 @@ const WriteDataHelperBuckets: FC = () => {
     body = (
       <List
         backgroundColor={InfluxColors.Obsidian}
-        style={{height: '118px'}}
-        maxHeight="118px"
+        style={{height: '200px'}}
+        maxHeight="200px"
       >
         {buckets.map(b => (
           <List.Item

--- a/src/writeData/components/WriteDataHelperTokens.tsx
+++ b/src/writeData/components/WriteDataHelperTokens.tsx
@@ -25,7 +25,6 @@ import {getAll} from 'src/resources/selectors'
 
 // Types
 import {AppState, ResourceType, Authorization} from 'src/types'
-import {DEFAULT_TOKEN_DESCRIPTION} from 'src/dashboards/constants'
 
 import GenerateTokenDropdown from 'src/authorizations/components/GenerateTokenDropdown'
 
@@ -89,7 +88,7 @@ const WriteDataHelperTokens: FC = () => {
             wrapText={true}
             gradient={Gradients.GundamPilot}
           >
-            {t.description || DEFAULT_TOKEN_DESCRIPTION}
+            {t.description}
           </List.Item>
         ))}
       </List>

--- a/src/writeData/components/WriteDataHelperTokens.tsx
+++ b/src/writeData/components/WriteDataHelperTokens.tsx
@@ -18,6 +18,7 @@ import {
 
 // Constants
 import {DOCS_URL_VERSION} from 'src/shared/constants/fluxFunctions'
+import {DEFAULT_TOKEN_DESCRIPTION} from 'src/dashboards/constants'
 
 // Utils
 import {getAll} from 'src/resources/selectors'
@@ -55,7 +56,7 @@ const WriteDataHelperTokens: FC = () => {
           target="_blank"
           rel="noreferrer"
         >
-          Tokens
+          API Tokens
         </a>
       </span>
     </EmptyState>
@@ -88,7 +89,7 @@ const WriteDataHelperTokens: FC = () => {
             wrapText={true}
             gradient={Gradients.GundamPilot}
           >
-            {t.description}
+            {t.description || DEFAULT_TOKEN_DESCRIPTION}
           </List.Item>
         ))}
       </List>


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/2199

Along with https://github.com/influxdata/docs-v2/pull/2929 this changes anywhere we display the text tokens to be API token

It also fixes an issue with the heights of the token/bucket selector on the client libs page.
