### PR TITLE
test(annotations e2e): target visible overlay component to avoid flakiness

### DIFF
--- a/cypress/e2e/util/annotationsSetup.ts
+++ b/cypress/e2e/util/annotationsSetup.ts
@@ -76,15 +76,17 @@ export const addAnnotation = (cy: Cypress.Chainable) => {
     cy.getByTestID('giraffe-inner-plot').click({shiftKey: true})
   })
 
-  cy.getByTestID('overlay--container').within(() => {
-    cy.getByTestID('edit-annotation-message').should('be.visible')
+  cy.getByTestID('overlay--container')
+    .filter(':visible')
+    .within(() => {
+      cy.getByTestID('edit-annotation-message').should('be.visible')
 
-    cy.getByTestID('edit-annotation-message')
-      .click()
-      .focused()
-      .type('im a hippopotamus')
-    cy.getByTestID('annotation-submit-button').click()
-  })
+      cy.getByTestID('edit-annotation-message')
+        .click()
+        .focused()
+        .type('im a hippopotamus')
+      cy.getByTestID('annotation-submit-button').click()
+    })
 }
 
 export const startEditingAnnotation = (cy: Cypress.Chainable) => {
@@ -99,26 +101,32 @@ export const startEditingAnnotation = (cy: Cypress.Chainable) => {
 export const editAnnotation = (cy: Cypress.Chainable) => {
   startEditingAnnotation(cy)
 
-  cy.getByTestID('overlay--container').within(() => {
-    cy.getByTestID('edit-annotation-message')
-      .should('be.visible', 1)
-      .clear()
+  cy.getByTestID('overlay--container')
+    .filter(':visible')
+    .within(() => {
+      cy.getByTestID('edit-annotation-message')
+        .should('be.visible')
+        .clear()
 
-    cy.getByTestID('edit-annotation-message')
-      .should('be.visible', 1)
-      .type('lets edit this annotation...')
+      cy.getByTestID('edit-annotation-message')
+        .should('be.visible')
+        .type('lets edit this annotation...')
 
-    cy.getByTestID('annotation-submit-button')
-      .should('be.visible', 1)
-      .click()
-  })
+      cy.getByTestID('annotation-submit-button')
+        .should('be.visible')
+        .click()
+    })
 }
 
 export const deleteAnnotation = (cy: Cypress.Chainable) => {
   // should have the annotation created , lets click it to show the modal.
   startEditingAnnotation(cy)
 
-  cy.getByTestID('delete-annotation-button').click()
+  cy.getByTestID('overlay--container')
+    .filter(':visible')
+    .within(() => {
+      cy.getByTestID('delete-annotation-button').click()
+    })
 
   // reload to make sure the annotation was deleted from the backend as well.
   reloadAndHandleAnnotationDefaultStatus()
@@ -172,18 +180,20 @@ export const addRangeAnnotation = (
     })
   })
 
-  cy.getByTestID('overlay--container').within(() => {
-    cy.getByTestID('edit-annotation-message')
-      .should('be.visible')
-      .click()
-      .focused()
-      .type('range annotation here!')
+  cy.getByTestID('overlay--container')
+    .filter(':visible')
+    .within(() => {
+      cy.getByTestID('edit-annotation-message')
+        .should('be.visible')
+        .click()
+        .focused()
+        .type('range annotation here!')
 
-    // make sure the two times (start and end) are not equal:
-    ensureRangeAnnotationTimesAreNotEqual(cy)
+      // make sure the two times (start and end) are not equal:
+      ensureRangeAnnotationTimesAreNotEqual(cy)
 
-    cy.getByTestID('annotation-submit-button').click()
-  })
+      cy.getByTestID('annotation-submit-button').click()
+    })
 }
 
 export const testAddAnnotation = (cy: Cypress.Chainable) => {
@@ -222,13 +232,17 @@ export const testEditRangeAnnotation = (
 
   startEditingAnnotation(cy)
 
-  cy.getByTestID('edit-annotation-message')
-    .should('have.length.of.at.least', 1)
-    .clear()
+  cy.getByTestID('overlay--container')
+    .filter(':visible')
+    .within(() => {
+      cy.getByTestID('edit-annotation-message')
+        .should('be.visible')
+        .clear()
 
-  cy.getByTestID('edit-annotation-message')
-    .should('have.length.of.at.least', 1)
-    .type('editing the text here for the range annotation')
+      cy.getByTestID('edit-annotation-message')
+        .should('be.visible')
+        .type('editing the text here for the range annotation')
+    })
 
   ensureRangeAnnotationTimesAreNotEqual(cy)
 


### PR DESCRIPTION
closes #2344
closes #2369

Cypress apparently has an issue where it will render the same component in the DOM twice, then fail tests that target that element because it assumes it's targeting a single element. We were seeing these issues in our annotations e2e tests on remocal where the annotations overlay would be rendered twice.

![screen_shot_2021-08-18_at_3 36 18_pm](https://user-images.githubusercontent.com/146112/130101865-38eea684-837a-4a45-924d-de1e68e713c9.png)

The fix is to target the visible instance of the overlay. I tested this by running the suite 15 times. There were three failures: one chunk loading issue and two timeouts from my computer being taxed, but no failures from detached DOM elements.

![Screen Shot 2021-08-19 at 8 49 33 AM](https://user-images.githubusercontent.com/146112/130102045-7b4ee024-1181-4d3d-b7b8-cb50827e27a6.png)

