### PR TITLE
build: replace OSS UI checksum instead of appending

### DIFF
--- a/scripts/publish-oss-release.bash
+++ b/scripts/publish-oss-release.bash
@@ -14,7 +14,7 @@
 yarn install && yarn build
 mkdir -p release
 tar -czvf release/build.tar.gz ./build
-cd release && shasum -a 256 build.tar.gz >> sha256.txt && cd ../
+cd release && shasum -a 256 build.tar.gz > sha256.txt && cd ../
 ghr \
   -t ${GITHUB_TOKEN} \
   -u influxdata \


### PR DESCRIPTION
Using the `>>` operator for adding the checksum of the built UI assets for OSS would result in a new checksum being appended to the file if the checksum file already exists. This would cause the checksum file to be invalid upon upload. This changes to the `>` operator, which will overwrite the contents of the file if it already exists.