### PR TITLE
fix: recent dashboards wrapping

### DIFF
--- a/src/me/containers/MePage.scss
+++ b/src/me/containers/MePage.scss
@@ -14,7 +14,7 @@
 
 .recent-dashboards--item {
   margin-bottom: $cf-space-2xs;
-  white-space: pre-wrap;
+  white-space: nowrap;
   word-break: break-all;
   padding-right: $cf-space-s;
 }


### PR DESCRIPTION
Closes #3219

with @appletreeisyellow

Previously long dashboard names would wrap in the Recent Dashboards widget and made it look weird. This changes the css to `nowrap` which will add a horizontal scrollbar if the dashboard name overflows.

![image](https://user-images.githubusercontent.com/6411855/144321533-5d341ebb-acdb-4453-ab83-2c2b9fd5f055.png)
