### PR TITLE
fix: fix rudderstack feature flag name

### DIFF
--- a/src/billing/components/PayAsYouGo/CancellationOverlay.tsx
+++ b/src/billing/components/PayAsYouGo/CancellationOverlay.tsx
@@ -58,7 +58,7 @@ const CancellationOverlay: FC<Props> = ({onHideOverlay}) => {
     }
 
     if (
-      isFlagEnabled('rudderStackReporting') &&
+      isFlagEnabled('rudderstackReporting') &&
       isFlagEnabled('trackCancellations')
     ) {
       // Send to Rudderstack

--- a/src/billing/components/PayAsYouGo/CancellationPanel.tsx
+++ b/src/billing/components/PayAsYouGo/CancellationPanel.tsx
@@ -27,7 +27,7 @@ const CancellationPanel: FC = () => {
   const handleCancelService = () => {
     if (
       isFlagEnabled('trackCancellations') &&
-      isFlagEnabled('rudderStackReporting')
+      isFlagEnabled('rudderstackReporting')
     ) {
       const payload = {
         org: org.id,

--- a/src/me/actions/thunks/index.ts
+++ b/src/me/actions/thunks/index.ts
@@ -45,7 +45,7 @@ export const getMe = () => async (
       user_id: user.id,
     })
 
-    if (CLOUD && isFlagEnabled('rudderStackReporting')) {
+    if (CLOUD && isFlagEnabled('rudderstackReporting')) {
       const state = getState()
       const org = getOrg(state)
       identify(user.id, {email: user.name, orgID: org.id})

--- a/src/organizations/components/DeleteOrgOverlay.tsx
+++ b/src/organizations/components/DeleteOrgOverlay.tsx
@@ -75,7 +75,7 @@ const DeleteOrgOverlay: FC = () => {
     }
 
     if (
-      isFlagEnabled('rudderStackReporting') &&
+      isFlagEnabled('rudderstackReporting') &&
       isFlagEnabled('trackCancellations')
     ) {
       track('DeleteOrgExecuted', payload)

--- a/src/organizations/components/OrgProfileDeletePanel.tsx
+++ b/src/organizations/components/OrgProfileDeletePanel.tsx
@@ -32,7 +32,7 @@ const OrgProfileTab: FC = () => {
   const handleShowDeleteOverlay = () => {
     if (
       isFlagEnabled('trackCancellations') &&
-      isFlagEnabled('rudderStackReporting')
+      isFlagEnabled('rudderstackReporting')
     ) {
       const payload = {
         org: org.id,


### PR DESCRIPTION
There was a typo in RudderStack Reporting flag. The actual flag name is: `rudderstackReporting` but it was typoed as `rudderStackReporting`..