### PR TITLE
feat: track delete initiation

### DIFF
--- a/src/organizations/components/OrgProfileDeletePanel.tsx
+++ b/src/organizations/components/OrgProfileDeletePanel.tsx
@@ -25,6 +25,7 @@ import {notify} from 'src/shared/actions/notifications'
 import {deleteAccountWarning} from 'src/shared/copy/notifications'
 import {CLOUD} from 'src/shared/constants'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import {event} from 'src/cloud/utils/reporting'
 
 // Types
 import {getQuartzMe} from 'src/me/selectors'
@@ -38,12 +39,15 @@ const OrgProfileTab: FC = () => {
   const dispatch = useDispatch()
 
   const handleShowDeleteOverlay = () => {
+    const payload = {
+      org: org.id,
+      tier: quartzMe?.accountType,
+      email: quartzMe?.email,
+    }
+
     if (isFlagEnabled('trackCancellations')) {
-      track('DeleteOrgInitiation', {
-        org: org.id,
-        tier: quartzMe?.accountType,
-        email: quartzMe?.email,
-      })
+      event('Delete Organization Initiated', payload)
+      track('DeleteOrgInitiation', payload)
     }
 
     history.push(`/orgs/${org.id}/about/delete`)

--- a/src/organizations/components/OrgProfileDeletePanel.tsx
+++ b/src/organizations/components/OrgProfileDeletePanel.tsx
@@ -2,6 +2,7 @@
 import React, {FC, useContext} from 'react'
 import {useSelector, useDispatch} from 'react-redux'
 import {useHistory} from 'react-router-dom'
+import {track} from 'rudder-sdk-js'
 
 // Components
 import {
@@ -23,12 +24,11 @@ import {getOrg} from 'src/organizations/selectors'
 import {notify} from 'src/shared/actions/notifications'
 import {deleteAccountWarning} from 'src/shared/copy/notifications'
 import {CLOUD} from 'src/shared/constants'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Types
 import {getQuartzMe} from 'src/me/selectors'
 import {NotificationButtonElement} from 'src/types'
-import {track} from 'rudder-sdk-js'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 const OrgProfileTab: FC = () => {
   const quartzMe = useSelector(getQuartzMe)

--- a/src/organizations/components/OrgProfileDeletePanel.tsx
+++ b/src/organizations/components/OrgProfileDeletePanel.tsx
@@ -39,13 +39,13 @@ const OrgProfileTab: FC = () => {
   const dispatch = useDispatch()
 
   const handleShowDeleteOverlay = () => {
-    const payload = {
-      org: org.id,
-      tier: quartzMe?.accountType,
-      email: quartzMe?.email,
-    }
-
     if (isFlagEnabled('trackCancellations')) {
+      const payload = {
+        org: org.id,
+        tier: quartzMe?.accountType,
+        email: quartzMe?.email,
+      }
+
       event('Delete Organization Initiated', payload)
       track('DeleteOrgInitiation', payload)
     }

--- a/src/organizations/components/OrgProfileDeletePanel.tsx
+++ b/src/organizations/components/OrgProfileDeletePanel.tsx
@@ -27,6 +27,8 @@ import {CLOUD} from 'src/shared/constants'
 // Types
 import {getQuartzMe} from 'src/me/selectors'
 import {NotificationButtonElement} from 'src/types'
+import {track} from 'rudder-sdk-js'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 const OrgProfileTab: FC = () => {
   const quartzMe = useSelector(getQuartzMe)
@@ -36,6 +38,14 @@ const OrgProfileTab: FC = () => {
   const dispatch = useDispatch()
 
   const handleShowDeleteOverlay = () => {
+    if (isFlagEnabled('TrackCancellations')) {
+      track('DeleteOrgInitiation', {
+        org: org.id,
+        tier: quartzMe?.accountType,
+        email: quartzMe?.email,
+      })
+    }
+
     history.push(`/orgs/${org.id}/about/delete`)
   }
 

--- a/src/organizations/components/OrgProfileDeletePanel.tsx
+++ b/src/organizations/components/OrgProfileDeletePanel.tsx
@@ -38,7 +38,7 @@ const OrgProfileTab: FC = () => {
   const dispatch = useDispatch()
 
   const handleShowDeleteOverlay = () => {
-    if (isFlagEnabled('TrackCancellations')) {
+    if (isFlagEnabled('trackCancellations')) {
       track('DeleteOrgInitiation', {
         org: org.id,
         tier: quartzMe?.accountType,


### PR DESCRIPTION
Closes #2424 

We need to start tracking when a user initiates the process of deleting an organization. As soon as a user clicks the `Delete` button in the picture below, we need to send data to snowflake using rudderstack.

![image](https://user-images.githubusercontent.com/1637395/133307236-ab7ec38d-499c-49ae-9737-c3b428eb9b12.png)

