### PR TITLE
fix: add keys to BucketMeta components that are rendered in lists

### DIFF
--- a/src/buckets/components/BucketCardMeta.tsx
+++ b/src/buckets/components/BucketCardMeta.tsx
@@ -43,7 +43,7 @@ const BucketCardMeta: FC<Props> = ({bucket, notify}) => {
   }
 
   const persistentBucketMeta = (
-    <span data-testid="bucket-retention">
+    <span data-testid="bucket-retention" key="bucket-retention">
       Retention: {capitalize(bucket.readableRetention)}
     </span>
   )
@@ -53,7 +53,10 @@ const BucketCardMeta: FC<Props> = ({bucket, notify}) => {
 
   const schemaLabel = `Schema Type: ${capitalize(schemaType)}`
   const schemaBlock = (
-    <span data-testid="bucket-schemaType"> {schemaLabel} </span>
+    <span data-testid="bucket-schemaType" key="bucket-schemaType">
+      {' '}
+      {schemaLabel}{' '}
+    </span>
   )
 
   const bucketInfo = CLOUD

--- a/src/buckets/components/BucketCardMeta.tsx
+++ b/src/buckets/components/BucketCardMeta.tsx
@@ -54,8 +54,7 @@ const BucketCardMeta: FC<Props> = ({bucket, notify}) => {
   const schemaLabel = `Schema Type: ${capitalize(schemaType)}`
   const schemaBlock = (
     <span data-testid="bucket-schemaType" key="bucket-schemaType">
-      {' '}
-      {schemaLabel}{' '}
+      {schemaLabel}
     </span>
   )
 


### PR DESCRIPTION
Closes #2612

Fixes key prop warning by rendering components directly instead of in an array
