### PR TITLE
fix: resources are now sorted naturally

### DIFF
--- a/src/shared/components/Filter.tsx
+++ b/src/shared/components/Filter.tsx
@@ -53,8 +53,8 @@ export default class FilterList<T extends Resource> extends PureComponent<
     return this.filtered.sort((item1, item2) => {
       if (this.props.sortByKey) {
         return this.collator.compare(
-          item1[this.props.sortByKey],
-          item2[this.props.sortByKey]
+          get(item1, this.props.sortByKey),
+          get(item2, this.props.sortByKey)
         )
       }
 

--- a/src/shared/components/Filter.tsx
+++ b/src/shared/components/Filter.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import {PureComponent} from 'react'
 
-import {get, sortBy, isEmpty, isObject, flatMap, sortedIndex} from 'lodash'
+import {get, isEmpty, isObject, flatMap, sortedIndex} from 'lodash'
 
 // Types
 import {Label} from 'src/types'
@@ -9,12 +9,14 @@ import {Label} from 'src/types'
 // searchKeys: the keys whose values you want to filter on
 // if the values are nested use dot notation i.e. tasks.org.name
 
+type Resource = {name?: string}
+
 export interface OwnProps<T> {
-  list: T[]
-  searchTerm: string
-  searchKeys: string[]
-  sortByKey?: string
   children: (list: T[]) => any
+  list: T[]
+  searchKeys: string[]
+  searchTerm: string
+  sortByKey?: string
 }
 
 export interface StateProps {
@@ -25,6 +27,7 @@ export type Props<T> = OwnProps<T> & StateProps
 
 const INEXACT_PATH = /\w+\[\]/g
 const EMPTY_ARRAY_BRACKETS = /\[\]?\./
+
 /**
  * Filters a list using a searchTerm and searchKeys where
  *  searchKeys is an array of strings represents either an
@@ -32,24 +35,31 @@ const EMPTY_ARRAY_BRACKETS = /\[\]?\./
  *  "user.name" (exact) or "authors[].name" (inexact)
  *
  */
+export default class FilterList<T extends Resource> extends PureComponent<
+  Props<T>
+> {
+  private collator: Intl.Collator
 
-export default class FilterList<T> extends PureComponent<Props<T>> {
+  public constructor(props) {
+    super(props)
+    this.collator = new Intl.Collator('en-us', {numeric: true})
+  }
+
   public render() {
     return this.props.children(this.sorted)
   }
 
   private get sorted(): T[] {
-    return sortBy<T>(this.filtered, [
-      (item: T) => {
-        const value = get(item, this.props.sortByKey)
+    return this.filtered.sort((item1, item2) => {
+      if (this.props.sortByKey) {
+        return this.collator.compare(
+          item1[this.props.sortByKey],
+          item2[this.props.sortByKey]
+        )
+      }
 
-        if (!!value && typeof value === 'string') {
-          return value.toLocaleLowerCase()
-        }
-
-        return value
-      },
-    ])
+      return this.collator.compare(item1.name, item2.name)
+    })
   }
 
   private get filtered(): T[] {

--- a/src/shared/utils/sort.test.ts
+++ b/src/shared/utils/sort.test.ts
@@ -1,0 +1,85 @@
+import {createDateTimeFormatter} from 'src/utils/datetime/formatters'
+import {DEFAULT_TIME_FORMAT} from 'src/utils/datetime/constants'
+
+import {getSortedResources, SortTypes} from 'src/shared/utils/sort'
+
+describe('getSortedResources', () => {
+  describe('sorting strings', () => {
+    it('sorts naturally, not lexicographically', () => {
+      const resources = [
+        {name: 'resource 2'},
+        {name: 'zoology'},
+        {name: 'resource 1'},
+      ]
+      expect(
+        getSortedResources(resources, 'name', 'asc', SortTypes.String)
+      ).toEqual([{name: 'resource 1'}, {name: 'resource 2'}, {name: 'zoology'}])
+    })
+
+    it('sorts in descending order as well', () => {
+      const resources = [
+        {name: 'resource 2'},
+        {name: 'zoology'},
+        {name: 'resource 1'},
+      ]
+      expect(
+        getSortedResources(resources, 'name', 'desc', SortTypes.String)
+      ).toEqual([{name: 'zoology'}, {name: 'resource 2'}, {name: 'resource 1'}])
+    })
+  })
+
+  describe('sorting dates', () => {
+    const dateTimeFormatter = createDateTimeFormatter(
+      DEFAULT_TIME_FORMAT,
+      'UTC'
+    )
+
+    it('sorts dates in ascending order', () => {
+      const resources = [
+        {date: dateTimeFormatter.format(new Date(1630350000000)), name: '1'},
+        {date: dateTimeFormatter.format(new Date(1630450000000)), name: '2'},
+        {date: dateTimeFormatter.format(new Date(1630150000000)), name: '3'},
+      ]
+      expect(
+        getSortedResources(resources, 'date', 'asc', SortTypes.Date)
+      ).toEqual([
+        {
+          date: '2021-08-28 11:26:40',
+          name: '3',
+        },
+        {
+          date: '2021-08-30 19:00:00',
+          name: '1',
+        },
+        {
+          date: '2021-08-31 22:46:40',
+          name: '2',
+        },
+      ])
+    })
+
+    it('sorts dates in descending order', () => {
+      const resources = [
+        {date: dateTimeFormatter.format(new Date(1630350000000)), name: '1'},
+        {date: dateTimeFormatter.format(new Date(1630450000000)), name: '2'},
+        {date: dateTimeFormatter.format(new Date(1630150000000)), name: '3'},
+      ]
+      expect(
+        getSortedResources(resources, 'date', 'desc', SortTypes.Date)
+      ).toEqual([
+        {
+          date: '2021-08-31 22:46:40',
+          name: '2',
+        },
+        {
+          date: '2021-08-30 19:00:00',
+          name: '1',
+        },
+        {
+          date: '2021-08-28 11:26:40',
+          name: '3',
+        },
+      ])
+    })
+  })
+})

--- a/src/shared/utils/sort.ts
+++ b/src/shared/utils/sort.ts
@@ -1,10 +1,12 @@
-import {orderBy, get, toLower} from 'lodash'
+import {toLower} from 'lodash'
 
 export enum SortTypes {
   String = 'string',
   Date = 'date',
   Float = 'float',
 }
+
+const collator = new Intl.Collator('en-us', {numeric: true})
 
 function orderByType(data, type) {
   switch (type) {
@@ -26,11 +28,18 @@ export function getSortedResources<T>(
   sortType: string
 ): T[] {
   if (sortKey && sortDirection) {
-    return orderBy<T>(
-      resourceList,
-      r => orderByType(get(r, sortKey), sortType),
-      [sortDirection]
-    )
+    return [...resourceList].sort((item1, item2) => {
+      if (sortDirection === 'desc') {
+        return collator.compare(
+          orderByType(item2[sortKey], sortType),
+          orderByType(item1[sortKey], sortType)
+        )
+      }
+      return collator.compare(
+        orderByType(item1[sortKey], sortType),
+        orderByType(item2[sortKey], sortType)
+      )
+    })
   }
   return resourceList
 }

--- a/src/shared/utils/sort.ts
+++ b/src/shared/utils/sort.ts
@@ -1,4 +1,4 @@
-import {toLower} from 'lodash'
+import {get, toLower} from 'lodash'
 
 export enum SortTypes {
   String = 'string',
@@ -31,13 +31,13 @@ export function getSortedResources<T>(
     return [...resourceList].sort((item1, item2) => {
       if (sortDirection === 'desc') {
         return collator.compare(
-          orderByType(item2[sortKey], sortType),
-          orderByType(item1[sortKey], sortType)
+          orderByType(get(item2, sortKey), sortType),
+          orderByType(get(item1, sortKey), sortType)
         )
       }
       return collator.compare(
-        orderByType(item1[sortKey], sortType),
-        orderByType(item2[sortKey], sortType)
+        orderByType(get(item1, sortKey), sortType),
+        orderByType(get(item2, sortKey), sortType)
       )
     })
   }


### PR DESCRIPTION
Closes #2512

#### Before (10 comes before 2):
![lexicographical](https://user-images.githubusercontent.com/146112/131410325-81c6d237-3bbd-45f4-b0ab-9dceb7f84592.png)

#### After:
![natural](https://user-images.githubusercontent.com/146112/131410332-930b4b85-131d-4380-ab50-1ac04e7dbe80.png)


