### PR TITLE
feat: preview button at the top of the pipe for certain pipe types

### DIFF
--- a/src/flows/components/FlowCard.tsx
+++ b/src/flows/components/FlowCard.tsx
@@ -59,15 +59,27 @@ const FlowCard: FC<Props> = ({id, isPinned}) => {
   const meta = []
 
   if (!!flow?.createdBy) {
-    meta.push(<>Created by {flow.createdBy}</>)
+    meta.push(
+      <React.Fragment key={`${flow.id}--created-by`}>
+        Created by {flow.createdBy}
+      </React.Fragment>
+    )
   }
 
   if (flow?.createdAt) {
-    meta.push(<>Created at {flow.createdAt}</>)
+    meta.push(
+      <React.Fragment key={`${flow.id}--created-at`}>
+        Created at {flow.createdAt}
+      </React.Fragment>
+    )
   }
 
   if (flow?.updatedAt) {
-    meta.push(<>Last Modified at {flow.updatedAt}</>)
+    meta.push(
+      <React.Fragment key={`${flow.id}--updated-at`}>
+        Last Modified at {flow.updatedAt}
+      </React.Fragment>
+    )
   }
 
   return (

--- a/src/flows/components/header/index.tsx
+++ b/src/flows/components/header/index.tsx
@@ -60,7 +60,7 @@ const FlowHeader: FC = () => {
     if (isFlagEnabled('shareNotebook')) {
       getNotebooksShare({query: {orgID: '', notebookID: flow.id}})
         .then(res => {
-          if (res.data) {
+          if (!!res?.data?.length) {
             // TODO: handle there being multiple links?
             setShare({id: res.data[0].id, accessID: res.data[0].accessID})
           }

--- a/src/flows/components/header/index.tsx
+++ b/src/flows/components/header/index.tsx
@@ -60,7 +60,7 @@ const FlowHeader: FC = () => {
     if (isFlagEnabled('shareNotebook')) {
       getNotebooksShare({query: {orgID: '', notebookID: flow.id}})
         .then(res => {
-          if (!!res?.data?.length) {
+          if (!!res?.data?.[0]) {
             // TODO: handle there being multiple links?
             setShare({id: res.data[0].id, accessID: res.data[0].accessID})
           }

--- a/src/flows/components/panel/FlowPanel.tsx
+++ b/src/flows/components/panel/FlowPanel.tsx
@@ -1,5 +1,12 @@
 // Libraries
-import React, {FC, useContext, useState, useRef, useEffect} from 'react'
+import React, {
+  FC,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import classnames from 'classnames'
 import {
   Button,
@@ -37,6 +44,12 @@ export interface Props extends PipeContextProps {
 
 export const DEFAULT_RESIZER_HEIGHT = 360
 export const MINIMUM_RESIZER_HEIGHT = 220
+
+const PANEL_PREVIEW_TYPES = new Set([
+  'visualization',
+  'columnEditor',
+  'notification',
+])
 
 const FlowPanel: FC<Props> = ({
   id,
@@ -136,6 +149,11 @@ const FlowPanel: FC<Props> = ({
     <div className="flow-panel--editable-title">Error</div>
   )
 
+  const showPreviewButton = useMemo(
+    () => PANEL_PREVIEW_TYPES.has(flow.data.byID[id].type),
+    [flow, id]
+  )
+
   if (
     flow.readOnly &&
     !/^(visualization|markdown)$/.test(flow.data.byID[id]?.type)
@@ -165,6 +183,15 @@ const FlowPanel: FC<Props> = ({
                     className="flows-config-panel-button"
                   />
                 </FeatureFlag>
+                {isVisible &&
+                  isFlagEnabled('notebooksPreviewFromHere') &&
+                  showPreviewButton && (
+                    <Button
+                      onClick={() => queryDependents(id)}
+                      icon={IconFont.Play}
+                      text="Preview"
+                    />
+                  )}
                 <MenuButton id={id} />
               </div>
             </>
@@ -186,14 +213,6 @@ const FlowPanel: FC<Props> = ({
               dragRef={handleRef}
               onStartDrag={handleMouseDown}
               dragging={isDragging === 2}
-            />
-          )}
-          {isVisible && isFlagEnabled('notebooksPreviewFromHere') && (
-            <Button
-              className="flow-footer--preview"
-              onClick={() => queryDependents(id)}
-              icon={IconFont.Play}
-              text="Preview from here"
             />
           )}
         </div>

--- a/src/flows/components/panel/FlowPanel.tsx
+++ b/src/flows/components/panel/FlowPanel.tsx
@@ -45,12 +45,6 @@ export interface Props extends PipeContextProps {
 export const DEFAULT_RESIZER_HEIGHT = 360
 export const MINIMUM_RESIZER_HEIGHT = 220
 
-const PANEL_PREVIEW_TYPES = new Set([
-  'visualization',
-  'columnEditor',
-  'notification',
-])
-
 const FlowPanel: FC<Props> = ({
   id,
   controls,
@@ -59,7 +53,9 @@ const FlowPanel: FC<Props> = ({
   children,
 }) => {
   const {flow, updateMeta} = useContext(FlowContext)
-  const {printMap, queryDependents} = useContext(FlowQueryContext)
+  const {printMap, queryDependents, getPanelQueries} = useContext(
+    FlowQueryContext
+  )
   const {id: focused} = useContext(SidebarContext)
 
   const isVisible = flow.meta.byID[id]?.visible
@@ -149,10 +145,10 @@ const FlowPanel: FC<Props> = ({
     <div className="flow-panel--editable-title">Error</div>
   )
 
-  const showPreviewButton = useMemo(
-    () => PANEL_PREVIEW_TYPES.has(flow.data.byID[id].type),
-    [flow, id]
-  )
+  const showPreviewButton = useMemo(() => !!getPanelQueries(id)?.visual, [
+    getPanelQueries,
+    id,
+  ])
 
   if (
     flow.readOnly &&

--- a/src/flows/constants.ts
+++ b/src/flows/constants.ts
@@ -1,0 +1,2 @@
+export const UNPROCESSED_PANEL_TEXT =
+  'This cell will display results from the previous cell after selecting Preview.'

--- a/src/flows/constants.ts
+++ b/src/flows/constants.ts
@@ -1,2 +1,0 @@
-export const UNPROCESSED_PANEL_TEXT =
-  'This cell will display results from the previous cell after selecting Preview.'

--- a/src/flows/index.ts
+++ b/src/flows/index.ts
@@ -7,6 +7,9 @@ export interface TypeLookup {
   [key: string]: TypeRegistration
 }
 
+export const UNPROCESSED_PANEL_TEXT =
+  'This cell will display results from the previous cell after selecting Preview.'
+
 export const PIPE_DEFINITIONS: TypeLookup = {}
 export const PROJECT_NAME: string = 'Notebook'
 export const DEFAULT_PROJECT_NAME: string = `Untitled ${PROJECT_NAME}`

--- a/src/flows/pipes/Columns/readOnly.tsx
+++ b/src/flows/pipes/Columns/readOnly.tsx
@@ -10,6 +10,9 @@ import {Hash, Mapping} from 'src/flows/pipes/Columns'
 // Contexts
 import {PipeContext} from 'src/flows/context/pipe'
 
+// Constants
+import {UNPROCESSED_PANEL_TEXT} from 'src/flows/constants'
+
 // Styles
 import './styles.scss'
 
@@ -17,7 +20,7 @@ const Columns: FC<PipeProp> = ({Context}) => {
   const {data, loading, results} = useContext(PipeContext)
 
   if (!results.parsed || !results.parsed.table) {
-    let msg = 'This cell will display columns from the previous cell'
+    let msg = UNPROCESSED_PANEL_TEXT
 
     if (loading === RemoteDataState.Loading) {
       msg = 'Loading'

--- a/src/flows/pipes/Columns/readOnly.tsx
+++ b/src/flows/pipes/Columns/readOnly.tsx
@@ -11,7 +11,7 @@ import {Hash, Mapping} from 'src/flows/pipes/Columns'
 import {PipeContext} from 'src/flows/context/pipe'
 
 // Constants
-import {UNPROCESSED_PANEL_TEXT} from 'src/flows/constants'
+import {UNPROCESSED_PANEL_TEXT} from 'src/flows'
 
 // Styles
 import './styles.scss'

--- a/src/flows/pipes/Columns/view.tsx
+++ b/src/flows/pipes/Columns/view.tsx
@@ -8,7 +8,7 @@ import {Hash, Mapping} from 'src/flows/pipes/Columns'
 import './styles.scss'
 
 // Constants
-import {UNPROCESSED_PANEL_TEXT} from 'src/flows/constants'
+import {UNPROCESSED_PANEL_TEXT} from 'src/flows'
 
 const View: FC<PipeProp> = ({Context}) => {
   const {update, data, results, loading} = useContext(PipeContext)

--- a/src/flows/pipes/Columns/view.tsx
+++ b/src/flows/pipes/Columns/view.tsx
@@ -7,6 +7,9 @@ import {Hash, Mapping} from 'src/flows/pipes/Columns'
 
 import './styles.scss'
 
+// Constants
+import {UNPROCESSED_PANEL_TEXT} from 'src/flows/constants'
+
 const View: FC<PipeProp> = ({Context}) => {
   const {update, data, results, loading} = useContext(PipeContext)
 
@@ -42,7 +45,7 @@ const View: FC<PipeProp> = ({Context}) => {
   }
 
   if (!results.parsed || !results.parsed.table) {
-    let msg = 'This cell will display columns from the previous cell'
+    let msg = UNPROCESSED_PANEL_TEXT
 
     if (loading === RemoteDataState.Loading) {
       msg = 'Loading'

--- a/src/flows/pipes/Notification/readOnly.tsx
+++ b/src/flows/pipes/Notification/readOnly.tsx
@@ -31,6 +31,9 @@ import {PipeProp} from 'src/types/flows'
 // Styles
 import 'src/flows/pipes/Notification/styles.scss'
 
+// Constants
+import {UNPROCESSED_PANEL_TEXT} from 'src/flows/constants'
+
 const ReadOnly: FC<PipeProp> = ({Context}) => {
   const {data, results, loading} = useContext(PipeContext)
 
@@ -40,7 +43,7 @@ const ReadOnly: FC<PipeProp> = ({Context}) => {
     }
 
     if (loading === RemoteDataState.NotStarted) {
-      return 'This cell will display results from the previous cell'
+      return UNPROCESSED_PANEL_TEXT
     }
 
     return 'No Data Returned'

--- a/src/flows/pipes/Notification/readOnly.tsx
+++ b/src/flows/pipes/Notification/readOnly.tsx
@@ -32,7 +32,7 @@ import {PipeProp} from 'src/types/flows'
 import 'src/flows/pipes/Notification/styles.scss'
 
 // Constants
-import {UNPROCESSED_PANEL_TEXT} from 'src/flows/constants'
+import {UNPROCESSED_PANEL_TEXT} from 'src/flows'
 
 const ReadOnly: FC<PipeProp> = ({Context}) => {
   const {data, results, loading} = useContext(PipeContext)

--- a/src/flows/pipes/Notification/view.tsx
+++ b/src/flows/pipes/Notification/view.tsx
@@ -61,7 +61,7 @@ import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import 'src/flows/pipes/Notification/styles.scss'
 
 // Constants
-import {UNPROCESSED_PANEL_TEXT} from 'src/flows/constants'
+import {UNPROCESSED_PANEL_TEXT} from 'src/flows'
 
 const Notification: FC<PipeProp> = ({Context}) => {
   const dispatch = useDispatch()

--- a/src/flows/pipes/Notification/view.tsx
+++ b/src/flows/pipes/Notification/view.tsx
@@ -56,8 +56,12 @@ import {
   testNotificationFailure,
 } from 'src/shared/copy/notifications'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+
 // Styles
 import 'src/flows/pipes/Notification/styles.scss'
+
+// Constants
+import {UNPROCESSED_PANEL_TEXT} from 'src/flows/constants'
 
 const Notification: FC<PipeProp> = ({Context}) => {
   const dispatch = useDispatch()
@@ -93,7 +97,7 @@ const Notification: FC<PipeProp> = ({Context}) => {
     }
 
     if (loading === RemoteDataState.NotStarted) {
-      return 'This cell will display results from the previous cell'
+      return UNPROCESSED_PANEL_TEXT
     }
 
     return 'No Data Returned'

--- a/src/flows/pipes/Visualization/view.tsx
+++ b/src/flows/pipes/Visualization/view.tsx
@@ -23,7 +23,7 @@ import {event} from 'src/cloud/utils/reporting'
 import {downloadTextFile} from 'src/shared/utils/download'
 
 // Constants
-import {UNPROCESSED_PANEL_TEXT} from 'src/flows/constants'
+import {UNPROCESSED_PANEL_TEXT} from 'src/flows'
 
 const Visualization: FC<PipeProp> = ({Context}) => {
   const {id, data, range, loading, results} = useContext(PipeContext)

--- a/src/flows/pipes/Visualization/view.tsx
+++ b/src/flows/pipes/Visualization/view.tsx
@@ -22,6 +22,9 @@ import {PopupContext} from 'src/flows/context/popup'
 import {event} from 'src/cloud/utils/reporting'
 import {downloadTextFile} from 'src/shared/utils/download'
 
+// Constants
+import {UNPROCESSED_PANEL_TEXT} from 'src/flows/constants'
+
 const Visualization: FC<PipeProp> = ({Context}) => {
   const {id, data, range, loading, results} = useContext(PipeContext)
   const {basic, getPanelQueries} = useContext(FlowQueryContext)
@@ -48,7 +51,7 @@ const Visualization: FC<PipeProp> = ({Context}) => {
     }
 
     if (loading === RemoteDataState.NotStarted) {
-      return 'This cell will display results from the previous cell'
+      return UNPROCESSED_PANEL_TEXT
     }
 
     return 'No Data Returned'

--- a/src/flows/style.scss
+++ b/src/flows/style.scss
@@ -279,10 +279,6 @@ $cf-radius-lg: $cf-radius + 4px;
   padding: 0px 8px;
 }
 
-.flow-footer--preview {
-  bottom: 3px;
-}
-
 .flow-panel--body,
 .flow-panel--results {
   border-radius: 0 0 $cf-radius $cf-radius;


### PR DESCRIPTION
Closes #2434 

This PR tweaks the existing "preview from here" functionality by plopping the preview button for specific pipes (visualization, columns, and notifications). It also cleans up some console errors, updates and centralizes the NotStarted state of specific pipes as per the design.