### PR TITLE
chore: segregate track and event for trackCancellations feat

### DIFF
--- a/src/billing/components/PayAsYouGo/CancellationOverlay.tsx
+++ b/src/billing/components/PayAsYouGo/CancellationOverlay.tsx
@@ -56,6 +56,7 @@ const CancellationOverlay: FC<Props> = ({onHideOverlay}) => {
       reason: VariableItems[reason],
       canContactForFeedback: canContactForFeedback ? 'true' : 'false',
     }
+    event('CancelServiceExecuted Event', payload)
 
     if (
       isFlagEnabled('rudderstackReporting') &&
@@ -77,15 +78,17 @@ const CancellationOverlay: FC<Props> = ({onHideOverlay}) => {
   }
 
   const handleDismiss = () => {
+    const payload = {
+      org: org.id,
+      tier: quartzMe?.accountType,
+      email: quartzMe?.email,
+    }
+    event('CancelServiceDismissed Event', payload)
+
     if (
       isFlagEnabled('rudderstackReporting') &&
       isFlagEnabled('trackCancellations')
     ) {
-      const payload = {
-        org: org.id,
-        tier: quartzMe?.accountType,
-        email: quartzMe?.email,
-      }
       // Send to Rudderstack
       track('CancelServiceDismissed', payload)
     }

--- a/src/billing/components/PayAsYouGo/CancellationPanel.tsx
+++ b/src/billing/components/PayAsYouGo/CancellationPanel.tsx
@@ -25,17 +25,17 @@ const CancellationPanel: FC = () => {
   const org = useSelector(getOrg)
 
   const handleCancelService = () => {
+    const payload = {
+      org: org.id,
+      tier: quartzMe?.accountType,
+      email: quartzMe?.email,
+    }
+    event('CancelServiceInitiation Event', payload)
+
     if (
       isFlagEnabled('trackCancellations') &&
       isFlagEnabled('rudderstackReporting')
     ) {
-      const payload = {
-        org: org.id,
-        tier: quartzMe?.accountType,
-        email: quartzMe?.email,
-      }
-
-      event('Cancel Service Initiated', payload)
       track('CancelServiceInitiation', payload)
     }
 

--- a/src/organizations/components/DeleteOrgOverlay.tsx
+++ b/src/organizations/components/DeleteOrgOverlay.tsx
@@ -50,15 +50,17 @@ const DeleteOrgOverlay: FC = () => {
   const org = useSelector(getOrg)
 
   const handleClose = () => {
+    const payload = {
+      org: org.id,
+      tier: quartzMe?.accountType,
+      email: quartzMe?.email,
+    }
+    event('DeleteOrgDismissed Event', payload)
+
     if (
       isFlagEnabled('rudderstackReporting') &&
       isFlagEnabled('trackCancellations')
     ) {
-      const payload = {
-        org: org.id,
-        tier: quartzMe?.accountType,
-        email: quartzMe?.email,
-      }
       // Send to Rudderstack
       track('DeleteOrgDismissed', payload)
     }
@@ -86,6 +88,7 @@ const DeleteOrgOverlay: FC = () => {
       suggestions,
       reason: VariableItems[reason],
     }
+    event('DeleteOrgExecuted Event', payload)
 
     if (
       isFlagEnabled('rudderstackReporting') &&

--- a/src/organizations/components/OrgProfileDeletePanel.tsx
+++ b/src/organizations/components/OrgProfileDeletePanel.tsx
@@ -30,17 +30,17 @@ const OrgProfileTab: FC = () => {
   const dispatch = useDispatch()
 
   const handleShowDeleteOverlay = () => {
+    const payload = {
+      org: org.id,
+      tier: quartzMe?.accountType,
+      email: quartzMe?.email,
+    }
+    event('DeleteOrgInitiation Event', payload)
+
     if (
       isFlagEnabled('trackCancellations') &&
       isFlagEnabled('rudderstackReporting')
     ) {
-      const payload = {
-        org: org.id,
-        tier: quartzMe?.accountType,
-        email: quartzMe?.email,
-      }
-
-      event('Delete Organization Initiated', payload)
       track('DeleteOrgInitiation', payload)
     }
 


### PR DESCRIPTION
Part of: #3322

Issue: Snowflake has been receiving data for a long while now. Rudderstack flag (rudderstackReporting) has been turned off and still the data has been reaching snowflake. We need to investigate, what's sending(leaking) data to rudderstack in order to get some clarity on the functionality which wasn't intended to be turned on yet.

One of the examples of the data in Snowflake which isn't being sent by `track` is: `loadTagSelectorValues function`. This is being sent only by `event`. I need to figure out if `/api/v2/app-metrics` is sending data to snowflake. I have reached out to Bucky as well as Ana and seems like they aren't sending data to snowflake. Ana will further investigate.

**Interim Solution:** In the meantime, I would like to segregate `event` and `track` to get clarity if event will be sending data to snowflake or not when rudderstack is turned off. Currently, both these events are happening in the condition where `rudderstackReporting` and `trackCancellations` are enabled. So, moving out event and sending it in all cases.