### PR TITLE
feat: alert prefab notebook

### DIFF
--- a/src/flows/templates/types/notification.ts
+++ b/src/flows/templates/types/notification.ts
@@ -1,0 +1,48 @@
+import {DEFAULT_TIME_RANGE} from 'src/shared/constants/timeRanges'
+import {AUTOREFRESH_DEFAULT} from 'src/shared/constants'
+import {PIPE_DEFINITIONS} from 'src/flows'
+
+export default register =>
+  register({
+    type: 'notification',
+    init: () => ({
+      name: 'New Alert',
+      spec: {
+        readOnly: false,
+        range: DEFAULT_TIME_RANGE,
+        refresh: AUTOREFRESH_DEFAULT,
+        pipes: [
+          {
+            title: 'Select a Metric',
+            visible: true,
+            type: 'metricSelector',
+            ...JSON.parse(
+              JSON.stringify(PIPE_DEFINITIONS['metricSelector'].initial)
+            ),
+          },
+          {
+            title: 'Validate the Data',
+            visible: true,
+            type: 'visualization',
+            properties: {type: 'simple-table', showAll: false},
+          },
+          {
+            title: 'Visualize the Result',
+            visible: true,
+            type: 'visualization',
+            ...JSON.parse(
+              JSON.stringify(PIPE_DEFINITIONS['visualization'].initial)
+            ),
+          },
+          {
+            type: 'notification',
+            visible: true,
+            title: 'New Notification',
+            ...JSON.parse(
+              JSON.stringify(PIPE_DEFINITIONS['notification'].initial)
+            ),
+          },
+        ],
+      },
+    }),
+  })


### PR DESCRIPTION




Closes #2152

<!-- Describe your proposed changes here. -->
Creates a prefab notebook that currently is "alert" in name only bc its waiting on the ticket that will rename all notification components to alert 

https://user-images.githubusercontent.com/29473622/128898029-c0d252dc-9e4f-477e-a896-8b56cad5c1cb.mov