### PR TITLE
test: hover over an annotation line instead of the whole graph

### DIFF
--- a/cypress/e2e/shared/annotations.range.test.ts
+++ b/cypress/e2e/shared/annotations.range.test.ts
@@ -31,7 +31,10 @@ describe('Annotations, but in a different test suite', () => {
       addAnnotation(cy)
 
       cy.getByTestID('cell blah').within(() => {
-        cy.getByTestID('giraffe-inner-plot').trigger('mouseover')
+        cy.get('.giraffe-annotation-line')
+          .should('exist')
+          .first()
+          .trigger('mouseover')
       })
       cy.getByTestID('giraffe-annotation-tooltip').contains('im a hippopotamus')
     })
@@ -50,7 +53,10 @@ describe('Annotations, but in a different test suite', () => {
 
       // annotation tooltip should say the old name
       cy.getByTestID('cell blah').within(() => {
-        cy.getByTestID('giraffe-inner-plot').trigger('mouseover')
+        cy.get('.giraffe-annotation-line')
+          .should('exist')
+          .first()
+          .trigger('mouseover')
       })
       cy.getByTestID('giraffe-annotation-tooltip').contains('im a hippopotamus')
     })
@@ -231,7 +237,7 @@ describe('Annotations, but in a different test suite', () => {
 
       // verify the annotation does NOT show up
       cy.getByTestID('cell blah').within(() => {
-        cy.getByTestID('giraffe-inner-plot').trigger('mouseover')
+        cy.get('.giraffe-annotation-line').should('not.exist')
       })
 
       cy.getByTestID('giraffe-annotation-tooltip').should('not.exist')

--- a/cypress/e2e/util/annotationsSetup.ts
+++ b/cypress/e2e/util/annotationsSetup.ts
@@ -158,7 +158,10 @@ export const deleteAnnotation = (cy: Cypress.Chainable) => {
 
 export const checkAnnotationText = (cy: Cypress.Chainable, text: string) => {
   cy.getByTestID('cell blah').within(() => {
-    cy.getByTestID('giraffe-inner-plot').trigger('mouseover')
+    cy.get('.giraffe-annotation-line')
+      .should('exist')
+      .first()
+      .trigger('mouseover')
   })
   cy.getByTestID('giraffe-annotation-tooltip').contains(text)
 }
@@ -236,7 +239,10 @@ export const testEditAnnotation = (cy: Cypress.Chainable) => {
 
   // annotation tooltip should say the new name
   cy.getByTestID('cell blah').within(() => {
-    cy.getByTestID('giraffe-inner-plot').trigger('mouseover')
+    cy.get('.giraffe-annotation-line')
+      .should('exist')
+      .first()
+      .trigger('mouseover')
   })
   cy.getByTestID('giraffe-annotation-tooltip').contains(
     'lets edit this annotation...'


### PR DESCRIPTION
Addresses: 
#2334 
#2466 
#2467 
#2692 

Potentially closes them out, but we'll see.

What we want is to trigger the annotation tooltip before making our assertions. Seems like this triggering of the annotation tooltip is the source of flakiness.

Instead of hovering over the whole graph, hover over an annotation line which will trigger the tooltip.
