### PR TITLE
chore: remove unused findBuckets function and functions making use of it

### DIFF
--- a/src/timeMachine/apis/QueryBuilderFetcher.ts
+++ b/src/timeMachine/apis/QueryBuilderFetcher.ts
@@ -1,9 +1,7 @@
 // APIs
 import {
-  findBuckets,
   findKeys,
   findValues,
-  FindBucketsOptions,
   FindKeysOptions,
   FindValuesOptions,
 } from 'src/timeMachine/apis/queryBuilder'
@@ -14,39 +12,10 @@ import {CancelBox} from 'src/types'
 type CancelableQuery = CancelBox<string[]>
 
 class QueryBuilderFetcher {
-  private findBucketsQuery: CancelableQuery
   private findKeysQueries: CancelableQuery[] = []
   private findValuesQueries: CancelableQuery[] = []
   private findKeysCache: {[key: string]: string[]} = {}
   private findValuesCache: {[key: string]: string[]} = {}
-  private findBucketsCache: {[key: string]: string[]} = {}
-
-  public async findBuckets(options: FindBucketsOptions): Promise<string[]> {
-    this.cancelFindBuckets()
-
-    const cacheKey = JSON.stringify(options)
-    const cachedResult = this.findBucketsCache[cacheKey]
-
-    if (cachedResult) {
-      return Promise.resolve(cachedResult)
-    }
-
-    const pendingResult = findBuckets(options)
-
-    pendingResult.promise
-      .then(result => {
-        this.findBucketsCache[cacheKey] = result
-      })
-      .catch(() => {})
-
-    return pendingResult.promise
-  }
-
-  public cancelFindBuckets(): void {
-    if (this.findBucketsQuery) {
-      this.findBucketsQuery.cancel()
-    }
-  }
 
   public async findKeys(
     index: number,
@@ -113,7 +82,6 @@ class QueryBuilderFetcher {
   }
 
   public clearCache(): void {
-    this.findBucketsCache = {}
     this.findKeysCache = {}
     this.findValuesCache = {}
   }

--- a/src/timeMachine/apis/__mocks__/queryBuilder.ts
+++ b/src/timeMachine/apis/__mocks__/queryBuilder.ts
@@ -1,8 +1,3 @@
-export const findBuckets = (_: string) => ({
-  promise: Promise.resolve(['b1', 'b2']),
-  cancel: () => {},
-})
-
 export const findKeys = (_: string) => ({
   promise: Promise.resolve(['tk1', 'tk2']),
   cancel: () => {},

--- a/src/timeMachine/apis/queryBuilder.ts
+++ b/src/timeMachine/apis/queryBuilder.ts
@@ -20,22 +20,6 @@ const DEFAULT_TIME_RANGE: TimeRange = pastThirtyDaysTimeRange
 const DEFAULT_LIMIT = 200
 const EXTENDED_LIMIT = 500
 
-export interface FindBucketsOptions {
-  url: string
-  orgID: string
-}
-
-export function findBuckets({orgID}: FindBucketsOptions): CancelBox<string[]> {
-  const query = `buckets()
-  |> sort(columns: ["name"])
-  |> limit(n: ${DEFAULT_LIMIT})`
-
-  event('runQuery', {
-    context: 'queryBuilder-findBuckets',
-  })
-  return extractBoxedCol(runQuery(orgID, query), 'name')
-}
-
 export interface FindKeysOptions {
   url: string
   orgID: string


### PR DESCRIPTION
Closes #3688

When fixing a different bug, I noticed this function, `findBuckets`, which isn't used, but might be confused with the actively used [`getBuckets`](https://github.com/influxdata/ui/blob/9d4b60ddd95e7fbfc6818bf21413d1f18b0cfc1f/src/buckets/actions/thunks.ts#L83) which handles fetching all buckets with no limit. 

I checked on tools and this query hasn't been used in over a year; it fires an event with a tag that has no records in the past year.