### PR TITLE
fix: redirect users to a plugin's page on cancel instead of going back

### DIFF
--- a/src/writeData/components/PluginAddToExistingConfiguration/Wizard.tsx
+++ b/src/writeData/components/PluginAddToExistingConfiguration/Wizard.tsx
@@ -23,6 +23,11 @@ import {
 } from 'src/dataLoaders/actions/steps'
 import {clearDataLoaders} from 'src/dataLoaders/actions/dataLoaders'
 
+// Selectors
+import {getOrg} from 'src/organizations/selectors'
+
+// Constants
+import {TELEGRAF_PLUGINS} from 'src/shared/constants/routes'
 const PLUGIN_CREATE_CONFIGURATION_OVERLAY_DEFAULT_WIDTH = 1200
 const PLUGIN_CREATE_CONFIGURATION_OVERLAY_OPTIONS_WIDTH = 480
 const PREVENT_OVERLAY_FLICKER_STEP = -1
@@ -39,7 +44,7 @@ const StepSwitcher = Loadable({
 
 interface WizardProps {
   history: {
-    goBack: () => void
+    push: (route: string) => void
   }
 }
 
@@ -61,6 +66,7 @@ const Wizard: FC<Props> = props => {
     onIncrementCurrentStepIndex,
     onSetCurrentStepIndex,
     onSetSubstepIndex,
+    org,
   } = props
 
   const {contentID} = useParams<ParamsType>()
@@ -80,7 +86,7 @@ const Wizard: FC<Props> = props => {
     onClearDataLoaders()
     onClearSteps()
     onSetCurrentStepIndex(PREVENT_OVERLAY_FLICKER_STEP)
-    history.goBack()
+    history.push(`/orgs/${org.id}/load-data/${TELEGRAF_PLUGINS}/${contentID}`)
     setIsVisible(false)
   }
 
@@ -134,8 +140,11 @@ const mstp = (state: AppState) => {
     },
   } = state
 
+  const org = getOrg(state)
+
   return {
     currentStepIndex: currentStep,
+    org,
   }
 }
 

--- a/src/writeData/components/PluginCreateConfiguration/Wizard.tsx
+++ b/src/writeData/components/PluginCreateConfiguration/Wizard.tsx
@@ -24,8 +24,12 @@ import {
 } from 'src/dataLoaders/actions/steps'
 import {clearDataLoaders} from 'src/dataLoaders/actions/dataLoaders'
 
+// Selectors
+import {getOrg} from 'src/organizations/selectors'
+
 // Constants
 import {getBucketOverlayWidth} from 'src/buckets/constants'
+import {TELEGRAF_PLUGINS} from 'src/shared/constants/routes'
 const PLUGIN_CREATE_CONFIGURATION_OVERLAY_DEFAULT_WIDTH = 1200
 const PLUGIN_CREATE_CONFIGURATION_OVERLAY_OPTIONS_WIDTH = 480
 
@@ -39,7 +43,7 @@ const StepSwitcher = Loadable({
 
 interface WizardProps {
   history: {
-    goBack: () => void
+    push: (route: string) => void
   }
 }
 
@@ -61,6 +65,7 @@ const Wizard: FC<Props> = props => {
     onIncrementCurrentStepIndex,
     onSetCurrentStepIndex,
     onSetSubstepIndex,
+    org,
     setBucketInfo,
     substepIndex,
   } = props
@@ -87,7 +92,7 @@ const Wizard: FC<Props> = props => {
       onSetSubstepIndex(0, 0)
     } else {
       setIsVisible(false)
-      history.goBack()
+      history.push(`/orgs/${org.id}/load-data/${TELEGRAF_PLUGINS}/${contentID}`)
     }
   }
 
@@ -148,8 +153,11 @@ const mstp = (state: AppState) => {
     },
   } = state
 
+  const org = getOrg(state)
+
   return {
     currentStepIndex: currentStep,
+    org,
     substepIndex: typeof substep === 'number' ? substep : 0,
   }
 }


### PR DESCRIPTION
Closes #2975 

Redirects the user to a specific route, the plugin's page, rather than going back to previous page  upon canceling. This prevents undesired behavior if the user's route history is corrupted during `/new` and `/edit`.