### PR TITLE
fix: individual buckets and telegrafs names should render when Buckets and Telegrafs accordion expands 

### DIFF
--- a/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
@@ -97,9 +97,9 @@ const CustomApiTokenOverlay: FC<Props> = props => {
       })
       setPermissions(perms)
     }
-    // Each time remoteDataState changes, the useEffect hook will be called. 
-    // BUT, code inside the hook won't run until remoteDataState is 'Done'. 
-    // Only then will props.bucketPermissions.sublevelPermissions will have value. 
+    // Each time remoteDataState changes, the useEffect hook will be called.
+    // BUT, code inside the hook won't run until remoteDataState is 'Done'.
+    // Only then will props.bucketPermissions.sublevelPermissions will have value.
     // Consequently, we update the permissions state.
   }, [props.remoteDataState])
 

--- a/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
@@ -97,6 +97,10 @@ const CustomApiTokenOverlay: FC<Props> = props => {
       })
       setPermissions(perms)
     }
+    // Each time remoteDataState changes, the useEffect hook will be called. 
+    // BUT, code inside the hook won't run until remoteDataState is 'Done'. 
+    // Only then will props.bucketPermissions.sublevelPermissions will have value. 
+    // Consequently, we update the permissions state.
   }, [props.remoteDataState])
 
   const handleDismiss = () => {

--- a/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
@@ -1,6 +1,7 @@
 import React, {FC, useState, useContext, useEffect} from 'react'
 import {connect} from 'react-redux'
 import 'src/authorizations/components/redesigned/customApiTokenOverlay.scss'
+import {isEmpty} from 'lodash'
 
 // Actions
 import {getBuckets} from 'src/buckets/actions/thunks'
@@ -81,19 +82,21 @@ const CustomApiTokenOverlay: FC<Props> = props => {
   }, [])
 
   useEffect(() => {
-    const perms = {
-      otherResources: {read: false, write: false},
-    }
-    props.allResources.forEach(resource => {
-      if (resource === 'telegrafs') {
-        perms[resource] = props.telegrafPermissions
-      } else if (resource === 'buckets') {
-        perms[resource] = props.bucketPermissions
-      } else {
-        perms[resource] = {read: false, write: false}
+    if (!isEmpty(props.bucketPermissions.sublevelPermissions)) {
+      const perms = {
+        otherResources: {read: false, write: false},
       }
-    })
-    setPermissions(perms)
+      props.allResources.forEach(resource => {
+        if (resource === 'telegrafs') {
+          perms[resource] = props.telegrafPermissions
+        } else if (resource === 'buckets') {
+          perms[resource] = props.bucketPermissions
+        } else {
+          perms[resource] = {read: false, write: false}
+        }
+      })
+      setPermissions(perms)
+    }
   }, [props.remoteDataState])
 
   const handleDismiss = () => {

--- a/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
@@ -74,16 +74,14 @@ const CustomApiTokenOverlay: FC<Props> = props => {
   const [permissions, setPermissions] = useState({})
   const [searchTerm, setSearchTerm] = useState('')
   const [status, setStatus] = useState(ComponentStatus.Disabled)
-
+  
   useEffect(() => {
     props.getBuckets()
     props.getTelegrafs()
   }, [])
 
   useEffect(() => {
-    if (permissions['telegrafs'] && permissions['buckets']) {
-      return
-    }
+
     const perms = {
       otherResources: {read: false, write: false},
     }
@@ -97,7 +95,7 @@ const CustomApiTokenOverlay: FC<Props> = props => {
       }
     })
     setPermissions(perms)
-  }, [props.telegrafPermissions, props.bucketPermissions])
+  }, [props.remoteDataState])
 
   const handleDismiss = () => {
     props.onClose()
@@ -339,7 +337,6 @@ const mstp = (state: AppState) => {
     ResourceType.Buckets,
     ResourceType.Telegrafs,
   ])
-
   const telegrafs = getAll<Telegraf>(state, ResourceType.Telegrafs)
   const telegrafPermissions = {
     read: false,

--- a/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
@@ -74,14 +74,13 @@ const CustomApiTokenOverlay: FC<Props> = props => {
   const [permissions, setPermissions] = useState({})
   const [searchTerm, setSearchTerm] = useState('')
   const [status, setStatus] = useState(ComponentStatus.Disabled)
-  
+
   useEffect(() => {
     props.getBuckets()
     props.getTelegrafs()
   }, [])
 
   useEffect(() => {
-
     const perms = {
       otherResources: {read: false, write: false},
     }


### PR DESCRIPTION
Closes #3226 

Background: 
Inside CustomAPITokenOverlay component, inside mstp, we fetch all telegrafs and buckets from redux store and populate fetched data inside bucketPermissions and telegrafPermissions object. 

Then after the component mounts, the useEffect hook constructs a new permissions object (perms) using our state props (bucketPermissions and telegrafPermissions) and updates the permission state. 

Before Fix: 
everytime props.bucketPermissions and props.telegrafPermissions change, the useEffect function check if the state has telegraf and bucket property. if false -> it updates the state (permissions). which causes components to re-render. 
But just because our permissions object has telegraf and buckets properties, it doesn't mean they have sublevel permission values. This is what's causing the bug mention in #3226. 


https://user-images.githubusercontent.com/66275100/141816576-947501c8-df04-41d5-b928-a13573522c9c.mov


Fix: 

instead of updating the state inside the useEffect every time the component mounts, we are now only updating state when props.bucketPermissions has sublevelPermissions value. this brings down the amount of times we update state from 3 times to only once.


https://user-images.githubusercontent.com/66275100/141816768-02faee27-a0e2-4059-a643-01d87e297570.mov








