### PR TITLE
fix: use the redesigned generateTokensDropdown in WriteDataHelperTokens

### DIFF
--- a/src/writeData/components/WriteDataHelperTokens.tsx
+++ b/src/writeData/components/WriteDataHelperTokens.tsx
@@ -28,6 +28,9 @@ import {AppState, ResourceType, Authorization} from 'src/types'
 
 import GenerateTokenDropdown from 'src/authorizations/components/GenerateTokenDropdown'
 
+import GenerateTokenDropdownRedesigned from 'src/authorizations/components/redesigned/GenerateTokenDropdown'
+import {isFlagEnabled} from '../../shared/utils/featureFlag'
+
 const WriteDataHelperTokens: FC = () => {
   const tokens = useSelector((state: AppState) =>
     getAll<Authorization>(state, ResourceType.Authorizations)
@@ -102,7 +105,11 @@ const WriteDataHelperTokens: FC = () => {
         className="write-data--details-widget-title"
       >
         Token
-        <GenerateTokenDropdown />
+        {isFlagEnabled('tokensUIRedesign') ? (
+          <GenerateTokenDropdownRedesigned />
+        ) : (
+          <GenerateTokenDropdown />
+        )}
       </Heading>
       {body}
     </>

--- a/src/writeData/components/WriteDataHelperTokens.tsx
+++ b/src/writeData/components/WriteDataHelperTokens.tsx
@@ -29,7 +29,7 @@ import {AppState, ResourceType, Authorization} from 'src/types'
 import GenerateTokenDropdown from 'src/authorizations/components/GenerateTokenDropdown'
 
 import GenerateTokenDropdownRedesigned from 'src/authorizations/components/redesigned/GenerateTokenDropdown'
-import {isFlagEnabled} from '../../shared/utils/featureFlag'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 const WriteDataHelperTokens: FC = () => {
   const tokens = useSelector((state: AppState) =>


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/3530

Uses the redesigned component in the `WriteDataHelperTokens`.


https://user-images.githubusercontent.com/18511823/149421961-0d584767-976b-45b7-aa55-4414dca502c2.mov


<!-- Describe your proposed changes here. -->
