### PR TITLE
fix: remove maps as a vis option for OSS

### DIFF
--- a/src/visualization/types/Map/index.tsx
+++ b/src/visualization/types/Map/index.tsx
@@ -5,14 +5,14 @@ import {GeoOptions as options} from 'src/visualization/types/Map/GeoOptions'
 import {CLOUD} from 'src/shared/constants'
 
 export default register => {
-  // The maps visualization is not supported on OSS.
-  CLOUD &&
-    register({
-      type: 'geo',
-      name: 'Map',
-      graphic: icon,
-      initial: properties,
-      component: view,
-      options,
-    })
+  register({
+    type: 'geo',
+    name: 'Map',
+    graphic: icon,
+    initial: properties,
+    component: view,
+    options,
+    // Maps are not supported on OSS
+    disabled: !CLOUD,
+  })
 }

--- a/src/visualization/types/Map/index.tsx
+++ b/src/visualization/types/Map/index.tsx
@@ -2,14 +2,17 @@ import icon from 'src/visualization/types/Map/icon'
 import properties from 'src/visualization/types/Map/properties'
 import view from 'src/visualization/types/Map/view'
 import {GeoOptions as options} from 'src/visualization/types/Map/GeoOptions'
+import {CLOUD} from 'src/shared/constants'
 
 export default register => {
-  register({
-    type: 'geo',
-    name: 'Map',
-    graphic: icon,
-    initial: properties,
-    component: view,
-    options,
-  })
+  // The maps visualization is not supported on OSS.
+  CLOUD &&
+    register({
+      type: 'geo',
+      name: 'Map',
+      graphic: icon,
+      initial: properties,
+      component: view,
+      options,
+    })
 }


### PR DESCRIPTION
Closes #3247

Makes it so that maps don't show up as a visualization option in OSS.