### PR TITLE
feat: add link to template pages from dashboards dropdown

### DIFF
--- a/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
@@ -88,7 +88,7 @@ class DashboardIndex extends PureComponent<Props, State> {
                 <AddResourceDropdown
                   onSelectNew={createDashboard}
                   onSelectImport={this.summonImportOverlay}
-                  onSelectTemplate={this.summonImportFromTemplateOverlay}
+                  onSelectTemplate={this.summonTemplatePage}
                   resourceName="Dashboard"
                   limitStatus={limitStatus}
                 />
@@ -155,14 +155,14 @@ class DashboardIndex extends PureComponent<Props, State> {
     history.push(`/orgs/${orgID}/dashboards-list/import`)
   }
 
-  private summonImportFromTemplateOverlay = (): void => {
+  private summonTemplatePage = (): void => {
     const {
       history,
       match: {
         params: {orgID},
       },
     } = this.props
-    history.push(`/orgs/${orgID}/dashboards-list/import/template`)
+    history.push(`/orgs/${orgID}/settings/templates`)
   }
 }
 

--- a/src/shared/components/AddResourceDropdown.tsx
+++ b/src/shared/components/AddResourceDropdown.tsx
@@ -81,7 +81,7 @@ class AddResourceDropdown extends PureComponent<Props> {
     const importOption = this.importOption
     const newOption = this.newOption
     const templateOption = this.templateOption
-    let fromDashboard = this.props.resourceName === 'Dashboard'
+    const fromDashboard = this.props.resourceName === 'Dashboard'
 
     const templateFromDashboard = (
       <Dropdown.Item

--- a/src/shared/components/AddResourceDropdown.tsx
+++ b/src/shared/components/AddResourceDropdown.tsx
@@ -82,7 +82,7 @@ class AddResourceDropdown extends PureComponent<Props> {
     const newOption = this.newOption
     const templateOption = this.templateOption
     let fromDashboard = this.props.resourceName === 'Dashboard'
-    
+
     const templateFromDashboard = (
       <Dropdown.Item
         id={templateOption}
@@ -114,7 +114,7 @@ class AddResourceDropdown extends PureComponent<Props> {
       >
         {importOption}
       </Dropdown.Item>,
-      ...(fromDashboard ? [templateFromDashboard] : [])
+      ...(fromDashboard ? [templateFromDashboard] : []),
     ]
 
     return items

--- a/src/shared/components/AddResourceDropdown.tsx
+++ b/src/shared/components/AddResourceDropdown.tsx
@@ -80,6 +80,20 @@ class AddResourceDropdown extends PureComponent<Props> {
   private get optionItems(): JSX.Element[] {
     const importOption = this.importOption
     const newOption = this.newOption
+    const templateOption = this.templateOption
+    let fromDashboard = this.props.resourceName === 'Dashboard'
+    
+    const templateFromDashboard = (
+      <Dropdown.Item
+        id={templateOption}
+        key={templateOption}
+        onClick={this.handleSelect}
+        value={templateOption}
+        testID="add-resource-dropdown--template"
+      >
+        {templateOption}
+      </Dropdown.Item>
+    )
 
     const items = [
       <Dropdown.Item
@@ -100,6 +114,7 @@ class AddResourceDropdown extends PureComponent<Props> {
       >
         {importOption}
       </Dropdown.Item>,
+      ...(fromDashboard ? [templateFromDashboard] : [])
     ]
 
     return items
@@ -114,7 +129,7 @@ class AddResourceDropdown extends PureComponent<Props> {
   }
 
   private get templateOption(): string {
-    return `From a Template`
+    return `Add a Template`
   }
 
   private handleLimit = (): void => {


### PR DESCRIPTION
Closes #1451 

Added 'Add a Template' option inside Create Dashboard dropdown that takes user to Setting's Template page. 

https://user-images.githubusercontent.com/66275100/141349753-e028de6f-1a50-465f-b5e3-5f9bc8c19373.mov



