### PR TITLE
chore: remove duplicate dependency from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
     "cross-env": "^5.2.0",
     "css-loader": "^3.1.0",
     "cypress": "8.7.0",
-    "cypress-file-upload": "^4.1.1",
     "cypress-file-upload": "^5.0.8",
     "cypress-log-to-output": "^1.1.2",
     "cypress-pipe": "^1.5.0",


### PR DESCRIPTION
Pretty straightforward clean-up. Removing a dependency that appears to have been accidentally added in the process of an upgrade