### PR TITLE
feat: added filter to other resources

### DIFF
--- a/src/authorizations/components/redesigned/AllAccordionBody.tsx
+++ b/src/authorizations/components/redesigned/AllAccordionBody.tsx
@@ -15,7 +15,7 @@ import {
 } from '@influxdata/clockface'
 
 interface OwnProps {
-  resourceName: string
+  resourceName: any
   permissions: any
   onToggleAll?: (name: string, permission: string) => void
   disabled: boolean
@@ -24,12 +24,12 @@ interface OwnProps {
 export const AllAccordionBody: FC<OwnProps> = props => {
   const {resourceName, disabled, permissions} = props
 
-  const handleReadToggle = () => {
-    const {onToggleAll, resourceName} = props
+  const handleReadToggle = resourceName => {
+    const {onToggleAll} = props
     onToggleAll(resourceName, 'read')
   }
-  const handleWriteToggle = () => {
-    const {onToggleAll, resourceName} = props
+  const handleWriteToggle = resourceName => {
+    const {onToggleAll} = props
     onToggleAll(resourceName, 'write')
   }
 
@@ -37,50 +37,72 @@ export const AllAccordionBody: FC<OwnProps> = props => {
     event.stopPropagation()
   }
 
+  const AllResourceAccordionBody = (permission?, resourceName?) => (
+    <FlexBox
+      margin={ComponentSize.Small}
+      justifyContent={JustifyContent.SpaceBetween}
+      direction={FlexDirection.Row}
+      stretchToFitWidth={true}
+      alignItems={AlignItems.Center}
+      style={{textAlign: 'start'}}
+    >
+      <FlexBox.Child basis={40} grow={8}>
+        <InputLabel size={ComponentSize.Small}>{`All ${
+          resourceName ? resourceName : props.resourceName
+        }`}</InputLabel>
+      </FlexBox.Child>
+      <FlexBox.Child grow={1} onClick={handleFlexboxClick}>
+        <Toggle
+          id={resourceName ? resourceName : props.resourceName}
+          type={InputToggleType.Checkbox}
+          onChange={handleReadToggle}
+          size={ComponentSize.ExtraSmall}
+          checked={permission ? permission.perm.read : permissions.read}
+          value={permission ? permission.name : props.resourceName}
+          style={{marginRight: '10px'}}
+          tabIndex={0}
+          disabled={disabled}
+        ></Toggle>
+      </FlexBox.Child>
+      <FlexBox.Child grow={1} onClick={handleFlexboxClick}>
+        <Toggle
+          id={resourceName ? resourceName + 1 : props.resourceName + 1}
+          type={InputToggleType.Checkbox}
+          onChange={handleWriteToggle}
+          size={ComponentSize.ExtraSmall}
+          checked={permission ? permission.perm.write : permissions.write}
+          value={permission ? permission.name : props.resourceName}
+          style={{marginRight: '0px'}}
+          tabIndex={0}
+          disabled={disabled}
+        ></Toggle>
+      </FlexBox.Child>
+    </FlexBox>
+  )
+
   return (
     <>
-      <Accordion.AccordionBodyItem className="resource-accordion-body">
-        <FlexBox
-          margin={ComponentSize.Small}
-          justifyContent={JustifyContent.SpaceBetween}
-          direction={FlexDirection.Row}
-          stretchToFitWidth={true}
-          alignItems={AlignItems.Center}
-          style={{textAlign: 'start'}}
-        >
-          <FlexBox.Child basis={40} grow={8}>
-            <InputLabel
-              size={ComponentSize.Small}
-            >{`All ${resourceName}`}</InputLabel>
-          </FlexBox.Child>
-          <FlexBox.Child grow={1} onClick={handleFlexboxClick}>
-            <Toggle
-              id={resourceName}
-              type={InputToggleType.Checkbox}
-              onChange={handleReadToggle}
-              size={ComponentSize.ExtraSmall}
-              checked={permissions.read}
-              value={permissions.read.toString()}
-              style={{marginRight: '10px'}}
-              tabIndex={0}
-              disabled={disabled}
-            ></Toggle>
-          </FlexBox.Child>
-          <FlexBox.Child grow={1} onClick={handleFlexboxClick}>
-            <Toggle
-              id={resourceName + 1}
-              type={InputToggleType.Checkbox}
-              onChange={handleWriteToggle}
-              size={ComponentSize.ExtraSmall}
-              checked={permissions.write}
-              value={permissions.write.toString()}
-              style={{marginRight: '0px'}}
-              tabIndex={0}
-              disabled={disabled}
-            ></Toggle>
-          </FlexBox.Child>
-        </FlexBox>
-      </Accordion.AccordionBodyItem>
+      {resourceName === 'All Resources' ? (
+        Object.keys(permissions).map(key => {
+          //[{name: perm:{read: write:}}]
+          let names = permissions[key].name
+
+          const resourceName = names.charAt(0).toUpperCase() + names.slice(1)
+
+          return (
+            <Accordion.AccordionBodyItem
+              key={key}
+              className="resource-accordion-body"
+            >
+              {AllResourceAccordionBody(permissions[key], resourceName)}
+            </Accordion.AccordionBodyItem>
+          )
+        })
+      ) : (
+        <Accordion.AccordionBodyItem className="resource-accordion-body">
+          {AllResourceAccordionBody()}
+        </Accordion.AccordionBodyItem>
+      )}
     </>
   )
 }

--- a/src/authorizations/components/redesigned/ResourceAccordion.tsx
+++ b/src/authorizations/components/redesigned/ResourceAccordion.tsx
@@ -67,23 +67,36 @@ class ResourceAccordion extends Component<OwnProps> {
             disabled={false}
           />
           {!permissions.otherResources.read && !permissions.otherResources.write
-            ? resources[1].map(resource => {
-                const resourceName =
-                  resource.charAt(0).toUpperCase() + resource.slice(1)
-
-                return (
-                  <AllAccordionBody
-                    key={resource}
-                    resourceName={resourceName}
-                    permissions={permissions[resource]}
-                    onToggleAll={onToggleAll}
-                    disabled={false}
-                  />
-                )
-              })
+            ? this.otherResourcesAccordionBody()
             : null}
         </Accordion>
       </>
+    )
+  }
+
+  otherResourcesAccordionBody = () => {
+    const {onToggleAll, resources, permissions} = this.props
+    const resourcePermissions = []
+
+    resources[1].map(resource => {
+      resourcePermissions.push({name: resource, perm: permissions[resource]})
+    })
+
+    return (
+      <Filter
+        list={resourcePermissions}
+        searchTerm={this.props.searchTerm}
+        searchKeys={['name']}
+      >
+        {filteredNames => (
+          <AllAccordionBody
+            resourceName={'All Resources'}
+            permissions={filteredNames}
+            onToggleAll={onToggleAll}
+            disabled={false}
+          />
+        )}
+      </Filter>
     )
   }
 
@@ -96,6 +109,7 @@ class ResourceAccordion extends Component<OwnProps> {
       )) {
         permissionNames.push(value)
       }
+
       return (
         <Filter
           list={permissionNames}


### PR DESCRIPTION
Closes #2917 

Changes: 
As a user, when I open the Other Resources accordion inside Custom Api Token Overlay and type inside the filter access permissions input box, the resources get filtered and rendered accordingly.


https://user-images.githubusercontent.com/66275100/138324453-a52ef5ba-949d-4dba-a6da-2d2e10b628eb.mov


