### PR TITLE
feat: Tokens customApiToken overlay permissions filter

### DIFF
--- a/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
@@ -81,6 +81,7 @@ const CustomApiTokenOverlay: FC<Props> = props => {
 
   useEffect(() => {
     const perms = {}
+
     props.allResources.forEach(resource => {
       if (resource === 'telegrafs') {
         perms[resource] = props.telegrafPermissions
@@ -199,7 +200,6 @@ const CustomApiTokenOverlay: FC<Props> = props => {
                 searchTerm={searchTerm}
                 placeholderText="Filter Access Permissions..."
                 onSearch={handleChangeSearchTerm}
-                testID="input-field--filter"
               />
               <FlexBox
                 margin={ComponentSize.Large}
@@ -236,6 +236,7 @@ const CustomApiTokenOverlay: FC<Props> = props => {
                 permissions={permissions}
                 onToggleAll={handleToggleAll}
                 onIndividualToggle={handleIndividualToggle}
+                searchTerm={searchTerm}
               />
             </FlexBox.Child>
           </FlexBox>

--- a/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
@@ -24,6 +24,7 @@ import {
   RemoteDataState,
 } from '@influxdata/clockface'
 import ResourceAccordion from 'src/authorizations/components/redesigned/ResourceAccordion'
+import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
 
 // Contexts
 import {OverlayContext} from 'src/overlays/components/OverlayController'
@@ -71,6 +72,7 @@ const CustomApiTokenOverlay: FC<Props> = props => {
 
   const [description, setDescription] = useState('')
   const [permissions, setPermissions] = useState({})
+  const [searchTerm, setSearchTerm] = useState('')
 
   useEffect(() => {
     props.getBuckets()
@@ -93,6 +95,10 @@ const CustomApiTokenOverlay: FC<Props> = props => {
 
   const handleDismiss = () => {
     props.onClose()
+  }
+
+  const handleChangeSearchTerm = (searchTerm: string): void => {
+    setSearchTerm(searchTerm)
   }
 
   const handleInputChange = event => {
@@ -189,6 +195,12 @@ const CustomApiTokenOverlay: FC<Props> = props => {
               />
             </Form.Element>
             <FlexBox.Child className="main-flexbox-child">
+              <SearchWidget
+                searchTerm={searchTerm}
+                placeholderText="Filter Access Permissions..."
+                onSearch={handleChangeSearchTerm}
+                testID="input-field--filter"
+              />
               <FlexBox
                 margin={ComponentSize.Large}
                 justifyContent={JustifyContent.SpaceBetween}

--- a/src/authorizations/components/redesigned/ResourceAccordion.tsx
+++ b/src/authorizations/components/redesigned/ResourceAccordion.tsx
@@ -57,7 +57,7 @@ class ResourceAccordion extends Component<OwnProps> {
     const {permissions, onIndividualToggle} = this.props
     const permissionNames = []
     if (resourceName === 'Telegrafs') {
-      for (const [key, value] of Object.entries(
+      for (const [, value] of Object.entries(
         permissions[resource].sublevelPermissions
       )) {
         permissionNames.push(value)
@@ -80,7 +80,7 @@ class ResourceAccordion extends Component<OwnProps> {
         </Filter>
       )
     } else if (resourceName === 'Buckets') {
-      for (const [key, value] of Object.entries(
+      for (const [, value] of Object.entries(
         permissions[resource].sublevelPermissions
       )) {
         permissionNames.push(value)

--- a/src/authorizations/components/redesigned/ResourceAccordion.tsx
+++ b/src/authorizations/components/redesigned/ResourceAccordion.tsx
@@ -4,8 +4,14 @@ import {isEmpty} from 'lodash'
 
 // Clockface
 import {Accordion} from '@influxdata/clockface'
+
+// Components
 import {ResourceAccordionHeader} from 'src/authorizations/components/redesigned/ResourceAccordionHeader'
 import {ResourceAccordionBody} from 'src/authorizations/components/redesigned/ResourceAccordionBody'
+import FilterList from 'src/shared/components/FilterList'
+
+// Types
+import {Resource} from 'src/client'
 
 interface OwnProps {
   resources: string[]
@@ -16,7 +22,10 @@ interface OwnProps {
     id: number,
     permission: string
   ) => void
+  searchTerm: string
 }
+
+const Filter = FilterList<Resource>()
 
 class ResourceAccordion extends Component<OwnProps> {
   public render() {
@@ -46,25 +55,52 @@ class ResourceAccordion extends Component<OwnProps> {
 
   getAccordionBody = (resourceName, resource) => {
     const {permissions, onIndividualToggle} = this.props
+    const permissionNames = []
     if (resourceName === 'Telegrafs') {
+      for (const [key, value] of Object.entries(
+        permissions[resource].sublevelPermissions
+      )) {
+        permissionNames.push(value)
+      }
       return (
-        <ResourceAccordionBody
-          resourceName={resource}
-          permissions={permissions[resource].sublevelPermissions}
-          onToggle={onIndividualToggle}
-          title="Individual Telegraf Configuration Names"
-          disabled={false}
-        />
+        <Filter
+          list={permissionNames}
+          searchTerm={this.props.searchTerm}
+          searchKeys={['name']}
+        >
+          {filteredNames => (
+            <ResourceAccordionBody
+              resourceName={resource}
+              permissions={filteredNames}
+              onToggle={onIndividualToggle}
+              title="Individual Telegraf Configuration Names"
+              disabled={false}
+            />
+          )}
+        </Filter>
       )
     } else if (resourceName === 'Buckets') {
+      for (const [key, value] of Object.entries(
+        permissions[resource].sublevelPermissions
+      )) {
+        permissionNames.push(value)
+      }
       return (
-        <ResourceAccordionBody
-          resourceName={resource}
-          permissions={permissions[resource].sublevelPermissions}
-          onToggle={onIndividualToggle}
-          title="Individual Bucket Names"
-          disabled={false}
-        />
+        <Filter
+          list={permissionNames}
+          searchTerm={this.props.searchTerm}
+          searchKeys={['name']}
+        >
+          {filteredNames => (
+            <ResourceAccordionBody
+              resourceName={resource}
+              permissions={filteredNames}
+              onToggle={onIndividualToggle}
+              title="Individual Bucket Names"
+              disabled={false}
+            />
+          )}
+        </Filter>
       )
     }
   }


### PR DESCRIPTION
Closes #1927 

With search parameter entered in the overlay input box, user can now filter resources of Bucket names and Telegraf configs. 

https://user-images.githubusercontent.com/66275100/135907921-7e9e7fa9-fb3a-41ea-8671-5c8589448823.mov



