### PR TITLE
fix: download as csv working again

### DIFF
--- a/src/flows/pipes/Table/view.tsx
+++ b/src/flows/pipes/Table/view.tsx
@@ -28,10 +28,10 @@ const Table: FC<PipeProp> = ({Context}) => {
 
   const dataExists = !!(results?.parsed?.table || []).length
 
-  const queryText = getPanelQueries(id)?.source || ''
   const download = () => {
     event('CSV Download Initiated')
-    basic(queryText).promise.then(response => {
+    const query = getPanelQueries(id)
+    basic(query?.source, query?.scope).promise.then(response => {
       if (response.type !== 'SUCCESS') {
         return
       }

--- a/src/flows/pipes/Visualization/view.tsx
+++ b/src/flows/pipes/Visualization/view.tsx
@@ -74,10 +74,10 @@ const Visualization: FC<PipeProp> = ({Context}) => {
 
   const dataExists = !!(results?.parsed?.table || []).length
 
-  const queryText = getPanelQueries(id)?.source || ''
   const download = () => {
     event('CSV Download Initiated')
-    basic(queryText).promise.then(response => {
+    const query = getPanelQueries(id)
+    basic(query?.source, query?.scope).promise.then(response => {
       if (response.type !== 'SUCCESS') {
         return
       }


### PR DESCRIPTION
looks like we forgot to pass the scope into the download as csv functionality somewhere along the way. this closes that on up