### PR TITLE
fix: update Giraffe to use latest icomoon assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "@influxdata/clockface": "^2.11.8",
     "@influxdata/flux": "^0.5.1",
     "@influxdata/flux-lsp-browser": "^0.5.53",
-    "@influxdata/giraffe": "^2.18.4",
+    "@influxdata/giraffe": "^2.18.6",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -870,10 +870,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/flux/-/flux-0.5.1.tgz#e39e7a7af9163fc9494422c8fed77f3ae1b68f56"
   integrity sha512-GHlkXBhSdJ2m56JzDkbnKPAqLj3/lexPooacu14AWTO4f2sDGLmzM7r0AxgdtU1M2x7EXNBwgGOI5EOAdN6mkw==
 
-"@influxdata/giraffe@^2.18.4":
-  version "2.18.4"
-  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.18.4.tgz#ee1c5baea72fa44e17d427400617ffbf9936659c"
-  integrity sha512-61CIdJnGsP//NedZW1GO4OAgLwcT5MC893UseT7Ne/souM7O5Cfpowogufx/z7BfjdN6axYMuRmqJU5RhYd9qA==
+"@influxdata/giraffe@^2.18.6":
+  version "2.18.6"
+  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.18.6.tgz#2fec6e4b3e5062b5e422c8a9472e1bc8eeabaead"
+  integrity sha512-R93SBGI/2oETlqrwJMIXVMy2Fulth9JoqVd5if90gwFF8S5N54H6KGi6ENcDJXRK7MPio2aNZ76g8QAtCPIldA==
   dependencies:
     merge-images "^2.0.0"
 


### PR DESCRIPTION
Closes #2629 

This should work, as seen locally:

https://user-images.githubusercontent.com/10736577/137045414-f460ffde-18c9-4bc8-9483-c9a8e2b489d9.mp4


