### PR TITLE
feat: adding Tokens banner to tokens pagination

### DIFF
--- a/src/authorizations/pagination/TokensTab.tsx
+++ b/src/authorizations/pagination/TokensTab.tsx
@@ -6,7 +6,7 @@ import {isEmpty} from 'lodash'
 import {AutoSizer} from 'react-virtualized'
 
 // Components
-import {Sort, ComponentSize, EmptyState} from '@influxdata/clockface'
+import {Sort, ComponentSize, EmptyState, BannerPanel, Gradients, IconFont, InfluxColors} from '@influxdata/clockface'
 import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
 import TokenList from 'src/authorizations/pagination/TokenList'
 import FilterList from 'src/shared/components/FilterList'
@@ -14,6 +14,7 @@ import TabbedPageHeader from 'src/shared/components/tabbed_page/TabbedPageHeader
 import GenerateTokenDropdown from 'src/authorizations/components/GenerateTokenDropdown'
 import GenerateTokenDropdownRedesigned from 'src/authorizations/components/redesigned/GenerateTokenDropdown'
 import ResourceSortDropdown from 'src/shared/components/resource_sort_dropdown/ResourceSortDropdown'
+import TokensRedesignBanner from 'src/authorizations/components/TokensRedesignBanner'
 
 // Types
 import {AppState, Authorization, ResourceType} from 'src/types'
@@ -45,6 +46,7 @@ interface StateProps {
 
 const DEFAULT_PAGINATION_CONTROL_HEIGHT = 62
 const DEFAULT_TAB_NAVIGATION_HEIGHT = 62
+const DEFAULT_ALERT_HEIGHT = 100
 
 type SortKey = keyof Authorization
 
@@ -123,45 +125,60 @@ class TokensTab extends PureComponent<Props, State> {
     }
 
     return (
+      <>
+          <BannerPanel
+            size={ComponentSize.ExtraSmall}
+            gradient={Gradients.PolarExpress}
+            icon={IconFont.Bell}
+            hideMobileIcon={true}
+            textColor={InfluxColors.Yeti} 
+          > 
+          <TokensRedesignBanner />
+          </BannerPanel>
       <AutoSizer>
         {({width, height}) => {
           const heightWithPagination =
             this.paginationRef?.current?.clientHeight +
               DEFAULT_TAB_NAVIGATION_HEIGHT ||
-            DEFAULT_PAGINATION_CONTROL_HEIGHT + DEFAULT_TAB_NAVIGATION_HEIGHT
+            DEFAULT_PAGINATION_CONTROL_HEIGHT + DEFAULT_TAB_NAVIGATION_HEIGHT + DEFAULT_ALERT_HEIGHT
 
-          const adjustedHeight = height - heightWithPagination
+          const adjustedHeight = height - heightWithPagination 
           return (
             <>
+          <div style={{margin: "10px 0px"}}>
+
               <TabbedPageHeader
                 childrenLeft={leftHeaderItems}
                 childrenRight={rightHeaderItems}
                 width={width}
-              />
+                
+                />
               <FilterAuthorizations
                 list={tokens}
                 searchTerm={searchTerm}
                 searchKeys={this.searchKeys}
-              >
+                >
                 {filteredAuths => (
                   <TokenList
-                    tokenCount={tokens.length}
-                    auths={filteredAuths}
-                    emptyState={this.emptyState}
-                    pageWidth={width}
-                    pageHeight={adjustedHeight}
-                    searchTerm={searchTerm}
-                    sortKey={sortKey}
-                    sortDirection={sortDirection}
-                    sortType={sortType}
-                    onClickColumn={this.handleClickColumn}
+                  tokenCount={tokens.length}
+                  auths={filteredAuths}
+                  emptyState={this.emptyState}
+                  pageWidth={width}
+                  pageHeight={adjustedHeight}
+                  searchTerm={searchTerm}
+                  sortKey={sortKey}
+                  sortDirection={sortDirection}
+                  sortType={sortType}
+                  onClickColumn={this.handleClickColumn}
                   />
-                )}
+                  )}
               </FilterAuthorizations>
+                  </div>
             </>
           )
         }}
       </AutoSizer>
