### PR TITLE
chore: update clone check test

### DIFF
--- a/cypress/e2e/shared/checks.test.ts
+++ b/cypress/e2e/shared/checks.test.ts
@@ -786,8 +786,6 @@ describe('Checks', () => {
   }
 
   describe('Clone checks', () => {
-    let bucketName: string = ''
-
     const initCheck = (check: GenCheck): Cypress.Chainable<any> => {
       cy.writeLPDataFromFile({
         filename: 'data/wumpus01.lp',
@@ -796,7 +794,7 @@ describe('Checks', () => {
       })
       cy.get<Organization>('@org').then((org: Organization) => {
         cy.get<Bucket>('@bucket').then((bucket: Bucket) => {
-          bucketName = bucket.name
+          cy.wrap(bucket.name).as('bucketName')
           createCheck(check, org, bucket, 'check')
         })
       })
@@ -854,10 +852,12 @@ describe('Checks', () => {
       cy.getByTestID('schedule-check').should('have.value', deadmanCheck.every)
       // 3.2 Assert query-builder
       cy.getByTestID('select-group--option').click()
-      cy.getByTestID(`selector-list ${bucketName}`).should(
-        'have.class',
-        'cf-list-item__active'
+      cy.get('@bucketName').then(bn =>
+        cy
+          .getByTestID(`selector-list ${bn}`)
+          .should('have.class', 'cf-list-item__active')
       )
+
       cy.getByTestID('selector-list wumpus').should(
         'have.class',
         'cf-list-item__active'


### PR DESCRIPTION
Noticed locally that after PR #3350 the clone check test was failing.  

This should fix it. 

<!-- Describe your proposed changes here. -->
Replaces scoped variable in test group with cypress alias. 
