### PR TITLE
chore: install giraffe 2.18.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "@influxdata/clockface": "^2.11.8",
     "@influxdata/flux": "^0.5.1",
     "@influxdata/flux-lsp-browser": "^0.5.53",
-    "@influxdata/giraffe": "^2.18.3",
+    "@influxdata/giraffe": "^2.18.4",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -863,10 +863,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/flux/-/flux-0.5.1.tgz#e39e7a7af9163fc9494422c8fed77f3ae1b68f56"
   integrity sha512-GHlkXBhSdJ2m56JzDkbnKPAqLj3/lexPooacu14AWTO4f2sDGLmzM7r0AxgdtU1M2x7EXNBwgGOI5EOAdN6mkw==
 
-"@influxdata/giraffe@^2.18.3":
-  version "2.18.3"
-  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.18.3.tgz#3c272806c2dec061acfc49879de009214aab744a"
-  integrity sha512-ru1ITSK317HVAhX2OnzDAePOfB2Uz+16T0YxX5y+mX4BjPfk5xiaGJFAUW+TabnRNIE+K9XQchwv+9yFPSa9XQ==
+"@influxdata/giraffe@^2.18.4":
+  version "2.18.4"
+  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.18.4.tgz#ee1c5baea72fa44e17d427400617ffbf9936659c"
+  integrity sha512-61CIdJnGsP//NedZW1GO4OAgLwcT5MC893UseT7Ne/souM7O5Cfpowogufx/z7BfjdN6axYMuRmqJU5RhYd9qA==
   dependencies:
     merge-images "^2.0.0"
 


### PR DESCRIPTION
Brings in a couple of bug fixes and UX improvements across different parts of the visualizations, released in giraffe [2.18.4](https://github.com/influxdata/giraffe/releases/tag/v2.18.4).

<!-- Describe your proposed changes here. -->
