### PR TITLE
fix: allow imports for previous_results

### DIFF
--- a/src/flows/pipes/RawFluxEditor/index.ts
+++ b/src/flows/pipes/RawFluxEditor/index.ts
@@ -4,8 +4,6 @@ import View from './view'
 import ReadOnly from './readOnly'
 import './style.scss'
 
-const PREVIOUS_REGEXP = /__PREVIOUS_RESULT__/g
-
 export default register => {
   register({
     type: 'rawFluxEditor',
@@ -32,17 +30,35 @@ export default register => {
     },
     source: (data, query) => {
       try {
-        const ast = parse(
-          data.queries[data.activeQuery].text.replace(PREVIOUS_REGEXP, query)
-        )
+        const q = parse(query)
+        const ast = parse(data.queries[data.activeQuery].text)
+        const body = q.body.map(b => b.location.source).join('\n')
+
         if (!ast.body.length) {
           return ''
         }
+
+        ast.imports = Object.values(
+          q.imports.concat(ast.imports).reduce((acc, curr) => {
+            acc[curr.path.value] = curr
+            return acc
+          }, {})
+        )
+
         find(ast, node => !!Object.keys(node.comments || {}).length).forEach(
           node => {
             delete node.comments
           }
         )
+
+        find(
+          ast,
+          node =>
+            node.type === 'Identifier' && node.name === '__PREVIOUS_RESULT__'
+        ).forEach(node => {
+          node.name = body
+        })
+
         return format_from_js_file(ast)
       } catch {
         return


### PR DESCRIPTION
Closes #2609

joins imports from both queries
injects body of the last query using ast (kind of)
supports multiple injections