### PR TITLE
fix: update limits func to account for errors and status

### DIFF
--- a/src/cloud/actions/limits.ts
+++ b/src/cloud/actions/limits.ts
@@ -277,8 +277,13 @@ export const getAssetLimits = () => async (dispatch, getState: GetState) => {
   try {
     const org = getOrg(getState())
 
-    const limits = await getOrgsLimits({orgID: org.id})
-    dispatch(setLimits(limits))
+    const resp = await getOrgsLimits({orgID: org.id})
+
+    if (resp.status !== 200) {
+      throw new Error(resp.data.message)
+    }
+
+    dispatch(setLimits(resp.data))
     dispatch(setLimitsStatus(RemoteDataState.Done))
   } catch (error) {
     console.error(error)

--- a/src/cloud/actions/limits.ts
+++ b/src/cloud/actions/limits.ts
@@ -238,7 +238,13 @@ export const getReadWriteCardinalityLimits = () => async (
   try {
     const org = getOrg(getState())
 
-    const limits = await getOrgsLimitsStatus({orgID: org.id})
+    const resp = await getOrgsLimitsStatus({orgID: org.id})
+
+    if (resp.status !== 200) {
+      throw new Error(resp.data.message)
+    }
+
+    const limits = resp.data
 
     if (limits.read.status === 'exceeded') {
       dispatch(notify(readLimitReached()))


### PR DESCRIPTION
This addresses an issue that cropped up with the recent work to centralize queries in yaml definitions. The previous implementation wasn't refactored for status checks and assigned the response as the limits data, rather than the returned data as the limits data.