### PR TITLE
fix: updated the getter in the string to get the right data for the operator page

### DIFF
--- a/src/operator/constants.tsx
+++ b/src/operator/constants.tsx
@@ -47,7 +47,7 @@ export const accountColumnInfo: CellInfo[] = [
     defaultValue: '',
   },
   {
-    path: 'marketplace.shortName',
+    path: 'marketplaceSubscription.marketplace',
     name: 'marketplace',
     defaultValue: 'Zuora',
   },


### PR DESCRIPTION
Closes #2648

This _should_ fix the issue that's being reported. This is a classic example of `get` leading to issues since we're obfuscating where the problem is. There's still the bigger issue of whether this works, since we don't have a way to test this functionality out in local development.  

<!-- Describe your proposed changes here. -->
