### PR TITLE
fix: use a separate component hierarchy to prevent unmounting during telegraf configuration creation

### DIFF
--- a/src/dataLoaders/components/collectorsWizard/TelegrafUIRefreshStepSwitcher.tsx
+++ b/src/dataLoaders/components/collectorsWizard/TelegrafUIRefreshStepSwitcher.tsx
@@ -2,18 +2,18 @@
 import React, {PureComponent} from 'react'
 
 // Components
-import SelectCollectorsStep from 'src/dataLoaders/components/collectorsWizard/select/SelectCollectorsStep'
-import PluginConfigSwitcher from 'src/dataLoaders/components/collectorsWizard/configure/PluginConfigSwitcher'
+import SelectCollectorsStep2 from 'src/dataLoaders/components/collectorsWizard/select/SelectCollectorsStep2'
+import {PluginCreateConfigurationCustomize} from 'src/writeData/components/PluginCreateConfigurationCustomize'
 
 import VerifyCollectorsStep from 'src/dataLoaders/components/collectorsWizard/verify/VerifyCollectorsStep'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 // Types
 import {CollectorsStep} from 'src/types/dataLoaders'
-import {CollectorsStepProps} from 'src/dataLoaders/components/collectorsWizard/CollectorsWizard'
+import {PluginCreateConfigurationStepProps} from 'src/writeData/components/PluginCreateConfigurationWizard'
 
 interface Props {
-  stepProps: CollectorsStepProps
+  stepProps: PluginCreateConfigurationStepProps
 }
 
 @ErrorHandling
