### PR TITLE
fix(telegraf): use logical or instead of nullish operator to allow empty strings

### DIFF
--- a/src/dataLoaders/components/collectorsWizard/select/SelectCollectorsStep.tsx
+++ b/src/dataLoaders/components/collectorsWizard/select/SelectCollectorsStep.tsx
@@ -41,7 +41,7 @@ type Props = OwnProps & ReduxProps
 @ErrorHandling
 export class SelectCollectorsStep extends PureComponent<Props> {
   public render() {
-    const selectedBucketName = this.props.bucket ?? this.props.buckets[0]?.name
+    const selectedBucketName = this.props.bucket || this.props.buckets[0]?.name
     return (
       <Form
         onSubmit={this.props.onIncrementCurrentStepIndex}


### PR DESCRIPTION
Closes #2371

The component that controls the overlay sends `''` (empty string) to the new telegraf overlay. Using `??` (which only fails on `null` and `undefined`) will erroneously fail this check.
