### PR TITLE
feat:  added clone token overlay

### DIFF
--- a/src/authorizations/actions/creators.ts
+++ b/src/authorizations/actions/creators.ts
@@ -1,17 +1,20 @@
 // Types
-import {RemoteDataState, AuthEntities} from 'src/types'
+import {RemoteDataState, AuthEntities, Authorization} from 'src/types'
 import {NormalizedSchema} from 'normalizr'
 
 export const SET_AUTH = 'SET_AUTH'
 export const ADD_AUTH = 'ADD_AUTH'
 export const EDIT_AUTH = 'EDIT_AUTH'
 export const REMOVE_AUTH = 'REMOVE_AUTH'
+export const SET_CURRENT_AUTH = 'SET_CURRENT_AUTH'
 
 export type Action =
   | ReturnType<typeof setAuthorizations>
   | ReturnType<typeof addAuthorization>
   | ReturnType<typeof editAuthorization>
   | ReturnType<typeof removeAuthorization>
+  | ReturnType<typeof setCurrentAuthorization>
+
 
 export const setAuthorizations = (
   status: RemoteDataState,
@@ -44,3 +47,13 @@ export const removeAuthorization = (id: string) =>
     type: REMOVE_AUTH,
     id,
   } as const)
+
+export const setCurrentAuthorization = (
+  status: RemoteDataState,
+  item?: Authorization
+  ) =>
+    ({
+      type: SET_CURRENT_AUTH,
+      status,
+      item,
+    } as const)

--- a/src/authorizations/actions/creators.ts
+++ b/src/authorizations/actions/creators.ts
@@ -15,7 +15,6 @@ export type Action =
   | ReturnType<typeof removeAuthorization>
   | ReturnType<typeof setCurrentAuthorization>
 
-
 export const setAuthorizations = (
   status: RemoteDataState,
   schema?: NormalizedSchema<AuthEntities, string[]>
@@ -51,9 +50,9 @@ export const removeAuthorization = (id: string) =>
 export const setCurrentAuthorization = (
   status: RemoteDataState,
   item?: Authorization
-  ) =>
-    ({
-      type: SET_CURRENT_AUTH,
-      status,
-      item,
-    } as const)
+) =>
+  ({
+    type: SET_CURRENT_AUTH,
+    status,
+    item,
+  } as const)

--- a/src/authorizations/actions/thunks.ts
+++ b/src/authorizations/actions/thunks.ts
@@ -15,6 +15,7 @@ import {
   addAuthorization,
   setAuthorizations,
   removeAuthorization,
+  setCurrentAuthorization,
 } from 'src/authorizations/actions/creators'
 import {notify} from 'src/shared/actions/notifications'
 
@@ -105,7 +106,10 @@ export const createAuthorization = (auth: Authorization) => async (
       authSchema
     )
 
+    const tokensNames = Object.keys(newAuth.entities.tokens);
+
     dispatch(addAuthorization(newAuth))
