### PR TITLE
fix: Fix broken Telegraf troubleshooting link

### DIFF
--- a/src/dataLoaders/components/verifyStep/ConnectionInformation.tsx
+++ b/src/dataLoaders/components/verifyStep/ConnectionInformation.tsx
@@ -59,7 +59,7 @@ class ConnectionInformation extends PureComponent<Props> {
   private get additionalText(): any {
     const docs = (
       <a
-        href={`https://docs.influxdata.com/telegraf/latest/administration/troubleshooting/`}
+        href={"https://docs.influxdata.com/telegraf/latest/administration/troubleshooting/"}
         target="_blank"
         rel="noreferrer"
       >

--- a/src/dataLoaders/components/verifyStep/ConnectionInformation.tsx
+++ b/src/dataLoaders/components/verifyStep/ConnectionInformation.tsx
@@ -60,7 +60,7 @@ class ConnectionInformation extends PureComponent<Props> {
   private get additionalText(): any {
     const docs = (
       <a
-        href={`https://docs.influxdata.com/telegraf/${DOCS_URL_VERSION}/administration/troubleshooting/`}
+        href={`https://docs.influxdata.com/telegraf/latest/administration/troubleshooting/`}
         target="_blank"
         rel="noreferrer"
       >

--- a/src/dataLoaders/components/verifyStep/ConnectionInformation.tsx
+++ b/src/dataLoaders/components/verifyStep/ConnectionInformation.tsx
@@ -59,7 +59,7 @@ class ConnectionInformation extends PureComponent<Props> {
   private get additionalText(): any {
     const docs = (
       <a
-        href={"https://docs.influxdata.com/telegraf/latest/administration/troubleshooting/"}
+        href="https://docs.influxdata.com/telegraf/latest/administration/troubleshooting/"
         target="_blank"
         rel="noreferrer"
       >

--- a/src/dataLoaders/components/verifyStep/ConnectionInformation.tsx
+++ b/src/dataLoaders/components/verifyStep/ConnectionInformation.tsx
@@ -3,7 +3,6 @@ import React, {PureComponent} from 'react'
 
 // Decorator
 import {ErrorHandling} from 'src/shared/decorators/errors'
-import {DOCS_URL_VERSION} from 'src/shared/constants/fluxFunctions'
 
 export enum LoadingState {
   NotStarted = 'NotStarted',


### PR DESCRIPTION
Closes influxdata/docs-v2#3439

This fixes a Telegraf troubleshooting link that is currently broken. Telegraf isn't versioned with InfluxDB, so the correct path for Telegraf links should just include `latest`. This will redirect to the latest Telegraf version.
