### PR TITLE
fix: add alerts as sub menu item

### DIFF
--- a/src/pageLayout/constants/navigationHierarchy.ts
+++ b/src/pageLayout/constants/navigationHierarchy.ts
@@ -131,8 +131,15 @@ export const generateNavItems = (): NavItem[] => {
       icon: IconFont.Bell,
       label: 'Alerts',
       link: `${orgPrefix}/alerting`,
-      activeKeywords: ['alerting'],
+      activeKeywords: ['alerting', 'alert-history'],
       menu: [
+        {
+          id: 'alerting',
+          testID: 'nav-item-alerting',
+          label: 'Alerts',
+          link: `${orgPrefix}/alerting`,
+
+        },
         {
           id: 'history',
           testID: 'nav-subitem-history',


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/2981

Just adds the Alerts as a sub menu item in the nav hierarchy. 

![image](https://user-images.githubusercontent.com/18511823/138335891-2f04c17b-af25-4083-bd06-ca1f5d4d1f3b.png)

