### PR TITLE
fix: generate correct name for orgs tokens

### DIFF
--- a/src/authorizations/utils/permissions.ts
+++ b/src/authorizations/utils/permissions.ts
@@ -329,14 +329,20 @@ export const generateDescription = apiPermissions => {
     }
   } else {
     apiPermissions.forEach(perm => {
-      if (perm.resource.name) {
+      if (perm.resource.type === 'orgs') {
         generatedDescription += `${capitalize(perm.action)} ${
           perm.resource.type
-        } ${perm.resource.name} `
+        }  `
       } else {
-        generatedDescription += `${capitalize(perm.action)} ${
-          perm.resource.type
-        } `
+        if (perm.resource.name) {
+          generatedDescription += `${capitalize(perm.action)} ${
+            perm.resource.type
+          } ${perm.resource.name} `
+        } else {
+          generatedDescription += `${capitalize(perm.action)} ${
+            perm.resource.type
+          } `
+        }
       }
     })
   }


### PR DESCRIPTION
Closes #3174 

Added an if statement inside `generateDescription` function in utils that checks if received api permission array is an orgs permission. If true, the function will take org's unique data structure into account and generate its name accordingly.

Top token has correct description (fix) . Botton token is wrong (before fix) 
![Screen Shot 2021-11-08 at 12 55 53 PM](https://user-images.githubusercontent.com/66275100/140801071-bd5c6e36-ea35-404c-8fb2-09897312e985.png)
 
