### PR TITLE
chore: make the autorefresher responsible for registering events

### DIFF
--- a/src/utils/AutoRefresher.ts
+++ b/src/utils/AutoRefresher.ts
@@ -16,16 +16,16 @@ export class AutoRefresher {
     this.unregisterListeners()
   }
 
-  private registerListeners() {
-    window.addEventListener('load', this.registerListeners.bind(this))
-    document.addEventListener('mousemove', this.registerListeners.bind(this))
-    document.addEventListener('keypress', this.registerListeners.bind(this))
+  private registerListeners = () => {
+    window.addEventListener('load', this.registerListeners)
+    document.addEventListener('mousemove', this.registerListeners)
+    document.addEventListener('keypress', this.registerListeners)
   }
 
-  private unregisterListeners() {
-    window.removeEventListener('load', this.registerListeners.bind(this))
-    document.removeEventListener('mousemove', this.registerListeners.bind(this))
-    document.removeEventListener('keypress', this.registerListeners.bind(this))
+  private unregisterListeners = () => {
+    window.removeEventListener('load', this.registerListeners)
+    document.removeEventListener('mousemove', this.registerListeners)
+    document.removeEventListener('keypress', this.registerListeners)
   }
 
   public subscribe(fn: func) {

--- a/src/utils/AutoRefresher.ts
+++ b/src/utils/AutoRefresher.ts
@@ -8,6 +8,26 @@ export class AutoRefresher {
   private intervalID: NodeJS.Timer
   private timerID: NodeJS.Timer
 
+  public onConnect() {
+    this.registerListeners()
+  }
+
+  public onDisconnect() {
+    this.unregisterListeners()
+  }
+
+  private registerListeners() {
+    window.addEventListener('load', this.registerListeners.bind(this))
+    document.addEventListener('mousemove', this.registerListeners.bind(this))
+    document.addEventListener('keypress', this.registerListeners.bind(this))
+  }
+
+  private unregisterListeners() {
+    window.removeEventListener('load', this.registerListeners.bind(this))
+    document.removeEventListener('mousemove', this.registerListeners.bind(this))
+    document.removeEventListener('keypress', this.registerListeners.bind(this))
+  }
+
   public subscribe(fn: func) {
     this.subscribers = [...this.subscribers, fn]
   }


### PR DESCRIPTION
The intent of this PR is the final clean up prior to integrating the AutoRefresh work with notebooks. The crux of what we're doing is making the AutoRefresher responsible for registering and unregistering the window events rather than having the view layer be responsible for it. The reason being that the view layer should define the conditions that those events should be triggered by, rather than defining the events and their conditions