### PR TITLE
feat: increase measurement tag limit from 200 to 500

### DIFF
--- a/src/flows/pipes/QueryBuilder/context.tsx
+++ b/src/flows/pipes/QueryBuilder/context.tsx
@@ -16,6 +16,8 @@ import {BucketContext} from 'src/flows/context/bucket.scoped'
 
 import {formatTimeRangeArguments} from 'src/timeMachine/apis/queryBuilder'
 
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+
 import {
   RemoteDataState,
   BuilderTagsType,
@@ -237,6 +239,10 @@ export const QueryBuilderProvider: FC = ({children}) => {
         _source = `from(bucket: "${data.buckets[0].name}")`
       }
 
+      const limit = isFlagEnabled('increasedMeasurmentTagLimit')
+        ? EXTENDED_TAG_LIMIT
+        : DEFAULT_TAG_LIMIT
+
       // TODO: Use the `v1.tagKeys` function from the Flux standard library once
       // this issue is resolved: https://github.com/influxdata/flux/issues/1071
       query(
@@ -248,7 +254,7 @@ export const QueryBuilderProvider: FC = ({children}) => {
               |> distinct()${searchString}${previousTagString}
               |> filter(fn: (r) => r._value != "_time" and r._value != "_start" and r._value !=  "_stop" and r._value != "_value")
               |> sort()
-              |> limit(n: ${EXTENDED_TAG_LIMIT})`,
+              |> limit(n: ${limit})`,
         scope
       )
         .then(resp => {

--- a/src/flows/pipes/QueryBuilder/context.tsx
+++ b/src/flows/pipes/QueryBuilder/context.tsx
@@ -23,6 +23,7 @@ import {
 } from 'src/types'
 
 const DEFAULT_TAG_LIMIT = 200
+const EXTENDED_TAG_LIMIT = 500
 
 interface APIResultArray<T> {
   selected: T[]
@@ -247,7 +248,7 @@ export const QueryBuilderProvider: FC = ({children}) => {
               |> distinct()${searchString}${previousTagString}
               |> filter(fn: (r) => r._value != "_time" and r._value != "_start" and r._value !=  "_stop" and r._value != "_value")
               |> sort()
-              |> limit(n: ${DEFAULT_TAG_LIMIT})`,
+              |> limit(n: ${EXTENDED_TAG_LIMIT})`,
         scope
       )
         .then(resp => {

--- a/src/timeMachine/apis/queryBuilder.ts
+++ b/src/timeMachine/apis/queryBuilder.ts
@@ -17,6 +17,7 @@ import {pastThirtyDaysTimeRange} from 'src/shared/constants/timeRanges'
 
 const DEFAULT_TIME_RANGE: TimeRange = pastThirtyDaysTimeRange
 const DEFAULT_LIMIT = 200
+const EXTENDED_LIMIT = 500
 
 export interface FindBucketsOptions {
   url: string
@@ -50,7 +51,7 @@ export function findKeys({
   tagsSelections,
   searchTerm = '',
   timeRange = DEFAULT_TIME_RANGE,
-  limit = DEFAULT_LIMIT,
+  limit = EXTENDED_LIMIT,
 }: FindKeysOptions): CancelBox<string[]> {
   const tagFilters = formatTagFilterPredicate(tagsSelections)
   const previousKeyFilter = formatTagKeyFilterCall(tagsSelections)


### PR DESCRIPTION
Closes #3432

Increases the measurement tag limit from 200 to 500 for query builder and notebooks.

![Screen Shot 2022-01-24 at 12 30 04 PM](https://user-images.githubusercontent.com/146112/150860303-3d54674c-1c51-4426-b9ee-2ad9801e58a4.png)
![Screen Shot 2022-01-24 at 12 31 18 PM](https://user-images.githubusercontent.com/146112/150860328-dbff842c-6d18-46ea-a5b6-21d7c1fb1dea.png)

