### PR TITLE
chore: adjust page/tabbing for multi account

### DIFF
--- a/cypress/e2e/cloud/billing.test.ts
+++ b/cypress/e2e/cloud/billing.test.ts
@@ -67,6 +67,16 @@ describe('Billing Page PAYG Users', () => {
             }).then(() => {
               cy.visit(`/orgs/${id}/billing`)
               cy.getByTestID('billing-page--header').should('be.visible')
+
+              // note:  when the 'multiAccount' feature flag is on/removed (so always on)
+              // remove the above line, replace with:
+
+              // cy.getByTestID('accounts-billing-tab').should('be.visible')
+              //
+              // cy.getByTestID('accounts-billing-tab').should(
+              //     'have.class',
+              //     'cf-tabs--tab__active'
+              // )
             })
           })
         })

--- a/cypress/e2e/cloud/zuoraOutage.test.ts
+++ b/cypress/e2e/cloud/zuoraOutage.test.ts
@@ -40,6 +40,16 @@ describe('Billing Page PAYG Users', () => {
               cy.wait(1000)
               cy.visit(`/orgs/${id}/billing`)
               cy.getByTestID('billing-page--header').should('be.visible')
+
+              // note:  when the 'multiAccount' feature flag is on/removed (so always on)
+              // remove the above line, replace with:
+
+              // cy.getByTestID('accounts-billing-tab').should('be.visible')
+              //
+              // cy.getByTestID('accounts-billing-tab').should(
+              //     'have.class',
+              //     'cf-tabs--tab__active'
+              // )
             })
           })
         })

