### PR TITLE
feat(notebooks): expressions sidebar

### DIFF
--- a/cypress/e2e/shared/flows.test.ts
+++ b/cypress/e2e/shared/flows.test.ts
@@ -436,17 +436,17 @@ describe('Flows', () => {
       cy.getByTestID('flux-toolbar--list').should('be.visible')
 
       // check that all expressions are listed
-      cy.getByTestID('test-measurements-test').should('be.visible')
-      cy.getByTestID('test-fields-dopeness').should('be.visible')
-      cy.getByTestID('test-tags-container_name').should('be.visible')
-      cy.getByTestID('test-columns-_start').should('be.visible')
-      cy.getByTestID('test-system-_source_measurement')
+      cy.getByTestID('measurements-test').should('be.visible')
+      cy.getByTestID('fields-dopeness').should('be.visible')
+      cy.getByTestID('tags-container_name').should('be.visible')
+      cy.getByTestID('columns-_start').should('be.visible')
+      cy.getByTestID('system-_source_measurement')
         .scrollIntoView()
         .should('be.visible')
 
       // filter for dopeness
       cy.getByTestID('flux-toolbar-search--input').type('dopeness')
-      cy.getByTestID('flux--test-fields-dopeness--inject').click({force: true})
+      cy.getByTestID('flux--fields-dopeness--inject').click({force: true})
 
       // make sure message contains injected expression
       cy.getByTestID('notification-message--textarea').contains('r.dopeness')

--- a/cypress/e2e/shared/flows.test.ts
+++ b/cypress/e2e/shared/flows.test.ts
@@ -8,7 +8,10 @@ describe('Flows', () => {
           cy.fixture('routes').then(({orgs}) => {
             cy.visit(`${orgs}/${id}`)
             cy.getByTestID('version-info')
-            cy.setFeatureFlags({simpleTable: true}).then(() => {
+            cy.setFeatureFlags({
+              simpleTable: true,
+              notebooksExp: true,
+            }).then(() => {
               cy.getByTestID('nav-item-flows').should('be.visible')
               cy.getByTestID('nav-item-flows').click()
             })
@@ -372,5 +375,81 @@ describe('Flows', () => {
 
     // visualizations should exist
     cy.getByTestID('giraffe-inner-plot').should('be.visible')
+  })
+
+  describe('alert panel', () => {
+    it('should build expressions list and allow for injection', () => {
+      const newBucketName = 'shmucket'
+      const now = Date.now()
+      cy.get<Organization>('@org').then(({id, name}: Organization) => {
+        cy.createBucket(id, name, newBucketName)
+      })
+      cy.writeData(
+        [
+          `test,container_name=cool dopeness=12 ${now - 1000}000000`,
+          `test,container_name=beans dopeness=18 ${now - 1200}000000`,
+          `test,container_name=cool dopeness=14 ${now - 1400}000000`,
+          `test,container_name=beans dopeness=10 ${now - 1600}000000`,
+        ],
+        newBucketName
+      )
+
+      const flowName = 'Flowbooks'
+
+      cy.getByTestID('create-flow--button')
+        .first()
+        .click()
+      cy.getByTestID('time-machine-submit-button').should('be.visible')
+
+      cy.getByTestID('page-title').click()
+      cy.getByTestID('renamable-page-title--input').type(`${flowName}`)
+
+      // select our bucket
+      cy.getByTestID('flow-bucket-selector').click()
+
+      cy.getByTestID(`flow-bucket-selector--${newBucketName}`).click()
+
+      // select measurement and field
+      cy.getByTestID('measurement-selector test').click()
+      cy.getByTestID('field-selector dopeness').click()
+
+      // select beans tag and click preview
+      cy.getByTestID('tag-selector beans').click()
+      cy.getByTestID('time-machine-submit-button').click()
+
+      // we should only see beans in the table
+      cy.getByTestID('simple-table').should('be.visible')
+      cy.getByTestID('table-cell beans')
+        .first()
+        .should('be.visible')
+      cy.getByTestID('table-cell cool').should('not.exist')
+
+      // add an alert cell
+      cy.getByTestID('panel-add-btn-2').click()
+      cy.getByTestID('add-flow-btn--notification').click()
+      cy.getByTestID('time-machine-submit-button').click()
+
+      // open exp sidebar panel
+      cy.getByTestID('notification-exp-button').scrollIntoView()
+      cy.getByTestID('notification-exp-button').should('be.visible')
+      cy.getByTestID('notification-exp-button').click()
+      cy.getByTestID('flux-toolbar--list').should('be.visible')
+
+      // check that all expressions are listed
+      cy.getByTestID('test-measurements-test').should('be.visible')
+      cy.getByTestID('test-fields-dopeness').should('be.visible')
+      cy.getByTestID('test-tags-container_name').should('be.visible')
+      cy.getByTestID('test-columns-_start').should('be.visible')
+      cy.getByTestID('test-system-_source_measurement')
+        .scrollIntoView()
+        .should('be.visible')
+
+      // filter for dopeness
+      cy.getByTestID('flux-toolbar-search--input').type('dopeness')
+      cy.getByTestID('flux--test-fields-dopeness--inject').click({force: true})
+
+      // make sure message contains injected expression
+      cy.getByTestID('notification-message--textarea').contains('r.dopeness')
+    })
   })
 })

--- a/cypress/e2e/shared/flows.test.ts
+++ b/cypress/e2e/shared/flows.test.ts
@@ -404,33 +404,20 @@ describe('Flows', () => {
       cy.getByTestID('page-title').click()
       cy.getByTestID('renamable-page-title--input').type(`${flowName}`)
 
-      // select our bucket
+      // select our bucket, measurement, field and tag
       cy.getByTestID('flow-bucket-selector').click()
-
       cy.getByTestID(`flow-bucket-selector--${newBucketName}`).click()
-
-      // select measurement and field
       cy.getByTestID('measurement-selector test').click()
       cy.getByTestID('field-selector dopeness').click()
-
-      // select beans tag and click preview
       cy.getByTestID('tag-selector beans').click()
-      cy.getByTestID('time-machine-submit-button').click()
-
-      // we should only see beans in the table
-      cy.getByTestID('simple-table').should('be.visible')
-      cy.getByTestID('table-cell beans')
-        .first()
-        .should('be.visible')
-      cy.getByTestID('table-cell cool').should('not.exist')
 
       // add an alert cell
       cy.getByTestID('panel-add-btn-2').click()
       cy.getByTestID('add-flow-btn--notification').click()
       cy.getByTestID('time-machine-submit-button').click()
+      cy.getByTestID('notification-exp-button').scrollIntoView()
 
       // open exp sidebar panel
-      cy.getByTestID('notification-exp-button').scrollIntoView()
       cy.getByTestID('notification-exp-button').should('be.visible')
       cy.getByTestID('notification-exp-button').click()
       cy.getByTestID('flux-toolbar--list').should('be.visible')
@@ -449,7 +436,9 @@ describe('Flows', () => {
       cy.getByTestID('flux--fields-dopeness--inject').click({force: true})
 
       // make sure message contains injected expression
-      cy.getByTestID('notification-message--textarea').contains('r.dopeness')
+      cy.getByTestID('notification-message--monaco-editor').contains(
+        'r.dopeness'
+      )
     })
   })
 })

--- a/src/flows/pipes/Notification/Expression.tsx
+++ b/src/flows/pipes/Notification/Expression.tsx
@@ -19,29 +19,25 @@ const ToolbarExpression: FC<Props> = ({
   onClickFunction,
   testID,
 }) => {
-  const expressionRef = createRef<HTMLDListElement>()
   const handleClickFunction = () => {
     onClickFunction(expression)
   }
 
   return (
-    <>
-      <dd
-        ref={expressionRef}
-        data-testid={testID}
-        className="flux-toolbar--list-item flux-toolbar--function"
-      >
-        <code>{expression}</code>
-        <Button
-          testID={`flux--${testID}--inject`}
-          text="Inject"
-          onClick={handleClickFunction}
-          size={ComponentSize.ExtraSmall}
-          className="flux-toolbar--injector"
-          color={ComponentColor.Primary}
-        />
-      </dd>
-    </>
+    <dd
+      data-testid={testID}
+      className="flux-toolbar--list-item flux-toolbar--function"
+    >
+      <code>{expression}</code>
+      <Button
+        testID={`flux--${testID}--inject`}
+        text="Inject"
+        onClick={handleClickFunction}
+        size={ComponentSize.ExtraSmall}
+        className="flux-toolbar--injector"
+        color={ComponentColor.Primary}
+      />
+    </dd>
   )
 }
 

--- a/src/flows/pipes/Notification/Expression.tsx
+++ b/src/flows/pipes/Notification/Expression.tsx
@@ -1,0 +1,50 @@
+// Libraries
+import React, {FC, createRef} from 'react'
+
+// Component
+import {Button, ComponentSize, ComponentColor} from '@influxdata/clockface'
+
+interface Props {
+  expression: string
+  onClickFunction: (expression: string) => void
+  testID: string
+}
+
+const defaultProps = {
+  testID: 'alert-expression',
+}
+
+const ToolbarExpression: FC<Props> = ({
+  expression,
+  onClickFunction,
+  testID,
+}) => {
+  const expressionRef = createRef<HTMLDListElement>()
+  const handleClickFunction = () => {
+    onClickFunction(expression)
+  }
+
+  return (
+    <>
+      <dd
+        ref={expressionRef}
+        data-testid={testID}
+        className="flux-toolbar--list-item flux-toolbar--function"
+      >
+        <code>{expression}</code>
+        <Button
+          testID={`flux--${testID}--inject`}
+          text="Inject"
+          onClick={handleClickFunction}
+          size={ComponentSize.ExtraSmall}
+          className="flux-toolbar--injector"
+          color={ComponentColor.Primary}
+        />
+      </dd>
+    </>
+  )
+}
+
+ToolbarExpression.defaultProps = defaultProps
+
+export default ToolbarExpression

--- a/src/flows/pipes/Notification/Expression.tsx
+++ b/src/flows/pipes/Notification/Expression.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FC, createRef} from 'react'
+import React, {FC} from 'react'
 
 // Component
 import {Button, ComponentSize, ComponentColor} from '@influxdata/clockface'

--- a/src/flows/pipes/Notification/Expressions.tsx
+++ b/src/flows/pipes/Notification/Expressions.tsx
@@ -95,16 +95,6 @@ const categoriesCompare = (a: string, b: string) => {
   return order.indexOf(a) - order.indexOf(b)
 }
 
-const isExpressionsEmpty = (schemaExpressions: SchemaExpressions) => {
-  let isEmptySchemas = 0
-  Object.keys(schemaExpressions).forEach(k => {
-    if (!schemaExpressions[k].length) {
-      isEmptySchemas += 1
-    }
-  })
-  return Object.keys(schemaExpressions).length === isEmptySchemas
-}
-
 const Expressions: FC<Props> = ({parsed, onSelect}) => {
   const [search, setSearch] = useState('')
   const updateSearch = useCallback(
@@ -121,7 +111,7 @@ const Expressions: FC<Props> = ({parsed, onSelect}) => {
 
   let expComponent
 
-  if (isExpressionsEmpty(schemaExpressions)) {
+  if (!Object.keys(schemaExpressions).length) {
     expComponent = (
       <EmptyState size={ComponentSize.ExtraSmall}>
         <EmptyState.Text>No expressions match your search</EmptyState.Text>

--- a/src/flows/pipes/Notification/Expressions.tsx
+++ b/src/flows/pipes/Notification/Expressions.tsx
@@ -1,0 +1,220 @@
+import React, {FC, useState, useMemo, useCallback, useContext} from 'react'
+
+import {
+  Input,
+  InputType,
+  IconFont,
+  DapperScrollbars,
+  EmptyState,
+  ComponentSize,
+} from '@influxdata/clockface'
+import {FromFluxResult} from '@influxdata/giraffe'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import Expression from 'src/flows/pipes/Notification/Expression'
+import {FlowContext} from 'src/flows/context/flow.current'
+
+interface Props {
+  parsed: FromFluxResult
+  id: string
+}
+
+interface Schemas {
+  [key: string]: SchemaExpressions
+}
+
+interface SchemaExpressions {
+  [key: string]: Array<string>
+}
+
+const Expressions: FC<Props> = ({id, parsed}) => {
+  const [search, setSearch] = useState('')
+  const {flow, updateData} = useContext(FlowContext)
+  const updateSearch = useCallback(
+    e => {
+      setSearch(e.target.value)
+    },
+    [search, setSearch]
+  )
+
+  const parsedResultToSchema = (parsed: FromFluxResult): Schemas => {
+    let ni
+    const filtered = [
+      /^_start$/,
+      /^_stop$/,
+      /^_time$/,
+      /^_value/,
+      /^_measurement$/,
+      /^_field$/,
+      /^table$/,
+      /^result$/,
+    ]
+    if (!parsed) {
+      return
+    }
+
+    const out = parsed.table as any
+    const len = out.length
+    const measurements = out.columns._measurement?.data
+    const fields = out.columns._field?.data
+    const columns = out.columnKeys.filter(key => {
+      return filtered.reduce((acc, curr) => {
+        return acc && !curr.test(key)
+      }, true)
+    })
+    const schema = {} as any
+
+    for (ni = 0; ni < len; ni++) {
+      if (!schema.hasOwnProperty(measurements[ni])) {
+        schema[measurements[ni]] = {}
+      }
+
+      // TODO: is there always only one field?
+      const filteredFields = [fields[ni]].filter(f =>
+        f.toLowerCase().includes(search.toLowerCase())
+      )
+      if (filteredFields.length) {
+        schema[measurements[ni]].fields = filteredFields
+      }
+
+      const filteredMeasurements = [
+        ...new Set<string>(measurements),
+      ].filter(m => m.toLowerCase().includes(search.toLowerCase()))
+      if (filteredMeasurements.length) {
+        schema[measurements[ni]].measurements = filteredMeasurements
+      }
+
+      const filteredSystems = [
+        '_check_id',
+        '_check_name',
+        '_level',
+        '_source_measurement',
+        '_type',
+      ].filter(s => s.toLowerCase().includes(search.toLowerCase()))
+      if (filteredSystems.length) {
+        schema[measurements[ni]].system = filteredSystems
+      }
+
+      const filteredTags = columns.filter(
+        c =>
+          !!out.columns[c].data[ni] &&
+          c.toLowerCase().includes(search.toLowerCase())
+      )
+      if (filteredTags.length) {
+        schema[measurements[ni]].tags = filteredTags
+      }
+
+      const otherColumns = ['_start', '_stop', '_measurement']
+      const filteredOtherColumns = out.columnKeys.filter(
+        c =>
+          otherColumns.includes(c) &&
+          c.toLowerCase().includes(search.toLowerCase())
+      )
+      if (filteredOtherColumns.length) {
+        schema[measurements[ni]].columns = filteredOtherColumns
+      }
+    }
+
+    return schema
+  }
+
+  const capitalizeFirstLetter = (s: string) => {
+    return s.charAt(0).toUpperCase() + s.slice(1)
+  }
+
+  const categoriesCompare = (a: string, b: string) => {
+    const order = ['measurements', 'fields', 'tags', 'columns', 'system']
+    return order.indexOf(a) - order.indexOf(b)
+  }
+
+  const isExpressionsEmpty = (schemaExpressions: Schemas) => {
+    if (!Object.keys(schemaExpressions).length) {
+      return true
+    }
+    let isEmptySchemas = 0
+    Object.values(schemaExpressions).forEach(s => {
+      if (!Object.keys(s).length) {
+        isEmptySchemas += 1
+      }
+    })
+    return Object.keys(schemaExpressions).length === isEmptySchemas
+  }
+
+  const inject = (exp: string): void => {
+    const data = flow.data.byID[id]
+    updateData(id, {
+      ...data,
+      message: [
+        data.message.slice(0, data.cursorPosition),
+        ` r.${exp}`,
+        data.message.slice(data.cursorPosition),
+      ].join(''),
+    })
+  }
+
+  const schemaExpressions = useMemo(() => parsedResultToSchema(parsed), [
+    parsed,
+    search,
+  ])
+
+  let expComponent
+
+  if (isExpressionsEmpty(schemaExpressions)) {
+    expComponent = (
+      <EmptyState size={ComponentSize.ExtraSmall}>
+        <EmptyState.Text>No expressions match your search</EmptyState.Text>
+      </EmptyState>
+    )
+  } else {
+    expComponent = Object.entries(schemaExpressions).map(([table, schema]) => (
+      <div key={`table-${table}`}>
+        {Object.keys(schema)
+          .sort((a, b) => categoriesCompare(a, b))
+          .map(category => (
+            <dl className="flux-toolbar--category" key={`${table}-${category}`}>
+              <dt className="flux-toolbar--heading">
+                {capitalizeFirstLetter(category)}
+              </dt>
+              {schema[category].map(exp => (
+                <Expression
+                  onClickFunction={inject}
+                  key={`${table}-${category}-${exp}`}
+                  testID={`${table}-${category}-${exp}`}
+                  expression={exp}
+                />
+              ))}
+            </dl>
+          ))}
+      </div>
+    ))
+  }
+
+  const body = isFlagEnabled('flowSidebar') ? (
+    <div className="flux-toolbar--list" data-testid="flux-toolbar--list">
+      {expComponent}
+    </div>
+  ) : (
+    <DapperScrollbars className="flux-toolbar--scroll-area">
+      <div className="flux-toolbar--list" data-testid="flux-toolbar--list">
+        {expComponent}
+      </div>
+    </DapperScrollbars>
+  )
+
+  return (
+    <div className="flux-toolbar">
+      <div className="flux-toolbar--search">
+        <Input
+          type={InputType.Text}
+          icon={IconFont.Search}
+          placeholder="Filter Expressions..."
+          onChange={updateSearch}
+          value={search}
+          testID="flux-toolbar-search--input"
+        />
+      </div>
+      {body}
+    </div>
+  )
+}
+
+export default Expressions

--- a/src/flows/pipes/Notification/Expressions.tsx
+++ b/src/flows/pipes/Notification/Expressions.tsx
@@ -1,4 +1,4 @@
-import React, {FC, useState, useMemo, useCallback, useContext} from 'react'
+import React, {FC, useState, useMemo, useCallback} from 'react'
 
 import {
   Input,
@@ -9,11 +9,10 @@ import {
 } from '@influxdata/clockface'
 import {FromFluxResult} from '@influxdata/giraffe'
 import Expression from 'src/flows/pipes/Notification/Expression'
-import {FlowContext} from 'src/flows/context/flow.current'
 
 interface Props {
   parsed: FromFluxResult
-  id: string
+  onSelect: (exp: string) => void
 }
 
 interface SchemaExpressions {
@@ -106,27 +105,14 @@ const isExpressionsEmpty = (schemaExpressions: SchemaExpressions) => {
   return Object.keys(schemaExpressions).length === isEmptySchemas
 }
 
-const Expressions: FC<Props> = ({id, parsed}) => {
+const Expressions: FC<Props> = ({parsed, onSelect}) => {
   const [search, setSearch] = useState('')
-  const {flow, updateData} = useContext(FlowContext)
   const updateSearch = useCallback(
     e => {
       setSearch(e.target.value)
     },
     [search, setSearch]
   )
-
-  const inject = (exp: string): void => {
-    const data = flow.data.byID[id]
-    updateData(id, {
-      ...data,
-      message: [
-        data.message.slice(0, data.cursorPosition),
-        ` r.${exp} `,
-        data.message.slice(data.cursorPosition),
-      ].join(''),
-    })
-  }
 
   const schemaExpressions = useMemo(
     () => parsedResultToSchema(parsed, search),
@@ -153,7 +139,7 @@ const Expressions: FC<Props> = ({id, parsed}) => {
               </dt>
               {schemaExpressions[category].map(exp => (
                 <Expression
-                  onClickFunction={inject}
+                  onClickFunction={onSelect}
                   key={`${category}-${exp}`}
                   testID={`${category}-${exp}`}
                   expression={exp}

--- a/src/flows/pipes/Notification/index.ts
+++ b/src/flows/pipes/Notification/index.ts
@@ -19,6 +19,7 @@ export default register => {
       ],
       message:
         '${strings.title(v: r._type)} for ${r._source_measurement} triggered at ${time(v: r._source_timestamp)}!',
+      cursorPosition: 0,
       endpoint: 'slack',
       endpointData: {
         url: 'https://hooks.slack.com/services/X/X/X',

--- a/src/flows/pipes/Notification/index.ts
+++ b/src/flows/pipes/Notification/index.ts
@@ -19,7 +19,6 @@ export default register => {
       ],
       message:
         '${strings.title(v: r._type)} for ${r._source_measurement} triggered at ${time(v: r._source_timestamp)}!',
-      cursorPosition: 0,
       endpoint: 'slack',
       endpointData: {
         url: 'https://hooks.slack.com/services/X/X/X',

--- a/src/flows/pipes/Notification/view.tsx
+++ b/src/flows/pipes/Notification/view.tsx
@@ -561,6 +561,7 @@ ${DEFAULT_ENDPOINTS[data.endpoint]?.generateTestQuery(data.endpointData)}`
                             isFlagEnabled('flowSidebar') ? launcher : toggleExp
                           }
                           color={ComponentColor.Secondary}
+                          testID="notification-exp-button"
                         />
                       </FlexBox.Child>
                     )}
@@ -610,6 +611,7 @@ ${DEFAULT_ENDPOINTS[data.endpoint]?.generateTestQuery(data.endpointData)}`
                           onFocus={updateCursor}
                           size={ComponentSize.Medium}
                           style={{height: '100%'}}
+                          testID="notification-message--textarea"
                         />
                       </Form.Element>
                     </FlexBox.Child>

--- a/src/flows/pipes/Notification/view.tsx
+++ b/src/flows/pipes/Notification/view.tsx
@@ -56,8 +56,6 @@ const Notification: FC<PipeProp> = ({Context}) => {
   const [status, setStatus] = useState<RemoteDataState>(
     RemoteDataState.NotStarted
   )
-  const [showExp, setShowExp] = useState(true)
-
   let intervalError = ''
   let offsetError = ''
 
@@ -445,10 +443,6 @@ ${DEFAULT_ENDPOINTS[data.endpoint]?.generateTestQuery(data.endpointData)}`
     }
   }
 
-  const toggleExp = useCallback(() => {
-    setShowExp(!showExp)
-  }, [setShowExp, showExp])
-
   const launcher = () => {
     if (showId === id) {
       hideSub()
@@ -557,9 +551,7 @@ ${DEFAULT_ENDPOINTS[data.endpoint]?.generateTestQuery(data.endpointData)}`
                       <FlexBox.Child grow={0} shrink={0}>
                         <Button
                           text="${exp}"
-                          onClick={
-                            isFlagEnabled('flowSidebar') ? launcher : toggleExp
-                          }
+                          onClick={launcher}
                           color={ComponentColor.Secondary}
                           testID="notification-exp-button"
                         />

--- a/src/shared/selectors/flags.ts
+++ b/src/shared/selectors/flags.ts
@@ -47,6 +47,7 @@ export const OSS_FLAGS = {
   simpleTable: false,
   exploreWithFlows: false,
   createWithFlows: false,
+  notebooksExp: false,
 }
 
 export const CLOUD_FLAGS = {
@@ -95,6 +96,7 @@ export const CLOUD_FLAGS = {
   simpleTable: false,
   exploreWithFlows: false,
   createWithFlows: false,
+  notebooksExp: false,
 }
 
 export const activeFlags = (state: AppState): FlagMap => {


### PR DESCRIPTION
Closes #2285

Dynamically populate list of expressions the user can insert into an alert message based on the results of their query. e2e test included.

![image](https://user-images.githubusercontent.com/6411855/133347587-6372f857-15b1-404f-87cc-39a1b3ec141d.png)

![image](https://user-images.githubusercontent.com/6411855/133347609-d5d8d09f-1d3b-4c33-aaa4-3d575b640419.png)


https://user-images.githubusercontent.com/6411855/133347694-f1db1a6b-8249-491b-afab-758bd295b894.mov



