### PR TITLE
chore: make the autorefresher responsible for the timeout functionality

### DIFF
--- a/src/dashboards/components/DashboardContainer.tsx
+++ b/src/dashboards/components/DashboardContainer.tsx
@@ -32,7 +32,6 @@ import {useRouteMatch} from 'react-router-dom'
 import {event} from 'src/cloud/utils/reporting'
 
 const DashboardContainer: FC = () => {
-  const timer = useRef(null)
   const dispatch = useDispatch()
   const {autoRefresh, dashboardID} = useSelector((state: AppState) => {
     const dashboardID = state.currentDashboard.id
@@ -46,25 +45,39 @@ const DashboardContainer: FC = () => {
   const isEditing = useRouteMatch(
     '/orgs/:orgID/dashboards/:dashboardID/cells/:cellID/edit'
   )
+
+  const startTimeout = () => {
+    GlobalAutoRefresher.startTimeout(
+      timeoutFunction,
+      autoRefresh.inactivityTimeout
+    )
+  }
+
   const registerListeners = useCallback(() => {
-    if (timer.current) {
-      registerStopListeners()
-    }
-
-    timer.current = setTimeout(() => {
-      dispatch(resetAutoRefresh(`dashboard-${dashboardID}`))
-      dispatch(notify(dashboardAutoRefreshTimeoutSuccess()))
-      registerStopListeners()
-      GlobalAutoRefresher.stopPolling()
-      event('dashboards.autorefresh.dashboardcontainer.inactivitytimeout', {
-        timeout: autoRefresh.inactivityTimeout,
-      })
-    }, autoRefresh.inactivityTimeout)
-
     window.addEventListener('load', registerListeners)
     document.addEventListener('mousemove', registerListeners)
     document.addEventListener('keypress', registerListeners)
-  }, [dashboardID, autoRefresh.inactivityTimeout])
+  }, [])
+
+  const registerStopListeners = useCallback(() => {
+    window.removeEventListener('load', registerListeners)
+    document.removeEventListener('mousemove', registerListeners)
+    document.removeEventListener('keypress', registerListeners)
+  }, [registerListeners])
+
+  const timeoutFunction = useCallback(() => {
+    dispatch(resetAutoRefresh(`dashboard-${dashboardID}`))
+    dispatch(notify(dashboardAutoRefreshTimeoutSuccess()))
+    registerStopListeners()
+    event('dashboards.autorefresh.dashboardcontainer.inactivitytimeout', {
+      timeout: autoRefresh.inactivityTimeout,
+    })
+  }, [
+    autoRefresh.inactivityTimeout,
+    dashboardID,
+    dispatch,
+    registerStopListeners,
+  ])
 
   const stopFunc = useCallback(() => {
     if (
@@ -92,18 +105,6 @@ const DashboardContainer: FC = () => {
     }
   }, [autoRefresh.status, stopFunc])
 
-  const registerStopListeners = useCallback(() => {
-    // Stop all existing timers and deregister everythang
-    if (timer.current) {
-      clearTimeout(timer.current)
-      timer.current = null
-    }
-
-    window.removeEventListener('load', registerListeners)
-    document.removeEventListener('mousemove', registerListeners)
-    document.removeEventListener('keypress', registerListeners)
-  }, [registerListeners, timer])
-
   useEffect(() => {
     if (isEditing) {
       registerStopListeners()
@@ -111,13 +112,12 @@ const DashboardContainer: FC = () => {
       return
     }
 
-    if (
-      autoRefresh?.status &&
-      autoRefresh.status === AutoRefreshStatus.Active
-    ) {
+    if (autoRefresh?.status === AutoRefreshStatus.Active) {
       GlobalAutoRefresher.poll(autoRefresh, stopFunc)
       document.addEventListener('visibilitychange', visChangeHandler)
       if (autoRefresh.inactivityTimeout > 0) {
+        registerStopListeners()
+        startTimeout()
         registerListeners()
       }
     } else {
@@ -135,6 +135,9 @@ const DashboardContainer: FC = () => {
     autoRefresh.inactivityTimeout,
     stopFunc,
     isEditing?.path,
+    registerListeners,
+    registerStopListeners,
+    startTimeout,
     visChangeHandler,
   ])
 

--- a/src/dashboards/components/DashboardContainer.tsx
+++ b/src/dashboards/components/DashboardContainer.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FC, useEffect, useCallback, useRef} from 'react'
+import React, {FC, useEffect, useCallback} from 'react'
 import {useDispatch, useSelector} from 'react-redux'
 
 // Components

--- a/src/utils/AutoRefresher.ts
+++ b/src/utils/AutoRefresher.ts
@@ -23,7 +23,15 @@ export class AutoRefresher {
     }, autoRefresh.interval)
   }
 
+  public startTimeout(startFunc: () => void, time: number) {
+    this.timerID = setTimeout(() => {
+      startFunc()
+      this.stopPolling()
+    }, time)
+  }
+
   public stopPolling() {
+    this.clearTimeout()
     this.clearInterval()
   }
 

--- a/src/utils/AutoRefresher.ts
+++ b/src/utils/AutoRefresher.ts
@@ -6,6 +6,7 @@ export class AutoRefresher {
   public subscribers: func[] = []
 
   private intervalID: NodeJS.Timer
+  private timerID: NodeJS.Timer
 
   public subscribe(fn: func) {
     this.subscribers = [...this.subscribers, fn]
@@ -33,6 +34,15 @@ export class AutoRefresher {
 
     clearInterval(this.intervalID)
     this.intervalID = null
+  }
+
+  private clearTimeout() {
+    if (!this.timerID) {
+      return
+    }
+
+    clearTimeout(this.timerID)
+    this.timerID = null
   }
 
   private refresh = (isAutoRefresh = false, stopFunc?: () => void) => {


### PR DESCRIPTION
This PR does some clean-up around the source of truth of controlling the timeout for the AutoRefresher within the dashboard by making the GlobalRefresher responsible for the timeout logic rather than having the view layer responsible for it. We're going to need to iterate on this design to handle multiple timers and intervals so that a user can have them set for multiple notebooks and dashboards without conflicts