### PR TITLE
fix: update the current task after updating task status

### DIFF
--- a/src/tasks/actions/thunks.test.ts
+++ b/src/tasks/actions/thunks.test.ts
@@ -103,14 +103,19 @@ describe('Tasks.Actions.Thunks', () => {
 
     await thunks.updateTaskStatus({...sampleTask, status: 'active'})(dispatch)
 
-    expect(dispatch.mock.calls.length).toEqual(2)
+    expect(dispatch.mock.calls.length).toEqual(3)
     expect(dispatch.mock.calls[0][0].type).toBe('EDIT_TASK')
     expect(
       dispatch.mock.calls[0][0].schema.entities.tasks[sampleTask.id]
     ).toEqual({...sampleTask, status: 'active'})
 
-    expect(dispatch.mock.calls[1][0].type).toBe('PUBLISH_NOTIFICATION')
-    expect(dispatch.mock.calls[1][0].payload.notification).toEqual(
+    expect(dispatch.mock.calls[1][0].type).toBe('SET_CURRENT_TASK')
+    expect(
+      dispatch.mock.calls[1][0].schema.entities.tasks[sampleTask.id]
+    ).toEqual({...sampleTask, status: 'active'})
+
+    expect(dispatch.mock.calls[2][0].type).toBe('PUBLISH_NOTIFICATION')
+    expect(dispatch.mock.calls[2][0].payload.notification).toEqual(
       taskUpdateSuccess()
     )
   })

--- a/src/tasks/actions/thunks.ts
+++ b/src/tasks/actions/thunks.ts
@@ -224,6 +224,7 @@ export const updateTaskStatus = (task: Task) => async (
     )
 
     dispatch(editTask(normTask))
+    dispatch(setCurrentTask(normTask))
     dispatch(notify(copy.taskUpdateSuccess()))
   } catch (e) {
     console.error(e)


### PR DESCRIPTION
Closes #3210

When on the Task runs page, toggling the task active status didn't update the page. FIXED.

The problem was an optimization made [here.](https://github.com/influxdata/ui/pull/3053/files#diff-c8f414b07947cac7332264ab0150c713ba9554309216393b7f91327b68e18774L148) That optimization removed the re-selection of the current task based on the task run's task id. Instead, the current task is updated when editing task status.

I think this is preferable, because it updates the store, which is the app's source of truth. So anyone selecting `state.resources.tasks.currentTask` can expect the store to be up to date, rather than relying on code calling the correct method.

<img src="https://user-images.githubusercontent.com/330044/141210131-a335e4af-afed-4a95-93b0-d73684ea29a6.png" />