### PR TITLE
fix: escape query builder searches more better

### DIFF
--- a/src/flows/pipes/QueryBuilder/context.tsx
+++ b/src/flows/pipes/QueryBuilder/context.tsx
@@ -221,7 +221,7 @@ export const QueryBuilderProvider: FC = ({children}) => {
         ? tagSelections.join(' and ')
         : 'true'
       const searchString = search
-        ? `\n  |> filter(fn: (r) => r._value =~ /(?i:${search})/)`
+        ? `\n  |> filter(fn: (r) => r._value =~ regexp.compile(v: "(?i:" + regexp.quoteMeta(v: "${search}") + ")"))`
         : ''
       const previousTagSelections = cards
         .slice(0, idx)
@@ -232,11 +232,11 @@ export const QueryBuilderProvider: FC = ({children}) => {
 
       const {scope} = getPanelQueries(id)
 
-      let _source
+      let _source = 'import "regexp"\n'
       if (data.buckets[0].type === 'sample') {
-        _source = `import "influxdata/influxdb/sample"\nsample.data(set: "${data.buckets[0].id}")`
+        _source += `import "influxdata/influxdb/sample"\nsample.data(set: "${data.buckets[0].id}")`
       } else {
-        _source = `from(bucket: "${data.buckets[0].name}")`
+        _source += `from(bucket: "${data.buckets[0].name}")`
       }
 
       const limit = isFlagEnabled('increasedMeasurmentTagLimit')
@@ -326,15 +326,15 @@ export const QueryBuilderProvider: FC = ({children}) => {
         ? tagSelections.join(' and ')
         : 'true'
       const searchString = search
-        ? `\n  |> filter(fn: (r) => r._value =~ /(?i:${search})/)`
+        ? `\n  |> filter(fn: (r) => r._value =~ regexp.compile(v: "(?i:" + regexp.quoteMeta(v: "${search}") + ")"))`
         : ''
 
       const {scope} = getPanelQueries(id)
-      let _source
+      let _source = 'import "regexp"\n'
       if (data.buckets[0].type === 'sample') {
-        _source = `import "influxdata/influxdb/sample"\nsample.data(set: "${data.buckets[0].id}")`
+        _source += `import "influxdata/influxdb/sample"\nsample.data(set: "${data.buckets[0].id}")`
       } else {
-        _source = `from(bucket: "${data.buckets[0].name}")`
+        _source += `from(bucket: "${data.buckets[0].name}")`
       }
 
       // TODO: Use the `v1.tagValues` function from the Flux standard library once


### PR DESCRIPTION
seems like i forgot about this PR
https://github.com/influxdata/ui/pull/816

updating the query builder to escape it's regexps better