### PR TITLE
fix: don't reference the task's owner id's name unless it exists

### DIFF
--- a/src/tasks/components/TaskRunsCard.tsx
+++ b/src/tasks/components/TaskRunsCard.tsx
@@ -54,7 +54,9 @@ const TaskRunsCard: FC<Props> = ({task}) => {
       })
     )
   }
-  const ownerName = members[task.ownerID] ? members[task.ownerID].name : ''
+  const ownerName = members[task?.ownerID]?.name
+    ? members[task.ownerID].name
+    : ''
   const handleRunTask = async () => {
     try {
       await dispatch(runTask(task.id))


### PR DESCRIPTION
Closes #3723

