### PR TITLE
chore: cleanup Notebooks empty state

### DIFF
--- a/src/flows/components/EmptyPipeList.scss
+++ b/src/flows/components/EmptyPipeList.scss
@@ -27,6 +27,7 @@
   width: 540px;
   height: 300px;
   background-image: url('~assets/images/flows-empty.svg');
+  filter: grayscale(100%);
   background-size: contain;
   background-position: center center;
   background-repeat: no-repeat;

--- a/src/flows/components/FlowsIndexEmpty.tsx
+++ b/src/flows/components/FlowsIndexEmpty.tsx
@@ -8,7 +8,7 @@ const FlowsIndexEmpty = () => {
     <EmptyState size={ComponentSize.ExtraSmall}>
       <div className="flow-empty">
         <div className="flow-empty--graphic" />
-        <EmptyState.Text style={{marginBottom: '0px'}}>
+        <EmptyState.Text className="margin-bottom-zero">
           You haven't created any {PROJECT_NAME_PLURAL} yet
         </EmptyState.Text>
       </div>

--- a/src/flows/components/FlowsIndexEmpty.tsx
+++ b/src/flows/components/FlowsIndexEmpty.tsx
@@ -1,18 +1,16 @@
 import React from 'react'
 import {ComponentSize, EmptyState} from '@influxdata/clockface'
 import {PROJECT_NAME_PLURAL} from 'src/flows'
-import FlowCreateButton from 'src/flows/components/FlowCreateButton'
 import 'src/flows/components/EmptyPipeList.scss'
 
 const FlowsIndexEmpty = () => {
   return (
-    <EmptyState size={ComponentSize.Large}>
+    <EmptyState size={ComponentSize.ExtraSmall}>
       <div className="flow-empty">
         <div className="flow-empty--graphic" />
-        <EmptyState.Text>
+        <EmptyState.Text style={{marginBottom: '0px'}}>
           You haven't created any {PROJECT_NAME_PLURAL} yet
         </EmptyState.Text>
-        <FlowCreateButton />
       </div>
     </EmptyState>
   )


### PR DESCRIPTION
remove create button from notebooks empty state, change image to grayscale, shrink component size to reduce unnecessary scrolling

Closes #2521 

