### PR TITLE
fix(paginatedBuckets): have pagination respect the length of filtered items

### DIFF
--- a/src/buckets/pagination/BucketList.tsx
+++ b/src/buckets/pagination/BucketList.tsx
@@ -46,7 +46,7 @@ class BucketList
   public totalPages: number
 
   public render() {
-    this.totalPages = Math.ceil(this.props.bucketCount / this.rowsPerPage)
+    this.totalPages = Math.ceil(this.props.buckets.length / this.rowsPerPage)
 
     return (
       <>


### PR DESCRIPTION
I forgot to take care of this on the first go around - the number of pages should change when filtering. Filtering the list of buckets down to a single page should remove all but one page from the pagination controls.