### PR TITLE
test: make testEditAnnotation and testEditRangeAnnotation similar

### DIFF
--- a/cypress/e2e/util/annotationsSetup.ts
+++ b/cypress/e2e/util/annotationsSetup.ts
@@ -76,17 +76,15 @@ export const addAnnotation = (cy: Cypress.Chainable) => {
     cy.getByTestID('giraffe-inner-plot').click({shiftKey: true})
   })
 
-  cy.getByTestID('overlay--container')
+  cy.getByTestID('overlay--container').should('be.visible')
+
+  cy.getByTestID('edit-annotation-message')
     .should('be.visible')
-    .within(() => {
-      cy.getByTestID('edit-annotation-message')
-        .should('be.visible')
-        .click()
-        .type('im a hippopotamus')
-      cy.getByTestID('annotation-submit-button')
-        .should('be.visible')
-        .click()
-    })
+    .click()
+    .type('im a hippopotamus')
+  cy.getByTestID('annotation-submit-button')
+    .should('be.visible')
+    .click()
 }
 
 export const startEditingAnnotation = (cy: Cypress.Chainable) => {
@@ -102,11 +100,9 @@ export const deleteAnnotation = (cy: Cypress.Chainable) => {
   // should have the annotation created , lets click it to show the modal.
   startEditingAnnotation(cy)
 
-  cy.getByTestID('overlay--container')
-    .should('be.visible')
-    .within(() => {
-      cy.getByTestID('delete-annotation-button').click({force: true})
-    })
+  cy.getByTestID('overlay--container').should('be.visible')
+
+  cy.getByTestID('delete-annotation-button').click({force: true})
 
   // reload to make sure the annotation was deleted from the backend as well.
   reloadAndHandleAnnotationDefaultStatus()
@@ -163,21 +159,19 @@ export const addRangeAnnotation = (
     })
   })
 
-  cy.getByTestID('overlay--container')
+  cy.getByTestID('overlay--container').should('be.visible')
+
+  cy.getByTestID('edit-annotation-message')
     .should('be.visible')
-    .within(() => {
-      cy.getByTestID('edit-annotation-message')
-        .should('be.visible')
-        .click()
-        .type('range annotation here!')
+    .click()
+    .type('range annotation here!')
 
-      // make sure the two times (start and end) are not equal:
-      ensureRangeAnnotationTimesAreNotEqual(cy)
+  // make sure the two times (start and end) are not equal:
+  ensureRangeAnnotationTimesAreNotEqual(cy)
 
-      cy.getByTestID('annotation-submit-button')
-        .should('be.visible')
-        .click()
-    })
+  cy.getByTestID('annotation-submit-button')
+    .should('be.visible')
+    .click()
 }
 
 export const testAddAnnotation = (cy: Cypress.Chainable) => {
@@ -195,18 +189,16 @@ export const testEditAnnotation = (cy: Cypress.Chainable) => {
 
   startEditingAnnotation(cy)
 
-  cy.getByTestID('overlay--container')
-    .should('be.visible')
-    .within(() => {
-      cy.getByTestID('edit-annotation-message')
-        .should('be.visible')
-        .clear()
-        .type('lets edit this annotation...')
+  cy.getByTestID('overlay--container').should('be.visible')
 
-      cy.getByTestID('annotation-submit-button')
-        .should('be.visible')
-        .click()
-    })
+  cy.getByTestID('edit-annotation-message')
+    .should('be.visible')
+    .clear()
+    .type('lets edit this annotation...')
+
+  cy.getByTestID('annotation-submit-button')
+    .should('be.visible')
+    .click()
 
   // reload to make sure the annotation was edited in the backend as well.
   reloadAndHandleAnnotationDefaultStatus()
@@ -231,14 +223,12 @@ export const testEditRangeAnnotation = (
 
   startEditingAnnotation(cy)
 
-  cy.getByTestID('overlay--container')
+  cy.getByTestID('overlay--container').should('be.visible')
+
+  cy.getByTestID('edit-annotation-message')
     .should('be.visible')
-    .within(() => {
-      cy.getByTestID('edit-annotation-message')
-        .should('be.visible')
-        .clear()
-        .type('editing the text here for the range annotation')
-    })
+    .clear()
+    .type('editing the text here for the range annotation')
 
   ensureRangeAnnotationTimesAreNotEqual(cy)
 


### PR DESCRIPTION
`testEditAnnotation` uses a separate `cy` in a function and does not return it. This might be the cause of the detaching from the DOM.

Let's make `testEditAnnotation` similar to `testEditRangeAnnotation` since the latter doesn't seem to be as flaky.
