### PR TITLE
chore: make explicit bucket uploading tests less flaky

### DIFF
--- a/cypress/e2e/cloud/buckets.test.ts
+++ b/cypress/e2e/cloud/buckets.test.ts
@@ -198,7 +198,11 @@ describe('Explicit Buckets', () => {
     cy.getByTestID('explicit-bucket-schema-choice-ID').click()
     cy.getByTestID('measurement-schema-add-file-button').click()
     cy.getByTestID('input-field').type('first schema file')
-    cy.getByTestID('drag-and-drop--input').attachFile('validSchema1.json')
+
+    const filename = 'validSchema1.json'
+    cy.getByTestID('drag-and-drop--input').attachFile(filename)
+    // making sure the file is there before moving on to the next step:
+    cy.getByTestID('displayArea').contains(filename)
 
     cy.getByTestID('bucket-form-submit').click()
 
@@ -298,7 +302,10 @@ fsRead,field,float`
       cy.getByTestID('measurement-schema-add-file-button').click()
       cy.getByTestID('input-field').type(schemaName)
 
-      cy.getByTestID('drag-and-drop--input').attachFile('validSchema1.json')
+      const filename = 'validSchema1.json'
+      cy.getByTestID('drag-and-drop--input').attachFile(filename)
+      // making sure the file is there before moving on to the next step:
+      cy.getByTestID('displayArea').contains(filename)
 
       cy.getByTestID('bucket-form-submit').click()
     })
@@ -347,6 +354,8 @@ fsRead,field,float`
           cy.getByTestID('drag-and-drop--input').attachFile(
             'invalidSchema.json'
           )
+          // don't need to check that the filename is showing;
+          // since there is an error it doesn't show up
 
           // should show error
           cy.getByTestID('form--element-error').should('exist')
@@ -357,10 +366,11 @@ fsRead,field,float`
           // error should be gone
           cy.getByTestID('form--element-error').should('not.exist')
 
+          const updateFilename = 'updateValidSchema1.json'
           // add the right one
-          cy.getByTestID('drag-and-drop--input').attachFile(
-            'updateValidSchema1.json'
-          )
+          cy.getByTestID('drag-and-drop--input').attachFile(updateFilename)
+          // making sure the file is there before moving on to the next step:
+          cy.getByTestID('displayArea').contains(updateFilename)
         })
       // need to get out of the 'within' for the readonly panel to find the submit button:
       cy.getByTestID('bucket-form-submit').click()

--- a/cypress/e2e/cloud/buckets.test.ts
+++ b/cypress/e2e/cloud/buckets.test.ts
@@ -38,7 +38,11 @@ const testSchemaFiles = (
 
   cy.getByTestID('measurement-schema-add-file-button').click()
   cy.getByTestID('input-field').type('first schema file')
+
   cy.getByTestID('drag-and-drop--input').attachFile(fixtureFileName)
+
+  // making sure the file is there before moving on to the next step:
+  cy.getByTestID('displayArea').contains(fixtureFileName)
 
   cy.getByTestID('bucket-form-submit').click()
 

--- a/cypress/e2e/cloud/buckets.test.ts
+++ b/cypress/e2e/cloud/buckets.test.ts
@@ -286,17 +286,18 @@ fsRead,field,float`
       .within(() => {
         cy.getByTestID('bucket-settings').click({force: true})
       })
-    cy.getByTestID('accordion-header').click()
     const schemaName = 'one schema'
     const fileName = 'one_schema.json'
 
-    cy.getByTestID('measurement-schema-add-file-button').click()
-    cy.getByTestID('input-field').type(schemaName)
+    cy.getByTestID('overlay--container').within(() => {
+      cy.getByTestID('accordion-header').click()
+      cy.getByTestID('measurement-schema-add-file-button').click()
+      cy.getByTestID('input-field').type(schemaName)
 
-    cy.getByTestID('drag-and-drop--input').attachFile('validSchema1.json')
+      cy.getByTestID('drag-and-drop--input').attachFile('validSchema1.json')
 
-    cy.getByTestID('bucket-form-submit').click()
-
+      cy.getByTestID('bucket-form-submit').click()
+    })
     // in settings:
     // b/c editing has a different url, this *should* work
     // give it some time for the submit to happen/the bucket list to show up
@@ -311,96 +312,104 @@ fsRead,field,float`
       .within(() => {
         cy.getByTestID('bucket-settings').click({force: true})
       })
-    cy.getByTestID('accordion-header').click()
 
-    cy.getByTestID('measurement-schema-readOnly-panel-0')
-      .should('exist')
-      .within(() => {
-        cy.getByTestID('measurement-schema-name-0')
-          .should('exist')
-          .contains(schemaName)
-          .should('exist')
+    cy.getByTestID('overlay--container').within(() => {
+      cy.getByTestID('accordion-header').click()
 
-        cy.getByTestID('measurement-schema-download-button').click()
-        cy.readFile(`cypress/downloads/${fileName}`)
-          .should('exist')
-          .then(fileContent => {
-            expect(fileContent[0].name).to.be.equal('time')
-            expect(fileContent[0].type).to.be.equal('timestamp')
+      cy.getByTestID('measurement-schema-readOnly-panel-0')
+        .should('exist')
+        .within(() => {
+          cy.getByTestID('measurement-schema-name-0')
+            .should('exist')
+            .contains(schemaName)
+            .should('exist')
 
-            expect(fileContent[1].name).to.be.equal('fsWrite')
-            expect(fileContent[1].type).to.be.equal('field')
-            expect(fileContent[1].dataType).to.be.equal('float')
-          })
+          cy.getByTestID('measurement-schema-download-button').click()
+          cy.readFile(`cypress/downloads/${fileName}`)
+            .should('exist')
+            .then(fileContent => {
+              expect(fileContent[0].name).to.be.equal('time')
+              expect(fileContent[0].type).to.be.equal('timestamp')
 
-        // cancel button should not be showing yet
-        cy.getByTestID('dndContainer-cancel-update').should('not.exist')
-
-        // use the invalid file first to test the error handling
-        cy.getByTestID('drag-and-drop--input').attachFile('invalidSchema.json')
-
-        // should show error
-        cy.getByTestID('form--element-error').should('exist')
-
-        // cancel it
-        cy.getByTestID('dndContainer-cancel-update').click()
-
-        // error should be gone
-        cy.getByTestID('form--element-error').should('not.exist')
-
-        // add the right one
-        cy.getByTestID('drag-and-drop--input').attachFile(
-          'updateValidSchema1.json'
-        )
-
-        cy.getByTestID('bucket-form-submit').click()
-
-        // in settings:
-        // give it some time for the submit to happen/the bucket list to show up
-        // check the url to make sure it has navigated back to the main buckets list
-        cy.location('pathname', {timeout: 60000}).should(
-          'match',
-          /.*load-data\/buckets$/
-        )
-
-        cy.getByTestID(`bucket-card explicit_bucket`)
-          .should('exist')
-          .within(() => {
-            cy.getByTestID('bucket-settings').click({force: true})
-          })
-        cy.getByTestID('accordion-header').click()
-
-        cy.getByTestID('measurement-schema-readOnly-panel-0')
-          .should('exist')
-          .within(() => {
-            cy.getByTestID('measurement-schema-name-0')
-              .should('exist')
-              .contains(schemaName)
-              .should('exist')
-
-            // remove the downloaded files
-            cy.exec('rm cypress/downloads/*', {
-              log: true,
-              failOnNonZeroExit: false,
+              expect(fileContent[1].name).to.be.equal('fsWrite')
+              expect(fileContent[1].type).to.be.equal('field')
+              expect(fileContent[1].dataType).to.be.equal('float')
             })
 
-            cy.getByTestID('measurement-schema-download-button').click()
-            cy.readFile(`cypress/downloads/${fileName}`)
-              .should('exist')
-              .then(fileContent => {
-                expect(fileContent[0].name).to.be.equal('time')
-                expect(fileContent[0].type).to.be.equal('timestamp')
+          // cancel button should not be showing yet
+          cy.getByTestID('dndContainer-cancel-update').should('not.exist')
 
-                expect(fileContent[1].name).to.be.equal('fsWrite')
-                expect(fileContent[1].type).to.be.equal('field')
-                expect(fileContent[1].dataType).to.be.equal('float')
+          // use the invalid file first to test the error handling
+          cy.getByTestID('drag-and-drop--input').attachFile(
+            'invalidSchema.json'
+          )
 
-                expect(fileContent[2].name).to.be.equal('hello there')
-                expect(fileContent[2].type).to.be.equal('field')
-                expect(fileContent[2].dataType).to.be.equal('string')
-              })
-          })
+          // should show error
+          cy.getByTestID('form--element-error').should('exist')
+
+          // cancel it
+          cy.getByTestID('dndContainer-cancel-update').click()
+
+          // error should be gone
+          cy.getByTestID('form--element-error').should('not.exist')
+
+          // add the right one
+          cy.getByTestID('drag-and-drop--input').attachFile(
+            'updateValidSchema1.json'
+          )
+        })
+      //need to get out of the 'within' for the readonly panel to find the submit button:
+      cy.getByTestID('bucket-form-submit').click()
+    })
+
+    // in settings:
+    // give it some time for the submit to happen/the bucket list to show up
+    // check the url to make sure it has navigated back to the main buckets list
+    cy.location('pathname', {timeout: 60000}).should(
+      'match',
+      /.*load-data\/buckets$/
+    )
+
+    cy.getByTestID(`bucket-card explicit_bucket`)
+      .should('exist')
+      .within(() => {
+        cy.getByTestID('bucket-settings').click({force: true})
       })
+
+    cy.getByTestID('overlay--container').within(() => {
+      cy.getByTestID('accordion-header').click()
+
+      cy.getByTestID('measurement-schema-readOnly-panel-0')
+        .should('exist')
+        .within(() => {
+          cy.getByTestID('measurement-schema-name-0')
+            .should('exist')
+            .contains(schemaName)
+            .should('exist')
+
+          // remove the downloaded files
+          cy.exec('rm cypress/downloads/*', {
+            log: true,
+            failOnNonZeroExit: false,
+          })
+
+          cy.getByTestID('measurement-schema-download-button').click()
+          cy.readFile(`cypress/downloads/${fileName}`)
+            .should('exist')
+            .then(fileContent => {
+              expect(fileContent[0].name).to.be.equal('time')
+              expect(fileContent[0].type).to.be.equal('timestamp')
+
+              expect(fileContent[1].name).to.be.equal('fsWrite')
+              expect(fileContent[1].type).to.be.equal('field')
+              expect(fileContent[1].dataType).to.be.equal('float')
+
+              expect(fileContent[2].name).to.be.equal('hello there')
+              expect(fileContent[2].type).to.be.equal('field')
+              expect(fileContent[2].dataType).to.be.equal('string')
+            })
+        })
+    })
   })
 })
 

--- a/cypress/e2e/cloud/buckets.test.ts
+++ b/cypress/e2e/cloud/buckets.test.ts
@@ -358,7 +358,7 @@ fsRead,field,float`
             'updateValidSchema1.json'
           )
         })
