### PR TITLE
chore: fix flaky pinned tests

### DIFF
--- a/cypress/e2e/cloud/pinned.test.ts
+++ b/cypress/e2e/cloud/pinned.test.ts
@@ -1,5 +1,4 @@
 import {Organization} from '../../../src/types'
-import {createFirstTask} from '../shared/tasks.test'
 
 describe('Pinned Items', () => {
   let orgID: string
@@ -144,14 +143,14 @@ describe('Pinned Items', () => {
             .then(({body}) => {
               cy.wrap(body.token).as('token')
               cy.getByTestID('tree-nav')
-              cy.getByTestID('nav-item-tasks').should('be.visible')
-              cy.getByTestID('nav-item-tasks').click()
+              cy.visit(`/orgs/${orgID}/tasks`)
+              cy.getByTestID('tree-nav')
             })
         )
       })
 
       taskName = 'Task'
-      createFirstTask(taskName, ({name}) => {
+      cy.createTaskFromEmpty(taskName, ({name}) => {
         return `import "influxdata/influxdb/v1{rightarrow}
 v1.tagValues(bucket: "${name}", tag: "_field"{rightarrow}
 from(bucket: "${name}"{rightarrow}

--- a/cypress/e2e/shared/tasks.test.ts
+++ b/cypress/e2e/shared/tasks.test.ts
@@ -1,4 +1,4 @@
-import {Organization, Bucket} from '../../../src/types'
+import {Organization} from '../../../src/types'
 
 // Chains of actions that involve hovering like below
 // cy.getByTestID('task-card')

--- a/cypress/e2e/shared/tasks.test.ts
+++ b/cypress/e2e/shared/tasks.test.ts
@@ -35,7 +35,7 @@ describe('Tasks', () => {
 
   it('can create a task', () => {
     const taskName = 'Task'
-    createFirstTask(taskName, ({name}) => {
+    cy.createTaskFromEmpty(taskName, ({name}) => {
       return `import "influxdata/influxdb/v1{rightarrow}
 v1.tagValues(bucket: "${name}", tag: "_field"{rightarrow}
 from(bucket: "${name}"{rightarrow}
@@ -60,7 +60,7 @@ from(bucket: "${name}"{rightarrow}
 
   it('can create a task using http.post', () => {
     const taskName = 'Task'
-    createFirstTask(taskName, () => {
+    cy.createTaskFromEmpty(taskName, () => {
       return `import "http"
 http.post(url: "https://foo.bar/baz", data: bytes(v: "body"))`
     })
@@ -461,7 +461,7 @@ http.post(url: "https://foo.bar/baz", data: bytes(v: "body"))`
     const interval = '12h'
     const offset = '30m'
     beforeEach(() => {
-      createFirstTask(
+      cy.createTaskFromEmpty(
         taskName,
         ({name}) => {
           return `import "influxdata/influxdb/v1{rightarrow}
@@ -796,30 +796,4 @@ const createTask = (
   cy.getByTestIDAndSetInputValue('task-form-schedule-input', every)
   cy.getByTestID('task-save-btn').click()
   cy.getByTestID('notification-success--dismiss').click()
-}
-
-export function createFirstTask(
-  name: string,
-  flux: (bucket: Bucket) => string,
-  interval: string = '24h',
-  offset: string = '20m'
-) {
-  cy.getByTestID('empty-tasks-list').within(() => {
-    cy.getByTestID('add-resource-dropdown--button').click()
-  })
-
-  cy.getByTestID('add-resource-dropdown--new').click()
-
-  cy.get<Bucket>('@bucket').then(bucket => {
-    cy.getByTestID('flux-editor').within(() => {
-      cy.get('textarea.inputarea')
-        .click({force: true})
-        .focused()
-        .type(flux(bucket), {force: true, delay: 2})
-    })
-  })
-
-  cy.getByInputName('name').type(name)
-  cy.getByTestID('task-form-schedule-input').type(interval)
-  cy.getByTestID('task-form-offset-input').type(offset)
 }

--- a/cypress/index.d.ts
+++ b/cypress/index.d.ts
@@ -40,6 +40,7 @@ import {
   upsertSecret,
   setFeatureFlags,
   quartzProvision,
+  createTaskFromEmpty,
 } from './support/commands'
 
 declare global {
@@ -88,6 +89,7 @@ declare global {
       setFeatureFlags: typeof setFeatureFlags
       upsertSecret: typeof upsertSecret
       quartzProvision: typeof quartzProvision
+      createTaskFromEmpty: typeof createTaskFromEmpty
     }
   }
 }

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -828,6 +828,32 @@ export const setFeatureFlags = (flags: FlagMap): Cypress.Chainable => {
   })
 }
 
+export const createTaskFromEmpty = (
+  name: string,
+  flux: (bucket: Bucket) => string,
+  interval: string = '24h',
+  offset: string = '20m'
+) => {
+  cy.getByTestID('empty-tasks-list').within(() => {
+    cy.getByTestID('add-resource-dropdown--button').click()
+  })
+
+  cy.getByTestID('add-resource-dropdown--new').click()
+
+  cy.get<Bucket>('@bucket').then(bucket => {
+    cy.getByTestID('flux-editor').within(() => {
+      cy.get('textarea.inputarea')
+        .click({force: true})
+        .focused()
+        .type(flux(bucket), {force: true, delay: 2})
+    })
+  })
+
+  cy.getByInputName('name').type(name)
+  cy.getByTestID('task-form-schedule-input').type(interval)
+  cy.getByTestID('task-form-offset-input').type(offset)
+}
+
 /* eslint-disable */
 // notification endpoints
 Cypress.Commands.add('createEndpoint', createEndpoint)
@@ -911,4 +937,5 @@ Cypress.Commands.add(
 )
 Cypress.Commands.add('getByTestIDAndSetInputValue', getByTestIDAndSetInputValue)
 Cypress.Commands.add('setFeatureFlags', setFeatureFlags)
+Cypress.Commands.add('createTaskFromEmpty', createTaskFromEmpty)
 /* eslint-enable */


### PR DESCRIPTION
Closes #2357

<!-- Describe your proposed changes here. -->
This hopefully addresses a flakiness in the pinned item tests related to tasks - i was seeing failures where it was attempting to hit the nav bar to get to tasks and it wasn't going there, so i made it a bit more explicit. Also, there was a function being imported from the tasks tests that was causing the pinned tests to run the entire tasks suite again, so i moved that to a command. 