### PR TITLE
fix: handle no bucket selected

### DIFF
--- a/src/flows/pipes/QueryBuilder/readOnly.tsx
+++ b/src/flows/pipes/QueryBuilder/readOnly.tsx
@@ -37,7 +37,9 @@ const QueryBuilder: FC<PipeProp> = ({Context}) => {
                         icon={IconFont.BucketSolid}
                         status={ComponentStatus.Disabled}
                       >
-                        {data.buckets[0].name ?? 'No Bucket Selected'}
+                        {!!data.buckets.length && data.buckets[0].name
+                          ? data.buckets[0].name
+                          : 'No Bucket Selected'}
                       </Dropdown.Button>
                     )}
                     menu={onCollapse => (

--- a/src/flows/pipes/QueryBuilder/readOnly.tsx
+++ b/src/flows/pipes/QueryBuilder/readOnly.tsx
@@ -37,7 +37,7 @@ const QueryBuilder: FC<PipeProp> = ({Context}) => {
                         icon={IconFont.BucketSolid}
                         status={ComponentStatus.Disabled}
                       >
-                        {!!data.buckets.length && data.buckets[0].name
+                        {!!data?.buckets?.length && data?.buckets?.[0]?.name
                           ? data.buckets[0].name
                           : 'No Bucket Selected'}
                       </Dropdown.Button>


### PR DESCRIPTION
Closes #3244

Previously the shared notebook would crash if no bucket was selected in query builder. This adds a safe guard so we show "No bucket selected"  instead

![image](https://user-images.githubusercontent.com/6411855/142049740-29c627da-e221-44e9-8e54-e05ff9f2ed0e.png)
