### PR TITLE
feat(buckets): store pagination and filter state in url on change

### DIFF
--- a/src/buckets/pagination/BucketList.tsx
+++ b/src/buckets/pagination/BucketList.tsx
@@ -49,7 +49,8 @@ class BucketList
     const params = new URLSearchParams(window.location.search)
     const urlPageNumber = parseInt(params.get('page'), 10)
 
-    const passedInPageIsValid = urlPageNumber && urlPageNumber <= this.totalPages && urlPageNumber >= 0
+    const passedInPageIsValid =
+      urlPageNumber && urlPageNumber <= this.totalPages && urlPageNumber >= 0
 
     if (passedInPageIsValid) {
       this.currentPage = urlPageNumber

--- a/src/buckets/pagination/BucketList.tsx
+++ b/src/buckets/pagination/BucketList.tsx
@@ -50,7 +50,7 @@ class BucketList
     const urlPageNumber = parseInt(params.get('page'), 10)
 
     const passedInPageIsValid =
-      urlPageNumber && urlPageNumber <= this.totalPages && urlPageNumber >= 0
+      urlPageNumber && urlPageNumber <= this.totalPages && urlPageNumber > 0
 
     if (passedInPageIsValid) {
       this.currentPage = urlPageNumber

--- a/src/buckets/pagination/BucketList.tsx
+++ b/src/buckets/pagination/BucketList.tsx
@@ -45,6 +45,17 @@ class BucketList
   public rowsPerPage: number = 10
   public totalPages: number
 
+  public componentDidMount() {
+    const params = new URLSearchParams(window.location.search)
+    const urlPageNumber = parseInt(params.get('page'), 10)
+
+    const passedInPageIsValid = urlPageNumber && urlPageNumber <= this.totalPages && urlPageNumber >= 0
+
+    if (passedInPageIsValid) {
+      this.currentPage = urlPageNumber
+    }
+  }
+
   public render() {
     this.totalPages = Math.ceil(this.props.bucketCount / this.rowsPerPage)
 
@@ -76,6 +87,9 @@ class BucketList
 
   public paginate = page => {
     this.currentPage = page
+    const url = new URL(location.href)
+    url.searchParams.set('page', page)
+    history.replaceState(null, '', url.toString())
     this.forceUpdate()
   }
 

--- a/src/buckets/pagination/BucketsTab.tsx
+++ b/src/buckets/pagination/BucketsTab.tsx
@@ -6,13 +6,7 @@ import {AutoSizer} from 'react-virtualized'
 
 // Components
 import {ErrorHandling} from 'src/shared/decorators/errors'
-import {
-  Grid,
-  ComponentSize,
-  Sort,
-  EmptyState,
-  Columns,
-} from '@influxdata/clockface'
+import {Columns, ComponentSize, EmptyState, Grid, Sort} from '@influxdata/clockface'
 import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
 import TabbedPageHeader from 'src/shared/components/tabbed_page/TabbedPageHeader'
 import FilterList from 'src/shared/components/FilterList'
@@ -25,14 +19,9 @@ import ResourceSortDropdown from 'src/shared/components/resource_sort_dropdown/R
 import CreateBucketButton from 'src/buckets/components/CreateBucketButton'
 
 // Actions
-import {
-  createBucket,
-  updateBucket,
-  deleteBucket,
-  getBucketSchema,
-} from 'src/buckets/actions/thunks'
+import {createBucket, deleteBucket, getBucketSchema, updateBucket} from 'src/buckets/actions/thunks'
 
-import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
+import {dismissOverlay, showOverlay} from 'src/overlays/actions/overlays'
 
 import {checkBucketLimits as checkBucketLimitsAction} from 'src/cloud/actions/limits'
 
@@ -42,7 +31,7 @@ import {getAll} from 'src/resources/selectors'
 import {SortTypes} from 'src/shared/utils/sort'
 
 // Types
-import {AppState, Bucket, ResourceType, OwnBucket} from 'src/types'
+import {AppState, Bucket, OwnBucket, ResourceType} from 'src/types'
 import {BucketSortKey} from 'src/shared/components/resource_sort_dropdown/generateSortItems'
 
 interface State {
@@ -79,7 +68,27 @@ class BucketsTab extends PureComponent<Props, State> {
 
   public componentDidMount() {
     this.props.checkBucketLimits()
+
+    let sortType: SortTypes = this.state.sortType
+    const params = new URLSearchParams(window.location.search)
+
+    let sortKey: BucketSortKey = 'name'
+    if (params.get('sortKey') === 'readableRetention') {
+      sortKey = 'readableRetention'
+      sortType = SortTypes.Date
+    }
+
+    let sortDirection: Sort = this.state.sortDirection
+    if (params.get('sortDirection') === Sort.Ascending){
+      sortDirection = Sort.Ascending
+    }
+    else if (params.get('sortDirection') === Sort.Descending){
+      sortDirection = Sort.Descending
+    }
+
+    this.setState({sortKey, sortDirection, sortType})
   }
+
 
   public render() {
     const {buckets, limitStatus} = this.props
@@ -190,6 +199,11 @@ class BucketsTab extends PureComponent<Props, State> {
     sortDirection: Sort,
     sortType: SortTypes
   ): void => {
+    const url = new URL(location.href)
+    url.searchParams.set('sortKey', sortKey)
+    url.searchParams.set('sortDirection', sortDirection)
+    history.replaceState(null, '', url.toString())
+
     this.setState({sortKey, sortDirection, sortType})
   }
 

--- a/src/buckets/pagination/BucketsTab.tsx
+++ b/src/buckets/pagination/BucketsTab.tsx
@@ -6,7 +6,13 @@ import {AutoSizer} from 'react-virtualized'
 
 // Components
 import {ErrorHandling} from 'src/shared/decorators/errors'
-import {Columns, ComponentSize, EmptyState, Grid, Sort} from '@influxdata/clockface'
+import {
+  Columns,
+  ComponentSize,
+  EmptyState,
+  Grid,
+  Sort,
+} from '@influxdata/clockface'
 import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
 import TabbedPageHeader from 'src/shared/components/tabbed_page/TabbedPageHeader'
 import FilterList from 'src/shared/components/FilterList'
@@ -19,7 +25,12 @@ import ResourceSortDropdown from 'src/shared/components/resource_sort_dropdown/R
 import CreateBucketButton from 'src/buckets/components/CreateBucketButton'
 
 // Actions
-import {createBucket, deleteBucket, getBucketSchema, updateBucket} from 'src/buckets/actions/thunks'
+import {
+  createBucket,
+  deleteBucket,
+  getBucketSchema,
+  updateBucket,
+} from 'src/buckets/actions/thunks'
 
 import {dismissOverlay, showOverlay} from 'src/overlays/actions/overlays'
 
@@ -79,16 +90,14 @@ class BucketsTab extends PureComponent<Props, State> {
     }
 
     let sortDirection: Sort = this.state.sortDirection
-    if (params.get('sortDirection') === Sort.Ascending){
+    if (params.get('sortDirection') === Sort.Ascending) {
       sortDirection = Sort.Ascending
-    }
-    else if (params.get('sortDirection') === Sort.Descending){
+    } else if (params.get('sortDirection') === Sort.Descending) {
       sortDirection = Sort.Descending
     }
 
     this.setState({sortKey, sortDirection, sortType})
   }
-
 
   public render() {
     const {buckets, limitStatus} = this.props

--- a/src/tasks/pagination/TasksList.tsx
+++ b/src/tasks/pagination/TasksList.tsx
@@ -90,7 +90,7 @@ export default class TasksList extends PureComponent<Props, State>
     const urlPageNumber = parseInt(params.get('page'), 10)
 
     const passedInPageIsValid =
-      urlPageNumber && urlPageNumber <= this.totalPages && urlPageNumber >= 0
+      urlPageNumber && urlPageNumber <= this.totalPages && urlPageNumber > 0
     if (passedInPageIsValid) {
       this.currentPage = urlPageNumber
     }


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/2725

This PR was inspired from https://github.com/influxdata/ui/pull/2610, basically does the same thing as implemented for paginated tasks, for buckets.

Video: 

https://user-images.githubusercontent.com/18511823/135359863-cc623bcc-c708-4b43-82a7-1d5a68f98abd.mov


