### PR TITLE
feat: change checkout routing and billing(page) for contract accountType

### DIFF
--- a/src/billing/components/BillingPageContents.tsx
+++ b/src/billing/components/BillingPageContents.tsx
@@ -14,7 +14,8 @@ const BillingPageContents: FC = () => {
   const quartzMe = useSelector(getQuartzMe)
 
   if (
-    quartzMe?.accountType === 'pay_as_you_go' &&
+    (quartzMe?.accountType === 'pay_as_you_go' ||
+      quartzMe?.accountType === 'contract') &&
     quartzMe?.billingProvider !== 'zuora'
   ) {
     return <MarketplaceBilling />

--- a/src/checkout/CheckoutPage.tsx
+++ b/src/checkout/CheckoutPage.tsx
@@ -1,4 +1,4 @@
-import React, {FC} from 'react'
+import React, {FC, useEffect, useMemo} from 'react'
 
 // Components
 import CheckoutForm from 'src/checkout/CheckoutForm'
@@ -6,8 +6,30 @@ import SuccessOverlay from 'src/checkout/SuccessOverlay'
 import CheckoutProvider from 'src/checkout/context/checkout'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import ZuoraOutagePage from 'src/shared/components/zuora/ZuoraOutagePage'
+import {useSelector} from 'react-redux'
+import {AppState} from 'src/types'
+import {useHistory} from 'react-router'
 
 const CheckoutV2: FC = () => {
+  const history = useHistory()
+  const accountType = useSelector(
+    (state: AppState) => state.me?.quartzMe?.accountType
+  )
+
+  const shouldContinue = useMemo(() => {
+    return accountType === 'free' || accountType === 'cancelled'
+  }, [accountType])
+
+  useEffect(() => {
+    if (!shouldContinue) {
+      history.push('/')
+    }
+  }, [shouldContinue])
+
+  if (!shouldContinue) {
+    return null
+  }
+
   return (
     <CheckoutProvider>
       <>


### PR DESCRIPTION
Closes #3276 

According to the requirements in the story above..

1. If the following(additional) logic doesn't hold true when going to billing page, show `MarketplaceBilling` component.
```
accountType === 'contract' && billingProvider !== 'zuora'
```

2. If the following(additional) logic holds true on `/checkout` page, then you will be rerouted to the main org page.
```
accountType NOT IN ('pay_as_you_go', 'contract')
```
