### PR TITLE
revert: "chore: remove the AutoRefreshDropdown Component"

### DIFF
--- a/cypress/e2e/oss/explorer.test.ts
+++ b/cypress/e2e/oss/explorer.test.ts
@@ -1,0 +1,40 @@
+import {points, makeGraphSnapshot} from '../../support/commands'
+
+describe('refresh', () => {
+  beforeEach(() => {
+    cy.writeData(points(10))
+
+    cy.getByTestID(`selector-list m`).click()
+    cy.getByTestID('time-machine-submit-button').click()
+
+    // select short time period to ensure graph changes after short time
+    cy.getByTestID('timerange-dropdown').click()
+    cy.getByTestID('dropdown-item-past5m').click()
+  })
+
+  // TODO: get this test passing for OSS
+  // This feature only exsists in OSS currently.
+  it.skip('auto refresh', () => {
+    const snapshot = makeGraphSnapshot()
+    cy.getByTestID('autorefresh-dropdown--button').click()
+    cy.getByTestID('auto-refresh-5s').click()
+
+    cy.wait(3_000)
+    makeGraphSnapshot().shouldBeSameAs(snapshot)
+
+    cy.wait(3_000)
+    const snapshot2 = makeGraphSnapshot()
+    snapshot2.shouldBeSameAs(snapshot, false)
+
+    cy.getByTestID('autorefresh-dropdown-refresh').should('not.be.visible')
+    cy.getByTestID('autorefresh-dropdown--button')
+      .should('contain.text', '5s')
+      .click()
+    cy.getByTestID('auto-refresh-paused').click()
+    cy.getByTestID('autorefresh-dropdown-refresh').should('be.visible')
+
+    // wait if graph changes after another 6s when autorefresh is paused
+    cy.wait(6_000)
+    makeGraphSnapshot().shouldBeSameAs(snapshot2)
+  })
+})

--- a/cypress/e2e/shared/dashboardsRefresh.test.ts
+++ b/cypress/e2e/shared/dashboardsRefresh.test.ts
@@ -564,18 +564,9 @@ describe('Dashboard refresh', () => {
           }
         })
 
-        // Set dashboard to auto refresh every 2s
-        cy.getByTestID('enable-auto-refresh-button').click()
-        cy.getByTestID('auto-refresh-input')
-          .clear()
-          .type('2s', {force: true})
-        cy.getByTestID('refresh-form-activate-button').click({force: true})
-
+        cy.getByTestID('autorefresh-dropdown-refresh').click()
         cy.wait('@refreshCellQuery')
         cy.wait('@refreshSecondQuery')
-
-        // Turn off auto refresh
-        cy.getByTestID('enable-auto-refresh-button').click()
       })
     })
   })

