### PR TITLE
fix: task run notification message should say scheduled

### DIFF
--- a/src/shared/copy/notifications.ts
+++ b/src/shared/copy/notifications.ts
@@ -793,7 +793,7 @@ export const taskGetFailed = (error: string): Notification => ({
 export const taskRetrySuccess = (id: string): Notification => ({
   ...defaultSuccessNotification,
   duration: FIVE_SECONDS,
-  message: `Task run ${id} was succesful`,
+  message: `Task run ${id} successfully scheduled`,
 })
 
 export const taskRetryFailed = (error: string): Notification => ({


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/2949

Minor message wording fix for the tasks run page notification.
