### PR TITLE
feat(paginated buckets): made paginated list scrollable instead of the whole page

### DIFF
--- a/src/buckets/pagination/BucketList.tsx
+++ b/src/buckets/pagination/BucketList.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {PureComponent, RefObject, createRef} from 'react'
+import React, {PureComponent, RefObject} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 import memoizeOne from 'memoize-one'
 
@@ -28,12 +28,11 @@ interface Props {
   onFilterChange: (searchTerm: string) => void
   pageHeight: number
   pageWidth: number
+  paginationRef: RefObject<HTMLDivElement>
   sortKey: string
   sortDirection: Sort
   sortType: SortTypes
 }
-
-const DEFAULT_PAGINATION_CONTROL_HEIGHT = 62
 
 class BucketList
   extends PureComponent<Props & RouteComponentProps<{orgID: string}>>
@@ -42,23 +41,11 @@ class BucketList
     getSortedResources
   )
 
-  private paginationRef: RefObject<HTMLDivElement>
   public currentPage: number = 1
   public rowsPerPage: number = 10
   public totalPages: number
 
-  constructor(props) {
-    super(props)
-
-    this.paginationRef = createRef<HTMLDivElement>()
-  }
-
   public render() {
-    const heightWithPagination =
-      this.paginationRef?.current?.clientHeight ||
-      DEFAULT_PAGINATION_CONTROL_HEIGHT
-    const height = this.props.pageHeight - heightWithPagination
-
     this.totalPages = Math.ceil(this.props.bucketCount / this.rowsPerPage)
 
     return (
@@ -66,13 +53,17 @@ class BucketList
         <ResourceList>
           <ResourceList.Body
             emptyState={this.props.emptyState}
-            style={{maxHeight: height, minHeight: height, overflow: 'scroll'}}
+            style={{
+              maxHeight: this.props.pageHeight,
+              minHeight: this.props.pageHeight,
+              overflow: 'scroll',
+            }}
           >
             {this.listBuckets}
           </ResourceList.Body>
         </ResourceList>
         <PaginationNav.PaginationNav
-          ref={this.paginationRef}
+          ref={this.props.paginationRef}
           style={{width: this.props.pageWidth}}
           totalPages={this.totalPages}
           currentPage={this.currentPage}

--- a/src/buckets/pagination/BucketsTab.tsx
+++ b/src/buckets/pagination/BucketsTab.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {PureComponent} from 'react'
+import React, {createRef, PureComponent, RefObject} from 'react'
 import {isEmpty} from 'lodash'
 import {connect, ConnectedProps} from 'react-redux'
 import {AutoSizer} from 'react-virtualized'
@@ -55,10 +55,15 @@ interface State {
 type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps
 
+const DEFAULT_PAGINATION_CONTROL_HEIGHT = 62
+const DEFAULT_TAB_NAVIGATION_HEIGHT = 62
+
 const FilterBuckets = FilterList<Bucket>()
 
 @ErrorHandling
 class BucketsTab extends PureComponent<Props, State> {
+  private paginationRef: RefObject<HTMLDivElement>
+
   constructor(props: Props) {
     super(props)
 
@@ -68,6 +73,8 @@ class BucketsTab extends PureComponent<Props, State> {
       sortDirection: Sort.Ascending,
       sortType: SortTypes.String,
     }
+
+    this.paginationRef = createRef<HTMLDivElement>()
   }
 
   public componentDidMount() {
@@ -108,6 +115,12 @@ class BucketsTab extends PureComponent<Props, State> {
     return (
       <AutoSizer>
         {({width, height}) => {
+          const heightWithPagination =
+            this.paginationRef?.current?.clientHeight +
+              DEFAULT_TAB_NAVIGATION_HEIGHT ||
+            DEFAULT_PAGINATION_CONTROL_HEIGHT + DEFAULT_TAB_NAVIGATION_HEIGHT
+
+          const adjustedHeight = height - heightWithPagination
           return (
             <>
               <TabbedPageHeader
@@ -116,7 +129,7 @@ class BucketsTab extends PureComponent<Props, State> {
                 width={width}
               />
 
-              <Grid style={{height, width}}>
+              <Grid style={{height: adjustedHeight, width}}>
                 <Grid.Row>
                   <Grid.Column
                     widthXS={Columns.Twelve}
@@ -141,11 +154,12 @@ class BucketsTab extends PureComponent<Props, State> {
                           onDeleteBucket={this.handleDeleteBucket}
                           onFilterChange={this.handleFilterUpdate}
                           onGetBucketSchema={this.handleShowBucketSchema}
-                          pageHeight={height}
+                          pageHeight={adjustedHeight}
                           pageWidth={width}
                           sortKey={sortKey}
                           sortDirection={sortDirection}
                           sortType={sortType}
+                          paginationRef={this.paginationRef}
                         />
                       )}
                     </FilterBuckets>

--- a/src/settings/components/LoadDataTabbedPage.tsx
+++ b/src/settings/components/LoadDataTabbedPage.tsx
@@ -24,8 +24,11 @@ type Props = ComponentProps & StateProps
 
 const LoadDataTabbedPage: FC<Props> = ({activeTab, orgID, children}) => {
   return (
-    <Page.Contents fullWidth={false} scrollable={true}>
-      <Tabs.Container orientation={Orientation.Horizontal}>
+    <Page.Contents fullWidth={false} scrollable={false}>
+      <Tabs.Container
+        orientation={Orientation.Horizontal}
+        stretchToFitHeight={true}
+      >
         <LoadDataNavigation activeTab={activeTab} orgID={orgID} />
         <ErrorBoundary>
           <Tabs.TabContents>{children}</Tabs.TabContents>


### PR DESCRIPTION
Closes #2627

Moves the paginated bucket list into its own panel that scrolls, so that the pagination controls remain in the same place

https://user-images.githubusercontent.com/146112/135137615-be710b45-dcc6-4160-8a82-66b42f7c18e9.mov



