### PR TITLE
feat: show bucket's ID for all buckets

### DIFF
--- a/src/buckets/components/BucketCardMeta.test.tsx
+++ b/src/buckets/components/BucketCardMeta.test.tsx
@@ -59,9 +59,9 @@ describe('bucket meta data card, testing that the schema type shows up properly'
     const card = getByTestId('resourceCard-buckets-fooabc')
 
     const schemaType = getByTestId('bucket-schemaType')
-    // should be three nodes ('system', '30 days', and 'implicit schema type')
+    // should be three nodes ('system', '30 days', and 'implicit schema type', <id string>)
 
-    expect(card.childElementCount).toEqual(3)
+    expect(card.childElementCount).toEqual(4)
 
     expect(schemaType).toHaveTextContent(IMPLICIT_TEXT)
   })
@@ -71,8 +71,8 @@ describe('bucket meta data card, testing that the schema type shows up properly'
 
     const card = getByTestId('resourceCard-buckets-fooabc')
 
-    // should be three nodes ('system', '30 days', 'implicit schema type')
-    expect(card.childElementCount).toEqual(3)
+    // should be three nodes ('system', '30 days', 'implicit schema type', <id string>)
+    expect(card.childElementCount).toEqual(4)
 
     expect(getByTestId('bucket-schemaType')).toHaveTextContent(IMPLICIT_TEXT)
   })

--- a/src/buckets/components/BucketCardMeta.tsx
+++ b/src/buckets/components/BucketCardMeta.tsx
@@ -58,19 +58,21 @@ const BucketCardMeta: FC<Props> = ({bucket, notify}) => {
     </span>
   )
   const bucketID = (
-    <CopyToClipboard text={bucket.id} onCopy={handleCopyAttempt} key={bucket.id}>
-        <span className="copy-bucket-id" title="Click to Copy to Clipboard">
-          ID: {bucket.id}
-          <span className="copy-bucket-id--helper">Copy to Clipboard</span>
-        </span>
-      </CopyToClipboard>
+    <CopyToClipboard
+      text={bucket.id}
+      onCopy={handleCopyAttempt}
+      key={bucket.id}
+    >
+      <span className="copy-bucket-id" title="Click to Copy to Clipboard">
+        ID: {bucket.id}
+        <span className="copy-bucket-id--helper">Copy to Clipboard</span>
+      </span>
+    </CopyToClipboard>
   )
 
   const bucketInfo = CLOUD
     ? [persistentBucketMeta, schemaBlock, bucketID]
     : [persistentBucketMeta, bucketID]
-
-  
 
   if (bucket.type === 'system') {
     return (

--- a/src/buckets/components/BucketCardMeta.tsx
+++ b/src/buckets/components/BucketCardMeta.tsx
@@ -57,10 +57,20 @@ const BucketCardMeta: FC<Props> = ({bucket, notify}) => {
       {schemaLabel}
     </span>
   )
+  const bucketID = (
+    <CopyToClipboard text={bucket.id} onCopy={handleCopyAttempt} key={bucket.id}>
+        <span className="copy-bucket-id" title="Click to Copy to Clipboard">
+          ID: {bucket.id}
+          <span className="copy-bucket-id--helper">Copy to Clipboard</span>
+        </span>
+      </CopyToClipboard>
+  )
 
   const bucketInfo = CLOUD
-    ? [persistentBucketMeta, schemaBlock]
-    : [persistentBucketMeta]
+    ? [persistentBucketMeta, schemaBlock, bucketID]
+    : [persistentBucketMeta, bucketID]
+
+  
 
   if (bucket.type === 'system') {
     return (
@@ -79,12 +89,6 @@ const BucketCardMeta: FC<Props> = ({bucket, notify}) => {
   return (
     <ResourceCard.Meta testID={`resourceCard-buckets-${bucket.id}`}>
       {bucketInfo}
-      <CopyToClipboard text={bucket.id} onCopy={handleCopyAttempt}>
-        <span className="copy-bucket-id" title="Click to Copy to Clipboard">
-          ID: {bucket.id}
-          <span className="copy-bucket-id--helper">Copy to Clipboard</span>
-        </span>
-      </CopyToClipboard>
     </ResourceCard.Meta>
   )
 }


### PR DESCRIPTION
Closes #1721 

**Before fix:** 
UI didn't show IDs for automated buckets like `_tasks` and `_monitoring`. 
<img width="1790" alt="Screen Shot 2021-11-10 at 10 55 56 AM" src="https://user-images.githubusercontent.com/66275100/141157640-7168ef66-dcc5-4d13-874e-cd1aa397df47.png">

**After Fix:** 
`BucketMetaCard` displays bucket ID despite bucket type
<img width="1781" alt="Screen Shot 2021-11-10 at 10 56 29 AM" src="https://user-images.githubusercontent.com/66275100/141157724-f1ed331f-038d-4340-814f-b4d765138e0f.png">


