### PR TITLE
feat: integrate test notifications for endpoints

### DIFF
--- a/src/flows/pipes/Notification/Endpoints.tsx
+++ b/src/flows/pipes/Notification/Endpoints.tsx
@@ -2,6 +2,8 @@ import Slack from 'src/flows/pipes/Notification/Slack'
 import PagerDuty from 'src/flows/pipes/Notification/PagerDuty'
 import HTTP from 'src/flows/pipes/Notification/HTTP'
 
+const TEST_NOTIFICATION = 'This is a test notification'
+
 export const DEFAULT_ENDPOINTS = {
   slack: {
     name: 'Slack',
@@ -12,6 +14,8 @@ export const DEFAULT_ENDPOINTS = {
     },
     view: Slack,
     generateImports: () => ['slack'].map(i => `import "${i}"`).join('\n'),
+    generateTestImports: () =>
+      ['array', 'slack'].map(i => `import "${i}"`).join('\n'),
     generateQuery: data => `task_data
 	|> schema["fieldsAsCols"]()
 	|> monitor["check"](
@@ -27,6 +31,16 @@ export const DEFAULT_ENDPOINTS = {
       color: "${data.color || '#34BB55'}"
     }))
   )`,
+    generateTestQuery: data => `
+  slack.message(
+    url: "${data.url}",
+    channel: "${data.channel || ''}",
+    text: "${TEST_NOTIFICATION}",
+    color: "${data.color || '#34BB55'}"
+  )
+
+  array.from(rows: [{value: 0}])
+	|> yield(name: "ignore")`,
   },
   http: {
     name: 'HTTP Post',
@@ -37,6 +51,8 @@ export const DEFAULT_ENDPOINTS = {
     view: HTTP,
     generateImports: () =>
       ['http', 'json'].map(i => `import "${i}"`).join('\n'),
+    generateTestImports: () =>
+      ['array', 'http', 'json'].map(i => `import "${i}"`).join('\n'),
     generateQuery: data => {
       const headers = [['"Content-Type"', '"application/json"']]
 
@@ -71,6 +87,34 @@ export const DEFAULT_ENDPOINTS = {
   }))`
       return out
     },
+    generateTestQuery: data => {
+      const headers = [['"Content-Type"', '"application/json"']]
+
+      if (data.auth === 'basic') {
+        headers.push([
+          'Authorization',
+          `http.basicAuth(u:"${data.username}", p:"${data.password}")`,
+        ])
+      }
+
+      if (data.auth === 'bearer') {
+        headers.push(['Authorization', `"Bearer ${data.token}"`])
+      }
+
+      const _headers = headers
+        .reduce((acc, curr) => {
+          acc.push(`${curr[0]}: ${curr[1]}`)
+          return acc
+        }, [])
+        .join(', ')
+
+      return `http["endpoint"](url: "${data.url}")(mapFn: (r) => {
+      return {headers: {${_headers}}, data: json["encode"](v: "${TEST_NOTIFICATION}")}
+  })
+
+  array.from(rows: [{value: 0}])
+	|> yield(name: "ignore")`
+    },
   },
   pagerduty: {
     name: 'Pager Duty',
@@ -80,16 +124,20 @@ export const DEFAULT_ENDPOINTS = {
       level: 'warning',
     },
     view: PagerDuty,
+    generateTestImports: () =>
+      ['array', 'pagerduty', 'influxdata/influxdb/secrets']
+        .map(i => `import "${i}"`)
+        .join('\n'),
     generateImports: () =>
       ['pagerduty', 'influxdata/influxdb/secrets']
         .map(i => `import "${i}"`)
         .join('\n'),
     generateQuery: data => `task_data
 	|> schema["fieldsAsCols"]()
-	|> monitor["check"](
+  |> monitor["check"](
 		data: check,
 		messageFn: messageFn,
-		crit: trigger,
+    crit: trigger,
 	)
 	|> monitor["notify"](data: notification, endpoint: pagerduty["endpoint"]()(mapFn: (r) => ({
         routingKey: "${data.key}",
@@ -99,9 +147,24 @@ export const DEFAULT_ENDPOINTS = {
         group: r["_source_measurement"],
         severity: pagerduty["severityFromLevel"](level: ${data.level}),
         eventAction: pagerduty["actionFromLevel"](level: ${data.level}),
-          source: notification["_notification_rule_name"],
-          summary: r["_message"],
-          timestamp: time(v: r["_source_timestamp"]),
+        source: notification["_notification_rule_name"],
+        summary: r["_message"],
+        timestamp: time(v: r["_source_timestamp"]),
   })))`,
+    generateTestQuery: data => `pagerduty["endpoint"]()(mapFn: (r) => ({
+      routingKey: "${data.key}",
+      client: "influxdata",
+      clientURL: "${data.url}",
+      class: r._check_name,
+      group: r["_source_measurement"],
+      severity: "critical",
+      eventAction: "trigger",
+      source: "Notebook Generated Test Notification",
+      summary: "${TEST_NOTIFICATION}",
+      timestamp: time(v: r["_source_timestamp"])
+}))
+  array.from(rows: [{value: 0}])
+	|> yield(name: "ignore")
+`,
   },
 }

--- a/src/flows/pipes/Notification/PagerDuty.tsx
+++ b/src/flows/pipes/Notification/PagerDuty.tsx
@@ -43,7 +43,7 @@ const PagerDuty: FC = () => {
       <Form.Element label="Routing Key">
         <Input
           name="key"
-          type={InputType.Text}
+          type={InputType.Password}
           value={data.endpointData.key}
           onChange={updateKey}
           size={ComponentSize.Medium}

--- a/src/shared/copy/notifications.ts
+++ b/src/shared/copy/notifications.ts
@@ -1420,3 +1420,17 @@ export const pinnedItemSuccess = (
   icon: IconFont.Star,
   message: `Successfully ${pinAction} pinned ${pinItemType} to homepage`,
 })
+
+export const testNotificationSuccess = (
+  source: 'slack' | 'pagerduty' | 'https'
+): Notification => ({
+  ...defaultSuccessNotification,
+  message: `A test alert has been sent to ${source}`,
+})
+
+export const testNotificationFailure = (
+  source: 'slack' | 'pagerduty' | 'https'
+): Notification => ({
+  ...defaultErrorNotification,
+  message: `Failed to send the test alert to ${source}. Please try again`,
+})

--- a/src/timeMachine/components/SubmitQueryButton.tsx
+++ b/src/timeMachine/components/SubmitQueryButton.tsx
@@ -30,6 +30,7 @@ import {getOrg} from 'src/organizations/selectors'
 import {AppState, RemoteDataState} from 'src/types'
 
 interface OwnProps {
+  color?: ComponentColor
   text?: string
   icon?: IconFont
   testID?: string
@@ -85,7 +86,7 @@ class SubmitQueryButton extends PureComponent<Props> {
   }
 
   public render() {
-    const {text, queryStatus, icon, testID, className} = this.props
+    const {color, text, queryStatus, icon, testID, className} = this.props
     if (queryStatus === RemoteDataState.Loading && this.state.timer) {
       return (
         <Button
@@ -108,7 +109,7 @@ class SubmitQueryButton extends PureComponent<Props> {
         size={ComponentSize.Small}
         status={this.buttonStatus}
         onClick={this.handleClick}
-        color={ComponentColor.Primary}
+        color={color ?? ComponentColor.Primary}
         testID={testID}
         style={{minWidth: '100px'}}
       />


### PR DESCRIPTION
Closes #2287

This PR adds the ability for a user to send a test notification with integrated services like making an http post request, a pagerduty alert, and a slack notification.
