### PR TITLE
chore: update KNXListener to knx_listener

### DIFF
--- a/src/writeData/components/telegrafInputPluginsConfigurationText/knx_listener.conf
+++ b/src/writeData/components/telegrafInputPluginsConfigurationText/knx_listener.conf
@@ -1,5 +1,5 @@
 # Listener capable of handling KNX bus messages provided through a KNX-IP Interface.
-[[inputs.KNXListener]]
+[[inputs.knx_listener]]
   ## Type of KNX-IP interface.
   ## Can be either "tunnel" or "router".
   # service_type = "tunnel"
@@ -8,7 +8,7 @@
   service_address = "localhost:3671"
 
   ## Measurement definition(s)
-  # [[inputs.KNXListener.measurement]]
+  # [[inputs.knx_listener.measurement]]
   #   ## Name of the measurement
   #   name = "temperature"
   #   ## Datapoint-Type (DPT) of the KNX messages
@@ -16,7 +16,7 @@
   #   ## List of Group-Addresses (GAs) assigned to the measurement
   #   addresses = ["5/5/1"]
 
-  # [[inputs.KNXListener.measurement]]
+  # [[inputs.knx_listener.measurement]]
   #   name = "illumination"
   #   dpt = "9.004"
   #   addresses = ["5/5/3"]

--- a/src/writeData/components/telegrafPlugins/knx_listener.md
+++ b/src/writeData/components/telegrafPlugins/knx_listener.md
@@ -11,7 +11,7 @@ This is a sample config for the plugin.
 
 ```toml
 # Listener capable of handling KNX bus messages provided through a KNX-IP Interface.
-[[inputs.KNXListener]]
+[[inputs.knx_listener]]
   ## Type of KNX-IP interface.
   ## Can be either "tunnel" or "router".
   # service_type = "tunnel"
@@ -20,7 +20,7 @@ This is a sample config for the plugin.
   service_address = "localhost:3671"
 
   ## Measurement definition(s)
-  # [[inputs.KNXListener.measurement]]
+  # [[inputs.knx_listener.measurement]]
   #   ## Name of the measurement
   #   name = "temperature"
   #   ## Datapoint-Type (DPT) of the KNX messages
@@ -28,7 +28,7 @@ This is a sample config for the plugin.
   #   ## List of Group-Addresses (GAs) assigned to the measurement
   #   addresses = ["5/5/1"]
 
-  # [[inputs.KNXListener.measurement]]
+  # [[inputs.knx_listener.measurement]]
   #   name = "illumination"
   #   dpt = "9.004"
   #   addresses = ["5/5/3"]

--- a/src/writeData/constants/contentTelegrafPlugins.ts
+++ b/src/writeData/constants/contentTelegrafPlugins.ts
@@ -950,7 +950,7 @@ export const WRITE_DATA_TELEGRAF_PLUGINS: TelegrafPluginAssets[] = [
     image: kinesis_consumerLogo,
   },
   {
-    id: 'KNXListener',
+    id: 'knx_listener',
     name: 'KNX',
     markdown: knx_listenerMarkdown,
     image: knx_listenerLogo,

--- a/src/writeData/utils/parsePluginsConfigurationText.ts
+++ b/src/writeData/utils/parsePluginsConfigurationText.ts
@@ -105,7 +105,7 @@ const inputPluginsList = [
   'kernel_vmstat',
   'kibana',
   'kinesis_consumer',
-  'KNXListener',
+  'knx_listener',
   'kube_inventory',
   'kubernetes',
   'lanz',


### PR DESCRIPTION
Closes #3163 

Changes `KNXListener` to `knx_listener` everywhere. Per the Telegraf Team, the correct name is `knx_listener`
