### PR TITLE
feat: allow self removal from account with ff on

### DIFF
--- a/src/shared/selectors/flags.ts
+++ b/src/shared/selectors/flags.ts
@@ -45,7 +45,6 @@ export const OSS_FLAGS = {
   boardWithFlows: false,
   createWithFlows: false,
   leadWithFlows: false,
-  selfRemovalFromAccount: false,
 }
 
 export const CLOUD_FLAGS = {
@@ -92,7 +91,6 @@ export const CLOUD_FLAGS = {
   boardWithFlows: false,
   createWithFlows: false,
   leadWithFlows: false,
-  selfRemovalFromAccount: false,
 }
 
 export const activeFlags = (state: AppState): FlagMap => {

--- a/src/shared/selectors/flags.ts
+++ b/src/shared/selectors/flags.ts
@@ -45,6 +45,7 @@ export const OSS_FLAGS = {
   boardWithFlows: false,
   createWithFlows: false,
   leadWithFlows: false,
+  selfRemovalFromAccount: false,
 }
 
 export const CLOUD_FLAGS = {
@@ -91,6 +92,7 @@ export const CLOUD_FLAGS = {
   boardWithFlows: false,
   createWithFlows: false,
   leadWithFlows: false,
+  selfRemovalFromAccount: false,
 }
 
 export const activeFlags = (state: AppState): FlagMap => {

--- a/src/users/components/UserListItem.tsx
+++ b/src/users/components/UserListItem.tsx
@@ -22,6 +22,9 @@ import {getMe} from 'src/me/selectors'
 // Types
 import {CloudUser} from 'src/types'
 
+// Utils
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+
 interface Props {
   user: CloudUser
 }
@@ -51,6 +54,7 @@ const UserListItem: FC<Props> = ({user}) => {
 
   const isCurrentUser = id === currentUserId
   const [revealOnHover, toggleRevealOnHover] = useState(true)
+  const selfRemovalFromAccount = isFlagEnabled('selfRemovalFromAccount')
 
   const handleShow = () => {
     toggleRevealOnHover(false)
@@ -89,7 +93,7 @@ const UserListItem: FC<Props> = ({user}) => {
       </IndexList.Cell>
       <IndexList.Cell className="user-list-cell-status">Active</IndexList.Cell>
       <IndexList.Cell revealOnHover={revealOnHover} alignment={Alignment.Right}>
-        {!isCurrentUser && (
+        {(!isCurrentUser || selfRemovalFromAccount) && (
           <ConfirmationButton
             icon={IconFont.Trash_New}
             onShow={handleShow}


### PR DESCRIPTION
Closes influxdata/quartz#4650

This allows users to remove themselves from an account when the `selfRemovalFromAccount` feature flag is on.