### PR TITLE
feat: explicit buckets: add csv for uploading and downloading

### DIFF
--- a/cypress/e2e/cloud/buckets.test.ts
+++ b/cypress/e2e/cloud/buckets.test.ts
@@ -174,7 +174,7 @@ describe('Explicit Buckets', () => {
       })
   })
 
-  it('should be able to create an explicit bucket and add schema file during editing', function() {
+  it('should be able to create an explicit bucket and add json schema file during editing', function() {
     cy.getByTestID('Create Bucket').click()
     cy.getByTestID('bucket-form-name').type('explicit_bucket')
     cy.getByTestID('accordion-header').click()
@@ -234,6 +234,79 @@ describe('Explicit Buckets', () => {
             expect(fileContent[1].name).to.be.equal('fsWrite')
             expect(fileContent[1].type).to.be.equal('field')
             expect(fileContent[1].dataType).to.be.equal('float')
+          })
+      })
+  })
+
+  it('should be able to create an explicit bucket and add csv schema file during editing', function() {
+    cy.getByTestID('Create Bucket').click()
+    cy.getByTestID('bucket-form-name').type('explicit_bucket')
+    cy.getByTestID('accordion-header').click()
+    cy.getByTestID('explicit-bucket-schema-choice-ID').click()
+
+    cy.getByTestID('bucket-form-submit').click()
+
+    cy.getByTestID(`bucket-card explicit_bucket`)
+      .should('exist')
+      .within(() => {
+        cy.getByTestID('bucket-settings').click()
+      })
+    cy.getByTestID('accordion-header').click()
+
+    cy.getByTestID('measurement-schema-add-file-button').click()
+    cy.getByTestID('input-field').type('first schema file')
+
+    const schemaFile = 'valid.csv'
+    const type = 'text/csv'
+
+      const origFileContents =  `name,type,dataType
+time,timestamp,
+host,tag,
+service,tag,
+fsRead,field,float`
+
+    const testFile = new File(
+      [
+       origFileContents
+      ],
+      schemaFile,
+      {type}
+    )
+
+    const event = {dataTransfer: {files: [testFile]}, force: true}
+    cy.getByTestID('dndContainer')
+      .trigger('dragover', event)
+      .trigger('drop', event)
+
+    cy.getByTestID('bucket-form-submit').click()
+
+    cy.getByTestID(`bucket-card explicit_bucket`)
+      .should('exist')
+      .within(() => {
+        cy.getByTestID('bucket-settings').click()
+      })
+    cy.getByTestID('accordion-header').click()
+
+    cy.getByTestID('advancedSection')
+      .should('exist')
+      .within(() => {
+        cy.getByTestID('csv-download-flavor-choice').click()
+
+        cy.getByTestID('measurement-schema-readOnly-panel-0')
+          .should('exist')
+          .within(() => {
+            cy.getByTestID('measurement-schema-name-0')
+              .contains('first schem...')
+              .should('exist')
+
+            cy.getByTestID('measurement-schema-download-button').click()
+
+            cy.readFile(`cypress/downloads/first_schema_file.csv`)
+              .should('exist')
+              .then(fileContent => {
+                console.log('got file contents...', fileContent)
+                  expect(fileContent).to.equal(origFileContents)
+              })
           })
       })
   })

--- a/cypress/e2e/cloud/buckets.test.ts
+++ b/cypress/e2e/cloud/buckets.test.ts
@@ -174,75 +174,68 @@ describe('Explicit Buckets', () => {
       })
   })
 
