### PR TITLE
fix: remove measurements from expressions sidebar

### DIFF
--- a/cypress/e2e/shared/flows.test.ts
+++ b/cypress/e2e/shared/flows.test.ts
@@ -426,7 +426,6 @@ describe('Flows', () => {
       cy.getByTestID('flux-toolbar--list').should('be.visible')
 
       // check that all expressions are listed
-      cy.getByTestID('measurements-test').should('be.visible')
       cy.getByTestID('fields-dopeness').should('be.visible')
       cy.getByTestID('tags-container_name').should('be.visible')
       cy.getByTestID('columns-_start').should('be.visible')

--- a/src/flows/pipes/Notification/Expressions.tsx
+++ b/src/flows/pipes/Notification/Expressions.tsx
@@ -38,7 +38,6 @@ const parsedResultToSchema = (
   }
 
   const out = parsed.table as any
-  const measurements = out.columns._measurement?.data
   const fields = out.columns._field?.data
   const columns = out.columnKeys.filter(key => {
     return filtered.reduce((acc, curr) => {
@@ -54,9 +53,6 @@ const parsedResultToSchema = (
     '_type',
   ]
   const schema = {
-    measurements: new Set<string>(
-      measurements?.filter(m => m.toLowerCase().includes(search.toLowerCase()))
-    ),
     fields: new Set<string>(
       fields?.filter(f => f.toLowerCase().includes(search.toLowerCase()))
     ),


### PR DESCRIPTION
Removes "measurements" from the expressions side bar because they aren't valid expressions. If you tried to use them, the Alert will fail with:

```
Error exhausting result iterator; Err: runtime error @41:8-41:74: check: failed to evaluate map function: 37:367-37:389: interpolated expression produced a null value: runtime error @41:8-41:74: check: failed to evaluate map function: 37:367-37:389: interpolated expression produced a null value
```

What it looks like now:

![image](https://user-images.githubusercontent.com/6411855/134744139-81a4b95b-7487-42e9-9541-615b41aab6ab.png)