### PR TITLE
fix: update Giraffe to update formatStatValue

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "@docsearch/react": "^3.0.0-alpha.37",
     "@influxdata/clockface": "^3.1.8",
     "@influxdata/flux-lsp-browser": "^0.8.0",
-    "@influxdata/giraffe": "^2.23.0",
+    "@influxdata/giraffe": "^2.23.1",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",
     "abortcontroller-polyfill": "^1.3.0",

--- a/src/visualization/utils/formatStatValue.ts
+++ b/src/visualization/utils/formatStatValue.ts
@@ -35,18 +35,13 @@ export const formatStatValue = (
 
   digits = Math.min(digits, MAX_DECIMAL_PLACES)
 
+  const formatter = Intl.NumberFormat(undefined, {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+  })
+
   if (typeof value === 'number') {
-    const [wholeNumber, fractionalNumber] = Number(value)
-      .toFixed(digits)
-      .split('.')
-
-    localeFormattedValue = Number(wholeNumber).toLocaleString(undefined, {
-      maximumFractionDigits: MAX_DECIMAL_PLACES,
-    })
-
-    if (fractionalNumber) {
-      localeFormattedValue += `.${fractionalNumber}`
-    }
+    localeFormattedValue = formatter.format(Number(value))
   } else if (typeof value === 'string') {
     localeFormattedValue = value
   } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1100,10 +1100,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/flux-lsp-browser/-/flux-lsp-browser-0.8.0.tgz#2b0b8d543f9b89e73ee2379a90aa66499fa92026"
   integrity sha512-A7bGnbDzOnsEIAYpxuqdKJjPbtlP5H5EcXsqdpMISdp80y0TBbGv41U3dsfrOIPENvXNYLjroIvp6QYnnF/uaw==
 
-"@influxdata/giraffe@^2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.23.0.tgz#3032a6e3266b44e6dd1b3c18474d3a818bcac909"
-  integrity sha512-HVIRU63GFKaAF5Y7ygwtxzabKTRvMxbZY50sqk2xzVxHO0dlp2xTHIYUlikNyaWh41RLI7lu4ESOkNQ2ZraNIQ==
+"@influxdata/giraffe@^2.23.1":
+  version "2.23.1"
+  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.23.1.tgz#d06b6409042988f32e75bf473e76fee736f072ab"
+  integrity sha512-ReV3sM59F8p8EE8cGtS+5dhsknB6bLx1cnF+jHBxVAaVKbZKypmdO89XuZV2nt/BidSpglK7cQ/pwcKvcGWQ0Q==
   dependencies:
     merge-images "^2.0.0"
 


### PR DESCRIPTION
Closes #3519 

- updates Giraffe to update `formatStatValue`
- copies `formatStatValue` from Giraffe for posterity
     _note_: `formatStatValue` should not be implemented by UI and will be removed in a separate pull request.
