### PR TITLE
fix: valign the table header cell

### DIFF
--- a/src/visualization/types/SimpleTable/InnerTable.tsx
+++ b/src/visualization/types/SimpleTable/InnerTable.tsx
@@ -1,5 +1,5 @@
 import React, {FC} from 'react'
-import {Table, ComponentSize} from '@influxdata/clockface'
+import {ComponentSize, Table, VerticalAlignment} from '@influxdata/clockface'
 import {SubsetTable} from 'src/visualization/types/SimpleTable'
 
 interface InnerProps {
@@ -10,7 +10,10 @@ const InnerTable: FC<InnerProps> = ({table}) => {
   const headers = Object.values(table.cols).map(c => {
     if (c.name === 'table') {
       return (
-        <Table.HeaderCell key="htable">
+        <Table.HeaderCell
+          key="htable"
+          verticalAlignment={VerticalAlignment.Top}
+        >
           table
           <label>{table.yield}</label>
         </Table.HeaderCell>


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/2035

A simple alignment change to fix the vertical alignment of the table header cell. 

<img width="762" alt="Screen Shot 2021-09-10 at 12 22 50 PM" src="https://user-images.githubusercontent.com/18511823/132906550-3deba91e-9650-449d-b1c0-3d16ca6fa317.png">

<!-- Describe your proposed changes here. -->