### PR TITLE
feat: Color Map pass the `colorMapping` object to giraffe

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "cy": "CYPRESS_dexUrl=https://$INGRESS_HOST:$PORT_HTTPS CYPRESS_baseUrl=http://localhost:9999 cypress open",
     "cy:dev": "source ../monitor-ci/.env && CYPRESS_dexUrl=CLOUD CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{cloud,shared}/**/*.*'",
     "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_dexUrl=OSS CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{oss,shared}/**/*.*'",
-    "generate": "export SHA=2da36d4beb7fc22dd8d037c3398c91c7ca2c346d && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
+    "generate": "export SHA=018d2381f78e52acbe1deaaff4c9512adf5e3703 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-meta": "if [ -z \"${CLOUD_URL}\" ]; then yarn generate-meta-oss; else yarn generate-meta-cloud; fi",
     "generate-meta-oss": "yarn oss-api && yarn notebooks && yarn unity && yarn annotations-oss && yarn pinned && yarn mapsd-oss && yarn cloudPriv",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "cy": "CYPRESS_dexUrl=https://$INGRESS_HOST:$PORT_HTTPS CYPRESS_baseUrl=http://localhost:9999 cypress open",
     "cy:dev": "source ../monitor-ci/.env && CYPRESS_dexUrl=CLOUD CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{cloud,shared}/**/*.*'",
     "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_dexUrl=OSS CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{oss,shared}/**/*.*'",
-    "generate": "export SHA=018d2381f78e52acbe1deaaff4c9512adf5e3703 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
+    "generate": "export SHA=1e7c6a915dd5ab74b3e72c86e0776fbf66f3d2c1 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-meta": "if [ -z \"${CLOUD_URL}\" ]; then yarn generate-meta-oss; else yarn generate-meta-cloud; fi",
     "generate-meta-oss": "yarn oss-api && yarn notebooks && yarn unity && yarn annotations-oss && yarn pinned && yarn mapsd-oss && yarn cloudPriv",

