### PR TITLE
feat: update all versions of fromFlux

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "@docsearch/react": "^3.0.0-alpha.37",
     "@influxdata/clockface": "^3.1.14",
     "@influxdata/flux-lsp-browser": "^0.8.0",
-    "@influxdata/giraffe": "^2.24.0",
+    "@influxdata/giraffe": "^2.24.1",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",
     "abortcontroller-polyfill": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "@docsearch/react": "^3.0.0-alpha.37",
     "@influxdata/clockface": "^3.1.14",
     "@influxdata/flux-lsp-browser": "^0.8.0",
-    "@influxdata/giraffe": "^2.23.1",
+    "@influxdata/giraffe": "^2.24.0",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",
     "abortcontroller-polyfill": "^1.3.0",

--- a/src/alerting/utils/history.test.ts
+++ b/src/alerting/utils/history.test.ts
@@ -33,6 +33,7 @@ describe('history utils', () => {
   beforeEach(jest.clearAllMocks)
 
   const fluxGroupKeyUnion = ['']
+  const resultColumnNames = []
   const length = 100
   const cols = 20
   const table: Table = {
@@ -51,6 +52,7 @@ describe('history utils', () => {
       mocked(fromFlux).mockImplementationOnce(() => ({
         table: {...table, length: 0},
         fluxGroupKeyUnion,
+        resultColumnNames,
       }))
 
       const actual = await processResponse({
@@ -70,6 +72,7 @@ describe('history utils', () => {
       mocked(fromFlux).mockImplementationOnce(() => ({
         table,
         fluxGroupKeyUnion,
+        resultColumnNames,
       }))
       const expected = range(length).map(i =>
         Object.fromEntries([

--- a/src/alerting/utils/statusEvents.test.ts
+++ b/src/alerting/utils/statusEvents.test.ts
@@ -21,6 +21,7 @@ describe('process statuses response', () => {
   beforeEach(jest.clearAllMocks)
 
   const fluxGroupKeyUnion = ['']
+  const resultColumnNames = []
   const length = 100
   const cols = 20
   const table: Table = {
@@ -38,6 +39,7 @@ describe('process statuses response', () => {
     mocked(fromFlux).mockImplementationOnce(() => ({
       table: {...table, length: 0},
       fluxGroupKeyUnion,
+      resultColumnNames,
     }))
 
     const actual = await processStatusesResponse({
@@ -55,7 +57,11 @@ describe('process statuses response', () => {
   })
 
   it('process single table', async () => {
-    mocked(fromFlux).mockImplementationOnce(() => ({table, fluxGroupKeyUnion}))
+    mocked(fromFlux).mockImplementationOnce(() => ({
+      table,
+      fluxGroupKeyUnion,
+      resultColumnNames,
+    }))
     const expected = range(length).map(i =>
       Object.fromEntries([
         ['table', 0],

--- a/src/shared/utils/fromFlux.legacy.ts
+++ b/src/shared/utils/fromFlux.legacy.ts
@@ -26,5 +26,6 @@ export default function fromFluxLegacy(csv: string): FromFluxResult {
       newTable(parsedFlux.table.length)
     ),
     fluxGroupKeyUnion: parsedFlux.fluxGroupKeyUnion,
+    resultColumnNames: parsedFlux.resultColumnNames,
   }
 }

--- a/src/shared/utils/fromFlux.test.ts
+++ b/src/shared/utils/fromFlux.test.ts
@@ -143,6 +143,66 @@ describe('fromFlux', () => {
     expect(fluxGroupKeyUnion).toEqual(['a', 'c', 'd'])
   })
 
+  test('returns all result column names', () => {
+    const CSV = `#group,true,false,false,true
+#datatype,string,string,string,string
+#default,new,,,
+,result,b,c,d
+,,0,0,0
+
+#group,false,false,true,false
+#datatype,string,string,string,string
+#default,old,,,
+,result,b,c,d
+,,0,0,0`
+
+    const flux = fromFlux(CSV)
+    const fluxLegacy = fromFluxLegacy(CSV)
+
+    expect(flux.resultColumnNames).toEqual(['new', 'old'])
+    expect(fluxLegacy.resultColumnNames).toEqual(['new', 'old'])
+  })
+
+  test('handles blank result column names', () => {
+    const CSV = `#group,true,false,false,true
+#datatype,string,string,string,string
+#default,,,,
+,result,b,c,d
+,,0,0,0
+
+#group,false,false,true,false
+#datatype,string,string,string,string
+#default,,,,
+,result,b,c,d
+,,0,0,0`
+
+    const flux = fromFlux(CSV)
+    const fluxLegacy = fromFluxLegacy(CSV)
+
+    expect(flux.resultColumnNames).toEqual([])
+    expect(fluxLegacy.resultColumnNames).toEqual([])
+  })
+
+  test('handles missing result column', () => {
+    const CSV = `#group,true,false,false,true
+#datatype,string,string,string,string
+#default,_result,,,
+,a,b,c,d
+,,0,0,0
+
+#group,false,false,true,false
+#datatype,string,string,string,string
+#default,_result,,,
+,a,b,c,d
+,,0,0,0`
+
+    const flux = fromFlux(CSV)
+    const fluxLegacy = fromFluxLegacy(CSV)
+
+    expect(flux.resultColumnNames).toEqual([])
+    expect(fluxLegacy.resultColumnNames).toEqual([])
+  })
+
   test('parses empty numeric values as null', () => {
     const CSV = `#group,false,false,true,true,false,true,true,true,true,true
 #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string

--- a/src/shared/utils/fromFlux.ts
+++ b/src/shared/utils/fromFlux.ts
@@ -135,6 +135,7 @@ export interface ParsedFlux {
     length: number
   }
   fluxGroupKeyUnion: string[]
+  resultColumnNames: string[]
 }
 
 export default function fromFlux(csv: string): ParsedFlux {
@@ -347,6 +348,13 @@ export default function fromFlux(csv: string): ParsedFlux {
       }
     })
 
+  const resultColumnNames = new Set<string>()
+  output?.result?.data.forEach(columnName => {
+    if (String(columnName).length > 0) {
+      resultColumnNames.add(String(columnName))
+    }
+  })
+
   return {
     table: {
       columnKeys: Object.keys(output),
@@ -354,5 +362,6 @@ export default function fromFlux(csv: string): ParsedFlux {
       length: runningTotal,
     },
     fluxGroupKeyUnion: Object.keys(groupKey),
+    resultColumnNames: Array.from(resultColumnNames),
   }
 }

--- a/src/timeMachine/selectors/index.ts
+++ b/src/timeMachine/selectors/index.ts
@@ -115,11 +115,13 @@ const getVisTableMemoized = memoizeOne(fromFlux)
 
 export const getVisTable = (
   state: AppState
-): {table: Table; fluxGroupKeyUnion: string[]} => {
+): {table: Table; fluxGroupKeyUnion: string[]; resultColumnNames: string[]} => {
   const files = getActiveTimeMachine(state).queryResults.files || []
-  const {table, fluxGroupKeyUnion} = getVisTableMemoized(files.join('\n\n'))
+  const {table, fluxGroupKeyUnion, resultColumnNames} = getVisTableMemoized(
+    files.join('\n\n')
+  )
 
-  return {table, fluxGroupKeyUnion}
+  return {table, fluxGroupKeyUnion, resultColumnNames}
 }
 
 const getNumericColumnsMemoized = memoizeOne(getNumericColumnsUtil)

--- a/src/visualization/types/Map/view.test.tsx
+++ b/src/visualization/types/Map/view.test.tsx
@@ -33,6 +33,7 @@ const setup = () => {
     result: {
       table,
       fluxGroupKeyUnion: ['', ''],
+      resultColumnNames: [],
       results: {},
     },
   }

--- a/src/visualization/types/Scatter/TimeAutoToggle.test.tsx
+++ b/src/visualization/types/Scatter/TimeAutoToggle.test.tsx
@@ -51,6 +51,7 @@ describe('Time Domain Auto Toggle', () => {
       results: {
         table,
         fluxGroupKeyUnion: ['', ''],
+        resultColumnNames: [],
         ...results,
       },
       update: jest.fn(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1172,10 +1172,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/flux-lsp-browser/-/flux-lsp-browser-0.8.0.tgz#2b0b8d543f9b89e73ee2379a90aa66499fa92026"
   integrity sha512-A7bGnbDzOnsEIAYpxuqdKJjPbtlP5H5EcXsqdpMISdp80y0TBbGv41U3dsfrOIPENvXNYLjroIvp6QYnnF/uaw==
 
-"@influxdata/giraffe@^2.24.0":
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.24.0.tgz#5f50bce5ab4f2064026083843489dde606465d63"
-  integrity sha512-W6lVvk1XSvMIRDj0oclAWE6OkxrgegxtHqrcBAEBR7v+9g61vVdgKHfhVkmaIM1EeDCFYWTDE4Au5F2ZGBbcaA==
+"@influxdata/giraffe@^2.24.1":
+  version "2.24.1"
+  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.24.1.tgz#082e6394f3f0a50e72c2e31d5f7621134dc56536"
+  integrity sha512-GHtlBXvUVewQkUK4BVEZ8itoEsA0U+WyquuxqmMBxaDSZCRQWtezIEeORxA1F9fJclsjeENjzMEVFPaODcyYIA==
   dependencies:
     merge-images "^2.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1172,10 +1172,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/flux-lsp-browser/-/flux-lsp-browser-0.8.0.tgz#2b0b8d543f9b89e73ee2379a90aa66499fa92026"
   integrity sha512-A7bGnbDzOnsEIAYpxuqdKJjPbtlP5H5EcXsqdpMISdp80y0TBbGv41U3dsfrOIPENvXNYLjroIvp6QYnnF/uaw==
 
-"@influxdata/giraffe@^2.23.1":
-  version "2.23.1"
-  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.23.1.tgz#d06b6409042988f32e75bf473e76fee736f072ab"
-  integrity sha512-ReV3sM59F8p8EE8cGtS+5dhsknB6bLx1cnF+jHBxVAaVKbZKypmdO89XuZV2nt/BidSpglK7cQ/pwcKvcGWQ0Q==
+"@influxdata/giraffe@^2.24.0":
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.24.0.tgz#5f50bce5ab4f2064026083843489dde606465d63"
+  integrity sha512-W6lVvk1XSvMIRDj0oclAWE6OkxrgegxtHqrcBAEBR7v+9g61vVdgKHfhVkmaIM1EeDCFYWTDE4Au5F2ZGBbcaA==
   dependencies:
     merge-images "^2.0.0"
 


### PR DESCRIPTION
Part 1 of #3404 

- updates Giraffe to use the new `fromFlux`
- updates all other versions of `fromFlux` to minimize confusion
- the new property `resultColumnNames` can be safely ignored if not needed
