### PR TITLE
fix: explicitly set width for pagination controls

### DIFF
--- a/src/tasks/pagination/TasksList.tsx
+++ b/src/tasks/pagination/TasksList.tsx
@@ -122,6 +122,7 @@ export default class TasksList extends PureComponent<Props, State>
         </ResourceList>
         <PaginationNav.PaginationNav
           ref={this.paginationRef}
+          style={{width: this.props.pageWidth}}
           totalPages={this.totalPages}
           currentPage={this.currentPage}
           pageRangeOffset={1}


### PR DESCRIPTION
Closes #2594

When the Pagination Nav doesn't have a width, it leads to wonky pagination calculations. The fix is to set its width.

https://user-images.githubusercontent.com/146112/133125180-bc58c817-a10a-460b-9327-92fe426582dd.mov
