### PR TITLE
fix(cloning): guard against whitespace being added to cloned resource names

### DIFF
--- a/src/utils/naming.test.ts
+++ b/src/utils/naming.test.ts
@@ -1,0 +1,17 @@
+import {incrementCloneName} from 'src/utils/naming'
+
+describe('The naming of a newly cloned resource', () => {
+  it('clones a resource with the same name', () => {
+    const namesList = ['duplicate this']
+    expect(incrementCloneName(namesList, 'duplicate this')).toBe(
+      'duplicate this (clone 1)'
+    )
+  })
+
+  it("clones a clone, but doesn't add any extra spaces", () => {
+    const namesList = ['duplicate this', 'duplicate this  (clone 1)']
+    expect(incrementCloneName(namesList, 'duplicate this  (clone 1)')).toBe(
+      'duplicate this (clone 2)'
+    )
+  })
+})

--- a/src/utils/naming.ts
+++ b/src/utils/naming.ts
@@ -23,11 +23,10 @@ export const incrementCloneName = (
 
   if (highestNumberedClone) {
     const newCloneNumber = highestNumberedClone + 1
-    return `${cloneName.replace(
-      /\(clone\s(\d)+\)/,
-      ''
-    )} (clone ${newCloneNumber})`
+    return `${cloneName
+      .replace(/\(clone\s(\d)+\)/, '')
+      .trim()} (clone ${newCloneNumber})`
   }
 
-  return `${cloneName} (clone 1)`
+  return `${cloneName.trim()} (clone 1)`
 }


### PR DESCRIPTION
Closes #2221
