### PR TITLE
fix: better error message for scraper URL validity

### DIFF
--- a/src/scrapers/components/CreateScraperForm.tsx
+++ b/src/scrapers/components/CreateScraperForm.tsx
@@ -137,7 +137,7 @@ export class ScraperTarget extends PureComponent<Props> {
     const isURLValid = url.startsWith('http://') || url.startsWith('https://')
 
     if (!isURLValid) {
-      return 'Target URL must begin with "http://"'
+      return 'Target URL must begin with "http://" or "https://"'
     }
 
     return null


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/22512

Small correction for the error message displayed from the basic URL validity check that takes place when creating a scraper.