### PR TITLE
fix: add fix-date to resolve safari issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,6 +172,7 @@
     "classnames": "^2.2.3",
     "codemirror": "^5.58.2",
     "connected-react-router": "^6.8.0",
+    "fix-date": "^1.1.6",
     "history": "^4.7.2",
     "honeybadger-js": "^1.0.2",
     "html-to-react": "1.3.4",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import classnames from 'classnames'
 import {Switch, Route} from 'react-router-dom'
 import {setAutoFreeze} from 'immer'
 import {AppSettingContext, AppSettingProvider} from 'src/shared/contexts/app'
-
+import 'fix-date'
 import {
   RUDDERSTACK_DATA_PLANE_URL,
   RUDDERSTACK_WRITE_KEY,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4738,6 +4738,11 @@ findup-sync@3.0.0:
     micromatch "^3.0.4"
     resolve-dir "^1.0.1"
 
+fix-date@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/fix-date/-/fix-date-1.1.6.tgz#3c89ef9ee49a70834901ab5fc871ac55aff36c48"
+  integrity sha1-PInvnuSacINJAatfyHGsVa/zbEg=
+
 flat-cache@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"


### PR DESCRIPTION
Closes #2634 

Safari doesn't support `new Date(yyyy-MM-dd HH:mm:ss)` like other browsers do so I added the [fix-date ](https://github.com/kenberkeley/fix-date) library to polyfill it for us. It's only 280 bytes in size so I think it's fine to add it, but am open to other alternatives. 

![image](https://user-images.githubusercontent.com/6411855/136121312-cefd07bf-0c53-4659-b8b0-3e7cf20a89e4.png)

