### PR TITLE
style: reduce margin between each pipe card

### DIFF
--- a/src/flows/components/ReadOnlyPipeList.tsx
+++ b/src/flows/components/ReadOnlyPipeList.tsx
@@ -38,7 +38,7 @@ const FlowPanel: FC<Props> = ({id, children, resizes}) => {
     .join(' ')
 
   return (
-    <div className={panelClassName} style={{marginBottom: '16px'}}>
+    <div className={panelClassName} style={{marginBottom: '4px'}}>
       <div className="flow-panel--header">
         <div className="flow-panel--title">{flow.meta.byID[id].title}</div>
       </div>

--- a/src/shared/components/TimeZoneDropdown.tsx
+++ b/src/shared/components/TimeZoneDropdown.tsx
@@ -16,7 +16,7 @@ const TimeZoneDropdown: FC = () => {
       options={TIME_ZONES.map(tz => tz.timeZone)}
       selectedOption={timeZone}
       onSelect={setTimeZone}
-      buttonIcon={IconFont.Annotate_New}
+      buttonIcon={IconFont.Pin_New}
       style={{width: '115px'}}
     />
   )

--- a/src/shared/components/TimeZoneDropdown.tsx
+++ b/src/shared/components/TimeZoneDropdown.tsx
@@ -16,7 +16,7 @@ const TimeZoneDropdown: FC = () => {
       options={TIME_ZONES.map(tz => tz.timeZone)}
       selectedOption={timeZone}
       onSelect={setTimeZone}
-      buttonIcon={IconFont.Pin_New}
+      buttonIcon={IconFont.Annotate_New}
       style={{width: '115px'}}
     />
   )


### PR DESCRIPTION
Closes #3408

This matches the first new design. The second new design is considered part of issue #3325, so the code is not included in this PR. 

Before:
<img width="1220" alt="Screen Shot 2021-12-30 at 3 45 45 PM" src="https://user-images.githubusercontent.com/14298407/147790044-f048d4c7-0df1-4afc-bcb2-80a25e8d5d8c.png">

After:
<img width="1222" alt="Screen Shot 2021-12-30 at 3 43 26 PM" src="https://user-images.githubusercontent.com/14298407/147790053-ce84324c-6ba8-4d52-9d35-ae3b21e50ad1.png">

