### PR TITLE
feat: get all the version history for the user and have a hover state with a glimpse at the publish by and publish at

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "cy": "CYPRESS_dexUrl=https://$INGRESS_HOST:$PORT_HTTPS CYPRESS_baseUrl=http://localhost:9999 cypress open",
     "cy:dev": "source ../monitor-ci/.env && CYPRESS_dexUrl=CLOUD CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{cloud,shared}/**/*.*'",
     "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_dexUrl=OSS CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{oss,shared}/**/*.*'",
-    "generate": "export SHA=40fb34a01f631d701c87025b2da98d5a4d62f94b && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
+    "generate": "export SHA=2670263b84efd14387ffcaa01102db328cded3e4 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-meta": "if [ -z \"${CLOUD_URL}\" ]; then yarn generate-meta-oss; else yarn generate-meta-cloud; fi",
     "generate-meta-oss": "yarn oss-api && yarn notebooks && yarn unity && yarn annotations-oss && yarn pinned && yarn mapsd-oss && yarn cloudPriv",

--- a/src/flows/components/header/PublishedVersions.tsx
+++ b/src/flows/components/header/PublishedVersions.tsx
@@ -1,0 +1,47 @@
+import React, {FC, useCallback, useContext, useEffect, useState} from 'react'
+import VersionBullet from 'src/flows/components/header/VersionBullet'
+import {FlowContext} from 'src/flows/context/flow.current'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import {
+  getNotebooksVersions,
+  VersionHistories,
+} from 'src/client/notebooksRoutes'
+
+const PublishedVersions: FC = () => {
+  const {flow} = useContext(FlowContext)
+  const [versions, setVersions] = useState<VersionHistories>([])
+
+  const handleGetNotebookVersions = useCallback(async () => {
+    try {
+      const response = await getNotebooksVersions({id: flow.id})
+
+      if (response.status !== 200) {
+        throw new Error(response.data.message)
+      }
+
+      setVersions(response.data)
+    } catch (error) {
+      console.error({error})
+    }
+  }, [flow])
+
+  useEffect(() => {
+    if (isFlagEnabled('flowPublishLifecycle')) {
+      handleGetNotebookVersions()
+    }
+  }, [handleGetNotebookVersions])
+
+  if (versions.length === 0) {
+    return null
+  }
+
+  return (
+    <>
+      {versions.map(version => (
+        <VersionBullet key={version.id} version={version} />
+      ))}
+    </>
+  )
+}
+
+export default PublishedVersions

--- a/src/flows/components/header/PublishedVersions.tsx
+++ b/src/flows/components/header/PublishedVersions.tsx
@@ -1,29 +1,12 @@
-import React, {FC, useCallback, useContext, useEffect, useState} from 'react'
+import React, {FC, useContext, useEffect} from 'react'
 import VersionBullet from 'src/flows/components/header/VersionBullet'
