### PR TITLE
fix: configuration of sidebar to adjust based on the button height above

### DIFF
--- a/src/flows/components/Sidebar.scss
+++ b/src/flows/components/Sidebar.scss
@@ -37,7 +37,9 @@
 
 .flow-sidebar--submenu {
   padding-top: $cf-marg-b;
-  height: 100%;
+  height: calc(
+    100% - 30px
+  ); // this is due to a scrollbar issue where the height of the button above it makes the 100% height unreachable: https://github.com/influxdata/ui/issues/2474
 }
 
 .flow-sidebar--dropdownmenu {


### PR DESCRIPTION
Closes #2474 

Updated the height of the submenu to adjust for the 30px that are being used up by the element above
