### PR TITLE
feat: remove example and category from notebook's flux functions 

### DIFF
--- a/src/flows/pipes/RawFluxEditor/dynamicFunction.tsx
+++ b/src/flows/pipes/RawFluxEditor/dynamicFunction.tsx
@@ -1,0 +1,119 @@
+// Libraries
+import React, {FC, createRef} from 'react'
+
+// Component
+import {
+  Popover,
+  PopoverPosition,
+  PopoverInteraction,
+  Appearance,
+  Button,
+  ComponentSize,
+  ComponentColor,
+  DapperScrollbars,
+} from '@influxdata/clockface'
+
+// Types
+import {FluxToolbarFunction} from 'src/types/shared'
+
+interface Props {
+  func: FluxToolbarFunction
+  onClickFunction: (func: FluxToolbarFunction) => void
+  testID: string
+}
+
+interface TooltipProps {
+  func: FluxToolbarFunction
+}
+
+const defaultProps = {
+  testID: 'flux-function',
+}
+
+const FunctionTooltipContents: FC<TooltipProps> = ({func}) => {
+  let argComponent = <div className="flux-function-docs--arguments">None</div>
+
+  if (func.args.length > 0) {
+    argComponent = (
+      <>
+        {func.args.map(a => (
+          <div className="flux-function-docs--arguments" key={a.name}>
+            <span>{a.name}:</span>
+            <span>{a.type}</span>
+            <div>{a.desc}</div>
+          </div>
+        ))}
+      </>
+    )
+  }
+
+  return (
+    <div className="flux-function-docs" data-testid={`flux-docs--${func.name}`}>
+      <DapperScrollbars autoHide={false}>
+        <div className="flux-toolbar--popover">
+          <article className="flux-functions-toolbar--description">
+            <div className="flux-function-docs--heading">Description</div>
+            <span>{func.desc}</span>
+          </article>
+          <article>
+            <div className="flux-function-docs--heading">Arguments</div>
+            <div className="flux-function-docs--snippet">{argComponent}</div>
+          </article>
+          <article>
+            <div className="flux-function-docs--heading">Example</div>
+            <div className="flux-function-docs--snippet">{func.example}</div>
+          </article>
+          <p className="tooltip--link">
+            Still have questions? Check out the{' '}
+            <a target="_blank" rel="noreferrer" href={func.link}>
+              Flux Docs
+            </a>
+            .
+          </p>
+        </div>
+      </DapperScrollbars>
+    </div>
+  )
+}
+
+const ToolbarFunction: FC<Props> = ({func, onClickFunction, testID}) => {
+  const functionRef = createRef<HTMLDListElement>()
+  const handleClickFunction = () => {
+    onClickFunction(func)
+  }
+
+  return (
+    <>
+      <Popover
+        appearance={Appearance.Outline}
+        enableDefaultStyles={false}
+        position={PopoverPosition.ToTheLeft}
+        triggerRef={functionRef}
+        showEvent={PopoverInteraction.Hover}
+        hideEvent={PopoverInteraction.Hover}
+        distanceFromTrigger={8}
+        testID="toolbar-popover"
+        contents={() => <FunctionTooltipContents func={func} />}
+      />
+      <dd
+        ref={functionRef}
+        data-testid={`flux--${testID}`}
+        className="flux-toolbar--list-item flux-toolbar--function"
+      >
+        <code>{func.name}</code>
+        <Button
+          testID={`flux--${testID}--inject`}
+          text="Inject"
+          onClick={handleClickFunction}
+          size={ComponentSize.ExtraSmall}
+          className="flux-toolbar--injector"
+          color={ComponentColor.Primary}
+        />
+      </dd>
+    </>
+  )
+}
+
+ToolbarFunction.defaultProps = defaultProps
+
+export default ToolbarFunction

