### PR TITLE
fix: allow simpleTable to be saved and updated on dashboards

### DIFF
--- a/src/views/helpers/index.ts
+++ b/src/views/helpers/index.ts
@@ -324,6 +324,7 @@ const NEW_VIEW_CREATORS = {
     ...defaultView(),
     properties: {
       type: 'simple-table',
+      shape: 'chronograf-v2',
       showAll: false,
     } as SimpleTableViewProperties,
   }),


### PR DESCRIPTION
Closes #3606
Closes #3625 

Like the description says, allows Simple Tables to be saved to dashboards. Allows other graphs to be converted to Simple Tables

![Screen Shot 2022-01-25 at 11 38 17 AM](https://user-images.githubusercontent.com/146112/151047286-de2714ca-b0ce-4364-8c57-2ef725aabba5.png)

