### PR TITLE
test: edit the annotation via api body instead of ui

### DIFF
--- a/cypress/e2e/util/annotationsSetup.ts
+++ b/cypress/e2e/util/annotationsSetup.ts
@@ -104,17 +104,23 @@ export const editAnnotation = (cy: Cypress.Chainable) => {
   cy.getByTestID('overlay--container')
     .filter(':visible')
     .within(() => {
-      cy.getByTestID('edit-annotation-message')
-        .should('be.visible')
-        .clear()
-
-      cy.getByTestID('edit-annotation-message')
-        .should('be.visible')
-        .type('lets edit this annotation...')
+      // interacting with the 'edit-annotation-message' box is unstable, causes flaky tests.
+      // to work around the issue, lets update the annotation by intercepting the request body.
+      cy.intercept(
+        'PUT',
+        '**/annotations/*',
+        (req: any) =>
+          (req.body = {
+            ...req.body,
+            summary: 'lets edit this annotation...',
+          })
+      ).as('updateAnnotation')
 
       cy.getByTestID('annotation-submit-button')
         .should('be.visible')
         .click()
+
+      cy.wait('@updateAnnotation')
     })
 }
 

--- a/cypress/e2e/util/annotationsSetup.ts
+++ b/cypress/e2e/util/annotationsSetup.ts
@@ -104,17 +104,30 @@ export const editAnnotation = (cy: Cypress.Chainable) => {
   cy.getByTestID('overlay--container')
     .filter(':visible')
     .within(() => {
-      // interacting with the 'edit-annotation-message' box is unstable, causes flaky tests.
-      // to work around the issue, lets update the annotation by intercepting the request body.
-      cy.intercept(
-        'PUT',
-        '**/annotations/*',
-        (req: any) =>
-          (req.body = {
-            ...req.body,
-            summary: 'lets edit this annotation...',
-          })
-      ).as('updateAnnotation')
+      if (Cypress.browser.name === 'firefox') {
+        // interacting with the 'edit-annotation-message' box is unstable in Firefox, causes flaky tests.
+        // to work around the issue, lets update the annotation by intercepting the request body.
+        cy.intercept(
+          'PUT',
+          '**/annotations/*',
+          (req: any) =>
+            (req.body = {
+              ...req.body,
+              summary: 'lets edit this annotation...',
+            })
+        ).as('updateAnnotation')
+      } else {
+        // for Chrome et. al., continue interacting with the UI per usual
+        cy.getByTestID('edit-annotation-message')
+          .should('be.visible')
+          .clear()
+
+        cy.getByTestID('edit-annotation-message')
+          .should('be.visible')
+          .type('lets edit this annotation...')
+
+        cy.intercept('PUT', '**/annotations/*').as('updateAnnotation')
+      }
 
       cy.getByTestID('annotation-submit-button')
         .should('be.visible')


### PR DESCRIPTION
Closes #2334

Interacting with the `edit-annotation-message` element makes these tests flaky. We've found no way to ensure that the input box doesn't become detached from the DOM. So instead of editing the annotation via the UI, we'll edit the request body of the API request to update the annotation.