### PR TITLE
fix(3523/3522/3524): python code gen formatting

### DIFF
--- a/src/writeData/clients/Python/dispose.example
+++ b/src/writeData/clients/Python/dispose.example
@@ -1,1 +1,1 @@
-client.close()
+    client.close()

--- a/src/writeData/clients/Python/execute.example
+++ b/src/writeData/clients/Python/execute.example
@@ -1,5 +1,5 @@
-query = """<%= query %>"""
-tables = client.query_api().query(query, org=org)
-for table in tables:
-    for record in table.records:
-        print(record)
+    query = """<%= query %>"""
+    tables = client.query_api().query(query, org=org)
+    for table in tables:
+        for record in table.records:
+            print(record)

--- a/src/writeData/clients/Python/execute.example
+++ b/src/writeData/clients/Python/execute.example
@@ -1,4 +1,4 @@
-query = '<%= query %>'
+query = """<%= query %>"""
 tables = client.query_api().query(query, org=org)
 for table in tables:
     for record in table.records:

--- a/src/writeData/clients/Python/write.0.example
+++ b/src/writeData/clients/Python/write.0.example
@@ -1,5 +1,5 @@
-write_api = client.write_api(write_options=SYNCHRONOUS)
+    write_api = client.write_api(write_options=SYNCHRONOUS)
 
-data = "mem,host=host1 used_percent=23.43234543"
-write_api.write(bucket, org, data)
+    data = "mem,host=host1 used_percent=23.43234543"
+    write_api.write(bucket, org, data)
 

--- a/src/writeData/clients/Python/write.1.example
+++ b/src/writeData/clients/Python/write.1.example
@@ -1,7 +1,7 @@
-point = Point("mem") \
-  .tag("host", "host1") \
-  .field("used_percent", 23.43234543) \
-  .time(datetime.utcnow(), WritePrecision.NS)
+    point = Point("mem") \
+        .tag("host", "host1") \
+        .field("used_percent", 23.43234543) \
+        .time(datetime.utcnow(), WritePrecision.NS)
 
-write_api.write(bucket, org, point)
+    write_api.write(bucket, org, point)
 

--- a/src/writeData/clients/Python/write.2.example
+++ b/src/writeData/clients/Python/write.2.example
@@ -1,4 +1,4 @@
-sequence = ["mem,host=host1 used_percent=23.43234543",
+    sequence = ["mem,host=host1 used_percent=23.43234543",
             "mem,host=host1 available_percent=15.856523"]
-write_api.write(bucket, org, sequence)
+    write_api.write(bucket, org, sequence)
 


### PR DESCRIPTION
Closes #3523
Closes #3522
Closes #3524

### DONE:
- inter-related tickets.
- 3524 and 3523: all python block expressions, after initialization, needs to be indented.
- 3522: make sure to triple string quote the query, so no need to worry about escaping.
- copy/paste into python shell to make sure it worked.
      - from all of the options on the client libraries page.
      - from the export-to-client option off the flow pipes.



### NOT DONE:
- could not re-create one of the situations seen in https://github.com/influxdata/ui/issues/3524.
      - I assume this is the "export to client" from the flow pipes. 
      - The only way this could happen would be if we were missing templates for both the `def.initialize` and `def.executeFull` in the ClientCodeCopyPage.
      - not sure if I should do any hypothetical defensive coding here. I noted this on the ticket and pinged the issue reporter for more details.



### Screenshot of client libraries page
<img width="794" alt="Screen Shot 2022-02-02 at 12 14 40 PM" src="https://user-images.githubusercontent.com/10232835/152235813-7abf231d-163f-4f23-a137-25f1ef5db249.png">
