### PR TITLE
fix: allow all three safari users to select simpleTable text

### DIFF
--- a/src/visualization/types/SimpleTable/style.scss
+++ b/src/visualization/types/SimpleTable/style.scss
@@ -7,6 +7,7 @@
   display: flex;
   flex-direction: column;
   font-family: $cf-code-font;
+  -webkit-user-select: text;
   user-select: text;
 
   .cf-dapper-scrollbars {


### PR DESCRIPTION
Closes #3650

Allows Safari users to select text from simple tables

![Screen Shot 2022-02-01 at 3 20 35 PM](https://user-images.githubusercontent.com/146112/152068015-4029bd27-a7b9-42ab-b969-5f6dd2056a7a.png)

