### PR TITLE
fix: sorting bug of telegraf plugins

### DIFF
--- a/src/dataLoaders/components/collectorsWizard/select/StreamingSelector2.tsx
+++ b/src/dataLoaders/components/collectorsWizard/select/StreamingSelector2.tsx
@@ -167,7 +167,9 @@ class StreamingSelectorTelegrafUiRefresh extends PureComponent<Props, State> {
         return 1
       }
       return 0
-    }).filter(plugin => plugin.name.toLocaleLowerCase().includes(searchTerm.toLocaleLowerCase()))
+    }).filter(plugin =>
+      plugin.name.toLocaleLowerCase().includes(searchTerm.toLocaleLowerCase())
+    )
   }
 
   private isCardChecked(bundle): boolean {

--- a/src/dataLoaders/components/collectorsWizard/select/StreamingSelector2.tsx
+++ b/src/dataLoaders/components/collectorsWizard/select/StreamingSelector2.tsx
@@ -160,14 +160,14 @@ class StreamingSelectorTelegrafUiRefresh extends PureComponent<Props, State> {
 
     return WRITE_DATA_TELEGRAF_PLUGINS.sort((plugin1, plugin2) => {
       // sort the plugins array alphabetically
-      if (plugin1.name.toLowerCase() < plugin2.name.toLowerCase()) {
+      if (plugin1.name.toLocaleLowerCase() < plugin2.name.toLocaleLowerCase()) {
         return -1
       }
-      if (plugin1.name.toLowerCase() > plugin2.name.toLowerCase()) {
+      if (plugin1.name.toLocaleLowerCase() > plugin2.name.toLocaleLowerCase()) {
         return 1
       }
       return 0
-    }).filter(b => b.name.toLowerCase().includes(searchTerm.toLowerCase()))
+    }).filter(plugin => plugin.name.toLocaleLowerCase().includes(searchTerm.toLocaleLowerCase()))
   }
 
   private isCardChecked(bundle): boolean {

--- a/src/dataLoaders/components/collectorsWizard/select/StreamingSelector2.tsx
+++ b/src/dataLoaders/components/collectorsWizard/select/StreamingSelector2.tsx
@@ -159,6 +159,7 @@ class StreamingSelectorTelegrafUiRefresh extends PureComponent<Props, State> {
     const {searchTerm} = this.state
 
     return WRITE_DATA_TELEGRAF_PLUGINS.sort((plugin1, plugin2) => {
+      // sort the plugins array alphabetically
       if (plugin1.name.toLowerCase() < plugin2.name.toLowerCase()) {
         return -1
       }

--- a/src/dataLoaders/components/collectorsWizard/select/StreamingSelector2.tsx
+++ b/src/dataLoaders/components/collectorsWizard/select/StreamingSelector2.tsx
@@ -158,9 +158,15 @@ class StreamingSelectorTelegrafUiRefresh extends PureComponent<Props, State> {
   private get filteredBundles(): TelegrafPlugin[] {
     const {searchTerm} = this.state
 
-    return WRITE_DATA_TELEGRAF_PLUGINS.filter(b =>
-      b.name.toLowerCase().includes(searchTerm.toLowerCase())
-    )
+    return WRITE_DATA_TELEGRAF_PLUGINS.sort((plugin1, plugin2) => {
+      if (plugin1.name.toLowerCase() < plugin2.name.toLowerCase()) {
+        return -1
+      }
+      if (plugin1.name.toLowerCase() > plugin2.name.toLowerCase()) {
+        return 1
+      }
+      return 0
+    }).filter(b => b.name.toLowerCase().includes(searchTerm.toLowerCase()))
   }
 
   private isCardChecked(bundle): boolean {


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/2711

In the [code here](https://github.com/influxdata/ui/blob/master/src/writeData/constants/contentTelegrafPlugins.ts#L414) we have a hard coded array of telegraf plugins, that was deciding the order of the plugins when we displayed it in the UI. 

I made it so that we use a sorted array, so no matter how we maintain the source array, we always have an alphabetically sorted UI.

<img width="1033" alt="Screen Shot 2021-09-27 at 3 01 44 PM" src="https://user-images.githubusercontent.com/18511823/134992023-34cd13fe-733b-482c-a041-4c2187838810.png">


