### PR TITLE
test: another take at the flaky flows test

### DIFF
--- a/cypress/e2e/shared/flows.test.ts
+++ b/cypress/e2e/shared/flows.test.ts
@@ -200,6 +200,7 @@ describe('Flows', () => {
       .first()
       .click()
     cy.getByTestID('time-machine-submit-button').should('be.visible')
+    cy.intercept('PATCH', '**/notebooks/*').as('updateNotebook')
 
     cy.getByTestID('page-title').click()
     cy.getByTestID('renamable-page-title--input').type(`${flowName}`)
@@ -234,6 +235,8 @@ describe('Flows', () => {
       .within(() => {
         cy.getByTestID(`selector-list beans`).click()
       })
+
+    cy.wait('@updateNotebook')
 
     cy.getByTestID('time-machine-submit-button').click()
 


### PR DESCRIPTION
This changes the test to wait on the `PATCH` request after editing the notebook before navigating away from the page. Passed 20x locally with firefox