### PR TITLE
fix: templates page font sizes

### DIFF
--- a/src/templates/components/CommunityTemplateHumanReadableResource.tsx
+++ b/src/templates/components/CommunityTemplateHumanReadableResource.tsx
@@ -11,17 +11,18 @@ import {event} from 'src/cloud/utils/reporting'
 // Types
 import {
   AppState,
-  Dashboard,
-  Task,
-  Label,
   Bucket,
-  Telegraf,
-  Variable,
-  ResourceType,
   Check,
+  Dashboard,
+  Label,
   NotificationEndpoint,
   NotificationRule,
+  ResourceType,
+  Task,
+  Telegraf,
+  Variable,
 } from 'src/types'
+import {Heading, HeadingElement} from '@influxdata/clockface'
 
 interface ComponentProps {
   link: string
@@ -51,7 +52,7 @@ const CommunityTemplateHumanReadableResourceUnconnected: FC<Props> = ({
 
   return (
     <Link to={link} onClick={recordClick}>
-      <code>{humanName}</code>
+      <Heading element={HeadingElement.H5}><code>{humanName}</code></Heading>
     </Link>
   )
 }

--- a/src/templates/components/CommunityTemplateHumanReadableResource.tsx
+++ b/src/templates/components/CommunityTemplateHumanReadableResource.tsx
@@ -52,7 +52,9 @@ const CommunityTemplateHumanReadableResourceUnconnected: FC<Props> = ({
 
   return (
     <Link to={link} onClick={recordClick}>
-      <Heading element={HeadingElement.H5}><code>{humanName}</code></Heading>
+      <Heading element={HeadingElement.H5}>
+        <code>{humanName}</code>
+      </Heading>
     </Link>
   )
 }

--- a/src/templates/components/CommunityTemplatesResourceSummary.tsx
+++ b/src/templates/components/CommunityTemplatesResourceSummary.tsx
@@ -49,7 +49,9 @@ export const CommunityTemplatesResourceSummary: FC<Props> = ({
       case 'Bucket': {
         return (
           <tr key={`${resource.templateMetaName}-${stackID}-${resource.kind}`}>
-            <td><Heading element={HeadingElement.H5}>{resource.kind}</Heading></td>
+            <td>
+              <Heading element={HeadingElement.H5}>{resource.kind}</Heading>
+            </td>
             <td>
               <CommunityTemplateHumanReadableResource
                 link={`/orgs/${orgID}/load-data/buckets`}
@@ -194,7 +196,9 @@ export const CommunityTemplatesResourceSummary: FC<Props> = ({
         onClick={handleToggleTable}
       >
         <Icon className={caretClassName} glyph={IconFont.CaretRight} />
-        <Heading element={HeadingElement.H4} style={{lineHeight: '40px'}}>{toggleText}</Heading>
+        <Heading element={HeadingElement.H4} style={{lineHeight: '40px'}}>
+          {toggleText}
+        </Heading>
       </div>
       {summaryState === 'expanded' && (
         <table className="community-templates--resources-table">

--- a/src/templates/components/CommunityTemplatesResourceSummary.tsx
+++ b/src/templates/components/CommunityTemplatesResourceSummary.tsx
@@ -3,7 +3,7 @@ import React, {FC, useState} from 'react'
 import classnames from 'classnames'
 
 // Components
-import {Icon, IconFont} from '@influxdata/clockface'
+import {Heading, HeadingElement, Icon, IconFont} from '@influxdata/clockface'
 import {CommunityTemplateHumanReadableResource} from 'src/templates/components/CommunityTemplateHumanReadableResource'
 
 // Types
@@ -49,7 +49,7 @@ export const CommunityTemplatesResourceSummary: FC<Props> = ({
       case 'Bucket': {
         return (
           <tr key={`${resource.templateMetaName}-${stackID}-${resource.kind}`}>
-            <td>{resource.kind}</td>
+            <td><Heading element={HeadingElement.H5}>{resource.kind}</Heading></td>
             <td>
               <CommunityTemplateHumanReadableResource
                 link={`/orgs/${orgID}/load-data/buckets`}
@@ -194,7 +194,7 @@ export const CommunityTemplatesResourceSummary: FC<Props> = ({
         onClick={handleToggleTable}
       >
         <Icon className={caretClassName} glyph={IconFont.CaretRight} />
-        <h6>{toggleText}</h6>
+        <Heading element={HeadingElement.H4} style={{lineHeight: '40px'}}>{toggleText}</Heading>
       </div>
       {summaryState === 'expanded' && (
         <table className="community-templates--resources-table">

--- a/src/templates/containers/CommunityTemplates.scss
+++ b/src/templates/containers/CommunityTemplates.scss
@@ -99,6 +99,7 @@
 }
 
 .community-templates--resources-table {
+  margin-left: 1.4em;
   & > tbody > tr > td {
     padding-right: $cf-space-2xs;
     font-size: 13px;
@@ -108,10 +109,6 @@
 .community-templates--resources-table-toggle {
   display: flex;
   align-items: center;
-
-  h6 {
-    margin: 0;
-  }
 
   &:hover {
     cursor: pointer;


### PR DESCRIPTION
Closes #3023

Minor UI fixes.

Before:

<img width="1518" alt="Capture d’écran, le 2021-11-08 à 4 22 35 PM" src="https://user-images.githubusercontent.com/18511823/140833894-aa972592-5dd9-4d0f-8256-fc586aacc1ee.png">

After: 

<img width="1477" alt="Capture d’écran, le 2021-11-08 à 4 03 46 PM" src="https://user-images.githubusercontent.com/18511823/140833801-bd66a070-56c9-477a-b8a5-268452ec8d2d.png">

<!-- Describe your proposed changes here. -->
