### PR TITLE
chore: remove GlobalRefresh feature flag

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,7 +77,7 @@ const App: FC = () => {
 
   return (
     <AppWrapper presentationMode={presentationMode} className={appWrapperClass}>
-      <GlobalSearch />
+      {CLOUD && <GlobalSearch />}
       <Notifications />
       <TooltipPortal />
       <NotesPortal />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,7 +77,7 @@ const App: FC = () => {
 
   return (
     <AppWrapper presentationMode={presentationMode} className={appWrapperClass}>
-      {isFlagEnabled('globalSearch') && <GlobalSearch />}
+      <GlobalSearch />
       <Notifications />
       <TooltipPortal />
       <NotesPortal />


### PR DESCRIPTION
This PR is just some general clean-up around the GlobalRefresh work to remove the feature flag. The feature has been live for a while now with no reported issues