### PR TITLE
feat(docsearch): update facetFilters for docsearch

### DIFF
--- a/src/shared/search/DocSearch.tsx
+++ b/src/shared/search/DocSearch.tsx
@@ -40,7 +40,7 @@ const DocSearch: FC<DocSearchProps> = ({type}) => {
 
   const facetFilters = useMemo(
     () => ({
-      facetFilters: [['project: influxdb', 'flux:true'], 'version: cloud'],
+      facetFilters: [['searchTag: influxdb-cloud', 'flux:true']],
     }),
     []
   )


### PR DESCRIPTION
This updates the Algolia docsearch facetFilters to match the new search tag pattern used in the docs. Search will temporarily stop working between the time we deploy the changes to the docs site and reindex our docs and when this change goes live.