### PR TITLE
chore: adding new event for measuring empty token state

### DIFF
--- a/src/flows/components/header/index.tsx
+++ b/src/flows/components/header/index.tsx
@@ -118,6 +118,7 @@ const FlowHeader: FC = () => {
       }))
 
       setTokens(_tokens)
+      event('Notebook share tokens', {count: _tokens.length})
     })
     event('Show Share Menu', {share: !!share ? 'sharing' : 'not sharing'})
   }


### PR DESCRIPTION
Closes #3372

the titles of these are all wrong, but we essentially want to see how many users are trying  to share a notebook and then finding themselves without any tokens to make the share link with. so here is an event that'll let us say someone got to a notebook, they tried to create a share, and they had `n` api tokens available to them. we  should be able to see how many people are reaching that point with zero api tokens and use that to justify the work outlined for the  api token modal work