### PR TITLE
fix: load the missing CSS for TelegrafUIRefreshWizard

### DIFF
--- a/src/dataLoaders/components/collectorsWizard/TelegrafUIRefreshWizard.tsx
+++ b/src/dataLoaders/components/collectorsWizard/TelegrafUIRefreshWizard.tsx
@@ -44,6 +44,9 @@ import {getOrg} from 'src/organizations/selectors'
 // Utils
 import {isSystemBucket} from 'src/buckets/constants'
 
+// Styles
+import 'src/writeData/components/AddPluginToConfiguration.scss'
+
 // Constants
 import {BUCKET_OVERLAY_WIDTH} from 'src/buckets/constants'
 const TELEGRAF_UI_REFRESH_OVERLAY_DEFAULT_WIDTH = 1200

--- a/src/dataLoaders/components/collectorsWizard/TelegrafUIRefreshWizard.tsx
+++ b/src/dataLoaders/components/collectorsWizard/TelegrafUIRefreshWizard.tsx
@@ -44,9 +44,6 @@ import {getOrg} from 'src/organizations/selectors'
 // Utils
 import {isSystemBucket} from 'src/buckets/constants'
 
-// Styles
-import 'src/writeData/components/AddPluginToConfiguration.scss'
-
 // Constants
 import {BUCKET_OVERLAY_WIDTH} from 'src/buckets/constants'
 const TELEGRAF_UI_REFRESH_OVERLAY_DEFAULT_WIDTH = 1200

--- a/src/style/chronograf.scss
+++ b/src/style/chronograf.scss
@@ -144,6 +144,7 @@
 @import 'src/writeData/components/fileUploads/FileUploads.scss';
 @import 'src/secrets/components/secrets.scss';
 @import 'src/buckets/components/createBucketForm/MeasurementSchema.scss';
+@import 'src/writeData/components/AddPluginToConfiguration.scss';
 
 // External
 @import '../../node_modules/@influxdata/react-custom-scrollbars/dist/styles.css';

--- a/src/writeData/components/AddPluginToConfiguration.tsx
+++ b/src/writeData/components/AddPluginToConfiguration.tsx
@@ -25,9 +25,6 @@ import {AppState} from 'src/types'
 // Selectors
 import {getAllTelegrafs} from 'src/resources/selectors'
 
-// Styles
-import 'src/writeData/components/AddPluginToConfiguration.scss'
-
 // Utils
 import {event} from 'src/cloud/utils/reporting'
 


### PR DESCRIPTION
Closes #2853 

Load the missing CSS so that the user does not have to visit Sources > Data to get that CSS.
