### PR TITLE
fix: query variable read-only issue fix

### DIFF
--- a/src/alerting/components/AlertingIndex.tsx
+++ b/src/alerting/components/AlertingIndex.tsx
@@ -61,7 +61,7 @@ const AlertingIndex: FunctionComponent = () => {
           scrollable={false}
           className={pageContentsClassName}
         >
-          <GetResources resources={[ResourceType.Labels, ResourceType.Buckets]}>
+          <GetResources resources={[ResourceType.Labels, ResourceType.Buckets, ResourceType.Variables]}>
             <GetAssetLimits>
               <SelectGroup
                 className="alerting-index--selector"

--- a/src/alerting/components/AlertingIndex.tsx
+++ b/src/alerting/components/AlertingIndex.tsx
@@ -61,7 +61,13 @@ const AlertingIndex: FunctionComponent = () => {
           scrollable={false}
           className={pageContentsClassName}
         >
-          <GetResources resources={[ResourceType.Labels, ResourceType.Buckets, ResourceType.Variables]}>
+          <GetResources
+            resources={[
+              ResourceType.Labels,
+              ResourceType.Buckets,
+              ResourceType.Variables,
+            ]}
+          >
             <GetAssetLimits>
               <SelectGroup
                 className="alerting-index--selector"

--- a/src/variables/selectors/index.tsx
+++ b/src/variables/selectors/index.tsx
@@ -148,10 +148,6 @@ export const getVariable = (state: AppState, variableID: string): Variable => {
   const ctx = state?.resources?.variables?.values?.[contextID]
   let vari = state?.resources?.variables?.byID?.[variableID]
 
-  if (vari) {
-    vari = JSON.parse(JSON.stringify(vari))
-  }
-
   if (ctx && ctx.values && ctx.values.hasOwnProperty(variableID)) {
     vari = {...vari, ...ctx.values[variableID]}
   }

--- a/src/variables/selectors/index.tsx
+++ b/src/variables/selectors/index.tsx
@@ -145,13 +145,11 @@ export const sortVariablesByName = (variables: Variable[]): Variable[] =>
 
 export const getVariable = (state: AppState, variableID: string): Variable => {
   const contextID = currentContext(state)
-  const ctx = get(state, ['resources', 'variables', 'values', contextID])
-  let vari = get(state, ['resources', 'variables', 'byID', variableID])
+  const ctx = state?.resources?.variables?.values?.[contextID]
+  let vari = state?.resources?.variables?.byID?.[variableID]
 
   if (vari) {
-    vari = JSON.parse(
-      JSON.stringify(get(state, ['resources', 'variables', 'byID', variableID]))
-    )
+    vari = JSON.parse(JSON.stringify(vari))
   }
 
   if (ctx && ctx.values && ctx.values.hasOwnProperty(variableID)) {

--- a/src/variables/selectors/index.tsx
+++ b/src/variables/selectors/index.tsx
@@ -148,6 +148,10 @@ export const getVariable = (state: AppState, variableID: string): Variable => {
   const ctx = get(state, ['resources', 'variables', 'values', contextID])
   let vari = get(state, ['resources', 'variables', 'byID', variableID])
 
+  if (vari) {
+    vari = JSON.parse(JSON.stringify(get(state, ['resources', 'variables', 'byID', variableID])))
+  }
+
   if (ctx && ctx.values && ctx.values.hasOwnProperty(variableID)) {
     vari = {...vari, ...ctx.values[variableID]}
   }

--- a/src/variables/selectors/index.tsx
+++ b/src/variables/selectors/index.tsx
@@ -149,7 +149,9 @@ export const getVariable = (state: AppState, variableID: string): Variable => {
   let vari = get(state, ['resources', 'variables', 'byID', variableID])
 
   if (vari) {
-    vari = JSON.parse(JSON.stringify(get(state, ['resources', 'variables', 'byID', variableID])))
+    vari = JSON.parse(
+      JSON.stringify(get(state, ['resources', 'variables', 'byID', variableID]))
+    )
   }
 
   if (ctx && ctx.values && ctx.values.hasOwnProperty(variableID)) {

--- a/src/variables/utils/hydrateVars.ts
+++ b/src/variables/utils/hydrateVars.ts
@@ -421,6 +421,7 @@ export const hydrateVars = (
   allVariables: Variable[],
   options: HydrateVarsOptions
 ): EventedCancelBox<Variable[]> => {
+  allVariables = JSON.parse(JSON.stringify(allVariables))
   const graph = findSubgraph(
     createVariableGraph(allVariables),
     variables

--- a/src/variables/utils/hydrateVars.ts
+++ b/src/variables/utils/hydrateVars.ts
@@ -421,7 +421,6 @@ export const hydrateVars = (
   allVariables: Variable[],
   options: HydrateVarsOptions
 ): EventedCancelBox<Variable[]> => {
-  allVariables = JSON.parse(JSON.stringify(allVariables))
   const graph = findSubgraph(
     createVariableGraph(allVariables),
     variables


### PR DESCRIPTION
Closes #2439 

`vari` is a read-only variable and that prevents us from overwriting `results` in `vari?.arguments?.values?.results`. So, the solution is to make a deep copy and use it as the variable so that we can overwrite any part of `vari` and its children.

