### PR TITLE
fix: make tabbed page scrollable again

### DIFF
--- a/src/settings/components/LoadDataTabbedPage.tsx
+++ b/src/settings/components/LoadDataTabbedPage.tsx
@@ -24,7 +24,7 @@ type Props = ComponentProps & StateProps
 
 const LoadDataTabbedPage: FC<Props> = ({activeTab, orgID, children}) => {
   return (
-    <Page.Contents fullWidth={false} scrollable={false}>
+    <Page.Contents fullWidth={false} scrollable={true}>
       <Tabs.Container
         orientation={Orientation.Horizontal}
         stretchToFitHeight={true}


### PR DESCRIPTION
Starts https://github.com/influxdata/ui/issues/2736

A quick fix to put out the fire. We'll fix the logic later. 