-      //need to get out of the 'within' for the readonly panel to find the submit button:
+      // need to get out of the 'within' for the readonly panel to find the submit button:
       cy.getByTestID('bucket-form-submit').click()
     })
 

--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -633,7 +633,7 @@ describe('DataExplorer', () => {
 
   describe('refresh', () => {
     beforeEach(() => {
-      cy.writeData(points(10))
+      cy.writeData(points(20))
 
       cy.getByTestID(`selector-list m`).click()
       cy.getByTestID('time-machine-submit-button').click()
@@ -649,6 +649,8 @@ describe('DataExplorer', () => {
       // graph will slightly move
       cy.wait(200)
       cy.get('.autorefresh-dropdown--pause').click()
+
+      // not actually same as (see the false as the second arg)
       makeGraphSnapshot().shouldBeSameAs(snapshot, false)
     })
   })

--- a/cypress/fixtures/invalidSchema.json
+++ b/cypress/fixtures/invalidSchema.json
@@ -1,0 +1,5 @@
+[
+  {"name": "time", "type": "timestamp"},
+  {"name": "fsWrite", "type": "field", "dataType": "float"},
+  {"name": "hello there"}
+]

--- a/cypress/fixtures/schema.csv
+++ b/cypress/fixtures/schema.csv
@@ -1,0 +1,5 @@
+name,type,dataType
+time,timestamp,
+host,tag,
+service,tag,
+fsRead,field,float

--- a/cypress/fixtures/updateValidSchema1.json
+++ b/cypress/fixtures/updateValidSchema1.json
@@ -1,0 +1,5 @@
+[
+  {"name": "time", "type": "timestamp"},
+  {"name": "fsWrite", "type": "field", "dataType": "float"},
+  {"name": "hello there", "type": "field", "dataType": "string"}
+]

--- a/cypress/fixtures/validSchema1.json
+++ b/cypress/fixtures/validSchema1.json
@@ -1,0 +1,4 @@
+[
+  {"name": "time", "type": "timestamp"},
+  {"name": "fsWrite", "type": "field", "dataType": "float"}
+]

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "css-loader": "^3.1.0",
     "cypress": "8.7.0",
     "cypress-file-upload": "^4.1.1",
+    "cypress-file-upload": "^5.0.8",
     "cypress-log-to-output": "^1.1.2",
     "cypress-pipe": "^1.5.0",
     "cypress-plugin-tab": "^1.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3934,12 +3934,10 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-cypress-file-upload@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/cypress-file-upload/-/cypress-file-upload-4.1.1.tgz#952713c8104ab7008de99c65bd63f74b244fe4df"
-  integrity sha512-tX6UhuJ63rNgjdzxglpX+ZYf/bM6PDhFMtt1qCBljLtAgdearqyfD1AHqyh59rOHCjfM+bf6FA3o9b/mdaX6pw==
-  dependencies:
-    mime "^2.4.4"
+cypress-file-upload@^5.0.8:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/cypress-file-upload/-/cypress-file-upload-5.0.8.tgz#d8824cbeaab798e44be8009769f9a6c9daa1b4a1"
+  integrity sha512-+8VzNabRk3zG6x8f8BWArF/xA/W0VK4IZNx3MV0jFWrJS/qKn8eHfa5nU73P9fOQAgwHFJx7zjg4lwOnljMO8g==
 
 cypress-log-to-output@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
using cypress file fixtures; used 'within' more.
