### PR TITLE
feat: re-enable exporting/importing of dashboards using v2 templates

### DIFF
--- a/src/dashboards/actions/thunks.ts
+++ b/src/dashboards/actions/thunks.ts
@@ -289,9 +289,10 @@ export const getDashboards = () => async (
   }
 }
 
-export const createDashboardFromTemplate = (
-  template: api.Template
-) => async (dispatch, getState: GetState) => {
+export const createDashboardFromTemplate = (template: api.Template) => async (
+  dispatch,
+  getState: GetState
+) => {
   try {
     const org = getOrg(getState())
 

--- a/src/dashboards/actions/thunks.ts
+++ b/src/dashboards/actions/thunks.ts
@@ -7,7 +7,7 @@ import {get} from 'lodash'
 // APIs
 import * as dashAPI from 'src/dashboards/apis'
 import * as api from 'src/client'
-import * as tempAPI from 'src/templates/api'
+import {createDashboardFromPkgrTemplate} from 'src/templates/api'
 import {createCellWithView} from 'src/cells/actions/thunks'
 
 // Schemas
@@ -62,7 +62,6 @@ import {
   GetState,
   View,
   Cell,
-  DashboardTemplate,
   Label,
   RemoteDataState,
   DashboardEntities,
@@ -291,12 +290,12 @@ export const getDashboards = () => async (
 }
 
 export const createDashboardFromTemplate = (
-  template: DashboardTemplate
+  template: api.Template
 ) => async (dispatch, getState: GetState) => {
   try {
     const org = getOrg(getState())
 
-    await tempAPI.createDashboardFromTemplate(template, org.id)
+    await createDashboardFromPkgrTemplate(template, org.id)
 
     const resp = await api.getDashboards({query: {orgID: org.id}})
 

--- a/src/dashboards/apis/index.ts
+++ b/src/dashboards/apis/index.ts
@@ -1,5 +1,9 @@
 // APIs
 import * as api from 'src/client'
+import {postTemplatesExport} from 'src/client'
+
+// Utils
+import {downloadTextFile} from 'src/shared/utils/download'
 
 // Types
 import {Cell, View, NewView, RemoteDataState} from 'src/types'
@@ -87,4 +91,20 @@ export const cloneUtilFunc = async (
       })
     }
   })
+}
+
+export const downloadDashboardTemplate = async (dashboard): Promise<void> => {
+  const resp = await postTemplatesExport({
+    data: {
+      resources: [
+        {
+          kind: 'Dashboard',
+          id: dashboard.id,
+        },
+      ],
+    },
+  })
+
+  const data = await resp.data
+  downloadTextFile(JSON.stringify(data), dashboard.name, '.json', 'text/json')
 }

--- a/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -3,6 +3,8 @@ import React, {createRef, PureComponent, RefObject} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
+import {downloadDashboardTemplate} from 'src/dashboards/apis'
+
 // Components
 import {
   IconFont,
@@ -182,6 +184,14 @@ class DashboardCard extends PureComponent<Props> {
           contents={() => (
             <List>
               <List.Item
+                onClick={this.handleExport}
+                size={ComponentSize.Small}
+                style={{fontWeight: 500}}
+                testID="context-export-dashboard"
+              >
+                Export
+              </List.Item>
+              <List.Item
                 onClick={this.handleCloneDashboard}
                 size={ComponentSize.Small}
                 style={{fontWeight: 500}}
@@ -261,6 +271,10 @@ class DashboardCard extends PureComponent<Props> {
 
     onRemoveDashboardLabel(id, label)
   }
+
+  private handleExport = () => {
+    downloadDashboardTemplate(this.props.dashboard)
+  }
 }
 
 const mdtp = {
@@ -273,13 +287,15 @@ const mdtp = {
   sendNotification: notify,
 }
 
-const mstp = (state: AppState) => {
+const mstp = (state: AppState, props: OwnProps) => {
+  const dashboard = state.resources.dashboards.byID[props.id]
   const me = getMe(state)
   const org = getOrg(state)
 
   return {
-    org,
+    dashboard,
     me,
+    org,
   }
 }
 const connector = connect(mstp, mdtp)

--- a/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -71,6 +71,9 @@ interface OwnProps {
 type ReduxProps = ConnectedProps<typeof connector>
 type Props = OwnProps & ReduxProps & RouteComponentProps<{orgID: string}>
 
+const fontWeight = {fontWeight: '500px'}
+const minWidth = {minWidth: '165px'}
+
 class DashboardCard extends PureComponent<Props> {
   public render() {
     const {
@@ -180,21 +183,21 @@ class DashboardCard extends PureComponent<Props> {
         <Popover
           appearance={Appearance.Outline}
           enableDefaultStyles={false}
-          style={{minWidth: '112px'}}
+          style={minWidth}
           contents={() => (
             <List>
               <List.Item
                 onClick={this.handleExport}
                 size={ComponentSize.Small}
-                style={{fontWeight: 500}}
+                style={fontWeight}
                 testID="context-export-dashboard"
               >
-                Export
+                Download Template
               </List.Item>
               <List.Item
                 onClick={this.handleCloneDashboard}
                 size={ComponentSize.Small}
-                style={{fontWeight: 500}}
+                style={fontWeight}
                 testID="context-clone-dashboard"
               >
                 Clone
@@ -204,7 +207,7 @@ class DashboardCard extends PureComponent<Props> {
                   onClick={this.handlePinDashboard}
                   disabled={this.props.isPinned}
                   size={ComponentSize.Small}
-                  style={{fontWeight: 500}}
+                  style={fontWeight}
                   testID="context-pin-dashboard"
                 >
                   Pin

--- a/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {RouteComponentProps} from 'react-router-dom'
+import {Route, RouteComponentProps, Switch} from 'react-router-dom'
 import {connect, ConnectedProps} from 'react-redux'
 
 // Decorators
@@ -14,6 +14,7 @@ import AddResourceDropdown from 'src/shared/components/AddResourceDropdown'
 import GetAssetLimits from 'src/cloud/components/GetAssetLimits'
 import RateLimitAlert from 'src/cloud/components/RateLimitAlert'
 import ResourceSortDropdown from 'src/shared/components/resource_sort_dropdown/ResourceSortDropdown'
+import DashboardImportOverlay from 'src/dashboards/components/DashboardImportOverlay'
 
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
@@ -84,6 +85,7 @@ class DashboardIndex extends PureComponent<Props, State> {
               <Page.ControlBarRight>
                 <AddResourceDropdown
                   onSelectNew={createDashboard}
+                  onSelectImport={this.summonImportOverlay}
                   onSelectTemplate={this.summonTemplatePage}
                   resourceName="Dashboard"
                   limitStatus={limitStatus}
@@ -111,6 +113,12 @@ class DashboardIndex extends PureComponent<Props, State> {
             </Page.Contents>
           </ErrorBoundary>
         </Page>
+        <Switch>
+          <Route
+            path="/orgs/:orgID/dashboards-list/import"
+            component={DashboardImportOverlay}
+          />
+        </Switch>
       </>
     )
   }
@@ -125,6 +133,16 @@ class DashboardIndex extends PureComponent<Props, State> {
     sortType: SortTypes
   ): void => {
     this.props.setDashboardSort({sortKey, sortDirection, sortType})
+  }
+
+  private summonImportOverlay = (): void => {
+    const {
+      history,
+      match: {
+        params: {orgID},
+      },
+    } = this.props
+    history.push(`/orgs/${orgID}/dashboards-list/import`)
   }
 
   private summonTemplatePage = (): void => {

--- a/src/dashboards/components/dashboard_index/DashboardsIndexContentsPaginated.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardsIndexContentsPaginated.tsx
@@ -140,6 +140,7 @@ class DashboardsIndexContents extends Component<Props> implements Pageable {
           searchTerm={searchTerm}
           onCreateDashboard={onCreateDashboard}
           summonImportFromTemplateOverlay={this.summonImportFromTemplateOverlay}
+          summonImportOverlay={this.summonImportOverlay}
         />
       )
     }
@@ -167,6 +168,16 @@ class DashboardsIndexContents extends Component<Props> implements Pageable {
         />
       </>
     )
+  }
+
+  private summonImportOverlay = (): void => {
+    const {
+      history,
+      match: {
+        params: {orgID},
+      },
+    } = this.props
+    history.push(`/orgs/${orgID}/dashboards-list/import`)
   }
 
   private summonImportFromTemplateOverlay = (): void => {

--- a/src/dashboards/components/dashboard_index/DashboardsIndexPaginated.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardsIndexPaginated.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {RouteComponentProps} from 'react-router-dom'
+import {Route, RouteComponentProps, Switch} from 'react-router-dom'
 import {connect, ConnectedProps} from 'react-redux'
 import {AutoSizer} from 'react-virtualized'
 
@@ -22,6 +22,7 @@ import AddResourceDropdown from 'src/shared/components/AddResourceDropdown'
 import GetAssetLimits from 'src/cloud/components/GetAssetLimits'
 import RateLimitAlert from 'src/cloud/components/RateLimitAlert'
 import ResourceSortDropdown from 'src/shared/components/resource_sort_dropdown/ResourceSortDropdown'
+import DashboardImportOverlay from 'src/dashboards/components/DashboardImportOverlay'
 
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
@@ -141,6 +142,7 @@ class DashboardIndex extends PureComponent<Props, State> {
                 <AddResourceDropdown
                   onSelectNew={createDashboard}
                   onSelectTemplate={this.summonTemplatePage}
+                  onSelectImport={this.summonImportOverlay}
                   resourceName="Dashboard"
                   limitStatus={limitStatus}
                 />
@@ -186,8 +188,24 @@ class DashboardIndex extends PureComponent<Props, State> {
             </Page.Contents>
           </ErrorBoundary>
         </Page>
+        <Switch>
+          <Route
+            path="/orgs/:orgID/dashboards-list/import"
+            component={DashboardImportOverlay}
+          />
+        </Switch>
       </SpinnerContainer>
     )
+  }
+
+  private summonImportOverlay = (): void => {
+    const {
+      history,
+      match: {
+        params: {orgID},
+      },
+    } = this.props
+    history.push(`/orgs/${orgID}/dashboards-list/import`)
   }
 
   private handleFilterDashboards = (searchTerm: string): void => {

--- a/src/dashboards/components/dashboard_index/DashboardsTableEmpty.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardsTableEmpty.tsx
@@ -16,12 +16,14 @@ import {ResourceType} from 'src/types'
 interface ComponentProps {
   searchTerm?: string
   onCreateDashboard: typeof createDashboard
+  summonImportOverlay: () => void
   summonImportFromTemplateOverlay: () => void
 }
 
 const DashboardsTableEmpty: FC<ComponentProps> = ({
   searchTerm,
   onCreateDashboard,
+  summonImportOverlay,
   summonImportFromTemplateOverlay,
 }) => {
   if (searchTerm) {
@@ -42,6 +44,7 @@ const DashboardsTableEmpty: FC<ComponentProps> = ({
           </EmptyState.Text>
           <AddResourceDropdown
             onSelectNew={onCreateDashboard}
+            onSelectImport={summonImportOverlay}
             onSelectTemplate={summonImportFromTemplateOverlay}
             resourceName="Dashboard"
           />
@@ -60,6 +63,7 @@ const DashboardsTableEmpty: FC<ComponentProps> = ({
               </EmptyState.Text>
               <AddResourceDropdown
                 onSelectNew={onCreateDashboard}
+                onSelectImport={summonImportOverlay}
                 onSelectTemplate={summonImportFromTemplateOverlay}
                 resourceName="Dashboard"
               />

--- a/src/dashboards/components/dashboard_index/Table.tsx
+++ b/src/dashboards/components/dashboard_index/Table.tsx
@@ -56,6 +56,7 @@ class DashboardsTable extends PureComponent<Props> {
           searchTerm={searchTerm}
           onCreateDashboard={onCreateDashboard}
           summonImportFromTemplateOverlay={this.summonImportFromTemplateOverlay}
+          summonImportOverlay={this.summonImportOverlay}
         />
       )
     }
@@ -69,6 +70,16 @@ class DashboardsTable extends PureComponent<Props> {
         onFilterChange={onFilterChange}
       />
     )
+  }
+
+  private summonImportOverlay = (): void => {
+    const {
+      history,
+      match: {
+        params: {orgID},
+      },
+    } = this.props
+    history.push(`/orgs/${orgID}/dashboards-list/import`)
   }
 
   private summonImportFromTemplateOverlay = (): void => {

--- a/src/shared/components/AddResourceDropdown.tsx
+++ b/src/shared/components/AddResourceDropdown.tsx
@@ -22,6 +22,7 @@ import {CLOUD} from 'src/shared/constants'
 
 interface OwnProps {
   onSelectNew: () => void
+  onSelectImport?: () => void
   onSelectTemplate?: () => void
   resourceName: string
   limitStatus?: LimitStatus['status']
@@ -77,6 +78,7 @@ class AddResourceDropdown extends PureComponent<Props> {
   }
 
   private get optionItems(): JSX.Element[] {
+    const importOption = this.importOption
     const newOption = this.newOption
     const templateOption = this.templateOption
     const fromDashboard = this.props.resourceName === 'Dashboard'
@@ -103,6 +105,15 @@ class AddResourceDropdown extends PureComponent<Props> {
       >
         {newOption}
       </Dropdown.Item>,
+      <Dropdown.Item
+        id={importOption}
+        key={importOption}
+        onClick={this.handleSelect}
+        value={importOption}
+        testID="add-resource-dropdown--import"
+      >
+        {importOption}
+      </Dropdown.Item>,
       ...(fromDashboard ? [templateFromDashboard] : []),
     ]
 
@@ -111,6 +122,10 @@ class AddResourceDropdown extends PureComponent<Props> {
 
   private get newOption(): string {
     return `New ${this.props.resourceName}`
+  }
+
+  private get importOption(): string {
+    return `Import ${this.props.resourceName}`
   }
 
   private get templateOption(): string {
@@ -123,7 +138,12 @@ class AddResourceDropdown extends PureComponent<Props> {
   }
 
   private handleSelect = (selection: string): void => {
-    const {onSelectNew, onSelectTemplate, limitStatus = 'ok'} = this.props
+    const {
+      onSelectNew,
+      onSelectImport,
+      onSelectTemplate,
+      limitStatus = 'ok',
+    } = this.props
 
     if (CLOUD && limitStatus === 'exceeded') {
       this.handleLimit()
@@ -132,6 +152,9 @@ class AddResourceDropdown extends PureComponent<Props> {
 
     if (selection === this.newOption) {
       onSelectNew()
+    }
+    if (selection === this.importOption) {
+      onSelectImport()
     }
     if (selection == this.templateOption) {
       onSelectTemplate()

--- a/src/templates/api/index.ts
+++ b/src/templates/api/index.ts
@@ -37,6 +37,7 @@ import {
   Error as PkgError,
   TemplateApply,
   TemplateSummary,
+  Template
 } from 'src/client'
 import {addDashboardDefaults} from 'src/schemas/dashboards'
 
@@ -106,6 +107,22 @@ export const createDashboardFromTemplate = async (
     console.error(error)
     throw new Error(error.message)
   }
+}
+
+export const createDashboardFromPkgrTemplate = async (
+  template: Template,
+  orgID: string
+): Promise<void> => {
+  await postTemplatesApply({
+    data: {
+      orgID,
+      dryRun: false,
+      template: {
+        contentType: 'json',
+        contents: template,
+      },
+    },
+  })
 }
 
 const addDashboardLabelsFromTemplate = async (

--- a/src/templates/api/index.ts
+++ b/src/templates/api/index.ts
@@ -37,7 +37,7 @@ import {
   Error as PkgError,
   TemplateApply,
   TemplateSummary,
-  Template
+  Template,
 } from 'src/client'
 import {addDashboardDefaults} from 'src/schemas/dashboards'
 


### PR DESCRIPTION
Closes #3802

Re-enables the exporting and importing of dashboards using the pkger/v2 templating system

- Tries to strike a balance between being functional, and not adding in a bunch of removed code
- Downloads the template directly - doesn't give the option to copy to clipboard (this was done to keep from having to re-install codemirror and several deleted stylesheets)
- Works by choosing a file or pasting in text
- Will only work with newly exported templates. Won't work with templates exported from the legacy system.



https://user-images.githubusercontent.com/146112/153267104-db235326-92e5-42fe-8ca4-2ac36c430793.mov


<!-- Describe your proposed changes here. -->
