### PR TITLE
test: add workaround for broken orgs test due to bug

### DIFF
--- a/cypress/e2e/cloud/orgs.test.ts
+++ b/cypress/e2e/cloud/orgs.test.ts
@@ -10,7 +10,8 @@ describe('Orgs', () => {
       cy.signin().then(() => {
         cy.get('@org').then(({id}: Organization) => cy.deleteOrg(id))
       })
-
+      // Have to clear local storage to work around this bug: https://github.com/influxdata/ui/issues/2427
+      cy.clearLocalStorage()
       cy.visit('/')
     })
 


### PR DESCRIPTION
Due to [this issue](https://github.com/influxdata/ui/issues/2427) we need to clear local storage before visiting the home page after deleting the org. This bug exposed itself after [this commit](https://github.com/influxdata/ui/commit/8ace8ccc219795a9000364eab5fd05b00f932952) forced all tests to wait for the homepage to load before beginning test execution (which is an intentional change that we want to keep).
