### PR TITLE
fix: new icon for the load data menu item in nav bar.

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
   },
   "dependencies": {
     "@docsearch/react": "^3.0.0-alpha.37",
-    "@influxdata/clockface": "^3.1.3",
+    "@influxdata/clockface": "^3.1.5",
     "@influxdata/flux": "^0.5.1",
     "@influxdata/flux-lsp-browser": "^0.5.53",
     "@influxdata/giraffe": "^2.20.0",

--- a/src/pageLayout/constants/navigationHierarchy.ts
+++ b/src/pageLayout/constants/navigationHierarchy.ts
@@ -40,7 +40,7 @@ export const generateNavItems = (): NavItem[] => {
     {
       id: 'load-data',
       testID: 'nav-item-load-data',
-      icon: IconFont.Ingest_New,
+      icon: IconFont.Upload_New,
       label: 'Load Data',
       shortLabel: 'Data',
       link: `${orgPrefix}/load-data/sources`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -855,10 +855,10 @@
     "@docsearch/css" "3.0.0-alpha.37"
     algoliasearch "^4.0.0"
 
-"@influxdata/clockface@^3.1.3":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-3.1.3.tgz#d6e4484f55d323909fc06ccfc14dc689c334a823"
-  integrity sha512-0hAW+ZDsherbOTd+kUI57NFbgd8xp06he0vR3YtozmkO0pXHEF5YiDN+1i0OeMczJaF0gGVEF48i07nnzDjvkQ==
+"@influxdata/clockface@^3.1.5":
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-3.1.5.tgz#d3a073351f35905e8aa937d66189a702a4055521"
+  integrity sha512-A2twQYz50XVU7zTVtkEGN5VghSdsyEbF1HbuiDt8ecyI1si7x2j853eHiMtZgeXCoDxAqkhp4ifys/3Vz2rJng==
 
 "@influxdata/flux-lsp-browser@^0.5.53":
   version "0.5.53"


### PR DESCRIPTION
Closes https://github.com/influxdata/clockface/issues/683

Replaces the Load data icon. Screenshot:

<img width="86" alt="Capture d’écran, le 2021-11-09 à 11 46 49 AM" src="https://user-images.githubusercontent.com/18511823/140985713-2ecaf1e5-af9d-48e0-b3d4-e0836a3798ba.png">

