### PR TITLE
feat(ecommerce): Hide remove last user in operator page

### DIFF
--- a/src/operator/account/AssociatedUsersTable.tsx
+++ b/src/operator/account/AssociatedUsersTable.tsx
@@ -21,6 +21,7 @@ import {OperatorContext} from 'src/operator/context/operator'
 
 const AssociatedTableUsers: FC = () => {
   const {account, handleRemoveUserFromAccount} = useContext(AccountContext)
+  const hasMultipleUsers = account?.users?.length > 1
   const {hasWritePermissions} = useContext(OperatorContext)
 
   return (
@@ -41,7 +42,7 @@ const AssociatedTableUsers: FC = () => {
                 resource={resource}
                 infos={acctUserColumnInfo}
               >
-                {hasWritePermissions && (
+                {hasWritePermissions && hasMultipleUsers && (
                   <RemoveFromAccount
                     removeUser={async () => {
                       await handleRemoveUserFromAccount(resource.id)


### PR DESCRIPTION
Closes influxdata/quartz#5656
Part of influxdata/quartz#5941

Hides button to delete the last user of an account from the operator page when they are the last user.