### PR TITLE
fix(notebooks): should be able to delete broken panels

### DIFF
--- a/src/flows/components/Sidebar.tsx
+++ b/src/flows/components/Sidebar.tsx
@@ -183,7 +183,7 @@ const Sidebar: FC = () => {
               return true
             }
 
-            if (!/^(inputs|transform)$/.test(PIPE_DEFINITIONS[type].family)) {
+            if (!/^(inputs|transform)$/.test(PIPE_DEFINITIONS[type]?.family)) {
               return true
             }
 


### PR DESCRIPTION
Related #2469 

Not sure what caused the original issue and I was unable to reproduce it after trying all morning. But I was able to add the broken notebook into my env and from there, found the reason why the broken panel couldn't be deleted. Only happens when the `flowSidebar` flag is on. 

before:

![image](https://user-images.githubusercontent.com/6411855/131393407-a8c49520-c169-4c29-a43a-6543481c4512.png)


after:


https://user-images.githubusercontent.com/6411855/131393217-640ff5ea-5b80-47c6-8ef6-403634ed886e.mov


