### PR TITLE
chore: tweaking  explicit bucket UI

### DIFF
--- a/src/buckets/components/createBucketForm/MeasurementSchema.scss
+++ b/src/buckets/components/createBucketForm/MeasurementSchema.scss
@@ -9,8 +9,8 @@
     border-radius: 3px;
 
     &.hasError {
-      border-color: $c-dreamsicle;
-      color: $c-dreamsicle;
+      border-color: $c-fire;
+      color: $c-fire;
     }
 
     input[type='file'].drag-and-drop--input {

--- a/src/buckets/components/createBucketForm/MiniFileDnd.tsx
+++ b/src/buckets/components/createBucketForm/MiniFileDnd.tsx
@@ -245,7 +245,7 @@ export const MiniFileDnd: FC<Props> = ({
 
   const dropZoneClasses = classnames('dnd', {
     active: dropAreaActive,
-    hasError: hasError && !fileName,
+    hasError: hasError,
   })
 
   const displayAreaClasses = classnames('display-area', {

--- a/src/buckets/constants/index.ts
+++ b/src/buckets/constants/index.ts
@@ -7,7 +7,7 @@ export const isSystemBucket = (bucketName: string): boolean => {
 
 export const getBucketOverlayWidth = () => {
   if (isFlagEnabled('measurementSchema') && CLOUD) {
-    return 575
+    return 650
   }
   return 450
 }


### PR DESCRIPTION
 widening the bucket overlay and adjusting the color to match the new clockface colors for v3.0

also fixing a small bug in which the error css of the mini file dnd was not getting set correctly 
(changing the flags for when a css class should be applied)