### PR TITLE
chore: wrap the flux parser in a try catch so panics dont crash the app

### DIFF
--- a/src/flows/pipes/RawFluxEditor/index.ts
+++ b/src/flows/pipes/RawFluxEditor/index.ts
@@ -49,20 +49,23 @@ export default register => {
       ],
     },
     generateFlux: (pipe, create, append) => {
-      const ast = parse(pipe.queries[pipe.activeQuery].text)
-      _walk(ast, node => !!Object.keys(node.comments || {}).length).forEach(
-        node => {
-          delete node.comments
+      try {
+        const ast = parse(pipe.queries[pipe.activeQuery].text)
+        _walk(ast, node => !!Object.keys(node.comments || {}).length).forEach(
+          node => {
+            delete node.comments
+          }
+        )
+        const text = format_from_js_file(ast)
+        if (!text.length) {
+          return
         }
-      )
-      const text = format_from_js_file(ast)
 
-      if (!text.length) {
+        create(text)
+        append(`__CURRENT_RESULT__ |> limit(n: 100)`)
+      } catch {
         return
       }
-
-      create(text)
-      append(`__CURRENT_RESULT__ |> limit(n: 100)`)
     },
   })
 }


### PR DESCRIPTION
Closes #2205
 
DON'T PANIC

I can't actually say if this resolves ALL issues, I feel like we should add some error boundaries on panels just to make sure that things aren't inoperable when a panic or error is returned but this resolves the case that a broken flux query broke the notebook