### PR TITLE
feat: Save btn in EditTokenOverlay activates when description updates

### DIFF
--- a/src/authorizations/components/redesigned/EditTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/EditTokenOverlay.tsx
@@ -65,7 +65,7 @@ const EditTokenOverlay: FC<Props> = props => {
 
   const onSave = () => {
     const {onUpdate, auth} = props
-    
+
     onUpdate({
       ...auth,
       description: description,

--- a/src/authorizations/components/redesigned/EditTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/EditTokenOverlay.tsx
@@ -16,6 +16,7 @@ import {
   JustifyContent,
   Button,
   ComponentColor,
+  ComponentStatus,
   Page,
 } from '@influxdata/clockface'
 import {EditResourceAccordion} from 'src/authorizations/components/redesigned/EditResourceAccordion'
@@ -28,7 +29,6 @@ import {updateAuthorization} from 'src/authorizations/actions/thunks'
 
 // Utills
 import {formatPermissionsObj} from 'src/authorizations/utils/permissions'
-
 interface OwnProps {
   auth: Authorization
   onDismissOverlay: () => void
@@ -45,7 +45,12 @@ const labels = {
 
 const EditTokenOverlay: FC<Props> = props => {
   const [description, setDescription] = useState(props.auth.description)
-  const handleInputChange = event => setDescription(event.target.value)
+  const [status, setStatus] = useState(ComponentStatus.Disabled)
+
+  const handleInputChange = event => {
+    setDescription(event.target.value)
+    setStatus(ComponentStatus.Default)
+  }
 
   const handleDismiss = () => props.onDismissOverlay()
 
@@ -60,7 +65,7 @@ const EditTokenOverlay: FC<Props> = props => {
 
   const onSave = () => {
     const {onUpdate, auth} = props
-
+    
     onUpdate({
       ...auth,
       description: description,
@@ -151,6 +156,8 @@ const EditTokenOverlay: FC<Props> = props => {
                   text="Save"
                   onClick={onSave}
                   testID="token-save-btn"
+                  status={status}
+                  id="save"
                 />
               </FlexBox>
             </Page.ControlBarCenter>

--- a/src/authorizations/components/redesigned/EditTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/EditTokenOverlay.tsx
@@ -157,7 +157,6 @@ const EditTokenOverlay: FC<Props> = props => {
                   onClick={onSave}
                   testID="token-save-btn"
                   status={status}
-                  id="save"
                 />
               </FlexBox>
             </Page.ControlBarCenter>

--- a/src/authorizations/components/redesigned/GenerateTokenDropdown.tsx
+++ b/src/authorizations/components/redesigned/GenerateTokenDropdown.tsx
@@ -51,7 +51,7 @@ const GenerateTokenDropdown: FC<ReduxProps & GenerateTokenProps> = ({
   return (
     <Dropdown
       testID="dropdown--gen-token"
-      style={{width: '160px'}}
+      style={{width: '180px'}}
       button={(active, onClick) => (
         <Dropdown.Button
           active={active}


### PR DESCRIPTION
Closes #2807 

`Save` button inside `EditTokenOverlay` by default is inactive. Only when user interacts and updates the token description will the `save` button status changes to active.

Button right when `EditTokenOverlay` is opened ...
<img width="1274" alt="Screen Shot 2021-10-08 at 1 54 40 PM" src="https://user-images.githubusercontent.com/66275100/136611324-2d35d3fd-4019-4b2c-83d0-765f7b72b4b6.png">
 Button after user updates description...
<img width="1267" alt="Screen Shot 2021-10-08 at 1 55 32 PM" src="https://user-images.githubusercontent.com/66275100/136611421-e92b37fe-c080-47ad-862e-534a986113c0.png">

