### PR TITLE
fix: reenables the run on add ability

### DIFF
--- a/src/flows/context/flow.query.tsx
+++ b/src/flows/context/flow.query.tsx
@@ -217,14 +217,8 @@ export const FlowQueryProvider: FC = ({children}) => {
     // _map.current and a rerender that updates the panel view components within the same render cycle
     // leading to a panel on the list without a corresponding map entry
     const forceUpdate =
-      (flow?.data?.allIDs ?? [])
-        .slice(0)
-        .sort((a, b) => a.localeCompare(b))
-        .join(' ') !==
-      (_map.current ?? [])
-        .map(m => m.id)
-        .sort((a, b) => a.localeCompare(b))
-        .join(' ')
+      (flow?.data?.allIDs ?? []).join(' ') !==
+      (_map.current ?? []).map(m => m.id).join(' ')
 
     if (forceUpdate) {
       _generateMap()

--- a/src/flows/context/flow.query.tsx
+++ b/src/flows/context/flow.query.tsx
@@ -213,10 +213,20 @@ export const FlowQueryProvider: FC = ({children}) => {
   }, [flow])
 
   const generateMap = (): Stage[] => {
-    if (
-      !_map.current ||
-      (!_map.current.length && (flow?.data?.allIDs ?? []).length)
-    ) {
+    // this is to get around an issue where a panel is added, which triggers the useEffect that updates
+    // _map.current and a rerender that updates the panel view components within the same render cycle
+    // leading to a panel on the list without a corresponding map entry
+    const forceUpdate =
+      (flow?.data?.allIDs ?? [])
+        .slice(0)
+        .sort((a, b) => a.localeCompare(b))
+        .join(' ') !==
+      (_map.current ?? [])
+        .map(m => m.id)
+        .sort((a, b) => a.localeCompare(b))
+        .join(' ')
+
+    if (forceUpdate) {
       _generateMap()
     }
 


### PR DESCRIPTION
Closes #3232

re-enables the interface reloading on panel add / removal / cloning.

i hate this solution, because the issue feels like it's covering up a problem that is rooted more in a misrepresented responsibility, where the flow.query context needs to recalculate if it's parent context (flow.current) had manipulated a nested object, but i couldn't quite get myself to saying that the generateMap function should be owned by the flow.current context. it might very well make more sense there, but while i hem and haw over that, we can at least unbreak the interface for our users.