### PR TITLE
feat: added metrics for user events 

### DIFF
--- a/src/authorizations/actions/thunks.ts
+++ b/src/authorizations/actions/thunks.ts
@@ -139,11 +139,12 @@ export const updateAuthorization = (authorization: Authorization) => async (
     if (resp.status !== 200) {
       throw new Error(resp.data.message)
     }
-
+    event('token.edit.success', {id: authorization.id})
     dispatch(getAuthorizations())
     dispatch(notify(authorizationUpdateSuccess()))
   } catch (e) {
     console.error(e)
+    event('token.edit.failure', {id: authorization.id})
     dispatch(notify(authorizationUpdateFailed(authorization.id)))
   }
 }

--- a/src/authorizations/components/redesigned/AllAccessTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/AllAccessTokenOverlay.tsx
@@ -27,6 +27,7 @@ import {OverlayContext} from 'src/overlays/components/OverlayController'
 
 // Utils
 import {allAccessPermissions} from 'src/authorizations/utils/permissions'
+import {event} from 'src/cloud/utils/reporting'
 
 // Selectors
 import {getOrg} from 'src/organizations/selectors'
@@ -54,6 +55,7 @@ const AllAccessTokenOverlay: FC<OwnProps> = props => {
     }
     dispatch(createAuthorization(token))
     handleDismiss()
+    event('token.allAccess.success', {meID, name: description})
     dispatch(showOverlay('access-token', null, () => dismissOverlay()))
   }
 

--- a/src/authorizations/components/redesigned/AllAccessTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/AllAccessTokenOverlay.tsx
@@ -55,7 +55,7 @@ const AllAccessTokenOverlay: FC<OwnProps> = props => {
     }
     dispatch(createAuthorization(token))
     handleDismiss()
-    event('token.allAccess.success', {meID, name: description})
+    event('token.allAccess.create.success', {meID, name: description})
     dispatch(showOverlay('access-token', null, () => dismissOverlay()))
   }
 

--- a/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/CustomApiTokenOverlay.tsx
@@ -46,6 +46,7 @@ import {
   formatResources,
   generateDescription,
 } from 'src/authorizations/utils/permissions'
+import {event} from 'src/cloud/utils/reporting'
 
 import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
 
@@ -243,9 +244,11 @@ const CustomApiTokenOverlay: FC<Props> = props => {
 
     try {
       await createAuthorization(token)
+      event('customApiToken.create.success', {description})
       showOverlay('access-token', null, () => dismissOverlay())
     } catch (e) {
       setStatus(ComponentStatus.Disabled)
+      event('customApiToken.create.failure', {description})
     }
   }
 

--- a/src/authorizations/components/redesigned/EditTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/EditTokenOverlay.tsx
@@ -100,21 +100,15 @@ const EditTokenOverlay: FC<Props> = props => {
     }
   }
 
