### PR TITLE
fix: add more column width specs

### DIFF
--- a/src/buckets/components/BucketsTab.tsx
+++ b/src/buckets/components/BucketsTab.tsx
@@ -110,7 +110,8 @@ class BucketsTab extends PureComponent<Props, State> {
             <Grid.Column
               widthXS={Columns.Twelve}
               widthSM={Columns.Eight}
-              widthMD={Columns.Ten}
+              widthMD={Columns.Nine}
+              widthLG={Columns.Ten}
             >
               <FilterBuckets
                 searchTerm={searchTerm}
@@ -140,7 +141,8 @@ class BucketsTab extends PureComponent<Props, State> {
             <Grid.Column
               widthXS={Columns.Twelve}
               widthSM={Columns.Four}
-              widthMD={Columns.Two}
+              widthMD={Columns.Three}
+              widthLG={Columns.Two}
             >
               <BucketExplainer />
             </Grid.Column>

--- a/src/buckets/pagination/BucketsTab.tsx
+++ b/src/buckets/pagination/BucketsTab.tsx
@@ -152,7 +152,8 @@ class BucketsTab extends PureComponent<Props, State> {
                   <Grid.Column
                     widthXS={Columns.Twelve}
                     widthSM={Columns.Eight}
-                    widthMD={Columns.Ten}
+                    widthMD={Columns.Nine}
+                    widthLG={Columns.Ten}
                   >
                     <FilterBuckets
                       searchTerm={searchTerm}
@@ -190,7 +191,8 @@ class BucketsTab extends PureComponent<Props, State> {
                   <Grid.Column
                     widthXS={Columns.Twelve}
                     widthSM={Columns.Four}
-                    widthMD={Columns.Two}
+                    widthMD={Columns.Three}
+                    widthLG={Columns.Two}
                   >
                     <BucketExplainer />
                   </Grid.Column>


### PR DESCRIPTION
Closes #3030

with @appletreeisyellow

Adds another grid width to the buckets tab to prevent the bucket helper text from getting too small.

https://user-images.githubusercontent.com/6411855/144333858-542d5bac-f420-4dd0-88b0-04ecb4f8e6bc.mov


