### PR TITLE
chore: change alerts activity text

### DIFF
--- a/src/checks/components/CheckActivityTableField.tsx
+++ b/src/checks/components/CheckActivityTableField.tsx
@@ -22,7 +22,7 @@ const CheckActivityTableField: FC<Props> = ({row: {checkName, checkID}}) => {
     return (
       <div
         className="check-name-field"
-        title="The check that created this no longer exists"
+        title="This status was generated from a custom alert Task"
       >
         {checkName}
       </div>


### PR DESCRIPTION
Closes #2422 


When you hover over a custom task which is listed in the Alerts Activity table, the current message is: `The check that created this no longer exists`. This needs to be updated so that this message makes more sense and is more relevant to the actual scenario where this activity row is actually generated by a custom task. New message: `This status was generated from a custom alert Task`
