### PR TITLE
fix: monaco editor minimap background fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
     "lodash": "^4.17.21",
     "luxon": "^2.0.2",
     "memoize-one": "^4.0.2",
-    "monaco-editor": "^0.19.2",
+    "monaco-editor": "^0.21.0",
     "monaco-editor-textmate": "^2.2.1",
     "monaco-editor-webpack-plugin": "^1.8.2",
     "monaco-languageclient": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -187,7 +187,7 @@
     "memoize-one": "^4.0.2",
     "monaco-editor": "^0.21.0",
     "monaco-editor-textmate": "^2.2.1",
-    "monaco-editor-webpack-plugin": "^1.8.2",
+    "monaco-editor-webpack-plugin": "^2.1.0",
     "monaco-languageclient": "^0.11.0",
     "monaco-textmate": "^3.0.1",
     "normalizr": "^3.4.1",

--- a/src/external/monaco.flux.theme.ts
+++ b/src/external/monaco.flux.theme.ts
@@ -63,6 +63,7 @@ function addTheme(monaco: MonacoType) {
       'editor.lineHighlightBackground': '#353640',
       'editorCursor.foreground': '#ffffff',
       'editorActiveLineNumber.foreground': '#bec2cc',
+      "minimap.background": InfluxColors.Grey15,
     },
   })
 }

--- a/src/external/monaco.flux.theme.ts
+++ b/src/external/monaco.flux.theme.ts
@@ -63,7 +63,7 @@ function addTheme(monaco: MonacoType) {
       'editor.lineHighlightBackground': '#353640',
       'editorCursor.foreground': '#ffffff',
       'editorActiveLineNumber.foreground': '#bec2cc',
-      "minimap.background": InfluxColors.Grey15,
+      'minimap.background': InfluxColors.Grey15,
     },
   })
 }

--- a/src/shared/components/FluxMonacoEditor.scss
+++ b/src/shared/components/FluxMonacoEditor.scss
@@ -15,10 +15,6 @@
   .minimap {
     border-left: 2px solid #4d4d60;
 
-    .minimap-decorations-layer {
-      background-color: #1a1a2a;
-    }
-
     .minimap-slider {
       background: rgba(53, 54, 64, 0.4);
 

--- a/src/tasks/components/TaskForm.scss
+++ b/src/tasks/components/TaskForm.scss
@@ -14,13 +14,13 @@
 .task-form--options {
   flex: 1 0 140px;
   padding: $ix-marg-d;
+  border-right: 2px solid $cf-grey-35;
 }
 
 .task-form--editor {
   position: relative;
   flex: 6 0 0;
   border-radius: 0 $radius $radius 0;
-  margin: $ix-marg-b;
 }
 
 .task-form--form-label {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7587,10 +7587,10 @@ monaco-editor-webpack-plugin@^1.8.2:
   dependencies:
     loader-utils "^1.2.3"
 
-monaco-editor@^0.19.2:
-  version "0.19.3"
-  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.19.3.tgz#1c994b3186c00650dbcd034d5370d46bf56c0663"
-  integrity sha512-2n1vJBVQF2Hhi7+r1mMeYsmlf18hjVb6E0v5SoMZyb4aeOmYPKun+CE3gYpiNA1KEvtSdaDHFBqH9d7Wd9vREg==
+monaco-editor@^0.21.0:
+  version "0.21.3"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.21.3.tgz#3381b66614b64d1c5e3b77dd5564ad496d1b4e5d"
+  integrity sha512-9N7wATLpi+googstvtm6IKg97vPQ77FDYEpkow5tLriM/VJ0DaTRyUP4UVzcoH7KlPDX+e/rE7/imcOUeGkT6g==
 
 monaco-languageclient@^0.11.0:
   version "0.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7580,12 +7580,12 @@ monaco-editor-textmate@^2.2.1:
   resolved "https://registry.yarnpkg.com/monaco-editor-textmate/-/monaco-editor-textmate-2.2.1.tgz#93f3f1932061dd2311b92a42ea1c027cfeb3e439"
   integrity sha512-RYTNNfvyjK15M0JA8WIi9UduU10eX5724UGNKnaA8MSetehjThGENctUTuKaxPk/k3pq59QzaQ/C06A44iJd3Q==
 
-monaco-editor-webpack-plugin@^1.8.2:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-1.8.2.tgz#3721b8d9a3e2e41b154cf2a2955a7d7246c03714"
-  integrity sha512-g9G7A/lxQtpPsYaZFBqm73dwVkOziGUXExIR6iW7ksZUaiMkpvdTiE9O8edgdJGo+XtCmjycmIKB1Lt8VKbSTQ==
+monaco-editor-webpack-plugin@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-2.1.0.tgz#216bd35512a282beac7befd2fcdc5adb110403ff"
+  integrity sha512-DG7Dpo/ItWEOl/BG2egc/UIiHoCbHjq0EOF0E6eJQT+6QNZBOfSVU4GxaXG+kQJXB8rauxli96Xp1ITnNLZtSw==
   dependencies:
-    loader-utils "^1.2.3"
+    loader-utils "^2.0.0"
 
 monaco-editor@^0.21.0:
   version "0.21.3"


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/3235

* updates the `monaco-editor` version so I could bring this patch in: https://github.com/microsoft/monaco-editor/issues/2074
* changes the minimap background using the color settings instead of overriding the CSS.

<img width="566" alt="Capture d’écran, le 2021-11-15 à 2 26 03 PM" src="https://user-images.githubusercontent.com/18511823/141856920-781c58e8-7a5f-4f73-acbe-57d3f4bcb3a1.png">

<!-- Describe your proposed changes here. -->
