### PR TITLE
fix: dashboard grid label flex

### DIFF
--- a/src/dashboards/components/DashboardsCardGrid.scss
+++ b/src/dashboards/components/DashboardsCardGrid.scss
@@ -57,7 +57,6 @@ $dashboard-grid-gap: $cf-marg-a;
   .cf-resource-description--preview,
   #text {
     max-width: 496px;
-    flex: 1 0 30px;
     overflow: hidden;
   }
 }


### PR DESCRIPTION
Closes #
![Screen Shot 2021-10-26 at 11 56 58 AM](https://user-images.githubusercontent.com/12561526/138924533-0886ea89-b291-4564-82d4-de3184ae5dfb.png)

<!-- Describe your propos
![Screen Shot 2021-10-26 at 12 13 09 PM](https://user-images.githubusercontent.com/12561526/138924517-29c3704b-c4ad-46d8-9fc8-18780c4bc8b1.png)
ed changes here. -->

![Screen Shot 2021-10-26 at 12 49 42 PM](https://user-images.githubusercontent.com/12561526/138924625-265de790-ae6e-4ecc-a275-ec0982f71d42.png)

instead of the description field increasing, the label container increasing
