### PR TITLE
chore(tests): reuse users throughout test suite

### DIFF
--- a/cypress/e2e/cloud/about.test.ts
+++ b/cypress/e2e/cloud/about.test.ts
@@ -2,25 +2,25 @@ import {Organization} from '../../../src/types'
 
 // resolve flakey behavior for the feature flag setting
 describe.skip('About Page for free users with only 1 user', () => {
-  beforeEach(() => {
-    cy.flush()
-
-    cy.signin().then(() => {
-      cy.get('@org').then(({id}: Organization) => {
-        cy.setFeatureFlags({
-          uiUnificationFlag: true,
-        }).then(() => {
-          cy.quartzProvision({
-            accountType: 'free',
-            hasUsers: false,
+  beforeEach(() =>
+    cy.flush().then(() =>
+      cy.signin().then(() => {
+        cy.get('@org').then(({id}: Organization) => {
+          cy.setFeatureFlags({
+            uiUnificationFlag: true,
           }).then(() => {
-            cy.visit(`/orgs/${id}/about`)
-            cy.getByTestID('about-page--header').should('be.visible')
+            cy.quartzProvision({
+              accountType: 'free',
+              hasUsers: false,
+            }).then(() => {
+              cy.visit(`/orgs/${id}/about`)
+              cy.getByTestID('about-page--header').should('be.visible')
+            })
           })
         })
       })
-    })
-  })
+    )
+  )
 
   it('should allow the delete account functionality', () => {
     cy.getByTestID('delete-org--button')
@@ -52,26 +52,25 @@ describe.skip('About Page for free users with only 1 user', () => {
 })
 
 describe('About Page for free users with multiple users', () => {
-  beforeEach(() => {
-    cy.flush()
-
-    cy.signin().then(() => {
-      cy.get('@org').then(({id}: Organization) => {
-        cy.setFeatureFlags({
-          uiUnificationFlag: true,
-        }).then(() => {
-          cy.quartzProvision({
-            accountType: 'free',
-            hasUsers: true,
+  beforeEach(() =>
+    cy.flush().then(() =>
+      cy.signin().then(() => {
+        cy.get('@org').then(({id}: Organization) => {
+          cy.setFeatureFlags({
+            uiUnificationFlag: true,
           }).then(() => {
-            cy.visit(`/orgs/${id}/about`)
-            cy.getByTestID('about-page--header').should('be.visible')
+            cy.quartzProvision({
+              accountType: 'free',
+              hasUsers: true,
+            }).then(() => {
+              cy.visit(`/orgs/${id}/about`)
+              cy.getByTestID('about-page--header').should('be.visible')
+            })
           })
         })
       })
-    })
-  })
-
+    )
+  )
   it('should display the warning and allow users to navigate to the users page when trying to delete when the user has multiple users', () => {
     cy.getByTestID('delete-org--button')
       .should('exist')
@@ -90,24 +89,24 @@ describe('About Page for free users with multiple users', () => {
 })
 
 describe('About Page for PAYG users', () => {
-  beforeEach(() => {
-    cy.flush()
-
-    cy.signin().then(() => {
-      cy.get('@org').then(({id}: Organization) => {
-        cy.setFeatureFlags({
-          uiUnificationFlag: true,
-        }).then(() => {
-          cy.quartzProvision({
-            accountType: 'pay_as_you_go',
+  beforeEach(() =>
+    cy.flush().then(() =>
+      cy.signin().then(() => {
+        cy.get('@org').then(({id}: Organization) => {
+          cy.setFeatureFlags({
+            uiUnificationFlag: true,
           }).then(() => {
-            cy.visit(`/orgs/${id}/about`)
-            cy.getByTestID('about-page--header').should('be.visible')
+            cy.quartzProvision({
+              accountType: 'pay_as_you_go',
+            }).then(() => {
+              cy.visit(`/orgs/${id}/about`)
+              cy.getByTestID('about-page--header').should('be.visible')
+            })
           })
         })
       })
-    })
-  })
+    )
+  )
 
   it('should not display the delete button', () => {
     cy.getByTestID('delete-org--button').should('not.exist')

--- a/cypress/e2e/cloud/billing.test.ts
+++ b/cypress/e2e/cloud/billing.test.ts
@@ -1,24 +1,24 @@
 import {Organization} from '../../../src/types'
 
 describe('Billing Page Free Users', () => {
-  beforeEach(() => {
-    cy.flush()
-
-    cy.signin().then(() => {
-      cy.get('@org').then(({id}: Organization) => {
-        cy.setFeatureFlags({
-          uiUnificationFlag: true,
-        }).then(() => {
-          cy.quartzProvision({
-            accountType: 'free',
+  beforeEach(() =>
+    cy.flush().then(() =>
+      cy.signin().then(() => {
+        cy.get('@org').then(({id}: Organization) => {
+          cy.setFeatureFlags({
+            uiUnificationFlag: true,
           }).then(() => {
-            cy.visit(`/orgs/${id}/billing`)
-            cy.getByTestID('billing-page--header').should('be.visible')
+            cy.quartzProvision({
+              accountType: 'free',
+            }).then(() => {
+              cy.visit(`/orgs/${id}/billing`)
+              cy.getByTestID('billing-page--header').should('be.visible')
+            })
           })
         })
       })
-    })
-  })
+    )
+  )
 
   it('should display the free billing page for free users', () => {
     cy.getByTestID('cloud-upgrade--button').should('be.visible')
@@ -55,22 +55,22 @@ describe('Billing Page Free Users', () => {
 })
 
 describe('Billing Page PAYG Users', () => {
-  beforeEach(() => {
-    cy.flush()
-
-    cy.signin().then(() => {
-      cy.get('@org').then(({id}: Organization) => {
-        cy.setFeatureFlags({uiUnificationFlag: true}).then(() => {
-          cy.quartzProvision({
-            accountType: 'pay_as_you_go',
-          }).then(() => {
-            cy.visit(`/orgs/${id}/billing`)
-            cy.getByTestID('billing-page--header').should('be.visible')
+  beforeEach(() =>
+    cy.flush().then(() =>
+      cy.signin().then(() => {
+        cy.get('@org').then(({id}: Organization) => {
+          cy.setFeatureFlags({uiUnificationFlag: true}).then(() => {
+            cy.quartzProvision({
+              accountType: 'pay_as_you_go',
+            }).then(() => {
+              cy.visit(`/orgs/${id}/billing`)
+              cy.getByTestID('billing-page--header').should('be.visible')
+            })
           })
         })
       })
-    })
-  })
+    )
+  )
 
   it('should display the free billing page for free users', () => {
     // The implication here is that there is no Upgrade Now button

--- a/cypress/e2e/cloud/pinned.test.ts
+++ b/cypress/e2e/cloud/pinned.test.ts
@@ -3,20 +3,20 @@ import {Organization} from '../../../src/types'
 describe('Pinned Items', () => {
   let orgID: string
   beforeEach(() => {
-    cy.flush()
-
-    cy.signin().then(() =>
-      cy.fixture('routes').then(() => {
-        cy.get('@org').then(({id}: any) => {
-          orgID = id
-          cy.setFeatureFlags({
-            pinnedItems: true,
-            docSearchWidget: true,
-          }).then(() => {
-            cy.getByTestID('tree-nav')
+    cy.flush().then(() =>
+      cy.signin().then(() =>
+        cy.fixture('routes').then(() => {
+          cy.get('@org').then(({id}: any) => {
+            orgID = id
+            cy.setFeatureFlags({
+              pinnedItems: true,
+              docSearchWidget: true,
+            }).then(() => {
+              cy.getByTestID('tree-nav')
+            })
           })
         })
-      })
+      )
     )
   })
 
@@ -131,24 +131,24 @@ describe('Pinned Items', () => {
   describe('Pin task tests', () => {
     let taskName: string
     beforeEach(() => {
-      cy.flush()
-
-      cy.signin().then(() => {
-        cy.get('@org').then(({id: orgID}: Organization) =>
-          cy
-            .createToken(orgID, 'test token', 'active', [
-              {action: 'write', resource: {type: 'views', orgID}},
-              {action: 'write', resource: {type: 'documents', orgID}},
-              {action: 'write', resource: {type: 'tasks', orgID}},
-            ])
-            .then(({body}) => {
-              cy.wrap(body.token).as('token')
-              cy.getByTestID('tree-nav')
-              cy.visit(`/orgs/${orgID}/tasks`)
-              cy.getByTestID('tree-nav')
-            })
-        )
-      })
+      cy.flush().then(() =>
+        cy.signin().then(() => {
+          cy.get('@org').then(({id: orgID}: Organization) =>
+            cy
+              .createToken(orgID, 'test token', 'active', [
+                {action: 'write', resource: {type: 'views', orgID}},
+                {action: 'write', resource: {type: 'documents', orgID}},
+                {action: 'write', resource: {type: 'tasks', orgID}},
+              ])
+              .then(({body}) => {
+                cy.wrap(body.token).as('token')
+                cy.getByTestID('tree-nav')
+                cy.visit(`/orgs/${orgID}/tasks`)
+                cy.getByTestID('tree-nav')
+              })
+          )
+        })
+      )
 
       taskName = 'Task'
       cy.createTaskFromEmpty(taskName, ({name}) => {

--- a/cypress/e2e/cloud/usage.test.ts
+++ b/cypress/e2e/cloud/usage.test.ts
@@ -9,21 +9,21 @@ const statHeaders = [
 
 describe('Usage Page Free User No Data', () => {
   beforeEach(() => {
-    cy.flush()
-
-    cy.signin().then(() => {
-      cy.get('@org').then(({id}: Organization) => {
-        cy.setFeatureFlags({uiUnificationFlag: true}).then(() => {
-          cy.quartzProvision({
-            hasData: false,
-            accountType: 'free',
-          }).then(() => {
-            cy.visit(`/orgs/${id}/usage`)
-            cy.getByTestID('usage-page--header').should('be.visible')
+    cy.flush().then(() =>
+      cy.signin().then(() => {
+        cy.get('@org').then(({id}: Organization) => {
+          cy.setFeatureFlags({uiUnificationFlag: true}).then(() => {
+            cy.quartzProvision({
+              hasData: false,
+              accountType: 'free',
+            }).then(() => {
+              cy.visit(`/orgs/${id}/usage`)
+              cy.getByTestID('usage-page--header').should('be.visible')
+            })
           })
         })
       })
-    })
+    )
   })
 
   it('should display the usage page common features', () => {
@@ -113,21 +113,21 @@ describe('Usage Page Free User No Data', () => {
 
 describe('Usage Page PAYG With Data', () => {
   beforeEach(() => {
-    cy.flush()
-
-    cy.signin().then(() => {
-      cy.get('@org').then(({id}: Organization) => {
-        cy.setFeatureFlags({uiUnificationFlag: true}).then(() => {
-          cy.quartzProvision({
-            hasData: true,
-            accountType: 'pay_as_you_go',
-          }).then(() => {
-            cy.visit(`/orgs/${id}/usage`)
-            cy.getByTestID('usage-page--header').should('be.visible')
+    cy.flush().then(() =>
+      cy.signin().then(() => {
+        cy.get('@org').then(({id}: Organization) => {
+          cy.setFeatureFlags({uiUnificationFlag: true}).then(() => {
+            cy.quartzProvision({
+              hasData: true,
+              accountType: 'pay_as_you_go',
+            }).then(() => {
+              cy.visit(`/orgs/${id}/usage`)
+              cy.getByTestID('usage-page--header').should('be.visible')
+            })
           })
         })
       })
-    })
+    )
   })
 
   it('should display the usage page with data for a PAYG user', () => {

--- a/cypress/e2e/cloud/users.test.ts
+++ b/cypress/e2e/cloud/users.test.ts
@@ -2,20 +2,20 @@ import {Organization} from '../../../src/types'
 
 describe('Users Page', () => {
   beforeEach(() => {
-    cy.flush()
-
-    cy.signin().then(() => {
-      cy.get('@org').then(({id}: Organization) => {
-        cy.setFeatureFlags({uiUnificationFlag: true}).then(() => {
-          cy.quartzProvision({
-            hasUsers: true,
-          }).then(() => {
-            cy.visit(`/orgs/${id}/users`)
-            cy.getByTestID('users-page--header').should('be.visible')
+    cy.flush().then(() =>
+      cy.signin().then(() => {
+        cy.get('@org').then(({id}: Organization) => {
+          cy.setFeatureFlags({uiUnificationFlag: true}).then(() => {
+            cy.quartzProvision({
+              hasUsers: true,
+            }).then(() => {
+              cy.visit(`/orgs/${id}/users`)
+              cy.getByTestID('users-page--header').should('be.visible')
+            })
           })
         })
       })
-    })
+    )
   })
 
   it('can CRUD Invites and Users', () => {

--- a/cypress/e2e/oss/buckets.test.ts
+++ b/cypress/e2e/oss/buckets.test.ts
@@ -1,18 +1,18 @@
 import {Organization} from '../../../src/types'
 
 describe('Buckets', () => {
-  beforeEach(() => {
-    cy.flush()
-
-    cy.signin().then(() => {
-      cy.get('@org').then(({id}: Organization) =>
-        cy.fixture('routes').then(({orgs, buckets}) => {
-          cy.visit(`${orgs}/${id}${buckets}`)
-          cy.getByTestID('tree-nav')
-        })
-      )
-    })
-  })
+  beforeEach(() =>
+    cy.flush().then(() =>
+      cy.signin().then(() => {
+        cy.get('@org').then(({id}: Organization) =>
+          cy.fixture('routes').then(({orgs, buckets}) => {
+            cy.visit(`${orgs}/${id}${buckets}`)
+            cy.getByTestID('tree-nav')
+          })
+        )
+      })
+    )
+  )
 
   // TODO: Skipping this until we can sort out the differences between OSS and Cloud
   it('can sort by name and retention', () => {

--- a/cypress/e2e/oss/dashboardsView.test.ts
+++ b/cypress/e2e/oss/dashboardsView.test.ts
@@ -1,16 +1,16 @@
 describe('Dashboard', () => {
-  beforeEach(() => {
-    cy.flush()
-
-    cy.signin().then(() =>
-      cy.fixture('routes').then(({orgs}) => {
-        cy.get('@org').then(({id: orgID}: any) => {
-          cy.visit(`${orgs}/${orgID}/dashboards-list`)
-          cy.getByTestID('tree-nav')
+  beforeEach(() =>
+    cy.flush().then(() =>
+      cy.signin().then(() =>
+        cy.fixture('routes').then(({orgs}) => {
+          cy.get('@org').then(({id: orgID}: any) => {
+            cy.visit(`${orgs}/${orgID}/dashboards-list`)
+            cy.getByTestID('tree-nav')
+          })
         })
-      })
+      )
     )
-  })
+  )
 
   it('does render image tags in markdown preview', () => {
     cy.get('@org').then(({id: orgID}: any) => {

--- a/cypress/e2e/oss/onboarding.test.ts
+++ b/cypress/e2e/oss/onboarding.test.ts
@@ -1,9 +1,9 @@
 describe('Onboarding Redirect', () => {
-  beforeEach(() => {
-    cy.flush()
-    cy.wrapEnvironmentVariablesForOss()
-    cy.visit('/')
-  })
+  beforeEach(() =>
+    cy
+      .flush()
+      .then(() => cy.wrapEnvironmentVariablesForOss().then(() => cy.visit('/')))
+  )
 
   it('Can redirect to onboarding page', () => {
     cy.getByTestID('init-step--head-main')
@@ -13,11 +13,13 @@ describe('Onboarding Redirect', () => {
 
 // NOTE: important to test for OSS
 describe('Onboarding', () => {
-  beforeEach(() => {
-    cy.flush()
-    cy.wrapEnvironmentVariablesForOss()
-    cy.visit('onboarding/0')
-  })
+  beforeEach(() =>
+    cy
+      .flush()
+      .then(() =>
+        cy.wrapEnvironmentVariablesForOss().then(() => cy.visit('onboarding/0'))
+      )
+  )
 
   it('Can Onboard to Quick Start', () => {
     cy.server()

--- a/cypress/e2e/oss/orgs.test.ts
+++ b/cypress/e2e/oss/orgs.test.ts
@@ -1,18 +1,15 @@
 import {Organization} from '../../../src/types'
 
 describe('Orgs', () => {
-  beforeEach(() => {
-    cy.flush()
-  })
+  beforeEach(() => cy.flush())
 
   describe('when there is a user with no orgs', () => {
-    beforeEach(() => {
+    beforeEach(() =>
       cy.signin().then(() => {
         cy.get('@org').then(({id}: Organization) => cy.deleteOrg(id))
+        cy.visit('/')
       })
-
-      cy.visit('/')
-    })
+    )
 
     it('forwards the user to the No Orgs Page', () => {
       cy.url().should('contain', 'no-org')

--- a/cypress/e2e/oss/scrapers.test.ts
+++ b/cypress/e2e/oss/scrapers.test.ts
@@ -5,17 +5,19 @@ const PAGE_LOAD_SLA = 10000
 
 describe('Scrapers', () => {
   beforeEach(() => {
-    cy.flush()
-
-    cy.signin().then(() => {
-      cy.get('@org').then(({id}: Organization) =>
-        cy.fixture('routes').then(({orgs}) => {
-          cy.visit(`${orgs}/${id}/load-data/scrapers`)
-          cy.getByTestID('tree-nav')
-        })
-      )
-    })
-    cy.get('[data-testid="resource-list--body"]', {timeout: PAGE_LOAD_SLA})
+    cy.flush().then(() =>
+      cy.signin().then(() => {
+        cy.get('@org').then(({id}: Organization) =>
+          cy.fixture('routes').then(({orgs}) => {
+            cy.visit(`${orgs}/${id}/load-data/scrapers`)
+            cy.getByTestID('tree-nav')
+            cy.get('[data-testid="resource-list--body"]', {
+              timeout: PAGE_LOAD_SLA,
+            })
+          })
+        )
+      })
+    )
   })
 
   describe('from the org settings', () => {

--- a/cypress/e2e/shared/about.test.ts
+++ b/cypress/e2e/shared/about.test.ts
@@ -1,16 +1,16 @@
 import {Organization} from '../../../src/types'
 
 describe('About Page', () => {
-  beforeEach(() => {
-    cy.flush()
-
-    cy.signin().then(() => {
-      cy.get('@org').then(({id}: Organization) => {
-        cy.visit(`/orgs/${id}/about`)
-        cy.getByTestID('about-page--header').should('be.visible')
+  beforeEach(() =>
+    cy.flush().then(() =>
+      cy.signin().then(() => {
+        cy.get('@org').then(({id}: Organization) => {
+          cy.visit(`/orgs/${id}/about`)
+          cy.getByTestID('about-page--header').should('be.visible')
+        })
       })
-    })
-  })
+    )
+  )
 
   it('should display everything correctly', () => {
     cy.getByTestID('common-ids--panel').within(() => {

--- a/cypress/e2e/shared/buckets.test.ts
+++ b/cypress/e2e/shared/buckets.test.ts
@@ -1,18 +1,18 @@
 import {Bucket, Organization} from '../../../src/types'
 
 describe('Buckets', () => {
-  beforeEach(() => {
-    cy.flush()
-
-    cy.signin().then(() => {
-      cy.get('@org').then(({id}: Organization) =>
-        cy.fixture('routes').then(({orgs, buckets}) => {
-          cy.visit(`${orgs}/${id}${buckets}`)
-          cy.getByTestID('tree-nav')
-        })
-      )
-    })
-  })
+  beforeEach(() =>
+    cy.flush().then(() =>
+      cy.signin().then(() => {
+        cy.get('@org').then(({id}: Organization) =>
+          cy.fixture('routes').then(({orgs, buckets}) => {
+            cy.visit(`${orgs}/${id}${buckets}`)
+            cy.getByTestID('tree-nav')
+          })
+        )
+      })
+    )
+  )
 
   describe('from the buckets index page', () => {
     it('can create a bucket', () => {

--- a/cypress/e2e/shared/checks.test.ts
+++ b/cypress/e2e/shared/checks.test.ts
@@ -7,27 +7,28 @@ const measurement = 'my_meas'
 const field = 'my_field'
 const stringField = 'string_field'
 describe('Checks', () => {
-  beforeEach(() => {
-    cy.flush()
-
-    cy.signin().then(() => {
-      // visit the alerting index
-      cy.get('@org').then(({id: orgID}: Organization) => {
-        cy.writeData([
-          `${measurement} ${field}=0,${stringField}="string1"`,
-          `${measurement} ${field}=1,${stringField}="string2"`,
-        ])
-        cy.fixture('routes').then(({orgs, alerting}) => {
-          cy.visit(`${orgs}/${orgID}${alerting}`)
-          cy.getByTestID('tree-nav')
+  beforeEach(() =>
+    cy.flush().then(() =>
+      cy.signin().then(() => {
+        // visit the alerting index
+        cy.get('@org').then(({id: orgID}: Organization) => {
+          cy.writeData([
+            `${measurement} ${field}=0,${stringField}="string1"`,
+            `${measurement} ${field}=1,${stringField}="string2"`,
+          ])
+          cy.fixture('routes').then(({orgs, alerting}) => {
+            cy.visit(`${orgs}/${orgID}${alerting}`)
+            cy.getByTestID('tree-nav')
+            cy.get('[data-testid="resource-list--body"]', {
+              timeout: PAGE_LOAD_SLA,
+            })
+            // User can only see all panels at once on large screens
+            cy.getByTestID('alerting-tab--checks').click({force: true})
+          })
         })
       })
-    })
-    cy.get('[data-testid="resource-list--body"]', {timeout: PAGE_LOAD_SLA})
-
-    // User can only see all panels at once on large screens
-    cy.getByTestID('alerting-tab--checks').click({force: true})
-  })
+    )
+  )
 
   it('can validate a threshold check', () => {
     cy.log('Create threshold check')

--- a/cypress/e2e/shared/dashboardsIndex.test.ts
+++ b/cypress/e2e/shared/dashboardsIndex.test.ts
@@ -6,18 +6,18 @@ const dashboardName2 = 'test dashboard'
 const dashSearchName = 'bEE'
 
 describe('Dashboards', () => {
-  beforeEach(() => {
-    cy.flush()
-
-    cy.signin().then(() =>
-      cy.fixture('routes').then(({orgs}) => {
-        cy.get<Organization>('@org').then(({id}: Organization) => {
-          cy.visit(`${orgs}/${id}/dashboards-list`)
-          cy.getByTestID('tree-nav')
+  beforeEach(() =>
+    cy.flush().then(() =>
+      cy.signin().then(() =>
+        cy.fixture('routes').then(({orgs}) => {
+          cy.get<Organization>('@org').then(({id}: Organization) => {
+            cy.visit(`${orgs}/${id}/dashboards-list`)
+            cy.getByTestID('tree-nav')
+          })
         })
-      })
+      )
     )
-  })
+  )
 
   it('empty state should have a header with text and a button to create a dashboard', () => {
     cy.getByTestID('page-contents').within(() => {

--- a/cypress/e2e/shared/dashboardsRefresh.test.ts
+++ b/cypress/e2e/shared/dashboardsRefresh.test.ts
@@ -2,17 +2,18 @@ import {Organization} from '../../../src/types'
 import * as moment from 'moment'
 
 describe('Dashboard refresh', () => {
-  beforeEach(() => {
-    cy.flush()
-    cy.signin().then(() =>
-      cy.fixture('routes').then(({orgs}) => {
-        cy.get('@org').then(({id: orgID}: Organization) => {
-          cy.visit(`${orgs}/${orgID}/dashboards-list`)
-          cy.getByTestID('tree-nav')
+  beforeEach(() =>
+    cy.flush().then(() =>
+      cy.signin().then(() =>
+        cy.fixture('routes').then(({orgs}) => {
+          cy.get('@org').then(({id: orgID}: Organization) => {
+            cy.visit(`${orgs}/${orgID}/dashboards-list`)
+            cy.getByTestID('tree-nav')
+          })
         })
-      })
+      )
     )
-  })
+  )
   describe('Dashboard auto refresh', () => {
     let routeToReturnTo = ''
     const jumpAheadTime = (timeAhead = '00:00:00') => {

--- a/cypress/e2e/shared/dashboardsView.test.ts
+++ b/cypress/e2e/shared/dashboardsView.test.ts
@@ -2,17 +2,18 @@ import {Organization, AppState, Dashboard} from '../../../src/types'
 import {lines} from '../../support/commands'
 
 describe('Dashboard', () => {
-  beforeEach(() => {
-    cy.flush()
-    cy.signin().then(() =>
-      cy.fixture('routes').then(({orgs}) => {
-        cy.get('@org').then(({id: orgID}: Organization) => {
-          cy.visit(`${orgs}/${orgID}/dashboards-list`)
-          cy.getByTestID('tree-nav')
+  beforeEach(() =>
+    cy.flush().then(() =>
+      cy.signin().then(() =>
+        cy.fixture('routes').then(({orgs}) => {
+          cy.get('@org').then(({id: orgID}: Organization) => {
+            cy.visit(`${orgs}/${orgID}/dashboards-list`)
+            cy.getByTestID('tree-nav')
+          })
         })
-      })
+      )
     )
-  })
+  )
 
   it("can edit a dashboard's name", () => {
     cy.get('@org').then(({id: orgID}: Organization) => {

--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -27,19 +27,19 @@ function getTimeMachineText() {
 }
 
 describe('DataExplorer', () => {
-  beforeEach(() => {
-    cy.flush()
-
-    cy.signin().then(() => {
-      cy.get('@org').then(({id}: Organization) => {
-        cy.createMapVariable(id)
-        cy.fixture('routes').then(({orgs, explorer}) => {
-          cy.visit(`${orgs}/${id}${explorer}`)
-          cy.getByTestID('tree-nav')
+  beforeEach(() =>
+    cy.flush().then(() =>
+      cy.signin().then(() => {
+        cy.get('@org').then(({id}: Organization) => {
+          cy.createMapVariable(id)
+          cy.fixture('routes').then(({orgs, explorer}) => {
+            cy.visit(`${orgs}/${id}${explorer}`)
+            cy.getByTestID('tree-nav')
+          })
         })
       })
-    })
-  })
+    )
+  )
 
   describe('data-explorer state', () => {
     it('should persist and display last submitted script editor script ', () => {

--- a/cypress/e2e/shared/explorerVisualizations.test.ts
+++ b/cypress/e2e/shared/explorerVisualizations.test.ts
@@ -15,19 +15,19 @@ const VIS_TYPES = [
   'table',
 ]
 describe('visualizations', () => {
-  beforeEach(() => {
-    cy.flush()
-
-    cy.signin().then(() => {
-      cy.get('@org').then(({id}: Organization) => {
-        cy.createMapVariable(id)
-        cy.fixture('routes').then(({orgs, explorer}) => {
-          cy.visit(`${orgs}/${id}${explorer}`)
-          cy.getByTestID('tree-nav')
+  beforeEach(() =>
+    cy.flush().then(() =>
+      cy.signin().then(() => {
+        cy.get('@org').then(({id}: Organization) => {
+          cy.createMapVariable(id)
+          cy.fixture('routes').then(({orgs, explorer}) => {
+            cy.visit(`${orgs}/${id}${explorer}`)
+            cy.getByTestID('tree-nav')
+          })
         })
       })
-    })
-  })
+    )
+  )
   describe('empty states', () => {
     it('shows a message if no queries have been created', () => {
       cy.getByTestID('empty-graph--no-queries').should('exist')

--- a/cypress/e2e/shared/flows.test.ts
+++ b/cypress/e2e/shared/flows.test.ts
@@ -1,21 +1,24 @@
 import {Organization} from '../../src/types'
 
 describe('Flows', () => {
-  beforeEach(() => {
-    cy.flush()
-    cy.signin().then(() => {
-      cy.get('@org').then(({id}: Organization) =>
-        cy.fixture('routes').then(({orgs}) => {
-          cy.visit(`${orgs}/${id}`)
-          cy.getByTestID('version-info')
-          cy.setFeatureFlags({notebooks: true, simpleTable: true}).then(() => {
-            cy.getByTestID('nav-item-flows').should('be.visible')
-            cy.getByTestID('nav-item-flows').click()
+  beforeEach(() =>
+    cy.flush().then(() =>
+      cy.signin().then(() => {
+        cy.get('@org').then(({id}: Organization) =>
+          cy.fixture('routes').then(({orgs}) => {
+            cy.visit(`${orgs}/${id}`)
+            cy.getByTestID('version-info')
+            cy.setFeatureFlags({notebooks: true, simpleTable: true}).then(
+              () => {
+                cy.getByTestID('nav-item-flows').should('be.visible')
+                cy.getByTestID('nav-item-flows').click()
+              }
+            )
           })
-        })
-      )
-    })
-  })
+        )
+      })
+    )
+  )
 
   it('CRUD a flow from the index page', () => {
     const now = Date.now()

--- a/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
+++ b/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
@@ -158,9 +158,7 @@ const getClients = (
 }
 
 describe('Flows', () => {
-  beforeEach(() => {
-    cy.flush()
-  })
+  beforeEach(() => cy.flush())
 
   describe('Flows Copy To Clipboard', () => {
     beforeEach(() => {

--- a/cypress/e2e/shared/home.test.ts
+++ b/cypress/e2e/shared/home.test.ts
@@ -1,10 +1,6 @@
 describe('Home Page Tests', () => {
   // Create tests for the home page. Issue: https://github.com/influxdata/ui/issues/939
-  beforeEach(() => {
-    cy.flush()
-
-    cy.signin()
-  })
+  beforeEach(() => cy.flush().then(() => cy.signin()))
 
   it('loads home page', () => {
     cy.getByTestID('home-page--header').should('exist')

--- a/cypress/e2e/shared/labels.test.ts
+++ b/cypress/e2e/shared/labels.test.ts
@@ -1,18 +1,18 @@
 import {Organization} from '../../../src/types'
 
 describe('labels', () => {
-  beforeEach(() => {
-    cy.flush()
-
-    cy.signin().then(() => {
-      cy.get('@org').then(({id}: Organization) =>
-        cy.fixture('routes').then(({orgs}) => {
-          cy.visit(`${orgs}/${id}/settings/labels`)
-          cy.getByTestID('tree-nav')
-        })
-      )
-    })
-  })
+  beforeEach(() =>
+    cy.flush().then(() =>
+      cy.signin().then(() => {
+        cy.get('@org').then(({id}: Organization) =>
+          cy.fixture('routes').then(({orgs}) => {
+            cy.visit(`${orgs}/${id}/settings/labels`)
+            cy.getByTestID('tree-nav')
+          })
+        )
+      })
+    )
+  )
 
   function hex2BgColor(hex: string): string {
     hex = hex.replace('#', '')

--- a/cypress/e2e/shared/legends.test.ts
+++ b/cypress/e2e/shared/legends.test.ts
@@ -15,19 +15,19 @@ const VIS_TYPES = [
 
 describe('Legends', () => {
   describe('in the Data Explorer', () => {
-    beforeEach(() => {
-      cy.flush()
-
-      cy.signin().then(() => {
-        cy.get('@org').then(({id}: Organization) => {
-          cy.createMapVariable(id)
-          cy.fixture('routes').then(({orgs, explorer}) => {
-            cy.visit(`${orgs}/${id}${explorer}`)
-            cy.getByTestID('tree-nav')
+    beforeEach(() =>
+      cy.flush().then(() =>
+        cy.signin().then(() => {
+          cy.get('@org').then(({id}: Organization) => {
+            cy.createMapVariable(id)
+            cy.fixture('routes').then(({orgs, explorer}) => {
+              cy.visit(`${orgs}/${id}${explorer}`)
+              cy.getByTestID('tree-nav')
+            })
           })
         })
-      })
-    })
+      )
+    )
 
     describe('hover legend aka "tooltip"', () => {
       it('gives the user a toggle for hide the tooltip only for line graph, line graph plus single stat, and band plot', () => {
@@ -412,18 +412,18 @@ describe('Legends', () => {
   })
 
   describe('in Dashboards', () => {
-    beforeEach(() => {
-      cy.flush()
-
-      cy.signin().then(() =>
-        cy.fixture('routes').then(({orgs}) => {
-          cy.get('@org').then(({id}: Organization) => {
-            cy.visit(`${orgs}/${id}/dashboards-list`)
-            cy.getByTestID('tree-nav')
+    beforeEach(() =>
+      cy.flush().then(() =>
+        cy.signin().then(() =>
+          cy.fixture('routes').then(({orgs}) => {
+            cy.get('@org').then(({id}: Organization) => {
+              cy.visit(`${orgs}/${id}/dashboards-list`)
+              cy.getByTestID('tree-nav')
+            })
           })
-        })
+        )
       )
-    })
+    )
 
     it('adds a new cell to a dashboard with the static legend options open and without submitting the query', () => {
       const cellName = 'anti-crash test not subbmited dashboard add cell'

--- a/cypress/e2e/shared/loadDataSources.test.ts
+++ b/cypress/e2e/shared/loadDataSources.test.ts
@@ -1,18 +1,18 @@
 import {Organization} from '../../src/types'
 
 describe('Load Data Sources', () => {
-  beforeEach(() => {
-    cy.flush()
-
-    cy.signin().then(() => {
-      cy.get('@org').then(({id}: Organization) =>
-        cy.fixture('routes').then(({orgs}) => {
-          cy.visit(`${orgs}/${id}/load-data/sources`)
-          cy.getByTestID('tree-nav')
-        })
-      )
-    })
-  })
+  beforeEach(() =>
+    cy.flush().then(() =>
+      cy.signin().then(() => {
+        cy.get('@org').then(({id}: Organization) =>
+          cy.fixture('routes').then(({orgs}) => {
+            cy.visit(`${orgs}/${id}/load-data/sources`)
+            cy.getByTestID('tree-nav')
+          })
+        )
+      })
+    )
+  )
 
   it('navigate to Client Library details view and render it with essentials', () => {
     cy.getByTestID('write-data--section client-libraries').within(() => {

--- a/cypress/e2e/shared/login.test.ts
+++ b/cypress/e2e/shared/login.test.ts
@@ -1,13 +1,12 @@
 describe('The Login Page', () => {
-  beforeEach(() => {
-    cy.flush()
-
-    cy.setupUser().then(({body}) => {
-      cy.wrap(body.org.id).as('orgID')
-    })
-
-    cy.visit('/')
-  })
+  beforeEach(() =>
+    cy.flush().then(() =>
+      cy.setupUser().then(({body}) => {
+        cy.wrap(body.org.id).as('orgID')
+        cy.visit('/')
+      })
+    )
+  )
 
   // NOTE: we aren't currently loading the login page
   // for dex

--- a/cypress/e2e/shared/nav.test.ts
+++ b/cypress/e2e/shared/nav.test.ts
@@ -2,9 +2,7 @@ import {Organization} from '../../../src/types'
 
 describe('navigation', () => {
   beforeEach(() => {
-    cy.flush()
-
-    cy.signin().then(() => cy.visit('/'))
+    cy.flush().then(() => cy.signin().then(() => cy.visit('/')))
   })
 
   it('can navigate to each page from left nav', () => {

--- a/cypress/e2e/shared/notificationEndpoints.test.ts
+++ b/cypress/e2e/shared/notificationEndpoints.test.ts
@@ -17,22 +17,22 @@ describe('Notification Endpoints', () => {
   }
 
   beforeEach(() => {
-    cy.flush()
+    cy.flush().then(() =>
+      cy.signin().then(() => {
+        cy.get('@org').then(({id}: Organization) =>
+          cy.fixture('routes').then(({orgs, alerting}) => {
+            cy.createEndpoint({...endpoint, orgID: id}).then(({body}) => {
+              cy.wrap(body).as('endpoint')
+            })
+            cy.visit(`${orgs}/${id}${alerting}`)
+            cy.getByTestID('tree-nav')
 
-    cy.signin().then(() => {
-      cy.get('@org').then(({id}: Organization) =>
-        cy.fixture('routes').then(({orgs, alerting}) => {
-          cy.createEndpoint({...endpoint, orgID: id}).then(({body}) => {
-            cy.wrap(body).as('endpoint')
+            // User can only see all panels at once on large screens
+            cy.getByTestID('alerting-tab--endpoints').click({force: true})
           })
-          cy.visit(`${orgs}/${id}${alerting}`)
-          cy.getByTestID('tree-nav')
-
-          // User can only see all panels at once on large screens
-          cy.getByTestID('alerting-tab--endpoints').click({force: true})
-        })
-      )
-    })
+        )
+      })
+    )
   })
 
   it('can create a notification endpoint', () => {

--- a/cypress/e2e/shared/notificationRules.test.ts
+++ b/cypress/e2e/shared/notificationRules.test.ts
@@ -7,28 +7,28 @@ describe('NotificationRules', () => {
   const name3 = 'Slack 3'
 
   beforeEach(() => {
-    cy.flush()
+    cy.flush().then(() =>
+      cy.signin().then(() => {
+        cy.get('@org').then(({id}: Organization) => {
+          // create the notification endpoints
+          cy.fixture('endpoints').then(({slack}) => {
+            cy.createEndpoint({...slack, name: name1, orgID: id})
+            cy.createEndpoint({...slack, name: name2, orgID: id}).then(
+              ({body}) => {
+                cy.wrap(body).as('selectedEndpoint')
+              }
+            )
+            cy.createEndpoint({...slack, name: name3, orgID: id})
+          })
 
-    cy.signin().then(() => {
-      cy.get('@org').then(({id}: Organization) => {
-        // create the notification endpoints
-        cy.fixture('endpoints').then(({slack}) => {
-          cy.createEndpoint({...slack, name: name1, orgID: id})
-          cy.createEndpoint({...slack, name: name2, orgID: id}).then(
-            ({body}) => {
-              cy.wrap(body).as('selectedEndpoint')
-            }
-          )
-          cy.createEndpoint({...slack, name: name3, orgID: id})
-        })
-
-        // visit the alerting index
-        cy.fixture('routes').then(({orgs, alerting}) => {
-          cy.visit(`${orgs}/${id}${alerting}`)
-          cy.getByTestID('tree-nav')
+          // visit the alerting index
+          cy.fixture('routes').then(({orgs, alerting}) => {
+            cy.visit(`${orgs}/${id}${alerting}`)
+            cy.getByTestID('tree-nav')
+          })
         })
       })
-    })
+    )
   })
 
   describe('When a rule does not exist', () => {

--- a/cypress/e2e/shared/orgs.test.ts
+++ b/cypress/e2e/shared/orgs.test.ts
@@ -1,7 +1,5 @@
 describe('Orgs', () => {
-  beforeEach(() => {
-    cy.flush()
-  })
+  beforeEach(() => cy.flush())
 
   describe('updating and switching orgs', () => {
     beforeEach(() => {

--- a/cypress/e2e/shared/queryBuilder.test.ts
+++ b/cypress/e2e/shared/queryBuilder.test.ts
@@ -15,17 +15,19 @@ const generateRandomSixDigitNumber = () => {
 
 describe('The Query Builder', () => {
   beforeEach(() => {
-    cy.flush()
+    cy.flush().then(() =>
+      cy
+        .signin()
+        .then(() =>
+          cy.writeData([
+            `mem,host=thrillbo-swaggins active=${generateRandomSixDigitNumber()}`,
+            `mem,host=thrillbo-swaggins cached=${generateRandomSixDigitNumber()}`,
 
-    cy.signin()
-
-    cy.writeData([
-      `mem,host=thrillbo-swaggins active=${generateRandomSixDigitNumber()}`,
-      `mem,host=thrillbo-swaggins cached=${generateRandomSixDigitNumber()}`,
-
-      `mem,host=thrillbo-swaggins active=${generateRandomSixDigitNumber()}`,
-      `mem,host=thrillbo-swaggins cached=${generateRandomSixDigitNumber()}`,
-    ])
+            `mem,host=thrillbo-swaggins active=${generateRandomSixDigitNumber()}`,
+            `mem,host=thrillbo-swaggins cached=${generateRandomSixDigitNumber()}`,
+          ])
+        )
+    )
   })
 
   describe('from the Data Explorer', () => {

--- a/cypress/e2e/shared/secrets.test.ts
+++ b/cypress/e2e/shared/secrets.test.ts
@@ -2,17 +2,18 @@ import {Organization} from '../../src/types'
 
 describe('Secrets', () => {
   beforeEach(() => {
-    cy.flush()
-    return cy.signin().then(() => {
-      cy.get('@org').then(({id}: Organization) =>
-        cy.fixture('routes').then(({orgs}) => {
-          cy.visit(`${orgs}/${id}/settings/`)
-          cy.getByTestID('tree-nav')
-          return cy.setFeatureFlags({secretsUI: true}).then(() => {
-            return cy.getByTestID('secrets--tab').click()
+    cy.flush().then(() => {
+      return cy.signin().then(() => {
+        cy.get('@org').then(({id}: Organization) =>
+          cy.fixture('routes').then(({orgs}) => {
+            cy.visit(`${orgs}/${id}/settings/`)
+            cy.getByTestID('tree-nav')
+            return cy.setFeatureFlags({secretsUI: true}).then(() => {
+              return cy.getByTestID('secrets--tab').click()
+            })
           })
-        })
-      )
+        )
+      })
     })
   })
 

--- a/cypress/e2e/shared/simpleTable.test.ts
+++ b/cypress/e2e/shared/simpleTable.test.ts
@@ -6,23 +6,24 @@ describe('simple table interactions', () => {
   const simpleLarge = 'simple-large'
   const simpleOverflow = 'simple-overflow'
   beforeEach(() => {
-    cy.flush()
-    cy.signin().then(() => {
-      cy.get('@org').then(({id: orgID}: Organization) => {
-        cy.fixture('routes').then(({orgs, explorer}) => {
-          cy.visit(`${orgs}/${orgID}${explorer}`)
-          cy.getByTestID('tree-nav')
-          cy.createBucket(orgID, name, simpleLarge)
-          cy.writeData(lines(300), simpleLarge)
-          cy.createBucket(orgID, name, simpleSmall)
-          cy.writeData(lines(30), simpleSmall)
-          cy.createBucket(orgID, name, simpleOverflow)
-          cy.writeData(lines(31), simpleOverflow)
-          cy.reload()
-          cy.setFeatureFlags({simpleTable: true})
+    cy.flush().then(() =>
+      cy.signin().then(() => {
+        cy.get('@org').then(({id: orgID}: Organization) => {
+          cy.fixture('routes').then(({orgs, explorer}) => {
+            cy.visit(`${orgs}/${orgID}${explorer}`)
+            cy.getByTestID('tree-nav')
+            cy.createBucket(orgID, name, simpleLarge)
+            cy.writeData(lines(300), simpleLarge)
+            cy.createBucket(orgID, name, simpleSmall)
+            cy.writeData(lines(30), simpleSmall)
+            cy.createBucket(orgID, name, simpleOverflow)
+            cy.writeData(lines(31), simpleOverflow)
+            cy.reload()
+            cy.setFeatureFlags({simpleTable: true})
+          })
         })
       })
-    })
+    )
   })
 
   it('should render correctly after switching from a dataset with more pages to one with fewer', () => {

--- a/cypress/e2e/shared/tasks.test.ts
+++ b/cypress/e2e/shared/tasks.test.ts
@@ -9,21 +9,21 @@ import {Organization} from '../../../src/types'
 
 describe('Tasks', () => {
   beforeEach(() => {
-    cy.flush()
-
-    cy.signin().then(() => {
-      cy.get<Organization>('@org').then(({id: orgID}: Organization) =>
-        cy
-          .createToken(orgID, 'test token', 'active', [
-            {action: 'write', resource: {type: 'views', orgID}},
-            {action: 'write', resource: {type: 'documents', orgID}},
-            {action: 'write', resource: {type: 'tasks', orgID}},
-          ])
-          .then(({body}) => {
-            cy.wrap(body.token).as('token')
-          })
-      )
-    })
+    cy.flush().then(() =>
+      cy.signin().then(() => {
+        cy.get<Organization>('@org').then(({id: orgID}: Organization) =>
+          cy
+            .createToken(orgID, 'test token', 'active', [
+              {action: 'write', resource: {type: 'views', orgID}},
+              {action: 'write', resource: {type: 'documents', orgID}},
+              {action: 'write', resource: {type: 'tasks', orgID}},
+            ])
+            .then(({body}) => {
+              cy.wrap(body.token).as('token')
+            })
+        )
+      })
+    )
 
     cy.fixture('routes').then(({orgs}) => {
       cy.get<Organization>('@org').then(({id}: Organization) => {

--- a/cypress/e2e/shared/telegrafPlugins.test.ts
+++ b/cypress/e2e/shared/telegrafPlugins.test.ts
@@ -2,16 +2,16 @@ import {Organization} from '../../../src/types'
 
 describe('Sources > Telegraf Plugins', () => {
   beforeEach(() => {
-    cy.flush()
-
-    cy.signin().then(() => {
-      cy.get('@org').then(({id}: Organization) =>
-        cy.fixture('routes').then(({orgs, sources}) => {
-          cy.visit(`${orgs}/${id}${sources}`)
-          cy.getByTestID('tree-nav')
-        })
-      )
-    })
+    cy.flush().then(() =>
+      cy.signin().then(() => {
+        cy.get('@org').then(({id}: Organization) =>
+          cy.fixture('routes').then(({orgs, sources}) => {
+            cy.visit(`${orgs}/${id}${sources}`)
+            cy.getByTestID('tree-nav')
+          })
+        )
+      })
+    )
   })
 
   it('can select a plugin and see details without an option to add to a configuration when feature is off', () => {

--- a/cypress/e2e/shared/telegrafs.test.ts
+++ b/cypress/e2e/shared/telegrafs.test.ts
@@ -5,18 +5,19 @@ const PAGE_LOAD_SLA = 80000
 
 describe('Collectors', () => {
   beforeEach(() => {
-    cy.flush()
-
-    cy.signin().then(() => {
-      cy.get('@org').then(({id}: Organization) =>
-        cy.fixture('routes').then(({orgs, telegrafs}) => {
-          cy.visit(`${orgs}/${id}${telegrafs}`)
-          cy.getByTestID('tree-nav')
-        })
-      )
-    })
-
-    cy.get('[data-testid="resource-list--body"]', {timeout: PAGE_LOAD_SLA})
+    cy.flush().then(() =>
+      cy.signin().then(() => {
+        cy.get('@org').then(({id}: Organization) =>
+          cy.fixture('routes').then(({orgs, telegrafs}) => {
+            cy.visit(`${orgs}/${id}${telegrafs}`)
+            cy.getByTestID('tree-nav')
+            cy.get('[data-testid="resource-list--body"]', {
+              timeout: PAGE_LOAD_SLA,
+            })
+          })
+        )
+      })
+    )
   })
 
   describe('from the org view', () => {

--- a/cypress/e2e/shared/tokens.test.ts
+++ b/cypress/e2e/shared/tokens.test.ts
@@ -9,49 +9,49 @@ describe('tokens', () => {
   let authData: {description: string; status: boolean; id: string}[]
 
   beforeEach(() => {
-    cy.flush()
+    cy.flush().then(() => {
+      // this is bad
+      // use a cypress alias instead
+      // docs.cypress.io/guides/core-concepts/variables-and-aliases.html#Avoiding-the-use-of-this
+      // docs.cypress.io/guides/core-concepts/variables-and-aliases.html#Aliases
+      authData = []
 
-    // this is bad
-    // use a cypress alias instead
-    // docs.cypress.io/guides/core-concepts/variables-and-aliases.html#Avoiding-the-use-of-this
-    // docs.cypress.io/guides/core-concepts/variables-and-aliases.html#Aliases
-    authData = []
+      cy.signin().then(() => {
+        cy.get('@org').then(({id}: Organization) => {
+          // check out array.reduce for the nested calls here
+          cy.request('api/v2/authorizations').then(resp => {
+            expect(resp.body).to.exist
+            authData.push({
+              description: resp.body.authorizations[0].description,
+              status: resp.body.authorizations[0].status === 'active',
+              id: resp.body.authorizations[0].id,
+            })
 
-    cy.signin().then(() => {
-      cy.get('@org').then(({id}: Organization) => {
-        // check out array.reduce for the nested calls here
-        cy.request('api/v2/authorizations').then(resp => {
-          expect(resp.body).to.exist
-          authData.push({
-            description: resp.body.authorizations[0].description,
-            status: resp.body.authorizations[0].status === 'active',
-            id: resp.body.authorizations[0].id,
-          })
-
-          cy.fixture('tokens.json').then(({tokens}) => {
-            tokens.forEach(token => {
-              token.permissions.forEach(p => (p.resource.orgID = id))
-              cy.createToken(
-                id,
-                token.description,
-                token.status,
-                token.permissions
-              ).then(resp => {
-                expect(resp.body).to.exist
-                authData.push({
-                  description: resp.body.description,
-                  status: resp.body.status === 'active',
-                  id: resp.body.id,
+            cy.fixture('tokens.json').then(({tokens}) => {
+              tokens.forEach(token => {
+                token.permissions.forEach(p => (p.resource.orgID = id))
+                cy.createToken(
+                  id,
+                  token.description,
+                  token.status,
+                  token.permissions
+                ).then(resp => {
+                  expect(resp.body).to.exist
+                  authData.push({
+                    description: resp.body.description,
+                    status: resp.body.status === 'active',
+                    id: resp.body.id,
+                  })
                 })
               })
             })
-          })
 
-          cy.fixture('routes').then(({orgs}) => {
-            cy.visit(`${orgs}/${id}/load-data/tokens`)
-            cy.getByTestID('tree-nav')
+            cy.fixture('routes').then(({orgs}) => {
+              cy.visit(`${orgs}/${id}/load-data/tokens`)
+              cy.getByTestID('tree-nav')
+            })
+            cy.get('[data-testid="resource-list"]', {timeout: PAGE_LOAD_SLA})
           })
-          cy.get('[data-testid="resource-list"]', {timeout: PAGE_LOAD_SLA})
         })
       })
     })

--- a/cypress/e2e/shared/variables.test.ts
+++ b/cypress/e2e/shared/variables.test.ts
@@ -2,17 +2,16 @@ import {Organization} from '../../../src/types'
 
 describe('Variables', () => {
   beforeEach(() => {
-    cy.flush()
-
-    cy.signin().then(() => {
-      cy.get('@org').then(({id}: Organization) => {
-        cy.createQueryVariable(id)
-        cy.visit(`orgs/${id}/settings/variables`)
-        cy.getByTestID('tree-nav')
+    cy.flush().then(() =>
+      cy.signin().then(() => {
+        cy.get('@org').then(({id}: Organization) => {
+          cy.createQueryVariable(id)
+          cy.visit(`orgs/${id}/settings/variables`)
+          cy.getByTestID('tree-nav')
+        })
+        cy.location('pathname').should('match', /\/variables$/)
       })
-    })
-
-    cy.location('pathname').should('match', /\/variables$/)
+    )
   })
 
   it('can CRUD a CSV, upload, map, and query variable and search for variables based on names', () => {

--- a/cypress/e2e/util/annotationsSetup.ts
+++ b/cypress/e2e/util/annotationsSetup.ts
@@ -1,70 +1,70 @@
 import {Organization} from '../../../src/types'
 import {lines} from '../../support/commands'
 
-export const setupData = (cy: Cypress.Chainable, plotTypeSuffix = '') => {
-  cy.flush()
-  return cy.signin().then(() =>
-    cy.get('@org').then(({id: orgID}: Organization) =>
-      cy.createDashboard(orgID).then(({body}) =>
-        cy.fixture('routes').then(({orgs}) => {
-          cy.visit(`${orgs}/${orgID}/dashboards/${body.id}`)
-          return cy
-            .setFeatureFlags({
-              useGiraffeGraphs: true,
-            })
-            .then(() => {
-              cy.createBucket(orgID, name, 'devbucket')
-              // have to add large amount of data to fill the window so that the random click for annotation works
-              cy.writeData(lines(3000), 'devbucket')
-
-              // make a dashboard cell
-              cy.getByTestID('add-cell--button').click()
-              cy.getByTestID('selector-list devbucket').should(
-                'have.length.of.at.least',
-                1
-              )
-              cy.getByTestID('selector-list devbucket').click()
-
-              cy.getByTestID('selector-list m').should(
-                'have.length.of.at.least',
-                1
-              )
-              cy.getByTestID('selector-list m').clickAttached()
-
-              cy.getByTestID('selector-list v').should(
-                'have.length.of.at.least',
-                1
-              )
-              cy.getByTestID('selector-list v').clickAttached()
-
-              if (plotTypeSuffix) {
-                cy.getByTestID('view-type--dropdown').click()
-                cy.getByTestID(`view-type--${plotTypeSuffix}`).click()
-              }
-
-              cy.getByTestID(`selector-list tv1`).should(
-                'have.length.of.at.least',
-                1
-              )
-              cy.getByTestID(`selector-list tv1`).clickAttached()
-
-              cy.getByTestID('time-machine-submit-button').click()
-
-              cy.getByTestID('overlay').within(() => {
-                cy.getByTestID('page-title').click()
-                cy.getByTestID('renamable-page-title--input')
-                  .clear()
-                  .type('blah')
-                cy.getByTestID('save-cell--button').click()
+export const setupData = (cy: Cypress.Chainable, plotTypeSuffix = '') =>
+  cy.flush().then(() =>
+    cy.signin().then(() =>
+      cy.get('@org').then(({id: orgID}: Organization) =>
+        cy.createDashboard(orgID).then(({body}) =>
+          cy.fixture('routes').then(({orgs}) => {
+            cy.visit(`${orgs}/${orgID}/dashboards/${body.id}`)
+            return cy
+              .setFeatureFlags({
+                useGiraffeGraphs: true,
               })
+              .then(() => {
+                cy.createBucket(orgID, name, 'devbucket')
+                // have to add large amount of data to fill the window so that the random click for annotation works
+                cy.writeData(lines(3000), 'devbucket')
 
-              cy.getByTestID('toggle-annotations-controls').click()
-            })
-        })
+                // make a dashboard cell
+                cy.getByTestID('add-cell--button').click()
+                cy.getByTestID('selector-list devbucket').should(
+                  'have.length.of.at.least',
+                  1
+                )
+                cy.getByTestID('selector-list devbucket').click()
+
+                cy.getByTestID('selector-list m').should(
+                  'have.length.of.at.least',
+                  1
+                )
+                cy.getByTestID('selector-list m').clickAttached()
+
+                cy.getByTestID('selector-list v').should(
+                  'have.length.of.at.least',
+                  1
+                )
+                cy.getByTestID('selector-list v').clickAttached()
+
+                if (plotTypeSuffix) {
+                  cy.getByTestID('view-type--dropdown').click()
+                  cy.getByTestID(`view-type--${plotTypeSuffix}`).click()
+                }
+
+                cy.getByTestID(`selector-list tv1`).should(
+                  'have.length.of.at.least',
+                  1
+                )
+                cy.getByTestID(`selector-list tv1`).clickAttached()
+
+                cy.getByTestID('time-machine-submit-button').click()
+
+                cy.getByTestID('overlay').within(() => {
+                  cy.getByTestID('page-title').click()
+                  cy.getByTestID('renamable-page-title--input')
+                    .clear()
+                    .type('blah')
+                  cy.getByTestID('save-cell--button').click()
+                })
+
+                cy.getByTestID('toggle-annotations-controls').click()
+              })
+          })
+        )
       )
     )
   )
-}
 
 export const reloadAndHandleAnnotationDefaultStatus = () => {
   cy.reload()

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -575,16 +575,27 @@ export const createToken = (
 
 // TODO: have to go through setup because we cannot create a user w/ a password via the user API
 export const setupUser = (): Cypress.Chainable<Cypress.Response<any>> => {
-  return cy.request({
-    method: 'GET',
-    url: '/debug/provision',
-  })
+  const defaultUser = Cypress.env('defaultUser')
+  const userParam = defaultUser ? `?user=${defaultUser}` : ''
+  return cy
+    .request({
+      method: 'GET',
+      url: `/debug/provision${userParam}`,
+    })
+    .then(response => {
+      Cypress.env('defaultUser', response.body.user.name)
+      return response
+    })
 }
 
 export const flush = () => {
-  cy.request('/debug/flush').then(response => {
-    expect(response.status).to.eq(200)
-  })
+  const defaultUser = Cypress.env('defaultUser')
+  const userParam = defaultUser ? `?user=${defaultUser}` : ''
+  return cy
+    .request({method: 'POST', url: `/debug/flush${userParam}`})
+    .then(response => {
+      expect(response.status).to.eq(200)
+    })
 }
 
 export type ProvisionData = {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -573,7 +573,6 @@ export const createToken = (
   })
 }
 
-// TODO: have to go through setup because we cannot create a user w/ a password via the user API
 export const setupUser = (): Cypress.Chainable<Cypress.Response<any>> => {
   const defaultUser = Cypress.env('defaultUser')
   const userParam = defaultUser ? `?user=${defaultUser}` : ''
@@ -583,6 +582,7 @@ export const setupUser = (): Cypress.Chainable<Cypress.Response<any>> => {
       url: `/debug/provision${userParam}`,
     })
     .then(response => {
+      expect(response.status).to.eq(200)
       Cypress.env('defaultUser', response.body.user.name)
       return response
     })
@@ -593,10 +593,12 @@ export const flush = () => {
   if (defaultUser) {
     return cy
       .request({method: 'POST', url: `/debug/flush?user=${defaultUser}`})
-      .then(response => {
-        expect(response.status).to.eq(200)
-      })
+      .then(response => expect(response.status).to.eq(200))
   }
+  // this isn't really needed - just need to return a chainable cypress obj
+  return cy
+    .request({method: 'GET', url: '/debug/flush'})
+    .then(response => expect(response.status).to.eq(200))
 }
 
 export type ProvisionData = {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -590,12 +590,13 @@ export const setupUser = (): Cypress.Chainable<Cypress.Response<any>> => {
 
 export const flush = () => {
   const defaultUser = Cypress.env('defaultUser')
-  const userParam = defaultUser ? `?user=${defaultUser}` : ''
-  return cy
-    .request({method: 'POST', url: `/debug/flush${userParam}`})
-    .then(response => {
-      expect(response.status).to.eq(200)
-    })
+  if (defaultUser) {
+    return cy
+      .request({method: 'POST', url: `/debug/flush?user=${defaultUser}`})
+      .then(response => {
+        expect(response.status).to.eq(200)
+      })
+  }
 }
 
 export type ProvisionData = {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,6 +62,16 @@ const App: FC = () => {
         })
       }
     }
+    if (CLOUD && isFlagEnabled('coveo')) {
+      const script = document.createElement('script')
+      script.src =
+        'https://platform.cloud.coveo.com/rest/organizations/influxdatanonproduction1eh1cn7go/pages/95a20052-218d-4048-9081-16dbcebbdebb/inappwidget/loader'
+      script.async = true
+      document.body.appendChild(script)
+      return () => {
+        document.body.removeChild(script)
+      }
+    }
     setAutoFreeze(false)
   }, [])
 

--- a/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -106,11 +106,14 @@ class DashboardCard extends PureComponent<Props> {
     const {id, onUpdateDashboard} = this.props
 
     onUpdateDashboard(id, {name})
-    try {
-      updatePinnedItemByParam(id, {name})
-      this.props.sendNotification(pinnedItemSuccess('dashboard', 'updated'))
-    } catch (err) {
-      this.props.sendNotification(pinnedItemFailure(err.message, 'dashboard'))
+
+    if (isFlagEnabled('pinnedItems') && CLOUD) {
+      try {
+        updatePinnedItemByParam(id, {name})
+        this.props.sendNotification(pinnedItemSuccess('dashboard', 'updated'))
+      } catch (err) {
+        this.props.sendNotification(pinnedItemFailure(err.message, 'dashboard'))
+      }
     }
   }
 

--- a/src/flows/components/FlowCard.tsx
+++ b/src/flows/components/FlowCard.tsx
@@ -10,7 +10,8 @@ import {FlowListContext} from 'src/flows/context/flow.list'
 
 // Utils
 import {updatePinnedItemByParam} from 'src/shared/contexts/pinneditems'
-
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import {CLOUD} from 'src/shared/constants'
 import {
   pinnedItemFailure,
   pinnedItemSuccess,
@@ -40,11 +41,13 @@ const FlowCard: FC<Props> = ({id, isPinned}) => {
 
   const handleRenameNotebook = (name: string) => {
     update(id, {...flow, name})
-    try {
-      updatePinnedItemByParam(id, {name})
-      dispatch(notify(pinnedItemSuccess('notebook', 'updated')))
-    } catch (err) {
-      dispatch(notify(pinnedItemFailure(err.message, 'update')))
+    if (isFlagEnabled('pinnedItems') && CLOUD) {
+      try {
+        updatePinnedItemByParam(id, {name})
+        dispatch(notify(pinnedItemSuccess('notebook', 'updated')))
+      } catch (err) {
+        dispatch(notify(pinnedItemFailure(err.message, 'update')))
+      }
     }
   }
 

--- a/src/flows/pipes/Notification/view.tsx
+++ b/src/flows/pipes/Notification/view.tsx
@@ -552,7 +552,7 @@ ${DEFAULT_ENDPOINTS[data.endpoint]?.generateTestQuery(data.endpointData)}`
             />
             <ExportTaskButton
               generate={generateTask}
-              text="Export as Alert Task"
+              text="Export Alert Task"
             />
           </FlexBox>
         </Panel.Footer>

--- a/src/flows/pipes/Schedule/ExportTaskButton.tsx
+++ b/src/flows/pipes/Schedule/ExportTaskButton.tsx
@@ -27,7 +27,7 @@ const ExportTaskButton: FC<Props> = ({text, generate}) => {
 
   const onClick = () => {
     event('Export Task Clicked', {from: 'schedule'})
-    launch(<ExportTaskOverlay />, {
+    launch(<ExportTaskOverlay text={text} />, {
       bucket: data.bucket,
       query: generate ? generate() : data.query,
       range,

--- a/src/flows/pipes/Schedule/ExportTaskOverlay/index.tsx
+++ b/src/flows/pipes/Schedule/ExportTaskOverlay/index.tsx
@@ -26,7 +26,10 @@ import {
 // Utils
 import {event} from 'src/cloud/utils/reporting'
 
-const ExportTaskOverlay: FC = () => {
+interface Props {
+  text?: string
+}
+const ExportTaskOverlay: FC<Props> = ({text}) => {
   const {activeTab, handleSetActiveTab} = useContext(Context)
   const {closeFn} = useContext(PopupContext)
 
@@ -40,7 +43,7 @@ const ExportTaskOverlay: FC = () => {
     <Overlay visible={true}>
       <Overlay.Container maxWidth={700}>
         <Overlay.Header
-          title="Export As Task"
+          title={text ?? 'Export As Task'}
           onDismiss={closer}
           testID="export-as-overlay--header"
         />
@@ -85,8 +88,8 @@ const ExportTaskOverlay: FC = () => {
   )
 }
 
-export default () => (
+export default ({text}: Props) => (
   <Provider>
-    <ExportTaskOverlay />
+    <ExportTaskOverlay text={text} />
   </Provider>
 )

--- a/src/tasks/components/TaskCard.tsx
+++ b/src/tasks/components/TaskCard.tsx
@@ -247,11 +247,13 @@ export class TaskCard extends PureComponent<
       task: {id},
     } = this.props
     onUpdate(name, id)
-    try {
-      updatePinnedItemByParam(id, {name})
-      this.props.sendNotification(pinnedItemSuccess('task', 'updated'))
-    } catch (err) {
-      this.props.sendNotification(pinnedItemFailure(err.message, 'task'))
+    if (isFlagEnabled('pinnedItems') && CLOUD) {
+      try {
+        updatePinnedItemByParam(id, {name})
+        this.props.sendNotification(pinnedItemSuccess('task', 'updated'))
+      } catch (err) {
+        this.props.sendNotification(pinnedItemFailure(err.message, 'task'))
+      }
     }
   }
 


### PR DESCRIPTION
The `ui-test-provisioner` has been updated to provide the ability to provision and flush individual users by passing them into the query params like `?user=23mcfly@influxdata.com`. This PR uses this ability so we can reuse users across all the tests in a single test suite. This will keep us from running into the "ran out of 1250 provisioned users" issue