### PR TITLE
fix: aggregate type error selectionbr

### DIFF
--- a/src/flows/shared/FriendlyQueryError.tsx
+++ b/src/flows/shared/FriendlyQueryError.tsx
@@ -29,7 +29,7 @@ const FriendlyQueryError: FC<Props> = ({error}) => {
     event(`Updating the Aggregate function in the Flow Query Builder`, {
       function: aggregateFunction.name,
     })
-    update({aggregateFunction})
+    update({functions: [{name: aggregateFunction.name}]})
   }
 
   if (!isAggTypeError) {


### PR DESCRIPTION
Closes #2224 

This PR updates the FriendlyErrorQuery message to properly handle click events of the aggregate function selector to update the aggregate function that's currently selected
