### PR TITLE
feat: remove prev button from the last step of telegraf overlay

### DIFF
--- a/cypress/e2e/shared/telegrafPlugins.test.ts
+++ b/cypress/e2e/shared/telegrafPlugins.test.ts
@@ -90,7 +90,7 @@ describe('Sources > Telegraf Plugins', () => {
     })
   })
 
-  it.only('can add the same plugin again to the same configuration', () => {
+  it('can add the same plugin again to the same configuration', () => {
     const examplePlugin = 'aerospike'
     const configurationName = `configuration with two ${examplePlugin}`
     const configurationDescription =

--- a/cypress/e2e/shared/telegrafPlugins.test.ts
+++ b/cypress/e2e/shared/telegrafPlugins.test.ts
@@ -90,7 +90,7 @@ describe('Sources > Telegraf Plugins', () => {
     })
   })
 
-  it('can add the same plugin again to the same configuration', () => {
+  it.only('can add the same plugin again to the same configuration', () => {
     const examplePlugin = 'aerospike'
     const configurationName = `configuration with two ${examplePlugin}`
     const configurationDescription =
@@ -170,7 +170,7 @@ describe('Sources > Telegraf Plugins', () => {
       ).should('be.visible')
       cy.getByTestID(
         'plugin-add-to-configuration-save-and-test--confirm-button'
-      ).should('be.visible')
+      ).should('be.visible').click()
       cy.getByTestID('next').click()
       cy.getByTestID('overlay--mask').should('not.exist')
     })

--- a/cypress/e2e/shared/telegrafPlugins.test.ts
+++ b/cypress/e2e/shared/telegrafPlugins.test.ts
@@ -84,9 +84,8 @@ describe('Sources > Telegraf Plugins', () => {
         'contain',
         'Your configurations have been saved'
       )
-      cy.getByTestID('overlay--footer').within(() => {
-        cy.getByTestID('next').click()
-      })
+
+      cy.getByTestID('next').click()
       cy.getByTestID('overlay--mask').should('not.exist')
     })
   })
@@ -131,9 +130,7 @@ describe('Sources > Telegraf Plugins', () => {
         'contain',
         'Your configurations have been saved'
       )
-      cy.getByTestID('overlay--footer').within(() => {
-        cy.getByTestID('next').click()
-      })
+      cy.getByTestID('next').click()
       cy.getByTestID('overlay--mask').should('not.exist')
 
       // Add to the existing config with the same plugin
@@ -224,9 +221,7 @@ describe('Sources > Telegraf Plugins', () => {
         'contain',
         'Your configurations have been saved'
       )
-      cy.getByTestID('overlay--footer').within(() => {
-        cy.getByTestID('next').click()
-      })
+      cy.getByTestID('next').click()
       cy.getByTestID('overlay--mask').should('not.exist')
 
       // Navigate back to Data > Sources to select another plugin

--- a/cypress/e2e/shared/telegrafPlugins.test.ts
+++ b/cypress/e2e/shared/telegrafPlugins.test.ts
@@ -170,12 +170,8 @@ describe('Sources > Telegraf Plugins', () => {
       ).should('be.visible')
       cy.getByTestID(
         'plugin-add-to-configuration-save-and-test--confirm-button'
-      )
-        .should('be.visible')
-        .click()
-      cy.getByTestID('overlay--footer').within(() => {
-        cy.getByTestID('next').click()
-      })
+      ).should('be.visible')
+      cy.getByTestID('next').click()
       cy.getByTestID('overlay--mask').should('not.exist')
     })
   })
@@ -269,9 +265,7 @@ describe('Sources > Telegraf Plugins', () => {
       )
         .should('be.visible')
         .click()
-      cy.getByTestID('overlay--footer').within(() => {
-        cy.getByTestID('next').click()
-      })
+      cy.getByTestID('next').click()
       cy.getByTestID('overlay--mask').should('not.exist')
     })
   })

--- a/cypress/e2e/shared/telegrafPlugins.test.ts
+++ b/cypress/e2e/shared/telegrafPlugins.test.ts
@@ -170,7 +170,9 @@ describe('Sources > Telegraf Plugins', () => {
       ).should('be.visible')
       cy.getByTestID(
         'plugin-add-to-configuration-save-and-test--confirm-button'
-      ).should('be.visible').click()
+      )
+        .should('be.visible')
+        .click()
       cy.getByTestID('next').click()
       cy.getByTestID('overlay--mask').should('not.exist')
     })

--- a/src/dataLoaders/components/collectorsWizard/verify/VerifyCollectorsStep.tsx
+++ b/src/dataLoaders/components/collectorsWizard/verify/VerifyCollectorsStep.tsx
@@ -3,9 +3,15 @@ import React, {PureComponent} from 'react'
 import {connect} from 'react-redux'
 
 // Components
-import {Form, DapperScrollbars} from '@influxdata/clockface'
+import {
+  Form,
+  DapperScrollbars,
+  Button,
+  ComponentColor,
+  ButtonType,
+  Overlay,
+} from '@influxdata/clockface'
 import DataStreaming from 'src/dataLoaders/components/verifyStep/DataStreaming'