+    dispatch(setCurrentAuthorization(RemoteDataState.Done, newAuth.entities.tokens[tokensNames[0]]));
     dispatch(notify(authorizationCreateSuccess()))
   } catch (error) {
     const message = error.data ? error.data.message : null

--- a/src/authorizations/actions/thunks.ts
+++ b/src/authorizations/actions/thunks.ts
@@ -106,10 +106,15 @@ export const createAuthorization = (auth: Authorization) => async (
       authSchema
     )
 
-    const tokensNames = Object.keys(newAuth.entities.tokens);
+    const tokensNames = Object.keys(newAuth.entities.tokens)
 
     dispatch(addAuthorization(newAuth))
-    dispatch(setCurrentAuthorization(RemoteDataState.Done, newAuth.entities.tokens[tokensNames[0]]));
+    dispatch(
+      setCurrentAuthorization(
+        RemoteDataState.Done,
+        newAuth.entities.tokens[tokensNames[0]]
+      )
+    )
     dispatch(notify(authorizationCreateSuccess()))
   } catch (error) {
     const message = error.data ? error.data.message : null

--- a/src/authorizations/actions/thunks.ts
+++ b/src/authorizations/actions/thunks.ts
@@ -105,14 +105,11 @@ export const createAuthorization = (auth: Authorization) => async (
       resp,
       authSchema
     )
-
-    const tokensNames = Object.keys(newAuth.entities.tokens)
-
     dispatch(addAuthorization(newAuth))
     dispatch(
       setCurrentAuthorization(
         RemoteDataState.Done,
-        newAuth.entities.tokens[tokensNames[0]]
+        newAuth.entities.tokens[newAuth.result]
       )
     )
     dispatch(notify(authorizationCreateSuccess()))

--- a/src/authorizations/components/redesigned/DisplayTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/DisplayTokenOverlay.tsx
@@ -29,7 +29,6 @@ const DisplayTokenOverlay: FC<Props> = props => {
   const handleDismiss = () => {
     props.onClose()
   }
-
   return (
     <Overlay.Container maxWidth={750}>
       <Overlay.Header

--- a/src/authorizations/components/redesigned/DisplayTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/DisplayTokenOverlay.tsx
@@ -25,14 +25,11 @@ interface OwnProps {
   onClose: () => void
 }
 
-
 const DisplayTokenOverlay: FC<Props> = props => {
-
-     
   const handleDismiss = () => {
     props.onClose()
   }
-  
+
   return (
     <Overlay.Container maxWidth={750}>
       <Overlay.Header
@@ -41,34 +38,27 @@ const DisplayTokenOverlay: FC<Props> = props => {
         wrapText={true}
       />
       <Overlay.Body>
-        
-      <FlexBox
-            direction={FlexDirection.Column}
-            margin={ComponentSize.Large}
-            alignItems={AlignItems.Stretch}
-          >
-        <Alert 
-            icon={IconFont.AlertTriangle}
-            color={ComponentColor.Primary}>
-            Make sure to copy your new personal access token now. You won't be able to see it again!
-        </Alert>
-        
-        <CodeSnippet
-            text={props.auth.token}
-            type="Token"
-        />
-          </FlexBox>
-        
+        <FlexBox
+          direction={FlexDirection.Column}
+          margin={ComponentSize.Large}
+          alignItems={AlignItems.Stretch}
+        >
+          <Alert icon={IconFont.AlertTriangle} color={ComponentColor.Primary}>
+            Make sure to copy your new personal access token now. You won't be
+            able to see it again!
+          </Alert>
+
+          <CodeSnippet text={props.auth.token} type="Token" />
+        </FlexBox>
       </Overlay.Body>
     </Overlay.Container>
   )
 }
 
 const mstp = (state: AppState) => {
-    const auth = state.resources.tokens.currentAuth.item 
-    return {auth}
-  }
-  
-  
+  const auth = state.resources.tokens.currentAuth.item
+  return {auth}
+}
+
 const connector = connect(mstp, null)
 export default connector(DisplayTokenOverlay)

--- a/src/authorizations/components/redesigned/DisplayTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/DisplayTokenOverlay.tsx
@@ -15,67 +15,48 @@ import {
 import CodeSnippet from 'src/shared/components/CodeSnippet'
 
 // Types
-import {Authorization, AppState} from 'src/types'
+import {AppState} from 'src/types'
 
 type ReduxProps = ConnectedProps<typeof connector>
 
-type Props = ReduxProps & OwnProps 
+type Props = ReduxProps & OwnProps
 
 interface OwnProps {
-  
   onClose: () => void
 }
 
-export const DisplayTokenOverlay: FC<Props> = props => {
+
+const DisplayTokenOverlay: FC<Props> = props => {
+
+     
   const handleDismiss = () => {
     props.onClose()
   }
   
-  console.log(props.authorizations) // undefined 
-
   return (
     <Overlay.Container maxWidth={750}>
       <Overlay.Header
         title="You've Successfully cloned an API Token"
         onDismiss={handleDismiss}
+        wrapText={true}
       />
       <Overlay.Body>
         
-          <FlexBox
-            alignItems={AlignItems.Center}
+      <FlexBox
             direction={FlexDirection.Column}
             margin={ComponentSize.Large}
+            alignItems={AlignItems.Stretch}
           >
         <Alert 
             icon={IconFont.AlertTriangle}
             color={ComponentColor.Primary}>
             Make sure to copy your new personal access token now. You won't be able to see it again!
         </Alert>
-        {/* <CodeSnippet
-            text={auth}
-            label={description}
-            type="Token"
-        /> */}
-        {/* <Panel>
-        <Panel.Header />
-            <Panel.Body>
-            <CopyToClipboard text="copy to clipboard" >
-                <Button
-                text="Copy to Clipboard"
-                testID="copy-to-clipboard"
-                color={ComponentColor.Secondary}
-                size={ComponentSize.ExtraSmall}
-                />
-                
-                    
-                </CopyToClipboard>
-                
-            </Panel.Body>
-        </Panel> */}
-          
-          
         
-            
+        <CodeSnippet
+            text={props.auth.token}
+            type="Token"
+        />
           </FlexBox>
         
       </Overlay.Body>
@@ -84,9 +65,10 @@ export const DisplayTokenOverlay: FC<Props> = props => {
 }
 
 const mstp = (state: AppState) => {
-    const authorizations = state.resources.tokens.byID
-    return {authorizations}
+    const auth = state.resources.tokens.currentAuth.item 
+    return {auth}
   }
   
   
 const connector = connect(mstp, null)
+export default connector(DisplayTokenOverlay)

--- a/src/authorizations/components/redesigned/DisplayTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/DisplayTokenOverlay.tsx
@@ -1,0 +1,92 @@
+import React, {FC} from 'react'
+import {connect, ConnectedProps} from 'react-redux'
+
+// Components
+import {
+  Overlay,
+  FlexBox,
+  Alert,
+  IconFont,
+  ComponentColor,
+  AlignItems,
+  FlexDirection,
+  ComponentSize,
+} from '@influxdata/clockface'
+import CodeSnippet from 'src/shared/components/CodeSnippet'
+
+// Types
+import {Authorization, AppState} from 'src/types'
+
+type ReduxProps = ConnectedProps<typeof connector>
+
+type Props = ReduxProps & OwnProps 
+
+interface OwnProps {
+  
+  onClose: () => void
+}
+
+export const DisplayTokenOverlay: FC<Props> = props => {
+  const handleDismiss = () => {
+    props.onClose()
+  }
+  
+  console.log(props.authorizations) // undefined 
+
+  return (
+    <Overlay.Container maxWidth={750}>
+      <Overlay.Header
+        title="You've Successfully cloned an API Token"
+        onDismiss={handleDismiss}
+      />
+      <Overlay.Body>
+        
+          <FlexBox
+            alignItems={AlignItems.Center}
+            direction={FlexDirection.Column}
+            margin={ComponentSize.Large}
+          >
+        <Alert 
+            icon={IconFont.AlertTriangle}
+            color={ComponentColor.Primary}>
+            Make sure to copy your new personal access token now. You won't be able to see it again!
+        </Alert>
+        {/* <CodeSnippet
+            text={auth}
+            label={description}
+            type="Token"
+        /> */}
+        {/* <Panel>
+        <Panel.Header />
+            <Panel.Body>
+            <CopyToClipboard text="copy to clipboard" >
+                <Button
+                text="Copy to Clipboard"
+                testID="copy-to-clipboard"
+                color={ComponentColor.Secondary}
+                size={ComponentSize.ExtraSmall}
+                />
+                
+                    
+                </CopyToClipboard>
+                
+            </Panel.Body>
+        </Panel> */}
+          
+          
+        
+            
+          </FlexBox>
+        
+      </Overlay.Body>
+    </Overlay.Container>
+  )
+}
+
+const mstp = (state: AppState) => {
+    const authorizations = state.resources.tokens.byID
+    return {authorizations}
+  }
+  
+  
+const connector = connect(mstp, null)

--- a/src/authorizations/components/redesigned/TokenRow.test.tsx
+++ b/src/authorizations/components/redesigned/TokenRow.test.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 // Fixtures
 import {TokenRow} from './TokenRow'
 import {auth} from 'mocks/dummyData'
-import {renderWithRedux} from 'src/mockState'
+import {renderWithReduxAndRouter} from 'src/mockState'
 
 const setup = (override?) => {
   const authorization = {
@@ -20,7 +20,7 @@ const setup = (override?) => {
     onClone: jest.fn(),
     ...override,
   }
-  return renderWithRedux(<TokenRow {...props} />)
+  return renderWithReduxAndRouter(<TokenRow {...props} />)
 }
 
 describe('TokenRowResourceCard', () => {

--- a/src/authorizations/components/redesigned/TokenRow.tsx
+++ b/src/authorizations/components/redesigned/TokenRow.tsx
@@ -2,6 +2,8 @@
 import React, {PureComponent} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
 import {createDateTimeFormatter} from 'src/utils/datetime/formatters'
+import {withRouter, RouteComponentProps} from 'react-router-dom'
+
 
 // Actions
 import {
@@ -25,6 +27,7 @@ import {
 
 import {Context} from 'src/clockface'
 
+
 // Types
 import {Authorization, AppState} from 'src/types'
 import {
@@ -42,10 +45,13 @@ interface OwnProps {
 
 type ReduxProps = ConnectedProps<typeof connector>
 
-type Props = ReduxProps & OwnProps
+type Props = ReduxProps & OwnProps & RouteComponentProps<{orgID: string}>
 
 const formatter = createDateTimeFormatter(UPDATED_AT_TIME_FORMAT)
 class TokensRow extends PureComponent<Props> {
+
+  // org = useSelector(getOrg)
+
   public render() {
     const {description} = this.props.auth
     const {auth} = this.props
@@ -110,17 +116,27 @@ class TokensRow extends PureComponent<Props> {
     this.props.onDelete(id, description)
   }
 
-  private handleClone = () => {
+  private handleClone = async () => {
+    const {
+      history,
+      match: {
+        params: {orgID},
+      },
+    } = this.props
+    
     const {description} = this.props.auth
 
     const allTokenDescriptions = Object.values(this.props.authorizations).map(
       auth => auth.description
     )
-
-    this.props.onClone({
+      console.log(this.props.auth)
+      const newAuth = await this.props.onClone({
       ...this.props.auth,
       description: incrementCloneName(allTokenDescriptions, description),
     })
+    console.log(newAuth)
+    history.push(`/orgs/${orgID}/load-data/tokens/generate/clone-access`)
+    
   }
 
   private handleClickDescription = () => {
@@ -147,4 +163,4 @@ const mdtp = {
 
 const connector = connect(mstp, mdtp)
 
-export const TokenRow = connector(TokensRow)
+export const TokenRow = connector(withRouter(TokensRow))

--- a/src/authorizations/components/redesigned/TokenRow.tsx
+++ b/src/authorizations/components/redesigned/TokenRow.tsx
@@ -4,7 +4,6 @@ import {connect, ConnectedProps} from 'react-redux'
 import {createDateTimeFormatter} from 'src/utils/datetime/formatters'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
-
 // Actions
 import {
   deleteAuthorization,
@@ -27,7 +26,6 @@ import {
 
 import {Context} from 'src/clockface'
 
-
 // Types
 import {Authorization, AppState} from 'src/types'
 import {
@@ -49,7 +47,6 @@ type Props = ReduxProps & OwnProps & RouteComponentProps<{orgID: string}>
 
 const formatter = createDateTimeFormatter(UPDATED_AT_TIME_FORMAT)
 class TokensRow extends PureComponent<Props> {
-
   // org = useSelector(getOrg)
 
   public render() {
@@ -116,27 +113,26 @@ class TokensRow extends PureComponent<Props> {
     this.props.onDelete(id, description)
   }
 
-  private handleClone =  () => {
+  private handleClone = () => {
     const {
       history,
       match: {
         params: {orgID},
       },
     } = this.props
-    
+
     const {description} = this.props.auth
 
     const allTokenDescriptions = Object.values(this.props.authorizations).map(
       auth => auth.description
     )
-      
-      this.props.onClone({
+
+    this.props.onClone({
       ...this.props.auth,
       description: incrementCloneName(allTokenDescriptions, description),
     })
-    
+
     history.push(`/orgs/${orgID}/load-data/tokens/generate/clone-access`)
-    
   }
 
   private handleClickDescription = () => {

--- a/src/authorizations/components/redesigned/TokenRow.tsx
+++ b/src/authorizations/components/redesigned/TokenRow.tsx
@@ -47,7 +47,6 @@ type Props = ReduxProps & OwnProps & RouteComponentProps<{orgID: string}>
 
 const formatter = createDateTimeFormatter(UPDATED_AT_TIME_FORMAT)
 class TokensRow extends PureComponent<Props> {
-
   public render() {
     const {description} = this.props.auth
     const {auth} = this.props

--- a/src/authorizations/components/redesigned/TokenRow.tsx
+++ b/src/authorizations/components/redesigned/TokenRow.tsx
@@ -116,7 +116,7 @@ class TokensRow extends PureComponent<Props> {
     this.props.onDelete(id, description)
   }
 
-  private handleClone = async () => {
+  private handleClone =  () => {
     const {
       history,
       match: {
@@ -129,12 +129,12 @@ class TokensRow extends PureComponent<Props> {
     const allTokenDescriptions = Object.values(this.props.authorizations).map(
       auth => auth.description
     )
-      console.log(this.props.auth)
-      const newAuth = await this.props.onClone({
+      
+      this.props.onClone({
       ...this.props.auth,
       description: incrementCloneName(allTokenDescriptions, description),
     })
-    console.log(newAuth)
+    
     history.push(`/orgs/${orgID}/load-data/tokens/generate/clone-access`)
     
   }

--- a/src/authorizations/components/redesigned/TokenRow.tsx
+++ b/src/authorizations/components/redesigned/TokenRow.tsx
@@ -47,7 +47,6 @@ type Props = ReduxProps & OwnProps & RouteComponentProps<{orgID: string}>
 
 const formatter = createDateTimeFormatter(UPDATED_AT_TIME_FORMAT)
 class TokensRow extends PureComponent<Props> {
-  // org = useSelector(getOrg)
 
   public render() {
     const {description} = this.props.auth

--- a/src/authorizations/containers/RedesignedTokensIndex.tsx
+++ b/src/authorizations/containers/RedesignedTokensIndex.tsx
@@ -12,7 +12,7 @@ import TokensTab from 'src/authorizations/components/redesigned/TokensTab'
 import {
   AllAccessTokenOverlay,
   CustomApiTokenOverlay,
-  DisplayTokenOverlay
+  DisplayTokenOverlay,
 } from 'src/overlays/components'
 
 // Utils
@@ -24,7 +24,6 @@ import {ResourceType} from 'src/types'
 import {ORGS, ORG_ID, TOKENS} from 'src/shared/constants/routes'
 
 const tokensPath = `/${ORGS}/${ORG_ID}/load-data/${TOKENS}/generate`
-
 
 @ErrorHandling
 class TokensIndex extends Component {

--- a/src/authorizations/containers/RedesignedTokensIndex.tsx
+++ b/src/authorizations/containers/RedesignedTokensIndex.tsx
@@ -12,6 +12,7 @@ import TokensTab from 'src/authorizations/components/redesigned/TokensTab'
 import {
   AllAccessTokenOverlay,
   CustomApiTokenOverlay,
+  DisplayTokenOverlay
 } from 'src/overlays/components'
 
 // Utils
@@ -23,6 +24,7 @@ import {ResourceType} from 'src/types'
 import {ORGS, ORG_ID, TOKENS} from 'src/shared/constants/routes'
 
 const tokensPath = `/${ORGS}/${ORG_ID}/load-data/${TOKENS}/generate`
+
 
 @ErrorHandling
 class TokensIndex extends Component {
@@ -45,6 +47,10 @@ class TokensIndex extends Component {
           <Route
             path={`${tokensPath}/custom-api`}
             component={CustomApiTokenOverlay}
+          />
+          <Route
+            path={`${tokensPath}/clone-access`}
+            component={DisplayTokenOverlay}
           />
         </Switch>
       </>

--- a/src/authorizations/reducers/index.test.ts
+++ b/src/authorizations/reducers/index.test.ts
@@ -27,6 +27,7 @@ const mockState = (): ResourceState['tokens'] => ({
     id02: {},
   },
   status: RemoteDataState.Done,
+  currentAuth: {status: RemoteDataState.Done, item: {}}
 })
 
 describe('the authorizations reducer', () => {

--- a/src/authorizations/reducers/index.test.ts
+++ b/src/authorizations/reducers/index.test.ts
@@ -27,7 +27,7 @@ const mockState = (): ResourceState['tokens'] => ({
     id02: {},
   },
   status: RemoteDataState.Done,
-  currentAuth: {status: RemoteDataState.Done, item: {}}
+  currentAuth: {status: RemoteDataState.Done, item: {}},
 })
 
 describe('the authorizations reducer', () => {

--- a/src/authorizations/reducers/index.ts
+++ b/src/authorizations/reducers/index.ts
@@ -14,6 +14,7 @@ import {
   ADD_AUTH,
   EDIT_AUTH,
   REMOVE_AUTH,
+  SET_CURRENT_AUTH,
 } from 'src/authorizations/actions/creators'
 
 // Utils
@@ -31,6 +32,7 @@ const initialState = (): AuthsState => ({
   status: RemoteDataState.NotStarted,
   byID: {},
   allIDs: [],
+  currentAuth: {status: RemoteDataState.NotStarted, item: {}},
 })
 
 export const authsReducer = (
@@ -59,6 +61,19 @@ export const authsReducer = (
 
       case EDIT_AUTH: {
         editResource<Authorization>(draftState, action, Authorizations)
+
+        return
+      }
+
+      case SET_CURRENT_AUTH: {
+        const {status, item} = action
+        draftState.currentAuth.status = status
+
+        if (item) {
+          draftState.currentAuth.item = item
+        } else {
+          draftState.currentAuth.item = {}
+        }
 
         return
       }

--- a/src/overlays/components/OverlayController.tsx
+++ b/src/overlays/components/OverlayController.tsx
@@ -72,7 +72,7 @@ export const OverlayController: FunctionComponent = () => {
       case 'add-custom-token':
         activeOverlay.current = <CustomApiTokenOverlay onClose={onClose} />
         break
-      case 'access-cloned-token':
+      case 'access-token':
         activeOverlay.current = <DisplayTokenOverlay onClose={onClose} />
         break
       case 'add-token':

--- a/src/overlays/components/OverlayController.tsx
+++ b/src/overlays/components/OverlayController.tsx
@@ -36,7 +36,7 @@ import NewDeadmanCheckEO from 'src/checks/components/NewDeadmanCheckEO'
 import AutoRefreshOverlay from 'src/dashboards/components/AutoRefreshOverlay'
 import CellCloneOverlay from 'src/shared/components/cells/CellCloneOverlay'
 import {CustomApiTokenOverlay} from 'src/authorizations/components/redesigned/CustomApiTokenOverlay'
-import {DisplayTokenOverlay} from 'src/authorizations/components/redesigned/DisplayTokenOverlay'
+import DisplayTokenOverlay from 'src/authorizations/components/redesigned/DisplayTokenOverlay'
 
 // Actions
 import {dismissOverlay} from 'src/overlays/actions/overlays'

--- a/src/overlays/components/OverlayController.tsx
+++ b/src/overlays/components/OverlayController.tsx
@@ -36,6 +36,7 @@ import NewDeadmanCheckEO from 'src/checks/components/NewDeadmanCheckEO'
 import AutoRefreshOverlay from 'src/dashboards/components/AutoRefreshOverlay'
 import CellCloneOverlay from 'src/shared/components/cells/CellCloneOverlay'
 import {CustomApiTokenOverlay} from 'src/authorizations/components/redesigned/CustomApiTokenOverlay'
+import {DisplayTokenOverlay} from 'src/authorizations/components/redesigned/DisplayTokenOverlay'
 
 // Actions
 import {dismissOverlay} from 'src/overlays/actions/overlays'
@@ -70,6 +71,9 @@ export const OverlayController: FunctionComponent = () => {
         break
       case 'add-custom-token':
         activeOverlay.current = <CustomApiTokenOverlay onClose={onClose} />
+        break
+      case 'access-cloned-token':
+        activeOverlay.current = <DisplayTokenOverlay onClose={onClose} />
         break
       case 'add-token':
         activeOverlay.current = <BucketsTokenOverlay onClose={onClose} />

--- a/src/overlays/components/index.tsx
+++ b/src/overlays/components/index.tsx
@@ -36,6 +36,14 @@ export const CustomApiTokenOverlay = RouteOverlay(
   }
 )
 
+export const DisplayTokenOverlay = RouteOverlay(
+  OverlayHandler,
+  'access-cloned-token',
+  (history, params) => {
+    history.push(`/orgs/${params.orgID}/load-data/tokens`)
+  }
+)
+
 export const BucketsTokenOverlay = RouteOverlay(
   OverlayHandler,
   'add-token',

--- a/src/overlays/components/index.tsx
+++ b/src/overlays/components/index.tsx
@@ -38,7 +38,7 @@ export const CustomApiTokenOverlay = RouteOverlay(
 
 export const DisplayTokenOverlay = RouteOverlay(
   OverlayHandler,
-  'access-cloned-token',
+  'access-token',
   (history, params) => {
     history.push(`/orgs/${params.orgID}/load-data/tokens`)
   }

--- a/src/overlays/reducers/overlays.ts
+++ b/src/overlays/reducers/overlays.ts
@@ -9,7 +9,7 @@ export type OverlayID =
   | 'add-note'
   | 'edit-note'
   | 'add-master-token'
-  | 'access-cloned-token'
+  | 'access-token'
   | 'add-token'
   | 'telegraf-config'
   | 'telegraf-output'

--- a/src/overlays/reducers/overlays.ts
+++ b/src/overlays/reducers/overlays.ts
@@ -9,6 +9,7 @@ export type OverlayID =
   | 'add-note'
   | 'edit-note'
   | 'add-master-token'
+  | 'access-cloned-token'
   | 'add-token'
   | 'telegraf-config'
   | 'telegraf-output'

--- a/src/types/resources.ts
+++ b/src/types/resources.ts
@@ -58,6 +58,10 @@ export interface TelegrafsState extends NormalizedState<Telegraf> {
   currentConfig: {status: RemoteDataState; item: string}
 }
 
+export interface AuthState extends NormalizedState<Authorization> {
+  currentAuth: {status: RemoteDataState; item: Authorization}
+}
+
 export interface RulesState extends NormalizedState<NotificationRule> {
   current: {status: RemoteDataState; rule: NotificationRule}
 }
@@ -71,7 +75,7 @@ type CellsState = Omit<NormalizedState<Cell>, 'allIDs'>
 
 // ResourceState defines the types for normalized resources
 export interface ResourceState {
-  [ResourceType.Authorizations]: NormalizedState<Authorization>
+  [ResourceType.Authorizations]: AuthState
   [ResourceType.Buckets]: NormalizedState<Bucket>
   [ResourceType.Cells]: CellsState
   [ResourceType.Checks]: NormalizedState<Check>

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -22,9 +22,6 @@ import {
 // AuthEntities defines the result of normalizr's normalization
 // of the "authorizations" resource
 export interface AuthEntities {
-  buckets: {
-    [uuid: string]: Authorization
-  }
   tokens: {
     [uuid: string]: Authorization
   }

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -24,6 +24,9 @@ import {
 export interface AuthEntities {
   buckets: {
     [uuid: string]: Authorization
+  },
+  tokens: {
+    [uuid: string]: Authorization
   }
 }
 

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -24,7 +24,7 @@ import {
 export interface AuthEntities {
   buckets: {
     [uuid: string]: Authorization
-  },
+  }
   tokens: {
     [uuid: string]: Authorization
   }


### PR DESCRIPTION
Closes #2217 
After a user clones a token successfully, an Overlay with the generated token and a copy button renders on UI.
The Overlay contains a warning telling user to copy token as it will be the only time they will see it. 

https://user-images.githubusercontent.com/66275100/128400683-732d8dc9-d6e5-4a84-9b68-1fd7ba901ddd.mov


