### PR TITLE
fix: allow RFC3339 as indicated in the placeholder for tick start

### DIFF
--- a/src/utils/datetime/constants.ts
+++ b/src/utils/datetime/constants.ts
@@ -1,2 +1,3 @@
 export const DEFAULT_TIME_FORMAT = 'YYYY-MM-DD HH:mm:ss'
 export const STRICT_ISO8061_TIME_FORMAT = 'STRICT_ISO8061_TIME_FORMAT'
+export const RFC3339_VALIDATOR = /(\d\d\d\d)(-)?(\d\d)(-)?(\d\d)(\s|T)?(\d\d)(:)?(\d\d)(:)?(\d\d)(\.\d+)?(Z|([+-])(\d\d)(:)?(\d\d))/

--- a/src/utils/datetime/constants.ts
+++ b/src/utils/datetime/constants.ts
@@ -1,3 +1,3 @@
 export const DEFAULT_TIME_FORMAT = 'YYYY-MM-DD HH:mm:ss'
 export const STRICT_ISO8061_TIME_FORMAT = 'STRICT_ISO8061_TIME_FORMAT'
-export const RFC3339_VALIDATOR = /(\d\d\d\d)(-)?(\d\d)(-)?(\d\d)(\s|T)?(\d\d)(:)?(\d\d)(:)?(\d\d)(\.\d+)?(Z|([+-])(\d\d)(:)?(\d\d))/
+export const RFC3339_PATTERN = /(\d\d\d\d)(-)?(\d\d)(-)?(\d\d)(\s|T)?(\d\d)(:)?(\d\d)(:)?(\d\d)(\.\d+)?(Z|([+-])(\d\d)(:)?(\d\d))/

--- a/src/utils/datetime/formatters.test.ts
+++ b/src/utils/datetime/formatters.test.ts
@@ -1,4 +1,5 @@
 import {
+  convertDateToRFC3339,
   createDateTimeFormatter,
   createRelativeFormatter,
 } from 'src/utils/datetime/formatters'
@@ -390,6 +391,33 @@ describe('the DateTime formatter', () => {
       const date = new Date(timestamp)
       const formatter = createDateTimeFormatter('hh:mm:ss.sss a')
       expect(formatter.format(date)).toBe(`${hour}:00:00.000 PM`)
+    })
+  })
+
+  describe('convert date to local time in RFC3339 format', () => {
+    it('can reject invalid dates', () => {
+      expect(convertDateToRFC3339(new Date('abcd'), 'Local')).toEqual(
+        'Invalid Date'
+      )
+      expect(convertDateToRFC3339(new Date('abcd'), 'UTC')).toEqual(
+        'Invalid Date'
+      )
+    })
+
+    it('can use a converted date as the argument to create a valid Date', () => {
+      let convertedDateString = convertDateToRFC3339(new Date(), 'Local')
+      let date = new Date(convertedDateString)
+      expect(date.toDateString()).not.toEqual('Invalid Date')
+      expect(() => {
+        date.toISOString()
+      }).not.toThrow()
+
+      convertedDateString = convertDateToRFC3339(new Date(), 'UTC')
+      date = new Date(convertedDateString)
+      expect(date.toDateString()).not.toEqual('Invalid Date')
+      expect(() => {
+        date.toISOString()
+      }).not.toThrow()
     })
   })
 })

--- a/src/utils/datetime/formatters.ts
+++ b/src/utils/datetime/formatters.ts
@@ -1,6 +1,7 @@
 // TODO: handle these any types
 
 import {TimeZone} from 'src/types'
+import {STRICT_ISO8061_TIME_FORMAT} from 'src/utils/datetime/constants'
 
 const dateTimeOptions: any = {
   hourCycle: 'h23',
@@ -67,6 +68,12 @@ export const createDateTimeFormatter = (
         )
       }
       break
+    }
+
+    case STRICT_ISO8061_TIME_FORMAT: {
+      return {
+        format: date => date,
+      }
     }
 
     case 'YYYY-MM-DD': {

--- a/src/utils/datetime/formatters.ts
+++ b/src/utils/datetime/formatters.ts
@@ -785,3 +785,26 @@ export const createDateTimeFormatter = (
     }
   }
 }
