### PR TITLE
chore: remove client.user and client.setup usages

### DIFF
--- a/cypress/e2e/shared/dashboardsRefresh.test.ts
+++ b/cypress/e2e/shared/dashboardsRefresh.test.ts
@@ -148,7 +148,7 @@ describe('Dashboard refresh', () => {
         cy.getByTestID('cancel-cell-edit--button').click()
       })
 
-      const queriesMade = cy.state('requests').filter((call: any) => {
+      const queriesMade = cy.state('requests')?.filter((call: any) => {
         call.alias === 'refreshQuery'
       }).length
 

--- a/src/Setup.tsx
+++ b/src/Setup.tsx
@@ -3,7 +3,7 @@ import React, {ReactElement, PureComponent, Suspense, lazy} from 'react'
 import {Switch, Route, RouteComponentProps} from 'react-router-dom'
 
 // APIs
-import {client} from 'src/utils/api'
+import {getSetup} from 'src/client'
 
 // Components
 import {ErrorHandling} from 'src/shared/decorators/errors'
@@ -60,7 +60,8 @@ export class Setup extends PureComponent<Props, State> {
       return
     }
 
-    const {allowed} = await client.setup.status()
+    const resp = await getSetup({})
+    const {allowed} = resp.data
     this.setState({
       loading: RemoteDataState.Done,
       allowed,
@@ -80,7 +81,8 @@ export class Setup extends PureComponent<Props, State> {
 
     if (prevProps.location.pathname.includes('/onboarding/2')) {
       this.setState({loading: RemoteDataState.Loading})
-      const {allowed} = await client.setup.status()
+      const resp = await getSetup({})
+      const {allowed} = resp.data
       this.setState({allowed, loading: RemoteDataState.Done})
     }
   }

--- a/src/Signin.tsx
+++ b/src/Signin.tsx
@@ -2,8 +2,7 @@
 import React, {ReactElement, PureComponent} from 'react'
 import {Switch, Route, RouteComponentProps} from 'react-router-dom'
 import {connect, ConnectedProps} from 'react-redux'
-
-import {client} from 'src/utils/api'
+import {getMe} from 'src/client'
 
 // Components
 import {ErrorHandling} from 'src/shared/decorators/errors'
@@ -95,7 +94,10 @@ export class Signin extends PureComponent<Props, State> {
 
   private checkForLogin = async () => {
     try {
-      await client.users.me()
+      const response = await getMe({})
+      if (response.status !== 200) {
+        throw new Error(response.data.message)
+      }
       this.setState({auth: true})
       const redirectIsSet = !!getFromLocalStorage('redirectTo')
       if (redirectIsSet) {

--- a/src/dataLoaders/actions/dataLoaders.ts
+++ b/src/dataLoaders/actions/dataLoaders.ts
@@ -58,6 +58,15 @@ import {
   TelegrafConfigCreationSuccess,
   TokenCreationError,
 } from 'src/shared/copy/notifications'
+import {CLOUD} from 'src/shared/constants'
+
+let createScraper = null
+let updateScraper = null
+
+if (!CLOUD) {
+  createScraper = require('src/client').postScraper
+  updateScraper = require('src/client').patchScraper
+}
 
 const DEFAULT_COLLECTION_INTERVAL = 10000
 
@@ -624,14 +633,16 @@ export const saveScraperTarget = () => async (
 
   try {
     if (id) {
-      await client.scrapers.update(id, {url, bucketID})
+      await updateScraper({scraperTargetID: id, data: {url, bucketID}})
     } else {
-      const newTarget = await client.scrapers.create({
-        name,
-        type: ScraperTargetRequest.TypeEnum.Prometheus,
-        url,
-        bucketID,
-        orgID,
+      const newTarget = await createScraper({
+        data: {
+          name,
+          type: ScraperTargetRequest.TypeEnum.Prometheus,
+          url,
+          bucketID,
+          orgID,
+        },
       })
       dispatch(setScraperTargetID(newTarget.id))
     }

--- a/src/me/actions/thunks/index.ts
+++ b/src/me/actions/thunks/index.ts
@@ -4,8 +4,9 @@ import {identify} from 'rudder-sdk-js'
 import {Dispatch} from 'react'
 
 // API
-import {client} from 'src/utils/api'
+import {getMe as apiGetApiMe} from 'src/client'
 import {getMe as apiGetQuartzMe} from 'src/client/unityRoutes'
+
 // Utils
 import {gaEvent, updateReportingContext} from 'src/cloud/utils/reporting'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
@@ -28,7 +29,12 @@ export const getMe = () => async (
   getState: GetState
 ) => {
   try {
-    const user = await client.users.me()
+    const resp = await apiGetApiMe({})
+
+    if (resp.status !== 200) {
+      throw new Error(resp.data.message)
+    }
+    const user = resp.data
     updateReportingContext({userID: user.id, userEmail: user.name})
 
     gaEvent('cloudAppUserDataReady', {

--- a/src/onboarding/actions/index.ts
+++ b/src/onboarding/actions/index.ts
@@ -9,12 +9,11 @@ import {SetupSuccess, SetupError} from 'src/shared/copy/notifications'
 import {notify} from 'src/shared/actions/notifications'
 
 // APIs
-import {client} from 'src/utils/api'
 import * as api from 'src/client'
+import {OnboardingRequest} from 'src/client'
 
 // Types
 import {AppThunk} from 'src/types'
-import {ISetupParams} from '@influxdata/influx'
 
 export type Action =
   | SetSetupParams
@@ -24,10 +23,12 @@ export type Action =
 
 interface SetSetupParams {
   type: 'SET_SETUP_PARAMS'
-  payload: {setupParams: ISetupParams}
+  payload: {setupParams: OnboardingRequest}
 }
 
-export const setSetupParams = (setupParams: ISetupParams): SetSetupParams => ({
+export const setSetupParams = (
+  setupParams: OnboardingRequest
+): SetSetupParams => ({
   type: 'SET_SETUP_PARAMS',
   payload: {setupParams},
 })
@@ -69,14 +70,18 @@ export const setBucketID = (bucketID: string): SetBucketID => ({
 })
 
 export const setupAdmin = (
-  params: ISetupParams
+  params: OnboardingRequest
 ): AppThunk<Promise<boolean>> => async dispatch => {
   try {
     dispatch(setSetupParams(params))
-    const response = await client.setup.create(params)
+    const response = await api.postSetup({data: params})
 
-    const {id: orgID} = response.org
-    const {id: bucketID} = response.bucket
+    if (response.status !== 201) {
+      throw new Error(response.data.message)
+    }
+
+    const {id: orgID} = response.data.org
+    const {id: bucketID} = response.data.bucket
 
     dispatch(setOrganizationID(orgID))
     dispatch(setBucketID(bucketID))

--- a/src/onboarding/components/AdminStep.tsx
+++ b/src/onboarding/components/AdminStep.tsx
@@ -10,7 +10,7 @@ import OnboardingButtons from 'src/onboarding/components/OnboardingButtons'
 import {setupAdmin} from 'src/onboarding/actions'
 
 // Types
-import {ISetupParams} from '@influxdata/influx'
+import {OnboardingRequest} from 'src/client'
 import {
   Columns,
   IconFont,
@@ -25,7 +25,7 @@ import {OnboardingStepProps} from 'src/onboarding/containers/OnboardingWizard'
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
-interface State extends ISetupParams {
+interface State extends OnboardingRequest {
   confirmPassword: string
   isPassMismatched: boolean
   isPassTooShort: boolean

--- a/src/onboarding/components/CompletionStep.tsx
+++ b/src/onboarding/components/CompletionStep.tsx
@@ -18,7 +18,6 @@ import {ossMetricsTemplate} from 'src/templates/constants/defaultTemplates'
 
 // APIs
 import {getDashboards} from 'src/organizations/apis'
-import {client} from 'src/utils/api'
 import {createDashboardFromTemplate as createDashboardFromTemplateAJAX} from 'src/templates/api'
 
 // Types
@@ -34,7 +33,13 @@ import {Dashboard} from 'src/types'
 import {ScraperTargetRequest} from '@influxdata/influx'
 import {OnboardingStepProps} from 'src/onboarding/containers/OnboardingWizard'
 import {QUICKSTART_SCRAPER_TARGET_URL} from 'src/dataLoaders/constants/pluginConfigs'
+import {CLOUD} from 'src/shared/constants'
 
+let createScraper = null
+
+if (!CLOUD) {
+  createScraper = require('src/client').postScraper
+}
 interface Props extends OnboardingStepProps {
   orgID: string
   bucketID: string
@@ -134,12 +139,14 @@ class CompletionStep extends PureComponent<Props> {
 
   private handleQuickStart = async () => {
     try {
-      await client.scrapers.create({
-        name: 'new target',
-        type: ScraperTargetRequest.TypeEnum.Prometheus,
-        url: QUICKSTART_SCRAPER_TARGET_URL,
-        bucketID: this.props.bucketID,
-        orgID: this.props.orgID,
+      await createScraper({
+        data: {
+          name: 'new target',
+          type: ScraperTargetRequest.TypeEnum.Prometheus,
+          url: QUICKSTART_SCRAPER_TARGET_URL,
+          bucketID: this.props.bucketID,
+          orgID: this.props.orgID,
+        },
       })
       this.props.notify(QuickstartScraperCreationSuccess)
     } catch (err) {

--- a/src/onboarding/components/OnboardingStepSwitcher.tsx
+++ b/src/onboarding/components/OnboardingStepSwitcher.tsx
@@ -8,12 +8,12 @@ import CompletionStep from 'src/onboarding/components/CompletionStep'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 // Types
-import {ISetupParams} from '@influxdata/influx'
+import {OnboardingRequest} from 'src/client'
 import {OnboardingStepProps} from 'src/onboarding/containers/OnboardingWizard'
 
 interface Props {
   onboardingStepProps: OnboardingStepProps
-  setupParams: ISetupParams
+  setupParams: OnboardingRequest
   currentStepIndex: number
   onSetupAdmin: any
   orgID: string

--- a/src/onboarding/containers/LoginPage.tsx
+++ b/src/onboarding/containers/LoginPage.tsx
@@ -11,7 +11,9 @@ import {
 } from '@influxdata/clockface'
 import {useHistory} from 'react-router-dom'
 import Notifications from 'src/shared/components/notifications/Notifications'
-import {client} from 'src/utils/api'
+
+// API
+import {getMe} from 'src/client'
 
 // Components
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
@@ -24,7 +26,12 @@ export const LoginPage: FC = () => {
 
   const getSessionValidity = useCallback(async () => {
     try {
-      await client.users.me()
+      const resp = await getMe({})
+
+      if (resp.status !== 200) {
+        throw new Error(resp.data.message)
+      }
+
       setHasValidSession(true)
     } catch {
       setHasValidSession(false)

--- a/src/onboarding/containers/OnboardingWizard.tsx
+++ b/src/onboarding/containers/OnboardingWizard.tsx
@@ -20,7 +20,7 @@ import {setSetupParams, setStepStatus, setupAdmin} from 'src/onboarding/actions'
 import {StepStatus} from 'src/clockface/constants/wizard'
 
 // Types
-import {ISetupParams} from '@influxdata/influx'
+import {OnboardingRequest} from 'src/client'
 import {AppState} from 'src/types'
 
 export interface OnboardingStepProps {
@@ -32,8 +32,8 @@ export interface OnboardingStepProps {
   stepStatuses: StepStatus[]
   stepTitles: string[]
   stepTestIds: string[]
-  setupParams: ISetupParams
-  handleSetSetupParams: (setupParams: ISetupParams) => void
+  setupParams: OnboardingRequest
+  handleSetSetupParams: (setupParams: OnboardingRequest) => void
   notify: typeof notifyAction
   onCompleteSetup: () => void
   onExit: () => void

--- a/src/onboarding/containers/OnboardingWizardPage.tsx
+++ b/src/onboarding/containers/OnboardingWizardPage.tsx
@@ -3,7 +3,7 @@ import React, {ReactElement, PureComponent} from 'react'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // APIs
-import {client} from 'src/utils/api'
+import {getSetup} from 'src/client'
 
 // Components
 import {
@@ -47,7 +47,8 @@ export class OnboardingWizardPage extends PureComponent<Props, State> {
   public async componentDidMount() {
     this.setState({loading: RemoteDataState.Loading})
     try {
-      const {allowed} = await client.setup.status()
+      const resp = await getSetup({})
+      const {allowed} = resp.data
       if (!allowed) {
         this.setState({isSetupComplete: true})
       }

--- a/src/onboarding/containers/SigninPage.tsx
+++ b/src/onboarding/containers/SigninPage.tsx
@@ -4,7 +4,7 @@ import {withRouter, RouteComponentProps} from 'react-router-dom'
 import {connect, ConnectedProps} from 'react-redux'
 
 // APIs
-import {client} from 'src/utils/api'
+import {getSetup} from 'src/client'
 
 // Actions
 import {dismissAllNotifications} from 'src/shared/actions/notifications'
@@ -44,7 +44,8 @@ class SigninPage extends PureComponent<Props, State> {
     }
   }
   public async componentDidMount() {
-    const {allowed} = await client.setup.status()
+    const resp = await getSetup({})
+    const {allowed} = resp.data
 
     if (allowed) {
       this.props.history.push('/onboarding/0')

--- a/src/onboarding/reducers/index.ts
+++ b/src/onboarding/reducers/index.ts
@@ -3,11 +3,11 @@ import {StepStatus} from 'src/clockface/constants/wizard'
 
 // Types
 import {Action} from 'src/onboarding/actions'
-import {ISetupParams} from '@influxdata/influx'
+import {OnboardingRequest} from 'src/client'
 
 export interface OnboardingState {
   stepStatuses: StepStatus[]
-  setupParams: ISetupParams
+  setupParams: OnboardingRequest
   orgID: string
   bucketID: string
 }

--- a/src/types/scrapers.ts
+++ b/src/types/scrapers.ts
@@ -1,3 +1,3 @@
-import {ScraperTargetResponse} from '@influxdata/influx'
+import {ScraperTargetResponse} from 'src/client'
 
 export interface Scraper extends ScraperTargetResponse {}

--- a/src/types/scrapers.ts
+++ b/src/types/scrapers.ts
@@ -1,3 +1,3 @@
-import {ScraperTargetResponse} from 'src/client'
+import * as oss from 'src/client'
 
-export interface Scraper extends ScraperTargetResponse {}
+export interface Scraper extends oss.ScraperTargetResponse {}


### PR DESCRIPTION
This PR is part of a series of PRs to consolidate our API and types within one source of truth by removing the client API and removing the dependency completely.