### PR TITLE
fix: fix background color for the checks panel

### DIFF
--- a/src/alerting/components/builder/ThresholdStatement.tsx
+++ b/src/alerting/components/builder/ThresholdStatement.tsx
@@ -60,7 +60,7 @@ const ThresholdStatement: FC<Props> = ({
   }
 
   return (
-    <Panel backgroundColor={InfluxColors.Grey15} testID="panel">
+    <Panel backgroundColor={InfluxColors.Grey5} testID="panel">
       <DismissButton
         color={ComponentColor.Default}
         onClick={removeLevel}

--- a/src/alerting/components/builder/ThresholdStatement.tsx
+++ b/src/alerting/components/builder/ThresholdStatement.tsx
@@ -60,7 +60,11 @@ const ThresholdStatement: FC<Props> = ({
   }
 
   return (
-    <Panel backgroundColor={InfluxColors.Grey5} testID="panel">
+    <Panel
+      backgroundColor={InfluxColors.Grey15}
+      style={{backgroundColor: 'rgba(51,51,70, .3)'}}
+      testID="panel"
+    >
       <DismissButton
         color={ComponentColor.Default}
         onClick={removeLevel}

--- a/src/checks/components/CheckTagRow.tsx
+++ b/src/checks/components/CheckTagRow.tsx
@@ -59,7 +59,7 @@ const CheckTagRow: FC<Props> = ({
           </FlexBox.Child>
           <FlexBox.Child grow={0} basis={20}>
             <TextBlock
-              backgroundColor={'#00000000'}
+              backgroundColor="#00000000"
               textColor={InfluxColors.Pool}
               text="="
             />

--- a/src/checks/components/CheckTagRow.tsx
+++ b/src/checks/components/CheckTagRow.tsx
@@ -3,15 +3,15 @@ import React, {FC} from 'react'
 
 // Components
 import {
+  ComponentColor,
+  ComponentSize,
+  DismissButton,
+  FlexBox,
+  FlexDirection,
+  InfluxColors,
   Input,
   Panel,
-  DismissButton,
   TextBlock,
-  FlexBox,
-  ComponentSize,
-  FlexDirection,
-  ComponentColor,
-  InfluxColors,
 } from '@influxdata/clockface'
 
 // Types
@@ -38,7 +38,7 @@ const CheckTagRow: FC<Props> = ({
     <Panel
       testID="tag-rule"
       className="alert-builder--tag-row"
-      backgroundColor={InfluxColors.Grey25}
+      style={{backgroundColor: 'rgba(51,51,70, .3)'}}
     >
       <DismissButton
         onClick={() => {
@@ -58,7 +58,11 @@ const CheckTagRow: FC<Props> = ({
             />
           </FlexBox.Child>
           <FlexBox.Child grow={0} basis={20}>
-            <TextBlock text="=" />
+            <TextBlock
+              backgroundColor={'#00000000'}
+              textColor={InfluxColors.Pool}
+              text="="
+            />
           </FlexBox.Child>
           <FlexBox.Child grow={1}>
             <Input


### PR DESCRIPTION
Closes #3024

Fix for the background color. screenshot: 

<img width="532" alt="Capture d’écran, le 2021-11-02 à 12 11 38 PM" src="https://user-images.githubusercontent.com/18511823/139930431-a65202c6-5014-485e-848e-204ac9bb661d.png">

