### PR TITLE
fix: test endpoint button shouldn't cancel queries

### DIFF
--- a/src/flows/pipes/Notification/view.tsx
+++ b/src/flows/pipes/Notification/view.tsx
@@ -44,11 +44,9 @@ import {
 // Styles
 import 'src/flows/pipes/Notification/styles.scss'
 
-const fakeNotify = notify
-
 const Notification: FC<PipeProp> = ({Context}) => {
   const dispatch = useDispatch()
-  const {query, cancel} = useContext(QueryContext)
+  const {query} = useContext(QueryContext)
   const {id, data, update, results, loading} = useContext(PipeContext)
   const {simplify, getPanelQueries} = useContext(FlowQueryContext)
   const [status, setStatus] = useState<RemoteDataState>(


### PR DESCRIPTION
Closes #2470 

Switches the "test endpoint" button to be a regular button instead of reusing the SubmitQueryPreview button which has some additional functionality that was causing weird behavior when the panel was unmounted


https://user-images.githubusercontent.com/6411855/131037314-9a846625-47d2-4580-a89c-67a544090b47.mov


