### PR TITLE
test: move intercept before visit

### DIFF
--- a/cypress/e2e/oss/onboarding.test.ts
+++ b/cypress/e2e/oss/onboarding.test.ts
@@ -80,6 +80,8 @@ describe('Onboarding', () => {
 
     cy.wait('@orgSetup')
 
+    cy.getByTestID('notification-success').should('be.visible')
+
     cy.get('@orgSetup').then(req => {
       const {
         response: {body},
@@ -116,6 +118,8 @@ describe('Onboarding', () => {
     cy.getByTestID('next').click()
 
     cy.wait('@orgSetup')
+
+    cy.getByTestID('notification-success').should('be.visible')
 
     cy.get('@orgSetup').then(req => {
       const {

--- a/cypress/e2e/oss/onboarding.test.ts
+++ b/cypress/e2e/oss/onboarding.test.ts
@@ -14,25 +14,19 @@ describe('Onboarding Redirect', () => {
 // NOTE: important to test for OSS
 describe('Onboarding', () => {
   beforeEach(() =>
-    cy
-      .flush()
-      .then(() =>
-        cy.wrapEnvironmentVariablesForOss().then(() => cy.visit('onboarding/0'))
-      )
+    cy.flush().then(() => {
+      cy.intercept('api/v2/setup').as('orgSetup')
+      cy.wrapEnvironmentVariablesForOss().then(() => cy.visit('onboarding/0'))
+    })
   )
 
   it('Can Onboard to Quick Start', () => {
-    cy.server()
-
-    // Will want to capture response from this
-    cy.intercept('POST', 'api/v2/setup').as('orgSetup')
-
     // Check and visit splash page
     cy.getByTestID('init-step--head-main').contains('Welcome to InfluxDB')
     cy.getByTestID('credits').contains('Powered by')
     cy.getByTestID('credits').contains('InfluxData')
 
-    // Continue
+    // Continue onboarding
     cy.getByTestID('onboarding-get-started').click()
 
     cy.location('pathname').should('include', 'onboarding/1')
@@ -113,12 +107,7 @@ describe('Onboarding', () => {
   })
 
   it('Can onboard to advanced', () => {
-    cy.server()
-    cy.wrapEnvironmentVariablesForOss()
-
-    cy.intercept('api/v2/setup').as('orgSetup')
-
-    // Continue
+    // Continue onboarding
     cy.getByTestID('onboarding-get-started').click()
     cy.location('pathname').should('include', 'onboarding/1')
 
@@ -149,11 +138,7 @@ describe('Onboarding', () => {
   })
 
   it('Can onboard to configure later', () => {
-    cy.server()
-
-    cy.intercept('api/v2/setup').as('orgSetup')
-
-    // Continue
+    // Continue onboarding
     cy.getByTestID('onboarding-get-started').click()
     cy.location('pathname').should('include', 'onboarding/1')
 


### PR DESCRIPTION
Visiting before intercepting in Cypress is known to cause flakiness.

- move all `.intercept`s into the `beforeEach` and before `.visit`
- remove the unnecessary and deprecated `cy.server`
- assert the notification banner for the successful creation of a user in all 3 onboarding tests