--- a/cypress/e2e/shared/flows.test.ts
+++ b/cypress/e2e/shared/flows.test.ts
@@ -7,8 +7,6 @@ describe('Flows', () => {
     cy.get('@org').then(({id}: Organization) =>
       cy.fixture('routes').then(({orgs}) => {
         cy.visit(`${orgs}/${id}`)
-        // TODO: remove when feature flag is removed
-        cy.setFeatureFlags({flowAutoRefresh: true})
       })
     )
     cy.getByTestID('version-info')
@@ -249,7 +247,9 @@ describe('Flows', () => {
       .should('be.visible')
     cy.getByTestID('table-cell cool').should('not.exist')
 
-    cy.getByTestID('enable-auto-refresh-button').should('exist')
+    // This is a random validator that the autorefresh option doesn't pop up
+    // In Flows again without explicit changes
+    cy.getByTestID('autorefresh-dropdown--button').should('not.exist')
 
     cy.clickNavBarItem('nav-item-flows')
 

--- a/src/dashboards/components/DashboardHeader.tsx
+++ b/src/dashboards/components/DashboardHeader.tsx
@@ -1,9 +1,10 @@
 // Libraries
-import React, {FC, useContext} from 'react'
+import React, {FC, useCallback, useContext} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
 import {RouteComponentProps, withRouter} from 'react-router-dom'
 
 // Components
+import AutoRefreshDropdown from 'src/shared/components/dropdown_auto_refresh/AutoRefreshDropdown'
 import TimeRangeDropdown from 'src/shared/components/TimeRangeDropdown'
 import DashboardLightModeToggle from 'src/dashboards/components/DashboardLightModeToggle'
 import GraphTips from 'src/shared/components/graph_tips/GraphTips'
@@ -77,6 +78,7 @@ type Props = OwnProps & ReduxProps & RouteComponentProps<{orgID: string}>
 
 const DashboardHeader: FC<Props> = ({
   dashboard,
+  onManualRefresh,
   toggleShowVariablesControls,
   showVariablesControls,
   onSetAutoRefreshStatus,
@@ -126,6 +128,12 @@ const DashboardHeader: FC<Props> = ({
       onSetAutoRefreshStatus(dashboard.id, AutoRefreshStatus.Active)
     }
   }
+
+  const resetCacheAndRefresh = useCallback((): void => {
+    // We want to invalidate the existing cache when a user manually refreshes the dashboard
+    resetQueryCache()
+    onManualRefresh()
+  }, [])
 
   const isActive =
     autoRefresh?.status && autoRefresh.status === AutoRefreshStatus.Active
@@ -240,6 +248,12 @@ const DashboardHeader: FC<Props> = ({
           <GraphTips />
         </Page.ControlBarLeft>
         <Page.ControlBarRight>
+          <AutoRefreshDropdown
+            onChoose={() => {}}
+            onManualRefresh={resetCacheAndRefresh}
+            selected={autoRefresh}
+            showAutoRefresh={false}
+          />
           <Button
             text={
               isActive

--- a/src/shared/components/dropdown_auto_refresh/AutoRefreshDropdown.scss
+++ b/src/shared/components/dropdown_auto_refresh/AutoRefreshDropdown.scss
@@ -1,0 +1,17 @@
+/*
+  Auto Refresh Dropdown
+  ------------------------------------------------------------------------------
+*/
+
+.autorefresh-dropdown {
+  display: flex;
+  flex-wrap: nowrap;
+
+  &.paused .cf-dropdown--selected {
+    opacity: 0;
+  }
+}
+
+.autorefresh-dropdown--pause {
+  margin-left: $ix-marg-a;
+}

--- a/src/shared/components/dropdown_auto_refresh/AutoRefreshDropdown.tsx
+++ b/src/shared/components/dropdown_auto_refresh/AutoRefreshDropdown.tsx
@@ -1,0 +1,190 @@
+// Libraries
+import React, {Component} from 'react'
+import classnames from 'classnames'
+
+// Components
+import {
+  SquareButton,
+  IconFont,
+  ComponentStatus,
+  Dropdown,
+} from '@influxdata/clockface'
+
+// Constants
+import autoRefreshOptions, {
+  AutoRefreshOption,
+  AutoRefreshOptionType,
+} from 'src/shared/data/autoRefreshes'
+
+// Types
+import {AutoRefresh, AutoRefreshStatus} from 'src/types'
+
+const DROPDOWN_WIDTH_COLLAPSED = 50
+const DROPDOWN_WIDTH_FULL = 84
+
+import {ErrorHandling} from 'src/shared/decorators/errors'
+
+interface Props {
+  selected: AutoRefresh
+  onChoose: (milliseconds: number) => void
+  onManualRefresh?: () => void
+  showAutoRefresh?: boolean
+  customClass?: string
+}
+
+@ErrorHandling
+export default class AutoRefreshDropdown extends Component<Props> {
+  public static defaultProps = {
+    showAutoRefresh: true,
+    selected: {
+      interval: 0,
+      status: 'paused',
+    },
+  }
+
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      isOpen: false,
+    }
+  }
+
+  public render() {
+    if (!this.props.showAutoRefresh) {
+      return <div className={this.className}>{this.manualRefreshButton}</div>
+    }
+    return (
+      <div className={this.className}>
+        <Dropdown
+          style={{width: `${this.dropdownWidthPixels}px`}}
+          button={(active, onClick) => (
+            <Dropdown.Button
+              active={active}
+              onClick={onClick}
+              status={this.dropdownStatus}
+              icon={this.dropdownIcon}
+              testID="autorefresh-dropdown--button"
+            >
+              {this.selectedOptionLabel}
+            </Dropdown.Button>
+          )}
+          menu={onCollapse => (
+            <Dropdown.Menu
+              onCollapse={onCollapse}
+              style={{width: `${DROPDOWN_WIDTH_FULL}px`}}
+            >
+              {autoRefreshOptions.map(option => {
+                if (option.type === AutoRefreshOptionType.Header) {
+                  return (
+                    <Dropdown.Divider
+                      key={option.id}
+                      id={option.id}
+                      text={option.label}
+                    />
+                  )
+                }
+
+                return (
+                  <Dropdown.Item
+                    key={option.id}
+                    id={option.id}
+                    testID={option.id}
+                    value={option}
+                    selected={option.id === this.selectedOptionID}
+                    onClick={this.handleDropdownChange}
+                  >
+                    {option.label}
+                  </Dropdown.Item>
+                )
+              })}
+            </Dropdown.Menu>
+          )}
+        />
+        {this.manualRefreshButton}
+      </div>
+    )
+  }
+
+  public handleDropdownChange = (
+    autoRefreshOption: AutoRefreshOption
+  ): void => {
+    this.props.onChoose(autoRefreshOption.milliseconds)
+  }
+
+  private get dropdownStatus(): ComponentStatus {
+    if (this.isDisabled) {
+      return ComponentStatus.Disabled
+    }
+
+    return ComponentStatus.Default
+  }
+
+  private get isDisabled(): boolean {
+    const {selected} = this.props
+
+    return selected.status === AutoRefreshStatus.Disabled
+  }
+
+  private get isPaused(): boolean {
+    const {selected} = this.props
+
+    return selected.status === AutoRefreshStatus.Paused || this.isDisabled
+  }
+
+  private get className(): string {
+    return classnames('autorefresh-dropdown', {paused: this.isPaused})
+  }
+
+  private get dropdownIcon(): IconFont {
+    if (this.isPaused) {
+      return IconFont.Pause
+    }
+
+    return IconFont.Refresh_New
+  }
+
+  private get dropdownWidthPixels(): number {
+    if (this.isPaused) {
+      return DROPDOWN_WIDTH_COLLAPSED
+    }
+
+    return DROPDOWN_WIDTH_FULL
+  }
+
+  private get selectedOptionID(): string {
+    const {selected} = this.props
+
+    const selectedOption = autoRefreshOptions.find(
+      option => option.milliseconds === selected.interval
+    )
+
+    return selectedOption.id
+  }
+
+  private get selectedOptionLabel(): string {
+    const {selected} = this.props
+
+    const selectedOption = autoRefreshOptions.find(
+      option => option.milliseconds === selected.interval
+    )
+
+    return selectedOption.label
+  }
+
+  private get manualRefreshButton(): JSX.Element {
+    const {onManualRefresh} = this.props
+    if (!onManualRefresh) {
+      return
+    }
+
+    return (
+      <SquareButton
+        icon={IconFont.Refresh_New}
+        onClick={onManualRefresh}
+        className={`autorefresh-dropdown--pause ${this.props.customClass}`}
+        testID="autorefresh-dropdown-refresh"
+      />
+    )
+  }
+}

--- a/src/style/chronograf.scss
+++ b/src/style/chronograf.scss
@@ -38,6 +38,7 @@
 @import 'src/shared/components/NotFound.scss';
 @import 'src/shared/components/SearchableDropdown.scss';
 @import 'src/shared/components/BoxTooltip.scss';
+@import 'src/shared/components/dropdown_auto_refresh/AutoRefreshDropdown.scss';
 @import 'src/shared/components/selectorList/SelectorList.scss';
 @import 'src/shared/components/CodeSnippet.scss';
 @import 'src/shared/components/TagSelectorCount.scss';

--- a/src/timeMachine/components/Queries.tsx
+++ b/src/timeMachine/components/Queries.tsx
@@ -7,6 +7,7 @@ import {withRouter, RouteComponentProps} from 'react-router-dom'
 import TimeMachineFluxEditor from 'src/timeMachine/components/TimeMachineFluxEditor'
 import CSVExportButton from 'src/shared/components/CSVExportButton'
 import TimeMachineQueriesSwitcher from 'src/timeMachine/components/QueriesSwitcher'
+import TimeMachineRefreshDropdown from 'src/timeMachine/components/RefreshDropdown'
 import TimeRangeDropdown from 'src/shared/components/TimeRangeDropdown'
 import TimeMachineQueryBuilder from 'src/timeMachine/components/QueryBuilder'
 import SubmitQueryButton from 'src/timeMachine/components/SubmitQueryButton'
@@ -66,6 +67,7 @@ class TimeMachineQueries extends PureComponent<Props> {
             {!isInCheckOverlay && (
               <>
                 <CSVExportButton />
+                <TimeMachineRefreshDropdown />
                 <TimeRangeDropdown
                   timeRange={timeRange}
                   onSetTimeRange={this.handleSetTimeRange}

--- a/src/timeMachine/components/RefreshDropdown.tsx
+++ b/src/timeMachine/components/RefreshDropdown.tsx
@@ -1,0 +1,101 @@
+// Libraries
+import React, {PureComponent} from 'react'
+import {connect, ConnectedProps} from 'react-redux'
+import {isEqual} from 'lodash'
+
+// Components
+import AutoRefreshDropdown from 'src/shared/components/dropdown_auto_refresh/AutoRefreshDropdown'
+
+// Utils
+import {AutoRefresher} from 'src/utils/AutoRefresher'
+
+// Actions
+import {executeQueries} from 'src/timeMachine/actions/queries'
+import {AutoRefreshStatus, AppState} from 'src/types'
+import {setAutoRefresh} from 'src/timeMachine/actions'
+import {getActiveTimeMachine} from 'src/timeMachine/selectors'
+
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps
+
+class TimeMachineRefreshDropdown extends PureComponent<Props> {
+  private autoRefresher = new AutoRefresher()
+
+  public componentDidMount() {
+    const {autoRefresh} = this.props
+    if (autoRefresh.status === AutoRefreshStatus.Active) {
+      this.autoRefresher.poll(autoRefresh)
+    }
+
+    this.autoRefresher.subscribe(this.executeQueries)
+  }
+
+  public componentDidUpdate(prevProps) {
+    const {autoRefresh} = this.props
+
+    if (!isEqual(autoRefresh, prevProps.autoRefresh)) {
+      if (autoRefresh.status === AutoRefreshStatus.Active) {
+        this.autoRefresher.poll(autoRefresh)
+        return
+      }
+
+      this.autoRefresher.stopPolling()
+    }
+  }
+
+  public componentWillUnmount() {
+    this.autoRefresher.unsubscribe(this.executeQueries)
+    this.autoRefresher.stopPolling()
+  }
+
+  public render() {
+    const {autoRefresh} = this.props
+
+    return (
+      <AutoRefreshDropdown
+        selected={autoRefresh}
+        onChoose={this.handleChooseAutoRefresh}
+        onManualRefresh={this.executeQueries}
+        showAutoRefresh={false}
+      />
+    )
+  }
+
+  private handleChooseAutoRefresh = (interval: number) => {
+    const {onSetAutoRefresh, autoRefresh} = this.props
+
+    if (interval === 0) {
+      onSetAutoRefresh({
+        ...autoRefresh,
+        status: AutoRefreshStatus.Paused,
+        interval,
+      })
+      return
+    }
+
+    onSetAutoRefresh({
+      ...autoRefresh,
+      interval,
+      status: AutoRefreshStatus.Active,
+    })
+  }
+
+  private executeQueries = () => {
+    this.props.onExecuteQueries()
+  }
+}
+
+const mstp = (state: AppState) => {
+  const {autoRefresh} = getActiveTimeMachine(state)
+
+  return {autoRefresh}
+}
+
+const mdtp = {
+  onExecuteQueries: executeQueries,
+  onSetAutoRefresh: setAutoRefresh,
+}
+
+const connector = connect(mstp, mdtp)
+
+export default connector(TimeMachineRefreshDropdown)


### PR DESCRIPTION
Reverts influxdata/ui#3699

I jumped the gun in assuming that the component named AutoRefreshDropdown was actually the old Auto Refresh component. Didn't realize that it served a purpose to refresh the dashboard, especially since the `showAutoRefresh` part was set to false. Reverting this work