### PR TITLE
feat: Edit overlay toggle for token status

### DIFF
--- a/src/authorizations/components/redesigned/EditTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/EditTokenOverlay.tsx
@@ -14,6 +14,9 @@ import {
   SlideToggle,
   ComponentSize,
   JustifyContent,
+  Button,
+  ComponentColor,
+  Page,
 } from '@influxdata/clockface'
 
 // Types
@@ -41,8 +44,9 @@ const labels = {
 
 const EditTokenOverlay: FC<Props> = props => {
   const [description, setDescription] = useState(props.auth.description)
-
+  const handleInputChange = event => setDescription(event.target.value)
   
+  const handleDismiss = () => props.onDismissOverlay()
 
   const changeToggle = () => {
     const {onUpdate, auth} = props
@@ -55,16 +59,23 @@ const EditTokenOverlay: FC<Props> = props => {
 
   }
 
-  const handleDismiss = () => props.onDismissOverlay()
+  const onSave = () => {
+    const {onUpdate, auth} = props
 
-  const handleInputChange = event => setDescription(event.target.value)
-
+    onUpdate({
+      ...auth,
+      description: description
+    })
+    handleDismiss()
+  }
   
 
   return (
-    <Overlay.Container maxWidth={830}>
+    <Overlay.Container maxWidth={630}>
       <Overlay.Header title="API Token Summary" onDismiss={handleDismiss} />
       <Overlay.Body>
+      <FlexBox alignItems={AlignItems.FlexStart} margin={ComponentSize.Medium}   direction={FlexDirection.Column} justifyContent={JustifyContent.SpaceBetween}>
+
         <FlexBox margin={ComponentSize.Medium}  direction={FlexDirection.Row}>
           <SlideToggle
             active={props.auth.status === 'active'}
@@ -76,9 +87,9 @@ const EditTokenOverlay: FC<Props> = props => {
         <Form>
         
           <FlexBox
-            alignItems={AlignItems.Center}
-            direction={FlexDirection.Column}
+            direction={FlexDirection.Row}
             margin={ComponentSize.Large}
+            justifyContent={JustifyContent.SpaceBetween}
           >
             <Form.Element label="Description">
               <Input
@@ -88,9 +99,31 @@ const EditTokenOverlay: FC<Props> = props => {
                 testID="custom-api-token-input"
               />
             </Form.Element>
-          </FlexBox>
+            </FlexBox>
+            <Page.ControlBarCenter>
+            <FlexBox
+            
+            margin={ComponentSize.Medium}
+          >
+            <Button
+              color={ComponentColor.Default}
+              text="Cancel"
+              onClick={handleDismiss}
+              testID="token-cancel-btn"
+            />
+            <Button
+              color={ComponentColor.Primary}
+              text="Save"
+              onClick={onSave}
+              testID="token-save-btn"
+            />
+            </FlexBox>
+            </Page.ControlBarCenter>
+          
         </Form>
+        </FlexBox>
       </Overlay.Body>
+      
     </Overlay.Container>
   )
 }

--- a/src/authorizations/components/redesigned/EditTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/EditTokenOverlay.tsx
@@ -1,5 +1,6 @@
 // Libraries
 import React, {FC, useState} from 'react'
+import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {
@@ -9,20 +10,51 @@ import {
   FlexBox,
   AlignItems,
   FlexDirection,
+  InputLabel,
+  SlideToggle,
   ComponentSize,
+  JustifyContent,
 } from '@influxdata/clockface'
 
 // Types
 import {Authorization} from 'src/types'
 
-interface Props {
+// Actions
+import {
+  updateAuthorization,
+} from 'src/authorizations/actions/thunks'
+
+
+interface OwnProps {
   auth: Authorization
   onDismissOverlay: () => void
 }
 
-export const EditTokenOverlay: FC<Props> = props => {
+type ReduxProps = ConnectedProps<typeof connector>
+
+type Props = ReduxProps & OwnProps
+
+const EditTokenOverlay: FC<Props> = props => {
   const [description, setDescription] = useState(props.auth.description)
 
+  let isTokenEnabled = () => {
+    const {auth} = props
+    
+    return auth.status === 'active'
+  }
+  const labelText = isTokenEnabled() ? 'Active' : 'Inactive'
+
+  const changeToggle = () => {
+    const {onUpdate} = props
+    const auth = {...props.auth}
+    auth.status = auth.status === 'active' ? 'inactive' : 'active'
+    onUpdate(auth)
+    console.log(auth.status)
+  }
+
+  
+  
+  
   const handleDismiss = () => {
     props.onDismissOverlay()
   }
@@ -31,11 +63,22 @@ export const EditTokenOverlay: FC<Props> = props => {
     setDescription(event.target.value)
   }
 
+  
+
   return (
     <Overlay.Container maxWidth={830}>
       <Overlay.Header title="API Token Summary" onDismiss={handleDismiss} />
       <Overlay.Body>
+        <FlexBox margin={ComponentSize.Medium}  direction={FlexDirection.Row}>
+          <SlideToggle
+            active={isTokenEnabled()}
+            size={ComponentSize.ExtraSmall}
+            onChange={changeToggle}
+          />
+          <InputLabel active={isTokenEnabled()}>{labelText}</InputLabel>
+        </FlexBox>
         <Form>
+        
           <FlexBox
             alignItems={AlignItems.Center}
             direction={FlexDirection.Column}
@@ -55,3 +98,11 @@ export const EditTokenOverlay: FC<Props> = props => {
     </Overlay.Container>
   )
 }
+
+const mdtp = {
+  onUpdate: updateAuthorization,
+}
+
+const connector = connect(null, mdtp)
+
+export default connector(EditTokenOverlay)

--- a/src/authorizations/components/redesigned/EditTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/EditTokenOverlay.tsx
@@ -23,10 +23,7 @@ import {
 import {Authorization} from 'src/types'
 
 // Actions
-import {
-  updateAuthorization,
-} from 'src/authorizations/actions/thunks'
-
+import {updateAuthorization} from 'src/authorizations/actions/thunks'
 
 interface OwnProps {
   auth: Authorization
@@ -39,24 +36,22 @@ type Props = ReduxProps & OwnProps
 
 const labels = {
   active: 'Active',
-  inactive: 'Inactive'
-};
+  inactive: 'Inactive',
+}
 
 const EditTokenOverlay: FC<Props> = props => {
   const [description, setDescription] = useState(props.auth.description)
   const handleInputChange = event => setDescription(event.target.value)
-  
+
   const handleDismiss = () => props.onDismissOverlay()
 
   const changeToggle = () => {
     const {onUpdate, auth} = props
-    
+
     onUpdate({
       ...auth,
-      status: auth.status === 'active' ? 'inactive' : 'active'
+      status: auth.status === 'active' ? 'inactive' : 'active',
     })
-    
-
   }
 
   const onSave = () => {
@@ -64,66 +59,65 @@ const EditTokenOverlay: FC<Props> = props => {
 
     onUpdate({
       ...auth,
-      description: description
+      description: description,
     })
     handleDismiss()
   }
-  
 
   return (
     <Overlay.Container maxWidth={630}>
       <Overlay.Header title="API Token Summary" onDismiss={handleDismiss} />
       <Overlay.Body>
-      <FlexBox alignItems={AlignItems.FlexStart} margin={ComponentSize.Medium}   direction={FlexDirection.Column} justifyContent={JustifyContent.SpaceBetween}>
-
-        <FlexBox margin={ComponentSize.Medium}  direction={FlexDirection.Row}>
-          <SlideToggle
-            active={props.auth.status === 'active'}
-            size={ComponentSize.ExtraSmall}
-            onChange={changeToggle}
-          />
-          <InputLabel active={props.auth.status === 'active'}>{labels[props.auth.status]}</InputLabel>
-        </FlexBox>
-        <Form>
-        
-          <FlexBox
-            direction={FlexDirection.Row}
-            margin={ComponentSize.Large}
-            justifyContent={JustifyContent.SpaceBetween}
-          >
-            <Form.Element label="Description">
-              <Input
-                placeholder="Describe this token"
-                value={description}
-                onChange={handleInputChange}
-                testID="custom-api-token-input"
-              />
-            </Form.Element>
+        <FlexBox
+          alignItems={AlignItems.FlexStart}
+          margin={ComponentSize.Medium}
+          direction={FlexDirection.Column}
+          justifyContent={JustifyContent.SpaceBetween}
+        >
+          <FlexBox margin={ComponentSize.Medium} direction={FlexDirection.Row}>
+            <SlideToggle
+              active={props.auth.status === 'active'}
+              size={ComponentSize.ExtraSmall}
+              onChange={changeToggle}
+            />
+            <InputLabel active={props.auth.status === 'active'}>
+              {labels[props.auth.status]}
+            </InputLabel>
+          </FlexBox>
+          <Form>
+            <FlexBox
+              direction={FlexDirection.Row}
+              margin={ComponentSize.Large}
+              justifyContent={JustifyContent.SpaceBetween}
+            >
+              <Form.Element label="Description">
+                <Input
+                  placeholder="Describe this token"
+                  value={description}
+                  onChange={handleInputChange}
+                  testID="custom-api-token-input"
+                />
+              </Form.Element>
             </FlexBox>
             <Page.ControlBarCenter>
-            <FlexBox
-            
-            margin={ComponentSize.Medium}
-          >
-            <Button
-              color={ComponentColor.Default}
-              text="Cancel"
-              onClick={handleDismiss}
-              testID="token-cancel-btn"
-            />
-            <Button
-              color={ComponentColor.Primary}
-              text="Save"
-              onClick={onSave}
-              testID="token-save-btn"
-            />
-            </FlexBox>
+              <FlexBox margin={ComponentSize.Medium}>
+                <Button
+                  color={ComponentColor.Default}
+                  text="Cancel"
+                  onClick={handleDismiss}
+                  testID="token-cancel-btn"
+                />
+                <Button
+                  color={ComponentColor.Primary}
+                  text="Save"
+                  onClick={onSave}
+                  testID="token-save-btn"
+                />
+              </FlexBox>
             </Page.ControlBarCenter>
-          
-        </Form>
+          </Form>
         </FlexBox>
       </Overlay.Body>
-      
     </Overlay.Container>
   )
 }

--- a/src/authorizations/components/redesigned/EditTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/EditTokenOverlay.tsx
@@ -34,34 +34,30 @@ type ReduxProps = ConnectedProps<typeof connector>
 
 type Props = ReduxProps & OwnProps
 
+const labels = {
+  active: 'Active',
+  inactive: 'Inactive'
+};
+
 const EditTokenOverlay: FC<Props> = props => {
   const [description, setDescription] = useState(props.auth.description)
 
-  let isTokenEnabled = () => {
-    const {auth} = props
-    
-    return auth.status === 'active'
-  }
-  const labelText = isTokenEnabled() ? 'Active' : 'Inactive'
+  
 
   const changeToggle = () => {
-    const {onUpdate} = props
-    const auth = {...props.auth}
-    auth.status = auth.status === 'active' ? 'inactive' : 'active'
-    onUpdate(auth)
-    console.log(auth.status)
+    const {onUpdate, auth} = props
+    
+    onUpdate({
+      ...auth,
+      status: auth.status === 'active' ? 'inactive' : 'active'
+    })
+    
+
   }
 
-  
-  
-  
-  const handleDismiss = () => {
-    props.onDismissOverlay()
-  }
+  const handleDismiss = () => props.onDismissOverlay()
 
-  const handleInputChange = event => {
-    setDescription(event.target.value)
-  }
+  const handleInputChange = event => setDescription(event.target.value)
 
   
 
@@ -71,11 +67,11 @@ const EditTokenOverlay: FC<Props> = props => {
       <Overlay.Body>
         <FlexBox margin={ComponentSize.Medium}  direction={FlexDirection.Row}>
           <SlideToggle
-            active={isTokenEnabled()}
+            active={props.auth.status === 'active'}
             size={ComponentSize.ExtraSmall}
             onChange={changeToggle}
           />
-          <InputLabel active={isTokenEnabled()}>{labelText}</InputLabel>
+          <InputLabel active={props.auth.status === 'active'}>{labels[props.auth.status]}</InputLabel>
         </FlexBox>
         <Form>
         

--- a/src/authorizations/components/redesigned/TokenList.tsx
+++ b/src/authorizations/components/redesigned/TokenList.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import memoizeOne from 'memoize-one';
-import isEqual from 'lodash/isEqual';
+import memoizeOne from 'memoize-one'
+import isEqual from 'lodash/isEqual'
 
 // Components
 import {Overlay, ResourceList} from '@influxdata/clockface'
@@ -47,11 +47,13 @@ export class TokenList extends PureComponent<Props, State> {
   }
 
   public componentDidUpdate(prevProps) {
-    const { auths: prevAuths } = prevProps;
-    const { auths: nextAuths } = this.props;
+    const {auths: prevAuths} = prevProps
+    const {auths: nextAuths} = this.props
 
     if (!isEqual(prevAuths, nextAuths)) {
-      const authInView = nextAuths.find(auth => auth.id === this.state.authInView?.id)
+      const authInView = nextAuths.find(
+        auth => auth.id === this.state.authInView?.id
+      )
       this.setState({authInView})
     }
   }
@@ -74,7 +76,6 @@ export class TokenList extends PureComponent<Props, State> {
           <EditTokenOverlay
             auth={authInView}
             onDismissOverlay={this.handleDismissOverlay}
-          
           />
         </Overlay>
       </>

--- a/src/authorizations/components/redesigned/TokenList.tsx
+++ b/src/authorizations/components/redesigned/TokenList.tsx
@@ -15,7 +15,6 @@ import {Sort} from '@influxdata/clockface'
 
 // Utils
 import {getSortedResources} from 'src/shared/utils/sort'
-import auth from '@influxdata/influx/dist/wrappers/auth'
 
 type SortKey = keyof Authorization
 

--- a/src/authorizations/components/redesigned/TokenList.tsx
+++ b/src/authorizations/components/redesigned/TokenList.tsx
@@ -5,7 +5,7 @@ import memoizeOne from 'memoize-one'
 // Components
 import {Overlay, ResourceList} from '@influxdata/clockface'
 import {TokenRow} from 'src/authorizations/components/redesigned/TokenRow'
-import {EditTokenOverlay} from 'src/authorizations/components/redesigned/EditTokenOverlay'
+import EditTokenOverlay from 'src/authorizations/components/redesigned/EditTokenOverlay'
 
 // Types
 import {Authorization} from 'src/types'
@@ -14,6 +14,7 @@ import {Sort} from '@influxdata/clockface'
 
 // Utils
 import {getSortedResources} from 'src/shared/utils/sort'
+import auth from '@influxdata/influx/dist/wrappers/auth'
 
 type SortKey = keyof Authorization
 
@@ -62,6 +63,7 @@ export class TokenList extends PureComponent<Props, State> {
           <EditTokenOverlay
             auth={authInView}
             onDismissOverlay={this.handleDismissOverlay}
+          
           />
         </Overlay>
       </>

--- a/src/authorizations/components/redesigned/TokenList.tsx
+++ b/src/authorizations/components/redesigned/TokenList.tsx
@@ -1,6 +1,7 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import memoizeOne from 'memoize-one'
+import memoizeOne from 'memoize-one';
+import isEqual from 'lodash/isEqual';
 
 // Components
 import {Overlay, ResourceList} from '@influxdata/clockface'
@@ -45,6 +46,17 @@ export class TokenList extends PureComponent<Props, State> {
       authInView: null,
     }
   }
+
+  public componentDidUpdate(prevProps) {
+    const { auths: prevAuths } = prevProps;
+    const { auths: nextAuths } = this.props;
+
+    if (!isEqual(prevAuths, nextAuths)) {
+      const authInView = nextAuths.find(auth => auth.id === this.state.authInView?.id)
+      this.setState({authInView})
+    }
+  }
+
   public render() {
     const {isTokenOverlayVisible, authInView} = this.state
 


### PR DESCRIPTION
Closes #1965 
**proposed changes**: 

- user can change the status of a token from active to inactive or vise versa 
- user can now update the description of a token and clicking save will update token 
- saving a token sends a `patch` request to the api and updates existing token 
- user can now click on cancel button and be directed back to Tokens List

https://user-images.githubusercontent.com/66275100/131388696-5f23d1d5-3bc2-4db2-9da3-d247bb07d6b1.mov


