### PR TITLE
fix: remove duplicated input configuration from the backend when telegrafUiRefresh is active

### DIFF
--- a/src/writeData/components/PluginCreateConfigurationFooter.tsx
+++ b/src/writeData/components/PluginCreateConfigurationFooter.tsx
@@ -1,6 +1,7 @@
 // Libraries
 import React, {FC, useEffect, useMemo} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
+import {useParams} from 'react-router'
 
 // Components
 import {
@@ -21,6 +22,10 @@ import {PluginCreateConfigurationStepProps} from 'src/writeData/components/Plugi
 // Selectors
 import {getDataLoaders} from 'src/dataLoaders/selectors'
 import {getAll} from 'src/resources/selectors'
+
+type ParamsType = {
+  [param: string]: string
+}
 
 type ReduxProps = ConnectedProps<typeof connector>
 type Props = PluginCreateConfigurationStepProps & ReduxProps
@@ -43,10 +48,24 @@ const PluginCreateConfigurationFooterComponent: FC<Props> = props => {
     return Boolean(telegrafConfig)
   }, [telegrafConfig])
 
+  const {contentID} = useParams<ParamsType>()
+
   useEffect(() => {
     if (telegrafConfig) {
       const {config} = telegrafConfig
-      onUpdateTelegraf({...telegrafConfig, config: `${config}${pluginConfig}`})
+      const position =
+        typeof config === 'string'
+          ? config.indexOf(`[[inputs.${contentID}]]`)
+          : -1
+      const updatedConfig =
+        position === -1
+          ? `${config}${pluginConfig}`
+          : `${config.substring(0, position)}${pluginConfig}`
+
+      onUpdateTelegraf({
+        ...telegrafConfig,
+        config: updatedConfig,
+      })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [shouldTelegrafUpdate])

--- a/src/writeData/components/PluginCreateConfigurationFooter.tsx
+++ b/src/writeData/components/PluginCreateConfigurationFooter.tsx
@@ -58,9 +58,9 @@ const PluginCreateConfigurationFooterComponent: FC<Props> = props => {
           ? config.indexOf(`[[inputs.${contentID}]]`)
           : -1
       const updatedConfig =
-        position === -1
-          ? `${config}${pluginConfig}`
-          : `${config.substring(0, position)}${pluginConfig}`
+        position >= 0
+          ? `${config.substring(0, position)}${pluginConfig}`
+          : `${config}${pluginConfig}`
 
       onUpdateTelegraf({
         ...telegrafConfig,


### PR DESCRIPTION
Closes #2625 

Certain plugins no longer have a duplicated `inputs` in the configuration.  See the list in #2625 

Here is an example with `inputs.kubernetes`

https://user-images.githubusercontent.com/10736577/133538891-78e6a22c-57ef-4a39-a106-1d90e26221f2.mp4


