### PR TITLE
build(lsp): Upgrade to flux-lsp-browser v0.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "@docsearch/react": "^3.0.0-alpha.37",
     "@influxdata/clockface": "^2.11.5",
     "@influxdata/flux": "^0.5.1",
-    "@influxdata/flux-lsp-browser": "^0.5.53",
+    "@influxdata/flux-lsp-browser": "^0.6.2",
     "@influxdata/giraffe": "^2.18.0",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -853,10 +853,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-2.11.5.tgz#7de207688806d42750726fbdd63f84466c355794"
   integrity sha512-0Uj9xst/4PfkYDHnW/0Ew22F0Ilo/QqsZnNKlvdey1xYlQ6cXl0CSL9BpaFrEbdoNQ9Yg8E1/l+zeDvwUXkQhg==
 
-"@influxdata/flux-lsp-browser@^0.5.53":
-  version "0.5.53"
-  resolved "https://registry.yarnpkg.com/@influxdata/flux-lsp-browser/-/flux-lsp-browser-0.5.53.tgz#03df756afa3e22d69310021d7c11e968bb8e1c0b"
-  integrity sha512-7cT2O2xJOD94/B7Cyp5I7ei5vX/vOsnuu4iaW/68rOTlKi1TCCpb8Lqu4fTrf8As16YwTFREOTIw9eHgE3Bh9Q==
+"@influxdata/flux-lsp-browser@^0.6.2":
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/@influxdata/flux-lsp-browser/-/flux-lsp-browser-0.6.2.tgz#877f8830329098a7483750c016203e67dcebb2ed"
+  integrity sha512-Ow1LDLkehDBwxt5imxQqSb5hajtYEv2ilFjAg4DQHvjoAzx6svupCEziVeWr9tQW3npzltC+0Q7NmHqfxjseKw==
 
 "@influxdata/flux@^0.5.1":
   version "0.5.1"


### PR DESCRIPTION
Upgrade flux-lsp-browser to [v0.6.2](https://github.com/influxdata/flux-lsp/releases/tag/v0.6.2)