### PR TITLE
fix: send plugin info as tag

### DIFF
--- a/src/dataLoaders/components/collectorsWizard/select/StreamingSelector2.tsx
+++ b/src/dataLoaders/components/collectorsWizard/select/StreamingSelector2.tsx
@@ -189,7 +189,7 @@ class StreamingSelectorTelegrafUiRefresh extends PureComponent<Props, State> {
       configured: ConfigurationState.Configured,
     }
     this.props.onTogglePluginBundle(pluginBuild)
-    event(`telegraf_page.create_new_config.${plugin}_plugin_selected`)
+    event(`telegraf_page.create_new_config.plugin_selected`, {plugin})
   }
 
   private handleFilterChange = (e: ChangeEvent<HTMLInputElement>): void => {


### PR DESCRIPTION
Addresses final concern in influxdata/idpe#11323

Simple change to send plugin info as a tag in the event.
