### PR TITLE
fix: add check to not allow only whitespace as bucket name

### DIFF
--- a/src/buckets/components/createBucketForm/BucketOverlayForm.tsx
+++ b/src/buckets/components/createBucketForm/BucketOverlayForm.tsx
@@ -7,7 +7,10 @@ import Retention from 'src/buckets/components/Retention'
 import {SchemaToggle} from 'src/buckets/components/createBucketForm/SchemaToggle'
 
 // Constants
-import {isSystemBucket} from 'src/buckets/constants'
+import {
+  isSystemBucket,
+  BUCKET_NAME_MINIMUM_CHARACTERS,
+} from 'src/buckets/constants'
 
 // Types
 import {
@@ -181,8 +184,11 @@ export default class BucketOverlayForm extends PureComponent<Props> {
       return 'This bucket needs a name'
     }
 
-    if (name.trim().length === 0) {
-      return 'Bucket name cannot be only whitespaces'
+    if (
+      name.trim().length === 0 ||
+      name.length < BUCKET_NAME_MINIMUM_CHARACTERS
+    ) {
+      return `Please enter a name with at least ${BUCKET_NAME_MINIMUM_CHARACTERS} letters or numbers`
     }
 
     return null

--- a/src/buckets/components/createBucketForm/BucketOverlayForm.tsx
+++ b/src/buckets/components/createBucketForm/BucketOverlayForm.tsx
@@ -177,12 +177,12 @@ export default class BucketOverlayForm extends PureComponent<Props> {
       return 'Only system bucket names can begin with _'
     }
 
-    if (name.trim().length === 0) {
-      return 'Bucket name cannot be only whitespaces'
-    }
-
     if (!name) {
       return 'This bucket needs a name'
+    }
+
+    if (name.trim().length === 0) {
+      return 'Bucket name cannot be only whitespaces'
     }
 
     return null

--- a/src/buckets/components/createBucketForm/BucketOverlayForm.tsx
+++ b/src/buckets/components/createBucketForm/BucketOverlayForm.tsx
@@ -177,6 +177,10 @@ export default class BucketOverlayForm extends PureComponent<Props> {
       return 'Only system bucket names can begin with _'
     }
 
+    if (name.trim().length === 0) {
+      return 'Bucket name cannot be only whitespaces'
+    }
+
     if (!name) {
       return 'This bucket needs a name'
     }

--- a/src/buckets/constants/index.ts
+++ b/src/buckets/constants/index.ts
@@ -5,3 +5,5 @@ export const isSystemBucket = (bucketName: string): boolean => {
 }
 
 export const BUCKET_OVERLAY_WIDTH = 450
+
+export const BUCKET_NAME_MINIMUM_CHARACTERS = 1


### PR DESCRIPTION
Closes #2326

Adds a check to invalidate bucket names that are only white spaces.

https://user-images.githubusercontent.com/18511823/132388304-6efb040c-ff26-463f-824b-5568217f29ad.mov


<!-- Describe your proposed changes here. -->
