### PR TITLE
feat: adding schema type (implicit or explicit) to bucket page

### DIFF
--- a/src/buckets/components/BucketCardMeta.test.tsx
+++ b/src/buckets/components/BucketCardMeta.test.tsx
@@ -21,59 +21,56 @@ const setup = (
   return renderWithRedux(<BucketCardMeta bucket={bucket} />)
 }
 
-describe(
-  'bucket meta data card, ' + 'testing that the schema type shows up properly',
-  () => {
-    it('should show the explicit schema type', () => {
-      const {getByTestId} = setup('explicit', 'user', 'fooabc')
+describe('bucket meta data card, testing that the schema type shows up properly', () => {
+  it('should show the explicit schema type', () => {
+    const {getByTestId} = setup('explicit', 'user', 'fooabc')
 
-      const card = getByTestId('resourceCard-buckets-fooabc')
+    const card = getByTestId('resourceCard-buckets-fooabc')
 
-      const schemaType = getByTestId('bucket-schemaType')
-      // should be three nodes ( '30 days', <id string>. and 'explicit schema type')
+    const schemaType = getByTestId('bucket-schemaType')
+    // should be three nodes ( '30 days', <id string>. and 'explicit schema type')
 
-      expect(card.childElementCount).toEqual(3)
+    expect(card.childElementCount).toEqual(3)
 
-      expect(schemaType).toHaveTextContent('Explicit Schema Type')
-    })
+    expect(schemaType).toHaveTextContent('Explicit Schema Type')
+  })
 
-    it('should show "implicit" if the schema  is not there, with a user bucket', () => {
-      const {getByTestId} = setup(null, 'user', 'fooabc')
+  it('should show "implicit" if the schema  is not there, with a user bucket', () => {
+    const {getByTestId} = setup(null, 'user', 'fooabc')
 
-      const card = getByTestId('resourceCard-buckets-fooabc')
+    const card = getByTestId('resourceCard-buckets-fooabc')
 
-      // should be three nodes ('30 days', "id string....", and 'implicit schema type')
-      expect(card.childElementCount).toEqual(3)
+    // should be three nodes ('30 days', "id string....", and 'implicit schema type')
+    expect(card.childElementCount).toEqual(3)
 
-      expect(getByTestId('bucket-schemaType')).toHaveTextContent(
-        'Implicit Schema Type'
-      )
-    })
+    expect(getByTestId('bucket-schemaType')).toHaveTextContent(
+      'Implicit Schema Type'
+    )
+  })
 
-    it('should show the implicit schema type', () => {
-      const {getByTestId} = setup('implicit', 'system', 'fooabc')
+  it('should show the implicit schema type', () => {
+    const {getByTestId} = setup('implicit', 'system', 'fooabc')
 
-      const card = getByTestId('resourceCard-buckets-fooabc')
+    const card = getByTestId('resourceCard-buckets-fooabc')
 
-      const schemaType = getByTestId('bucket-schemaType')
-      // should be three nodes ('system', '30 days', and 'implicit schema type')
+    const schemaType = getByTestId('bucket-schemaType')
+    // should be three nodes ('system', '30 days', and 'implicit schema type')
 
-      expect(card.childElementCount).toEqual(3)
+    expect(card.childElementCount).toEqual(3)
 
-      expect(schemaType).toHaveTextContent('Implicit Schema Type')
-    })
+    expect(schemaType).toHaveTextContent('Implicit Schema Type')
+  })
 
-    it('should show "implicit" if the schema  is not there, with a system bucket', () => {
-      const {getByTestId} = setup(null, 'system', 'fooabc')
+  it('should show "implicit" if the schema  is not there, with a system bucket', () => {
+    const {getByTestId} = setup(null, 'system', 'fooabc')
 
-      const card = getByTestId('resourceCard-buckets-fooabc')
+    const card = getByTestId('resourceCard-buckets-fooabc')
 
-      // should be three nodes ('system', '30 days', 'implicit schema type')
-      expect(card.childElementCount).toEqual(3)
+    // should be three nodes ('system', '30 days', 'implicit schema type')
+    expect(card.childElementCount).toEqual(3)
 
-      expect(getByTestId('bucket-schemaType')).toHaveTextContent(
-        'Implicit Schema Type'
-      )
-    })
-  }
-)
+    expect(getByTestId('bucket-schemaType')).toHaveTextContent(
+      'Implicit Schema Type'
+    )
+  })
+})

