### PR TITLE
feat: override interval for Free tier users in agent settings

### DIFF
--- a/src/writeData/components/PluginCreateConfigurationFooter.tsx
+++ b/src/writeData/components/PluginCreateConfigurationFooter.tsx
@@ -21,12 +21,22 @@ import {PluginCreateConfigurationStepProps} from 'src/writeData/components/Plugi
 // Selectors
 import {getDataLoaders} from 'src/dataLoaders/selectors'
 import {getAll} from 'src/resources/selectors'
+import {getQuartzMe} from 'src/me/selectors'
 
 type ReduxProps = ConnectedProps<typeof connector>
 type Props = PluginCreateConfigurationStepProps & ReduxProps
 
+const agentSettingPatternDefault = `[agent]
+  ## Default data collection interval for all inputs
+  interval = "10s"`
+
+const agentSettingPatternFreeTier = `[agent]
+  ## Default data collection interval for all inputs
+  interval = "20s"`
+
 const PluginCreateConfigurationFooterComponent: FC<Props> = props => {
   const {
+    accountType,
     currentStepIndex,
     isValidConfiguration,
     onDecrementCurrentStepIndex,
@@ -47,7 +57,13 @@ const PluginCreateConfigurationFooterComponent: FC<Props> = props => {
 
   useEffect(() => {
     if (telegrafConfig) {
-      const {config} = telegrafConfig
+      let {config} = telegrafConfig
+      if (accountType === 'free') {
+        config = config.replace(
+          agentSettingPatternDefault,
+          agentSettingPatternFreeTier
+        )
+      }
       const position =
         typeof config === 'string'
           ? config.indexOf(`[[inputs.${pluginConfigName}]]`)
@@ -131,6 +147,7 @@ const PluginCreateConfigurationFooterComponent: FC<Props> = props => {
 
 const mstp = (state: AppState) => {
   const {telegrafConfigID} = getDataLoaders(state)
+  const {accountType} = getQuartzMe(state)
   let telegrafConfig = null
   if (telegrafConfigID) {
     const telegrafs = getAll<Telegraf>(state, ResourceType.Telegrafs)
@@ -138,7 +155,7 @@ const mstp = (state: AppState) => {
       telegraf => telegraf.id === telegrafConfigID
     )
   }
-  return {telegrafConfig}
+  return {accountType, telegrafConfig}
 }
 
 const mdtp = {

--- a/src/writeData/components/PluginCreateConfigurationFooter.tsx
+++ b/src/writeData/components/PluginCreateConfigurationFooter.tsx
@@ -23,6 +23,9 @@ import {getDataLoaders} from 'src/dataLoaders/selectors'
 import {getAll} from 'src/resources/selectors'
 import {getQuartzMe} from 'src/me/selectors'
 
+// Utils
+import {CLOUD} from 'src/shared/constants'
+
 type ReduxProps = ConnectedProps<typeof connector>
 type Props = PluginCreateConfigurationStepProps & ReduxProps
 
@@ -58,7 +61,7 @@ const PluginCreateConfigurationFooterComponent: FC<Props> = props => {
   useEffect(() => {
     if (telegrafConfig) {
       let {config} = telegrafConfig
-      if (accountType === 'free') {
+      if (CLOUD && accountType === 'free') {
         config = config.replace(
           agentSettingPatternDefault,
           agentSettingPatternFreeTier
@@ -147,7 +150,7 @@ const PluginCreateConfigurationFooterComponent: FC<Props> = props => {
 
 const mstp = (state: AppState) => {
   const {telegrafConfigID} = getDataLoaders(state)
-  const {accountType} = getQuartzMe(state)
+  const accountType = getQuartzMe(state)?.accountType ?? 'free'
   let telegrafConfig = null
   if (telegrafConfigID) {
     const telegrafs = getAll<Telegraf>(state, ResourceType.Telegrafs)


### PR DESCRIPTION
Closes #1406 

Search and replace "interval" in the agent settings when a Free tier user creates a new Telegraf configuration 