### PR TITLE
chore: fix sass deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
   },
   "dependencies": {
     "@docsearch/react": "^3.0.0-alpha.37",
-    "@influxdata/clockface": "^3.1.7",
+    "@influxdata/clockface": "^3.1.8",
     "@influxdata/flux": "^0.5.1",
     "@influxdata/flux-lsp-browser": "^0.5.53",
     "@influxdata/giraffe": "^2.20.3",

--- a/src/annotations/components/controlBar/AnnotationPills.scss
+++ b/src/annotations/components/controlBar/AnnotationPills.scss
@@ -13,7 +13,7 @@
   display: flex;
   align-items: center;
   padding: 0 $cf-space-2xs;
-  border-radius: ($cf-form-sm-height - $cf-space-3xs) / 2;
+  border-radius: ($cf-form-sm-height - $cf-space-3xs) * 0.5;
   background-color: $cf-grey-15;
 
   &:hover {

--- a/src/clockface/components/context_menu/ContextMenu.scss
+++ b/src/clockface/components/context_menu/ContextMenu.scss
@@ -139,7 +139,7 @@ $context-menu--arrow-size: 8px;
     }
 
     .context-menu--list:before {
-      right: calc(100% - #{$context-menu--toggle-size / 2});
+      right: calc(100% - #{$context-menu--toggle-size * 0.5});
     }
   }
 }
@@ -160,7 +160,7 @@ $context-menu--arrow-size: 8px;
     }
 
     .context-menu--list:before {
-      right: $context-menu--toggle-size / 2;
+      right: $context-menu--toggle-size * 0.5;
     }
   }
 }

--- a/src/flows/FlowVariables.scss
+++ b/src/flows/FlowVariables.scss
@@ -11,5 +11,5 @@ $flow-panel--node-dot: 16px;
 $flow-panel--insert-gap: 24px;
 
 $flow-panel--insert-connector: (
-    ($flow-header-height - $flow-panel--node-dot) / 2
+    ($flow-header-height - $flow-panel--node-dot) * 0.5
   ) + $flow-panel--insert-gap;

--- a/src/flows/components/panel/InsertCellButton.scss
+++ b/src/flows/components/panel/InsertCellButton.scss
@@ -13,7 +13,7 @@
   &:after {
     content: '';
     position: absolute;
-    left: $flow-panel--node-gap / 2;
+    left: $flow-panel--node-gap * 0.5;
     width: $cf-border;
     pointer-events: none;
     z-index: 2;
@@ -46,7 +46,7 @@
   border-radius: 50%;
   position: absolute;
   top: 50%;
-  left: $flow-panel--node-gap / 2;
+  left: $flow-panel--node-gap * 0.5;
   transform: translate(-50%, -50%);
   cursor: pointer;
   background: linear-gradient(45deg, #5c10a0 0%, #8e1fc3 100%);
@@ -58,7 +58,7 @@
 .flow-divider--collapse {
   position: absolute;
   top: 50%;
-  left: $flow-panel--node-gap / 2 + 20;
+  left: $flow-panel--node-gap * 0.5 + 20;
   transform: translate(0, -50%);
   padding: 4px 16px;
 }

--- a/src/flows/style.scss
+++ b/src/flows/style.scss
@@ -50,11 +50,11 @@ $cf-radius-lg: $cf-radius + 4px;
     // Ensures there is no visible gap
     bottom: 0;
     top: 0;
-    left: ($flow-panel--node-gap / 2) - ($cf-border / 2);
+    left: ($flow-panel--node-gap * 0.5) - ($cf-border * 0.5);
   }
 
   &:first-child::after {
-    top: ($flow-header-height - $flow-panel--node-dot) / 2;
+    top: ($flow-header-height - $flow-panel--node-dot) * 0.5;
   }
 }
 
