### PR TITLE
fix: allow no functions to be selected in query builder custom aggregation

### DIFF
--- a/src/timeMachine/actions/queryBuilderThunks.ts
+++ b/src/timeMachine/actions/queryBuilderThunks.ts
@@ -5,7 +5,6 @@ import {queryBuilderFetcher} from 'src/timeMachine/apis/QueryBuilderFetcher'
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'
-import {prohibitedDeselect} from 'src/shared/copy/notifications'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // API
@@ -55,7 +54,6 @@ import {
   setFunctions,
 } from 'src/timeMachine/actions/queryBuilder'
 import {setBuckets} from 'src/buckets/actions/creators'
-import {notify} from 'src/shared/actions/notifications'
 
 // Constants
 import {AGG_WINDOW_AUTO} from 'src/timeMachine/constants/queryBuilder'
@@ -355,12 +353,7 @@ export const multiSelectBuilderFunction = (name: string) => (
     // add clicked to selected
     dispatch(setFunctions([...functionNames, name]))
   } else {
-    if (functions.length > 1) {
-      // if more than one function is selected, remove clicked from selected
-      dispatch(setFunctions(functionNames.filter(n => n != name)))
-    } else {
-      dispatch(notify(prohibitedDeselect()))
-    }
+    dispatch(setFunctions(functionNames.filter(n => n != name)))
   }
 }
 

--- a/src/views/helpers/index.ts
+++ b/src/views/helpers/index.ts
@@ -74,7 +74,7 @@ export function defaultBuilderConfig(): BuilderConfig {
   return {
     buckets: [],
     tags: [{key: '_measurement', values: [], aggregateFunctionType: 'filter'}],
-    functions: [],
+    functions: [{name: DEFAULT_AGGREGATE_FUNCTION}],
     aggregateWindow: {period: AGG_WINDOW_AUTO, fillValues: DEFAULT_FILLVALUES},
   }
 }

--- a/src/views/helpers/index.ts
+++ b/src/views/helpers/index.ts
@@ -74,7 +74,7 @@ export function defaultBuilderConfig(): BuilderConfig {
   return {
     buckets: [],
     tags: [{key: '_measurement', values: [], aggregateFunctionType: 'filter'}],
-    functions: [{name: DEFAULT_AGGREGATE_FUNCTION}],
+    functions: [],
     aggregateWindow: {period: AGG_WINDOW_AUTO, fillValues: DEFAULT_FILLVALUES},
   }
 }


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/3043

Allows to unselect the default values that way users can opt in to have no custom selected aggregate functions. 

Video: 

https://user-images.githubusercontent.com/18511823/149415871-06f0b91c-4106-4c3d-b3a2-7d8d56a0c64b.mov



