### PR TITLE
test: simplify the annotations actions

### DIFF
--- a/cypress/e2e/util/annotationsSetup.ts
+++ b/cypress/e2e/util/annotationsSetup.ts
@@ -79,13 +79,13 @@ export const addAnnotation = (cy: Cypress.Chainable) => {
   cy.getByTestID('overlay--container')
     .filter(':visible')
     .within(() => {
-      cy.getByTestID('edit-annotation-message').should('be.visible')
-
       cy.getByTestID('edit-annotation-message')
+        .should('be.visible')
         .click()
-        .focused()
         .type('im a hippopotamus')
-      cy.getByTestID('annotation-submit-button').click()
+      cy.getByTestID('annotation-submit-button')
+        .should('be.visible')
+        .click()
     })
 }
 
@@ -130,7 +130,7 @@ export const deleteAnnotation = (cy: Cypress.Chainable) => {
 
   // annotation line should not exist in the dashboard cell
   cy.getByTestID('cell blah').within(() => {
-    cy.get('line').should('not.exist')
+    cy.get('.giraffe-annotation-line').should('not.exist')
   })
 }
 
@@ -186,13 +186,14 @@ export const addRangeAnnotation = (
       cy.getByTestID('edit-annotation-message')
         .should('be.visible')
         .click()
-        .focused()
         .type('range annotation here!')
 
       // make sure the two times (start and end) are not equal:
       ensureRangeAnnotationTimesAreNotEqual(cy)
 
-      cy.getByTestID('annotation-submit-button').click()
+      cy.getByTestID('annotation-submit-button')
+        .should('be.visible')
+        .click()
     })
 }
 
@@ -241,9 +242,6 @@ export const testEditRangeAnnotation = (
       cy.getByTestID('edit-annotation-message')
         .should('be.visible')
         .clear()
-
-      cy.getByTestID('edit-annotation-message')
-        .should('be.visible')
         .type('editing the text here for the range annotation')
     })
 


### PR DESCRIPTION
Simplify the annotations actions. Don't repeat the cy.get
