### PR TITLE
chore: add more logs when provisioning user

### DIFF
--- a/cypress/e2e/shared/flows.test.ts
+++ b/cypress/e2e/shared/flows.test.ts
@@ -3,21 +3,23 @@ import {Organization} from '../../src/types'
 describe('Flows', () => {
   beforeEach(() =>
     cy.flush().then(() =>
-      cy.signin().then(() => {
+      cy.signin().then(() =>
         cy.get('@org').then(({id}: Organization) =>
           cy.fixture('routes').then(({orgs}) => {
             cy.visit(`${orgs}/${id}`)
             cy.getByTestID('version-info')
-            cy.setFeatureFlags({
-              simpleTable: true,
-              notebooksExp: true,
-            }).then(() => {
-              cy.getByTestID('nav-item-flows').should('be.visible')
-              cy.getByTestID('nav-item-flows').click()
-            })
+            return cy
+              .setFeatureFlags({
+                simpleTable: true,
+                notebooksExp: true,
+              })
+              .then(() => {
+                cy.getByTestID('nav-item-flows').should('be.visible')
+                return cy.getByTestID('nav-item-flows').click()
+              })
           })
         )
-      })
+      )
     )
   )
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -584,6 +584,11 @@ export const setupUser = (): Cypress.Chainable<any> => {
     .then(response => {
       if (response.status === 200) {
         Cypress.env('defaultUser', response.body.user.name)
+        if (defaultUser) {
+          cy.log(`re-provsioned user ${defaultUser} successfully`)
+        } else {
+          cy.log(`provisioned new user ${response.body.user.name} successfully`)
+        }
         return response
       } else {
         // if for some reason the user wasn't flushed, do it now
@@ -599,6 +604,7 @@ export const flush = (): Cypress.Chainable<Cypress.Response<any>> => {
       .request({method: 'POST', url: `/debug/flush?user=${defaultUser}`})
       .then(response => {
         expect(response.status).to.eq(200)
+        cy.log(`flushed user ${defaultUser} successfully`)
         return response
       })
   }


### PR DESCRIPTION
We're still experiencing occasional issues with ui-test-provisioner where it errors saying "cannot provision user XYmcfly@influxdata.com because the user already exists". This PR adds logging to help us understand what's going on when this happens.

It also cleans up the before each of the flows.test.ts file.
