### PR TITLE
test: fix annotations tests with extra precautions

### DIFF
--- a/cypress/e2e/shared/annotations.range.test.ts
+++ b/cypress/e2e/shared/annotations.range.test.ts
@@ -1,6 +1,7 @@
 import {
   ANNOTATION_TEXT,
   EDIT_ANNOTATION_TEXT,
+  NO_TEXT,
   RANGE_ANNOTATION_TEXT,
   addAnnotation,
   addRangeAnnotation,
@@ -50,8 +51,8 @@ describe('Annotations, but in a different test suite', () => {
       cy.getByTestID('annotation-message--form').should('be.visible')
 
       cy.getByTestID('edit-annotation-message')
-        .clear()
-        .type(EDIT_ANNOTATION_TEXT)
+        .invoke('val', EDIT_ANNOTATION_TEXT)
+        .type(NO_TEXT)
 
       cy.getByTestID('edit-annotation-cancel-button').click()
 
@@ -155,10 +156,8 @@ describe('Annotations, but in a different test suite', () => {
       })
       cy.getByTestID('overlay--container').within(() => {
         cy.getByTestID('edit-annotation-message')
-          .should('be.visible')
-          .click()
-          .focused()
-          .type(RANGE_ANNOTATION_TEXT)
+          .invoke('val', RANGE_ANNOTATION_TEXT)
+          .type(NO_TEXT)
 
         // should be of type 'point'
         cy.getByTestID('annotation-form-point-type-option--input').should(

--- a/cypress/e2e/shared/annotations.range.test.ts
+++ b/cypress/e2e/shared/annotations.range.test.ts
@@ -46,6 +46,9 @@ describe('Annotations, but in a different test suite', () => {
       // should have the annotation created, lets click it to show the modal.
       startEditingAnnotation(cy)
 
+      cy.getByTestID('overlay--container').should('be.visible')
+      cy.getByTestID('annotation-message--form').should('be.visible')
+
       cy.getByTestID('edit-annotation-message')
         .clear()
         .type(EDIT_ANNOTATION_TEXT)
@@ -76,6 +79,8 @@ describe('Annotations, but in a different test suite', () => {
     it('can add a range annotation, then edit it and switch back and forth from point->range and the endtime stays the same', () => {
       addRangeAnnotation(cy)
       startEditingAnnotation(cy)
+
+      cy.getByTestID('overlay--container').should('be.visible')
 
       // verify there is an end time:
       cy.getByTestID('endTime-testID').should('be.visible')
@@ -110,6 +115,8 @@ describe('Annotations, but in a different test suite', () => {
       addRangeAnnotation(cy)
       startEditingAnnotation(cy)
 
+      cy.getByTestID('overlay--container').should('be.visible')
+
       // verify that it is range annotation (the range selector option is selected)
       cy.getByTestID('annotation-form-range-type-option--input').should(
         'be.checked'
@@ -131,7 +138,9 @@ describe('Annotations, but in a different test suite', () => {
 
       // make sure the edit was saved successfully
       cy.getByTestID('notification-success').should('be.visible')
+
       startEditingAnnotation(cy)
+      cy.getByTestID('overlay--container').should('be.visible')
 
       // make sure it is (still) a point annotation:
       cy.getByTestID('endTime-testID').should('not.exist')
@@ -191,6 +200,8 @@ describe('Annotations, but in a different test suite', () => {
       checkAnnotationText(cy, RANGE_ANNOTATION_TEXT)
 
       startEditingAnnotation(cy)
+
+      cy.getByTestID('overlay--container').should('be.visible')
 
       // verify there is an end time:
       cy.getByTestID('endTime-testID').should('be.visible')

--- a/cypress/e2e/util/annotationsSetup.ts
+++ b/cypress/e2e/util/annotationsSetup.ts
@@ -6,6 +6,7 @@ export const EDIT_ANNOTATION_TEXT = 'lets edit this annotation...'
 export const RANGE_ANNOTATION_TEXT = 'range annotation here!'
 export const EDIT_RANGE_ANNOTATION_TEXT =
   'editing the text here for the range annotation'
+export const NO_TEXT = ' {backspace}'
 
 export const setupData = (cy: Cypress.Chainable, plotTypeSuffix = '') =>
   cy.flush().then(() =>
@@ -77,8 +78,8 @@ export const addAnnotation = (cy: Cypress.Chainable) => {
   cy.getByTestID('annotation-message--form').should('be.visible')
 
   cy.getByTestID('edit-annotation-message')
-    .click()
-    .type(ANNOTATION_TEXT)
+    .invoke('val', ANNOTATION_TEXT)
+    .type(NO_TEXT)
   cy.getByTestID('annotation-submit-button').click()
 }
 
@@ -147,8 +148,8 @@ export const addRangeAnnotation = (
   cy.getByTestID('annotation-message--form').should('be.visible')
 
   cy.getByTestID('edit-annotation-message')
-    .click()
-    .type(RANGE_ANNOTATION_TEXT)
+    .invoke('val', RANGE_ANNOTATION_TEXT)
+    .type(NO_TEXT)
 
   cy.getByTestID('annotation-submit-button').click()
 }
@@ -169,9 +170,8 @@ export const testEditAnnotation = (cy: Cypress.Chainable) => {
   cy.getByTestID('annotation-message--form').should('be.visible')
 
   cy.getByTestID('edit-annotation-message')
-    .click()
-    .clear()
-    .type(EDIT_ANNOTATION_TEXT)
+    .invoke('val', EDIT_ANNOTATION_TEXT)
+    .type(NO_TEXT)
 
   cy.getByTestID('annotation-submit-button').click()
 
@@ -193,9 +193,8 @@ export const testEditRangeAnnotation = (
   cy.getByTestID('annotation-message--form').should('be.visible')
 
   cy.getByTestID('edit-annotation-message')
-    .click()
-    .clear()
-    .type(EDIT_RANGE_ANNOTATION_TEXT)
+    .invoke('val', EDIT_RANGE_ANNOTATION_TEXT)
+    .type(NO_TEXT)
 
   // ensure the two times are not equal
   cy.getByTestID('endTime-testID')

--- a/cypress/e2e/util/annotationsSetup.ts
+++ b/cypress/e2e/util/annotationsSetup.ts
@@ -122,18 +122,6 @@ export const checkAnnotationText = (cy: Cypress.Chainable, text: string) => {
   cy.getByTestID('giraffe-annotation-tooltip').contains(text)
 }
 
-const ensureRangeAnnotationTimesAreNotEqual = (cy: Cypress.Chainable) => {
-  cy.getByTestID('endTime-testID')
-    .invoke('val')
-    .then(endTimeValue => {
-      cy.getByTestID('startTime-testID')
-        .invoke('val')
-        .then(startTimeValue => {
-          expect(endTimeValue).to.not.equal(startTimeValue)
-        })
-    })
-}
-
 export const addRangeAnnotation = (
   cy: Cypress.Chainable,
   layerTestID = 'line'
@@ -167,9 +155,6 @@ export const addRangeAnnotation = (
     })
     .click()
     .type(RANGE_ANNOTATION_TEXT)
-
-  // make sure the two times (start and end) are not equal:
-  ensureRangeAnnotationTimesAreNotEqual(cy)
 
   cy.getByTestID('annotation-submit-button').click()
 }
@@ -222,7 +207,16 @@ export const testEditRangeAnnotation = (
     .clear()
     .type(EDIT_RANGE_ANNOTATION_TEXT)
 
-  ensureRangeAnnotationTimesAreNotEqual(cy)
+  // ensure the two times are not equal
+  cy.getByTestID('endTime-testID')
+    .invoke('val')
+    .then(endTimeValue => {
+      cy.getByTestID('startTime-testID')
+        .invoke('val')
+        .then(startTimeValue => {
+          expect(endTimeValue).to.not.equal(startTimeValue)
+        })
+    })
 
   cy.getByTestID('annotation-submit-button').click()
 

--- a/cypress/e2e/util/annotationsSetup.ts
+++ b/cypress/e2e/util/annotationsSetup.ts
@@ -77,9 +77,6 @@ export const addAnnotation = (cy: Cypress.Chainable) => {
   cy.getByTestID('annotation-message--form').should('be.visible')
 
   cy.getByTestID('edit-annotation-message')
-    .should($el => {
-      expect(Cypress.dom.isDetached($el)).to.be.false
-    })
     .click()
     .type(ANNOTATION_TEXT)
   cy.getByTestID('annotation-submit-button').click()
@@ -150,9 +147,6 @@ export const addRangeAnnotation = (
   cy.getByTestID('annotation-message--form').should('be.visible')
 
   cy.getByTestID('edit-annotation-message')
-    .should($el => {
-      expect(Cypress.dom.isDetached($el)).to.be.false
-    })
     .click()
     .type(RANGE_ANNOTATION_TEXT)
 
@@ -175,9 +169,7 @@ export const testEditAnnotation = (cy: Cypress.Chainable) => {
   cy.getByTestID('annotation-message--form').should('be.visible')
 
   cy.getByTestID('edit-annotation-message')
-    .should($el => {
-      expect(Cypress.dom.isDetached($el)).to.be.false
-    })
+    .click()
     .clear()
     .type(EDIT_ANNOTATION_TEXT)
 
@@ -201,9 +193,7 @@ export const testEditRangeAnnotation = (
   cy.getByTestID('annotation-message--form').should('be.visible')
 
   cy.getByTestID('edit-annotation-message')
-    .should($el => {
-      expect(Cypress.dom.isDetached($el)).to.be.false
-    })
+    .click()
     .clear()
     .type(EDIT_RANGE_ANNOTATION_TEXT)
 


### PR DESCRIPTION
- add assertion for overlay in the range annotation tests
- remove assertion in `addRangeAnnotation` helper function
- assert that range times are equal or not equal as appropriate per test
- call `invoke` on `<TextArea>` to insert text and reduce the amount of typing and re-renders