### PR TITLE
feat: generate token description

### DIFF
--- a/src/authorizations/components/TokenRow.tsx
+++ b/src/authorizations/components/TokenRow.tsx
@@ -46,8 +46,6 @@ class TokenRow extends PureComponent<Props> {
     const labelText = this.isTokenEnabled ? 'Active' : 'Inactive'
     const date = new Date(auth.createdAt)
 
-    console.log("auth from tokenRow: ", auth)
-
     return (
       <ResourceCard
         contextMenu={this.contextMenu}
@@ -99,7 +97,7 @@ class TokenRow extends PureComponent<Props> {
   }
 
   // private noNameTokens = () => {
-    // const {auth} = this.props
+  // const {auth} = this.props
 
   // }
 

--- a/src/authorizations/components/TokenRow.tsx
+++ b/src/authorizations/components/TokenRow.tsx
@@ -45,6 +45,9 @@ class TokenRow extends PureComponent<Props> {
     const {auth} = this.props
     const labelText = this.isTokenEnabled ? 'Active' : 'Inactive'
     const date = new Date(auth.createdAt)
+
+    console.log("auth from tokenRow: ", auth)
+
     return (
       <ResourceCard
         contextMenu={this.contextMenu}
@@ -94,6 +97,11 @@ class TokenRow extends PureComponent<Props> {
     const {auth} = this.props
     return auth.status === 'active'
   }
+
+  // private noNameTokens = () => {
+    // const {auth} = this.props
+
+  // }
 
   private changeToggle = () => {
     const {auth, onUpdate} = this.props

--- a/src/authorizations/components/TokenRow.tsx
+++ b/src/authorizations/components/TokenRow.tsx
@@ -96,11 +96,6 @@ class TokenRow extends PureComponent<Props> {
     return auth.status === 'active'
   }
 
-  // private noNameTokens = () => {
-  // const {auth} = this.props
-
-  // }
-
   private changeToggle = () => {
     const {auth, onUpdate} = this.props
     if (auth.status === 'active') {

--- a/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
@@ -149,10 +149,8 @@ const CustomApiTokenOverlay: FC<Props> = props => {
     setPermissions(newPerm)
   }
 
-  const generateToken = () => {
-    const {onCreateAuthorization, orgID, showOverlay} = props
+  const generateDescription = (apiPermissions) => {
 
-    const apiPermissions = formatApiPermissions(permissions, orgID);
     let generatedDescription = ""
     
     if(apiPermissions.length > 2) {
@@ -160,8 +158,8 @@ const CustomApiTokenOverlay: FC<Props> = props => {
       apiPermissions.forEach((perm) => {
          actions.push(perm.action)
       })
-      const isRead = actions.some(action => action === 'read') // true
-      const isWrite = actions.some(action => action === 'write') // true
+      const isRead = actions.some(action => action === 'read') 
+      const isWrite = actions.some(action => action === 'write') 
 
       if(isRead && isWrite) {
         generatedDescription += `Read Multiple / Write Multiple`
@@ -184,11 +182,18 @@ const CustomApiTokenOverlay: FC<Props> = props => {
         }
       })
     }
-    
 
+    return generatedDescription
+  }
+
+  const generateToken = () => {
+    const {onCreateAuthorization, orgID, showOverlay} = props
+
+    const apiPermissions = formatApiPermissions(permissions, orgID)
+    
     const token: Authorization = {
       orgID: orgID,
-      description: description ? description : generatedDescription,
+      description: description ? description : generateDescription(apiPermissions),
       permissions: apiPermissions,
     }
 

--- a/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
@@ -41,6 +41,8 @@ import {getResourcesStatus} from 'src/resources/selectors/getResourcesStatus'
 import {formatApiPermissions} from 'src/authorizations/utils/permissions'
 
 import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
+import {capitalize} from 'lodash'
+
 
 interface OwnProps {
   onClose: () => void
@@ -150,10 +152,44 @@ const CustomApiTokenOverlay: FC<Props> = props => {
   const generateToken = () => {
     const {onCreateAuthorization, orgID, showOverlay} = props
 
+    const apiPermissions = formatApiPermissions(permissions, orgID);
+    let generatedDescription = ""
+    
+    if(apiPermissions.length > 2) {
+      const actions = []
+      apiPermissions.forEach((perm) => {
+         actions.push(perm.action)
+      })
+      const isRead = actions.some(action => action === 'read') // true
+      const isWrite = actions.some(action => action === 'write') // true
+
+      if(isRead && isWrite) {
+        generatedDescription += `Read Multiple / Write Multiple`
+
+      } else if (isRead) {
+        generatedDescription += `Read Multiple`
+
+      } else if (isWrite) {
+        generatedDescription += `Write Multiple`
+      }
+
+    } else {
+      apiPermissions.forEach((perm) => {
+      
+        if(perm.resource.name) {
+          generatedDescription += ` ${capitalize(perm.action)} ${perm.resource.type} ${perm.resource.name} `
+  
+        } else {
+          generatedDescription += ` ${capitalize(perm.action)} ${perm.resource.type} `
+        }
+      })
+    }
+    
+
     const token: Authorization = {
       orgID: orgID,
-      description: description,
-      permissions: formatApiPermissions(permissions, props.orgID),
+      description: description ? description : generatedDescription,
+      permissions: apiPermissions,
     }
 
     onCreateAuthorization(token)

--- a/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
@@ -38,10 +38,12 @@ import {getAll} from 'src/resources/selectors'
 import {getResourcesStatus} from 'src/resources/selectors/getResourcesStatus'
 
 // Utils
-import {formatApiPermissions} from 'src/authorizations/utils/permissions'
+import {
+  formatApiPermissions,
+  generateDescription,
+} from 'src/authorizations/utils/permissions'
 
 import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
-import {capitalize} from 'lodash'
 
 interface OwnProps {
   onClose: () => void
@@ -146,41 +148,6 @@ const CustomApiTokenOverlay: FC<Props> = props => {
     newPerm[resourceName][permission] = headerPermValue
 
     setPermissions(newPerm)
-  }
-
-  const generateDescription = apiPermissions => {
-    let generatedDescription = ''
-
-    if (apiPermissions.length > 2) {
-      const actions = []
-      apiPermissions.forEach(perm => {
-        actions.push(perm.action)
-      })
-      const isRead = actions.some(action => action === 'read')
-      const isWrite = actions.some(action => action === 'write')
-
-      if (isRead && isWrite) {
-        generatedDescription += `Read Multiple Write Multiple`
-      } else if (isRead) {
-        generatedDescription += `Read Multiple`
-      } else if (isWrite) {
-        generatedDescription += `Write Multiple`
-      }
-    } else {
-      apiPermissions.forEach(perm => {
-        if (perm.resource.name) {
-          generatedDescription += ` ${capitalize(perm.action)} ${
-            perm.resource.type
-          } ${perm.resource.name} `
-        } else {
-          generatedDescription += ` ${capitalize(perm.action)} ${
-            perm.resource.type
-          } `
-        }
-      })
-    }
-
-    return generatedDescription
   }
 
   const generateToken = () => {

--- a/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
@@ -43,7 +43,6 @@ import {formatApiPermissions} from 'src/authorizations/utils/permissions'
 import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
 import {capitalize} from 'lodash'
 
-
 interface OwnProps {
   onClose: () => void
 }
@@ -149,36 +148,34 @@ const CustomApiTokenOverlay: FC<Props> = props => {
     setPermissions(newPerm)
   }
 
-  const generateDescription = (apiPermissions) => {
+  const generateDescription = apiPermissions => {
+    let generatedDescription = ''
 
-    let generatedDescription = ""
-    
-    if(apiPermissions.length > 2) {
+    if (apiPermissions.length > 2) {
       const actions = []
-      apiPermissions.forEach((perm) => {
-         actions.push(perm.action)
+      apiPermissions.forEach(perm => {
+        actions.push(perm.action)
       })
-      const isRead = actions.some(action => action === 'read') 
-      const isWrite = actions.some(action => action === 'write') 
+      const isRead = actions.some(action => action === 'read')
+      const isWrite = actions.some(action => action === 'write')
 
-      if(isRead && isWrite) {
-        generatedDescription += `Read Multiple / Write Multiple`
-
+      if (isRead && isWrite) {
+        generatedDescription += `Read Multiple Write Multiple`
       } else if (isRead) {
         generatedDescription += `Read Multiple`
-
       } else if (isWrite) {
         generatedDescription += `Write Multiple`
       }
-
     } else {
-      apiPermissions.forEach((perm) => {
-      
-        if(perm.resource.name) {
-          generatedDescription += ` ${capitalize(perm.action)} ${perm.resource.type} ${perm.resource.name} `
-  
+      apiPermissions.forEach(perm => {
+        if (perm.resource.name) {
+          generatedDescription += ` ${capitalize(perm.action)} ${
+            perm.resource.type
+          } ${perm.resource.name} `
         } else {
-          generatedDescription += ` ${capitalize(perm.action)} ${perm.resource.type} `
+          generatedDescription += ` ${capitalize(perm.action)} ${
+            perm.resource.type
+          } `
         }
       })
     }
@@ -190,10 +187,12 @@ const CustomApiTokenOverlay: FC<Props> = props => {
     const {onCreateAuthorization, orgID, showOverlay} = props
 
     const apiPermissions = formatApiPermissions(permissions, orgID)
-    
+
     const token: Authorization = {
       orgID: orgID,
-      description: description ? description : generateDescription(apiPermissions),
+      description: description
+        ? description
+        : generateDescription(apiPermissions),
       permissions: apiPermissions,
     }
 

--- a/src/authorizations/components/redesigned/TokenRow.tsx
+++ b/src/authorizations/components/redesigned/TokenRow.tsx
@@ -115,10 +115,10 @@ class TokensRow extends PureComponent<Props> {
 
     permissions.forEach((perm) => {
       if(perm.resource.name) {
-        tokenDescription += ` ${capitalize(perm.action)} ${perm.resource.type} ${perm.resource.name}`
+        tokenDescription += ` ${capitalize(perm.action)} ${perm.resource.type} ${perm.resource.name} / `
 
       } else {
-        tokenDescription += ` ${capitalize(perm.action)} ${perm.resource.type}`
+        tokenDescription += ` ${capitalize(perm.action)} ${perm.resource.type} / `
       }
     })
 

--- a/src/authorizations/components/redesigned/TokenRow.tsx
+++ b/src/authorizations/components/redesigned/TokenRow.tsx
@@ -3,6 +3,7 @@ import React, {PureComponent} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
 import {createDateTimeFormatter} from 'src/utils/datetime/formatters'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
+import {capitalize} from 'lodash'
 
 // Actions
 import {
@@ -53,7 +54,7 @@ class TokensRow extends PureComponent<Props> {
     const {description} = this.props.auth
     const {auth} = this.props
     const date = new Date(auth.createdAt)
-
+    console.log("from token row : ", auth)
     return (
       <ResourceCard
         contextMenu={this.contextMenu}
@@ -72,7 +73,7 @@ class TokensRow extends PureComponent<Props> {
             onUpdate={this.handleUpdateName}
             onClick={this.handleClickDescription}
             name={description}
-            noNameString={DEFAULT_TOKEN_DESCRIPTION}
+            noNameString={this.noNameToken()}
             testID={`token-name ${auth.description}`}
           />
           <ResourceCard.Meta>
@@ -106,6 +107,22 @@ class TokensRow extends PureComponent<Props> {
         </FlexBox>
       </Context>
     )
+  }
+
+  private noNameToken = () => {
+    const { permissions } = this.props.auth
+    let tokenDescription = ""
+
+    permissions.forEach((perm) => {
+      if(perm.resource.name) {
+        tokenDescription += ` ${capitalize(perm.action)} ${perm.resource.type} ${perm.resource.name}`
+
+      } else {
+        tokenDescription += ` ${capitalize(perm.action)} ${perm.resource.type}`
+      }
+    })
+
+    return tokenDescription
   }
 
   private handleDelete = () => {

--- a/src/authorizations/components/redesigned/TokenRow.tsx
+++ b/src/authorizations/components/redesigned/TokenRow.tsx
@@ -30,9 +30,7 @@ import {Context} from 'src/clockface'
 
 // Types
 import {Authorization, AppState} from 'src/types'
-import {
-  UPDATED_AT_TIME_FORMAT,
-} from 'src/dashboards/constants'
+import {UPDATED_AT_TIME_FORMAT} from 'src/dashboards/constants'
 
 import {relativeTimestampFormatter} from 'src/shared/utils/relativeTimestampFormatter'
 import {incrementCloneName} from 'src/utils/naming'

--- a/src/authorizations/components/redesigned/TokenRow.tsx
+++ b/src/authorizations/components/redesigned/TokenRow.tsx
@@ -3,7 +3,6 @@ import React, {PureComponent} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
 import {createDateTimeFormatter} from 'src/utils/datetime/formatters'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {capitalize} from 'lodash'
 
 // Actions
 import {
@@ -32,7 +31,6 @@ import {Context} from 'src/clockface'
 // Types
 import {Authorization, AppState} from 'src/types'
 import {
-  DEFAULT_TOKEN_DESCRIPTION,
   UPDATED_AT_TIME_FORMAT,
 } from 'src/dashboards/constants'
 
@@ -54,7 +52,6 @@ class TokensRow extends PureComponent<Props> {
     const {description} = this.props.auth
     const {auth} = this.props
     const date = new Date(auth.createdAt)
-    console.log("from token row : ", auth)
     return (
       <ResourceCard
         contextMenu={this.contextMenu}
@@ -73,7 +70,6 @@ class TokensRow extends PureComponent<Props> {
             onUpdate={this.handleUpdateName}
             onClick={this.handleClickDescription}
             name={description}
-            noNameString={this.noNameToken()}
             testID={`token-name ${auth.description}`}
           />
           <ResourceCard.Meta>
@@ -107,22 +103,6 @@ class TokensRow extends PureComponent<Props> {
         </FlexBox>
       </Context>
     )
-  }
-
-  private noNameToken = () => {
-    const { permissions } = this.props.auth
-    let tokenDescription = ""
-
-    permissions.forEach((perm) => {
-      if(perm.resource.name) {
-        tokenDescription += ` ${capitalize(perm.action)} ${perm.resource.type} ${perm.resource.name} / `
-
-      } else {
-        tokenDescription += ` ${capitalize(perm.action)} ${perm.resource.type} / `
-      }
-    })
-
-    return tokenDescription
   }
 
   private handleDelete = () => {

--- a/src/authorizations/components/redesigned/TokenRow.tsx
+++ b/src/authorizations/components/redesigned/TokenRow.tsx
@@ -30,7 +30,10 @@ import {Context} from 'src/clockface'
 
 // Types
 import {Authorization, AppState} from 'src/types'
-import {UPDATED_AT_TIME_FORMAT} from 'src/dashboards/constants'
+import {
+  UPDATED_AT_TIME_FORMAT,
+  DEFAULT_TOKEN_DESCRIPTION,
+} from 'src/dashboards/constants'
 
 import {relativeTimestampFormatter} from 'src/shared/utils/relativeTimestampFormatter'
 import {incrementCloneName} from 'src/utils/naming'
@@ -68,6 +71,7 @@ class TokensRow extends PureComponent<Props> {
             onUpdate={this.handleUpdateName}
             onClick={this.handleClickDescription}
             name={description}
+            noNameString={DEFAULT_TOKEN_DESCRIPTION}
             testID={`token-name ${auth.description}`}
           />
           <ResourceCard.Meta>

--- a/src/authorizations/utils/permissions.test.ts
+++ b/src/authorizations/utils/permissions.test.ts
@@ -1,5 +1,6 @@
 import {allAccessPermissions, toggleSelectedBucket} from './permissions'
 import {CLOUD} from 'src/shared/constants'
+import {generateDescription} from 'src/authorizations/utils/permissions'
 
 // TODO remove all of this when we move to server side authority
 const ossHvhs = [
@@ -511,6 +512,142 @@ const cloudHvhs = [
   },
 ]
 
+const apiPermission1 = [
+  {
+    action: 'read',
+    resource: {
+      id: '34234532',
+      name: '_monitoring',
+      orgID: 'd34323',
+      type: 'buckets',
+    },
+  },
+  {
+    action: 'write',
+    resource: {
+      id: '34233432',
+      name: '_monitoring',
+      orgID: 'd34323',
+      type: 'buckets',
+    },
+  },
+  {
+    action: 'read',
+    resource: {
+      id: '34234532',
+      name: 'devbucket',
+      orgID: 'd34323',
+      type: 'buckets',
+    },
+  },
+  {
+    action: 'write',
+    resource: {
+      id: '34234532',
+      name: 'devbucket',
+      orgID: 'd34323',
+      type: 'buckets',
+    },
+  },
+]
+
+const apiPermission2 = [
+  {
+    action: 'read',
+    resource: {
+      orgID: 'd34323',
+      type: 'telegraf',
+    },
+  },
+  {
+    action: 'write',
+    resource: {
+      orgID: 'd34323',
+      type: 'telegraf',
+    },
+  },
+]
+
+const apiPermission3 = [
+  {
+    action: 'read',
+    resource: {
+      id: '34234532',
+      name: '_monitoring',
+      orgID: 'd34323',
+      type: 'buckets',
+    },
+  },
+  {
+    action: 'read',
+    resource: {
+      id: '34233432',
+      name: '_monitoring',
+      orgID: 'd34323',
+      type: 'buckets',
+    },
+  },
+  {
+    action: 'read',
+    resource: {
+      id: '34234532',
+      name: 'devbucket',
+      orgID: 'd34323',
+      type: 'buckets',
+    },
+  },
+]
+
+const apiPermission4 = [
+  {
+    action: 'write',
+    resource: {
+      id: '34234532',
+      name: '_monitoring',
+      orgID: 'd34323',
+      type: 'buckets',
+    },
+  },
+  {
+    action: 'write',
+    resource: {
+      id: '34233432',
+      name: '_monitoring',
+      orgID: 'd34323',
+      type: 'buckets',
+    },
+  },
+  {
+    action: 'write',
+    resource: {
+      id: '34234532',
+      name: 'devbucket',
+      orgID: 'd34323',
+      type: 'buckets',
+    },
+  },
+]
+
+const apiPermission5 = [
+  {
+    action: 'read',
+    resource: {
+      id: '34234532',
+      name: '_monitoring',
+      orgID: 'd34323',
+      type: 'buckets',
+    },
+  },
+  {
+    action: 'write',
+    resource: {
+      id: '34233432',
+      name: '_monitoring',
+      orgID: 'd34323',
+      type: 'buckets',
+    },
+  },
+]
 test('all-access tokens/authorizations production test', () => {
   if (CLOUD) {
     expect(allAccessPermissions('bulldogs', 'mario')).toMatchObject(cloudHvhs)
@@ -531,4 +668,32 @@ test('toggleSelectedBucket test', () => {
     'bucket1',
     'bucket3',
   ])
+})
+
+describe('generateDescription method', () => {
+  test('creates a description for token with mutiple permissions', () => {
+    expect(generateDescription(apiPermission1)).toBe(
+      'Read Multiple Write Multiple'
+    )
+  })
+
+  test('creates a read multiple description for token with mutiple read only permissions', () => {
+    expect(generateDescription(apiPermission3)).toBe('Read Multiple')
+  })
+
+  test('creates a write multiple description for token with mutiple write only permissions', () => {
+    expect(generateDescription(apiPermission4)).toBe('Write Multiple')
+  })
+
+  test('creates a description for token with less than 2 permissions', () => {
+    expect(generateDescription(apiPermission2)).toBe(
+      'Read telegraf Write telegraf'
+    )
+  })
+
+  test('creates a description for token with less than 2 permissions', () => {
+    expect(generateDescription(apiPermission5)).toBe(
+      'Read buckets _monitoring Write buckets _monitoring'
+    )
+  })
 })

--- a/src/authorizations/utils/permissions.ts
+++ b/src/authorizations/utils/permissions.ts
@@ -292,16 +292,16 @@ export const generateDescription = apiPermissions => {
   } else {
     apiPermissions.forEach(perm => {
       if (perm.resource.name) {
-        generatedDescription += ` ${capitalize(perm.action)} ${
+        generatedDescription += `${capitalize(perm.action)} ${
           perm.resource.type
         } ${perm.resource.name} `
       } else {
-        generatedDescription += ` ${capitalize(perm.action)} ${
+        generatedDescription += `${capitalize(perm.action)} ${
           perm.resource.type
         } `
       }
     })
   }
 
-  return generatedDescription
+  return generatedDescription.trim()
 }

--- a/src/authorizations/utils/permissions.ts
+++ b/src/authorizations/utils/permissions.ts
@@ -1,5 +1,6 @@
 import {Bucket, Permission} from 'src/types'
 import {CLOUD} from 'src/shared/constants'
+import {capitalize} from 'lodash'
 
 type PermissionTypes = Permission['resource']['type']
 
@@ -268,4 +269,39 @@ export const formatApiPermissions = (permissions, orgID) => {
     }
   })
   return apiPerms
+}
+
+export const generateDescription = apiPermissions => {
+  let generatedDescription = ''
+
+  if (apiPermissions.length > 2) {
+    const actions = []
+    apiPermissions.forEach(perm => {
+      actions.push(perm.action)
+    })
+    const isRead = actions.some(action => action === 'read')
+    const isWrite = actions.some(action => action === 'write')
+
+    if (isRead && isWrite) {
+      generatedDescription += `Read Multiple Write Multiple`
+    } else if (isRead) {
+      generatedDescription += `Read Multiple`
+    } else if (isWrite) {
+      generatedDescription += `Write Multiple`
+    }
+  } else {
+    apiPermissions.forEach(perm => {
+      if (perm.resource.name) {
+        generatedDescription += ` ${capitalize(perm.action)} ${
+          perm.resource.type
+        } ${perm.resource.name} `
+      } else {
+        generatedDescription += ` ${capitalize(perm.action)} ${
+          perm.resource.type
+        } `
+      }
+    })
+  }
+
+  return generatedDescription
 }


### PR DESCRIPTION
Closes #2107 

When user who is creating token using custom api option, selects list of resources and permissions, and clicks Generate, if  token description is not provided, the description is generated in the backend based on user selections. 

In the case of user giving a token multiple permissions, a token description with `Read Multiple Write Multiple` is generated.

https://user-images.githubusercontent.com/66275100/134956806-267961b9-0516-4525-b70f-1149adf4e722.mov

 
