### PR TITLE
fix(datepicker): move state mutation outside of rendering

### DIFF
--- a/src/shared/components/dateRangePicker/DatePicker.tsx
+++ b/src/shared/components/dateRangePicker/DatePicker.tsx
@@ -70,6 +70,12 @@ class DatePicker extends PureComponent<Props, State> {
     inputFormat: null,
   }
 
+  public componentDidUpdate() {
+    if (this.isInputValueInvalid) {
+      this.props.onInvalidInput()
+    }
+  }
+
   public render() {
     const {dateTime, label, maxDate, minDate, timeZone} = this.props
 
@@ -127,8 +133,6 @@ class DatePicker extends PureComponent<Props, State> {
     const {inputValue, inputFormat} = this.state
 
     if (this.isInputValueInvalid) {
-      const {onInvalidInput} = this.props
-      onInvalidInput()
       return inputValue
     }
 


### PR DESCRIPTION
Closes #2479

a getter function that returns a value called a passed in function `onInvalidInput` which sets state in a parent component during rendering. Moving the `onInvalidInput` outside of the value getter and into `componentDidUpdate` fixes both issues - the state mutation during rendering and the getter function that has setter side effects.