### PR TITLE
test: remove the intercept for annotations editing

### DIFF
--- a/cypress/e2e/util/annotationsSetup.ts
+++ b/cypress/e2e/util/annotationsSetup.ts
@@ -92,7 +92,7 @@ export const addAnnotation = (cy: Cypress.Chainable) => {
 export const startEditingAnnotation = (cy: Cypress.Chainable) => {
   cy.getByTestID('cell blah').within(() => {
     // we have 2 line layers by the same id, we only want to click on the first
-    cy.get('line')
+    cy.get('.giraffe-annotation-line')
       .first()
       .click({force: true})
   })
@@ -104,36 +104,14 @@ export const editAnnotation = (cy: Cypress.Chainable) => {
   cy.getByTestID('overlay--container')
     .filter(':visible')
     .within(() => {
-      if (Cypress.browser.name === 'firefox') {
-        // interacting with the 'edit-annotation-message' box is unstable in Firefox, causes flaky tests.
-        // to work around the issue, lets update the annotation by intercepting the request body.
-        cy.intercept(
-          'PUT',
-          '**/annotations/*',
-          (req: any) =>
-            (req.body = {
-              ...req.body,
-              summary: 'lets edit this annotation...',
-            })
-        ).as('updateAnnotation')
-      } else {
-        // for Chrome et. al., continue interacting with the UI per usual
-        cy.getByTestID('edit-annotation-message')
-          .should('be.visible')
-          .clear()
-
-        cy.getByTestID('edit-annotation-message')
-          .should('be.visible')
-          .type('lets edit this annotation...')
-
-        cy.intercept('PUT', '**/annotations/*').as('updateAnnotation')
-      }
+      cy.getByTestID('edit-annotation-message')
+        .should('be.visible')
+        .clear()
+        .type('lets edit this annotation...')
 
       cy.getByTestID('annotation-submit-button')
         .should('be.visible')
         .click()
-
-      cy.wait('@updateAnnotation')
     })
 }
 


### PR DESCRIPTION
We were very close to a perfect rerun of 20x for Annotations single stat. We ran into a flake here: https://app.circleci.com/pipelines/github/influxdata/monitor-ci/6222/workflows/4cf1372e-0674-4a29-ac7c-bd72837093ca

Looks like we should wait for the intercept before trying to click. Let's do that and see what happens.