### PR TITLE
fix: show errors for panels

### DIFF
--- a/src/flows/pipes/Table/view.tsx
+++ b/src/flows/pipes/Table/view.tsx
@@ -81,6 +81,7 @@ const Table: FC<PipeProp> = ({Context}) => {
               className="panel-resizer--vis-toggle"
             />
           </div>
+          <div className="panel-resizer--error">{results.error}</div>
         </div>
       </Context>
     )

--- a/src/flows/pipes/Visualization/view.tsx
+++ b/src/flows/pipes/Visualization/view.tsx
@@ -128,6 +128,7 @@ const Visualization: FC<PipeProp> = ({Context}) => {
               className="panel-resizer--vis-toggle"
             />
           </div>
+          <div className="panel-resizer--error">{results.error}</div>
         </div>
       </Context>
     )


### PR DESCRIPTION
Closes #2933

threw out a bit too much when removing the aggWindow errors