### PR TITLE
feat: Token status in EditTokenOvelray updates when save button is clicked

### DIFF
--- a/src/authorizations/components/redesigned/EditTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/EditTokenOverlay.tsx
@@ -46,7 +46,11 @@ const labels = {
 const EditTokenOverlay: FC<Props> = props => {
   const [description, setDescription] = useState(props.auth.description)
   const [status, setStatus] = useState(ComponentStatus.Disabled)
+  const [togglestatus, setToggleStatus] = useState(props.auth.status === 'active')
+  const [label, setlabel] = useState(props.auth.status)
 
+  
+  
   const handleInputChange = event => {
     setDescription(event.target.value)
     setStatus(ComponentStatus.Default)
@@ -55,12 +59,16 @@ const EditTokenOverlay: FC<Props> = props => {
   const handleDismiss = () => props.onDismissOverlay()
 
   const changeToggle = () => {
-    const {onUpdate, auth} = props
-
-    onUpdate({
-      ...auth,
-      status: auth.status === 'active' ? 'inactive' : 'active',
-    })
+    setStatus(ComponentStatus.Default)
+    
+    if(togglestatus) {
+      setToggleStatus(false) 
+      setlabel('inactive')
+    }else {
+      setToggleStatus(true) 
+      setlabel('active')
+    }
+    
   }
 
   const onSave = () => {
@@ -69,6 +77,7 @@ const EditTokenOverlay: FC<Props> = props => {
     onUpdate({
       ...auth,
       description: description,
+      status: togglestatus ? 'active' : 'inactive'
     })
     handleDismiss()
   }
@@ -85,12 +94,12 @@ const EditTokenOverlay: FC<Props> = props => {
         >
           <FlexBox margin={ComponentSize.Medium} direction={FlexDirection.Row}>
             <SlideToggle
-              active={props.auth.status === 'active'}
+              active={togglestatus}
               size={ComponentSize.ExtraSmall}
               onChange={changeToggle}
             />
-            <InputLabel active={props.auth.status === 'active'}>
-              {labels[props.auth.status]}
+            <InputLabel active={togglestatus}>
+              {labels[label]}
             </InputLabel>
           </FlexBox>
           <Form>

--- a/src/authorizations/components/redesigned/EditTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/EditTokenOverlay.tsx
@@ -46,11 +46,11 @@ const labels = {
 const EditTokenOverlay: FC<Props> = props => {
   const [description, setDescription] = useState(props.auth.description)
   const [status, setStatus] = useState(ComponentStatus.Disabled)
-  const [togglestatus, setToggleStatus] = useState(props.auth.status === 'active')
+  const [togglestatus, setToggleStatus] = useState(
+    props.auth.status === 'active'
+  )
   const [label, setlabel] = useState(props.auth.status)
 
-  
-  
   const handleInputChange = event => {
     setDescription(event.target.value)
     setStatus(ComponentStatus.Default)
@@ -60,15 +60,14 @@ const EditTokenOverlay: FC<Props> = props => {
 
   const changeToggle = () => {
     setStatus(ComponentStatus.Default)
-    
-    if(togglestatus) {
-      setToggleStatus(false) 
+
+    if (togglestatus) {
+      setToggleStatus(false)
       setlabel('inactive')
-    }else {
-      setToggleStatus(true) 
+    } else {
+      setToggleStatus(true)
       setlabel('active')
     }
-    
   }
 
   const onSave = () => {
@@ -77,7 +76,7 @@ const EditTokenOverlay: FC<Props> = props => {
     onUpdate({
       ...auth,
       description: description,
-      status: togglestatus ? 'active' : 'inactive'
+      status: togglestatus ? 'active' : 'inactive',
     })
     handleDismiss()
   }
@@ -98,9 +97,7 @@ const EditTokenOverlay: FC<Props> = props => {
               size={ComponentSize.ExtraSmall}
               onChange={changeToggle}
             />
-            <InputLabel active={togglestatus}>
-              {labels[label]}
-            </InputLabel>
+            <InputLabel active={togglestatus}>{labels[label]}</InputLabel>
           </FlexBox>
           <Form>
             <FlexBox


### PR DESCRIPTION
Closes #2838 

Before Proposed Change: 
when the toggle on the EditTokenOverlay changes active/inactive, instead of waiting until user clicks save, we directly call the api with update parameters.

Proposed Change: 
When the user clicks the toggle, the Save button becomes active - indicating to user to save changes. Then when the save button is clicked, it calls the api with updated parameters and saves new changes. 

https://user-images.githubusercontent.com/66275100/136838442-ea0ead08-14b1-4ced-bb8c-32f3304df65e.mov


