### PR TITLE
chore: use latest openApi

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "cy": "CYPRESS_dexUrl=https://$INGRESS_HOST:$PORT_HTTPS CYPRESS_baseUrl=http://localhost:9999 cypress open",
     "cy:dev": "source ../monitor-ci/.env && CYPRESS_dexUrl=CLOUD CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{cloud,shared}/**/*.*'",
     "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_dexUrl=OSS CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{oss,shared}/**/*.*'",
-    "generate": "export SHA=ff46a7b36f05812b08616e3c8336d53e738d09ae && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
+    "generate": "export SHA=653a3ddf1991968b898bc1cc3e5e329833cac01a && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-meta": "if [ -z \"${CLOUD_URL}\" ]; then yarn generate-meta-oss; else yarn generate-meta-cloud; fi",
     "generate-meta-oss": "yarn oss-api && yarn notebooks && yarn unity && yarn annotations-oss && yarn pinned && yarn mapsd-oss && yarn cloudPriv",

--- a/src/buckets/components/context/lineProtocol.tsx
+++ b/src/buckets/components/context/lineProtocol.tsx
@@ -82,8 +82,9 @@ export const LineProtocolProvider: FC<Props> = React.memo(({children}) => {
         } else if (resp.status === 429) {
           setWriteStatus(RemoteDataState.Error)
           setWriteError('Failed due to plan limits: read cardinality reached')
-        } else if (resp.status === 403) {
-          const error = getErrorMessage(resp)
+        } else if (resp.status === 404) {
+          const error =
+            getErrorMessage(resp) || 'Endpoint not Found; Failed to write data'
           setWriteStatus(RemoteDataState.Error)
           setWriteError(error)
         } else {

--- a/src/buckets/components/context/lineProtocol.tsx
+++ b/src/buckets/components/context/lineProtocol.tsx
@@ -68,6 +68,20 @@ export const LineProtocolProvider: FC<Props> = React.memo(({children}) => {
     setWriteError('')
   }
 
+  /**
+   *  change in newest api:  error 429 (too many requests) is in CLOUD and not in OSS
+   *
+   *  doing the 'as any' cast away from the type because: safest way; this error code will never happen in OSS;
+   *    so the clause will never be activated, and the user still gets the proper error.
+   *
+   *    other strategies not implement here, with reasoning:
+   *
+   *    1) not removing the clause and drop down to the generic error
+   *          because then the user doesn't get a good error message
+   *    2) bad code smell: add it to oss for code purposes, knowing it will never be called
+   *    3) can't do an IF CLOUD b/c the code just ISN'T THERE; the type (PostWriteResult) exists in both
+   *       cloud and oss and is different in each environment
+   */
   const writeLineProtocol = useCallback(
     async (bucket: string) => {
       try {
@@ -79,7 +93,8 @@ export const LineProtocolProvider: FC<Props> = React.memo(({children}) => {
 
         if (resp.status === 204) {
           setWriteStatus(RemoteDataState.Done)
-        } else if (resp.status === 429) {
+          // here is the cast:
+        } else if ((resp.status as any) === 429) {
           setWriteStatus(RemoteDataState.Error)
           setWriteError('Failed due to plan limits: read cardinality reached')
         } else if (resp.status === 404) {


### PR DESCRIPTION
updates to the latest openApi sha for building the backend api that the ui calls.

tweaked the lineProtocol error codes that have changed.  

needed for explicit buckets 
#2231 
