### PR TITLE
fix: pass time zone information to giraffe table graph

### DIFF
--- a/src/visualization/types/Table/view.tsx
+++ b/src/visualization/types/Table/view.tsx
@@ -84,6 +84,7 @@ const TableGraphs: FC<Props> = ({properties, result}) => {
   })
   const filteredTables = tables.filter(t => t.name.includes(search))
 
+  const {timeZone} = useContext(AppSettingContext)
   if (isFlagEnabled('useGiraffeGraphs')) {
     const parsed = parseFromFluxResults(result)
     const fluxResponse = parsed.tableData.join('\n')
@@ -93,7 +94,7 @@ const TableGraphs: FC<Props> = ({properties, result}) => {
         {
           type: 'table',
           properties,
-          timeZone: 'Local',
+          timeZone: timeZone,
           tableTheme: theme,
         },
       ],


### PR DESCRIPTION
Closes #2569

Passes timezone information to the giraffe table graph.

Screen shot: 
<img width="1389" alt="Screen Shot 2021-09-09 at 9 33 35 AM" src="https://user-images.githubusercontent.com/18511823/132726181-7a4d0e8b-75bf-4541-9a5f-931656e0aae0.png">
