### PR TITLE
fix(3629): cannot create rules from deactive endpoints

### DIFF
--- a/src/alerting/components/AlertingIndex.tsx
+++ b/src/alerting/components/AlertingIndex.tsx
@@ -17,7 +17,6 @@ import GetAssetLimits from 'src/cloud/components/GetAssetLimits'
 import RateLimitAlert from 'src/cloud/components/RateLimitAlert'
 import GetResources from 'src/resources/components/GetResources'
 import EditCheckEO from 'src/checks/components/EditCheckEO'
-import NewRuleOverlay from 'src/notifications/rules/components/NewRuleOverlay'
 import EditRuleOverlay from 'src/notifications/rules/components/EditRuleOverlay'
 import NewEndpointOverlay from 'src/notifications/endpoints/components/NewEndpointOverlay'
 import EditEndpointOverlay from 'src/notifications/endpoints/components/EditEndpointOverlay'
@@ -168,7 +167,6 @@ const AlertingIndex: FunctionComponent = () => {
           path={`${alertsPath}/checks/:checkID/edit`}
           component={EditCheckEO}
         />
-        <Route path={`${alertsPath}/rules/new`} component={NewRuleOverlay} />
         <Route
           path={`${alertsPath}/rules/:ruleID/edit`}
           component={EditRuleOverlay}

--- a/src/notifications/endpoints/selectors/index.ts
+++ b/src/notifications/endpoints/selectors/index.ts
@@ -13,3 +13,13 @@ export const sortEndpointsByName = (
   endpoints.sort((a, b) =>
     a.name.toLowerCase() > b.name.toLowerCase() ? 1 : -1
   )
+
+export const getAllActiveEndpoints = (state: AppState): NotificationEndpoint[] => {
+  const endpoints = state.resources.endpoints.allIDs.reduce(
+    (acc, id) => state.resources.endpoints.byID[id]?.activeStatus == 'active'
+      ? acc.concat([state.resources.endpoints.byID[id]])
+      : acc,
+    []
+  )
+  return !!endpoints.length ? sortEndpointsByName(endpoints) : []
+}

--- a/src/notifications/endpoints/selectors/index.ts
+++ b/src/notifications/endpoints/selectors/index.ts
@@ -14,11 +14,14 @@ export const sortEndpointsByName = (
     a.name.toLowerCase() > b.name.toLowerCase() ? 1 : -1
   )
 
-export const getAllActiveEndpoints = (state: AppState): NotificationEndpoint[] => {
+export const getAllActiveEndpoints = (
+  state: AppState
+): NotificationEndpoint[] => {
   const endpoints = state.resources.endpoints.allIDs.reduce(
-    (acc, id) => state.resources.endpoints.byID[id]?.activeStatus == 'active'
-      ? acc.concat([state.resources.endpoints.byID[id]])
-      : acc,
+    (acc, id) =>
+      state.resources.endpoints.byID[id]?.activeStatus == 'active'
+        ? acc.concat([state.resources.endpoints.byID[id]])
+        : acc,
     []
   )
   return !!endpoints.length ? sortEndpointsByName(endpoints) : []

--- a/src/notifications/rules/components/NewRuleOverlay.tsx
+++ b/src/notifications/rules/components/NewRuleOverlay.tsx
@@ -1,10 +1,13 @@
 // Libraries
-import React, {useMemo, FC} from 'react'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect, ConnectedProps} from 'react-redux'
+import React, {useMemo, FC, useContext} from 'react'
+import {useDispatch, useSelector} from 'react-redux'
 
-// Actions
+// Actions, Selectors
 import {createRule} from 'src/notifications/rules/actions/thunks'
+import {getOrg} from 'src/organizations/selectors'
+
+// Contexts
+import {OverlayContext} from 'src/overlays/components/OverlayController'
 
 // Components
 import RuleOverlayContents from 'src/notifications/rules/components/RuleOverlayContents'
@@ -17,24 +20,14 @@ import {initRuleDraft} from 'src/notifications/rules/utils'
 // Types
 import {NotificationRuleDraft} from 'src/types'
 
-type ReduxProps = ConnectedProps<typeof connector>
-type Props = RouteComponentProps<{orgID: string}> & ReduxProps
+const NewRuleOverlay: FC = () => {
+  const dispatch = useDispatch()
+  const {onClose} = useContext(OverlayContext)
+  const orgID = useSelector(getOrg)?.id
 
-const NewRuleOverlay: FC<Props> = ({
-  match: {
-    params: {orgID},
-  },
-  history,
-  onCreateRule,
-}) => {
-  const handleDismiss = () => {
-    history.push(`/orgs/${orgID}/alerting`)
-  }
-
-  const handleCreateRule = async (rule: NotificationRuleDraft) => {
-    await onCreateRule(rule)
-
-    handleDismiss()
+  const handleCreateRule = async(rule: NotificationRuleDraft) => {
+    await dispatch(createRule(rule))
+    onClose()
   }
 
   const initialState = useMemo(() => initRuleDraft(orgID), [orgID])
@@ -45,7 +38,7 @@ const NewRuleOverlay: FC<Props> = ({
         <Overlay.Container maxWidth={800}>
           <Overlay.Header
             title="Create a Notification Rule"
-            onDismiss={handleDismiss}
+            onDismiss={onClose}
             testID="dismiss-overlay"
           />
           <Overlay.Body>
@@ -60,10 +53,4 @@ const NewRuleOverlay: FC<Props> = ({
   )
 }
 
-const mdtp = {
-  onCreateRule: createRule,
-}
-
-const connector = connect(null, mdtp)
-
-export default connector(withRouter(NewRuleOverlay))
+export default NewRuleOverlay

--- a/src/notifications/rules/components/NewRuleOverlay.tsx
+++ b/src/notifications/rules/components/NewRuleOverlay.tsx
@@ -25,7 +25,7 @@ const NewRuleOverlay: FC = () => {
   const {onClose} = useContext(OverlayContext)
   const orgID = useSelector(getOrg)?.id
 
-  const handleCreateRule = async(rule: NotificationRuleDraft) => {
+  const handleCreateRule = async (rule: NotificationRuleDraft) => {
     await dispatch(createRule(rule))
     onClose()
   }

--- a/src/notifications/rules/components/RuleMessage.tsx
+++ b/src/notifications/rules/components/RuleMessage.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC, useEffect} from 'react'
-import {connect} from 'react-redux'
+import {useSelector} from 'react-redux'
 
 // Components
 import {
@@ -16,29 +16,19 @@ import RuleMessageContents from 'src/notifications/rules/components/RuleMessageC
 
 // Utils
 import {getRuleVariantDefaults} from 'src/notifications/rules/utils'
-import {getAll} from 'src/resources/selectors'
+import {getAllActiveEndpoints} from 'src/notifications/endpoints/selectors'
 import {useRuleDispatch} from './RuleOverlayProvider'
 
 // Types
-import {
-  NotificationEndpoint,
-  NotificationRuleDraft,
-  AppState,
-  ResourceType,
-} from 'src/types'
+import {NotificationRuleDraft} from 'src/types'
 
-interface StateProps {
-  endpoints: NotificationEndpoint[]
-}
-
-interface OwnProps {
+interface Props {
   rule: NotificationRuleDraft
 }
 
-type Props = OwnProps & StateProps
-
-const RuleMessage: FC<Props> = ({endpoints, rule}) => {
+const RuleMessage: FC<Props> = ({rule}) => {
   const dispatch = useRuleDispatch()
+  const endpoints = useSelector(getAllActiveEndpoints)
 
   const onSelectEndpoint = endpointID => {
     dispatch({
@@ -80,15 +70,4 @@ const RuleMessage: FC<Props> = ({endpoints, rule}) => {
   )
 }
 
-const mstp = (state: AppState) => {
-  const endpoints = getAll<NotificationEndpoint>(
-    state,
-    ResourceType.NotificationEndpoints
-  )
-
-  return {
-    endpoints,
-  }
-}
-
-export default connect(mstp)(RuleMessage)
+export default RuleMessage

--- a/src/notifications/rules/components/RulesColumn.tsx
+++ b/src/notifications/rules/components/RulesColumn.tsx
@@ -30,18 +30,14 @@ interface Props {
   tabIndex: number
 }
 
-const NotificationRulesColumn: FunctionComponent<Props> = ({
-  tabIndex,
-}) => {
+const NotificationRulesColumn: FunctionComponent<Props> = ({tabIndex}) => {
   const dispatch = useDispatch()
   const endpoints = useSelector(getAllActiveEndpoints)
   const rules = useSelector(getAllRules)
 
   const handleOpenOverlay = () => {
     event('Create Notification Rule opened')
-    dispatch(
-      showOverlay('create-rule', null, () => dispatch(dismissOverlay()))
-    )
+    dispatch(showOverlay('create-rule', null, () => dispatch(dismissOverlay())))
   }
 
   const tooltipContents = (

--- a/src/notifications/rules/components/RulesColumn.tsx
+++ b/src/notifications/rules/components/RulesColumn.tsx
@@ -1,15 +1,9 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
-import {connect} from 'react-redux'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
+import {useDispatch, useSelector} from 'react-redux'
 
 // Types
-import {
-  NotificationEndpoint,
-  NotificationRuleDraft,
-  AppState,
-  ResourceType,
-} from 'src/types'
+import {ResourceType} from 'src/types'
 
 // Components
 import {
@@ -20,34 +14,34 @@ import {
 } from '@influxdata/clockface'
 import NotificationRuleCards from 'src/notifications/rules/components/RuleCards'
 import AlertsColumn from 'src/alerting/components/AlertsColumn'
+import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
 
 // Constants
 import {DOCS_URL_VERSION} from 'src/shared/constants/fluxFunctions'
 
 // Selectors
-import {getAll} from 'src/resources/selectors'
+import {getAllActiveEndpoints} from 'src/notifications/endpoints/selectors'
+import {getAllRules} from 'src/notifications/rules/selectors'
 
-interface OwnProps {
+// Utils
+import {event} from 'src/cloud/utils/reporting'
+
+interface Props {
   tabIndex: number
 }
 
-interface StateProps {
-  rules: NotificationRuleDraft[]
-  endpoints: NotificationEndpoint[]
-}
-
-type Props = OwnProps & StateProps & RouteComponentProps<{orgID: string}>
-
 const NotificationRulesColumn: FunctionComponent<Props> = ({
-  rules,
-  history,
-  match,
-  endpoints,
   tabIndex,
 }) => {
+  const dispatch = useDispatch()
+  const endpoints = useSelector(getAllActiveEndpoints)
+  const rules = useSelector(getAllRules)
+
   const handleOpenOverlay = () => {
-    const newRuleRoute = `/orgs/${match.params.orgID}/alerting/rules/new`
-    history.push(newRuleRoute)
+    event('Create Notification Rule opened')
+    dispatch(
+      showOverlay('create-rule', null, () => dispatch(dismissOverlay()))
+    )
   }
 
   const tooltipContents = (
@@ -106,21 +100,4 @@ const NotificationRulesColumn: FunctionComponent<Props> = ({
   )
 }
 
-const mstp = (state: AppState) => {
-  const rules = getAll<NotificationRuleDraft>(
-    state,
-    ResourceType.NotificationRules
-  )
-
-  const endpoints = getAll<NotificationEndpoint>(
-    state,
-    ResourceType.NotificationEndpoints
-  )
-
-  return {rules, endpoints}
-}
-
-export default connect<StateProps>(
-  mstp,
-  null
-)(withRouter(NotificationRulesColumn))
+export default NotificationRulesColumn

--- a/src/notifications/rules/selectors/index.ts
+++ b/src/notifications/rules/selectors/index.ts
@@ -1,4 +1,5 @@
-import {AppState, NotificationRuleDraft} from 'src/types'
+import {AppState, ResourceType, NotificationRuleDraft} from 'src/types'
+import {getAll} from 'src/resources/selectors'
 
 export const getRuleIDs = (state: AppState): {[x: string]: boolean} => {
   return state.resources.rules.allIDs.reduce(
@@ -7,13 +8,13 @@ export const getRuleIDs = (state: AppState): {[x: string]: boolean} => {
   )
 }
 
-
-export const sortRulesByName = <T extends {name: string}>(
-  rules: T[]
-): T[] =>
+export const sortRulesByName = <T extends {name: string}>(rules: T[]): T[] =>
   rules.sort((a, b) => (a.name.toLowerCase() > b.name.toLowerCase() ? 1 : -1))
 
-export const getAllRules = (state: AppState): NotificationRuleDraft[] => {
-  const rules: NotificationRuleDraft[] = Object.values(state.resources.rules.byID)
+export const getAllRules = (state: AppState) => {
+  const rules = getAll<NotificationRuleDraft>(
+    state,
+    ResourceType.NotificationRules
+  )
   return !!rules.length ? sortRulesByName(rules) : []
 }

--- a/src/notifications/rules/selectors/index.ts
+++ b/src/notifications/rules/selectors/index.ts
@@ -7,7 +7,13 @@ export const getRuleIDs = (state: AppState): {[x: string]: boolean} => {
   )
 }
 
-export const sortRulesByName = (
-  rules: NotificationRuleDraft[]
-): NotificationRuleDraft[] =>
+
+export const sortRulesByName = <T extends {name: string}>(
+  rules: T[]
+): T[] =>
   rules.sort((a, b) => (a.name.toLowerCase() > b.name.toLowerCase() ? 1 : -1))
+
+export const getAllRules = (state: AppState): NotificationRuleDraft[] => {
+  const rules: NotificationRuleDraft[] = Object.values(state.resources.rules.byID)
+  return !!rules.length ? sortRulesByName(rules) : []
+}

--- a/src/overlays/components/OverlayController.tsx
+++ b/src/overlays/components/OverlayController.tsx
@@ -35,6 +35,7 @@ import AutoRefreshOverlay from 'src/dashboards/components/AutoRefreshOverlay'
 import CellCloneOverlay from 'src/shared/components/cells/CellCloneOverlay'
 import CustomApiTokenOverlay from 'src/authorizations/components/CustomApiTokenOverlay'
 import DisplayTokenOverlay from 'src/authorizations/components/DisplayTokenOverlay'
+import NewRuleOverlay from 'src/notifications/rules/components/NewRuleOverlay'
 import CreateSecretOverlay from 'src/secrets/components/CreateSecret/CreateSecretOverlay'
 
 // Actions
@@ -131,6 +132,9 @@ export const OverlayController: FunctionComponent = () => {
         break
       case 'cell-copy-overlay':
         activeOverlay.current = <CellCloneOverlay />
+        break
+      case 'create-rule':
+        activeOverlay.current = <NewRuleOverlay />
         break
       case 'create-secret':
         activeOverlay.current = <CreateSecretOverlay />

--- a/src/overlays/reducers/overlays.ts
+++ b/src/overlays/reducers/overlays.ts
@@ -27,6 +27,7 @@ export type OverlayID =
   | 'toggle-auto-refresh'
   | 'cell-copy-overlay'
   | 'bucket-schema-show'
+  | 'create-rule'
   | 'create-secret'
 
 export interface OverlayState {


### PR DESCRIPTION
Closes #3629 
Problem was that in the Alerts part of the application, a disabled endpoint was still available to create a Notification Rule.

### Done:
* make selector for getAllActiveEndpoints()
* use the new state connector pattern in the components touched (NewRuleOverlay, RuleMessage, RulesColumn, AlertsColumn)
* use our new overlay controller part in the overlay touched (NewRuleOverlay).
* confirmed worked (see video below).
* confirmed could still create function e2e alert notifications.

### Proof that works:
https://user-images.githubusercontent.com/10232835/153638262-5c4a79e7-4aa3-4ff0-9f5e-1ffd4bfd5569.mov


