### PR TITLE
fix: exit 3 bug in CI script

### DIFF
--- a/scripts/run-monitor-ci-tests.bash
+++ b/scripts/run-monitor-ci-tests.bash
@@ -215,8 +215,8 @@ do
 			if [ -n "${workflow_id}" ]; then
 				printf "\nSUCCESS: monitor-ci workflow with id ${workflow_id} passed: https://app.circleci.com/pipelines/github/influxdata/monitor-ci/${pipeline_number}/workflows/${workflow_id} \n"
 			else
-				# get the workflow_id of this failed required workflow
-				workflow_id=$(echo ${workflows} | jq -r --arg name "${required_workflow_name}" '.items | map(select(.name == $name and .status == "failed")) | .[].id')
+				# get the workflow_id of this failed required workflow (if there are multiple, get the most recent one)
+				workflow_id=$(echo ${workflows} | jq -r --arg name "${required_workflow_name}" '.items |= sort_by(.created_at) | .items | map(select(.name == $name and .status == "failed")) | .[-1].id')
 
 				# get the jobs that failed for this workflow
 				jobs=$(curl -s --request GET \


### PR DESCRIPTION
This should fix the "exit status 3" bug in our pipeline. The issue was that when you retried the pipeline more than once, it would find multiple failed workflows with the same name when it was expecting to only find one. The solution was to grab the most recent failed workflow.

![image](https://user-images.githubusercontent.com/6411855/128102075-4d8b43df-2582-41f4-b36a-3a87ac5d8d81.png)
