### PR TITLE
fix: add some defensive programming in there

### DIFF
--- a/src/tasks/components/TaskRunsCard.tsx
+++ b/src/tasks/components/TaskRunsCard.tsx
@@ -45,7 +45,7 @@ const TaskRunsCard: FC<Props> = ({task}) => {
   const members = useSelector((state: AppState) => state.resources.members.byID)
   const org = useSelector(getOrg)
   const history = useHistory()
-  const [route, setRoute] = useState(`/orgs/${org.id}/tasks/${task.id}/edit`)
+  const [route, setRoute] = useState(`/orgs/${org?.id}/tasks/${task?.id}/edit`)
   const changeToggle = () => {
     dispatch(
       updateTaskStatus({
@@ -81,6 +81,10 @@ const TaskRunsCard: FC<Props> = ({task}) => {
       return
     }
 
+    if (!task) {
+      return
+    }
+
     fetch(`/api/v2private/notebooks/resources?type=tasks&resource=${task.id}`, {
       method: 'GET',
       headers: {
@@ -101,7 +105,7 @@ const TaskRunsCard: FC<Props> = ({task}) => {
       .catch(() => {
         setRoute(`/notebook/from/task/${task.id}`)
       })
-  }, [isFlagEnabled('createWithFlows')])
+  }, [isFlagEnabled('createWithFlows'), task])
 
   if (!task) {
     return null


### PR DESCRIPTION
i can't reproduce it locally, but there's a case where the task is being passed into the taskrunscard as null. i decided to patch up those cases where task can be null to see if it helps alleviate the problem.