### PR TITLE
chore(e2e): skip flakey billing page tests

### DIFF
--- a/cypress/e2e/cloud/billing.test.ts
+++ b/cypress/e2e/cloud/billing.test.ts
@@ -20,7 +20,7 @@ describe('Billing Page Free Users', () => {
     )
   )
 
-  it('should display the free billing page for free users', () => {
+  it.skip('should display the free billing page for free users', () => {
     cy.getByTestID('cloud-upgrade--button').should('be.visible')
     cy.getByTestID('title-header--name')
       .should('not.have.value', 'blockedNotificationRules')
@@ -80,7 +80,7 @@ describe('Billing Page PAYG Users', () => {
     )
   )
 
-  it('should display the free billing page for free users', () => {
+  it.skip('should display the free billing page for free users', () => {
     // The implication here is that there is no Upgrade Now button
     cy.get('.cf-page-header--fixed')
       .children()


### PR DESCRIPTION
This has interrupted a couple of alchemy merge attempts now and has been labelled as flaky by circle's automation.

Here is an example: https://app.circleci.com/pipelines/github/influxdata/idpe/24115/workflows/9a264a85-ba55-4d98-b86e-68807e6cb0fc/jobs/1026844/tests
