### PR TITLE
chore: undo resizing of the markdown

### DIFF
--- a/src/flows/pipes/Markdown/style.scss
+++ b/src/flows/pipes/Markdown/style.scss
@@ -10,6 +10,7 @@
 
 .flow-panel--body .markdown-editor--monaco {
   position: relative;
+  height: 100%;
 
   .react-monaco-editor-container {
     min-height: 100px;

--- a/src/flows/pipes/Markdown/style.scss
+++ b/src/flows/pipes/Markdown/style.scss
@@ -10,7 +10,10 @@
 
 .flow-panel--body .markdown-editor--monaco {
   position: relative;
-  height: 100%;
+
+  .react-monaco-editor-container {
+    min-height: 100px;
+  }
 }
 
 .flow-panel--markdown__placeholder.markdown-format {

--- a/src/flows/pipes/Markdown/style.scss
+++ b/src/flows/pipes/Markdown/style.scss
@@ -10,7 +10,6 @@
 
 .flow-panel--body .markdown-editor--monaco {
   position: relative;
-  height: 100%;
 
   .react-monaco-editor-container {
     min-height: 100px;

--- a/src/flows/pipes/Markdown/view.tsx
+++ b/src/flows/pipes/Markdown/view.tsx
@@ -37,7 +37,11 @@ const MarkdownPanel: FC<PipeProp> = ({Context}) => {
         />
       }
     >
-      <MarkdownMonacoEditor script={data.text} onChangeScript={handleChange} />
+      <MarkdownMonacoEditor
+        script={data.text}
+        onChangeScript={handleChange}
+        autogrow
+      />
     </Suspense>
   )
 

--- a/src/flows/pipes/Markdown/view.tsx
+++ b/src/flows/pipes/Markdown/view.tsx
@@ -51,11 +51,7 @@ const MarkdownPanel: FC<PipeProp> = ({Context}) => {
   }
 
   const controls = <MarkdownModeToggle />
-  return (
-    <Context controls={controls} resizes>
-      {panelContents}
-    </Context>
-  )
+  return <Context controls={controls}>{panelContents}</Context>
 }
 
 export default MarkdownPanel


### PR DESCRIPTION
Closes #2070 

Reenables autosizing of the markdown panel
