### PR TITLE
chore: reset a users input after a successful login

### DIFF
--- a/src/users/context/users.tsx
+++ b/src/users/context/users.tsx
@@ -132,6 +132,7 @@ export const UsersProvider: FC<Props> = React.memo(({children}) => {
 
       setInvites(prevInvites => [resp.data, ...prevInvites])
       dispatch(notify(inviteSent()))
+      setDraftInvite(draft)
     } catch (error) {
       dispatch(notify(inviteFailed()))
       console.error(error)


### PR DESCRIPTION
Some residual clean up after importing other UI code. This is to reset the input field once a user has successfully invited a user to their organization.