### PR TITLE
fix: update wording and mark required in Telegraf configuration modal

### DIFF
--- a/src/dataLoaders/components/collectorsWizard/select/TelegrafUIRefreshCollectorsStep.tsx
+++ b/src/dataLoaders/components/collectorsWizard/select/TelegrafUIRefreshCollectorsStep.tsx
@@ -62,9 +62,16 @@ export class SelectCollectorsStep extends PureComponent<Props, State> {
                 Where do you want to collect data from?
               </h3>
               <h5 className="wizard-step--sub-title">
-                Telegraf is an open-source data collection agent for collecting
-                and reporting metrics. Simply choose one of the plugin libraries
-                to start writing data into influxDB. LINK.
+                <a
+                  href="https://www.influxdata.com/time-series-platform/telegraf/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Telegraf
+                </a>{' '}
+                is an open-source data collection agent for collecting and
+                reporting metrics. Simply choose a bucket and one of the plugin
+                libraries to start writing data into InfluxDB.
               </h5>
             </Grid.Column>
           </Grid.Row>

--- a/src/dataLoaders/components/collectorsWizard/select/TelegrafUIRefreshCollectorsStep.tsx
+++ b/src/dataLoaders/components/collectorsWizard/select/TelegrafUIRefreshCollectorsStep.tsx
@@ -71,7 +71,14 @@ export class SelectCollectorsStep extends PureComponent<Props, State> {
                 </a>{' '}
                 is an open-source data collection agent for collecting and
                 reporting metrics. Simply choose a bucket and one of the plugin
-                libraries to start writing data into InfluxDB.
+                libraries to start writing data into InfluxDB. View Telegraf{' '}
+                <a
+                  href="https://docs.influxdata.com/telegraf/latest/plugins/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  plugin documentation.
+                </a>
               </h5>
             </Grid.Column>
           </Grid.Row>

--- a/src/dataLoaders/components/collectorsWizard/select/TelegrafUIRefreshSelector.tsx
+++ b/src/dataLoaders/components/collectorsWizard/select/TelegrafUIRefreshSelector.tsx
@@ -142,7 +142,7 @@ class TelegrafUIRefreshSelector extends PureComponent<Props, State> {
           <>
             <Grid.Row>
               <Grid.Column widthSM={Columns.Six}>
-                <FormElement label="Bucket">
+                <FormElement label="Bucket" required={true}>
                   <BucketDropdown
                     selectedBucketID={selectedBucket?.id}
                     buckets={sortedBuckets}


### PR DESCRIPTION
- Closes #3029 

- Bucket dropdown is now marked as required
- Updates wording for "Simply choose **a bucket and** one of..."
- The word "Telegraf" is now a link

<img width="1004" alt="Screen Shot 2021-10-28 at 4 47 01 PM" src="https://user-images.githubusercontent.com/10736577/139353300-e8c0bd0e-f363-482e-bc5c-fd957a02fd25.png">

