### PR TITLE
fix: add check for response status to fix flaky test

### DIFF
--- a/cypress/e2e/shared/secrets.test.ts
+++ b/cypress/e2e/shared/secrets.test.ts
@@ -27,7 +27,8 @@ describe('Secrets', () => {
     // Create secrets via the API, check visibility and sorting
     cy.get('@org').then(({id: orgID}: Organization) => {
       cy.upsertSecret(orgID, {toEverybody: 'rupees baby'})
-        .then(() => {
+        .then((resp: Response) => {
+          expect(resp.status).to.eq(204)
           cy.reload()
           cy.getByTestID('secret-card--toEverybody').should('be.visible')
           cy.getByTestID('copy-to-clipboard--toEverybody').should('exist')


### PR DESCRIPTION
The secrets test was failing on the cy.reload() and it seems most likely that this was because the feature flag had not persisted to redux yet.  I couldn't intercept the cy.upsertSecret as the API returned too quickly for cy.wait.

So I've added a check on the value of the response status code from the API hoping that will be enough extra time for Redux to do its thing.

Closes #2361 
