### PR TITLE
chore: notifications dont refresh all the time on autorefresh

### DIFF
--- a/src/flows/pipes/Notification/view.tsx
+++ b/src/flows/pipes/Notification/view.tsx
@@ -560,7 +560,7 @@ ${ENDPOINT_DEFINITIONS[data.endpoint]?.generateTestQuery(data.endpointData)}`
   return (
     <Context>
       <div className="notification">
-        {RemoteDataState.Loading && (
+        {loading === RemoteDataState.Loading && (
           <TechnoSpinner
             style={{width: 25, height: 25, position: 'absolute', right: 15}}
           />

--- a/src/flows/pipes/Notification/view.tsx
+++ b/src/flows/pipes/Notification/view.tsx
@@ -520,8 +520,9 @@ ${ENDPOINT_DEFINITIONS[data.endpoint]?.generateTestQuery(data.endpointData)}`
   }
 
   if (
-    loading === RemoteDataState.NotStarted ||
-    loading === RemoteDataState.Loading
+    (loading === RemoteDataState.NotStarted ||
+      loading === RemoteDataState.Loading) &&
+    !numericColumns.length
   ) {
     return (
       <Context>
@@ -559,6 +560,11 @@ ${ENDPOINT_DEFINITIONS[data.endpoint]?.generateTestQuery(data.endpointData)}`
   return (
     <Context>
       <div className="notification">
+        {RemoteDataState.Loading && (
+          <TechnoSpinner
+            style={{width: 25, height: 25, position: 'absolute', right: 15}}
+          />
+        )}
         <Threshold />
         <FlexBox margin={ComponentSize.Medium} style={{padding: '24px 0'}}>
           <FlexBox.Child grow={1} shrink={1}>


### PR DESCRIPTION
This PR is some clean up around the auto refresh functionality for tools for users that have a notification already setup. We need to follow up on the design and user story here so that things are validated properly once the user already makes a selection but updates the existing query in the pipe above. Should we invalidate their previous selection? Should we keep it and make the sequence a submission error issue? Will need to sync with product about it @garylfowler