### PR TITLE
chore: add template event

### DIFF
--- a/src/flows/components/FromTemplatePage.tsx
+++ b/src/flows/components/FromTemplatePage.tsx
@@ -6,6 +6,7 @@ import {TEMPLATES} from 'src/flows/templates'
 
 import {getOrg} from 'src/organizations/selectors'
 import NotFound from 'src/shared/components/NotFound'
+import {event} from 'src/cloud/utils/reporting'
 import {
   FlowListProvider,
   FlowListContext,
@@ -29,6 +30,8 @@ const Template: FC = () => {
     }
 
     setLoading(true)
+
+    event('Notebook created from template', {type: params[0]})
 
     add(hydrate(TEMPLATES[params[0]].init.apply(this, params.slice(1)))).then(
       id => {


### PR DESCRIPTION
We are leaning into creating notebooks from a template as a way to improve the conversion rates of some key workflows we'd like to focus on. To be able to properly segment the data, we need to know where our users came from. this adds that event