### PR TITLE
fix(load-data): add bucket selector back to flux annotated csv and LP

### DIFF
--- a/src/writeData/components/fileUploads/UploadDataDetailsView.tsx
+++ b/src/writeData/components/fileUploads/UploadDataDetailsView.tsx
@@ -87,7 +87,7 @@ const UploadDataDetailsView: FC = () => {
                   className="write-data--details-content markdown-format"
                   data-testid="load-data-details-content"
                 >
-                  {name !== 'csv' ?? (
+                  {contentID !== 'csv' && (
                     <Panel backgroundColor={InfluxColors.Grey15}>
                       <Panel.Body size={ComponentSize.ExtraSmall}>
                         <WriteDataHelperBuckets />


### PR DESCRIPTION
Closes #3721

Adds back the bucket selector to Annotated CSV and Line Protocol. Keeps it removed from CSV

![Screen Shot 2022-01-31 at 12 12 01 PM](https://user-images.githubusercontent.com/146112/151867122-6dfd0707-6770-4826-bbe9-00d6a8b9e3c0.png)
![Screen Shot 2022-01-31 at 12 12 04 PM](https://user-images.githubusercontent.com/146112/151867134-f523fcc7-672b-4e61-bbed-067f56c0224b.png)
![Screen Shot 2022-01-31 at 12 12 06 PM](https://user-images.githubusercontent.com/146112/151867137-78d850cd-fc2c-4767-81a2-f24024869f7a.png)

