### PR TITLE
fix: fix monaco editor colors after Clockface 3 release

### DIFF
--- a/src/external/monaco.flux.theme.ts
+++ b/src/external/monaco.flux.theme.ts
@@ -1,4 +1,5 @@
 import {MonacoType} from 'src/types'
+import {InfluxColors} from '@influxdata/clockface'
 
 const THEME_NAME = 'baseTheme'
 
@@ -55,8 +56,8 @@ function addTheme(monaco: MonacoType) {
     ],
     colors: {
       'editor.foreground': '#F8F8F8',
-      'editor.background': '#202028',
-      'editorGutter.background': '#25252e',
+      'editor.background': InfluxColors.Grey15,
+      'editorGutter.background': InfluxColors.Grey15,
       'editor.selectionBackground': '#353640',
       'editorLineNumber.foreground': '#666978',
       'editor.lineHighlightBackground': '#353640',

--- a/src/shared/components/FluxMonacoEditor.scss
+++ b/src/shared/components/FluxMonacoEditor.scss
@@ -13,7 +13,11 @@
   }
 
   .minimap {
-    border-left: 2px solid #25252e;
+    border-left: 2px solid #4d4d60;
+
+    .minimap-decorations-layer {
+      background-color: #1a1a2a;
+    }
 
     .minimap-slider {
       background: rgba(53, 54, 64, 0.4);
@@ -37,10 +41,6 @@
 
   .scroll-decoration {
     box-shadow: #1b1b1b 0 6px 6px -6px inset;
-  }
-
-  .margin {
-    background: #25252e;
   }
 
   .current-line ~ .line-numbers {


### PR DESCRIPTION
Closes #2995 

Just better colors for the Monaco editor so it fits in with the new Clockface 3 release. 

<img width="1535" alt="Capture d’écran, le 2021-11-08 à 1 22 12 PM" src="https://user-images.githubusercontent.com/18511823/140813158-30f9e5bb-b797-4977-9514-b86ba941968d.png">

<img width="971" alt="Capture d’écran, le 2021-11-08 à 1 21 52 PM" src="https://user-images.githubusercontent.com/18511823/140813166-255e6d83-00b0-4b40-a5ed-75523e55d9d6.png">


