### PR TITLE
fix: query.text was being updated in place

### DIFF
--- a/src/flows/pipes/RawFluxEditor/view.tsx
+++ b/src/flows/pipes/RawFluxEditor/view.tsx
@@ -100,7 +100,13 @@ const Query: FC<PipeProp> = ({Context}) => {
         },
       ]
 
-      if (fn.package && !query.text.includes(`import "${fn.package}"`)) {
+      if (
+        fn.package &&
+        !editorInstance
+          .getModel()
+          .getValue()
+          .includes(`import "${fn.package}"`)
+      ) {
         edits.unshift({
           range: new window.monaco.Range(1, 1, 1, 1),
           text: `import "${fn.package}"\n`,


### PR DESCRIPTION
Closes #2240

this just grabs the value directly from monaco at injection time instead of passing it all around the contexts and reducers and stuff