### PR TITLE
feat: add more events and throw in an experiment to run

### DIFF
--- a/src/tasks/components/TaskHeader.tsx
+++ b/src/tasks/components/TaskHeader.tsx
@@ -1,5 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
+import {Link} from 'react-router-dom'
 
 // Components
 import {
@@ -9,6 +10,7 @@ import {
   Page,
 } from '@influxdata/clockface'
 import RateLimitAlert from 'src/cloud/components/RateLimitAlert'
+import {FeatureFlag} from 'src/shared/utils/featureFlag'
 
 interface Props {
   title: string
@@ -27,6 +29,12 @@ export default class TaskHeader extends PureComponent<Props> {
           <RateLimitAlert />
         </Page.Header>
         <Page.ControlBar fullWidth={true}>
+          <Page.ControlBarLeft className="task-header--cta">
+            <FeatureFlag name="flowsCTA">
+              <span>Need something more?</span>
+              <Link to="/notebook/from/task">Create a Notebook</Link>
+            </FeatureFlag>
+          </Page.ControlBarLeft>
           <Page.ControlBarRight>
             <Button
               color={ComponentColor.Default}

--- a/src/tasks/components/TaskImportOverlay.tsx
+++ b/src/tasks/components/TaskImportOverlay.tsx
@@ -1,6 +1,7 @@
 import React, {PureComponent} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 import {connect, ConnectedProps} from 'react-redux'
+import {event} from 'src/cloud/utils/reporting'
 
 // Components
 import ImportOverlay from 'src/shared/components/ImportOverlay'
@@ -63,6 +64,8 @@ class TaskImportOverlay extends PureComponent<Props> {
       notify(invalidJSON(error.message))
       return
     }
+
+    event('Valid JSON Task Import Submitted')
 
     createTaskFromTemplate(template)
     this.onDismiss()

--- a/src/tasks/components/TasksPage.scss
+++ b/src/tasks/components/TasksPage.scss
@@ -16,3 +16,7 @@
   border-radius: $radius;
   font-style: italic;
 }
+
+.task-header--cta {
+  font-size: 16px;
+}

--- a/src/tasks/containers/TaskPage.tsx
+++ b/src/tasks/containers/TaskPage.tsx
@@ -26,6 +26,7 @@ import {
   addDestinationToFluxScript,
 } from 'src/utils/taskOptionsToFluxScript'
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
+import {event} from 'src/cloud/utils/reporting'
 
 // Types
 import {AppState, TaskOptionKeys, TaskSchedule} from 'src/types'
@@ -125,6 +126,7 @@ class TaskPage extends PureComponent<Props> {
     // currently we delete that part of the script
     script = script.replace(new RegExp('option\\s+task\\s+=\\s+{(.|\\s)*}'), '')
 
+    event('Valid Task Form Submitted')
     this.props.saveNewScript(script, preamble).then(() => {
       this.props.goToTasks()
     })


### PR DESCRIPTION
we think that people would want to build tasks in notebooks more than the current task creation interface, they just don't know how to. but we dont know that for sure, so lets give users who have demonstrated that they intend to create a task the option to use a notebook instead. if they dont want to, they just dont have to click on the link.

this experiment is to drive more people who want to create tasks through notebooks, and to validate that the task creation interface is better in notebooks. we can measure success by the conversion of people who generate a task through the notebook interface. more sustained tasks exported... the more confidence we have in depreciating the existing task interface. if a bunch of people click on the link and no more tasks are generated, we know we have more work to do on the notebooks workflow for task users.

the CTA is behind a feature flag so we can build up a baseline for the conversion of the existing task creation funnel before turning it on.

![Screenshot from 2021-08-09 13-13-08](https://user-images.githubusercontent.com/1434802/128769631-e4b25a02-d05e-413a-a88a-ad2c7f68eea3.png)
