### PR TITLE
fix: remove x scrollbar from TaskList by accounting for pinned items width

### DIFF
--- a/src/tasks/pagination/TasksList.tsx
+++ b/src/tasks/pagination/TasksList.tsx
@@ -2,6 +2,9 @@
 import React, {PureComponent, RefObject, createRef} from 'react'
 import memoizeOne from 'memoize-one'
 
+// Styles
+import 'src/tasks/pagination/tasksPagination.scss'
+
 // Components
 import {ResourceList} from '@influxdata/clockface'
 import TaskCard from 'src/tasks/components/TaskCard'

--- a/src/tasks/pagination/tasksPagination.scss
+++ b/src/tasks/pagination/tasksPagination.scss
@@ -1,0 +1,3 @@
+.cf-resource-card--context-menu {
+  right: 28px;
+}


### PR DESCRIPTION
Closes #2601

Increases the `right` offset of the context menu buttons to account for the pinned items button.

![Screen Shot 2021-09-13 at 3 55 34 PM](https://user-images.githubusercontent.com/146112/133167491-9630e639-0477-4e14-b775-70bbd610f5bb.png)
