### PR TITLE
test: remove reloading, assert for toast on edit and delete, and upda…

### DIFF
--- a/cypress/e2e/shared/annotations.range.test.ts
+++ b/cypress/e2e/shared/annotations.range.test.ts
@@ -1,8 +1,10 @@
 import {
+  ANNOTATION_TEXT,
+  EDIT_ANNOTATION_TEXT,
+  RANGE_ANNOTATION_TEXT,
   addAnnotation,
   addRangeAnnotation,
   checkAnnotationText,
-  reloadAndHandleAnnotationDefaultStatus,
   setupData,
   startEditingAnnotation,
 } from '../util/annotationsSetup'
@@ -31,12 +33,11 @@ describe('Annotations, but in a different test suite', () => {
       addAnnotation(cy)
 
       cy.getByTestID('cell blah').within(() => {
-        cy.get('.giraffe-annotation-line')
+        cy.get('.giraffe-annotation-click-target')
           .should('exist')
-          .first()
           .trigger('mouseover')
       })
-      cy.getByTestID('giraffe-annotation-tooltip').contains('im a hippopotamus')
+      cy.getByTestID('giraffe-annotation-tooltip').contains(ANNOTATION_TEXT)
     })
 
     it('can cancel an annotation edit process by clicking on the cancel button in the edit annotation form', () => {
@@ -47,18 +48,17 @@ describe('Annotations, but in a different test suite', () => {
 
       cy.getByTestID('edit-annotation-message')
         .clear()
-        .type('lets edit this annotation...')
+        .type(EDIT_ANNOTATION_TEXT)
 
       cy.getByTestID('edit-annotation-cancel-button').click()
 
       // annotation tooltip should say the old name
       cy.getByTestID('cell blah').within(() => {
-        cy.get('.giraffe-annotation-line')
+        cy.get('.giraffe-annotation-click-target')
           .should('exist')
-          .first()
           .trigger('mouseover')
       })
-      cy.getByTestID('giraffe-annotation-tooltip').contains('im a hippopotamus')
+      cy.getByTestID('giraffe-annotation-tooltip').contains(ANNOTATION_TEXT)
     })
   })
 
