### PR TITLE
chore: adjusting font weight to decrease blurriness

### DIFF
--- a/src/shared/components/dateRangePicker/DateRangePicker.scss
+++ b/src/shared/components/dateRangePicker/DateRangePicker.scss
@@ -15,6 +15,7 @@
   .react-datepicker {
     font-family: $ix-text-font;
     font-size: $ix-text-base-1;
+    font-weight: 400;
   }
 
   .range-picker--date-pickers {


### PR DESCRIPTION
Closes #2796 

adjusting font weight to look less blurry.

I initially changed the font itself, and was directed to keep the font (Rubik), and adjust the weight instead.

before:
![Screen Shot 2021-10-25 at 11 41 27 AM](https://user-images.githubusercontent.com/3900960/138730841-03334d01-aa81-458b-997c-56f03dd96d09.png)


after:
![Screen Shot 2021-10-25 at 11 41 17 AM](https://user-images.githubusercontent.com/3900960/138730854-f5d197dc-6a08-458e-9a71-a5ba3f7226e5.png)
 
