### PR TITLE
fix: move to last

### DIFF
--- a/src/flows/pipes/Visualization/index.ts
+++ b/src/flows/pipes/Visualization/index.ts
@@ -25,7 +25,7 @@ export default register => {
         pipe.properties.type === 'single-stat' ||
         pipe.properties.type === 'gauge'
       ) {
-        append('__CURRENT_RESULT__ |> max(column: "_time")')
+        append('__CURRENT_RESULT__ |> last()')
         return
       }
 


### PR DESCRIPTION
fixes an issue that came up in tools were `|> group() |> count() |> group()` (the only way to add things in our system) leaves you with no `_time` column, rendering and error when you run single stat and gauge visualizations with the changes from #2253. ` |> last()` doesn't seem to cause this