### PR TITLE
test: update test e2e remocal script

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test:e2e:clean": "rm junit-results/*.xml",
     "test:e2e:all": "yarn test:e2e:clean && yarn test:e2e; yarn test:e2e:report;",
     "test:e2e:kind": "CYPRESS_dexUrl=http://dex-twodotoh.a.influxcloud.dev.local CYPRESS_baseUrl=https://twodotoh.a.influxcloud.dev.local CYPRESS_password=password cypress open --browser chrome --config chromeWebSecurity=false",
-    "test:e2e:remocal": "CYPRESS_dexUrl=https://dex-twodotoh-dev-${NS}.a.influxcloud.dev.local CYPRESS_baseUrl=https://twodotoh-dev-${NS}.a.influxcloud.dev.local CYPRESS_password=password cypress open --browser chrome --config chromeWebSecurity=false",
+    "test:e2e:remocal": "CYPRESS_dexUrl=https://dex-${NS}.a.influxcloud.dev.local CYPRESS_baseUrl=https://${NS}.a.influxcloud.dev.local CYPRESS_password=password cypress open --browser chrome --config chromeWebSecurity=false",
     "test:circleci": "yarn run test:ci --maxWorkers=2",
     "test:ci": "JEST_JUNIT_OUTPUT_DIR=\"./coverage\" jest --ci --coverage",
     "lint": "yarn tsc && yarn prettier && yarn eslint",


### PR DESCRIPTION
Now that remocal namespaces are not limited to starting with "twodotoh-dev" let's update the script to allow e2e tests to run locally with any namespace name.
