### PR TITLE
chore: clarify comment regarding query response from a new bucket

### DIFF
--- a/src/dataLoaders/components/verifyStep/DataListening.tsx
+++ b/src/dataLoaders/components/verifyStep/DataListening.tsx
@@ -131,7 +131,7 @@ class DataListening extends PureComponent<Props, State> {
         throw new Error(result.message)
       }
 
-      // if the bucket is empty, the CSV returned is '\n' which has a length of 2
+      // if the bucket is empty, the CSV returned is '\r\n' which has a length of 2
       // so instead,  we check for the trimmed version.
       responseLength = result.csv.trim().length
       timePassed = Number(new Date()) - this.startTime


### PR DESCRIPTION
Related to #2820 

During investigation of #2820 it was determined that no action is needed to address it since it is a non-issue. User must complete all steps before a measurable response comes back.

However, let's clarify this comment so that future eyes will see the reason quicker.