### PR TITLE
chore: update the bug report template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-Thank you for reporting a bug in InfluxData UI.
+<!-- Thank you for reporting a bug in InfluxData UI.
 
 - Please ask usage questions on the Influx Community site.
   - https://community.influxdata.com/
@@ -17,6 +17,10 @@ Thank you for reporting a bug in InfluxData UI.
 - The fastest way to fix a bug is to open a Pull Request.
   - https://github.com/influxdata/ui/pulls
 
+-->
+
+## About the bug
+
 **Steps to reproduce:**
 List the minimal actions needed to reproduce the behavior.
 
@@ -25,24 +29,33 @@ List the minimal actions needed to reproduce the behavior.
 3. ...
 
 **Expected behavior:**
-Describe what you expected to happen.
+<!-- Describe what you expected to happen. -->
 
 **Actual behavior:**
-Describe What actually happened.
+<!-- Describe What actually happened. -->
+
+**Visual Proof:**
+<!-- (please attach screenshots, videos, as applicable) -->
+
+
+## About your environment
 
 **Environment info:**
 
+<!--
 - System info: Run `uname -srm` and copy the output here
 - InfluxDB version: Run `influxd version` and copy the output here
 - Other relevant environment details: Container runtime, disk info, etc
 
+-->
+
 **Config:**
-Copy any non-default config values here or attach the full config as a gist or file.
+<!-- Copy any non-default config values here or attach the full config as a gist or file. -->
 
 <!-- The following sections are only required if relevant. -->
 
 **Logs:**
-Include snippet of errors in log.
+<!--- Include snippet of errors in log. -->
 
 **Performance:**
 Generate profiles with the following commands for bugs related to performance, locking, out of memory (OOM), etc.


### PR DESCRIPTION
Closes #

Being on bug duty twice I noticed two things:

* Quite a few bug reports were entirely just blank templates, I think it is because the current one is too noisy and the reporter thinks that the bug information is pre-populated.
* As a bug squasher, the report has too many things, unorganized, the greeting message need not be shown in the final report, there was no separation between the bug and the environment information. No hint to let the user know to add screenshots/visual information.


Screenshot

<img width="728" alt="Screen Shot 2021-09-21 at 12 44 36 PM" src="https://user-images.githubusercontent.com/18511823/134237329-afad20d4-e432-402b-8ffa-353257160fd1.png">

