### PR TITLE
fix: add return to handle promise correctly

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -142,7 +142,7 @@ export const wrapEnvironmentVariablesForCloud = (): Cypress.Chainable<Cypress.Re
             b.name !== '_monitoring'
         )
         cy.wrap(bucket).as('bucket')
-        wrapDefaultBucket()
+        return wrapDefaultBucket()
       })
     })
 }


### PR DESCRIPTION
Noticed a bunch of tests were failing because the request to `/api/v2/me` was being aborted. I think this is because we were missing an explicit return in the `cy.signin()` chain. So basically it is possible that the signin flow isn't fully completed before the test starts execution. 