### PR TITLE
test: update annotations tests to prevent detaching

### DIFF
--- a/cypress/e2e/util/annotationsSetup.ts
+++ b/cypress/e2e/util/annotationsSetup.ts
@@ -1,6 +1,12 @@
 import {Organization} from '../../../src/types'
 import {points} from '../../support/commands'
 
+const ANNOTATION_TEXT = 'im a hippopotamus'
+const EDIT_ANNOTATION_TEXT = 'lets edit this annotation...'
+const RANGE_ANNOTATION_TEXT = 'range annotation here!'
+const EDIT_RANGE_ANNOTATION_TEXT =
+  'editing the text here for the range annotation'
+
 export const setupData = (cy: Cypress.Chainable, plotTypeSuffix = '') =>
   cy.flush().then(() =>
     cy.signin().then(() =>
@@ -73,14 +79,12 @@ export const addAnnotation = (cy: Cypress.Chainable) => {
   })
 
   cy.getByTestID('overlay--container').should('be.visible')
+  cy.getByTestID('annotation-message--form').should('be.visible')
 
   cy.getByTestID('edit-annotation-message')
-    .should('be.visible')
     .click()
-    .type('im a hippopotamus')
-  cy.getByTestID('annotation-submit-button')
-    .should('be.visible')
-    .click()
+    .type(ANNOTATION_TEXT)
+  cy.getByTestID('annotation-submit-button').click()
 }
 
 export const startEditingAnnotation = (cy: Cypress.Chainable) => {
@@ -88,7 +92,7 @@ export const startEditingAnnotation = (cy: Cypress.Chainable) => {
     // we have 2 line layers by the same id, we only want to click on the first
     cy.get('.giraffe-annotation-line')
       .first()
-      .click({force: true})
+      .clickAttached()
   })
 }
 
@@ -98,7 +102,7 @@ export const deleteAnnotation = (cy: Cypress.Chainable) => {
 
   cy.getByTestID('overlay--container').should('be.visible')
 
-  cy.getByTestID('delete-annotation-button').click({force: true})
+  cy.getByTestID('delete-annotation-button').clickAttached()
 
   // reload to make sure the annotation was deleted from the backend as well.
   reloadAndHandleAnnotationDefaultStatus()
@@ -156,18 +160,16 @@ export const addRangeAnnotation = (
   })
 
   cy.getByTestID('overlay--container').should('be.visible')
+  cy.getByTestID('annotation-message--form').should('be.visible')
 
   cy.getByTestID('edit-annotation-message')
-    .should('be.visible')
     .click()
-    .type('range annotation here!')
+    .type(RANGE_ANNOTATION_TEXT)
 
   // make sure the two times (start and end) are not equal:
   ensureRangeAnnotationTimesAreNotEqual(cy)
 
