### PR TITLE
chore: normalize the naming for autorefresh to make it more generic and intuitive

### DIFF
--- a/cypress/e2e/shared/dashboardsRefresh.test.ts
+++ b/cypress/e2e/shared/dashboardsRefresh.test.ts
@@ -134,7 +134,7 @@ describe('Dashboard refresh', () => {
       })
     })
 
-    it.only('does not refresh if user edits cell, until user comes back, and then continues', () => {
+    it('does not refresh if user edits cell, until user comes back, and then continues', () => {
       cy.get<Organization>('@org').then((org: Organization) => {
         cy.getByTestID('enable-auto-refresh-button').click()
         cy.getByTestID('auto-refresh-input')

--- a/cypress/e2e/shared/dashboardsRefresh.test.ts
+++ b/cypress/e2e/shared/dashboardsRefresh.test.ts
@@ -148,7 +148,9 @@ describe('Dashboard refresh', () => {
             .type(`${jumpAheadTime('00:00:10')}`, {force: true})
           cy.getByTestID('daterange--apply-btn').click()
         })
-        cy.intercept('POST', `/api/v2/query?orgID=${org.id}`).as('refreshQuery')
+        cy.intercept('POST', `/api/v2/query?orgID=${org.id}`, req => {
+          req.alias = 'refreshQuery'
+        })
 
         cy.getByTestID('refresh-form-activate-button').click()
 

--- a/cypress/e2e/shared/dashboardsRefresh.test.ts
+++ b/cypress/e2e/shared/dashboardsRefresh.test.ts
@@ -206,8 +206,7 @@ describe('Dashboard refresh', () => {
           .invoke('dispatch', {
             type: 'SET_INACTIVITY_TIMEOUT',
             ...{
-              dashboardID: cy.state().window.store.getState().currentDashboard
-                .id,
+              id: cy.state().window.store.getState().currentDashboard.id,
               inactivityTimeout: 3000,
             },
           })

--- a/cypress/e2e/shared/dashboardsRefresh.test.ts
+++ b/cypress/e2e/shared/dashboardsRefresh.test.ts
@@ -134,7 +134,7 @@ describe('Dashboard refresh', () => {
       })
     })
 
-    it('does not refresh if user edits cell, until user comes back, and then continues', () => {
+    it.only('does not refresh if user edits cell, until user comes back, and then continues', () => {
       cy.get<Organization>('@org').then((org: Organization) => {
         cy.getByTestID('enable-auto-refresh-button').click()
         cy.getByTestID('auto-refresh-input')
@@ -148,9 +148,7 @@ describe('Dashboard refresh', () => {
             .type(`${jumpAheadTime('00:00:10')}`, {force: true})
           cy.getByTestID('daterange--apply-btn').click()
         })
-        cy.intercept('POST', `/api/v2/query?orgID=${org.id}`, req => {
-          req.alias = 'refreshQuery'
-        })
+        cy.intercept('POST', `/api/v2/query?orgID=${org.id}`).as('refreshQuery')
 
         cy.getByTestID('refresh-form-activate-button').click()
 
@@ -166,8 +164,6 @@ describe('Dashboard refresh', () => {
         cy.getByTestID('overlay').within(() => {
           cy.getByTestID('cancel-cell-edit--button').click()
         })
-
-        expect(!!cy.state('requests')).to.eq(false)
 
         cy.visit(routeToReturnTo)
         cy.wait('@refreshQuery')

--- a/src/dashboards/components/DashboardContainer.tsx
+++ b/src/dashboards/components/DashboardContainer.tsx
@@ -11,7 +11,7 @@ import DashboardRoute from 'src/shared/components/DashboardRoute'
 
 // Actions
 import {setCurrentPage} from 'src/shared/reducers/currentPage'
-import {resetDashboardAutoRefresh} from 'src/shared/actions/autoRefresh'
+import {resetAutoRefresh} from 'src/shared/actions/autoRefresh'
 // Utils
 import {GlobalAutoRefresher} from 'src/utils/AutoRefresher'
 
@@ -51,7 +51,7 @@ const DashboardContainer: FC = () => {
     }
 
     timer.current = setTimeout(() => {
-      dispatch(resetDashboardAutoRefresh(dashboard))
+      dispatch(resetAutoRefresh(dashboard))
       dispatch(notify(dashboardAutoRefreshTimeoutSuccess()))
       registerStopListeners()
       GlobalAutoRefresher.stopPolling()
@@ -71,7 +71,7 @@ const DashboardContainer: FC = () => {
       new Date(autoRefresh?.duration?.upper).getTime() <= new Date().getTime()
     ) {
       GlobalAutoRefresher.stopPolling()
-      dispatch(resetDashboardAutoRefresh(dashboard))
+      dispatch(resetAutoRefresh(dashboard))
     }
   }, [
     dashboard,

--- a/src/dashboards/components/DashboardHeader.tsx
+++ b/src/dashboards/components/DashboardHeader.tsx
@@ -29,7 +29,7 @@ import {AnnotationsControlBarToggleButton} from 'src/annotations/components/Anno
 import {toggleShowVariablesControls as toggleShowVariablesControlsAction} from 'src/userSettings/actions'
 import {updateDashboard as updateDashboardAction} from 'src/dashboards/actions/thunks'
 import {
-  resetDashboardAutoRefresh as resetDashboardAutoRefreshAction,
+  resetAutoRefresh as resetAutoRefreshAction,
   setAutoRefreshStatus as setAutoRefreshStatusAction,
 } from 'src/shared/actions/autoRefresh'
 import {
@@ -315,7 +315,7 @@ const mdtp = {
   onSetAutoRefreshStatus: setAutoRefreshStatusAction,
   updateQueryParams: updateQueryParamsAction,
   setDashboardTimeRange: setDashboardTimeRangeAction,
-  resetAutoRefresh: resetDashboardAutoRefreshAction,
+  resetAutoRefresh: resetAutoRefreshAction,
   showOverlay: showOverlayAction,
   dismissOverlay: dismissOverlayAction,
 }

--- a/src/flows/components/header/index.tsx
+++ b/src/flows/components/header/index.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FC, useContext, useState, useEffect} from 'react'
 import {useHistory, Link} from 'react-router-dom'
-import {useSelector} from 'react-redux'
+import {useSelector, useDispatch} from 'react-redux'
 
 // Contexts
 import {FlowContext} from 'src/flows/context/flow.current'
@@ -11,6 +11,7 @@ import {deletePinnedItemByParam} from 'src/shared/contexts/pinneditems'
 
 // Components
 import {
+  Button,
   Page,
   SquareButton,
   IconFont,
@@ -21,20 +22,15 @@ import {
   Dropdown,
   ErrorTooltip,
 } from '@influxdata/clockface'
-import {PROJECT_NAME, PROJECT_NAME_PLURAL} from 'src/flows'
 import TimeZoneDropdown from 'src/shared/components/TimeZoneDropdown'
 import TimeRangeDropdown from 'src/flows/components/header/TimeRangeDropdown'
 import Submit from 'src/flows/components/header/Submit'
 import SaveState from 'src/flows/components/header/SaveState'
 import PresentationMode from 'src/flows/components/header/PresentationMode'
 import RenamablePageTitle from 'src/pageLayout/components/RenamablePageTitle'
-import {DEFAULT_PROJECT_NAME} from 'src/flows'
-import {serialize} from 'src/flows/context/flow.list'
 import {FeatureFlag} from 'src/shared/utils/featureFlag'
-import {updatePinnedItemByParam} from 'src/shared/contexts/pinneditems'
-import {getOrg} from 'src/organizations/selectors'
-import {getAuthorizations} from 'src/client/generatedRoutes'
-import {RemoteDataState} from 'src/types'
+
+// Utility
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {
   getNotebooksShare,
@@ -42,6 +38,22 @@ import {
   postNotebooksShare,
 } from 'src/client/notebooksRoutes'
 import {event} from 'src/cloud/utils/reporting'
+import {dismissOverlay, showOverlay} from 'src/overlays/actions/overlays'
+import {resetAutoRefresh} from 'src/shared/actions/autoRefresh'
+import {serialize} from 'src/flows/context/flow.list'
+import {updatePinnedItemByParam} from 'src/shared/contexts/pinneditems'
+import {getOrg} from 'src/organizations/selectors'
+import {getAuthorizations} from 'src/client/generatedRoutes'
+
+// Types
+import {AppState, AutoRefreshStatus, RemoteDataState} from 'src/types'
+
+// Constants
+import {
+  DEFAULT_PROJECT_NAME,
+  PROJECT_NAME,
+  PROJECT_NAME_PLURAL,
+} from 'src/flows'
 
 interface Token {
   token: string
@@ -58,6 +70,10 @@ const FlowHeader: FC = () => {
   const {flow, updateOther} = useContext(FlowContext)
   const history = useHistory()
   const {id: orgID} = useSelector(getOrg)
+  const autoRefresh = useSelector(
+    (state: AppState) => state.autoRefresh?.[flow?.id]
+  )
+  const dispatch = useDispatch()
   const [sharing, setSharing] = useState(false)
   const [token, setToken] = useState<Token>()
   const [loadingToken, setLoadingToken] = useState(RemoteDataState.NotStarted)
@@ -202,6 +218,8 @@ const FlowHeader: FC = () => {
     </Dropdown.Item>
   ))
 
+  const isActive = autoRefresh?.status === AutoRefreshStatus.Active
+
   return (
     <>
       <Page.Header fullWidth>
@@ -222,6 +240,29 @@ const FlowHeader: FC = () => {
             <PresentationMode />
             <TimeZoneDropdown />
             <TimeRangeDropdown />
+            {isFlagEnabled('flowAutoRefresh') && (
+              <Button
+                text={
+                  isActive
+                    ? `Refreshing Every ${autoRefresh.label}`
+                    : 'Enable Auto Refresh'
+                }
+                color={
+                  isActive ? ComponentColor.Secondary : ComponentColor.Default
+                }
+                onClick={
+                  isActive
+                    ? () => dispatch(resetAutoRefresh(flow?.id))
+                    : () =>
+                        dispatch(
+                          showOverlay('toggle-auto-refresh', null, () =>
+                            dispatch(dismissOverlay())
+                          )
+                        )
+                }
+                testID="enable-auto-refresh-button"
+              />
+            )}
             {flow?.id && (
               <>
                 <ConfirmationButton

--- a/src/shared/actions/autoRefresh.ts
+++ b/src/shared/actions/autoRefresh.ts
@@ -4,58 +4,55 @@ export type Action =
   | SetAutoRefresh
   | SetAutoRefreshStatus
   | ReturnType<typeof setAutoRefreshDuration>
-  | ReturnType<typeof resetDashboardAutoRefresh>
+  | ReturnType<typeof resetAutoRefresh>
   | ReturnType<typeof setInactivityTimeout>
 
 interface SetAutoRefresh {
   type: 'SET_AUTO_REFRESH_INTERVAL'
-  payload: {dashboardID: string; milliseconds: number; label: string}
+  payload: {id: string; milliseconds: number; label: string}
 }
 
 export const setAutoRefreshInterval = (
-  dashboardID: string,
+  id: string,
   milliseconds: number,
   label: string
 ): SetAutoRefresh => ({
   type: 'SET_AUTO_REFRESH_INTERVAL',
-  payload: {dashboardID, milliseconds, label},
+  payload: {id, milliseconds, label},
 })
 
 interface SetAutoRefreshStatus {
   type: 'SET_AUTO_REFRESH_STATUS'
-  payload: {dashboardID: string; status: AutoRefreshStatus}
+  payload: {id: string; status: AutoRefreshStatus}
 }
 
 export const setAutoRefreshStatus = (
-  dashboardID: string,
+  id: string,
   status: AutoRefreshStatus
 ): SetAutoRefreshStatus => ({
   type: 'SET_AUTO_REFRESH_STATUS',
-  payload: {dashboardID, status},
+  payload: {id, status},
 })
 
 export const setAutoRefreshDuration = (
-  dashboardID: string,
+  id: string,
   duration: CustomTimeRange | null
 ) =>
   ({
     type: 'SET_AUTO_REFRESH_DURATION',
     duration,
-    dashboardID,
+    id,
   } as const)
 
-export const resetDashboardAutoRefresh = (dashboardID: string) =>
+export const resetAutoRefresh = (id: string) =>
   ({
-    type: 'RESET_DASHBOARD_AUTO_REFRESH',
-    dashboardID,
+    type: 'RESET_AUTO_REFRESH',
+    id,
   } as const)
 
-export const setInactivityTimeout = (
-  dashboardID: string,
-  inactivityTimeout: number
-) =>
+export const setInactivityTimeout = (id: string, inactivityTimeout: number) =>
   ({
     type: 'SET_INACTIVITY_TIMEOUT',
-    dashboardID,
+    id,
     inactivityTimeout,
   } as const)

--- a/src/shared/reducers/autoRefresh.ts
+++ b/src/shared/reducers/autoRefresh.ts
@@ -9,7 +9,7 @@ import {Action} from 'src/shared/actions/autoRefresh'
 import {AutoRefresh} from 'src/types'
 
 export interface AutoRefreshState {
-  [dashboardID: string]: AutoRefresh
+  [id: string]: AutoRefresh
 }
 
 export const initialState = (): AutoRefreshState => {
@@ -20,55 +20,55 @@ export const autoRefreshReducer = (state = initialState(), action: Action) =>
   produce(state, draftState => {
     switch (action.type) {
       case 'SET_AUTO_REFRESH_INTERVAL': {
-        const {dashboardID, milliseconds, label} = action.payload
+        const {id, milliseconds, label} = action.payload
 
-        if (!draftState[dashboardID]) {
-          draftState[dashboardID] = AUTOREFRESH_DEFAULT
+        if (!draftState[id]) {
+          draftState[id] = AUTOREFRESH_DEFAULT
         }
 
-        draftState[dashboardID].interval = milliseconds
-        draftState[dashboardID].label = label
+        draftState[id].interval = milliseconds
+        draftState[id].label = label
 
         return
       }
 
       case 'SET_AUTO_REFRESH_STATUS': {
-        const {dashboardID, status} = action.payload
+        const {id, status} = action.payload
 
-        if (!draftState[dashboardID]) {
-          draftState[dashboardID] = {...AUTOREFRESH_DEFAULT, status}
+        if (!draftState[id]) {
+          draftState[id] = {...AUTOREFRESH_DEFAULT, status}
         } else {
-          draftState[dashboardID].status = status
+          draftState[id].status = status
         }
 
         return
       }
 
       case 'SET_AUTO_REFRESH_DURATION': {
-        const {duration, dashboardID} = action
+        const {duration, id} = action
 
-        if (!draftState[dashboardID]) {
-          draftState[dashboardID] = AUTOREFRESH_DEFAULT
+        if (!draftState[id]) {
+          draftState[id] = AUTOREFRESH_DEFAULT
         }
 
-        draftState[dashboardID].duration = duration
+        draftState[id].duration = duration
         return
       }
 
       case 'SET_INACTIVITY_TIMEOUT': {
-        const {dashboardID, inactivityTimeout} = action
+        const {id, inactivityTimeout} = action
 
-        if (!draftState[dashboardID]) {
-          draftState[dashboardID] = AUTOREFRESH_DEFAULT
+        if (!draftState[id]) {
+          draftState[id] = AUTOREFRESH_DEFAULT
         }
 
-        draftState[dashboardID].inactivityTimeout = inactivityTimeout
+        draftState[id].inactivityTimeout = inactivityTimeout
         return
       }
 
-      case 'RESET_DASHBOARD_AUTO_REFRESH': {
-        const {dashboardID} = action
-        draftState[dashboardID] = AUTOREFRESH_DEFAULT
+      case 'RESET_AUTO_REFRESH': {
+        const {id} = action
+        draftState[id] = AUTOREFRESH_DEFAULT
         return
       }
     }


### PR DESCRIPTION
This is a pretty straightforward PR that's meant to be a step into integrating the autorefresh functionality into notebooks. We're going to want to expand the scope of the autorefresh functionality beyond dashboards, so this is just a step to take to normalize some of the naming and reduce confusion across the board when we get to integrating it into notebooks