### PR TITLE
chore(notebooks): handle when query errors are returned

### DIFF
--- a/src/flows/components/ReadOnly.tsx
+++ b/src/flows/components/ReadOnly.tsx
@@ -44,12 +44,23 @@ const RunPipeResults: FC = () => {
     )
     map.forEach(id => {
       fetch(`/api/share/${accessID}/query/${id}`)
-        .then(res => res.text())
-        .then(resp => {
-          const csv = fromFlux(resp)
-          setResult(id, {parsed: csv, source: ''})
-          setStatuses({[id]: RemoteDataState.Done})
-        })
+        .then(res =>
+          res.text().then(resp => {
+            if (res.status == 200) {
+              const csv = fromFlux(resp)
+              setResult(id, {parsed: csv, source: ''})
+              setStatuses({[id]: RemoteDataState.Done})
+            } else {
+              try {
+                const json = JSON.parse(resp)
+                setResult(id, {error: json.message || json.error})
+              } catch (err) {
+                setResult(id, {error: resp})
+              }
+              setStatuses({[id]: RemoteDataState.Error})
+            }
+          })
+        )
         .catch(err => {
           console.error('failed to execute query', err)
           setStatuses({[id]: RemoteDataState.Error})


### PR DESCRIPTION
Closes #3129 

This PR handles the new query errors returned from notebooksd for shared notebooks

![image](https://user-images.githubusercontent.com/6411855/140221592-f532da77-8972-4497-afdd-743db6469baa.png)
