### PR TITLE
fix: always fetch latest OSS version info

### DIFF
--- a/src/shared/components/VersionInfoOSS.tsx
+++ b/src/shared/components/VersionInfoOSS.tsx
@@ -17,10 +17,8 @@ const VersionInfoOSS: FC = () => {
   const versionInfo = useSelector(getVersionInfo)
 
   useEffect(() => {
-    if (!versionInfo.version || !versionInfo.commit) {
-      dispatch(fetchVersionInfo())
-    }
-  })
+    dispatch(fetchVersionInfo())
+  }, [dispatch])
 
   return (
     <>


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/22210

This is a small update to ensure that the OSS version info is always fetched anew when a component that displays the version info is rendered.

Previously it would only fetch the version info if the info was not currently present in state. This has proven to be problematic when people do OSS updates, since the state from the previous version was being re-generated from local storage which included the old version info, rather than the new version info. This would make it seem like the UI had not been updated with the OSS update, etc.

Making a new API call every time the version info component is rendered is doubtlessly less efficient than storing the information for use between renderings, but will ensure a consistent visual representation of the OSS version when the server is upgraded. The payload for this API call is small and the component is not in a high-traffic part of the application, so the performance impact should be insignificant.