### PR TITLE
fix(3706): test query for notebooks alert http endpoint

### DIFF
--- a/src/flows/pipes/Notification/endpoints/HTTP/index.ts
+++ b/src/flows/pipes/Notification/endpoints/HTTP/index.ts
@@ -45,9 +45,10 @@ export default register => {
 		messageFn: messageFn,
 		crit: trigger,
 	)
-	|> monitor["notify"](data: notification, endpoint: http["endpoint"](url: "${data.url}")(mapFn: (r) => {
-      body = {r with _version: 1}
-      return {headers: {${_headers}}, data: json["encode"](v: body)}
+  |> monitor["notify"](data: notification, endpoint: http.endpoint(url: "${data.url}")(
+    mapFn: (r) => {
+        body = {r with _version: 1}
+        return {headers: {${_headers}}, data: json.encode(v: body)}
   }))`
       return out
     },
@@ -74,8 +75,8 @@ export default register => {
 
       return `http.post(
         url: "${data.url}",
-        data: json["encode"](v: "${TEST_NOTIFICATION}"),
-        headers: {${_headers}}
+        headers: {${_headers}},
+        data: json.encode(v: { msg: "${TEST_NOTIFICATION}"})
       )
 
   array.from(rows: [{value: 0}])

--- a/src/flows/pipes/Notification/endpoints/HTTP/index.ts
+++ b/src/flows/pipes/Notification/endpoints/HTTP/index.ts
@@ -72,9 +72,11 @@ export default register => {
         }, [])
         .join(', ')
 
-      return `http["endpoint"](url: "${data.url}")(mapFn: (r) => {
-      return {headers: {${_headers}}, data: json["encode"](v: "${TEST_NOTIFICATION}")}
-  })
+      return `http.post(
+        url: "${data.url}",
+        data: json["encode"](v: "${TEST_NOTIFICATION}"),
+        headers: {${_headers}}
+      )
 
   array.from(rows: [{value: 0}])
 	|> yield(name: "ignore")`


### PR DESCRIPTION
Closes #3706
Issue was that the test Alert, in notebooks, was not functional.

## Done:
* small change to query used for http alerts in notebook. 
     * Update to latest flux syntax, and confirm is working.
* change the running task query to also use the latest flux syntax.
    * confirmed is still working. payload not changed either.
* Confirmed the notebooks task lifecycle still works (for http notifications):
      1. send test alert
      2. export alert as task
      3. task runs, sending notifications
      4. inactivate task --> see that it stop sending notifications.



## Screenshots (proof of functionality)
* test alert
<img width="1968" alt="Screen Shot 2022-02-08 at 11 24 52 AM" src="https://user-images.githubusercontent.com/10232835/153060601-0f5d8b6e-78a8-4cdd-915d-0f36dc2c062c.png">


* outut flux from exported task
<img width="1880" alt="Screen Shot 2022-02-08 at 11 16 36 AM" src="https://user-images.githubusercontent.com/10232835/153059871-57951a80-3adc-4dec-b41e-0dce98f8aff7.png">

* exported task will run
<img width="1566" alt="Screen Shot 2022-02-08 at 11 17 04 AM" src="https://user-images.githubusercontent.com/10232835/153059836-5a397b35-b450-4a34-b58e-1cce7faea282.png">

* comparison of parsed body (before and after changes). tl;dr payload is the same.
    * before:
    ```
    {
        "_check_id": "d8b1gd7p7565",
        "_check_name": "Notebook Generated Check",
        "_level": "crit",
        "_measurement": "notifications",
        "_message": "Custom for airSensors triggered at 2022-02-08T17:48:08.000000000Z!",
        "_notebook_link": "https://<NAMESPACE>.remocal.influxdev.co/orgs/a767fa74c45001fd/notebooks/5fb6aa11d0dc4000",
        "_notification_endpoint_id": "d8b1gd7p7565",
        "_notification_endpoint_name": "Notebook Generated Endpoint",
        "_notification_rule_id": "d8b1gd7p7565",
        "_notification_rule_name": "Notebook Generated Rule",
        "_source_measurement": "airSensors",
        "_source_timestamp": 1644342488000000000,
        "_start": "2022-02-08T17:48:08Z",
        "_status_timestamp": 1644346088000000000,
        "_stop": "2022-02-08T18:48:08Z",
        "_time": "2022-02-08T18:48:08Z",
        "_type": "custom",
        "_version": 1,
        "co": 0.40518055604716896,
        "sensor_id": "TLM0203"
    }
    ```
    * after:
    ```
    {
        "_check_id": "d8b1gd7p7565",
        "_check_name": "Notebook Generated Check",
        "_level": "crit",
        "_measurement": "notifications",
        "_message": "Custom for airSensors triggered at 2022-02-08T18:14:43.000000000Z!",
        "_notebook_link": "https://<NAMESPACE>.remocal.influxdev.co/orgs/a767fa74c45001fd/notebooks/5fb6aa11d0dc4000",
        "_notification_endpoint_id": "d8b1gd7p7565",
        "_notification_endpoint_name": "Notebook Generated Endpoint",
        "_notification_rule_id": "d8b1gd7p7565",
        "_notification_rule_name": "Notebook Generated Rule",
        "_source_measurement": "airSensors",
        "_source_timestamp": 1644344083000000000,
        "_start": "2022-02-08T18:14:43Z",
        "_status_timestamp": 1644347683000000000,
        "_stop": "2022-02-08T19:14:43Z",
        "_time": "2022-02-08T19:14:43Z",
        "_type": "custom",
        "_version": 1,
        "co": 0.5874328698693015,
        "sensor_id": "TLM0203"
    }
    ```
