### PR TITLE
fix: threshold setting issue when focus would change when value updated

### DIFF
--- a/src/flows/pipes/Notification/Threshold.tsx
+++ b/src/flows/pipes/Notification/Threshold.tsx
@@ -303,7 +303,7 @@ const Threshold: FC = () => {
           margin={ComponentSize.Medium}
           stretchToFitWidth
           testID="component-spacer"
-          key={`${threshold.type}_${threshold.field}_${threshold.value}_${index}`}
+          key={`${threshold.type}_${index}`}
         >
           <TextBlock
             testID="when-value-text-block"


### PR DESCRIPTION
Closes #2471 

The value of the threshold was being used for the key, but when the value would change, the key would be different and the focus would be lost