### PR TITLE
fix: make invalid handler required and define in all consumers

### DIFF
--- a/src/shared/components/dateRangePicker/DatePicker.tsx
+++ b/src/shared/components/dateRangePicker/DatePicker.tsx
@@ -36,7 +36,7 @@ interface Props {
   maxDate?: string
   minDate?: string
   onSelectDate: (date: string) => void
-  onInvalidInput?: () => void
+  onInvalidInput: () => void
 }
 
 interface State {

--- a/src/visualization/components/internal/TimeTickInput.tsx
+++ b/src/visualization/components/internal/TimeTickInput.tsx
@@ -43,6 +43,8 @@ interface TimeTickInputProps {
   update: (data: any) => void
 }
 
+const noOp = () => {}
+
 export const TimeTickInput: FC<TimeTickInputProps> = props => {
   const {
     axisName,
@@ -198,6 +200,7 @@ export const TimeTickInput: FC<TimeTickInputProps> = props => {
                       dateTime={getDatePickerDateTime()}
                       onSelectDate={handleSelectDate}
                       label="Start Tick Marks At"
+                      onInvalidInput={noOp}
                     />
                   </div>
                   <Button


### PR DESCRIPTION
Closes #3395 

The Date Picker for the Time Ticks customization was crashing because it did not have a handler that was added after the Time Ticks were implemented. We are adding the handler here. Also, let's correct the interface for the Date Picker by making the handler a required prop. Previously the prop was optional, but it should not have been.

Here is the Time Tick customization working correctly when the user types instead of clicks:

https://user-images.githubusercontent.com/10736577/148476127-f80e2500-2882-47e2-88d4-a724a577bd3d.mp4


