### PR TITLE
fix(notebooks): allow for selectable, copyable errors

### DIFF
--- a/src/flows/shared/Resizer.scss
+++ b/src/flows/shared/Resizer.scss
@@ -97,7 +97,7 @@ $panel-resizer--drag-handle: 30px;
 .panel-resizer--error,
 .panel-resizer--empty {
   color: $g15-platinum;
-  user-select: none;
+  user-select: text;
   padding: $cf-marg-b 0;
   font-weight: $cf-font-weight--medium;
   height: 30px;


### PR DESCRIPTION
Closes #2262 

Simple CSS change to allow for error messages in notebooks to be selectable 

![image](https://user-images.githubusercontent.com/6411855/133120143-14fc95ad-061a-4965-bd3a-69cff74efaaf.png)
