### PR TITLE
fix: notification endpoints toggle on token creation

### DIFF
--- a/src/authorizations/components/redesigned/ResourceAccordion.tsx
+++ b/src/authorizations/components/redesigned/ResourceAccordion.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {Component} from 'react'
-import {isEmpty, capitalize} from 'lodash'
+import {isEmpty} from 'lodash'
 
 // Clockface
 import {Accordion} from '@influxdata/clockface'
@@ -27,7 +27,7 @@ class ResourceAccordion extends Component<OwnProps> {
     }
 
     return resources.map(resource => {
-      const resourceName = capitalize(resource)
+      const resourceName = resource.charAt(0).toUpperCase() + resource.slice(1)
 
       return (
         <Accordion key={resource}>
@@ -37,7 +37,6 @@ class ResourceAccordion extends Component<OwnProps> {
             onToggleAll={onToggleAll}
             disabled={false}
           />
-
           {!isEmpty(permissions[resource].sublevelPermissions) &&
             this.getAccordionBody(resourceName, resource)}
         </Accordion>


### PR DESCRIPTION
Closes #2682 

<!-- Describe your proposed changes here. -->
Reverting this change because lodash's `capitalize` function, capitalizes the first letter but lower cases everything else. This breaks the notification endpoints because they are being stored in our obj as `notificationEndpoints` and we are trying to access `notificaitonendpoints`. So this fix only capitalizes first letter for display of the resources on the CustomApiTokenOverlay
