### PR TITLE
feat: show newly created token

### DIFF
--- a/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
@@ -58,6 +58,7 @@ interface DispatchProps {
   onCreateAuthorization: (auth) => void
 }
 
+
 type Props = OwnProps & StateProps & DispatchProps
 
 const CustomApiTokenOverlay: FC<Props> = props => {
@@ -235,7 +236,6 @@ const CustomApiTokenOverlay: FC<Props> = props => {
     </Overlay.Container>
   )
 }
-
 
 const mstp = (state: AppState) => {
   const remoteDataState = getResourcesStatus(state, [

--- a/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
@@ -40,6 +40,8 @@ import {getResourcesStatus} from 'src/resources/selectors/getResourcesStatus'
 // Utils
 import {formatApiPermissions} from 'src/authorizations/utils/permissions'
 
+import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
+
 interface OwnProps {
   onClose: () => void
 }
@@ -56,8 +58,8 @@ interface DispatchProps {
   getBuckets: () => void
   getTelegrafs: () => void
   onCreateAuthorization: (auth) => void
+  showOverlay: (arg1: string, arg2: any, any) => {}
 }
-
 
 type Props = OwnProps & StateProps & DispatchProps
 
@@ -146,13 +148,16 @@ const CustomApiTokenOverlay: FC<Props> = props => {
   }
 
   const generateToken = () => {
+    const {onCreateAuthorization, orgID, showOverlay} = props
+
     const token: Authorization = {
-      orgID: props.orgID,
+      orgID: orgID,
       description: description,
       permissions: formatApiPermissions(permissions, props.orgID),
     }
 
-    props.onCreateAuthorization(token)
+    onCreateAuthorization(token)
+    showOverlay('access-token', null, () => dismissOverlay())
   }
 
   return (
@@ -237,7 +242,6 @@ const CustomApiTokenOverlay: FC<Props> = props => {
   )
 }
 
-
 const mstp = (state: AppState) => {
   const remoteDataState = getResourcesStatus(state, [
     ResourceType.Buckets,
@@ -287,6 +291,8 @@ const mdtp = {
   getBuckets,
   getTelegrafs,
   onCreateAuthorization: createAuthorization,
+  showOverlay,
+  dismissOverlay,
 }
 
 export default connect(mstp, mdtp)(CustomApiTokenOverlay)

--- a/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
@@ -237,6 +237,7 @@ const CustomApiTokenOverlay: FC<Props> = props => {
   )
 }
 
+
 const mstp = (state: AppState) => {
   const remoteDataState = getResourcesStatus(state, [
     ResourceType.Buckets,

--- a/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
@@ -236,6 +236,7 @@ const CustomApiTokenOverlay: FC<Props> = props => {
   )
 }
 
+
 const mstp = (state: AppState) => {
   const remoteDataState = getResourcesStatus(state, [
     ResourceType.Buckets,


### PR DESCRIPTION
Closes #1932 

As a user going through token creation process,
when clicking `Generate`, the workflow now moves to Displaying Token Overlay.
The Display Token Overlay contains:

-  A token header
-  An alert displayed to copy token
-  Overlay dismiss button
-  The newly created token
-  Copy to Clipboard Button

https://user-images.githubusercontent.com/66275100/134379151-23b538d1-e813-4644-bb63-42118e5386ab.mov



