### PR TITLE
feat: when query variables fail to load, show a message to the user

### DIFF
--- a/cypress/e2e/shared/dashboardsView.test.ts
+++ b/cypress/e2e/shared/dashboardsView.test.ts
@@ -884,8 +884,16 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
             // and cause the rest to exist in loading states
             cy.getByTestID('variable-dropdown--build').should(
               'contain',
-              'Loading'
+              'Error'
             )
+
+            // An error notification should tell the user that this failed
+            cy.getByTestID('notification-error').contains(
+              'could not find bucket "beans"'
+            )
+            cy.getByTestID('notification-error--dismiss').click({
+              multiple: true,
+            })
 
             cy.getByTestIDSubStr('cell--view-empty')
 

--- a/cypress/e2e/shared/dashboardsView.test.ts
+++ b/cypress/e2e/shared/dashboardsView.test.ts
@@ -1039,11 +1039,17 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
           'beans'
         )
 
-        // and cause the rest to exist in loading states
+        // and cause the rest to exist in error states
         cy.getByTestIDSubStr('variable-dropdown--dependent').should(
           'contain',
-          'Loading'
+          'Error'
         )
+
+        // An error notification should tell the user that this failed
+        cy.getByTestID('notification-error').contains(
+          'could not find bucket "beans"'
+        )
+        cy.getByTestID('notification-error--dismiss').click()
 
         cy.getByTestIDSubStr('cell--view-empty')
 

--- a/src/shared/copy/notifications.ts
+++ b/src/shared/copy/notifications.ts
@@ -428,6 +428,12 @@ export const getVariableFailed = (): Notification => ({
   message: 'Failed to fetch variable',
 })
 
+export const getVariableFailedWithMessage = (name, message): Notification => ({
+  ...defaultErrorNotification,
+  duration: INDEFINITE,
+  message: `Failed to fetch variable ${name}: ${message}`,
+})
+
 export const createVariableFailed = (error: string): Notification => ({
   ...defaultErrorNotification,
   icon: IconFont.Cube,

--- a/src/variables/actions/thunks.ts
+++ b/src/variables/actions/thunks.ts
@@ -82,6 +82,7 @@ export const getVariables = (controller?: AbortController) => async (
       {query: {orgID: org.id}},
       {signal: controller?.signal}
     )
+
     if (!resp) {
       return
     }
@@ -186,6 +187,12 @@ export const hydrateVariables = (
       dispatch(setVariable(variable.id, RemoteDataState.Done, _variable))
     }
   })
+
+  hydration.on('error', (variable, error) => {
+    dispatch(setVariable(variable.id, RemoteDataState.Error))
+    dispatch(notify(copy.getVariableFailedWithMessage(variable?.name, error)))
+  })
+
   await hydration.promise
 }
 

--- a/src/variables/components/TypeAheadVariableDropdown.tsx
+++ b/src/variables/components/TypeAheadVariableDropdown.tsx
@@ -267,7 +267,11 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
     }
 
     const getInnerComponent = () => {
-      if (status === RemoteDataState.Loading || this.noValuesPresent()) {
+      if (
+        status === RemoteDataState.Loading ||
+        status === RemoteDataState.Error ||
+        this.noValuesPresent()
+      ) {
         return placeHolderText
       } else {
         return (
@@ -385,6 +389,10 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
     if (status === RemoteDataState.Loading) {
       return 'Loading...'
     }
+    if (status === RemoteDataState.Error) {
+      return 'Error'
+    }
+
     if (this.noFilteredValuesPresent()) {
       return 'No Values'
     }

--- a/src/variables/mocks/index.ts
+++ b/src/variables/mocks/index.ts
@@ -46,7 +46,8 @@ export const defaultVariableAssignments: VariableAssignment[] = [
 export const createVariable = (
   name: string,
   query: string,
-  selected?: string
+  selected?: string,
+  status: RemoteDataState = RemoteDataState.Done
 ): Variable => ({
   name,
   id: name,
@@ -60,7 +61,7 @@ export const createVariable = (
       language: 'flux',
     },
   },
-  status: RemoteDataState.Done,
+  status,
 })
 
 export const createMapVariable = (

--- a/src/variables/utils/hydrateVars.ts
+++ b/src/variables/utils/hydrateVars.ts
@@ -338,11 +338,13 @@ const invalidateCycles = (graph: VariableNode[]): void => {
 /*
   Given a node, mark all ancestors of that node as `Error`.
 */
-const invalidateAncestors = (node: VariableNode): void => {
+const invalidateAncestors = (node: VariableNode, e: Error, on: any): void => {
   const ancestors = collectAncestors(node)
 
   for (const ancestor of ancestors) {
     ancestor.status = RemoteDataState.Error
+    on.fire('error', ancestor.variable, e)
+
     if (ancestor.variable.arguments.type === 'query') {
       ancestor.variable.arguments.values.results = []
     }
@@ -466,7 +468,7 @@ export const hydrateVars = (
       node.variable.arguments.values.results = []
 
       on.fire('error', node.variable, e)
-      invalidateAncestors(node)
+      invalidateAncestors(node, e, on)
     }
   }
 

--- a/src/variables/utils/hydrateVars.ts
+++ b/src/variables/utils/hydrateVars.ts
@@ -465,6 +465,7 @@ export const hydrateVars = (
       node.status = RemoteDataState.Error
       node.variable.arguments.values.results = []
 
+      on.fire('error', node.variable, e)
       invalidateAncestors(node)
     }
   }


### PR DESCRIPTION
[Closes EAR#2795](https://github.com/influxdata/EAR/issues/2795)

### Previously:
- A query variable that 404ed when executing against a bucket would fail silently and keep the page in a loading state.

### Now:
- `hydrateVars.ts` fires an error event with the variable that failed and the error message it failed with
- `variables/thunks.ts` shows an error notification with the variable name and the error
- `TypeAheadVariableDropdown.tsx` will show an error if the variable it's fetching is an an error state

**A single variable failing**
![Screen Shot 2021-12-15 at 3 55 39 PM](https://user-images.githubusercontent.com/146112/146409416-a965f547-73b9-46ab-ac3b-5661752e848e.png)

**Dependent Variable failing**
![Screen Shot 2021-12-17 at 9 46 27 AM](https://user-images.githubusercontent.com/146112/146587198-efaca540-33b1-4dc4-a283-5338d33c97a0.png)