--- a/src/buckets/components/BucketCardMeta.test.tsx
+++ b/src/buckets/components/BucketCardMeta.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react'
+import {renderWithRedux} from 'src/mockState'
+import BucketCardMeta from 'src/buckets/components/BucketCardMeta'
+import {OwnBucket} from '../../types'
+import {SchemaType} from '../../client'
+
+// setting 'now' as the first of march, 2021 at 11 am.
+// the clocks changed on march 14, btw
+const now = new Date('2021-03-01 11:00 am').getTime()
+
+const setup = (
+  schemaType: SchemaType,
+  type: 'user' | 'system' = 'system',
+  id: string
+) => {
+  const bucket: OwnBucket = {
+    id,
+    type,
+    schemaType,
+    readableRetention: '30 days',
+    name: 'testBucket',
+    retentionRules: [],
+    labels: [],
+  }
+
+  return renderWithRedux(<BucketCardMeta bucket={bucket} />)
+}
+
+describe(
+  'bucket meta data card, ' +
+    'testing that the schema type shows up (or disappears) properly',
+  () => {
+    it('should show the explicit schema type', () => {
+      const {getByTestId} = setup('explicit', 'user', 'fooabc')
+
+      const card = getByTestId('resourceCard-buckets-fooabc')
+
+      const schemaType = getByTestId('bucket-schemaType')
+      // should be three nodes ( '30 days', <id string>. and 'implicit schema type')
+
+     expect(card.childElementCount).toEqual(3)
+
+      expect(schemaType).toHaveTextContent('Explicit Schema Type')
+    })
+
+    it('should not show the schema if it is not there', () => {
+      const {queryByTestId, getByTestId} = setup(null, 'user', 'fooabc')
+
+      const card = getByTestId('resourceCard-buckets-fooabc')
+
+      // should be two nodes ('30 days', "id string....")
+      expect(card.childElementCount).toEqual(2)
+
+      expect(queryByTestId('bucket-schemaType')).toBeNull()
+    })
+
+    it('should show the implicit schema type', () => {
+      const {getByTestId} = setup('implicit', 'system', 'fooabc')
+
+      const card = getByTestId('resourceCard-buckets-fooabc')
+
+      const schemaType = getByTestId('bucket-schemaType')
+      // should be three nodes ('system', '30 days', and 'implicit schema type')
+
+      expect(card.childElementCount).toEqual(3)
+
+      expect(schemaType).toHaveTextContent('Implicit Schema Type')
+    })
+
+    it('should not show the schema if it is not there', () => {
+      const {queryByTestId, getByTestId} = setup(null, 'system', 'fooabc')
+
+      const card = getByTestId('resourceCard-buckets-fooabc')
+
+      // should be three nodes ('system', '30 days')
+      expect(card.childElementCount).toEqual(2)
+
+      expect(queryByTestId('bucket-schemaType')).toBeNull()
+    })
+  }
+)

--- a/src/buckets/components/BucketCardMeta.test.tsx
+++ b/src/buckets/components/BucketCardMeta.test.tsx
@@ -1,12 +1,8 @@
 import React from 'react'
 import {renderWithRedux} from 'src/mockState'
-import BucketCardMeta from 'src/buckets/components/BucketCardMeta'
+import BucketCardMeta from './BucketCardMeta'
 import {OwnBucket} from '../../types'
 import {SchemaType} from '../../client'
