### PR TITLE
fix: SimpleTable resizing bug that creates identical pages

### DIFF
--- a/src/visualization/context/pagination.tsx
+++ b/src/visualization/context/pagination.tsx
@@ -63,7 +63,7 @@ export const PaginationProvider: FC<PaginationProviderProps> = ({
 
   const previous = useCallback(() => {
     setOffset(calcPrevPageOffset(offset, size))
-  }, [offset, size, setOffset]) 
+  }, [offset, size, setOffset])
 
   const setPage = useCallback(
     (page: number) => {

--- a/src/visualization/context/pagination.tsx
+++ b/src/visualization/context/pagination.tsx
@@ -59,17 +59,17 @@ export const PaginationProvider: FC<PaginationProviderProps> = ({
     } else {
       setOffset(offset + size)
     }
-  }, [offset, size, setOffset])
+  }, [offset, size, setOffset]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const previous = useCallback(() => {
     setOffset(calcPrevPageOffset(offset, size))
-  }, [offset, size, setOffset])
+  }, [offset, size, setOffset]) 
 
   const setPage = useCallback(
     (page: number) => {
       setOffset(calcOffset(page, maxSize, total))
     },
-    [offset, maxSize, setOffset]
+    [offset, maxSize, setOffset] // eslint-disable-line react-hooks/exhaustive-deps
   )
 
   return (

--- a/src/visualization/types/SimpleTable/PagedTable.tsx
+++ b/src/visualization/types/SimpleTable/PagedTable.tsx
@@ -278,21 +278,21 @@ const PagedTable: FC<Props> = ({result, properties}) => {
 
   useEffect(() => {
     setSize(size)
-  }, [size])
+  }, [size]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     setMaxSize(measurePage(result, 0, height))
-  }, [height, result])
+  }, [height, result]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     setPage(1)
-  }, [result])
+  }, [result]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (maxSize) {
       setTotalPages(Math.ceil((result?.table?.length ?? 0) / maxSize))
     }
-  }, [maxSize])
+  }, [maxSize]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const inner =
     !!size &&

--- a/src/visualization/types/SimpleTable/PagedTable.tsx
+++ b/src/visualization/types/SimpleTable/PagedTable.tsx
@@ -292,7 +292,7 @@ const PagedTable: FC<Props> = ({result, properties}) => {
     if (maxSize) {
       setTotalPages(Math.ceil((result?.table?.length ?? 0) / maxSize))
     }
-  }, [maxSize]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [maxSize, result]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const inner =
     !!size &&

--- a/src/visualization/types/SimpleTable/PagedTable.tsx
+++ b/src/visualization/types/SimpleTable/PagedTable.tsx
@@ -274,7 +274,7 @@ const PagedTable: FC<Props> = ({result, properties}) => {
   }, [result, offset, height])
   const tables = useMemo(() => {
     return subsetResult(result, offset, size, properties.showAll)
-  }, [result, offset, size])
+  }, [result, offset, size]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     setSize(size)

--- a/src/visualization/types/SimpleTable/PagedTable.tsx
+++ b/src/visualization/types/SimpleTable/PagedTable.tsx
@@ -281,20 +281,18 @@ const PagedTable: FC<Props> = ({result, properties}) => {
   }, [size])
 
   useEffect(() => {
-    if (size > maxSize) {
-      setMaxSize(size)
-    }
-  }, [size])
+    setMaxSize(measurePage(result, 0, height))
+  }, [height, result])
 
   useEffect(() => {
     setPage(1)
   }, [result])
 
   useEffect(() => {
-    if (size) {
-      setTotalPages(Math.ceil((result?.table?.length ?? 0) / size))
+    if (maxSize) {
+      setTotalPages(Math.ceil((result?.table?.length ?? 0) / maxSize))
     }
-  }, [height, result])
+  }, [maxSize])
 
   const inner =
     !!size &&


### PR DESCRIPTION
Closes #2170

## Context
The reason why there were duplicate pages with only a single row of data in #2170 is due to `setTotalPages(Math.ceil((result?.table?.length ?? 0) / size))`. Because `size` refers to how many rows are in the table not how many can fit, going to the last page where there is a partially filled table will cause the calculation to set the total number of pages to be much larger than what it should be. In the calculation of what rows appear on that page, if the page selected is out of the true bounds (meaning the math will result in a unexpectedly large offset), it will default it to show only the last row of data, which is what happened in #2170.

The change to setMaxSize has little to do with the issue, but it causes issues when resizing as well.

## Demo
https://user-images.githubusercontent.com/39343323/128261892-f73b1942-e2a5-4422-935a-2077e256e0ab.mov

## Warning
This fix also bring up another issue where the middle part of the pagination just disappears. However, it was concluded that it is most likely a clockface issue. This currently does not appear on production.

If the video is not render, then go here for the issue and a video in more detail. https://github.com/influxdata/clockface/issues/654

Uploading Screen Recording 2021-08-04 at 5.43.20 PM.mov…

