### PR TITLE
chore: reduce the size of the first overlay in Plugin page configuration creation

### DIFF
--- a/src/writeData/components/PluginCreateConfigurationWizard.tsx
+++ b/src/writeData/components/PluginCreateConfigurationWizard.tsx
@@ -25,7 +25,7 @@ import {clearDataLoaders} from 'src/dataLoaders/actions/dataLoaders'
 import {BUCKET_OVERLAY_WIDTH} from 'src/buckets/constants'
 
 const PLUGIN_CREATE_CONFIGURATION_OVERLAY_DEFAULT_WIDTH = 1200
-const PLUGIN_CREATE_CONFIGURATION_OVERLAY_OPTIONS_WIDTH = 800
+const PLUGIN_CREATE_CONFIGURATION_OVERLAY_OPTIONS_WIDTH = 480
 
 const spinner = <div />
 const PluginCreateConfigurationStepSwitcher = Loadable({


### PR DESCRIPTION
Part of #1555 

BEFORE, too wide:
<img width="1680" alt="Screen Shot 2021-08-19 at 1 47 54 PM" src="https://user-images.githubusercontent.com/10736577/130522097-5edab185-9515-43cb-9cea-9cd579753507.png">


AFTER, much better:
<img width="1680" alt="Screen Shot 2021-08-19 at 1 48 33 PM" src="https://user-images.githubusercontent.com/10736577/130522123-d9ab58f5-8cdd-4c66-9159-322d6e8a0c74.png">

