### PR TITLE
fix: connect the API changes to the UI to get maps to display in shared notebooks

### DIFF
--- a/src/visualization/types/Map/view.tsx
+++ b/src/visualization/types/Map/view.tsx
@@ -51,7 +51,14 @@ const GeoPlot: FC<Props> = ({result, properties}) => {
   })
 
   useEffect(() => {
-    if (CLOUD) {
+    const token = properties?.layers?.find(
+      layer => layer?.tileServerConfiguration?.tileServerUrl
+    )
+    if (CLOUD && token) {
+      setMapServiceError(RemoteDataState.Done)
+      setMapToken(token.tileServerConfiguration?.tileServerUrl)
+    }
+    if (CLOUD && !token) {
       const getToken = async () => {
         try {
           setMapServiceError(RemoteDataState.Loading)
@@ -71,7 +78,7 @@ const GeoPlot: FC<Props> = ({result, properties}) => {
       }
       getToken()
     }
-  }, [])
+  }, [properties.layers])
 
   useEffect(() => {
     try {
@@ -132,6 +139,7 @@ const GeoPlot: FC<Props> = ({result, properties}) => {
       </div>
     )
   }
+
   const tileServerConfiguration = {
     tileServerUrl: getMapboxUrl(),
     bingKey: '',


### PR DESCRIPTION
Closes #3245

This PR (along with a corresponding API change), fixes the issue where maps in shared notebooks can't be displayed. The API PR goes into more detail as to what the issue is, and how it's resolved

