### PR TITLE
fix: sidebar css

### DIFF
--- a/src/flows/components/Sidebar.scss
+++ b/src/flows/components/Sidebar.scss
@@ -3,7 +3,7 @@
 .flow-sidebar {
   flex: 0 0 300px;
   width: 300px;
-  padding: 0 $cf-marg-b;
+  padding: 0 0 0 $cf-marg-b;
 
   .sidebar--item {
     width: 137px;
@@ -40,6 +40,10 @@
   height: calc(
     100% - 30px
   ); // this is due to a scrollbar issue where the height of the button above it makes the 100% height unreachable: https://github.com/influxdata/ui/issues/2474
+}
+
+.flow-sidebar--submenu-wrapper {
+  width: calc(100% - 16px);
 }
 
 .flow-sidebar--dropdownmenu {

--- a/src/flows/components/Sidebar.tsx
+++ b/src/flows/components/Sidebar.tsx
@@ -43,7 +43,7 @@ export const SubSideBar: FC = () => {
           thumbStopColor="gray"
           thumbStartColor="gray"
         >
-          {submenu}
+          <div className="flow-sidebar--submenu-wrapper">{submenu}</div>
         </DapperScrollbars>
       </div>
     </div>


### PR DESCRIPTION
Cleans up the sidebar css to avoid the search box overlapping the scrollbar

Functions:
![image](https://user-images.githubusercontent.com/6411855/135178057-25ecb4f0-069d-41b9-abcd-7b10b62b0705.png)

Expressions:
![image](https://user-images.githubusercontent.com/6411855/135178084-e64c32f9-b5e2-4b81-8daf-ff9c4c62198e.png)
