### PR TITLE
fix: added default token description

### DIFF
--- a/src/writeData/components/WriteDataHelperTokens.tsx
+++ b/src/writeData/components/WriteDataHelperTokens.tsx
@@ -24,6 +24,7 @@ import {getAll} from 'src/resources/selectors'
 
 // Types
 import {AppState, ResourceType, Authorization} from 'src/types'
+import {DEFAULT_TOKEN_DESCRIPTION} from 'src/dashboards/constants'
 
 import GenerateTokenDropdown from 'src/authorizations/components/GenerateTokenDropdown'
 
@@ -32,6 +33,11 @@ const WriteDataHelperTokens: FC = () => {
     getAll<Authorization>(state, ResourceType.Authorizations)
   )
   const {token, changeToken} = useContext(WriteDataDetailsContext)
+  tokens.map(t => {
+    t.description.length === 0
+      ? (t.description = DEFAULT_TOKEN_DESCRIPTION)
+      : t.description
+  })
 
   let body = (
     <EmptyState

--- a/src/writeData/components/WriteDataHelperTokens.tsx
+++ b/src/writeData/components/WriteDataHelperTokens.tsx
@@ -33,10 +33,14 @@ const WriteDataHelperTokens: FC = () => {
     getAll<Authorization>(state, ResourceType.Authorizations)
   )
   const {token, changeToken} = useContext(WriteDataDetailsContext)
-  tokens.map(token => {
-    token.description?.length === 0
-      ? (token.description = DEFAULT_TOKEN_DESCRIPTION)
-      : token.description
+  const tokensWithDescription = tokens.map(token => {
+    return {
+      ...token,
+      description:
+        token?.description?.length === 0
+          ? DEFAULT_TOKEN_DESCRIPTION
+          : token.description,
+    }
   })
 
   let body = (
@@ -65,7 +69,7 @@ const WriteDataHelperTokens: FC = () => {
     return tokenID === token.id
   }
 
-  if (tokens.length) {
+  if (tokensWithDescription.length) {
     body = (
       <List
         backgroundColor={InfluxColors.Obsidian}
@@ -73,7 +77,7 @@ const WriteDataHelperTokens: FC = () => {
         maxHeight="200px"
         testID="write-data-tokens-list"
       >
-        {tokens.map(t => (
+        {tokensWithDescription.map(t => (
           <List.Item
             size={ComponentSize.Small}
             key={t.id}

--- a/src/writeData/components/WriteDataHelperTokens.tsx
+++ b/src/writeData/components/WriteDataHelperTokens.tsx
@@ -33,10 +33,10 @@ const WriteDataHelperTokens: FC = () => {
     getAll<Authorization>(state, ResourceType.Authorizations)
   )
   const {token, changeToken} = useContext(WriteDataDetailsContext)
-  tokens.map(t => {
-    t.description.length === 0
-      ? (t.description = DEFAULT_TOKEN_DESCRIPTION)
-      : t.description
+  tokens.map(token => {
+    token.description?.length === 0
+      ? (token.description = DEFAULT_TOKEN_DESCRIPTION)
+      : token.description
   })
 
   let body = (


### PR DESCRIPTION
Closes #2199 

tokens without descriptions are showing up on the client libraries page with an empty description. 
Before: 
<img width="1168" alt="before" src="https://user-images.githubusercontent.com/66275100/128766305-e5209e6c-5100-458d-b8ec-4b01b46f47f0.png">
After: 
<img width="1169" alt="after" src="https://user-images.githubusercontent.com/66275100/128766319-8efc962c-5312-4409-b39e-7ca058cb7bfb.png">
pr fixes this issue by importing `DEFAULT_TOKEN_DESCRIPTION` and using it in place of no name tokens.
