### PR TITLE
refactor: replace moment in timeMachine/selector/index.ts

### DIFF
--- a/src/timeMachine/selectors/index.test.ts
+++ b/src/timeMachine/selectors/index.test.ts
@@ -35,7 +35,7 @@ describe('TimeMachine.Selectors.Index', () => {
   })
 
   const date = '2019-01-01'
-  const newYears = moment(date).valueOf()
+  const newYears = new Date(date).valueOf()
   it(`getStartTime should return ${newYears} when lower is ${date}`, () => {
     const timeRange = {
       type: custom,
@@ -54,7 +54,7 @@ describe('TimeMachine.Selectors.Index', () => {
     expect(getEndTime(timeRange)).toEqual(newYears)
   })
 
-  const now = moment().valueOf()
+  const now = new Date().valueOf()
   it(`getEndTime should return ${now} when upper is null and lower includes now()`, () => {
     expect(getEndTime(pastThirtyDaysTimeRange)).toBeGreaterThanOrEqual(now)
   })

--- a/src/timeMachine/selectors/index.ts
+++ b/src/timeMachine/selectors/index.ts
@@ -270,7 +270,7 @@ export const getStartTime = (timeRange: TimeRange) => {
   }
   switch (timeRange.type) {
     case 'custom':
-      return moment(timeRange.lower).valueOf()
+      return new Date(timeRange.lower).valueOf()
     case 'selectable-duration': {
       const startTime = new Date()
       startTime.setSeconds(startTime.getSeconds() - timeRange.seconds)
@@ -298,9 +298,9 @@ export const getEndTime = (timeRange: TimeRange): number => {
     return null
   }
   if (timeRange.type === 'custom') {
-    return moment(timeRange.upper).valueOf()
+    return new Date(timeRange.upper).valueOf()
   }
-  return moment().valueOf()
+  return new Date().valueOf()
 }
 
 export const getActiveTimeRange = (

--- a/src/timeMachine/selectors/index.ts
+++ b/src/timeMachine/selectors/index.ts
@@ -1,6 +1,5 @@
 // Libraries
 import memoizeOne from 'memoize-one'
-import moment from 'moment'
 import {get} from 'lodash'
 import {fromFlux, Table} from '@influxdata/giraffe'
 


### PR DESCRIPTION
Closes #2053

Part of #1844 


This PR removes `moment` from the timeMachine selectors.

We attempted this in another PR [#2054], here is what happened and why it didn't work:

* Our tests use `moment js` to test anything with time. The `Date` implementation of `Date.valueOf` is slightly different than `moment.valueOf`. To make the tests pass, I did a bunch of things to change timezones and time manipulation, which passed the tests, but was wrong. So that caused a bug in the production where we had empty spaces of graph visualizations. [[Slack conversation thread of bug]](https://influxdata.slack.com/archives/CLHATC50E/p1627583826386700)

This time, we replace the moment in the test as well, that way tests pass and the logic is correct as well. 

Screenshot. no blank spaces this time: 

<img width="1530" alt="Screen Shot 2021-08-03 at 10 27 09 AM" src="https://user-images.githubusercontent.com/18511823/128059971-8168bf82-6d03-4d7a-ad58-f898878a4417.png">

