### PR TITLE
fix: make tabbed page respect the feature flags for scrollable logic

### DIFF
--- a/src/settings/components/LoadDataTabbedPage.tsx
+++ b/src/settings/components/LoadDataTabbedPage.tsx
@@ -42,8 +42,8 @@ const LoadDataTabbedPage: FC<Props> = ({activeTab, orgID, children}) => {
   )
 }
 
-// this function returns whether the page should be allowed to scroll or not.
-const shouldPageBeScrollable = (activeTab: string) : boolean => {
+// this function returns whether the page should be allowed to scroll or not based on the featureFlag enabled and the current tab the user is on.
+const shouldPageBeScrollable = (activeTab: string): boolean => {
   return activeTab !== 'buckets' || isFlagEnabled('fetchAllBuckets')
 }
 

--- a/src/settings/components/LoadDataTabbedPage.tsx
+++ b/src/settings/components/LoadDataTabbedPage.tsx
@@ -12,6 +12,7 @@ import {getOrg} from 'src/organizations/selectors'
 
 // Types
 import {AppState} from 'src/types'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 interface ComponentProps {
   activeTab: string
@@ -24,7 +25,10 @@ type Props = ComponentProps & StateProps
 
 const LoadDataTabbedPage: FC<Props> = ({activeTab, orgID, children}) => {
   return (
-    <Page.Contents fullWidth={false} scrollable={false}>
+    <Page.Contents
+      fullWidth={false}
+      scrollable={shouldPageBeScrollable(activeTab)}
+    >
       <Tabs.Container
         orientation={Orientation.Horizontal}
         stretchToFitHeight={true}
@@ -36,6 +40,11 @@ const LoadDataTabbedPage: FC<Props> = ({activeTab, orgID, children}) => {
       </Tabs.Container>
     </Page.Contents>
   )
+}
+
+// this function returns whether the page should be allowed to scroll or not.
+const shouldPageBeScrollable = (activeTab: string) : boolean => {
+  return activeTab !== 'buckets' || isFlagEnabled('fetchAllBuckets')
 }
 
 const mstp = (state: AppState) => {

--- a/src/settings/components/LoadDataTabbedPage.tsx
+++ b/src/settings/components/LoadDataTabbedPage.tsx
@@ -44,7 +44,10 @@ const LoadDataTabbedPage: FC<Props> = ({activeTab, orgID, children}) => {
 
 // this function returns whether the page should be allowed to scroll or not based on the featureFlag enabled and the current tab the user is on.
 const shouldPageBeScrollable = (activeTab: string): boolean => {
-  return activeTab !== 'buckets' || isFlagEnabled('fetchAllBuckets')
+  if (activeTab === 'buckets' && isFlagEnabled('fetchAllBuckets')) {
+    return false
+  }
+  return true
 }
 
 const mstp = (state: AppState) => {


### PR DESCRIPTION
Closes #2736 

Depending on what page the user is on and the feature flag `fetchAllBuckets` (which allows for paginating the buckets and improves user experience) we need to decide whether the `scrollable` property is allowed to be `true` or `false`.

I wrapped it in a function so that when we paginate other areas like the `Tokens` we can just append that logic to the function.  
