### PR TITLE
feat: update script to fetch latest Telegraf plugins and run script

### DIFF
--- a/src/writeData/components/telegrafInputPluginsConfigurationText/couchbase.conf
+++ b/src/writeData/components/telegrafInputPluginsConfigurationText/couchbase.conf
@@ -13,3 +13,11 @@
 
   ## Filter bucket fields to include only here.
   # bucket_stats_included = ["quota_percent_used", "ops_per_sec", "disk_fetches", "item_count", "disk_used", "data_used", "mem_used"]
+
+  ## Optional TLS Config
+  # tls_ca = "/etc/telegraf/ca.pem"
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+  ## Use TLS but skip chain & host verification (defaults to false)
+  ## If set to false, tls_cert and tls_key are required
+  # insecure_skip_verify = false

--- a/src/writeData/components/telegrafInputPluginsConfigurationText/elasticsearch_query.conf
+++ b/src/writeData/components/telegrafInputPluginsConfigurationText/elasticsearch_query.conf
@@ -37,6 +37,13 @@
     ## The date/time field in the Elasticsearch index (mandatory).
     date_field = "@timestamp"
 
+    ## If the field used for the date/time field in Elasticsearch is also using
+    ## a custom date/time format it may be required to provide the format to
+    ## correctly parse the field.
+    ##
+    ## If using one of the built in elasticsearch formats this is not required.
+    # date_field_custom_format = ""
+
     ## Time window to query (eg. "1m" to query documents from last minute).
     ## Normally should be set to same as collection interval
     query_period = "1m"

--- a/src/writeData/components/telegrafInputPluginsConfigurationText/ethtool.conf
+++ b/src/writeData/components/telegrafInputPluginsConfigurationText/ethtool.conf
@@ -5,3 +5,12 @@
 
   ## List of interfaces to ignore when pulling metrics.
   # interface_exclude = ["eth1"]
+
+  ## Some drivers declare statistics with extra whitespace, different spacing,
+  ## and mix cases. This list, when enabled, can be used to clean the keys.
+  ## Here are the current possible normalizations:
+  ##  * snakecase: converts fooBarBaz to foo_bar_baz
+  ##  * trim: removes leading and trailing whitespace
+  ##  * lower: changes all capitalized letters to lowercase
+  ##  * underscore: replaces spaces with underscores
+  # normalize_keys = ["snakecase", "trim", "lower", "underscore"]

--- a/src/writeData/components/telegrafInputPluginsConfigurationText/intel_rdt.conf
+++ b/src/writeData/components/telegrafInputPluginsConfigurationText/intel_rdt.conf
@@ -22,3 +22,7 @@
 	## Mandatory if cores aren't set and forbidden if cores are specified.
 	## e.g. ["qemu", "pmd"]
 	# processes = ["process"]
+
+	## Specify if the pqos process should be called with sudo.
+	## Mandatory if the telegraf process does not run as root.
+	# use_sudo = false

--- a/src/writeData/components/telegrafInputPluginsConfigurationText/win_eventlog.conf
+++ b/src/writeData/components/telegrafInputPluginsConfigurationText/win_eventlog.conf
@@ -1,3 +1,4 @@
+# Input plugin to collect Windows Event Log messages
 [[inputs.win_eventlog]]
   ## Telegraf should have Administrator permissions to subscribe for some Windows Events channels
   ## (System log, for example)

--- a/src/writeData/utils/parsePluginsConfigurationText.ts
+++ b/src/writeData/utils/parsePluginsConfigurationText.ts
@@ -217,23 +217,59 @@ const inputPluginsList = [
   'zookeeper',
 ]
 
-let version = process.argv.slice(2)
-if (String(version).length === 0) {
-  console.warn(
-    logSymbols.warning + ' \x1b[33m%s\x1b[0m',
-    '*** WARNING ***: No version number provided, using "master"\n'
-  )
-  version = ['master']
-}
+/*
+  STEP 2:
+    on the command line, run
+      yarn telegraf-plugins:update [TELEGRAF_RELEASE_VERSION]
+        if given, will update plugins for the given Telegraf release
+        if omitted, will use the latest Telegraf release
 
-const telegrafConfigFilePath = `https://raw.githubusercontent.com/influxdata/telegraf/${version}/etc/telegraf.conf`
+*/
 
