### PR TITLE
fix(notebooks): accessID length, share btn color, query builder dropdown

### DIFF
--- a/src/flows/components/ReadOnly.tsx
+++ b/src/flows/components/ReadOnly.tsx
@@ -64,7 +64,7 @@ const RunPipeResults: FC = () => {
 const ReadOnly: FC = ({children}) => {
   const {flow} = useContext(FlowContext)
   const params = useParams<{accessID: string}>()
-  if (!params.accessID || params.accessID.length !== 16 || !flow) {
+  if (!params.accessID || !flow) {
     return (
       <div style={{width: '100%'}}>
         <NotFound />

--- a/src/flows/components/header/index.tsx
+++ b/src/flows/components/header/index.tsx
@@ -205,7 +205,7 @@ const FlowHeader: FC = () => {
                   icon={IconFont.Share}
                   onClick={showShare}
                   color={
-                    !share ? ComponentColor.Primary : ComponentColor.Secondary
+                    !!share ? ComponentColor.Primary : ComponentColor.Secondary
                   }
                   titleText="Share Notebook"
                 />

--- a/src/flows/pipes/QueryBuilder/readOnly.tsx
+++ b/src/flows/pipes/QueryBuilder/readOnly.tsx
@@ -37,7 +37,7 @@ const QueryBuilder: FC<PipeProp> = ({Context}) => {
                         icon={IconFont.BucketSolid}
                         status={ComponentStatus.Disabled}
                       >
-                        {data.buckets[0] ?? 'No Bucket Selected'}
+                        {data.buckets[0].name ?? 'No Bucket Selected'}
                       </Dropdown.Button>
                     )}
                     menu={onCollapse => (


### PR DESCRIPTION
Fixes some tiny notebooks bugs.

- we're going to change the structure of the accessID, so the UI can't be enforcing the length right now. Might re-add this at a later date
- I got the share button colors backwards in https://github.com/influxdata/ui/pull/3052 🤦 
- fixes a bug where the readonly query builder panel would crash a shared notebook because we weren't accessing the `.name` prop