### PR TITLE
fix: remove regression in webpack dev configuration related to ts errors

### DIFF
--- a/webpack.common.ts
+++ b/webpack.common.ts
@@ -1,6 +1,6 @@
 const path = require('path')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
-const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
+
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin')
 const {CleanWebpackPlugin} = require('clean-webpack-plugin')
@@ -138,7 +138,6 @@ module.exports = {
       filename: `${STATIC_DIRECTORY}[contenthash:10].css`,
       chunkFilename: `${STATIC_DIRECTORY}[id].[contenthash:10].css`,
     }),
-    new ForkTsCheckerWebpackPlugin(),
     new WorkerPlugin(),
     new webpack.ProgressPlugin(),
     new webpack.EnvironmentPlugin({

--- a/webpack.dev.ts
+++ b/webpack.dev.ts
@@ -7,6 +7,7 @@ const PUBLIC = process.env.PUBLIC || undefined
 const {BASE_PATH} = require('./src/utils/env')
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer')
   .BundleAnalyzerPlugin
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
 
 const webpack = require('webpack')
 
@@ -42,6 +43,11 @@ module.exports = merge(common, {
       },
     },
     client: {
+      progress: false,
+      overlay: {
+        errors: true,
+        warnings: false,
+      },
       webSocketURL: {
         hostname: '0.0.0.0',
         pathname: `${BASE_PATH}hmr`,
@@ -50,6 +56,12 @@ module.exports = merge(common, {
     },
   },
   plugins: [
+    new ForkTsCheckerWebpackPlugin({
+      async: true,
+      logger: {
+        devServer: false, // don't block UI compilation on TS errors
+      },
+    }),
     new webpack.DllReferencePlugin({
       context: path.join(__dirname, 'build'),
       manifest: require('./build/vendor-manifest.json'),

--- a/webpack.prod.ts
+++ b/webpack.prod.ts
@@ -10,6 +10,7 @@ const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin')
 const TerserJSPlugin = require('terser-webpack-plugin')
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer')
   .BundleAnalyzerPlugin
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
 
 const {STATIC_DIRECTORY} = require('./src/utils/env')
 
@@ -53,5 +54,6 @@ module.exports = merge(common, {
       openAnalyzer: false,
       generateStatsFile: true,
     }),
+    new ForkTsCheckerWebpackPlugin(),
   ],
 })


### PR DESCRIPTION
TypeScript errors will no longer fail compilation

Tested dev builds and prod builds. Dev builds won't fail compilation under TS errors, prod builds will.