### PR TITLE
fix: (Multi-Account) switch account modal styling tweaks

### DIFF
--- a/src/accounts/AccountPage.tsx
+++ b/src/accounts/AccountPage.tsx
@@ -63,6 +63,7 @@ const AccountAboutPage: FC = () => {
 
   const inputStyle = {width: 250}
   const labelStyle = {marginBottom: 8}
+  const dividerStyle = {marginTop: '32px'}
 
   return (
     <AccountTabContainer activeTab="about">
@@ -75,7 +76,7 @@ const AccountAboutPage: FC = () => {
               onClick={showSwitchAccountDialog}
               testID="user-account-switch-btn"
             />
-            <hr style={{marginTop: '32px'}} />
+            <hr style={dividerStyle} />
           </div>
         )}
 

--- a/src/accounts/AccountPage.tsx
+++ b/src/accounts/AccountPage.tsx
@@ -68,18 +68,18 @@ const AccountAboutPage: FC = () => {
     <AccountTabContainer activeTab="about">
       <>
         {userAccounts && userAccounts.length >= 2 && (
-          <React.Fragment>
+          <div>
             <Button
               text="Switch Account"
               icon={IconFont.Switch_New}
               onClick={showSwitchAccountDialog}
               testID="user-account-switch-btn"
             />
-            <hr />
-          </React.Fragment>
+            <hr style={{marginTop: '32px'}}/>
+          </div>
         )}
 
-        <h2 data-testid="account-settings--header"> Account Details </h2>
+        <h4 data-testid="account-settings--header"> Account Details </h4>
         <div style={labelStyle}>Account Name</div>
         <FlexBox direction={FlexDirection.Row} margin={ComponentSize.Medium}>
           <Input

--- a/src/accounts/AccountPage.tsx
+++ b/src/accounts/AccountPage.tsx
@@ -75,7 +75,7 @@ const AccountAboutPage: FC = () => {
               onClick={showSwitchAccountDialog}
               testID="user-account-switch-btn"
             />
-            <hr style={{marginTop: '32px'}}/>
+            <hr style={{marginTop: '32px'}} />
           </div>
         )}
 

--- a/src/accounts/SwitchAccountOverlay.tsx
+++ b/src/accounts/SwitchAccountOverlay.tsx
@@ -132,9 +132,9 @@ export const SwitchAccountOverlay: FC<Props> = ({onDismissOverlay}) => {
     'Select a Different Account to Enable the Switch Button'
 
   return (
-    <Overlay.Container maxWidth={630} testID="switch-account--dialog">
+    <Overlay.Container maxWidth={420} testID="switch-account--dialog">
       <Overlay.Header
-        title="Switch Account"
+        title="Switch account"
         wrapText={true}
         onDismiss={onDismissOverlay}
       />
@@ -146,19 +146,21 @@ export const SwitchAccountOverlay: FC<Props> = ({onDismissOverlay}) => {
           text="Cancel"
           testID="multi-account-switch-cancel"
           onClick={onDismissOverlay}
+          color={ComponentColor.Tertiary}
         />
         <Button
           testID="switch-default-account--btn"
-          text="Set Default Account"
+          text="Set as default"
           status={defaultButtonStatus}
           onClick={doSetDefaultAccount}
         />
         <Button
-          text="Switch Account"
+          text="Switch"
           onClick={doSwitchAccount}
           status={switchButtonStatus}
           disabledTitleText={disabledTitleText}
           testID="actually-switch-account--btn"
+          color={ComponentColor.Primary}
         />
       </Overlay.Footer>
     </Overlay.Container>

--- a/src/accounts/SwitchAccountOverlay.tsx
+++ b/src/accounts/SwitchAccountOverlay.tsx
@@ -42,7 +42,7 @@ const ToggleGroup: FC<ToggleProps> = ({onClickAcct}) => {
     setSelectedAcct(numAcct)
   }
 
-  const style = {marginBottom: 7}
+  const style = {marginBottom: 17}
 
   return (
     <React.Fragment>


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/3761

Minor styling fixes to match the design team's suggestions.

**Account Page**
Prev:

<img width="1007" alt="Screen Shot 2022-02-03 at 12 47 51 PM" src="https://user-images.githubusercontent.com/18511823/152417695-ef7b9c81-b494-4a97-8e38-f8a84b2fa014.png">

After change:

<img width="1009" alt="Screen Shot 2022-02-03 at 12 49 30 PM" src="https://user-images.githubusercontent.com/18511823/152418017-df871287-4cad-4825-a591-835d3b8efd4a.png">


**Modal**
Prev:

<img width="730" alt="Screen Shot 2022-02-03 at 12 48 47 PM" src="https://user-images.githubusercontent.com/18511823/152417861-0ea86272-a9c0-4273-bd85-4dd0a683cbfc.png">


After change:

<img width="445" alt="Screen Shot 2022-02-03 at 12 56 04 PM" src="https://user-images.githubusercontent.com/18511823/152418959-cc4de04e-c4f3-4bef-970a-802a5177fae8.png">

