### PR TITLE
chore: turn off scrollBeyondLastLine to fix scroll trap

### DIFF
--- a/src/shared/components/FluxMonacoEditor.tsx
+++ b/src/shared/components/FluxMonacoEditor.tsx
@@ -138,6 +138,7 @@ const FluxEditorMonaco: FC<Props> = ({
             automaticLayout: true,
             readOnly: readOnly || false,
             wordWrap: wrapLines ?? 'off',
+            scrollBeyondLastLine: false,
           }}
           editorDidMount={editorDidMount}
         />


### PR DESCRIPTION
Closes #2501 

As suggested in the issue below, turning off `scrollBeyondLastLine` fixes the issue where monaco takes up more height than its container, solving our scroll trap issue.

This also applies the same behavior to the data explorer page too which I think is desired.

https://github.com/microsoft/monaco-editor/issues/29

Notebooks:


https://user-images.githubusercontent.com/6411855/132924730-0cdebc55-fc45-48cb-aca5-6d5f54cb9fef.mov


Data Explorer:

https://user-images.githubusercontent.com/6411855/132924641-2001d9b7-a948-4394-b7d9-7253dd00da79.mov

