### PR TITLE
chore: clean up thunks to use single api file

### DIFF
--- a/src/authorizations/actions/thunks.ts
+++ b/src/authorizations/actions/thunks.ts
@@ -3,7 +3,6 @@ import {normalize} from 'normalizr'
 import {Dispatch} from 'react'
 
 // API
-import * as authAPI from 'src/authorizations/apis'
 import * as api from 'src/client'
 
 // Schemas
@@ -102,7 +101,7 @@ export const createAuthorization = (auth: Authorization) => async (
   dispatch: Dispatch<Action | NotificationAction>
 ) => {
   try {
-    const resp = await authAPI.createAuthorization(auth)
+    const resp = await api.createAuthorization(auth)
 
     const newAuth = normalize<Authorization, AuthEntities, string>(
       resp,

--- a/src/authorizations/apis/index.ts
+++ b/src/authorizations/apis/index.ts
@@ -1,27 +1,9 @@
-import {Authorization} from 'src/types'
-import {postAuthorization} from 'src/client'
+// import {Authorization} from 'src/types'
+// import {postAuthorization} from 'src/client'
 import {getAuthConnection} from 'src/client/unityRoutes'
 import {getOauthClientConfig} from 'src/client/cloudPrivRoutes'
 import {OAuthClientConfig} from 'src/client/cloudPrivRoutes'
 
-export const createAuthorization = async (
-  authorization
-): Promise<Authorization> => {
-  try {
-    const resp = await postAuthorization({
-      data: authorization,
-    })
-
-    if (resp.status !== 201) {
-      throw new Error(resp.data.message)
-    }
-
-    return resp.data
-  } catch (error) {
-    console.error(error)
-    throw error
-  }
-}
 
 export const getAuth0Config = async (
   redirectTo?: string

--- a/src/authorizations/apis/index.ts
+++ b/src/authorizations/apis/index.ts
@@ -4,7 +4,6 @@ import {getAuthConnection} from 'src/client/unityRoutes'
 import {getOauthClientConfig} from 'src/client/cloudPrivRoutes'
 import {OAuthClientConfig} from 'src/client/cloudPrivRoutes'
 
-
 export const getAuth0Config = async (
   redirectTo?: string
 ): Promise<OAuthClientConfig> => {

--- a/src/authorizations/components/redesigned/TokensTab.test.tsx
+++ b/src/authorizations/components/redesigned/TokensTab.test.tsx
@@ -60,7 +60,7 @@ jest.mock('../../../../src/client', () => ({
     }
   }),
 }))
-jest.mock('src/authorizations/apis', () => ({
+jest.mock('src/client', () => ({
   createAuthorization: jest.fn(() => {
     return {
       ...auth2,

--- a/src/authorizations/components/redesigned/TokensTab.test.tsx
+++ b/src/authorizations/components/redesigned/TokensTab.test.tsx
@@ -7,7 +7,7 @@ import {AuthorizationUpdateRequest as AuthApi} from '@influxdata/influx'
 
 import {mocked} from 'ts-jest/utils'
 
-import {createAuthorization} from 'src/authorizations/apis'
+import {createAuthorization} from 'src/client'
 import TokensTab from './TokensTab'
 
 import {deleteAuthorization} from '../../../../src/client'

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -7,7 +7,6 @@ import {getAPIBasepath} from 'src/utils/basepath'
 import {Authorization} from 'src/types'
 import {postAuthorization} from 'src/client'
 
-
 export const createAuthorization = async (
   authorization
 ): Promise<Authorization> => {
@@ -19,7 +18,7 @@ export const createAuthorization = async (
     if (resp.status !== 201) {
       throw new Error(resp.data.message)
     }
-    
+
     return resp.data
   } catch (error) {
     console.error(error)
@@ -45,7 +44,5 @@ setResponseHandler((status, headers, data) => {
 
   return {status, headers, data}
 })
-
-
 
 export * from './generatedRoutes'

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -4,6 +4,28 @@ import {
   postSignout,
 } from './generatedRoutes'
 import {getAPIBasepath} from 'src/utils/basepath'
+import {Authorization} from 'src/types'
+import {postAuthorization} from 'src/client'
+
+
+export const createAuthorization = async (
+  authorization
+): Promise<Authorization> => {
+  try {
+    const resp = await postAuthorization({
+      data: authorization,
+    })
+
+    if (resp.status !== 201) {
+      throw new Error(resp.data.message)
+    }
+    
+    return resp.data
+  } catch (error) {
+    console.error(error)
+    throw error
+  }
+}
 
 setRequestHandler((url: string, query: string, init: RequestInit) => {
   return {
@@ -23,5 +45,7 @@ setResponseHandler((status, headers, data) => {
 
   return {status, headers, data}
 })
+
+
 
 export * from './generatedRoutes'

--- a/src/dataLoaders/actions/dataLoaders.ts
+++ b/src/dataLoaders/actions/dataLoaders.ts
@@ -5,7 +5,7 @@ import {normalize} from 'normalizr'
 // APIs
 import {client} from 'src/utils/api'
 import {ScraperTargetRequest, PermissionResource} from '@influxdata/influx'
-import {createAuthorization} from 'src/authorizations/apis'
+import {createAuthorization} from 'src/client'
 
 // Schemas
 import {authSchema} from 'src/schemas'


### PR DESCRIPTION
see #2518 

`createAuthorization` function is moved inside the file path the rest of the authorization functions are located. Authorizations thunks file now imports one api file and is able to access all functions needed to get, post, update, and delete tokens. 
