### PR TITLE
feat: store pagination and filter state in url on change

### DIFF
--- a/src/tasks/pagination/TasksList.tsx
+++ b/src/tasks/pagination/TasksList.tsx
@@ -90,6 +90,15 @@ export default class TasksList extends PureComponent<Props, State>
   }
 
   public componentDidMount() {
+    const params = new URLSearchParams(window.location.search)
+    const urlPageNumber = parseInt(params.get('page'), 10)
+
+    const passedInPageIsValid =
+      urlPageNumber && urlPageNumber <= this.totalPages && urlPageNumber >= 0
+    if (passedInPageIsValid) {
+      this.currentPage = urlPageNumber
+    }
+
     this.props.checkTaskLimits()
     if (CLOUD && isFlagEnabled('pinnedItems')) {
       getPinnedItems()
@@ -137,6 +146,9 @@ export default class TasksList extends PureComponent<Props, State>
 
   public paginate = page => {
     this.currentPage = page
+    const url = new URL(location.href)
+    url.searchParams.set('page', page)
+    history.replaceState(null, '', url.toString())
     this.forceUpdate()
   }
 

--- a/src/tasks/pagination/TasksPage.tsx
+++ b/src/tasks/pagination/TasksPage.tsx
@@ -86,7 +86,7 @@ class TasksPage extends PureComponent<Props, State> {
     this.props.getTasks(-1) // -1 means fetch all tasks with no limit
     this.props.getLabels()
 
-    let sortType = this.state.sortType
+    let sortType: SortTypes = this.state.sortType
     const params = new URLSearchParams(window.location.search)
 
     let sortKey: TaskSortKey = 'name'
@@ -100,7 +100,7 @@ class TasksPage extends PureComponent<Props, State> {
       sortType = SortTypes.String
     }
 
-    let sortDirection = this.state.sortDirection
+    let sortDirection: Sort = this.state.sortDirection
     if (params.get('sortDirection') === Sort.Ascending) {
       sortDirection = Sort.Ascending
     } else if (params.get('sortDirection') === Sort.Descending) {

--- a/src/tasks/pagination/TasksPage.tsx
+++ b/src/tasks/pagination/TasksPage.tsx
@@ -83,8 +83,31 @@ class TasksPage extends PureComponent<Props, State> {
   }
 
   public componentDidMount() {
-    this.props.getTasks(-1) // -1 means fetch all tasks with no limit, basic means don't include query text
+    this.props.getTasks(-1) // -1 means fetch all tasks with no limit
     this.props.getLabels()
+
+    let sortType = this.state.sortType
+    const params = new URLSearchParams(window.location.search)
+
+    let sortKey: TaskSortKey = 'name'
+    if (params.get('sortKey') === 'status') {
+      sortKey = 'status'
+    } else if (params.get('sortKey') === 'latestCompleted') {
+      sortKey = 'latestCompleted'
+      sortType = SortTypes.Date
+    } else if (params.get('sortKey') === 'every') {
+      sortKey = 'every'
+      sortType = SortTypes.String
+    }
+
+    let sortDirection = this.state.sortDirection
+    if (params.get('sortDirection') === Sort.Ascending) {
+      sortDirection = Sort.Ascending
+    } else if (params.get('sortDirection') === Sort.Descending) {
+      sortDirection = Sort.Descending
+    }
+
+    this.setState({sortKey, sortDirection, sortType})
   }
 
   public render(): JSX.Element {
@@ -177,6 +200,11 @@ class TasksPage extends PureComponent<Props, State> {
     sortDirection: Sort,
     sortType: SortTypes
   ) => {
+    const url = new URL(location.href)
+    url.searchParams.set('sortKey', sortKey)
+    url.searchParams.set('sortDirection', sortDirection)
+    history.replaceState(null, '', url.toString())
+
     this.setState({sortKey, sortDirection, sortType})
   }
 


### PR DESCRIPTION
Closes https://github.com/influxdata/idpe/issues/11749

Stores the current choice for page and sorting options in the url.
1. Allows a user to reload the page and see the same results they just saw
2. Allows a user to share their page with a teammate who can then see the same results


https://user-images.githubusercontent.com/146112/133320621-000137b3-1d07-4cf1-a144-d2eaa6d4b5e9.mov

