### PR TITLE
feat: Edit overlay permissions

### DIFF
--- a/src/authorizations/components/redesigned/EditResourceAccordion.tsx
+++ b/src/authorizations/components/redesigned/EditResourceAccordion.tsx
@@ -1,0 +1,77 @@
+// Libraries
+import {Component} from 'react'
+
+interface Props {
+  permissions: any
+}
+
+export class ResourceAccordion extends Component<Props, {}> {
+  public render() {
+    // const {resources} = this.props // []
+    const {permissions} = this.props
+    /* {
+      "telegrafs": {
+      id: ""
+      orgID:
+      subLevelPermissions: {
+        id: {
+          id: ""
+          permissions: {read: false, write: false}
+        }
+      }
+      },
+      annotations: {read: false, write: false}
+    }
+    */
+
+    console.log(Object.keys(permissions))
+
+    if (!permissions) {
+      return null
+    }
+    // return resources.map(resource => {
+    //   const resourceName = resource.charAt(0).toUpperCase() + resource.slice(1)
+    //   // console.log("resource", resource) resorce = buckets or telegrafs
+    //   console.log(permissions[resource])
+    //   return (
+    //     <Accordion key={resource}>
+    //       <ResourceAccordionHeader
+    //         resourceName={resourceName} // Buckets
+    //         permissions={permissions[resource]} // props.bucketPermissions
+    //         onToggleAll={this.handleToggleAll}
+    //       />
+    //       {resourceName === 'Telegrafs' ||
+    //         (resourceName === 'Buckets' && (
+    //           <GetResources resources={[ResourceType[resourceName]]}>
+    //             {!isEmpty(permissions[resource].sublevelPermissions) &&
+    //               this.getAccordionBody(resourceName, resource)}
+    //           </GetResources>
+    //         ))}
+    //     </Accordion>
+    //   )
+    // })
+  }
+
+  // getAccordionBody = (resourceName, resource) => {
+  //   const {permissions} = this.props
+  //   if (resourceName === 'Telegrafs') {
+  //     return (
+  //       <ResourceAccordionBody
+  //         resourceName={resource}
+  //         permissions={permissions[resource].sublevelPermissions}
+  //         onToggle={this.handleIndividualToggle}
+  //         title="Individual Telegraf Configuration Names"
+  //       />
+  //     )
+  //   } else if (resourceName === 'Buckets') {
+  //     return (
+  //       <ResourceAccordionBody
+  //         resourceName={resource}
+  //         permissions={permissions[resource].sublevelPermissions}
+  //         onToggle={this.handleIndividualToggle}
+  //         title="Individual Bucket Names"
+  //       />
+  //     )
+  //   }
+  }
+}

--- a/src/authorizations/components/redesigned/EditResourceAccordion.tsx
+++ b/src/authorizations/components/redesigned/EditResourceAccordion.tsx
@@ -30,7 +30,7 @@ export class EditResourceAccordion extends Component<Props, {}> {
           {resourceName === 'Telegrafs' ||
             (resourceName === 'Buckets' &&
               !isEmpty(permissions[key].sublevelPermissions) &&
-                this.getAccordionBody(resourceName, key))}
+              this.getAccordionBody(resourceName, key))}
         </Accordion>
       )
     })