@@ -261,7 +261,7 @@ $cf-radius-lg: $cf-radius + 4px;
 .flow-panel--title-icon {
   position: absolute;
   top: 50%;
-  right: $cf-form-sm-height / 2;
+  right: $cf-form-sm-height * 0.5;
   transform: translate(50%, -50%);
   opacity: 0;
   transition: opacity 0.25s ease;

--- a/src/pageLayout/components/RenamablePageTitle.scss
+++ b/src/pageLayout/components/RenamablePageTitle.scss
@@ -70,7 +70,7 @@ $renamable-page-title--padding: 0;
   position: absolute;
   font-size: 1.5em;
   top: 50%;
-  right: $renamable-page-title--height / 2;
+  right: $renamable-page-title--height * 0.5;
   transform: translate(50%, -50%);
   opacity: 0;
   transition: opacity 0.25s ease;

--- a/src/shared/components/Checkbox.scss
+++ b/src/shared/components/Checkbox.scss
@@ -26,7 +26,7 @@ $checkbox--h-padding: $ix-marg-c;
   }
 
   &:before {
-    left: $checkbox--size / 2;
+    left: $checkbox--size * 0.5;
     z-index: 2;
     width: $checkbox--size;
     height: $checkbox--size;
@@ -35,7 +35,7 @@ $checkbox--h-padding: $ix-marg-c;
   }
 
   &:after {
-    left: $checkbox--size / 2;
+    left: $checkbox--size * 0.5;
     z-index: 3;
     width: $checkbox--dot-size;
     height: $checkbox--dot-size;

--- a/src/shared/components/ThresholdMarkers.scss
+++ b/src/shared/components/ThresholdMarkers.scss
@@ -71,8 +71,8 @@ $threshold-marker--caret-width: 12px;
 
   &:before {
     content: '';
-    border-top: ($threshold-marker--handle-height / 2) solid transparent;
-    border-bottom: ($threshold-marker--handle-height / 2) solid transparent;
+    border-top: ($threshold-marker--handle-height * 0.5) solid transparent;
+    border-bottom: ($threshold-marker--handle-height * 0.5) solid transparent;
     display: block;
     left: 0 - $threshold-marker--caret-width;
     position: absolute;

--- a/src/shared/components/cells/Cell.scss
+++ b/src/shared/components/cells/Cell.scss
@@ -85,7 +85,7 @@ $cell--header-button-active-color: $c-pool;
   &,
   &:before,
   &:after {
-    border-radius: $ix-border / 2;
+    border-radius: $ix-border * 0.5;
     background-color: $cell--header-button-color;
     transition: background-color 0.25s ease;
   }

--- a/src/shared/components/dapperScrollbars/DapperScrollbars.scss
+++ b/src/shared/components/dapperScrollbars/DapperScrollbars.scss
@@ -20,20 +20,20 @@ $dapper-scrollbars--size: 6px;
 .dapper-scrollbars--track-x {
   height: $dapper-scrollbars--size !important;
   width: calc(100% - #{$dapper-scrollbars--size}) !important;
-  bottom: $dapper-scrollbars--size / 2 !important;
-  left: $dapper-scrollbars--size / 2 !important;
+  bottom: $dapper-scrollbars--size * 0.5 !important;
+  left: $dapper-scrollbars--size * 0.5 !important;
 }
 
 .dapper-scrollbars--track-y {
   width: $dapper-scrollbars--size !important;
   height: calc(100% - #{$dapper-scrollbars--size}) !important;
-  right: $dapper-scrollbars--size / 2 !important;
-  top: $dapper-scrollbars--size / 2 !important;
+  right: $dapper-scrollbars--size * 0.5 !important;
+  top: $dapper-scrollbars--size * 0.5 !important;
 }
 
 .dapper-scrollbars--thumb-x,
 .dapper-scrollbars--thumb-y {
-  border-radius: $dapper-scrollbars--size / 2 !important;
+  border-radius: $dapper-scrollbars--size * 0.5 !important;
 }
 
 .dapper-scrollbars--thumb-x {

--- a/src/shared/components/inlineLabels/InlineLabels.scss
+++ b/src/shared/components/inlineLabels/InlineLabels.scss
@@ -3,7 +3,7 @@
   ------------------------------------------------------------------------------
 */
 
-$inline-labels--margin: $ix-border / 2;
+$inline-labels--margin: $ix-border * 0.5;
 
 .inline-labels {
   width: 100%;
@@ -71,7 +71,7 @@ $label-edit-button-diameter: 18px; // Should be the same as the height of labels
     height: $cf-border;
     width: floor($label-edit-button-diameter * 0.5);
     background-color: $cf-white;
-    border-radius: $cf-border / 2;
+    border-radius: $cf-border * 0.5;
     transition: width 0.25s ease;
   }
 

--- a/src/shared/components/selectorList/SelectorList.scss
+++ b/src/shared/components/selectorList/SelectorList.scss
@@ -10,8 +10,8 @@ $selector-list--header-margin: $ix-marg-b + $ix-border;
   height: 100%;
 
   > * {
-    margin-left: $selector-list--margin / 2;
-    margin-right: $selector-list--margin / 2;
+    margin-left: $selector-list--margin * 0.5;
+    margin-right: $selector-list--margin * 0.5;
 
     &:first-child {
       margin-left: 0;
@@ -85,9 +85,9 @@ $selector-list--header-margin: $ix-marg-b + $ix-border;
 }
 
 .selector-list--hamburger {
-  flex: 0 0 ($selector-list--header-height / 2);
+  flex: 0 0 ($selector-list--header-height * 0.5);
   height: $ix-border;
-  border-radius: $ix-border / 2;
+  border-radius: $ix-border * 0.5;
   background-color: $cf-grey-35;
   margin-left: $selector-list--header-margin;
   position: relative;
@@ -101,7 +101,7 @@ $selector-list--header-margin: $ix-marg-b + $ix-border;
     width: 100%;
     height: 100%;
     background-color: $cf-grey-35;
-    border-radius: $ix-border / 2;
+    border-radius: $ix-border * 0.5;
     transition: background-color 0.25s ease;
   }
 

--- a/src/shared/components/tables/TableGraphs.scss
+++ b/src/shared/components/tables/TableGraphs.scss
@@ -139,7 +139,7 @@ $table-light-graph--border: $cf-grey-85;
   background-color: $table-graph--cell;
   font-weight: 500;
   color: $table-graph--text-color;
-  border: ($cf-border / 2) solid $table-graph--border;
+  border: ($cf-border * 0.5) solid $table-graph--border;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;

--- a/src/tasks/components/TasksPage.scss
+++ b/src/tasks/components/TasksPage.scss
@@ -6,7 +6,7 @@
 .hidden-tasks-alert {
   font-size: 13px;
   font-weight: 600;
-  margin-top: ($ix-border / 2);
+  margin-top: ($ix-border * 0.5);
   width: 100%;
   background-color: rgba($cf-grey-15, 0.5);
   text-align: center;

--- a/src/timeMachine/components/Queries.scss
+++ b/src/timeMachine/components/Queries.scss
@@ -15,7 +15,7 @@
   background-color: $cf-grey-5;
   padding: $cf-space-3xs;
   padding-bottom: 0;
-  border-radius: $cf-radius + ($cf-border / 2);
+  border-radius: $cf-radius + ($cf-border * 0.5);
 }
 
 .time-machine-queries--tabs {

--- a/src/timeMachine/components/RawFluxDataTable.scss
+++ b/src/timeMachine/components/RawFluxDataTable.scss
@@ -2,7 +2,7 @@
 
 .raw-flux-data-table > .fancy-scroll--container,
 .raw-flux-data-table--cell {
-  border: ($ix-border / 2) solid $cf-grey-15;
+  border: ($ix-border * 0.5) solid $cf-grey-15;
 }
 
 .raw-flux-data-table--cell {

--- a/src/timeMachine/components/builderCard/BuilderCard.scss
+++ b/src/timeMachine/components/builderCard/BuilderCard.scss
@@ -10,8 +10,8 @@ $builder-card--header-margin: $ix-marg-b + $ix-border;
   height: 100%;
 
   > * {
-    margin-left: $builder-card--margin / 2;
-    margin-right: $builder-card--margin / 2;
+    margin-left: $builder-card--margin * 0.5;
+    margin-right: $builder-card--margin * 0.5;
 
     &:first-child {
       margin-left: 0;
@@ -87,9 +87,9 @@ $builder-card--header-margin: $ix-marg-b + $ix-border;
 }
 
 .builder-card--hamburger {
-  flex: 0 0 ($builder-card--header-height / 2);
+  flex: 0 0 ($builder-card--header-height * 0.5);
   height: $ix-border;
-  border-radius: $ix-border / 2;
+  border-radius: $ix-border * 0.5;
   background-color: $cf-grey-35;
   margin-left: $builder-card--header-margin;
   position: relative;
@@ -103,7 +103,7 @@ $builder-card--header-margin: $ix-marg-b + $ix-border;
     width: 100%;
     height: 100%;
     background-color: $cf-grey-35;
-    border-radius: $ix-border / 2;
+    border-radius: $ix-border * 0.5;
     transition: background-color 0.25s ease;
   }
 

--- a/src/variables/components/VariableDropdown.scss
+++ b/src/variables/components/VariableDropdown.scss
@@ -49,7 +49,7 @@
   .hamburger {
     width: 10px;
     height: $cf-border;
-    border-radius: $cf-border / 2;
+    border-radius: $cf-border * 0.5;
     position: absolute;
     top: 50%;
     right: 0;
@@ -66,7 +66,7 @@
       height: 100%;
       background-color: $c-star;
       transition: background-color 0.25s ease;
-      border-radius: $cf-border / 2;
+      border-radius: $cf-border * 0.5;
       left: 0;
     }
     &:before {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1099,10 +1099,10 @@
     gud "^1.0.0"
     warning "^4.0.3"
 
-"@influxdata/clockface@^3.1.7":
-  version "3.1.7"
-  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-3.1.7.tgz#f66e5f4b116fcc6aa1da18368fdc41f51123585e"
-  integrity sha512-FQKfsQy/Emi04gTj8oDsQo6uXv2QLrKekUmh1vmsHaso4HlTyo3/nuZ2lvx1sEESmND1+RQfoi2piuFtIQQHwQ==
+"@influxdata/clockface@^3.1.8":
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-3.1.8.tgz#1b4dfc156e3cb0742beda0f50ae2b471411571b4"
+  integrity sha512-REuXFbWIPulS18yvY9BqdEfhE0ngnG2GeSukZKD9NSUWjwhZ+Z4woRQmGQlmU0j320V9hW0/rMAHXS5RV66Maw==
 
 "@influxdata/flux-lsp-browser@^0.5.53":
   version "0.5.99"


### PR DESCRIPTION
Closes #3362

run `sass-migrator division **/*.scss` to automatically update scss files to fix deprecation warning.

See: https://github.com/influxdata/clockface/pull/707