--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -181,14 +181,11 @@ const XYPlot: FC<Props> = ({
   }
 
   const [, fillColumnMap] = createGroupIDColumn(result.table, groupKey)
-  console.log({fillColumnMap, properties})
 
   const {colorMappingForGiraffe} = getColorMappingObjects(
     fillColumnMap,
     properties
   )
-
-  console.log({colorMappingForGiraffe})
 
   const config: Config = {
     ...currentTheme,

--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -9,7 +9,7 @@ import {
   STACKED_LINE_CUMULATIVE,
   createGroupIDColumn,
   getDomainDataFromLines,
-  lineTransform,
+  lineTransform, LineLayerConfig,
 } from '@influxdata/giraffe'
 
 // Components
@@ -223,12 +223,15 @@ const XYPlot: FC<Props> = ({
         interpolation,
         position: properties.position,
         colors: colorHexes,
-        colorMapping,
         shadeBelow: !!properties.shadeBelow,
         shadeBelowOpacity: 0.08,
         hoverDimension: properties.hoverDimension,
       },
     ],
+  }
+
+  if (isFlagEnabled('graphColorMapping')) {
+    (config.layers[0] as LineLayerConfig).colorMapping = colorMapping
   }
 
   addAnnotationLayer(

--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -9,7 +9,8 @@ import {
   STACKED_LINE_CUMULATIVE,
   createGroupIDColumn,
   getDomainDataFromLines,
-  lineTransform, LineLayerConfig,
+  lineTransform,
+  LineLayerConfig,
 } from '@influxdata/giraffe'
 
 // Components
@@ -231,7 +232,11 @@ const XYPlot: FC<Props> = ({
   }
 
   if (isFlagEnabled('graphColorMapping')) {
-    (config.layers[0] as LineLayerConfig).colorMapping = colorMapping
+    const layer = {...(config.layers[0] as LineLayerConfig)}
+
+    layer.colorMapping = colorMapping
+
+    config.layers[0] = layer
   }
 
   addAnnotationLayer(

--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -51,6 +51,7 @@ import {
 // Annotations
 import {addAnnotationLayer} from 'src/visualization/utils/annotationUtils'
 import {getColorMappingObjects} from 'src/visualization/utils/colorMappingUtils'
+import {isFlagEnabled} from '../../../shared/utils/featureFlag'
 
 interface Props extends VisualizationProps {
   properties: XYViewProperties
@@ -180,12 +181,16 @@ const XYPlot: FC<Props> = ({
     return <EmptyGraphMessage message={INVALID_DATA_COPY} />
   }
 
-  const [, fillColumnMap] = createGroupIDColumn(result.table, groupKey)
+  let colorMapping = null
 
-  const {colorMappingForGiraffe} = getColorMappingObjects(
-    fillColumnMap,
-    properties
-  )
+  if (isFlagEnabled('graphColorMapping')) {
+    const [, fillColumnMap] = createGroupIDColumn(result.table, groupKey)
+    const {colorMappingForGiraffe} = getColorMappingObjects(
+      fillColumnMap,
+      properties
+    )
+    colorMapping = colorMappingForGiraffe
+  }
 
   const config: Config = {
     ...currentTheme,
@@ -218,7 +223,7 @@ const XYPlot: FC<Props> = ({
         interpolation,
         position: properties.position,
         colors: colorHexes,
-        colorMapping: colorMappingForGiraffe,
+        colorMapping,
         shadeBelow: !!properties.shadeBelow,
         shadeBelowOpacity: 0.08,
         hoverDimension: properties.hoverDimension,

--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -50,6 +50,7 @@ import {
 
 // Annotations
 import {addAnnotationLayer} from 'src/visualization/utils/annotationUtils'
+import {getColorMappingObjects} from 'src/visualization/utils/colorMappingUtils'
 
 interface Props extends VisualizationProps {
   properties: XYViewProperties
@@ -179,6 +180,12 @@ const XYPlot: FC<Props> = ({
     return <EmptyGraphMessage message={INVALID_DATA_COPY} />
   }
 
+  const [, fillColumnMap] = createGroupIDColumn(result.table, groupKey)
+  const {colorMappingForGiraffe} = getColorMappingObjects(
+    fillColumnMap,
+    properties
+  )
+
   const config: Config = {
     ...currentTheme,
     table: result.table,
@@ -210,6 +217,7 @@ const XYPlot: FC<Props> = ({
         interpolation,
         position: properties.position,
         colors: colorHexes,
+        colorMapping: colorMappingForGiraffe,
         shadeBelow: !!properties.shadeBelow,
         shadeBelowOpacity: 0.08,
         hoverDimension: properties.hoverDimension,

--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -181,10 +181,14 @@ const XYPlot: FC<Props> = ({
   }
 
   const [, fillColumnMap] = createGroupIDColumn(result.table, groupKey)
+  console.log({fillColumnMap, properties})
+
   const {colorMappingForGiraffe} = getColorMappingObjects(
     fillColumnMap,
     properties
   )
+
+  console.log({colorMappingForGiraffe})
 
   const config: Config = {
     ...currentTheme,

--- a/src/visualization/utils/colorMappingUtils.test.ts
+++ b/src/visualization/utils/colorMappingUtils.test.ts
@@ -224,7 +224,7 @@ const dataFromIDPE_fiveSeries = {
   },
 }
 const expectedData = {
-  threeSeries : {
+  threeSeries: {
     mappingForGiraffe: {
       mappings: [
         {
@@ -339,7 +339,7 @@ const expectedData = {
         'co-airSensors-TLM0104-mean-': 1,
       },
     },
-  }
+  },
 }
 
 describe('color mapping utils', function() {
@@ -353,7 +353,9 @@ describe('color mapping utils', function() {
       dataFromIDPE_noColorMapping.properties as XYViewProperties
     )
 
-    expect(colorMappingForGiraffe).toStrictEqual(expectedData.threeSeries.mappingForGiraffe)
+    expect(colorMappingForGiraffe).toStrictEqual(
+      expectedData.threeSeries.mappingForGiraffe
+    )
     expect(needsToSaveToIDPE).toBe(true)
     expect(colorMappingForIDPE).toStrictEqual(
       expectedData.threeSeries.mappingForIDPE.colorMapping
@@ -370,7 +372,9 @@ describe('color mapping utils', function() {
       dataFromIDPE_sameColorMapping.properties as XYViewProperties
     )
 
-    expect(colorMappingForGiraffe).toStrictEqual(expectedData.threeSeries.mappingForGiraffe)
+    expect(colorMappingForGiraffe).toStrictEqual(
+      expectedData.threeSeries.mappingForGiraffe
+    )
     expect(needsToSaveToIDPE).toBe(false)
 
     // no object returned for IDPE since we don't need to save
@@ -387,7 +391,9 @@ describe('color mapping utils', function() {
       dataFromIDPE_fiveSeries.properties as XYViewProperties
     )
 
-    expect(colorMappingForGiraffe).toStrictEqual(expectedData.fiveSeries.mappingForGiraffe)
+    expect(colorMappingForGiraffe).toStrictEqual(
+      expectedData.fiveSeries.mappingForGiraffe
+    )
     expect(needsToSaveToIDPE).toBe(true)
     expect(colorMappingForIDPE).toStrictEqual(
       expectedData.fiveSeries.mappingForIDPE.colorMapping

--- a/src/visualization/utils/colorMappingUtils.test.ts
+++ b/src/visualization/utils/colorMappingUtils.test.ts
@@ -6,6 +6,7 @@ import {XYViewProperties} from '../../client'
 const MOCK_START = 1639775162126
 const MOCK_STOP = 1639778762126
 const dataFromIDPE_noColorMapping = {
+  // the columnGroup is not saved in IDPE but generated using the createGroupIdColumn
   columnGroup: {
     mappings: [
       {
@@ -70,6 +71,79 @@ const dataFromIDPE_noColorMapping = {
   },
 }
 
+const dataFromIDPE_sameColorMapping = {
+  // the columnGroup is not saved in IDPE but generated using the createGroupIdColumn
+  columnGroup: {
+    mappings: [
+      {
+        _start: `${MOCK_START}`,
+        _stop: `${MOCK_STOP}`,
+        _field: 'co',
+        _measurement: 'airSensors',
+        sensor_id: 'TLM0100',
+        result: 'mean',
+        color: '#31C0F6',
+      },
+      {
+        _start: `${MOCK_START}`,
+        _stop: `${MOCK_STOP}`,
+        _field: 'co',
+        _measurement: 'airSensors',
+        sensor_id: 'TLM0101',
+        result: 'mean',
+        color: '#A500A5',
+      },
+      {
+        _start: `${MOCK_START}`,
+        _stop: `${MOCK_STOP}`,
+        _field: 'co',
+        _measurement: 'airSensors',
+        sensor_id: 'TLM0102',
+        result: 'mean',
+        color: '#FF7E27',
+      },
+    ],
+    columnKeys: [
+      '_start',
+      '_stop',
+      '_field',
+      '_measurement',
+      'sensor_id',
+      'result',
+    ],
+  },
+  properties: {
+    colors: [
+      {
+        id: '2f2d8b62-5e53-46b2-bde9-a291bcc5f9e7',
+        type: 'scale',
+        hex: '#31C0F6',
+        name: 'Nineteen Eighty Four',
+        value: 0,
+      },
+      {
+        id: '4b0d1e17-2177-40cf-b524-980fe80f6ca8',
+        type: 'scale',
+        hex: '#A500A5',
+        name: 'Nineteen Eighty Four',
+        value: 0,
+      },
+      {
+        id: 'd90d4be9-14f8-48da-a309-8d2cb50f6961',
+        type: 'scale',
+        hex: '#FF7E27',
+        name: 'Nineteen Eighty Four',
+        value: 0,
+      },
+    ],
+    colorMapping: {
+      'co-airSensors-TLM0100-mean-': 0,
+      'co-airSensors-TLM0101-mean-': 1,
+      'co-airSensors-TLM0102-mean-': 2,
+    },
+  },
+}
+
 const expectedData = {
   mappingForGiraffe: {
     mappings: [
@@ -109,11 +183,6 @@ const expectedData = {
       'sensor_id',
       'result',
     ],
-    seriesToColorIndexMap: {
-      'co-airSensors-TLM0100-mean-': 0,
-      'co-airSensors-TLM0101-mean-': 1,
-      'co-airSensors-TLM0102-mean-': 2,
-    },
   },
   mappingForIDPE: {
     colorMapping: {
@@ -140,5 +209,22 @@ describe('color mapping utils', function() {
     expect(colorMappingForIDPE).toStrictEqual(
       expectedData.mappingForIDPE.colorMapping
     )
+  })
+
+  it('should return the IDPE mapping when the mappings are the same and need not be re-generated', function() {
+    const {
+      colorMappingForGiraffe,
+      colorMappingForIDPE,
+      needsToSaveToIDPE,
+    } = getColorMappingObjects(
+      dataFromIDPE_sameColorMapping.columnGroup,
+      dataFromIDPE_sameColorMapping.properties as XYViewProperties
+    )
+
+    expect(colorMappingForGiraffe).toStrictEqual(expectedData.mappingForGiraffe)
+    expect(needsToSaveToIDPE).toBe(false)
+
+    // no object returned for IDPE since we don't need to save
+    expect(colorMappingForIDPE).toStrictEqual(undefined)
   })
 })

--- a/src/visualization/utils/colorMappingUtils.test.ts
+++ b/src/visualization/utils/colorMappingUtils.test.ts
@@ -1,0 +1,139 @@
+// tests will go here
+
+import {getColorMappingObjects} from './colorMappingUtils'
+import {XYViewProperties} from '../../client'
+
+const MOCK_START = 1639775162126
+const MOCK_STOP = 1639778762126
+const dataFromIDPE_noColorMapping = {
+  "columnGroup": {
+    "mappings": [
+      {
+        "_start": `${MOCK_START}`,
+        "_stop": `${MOCK_STOP}`,
+        "_field": "co",
+        "_measurement": "airSensors",
+        "sensor_id": "TLM0100",
+        "result": "mean"
+      },
+      {
+        "_start": `${MOCK_START}`,
+        "_stop": `${MOCK_STOP}`,
+        "_field": "co",
+        "_measurement": "airSensors",
+        "sensor_id": "TLM0101",
+        "result": "mean"
+      },
+      {
+        "_start": `${MOCK_START}`,
+        "_stop": `${MOCK_STOP}`,
+        "_field": "co",
+        "_measurement": "airSensors",
+        "sensor_id": "TLM0102",
+        "result": "mean"
+      }
+    ],
+    "columnKeys": [
+      "_start",
+      "_stop",
+      "_field",
+      "_measurement",
+      "sensor_id",
+      "result"
+    ]
+  },
+  "properties": {
+    // no colorMapping present
+    "colors": [
+      {
+        "id": "2f2d8b62-5e53-46b2-bde9-a291bcc5f9e7",
+        "type": "scale",
+        "hex": "#31C0F6",
+        "name": "Nineteen Eighty Four",
+        "value": 0
+      },
+      {
+        "id": "4b0d1e17-2177-40cf-b524-980fe80f6ca8",
+        "type": "scale",
+        "hex": "#A500A5",
+        "name": "Nineteen Eighty Four",
+        "value": 0
+      },
+      {
+        "id": "d90d4be9-14f8-48da-a309-8d2cb50f6961",
+        "type": "scale",
+        "hex": "#FF7E27",
+        "name": "Nineteen Eighty Four",
+        "value": 0
+      }
+    ],
+  }
+}
+
+const expectedData = {
+  'mappingForGiraffe' : {
+    "mappings": [
+      {
+        "_start": `${MOCK_START}`,
+        "_stop": `${MOCK_STOP}`,
+        "_field": "co",
+        "_measurement": "airSensors",
+        "sensor_id": "TLM0100",
+        "result": "mean",
+        "color": "#31C0F6"
+      },
+      {
+        "_start": `${MOCK_START}`,
+        "_stop": `${MOCK_STOP}`,
+        "_field": "co",
+        "_measurement": "airSensors",
+        "sensor_id": "TLM0101",
+        "result": "mean",
+        "color": "#A500A5"
+      },
+      {
+        "_start": `${MOCK_START}`,
+        "_stop": `${MOCK_STOP}`,
+        "_field": "co",
+        "_measurement": "airSensors",
+        "sensor_id": "TLM0102",
+        "result": "mean",
+        "color": "#FF7E27"
+      }
+    ],
+    "columnKeys": [
+      "_start",
+      "_stop",
+      "_field",
+      "_measurement",
+      "sensor_id",
+      "result"
+    ],
+    "seriesToColorIndexMap": {
+      "co-airSensors-TLM0100-mean-": 0,
+      "co-airSensors-TLM0101-mean-": 1,
+      "co-airSensors-TLM0102-mean-": 2
+    }
+  },
+  'mappingForIDPE': {
+    "colorMapping": {
+      "co-airSensors-TLM0100-mean-": 0,
+      "co-airSensors-TLM0101-mean-": 1,
+      "co-airSensors-TLM0102-mean-": 2
+    }
+  }
+}
+
+describe('color mapping utils', function() {
+  it('should generate a color mapping when view properties from the IDPE do not have colorMapping', function() {
+    const {colorMappingForGiraffe, colorMappingForIDPE, needsToSaveToIDPE} = getColorMappingObjects(
+      dataFromIDPE_noColorMapping.columnGroup,
+      dataFromIDPE_noColorMapping.properties as XYViewProperties
+    )
+
+    expect(colorMappingForGiraffe).toStrictEqual(expectedData.mappingForGiraffe)
+    expect(needsToSaveToIDPE).toBe(true)
+    expect(colorMappingForIDPE).toStrictEqual(expectedData.mappingForIDPE.colorMapping)
+  })
+})
+

--- a/src/visualization/utils/colorMappingUtils.test.ts
+++ b/src/visualization/utils/colorMappingUtils.test.ts
@@ -70,7 +70,6 @@ const dataFromIDPE_noColorMapping = {
     ],
   },
 }
-
 const dataFromIDPE_sameColorMapping = {
   // the columnGroup is not saved in IDPE but generated using the createGroupIdColumn
   columnGroup: {
@@ -143,9 +142,9 @@ const dataFromIDPE_sameColorMapping = {
     },
   },
 }
-
-const expectedData = {
-  mappingForGiraffe: {
+const dataFromIDPE_fiveSeries = {
+  // the columnGroup is not saved in IDPE but generated using the createGroupIdColumn
+  columnGroup: {
     mappings: [
       {
         _start: `${MOCK_START}`,
@@ -154,7 +153,6 @@ const expectedData = {
         _measurement: 'airSensors',
         sensor_id: 'TLM0100',
         result: 'mean',
-        color: '#31C0F6',
       },
       {
         _start: `${MOCK_START}`,
@@ -163,7 +161,6 @@ const expectedData = {
         _measurement: 'airSensors',
         sensor_id: 'TLM0101',
         result: 'mean',
-        color: '#A500A5',
       },
       {
         _start: `${MOCK_START}`,
@@ -172,7 +169,22 @@ const expectedData = {
         _measurement: 'airSensors',
         sensor_id: 'TLM0102',
         result: 'mean',
-        color: '#FF7E27',
+      },
+      {
+        _start: `${MOCK_START}`,
+        _stop: `${MOCK_STOP}`,
+        _field: 'co',
+        _measurement: 'airSensors',
+        sensor_id: 'TLM0103',
+        result: 'mean',
+      },
+      {
+        _start: `${MOCK_START}`,
+        _stop: `${MOCK_STOP}`,
+        _field: 'co',
+        _measurement: 'airSensors',
+        sensor_id: 'TLM0104',
+        result: 'mean',
       },
     ],
     columnKeys: [
@@ -184,13 +196,150 @@ const expectedData = {
       'result',
     ],
   },
-  mappingForIDPE: {
-    colorMapping: {
-      'co-airSensors-TLM0100-mean-': 0,
-      'co-airSensors-TLM0101-mean-': 1,
-      'co-airSensors-TLM0102-mean-': 2,
+  properties: {
+    // no colorMapping present
+    colors: [
+      {
+        id: '2f2d8b62-5e53-46b2-bde9-a291bcc5f9e7',
+        type: 'scale',
+        hex: '#31C0F6',
+        name: 'Nineteen Eighty Four',
+        value: 0,
+      },
+      {
+        id: '4b0d1e17-2177-40cf-b524-980fe80f6ca8',
+        type: 'scale',
+        hex: '#A500A5',
+        name: 'Nineteen Eighty Four',
+        value: 0,
+      },
+      {
+        id: 'd90d4be9-14f8-48da-a309-8d2cb50f6961',
+        type: 'scale',
+        hex: '#FF7E27',
+        name: 'Nineteen Eighty Four',
+        value: 0,
+      },
+    ],
+  },
+}
+const expectedData = {
+  threeSeries : {
+    mappingForGiraffe: {
+      mappings: [
+        {
+          _start: `${MOCK_START}`,
+          _stop: `${MOCK_STOP}`,
+          _field: 'co',
+          _measurement: 'airSensors',
+          sensor_id: 'TLM0100',
+          result: 'mean',
+          color: '#31C0F6',
+        },
+        {
+          _start: `${MOCK_START}`,
+          _stop: `${MOCK_STOP}`,
+          _field: 'co',
+          _measurement: 'airSensors',
+          sensor_id: 'TLM0101',
+          result: 'mean',
+          color: '#A500A5',
+        },
+        {
+          _start: `${MOCK_START}`,
+          _stop: `${MOCK_STOP}`,
+          _field: 'co',
+          _measurement: 'airSensors',
+          sensor_id: 'TLM0102',
+          result: 'mean',
+          color: '#FF7E27',
+        },
+      ],
+      columnKeys: [
+        '_start',
+        '_stop',
+        '_field',
+        '_measurement',
+        'sensor_id',
+        'result',
+      ],
+    },
+    mappingForIDPE: {
+      colorMapping: {
+        'co-airSensors-TLM0100-mean-': 0,
+        'co-airSensors-TLM0101-mean-': 1,
+        'co-airSensors-TLM0102-mean-': 2,
+      },
     },
   },
+  fiveSeries: {
+    mappingForGiraffe: {
+      mappings: [
+        {
+          _start: `${MOCK_START}`,
+          _stop: `${MOCK_STOP}`,
+          _field: 'co',
+          _measurement: 'airSensors',
+          sensor_id: 'TLM0100',
+          result: 'mean',
+          color: '#31C0F6',
+        },
+        {
+          _start: `${MOCK_START}`,
+          _stop: `${MOCK_STOP}`,
+          _field: 'co',
+          _measurement: 'airSensors',
+          sensor_id: 'TLM0101',
+          result: 'mean',
+          color: '#A500A5',
+        },
+        {
+          _start: `${MOCK_START}`,
+          _stop: `${MOCK_STOP}`,
+          _field: 'co',
+          _measurement: 'airSensors',
+          sensor_id: 'TLM0102',
+          result: 'mean',
+          color: '#FF7E27',
+        },
+        {
+          _start: `${MOCK_START}`,
+          _stop: `${MOCK_STOP}`,
+          _field: 'co',
+          _measurement: 'airSensors',
+          sensor_id: 'TLM0103',
+          result: 'mean',
+          color: '#31C0F6',
+        },
+        {
+          _start: `${MOCK_START}`,
+          _stop: `${MOCK_STOP}`,
+          _field: 'co',
+          _measurement: 'airSensors',
+          sensor_id: 'TLM0104',
+          result: 'mean',
+          color: '#A500A5',
+        },
+      ],
+      columnKeys: [
+        '_start',
+        '_stop',
+        '_field',
+        '_measurement',
+        'sensor_id',
+        'result',
+      ],
+    },
+    mappingForIDPE: {
+      colorMapping: {
+        'co-airSensors-TLM0100-mean-': 0,
+        'co-airSensors-TLM0101-mean-': 1,
+        'co-airSensors-TLM0102-mean-': 2,
+        'co-airSensors-TLM0103-mean-': 0,
+        'co-airSensors-TLM0104-mean-': 1,
+      },
+    },
+  }
 }
 
 describe('color mapping utils', function() {
@@ -204,10 +353,10 @@ describe('color mapping utils', function() {
       dataFromIDPE_noColorMapping.properties as XYViewProperties
     )
 
-    expect(colorMappingForGiraffe).toStrictEqual(expectedData.mappingForGiraffe)
+    expect(colorMappingForGiraffe).toStrictEqual(expectedData.threeSeries.mappingForGiraffe)
     expect(needsToSaveToIDPE).toBe(true)
     expect(colorMappingForIDPE).toStrictEqual(
-      expectedData.mappingForIDPE.colorMapping
+      expectedData.threeSeries.mappingForIDPE.colorMapping
     )
   })
 
@@ -221,10 +370,27 @@ describe('color mapping utils', function() {
       dataFromIDPE_sameColorMapping.properties as XYViewProperties
     )
 
-    expect(colorMappingForGiraffe).toStrictEqual(expectedData.mappingForGiraffe)
+    expect(colorMappingForGiraffe).toStrictEqual(expectedData.threeSeries.mappingForGiraffe)
     expect(needsToSaveToIDPE).toBe(false)
 
     // no object returned for IDPE since we don't need to save
     expect(colorMappingForIDPE).toStrictEqual(undefined)
+  })
+
+  it('should generate a color mapping when view properties from the IDPE do not have colorMapping and there are more series than the number of colors in the color array (5 series, 3 colors)', function() {
+    const {
+      colorMappingForGiraffe,
+      colorMappingForIDPE,
+      needsToSaveToIDPE,
+    } = getColorMappingObjects(
+      dataFromIDPE_fiveSeries.columnGroup,
+      dataFromIDPE_fiveSeries.properties as XYViewProperties
+    )
+
+    expect(colorMappingForGiraffe).toStrictEqual(expectedData.fiveSeries.mappingForGiraffe)
+    expect(needsToSaveToIDPE).toBe(true)
+    expect(colorMappingForIDPE).toStrictEqual(
+      expectedData.fiveSeries.mappingForIDPE.colorMapping
+    )
   })
 })

--- a/src/visualization/utils/colorMappingUtils.test.ts
+++ b/src/visualization/utils/colorMappingUtils.test.ts
@@ -6,134 +6,139 @@ import {XYViewProperties} from '../../client'
 const MOCK_START = 1639775162126
 const MOCK_STOP = 1639778762126
 const dataFromIDPE_noColorMapping = {
-  "columnGroup": {
-    "mappings": [
+  columnGroup: {
+    mappings: [
       {
-        "_start": `${MOCK_START}`,
-        "_stop": `${MOCK_STOP}`,
-        "_field": "co",
-        "_measurement": "airSensors",
-        "sensor_id": "TLM0100",
-        "result": "mean"
+        _start: `${MOCK_START}`,
+        _stop: `${MOCK_STOP}`,
+        _field: 'co',
+        _measurement: 'airSensors',
+        sensor_id: 'TLM0100',
+        result: 'mean',
       },
       {
-        "_start": `${MOCK_START}`,
-        "_stop": `${MOCK_STOP}`,
-        "_field": "co",
-        "_measurement": "airSensors",
-        "sensor_id": "TLM0101",
-        "result": "mean"
+        _start: `${MOCK_START}`,
+        _stop: `${MOCK_STOP}`,
+        _field: 'co',
+        _measurement: 'airSensors',
+        sensor_id: 'TLM0101',
+        result: 'mean',
       },
       {
-        "_start": `${MOCK_START}`,
-        "_stop": `${MOCK_STOP}`,
-        "_field": "co",
-        "_measurement": "airSensors",
-        "sensor_id": "TLM0102",
-        "result": "mean"
-      }
+        _start: `${MOCK_START}`,
+        _stop: `${MOCK_STOP}`,
+        _field: 'co',
+        _measurement: 'airSensors',
+        sensor_id: 'TLM0102',
+        result: 'mean',
+      },
     ],
-    "columnKeys": [
-      "_start",
-      "_stop",
-      "_field",
-      "_measurement",
-      "sensor_id",
-      "result"
-    ]
+    columnKeys: [
+      '_start',
+      '_stop',
+      '_field',
+      '_measurement',
+      'sensor_id',
+      'result',
+    ],
   },
-  "properties": {
+  properties: {
     // no colorMapping present
-    "colors": [
+    colors: [
       {
-        "id": "2f2d8b62-5e53-46b2-bde9-a291bcc5f9e7",
-        "type": "scale",
-        "hex": "#31C0F6",
-        "name": "Nineteen Eighty Four",
-        "value": 0
+        id: '2f2d8b62-5e53-46b2-bde9-a291bcc5f9e7',
+        type: 'scale',
+        hex: '#31C0F6',
+        name: 'Nineteen Eighty Four',
+        value: 0,
       },
       {
-        "id": "4b0d1e17-2177-40cf-b524-980fe80f6ca8",
-        "type": "scale",
-        "hex": "#A500A5",
-        "name": "Nineteen Eighty Four",
-        "value": 0
+        id: '4b0d1e17-2177-40cf-b524-980fe80f6ca8',
+        type: 'scale',
+        hex: '#A500A5',
+        name: 'Nineteen Eighty Four',
+        value: 0,
       },
       {
-        "id": "d90d4be9-14f8-48da-a309-8d2cb50f6961",
-        "type": "scale",
-        "hex": "#FF7E27",
-        "name": "Nineteen Eighty Four",
-        "value": 0
-      }
+        id: 'd90d4be9-14f8-48da-a309-8d2cb50f6961',
+        type: 'scale',
+        hex: '#FF7E27',
+        name: 'Nineteen Eighty Four',
+        value: 0,
+      },
     ],
-  }
+  },
 }
 
 const expectedData = {
-  'mappingForGiraffe' : {
-    "mappings": [
+  mappingForGiraffe: {
+    mappings: [
       {
-        "_start": `${MOCK_START}`,
-        "_stop": `${MOCK_STOP}`,
-        "_field": "co",
-        "_measurement": "airSensors",
-        "sensor_id": "TLM0100",
-        "result": "mean",
-        "color": "#31C0F6"
+        _start: `${MOCK_START}`,
+        _stop: `${MOCK_STOP}`,
+        _field: 'co',
+        _measurement: 'airSensors',
+        sensor_id: 'TLM0100',
+        result: 'mean',
+        color: '#31C0F6',
       },
       {
-        "_start": `${MOCK_START}`,
-        "_stop": `${MOCK_STOP}`,
-        "_field": "co",
-        "_measurement": "airSensors",
-        "sensor_id": "TLM0101",
-        "result": "mean",
-        "color": "#A500A5"
+        _start: `${MOCK_START}`,
+        _stop: `${MOCK_STOP}`,
+        _field: 'co',
+        _measurement: 'airSensors',
+        sensor_id: 'TLM0101',
+        result: 'mean',
+        color: '#A500A5',
       },
       {
-        "_start": `${MOCK_START}`,
-        "_stop": `${MOCK_STOP}`,
-        "_field": "co",
-        "_measurement": "airSensors",
-        "sensor_id": "TLM0102",
-        "result": "mean",
-        "color": "#FF7E27"
-      }
+        _start: `${MOCK_START}`,
+        _stop: `${MOCK_STOP}`,
+        _field: 'co',
+        _measurement: 'airSensors',
+        sensor_id: 'TLM0102',
+        result: 'mean',
+        color: '#FF7E27',
+      },
     ],
-    "columnKeys": [
-      "_start",
-      "_stop",
-      "_field",
-      "_measurement",
-      "sensor_id",
-      "result"
+    columnKeys: [
+      '_start',
+      '_stop',
+      '_field',
+      '_measurement',
+      'sensor_id',
+      'result',
     ],
-    "seriesToColorIndexMap": {
-      "co-airSensors-TLM0100-mean-": 0,
-      "co-airSensors-TLM0101-mean-": 1,
-      "co-airSensors-TLM0102-mean-": 2
-    }
+    seriesToColorIndexMap: {
+      'co-airSensors-TLM0100-mean-': 0,
+      'co-airSensors-TLM0101-mean-': 1,
+      'co-airSensors-TLM0102-mean-': 2,
+    },
   },
-  'mappingForIDPE': {
-    "colorMapping": {
-      "co-airSensors-TLM0100-mean-": 0,
-      "co-airSensors-TLM0101-mean-": 1,
-      "co-airSensors-TLM0102-mean-": 2
-    }
-  }
+  mappingForIDPE: {
+    colorMapping: {
+      'co-airSensors-TLM0100-mean-': 0,
+      'co-airSensors-TLM0101-mean-': 1,
+      'co-airSensors-TLM0102-mean-': 2,
+    },
+  },
 }
 
 describe('color mapping utils', function() {
   it('should generate a color mapping when view properties from the IDPE do not have colorMapping', function() {
-    const {colorMappingForGiraffe, colorMappingForIDPE, needsToSaveToIDPE} = getColorMappingObjects(
+    const {
+      colorMappingForGiraffe,
+      colorMappingForIDPE,
+      needsToSaveToIDPE,
+    } = getColorMappingObjects(
       dataFromIDPE_noColorMapping.columnGroup,
       dataFromIDPE_noColorMapping.properties as XYViewProperties
     )
 
     expect(colorMappingForGiraffe).toStrictEqual(expectedData.mappingForGiraffe)
     expect(needsToSaveToIDPE).toBe(true)
-    expect(colorMappingForIDPE).toStrictEqual(expectedData.mappingForIDPE.colorMapping)
+    expect(colorMappingForIDPE).toStrictEqual(
+      expectedData.mappingForIDPE.colorMapping
+    )
   })
 })
-

--- a/src/visualization/utils/colorMappingUtils.test.ts
+++ b/src/visualization/utils/colorMappingUtils.test.ts
@@ -1,5 +1,3 @@
-// tests will go here
-
 import {getColorMappingObjects} from './colorMappingUtils'
 import {XYViewProperties} from '../../client'
 

--- a/src/visualization/utils/colorMappingUtils.ts
+++ b/src/visualization/utils/colorMappingUtils.ts
@@ -16,7 +16,7 @@ const areMappingsSame = (map1, map2) => {
 
   // If number of properties is different,
   // objects are not equivalent
-  if (aProps.length != bProps.length) {
+  if (aProps.length !== bProps.length) {
     return false
   }
 
@@ -48,7 +48,6 @@ export const getColorMappingObjects = (
     columnGroupMap,
     properties
   )
-  let needsToSaveToIDPE = false
 
   // if the mappings from the IDPE and the *required* one's for the current view are the same, we don't need to generate new mappings
   if (areMappingsSame(properties.colorMapping, seriesToColorIndexMap)) {
@@ -64,8 +63,7 @@ export const getColorMappingObjects = (
       graphLine.color = colors[properties.colorMapping[seriesID]].hex
     })
 
-    needsToSaveToIDPE = false
-
+    const needsToSaveToIDPE = false
     return {
       colorMappingForGiraffe: {columnKeys, ...mappings},
       needsToSaveToIDPE,
@@ -73,6 +71,7 @@ export const getColorMappingObjects = (
   } else {
     const columnKeys = columnGroupMap.columnKeys
     const mappings = {...columnGroupMap}
+    const needsToSaveToIDPE = true
 
     mappings.mappings.forEach(graphLine => {
       const seriesID = getSeriesId(graphLine, columnKeys)
@@ -85,9 +84,7 @@ export const getColorMappingObjects = (
 
     const newColorMappingForGiraffe = {
       ...mappings,
-      seriesToColorIndexMap,
     }
-    needsToSaveToIDPE = true
 
     return {
       colorMappingForIDPE: seriesToColorIndexMap,
@@ -97,6 +94,33 @@ export const getColorMappingObjects = (
   }
 }
 
+/**
+ * This function returns the series id of the graphLine.
+ * Example Graph line would look like:
+ * {
+ *    _start: `${MOCK_START}`,
+ *    _stop: `${MOCK_STOP}`,
+ *    _field: 'co',
+ *    _measurement: 'airSensors',
+ *    sensor_id: 'TLM0102',
+ *    result: 'mean',
+ * },
+ *
+ * The columnKeys are:
+ * columnKeys: [
+ *       '_start',
+ *       '_stop',
+ *       '_field',
+ *       '_measurement',
+ *       'sensor_id',
+ *       'result',
+ *     ],
+ *
+ * the seriesID would be : "co-airSensors-TLM0102-mean-"
+ *
+ * @param graphLine
+ * @param columnKeys
+ */
 const getSeriesId = (graphLine, columnKeys) => {
   let id = ''
   for (const key of columnKeys) {

--- a/src/visualization/utils/colorMappingUtils.ts
+++ b/src/visualization/utils/colorMappingUtils.ts
@@ -37,7 +37,7 @@ const areMappingsSame = (map1, map2) => {
  * Returns the colorMapping objects for UI, based on the state of the current view it will return the existing or generate a new one and request trigger saving to IDPE
  * @param columnGroupMap
  * @param properties
- * @returns [colorMappingForIDPE, colorMappingForGiraffe, needsToSaveToIDPE]
+ * @returns an object shaped : {colorMappingForIDPE?, colorMappingForGiraffe?, needsToSaveToIDPE}
  */
 
 export const getColorMappingObjectsForIDPEAndGiraffe = (
@@ -50,8 +50,9 @@ export const getColorMappingObjectsForIDPEAndGiraffe = (
   )
   let needsToSaveToIDPE = false
 
+  // if the mappings from the IDPE and the *required* one's for the current view are the same, we don't need to generate new mappings
   if (areMappingsSame(properties.colorMapping, seriesToColorIndexMap)) {
-    console.log('@ui color mapping already exists returning', properties)
+    console.log('@ui color mapping already exists ', {properties})
 
     const columnKeys = columnGroupMap.columnKeys
     const mappings = {...columnGroupMap}
@@ -60,23 +61,31 @@ export const getColorMappingObjectsForIDPEAndGiraffe = (
       const seriesID = getSeriesId(graphLine, columnKeys)
 
       const colors = properties.colors
+
+      // this is needed for giraffe
       graphLine.color = colors[properties.colorMapping[seriesID]].hex
     })
 
     needsToSaveToIDPE = false
 
-    return [{columnKeys, ...mappings}, needsToSaveToIDPE]
+    return {
+      colorMappingForGiraffe: {columnKeys, ...mappings},
+      needsToSaveToIDPE,
+    }
   } else {
     console.log('@ui needs new colormapping, generating...')
 
     needsToSaveToIDPE = true
     const newColorMappingForGiraffe = {
       ...columnGroupMap,
-      seriesToColorIndexMap: seriesToColorIndexMap,
+      seriesToColorIndexMap,
     }
-    const colorMappingForIDPE = seriesToColorIndexMap
 
-    return [colorMappingForIDPE, newColorMappingForGiraffe, needsToSaveToIDPE]
+    return {
+      colorMappingForIDPE: seriesToColorIndexMap,
+      colorMappingForGiraffe: newColorMappingForGiraffe,
+      needsToSaveToIDPE,
+    }
   }
 }
 

--- a/src/visualization/utils/colorMappingUtils.ts
+++ b/src/visualization/utils/colorMappingUtils.ts
@@ -40,7 +40,7 @@ const areMappingsSame = (map1, map2) => {
  * @returns an object shaped : {colorMappingForIDPE?, colorMappingForGiraffe?, needsToSaveToIDPE}
  */
 
-export const getColorMappingObjectsForIDPEAndGiraffe = (
+export const getColorMappingObjects = (
   columnGroupMap,
   properties: XYViewProperties
 ) => {
@@ -52,8 +52,6 @@ export const getColorMappingObjectsForIDPEAndGiraffe = (
 
   // if the mappings from the IDPE and the *required* one's for the current view are the same, we don't need to generate new mappings
   if (areMappingsSame(properties.colorMapping, seriesToColorIndexMap)) {
-    console.log('@ui color mapping already exists ', {properties})
-
     const columnKeys = columnGroupMap.columnKeys
     const mappings = {...columnGroupMap}
 
@@ -73,13 +71,23 @@ export const getColorMappingObjectsForIDPEAndGiraffe = (
       needsToSaveToIDPE,
     }
   } else {
-    console.log('@ui needs new colormapping, generating...')
+    const columnKeys = columnGroupMap.columnKeys
+    const mappings = {...columnGroupMap}
 
-    needsToSaveToIDPE = true
+    mappings.mappings.forEach(graphLine => {
+      const seriesID = getSeriesId(graphLine, columnKeys)
+
+      const colors = properties.colors
+
+      // this is needed for giraffe
+      graphLine.color = colors[seriesToColorIndexMap[seriesID]].hex
+    })
+
     const newColorMappingForGiraffe = {
-      ...columnGroupMap,
+      ...mappings,
       seriesToColorIndexMap,
     }
+    needsToSaveToIDPE = true
 
     return {
       colorMappingForIDPE: seriesToColorIndexMap,

--- a/src/visualization/utils/colorMappingUtils.ts
+++ b/src/visualization/utils/colorMappingUtils.ts
@@ -1,0 +1,113 @@
+import {XYViewProperties} from 'src/types'
+
+/**
+ * Evaluates deeper equality for two map objects based on their key:value pair
+ * @param map1
+ * @param map2
+ */
+const areMappingsSame = (map1, map2) => {
+  if (!map1 || !map2) {
+    return false
+  }
+
+  // Create arrays of property names
+  const aProps = Object.getOwnPropertyNames(map1)
+  const bProps = Object.getOwnPropertyNames(map2)
+
+  // If number of properties is different,
+  // objects are not equivalent
+  if (aProps.length != bProps.length) {
+    return false
+  }
+
+  for (let i = 0; i < aProps.length; i++) {
+    const propName = aProps[i]
+
+    // If values of same property are not equal,
+    // objects are not equivalent
+    if (map1[propName] !== map2[propName]) {
+      return false
+    }
+  }
+
+  return true
+}
+
+/**
+ * Returns the colorMapping objects for UI, based on the state of the current view it will return the existing or generate a new one and request trigger saving to IDPE
+ * @param columnGroupMap
+ * @param properties
+ * @returns [colorMappingForIDPE, colorMappingForGiraffe, needsToSaveToIDPE]
+ */
+
+export const getColorMappingObjectsForIDPEAndGiraffe = (
+  columnGroupMap,
+  properties: XYViewProperties
+) => {
+  const seriesToColorIndexMap = generateSeriesToColorIndexMap(
+    columnGroupMap,
+    properties
+  )
+  let needsToSaveToIDPE = false
+
+  if (areMappingsSame(properties.colorMapping, seriesToColorIndexMap)) {
+    console.log('@ui color mapping already exists returning', properties)
+
+    const columnKeys = columnGroupMap.columnKeys
+    const mappings = {...columnGroupMap}
+
+    mappings.mappings.forEach(graphLine => {
+      const seriesID = getSeriesId(graphLine, columnKeys)
+
+      const colors = properties.colors
+      graphLine.color = colors[properties.colorMapping[seriesID]].hex
+    })
+
+    needsToSaveToIDPE = false
+
+    return [{columnKeys, ...mappings}, needsToSaveToIDPE]
+  } else {
+    console.log('@ui needs new colormapping, generating...')
+
+    needsToSaveToIDPE = true
+    const newColorMappingForGiraffe = {
+      ...columnGroupMap,
+      seriesToColorIndexMap: seriesToColorIndexMap,
+    }
+    const colorMappingForIDPE = seriesToColorIndexMap
+
+    return [colorMappingForIDPE, newColorMappingForGiraffe, needsToSaveToIDPE]
+  }
+}
+
+const getSeriesId = (graphLine, columnKeys) => {
+  let id = ''
+  for (const key of columnKeys) {
+    // ignore the '_start' and '_stop' columns when generating the ID.
+    if (key !== '_start' && key !== '_stop') {
+      id += graphLine[key] + '-'
+    }
+  }
+  return id
+}
+
+/**
+ * This function generates a map that maps the series ID to the color Index.
+ * @param columnGroupMap - generated using the createGroupIDColumn function
+ * @param properties - XYViewProperties
+ * @returns - a map that contains the series ID and it's color index (value bounded by the properties.colors array)
+ */
+
+export const generateSeriesToColorIndexMap = (
+  columnGroupMap,
+  properties: XYViewProperties
+) => {
+  const seriesToColorIndexMap = {}
+
+  columnGroupMap.mappings.forEach((graphLine, colorIndex) => {
+    const id = getSeriesId(graphLine, columnGroupMap.columnKeys)
+    seriesToColorIndexMap[id] = colorIndex % properties.colors.length
+  })
+
+  return {...seriesToColorIndexMap}
+}

--- a/src/visualization/utils/colorMappingUtils.ts
+++ b/src/visualization/utils/colorMappingUtils.ts
@@ -120,8 +120,8 @@ export const generateSeriesToColorIndexMap = (
   properties: XYViewProperties
 ) => {
   const seriesToColorIndexMap = {}
-
-  columnGroupMap.mappings.forEach((graphLine, colorIndex) => {
+  const cgMap = {...columnGroupMap}
+  cgMap.mappings.forEach((graphLine, colorIndex) => {
     const id = getSeriesId(graphLine, columnGroupMap.columnKeys)
     seriesToColorIndexMap[id] = colorIndex % properties.colors.length
   })


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/3098

Bigger Picture: 

<img width="1490" alt="Screen Shot 2021-12-17 at 3 34 02 PM" src="https://user-images.githubusercontent.com/18511823/146615656-f8af01e7-2481-4846-8bb6-243c7397ad39.png">

The `translate` is basically looking at the `viewProperties.colorMapping` object from the `idpe` and then looking up the `color` using the index in the `properties.colors` array. We then embed the `color` property into the `mappings.[series_index]` object in giraffe.

Visualization of how the colorMapping object is translated into color for the giraffe. This translation happens in the UI. (`getColorMappingObjects` function)  

<img width="1132" alt="Screen Shot 2021-12-17 at 3 51 12 PM" src="https://user-images.githubusercontent.com/18511823/146616789-33bba517-754d-4c50-bf00-f75ba1a833eb.png">

