### PR TITLE
test: attempt to fix flaky task test by separating should and contains

### DIFF
--- a/cypress/e2e/shared/tasks.test.ts
+++ b/cypress/e2e/shared/tasks.test.ts
@@ -267,9 +267,9 @@ http.post(url: "https://foo.bar/baz", data: bytes(v: "body"))`
 
       // focused() waits for monoco editor to get input focus
       cy.focused()
-      cy.getByTestID('flux-editor')
-        .should('be.visible')
-        .contains('option task = {')
+      cy.getByTestID('flux-editor').should('be.visible')
+
+      cy.contains('option task = {')
 
       cy.getByTestID('task-form-name').should('have.value', '🦄ask (clone 1)')
       cy.getByTestID('task-form-name')


### PR DESCRIPTION
I couldn't get the test failures seen on CI locally to begin with, so I'm not sure how effective this will be.

I ran this in a loop of 10 runs a few times and had all greens.
