### PR TITLE
Tokens:  generating token with no permission bug

### DIFF
--- a/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
@@ -75,9 +75,7 @@ const CustomApiTokenOverlay: FC<Props> = props => {
   useEffect(() => {
     props.getBuckets()
     props.getTelegrafs()
-    
   }, [])
-
 
   useEffect(() => {
     const perms = {}
@@ -164,7 +162,7 @@ const CustomApiTokenOverlay: FC<Props> = props => {
       permissions: apiPermissions,
     }
     onCreateAuthorization(token)
-    if(token.permissions.length > 0) {
+    if (token.permissions.length > 0) {
       showOverlay('access-token', null, () => dismissOverlay())
     }
   }

--- a/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
@@ -75,7 +75,9 @@ const CustomApiTokenOverlay: FC<Props> = props => {
   useEffect(() => {
     props.getBuckets()
     props.getTelegrafs()
+    
   }, [])
+
 
   useEffect(() => {
     const perms = {}
@@ -152,7 +154,6 @@ const CustomApiTokenOverlay: FC<Props> = props => {
 
   const generateToken = () => {
     const {onCreateAuthorization, orgID, showOverlay} = props
-
     const apiPermissions = formatApiPermissions(permissions, orgID)
 
     const token: Authorization = {
@@ -162,9 +163,10 @@ const CustomApiTokenOverlay: FC<Props> = props => {
         : generateDescription(apiPermissions),
       permissions: apiPermissions,
     }
-
     onCreateAuthorization(token)
-    showOverlay('access-token', null, () => dismissOverlay())
+    if(token.permissions.length > 0) {
+      showOverlay('access-token', null, () => dismissOverlay())
+    }
   }
 
   return (

--- a/src/authorizations/utils/permissions.ts
+++ b/src/authorizations/utils/permissions.ts
@@ -192,20 +192,20 @@ export const formatPermissionsObj = permissions => {
   Object.keys(newPerms).forEach(resource => {
     const accordionPermission = {...newPerms[resource]}
     if (accordionPermission.sublevelPermissions) {
-      accordionPermission.read = !Object.keys(
+      accordionPermission.read = Object.keys(
         accordionPermission.sublevelPermissions
-      ).some(
+      ).every(
         key =>
           accordionPermission.sublevelPermissions[key].permissions.read ===
-          false
+          true
       )
 
-      accordionPermission.write = !Object.keys(
+      accordionPermission.write = Object.keys(
         accordionPermission.sublevelPermissions
-      ).some(
+      ).every(
         key =>
           accordionPermission.sublevelPermissions[key].permissions.write ===
-          false
+          true
       )
 
       newPerms[resource] = accordionPermission

--- a/src/authorizations/utils/permissions.ts
+++ b/src/authorizations/utils/permissions.ts
@@ -196,8 +196,7 @@ export const formatPermissionsObj = permissions => {
         accordionPermission.sublevelPermissions
       ).every(
         key =>
-          accordionPermission.sublevelPermissions[key].permissions.read ===
-          true
+          accordionPermission.sublevelPermissions[key].permissions.read === true
       )
 
       accordionPermission.write = Object.keys(


### PR DESCRIPTION
Closes #2740 

**Proposed Changes:** 
code checks if user has selected resource permissions. This can be confirmed by the the length of the permissions array. In the case of user who has selected permissions, the array length will be greater than 0. Only then the `showOverlay` method fires, rendering the newly created token information to user.

https://user-images.githubusercontent.com/66275100/136098876-e34adb54-e602-4832-a529-f1e4fadb6148.mov

 