-const telegrafWindowsConfigFilePath = `https://raw.githubusercontent.com/influxdata/telegraf/${version}/etc/telegraf_windows.conf`
+const GITHUB_TELEGRAF_RELEASE_API_PATH =
+  'https://api.github.com/repos/influxdata/telegraf/releases'
 
-console.warn(
-  logSymbols.info + ' \x1b[36m%s\x1b[0m',
-  `Parsing Telegraf Plugins at ${telegrafConfigFilePath}\n`
-)
+const getVersion = new Promise((resolve, reject) => {
+  const version = process.argv.slice(2)
+  if (String(version).length === 0) {
+    console.warn(
+      logSymbols.warning + ' \x1b[33m%s\x1b[0m',
+      'No version number provided, using latest release... '
+    )
+    https.get(
+      GITHUB_TELEGRAF_RELEASE_API_PATH,
+      {
+        headers: {
+          'User-Agent': 'request',
+        },
+      },
+      response => {
+        let contents = ''
+        response.on('data', chunk => {
+          contents += chunk
+        })
+
+        response.on('error', error => {
+          reject(error)
+        })
+
+        response.on('end', () => {
+          const versions = JSON.parse(String(contents))
+          const latestVersion = Array.isArray(versions)
+            ? versions[0].name
+            : 'master'
+          console.warn(
+            logSymbols.warning + ' \x1b[33m%s\x1b[0m',
+            latestVersion + '\n'
+          )
+          resolve(latestVersion)
+        })
+      }
+    )
+  } else {
+    resolve(version)
+  }
+})
 
 const parsedPluginsPath =
   'src/writeData/components/telegrafInputPluginsConfigurationText/'
@@ -284,89 +320,23 @@ const formatConfigurationText = configurationText => {
   return configurationText + '\n'
 }
 
