### PR TITLE
feat: increase limit of tag keys and values from 200 - 500

### DIFF
--- a/src/flows/pipes/QueryBuilder/context.tsx
+++ b/src/flows/pipes/QueryBuilder/context.tsx
@@ -337,6 +337,10 @@ export const QueryBuilderProvider: FC = ({children}) => {
         _source = `from(bucket: "${data.buckets[0].name}")`
       }
 
+      const limit = isFlagEnabled('increasedMeasurmentTagLimit')
+        ? EXTENDED_TAG_LIMIT
+        : DEFAULT_TAG_LIMIT
+
       // TODO: Use the `v1.tagValues` function from the Flux standard library once
       // this issue is resolved: https://github.com/influxdata/flux/issues/1071
       query(
@@ -348,7 +352,7 @@ export const QueryBuilderProvider: FC = ({children}) => {
               |> distinct(column: "${
                 cards[idx].keys.selected[0]
               }")${searchString}
-              |> limit(n: ${DEFAULT_TAG_LIMIT})
+              |> limit(n: ${limit})
               |> sort()`,
         scope
       )

--- a/src/timeMachine/apis/queryBuilder.ts
+++ b/src/timeMachine/apis/queryBuilder.ts
@@ -100,6 +100,10 @@ export function findValues({
     ? ''
     : `\n  |> filter(fn: (r) => r._value =~ regexp.compile(v: "(?i:" + regexp.quoteMeta(v: "${searchTerm}") + ")"))`
 
+  const adjustedLimit = isFlagEnabled('increasedMeasurmentTagLimit')
+    ? EXTENDED_LIMIT
+    : limit
+
   // TODO: Use the `v1.tagValues` function from the Flux standard library once
   // this issue is resolved: https://github.com/influxdata/flux/issues/1071
   const query = `import "regexp"
@@ -110,7 +114,7 @@ export function findValues({
   |> keep(columns: ["${key}"])
   |> group()
   |> distinct(column: "${key}")${searchFilter}
-  |> limit(n: ${limit})
+  |> limit(n: ${adjustedLimit})
   |> sort()`
 
   event('runQuery', {


### PR DESCRIPTION
Closes #3432

Follow-up to https://github.com/influxdata/ui/pull/3684
