### PR TITLE
feat(notebooks): alert _notebook_link var

### DIFF
--- a/cypress/e2e/shared/flows.test.ts
+++ b/cypress/e2e/shared/flows.test.ts
@@ -436,11 +436,31 @@ describe('Flows', () => {
       // filter for dopeness
       cy.getByTestID('flux-toolbar-search--input').type('dopeness')
       cy.getByTestID('flux--fields-dopeness--inject').click({force: true})
+      cy.getByTestID('flux-toolbar-search--input').clear()
+      // filter for notebook
+      cy.getByTestID('flux-toolbar-search--input').type('notebook')
+      cy.getByTestID('flux--system-_notebook_link--inject').click({force: true})
 
-      // make sure message contains injected expression
+      // make sure message contains injected expressions
       cy.getByTestID('notification-message--monaco-editor').contains(
         'r.dopeness'
       )
+      cy.getByTestID('notification-message--monaco-editor').contains(
+        'r._notebook_link'
+      )
+
+      // make sure task export contains notebook link
+      cy.getByTestID('task-form-save').click()
+      cy.getByTestID('overlay--body').should('be.visible')
+      cy.getByTestID('flux-editor').should('exist')
+      cy.getByTestID('form--footer').scrollIntoView()
+      cy.getByTestID('overlay--body').within(() => {
+        cy.url().then(url => {
+          cy.getByTestID('flux-editor').contains(
+            `|> set(key: "_notebook_link", value: "${url}")`
+          )
+        })
+      })
     })
   })
 })

--- a/src/flows/pipes/Notification/Endpoints.tsx
+++ b/src/flows/pipes/Notification/Endpoints.tsx
@@ -23,6 +23,7 @@ export const DEFAULT_ENDPOINTS = {
       ['array', 'slack'].map(i => `import "${i}"`).join('\n'),
     generateQuery: data => `task_data
 	|> schema["fieldsAsCols"]()
+  |> set(key: "_notebook_link", value: "${window.location.href}")
 	|> monitor["check"](
 		data: check,
 		messageFn: messageFn,
@@ -82,6 +83,7 @@ export const DEFAULT_ENDPOINTS = {
 
       const out = `task_data
 	|> schema["fieldsAsCols"]()
+  |> set(key: "_notebook_link", value: "${window.location.href}")
 	|> monitor["check"](
 		data: check,
 		messageFn: messageFn,
@@ -141,6 +143,7 @@ export const DEFAULT_ENDPOINTS = {
         .join('\n'),
     generateQuery: data => `task_data
 	|> schema["fieldsAsCols"]()
+  |> set(key: "_notebook_link", value: "${window.location.href}")  
   |> monitor["check"](
 		data: check,
 		messageFn: messageFn,

--- a/src/flows/pipes/Notification/Endpoints.tsx
+++ b/src/flows/pipes/Notification/Endpoints.tsx
@@ -23,7 +23,7 @@ export const DEFAULT_ENDPOINTS = {
       ['array', 'slack'].map(i => `import "${i}"`).join('\n'),
     generateQuery: data => `task_data
 	|> schema["fieldsAsCols"]()
-  |> set(key: "_notebook_link", value: "${window.location.href}")
+      |> set(key: "_notebook_link", value: "${window.location.href}")
 	|> monitor["check"](
 		data: check,
 		messageFn: messageFn,
@@ -83,7 +83,7 @@ export const DEFAULT_ENDPOINTS = {
 
       const out = `task_data
 	|> schema["fieldsAsCols"]()
-  |> set(key: "_notebook_link", value: "${window.location.href}")
+      |> set(key: "_notebook_link", value: "${window.location.href}")
 	|> monitor["check"](
 		data: check,
 		messageFn: messageFn,

--- a/src/flows/pipes/Notification/Expressions.tsx
+++ b/src/flows/pipes/Notification/Expressions.tsx
@@ -49,9 +49,9 @@ const parsedResultToSchema = (
     '_check_id',
     '_check_name',
     '_level',
+    '_notebook_link',
     '_source_measurement',
     '_type',
-    '_notebook_link',
   ]
   const schema = {
     fields: new Set<string>(

--- a/src/flows/pipes/Notification/Expressions.tsx
+++ b/src/flows/pipes/Notification/Expressions.tsx
@@ -51,6 +51,7 @@ const parsedResultToSchema = (
     '_level',
     '_source_measurement',
     '_type',
+    '_notebook_link',
   ]
   const schema = {
     fields: new Set<string>(

--- a/src/flows/pipes/Notification/view.tsx
+++ b/src/flows/pipes/Notification/view.tsx
@@ -291,7 +291,6 @@ notification = {
 	_notification_rule_name: "Notebook Generated Rule",
 	_notification_endpoint_id: "${id}",
 	_notification_endpoint_name: "Notebook Generated Endpoint",
-  _notebook_link: "${window.location.href}",
 }
 
 task_data = ${format_from_js_file(ast)}
@@ -406,7 +405,6 @@ notification = {
 	_notification_rule_name: "Notebook Generated Rule",
 	_notification_endpoint_id: "${id}",
 	_notification_endpoint_name: "Notebook Generated Endpoint",
-  _notebook_link: "${window.location.href}",
 }
 
 task_data = ${format_from_js_file(ast)}

--- a/src/flows/pipes/Notification/view.tsx
+++ b/src/flows/pipes/Notification/view.tsx
@@ -291,6 +291,7 @@ notification = {
 	_notification_rule_name: "Notebook Generated Rule",
 	_notification_endpoint_id: "${id}",
 	_notification_endpoint_name: "Notebook Generated Endpoint",
+  _notebook_link: "${window.location.href}",
 }
 
 task_data = ${format_from_js_file(ast)}
@@ -405,6 +406,7 @@ notification = {
 	_notification_rule_name: "Notebook Generated Rule",
 	_notification_endpoint_id: "${id}",
 	_notification_endpoint_name: "Notebook Generated Endpoint",
+  _notebook_link: "${window.location.href}",
 }
 
 task_data = ${format_from_js_file(ast)}
@@ -588,6 +590,11 @@ ${DEFAULT_ENDPOINTS[data.endpoint]?.generateTestQuery(data.endpointData)}`
                           onClick={launcher}
                           color={ComponentColor.Secondary}
                           testID="notification-exp-button"
+                          status={
+                            editorInstance
+                              ? ComponentStatus.Default
+                              : ComponentStatus.Loading
+                          }
                         />
                       </FlexBox.Child>
                     )}


### PR DESCRIPTION
Closes #2671 

Adds a system var `_notebook_link` that can be used in the notification panel in notebooks like `${r._notebook_link}`. Also added this var to the Expressions sidebar. 

Also fixed a bug where the Expressions sidebar could be opened before the notification message monaco editor was mounted, causing the two to be disconnected. Now the expression button shows a loader until the editor is ready.

Includes e2e test.

Expression button waits for monaco editor:
<img width="699" alt="Screen Shot 2021-09-30 at 10 36 02AM" src="https://user-images.githubusercontent.com/6411855/135505135-2073e336-5ac5-48c2-8371-0bb2ac47a9db.png">

_notebook_link added to expressions sidebar:
![image](https://user-images.githubusercontent.com/6411855/135548979-849ff9bf-9919-49d9-802d-b02e2a1f4b15.png)

Task query contains url:
![image](https://user-images.githubusercontent.com/6411855/135548906-183f7216-e8a0-47f3-b46a-0b58890da84c.png)

Example slack alert using variable:
![image](https://user-images.githubusercontent.com/6411855/135548323-70419f8b-d854-42e0-b230-335d44f9f334.png)