-  it.only('should be able to create an explicit bucket and add schema file during editing', function() {
+  it('should be able to create an explicit bucket and add schema file during editing', function() {
     cy.getByTestID('Create Bucket').click()
-    cy.getByTestID('overlay--container').within(() => {
-      cy.getByTestID('bucket-form-name').type('explicit_bucket')
-      cy.getByTestID('accordion-header').click()
-      cy.getByTestID('explicit-bucket-schema-choice-ID').click()
+    cy.getByTestID('bucket-form-name').type('explicit_bucket')
+    cy.getByTestID('accordion-header').click()
+    cy.getByTestID('explicit-bucket-schema-choice-ID').click()
 
-      cy.getByTestID('bucket-form-submit').click()
-    })
+    cy.getByTestID('bucket-form-submit').click()
+
     cy.getByTestID(`bucket-card explicit_bucket`)
       .should('exist')
       .within(() => {
         cy.getByTestID('bucket-settings').click()
       })
+    cy.getByTestID('accordion-header').click()
 
-    cy.getByTestID('overlay--container').within(() => {
-      cy.getByTestID('accordion-header').click()
+    cy.getByTestID('measurement-schema-add-file-button').click()
+    cy.getByTestID('input-field').type('first schema file')
 
-      cy.getByTestID('measurement-schema-add-file-button').click()
-      cy.getByTestID('input-field').type('first schema file')
-
-      const schemaFile = 'valid.json'
-      const type = 'application/json'
-      const testFile = new File(
-        [
-          `[{"name":"time","type":"timestamp"},
+    const schemaFile = 'valid.json'
+    const type = 'application/json'
+    const testFile = new File(
+      [
+        `[{"name":"time","type":"timestamp"},
         {"name":"fsWrite","type":"field","dataType":"float"} ]`,
-        ],
-        schemaFile,
-        {type}
-      )
+      ],
+      schemaFile,
+      {type}
+    )
 
-      const event = {dataTransfer: {files: [testFile]}, force: true}
-      cy.getByTestID('dndContainer')
-        .trigger('dragover', event)
-        .trigger('drop', event)
+    const event = {dataTransfer: {files: [testFile]}, force: true}
+    cy.getByTestID('dndContainer')
+      .trigger('dragover', event)
+      .trigger('drop', event)
 
-      cy.getByTestID('bucket-form-submit').click()
-    })
+    cy.getByTestID('bucket-form-submit').click()
 
     cy.getByTestID(`bucket-card explicit_bucket`)
       .should('exist')
       .within(() => {
         cy.getByTestID('bucket-settings').click()
       })
+    cy.getByTestID('accordion-header').click()
 
-    cy.getByTestID('overlay--container').within(() => {
-      cy.getByTestID('accordion-header').click()
+    cy.getByTestID('measurement-schema-readOnly-panel-0')
+      .should('exist')
+      .within(() => {
+        cy.getByTestID('measurement-schema-name-0')
+          .contains('first schem...')
+          .should('exist')
 
-      cy.getByTestID('measurement-schema-readOnly-panel-0')
-        .should('exist')
-        .within(() => {
-          cy.getByTestID('measurement-schema-name-0')
-            .contains('first schem...')
-            .should('exist')
+        cy.getByTestID('measurement-schema-download-button').click()
+        cy.readFile(`cypress/downloads/first_schema_file.json`)
+          .should('exist')
+          .then(fileContent => {
+            expect(fileContent[0].name).to.be.equal('time')
+            expect(fileContent[0].type).to.be.equal('timestamp')
 
-          cy.getByTestID('measurement-schema-download-button').click()
-          cy.readFile(`cypress/downloads/first_schema_file.json`)
-            .should('exist')
-            .then(fileContent => {
-              expect(fileContent[0].name).to.be.equal('time')
-              expect(fileContent[0].type).to.be.equal('timestamp')
-
-              expect(fileContent[1].name).to.be.equal('fsWrite')
-              expect(fileContent[1].type).to.be.equal('field')
-              expect(fileContent[1].dataType).to.be.equal('float')
-            })
-        })
-    })
+            expect(fileContent[1].name).to.be.equal('fsWrite')
+            expect(fileContent[1].type).to.be.equal('field')
+            expect(fileContent[1].dataType).to.be.equal('float')
+          })
+      })
   })
 
   it('should be able to create an explicit bucket and update the existing schema file during editing', function() {

--- a/cypress/e2e/cloud/buckets.test.ts
+++ b/cypress/e2e/cloud/buckets.test.ts
@@ -15,6 +15,83 @@ const setupData = (cy: Cypress.Chainable, enableMeasurementSchema = false) =>
       )
     )
   )
+
+const testSchemaFiles = (
+  cy: Cypress.Chainable,
+  isCsv: boolean,
+  origFileContents: string,
+  checkContents: (cy: Cypress.Chainable) => void
+) => {
+  cy.getByTestID('Create Bucket').click()
+  cy.getByTestID('bucket-form-name').type('explicit_bucket')
+  cy.getByTestID('accordion-header').click()
+  cy.getByTestID('explicit-bucket-schema-choice-ID').click()
+
+  cy.getByTestID('bucket-form-submit').click()
+
+  cy.getByTestID(`bucket-card explicit_bucket`)
+    .should('exist')
+    .within(() => {
+      cy.getByTestID('bucket-settings').click()
+    })
+  cy.getByTestID('accordion-header').click()
+
+  cy.getByTestID('measurement-schema-add-file-button').click()
+  cy.getByTestID('input-field').type('first schema file')
+
+  let schemaFile = 'valid.json'
+  let type = 'application/json'
+
+  if (isCsv) {
+    schemaFile = 'valid.csv'
+    type = 'text/csv'
+  }
+
+  const testFile = new File([origFileContents], schemaFile, {type})
+
+  const event = {dataTransfer: {files: [testFile]}, force: true}
+  cy.getByTestID('dndContainer')
+    .trigger('dragover', event)
+    .trigger('drop', event)
+
+  cy.getByTestID('bucket-form-submit').click()
+
+  cy.getByTestID(`bucket-card explicit_bucket`)
+    .should('exist')
+    .within(() => {
+      cy.getByTestID('bucket-settings').click()
+    })
+  cy.getByTestID('accordion-header').click()
+
+  cy.getByTestID('advancedSection')
+    .should('exist')
+    .within(() => {
+      if (isCsv) {
+        cy.getByTestID('csv-download-flavor-choice').click()
+      } else {
+        //todo:  check that json is selected
+      }
+
+      cy.getByTestID('measurement-schema-readOnly-panel-0')
+        .should('exist')
+        .within(() => {
+          cy.getByTestID('measurement-schema-name-0')
+            .contains('first schem...')
+            .should('exist')
+
+          cy.getByTestID('measurement-schema-download-button').click()
+
+          checkContents(cy)
+          // cy.readFile(`cypress/downloads/first_schema_file.csv`)
+          //     .should('exist')
+          //     .then(fileContent => {
+          //         console.log('got file contents...', fileContent)
+          //         expect(fileContent).to.equal(origFileContents)
+          //     })
+        })
+    })
+}
+
 describe('Explicit Buckets', () => {
   beforeEach(() => {
     setupData(cy, true)
@@ -25,7 +102,6 @@ describe('Explicit Buckets', () => {
       failOnNonZeroExit: false,
     })
   })
-
   it('can create a bucket with an explicit schema', () => {
     cy.getByTestID('Create Bucket').click()
     cy.getByTestID('overlay--container').within(() => {
@@ -175,140 +251,39 @@ describe('Explicit Buckets', () => {
   })
 
   it('should be able to create an explicit bucket and add json schema file during editing', function() {
-    cy.getByTestID('Create Bucket').click()
-    cy.getByTestID('bucket-form-name').type('explicit_bucket')
-    cy.getByTestID('accordion-header').click()
-    cy.getByTestID('explicit-bucket-schema-choice-ID').click()
+    const origFileContents = `[{"name":"time","type":"timestamp"},
+        {"name":"fsWrite","type":"field","dataType":"float"} ]`
 
-    cy.getByTestID('bucket-form-submit').click()
+    const checkContents = (cy: Cypress.Chainable) => {
+      cy.readFile(`cypress/downloads/first_schema_file.json`)
+        .should('exist')
+        .then(fileContent => {
+          expect(fileContent[0].name).to.be.equal('time')
+          expect(fileContent[0].type).to.be.equal('timestamp')
 
-    cy.getByTestID(`bucket-card explicit_bucket`)
-      .should('exist')
-      .within(() => {
-        cy.getByTestID('bucket-settings').click()
-      })
-    cy.getByTestID('accordion-header').click()
-
-    cy.getByTestID('measurement-schema-add-file-button').click()
-    cy.getByTestID('input-field').type('first schema file')
-
-    const schemaFile = 'valid.json'
-    const type = 'application/json'
-    const testFile = new File(
-      [
-        `[{"name":"time","type":"timestamp"},
-        {"name":"fsWrite","type":"field","dataType":"float"} ]`,
-      ],
-      schemaFile,
-      {type}
-    )
-
-    const event = {dataTransfer: {files: [testFile]}, force: true}
-    cy.getByTestID('dndContainer')
-      .trigger('dragover', event)
-      .trigger('drop', event)
-
-    cy.getByTestID('bucket-form-submit').click()
-
-    cy.getByTestID(`bucket-card explicit_bucket`)
-      .should('exist')
-      .within(() => {
-        cy.getByTestID('bucket-settings').click()
-      })
-    cy.getByTestID('accordion-header').click()
-
-    cy.getByTestID('measurement-schema-readOnly-panel-0')
-      .should('exist')
-      .within(() => {
-        cy.getByTestID('measurement-schema-name-0')
-          .contains('first schem...')
-          .should('exist')
-
-        cy.getByTestID('measurement-schema-download-button').click()
-        cy.readFile(`cypress/downloads/first_schema_file.json`)
-          .should('exist')
-          .then(fileContent => {
-            expect(fileContent[0].name).to.be.equal('time')
-            expect(fileContent[0].type).to.be.equal('timestamp')
-
-            expect(fileContent[1].name).to.be.equal('fsWrite')
-            expect(fileContent[1].type).to.be.equal('field')
-            expect(fileContent[1].dataType).to.be.equal('float')
-          })
-      })
+          expect(fileContent[1].name).to.be.equal('fsWrite')
+          expect(fileContent[1].type).to.be.equal('field')
+          expect(fileContent[1].dataType).to.be.equal('float')
+        })
+    }
+    testSchemaFiles(cy, false, origFileContents, checkContents)
   })
 
   it('should be able to create an explicit bucket and add csv schema file during editing', function() {
-    cy.getByTestID('Create Bucket').click()
-    cy.getByTestID('bucket-form-name').type('explicit_bucket')
-    cy.getByTestID('accordion-header').click()
-    cy.getByTestID('explicit-bucket-schema-choice-ID').click()
-
-    cy.getByTestID('bucket-form-submit').click()
-
-    cy.getByTestID(`bucket-card explicit_bucket`)
-      .should('exist')
-      .within(() => {
-        cy.getByTestID('bucket-settings').click()
-      })
-    cy.getByTestID('accordion-header').click()
-
-    cy.getByTestID('measurement-schema-add-file-button').click()
-    cy.getByTestID('input-field').type('first schema file')
-
-    const schemaFile = 'valid.csv'
-    const type = 'text/csv'
-
-      const origFileContents =  `name,type,dataType
+    const origFileContents = `name,type,dataType
 time,timestamp,
 host,tag,
 service,tag,
 fsRead,field,float`
 
-    const testFile = new File(
-      [
-       origFileContents
-      ],
-      schemaFile,
-      {type}
-    )
-
-    const event = {dataTransfer: {files: [testFile]}, force: true}
-    cy.getByTestID('dndContainer')
-      .trigger('dragover', event)
-      .trigger('drop', event)
-
-    cy.getByTestID('bucket-form-submit').click()
-
-    cy.getByTestID(`bucket-card explicit_bucket`)
-      .should('exist')
-      .within(() => {
-        cy.getByTestID('bucket-settings').click()
-      })
-    cy.getByTestID('accordion-header').click()
-
-    cy.getByTestID('advancedSection')
-      .should('exist')
-      .within(() => {
-        cy.getByTestID('csv-download-flavor-choice').click()
-
-        cy.getByTestID('measurement-schema-readOnly-panel-0')
-          .should('exist')
-          .within(() => {
-            cy.getByTestID('measurement-schema-name-0')
-              .contains('first schem...')
-              .should('exist')
-
-            cy.getByTestID('measurement-schema-download-button').click()
-
-            cy.readFile(`cypress/downloads/first_schema_file.csv`)
-              .should('exist')
-              .then(fileContent => {
-                console.log('got file contents...', fileContent)
-                  expect(fileContent).to.equal(origFileContents)
-              })
-          })
-      })
+    const checkContents = (cy: Cypress.Chainable) => {
+      cy.readFile(`cypress/downloads/first_schema_file.csv`)
+        .should('exist')
+        .then(fileContent => {
+          expect(fileContent).to.equal(origFileContents)
+        })
+    }
+    testSchemaFiles(cy, true, origFileContents, checkContents)
   })
 
   it('should be able to create an explicit bucket and update the existing schema file during editing', function() {

--- a/cypress/e2e/cloud/buckets.test.ts
+++ b/cypress/e2e/cloud/buckets.test.ts
@@ -68,8 +68,6 @@ const testSchemaFiles = (
     .within(() => {
       if (isCsv) {
         cy.getByTestID('csv-download-flavor-choice').click()
-      } else {
-        //todo:  check that json is selected
       }
 
       cy.getByTestID('measurement-schema-readOnly-panel-0')
@@ -80,14 +78,7 @@ const testSchemaFiles = (
             .should('exist')
 
           cy.getByTestID('measurement-schema-download-button').click()
-
           checkContents(cy)
-          // cy.readFile(`cypress/downloads/first_schema_file.csv`)
-          //     .should('exist')
-          //     .then(fileContent => {
-          //         console.log('got file contents...', fileContent)
-          //         expect(fileContent).to.equal(origFileContents)
-          //     })
         })
     })
 }

--- a/cypress/e2e/cloud/buckets.test.ts
+++ b/cypress/e2e/cloud/buckets.test.ts
@@ -63,7 +63,7 @@ const testSchemaFiles = (
     })
   cy.getByTestID('accordion-header').click()
 
-  cy.getByTestID('advancedSection')
+  cy.getByTestID('accordion--advanced-section')
     .should('exist')
     .within(() => {
       if (isCsv) {

--- a/cypress/e2e/cloud/buckets.test.ts
+++ b/cypress/e2e/cloud/buckets.test.ts
@@ -174,68 +174,75 @@ describe('Explicit Buckets', () => {
       })
   })
 
-  it('should be able to create an explicit bucket and add schema file during editing', function() {
+  it.only('should be able to create an explicit bucket and add schema file during editing', function() {
     cy.getByTestID('Create Bucket').click()
-    cy.getByTestID('bucket-form-name').type('explicit_bucket')
-    cy.getByTestID('accordion-header').click()
-    cy.getByTestID('explicit-bucket-schema-choice-ID').click()
+    cy.getByTestID('overlay--container').within(() => {
+      cy.getByTestID('bucket-form-name').type('explicit_bucket')
+      cy.getByTestID('accordion-header').click()
+      cy.getByTestID('explicit-bucket-schema-choice-ID').click()
 
-    cy.getByTestID('bucket-form-submit').click()
-
+      cy.getByTestID('bucket-form-submit').click()
+    })
     cy.getByTestID(`bucket-card explicit_bucket`)
       .should('exist')
       .within(() => {
         cy.getByTestID('bucket-settings').click()
       })
-    cy.getByTestID('accordion-header').click()
 
-    cy.getByTestID('measurement-schema-add-file-button').click()
-    cy.getByTestID('input-field').type('first schema file')
+    cy.getByTestID('overlay--container').within(() => {
+      cy.getByTestID('accordion-header').click()
 
-    const schemaFile = 'valid.json'
-    const type = 'application/json'
-    const testFile = new File(
-      [
-        `[{"name":"time","type":"timestamp"},
+      cy.getByTestID('measurement-schema-add-file-button').click()
+      cy.getByTestID('input-field').type('first schema file')
+
+      const schemaFile = 'valid.json'
+      const type = 'application/json'
+      const testFile = new File(
+        [
+          `[{"name":"time","type":"timestamp"},
         {"name":"fsWrite","type":"field","dataType":"float"} ]`,
-      ],
-      schemaFile,
-      {type}
-    )
+        ],
+        schemaFile,
+        {type}
+      )
 
-    const event = {dataTransfer: {files: [testFile]}, force: true}
-    cy.getByTestID('dndContainer')
-      .trigger('dragover', event)
-      .trigger('drop', event)
+      const event = {dataTransfer: {files: [testFile]}, force: true}
+      cy.getByTestID('dndContainer')
+        .trigger('dragover', event)
+        .trigger('drop', event)
 
-    cy.getByTestID('bucket-form-submit').click()
+      cy.getByTestID('bucket-form-submit').click()
+    })
 
     cy.getByTestID(`bucket-card explicit_bucket`)
       .should('exist')
       .within(() => {
         cy.getByTestID('bucket-settings').click()
       })
-    cy.getByTestID('accordion-header').click()
 
-    cy.getByTestID('measurement-schema-readOnly-panel-0')
-      .should('exist')
-      .within(() => {
-        cy.getByTestID('measurement-schema-name-0')
-          .contains('first schem...')
-          .should('exist')
+    cy.getByTestID('overlay--container').within(() => {
+      cy.getByTestID('accordion-header').click()
 
-        cy.getByTestID('measurement-schema-download-button').click()
-        cy.readFile(`cypress/downloads/first_schema_file.json`)
-          .should('exist')
-          .then(fileContent => {
-            expect(fileContent[0].name).to.be.equal('time')
-            expect(fileContent[0].type).to.be.equal('timestamp')
+      cy.getByTestID('measurement-schema-readOnly-panel-0')
+        .should('exist')
+        .within(() => {
+          cy.getByTestID('measurement-schema-name-0')
+            .contains('first schem...')
+            .should('exist')
 
-            expect(fileContent[1].name).to.be.equal('fsWrite')
-            expect(fileContent[1].type).to.be.equal('field')
-            expect(fileContent[1].dataType).to.be.equal('float')
-          })
-      })
+          cy.getByTestID('measurement-schema-download-button').click()
+          cy.readFile(`cypress/downloads/first_schema_file.json`)
+            .should('exist')
+            .then(fileContent => {
+              expect(fileContent[0].name).to.be.equal('time')
+              expect(fileContent[0].type).to.be.equal('timestamp')
+
+              expect(fileContent[1].name).to.be.equal('fsWrite')
+              expect(fileContent[1].type).to.be.equal('field')
+              expect(fileContent[1].dataType).to.be.equal('float')
+            })
+        })
+    })
   })
 
   it('should be able to create an explicit bucket and update the existing schema file during editing', function() {

--- a/cypress/e2e/shared/tokens.test.ts
+++ b/cypress/e2e/shared/tokens.test.ts
@@ -170,7 +170,9 @@ describe('tokens', () => {
     cy.get('.cf-resource-card')
       .first()
       .within(() => {
-        cy.getByTestID('context-delete-menu--button').click()
+        cy.getByTestID('context-delete-menu--button')
+          .should('exist')
+          .click()
       })
     cy.getByTestID('context-delete-menu--confirm-button').click()
 
@@ -192,7 +194,9 @@ describe('tokens', () => {
     cy.get('.cf-resource-card')
       .first()
       .within(() => {
-        cy.getByTestID('context-delete-menu--button').click()
+        cy.getByTestID('context-delete-menu--button')
+          .should('exist')
+          .click()
       })
     cy.getByTestID('context-delete-menu--confirm-button').click()
 

--- a/src/buckets/components/createBucketForm/BucketOverlayForm.tsx
+++ b/src/buckets/components/createBucketForm/BucketOverlayForm.tsx
@@ -164,7 +164,7 @@ export default class BucketOverlayForm extends PureComponent<Props> {
             <Accordion.AccordionHeader>
               <span>Advanced Configuration (Optional)</span>
             </Accordion.AccordionHeader>
-            <Accordion.AccordionBodyItem testID="advancedSection">
+            <Accordion.AccordionBodyItem testID="accordion--advanced-section">
               <div>{contents}</div>
             </Accordion.AccordionBodyItem>
           </Accordion>

--- a/src/buckets/components/createBucketForm/BucketOverlayForm.tsx
+++ b/src/buckets/components/createBucketForm/BucketOverlayForm.tsx
@@ -164,7 +164,7 @@ export default class BucketOverlayForm extends PureComponent<Props> {
             <Accordion.AccordionHeader>
               <span>Advanced Configuration (Optional)</span>
             </Accordion.AccordionHeader>
-            <Accordion.AccordionBodyItem>
+            <Accordion.AccordionBodyItem testID="advancedSection">
               <div>{contents}</div>
             </Accordion.AccordionBodyItem>
           </Accordion>

--- a/src/buckets/components/createBucketForm/MeasurementSchema.scss
+++ b/src/buckets/components/createBucketForm/MeasurementSchema.scss
@@ -32,8 +32,20 @@
     }
   }
 }
-
 .schema-section {
+  .option {
+    margin-bottom: 6px !important;
+  }
+}
+
+.measurement-section {
+  .option:nth-child(3) {
+    margin-left: 10px;
+  }
+}
+
+.schema-section,
+.measurement-section {
   &.measurement {
     margin-top: 15px;
   }
@@ -83,10 +95,6 @@
   .value-text {
     color: $cf-white;
     font-weight: 500;
-  }
-
-  .option {
-    margin-bottom: 6px !important;
   }
 
   .measurement-schema-panel-container {

--- a/src/buckets/components/createBucketForm/MeasurementSchemaSection.test.tsx
+++ b/src/buckets/components/createBucketForm/MeasurementSchemaSection.test.tsx
@@ -6,6 +6,7 @@ import {
   areNewSchemasValid,
   areSchemaUpdatesValid,
 } from './MeasurementSchemaUtils'
+import {toCsvString} from './MeasurementSchemaSection'
 
 const oneColumns = [
   {name: 'time', type: 'timestamp'},
@@ -262,5 +263,25 @@ describe('test schema  update validity function', () => {
   })
   it('should be valid, it is null', () => {
     doTest(null, true)
+  })
+})
+
+describe('test csv conversion function (object->csv file)', () => {
+  it('should create a valid csv file', () => {
+    const csvString = toCsvString(oneColumns)
+
+    const lines = csvString.split('\n')
+    expect(lines[0]).toEqual('name,type,dataType')
+    expect(lines[1]).toEqual('time,timestamp,')
+    expect(lines[2]).toEqual('host,tag,')
+    expect(lines[3]).toEqual('service,tag,')
+    expect(lines[4]).toEqual('fsRead,field,float')
+    expect(lines[5]).toEqual('fsWrite,field,float')
+    expect(lines[6]).toEqual('timeSignature,tag,')
+    expect(lines[7]).toEqual('composer,tag,')
+    expect(lines[8]).toEqual('instrument,field,string')
+    expect(lines[9]).toEqual('one,field,string')
+
+    expect(lines.length).toEqual(10)
   })
 })

--- a/src/buckets/components/createBucketForm/MeasurementSchemaSection.test.tsx
+++ b/src/buckets/components/createBucketForm/MeasurementSchemaSection.test.tsx
@@ -322,4 +322,18 @@ describe('test csv to array function (parsing)', () => {
     expect(secondKeys).toContain('type')
     expect(secondKeys).not.toContain('dataType')
   })
+  it('should throw an error because of bad columns in the csv', () => {
+    const contents = `name,type,data_type
+    hello,how,are
+    you,today,`
+    try {
+      const parsed = csvToObjectArray(contents)
+      fail('code should not reach here, it should throw an error')
+    } catch (error) {
+      expect(error).not.toEqual(null)
+      expect(error.message).toEqual(
+        'csv headers are not correct; they need to be : "name, type, dataType"'
+      )
+    }
+  })
 })

--- a/src/buckets/components/createBucketForm/MeasurementSchemaSection.test.tsx
+++ b/src/buckets/components/createBucketForm/MeasurementSchemaSection.test.tsx
@@ -5,6 +5,7 @@ import {
   TOO_LONG_ERROR,
   areNewSchemasValid,
   areSchemaUpdatesValid,
+  csvToArray,
 } from './MeasurementSchemaUtils'
 import {toCsvString} from './MeasurementSchemaSection'
 
@@ -283,5 +284,42 @@ describe('test csv conversion function (object->csv file)', () => {
     expect(lines[9]).toEqual('one,field,string')
 
     expect(lines.length).toEqual(10)
+  })
+})
+describe('test csv to array function (parsing)', () => {
+  it('should parse the csv correctly', () => {
+    const contents = `foo,bar,baz
+    hello,how,are
+    you,today,really`
+
+    const parsed = csvToArray(contents)
+
+    expect(parsed?.length).toEqual(2)
+    expect(parsed[0]['foo']).toEqual('hello')
+    expect(parsed[0]['bar']).toEqual('how')
+    expect(parsed[0]['baz']).toEqual('are')
+    expect(parsed[1]['foo']).toEqual('you')
+    expect(parsed[1]['bar']).toEqual('today')
+    expect(parsed[1]['baz']).toEqual('really')
+  })
+  it('should parse the csv correctly, with a missing third element', () => {
+    const contents = `foo,bar,baz
+    hello,how,are
+    you,today,`
+
+    const parsed = csvToArray(contents)
+
+    expect(parsed?.length).toEqual(2)
+    expect(parsed[0]['foo']).toEqual('hello')
+    expect(parsed[0]['bar']).toEqual('how')
+    expect(parsed[0]['baz']).toEqual('are')
+    expect(parsed[1]['foo']).toEqual('you')
+    expect(parsed[1]['bar']).toEqual('today')
+
+    const secondKeys = Object.keys(parsed[1])
+    expect(secondKeys.length).toEqual(2)
+    expect(secondKeys).toContain('foo')
+    expect(secondKeys).toContain('bar')
+    expect(secondKeys).not.toContain('baz')
   })
 })

--- a/src/buckets/components/createBucketForm/MeasurementSchemaSection.test.tsx
+++ b/src/buckets/components/createBucketForm/MeasurementSchemaSection.test.tsx
@@ -5,7 +5,7 @@ import {
   TOO_LONG_ERROR,
   areNewSchemasValid,
   areSchemaUpdatesValid,
-  csvToArray,
+  csvToObjectArray,
   toCsvString,
 } from './MeasurementSchemaUtils'
 
@@ -288,38 +288,38 @@ describe('test csv conversion function (object->csv file)', () => {
 })
 describe('test csv to array function (parsing)', () => {
   it('should parse the csv correctly', () => {
-    const contents = `foo,bar,baz
+    const contents = `name,type,dataType
     hello,how,are
     you,today,really`
 
-    const parsed = csvToArray(contents)
+    const parsed = csvToObjectArray(contents)
 
     expect(parsed?.length).toEqual(2)
-    expect(parsed[0]['foo']).toEqual('hello')
-    expect(parsed[0]['bar']).toEqual('how')
-    expect(parsed[0]['baz']).toEqual('are')
-    expect(parsed[1]['foo']).toEqual('you')
-    expect(parsed[1]['bar']).toEqual('today')
-    expect(parsed[1]['baz']).toEqual('really')
+    expect(parsed[0]['name']).toEqual('hello')
+    expect(parsed[0]['type']).toEqual('how')
+    expect(parsed[0]['dataType']).toEqual('are')
+    expect(parsed[1]['name']).toEqual('you')
+    expect(parsed[1]['type']).toEqual('today')
+    expect(parsed[1]['dataType']).toEqual('really')
   })
   it('should parse the csv correctly, with a missing third element', () => {
-    const contents = `foo,bar,baz
+    const contents = `name,type,dataType
     hello,how,are
     you,today,`
 
-    const parsed = csvToArray(contents)
+    const parsed = csvToObjectArray(contents)
 
     expect(parsed?.length).toEqual(2)
-    expect(parsed[0]['foo']).toEqual('hello')
-    expect(parsed[0]['bar']).toEqual('how')
-    expect(parsed[0]['baz']).toEqual('are')
-    expect(parsed[1]['foo']).toEqual('you')
-    expect(parsed[1]['bar']).toEqual('today')
+    expect(parsed[0]['name']).toEqual('hello')
+    expect(parsed[0]['type']).toEqual('how')
+    expect(parsed[0]['dataType']).toEqual('are')
+    expect(parsed[1]['name']).toEqual('you')
+    expect(parsed[1]['type']).toEqual('today')
 
     const secondKeys = Object.keys(parsed[1])
     expect(secondKeys.length).toEqual(2)
-    expect(secondKeys).toContain('foo')
-    expect(secondKeys).toContain('bar')
-    expect(secondKeys).not.toContain('baz')
+    expect(secondKeys).toContain('name')
+    expect(secondKeys).toContain('type')
+    expect(secondKeys).not.toContain('dataType')
   })
 })

--- a/src/buckets/components/createBucketForm/MeasurementSchemaSection.test.tsx
+++ b/src/buckets/components/createBucketForm/MeasurementSchemaSection.test.tsx
@@ -327,7 +327,7 @@ describe('test csv to array function (parsing)', () => {
     hello,how,are
     you,today,`
     try {
-      const parsed = csvToObjectArray(contents)
+      csvToObjectArray(contents)
       fail('code should not reach here, it should throw an error')
     } catch (error) {
       expect(error).not.toEqual(null)

--- a/src/buckets/components/createBucketForm/MeasurementSchemaSection.test.tsx
+++ b/src/buckets/components/createBucketForm/MeasurementSchemaSection.test.tsx
@@ -6,8 +6,8 @@ import {
   areNewSchemasValid,
   areSchemaUpdatesValid,
   csvToArray,
+  toCsvString,
 } from './MeasurementSchemaUtils'
-import {toCsvString} from './MeasurementSchemaSection'
 
 const oneColumns = [
   {name: 'time', type: 'timestamp'},

--- a/src/buckets/components/createBucketForm/MeasurementSchemaSection.tsx
+++ b/src/buckets/components/createBucketForm/MeasurementSchemaSection.tsx
@@ -338,8 +338,8 @@ const EditingPanel: FC<PanelProps> = ({
     downloadTextFile(contents, name || 'schema', extension)
   }
 
-  const handleFileUpload = (contents: string, isCsv: boolean) => {
-    const columns = getColumnsFromFile(contents, isCsv)
+  const handleFileUpload = (contents: string, fileType: DownloadTypes) => {
+    const columns = getColumnsFromFile(contents, fileType)
     onAddUpdate(columns, index)
   }
 
@@ -490,12 +490,11 @@ export const MeasurementSchemaSection: FC<Props> = ({
         downloadFormat={downloadType}
       />
     ))
+
+    const labelStyle = {marginRight: 10}
     const downloadToggle = (
       <FlexBox direction={FlexDirection.Row}>
-        <InputLabel style={{marginRight: 10}}>
-          {' '}
-          Download File Format:{' '}
-        </InputLabel>
+        <InputLabel style={labelStyle}> Download File Format: </InputLabel>
         <Toggle
           tabIndex={1}
           value="json"

--- a/src/buckets/components/createBucketForm/MeasurementSchemaSection.tsx
+++ b/src/buckets/components/createBucketForm/MeasurementSchemaSection.tsx
@@ -31,7 +31,10 @@ import {
   toCsvString,
 } from 'src/buckets/components/createBucketForm/MeasurementSchemaUtils'
 import {downloadTextFile} from 'src/shared/utils/download'
-import {MiniFileDnd} from 'src/buckets/components/createBucketForm/MiniFileDnd'
+import {
+  DownloadTypes,
+  MiniFileDnd,
+} from 'src/buckets/components/createBucketForm/MiniFileDnd'
 
 import {CLOUD} from 'src/shared/constants'
 import classnames from 'classnames'
@@ -75,8 +78,6 @@ interface Props {
   onAddSchemas: (schemas: typeof MeasurementSchema, b?: boolean) => void
   showSchemaValidation: boolean
 }
-
-type DownloadTypes = 'csv' | 'json'
 
 /**
  * toggleUpdate:  is this line being updated?
@@ -178,12 +179,12 @@ const AddingPanel: FC<AddingProps> = ({
   // overridden.  with the propagation, the error state only gets called once properly.
   const handleFileUpload = (
     contents: string,
-    isCsv: boolean,
+    fileType: DownloadTypes,
     fileName: string
   ) => {
     // keep swapping out the file, cancel out of the dialog, x out the adding line....etc
 
-    const columns = getColumnsFromFile(contents, isCsv)
+    const columns = getColumnsFromFile(contents, fileType)
     onAddContents(columns, fileName, index)
   }
 

--- a/src/buckets/components/createBucketForm/MeasurementSchemaSection.tsx
+++ b/src/buckets/components/createBucketForm/MeasurementSchemaSection.tsx
@@ -19,6 +19,9 @@ import {
   InputType,
   Panel,
   FormElementError,
+  Toggle,
+  InputToggleType,
+  InputLabel,
 } from '@influxdata/clockface'
 
 import 'src/buckets/components/createBucketForm/MeasurementSchema.scss'
@@ -348,6 +351,7 @@ const EditingPanel: FC<PanelProps> = ({
   const handleDownloadSchema = () => {
     const {name} = measurementSchema
     const contents = JSON.stringify(measurementSchema.columns)
+    // if csv selected, do csv conversion instead TODO
     event('bucket.download.schema.explicit')
     downloadTextFile(contents, name || 'schema', '.json')
   }
@@ -464,6 +468,7 @@ export const MeasurementSchemaSection: FC<Props> = ({
       hasUpdate: false,
     })) || []
   const [schemaUpdates, setSchemaUpdates] = useState(updateInit)
+  const [downloadType, setDownloadType] = useState('json')
 
   // every time we update the local schema, should also send up the schema to the parent
   // so putting them together here
@@ -502,9 +507,11 @@ export const MeasurementSchemaSection: FC<Props> = ({
     'https://docs.influxdata.com/influxdb/cloud/organizations/buckets/bucket-schema/'
 
   const schemas = measurementSchemaList?.measurementSchemas
-  let readPanels = null
+  let readSection = null
   if (schemas) {
-    readPanels = schemas.map((oneSchema, index) => (
+
+
+    const readPanels = schemas.map((oneSchema, index) => (
       <EditingPanel
         key={`mss-ep-${index}`}
         measurementSchema={oneSchema}
@@ -513,6 +520,52 @@ export const MeasurementSchemaSection: FC<Props> = ({
         toggleUpdate={toggleUpdate}
       />
     ))
+    const downloadToggle = (
+        <React.Fragment>
+          <Toggle
+              tabIndex={1}
+              value="json"
+              id="json-download-flavor-choice"
+              name="json-download-flavor-choice"
+              className="option"
+              checked={downloadType === 'json'}
+              onChange={setDownloadType}
+              type={InputToggleType.Radio}
+              size={ComponentSize.ExtraSmall}
+              color={ComponentColor.Primary}
+              testID="json-download-flavor-choice"
+          >
+            <InputLabel
+                htmlFor="json-download-flavor-choice"
+                active={downloadType === 'json'}
+            >
+              json
+            </InputLabel>
+          </Toggle>
+          <Toggle
+              tabIndex={2}
+              value="csv"
+              id="csv-download-flavor-choice"
+              name="csv-download-flavor-choice"
+              className="option"
+              checked={downloadType === 'csv'}
+              onChange={setDownloadType}
+              type={InputToggleType.Radio}
+              size={ComponentSize.ExtraSmall}
+              color={ComponentColor.Primary}
+              testID="csv-download-flavor-choice"
+          >
+            <InputLabel
+                htmlFor="csv-download-flavor-choice"
+                active={downloadType === 'csv'}
+            >
+              csv
+            </InputLabel>
+          </Toggle>
+        </React.Fragment>
+    )
+    readSection = <>{downloadToggle} {readPanels} </>
+
   }
 
   const setNewSchemasWithUpdates = schemaArray => {
@@ -611,6 +664,8 @@ export const MeasurementSchemaSection: FC<Props> = ({
     showSchemaValidation,
   ])
 
+
+
   return (
     <FlexBox
       direction={FlexDirection.Column}
@@ -631,7 +686,7 @@ export const MeasurementSchemaSection: FC<Props> = ({
           </a>
         </div>
       </div>
-      {readPanels}
+      {readSection}
       {addSchemaButton}
       {addPanels}
     </FlexBox>

--- a/src/buckets/components/createBucketForm/MeasurementSchemaSection.tsx
+++ b/src/buckets/components/createBucketForm/MeasurementSchemaSection.tsx
@@ -28,6 +28,7 @@ import 'src/buckets/components/createBucketForm/MeasurementSchema.scss'
 import {
   isNameValid,
   getColumnsFromFile,
+  toCsvString,
 } from 'src/buckets/components/createBucketForm/MeasurementSchemaUtils'
 import {downloadTextFile} from 'src/shared/utils/download'
 import {MiniFileDnd} from 'src/buckets/components/createBucketForm/MiniFileDnd'
@@ -412,25 +413,6 @@ export interface SchemaUpdateInfo {
   hasUpdate: boolean
   isValid?: boolean
   columns?: typeof MeasurementSchemaColumn[]
-}
-
-export const toCsvString = columns => {
-  return [
-    ['name', 'type', 'dataType'],
-    ...columns.map(schemaLine => {
-      const line = [schemaLine.name, schemaLine.type]
-      if (schemaLine.dataType) {
-        line.push(schemaLine.dataType)
-      } else {
-        // putting in an empty entry, to get the trailing comma if there are only two entries
-        // this make the line be: ' host,tag,' as opposed to : ' host,tag'
-        line.push('')
-      }
-      return line
-    }),
-  ]
-    .map(e => e.join(','))
-    .join('\n')
 }
 
 export const MeasurementSchemaSection: FC<Props> = ({

--- a/src/buckets/components/createBucketForm/MeasurementSchemaSection.tsx
+++ b/src/buckets/components/createBucketForm/MeasurementSchemaSection.tsx
@@ -145,8 +145,8 @@ const getColumnsFromFile = (contents: string) => {
 }
 
 // the first is for dnd; the second is for the file input
-const allowedTypes = ['application/json']
-const allowedExtensions = '.json'
+const allowedTypes = ['application/json', 'text/csv']
+const allowedExtensions = '.json,.csv'
 
 const AddingPanel: FC<AddingProps> = ({
   index,

--- a/src/buckets/components/createBucketForm/MeasurementSchemaUtils.ts
+++ b/src/buckets/components/createBucketForm/MeasurementSchemaUtils.ts
@@ -1,3 +1,5 @@
+import {DownloadTypes} from './MiniFileDnd'
+
 const typeStrings = ['timestamp', 'tag', 'field']
 const dataTypeStrings = ['integer', 'float', 'boolean', 'string', 'unsigned']
 
@@ -111,11 +113,14 @@ export const areSchemaUpdatesValid = schemaInfo => {
 // the MiniFileDnd component will catch any errors thrown here
 // and display them to the user; as this method is only called from within
 // the 'handleFileUpload' that is passed to and called by the MiniFileDnd Component.
-export const getColumnsFromFile = (contents: string, isCsv: boolean) => {
+export const getColumnsFromFile = (
+  contents: string,
+  fileType: DownloadTypes
+) => {
   // do parsing here;  to check if in the correct format:
   let columns = null
   if (contents) {
-    if (isCsv) {
+    if (fileType === 'csv') {
       columns = csvToObjectArray(contents)
     } else {
       // it's json:

--- a/src/buckets/components/createBucketForm/MeasurementSchemaUtils.ts
+++ b/src/buckets/components/createBucketForm/MeasurementSchemaUtils.ts
@@ -166,3 +166,22 @@ export const csvToArray = (contents: string, delimiter = ',') => {
   // return the array
   return arr
 }
+
+export const toCsvString = columns => {
+  return [
+    ['name', 'type', 'dataType'],
+    ...columns.map(schemaLine => {
+      const line = [schemaLine.name, schemaLine.type]
+      if (schemaLine.dataType) {
+        line.push(schemaLine.dataType)
+      } else {
+        // putting in an empty entry, to get the trailing comma if there are only two entries
+        // this make the line be: ' host,tag,' as opposed to : ' host,tag'
+        line.push('')
+      }
+      return line
+    }),
+  ]
+    .map(e => e.join(','))
+    .join('\n')
+}

--- a/src/buckets/components/createBucketForm/MeasurementSchemaUtils.ts
+++ b/src/buckets/components/createBucketForm/MeasurementSchemaUtils.ts
@@ -116,7 +116,7 @@ export const getColumnsFromFile = (contents: string, isCsv: boolean) => {
   let columns = null
   if (contents) {
     if (isCsv) {
-      columns = csvToArray(contents)
+      columns = csvToObjectArray(contents)
     } else {
       // it's json:
 
@@ -132,39 +132,40 @@ export const getColumnsFromFile = (contents: string, isCsv: boolean) => {
   return columns
 }
 /**
- * take a csv file, as a string, and turn it into a javascript object
+ * take a csv file, as a string, and turn it into an array of javascript objects.
+ *
  * based off: https://sebhastian.com/javascript-csv-to-array/
  * if the value isn't present, then it isn't put into the object.
  * all strings are trimmed as well.
  */
-export const csvToArray = (contents: string, delimiter = ',') => {
-  // slice from start of text to the first \n index
-  // use split to create an array from string by delimiter
+export const csvToObjectArray = (contents: string, delimiter = ',') => {
   const headers = contents.slice(0, contents.indexOf('\n')).split(delimiter)
 
-  // slice from \n index + 1 to the end of the text
-  // use split to create an array of each csv value row
+  // check that the headers are correct; if not throw an exception:
+  if (
+    headers[0] !== 'name' ||
+    headers[1] !== 'type' ||
+    headers[2] !== 'dataType'
+  ) {
+    throw {
+      message:
+        'csv headers are not correct; they need to be : "name, type, dataType"',
+    }
+  }
+
   const rows = contents.slice(contents.indexOf('\n') + 1).split('\n')
 
-  // Map the rows
-  // split values from each row into an array
-  // use headers.reduce to create an object
-  // object properties derived from headers:values
-  // the object passed as an element of the array
-  const arr = rows.map(function(row) {
+  return rows.map(function(row) {
     const values = row.split(delimiter)
-    const el = headers.reduce(function(object, header, index) {
+
+    return headers.reduce(function(object, header, index) {
       const val = values[index]
       if (val) {
         object[header] = val.trim()
       }
       return object
     }, {})
-    return el
   })
-
-  // return the array
-  return arr
 }
 
 export const toCsvString = columns => {
@@ -182,6 +183,6 @@ export const toCsvString = columns => {
       return line
     }),
   ]
-    .map(e => e.join(','))
+    .map(lineItem => lineItem.join(','))
     .join('\n')
 }

--- a/src/buckets/components/createBucketForm/MiniFileDnd.test.tsx
+++ b/src/buckets/components/createBucketForm/MiniFileDnd.test.tsx
@@ -1,11 +1,15 @@
 import React from 'react'
 import {renderWithRedux} from 'src/mockState'
-import {csvToArray, MiniFileDnd, setGrammar} from './MiniFileDnd'
+import {MiniFileDnd, setGrammar} from './MiniFileDnd'
 
 const setup = (
   allowedExtensions: string,
   allowedTypes: string[],
-  handleFileUpload: (contents: string, fileName: string) => void,
+  handleFileUpload: (
+    contents: string,
+    isCsv: boolean,
+    fileName: string
+  ) => void,
   setErrorState: (hasError: boolean, message?: string) => void,
   alreadySetFileName?: string
 ) => {
@@ -21,8 +25,9 @@ const setup = (
 }
 
 const mockSetErrorState = jest.fn((hasError, message) => ({hasError, message}))
-const mockHandleFileUpload = jest.fn((contents, fileName) => ({
+const mockHandleFileUpload = jest.fn((contents, isCsv, fileName) => ({
   contents,
+  isCsv,
   fileName,
 }))
 
@@ -74,43 +79,6 @@ describe('mini file uploader, testing rendering and behavior', () => {
 
     const displayArea = getByTestId('displayArea')
     expect(displayArea).toHaveTextContent(fileName)
-  })
-})
-describe('test csv to array function (parsing)', () => {
-  it('should parse the csv correctly', () => {
-    const contents = `foo,bar,baz
-    hello,how,are
-    you,today,really`
-
-    const parsed = csvToArray(contents)
-
-    expect(parsed?.length).toEqual(2)
-    expect(parsed[0]['foo']).toEqual('hello')
-    expect(parsed[0]['bar']).toEqual('how')
-    expect(parsed[0]['baz']).toEqual('are')
-    expect(parsed[1]['foo']).toEqual('you')
-    expect(parsed[1]['bar']).toEqual('today')
-    expect(parsed[1]['baz']).toEqual('really')
-  })
-  it('should parse the csv correctly, with a missing third element', () => {
-    const contents = `foo,bar,baz
-    hello,how,are
-    you,today,`
-
-    const parsed = csvToArray(contents)
-
-    expect(parsed?.length).toEqual(2)
-    expect(parsed[0]['foo']).toEqual('hello')
-    expect(parsed[0]['bar']).toEqual('how')
-    expect(parsed[0]['baz']).toEqual('are')
-    expect(parsed[1]['foo']).toEqual('you')
-    expect(parsed[1]['bar']).toEqual('today')
-
-    const secondKeys = Object.keys(parsed[1])
-    expect(secondKeys.length).toEqual(2)
-    expect(secondKeys).toContain('foo')
-    expect(secondKeys).toContain('bar')
-    expect(secondKeys).not.toContain('baz')
   })
 })
 describe('test grammar function for error messages', () => {

--- a/src/buckets/components/createBucketForm/MiniFileDnd.test.tsx
+++ b/src/buckets/components/createBucketForm/MiniFileDnd.test.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
 import {renderWithRedux} from 'src/mockState'
-import {MiniFileDnd, setGrammar} from './MiniFileDnd'
+import {DownloadTypes, MiniFileDnd, setGrammar} from './MiniFileDnd'
 
 const setup = (
   allowedExtensions: string,
   allowedTypes: string[],
   handleFileUpload: (
     contents: string,
-    isCsv: boolean,
+    fileType: DownloadTypes,
     fileName: string
   ) => void,
   setErrorState: (hasError: boolean, message?: string) => void,

--- a/src/buckets/components/createBucketForm/MiniFileDnd.test.tsx
+++ b/src/buckets/components/createBucketForm/MiniFileDnd.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import {renderWithRedux} from 'src/mockState'
-import {MiniFileDnd, setGrammar} from './MiniFileDnd'
+import {csvToArray, MiniFileDnd, setGrammar} from './MiniFileDnd'
 
 const setup = (
   allowedExtensions: string,
@@ -76,7 +76,43 @@ describe('mini file uploader, testing rendering and behavior', () => {
     expect(displayArea).toHaveTextContent(fileName)
   })
 })
+describe('test csv to array function (parsing)', () => {
+  it('should parse the csv correctly', () => {
+    const contents = `foo,bar,baz
+    hello,how,are
+    you,today,really`
 
+    const parsed = csvToArray(contents)
+
+    expect(parsed?.length).toEqual(2)
+    expect(parsed[0]['foo']).toEqual('hello')
+    expect(parsed[0]['bar']).toEqual('how')
+    expect(parsed[0]['baz']).toEqual('are')
+    expect(parsed[1]['foo']).toEqual('you')
+    expect(parsed[1]['bar']).toEqual('today')
+    expect(parsed[1]['baz']).toEqual('really')
+  })
+  it('should parse the csv correctly, with a missing third element', () => {
+    const contents = `foo,bar,baz
+    hello,how,are
+    you,today,`
+
+    const parsed = csvToArray(contents)
+
+    expect(parsed?.length).toEqual(2)
+    expect(parsed[0]['foo']).toEqual('hello')
+    expect(parsed[0]['bar']).toEqual('how')
+    expect(parsed[0]['baz']).toEqual('are')
+    expect(parsed[1]['foo']).toEqual('you')
+    expect(parsed[1]['bar']).toEqual('today')
+
+    const secondKeys = Object.keys(parsed[1])
+    expect(secondKeys.length).toEqual(2)
+    expect(secondKeys).toContain('foo')
+    expect(secondKeys).toContain('bar')
+    expect(secondKeys).not.toContain('baz')
+  })
+})
 describe('test grammar function for error messages', () => {
   it('should have correct grammar for one element', () => {
     const foo1 = ['ack']

--- a/src/buckets/components/createBucketForm/MiniFileDnd.tsx
+++ b/src/buckets/components/createBucketForm/MiniFileDnd.tsx
@@ -33,7 +33,8 @@ import {
  * allowedExtensions =".png, .jpg, .jpeg"
  *
  * handleFileUpload: required function that sends along the text contents of the file
- * being uploaded along with the name of the file.
+ * being uploaded; a flag that is set to true if it is a csv file (else it is a json file),
+ * and the (optional) name of the file.
  *
  *   this method  is within a try/catch, so if the method throws an error, it will
  *   be caught *here* in this component, so that this component can then
@@ -51,7 +52,7 @@ import {
  *   but this component can be displayed as if the file is already uploaded (it is, in the state
  *   of the parent)
  *
- *   preFileUpload: a mothod (optional) that is called when the file upload starts
+ *   preFileUpload: a method (optional) that is called when the file upload starts
  *   this is guaranteed to be called, whereas the method handleFileUpload
  *   might error out.  this is used for telling the parent that the component has been used,
  *   so it can set relevant flags for styling; for example
@@ -65,7 +66,11 @@ import {
 interface Props {
   allowedExtensions: string
   allowedTypes: string[]
-  handleFileUpload: (contents: string, fileName?: string) => void
+  handleFileUpload: (
+    contents: string,
+    isCsv: boolean,
+    fileName?: string
+  ) => void
   setErrorState: (hasError: boolean, message?: string) => void
   alreadySetFileName?: string
   defaultText?: string
@@ -199,14 +204,8 @@ export const MiniFileDnd: FC<Props> = ({
     setErrorState(hasError, message)
   }
 
-  const processFile = (file, isCsv?: boolean) => {
+  const processFile = (file, isCsv: boolean = false) => {
     console.log('processing file...... is csv??', isCsv)
-    if (isCsv) {
-      console.log('csv not enabled yet....')
-      // todo: use this: https://sebhastian.com/javascript-csv-to-array/
-      // and write a test for it
-      return
-    }
 
     const reader = new FileReader()
     reader.readAsText(file)
@@ -217,7 +216,7 @@ export const MiniFileDnd: FC<Props> = ({
         preFileUpload()
       }
       try {
-        handleFileUpload(reader.result as string, fileName)
+        handleFileUpload(reader.result as string, isCsv, fileName)
 
         setFileName(fileName)
         setError(false)

--- a/src/buckets/components/createBucketForm/MiniFileDnd.tsx
+++ b/src/buckets/components/createBucketForm/MiniFileDnd.tsx
@@ -95,6 +95,41 @@ export const setGrammar = (fileTypes: string[]) => {
 }
 
 /**
+ * take a csv file, as a string, and turn it into a javascript object
+ * based off: https://sebhastian.com/javascript-csv-to-array/
+ * if the value isn't present, then it isn't put into the object.
+ * all strings are trimmed as well.
+ */
+export const csvToArray = (contents: string, delimiter = ',') => {
+  // slice from start of text to the first \n index
+  // use split to create an array from string by delimiter
+  const headers = contents.slice(0, contents.indexOf('\n')).split(delimiter)
+
+  // slice from \n index + 1 to the end of the text
+  // use split to create an array of each csv value row
+  const rows = contents.slice(contents.indexOf('\n') + 1).split('\n')
+
+  // Map the rows
+  // split values from each row into an array
+  // use headers.reduce to create an object
+  // object properties derived from headers:values
+  // the object passed as an element of the array
+  const arr = rows.map(function(row) {
+    const values = row.split(delimiter)
+    const el = headers.reduce(function(object, header, index) {
+      const val = values[index]
+      if (val) {
+        object[header] = val.trim()
+      }
+      return object
+    }, {})
+    return el
+  })
+
+  // return the array
+  return arr
+}
+/**
  *  This is a small File Drag-and-Drop Input
  *  It just has some text, with an outline.  There is no icon.
  *
@@ -168,6 +203,8 @@ export const MiniFileDnd: FC<Props> = ({
     console.log('processing file...... is csv??', isCsv)
     if (isCsv) {
       console.log('csv not enabled yet....')
+      // todo: use this: https://sebhastian.com/javascript-csv-to-array/
+      // and write a test for it
       return
     }
 

--- a/src/buckets/components/createBucketForm/MiniFileDnd.tsx
+++ b/src/buckets/components/createBucketForm/MiniFileDnd.tsx
@@ -33,7 +33,7 @@ import {
  * allowedExtensions =".png, .jpg, .jpeg"
  *
  * handleFileUpload: required function that sends along the text contents of the file
- * being uploaded; a flag that is set to true if it is a csv file (else it is a json file),
+ * being uploaded; an enumerated type that states the download file type (csv or json),
  * and the (optional) name of the file.
  *
  *   this method  is within a try/catch, so if the method throws an error, it will
@@ -68,7 +68,7 @@ interface Props {
   allowedTypes: string[]
   handleFileUpload: (
     contents: string,
-    isCsv: boolean,
+    fileType: DownloadTypes,
     fileName?: string
   ) => void
   setErrorState: (hasError: boolean, message?: string) => void
@@ -98,6 +98,8 @@ export const setGrammar = (fileTypes: string[]) => {
 
   return addOrToLastOne().join(', ')
 }
+
+export type DownloadTypes = 'csv' | 'json'
 
 /**
  *  This is a small File Drag-and-Drop Input
@@ -169,7 +171,7 @@ export const MiniFileDnd: FC<Props> = ({
     setErrorState(hasError, message)
   }
 
-  const processFile = (file, isCsv: boolean = false) => {
+  const processFile = (file, fileType) => {
     const reader = new FileReader()
     reader.readAsText(file)
     reader.onload = () => {
@@ -179,7 +181,7 @@ export const MiniFileDnd: FC<Props> = ({
         preFileUpload()
       }
       try {
-        handleFileUpload(reader.result as string, isCsv, fileName)
+        handleFileUpload(reader.result as string, fileType, fileName)
 
         setFileName(fileName)
         setError(false)
@@ -197,12 +199,9 @@ export const MiniFileDnd: FC<Props> = ({
     }
 
     const fileExt = file.name.split('.').pop()
-    let processCsv = false
-    if (fileExt === 'csv') {
-      processCsv = true
-    }
+
     // don't need to see if the file type is valid; the input filters it already for us
-    processFile(file, processCsv)
+    processFile(file, fileExt)
   }
 
   const dropHandler = (event: any): void => {
@@ -217,7 +216,8 @@ export const MiniFileDnd: FC<Props> = ({
     const fileType = file.type
 
     if (allowedTypes.includes(fileType)) {
-      processFile(file, fileType === 'text/csv')
+      const downloadFileType = fileType === 'text/csv' ? 'csv' : 'json'
+      processFile(file, downloadFileType)
     } else {
       const niceTypes = setGrammar(allowedTypes)
       const fileTypeInfo = fileType ? ` (${fileType})` : ''

--- a/src/buckets/components/createBucketForm/MiniFileDnd.tsx
+++ b/src/buckets/components/createBucketForm/MiniFileDnd.tsx
@@ -170,8 +170,6 @@ export const MiniFileDnd: FC<Props> = ({
   }
 
   const processFile = (file, isCsv: boolean = false) => {
-    console.log('processing file...... is csv??', isCsv)
-
     const reader = new FileReader()
     reader.readAsText(file)
     reader.onload = () => {
@@ -198,7 +196,6 @@ export const MiniFileDnd: FC<Props> = ({
       return
     }
 
-    console.log('file props...', file, file.name)
     const fileExt = file.name.split('.').pop()
     let processCsv = false
     if (fileExt === 'csv') {

--- a/src/buckets/components/createBucketForm/MiniFileDnd.tsx
+++ b/src/buckets/components/createBucketForm/MiniFileDnd.tsx
@@ -164,7 +164,13 @@ export const MiniFileDnd: FC<Props> = ({
     setErrorState(hasError, message)
   }
 
-  const processFile = file => {
+  const processFile = (file, isCsv?: boolean) => {
+    console.log('processing file...... is csv??', isCsv)
+    if (isCsv) {
+      console.log('csv not enabled yet....')
+      return
+    }
+
     const reader = new FileReader()
     reader.readAsText(file)
     reader.onload = () => {
@@ -191,8 +197,14 @@ export const MiniFileDnd: FC<Props> = ({
       return
     }
 
+    console.log('file props...', file, file.name)
+    const fileExt = file.name.split('.').pop()
+    let processCsv = false
+    if (fileExt === 'csv') {
+      processCsv = true
+    }
     // don't need to see if the file type is valid; the input filters it already for us
-    processFile(file)
+    processFile(file, processCsv)
   }
 
   const dropHandler = (event: any): void => {
@@ -207,7 +219,7 @@ export const MiniFileDnd: FC<Props> = ({
     const fileType = file.type
 
     if (allowedTypes.includes(fileType)) {
-      processFile(file)
+      processFile(file, fileType === 'text/csv')
     } else {
       const niceTypes = setGrammar(allowedTypes)
       const fileTypeInfo = fileType ? ` (${fileType})` : ''

--- a/src/buckets/components/createBucketForm/MiniFileDnd.tsx
+++ b/src/buckets/components/createBucketForm/MiniFileDnd.tsx
@@ -100,41 +100,6 @@ export const setGrammar = (fileTypes: string[]) => {
 }
 
 /**
- * take a csv file, as a string, and turn it into a javascript object
- * based off: https://sebhastian.com/javascript-csv-to-array/
- * if the value isn't present, then it isn't put into the object.
- * all strings are trimmed as well.
- */
-export const csvToArray = (contents: string, delimiter = ',') => {
-  // slice from start of text to the first \n index
-  // use split to create an array from string by delimiter
-  const headers = contents.slice(0, contents.indexOf('\n')).split(delimiter)
-
-  // slice from \n index + 1 to the end of the text
-  // use split to create an array of each csv value row
-  const rows = contents.slice(contents.indexOf('\n') + 1).split('\n')
-
-  // Map the rows
-  // split values from each row into an array
-  // use headers.reduce to create an object
-  // object properties derived from headers:values
-  // the object passed as an element of the array
-  const arr = rows.map(function(row) {
-    const values = row.split(delimiter)
-    const el = headers.reduce(function(object, header, index) {
-      const val = values[index]
-      if (val) {
-        object[header] = val.trim()
-      }
-      return object
-    }, {})
-    return el
-  })
-
-  // return the array
-  return arr
-}
-/**
  *  This is a small File Drag-and-Drop Input
  *  It just has some text, with an outline.  There is no icon.
  *


### PR DESCRIPTION
Closes #3094 #3095 

before this pr; when uploading new measurement schemas, updating existing measurement schemas, and downloading measurement schemas, all the files were in the json format.

this ticket allows a user to use the csv file format as well.  

so they can do new uploads, updates,  and downloads in csv.

for updates/uploads, just select either a csv or json file and it just works transparently with no change for the user.

for downloads, there is a new radio button to specify the format.  it is by default json, but can be switched to csv instead.

https://user-images.githubusercontent.com/3900960/140376910-87cc9664-e06e-48be-95a6-eda3d2b746c1.mov



