### PR TITLE
feat: fix overlay title when token is cloned vs created

### DIFF
--- a/src/authorizations/components/redesigned/DisplayTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/DisplayTokenOverlay.tsx
@@ -30,7 +30,11 @@ const DisplayTokenOverlay: FC<Props> = props => {
   return (
     <Overlay.Container maxWidth={750}>
       <Overlay.Header
-        title= {overlayID === 'access-token' ? "You've successfully created an API Token" : "You've successfully cloned an API Token"}
+        title={
+          overlayID === 'access-token'
+            ? "You've successfully created an API Token"
+            : "You've successfully cloned an API Token"
+        }
         onDismiss={onClose}
         wrapText={true}
       />

--- a/src/authorizations/components/redesigned/DisplayTokenOverlay.tsx
+++ b/src/authorizations/components/redesigned/DisplayTokenOverlay.tsx
@@ -25,12 +25,12 @@ type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps
 
 const DisplayTokenOverlay: FC<Props> = props => {
-  const {onClose} = useContext(OverlayContext)
+  const {onClose, overlayID} = useContext(OverlayContext)
 
   return (
     <Overlay.Container maxWidth={750}>
       <Overlay.Header
-        title="You've successfully created an API token"
+        title= {overlayID === 'access-token' ? "You've successfully created an API Token" : "You've successfully cloned an API Token"}
         onDismiss={onClose}
         wrapText={true}
       />

--- a/src/authorizations/components/redesigned/TokenRow.tsx
+++ b/src/authorizations/components/redesigned/TokenRow.tsx
@@ -156,7 +156,7 @@ class TokensRow extends PureComponent<Props> {
         description: incrementCloneName(allTokenDescriptions, description),
       })
       event('token.clone.success', {id: this.props.auth.id, name: description})
-      this.props.showOverlay('access-token', null, () => dismissOverlay())
+      this.props.showOverlay('access-cloned-token', null, () => dismissOverlay())
     } catch {
       event('token.clone.failure', {id: this.props.auth.id, name: description})
     }

--- a/src/authorizations/components/redesigned/TokenRow.tsx
+++ b/src/authorizations/components/redesigned/TokenRow.tsx
@@ -156,7 +156,9 @@ class TokensRow extends PureComponent<Props> {
         description: incrementCloneName(allTokenDescriptions, description),
       })
       event('token.clone.success', {id: this.props.auth.id, name: description})
-      this.props.showOverlay('access-cloned-token', null, () => dismissOverlay())
+      this.props.showOverlay('access-cloned-token', null, () =>
+        dismissOverlay()
+      )
     } catch {
       event('token.clone.failure', {id: this.props.auth.id, name: description})
     }

--- a/src/overlays/components/OverlayController.tsx
+++ b/src/overlays/components/OverlayController.tsx
@@ -71,6 +71,7 @@ export const OverlayController: FunctionComponent = () => {
       case 'add-custom-token':
         activeOverlay.current = <CustomApiTokenOverlay onClose={onClose} />
         break
+      case 'access-cloned-token':
       case 'access-token':
         activeOverlay.current = <DisplayTokenOverlay />
         break

--- a/src/overlays/components/OverlayController.tsx
+++ b/src/overlays/components/OverlayController.tsx
@@ -62,6 +62,8 @@ export const OverlayController: FunctionComponent = () => {
   useMemo(() => {
     switch (overlayID) {
       case 'add-note':
+        activeOverlay.current = <NoteEditorOverlay onClose={onClose} />
+        break
       case 'edit-note':
         activeOverlay.current = <NoteEditorOverlay onClose={onClose} />
         break
@@ -72,6 +74,8 @@ export const OverlayController: FunctionComponent = () => {
         activeOverlay.current = <CustomApiTokenOverlay onClose={onClose} />
         break
       case 'access-cloned-token':
+        activeOverlay.current = <DisplayTokenOverlay />
+        break
       case 'access-token':
         activeOverlay.current = <DisplayTokenOverlay />
         break

--- a/src/overlays/reducers/overlays.ts
+++ b/src/overlays/reducers/overlays.ts
@@ -10,6 +10,7 @@ export type OverlayID =
   | 'edit-note'
   | 'add-master-token'
   | 'access-token'
+  | 'access-cloned-token'
   | 'add-custom-token'
   | 'add-token'
   | 'telegraf-config'


### PR DESCRIPTION
Closes #3616 

Before fix: Overlay title reads "You've successfully created an API token" whether token is being created or cloned. 
![Screen Shot 2022-01-18 at 1 53 00 PM](https://user-images.githubusercontent.com/66275100/150008778-d5023ed3-2dca-4b13-a194-6a753d75f68c.png)

After fix: 
https://user-images.githubusercontent.com/66275100/150004759-b0bca547-b619-4566-ba02-ada9f70093fc.mov

