### PR TITLE
fix: remove the old manual refresh test in data explorer

### DIFF
--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -1,5 +1,5 @@
 import {Organization} from '../../../src/types'
-import {points, makeGraphSnapshot} from '../../support/commands'
+import {points} from '../../support/commands'
 import {
   FROM,
   RANGE,

--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -632,30 +632,6 @@ describe('DataExplorer', () => {
     })
   })
 
-  describe('refresh', () => {
-    beforeEach(() => {
-      cy.writeData(points(20))
-
-      cy.getByTestID(`selector-list m`).click()
-      cy.getByTestID('time-machine-submit-button').click()
-
-      // select short time period to ensure graph changes after short time
-      cy.getByTestID('timerange-dropdown').click()
-      cy.getByTestID('dropdown-item-past5m').click()
-    })
-
-    it('manual refresh', () => {
-      const snapshot = makeGraphSnapshot()
-
-      // graph will slightly move
-      cy.wait(200)
-      cy.get('.autorefresh-dropdown--pause').click()
-
-      // not actually same as (see the false as the second arg)
-      makeGraphSnapshot().shouldBeSameAs(snapshot, false)
-    })
-  })
-
   describe('saving', () => {
     beforeEach(() => {
       cy.writeData(points(10))


### PR DESCRIPTION
This PR is a fix on the test for #3699