### PR TITLE
test: testing both format util functions for permissions

### DIFF
--- a/src/authorizations/utils/permissions.test.ts
+++ b/src/authorizations/utils/permissions.test.ts
@@ -1,6 +1,10 @@
 import {allAccessPermissions, toggleSelectedBucket} from './permissions'
 import {CLOUD} from 'src/shared/constants'
-import {generateDescription, formatApiPermissions, formatPermissionsObj} from 'src/authorizations/utils/permissions'
+import {
+  generateDescription,
+  formatApiPermissions,
+  formatPermissionsObj,
+} from 'src/authorizations/utils/permissions'
 
 // TODO remove all of this when we move to server side authority
 const ossHvhs = [
@@ -726,20 +730,18 @@ describe('generateDescription method', () => {
   })
 })
 
-// test format api perms - the method that converts perm into api style perm 
-// perm = { annotations: {read: true, write: false}} --> perm = {{action: read, resource: {orgID: 3432, type: annotations}}}
-const orgID = "ba9198e037d35d4d"
-const orgName = "dev"
-const monitoringID = "25a6692ba25d7147"
+const orgID = 'ba9198e037d35d4d'
+const orgName = 'dev'
+const monitoringID = '25a6692ba25d7147'
 
 const allAccessAccordionPerms = {
   annotations: {
-      read: true, 
-      write: false 
-   },
+    read: true,
+    write: false,
+  },
   authorizations: {
-      read: false, 
-      write: true
+    read: false,
+    write: true,
   },
 }
 
