### PR TITLE
chore: add eventing on checkout success

### DIFF
--- a/src/checkout/context/checkout.tsx
+++ b/src/checkout/context/checkout.tsx
@@ -32,6 +32,7 @@ import {PAYG_CREDIT_EXPERIMENT_ID} from 'src/shared/constants'
 import {CreditCardParams, RemoteDataState} from 'src/types'
 import {getErrorMessage} from 'src/utils/api'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import {event} from 'src/cloud/utils/reporting'
 
 export type Props = {
   children: JSX.Element
@@ -310,6 +311,9 @@ export const CheckoutProvider: FC<Props> = React.memo(({children}) => {
           throw new Error(response.data.message)
         }
 
+        event('CheckoutSuccess', {
+          creditApplied: isPaygCreditActive ? 'true' : 'false',
+        })
         setCheckoutStatus(RemoteDataState.Done)
       } catch (error) {
         console.error(error)


### PR DESCRIPTION
After successful checkout from free to payg, sent an event log denoting whether PAYG credit was applied or not as payload.