### PR TITLE
fix: wait for root page to load before continuing test

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -113,7 +113,6 @@ export const loginViaDex = (username: string, password: string) => {
                 })
                 .then(() => {
                   cy.visit('/')
-                  // cy.getCookie('session').should('exist')
                   cy.location('pathname').should('not.eq', '/signin')
                   return cy.getByTestID('tree-nav')
                 })

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -87,33 +87,38 @@ export const loginViaDex = (username: string, password: string) => {
           followRedirect: false,
           method: 'GET',
         })
-        .then(secondResp => {
-          cy.request({
-            url: Cypress.env(DEX_URL_VAR) + secondResp.headers.location,
-            method: 'POST',
-            form: true,
-            body: {
-              login: username,
-              password: password,
-            },
-            followRedirect: false,
-          }).then(thirdResp => {
-            const req = (thirdResp.headers.location as string).split(
-              '/approval?req='
-            )[1]
-            cy.request({
-              url: thirdResp.redirectedToUrl,
-              followRedirect: true,
-              form: true,
+        .then(secondResp =>
+          cy
+            .request({
+              url: Cypress.env(DEX_URL_VAR) + secondResp.headers.location,
               method: 'POST',
-              body: {req: req, approval: 'approve'},
-            }).then(() => {
-              cy.visit('/')
-              // cy.getCookie('session').should('exist')
-              cy.location('pathname').should('not.eq', '/signin')
+              form: true,
+              body: {
+                login: username,
+                password: password,
+              },
+              followRedirect: false,
             })
-          })
-        })
+            .then(thirdResp => {
+              const req = (thirdResp.headers.location as string).split(
+                '/approval?req='
+              )[1]
+              return cy
+                .request({
+                  url: thirdResp.redirectedToUrl,
+                  followRedirect: true,
+                  form: true,
+                  method: 'POST',
+                  body: {req: req, approval: 'approve'},
+                })
+                .then(() => {
+                  cy.visit('/')
+                  // cy.getCookie('session').should('exist')
+                  cy.location('pathname').should('not.eq', '/signin')
+                  return cy.getByTestID('tree-nav')
+                })
+            })
+        )
     )
 }
 


### PR DESCRIPTION
Still trying to hunt down the cause for the timeouts during the initial UI page load in CI. The /api/v2/me requests are being aborted which means that we're navigating away from the root page prematurely. And because the request is aborted, the auth flows gets screwed up which causes the infinite spinner.

Going to try and wait for the page to load after the initial `cy.visit('/')` to see if that helps. I also cleaned up the handling of promises in the loginViaDex function
