### PR TITLE
fix: sorting buckets across UI

### DIFF
--- a/cypress/e2e/cloud/buckets.test.ts
+++ b/cypress/e2e/cloud/buckets.test.ts
@@ -492,15 +492,15 @@ describe('Buckets', () => {
       ]
       const retentionDesc = [
         defaultBucket,
-        monitoringBucket,
         createdBucket,
+        monitoringBucket,
         tasksBucket,
       ]
       const retentionAsc = [
-        tasksBucket,
-        monitoringBucket,
         createdBucket,
         defaultBucket,
+        tasksBucket,
+        monitoringBucket,
       ]
 
       cy.getByTestID('Create Bucket').click()

--- a/cypress/e2e/oss/buckets.test.ts
+++ b/cypress/e2e/oss/buckets.test.ts
@@ -17,7 +17,7 @@ describe('Buckets', () => {
   // TODO: Skipping this until we can sort out the differences between OSS and Cloud
   it('can sort by name and retention', () => {
     const buckets = ['defbuck', '_tasks', '_monitoring']
-    const retentionDesc = ['_monitoring', '_tasks', 'defbuck']
+    const retentionDesc = ['defbuck', '_monitoring', '_tasks']
     const retentionAsc = ['defbuck', '_tasks', '_monitoring']
 
     cy.getByTestID('resource-sorter--button')

--- a/cypress/e2e/oss/buckets.test.ts
+++ b/cypress/e2e/oss/buckets.test.ts
@@ -14,7 +14,6 @@ describe('Buckets', () => {
     )
   )
 
-  // TODO: Skipping this until we can sort out the differences between OSS and Cloud
   it('can sort by name and retention', () => {
     const buckets = ['defbuck', '_tasks', '_monitoring']
     const retentionDesc = ['defbuck', '_monitoring', '_tasks']

--- a/src/authorizations/components/redesigned/IndividualAccordionBody.tsx
+++ b/src/authorizations/components/redesigned/IndividualAccordionBody.tsx
@@ -28,15 +28,14 @@ export const IndividualAccordionBody: FC<Props> = props => {
   const {resourceName, permissions, onToggle, title, disabled} = props
   let sortedPermissions
 
-  if(title === 'Individual Bucket Names') {
-      // re-order buckets: user buckets first followed by system buckets
-    const systemBuckets = permissions.splice(0,2) 
+  if (title === 'Individual Bucket Names') {
+    // re-order buckets: user buckets first followed by system buckets
+    const systemBuckets = permissions.splice(0, 2)
     sortedPermissions = [...permissions, ...systemBuckets]
   } else {
     sortedPermissions = [...permissions]
   }
-  
-  
+
   const handleReadToggle = id => {
     onToggle(resourceName, id, PermissionType.Read)
   }
@@ -90,10 +89,8 @@ export const IndividualAccordionBody: FC<Props> = props => {
       <Accordion.AccordionBodyItem className="resource-accordion-body">
         {title}
       </Accordion.AccordionBodyItem>
-      {
-      permissions
-        ? 
-        Object.keys(sortedPermissions).map(key => {
+      {permissions
+        ? Object.keys(sortedPermissions).map(key => {
             return (
               <Accordion.AccordionBodyItem
                 key={sortedPermissions[key].id}

--- a/src/authorizations/components/redesigned/IndividualAccordionBody.tsx
+++ b/src/authorizations/components/redesigned/IndividualAccordionBody.tsx
@@ -28,10 +28,19 @@ export const IndividualAccordionBody: FC<Props> = props => {
   const {resourceName, permissions, onToggle, title, disabled} = props
   let sortedPermissions
 
-  if (title === 'Individual Bucket Names') {
+  if (resourceName === 'buckets') {
     // re-order buckets: user buckets first followed by system buckets
-    const systemBuckets = permissions.splice(0, 2)
-    sortedPermissions = [...permissions, ...systemBuckets]
+    const systemBuckets = []
+    const userBuckets = []
+
+    permissions.forEach(bucket => {
+      if (bucket.name === '_monitoring' || bucket.name === '_tasks') {
+        systemBuckets.push(bucket)
+      } else {
+        userBuckets.push(bucket)
+      }
+    })
+    sortedPermissions = [...userBuckets, ...systemBuckets]
   } else {
     sortedPermissions = [...permissions]
   }

--- a/src/authorizations/components/redesigned/IndividualAccordionBody.tsx
+++ b/src/authorizations/components/redesigned/IndividualAccordionBody.tsx
@@ -26,7 +26,17 @@ interface Props {
 
 export const IndividualAccordionBody: FC<Props> = props => {
   const {resourceName, permissions, onToggle, title, disabled} = props
+  let sortedPermissions
 
+  if(title === 'Individual Bucket Names') {
+      // re-order buckets: user buckets first followed by system buckets
+    const systemBuckets = permissions.splice(0,2) 
+    sortedPermissions = [...permissions, ...systemBuckets]
+  } else {
+    sortedPermissions = [...permissions]
+  }
+  
+  
   const handleReadToggle = id => {
     onToggle(resourceName, id, PermissionType.Read)
   }
@@ -80,14 +90,16 @@ export const IndividualAccordionBody: FC<Props> = props => {
       <Accordion.AccordionBodyItem className="resource-accordion-body">
         {title}
       </Accordion.AccordionBodyItem>
-      {permissions
-        ? Object.keys(permissions).map(key => {
+      {
+      permissions
+        ? 
+        Object.keys(sortedPermissions).map(key => {
             return (
               <Accordion.AccordionBodyItem
-                key={permissions[key].id}
+                key={sortedPermissions[key].id}
                 className="resource-accordion-body"
               >
-                {accordionBody(permissions[key])}
+                {accordionBody(sortedPermissions[key])}
               </Accordion.AccordionBodyItem>
             )
           })

--- a/src/buckets/components/BucketList.tsx
+++ b/src/buckets/components/BucketList.tsx
@@ -36,7 +36,9 @@ class BucketList extends PureComponent<
     getSortedResources
   )
 
+
   public render() {
+    
     return (
       <ResourceList>
         <ResourceList.Body emptyState={this.props.emptyState}>
@@ -57,14 +59,26 @@ class BucketList extends PureComponent<
       onUpdateBucket,
       onGetBucketSchema,
     } = this.props
+   
     const sortedBuckets = this.memGetSortedResources(
       buckets,
       sortKey,
       sortDirection,
-      sortType
+      sortType,
+      
     )
+    const userBuckets = []
+    const systemBuckets = []
+    sortedBuckets.forEach(bucket => {
+      if(bucket.type === 'user') {
+        userBuckets.push(bucket)
+      }else {
+        systemBuckets.push(bucket)
+      }
+    })
+    const userAndSystemBuckets = [...userBuckets, ...systemBuckets]
 
-    return sortedBuckets.map(bucket => {
+    return userAndSystemBuckets.map(bucket => {
       return (
         <BucketCard
           key={bucket.id}

--- a/src/buckets/components/BucketList.tsx
+++ b/src/buckets/components/BucketList.tsx
@@ -36,9 +36,7 @@ class BucketList extends PureComponent<
     getSortedResources
   )
 
-
   public render() {
-    
     return (
       <ResourceList>
         <ResourceList.Body emptyState={this.props.emptyState}>
@@ -59,20 +57,19 @@ class BucketList extends PureComponent<
       onUpdateBucket,
       onGetBucketSchema,
     } = this.props
-   
+
     const sortedBuckets = this.memGetSortedResources(
       buckets,
       sortKey,
       sortDirection,
-      sortType,
-      
+      sortType
     )
     const userBuckets = []
     const systemBuckets = []
     sortedBuckets.forEach(bucket => {
-      if(bucket.type === 'user') {
+      if (bucket.type === 'user') {
         userBuckets.push(bucket)
-      }else {
+      } else {
         systemBuckets.push(bucket)
       }
     })

--- a/src/buckets/pagination/BucketList.tsx
+++ b/src/buckets/pagination/BucketList.tsx
@@ -128,9 +128,9 @@ class BucketList
     const userBuckets = []
     const systemBuckets = []
     sortedBuckets.forEach(bucket => {
-      if(bucket.type === 'user') {
+      if (bucket.type === 'user') {
         userBuckets.push(bucket)
-      }else {
+      } else {
         systemBuckets.push(bucket)
       }
     })

--- a/src/buckets/pagination/BucketList.tsx
+++ b/src/buckets/pagination/BucketList.tsx
@@ -125,9 +125,20 @@ class BucketList
       this.props.bucketCount
     )
 
+    const userBuckets = []
+    const systemBuckets = []
+    sortedBuckets.forEach(bucket => {
+      if(bucket.type === 'user') {
+        userBuckets.push(bucket)
+      }else {
+        systemBuckets.push(bucket)
+      }
+    })
+    const userAndSystemBuckets = [...userBuckets, ...systemBuckets]
+
     const buckets = []
     for (let i = startIndex; i < endIndex; i++) {
-      const bucket = sortedBuckets[i]
+      const bucket = userAndSystemBuckets[i]
       if (bucket) {
         buckets.push(
           <BucketCard

--- a/src/timeMachine/components/queryBuilder/BucketsSelector.tsx
+++ b/src/timeMachine/components/queryBuilder/BucketsSelector.tsx
@@ -14,27 +14,31 @@ import {selectBucket} from 'src/timeMachine/actions/queryBuilderThunks'
 
 // Utils
 import {getActiveQuery} from 'src/timeMachine/selectors'
-import {getAll, getStatus} from 'src/resources/selectors'
+import {getStatus} from 'src/resources/selectors'
+import {getSortedBuckets} from 'src/buckets/selectors/index'
 
 // Types
-import {AppState, Bucket, ResourceType} from 'src/types'
+import {AppState, ResourceType} from 'src/types'
 import {RemoteDataState} from 'src/types'
 
 type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps
 
-const fb = term => bucket =>
+const fb = term => bucket => 
+  
   bucket.toLocaleLowerCase().includes(term.toLocaleLowerCase())
 
 const BucketSelector: FunctionComponent<Props> = ({
-  selectedBucket,
-  bucketNames,
+  selectedBucket, 
+  sortedBucketNames, 
   bucketsStatus,
   onSelectBucket,
+  
 }) => {
   const [searchTerm, setSearchTerm] = useState('')
-  const list = bucketNames.filter(fb(searchTerm))
-
+  
+  const list = sortedBucketNames.filter(fb(searchTerm))  
+  
   const onSelect = (bucket: string) => {
     onSelectBucket(bucket, true)
   }
@@ -51,7 +55,7 @@ const BucketSelector: FunctionComponent<Props> = ({
     )
   }
 
-  if (bucketsStatus === RemoteDataState.Done && !bucketNames.length) {
+  if (bucketsStatus === RemoteDataState.Done && !sortedBucketNames.length) {
     return <BuilderCard.Empty>No buckets found</BuilderCard.Empty>
   }
 
@@ -100,13 +104,13 @@ const Selector: FunctionComponent<SelectorProps> = ({
 }
 
 const mstp = (state: AppState) => {
-  const buckets = getAll<Bucket>(state, ResourceType.Buckets)
-  const bucketNames = buckets.map(bucket => bucket.name || '')
+
+  const sortedBucketNames = getSortedBuckets(state).map(bucket => bucket.name || '')
   const bucketsStatus = getStatus(state, ResourceType.Buckets)
   const selectedBucket =
-    getActiveQuery(state).builderConfig.buckets[0] || bucketNames[0]
+    getActiveQuery(state).builderConfig.buckets[0] || sortedBucketNames[0]
 
-  return {selectedBucket, bucketNames, bucketsStatus}
+  return {selectedBucket, sortedBucketNames, bucketsStatus}
 }
 
 const mdtp = {

--- a/src/timeMachine/components/queryBuilder/BucketsSelector.tsx
+++ b/src/timeMachine/components/queryBuilder/BucketsSelector.tsx
@@ -24,21 +24,19 @@ import {RemoteDataState} from 'src/types'
 type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps
 
-const fb = term => bucket => 
-  
+const fb = term => bucket =>
   bucket.toLocaleLowerCase().includes(term.toLocaleLowerCase())
 
 const BucketSelector: FunctionComponent<Props> = ({
-  selectedBucket, 
-  sortedBucketNames, 
+  selectedBucket,
+  sortedBucketNames,
   bucketsStatus,
   onSelectBucket,
-  
 }) => {
   const [searchTerm, setSearchTerm] = useState('')
-  
-  const list = sortedBucketNames.filter(fb(searchTerm))  
-  
+
+  const list = sortedBucketNames.filter(fb(searchTerm))
+
   const onSelect = (bucket: string) => {
     onSelectBucket(bucket, true)
   }
@@ -104,8 +102,9 @@ const Selector: FunctionComponent<SelectorProps> = ({
 }
 
 const mstp = (state: AppState) => {
-
-  const sortedBucketNames = getSortedBuckets(state).map(bucket => bucket.name || '')
+  const sortedBucketNames = getSortedBuckets(state).map(
+    bucket => bucket.name || ''
+  )
   const bucketsStatus = getStatus(state, ResourceType.Buckets)
   const selectedBucket =
     getActiveQuery(state).builderConfig.buckets[0] || sortedBucketNames[0]


### PR DESCRIPTION
Closes #3080 

Before fix: 
buckets tab -> we have system buckets listed first and then the rest follow in alphabetical order.
In data explorer -> we have them all listed alphabetically. System & user buckets
lastly, in notebooks -> we have 3 categories. user, system, and sample. and buckets are listed in each category in alphabetical order

After fix: 
All three places in the UI where buckets are listed are now ordered alphabetically by bucket type (user buckets followed by system bucket) 
**Bucket Tab:** 
https://user-images.githubusercontent.com/66275100/142675310-c68da837-1354-4f5c-859b-3c44bba73680.mov
**Data Explorer:** 
https://user-images.githubusercontent.com/66275100/142675360-94ab9774-73bf-48fe-a2d2-6cae04e95987.mov
**Notebooks:** 
https://user-images.githubusercontent.com/66275100/142675445-9251966b-4a4c-4247-ad8f-5250a3b8e85e.mov


