### PR TITLE
chore: refactor query context to fit gqc reqs

### DIFF
--- a/src/alerting/utils/statusEvents.ts
+++ b/src/alerting/utils/statusEvents.ts
@@ -11,12 +11,8 @@ import {CancelBox, StatusRow, File} from 'src/types'
 import {RunQueryResult} from 'src/shared/apis/query'
 import {Row} from 'src/types'
 
-export const runStatusesQuery = (
-  orgID: string,
-  checkID: string,
-  extern: File
-): CancelBox<StatusRow[][]> => {
-  const query = `
+export const getStatusesQuery = (checkID: string): string => {
+  return `
 from(bucket: "${MONITORING_BUCKET}")
   |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
   |> filter(fn: (r) => r._measurement == "statuses" and r._field == "_message")
@@ -31,6 +27,14 @@ from(bucket: "${MONITORING_BUCKET}")
                       "_check_name": "checkName",
                       "_level": "level"})
 `
+}
+
+export const runStatusesQuery = (
+  orgID: string,
+  checkID: string,
+  extern: File
+): CancelBox<StatusRow[][]> => {
+  const query = getStatusesQuery(checkID)
 
   event('runQuery', {context: 'checkStatuses'})
   return processStatusesResponse(runQuery(orgID, query, extern)) as CancelBox<

--- a/src/dataExplorer/components/DataExplorer.tsx
+++ b/src/dataExplorer/components/DataExplorer.tsx
@@ -15,6 +15,8 @@ import {HoverTimeProvider} from 'src/dashboards/utils/hoverTime'
 import {queryBuilderFetcher} from 'src/timeMachine/apis/QueryBuilderFetcher'
 import {readQueryParams} from 'src/shared/utils/queryParams'
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
+import GlobalQueryProvider from 'src/shared/contexts/global'
+import QueryProvider from 'src/shared/contexts/query'
 
 const DataExplorer: FC = () => {
   const dispatch = useDispatch()
@@ -31,7 +33,11 @@ const DataExplorer: FC = () => {
       <LimitChecker>
         <div className="data-explorer">
           <HoverTimeProvider>
-            <TimeMachine />
+            <QueryProvider>
+              <GlobalQueryProvider>
+                <TimeMachine />
+              </GlobalQueryProvider>
+            </QueryProvider>
           </HoverTimeProvider>
         </div>
       </LimitChecker>

--- a/src/flows/components/FlowPage.tsx
+++ b/src/flows/components/FlowPage.tsx
@@ -26,6 +26,7 @@ import {PROJECT_NAME_PLURAL} from 'src/flows'
 import 'src/flows/style.scss'
 
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
+import GlobalQueryProvider from 'src/shared/contexts/global'
 
 const FlowFromRoute = () => {
   const {id} = useParams<{id: string}>()
@@ -45,38 +46,40 @@ const FlowFromRoute = () => {
 
 const FlowContainer: FC = () => (
   <QueryProvider>
-    <CurrentFlowProvider>
-      <RunModeProvider>
-        <FlowFromRoute />
-        <ResultsProvider>
-          <FlowQueryProvider>
-            <FlowKeyboardPreview />
-            <SidebarProvider>
-              <Page>
-                <FlowHeader />
-                <Page.Contents
-                  fullWidth={true}
-                  scrollable={false}
-                  className="flow-page"
-                >
-                  <PopupProvider>
-                    <DapperScrollbars
-                      noScrollX
-                      thumbStartColor="gray"
-                      thumbStopColor="gray"
-                    >
-                      <PipeList />
-                    </DapperScrollbars>
-                    <SubSideBar />
-                    <PopupDrawer />
-                  </PopupProvider>
-                </Page.Contents>
-              </Page>
-            </SidebarProvider>
-          </FlowQueryProvider>
-        </ResultsProvider>
-      </RunModeProvider>
-    </CurrentFlowProvider>
+    <GlobalQueryProvider>
+      <CurrentFlowProvider>
+        <RunModeProvider>
+          <FlowFromRoute />
+          <ResultsProvider>
+            <FlowQueryProvider>
+              <FlowKeyboardPreview />
+              <SidebarProvider>
+                <Page>
+                  <FlowHeader />
+                  <Page.Contents
+                    fullWidth={true}
+                    scrollable={false}
+                    className="flow-page"
+                  >
+                    <PopupProvider>
+                      <DapperScrollbars
+                        noScrollX
+                        thumbStartColor="gray"
+                        thumbStopColor="gray"
+                      >
+                        <PipeList />
+                      </DapperScrollbars>
+                      <SubSideBar />
+                      <PopupDrawer />
+                    </PopupProvider>
+                  </Page.Contents>
+                </Page>
+              </SidebarProvider>
+            </FlowQueryProvider>
+          </ResultsProvider>
+        </RunModeProvider>
+      </CurrentFlowProvider>
+    </GlobalQueryProvider>
   </QueryProvider>
 )
 

--- a/src/flows/components/header/Submit.tsx
+++ b/src/flows/components/header/Submit.tsx
@@ -10,7 +10,7 @@ import {
   ButtonGroup,
 } from '@influxdata/clockface'
 
-import {SubmitQueryButton} from 'src/timeMachine/components/SubmitQueryButton'
+import SubmitQueryButton from 'src/timeMachine/components/SubmitQueryButton'
 import {QueryContext} from 'src/shared/contexts/query'
 import {FlowQueryContext} from 'src/flows/context/flow.query'
 import {RunModeContext, RunMode} from 'src/flows/context/runMode'
@@ -24,11 +24,13 @@ import 'src/flows/components/header/Submit.scss'
 
 // Types
 import {RemoteDataState} from 'src/types'
+import {GlobalQueryContext} from 'src/shared/contexts/global'
 
 const fakeNotify = notify
 
 export const Submit: FC = () => {
   const {cancel} = useContext(QueryContext)
+  const globalQueryContext = useContext(GlobalQueryContext)
   const {runMode, setRunMode} = useContext(RunModeContext)
   const {generateMap, queryAll, status} = useContext(FlowQueryContext)
 
@@ -49,12 +51,12 @@ export const Submit: FC = () => {
           text={runMode}
           className="flows--submit-button"
           icon={IconFont.Play}
-          submitButtonDisabled={hasQueries === false}
-          queryStatus={status}
-          onSubmit={handleSubmit}
-          onNotify={fakeNotify}
-          queryID=""
-          cancelAllRunningQueries={cancel}
+          isSubmitButtonDisabled={hasQueries === false}
+          submitQueryStatus={status}
+          onHandleSubmit={handleSubmit}
+          onHandleNotify={fakeNotify}
+          cancelQueries={cancel}
+          globalQueryContext={globalQueryContext}
         />
         {status !== RemoteDataState.Loading && (
           <SquareButton

--- a/src/flows/context/flow.query.tsx
+++ b/src/flows/context/flow.query.tsx
@@ -259,7 +259,7 @@ export const FlowQueryProvider: FC = ({children}) => {
     }
 
     if (isFlagEnabled('GlobalQueryContext')) {
-      return runGlobalQuery(text, override)
+      return runGlobalQuery(text, _override)
     }
 
     return queryAPI(text, _override)
@@ -280,7 +280,7 @@ export const FlowQueryProvider: FC = ({children}) => {
     }
 
     if (isFlagEnabled('GlobalQueryContext')) {
-      return runGlobalBasic(text, override)
+      return runGlobalBasic(text, _override)
     }
 
     return basicAPI(text, _override)

--- a/src/flows/context/flow.query.tsx
+++ b/src/flows/context/flow.query.tsx
@@ -13,6 +13,7 @@ import EmptyGraphMessage from 'src/shared/components/EmptyGraphMessage'
 import {parseDuration, timeRangeToDuration} from 'src/shared/utils/duration'
 import {useEvent, sendEvent} from 'src/users/hooks/useEvent'
 import {getOrg} from 'src/organizations/selectors'
+import {v4 as UUID} from 'uuid'
 
 // Constants
 import {
@@ -254,7 +255,7 @@ export const FlowQueryProvider: FC = ({children}) => {
       },
     }
 
-    return queryAPI(text, _override)
+    return queryAPI(UUID(), text, _override)
   }
 
   const basic = (text: string, override?: QueryScope): Promise<FluxResult> => {
@@ -268,7 +269,7 @@ export const FlowQueryProvider: FC = ({children}) => {
       },
     }
 
-    return basicAPI(text, _override)
+    return basicAPI(UUID(), text, _override)
   }
 
   const statuses = Object.values(loading)

--- a/src/flows/context/flow.query.tsx
+++ b/src/flows/context/flow.query.tsx
@@ -13,7 +13,6 @@ import EmptyGraphMessage from 'src/shared/components/EmptyGraphMessage'
 import {parseDuration, timeRangeToDuration} from 'src/shared/utils/duration'
 import {useEvent, sendEvent} from 'src/users/hooks/useEvent'
 import {getOrg} from 'src/organizations/selectors'
-import {v4 as UUID} from 'uuid'
 
 // Constants
 import {
@@ -255,7 +254,7 @@ export const FlowQueryProvider: FC = ({children}) => {
       },
     }
 
-    return queryAPI(UUID(), text, _override)
+    return queryAPI(text, _override)
   }
 
   const basic = (text: string, override?: QueryScope): Promise<FluxResult> => {
@@ -269,7 +268,7 @@ export const FlowQueryProvider: FC = ({children}) => {
       },
     }
 
-    return basicAPI(UUID(), text, _override)
+    return basicAPI(text, _override)
   }
 
   const statuses = Object.values(loading)

--- a/src/flows/pipes/Visualization/ExportDashboardOverlay/Visualization.tsx
+++ b/src/flows/pipes/Visualization/ExportDashboardOverlay/Visualization.tsx
@@ -10,6 +10,7 @@ import {View} from 'src/visualization'
 // Types
 import {RemoteDataState} from 'src/types'
 import {FluxResult} from 'src/types/flows'
+import GlobalQueryProvider from 'src/shared/contexts/global'
 
 const Visualization: FC = () => {
   const [results, setResults] = useState<FluxResult>(null)
@@ -48,8 +49,10 @@ const Visualization: FC = () => {
 
 export default () => (
   <QueryProvider>
-    <FlowQueryProvider>
-      <Visualization />
-    </FlowQueryProvider>
+    <GlobalQueryProvider>
+      <FlowQueryProvider>
+        <Visualization />
+      </FlowQueryProvider>
+    </GlobalQueryProvider>
   </QueryProvider>
 )

--- a/src/shared/contexts/global.tsx
+++ b/src/shared/contexts/global.tsx
@@ -244,6 +244,8 @@ const GlobalQueryProvider: FC<Props> = ({children}) => {
     stateCallback({...responses})
 
     setTimeout(() => {
+      // eslint-disable-next-line no-console
+      console.log(`clearing resultset for ${queryId}`)
       delete responses[queryId]
       stateCallback({...responses})
     }, DEFAULT_TTL)

--- a/src/shared/contexts/global.tsx
+++ b/src/shared/contexts/global.tsx
@@ -1,0 +1,270 @@
+// Libraries
+import React, {FC, createContext, useState, ReactChild, useContext} from 'react'
+
+import {RunQueryResult} from 'src/shared/apis/query'
+import {CancelBox, QueryScope} from 'src/types'
+
+// Types
+
+// Utils
+import {parseASTIM} from 'src/variables/utils/astim'
+import {hashCode} from 'src/shared/apis/queryCache'
+import {FromFluxResult, FluxDataType, Table} from '@influxdata/giraffe'
+import {parse, format_from_js_file} from '@influxdata/flux'
+import {getVarVals} from 'src/shared/contexts/query'
+import {QueryContext} from 'src/shared/contexts/query'
+
+interface OwnProps {
+  children: ReactChild
+}
+
+type Props = OwnProps
+
+type Column =
+  | {
+      name: string
+      type: 'number'
+      fluxDataType: FluxDataType
+      data: Array<number | null>
+    } //  parses empty numeric values as null
+  | {name: string; type: 'time'; fluxDataType: FluxDataType; data: number[]}
+  | {name: string; type: 'boolean'; fluxDataType: FluxDataType; data: boolean[]}
+  | {name: string; type: 'string'; fluxDataType: FluxDataType; data: string[]}
+
+interface Columns {
+  [columnKey: string]: Column
+}
+
+// This isn't actually optional, it just makes the type system work
+interface InternalTable extends Table {
+  columns?: Columns
+}
+
+interface InternalFromFluxResult extends FromFluxResult {
+  table: InternalTable
+}
+
+interface FluxResult {
+  source: string // the query that was used to generate the flux
+  parsed: InternalFromFluxResult // the parsed result
+  error?: string // any error that might have happend while fetching
+}
+
+export interface GlobalQueryContextType {
+  cancel: (query?: string) => void
+  isCached: (query: string, override: QueryScope, basiOnly?: boolean) => boolean
+  getQueryHash: (query: string, override: QueryScope) => string
+  runGlobalQuery: (query: string, override?: QueryScope) => Promise<FluxResult>
+  runGlobalBasic: (
+    query: string,
+    override?: QueryScope
+  ) => CancelBox<RunQueryResult>
+  isInitialized: boolean
+}
+
+export const DEFAULT_GLOBAL_QUERY_CONTEXT: GlobalQueryContextType = {
+  cancel: (_?: string) => null,
+  getQueryHash: (_: string, __: QueryScope) => '',
+  isCached: (_: string, __: QueryScope, ___?: boolean) => false,
+  runGlobalQuery: (_: string, __?: QueryScope) => null,
+  runGlobalBasic: (_: string, __?: QueryScope) => null,
+  isInitialized: false,
+}
+
+// 30 Seconds
+const DEFAULT_TTL = 30000
+
+export const GlobalQueryContext = createContext<GlobalQueryContextType>(
+  DEFAULT_GLOBAL_QUERY_CONTEXT
+)
+interface Query {
+  id: string
+  text: string
+}
+
+interface CancelMap {
+  [key: string]: () => void
+}
+
+interface QueryMap {
+  [key: string]: Query
+}
+
+interface QueryResponseMap {
+  [key: string]: FluxResult
+}
+interface BasicResponseMap {
+  [key: string]: RunQueryResult
+}
+
+const GlobalQueryProvider: FC<Props> = ({children}) => {
+  // const buckets = useSelector((state: AppState) => getSortedBuckets(state))
+  //   const orgId = useSelector(getOrg).id
+  const [queries, setQueries] = useState({} as QueryMap)
+  const [pending, setPending] = useState({} as CancelMap)
+  const [queryResponses, setQueryResponses] = useState({} as QueryResponseMap)
+  const [basicResponses, setBasicResponses] = useState({} as BasicResponseMap)
+  const {basic, query} = useContext(QueryContext)
+
+  const buildQueryText = (rawQuery: string, override: QueryScope) => {
+    const ast = parseASTIM(rawQuery).getAST()
+    const varVals = getVarVals(override?.vars, ast)
+    const optionAST = parse(`option v = {\n${varVals}\n}\n`)
+
+    if (varVals.length) {
+      ast.body.unshift(optionAST.body[0])
+    }
+
+    return format_from_js_file(ast)
+  }
+
+  const updateBasicResponses = (
+    queryId: string,
+    response: RunQueryResult
+  ): void => {
+    cancelPending(queryId)
+    setBasicResponses({...basicResponses, [queryId]: response})
+    setTimeout(() => {
+      delete basicResponses[queryId]
+      setBasicResponses(basicResponses)
+    }, DEFAULT_TTL)
+  }
+
+  const getQuery = (text: string): Query => {
+    const hash = hashCode(text)
+    let queryObj = queries[hash]
+    if (!queryObj) {
+      queryObj = {
+        text,
+        id: hash,
+      } as Query
+
+      setQueries({...queries, [hash]: queryObj})
+    }
+
+    return queryObj
+  }
+
+  const runGlobalBasic = (
+    rawQuery: string,
+    override: QueryScope,
+    prebuilt?: boolean
+  ): CancelBox<RunQueryResult> => {
+    let text = rawQuery
+    if (!prebuilt) {
+      text = buildQueryText(rawQuery, override)
+    }
+
+    const queryObj = getQuery(text)
+    const response = basicResponses[queryObj.id]
+
+    if (response) {
+      return {
+        id: queryObj.id,
+        promise: new Promise(resolve => resolve(response)),
+        cancel: () => {},
+      } as CancelBox<RunQueryResult>
+    }
+
+    const result = basic(queryObj.text, override)
+
+    setPending({...pending, [queryObj.id]: result.cancel})
+
+    result.promise.then(res => {
+      updateBasicResponses(queryObj.id, res)
+
+      return res
+    })
+
+    return {
+      id: queryObj.id,
+      promise: result.promise,
+      cancel: () => {
+        cancelPending(queryObj.id, true)
+      },
+    } as CancelBox<RunQueryResult>
+  }
+
+  const runGlobalQuery = (
+    rawQuery: string,
+    override: QueryScope
+  ): Promise<FluxResult> => {
+    const text = buildQueryText(rawQuery, override)
+    const queryObj = getQuery(text)
+    const response = queryResponses[queryObj.id]
+
+    if (response) {
+      return new Promise(resolve => {
+        resolve(response)
+      })
+    }
+
+    return query(queryObj.text, override).then(res => {
+      updateQueryResponses(queryObj.id, res)
+
+      return res
+    })
+  }
+
+  const cancel = (text?: string, override?: QueryMap) => {
+    if (!text) {
+      Object.keys(pending).forEach(pid => pending[pid]())
+      setPending({})
+      return
+    }
+
+    const hash = hashCode(buildQueryText(text, override))
+    cancelPending(hash, true)
+  }
+
+  const isInitialized = true
+
+  const cancelPending = (queryId, callBeforeDeleting = false) => {
+    if (!pending[queryId]) {
+      return
+    }
+
+    callBeforeDeleting && pending[queryId]()
+
+    delete pending[queryId]
+    setPending({...pending})
+  }
+
+  const updateQueryResponses = (queryId: string, response: FluxResult) => {
+    setQueryResponses({...queryResponses, [queryId]: response})
+    setTimeout(() => {
+      delete queryResponses[queryId]
+      setQueryResponses(queryResponses)
+    }, DEFAULT_TTL)
+  }
+
+  const isCached = (query: string, override: QueryMap, basicOnly = false) => {
+    const text = buildQueryText(query, override)
+    const hash = hashCode(text)
+
+    return basicOnly ? !!basicResponses[hash] : !!queryResponses[hash]
+  }
+
+  const getQueryHash = (query: string, override: QueryScope) => {
+    const text = buildQueryText(query, override)
+
+    return hashCode(text)
+  }
+
+  return (
+    <GlobalQueryContext.Provider
+      value={{
+        cancel,
+        isCached,
+        getQueryHash,
+        runGlobalBasic,
+        runGlobalQuery,
+        isInitialized,
+      }}
+    >
+      {children}
+    </GlobalQueryContext.Provider>
+  )
+}
+
+export default GlobalQueryProvider

--- a/src/shared/contexts/query.tsx
+++ b/src/shared/contexts/query.tsx
@@ -41,22 +41,14 @@ interface CancelMap {
 }
 
 export interface QueryContextType {
-  basic: (
-    text: string,
-    override?: QueryScope,
-    responseCallback?: (response: RunQueryResult) => void
-  ) => any
+  basic: (text: string, override?: QueryScope) => any
   query: (text: string, override?: QueryScope) => Promise<FluxResult>
   cancel: (id?: string) => void
 }
 
 export const DEFAULT_CONTEXT: QueryContextType = {
-  basic: (
-    __: string,
-    ___?: QueryScope,
-    ____?: (_: RunQueryResult) => void
-  ) => {},
-  query: (__: string, ___?: QueryScope) => Promise.resolve({} as FluxResult),
+  basic: (_: string, __?: QueryScope) => {},
+  query: (_: string, __?: QueryScope) => Promise.resolve({} as FluxResult),
   cancel: (_?: string) => {},
 }
 
@@ -462,9 +454,9 @@ export const QueryProvider: FC = ({children}) => {
       dialect: {annotations: ['group', 'datatype', 'default']},
     }
 
-    const id = UUID()
     const controller = new AbortController()
 
+    const id = UUID()
     const promise = fetch(url, {
       method: 'POST',
       headers,
@@ -480,14 +472,12 @@ export const QueryProvider: FC = ({children}) => {
                 setPending({...pending})
               }
 
-              const result = {
+              return {
                 type: 'SUCCESS',
                 csv,
                 bytesRead: csv.length,
                 didTruncate: false,
               } as RunQueryResult
-
-              return result
             })
           }
 
@@ -576,7 +566,6 @@ export const QueryProvider: FC = ({children}) => {
           requestAnimationFrame(() => {
             try {
               const parsed = fromFlux(raw.csv)
-
               resolve({
                 source: text,
                 parsed,

--- a/src/shared/contexts/query.tsx
+++ b/src/shared/contexts/query.tsx
@@ -35,6 +35,7 @@ import {
   File,
 } from 'src/types'
 import {RunQueryResult} from 'src/shared/apis/query'
+import { getVarVals } from './utils'
 
 interface CancelMap {
   [key: string]: () => void
@@ -237,115 +238,7 @@ export const simplify = (text, vars: VariableMap = {}) => {
     const ast = parse(text)
     const usedVars = _getVars(ast, vars)
 
-    // Grab all global variables and turn them into a hashmap
-    // TODO: move off this variable junk and just use strings
-    const globalDefinedVars = Object.values(usedVars).reduce((acc, v) => {
-      let _val
-
-      if (!v) {
-        return acc
-      }
-
-      if (v.id === WINDOW_PERIOD) {
-        acc[v.id] = (v.arguments?.values || [10000])[0] + 'ms'
-
-        return acc
-      }
-
-      if (v.id === TIME_RANGE_START || v.id === TIME_RANGE_STOP) {
-        const val = v.arguments.values[0]
-
-        if (!isNaN(Date.parse(val))) {
-          acc[v.id] = new Date(val).toISOString()
-          return acc
-        }
-
-        if (typeof val === 'string') {
-          if (val) {
-            acc[v.id] = val
-          }
-
-          return acc
-        }
-
-        _val = '-' + val[0].magnitude + val[0].unit
-
-        if (_val !== '-') {
-          acc[v.id] = _val
-        }
-
-        return acc
-      }
-
-      if (v.arguments.type === 'map') {
-        _val =
-          v.arguments.values[
-            v.selected ? v.selected[0] : Object.keys(v.arguments.values)[0]
-          ]
-
-        if (_val) {
-          acc[v.id] = _val
-        }
-
-        return acc
-      }
-
-      if (v.arguments.type === 'constant') {
-        _val = v.selected ? v.selected[0] : v.arguments.values[0]
-
-        if (_val) {
-          acc[v.id] = _val
-        }
-
-        return acc
-      }
-
-      if (v.arguments.type === 'query') {
-        if (!v.selected || !v.selected[0]) {
-          return
-        }
-
-        acc[v.id] = v.selected[0]
-        return acc
-      }
-
-      return acc
-    }, {})
-
-    // Grab all variables that are defined in the query while removing the old definition from the AST
-    const queryDefinedVars = remove(
-      ast,
-      node => node.type === 'OptionStatement' && node.assignment.id.name === 'v'
-    ).reduce((acc, curr) => {
-      // eslint-disable-next-line no-extra-semi
-      ;(curr.assignment?.init?.properties || []).reduce((_acc, _curr) => {
-        if (_curr.key?.name && _curr.value?.location?.source) {
-          _acc[_curr.key.name] = _curr.value.location.source
-        }
-
-        return _acc
-      }, acc)
-
-      return acc
-    }, {})
-
-    // Merge the two variable maps, allowing for any user defined variables to override
-    // global system variables
-    const joinedVars = Object.keys(usedVars).reduce((acc, curr) => {
-      if (globalDefinedVars.hasOwnProperty(curr)) {
-        acc[curr] = globalDefinedVars[curr]
-      }
-
-      if (queryDefinedVars.hasOwnProperty(curr)) {
-        acc[curr] = queryDefinedVars[curr]
-      }
-
-      return acc
-    }, {})
-
-    const varVals = Object.entries(joinedVars)
-      .map(([k, v]) => `${k}: ${v}`)
-      .join(',\n')
+    const varVals = getVarVals(usedVars, ast)
     const optionAST = parse(`option v = {\n${varVals}\n}\n`)
 
     if (varVals.length) {

--- a/src/shared/contexts/query.tsx
+++ b/src/shared/contexts/query.tsx
@@ -1,7 +1,7 @@
 import React, {FC, useEffect, useState} from 'react'
 import {useDispatch, useSelector} from 'react-redux'
-import {parse, format_from_js_file} from '@influxdata/flux'
 import {v4 as UUID} from 'uuid'
+import {parse, format_from_js_file} from '@influxdata/flux'
 
 import {getOrg} from 'src/organizations/selectors'
 import {getBuckets} from 'src/buckets/actions/thunks'
@@ -477,7 +477,7 @@ export const QueryProvider: FC = ({children}) => {
                 csv,
                 bytesRead: csv.length,
                 didTruncate: false,
-              } as RunQueryResult
+              }
             })
           }
 

--- a/src/timeMachine/actions/queries.ts
+++ b/src/timeMachine/actions/queries.ts
@@ -332,10 +332,11 @@ export const executeQueries = (abortController?: AbortController) => async (
       }
       const result = runQuery(orgID, text, extern, abortController)
       setQueryByHashID(queryID, result)
+
       return result
     })
-    const results = await Promise.all(pendingResults.map(r => r.promise))
 
+    const results = await Promise.all(pendingResults.map(r => r.promise))
     const duration = window.performance.now() - startTime
 
     event('executeQueries querying', {time: startDate}, {duration})
@@ -422,7 +423,7 @@ interface SaveDraftQueriesAction {
   type: 'SAVE_DRAFT_QUERIES'
 }
 
-const saveDraftQueries = (): SaveDraftQueriesAction => ({
+export const saveDraftQueries = (): SaveDraftQueriesAction => ({
   type: 'SAVE_DRAFT_QUERIES',
 })
 

--- a/src/timeMachine/components/Queries.tsx
+++ b/src/timeMachine/components/Queries.tsx
@@ -39,6 +39,7 @@ import {getTimeRange} from 'src/dashboards/selectors'
 
 // Types
 import {AppState, TimeRange, AutoRefreshStatus} from 'src/types'
+import {GlobalQueryContextType} from 'src/shared/contexts/global'
 
 type ReduxProps = ConnectedProps<typeof connector>
 type RouterProps = RouteComponentProps<{
@@ -46,11 +47,17 @@ type RouterProps = RouteComponentProps<{
   dashboardID: string
   orgID: string
 }>
-type Props = ReduxProps & RouterProps
+type OwnProps = {globalQueryContext?: GlobalQueryContextType}
+type Props = ReduxProps & RouterProps & OwnProps
 
 class TimeMachineQueries extends PureComponent<Props> {
   public render() {
-    const {timeRange, isInCheckOverlay, activeQuery} = this.props
+    const {
+      timeRange,
+      isInCheckOverlay,
+      activeQuery,
+      globalQueryContext,
+    } = this.props
 
     return (
       <div className="time-machine-queries">
@@ -75,7 +82,7 @@ class TimeMachineQueries extends PureComponent<Props> {
                 <TimeMachineQueriesSwitcher />
               </>
             )}
-            <SubmitQueryButton />
+            <SubmitQueryButton globalQueryContext={globalQueryContext} />
           </FlexBox>
         </div>
         <div className="time-machine-queries--body">{this.queryEditor}</div>

--- a/src/timeMachine/components/TimeMachine.tsx
+++ b/src/timeMachine/components/TimeMachine.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {useState, FunctionComponent} from 'react'
+import React, {useState, FunctionComponent, useContext} from 'react'
 import {connect} from 'react-redux'
 import classnames from 'classnames'
 
@@ -17,6 +17,10 @@ import {getActiveTimeMachine} from 'src/timeMachine/selectors'
 // Types
 import {AppState, TimeMachineTab} from 'src/types'
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
+import {
+  GlobalQueryContext,
+  GlobalQueryContextType,
+} from 'src/shared/contexts/global'
 
 const INITIAL_RESIZER_HANDLE = 0.5
 
@@ -30,6 +34,9 @@ const TimeMachine: FunctionComponent<StateProps> = ({
   isViewingVisOptions,
 }) => {
   const [dragPosition, setDragPosition] = useState([INITIAL_RESIZER_HANDLE])
+  const globalQueryContext = useContext<GlobalQueryContextType>(
+    GlobalQueryContext
+  )
 
   const containerClassName = classnames('time-machine', {
     'time-machine--split': isViewingVisOptions,
@@ -39,7 +46,9 @@ const TimeMachine: FunctionComponent<StateProps> = ({
   if (activeTab === 'alerting') {
     bottomContents = <TimeMachineAlerting />
   } else if (activeTab === 'queries') {
-    bottomContents = <TimeMachineQueries />
+    bottomContents = (
+      <TimeMachineQueries globalQueryContext={globalQueryContext} />
+    )
   } else if (activeTab === 'customCheckQuery') {
     bottomContents = <TimeMachineCheckQuery />
   }


### PR DESCRIPTION
In order to start using `basic` from shared context, I need to make some changes. Please suggest an alternative, if you are not fond of this solution.
