### PR TITLE
chore: remove clients.users.me usage

### DIFF
--- a/src/Signin.tsx
+++ b/src/Signin.tsx
@@ -30,7 +30,7 @@ import {
 
 // Types
 import {RemoteDataState} from 'src/types'
-import {getMe} from './client'
+import {getMe} from 'src/client'
 
 interface State {
   loading: RemoteDataState

--- a/src/Signin.tsx
+++ b/src/Signin.tsx
@@ -3,8 +3,6 @@ import React, {ReactElement, PureComponent} from 'react'
 import {Switch, Route, RouteComponentProps} from 'react-router-dom'
 import {connect, ConnectedProps} from 'react-redux'
 
-import {client} from 'src/utils/api'
-
 // Components
 import {ErrorHandling} from 'src/shared/decorators/errors'
 import {SpinnerContainer, TechnoSpinner} from '@influxdata/clockface'
@@ -32,6 +30,7 @@ import {
 
 // Types
 import {RemoteDataState} from 'src/types'
+import {getMe} from './client'
 
 interface State {
   loading: RemoteDataState
@@ -95,7 +94,12 @@ export class Signin extends PureComponent<Props, State> {
 
   private checkForLogin = async () => {
     try {
-      await client.users.me()
+      const resp = await getMe({})
+
+      if (resp.status !== 200) {
+        throw new Error(resp.data.message)
+      }
+
       this.setState({auth: true})
       const redirectIsSet = !!getFromLocalStorage('redirectTo')
       if (redirectIsSet) {

--- a/src/me/actions/thunks/index.ts
+++ b/src/me/actions/thunks/index.ts
@@ -5,6 +5,7 @@ import {Dispatch} from 'react'
 
 // API
 import {client} from 'src/utils/api'
+import {getMe as apiGetApiMe} from 'src/client'
 import {getMe as apiGetQuartzMe} from 'src/client/unityRoutes'
 // Utils
 import {gaEvent, updateReportingContext} from 'src/cloud/utils/reporting'
@@ -28,7 +29,12 @@ export const getMe = () => async (
   getState: GetState
 ) => {
   try {
-    const user = await client.users.me()
+    const resp = await apiGetApiMe({})
+
+    if (resp.status !== 200) {
+      throw new Error(resp.data.message)
+    }
+    const user = resp.data
     updateReportingContext({userID: user.id, userEmail: user.name})
 
     gaEvent('cloudAppUserDataReady', {

--- a/src/me/actions/thunks/index.ts
+++ b/src/me/actions/thunks/index.ts
@@ -4,7 +4,6 @@ import {identify} from 'rudder-sdk-js'
 import {Dispatch} from 'react'
 
 // API
-import {client} from 'src/utils/api'
 import {getMe as apiGetApiMe} from 'src/client'
 import {getMe as apiGetQuartzMe} from 'src/client/unityRoutes'
 // Utils

--- a/src/onboarding/containers/LoginPage.tsx
+++ b/src/onboarding/containers/LoginPage.tsx
@@ -11,7 +11,9 @@ import {
 } from '@influxdata/clockface'
 import {useHistory} from 'react-router-dom'
 import Notifications from 'src/shared/components/notifications/Notifications'
-import {client} from 'src/utils/api'
+
+// Types
+import {getMe} from 'src/client'
 
 // Components
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
@@ -24,7 +26,12 @@ export const LoginPage: FC = () => {
 
   const getSessionValidity = useCallback(async () => {
     try {
-      await client.users.me()
+      const resp = await getMe({})
+
+      if (resp.status !== 200) {
+        throw new Error(resp.data.message)
+      }
+
       setHasValidSession(true)
     } catch {
       setHasValidSession(false)


### PR DESCRIPTION
Closes #3383

Replace all usages of `clients.users.me` with the `getMe` request that's generated in generatedRoutes.