+        </>
     )
   }
 

--- a/src/authorizations/pagination/TokensTab.tsx
+++ b/src/authorizations/pagination/TokensTab.tsx
@@ -6,7 +6,15 @@ import {isEmpty} from 'lodash'
 import {AutoSizer} from 'react-virtualized'
 
 // Components
-import {Sort, ComponentSize, EmptyState, BannerPanel, Gradients, IconFont, InfluxColors} from '@influxdata/clockface'
+import {
+  Sort,
+  ComponentSize,
+  EmptyState,
+  BannerPanel,
+  Gradients,
+  IconFont,
+  InfluxColors,
+} from '@influxdata/clockface'
 import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
 import TokenList from 'src/authorizations/pagination/TokenList'
 import FilterList from 'src/shared/components/FilterList'
@@ -128,16 +136,15 @@ class TokensTab extends PureComponent<Props, State> {
       if (!isFlagEnabled('tokensUIRedesign')) {
         return (
           <>
-          <BannerPanel
-            size={ComponentSize.ExtraSmall}
-            gradient={Gradients.PolarExpress}
-            icon={IconFont.Bell}
-            hideMobileIcon={true}
-            textColor={InfluxColors.Yeti} 
-          > 
-          <TokensRedesignBanner />
-          </BannerPanel>
-          
+            <BannerPanel
+              size={ComponentSize.ExtraSmall}
+              gradient={Gradients.PolarExpress}
+              icon={IconFont.Bell}
+              hideMobileIcon={true}
+              textColor={InfluxColors.Yeti}
+            >
+              <TokensRedesignBanner />
+            </BannerPanel>
           </>
         )
       }
@@ -145,55 +152,59 @@ class TokensTab extends PureComponent<Props, State> {
 
     return (
       <>
-          {tokensBanner()}
-      <AutoSizer>
-        {({width, height}) => {
-          // if tokens redesign flag is off, adjust the page height so the banner doesn't push the pagination controller off 
-          let heightWithPagination
-          isFlagEnabled('tokensUIRedesign') ? heightWithPagination = this.paginationRef?.current?.clientHeight +
-          DEFAULT_TAB_NAVIGATION_HEIGHT ||
-        DEFAULT_PAGINATION_CONTROL_HEIGHT + DEFAULT_TAB_NAVIGATION_HEIGHT : heightWithPagination = this.paginationRef?.current?.clientHeight +
-              DEFAULT_TAB_NAVIGATION_HEIGHT ||
-            DEFAULT_PAGINATION_CONTROL_HEIGHT + DEFAULT_TAB_NAVIGATION_HEIGHT + DEFAULT_ALERT_HEIGHT
-            
+        {tokensBanner()}
+        <AutoSizer>
+          {({width, height}) => {
+            // if tokens redesign flag is off, adjust the page height so the banner doesn't push the pagination controller off
+            let heightWithPagination
+            isFlagEnabled('tokensUIRedesign')
+              ? (heightWithPagination =
+                  this.paginationRef?.current?.clientHeight +
+                    DEFAULT_TAB_NAVIGATION_HEIGHT ||
+                  DEFAULT_PAGINATION_CONTROL_HEIGHT +
+                    DEFAULT_TAB_NAVIGATION_HEIGHT)
+              : (heightWithPagination =
+                  this.paginationRef?.current?.clientHeight +
+                    DEFAULT_TAB_NAVIGATION_HEIGHT ||
+                  DEFAULT_PAGINATION_CONTROL_HEIGHT +
+                    DEFAULT_TAB_NAVIGATION_HEIGHT +
+                    DEFAULT_ALERT_HEIGHT)
 
-          const adjustedHeight = height - heightWithPagination 
-          return (
-            <>
-          <div style={{margin: "10px 0px"}}>
-
-              <TabbedPageHeader
-                childrenLeft={leftHeaderItems}
-                childrenRight={rightHeaderItems}
-                width={width}
-                
-                />
-              <FilterAuthorizations
-                list={tokens}
-                searchTerm={searchTerm}
-                searchKeys={this.searchKeys}
-                >
-                {filteredAuths => (
-                  <TokenList
-                  tokenCount={tokens.length}
-                  auths={filteredAuths}
-                  emptyState={this.emptyState}
-                  pageWidth={width}
-                  pageHeight={adjustedHeight}
-                  searchTerm={searchTerm}
-                  sortKey={sortKey}
-                  sortDirection={sortDirection}
-                  sortType={sortType}
-                  onClickColumn={this.handleClickColumn}
+            const adjustedHeight = height - heightWithPagination
+            return (
+              <>
+                <div style={{margin: '10px 0px'}}>
+                  <TabbedPageHeader
+                    childrenLeft={leftHeaderItems}
+                    childrenRight={rightHeaderItems}
+                    width={width}
                   />
-                  )}
-              </FilterAuthorizations>
-                  </div>
-            </>
-          )
-        }}
-      </AutoSizer>
-        </>
+                  <FilterAuthorizations
+                    list={tokens}
+                    searchTerm={searchTerm}
+                    searchKeys={this.searchKeys}
+                  >
+                    {filteredAuths => (
+                      <TokenList
+                        tokenCount={tokens.length}
+                        auths={filteredAuths}
+                        emptyState={this.emptyState}
+                        pageWidth={width}
+                        pageHeight={adjustedHeight}
+                        searchTerm={searchTerm}
+                        sortKey={sortKey}
+                        sortDirection={sortDirection}
+                        sortType={sortType}
+                        onClickColumn={this.handleClickColumn}
+                      />
+                    )}
+                  </FilterAuthorizations>
+                </div>
+              </>
+            )
+          }}
+        </AutoSizer>
+      </>
     )
   }
 

--- a/src/authorizations/pagination/TokensTab.tsx
+++ b/src/authorizations/pagination/TokensTab.tsx
@@ -124,8 +124,10 @@ class TokensTab extends PureComponent<Props, State> {
       rightHeaderItems = <GenerateTokenDropdownRedesigned />
     }
 
-    return (
-      <>
+    const tokensBanner = () => {
+      if (!isFlagEnabled('tokensUIRedesign')) {
+        return (
+          <>
           <BannerPanel
             size={ComponentSize.ExtraSmall}
             gradient={Gradients.PolarExpress}
@@ -135,12 +137,25 @@ class TokensTab extends PureComponent<Props, State> {
           > 
           <TokensRedesignBanner />
           </BannerPanel>
+          
+          </>
+        )
+      }
+    }
+
+    return (
+      <>
+          {tokensBanner()}
       <AutoSizer>
         {({width, height}) => {
-          const heightWithPagination =
-            this.paginationRef?.current?.clientHeight +
+          // if tokens redesign flag is off, adjust the page height so the banner doesn't push the pagination controller off 
+          let heightWithPagination
+          isFlagEnabled('tokensUIRedesign') ? heightWithPagination = this.paginationRef?.current?.clientHeight +
+          DEFAULT_TAB_NAVIGATION_HEIGHT ||
+        DEFAULT_PAGINATION_CONTROL_HEIGHT + DEFAULT_TAB_NAVIGATION_HEIGHT : heightWithPagination = this.paginationRef?.current?.clientHeight +
               DEFAULT_TAB_NAVIGATION_HEIGHT ||
             DEFAULT_PAGINATION_CONTROL_HEIGHT + DEFAULT_TAB_NAVIGATION_HEIGHT + DEFAULT_ALERT_HEIGHT
+            
 
           const adjustedHeight = height - heightWithPagination 
           return (


### PR DESCRIPTION
Added tokens banner to tokens paginations page. 


Before fix, tokens banner only rendered when `paginatedTokens` feature flag is off. 
Picture attached below is UI with banner on paginated tokens page. 

<img width="1333" alt="Screen Shot 2021-12-09 at 5 42 22 PM" src="https://user-images.githubusercontent.com/66275100/145492854-a178577a-7153-4930-a78f-d7d47a983829.png">

