### PR TITLE
chore: update export as alert task header and button text

### DIFF
--- a/src/flows/pipes/Notification/view.tsx
+++ b/src/flows/pipes/Notification/view.tsx
@@ -552,7 +552,7 @@ ${DEFAULT_ENDPOINTS[data.endpoint]?.generateTestQuery(data.endpointData)}`
             />
             <ExportTaskButton
               generate={generateTask}
-              text="Export as Alert Task"
+              text="Export Alert Task"
             />
           </FlexBox>
         </Panel.Footer>

--- a/src/flows/pipes/Schedule/ExportTaskButton.tsx
+++ b/src/flows/pipes/Schedule/ExportTaskButton.tsx
@@ -27,7 +27,7 @@ const ExportTaskButton: FC<Props> = ({text, generate}) => {
 
   const onClick = () => {
     event('Export Task Clicked', {from: 'schedule'})
-    launch(<ExportTaskOverlay />, {
+    launch(<ExportTaskOverlay text={text} />, {
       bucket: data.bucket,
       query: generate ? generate() : data.query,
       range,

--- a/src/flows/pipes/Schedule/ExportTaskOverlay/index.tsx
+++ b/src/flows/pipes/Schedule/ExportTaskOverlay/index.tsx
@@ -26,7 +26,10 @@ import {
 // Utils
 import {event} from 'src/cloud/utils/reporting'
 
-const ExportTaskOverlay: FC = () => {
+interface Props {
+  text?: string
+}
+const ExportTaskOverlay: FC<Props> = ({text}) => {
   const {activeTab, handleSetActiveTab} = useContext(Context)
   const {closeFn} = useContext(PopupContext)
 
@@ -40,7 +43,7 @@ const ExportTaskOverlay: FC = () => {
     <Overlay visible={true}>
       <Overlay.Container maxWidth={700}>
         <Overlay.Header
-          title="Export As Task"
+          title={text ?? 'Export As Task'}
           onDismiss={closer}
           testID="export-as-overlay--header"
         />
@@ -85,8 +88,8 @@ const ExportTaskOverlay: FC = () => {
   )
 }
 
-export default () => (
+export default ({text}: Props) => (
   <Provider>
-    <ExportTaskOverlay />
+    <ExportTaskOverlay text={text} />
   </Provider>
 )


### PR DESCRIPTION
Closes #2522

This PR updates the overlay title to match the button whenever a user clicks the export alert task button. 

![export-alert-task](https://user-images.githubusercontent.com/19984220/132017217-746a03af-09d3-4a8b-a798-731775c309a2.gif)

