### PR TITLE
feat: open tasks as notebooks

### DIFF
--- a/src/flows/templates/types/task.ts
+++ b/src/flows/templates/types/task.ts
@@ -1,44 +1,117 @@
 import {DEFAULT_TIME_RANGE} from 'src/shared/constants/timeRanges'
 import {AUTOREFRESH_DEFAULT} from 'src/shared/constants'
+import {parse, format_from_js_file} from '@influxdata/flux'
+import {remove} from 'src/shared/contexts/query'
 
 export default register =>
   register({
     type: 'task',
-    init: () =>
-      Promise.resolve({
-        spec: {
-          readOnly: false,
-          range: DEFAULT_TIME_RANGE,
-          refresh: AUTOREFRESH_DEFAULT,
-          pipes: [
-            {
-              activeQuery: 0,
-              queries: [
-                {
-                  text: '',
-                  editMode: 'advanced',
-                  builderConfig: {
-                    buckets: [],
-                    tags: [],
-                    functions: [],
+    init: id => {
+      if (!id) {
+        return Promise.resolve({
+          spec: {
+            readOnly: false,
+            range: DEFAULT_TIME_RANGE,
+            refresh: AUTOREFRESH_DEFAULT,
+            pipes: [
+              {
+                activeQuery: 0,
+                queries: [
+                  {
+                    text: '',
+                    editMode: 'advanced',
+                    builderConfig: {
+                      buckets: [],
+                      tags: [],
+                      functions: [],
+                    },
                   },
+                ],
+                type: 'rawFluxEditor',
+                title: 'Query to Run',
+                visible: true,
+              },
+              {
+                title: 'Validate the Data',
+                visible: true,
+                type: 'table',
+              },
+              {
+                type: 'schedule',
+                title: 'Schedule',
+                visible: true,
+              },
+            ],
+          },
+        })
+      }
+
+      return fetch(`/api/v2/tasks/${id}`)
+        .then(resp => resp.json())
+        .then(resp => {
+          const ast = parse(resp.flux)
+          const taskParams = remove(
+            ast,
+            node =>
+              node.type === 'OptionStatement' &&
+              node.assignment.id.name === 'task'
+          )
+            .reverse()
+            .reduce((acc, curr) => {
+              // eslint-disable-next-line no-extra-semi
+              ;(curr.assignment?.init?.properties || []).reduce(
+                (_acc, _curr) => {
+                  if (_curr.key?.name && _curr.value?.location?.source) {
+                    _acc[_curr.key.name] = _curr.value.location.source
+                  }
+
+                  return _acc
+                },
+                acc
+              )
+
+              return acc
+            }, {})
+
+          return {
+            name: resp.name,
+            spec: {
+              readOnly: false,
+              range: DEFAULT_TIME_RANGE,
+              refresh: AUTOREFRESH_DEFAULT,
+              pipes: [
+                {
+                  activeQuery: 0,
+                  queries: [
+                    {
+                      text: format_from_js_file(ast),
+                      editMode: 'advanced',
+                      builderConfig: {
+                        buckets: [],
+                        tags: [],
+                        functions: [],
+                      },
+                    },
+                  ],
+                  type: 'rawFluxEditor',
+                  title: 'Query to Run',
+                  visible: true,
+                },
+                {
+                  title: 'Validate the Data',
+                  visible: true,
+                  type: 'table',
+                },
+                {
+                  type: 'schedule',
+                  title: 'Schedule',
+                  visible: true,
+                  interval: taskParams.every,
+                  offset: taskParams.offset,
                 },
               ],
-              type: 'rawFluxEditor',
-              title: 'Query to Run',
-              visible: true,
             },
-            {
-              title: 'Validate the Data',
-              visible: true,
-              type: 'table',
-            },
-            {
-              type: 'schedule',
-              title: 'Schedule',
-              visible: true,
-            },
-          ],
-        },
-      }),
+          }
+        })
+    },
   })

--- a/src/tasks/components/TaskRunsCard.tsx
+++ b/src/tasks/components/TaskRunsCard.tsx
@@ -25,6 +25,7 @@ import {
   runTask,
   getRuns,
 } from 'src/tasks/actions/thunks'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Actions For Members
 import {getMembers} from 'src/members/actions/thunks'
@@ -145,6 +146,12 @@ class UnconnectedTaskRunsCard extends PureComponent<
         params: {orgID},
       },
     } = this.props
+
+    if (isFlagEnabled('createWithFlows')) {
+      history.push(`/notebook/from/task/${task.id}`)
+      return
+    }
+
     setCurrentTasksPage(TaskPage.TaskRunsPage)
     history.push(`/orgs/${orgID}/tasks/${task.id}/edit`)
   }


### PR DESCRIPTION
when we turn on the `createWithFlows` flag, people are going to be generating tasks with notebooks.
now they will be editing tasks with notebooks as well

![Kapture 2021-10-15 at 13 15 46](https://user-images.githubusercontent.com/1434802/137548390-588152fa-29a4-46a8-9f42-2e1e814c6f83.gif)
