### PR TITLE
feat: changed view overlay to edit overlay

### DIFF
--- a/src/authorizations/components/redesigned/EditTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/EditTokenOverlay.tsx
@@ -1,0 +1,57 @@
+// Libraries
+import React, {FC, useState} from 'react'
+
+// Components
+import {
+  Overlay,
+  Form,
+  Input,
+  FlexBox,
+  AlignItems,
+  FlexDirection,
+  ComponentSize,
+} from '@influxdata/clockface'
+
+// Types
+import {Authorization} from 'src/types'
+
+interface Props {
+  auth: Authorization
+  onDismissOverlay: () => void
+}
+
+export const EditTokenOverlay: FC<Props> = props => {
+  const [description, setDescription] = useState(props.auth.description)
+
+  const handleDismiss = () => {
+    props.onDismissOverlay()
+  }
+
+  const handleInputChange = event => {
+    setDescription(event.target.value)
+  }
+
+  return (
+    <Overlay.Container maxWidth={830}>
+      <Overlay.Header title="API Token Summary" onDismiss={handleDismiss} />
+      <Overlay.Body>
+        <Form>
+          <FlexBox
+            alignItems={AlignItems.Center}
+            direction={FlexDirection.Column}
+            margin={ComponentSize.Large}
+          >
+            <Form.Element label="Description">
+              <Input
+                placeholder="Describe this token"
+                value={description}
+                onChange={handleInputChange}
+                testID="custom-api-token-input"
+              />
+            </Form.Element>
+          </FlexBox>
+        </Form>
+      </Overlay.Body>
+    </Overlay.Container>
+  )
+}

--- a/src/authorizations/components/redesigned/TokenList.tsx
+++ b/src/authorizations/components/redesigned/TokenList.tsx
@@ -5,7 +5,7 @@ import memoizeOne from 'memoize-one'
 // Components
 import {Overlay, ResourceList} from '@influxdata/clockface'
 import {TokenRow} from 'src/authorizations/components/redesigned/TokenRow'
-import ViewTokenOverlay from 'src/authorizations/components/ViewTokenOverlay'
+import {EditTokenOverlay} from 'src/authorizations/components/redesigned/EditTokenOverlay'
 
 // Types
 import {Authorization} from 'src/types'
@@ -60,7 +60,7 @@ export class TokenList extends PureComponent<Props, State> {
         </ResourceList>
 
         <Overlay visible={isTokenOverlayVisible}>
-          <ViewTokenOverlay
+          <EditTokenOverlay
             auth={authInView}
             onDismissOverlay={this.handleDismissOverlay}
           />


### PR DESCRIPTION
Closes #1964 

Followed `CustomApiTokenOverlay.tsx` to set up the overlay frame. 

<img width="1435" alt="Screen Shot 2021-08-10 at 12 27 14 PM" src="https://user-images.githubusercontent.com/39343323/128906400-9d270b8e-1849-4b92-a6c9-d9a6127016e7.png">
