### PR TITLE
feat: reorg notebook nav

### DIFF
--- a/src/flows/components/AddButtons.tsx
+++ b/src/flows/components/AddButtons.tsx
@@ -25,15 +25,11 @@ interface Props {
 
 const SUPPORTED_FAMILIES = [
   {
-    name: 'Input',
+    name: 'Data Source',
     family: 'inputs',
   },
   {
-    name: 'Transform',
-    family: 'transform',
-  },
-  {
-    name: 'Pass-through',
+    name: 'Visualization',
     family: 'passThrough',
   },
   {
@@ -41,12 +37,8 @@ const SUPPORTED_FAMILIES = [
     family: 'test',
   },
   {
-    name: 'Output',
+    name: 'Action',
     family: 'output',
-  },
-  {
-    name: 'Side Effects',
-    family: 'sideEffects',
   },
 ]
 

--- a/src/flows/components/PresetFlows.tsx
+++ b/src/flows/components/PresetFlows.tsx
@@ -14,7 +14,6 @@ export const PRESET_MAP = [
   {title: 'Set an Alert', href: '/notebook/from/notification', testID: 'alert'},
   {title: 'Schedule a Task', href: '/notebook/from/task', testID: 'task'},
   {title: 'Write a Flux Script', href: '/notebook/from/flux', testID: 'script'},
-  {title: 'Blank Notebook', href: '/notebook/from/blank', testID: 'blank'},
 ]
 
 const PresetFlows: FC = () => {

--- a/src/flows/pipes/Markdown/index.ts
+++ b/src/flows/pipes/Markdown/index.ts
@@ -11,7 +11,7 @@ export default register => {
     component: MarkdownPanel,
     readOnlyComponent: ReadOnly,
     featureFlag: 'flow-panel--markdown',
-    button: 'Markdown',
+    button: 'Note',
     initial: () => ({
       text: '',
       mode: 'edit',

--- a/src/flows/pipes/MetricSelector/index.ts
+++ b/src/flows/pipes/MetricSelector/index.ts
@@ -11,6 +11,7 @@ export default register => {
     component: View,
     readOnlyComponent: ReadOnly,
     button: 'Metric Selector',
+    disabled: true,
     initial: {
       field: '',
       measurement: '',

--- a/src/flows/pipes/RawFluxEditor/index.ts
+++ b/src/flows/pipes/RawFluxEditor/index.ts
@@ -7,8 +7,8 @@ import './style.scss'
 export default register => {
   register({
     type: 'rawFluxEditor',
-    family: 'transform',
-    priority: 1,
+    family: 'inputs',
+    priority: 0,
     component: View,
     readOnlyComponent: ReadOnly,
     featureFlag: 'flow-panel--raw-flux',

--- a/src/flows/pipes/Schedule/index.ts
+++ b/src/flows/pipes/Schedule/index.ts
@@ -9,6 +9,6 @@ export default register => {
     component: View,
     readOnlyComponent: ReadOnly,
     featureFlag: 'flow-panel--schedule',
-    button: 'Schedule',
+    button: 'Task',
   })
 }

--- a/src/flows/pipes/Table/index.ts
+++ b/src/flows/pipes/Table/index.ts
@@ -1,0 +1,33 @@
+import View from './view'
+import {parse} from '@influxdata/flux'
+
+import {SUPPORTED_VISUALIZATIONS} from 'src/visualization'
+
+export default register => {
+  register({
+    type: 'table',
+    family: 'passThrough',
+    priority: 3,
+    component: View,
+    button: 'Table',
+    initial: {
+      properties: SUPPORTED_VISUALIZATIONS['simple-table'].initial,
+    },
+    visual: (data, query) => {
+      if (!query) {
+        return ''
+      }
+
+      try {
+        const ast = parse(query)
+        if (!ast.body.length) {
+          return ''
+        }
+      } catch {
+        return ''
+      }
+
+      return `${query} |> limit(n: 100)`
+    },
+  })
+}

--- a/src/flows/pipes/Table/view.tsx
+++ b/src/flows/pipes/Table/view.tsx
@@ -1,0 +1,135 @@
+// Libraries
+import React, {FC, useContext, useEffect, useMemo} from 'react'
+
+// Components
+import {Icon, IconFont} from '@influxdata/clockface'
+import FriendlyQueryError from 'src/flows/shared/FriendlyQueryError'
+
+// Utilities
+import {View} from 'src/visualization'
+
+// Types
+import {RemoteDataState} from 'src/types'
+import {PipeProp} from 'src/types/flows'
+
+import {PipeContext} from 'src/flows/context/pipe'
+import {FlowQueryContext} from 'src/flows/context/flow.query'
+import {SidebarContext} from 'src/flows/context/sidebar'
+import {PopupContext} from 'src/flows/context/popup'
+
+import {event} from 'src/cloud/utils/reporting'
+import {downloadTextFile} from 'src/shared/utils/download'
+
+// Constants
+import {UNPROCESSED_PANEL_TEXT} from 'src/flows'
+
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+
+const Table: FC<PipeProp> = ({Context}) => {
+  const {id, data, range, loading, results} = useContext(PipeContext)
+  const {basic, getPanelQueries} = useContext(FlowQueryContext)
+  const {register} = useContext(SidebarContext)
+  const {launch} = useContext(PopupContext)
+
+  const dataExists = !!(results?.parsed?.table || []).length
+
+  const queryText = getPanelQueries(id, true)?.source || ''
+  const download = () => {
+    event('CSV Download Initiated')
+    basic(queryText).promise.then(response => {
+      if (response.type !== 'SUCCESS') {
+        return
+      }
+
+      downloadTextFile(response.csv, 'influx.data', '.csv', 'text/csv')
+    })
+  }
+
+  const loadingText = useMemo(() => {
+    if (loading === RemoteDataState.Loading) {
+      return 'Loading'
+    }
+
+    if (loading === RemoteDataState.NotStarted) {
+      return UNPROCESSED_PANEL_TEXT
+    }
+
+    return 'No Data Returned'
+  }, [loading])
+
+  useEffect(() => {
+    if (!id) {
+      return
+    }
+
+    register(id, [
+      {
+        title: 'Table',
+        actions: [
+          {
+            title: 'Download as CSV',
+            disable: !dataExists,
+            action: download,
+          },
+        ],
+      },
+    ])
+  }, [id, data.properties, results.parsed, range])
+
+  if (results.error) {
+    return (
+      <Context>
+        <div className="panel-resizer panel-resizer__visible panel-resizer--error-state">
+          <div className="panel-resizer--header panel-resizer--header__multiple-controls">
+            <Icon
+              glyph={IconFont.AlertTriangle}
+              className="panel-resizer--vis-toggle"
+            />
+          </div>
+          <FriendlyQueryError error={results.error} />
+        </div>
+      </Context>
+    )
+  }
+
+  if (!dataExists) {
+    return (
+      <Context>
+        <div className="panel-resizer panel-resizer__visible" id={id}>
+          <div className="panel-resizer--header panel-resizer--header__multiple-controls">
+            <Icon
+              glyph={IconFont.BarChart}
+              className="panel-resizer--vis-toggle"
+            />
+          </div>
+          <div className="panel-resizer--body">
+            <div className="panel-resizer--empty">{loadingText}</div>
+          </div>
+        </div>
+      </Context>
+    )
+  }
+
+  let caveat = (
+    <label style={{alignSelf: 'center', marginRight: '12px'}}>
+      Limited to most recent 100 results per series
+    </label>
+  )
+
+  return (
+    <Context resizes controls={caveat}>
+      <div className="flow-visualization" id={id}>
+        <div className="flow-visualization--view">
+          <View
+            loading={loading}
+            properties={{type: 'simple-table', showAll: false}}
+            result={results.parsed}
+            timeRange={range}
+          />
+        </div>
+      </div>
+    </Context>
+  )
+}
+
+export default Table

--- a/src/flows/pipes/ToBucket/index.ts
+++ b/src/flows/pipes/ToBucket/index.ts
@@ -5,7 +5,7 @@ export default register => {
   register({
     type: 'toBucket',
     family: 'output',
-    priority: 1,
+    priority: 0,
     component: View,
     readOnlyComponent: ReadOnly,
     featureFlag: 'flow-panel--to-bucket',

--- a/src/flows/pipes/Visualization/index.ts
+++ b/src/flows/pipes/Visualization/index.ts
@@ -10,7 +10,7 @@ export default register => {
     type: 'visualization',
     family: 'passThrough',
     component: View,
-    button: 'Visualization',
+    button: 'Graph',
     initial: {
       functions: [{name: 'mean'}],
       period: '',

--- a/src/flows/templates/types/bucket.ts
+++ b/src/flows/templates/types/bucket.ts
@@ -23,12 +23,9 @@ export default register =>
               buckets: [name],
             },
             {
-              type: 'visualization',
-              properties: {
-                type: 'simple-table',
-                showAll: false,
-                title: 'Validate the Data',
-              },
+              title: 'Validate the Data',
+              visible: true,
+              type: 'table',
             },
             {
               title: 'Visualize the Result',

--- a/src/flows/templates/types/default.ts
+++ b/src/flows/templates/types/default.ts
@@ -23,8 +23,7 @@ export default register =>
             {
               title: 'Validate the Data',
               visible: true,
-              type: 'visualization',
-              properties: {type: 'simple-table', showAll: false},
+              type: 'table',
             },
             {
               title: 'Visualize the Result',

--- a/src/flows/templates/types/flux.ts
+++ b/src/flows/templates/types/flux.ts
@@ -30,14 +30,9 @@ export default register =>
               visible: true,
             },
             {
-              type: 'visualization',
-              properties: {
-                type: 'simple-table',
-                showAll: false,
-              },
-              period: '10s',
               title: 'Validate the Data',
               visible: true,
+              type: 'table',
             },
           ],
         },

--- a/src/flows/templates/types/notification.ts
+++ b/src/flows/templates/types/notification.ts
@@ -23,8 +23,7 @@ export default register =>
             {
               title: 'Validate the Data',
               visible: true,
-              type: 'visualization',
-              properties: {type: 'simple-table', showAll: false},
+              type: 'table',
             },
             {
               title: 'Visualize the Result',

--- a/src/flows/templates/types/task.ts
+++ b/src/flows/templates/types/task.ts
@@ -29,14 +29,9 @@ export default register =>
               visible: true,
             },
             {
-              type: 'visualization',
-              properties: {
-                type: 'simple-table',
-                showAll: false,
-              },
-              period: '10s',
               title: 'Validate the Data',
               visible: true,
+              type: 'table',
             },
             {
               type: 'schedule',


### PR DESCRIPTION
<img width="528" alt="Screen Shot 2021-10-14 at 8 58 38 AM" src="https://user-images.githubusercontent.com/1434802/137362699-a8ffd285-51a5-4a88-b93f-802e00ef7320.png">

paring down the options available to the user when making a notebook and renaming some nav items to make them more inline with the rest of the app's folksonomy.

some feedback was that it was rough for a user to add a visualization panel, then find the dropdown, then know what a simple table was... at the bottom of a list of other equally meaningless options, just to get introspection into their data. so i added a new panel called 'Table' that is just a simple table without any of the options to change it, and updated the templates to use it. this wont break existing visualizations, just dresses up the base functionality a little better for the use case.

also removed the "blank" template. people weren't using it

