### PR TITLE
fix: share button only on saved notebooks

### DIFF
--- a/src/flows/components/header/index.tsx
+++ b/src/flows/components/header/index.tsx
@@ -199,16 +199,18 @@ const FlowHeader: FC = () => {
             <PresentationMode />
             <TimeZoneDropdown />
             <TimeRangeDropdown />
-            <FeatureFlag name="shareNotebook">
-              <SquareButton
-                icon={IconFont.Share}
-                onClick={showShare}
-                color={
-                  !share ? ComponentColor.Default : ComponentColor.Secondary
-                }
-                titleText="Share Notebook"
-              />
-            </FeatureFlag>
+            {flow?.id && (
+              <FeatureFlag name="shareNotebook">
+                <SquareButton
+                  icon={IconFont.Share}
+                  onClick={showShare}
+                  color={
+                    !share ? ComponentColor.Default : ComponentColor.Secondary
+                  }
+                  titleText="Share Notebook"
+                />
+              </FeatureFlag>
+            )}
             <FeatureFlag name="flow-snapshot">
               <SquareButton
                 icon={IconFont.Export}


### PR DESCRIPTION
Only show the share button on saved notebooks (not ephemeral ones)
