### PR TITLE
chore: update Giraffe

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "@influxdata/clockface": "^3.1.6",
     "@influxdata/flux": "^0.5.1",
     "@influxdata/flux-lsp-browser": "^0.5.53",
-    "@influxdata/giraffe": "^2.20.0",
+    "@influxdata/giraffe": "^2.20.2",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -870,10 +870,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/flux/-/flux-0.5.1.tgz#e39e7a7af9163fc9494422c8fed77f3ae1b68f56"
   integrity sha512-GHlkXBhSdJ2m56JzDkbnKPAqLj3/lexPooacu14AWTO4f2sDGLmzM7r0AxgdtU1M2x7EXNBwgGOI5EOAdN6mkw==
 
-"@influxdata/giraffe@^2.20.0":
-  version "2.20.0"
-  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.20.0.tgz#587e9e19edaacd9bad17555804ffd06f1594c885"
-  integrity sha512-hKNxZts+fZRhK3O5xJU8gr7w31IZcB2W9DXbL4sD5ncys6pV5vblH4fw2/kmA03N+nif+rIo7Usx/w0UjHV76w==
+"@influxdata/giraffe@^2.20.2":
+  version "2.20.2"
+  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.20.2.tgz#c59cb3b790e60a43f33b6fe9e8c3ca789c1592f3"
+  integrity sha512-cgNs5511bwAqJ9Yb79QFx1XjU7d/1zOfMzxNUf5Rc2t6lI10i4alU1IF6T4qAPEUE1rG+YvYm4F8mNrg3o+DPQ==
   dependencies:
     merge-images "^2.0.0"
 


### PR DESCRIPTION
Update Giraffe

- updates dependencies with versions suggested by dependabot for security
- adds the "repository" field in Giraffe's package.json