### PR TITLE
feat: remove bucket and telegraf titles from `EditTokenOvelray`

### DIFF
--- a/src/authorizations/components/redesigned/EditResourceAccordion.tsx
+++ b/src/authorizations/components/redesigned/EditResourceAccordion.tsx
@@ -103,7 +103,6 @@ export class EditResourceAccordion extends Component<Props> {
             <IndividualAccordionBody
               resourceName={resource}
               permissions={filteredNames}
-              title="Individual Telegraf Configuration Names"
               disabled={true}
             />
           )}
@@ -125,7 +124,6 @@ export class EditResourceAccordion extends Component<Props> {
             <IndividualAccordionBody
               resourceName={resource}
               permissions={filteredNames}
-              title="Individual Bucket Names"
               disabled={true}
             />
           )}

--- a/src/authorizations/components/redesigned/IndividualAccordionBody.tsx
+++ b/src/authorizations/components/redesigned/IndividualAccordionBody.tsx
@@ -95,12 +95,13 @@ export const IndividualAccordionBody: FC<Props> = props => {
   )
 
   return (
-    <>{title ? (
-      <Accordion.AccordionBodyItem className="resource-accordion-body">
-        {title}
-      </Accordion.AccordionBodyItem>
-    ) : null}
-      
+    <>
+      {title ? (
+        <Accordion.AccordionBodyItem className="resource-accordion-body">
+          {title}
+        </Accordion.AccordionBodyItem>
+      ) : null}
+
       {permissions
         ? Object.keys(sortedPermissions).map(key => {
             return (

--- a/src/authorizations/components/redesigned/IndividualAccordionBody.tsx
+++ b/src/authorizations/components/redesigned/IndividualAccordionBody.tsx
@@ -21,7 +21,7 @@ interface Props {
   resourceName: string
   permissions: any
   onToggle?: (name, id, permission) => void
-  title: string
+  title?: string
   disabled: boolean
 }
 
@@ -95,10 +95,12 @@ export const IndividualAccordionBody: FC<Props> = props => {
   )
 
   return (
-    <>
+    <>{title ? (
       <Accordion.AccordionBodyItem className="resource-accordion-body">
         {title}
       </Accordion.AccordionBodyItem>
+    ) : null}
+      
       {permissions
         ? Object.keys(sortedPermissions).map(key => {
             return (


### PR DESCRIPTION
Closes #3355 

Removed Bucket and Telegraf titles inside `EditTokenOverlay`. 
See #3355 for more info. 

Before fix: 
![Screen Shot 2021-12-08 at 10 46 12 AM](https://user-images.githubusercontent.com/66275100/145248467-ac1b1d5d-7e46-424b-bf41-3fef7ac66bc0.png)

After fix: 
![Screen Shot 2021-12-08 at 10 46 41 AM](https://user-images.githubusercontent.com/66275100/145248568-5d6028d7-13e9-4681-9ebc-b92f70577d5a.png)