-
-// setting 'now' as the first of march, 2021 at 11 am.
-// the clocks changed on march 14, btw
-const now = new Date('2021-03-01 11:00 am').getTime()
 
 const setup = (
   schemaType: SchemaType,
@@ -22,13 +18,11 @@ const setup = (
     retentionRules: [],
     labels: [],
   }
-
   return renderWithRedux(<BucketCardMeta bucket={bucket} />)
 }
 
 describe(
-  'bucket meta data card, ' +
-    'testing that the schema type shows up (or disappears) properly',
+  'bucket meta data card, ' + 'testing that the schema type shows up properly',
   () => {
     it('should show the explicit schema type', () => {
       const {getByTestId} = setup('explicit', 'user', 'fooabc')
@@ -36,22 +30,24 @@ describe(
       const card = getByTestId('resourceCard-buckets-fooabc')
 
       const schemaType = getByTestId('bucket-schemaType')
-      // should be three nodes ( '30 days', <id string>. and 'implicit schema type')
+      // should be three nodes ( '30 days', <id string>. and 'explicit schema type')
 
-     expect(card.childElementCount).toEqual(3)
+      expect(card.childElementCount).toEqual(3)
 
       expect(schemaType).toHaveTextContent('Explicit Schema Type')
     })
 
-    it('should not show the schema if it is not there', () => {
-      const {queryByTestId, getByTestId} = setup(null, 'user', 'fooabc')
+    it('should show "implicit" if the schema  is not there, with a user bucket', () => {
+      const {getByTestId} = setup(null, 'user', 'fooabc')
 
       const card = getByTestId('resourceCard-buckets-fooabc')
 
-      // should be two nodes ('30 days', "id string....")
-      expect(card.childElementCount).toEqual(2)
+      // should be three nodes ('30 days', "id string....", and 'implicit schema type')
+      expect(card.childElementCount).toEqual(3)
 
-      expect(queryByTestId('bucket-schemaType')).toBeNull()
+      expect(getByTestId('bucket-schemaType')).toHaveTextContent(
+        'Implicit Schema Type'
+      )
     })
 
     it('should show the implicit schema type', () => {
@@ -67,15 +63,17 @@ describe(
       expect(schemaType).toHaveTextContent('Implicit Schema Type')
     })
 
-    it('should not show the schema if it is not there', () => {
-      const {queryByTestId, getByTestId} = setup(null, 'system', 'fooabc')
+    it('should show "implicit" if the schema  is not there, with a system bucket', () => {
+      const {getByTestId} = setup(null, 'system', 'fooabc')
 
       const card = getByTestId('resourceCard-buckets-fooabc')
 
-      // should be three nodes ('system', '30 days')
-      expect(card.childElementCount).toEqual(2)
+      // should be three nodes ('system', '30 days', 'implicit schema type')
+      expect(card.childElementCount).toEqual(3)
 
-      expect(queryByTestId('bucket-schemaType')).toBeNull()
+      expect(getByTestId('bucket-schemaType')).toHaveTextContent(
+        'Implicit Schema Type'
+      )
     })
   }
 )

--- a/src/buckets/components/BucketCardMeta.tsx
+++ b/src/buckets/components/BucketCardMeta.tsx
@@ -47,23 +47,13 @@ const BucketCardMeta: FC<Props> = ({bucket, notify}) => {
     </span>
   )
 
-  // need to create an array here; and add the schemaType if present
-  // if instead schemaType was null and had content if present, then if it is null
-  // the resourcecard.meta makes a 'null' child out of it and creates an extra space.
-  // so putting the type, if present into an array solves that problem.
-  const metaBlocks = [persistentBucketMeta]
+  // if the schema type isn't present just default to implicit
+  const schemaType = bucket?.schemaType || 'implicit'
 
-  // if the schema type isn't present it just doesn't get displayed.
-  // so future/current proof (works fine without it, works well with it)
-  const schemaType = bucket?.schemaType
-
-  if (schemaType) {
-    const schemaLabel = `${capitalize(schemaType)} Schema Type`
-    const schemaBlock = (
-      <span data-testid="bucket-schemaType"> {schemaLabel} </span>
-    )
-    metaBlocks.push(schemaBlock)
-  }
+  const schemaLabel = `${capitalize(schemaType)} Schema Type`
+  const schemaBlock = (
+    <span data-testid="bucket-schemaType"> {schemaLabel} </span>
+  )
 
   if (bucket.type === 'system') {
     return (
@@ -74,14 +64,16 @@ const BucketCardMeta: FC<Props> = ({bucket, notify}) => {
         >
           System Bucket
         </span>
-        {metaBlocks}
+        {persistentBucketMeta}
+        {schemaBlock}
       </ResourceCard.Meta>
     )
   }
 
   return (
     <ResourceCard.Meta testID={`resourceCard-buckets-${bucket.id}`}>
-      {metaBlocks}
+      {persistentBucketMeta}
+      {schemaBlock}
       <CopyToClipboard text={bucket.id} onCopy={handleCopyAttempt}>
         <span className="copy-bucket-id" title="Click to Copy to Clipboard">
           ID: {bucket.id}

--- a/src/buckets/components/BucketCardMeta.tsx
+++ b/src/buckets/components/BucketCardMeta.tsx
@@ -47,23 +47,41 @@ const BucketCardMeta: FC<Props> = ({bucket, notify}) => {
     </span>
   )
 
+  // need to create an array here; and add the schemaType if present
+  // if instead schemaType was null and had content if present, then if it is null
+  // the resourcecard.meta makes a 'null' child out of it and creates an extra space.
+  // so putting the type, if present into an array solves that problem.
+  const metaBlocks = [persistentBucketMeta]
+
+  // if the schema type isn't present it just doesn't get displayed.
+  // so future/current proof (works fine without it, works well with it)
+  const schemaType = bucket?.schemaType
+
+  if (schemaType) {
+    const schemaLabel = `${capitalize(schemaType)} Schema Type`
+    const schemaBlock = (
+      <span data-testid="bucket-schemaType"> {schemaLabel} </span>
+    )
+    metaBlocks.push(schemaBlock)
+  }
+
   if (bucket.type === 'system') {
     return (
-      <ResourceCard.Meta>
+      <ResourceCard.Meta testID={`resourceCard-buckets-${bucket.id}`}>
         <span
           className="system-bucket"
           key={`system-bucket-indicator-${bucket.id}`}
         >
           System Bucket
         </span>
-        {persistentBucketMeta}
+        {metaBlocks}
       </ResourceCard.Meta>
     )
   }
 
   return (
-    <ResourceCard.Meta>
-      {persistentBucketMeta}
+    <ResourceCard.Meta testID={`resourceCard-buckets-${bucket.id}`}>
+      {metaBlocks}
       <CopyToClipboard text={bucket.id} onCopy={handleCopyAttempt}>
         <span className="copy-bucket-id" title="Click to Copy to Clipboard">
           ID: {bucket.id}


### PR DESCRIPTION
 * added unit tests
 * if the data is not there, then  the  'implicit' type is the default

Closes #1578



