### PR TITLE
fix: better error message for scraper URL validity

### DIFF
--- a/src/scrapers/components/CreateScraperForm.tsx
+++ b/src/scrapers/components/CreateScraperForm.tsx
@@ -139,7 +139,7 @@ export class ScraperTarget extends PureComponent<Props> {
       _.startsWith(url, 'http://') || _.startsWith(url, 'https://')
 
     if (!isURLValid) {
-      return 'Target URL must begin with "http://"'
+      return 'Target URL must begin with "http://" or "https://"'
     }
 
     return null


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/22512 for the `OSS-2.0` branch
Backport of https://github.com/influxdata/ui/pull/2666

Clean cherry-pick