### PR TITLE
chore: change notebooks alerts panel endpoints to dropdown and fix firefox tests for pinned items

### DIFF
--- a/cypress/e2e/cloud/pinned.test.ts
+++ b/cypress/e2e/cloud/pinned.test.ts
@@ -71,11 +71,12 @@ describe('Pinned Items', () => {
           .first()
           .click()
 
+        cy.intercept('PUT', '**/pinned/*').as('updatePinned')
         cy.get('.cf-input-field')
           .type('Bucks In Six')
           .type('{enter}')
       })
-
+      cy.wait('@updatePinned')
       cy.visit('/')
       cy.getByTestID('tree-nav')
       cy.getByTestID('pinneditems--container').within(() => {
@@ -188,12 +189,12 @@ from(bucket: "${name}"{rightarrow}
           .first()
           .click()
 
+        cy.intercept('PUT', '**/pinned/*').as('updatePinned')
         cy.get('.cf-input-field')
           .type('Bucks In Six')
           .type('{enter}')
       })
-
-      cy.visit('/')
+      cy.wait('@updatePinned')
       cy.getByTestID('tree-nav')
       cy.getByTestID('pinneditems--container').within(() => {
         cy.getByTestID('pinneditems--link').should(
@@ -282,12 +283,14 @@ from(bucket: "${name}"{rightarrow}
       cy.getByTestID('flow-card--name-button')
         .first()
         .click()
+      cy.intercept('PUT', '**/pinned/*').as('updatePinned')
 
       cy.get('.cf-input-field')
         .last()
         .focus()
         .type('Bucks In Six')
         .type('{enter}')
+      cy.wait('@updatePinned')
       cy.visit('/')
       cy.getByTestID('tree-nav')
       cy.getByTestID('pinneditems--container').within(() => {

--- a/cypress/e2e/cloud/pinned.test.ts
+++ b/cypress/e2e/cloud/pinned.test.ts
@@ -195,6 +195,7 @@ from(bucket: "${name}"{rightarrow}
           .type('{enter}')
       })
       cy.wait('@updatePinned')
+      cy.visit('/')
       cy.getByTestID('tree-nav')
       cy.getByTestID('pinneditems--container').within(() => {
         cy.getByTestID('pinneditems--link').should(

--- a/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -217,7 +217,11 @@ class DashboardCard extends PureComponent<Props> {
     const {id, onUpdateDashboard} = this.props
 
     onUpdateDashboard(id, {description})
-    updatePinnedItemByParam(id, {description})
+    try {
+      updatePinnedItemByParam(id, {description})
+    } catch (err) {
+      this.props.sendNotification(pinnedItemFailure(err.message, 'dashboard'))
+    }
   }
 
   private handleAddLabel = (label: Label) => {

--- a/src/flows/components/header/index.tsx
+++ b/src/flows/components/header/index.tsx
@@ -32,7 +32,11 @@ const FlowHeader: FC = () => {
 
   const handleRename = (name: string) => {
     update({name})
-    updatePinnedItemByParam(id, {name})
+    try {
+      updatePinnedItemByParam(id, {name})
+    } catch (err) {
+      console.error(err)
+    }
   }
 
   const printJSON = () => {

--- a/src/flows/pipes/Notification/styles.scss
+++ b/src/flows/pipes/Notification/styles.scss
@@ -1,0 +1,4 @@
+.flows-endpoints--dropdown {
+  max-width: 13%;
+  background: #181820;
+}

--- a/src/flows/pipes/Notification/view.tsx
+++ b/src/flows/pipes/Notification/view.tsx
@@ -15,7 +15,6 @@ import {
   AlignItems,
   JustifyContent,
   Dropdown,
-  InfluxColors,
 } from '@influxdata/clockface'
 import {RemoteDataState} from 'src/types'
 

--- a/src/flows/pipes/Notification/view.tsx
+++ b/src/flows/pipes/Notification/view.tsx
@@ -10,12 +10,12 @@ import {
   Icon,
   IconFont,
   ComponentSize,
-  Tabs,
-  Orientation,
   Panel,
   TextArea,
   AlignItems,
   JustifyContent,
+  Dropdown,
+  InfluxColors,
 } from '@influxdata/clockface'
 import {RemoteDataState} from 'src/types'
 
@@ -34,6 +34,9 @@ import {PipeProp} from 'src/types/flows'
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'
+
+// Styles
+import 'src/flows/pipes/Notification/styles.scss'
 
 const Notification: FC<PipeProp> = ({Context}) => {
   const {id, data, update, results, loading} = useContext(PipeContext)
@@ -148,13 +151,14 @@ const Notification: FC<PipeProp> = ({Context}) => {
   }, [hasTaskOption])
 
   const avail = Object.keys(DEFAULT_ENDPOINTS).map(k => (
-    <Tabs.Tab
+    <Dropdown.Item
       key={k}
       id={k}
       onClick={() => updateEndpoint(k)}
-      text={DEFAULT_ENDPOINTS[k].name}
-      active={data.endpoint === k}
-    />
+      selected={data.endpoint === k}
+    >
+      {DEFAULT_ENDPOINTS[k].name}
+    </Dropdown.Item>
   ))
 
   const generateTask = useCallback(() => {
@@ -352,9 +356,9 @@ ${DEFAULT_ENDPOINTS[data.endpoint]?.generateQuery(data.endpointData)}`
           </FlexBox.Child>
         </FlexBox>
         <FlexBox alignItems={AlignItems.Stretch} margin={ComponentSize.Medium}>
-          <FlexBox.Child grow={0} shrink={0}>
-            <Tabs orientation={Orientation.Vertical}>{avail}</Tabs>
-          </FlexBox.Child>
+          <Dropdown.Menu className="flows-endpoints--dropdown">
+            {avail}
+          </Dropdown.Menu>
           <FlexBox.Child grow={1} shrink={1}>
             {React.createElement(DEFAULT_ENDPOINTS[data.endpoint].view)}
           </FlexBox.Child>


### PR DESCRIPTION
Closes #

<!-- Describe your proposed changes here. -->
This change should address the flakiness in the firefox pinned items tests, hopefully, along the way, but the main point is this: 
![Screen Shot 2021-08-18 at 2 51 17 PM](https://user-images.githubusercontent.com/29473622/129962998-5ecc4c41-7859-47fe-8875-c99cb68f2833.png)
