### PR TITLE
fix: check to see colors exist in the viewProperties before executing color mapping code

### DIFF
--- a/src/timeMachine/components/Vis.tsx
+++ b/src/timeMachine/components/Vis.tsx
@@ -95,7 +95,7 @@ const TimeMachineVis: FC<Props> = ({
       giraffeResult.table.getColumnType('_value') !== 'number' &&
       !!giraffeResult.table.length)
 
-  if (isFlagEnabled('graphColorMapping')) {
+  if (isFlagEnabled('graphColorMapping') && viewProperties.hasOwnProperty('colors')) {
     const groupKey = [...giraffeResult.fluxGroupKeyUnion, 'result']
     const [, fillColumnMap] = createGroupIDColumn(giraffeResult.table, groupKey)
     const {colorMappingForIDPE, needsToSaveToIDPE} = getColorMappingObjects(

--- a/src/timeMachine/components/Vis.tsx
+++ b/src/timeMachine/components/Vis.tsx
@@ -95,7 +95,10 @@ const TimeMachineVis: FC<Props> = ({
       giraffeResult.table.getColumnType('_value') !== 'number' &&
       !!giraffeResult.table.length)
 
-  if (isFlagEnabled('graphColorMapping') && viewProperties.hasOwnProperty('colors')) {
+  if (
+    isFlagEnabled('graphColorMapping') &&
+    viewProperties.hasOwnProperty('colors')
+  ) {
     const groupKey = [...giraffeResult.fluxGroupKeyUnion, 'result']
     const [, fillColumnMap] = createGroupIDColumn(giraffeResult.table, groupKey)
     const {colorMappingForIDPE, needsToSaveToIDPE} = getColorMappingObjects(


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/3745

The problem is that the color mapping code assumes that `properties.colors` will exist. We missed the part to make sure the code is only called when the properties have the `colors` exist. 

https://user-images.githubusercontent.com/18511823/152029038-e5226173-59a0-438a-ab8b-216fcea7b543.mov


