### PR TITLE
fix: clicking on the markdown doesnt make it editable

### DIFF
--- a/src/flows/pipes/Markdown/view.tsx
+++ b/src/flows/pipes/Markdown/view.tsx
@@ -12,6 +12,7 @@ import MarkdownModeToggle from './MarkdownModeToggle'
 import {MarkdownRenderer} from 'src/shared/components/views/MarkdownRenderer'
 import {PipeContext} from 'src/flows/context/pipe'
 import {PipeProp} from 'src/types/flows'
+import {FlowContext} from 'src/flows/context/flow.current'
 
 const MarkdownMonacoEditor = lazy(() =>
   import('src/shared/components/MarkdownMonacoEditor')
@@ -19,10 +20,7 @@ const MarkdownMonacoEditor = lazy(() =>
 
 const MarkdownPanel: FC<PipeProp> = ({Context}) => {
   const {data, update} = useContext(PipeContext)
-
-  const handlePreviewClick = (): void => {
-    update({mode: 'edit'})
-  }
+  const {flow} = useContext(FlowContext)
 
   const handleChange = (text: string): void => {
     update({text})
@@ -45,10 +43,10 @@ const MarkdownPanel: FC<PipeProp> = ({Context}) => {
     </Suspense>
   )
 
-  if (data.mode === 'preview') {
+  if (flow.readOnly || data.mode === 'preview') {
     const markdownClassname = classnames('flow-panel--markdown markdown-format')
     panelContents = (
-      <div className={markdownClassname} onClick={handlePreviewClick}>
+      <div className={markdownClassname}>
         <MarkdownRenderer text={data.text} />
       </div>
     )


### PR DESCRIPTION
Closes #2674 

This PR updates the markdown panel so that clicking on it while the markdown pipe is in `preview` mode doesn't make it editable. It also introduces a new pattern where a flow that's in presentation will display the markdown as being in preview mode

![markdown-pipe](https://user-images.githubusercontent.com/19984220/134418451-93a373b3-7732-4e69-8431-857ea4ed5c3e.gif)


<!-- Describe your proposed changes here. -->
