### PR TITLE
chore: add coveo script behind FF

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,6 +62,16 @@ const App: FC = () => {
         })
       }
     }
+    if (CLOUD && isFlagEnabled('coveo')) {
+      const script = document.createElement('script')
+      script.src =
+        'https://platform.cloud.coveo.com/rest/organizations/influxdatanonproduction1eh1cn7go/pages/95a20052-218d-4048-9081-16dbcebbdebb/inappwidget/loader'
+      script.async = true
+      document.body.appendChild(script)
+      return () => {
+        document.body.removeChild(script)
+      }
+    }
     setAutoFreeze(false)
   }, [])
 


### PR DESCRIPTION
This way we can toggle it for environments as needed.

The dynamic injection is the expedient method of getting this feature out behind a flag for demonstration purposes. The public key has been provided by Coveo and this was an implementation suggestion that allows us to work with their team on ensuring our integration is working as necessary. This shouldn't introduce any security concerns im aware of, and will allow us to work further with Coveo on developing a future-proof solution for integration

While this does represent a diversion from our usual implementation patterns, it should be noted that this suggestion was provided directly by the Coveo team and allows us to iterate quickly on the feature within a testing context and a public key that they can immediately invalidate should anything arise that is of concern.