### PR TITLE
chore: swap influxdata/influx types for generated types or types defined in the UI

### DIFF
--- a/mocks/dummyData.ts
+++ b/mocks/dummyData.ts
@@ -1,192 +1,6 @@
 import {match} from 'react-router'
-import {ViewProperties} from 'src/client'
-import {
-  Cell,
-  Dashboard,
-  Task,
-  ConfigurationState,
-  RemoteDataState,
-  Label,
-} from 'src/types'
-import {OnboardingStepProps} from 'src/onboarding/containers/OnboardingWizard'
 import {RouteComponentProps} from 'react-router-dom'
-import {NumericColumnData} from '@influxdata/giraffe'
-import {
-  Source,
-  TelegrafPluginInputCpu,
-  TelegrafPluginInputRedis,
-  TelegrafPluginInputDisk,
-  TelegrafPluginInputDiskio,
-  TelegrafPluginInputMem,
-  TelegrafPluginInputSystem,
-  TelegrafPluginInputProcesses,
-  TelegrafPluginInputNet,
-  TelegrafPluginInputProcstat,
-  TelegrafPluginInputDocker,
-  TelegrafPluginInputSwap,
-  Task as TaskApi,
-  Organization,
-  Variable,
-  Authorization,
-  AuthorizationUpdateRequest,
-  Permission,
-  PermissionResource,
-} from '@influxdata/influx'
-
-export const queryConfig = {
-  queries: [
-    {
-      id: '60842c85-8bc7-4180-a844-b974e47a98cd',
-      query:
-        'SELECT mean(:fields:), mean("usage_user") AS "mean_usage_user" FROM "telegraf"."autogen"."cpu" WHERE time > :dashboardTime: GROUP BY time(:interval:) FILL(null)',
-      queryConfig: {
-        id: '60842c85-8bc7-4180-a844-b974e47a98cd',
-        database: 'telegraf',
-        measurement: 'cpu',
-        retentionPolicy: 'autogen',
-        fields: [
-          {
-            value: 'mean',
-            type: 'func',
-            alias: '',
-            args: [{value: 'usage_idle', type: 'field', alias: ''}],
-          },
-          {
-            value: 'mean',
-            type: 'func',
-            alias: 'mean_usage_user',
-            args: [{value: 'usage_user', type: 'field', alias: ''}],
-          },
-        ],
-        tags: {},
-        groupBy: {time: 'auto', tags: []},
-        areTagsAccepted: false,
-        fill: 'null',
-        rawText:
-          'SELECT mean(:fields:), mean("usage_user") AS "mean_usage_user" FROM "telegraf"."autogen"."cpu" WHERE time > :dashboardTime: GROUP BY time(:interval:) FILL(null)',
-        range: null,
-        shifts: [],
-      },
-      queryTemplated:
-        'SELECT mean("usage_idle"), mean("usage_user") AS "mean_usage_user" FROM "telegraf"."autogen"."cpu" WHERE time > :dashboardTime: GROUP BY time(:interval:) FILL(null)',
-      tempVars: [
-        {
-          tempVar: ':fields:',
-          values: [{value: 'usage_idle', type: 'fieldKey', selected: true}],
-        },
-      ],
-    },
-  ],
-}
-
-export const source: Source = {
-  id: '16',
-  name: 'ssl',
-  type: Source.TypeEnum.Self,
-  username: 'admin',
-  url: 'https://localhost:9086',
-  insecureSkipVerify: true,
-  telegraf: 'telegraf',
-}
-
-export const query = {
-  id: '0',
-  database: 'db1',
-  measurement: 'm1',
-  retentionPolicy: 'r1',
-  fill: 'null',
-  fields: [
-    {
-      value: 'f1',
-      type: 'field',
-      alias: 'foo',
-      args: [],
-    },
-  ],
-  tags: {
-    tk1: ['tv1', 'tv2'],
-  },
-  groupBy: {
-    time: null,
-    tags: [],
-  },
-  areTagsAccepted: true,
-  rawText: null,
-  status: null,
-  shifts: [],
-}
-
-// Dashboards
-export const dashboard: Dashboard = {
-  id: '1',
-  orgID: '02ee9e2a29d73000',
-  cells: [],
-  name: 'd1',
-  links: {
-    self: 'self/link',
-    cells: 'cells/link',
-  },
-  meta: {
-    createdAt: '2019-01-08T11:57:31.562044-08:00',
-    updatedAt: '2019-01-08T12:57:31.562048-08:00',
-  },
-  labels: [],
-  status: RemoteDataState.Done,
-}
-
-export const labels: Label[] = [
-  {
-    id: '0001',
-    name: 'Trogdor',
-    properties: {
-      color: '#44ffcc',
-      description: 'Burninating the countryside',
-    },
-    status: RemoteDataState.Done,
-  },
-  {
-    id: '0002',
-    name: 'Strawberry',
-    properties: {
-      color: '#ff0054',
-      description: 'It is a great fruit',
-    },
-    status: RemoteDataState.Done,
-  },
-]
-
-const labelIDs = labels.map(l => l.id)
-
-export const dashboardWithLabels: Dashboard = {
-  id: '1',
-  cells: [],
-  name: 'd1',
-  orgID: '02ee9e2a29d73000',
-  links: {
-    self: 'self/link',
-    cells: 'cells/link',
-  },
-  meta: {
-    createdAt: '2019-01-08T11:57:31.562044-08:00',
-    updatedAt: '2019-01-08T12:57:31.562048-08:00',
-  },
-  status: RemoteDataState.Done,
-  labels: labelIDs,
-}
-
-export const cell: Cell = {
-  x: 0,
-  y: 0,
-  w: 4,
-  h: 4,
-  id: '0246e457-916b-43e3-be99-211c4cbc03e8',
-  dashboardID: 'dummyDashboardID',
-  links: {
-    self: 'self/link',
-    view: 'view/link',
-  },
-  status: RemoteDataState.Done,
-}
+import {AuthorizationUpdateRequest, Organization} from 'src/types'
 
 export const orgs: Organization[] = [
   {
@@ -200,62 +14,6 @@ export const orgs: Organization[] = [
     name: 'RadicalOrganization',
   },
 ]
-
-export const tasks: Task[] = [
-  {
-    id: '02ef9deff2141000',
-    orgID: '02ee9e2a29d73000',
-    name: 'pasdlak',
-    status: TaskApi.StatusEnum.Active,
-    flux:
-      'option task = {\n  name: "pasdlak",\n  cron: "2 0 * * *"\n}\nfrom(bucket: "inbucket") \n|> range(start: -1h)',
-    cron: '2 0 * * *',
-    org: 'default',
-    labels: [],
-    createdAt: '2021-06-08T00:25:17.501582756Z',
-    latestCompleted: '2021-06-08T02:25:52.118899855Z',
-  },
-  {
-    id: '02f12c50dba72000',
-    orgID: '02ee9e2a29d73000',
-    name: 'somename',
-    status: TaskApi.StatusEnum.Active,
-    flux:
-      'option task = {\n  name: "somename",\n  every: 1m,\n}\nfrom(bucket: "inbucket") \n|> range(start: -task.every)',
-    every: '1m0s',
-    org: 'default',
-    labels: labelIDs,
-    createdAt: '2021-06-08T00:25:17.501582756Z',
-    latestCompleted: '2021-06-08T02:25:52.118899855Z',
-  },
-]
-
-export const variables: Variable[] = [
-  {
-    name: 'LittleVariable',
-    orgID: '0',
-    arguments: {
-      type: 'query',
-      values: {query: '1 + 1 ', language: 'flux'},
-    },
-  },
-]
-
-export const defaultOnboardingStepProps: OnboardingStepProps = {
-  currentStepIndex: 0,
-  onSetCurrentStepIndex: jest.fn(),
-  onIncrementCurrentStepIndex: jest.fn(),
-  onDecrementCurrentStepIndex: jest.fn(),
-  onSetStepStatus: jest.fn(),
-  stepStatuses: [],
-  stepTitles: [],
-  stepTestIds: [],
-  setupParams: {username: '', password: '', org: '', bucket: ''},
-  handleSetSetupParams: jest.fn(),
-  notify: jest.fn(),
-  onCompleteSetup: jest.fn(),
-  onExit: jest.fn(),
-}
 
 const match: match<{orgID: string}> = {
   isExact: false,
@@ -272,583 +30,6 @@ export const withRouterProps: RouteComponentProps<{orgID: string}> = {
   history: null,
 }
 
-export const token =
-  'm4aUjEIhM758JzJgRmI6f3KNOBw4ZO77gdwERucF0bj4QOLHViD981UWzjaxW9AbyA5THOMBp2SVZqzbui2Ehw=='
-
-export const telegrafConfigID = '030358c935b18000'
-
-export const cpuPlugin = {
-  name: 'cpu',
-  type: 'input',
-  comment: 'this is a test',
-  config: {},
-}
-
-export const telegrafPlugin = {
-  name: TelegrafPluginInputCpu.NameEnum.Cpu,
-  configured: ConfigurationState.Unconfigured,
-  active: false,
-}
-
-export const cpuTelegrafPlugin = {
-  ...telegrafPlugin,
-  configured: ConfigurationState.Configured,
-  templateID: '0000000000000009',
-}
-
-export const diskTelegrafPlugin = {
-  ...telegrafPlugin,
-  name: TelegrafPluginInputDisk.NameEnum.Disk,
-  configured: ConfigurationState.Configured,
-  templateID: '0000000000000009',
-}
-
-export const diskioTelegrafPlugin = {
-  ...telegrafPlugin,
-  name: TelegrafPluginInputDiskio.NameEnum.Diskio,
-  configured: ConfigurationState.Configured,
-  templateID: '0000000000000009',
-}
-
-export const netTelegrafPlugin = {
-  ...telegrafPlugin,
-  name: TelegrafPluginInputNet.NameEnum.Net,
-  configured: ConfigurationState.Configured,
-  templateID: '0000000000000009',
-}
-
-export const memTelegrafPlugin = {
-  ...telegrafPlugin,
-  name: TelegrafPluginInputMem.NameEnum.Mem,
-  configured: ConfigurationState.Configured,
-  templateID: '0000000000000009',
-}
-
-export const processesTelegrafPlugin = {
-  ...telegrafPlugin,
-  name: TelegrafPluginInputProcesses.NameEnum.Processes,
-  configured: ConfigurationState.Configured,
-  templateID: '0000000000000009',
-}
-
-export const procstatTelegrafPlugin = {
-  ...telegrafPlugin,
-  name: TelegrafPluginInputProcstat.NameEnum.Procstat,
-  configured: ConfigurationState.Unconfigured,
-}
-
-export const systemTelegrafPlugin = {
-  ...telegrafPlugin,
-  name: TelegrafPluginInputSystem.NameEnum.System,
-  configured: ConfigurationState.Configured,
-  templateID: '0000000000000009',
-}
-
-export const redisTelegrafPlugin = {
-  ...telegrafPlugin,
-  name: TelegrafPluginInputRedis.NameEnum.Redis,
-  templateID: '0000000000000008',
-}
-
-export const swapTelegrafPlugin = {
-  ...telegrafPlugin,
-  name: TelegrafPluginInputSwap.NameEnum.Swap,
-  configured: ConfigurationState.Configured,
-  templateID: '0000000000000009',
-}
-
-export const redisPlugin = {
-  name: TelegrafPluginInputRedis.NameEnum.Redis,
-  type: TelegrafPluginInputRedis.TypeEnum.Input,
-  config: {
-    servers: [],
-    password: '',
-  },
-}
-
-export const dockerTelegrafPlugin = {
-  ...telegrafPlugin,
-  name: TelegrafPluginInputDocker.NameEnum.Docker,
-  configured: ConfigurationState.Configured,
-  templateID: '0000000000000002',
-}
-
-export const influxDB2Plugin = {
-  name: 'influxdb_v2',
-  type: 'output',
-  comment: 'write to influxdb v2',
-  config: {
-    urls: ['http://127.0.0.1:9999'],
-    token,
-    organization: 'default',
-    bucket: 'defbuck',
-  },
-}
-
-export const telegrafConfig = {
-  id: telegrafConfigID,
-  orgID: '1',
-  name: 'in n out',
-  created: '2018-11-28T18:56:48.854337-08:00',
-  lastModified: '2018-11-28T18:56:48.854337-08:00',
-  lastModifiedBy: '030358b695318000',
-  agent: {collectionInterval: 15},
-  plugins: [cpuPlugin, influxDB2Plugin],
-}
-
-export const getTelegrafConfigsResponse = {
-  data: {
-    configurations: [telegrafConfig],
-  },
-  status: 200,
-  statusText: 'OK',
-  headers: {
-    date: 'Thu, 29 Nov 2018 18:10:21 GMT',
-    'content-length': '570',
-    'content-type': 'application/json; charset=utf-8',
-  },
-  config: {
-    transformRequest: {},
-    transformResponse: {},
-    timeout: 0,
-    xsrfCookieName: 'XSRF-TOKEN',
-    xsrfHeaderName: 'X-XSRF-TOKEN',
-    maxContentLength: -1,
-    headers: {Accept: 'application/json, text/plain, */*'},
-    method: 'get',
-    url: '/api/v2/telegrafs?org=',
-  },
-  request: {},
-}
-
-export const createTelegrafConfigResponse = {
-  data: telegrafConfig,
-}
-
-export const bucket = {
-  links: {
-    labels: '/api/v2/buckets/034a10d6f7a6b000/labels',
-    log: '/api/v2/buckets/034a10d6f7a6b000/log',
-    org: '/api/v2/orgs/034a0adc49a6b000',
-    self: '/api/v2/buckets/034a10d6f7a6b000',
-  },
-  id: '034a10d6f7a6b000',
-  orgID: '034a0adc49a6b000',
-  name: 'newbuck',
-  retentionRules: [],
-  labels: [],
-}
-
-export const buckets = [
-  {
-    links: {
-      labels: '/api/v2/buckets/034a10d6f7a6b000/labels',
-      log: '/api/v2/buckets/034a10d6f7a6b000/log',
-      org: '/api/v2/orgs/034a0adc49a6b000',
-      self: '/api/v2/buckets/034a10d6f7a6b000',
-    },
-    id: '034a10d6f7a6b000',
-    orgID: '034a0adc49a6b000',
-    name: 'newbuck',
-    retentionRules: [],
-    readableRetention: 'forever',
-    labels: [],
-  },
-  {
-    links: {
-      labels: '/api/v2/buckets/034a10d6f7a6b000/labels',
-      log: '/api/v2/buckets/034a10d6f7a6b000/log',
-      org: '/api/v2/orgs/034a0adc49a6b000',
-      self: '/api/v2/buckets/034a10d6f7a6b000',
-    },
-    id: '034a10d6f7a6b001',
-    orgID: '034a0adc49a6b000',
-    name: 'newbuck1',
-    retentionRules: [],
-    readableRetention: 'forever',
-    labels: [],
-  },
-]
-
-export const setSetupParamsResponse = {
-  data: {
-    user: {
-      links: {
-        log: '/api/v2/users/033bc62520fe3000/log',
-        self: '/api/v2/users/033bc62520fe3000',
-      },
-      id: '033bc62520fe3000',
-      name: 'iris',
-    },
-    bucket: {
-      links: {
-        labels: '/api/v2/buckets/033bc62534fe3000/labels',
-        log: '/api/v2/buckets/033bc62534fe3000/log',
-        org: '/api/v2/orgs/033bc62534be3000',
-        self: '/api/v2/buckets/033bc62534fe3000',
-      },
-      id: '033bc62534fe3000',
-      orgID: '033bc62534be3000',
-      name: 'defbuck',
-      retentionRules: [],
-      labels: [],
-    },
-    org: {
-      links: {
-        buckets: '/api/v2/buckets?org=default',
-        dashboards: '/api/v2/dashboards?org=default',
-        labels: '/api/v2/orgs/033bc62534be3000/labels',
-        log: '/api/v2/orgs/033bc62534be3000/log',
-        members: '/api/v2/orgs/033bc62534be3000/members',
-        secrets: '/api/v2/orgs/033bc62534be3000/secrets',
-        self: '/api/v2/orgs/033bc62534be3000',
-        tasks: '/api/v2/tasks?org=default',
-      },
-      id: '033bc62534be3000',
-      name: 'default',
-    },
-    auth: {
-      id: '033bc62534fe3001',
-      token:
-        'GSEx9BfvjlwQZfjoMgYX9rARwK2Nzc2jaiLdZso9E6X9K1ymldtQ3DwYbCqV3ClJ47sXdI1nLzsP2C1S4u76hA==',
-      status: 'active',
-      description: "iris's Token",
-      orgID: '033bc62534be3000',
-      org: 'default',
-      userID: '033bc62520fe3000',
-      user: 'iris',
-      permissions: [
-        {
-          action: 'read',
-          resource: 'authorizations',
-          orgID: '033bc62534be3000',
-        },
-        {
-          action: 'write',
-          resource: 'authorizations',
-          orgID: '033bc62534be3000',
-        },
-        {action: 'read', resource: 'buckets', orgID: '033bc62534be3000'},
-        {action: 'write', resource: 'buckets', orgID: '033bc62534be3000'},
-        {action: 'read', resource: 'dashboards', orgID: '033bc62534be3000'},
-        {action: 'write', resource: 'dashboards', orgID: '033bc62534be3000'},
-        {action: 'read', resource: 'orgs', orgID: '033bc62534be3000'},
-        {action: 'write', resource: 'orgs', orgID: '033bc62534be3000'},
-        {action: 'read', resource: 'sources', orgID: '033bc62534be3000'},
-        {action: 'write', resource: 'sources', orgID: '033bc62534be3000'},
-        {action: 'read', resource: 'tasks', orgID: '033bc62534be3000'},
-        {action: 'write', resource: 'tasks', orgID: '033bc62534be3000'},
-        {action: 'read', resource: 'telegrafs', orgID: '033bc62534be3000'},
-        {action: 'write', resource: 'telegrafs', orgID: '033bc62534be3000'},
-        {action: 'read', resource: 'users', orgID: '033bc62534be3000'},
-        {action: 'write', resource: 'users', orgID: '033bc62534be3000'},
-      ],
-      links: {
-        self: '/api/v2/authorizations/033bc62534fe3001',
-        user: '/api/v2/users/033bc62520fe3000',
-      },
-    },
-  },
-  status: 201,
-  statusText: 'Created',
-  headers: {
-    'access-control-allow-origin': 'http://localhost:9999',
-    date: 'Fri, 11 Jan 2019 22:49:33 GMT',
-    'access-control-allow-headers':
-      'Accept, Content-Type, Content-Length, Accept-Encoding, Authorization',
-    'transfer-encoding': 'chunked',
-    'access-control-allow-methods': 'POST, GET, OPTIONS, PUT, DELETE',
-    'content-type': 'application/json; charset=utf-8',
-  },
-  config: {
-    transformRequest: {},
-    transformResponse: {},
-    timeout: 0,
-    xsrfCookieName: 'XSRF-TOKEN',
-    xsrfHeaderName: 'X-XSRF-TOKEN',
-    maxContentLength: -1,
-    headers: {
-      Accept: 'application/json, text/plain, */*',
-      'Content-Type': 'application/json',
-    },
-    method: 'post',
-    data:
-      '{"username":"iris","password":"iris","org":"default","bucket":"defbuck"}',
-    url: '/api/v2/setup',
-  },
-  request: {},
-}
-
-export const telegraf = [
-  {
-    id: '03636a150fb51000',
-    name: 'Name this Configuration',
-    orgID: '03636a0aabb51000',
-  },
-  {
-    id: '03636a150fb51001',
-    name: 'Name this Configuration',
-    orgID: '03636a0aabb51000',
-  },
-]
-
-export const scraperTargets = [
-  {
-    bucket: 'a',
-    bucketID: '03636a0aabb51001',
-    id: '03636a0bfe351000',
-    name: 'new target',
-    orgID: '03636a0aabb51000',
-    organization: 'a',
-    type: 'prometheus',
-    url: 'http://localhost:9999/metrics',
-  },
-  {
-    bucket: 'a',
-    bucketID: '03636a0aabb51001',
-    id: '03636a0bfe351001',
-    name: 'new target',
-    orgID: '03636a0aabb51000',
-    organization: 'a',
-    type: 'prometheus',
-    url: 'http://localhost:9999/metrics',
-  },
-]
-
-export const auth: Authorization = {
-  id: '03c03a8a64728000',
-  token:
-    'RcW2uWiD-vfxujKyJCirK8un3lJsWPfiA6ulmWY_SlSITUal7Z180OwExiKKfrO98X8W6qGrd5hSGdag-hEpWw==',
-  status: AuthorizationUpdateRequest.StatusEnum.Active,
-  description: 'My token',
-  orgID: '039edab314789000',
-  org: 'a',
-  userID: '039edab303789000',
-  user: 'adminuser',
-  permissions: [
-    {
-      action: Permission.ActionEnum.Read,
-      resource: {
-        type: PermissionResource.TypeEnum.Orgs,
-        id: '039edab314789000',
-        name: 'a',
-      },
-    },
-    {
-      action: Permission.ActionEnum.Read,
-      resource: {
-        type: PermissionResource.TypeEnum.Authorizations,
-        orgID: '039edab314789000',
-        org: 'a',
-      },
-    },
-    {
-      action: Permission.ActionEnum.Write,
-      resource: {
-        type: PermissionResource.TypeEnum.Authorizations,
-        orgID: '039edab314789000',
-        org: 'a',
-      },
-    },
-    {
-      action: Permission.ActionEnum.Read,
-      resource: {
-        type: PermissionResource.TypeEnum.Buckets,
-        orgID: '039edab314789000',
-        org: 'a',
-      },
-    },
-    {
-      action: Permission.ActionEnum.Write,
-      resource: {
-        type: PermissionResource.TypeEnum.Buckets,
-        orgID: '039edab314789000',
-        org: 'a',
-      },
-    },
-    {
-      action: Permission.ActionEnum.Read,
-      resource: {
-        type: PermissionResource.TypeEnum.Dashboards,
-        orgID: '039edab314789000',
-        org: 'a',
-      },
-    },
-    {
-      action: Permission.ActionEnum.Write,
-      resource: {
-        type: PermissionResource.TypeEnum.Dashboards,
-        orgID: '039edab314789000',
-        org: 'a',
-      },
-    },
-    {
-      action: Permission.ActionEnum.Read,
-      resource: {
-        type: PermissionResource.TypeEnum.Sources,
-        orgID: '039edab314789000',
-        org: 'a',
-      },
-    },
-    {
-      action: Permission.ActionEnum.Write,
-      resource: {
-        type: PermissionResource.TypeEnum.Sources,
-        orgID: '039edab314789000',
-        org: 'a',
-      },
-    },
-    {
-      action: Permission.ActionEnum.Read,
-      resource: {
-        type: PermissionResource.TypeEnum.Tasks,
-        orgID: '039edab314789000',
-        org: 'a',
-      },
-    },
-    {
-      action: Permission.ActionEnum.Write,
-      resource: {
-        type: PermissionResource.TypeEnum.Tasks,
-        orgID: '039edab314789000',
-        org: 'a',
-      },
-    },
-    {
-      action: Permission.ActionEnum.Read,
-      resource: {
-        type: PermissionResource.TypeEnum.Telegrafs,
-        orgID: '039edab314789000',
-        org: 'a',
-      },
-    },
-    {
-      action: Permission.ActionEnum.Write,
-      resource: {
-        type: PermissionResource.TypeEnum.Telegrafs,
-        orgID: '039edab314789000',
-        org: 'a',
-      },
-    },
-    {
-      action: Permission.ActionEnum.Read,
-      resource: {
-        type: PermissionResource.TypeEnum.Users,
-        orgID: '039edab314789000',
-        org: 'a',
-      },
-    },
-    {
-      action: Permission.ActionEnum.Write,
-      resource: {
-        type: PermissionResource.TypeEnum.Users,
-        orgID: '039edab314789000',
-        org: 'a',
-      },
-    },
-    {
-      action: Permission.ActionEnum.Read,
-      resource: {
-        type: PermissionResource.TypeEnum.Variables,
-        orgID: '039edab314789000',
-        org: 'a',
-      },
-    },
-    {
-      action: Permission.ActionEnum.Write,
-      resource: {
-        type: PermissionResource.TypeEnum.Variables,
-        orgID: '039edab314789000',
-        org: 'a',
-      },
-    },
-    {
-      action: Permission.ActionEnum.Read,
-      resource: {
-        type: PermissionResource.TypeEnum.Scrapers,
-        orgID: '039edab314789000',
-        org: 'a',
-      },
-    },
-    {
-      action: Permission.ActionEnum.Write,
-      resource: {
-        type: PermissionResource.TypeEnum.Scrapers,
-        orgID: '039edab314789000',
-        org: 'a',
-      },
-    },
-    {
-      action: Permission.ActionEnum.Read,
-      resource: {
-        type: PermissionResource.TypeEnum.Secrets,
-        orgID: '039edab314789000',
-        org: 'a',
-      },
-    },
-    {
-      action: Permission.ActionEnum.Write,
-      resource: {
-        type: PermissionResource.TypeEnum.Secrets,
-        orgID: '039edab314789000',
-        org: 'a',
-      },
-    },
-    {
-      action: Permission.ActionEnum.Read,
-      resource: {
-        type: PermissionResource.TypeEnum.Labels,
-        orgID: '039edab314789000',
-        org: 'a',
-      },
-    },
-    {
-      action: Permission.ActionEnum.Write,
-      resource: {
-        type: PermissionResource.TypeEnum.Labels,
-        orgID: '039edab314789000',
-        org: 'a',
-      },
-    },
-    {
-      action: Permission.ActionEnum.Read,
-      resource: {
-        type: PermissionResource.TypeEnum.Views,
-        orgID: '039edab314789000',
-        org: 'a',
-      },
-    },
-    {
-      action: Permission.ActionEnum.Write,
-      resource: {
-        type: PermissionResource.TypeEnum.Views,
-        orgID: '039edab314789000',
-        org: 'a',
-      },
-    },
-    {
-      action: Permission.ActionEnum.Read,
-      resource: {
-        type: PermissionResource.TypeEnum.Documents,
-        orgID: '039edab314789000',
-        org: 'a',
-      },
-    },
-    {
-      action: Permission.ActionEnum.Write,
-      resource: {
-        type: PermissionResource.TypeEnum.Documents,
-        orgID: '039edab314789000',
-        org: 'a',
-      },
-    },
-  ],
-  links: {
-    self: '/api/v2/authorizations/03c03a8a64728000',
-    user: '/api/v2/users/039edab303789000',
-  },
-}
-
 export const auth2 = {
   id: '03c03a8a64728000',
   token:
@@ -863,217 +44,217 @@ export const auth2 = {
   user: 'adminuser',
   permissions: [
     {
-      action: Permission.ActionEnum.Read,
+      action: 'read',
       resource: {
-        type: PermissionResource.TypeEnum.Orgs,
+        type: 'orgs',
         id: '039edab314789000',
         name: 'a',
       },
     },
     {
-      action: Permission.ActionEnum.Read,
+      action: 'read',
       resource: {
-        type: PermissionResource.TypeEnum.Authorizations,
+        type: 'authorizations',
         orgID: '039edab314789000',
         org: 'a',
       },
     },
     {
-      action: Permission.ActionEnum.Write,
+      action: 'write',
       resource: {
-        type: PermissionResource.TypeEnum.Authorizations,
+        type: 'authorizations',
         orgID: '039edab314789000',
         org: 'a',
       },
     },
     {
-      action: Permission.ActionEnum.Read,
+      action: 'read',
       resource: {
-        type: PermissionResource.TypeEnum.Buckets,
+        type: 'buckets',
         orgID: '039edab314789000',
         org: 'a',
       },
     },
     {
-      action: Permission.ActionEnum.Write,
+      action: 'write',
       resource: {
-        type: PermissionResource.TypeEnum.Buckets,
+        type: 'buckets',
         orgID: '039edab314789000',
         org: 'a',
       },
     },
     {
-      action: Permission.ActionEnum.Read,
+      action: 'read',
       resource: {
-        type: PermissionResource.TypeEnum.Dashboards,
+        type: 'dashboards',
         orgID: '039edab314789000',
         org: 'a',
       },
     },
     {
-      action: Permission.ActionEnum.Write,
+      action: 'write',
       resource: {
-        type: PermissionResource.TypeEnum.Dashboards,
+        type: 'dashboards',
         orgID: '039edab314789000',
         org: 'a',
       },
     },
     {
-      action: Permission.ActionEnum.Read,
+      action: 'read',
       resource: {
-        type: PermissionResource.TypeEnum.Sources,
+        type: 'sources',
         orgID: '039edab314789000',
         org: 'a',
       },
     },
     {
-      action: Permission.ActionEnum.Write,
+      action: 'write',
       resource: {
-        type: PermissionResource.TypeEnum.Sources,
+        type: 'sources',
         orgID: '039edab314789000',
         org: 'a',
       },
     },
     {
-      action: Permission.ActionEnum.Read,
+      action: 'read',
       resource: {
-        type: PermissionResource.TypeEnum.Tasks,
+        type: 'tasks',
         orgID: '039edab314789000',
         org: 'a',
       },
     },
     {
-      action: Permission.ActionEnum.Write,
+      action: 'write',
       resource: {
-        type: PermissionResource.TypeEnum.Tasks,
+        type: 'tasks',
         orgID: '039edab314789000',
         org: 'a',
       },
     },
     {
-      action: Permission.ActionEnum.Read,
+      action: 'read',
       resource: {
-        type: PermissionResource.TypeEnum.Telegrafs,
+        type: 'telegrafs',
         orgID: '039edab314789000',
         org: 'a',
       },
     },
     {
-      action: Permission.ActionEnum.Write,
+      action: 'write',
       resource: {
-        type: PermissionResource.TypeEnum.Telegrafs,
+        type: 'telegrafs',
         orgID: '039edab314789000',
         org: 'a',
       },
     },
     {
-      action: Permission.ActionEnum.Read,
+      action: 'read',
       resource: {
-        type: PermissionResource.TypeEnum.Users,
+        type: 'users',
         orgID: '039edab314789000',
         org: 'a',
       },
     },
     {
-      action: Permission.ActionEnum.Write,
+      action: 'write',
       resource: {
-        type: PermissionResource.TypeEnum.Users,
+        type: 'users',
         orgID: '039edab314789000',
         org: 'a',
       },
     },
     {
-      action: Permission.ActionEnum.Read,
+      action: 'read',
       resource: {
-        type: PermissionResource.TypeEnum.Variables,
+        type: 'variables',
         orgID: '039edab314789000',
         org: 'a',
       },
     },
     {
-      action: Permission.ActionEnum.Write,
+      action: 'write',
       resource: {
-        type: PermissionResource.TypeEnum.Variables,
+        type: 'variables',
         orgID: '039edab314789000',
         org: 'a',
       },
     },
     {
-      action: Permission.ActionEnum.Read,
+      action: 'read',
       resource: {
-        type: PermissionResource.TypeEnum.Scrapers,
+        type: 'scrapers',
         orgID: '039edab314789000',
         org: 'a',
       },
     },
     {
-      action: Permission.ActionEnum.Write,
+      action: 'write',
       resource: {
-        type: PermissionResource.TypeEnum.Scrapers,
+        type: 'scrapers',
         orgID: '039edab314789000',
         org: 'a',
       },
     },
     {
-      action: Permission.ActionEnum.Read,
+      action: 'read',
       resource: {
-        type: PermissionResource.TypeEnum.Secrets,
+        type: 'secrets',
         orgID: '039edab314789000',
         org: 'a',
       },
     },
     {
-      action: Permission.ActionEnum.Write,
+      action: 'write',
       resource: {
-        type: PermissionResource.TypeEnum.Secrets,
+        type: 'secrets',
         orgID: '039edab314789000',
         org: 'a',
       },
     },
     {
-      action: Permission.ActionEnum.Read,
+      action: 'read',
       resource: {
-        type: PermissionResource.TypeEnum.Labels,
+        type: 'labels',
         orgID: '039edab314789000',
         org: 'a',
       },
     },
     {
-      action: Permission.ActionEnum.Write,
+      action: 'write',
       resource: {
-        type: PermissionResource.TypeEnum.Labels,
+        type: 'labels',
         orgID: '039edab314789000',
         org: 'a',
       },
     },
     {
-      action: Permission.ActionEnum.Read,
+      action: 'read',
       resource: {
-        type: PermissionResource.TypeEnum.Views,
+        type: 'views',
         orgID: '039edab314789000',
         org: 'a',
       },
     },
     {
-      action: Permission.ActionEnum.Write,
+      action: 'write',
       resource: {
-        type: PermissionResource.TypeEnum.Views,
+        type: 'views',
         orgID: '039edab314789000',
         org: 'a',
       },
     },
     {
-      action: Permission.ActionEnum.Read,
+      action: 'read',
       resource: {
-        type: PermissionResource.TypeEnum.Documents,
+        type: 'documents',
         orgID: '039edab314789000',
         org: 'a',
       },
     },
     {
-      action: Permission.ActionEnum.Write,
+      action: 'write',
       resource: {
-        type: PermissionResource.TypeEnum.Documents,
+        type: 'documents',
         orgID: '039edab314789000',
         org: 'a',
       },
@@ -1084,195 +265,3 @@ export const auth2 = {
     user: '/api/v2/users/039edab303789000',
   },
 }
-
-export const viewProperties: ViewProperties = {
-  shape: 'chronograf-v2',
-  queries: [
-    {
-      text:
-        'from(bucket: v.bucket)\n  |> range(start: v.timeRangeStart)\n  |> filter(fn: (r) => r._measurement == "mem")\n  |> filter(fn: (r) => r._field == "used_percent")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: "mean")',
-      editMode: 'advanced',
-      name: '',
-      builderConfig: {
-        buckets: [],
-        tags: [
-          {
-            key: '_measurement',
-            values: [],
-            aggregateFunctionType: 'filter',
-          },
-        ],
-        functions: [],
-        aggregateWindow: {
-          period: '',
-        },
-      },
-    },
-  ],
-  axes: {
-    x: {
-      bounds: ['', ''],
-      label: '',
-      prefix: '',
-      suffix: '',
-      base: '10',
-      scale: 'linear',
-    },
-    y: {
-      bounds: ['', ''],
-      label: '',
-      prefix: '',
-      suffix: '%',
-      base: '10',
-      scale: 'linear',
-    },
-  },
-  type: 'line-plus-single-stat',
-  colors: [
-    {
-      id: 'base',
-      type: 'text',
-      hex: '#00C9FF',
-      name: 'laser',
-      value: 0,
-    },
-    {
-      id: '1ce2dd3d-ece9-4305-b938-5b1538063119',
-      type: 'scale',
-      hex: '#8F8AF4',
-      name: 'Do Androids Dream of Electric Sheep?',
-      value: 0,
-    },
-    {
-      id: '2e1d1dbf-6ed3-4978-9622-2a90548363a9',
-      type: 'scale',
-      hex: '#A51414',
-      name: 'Do Androids Dream of Electric Sheep?',
-      value: 0,
-    },
-    {
-      id: 'edda21a2-1c61-40df-9c2f-c85e16978548',
-      type: 'scale',
-      hex: '#F4CF31',
-      name: 'Do Androids Dream of Electric Sheep?',
-      value: 0,
-    },
-  ],
-  prefix: '',
-  suffix: '%',
-  decimalPlaces: {
-    isEnforced: true,
-    digits: 1,
-  },
-  note: '',
-  showNoteWhenEmpty: false,
-  xColumn: '_time',
-  yColumn: '_value',
-  shadeBelow: true,
-  hoverDimension: 'y',
-  position: 'overlaid',
-}
-
-export const numericColumnData: NumericColumnData = [
-  1573766950000,
-  1573766950000,
-  1573766960000,
-  1573766970000,
-  1573766980000,
-  1573766990000,
-  1573767000000,
-  1573767010000,
-  1573767020000,
-  1573767030000,
-  1573767040000,
-  1573767050000,
-  1573767060000,
-  1573767070000,
-  1573767080000,
-  1573767090000,
-  1573767100000,
-  1573767110000,
-  1573767120000,
-  1573767130000,
-  1573767140000,
-  1573767150000,
-  1573767160000,
-  1573767170000,
-  1573767180000,
-  1573767190000,
-  1573767200000,
-  1573767210000,
-  1573767220000,
-  1573767230000,
-  1573767240000,
-  1573767250000,
-  1573767260000,
-  1573767270000,
-  1573767280000,
-  1573767290000,
-  1573767300000,
-  1573767310000,
-  1573767320000,
-  1573767330000,
-  1573767340000,
-  1573767350000,
-  1573767360000,
-  1573767370000,
-  1573767380000,
-  1573767390000,
-  1573767400000,
-  1573767410000,
-  1573767420000,
-  1573767430000,
-  1573767440000,
-  1573767450000,
-  1573767460000,
-  1573767470000,
-  1573767480000,
-  1573767490000,
-  1573767500000,
-  1573767510000,
-  1573767520000,
-  1573767530000,
-  1573767540000,
-  1573767550000,
-  1573767560000,
-  1573767570000,
-  1573767580000,
-  1573767590000,
-  1573767600000,
-  1573767610000,
-  1573767620000,
-  1573767630000,
-  1573767640000,
-  1573767650000,
-  1573767660000,
-  1573767670000,
-  1573767680000,
-  1573767690000,
-  1573767700000,
-  1573767710000,
-  1573767720000,
-  1573767730000,
-  1573767740000,
-  1573767750000,
-  1573767760000,
-  1573767770000,
-  1573767780000,
-  1573767790000,
-  1573767800000,
-  1573767810000,
-  1573767820000,
-  1573767830000,
-  1573767840000,
-  1573767850000,
-  1573767860000,
-  1573767870000,
-  1573767880000,
-  1573767890000,
-  1573767900000,
-  1573767910000,
-  1573767920000,
-  1573767930000,
-  1573767940000,
-]

--- a/mocks/dummyData.ts
+++ b/mocks/dummyData.ts
@@ -1,6 +1,166 @@
 import {match} from 'react-router'
+import {ViewProperties} from 'src/client'
+import {
+  Cell,
+  Dashboard,
+  Task,
+  ConfigurationState,
+  RemoteDataState,
+  Label,
+  Authorization,
+  AuthorizationUpdateRequest,
+  Organization,
+  Variable,
+} from 'src/types'
+import {OnboardingStepProps} from 'src/onboarding/containers/OnboardingWizard'
 import {RouteComponentProps} from 'react-router-dom'
-import {AuthorizationUpdateRequest, Organization} from 'src/types'
+import {NumericColumnData} from '@influxdata/giraffe'
+import {Resource} from 'src/client'
+
+export const queryConfig = {
+  queries: [
+    {
+      id: '60842c85-8bc7-4180-a844-b974e47a98cd',
+      query:
+        'SELECT mean(:fields:), mean("usage_user") AS "mean_usage_user" FROM "telegraf"."autogen"."cpu" WHERE time > :dashboardTime: GROUP BY time(:interval:) FILL(null)',
+      queryConfig: {
+        id: '60842c85-8bc7-4180-a844-b974e47a98cd',
+        database: 'telegraf',
+        measurement: 'cpu',
+        retentionPolicy: 'autogen',
+        fields: [
+          {
+            value: 'mean',
+            type: 'func',
+            alias: '',
+            args: [{value: 'usage_idle', type: 'field', alias: ''}],
+          },
+          {
+            value: 'mean',
+            type: 'func',
+            alias: 'mean_usage_user',
+            args: [{value: 'usage_user', type: 'field', alias: ''}],
+          },
+        ],
+        tags: {},
+        groupBy: {time: 'auto', tags: []},
+        areTagsAccepted: false,
+        fill: 'null',
+        rawText:
+          'SELECT mean(:fields:), mean("usage_user") AS "mean_usage_user" FROM "telegraf"."autogen"."cpu" WHERE time > :dashboardTime: GROUP BY time(:interval:) FILL(null)',
+        range: null,
+        shifts: [],
+      },
+      queryTemplated:
+        'SELECT mean("usage_idle"), mean("usage_user") AS "mean_usage_user" FROM "telegraf"."autogen"."cpu" WHERE time > :dashboardTime: GROUP BY time(:interval:) FILL(null)',
+      tempVars: [
+        {
+          tempVar: ':fields:',
+          values: [{value: 'usage_idle', type: 'fieldKey', selected: true}],
+        },
+      ],
+    },
+  ],
+}
+
+export const query = {
+  id: '0',
+  database: 'db1',
+  measurement: 'm1',
+  retentionPolicy: 'r1',
+  fill: 'null',
+  fields: [
+    {
+      value: 'f1',
+      type: 'field',
+      alias: 'foo',
+      args: [],
+    },
+  ],
+  tags: {
+    tk1: ['tv1', 'tv2'],
+  },
+  groupBy: {
+    time: null,
+    tags: [],
+  },
+  areTagsAccepted: true,
+  rawText: null,
+  status: null,
+  shifts: [],
+}
+
+// Dashboards
+export const dashboard: Dashboard = {
+  id: '1',
+  orgID: '02ee9e2a29d73000',
+  cells: [],
+  name: 'd1',
+  links: {
+    self: 'self/link',
+    cells: 'cells/link',
+  },
+  meta: {
+    createdAt: '2019-01-08T11:57:31.562044-08:00',
+    updatedAt: '2019-01-08T12:57:31.562048-08:00',
+  },
+  labels: [],
+  status: RemoteDataState.Done,
+}
+
+export const labels: Label[] = [
+  {
+    id: '0001',
+    name: 'Trogdor',
+    properties: {
+      color: '#44ffcc',
+      description: 'Burninating the countryside',
+    },
+    status: RemoteDataState.Done,
+  },
+  {
+    id: '0002',
+    name: 'Strawberry',
+    properties: {
+      color: '#ff0054',
+      description: 'It is a great fruit',
+    },
+    status: RemoteDataState.Done,
+  },
+]
+
+const labelIDs = labels.map(l => l.id)
+
+export const dashboardWithLabels: Dashboard = {
+  id: '1',
+  cells: [],
+  name: 'd1',
+  orgID: '02ee9e2a29d73000',
+  links: {
+    self: 'self/link',
+    cells: 'cells/link',
+  },
+  meta: {
+    createdAt: '2019-01-08T11:57:31.562044-08:00',
+    updatedAt: '2019-01-08T12:57:31.562048-08:00',
+  },
+  status: RemoteDataState.Done,
+  labels: labelIDs,
+}
+
+export const cell: Cell = {
+  x: 0,
+  y: 0,
+  w: 4,
+  h: 4,
+  id: '0246e457-916b-43e3-be99-211c4cbc03e8',
+  dashboardID: 'dummyDashboardID',
+  links: {
+    self: 'self/link',
+    view: 'view/link',
+  },
+  status: RemoteDataState.Done,
+}
 
 export const orgs: Organization[] = [
   {
@@ -15,6 +175,62 @@ export const orgs: Organization[] = [
   },
 ]
 
+export const tasks: Task[] = [
+  {
+    id: '02ef9deff2141000',
+    orgID: '02ee9e2a29d73000',
+    name: 'pasdlak',
+    status: 'active',
+    flux:
+      'option task = {\n  name: "pasdlak",\n  cron: "2 0 * * *"\n}\nfrom(bucket: "inbucket") \n|> range(start: -1h)',
+    cron: '2 0 * * *',
+    org: 'default',
+    labels: [],
+    createdAt: '2021-06-08T00:25:17.501582756Z',
+    latestCompleted: '2021-06-08T02:25:52.118899855Z',
+  },
+  {
+    id: '02f12c50dba72000',
+    orgID: '02ee9e2a29d73000',
+    name: 'somename',
+    status: 'active',
+    flux:
+      'option task = {\n  name: "somename",\n  every: 1m,\n}\nfrom(bucket: "inbucket") \n|> range(start: -task.every)',
+    every: '1m0s',
+    org: 'default',
+    labels: labelIDs,
+    createdAt: '2021-06-08T00:25:17.501582756Z',
+    latestCompleted: '2021-06-08T02:25:52.118899855Z',
+  },
+]
+
+export const variables: Variable[] = [
+  {
+    name: 'LittleVariable',
+    orgID: '0',
+    arguments: {
+      type: 'query',
+      values: {query: '1 + 1 ', language: 'flux'},
+    },
+  },
+]
+
+export const defaultOnboardingStepProps: OnboardingStepProps = {
+  currentStepIndex: 0,
+  onSetCurrentStepIndex: jest.fn(),
+  onIncrementCurrentStepIndex: jest.fn(),
+  onDecrementCurrentStepIndex: jest.fn(),
+  onSetStepStatus: jest.fn(),
+  stepStatuses: [],
+  stepTitles: [],
+  stepTestIds: [],
+  setupParams: {username: '', password: '', org: '', bucket: ''},
+  handleSetSetupParams: jest.fn(),
+  notify: jest.fn(),
+  onCompleteSetup: jest.fn(),
+  onExit: jest.fn(),
+}
+
 const match: match<{orgID: string}> = {
   isExact: false,
   path: '',
@@ -28,6 +244,583 @@ export const withRouterProps: RouteComponentProps<{orgID: string}> = {
   match,
   location: null,
   history: null,
+}
+
+export const token =
+  'm4aUjEIhM758JzJgRmI6f3KNOBw4ZO77gdwERucF0bj4QOLHViD981UWzjaxW9AbyA5THOMBp2SVZqzbui2Ehw=='
+
+export const telegrafConfigID = '030358c935b18000'
+
+export const cpuPlugin = {
+  name: 'cpu',
+  type: 'input',
+  comment: 'this is a test',
+  config: {},
+}
+
+export const telegrafPlugin = {
+  name: 'cpu',
+  configured: ConfigurationState.Unconfigured,
+  active: false,
+}
+
+export const cpuTelegrafPlugin = {
+  ...telegrafPlugin,
+  configured: ConfigurationState.Configured,
+  templateID: '0000000000000009',
+}
+
+export const diskTelegrafPlugin = {
+  ...telegrafPlugin,
+  name: 'disk',
+  configured: ConfigurationState.Configured,
+  templateID: '0000000000000009',
+}
+
+export const diskioTelegrafPlugin = {
+  ...telegrafPlugin,
+  name: 'diskio',
+  configured: ConfigurationState.Configured,
+  templateID: '0000000000000009',
+}
+
+export const netTelegrafPlugin = {
+  ...telegrafPlugin,
+  name: 'net',
+  configured: ConfigurationState.Configured,
+  templateID: '0000000000000009',
+}
+
+export const memTelegrafPlugin = {
+  ...telegrafPlugin,
+  name: 'mem',
+  configured: ConfigurationState.Configured,
+  templateID: '0000000000000009',
+}
+
+export const processesTelegrafPlugin = {
+  ...telegrafPlugin,
+  name: 'processes',
+  configured: ConfigurationState.Configured,
+  templateID: '0000000000000009',
+}
+
+export const procstatTelegrafPlugin = {
+  ...telegrafPlugin,
+  name: 'procstat',
+  configured: ConfigurationState.Unconfigured,
+}
+
+export const systemTelegrafPlugin = {
+  ...telegrafPlugin,
+  name: 'system',
+  configured: ConfigurationState.Configured,
+  templateID: '0000000000000009',
+}
+
+export const redisTelegrafPlugin = {
+  ...telegrafPlugin,
+  name: 'redis',
+  templateID: '0000000000000008',
+}
+
+export const swapTelegrafPlugin = {
+  ...telegrafPlugin,
+  name: 'swap',
+  configured: ConfigurationState.Configured,
+  templateID: '0000000000000009',
+}
+
+export const redisPlugin = {
+  name: 'redis',
+  type: 'input',
+  config: {
+    servers: [],
+    password: '',
+  },
+}
+
+export const dockerTelegrafPlugin = {
+  ...telegrafPlugin,
+  name: 'docker',
+  configured: ConfigurationState.Configured,
+  templateID: '0000000000000002',
+}
+
+export const influxDB2Plugin = {
+  name: 'influxdb_v2',
+  type: 'output',
+  comment: 'write to influxdb v2',
+  config: {
+    urls: ['http://127.0.0.1:9999'],
+    token,
+    organization: 'default',
+    bucket: 'defbuck',
+  },
+}
+
+export const telegrafConfig = {
+  id: telegrafConfigID,
+  orgID: '1',
+  name: 'in n out',
+  created: '2018-11-28T18:56:48.854337-08:00',
+  lastModified: '2018-11-28T18:56:48.854337-08:00',
+  lastModifiedBy: '030358b695318000',
+  agent: {collectionInterval: 15},
+  plugins: [cpuPlugin, influxDB2Plugin],
+}
+
+export const getTelegrafConfigsResponse = {
+  data: {
+    configurations: [telegrafConfig],
+  },
+  status: 200,
+  statusText: 'OK',
+  headers: {
+    date: 'Thu, 29 Nov 2018 18:10:21 GMT',
+    'content-length': '570',
+    'content-type': 'application/json; charset=utf-8',
+  },
+  config: {
+    transformRequest: {},
+    transformResponse: {},
+    timeout: 0,
+    xsrfCookieName: 'XSRF-TOKEN',
+    xsrfHeaderName: 'X-XSRF-TOKEN',
+    maxContentLength: -1,
+    headers: {Accept: 'application/json, text/plain, */*'},
+    method: 'get',
+    url: '/api/v2/telegrafs?org=',
+  },
+  request: {},
+}
+
+export const createTelegrafConfigResponse = {
+  data: telegrafConfig,
+}
+
+export const bucket = {
+  links: {
+    labels: '/api/v2/buckets/034a10d6f7a6b000/labels',
+    log: '/api/v2/buckets/034a10d6f7a6b000/log',
+    org: '/api/v2/orgs/034a0adc49a6b000',
+    self: '/api/v2/buckets/034a10d6f7a6b000',
+  },
+  id: '034a10d6f7a6b000',
+  orgID: '034a0adc49a6b000',
+  name: 'newbuck',
+  retentionRules: [],
+  labels: [],
+}
+
+export const buckets = [
+  {
+    links: {
+      labels: '/api/v2/buckets/034a10d6f7a6b000/labels',
+      log: '/api/v2/buckets/034a10d6f7a6b000/log',
+      org: '/api/v2/orgs/034a0adc49a6b000',
+      self: '/api/v2/buckets/034a10d6f7a6b000',
+    },
+    id: '034a10d6f7a6b000',
+    orgID: '034a0adc49a6b000',
+    name: 'newbuck',
+    retentionRules: [],
+    readableRetention: 'forever',
+    labels: [],
+  },
+  {
+    links: {
+      labels: '/api/v2/buckets/034a10d6f7a6b000/labels',
+      log: '/api/v2/buckets/034a10d6f7a6b000/log',
+      org: '/api/v2/orgs/034a0adc49a6b000',
+      self: '/api/v2/buckets/034a10d6f7a6b000',
+    },
+    id: '034a10d6f7a6b001',
+    orgID: '034a0adc49a6b000',
+    name: 'newbuck1',
+    retentionRules: [],
+    readableRetention: 'forever',
+    labels: [],
+  },
+]
+
+export const setSetupParamsResponse = {
+  data: {
+    user: {
+      links: {
+        log: '/api/v2/users/033bc62520fe3000/log',
+        self: '/api/v2/users/033bc62520fe3000',
+      },
+      id: '033bc62520fe3000',
+      name: 'iris',
+    },
+    bucket: {
+      links: {
+        labels: '/api/v2/buckets/033bc62534fe3000/labels',
+        log: '/api/v2/buckets/033bc62534fe3000/log',
+        org: '/api/v2/orgs/033bc62534be3000',
+        self: '/api/v2/buckets/033bc62534fe3000',
+      },
+      id: '033bc62534fe3000',
+      orgID: '033bc62534be3000',
+      name: 'defbuck',
+      retentionRules: [],
+      labels: [],
+    },
+    org: {
+      links: {
+        buckets: '/api/v2/buckets?org=default',
+        dashboards: '/api/v2/dashboards?org=default',
+        labels: '/api/v2/orgs/033bc62534be3000/labels',
+        log: '/api/v2/orgs/033bc62534be3000/log',
+        members: '/api/v2/orgs/033bc62534be3000/members',
+        secrets: '/api/v2/orgs/033bc62534be3000/secrets',
+        self: '/api/v2/orgs/033bc62534be3000',
+        tasks: '/api/v2/tasks?org=default',
+      },
+      id: '033bc62534be3000',
+      name: 'default',
+    },
+    auth: {
+      id: '033bc62534fe3001',
+      token:
+        'GSEx9BfvjlwQZfjoMgYX9rARwK2Nzc2jaiLdZso9E6X9K1ymldtQ3DwYbCqV3ClJ47sXdI1nLzsP2C1S4u76hA==',
+      status: 'active',
+      description: "iris's Token",
+      orgID: '033bc62534be3000',
+      org: 'default',
+      userID: '033bc62520fe3000',
+      user: 'iris',
+      permissions: [
+        {
+          action: 'read',
+          resource: 'authorizations',
+          orgID: '033bc62534be3000',
+        },
+        {
+          action: 'write',
+          resource: 'authorizations',
+          orgID: '033bc62534be3000',
+        },
+        {action: 'read', resource: 'buckets', orgID: '033bc62534be3000'},
+        {action: 'write', resource: 'buckets', orgID: '033bc62534be3000'},
+        {action: 'read', resource: 'dashboards', orgID: '033bc62534be3000'},
+        {action: 'write', resource: 'dashboards', orgID: '033bc62534be3000'},
+        {action: 'read', resource: 'orgs', orgID: '033bc62534be3000'},
+        {action: 'write', resource: 'orgs', orgID: '033bc62534be3000'},
+        {action: 'read', resource: 'sources', orgID: '033bc62534be3000'},
+        {action: 'write', resource: 'sources', orgID: '033bc62534be3000'},
+        {action: 'read', resource: 'tasks', orgID: '033bc62534be3000'},
+        {action: 'write', resource: 'tasks', orgID: '033bc62534be3000'},
+        {action: 'read', resource: 'telegrafs', orgID: '033bc62534be3000'},
+        {action: 'write', resource: 'telegrafs', orgID: '033bc62534be3000'},
+        {action: 'read', resource: 'users', orgID: '033bc62534be3000'},
+        {action: 'write', resource: 'users', orgID: '033bc62534be3000'},
+      ],
+      links: {
+        self: '/api/v2/authorizations/033bc62534fe3001',
+        user: '/api/v2/users/033bc62520fe3000',
+      },
+    },
+  },
+  status: 201,
+  statusText: 'Created',
+  headers: {
+    'access-control-allow-origin': 'http://localhost:9999',
+    date: 'Fri, 11 Jan 2019 22:49:33 GMT',
+    'access-control-allow-headers':
+      'Accept, Content-Type, Content-Length, Accept-Encoding, Authorization',
+    'transfer-encoding': 'chunked',
+    'access-control-allow-methods': 'POST, GET, OPTIONS, PUT, DELETE',
+    'content-type': 'application/json; charset=utf-8',
+  },
+  config: {
+    transformRequest: {},
+    transformResponse: {},
+    timeout: 0,
+    xsrfCookieName: 'XSRF-TOKEN',
+    xsrfHeaderName: 'X-XSRF-TOKEN',
+    maxContentLength: -1,
+    headers: {
+      Accept: 'application/json, text/plain, */*',
+      'Content-Type': 'application/json',
+    },
+    method: 'post',
+    data:
+      '{"username":"iris","password":"iris","org":"default","bucket":"defbuck"}',
+    url: '/api/v2/setup',
+  },
+  request: {},
+}
+
+export const telegraf = [
+  {
+    id: '03636a150fb51000',
+    name: 'Name this Configuration',
+    orgID: '03636a0aabb51000',
+  },
+  {
+    id: '03636a150fb51001',
+    name: 'Name this Configuration',
+    orgID: '03636a0aabb51000',
+  },
+]
+
+export const scraperTargets = [
+  {
+    bucket: 'a',
+    bucketID: '03636a0aabb51001',
+    id: '03636a0bfe351000',
+    name: 'new target',
+    orgID: '03636a0aabb51000',
+    organization: 'a',
+    type: 'prometheus',
+    url: 'http://localhost:9999/metrics',
+  },
+  {
+    bucket: 'a',
+    bucketID: '03636a0aabb51001',
+    id: '03636a0bfe351001',
+    name: 'new target',
+    orgID: '03636a0aabb51000',
+    organization: 'a',
+    type: 'prometheus',
+    url: 'http://localhost:9999/metrics',
+  },
+]
+
+export const auth: Authorization = {
+  id: '03c03a8a64728000',
+  token:
+    'RcW2uWiD-vfxujKyJCirK8un3lJsWPfiA6ulmWY_SlSITUal7Z180OwExiKKfrO98X8W6qGrd5hSGdag-hEpWw==',
+  status: AuthorizationUpdateRequest.StatusEnum.Active,
+  description: 'My token',
+  orgID: '039edab314789000',
+  org: 'a',
+  userID: '039edab303789000',
+  user: 'adminuser',
+  permissions: [
+    {
+      action: 'read',
+      resource: {
+        type: 'orgs',
+        id: '039edab314789000',
+        name: 'a',
+      },
+    },
+    {
+      action: 'read',
+      resource: {
+        type: 'authorizations',
+        orgID: '039edab314789000',
+        org: 'a',
+      },
+    },
+    {
+      action: 'write',
+      resource: {
+        type: 'authorizations',
+        orgID: '039edab314789000',
+        org: 'a',
+      },
+    },
+    {
+      action: 'read',
+      resource: {
+        type: 'buckets',
+        orgID: '039edab314789000',
+        org: 'a',
+      },
+    },
+    {
+      action: 'write',
+      resource: {
+        type: 'buckets',
+        orgID: '039edab314789000',
+        org: 'a',
+      },
+    },
+    {
+      action: 'read',
+      resource: {
+        type: 'dashboards',
+        orgID: '039edab314789000',
+        org: 'a',
+      },
+    },
+    {
+      action: 'write',
+      resource: {
+        type: 'dashboards',
+        orgID: '039edab314789000',
+        org: 'a',
+      },
+    },
+    {
+      action: 'read',
+      resource: {
+        type: 'sources',
+        orgID: '039edab314789000',
+        org: 'a',
+      },
+    },
+    {
+      action: 'write',
+      resource: {
+        type: Resource.TypeEnum.Sources,
+        orgID: '039edab314789000',
+        org: 'a',
+      },
+    },
+    {
+      action: 'read',
+      resource: {
+        type: 'tasks',
+        orgID: '039edab314789000',
+        org: 'a',
+      },
+    },
+    {
+      action: 'write',
+      resource: {
+        type: 'tasks',
+        orgID: '039edab314789000',
+        org: 'a',
+      },
+    },
+    {
+      action: 'read',
+      resource: {
+        type: 'telegrafs',
+        orgID: '039edab314789000',
+        org: 'a',
+      },
+    },
+    {
+      action: 'write',
+      resource: {
+        type: 'telegrafs',
+        orgID: '039edab314789000',
+        org: 'a',
+      },
+    },
+    {
+      action: 'read',
+      resource: {
+        type: 'users',
+        orgID: '039edab314789000',
+        org: 'a',
+      },
+    },
+    {
+      action: 'write',
+      resource: {
+        type: 'users',
+        orgID: '039edab314789000',
+        org: 'a',
+      },
+    },
+    {
+      action: 'read',
+      resource: {
+        type: 'variables',
+        orgID: '039edab314789000',
+        org: 'a',
+      },
+    },
+    {
+      action: 'write',
+      resource: {
+        type: 'variables',
+        orgID: '039edab314789000',
+        org: 'a',
+      },
+    },
+    {
+      action: 'read',
+      resource: {
+        type: 'scrapers',
+        orgID: '039edab314789000',
+        org: 'a',
+      },
+    },
+    {
+      action: 'write',
+      resource: {
+        type: 'scrapers',
+        orgID: '039edab314789000',
+        org: 'a',
+      },
+    },
+    {
+      action: 'read',
+      resource: {
+        type: 'secrets',
+        orgID: '039edab314789000',
+        org: 'a',
+      },
+    },
+    {
+      action: 'write',
+      resource: {
+        type: 'secrets',
+        orgID: '039edab314789000',
+        org: 'a',
+      },
+    },
+    {
+      action: 'read',
+      resource: {
+        type: 'labels',
+        orgID: '039edab314789000',
+        org: 'a',
+      },
+    },
+    {
+      action: 'write',
+      resource: {
+        type: 'labels',
+        orgID: '039edab314789000',
+        org: 'a',
+      },
+    },
+    {
+      action: 'read',
+      resource: {
+        type: Resource.TypeEnum.Views,
+        orgID: '039edab314789000',
+        org: 'a',
+      },
+    },
+    {
+      action: 'write',
+      resource: {
+        type: Resource.TypeEnum.Views,
+        orgID: '039edab314789000',
+        org: 'a',
+      },
+    },
+    {
+      action: 'read',
+      resource: {
+        type: Resource.TypeEnum.Documents,
+        orgID: '039edab314789000',
+        org: 'a',
+      },
+    },
+    {
+      action: 'write',
+      resource: {
+        type: Resource.TypeEnum.Documents,
+        orgID: '039edab314789000',
+        org: 'a',
+      },
+    },
+  ],
+  links: {
+    self: '/api/v2/authorizations/03c03a8a64728000',
+    user: '/api/v2/users/039edab303789000',
+  },
 }
 
 export const auth2 = {
@@ -102,7 +895,7 @@ export const auth2 = {
     {
       action: 'read',
       resource: {
-        type: 'sources',
+        type: Resource.TypeEnum.Sources,
         orgID: '039edab314789000',
         org: 'a',
       },
@@ -110,7 +903,7 @@ export const auth2 = {
     {
       action: 'write',
       resource: {
-        type: 'sources',
+        type: Resource.TypeEnum.Sources,
         orgID: '039edab314789000',
         org: 'a',
       },
@@ -230,7 +1023,7 @@ export const auth2 = {
     {
       action: 'read',
       resource: {
-        type: 'views',
+        type: Resource.TypeEnum.Views,
         orgID: '039edab314789000',
         org: 'a',
       },
@@ -238,7 +1031,7 @@ export const auth2 = {
     {
       action: 'write',
       resource: {
-        type: 'views',
+        type: Resource.TypeEnum.Views,
         orgID: '039edab314789000',
         org: 'a',
       },
@@ -246,7 +1039,7 @@ export const auth2 = {
     {
       action: 'read',
       resource: {
-        type: 'documents',
+        type: Resource.TypeEnum.Documents,
         orgID: '039edab314789000',
         org: 'a',
       },
@@ -254,7 +1047,7 @@ export const auth2 = {
     {
       action: 'write',
       resource: {
-        type: 'documents',
+        type: Resource.TypeEnum.Documents,
         orgID: '039edab314789000',
         org: 'a',
       },
@@ -265,3 +1058,195 @@ export const auth2 = {
     user: '/api/v2/users/039edab303789000',
   },
 }
+
+export const viewProperties: ViewProperties = {
+  shape: 'chronograf-v2',
+  queries: [
+    {
+      text:
+        'from(bucket: v.bucket)\n  |> range(start: v.timeRangeStart)\n  |> filter(fn: (r) => r._measurement == "mem")\n  |> filter(fn: (r) => r._field == "used_percent")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: "mean")',
+      editMode: 'advanced',
+      name: '',
+      builderConfig: {
+        buckets: [],
+        tags: [
+          {
+            key: '_measurement',
+            values: [],
+            aggregateFunctionType: 'filter',
+          },
+        ],
+        functions: [],
+        aggregateWindow: {
+          period: '',
+        },
+      },
+    },
+  ],
+  axes: {
+    x: {
+      bounds: ['', ''],
+      label: '',
+      prefix: '',
+      suffix: '',
+      base: '10',
+      scale: 'linear',
+    },
+    y: {
+      bounds: ['', ''],
+      label: '',
+      prefix: '',
+      suffix: '%',
+      base: '10',
+      scale: 'linear',
+    },
+  },
+  type: 'line-plus-single-stat',
+  colors: [
+    {
+      id: 'base',
+      type: 'text',
+      hex: '#00C9FF',
+      name: 'laser',
+      value: 0,
+    },
+    {
+      id: '1ce2dd3d-ece9-4305-b938-5b1538063119',
+      type: 'scale',
+      hex: '#8F8AF4',
+      name: 'Do Androids Dream of Electric Sheep?',
+      value: 0,
+    },
+    {
+      id: '2e1d1dbf-6ed3-4978-9622-2a90548363a9',
+      type: 'scale',
+      hex: '#A51414',
+      name: 'Do Androids Dream of Electric Sheep?',
+      value: 0,
+    },
+    {
+      id: 'edda21a2-1c61-40df-9c2f-c85e16978548',
+      type: 'scale',
+      hex: '#F4CF31',
+      name: 'Do Androids Dream of Electric Sheep?',
+      value: 0,
+    },
+  ],
+  prefix: '',
+  suffix: '%',
+  decimalPlaces: {
+    isEnforced: true,
+    digits: 1,
+  },
+  note: '',
+  showNoteWhenEmpty: false,
+  xColumn: '_time',
+  yColumn: '_value',
+  shadeBelow: true,
+  hoverDimension: 'y',
+  position: 'overlaid',
+}
+
+export const numericColumnData: NumericColumnData = [
+  1573766950000,
+  1573766950000,
+  1573766960000,
+  1573766970000,
+  1573766980000,
+  1573766990000,
+  1573767000000,
+  1573767010000,
+  1573767020000,
+  1573767030000,
+  1573767040000,
+  1573767050000,
+  1573767060000,
+  1573767070000,
+  1573767080000,
+  1573767090000,
+  1573767100000,
+  1573767110000,
+  1573767120000,
+  1573767130000,
+  1573767140000,
+  1573767150000,
+  1573767160000,
+  1573767170000,
+  1573767180000,
+  1573767190000,
+  1573767200000,
+  1573767210000,
+  1573767220000,
+  1573767230000,
+  1573767240000,
+  1573767250000,
+  1573767260000,
+  1573767270000,
+  1573767280000,
+  1573767290000,
+  1573767300000,
+  1573767310000,
+  1573767320000,
+  1573767330000,
+  1573767340000,
+  1573767350000,
+  1573767360000,
+  1573767370000,
+  1573767380000,
+  1573767390000,
+  1573767400000,
+  1573767410000,
+  1573767420000,
+  1573767430000,
+  1573767440000,
+  1573767450000,
+  1573767460000,
+  1573767470000,
+  1573767480000,
+  1573767490000,
+  1573767500000,
+  1573767510000,
+  1573767520000,
+  1573767530000,
+  1573767540000,
+  1573767550000,
+  1573767560000,
+  1573767570000,
+  1573767580000,
+  1573767590000,
+  1573767600000,
+  1573767610000,
+  1573767620000,
+  1573767630000,
+  1573767640000,
+  1573767650000,
+  1573767660000,
+  1573767670000,
+  1573767680000,
+  1573767690000,
+  1573767700000,
+  1573767710000,
+  1573767720000,
+  1573767730000,
+  1573767740000,
+  1573767750000,
+  1573767760000,
+  1573767770000,
+  1573767780000,
+  1573767790000,
+  1573767800000,
+  1573767810000,
+  1573767820000,
+  1573767830000,
+  1573767840000,
+  1573767850000,
+  1573767860000,
+  1573767870000,
+  1573767880000,
+  1573767890000,
+  1573767900000,
+  1573767910000,
+  1573767920000,
+  1573767930000,
+  1573767940000,
+]

--- a/mocks/dummyData.ts
+++ b/mocks/dummyData.ts
@@ -7,13 +7,15 @@ import {
   ConfigurationState,
   RemoteDataState,
   Label,
-  Authorization,
   Organization,
-  GenVariable,
+  GenVariable as Variable,
+  Authorization,
 } from 'src/types'
 import {OnboardingStepProps} from 'src/onboarding/containers/OnboardingWizard'
 import {RouteComponentProps} from 'react-router-dom'
 import {NumericColumnData} from '@influxdata/giraffe'
+import {PermissionResource} from '@influxdata/influx'
+import {CLOUD} from 'src/shared/constants'
 
 export const queryConfig = {
   queries: [
@@ -202,7 +204,7 @@ export const tasks: Task[] = [
   },
 ]
 
-export const variables: GenVariable[] = [
+export const variables: Variable[] = [
   {
     name: 'LittleVariable',
     orgID: '0',
@@ -506,6 +508,8 @@ export const setSetupParamsResponse = {
         {action: 'write', resource: 'dashboards', orgID: '033bc62534be3000'},
         {action: 'read', resource: 'orgs', orgID: '033bc62534be3000'},
         {action: 'write', resource: 'orgs', orgID: '033bc62534be3000'},
+        {action: 'read', resource: 'sources', orgID: '033bc62534be3000'},
+        {action: 'write', resource: 'sources', orgID: '033bc62534be3000'},
         {action: 'read', resource: 'tasks', orgID: '033bc62534be3000'},
         {action: 'write', resource: 'tasks', orgID: '033bc62534be3000'},
         {action: 'read', resource: 'telegrafs', orgID: '033bc62534be3000'},
@@ -585,7 +589,7 @@ export const scraperTargets = [
   },
 ]
 
-export const auth: Authorization = {
+const commonAuth: Authorization = {
   id: '03c03a8a64728000',
   token:
     'RcW2uWiD-vfxujKyJCirK8un3lJsWPfiA6ulmWY_SlSITUal7Z180OwExiKKfrO98X8W6qGrd5hSGdag-hEpWw==',
@@ -787,6 +791,54 @@ export const auth: Authorization = {
   },
 }
 
+const getCloudAuth = () => {
+  const common: any = {
+    ...commonAuth,
+  }
+  return common
+}
+
+const getOssAuth = () => {
+  const common = getCloudAuth()
+  common.permissions?.push(
+    {
+      action: 'read',
+      resource: {
+        type: 'scrapers',
+        orgID: '039edab314789000',
+        org: 'a',
+      },
+    },
+    {
+      action: 'write',
+      resource: {
+        type: 'scrapers',
+        orgID: '039edab314789000',
+        org: 'a',
+      },
+    },
+    {
+      action: 'read',
+      resource: {
+        type: 'sources',
+        orgID: '039edab314789000',
+        org: 'a',
+      },
+    },
+    {
+      action: 'write',
+      resource: {
+        type: 'sources',
+        orgID: '039edab314789000',
+        org: 'a',
+      },
+    }
+  )
+  return common
+}
+
+export const auth = CLOUD ? getCloudAuth() : getOssAuth()
+
 export const auth2 = {
   id: '03c03a8a64728000',
   token:
@@ -859,6 +911,22 @@ export const auth2 = {
     {
       action: 'read',
       resource: {
+        type: 'sources',
+        orgID: '039edab314789000',
+        org: 'a',
+      },
+    },
+    {
+      action: 'write',
+      resource: {
+        type: 'sources',
+        orgID: '039edab314789000',
+        org: 'a',
+      },
+    },
+    {
+      action: 'read',
+      resource: {
         type: 'tasks',
         orgID: '039edab314789000',
         org: 'a',
@@ -916,6 +984,22 @@ export const auth2 = {
       action: 'write',
       resource: {
         type: 'variables',
+        orgID: '039edab314789000',
+        org: 'a',
+      },
+    },
+    {
+      action: 'read',
+      resource: {
+        type: PermissionResource.TypeEnum.Scrapers,
+        orgID: '039edab314789000',
+        org: 'a',
+      },
+    },
+    {
+      action: 'write',
+      resource: {
+        type: PermissionResource.TypeEnum.Scrapers,
         orgID: '039edab314789000',
         org: 'a',
       },

--- a/mocks/dummyData.ts
+++ b/mocks/dummyData.ts
@@ -8,14 +8,12 @@ import {
   RemoteDataState,
   Label,
   Authorization,
-  AuthorizationUpdateRequest,
   Organization,
-  Variable,
+  GenVariable,
 } from 'src/types'
 import {OnboardingStepProps} from 'src/onboarding/containers/OnboardingWizard'
 import {RouteComponentProps} from 'react-router-dom'
 import {NumericColumnData} from '@influxdata/giraffe'
-import {Resource} from 'src/client'
 
 export const queryConfig = {
   queries: [
@@ -129,7 +127,7 @@ export const labels: Label[] = [
   },
 ]
 
-const labelIDs = labels.map(l => l.id)
+const labelIDs: any[] = labels.map(l => l.id)
 
 export const dashboardWithLabels: Dashboard = {
   id: '1',
@@ -204,7 +202,7 @@ export const tasks: Task[] = [
   },
 ]
 
-export const variables: Variable[] = [
+export const variables: GenVariable[] = [
   {
     name: 'LittleVariable',
     orgID: '0',
@@ -508,8 +506,6 @@ export const setSetupParamsResponse = {
         {action: 'write', resource: 'dashboards', orgID: '033bc62534be3000'},
         {action: 'read', resource: 'orgs', orgID: '033bc62534be3000'},
         {action: 'write', resource: 'orgs', orgID: '033bc62534be3000'},
-        {action: 'read', resource: 'sources', orgID: '033bc62534be3000'},
-        {action: 'write', resource: 'sources', orgID: '033bc62534be3000'},
         {action: 'read', resource: 'tasks', orgID: '033bc62534be3000'},
         {action: 'write', resource: 'tasks', orgID: '033bc62534be3000'},
         {action: 'read', resource: 'telegrafs', orgID: '033bc62534be3000'},
@@ -593,7 +589,7 @@ export const auth: Authorization = {
   id: '03c03a8a64728000',
   token:
     'RcW2uWiD-vfxujKyJCirK8un3lJsWPfiA6ulmWY_SlSITUal7Z180OwExiKKfrO98X8W6qGrd5hSGdag-hEpWw==',
-  status: AuthorizationUpdateRequest.StatusEnum.Active,
+  status: 'active',
   description: 'My token',
   orgID: '039edab314789000',
   org: 'a',
@@ -659,22 +655,6 @@ export const auth: Authorization = {
     {
       action: 'read',
       resource: {
-        type: 'sources',
-        orgID: '039edab314789000',
-        org: 'a',
-      },
-    },
-    {
-      action: 'write',
-      resource: {
-        type: Resource.TypeEnum.Sources,
-        orgID: '039edab314789000',
-        org: 'a',
-      },
-    },
-    {
-      action: 'read',
-      resource: {
         type: 'tasks',
         orgID: '039edab314789000',
         org: 'a',
@@ -739,22 +719,6 @@ export const auth: Authorization = {
     {
       action: 'read',
       resource: {
-        type: 'scrapers',
-        orgID: '039edab314789000',
-        org: 'a',
-      },
-    },
-    {
-      action: 'write',
-      resource: {
-        type: 'scrapers',
-        orgID: '039edab314789000',
-        org: 'a',
-      },
-    },
-    {
-      action: 'read',
-      resource: {
         type: 'secrets',
         orgID: '039edab314789000',
         org: 'a',
@@ -787,7 +751,7 @@ export const auth: Authorization = {
     {
       action: 'read',
       resource: {
-        type: Resource.TypeEnum.Views,
+        type: 'views',
         orgID: '039edab314789000',
         org: 'a',
       },
@@ -795,7 +759,7 @@ export const auth: Authorization = {
     {
       action: 'write',
       resource: {
-        type: Resource.TypeEnum.Views,
+        type: 'views',
         orgID: '039edab314789000',
         org: 'a',
       },
@@ -803,7 +767,7 @@ export const auth: Authorization = {
     {
       action: 'read',
       resource: {
-        type: Resource.TypeEnum.Documents,
+        type: 'documents',
         orgID: '039edab314789000',
         org: 'a',
       },
@@ -811,7 +775,7 @@ export const auth: Authorization = {
     {
       action: 'write',
       resource: {
-        type: Resource.TypeEnum.Documents,
+        type: 'documents',
         orgID: '039edab314789000',
         org: 'a',
       },
@@ -827,7 +791,7 @@ export const auth2 = {
   id: '03c03a8a64728000',
   token:
     'RcW2uWiD-vfxujKyJCirK8un3lJsWPfiA6ulmWY_SlSITUal7Z180OwExiKKfrO98X8W6qGrd5hSGdag-hEpWw==',
-  status: AuthorizationUpdateRequest.StatusEnum.Active,
+  status: 'active',
   description: 'My token',
   orgID: '039edab314789000',
   org: 'a',
@@ -895,22 +859,6 @@ export const auth2 = {
     {
       action: 'read',
       resource: {
-        type: Resource.TypeEnum.Sources,
-        orgID: '039edab314789000',
-        org: 'a',
-      },
-    },
-    {
-      action: 'write',
-      resource: {
-        type: Resource.TypeEnum.Sources,
-        orgID: '039edab314789000',
-        org: 'a',
-      },
-    },
-    {
-      action: 'read',
-      resource: {
         type: 'tasks',
         orgID: '039edab314789000',
         org: 'a',
@@ -975,22 +923,6 @@ export const auth2 = {
     {
       action: 'read',
       resource: {
-        type: 'scrapers',
-        orgID: '039edab314789000',
-        org: 'a',
-      },
-    },
-    {
-      action: 'write',
-      resource: {
-        type: 'scrapers',
-        orgID: '039edab314789000',
-        org: 'a',
-      },
-    },
-    {
-      action: 'read',
-      resource: {
         type: 'secrets',
         orgID: '039edab314789000',
         org: 'a',
@@ -1023,7 +955,7 @@ export const auth2 = {
     {
       action: 'read',
       resource: {
-        type: Resource.TypeEnum.Views,
+        type: 'views',
         orgID: '039edab314789000',
         org: 'a',
       },
@@ -1031,7 +963,7 @@ export const auth2 = {
     {
       action: 'write',
       resource: {
-        type: Resource.TypeEnum.Views,
+        type: 'views',
         orgID: '039edab314789000',
         org: 'a',
       },
@@ -1039,7 +971,7 @@ export const auth2 = {
     {
       action: 'read',
       resource: {
-        type: Resource.TypeEnum.Documents,
+        type: 'documents',
         orgID: '039edab314789000',
         org: 'a',
       },
@@ -1047,7 +979,7 @@ export const auth2 = {
     {
       action: 'write',
       resource: {
-        type: Resource.TypeEnum.Documents,
+        type: 'documents',
         orgID: '039edab314789000',
         org: 'a',
       },

--- a/src/authorizations/apis/__mocks__/data.ts
+++ b/src/authorizations/apis/__mocks__/data.ts
@@ -1,13 +1,4 @@
-import {
-  Permission,
-  PermissionResource,
-  Authorization,
-  AuthorizationUpdateRequest,
-} from '@influxdata/influx'
-
-const {TypeEnum} = PermissionResource
-const {ActionEnum} = Permission
-const {StatusEnum} = AuthorizationUpdateRequest
+import {Authorization} from 'src/types'
 
 export const authorization: Authorization = {
   links: {
@@ -17,13 +8,13 @@ export const authorization: Authorization = {
   id: '030444b11fb10000',
   token:
     'ohEmfY80A9UsW_cicNXgOMIPIsUvU6K9YcpTfCPQE3NV8Y6nTsCwVghczATBPyQh96CoZkOW5DIKldya6Y84KA==',
-  status: StatusEnum.Active,
+  status: 'active',
   user: 'watts',
   userID: '030444b10a710000',
   orgID: '030444b10a713000',
   description: 'im a token',
   permissions: [
-    {action: ActionEnum.Write, resource: {type: TypeEnum.Orgs}},
-    {action: ActionEnum.Write, resource: {type: TypeEnum.Buckets}},
+    {action: 'write', resource: {type: 'orgs'}},
+    {action: 'write', resource: {type: 'buckets'}},
   ],
 }

--- a/src/authorizations/apis/__mocks__/index.ts
+++ b/src/authorizations/apis/__mocks__/index.ts
@@ -1,7 +1,7 @@
 import {authorization} from './data'
 
 // Types
-import {Authorization} from '@influxdata/influx'
+import {Authorization} from 'src/types'
 
 export const getAuthorizations = async (): Promise<Authorization[]> => {
   return Promise.resolve([authorization, {...authorization, id: '1'}])

--- a/src/authorizations/components/ViewTokenOverlay.test.tsx
+++ b/src/authorizations/components/ViewTokenOverlay.test.tsx
@@ -10,6 +10,7 @@ import {auth} from 'mocks/dummyData'
 import {Permission} from 'src/types'
 import {get} from 'lodash'
 import {renderWithReduxAndRouter} from 'src/mockState'
+import {CLOUD} from 'src/shared/constants'
 
 const permissions = (
   permissions: Permission[]
@@ -57,7 +58,7 @@ describe('Account', () => {
     it('renders permissions correctly', () => {
       const actual = permissions(auth.permissions)
 
-      const expected = {
+      const expected: any = {
         'orgs-a': ['read'],
         authorizations: ['read', 'write'],
         buckets: ['read', 'write'],
@@ -70,6 +71,11 @@ describe('Account', () => {
         labels: ['read', 'write'],
         views: ['read', 'write'],
         documents: ['read', 'write'],
+      }
+
+      if (!CLOUD) {
+        expected.scrapers = ['read', 'write']
+        expected.sources = ['read', 'write']
       }
 
       expect(actual).toEqual(expected)

--- a/src/authorizations/components/ViewTokenOverlay.test.tsx
+++ b/src/authorizations/components/ViewTokenOverlay.test.tsx
@@ -7,7 +7,7 @@ import ViewTokenOverlay from 'src/authorizations/components/ViewTokenOverlay'
 
 // Fixtures
 import {auth} from 'mocks/dummyData'
-import {Permission} from '@influxdata/influx'
+import {Permission} from 'src/types'
 import {get} from 'lodash'
 import {renderWithReduxAndRouter} from 'src/mockState'
 

--- a/src/authorizations/components/ViewTokenOverlay.test.tsx
+++ b/src/authorizations/components/ViewTokenOverlay.test.tsx
@@ -13,7 +13,7 @@ import {renderWithReduxAndRouter} from 'src/mockState'
 
 const permissions = (
   permissions: Permission[]
-): {[x: string]: Permission.ActionEnum[]} => {
+): {[x: string]: ('read' | 'write')[]} => {
   const p = permissions.reduce((acc, {action, resource}) => {
     const {type} = resource
     const name = get(resource, 'name', '')
@@ -62,12 +62,10 @@ describe('Account', () => {
         authorizations: ['read', 'write'],
         buckets: ['read', 'write'],
         dashboards: ['read', 'write'],
-        sources: ['read', 'write'],
         tasks: ['read', 'write'],
         telegrafs: ['read', 'write'],
         users: ['read', 'write'],
         variables: ['read', 'write'],
-        scrapers: ['read', 'write'],
         secrets: ['read', 'write'],
         labels: ['read', 'write'],
         views: ['read', 'write'],

--- a/src/authorizations/components/redesigned/TokensTab.test.tsx
+++ b/src/authorizations/components/redesigned/TokensTab.test.tsx
@@ -3,7 +3,6 @@ import React from 'react'
 import {fireEvent, screen, waitFor} from '@testing-library/react'
 import {renderWithReduxAndRouter} from 'src/mockState'
 import {mockAppState} from 'src/mockAppState'
-import {AuthorizationUpdateRequest as AuthApi} from 'src/types'
 
 import {mocked} from 'ts-jest/utils'
 
@@ -20,7 +19,7 @@ const InactiveToken = {
   id: '02f12c50dcb93000',
   orgID: '02ee9e2a29d73000',
   token: 'skjflkdsjfkd',
-  status: AuthApi.StatusEnum.Inactive,
+  status: 'Inactive',
   org: 'default',
   description: 'XYZ',
 }

--- a/src/authorizations/components/redesigned/TokensTab.test.tsx
+++ b/src/authorizations/components/redesigned/TokensTab.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import {fireEvent, screen, waitFor} from '@testing-library/react'
 import {renderWithReduxAndRouter} from 'src/mockState'
 import {mockAppState} from 'src/mockAppState'
-import {AuthorizationUpdateRequest as AuthApi} from '@influxdata/influx'
+import {AuthorizationUpdateRequest as AuthApi} from 'src/types'
 
 import {mocked} from 'ts-jest/utils'
 

--- a/src/clockface/components/inputs/multipleInput/MultipleInput.test.tsx
+++ b/src/clockface/components/inputs/multipleInput/MultipleInput.test.tsx
@@ -5,7 +5,6 @@ import {screen} from '@testing-library/react'
 // Components
 import MultipleInput from './MultipleInput'
 
-import {TelegrafPluginInputCpu} from '@influxdata/influx'
 import {renderWithReduxAndRouter} from 'src/mockState'
 
 const setup = (override = {}) => {
@@ -18,7 +17,7 @@ const setup = (override = {}) => {
     autoFocus: true,
     tags: [],
     onSetConfigArrayValue: jest.fn(),
-    telegrafPluginName: TelegrafPluginInputCpu.NameEnum.Cpu,
+    telegrafPluginName: 'cpu',
     ...override,
   }
 

--- a/src/clockface/components/inputs/multipleInput/MultipleRows.test.tsx
+++ b/src/clockface/components/inputs/multipleInput/MultipleRows.test.tsx
@@ -5,7 +5,6 @@ import {screen} from '@testing-library/react'
 // Components
 import MultipleRows from './MultipleRows'
 
-import {TelegrafPluginInputCpu} from '@influxdata/influx'
 import {renderWithReduxAndRouter} from 'src/mockState'
 
 const setup = (override = {}) => {
@@ -15,7 +14,7 @@ const setup = (override = {}) => {
     fieldName: '',
     tags: [],
     onSetConfigArrayValue: jest.fn(),
-    telegrafPluginName: TelegrafPluginInputCpu.NameEnum.Cpu,
+    telegrafPluginName: 'cpu',
     ...override,
   }
 

--- a/src/clockface/components/inputs/multipleInput/Row.test.tsx
+++ b/src/clockface/components/inputs/multipleInput/Row.test.tsx
@@ -5,7 +5,6 @@ import {screen} from '@testing-library/react'
 // Components
 import Row from './Row'
 
-import {TelegrafPluginInputCpu} from '@influxdata/influx'
 import {renderWithReduxAndRouter} from 'src/mockState'
 
 const setup = (override = {}) => {
@@ -15,7 +14,7 @@ const setup = (override = {}) => {
     onDeleteTag: jest.fn(),
     onSetConfigArrayValue: jest.fn(),
     fieldName: '',
-    telegrafPluginName: TelegrafPluginInputCpu.NameEnum.Cpu,
+    telegrafPluginName: 'cpu',
     index: 0,
     ...override,
   }

--- a/src/dataLoaders/actions/dataLoaders.ts
+++ b/src/dataLoaders/actions/dataLoaders.ts
@@ -382,7 +382,7 @@ export const createOrUpdateTelegrafConfigAsync = () => async (
   const {bucket} = getSteps(getState())
 
   const influxDB2Out = {
-    name: 'nfluxdb_v2',
+    name: 'influxdb_v2',
     type: 'output',
     config: {
       urls: [`${window.location.origin}`],

--- a/src/dataLoaders/actions/dataLoaders.ts
+++ b/src/dataLoaders/actions/dataLoaders.ts
@@ -4,7 +4,7 @@ import {normalize} from 'normalizr'
 
 // APIs
 import {client} from 'src/utils/api'
-import {ScraperTargetRequest, PermissionResource} from '@influxdata/influx'
+import {ScraperTargetRequest} from '@influxdata/influx'
 import {createAuthorization} from 'src/authorizations/apis'
 
 // Schemas
@@ -42,11 +42,7 @@ import {
   TelegrafEntities,
   Telegraf,
 } from 'src/types'
-import {
-  TelegrafRequest,
-  TelegrafPluginOutputInfluxDBV2,
-  Permission,
-} from '@influxdata/influx'
+import {TelegrafRequest} from '@influxdata/influx'
 import {Dispatch} from 'redux'
 
 // Actions
@@ -386,8 +382,8 @@ export const createOrUpdateTelegrafConfigAsync = () => async (
   const {bucket} = getSteps(getState())
 
   const influxDB2Out = {
-    name: TelegrafPluginOutputInfluxDBV2.NameEnum.InfluxdbV2,
-    type: TelegrafPluginOutputInfluxDBV2.TypeEnum.Output,
+    name: 'nfluxdb_v2',
+    type: 'output',
     config: {
       urls: [`${window.location.origin}`],
       token: '$INFLUX_TOKEN',
@@ -467,17 +463,17 @@ export const generateTelegrafToken = (configID: string) => async (
     }
     const permissions = [
       {
-        action: Permission.ActionEnum.Write,
+        action: 'write',
         resource: {
-          type: PermissionResource.TypeEnum.Buckets,
+          type: 'buckets',
           id: bucket.id,
           orgID,
         },
       },
       {
-        action: Permission.ActionEnum.Read,
+        action: 'read',
         resource: {
-          type: PermissionResource.TypeEnum.Telegrafs,
+          type: 'telegrafs',
           id: configID,
           orgID,
         },
@@ -543,17 +539,17 @@ const createTelegraf = async (dispatch, getState: GetState, plugins) => {
 
     const permissions = [
       {
-        action: Permission.ActionEnum.Write,
+        action: 'write',
         resource: {
-          type: PermissionResource.TypeEnum.Buckets,
+          type: 'buckets',
           id: bucketID,
           orgID: org.id,
         },
       },
       {
-        action: Permission.ActionEnum.Read,
+        action: 'read',
         resource: {
-          type: PermissionResource.TypeEnum.Telegrafs,
+          type: 'telegrafs',
           id: tc.id,
           orgID: org.id,
         },

--- a/src/dataLoaders/components/collectorsWizard/configure/ConfigFieldHandler.test.tsx
+++ b/src/dataLoaders/components/collectorsWizard/configure/ConfigFieldHandler.test.tsx
@@ -10,18 +10,12 @@ import {telegrafPluginsInfo} from 'src/dataLoaders/constants/pluginConfigs'
 import {telegrafPlugin} from 'mocks/dummyData'
 
 // Types
-import {
-  TelegrafPluginInputCpu,
-  TelegrafPluginInputRedis,
-} from '@influxdata/influx'
-
 import {renderWithReduxAndRouter} from 'src/mockState'
 
 const setup = (override = {}) => {
   const props = {
     telegrafPlugin,
-    configFields:
-      telegrafPluginsInfo[TelegrafPluginInputCpu.NameEnum.Cpu].fields,
+    configFields: telegrafPluginsInfo['cpu'].fields,
     onUpdateTelegrafPluginConfig: jest.fn(),
     onAddConfigValue: jest.fn(),
     onRemoveConfigValue: jest.fn(),
@@ -37,8 +31,7 @@ describe('DataLoaders.Components.CollectorsWizard.Configure.ConfigFieldHandler',
     it('renders no config text', async () => {
       setup({
         telegrafPlugin,
-        configFields:
-          telegrafPluginsInfo[TelegrafPluginInputCpu.NameEnum.Cpu].fields,
+        configFields: telegrafPluginsInfo['cpu'].fields,
       })
       const noConfig = await screen.findByTestId('no-config')
       expect(noConfig).toBeVisible()
@@ -47,8 +40,7 @@ describe('DataLoaders.Components.CollectorsWizard.Configure.ConfigFieldHandler',
 
   describe('if configFields have  keys', () => {
     it('renders correct number of switchers', async () => {
-      const configFields =
-        telegrafPluginsInfo[TelegrafPluginInputRedis.NameEnum.Redis].fields
+      const configFields = telegrafPluginsInfo['redis'].fields
       setup({
         telegrafPlugin,
         configFields,

--- a/src/dataLoaders/components/collectorsWizard/configure/PluginConfigForm.test.tsx
+++ b/src/dataLoaders/components/collectorsWizard/configure/PluginConfigForm.test.tsx
@@ -9,22 +9,18 @@ import {PluginConfigForm} from 'src/dataLoaders/components/collectorsWizard/conf
 import {telegrafPluginsInfo} from 'src/dataLoaders/constants/pluginConfigs'
 import {telegrafPlugin} from 'mocks/dummyData'
 
-// Types
-import {TelegrafPluginInputCpu} from '@influxdata/influx'
-
 import {renderWithReduxAndRouter} from 'src/mockState'
 
 const setup = (override = {}) => {
   const props = {
     telegrafPlugin,
-    configFields:
-      telegrafPluginsInfo[TelegrafPluginInputCpu.NameEnum.Cpu].fields,
+    configFields: telegrafPluginsInfo['cpu'].fields,
     onUpdateTelegrafPluginConfig: jest.fn(),
     onAddConfigValue: jest.fn(),
     onRemoveConfigValue: jest.fn(),
     authToken: '',
     onSetConfigArrayValue: jest.fn(),
-    telegrafPluginName: TelegrafPluginInputCpu.NameEnum.Cpu,
+    telegrafPluginName: 'cpu',
     onSetActiveTelegrafPlugin: jest.fn(),
     onClickPrevious: jest.fn(),
     onClickSkip: jest.fn(),
@@ -43,8 +39,7 @@ describe('DataLoaders.Components.CollectorsWizard.Configure.PluginConfigForm', (
     it('renders text and buttons', async () => {
       setup({
         telegrafPlugin,
-        configFields:
-          telegrafPluginsInfo[TelegrafPluginInputCpu.NameEnum.Cpu].fields,
+        configFields: telegrafPluginsInfo['cpu'].fields,
       })
       const form = await screen.findByTestId('form-container')
       const title = await screen.getByRole('heading', {level: 3})

--- a/src/dataLoaders/components/collectorsWizard/configure/PluginConfigSwitcher.test.tsx
+++ b/src/dataLoaders/components/collectorsWizard/configure/PluginConfigSwitcher.test.tsx
@@ -9,7 +9,6 @@ import EmptyDataSourceState from 'src/dataLoaders/components/configureStep/Empty
 
 // Constants
 import {telegrafPlugin, token} from 'mocks/dummyData'
-import {TelegrafPluginInputCpu} from '@influxdata/influx'
 
 const setup = (override = {}) => {
   const props = {
@@ -20,7 +19,7 @@ const setup = (override = {}) => {
     onAddConfigValue: jest.fn(),
     onRemoveConfigValue: jest.fn(),
     onSetConfigArrayValue: jest.fn(),
-    telegrafPluginName: TelegrafPluginInputCpu.NameEnum.Cpu,
+    telegrafPluginName: 'cpu',
     onClickNext: jest.fn(),
     onClickPrevious: jest.fn(),
     onClickSkip: jest.fn(),

--- a/src/dataLoaders/components/configureStep/streaming/ArrayFormElement.test.tsx
+++ b/src/dataLoaders/components/configureStep/streaming/ArrayFormElement.test.tsx
@@ -6,8 +6,6 @@ import {screen} from '@testing-library/react'
 import ArrayFormElement from 'src/dataLoaders/components/configureStep/streaming/ArrayFormElement'
 import {renderWithReduxAndRouter} from 'src/mockState'
 
-import {TelegrafPluginInputCpu} from '@influxdata/influx'
-
 const setup = (override = {}) => {
   const props = {
     fieldName: '',
@@ -18,7 +16,7 @@ const setup = (override = {}) => {
     fieldType: null,
     helpText: '',
     onSetConfigArrayValue: jest.fn(),
-    telegrafPluginName: TelegrafPluginInputCpu.NameEnum.Cpu,
+    telegrafPluginName: 'cpu',
     ...override,
   }
 

--- a/src/dataLoaders/components/configureStep/streaming/ConfigFieldSwitcher.test.tsx
+++ b/src/dataLoaders/components/configureStep/streaming/ConfigFieldSwitcher.test.tsx
@@ -7,7 +7,6 @@ import ConfigFieldSwitcher from 'src/dataLoaders/components/configureStep/stream
 
 // Types
 import {ConfigFieldType} from 'src/types'
-import {TelegrafPluginInputCpu} from '@influxdata/influx'
 
 import {renderWithReduxAndRouter} from 'src/mockState'
 
@@ -22,7 +21,7 @@ const setup = (override = {}) => {
     value: '',
     isRequired: true,
     onSetConfigArrayValue: jest.fn(),
-    telegrafPluginName: TelegrafPluginInputCpu.NameEnum.Cpu,
+    telegrafPluginName: 'cpu',
     ...override,
   }
 

--- a/src/dataLoaders/constants/pluginConfigs.ts
+++ b/src/dataLoaders/constants/pluginConfigs.ts
@@ -6,29 +6,6 @@ import {
   BundleName,
 } from 'src/types'
 
-import {
-  TelegrafPluginInputCpu,
-  TelegrafPluginInputDisk,
-  TelegrafPluginInputDiskio,
-  TelegrafPluginInputDocker,
-  TelegrafPluginInputFile,
-  TelegrafPluginInputKernel,
-  TelegrafPluginInputKubernetes,
-  TelegrafPluginInputLogParser,
-  TelegrafPluginInputMem,
-  TelegrafPluginInputNet,
-  TelegrafPluginInputNetResponse,
-  TelegrafPluginInputNginx,
-  TelegrafPluginInputProcesses,
-  TelegrafPluginInputProcstat,
-  TelegrafPluginInputPrometheus,
-  TelegrafPluginInputRedis,
-  TelegrafPluginInputSyslog,
-  TelegrafPluginInputSwap,
-  TelegrafPluginInputSystem,
-  TelegrafPluginInputTail,
-} from '@influxdata/influx'
-
 export const QUICKSTART_SCRAPER_TARGET_URL = `${window.location.origin}/metrics`
 
 interface PluginBundles {
@@ -37,47 +14,47 @@ interface PluginBundles {
 
 export const pluginsByBundle: PluginBundles = {
   [BundleName.System]: [
-    TelegrafPluginInputCpu.NameEnum.Cpu,
-    TelegrafPluginInputDisk.NameEnum.Disk,
-    TelegrafPluginInputDiskio.NameEnum.Diskio,
-    TelegrafPluginInputSystem.NameEnum.System,
-    TelegrafPluginInputMem.NameEnum.Mem,
-    TelegrafPluginInputNet.NameEnum.Net,
-    TelegrafPluginInputProcesses.NameEnum.Processes,
-    TelegrafPluginInputSwap.NameEnum.Swap,
+    'cpu',
+    'disk',
+    'diskio',
+    'system',
+    'mem',
+    'net',
+    'processes',
+    'swap',
   ],
-  [BundleName.Docker]: [TelegrafPluginInputDocker.NameEnum.Docker],
-  [BundleName.Kubernetes]: [TelegrafPluginInputKubernetes.NameEnum.Kubernetes],
-  [BundleName.Nginx]: [TelegrafPluginInputNginx.NameEnum.Nginx],
-  [BundleName.Redis]: [TelegrafPluginInputRedis.NameEnum.Redis],
+  [BundleName.Docker]: ['docker'],
+  [BundleName.Kubernetes]: ['kubernetes'],
+  [BundleName.Nginx]: ['nginx'],
+  [BundleName.Redis]: ['redis'],
 }
 
 export const telegrafPluginsInfo: TelegrafPluginInfo = {
-  [TelegrafPluginInputCpu.NameEnum.Cpu]: {
+  cpu: {
     fields: null,
     defaults: {
-      name: TelegrafPluginInputCpu.NameEnum.Cpu,
-      type: TelegrafPluginInputCpu.TypeEnum.Input,
+      name: 'cpu',
+      type: 'input',
     },
     templateID: '0000000000000009',
   },
-  [TelegrafPluginInputDisk.NameEnum.Disk]: {
+  disk: {
     fields: null,
     defaults: {
-      name: TelegrafPluginInputDisk.NameEnum.Disk,
-      type: TelegrafPluginInputDisk.TypeEnum.Input,
+      name: 'disk',
+      type: 'input',
     },
     templateID: '0000000000000009',
   },
-  [TelegrafPluginInputDiskio.NameEnum.Diskio]: {
+  diskio: {
     fields: null,
     defaults: {
-      name: TelegrafPluginInputDiskio.NameEnum.Diskio,
-      type: TelegrafPluginInputDiskio.TypeEnum.Input,
+      name: 'diskio',
+      type: 'input',
     },
     templateID: '0000000000000009',
   },
-  [TelegrafPluginInputDocker.NameEnum.Docker]: {
+  docker: {
     fields: {
       endpoint: {
         type: ConfigFieldType.String,
@@ -85,13 +62,13 @@ export const telegrafPluginsInfo: TelegrafPluginInfo = {
       },
     },
     defaults: {
-      name: TelegrafPluginInputDocker.NameEnum.Docker,
-      type: TelegrafPluginInputDocker.TypeEnum.Input,
+      name: 'docker',
+      type: 'input',
       config: {endpoint: ''},
     },
     templateID: '0000000000000002',
   },
-  [TelegrafPluginInputFile.NameEnum.File]: {
+  file: {
     fields: {
       files: {
         type: ConfigFieldType.StringArray,
@@ -99,19 +76,19 @@ export const telegrafPluginsInfo: TelegrafPluginInfo = {
       },
     },
     defaults: {
-      name: TelegrafPluginInputFile.NameEnum.File,
-      type: TelegrafPluginInputFile.TypeEnum.Input,
+      name: 'file',
+      type: 'input',
       config: {files: []},
     },
   },
-  [TelegrafPluginInputKernel.NameEnum.Kernel]: {
+  kernel: {
     fields: null,
     defaults: {
-      name: TelegrafPluginInputKernel.NameEnum.Kernel,
-      type: TelegrafPluginInputDiskio.TypeEnum.Input,
+      name: 'kernel',
+      type: 'input',
     },
   },
-  [TelegrafPluginInputKubernetes.NameEnum.Kubernetes]: {
+  kubernetes: {
     fields: {
       url: {
         type: ConfigFieldType.Uri,
@@ -119,141 +96,141 @@ export const telegrafPluginsInfo: TelegrafPluginInfo = {
       },
     },
     defaults: {
-      name: TelegrafPluginInputKubernetes.NameEnum.Kubernetes,
-      type: TelegrafPluginInputKubernetes.TypeEnum.Input,
+      name: 'kubernetes',
+      type: 'input',
       config: {url: ''},
     },
     templateID: '0000000000000005',
   },
-  [TelegrafPluginInputLogParser.NameEnum.Logparser]: {
+  logparser: {
     fields: {files: {type: ConfigFieldType.StringArray, isRequired: true}},
     defaults: {
-      name: TelegrafPluginInputLogParser.NameEnum.Logparser,
-      type: TelegrafPluginInputLogParser.TypeEnum.Input,
+      name: 'logparser',
+      type: 'input',
       config: {files: []},
     },
   },
-  [TelegrafPluginInputMem.NameEnum.Mem]: {
+  mem: {
     fields: null,
     defaults: {
-      name: TelegrafPluginInputMem.NameEnum.Mem,
-      type: TelegrafPluginInputMem.TypeEnum.Input,
+      name: 'mem',
+      type: 'input',
     },
     templateID: '0000000000000009',
   },
-  [TelegrafPluginInputNet.NameEnum.Net]: {
+  net: {
     fields: null,
     defaults: {
-      name: TelegrafPluginInputNet.NameEnum.Net,
-      type: TelegrafPluginInputNet.TypeEnum.Input,
+      name: 'net',
+      type: 'input',
     },
     templateID: '0000000000000009',
   },
-  [TelegrafPluginInputNetResponse.NameEnum.NetResponse]: {
+  net_response: {
     fields: null,
     defaults: {
-      name: TelegrafPluginInputNetResponse.NameEnum.NetResponse,
-      type: TelegrafPluginInputNetResponse.TypeEnum.Input,
+      name: 'net_response',
+      type: 'input',
     },
   },
-  [TelegrafPluginInputNginx.NameEnum.Nginx]: {
+  nginx: {
     fields: {urls: {type: ConfigFieldType.UriArray, isRequired: true}},
     defaults: {
-      name: TelegrafPluginInputNginx.NameEnum.Nginx,
-      type: TelegrafPluginInputNginx.TypeEnum.Input,
+      name: 'nginx',
+      type: 'input',
     },
     templateID: '0000000000000006',
   },
-  [TelegrafPluginInputProcesses.NameEnum.Processes]: {
+  ['processes']: {
     fields: null,
     defaults: {
-      name: TelegrafPluginInputProcesses.NameEnum.Processes,
-      type: TelegrafPluginInputProcesses.TypeEnum.Input,
+      name: 'processes',
+      type: 'input',
     },
     templateID: '0000000000000009',
   },
-  [TelegrafPluginInputProcstat.NameEnum.Procstat]: {
+  procstat: {
     fields: {exe: {type: ConfigFieldType.String, isRequired: true}},
     defaults: {
-      name: TelegrafPluginInputProcstat.NameEnum.Procstat,
-      type: TelegrafPluginInputProcstat.TypeEnum.Input,
+      name: 'procstat',
+      type: 'input',
       config: {exe: ''},
     },
   },
-  [TelegrafPluginInputPrometheus.NameEnum.Prometheus]: {
+  prometheus: {
     fields: {urls: {type: ConfigFieldType.UriArray, isRequired: true}},
     defaults: {
-      name: TelegrafPluginInputPrometheus.NameEnum.Prometheus,
-      type: TelegrafPluginInputPrometheus.TypeEnum.Input,
+      name: 'prometheus',
+      type: 'input',
       config: {urls: []},
     },
   },
-  [TelegrafPluginInputRedis.NameEnum.Redis]: {
+  redis: {
     fields: {
       servers: {type: ConfigFieldType.StringArray, isRequired: true},
       password: {type: ConfigFieldType.String, isRequired: false},
     },
     defaults: {
-      name: TelegrafPluginInputRedis.NameEnum.Redis,
-      type: TelegrafPluginInputRedis.TypeEnum.Input,
+      name: 'redis',
+      type: 'input',
       config: {servers: [], password: ''},
     },
     templateID: '0000000000000008',
   },
-  [TelegrafPluginInputSyslog.NameEnum.Syslog]: {
+  syslog: {
     fields: {server: {type: ConfigFieldType.String, isRequired: true}},
     defaults: {
-      name: TelegrafPluginInputSyslog.NameEnum.Syslog,
-      type: TelegrafPluginInputSyslog.TypeEnum.Input,
+      name: 'syslog',
+      type: 'input',
       config: {server: ''},
     },
   },
-  [TelegrafPluginInputSwap.NameEnum.Swap]: {
+  swap: {
     fields: null,
     defaults: {
-      name: TelegrafPluginInputSwap.NameEnum.Swap,
-      type: TelegrafPluginInputSwap.TypeEnum.Input,
+      name: 'swap',
+      type: 'input',
     },
     templateID: '0000000000000009',
   },
-  [TelegrafPluginInputSystem.NameEnum.System]: {
+  system: {
     fields: null,
     defaults: {
-      name: TelegrafPluginInputSystem.NameEnum.System,
-      type: TelegrafPluginInputSystem.TypeEnum.Input,
+      name: 'system',
+      type: 'input',
     },
     templateID: '0000000000000009',
   },
-  [TelegrafPluginInputTail.NameEnum.Tail]: {
+  tail: {
     fields: null,
     defaults: {
-      name: TelegrafPluginInputTail.NameEnum.Tail,
-      type: TelegrafPluginInputTail.TypeEnum.Input,
+      name: 'tail',
+      type: 'input',
     },
   },
 }
 
 export const PLUGIN_OPTIONS: TelegrafPluginName[] = [
-  TelegrafPluginInputCpu.NameEnum.Cpu,
-  TelegrafPluginInputDisk.NameEnum.Disk,
-  TelegrafPluginInputDiskio.NameEnum.Diskio,
-  TelegrafPluginInputDocker.NameEnum.Docker,
-  TelegrafPluginInputFile.NameEnum.File,
-  TelegrafPluginInputKernel.NameEnum.Kernel,
-  TelegrafPluginInputKubernetes.NameEnum.Kubernetes,
-  TelegrafPluginInputLogParser.NameEnum.Logparser,
-  TelegrafPluginInputMem.NameEnum.Mem,
-  TelegrafPluginInputNet.NameEnum.Net,
-  TelegrafPluginInputNetResponse.NameEnum.NetResponse,
-  TelegrafPluginInputNginx.NameEnum.Nginx,
-  TelegrafPluginInputProcesses.NameEnum.Processes,
-  TelegrafPluginInputProcstat.NameEnum.Procstat,
-  TelegrafPluginInputPrometheus.NameEnum.Prometheus,
-  TelegrafPluginInputRedis.NameEnum.Redis,
-  TelegrafPluginInputSyslog.NameEnum.Syslog,
-  TelegrafPluginInputSwap.NameEnum.Swap,
-  TelegrafPluginInputSystem.NameEnum.System,
-  TelegrafPluginInputTail.NameEnum.Tail,
+  'cpu',
+  'disk',
+  'diskio',
+  'docker',
+  'file',
+  'kernel',
+  'kubernetes',
+  'logparser',
+  'mem',
+  'net',
+  'net_response',
+  'nginx',
+  'processes',
+  'procstat',
+  'prometheus',
+  'redis',
+  'syslog',
+  'swap',
+  'system',
+  'tail',
 ]
 
 import {

--- a/src/dataLoaders/constants/pluginConfigs.ts
+++ b/src/dataLoaders/constants/pluginConfigs.ts
@@ -5,6 +5,13 @@ import {
   ConfigFieldType,
   BundleName,
 } from 'src/types'
+import {
+  LogoCpu,
+  LogoDocker,
+  LogoKubernetes,
+  LogoNginx,
+  LogoRedis,
+} from 'src/dataLoaders/graphics'
 
 export const QUICKSTART_SCRAPER_TARGET_URL = `${window.location.origin}/metrics`
 
@@ -209,37 +216,6 @@ export const telegrafPluginsInfo: TelegrafPluginInfo = {
     },
   },
 }
-
-export const PLUGIN_OPTIONS: TelegrafPluginName[] = [
-  'cpu',
-  'disk',
-  'diskio',
-  'docker',
-  'file',
-  'kernel',
-  'kubernetes',
-  'logparser',
-  'mem',
-  'net',
-  'net_response',
-  'nginx',
-  'processes',
-  'procstat',
-  'prometheus',
-  'redis',
-  'syslog',
-  'swap',
-  'system',
-  'tail',
-]
-
-import {
-  LogoCpu,
-  LogoDocker,
-  LogoKubernetes,
-  LogoNginx,
-  LogoRedis,
-} from 'src/dataLoaders/graphics'
 
 export const BUNDLE_LOGOS = {
   [BundleName.System]: LogoCpu,

--- a/src/dataLoaders/reducers/dataLoaders.test.ts
+++ b/src/dataLoaders/reducers/dataLoaders.test.ts
@@ -45,13 +45,6 @@ import {QUICKSTART_SCRAPER_TARGET_URL} from 'src/dataLoaders/constants/pluginCon
 
 // Types
 import {
-  TelegrafPluginInputCpu,
-  TelegrafPluginInputDisk,
-  TelegrafPluginInputRedis,
-  TelegrafPluginInputKubernetes,
-  TelegrafPluginInputFile,
-} from '@influxdata/influx'
-import {
   DataLoaderType,
   ConfigurationState,
   TelegrafPlugin,
@@ -83,20 +76,20 @@ describe('dataLoader reducer', () => {
         type: DataLoaderType.Streaming,
         telegrafPlugins: [
           {
-            name: TelegrafPluginInputCpu.NameEnum.Cpu,
+            name: 'cpu',
             configured: ConfigurationState.Unconfigured,
             active: true,
             templateID: '0000000000000009',
           },
           {
-            name: TelegrafPluginInputDisk.NameEnum.Disk,
+            name: 'disk',
             configured: ConfigurationState.Unconfigured,
             active: false,
             templateID: '0000000000000009',
           },
         ],
       },
-      setActiveTelegrafPlugin(TelegrafPluginInputDisk.NameEnum.Disk)
+      setActiveTelegrafPlugin('disk')
     )
 
     const expected = {
@@ -104,13 +97,13 @@ describe('dataLoader reducer', () => {
       type: DataLoaderType.Streaming,
       telegrafPlugins: [
         {
-          name: TelegrafPluginInputCpu.NameEnum.Cpu,
+          name: 'cpu',
           configured: ConfigurationState.Unconfigured,
           active: false,
           templateID: '0000000000000009',
         },
         {
-          name: TelegrafPluginInputDisk.NameEnum.Disk,
+          name: 'disk',
           configured: ConfigurationState.Unconfigured,
           active: true,
           templateID: '0000000000000009',
@@ -127,19 +120,19 @@ describe('dataLoader reducer', () => {
         ...INITIAL_STATE,
         telegrafPlugins: [
           {
-            name: TelegrafPluginInputDisk.NameEnum.Disk,
+            name: 'disk',
             configured: ConfigurationState.Configured,
             active: false,
             templateID: '0000000000000009',
           },
           {
-            name: TelegrafPluginInputFile.NameEnum.File,
+            name: 'file',
             configured: ConfigurationState.Configured,
             active: false,
             templateID: '0000000000000009',
             plugin: {
-              name: TelegrafPluginInputFile.NameEnum.File,
-              type: TelegrafPluginInputFile.TypeEnum.Input,
+              name: 'file',
+              type: 'input',
               config: {
                 files: [],
               },
@@ -147,26 +140,26 @@ describe('dataLoader reducer', () => {
           },
         ],
       },
-      setPluginConfiguration(TelegrafPluginInputFile.NameEnum.File)
+      setPluginConfiguration('file')
     )
 
     const expected = {
       ...INITIAL_STATE,
       telegrafPlugins: [
         {
-          name: TelegrafPluginInputDisk.NameEnum.Disk,
+          name: 'disk',
           configured: ConfigurationState.Configured,
           active: false,
           templateID: '0000000000000009',
         },
         {
-          name: TelegrafPluginInputFile.NameEnum.File,
+          name: 'file',
           configured: ConfigurationState.InvalidConfiguration,
           active: false,
           templateID: '0000000000000009',
           plugin: {
-            name: TelegrafPluginInputFile.NameEnum.File,
-            type: TelegrafPluginInputFile.TypeEnum.Input,
+            name: 'file',
+            type: 'input',
             config: {
               files: [],
             },
@@ -184,13 +177,13 @@ describe('dataLoader reducer', () => {
         ...INITIAL_STATE,
         telegrafPlugins: [
           {
-            name: TelegrafPluginInputKubernetes.NameEnum.Kubernetes,
+            name: 'kubernetes',
             configured: ConfigurationState.Unconfigured,
             templateID: '0000000000000005',
             active: false,
             plugin: {
-              name: TelegrafPluginInputKubernetes.NameEnum.Kubernetes,
-              type: TelegrafPluginInputKubernetes.TypeEnum.Input,
+              name: 'kubernetes',
+              type: 'input',
               config: {
                 url: 'https://server.net',
               },
@@ -198,20 +191,20 @@ describe('dataLoader reducer', () => {
           },
         ],
       },
-      setPluginConfiguration(TelegrafPluginInputKubernetes.NameEnum.Kubernetes)
+      setPluginConfiguration('kubernetes')
     )
 
     const expected = {
       ...INITIAL_STATE,
       telegrafPlugins: [
         {
-          name: TelegrafPluginInputKubernetes.NameEnum.Kubernetes,
+          name: 'kubernetes',
           configured: ConfigurationState.Configured,
           active: false,
           templateID: '0000000000000005',
           plugin: {
-            name: TelegrafPluginInputKubernetes.NameEnum.Kubernetes,
-            type: TelegrafPluginInputKubernetes.TypeEnum.Input,
+            name: 'kubernetes',
+            type: 'input',
             config: {
               url: 'https://server.net',
             },
@@ -238,18 +231,14 @@ describe('dataLoader reducer', () => {
       config: {servers: [], password: ''},
     }
     const tp: TelegrafPlugin = {
-      name: TelegrafPluginInputRedis.NameEnum.Redis,
+      name: 'redis',
       configured: ConfigurationState.Unconfigured,
       active: true,
       plugin,
     }
     const actual = dataLoadersReducer(
       {...INITIAL_STATE, telegrafPlugins: [tp]},
-      updateTelegrafPluginConfig(
-        TelegrafPluginInputRedis.NameEnum.Redis,
-        'password',
-        'pa$$w0rd'
-      )
+      updateTelegrafPluginConfig('redis', 'password', 'pa$$w0rd')
     )
 
     const expected = {
@@ -274,18 +263,14 @@ describe('dataLoader reducer', () => {
       config: {servers: ['first'], password: ''},
     }
     const tp: TelegrafPlugin = {
-      name: TelegrafPluginInputRedis.NameEnum.Redis,
+      name: 'redis',
       configured: ConfigurationState.Unconfigured,
       active: true,
       plugin,
     }
     const actual = dataLoadersReducer(
       {...INITIAL_STATE, telegrafPlugins: [tp]},
-      addConfigValue(
-        TelegrafPluginInputRedis.NameEnum.Redis,
-        'servers',
-        'second'
-      )
+      addConfigValue('redis', 'servers', 'second')
     )
 
     const expected = {
@@ -310,18 +295,14 @@ describe('dataLoader reducer', () => {
       config: {servers: ['first', 'second'], password: ''},
     }
     const tp: TelegrafPlugin = {
-      name: TelegrafPluginInputRedis.NameEnum.Redis,
+      name: 'redis',
       configured: ConfigurationState.Unconfigured,
       active: true,
       plugin,
     }
     const actual = dataLoadersReducer(
       {...INITIAL_STATE, telegrafPlugins: [tp]},
-      removeConfigValue(
-        TelegrafPluginInputRedis.NameEnum.Redis,
-        'servers',
-        'first'
-      )
+      removeConfigValue('redis', 'servers', 'first')
     )
 
     const expected = {

--- a/src/dataLoaders/utils/pluginConfigs.test.ts
+++ b/src/dataLoaders/utils/pluginConfigs.test.ts
@@ -6,15 +6,11 @@ import {
 
 // Types
 import {BundleName} from 'src/types/dataLoaders'
-import {
-  TelegrafPluginInputCpu,
-  TelegrafPluginInputSystem,
-} from '@influxdata/influx'
 
 describe('Onboarding.Utils.PluginConfig', () => {
   describe('if plugin is found in only one bundle', () => {
     it('isPluginUniqueToBundle returns true', () => {
-      const telegrafPlugin = TelegrafPluginInputCpu.NameEnum.Cpu
+      const telegrafPlugin = 'cpu'
       const bundle = BundleName.System
       const bundles = [BundleName.System, BundleName.Docker]
 
@@ -26,7 +22,7 @@ describe('Onboarding.Utils.PluginConfig', () => {
 
   describe('if plugin is not in bundle', () => {
     it('isPluginInBundle returns false', () => {
-      const telegrafPlugin = TelegrafPluginInputSystem.NameEnum.System
+      const telegrafPlugin = 'system'
       const bundle = BundleName.Docker
 
       const actual = isPluginInBundle(telegrafPlugin, bundle)
@@ -37,7 +33,7 @@ describe('Onboarding.Utils.PluginConfig', () => {
 
   describe('if plugin is in bundle', () => {
     it('isPluginInBundle returns true', () => {
-      const telegrafPlugin = TelegrafPluginInputSystem.NameEnum.System
+      const telegrafPlugin = 'system'
       const bundle = BundleName.System
 
       const actual = isPluginInBundle(telegrafPlugin, bundle)

--- a/src/members/actions/thunks.ts
+++ b/src/members/actions/thunks.ts
@@ -15,7 +15,7 @@ import {
   MemberEntities,
   ResourceType,
 } from 'src/types'
-import {AddResourceMemberRequestBody} from '@influxdata/influx'
+import {AddResourceMemberRequestBody} from 'src/client'
 
 // Actions
 import {

--- a/src/members/dummyData.ts
+++ b/src/members/dummyData.ts
@@ -1,31 +1,31 @@
-import {ResourceOwner, User} from '@influxdata/influx'
+import {ResourceOwner} from 'src/client'
 
 export const resouceOwner: ResourceOwner[] = [
   {
     id: '1',
     name: 'John',
-    status: User.StatusEnum.Active,
+    status: 'active',
     links: {
       self: '/api/v2/users/1',
     },
-    role: ResourceOwner.RoleEnum.Owner,
+    role: 'owner',
   },
   {
     id: '2',
     name: 'Jane',
-    status: User.StatusEnum.Active,
+    status: 'active',
     links: {
       self: '/api/v2/users/2',
     },
-    role: ResourceOwner.RoleEnum.Owner,
+    role: 'owner',
   },
   {
     id: '3',
     name: 'Smith',
-    status: User.StatusEnum.Active,
+    status: 'active',
     links: {
       self: '/api/v2/users/3',
     },
-    role: ResourceOwner.RoleEnum.Owner,
+    role: 'owner',
   },
 ]

--- a/src/shared/utils/resourceToTemplate.test.ts
+++ b/src/shared/utils/resourceToTemplate.test.ts
@@ -5,7 +5,6 @@ import {
   variableToTemplate,
   dashboardToTemplate,
 } from 'src/shared/utils/resourceToTemplate'
-import {TemplateType} from '@influxdata/influx'
 import {createVariable} from 'src/variables/mocks'
 import {
   myDashboard,
@@ -35,7 +34,7 @@ describe('resourceToTemplate', () => {
   describe('labelToRelationship', () => {
     it('converts a label to a relationship struct', () => {
       const actual = labelToRelationship(myfavelabel)
-      const expected = {type: TemplateType.Label, id: myfavelabel.id}
+      const expected = {type: 'label', id: myfavelabel.id}
 
       expect(actual).toEqual(expected)
     })
@@ -45,7 +44,7 @@ describe('resourceToTemplate', () => {
     it('converts a label to a data structure in included', () => {
       const actual = labelToIncluded(myfavelabel)
       const expected = {
-        type: TemplateType.Label,
+        type: 'label',
         id: myfavelabel.id,
         attributes: {
           name: myfavelabel.name,
@@ -241,7 +240,7 @@ describe('resourceToTemplate', () => {
                 },
               },
               id: '037b0c86a92a2000',
-              type: TemplateType.Label,
+              type: 'label',
             },
           ],
         },

--- a/src/shared/utils/resourceToTemplate.ts
+++ b/src/shared/utils/resourceToTemplate.ts
@@ -14,6 +14,7 @@ import {
   Variable,
   LabelRelationship,
   LabelIncluded,
+  TemplateType,
 } from 'src/types'
 import {DocumentCreate} from '@influxdata/influx'
 
@@ -62,12 +63,12 @@ const blankDashboardTemplate = () => {
 }
 
 export const labelToRelationship = (l: Label): LabelRelationship => {
-  return {type: 'label', id: l.id}
+  return {type: TemplateType.Label, id: l.id}
 }
 
 export const labelToIncluded = (l: Label): LabelIncluded => {
   return {
-    type: 'label',
+    type: TemplateType.Label,
     id: l.id,
     attributes: {
       name: l.name,
@@ -113,7 +114,7 @@ export const taskToTemplate = (
         type: 'task',
         attributes: taskAttributes,
         relationships: {
-          ['label']: {data: relationshipsLabels},
+          [TemplateType.Label]: {data: relationshipsLabels},
         },
       },
       included: [...baseTemplate.content.included, ...includedLabels],
@@ -216,7 +217,7 @@ export const variableToTemplate = (
           ['variable']: {
             data: [...variableRelationships],
           },
-          ['label']: {
+          [TemplateType.Label]: {
             data: [...labelRelationships],
           },
         },
@@ -250,7 +251,7 @@ const variableToIncluded = (v: Variable, labelsByID: LabelsByID) => {
     type: 'variable',
     attributes: variableAttributes,
     relationships: {
-      ['label']: {
+      [TemplateType.Label]: {
         data: [...labelRelationships],
       },
     },
@@ -317,7 +318,7 @@ export const dashboardToTemplate = (
         type: 'dashboard',
         attributes: dashboardAttributes,
         relationships: {
-          ['label']: {data: relationshipsLabels},
+          [TemplateType.Label]: {data: relationshipsLabels},
           ['cell']: {data: relationshipsCells},
           ['variable']: {data: relationshipsVariables},
         },

--- a/src/shared/utils/resourceToTemplate.ts
+++ b/src/shared/utils/resourceToTemplate.ts
@@ -15,7 +15,7 @@ import {
   LabelRelationship,
   LabelIncluded,
 } from 'src/types'
-import {TemplateType, DocumentCreate} from '@influxdata/influx'
+import {DocumentCreate} from '@influxdata/influx'
 
 const CURRENT_TEMPLATE_VERSION = '1'
 
@@ -29,10 +29,10 @@ const blankTaskTemplate = () => {
   const baseTemplate = blankTemplate()
   return {
     ...baseTemplate,
-    meta: {...baseTemplate.meta, type: TemplateType.Task},
+    meta: {...baseTemplate.meta, type: 'task'},
     content: {
       ...baseTemplate.content,
-      data: {...baseTemplate.content.data, type: TemplateType.Task},
+      data: {...baseTemplate.content.data, type: 'task'},
     },
   }
 }
@@ -41,10 +41,10 @@ const blankVariableTemplate = () => {
   const baseTemplate = blankTemplate()
   return {
     ...baseTemplate,
-    meta: {...baseTemplate.meta, type: TemplateType.Variable},
+    meta: {...baseTemplate.meta, type: 'variable'},
     content: {
       ...baseTemplate.content,
-      data: {...baseTemplate.content.data, type: TemplateType.Variable},
+      data: {...baseTemplate.content.data, type: 'variable'},
     },
   }
 }
@@ -53,21 +53,21 @@ const blankDashboardTemplate = () => {
   const baseTemplate = blankTemplate()
   return {
     ...baseTemplate,
-    meta: {...baseTemplate.meta, type: TemplateType.Dashboard},
+    meta: {...baseTemplate.meta, type: 'dashboard'},
     content: {
       ...baseTemplate.content,
-      data: {...baseTemplate.content.data, type: TemplateType.Dashboard},
+      data: {...baseTemplate.content.data, type: 'dashboard'},
     },
   }
 }
 
 export const labelToRelationship = (l: Label): LabelRelationship => {
-  return {type: TemplateType.Label, id: l.id}
+  return {type: 'label', id: l.id}
 }
 
 export const labelToIncluded = (l: Label): LabelIncluded => {
   return {
-    type: TemplateType.Label,
+    type: 'label',
     id: l.id,
     attributes: {
       name: l.name,
@@ -110,10 +110,10 @@ export const taskToTemplate = (
       ...baseTemplate.content,
       data: {
         ...baseTemplate.content.data,
-        type: TemplateType.Task,
+        type: 'task',
         attributes: taskAttributes,
         relationships: {
-          [TemplateType.Label]: {data: relationshipsLabels},
+          ['label']: {data: relationshipsLabels},
         },
       },
       included: [...baseTemplate.content.included, ...includedLabels],
@@ -142,14 +142,14 @@ const viewToIncluded = (view: View) => {
   }
 
   return {
-    type: TemplateType.View,
+    type: 'view',
     id: view.id,
     attributes: {name: view.name, properties},
   }
 }
 
 const viewToRelationship = (view: View) => ({
-  type: TemplateType.View,
+  type: 'view',
   id: view.id,
 })
 
@@ -161,10 +161,10 @@ const cellToIncluded = (cell: Cell, views: View[]) => {
 
   return {
     id: cell.id,
-    type: TemplateType.Cell,
+    type: 'cell',
     attributes: cellAttributes,
     relationships: {
-      [TemplateType.View]: {
+      ['view']: {
         data: viewRelationship,
       },
     },
@@ -172,7 +172,7 @@ const cellToIncluded = (cell: Cell, views: View[]) => {
 }
 
 const cellToRelationship = (cell: Cell) => ({
-  type: TemplateType.Cell,
+  type: 'cell',
   id: cell.id,
 })
 
@@ -213,10 +213,10 @@ export const variableToTemplate = (
         ...baseTemplate.content.data,
         ...variableData,
         relationships: {
-          [TemplateType.Variable]: {
+          ['variable']: {
             data: [...variableRelationships],
           },
-          [TemplateType.Label]: {
+          ['label']: {
             data: [...labelRelationships],
           },
         },
@@ -247,10 +247,10 @@ const variableToIncluded = (v: Variable, labelsByID: LabelsByID) => {
 
   return {
     id: v.id,
-    type: TemplateType.Variable,
+    type: 'variable',
     attributes: variableAttributes,
     relationships: {
-      [TemplateType.Label]: {
+      ['label']: {
         data: [...labelRelationships],
       },
     },
@@ -258,7 +258,7 @@ const variableToIncluded = (v: Variable, labelsByID: LabelsByID) => {
 }
 
 const variableToRelationship = (v: Variable) => ({
-  type: TemplateType.Variable,
+  type: 'variable',
   id: v.id,
 })
 
@@ -314,12 +314,12 @@ export const dashboardToTemplate = (
       ...baseTemplate.content,
       data: {
         ...baseTemplate.content.data,
-        type: TemplateType.Dashboard,
+        type: 'dashboard',
         attributes: dashboardAttributes,
         relationships: {
-          [TemplateType.Label]: {data: relationshipsLabels},
-          [TemplateType.Cell]: {data: relationshipsCells},
-          [TemplateType.Variable]: {data: relationshipsVariables},
+          ['label']: {data: relationshipsLabels},
+          ['cell']: {data: relationshipsCells},
+          ['variable']: {data: relationshipsVariables},
         },
       },
       included: [

--- a/src/tasks/containers/TasksPage.test.tsx
+++ b/src/tasks/containers/TasksPage.test.tsx
@@ -6,7 +6,7 @@ import {fireEvent, screen, waitFor} from '@testing-library/react'
 import {tasks, orgs, withRouterProps, labels} from 'mocks/dummyData'
 import {renderWithReduxAndRouter} from 'src/mockState'
 import {mockAppState} from 'src/mockAppState'
-import {RemoteDataState, Task as TaskApi} from 'src/types'
+import {RemoteDataState} from 'src/types'
 import {createMemoryHistory} from 'history'
 
 // Items under test
@@ -26,7 +26,7 @@ const InactiveTask = {
   id: '02f12c50dcb93000',
   orgID: '02ee9e2a29d73000',
   name: 'Dead Beetle',
-  status: TaskApi.StatusEnum.Inactive,
+  status: 'inactive',
   flux: sampleScript,
   every: '1h',
   org: 'default',

--- a/src/tasks/containers/TasksPage.test.tsx
+++ b/src/tasks/containers/TasksPage.test.tsx
@@ -1,13 +1,12 @@
 // Installed libraries
 import React from 'react'
 import {fireEvent, screen, waitFor} from '@testing-library/react'
-import {Task as TaskApi} from '@influxdata/influx'
 
 // Constants
 import {tasks, orgs, withRouterProps, labels} from 'mocks/dummyData'
 import {renderWithReduxAndRouter} from 'src/mockState'
 import {mockAppState} from 'src/mockAppState'
-import {RemoteDataState} from 'src/types'
+import {RemoteDataState, Task as TaskApi} from 'src/types'
 import {createMemoryHistory} from 'history'
 
 // Items under test

--- a/src/templates/api/index.ts
+++ b/src/templates/api/index.ts
@@ -44,7 +44,6 @@ import {addDashboardDefaults} from 'src/schemas/dashboards'
 import {
   DashboardTemplate,
   Dashboard,
-  TemplateType,
   InstalledStack,
   Cell,
   CellIncluded,
@@ -65,10 +64,7 @@ export const createDashboardFromTemplate = async (
   try {
     const {content} = template
 
-    if (
-      content.data.type !== TemplateType.Dashboard ||
-      template.meta.version !== '1'
-    ) {
+    if (content.data.type !== 'dashboard' || template.meta.version !== '1') {
       throw new Error('Cannot create dashboard from this template')
     }
 
@@ -213,11 +209,11 @@ const createCellsFromTemplate = async (
     content: {data, included},
   } = template
 
-  if (!data.relationships || !data.relationships[TemplateType.Cell]) {
+  if (!data.relationships || !data.relationships['cell']) {
     return
   }
 
-  const cellRelationships = data.relationships[TemplateType.Cell].data
+  const cellRelationships = data.relationships['cell'].data
 
   const cellsToCreate = findIncludedsFromRelationships<CellIncluded>(
     included,
@@ -261,7 +257,7 @@ const createViewsFromTemplate = async (
       content: {included},
     } = template
 
-    const viewRelationship = c.relationships[TemplateType.View].data
+    const viewRelationship = c.relationships['view'].data
 
     return findIncludedFromRelationship<ViewIncluded>(
       included,
@@ -288,7 +284,7 @@ const createVariablesFromTemplate = async (
   const {
     content: {data, included},
   } = template
-  if (!data.relationships || !data.relationships[TemplateType.Variable]) {
+  if (!data.relationships || !data.relationships['variable']) {
     return
   }
   const variablesIncluded = findIncludedVariables(included)
@@ -357,10 +353,7 @@ export const createVariableFromTemplate = async (
 ) => {
   const {content} = template
   try {
-    if (
-      content.data.type !== TemplateType.Variable ||
-      template.meta.version !== '1'
-    ) {
+    if (content.data.type !== 'variable' || template.meta.version !== '1') {
       throw new Error('Cannot create variable from this template')
     }
 

--- a/src/templates/utils/index.test.ts
+++ b/src/templates/utils/index.test.ts
@@ -10,23 +10,20 @@ import {
   validateTemplateURL,
   readMeFormatter,
 } from 'src/templates/utils/'
-import {TemplateType} from 'src/types'
 
 const includeds = [
-  {type: TemplateType.Cell, id: '1', attributes: {id: 'a'}},
-  {type: TemplateType.View, id: '3'},
-  {type: TemplateType.Variable, id: '3'},
-  {type: TemplateType.Variable, id: '1'},
+  {type: 'cell', id: '1', attributes: {id: 'a'}},
+  {type: 'view', id: '3'},
+  {type: 'variable', id: '3'},
+  {type: 'variable', id: '1'},
 ]
-const relationships = [{type: TemplateType.Cell, id: '1'}]
+const relationships = [{type: 'cell', id: '1'}]
 
 describe('Templates utils', () => {
   describe('findIncludedsFromRelationships', () => {
     it('finds item in included that matches relationship', () => {
       const actual = findIncludedsFromRelationships(includeds, relationships)
-      const expected = [
-        {type: TemplateType.Cell, id: '1', attributes: {id: 'a'}},
-      ]
+      const expected = [{type: 'cell', id: '1', attributes: {id: 'a'}}]
 
       expect(actual).toEqual(expected)
     })
@@ -35,7 +32,7 @@ describe('Templates utils', () => {
   describe('findIncludedFromRelationship', () => {
     it('finds included that matches relationship', () => {
       const actual = findIncludedFromRelationship(includeds, relationships[0])
-      const expected = {type: TemplateType.Cell, id: '1', attributes: {id: 'a'}}
+      const expected = {type: 'cell', id: '1', attributes: {id: 'a'}}
 
       expect(actual).toEqual(expected)
     })
@@ -45,8 +42,8 @@ describe('Templates utils', () => {
     it('finds included that matches relationship', () => {
       const actual = findIncludedVariables(includeds)
       const expected = [
-        {type: TemplateType.Variable, id: '3'},
-        {type: TemplateType.Variable, id: '1'},
+        {type: 'variable', id: '3'},
+        {type: 'variable', id: '1'},
       ]
 
       expect(actual).toEqual(expected)

--- a/src/templates/utils/index.test.ts
+++ b/src/templates/utils/index.test.ts
@@ -10,20 +10,23 @@ import {
   validateTemplateURL,
   readMeFormatter,
 } from 'src/templates/utils/'
+import {TemplateType} from 'src/types'
 
 const includeds = [
-  {type: 'cell', id: '1', attributes: {id: 'a'}},
-  {type: 'view', id: '3'},
-  {type: 'variable', id: '3'},
-  {type: 'variable', id: '1'},
+  {type: TemplateType.Cell, id: '1', attributes: {id: 'a'}},
+  {type: TemplateType.View, id: '3'},
+  {type: TemplateType.Variable, id: '3'},
+  {type: TemplateType.Variable, id: '1'},
 ]
-const relationships = [{type: 'cell', id: '1'}]
+const relationships = [{type: TemplateType.Cell, id: '1'}]
 
 describe('Templates utils', () => {
   describe('findIncludedsFromRelationships', () => {
     it('finds item in included that matches relationship', () => {
       const actual = findIncludedsFromRelationships(includeds, relationships)
-      const expected = [{type: 'cell', id: '1', attributes: {id: 'a'}}]
+      const expected = [
+        {type: TemplateType.Cell, id: '1', attributes: {id: 'a'}},
+      ]
 
       expect(actual).toEqual(expected)
     })
@@ -32,7 +35,7 @@ describe('Templates utils', () => {
   describe('findIncludedFromRelationship', () => {
     it('finds included that matches relationship', () => {
       const actual = findIncludedFromRelationship(includeds, relationships[0])
-      const expected = {type: 'cell', id: '1', attributes: {id: 'a'}}
+      const expected = {type: TemplateType.Cell, id: '1', attributes: {id: 'a'}}
 
       expect(actual).toEqual(expected)
     })
@@ -42,8 +45,8 @@ describe('Templates utils', () => {
     it('finds included that matches relationship', () => {
       const actual = findIncludedVariables(includeds)
       const expected = [
-        {type: 'variable', id: '3'},
-        {type: 'variable', id: '1'},
+        {type: TemplateType.Variable, id: '3'},
+        {type: TemplateType.Variable, id: '1'},
       ]
 
       expect(actual).toEqual(expected)

--- a/src/templates/utils/index.ts
+++ b/src/templates/utils/index.ts
@@ -43,9 +43,7 @@ export const findLabelsToCreate = (
 }
 
 export const findIncludedVariables = (included: {type: TemplateType}[]) => {
-  return included.filter(
-    (r): r is VariableIncluded => r.type === TemplateType.Variable
-  )
+  return included.filter((r): r is VariableIncluded => r.type === 'variable')
 }
 
 export const findVariablesToCreate = (
@@ -59,7 +57,7 @@ export const findVariablesToCreate = (
 
 export const hasLabelsRelationships = (resource: {
   relationships?: Relationships
-}) => !!resource.relationships && !!resource.relationships[TemplateType.Label]
+}) => !!resource.relationships && !!resource.relationships['label']
 
 export const getLabelRelationships = (resource: {
   relationships?: Relationships
@@ -68,11 +66,11 @@ export const getLabelRelationships = (resource: {
     return []
   }
 
-  return [].concat(resource.relationships[TemplateType.Label].data)
+  return [].concat(resource.relationships['label'].data)
 }
 
 export const getIncludedLabels = (included: {type: TemplateType}[]) =>
-  included.filter((i): i is LabelIncluded => i.type === TemplateType.Label)
+  included.filter((i): i is LabelIncluded => i.type === 'label')
 
 export interface TemplateDetails {
   directory: string

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,4 +1,4 @@
-export {Authorization, Permission} from 'src/client'
+export {Authorization, AuthorizationUpdateRequest, Permission} from 'src/client'
 
 export enum Auth0Connection {
   Google = 'google-oauth2',

--- a/src/types/dataLoaders.ts
+++ b/src/types/dataLoaders.ts
@@ -1,50 +1,9 @@
-// Types
-import {
-  TelegrafPluginInputCpu,
-  TelegrafPluginInputDisk,
-  TelegrafPluginInputDiskio,
-  TelegrafPluginInputDocker,
-  TelegrafPluginInputFile,
-  TelegrafPluginInputKernel,
-  TelegrafPluginInputKubernetes,
-  TelegrafPluginInputLogParser,
-  TelegrafPluginInputMem,
-  TelegrafPluginInputNet,
-  TelegrafPluginInputNetResponse,
-  TelegrafPluginInputNginx,
-  TelegrafPluginInputProcesses,
-  TelegrafPluginInputProcstat,
-  TelegrafPluginInputPrometheus,
-  TelegrafPluginInputRedis,
-  TelegrafPluginInputSyslog,
-  TelegrafPluginInputSwap,
-  TelegrafPluginInputSystem,
-  TelegrafPluginInputTail,
-  TelegrafPluginOutputFile,
-  TelegrafPluginOutputInfluxDBV2,
-  TelegrafPluginInputDockerConfig,
-  TelegrafPluginInputFileConfig,
-  TelegrafPluginInputKubernetesConfig,
-  TelegrafPluginInputLogParserConfig,
-  TelegrafPluginInputProcstatConfig,
-  TelegrafPluginInputPrometheusConfig,
-  TelegrafPluginInputRedisConfig,
-  TelegrafPluginInputSyslogConfig,
-  TelegrafPluginOutputFileConfig,
-  TelegrafPluginOutputInfluxDBV2Config,
-} from '@influxdata/influx'
+import {TelegrafPlugin as GenTelegrafPlugin} from 'src/client'
 
-export enum DataLoaderStep {
-  'Configure',
-}
+export interface Plugin extends GenTelegrafPlugin {}
 
 export enum CollectorsStep {
   'Select',
-  'Configure',
-  'Verify',
-}
-
-export enum LineProtocolStep {
   'Configure',
   'Verify',
 }
@@ -87,50 +46,7 @@ export enum DataLoaderType {
   Empty = '',
 }
 
-export type PluginConfig =
-  | TelegrafPluginInputDockerConfig
-  | TelegrafPluginInputFileConfig
-  | TelegrafPluginInputKubernetesConfig
-  | TelegrafPluginInputLogParserConfig
-  | TelegrafPluginInputProcstatConfig
-  | TelegrafPluginInputPrometheusConfig
-  | TelegrafPluginInputRedisConfig
-  | TelegrafPluginInputSyslogConfig
-  | TelegrafPluginOutputFileConfig
-  | TelegrafPluginOutputInfluxDBV2Config
-
-export type Plugin =
-  | TelegrafPluginInputCpu
-  | TelegrafPluginInputDisk
-  | TelegrafPluginInputDiskio
-  | TelegrafPluginInputDocker
-  | TelegrafPluginInputFile
-  | TelegrafPluginInputKernel
-  | TelegrafPluginInputKubernetes
-  | TelegrafPluginInputLogParser
-  | TelegrafPluginInputMem
-  | TelegrafPluginInputNet
-  | TelegrafPluginInputNetResponse
-  | TelegrafPluginInputNginx
-  | TelegrafPluginInputProcesses
-  | TelegrafPluginInputProcstat
-  | TelegrafPluginInputPrometheus
-  | TelegrafPluginInputRedis
-  | TelegrafPluginInputSyslog
-  | TelegrafPluginInputSwap
-  | TelegrafPluginInputSystem
-  | TelegrafPluginInputTail
-  | TelegrafPluginOutputFile
-  | TelegrafPluginOutputInfluxDBV2
-  | TelegrafPluginGeneric
-
-export type TelegrafPluginGeneric = {
-  name: string
-  type: string
-  comment?: string
-}
-
-export interface TelegrafPlugin {
+export interface TelegrafPlugin extends GenTelegrafPlugin {
   name: TelegrafPluginName
   configured: ConfigurationState
   active: boolean
@@ -147,13 +63,6 @@ export enum BundleName {
 }
 
 export type TelegrafPluginName = string
-
-export enum LineProtocolStatus {
-  ImportData = 'importData',
-  Loading = 'loading',
-  Success = 'success',
-  Error = 'error',
-}
 
 export enum Precision {
   Milliseconds = 'Milliseconds',

--- a/src/types/dataLoaders.ts
+++ b/src/types/dataLoaders.ts
@@ -1,6 +1,8 @@
 import {TelegrafPlugin as GenTelegrafPlugin} from 'src/client'
 
-export interface Plugin extends GenTelegrafPlugin {}
+export interface Plugin extends Omit<GenTelegrafPlugin, 'config'> {
+  config?: any
+}
 
 export enum CollectorsStep {
   'Select',

--- a/src/types/templates.ts
+++ b/src/types/templates.ts
@@ -3,7 +3,6 @@ import {
   DocumentCreate,
   DocumentMeta,
   TemplateSummary as GenTemplateSummary,
-  TemplateType,
 } from '@influxdata/influx'
 import {
   Cell,
@@ -18,6 +17,15 @@ import {
 } from 'src/types'
 
 import {Stack} from 'src/client'
+
+export declare enum TemplateType {
+  Label = 'label',
+  Task = 'task',
+  Dashboard = 'dashboard',
+  View = 'view',
+  Cell = 'cell',
+  Variable = 'variable',
+}
 
 export interface InstalledStack extends Stack {
   eventType: string
@@ -95,10 +103,10 @@ export type Relationships = {
 type OneOrMany<T> = T | T[]
 
 interface RelationshipMap {
-  [TemplateType.Cell]: CellRelationship
-  [TemplateType.Label]: LabelRelationship
-  [TemplateType.View]: ViewRelationship
-  [TemplateType.Variable]: VariableRelationship
+  cell: CellRelationship
+  label: LabelRelationship
+  view: ViewRelationship
+  variable: VariableRelationship
 }
 
 export interface CellRelationship {
@@ -107,7 +115,7 @@ export interface CellRelationship {
 }
 
 export interface LabelRelationship {
-  type: TemplateType.Label
+  type: 'label'
   id: string
 }
 
@@ -131,7 +139,7 @@ export interface CellIncluded extends TemplateIncluded {
   type: TemplateType.Cell
   attributes: Cell
   relationships: {
-    [TemplateType.View]: {data: ViewRelationship}
+    view: {data: ViewRelationship}
   }
 }
 
@@ -209,5 +217,3 @@ export interface VariableTemplate extends TemplateBase {
 }
 
 export type Template = TaskTemplate | DashboardTemplate | VariableTemplate
-
-export {TemplateType} from '@influxdata/influx'

--- a/src/types/templates.ts
+++ b/src/types/templates.ts
@@ -115,7 +115,7 @@ export interface CellRelationship {
 }
 
 export interface LabelRelationship {
-  type: 'label'
+  type: TemplateType.Label
   id: string
 }
 

--- a/src/types/templates.ts
+++ b/src/types/templates.ts
@@ -18,7 +18,7 @@ import {
 
 import {Stack} from 'src/client'
 
-export declare enum TemplateType {
+export enum TemplateType {
   Label = 'label',
   Task = 'task',
   Dashboard = 'dashboard',


### PR DESCRIPTION
Closes #3471 

This is part of a larger process to try and remove / update one of our dependencies. The point of this PR is to reduce the usage of the `@influxdata/influx` dependency by consolidating sources of truth to ones generated based on the OpenAPI yamls. Coupled with other work (both past and future), this should limit the usages of the `@influxdata/influx` dependency as best as possible so that we can look into removing it completely or updating it.