### PR TITLE
refactor: replace isValid from the datePicker

### DIFF
--- a/src/shared/components/dateRangePicker/DatePicker.tsx
+++ b/src/shared/components/dateRangePicker/DatePicker.tsx
@@ -151,9 +151,8 @@ class DatePicker extends PureComponent<Props, State> {
   }
 
   private get inputErrorMessage(): string | undefined {
-    const {inputFormat} = this.state
     if (this.isInputValueInvalid) {
-      return inputFormat
+      return `Format must be YYYY-MM-DD HH:mm:ss`
     }
 
     return '\u00a0\u00a0'

--- a/src/shared/components/dateRangePicker/DatePicker.tsx
+++ b/src/shared/components/dateRangePicker/DatePicker.tsx
@@ -37,7 +37,7 @@ interface State {
   inputFormat: string
 }
 
-const isValidRTC3339 = (d: string): boolean => {
+const isValidDatepickerFormat = (d: string): boolean => {
   return (
     isValid(d, 'YYYY-MM-DD HH:mm') ||
     isValid(d, 'YYYY-MM-DD HH:mm:ss') ||
@@ -147,12 +147,13 @@ class DatePicker extends PureComponent<Props, State> {
       return false
     }
 
-    return !isValidRTC3339(inputValue)
+    return !isValidDatepickerFormat(inputValue)
   }
 
   private get inputErrorMessage(): string | undefined {
+    const {inputFormat} = this.state
     if (this.isInputValueInvalid) {
-      return 'Format must be YYYY-MM-DD HH:mm:ss'
+      return inputFormat
     }
 
     return '\u00a0\u00a0'
@@ -210,7 +211,7 @@ class DatePicker extends PureComponent<Props, State> {
     const {onSelectDate, timeZone} = this.props
     const value = e.target.value
 
-    if (isValidRTC3339(value)) {
+    if (isValidDatepickerFormat(value)) {
       const inputDate = new Date(value)
 
       if (timeZone === 'UTC') {

--- a/src/shared/components/dateRangePicker/DatePicker.tsx
+++ b/src/shared/components/dateRangePicker/DatePicker.tsx
@@ -152,7 +152,7 @@ class DatePicker extends PureComponent<Props, State> {
 
   private get inputErrorMessage(): string | undefined {
     if (this.isInputValueInvalid) {
-      return `Format must be YYYY-MM-DD HH:mm:ss`
+      return 'Format must be YYYY-MM-DD HH:mm:ss'
     }
 
     return '\u00a0\u00a0'

--- a/src/shared/components/dateRangePicker/DatePicker.tsx
+++ b/src/shared/components/dateRangePicker/DatePicker.tsx
@@ -41,9 +41,9 @@ const isValidRTC3339 = (d: string): boolean => {
   return (
     isValid(d, 'YYYY-MM-DD HH:mm') ||
     isValid(d, 'YYYY-MM-DD HH:mm:ss') ||
-    isValid(d, 'YYYY-MM-DD HH:mm:ss.SSS') ||
+    isValid(d, 'YYYY-MM-DD HH:mm:ss.sss') ||
     isValid(d, 'YYYY-MM-DD') ||
-    new Date(d).toISOString() === d
+    moment(d).toISOString() === d
   )
 }
 
@@ -57,7 +57,7 @@ const getFormat = (d: string): string => {
   if (isValid(d, 'YYYY-MM-DD HH:mm:ss')) {
     return 'YYYY-MM-DD HH:mm:ss'
   }
-  if (isValid(d, 'YYYY-MM-DD HH:mm:ss.SSS')) {
+  if (isValid(d, 'YYYY-MM-DD HH:mm:ss.sss')) {
     return 'YYYY-MM-DD HH:mm:ss.sss'
   }
   return null

--- a/src/shared/components/dateRangePicker/DatePicker.tsx
+++ b/src/shared/components/dateRangePicker/DatePicker.tsx
@@ -20,6 +20,7 @@ import {getTimeZone} from 'src/dashboards/selectors'
 
 // Constants
 import {DEFAULT_TIME_FORMAT} from 'src/utils/datetime/constants'
+import {isValid} from 'src/utils/datetime/validator'
 
 interface Props {
   label: string
@@ -38,25 +39,25 @@ interface State {
 
 const isValidRTC3339 = (d: string): boolean => {
   return (
-    moment(d, 'YYYY-MM-DD HH:mm', true).isValid() ||
-    moment(d, 'YYYY-MM-DD HH:mm:ss', true).isValid() ||
-    moment(d, 'YYYY-MM-DD HH:mm:ss.SSS', true).isValid() ||
-    moment(d, 'YYYY-MM-DD', true).isValid() ||
-    moment(d).toISOString() === d
+    isValid(d, 'YYYY-MM-DD HH:mm') ||
+    isValid(d, 'YYYY-MM-DD HH:mm:ss') ||
+    isValid(d, 'YYYY-MM-DD HH:mm:ss.SSS') ||
+    isValid(d, 'YYYY-MM-DD') ||
+    new Date(d).toISOString() === d
   )
 }
 
 const getFormat = (d: string): string => {
-  if (moment(d, 'YYYY-MM-DD', true).isValid()) {
+  if (isValid(d, 'YYYY-MM-DD')) {
     return 'YYYY-MM-DD'
   }
-  if (moment(d, 'YYYY-MM-DD HH:mm', true).isValid()) {
+  if (isValid(d, 'YYYY-MM-DD HH:mm')) {
     return 'YYYY-MM-DD HH:mm'
   }
-  if (moment(d, 'YYYY-MM-DD HH:mm:ss', true).isValid()) {
+  if (isValid(d, 'YYYY-MM-DD HH:mm:ss')) {
     return 'YYYY-MM-DD HH:mm:ss'
   }
-  if (moment(d, 'YYYY-MM-DD HH:mm:ss.SSS', true).isValid()) {
+  if (isValid(d, 'YYYY-MM-DD HH:mm:ss.SSS')) {
     return 'YYYY-MM-DD HH:mm:ss.sss'
   }
   return null


### PR DESCRIPTION
Closes: #2347
Part of #1844 

Now that we have a validator in our codebase, we can replace the moment's isValid in the datepicker.

_Video of the datepicker uploading soon_
<!-- Describe your proposed changes here. -->
