### PR TITLE
fix: remove space from PagerDuty in notebook alert cells

### DIFF
--- a/src/flows/pipes/Notification/endpoints/PagerDuty/index.ts
+++ b/src/flows/pipes/Notification/endpoints/PagerDuty/index.ts
@@ -5,7 +5,7 @@ import PagerDutyReadOnly from './readOnly'
 export default register => {
   register({
     type: 'pagerduty',
-    name: 'Pager Duty',
+    name: 'PagerDuty',
     data: {
       url: '',
       key: '',


### PR DESCRIPTION
The registered trademark name for PagerDuty does not include a space. This change updates the name for the endpoint selector in notebook alert cells to use the trademarked name.
