### PR TITLE
fix: save a notebook if it is ephemeral before linking

### DIFF
--- a/src/flows/pipes/Schedule/ExportTaskButton.tsx
+++ b/src/flows/pipes/Schedule/ExportTaskButton.tsx
@@ -106,8 +106,7 @@ const ExportTaskButton: FC<Props> = ({
         if (isFlagEnabled('createWithFlows')) {
           new Promise(resolve => {
             if (flow.id) {
-              resolve(flow.id)
-              return
+              return resolve(flow.id)
             }
 
             return add(flow).then(id => resolve(id))

--- a/src/flows/pipes/Schedule/ExportTaskButton.tsx
+++ b/src/flows/pipes/Schedule/ExportTaskButton.tsx
@@ -106,10 +106,11 @@ const ExportTaskButton: FC<Props> = ({
         if (isFlagEnabled('createWithFlows')) {
           new Promise(resolve => {
             if (flow.id) {
-              return resolve(flow.id)
+              resolve(flow.id)
+              return
             }
 
-            return add(flow).then(id => resolve(id))
+            add(flow).then(id => resolve(id))
           })
             .then(id => {
               return fetch(`/api/v2private/notebooks/${id}/resources`, {


### PR DESCRIPTION
we've been waiting on trying the new task publish lifecycle because it didn't work when the notebook isn't saved. this isn't the default in dev mode, and i'm pretty sure we're inverting this pattern to make the publish button responsible for exporting resources, but it's currently the way prod works.

SO WE'RE SHORING IT UP UNTIL THEN