-  const onSave = async () => {
+  const onSave = () => {
     const {auth, updateAuthorization} = props
 
-    try {
-      await updateAuthorization({
-        ...auth,
-        description: description,
-        status: togglestatus ? 'active' : 'inactive',
-      })
-      event('token.edit.success', {id: auth.id, name: description})
-      handleDismiss()
-    } catch {
-      event('token.edit.failure', {id: auth.id})
-    }
-    
+    updateAuthorization({
+      ...auth,
+      description: description,
+      status: togglestatus ? 'active' : 'inactive',
+    })
+    handleDismiss()
   }
 
   return (

--- a/src/authorizations/components/redesigned/EditTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/EditTokenOverlay.tsx
@@ -117,7 +117,6 @@ const EditTokenOverlay: FC<Props> = props => {
     } catch {
       event('token.edit.failure', {id: auth.id})
     }
-    
   }
 
   return (

--- a/src/authorizations/components/redesigned/EditTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/EditTokenOverlay.tsx
@@ -31,11 +31,8 @@ import {getTelegraf} from 'src/telegrafs/actions/thunks'
 
 // Utills
 import {formatPermissionsObj} from 'src/authorizations/utils/permissions'
-<<<<<<< HEAD
 import _ from 'lodash'
-=======
 import {event} from 'src/cloud/utils/reporting'
->>>>>>> 61ffd2153 (feat: metrics added to tokens redesign)
 interface OwnProps {
   auth: Authorization
   onDismissOverlay: () => void
@@ -103,15 +100,21 @@ const EditTokenOverlay: FC<Props> = props => {
     }
   }
 
-  const onSave = () => {
+  const onSave = async () => {
     const {auth, updateAuthorization} = props
 
-    updateAuthorization({
-      ...auth,
-      description: description,
-      status: togglestatus ? 'active' : 'inactive',
-    })
-    handleDismiss()
+    try {
+      await updateAuthorization({
+        ...auth,
+        description: description,
+        status: togglestatus ? 'active' : 'inactive',
+      })
+      event('token.edit.success', {id: auth.id, name: description})
+      handleDismiss()
+    } catch {
+      event('token.edit.failure', {id: auth.id})
+    }
+    
   }
 
   return (

--- a/src/authorizations/components/redesigned/EditTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/EditTokenOverlay.tsx
@@ -103,20 +103,15 @@ const EditTokenOverlay: FC<Props> = props => {
     }
   }
 
-  const onSave = async () => {
+  const onSave = () => {
     const {auth, updateAuthorization} = props
 
-    try {
-      await updateAuthorization({
-        ...auth,
-        description: description,
-        status: togglestatus ? 'active' : 'inactive',
-      })
-      event('token.edit.success', {id: auth.id, name: description})
-      handleDismiss()
-    } catch {
-      event('token.edit.failure', {id: auth.id})
-    }
+    updateAuthorization({
+      ...auth,
+      description: description,
+      status: togglestatus ? 'active' : 'inactive',
+    })
+    handleDismiss()
   }
 
   return (

--- a/src/authorizations/components/redesigned/EditTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/EditTokenOverlay.tsx
@@ -31,7 +31,11 @@ import {getTelegraf} from 'src/telegrafs/actions/thunks'
 
 // Utills
 import {formatPermissionsObj} from 'src/authorizations/utils/permissions'
+<<<<<<< HEAD
 import _ from 'lodash'
+=======
+import {event} from 'src/cloud/utils/reporting'
+>>>>>>> 61ffd2153 (feat: metrics added to tokens redesign)
 interface OwnProps {
   auth: Authorization
   onDismissOverlay: () => void
@@ -89,7 +93,7 @@ const EditTokenOverlay: FC<Props> = props => {
 
   const changeToggle = () => {
     setStatus(ComponentStatus.Default)
-
+    event('tokens.status.updated')
     if (togglestatus) {
       setToggleStatus(false)
       setlabel('inactive')
@@ -99,15 +103,21 @@ const EditTokenOverlay: FC<Props> = props => {
     }
   }
 
-  const onSave = () => {
+  const onSave = async () => {
     const {auth, updateAuthorization} = props
 
-    updateAuthorization({
-      ...auth,
-      description: description,
-      status: togglestatus ? 'active' : 'inactive',
-    })
-    handleDismiss()
+    try {
+      await updateAuthorization({
+        ...auth,
+        description: description,
+        status: togglestatus ? 'active' : 'inactive',
+      })
+      event('token.edit.success', {id: auth.id, name: description})
+      handleDismiss()
+    } catch {
+      event('token.edit.failure', {id: auth.id})
+    }
+    
   }
 
   return (

--- a/src/authorizations/components/redesigned/GenerateTokenDropdown.tsx
+++ b/src/authorizations/components/redesigned/GenerateTokenDropdown.tsx
@@ -14,6 +14,9 @@ import {getAllResources} from 'src/authorizations/actions/thunks'
 import {notify} from 'src/shared/actions/notifications'
 import {getResourcesTokensFailure} from 'src/shared/copy/notifications'
 
+// Utils
+import {event} from 'src/cloud/utils/reporting'
+
 type GenerateTokenProps = RouteComponentProps
 type ReduxProps = ConnectedProps<typeof connector>
 
@@ -29,14 +32,17 @@ const GenerateTokenDropdown: FC<ReduxProps & GenerateTokenProps> = ({
 
   const handleAllAccess = () => {
     showOverlay('add-master-token', null, dismissOverlay)
+    event('all access overlay accessed')
   }
 
   const handleCustomApi = async () => {
     try {
       await getAllResources()
       showOverlay('add-custom-token', null, dismissOverlay)
+      event('custom API overlay accessed')
     } catch (e) {
       dispatch(notify(getResourcesTokensFailure()))
+      event('custom API overlay failed to open')
     }
   }
 

--- a/src/authorizations/components/redesigned/GenerateTokenDropdown.tsx
+++ b/src/authorizations/components/redesigned/GenerateTokenDropdown.tsx
@@ -32,17 +32,17 @@ const GenerateTokenDropdown: FC<ReduxProps & GenerateTokenProps> = ({
 
   const handleAllAccess = () => {
     showOverlay('add-master-token', null, dismissOverlay)
-    event('all access overlay accessed')
+    event('generate_token_dropdown.all_access_overlay.opened')
   }
 
   const handleCustomApi = async () => {
     try {
       await getAllResources()
       showOverlay('add-custom-token', null, dismissOverlay)
-      event('custom API overlay accessed')
+      event('generate_token_dropdown.custom_API_token_overlay.opened')
     } catch (e) {
       dispatch(notify(getResourcesTokensFailure()))
-      event('custom API overlay failed to open')
+      event('generate_token_dropdown.custom_API_token_overlay.failed')
     }
   }
 

--- a/src/authorizations/components/redesigned/TokenRow.tsx
+++ b/src/authorizations/components/redesigned/TokenRow.tsx
@@ -157,7 +157,7 @@ class TokensRow extends PureComponent<Props> {
 
   private handleClickDescription = () => {
     const {onClickDescription, auth} = this.props
-    event('edit token overlay accessed')
+    event('token_row.edit_overlay.opened')
     onClickDescription(auth.id)
   }
 

--- a/src/authorizations/components/redesigned/TokenRow.tsx
+++ b/src/authorizations/components/redesigned/TokenRow.tsx
@@ -142,7 +142,7 @@ class TokensRow extends PureComponent<Props> {
     const allTokenDescriptions = Object.values(this.props.authorizations).map(
       auth => auth.description
     )
-    
+
     try {
       await this.props.createAuthorization({
         ...this.props.auth,
@@ -153,7 +153,6 @@ class TokensRow extends PureComponent<Props> {
     } catch {
       event('token.clone.failure', {id: this.props.auth.id, name: description})
     }
-    
   }
 
   private handleClickDescription = () => {
@@ -165,7 +164,10 @@ class TokensRow extends PureComponent<Props> {
   private handleUpdateName = (value: string) => {
     const {auth, updateAuthorization} = this.props
     updateAuthorization({...auth, description: value})
-    event('token.desciption.edited', {id: this.props.auth.id, description: value})
+    event('token.desciption.edited', {
+      id: this.props.auth.id,
+      description: value,
+    })
   }
 }
 

--- a/src/authorizations/components/redesigned/TokenRow.tsx
+++ b/src/authorizations/components/redesigned/TokenRow.tsx
@@ -40,6 +40,7 @@ import {
 
 import {relativeTimestampFormatter} from 'src/shared/utils/relativeTimestampFormatter'
 import {incrementCloneName} from 'src/utils/naming'
+import {event} from 'src/cloud/utils/reporting'
 
 interface OwnProps {
   auth: Authorization
@@ -136,28 +137,35 @@ class TokensRow extends PureComponent<Props> {
     this.props.deleteAuthorization(id, description)
   }
 
-  private handleClone = () => {
+  private handleClone = async () => {
     const {description} = this.props.auth
-
     const allTokenDescriptions = Object.values(this.props.authorizations).map(
       auth => auth.description
     )
-
-    this.props.createAuthorization({
-      ...this.props.auth,
-      description: incrementCloneName(allTokenDescriptions, description),
-    })
-    this.props.showOverlay('access-token', null, () => dismissOverlay())
+    
+    try {
+      await this.props.createAuthorization({
+        ...this.props.auth,
+        description: incrementCloneName(allTokenDescriptions, description),
+      })
+      event('token.clone.success', {id: this.props.auth.id, name: description})
+      this.props.showOverlay('access-token', null, () => dismissOverlay())
+    } catch {
+      event('token.clone.failure', {id: this.props.auth.id, name: description})
+    }
+    
   }
 
   private handleClickDescription = () => {
     const {onClickDescription, auth} = this.props
+    event('edit token overlay accessed')
     onClickDescription(auth.id)
   }
 
   private handleUpdateName = (value: string) => {
     const {auth, updateAuthorization} = this.props
     updateAuthorization({...auth, description: value})
+    event('token.desciption.edited', {id: this.props.auth.id, description: value})
   }
 }
 


### PR DESCRIPTION
Closes #3132 

Added metrics for user events for the following: 
- when editing a token is a success
- when editing a token is a failure
-  when active/inactive happens (word differently)
-  when description on resource card is edited
-  when deleting a token is a success
-  when deleting a token is a failure
-  when cloning a token is a success
-  when cloning a token is a failure
-  when adding an all-access token is a success
-  when adding a custom api token is a success
-  when adding a token is a failure
-  fire each event when overlays are opened