--- a/src/me/components/UsagePanel.tsx
+++ b/src/me/components/UsagePanel.tsx
@@ -25,7 +25,7 @@ const UsagePanel: FC = () => {
     <Panel>
       <Panel.Header>
         <Heading element={HeadingElement.H3}>
-          <label htmlFor="usagepanel--title">Usage ARTEMIS</label>
+          <label htmlFor="usagepanel--title">Usage</label>
         </Heading>
       </Panel.Header>
       <Panel.Body

--- a/src/me/components/UsagePanel.tsx
+++ b/src/me/components/UsagePanel.tsx
@@ -25,7 +25,7 @@ const UsagePanel: FC = () => {
     <Panel>
       <Panel.Header>
         <Heading element={HeadingElement.H3}>
-          <label htmlFor="usagepanel--title">Usage</label>
+          <label htmlFor="usagepanel--title">Usage ARTEMIS</label>
         </Heading>
       </Panel.Header>
       <Panel.Body

--- a/src/organizations/components/OrgNavigation.tsx
+++ b/src/organizations/components/OrgNavigation.tsx
@@ -28,6 +28,7 @@ enum Tab {
   Members = 'members-oss',
   Users = 'users',
   About = 'about',
+  Usage = 'usage',
 }
 
 const OrgNavigation: FC<Props> = ({activeTab}) => {
@@ -62,6 +63,14 @@ const OrgNavigation: FC<Props> = ({activeTab}) => {
       link: `/orgs/${orgID}/about`,
     },
   ]
+
+  if (CLOUD && isFlagEnabled('multiAccount')) {
+    tabs.push({
+      text: 'usage',
+      id: Tab.Usage,
+      link: `/orgs/${orgID}/usage`,
+    })
+  }
 
   return (
     <Tabs orientation={Orientation.Horizontal} size={ComponentSize.Large}>

--- a/src/organizations/components/OrgNavigation.tsx
+++ b/src/organizations/components/OrgNavigation.tsx
@@ -11,6 +11,7 @@ import {CLOUD} from 'src/shared/constants'
 
 // Utils
 import {getOrg} from 'src/organizations/selectors'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 interface Props {
   activeTab: string
@@ -32,6 +33,16 @@ enum Tab {
 const OrgNavigation: FC<Props> = ({activeTab}) => {
   const orgID = useSelector(getOrg)?.id
 
+  const tabNames = {
+    userCloudTab: 'Users',
+    aboutTab: 'About',
+  }
+
+  if (isFlagEnabled('multiAccount')) {
+    tabNames.userCloudTab = 'Members'
+    tabNames.aboutTab = 'Settings'
+  }
+
   const tabs: OrgPageTab[] = [
     {
       text: 'Members',
@@ -40,13 +51,13 @@ const OrgNavigation: FC<Props> = ({activeTab}) => {
       link: `/orgs/${orgID}/members`,
     },
     {
-      text: 'Users',
+      text: tabNames.userCloudTab,
       id: Tab.Users,
       enabled: () => CLOUD,
       link: `/orgs/${orgID}/users`,
     },
     {
-      text: 'About',
+      text: tabNames.aboutTab,
       id: Tab.About,
       link: `/orgs/${orgID}/about`,
     },

--- a/src/organizations/containers/OrgProfilePage.tsx
+++ b/src/organizations/containers/OrgProfilePage.tsx
@@ -15,10 +15,10 @@ import DeleteOrgOverlay from 'src/organizations/components/DeleteOrgOverlay'
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 import {getQuartzMe} from 'src/me/selectors'
 import DeleteOrgProvider from 'src/organizations/components/DeleteOrgContext'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Constants
 import {CLOUD} from 'src/shared/constants'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 const OrgProfilePage: FC = () => {
   const quartzMe = useSelector(getQuartzMe)

--- a/src/organizations/containers/OrgProfilePage.tsx
+++ b/src/organizations/containers/OrgProfilePage.tsx
@@ -18,13 +18,16 @@ import DeleteOrgProvider from 'src/organizations/components/DeleteOrgContext'
 
 // Constants
 import {CLOUD} from 'src/shared/constants'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 const OrgProfilePage: FC = () => {
   const quartzMe = useSelector(getQuartzMe)
 
+  const subTitle = isFlagEnabled('multiAccount') ? 'Settings' : 'About'
+
   return (
     <>
-      <Page titleTag={pageTitleSuffixer(['About', 'Organization'])}>
+      <Page titleTag={pageTitleSuffixer([subTitle, 'Organization'])}>
         <OrgHeader testID="about-page--header" />
         <OrgTabbedPage activeTab="about">
           <OrgProfileTab />

--- a/src/pageLayout/components/UserWidget.tsx
+++ b/src/pageLayout/components/UserWidget.tsx
@@ -98,7 +98,7 @@ const UserWidget: FC<Props> = ({
         <TreeNav.SubHeading label="Organization" />
         <TreeNav.UserItem
           id="users"
-          label="Users"
+          label="Members"
           testID="user-nav-item-users"
           linkElement={className => (
             <Link className={className} to={`${orgPrefix}/users`} />
@@ -106,7 +106,7 @@ const UserWidget: FC<Props> = ({
         />
         <TreeNav.UserItem
           id="about"
-          label="About"
+          label="Settings"
           testID="user-nav-item-about"
           linkElement={className => (
             <Link className={className} to={`${orgPrefix}/about`} />

--- a/src/usage/UsagePage.tsx
+++ b/src/usage/UsagePage.tsx
@@ -6,12 +6,12 @@ import {Page} from '@influxdata/clockface'
 import UsageToday from 'src/usage/UsageToday'
 import RateLimitAlert from 'src/cloud/components/RateLimitAlert'
 import LimitChecker from 'src/cloud/components/LimitChecker'
+import OrgHeader from 'src/organizations/components/OrgHeader'
+import OrgTabbedPage from 'src/organizations/components/OrgTabbedPage'
 
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
-import OrgHeader from '../organizations/components/OrgHeader'
-import OrgTabbedPage from '../organizations/components/OrgTabbedPage'
 
 const Usage: FC = () => {
   if (isFlagEnabled('multiAccount')) {

--- a/src/usage/UsagePage.tsx
+++ b/src/usage/UsagePage.tsx
@@ -9,19 +9,35 @@ import LimitChecker from 'src/cloud/components/LimitChecker'
 
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import OrgHeader from '../organizations/components/OrgHeader'
+import OrgTabbedPage from '../organizations/components/OrgTabbedPage'
 
-const Usage: FC = () => (
-  <Page titleTag={pageTitleSuffixer(['Usage'])}>
-    <Page.Header fullWidth={false} testID="usage-page--header">
-      <Page.Title title="Usage" />
-      <LimitChecker>
-        <RateLimitAlert />
-      </LimitChecker>
-    </Page.Header>
-    <Page.Contents scrollable={true}>
-      <UsageToday />
-    </Page.Contents>
-  </Page>
-)
+const Usage: FC = () => {
+  if (isFlagEnabled('multiAccount')) {
+    return (
+      <Page titleTag={pageTitleSuffixer(['Usage', 'Organization'])}>
+        <OrgHeader testID="usage-page--header" />
+        <OrgTabbedPage activeTab="usage">
+          <UsageToday />
+        </OrgTabbedPage>
+      </Page>
+    )
+  }
+
+  return (
+    <Page titleTag={pageTitleSuffixer(['Usage'])}>
+      <Page.Header fullWidth={false} testID="usage-page--header">
+        <Page.Title title="Usage" />
+        <LimitChecker>
+          <RateLimitAlert />
+        </LimitChecker>
+      </Page.Header>
+      <Page.Contents scrollable={true}>
+        <UsageToday />
+      </Page.Contents>
+    </Page>
+  )
+}
 
 export default Usage

--- a/src/users/components/UserListContainer.tsx
+++ b/src/users/components/UserListContainer.tsx
@@ -10,17 +10,25 @@ import OrgTabbedPage from 'src/organizations/components/OrgTabbedPage'
 
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
-const UserListContainer: FC = () => (
-  <Page titleTag={pageTitleSuffixer(['Users', 'Organization'])}>
-    <OrgHeader testID="users-page--header" />
-    <OrgTabbedPage activeTab="users">
-      <>
-        <UserListInviteForm />
-        <UserList />
-      </>
-    </OrgTabbedPage>
-  </Page>
-)
+const UserListContainer: FC = () => {
+  let titleTags = ['Users', 'Organization']
+  if (isFlagEnabled('multiAccount')) {
+    titleTags = ['Members', 'Organization']
+  }
+
+  return (
+    <Page titleTag={pageTitleSuffixer(titleTags)}>
+      <OrgHeader testID="users-page--header" />
+      <OrgTabbedPage activeTab="users">
+        <>
+          <UserListInviteForm />
+          <UserList />
+        </>
+      </OrgTabbedPage>
+    </Page>
+  )
+}
 
 export default UserListContainer

--- a/src/users/components/UserListContainer.tsx
+++ b/src/users/components/UserListContainer.tsx
@@ -13,13 +13,10 @@ import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 const UserListContainer: FC = () => {
-  let titleTags = ['Users', 'Organization']
-  if (isFlagEnabled('multiAccount')) {
-    titleTags = ['Members', 'Organization']
-  }
+  const subTitle = isFlagEnabled('multiAccount') ? 'Members' : 'Users'
 
   return (
-    <Page titleTag={pageTitleSuffixer(titleTags)}>
+    <Page titleTag={pageTitleSuffixer([subTitle, 'Organization'])}>
       <OrgHeader testID="users-page--header" />
       <OrgTabbedPage activeTab="users">
         <>


### PR DESCRIPTION
Closes #3463 #3568

renames pages,
(Organization: users->members, about->settings)
and puts the "Usage" page under the organization tabbed page

only shows if the flag is on.

just cosmetic; no functional changes.
