### PR TITLE
fix: don't show bucket schema info on OSS bucket meta cards

### DIFF
--- a/src/buckets/components/BucketCardMeta.test.tsx
+++ b/src/buckets/components/BucketCardMeta.test.tsx
@@ -19,7 +19,7 @@ const setup = (
     labels: [],
   }
   return renderWithRedux(<BucketCardMeta bucket={bucket} />)
-} 
+}
 
 jest.mock('src/shared/constants/index', () => ({
   CLOUD: true,
@@ -29,11 +29,6 @@ const EXPLICIT_TEXT = 'Schema Type: Explicit'
 const IMPLICIT_TEXT = 'Schema Type: Implicit'
 
 describe('bucket meta data card, testing that the schema type shows up properly', () => {
-  beforeEach(() => {
-    process.env = { CLOUD_URL: "hello" }
-
-  });
-
   it('should show the explicit schema type', () => {
     const {getByTestId} = setup('explicit', 'user', 'fooabc')
 

--- a/src/buckets/components/BucketCardMeta.test.tsx
+++ b/src/buckets/components/BucketCardMeta.test.tsx
@@ -19,12 +19,21 @@ const setup = (
     labels: [],
   }
   return renderWithRedux(<BucketCardMeta bucket={bucket} />)
-}
+} 
+
+jest.mock('src/shared/constants/index', () => ({
+  CLOUD: true,
+}))
 
 const EXPLICIT_TEXT = 'Schema Type: Explicit'
 const IMPLICIT_TEXT = 'Schema Type: Implicit'
 
 describe('bucket meta data card, testing that the schema type shows up properly', () => {
+  beforeEach(() => {
+    process.env = { CLOUD_URL: "hello" }
+
+  });
+
   it('should show the explicit schema type', () => {
     const {getByTestId} = setup('explicit', 'user', 'fooabc')
 

--- a/src/buckets/components/BucketCardMeta.tsx
+++ b/src/buckets/components/BucketCardMeta.tsx
@@ -5,6 +5,7 @@ import {capitalize} from 'lodash'
 import {connect, ConnectedProps} from 'react-redux'
 
 // Constants
+import {CLOUD} from 'src/shared/constants'
 import {
   copyToClipboardSuccess,
   copyToClipboardFailed,
@@ -55,6 +56,10 @@ const BucketCardMeta: FC<Props> = ({bucket, notify}) => {
     <span data-testid="bucket-schemaType"> {schemaLabel} </span>
   )
 
+  const bucketInfo = CLOUD
+    ? [schemaBlock, persistentBucketMeta]
+    : [persistentBucketMeta]
+
   if (bucket.type === 'system') {
     return (
       <ResourceCard.Meta testID={`resourceCard-buckets-${bucket.id}`}>
@@ -64,16 +69,14 @@ const BucketCardMeta: FC<Props> = ({bucket, notify}) => {
         >
           System Bucket
         </span>
-        {persistentBucketMeta}
-        {schemaBlock}
+        {bucketInfo}
       </ResourceCard.Meta>
     )
   }
 
   return (
     <ResourceCard.Meta testID={`resourceCard-buckets-${bucket.id}`}>
-      {persistentBucketMeta}
-      {schemaBlock}
+      {bucketInfo}
       <CopyToClipboard text={bucket.id} onCopy={handleCopyAttempt}>
         <span className="copy-bucket-id" title="Click to Copy to Clipboard">
           ID: {bucket.id}

--- a/src/buckets/components/BucketCardMeta.tsx
+++ b/src/buckets/components/BucketCardMeta.tsx
@@ -57,7 +57,7 @@ const BucketCardMeta: FC<Props> = ({bucket, notify}) => {
   )
 
   const bucketInfo = CLOUD
-    ? [schemaBlock, persistentBucketMeta]
+    ? [persistentBucketMeta, schemaBlock]
     : [persistentBucketMeta]
 
   if (bucket.type === 'system') {


### PR DESCRIPTION
Closes #2520

Prevents bucket schema info from being shown on OSS, which does not have the concept of bucket schema.