### PR TITLE
feat(tasks): when fetching all tasks, fetch basic version

### DIFF
--- a/src/shared/containers/SetOrg.tsx
+++ b/src/shared/containers/SetOrg.tsx
@@ -12,6 +12,7 @@ import {
   TasksPagePaginated,
   TaskPage,
   TaskRunsPage,
+  TaskRunsPagePaginated,
   TaskEditPage,
   DashboardsIndex,
   DataExplorerPage,
@@ -155,6 +156,17 @@ const SetOrg: FC = () => {
           <Route path={`${orgPath}/checks/:checkID`} component={CheckHistory} />
 
           {/* Tasks */}
+          {isFlagEnabled('paginatedTasks') ? (
+            <Route
+              path={`${orgPath}/tasks/:id/runs`}
+              component={TaskRunsPagePaginated}
+            />
+          ) : (
+            <Route
+              path={`${orgPath}/tasks/:id/runs`}
+              component={TaskRunsPage}
+            />
+          )}
           <Route path={`${orgPath}/tasks/:id/runs`} component={TaskRunsPage} />
           <Route path={`${orgPath}/tasks/:id/edit`} component={TaskEditPage} />
           <Route path={`${orgPath}/tasks/new`} component={TaskPage} />

--- a/src/shared/containers/index.tsx
+++ b/src/shared/containers/index.tsx
@@ -12,6 +12,9 @@ export const TaskPage = lazy(() => import('src/tasks/containers/TaskPage'))
 export const TaskRunsPage = lazy(() =>
   import('src/tasks/components/TaskRunsPage')
 )
+export const TaskRunsPagePaginated = lazy(() =>
+  import('src/tasks/pagination/TaskRunsPage')
+)
 export const TaskEditPage = lazy(() =>
   import('src/tasks/containers/TaskEditPage')
 )

--- a/src/tasks/actions/thunks.ts
+++ b/src/tasks/actions/thunks.ts
@@ -63,7 +63,10 @@ type Action = TaskAction | ExternalActions | ReturnType<typeof getTasks>
 type ExternalActions = NotifyAction | ReturnType<typeof checkTaskLimits>
 
 // Thunks
-export const getTasks = (limit: number = TASK_LIMIT) => async (
+export const getTasks = (
+  limit: number = TASK_LIMIT,
+  type = 'default'
+) => async (
   dispatch: Dispatch<TaskAction | NotifyAction>,
   getState: GetState
 ): Promise<void> => {
@@ -75,7 +78,7 @@ export const getTasks = (limit: number = TASK_LIMIT) => async (
 
     const org = getOrg(state)
 
-    const query: GetTasksParams['query'] = {orgID: org.id, limit}
+    const query: GetTasksParams['query'] = {orgID: org.id, limit, type}
 
     const resp = await api.getTasks({query})
 

--- a/src/tasks/actions/thunks.ts
+++ b/src/tasks/actions/thunks.ts
@@ -32,6 +32,7 @@ import {
 // Constants
 import * as copy from 'src/shared/copy/notifications'
 import {parse} from 'src/external/parser'
+import {CLOUD} from 'src/shared/constants'
 
 // Types
 import {
@@ -78,7 +79,10 @@ export const getTasks = (
 
     const org = getOrg(state)
 
-    const query: GetTasksParams['query'] = {orgID: org.id, limit, type}
+    const query: GetTasksParams['query'] = {orgID: org.id, limit}
+    if (CLOUD) {
+      query.type = type
+    }
 
     const resp = await api.getTasks({query})
 

--- a/src/tasks/pagination/TasksPage.tsx
+++ b/src/tasks/pagination/TasksPage.tsx
@@ -83,7 +83,7 @@ class TasksPage extends PureComponent<Props, State> {
   }
 
   public componentDidMount() {
-    this.props.getTasks(-1) // -1 means fetch all tasks with no limit
+    this.props.getTasks(-1, 'basic') // -1 means fetch all tasks with no limit
     this.props.getLabels()
 
     let sortType: SortTypes = this.state.sortType


### PR DESCRIPTION
Closes https://github.com/influxdata/idpe/issues/11742

Updated the tasks page to use the basic form when fetching all tasks. This makes it so that the flux query text isn't fetched. It's instead fetched when we load the individual task for the tasks run page, or to edit the task query.

![Screen Shot 2021-10-11 at 12 28 07 PM](https://user-images.githubusercontent.com/146112/136845676-ef58c4a0-cf73-4b12-80e0-35862e86d709.png)