-/*
-  // STEP 2: on the command line, run with the desired release version, for example: v1.19.3
-  yarn telegraf-plugins:update TELEGRAF_RELEASE_VERSION
- */
-const noConfigs = []
-const parseTelegrafConf = new Promise((resolve, reject) => {
-  fetch(telegrafConfigFilePath).then(
-    parsedPluginsText => {
-      if (Array.isArray(parsedPluginsText)) {
-        const parsedPluginsNames = []
-        parsedPluginsText.forEach(pluginText => {
-          const pattern = /(.*)\[\[inputs.(.*)\]\]/g
-          const match = pluginText.match(pattern)
-          if (match) {
-            const pluginName = match[0]
-              .replace(/(.*)\[\[inputs./g, '')
-              .replace(/\]\](.*)/g, '')
-            parsedPluginsNames.push(pluginName)
-            const destinationFilPath = parsedPluginsPath + pluginName + '.conf'
-            fs.writeFile(
-              destinationFilPath,
-              formatConfigurationText(pluginText),
-              () => {}
-            )
-          }
-        })
-        const noPluginEntry = parsedPluginsNames.filter(
-          pluginName => !inputPluginsList.includes(pluginName)
-        )
+getVersion.then(version => {
+  const telegrafConfigFilePath = `https://raw.githubusercontent.com/influxdata/telegraf/${version}/etc/telegraf.conf`
 
-        if (noPluginEntry.length) {
-          console.warn(
-            logSymbols.warning +
-              ' Plugins not listed in the Data > Sources page of the UI:',
-            noPluginEntry,
-            '\n'
-          )
-        } else {
-          console.warn(
-            logSymbols.success + ' \x1b[32m%s\x1b[0m',
-            'Congratulations! All Plugins accounted for and showing in Data > Sources'
-          )
-        }
+  const telegrafWindowsConfigFilePath = `https://raw.githubusercontent.com/influxdata/telegraf/${version}/etc/telegraf_windows.conf`
 
-        inputPluginsList.forEach(pluginName => {
-          const pattern = new RegExp(`\\binputs.${pluginName}\\b`, 'gi')
-          const result = parsedPluginsText.find(config => config.match(pattern))
-          if (!result) {
-            noConfigs.push(pluginName)
-          }
-        })
-
-        if (noConfigs.length) {
-          console.warn(
-            logSymbols.warning + ' Could not find',
-            noConfigs,
-            'in telegraf.conf\n'
-          )
-        }
-        resolve(noConfigs)
-      } else {
-        console.warn(
-          logSymbols.error + ' \x1b[31m%s\x1b[0m',
-          'ERROR: Unexpected result: the fetched file was not parsed into an array'
-        )
-        reject(parsedPluginsText)
-      }
-    },
-    fetchError => reject(fetchError)
+  console.warn(
+    logSymbols.info + ' \x1b[36m%s\x1b[0m',
+    `Parsing Telegraf Plugins at ${telegrafConfigFilePath}\n`
   )
-})
 
-parseTelegrafConf.then(
-  nonWindowsPlugins => {
-    console.warn('Searching elsewhere...')
-    console.warn(
-      logSymbols.info + ' \x1b[36m%s\x1b[0m',
-      ` Parsing Telegraf Windows Plugins at ${telegrafWindowsConfigFilePath}\n`
-    )
-    fetch(telegrafWindowsConfigFilePath).then(
+  const noConfigs = []
+
+  const parseTelegrafConf = new Promise((resolve, reject) => {
+    fetch(telegrafConfigFilePath).then(
       parsedPluginsText => {
         if (Array.isArray(parsedPluginsText)) {
-          const parsedWindowsPluginsNames = []
+          const parsedPluginsNames = []
           parsedPluginsText.forEach(pluginText => {
             const pattern = /(.*)\[\[inputs.(.*)\]\]/g
             const match = pluginText.match(pattern)
@@ -374,76 +344,153 @@ parseTelegrafConf.then(
               const pluginName = match[0]
                 .replace(/(.*)\[\[inputs./g, '')
                 .replace(/\]\](.*)/g, '')
-
-              if (
-                Array.isArray(nonWindowsPlugins) &&
-                nonWindowsPlugins.includes(pluginName)
-              ) {
-                parsedWindowsPluginsNames.push(pluginName)
-                const destinationFilPath =
-                  parsedPluginsPath + pluginName + '.conf'
-                fs.writeFile(
-                  destinationFilPath,
-                  formatConfigurationText(pluginText),
-                  () => {}
-                )
-              }
+              parsedPluginsNames.push(pluginName)
+              const destinationFilPath =
+                parsedPluginsPath + pluginName + '.conf'
+              fs.writeFile(
+                destinationFilPath,
+                formatConfigurationText(pluginText),
+                () => {}
+              )
             }
           })
-
-          const noPluginEntry = parsedWindowsPluginsNames.filter(
+          const noPluginEntry = parsedPluginsNames.filter(
             pluginName => !inputPluginsList.includes(pluginName)
           )
-
-          console.warn(
-            logSymbols.success + ' Found:',
-            parsedWindowsPluginsNames,
-            '\n'
-          )
-
-          const windowsPluginsNotUpdated = noConfigs.filter(
-            pluginName => !parsedWindowsPluginsNames.includes(pluginName)
-          )
-
-          if (windowsPluginsNotUpdated.length) {
-            console.warn(
-              logSymbols.error + ' \x1b[31m%s\x1b[0m',
-              'Unable to update',
-              windowsPluginsNotUpdated,
-              '\n'
-            )
-          }
 
           if (noPluginEntry.length) {
             console.warn(
               logSymbols.warning +
-                ' Windows plugins not in the Data > Sources page of the UI:',
+                ' Plugins not listed in the Data > Sources page of the UI:',
               noPluginEntry,
               '\n'
             )
           } else {
             console.warn(
-              logSymbols.success +
-                ` All Windows Plugins are listed${
-                  windowsPluginsNotUpdated.length
-                    ? ' but may not be updated '
-                    : ' '
-                }in the Data > Sources page of the UI\n`
+              logSymbols.success + ' \x1b[32m%s\x1b[0m',
+              'Congratulations! All Plugins accounted for and showing in Data > Sources'
             )
           }
+
+          inputPluginsList.forEach(pluginName => {
+            const pattern = new RegExp(`\\binputs.${pluginName}\\b`, 'gi')
+            const result = parsedPluginsText.find(config =>
+              config.match(pattern)
+            )
+            if (!result) {
+              noConfigs.push(pluginName)
+            }
+          })
+
+          if (noConfigs.length) {
+            console.warn(
+              logSymbols.warning + ' Could not find',
+              noConfigs,
+              'in telegraf.conf\n'
+            )
+          }
+          resolve(noConfigs)
         } else {
           console.warn(
             logSymbols.error + ' \x1b[31m%s\x1b[0m',
             'ERROR: Unexpected result: the fetched file was not parsed into an array'
           )
+          reject(parsedPluginsText)
         }
       },
-      fetchError => {
-        console.error(logSymbols.error, ' ERROR:', fetchError)
-      }
+      fetchError => reject(fetchError)
     )
-  },
-  fetchError => {
-    console.error(logSymbols.error, ' ERROR:', fetchError)
-  }
-)
+  })
+
+  parseTelegrafConf.then(
+    nonWindowsPlugins => {
+      console.warn('Searching elsewhere...')
+      console.warn(
+        logSymbols.info + ' \x1b[36m%s\x1b[0m',
+        ` Parsing Telegraf Windows Plugins at ${telegrafWindowsConfigFilePath}\n`
+      )
+      fetch(telegrafWindowsConfigFilePath).then(
+        parsedPluginsText => {
+          if (Array.isArray(parsedPluginsText)) {
+            const parsedWindowsPluginsNames = []
+            parsedPluginsText.forEach(pluginText => {
+              const pattern = /(.*)\[\[inputs.(.*)\]\]/g
+              const match = pluginText.match(pattern)
+              if (match) {
+                const pluginName = match[0]
+                  .replace(/(.*)\[\[inputs./g, '')
+                  .replace(/\]\](.*)/g, '')
+
+                if (
+                  Array.isArray(nonWindowsPlugins) &&
+                  nonWindowsPlugins.includes(pluginName)
+                ) {
+                  parsedWindowsPluginsNames.push(pluginName)
+                  const destinationFilPath =
+                    parsedPluginsPath + pluginName + '.conf'
+                  fs.writeFile(
+                    destinationFilPath,
+                    formatConfigurationText(pluginText),
+                    () => {}
+                  )
+                }
+              }
+            })
+
+            const noPluginEntry = parsedWindowsPluginsNames.filter(
+              pluginName => !inputPluginsList.includes(pluginName)
+            )
+
+            console.warn(
+              logSymbols.success + ' Found:',
+              parsedWindowsPluginsNames,
+              '\n'
+            )
+
+            const windowsPluginsNotUpdated = noConfigs.filter(
+              pluginName => !parsedWindowsPluginsNames.includes(pluginName)
+            )
+
+            if (windowsPluginsNotUpdated.length) {
+              console.warn(
+                logSymbols.error + ' \x1b[31m%s\x1b[0m',
+                'Unable to update',
+                windowsPluginsNotUpdated,
+                '\n'
+              )
+            }
+
+            if (noPluginEntry.length) {
+              console.warn(
+                logSymbols.warning +
+                  ' Windows plugins not in the Data > Sources page of the UI:',
+                noPluginEntry,
+                '\n'
+              )
+            } else {
+              console.warn(
+                logSymbols.success +
+                  ` All Windows Plugins are listed${
+                    windowsPluginsNotUpdated.length
+                      ? ' but may not be updated '
+                      : ' '
+                  }in the Data > Sources page of the UI\n`
+              )
+            }
+          } else {
+            console.warn(
+              logSymbols.error + ' \x1b[31m%s\x1b[0m',
+              'ERROR: Unexpected result: the fetched file was not parsed into an array'
+            )
+          }
+        },
+        fetchError => {
+          console.error(logSymbols.error, ' ERROR:', fetchError)
+        }
+      )
+    },
+    fetchError => {
+      console.error(logSymbols.error, ' ERROR:', fetchError)
+    }
+  )
+})


### PR DESCRIPTION
Closes #3159 

Updates the script that fetches the latest configuration for all Telegraf plugins:
- use the latest release number if not given as an argument
- the latest release number is available from an api call to github
- resolve the above before proceeding to fetch the plugins


Runs the updated script to update the Telegraf plugins:
- exception: KNX Listener which appears to have its name changed yet again; will handle as a separate issue
