### PR TITLE
fix: notebooks scroll bar in presentation mode

### DIFF
--- a/src/flows/components/PipeList.tsx
+++ b/src/flows/components/PipeList.tsx
@@ -71,34 +71,36 @@ const PipeList: FC = () => {
     }
 
     return (
-      <Grid
-        cols={12}
-        layout={layout}
-        rowHeight={DASHBOARD_LAYOUT_ROW_HEIGHT}
-        useCSSTransforms={false}
-        containerPadding={[0, 0]}
-        margin={[LAYOUT_MARGIN, LAYOUT_MARGIN]}
-        onLayoutChange={layoutChange}
-        draggableHandle=".cell--draggable"
-        isDraggable
-        isResizable
-      >
-        {flow.data.allIDs
-          .filter(
-            id =>
-              /^(visualization|markdown)$/.test(flow.data.byID[id]?.type) &&
-              flow.meta.byID[id].visible
-          )
-          .map(id => (
-            <div
-              key={id}
-              className="cell"
-              data-testid={`cell ${flow.meta.byID[id].title}`}
-            >
-              <PresentationPipe id={id} />
-            </div>
-          ))}
-      </Grid>
+      <div className="flow">
+        <Grid
+          cols={12}
+          layout={layout}
+          rowHeight={DASHBOARD_LAYOUT_ROW_HEIGHT}
+          useCSSTransforms={false}
+          containerPadding={[0, 0]}
+          margin={[LAYOUT_MARGIN, LAYOUT_MARGIN]}
+          onLayoutChange={layoutChange}
+          draggableHandle=".cell--draggable"
+          isDraggable
+          isResizable
+        >
+          {flow.data.allIDs
+            .filter(
+              id =>
+                /^(visualization|markdown)$/.test(flow.data.byID[id]?.type) &&
+                flow.meta.byID[id].visible
+            )
+            .map(id => (
+              <div
+                key={id}
+                className="cell"
+                data-testid={`cell ${flow.meta.byID[id].title}`}
+              >
+                <PresentationPipe id={id} />
+              </div>
+            ))}
+        </Grid>
+      </div>
     )
   }
 


### PR DESCRIPTION
Closes #3340

The scroll bar in notebooks was covered in presentation mode. Now the scroll bar is visible.

Before:
<img width="843" alt="Before" src="https://user-images.githubusercontent.com/14298407/145089309-46732d41-4c1d-440b-a443-baa03c441822.png">

After:
<img width="887" alt="After" src="https://user-images.githubusercontent.com/14298407/145089322-dafb30d0-724d-4f30-a221-c623c384c8f1.png">
