### PR TITLE
fix: allow continue Telegraf config editing to continue on valid default selection

### DIFF
--- a/src/writeData/components/PluginAddToExistingConfiguration/Configure.tsx
+++ b/src/writeData/components/PluginAddToExistingConfiguration/Configure.tsx
@@ -64,6 +64,8 @@ const ConfigureComponent: FC<Props> = props => {
 
   if (!selectedTelegraf) {
     setIsValidConfiguration(false)
+  } else {
+    setIsValidConfiguration(true)
   }
 
   const selectedName = selectedTelegraf


### PR DESCRIPTION
Closes #3167 

Only invalid selection was being checked. Add the check for a valid selection, so that user can continue.


https://user-images.githubusercontent.com/10736577/140585903-6eae6da3-13e7-4f60-b1c9-29d6ef405c4b.mp4

