### PR TITLE
chore: fix broken links in Webhooks plugin page

### DIFF
--- a/src/writeData/components/telegrafPlugins/webhooks.md
+++ b/src/writeData/components/telegrafPlugins/webhooks.md
@@ -44,12 +44,12 @@ $ sudo service telegraf start
 
 ### Available webhooks
 
-- [Filestack](filestack/)
-- [Github](github/)
-- [Mandrill](mandrill/)
-- [Rollbar](rollbar/)
-- [Papertrail](papertrail/)
-- [Particle](particle/)
+- <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/filestack" target="_blank">Filestack</a>
+- <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/github" target="_blank">Github</a>
+- <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/mandrill" target="_blank">Mandrill</a>
+- <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/rollbar" target="_blank">Rollbar</a>
+- <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/papertrail" target="_blank">Papertrail</a>
+- <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/particle" target="_blank">Particle</a>
 
 
 ### Adding new webhooks plugin
@@ -58,4 +58,4 @@ $ sudo service telegraf start
 1. Your plugin must implement the `Webhook` interface
 1. Import your plugin in the `webhooks.go` file and add it to the `Webhooks` struct
 
-Both [Github](github/) and [Rollbar](rollbar/) are good example to follow.
+Both <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/github" target="_blank">Github</a> and <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/rollbar" target="_blank">Rollbar</a> are good examples to follow.

--- a/src/writeData/components/telegrafPlugins/webhooks.md
+++ b/src/writeData/components/telegrafPlugins/webhooks.md
@@ -44,12 +44,12 @@ $ sudo service telegraf start
 
 ### Available webhooks
 
-- <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/filestack/README.md" target="_blank">Filestack</a>
-- <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/github/README.md" target="_blank">Github</a>
-- <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/mandrill/README.md" target="_blank">Mandrill</a>
-- <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/rollbar/README.md" target="_blank">Rollbar</a>
-- <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/papertrail/README.md" target="_blank">Papertrail</a>
-- <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/particle/README.md" target="_blank">Particle</a>
+- <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/filestack/README.md" target="_blank" rel="noopener noreferrer">Filestack</a>
+- <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/github/README.md" target="_blank" rel="noopener noreferrer">Github</a>
+- <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/mandrill/README.md" target="_blank" rel="noopener noreferrer">Mandrill</a>
+- <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/rollbar/README.md" target="_blank" rel="noopener noreferrer">Rollbar</a>
+- <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/papertrail/README.md" target="_blank" rel="noopener noreferrer">Papertrail</a>
+- <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/particle/README.md" target="_blank" rel="noopener noreferrer">Particle</a>
 
 
 ### Adding new webhooks plugin
@@ -58,4 +58,4 @@ $ sudo service telegraf start
 1. Your plugin must implement the `Webhook` interface
 1. Import your plugin in the `webhooks.go` file and add it to the `Webhooks` struct
 
-Both <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/github/README.md" target="_blank">Github</a> and <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/rollbar/README.md" target="_blank">Rollbar</a> are good examples to follow.
+Both <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/github/README.md" target="_blank" rel="noopener noreferrer">Github</a> and <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/rollbar/README.md" target="_blank" rel="noopener noreferrer">Rollbar</a> are good examples to follow.

--- a/src/writeData/components/telegrafPlugins/webhooks.md
+++ b/src/writeData/components/telegrafPlugins/webhooks.md
@@ -44,12 +44,12 @@ $ sudo service telegraf start
 
 ### Available webhooks
 
-- <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/filestack" target="_blank">Filestack</a>
-- <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/github" target="_blank">Github</a>
-- <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/mandrill" target="_blank">Mandrill</a>
-- <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/rollbar" target="_blank">Rollbar</a>
-- <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/papertrail" target="_blank">Papertrail</a>
-- <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/particle" target="_blank">Particle</a>
+- <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/filestack/README.md" target="_blank">Filestack</a>
+- <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/github/README.md" target="_blank">Github</a>
+- <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/mandrill/README.md" target="_blank">Mandrill</a>
+- <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/rollbar/README.md" target="_blank">Rollbar</a>
+- <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/papertrail/README.md" target="_blank">Papertrail</a>
+- <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/particle/README.md" target="_blank">Particle</a>
 
 
 ### Adding new webhooks plugin
@@ -58,4 +58,4 @@ $ sudo service telegraf start
 1. Your plugin must implement the `Webhook` interface
 1. Import your plugin in the `webhooks.go` file and add it to the `Webhooks` struct
 
-Both <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/github" target="_blank">Github</a> and <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/rollbar" target="_blank">Rollbar</a> are good examples to follow.
+Both <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/github/README.md" target="_blank">Github</a> and <a href="https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/rollbar/README.md" target="_blank">Rollbar</a> are good examples to follow.


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/20229

- use the correct url; redirect to the appropriate Telegraf README page
- use anchor tags to open links in a new tab
