### PR TITLE
fix: manual task run waits for response from server

### DIFF
--- a/src/tasks/components/TaskRunsCard.tsx
+++ b/src/tasks/components/TaskRunsCard.tsx
@@ -127,11 +127,11 @@ class UnconnectedTaskRunsCard extends PureComponent<
     )
   }
 
-  private handleRunTask = () => {
+  private handleRunTask = async () => {
     const {onRunTask, match, getRuns} = this.props
     try {
-      onRunTask(match.params.id)
-      getRuns(match.params.id)
+      await onRunTask(match.params.id)
+      await getRuns(match.params.id)
     } catch (error) {
       console.error(error)
     }


### PR DESCRIPTION
Closes #2946

Adds the async/await logic, as exists for manually retrying a task in: https://github.com/influxdata/ui/blob/b56ceba119687da427e5a67fd5a8e0ce50895149/src/tasks/components/TaskRunsRow.tsx#L89-L94

Per the linked issue, this should fix the bug where _sometimes_ on cloud when you manually run a task, the task runs list doesn't refresh. Also of note is that this undesirable behavior happens close to 100% on OSS due to network latency differences, so it will be more impactful for OSS when coupled with the fix for https://github.com/influxdata/influxdb/issues/21451