### PR TITLE
chore: react select type ahead var integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -203,6 +203,7 @@
     "react-monaco-editor": "^0.33.0",
     "react-redux": "^7.2.0",
     "react-router-dom": "^5.2.0",
+    "react-select": "^5.2.2",
     "react-virtualized": "^9.18.5",
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0",

--- a/src/accounts/SwitchAccountOverlay.tsx
+++ b/src/accounts/SwitchAccountOverlay.tsx
@@ -141,17 +141,17 @@ export const SwitchAccountOverlay: FC<Props> = ({onDismissOverlay}) => {
       <Overlay.Footer>
         <Button text="Cancel" onClick={onDismissOverlay} />
         <Button
+          testID="switch-default-account--btn"
+          text="Set Default Account"
+          status={defaultButtonStatus}
+          onClick={doSetDefaultAccount}
+        />
+        <Button
           text="Switch Account"
           onClick={doSwitchAccount}
           status={switchButtonStatus}
           disabledTitleText={disabledTitleText}
           testID="actually-switch-account--btn"
-        />
-        <Button
-          testID="switch-default-account--btn"
-          text="Set Default Account"
-          status={defaultButtonStatus}
-          onClick={doSetDefaultAccount}
         />
       </Overlay.Footer>
     </Overlay.Container>

--- a/src/dashboards/components/variablesControlBar/DraggableDropdown.tsx
+++ b/src/dashboards/components/variablesControlBar/DraggableDropdown.tsx
@@ -3,8 +3,11 @@ import React, {FC} from 'react'
 import classnames from 'classnames'
 import {Draggable} from 'react-beautiful-dnd'
 
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+
 // Components
 import TypeAheadVariableDropdown from 'src/variables/components/TypeAheadVariableDropdown'
+import VariableDropdownReactSelect from 'src/variables/components/VariableDropdownReactSelect'
 
 interface Props {
   id: string
@@ -13,6 +16,10 @@ interface Props {
 }
 
 const DraggableDropdown: FC<Props> = ({id, index, name}) => {
+  const DropdownComponent = isFlagEnabled('reactSelectVariableDropdown')
+    ? VariableDropdownReactSelect
+    : TypeAheadVariableDropdown
+
   return (
     <Draggable index={index} draggableId={id}>
       {(provided, snapshot) => (
@@ -32,7 +39,7 @@ const DraggableDropdown: FC<Props> = ({id, index, name}) => {
           <div className="variable-dropdown--label">
             <span>{name}</span>
           </div>
-          <TypeAheadVariableDropdown variableID={id} />
+          <DropdownComponent variableID={id} />
         </div>
       )}
     </Draggable>

--- a/src/variables/components/VariableDropdown.scss
+++ b/src/variables/components/VariableDropdown.scss
@@ -5,6 +5,12 @@
   border-radius: $cf-radius;
   background-color: $cf-grey-25;
   margin-right: $cf-border;
+  /** color: darkgrey; */
+  margin-top: 6px;
+
+  .select__input-container {
+    color: white;
+  }
 }
 
 .variable-dropdown__dragging {

--- a/src/variables/components/VariableDropdown.scss
+++ b/src/variables/components/VariableDropdown.scss
@@ -5,7 +5,6 @@
   border-radius: $cf-radius;
   background-color: $cf-grey-25;
   margin-right: $cf-border;
-  /** color: darkgrey; */
   margin-top: 6px;
 
   .select__input-container {

--- a/src/variables/components/VariableDropdownReactSelect.tsx
+++ b/src/variables/components/VariableDropdownReactSelect.tsx
@@ -5,6 +5,11 @@ import {connect, ConnectedProps} from 'react-redux'
 // Components
 import Select from 'react-select'
 
+import {
+  InfluxColors,
+} from '@influxdata/clockface'
+
+
 // Actions
 import {selectValue} from 'src/variables/actions/thunks'
 
@@ -90,7 +95,7 @@ class VariableDropdownReactSelect extends PureComponent<Props, MyState> {
     const inputBackground = 'black'
     const background = '#2c2d35'
     const focusColor = '#46454e'
-    const selectColor = '#ce58eb'
+    const selectColor = InfluxColors.Comet // '#ce58eb'
     const dropdownBackgroundFocused = '#5d5f6f'
     const dropdownBackgroundNotFocused = '#828497'
     const clearIndicatorHoverColor = 'white'

--- a/src/variables/components/VariableDropdownReactSelect.tsx
+++ b/src/variables/components/VariableDropdownReactSelect.tsx
@@ -25,7 +25,6 @@ type Props = OwnProps & ReduxProps
 
 interface MyState {
   shownValues: string[]
-  selectHappened: boolean
   loaded: boolean
 }
 
@@ -35,7 +34,6 @@ class VariableDropdownReactSelect extends PureComponent<Props, MyState> {
 
     const defaultState = {
       shownValues: props.values,
-      selectHappened: false,
       loaded: false,
     }
 
@@ -48,18 +46,15 @@ class VariableDropdownReactSelect extends PureComponent<Props, MyState> {
   }
 
   // set the 'shownValues' after loading, and
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate(prevProps) {
     const {values, status} = this.props
     const {values: prevVals, status: prevStatus} = prevProps
-    const {loaded, selectHappened} = this.state
-    const {selectHappened: prevSelectHappened} = prevState
+    const {loaded} = this.state
 
     let newState = {}
 
     const justLoaded =
       status === RemoteDataState.Done && prevStatus !== RemoteDataState.Done
-
-    const justSelected = selectHappened && !prevSelectHappened
 
     // this is for updating the values:
     // (only want this to run *once* when the values get loaded)
@@ -74,11 +69,6 @@ class VariableDropdownReactSelect extends PureComponent<Props, MyState> {
         shownValues: values,
         loaded: true,
       }
-    }
-
-    // for updating the selected value:
-    if (justSelected) {
-      newState = {...newState, selectHappened: false}
     }
 
     this.setState(newState)
@@ -251,14 +241,6 @@ class VariableDropdownReactSelect extends PureComponent<Props, MyState> {
     if (onSelect) {
       onSelect()
     }
-
-    const newState = {
-      ...this.state,
-      actualVal: selectedValue,
-      selectHappened: true,
-    }
-
-    this.setState(newState)
   }
 
   // show the 'loading' or 'no values' as a string (no input field yet!)

--- a/src/variables/components/VariableDropdownReactSelect.tsx
+++ b/src/variables/components/VariableDropdownReactSelect.tsx
@@ -30,7 +30,6 @@ type Props = OwnProps & ReduxProps
 // the typed val is what the user types in
 interface MyState {
   actualVal: string
-  selectIndex: number
   shownValues: string[]
   selectHappened: boolean
   menuOpen: MenuStatus
@@ -43,7 +42,6 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
 
     const defaultState = {
       actualVal: '',
-      selectIndex: -1,
       shownValues: props.values,
       selectHappened: false,
       menuOpen: null,
@@ -285,7 +283,6 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
       typedValue: selectedValue,
       actualVal: selectedValue,
       selectHappened: true,
-      selectIndex: -1,
     }
 
     if (closeMenuNow) {

--- a/src/variables/components/VariableDropdownReactSelect.tsx
+++ b/src/variables/components/VariableDropdownReactSelect.tsx
@@ -73,10 +73,10 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
 
     let newState = {}
 
-    const justLoaded = () =>
+    const justLoaded =
       status === RemoteDataState.Done && prevStatus !== RemoteDataState.Done
 
-    const justSelected = () =>
+    const justSelected =
       selectHappened &&
       !prevSelectHappened &&
       actualVal &&
@@ -84,7 +84,7 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
 
     // this is for updating the values:
     // (only want this to run *once* when the values get loaded)
-    if (justLoaded()) {
+    if (justLoaded) {
       newState = this.getInitialValuesAfterLoading()
     } else if (
       !loaded &&
@@ -110,12 +110,8 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
       newState['menuOpen'] = null
     }
 
-    // need to have this, as the 'onClickAwayHere' gets triggered *before*
-    // the selected value is set to the actualValue (it keeps re-using the original
-    // property)
-
     // for updating the selected value:
-    if (justSelected()) {
+    if (justSelected) {
       newState = {...newState, typedValue: actualVal, selectHappened: false}
     }
 
@@ -152,6 +148,8 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
     const background = '#2c2d35'
     const focusColor = '#46454e'
     const selectColor = '#ce58eb'
+    const dropdownBackgroundFocused = '#5d5f6f'
+    const dropdownBackgroundNotFocused = '#828497'
 
     const customStyles = {
       option: (provided, state) => {
@@ -200,7 +198,9 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
         display: 'none',
       }),
       dropdownIndicator: (provided, state) => {
-        const hoverBackground = state.isFocused ? '#5d5f6f' : '#828497'
+        const hoverBackground = state.isFocused
+          ? dropdownBackgroundFocused
+          : dropdownBackgroundNotFocused
 
         return {
           ...provided,
@@ -238,7 +238,6 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
     // primary50 is the color that is used when an item is clicked on to change the selection
     // have not found an alternative way (via the customStyles) to change that color)
 
-    //    const style={width:200}
     const selectedObjectValue = {value: selectedValue, label: selectedValue}
     return (
       <Select
@@ -263,22 +262,7 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
         })}
       />
     )
-    //
   }
-
-  // private getWidth(placeHolderText) {
-  //   const {values} = this.props
-  //   const allVals = [placeHolderText, ...values]
-  //   const longestItemWidth = Math.floor(
-  //     allVals.reduce(function(a, b) {
-  //       return a.length > b.length ? a : b
-  //     }, '').length * 10
-  //   )
-  //
-  //   const widthLength = Math.max(192, longestItemWidth)
-  //   const widthStyle = {width: `${widthLength}px`}
-  //   return widthStyle
-  // }
 
   private handleSelect = (selectedValue: string, closeMenuNow?: boolean) => {
     const {
@@ -340,7 +324,8 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
     const {status} = this.props
 
     return (
-      status === RemoteDataState.Done && (!Array.isArray(valsToUse) || valsToUse.length === 0)
+      status === RemoteDataState.Done &&
+      (!Array.isArray(valsToUse) || valsToUse.length === 0)
     )
   }
 }

--- a/src/variables/components/VariableDropdownReactSelect.tsx
+++ b/src/variables/components/VariableDropdownReactSelect.tsx
@@ -1,0 +1,374 @@
+// Libraries
+import React, {PureComponent} from 'react'
+import {connect, ConnectedProps} from 'react-redux'
+import Select from 'react-select'
+
+// Components
+import {MenuStatus} from '@influxdata/clockface'
+
+// Actions
+import {selectValue} from 'src/variables/actions/thunks'
+
+// Utils
+import {getVariable, normalizeValues} from 'src/variables/selectors'
+
+// Types
+import {AppState, RemoteDataState} from 'src/types'
+
+interface OwnProps {
+  variableID: string
+  testID?: string
+  onSelect?: () => void
+}
+
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps
+
+// actualVal keeps track of the actual, selected variable
+// it allows the component to return to that if something was typed that is not in the selected list
+
+// the typed val is what the user types in
+interface MyState {
+  actualVal: string
+  selectIndex: number
+  shownValues: string[]
+  selectHappened: boolean
+  menuOpen: MenuStatus
+  loaded: boolean
+}
+
+class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
+  constructor(props) {
+    super(props)
+
+    const defaultState = {
+      actualVal: '',
+      selectIndex: -1,
+      shownValues: props.values,
+      selectHappened: false,
+      menuOpen: null,
+      loaded: false,
+    }
+
+    // if it's a csv var, loading is instantaneous, so if it is done just set it:
+    if (props.status === RemoteDataState.Done) {
+      defaultState.actualVal = props.selectedValue
+      defaultState.loaded = true
+    }
+
+    this.state = defaultState
+  }
+
+  // set the 'shownValues' after loading, and
+  // resets the menuOpen variable
+  componentDidUpdate(prevProps, prevState) {
+    const {values, selectedValue, status} = this.props
+    const {values: prevVals, status: prevStatus} = prevProps
+    const {actualVal, loaded, selectHappened, menuOpen} = this.state
+    const {
+      actualVal: prevActualVal,
+      selectHappened: prevSelectHappened,
+      menuOpen: prevMenuOpen,
+    } = prevState
+
+    let newState = {}
+
+    const justLoaded = () =>
+      status === RemoteDataState.Done && prevStatus !== RemoteDataState.Done
+
+    const justSelected = () =>
+      selectHappened &&
+      !prevSelectHappened &&
+      actualVal &&
+      actualVal !== prevActualVal
+
+    // this is for updating the values:
+    // (only want this to run *once* when the values get loaded)
+    if (justLoaded()) {
+      newState = this.getInitialValuesAfterLoading()
+    } else if (
+      !loaded &&
+      status === RemoteDataState.Done &&
+      prevVals.length !== values.length
+    ) {
+      newState = {
+        shownValues: values,
+        typedValue: selectedValue,
+        loaded: true,
+      }
+    }
+
+    /**
+     * unset the menuOpen; it should be set to closed (or open) only once; then undone
+     * this is needed because: (from clockface Dropdown.tsx documentation):
+     * if the string is set to 'open', and then the user closes it, and the code sets it to open again,
+     * unless the code sets it to something else in between (like null or 'close'),
+     * then nothing will happen- the menu will not open)
+     */
+
+    if (menuOpen !== prevMenuOpen && menuOpen !== null) {
+      newState['menuOpen'] = null
+    }
+
+    // need to have this, as the 'onClickAwayHere' gets triggered *before*
+    // the selected value is set to the actualValue (it keeps re-using the original
+    // property)
+
+    // for updating the selected value:
+    if (justSelected()) {
+      newState = {...newState, typedValue: actualVal, selectHappened: false}
+    }
+
+    this.setState(newState)
+  }
+
+  getInitialValuesAfterLoading() {
+    const {values} = this.props
+    // it reloaded; maybe because of a dependent var
+    // want to re-init
+
+    return {
+      shownValues: values,
+      loaded: true,
+    }
+  }
+
+  render() {
+    const {selectedValue, name, status} = this.props
+    const {shownValues} = this.state
+
+    //const shownValues = ['ab', 'c', 'd', 'ernie', 'rosita', 'bert']
+    const isDisabled = !shownValues || shownValues.length === 0
+
+    //const placeHolderText = this.getPlaceHolderText('Select a Value')
+
+    console.log(`trying to render ${name}.....`, shownValues)
+    let realVals = []
+
+    //   make them all look like: { value: 'vanilla', label: 'Vanilla' }
+    if (shownValues && shownValues.length) {
+      realVals = shownValues.map(val => ({value: val, label: val}))
+    }
+    const placeHolderText = this.getPlaceHolderText('Select a Value')
+
+    const foreground = 'white'
+    const background = '#2c2d35'
+    //  const background= 'cyan'
+    const focusColor = '#46454e'
+    const selectColor = '#ce58eb'
+
+    const customStyles = {
+      option: (provided, state) => {
+        let backgroundColor = state.isFocused ? focusColor : background
+
+        if (state.isSelected) {
+          backgroundColor = selectColor
+        }
+
+        return {
+          ...provided,
+          color: foreground,
+          backgroundColor,
+          padding: 10,
+        }
+      },
+      clearIndicator: provided => {
+        // console.log("clear indicator...state??? ACK", state)
+        // const foregroundColor = state.isFocused? 'yellow' : 'cyan'
+        return {
+          ...provided,
+          '&:hover': {
+            color: 'white',
+          },
+        }
+      },
+      control: () => ({
+        width: 225,
+        height: 40,
+        color: foreground,
+        padding: 3,
+        backgroundColor: background,
+        display: 'flex',
+      }),
+      valueContainer: provided => ({
+        ...provided,
+        color: foreground,
+        backgroundColor: 'black',
+      }),
+      placeHolder: provided => ({
+        ...provided,
+        color: foreground,
+        backgroundColor: 'black',
+      }),
+      indicatorSeparator: () => ({
+        display: 'none',
+      }),
+      dropdownIndicator: (provided, state) => {
+        //console.log('in ddi....state???', state)
+        const hoverBackground = state.isFocused ? '#5d5f6f' : '#828497'
+
+        return {
+          ...provided,
+          color: foreground,
+          '&:hover': {
+            background: hoverBackground,
+            color: foreground,
+          },
+        }
+      },
+      singleValue: (provided, state) => {
+        const opacity = state.isDisabled ? 0.5 : 1
+        const transition = 'opacity 300ms'
+
+        return {
+          ...provided,
+          opacity,
+          transition,
+          color: foreground,
+          backgroundColor: 'black',
+        }
+      },
+      menu: provided => ({
+        ...provided,
+        zIndex: 15,
+        backgroundColor: background,
+      }),
+    }
+
+    const onChange = selection => {
+      if (selection && selection.value) {
+        this.handleSelect(selection.value)
+      }
+    }
+    // primary50 is the color that is used when an item is clicked on to change the selection
+    // have not found an alternative way (via the customStyles) to change that color)
+
+    //    const style={width:200}
+    const selectedObjectValue = {value: selectedValue, label: selectedValue}
+    return (
+      <Select
+        classNamePrefix="select"
+        onChange={onChange}
+        defaultValue={selectedObjectValue}
+        isDisabled={isDisabled}
+        isLoading={status === RemoteDataState.Loading || isDisabled}
+        isClearable={true}
+        isRtl={false}
+        isSearchable={true}
+        styles={customStyles}
+        name={name}
+        options={realVals}
+        placeholder={placeHolderText}
+        theme={theme => ({
+          ...theme,
+          colors: {
+            ...theme.colors,
+            primary50: selectColor,
+          },
+        })}
+      />
+    )
+    //
+  }
+
+  // private getWidth(placeHolderText) {
+  //   const {values} = this.props
+  //   const allVals = [placeHolderText, ...values]
+  //   const longestItemWidth = Math.floor(
+  //     allVals.reduce(function(a, b) {
+  //       return a.length > b.length ? a : b
+  //     }, '').length * 10
+  //   )
+  //
+  //   const widthLength = Math.max(192, longestItemWidth)
+  //   const widthStyle = {width: `${widthLength}px`}
+  //   return widthStyle
+  // }
+
+  private handleSelect = (selectedValue: string, closeMenuNow?: boolean) => {
+    const {
+      variableID,
+      onSelectValue,
+      onSelect,
+      selectedValue: prevSelectedValue,
+    } = this.props
+
+    if (prevSelectedValue !== selectedValue) {
+      onSelectValue(variableID, selectedValue)
+    }
+
+    if (onSelect) {
+      onSelect()
+    }
+
+    const newState = {
+      typedValue: selectedValue,
+      actualVal: selectedValue,
+      selectHappened: true,
+      selectIndex: -1,
+    }
+
+    if (closeMenuNow) {
+      newState['menuOpen'] = MenuStatus.Closed
+    }
+
+    // @ts-ignore
+    this.setState(newState)
+  }
+
+  // show the 'loading' or 'no values' as a string (no input field yet!)
+  // when it is loading
+  getPlaceHolderText = (defaultText: string = '') => {
+    const {status} = this.props
+
+    if (status === RemoteDataState.Loading) {
+      return 'Loading...'
+    }
+    if (this.noFilteredValuesPresent()) {
+      return 'No Values'
+    }
+
+    return defaultText
+  }
+
+  noFilteredValuesPresent = () => {
+    const {shownValues} = this.state
+    return this.internalNoValuesPresent(shownValues)
+  }
+
+  noValuesPresent = () => {
+    const {values} = this.props
+    return this.internalNoValuesPresent(values)
+  }
+
+  internalNoValuesPresent = valsToUse => {
+    const {status} = this.props
+
+    return (
+      status === RemoteDataState.Done && (!valsToUse || valsToUse.length === 0)
+    )
+  }
+}
+
+const mstp = (state: AppState, props: OwnProps) => {
+  const {variableID} = props
+  const variable = getVariable(state, variableID)
+  const selected =
+    variable.selected && variable.selected.length ? variable.selected[0] : null
+
+  // the values are the options for the dropdown
+  return {
+    status: variable.status,
+    values: normalizeValues(variable),
+    selectedValue: selected,
+    name: variable.name,
+  }
+}
+
+const mdtp = {
+  onSelectValue: selectValue,
+}
+
+const connector = connect(mstp, mdtp)
+
+export default connector(TypeAheadVariableDropdown)

--- a/src/variables/components/VariableDropdownReactSelect.tsx
+++ b/src/variables/components/VariableDropdownReactSelect.tsx
@@ -14,6 +14,7 @@ import {getVariable, normalizeValues} from 'src/variables/selectors'
 
 // Types
 import {AppState, RemoteDataState} from 'src/types'
+import {backgroundColor} from 'html2canvas/dist/types/css/property-descriptors/background-color'
 
 interface OwnProps {
   variableID: string
@@ -152,6 +153,7 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
     const placeHolderText = this.getPlaceHolderText('Select a Value')
 
     const foreground = 'white'
+    const inputBackground = 'black'
     const background = '#2c2d35'
     //  const background= 'cyan'
     const focusColor = '#46454e'
@@ -193,12 +195,12 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
       valueContainer: provided => ({
         ...provided,
         color: foreground,
-        backgroundColor: 'black',
+        backgroundColor: inputBackground,
       }),
       placeHolder: provided => ({
         ...provided,
         color: foreground,
-        backgroundColor: 'black',
+        backgroundColor: inputBackground,
       }),
       indicatorSeparator: () => ({
         display: 'none',
@@ -225,7 +227,7 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
           opacity,
           transition,
           color: foreground,
-          backgroundColor: 'black',
+          backgroundColor: inputBackground,
         }
       },
       menu: provided => ({

--- a/src/variables/components/VariableDropdownReactSelect.tsx
+++ b/src/variables/components/VariableDropdownReactSelect.tsx
@@ -5,10 +5,7 @@ import {connect, ConnectedProps} from 'react-redux'
 // Components
 import Select from 'react-select'
 
-import {
-  InfluxColors,
-} from '@influxdata/clockface'
-
+import {InfluxColors} from '@influxdata/clockface'
 
 // Actions
 import {selectValue} from 'src/variables/actions/thunks'
@@ -91,14 +88,14 @@ class VariableDropdownReactSelect extends PureComponent<Props, MyState> {
   }
 
   makeCustomStyles = () => {
-    const foreground = 'white'
+    const foreground = InfluxColors.White
     const inputBackground = 'black'
     const background = '#2c2d35'
     const focusColor = '#46454e'
     const selectColor = InfluxColors.Comet // '#ce58eb'
     const dropdownBackgroundFocused = '#5d5f6f'
-    const dropdownBackgroundNotFocused = '#828497'
-    const clearIndicatorHoverColor = 'white'
+    const dropdownBackgroundNotFocused = InfluxColors.Wolf // '#828294'  was '#828497'
+    const clearIndicatorHoverColor = InfluxColors.White
 
     return {
       selectColor,

--- a/src/variables/components/VariableDropdownReactSelect.tsx
+++ b/src/variables/components/VariableDropdownReactSelect.tsx
@@ -23,12 +23,7 @@ interface OwnProps {
 type ReduxProps = ConnectedProps<typeof connector>
 type Props = OwnProps & ReduxProps
 
-// actualVal keeps track of the actual, selected variable
-// it allows the component to return to that if something was typed that is not in the selected list
-
-// the typed val is what the user types in
 interface MyState {
-  actualVal: string
   shownValues: string[]
   selectHappened: boolean
   loaded: boolean
@@ -39,7 +34,6 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
     super(props)
 
     const defaultState = {
-      actualVal: '',
       shownValues: props.values,
       selectHappened: false,
       loaded: false,
@@ -47,7 +41,6 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
 
     // if it's a csv var, loading is instantaneous, so if it is done just set it:
     if (props.status === RemoteDataState.Done) {
-      defaultState.actualVal = props.selectedValue
       defaultState.loaded = true
     }
 
@@ -56,23 +49,17 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
 
   // set the 'shownValues' after loading, and
   componentDidUpdate(prevProps, prevState) {
-    const {values, selectedValue, status} = this.props
+    const {values, status} = this.props
     const {values: prevVals, status: prevStatus} = prevProps
-    const {actualVal, loaded, selectHappened} = this.state
-    const {
-      actualVal: prevActualVal,
-      selectHappened: prevSelectHappened} = prevState
+    const {loaded, selectHappened} = this.state
+    const {selectHappened: prevSelectHappened} = prevState
 
     let newState = {}
 
     const justLoaded =
       status === RemoteDataState.Done && prevStatus !== RemoteDataState.Done
 
-    const justSelected =
-      selectHappened &&
-      !prevSelectHappened &&
-      actualVal &&
-      actualVal !== prevActualVal
+    const justSelected = selectHappened && !prevSelectHappened
 
     // this is for updating the values:
     // (only want this to run *once* when the values get loaded)
@@ -85,14 +72,13 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
     ) {
       newState = {
         shownValues: values,
-        typedValue: selectedValue,
         loaded: true,
       }
     }
 
     // for updating the selected value:
     if (justSelected) {
-      newState = {...newState, typedValue: actualVal, selectHappened: false}
+      newState = {...newState, selectHappened: false}
     }
 
     this.setState(newState)
@@ -130,6 +116,7 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
     const selectColor = '#ce58eb'
     const dropdownBackgroundFocused = '#5d5f6f'
     const dropdownBackgroundNotFocused = '#828497'
+    const clearIndicatorHoverColor = 'white'
 
     const customStyles = {
       option: (provided, state) => {
@@ -152,7 +139,7 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
         return {
           ...provided,
           '&:hover': {
-            color: 'white',
+            color: clearIndicatorHoverColor,
           },
         }
       },
@@ -244,7 +231,7 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
     )
   }
 
-  private handleSelect = (selectedValue: string, closeMenuNow?: boolean) => {
+  private handleSelect = (selectedValue: string) => {
     const {
       variableID,
       onSelectValue,
@@ -262,7 +249,6 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
 
     const newState = {
       ...this.state,
-      typedValue: selectedValue,
       actualVal: selectedValue,
       selectHappened: true,
     }

--- a/src/variables/components/VariableDropdownReactSelect.tsx
+++ b/src/variables/components/VariableDropdownReactSelect.tsx
@@ -14,7 +14,6 @@ import {getVariable, normalizeValues} from 'src/variables/selectors'
 
 // Types
 import {AppState, RemoteDataState} from 'src/types'
-import {backgroundColor} from 'html2canvas/dist/types/css/property-descriptors/background-color'
 
 interface OwnProps {
   variableID: string
@@ -138,15 +137,11 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
     const {selectedValue, name, status} = this.props
     const {shownValues} = this.state
 
-    //const shownValues = ['ab', 'c', 'd', 'ernie', 'rosita', 'bert']
     const isDisabled = !shownValues || shownValues.length === 0
 
-    //const placeHolderText = this.getPlaceHolderText('Select a Value')
-
-    console.log(`trying to render ${name}.....`, shownValues)
     let realVals = []
 
-    //   make them all look like: { value: 'vanilla', label: 'Vanilla' }
+    //  make them all look like: { value: 'vanilla', label: 'Vanilla' }
     if (shownValues && shownValues.length) {
       realVals = shownValues.map(val => ({value: val, label: val}))
     }
@@ -155,7 +150,6 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
     const foreground = 'white'
     const inputBackground = 'black'
     const background = '#2c2d35'
-    //  const background= 'cyan'
     const focusColor = '#46454e'
     const selectColor = '#ce58eb'
 
@@ -206,7 +200,6 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
         display: 'none',
       }),
       dropdownIndicator: (provided, state) => {
-        //console.log('in ddi....state???', state)
         const hoverBackground = state.isFocused ? '#5d5f6f' : '#828497'
 
         return {
@@ -304,6 +297,7 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
     }
 
     const newState = {
+      ...this.state,
       typedValue: selectedValue,
       actualVal: selectedValue,
       selectHappened: true,
@@ -314,7 +308,6 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
       newState['menuOpen'] = MenuStatus.Closed
     }
 
-    // @ts-ignore
     this.setState(newState)
   }
 

--- a/src/variables/components/VariableDropdownReactSelect.tsx
+++ b/src/variables/components/VariableDropdownReactSelect.tsx
@@ -29,7 +29,7 @@ interface MyState {
   loaded: boolean
 }
 
-class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
+class VariableDropdownReactSelect extends PureComponent<Props, MyState> {
   constructor(props) {
     super(props)
 
@@ -95,20 +95,7 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
     }
   }
 
-  render() {
-    const {selectedValue, name, status} = this.props
-    const {shownValues} = this.state
-
-    const isDisabled = !Array.isArray(shownValues) || shownValues.length === 0
-
-    let realVals = []
-
-    //  make them all look like: { value: 'vanilla', label: 'Vanilla' }
-    if (shownValues && shownValues.length) {
-      realVals = shownValues.map(val => ({value: val, label: val}))
-    }
-    const placeHolderText = this.getPlaceHolderText('Select a Value')
-
+  makeCustomStyles = () => {
     const foreground = 'white'
     const inputBackground = 'black'
     const background = '#2c2d35'
@@ -118,93 +105,111 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
     const dropdownBackgroundNotFocused = '#828497'
     const clearIndicatorHoverColor = 'white'
 
-    const customStyles = {
-      option: (provided, state) => {
-        let backgroundColor = state.isFocused ? focusColor : background
+    return {
+      selectColor,
+      styles: {
+        option: (provided, state) => {
+          let backgroundColor = state.isFocused ? focusColor : background
 
-        if (state.isSelected) {
-          backgroundColor = selectColor
-        }
+          if (state.isSelected) {
+            backgroundColor = selectColor
+          }
 
-        return {
-          ...provided,
-          color: foreground,
-          backgroundColor,
-          padding: 10,
-        }
-      },
-      clearIndicator: provided => {
-        // console.log("clear indicator...state??? ACK", state)
-        // const foregroundColor = state.isFocused? 'yellow' : 'cyan'
-        return {
-          ...provided,
-          '&:hover': {
-            color: clearIndicatorHoverColor,
-          },
-        }
-      },
-      control: () => ({
-        width: 225,
-        height: 40,
-        color: foreground,
-        padding: 3,
-        backgroundColor: background,
-        display: 'flex',
-      }),
-      valueContainer: provided => ({
-        ...provided,
-        color: foreground,
-        backgroundColor: inputBackground,
-      }),
-      placeHolder: provided => ({
-        ...provided,
-        color: foreground,
-        backgroundColor: inputBackground,
-      }),
-      indicatorSeparator: () => ({
-        display: 'none',
-      }),
-      dropdownIndicator: (provided, state) => {
-        const hoverBackground = state.isFocused
-          ? dropdownBackgroundFocused
-          : dropdownBackgroundNotFocused
-
-        return {
-          ...provided,
-          color: foreground,
-          '&:hover': {
-            background: hoverBackground,
+          return {
+            ...provided,
             color: foreground,
-          },
-        }
-      },
-      singleValue: (provided, state) => {
-        const opacity = state.isDisabled ? 0.5 : 1
-        const transition = 'opacity 300ms'
-
-        return {
+            backgroundColor,
+            padding: 10,
+          }
+        },
+        clearIndicator: provided => {
+          return {
+            ...provided,
+            '&:hover': {
+              color: clearIndicatorHoverColor,
+            },
+          }
+        },
+        control: () => ({
+          width: 225,
+          height: 40,
+          color: foreground,
+          padding: 3,
+          backgroundColor: background,
+          display: 'flex',
+        }),
+        valueContainer: provided => ({
           ...provided,
-          opacity,
-          transition,
           color: foreground,
           backgroundColor: inputBackground,
-        }
+        }),
+        placeHolder: provided => ({
+          ...provided,
+          color: foreground,
+          backgroundColor: inputBackground,
+        }),
+        indicatorSeparator: () => ({
+          display: 'none',
+        }),
+        dropdownIndicator: (provided, state) => {
+          const hoverBackground = state.isFocused
+            ? dropdownBackgroundFocused
+            : dropdownBackgroundNotFocused
+
+          return {
+            ...provided,
+            color: foreground,
+            '&:hover': {
+              background: hoverBackground,
+              color: foreground,
+            },
+          }
+        },
+        singleValue: (provided, state) => {
+          const opacity = state.isDisabled ? 0.5 : 1
+          const transition = 'opacity 300ms'
+
+          return {
+            ...provided,
+            opacity,
+            transition,
+            color: foreground,
+            backgroundColor: inputBackground,
+          }
+        },
+        menu: provided => ({
+          ...provided,
+          zIndex: 15,
+          backgroundColor: background,
+        }),
       },
-      menu: provided => ({
-        ...provided,
-        zIndex: 15,
-        backgroundColor: background,
-      }),
     }
+  }
+
+  customStyles = this.makeCustomStyles()
+
+  render() {
+    const {selectedValue, name, status} = this.props
+    const {shownValues} = this.state
+
+    const isDisabled = !Array.isArray(shownValues) || shownValues.length === 0
+
+    let realVals = []
+
+    //  make them all look like: { value: 'vanilla', label: 'vanilla' }
+    if (!isDisabled) {
+      realVals = shownValues.map(val => ({value: val, label: val}))
+    }
+    const placeHolderText = this.getPlaceHolderText('Select a Value')
 
     const onChange = selection => {
       if (selection && selection.value) {
         this.handleSelect(selection.value)
       }
     }
+
     // primary50 is the color that is used when an item is clicked on to change the selection
     // have not found an alternative way (via the customStyles) to change that color)
-
     const selectedObjectValue = {value: selectedValue, label: selectedValue}
     return (
       <Select
@@ -216,7 +221,7 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
         isClearable={true}
         isRtl={false}
         isSearchable={true}
-        styles={customStyles}
+        styles={this.customStyles.styles}
         name={name}
         options={realVals}
         placeholder={placeHolderText}
@@ -224,7 +229,7 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
           ...theme,
           colors: {
             ...theme.colors,
-            primary50: selectColor,
+            primary50: this.customStyles.selectColor,
           },
         })}
       />
@@ -312,4 +317,4 @@ const mdtp = {
 
 const connector = connect(mstp, mdtp)
 
-export default connector(TypeAheadVariableDropdown)
+export default connector(VariableDropdownReactSelect)

--- a/src/variables/components/VariableDropdownReactSelect.tsx
+++ b/src/variables/components/VariableDropdownReactSelect.tsx
@@ -340,7 +340,7 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
     const {status} = this.props
 
     return (
-      status === RemoteDataState.Done && (!valsToUse || valsToUse.length === 0)
+      status === RemoteDataState.Done && (!Array.isArray(valsToUse) || valsToUse.length === 0)
     )
   }
 }

--- a/src/variables/components/VariableDropdownReactSelect.tsx
+++ b/src/variables/components/VariableDropdownReactSelect.tsx
@@ -137,7 +137,7 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
     const {selectedValue, name, status} = this.props
     const {shownValues} = this.state
 
-    const isDisabled = !shownValues || shownValues.length === 0
+    const isDisabled = !Array.isArray(shownValues) || shownValues.length === 0
 
     let realVals = []
 

--- a/src/variables/components/VariableDropdownReactSelect.tsx
+++ b/src/variables/components/VariableDropdownReactSelect.tsx
@@ -1,10 +1,9 @@
 // Libraries
 import React, {PureComponent} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
-import Select from 'react-select'
 
 // Components
-import {MenuStatus} from '@influxdata/clockface'
+import Select from 'react-select'
 
 // Actions
 import {selectValue} from 'src/variables/actions/thunks'
@@ -32,7 +31,6 @@ interface MyState {
   actualVal: string
   shownValues: string[]
   selectHappened: boolean
-  menuOpen: MenuStatus
   loaded: boolean
 }
 
@@ -44,7 +42,6 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
       actualVal: '',
       shownValues: props.values,
       selectHappened: false,
-      menuOpen: null,
       loaded: false,
     }
 
@@ -58,16 +55,13 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
   }
 
   // set the 'shownValues' after loading, and
-  // resets the menuOpen variable
   componentDidUpdate(prevProps, prevState) {
     const {values, selectedValue, status} = this.props
     const {values: prevVals, status: prevStatus} = prevProps
-    const {actualVal, loaded, selectHappened, menuOpen} = this.state
+    const {actualVal, loaded, selectHappened} = this.state
     const {
       actualVal: prevActualVal,
-      selectHappened: prevSelectHappened,
-      menuOpen: prevMenuOpen,
-    } = prevState
+      selectHappened: prevSelectHappened} = prevState
 
     let newState = {}
 
@@ -94,18 +88,6 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
         typedValue: selectedValue,
         loaded: true,
       }
-    }
-
-    /**
-     * unset the menuOpen; it should be set to closed (or open) only once; then undone
-     * this is needed because: (from clockface Dropdown.tsx documentation):
-     * if the string is set to 'open', and then the user closes it, and the code sets it to open again,
-     * unless the code sets it to something else in between (like null or 'close'),
-     * then nothing will happen- the menu will not open)
-     */
-
-    if (menuOpen !== prevMenuOpen && menuOpen !== null) {
-      newState['menuOpen'] = null
     }
 
     // for updating the selected value:
@@ -283,10 +265,6 @@ class TypeAheadVariableDropdown extends PureComponent<Props, MyState> {
       typedValue: selectedValue,
       actualVal: selectedValue,
       selectHappened: true,
-    }
-
-    if (closeMenuNow) {
-      newState['menuOpen'] = MenuStatus.Closed
     }
 
     this.setState(newState)

--- a/yarn.lock
+++ b/yarn.lock
@@ -988,6 +988,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.0", "@babel/runtime@^7.13.10", "@babel/runtime@^7.5.5":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.7.tgz#03ff99f64106588c9c403c6ecb8c3bafbbdff1fa"
+  integrity sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.16.0", "@babel/template@^7.3.3":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.0.tgz#d16a35ebf4cd74e202083356fab21dd89363ddd6"
@@ -1076,6 +1083,71 @@
     "@algolia/autocomplete-preset-algolia" "1.5.0"
     "@docsearch/css" "3.0.0-alpha.42"
     algoliasearch "^4.0.0"
+
+"@emotion/cache@^11.4.0", "@emotion/cache@^11.7.1":
+  version "11.7.1"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.7.1.tgz#08d080e396a42e0037848214e8aa7bf879065539"
+  integrity sha512-r65Zy4Iljb8oyjtLeCuBH8Qjiy107dOYC6SJq7g7GV5UCQWMObY4SJDPGFjiiVpPrOJ2hmJOoBiYTC7hwx9E2A==
+  dependencies:
+    "@emotion/memoize" "^0.7.4"
+    "@emotion/sheet" "^1.1.0"
+    "@emotion/utils" "^1.0.0"
+    "@emotion/weak-memoize" "^0.2.5"
+    stylis "4.0.13"
+
+"@emotion/hash@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
+  integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
+
+"@emotion/memoize@^0.7.4":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.5.tgz#2c40f81449a4e554e9fc6396910ed4843ec2be50"
+  integrity sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==
+
+"@emotion/react@^11.1.1":
+  version "11.7.1"
+  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.7.1.tgz#3f800ce9b20317c13e77b8489ac4a0b922b2fe07"
+  integrity sha512-DV2Xe3yhkF1yT4uAUoJcYL1AmrnO5SVsdfvu+fBuS7IbByDeTVx9+wFmvx9Idzv7/78+9Mgx2Hcmr7Fex3tIyw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@emotion/cache" "^11.7.1"
+    "@emotion/serialize" "^1.0.2"
+    "@emotion/sheet" "^1.1.0"
+    "@emotion/utils" "^1.0.0"
+    "@emotion/weak-memoize" "^0.2.5"
+    hoist-non-react-statics "^3.3.1"
+
+"@emotion/serialize@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.0.2.tgz#77cb21a0571c9f68eb66087754a65fa97bfcd965"
+  integrity sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==
+  dependencies:
+    "@emotion/hash" "^0.8.0"
+    "@emotion/memoize" "^0.7.4"
+    "@emotion/unitless" "^0.7.5"
+    "@emotion/utils" "^1.0.0"
+    csstype "^3.0.2"
+
+"@emotion/sheet@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.1.0.tgz#56d99c41f0a1cda2726a05aa6a20afd4c63e58d2"
+  integrity sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g==
+
+"@emotion/unitless@^0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
+  integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
+
+"@emotion/utils@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.0.0.tgz#abe06a83160b10570816c913990245813a2fd6af"
+  integrity sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA==
+
+"@emotion/weak-memoize@^0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
+  integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
 "@gar/promisify@^1.0.1":
   version "1.1.2"
@@ -1702,6 +1774,13 @@
   integrity sha512-RNSXOyb3VyRs/EOGmjBhhGKTbnN6fHWvy5FNLzWfOWOGjgVUKqJZXfpKzLmgoU8h6Hj8mpALj/mbXQASOb92wQ==
   dependencies:
     "@types/history" "*"
+    "@types/react" "*"
+
+"@types/react-transition-group@^4.4.0":
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.4.tgz#acd4cceaa2be6b757db61ed7b432e103242d163e"
+  integrity sha512-7gAPz7anVK5xzbeQW9wFBDg7G++aPLAFY0QaSMOou9rJZpbuI58WAuJrgu+qR92l61grlnCUe7AFX8KGahAgug==
+  dependencies:
     "@types/react" "*"
 
 "@types/react-virtualized@^9.18.3":
@@ -4359,7 +4438,7 @@ dom-css@^2.0.0:
     prefix-style "2.0.1"
     to-camel-case "1.0.0"
 
-dom-helpers@^5.1.3:
+dom-helpers@^5.0.1, dom-helpers@^5.1.3:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
   integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
@@ -5650,7 +5729,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -7675,7 +7754,7 @@ memoize-one@^4.0.2:
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.1.0.tgz#a2387c58c03fff27ca390c31b764a79addf3f906"
   integrity sha512-2GApq0yI/b22J2j9rhbrAlsHb0Qcz+7yWxeLG8h+95sl1XPUgeLimQSOdur4Vw7cUhrBHwaUZxWFZueojqNRzA==
 
-memoize-one@^5.1.1:
+memoize-one@^5.0.0, memoize-one@^5.1.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
   integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
@@ -9511,6 +9590,29 @@ react-router@5.2.1:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
+react-select@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-5.2.2.tgz#3d5edf0a60f1276fd5f29f9f90a305f0a25a5189"
+  integrity sha512-miGS2rT1XbFNjduMZT+V73xbJEeMzVkJOz727F6MeAr2hKE0uUSA8Ff7vD44H32x2PD3SRB6OXTY/L+fTV3z9w==
+  dependencies:
+    "@babel/runtime" "^7.12.0"
+    "@emotion/cache" "^11.4.0"
+    "@emotion/react" "^11.1.1"
+    "@types/react-transition-group" "^4.4.0"
+    memoize-one "^5.0.0"
+    prop-types "^15.6.0"
+    react-transition-group "^4.3.0"
+
+react-transition-group@^4.3.0:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.2.tgz#8b59a56f09ced7b55cbd53c36768b922890d5470"
+  integrity sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
+
 react-virtualized@^9.18.5:
   version "9.22.3"
   resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.22.3.tgz#f430f16beb0a42db420dbd4d340403c0de334421"
@@ -10646,6 +10748,11 @@ stylehacks@^5.0.1:
   dependencies:
     browserslist "^4.16.0"
     postcss-selector-parser "^6.0.4"
+
+stylis@4.0.13:
+  version "4.0.13"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.13.tgz#f5db332e376d13cc84ecfe5dace9a2a51d954c91"
+  integrity sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag==
 
 superagent@^5.3.1:
   version "5.3.1"


### PR DESCRIPTION
Closes #3657 

accessible via the feature flag:  reactSelectVariableDropdown
will put in a separate idpe PR to add this (as well as put into config cat) before merging this PR

I went over the coloring and styles with andy moon.

the styling has been adjusted to look as similar as possible to the existing component.

when doing the review, compare the new file against the older, original component: https://github.com/influxdata/ui/blob/master/src/variables/components/TypeAheadVariableDropdown.tsx

screencap video:    (there are 900+ entries in the dropdown in the video below, btw)

https://user-images.githubusercontent.com/3900960/150604449-6c109c5d-e7a8-4b7c-a12c-e5b3b8201c52.mov


