### PR TITLE
feat: Add query time to Operator view

### DIFF
--- a/cypress/e2e/cloud/operatorRO.test.ts
+++ b/cypress/e2e/cloud/operatorRO.test.ts
@@ -110,7 +110,6 @@ describe('Operator Page', () => {
       'bucket.maxRetentionDuration',
       'notificationRule.maxNotifications',
       'dashboard.maxDashboards',
-      'dashboard.queryTime',
       'task.maxTasks',
       'check.maxChecks',
       'notificationRule.blockedNotificationRules',

--- a/cypress/e2e/cloud/operatorRO.test.ts
+++ b/cypress/e2e/cloud/operatorRO.test.ts
@@ -105,6 +105,7 @@ describe('Operator Page', () => {
       'rate.readKBs',
       'rate.writeKBs',
       'rate.cardinality',
+      'rate.queryTime',
       'bucket.maxBuckets',
       'bucket.maxRetentionDuration',
       'notificationRule.maxNotifications',

--- a/cypress/e2e/cloud/operatorRO.test.ts
+++ b/cypress/e2e/cloud/operatorRO.test.ts
@@ -109,6 +109,7 @@ describe('Operator Page', () => {
       'bucket.maxRetentionDuration',
       'notificationRule.maxNotifications',
       'dashboard.maxDashboards',
+      'dashboard.queryTime',
       'task.maxTasks',
       'check.maxChecks',
       'notificationRule.blockedNotificationRules',

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "cy": "CYPRESS_dexUrl=https://$INGRESS_HOST:$PORT_HTTPS CYPRESS_baseUrl=http://localhost:9999 cypress open",
     "cy:dev": "source ../monitor-ci/.env && CYPRESS_dexUrl=CLOUD CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{cloud,shared}/**/*.*'",
     "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_dexUrl=OSS CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{oss,shared}/**/*.*'",
-    "generate": "export SHA=2670263b84efd14387ffcaa01102db328cded3e4 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
+    "generate": "export SHA=803dd751c45e2757467df5b100022b526152e1a6 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-meta": "if [ -z \"${CLOUD_URL}\" ]; then yarn generate-meta-oss; else yarn generate-meta-cloud; fi",
     "generate-meta-oss": "yarn oss-api && yarn notebooks && yarn unity && yarn annotations-oss && yarn pinned && yarn mapsd-oss && yarn cloudPriv",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "cy": "CYPRESS_dexUrl=https://$INGRESS_HOST:$PORT_HTTPS CYPRESS_baseUrl=http://localhost:9999 cypress open",
     "cy:dev": "source ../monitor-ci/.env && CYPRESS_dexUrl=CLOUD CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{cloud,shared}/**/*.*'",
     "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_dexUrl=OSS CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{oss,shared}/**/*.*'",
-    "generate": "export SHA=803dd751c45e2757467df5b100022b526152e1a6 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
+    "generate": "export SHA=9933c20c69cde9e139dcb43af06b388c49761e72 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-meta": "if [ -z \"${CLOUD_URL}\" ]; then yarn generate-meta-oss; else yarn generate-meta-cloud; fi",
     "generate-meta-oss": "yarn oss-api && yarn notebooks && yarn unity && yarn annotations-oss && yarn pinned && yarn mapsd-oss && yarn cloudPriv",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "cy": "CYPRESS_dexUrl=https://$INGRESS_HOST:$PORT_HTTPS CYPRESS_baseUrl=http://localhost:9999 cypress open",
     "cy:dev": "source ../monitor-ci/.env && CYPRESS_dexUrl=CLOUD CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{cloud,shared}/**/*.*'",
     "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_dexUrl=OSS CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{oss,shared}/**/*.*'",
-    "generate": "export SHA=9933c20c69cde9e139dcb43af06b388c49761e72 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
+    "generate": "export SHA=1db94907acd4f8cb1eea002980af72edb2822990 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-meta": "if [ -z \"${CLOUD_URL}\" ]; then yarn generate-meta-oss; else yarn generate-meta-cloud; fi",
     "generate-meta-oss": "yarn oss-api && yarn notebooks && yarn unity && yarn annotations-oss && yarn pinned && yarn mapsd-oss && yarn cloudPriv",

--- a/src/billing/components/Free/OrgLimits.tsx
+++ b/src/billing/components/Free/OrgLimits.tsx
@@ -43,19 +43,21 @@ const OrgLimits: FC = () => {
             })
         }
         if (name === 'rate') {
-          return Object.entries(value).map(([n, v]: [string, Limit]) => {
-            return (
-              <Grid.Column
-                key={n}
-                widthXS={Columns.Twelve}
-                widthSM={Columns.Six}
-                widthMD={Columns.Four}
-                widthLG={Columns.Three}
-              >
-                <OrgLimitStat name={n} value={v.maxAllowed} />
-              </Grid.Column>
-            )
-          })
+          return Object.entries(value)
+            .filter(([n]) => n !== 'queryTime')
+            .map(([n, v]: [string, Limit]) => {
+              return (
+                <Grid.Column
+                  key={n}
+                  widthXS={Columns.Twelve}
+                  widthSM={Columns.Six}
+                  widthMD={Columns.Four}
+                  widthLG={Columns.Three}
+                >
+                  <OrgLimitStat name={n} value={v.maxAllowed} />
+                </Grid.Column>
+              )
+            })
         }
         return (
           <Grid.Column

--- a/src/billing/utils/timeHelpers.test.ts
+++ b/src/billing/utils/timeHelpers.test.ts
@@ -1,9 +1,11 @@
 import {
-  nsToHours,
   hoursToDays,
   hoursToNs,
-  nsToDays,
   minToSeconds,
+  nsToDays,
+  nsToHours,
+  nsToSeconds,
+  secondsToNs,
 } from './timeHelpers'
 
 it('converts nanoseconds to hours', () => {
@@ -26,10 +28,20 @@ it('converts hours to nanoseconds', () => {
   expect(hoursToNs(720)).toEqual(2592000000000000)
 })
 
+it('converts nanoseconds to seconds', () => {
+  expect(nsToSeconds(1500000000000)).toEqual(1500)
+})
+
+it('converts seconds to nanoseconds', () => {
+  expect(secondsToNs(1500)).toEqual(1500000000000)
+})
+
 it('does not convert -1 (disabled)', () => {
   expect(nsToHours(-1)).toEqual(-1)
   expect(hoursToDays(-1)).toEqual(-1)
   expect(nsToDays(-1)).toEqual(-1)
   expect(minToSeconds(-1)).toEqual(-1)
   expect(hoursToNs(-1)).toEqual(-1)
+  expect(nsToSeconds(-1)).toEqual(-1)
+  expect(secondsToNs(-1)).toEqual(-1)
 })

--- a/src/billing/utils/timeHelpers.ts
+++ b/src/billing/utils/timeHelpers.ts
@@ -10,6 +10,8 @@ const secondsPerHour = minutesPerHour * secondsPerMinute
 const nanoPerHour =
   secondsPerHour * milliPerSecond * microPerMilli * nanoPerMicro
 
+const nanoPerSecond = milliPerSecond * microPerMilli * nanoPerMicro
+
 export const nsToHours = (ns: number): number => {
   if (ns === -1) {
     return ns
@@ -57,4 +59,20 @@ export const minToSeconds = (min: number) => {
     return min
   }
   return min * secondsPerMinute
+}
+
+export const nsToSeconds = (ns: number): number => {
+  if (ns === -1) {
+    return ns
+  }
+
+  return ns / nanoPerSecond
+}
+
+export const secondsToNs = (seconds: number): number => {
+  if (seconds === -1) {
+    return seconds
+  }
+
+  return seconds * nanoPerSecond
 }

--- a/src/billing/utils/timeHelpers.ts
+++ b/src/billing/utils/timeHelpers.ts
@@ -7,10 +7,9 @@ const hoursPerDay = 24
 
 const secondsPerHour = minutesPerHour * secondsPerMinute
 
-const nanoPerHour =
-  secondsPerHour * milliPerSecond * microPerMilli * nanoPerMicro
-
 const nanoPerSecond = milliPerSecond * microPerMilli * nanoPerMicro
+
+const nanoPerHour = secondsPerHour * nanoPerSecond
 
 export const nsToHours = (ns: number): number => {
   if (ns === -1) {

--- a/src/cloud/actions/limits.ts
+++ b/src/cloud/actions/limits.ts
@@ -58,7 +58,7 @@ export enum ActionTypes {
   SetChecksLimitStatus = 'SET_CHECKS_LIMIT_STATUS',
   SetRulesLimitStatus = 'SET_RULES_LIMIT_STATUS',
   SetEndpointsLimitStatus = 'SET_ENDPOINTS_LIMIT_STATUS',
-  SetQueryTimeLimitStatus = 'SET_QUERY_TIME_LIMIT_STATUS',
+  SetQueryTimeRateLimitStatus = 'SET_QUERY_TIME_RATE_LIMIT_STATUS',
   SetReadRateLimitStatus = 'SET_READ_RATE_LIMIT_STATUS',
   SetWriteRateLimitStatus = 'SET_WRITE_RATE_LIMIT_STATUS',
   SetCardinalityLimitStatus = 'SET_CARDINALITY_LIMIT_STATUS',
@@ -73,7 +73,7 @@ export type Actions =
   | SetChecksLimitStatus
   | SetRulesLimitStatus
   | SetEndpointsLimitStatus
-  | SetQueryTimeLimitStatus
+  | SetQueryTimeRateLimitStatus
   | SetReadRateLimitStatus
   | SetWriteRateLimitStatus
   | SetCardinalityLimitStatus
@@ -174,16 +174,16 @@ export const setEndpointsLimitStatus = (
   }
 }
 
-export interface SetQueryTimeLimitStatus {
-  type: ActionTypes.SetQueryTimeLimitStatus
+export interface SetQueryTimeRateLimitStatus {
+  type: ActionTypes.SetQueryTimeRateLimitStatus
   payload: {limitStatus: LimitStatus['status']}
 }
 
-export const SetQueryTimeLimitStatus = (
+export const SetQueryTimeRateLimitStatus = (
   limitStatus: LimitStatus['status']
-): SetQueryTimeLimitStatus => {
+): SetQueryTimeRateLimitStatus => {
   return {
-    type: ActionTypes.SetQueryTimeLimitStatus,
+    type: ActionTypes.SetQueryTimeRateLimitStatus,
     payload: {limitStatus},
   }
 }

--- a/src/cloud/actions/limits.ts
+++ b/src/cloud/actions/limits.ts
@@ -58,6 +58,7 @@ export enum ActionTypes {
   SetChecksLimitStatus = 'SET_CHECKS_LIMIT_STATUS',
   SetRulesLimitStatus = 'SET_RULES_LIMIT_STATUS',
   SetEndpointsLimitStatus = 'SET_ENDPOINTS_LIMIT_STATUS',
+  SetQueryTimeLimitStatus = 'SET_QUERY_TIME_LIMIT_STATUS',
   SetReadRateLimitStatus = 'SET_READ_RATE_LIMIT_STATUS',
   SetWriteRateLimitStatus = 'SET_WRITE_RATE_LIMIT_STATUS',
   SetCardinalityLimitStatus = 'SET_CARDINALITY_LIMIT_STATUS',
@@ -72,6 +73,7 @@ export type Actions =
   | SetChecksLimitStatus
   | SetRulesLimitStatus
   | SetEndpointsLimitStatus
+  | SetQueryTimeLimitStatus
   | SetReadRateLimitStatus
   | SetWriteRateLimitStatus
   | SetCardinalityLimitStatus
@@ -168,6 +170,20 @@ export const setEndpointsLimitStatus = (
 ): SetEndpointsLimitStatus => {
   return {
     type: ActionTypes.SetEndpointsLimitStatus,
+    payload: {limitStatus},
+  }
+}
+
+export interface SetQueryTimeLimitStatus {
+  type: ActionTypes.SetQueryTimeLimitStatus
+  payload: {limitStatus: LimitStatus['status']}
+}
+
+export const SetQueryTimeLimitStatus = (
+  limitStatus: LimitStatus['status']
+): SetQueryTimeLimitStatus => {
+  return {
+    type: ActionTypes.SetQueryTimeLimitStatus,
     payload: {limitStatus},
   }
 }

--- a/src/cloud/reducers/limits.ts
+++ b/src/cloud/reducers/limits.ts
@@ -145,7 +145,7 @@ export const limitsReducer = (
         return
       }
 
-      case ActionTypes.SetQueryTimeLimitStatus: {
+      case ActionTypes.SetQueryTimeRateLimitStatus: {
         draftState.rate.queryTime.limitStatus = action.payload.limitStatus
         return
       }

--- a/src/cloud/reducers/limits.ts
+++ b/src/cloud/reducers/limits.ts
@@ -19,6 +19,7 @@ export interface LimitsState {
   endpoints: LimitWithBlocked
   rate: {
     readKBs: Limit
+    queryTime: Limit
     writeKBs: Limit
     cardinality: Limit
   }
@@ -41,6 +42,7 @@ export const defaultState: LimitsState = {
   endpoints: defaultLimitWithBlocked,
   rate: {
     readKBs: defaultLimit,
+    queryTime: defaultLimit,
     writeKBs: defaultLimit,
     cardinality: defaultLimit,
   },
@@ -102,8 +104,9 @@ export const limitsReducer = (
         }
 
         if (limits.rate) {
-          const {readKBs, writeKBs, cardinality} = limits.rate
+          const {queryTime, readKBs, writeKBs, cardinality} = limits.rate
 
+          draftState.rate.queryTime.maxAllowed = queryTime
           draftState.rate.readKBs.maxAllowed = readKBs
           draftState.rate.writeKBs.maxAllowed = writeKBs
           draftState.rate.cardinality.maxAllowed = cardinality
@@ -139,6 +142,11 @@ export const limitsReducer = (
 
       case ActionTypes.SetEndpointsLimitStatus: {
         draftState.endpoints.limitStatus = action.payload.limitStatus
+        return
+      }
+
+      case ActionTypes.SetQueryTimeLimitStatus: {
+        draftState.rate.queryTime.limitStatus = action.payload.limitStatus
         return
       }
 

--- a/src/cloud/reducers/limits.ts
+++ b/src/cloud/reducers/limits.ts
@@ -106,7 +106,7 @@ export const limitsReducer = (
         if (limits.rate) {
           const {queryTime, readKBs, writeKBs, cardinality} = limits.rate
 
-          draftState.rate.queryTime.maxAllowed = queryTime
+          draftState.rate.queryTime.maxAllowed = queryTime / 1e9
           draftState.rate.readKBs.maxAllowed = readKBs
           draftState.rate.writeKBs.maxAllowed = writeKBs
           draftState.rate.cardinality.maxAllowed = cardinality

--- a/src/operator/OrgOverlay.tsx
+++ b/src/operator/OrgOverlay.tsx
@@ -204,6 +204,17 @@ const OrgOverlay: FC = () => {
                   </Grid.Column>
                 </Grid.Row>
                 <Grid.Row>
+                  <Grid.Column widthMD={Columns.Three}>
+                    <Form.Label label="Query Time (seconds)" />
+                    <LimitsField
+                      type={InputType.Number}
+                      name="dashboard.queryTime"
+                      limits={limits}
+                      onChangeLimits={setLimits}
+                    />
+                  </Grid.Column>
+                </Grid.Row>
+                <Grid.Row>
                   <h4>Notification Rules</h4>
                   <Grid.Column widthMD={Columns.Three}>
                     <Form.Label label="Blocked Notification Rules" />

--- a/src/operator/OrgOverlay.tsx
+++ b/src/operator/OrgOverlay.tsx
@@ -147,6 +147,17 @@ const OrgOverlay: FC = () => {
                 </Grid.Row>
                 <Grid.Row>
                   <Grid.Column widthMD={Columns.Three}>
+                    <Form.Label label="Query Time (seconds)" />
+                    <LimitsField
+                      type={InputType.Number}
+                      name="rate.queryTime"
+                      limits={limits}
+                      onChangeLimits={setLimits}
+                    />
+                  </Grid.Column>
+                </Grid.Row>
+                <Grid.Row>
+                  <Grid.Column widthMD={Columns.Three}>
                     <Form.Label label="Max Buckets" />
                     <LimitsField
                       type={InputType.Number}
@@ -198,17 +209,6 @@ const OrgOverlay: FC = () => {
                     <LimitsField
                       type={InputType.Number}
                       name="check.maxChecks"
-                      limits={limits}
-                      onChangeLimits={setLimits}
-                    />
-                  </Grid.Column>
-                </Grid.Row>
-                <Grid.Row>
-                  <Grid.Column widthMD={Columns.Three}>
-                    <Form.Label label="Query Time (seconds)" />
-                    <LimitsField
-                      type={InputType.Number}
-                      name="dashboard.queryTime"
                       limits={limits}
                       onChangeLimits={setLimits}
                     />

--- a/src/operator/context/overlay.tsx
+++ b/src/operator/context/overlay.tsx
@@ -18,7 +18,7 @@ import {
 import {toDisplayLimits} from 'src/operator/utils'
 
 // Types
-import {OrgLimits, OperatorOrg} from 'src/types'
+import {OperatorOrgLimits, OperatorOrg} from 'src/types'
 import {RemoteDataState} from 'src/types'
 
 export type Props = {
@@ -26,26 +26,26 @@ export type Props = {
 }
 
 export interface OverlayContextType {
-  limits: OrgLimits
+  limits: OperatorOrgLimits
   limitsStatus: RemoteDataState
   handleGetLimits: (id: string) => void
   handleGetOrg: (id: string) => void
-  handleUpdateLimits: (id: string, limits: OrgLimits) => void
+  handleUpdateLimits: (id: string, limits: OperatorOrgLimits) => void
   organization: OperatorOrg
   orgStatus: RemoteDataState
-  setLimits: (_: OrgLimits) => void
+  setLimits: (_: OperatorOrgLimits) => void
   updateLimitStatus: RemoteDataState
 }
 
 export const DEFAULT_CONTEXT: OverlayContextType = {
   handleGetLimits: (_: string) => {},
   handleGetOrg: (_: string) => {},
-  handleUpdateLimits: (_id: string, _limits: OrgLimits) => {},
+  handleUpdateLimits: (_id: string, _limits: OperatorOrgLimits) => {},
   limits: null,
   limitsStatus: RemoteDataState.NotStarted,
   organization: null,
   orgStatus: RemoteDataState.NotStarted,
-  setLimits: (_: OrgLimits) => {},
+  setLimits: (_: OperatorOrgLimits) => {},
   updateLimitStatus: RemoteDataState.NotStarted,
 }
 
@@ -111,7 +111,7 @@ export const OverlayProvider: FC<Props> = React.memo(({children}) => {
   )
 
   const handleUpdateLimits = useCallback(
-    async (id: string, updatedLimits: OrgLimits) => {
+    async (id: string, updatedLimits: OperatorOrgLimits) => {
       try {
         setUpdateLimitStatus(RemoteDataState.Loading)
         await putOperatorOrgsLimits({orgId: id, data: updatedLimits})

--- a/src/operator/utils.test.ts
+++ b/src/operator/utils.test.ts
@@ -1,8 +1,8 @@
-import {OrgLimits} from 'src/types'
+import {OperatorOrgLimits} from 'src/types'
 import {fromDisplayLimits, toDisplayLimits} from 'src/operator/utils'
 
 describe('converting limits for display', () => {
-  const limits: OrgLimits = {
+  const limits: OperatorOrgLimits = {
     bucket: {
       maxBuckets: 2,
       maxRetentionDuration: 86400000000000,
@@ -23,6 +23,7 @@ describe('converting limits for display', () => {
     orgID: 'ID',
     rate: {
       cardinality: 10000,
+      queryTime: 1500000000000,
       readKBs: 100000,
       writeKBs: 1000,
     },
@@ -31,7 +32,7 @@ describe('converting limits for display', () => {
     },
   }
 
-  it('converts max retention duration from ns to hours', () => {
+  it('converts max retention duration from ns to hours and query time from ns to seconds', () => {
     const actual = toDisplayLimits(limits)
     const expected = {
       ...limits,
@@ -39,12 +40,16 @@ describe('converting limits for display', () => {
         ...limits.bucket,
         maxRetentionDuration: 24,
       },
+      rate: {
+        ...limits.rate,
+        queryTime: 1500,
+      },
     }
 
     expect(actual).toEqual(expected)
   })
 
-  it('converts max retention duration from hours to ns', () => {
+  it('converts max retention duration from hours to ns and query time from seconds to ns', () => {
     const displayLimits = toDisplayLimits(limits)
 
     expect(fromDisplayLimits(displayLimits)).toEqual(limits)

--- a/src/operator/utils.ts
+++ b/src/operator/utils.ts
@@ -1,12 +1,17 @@
-import {hoursToNs, nsToHours} from 'src/billing/utils/timeHelpers'
+import {
+  hoursToNs,
+  nsToHours,
+  nsToSeconds,
+  secondsToNs,
+} from 'src/billing/utils/timeHelpers'
 
 // Types
-import {OrgLimits} from 'src/types'
+import {OperatorOrgLimits} from 'src/types'
 
 const updateMaxRetentionWithCallback = (
-  limits: OrgLimits,
+  limits: OperatorOrgLimits,
   cb: typeof nsToHours | typeof hoursToNs
-): OrgLimits => ({
+): OperatorOrgLimits => ({
   ...limits,
   bucket: {
     ...limits?.bucket,
@@ -14,8 +19,27 @@ const updateMaxRetentionWithCallback = (
   },
 })
 
-export const toDisplayLimits = (limits: OrgLimits): OrgLimits =>
-  updateMaxRetentionWithCallback(limits, nsToHours)
+const updateQueryTimeWithCallback = (
+  limits: OperatorOrgLimits,
+  cb: typeof nsToSeconds | typeof secondsToNs
+): OperatorOrgLimits => ({
+  ...limits,
+  rate: {
+    ...limits?.rate,
+    queryTime: cb(limits?.rate?.queryTime),
+  },
+})
 
-export const fromDisplayLimits = (displayLimits: OrgLimits): OrgLimits =>
-  updateMaxRetentionWithCallback(displayLimits, hoursToNs)
+export const toDisplayLimits = (
+  limits: OperatorOrgLimits
+): OperatorOrgLimits => {
+  const newLimits = updateMaxRetentionWithCallback(limits, nsToHours)
+  return updateQueryTimeWithCallback(newLimits, nsToSeconds)
+}
+
+export const fromDisplayLimits = (
+  displayLimits: OperatorOrgLimits
+): OperatorOrgLimits => {
+  const newLimits = updateMaxRetentionWithCallback(displayLimits, hoursToNs)
+  return updateQueryTimeWithCallback(newLimits, secondsToNs)
+}

--- a/src/types/operator.ts
+++ b/src/types/operator.ts
@@ -4,6 +4,7 @@ export {
   OperatorOrgLimits,
   Organization as OperatorOrg,
   Organizations,
+  OrgLimits,
   User as OperatorUser,
 } from 'src/client/unityRoutes'
 

--- a/src/types/operator.ts
+++ b/src/types/operator.ts
@@ -1,9 +1,9 @@
 export {
   OperatorAccount,
   OperatorAccounts,
+  OperatorOrgLimits,
   Organization as OperatorOrg,
   Organizations,
-  OrgLimits,
   User as OperatorUser,
 } from 'src/client/unityRoutes'
 


### PR DESCRIPTION
Part of Quartz #5810

I added `query time` to the limits display in `Operator` view. This also required changing to the new `OperatorOrgLimits` type in the operator related files. Additionally `query time` was added to the `LimitsReducer` to allow for update request in Operator view, but is filtered from `LimitStatus` to avoid displaying the limit type for non-Operators. 

Non-operator view: 
<img width="1748" alt="Screen Shot 2022-02-08 at 1 06 33 PM" src="https://user-images.githubusercontent.com/64158805/153093357-6a63b7ae-fcd1-4b73-80c1-4ff58902b776.png">

Operator view and function:
https://user-images.githubusercontent.com/64158805/153093491-c4920cf2-1856-4041-a5c7-c5197518e6f4.mp4