@@ -108,7 +108,6 @@ describe('Annotations, but in a different test suite', () => {
     })
     it('can add a range annotation, then edit it and change to a point annotation', () => {
       addRangeAnnotation(cy)
-      reloadAndHandleAnnotationDefaultStatus()
       startEditingAnnotation(cy)
 
       // verify that it is range annotation (the range selector option is selected)
@@ -130,8 +129,8 @@ describe('Annotations, but in a different test suite', () => {
       // save it
       cy.getByTestID('annotation-submit-button').click()
 
-      // reload to make sure it gets to the backend
-      reloadAndHandleAnnotationDefaultStatus()
+      // make sure the edit was saved successfully
+      cy.getByTestID('notification-success').should('be.visible')
       startEditingAnnotation(cy)
 
       // make sure it is (still) a point annotation:
@@ -150,7 +149,7 @@ describe('Annotations, but in a different test suite', () => {
           .should('be.visible')
           .click()
           .focused()
-          .type('random annotation, should be a range')
+          .type(RANGE_ANNOTATION_TEXT)
 
         // should be of type 'point'
         cy.getByTestID('annotation-form-point-type-option--input').should(
@@ -189,7 +188,7 @@ describe('Annotations, but in a different test suite', () => {
               })
           })
       }) // end overlay-container within
-      checkAnnotationText(cy, 'random annotation, should be a range')
+      checkAnnotationText(cy, RANGE_ANNOTATION_TEXT)
 
       startEditingAnnotation(cy)
 
@@ -226,18 +225,15 @@ describe('Annotations, but in a different test suite', () => {
       // create an annotation
       addAnnotation(cy)
 
-      // reload to make sure the annotation was added in the backend as well.
-      reloadAndHandleAnnotationDefaultStatus()
-
       // verify the tooltip shows up
-      checkAnnotationText(cy, 'im a hippopotamus')
+      checkAnnotationText(cy, ANNOTATION_TEXT)
 
       // turn off annotations mode
       cy.getByTestID('toggle-annotations-controls').click()
 
       // verify the annotation does NOT show up
       cy.getByTestID('cell blah').within(() => {
-        cy.get('.giraffe-annotation-line').should('not.exist')
+        cy.get('.giraffe-annotation-click-target').should('not.exist')
       })
 
       cy.getByTestID('giraffe-annotation-tooltip').should('not.exist')

--- a/cypress/e2e/util/annotationsSetup.ts
+++ b/cypress/e2e/util/annotationsSetup.ts
@@ -1,10 +1,10 @@
 import {Organization} from '../../../src/types'
 import {points} from '../../support/commands'
 
-const ANNOTATION_TEXT = 'im a hippopotamus'
-const EDIT_ANNOTATION_TEXT = 'lets edit this annotation...'
-const RANGE_ANNOTATION_TEXT = 'range annotation here!'
-const EDIT_RANGE_ANNOTATION_TEXT =
+export const ANNOTATION_TEXT = 'im a hippopotamus'
+export const EDIT_ANNOTATION_TEXT = 'lets edit this annotation...'
+export const RANGE_ANNOTATION_TEXT = 'range annotation here!'
+export const EDIT_RANGE_ANNOTATION_TEXT =
   'editing the text here for the range annotation'
 
 export const setupData = (cy: Cypress.Chainable, plotTypeSuffix = '') =>
@@ -68,11 +68,6 @@ export const setupData = (cy: Cypress.Chainable, plotTypeSuffix = '') =>
     )
   )
 
-export const reloadAndHandleAnnotationDefaultStatus = () => {
-  cy.reload()
-  cy.getByTestID('toggle-annotations-controls').click()
-}
-
 export const addAnnotation = (cy: Cypress.Chainable) => {
   cy.getByTestID('cell blah').within(() => {
     cy.getByTestID('giraffe-inner-plot').click({shiftKey: true})
@@ -107,8 +102,8 @@ export const deleteAnnotation = (cy: Cypress.Chainable) => {
 
   cy.getByTestID('delete-annotation-button').clickAttached()
 
-  // reload to make sure the annotation was deleted from the backend as well.
-  reloadAndHandleAnnotationDefaultStatus()
+  // make sure the delete was successful
+  cy.getByTestID('notification-success').should('be.visible')
 
   // annotation line should not exist in the dashboard cell
   cy.getByTestID('cell blah').within(() => {
@@ -182,9 +177,6 @@ export const addRangeAnnotation = (
 export const testAddAnnotation = (cy: Cypress.Chainable) => {
   addAnnotation(cy)
 
-  // reload to make sure the annotation was added in the backend as well.
-  reloadAndHandleAnnotationDefaultStatus()
-
   // we need to see if the annotations got created and that the tooltip says "I'm a hippopotamus"
   checkAnnotationText(cy, ANNOTATION_TEXT)
 }
@@ -206,8 +198,8 @@ export const testEditAnnotation = (cy: Cypress.Chainable) => {
 
   cy.getByTestID('annotation-submit-button').click()
 
-  // reload to make sure the annotation was edited in the backend as well.
-  reloadAndHandleAnnotationDefaultStatus()
+  // make sure the edit was saved successfully
+  cy.getByTestID('notification-success').should('be.visible')
 
   checkAnnotationText(cy, EDIT_ANNOTATION_TEXT)
 }
@@ -234,8 +226,8 @@ export const testEditRangeAnnotation = (
 
   cy.getByTestID('annotation-submit-button').click()
 
-  // reload to make sure the annotation was edited in the backend as well.
-  reloadAndHandleAnnotationDefaultStatus()
+  // make sure the edit was saved successfully
+  cy.getByTestID('notification-success').should('be.visible')
 
   checkAnnotationText(cy, EDIT_RANGE_ANNOTATION_TEXT)
 }


### PR DESCRIPTION
Firefox seems to be very eager to reload the page. This is likely the cause of the flakiness.

- remove the `cy.reload` and assert for the notification of a successful edit or deletion
- update the range annotations tests
