### PR TITLE
feat: Tokens Redesign - delete token confirmation

### DIFF
--- a/src/authorizations/components/redesigned/TokenRow.tsx
+++ b/src/authorizations/components/redesigned/TokenRow.tsx
@@ -24,6 +24,7 @@ import {
   Button,
   ResourceCard,
   IconFont,
+  ButtonShape,
 } from '@influxdata/clockface'
 
 import {Context} from 'src/clockface'
@@ -49,11 +50,13 @@ type Props = ReduxProps & OwnProps & RouteComponentProps<{orgID: string}>
 
 const formatter = createDateTimeFormatter(UPDATED_AT_TIME_FORMAT)
 class TokensRow extends PureComponent<Props> {
+
+  
   public render() {
     const {description} = this.props.auth
     const {auth} = this.props
     const date = new Date(auth.createdAt)
-
+    
     return (
       <ResourceCard
         contextMenu={this.contextMenu}
@@ -89,28 +92,38 @@ class TokensRow extends PureComponent<Props> {
     return (
       <Context>
         <FlexBox margin={ComponentSize.Medium}>
-          <Button
+            <Button 
             icon={IconFont.Duplicate}
             color={ComponentColor.Secondary}
             text="Clone"
             onClick={this.handleClone}
             testID="clone-token"
-          />
-          <Button
+            size={ComponentSize.ExtraSmall}
+            />
+      
+          <Context.Menu
             icon={IconFont.Trash}
             color={ComponentColor.Danger}
             text="Delete"
-            onClick={this.handleDelete}
+            shape={ButtonShape.StretchToFit}
             testID="delete-token"
-          />
+          >
+            <Context.Item 
+            label="Confirm"
+            action={this.handleDelete}
+            />
+          </Context.Menu>
+          
         </FlexBox>
       </Context>
     )
   }
 
   private handleDelete = () => {
+    
     const {id, description} = this.props.auth
     this.props.onDelete(id, description)
+
   }
 
   private handleClone = () => {

--- a/src/authorizations/components/redesigned/TokenRow.tsx
+++ b/src/authorizations/components/redesigned/TokenRow.tsx
@@ -107,6 +107,7 @@ class TokensRow extends PureComponent<Props> {
             text="Delete"
             shape={ButtonShape.StretchToFit}
             testID="delete-token"
+            size={ComponentSize.ExtraSmall}
           >
             <Context.Item 
             label="Confirm"

--- a/src/authorizations/components/redesigned/TokenRow.tsx
+++ b/src/authorizations/components/redesigned/TokenRow.tsx
@@ -106,12 +106,12 @@ class TokensRow extends PureComponent<Props> {
             color={ComponentColor.Danger}
             text="Delete"
             shape={ButtonShape.StretchToFit}
-            testID="delete-token"
             size={ComponentSize.ExtraSmall}
           >
             <Context.Item 
             label="Confirm"
             action={this.handleDelete}
+            testID="delete-token"
             />
           </Context.Menu>
           

--- a/src/authorizations/components/redesigned/TokenRow.tsx
+++ b/src/authorizations/components/redesigned/TokenRow.tsx
@@ -50,13 +50,11 @@ type Props = ReduxProps & OwnProps & RouteComponentProps<{orgID: string}>
 
 const formatter = createDateTimeFormatter(UPDATED_AT_TIME_FORMAT)
 class TokensRow extends PureComponent<Props> {
-
-  
   public render() {
     const {description} = this.props.auth
     const {auth} = this.props
     const date = new Date(auth.createdAt)
-    
+
     return (
       <ResourceCard
         contextMenu={this.contextMenu}
@@ -92,15 +90,15 @@ class TokensRow extends PureComponent<Props> {
     return (
       <Context>
         <FlexBox margin={ComponentSize.Medium}>
-            <Button 
+          <Button
             icon={IconFont.Duplicate}
             color={ComponentColor.Secondary}
             text="Clone"
             onClick={this.handleClone}
             testID="clone-token"
             size={ComponentSize.ExtraSmall}
-            />
-      
+          />
+
           <Context.Menu
             icon={IconFont.Trash}
             color={ComponentColor.Danger}
@@ -108,23 +106,20 @@ class TokensRow extends PureComponent<Props> {
             shape={ButtonShape.StretchToFit}
             size={ComponentSize.ExtraSmall}
           >
-            <Context.Item 
-            label="Confirm"
-            action={this.handleDelete}
-            testID="delete-token"
+            <Context.Item
+              label="Confirm"
+              action={this.handleDelete}
+              testID="delete-token"
             />
           </Context.Menu>
-          
         </FlexBox>
       </Context>
     )
   }
 
   private handleDelete = () => {
-    
     const {id, description} = this.props.auth
     this.props.onDelete(id, description)
-
   }
 
   private handleClone = () => {


### PR DESCRIPTION
Closes #1934 

When a user is in the Tokens Page, and selects Delete for a token,
a confirmation appears, and if the users confirms, the token is deleted via the API and removed from the UI.


https://user-images.githubusercontent.com/66275100/134982942-3b0e66ea-d4c1-4de5-a4d5-f33174e39e5e.mov


