### PR TITLE
fix: remove persistent scrollbar on paginated token list

### DIFF
--- a/src/authorizations/pagination/TokenList.tsx
+++ b/src/authorizations/pagination/TokenList.tsx
@@ -104,7 +104,7 @@ export default class TokenList extends PureComponent<Props, State> {
             style={{
               maxHeight: this.props.pageHeight,
               minHeight: this.props.pageHeight,
-              overflow: 'scroll',
+              overflow: 'auto',
             }}
             testID="token-list"
           >


### PR DESCRIPTION
Closes #3324

overflow was set to `scroll` instead of `auto`.

See https://github.com/influxdata/ui/pull/2809/ which is a previous fix for the same issue on tokens and buckets
