### PR TITLE
refactor: move DEFAULT_TIME_FORMAT to src/utils/datetime/constants

### DIFF
--- a/src/alerting/components/TimeTableField.tsx
+++ b/src/alerting/components/TimeTableField.tsx
@@ -2,7 +2,7 @@
 import React, {FC} from 'react'
 
 // Constants
-import {DEFAULT_TIME_FORMAT} from 'src/shared/constants'
+import {DEFAULT_TIME_FORMAT} from 'src/utils/datetime/constants'
 
 // Types
 import {StatusRow, NotificationRow} from 'src/types'

--- a/src/annotations/components/annotationForm/AnnotationForm.test.tsx
+++ b/src/annotations/components/annotationForm/AnnotationForm.test.tsx
@@ -10,7 +10,7 @@ import {
 import {fireEvent} from '@testing-library/react'
 import {createDateTimeFormatter} from 'src/utils/datetime/formatters'
 import {REQUIRED_ERROR} from 'src/annotations/components/annotationForm/AnnotationTimeInput'
-import {DEFAULT_TIME_FORMAT} from 'src/shared/constants'
+import {DEFAULT_TIME_FORMAT} from 'src/utils/datetime/constants'
 
 // setting 'now' as the first of march, 2021 at 11 am.
 // the clocks changed on march 14, btw

--- a/src/annotations/components/annotationForm/AnnotationForm.tsx
+++ b/src/annotations/components/annotationForm/AnnotationForm.tsx
@@ -34,7 +34,7 @@ import {ANNOTATION_FORM_WIDTH} from 'src/annotations/constants'
 
 // Style
 import 'src/annotations/components/annotationForm/annotationForm.scss'
-import {DEFAULT_TIME_FORMAT} from 'src/shared/constants'
+import {DEFAULT_TIME_FORMAT} from 'src/utils/datetime/constants'
 
 type AnnotationType = 'point' | 'range'
 

--- a/src/functions/components/FunctionRunLogRow.tsx
+++ b/src/functions/components/FunctionRunLogRow.tsx
@@ -6,7 +6,7 @@ import {IndexList} from '@influxdata/clockface'
 
 // Types
 import {FunctionRunLog} from 'src/client/managedFunctionsRoutes'
-import {DEFAULT_TIME_FORMAT} from 'src/shared/constants'
+import {DEFAULT_TIME_FORMAT} from 'src/utils/datetime/constants'
 import {FormattedDateTime} from 'src/utils/datetime/FormattedDateTime'
 
 const FunctionRunLogRow: FC<FunctionRunLog> = ({

--- a/src/functions/components/FunctionRunsRow.tsx
+++ b/src/functions/components/FunctionRunsRow.tsx
@@ -13,7 +13,7 @@ import FunctionRunLogsOverlay from 'src/functions/components/FunctionRunLogsOver
 
 // Types
 import {FunctionRun} from 'src/client/managedFunctionsRoutes'
-import {DEFAULT_TIME_FORMAT} from 'src/shared/constants'
+import {DEFAULT_TIME_FORMAT} from 'src/utils/datetime/constants'
 
 // Utils
 import {FormattedDateTime} from 'src/utils/datetime/FormattedDateTime'

--- a/src/shared/components/dateRangePicker/DatePicker.tsx
+++ b/src/shared/components/dateRangePicker/DatePicker.tsx
@@ -19,7 +19,7 @@ import {createDateTimeFormatter} from 'src/utils/datetime/formatters'
 import {getTimeZone} from 'src/dashboards/selectors'
 
 // Constants
-import {DEFAULT_TIME_FORMAT} from 'src/shared/constants'
+import {DEFAULT_TIME_FORMAT} from 'src/utils/datetime/constants'
 
 interface Props {
   label: string

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -41,8 +41,6 @@ export const EMPTY_ZUORA_PARAMS: CreditCardParams = {
 export const BALANCE_THRESHOLD_DEFAULT = 10
 export const MINIMUM_BALANCE_THRESHOLD = 1
 
-export const DEFAULT_TIME_FORMAT = 'YYYY-MM-DD HH:mm:ss'
-
 export const DROPDOWN_MENU_MAX_HEIGHT = 240
 
 export const PRESENTATION_MODE_ANIMATION_DELAY = 0 // In milliseconds.

--- a/src/tasks/components/RunLogRow.tsx
+++ b/src/tasks/components/RunLogRow.tsx
@@ -8,7 +8,7 @@ import {IndexList} from '@influxdata/clockface'
 import {LogEvent} from 'src/types'
 
 // DateTime
-import {DEFAULT_TIME_FORMAT} from 'src/shared/constants'
+import {DEFAULT_TIME_FORMAT} from 'src/utils/datetime/constants'
 import {FormattedDateTime} from 'src/utils/datetime/FormattedDateTime'
 
 interface Props {

--- a/src/tasks/components/TaskRunsCard.tsx
+++ b/src/tasks/components/TaskRunsCard.tsx
@@ -36,7 +36,7 @@ import {ComponentColor, Button} from '@influxdata/clockface'
 import {Task, AppState} from 'src/types'
 
 // DateTime
-import {DEFAULT_TIME_FORMAT} from 'src/shared/constants'
+import {DEFAULT_TIME_FORMAT} from 'src/utils/datetime/constants'
 import {FormattedDateTime} from 'src/utils/datetime/FormattedDateTime'
 interface PassedProps {
   task: Task

--- a/src/tasks/components/TaskRunsPage.test.tsx
+++ b/src/tasks/components/TaskRunsPage.test.tsx
@@ -15,7 +15,7 @@ import {mockAppState} from 'src/mockAppState'
 import {RemoteDataState} from 'src/types'
 
 // DateTime
-import {DEFAULT_TIME_FORMAT} from 'src/shared/constants'
+import {DEFAULT_TIME_FORMAT} from 'src/utils/datetime/constants'
 import {createDateTimeFormatter} from 'src/utils/datetime/formatters'
 
 const runIDs = [

--- a/src/tasks/components/TaskRunsRow.tsx
+++ b/src/tasks/components/TaskRunsRow.tsx
@@ -14,7 +14,7 @@ import {getLogs, retryTask, getRuns} from 'src/tasks/actions/thunks'
 // Types
 import {ComponentSize, ComponentColor, Button} from '@influxdata/clockface'
 import {AppState, Run} from 'src/types'
-import {DEFAULT_TIME_FORMAT} from 'src/shared/constants'
+import {DEFAULT_TIME_FORMAT} from 'src/utils/datetime/constants'
 
 interface OwnProps {
   taskID: string

--- a/src/utils/datetime/FormattedDateTime.test.tsx
+++ b/src/utils/datetime/FormattedDateTime.test.tsx
@@ -6,7 +6,7 @@ import {FormattedDateTime} from 'src/utils/datetime/FormattedDateTime'
 
 import {setTimeZone} from 'src/shared/actions/app'
 
-import {DEFAULT_TIME_FORMAT} from 'src/shared/constants/index'
+import {DEFAULT_TIME_FORMAT} from 'src/utils/datetime/constants'
 
 const timestamp = 426196800000 // july 4th, 1983
 

--- a/src/utils/datetime/README.md
+++ b/src/utils/datetime/README.md
@@ -6,7 +6,7 @@ Our UI's Canonical DateTime formatter. It comes with a component which is aware 
 
 ```ts
 import {FormattedDateTime} from 'src/utils/datetime/FormattedDateTime'
-import {DEFAULT_TIME_FORMAT} from 'src/shared/constants/index'
+import {DEFAULT_TIME_FORMAT} from 'src/utils/datetime/constants'
 
 const FunctionFella: ({timestamp: string}) => {
   return <FormattedDateTime format={DEFAULT_TIME_FORMAT} date={new Date(timestamp)} /> 

--- a/src/views/selectors/index.test.ts
+++ b/src/views/selectors/index.test.ts
@@ -1,5 +1,5 @@
 import {AppState} from 'src/types'
-import {DEFAULT_TIME_FORMAT} from 'src/shared/constants'
+import {DEFAULT_TIME_FORMAT} from 'src/utils/datetime/constants'
 import {getTimeFormatForView} from 'src/views/selectors/index'
 
 const MOCK_APP_STATE = ({

--- a/src/views/selectors/index.ts
+++ b/src/views/selectors/index.ts
@@ -3,7 +3,7 @@ import {AppState, View, ResourceType, Dashboard} from 'src/types'
 
 // Selectors
 import {getByID} from 'src/resources/selectors'
-import {DEFAULT_TIME_FORMAT} from 'src/shared/constants'
+import {DEFAULT_TIME_FORMAT} from 'src/utils/datetime/constants'
 
 export const getViewsForDashboard = (
   state: AppState,

--- a/src/visualization/types/SingleStat/view.tsx
+++ b/src/visualization/types/SingleStat/view.tsx
@@ -22,7 +22,7 @@ import {
 
 import './style.scss'
 import {AppSettingContext} from 'src/shared/contexts/app'
-import {DEFAULT_TIME_FORMAT} from 'src/shared/constants'
+import {DEFAULT_TIME_FORMAT} from 'src/utils/datetime/constants'
 
 // Selectors
 import {isAnnotationsModeEnabled} from 'src/annotations/selectors'

--- a/src/visualization/types/SingleStatWithLine/view.tsx
+++ b/src/visualization/types/SingleStatWithLine/view.tsx
@@ -42,10 +42,7 @@ import {generateThresholdsListHexs} from 'src/shared/constants/colorOperations'
 import {AppSettingContext} from 'src/shared/contexts/app'
 
 // Constants
-import {
-  VIS_THEME,
-  VIS_THEME_LIGHT,
-} from 'src/shared/constants'
+import {VIS_THEME, VIS_THEME_LIGHT} from 'src/shared/constants'
 import {DEFAULT_TIME_FORMAT} from 'src/utils/datetime/constants'
 import {DEFAULT_LINE_COLORS} from 'src/shared/constants/graphColorPalettes'
 import {INVALID_DATA_COPY} from 'src/visualization/constants'

--- a/src/visualization/types/SingleStatWithLine/view.tsx
+++ b/src/visualization/types/SingleStatWithLine/view.tsx
@@ -43,10 +43,10 @@ import {AppSettingContext} from 'src/shared/contexts/app'
 
 // Constants
 import {
-  DEFAULT_TIME_FORMAT,
   VIS_THEME,
   VIS_THEME_LIGHT,
 } from 'src/shared/constants'
+import {DEFAULT_TIME_FORMAT} from 'src/utils/datetime/constants'
 import {DEFAULT_LINE_COLORS} from 'src/shared/constants/graphColorPalettes'
 import {INVALID_DATA_COPY} from 'src/visualization/constants'
 

--- a/src/visualization/types/Table/transform.ts
+++ b/src/visualization/types/Table/transform.ts
@@ -2,7 +2,7 @@ import {get, findIndex, replace, indexOf, orderBy, drop, unzip} from 'lodash'
 import {fastMap, fastReduce, fastFilter} from 'src/utils/fast'
 
 import {CELL_HORIZONTAL_PADDING, DEFAULT_TIME_FIELD} from './constants'
-import {DEFAULT_TIME_FORMAT} from 'src/shared/constants'
+import {DEFAULT_TIME_FORMAT} from 'src/utils/datetime/constants'
 
 import {
   SortOptions,

--- a/src/visualization/utils/getFormatter.test.ts
+++ b/src/visualization/utils/getFormatter.test.ts
@@ -1,5 +1,5 @@
 import {getFormatter} from './getFormatter'
-import {DEFAULT_TIME_FORMAT} from '../../shared/constants'
+import {DEFAULT_TIME_FORMAT} from '../../utils/datetime/constants'
 import {Base, TimeZone} from '../../types'
 
 // July 4th, 1983, 20:00:00 UTC

--- a/src/visualization/utils/getFormatter.ts
+++ b/src/visualization/utils/getFormatter.ts
@@ -1,6 +1,7 @@
 import {resolveTimeFormat} from 'src/visualization/utils/timeFormat'
 import {Base, TimeZone} from 'src/types'
-import {VIS_SIG_DIGITS, DEFAULT_TIME_FORMAT} from 'src/shared/constants'
+import {VIS_SIG_DIGITS} from 'src/shared/constants'
+import {DEFAULT_TIME_FORMAT} from 'src/utils/datetime/constants'
 import {
   binaryPrefixFormatter,
   timeFormatter,

--- a/src/visualization/utils/timeFormat.ts
+++ b/src/visualization/utils/timeFormat.ts
@@ -1,4 +1,4 @@
-import {DEFAULT_TIME_FORMAT} from 'src/shared/constants'
+import {DEFAULT_TIME_FORMAT} from 'src/utils/datetime/constants'
 
 export const FORMAT_OPTIONS: Array<{text: string}> = [
   {text: DEFAULT_TIME_FORMAT}, // 'YYYY-MM-DD HH:mm:ss'


### PR DESCRIPTION
Closes #2254

A simple refactor so that cypress e2e tests can use the `DEFAULT_TIME_FORMAT`. 

<!-- Describe your proposed changes here. -->
