### PR TITLE
fix: flakey annotation xy, delete test

### DIFF
--- a/cypress/e2e/util/annotationsSetup.ts
+++ b/cypress/e2e/util/annotationsSetup.ts
@@ -144,7 +144,7 @@ export const deleteAnnotation = (cy: Cypress.Chainable) => {
   cy.getByTestID('overlay--container')
     .filter(':visible')
     .within(() => {
-      cy.getByTestID('delete-annotation-button').click()
+      cy.getByTestID('delete-annotation-button').click({force: true})
     })
 
   // reload to make sure the annotation was deleted from the backend as well.


### PR DESCRIPTION
Closes #2468

The problem is that that overlay renders multiple times, from my understanding, and this causes the cypress element to be dead, and hence the complaint. 

This seems to be a common problem, Cypress is not automatically re-querying the element. [[Issue in cypress](https://github.com/cypress-io/cypress/issues/7306)] The best hacky solution seems to be using `.click({force: true})`. It is also a pattern in other e2e tests in our app. 

They [Cypress's team] said they will fix this issue, but it will most likely be after some time. The exact comment: [[Link](https://github.com/cypress-io/cypress/issues/7306#issuecomment-906547691)]

> Our team does have plans to address this issue. As with all the other long standing issues, it is very complex to fix and would likely introduce breaking changes. There's investigation being done on how to technically execute a fix for this.
> 
> The core of the technical challenge is understanding when the application under test has undergone some mutation so that we can know how to handle detached/removed DOM elements where simple requerying is not going to work in those situations.

**Experiment results**: Ran the tests 20 times, no flake.

<img width="564" alt="Screen Shot 2021-08-27 at 2 10 30 PM" src="https://user-images.githubusercontent.com/18511823/131188967-2d6b7f6f-ed5b-407c-94e6-d78b2580cf45.png">