### PR TITLE
test: add basic rendering pipeline test to guard against rendering regressions

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -16,6 +16,9 @@ module.exports = {
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   moduleNameMapper: {
     '\\.(css|scss)$': 'identity-obj-proxy',
+    'react-dnd$': 'react-dnd/dist/cjs',
+    'react-dnd-html5-backend$': 'react-dnd-html5-backend/dist/cjs',
+    'dnd-core$': 'dnd-core/dist/cjs',
   },
   globals: {
     'ts-jest': {

--- a/src/visualization/components/View.test.tsx
+++ b/src/visualization/components/View.test.tsx
@@ -1,0 +1,113 @@
+import React from 'react'
+import {createStore} from 'redux'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import {normalize} from 'normalizr'
+import {mocked} from 'ts-jest/utils'
+
+import {AnnotationsList, QueryViewProperties, RemoteDataState} from 'src/types'
+
+const supportedVisualizations = {}
+import Band from 'src/visualization/types/Band/index'
+import Check from 'src/visualization/types/Check/index'
+import Gauge from 'src/visualization/types/Gauge/index'
+import Graph from 'src/visualization/types/Graph/index'
+import Heatmap from 'src/visualization/types/Heatmap/index'
+import Histogram from 'src/visualization/types/Histogram/index'
+import GeoMap from 'src/visualization/types/Map/index'
+import Mosaic from 'src/visualization/types/Mosaic/index'
+import Scatter from 'src/visualization/types/Scatter/index'
+import SimpleTable from 'src/visualization/types/SimpleTable/index'
+import SingleStat from 'src/visualization/types/SingleStat/index'
+import SingleStatWithLine from 'src/visualization/types/SingleStatWithLine/index'
+// import Table from 'src/visualization/types/Table/index'
+
+Band(visualization => {
+  supportedVisualizations[visualization.type] = visualization
+})
+Check(visualization => {
+  supportedVisualizations[visualization.type] = visualization
+})
+Gauge(visualization => {
+  supportedVisualizations[visualization.type] = visualization
+})
+Graph(visualization => {
+  supportedVisualizations[visualization.type] = visualization
+})
+Heatmap(visualization => {
+  supportedVisualizations[visualization.type] = visualization
+})
+Histogram(visualization => {
+  supportedVisualizations[visualization.type] = visualization
+})
+GeoMap(visualization => {
+  supportedVisualizations[visualization.type] = visualization
+})
+Mosaic(visualization => {
+  supportedVisualizations[visualization.type] = visualization
+})
+Scatter(visualization => {
+  supportedVisualizations[visualization.type] = visualization
+})
+SimpleTable(visualization => {
+  supportedVisualizations[visualization.type] = visualization
+})
+SingleStat(visualization => {
+  supportedVisualizations[visualization.type] = visualization
+})
+SingleStatWithLine(visualization => {
+  supportedVisualizations[visualization.type] = visualization
+})
+// Table((visualization) => {
+//   supportedVisualizations[visualization.type] = visualization
+// })
+
+jest.doMock('src/visualization/contextLoader', () => {
+  return {
+    ...(jest as any).requireActual('src/visualization/contextLoader'),
+    buildSupportedVisualizations: jest.fn(() => {
+      return supportedVisualizations
+    }),
+  }
+})
+
+import {View, SUPPORTED_VISUALIZATIONS} from 'src/visualization'
+
+const setup = properties => {
+  const loading = RemoteDataState.NotStarted
+  const id = 'a2710d76-021a-49ca-a7aa-b2e8bacf4022'
+  const annotations: AnnotationsList = {}
+  const errorMessage = ''
+  const ranges: any = {}
+  const giraffeResult = null
+  const isInitialFetch = true
+
+  return render(
+    <View
+      loading={loading}
+      error={errorMessage}
+      isInitial={isInitialFetch}
+      properties={properties}
+      result={giraffeResult}
+      timeRange={ranges}
+      annotations={annotations}
+      cellID={id}
+    />
+  )
+}
+
+describe('the view rendering pipeline', () => {
+  Object.keys(SUPPORTED_VISUALIZATIONS).forEach(visualizationType => {
+    it('renders the visualization', () => {
+      const {container} = setup(SUPPORTED_VISUALIZATIONS[visualizationType])
+      expect(container).not.toHaveTextContent(
+        'An InfluxDB error has occurred. Please report the issue'
+      )
+    })
+  })
+})

--- a/src/visualization/components/View.test.tsx
+++ b/src/visualization/components/View.test.tsx
@@ -1,18 +1,7 @@
 import React from 'react'
-import {createStore} from 'redux'
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react'
-import {normalize} from 'normalizr'
-import {mocked} from 'ts-jest/utils'
+import {render} from '@testing-library/react'
+import {AnnotationsList, RemoteDataState} from 'src/types'
 
-import {AnnotationsList, QueryViewProperties, RemoteDataState} from 'src/types'
-
-const supportedVisualizations = {}
 import Band from 'src/visualization/types/Band/index'
 import Check from 'src/visualization/types/Check/index'
 import Gauge from 'src/visualization/types/Gauge/index'
@@ -25,7 +14,9 @@ import Scatter from 'src/visualization/types/Scatter/index'
 import SimpleTable from 'src/visualization/types/SimpleTable/index'
 import SingleStat from 'src/visualization/types/SingleStat/index'
 import SingleStatWithLine from 'src/visualization/types/SingleStatWithLine/index'
-// import Table from 'src/visualization/types/Table/index'
+import Table from 'src/visualization/types/Table/index'
+
+const supportedVisualizations = {}
 
 Band(visualization => {
   supportedVisualizations[visualization.type] = visualization
@@ -63,9 +54,9 @@ SingleStat(visualization => {
 SingleStatWithLine(visualization => {
   supportedVisualizations[visualization.type] = visualization
 })
-// Table((visualization) => {
-//   supportedVisualizations[visualization.type] = visualization
-// })
+Table(visualization => {
+  supportedVisualizations[visualization.type] = visualization
+})
 
 jest.doMock('src/visualization/contextLoader', () => {
   return {

--- a/src/visualization/contextLoader.ts
+++ b/src/visualization/contextLoader.ts
@@ -1,0 +1,57 @@
+import {FunctionComponent, ComponentClass} from 'react'
+import {AnnotationsList, ViewProperties, TimeRange} from 'src/types'
+import {FluxResult} from 'src/types/flows'
+import {SimpleTableViewProperties} from 'src/visualization/types/SimpleTable'
+
+export interface VisualizationOptionProps {
+  properties: ViewProperties
+  results: FluxResult['parsed']
+  update: (obj: any) => void
+}
+
+export interface VisualizationProps {
+  properties: ViewProperties | SimpleTableViewProperties
+  result: FluxResult['parsed']
+  timeRange?: TimeRange
+  annotations?: AnnotationsList
+  cellID?: string
+}
+
+export interface Visualization {
+  type: string // a unique string that identifies a visualization
+  name: string // the name that shows up in the dropdown
+  graphic: JSX.Element // the icon that shows up in the dropdown
+  component?:
+    | FunctionComponent<VisualizationProps>
+    | ComponentClass<VisualizationProps> // the view component for rendering the interface
+  disabled?: boolean // if you should show it or not, takes precidence over feature flagging
+  featureFlag?: string // designates a flag that should enable the panel type
+  initial: ViewProperties // the default state
+  options?: FunctionComponent<VisualizationOptionProps> // the view component for rendering the interface
+}
+
+export interface Visualizations {
+  [visualizationType: string]: Visualization
+}
+
+export const buildSupportedVisualizations = (): Visualizations => {
+  const supportedVisualizations: Visualizations = {}
+  const visualizationDefintionContext = require.context(
+    './types',
+    true,
+    /index\.(ts|tsx)$/
+  )
+
+  visualizationDefintionContext
+    .keys()
+    .forEach(visualizationDefinitionIndexFile => {
+      const visualizationDefinitionModule = visualizationDefintionContext(
+        visualizationDefinitionIndexFile
+      )
+      visualizationDefinitionModule.default((visualization: Visualization) => {
+        supportedVisualizations[visualization.type] = visualization
+      })
+    })
+
+  return supportedVisualizations
+}

--- a/src/visualization/index.ts
+++ b/src/visualization/index.ts
@@ -1,56 +1,19 @@
-import {FunctionComponent, ComponentClass} from 'react'
-import {AnnotationsList, ViewProperties, TimeRange} from 'src/types'
-import {FluxResult} from 'src/types/flows'
-import {SimpleTableViewProperties} from 'src/visualization/types/SimpleTable'
+import {
+  buildSupportedVisualizations,
+  Visualization,
+  Visualizations,
+  VisualizationProps,
+  VisualizationOptionProps,
+} from 'src/visualization/contextLoader'
 
-export interface VisualizationOptionProps {
-  properties: ViewProperties
-  results: FluxResult['parsed']
-  update: (obj: any) => void
+export {
+  Visualization,
+  Visualizations,
+  VisualizationProps,
+  VisualizationOptionProps,
 }
 
-export interface VisualizationProps {
-  properties: ViewProperties | SimpleTableViewProperties
-  result: FluxResult['parsed']
-  timeRange?: TimeRange
-  annotations?: AnnotationsList
-  cellID?: string
-}
-
-export interface Visualization {
-  type: string // a unique string that identifies a visualization
-  name: string // the name that shows up in the dropdown
-  graphic: JSX.Element // the icon that shows up in the dropdown
-  component?:
-    | FunctionComponent<VisualizationProps>
-    | ComponentClass<VisualizationProps> // the view component for rendering the interface
-  disabled?: boolean // if you should show it or not, takes precidence over feature flagging
-  featureFlag?: string // designates a flag that should enable the panel type
-  initial: ViewProperties // the default state
-  options?: FunctionComponent<VisualizationOptionProps> // the view component for rendering the interface
-}
-
-interface Visualizations {
-  [visualizationType: string]: Visualization
-}
-
-export const SUPPORTED_VISUALIZATIONS: Visualizations = {}
-
-const visualizationDefintionContext = require.context(
-  './types',
-  true,
-  /index\.(ts|tsx)$/
-)
-visualizationDefintionContext
-  .keys()
-  .forEach(visualizationDefinitionIndexFile => {
-    const visualizationDefinitionModule = visualizationDefintionContext(
-      visualizationDefinitionIndexFile
-    )
-    visualizationDefinitionModule.default((def: Visualization) => {
-      SUPPORTED_VISUALIZATIONS[def.type] = def
-    })
-  })
+export const SUPPORTED_VISUALIZATIONS: Visualizations = buildSupportedVisualizations()
 
 export {default as View} from 'src/visualization/components/View'
 export {default as ViewOptions} from 'src/visualization/components/ViewOptions'


### PR DESCRIPTION
Closes #2453

- Moves the functionality that builds the list of supported visualizations from a directory scan into a separate file
- Adds a simple test that will fail if a component throws an error during rendering

**The way this is setup requires updating this test any time a new component is added**

### Testing a failure:
- checkout this branch `git fetch && git checkout bucky_view_pipeline_test`
- start the tests: `yarn test:watch src/visualization/components/View.test.tsx`
- apply [this diff](https://gist.githubusercontent.com/hoorayimhelping/93bf309b0d9cfcedc9a121012f30dbdb/raw/c86ae3fd68039719d71ef136c1e6e2b9da1efda4/foo.diff) with this command:
   ```bash
     curl https://gist.githubusercontent.com/hoorayimhelping/93bf309b0d9cfcedc9a121012f30dbdb/raw/c86ae3fd68039719d71ef136c1e6e2b9da1efda4/foo.diff | git apply
   ```
