### PR TITLE
fix: make pagination render methods pure

### DIFF
--- a/src/buckets/pagination/BucketList.tsx
+++ b/src/buckets/pagination/BucketList.tsx
@@ -57,14 +57,16 @@ class BucketList
     }
   }
 
-  public render() {
-    this.totalPages = Math.ceil(this.props.buckets.length / this.rowsPerPage)
-
+  public componentDidUpdate() {
     // if the user filters the list while on a page that is
     // outside the new filtered list put them on the last page of the new list
     if (this.currentPage > this.totalPages) {
       this.paginate(this.totalPages)
     }
+  }
+
+  public render() {
+    this.totalPages = Math.ceil(this.props.buckets.length / this.rowsPerPage)
 
     return (
       <>

--- a/src/tasks/pagination/TasksList.tsx
+++ b/src/tasks/pagination/TasksList.tsx
@@ -107,6 +107,14 @@ export default class TasksList extends PureComponent<Props, State>
     }
   }
 
+  public componentDidUpdate() {
+    // if the user filters the list while on a page that is
+    // outside the new filtered list put them on the last page of the new list
+    if (this.currentPage > this.totalPages) {
+      this.paginate(this.totalPages)
+    }
+  }
+
   public componentWillUnmount() {
     this.isComponentMounted = false
   }
@@ -118,12 +126,6 @@ export default class TasksList extends PureComponent<Props, State>
     const height = this.props.pageHeight - heightWithPagination
 
     this.totalPages = Math.ceil(this.props.tasks.length / this.rowsPerPage)
-
-    // if the user filters the list while on a page that is
-    // outside the new filtered list put them on the last page of the new list
-    if (this.currentPage > this.totalPages) {
-      this.paginate(this.totalPages)
-    }
 
     return (
       <>


### PR DESCRIPTION
Move a method call that eventually called forceUpdate() out of render
and into componentDidUpdate


This will fix warnings that 'render should be a pure method'