### PR TITLE
fix: make the search box on the load-data/sources page sticky

### DIFF
--- a/src/settings/components/LoadDataTabbedPage.tsx
+++ b/src/settings/components/LoadDataTabbedPage.tsx
@@ -52,6 +52,9 @@ const shouldPageBeScrollable = (activeTab: string): boolean => {
   if (activeTab === 'tokens' && isFlagEnabled('paginatedTokens')) {
     return false
   }
+  if (activeTab === 'sources') {
+    return false
+  }
 
   return true
 }

--- a/src/writeData/containers/WriteDataPage.tsx
+++ b/src/writeData/containers/WriteDataPage.tsx
@@ -32,7 +32,9 @@ const WriteDataPage: FC = () => {
         <LoadDataHeader />
         <LoadDataTabbedPage activeTab="sources">
           <WriteDataSearchBar />
-          <WriteDataSections />
+          <Page.Contents scrollable={true}>
+            <WriteDataSections />
+          </Page.Contents>
         </LoadDataTabbedPage>
       </Page>
     </WriteDataSearchContext.Provider>


### PR DESCRIPTION
Closes #215

- Makes the search box on the load-data/sources page sticky
  - This makes a persistent scrollbar appear

https://user-images.githubusercontent.com/146112/151451466-56d3c989-e459-4fde-a875-8c2d89619c84.mov


