### PR TITLE
fix: cleaning up some events

### DIFF
--- a/src/flows/pipes/Notification/view.tsx
+++ b/src/flows/pipes/Notification/view.tsx
@@ -564,6 +564,7 @@ ${DEFAULT_ENDPOINTS[data.endpoint]?.generateTestQuery(data.endpointData)}`
             <ExportTaskButton
               generate={generateTask}
               text="Export Alert Task"
+              type="alert"
             />
           </FlexBox>
         </Panel.Footer>

--- a/src/flows/pipes/Schedule/ExportTaskButton.tsx
+++ b/src/flows/pipes/Schedule/ExportTaskButton.tsx
@@ -18,16 +18,17 @@ import {event} from 'src/cloud/utils/reporting'
 
 interface Props {
   text: string
+  type: string
   generate?: () => string
 }
 
-const ExportTaskButton: FC<Props> = ({text, generate}) => {
+const ExportTaskButton: FC<Props> = ({text, type, generate}) => {
   const {data, range} = useContext(PipeContext)
   const {launch} = useContext(PopupContext)
 
   const onClick = () => {
-    event('Export Task Clicked', {from: 'schedule'})
-    launch(<ExportTaskOverlay text={text} />, {
+    event('Export Task Clicked', {from: type})
+    launch(<ExportTaskOverlay text={text} type={type} />, {
       bucket: data.bucket,
       query: generate ? generate() : data.query,
       range,

--- a/src/flows/pipes/Schedule/ExportTaskOverlay/context.tsx
+++ b/src/flows/pipes/Schedule/ExportTaskOverlay/context.tsx
@@ -60,7 +60,10 @@ const DEFAULT_CONTEXT: ContextType = {
 
 export const Context = React.createContext<ContextType>(DEFAULT_CONTEXT)
 
-export const Provider: FC = ({children}) => {
+interface Props {
+  type: string
+}
+export const Provider: FC<Props> = ({type, children}) => {
   const dispatch = useDispatch()
   const org = useSelector(getOrg)
   const [activeTab, setActiveTab] = useState(ExportAsTask.Create)
@@ -146,7 +149,7 @@ export const Provider: FC = ({children}) => {
     }
 
     if (activeTab === ExportAsTask.Create) {
-      event('Export Task Completed', {exportType: 'create'})
+      event('Export Task Completed', {exportType: 'create', from: type})
 
       try {
         const resp = await postTask({data: {orgID: org.id, flux: script}})
@@ -165,7 +168,7 @@ export const Provider: FC = ({children}) => {
         }
       }
     } else {
-      event('Export Task Completed', {exportType: 'update'})
+      event('Export Task Completed', {exportType: 'update', from: type})
 
       // TODO: get these values from the query and not the data store
       try {

--- a/src/flows/pipes/Schedule/ExportTaskOverlay/index.tsx
+++ b/src/flows/pipes/Schedule/ExportTaskOverlay/index.tsx
@@ -28,6 +28,7 @@ import {event} from 'src/cloud/utils/reporting'
 
 interface Props {
   text?: string
+  type: string
 }
 const ExportTaskOverlay: FC<Props> = ({text}) => {
   const {activeTab, handleSetActiveTab} = useContext(Context)
@@ -88,8 +89,8 @@ const ExportTaskOverlay: FC<Props> = ({text}) => {
   )
 }
 
-export default ({text}: Props) => (
-  <Provider>
-    <ExportTaskOverlay text={text} />
+export default ({text, type}: Props) => (
+  <Provider type={type}>
+    <ExportTaskOverlay text={text} type={type} />
   </Provider>
 )

--- a/src/flows/pipes/Schedule/view.tsx
+++ b/src/flows/pipes/Schedule/view.tsx
@@ -149,7 +149,11 @@ const Schedule: FC<PipeProp> = ({Context}) => {
   }, [queryText, data.interval, data.offset])
 
   const persist = (
-    <ExportTaskButton generate={generateTask} text="Export as Task" />
+    <ExportTaskButton
+      generate={generateTask}
+      text="Export as Task"
+      type="task"
+    />
   )
 
   return (


### PR DESCRIPTION
something happened and we found we had an issue where notification and alert panels were sharing some events, which means we have to throw out all the user data! This was the fastest way i could shoehorn this into here so we could start getting clean data for reading our funnels