### PR TITLE
feat: customApiTokenOverlay re-renders multiple times

### DIFF
--- a/src/authorizations/actions/thunks.ts
+++ b/src/authorizations/actions/thunks.ts
@@ -105,7 +105,6 @@ export const createAuthorization = (auth: Authorization) => async (
 ) => {
   try {
     const resp = await authAPI.createAuthorization(auth)
-    console.log("line 108")
     const newAuth = normalize<Authorization, AuthEntities, string>(
       resp,
       authSchema
@@ -122,7 +121,6 @@ export const createAuthorization = (auth: Authorization) => async (
     dispatch(notify(authorizationCreateSuccess()))
   } catch (error) {
     event('token.create.failure')
-    console.log("line 125")
     const message = getErrorMessage(error)
     dispatch(notify(authorizationCreateFailed(message)))
     throw error

--- a/src/authorizations/actions/thunks.ts
+++ b/src/authorizations/actions/thunks.ts
@@ -105,7 +105,7 @@ export const createAuthorization = (auth: Authorization) => async (
 ) => {
   try {
     const resp = await authAPI.createAuthorization(auth)
-
+    console.log("line 108")
     const newAuth = normalize<Authorization, AuthEntities, string>(
       resp,
       authSchema
@@ -122,6 +122,7 @@ export const createAuthorization = (auth: Authorization) => async (
     dispatch(notify(authorizationCreateSuccess()))
   } catch (error) {
     event('token.create.failure')
+    console.log("line 125")
     const message = getErrorMessage(error)
     dispatch(notify(authorizationCreateFailed(message)))
     throw error

--- a/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
@@ -92,7 +92,7 @@ const CustomApiTokenOverlay: FC<Props> = props => {
       } else if (resource === 'buckets') {
         perms[resource] = props.bucketPermissions
       } else {
-        perms[resource] = {read: false, write: false} 
+        perms[resource] = {read: false, write: false}
       }
     })
     setPermissions(perms)
@@ -225,7 +225,6 @@ const CustomApiTokenOverlay: FC<Props> = props => {
   }
 
   const generateToken = async () => {
-    
     const {orgID, showOverlay, orgName, createAuthorization} = props
     const apiPermissions = formatApiPermissions(permissions, orgID, orgName)
 
@@ -236,7 +235,7 @@ const CustomApiTokenOverlay: FC<Props> = props => {
         : generateDescription(apiPermissions),
       permissions: apiPermissions,
     }
-    
+
     try {
       await createAuthorization(token)
       showOverlay('access-token', null, () => dismissOverlay())

--- a/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
@@ -81,17 +81,18 @@ const CustomApiTokenOverlay: FC<Props> = props => {
   }, [])
 
   useEffect(() => {
+    if (permissions['telegrafs'] && permissions['buckets']) return
+
     const perms = {
       otherResources: {read: false, write: false},
     }
-
     props.allResources.forEach(resource => {
       if (resource === 'telegrafs') {
         perms[resource] = props.telegrafPermissions
       } else if (resource === 'buckets') {
         perms[resource] = props.bucketPermissions
       } else {
-        perms[resource] = {read: false, write: false}
+        perms[resource] = {read: false, write: false} 
       }
     })
     setPermissions(perms)
@@ -143,6 +144,7 @@ const CustomApiTokenOverlay: FC<Props> = props => {
 
   const handleIndividualToggle = (resourceName, id, permission) => {
     setStatus(ComponentStatus.Default)
+
     const permValue =
       permissions[resourceName].sublevelPermissions[id].permissions[permission]
 
@@ -239,9 +241,7 @@ const CustomApiTokenOverlay: FC<Props> = props => {
       await createAuthorization(token)
       showOverlay('access-token', null, () => dismissOverlay())
     } catch (e) {
-      console.log("in catch", e)
       setStatus(ComponentStatus.Disabled)
-      throw e
     }
   }
 
@@ -252,7 +252,7 @@ const CustomApiTokenOverlay: FC<Props> = props => {
         onDismiss={onClose}
       />
       <Overlay.Body>
-        <Form onSubmit={generateToken}>
+        <Form>
           <FlexBox
             alignItems={AlignItems.Center}
             direction={FlexDirection.Column}

--- a/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
@@ -81,8 +81,8 @@ const CustomApiTokenOverlay: FC<Props> = props => {
   }, [])
 
   useEffect(() => {
-    if (permissions['telegrafs'] && permissions['buckets']) { 
-      return 
+    if (permissions['telegrafs'] && permissions['buckets']) {
+      return
     }
     const perms = {
       otherResources: {read: false, write: false},

--- a/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
@@ -223,6 +223,7 @@ const CustomApiTokenOverlay: FC<Props> = props => {
   }
 
   const generateToken = async () => {
+    
     const {orgID, showOverlay, orgName, createAuthorization} = props
     const apiPermissions = formatApiPermissions(permissions, orgID, orgName)
 
@@ -233,11 +234,12 @@ const CustomApiTokenOverlay: FC<Props> = props => {
         : generateDescription(apiPermissions),
       permissions: apiPermissions,
     }
-
+    
     try {
       await createAuthorization(token)
       showOverlay('access-token', null, () => dismissOverlay())
     } catch (e) {
+      console.log("in catch", e)
       setStatus(ComponentStatus.Disabled)
       throw e
     }
@@ -250,7 +252,7 @@ const CustomApiTokenOverlay: FC<Props> = props => {
         onDismiss={onClose}
       />
       <Overlay.Body>
-        <Form>
+        <Form onSubmit={generateToken}>
           <FlexBox
             alignItems={AlignItems.Center}
             direction={FlexDirection.Column}

--- a/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
@@ -81,8 +81,9 @@ const CustomApiTokenOverlay: FC<Props> = props => {
   }, [])
 
   useEffect(() => {
-    if (permissions['telegrafs'] && permissions['buckets']) return
-
+    if (permissions['telegrafs'] && permissions['buckets']) { 
+      return 
+    }
     const perms = {
       otherResources: {read: false, write: false},
     }

--- a/src/authorizations/utils/permissions.ts
+++ b/src/authorizations/utils/permissions.ts
@@ -234,7 +234,7 @@ export const formatApiPermissions = (permissions, orgID, orgName) => {
       return
     }
     if (permissions[key].read) {
-      if (key === 'orgs') {
+      // if (key === 'orgs') {
         apiPerms.push({
           action: 'read',
           resource: {
@@ -243,7 +243,7 @@ export const formatApiPermissions = (permissions, orgID, orgName) => {
             type: key,
           },
         })
-      } else {
+      // } else {
         apiPerms.push({
           action: 'read',
           resource: {
@@ -251,7 +251,7 @@ export const formatApiPermissions = (permissions, orgID, orgName) => {
             type: key,
           },
         })
-      }
+      // }
     }
     if (permissions[key].write) {
       if (key === 'orgs') {

--- a/src/authorizations/utils/permissions.ts
+++ b/src/authorizations/utils/permissions.ts
@@ -234,7 +234,7 @@ export const formatApiPermissions = (permissions, orgID, orgName) => {
       return
     }
     if (permissions[key].read) {
-      // if (key === 'orgs') {
+      if (key === 'orgs') {
         apiPerms.push({
           action: 'read',
           resource: {
@@ -243,7 +243,7 @@ export const formatApiPermissions = (permissions, orgID, orgName) => {
             type: key,
           },
         })
-      // } else {
+      } else {
         apiPerms.push({
           action: 'read',
           resource: {
@@ -251,7 +251,7 @@ export const formatApiPermissions = (permissions, orgID, orgName) => {
             type: key,
           },
         })
-      // }
+      }
     }
     if (permissions[key].write) {
       if (key === 'orgs') {


### PR DESCRIPTION
Closes #2899 

Issue - When creating a Custom API Token and an error is thrown, the user selected permissions are removed. The user should still be able to see the selected permissions from before. Also, when clicking on different permissions while the Failed notification is displaying, the selected permissions disappear when the notification is dismissed.

Fix - added an if statement inside useEffect to check if permissions object has telegrafs and buckets values. if true, we can skip updating permission (state), which in turn will stop the component from re-rendering. 

https://user-images.githubusercontent.com/66275100/140400827-5c8c3101-ba18-4cb8-8c52-cd6b545a1b16.mov
