### PR TITLE
fix: Notebook Single Stat view stays in place when users configure

### DIFF
--- a/src/flows/pipes/Notification/readOnly.tsx
+++ b/src/flows/pipes/Notification/readOnly.tsx
@@ -11,7 +11,7 @@ import {
   ComponentSize,
   Panel,
   AlignItems,
-  Dropdown,
+  List,
   InfluxColors,
   TechnoSpinner,
   SpinnerContainer,
@@ -143,13 +143,13 @@ const ReadOnly: FC<PipeProp> = ({Context}) => {
                     <Form.Element
                       required={true}
                       label="Endpoint"
-                      className="endpoint-dropdown--element"
+                      className="endpoint-list--element"
                     >
-                      <Dropdown.Menu className="flows-endpoints--dropdown">
-                        <Dropdown.Item selected={true}>
+                      <List>
+                        <List.Item selected={true}>
                           {ENDPOINT_DEFINITIONS[data.endpoint].name}
-                        </Dropdown.Item>
-                      </Dropdown.Menu>
+                        </List.Item>
+                      </List>
                     </Form.Element>
                     <FlexBox.Child grow={1} shrink={1}>
                       <Form.Element

--- a/src/flows/pipes/Notification/styles.scss
+++ b/src/flows/pipes/Notification/styles.scss
@@ -1,8 +1,3 @@
-.flows-endpoints--dropdown {
-  background: #181820;
-  height: 100%;
-}
-
 .slack-endpoint-details--flex {
   display: flex;
   flex-direction: column;
@@ -56,7 +51,7 @@
   padding: 8px;
 }
 
-.endpoint-dropdown--element {
+.endpoint-list--element {
   flex: 1;
   max-width: 14%;
 }

--- a/src/flows/pipes/Notification/view.tsx
+++ b/src/flows/pipes/Notification/view.tsx
@@ -23,7 +23,7 @@ import {
   Panel,
   AlignItems,
   JustifyContent,
-  Dropdown,
+  List,
   ComponentColor,
   Button,
   InfluxColors,
@@ -247,7 +247,7 @@ const Notification: FC<PipeProp> = ({Context}) => {
     )
     .sort((a, b) => ENDPOINT_ORDER.indexOf(a) - ENDPOINT_ORDER.indexOf(b))
     .map(k => (
-      <Dropdown.Item
+      <List.Item
         key={k}
         id={k}
         testID={`dropdown-item--${k}`}
@@ -255,7 +255,7 @@ const Notification: FC<PipeProp> = ({Context}) => {
         selected={data.endpoint === k}
       >
         {ENDPOINT_DEFINITIONS[k].name}
-      </Dropdown.Item>
+      </List.Item>
     ))
 
   const generateDeadmanTask = useCallback(() => {
@@ -646,14 +646,9 @@ ${ENDPOINT_DEFINITIONS[data.endpoint]?.generateTestQuery(data.endpointData)}`
                     <Form.Element
                       required={true}
                       label="Endpoint"
-                      className="endpoint-dropdown--element"
+                      className="endpoint-list--element"
                     >
-                      <Dropdown.Menu
-                        className="flows-endpoints--dropdown"
-                        maxHeight={500}
-                      >
-                        {avail}
-                      </Dropdown.Menu>
+                      <List>{avail}</List>
                     </Form.Element>
                     <FlexBox.Child grow={1} shrink={1}>
                       <Form.Element


### PR DESCRIPTION
Closes #3512 

There was a bug in Notebook Single Stat, when users configure, the view auto focused on a cell under the graph cell. We want the view to stay in place when users configure.

Before:

![notebook-bug](https://user-images.githubusercontent.com/19984220/148272107-613c7923-6bff-45c8-bb6a-30e12c40fe26.gif)

After:

![success](https://user-images.githubusercontent.com/14298407/149025258-e1f13d4e-eb9c-4c51-b8b1-98b8914db2d1.gif)

---

### Explanation on the bug

The bug only appears when there is an Alert cell somewhere under the Single Stat graph cell. This is caused by using `<Dropdown.Menu>` in the Alert cell because the view is auto focused to show the selected dropdown item. 

### How it is being fixed

Replace `<Dropdown.Menu>` with `<List>` fixed this issue because List doesn't have the side-effect of auto focusing. 
