### PR TITLE
feat: add error thresholds setting for visualization panels on notebooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,6 +192,7 @@
     "normalizr": "^3.4.1",
     "onigasm": "^2.2.4",
     "papaparse": "^5.2.0",
+    "qrcode.react": "^1.0.1",
     "qs": "^6.5.2",
     "react": "^17.0.2",
     "react-beautiful-dnd": "^13.0.0",

--- a/src/flows/components/Sidebar.scss
+++ b/src/flows/components/Sidebar.scss
@@ -1,7 +1,7 @@
 @import '@influxdata/clockface/dist/variables.scss';
 
 .flow-sidebar {
-  flex: 0 0 300px;
+  flex: 0 0 300px; // TODO(ariel): the sidebar needs more real estate for this to work. 550px is a good min, but a redesign is likely needed
   width: 300px;
   padding: 0 $cf-space-2xs;
 
@@ -42,6 +42,7 @@
 
 .flow-sidebar--submenu-wrapper {
   width: calc(100% - 16px);
+  padding-bottom: 20px;
 }
 
 .flow-sidebar--dropdownmenu {

--- a/src/flows/components/Sidebar.scss
+++ b/src/flows/components/Sidebar.scss
@@ -1,8 +1,8 @@
 @import '@influxdata/clockface/dist/variables.scss';
 
 .flow-sidebar {
-  flex: 0 0 300px; // TODO(ariel): the sidebar needs more real estate for this to work. 550px is a good min, but a redesign is likely needed
-  width: 300px;
+  flex: 0 0 calc(420px - $cf-space-2xs);
+  width: 420px - $cf-space-2xs;
   padding: 0 $cf-space-2xs;
 
   .sidebar--item {

--- a/src/flows/pipes/Notification/Threshold.tsx
+++ b/src/flows/pipes/Notification/Threshold.tsx
@@ -19,14 +19,15 @@ import 'src/flows/pipes/Notification/Threshold.scss'
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'
+import {COMMON_THRESHOLD_TYPES} from 'src/flows/pipes/Visualization/ErrorThresholds'
 
-enum ThresholdFormat {
+export enum ThresholdFormat {
   Value = 'value',
   Range = 'range',
   Deadman = 'deadman',
 }
 
-type Threshold = {
+export type Threshold = {
   value: number
   type: string
   field: string
@@ -39,48 +40,7 @@ type Threshold = {
 export const deadmanType = 'missing-for-longer-than'
 
 export const THRESHOLD_TYPES = {
-  greater: {
-    name: 'greater than',
-    format: ThresholdFormat.Value,
-    condition: data => `(r) => (r["${data.field}"] > ${data.value})`,
-  },
-  'greater-equal': {
-    name: 'greater than or equal to',
-    format: ThresholdFormat.Value,
-    condition: data => `(r) => (r["${data.field}"] >= ${data.value})`,
-  },
-  less: {
-    name: 'less than',
-    format: ThresholdFormat.Value,
-    condition: data => `(r) => (r["${data.field}"] < ${data.value})`,
-  },
-  'less-equal': {
-    name: 'less than or equal to',
-    format: ThresholdFormat.Value,
-    condition: data => `(r) => (r["${data.field}"] <= ${data.value})`,
-  },
-  equal: {
-    name: 'equal to',
-    format: ThresholdFormat.Value,
-    condition: data => `(r) => (r["${data.field}"] == ${data.value})`,
-  },
-  'not-equal': {
-    name: 'not equal to',
-    format: ThresholdFormat.Value,
-    condition: data => `(r) => (r["${data.field}"] != ${data.value})`,
-  },
-  between: {
-    name: 'between',
-    format: ThresholdFormat.Range,
-    condition: data =>
-      `(r) => (r["${data.field}"] > ${data.min} and r["${data.field}"] < ${data.max})`,
-  },
-  'not-between': {
-    name: 'not between',
-    format: ThresholdFormat.Range,
-    condition: data =>
-      `(r) => (r["${data.field}"] < ${data.min} or r["${data.field}"] > ${data.max})`,
-  },
+  ...COMMON_THRESHOLD_TYPES,
   [deadmanType]: {
     name: 'missing for longer than',
     format: ThresholdFormat.Deadman,

--- a/src/flows/pipes/Notification/Threshold.tsx
+++ b/src/flows/pipes/Notification/Threshold.tsx
@@ -19,34 +19,12 @@ import 'src/flows/pipes/Notification/Threshold.scss'
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'
-import {COMMON_THRESHOLD_TYPES} from 'src/flows/pipes/Visualization/ErrorThresholds'
-
-export enum ThresholdFormat {
-  Value = 'value',
-  Range = 'range',
-  Deadman = 'deadman',
-}
-
-export type Threshold = {
-  value: number
-  type: string
-  field: string
-  max?: number
-  min?: number
-  deadmanCheckValue?: string
-  deadmanStopValue: string
-}
-
-export const deadmanType = 'missing-for-longer-than'
-
-export const THRESHOLD_TYPES = {
-  ...COMMON_THRESHOLD_TYPES,
-  [deadmanType]: {
-    name: 'missing for longer than',
-    format: ThresholdFormat.Deadman,
-    condition: _ => `(r) => (r["dead"])`,
-  },
-}
+import {
+  deadmanType,
+  Threshold,
+  ThresholdFormat,
+  THRESHOLD_TYPES,
+} from 'src/flows/pipes/Visualization/threshold'
 
 interface Props {
   readOnly?: boolean

--- a/src/flows/pipes/Notification/Threshold.tsx
+++ b/src/flows/pipes/Notification/Threshold.tsx
@@ -40,7 +40,7 @@ const Threshold: FC<Props> = ({readOnly}) => {
   const thresholds = useMemo(() => data?.thresholds ?? [], [data?.thresholds])
 
   const setThresholdType = useCallback(
-    (type, index) => {
+    (type: string, index) => {
       if (!THRESHOLD_TYPES[type]) {
         return
       }

--- a/src/flows/pipes/Notification/view.tsx
+++ b/src/flows/pipes/Notification/view.tsx
@@ -34,10 +34,11 @@ import {PipeContext} from 'src/flows/context/pipe'
 import {FlowQueryContext} from 'src/flows/context/flow.query'
 import {remove} from 'src/shared/contexts/query'
 import Expressions from 'src/flows/pipes/Notification/Expressions'
-import Threshold, {
+import Threshold from 'src/flows/pipes/Notification/Threshold'
+import {
   deadmanType,
   THRESHOLD_TYPES,
-} from 'src/flows/pipes/Notification/Threshold'
+} from 'src/flows/pipes/Visualization/threshold'
 import {
   ENDPOINT_DEFINITIONS,
   ENDPOINT_ORDER,

--- a/src/flows/pipes/Visualization/Controls.tsx
+++ b/src/flows/pipes/Visualization/Controls.tsx
@@ -13,9 +13,10 @@ import {
 } from 'src/visualization'
 import {ViewType} from 'src/types'
 import {event} from 'src/cloud/utils/reporting'
-
+import ErrorThresholds from 'src/flows/pipes/Visualization/ErrorThresholds'
 import {SidebarContext} from 'src/flows/context/sidebar'
 import {PipeContext, PipeProvider} from 'src/flows/context/pipe'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 const WrappedViewOptions: FC = () => {
   const {data, update, results} = useContext(PipeContext)
@@ -33,11 +34,14 @@ const WrappedViewOptions: FC = () => {
   )
 
   return (
-    <ViewOptions
-      properties={data.properties}
-      results={results.parsed}
-      update={updateProperties}
-    />
+    <>
+      <ViewOptions
+        properties={data.properties}
+        results={results.parsed}
+        update={updateProperties}
+      />
+      {isFlagEnabled('flowErrorThresholds') && <ErrorThresholds />}
+    </>
   )
 }
 

--- a/src/flows/pipes/Visualization/ErrorThresholds.tsx
+++ b/src/flows/pipes/Visualization/ErrorThresholds.tsx
@@ -18,21 +18,12 @@ import {
 } from '@influxdata/clockface'
 import {PipeContext} from 'src/flows/context/pipe'
 import {event} from 'src/cloud/utils/reporting'
+import {
+  ThresholdFormat,
+  Threshold,
+} from 'src/flows/pipes/Notification/Threshold'
 
-enum ThresholdFormat {
-  Value = 'value',
-  Range = 'range',
-}
-
-type Threshold = {
-  value: number
-  type: string
-  field: string
-  max?: number
-  min?: number
-}
-
-export const THRESHOLD_TYPES = {
+export const COMMON_THRESHOLD_TYPES = {
   greater: {
     name: 'greater than',
     format: ThresholdFormat.Value,
@@ -90,7 +81,7 @@ const ErrorThresholds: FC = () => {
 
   const setThresholdType = useCallback(
     (type, index) => {
-      if (!THRESHOLD_TYPES[type]) {
+      if (!COMMON_THRESHOLD_TYPES[type]) {
         return
       }
 
@@ -105,7 +96,7 @@ const ErrorThresholds: FC = () => {
       threshold.type = type
       threshold.field = threshold.field || '_value'
 
-      if (THRESHOLD_TYPES[type].format === ThresholdFormat.Range) {
+      if (COMMON_THRESHOLD_TYPES[type].format === ThresholdFormat.Range) {
         threshold.min = 0
         threshold.max = 100
         delete threshold.value
@@ -220,17 +211,19 @@ const ErrorThresholds: FC = () => {
 
   const funcDropdown = useCallback(
     (threshold: Threshold, index: number) => {
-      const menuItems = Object.entries(THRESHOLD_TYPES).map(([key, value]) => (
-        <Dropdown.Item
-          key={key}
-          value={key}
-          onClick={type => setThresholdType(type, index)}
-          selected={key === threshold?.type}
-          title={value.name}
-        >
-          {value?.name}
-        </Dropdown.Item>
-      ))
+      const menuItems = Object.entries(COMMON_THRESHOLD_TYPES).map(
+        ([key, value]) => (
+          <Dropdown.Item
+            key={key}
+            value={key}
+            onClick={type => setThresholdType(type, index)}
+            selected={key === threshold?.type}
+            title={value.name}
+          >
+            {value?.name}
+          </Dropdown.Item>
+        )
+      )
       const menu = onCollapse => (
         <Dropdown.Menu onCollapse={onCollapse}>{menuItems}</Dropdown.Menu>
       )
@@ -241,7 +234,7 @@ const ErrorThresholds: FC = () => {
           size={ComponentSize.Medium}
           status={ComponentStatus.Default}
         >
-          {THRESHOLD_TYPES[threshold?.type]?.name || 'Select a function'}
+          {COMMON_THRESHOLD_TYPES[threshold?.type]?.name || 'Select a function'}
         </Dropdown.Button>
       )
       return <Dropdown menu={menu} button={menuButton} />
@@ -250,7 +243,9 @@ const ErrorThresholds: FC = () => {
   )
 
   const thresholdEntry = (threshold: Threshold, index: number) => {
-    if (THRESHOLD_TYPES[threshold?.type]?.format === ThresholdFormat.Range) {
+    if (
+      COMMON_THRESHOLD_TYPES[threshold?.type]?.format === ThresholdFormat.Range
+    ) {
       return (
         <FlexBox
           direction={FlexDirection.Row}

--- a/src/flows/pipes/Visualization/ErrorThresholds.tsx
+++ b/src/flows/pipes/Visualization/ErrorThresholds.tsx
@@ -19,54 +19,10 @@ import {
 import {PipeContext} from 'src/flows/context/pipe'
 import {event} from 'src/cloud/utils/reporting'
 import {
-  ThresholdFormat,
+  COMMON_THRESHOLD_TYPES,
   Threshold,
-} from 'src/flows/pipes/Notification/Threshold'
-
-export const COMMON_THRESHOLD_TYPES = {
-  greater: {
-    name: 'greater than',
-    format: ThresholdFormat.Value,
-    condition: data => `(r) => (r["${data.field}"] > ${data.value})`,
-  },
-  'greater-equal': {
-    name: 'greater than or equal to',
-    format: ThresholdFormat.Value,
-    condition: data => `(r) => (r["${data.field}"] >= ${data.value})`,
-  },
-  less: {
-    name: 'less than',
-    format: ThresholdFormat.Value,
-    condition: data => `(r) => (r["${data.field}"] < ${data.value})`,
-  },
-  'less-equal': {
-    name: 'less than or equal to',
-    format: ThresholdFormat.Value,
-    condition: data => `(r) => (r["${data.field}"] <= ${data.value})`,
-  },
-  equal: {
-    name: 'equal to',
-    format: ThresholdFormat.Value,
-    condition: data => `(r) => (r["${data.field}"] == ${data.value})`,
-  },
-  'not-equal': {
-    name: 'not equal to',
-    format: ThresholdFormat.Value,
-    condition: data => `(r) => (r["${data.field}"] != ${data.value})`,
-  },
-  between: {
-    name: 'between',
-    format: ThresholdFormat.Range,
-    condition: data =>
-      `(r) => (r["${data.field}"] > ${data.min} and r["${data.field}"] < ${data.max})`,
-  },
-  'not-between': {
-    name: 'not between',
-    format: ThresholdFormat.Range,
-    condition: data =>
-      `(r) => (r["${data.field}"] < ${data.min} or r["${data.field}"] > ${data.max})`,
-  },
-}
+  ThresholdFormat,
+} from 'src/flows/pipes/Visualization/threshold'
 
 const ErrorThresholds: FC = () => {
   const {data, update, results} = useContext(PipeContext)

--- a/src/flows/pipes/Visualization/ErrorThresholds.tsx
+++ b/src/flows/pipes/Visualization/ErrorThresholds.tsx
@@ -1,0 +1,378 @@
+// Libraries
+import React, {ChangeEvent, FC, useCallback, useContext, useMemo} from 'react'
+
+// Components
+import {
+  AlignItems,
+  ComponentSize,
+  ComponentStatus,
+  Dropdown,
+  Icon,
+  IconFont,
+  Input,
+  InputType,
+  FlexBox,
+  FlexDirection,
+  Form,
+  TextBlock,
+} from '@influxdata/clockface'
+import {PipeContext} from 'src/flows/context/pipe'
+import {event} from 'src/cloud/utils/reporting'
+
+enum ThresholdFormat {
+  Value = 'value',
+  Range = 'range',
+}
+
+type Threshold = {
+  value: number
+  type: string
+  field: string
+  max?: number
+  min?: number
+}
+
+export const THRESHOLD_TYPES = {
+  greater: {
+    name: 'greater than',
+    format: ThresholdFormat.Value,
+    condition: data => `(r) => (r["${data.field}"] > ${data.value})`,
+  },
+  'greater-equal': {
+    name: 'greater than or equal to',
+    format: ThresholdFormat.Value,
+    condition: data => `(r) => (r["${data.field}"] >= ${data.value})`,
+  },
+  less: {
+    name: 'less than',
+    format: ThresholdFormat.Value,
+    condition: data => `(r) => (r["${data.field}"] < ${data.value})`,
+  },
+  'less-equal': {
+    name: 'less than or equal to',
+    format: ThresholdFormat.Value,
+    condition: data => `(r) => (r["${data.field}"] <= ${data.value})`,
+  },
+  equal: {
+    name: 'equal to',
+    format: ThresholdFormat.Value,
+    condition: data => `(r) => (r["${data.field}"] == ${data.value})`,
+  },
+  'not-equal': {
+    name: 'not equal to',
+    format: ThresholdFormat.Value,
+    condition: data => `(r) => (r["${data.field}"] != ${data.value})`,
+  },
+  between: {
+    name: 'between',
+    format: ThresholdFormat.Range,
+    condition: data =>
+      `(r) => (r["${data.field}"] > ${data.min} and r["${data.field}"] < ${data.max})`,
+  },
+  'not-between': {
+    name: 'not between',
+    format: ThresholdFormat.Range,
+    condition: data =>
+      `(r) => (r["${data.field}"] < ${data.min} or r["${data.field}"] > ${data.max})`,
+  },
+}
+
+const ErrorThresholds: FC = () => {
+  const {data, update, results} = useContext(PipeContext)
+
+  const fields = Array.from(
+    new Set(results.parsed.table.columns['_field']?.data as string[])
+  )
+
+  const errorThresholds = useMemo(() => data?.errorThresholds ?? [], [
+    data?.errorThresholds,
+  ])
+
+  const setThresholdType = useCallback(
+    (type, index) => {
+      if (!THRESHOLD_TYPES[type]) {
+        return
+      }
+
+      event('Changed Error Threshold', {type})
+
+      const threshold = errorThresholds.find((_, i) => index === i)
+
+      if (!threshold) {
+        return
+      }
+
+      threshold.type = type
+      threshold.field = threshold.field || '_value'
+
+      if (THRESHOLD_TYPES[type].format === ThresholdFormat.Range) {
+        threshold.min = 0
+        threshold.max = 100
+        delete threshold.value
+      } else {
+        threshold.value = 20
+      }
+      update({errorThresholds})
+    },
+    [errorThresholds, update]
+  )
+
+  const setColumn = useCallback(
+    (column: string, index: number) => {
+      event('Changed Notification Threshold Column')
+
+      const threshold = errorThresholds.find((_, i) => index === i)
+
+      if (threshold) {
+        threshold.field = column
+      }
+
+      update({errorThresholds})
+    },
+    [errorThresholds, update]
+  )
+
+  const handleAddThreshold = () => {
+    event('Error Threshold Added to Visualization Panel')
+    update({
+      errorThresholds: [
+        ...(errorThresholds ?? []),
+        {
+          type: 'greater',
+          value: 0,
+        },
+      ],
+    })
+  }
+
+  const handleRemoveThreshold = (index: number) => {
+    const copy = errorThresholds.slice()
+    copy.splice(index, 1)
+
+    update({
+      errorThresholds: copy,
+    })
+  }
+
+  const updateMin = (event: ChangeEvent<HTMLInputElement>, index: number) => {
+    const threshold = errorThresholds.find((_, i) => index === i)
+
+    if (threshold) {
+      threshold.min = Number(event.target.value)
+    }
+
+    update({errorThresholds})
+  }
+
+  const updateMax = (event: ChangeEvent<HTMLInputElement>, index: number) => {
+    const threshold = errorThresholds.find((_, i) => index === i)
+
+    if (threshold) {
+      threshold.max = Number(event.target.value)
+    }
+
+    update({errorThresholds})
+  }
+
+  const updateValue = (
+    changeEvent: ChangeEvent<HTMLInputElement>,
+    index: number
+  ) => {
+    event('Alert Panel (Notebooks) - Threshold Value Entered')
+    const threshold = errorThresholds.find((_, i) => index === i)
+
+    if (threshold) {
+      threshold.value = Number(changeEvent.target.value)
+    }
+
+    update({errorThresholds})
+  }
+
+  const columnDropdown = useCallback(
+    (threshold: Threshold, index: number) => {
+      const menuItems = fields.map(key => (
+        <Dropdown.Item
+          key={key}
+          value={key}
+          onClick={field => setColumn(field, index)}
+          selected={key === threshold?.field}
+          title={key}
+        >
+          {key}
+        </Dropdown.Item>
+      ))
+      const menu = onCollapse => (
+        <Dropdown.Menu onCollapse={onCollapse}>{menuItems}</Dropdown.Menu>
+      )
+      const menuButton = (active, onClick) => (
+        <Dropdown.Button
+          onClick={onClick}
+          active={active}
+          size={ComponentSize.Medium}
+        >
+          {threshold?.field || 'Select a field'}
+        </Dropdown.Button>
+      )
+      return <Dropdown menu={menu} button={menuButton} />
+    },
+    [fields, setColumn]
+  )
+
+  const funcDropdown = useCallback(
+    (threshold: Threshold, index: number) => {
+      const menuItems = Object.entries(THRESHOLD_TYPES).map(([key, value]) => (
+        <Dropdown.Item
+          key={key}
+          value={key}
+          onClick={type => setThresholdType(type, index)}
+          selected={key === threshold?.type}
+          title={value.name}
+        >
+          {value?.name}
+        </Dropdown.Item>
+      ))
+      const menu = onCollapse => (
+        <Dropdown.Menu onCollapse={onCollapse}>{menuItems}</Dropdown.Menu>
+      )
+      const menuButton = (active, onClick) => (
+        <Dropdown.Button
+          onClick={onClick}
+          active={active}
+          size={ComponentSize.Medium}
+          status={ComponentStatus.Default}
+        >
+          {THRESHOLD_TYPES[threshold?.type]?.name || 'Select a function'}
+        </Dropdown.Button>
+      )
+      return <Dropdown menu={menu} button={menuButton} />
+    },
+    [setThresholdType]
+  )
+
+  const thresholdEntry = (threshold: Threshold, index: number) => {
+    if (THRESHOLD_TYPES[threshold?.type]?.format === ThresholdFormat.Range) {
+      return (
+        <FlexBox
+          direction={FlexDirection.Row}
+          margin={ComponentSize.Small}
+          stretchToFitWidth
+        >
+          <FlexBox.Child grow={1}>
+            <Input
+              name="interval"
+              type={InputType.Text}
+              placeholder="min"
+              value={threshold.min}
+              onChange={event => updateMin(event, index)}
+              size={ComponentSize.Medium}
+            />
+          </FlexBox.Child>
+          <TextBlock testID="is-value-text-block" text="to" />
+          <FlexBox.Child grow={1}>
+            <Input
+              name="interval"
+              type={InputType.Text}
+              placeholder="max"
+              value={threshold.max}
+              onChange={event => updateMax(event, index)}
+              size={ComponentSize.Medium}
+            />
+          </FlexBox.Child>
+        </FlexBox>
+      )
+    }
+    return (
+      <FlexBox
+        direction={FlexDirection.Row}
+        margin={ComponentSize.Small}
+        stretchToFitWidth
+      >
+        <FlexBox.Child grow={1}>
+          <Input
+            name="interval"
+            type={InputType.Text}
+            placeholder="value"
+            value={threshold.value}
+            onChange={event => updateValue(event, index)}
+            size={ComponentSize.Medium}
+          />
+        </FlexBox.Child>
+      </FlexBox>
+    )
+  }
+
+  return (
+    <FlexBox
+      direction={FlexDirection.Column}
+      alignItems={AlignItems.Stretch}
+      margin={ComponentSize.Medium}
+      testID="threshold-error-settings"
+    >
+      <Form.Element label="Error Thresholds">
+        <FlexBox
+          direction={FlexDirection.Column}
+          margin={ComponentSize.Small}
+          testID="component-spacer"
+        >
+          {data?.errorThresholds?.map((threshold: any, index: number) => (
+            <FlexBox
+              direction={FlexDirection.Row}
+              margin={ComponentSize.Medium}
+              stretchToFitWidth
+              testID="component-spacer"
+              key={`${threshold.type}_${index}`}
+            >
+              <TextBlock
+                testID="when-value-text-block"
+                text={index === 0 ? 'When' : 'And'}
+                style={{minWidth: 56, textAlign: 'center'}}
+              />
+              <FlexBox.Child grow={2} testID="component-spacer--flex-child">
+                {columnDropdown(threshold, index)}
+              </FlexBox.Child>
+              <TextBlock testID="is-value-text-block" text="is" />
+              <FlexBox.Child grow={2} testID="component-spacer--flex-child">
+                {funcDropdown(threshold, index)}
+              </FlexBox.Child>
+              <FlexBox.Child grow={3} testID="component-spacer--flex-child">
+                {thresholdEntry(threshold, index)}
+              </FlexBox.Child>
+              <FlexBox.Child grow={1} testID="component-spacer--flex-child">
+                <div
+                  className="threshold-trash-icon--block"
+                  onClick={() => handleRemoveThreshold(index)}
+                >
+                  <Icon glyph={IconFont.Trash_New} />
+                </div>
+              </FlexBox.Child>
+            </FlexBox>
+          ))}
+        </FlexBox>
+        <FlexBox
+          direction={FlexDirection.Row}
+          margin={ComponentSize.Small}
+          stretchToFitWidth
+          testID="component-spacer"
+        >
+          <div
+            className="threshold-add-icon--block"
+            onClick={handleAddThreshold}
+          >
+            <TextBlock
+              testID="add-value-text-block"
+              text="+"
+              style={{
+                fontWeight: 400,
+                fontSize: 25,
+                textAlign: 'center',
+                minWidth: 56,
+              }}
+            />
+          </div>
+        </FlexBox>
+      </Form.Element>
+    </FlexBox>
+  )
+}
+
+export default ErrorThresholds

--- a/src/flows/pipes/Visualization/QRCode.tsx
+++ b/src/flows/pipes/Visualization/QRCode.tsx
@@ -1,0 +1,39 @@
+import React, {FC, useEffect, useRef} from 'react'
+import {InfluxColors} from '@influxdata/clockface'
+import QRCode from 'qrcode.react'
+
+type Props = {
+  url: string
+}
+
+const QRComponent: FC<Props> = ({url}) => {
+  const ref = useRef(null)
+  const [size, setSize] = React.useState(100)
+
+  useEffect(() => {
+    if (!ref?.current) {
+      return
+    }
+    setSize(ref.current.getBoundingClientRect().width)
+  }, [])
+
+  return (
+    <div ref={ref} className="qr-code">
+      <QRCode
+        value={url}
+        size={size}
+        fgColor={InfluxColors.Fire}
+        bgColor={InfluxColors.White}
+        imageSettings={{
+          src:
+            'https://www.influxdata.com/wp-content/uploads/Favicon-blue-200x200.png',
+          width: size * 0.2,
+          height: size * 0.2,
+          excavate: true,
+        }}
+      />
+    </div>
+  )
+}
+
+export default QRComponent

--- a/src/flows/pipes/Visualization/style.scss
+++ b/src/flows/pipes/Visualization/style.scss
@@ -8,6 +8,7 @@
   height: 100%;
 }
 
+.flow-visualization--view-error,
 .flow-visualization--view {
   width: 100%;
   border-radius: $cf-radius-sm;
@@ -17,6 +18,9 @@
   .empty-graph-error {
     height: 200px;
   }
+}
+.flow-visualization--view-error {
+  background-color: $c-fire;
 }
 
 .flow-sidebar--submenu .view-options {

--- a/src/flows/pipes/Visualization/style.scss
+++ b/src/flows/pipes/Visualization/style.scss
@@ -18,6 +18,10 @@
   .empty-graph-error {
     height: 200px;
   }
+
+  .qr-code {
+    width: 60%;
+  }
 }
 .flow-visualization--view-error {
   background-color: $c-fire;

--- a/src/flows/pipes/Visualization/threshold.ts
+++ b/src/flows/pipes/Visualization/threshold.ts
@@ -1,0 +1,71 @@
+export enum ThresholdFormat {
+  Value = 'value',
+  Range = 'range',
+  Deadman = 'deadman',
+}
+
+export type Threshold = {
+  value: number
+  type: string
+  field: string
+  max?: number
+  min?: number
+  deadmanCheckValue?: string
+  deadmanStopValue: string
+}
+
+export const COMMON_THRESHOLD_TYPES = {
+  greater: {
+    name: 'greater than',
+    format: ThresholdFormat.Value,
+    condition: data => `(r) => (r["${data.field}"] > ${data.value})`,
+  },
+  'greater-equal': {
+    name: 'greater than or equal to',
+    format: ThresholdFormat.Value,
+    condition: data => `(r) => (r["${data.field}"] >= ${data.value})`,
+  },
+  less: {
+    name: 'less than',
+    format: ThresholdFormat.Value,
+    condition: data => `(r) => (r["${data.field}"] < ${data.value})`,
+  },
+  'less-equal': {
+    name: 'less than or equal to',
+    format: ThresholdFormat.Value,
+    condition: data => `(r) => (r["${data.field}"] <= ${data.value})`,
+  },
+  equal: {
+    name: 'equal to',
+    format: ThresholdFormat.Value,
+    condition: data => `(r) => (r["${data.field}"] == ${data.value})`,
+  },
+  'not-equal': {
+    name: 'not equal to',
+    format: ThresholdFormat.Value,
+    condition: data => `(r) => (r["${data.field}"] != ${data.value})`,
+  },
+  between: {
+    name: 'between',
+    format: ThresholdFormat.Range,
+    condition: data =>
+      `(r) => (r["${data.field}"] > ${data.min} and r["${data.field}"] < ${data.max})`,
+  },
+  'not-between': {
+    name: 'not between',
+    format: ThresholdFormat.Range,
+    condition: data =>
+      `(r) => (r["${data.field}"] < ${data.min} or r["${data.field}"] > ${data.max})`,
+  },
+}
+
+export const deadmanType = 'missing-for-longer-than'
+
+export const THRESHOLD_TYPES = {
+  ...COMMON_THRESHOLD_TYPES,
+  [deadmanType]: {
+    name: 'missing for longer than',
+    format: ThresholdFormat.Deadman,
+    condition: _ => `(r) => (r["dead"])`,
+  },
+}

--- a/src/flows/pipes/Visualization/view.tsx
+++ b/src/flows/pipes/Visualization/view.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC, useContext, useEffect, useMemo} from 'react'
-import QRCode from 'qrcode.react'
+import QRComponent from 'src/flows/pipes/Visualization/QRCode'
 
 // Components
 import {
@@ -10,7 +10,6 @@ import {
   FlexDirection,
   Icon,
   IconFont,
-  InfluxColors,
   JustifyContent,
 } from '@influxdata/clockface'
 import Controls from 'src/flows/pipes/Visualization/Controls'
@@ -257,10 +256,6 @@ const Visualization: FC<PipeProp> = ({Context}) => {
       const url = new URL(
         `${window.location.origin}${window.location.pathname}?panel=${id}`
       ).toString()
-      const doc = document.getElementById(
-        `${triggeredErrorThresholdMessage}-${id}`
-      )
-      const size = doc?.offsetHeight * 0.4 ?? 100
 
       return (
         <Context controls={<Controls />} resizes>
@@ -295,19 +290,7 @@ const Visualization: FC<PipeProp> = ({Context}) => {
                   justifyContent={JustifyContent.Center}
                   alignItems={AlignItems.Center}
                 >
-                  <QRCode
-                    value={url}
-                    size={size}
-                    fgColor={InfluxColors.Fire}
-                    bgColor={InfluxColors.White}
-                    imageSettings={{
-                      src:
-                        'https://www.influxdata.com/wp-content/uploads/Favicon-blue-200x200.png',
-                      width: size * 0.2,
-                      height: size * 0.2,
-                      excavate: true,
-                    }}
-                  />
+                  <QRComponent url={url} />
                   <div className="panel-threshold--message">
                     {triggeredErrorThresholdMessage}
                   </div>

--- a/src/flows/shared/Resizer.scss
+++ b/src/flows/shared/Resizer.scss
@@ -80,6 +80,7 @@ $panel-resizer--drag-handle: 30px;
 
 .panel-resizer--body,
 .panel-resizer--empty,
+.panel-threshold--message,
 .panel-resizer--error {
   position: relative;
   flex: 1 0 0;
@@ -100,6 +101,15 @@ $panel-resizer--drag-handle: 30px;
   user-select: text;
   padding: $cf-space-2xs 0;
   font-weight: $cf-font-weight--medium;
+  height: 30px;
+}
+
+.panel-threshold--message {
+  color: '#EFA5A9';
+  user-select: text;
+  padding: $cf-space-2xs 0;
+  font-weight: $cf-font-weight--bold;
+  text-align: center;
   height: 30px;
 }
 

--- a/src/shared/constants/graphColorPalettes.ts
+++ b/src/shared/constants/graphColorPalettes.ts
@@ -291,6 +291,30 @@ export const LINE_COLORS_SOLID_PURPLE = [
   },
 ]
 
+export const LINE_COLORS_SOLID_WHITE = [
+  {
+    type: COLOR_TYPE_SCALE,
+    hex: '#fff',
+    id: uuid.v4(),
+    name: 'Solid White',
+    value: 0,
+  },
+  {
+    type: COLOR_TYPE_SCALE,
+    hex: '#fff',
+    id: uuid.v4(),
+    name: 'Solid White',
+    value: 0,
+  },
+  {
+    type: COLOR_TYPE_SCALE,
+    hex: '#fff',
+    id: uuid.v4(),
+    name: 'Solid White',
+    value: 0,
+  },
+]
+
 export const DEFAULT_LINE_COLORS = LINE_COLORS_A
 
 export const LINE_COLOR_SCALES = [
@@ -306,6 +330,7 @@ export const LINE_COLOR_SCALES = [
   LINE_COLORS_SOLID_YELLOW,
   LINE_COLORS_SOLID_GREEN,
   LINE_COLORS_SOLID_PURPLE,
+  LINE_COLORS_SOLID_WHITE,
 ].map(colorScale => {
   const name = colorScale[0].name
   const colors = colorScale

--- a/yarn.lock
+++ b/yarn.lock
@@ -9271,6 +9271,20 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
+qr.js@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/qr.js/-/qr.js-0.0.0.tgz#cace86386f59a0db8050fa90d9b6b0e88a1e364f"
+  integrity sha1-ys6GOG9ZoNuAUPqQ2baw6IoeNk8=
+
+qrcode.react@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/qrcode.react/-/qrcode.react-1.0.1.tgz#2834bb50e5e275ffe5af6906eff15391fe9e38a5"
+  integrity sha512-8d3Tackk8IRLXTo67Y+c1rpaiXjoz/Dd2HpcMdW//62/x8J1Nbho14Kh8x974t9prsLHN6XqVgcnRiBGFptQmg==
+  dependencies:
+    loose-envify "^1.4.0"
+    prop-types "^15.6.0"
+    qr.js "0.0.0"
+
 qs@6.7.0:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"


### PR DESCRIPTION
This PR is an initial attempt at allowing users to have UI-based alerting based on specific thresholds set in the UI. The story here is that we want a way to engage a user beyond the current alerting system so that, in the event a user is watching an updating notebook live in presentation mode, they will be able to somehow access that panel directly and take some sort of actionable steps to identifying and remediating that issue beyond the regular alerting system. We do this by allowing the user to set specific thresholds that will generate a QR code that can be scanned and deep-linked to in a notebook whenever the threshold appears.

As part of this, we will need to also integrate auto-refresh of notebooks so that notebooks can be run at a regular interval. In addition, in order to get this feature out live, we will need to rework the notebook sidebar so that it allows the user to interact with the UI in a meaningful way.
