### PR TITLE
fix: show the filename and message for the uploaded file

### DIFF
--- a/src/dataLoaders/components/DataLoadersOverlay.scss
+++ b/src/dataLoaders/components/DataLoadersOverlay.scss
@@ -93,7 +93,7 @@ $line-protocol--content-height: 206px;
 }
 
 .line-protocol--spinner {
-  height: $line-protocol--content-height + $ix-marg-b + $form-sm-height;
+  height: $line-protocol--content-height + $ix-marg-f + $form-sm-height;
   border: $ix-border solid $cf-grey-15;
   border-radius: $ix-radius;
   display: flex;

--- a/src/shared/components/DragAndDrop.scss
+++ b/src/shared/components/DragAndDrop.scss
@@ -47,7 +47,7 @@ input[type='file'].drag-and-drop--input {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  margin: 0 0 30px 0;
+  padding: 0 0 15px 0;
   font-size: 20px;
   font-weight: 400;
   &.empty {


### PR DESCRIPTION
Closes #2744

Now the filename and message are no longer covered.

Filename:
<img width="1420" alt="Screen Shot 2021-12-02 at 4 37 32 PM" src="https://user-images.githubusercontent.com/14298407/144525070-89bdc442-7a96-4e2c-8843-c5ae7b39c2ff.png">


Message:
<img width="1427" alt="Screen Shot 2021-12-02 at 4 38 20 PM" src="https://user-images.githubusercontent.com/14298407/144525046-fad412f4-dd26-4579-9766-4c6a42d760a4.png">


