### PR TITLE
feat: move auto refresh button and update display name

### DIFF
--- a/cypress/e2e/shared/dashboardsRefresh.test.ts
+++ b/cypress/e2e/shared/dashboardsRefresh.test.ts
@@ -172,14 +172,14 @@ describe('Dashboard refresh', () => {
         cy.wait(5000)
         cy.getByTestID(
           'enable-auto-refresh-button'
-        ).contains('ENABLE AUTO REFRESH', {matchCase: false})
+        ).contains('SET AUTO REFRESH', {matchCase: false})
       })
     })
     it('can timeout on a preset inactivity timeout', done => {
       cy.get<Organization>('@org').then((org: Organization) => {
         cy.getByTestID(
           'enable-auto-refresh-button'
-        ).contains('ENABLE AUTO REFRESH', {matchCase: false})
+        ).contains('SET AUTO REFRESH', {matchCase: false})
 
         cy.getByTestID('enable-auto-refresh-button').click()
         cy.getByTestID('auto-refresh-input')
@@ -214,7 +214,7 @@ describe('Dashboard refresh', () => {
         cy.wait(3100)
         cy.getByTestID(
           'enable-auto-refresh-button'
-        ).contains('ENABLE AUTO REFRESH', {matchCase: false})
+        ).contains('SET AUTO REFRESH', {matchCase: false})
 
         cy.wait('@refreshQuery')
         cy.wait('@refreshQuery')

--- a/src/dashboards/components/DashboardHeader.tsx
+++ b/src/dashboards/components/DashboardHeader.tsx
@@ -244,7 +244,7 @@ const DashboardHeader: FC<Props> = ({
             text={
               isActive
                 ? `Refreshing Every ${autoRefresh.label}`
-                : 'Enable Auto Refresh'
+                : 'Set Auto Refresh'
             }
             color={isActive ? ComponentColor.Secondary : ComponentColor.Default}
             onClick={

--- a/src/flows/components/header/AutoRefreshButton.tsx
+++ b/src/flows/components/header/AutoRefreshButton.tsx
@@ -100,9 +100,7 @@ const AutoRefreshButton: FC = () => {
   return (
     <Button
       text={
-        isActive
-          ? `Refreshing Every ${autoRefresh?.label}`
-          : 'Enable Auto Refresh'
+        isActive ? `Refreshing Every ${autoRefresh?.label}` : 'Set Auto Refresh'
       }
       color={isActive ? ComponentColor.Secondary : ComponentColor.Default}
       onClick={

--- a/src/flows/components/header/index.tsx
+++ b/src/flows/components/header/index.tsx
@@ -389,13 +389,13 @@ const FlowHeader: FC = () => {
         <Page.ControlBar fullWidth>
           <Page.ControlBarLeft>
             <Submit />
+            {isFlagEnabled('flowAutoRefresh') && <AutoRefreshButton />}
             <SaveState />
           </Page.ControlBarLeft>
           <Page.ControlBarRight>
             <PresentationMode />
             <TimeZoneDropdown />
             <TimeRangeDropdown />
-            {isFlagEnabled('flowAutoRefresh') && <AutoRefreshButton />}
             {flow?.id && (
               <>
                 <SquareButton


### PR DESCRIPTION
Closes #3681 

This PR moves the auto refresh button next to "Run" button and update the button display name in Notebooks. 

Before:
<img width="1201" alt="Screen Shot 2022-01-27 at 5 00 25 PM" src="https://user-images.githubusercontent.com/14298407/151457569-4179269c-11e0-478a-8180-f0c33d855af5.png">

After:
<img width="1204" alt="Screen Shot 2022-01-27 at 4 50 38 PM" src="https://user-images.githubusercontent.com/14298407/151457601-cbbe78a8-c115-4afd-bc03-292fbea4ae3b.png">

