### PR TITLE
chore: remove operatorRole featureflag

### DIFF
--- a/src/operator/context/operator.tsx
+++ b/src/operator/context/operator.tsx
@@ -128,9 +128,7 @@ export const OperatorProvider: FC<Props> = React.memo(({children}) => {
     status = RemoteDataState.Loading
   }
 
-  const hasWritePermissions =
-    !isFlagEnabled('operatorRole') ||
-    (quartzMe.isOperator && quartzMe?.operatorRole === 'read-write')
+  const hasWritePermissions = (quartzMe.isOperator && quartzMe?.operatorRole === 'read-write')
 
   return (
     <OperatorContext.Provider


### PR DESCRIPTION
Remove `operatorRole` feature flag. It's turned on in every environment.