### PR TITLE
fix: monaco syntax highlighting, other expression bugs

### DIFF
--- a/cypress/e2e/shared/flows.test.ts
+++ b/cypress/e2e/shared/flows.test.ts
@@ -416,6 +416,7 @@ describe('Flows', () => {
       cy.getByTestID('add-flow-btn--notification').click()
       cy.getByTestID('time-machine-submit-button').click()
       cy.getByTestID('notification-exp-button').scrollIntoView()
+      cy.getByTestID('text-editor').should('be.visible')
 
       // open exp sidebar panel
       cy.getByTestID('notification-exp-button').should('be.visible')

--- a/src/flows/pipes/Notification/Expressions.tsx
+++ b/src/flows/pipes/Notification/Expressions.tsx
@@ -55,19 +55,19 @@ const parsedResultToSchema = (
   ]
   const schema = {
     measurements: new Set<string>(
-      measurements.filter(m => m.toLowerCase().includes(search.toLowerCase()))
+      measurements?.filter(m => m.toLowerCase().includes(search.toLowerCase()))
     ),
     fields: new Set<string>(
-      fields.filter(f => f.toLowerCase().includes(search.toLowerCase()))
+      fields?.filter(f => f.toLowerCase().includes(search.toLowerCase()))
     ),
     tags: new Set<string>(
-      columns.filter(
+      columns?.filter(
         c =>
           out.columns[c].data.filter(d => d) &&
           c.toLowerCase().includes(search.toLowerCase())
       )
     ),
-    columns: out.columnKeys.filter(
+    columns: out.columnKeys?.filter(
       c =>
         columnsToInclude.includes(c) &&
         c.toLowerCase().includes(search.toLowerCase())

--- a/src/flows/pipes/Notification/NotificationMonacoEditor.tsx
+++ b/src/flows/pipes/Notification/NotificationMonacoEditor.tsx
@@ -29,6 +29,7 @@ const NotificationMonacoEditor: FC<Props> = ({
     if (setEditorInstance) {
       setEditorInstance(editor)
     }
+    editor.focus()
   }
 
   return (

--- a/src/flows/pipes/Notification/NotificationMonacoEditor.tsx
+++ b/src/flows/pipes/Notification/NotificationMonacoEditor.tsx
@@ -1,0 +1,68 @@
+// Libraries
+import React, {FC} from 'react'
+
+// Components
+import MonacoEditor from 'react-monaco-editor'
+
+// Utils
+import LANGID from 'src/external/monaco.markdown.syntax'
+import THEME_NAME from 'src/external/monaco.flux.theme'
+
+// Types
+import {EditorType} from 'src/types'
+import {OnChangeScript} from 'src/types/flux'
+
+import 'src/shared/components/FluxMonacoEditor.scss'
+
+interface Props {
+  setEditorInstance?: (editor: EditorType) => void
+  text: string
+  onChangeText: OnChangeScript
+}
+
+const NotificationMonacoEditor: FC<Props> = ({
+  text,
+  onChangeText,
+  setEditorInstance,
+}) => {
+  const editorDidMount = (editor: EditorType) => {
+    if (setEditorInstance) {
+      setEditorInstance(editor)
+    }
+  }
+
+  const onChange = (text: string) => {
+    onChangeText(text)
+  }
+
+  return (
+    <div className="markdown-editor--monaco" data-testid="text-editor">
+      <MonacoEditor
+        language={LANGID}
+        theme={THEME_NAME}
+        value={text}
+        onChange={onChange}
+        height="300px"
+        options={{
+          fontSize: 13,
+          fontFamily: '"IBMPlexMono", monospace',
+          cursorWidth: 2,
+          lineNumbersMinChars: 4,
+          lineDecorationsWidth: 0,
+          minimap: {
+            enabled: false,
+          },
+          contextmenu: false,
+          overviewRulerBorder: false,
+          automaticLayout: true,
+          wordWrap: 'on',
+          lineNumbers: 'off',
+          scrollBeyondLastLine: false,
+        }}
+        editorDidMount={editorDidMount}
+      />
+    </div>
+  )
+}
+
+export default NotificationMonacoEditor

--- a/src/flows/pipes/Notification/NotificationMonacoEditor.tsx
+++ b/src/flows/pipes/Notification/NotificationMonacoEditor.tsx
@@ -31,17 +31,13 @@ const NotificationMonacoEditor: FC<Props> = ({
     }
   }
 
-  const onChange = (text: string) => {
-    onChangeText(text)
-  }
-
   return (
     <div className="markdown-editor--monaco" data-testid="text-editor">
       <MonacoEditor
         language={LANGID}
         theme={THEME_NAME}
         value={text}
-        onChange={onChange}
+        onChange={onChangeText}
         height="300px"
         options={{
           fontSize: 13,

--- a/src/flows/pipes/Notification/view.tsx
+++ b/src/flows/pipes/Notification/view.tsx
@@ -6,6 +6,7 @@ import React, {
   useMemo,
   useState,
   lazy,
+  Suspense,
 } from 'react'
 import {useDispatch} from 'react-redux'
 import {parse, format_from_js_file} from '@influxdata/flux'
@@ -25,6 +26,8 @@ import {
   ComponentColor,
   Button,
   InfluxColors,
+  TechnoSpinner,
+  SpinnerContainer,
 } from '@influxdata/clockface'
 import {PipeContext} from 'src/flows/context/pipe'
 import {FlowQueryContext} from 'src/flows/context/flow.query'
@@ -625,11 +628,20 @@ ${DEFAULT_ENDPOINTS[data.endpoint]?.generateTestQuery(data.endpointData)}`
                           className="markdown-editor--monaco"
                           data-testid="notification-message--monaco-editor"
                         >
-                          <NotificationMonacoEditor
-                            text={data.message}
-                            onChangeText={updateMessage}
-                            setEditorInstance={setEditorInstance}
-                          />
+                          <Suspense
+                            fallback={
+                              <SpinnerContainer
+                                loading={RemoteDataState.Loading}
+                                spinnerComponent={<TechnoSpinner />}
+                              />
+                            }
+                          >
+                            <NotificationMonacoEditor
+                              text={data.message}
+                              onChangeText={updateMessage}
+                              setEditorInstance={setEditorInstance}
+                            />
+                          </Suspense>
                         </div>
                       </Form.Element>
                     </FlexBox.Child>

--- a/src/flows/pipes/Notification/view.tsx
+++ b/src/flows/pipes/Notification/view.tsx
@@ -1,5 +1,12 @@
 // Libraries
-import React, {FC, useContext, useCallback, useMemo, useState} from 'react'
+import React, {
+  FC,
+  useContext,
+  useCallback,
+  useMemo,
+  useState,
+  lazy,
+} from 'react'
 import {useDispatch} from 'react-redux'
 import {parse, format_from_js_file} from '@influxdata/flux'
 import {
@@ -19,7 +26,6 @@ import {
   Button,
   InfluxColors,
 } from '@influxdata/clockface'
-import MonacoEditor from 'react-monaco-editor'
 import {PipeContext} from 'src/flows/context/pipe'
 import {FlowQueryContext} from 'src/flows/context/flow.query'
 import {remove} from 'src/shared/contexts/query'
@@ -31,6 +37,9 @@ import Threshold, {
 import {DEFAULT_ENDPOINTS} from 'src/flows/pipes/Notification/Endpoints'
 import ExportTaskButton from 'src/flows/pipes/Schedule/ExportTaskButton'
 import {SidebarContext} from 'src/flows/context/sidebar'
+const NotificationMonacoEditor = lazy(() =>
+  import('src/flows/pipes/Notification/NotificationMonacoEditor')
+)
 
 // Types
 import {RemoteDataState, EditorType} from 'src/types'
@@ -44,9 +53,6 @@ import {
   testNotificationFailure,
 } from 'src/shared/copy/notifications'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
-import LANGID from 'src/external/monaco.markdown.syntax'
-import THEME_NAME from 'src/external/monaco.flux.theme'
-
 // Styles
 import 'src/flows/pipes/Notification/styles.scss'
 
@@ -154,10 +160,6 @@ const Notification: FC<PipeProp> = ({Context}) => {
     })
   }
 
-  const editorDidMount = (editor: EditorType) => {
-    setEditorInstance(editor)
-  }
-
   const inject = useCallback(
     (exp: string): void => {
       if (!editorInstance) {
@@ -172,7 +174,7 @@ const Notification: FC<PipeProp> = ({Context}) => {
             p.lineNumber,
             p.column
           ),
-          text: ` r.${exp} `,
+          text: ` \$\{r.${exp}\} `,
         },
       ]
 
@@ -623,29 +625,10 @@ ${DEFAULT_ENDPOINTS[data.endpoint]?.generateTestQuery(data.endpointData)}`
                           className="markdown-editor--monaco"
                           data-testid="notification-message--monaco-editor"
                         >
-                          <MonacoEditor
-                            language={LANGID}
-                            theme={THEME_NAME}
-                            value={data.message}
-                            onChange={updateMessage}
-                            height="300px"
-                            options={{
-                              fontSize: 13,
-                              fontFamily: '"IBMPlexMono", monospace',
-                              cursorWidth: 2,
-                              lineNumbersMinChars: 4,
-                              lineDecorationsWidth: 0,
-                              minimap: {
-                                enabled: false,
-                              },
-                              contextmenu: false,
-                              overviewRulerBorder: false,
-                              automaticLayout: true,
-                              wordWrap: 'on',
-                              lineNumbers: 'off',
-                              scrollBeyondLastLine: false,
-                            }}
-                            editorDidMount={editorDidMount}
+                          <NotificationMonacoEditor
+                            text={data.message}
+                            onChangeText={updateMessage}
+                            setEditorInstance={setEditorInstance}
                           />
                         </div>
                       </Form.Element>


### PR DESCRIPTION
Closes #2636 

- fixes monaco syntax highlighting by moving the monaco editor out of the Notification panel's view and into its own component. 
- adds `${ }` around the inserted variables
- handles queries without measurements, fields, tags

![image](https://user-images.githubusercontent.com/6411855/133666896-98f88dea-0afb-4610-82d3-3bbb49babd72.png)

![image](https://user-images.githubusercontent.com/6411855/133667433-e7189d8e-cd2c-4259-a723-9ed52d96e65d.png)
