### PR TITLE
fix(paginated buckets): move user to last page of filtered results after filtering

### DIFF
--- a/src/buckets/pagination/BucketList.tsx
+++ b/src/buckets/pagination/BucketList.tsx
@@ -60,6 +60,12 @@ class BucketList
   public render() {
     this.totalPages = Math.ceil(this.props.buckets.length / this.rowsPerPage)
 
+    // if the user filters the list while on a page that is
+    // outside the new filtered list put them on the last page of the new list
+    if (this.currentPage > this.totalPages) {
+      this.paginate(this.totalPages)
+    }
+
     return (
       <>
         <ResourceList>


### PR DESCRIPTION
Closes #2761

If you're on a page of results and you filter those results and the number of pages is reduced below the page you're on, it should put you on the last of the results page.

https://user-images.githubusercontent.com/146112/135666089-ca3c0008-9ef5-4713-8f7d-438d2c5df474.mov



