### PR TITLE
feat: make date time formatter hourCycle h23; minor refactor

### DIFF
--- a/src/utils/datetime/formatters.test.ts
+++ b/src/utils/datetime/formatters.test.ts
@@ -71,7 +71,7 @@ describe('the DateTime formatter', () => {
       expect(formatter.format(date)).toBe(`1983-07-04 ${hourUTC24}:00:00`)
     })
 
-    it('formats DateTimes in the default time YYYY-MM-DD HH:mm:ss in UTC, for midnight timestamp', () => {
+    it('formats DateTimes in the default time YYYY-MM-DD HH:mm:ss in UTC, format midnight as 00:00 not 24:00', () => {
       const date = new Date(timestamp)
       date.setHours(date.getHours() + 4) // 20:00 + 4 hrs = Midnight
       const formatter = createDateTimeFormatter('YYYY-MM-DD HH:mm:ss', 'UTC')

--- a/src/utils/datetime/formatters.test.ts
+++ b/src/utils/datetime/formatters.test.ts
@@ -71,6 +71,13 @@ describe('the DateTime formatter', () => {
       expect(formatter.format(date)).toBe(`1983-07-04 ${hourUTC24}:00:00`)
     })
 
+    it('formats DateTimes in the default time YYYY-MM-DD HH:mm:ss in UTC, for midnight timestamp', () => {
+      const date = new Date(timestamp)
+      date.setHours(date.getHours() + 4) // 20:00 + 4 hrs = Midnight
+      const formatter = createDateTimeFormatter('YYYY-MM-DD HH:mm:ss', 'UTC')
+      expect(formatter.format(date)).toBe(`1983-07-05 00:00:00`)
+    })
+
     it('formats DateTimes in the format, YYYY-MM-DD in UTC', () => {
       const date = new Date(timestamp)
       const formatter = createDateTimeFormatter('YYYY-MM-DD', 'UTC')

--- a/src/utils/datetime/formatters.ts
+++ b/src/utils/datetime/formatters.ts
@@ -3,7 +3,7 @@
 import {TimeZone} from 'src/types'
 
 const dateTimeOptions: any = {
-  hour12: true,
+  hourCycle: 'h23',
   day: '2-digit',
   month: '2-digit',
   year: 'numeric',
@@ -13,7 +13,7 @@ const dateTimeOptions: any = {
 }
 
 const timeOptions: any = {
-  hour12: true,
+  hourCycle: 'h23',
   hour: 'numeric',
   minute: 'numeric',
   second: 'numeric',
@@ -72,7 +72,6 @@ export const createDateTimeFormatter = (
     case 'YYYY-MM-DD': {
       const options = {
         ...dateTimeOptions,
-        hour12: false,
       }
 
       if (timeZone === 'UTC') {
@@ -101,6 +100,7 @@ export const createDateTimeFormatter = (
     case 'YYYY-MM-DD hh:mm:ss a': {
       const options = {
         ...dateTimeOptions,
+        hour12: true,
       }
 
       if (timeZone === 'UTC') {
@@ -130,6 +130,7 @@ export const createDateTimeFormatter = (
       const options = {
         ...dateTimeOptions,
         timeZoneName: 'short',
+        hour12: true,
       }
 
       if (timeZone === 'UTC') {
@@ -159,7 +160,6 @@ export const createDateTimeFormatter = (
     case 'YYYY-MM-DD HH:mm:ss': {
       const options = {
         ...dateTimeOptions,
-        hour12: false,
       }
 
       if (timeZone === 'UTC') {
@@ -189,7 +189,6 @@ export const createDateTimeFormatter = (
       const options = {
         ...dateTimeOptions,
         fractionalSecondDigits: 3,
-        hour12: false,
       }
 
       if (timeZone === 'UTC') {
@@ -218,7 +217,6 @@ export const createDateTimeFormatter = (
     case 'YYYY-MM-DD HH:mm': {
       const options = {
         ...dateTimeOptions,
-        hour12: false,
       }
 
       if (timeZone === 'UTC') {
@@ -248,7 +246,6 @@ export const createDateTimeFormatter = (
       const options = {
         ...dateTimeOptions,
         fractionalSecondDigits: 3,
-        hour12: false,
       }
 
       if (timeZone === 'UTC') {
@@ -278,6 +275,7 @@ export const createDateTimeFormatter = (
       const options = {
         ...dateTimeOptions,
         fractionalSecondDigits: 3,
+        hour12: true,
       }
 
       if (timeZone === 'UTC') {
@@ -306,7 +304,6 @@ export const createDateTimeFormatter = (
     case 'MM/DD/YYYY HH:mm:ss.sss': {
       const options = {
         ...dateTimeOptions,
-        hour12: false,
         fractionalSecondDigits: 3,
       }
 
@@ -337,6 +334,7 @@ export const createDateTimeFormatter = (
       const options = {
         ...dateTimeOptions,
         fractionalSecondDigits: 3,
+        hour12: true,
       }
 
       if (timeZone === 'UTC') {
@@ -365,7 +363,6 @@ export const createDateTimeFormatter = (
     case 'YYYY/MM/DD HH:mm:ss': {
       const options = {
         ...dateTimeOptions,
-        hour12: false,
       }
 
       if (timeZone === 'UTC') {
@@ -394,6 +391,7 @@ export const createDateTimeFormatter = (
     case 'YYYY/MM/DD hh:mm:ss a': {
       const options = {
         ...dateTimeOptions,
+        hour12: true,
       }
 
       if (timeZone === 'UTC') {
@@ -426,7 +424,6 @@ export const createDateTimeFormatter = (
         ...dateTimeOptions,
         month: 'long',
         day: 'numeric',
-        hour12: false,
       }
 
       if (timeZone === 'UTC') {
@@ -457,6 +454,7 @@ export const createDateTimeFormatter = (
         ...dateTimeOptions,
         month: 'long',
         day: 'numeric',
+        hour12: true,
       }
 
       if (timeZone === 'UTC') {
@@ -488,7 +486,6 @@ export const createDateTimeFormatter = (
         month: 'long',
         day: 'numeric',
         weekday: 'long',
-        hour12: false,
       }
 
       if (timeZone === 'UTC') {
@@ -520,6 +517,7 @@ export const createDateTimeFormatter = (
         month: 'long',
         day: 'numeric',
         weekday: 'long',
+        hour12: true,
       }
 
       if (timeZone === 'UTC') {
@@ -550,7 +548,6 @@ export const createDateTimeFormatter = (
     case 'HH:mm': {
       const options = {
         ...timeOptions,
-        hour12: false,
       }
 
       if (timeZone === 'UTC') {
@@ -579,6 +576,7 @@ export const createDateTimeFormatter = (
     case 'hh:mm a': {
       const options = {
         ...timeOptions,
+        hour12: true,
       }
 
       if (timeZone === 'UTC') {
@@ -607,7 +605,6 @@ export const createDateTimeFormatter = (
     case 'HH:mm:ss': {
       const options = {
         ...timeOptions,
-        hour12: false,
       }
 
       if (timeZone === 'UTC') {
@@ -636,6 +633,7 @@ export const createDateTimeFormatter = (
     case 'hh:mm:ss a': {
       const options = {
         ...timeOptions,
+        hour12: true,
       }
 
       if (timeZone === 'UTC') {
@@ -664,7 +662,6 @@ export const createDateTimeFormatter = (
     case 'HH:mm:ss ZZ': {
       const options = {
         ...timeOptions,
-        hour12: false,
         timeZoneName: 'short',
       }
 
@@ -695,6 +692,7 @@ export const createDateTimeFormatter = (
       const options = {
         ...timeOptions,
         timeZoneName: 'short',
+        hour12: true,
       }
 
       if (timeZone === 'UTC') {
@@ -723,7 +721,6 @@ export const createDateTimeFormatter = (
     case 'HH:mm:ss.sss': {
       const options = {
         ...timeOptions,
-        hour12: false,
         fractionalSecondDigits: 3,
       }
 
@@ -754,6 +751,7 @@ export const createDateTimeFormatter = (
       const options = {
         ...timeOptions,
         fractionalSecondDigits: 3,
+        hour12: true,
       }
 
       if (timeZone === 'UTC') {


### PR DESCRIPTION
Closes #2202

This PR adds the functionality to make the date time formatter's hourCycle to be h23. Currently by default, its h24, which means the time formatting formats in the range : `01:00 - 24:59` 

The more familiar one, h23, formats it from `00:00 - 23:59`. This was the app's default formatting as well when using `momentjs`

Some reviewer notes: 

* I refactored the settings for the formatter, previously, the `dateTimeOptions` had the following parameters:

```
const dateTimeOptions: any = {
  hour12: true,
  day: '2-digit',
  month: '2-digit',
  year: 'numeric',
  hour: 'numeric',
  minute: 'numeric',
  second: 'numeric',
}
```

Notice, the `hour12`, set to `true` by default, this felt like it was going against our `DEFAULT_TIME_FORMAT` which says 24h is the default. So instead of turning all the `hour12` to `false` where 24 hour was needed, I turned on 24 hour by default, and explicitly added `hour12: true` where needed.


--

Screenshot example, when we use moment this is what the formatting looks like: 

<img width="678" alt="Screen Shot 2021-08-01 at 7 06 42 PM" src="https://user-images.githubusercontent.com/18511823/127782545-2d287105-8582-4d5b-8b13-d194dcff81af.png">

When we switch it out with the existing, in progress date-time formatter, the same time looks like this: 


<img width="437" alt="Screen Shot 2021-08-01 at 7 21 54 PM" src="https://user-images.githubusercontent.com/18511823/127782900-e4f8a44a-d87f-4103-85ee-85da903cc74e.png">
