### PR TITLE
refactor: remove moment toISOString from AnnotationTimeInput.tsx

### DIFF
--- a/src/annotations/components/annotationForm/AnnotationTimeInput.tsx
+++ b/src/annotations/components/annotationForm/AnnotationTimeInput.tsx
@@ -14,6 +14,10 @@ import {ComponentStatus, Form, Input} from '@influxdata/clockface'
 
 // Context
 import {AppSettingContext} from 'src/shared/contexts/app'
+import {setTimeToUTC} from 'src/dashboards/selectors'
+
+// Utils
+import {convertAnnotationTime12to24} from 'src/shared/utils/dateTimeUtils'
 
 interface Props {
   onChange: (newTime: string) => void
@@ -45,7 +49,19 @@ export const AnnotationTimeInput: FC<Props> = (props: Props) => {
   )
 
   const isValidTimeFormat = (inputValue: string): boolean => {
-    const isValid = moment(inputValue, timeFormat, true).isValid()
+    let isValid = moment(inputValue, timeFormat, true).isValid()
+
+    // momentjs says this format is valid: '2021-07-19 12:01:20 P' whereas the Date library needs the extra M like this: '2021-07-19 12:01:20 PM'
+    // and that throws off the validation logic. temporary solution is to check whether meridian are the correct format
+    if (
+      isValid &&
+      !(
+        inputValue.split(' ')[2].toUpperCase() === 'AM' ||
+        inputValue.split(' ')[2].toUpperCase() === 'PM'
+      )
+    ) {
+      isValid = false
+    }
     props.onValidityCheck(isValid)
     return isValid
   }
@@ -74,19 +90,13 @@ export const AnnotationTimeInput: FC<Props> = (props: Props) => {
 
     if (isValidTimeFormat(event.target.value)) {
       if (timeZone === 'UTC') {
-        props.onChange(
-          moment
-            .utc(event.target.value, timeFormat)
-            .toDate()
-            .toISOString()
-        )
+        props.onChange(setTimeToUTC(event.target.value))
         return
       }
 
+      // we need to convert the timeformat from 12 to 24 because Firefox's Date implementation does not parse 12 hr formats
       props.onChange(
-        moment(event.target.value, timeFormat)
-          .toDate()
-          .toISOString()
+        new Date(convertAnnotationTime12to24(event.target.value)).toISOString()
       )
     }
   }

--- a/src/shared/utils/dateTimeUtils.ts
+++ b/src/shared/utils/dateTimeUtils.ts
@@ -42,3 +42,25 @@ export function addDurationToDate(
     }
   }
 }
+
+
+// this method converts annotations local time format [YYYY-MM-DD h:mm:ss A] from 12 hour to 24
+// this is needed because of the discrepencies between Date implementation between Chrome and Firefox
+// workaround is to convert the 12 hr time to 24 hr, so that it works in both browser environments.
+export const convertAnnotationTime12to24 = (time12h: string) => {
+  const [date, time, meridiem] = time12h.split(' ')
+
+  let hours = time.split(':')[0]
+  const minutes = time.split(':')[1]
+  const seconds = time.split(':')[2]
+
+  if (hours === '12') {
+    hours = '00'
+  }
+
+  if (meridiem.toUpperCase() === 'PM') {
+    hours = (parseInt(hours, 10) + 12).toString()
+  }
+
+  return `${date} ${hours}:${minutes}:${seconds}`
+}

--- a/src/shared/utils/dateTimeUtils.ts
+++ b/src/shared/utils/dateTimeUtils.ts
@@ -43,7 +43,6 @@ export function addDurationToDate(
   }
 }
 
-
 // this method converts annotations local time format [YYYY-MM-DD h:mm:ss A] from 12 hour to 24
 // this is needed because of the discrepencies between Date implementation between Chrome and Firefox
 // workaround is to convert the 12 hr time to 24 hr, so that it works in both browser environments.


### PR DESCRIPTION
Closes #2029

part of : #1844

This PR removes `moment` from `src/annotations/components/annotationForm/AnnotationTimeInput.tsx`