@@ -749,89 +751,85 @@ const allAccessApiPerm = [
     resource: {
       orgID: orgID,
       type: 'annotations',
-    }
-  }, 
+    },
+  },
   {
     action: 'write',
     resource: {
       orgID: orgID,
       type: 'authorizations',
-    }
-  }
-  
+    },
+  },
 ]
 
 const nonAllAcessAccordionPerms = {
   buckets: {
-    read: false, 
-    write: false, 
+    read: false,
+    write: false,
     sublevelPermissions: {
-      "25a6692ba25d7147": {
-          id: "25a6692ba25d7147",
-          name: "_monitoring",
-          orgID: "ba9198e037d35d4d",
-          permissions: {read: true, write: true}
-        },
-      "28eccf12e3e4ff8e": {
-          id: "28eccf12e3e4ff8e",
-          name: "frontendservices",
-          orgID: "ba9198e037d35d4d",
-          permissions: {read: false, write: false}
-        },
-        "32b8e84498b27938": {
-          id: "32b8e84498b27938",
-          name: "devbucket",
-          orgID: "ba9198e037d35d4d",
-          permissions: {read: false, write: false}
-        },
-      }   
-
-  }
+      '25a6692ba25d7147': {
+        id: '25a6692ba25d7147',
+        name: '_monitoring',
+        orgID: 'ba9198e037d35d4d',
+        permissions: {read: true, write: true},
+      },
+      '28eccf12e3e4ff8e': {
+        id: '28eccf12e3e4ff8e',
+        name: 'frontendservices',
+        orgID: 'ba9198e037d35d4d',
+        permissions: {read: false, write: false},
+      },
+      '32b8e84498b27938': {
+        id: '32b8e84498b27938',
+        name: 'devbucket',
+        orgID: 'ba9198e037d35d4d',
+        permissions: {read: false, write: false},
+      },
+    },
+  },
 }
 
 const nonAllAcessAccordionPerms2 = {
   buckets: {
-    read: true, 
-    write: true, 
+    read: true,
+    write: true,
     sublevelPermissions: {
-      "25a6692ba25d7147": {
-          id: "25a6692ba25d7147",
-          name: "_monitoring",
-          orgID: "ba9198e037d35d4d",
-          permissions: {read: true, write: true}
-        }
-      }   
-
-  }
+      '25a6692ba25d7147': {
+        id: '25a6692ba25d7147',
+        name: '_monitoring',
+        orgID: 'ba9198e037d35d4d',
+        permissions: {read: true, write: true},
+      },
+    },
+  },
 }
 
 const nonAllAcessApiPerms = [
   {
-    action: 'read', 
-    resource: { 
+    action: 'read',
+    resource: {
       orgID: orgID,
       type: 'buckets',
       id: monitoringID,
-      name: "_monitoring"
-    }
+      name: '_monitoring',
+    },
   },
   {
-    action: 'write', 
-    resource: { 
+    action: 'write',
+    resource: {
       orgID: orgID,
       type: 'buckets',
       id: monitoringID,
-      name: "_monitoring"
-    }
-  }
-  
+      name: '_monitoring',
+    },
+  },
 ]
 
 const orgsAccordionPerm = {
   orgs: {
-    read: true, 
-    write: true
-  }
+    read: true,
+    write: true,
+  },
 }
 
 const orgsApiPerm = [
@@ -845,32 +843,41 @@ const orgsApiPerm = [
   },
   {
     action: 'write',
-      resource: {
-        id: orgID,
-        name: orgName,
-        type: 'orgs',
-      },
-  }
+    resource: {
+      id: orgID,
+      name: orgName,
+      type: 'orgs',
+    },
+  },
 ]
 
 describe('Testing formatApiPermissions function', () => {
   test('does it convert all access permission object into api permission', () => {
-    expect(formatApiPermissions(allAccessAccordionPerms, orgID, orgName)).toMatchObject(allAccessApiPerm)
+    expect(
+      formatApiPermissions(allAccessAccordionPerms, orgID, orgName)
+    ).toMatchObject(allAccessApiPerm)
   })
   test('does it convert non-all access permission object into api permission', () => {
-    expect(formatApiPermissions(nonAllAcessAccordionPerms, orgID, orgName)).toMatchObject(nonAllAcessApiPerms)
+    expect(
+      formatApiPermissions(nonAllAcessAccordionPerms, orgID, orgName)
+    ).toMatchObject(nonAllAcessApiPerms)
   })
   test('does it convert orgs permission object into api permission', () => {
-    expect(formatApiPermissions(orgsAccordionPerm, orgID, orgName)).toMatchObject(orgsApiPerm)
+    expect(
+      formatApiPermissions(orgsAccordionPerm, orgID, orgName)
+    ).toMatchObject(orgsApiPerm)
   })
-  
 })
 describe('Testing formatPermissionsObj function', () => {
   test('for api permissions with IDs, it creates perms with sublevel permissions', () => {
-    expect(formatPermissionsObj(nonAllAcessApiPerms)).toMatchObject(nonAllAcessAccordionPerms2)
+    expect(formatPermissionsObj(nonAllAcessApiPerms)).toMatchObject(
+      nonAllAcessAccordionPerms2
+    )
   })
   test('if all sublevel permissions are true, it updates the top level perms to true', () => {
-    expect(formatPermissionsObj(nonAllAcessApiPerms)).toEqual(nonAllAcessAccordionPerms2)
+    expect(formatPermissionsObj(nonAllAcessApiPerms)).toEqual(
+      nonAllAcessAccordionPerms2
+    )
   })
   test('for all access permissions, it creates an all access accordion api permission', () => {
     expect(formatPermissionsObj(orgsApiPerm)).toMatchObject(orgsAccordionPerm)

--- a/src/authorizations/utils/permissions.test.ts
+++ b/src/authorizations/utils/permissions.test.ts
@@ -1,6 +1,6 @@
 import {allAccessPermissions, toggleSelectedBucket} from './permissions'
 import {CLOUD} from 'src/shared/constants'
-import {generateDescription, formatApiPermissions} from 'src/authorizations/utils/permissions'
+import {generateDescription, formatApiPermissions, formatPermissionsObj} from 'src/authorizations/utils/permissions'
 
 // TODO remove all of this when we move to server side authority
 const ossHvhs = [
@@ -732,7 +732,7 @@ const orgID = "ba9198e037d35d4d"
 const orgName = "blegesse"
 const monitoringID = "25a6692ba25d7147"
 
-const allAccessPerms = {
+const allAccessAccordionPerms = {
   annotations: {
       read: true, 
       write: false 
@@ -761,7 +761,7 @@ const allAccessApiPerm = [
   
 ]
 
-const nonAllAcessPerms = {
+const nonAllAcessAccordionPerms = {
   buckets: {
     read: false, 
     write: false, 
@@ -789,6 +789,22 @@ const nonAllAcessPerms = {
   }
 }
 
+const nonAllAcessAccordionPerms2 = {
+  buckets: {
+    read: true, 
+    write: true, 
+    sublevelPermissions: {
+      "25a6692ba25d7147": {
+          id: "25a6692ba25d7147",
+          name: "_monitoring",
+          orgID: "ba9198e037d35d4d",
+          permissions: {read: true, write: true}
+        }
+      }   
+
+  }
+}
+
 const nonAllAcessApiPerms = [
   {
     action: 'read', 
@@ -811,7 +827,7 @@ const nonAllAcessApiPerms = [
   
 ]
 
-const orgsPerm = {
+const orgsAccordionPerm = {
   orgs: {
     read: true, 
     write: true
@@ -836,7 +852,7 @@ const orgsApiPerm = [
       },
   }
 ]
-const permissions = {
+const accordionPermissions = {
   annotations: {
       read: false, 
       write: false 
@@ -946,15 +962,42 @@ const permissions = {
 
 } 
 
-describe('formatApiPermissions method', () => {
+const apiBucketPerm = [
+  {
+    action: "read",
+    resource:{
+      id: "25a6692ba25d7147",
+      name: "_monitoring",
+      org: "dev",
+      orgID: "ba9198e037d35d4d",
+      type: "buckets"
+    }
+
+  }
+]
+
+
+
+describe('Testing formatApiPermissions function', () => {
   test('does it convert all access permission object into api permission', () => {
-    expect(formatApiPermissions(allAccessPerms, orgID, orgName)).toEqual(allAccessApiPerm)
+    expect(formatApiPermissions(allAccessAccordionPerms, orgID, orgName)).toMatchObject(allAccessApiPerm)
   })
   test('does it convert non-all access permission object into api permission', () => {
-    expect(formatApiPermissions(nonAllAcessPerms, orgID, orgName)).toEqual(nonAllAcessApiPerms)
+    expect(formatApiPermissions(nonAllAcessAccordionPerms, orgID, orgName)).toMatchObject(nonAllAcessApiPerms)
   })
   test('does it convert orgs permission object into api permission', () => {
-    expect(formatApiPermissions(orgsPerm, orgID, orgName)).toEqual(orgsApiPerm)
+    expect(formatApiPermissions(orgsAccordionPerm, orgID, orgName)).toMatchObject(orgsApiPerm)
   })
   
+})
+describe('Testing formatPermissionsObj function', () => {
+  test('for api permissions with IDs, it creates perms with sublevel permissions', () => {
+    expect(formatPermissionsObj(nonAllAcessApiPerms)).toMatchObject(nonAllAcessAccordionPerms2)
+  })
+  test('if all sublevel permissions are true, it updates the top level perms to true', () => {
+    expect(formatPermissionsObj(nonAllAcessApiPerms)).toEqual(nonAllAcessAccordionPerms2)
+  })
+  test('for all access permissions, it creates an all access accordion api permission', () => {
+    expect(formatPermissionsObj(orgsApiPerm)).toMatchObject(orgsAccordionPerm)
+  })
 })

--- a/src/authorizations/utils/permissions.test.ts
+++ b/src/authorizations/utils/permissions.test.ts
@@ -729,7 +729,7 @@ describe('generateDescription method', () => {
 // test format api perms - the method that converts perm into api style perm 
 // perm = { annotations: {read: true, write: false}} --> perm = {{action: read, resource: {orgID: 3432, type: annotations}}}
 const orgID = "ba9198e037d35d4d"
-const orgName = "blegesse"
+const orgName = "dev"
 const monitoringID = "25a6692ba25d7147"
 
 const allAccessAccordionPerms = {
@@ -852,131 +852,6 @@ const orgsApiPerm = [
       },
   }
 ]
-const accordionPermissions = {
-  annotations: {
-      read: false, 
-      write: false 
-   },
-  authorizations: {
-      read: false, 
-      write: false
-  },
-  buckets: {
-      read: false, 
-      write: false, 
-      sublevelPermissions: {
-        "25a6692ba25d7147": {
-            id: "25a6692ba25d7147",
-            name: "_monitoring",
-            orgID: "ba9198e037d35d4d",
-            permissions: {read: true, write: true}
-          },
-        "28eccf12e3e4ff8e": {
-            id: "28eccf12e3e4ff8e",
-            name: "frontendservices",
-            orgID: "ba9198e037d35d4d",
-            permissions: {read: false, write: false}
-          },
-          "32b8e84498b27938": {
-            id: "32b8e84498b27938",
-            name: "devbucket",
-            orgID: "ba9198e037d35d4d",
-            permissions: {read: false, write: false}
-          },
-        }   
-
-  },
-  checks: {
-      read: false, 
-      write: false
-  },
-  dashboards: {
-      read: false, 
-      write: false
-  },
-  dbrp: {
-      read: false, 
-      write: false
-  },
-  documents: {
-      read: false,
-      write: false
-  },
-  flows: {
-      read: false, 
-      write: false
-  },
-  functions: {
-      read: false, 
-      write: false
-  },
-  labels: {
-      read: false, 
-      write: false
-  },
-  notificationEndpoints: {
-      read: false, 
-      write: false
-  },
-  notificationRules: {
-      read: false, 
-      write: false
-  },
-  orgs: {
-      read: false, 
-      write: false
-  },
-  otherResources: {
-      read: false, 
-      write: false
-  },
-  scrapers: {
-      read: false, 
-      write: false
-  },
-  secrets: {
-      read: false, 
-      write: false
-  },
-  sources: {
-      read: false, 
-      write: false
-  },
-  tasks: {
-      read: false, 
-      write: false
-  },
-  telegrafs: {
-      read: false, 
-      write: false, 
-      sublevelPermissions: {}
-  },
-  users: {
-      read: false, 
-      write: false
-  },
-  variables: {
-      read: false, 
-      write: false
-  }
-
-} 
-
-const apiBucketPerm = [
-  {
-    action: "read",
-    resource:{
-      id: "25a6692ba25d7147",
-      name: "_monitoring",
-      org: "dev",
-      orgID: "ba9198e037d35d4d",
-      type: "buckets"
-    }
-
-  }
-]
-
-
 
 describe('Testing formatApiPermissions function', () => {
   test('does it convert all access permission object into api permission', () => {

--- a/src/authorizations/utils/permissions.test.ts
+++ b/src/authorizations/utils/permissions.test.ts
@@ -1,6 +1,6 @@
 import {allAccessPermissions, toggleSelectedBucket} from './permissions'
 import {CLOUD} from 'src/shared/constants'
-import {generateDescription} from 'src/authorizations/utils/permissions'
+import {generateDescription, formatApiPermissions} from 'src/authorizations/utils/permissions'
 
 // TODO remove all of this when we move to server side authority
 const ossHvhs = [
@@ -724,4 +724,237 @@ describe('generateDescription method', () => {
       'Read buckets _monitoring Write buckets _monitoring'
     )
   })
+})
+
+// test format api perms - the method that converts perm into api style perm 
+// perm = { annotations: {read: true, write: false}} --> perm = {{action: read, resource: {orgID: 3432, type: annotations}}}
+const orgID = "ba9198e037d35d4d"
+const orgName = "blegesse"
+const monitoringID = "25a6692ba25d7147"
+
+const allAccessPerms = {
+  annotations: {
+      read: true, 
+      write: false 
+   },
+  authorizations: {
+      read: false, 
+      write: true
+  },
+}
+
+const allAccessApiPerm = [
+  {
+    action: 'read',
+    resource: {
+      orgID: orgID,
+      type: 'annotations',
+    }
+  }, 
+  {
+    action: 'write',
+    resource: {
+      orgID: orgID,
+      type: 'authorizations',
+    }
+  }
+  
+]
+
+const nonAllAcessPerms = {
+  buckets: {
+    read: false, 
+    write: false, 
+    sublevelPermissions: {
+      "25a6692ba25d7147": {
+          id: "25a6692ba25d7147",
+          name: "_monitoring",
+          orgID: "ba9198e037d35d4d",
+          permissions: {read: true, write: true}
+        },
+      "28eccf12e3e4ff8e": {
+          id: "28eccf12e3e4ff8e",
+          name: "frontendservices",
+          orgID: "ba9198e037d35d4d",
+          permissions: {read: false, write: false}
+        },
+        "32b8e84498b27938": {
+          id: "32b8e84498b27938",
+          name: "devbucket",
+          orgID: "ba9198e037d35d4d",
+          permissions: {read: false, write: false}
+        },
+      }   
+
+  }
+}
+
+const nonAllAcessApiPerms = [
+  {
+    action: 'read', 
+    resource: { 
+      orgID: orgID,
+      type: 'buckets',
+      id: monitoringID,
+      name: "_monitoring"
+    }
+  },
+  {
+    action: 'write', 
+    resource: { 
+      orgID: orgID,
+      type: 'buckets',
+      id: monitoringID,
+      name: "_monitoring"
+    }
+  }
+  
+]
+
+const orgsPerm = {
+  orgs: {
+    read: true, 
+    write: true
+  }
+}
+
+const orgsApiPerm = [
+  {
+    action: 'read',
+    resource: {
+      id: orgID,
+      name: orgName,
+      type: 'orgs',
+    },
+  },
+  {
+    action: 'write',
+      resource: {
+        id: orgID,
+        name: orgName,
+        type: 'orgs',
+      },
+  }
+]
+const permissions = {
+  annotations: {
+      read: false, 
+      write: false 
+   },
+  authorizations: {
+      read: false, 
+      write: false
+  },
+  buckets: {
+      read: false, 
+      write: false, 
+      sublevelPermissions: {
+        "25a6692ba25d7147": {
+            id: "25a6692ba25d7147",
+            name: "_monitoring",
+            orgID: "ba9198e037d35d4d",
+            permissions: {read: true, write: true}
+          },
+        "28eccf12e3e4ff8e": {
+            id: "28eccf12e3e4ff8e",
+            name: "frontendservices",
+            orgID: "ba9198e037d35d4d",
+            permissions: {read: false, write: false}
+          },
+          "32b8e84498b27938": {
+            id: "32b8e84498b27938",
+            name: "devbucket",
+            orgID: "ba9198e037d35d4d",
+            permissions: {read: false, write: false}
+          },
+        }   
+
+  },
+  checks: {
+      read: false, 
+      write: false
+  },
+  dashboards: {
+      read: false, 
+      write: false
+  },
+  dbrp: {
+      read: false, 
+      write: false
+  },
+  documents: {
+      read: false,
+      write: false
+  },
+  flows: {
+      read: false, 
+      write: false
+  },
+  functions: {
+      read: false, 
+      write: false
+  },
+  labels: {
+      read: false, 
+      write: false
+  },
+  notificationEndpoints: {
+      read: false, 
+      write: false
+  },
+  notificationRules: {
+      read: false, 
+      write: false
+  },
+  orgs: {
+      read: false, 
+      write: false
+  },
+  otherResources: {
+      read: false, 
+      write: false
+  },
+  scrapers: {
+      read: false, 
+      write: false
+  },
+  secrets: {
+      read: false, 
+      write: false
+  },
+  sources: {
+      read: false, 
+      write: false
+  },
+  tasks: {
+      read: false, 
+      write: false
+  },
+  telegrafs: {
+      read: false, 
+      write: false, 
+      sublevelPermissions: {}
+  },
+  users: {
+      read: false, 
+      write: false
+  },
+  variables: {
+      read: false, 
+      write: false
+  }
+
+} 
+
+describe('formatApiPermissions method', () => {
+  test('does it convert all access permission object into api permission', () => {
+    expect(formatApiPermissions(allAccessPerms, orgID, orgName)).toEqual(allAccessApiPerm)
+  })
+  test('does it convert non-all access permission object into api permission', () => {
+    expect(formatApiPermissions(nonAllAcessPerms, orgID, orgName)).toEqual(nonAllAcessApiPerms)
+  })
+  test('does it convert orgs permission object into api permission', () => {
+    expect(formatApiPermissions(orgsPerm, orgID, orgName)).toEqual(orgsApiPerm)
+  })
+  
 })


### PR DESCRIPTION
Closes #2877 

PR tests the two util functions inside Permissions.ts; `formatApiPermissions` (takes in accordion style permissions and converts it to api permission) and `formatPermissionsObj` (takes in api permission and converts it to accordion permissions) 
