### PR TITLE
chore: handle 503 from quartz billing

### DIFF
--- a/src/billing/components/BillingContactDisplay.tsx
+++ b/src/billing/components/BillingContactDisplay.tsx
@@ -13,29 +13,32 @@ const BillingContactDisplay: FC = () => {
     <Panel.Body size={ComponentSize.Large} testID="billing-contact">
       <Grid>
         <Grid.Row>
-          <BillingContactItem header="First Name" value={contact.firstName} />
-          <BillingContactItem header="Last Name" value={contact.lastName} />
+          <BillingContactItem header="First Name" value={contact?.firstName} />
+          <BillingContactItem header="Last Name" value={contact?.lastName} />
         </Grid.Row>
         <Grid.Row>
           <BillingContactItem
             header="Company Name"
-            value={contact.companyName}
+            value={contact?.companyName}
           />
-          <BillingContactItem header="Country" value={contact.country} />
+          <BillingContactItem header="Country" value={contact?.country} />
         </Grid.Row>
         <Grid.Row>
           <BillingContactItem
             header="Physical Address"
-            value={`${contact.street1}, ${contact.street2}`}
+            value={`${contact?.street1}, ${contact?.street2}`}
           />
         </Grid.Row>
         <Grid.Row>
-          <BillingContactItem header="City" value={contact.city} />
+          <BillingContactItem header="City" value={contact?.city} />
           <BillingContactItem
             header="State (Subdivision)"
-            value={contact.subdivision}
+            value={contact?.subdivision}
           />
-          <BillingContactItem header="Postal Code" value={contact.postalCode} />
+          <BillingContactItem
+            header="Postal Code"
+            value={contact?.postalCode}
+          />
         </Grid.Row>
       </Grid>
     </Panel.Body>

--- a/src/billing/components/PayAsYouGo/PlanTypePanel.tsx
+++ b/src/billing/components/PayAsYouGo/PlanTypePanel.tsx
@@ -32,7 +32,7 @@ const PlanTypePanel: FC = () => {
             size={ComponentSize.ExtraSmall}
             testID="payg-plan--region-body"
           >
-            {billingInfo.region}
+            {billingInfo?.region}
           </Panel.Body>
         </Panel>
         <Panel
@@ -50,7 +50,7 @@ const PlanTypePanel: FC = () => {
             testID="payg-plan--balance-body"
           >
             <span className="money">
-              {parseFloat(`${billingInfo.balance}`).toFixed(2)}
+              {parseFloat(`${billingInfo?.balance}`).toFixed(2)}
             </span>
           </Panel.Body>
         </Panel>
@@ -68,7 +68,7 @@ const PlanTypePanel: FC = () => {
             size={ComponentSize.ExtraSmall}
             testID="payg-plan--updated-body"
           >
-            {new Date(billingInfo.balanceUpdatedAt).toLocaleString('default', {
+            {new Date(billingInfo?.balanceUpdatedAt).toLocaleString('default', {
               month: 'numeric',
               day: 'numeric',
               year: 'numeric',

--- a/src/billing/components/PaymentInfo/PaymentDisplay.tsx
+++ b/src/billing/components/PaymentInfo/PaymentDisplay.tsx
@@ -9,10 +9,10 @@ const PaymentDisplay: FC = () => {
   return (
     <div data-testid="payment-display">
       <p>
-        Your current payment card is {paymentMethod.cardType}{' '}
-        <strong>{paymentMethod.cardNumber}</strong> &mdash; Expiring{' '}
+        Your current payment card is {paymentMethod?.cardType}{' '}
+        <strong>{paymentMethod?.cardNumber}</strong> &mdash; Expiring{' '}
         <strong>
-          {paymentMethod.expirationMonth}/{paymentMethod.expirationYear}
+          {paymentMethod?.expirationMonth}/{paymentMethod?.expirationYear}
         </strong>
       </p>
     </div>

--- a/src/billing/components/PaymentInfo/PaymentPanel.tsx
+++ b/src/billing/components/PaymentInfo/PaymentPanel.tsx
@@ -14,7 +14,6 @@ const PaymentPanel: FC = () => {
     billingInfo: {paymentMethod},
     handleUpdatePaymentMethod,
   } = useContext(BillingContext)
-
   const [isEditing, setIsEditing] = useState(paymentMethod === null)
 
   const hasExistingPayment = paymentMethod !== null

--- a/src/billing/context/billing.tsx
+++ b/src/billing/context/billing.tsx
@@ -74,8 +74,22 @@ export interface BillingContextType {
   zuoraParamsStatus: RemoteDataState
 }
 
+const DEFAULT_BILLING_INFO = {
+  balance: 0,
+  balanceUpdatedAt: '',
+  contact: {
+    companyName: '',
+    email: '',
+    firstName: '',
+    lastName: '',
+    country: '',
+    city: '',
+    postalCode: '',
+  },
+} as BillingInfo
+
 export const DEFAULT_CONTEXT: BillingContextType = {
-  billingInfo: null,
+  billingInfo: DEFAULT_BILLING_INFO,
   billingInfoStatus: RemoteDataState.NotStarted,
   billingSettings: null,
   billingSettingsStatus: RemoteDataState.NotStarted,
@@ -130,7 +144,9 @@ export const BillingProvider: FC<Props> = React.memo(({children}) => {
     RemoteDataState.NotStarted
   )
 
-  const [billingInfo, setBillingInfo] = useState(null)
+  const [billingInfo, setBillingInfo] = useState<BillingInfo>(
+    DEFAULT_CONTEXT.billingInfo
+  )
   const [billingInfoStatus, setBillingInfoStatus] = useState(
     RemoteDataState.NotStarted
   )


### PR DESCRIPTION
When the zuora outage flag is turned on in quartz, it starts sending `503` which UI isn't able to handle and crashes on billing page. See image below:
![image](https://user-images.githubusercontent.com/1637395/139505279-fe0a7792-4c1d-4c0b-92dc-afec31bbdc4d.png)

___________________________

So, adding a default empty `BillingInfo` and now will be accessing nullable fields.

If the quartz outage flag isn't turned on and there's a problem with the billing route, this is what this page will look like:
![image](https://user-images.githubusercontent.com/1637395/139505818-8673a2f6-1340-44e8-994e-7126b8388298.png)

___________________________

When we set `influx.set('quartzZuoraDisabled', true)`, we should be seeing this:
![image](https://user-images.githubusercontent.com/1637395/139505887-9f5f9b62-5c6f-43be-8e48-2d5d1c1dc23b.png)

______________________________

Checkout Page looks normal when the flag isn't turned on and looks like this when the flag is turned on:
![image](https://user-images.githubusercontent.com/1637395/139506244-128a15de-15bc-4c1b-b708-afb80787354a.png)
