### PR TITLE
test: type only in the focused element

### DIFF
--- a/cypress/e2e/shared/annotations.band.test.ts
+++ b/cypress/e2e/shared/annotations.band.test.ts
@@ -7,6 +7,7 @@ import {
   testEditAnnotation,
   testEditRangeAnnotation,
   testDeleteAnnotation,
+  RANGE_ANNOTATION_TEXT,
 } from '../util/annotationsSetup'
 
 describe('The Annotations UI functionality on a band plot graph type', () => {
@@ -26,7 +27,7 @@ describe('The Annotations UI functionality on a band plot graph type', () => {
 
   it('can add a range annotation for the band plot', () => {
     addRangeAnnotation(cy, 'band-chart')
-    checkAnnotationText(cy, 'range annotation here!')
+    checkAnnotationText(cy, RANGE_ANNOTATION_TEXT)
   })
   it('can add and edit a range annotation for the band plot', () => {
     testEditRangeAnnotation(cy, 'band-chart')

--- a/cypress/e2e/shared/annotations.range.test.ts
+++ b/cypress/e2e/shared/annotations.range.test.ts
@@ -130,13 +130,17 @@ describe('Annotations, but in a different test suite', () => {
         .invoke('val')
         .then(endTimeValue => {
           // switch it to a point annotation
-          cy.getByTestID('annotation-form-point-type-option').click()
+          cy.getByTestID('annotation-form-point-type-option')
+            .should('not.have.class', 'cf-select-group--option__active')
+            .click()
 
           // the endTime input should disappear
           cy.getByTestID('endTime-testID').should('not.exist')
 
           // switch back to range:
-          cy.getByTestID('annotation-form-range-type-option').click()
+          cy.getByTestID('annotation-form-range-type-option')
+            .should('not.have.class', 'cf-select-group--option__active')
+            .click()
 
           cy.getByTestID('endTime-testID')
             .should('be.visible')
@@ -158,7 +162,9 @@ describe('Annotations, but in a different test suite', () => {
       )
 
       // switch it to a point annotation
-      cy.getByTestID('annotation-form-point-type-option').click()
+      cy.getByTestID('annotation-form-point-type-option')
+        .should('not.have.class', 'cf-select-group--option__active')
+        .click()
 
       // verify that it is a point annotation now
       cy.getByTestID('annotation-form-point-type-option--input').should(
@@ -205,7 +211,9 @@ describe('Annotations, but in a different test suite', () => {
         cy.getByTestID('endTime-testID').should('not.exist')
 
         // now: click the button to switch to range:
-        cy.getByTestID('annotation-form-range-type-option').click()
+        cy.getByTestID('annotation-form-range-type-option')
+          .should('not.have.class', 'cf-select-group--option__active')
+          .click()
 
         // now, the end time input SHOULD show up
         cy.getByTestID('endTime-testID').should('be.visible')

--- a/cypress/e2e/shared/annotations.range.test.ts
+++ b/cypress/e2e/shared/annotations.range.test.ts
@@ -164,7 +164,9 @@ describe('Annotations, but in a different test suite', () => {
       cy.getByTestID('endTime-testID').should('not.exist')
 
       // save it
-      cy.getByTestID('annotation-submit-button').click({force: true})
+      cy.getByTestID('annotation-submit-button')
+        .should('not.be.disabled')
+        .click()
 
       // make sure the edit was saved successfully
       cy.getByTestID('notification-success').should('be.visible')
@@ -221,7 +223,9 @@ describe('Annotations, but in a different test suite', () => {
                   .clear()
                   .type(newEndTime)
 
-                cy.getByTestID('annotation-submit-button').click({force: true})
+                cy.getByTestID('annotation-submit-button')
+                  .should('not.be.disabled')
+                  .click()
               })
           })
       }) // end overlay-container within

--- a/cypress/e2e/shared/annotations.range.test.ts
+++ b/cypress/e2e/shared/annotations.range.test.ts
@@ -55,7 +55,7 @@ describe('Annotations, but in a different test suite', () => {
         .should($el => {
           expect(Cypress.dom.isDetached($el)).to.be.false
         })
-        .type(PERIOD, {force: true})
+        .type(PERIOD, {force: true, waitForAnimations: false})
 
       cy.getByTestID('edit-annotation-cancel-button').click()
 
@@ -163,7 +163,7 @@ describe('Annotations, but in a different test suite', () => {
           .should($el => {
             expect(Cypress.dom.isDetached($el)).to.be.false
           })
-          .type(PERIOD, {force: true})
+          .type(PERIOD, {force: true, waitForAnimations: false})
 
         // should be of type 'point'
         cy.getByTestID('annotation-form-point-type-option--input').should(

--- a/cypress/e2e/shared/annotations.range.test.ts
+++ b/cypress/e2e/shared/annotations.range.test.ts
@@ -55,7 +55,7 @@ describe('Annotations, but in a different test suite', () => {
         .should($el => {
           expect(Cypress.dom.isDetached($el)).to.be.false
         })
-        .click({multiple: true})
+        .click({force: true, multiple: true})
         .type(PERIOD)
 
       cy.getByTestID('edit-annotation-cancel-button').click()
@@ -164,7 +164,7 @@ describe('Annotations, but in a different test suite', () => {
           .should($el => {
             expect(Cypress.dom.isDetached($el)).to.be.false
           })
-          .click({multiple: true})
+          .click({force: true, multiple: true})
           .type(PERIOD)
 
         // should be of type 'point'

--- a/cypress/e2e/shared/annotations.range.test.ts
+++ b/cypress/e2e/shared/annotations.range.test.ts
@@ -52,7 +52,7 @@ describe('Annotations, but in a different test suite', () => {
 
       cy.getByTestID('edit-annotation-message')
         .invoke('val', EDIT_ANNOTATION_TEXT)
-        .click()
+        .click({multiple: true})
         .type(PERIOD)
 
       cy.getByTestID('edit-annotation-cancel-button').click()
@@ -158,7 +158,7 @@ describe('Annotations, but in a different test suite', () => {
       cy.getByTestID('overlay--container').within(() => {
         cy.getByTestID('edit-annotation-message')
           .invoke('val', RANGE_ANNOTATION_TEXT)
-          .click()
+          .click({multiple: true})
           .type(PERIOD)
 
         // should be of type 'point'

--- a/cypress/e2e/shared/annotations.range.test.ts
+++ b/cypress/e2e/shared/annotations.range.test.ts
@@ -1,7 +1,7 @@
 import {
   ANNOTATION_TEXT,
   EDIT_ANNOTATION_TEXT,
-  NO_TEXT,
+  PERIOD,
   RANGE_ANNOTATION_TEXT,
   addAnnotation,
   addRangeAnnotation,
@@ -52,7 +52,7 @@ describe('Annotations, but in a different test suite', () => {
 
       cy.getByTestID('edit-annotation-message')
         .invoke('val', EDIT_ANNOTATION_TEXT)
-        .type(NO_TEXT)
+        .type(PERIOD)
 
       cy.getByTestID('edit-annotation-cancel-button').click()
 
@@ -157,7 +157,7 @@ describe('Annotations, but in a different test suite', () => {
       cy.getByTestID('overlay--container').within(() => {
         cy.getByTestID('edit-annotation-message')
           .invoke('val', RANGE_ANNOTATION_TEXT)
-          .type(NO_TEXT)
+          .type(PERIOD)
 
         // should be of type 'point'
         cy.getByTestID('annotation-form-point-type-option--input').should(

--- a/cypress/e2e/shared/annotations.range.test.ts
+++ b/cypress/e2e/shared/annotations.range.test.ts
@@ -55,6 +55,7 @@ describe('Annotations, but in a different test suite', () => {
         .should($el => {
           expect(Cypress.dom.isDetached($el)).to.be.false
         })
+        .last()
         .click()
         .type(PERIOD)
 
@@ -164,6 +165,7 @@ describe('Annotations, but in a different test suite', () => {
           .should($el => {
             expect(Cypress.dom.isDetached($el)).to.be.false
           })
+          .last()
           .click()
           .type(PERIOD)
 

--- a/cypress/e2e/shared/annotations.range.test.ts
+++ b/cypress/e2e/shared/annotations.range.test.ts
@@ -55,7 +55,6 @@ describe('Annotations, but in a different test suite', () => {
         .should($el => {
           expect(Cypress.dom.isDetached($el)).to.be.false
         })
-        .click({force: true, multiple: true})
         .type(PERIOD, {force: true})
 
       cy.getByTestID('edit-annotation-cancel-button').click()
@@ -164,7 +163,6 @@ describe('Annotations, but in a different test suite', () => {
           .should($el => {
             expect(Cypress.dom.isDetached($el)).to.be.false
           })
-          .click({force: true, multiple: true})
           .type(PERIOD, {force: true})
 
         // should be of type 'point'

--- a/cypress/e2e/shared/annotations.range.test.ts
+++ b/cypress/e2e/shared/annotations.range.test.ts
@@ -55,8 +55,7 @@ describe('Annotations, but in a different test suite', () => {
         .should($el => {
           expect(Cypress.dom.isDetached($el)).to.be.false
         })
-        .last()
-        .click()
+        .click({multiple: true})
         .type(PERIOD)
 
       cy.getByTestID('edit-annotation-cancel-button').click()
@@ -165,8 +164,7 @@ describe('Annotations, but in a different test suite', () => {
           .should($el => {
             expect(Cypress.dom.isDetached($el)).to.be.false
           })
-          .last()
-          .click()
+          .click({multiple: true})
           .type(PERIOD)
 
         // should be of type 'point'

--- a/cypress/e2e/shared/annotations.range.test.ts
+++ b/cypress/e2e/shared/annotations.range.test.ts
@@ -1,7 +1,6 @@
 import {
   ANNOTATION_TEXT,
   EDIT_ANNOTATION_TEXT,
-  PERIOD,
   RANGE_ANNOTATION_TEXT,
   addAnnotation,
   addRangeAnnotation,
@@ -30,6 +29,36 @@ describe('Annotations, but in a different test suite', () => {
       cy.getByTestID('annotations-control-bar').should('not.exist')
     })
 
+    it('can create an annotation, and then after turning off annotation mode annotations disappear', () => {
+      // create an annotation
+      addAnnotation(cy)
+
+      // verify the tooltip shows up
+      checkAnnotationText(cy, ANNOTATION_TEXT)
+
+      // turn off annotations mode
+      cy.getByTestID('toggle-annotations-controls').click()
+
+      // verify the annotation does NOT show up
+      cy.getByTestID('cell blah').within(() => {
+        cy.get('.giraffe-annotation-click-target').should('not.exist')
+      })
+
+      cy.getByTestID('giraffe-annotation-tooltip').should('not.exist')
+    })
+
+    it('cannot create an annotation when graph is clicked and annotation mode is off', () => {
+      // switch off the control bar
+      cy.getByTestID('toggle-annotations-controls').click()
+      cy.getByTestID('annotations-control-bar').should('not.exist')
+
+      cy.getByTestID('cell blah').within(() => {
+        cy.getByTestID('giraffe-inner-plot').click({shiftKey: true})
+      })
+
+      cy.getByTestID('overlay--container').should('not.exist')
+    })
+
     it('can show a tooltip when annotation is hovered on in the graph', () => {
       addAnnotation(cy)
 
@@ -51,11 +80,8 @@ describe('Annotations, but in a different test suite', () => {
       cy.getByTestID('annotation-message--form').should('be.visible')
 
       cy.getByTestID('edit-annotation-message')
-        .invoke('val', EDIT_ANNOTATION_TEXT)
-        .should($el => {
-          expect(Cypress.dom.isDetached($el)).to.be.false
-        })
-        .type(PERIOD, {force: true, waitForAnimations: false})
+        .focused()
+        .type(EDIT_ANNOTATION_TEXT)
 
       cy.getByTestID('edit-annotation-cancel-button').click()
 
@@ -159,11 +185,8 @@ describe('Annotations, but in a different test suite', () => {
       })
       cy.getByTestID('overlay--container').within(() => {
         cy.getByTestID('edit-annotation-message')
-          .invoke('val', RANGE_ANNOTATION_TEXT)
-          .should($el => {
-            expect(Cypress.dom.isDetached($el)).to.be.false
-          })
-          .type(PERIOD, {force: true, waitForAnimations: false})
+          .focused()
+          .type(RANGE_ANNOTATION_TEXT)
 
         // should be of type 'point'
         cy.getByTestID('annotation-form-point-type-option--input').should(
@@ -202,6 +225,7 @@ describe('Annotations, but in a different test suite', () => {
               })
           })
       }) // end overlay-container within
+
       checkAnnotationText(cy, RANGE_ANNOTATION_TEXT)
 
       startEditingAnnotation(cy)
@@ -235,36 +259,6 @@ describe('Annotations, but in a different test suite', () => {
               expect(minutes).to.equal(10)
             })
         })
-    })
-
-    it('can create an annotation, and then after turning off annotation mode annotations disappear', () => {
-      // create an annotation
-      addAnnotation(cy)
-
-      // verify the tooltip shows up
-      checkAnnotationText(cy, ANNOTATION_TEXT)
-
-      // turn off annotations mode
-      cy.getByTestID('toggle-annotations-controls').click()
-
-      // verify the annotation does NOT show up
-      cy.getByTestID('cell blah').within(() => {
-        cy.get('.giraffe-annotation-click-target').should('not.exist')
-      })
-
-      cy.getByTestID('giraffe-annotation-tooltip').should('not.exist')
-    })
-
-    it('cannot create an annotation when graph is clicked and annotation mode is off', () => {
-      // switch off the control bar
-      cy.getByTestID('toggle-annotations-controls').click()
-      cy.getByTestID('annotations-control-bar').should('not.exist')
-
-      cy.getByTestID('cell blah').within(() => {
-        cy.getByTestID('giraffe-inner-plot').click({shiftKey: true})
-      })
-
-      cy.getByTestID('overlay--container').should('not.exist')
     })
   })
 })

--- a/cypress/e2e/shared/annotations.range.test.ts
+++ b/cypress/e2e/shared/annotations.range.test.ts
@@ -81,6 +81,8 @@ describe('Annotations, but in a different test suite', () => {
 
       cy.getByTestID('edit-annotation-message')
         .focused()
+        .clear()
+        .focused()
         .type(EDIT_ANNOTATION_TEXT)
 
       cy.getByTestID('edit-annotation-cancel-button').click()
@@ -91,6 +93,7 @@ describe('Annotations, but in a different test suite', () => {
           .should('exist')
           .trigger('mouseover')
       })
+
       cy.getByTestID('giraffe-annotation-tooltip').contains(ANNOTATION_TEXT)
     })
   })
@@ -100,6 +103,7 @@ describe('Annotations, but in a different test suite', () => {
       cy.getByTestID('cell blah').within(() => {
         cy.getByTestID('giraffe-inner-plot').click({shiftKey: true})
       })
+
       cy.getByTestID('overlay--container').within(() => {
         cy.getByTestID('annotation-form-point-type-option').should('be.visible')
         cy.getByTestID('annotation-form-range-type-option').should('be.visible')
@@ -108,6 +112,7 @@ describe('Annotations, but in a different test suite', () => {
 
     it('can add a range annotation, then edit it and switch back and forth from point->range and the endtime stays the same', () => {
       addRangeAnnotation(cy)
+
       startEditingAnnotation(cy)
 
       cy.getByTestID('overlay--container').should('be.visible')
@@ -185,6 +190,7 @@ describe('Annotations, but in a different test suite', () => {
       cy.getByTestID('cell blah').within(() => {
         cy.getByTestID('giraffe-inner-plot').click({shiftKey: true})
       })
+
       cy.getByTestID('overlay--container').within(() => {
         cy.getByTestID('edit-annotation-message')
           .focused()

--- a/cypress/e2e/shared/annotations.range.test.ts
+++ b/cypress/e2e/shared/annotations.range.test.ts
@@ -52,6 +52,7 @@ describe('Annotations, but in a different test suite', () => {
 
       cy.getByTestID('edit-annotation-message')
         .invoke('val', EDIT_ANNOTATION_TEXT)
+        .click()
         .type(PERIOD)
 
       cy.getByTestID('edit-annotation-cancel-button').click()
@@ -157,6 +158,7 @@ describe('Annotations, but in a different test suite', () => {
       cy.getByTestID('overlay--container').within(() => {
         cy.getByTestID('edit-annotation-message')
           .invoke('val', RANGE_ANNOTATION_TEXT)
+          .click()
           .type(PERIOD)
 
         // should be of type 'point'

--- a/cypress/e2e/shared/annotations.range.test.ts
+++ b/cypress/e2e/shared/annotations.range.test.ts
@@ -52,7 +52,10 @@ describe('Annotations, but in a different test suite', () => {
 
       cy.getByTestID('edit-annotation-message')
         .invoke('val', EDIT_ANNOTATION_TEXT)
-        .click({multiple: true})
+        .should($el => {
+          expect(Cypress.dom.isDetached($el)).to.be.false
+        })
+        .click()
         .type(PERIOD)
 
       cy.getByTestID('edit-annotation-cancel-button').click()
@@ -158,7 +161,10 @@ describe('Annotations, but in a different test suite', () => {
       cy.getByTestID('overlay--container').within(() => {
         cy.getByTestID('edit-annotation-message')
           .invoke('val', RANGE_ANNOTATION_TEXT)
-          .click({multiple: true})
+          .should($el => {
+            expect(Cypress.dom.isDetached($el)).to.be.false
+          })
+          .click()
           .type(PERIOD)
 
         // should be of type 'point'

--- a/cypress/e2e/shared/annotations.range.test.ts
+++ b/cypress/e2e/shared/annotations.range.test.ts
@@ -56,7 +56,7 @@ describe('Annotations, but in a different test suite', () => {
           expect(Cypress.dom.isDetached($el)).to.be.false
         })
         .click({force: true, multiple: true})
-        .type(PERIOD)
+        .type(PERIOD, {force: true})
 
       cy.getByTestID('edit-annotation-cancel-button').click()
 
@@ -139,7 +139,7 @@ describe('Annotations, but in a different test suite', () => {
       cy.getByTestID('endTime-testID').should('not.exist')
 
       // save it
-      cy.getByTestID('annotation-submit-button').click()
+      cy.getByTestID('annotation-submit-button').click({force: true})
 
       // make sure the edit was saved successfully
       cy.getByTestID('notification-success').should('be.visible')
@@ -165,7 +165,7 @@ describe('Annotations, but in a different test suite', () => {
             expect(Cypress.dom.isDetached($el)).to.be.false
           })
           .click({force: true, multiple: true})
-          .type(PERIOD)
+          .type(PERIOD, {force: true})
 
         // should be of type 'point'
         cy.getByTestID('annotation-form-point-type-option--input').should(
@@ -200,7 +200,7 @@ describe('Annotations, but in a different test suite', () => {
                   .clear()
                   .type(newEndTime)
 
-                cy.getByTestID('annotation-submit-button').click()
+                cy.getByTestID('annotation-submit-button').click({force: true})
               })
           })
       }) // end overlay-container within

--- a/cypress/e2e/shared/annotations.singlestat.test.ts
+++ b/cypress/e2e/shared/annotations.singlestat.test.ts
@@ -7,6 +7,7 @@ import {
   testEditAnnotation,
   testEditRangeAnnotation,
   testDeleteAnnotation,
+  RANGE_ANNOTATION_TEXT,
 } from '../util/annotationsSetup'
 
 describe('The Annotations UI functionality on a graph + single stat graph type', () => {
@@ -25,7 +26,7 @@ describe('The Annotations UI functionality on a graph + single stat graph type',
   })
   it('can add a range annotation for the xy single stat + line graph', () => {
     addRangeAnnotation(cy)
-    checkAnnotationText(cy, 'range annotation here!')
+    checkAnnotationText(cy, RANGE_ANNOTATION_TEXT)
   })
   it('can add and edit a range annotation for the single stat + line graph', () => {
     testEditRangeAnnotation(cy)

--- a/cypress/e2e/shared/annotations.xy.test.ts
+++ b/cypress/e2e/shared/annotations.xy.test.ts
@@ -7,6 +7,7 @@ import {
   testEditAnnotation,
   testEditRangeAnnotation,
   testDeleteAnnotation,
+  RANGE_ANNOTATION_TEXT,
 } from '../util/annotationsSetup'
 
 describe('The Annotations UI functionality, on a graph (xy line) graph type', () => {
@@ -23,7 +24,7 @@ describe('The Annotations UI functionality, on a graph (xy line) graph type', ()
   })
   it('can add a range annotation for the xy line graph', () => {
     addRangeAnnotation(cy)
-    checkAnnotationText(cy, 'range annotation here!')
+    checkAnnotationText(cy, RANGE_ANNOTATION_TEXT)
   })
   it('can add and edit a range annotation for the xy line graph', () => {
     testEditRangeAnnotation(cy)

--- a/cypress/e2e/util/annotationsSetup.ts
+++ b/cypress/e2e/util/annotationsSetup.ts
@@ -82,7 +82,7 @@ export const addAnnotation = (cy: Cypress.Chainable) => {
     .should($el => {
       expect(Cypress.dom.isDetached($el)).to.be.false
     })
-    .click({multiple: true})
+    .click({force: true, multiple: true})
     .type(PERIOD)
   cy.getByTestID('annotation-submit-button').click()
 }
@@ -156,7 +156,7 @@ export const addRangeAnnotation = (
     .should($el => {
       expect(Cypress.dom.isDetached($el)).to.be.false
     })
-    .click({multiple: true})
+    .click({force: true, multiple: true})
     .type(PERIOD)
 
   cy.getByTestID('annotation-submit-button').click()
@@ -182,7 +182,7 @@ export const testEditAnnotation = (cy: Cypress.Chainable) => {
     .should($el => {
       expect(Cypress.dom.isDetached($el)).to.be.false
     })
-    .click({multiple: true})
+    .click({force: true, multiple: true})
     .type(PERIOD)
 
   cy.getByTestID('annotation-submit-button').click()
@@ -209,7 +209,7 @@ export const testEditRangeAnnotation = (
     .should($el => {
       expect(Cypress.dom.isDetached($el)).to.be.false
     })
-    .click({multiple: true})
+    .click({force: true, multiple: true})
     .type(PERIOD)
 
   // ensure the two times are not equal

--- a/cypress/e2e/util/annotationsSetup.ts
+++ b/cypress/e2e/util/annotationsSetup.ts
@@ -2,11 +2,11 @@ import {Organization} from '../../../src/types'
 import {points} from '../../support/commands'
 
 export const ANNOTATION_TEXT = 'im a hippopotamus'
-export const EDIT_ANNOTATION_TEXT = 'lets edit this annotation...'
-export const RANGE_ANNOTATION_TEXT = 'range annotation here!'
+export const EDIT_ANNOTATION_TEXT = 'lets edit this annotation'
+export const RANGE_ANNOTATION_TEXT = 'range annotation here'
 export const EDIT_RANGE_ANNOTATION_TEXT =
   'editing the text here for the range annotation'
-export const NO_TEXT = ' {backspace}'
+export const PERIOD = '.'
 
 export const setupData = (cy: Cypress.Chainable, plotTypeSuffix = '') =>
   cy.flush().then(() =>
@@ -79,7 +79,7 @@ export const addAnnotation = (cy: Cypress.Chainable) => {
 
   cy.getByTestID('edit-annotation-message')
     .invoke('val', ANNOTATION_TEXT)
-    .type(NO_TEXT)
+    .type(PERIOD)
   cy.getByTestID('annotation-submit-button').click()
 }
 
@@ -149,7 +149,7 @@ export const addRangeAnnotation = (
 
   cy.getByTestID('edit-annotation-message')
     .invoke('val', RANGE_ANNOTATION_TEXT)
-    .type(NO_TEXT)
+    .type(PERIOD)
 
   cy.getByTestID('annotation-submit-button').click()
 }
@@ -171,7 +171,7 @@ export const testEditAnnotation = (cy: Cypress.Chainable) => {
 
   cy.getByTestID('edit-annotation-message')
     .invoke('val', EDIT_ANNOTATION_TEXT)
-    .type(NO_TEXT)
+    .type(PERIOD)
 
   cy.getByTestID('annotation-submit-button').click()
 
@@ -194,7 +194,7 @@ export const testEditRangeAnnotation = (
 
   cy.getByTestID('edit-annotation-message')
     .invoke('val', EDIT_RANGE_ANNOTATION_TEXT)
-    .type(NO_TEXT)
+    .type(PERIOD)
 
   // ensure the two times are not equal
   cy.getByTestID('endTime-testID')

--- a/cypress/e2e/util/annotationsSetup.ts
+++ b/cypress/e2e/util/annotationsSetup.ts
@@ -79,7 +79,7 @@ export const addAnnotation = (cy: Cypress.Chainable) => {
 
   cy.getByTestID('edit-annotation-message')
     .invoke('val', ANNOTATION_TEXT)
-    .click()
+    .click({multiple: true})
     .type(PERIOD)
   cy.getByTestID('annotation-submit-button').click()
 }
@@ -150,7 +150,7 @@ export const addRangeAnnotation = (
 
   cy.getByTestID('edit-annotation-message')
     .invoke('val', RANGE_ANNOTATION_TEXT)
-    .click()
+    .click({multiple: true})
     .type(PERIOD)
 
   cy.getByTestID('annotation-submit-button').click()
@@ -173,7 +173,7 @@ export const testEditAnnotation = (cy: Cypress.Chainable) => {
 
   cy.getByTestID('edit-annotation-message')
     .invoke('val', EDIT_ANNOTATION_TEXT)
-    .click()
+    .click({multiple: true})
     .type(PERIOD)
 
   cy.getByTestID('annotation-submit-button').click()
@@ -197,7 +197,7 @@ export const testEditRangeAnnotation = (
 
   cy.getByTestID('edit-annotation-message')
     .invoke('val', EDIT_RANGE_ANNOTATION_TEXT)
-    .click()
+    .click({multiple: true})
     .type(PERIOD)
 
   // ensure the two times are not equal

--- a/cypress/e2e/util/annotationsSetup.ts
+++ b/cypress/e2e/util/annotationsSetup.ts
@@ -6,7 +6,6 @@ export const EDIT_ANNOTATION_TEXT = 'lets edit this annotation'
 export const RANGE_ANNOTATION_TEXT = 'range annotation here'
 export const EDIT_RANGE_ANNOTATION_TEXT =
   'editing the text here for the range annotation'
-export const PERIOD = '.'
 
 export const setupData = (cy: Cypress.Chainable, plotTypeSuffix = '') =>
   cy.flush().then(() =>
@@ -78,11 +77,8 @@ export const addAnnotation = (cy: Cypress.Chainable) => {
   cy.getByTestID('annotation-message--form').should('be.visible')
 
   cy.getByTestID('edit-annotation-message')
-    .invoke('val', ANNOTATION_TEXT)
-    .should($el => {
-      expect(Cypress.dom.isDetached($el)).to.be.false
-    })
-    .type(PERIOD, {force: true, waitForAnimations: false})
+    .focused()
+    .type(ANNOTATION_TEXT)
 
   cy.getByTestID('annotation-submit-button').click({force: true})
 }
@@ -152,11 +148,8 @@ export const addRangeAnnotation = (
   cy.getByTestID('annotation-message--form').should('be.visible')
 
   cy.getByTestID('edit-annotation-message')
-    .invoke('val', RANGE_ANNOTATION_TEXT)
-    .should($el => {
-      expect(Cypress.dom.isDetached($el)).to.be.false
-    })
-    .type(PERIOD, {force: true, waitForAnimations: false})
+    .focused()
+    .type(RANGE_ANNOTATION_TEXT)
 
   cy.getByTestID('annotation-submit-button').click({force: true})
 }
@@ -177,11 +170,8 @@ export const testEditAnnotation = (cy: Cypress.Chainable) => {
   cy.getByTestID('annotation-message--form').should('be.visible')
 
   cy.getByTestID('edit-annotation-message')
-    .invoke('val', EDIT_ANNOTATION_TEXT)
-    .should($el => {
-      expect(Cypress.dom.isDetached($el)).to.be.false
-    })
-    .type(PERIOD, {force: true, waitForAnimations: false})
+    .focused()
+    .type(EDIT_ANNOTATION_TEXT)
 
   cy.getByTestID('annotation-submit-button').click({force: true})
 
@@ -203,11 +193,8 @@ export const testEditRangeAnnotation = (
   cy.getByTestID('annotation-message--form').should('be.visible')
 
   cy.getByTestID('edit-annotation-message')
-    .invoke('val', EDIT_RANGE_ANNOTATION_TEXT)
-    .should($el => {
-      expect(Cypress.dom.isDetached($el)).to.be.false
-    })
-    .type(PERIOD, {force: true, waitForAnimations: false})
+    .focused()
+    .type(EDIT_RANGE_ANNOTATION_TEXT)
 
   // ensure the two times are not equal
   cy.getByTestID('endTime-testID')

--- a/cypress/e2e/util/annotationsSetup.ts
+++ b/cypress/e2e/util/annotationsSetup.ts
@@ -82,7 +82,6 @@ export const addAnnotation = (cy: Cypress.Chainable) => {
     .should($el => {
       expect(Cypress.dom.isDetached($el)).to.be.false
     })
-    .click({force: true, multiple: true})
     .type(PERIOD, {force: true})
 
   cy.getByTestID('annotation-submit-button').click({force: true})
@@ -157,7 +156,6 @@ export const addRangeAnnotation = (
     .should($el => {
       expect(Cypress.dom.isDetached($el)).to.be.false
     })
-    .click({force: true, multiple: true})
     .type(PERIOD, {force: true})
 
   cy.getByTestID('annotation-submit-button').click({force: true})
@@ -183,7 +181,6 @@ export const testEditAnnotation = (cy: Cypress.Chainable) => {
     .should($el => {
       expect(Cypress.dom.isDetached($el)).to.be.false
     })
-    .click({force: true, multiple: true})
     .type(PERIOD, {force: true})
 
   cy.getByTestID('annotation-submit-button').click({force: true})
@@ -210,7 +207,6 @@ export const testEditRangeAnnotation = (
     .should($el => {
       expect(Cypress.dom.isDetached($el)).to.be.false
     })
-    .click({force: true, multiple: true})
     .type(PERIOD, {force: true})
 
   // ensure the two times are not equal

--- a/cypress/e2e/util/annotationsSetup.ts
+++ b/cypress/e2e/util/annotationsSetup.ts
@@ -175,6 +175,8 @@ export const testEditAnnotation = (cy: Cypress.Chainable) => {
 
   cy.getByTestID('edit-annotation-message')
     .focused()
+    .clear()
+    .focused()
     .type(EDIT_ANNOTATION_TEXT)
 
   cy.getByTestID('annotation-submit-button')
@@ -199,6 +201,8 @@ export const testEditRangeAnnotation = (
   cy.getByTestID('annotation-message--form').should('be.visible')
 
   cy.getByTestID('edit-annotation-message')
+    .focused()
+    .clear()
     .focused()
     .type(EDIT_RANGE_ANNOTATION_TEXT)
 

--- a/cypress/e2e/util/annotationsSetup.ts
+++ b/cypress/e2e/util/annotationsSetup.ts
@@ -79,6 +79,7 @@ export const addAnnotation = (cy: Cypress.Chainable) => {
 
   cy.getByTestID('edit-annotation-message')
     .invoke('val', ANNOTATION_TEXT)
+    .click()
     .type(PERIOD)
   cy.getByTestID('annotation-submit-button').click()
 }
@@ -149,6 +150,7 @@ export const addRangeAnnotation = (
 
   cy.getByTestID('edit-annotation-message')
     .invoke('val', RANGE_ANNOTATION_TEXT)
+    .click()
     .type(PERIOD)
 
   cy.getByTestID('annotation-submit-button').click()
@@ -171,6 +173,7 @@ export const testEditAnnotation = (cy: Cypress.Chainable) => {
 
   cy.getByTestID('edit-annotation-message')
     .invoke('val', EDIT_ANNOTATION_TEXT)
+    .click()
     .type(PERIOD)
 
   cy.getByTestID('annotation-submit-button').click()
@@ -194,6 +197,7 @@ export const testEditRangeAnnotation = (
 
   cy.getByTestID('edit-annotation-message')
     .invoke('val', EDIT_RANGE_ANNOTATION_TEXT)
+    .click()
     .type(PERIOD)
 
   // ensure the two times are not equal

--- a/cypress/e2e/util/annotationsSetup.ts
+++ b/cypress/e2e/util/annotationsSetup.ts
@@ -82,6 +82,7 @@ export const addAnnotation = (cy: Cypress.Chainable) => {
     .should($el => {
       expect(Cypress.dom.isDetached($el)).to.be.false
     })
+    .last()
     .click()
     .type(PERIOD)
   cy.getByTestID('annotation-submit-button').click()
@@ -156,6 +157,7 @@ export const addRangeAnnotation = (
     .should($el => {
       expect(Cypress.dom.isDetached($el)).to.be.false
     })
+    .last()
     .click()
     .type(PERIOD)
 
@@ -182,6 +184,7 @@ export const testEditAnnotation = (cy: Cypress.Chainable) => {
     .should($el => {
       expect(Cypress.dom.isDetached($el)).to.be.false
     })
+    .last()
     .click()
     .type(PERIOD)
 
@@ -209,6 +212,7 @@ export const testEditRangeAnnotation = (
     .should($el => {
       expect(Cypress.dom.isDetached($el)).to.be.false
     })
+    .last()
     .click()
     .type(PERIOD)
 

--- a/cypress/e2e/util/annotationsSetup.ts
+++ b/cypress/e2e/util/annotationsSetup.ts
@@ -82,8 +82,7 @@ export const addAnnotation = (cy: Cypress.Chainable) => {
     .should($el => {
       expect(Cypress.dom.isDetached($el)).to.be.false
     })
-    .last()
-    .click()
+    .click({multiple: true})
     .type(PERIOD)
   cy.getByTestID('annotation-submit-button').click()
 }
@@ -157,8 +156,7 @@ export const addRangeAnnotation = (
     .should($el => {
       expect(Cypress.dom.isDetached($el)).to.be.false
     })
-    .last()
-    .click()
+    .click({multiple: true})
     .type(PERIOD)
 
   cy.getByTestID('annotation-submit-button').click()
@@ -184,8 +182,7 @@ export const testEditAnnotation = (cy: Cypress.Chainable) => {
     .should($el => {
       expect(Cypress.dom.isDetached($el)).to.be.false
     })
-    .last()
-    .click()
+    .click({multiple: true})
     .type(PERIOD)
 
   cy.getByTestID('annotation-submit-button').click()
@@ -212,8 +209,7 @@ export const testEditRangeAnnotation = (
     .should($el => {
       expect(Cypress.dom.isDetached($el)).to.be.false
     })
-    .last()
-    .click()
+    .click({multiple: true})
     .type(PERIOD)
 
   // ensure the two times are not equal

--- a/cypress/e2e/util/annotationsSetup.ts
+++ b/cypress/e2e/util/annotationsSetup.ts
@@ -80,7 +80,9 @@ export const addAnnotation = (cy: Cypress.Chainable) => {
     .focused()
     .type(ANNOTATION_TEXT)
 
-  cy.getByTestID('annotation-submit-button').click({force: true})
+  cy.getByTestID('annotation-submit-button')
+    .should('not.be.disabled')
+    .click()
 }
 
 export const startEditingAnnotation = (cy: Cypress.Chainable) => {
@@ -151,7 +153,9 @@ export const addRangeAnnotation = (
     .focused()
     .type(RANGE_ANNOTATION_TEXT)
 
-  cy.getByTestID('annotation-submit-button').click({force: true})
+  cy.getByTestID('annotation-submit-button')
+    .should('not.be.disabled')
+    .click()
 }
 
 export const testAddAnnotation = (cy: Cypress.Chainable) => {
@@ -173,7 +177,9 @@ export const testEditAnnotation = (cy: Cypress.Chainable) => {
     .focused()
     .type(EDIT_ANNOTATION_TEXT)
 
-  cy.getByTestID('annotation-submit-button').click({force: true})
+  cy.getByTestID('annotation-submit-button')
+    .should('not.be.disabled')
+    .click()
 
   // make sure the edit was saved successfully
   cy.getByTestID('notification-success').should('be.visible')
@@ -207,7 +213,9 @@ export const testEditRangeAnnotation = (
         })
     })
 
-  cy.getByTestID('annotation-submit-button').click({force: true})
+  cy.getByTestID('annotation-submit-button')
+    .should('not.be.disabled')
+    .click()
 
   // make sure the edit was saved successfully
   cy.getByTestID('notification-success').should('be.visible')

--- a/cypress/e2e/util/annotationsSetup.ts
+++ b/cypress/e2e/util/annotationsSetup.ts
@@ -83,8 +83,9 @@ export const addAnnotation = (cy: Cypress.Chainable) => {
       expect(Cypress.dom.isDetached($el)).to.be.false
     })
     .click({force: true, multiple: true})
-    .type(PERIOD)
-  cy.getByTestID('annotation-submit-button').click()
+    .type(PERIOD, {force: true})
+
+  cy.getByTestID('annotation-submit-button').click({force: true})
 }
 
 export const startEditingAnnotation = (cy: Cypress.Chainable) => {
@@ -157,9 +158,9 @@ export const addRangeAnnotation = (
       expect(Cypress.dom.isDetached($el)).to.be.false
     })
     .click({force: true, multiple: true})
-    .type(PERIOD)
+    .type(PERIOD, {force: true})
 
-  cy.getByTestID('annotation-submit-button').click()
+  cy.getByTestID('annotation-submit-button').click({force: true})
 }
 
 export const testAddAnnotation = (cy: Cypress.Chainable) => {
@@ -183,9 +184,9 @@ export const testEditAnnotation = (cy: Cypress.Chainable) => {
       expect(Cypress.dom.isDetached($el)).to.be.false
     })
     .click({force: true, multiple: true})
-    .type(PERIOD)
+    .type(PERIOD, {force: true})
 
-  cy.getByTestID('annotation-submit-button').click()
+  cy.getByTestID('annotation-submit-button').click({force: true})
 
   // make sure the edit was saved successfully
   cy.getByTestID('notification-success').should('be.visible')
@@ -210,7 +211,7 @@ export const testEditRangeAnnotation = (
       expect(Cypress.dom.isDetached($el)).to.be.false
     })
     .click({force: true, multiple: true})
-    .type(PERIOD)
+    .type(PERIOD, {force: true})
 
   // ensure the two times are not equal
   cy.getByTestID('endTime-testID')
@@ -223,7 +224,7 @@ export const testEditRangeAnnotation = (
         })
     })
 
-  cy.getByTestID('annotation-submit-button').click()
+  cy.getByTestID('annotation-submit-button').click({force: true})
 
   // make sure the edit was saved successfully
   cy.getByTestID('notification-success').should('be.visible')

--- a/cypress/e2e/util/annotationsSetup.ts
+++ b/cypress/e2e/util/annotationsSetup.ts
@@ -79,7 +79,10 @@ export const addAnnotation = (cy: Cypress.Chainable) => {
 
   cy.getByTestID('edit-annotation-message')
     .invoke('val', ANNOTATION_TEXT)
-    .click({multiple: true})
+    .should($el => {
+      expect(Cypress.dom.isDetached($el)).to.be.false
+    })
+    .click()
     .type(PERIOD)
   cy.getByTestID('annotation-submit-button').click()
 }
@@ -150,7 +153,10 @@ export const addRangeAnnotation = (
 
   cy.getByTestID('edit-annotation-message')
     .invoke('val', RANGE_ANNOTATION_TEXT)
-    .click({multiple: true})
+    .should($el => {
+      expect(Cypress.dom.isDetached($el)).to.be.false
+    })
+    .click()
     .type(PERIOD)
 
   cy.getByTestID('annotation-submit-button').click()
@@ -173,7 +179,10 @@ export const testEditAnnotation = (cy: Cypress.Chainable) => {
 
   cy.getByTestID('edit-annotation-message')
     .invoke('val', EDIT_ANNOTATION_TEXT)
-    .click({multiple: true})
+    .should($el => {
+      expect(Cypress.dom.isDetached($el)).to.be.false
+    })
+    .click()
     .type(PERIOD)
 
   cy.getByTestID('annotation-submit-button').click()
@@ -197,7 +206,10 @@ export const testEditRangeAnnotation = (
 
   cy.getByTestID('edit-annotation-message')
     .invoke('val', EDIT_RANGE_ANNOTATION_TEXT)
-    .click({multiple: true})
+    .should($el => {
+      expect(Cypress.dom.isDetached($el)).to.be.false
+    })
+    .click()
     .type(PERIOD)
 
   // ensure the two times are not equal

--- a/cypress/e2e/util/annotationsSetup.ts
+++ b/cypress/e2e/util/annotationsSetup.ts
@@ -82,7 +82,7 @@ export const addAnnotation = (cy: Cypress.Chainable) => {
     .should($el => {
       expect(Cypress.dom.isDetached($el)).to.be.false
     })
-    .type(PERIOD, {force: true})
+    .type(PERIOD, {force: true, waitForAnimations: false})
 
   cy.getByTestID('annotation-submit-button').click({force: true})
 }
@@ -156,7 +156,7 @@ export const addRangeAnnotation = (
     .should($el => {
       expect(Cypress.dom.isDetached($el)).to.be.false
     })
-    .type(PERIOD, {force: true})
+    .type(PERIOD, {force: true, waitForAnimations: false})
 
   cy.getByTestID('annotation-submit-button').click({force: true})
 }
@@ -181,7 +181,7 @@ export const testEditAnnotation = (cy: Cypress.Chainable) => {
     .should($el => {
       expect(Cypress.dom.isDetached($el)).to.be.false
     })
-    .type(PERIOD, {force: true})
+    .type(PERIOD, {force: true, waitForAnimations: false})
 
   cy.getByTestID('annotation-submit-button').click({force: true})
 
@@ -207,7 +207,7 @@ export const testEditRangeAnnotation = (
     .should($el => {
       expect(Cypress.dom.isDetached($el)).to.be.false
     })
-    .type(PERIOD, {force: true})
+    .type(PERIOD, {force: true, waitForAnimations: false})
 
   // ensure the two times are not equal
   cy.getByTestID('endTime-testID')


### PR DESCRIPTION
The idea here is:
~~- `invoke('val', 'some annotations text')` to prevent re-render~~
~~- `type()` just one character to make the `<TextArea>` dirty and thus saveable~~
~~- avoid any flakiness from the re-render because we aren't typing 2 or more characters~~
~~- submit the annotation add/edit immediately~~

*** UPDATE:
The `<AnnotationMessageInput />` element does a focus on the text area. Let's use that forced focus to our advantage and type only in that focused element.
