### PR TITLE
fix: Add Secrets to expanded left nav

### DIFF
--- a/src/pageLayout/constants/navigationHierarchy.ts
+++ b/src/pageLayout/constants/navigationHierarchy.ts
@@ -156,6 +156,13 @@ export const generateNavItems = (): NavItem[] => {
           label: 'Labels',
           link: `${orgPrefix}/settings/labels`,
         },
+        {
+          id: 'secrets',
+          enabled: () => isFlagEnabled('secretsUI'),
+          testID: 'nav-subitem-secrets',
+          label: 'Secrets',
+          link: `${orgPrefix}/settings/secrets`,
+        },
       ],
     },
     {


### PR DESCRIPTION
Closes #2211 

There's an expanded view of the left navigation area.  This adds the Secrets functionality to show there if the appropriate feature flag is enabled.
