### PR TITLE
revert: "fix: remove the old manual refresh test in data explorer"

### DIFF
--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -1,5 +1,5 @@
 import {Organization} from '../../../src/types'
-import {points} from '../../support/commands'
+import {points, makeGraphSnapshot} from '../../support/commands'
 import {
   FROM,
   RANGE,
@@ -629,6 +629,30 @@ describe('DataExplorer', () => {
       cy.getByTestID('right-click--remove-tab').click()
 
       cy.get('.query-tab').should('have.length', 1)
+    })
+  })
+
+  describe('refresh', () => {
+    beforeEach(() => {
+      cy.writeData(points(20))
+
+      cy.getByTestID(`selector-list m`).click()
+      cy.getByTestID('time-machine-submit-button').click()
+
+      // select short time period to ensure graph changes after short time
+      cy.getByTestID('timerange-dropdown').click()
+      cy.getByTestID('dropdown-item-past5m').click()
+    })
+
+    it('manual refresh', () => {
+      const snapshot = makeGraphSnapshot()
+
+      // graph will slightly move
+      cy.wait(200)
+      cy.get('.autorefresh-dropdown--pause').click()
+
+      // not actually same as (see the false as the second arg)
+      makeGraphSnapshot().shouldBeSameAs(snapshot, false)
     })
   })
 


### PR DESCRIPTION
Reverts influxdata/ui#3717

This is another part of reverting code in addition to #3737. The `AutoRefreshDropdown` is still used in Data Explorer by the code reverted in #3737, so we want to add this test back.