### PR TITLE
feat: move create bucket form into its own component

### DIFF
--- a/src/buckets/components/CreateBucketForm.tsx
+++ b/src/buckets/components/CreateBucketForm.tsx
@@ -18,7 +18,7 @@ import {
   initialBucketState,
   DEFAULT_RULES,
 } from 'src/buckets/reducers/createBucket'
-import {AppState, Bucket} from 'src/types'
+import {AppState, Bucket, RetentionRule} from 'src/types'
 
 // Selectors
 import {getOrg} from 'src/organizations/selectors'
@@ -29,7 +29,7 @@ interface CreateBucketFormProps {
   onClose: () => void
 }
 
-const CreateBucketForm: FC<CreateBucketFormProps> = props => {
+export const CreateBucketForm: FC<CreateBucketFormProps> = props => {
   const {onClose} = props
   const org = useSelector(getOrg)
   const isRetentionLimitEnforced = useSelector((state: AppState): boolean => {
@@ -45,7 +45,9 @@ const CreateBucketForm: FC<CreateBucketFormProps> = props => {
     initialBucketState(isRetentionLimitEnforced, org.id)
   )
 
-  const retentionRule = state.retentionRules.find(r => r.type === 'expire')
+  const retentionRule = state.retentionRules.find(
+    (rule: RetentionRule) => rule.type === 'expire'
+  )
   const retentionSeconds = retentionRule ? retentionRule.everySeconds : 3600
 
   const handleChangeRuleType = (ruleType: RuleType): void => {
@@ -104,5 +106,3 @@ const CreateBucketForm: FC<CreateBucketFormProps> = props => {
     />
   )
 }
-
-export default CreateBucketForm

--- a/src/buckets/components/CreateBucketForm.tsx
+++ b/src/buckets/components/CreateBucketForm.tsx
@@ -1,0 +1,108 @@
+// Libraries
+import React, {FC, ChangeEvent, FormEvent, useReducer} from 'react'
+import {useSelector, useDispatch} from 'react-redux'
+
+// Components
+import BucketOverlayForm from 'src/buckets/components/BucketOverlayForm'
+
+// Actions
+import {createBucketAndUpdate} from 'src/buckets/actions/thunks'
+
+// Constants
+import {CLOUD} from 'src/shared/constants'
+
+// Types
+import {
+  createBucketReducer,
+  RuleType,
+  initialBucketState,
+  DEFAULT_RULES,
+} from 'src/buckets/reducers/createBucket'
+import {AppState, Bucket} from 'src/types'
+
+// Selectors
+import {getOrg} from 'src/organizations/selectors'
+import {getBucketRetentionLimit} from 'src/cloud/utils/limits'
+import {getOverlayParams} from 'src/overlays/selectors'
+
+interface CreateBucketFormProps {
+  onClose: () => void
+}
+
+const CreateBucketForm: FC<CreateBucketFormProps> = props => {
+  const {onClose} = props
+  const org = useSelector(getOrg)
+  const isRetentionLimitEnforced = useSelector((state: AppState): boolean => {
+    if (CLOUD) {
+      return getBucketRetentionLimit(state)
+    }
+    return false
+  })
+  const overlayParams = useSelector(getOverlayParams)
+  const reduxDispatch = useDispatch()
+  const [state, dispatch] = useReducer(
+    createBucketReducer,
+    initialBucketState(isRetentionLimitEnforced, org.id)
+  )
+
+  const retentionRule = state.retentionRules.find(r => r.type === 'expire')
+  const retentionSeconds = retentionRule ? retentionRule.everySeconds : 3600
+
+  const handleChangeRuleType = (ruleType: RuleType): void => {
+    if (ruleType === 'expire') {
+      dispatch({type: 'updateRetentionRules', payload: DEFAULT_RULES})
+    } else {
+      dispatch({type: 'updateRetentionRules', payload: []})
+    }
+    dispatch({type: 'updateRuleType', payload: ruleType})
+  }
+
+  const handleChangeRetentionRule = (everySeconds: number): void => {
+    const retentionRules = [
+      {
+        type: 'expire',
+        everySeconds,
+      },
+    ]
+
+    dispatch({type: 'updateRetentionRules', payload: retentionRules})
+  }
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>): void => {
+    event.preventDefault()
+
+    reduxDispatch(createBucketAndUpdate(state, handleUpdateBucket))
+    onClose()
+  }
+
+  const handleUpdateBucket = (bucket: Bucket): void => {
+    if (overlayParams?.onUpdateBucket) {
+      overlayParams.onUpdateBucket(bucket)
+    }
+  }
+
+  const handleChangeInput = (event: ChangeEvent<HTMLInputElement>): void => {
+    const value = event.target.value
+
+    if (event.target.name === 'name') {
+      dispatch({type: 'updateName', payload: value})
+    }
+  }
+
+  return (
+    <BucketOverlayForm
+      name={state.name}
+      buttonText="Create"
+      disableRenaming={false}
+      ruleType={state.ruleType}
+      onClose={onClose}
+      onSubmit={handleSubmit}
+      onChangeInput={handleChangeInput}
+      retentionSeconds={retentionSeconds}
+      onChangeRuleType={handleChangeRuleType}
+      onChangeRetentionRule={handleChangeRetentionRule}
+    />
+  )
+}
+
+export default CreateBucketForm

--- a/src/buckets/components/CreateBucketOverlay.tsx
+++ b/src/buckets/components/CreateBucketOverlay.tsx
@@ -1,110 +1,23 @@
 // Libraries
-import React, {FC, ChangeEvent, FormEvent, useReducer, useContext} from 'react'
-import {useSelector, useDispatch} from 'react-redux'
+import React, {FC, useContext} from 'react'
 
 // Components
 import {Overlay} from '@influxdata/clockface'
-import BucketOverlayForm from 'src/buckets/components/BucketOverlayForm'
+import CreateBucketForm from 'src/buckets/components/CreateBucketForm'
 
 // Contexts
 import {OverlayContext} from 'src/overlays/components/OverlayController'
 
-// Actions
-import {createBucketAndUpdate} from 'src/buckets/actions/thunks'
-
 // Constants
-import {CLOUD} from 'src/shared/constants'
-
-// Types
-import {
-  createBucketReducer,
-  RuleType,
-  initialBucketState,
-  DEFAULT_RULES,
-} from 'src/buckets/reducers/createBucket'
-import {AppState, Bucket} from 'src/types'
-
-// Selectors
-import {getOrg} from 'src/organizations/selectors'
-import {getBucketRetentionLimit} from 'src/cloud/utils/limits'
-import {getOverlayParams} from 'src/overlays/selectors'
+import {BUCKET_OVERLAY_WIDTH} from 'src/buckets/constants'
 
 const CreateBucketOverlay: FC = () => {
-  const org = useSelector(getOrg)
-  const isRetentionLimitEnforced = useSelector((state: AppState): boolean => {
-    if (CLOUD) {
-      return getBucketRetentionLimit(state)
-    }
-    return false
-  })
-  const overlayParams = useSelector(getOverlayParams)
-  const reduxDispatch = useDispatch()
   const {onClose} = useContext(OverlayContext)
-  const [state, dispatch] = useReducer(
-    createBucketReducer,
-    initialBucketState(isRetentionLimitEnforced, org.id)
-  )
-
-  const retentionRule = state.retentionRules.find(r => r.type === 'expire')
-  const retentionSeconds = retentionRule ? retentionRule.everySeconds : 3600
-
-  const handleChangeRuleType = (ruleType: RuleType): void => {
-    if (ruleType === 'expire') {
-      dispatch({type: 'updateRetentionRules', payload: DEFAULT_RULES})
-    } else {
-      dispatch({type: 'updateRetentionRules', payload: []})
-    }
-    dispatch({type: 'updateRuleType', payload: ruleType})
-  }
-
-  const handleChangeRetentionRule = (everySeconds: number): void => {
-    const retentionRules = [
-      {
-        type: 'expire',
-        everySeconds,
-      },
-    ]
-
-    dispatch({type: 'updateRetentionRules', payload: retentionRules})
-  }
-
-  const handleSubmit = (e: FormEvent<HTMLFormElement>): void => {
-    e.preventDefault()
-
-    reduxDispatch(createBucketAndUpdate(state, handleUpdateBucket))
-    onClose()
-  }
-
-  const handleUpdateBucket = (bucket: Bucket): void => {
-    if (overlayParams?.onUpdateBucket) {
-      overlayParams.onUpdateBucket(bucket)
-    }
-  }
-
-  const handleChangeInput = (e: ChangeEvent<HTMLInputElement>): void => {
-    const value = e.target.value
-
-    if (e.target.name === 'name') {
-      dispatch({type: 'updateName', payload: value})
-    }
-  }
-
   return (
-    <Overlay.Container maxWidth={400}>
+    <Overlay.Container maxWidth={BUCKET_OVERLAY_WIDTH}>
       <Overlay.Header title="Create Bucket" onDismiss={onClose} />
       <Overlay.Body>
-        <BucketOverlayForm
-          name={state.name}
-          buttonText="Create"
-          disableRenaming={false}
-          ruleType={state.ruleType}
-          onClose={onClose}
-          onSubmit={handleSubmit}
-          onChangeInput={handleChangeInput}
-          retentionSeconds={retentionSeconds}
-          onChangeRuleType={handleChangeRuleType}
-          onChangeRetentionRule={handleChangeRetentionRule}
-        />
+        <CreateBucketForm onClose={onClose} />
       </Overlay.Body>
     </Overlay.Container>
   )

--- a/src/buckets/components/CreateBucketOverlay.tsx
+++ b/src/buckets/components/CreateBucketOverlay.tsx
@@ -3,7 +3,7 @@ import React, {FC, useContext} from 'react'
 
 // Components
 import {Overlay} from '@influxdata/clockface'
-import CreateBucketForm from 'src/buckets/components/CreateBucketForm'
+import {CreateBucketForm} from 'src/buckets/components/CreateBucketForm'
 
 // Contexts
 import {OverlayContext} from 'src/overlays/components/OverlayController'

--- a/src/buckets/constants/index.ts
+++ b/src/buckets/constants/index.ts
@@ -3,3 +3,5 @@ import {startsWith} from 'lodash'
 export const isSystemBucket = (bucketName: string): boolean => {
   return startsWith(bucketName, '_')
 }
+
+export const BUCKET_OVERLAY_WIDTH = 400


### PR DESCRIPTION
As part of #1555 

Currently, the form that creates a new bucket is implemented directly into its own overlay. Soon, there will be multiple places in the ui that can create new buckets, and each of these places may use the overlay a little differently. Therefore, let's separate the overlay from the form so that a common form can be re-used.

This is what happened:
- almost all of the code for `CreateBucketOverlay` moved to `CreateBucketForm` (new file)
- only the `onClose` method was not moved
- `CreateBucketForm` contains all of the previous logic, except `onClose` which is now a prop
- `CreateBucketOverlay` imports the new component and passes in `onClose`
