### PR TITLE
fix: allow sorting by duration in task runs

### DIFF
--- a/src/tasks/components/TaskRunsPage.tsx
+++ b/src/tasks/components/TaskRunsPage.tsx
@@ -112,6 +112,9 @@ class TaskRunsPage extends PureComponent<Props, State> {
 
     if (sortKey !== 'status') {
       sortType = SortTypes.Date
+      if (sortKey === 'duration') {
+        sortType = SortTypes.Float
+      }
     }
 
     this.setState({sortKey, sortDirection: nextSort, sortType})


### PR DESCRIPTION
Sorting on task runs didn't work on duration - it just didn't sort because it was trying to sort by date instead of by number, which is what the task run duration is.
![Screen Shot 2021-08-30 at 4 22 40 PM](https://user-images.githubusercontent.com/146112/131418123-0e61ecff-e0e9-413b-89b0-bd332948feea.png)

![Screen Shot 2021-08-30 at 4 22 38 PM](https://user-images.githubusercontent.com/146112/131418113-dee778b8-211c-4025-9af2-d610c246c73d.png)

