### PR TITLE
fix: remove conditional imports to get maps to not error when requesting data

### DIFF
--- a/src/visualization/types/Map/index.tsx
+++ b/src/visualization/types/Map/index.tsx
@@ -1,20 +1,9 @@
-import icon from './icon'
-import {CLOUD} from 'src/shared/constants'
-
-let properties = null
-let options = null
-let view = null
-
-if (CLOUD) {
-  properties = require('./properties')
-  view = require('./view')
-  options = require('./GeoOptions').GeoOptions
-}
+import icon from 'src/visualization/types/Map/icon'
+import properties from 'src/visualization/types/Map/properties'
+import view from 'src/visualization/types/Map/view'
+import {GeoOptions as options} from 'src/visualization/types/Map/GeoOptions'
 
 export default register => {
-  if (!CLOUD) {
-    return
-  }
   register({
     type: 'geo',
     name: 'Map',

--- a/src/visualization/types/Map/view.tsx
+++ b/src/visualization/types/Map/view.tsx
@@ -17,7 +17,11 @@ import {
 import {event} from 'src/cloud/utils/reporting'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {CLOUD} from 'src/shared/constants'
-import {getMapToken} from 'src/client/mapsdRoutes'
+let getMapToken = null
+
+if (CLOUD) {
+  getMapToken = require('src/client/mapsdRoutes').getMapToken
+}
 
 interface Props extends VisualizationProps {
   properties: GeoViewProperties

--- a/src/visualization/types/Map/view.tsx
+++ b/src/visualization/types/Map/view.tsx
@@ -17,12 +17,8 @@ import {
 import {event} from 'src/cloud/utils/reporting'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {CLOUD} from 'src/shared/constants'
+import {getMapToken} from 'src/client/mapsdRoutes'
 
-let getMapToken = null
-
-if (CLOUD) {
-  getMapToken = require('src/client/mapsdRoutes').getMapToken
-}
 interface Props extends VisualizationProps {
   properties: GeoViewProperties
 }


### PR DESCRIPTION
This PR attempts to fix the issue where displaying the `maps` visualization was rendering an `InfluxDB Error has occurred`, but where the data was actually there. It appears as though some of the conditional import that was being used to separate the OSS build from the Cloud build contributed to these failures, this PR is an attempt to see if that separation is still necessary, and whether removing that conditional logic resolves this issue.

Unfortunately, every attempt made to query the maps endpoint returned a 500 error in remocal locally so I'm not certain if there's a gap in implementation that needs to be filled for remocal, or if that's to be expected anywhere but in production