### PR TITLE
fix: disable clockface CSS filtering to improve visual performance

### DIFF
--- a/src/writeData/components/WriteDataItem.scss
+++ b/src/writeData/components/WriteDataItem.scss
@@ -5,6 +5,12 @@
   color: $cf-white;
 }
 
+.write-data--item {
+  .cf-selectable-card--children {
+    filter: unset !important;
+  }
+}
+
 .write-data--item-thumb {
   position: relative;
   display: flex;

--- a/src/writeData/components/WriteDataSections.tsx
+++ b/src/writeData/components/WriteDataSections.tsx
@@ -10,7 +10,7 @@ import {search as searchPlugins} from 'src/writeData/constants/contentTelegrafPl
 import {searchClients} from 'src/writeData'
 
 // Components
-import {EmptyState, ComponentSize, Grid} from '@influxdata/clockface'
+import {EmptyState, ComponentSize} from '@influxdata/clockface'
 import FileUploadSection from 'src/writeData/components/FileUploadSection'
 import ClientLibrarySection from 'src/writeData/components/ClientLibrarySection'
 import TelegrafPluginSection from 'src/writeData/components/TelegrafPluginSection'
@@ -34,17 +34,9 @@ const WriteDataSections: FC = () => {
 
   return (
     <>
-      <Grid>
-        <Grid.Row>
-          <FileUploadSection />
-        </Grid.Row>
-        <Grid.Row>
-          <ClientLibrarySection />
-        </Grid.Row>
-        <Grid.Row>
-          <TelegrafPluginSection />
-        </Grid.Row>
-      </Grid>
+      <FileUploadSection />
+      <ClientLibrarySection />
+      <TelegrafPluginSection />
     </>
   )
 }


### PR DESCRIPTION
Addresses the performance issues in Safari with the Load Data > Sources page:

- reverts a previous attempt which only made plugins smaller and did nothing for visual peformance
- disables the CSS filtering which is the real culprit of the slow rendering


https://user-images.githubusercontent.com/10736577/146468321-7656140e-9144-4729-b8ad-b1b1083ba478.mp4