+
+export const convertDateToRFC3339 = (date: Date, timeZone: string): string => {
+  if (!date || date.toDateString() === 'Invalid Date') {
+    return date.toDateString()
+  }
+
+  if (timeZone === 'Local') {
+    const year = date.getFullYear()
+    const month =
+      date.getMonth() + 1 < 10
+        ? `0${date.getMonth() + 1}`
+        : `${date.getMonth() + 1}`
+    const dayOfMonth =
+      date.getDate() < 10 ? `0${date.getDate()}` : `${date.getDate()}`
+
+    const timeStringParsed = date.toTimeString().split(' ')
+    const localTime = timeStringParsed[0]
+    const utcOffset = timeStringParsed[1].replace('GMT', '')
+
+    return `${year}-${month}-${dayOfMonth} ${localTime}${utcOffset}`
+  }
+  return date.toISOString()
+}

--- a/src/utils/datetime/validator.test.ts
+++ b/src/utils/datetime/validator.test.ts
@@ -1,4 +1,4 @@
-import {isValid, isValidStrictly} from './validator'
+import {isValid, isValidRFC3339, isValidStrictly} from './validator'
 
 describe('the datetime validator', () => {
   it('should return true on valid date formats', function() {
@@ -55,6 +55,7 @@ describe('the datetime validator', () => {
       )
     ).toBeTruthy()
   })
+
   it('should return false on invalid date formats', function() {
     expect(isValid('1999-02-09 23:00', 'YYYY-MM-DD HH:mm:ss')).toBeFalsy()
     expect(
@@ -98,6 +99,7 @@ describe('the datetime validator', () => {
       )
     ).toBeFalsy()
   })
+
   it('should be strict on date formats', function() {
     expect(
       isValidStrictly('1999-02-09 23:00:0', 'YYYY-MM-DD HH:mm:ss')
@@ -149,5 +151,55 @@ describe('the datetime validator', () => {
         'dddd, MMMM D, YYYY hh:mm:ss a'
       )
     ).toBeFalsy()
+  })
+
+  describe('can validate RFC3339 format', () => {
+    it('can identify valid RFC3339 format', () => {
+      expect(isValidRFC3339(new Date().toISOString())).toBeTruthy()
+
+      expect(isValidRFC3339('2022-01-11T23:00:00Z')).toBeTruthy()
+      expect(isValidRFC3339('2022-01-11T00:00:00Z')).toBeTruthy()
+      expect(isValidRFC3339('2022-01-11T23:00:00+0800')).toBeTruthy()
+      expect(isValidRFC3339('2022-01-11T23:00:00+08:00')).toBeTruthy()
+      expect(isValidRFC3339('2022-01-11T23:00:00-0800')).toBeTruthy()
+      expect(isValidRFC3339('2022-01-11T23:00:00-08:00')).toBeTruthy()
+      expect(isValidRFC3339('2022-01-11T23:00:00+00:00')).toBeTruthy()
+      expect(isValidRFC3339('2022-01-11T23:00:00-00:00')).toBeTruthy()
+      expect(isValidRFC3339('2022-01-11T23:00:00+0000')).toBeTruthy()
+      expect(isValidRFC3339('2022-01-11T23:00:00-0000')).toBeTruthy()
+      expect(isValidRFC3339('2022-01-11T23:00:00+10:30')).toBeTruthy()
+
+      expect(isValidRFC3339('2022-01-11 23:00:00Z')).toBeTruthy()
+      expect(isValidRFC3339('2022-01-11 00:00:00Z')).toBeTruthy()
+      expect(isValidRFC3339('2022-01-11 23:00:00+0800')).toBeTruthy()
+      expect(isValidRFC3339('2022-01-11 23:00:00+08:00')).toBeTruthy()
+      expect(isValidRFC3339('2022-01-11 23:00:00-0800')).toBeTruthy()
+      expect(isValidRFC3339('2022-01-11 23:00:00-08:00')).toBeTruthy()
+      expect(isValidRFC3339('2022-01-11 23:00:00+00:00')).toBeTruthy()
+      expect(isValidRFC3339('2022-01-11 23:00:00-00:00')).toBeTruthy()
+      expect(isValidRFC3339('2022-01-11 23:00:00+0000')).toBeTruthy()
+      expect(isValidRFC3339('2022-01-11 23:00:00-0000')).toBeTruthy()
+      expect(isValidRFC3339('2022-01-11 23:00:00+10:30')).toBeTruthy()
+    })
+
+    it('can identify invalid RFC3339 format', () => {
+      expect(isValidRFC3339('22-01-11T23:00:00')).toBeFalsy()
+      expect(isValidRFC3339('01-11T23:00:00')).toBeFalsy()
+      expect(isValidRFC3339('20220111T230000Z')).toBeFalsy()
+      expect(isValidRFC3339('2022-344T23:00:00Z')).toBeFalsy()
+      expect(isValidRFC3339('2022-01-11T23:00:00')).toBeFalsy()
+      expect(isValidRFC3339('2022-01-11T23:00:00+Z')).toBeFalsy()
+      expect(isValidRFC3339('2022-01-11T23:00:00+0')).toBeFalsy()
+      expect(isValidRFC3339('2022-01-11T23:00:00+8')).toBeFalsy()
+
+      expect(isValidRFC3339('22-01-11 23:00:00')).toBeFalsy()
+      expect(isValidRFC3339('01-11 23:00:00')).toBeFalsy()
+      expect(isValidRFC3339('20220111230000Z')).toBeFalsy()
+      expect(isValidRFC3339('2022-344 23:00:00Z')).toBeFalsy()
+      expect(isValidRFC3339('2022-01-11 23:00:00')).toBeFalsy()
+      expect(isValidRFC3339('2022-01-11 23:00:00+Z')).toBeFalsy()
+      expect(isValidRFC3339('2022-01-11 23:00:00+0')).toBeFalsy()
+      expect(isValidRFC3339('2022-01-11 23:00:00+8')).toBeFalsy()
+    })
   })
 })

--- a/src/utils/datetime/validator.ts
+++ b/src/utils/datetime/validator.ts
@@ -1,5 +1,8 @@
 import {DateTime} from 'luxon'
-import {DEFAULT_TIME_FORMAT} from 'src/utils/datetime/constants'
+import {
+  DEFAULT_TIME_FORMAT,
+  RFC3339_PATTERN,
+} from 'src/utils/datetime/constants'
 
 const formatToLuxonMap = {
   [DEFAULT_TIME_FORMAT]: {
@@ -112,5 +115,11 @@ export const isValidStrictly = (
   return (
     strictCheck(formattedDateTimeString, format) &&
     DateTime.fromFormat(formattedDateTimeString, dateFnsFormatString).isValid
+  )
+}
+
+export const isValidRFC3339 = (input: string) => {
+  return (
+    RFC3339_PATTERN.test(input) && new Date(input).toString() !== 'Invalid Date'
   )
 }

--- a/src/visualization/components/internal/AxisTicksGenerator.tsx
+++ b/src/visualization/components/internal/AxisTicksGenerator.tsx
@@ -110,13 +110,6 @@ const AxisTicksGenerator: FC<Props> = ({
             update={update}
             elementStylingClass="value-tick-input--custom"
           />
-          <TimeTickInput
-            axisName={axisName}
-            tickPropertyName="start"
-            tickOptions={generateAxisTicks}
-            initialTickOptionValue={tickStart}
-            update={update}
-          />
           <ValueTickInput
             axisName={axisName}
             tickPropertyName="step"
@@ -124,6 +117,13 @@ const AxisTicksGenerator: FC<Props> = ({
             initialTickOptionValue={tickStep}
             label="Tick Mark Interval"
             placeholder="milliseconds"
+            update={update}
+          />
+          <TimeTickInput
+            axisName={axisName}
+            tickPropertyName="start"
+            tickOptions={generateAxisTicks}
+            initialTickOptionValue={tickStart}
             update={update}
           />
         </Grid.Row>
@@ -142,18 +142,18 @@ const AxisTicksGenerator: FC<Props> = ({
           />
           <ValueTickInput
             axisName={axisName}
-            tickPropertyName="start"
-            tickOptions={generateAxisTicks}
-            initialTickOptionValue={tickStart}
-            label="Start Tick Marks At"
-            update={update}
-          />
-          <ValueTickInput
-            axisName={axisName}
             tickPropertyName="step"
             tickOptions={generateAxisTicks}
             initialTickOptionValue={tickStep}
             label="Tick Mark Interval"
+            update={update}
+          />
+          <ValueTickInput
+            axisName={axisName}
+            tickPropertyName="start"
+            tickOptions={generateAxisTicks}
+            initialTickOptionValue={tickStart}
+            label="Start Tick Marks At"
             update={update}
           />
         </Grid.Row>


### PR DESCRIPTION
Closes #3396 

- Fixes the "Start Time Ticks At" input to actually take a string in RFC3339 format. Previously, it was only taking a Unix timestamp.

- The time is converted to either "Local" or "UTC" based on the current selection for the Time Zone of the app. Must be done because the back-end still stores the "Start Time Ticks At" as a number (Unix timestamp) but we want to display a human readable format (RFC3339).


https://user-images.githubusercontent.com/10736577/149055860-d5bec2f2-98a1-4b23-91e0-0d87d2de8cc3.mp4