-  cy.getByTestID('annotation-submit-button')
-    .should('be.visible')
-    .click()
+  cy.getByTestID('annotation-submit-button').click()
 }
 
 export const testAddAnnotation = (cy: Cypress.Chainable) => {
@@ -177,7 +179,7 @@ export const testAddAnnotation = (cy: Cypress.Chainable) => {
   reloadAndHandleAnnotationDefaultStatus()
 
   // we need to see if the annotations got created and that the tooltip says "I'm a hippopotamus"
-  checkAnnotationText(cy, 'im a hippopotamus')
+  checkAnnotationText(cy, ANNOTATION_TEXT)
 }
 
 export const testEditAnnotation = (cy: Cypress.Chainable) => {
@@ -186,15 +188,13 @@ export const testEditAnnotation = (cy: Cypress.Chainable) => {
   startEditingAnnotation(cy)
 
   cy.getByTestID('overlay--container').should('be.visible')
+  cy.getByTestID('annotation-message--form').should('be.visible')
 
   cy.getByTestID('edit-annotation-message')
-    .should('be.visible')
     .clear()
-    .type('lets edit this annotation...')
+    .type(EDIT_ANNOTATION_TEXT)
 
-  cy.getByTestID('annotation-submit-button')
-    .should('be.visible')
-    .click()
+  cy.getByTestID('annotation-submit-button').click()
 
   // reload to make sure the annotation was edited in the backend as well.
   reloadAndHandleAnnotationDefaultStatus()
@@ -206,9 +206,7 @@ export const testEditAnnotation = (cy: Cypress.Chainable) => {
       .first()
       .trigger('mouseover')
   })
-  cy.getByTestID('giraffe-annotation-tooltip').contains(
-    'lets edit this annotation...'
-  )
+  cy.getByTestID('giraffe-annotation-tooltip').contains(EDIT_ANNOTATION_TEXT)
 }
 
 export const testEditRangeAnnotation = (
@@ -220,11 +218,11 @@ export const testEditRangeAnnotation = (
   startEditingAnnotation(cy)
 
   cy.getByTestID('overlay--container').should('be.visible')
+  cy.getByTestID('annotation-message--form').should('be.visible')
 
   cy.getByTestID('edit-annotation-message')
-    .should('be.visible')
     .clear()
-    .type('editing the text here for the range annotation')
+    .type(EDIT_RANGE_ANNOTATION_TEXT)
 
   ensureRangeAnnotationTimesAreNotEqual(cy)
 
@@ -233,7 +231,7 @@ export const testEditRangeAnnotation = (
   // reload to make sure the annotation was edited in the backend as well.
   reloadAndHandleAnnotationDefaultStatus()
 
-  checkAnnotationText(cy, 'editing the text here for the range annotation')
+  checkAnnotationText(cy, EDIT_RANGE_ANNOTATION_TEXT)
 }
 
 export const testDeleteAnnotation = (cy: Cypress.Chainable) => {

--- a/cypress/e2e/util/annotationsSetup.ts
+++ b/cypress/e2e/util/annotationsSetup.ts
@@ -92,11 +92,10 @@ export const addAnnotation = (cy: Cypress.Chainable) => {
 
 export const startEditingAnnotation = (cy: Cypress.Chainable) => {
   cy.getByTestID('cell blah').should('be.visible')
-  cy.get('.giraffe-annotation-line')
+  cy.get('.giraffe-annotation-click-target')
     .should($el => {
       expect(Cypress.dom.isDetached($el)).to.be.false
     })
-    .first()
     .click({force: true})
 }
 
@@ -113,17 +112,16 @@ export const deleteAnnotation = (cy: Cypress.Chainable) => {
 
   // annotation line should not exist in the dashboard cell
   cy.getByTestID('cell blah').within(() => {
-    cy.get('.giraffe-annotation-line').should('not.exist')
+    cy.get('.giraffe-annotation-click-target').should('not.exist')
   })
 }
 
 export const checkAnnotationText = (cy: Cypress.Chainable, text: string) => {
   cy.getByTestID('cell blah').within(() => {
-    cy.get('.giraffe-annotation-line')
+    cy.get('.giraffe-annotation-click-target')
       .should($el => {
         expect(Cypress.dom.isDetached($el)).to.be.false
       })
-      .first()
       .trigger('mouseover')
   })
   cy.getByTestID('giraffe-annotation-tooltip').contains(text)

--- a/cypress/e2e/util/annotationsSetup.ts
+++ b/cypress/e2e/util/annotationsSetup.ts
@@ -88,12 +88,13 @@ export const addAnnotation = (cy: Cypress.Chainable) => {
 }
 
 export const startEditingAnnotation = (cy: Cypress.Chainable) => {
-  cy.getByTestID('cell blah').within(() => {
-    // we have 2 line layers by the same id, we only want to click on the first
-    cy.get('.giraffe-annotation-line')
-      .first()
-      .clickAttached()
-  })
+  cy.getByTestID('cell blah').should('be.visible')
+  cy.get('.giraffe-annotation-line')
+    .should($el => {
+      expect(Cypress.dom.isDetached($el)).to.be.false
+    })
+    .first()
+    .click({force: true})
 }
 
 export const deleteAnnotation = (cy: Cypress.Chainable) => {
@@ -116,7 +117,9 @@ export const deleteAnnotation = (cy: Cypress.Chainable) => {
 export const checkAnnotationText = (cy: Cypress.Chainable, text: string) => {
   cy.getByTestID('cell blah').within(() => {
     cy.get('.giraffe-annotation-line')
-      .should('exist')
+      .should($el => {
+        expect(Cypress.dom.isDetached($el)).to.be.false
+      })
       .first()
       .trigger('mouseover')
   })
@@ -199,14 +202,7 @@ export const testEditAnnotation = (cy: Cypress.Chainable) => {
   // reload to make sure the annotation was edited in the backend as well.
   reloadAndHandleAnnotationDefaultStatus()
 
-  // annotation tooltip should say the new name
-  cy.getByTestID('cell blah').within(() => {
-    cy.get('.giraffe-annotation-line')
-      .should('exist')
-      .first()
-      .trigger('mouseover')
-  })
-  cy.getByTestID('giraffe-annotation-tooltip').contains(EDIT_ANNOTATION_TEXT)
+  checkAnnotationText(cy, EDIT_ANNOTATION_TEXT)
 }
 
 export const testEditRangeAnnotation = (

--- a/cypress/e2e/util/annotationsSetup.ts
+++ b/cypress/e2e/util/annotationsSetup.ts
@@ -82,6 +82,9 @@ export const addAnnotation = (cy: Cypress.Chainable) => {
   cy.getByTestID('annotation-message--form').should('be.visible')
 
   cy.getByTestID('edit-annotation-message')
+    .should($el => {
+      expect(Cypress.dom.isDetached($el)).to.be.false
+    })
     .click()
     .type(ANNOTATION_TEXT)
   cy.getByTestID('annotation-submit-button').click()
@@ -166,6 +169,9 @@ export const addRangeAnnotation = (
   cy.getByTestID('annotation-message--form').should('be.visible')
 
   cy.getByTestID('edit-annotation-message')
+    .should($el => {
+      expect(Cypress.dom.isDetached($el)).to.be.false
+    })
     .click()
     .type(RANGE_ANNOTATION_TEXT)
 
@@ -194,6 +200,9 @@ export const testEditAnnotation = (cy: Cypress.Chainable) => {
   cy.getByTestID('annotation-message--form').should('be.visible')
 
   cy.getByTestID('edit-annotation-message')
+    .should($el => {
+      expect(Cypress.dom.isDetached($el)).to.be.false
+    })
     .clear()
     .type(EDIT_ANNOTATION_TEXT)
 
@@ -217,6 +226,9 @@ export const testEditRangeAnnotation = (
   cy.getByTestID('annotation-message--form').should('be.visible')
 
   cy.getByTestID('edit-annotation-message')
+    .should($el => {
+      expect(Cypress.dom.isDetached($el)).to.be.false
+    })
     .clear()
     .type(EDIT_RANGE_ANNOTATION_TEXT)
 

--- a/src/annotations/components/annotationForm/AnnotationMessageInput.tsx
+++ b/src/annotations/components/annotationForm/AnnotationMessageInput.tsx
@@ -37,6 +37,7 @@ export const AnnotationMessageInput: FC<Props> = (props: Props) => {
       label={`Message (${characterCount} / ${characterLimit})`}
       required={true}
       errorMessage={validationMessage}
+      testID="annotation-message--form"
     >
       <TextArea
         name="message"


### PR DESCRIPTION
From observing repeated flakiness, it is clear that Annotations tests have a common problem. Elements are detached from the DOM when a test command tries to execute. Let's guard against these.

- assert that certain elements are not detached
- execute certain commands only after the above
- use a new click target for annotations
- add a `testID` for the annotation message form to assert visibility