@@ -23,9 +23,9 @@ class StepSwitcher extends PureComponent<Props> {
 
     switch (stepProps.currentStepIndex) {
       case CollectorsStep.Select:
-        return <SelectCollectorsStep {...stepProps} />
+        return <SelectCollectorsStep2 {...stepProps} />
       case CollectorsStep.Configure:
-        return <PluginConfigSwitcher />
+        return <PluginCreateConfigurationCustomize {...stepProps} />
       case CollectorsStep.Verify:
         return <VerifyCollectorsStep {...stepProps} />
       default:

--- a/src/dataLoaders/components/collectorsWizard/TelegrafUIRefreshWizard.tsx
+++ b/src/dataLoaders/components/collectorsWizard/TelegrafUIRefreshWizard.tsx
@@ -7,16 +7,16 @@ import {withRouter, RouteComponentProps} from 'react-router-dom'
 // Components
 import {ErrorHandling} from 'src/shared/decorators/errors'
 import {Overlay} from '@influxdata/clockface'
+import PageSpinner from 'src/perf/components/PageSpinner'
 import {PluginCreateConfigurationFooter} from 'src/writeData/components/PluginCreateConfigurationFooter'
 
-const spinner = <div />
 const TelegrafUIRefreshStepSwitcher = Loadable({
   loader: () =>
     import(
       'src/dataLoaders/components/collectorsWizard/TelegrafUIRefreshStepSwitcher'
     ),
   loading() {
-    return spinner
+    return <PageSpinner />
   },
 })
 
@@ -49,11 +49,15 @@ type Props = ReduxProps & RouteComponentProps<{orgID: string}>
 
 @ErrorHandling
 class TelegrafUIRefreshWizard extends PureComponent<Props> {
-  public state = {pluginConfig: '', isValidConfiguration: false}
+  public state = {
+    pluginConfig: '',
+    isValidConfiguration: false,
+    isVisible: true,
+  }
 
   public componentDidMount() {
     const {bucket, buckets} = this.props
-    if (!bucket && buckets && buckets.length) {
+    if (!bucket && Array.isArray(buckets) && buckets.length) {
       const {orgID, name, id} = buckets[0]
       this.props.onSetBucketInfo(orgID, name, id)
     }
@@ -69,7 +73,7 @@ class TelegrafUIRefreshWizard extends PureComponent<Props> {
     }
 
     return (
-      <Overlay visible={true}>
+      <Overlay visible={this.state.isVisible}>
         <Overlay.Container maxWidth={1200}>
           <Overlay.Header
             title="Create a Telegraf Configuration"
@@ -89,6 +93,7 @@ class TelegrafUIRefreshWizard extends PureComponent<Props> {
     const {onClearDataLoaders, onClearSteps} = this.props
     onClearDataLoaders()
     onClearSteps()
+    this.setState({isVisible: false})
     history.push(`/orgs/${org.id}/load-data/telegrafs`)
   }
 

--- a/src/dataLoaders/components/collectorsWizard/TelegrafUIRefreshWizard.tsx
+++ b/src/dataLoaders/components/collectorsWizard/TelegrafUIRefreshWizard.tsx
@@ -1,0 +1,178 @@
+// Libraries
+import React, {PureComponent} from 'react'
+import Loadable from 'react-loadable'
+import {connect, ConnectedProps} from 'react-redux'
+import {withRouter, RouteComponentProps} from 'react-router-dom'
+
+// Components
+import {ErrorHandling} from 'src/shared/decorators/errors'
+import {Overlay} from '@influxdata/clockface'
+import {PluginCreateConfigurationFooter} from 'src/writeData/components/PluginCreateConfigurationFooter'
+
+const spinner = <div />
+const TelegrafUIRefreshStepSwitcher = Loadable({
+  loader: () =>
+    import(
+      'src/dataLoaders/components/collectorsWizard/TelegrafUIRefreshStepSwitcher'
+    ),
+  loading() {
+    return spinner
+  },
+})
+
+// Actions
+import {notify as notifyAction} from 'src/shared/actions/notifications'
+import {
+  clearSteps,
+  decrementCurrentStepIndex,
+  incrementCurrentStepIndex,
+  setBucketInfo,
+  setCurrentStepIndex,
+  setSubstepIndex,
+} from 'src/dataLoaders/actions/steps'
+
+import {clearDataLoaders} from 'src/dataLoaders/actions/dataLoaders'
+
+// Types
+import {AppState, Bucket, ResourceType} from 'src/types'
+import {PluginCreateConfigurationStepProps} from 'src/writeData/components/PluginCreateConfigurationWizard'
+
+// Selectors
+import {getAll} from 'src/resources/selectors'
+import {getOrg} from 'src/organizations/selectors'
+
+// Utils
+import {isSystemBucket} from 'src/buckets/constants'
+
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps & RouteComponentProps<{orgID: string}>
+
+@ErrorHandling
+class TelegrafUIRefreshWizard extends PureComponent<Props> {
+  public state = {pluginConfig: '', isValidConfiguration: false}
+
+  public componentDidMount() {
+    const {bucket, buckets} = this.props
+    if (!bucket && buckets && buckets.length) {
+      const {orgID, name, id} = buckets[0]
+      this.props.onSetBucketInfo(orgID, name, id)
+    }
+    this.props.onSetCurrentStepIndex(0)
+  }
+
+  public render() {
+    const {currentStepIndex} = this.props
+    let overlayBodyClassName = 'data-loading--overlay'
+
+    if (currentStepIndex === 1) {
+      overlayBodyClassName = ''
+    }
+
+    return (
+      <Overlay visible={true}>
+        <Overlay.Container maxWidth={1200}>
+          <Overlay.Header
+            title="Create a Telegraf Configuration"
+            onDismiss={this.handleDismiss}
+          />
+          <Overlay.Body className={overlayBodyClassName}>
+            <TelegrafUIRefreshStepSwitcher stepProps={this.stepProps} />
+          </Overlay.Body>
+          <PluginCreateConfigurationFooter {...this.stepProps} />
+        </Overlay.Container>
+      </Overlay>
+    )
+  }
+
+  private handleDismiss = () => {
+    const {history, org} = this.props
+    const {onClearDataLoaders, onClearSteps} = this.props
+    onClearDataLoaders()
+    onClearSteps()
+    history.push(`/orgs/${org.id}/load-data/telegrafs`)
+  }
+
+  private handleSetIsValidConfiguration = (isValid: boolean) => {
+    this.setState({isValidConfiguration: isValid})
+  }
+
+  private handleSetPluginConfig = (config: string) => {
+    this.setState({pluginConfig: config})
+  }
+
+  private get stepProps(): PluginCreateConfigurationStepProps {
+    const {
+      currentStepIndex,
+      notify,
+      onDecrementCurrentStepIndex,
+      onIncrementCurrentStepIndex,
+      onSetSubstepIndex,
+      substep,
+      telegrafPlugins,
+    } = this.props
+
+    const selectedPluginName = telegrafPlugins?.length
+      ? telegrafPlugins[0].name
+      : ''
+
+    return {
+      currentStepIndex,
+      isValidConfiguration: this.state.isValidConfiguration,
+      notify,
+      onDecrementCurrentStepIndex,
+      onExit: this.handleDismiss,
+      onIncrementCurrentStepIndex,
+      onSetSubstepIndex,
+      pluginConfig: this.state.pluginConfig,
+      pluginConfigName: selectedPluginName,
+      setIsValidConfiguration: this.handleSetIsValidConfiguration,
+      setPluginConfig: this.handleSetPluginConfig,
+      substepIndex: typeof substep === 'number' ? substep : 0,
+    }
+  }
+}
+
+const mstp = (state: AppState) => {
+  const {
+    dataLoading: {
+      dataLoaders: {telegrafPlugins},
+      steps: {currentStep, substep = 0, bucket},
+    },
+    me: {name},
+    telegrafEditor,
+  } = state
+
+  const buckets = getAll<Bucket>(state, ResourceType.Buckets)
+
+  const nonSystemBuckets = buckets.filter(
+    bucket => !isSystemBucket(bucket.name)
+  )
+
+  const org = getOrg(state)
+
+  return {
+    telegrafPlugins,
+    text: telegrafEditor.text,
+    currentStepIndex: currentStep,
+    substep,
+    username: name,
+    bucket,
+    buckets: nonSystemBuckets,
+    org,
+  }
+}
+
+const mdtp = {
+  notify: notifyAction,
+  onClearDataLoaders: clearDataLoaders,
+  onClearSteps: clearSteps,
+  onDecrementCurrentStepIndex: decrementCurrentStepIndex,
+  onIncrementCurrentStepIndex: incrementCurrentStepIndex,
+  onSetBucketInfo: setBucketInfo,
+  onSetCurrentStepIndex: setCurrentStepIndex,
+  onSetSubstepIndex: setSubstepIndex,
+}
+
+const connector = connect(mstp, mdtp)
+
+export default connector(withRouter(TelegrafUIRefreshWizard))

--- a/src/dataLoaders/components/collectorsWizard/select/SelectCollectorsStep2.tsx
+++ b/src/dataLoaders/components/collectorsWizard/select/SelectCollectorsStep2.tsx
@@ -6,7 +6,6 @@ import {connect, ConnectedProps} from 'react-redux'
 import {Form, DapperScrollbars, Grid, Columns} from '@influxdata/clockface'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 import StreamingSelectorTelegrafUiRefresh from 'src/dataLoaders/components/collectorsWizard/select/StreamingSelector2'
-import OnboardingButtons from 'src/onboarding/components/OnboardingButtons'
 
 // Actions
 import {
@@ -17,8 +16,7 @@ import {setBucketInfo} from 'src/dataLoaders/actions/steps'
 
 // Types
 import {Bucket} from 'src/types'
-import {ComponentStatus} from '@influxdata/clockface'
-import {CollectorsStepProps} from 'src/dataLoaders/components/collectorsWizard/CollectorsWizard'
+import {PluginCreateConfigurationStepProps} from 'src/writeData/components/PluginCreateConfigurationWizard'
 import {AppState, ResourceType} from 'src/types'
 
 // Selectors
@@ -28,7 +26,7 @@ import {getAll} from 'src/resources/selectors'
 import {isSystemBucket} from 'src/buckets/constants'
 import {TelegrafPlugin} from 'src/types/dataLoaders'
 
-export interface OwnProps extends CollectorsStepProps {
+export interface OwnProps extends PluginCreateConfigurationStepProps {
   buckets: Bucket[]
 }
 
@@ -42,6 +40,14 @@ type Props = OwnProps & ReduxProps
 @ErrorHandling
 export class SelectCollectorsStep extends PureComponent<Props, State> {
   state = {selectedBucketName: ''}
+
+  public componentDidUpdate() {
+    const {setIsValidConfiguration} = this.props
+    if (this.state.selectedBucketName && this.props.telegrafPlugins?.length) {
+      setIsValidConfiguration(true)
+    }
+  }
+
   public render() {
     return (
       <Form
@@ -73,31 +79,8 @@ export class SelectCollectorsStep extends PureComponent<Props, State> {
             onSelectBucket={this.handleSelectBucket}
           />
         </DapperScrollbars>
-        <OnboardingButtons
-          autoFocusNext={true}
-          nextButtonStatus={this.nextButtonStatus}
-          className="data-loading--button-container"
-        />
       </Form>
     )
-  }
-
-  private get nextButtonStatus(): ComponentStatus {
-    const {telegrafPlugins, buckets} = this.props
-    const {selectedBucketName} = this.state
-    if (!buckets || !buckets.length) {
-      return ComponentStatus.Disabled
-    }
-
-    if (!telegrafPlugins.length) {
-      return ComponentStatus.Disabled
-    }
-
-    if (!selectedBucketName) {
-      return ComponentStatus.Disabled
-    }
-
-    return ComponentStatus.Default
   }
 
   private handleSelectBucket = (bucket: Bucket) => {

--- a/src/telegrafs/containers/TelegrafsPage.tsx
+++ b/src/telegrafs/containers/TelegrafsPage.tsx
@@ -11,6 +11,7 @@ import GetResources from 'src/resources/components/GetResources'
 import LimitChecker from 'src/cloud/components/LimitChecker'
 import TelegrafInstructionsOverlay from 'src/telegrafs/components/TelegrafInstructionsOverlay'
 import CollectorsWizard from 'src/dataLoaders/components/collectorsWizard/CollectorsWizard'
+import TelegrafUIRefreshWizard from 'src/dataLoaders/components/collectorsWizard/TelegrafUIRefreshWizard'
 import {Page} from '@influxdata/clockface'
 import OverlayHandler, {
   RouteOverlay,
@@ -33,6 +34,7 @@ const TelegrafOutputOverlay = RouteOverlay(
 
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Types
 import {ResourceType} from 'src/types'
@@ -72,7 +74,14 @@ class TelegrafsPage extends PureComponent {
             path={`${telegrafsPath}/output`}
             component={TelegrafOutputOverlay}
           />
-          <Route path={`${telegrafsPath}/new`} component={CollectorsWizard} />
+          <Route
+            path={`${telegrafsPath}/new`}
+            component={
+              isFlagEnabled('telegrafUiRefresh')
+                ? TelegrafUIRefreshWizard
+                : CollectorsWizard
+            }
+          />
         </Switch>
       </>
     )

--- a/src/writeData/components/PluginCreateConfigurationFooter.tsx
+++ b/src/writeData/components/PluginCreateConfigurationFooter.tsx
@@ -1,7 +1,6 @@
 // Libraries
 import React, {FC, useEffect, useMemo} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
-import {useParams} from 'react-router'
 
 // Components
 import {
@@ -23,10 +22,6 @@ import {PluginCreateConfigurationStepProps} from 'src/writeData/components/Plugi
 import {getDataLoaders} from 'src/dataLoaders/selectors'
 import {getAll} from 'src/resources/selectors'
 
-type ParamsType = {
-  [param: string]: string
-}
-
 type ReduxProps = ConnectedProps<typeof connector>
 type Props = PluginCreateConfigurationStepProps & ReduxProps
 
@@ -40,22 +35,22 @@ const PluginCreateConfigurationFooterComponent: FC<Props> = props => {
     onSaveTelegrafConfig,
     onUpdateTelegraf,
     substepIndex,
+    setIsValidConfiguration,
     telegrafConfig,
     pluginConfig,
+    pluginConfigName,
   } = props
 
   const shouldTelegrafUpdate = useMemo(() => {
     return Boolean(telegrafConfig)
   }, [telegrafConfig])
 
-  const {contentID} = useParams<ParamsType>()
-
   useEffect(() => {
     if (telegrafConfig) {
       const {config} = telegrafConfig
       const position =
         typeof config === 'string'
-          ? config.indexOf(`[[inputs.${contentID}]]`)
+          ? config.indexOf(`[[inputs.${pluginConfigName}]]`)
           : -1
       const updatedConfig =
         position >= 0
@@ -75,6 +70,11 @@ const PluginCreateConfigurationFooterComponent: FC<Props> = props => {
     onIncrementCurrentStepIndex()
   }
 
+  const handleContinueFromStepZero = () => {
+    setIsValidConfiguration(false)
+    onIncrementCurrentStepIndex()
+  }
+
   if (substepIndex === 1 || currentStepIndex === 2) {
     return null
   }
@@ -91,7 +91,12 @@ const PluginCreateConfigurationFooterComponent: FC<Props> = props => {
         />
         <Button
           color={ComponentColor.Primary}
-          onClick={onIncrementCurrentStepIndex}
+          onClick={handleContinueFromStepZero}
+          status={
+            isValidConfiguration
+              ? ComponentStatus.Valid
+              : ComponentStatus.Disabled
+          }
           tabIndex={0}
           testID="plugin-create-configuration-continue-configuring"
           text="Continue Configuring"

--- a/src/writeData/components/PluginCreateConfigurationOptions.tsx
+++ b/src/writeData/components/PluginCreateConfigurationOptions.tsx
@@ -35,7 +35,10 @@ const PluginCreateConfigurationOptionsComponent: FC<Props> = props => {
     onSetSubstepIndex,
     onSetTelegrafConfigName,
     telegrafConfigName,
+    setIsValidConfiguration,
   } = props
+
+  setIsValidConfiguration(true) // always true for this component
 
   let selectedBucket = buckets.find(b => b.name === bucket)
 

--- a/src/writeData/components/PluginCreateConfigurationWizard.tsx
+++ b/src/writeData/components/PluginCreateConfigurationWizard.tsx
@@ -40,17 +40,17 @@ const PluginCreateConfigurationStepSwitcher = Loadable({
 
 export interface PluginCreateConfigurationStepProps {
   currentStepIndex: number
+  isValidConfiguration: boolean
   notify: typeof notifyAction
   onDecrementCurrentStepIndex: () => void
   onExit: () => void
   onIncrementCurrentStepIndex: () => void
   onSetSubstepIndex: (currentStepIndex: number, subStepIndex: number) => void
-  substepIndex: number
   pluginConfig: string
-  setPluginConfig: (config: string) => void
-  isValidConfiguration: boolean
-  setIsValidConfiguration: (isValid: boolean) => void
   pluginConfigName: string
+  setIsValidConfiguration: (isValid: boolean) => void
+  setPluginConfig: (config: string) => void
+  substepIndex: number
 }
 
 interface PluginCreateConfigurationWizardProps {

--- a/src/writeData/components/PluginCreateConfigurationWizard.tsx
+++ b/src/writeData/components/PluginCreateConfigurationWizard.tsx
@@ -6,6 +6,7 @@ import {useParams} from 'react-router'
 
 // Components
 import {Overlay} from '@influxdata/clockface'
+import PageSpinner from 'src/perf/components/PageSpinner'
 import {PluginCreateConfigurationFooter} from 'src/writeData/components/PluginCreateConfigurationFooter'
 
 // Types
@@ -27,14 +28,12 @@ import {BUCKET_OVERLAY_WIDTH} from 'src/buckets/constants'
 
 const PLUGIN_CREATE_CONFIGURATION_OVERLAY_DEFAULT_WIDTH = 1200
 const PLUGIN_CREATE_CONFIGURATION_OVERLAY_OPTIONS_WIDTH = 480
-const PREVENT_OVERLAY_FLICKER_STEP = -1
 
-const spinner = <div />
 const PluginCreateConfigurationStepSwitcher = Loadable({
   loader: () =>
     import('src/writeData/components/PluginCreateConfigurationStepSwitcher'),
   loading() {
-    return spinner
+    return <PageSpinner />
   },
 })
 
@@ -91,6 +90,7 @@ const PluginCreateConfigurationWizard: FC<Props> = props => {
   const [isValidConfiguration, setIsValidConfiguration] = useState<boolean>(
     false
   )
+  const [isVisible, setIsVisible] = useState<boolean>(true)
 
   const handleDismiss = () => {
     onClearDataLoaders()
@@ -98,7 +98,7 @@ const PluginCreateConfigurationWizard: FC<Props> = props => {
     if (substepIndex === 1) {
       onSetSubstepIndex(0, 0)
     } else {
-      onSetCurrentStepIndex(PREVENT_OVERLAY_FLICKER_STEP)
+      setIsVisible(false)
       history.goBack()
     }
   }
@@ -141,7 +141,7 @@ const PluginCreateConfigurationWizard: FC<Props> = props => {
   }
 
   return (
-    <Overlay visible={true}>
+    <Overlay visible={isVisible}>
       <Overlay.Container maxWidth={maxWidth}>
         <Overlay.Header title={title} onDismiss={handleDismiss} />
         <Overlay.Body className={overlayBodyClassName}>


### PR DESCRIPTION
Closes #2663 

Fixes the "Create Configuration" flow from Data > Telegraf. Previously, the selected input plugin would not be saved even though the configuration itself was saved. The update api call was not being made because the component responsible for making that call was unmounted before it could do so.

We fix this by
- creating a new component hierarchy that uses the new telegraf configuration creation wizard properly (does not unmount)
- making minor adjustments to the Footer to allow for the usage from a different flow
- restoring CollectorsStepSwitcher to an earlier version by removing unused code


https://user-images.githubusercontent.com/10736577/134601560-1665d2c9-94d2-438c-a7c1-a3ca66641df5.mp4




