### PR TITLE
refactor: replace moment toISOString from the DatePicker.tsx

### DIFF
--- a/src/shared/components/dateRangePicker/DatePicker.tsx
+++ b/src/shared/components/dateRangePicker/DatePicker.tsx
@@ -1,7 +1,6 @@
 // Libraries
 import React, {PureComponent, ChangeEvent} from 'react'
 import ReactDatePicker from 'react-datepicker'
-import moment from 'moment'
 import {connect} from 'react-redux'
 
 // Components
@@ -21,6 +20,7 @@ import {getTimeZone} from 'src/dashboards/selectors'
 // Constants
 import {DEFAULT_TIME_FORMAT} from 'src/utils/datetime/constants'
 import {isValid} from 'src/utils/datetime/validator'
+import {isISODate} from 'src/shared/utils/dateTimeUtils'
 
 interface Props {
   label: string
@@ -43,7 +43,7 @@ const isValidDatepickerFormat = (d: string): boolean => {
     isValid(d, 'YYYY-MM-DD HH:mm:ss') ||
     isValid(d, 'YYYY-MM-DD HH:mm:ss.sss') ||
     isValid(d, 'YYYY-MM-DD') ||
-    moment(d).toISOString() === d
+    isISODate(d)
   )
 }
 

--- a/src/shared/components/dateRangePicker/DatePicker.tsx
+++ b/src/shared/components/dateRangePicker/DatePicker.tsx
@@ -180,12 +180,13 @@ class DatePicker extends PureComponent<Props, State> {
   }
 
   private overrideInputState = (): void => {
-    const {dateTime} = this.props
+    const {dateTime, timeZone} = this.props
     const {inputFormat} = this.state
 
-    let value = moment(dateTime).toISOString()
+    let value = new Date(dateTime).toISOString()
     if (inputFormat) {
-      value = moment(dateTime).format(inputFormat)
+      const formatter = createDateTimeFormatter(inputFormat, timeZone)
+      value = formatter.format(dateTime)
     }
 
     this.setState({inputValue: value, inputFormat: getFormat(value)})

--- a/src/shared/utils/dateTimeUtils.test.ts
+++ b/src/shared/utils/dateTimeUtils.test.ts
@@ -1,4 +1,4 @@
-import {addDurationToDate} from './dateTimeUtils'
+import {addDurationToDate, isISODate} from './dateTimeUtils'
 
 // July 4th, 1983, 20:00:00 UTC ===> 1983-07-04T20:00:00.000Z
 const timestamp = 426196800000
@@ -32,5 +32,17 @@ describe('incrementDate', () => {
     const futureDate = addDurationToDate(new Date(timestamp), -1, 'd')
 
     expect(futureDate.toISOString()).toBe('1983-07-03T20:00:00.000Z')
+  })
+})
+
+describe('isISODate', function() {
+  it('should return true for a valid ISO date format', function() {
+    expect(isISODate('1983-07-03T20:00:00.000Z')).toBeTruthy()
+  })
+  it('should return false for an invalid ISO date format', function() {
+    expect(isISODate('1983-07-03A20:00:00.000')).toBeFalsy()
+  })
+  it('should return false for an empty string', function() {
+    expect(isISODate('')).toBeFalsy()
   })
 })

--- a/src/shared/utils/dateTimeUtils.ts
+++ b/src/shared/utils/dateTimeUtils.ts
@@ -46,6 +46,7 @@ export function addDurationToDate(
 // checks whether the passed date is ISO format
 // see: https://stackoverflow.com/a/52869830
 export function isISODate(dateString: string): boolean {
+  // this regex tests the input string for the ISO format, YYYY-MM-DDTHH:mm:ss.sssZ
   if (!/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/.test(dateString)) {
     return false
   }

--- a/src/shared/utils/dateTimeUtils.ts
+++ b/src/shared/utils/dateTimeUtils.ts
@@ -48,8 +48,7 @@ export function isISODate(dateString: string): boolean {
   try {
     const date = new Date(dateString)
     return date.toISOString() === dateString
-  }
-  catch (error) {
+  } catch (error) {
     return false
   }
 }

--- a/src/shared/utils/dateTimeUtils.ts
+++ b/src/shared/utils/dateTimeUtils.ts
@@ -42,3 +42,12 @@ export function addDurationToDate(
     }
   }
 }
+
+// checks whether the passed date is ISO format
+export function isISODate(dateString: string): boolean {
+  if (!/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/.test(dateString)) {
+    return false
+  }
+  const date = new Date(dateString)
+  return date.toISOString() === dateString
+}

--- a/src/shared/utils/dateTimeUtils.ts
+++ b/src/shared/utils/dateTimeUtils.ts
@@ -44,6 +44,7 @@ export function addDurationToDate(
 }
 
 // checks whether the passed date is ISO format
+// see: https://stackoverflow.com/a/52869830
 export function isISODate(dateString: string): boolean {
   if (!/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/.test(dateString)) {
     return false

--- a/src/shared/utils/dateTimeUtils.ts
+++ b/src/shared/utils/dateTimeUtils.ts
@@ -44,12 +44,12 @@ export function addDurationToDate(
 }
 
 // checks whether the passed date is ISO format
-// see: https://stackoverflow.com/a/52869830
 export function isISODate(dateString: string): boolean {
-  // this regex tests the input string for the ISO format, YYYY-MM-DDTHH:mm:ss.sssZ
-  if (!/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/.test(dateString)) {
+  try {
+    const date = new Date(dateString)
+    return date.toISOString() === dateString
+  }
+  catch (error) {
     return false
   }
-  const date = new Date(dateString)
-  return date.toISOString() === dateString
 }


### PR DESCRIPTION
Closes #2366
Part of #1844

Removes moment from `DatePicker`. 
