### PR TITLE
fix: clickable link on exporting to client library

### DIFF
--- a/src/shared/components/views/MarkdownRenderer.tsx
+++ b/src/shared/components/views/MarkdownRenderer.tsx
@@ -40,6 +40,7 @@ export const MarkdownRenderer: FC<Props> = ({className = '', text}) => {
       <ReactMarkdown
         className={className}
         components={{img: disallowedImageRenderer}}
+        linkTarget="_blank"
       >
         {text}
       </ReactMarkdown>
@@ -51,6 +52,7 @@ export const MarkdownRenderer: FC<Props> = ({className = '', text}) => {
     <ReactMarkdown
       className={className}
       components={{img: allowedImageRenderer}}
+      linkTarget="_blank"
     >
       {text}
     </ReactMarkdown>

--- a/src/writeData/clients/Arduino/description.md
+++ b/src/writeData/clients/Arduino/description.md
@@ -1,4 +1,4 @@
-For more detailed and up to date information check out the <a href="https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino" target="_blank" rel="noreferrer">GitHub Repository</a>
+For more detailed and up to date information check out the [GitHub Repository](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino)
 
 ##### Install Library
 

--- a/src/writeData/clients/CSharp/description.md
+++ b/src/writeData/clients/CSharp/description.md
@@ -1,4 +1,4 @@
-For more detailed and up to date information check out the <a href="https://github.com/influxdata/influxdb-client-csharp" target="_blank" rel="noreferrer">GitHub Repository</a>
+For more detailed and up to date information check out the [GitHub Repository](https://github.com/influxdata/influxdb-client-csharp)
 
 ##### Install Package
 

--- a/src/writeData/clients/Go/description.md
+++ b/src/writeData/clients/Go/description.md
@@ -1,1 +1,1 @@
-For more detailed and up to date information check out the <a href="https://github.com/influxdata/influxdb-client-go" target="_blank" rel="noreferrer">GitHub Repository</a>
+For more detailed and up to date information check out the [GitHub Repository](https://github.com/influxdata/influxdb-client-go)

--- a/src/writeData/clients/Java/description.md
+++ b/src/writeData/clients/Java/description.md
@@ -1,4 +1,4 @@
-For more detailed and up to date information check out the <a href="https://github.com/influxdata/influxdb-client-java" target="_blank" rel="noreferrer">GitHub Repository</a>
+For more detailed and up to date information check out the [GitHub Repository](https://github.com/influxdata/influxdb-client-java)
 
 ##### Add Dependency
 

--- a/src/writeData/clients/Javascript/description.md
+++ b/src/writeData/clients/Javascript/description.md
@@ -1,4 +1,4 @@
-For more detailed and up to date information check out the <a href="https://github.com/influxdata/influxdb-client-js" target="_blank"  rel="noreferrer">GitHub Repository</a>
+For more detailed and up to date information check out the [GitHub Repository](https://github.com/influxdata/influxdb-client-js)
 
 ##### Install via NPM
 

--- a/src/writeData/clients/Kotlin/description.md
+++ b/src/writeData/clients/Kotlin/description.md
@@ -1,4 +1,4 @@
-For more detailed and up to date information check out the <a href="https://github.com/influxdata/influxdb-client-java/tree/master/client-kotlin" target="_blank"  rel="noreferrer">GitHub Repository</a>
+For more detailed and up to date information check out the [GitHub Repository](https://github.com/influxdata/influxdb-client-java/tree/master/client-kotlin)
 
 ##### Add Dependency
 

--- a/src/writeData/clients/PHP/description.md
+++ b/src/writeData/clients/PHP/description.md
@@ -1,4 +1,4 @@
-For more detailed and up to date information check out the <a href="https://github.com/influxdata/influxdb-client-php" target="_blank"  rel="noreferrer">GitHub Repository</a>
+For more detailed and up to date information check out the [GitHub Repository](https://github.com/influxdata/influxdb-client-php)
 
 ##### Install via Composer
 

--- a/src/writeData/clients/Python/description.md
+++ b/src/writeData/clients/Python/description.md
@@ -1,4 +1,4 @@
-For more detailed and up to date information check out the <a href="https://github.com/influxdata/influxdb-client-python" target="_blank"  rel="noreferrer">GitHub Repository</a>
+For more detailed and up to date information check out the [GitHub Repository](https://github.com/influxdata/influxdb-client-python)
 
 ##### Install Package
 

--- a/src/writeData/clients/R/description.md
+++ b/src/writeData/clients/R/description.md
@@ -1,4 +1,4 @@
-For more detailed and up to date information check out the <a href="https://github.com/influxdata/influxdb-client-r" target="_blank" rel="noreferrer">GitHub Repository</a>
+For more detailed and up to date information check out the [GitHub Repository](https://github.com/influxdata/influxdb-client-r)
 
 ##### Install Package
 

--- a/src/writeData/clients/Ruby/description.md
+++ b/src/writeData/clients/Ruby/description.md
@@ -1,4 +1,4 @@
-For more detailed and up to date information check out the <a href="https://github.com/influxdata/influxdb-client-ruby" target="_blank"  rel="noreferrer">GitHub Repository</a>
+For more detailed and up to date information check out the [GitHub Repository](https://github.com/influxdata/influxdb-client-ruby)
 
 ##### Install the Gem
 

--- a/src/writeData/clients/Scala/description.md
+++ b/src/writeData/clients/Scala/description.md
@@ -1,4 +1,4 @@
-For more detailed and up to date information check out the <a href="https://github.com/influxdata/influxdb-client-java/tree/master/client-scala" target="_blank"  rel="noreferrer">GitHub Repository</a>
+For more detailed and up to date information check out the [GitHub Repository](https://github.com/influxdata/influxdb-client-java/tree/master/client-scala)
 
 ##### Add Dependency
 

--- a/src/writeData/components/fileUploads/AnnotatedCSV.md
+++ b/src/writeData/components/fileUploads/AnnotatedCSV.md
@@ -1,4 +1,4 @@
-For more detailed and up to date information check out the <a href="https://docs.influxdata.com/influxdb/v2.0/write-data/developer-tools/csv/#csv-annotations" target="_blank" rel="noreferrer">Annotated CSV Documentation</a>
+For more detailed and up to date information check out the [Annotated CSV Documentation](https://docs.influxdata.com/influxdb/v2.0/write-data/developer-tools/csv/#csv-annotations)
 
 ##### Getting Started
 


### PR DESCRIPTION
Closes #3239 

The UI wasn't showing the clickable link but HTML tag. We want the link to be clickable and opens in a new tab. This PR fixed the UI. 

Note that this fix doesn't support **"noreferrer noopener"** keyword as `< ReactMarkdown>` doesn't support `rel` attribute currently. 

Before:
<img width="1102" alt="Screen Shot 2022-01-10 at 4 05 14 PM" src="https://user-images.githubusercontent.com/14298407/148846929-10cec001-0663-48a1-9939-83a943aa67ae.png">

After:
<img width="1102" alt="Screen Shot 2022-01-10 at 4 04 46 PM" src="https://user-images.githubusercontent.com/14298407/148846915-790502c9-bdff-4bba-9310-6d9c3e2424f0.png">