--- a/src/flows/pipes/RawFluxEditor/dynamicFunction.tsx
+++ b/src/flows/pipes/RawFluxEditor/dynamicFunction.tsx
@@ -59,10 +59,6 @@ const FunctionTooltipContents: FC<TooltipProps> = ({func}) => {
             <div className="flux-function-docs--heading">Arguments</div>
             <div className="flux-function-docs--snippet">{argComponent}</div>
           </article>
-          <article>
-            <div className="flux-function-docs--heading">Example</div>
-            <div className="flux-function-docs--snippet">{func.example}</div>
-          </article>
           <p className="tooltip--link">
             Still have questions? Check out the{' '}
             <a target="_blank" rel="noreferrer" href={func.link}>

--- a/src/flows/pipes/RawFluxEditor/dynamicFunctions.tsx
+++ b/src/flows/pipes/RawFluxEditor/dynamicFunctions.tsx
@@ -1,0 +1,87 @@
+import React, {FC, useState, useMemo, useCallback} from 'react'
+
+import {EmptyState, ComponentSize} from '@influxdata/clockface'
+import {FLUX_FUNCTIONS} from 'src/shared/constants/fluxFunctions'
+import {FluxToolbarFunction} from 'src/types/shared'
+import Fn from 'src/flows/pipes/RawFluxEditor/dynamicFunction'
+import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
+
+interface Props {
+  onSelect: (fn: FluxToolbarFunction) => void
+}
+
+interface FilteredFn {
+  [key: string]: FluxToolbarFunction[]
+}
+
+const DynamicFunctions: FC<Props> = ({onSelect}) => {
+  const [search, setSearch] = useState('')
+  const updateSearch = useCallback(
+    text => {
+      setSearch(text)
+    },
+    [search, setSearch]
+  )
+
+  const filteredFunctions: FilteredFn = useMemo(
+    () =>
+      FLUX_FUNCTIONS.filter(fn => {
+        return (
+          !search.length || fn.name.toLowerCase().includes(search.toLowerCase())
+        )
+      }).reduce((acc, fn) => {
+        if (!acc[fn.category]) {
+          acc[fn.category] = [] as FluxToolbarFunction[]
+        }
+
+        acc[fn.category].push(fn)
+
+        return acc
+      }, {}),
+    [search]
+  )
+
+  return useMemo(() => {
+    let fnComponent
+
+    if (!Object.keys(filteredFunctions).length) {
+      fnComponent = (
+        <EmptyState size={ComponentSize.ExtraSmall}>
+          <EmptyState.Text>No functions match your search</EmptyState.Text>
+        </EmptyState>
+      )
+    } else {
+      fnComponent = Object.entries(filteredFunctions).map(([category, fns]) => (
+        <dl className="flux-toolbar--category" key={category}>
+          <dt className="flux-toolbar--heading">{category}</dt>
+          {fns.map(fn => (
+            <Fn
+              onClickFunction={onSelect}
+              key={`${fn.name}_${fn.desc}`}
+              func={fn}
+              testID={fn.name}
+            />
+          ))}
+        </dl>
+      ))
+    }
+
+    return (
+      <div className="flux-toolbar">
+        <div className="flux-toolbar--search">
+          <SearchWidget
+            placeholderText="Filter Functions..."
+            onSearch={updateSearch}
+            searchTerm={search}
+            testID="flux-toolbar-search--input"
+          />
+        </div>
+        <div className="flux-toolbar--list" data-testid="flux-toolbar--list">
+          {fnComponent}
+        </div>
+      </div>
+    )
+  }, [search, onSelect])
+}
+
+export default DynamicFunctions

--- a/src/flows/pipes/RawFluxEditor/dynamicFunctions.tsx
+++ b/src/flows/pipes/RawFluxEditor/dynamicFunctions.tsx
@@ -10,7 +10,6 @@ interface Props {
   onSelect: (fn: FluxToolbarFunction) => void
 }
 
-
 const DynamicFunctions: FC<Props> = ({onSelect}) => {
   const [search, setSearch] = useState('')
   const updateSearch = useCallback(
@@ -34,14 +33,14 @@ const DynamicFunctions: FC<Props> = ({onSelect}) => {
         </EmptyState>
       )
     } else {
-      fnComponent = filteredFunctions.map( fn => 
-            <Fn
-              onClickFunction={onSelect}
-              key={`${fn.name}_${fn.desc}`}
-              func={fn}
-              testID={fn.name}
-            />
-          )
+      fnComponent = filteredFunctions.map(fn => (
+        <Fn
+          onClickFunction={onSelect}
+          key={`${fn.name}_${fn.desc}`}
+          func={fn}
+          testID={fn.name}
+        />
+      ))
     }
 
     return (

--- a/src/flows/pipes/RawFluxEditor/dynamicFunctions.tsx
+++ b/src/flows/pipes/RawFluxEditor/dynamicFunctions.tsx
@@ -10,9 +10,6 @@ interface Props {
   onSelect: (fn: FluxToolbarFunction) => void
 }
 
-interface FilteredFn {
-  [key: string]: FluxToolbarFunction[]
-}
 
 const DynamicFunctions: FC<Props> = ({onSelect}) => {
   const [search, setSearch] = useState('')
@@ -23,47 +20,28 @@ const DynamicFunctions: FC<Props> = ({onSelect}) => {
     [search, setSearch]
   )
 
-  const filteredFunctions: FilteredFn = useMemo(
-    () =>
-      FLUX_FUNCTIONS.filter(fn => {
-        return (
-          !search.length || fn.name.toLowerCase().includes(search.toLowerCase())
-        )
-      }).reduce((acc, fn) => {
-        if (!acc[fn.category]) {
-          acc[fn.category] = [] as FluxToolbarFunction[]
-        }
-
-        acc[fn.category].push(fn)
-
-        return acc
-      }, {}),
-    [search]
+  const filteredFunctions = FLUX_FUNCTIONS.filter(func =>
+    func.name.toLowerCase().includes(search.toLowerCase())
   )
 
   return useMemo(() => {
     let fnComponent
 
-    if (!Object.keys(filteredFunctions).length) {
+    if (!filteredFunctions.length) {
       fnComponent = (
         <EmptyState size={ComponentSize.ExtraSmall}>
           <EmptyState.Text>No functions match your search</EmptyState.Text>
         </EmptyState>
       )
     } else {
-      fnComponent = Object.entries(filteredFunctions).map(([category, fns]) => (
-        <dl className="flux-toolbar--category" key={category}>
-          <dt className="flux-toolbar--heading">{category}</dt>
-          {fns.map(fn => (
+      fnComponent = filteredFunctions.map( fn => 
             <Fn
               onClickFunction={onSelect}
               key={`${fn.name}_${fn.desc}`}
               func={fn}
               testID={fn.name}
             />
-          ))}
-        </dl>
-      ))
+          )
     }
 
     return (

--- a/src/flows/pipes/RawFluxEditor/view.tsx
+++ b/src/flows/pipes/RawFluxEditor/view.tsx
@@ -128,11 +128,10 @@ const Query: FC<PipeProp> = ({Context}) => {
     } else {
       event('Flux Panel (Notebooks) - Toggle Functions - On')
       show(id)
-      if(isFlagEnabled('fluxDynamicDocs')){
+      if (isFlagEnabled('fluxDynamicDocs')) {
         showSub(<DynamicFunctions onSelect={inject} />)
       } else {
         showSub(<Functions onSelect={inject} />)
-
       }
     }
   }

--- a/src/flows/pipes/RawFluxEditor/view.tsx
+++ b/src/flows/pipes/RawFluxEditor/view.tsx
@@ -25,12 +25,14 @@ import {PipeProp} from 'src/types/flows'
 import {PipeContext} from 'src/flows/context/pipe'
 import {SidebarContext} from 'src/flows/context/sidebar'
 import Functions from 'src/flows/pipes/RawFluxEditor/functions'
+import DynamicFunctions from 'src/flows/pipes/RawFluxEditor/dynamicFunctions'
 
 // Styles
 import 'src/flows/pipes/RawFluxEditor/style.scss'
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 const FluxMonacoEditor = lazy(() =>
   import('src/shared/components/FluxMonacoEditor')
@@ -126,7 +128,12 @@ const Query: FC<PipeProp> = ({Context}) => {
     } else {
       event('Flux Panel (Notebooks) - Toggle Functions - On')
       show(id)
-      showSub(<Functions onSelect={inject} />)
+      if(isFlagEnabled('fluxDynamicDocs')){
+        showSub(<DynamicFunctions onSelect={inject} />)
+      } else {
+        showSub(<Functions onSelect={inject} />)
+
+      }
     }
   }
 


### PR DESCRIPTION
see #3105 & #3106 

As part of the Flux Dynamic Help Panels epic, this pr removes the example section from notebook's flux function flyover panel and lists flux functions without categories. This change is behind a feature flag influx.toggle('fluxDynamicDocs')

Notebooks flux functions with feature flag off: 
![Screen Shot 2021-12-15 at 12 15 07 PM](https://user-images.githubusercontent.com/66275100/146242364-205bfc8f-2179-491d-8de9-2b90b708313c.png)
Notebooks flux functions with feature flag on: 
![Screen Shot 2021-12-15 at 12 16 01 PM](https://user-images.githubusercontent.com/66275100/146242486-2b02989a-8083-4c86-928d-ede817e2dee2.png)