-import {FlowContext} from 'src/flows/context/flow.current'
+import {VersionPublishContext} from 'src/flows/context/version.publish'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
-import {
-  getNotebooksVersions,
-  VersionHistories,
-} from 'src/client/notebooksRoutes'
 
 const PublishedVersions: FC = () => {
-  const {flow} = useContext(FlowContext)
-  const [versions, setVersions] = useState<VersionHistories>([])
-
-  const handleGetNotebookVersions = useCallback(async () => {
-    try {
-      const response = await getNotebooksVersions({id: flow.id})
-
-      if (response.status !== 200) {
-        throw new Error(response.data.message)
-      }
-
-      setVersions(response.data)
-    } catch (error) {
-      console.error({error})
-    }
-  }, [flow])
+  const {versions, handleGetNotebookVersions} = useContext(
+    VersionPublishContext
+  )
 
   useEffect(() => {
     if (isFlagEnabled('flowPublishLifecycle')) {

--- a/src/flows/components/header/PublishedVersions.tsx
+++ b/src/flows/components/header/PublishedVersions.tsx
@@ -1,18 +1,9 @@
-import React, {FC, useContext, useEffect} from 'react'
+import React, {FC, useContext} from 'react'
 import VersionBullet from 'src/flows/components/header/VersionBullet'
 import {VersionPublishContext} from 'src/flows/context/version.publish'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 const PublishedVersions: FC = () => {
-  const {versions, handleGetNotebookVersions} = useContext(
-    VersionPublishContext
-  )
-
-  useEffect(() => {
-    if (isFlagEnabled('flowPublishLifecycle')) {
-      handleGetNotebookVersions()
-    }
-  }, [handleGetNotebookVersions])
+  const {versions} = useContext(VersionPublishContext)
 
   if (versions.length === 0) {
     return null

--- a/src/flows/components/header/VersionBullet.scss
+++ b/src/flows/components/header/VersionBullet.scss
@@ -1,0 +1,41 @@
+.publish-version-bullet--button {
+  margin-right: 40px;
+
+  &:hover {
+    cursor: pointer;
+  }
+}
+
+.publish-version-bullet--button::before {
+  content: '';
+  height: 25px;
+  width: 4px;
+  transform: translate(-480%, 0%) rotate(-90deg);
+
+  @media screen and (max-width: $cf-grid--breakpoint-md) {
+    transform: translate(-380%, 0%) rotate(-90deg);
+  }
+  background: #333346;
+  background: -moz-linear-gradient(top, #333346 0%, #8e1fc3 100%);
+  background: -webkit-linear-gradient(top, #333346 0%, #8e1fc3 100%);
+  background: linear-gradient(to bottom, #333346 0%, #8e1fc3 100%);
+}
+
+.publish-version--tooltip {
+  padding: 10px;
+}
+
+.publish-version-bullet--button::after {
+  content: '';
+  height: 25px;
+  width: 4px;
+  transform: translate(480%, 0) rotate(90deg);
+
+  @media screen and (max-width: $cf-grid--breakpoint-md) {
+    transform: translate(380%, 0%) rotate(90deg);
+  }
+  background: #333346;
+  background: -moz-linear-gradient(top, #333346 0%, #8e1fc3 100%);
+  background: -webkit-linear-gradient(top, #333346 0%, #8e1fc3 100%);
+  background: linear-gradient(to bottom, #333346 0%, #8e1fc3 100%);
+}

--- a/src/flows/components/header/VersionBullet.tsx
+++ b/src/flows/components/header/VersionBullet.tsx
@@ -1,0 +1,55 @@
+import React, {createRef, FC, RefObject} from 'react'
+import {
+  Appearance,
+  Bullet,
+  ComponentSize,
+  IconFont,
+  InfluxColors,
+  Popover,
+  PopoverInteraction,
+} from '@influxdata/clockface'
+
+// Types
+import {VersionHistory} from 'src/client/notebooksRoutes'
+
+type Props = {
+  version: VersionHistory
+}
+
+const VersionBullet: FC<Props> = ({version}) => {
+  const triggerRef: RefObject<HTMLElement> = createRef()
+
+  const handleBulletClick = () => {
+    // TODO(ariel): navigate to the version history based on the passed in version
+  }
+
+  return (
+    <>
+      <div onClick={handleBulletClick}>
+        <Bullet
+          className="publish-version-bullet--button"
+          glyph={IconFont.Checkmark_New}
+          size={ComponentSize.Small}
+          color={InfluxColors.White}
+          backgroundColor={InfluxColors.Amethyst}
+          ref={triggerRef}
+        />
+      </div>
+      <Popover
+        appearance={Appearance.Outline}
+        triggerRef={triggerRef}
+        enableDefaultStyles={false}
+        showEvent={PopoverInteraction.Hover}
+        hideEvent={PopoverInteraction.Hover}
+        contents={() => (
+          <h6 className="publish-version--tooltip">
+            Published by {version.publishedBy} at{' '}
+            {new Date(version.publishedAt).toLocaleString()}
+          </h6>
+        )}
+      />
+    </>
+  )
+}
+
+export default VersionBullet

--- a/src/flows/components/header/index.tsx
+++ b/src/flows/components/header/index.tsx
@@ -31,6 +31,7 @@ import {
   List,
 } from '@influxdata/clockface'
 
+import PublishedVersions from 'src/flows/components/header/PublishedVersions'
 import AutoRefreshButton from 'src/flows/components/header/AutoRefreshButton'
 import TimeZoneDropdown from 'src/shared/components/TimeZoneDropdown'
 import TimeRangeDropdown from 'src/flows/components/header/TimeRangeDropdown'
@@ -153,7 +154,7 @@ const FlowHeader: FC = () => {
       try {
         const response = await postNotebooksVersion({id: flow.id})
 
-        if (response.status !== 204) {
+        if (response.status < 200 && response.status > 299) {
           throw new Error(response.data.message)
         }
 
@@ -450,6 +451,13 @@ const FlowHeader: FC = () => {
                 titleText="Export Notebook"
               />
             </FeatureFlag>
+          </Page.ControlBarRight>
+        </Page.ControlBar>
+      )}
+      {isFlagEnabled('flowPublishLifecycle') && (
+        <Page.ControlBar fullWidth>
+          <Page.ControlBarRight>
+            <PublishedVersions />
           </Page.ControlBarRight>
         </Page.ControlBar>
       )}

--- a/src/flows/components/header/index.tsx
+++ b/src/flows/components/header/index.tsx
@@ -154,7 +154,7 @@ const FlowHeader: FC = () => {
       try {
         const response = await postNotebooksVersion({id: flow.id})
 
-        if (response.status < 200 && response.status > 299) {
+        if (response.status !== 200) {
           throw new Error(response.data.message)
         }
 

--- a/src/flows/context/version.publish.tsx
+++ b/src/flows/context/version.publish.tsx
@@ -4,6 +4,7 @@ import React, {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useState,
 } from 'react'
 import {useDispatch} from 'react-redux'
@@ -17,6 +18,7 @@ import {
   postNotebooksVersion,
   VersionHistories,
 } from 'src/client/notebooksRoutes'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {notify} from 'src/shared/actions/notifications'
 import {
   publishNotebookFailed,
@@ -27,14 +29,12 @@ import {
 import {RemoteDataState} from 'src/types'
 
 interface ContextType {
-  handleGetNotebookVersions: () => void
   handlePublish: () => void
   publishLoading: RemoteDataState
   versions: VersionHistories
 }
 
 const DEFAULT_CONTEXT: ContextType = {
-  handleGetNotebookVersions: () => {},
   handlePublish: () => {},
   publishLoading: RemoteDataState.NotStarted,
   versions: [],
@@ -64,6 +64,12 @@ export const VersionPublishProvider: FC = ({children}) => {
     }
   }, [flow.id])
 
+  useEffect(() => {
+    if (isFlagEnabled('flowPublishLifecycle')) {
+      handleGetNotebookVersions()
+    }
+  }, [handleGetNotebookVersions])
+
   const handlePublish = useCallback(async () => {
     try {
       const response = await postNotebooksVersion({id: flow.id})
@@ -84,7 +90,6 @@ export const VersionPublishProvider: FC = ({children}) => {
   return (
     <VersionPublishContext.Provider
       value={{
-        handleGetNotebookVersions,
         handlePublish,
         publishLoading,
         versions,

--- a/src/flows/context/version.publish.tsx
+++ b/src/flows/context/version.publish.tsx
@@ -1,0 +1,96 @@
+// Libraries
+import React, {
+  FC,
+  createContext,
+  useCallback,
+  useContext,
+  useState,
+} from 'react'
+import {useDispatch} from 'react-redux'
+
+// Context
+import {FlowContext} from 'src/flows/context/flow.current'
+
+// Utils
+import {
+  getNotebooksVersions,
+  postNotebooksVersion,
+  VersionHistories,
+} from 'src/client/notebooksRoutes'
+import {notify} from 'src/shared/actions/notifications'
+import {
+  publishNotebookFailed,
+  publishNotebookSuccessful,
+} from 'src/shared/copy/notifications'
+
+// Types
+import {RemoteDataState} from 'src/types'
+
+interface ContextType {
+  handleGetNotebookVersions: () => void
+  handlePublish: () => void
+  publishLoading: RemoteDataState
+  versions: VersionHistories
+}
+
+const DEFAULT_CONTEXT: ContextType = {
+  handleGetNotebookVersions: () => {},
+  handlePublish: () => {},
+  publishLoading: RemoteDataState.NotStarted,
+  versions: [],
+}
+
+export const VersionPublishContext = createContext<ContextType>(DEFAULT_CONTEXT)
+
+export const VersionPublishProvider: FC = ({children}) => {
+  const {flow} = useContext(FlowContext)
+  const dispatch = useDispatch()
+  const [versions, setVersions] = useState([])
+  const [publishLoading, setPublishLoading] = useState<RemoteDataState>(
+    RemoteDataState.NotStarted
+  )
+
+  const handleGetNotebookVersions = useCallback(async () => {
+    try {
+      const response = await getNotebooksVersions({id: flow.id})
+
+      if (response.status !== 200) {
+        throw new Error(response.data.message)
+      }
+
+      setVersions(response.data)
+    } catch (error) {
+      console.error({error})
+    }
+  }, [flow.id])
+
+  const handlePublish = useCallback(async () => {
+    try {
+      const response = await postNotebooksVersion({id: flow.id})
+
+      if (response.status !== 200) {
+        throw new Error(response.data.message)
+      }
+
+      dispatch(notify(publishNotebookSuccessful(flow.name)))
+      setPublishLoading(RemoteDataState.Done)
+      handleGetNotebookVersions()
+    } catch (error) {
+      dispatch(notify(publishNotebookFailed(flow.name)))
+      setPublishLoading(RemoteDataState.Error)
+    }
+  }, [dispatch, handleGetNotebookVersions, flow.id, flow.name])
+
+  return (
+    <VersionPublishContext.Provider
+      value={{
+        handleGetNotebookVersions,
+        handlePublish,
+        publishLoading,
+        versions,
+      }}
+    >
+      {children}
+    </VersionPublishContext.Provider>
+  )
+}

--- a/src/style/chronograf.scss
+++ b/src/style/chronograf.scss
@@ -142,6 +142,7 @@
 @import 'src/buckets/components/createBucketForm/MeasurementSchema.scss';
 @import 'src/writeData/components/AddPluginToConfiguration.scss';
 @import 'src/authorizations/components/customApiTokenOverlay.scss';
+@import 'src/flows/components/header/VersionBullet.scss';
 
 // External
 @import '../../node_modules/@influxdata/react-custom-scrollbars/dist/styles.css';


### PR DESCRIPTION
So KAP was giving me a hard time with a gif, here's a picture:

![Screen Shot 2022-02-07 at 2 29 07 PM](https://user-images.githubusercontent.com/19984220/152883148-c43ca48d-de4f-41ea-aa7e-850f5d1f81b9.png)

### Background

As part of the publish lifecycle work, we're going to want to allow users to scroll through their previous version history in order to potential revert / clone from a specific version of a notebook's published history. 

The purpose of this PR is to allow a simple interface for users to be able to see at a glance their published history (by who and when). This does not fully integrate the full lifecycle of a user viewing their published history, but merely introduces the first step at that.

