### PR TITLE
fix: use "T" separator in time format placeholder to accomodate Safari

### DIFF
--- a/src/utils/datetime/formatters.test.ts
+++ b/src/utils/datetime/formatters.test.ts
@@ -419,6 +419,50 @@ describe('the DateTime formatter', () => {
         date.toISOString()
       }).not.toThrow()
     })
+
+    it('can use the T as a separator', () => {
+      let convertedDateString = convertDateToRFC3339(
+        new Date('2022-01-18T17:30:00Z'),
+        'Local'
+      )
+      let date = new Date(convertedDateString)
+      expect(date.toDateString()).not.toEqual('Invalid Date')
+      expect(() => {
+        date.toISOString()
+      }).not.toThrow()
+
+      convertedDateString = convertDateToRFC3339(
+        new Date('2022-01-19T01:30:00-0800'),
+        'UTC'
+      )
+      date = new Date(convertedDateString)
+      expect(date.toDateString()).not.toEqual('Invalid Date')
+      expect(() => {
+        date.toISOString()
+      }).not.toThrow()
+    })
+
+    it('can use space as a separator', () => {
+      let convertedDateString = convertDateToRFC3339(
+        new Date('2022-01-18 17:30:00Z'),
+        'Local'
+      )
+      let date = new Date(convertedDateString)
+      expect(date.toDateString()).not.toEqual('Invalid Date')
+      expect(() => {
+        date.toISOString()
+      }).not.toThrow()
+
+      convertedDateString = convertDateToRFC3339(
+        new Date('2022-01-19 01:30:00-0800'),
+        'UTC'
+      )
+      date = new Date(convertedDateString)
+      expect(date.toDateString()).not.toEqual('Invalid Date')
+      expect(() => {
+        date.toISOString()
+      }).not.toThrow()
+    })
   })
 })
 

--- a/src/utils/datetime/formatters.ts
+++ b/src/utils/datetime/formatters.ts
@@ -804,7 +804,7 @@ export const convertDateToRFC3339 = (date: Date, timeZone: string): string => {
     const localTime = timeStringParsed[0]
     const utcOffset = timeStringParsed[1].replace('GMT', '')
 
-    return `${year}-${month}-${dayOfMonth} ${localTime}${utcOffset}`
+    return `${year}-${month}-${dayOfMonth}T${localTime}${utcOffset}`
   }
   return date.toISOString()
 }

--- a/src/visualization/components/internal/TimeTickInput.tsx
+++ b/src/visualization/components/internal/TimeTickInput.tsx
@@ -67,7 +67,7 @@ export const TimeTickInput: FC<TimeTickInputProps> = props => {
     tickPropertyName,
     tickOptions,
     initialTickOptionValue,
-    dateFormatPlaceholder = 'RFC 3339 or YYYY-MM-DD HH:MM:SSZ',
+    dateFormatPlaceholder = 'RFC 3339 or YYYY-MM-DDTHH:mm:ssZ',
     update,
   } = props
 


### PR DESCRIPTION
Closes #3620 

- uses `T` as the separator for the placeholder, reducing confusion for Safari users
- still allows space as the separator for other browsers that are more flexible such as Chrome and Firefox
- minor change to the case for the time portion of the format to differentiate `M` (month) and `m` (minutes)

This works in Safari:


https://user-images.githubusercontent.com/10736577/150049339-7923fd6b-6ead-487a-8c91-2ffa41db2d80.mp4


And it still works in Chrome using the space separator:


https://user-images.githubusercontent.com/10736577/150049484-263575dc-6ad3-4a6b-aae0-c2c982c3b837.mp4


