### PR TITLE
chore: removed Error optional property from allResources

### DIFF
--- a/src/authorizations/actions/creators.ts
+++ b/src/authorizations/actions/creators.ts
@@ -1,7 +1,6 @@
 // Types
 import {RemoteDataState, AuthEntities, Authorization} from 'src/types'
 import {NormalizedSchema} from 'normalizr'
-import {Error} from 'src/client'
 
 export const SET_AUTH = 'SET_AUTH'
 export const ADD_AUTH = 'ADD_AUTH'

--- a/src/authorizations/actions/creators.ts
+++ b/src/authorizations/actions/creators.ts
@@ -60,7 +60,7 @@ export const setCurrentAuthorization = (
     item,
   } as const)
 
-export const setAllResources = (list?: string[] | Error) =>
+export const setAllResources = (list?: string[]) =>
   ({
     type: SET_ALL_RESOURCES,
     list,

--- a/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
@@ -1,5 +1,5 @@
 import React, {FC, useState, useContext, useEffect} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import 'src/authorizations/components/redesigned/customApiTokenOverlay.scss'
 
 // Actions
@@ -21,7 +21,6 @@ import {
   ButtonShape,
   InputLabel,
   JustifyContent,
-  RemoteDataState,
   ComponentStatus,
 } from '@influxdata/clockface'
 import ResourceAccordion from 'src/authorizations/components/redesigned/ResourceAccordion'
@@ -33,6 +32,7 @@ import {OverlayContext} from 'src/overlays/components/OverlayController'
 // Types
 import {AppState, ResourceType, Authorization} from 'src/types'
 import {Bucket, Telegraf} from 'src/client'
+import {RouteComponentProps} from 'react-router-dom'
 
 // Seletors
 import {getOrg} from 'src/organizations/selectors'
@@ -48,31 +48,16 @@ import {
 
 import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
 
+
 interface OwnProps {
   onClose: () => void
 }
 
-interface StateProps {
-  allResources: string[]
-  telegrafPermissions: any
-  bucketPermissions: any
-  remoteDataState: RemoteDataState
-  orgID: string
-  orgName: string
-}
-
-interface DispatchProps {
-  getBuckets: () => void
-  getTelegrafs: () => void
-  createAuthorization: (auth) => void
-  showOverlay: (arg1: string, arg2: any, any) => {}
-}
-
-type Props = OwnProps & StateProps & DispatchProps
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps & OwnProps & RouteComponentProps<{orgID: string}>
 
 const CustomApiTokenOverlay: FC<Props> = props => {
   const {onClose} = useContext(OverlayContext)
-
   const [description, setDescription] = useState('')
   const [permissions, setPermissions] = useState({})
   const [searchTerm, setSearchTerm] = useState('')
@@ -87,7 +72,7 @@ const CustomApiTokenOverlay: FC<Props> = props => {
     const perms = {
       otherResources: {read: false, write: false},
     }
-
+    
     props.allResources.forEach(resource => {
       if (resource === 'telegrafs') {
         perms[resource] = props.telegrafPermissions
@@ -99,7 +84,7 @@ const CustomApiTokenOverlay: FC<Props> = props => {
     })
     setPermissions(perms)
   }, [props.telegrafPermissions, props.bucketPermissions])
-
+  
   const handleDismiss = () => {
     props.onClose()
   }
@@ -389,4 +374,5 @@ const mdtp = {
   dismissOverlay,
 }
 
-export default connect(mstp, mdtp)(CustomApiTokenOverlay)
+const connector = connect(mstp, mdtp)
+export default connector(CustomApiTokenOverlay)

--- a/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
@@ -1,5 +1,5 @@
 import React, {FC, useState, useContext, useEffect} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
+import {connect} from 'react-redux'
 import 'src/authorizations/components/redesigned/customApiTokenOverlay.scss'
 
 // Actions
@@ -20,6 +20,7 @@ import {
   ComponentColor,
   ButtonShape,
   InputLabel,
+  RemoteDataState,
   JustifyContent,
   ComponentStatus,
 } from '@influxdata/clockface'
@@ -32,7 +33,6 @@ import {OverlayContext} from 'src/overlays/components/OverlayController'
 // Types
 import {AppState, ResourceType, Authorization} from 'src/types'
 import {Bucket, Telegraf} from 'src/client'
-import {RouteComponentProps} from 'react-router-dom'
 
 // Seletors
 import {getOrg} from 'src/organizations/selectors'
@@ -51,9 +51,22 @@ import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
 interface OwnProps {
   onClose: () => void
 }
+interface StateProps {
+  allResources: string[]
+  telegrafPermissions: any
+  bucketPermissions: any
+  remoteDataState: RemoteDataState
+  orgID: string
+  orgName: string
+}
+interface DispatchProps {
+  getBuckets: () => void
+  getTelegrafs: () => void
+  createAuthorization: (auth) => void
+  showOverlay: (arg1: string, arg2: any, any) => {}
+}
 
-type ReduxProps = ConnectedProps<typeof connector>
-type Props = ReduxProps & OwnProps & RouteComponentProps<{orgID: string}>
+type Props = StateProps & OwnProps & DispatchProps
 
 const CustomApiTokenOverlay: FC<Props> = props => {
   const {onClose} = useContext(OverlayContext)

--- a/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
@@ -48,7 +48,6 @@ import {
 
 import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
 
-
 interface OwnProps {
   onClose: () => void
 }
@@ -72,7 +71,7 @@ const CustomApiTokenOverlay: FC<Props> = props => {
     const perms = {
       otherResources: {read: false, write: false},
     }
-    
+
     props.allResources.forEach(resource => {
       if (resource === 'telegrafs') {
         perms[resource] = props.telegrafPermissions
@@ -84,7 +83,7 @@ const CustomApiTokenOverlay: FC<Props> = props => {
     })
     setPermissions(perms)
   }, [props.telegrafPermissions, props.bucketPermissions])
-  
+
   const handleDismiss = () => {
     props.onClose()
   }

--- a/src/types/resources.ts
+++ b/src/types/resources.ts
@@ -61,7 +61,7 @@ export interface TelegrafsState extends NormalizedState<Telegraf> {
 
 export interface AuthState extends NormalizedState<Authorization> {
   currentAuth: {status: RemoteDataState; item: Authorization}
-  allResources: string[] | Error
+  allResources: string[] 
 }
 
 export interface RulesState extends NormalizedState<NotificationRule> {

--- a/src/types/resources.ts
+++ b/src/types/resources.ts
@@ -1,4 +1,3 @@
-import {Error} from 'src/client'
 import {
   Authorization,
   Bucket,

--- a/src/types/resources.ts
+++ b/src/types/resources.ts
@@ -61,7 +61,7 @@ export interface TelegrafsState extends NormalizedState<Telegraf> {
 
 export interface AuthState extends NormalizedState<Authorization> {
   currentAuth: {status: RemoteDataState; item: Authorization}
-  allResources: string[] 
+  allResources: string[]
 }
 
 export interface RulesState extends NormalizedState<NotificationRule> {


### PR DESCRIPTION
Closes #2683 

The `allResources` in redux state for tokens has a type of String[] | Error. During investigation, it became apparent  having `Error` as an optional property for allResources was redundant since the `getAllResources` function inside thunks already contains code that takes care of >200 status. 
