### PR TITLE
fix: updated token delete confirmation wording

### DIFF
--- a/src/authorizations/components/redesigned/TokenRow.tsx
+++ b/src/authorizations/components/redesigned/TokenRow.tsx
@@ -98,7 +98,7 @@ class TokensRow extends PureComponent<Props> {
           icon={IconFont.Trash_New}
           shape={ButtonShape.Square}
           size={ComponentSize.ExtraSmall}
-          confirmationLabel="Yes, delete this dashboard"
+          confirmationLabel="Yes, delete this token"
           onConfirm={this.handleDelete}
           confirmationButtonText="Confirm"
           testID="context-delete-menu"


### PR DESCRIPTION
Closes #3270 

Before fix: 
when user clicks on token's delete button, the confirmation reads "Yes, delete this dashboard" 
![token](https://user-images.githubusercontent.com/66275100/142242184-bba8cf3d-3ae1-44b0-aa7a-39e85425c846.png)

After fix:
Confirmation text for deleting token reads "Yes, delete this token" 
![Screen Shot 2021-11-17 at 10 36 04 AM](https://user-images.githubusercontent.com/66275100/142242307-2f4972b2-572b-4bc4-b2a8-2e652ecbead4.png)


