### PR TITLE
feat: Explicit buckets- add schemas on create

### DIFF
--- a/cypress/e2e/cloud/buckets.test.ts
+++ b/cypress/e2e/cloud/buckets.test.ts
@@ -26,13 +26,18 @@ describe('Explicit Buckets', () => {
       cy.getByInputName('name').type('explicit-bucket-test')
 
       cy.getByTestID('schemaBucketToggle').click()
+
+      // measurement schema section should NOT be showing at this time
+      // (b/c in 'implicit' mode by default)
+      cy.getByTestID('measurement-schema-section-parent').should('not.exist')
+
       const explicitBtn = cy.getByTestID('explicit-bucket-schema-choice-ID')
       explicitBtn.should('be.visible')
       explicitBtn.click()
 
-      // measurement schema section should NOT be showing at this time
-      // (b/c capability to add new measurement schemas at creation not added yet)
-      cy.getByTestID('measurement-schema-section-parent').should('not.exist')
+      // measurement schema section should BE showing at this time
+      // (b/c just changed mode to explicit)
+      cy.getByTestID('measurement-schema-section-parent').should('exist')
 
       cy.getByTestID('bucket-form-submit').click()
     })

--- a/src/buckets/actions/thunks.ts
+++ b/src/buckets/actions/thunks.ts
@@ -149,10 +149,7 @@ export const createBucketAndUpdate = (
     dispatch(addBucket(newBucket))
     dispatch(checkBucketLimits())
 
-    if (resp.data.schemaType === 'explicit' && schemas && schemas.length) {
-      // in case they choose explicit, add schemas, then change their mind back and
-      // change it to implicit; or if explicit and choose not to add schemas at this time.
-
+    if (schemas && schemas.length) {
       schemas.forEach(mschemaCreateRequest => {
         addMeasurementSchemaToBucketInternal(
           resp.data.id,
@@ -369,7 +366,7 @@ export const addSchemaToBucket = (
   bucketName: string,
   schema: typeof MeasurementSchemaCreateRequest
 ) => async (dispatch: Dispatch<Action>) => {
-  await addMeasurementSchemaToBucketInternal(
+  addMeasurementSchemaToBucketInternal(
     bucketID,
     schema,
     orgID,

--- a/src/buckets/actions/thunks.ts
+++ b/src/buckets/actions/thunks.ts
@@ -150,7 +150,7 @@ export const createBucketAndUpdate = (
     dispatch(addBucket(newBucket))
     dispatch(checkBucketLimits())
 
-    if (resp.data.schemaType === 'explicit') {
+    if (resp.data.schemaType === 'explicit' && schemas && schemas.length) {
       // in case they choose explicit, add schemas, then change their mind back and
       // change it to implicit
 
@@ -166,7 +166,9 @@ export const createBucketAndUpdate = (
         )
       })
     } else {
-      console.log(' implicit, not adding any schemas....')
+      console.log(
+        ' implicit (or no schemas present), not adding any schemas....'
+      )
     }
 
     // think....only call update after measurement schemas added (if there are schemas to add???)

--- a/src/buckets/actions/thunks.ts
+++ b/src/buckets/actions/thunks.ts
@@ -365,7 +365,7 @@ export const addSchemaToBucket = (
   orgID: string,
   bucketName: string,
   schema: typeof MeasurementSchemaCreateRequest
-) => async (dispatch: Dispatch<Action>) => {
+) => (dispatch: Dispatch<Action>) => {
   addMeasurementSchemaToBucketInternal(
     bucketID,
     schema,

--- a/src/buckets/actions/thunks.ts
+++ b/src/buckets/actions/thunks.ts
@@ -146,15 +146,12 @@ export const createBucketAndUpdate = (
     )
 
     // just created the bucket, now add any schemas that might be there:
-
     dispatch(addBucket(newBucket))
     dispatch(checkBucketLimits())
 
     if (resp.data.schemaType === 'explicit' && schemas && schemas.length) {
       // in case they choose explicit, add schemas, then change their mind back and
-      // change it to implicit
-
-      console.log('about to add schemas....', schemas)
+      // change it to implicit; or if explicit and choose not to add schemas at this time.
 
       schemas.forEach(mschemaCreateRequest => {
         addMeasurementSchemaToBucketInternal(
@@ -165,13 +162,8 @@ export const createBucketAndUpdate = (
           dispatch
         )
       })
-    } else {
-      console.log(
-        ' implicit (or no schemas present), not adding any schemas....'
-      )
     }
 
-    // think....only call update after measurement schemas added (if there are schemas to add???)
     update(newBucket.entities.buckets[resp.data.id])
   } catch (error) {
     console.error(error)

--- a/src/buckets/components/createBucketForm/BucketOverlayForm.tsx
+++ b/src/buckets/components/createBucketForm/BucketOverlayForm.tsx
@@ -99,12 +99,12 @@ export default class BucketOverlayForm extends PureComponent<Props> {
       onChangeRetentionRule,
       onClickRename,
       testID = 'bucket-form',
-      schemaType,
+      schemaType: readOnlySchemaType,
       measurementSchemaList,
       showSchemaValidation,
     } = this.props
 
-    const {showAdvanced} = this.state
+    const {showAdvanced, schemaType} = this.state
 
     const nameInputStatus = isEditing && ComponentStatus.Disabled
 
@@ -117,29 +117,36 @@ export default class BucketOverlayForm extends PureComponent<Props> {
       />
     )
 
-    const measurementSchemaSection =
-      schemaType === 'explicit' ? measurementSchemaComponent : null
+    const showMeasurementSchemaSection =
+      (isEditing && readOnlySchemaType === 'explicit') ||
+      schemaType === 'explicit'
+
+    const measurementSchemaSection = showMeasurementSchemaSection
+      ? measurementSchemaComponent
+      : null
 
     const makeAdvancedSection = () => {
       if (isFlagEnabled('measurementSchema') && CLOUD) {
-        let contents = null
+        //let contents = null
+        let schemaToggle = (
+          <SchemaToggle onChangeSchemaType={this.onChangeSchemaTypeInternal} />
+        )
+
         if (isEditing) {
-          contents = (
-            <>
-              <SchemaToggle
-                key="schemaToggleSection"
-                readOnlySchemaType={schemaType}
-              />
-              {measurementSchemaSection}
-            </>
-          )
-        } else {
-          contents = (
+          schemaToggle = (
             <SchemaToggle
-              onChangeSchemaType={this.onChangeSchemaTypeInternal}
+              key="schemaToggleSection"
+              readOnlySchemaType={readOnlySchemaType}
             />
           )
         }
+
+        const contents = (
+          <>
+            {schemaToggle}
+            {measurementSchemaSection}
+          </>
+        )
 
         return (
           <Accordion expanded={showAdvanced} testID="schemaBucketToggle">

--- a/src/buckets/components/createBucketForm/BucketOverlayForm.tsx
+++ b/src/buckets/components/createBucketForm/BucketOverlayForm.tsx
@@ -127,7 +127,6 @@ export default class BucketOverlayForm extends PureComponent<Props> {
 
     const makeAdvancedSection = () => {
       if (isFlagEnabled('measurementSchema') && CLOUD) {
-        //let contents = null
         let schemaToggle = (
           <SchemaToggle onChangeSchemaType={this.onChangeSchemaTypeInternal} />
         )

--- a/src/buckets/components/createBucketForm/CreateBucketForm.tsx
+++ b/src/buckets/components/createBucketForm/CreateBucketForm.tsx
@@ -24,6 +24,7 @@ import {AppState, Bucket, RetentionRule} from 'src/types'
 import {getOrg} from 'src/organizations/selectors'
 import {getBucketRetentionLimit} from 'src/cloud/utils/limits'
 import {getOverlayParams} from 'src/overlays/selectors'
+import {areNewSchemasValid} from './MeasurementSchemaUtils'
 
 let SchemaType = null,
   MeasurementSchemaCreateRequest = null
@@ -99,22 +100,12 @@ export const CreateBucketForm: FC<CreateBucketFormProps> = props => {
     }
 
     // ok; we are in explicit mode:  keep going!
-    // are there measurement schemas?
-    const haveSchemas =
-      Array.isArray(newMeasurementSchemaRequests) &&
-      newMeasurementSchemaRequests.length
+    const result = areNewSchemasValid(newMeasurementSchemaRequests)
 
-    if (!haveSchemas) {
-      // no schemas, nothing to validate, so everything is fine
-      // even if it is in explicit mode, can add schemas later
-      return true
+    if (result) {
+      return result
     }
-    // if so, are they all valid?
-    const alltrue = newMeasurementSchemaRequests.every(schema => schema.valid)
 
-    if (alltrue) {
-      return true
-    }
     // not all true :(
 
     // if not valid, decorate them to show they are not valid!

--- a/src/buckets/components/createBucketForm/CreateBucketForm.tsx
+++ b/src/buckets/components/createBucketForm/CreateBucketForm.tsx
@@ -19,13 +19,13 @@ import {
   DEFAULT_RULES,
 } from 'src/buckets/reducers/createBucket'
 import {AppState, Bucket, RetentionRule} from 'src/types'
-import {event as influxEvent} from '../../../cloud/utils/reporting'
+import {event} from 'src/cloud/utils/reporting'
 
 // Selectors
 import {getOrg} from 'src/organizations/selectors'
 import {getBucketRetentionLimit} from 'src/cloud/utils/limits'
 import {getOverlayParams} from 'src/overlays/selectors'
-import {areNewSchemasValid} from './MeasurementSchemaUtils'
+import {areNewSchemasValid} from 'src/buckets/components/createBucketForm/MeasurementSchemaUtils'
 
 let SchemaType = null,
   MeasurementSchemaCreateRequest = null
@@ -114,21 +114,21 @@ export const CreateBucketForm: FC<CreateBucketFormProps> = props => {
     return false
   }
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>): void => {
-    event.preventDefault()
+  const handleSubmit = (evt: FormEvent<HTMLFormElement>): void => {
+    evt.preventDefault()
     if (isValid()) {
       let mSchemas = []
-      if (newMeasurementSchemaRequests) {
+      if (state.schemaType === 'explicit' && newMeasurementSchemaRequests) {
         mSchemas = newMeasurementSchemaRequests.map(item => ({
           columns: item.columns,
           name: item.name,
         }))
       }
 
-      influxEvent('bucket.creation')
+      event('bucket.creation')
 
       for (let i = 0; i < mSchemas.length; i++) {
-        influxEvent('bucket.schema.explicit.creation.uploadSchema')
+        event('bucket.schema.explicit.creation.uploadSchema')
       }
 
       reduxDispatch(createBucketAndUpdate(state, handleUpdateBucket, mSchemas))

--- a/src/buckets/components/createBucketForm/CreateBucketForm.tsx
+++ b/src/buckets/components/createBucketForm/CreateBucketForm.tsx
@@ -19,6 +19,7 @@ import {
   DEFAULT_RULES,
 } from 'src/buckets/reducers/createBucket'
 import {AppState, Bucket, RetentionRule} from 'src/types'
+import {event as influxEvent} from '../../../cloud/utils/reporting'
 
 // Selectors
 import {getOrg} from 'src/organizations/selectors'
@@ -116,12 +117,18 @@ export const CreateBucketForm: FC<CreateBucketFormProps> = props => {
   const handleSubmit = (event: FormEvent<HTMLFormElement>): void => {
     event.preventDefault()
     if (isValid()) {
-      let mSchemas = null
+      let mSchemas = []
       if (newMeasurementSchemaRequests) {
         mSchemas = newMeasurementSchemaRequests.map(item => ({
           columns: item.columns,
           name: item.name,
         }))
+      }
+
+      influxEvent('bucket.creation')
+
+      for (let i = 0; i < mSchemas.length; i++) {
+        influxEvent('bucket.schema.explicit.creation.uploadSchema')
       }
 
       reduxDispatch(createBucketAndUpdate(state, handleUpdateBucket, mSchemas))

--- a/src/buckets/components/createBucketForm/MeasurementSchemaSection.test.tsx
+++ b/src/buckets/components/createBucketForm/MeasurementSchemaSection.test.tsx
@@ -139,19 +139,22 @@ describe('test schema validity function', () => {
     const actual = areNewSchemasValid(data)
     expect(actual).toBe(expected)
   }
-  it('should be invalid (false)', () => {
+  it('should be invalid (false); array contains a false', () => {
     doTest(schemaRequestList1, false)
   })
-  it('should be valid (true)', () => {
+  it('should be valid (true), array is all true', () => {
     doTest(schemaRequestList2, true)
   })
-  it('should be valid (true)', () => {
+  it('should be valid (true), array of one true item', () => {
     doTest(schemaRequestList3, true)
   })
-  it('should be invalid (false)', () => {
+  it('should be invalid (false), array of one false item', () => {
     doTest(schemaRequestList4, false)
   })
   it('should be valid, it is empty', () => {
     doTest([], true)
+  })
+  it('should be valid, it is null', () => {
+    doTest(null, true)
   })
 })

--- a/src/buckets/components/createBucketForm/MeasurementSchemaSection.test.tsx
+++ b/src/buckets/components/createBucketForm/MeasurementSchemaSection.test.tsx
@@ -3,6 +3,7 @@ import {
   START_ERROR,
   isNameValid,
   TOO_LONG_ERROR,
+  areNewSchemasValid,
 } from './MeasurementSchemaUtils'
 
 const oneColumns = [
@@ -55,6 +56,24 @@ const columns3 = [
   {name: 'fsWrite', type: 'field', dataType: 'float'},
   {name: 'timeSignature', type: 'tag'},
 ]
+
+const schemaRequestList1 = [
+  {valid: true},
+  {valid: true},
+  {valid: false},
+  {valid: true},
+]
+
+const schemaRequestList2 = [
+  {valid: true},
+  {valid: true},
+  {valid: true},
+  {valid: true},
+]
+
+const schemaRequestList3 = [{valid: true}]
+
+const schemaRequestList4 = [{valid: false}]
 
 describe('test data validity function', () => {
   const doTest = (data, expected) => {
@@ -112,5 +131,27 @@ describe('test name validity function', () => {
     const testMe =
       'supercalifgragahatahaeuhtsueasupercalifgragahatahaeuhtsueatuaetsnheuahtnsaeuhtnseuahtnseuahtnseuhtneuahtneuhtnseuhtnseuhtnseuhtnseuhnst'
     doTest(testMe, false, TOO_LONG_ERROR)
+  })
+})
+
+describe('test schema validity function', () => {
+  const doTest = (data, expected) => {
+    const actual = areNewSchemasValid(data)
+    expect(actual).toBe(expected)
+  }
+  it('should be invalid (false)', () => {
+    doTest(schemaRequestList1, false)
+  })
+  it('should be valid (true)', () => {
+    doTest(schemaRequestList2, true)
+  })
+  it('should be valid (true)', () => {
+    doTest(schemaRequestList3, true)
+  })
+  it('should be invalid (false)', () => {
+    doTest(schemaRequestList4, false)
+  })
+  it('should be valid, it is empty', () => {
+    doTest([], true)
   })
 })

--- a/src/buckets/components/createBucketForm/MeasurementSchemaSection.tsx
+++ b/src/buckets/components/createBucketForm/MeasurementSchemaSection.tsx
@@ -40,12 +40,10 @@ if (CLOUD) {
     .MeasurementSchemaList
 }
 
-// note:  once you can add schemas in the create mode,
-// make the second arg required
 interface Props {
   measurementSchemaList?: typeof MeasurementSchemaList
-  onUpdateSchemas?: (schemas: any, b?: boolean) => void
-  showSchemaValidation?: boolean
+  onUpdateSchemas: (schemas: any, b?: boolean) => void
+  showSchemaValidation: boolean
 }
 interface PanelProps {
   measurementSchema: typeof MeasurementSchema
@@ -264,7 +262,7 @@ export const MeasurementSchemaSection: FC<Props> = ({
   const link =
     'https://docs.influxdata.com/influxdb/cloud/organizations/buckets/bucket-schema/'
 
-  const schemas = measurementSchemaList.measurementSchemas
+  const schemas = measurementSchemaList?.measurementSchemas
   let readPanels = null
   if (schemas) {
     readPanels = schemas.map((oneSchema, index) => (

--- a/src/buckets/components/createBucketForm/MeasurementSchemaUtils.ts
+++ b/src/buckets/components/createBucketForm/MeasurementSchemaUtils.ts
@@ -94,10 +94,5 @@ export const areNewSchemasValid = newMeasurementSchemaRequests => {
     return true
   }
   // if so, are they all valid?
-  const alltrue = newMeasurementSchemaRequests.every(schema => schema.valid)
-
-  if (alltrue) {
-    return true
-  }
-  return false
+  return newMeasurementSchemaRequests.every(schema => schema.valid)
 }

--- a/src/buckets/components/createBucketForm/MeasurementSchemaUtils.ts
+++ b/src/buckets/components/createBucketForm/MeasurementSchemaUtils.ts
@@ -82,3 +82,22 @@ export const isNameValid = name => {
   }
   return {valid: true, message: null}
 }
+
+export const areNewSchemasValid = newMeasurementSchemaRequests => {
+  const haveSchemas =
+    Array.isArray(newMeasurementSchemaRequests) &&
+    newMeasurementSchemaRequests.length
+
+  if (!haveSchemas) {
+    // no schemas, nothing to validate, so everything is fine
+    // even if it is in explicit mode, can add schemas later
+    return true
+  }
+  // if so, are they all valid?
+  const alltrue = newMeasurementSchemaRequests.every(schema => schema.valid)
+
+  if (alltrue) {
+    return true
+  }
+  return false
+}

--- a/src/buckets/components/createBucketForm/UpdateBucketOverlay.tsx
+++ b/src/buckets/components/createBucketForm/UpdateBucketOverlay.tsx
@@ -38,8 +38,8 @@ import {getBucketFailed} from 'src/shared/copy/notifications'
 // Types
 import {OwnBucket} from 'src/types'
 import {CLOUD} from 'src/shared/constants'
-import {event} from '../../../cloud/utils/reporting'
-import {areNewSchemasValid} from './MeasurementSchemaUtils'
+import {event} from 'src/cloud/utils/reporting'
+import {areNewSchemasValid} from 'src/buckets/components/createBucketForm/MeasurementSchemaUtils'
 
 let SchemaType = null,
   MeasurementSchemaCreateRequest = null

--- a/src/buckets/components/createBucketForm/UpdateBucketOverlay.tsx
+++ b/src/buckets/components/createBucketForm/UpdateBucketOverlay.tsx
@@ -39,6 +39,7 @@ import {getBucketFailed} from 'src/shared/copy/notifications'
 import {OwnBucket} from 'src/types'
 import {CLOUD} from 'src/shared/constants'
 import {event} from '../../../cloud/utils/reporting'
+import {areNewSchemasValid} from './MeasurementSchemaUtils'
 
 let SchemaType = null,
   MeasurementSchemaCreateRequest = null
@@ -158,20 +159,10 @@ const UpdateBucketOverlay: FunctionComponent<Props> = ({
 
   const isValid = () => {
     // are there measurement schemas?
-    const haveSchemas =
-      Array.isArray(newMeasurementSchemaRequests) &&
-      newMeasurementSchemaRequests.length
+    const result = areNewSchemasValid(newMeasurementSchemaRequests)
 
-    if (!haveSchemas) {
-      // no schemas, nothing to validate, so everything is fine
-      return true
-    }
-    // if so, are they all valid?
-
-    const alltrue = newMeasurementSchemaRequests.every(schema => schema.valid)
-
-    if (alltrue) {
-      return true
+    if (result) {
+      return result
     }
     // not all true :(
 

--- a/src/buckets/reducers/createBucket.ts
+++ b/src/buckets/reducers/createBucket.ts
@@ -17,6 +17,7 @@ export interface ReducerState {
   readableRetention: string
   orgID: string
   type: 'user'
+  schemaType: 'implicit' | 'explicit'
 }
 
 export type ReducerActionType =
@@ -47,6 +48,7 @@ export const initialBucketState = (
     : 'forever',
   orgID,
   type: 'user' as 'user',
+  schemaType: 'implicit',
 })
 
 export const createBucketReducer = (state: ReducerState, action: Action) => {


### PR DESCRIPTION
Closes #2505 

Can now add measurement schemas during bucket creation.  

the measurement schema section appears/disappears when you toggle the 'schematype' radiobutton.

this means that if you add data, then switch back to implicit, the section disappears (along with its data).

it does correct validation:  it only validates the data when the schema type is explicit.
and you don't have to add measurement schemas if you are creating an explicit bucket, measurement schemas can be added later.

added these two events:

bucket.schema.explicit.creation.uploadSchema: triggers for each schema being added
bucket.creation: when a bucket is created (this didn't already exist, so added it)

![Screen Shot 2021-10-05 at 2 56 30 PM](https://user-images.githubusercontent.com/3900960/136085663-3ebd1d14-2474-41d9-b505-a24ae70969d2.png)

![Screen Shot 2021-10-05 at 2 56 39 PM](https://user-images.githubusercontent.com/3900960/136085695-7ea0b84a-202f-45a6-9e72-c4f523e8fa72.png)

the validation, backend calls, etc are all the same as from when the bucket already exists.

the backend call needs the bucket id, so the bucket is created first; then the schema is added.  so the notifications show up for adding the schema (successfully or unsuccessfully) too.

