### PR TITLE
feat: consume the input plugin configuration from .conf files

### DIFF
--- a/src/dataLoaders/actions/dataLoaders.ts
+++ b/src/dataLoaders/actions/dataLoaders.ts
@@ -398,7 +398,7 @@ export const createOrUpdateTelegrafConfigAsync = () => async (
   const plugins = telegrafPlugins.reduce(
     (acc, tp) => {
       if (tp.configured === ConfigurationState.Configured) {
-        return [...acc, tp.plugin || createNewPlugin(tp.name)]
+        return [...acc, tp.plugin || createNewPlugin(tp)]
       }
 
       return acc

--- a/src/dataLoaders/reducers/dataLoaders.ts
+++ b/src/dataLoaders/reducers/dataLoaders.ts
@@ -117,7 +117,7 @@ export default (state = INITIAL_STATE, action: Action): DataLoadersState => {
         ...state,
         telegrafPlugins: state.telegrafPlugins.map(tp => {
           if (tp.name === action.payload.name) {
-            const plugin = get(tp, 'plugin', createNewPlugin(tp.name))
+            const plugin = get(tp, 'plugin', createNewPlugin(tp))
 
             return {
               ...tp,
@@ -136,7 +136,7 @@ export default (state = INITIAL_STATE, action: Action): DataLoadersState => {
         ...state,
         telegrafPlugins: state.telegrafPlugins.map(tp => {
           if (tp.name === action.payload.pluginName) {
-            const plugin = get(tp, 'plugin', createNewPlugin(tp.name))
+            const plugin = get(tp, 'plugin', createNewPlugin(tp))
 
             const config = get(plugin, ['config', action.payload.fieldName], [])
 
@@ -162,7 +162,7 @@ export default (state = INITIAL_STATE, action: Action): DataLoadersState => {
         ...state,
         telegrafPlugins: state.telegrafPlugins.map(tp => {
           if (tp.name === action.payload.pluginName) {
-            const plugin = get(tp, 'plugin', createNewPlugin(tp.name))
+            const plugin = get(tp, 'plugin', createNewPlugin(tp))
 
             const configFieldValues = get(
               plugin,
@@ -190,7 +190,7 @@ export default (state = INITIAL_STATE, action: Action): DataLoadersState => {
         ...state,
         telegrafPlugins: state.telegrafPlugins.map(tp => {
           if (tp.name === action.payload.pluginName) {
-            const plugin = get(tp, 'plugin', createNewPlugin(tp.name))
+            const plugin = get(tp, 'plugin', createNewPlugin(tp))
             const configValues = get(
               plugin,
               `config.${action.payload.field}`,
@@ -228,7 +228,7 @@ export default (state = INITIAL_STATE, action: Action): DataLoadersState => {
               return {...tp, configured: ConfigurationState.Configured}
             }
 
-            const plugin = getDeep<Plugin>(tp, 'plugin', createNewPlugin(name))
+            const plugin = getDeep<Plugin>(tp, 'plugin', createNewPlugin(tp))
             const config = get(plugin, 'config', {})
 
             let isValidConfig = true

--- a/src/dataLoaders/utils/pluginConfigs.ts
+++ b/src/dataLoaders/utils/pluginConfigs.ts
@@ -8,10 +8,11 @@ import {
 
 // Types
 import {
-  TelegrafPluginName,
+  BundleName,
   ConfigFields,
   Plugin,
-  BundleName,
+  TelegrafPlugin,
+  TelegrafPluginName,
 } from 'src/types/dataLoaders'
 
 export const getConfigFields = (
@@ -32,8 +33,19 @@ export const updateConfigFields = <T extends Plugin>(
   })
 }
 
-export const createNewPlugin = (name: TelegrafPluginName): Plugin => {
-  return telegrafPluginsInfo[name].defaults
+export const createNewPlugin = (plugin: TelegrafPlugin): Plugin => {
+  if (telegrafPluginsInfo[plugin?.name]) {
+    return telegrafPluginsInfo[plugin.name].defaults
+  }
+  const {
+    plugin: {type: pluginType} = {
+      type: 'input',
+    },
+  } = plugin
+  return {
+    name: plugin.name ? plugin.name : 'plugin-input',
+    type: pluginType,
+  }
 }
 
 export const isPluginUniqueToBundle = (

--- a/src/types/dataLoaders.ts
+++ b/src/types/dataLoaders.ts
@@ -122,6 +122,13 @@ export type Plugin =
   | TelegrafPluginInputTail
   | TelegrafPluginOutputFile
   | TelegrafPluginOutputInfluxDBV2
+  | TelegrafPluginGeneric
+
+export type TelegrafPluginGeneric = {
+  name: string
+  type: string
+  comment?: string
+}
 
 export interface TelegrafPlugin {
   name: TelegrafPluginName
@@ -139,29 +146,7 @@ export enum BundleName {
   Redis = 'Redis',
 }
 
-export type TelegrafPluginName =
-  | TelegrafPluginInputCpu.NameEnum.Cpu
-  | TelegrafPluginInputDisk.NameEnum.Disk
-  | TelegrafPluginInputDiskio.NameEnum.Diskio
-  | TelegrafPluginInputDocker.NameEnum.Docker
-  | TelegrafPluginInputFile.NameEnum.File
-  | TelegrafPluginInputKernel.NameEnum.Kernel
-  | TelegrafPluginInputKubernetes.NameEnum.Kubernetes
-  | TelegrafPluginInputLogParser.NameEnum.Logparser
-  | TelegrafPluginInputMem.NameEnum.Mem
-  | TelegrafPluginInputNet.NameEnum.Net
-  | TelegrafPluginInputNetResponse.NameEnum.NetResponse
-  | TelegrafPluginInputNginx.NameEnum.Nginx
-  | TelegrafPluginInputProcesses.NameEnum.Processes
-  | TelegrafPluginInputProcstat.NameEnum.Procstat
-  | TelegrafPluginInputPrometheus.NameEnum.Prometheus
-  | TelegrafPluginInputRedis.NameEnum.Redis
-  | TelegrafPluginInputSyslog.NameEnum.Syslog
-  | TelegrafPluginInputSwap.NameEnum.Swap
-  | TelegrafPluginInputSystem.NameEnum.System
-  | TelegrafPluginInputTail.NameEnum.Tail
-  | TelegrafPluginOutputFile.NameEnum.File
-  | TelegrafPluginOutputInfluxDBV2.NameEnum.InfluxdbV2
+export type TelegrafPluginName = string
 
 export enum LineProtocolStatus {
   ImportData = 'importData',

--- a/src/writeData/components/AddPluginToConfiguration.scss
+++ b/src/writeData/components/AddPluginToConfiguration.scss
@@ -11,6 +11,10 @@
   margin-bottom: $cf-marg-b;
 }
 
-.plugin-creat-configuration--editor {
+.plugin-create-configuration--editor {
   margin-top: $cf-marg-b;
+}
+
+.plugin-create-configuration--notify-agent-output {
+  font-style: italic;
 }

--- a/src/writeData/components/PluginCreateConfigurationCustomize.tsx
+++ b/src/writeData/components/PluginCreateConfigurationCustomize.tsx
@@ -48,8 +48,6 @@ const PluginCreateConfigurationCustomizeComponent: FC<Props> = props => {
 
   const {contentID} = useParams<ParamsType>()
 
-  const workingConfig = pluginConfig
-
   const handleError = error => {
     setIsValidConfiguration(false)
     setPluginConfig(`${error}`)
@@ -131,7 +129,7 @@ const PluginCreateConfigurationCustomizeComponent: FC<Props> = props => {
         <Grid.Row className="plugin-create-configuration--editor">
           <div className="config-overlay">
             <TelegrafConfig
-              config={workingConfig}
+              config={pluginConfig}
               onChangeConfig={handleChangeConfig}
             />
           </div>

--- a/src/writeData/components/PluginCreateConfigurationFooter.tsx
+++ b/src/writeData/components/PluginCreateConfigurationFooter.tsx
@@ -3,7 +3,12 @@ import React, {FC, useEffect, useMemo} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
 
 // Components
-import {Button, ComponentColor, Overlay} from '@influxdata/clockface'
+import {
+  Button,
+  ComponentColor,
+  ComponentStatus,
+  Overlay,
+} from '@influxdata/clockface'
 
 // Actions
 import {createOrUpdateTelegrafConfigAsync} from 'src/dataLoaders/actions/dataLoaders'
@@ -23,6 +28,7 @@ type Props = PluginCreateConfigurationStepProps & ReduxProps
 const PluginCreateConfigurationFooterComponent: FC<Props> = props => {
   const {
     currentStepIndex,
+    isValidConfiguration,
     onDecrementCurrentStepIndex,
     onExit,
     onIncrementCurrentStepIndex,
@@ -34,16 +40,13 @@ const PluginCreateConfigurationFooterComponent: FC<Props> = props => {
   } = props
 
   const shouldTelegrafUpdate = useMemo(() => {
-    if (telegrafConfig) {
-      return true
-    }
-    return false
+    return Boolean(telegrafConfig)
   }, [telegrafConfig])
 
   useEffect(() => {
     if (telegrafConfig) {
       const {config} = telegrafConfig
-      onUpdateTelegraf({...telegrafConfig, config: config + pluginConfig})
+      onUpdateTelegraf({...telegrafConfig, config: `${config}${pluginConfig}`})
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [shouldTelegrafUpdate])
@@ -89,6 +92,11 @@ const PluginCreateConfigurationFooterComponent: FC<Props> = props => {
       <Button
         color={ComponentColor.Primary}
         onClick={handleSaveAndTest}
+        status={
+          isValidConfiguration
+            ? ComponentStatus.Valid
+            : ComponentStatus.Disabled
+        }
         tabIndex={0}
         testID="plugin-create-configuration-save-and-test"
         text="Save and Test"

--- a/src/writeData/components/PluginCreateConfigurationFooter.tsx
+++ b/src/writeData/components/PluginCreateConfigurationFooter.tsx
@@ -1,19 +1,21 @@
 // Libraries
-import React, {FC} from 'react'
+import React, {FC, useEffect, useMemo} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {Button, ComponentColor, Overlay} from '@influxdata/clockface'
 
 // Actions
-import {
-  addPluginBundleWithPlugins,
-  createOrUpdateTelegrafConfigAsync,
-} from 'src/dataLoaders/actions/dataLoaders'
+import {createOrUpdateTelegrafConfigAsync} from 'src/dataLoaders/actions/dataLoaders'
+import {updateTelegraf} from 'src/telegrafs/actions/thunks'
 
 // Types
-import {BundleName} from 'src/types/dataLoaders'
+import {AppState, ResourceType, Telegraf} from 'src/types'
 import {PluginCreateConfigurationStepProps} from 'src/writeData/components/PluginCreateConfigurationWizard'
+
+// Selectors
+import {getDataLoaders} from 'src/dataLoaders/selectors'
+import {getAll} from 'src/resources/selectors'
 
 type ReduxProps = ConnectedProps<typeof connector>
 type Props = PluginCreateConfigurationStepProps & ReduxProps
@@ -21,16 +23,32 @@ type Props = PluginCreateConfigurationStepProps & ReduxProps
 const PluginCreateConfigurationFooterComponent: FC<Props> = props => {
   const {
     currentStepIndex,
-    onAddPluginBundle,
     onDecrementCurrentStepIndex,
     onExit,
     onIncrementCurrentStepIndex,
     onSaveTelegrafConfig,
+    onUpdateTelegraf,
     substepIndex,
+    telegrafConfig,
+    pluginConfig,
   } = props
 
+  const shouldTelegrafUpdate = useMemo(() => {
+    if (telegrafConfig) {
+      return true
+    }
+    return false
+  }, [telegrafConfig])
+
+  useEffect(() => {
+    if (telegrafConfig) {
+      const {config} = telegrafConfig
+      onUpdateTelegraf({...telegrafConfig, config: config + pluginConfig})
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shouldTelegrafUpdate])
+
   const handleSaveAndTest = () => {
-    onAddPluginBundle(BundleName.System)
     onSaveTelegrafConfig()
     onIncrementCurrentStepIndex()
   }
@@ -79,12 +97,25 @@ const PluginCreateConfigurationFooterComponent: FC<Props> = props => {
   )
 }
 
-const mdtp = {
-  onAddPluginBundle: addPluginBundleWithPlugins,
-  onSaveTelegrafConfig: createOrUpdateTelegrafConfigAsync,
+const mstp = (state: AppState) => {
+  const {telegrafConfigID} = getDataLoaders(state)
+
+  let telegrafConfig = null
+  if (telegrafConfigID) {
+    const telegrafs = getAll<Telegraf>(state, ResourceType.Telegrafs)
+    telegrafConfig = telegrafs.find(
+      telegraf => telegraf.id === telegrafConfigID
+    )
+  }
+  return {telegrafConfig}
 }
 
-const connector = connect(null, mdtp)
+const mdtp = {
+  onSaveTelegrafConfig: createOrUpdateTelegrafConfigAsync,
+  onUpdateTelegraf: updateTelegraf,
+}
+
+const connector = connect(mstp, mdtp)
 
 export const PluginCreateConfigurationFooter = connector(
   PluginCreateConfigurationFooterComponent

--- a/src/writeData/components/PluginCreateConfigurationWizard.tsx
+++ b/src/writeData/components/PluginCreateConfigurationWizard.tsx
@@ -47,6 +47,8 @@ export interface PluginCreateConfigurationStepProps {
   substepIndex: number
   pluginConfig: string
   setPluginConfig: (config: string) => void
+  isValidConfiguration: boolean
+  setIsValidConfiguration: (isValid: boolean) => void
 }
 
 interface PluginCreateConfigurationWizardProps {
@@ -78,6 +80,9 @@ const PluginCreateConfigurationWizard: FC<Props> = props => {
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const [pluginConfig, setPluginConfig] = useState<string>('')
+  const [isValidConfiguration, setIsValidConfiguration] = useState<boolean>(
+    false
+  )
 
   const handleDismiss = () => {
     onClearDataLoaders()
@@ -92,21 +97,23 @@ const PluginCreateConfigurationWizard: FC<Props> = props => {
 
   const stepProps = {
     currentStepIndex,
+    isValidConfiguration,
     notify,
     onDecrementCurrentStepIndex,
     onExit: handleDismiss,
     onIncrementCurrentStepIndex,
     onSetSubstepIndex,
-    substepIndex,
     pluginConfig,
+    setIsValidConfiguration,
     setPluginConfig,
+    substepIndex,
   }
 
   let title = 'Configuration Options'
   if (currentStepIndex === 0 && substepIndex === 1) {
     title = 'Create Bucket'
   } else if (currentStepIndex !== 0) {
-    title = 'Create a Telegraf Configuration'
+    title = 'Add Plugin to a new Telegraf Configuration'
   }
 
   let maxWidth = PLUGIN_CREATE_CONFIGURATION_OVERLAY_DEFAULT_WIDTH

--- a/src/writeData/components/PluginCreateConfigurationWizard.tsx
+++ b/src/writeData/components/PluginCreateConfigurationWizard.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FC, useEffect} from 'react'
+import React, {FC, useEffect, useState} from 'react'
 import Loadable from 'react-loadable'
 import {connect, ConnectedProps} from 'react-redux'
 
@@ -26,6 +26,7 @@ import {BUCKET_OVERLAY_WIDTH} from 'src/buckets/constants'
 
 const PLUGIN_CREATE_CONFIGURATION_OVERLAY_DEFAULT_WIDTH = 1200
 const PLUGIN_CREATE_CONFIGURATION_OVERLAY_OPTIONS_WIDTH = 480
+const PREVENT_OVERLAY_FLICKER_STEP = -1
 
 const spinner = <div />
 const PluginCreateConfigurationStepSwitcher = Loadable({
@@ -44,6 +45,8 @@ export interface PluginCreateConfigurationStepProps {
   onIncrementCurrentStepIndex: () => void
   onSetSubstepIndex: (currentStepIndex: number, subStepIndex: number) => void
   substepIndex: number
+  pluginConfig: string
+  setPluginConfig: (config: string) => void
 }
 
 interface PluginCreateConfigurationWizardProps {
@@ -60,8 +63,8 @@ const PluginCreateConfigurationWizard: FC<Props> = props => {
     currentStepIndex,
     history,
     notify,
-    onClearSteps,
     onClearDataLoaders,
+    onClearSteps,
     onDecrementCurrentStepIndex,
     onIncrementCurrentStepIndex,
     onSetCurrentStepIndex,
@@ -74,12 +77,15 @@ const PluginCreateConfigurationWizard: FC<Props> = props => {
     onSetSubstepIndex(0, 0)
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
+  const [pluginConfig, setPluginConfig] = useState<string>('')
+
   const handleDismiss = () => {
     onClearDataLoaders()
     onClearSteps()
     if (substepIndex === 1) {
       onSetSubstepIndex(0, 0)
     } else {
+      onSetCurrentStepIndex(PREVENT_OVERLAY_FLICKER_STEP)
       history.goBack()
     }
   }
@@ -92,6 +98,8 @@ const PluginCreateConfigurationWizard: FC<Props> = props => {
     onIncrementCurrentStepIndex,
     onSetSubstepIndex,
     substepIndex,
+    pluginConfig,
+    setPluginConfig,
   }
 
   let title = 'Configuration Options'
@@ -144,8 +152,8 @@ const mstp = (state: AppState) => {
 
 const mdtp = {
   notify: notifyAction,
-  onClearSteps: clearSteps,
   onClearDataLoaders: clearDataLoaders,
+  onClearSteps: clearSteps,
   onDecrementCurrentStepIndex: decrementCurrentStepIndex,
   onIncrementCurrentStepIndex: incrementCurrentStepIndex,
   onSetCurrentStepIndex: setCurrentStepIndex,

--- a/src/writeData/constants/contentTelegrafPlugins.ts
+++ b/src/writeData/constants/contentTelegrafPlugins.ts
@@ -1585,7 +1585,84 @@ export const search = (term: string): TelegrafPlugin[] =>
     item.name.toLowerCase().includes(term.toLowerCase())
   ).sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()))
 
-export const TELEGRAF_DEFAULT_OUTPUT = ` [[outputs.influxdb_v2]]
+export const TELEGRAF_DEFAULT_OUTPUT = `# Configuration for telegraf agent
+[agent]
+  ## Default data collection interval for all inputs
+  interval = "10s"
+  ## Rounds collection interval to 'interval'
+  ## ie, if interval="10s" then always collect on :00, :10, :20, etc.
+  round_interval = true
+
+  ## Telegraf will send metrics to outputs in batches of at most
+  ## metric_batch_size metrics.
+  ## This controls the size of writes that Telegraf sends to output plugins.
+  metric_batch_size = 1000
+
+  ## Maximum number of unwritten metrics per output.  Increasing this value
+  ## allows for longer periods of output downtime without dropping metrics at the
+  ## cost of higher maximum memory usage.
+  metric_buffer_limit = 10000
+
+  ## Collection jitter is used to jitter the collection by a random amount.
+  ## Each plugin will sleep for a random time within jitter before collecting.
+  ## This can be used to avoid many plugins querying things like sysfs at the
+  ## same time, which can have a measurable effect on the system.
+  collection_jitter = "0s"
+
+  ## Default flushing interval for all outputs. Maximum flush_interval will be
+  ## flush_interval + flush_jitter
+  flush_interval = "10s"
+  ## Jitter the flush interval by a random amount. This is primarily to avoid
+  ## large write spikes for users running a large number of telegraf instances.
+  ## ie, a jitter of 5s and interval 10s means flushes will happen every 10-15s
+  flush_jitter = "0s"
+
+  ## By default or when set to "0s", precision will be set to the same
+  ## timestamp order as the collection interval, with the maximum being 1s.
+  ##   ie, when interval = "10s", precision will be "1s"
+  ##       when interval = "250ms", precision will be "1ms"
+  ## Precision will NOT be used for service inputs. It is up to each individual
+  ## service input to set the timestamp at the appropriate precision.
+  ## Valid time units are "ns", "us" (or "µs"), "ms", "s".
+  precision = ""
+
+  ## Log at debug level.
+  # debug = false
+  ## Log only error level messages.
+  # quiet = false
+
+  ## Log target controls the destination for logs and can be one of "file",
+  ## "stderr" or, on Windows, "eventlog".  When set to "file", the output file
+  ## is determined by the "logfile" setting.
+  # logtarget = "file"
+
+  ## Name of the file to be logged to when using the "file" logtarget.  If set to
+  ## the empty string then logs are written to stderr.
+  # logfile = ""
+
+  ## The logfile will be rotated after the time interval specified.  When set
+  ## to 0 no time based rotation is performed.  Logs are rotated only when
+  ## written to, if there is no log activity rotation may be delayed.
+  # logfile_rotation_interval = "0d"
+
+  ## The logfile will be rotated when it becomes larger than the specified
+  ## size.  When set to 0 no size based rotation is performed.
+  # logfile_rotation_max_size = "0MB"
+
+  ## Maximum number of rotated archives to keep, any older logs are deleted.
+  ## If set to -1, no archives are removed.
+  # logfile_rotation_max_archives = 5
+
+  ## Pick a timezone to use when logging or type 'local' for local time.
+  ## Example: America/Chicago
+  # log_with_timezone = ""
+
+  ## Override default hostname, if empty use os.Hostname()
+  hostname = ""
+  ## If set to true, do no set the "host" tag in the telegraf agent.
+  omit_hostname = false
+
+[[outputs.influxdb_v2]]
 ## The URLs of the InfluxDB cluster nodes.
 ##
 ## Multiple URLs can be specified for a single cluster, only ONE of the


### PR DESCRIPTION
Closes #2160 
Closes #2603 

- Consumes the appropriate .conf file for the selected Plugin when creating a Telegraf configuration from a Plugin's page.
- Fixes the flicker after clicking "Finish"
***EDIT: added:
- Removes "Download Config" and "Copy to Clipboard" buttons
- Changes "Agent Name" to "Configuration Name"
- Adds a line of text below the editor to warn user that a default agent and output will be inserted upon saving


https://user-images.githubusercontent.com/10736577/133173348-908b633a-6824-4ec1-ad2a-be0537b7a5f8.mp4



Also updated the customization step by removing some buttons, renaming the label "Agent Name" to "Configuration Name", and adding a note below the editor to let the user know that a default agent and output will be inserted.
<img width="1680" alt="Screen Shot 2021-09-14 at 4 10 40 PM" src="https://user-images.githubusercontent.com/10736577/133346612-81124fad-ca4f-4715-ae50-505b25bb0f7d.png">
