### PR TITLE
test: unchain the steps to create an annotation

### DIFF
--- a/cypress/e2e/util/annotationsSetup.ts
+++ b/cypress/e2e/util/annotationsSetup.ts
@@ -92,8 +92,9 @@ export const addAnnotation = (cy: Cypress.Chainable) => {
   })
 
   cy.getByTestID('overlay--container').within(() => {
+    cy.getByTestID('edit-annotation-message').should('be.visible')
+
     cy.getByTestID('edit-annotation-message')
-      .should('be.visible')
       .click()
       .focused()
       .type('im a hippopotamus')


### PR DESCRIPTION
This attempts to address this type of e2e test failure: https://app.circleci.com/pipelines/github/influxdata/monitor-ci/3581/workflows/85bfb072-17ec-4630-b264-9f56bb5ebee5/jobs/41635

note: this leaves `.focused()` in place to see if it has an influence on flakiness in chaining.