### PR TITLE
fix: typo in billing stats while loading

### DIFF
--- a/src/usage/BillingStatsPanel.tsx
+++ b/src/usage/BillingStatsPanel.tsx
@@ -41,7 +41,9 @@ const BillingStatsPanel: FC = () => {
           data-testid="usage-billing--title"
         >
           <h4 className="usage--billing-date-range">
-            {`Billing Stats For ${billingDate} to Today`}
+            {billingDate
+              ? `Billing Stats For ${billingDate} to Today`
+              : 'Billing Stats'}
           </h4>
         </ReflessPopover>
         <QuestionMarkTooltip


### PR DESCRIPTION
Closes #3062

with @appletreeisyellow

While the billing data is loading, we want the header to say "Billing Stats" instead of "Billing stats for to today" which looks like a typo. 

Loading:
![image](https://user-images.githubusercontent.com/6411855/144323115-22daa1ba-cd29-406a-a6b6-fc93f68d6ec2.png)

Done loading:
![image](https://user-images.githubusercontent.com/6411855/144323187-9dc90b7d-5da5-4479-80d9-e963ef65a287.png)
