### PR TITLE
feat: add created by UI for flows

### DIFF
--- a/cypress/e2e/cloud/pinned.test.ts
+++ b/cypress/e2e/cloud/pinned.test.ts
@@ -44,7 +44,7 @@ describe('Pinned Items', () => {
         .first()
         .trigger('mouseover')
         .within(() => {
-          cy.getByTestID('context-pin-menu').click()
+          cy.getByTestID('context-pin-menu').click({force: true})
           cy.getByTestID('context-pin-dashboard').click()
         })
       cy.visit('/')
@@ -59,7 +59,7 @@ describe('Pinned Items', () => {
         .first()
         .trigger('mouseover')
         .within(() => {
-          cy.getByTestID('context-pin-menu').click()
+          cy.getByTestID('context-pin-menu').click({force: true})
           cy.getByTestID('context-pin-dashboard').click()
         })
       cy.getByTestID('dashboard-card').within(() => {
@@ -92,7 +92,7 @@ describe('Pinned Items', () => {
         .first()
         .trigger('mouseover')
         .within(() => {
-          cy.getByTestID('context-pin-menu').click()
+          cy.getByTestID('context-pin-menu').click({force: true})
           cy.getByTestID('context-pin-dashboard').click()
         })
       cy.visit('/')
@@ -166,7 +166,7 @@ from(bucket: "${name}"{rightarrow}
         .first()
         .trigger('mouseover')
         .then(() => {
-          cy.getByTestID('context-pin-menu').click()
+          cy.getByTestID('context-pin-menu').click({force: true})
           cy.getByTestID('context-pin-task').click()
         })
     })
@@ -259,7 +259,7 @@ from(bucket: "${name}"{rightarrow}
       cy.getByTestID('flow-card--Flow')
         .trigger('mouseover')
         .then(() => {
-          cy.getByTestID('context-pin-menu').click()
+          cy.getByTestID('context-pin-menu').click({force: true})
           cy.getByTestID('context-pin-flow').click()
         })
       cy.visit('/')
@@ -273,7 +273,7 @@ from(bucket: "${name}"{rightarrow}
       cy.getByTestID('flow-card--Flow')
         .trigger('mouseover')
         .then(() => {
-          cy.getByTestID('context-pin-menu').click()
+          cy.getByTestID('context-pin-menu').click({force: true})
           cy.getByTestID('context-pin-flow').click()
         })
       cy.getByTestID('resource-editable-name')
@@ -318,7 +318,7 @@ from(bucket: "${name}"{rightarrow}
       cy.getByTestID('flow-card--Bucks In Six')
         .trigger('mouseover')
         .then(() => {
-          cy.getByTestID('context-pin-menu').click()
+          cy.getByTestID('context-pin-menu').click({force: true})
           cy.getByTestID('context-pin-flow').click()
           cy.getByTestID('context-delete-menu Bucks In Six').click()
           cy.getByTestID('context-delete-flow Bucks In Six').click()

--- a/cypress/e2e/cloud/pinned.test.ts
+++ b/cypress/e2e/cloud/pinned.test.ts
@@ -260,7 +260,7 @@ from(bucket: "${name}"{rightarrow}
         .trigger('mouseover')
         .then(() => {
           cy.getByTestID('context-pin-menu').click({force: true})
-          cy.getByTestID('context-pin-flow').click()
+          cy.getByTestID('context-pin-flow').click({force: true})
         })
       cy.visit('/')
       cy.getByTestID('tree-nav')
@@ -274,7 +274,7 @@ from(bucket: "${name}"{rightarrow}
         .trigger('mouseover')
         .then(() => {
           cy.getByTestID('context-pin-menu').click({force: true})
-          cy.getByTestID('context-pin-flow').click()
+          cy.getByTestID('context-pin-flow').click({force: true})
         })
       cy.getByTestID('resource-editable-name')
         .first()
@@ -319,7 +319,7 @@ from(bucket: "${name}"{rightarrow}
         .trigger('mouseover')
         .then(() => {
           cy.getByTestID('context-pin-menu').click({force: true})
-          cy.getByTestID('context-pin-flow').click()
+          cy.getByTestID('context-pin-flow').click({force: true})
           cy.getByTestID('context-delete-menu Bucks In Six').click()
           cy.getByTestID('context-delete-flow Bucks In Six').click()
         })

--- a/cypress/e2e/cloud/pinned.test.ts
+++ b/cypress/e2e/cloud/pinned.test.ts
@@ -320,8 +320,12 @@ from(bucket: "${name}"{rightarrow}
         .then(() => {
           cy.getByTestID('context-pin-menu').click({force: true})
           cy.getByTestID('context-pin-flow').click({force: true})
-          cy.getByTestID('context-delete-menu Bucks In Six').click()
-          cy.getByTestID('context-delete-flow Bucks In Six').click()
+          cy.getByTestID('context-delete-menu Bucks In Six').click({
+            force: true,
+          })
+          cy.getByTestID('context-delete-flow Bucks In Six').click({
+            force: true,
+          })
         })
       cy.visit('/')
       cy.getByTestID('tree-nav')

--- a/src/flows/components/FlowCard.tsx
+++ b/src/flows/components/FlowCard.tsx
@@ -28,8 +28,6 @@ const FlowCard: FC<Props> = ({id, isPinned}) => {
   const flow = flows[id]
   const {orgID} = useParams<{orgID: string}>()
 
-  console.log({flow})
-
   const history = useHistory()
   const dispatch = useDispatch()
 

--- a/src/flows/components/FlowCard.tsx
+++ b/src/flows/components/FlowCard.tsx
@@ -28,6 +28,8 @@ const FlowCard: FC<Props> = ({id, isPinned}) => {
   const flow = flows[id]
   const {orgID} = useParams<{orgID: string}>()
 
+  console.log({flow})
+
   const history = useHistory()
   const dispatch = useDispatch()
 
@@ -56,6 +58,20 @@ const FlowCard: FC<Props> = ({id, isPinned}) => {
     }
   }
 
+  const meta = []
+
+  if (!!flow?.createdBy) {
+    meta.push(<>Created by {flow.createdBy}</>)
+  }
+
+  if (flow?.createdAt) {
+    meta.push(<>Created at {flow.createdAt}</>)
+  }
+
+  if (flow?.updatedAt) {
+    meta.push(<>Last Modified at {flow.updatedAt}</>)
+  }
+
   return (
     <ResourceCard
       key={`flow-card--${id}`}
@@ -68,10 +84,7 @@ const FlowCard: FC<Props> = ({id, isPinned}) => {
         onUpdate={handleRenameNotebook}
         buttonTestID="flow-card--name-button"
       />
-      <ResourceCard.Meta>
-        {flow?.createdAt ? <>Created at {flow.createdAt}</> : null}
-        {flow?.updatedAt ? <>Last Modified at {flow.updatedAt}</> : null}
-      </ResourceCard.Meta>
+      <ResourceCard.Meta>{meta}</ResourceCard.Meta>
     </ResourceCard>
   )
 }

--- a/src/flows/context/flow.list.tsx
+++ b/src/flows/context/flow.list.tsx
@@ -115,6 +115,7 @@ export function hydrate(data) {
     readOnly: data.spec.readOnly,
     createdAt: data.createdAt,
     updatedAt: data.updatedAt,
+    createdBy: data.createdBy,
   }
   if (data.id) {
     flow.id = data.id

--- a/src/types/flows.ts
+++ b/src/types/flows.ts
@@ -104,6 +104,7 @@ export interface Flow {
   readOnly?: boolean
   createdAt?: Date
   updatedAt?: Date
+  createdBy?: string
 }
 
 export interface FlowListState {


### PR DESCRIPTION
Closes #1381 

This PR integrates a recent API migration that sets a user's name when creating a notebook to the associated notebook. This PR also modifies the existing logic that displays the meta data of a notebooks since the styling was being thrown off whenever a user's meta data was set to `null`. This way existing notebooks that don't have the createdBy field won't look wonky

<img width="1181" alt="Screen Shot 2021-09-24 at 12 54 16 PM" src="https://user-images.githubusercontent.com/19984220/134732675-7790414e-d914-4349-a8e0-26ce361e7ef5.png">
