### PR TITLE
fix: always fetch latest OSS version info

### DIFF
--- a/src/shared/components/VersionInfoOSS.tsx
+++ b/src/shared/components/VersionInfoOSS.tsx
@@ -17,10 +17,8 @@ const VersionInfoOSS: FC = () => {
   const versionInfo = useSelector(getVersionInfo)
 
   useEffect(() => {
-    if (!versionInfo.version || !versionInfo.commit) {
-      dispatch(fetchVersionInfo())
-    }
-  })
+    dispatch(fetchVersionInfo())
+  }, [dispatch])
 
   return (
     <>


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/22239
Backport of https://github.com/influxdata/ui/pull/2379

Clean cherry pick