### PR TITLE
fix: meta key to open multiple notebooks from the index page

### DIFF
--- a/src/flows/components/FlowCard.tsx
+++ b/src/flows/components/FlowCard.tsx
@@ -31,8 +31,13 @@ const FlowCard: FC<Props> = ({id, isPinned}) => {
   const history = useHistory()
   const dispatch = useDispatch()
 
-  const handleClick = () => {
-    history.push(`/orgs/${orgID}/${PROJECT_NAME_PLURAL.toLowerCase()}/${id}`)
+  const handleClick = event => {
+    const url = `/orgs/${orgID}/${PROJECT_NAME_PLURAL.toLowerCase()}/${id}`
+    if (event.metaKey) {
+      window.open(url, '_blank', 'noopener')
+    } else {
+      history.push(url)
+    }
   }
 
   const contextMenu = (


### PR DESCRIPTION
Closes #2675 

This PR adds meta key click functionality to open a notebook in a new tab from the index page

![flox-index](https://user-images.githubusercontent.com/19984220/134356959-a0a0a9a3-3cb4-4ba2-8f26-acaa5ce6d5ab.gif)

