### PR TITLE
chore: add more links to the doc search widget

### DIFF
--- a/src/me/components/DocSearchWidget.tsx
+++ b/src/me/components/DocSearchWidget.tsx
@@ -26,7 +26,13 @@ const supportLinks = [
   },
   {
     link: 'https://github.com/influxdata/ui/issues/new',
-    title: 'Report a bug',
+    title: '🐛 Report a bug',
+  },
+  {link: 'https://community.influxdata.com', title: '💭 Community Forum'},
+  {
+    link:
+      'https://github.com/influxdata/influxdb/issues/new?template=feature_request.md',
+    title: '✨ Feature Requests',
   },
 ]
 


### PR DESCRIPTION
This PR does some clean up around the doc search widget to allow users to access the community slack and make feature requests directly from the doc search widget