-import OnboardingButtons from 'src/onboarding/components/OnboardingButtons'
 
 // Types
 import {CollectorsStepProps} from 'src/dataLoaders/components/collectorsWizard/CollectorsWizard'
@@ -29,14 +35,7 @@ export type Props = StateProps & OwnProps
 @ErrorHandling
 export class VerifyCollectorStep extends PureComponent<Props> {
   public render() {
-    const {
-      telegrafConfigID,
-      bucket,
-      org,
-      onDecrementCurrentStepIndex,
-      onExit,
-      token,
-    } = this.props
+    const {telegrafConfigID, bucket, org, onExit, token} = this.props
 
     return (
       <Form onSubmit={onExit} className="data-loading--form">
@@ -57,11 +56,15 @@ export class VerifyCollectorStep extends PureComponent<Props> {
             configID={telegrafConfigID}
           />
         </DapperScrollbars>
-        <OnboardingButtons
-          onClickBack={onDecrementCurrentStepIndex}
-          nextButtonText="Finish"
-          className="data-loading--button-container"
-        />
+
+        <Overlay.Footer className="data-loading--button-container">
+          <Button
+            color={ComponentColor.Primary}
+            text="Finish"
+            type={ButtonType.Submit}
+            testID="next"
+          />
+        </Overlay.Footer>
       </Form>
     )
   }

--- a/src/dataLoaders/components/collectorsWizard/verify/VerifyCollectorsStep.tsx
+++ b/src/dataLoaders/components/collectorsWizard/verify/VerifyCollectorsStep.tsx
@@ -9,7 +9,7 @@ import {
   Button,
   ComponentColor,
   ButtonType,
-  Overlay,
+  FlexBox,
 } from '@influxdata/clockface'
 import DataStreaming from 'src/dataLoaders/components/verifyStep/DataStreaming'
 
@@ -57,14 +57,14 @@ export class VerifyCollectorStep extends PureComponent<Props> {
           />
         </DapperScrollbars>
 
-        <Overlay.Footer className="data-loading--button-container">
+        <FlexBox className="data-loading--button-container">
           <Button
             color={ComponentColor.Primary}
             text="Finish"
             type={ButtonType.Submit}
             testID="next"
           />
-        </Overlay.Footer>
+        </FlexBox>
       </Form>
     )
   }

--- a/src/dataLoaders/components/verifyStep/TelegrafInstructions.tsx
+++ b/src/dataLoaders/components/verifyStep/TelegrafInstructions.tsx
@@ -22,8 +22,8 @@ class TelegrafInstructions extends PureComponent<Props> {
     }/api/v2/telegrafs/${configID || ''}`
     const exportToken = `export INFLUX_TOKEN=${token || '<INFLUX_TOKEN>'}`
     return (
-      <div data-testid="setup-instructions" className="telegraf-instructions">
-        <h6>1. Install the Latest Telegraf</h6>
+      <div data-testid="setup-instructions" className="telegraf-instructions" style={{textAlign:'left'}}>
+        <h5>1. Install the Latest Telegraf</h5>
         <p>
           You can install the latest Telegraf by visiting the{' '}
           <a
@@ -36,14 +36,14 @@ class TelegrafInstructions extends PureComponent<Props> {
           page. If you already have Telegraf installed on your system, make sure
           it's up to date. You will need version 1.9.2 or higher.
         </p>
-        <h6>2. Configure your API Token</h6>
+        <h5>2. Configure your API Token</h5>
         <p>
           Your API token is required for pushing data into InfluxDB. You can
           copy the following command to your terminal window to set an
           environment variable with your token.
         </p>
         <TokenCodeSnippet token={exportToken} configID={configID} label="CLI" />
-        <h6>3. Start Telegraf</h6>
+        <h5>3. Start Telegraf</h5>
         <p>
           Finally, you can run the following command to start the Telegraf agent
           running on your machine.

--- a/src/dataLoaders/components/verifyStep/TelegrafInstructions.tsx
+++ b/src/dataLoaders/components/verifyStep/TelegrafInstructions.tsx
@@ -22,7 +22,11 @@ class TelegrafInstructions extends PureComponent<Props> {
     }/api/v2/telegrafs/${configID || ''}`
     const exportToken = `export INFLUX_TOKEN=${token || '<INFLUX_TOKEN>'}`
     return (
-      <div data-testid="setup-instructions" className="telegraf-instructions" style={{textAlign:'left'}}>
+      <div
+        data-testid="setup-instructions"
+        className="telegraf-instructions"
+        style={{textAlign: 'left'}}
+      >
         <h5>1. Install the Latest Telegraf</h5>
         <p>
           You can install the latest Telegraf by visiting the{' '}


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/2751

Remove the previous button from the last step of the Telegraf Refresh UI Overlay. (The one where it shows the instructions, the final step.)

Screenshot:


<img width="1065" alt="Capture d’écran, le 2021-10-01 à 12 26 22 PM" src="https://user-images.githubusercontent.com/18511823/135676166-ba803b8f-d814-43ca-a6f6-4005f7a59f36.png">

