### PR TITLE
feat: handle deep linking for a logged out user

### DIFF
--- a/src/organizations/apis/index.ts
+++ b/src/organizations/apis/index.ts
@@ -1,11 +1,14 @@
 // API
-import {getDashboards as apiGetDashboards} from 'src/client'
+import {getDashboards as apiGetDashboards, getOrgs} from 'src/client'
 
 // Types
 import {Dashboard, Organization} from 'src/types'
 
 // Utils
 import {addDashboardDefaults} from 'src/schemas/dashboards'
+
+// Metrics
+import {event} from 'src/cloud/utils/reporting'
 
 // CRUD APIs for Organizations and Organization resources
 // i.e. Organization Members, Buckets, Dashboards etc
@@ -31,5 +34,25 @@ export const getDashboards = async (
   } catch (error) {
     console.error('Could not get buckets for org', error)
     throw error
+  }
+}
+
+export const getOrg = async () => {
+  try {
+    const resp = await getOrgs({})
+
+    if (resp.status !== 200) {
+      throw new Error(resp.data.message)
+    }
+
+    const {orgs} = resp.data
+
+    if (Array.isArray(orgs) && orgs.length) {
+      return orgs[0]
+    }
+
+    throw new Error('Orgs was not an array')
+  } catch (error) {
+    event('api.getOrg.fetch.error', {error})
   }
 }


### PR DESCRIPTION
Closes #3569

Should handle deep linking for a user who is logged out and logs in. If `org` is null, which happens directly after they log in and hit the 404 handler, it will fetch the org and redirect them to the correct place.

Was kind of hard to test locally since we don't have an exact analogue for logging in locally. Will be able to do a better test behind a feature flag in production.