### PR TITLE
fix: test typo

### DIFF
--- a/cypress/e2e/shared/dashboardsIndex.test.ts
+++ b/cypress/e2e/shared/dashboardsIndex.test.ts
@@ -557,14 +557,14 @@ describe('Dashboards', () => {
           cy.getByTestID('tree-nav')
           cy.getByTestID('nav-item-dashboards').click()
           cy.getByTestID('dashboard-card--name').click()
-          cy.getByTestID('page-title').type('dshboard') // dashboard name added to prevent failure due to downloading JSON with a different name
+          cy.getByTestID('page-title').type('dashboard') // dashboard name added to prevent failure due to downloading JSON with a different name
           cy.getByTestID('nav-item-dashboards').click()
           cy.getByTestID('dashboard-card').invoke('hover')
           cy.getByTestID('context-export-menu').click()
           cy.getByTestID('context-menu-item-export').click()
           cy.getByTestID('button').click()
           // readFile has a 4s timeout before the test fails
-          cy.readFile('cypress/downloads/dshboard.json').should('exist')
+          cy.readFile('cypress/downloads/dashboard.json').should('exist')
         })
       })
     })


### PR DESCRIPTION
`dshboard` -> `dashboard`

should fix this problem 
![image](https://user-images.githubusercontent.com/6411855/136079011-bb77bd67-88a3-41bf-ae9d-6698ee7dcb17.png)

