### PR TITLE
feat: simplify query vars

### DIFF
--- a/src/flows/context/flow.query.tsx
+++ b/src/flows/context/flow.query.tsx
@@ -1,11 +1,4 @@
-import React, {
-  FC,
-  useContext,
-  useMemo,
-  useEffect,
-  useState,
-  useRef,
-} from 'react'
+import React, {FC, useContext, useEffect, useState, useRef} from 'react'
 import {useDispatch, useSelector} from 'react-redux'
 import {FlowContext} from 'src/flows/context/flow.current'
 import {ResultsContext} from 'src/flows/context/results'
@@ -15,7 +8,6 @@ import {FluxResult, QueryScope} from 'src/types/flows'
 import {PIPE_DEFINITIONS, PROJECT_NAME} from 'src/flows'
 import {notify} from 'src/shared/actions/notifications'
 import EmptyGraphMessage from 'src/shared/components/EmptyGraphMessage'
-import {parseDuration, timeRangeToDuration} from 'src/shared/utils/duration'
 import {useEvent, sendEvent} from 'src/users/hooks/useEvent'
 import {getOrg} from 'src/organizations/selectors'
 
@@ -26,7 +18,7 @@ import {
 } from 'src/shared/copy/notifications'
 
 // Types
-import {AppState, RemoteDataState} from 'src/types'
+import {RemoteDataState} from 'src/types'
 
 export interface Stage {
   id: string
@@ -100,11 +92,13 @@ export const FlowQueryProvider: FC = ({children}) => {
   const _map = useRef([])
   let timeRangeStart, timeRangeStop
 
-  if (!flow.range) {
+  if (!flow?.range) {
     timeRangeStart = timeRangeStop = null
   } else {
-    if (flow.range.type !== 'custom') {
-      timeRangeStart = parseDurations(timeRangeToDuration(flow.range))
+    if (flow.range.type === 'selectable-duration') {
+      timeRangeStart = '-' + flow.range.duration
+    } else if (flow.range.type === 'duration') {
+      timeRangeStart = '-' + flow.range.lower
     } else if (isNaN(Date.parse(flow.range.lower))) {
       timeRangeStart = null
     } else {
@@ -134,8 +128,8 @@ export const FlowQueryProvider: FC = ({children}) => {
           org: org.id,
           vars: {
             timeRangeStart,
-            timeRangeStop
-          }
+            timeRangeStop,
+          },
         },
         source: '',
         visual: '',
@@ -397,7 +391,7 @@ export const FlowQueryProvider: FC = ({children}) => {
   const simple = (text: string) => {
     return simplify(text, {
       timeRangeStart,
-      timeRangeStop
+      timeRangeStop,
     })
   }
 

--- a/src/shared/contexts/query.tsx
+++ b/src/shared/contexts/query.tsx
@@ -12,7 +12,6 @@ import {
   FluxResult,
   QueryScope,
   InternalFromFluxResult,
-  VariableMap,
   Column,
 } from 'src/types/flows'
 import {propertyTime} from 'src/shared/utils/getMinDurationFromAST'
@@ -23,11 +22,6 @@ import {
   RATE_LIMIT_ERROR_STATUS,
   RATE_LIMIT_ERROR_TEXT,
 } from 'src/cloud/constants'
-import {
-  TIME_RANGE_START,
-  TIME_RANGE_STOP,
-  WINDOW_PERIOD,
-} from 'src/variables/constants'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Types
@@ -121,38 +115,6 @@ export const remove = (node: File, test, acc = []) => {
   return acc
 }
 
-const _getVars = (
-  ast,
-  allVars: VariableMap = {},
-  acc: VariableMap = {}
-): VariableMap =>
-  find(
-    ast,
-    node => node?.type === 'MemberExpression' && node?.object?.name === 'v'
-  )
-    .map(node => node.property.name)
-    .reduce((tot, curr) => {
-      if (tot.hasOwnProperty(curr)) {
-        return tot
-      }
-
-      if (!allVars[curr]) {
-        tot[curr] = null
-        return tot
-      }
-      tot[curr] = allVars[curr]
-
-      if (tot[curr].arguments.type === 'query') {
-        if (isFlagEnabled('fastFlows')) {
-          _getVars(parseQuery(tot[curr].arguments.values.query), allVars, tot)
-        } else {
-          _getVars(parse(tot[curr].arguments.values.query), allVars, tot)
-        }
-      }
-
-      return tot
-    }, acc)
-
 const _addWindowPeriod = (ast, optionAST): void => {
   const queryRanges = find(
     ast,
@@ -194,6 +156,7 @@ const _addWindowPeriod = (ast, optionAST): void => {
 
     return
   }
+
   const starts = queryRanges.map(t => t.start)
   const stops = queryRanges.map(t => t.stop)
   const cartesianProduct = starts.map(start => stops.map(stop => [start, stop]))
@@ -243,83 +206,15 @@ const _addWindowPeriod = (ast, optionAST): void => {
   })
 }
 
-export const simplify = (text, vars: VariableMap = {}) => {
+export const simplify = (text, vars = {}) => {
   try {
     const ast = isFlagEnabled('fastFlows') ? parseQuery(text) : parse(text)
-    const usedVars = _getVars(ast, vars)
-
-    // Grab all global variables and turn them into a hashmap
-    // TODO: move off this variable junk and just use strings
-    const globalDefinedVars = Object.values(usedVars).reduce((acc, v) => {
-      let _val
-
-      if (!v) {
-        return acc
-      }
-
-      if (v.id === WINDOW_PERIOD) {
-        acc[v.id] = (v.arguments?.values || [10000])[0] + 'ms'
-
-        return acc
-      }
-
-      if (v.id === TIME_RANGE_START || v.id === TIME_RANGE_STOP) {
-        const val = v.arguments.values[0]
-
-        if (!isNaN(Date.parse(val))) {
-          acc[v.id] = new Date(val).toISOString()
-          return acc
-        }
-
-        if (typeof val === 'string') {
-          if (val) {
-            acc[v.id] = val
-          }
-
-          return acc
-        }
-
-        _val = '-' + val[0].magnitude + val[0].unit
-
-        if (_val !== '-') {
-          acc[v.id] = _val
-        }
-
-        return acc
-      }
-
-      if (v.arguments.type === 'map') {
-        _val =
-          v.arguments.values[
-            v.selected ? v.selected[0] : Object.keys(v.arguments.values)[0]
-          ]
-
-        if (_val) {
-          acc[v.id] = _val
-        }
-
-        return acc
-      }
-
-      if (v.arguments.type === 'constant') {
-        _val = v.selected ? v.selected[0] : v.arguments.values[0]
-
-        if (_val) {
-          acc[v.id] = _val
-        }
-
-        return acc
-      }
-
-      if (v.arguments.type === 'query') {
-        if (!v.selected || !v.selected[0]) {
-          return
-        }
-
-        acc[v.id] = v.selected[0]
-        return acc
-      }
-
+    const referencedVars = find(
+      ast,
+      node => node?.type === 'MemberExpression' && node?.object?.name === 'v'
+    ).map(node => node.property.name)
+    .reduce((acc, curr) => {
+      acc[curr] = vars[curr]
       return acc
     }, {})
 
@@ -342,24 +237,23 @@ export const simplify = (text, vars: VariableMap = {}) => {
 
     // Merge the two variable maps, allowing for any user defined variables to override
     // global system variables
-    const joinedVars = Object.keys(usedVars).reduce((acc, curr) => {
-      if (globalDefinedVars.hasOwnProperty(curr)) {
-        acc[curr] = globalDefinedVars[curr]
+    Object.keys(queryDefinedVars).forEach(var => {
+      if (referencedVars.hasOwnProperty(var)) {
+        referencedVars[var] = queryDefinedVars[var]
       }
+    })
 
-      if (queryDefinedVars.hasOwnProperty(curr)) {
-        acc[curr] = queryDefinedVars[curr]
-      }
-
-      return acc
-    }, {})
-
-    const varVals = Object.entries(joinedVars)
+    const varVals = Object.entries(referencedVars)
       .map(([k, v]) => `${k}: ${v}`)
       .join(',\n')
     const optionAST = isFlagEnabled('fastFlows')
       ? parseQuery(`option v = {\n${varVals}\n}\n`)
       : parse(`option v = {\n${varVals}\n}\n`)
+
+    // load in windowPeriod at the last second, because it needs to self reference all the things
+    if (referencedVars.hasOwnProperty('windowPeriod')) {
+      _addWindowPeriod(ast, optionAST)
+    }
 
     if (varVals.length) {
       ast.body.unshift(optionAST.body[0])
@@ -393,11 +287,6 @@ export const simplify = (text, vars: VariableMap = {}) => {
         ? parseQuery(`option task = {\n${taskVals}\n}\n`)
         : parse(`option task = {\n${taskVals}\n}\n`)
       ast.body.unshift(taskAST.body[0])
-    }
-
-    // load in windowPeriod at the last second, because it needs to self reference all the things
-    if (usedVars.hasOwnProperty('windowPeriod')) {
-      _addWindowPeriod(ast, optionAST)
     }
 
     // turn it back into a query


### PR DESCRIPTION
removing the strange variable resource <-> AST partial mechanism of dealing with variables in queries in notebooks, which aren't technically supported but needed for setting the timerange and the like. the idea here is that we should be treating all variables within a query as a hashmap of strings, and whatever mechanisms are required for handling variable recursion and defining it as a string should be handled via a separate mechanism. hoping that this will be a precursor for defining a timeranges in a panel, decoupling from the `SelectableTimeRange` format and opening up the possibility for new ways of defining time ranges (eg { from: - 1w, to: -3d})