### PR TITLE
fix: fixes the issue that toggling the timerange didnt update the queries timerange

### DIFF
--- a/src/flows/context/flow.query.tsx
+++ b/src/flows/context/flow.query.tsx
@@ -1,4 +1,4 @@
-import React, {FC, useContext, useEffect, useState, useRef} from 'react'
+import React, {FC, useContext, useEffect, useRef} from 'react'
 import {useDispatch, useSelector} from 'react-redux'
 import {FlowContext} from 'src/flows/context/flow.current'
 import {ResultsContext} from 'src/flows/context/results'
@@ -62,21 +62,23 @@ export const FlowQueryProvider: FC = ({children}) => {
   const {setResult, setStatuses, statuses} = useContext(ResultsContext)
   const {query: queryAPI, basic: basicAPI} = useContext(QueryContext)
   const org = useSelector(getOrg) ?? {id: ''}
-  const [prevLower, setPrevLower] = useState<string>(flow?.range?.lower)
 
   const dispatch = useDispatch()
   const notebookQueryKey = `queryAll-${flow?.name}`
 
   useEffect(() => {
-    if (flow?.range?.lower !== prevLower) {
-      // only run the query if a previously set value has been changed.
-      // unless we're in presentation mode, then we should run the query on load.
-      if (prevLower || flow.readOnly) {
-        queryAll()
-      }
-      setPrevLower(flow?.range?.lower)
+    if (!flow?.range) {
+      return
     }
-  }, [flow])
+    _generateMap()
+    queryAll()
+  }, [flow?.range])
+
+  useEffect(() => {
+    if (flow?.readOnly) {
+      queryAll()
+    }
+  }, [flow?.readOnly])
 
   // Share querying event across tabs
   const handleStorageEvent = e => {


### PR DESCRIPTION
Closes #3526 

This PR addresses an issue where toggling the time range of a notebook would run the query for that notebook based on the previously selected timerange. This PR also cleans up some implementation details where we were setting the timerange of the notebook in two separate places, which was causing some weirdness with state syncing.
