### PR TITLE
feat: use type ahead dropdown

### DIFF
--- a/src/shared/components/cells/CellCloneOverlay.tsx
+++ b/src/shared/components/cells/CellCloneOverlay.tsx
@@ -135,11 +135,9 @@ const CellCloneOverlay: FC = () => {
     )
   }
 
-  const selectedDashboard  = otherDashboards.find(
+  const selectedDashboard = otherDashboards.find(
     d => d.id === destinationDashboardID
   )
-
-  console.log('has a selected dash??? 44a-jill', selectedDashboard)
 
   const dashItems = otherDashboards as SelectableItem[]
 

--- a/src/shared/components/cells/CellCloneOverlay.tsx
+++ b/src/shared/components/cells/CellCloneOverlay.tsx
@@ -13,6 +13,8 @@ import {
   SlideToggle,
   Form,
   ComponentStatus,
+  TypeAheadDropDown,
+  SelectableItem,
 } from '@influxdata/clockface'
 
 // Actions
@@ -138,43 +140,36 @@ const CellCloneOverlay: FC = () => {
     d => d.id === destinationDashboardID
   )?.name
 
+  // otherDashboards.sort((dash1, dash2) => {
+  //   return dash1.name.localeCompare(dash2.name)
+  // })
+
+  console.log('UNsorted dashes??', otherDashboards)
+  const dashItems = otherDashboards as SelectableItem[]
+
+  const onDashSelection = item => {
+    setDestinationDashboardID(item?.id)
+  }
+
+  const typeAheadDropdown = (
+    <TypeAheadDropDown
+      items={dashItems}
+      onSelect={onDashSelection}
+      buttonTestId="clone-to-other-dashboard"
+      menuTestID="copy-dashboard-cell--dropdown-menu"
+      itemTestIdPrefix="other-dashboard"
+      sortNames={true}
+      placeholderText="Choose a Destination Dashboard"
+      defaultNameText="Name this Dashboard"
+    />
+  )
+
   return (
     <Overlay.Container maxWidth={400}>
       <Overlay.Header title="Move Cell" onDismiss={onClose} />
       <Overlay.Body className="dashboard-clonecell--overlayopen">
         <Form.Element label="" className="dashboard-clonecell--dropdownopen">
-          <Dropdown
-            className="dashboard-clonecell--dropdownopen"
-            button={(active, onClick) => (
-              <Dropdown.Button
-                active={active}
-                onClick={onClick}
-                testID="clone-to-other-dashboard"
-              >
-                {selectedDashboard ?? 'Choose a Destination Dashboard'}
-              </Dropdown.Button>
-            )}
-            menu={onCollapse => (
-              <Dropdown.Menu
-                onCollapse={onCollapse}
-                testID="copy-dashboard-cell--dropdown-menu"
-              >
-                {otherDashboards.map(d => {
-                  return (
-                    <Dropdown.Item
-                      key={d.id}
-                      value={d.id}
-                      onClick={id => setDestinationDashboardID(id)}
-                      selected={d.id === destinationDashboardID}
-                      testID={`other-dashboard-${d.id}`}
-                    >
-                      {d.name ?? 'Name this Dashboard'}
-                    </Dropdown.Item>
-                  )
-                })}
-              </Dropdown.Menu>
-            )}
-          />
+          {typeAheadDropdown}
         </Form.Element>
         <Form.Element label="" className="dashboard-clonecell--removecurrent">
           <span className="dashboard-clonecell--movetype">Move type: </span>

--- a/src/shared/components/cells/CellCloneOverlay.tsx
+++ b/src/shared/components/cells/CellCloneOverlay.tsx
@@ -5,7 +5,6 @@ import {useDispatch, useSelector} from 'react-redux'
 import {OverlayContext} from 'src/overlays/components/OverlayController'
 // Clockface
 import {
-  Dropdown,
   Button,
   Overlay,
   ComponentColor,
@@ -136,15 +135,12 @@ const CellCloneOverlay: FC = () => {
     )
   }
 
-  const selectedDashboard = otherDashboards.find(
+  const selectedDashboard  = otherDashboards.find(
     d => d.id === destinationDashboardID
-  )?.name
+  )
 
-  // otherDashboards.sort((dash1, dash2) => {
-  //   return dash1.name.localeCompare(dash2.name)
-  // })
+  console.log('has a selected dash??? 44a-jill', selectedDashboard)
 
-  console.log('UNsorted dashes??', otherDashboards)
   const dashItems = otherDashboards as SelectableItem[]
 
   const onDashSelection = item => {
@@ -159,6 +155,7 @@ const CellCloneOverlay: FC = () => {
       menuTestID="copy-dashboard-cell--dropdown-menu"
       itemTestIdPrefix="other-dashboard"
       sortNames={true}
+      selectedOption={selectedDashboard as SelectableItem}
       placeholderText="Choose a Destination Dashboard"
       defaultNameText="Name this Dashboard"
     />


### PR DESCRIPTION
Closes #2993 

uses the new type-ahead clockface component to enable search on the dropdown; plus alphabetizing the entries (in ascending order)

