### PR TITLE
fix(notebooks): presentation and nav tree bugs, share warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
   },
   "dependencies": {
     "@docsearch/react": "^3.0.0-alpha.37",
-    "@influxdata/clockface": "^3.1.5",
+    "@influxdata/clockface": "^3.1.6",
     "@influxdata/flux": "^0.5.1",
     "@influxdata/flux-lsp-browser": "^0.5.53",
     "@influxdata/giraffe": "^2.20.0",

--- a/src/flows/components/FromTemplatePage.tsx
+++ b/src/flows/components/FromTemplatePage.tsx
@@ -14,6 +14,7 @@ import {
   hydrate,
 } from 'src/flows/context/flow.list'
 import {FlowProvider, FlowContext} from 'src/flows/context/flow.current'
+import {AppSettingProvider} from 'src/shared/contexts/app'
 import QueryProvider from 'src/shared/contexts/query'
 import {FlowPage} from 'src/flows/components/FlowPage'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
@@ -85,24 +86,26 @@ const FromTemplatePage: FC = () => {
   if (isFlagEnabled('ephemeralNotebook')) {
     return (
       <AppWrapper>
-        <Notifications />
-        <TooltipPortal />
-        <NotesPortal />
-        <OverlayProviderComp>
-          <OverlayController />
-        </OverlayProviderComp>
-        <EngagementLink />
-        <TreeNav />
-        <QueryProvider>
-          <FlowListProvider>
-            <FlowProvider>
-              <Switch>
-                <Route path="/notebook/from/*" component={Template} />
-                <Route component={NotFound} />
-              </Switch>
-            </FlowProvider>
-          </FlowListProvider>
-        </QueryProvider>
+        <AppSettingProvider>
+          <Notifications />
+          <TooltipPortal />
+          <NotesPortal />
+          <OverlayProviderComp>
+            <OverlayController />
+          </OverlayProviderComp>
+          <EngagementLink />
+          <TreeNav />
+          <QueryProvider>
+            <FlowListProvider>
+              <FlowProvider>
+                <Switch>
+                  <Route path="/notebook/from/*" component={Template} />
+                  <Route component={NotFound} />
+                </Switch>
+              </FlowProvider>
+            </FlowListProvider>
+          </QueryProvider>
+        </AppSettingProvider>
       </AppWrapper>
     )
   }

--- a/src/flows/components/header/Submit.scss
+++ b/src/flows/components/header/Submit.scss
@@ -8,3 +8,10 @@
 .submit-btn span {
   margin-right: 0.6em;
 }
+
+.warning-icon {
+  color: $c-thunder;
+  &:hover {
+    color: $c-pineapple;
+  }
+}

--- a/src/flows/components/header/index.tsx
+++ b/src/flows/components/header/index.tsx
@@ -15,6 +15,7 @@ import {
   ComponentColor,
   ComponentStatus,
   Dropdown,
+  ErrorTooltip,
 } from '@influxdata/clockface'
 import TimeZoneDropdown from 'src/shared/components/TimeZoneDropdown'
 import TimeRangeDropdown from 'src/flows/components/header/TimeRangeDropdown'
@@ -246,6 +247,11 @@ const FlowHeader: FC = () => {
                 </Dropdown.Menu>
               )}
               style={{width: '250px', flex: '0 0 250px'}}
+            />
+            <ErrorTooltip
+              className="warning-icon"
+              tooltipContents="By sharing this link, your org may incur charges when a user visits the page and the query is run."
+              tooltipStyle={{width: '250px'}}
             />
             <SquareButton
               icon={IconFont.Checkmark_New}

--- a/src/flows/style.scss
+++ b/src/flows/style.scss
@@ -74,6 +74,7 @@ $cf-radius-lg: $cf-radius + 4px;
 }
 
 .presentation-panel {
+  overflow: auto;
   display: flex;
   height: 100%;
   flex-direction: column;

--- a/src/pageLayout/constants/navigationHierarchy.ts
+++ b/src/pageLayout/constants/navigationHierarchy.ts
@@ -106,7 +106,7 @@ export const generateNavItems = (): NavItem[] => {
       label: PROJECT_NAME_PLURAL,
       shortLabel: PROJECT_NAME_SHORT,
       link: `${orgPrefix}/${PROJECT_NAME_PLURAL.toLowerCase()}`,
-      activeKeywords: [PROJECT_NAME_PLURAL.toLowerCase()],
+      activeKeywords: [PROJECT_NAME_PLURAL.toLowerCase(), 'notebook/from'],
     },
     {
       id: 'dashboards',

--- a/src/pageLayout/utils/index.test.ts
+++ b/src/pageLayout/utils/index.test.ts
@@ -31,7 +31,7 @@ describe('pageLayout.utils.getNavItemActivation', () => {
       false
     )
 
-    pathname = '/new/meme/reviews'
+    pathname = '/new/superb/reviews'
     expect(
       getNavItemActivation([HOMEPAGE_PATHNAME, 'account'], pathname)
     ).toEqual(false)

--- a/src/pageLayout/utils/index.test.ts
+++ b/src/pageLayout/utils/index.test.ts
@@ -71,5 +71,8 @@ describe('pageLayout.utils.getNavItemActivation', () => {
     expect(getNavItemActivation([given], `${base}${given}/${given}`)).toEqual(
       true
     )
+
+    given = 'notebook/from'
+    expect(getNavItemActivation([given], `${base}${given}`)).toEqual(true)
   })
 })

--- a/src/pageLayout/utils/index.test.ts
+++ b/src/pageLayout/utils/index.test.ts
@@ -21,7 +21,7 @@ describe('pageLayout.utils.getNavItemActivation', () => {
       getNavItemActivation([HOMEPAGE_PATHNAME, 'account'], pathname)
     ).toEqual(true)
 
-    pathname = '/orgs/3491cbaef55b4559/some-path'
+    pathname = '/orgs/3491cbaef55b4559/not-a-path'
     expect(
       getNavItemActivation([HOMEPAGE_PATHNAME, 'account'], pathname)
     ).toEqual(false)
@@ -69,21 +69,6 @@ describe('pageLayout.utils.getNavItemActivation', () => {
 
     given = 'buckets'
     expect(getNavItemActivation([given], `${base}${given}/${given}`)).toEqual(
-      true
-    )
-
-    given = 'telegrafs'
-    expect(getNavItemActivation([given], `${base}/${given}${given}`)).toEqual(
-      false
-    )
-
-    given = 'scrapers'
-    expect(
-      getNavItemActivation([given], `${base}/${given}${given}${given}`)
-    ).toEqual(false)
-
-    given = 'tokens'
-    expect(getNavItemActivation([given], `${base}////////${given}`)).toEqual(
       true
     )
   })

--- a/src/pageLayout/utils/index.ts
+++ b/src/pageLayout/utils/index.ts
@@ -1,14 +1,6 @@
-// Constants
-import {HOMEPAGE_PATHNAME} from 'src/shared/constants'
-
 export const getNavItemActivation = (
   keywords: string[],
   location: string
 ): boolean => {
-  const ignoreOrgAndOrgID = 3
-  const parentPath = location.split('/').slice(ignoreOrgAndOrgID)
-  if (!parentPath.length) {
-    parentPath.push(HOMEPAGE_PATHNAME)
-  }
-  return keywords.some(path => parentPath.includes(path))
+  return keywords.some(path => location.includes(path))
 }

--- a/src/pageLayout/utils/index.ts
+++ b/src/pageLayout/utils/index.ts
@@ -1,6 +1,12 @@
+// Constants
+import {HOMEPAGE_PATHNAME} from 'src/shared/constants'
+
 export const getNavItemActivation = (
   keywords: string[],
   location: string
 ): boolean => {
+  if (location.split('/').length <= 3) {
+    location = HOMEPAGE_PATHNAME
+  }
   return keywords.some(path => location.includes(path))
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -855,10 +855,10 @@
     "@docsearch/css" "3.0.0-alpha.37"
     algoliasearch "^4.0.0"
 
-"@influxdata/clockface@^3.1.5":
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-3.1.5.tgz#d3a073351f35905e8aa937d66189a702a4055521"
-  integrity sha512-A2twQYz50XVU7zTVtkEGN5VghSdsyEbF1HbuiDt8ecyI1si7x2j853eHiMtZgeXCoDxAqkhp4ifys/3Vz2rJng==
+"@influxdata/clockface@^3.1.6":
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-3.1.6.tgz#3e86dcf100816048a7282c835d42f70e2a642bff"
+  integrity sha512-Rq8iwozupCFrsmAg5cTwF1EhS4Hog8yNoCE2p2EwICRlPef2RArN+rqDYj+k0tljUv8WUHaL0jvcV/Mf7s9UZA==
 
 "@influxdata/flux-lsp-browser@^0.5.53":
   version "0.5.53"


### PR DESCRIPTION
Closes #3164 , #3070

## Fixes bug with presentation mode where panels were overlapping because overflow wasn't being handled

![image](https://user-images.githubusercontent.com/6411855/141387568-149a842b-2a81-4814-8e4b-93630b7298bf.png)


## Fixes bug with nav tree when creating notebook from template

![image](https://user-images.githubusercontent.com/6411855/141387585-a33c05e4-924a-4bc4-8dc0-76dadd543d10.png)

## Adds warning to notebooks sharing

![image](https://user-images.githubusercontent.com/6411855/141393630-79d86960-ec52-4ce0-b062-b2ae2cd615ed.png)


