### PR TITLE
test: attempt to fix onboarding test flake by asserting on succes notication

### DIFF
--- a/cypress/e2e/oss/onboarding.test.ts
+++ b/cypress/e2e/oss/onboarding.test.ts
@@ -163,6 +163,8 @@ describe('Onboarding', () => {
 
     cy.wait('@orgSetup')
 
+    cy.getByTestID('notification-success').should('be.visible')
+
     cy.get('@orgSetup').then(req => {
       const {
         response: {body},


### PR DESCRIPTION
Closes #3515

It appears that the test was moving too fast for the server by making use of a request that hadn't returned.

I'm not 100% sure how effective this will be. It was very difficult to get my environment set up to run the oss test. Onboarding failed to work in e2e tests and locally, and it wasn't clear why under kind, so this PR will be the canary on whether this change worked.