### PR TITLE
build(lsp): Upgrade flux-lsp-browser to v0.5.53

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
   "dependencies": {
     "@influxdata/clockface": "^2.6.6",
     "@influxdata/flux": "^0.5.1",
-    "@influxdata/flux-lsp-browser": "^0.5.47",
+    "@influxdata/flux-lsp-browser": "^0.5.53",
     "@influxdata/giraffe": "^2.7.0",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -715,10 +715,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-2.6.6.tgz#5eeb42110da8e967eb8199a337e9923935d49fe1"
   integrity sha512-bbEwkwWHFQvxrWa3yOWn65Th+/JdNVJp5Nzx55v93tIWa93O1H/q3sFp96lZbMA1WH8eO5mz1qvNDVAkqF4crw==
 
-"@influxdata/flux-lsp-browser@^0.5.47":
-  version "0.5.47"
-  resolved "https://registry.yarnpkg.com/@influxdata/flux-lsp-browser/-/flux-lsp-browser-0.5.47.tgz#25b2abc6397e01ad47cc8b1f93cb83d14ba4e76d"
-  integrity sha512-Ejml0Ez4SAf0TE9UVRZS+noY9e73MfG2d+fLu0BNR876ih90205xAdkf3uUvfB3nXOs33Tq2HhfkZHGXkSRP6g==
+"@influxdata/flux-lsp-browser@^0.5.53":
+  version "0.5.53"
+  resolved "https://registry.yarnpkg.com/@influxdata/flux-lsp-browser/-/flux-lsp-browser-0.5.53.tgz#03df756afa3e22d69310021d7c11e968bb8e1c0b"
+  integrity sha512-7cT2O2xJOD94/B7Cyp5I7ei5vX/vOsnuu4iaW/68rOTlKi1TCCpb8Lqu4fTrf8As16YwTFREOTIw9eHgE3Bh9Q==
 
 "@influxdata/flux@^0.5.1":
   version "0.5.1"


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/22080

Cherry-pick of a847c264e5e1be800adb2b63e4496128a18b6471

Updates the OSS-2.0 branch `flux-lsp-browser` to the latest version since the OSS 2.0.8 release will use the latest version of flux.

Note that the CI for this branch is currently very minimal since the e2e tests run on the OSS side when we update the pinned release number there.