### PR TITLE
feat: added clone functionality to TokenRow

### DIFF
--- a/src/authorizations/components/redesigned/TokenList.tsx
+++ b/src/authorizations/components/redesigned/TokenList.tsx
@@ -83,13 +83,8 @@ export class TokenList extends PureComponent<Props, State> {
         key={auth.id}
         auth={auth}
         onClickDescription={this.handleClickDescription}
-        onClone={this.handleClone}
       />
     ))
-  }
-
-  private handleClone = () => {
-    // clone functionality coming soon!
   }
 
   private handleDismissOverlay = () => {

--- a/src/authorizations/components/redesigned/TokenRow.tsx
+++ b/src/authorizations/components/redesigned/TokenRow.tsx
@@ -7,6 +7,7 @@ import {createDateTimeFormatter} from 'src/utils/datetime/formatters'
 import {
   deleteAuthorization,
   updateAuthorization,
+  createAuthorization,
 } from 'src/authorizations/actions/thunks'
 
 // Components
@@ -25,18 +26,18 @@ import {
 import {Context} from 'src/clockface'
 
 // Types
-import {Authorization} from 'src/types'
+import {Authorization, AppState} from 'src/types'
 import {
   DEFAULT_TOKEN_DESCRIPTION,
   UPDATED_AT_TIME_FORMAT,
 } from 'src/dashboards/constants'
 
 import {relativeTimestampFormatter} from 'src/shared/utils/relativeTimestampFormatter'
+import { incrementCloneName } from 'src/utils/naming'
 
 interface OwnProps {
   auth: Authorization
   onClickDescription: (authID: string) => void
-  onClone: (authID: string) => void
 }
 
 type ReduxProps = ConnectedProps<typeof connector>
@@ -110,7 +111,16 @@ class TokensRow extends PureComponent<Props> {
   }
 
   private handleClone = () => {
-    this.props.onClone(this.props.auth.id)
+    const {description} = this.props.auth
+
+    const alltokenNames = Object.values(this.props.authorizations).map(
+      auth => auth.description
+    )
+    
+    this.props.onClone({
+      ...this.props.auth,
+      description: incrementCloneName(alltokenNames, description)
+    })
   }
 
   private handleClickDescription = () => {
@@ -124,11 +134,18 @@ class TokensRow extends PureComponent<Props> {
   }
 }
 
+const mstp = (state: AppState) => {
+  
+  const authorizations = state.resources.tokens.byID
+  return {authorizations}
+}
+
 const mdtp = {
   onDelete: deleteAuthorization,
   onUpdate: updateAuthorization,
+  onClone: createAuthorization,
 }
 
-const connector = connect(null, mdtp)
+const connector = connect(mstp, mdtp)
 
 export const TokenRow = connector(TokensRow)

--- a/src/authorizations/components/redesigned/TokenRow.tsx
+++ b/src/authorizations/components/redesigned/TokenRow.tsx
@@ -33,7 +33,7 @@ import {
 } from 'src/dashboards/constants'
 
 import {relativeTimestampFormatter} from 'src/shared/utils/relativeTimestampFormatter'
-import { incrementCloneName } from 'src/utils/naming'
+import {incrementCloneName} from 'src/utils/naming'
 
 interface OwnProps {
   auth: Authorization
@@ -116,10 +116,10 @@ class TokensRow extends PureComponent<Props> {
     const alltokenNames = Object.values(this.props.authorizations).map(
       auth => auth.description
     )
-    
+
     this.props.onClone({
       ...this.props.auth,
-      description: incrementCloneName(alltokenNames, description)
+      description: incrementCloneName(alltokenNames, description),
     })
   }
 
@@ -135,7 +135,6 @@ class TokensRow extends PureComponent<Props> {
 }
 
 const mstp = (state: AppState) => {
-  
   const authorizations = state.resources.tokens.byID
   return {authorizations}
 }

--- a/src/authorizations/components/redesigned/TokenRow.tsx
+++ b/src/authorizations/components/redesigned/TokenRow.tsx
@@ -113,13 +113,13 @@ class TokensRow extends PureComponent<Props> {
   private handleClone = () => {
     const {description} = this.props.auth
 
-    const alltokenNames = Object.values(this.props.authorizations).map(
+    const allTokenDescriptions = Object.values(this.props.authorizations).map(
       auth => auth.description
     )
 
     this.props.onClone({
       ...this.props.auth,
-      description: incrementCloneName(alltokenNames, description),
+      description: incrementCloneName(allTokenDescriptions, description),
     })
   }
 


### PR DESCRIPTION
Closes #1933 

When a user selects an existing token from the main tokens page and clicks Clone,
a new token is generated with the same resources and permissions as the existing token, with the following naming convention in its description: {description} (clone #)
<img width="1120" alt="Screen Shot 2021-08-02 at 6 30 28 PM" src="https://user-images.githubusercontent.com/66275100/127935868-1dfd98a4-34cf-45b6-8f7a-6a3da74671c1.png">