--- a/src/authorizations/components/redesigned/EditResourceAccordion.tsx
+++ b/src/authorizations/components/redesigned/EditResourceAccordion.tsx
@@ -22,11 +22,10 @@ export class EditResourceAccordion extends Component<Props, {}> {
       const resourceName = key.charAt(0).toUpperCase() + key.slice(1)
       console.log('resourceName: ', resourceName)
       return (
-        <Accordion key={key}>
+        <Accordion key={key} expanded={true}>
           <ResourceAccordionHeader
             resourceName={resourceName}
             permissions={permissions[key]}
-            onToggleAll={(random, blah) => console.log('ahhh')}
             disabled={true}
           />
           {resourceName === 'Telegrafs' ||
@@ -45,7 +44,6 @@ export class EditResourceAccordion extends Component<Props, {}> {
         <ResourceAccordionBody
           resourceName={resource}
           permissions={permissions[resource].sublevelPermissions}
-          onToggle={(random, blah) => console.log('ahhh')}
           title="Individual Telegraf Configuration Names"
           disabled={true}
         />
@@ -55,7 +53,6 @@ export class EditResourceAccordion extends Component<Props, {}> {
         <ResourceAccordionBody
           resourceName={resource}
           permissions={permissions[resource].sublevelPermissions}
-          onToggle={(random, blah) => console.log('ahhh')}
           title="Individual Bucket Names"
           disabled={true}
         />

--- a/src/authorizations/components/redesigned/EditResourceAccordion.tsx
+++ b/src/authorizations/components/redesigned/EditResourceAccordion.tsx
@@ -20,7 +20,6 @@ export class EditResourceAccordion extends Component<Props, {}> {
 
     return Object.keys(permissions).map(key => {
       const resourceName = key.charAt(0).toUpperCase() + key.slice(1)
-      console.log('resourceName: ', resourceName)
       return (
         <Accordion key={key} expanded={true}>
           <ResourceAccordionHeader

--- a/src/authorizations/components/redesigned/EditResourceAccordion.tsx
+++ b/src/authorizations/components/redesigned/EditResourceAccordion.tsx
@@ -5,7 +5,6 @@ import {isEmpty} from 'lodash'
 import {Accordion} from '@influxdata/clockface'
 
 import {ResourceAccordionHeader} from './ResourceAccordionHeader'
-import GetResources from 'src/resources/components/GetResources'
 import {ResourceAccordionBody} from './ResourceAccordionBody'
 
 interface Props {
@@ -19,12 +18,6 @@ export class EditResourceAccordion extends Component<Props, {}> {
       return null
     }
 
-    return <>{this.getAccordionHeader()}</>
-  }
-
-  getAccordionHeader = () => {
-    const {permissions} = this.props
-
     return Object.keys(permissions).map(key => {
       const resourceName = key.charAt(0).toUpperCase() + key.slice(1)
       console.log('resourceName: ', resourceName)
@@ -32,38 +25,41 @@ export class EditResourceAccordion extends Component<Props, {}> {
         <Accordion key={key}>
           <ResourceAccordionHeader
             resourceName={resourceName}
-            permissions={permissions[key]} // props.bucketPermissions
+            permissions={permissions[key]}
             onToggleAll={(random, blah) => console.log('ahhh')}
+            disabled={true}
           />
-          {/* {resourceName === 'Telegrafs' ||
-              (resourceName === 'Buckets' && (
-                  !isEmpty(permissions[key].sublevelPermissions) &&
-                    this.getAccordionBody(resourceName, key)
-              ))} */}
+          {resourceName === 'Telegrafs' ||
+            (resourceName === 'Buckets' &&
+              !isEmpty(permissions[key].sublevelPermissions) &&
+                this.getAccordionBody(resourceName, key))}
         </Accordion>
       )
     })
   }
-}
 
-// getAccordionBody = (resourceName, resource) => {
-//   const {permissions} = this.props
-//   if (resourceName === 'Telegrafs') {
-//     return (
-//       <ResourceAccordionBody
-//         resourceName={resource}
-//         permissions={permissions[resource].sublevelPermissions}
-//         onToggle={this.handleIndividualToggle}
-//         title="Individual Telegraf Configuration Names"
-//       />
-//     )
-//   } else if (resourceName === 'Buckets') {
-//     return (
-//       <ResourceAccordionBody
-//         resourceName={resource}
-//         permissions={permissions[resource].sublevelPermissions}
-//         onToggle={this.handleIndividualToggle}
-//         title="Individual Bucket Names"
-//       />
-//     )
-//   }
+  getAccordionBody = (resourceName, resource) => {
+    const {permissions} = this.props
+    if (resourceName === 'Telegrafs') {
+      return (
+        <ResourceAccordionBody
+          resourceName={resource}
+          permissions={permissions[resource].sublevelPermissions}
+          onToggle={(random, blah) => console.log('ahhh')}
+          title="Individual Telegraf Configuration Names"
+          disabled={true}
+        />
+      )
+    } else if (resourceName === 'Buckets') {
+      return (
+        <ResourceAccordionBody
+          resourceName={resource}
+          permissions={permissions[resource].sublevelPermissions}
+          onToggle={(random, blah) => console.log('ahhh')}
+          title="Individual Bucket Names"
+          disabled={true}
+        />
+      )
+    }
+  }
+}

--- a/src/authorizations/components/redesigned/EditResourceAccordion.tsx
+++ b/src/authorizations/components/redesigned/EditResourceAccordion.tsx
@@ -1,77 +1,69 @@
 // Libraries
-import {Component} from 'react'
+import React, {Component} from 'react'
+import {isEmpty} from 'lodash'
+
+import {Accordion} from '@influxdata/clockface'
+
+import {ResourceAccordionHeader} from './ResourceAccordionHeader'
+import GetResources from 'src/resources/components/GetResources'
+import {ResourceAccordionBody} from './ResourceAccordionBody'
 
 interface Props {
   permissions: any
 }
 
-export class ResourceAccordion extends Component<Props, {}> {
+export class EditResourceAccordion extends Component<Props, {}> {
   public render() {
-    // const {resources} = this.props // []
     const {permissions} = this.props
-    /* {
-      "telegrafs": {
-      id: ""
-      orgID:
-      subLevelPermissions: {
-        id: {
-          id: ""
-          permissions: {read: false, write: false}
-        }
-      }
-      },
-      annotations: {read: false, write: false}
-    }
-    */
-
-    console.log(Object.keys(permissions))
-
     if (!permissions) {
       return null
     }
-    // return resources.map(resource => {
-    //   const resourceName = resource.charAt(0).toUpperCase() + resource.slice(1)
-    //   // console.log("resource", resource) resorce = buckets or telegrafs
-    //   console.log(permissions[resource])
-    //   return (
-    //     <Accordion key={resource}>
-    //       <ResourceAccordionHeader
-    //         resourceName={resourceName} // Buckets
-    //         permissions={permissions[resource]} // props.bucketPermissions
-    //         onToggleAll={this.handleToggleAll}
-    //       />
-    //       {resourceName === 'Telegrafs' ||
-    //         (resourceName === 'Buckets' && (
-    //           <GetResources resources={[ResourceType[resourceName]]}>
-    //             {!isEmpty(permissions[resource].sublevelPermissions) &&
-    //               this.getAccordionBody(resourceName, resource)}
-    //           </GetResources>
-    //         ))}
-    //     </Accordion>
-    //   )
-    // })
+
+    return <>{this.getAccordionHeader()}</>
   }
 
-  // getAccordionBody = (resourceName, resource) => {
-  //   const {permissions} = this.props
-  //   if (resourceName === 'Telegrafs') {
-  //     return (
-  //       <ResourceAccordionBody
-  //         resourceName={resource}
-  //         permissions={permissions[resource].sublevelPermissions}
-  //         onToggle={this.handleIndividualToggle}
-  //         title="Individual Telegraf Configuration Names"
-  //       />
-  //     )
-  //   } else if (resourceName === 'Buckets') {
-  //     return (
-  //       <ResourceAccordionBody
-  //         resourceName={resource}
-  //         permissions={permissions[resource].sublevelPermissions}
-  //         onToggle={this.handleIndividualToggle}
-  //         title="Individual Bucket Names"
-  //       />
-  //     )
-  //   }
+  getAccordionHeader = () => {
+    const {permissions} = this.props
+
+    return Object.keys(permissions).map(key => {
+      const resourceName = key.charAt(0).toUpperCase() + key.slice(1)
+      console.log('resourceName: ', resourceName)
+      return (
+        <Accordion key={key}>
+          <ResourceAccordionHeader
+            resourceName={resourceName}
+            permissions={permissions[key]} // props.bucketPermissions
+            onToggleAll={(random, blah) => console.log('ahhh')}
+          />
+          {/* {resourceName === 'Telegrafs' ||
+              (resourceName === 'Buckets' && (
+                  !isEmpty(permissions[key].sublevelPermissions) &&
+                    this.getAccordionBody(resourceName, key)
+              ))} */}
+        </Accordion>
+      )
+    })
   }
 }
+
+// getAccordionBody = (resourceName, resource) => {
+//   const {permissions} = this.props
+//   if (resourceName === 'Telegrafs') {
+//     return (
+//       <ResourceAccordionBody
+//         resourceName={resource}
+//         permissions={permissions[resource].sublevelPermissions}
+//         onToggle={this.handleIndividualToggle}
+//         title="Individual Telegraf Configuration Names"
+//       />
+//     )
+//   } else if (resourceName === 'Buckets') {
+//     return (
+//       <ResourceAccordionBody
+//         resourceName={resource}
+//         permissions={permissions[resource].sublevelPermissions}
+//         onToggle={this.handleIndividualToggle}
+//         title="Individual Bucket Names"
+//       />
+//     )
+//   }

--- a/src/authorizations/components/redesigned/EditResourceAccordion.tsx
+++ b/src/authorizations/components/redesigned/EditResourceAccordion.tsx
@@ -7,7 +7,6 @@ import {Accordion} from '@influxdata/clockface'
 import {ResourceAccordionHeader} from 'src/authorizations/components/redesigned/ResourceAccordionHeader'
 import {ResourceAccordionBody} from 'src/authorizations/components/redesigned/ResourceAccordionBody'
 
-
 interface Props {
   permissions: any
 }
@@ -19,7 +18,7 @@ export class EditResourceAccordion extends Component<Props> {
       return null
     }
 
-    return Object.keys(permissions).map(key => { 
+    return Object.keys(permissions).map(key => {
       const resourceName = capitalize(key)
       return (
         <Accordion key={key} expanded={true}>

--- a/src/authorizations/components/redesigned/EditResourceAccordion.tsx
+++ b/src/authorizations/components/redesigned/EditResourceAccordion.tsx
@@ -1,25 +1,26 @@
 // Libraries
 import React, {Component} from 'react'
-import {isEmpty} from 'lodash'
+import {isEmpty, capitalize} from 'lodash'
 
 import {Accordion} from '@influxdata/clockface'
 
-import {ResourceAccordionHeader} from './ResourceAccordionHeader'
-import {ResourceAccordionBody} from './ResourceAccordionBody'
+import {ResourceAccordionHeader} from 'src/authorizations/components/redesigned/ResourceAccordionHeader'
+import {ResourceAccordionBody} from 'src/authorizations/components/redesigned/ResourceAccordionBody'
+
 
 interface Props {
   permissions: any
 }
 
-export class EditResourceAccordion extends Component<Props, {}> {
+export class EditResourceAccordion extends Component<Props> {
   public render() {
     const {permissions} = this.props
     if (!permissions) {
       return null
     }
 
-    return Object.keys(permissions).map(key => {
-      const resourceName = key.charAt(0).toUpperCase() + key.slice(1)
+    return Object.keys(permissions).map(key => { 
+      const resourceName = capitalize(key)
       return (
         <Accordion key={key} expanded={true}>
           <ResourceAccordionHeader

--- a/src/authorizations/components/redesigned/EditTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/EditTokenOverlay.tsx
@@ -24,7 +24,7 @@ import {Authorization} from 'src/types'
 
 // Actions
 import {updateAuthorization} from 'src/authorizations/actions/thunks'
-import { ActionTypes } from 'src/shared/actions/app'
+import {ActionTypes} from 'src/shared/actions/app'
 
 interface OwnProps {
   auth: Authorization
@@ -72,15 +72,19 @@ const EditTokenOverlay: FC<Props> = props => {
 
     const newPerms = {}
     permissions.map(perm => {
-
-      let p 
-        if((newPerms.hasOwnProperty(perm.resource.type))){
-          p = {...newPerms[perm.resource.type]}
-          if(perm.resource.id && (perm.resource.type === 'buckets' || perm.resource.type === 'telegrafs')) {
-            if(p.sublevelPermissions.hasOwnProperty(perm.resource.id)) {
-              p.sublevelPermissions[perm.resource.id].permissions[perm.action] = true
-            }
-            else {
+      let p
+      if (newPerms.hasOwnProperty(perm.resource.type)) {
+        p = {...newPerms[perm.resource.type]}
+        if (
+          perm.resource.id &&
+          (perm.resource.type === 'buckets' ||
+            perm.resource.type === 'telegrafs')
+        ) {
+          if (p.sublevelPermissions.hasOwnProperty(perm.resource.id)) {
+            p.sublevelPermissions[perm.resource.id].permissions[
+              perm.action
+            ] = true
+          } else {
             p.sublevelPermissions[perm.resource.id] = {
               id: perm.resource.id,
               orgID: perm.resource.orgID,
@@ -91,35 +95,36 @@ const EditTokenOverlay: FC<Props> = props => {
               },
             }
           }
+        } else {
+          p[perm.action] = true
+        }
+      } else {
+        if (
+          perm.resource.id &&
+          (perm.resource.type === 'buckets' ||
+            perm.resource.type === 'telegrafs')
+        ) {
+          p = {
+            read: false,
+            write: false,
+            sublevelPermissions: {
+              [perm.resource.id]: {
+                id: perm.resource.id,
+                orgID: perm.resource.orgID,
+                name: perm.resource.name,
+                permissions: {
+                  read: perm.action === 'read',
+                  write: perm.action === 'write',
+                },
+              },
+            },
           }
-          else {
-            p[perm.action] = true
+        } else {
+          p = {
+            read: perm.action === 'read',
+            write: perm.action === 'write',
           }
         }
-        else {
-          if(perm.resource.id && (perm.resource.type === 'buckets' || perm.resource.type === 'telegrafs')){
-            p = {
-              read: false,
-              write: false,
-              sublevelPermissions: {
-                [perm.resource.id]: {
-                  id: perm.resource.id,
-                  orgID: perm.resource.orgID,
-                  name: perm.resource.name,
-                  permissions: {
-                    read: perm.action === 'read',
-                    write: perm.action === 'write',
-                  },
-                }
-              }
-            }
-          }
-          else {
-            p = {
-              read: perm.action === "read",
-              write: perm.action === "write"
-            }
-          }
       }
 
       newPerms[perm.resource.type] = p
@@ -128,23 +133,14 @@ const EditTokenOverlay: FC<Props> = props => {
     Object.keys(newPerms).map(resource => {
       const p = {...newPerms[resource]}
       if (p.sublevelPermissions) {
-        console.log("inside if statment")
-        p.read = !Object.keys(
-          p.sublevelPermissions
-        ).some(
-          key =>
-            p.sublevelPermissions[key].permissions.read ===
-            false
+        p.read = !Object.keys(p.sublevelPermissions).some(
+          key => p.sublevelPermissions[key].permissions.read === false
         )
-  
-        p.write = !Object.keys(
-          p.sublevelPermissions
-        ).some(
-          key =>
-            p.sublevelPermissions[key].permissions.write ===
-            false
+
+        p.write = !Object.keys(p.sublevelPermissions).some(
+          key => p.sublevelPermissions[key].permissions.write === false
         )
-  
+
         newPerms[resource] = p
       }
     })

--- a/src/authorizations/components/redesigned/EditTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/EditTokenOverlay.tsx
@@ -18,7 +18,7 @@ import {
   ComponentColor,
   Page,
 } from '@influxdata/clockface'
-import {EditResourceAccordion} from './EditResourceAccordion'
+import {EditResourceAccordion} from 'src/authorizations/components/redesigned/EditResourceAccordion'
 
 // Types
 import {Authorization} from 'src/types'
@@ -27,7 +27,7 @@ import {Authorization} from 'src/types'
 import {updateAuthorization} from 'src/authorizations/actions/thunks'
 
 // Utills
-import {formatPermissionsObj} from './../../utils/permissions'
+import {formatPermissionsObj} from 'src/authorizations/utils/permissions'
 
 interface OwnProps {
   auth: Authorization

--- a/src/authorizations/components/redesigned/EditTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/EditTokenOverlay.tsx
@@ -18,6 +18,7 @@ import {
   ComponentColor,
   Page,
 } from '@influxdata/clockface'
+import {EditResourceAccordion} from './EditResourceAccordion'
 
 // Types
 import {Authorization} from 'src/types'
@@ -74,6 +75,7 @@ const EditTokenOverlay: FC<Props> = props => {
     const newPerms = permissions.reduce((acc, {action, resource}) => {
       const {type, id, orgID, name} = resource
       let p
+
       if (acc.hasOwnProperty(type)) {
         p = {...acc[type]}
         if (id && (type === 'buckets' || type === 'telegrafs')) {
@@ -136,9 +138,8 @@ const EditTokenOverlay: FC<Props> = props => {
       }
     })
     console.log('updated PERMS: ', newPerms)
+    return newPerms
   }
-
-  formatPermissionsObj()
 
   return (
     <Overlay.Container maxWidth={630}>
@@ -206,7 +207,7 @@ const EditTokenOverlay: FC<Props> = props => {
                   </InputLabel>
                 </FlexBox.Child>
               </FlexBox>
-              {/* <ResourceAccordion resources={resources} /> */}
+              <EditResourceAccordion permissions={formatPermissionsObj()} />
             </FlexBox.Child>
             <Page.ControlBarCenter>
               <FlexBox margin={ComponentSize.Medium}>

--- a/src/authorizations/components/redesigned/EditTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/EditTokenOverlay.tsx
@@ -64,6 +64,41 @@ const EditTokenOverlay: FC<Props> = props => {
     handleDismiss()
   }
   console.log(props.auth)
+
+  const formatPermissionsObj = () => {
+    const {
+      auth: {permissions},
+    } = props
+
+    const newPerms = {}
+    permissions.map(perm => {
+      const p = {
+        read: perm.action === 'read',
+        write: perm.action === 'write',
+        // todo: add only for telegrafs and buckets
+        subLevelPermissions: {},
+      }
+
+      if (perm.resource.id) {
+        p.subLevelPermissions[perm.resource.id] = {
+          id: perm.resource.id,
+          orgID: perm.resource.orgID,
+          name: perm.resource.name,
+          permissions: {
+            read: perm.action === 'read',
+            write: perm.action === 'write',
+          },
+        }
+      }
+
+      newPerms[perm.resource.type] = p
+    })
+    console.log('NEw PERMISSIONS: ', newPerms)
+  }
+
+  formatPermissionsObj()
+
+  // manipulate to match the accordion permissions
   return (
     <Overlay.Container maxWidth={630}>
       <Overlay.Header title="API Token Summary" onDismiss={handleDismiss} />

--- a/src/authorizations/components/redesigned/EditTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/EditTokenOverlay.tsx
@@ -68,8 +68,6 @@ const EditTokenOverlay: FC<Props> = props => {
     handleDismiss()
   }
 
-  
-
   return (
     <Overlay.Container maxWidth={630}>
       <Overlay.Header title="API Token Summary" onDismiss={handleDismiss} />
@@ -136,7 +134,9 @@ const EditTokenOverlay: FC<Props> = props => {
                   </InputLabel>
                 </FlexBox.Child>
               </FlexBox>
-              <EditResourceAccordion permissions={formatPermissionsObj(props.auth.permissions)} />
+              <EditResourceAccordion
+                permissions={formatPermissionsObj(props.auth.permissions)}
+              />
             </FlexBox.Child>
             <Page.ControlBarCenter>
               <FlexBox margin={ComponentSize.Medium}>

--- a/src/authorizations/components/redesigned/EditTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/EditTokenOverlay.tsx
@@ -26,6 +26,9 @@ import {Authorization} from 'src/types'
 // Actions
 import {updateAuthorization} from 'src/authorizations/actions/thunks'
 
+// Utills
+import {formatPermissionsObj} from './../../utils/permissions'
+
 interface OwnProps {
   auth: Authorization
   onDismissOverlay: () => void
@@ -65,81 +68,7 @@ const EditTokenOverlay: FC<Props> = props => {
     handleDismiss()
   }
 
-  console.log('props.auth: ', props.auth)
-
-  const formatPermissionsObj = () => {
-    const {
-      auth: {permissions},
-    } = props
-
-    const newPerms = permissions.reduce((acc, {action, resource}) => {
-      const {type, id, orgID, name} = resource
-      let p
-
-      if (acc.hasOwnProperty(type)) {
-        p = {...acc[type]}
-        if (id && (type === 'buckets' || type === 'telegrafs')) {
-          if (p.sublevelPermissions.hasOwnProperty(id)) {
-            p.sublevelPermissions[id].permissions[action] = true
-          } else {
-            p.sublevelPermissions[id] = {
-              id: id,
-              orgID: orgID,
-              name: name,
-              permissions: {
-                read: action === 'read',
-                write: action === 'write',
-              },
-            }
-          }
-        } else {
-          p[action] = true
-        }
-      } else {
-        if (id && (type === 'buckets' || type === 'telegrafs')) {
-          p = {
-            read: false,
-            write: false,
-            sublevelPermissions: {
-              [id]: {
-                id: id,
-                orgID: orgID,
-                name: name,
-                permissions: {
-                  read: action === 'read',
-                  write: action === 'write',
-                },
-              },
-            },
-          }
-        } else {
-          p = {
-            read: action === 'read',
-            write: action === 'write',
-          }
-        }
-      }
-
-      return {...acc, [type]: p}
-    }, {})
-
-    Object.keys(newPerms).map(resource => {
-      const p = {...newPerms[resource]}
-      if (p.sublevelPermissions) {
-        p.read = !Object.keys(p.sublevelPermissions).some(
-          key => p.sublevelPermissions[key].permissions.read === false
-        )
-
-        p.write = !Object.keys(p.sublevelPermissions).some(
-          key => p.sublevelPermissions[key].permissions.write === false
-        )
-
-        newPerms[resource] = p
-      }
-    })
-    console.log('updated PERMS: ', newPerms)
-    return newPerms
-  }
+  
 
   return (
     <Overlay.Container maxWidth={630}>
@@ -207,7 +136,7 @@ const EditTokenOverlay: FC<Props> = props => {
                   </InputLabel>
                 </FlexBox.Child>
               </FlexBox>
-              <EditResourceAccordion permissions={formatPermissionsObj()} />
+              <EditResourceAccordion permissions={formatPermissionsObj(props.auth.permissions)} />
             </FlexBox.Child>
             <Page.ControlBarCenter>
               <FlexBox margin={ComponentSize.Medium}>

--- a/src/authorizations/components/redesigned/EditTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/EditTokenOverlay.tsx
@@ -72,27 +72,79 @@ const EditTokenOverlay: FC<Props> = props => {
 
     const newPerms = {}
     permissions.map(perm => {
-      const p = {
-        read: perm.action === 'read',
-        write: perm.action === 'write',
-        // todo: add only for telegrafs and buckets
-        subLevelPermissions: {},
-      }
 
-      if (perm.resource.id) {
-        p.subLevelPermissions[perm.resource.id] = {
-          id: perm.resource.id,
-          orgID: perm.resource.orgID,
-          name: perm.resource.name,
-          permissions: {
-            read: perm.action === 'read',
-            write: perm.action === 'write',
-          },
+      let p 
+      if(perm.resource.type === 'buckets') {
+        if((newPerms.hasOwnProperty(perm.resource.type))){
+          p = {...newPerms[perm.resource.type]}
+          if(perm.resource.id) {
+            if(p.subLevelPermissions.hasOwnProperty(perm.resource.id)) {
+              p.subLevelPermissions[perm.resource.id].permissions[perm.action] = true
+            }
+            else {
+            p.subLevelPermissions[perm.resource.id] = {
+              id: perm.resource.id,
+              orgID: perm.resource.orgID,
+              name: perm.resource.name,
+              permissions: {
+                read: perm.action === 'read',
+                write: perm.action === 'write',
+              },
+            }
+          }
+          }
         }
+        else {
+          if(perm.resource.id){
+            p = {
+              read: false,
+              write: false,
+              subLevelPermissions: {
+                [perm.resource.id]: {
+                  id: perm.resource.id,
+                  orgID: perm.resource.orgID,
+                  name: perm.resource.name,
+                  permissions: {
+                    read: perm.action === 'read',
+                    write: perm.action === 'write',
+                  },
+                }
+              }
+            }
+          }
+          else {
+            p = {
+              read: perm.action === "read",
+              write: perm.action === "write"
+            }
+          }
       }
 
       newPerms[perm.resource.type] = p
     })
+
+    Object.keys(newPerms).map(resource => {
+      const p = {...newPerms[resource]}
+
+      p.read = !Object.keys(
+        p.subLevelPermissions
+      ).some(
+        key =>
+          p.subLevelPermissions[key].permissions.read ===
+          false
+      )
+
+      p.write = !Object.keys(
+        p.subLevelPermissions
+      ).some(
+        key =>
+          p.subLevelPermissions[key].permissions.write ===
+          false
+      )
+
+      newPerms[resource] = p
+    })
+
     console.log('NEw PERMISSIONS: ', newPerms)
   }
 

--- a/src/authorizations/components/redesigned/EditTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/EditTokenOverlay.tsx
@@ -63,7 +63,7 @@ const EditTokenOverlay: FC<Props> = props => {
     })
     handleDismiss()
   }
-
+  console.log(props.auth)
   return (
     <Overlay.Container maxWidth={630}>
       <Overlay.Header title="API Token Summary" onDismiss={handleDismiss} />
@@ -99,6 +99,39 @@ const EditTokenOverlay: FC<Props> = props => {
                 />
               </Form.Element>
             </FlexBox>
+            <FlexBox.Child className="main-flexbox-child">
+              <FlexBox
+                margin={ComponentSize.Large}
+                justifyContent={JustifyContent.SpaceBetween}
+                direction={FlexDirection.Row}
+                stretchToFitWidth={true}
+                alignItems={AlignItems.Center}
+                className="flex-box-label"
+              >
+                <FlexBox.Child basis={40} grow={8}>
+                  <InputLabel size={ComponentSize.ExtraSmall}>
+                    Resources
+                  </InputLabel>
+                </FlexBox.Child>
+                <FlexBox.Child grow={1} className="flexbox-child-label-read">
+                  <InputLabel
+                    className="input-label-read"
+                    size={ComponentSize.ExtraSmall}
+                  >
+                    Read
+                  </InputLabel>
+                </FlexBox.Child>
+                <FlexBox.Child grow={1} className="flexbox-child-label-write">
+                  <InputLabel
+                    className="input-label-write"
+                    size={ComponentSize.ExtraSmall}
+                  >
+                    Write
+                  </InputLabel>
+                </FlexBox.Child>
+              </FlexBox>
+              {/* <ResourceAccordion resources={resources} /> */}
+            </FlexBox.Child>
             <Page.ControlBarCenter>
               <FlexBox margin={ComponentSize.Medium}>
                 <Button

--- a/src/authorizations/components/redesigned/EditTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/EditTokenOverlay.tsx
@@ -24,6 +24,7 @@ import {Authorization} from 'src/types'
 
 // Actions
 import {updateAuthorization} from 'src/authorizations/actions/thunks'
+import { ActionTypes } from 'src/shared/actions/app'
 
 interface OwnProps {
   auth: Authorization
@@ -63,7 +64,6 @@ const EditTokenOverlay: FC<Props> = props => {
     })
     handleDismiss()
   }
-  console.log(props.auth)
 
   const formatPermissionsObj = () => {
     const {
@@ -74,15 +74,14 @@ const EditTokenOverlay: FC<Props> = props => {
     permissions.map(perm => {
 
       let p 
-      if(perm.resource.type === 'buckets') {
         if((newPerms.hasOwnProperty(perm.resource.type))){
           p = {...newPerms[perm.resource.type]}
-          if(perm.resource.id) {
-            if(p.subLevelPermissions.hasOwnProperty(perm.resource.id)) {
-              p.subLevelPermissions[perm.resource.id].permissions[perm.action] = true
+          if(perm.resource.id && (perm.resource.type === 'buckets' || perm.resource.type === 'telegrafs')) {
+            if(p.sublevelPermissions.hasOwnProperty(perm.resource.id)) {
+              p.sublevelPermissions[perm.resource.id].permissions[perm.action] = true
             }
             else {
-            p.subLevelPermissions[perm.resource.id] = {
+            p.sublevelPermissions[perm.resource.id] = {
               id: perm.resource.id,
               orgID: perm.resource.orgID,
               name: perm.resource.name,
@@ -93,13 +92,16 @@ const EditTokenOverlay: FC<Props> = props => {
             }
           }
           }
+          else {
+            p[perm.action] = true
+          }
         }
         else {
-          if(perm.resource.id){
+          if(perm.resource.id && (perm.resource.type === 'buckets' || perm.resource.type === 'telegrafs')){
             p = {
               read: false,
               write: false,
-              subLevelPermissions: {
+              sublevelPermissions: {
                 [perm.resource.id]: {
                   id: perm.resource.id,
                   orgID: perm.resource.orgID,
@@ -125,32 +127,31 @@ const EditTokenOverlay: FC<Props> = props => {
 
     Object.keys(newPerms).map(resource => {
       const p = {...newPerms[resource]}
-
-      p.read = !Object.keys(
-        p.subLevelPermissions
-      ).some(
-        key =>
-          p.subLevelPermissions[key].permissions.read ===
-          false
-      )
-
-      p.write = !Object.keys(
-        p.subLevelPermissions
-      ).some(
-        key =>
-          p.subLevelPermissions[key].permissions.write ===
-          false
-      )
-
-      newPerms[resource] = p
+      if (p.sublevelPermissions) {
+        console.log("inside if statment")
+        p.read = !Object.keys(
+          p.sublevelPermissions
+        ).some(
+          key =>
+            p.sublevelPermissions[key].permissions.read ===
+            false
+        )
+  
+        p.write = !Object.keys(
+          p.sublevelPermissions
+        ).some(
+          key =>
+            p.sublevelPermissions[key].permissions.write ===
+            false
+        )
+  
+        newPerms[resource] = p
+      }
     })
-
-    console.log('NEw PERMISSIONS: ', newPerms)
   }
 
   formatPermissionsObj()
 
-  // manipulate to match the accordion permissions
   return (
     <Overlay.Container maxWidth={630}>
       <Overlay.Header title="API Token Summary" onDismiss={handleDismiss} />

--- a/src/authorizations/components/redesigned/ResourceAccordion.tsx
+++ b/src/authorizations/components/redesigned/ResourceAccordion.tsx
@@ -88,6 +88,7 @@ class ResourceAccordion extends Component<Props, State> {
             resourceName={resourceName} // Buckets
             permissions={permissions[resource]} // props.bucketPermissions
             onToggleAll={this.handleToggleAll}
+            disabled={false}
           />
           {resourceName === 'Telegrafs' ||
             (resourceName === 'Buckets' && (
@@ -110,6 +111,7 @@ class ResourceAccordion extends Component<Props, State> {
           permissions={permissions[resource].sublevelPermissions}
           onToggle={this.handleIndividualToggle}
           title="Individual Telegraf Configuration Names"
+          disabled={false}
         />
       )
     } else if (resourceName === 'Buckets') {
@@ -119,6 +121,7 @@ class ResourceAccordion extends Component<Props, State> {
           permissions={permissions[resource].sublevelPermissions}
           onToggle={this.handleIndividualToggle}
           title="Individual Bucket Names"
+          disabled={false}
         />
       )
     }

--- a/src/authorizations/components/redesigned/ResourceAccordion.tsx
+++ b/src/authorizations/components/redesigned/ResourceAccordion.tsx
@@ -80,13 +80,12 @@ class ResourceAccordion extends Component<Props, State> {
     }
     return resources.map(resource => {
       const resourceName = resource.charAt(0).toUpperCase() + resource.slice(1)
-      // console.log("resource", resource) resorce = buckets or telegrafs
-      console.log(permissions[resource])
+  
       return (
         <Accordion key={resource}>
           <ResourceAccordionHeader
-            resourceName={resourceName} // Buckets
-            permissions={permissions[resource]} // props.bucketPermissions
+            resourceName={resourceName} 
+            permissions={permissions[resource]} 
             onToggleAll={this.handleToggleAll}
             disabled={false}
           />
@@ -128,7 +127,6 @@ class ResourceAccordion extends Component<Props, State> {
   }
 
   handleToggleAll = (resourceName, permission) => {
-    // resourceName = Buckets || Telegrafs & permission = read || write
     const {permissions} = this.state
 
     const newPerm = {...permissions}

--- a/src/authorizations/components/redesigned/ResourceAccordion.tsx
+++ b/src/authorizations/components/redesigned/ResourceAccordion.tsx
@@ -4,9 +4,9 @@ import {isEmpty} from 'lodash'
 
 // Clockface
 import {Accordion} from '@influxdata/clockface'
-import {ResourceAccordionHeader} from './ResourceAccordionHeader'
+import {ResourceAccordionHeader} from 'src/authorizations/components/redesigned/ResourceAccordionHeader'
 import GetResources from 'src/resources/components/GetResources'
-import {ResourceAccordionBody} from './ResourceAccordionBody'
+import {ResourceAccordionBody} from 'src/authorizations/components/redesigned/ResourceAccordionBody'
 
 // Types
 import {AppState, Telegraf, ResourceType} from 'src/types'

--- a/src/authorizations/components/redesigned/ResourceAccordion.tsx
+++ b/src/authorizations/components/redesigned/ResourceAccordion.tsx
@@ -80,12 +80,13 @@ class ResourceAccordion extends Component<Props, State> {
     }
     return resources.map(resource => {
       const resourceName = resource.charAt(0).toUpperCase() + resource.slice(1)
-
+      // console.log("resource", resource) resorce = buckets or telegrafs
+      console.log(permissions[resource])
       return (
         <Accordion key={resource}>
           <ResourceAccordionHeader
-            resourceName={resourceName}
-            permissions={permissions[resource]}
+            resourceName={resourceName} // Buckets
+            permissions={permissions[resource]} // props.bucketPermissions
             onToggleAll={this.handleToggleAll}
           />
           {resourceName === 'Telegrafs' ||
@@ -124,6 +125,7 @@ class ResourceAccordion extends Component<Props, State> {
   }
 
   handleToggleAll = (resourceName, permission) => {
+    // resourceName = Buckets || Telegrafs & permission = read || write
     const {permissions} = this.state
 
     const newPerm = {...permissions}

--- a/src/authorizations/components/redesigned/ResourceAccordion.tsx
+++ b/src/authorizations/components/redesigned/ResourceAccordion.tsx
@@ -80,12 +80,12 @@ class ResourceAccordion extends Component<Props, State> {
     }
     return resources.map(resource => {
       const resourceName = resource.charAt(0).toUpperCase() + resource.slice(1)
-  
+
       return (
         <Accordion key={resource}>
           <ResourceAccordionHeader
-            resourceName={resourceName} 
-            permissions={permissions[resource]} 
+            resourceName={resourceName}
+            permissions={permissions[resource]}
             onToggleAll={this.handleToggleAll}
             disabled={false}
           />

--- a/src/authorizations/components/redesigned/ResourceAccordionBody.tsx
+++ b/src/authorizations/components/redesigned/ResourceAccordionBody.tsx
@@ -52,7 +52,7 @@ export const ResourceAccordionBody: FC<Props> = props => {
           type={InputToggleType.Checkbox}
           onChange={handleReadToggle}
           size={ComponentSize.ExtraSmall}
-          checked={telegraf.permissions.read} // sublevelPermissions.permissions.read = true or false
+          checked={telegraf.permissions.read} 
           style={{marginRight: '10px'}}
           tabIndex={0}
           disabled={disabled}

--- a/src/authorizations/components/redesigned/ResourceAccordionBody.tsx
+++ b/src/authorizations/components/redesigned/ResourceAccordionBody.tsx
@@ -52,7 +52,7 @@ export const ResourceAccordionBody: FC<Props> = props => {
           type={InputToggleType.Checkbox}
           onChange={handleReadToggle}
           size={ComponentSize.ExtraSmall}
-          checked={telegraf.permissions.read} 
+          checked={telegraf.permissions.read}
           style={{marginRight: '10px'}}
           tabIndex={0}
           disabled={disabled}

--- a/src/authorizations/components/redesigned/ResourceAccordionBody.tsx
+++ b/src/authorizations/components/redesigned/ResourceAccordionBody.tsx
@@ -20,10 +20,11 @@ interface Props {
   permissions: any
   onToggle: (name, id, permission) => void
   title: string
+  disabled: boolean
 }
 
 export const ResourceAccordionBody: FC<Props> = props => {
-  const {resourceName, permissions, onToggle, title} = props
+  const {resourceName, permissions, onToggle, title, disabled} = props
 
   const handleReadToggle = id => {
     onToggle(resourceName, id, PermissionType.Read)
@@ -51,10 +52,10 @@ export const ResourceAccordionBody: FC<Props> = props => {
           type={InputToggleType.Checkbox}
           onChange={handleReadToggle}
           size={ComponentSize.ExtraSmall}
-          checked={telegraf.permissions.read} // sublevelPermissions.permissions.read = true or false 
+          checked={telegraf.permissions.read} // sublevelPermissions.permissions.read = true or false
           style={{marginRight: '10px'}}
           tabIndex={0}
-          disabled={false}
+          disabled={disabled}
         ></Toggle>
       </FlexBox.Child>
       <FlexBox.Child grow={1}>
@@ -67,7 +68,7 @@ export const ResourceAccordionBody: FC<Props> = props => {
           checked={telegraf.permissions.write}
           style={{marginRight: '10px'}}
           tabIndex={0}
-          disabled={false}
+          disabled={disabled}
         ></Toggle>
       </FlexBox.Child>
     </FlexBox>

--- a/src/authorizations/components/redesigned/ResourceAccordionBody.tsx
+++ b/src/authorizations/components/redesigned/ResourceAccordionBody.tsx
@@ -18,7 +18,7 @@ import {PermissionType} from 'src/types/tokens'
 interface Props {
   resourceName: string
   permissions: any
-  onToggle: (name, id, permission) => void
+  onToggle?: (name, id, permission) => void
   title: string
   disabled: boolean
 }

--- a/src/authorizations/components/redesigned/ResourceAccordionBody.tsx
+++ b/src/authorizations/components/redesigned/ResourceAccordionBody.tsx
@@ -51,7 +51,7 @@ export const ResourceAccordionBody: FC<Props> = props => {
           type={InputToggleType.Checkbox}
           onChange={handleReadToggle}
           size={ComponentSize.ExtraSmall}
-          checked={telegraf.permissions.read}
+          checked={telegraf.permissions.read} // sublevelPermissions.permissions.read = true or false 
           style={{marginRight: '10px'}}
           tabIndex={0}
           disabled={false}

--- a/src/authorizations/components/redesigned/ResourceAccordionHeader.tsx
+++ b/src/authorizations/components/redesigned/ResourceAccordionHeader.tsx
@@ -16,7 +16,7 @@ import {
 interface OwnProps {
   resourceName: string
   permissions: any
-  onToggleAll: (name: string, permission: string) => void
+  onToggleAll?: (name: string, permission: string) => void
   disabled: boolean
 }
 

--- a/src/authorizations/components/redesigned/ResourceAccordionHeader.tsx
+++ b/src/authorizations/components/redesigned/ResourceAccordionHeader.tsx
@@ -17,10 +17,11 @@ interface OwnProps {
   resourceName: string
   permissions: any
   onToggleAll: (name: string, permission: string) => void
+  disabled: boolean
 }
 
 export const ResourceAccordionHeader: FC<OwnProps> = props => {
-  const {resourceName} = props
+  const {resourceName, disabled} = props
 
   const handleReadToggle = () => {
     const {onToggleAll, resourceName} = props
@@ -59,7 +60,7 @@ export const ResourceAccordionHeader: FC<OwnProps> = props => {
             value={permissions.read.toString()}
             style={{marginRight: '10px'}}
             tabIndex={0}
-            disabled={false}
+            disabled={disabled}
           ></Toggle>
         </FlexBox.Child>
         <FlexBox.Child grow={1} onClick={handleFlexboxClick}>
@@ -72,7 +73,7 @@ export const ResourceAccordionHeader: FC<OwnProps> = props => {
             value={permissions.write.toString()}
             style={{marginRight: '0px'}}
             tabIndex={0}
-            disabled={false}
+            disabled={disabled}
           ></Toggle>
         </FlexBox.Child>
       </FlexBox>

--- a/src/authorizations/utils/permissions.ts
+++ b/src/authorizations/utils/permissions.ts
@@ -135,3 +135,73 @@ export enum BucketTab {
   AllBuckets = 'All Buckets',
   Scoped = 'Scoped',
 }
+
+export const formatPermissionsObj = (permissions) => {
+
+  const newPerms = permissions.reduce((acc, {action, resource}) => {
+    const {type, id, orgID, name} = resource
+    let p
+
+    if (acc.hasOwnProperty(type)) {
+      p = {...acc[type]}
+      if (id && (type === 'buckets' || type === 'telegrafs')) {
+        if (p.sublevelPermissions.hasOwnProperty(id)) {
+          p.sublevelPermissions[id].permissions[action] = true
+        } else {
+          p.sublevelPermissions[id] = {
+            id: id,
+            orgID: orgID,
+            name: name,
+            permissions: {
+              read: action === 'read',
+              write: action === 'write',
+            },
+          }
+        }
+      } else {
+        p[action] = true
+      }
+    } else {
+      if (id && (type === 'buckets' || type === 'telegrafs')) {
+        p = {
+          read: false,
+          write: false,
+          sublevelPermissions: {
+            [id]: {
+              id: id,
+              orgID: orgID,
+              name: name,
+              permissions: {
+                read: action === 'read',
+                write: action === 'write',
+              },
+            },
+          },
+        }
+      } else {
+        p = {
+          read: action === 'read',
+          write: action === 'write',
+        }
+      }
+    }
+
+    return {...acc, [type]: p}
+  }, {})
+
+  Object.keys(newPerms).map(resource => {
+    const p = {...newPerms[resource]}
+    if (p.sublevelPermissions) {
+      p.read = !Object.keys(p.sublevelPermissions).some(
+        key => p.sublevelPermissions[key].permissions.read === false
+      )
+
+      p.write = !Object.keys(p.sublevelPermissions).some(
+        key => p.sublevelPermissions[key].permissions.write === false
+      )
+
+      newPerms[resource] = p
+    }
+  })
+  return newPerms
+}

--- a/src/authorizations/utils/permissions.ts
+++ b/src/authorizations/utils/permissions.ts
@@ -136,8 +136,7 @@ export enum BucketTab {
   Scoped = 'Scoped',
 }
 
-export const formatPermissionsObj = (permissions) => {
-
+export const formatPermissionsObj = permissions => {
   const newPerms = permissions.reduce((acc, {action, resource}) => {
     const {type, id, orgID, name} = resource
     let p

--- a/src/authorizations/utils/permissions.ts
+++ b/src/authorizations/utils/permissions.ts
@@ -139,15 +139,15 @@ export enum BucketTab {
 export const formatPermissionsObj = permissions => {
   const newPerms = permissions.reduce((acc, {action, resource}) => {
     const {type, id, orgID, name} = resource
-    let p
+    let accordionPermission
 
     if (acc.hasOwnProperty(type)) {
-      p = {...acc[type]}
+      accordionPermission = {...acc[type]}
       if (id && (type === 'buckets' || type === 'telegrafs')) {
-        if (p.sublevelPermissions.hasOwnProperty(id)) {
-          p.sublevelPermissions[id].permissions[action] = true
+        if (accordionPermission.sublevelPermissions.hasOwnProperty(id)) {
+          accordionPermission.sublevelPermissions[id].permissions[action] = true
         } else {
-          p.sublevelPermissions[id] = {
+          accordionPermission.sublevelPermissions[id] = {
             id: id,
             orgID: orgID,
             name: name,
@@ -158,11 +158,11 @@ export const formatPermissionsObj = permissions => {
           }
         }
       } else {
-        p[action] = true
+        accordionPermission[action] = true
       }
     } else {
       if (id && (type === 'buckets' || type === 'telegrafs')) {
-        p = {
+        accordionPermission = {
           read: false,
           write: false,
           sublevelPermissions: {
@@ -178,28 +178,28 @@ export const formatPermissionsObj = permissions => {
           },
         }
       } else {
-        p = {
+        accordionPermission = {
           read: action === 'read',
           write: action === 'write',
         }
       }
     }
 
-    return {...acc, [type]: p}
+    return {...acc, [type]: accordionPermission}
   }, {})
 
-  Object.keys(newPerms).map(resource => {
-    const p = {...newPerms[resource]}
-    if (p.sublevelPermissions) {
-      p.read = !Object.keys(p.sublevelPermissions).some(
-        key => p.sublevelPermissions[key].permissions.read === false
+  Object.keys(newPerms).forEach(resource => {
+    const accordionPermission = {...newPerms[resource]}
+    if (accordionPermission.sublevelPermissions) {
+      accordionPermission.read = !Object.keys(accordionPermission.sublevelPermissions).some(
+        key => accordionPermission.sublevelPermissions[key].permissions.read === false
       )
 
-      p.write = !Object.keys(p.sublevelPermissions).some(
-        key => p.sublevelPermissions[key].permissions.write === false
+      accordionPermission.write = !Object.keys(accordionPermission.sublevelPermissions).some(
+        key => accordionPermission.sublevelPermissions[key].permissions.write === false
       )
 
-      newPerms[resource] = p
+      newPerms[resource] = accordionPermission
     }
   })
   return newPerms

--- a/src/authorizations/utils/permissions.ts
+++ b/src/authorizations/utils/permissions.ts
@@ -191,12 +191,20 @@ export const formatPermissionsObj = permissions => {
   Object.keys(newPerms).forEach(resource => {
     const accordionPermission = {...newPerms[resource]}
     if (accordionPermission.sublevelPermissions) {
-      accordionPermission.read = !Object.keys(accordionPermission.sublevelPermissions).some(
-        key => accordionPermission.sublevelPermissions[key].permissions.read === false
+      accordionPermission.read = !Object.keys(
+        accordionPermission.sublevelPermissions
+      ).some(
+        key =>
+          accordionPermission.sublevelPermissions[key].permissions.read ===
+          false
       )
 
-      accordionPermission.write = !Object.keys(accordionPermission.sublevelPermissions).some(
-        key => accordionPermission.sublevelPermissions[key].permissions.write === false
+      accordionPermission.write = !Object.keys(
+        accordionPermission.sublevelPermissions
+      ).some(
+        key =>
+          accordionPermission.sublevelPermissions[key].permissions.write ===
+          false
       )
 
       newPerms[resource] = accordionPermission


### PR DESCRIPTION
Closes #1966 

Inside the Edit Token Overlay, user can now see permissions for a token. 
The permissions are disabled and not selectable. 

![Screen Shot 2021-09-14 at 4 37 10 PM](https://user-images.githubusercontent.com/66275100/133337359-ea0336f4-ac9d-4aa0-82f3-40dc0df00625.png)
![Screen Shot 2021-09-14 at 4 37 30 PM](https://user-images.githubusercontent.com/66275100/133337396-12fe6d0e-82c7-4196-814e-246ba14ec16e.png)

