### PR TITLE
fix: update the avatar name when account is switched

### DIFF
--- a/src/accounts/context/userAccount.tsx
+++ b/src/accounts/context/userAccount.tsx
@@ -163,7 +163,10 @@ export const UserAccountProvider: FC<Props> = React.memo(({children}) => {
         userAccounts[activeIndex].name = newName
         setUserAccounts(userAccounts)
 
-        if (isFlagEnabled('avatarNameForMultiAccountFix')) {
+        if (
+          isFlagEnabled('multiAccount') &&
+          isFlagEnabled('avatarNameForMultiAccountFix')
+        ) {
           const name = resp.data.name
           const id = resp.data.id.toString()
           // update the state

--- a/src/accounts/context/userAccount.tsx
+++ b/src/accounts/context/userAccount.tsx
@@ -27,8 +27,10 @@ import {event} from 'src/cloud/utils/reporting'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {useHistory} from 'react-router-dom'
 import {getErrorMessage} from 'src/utils/api'
-import {setMe} from '../../me/actions/creators'
-import {MeState} from '../../me/reducers'
+
+// Actions
+import {setMe} from 'src/me/actions/creators'
+import {MeState} from 'src/me/reducers'
 
 export type Props = {
   children: JSX.Element

--- a/src/accounts/context/userAccount.tsx
+++ b/src/accounts/context/userAccount.tsx
@@ -27,6 +27,8 @@ import {event} from 'src/cloud/utils/reporting'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {useHistory} from 'react-router-dom'
 import {getErrorMessage} from 'src/utils/api'
+import {setMe} from '../../me/actions/creators'
+import {MeState} from '../../me/reducers'
 
 export type Props = {
   children: JSX.Element
@@ -158,6 +160,13 @@ export const UserAccountProvider: FC<Props> = React.memo(({children}) => {
         // change the name, and reset the active accts:
         userAccounts[activeIndex].name = newName
         setUserAccounts(userAccounts)
+
+        if (isFlagEnabled('avatarNameForMultiAccountFix')) {
+          const name = resp.data.name
+          const id = resp.data.id.toString()
+          // update the state
+          dispatch(setMe({name, id} as MeState))
+        }
       }
     } catch (error) {
       dispatch(notify(accountRenameError(oldName)))

--- a/src/me/actions/thunks/index.ts
+++ b/src/me/actions/thunks/index.ts
@@ -5,7 +5,7 @@ import {Dispatch} from 'react'
 
 // API
 import {getMe as apiGetApiMe} from 'src/client'
-import {getMe as apiGetQuartzMe} from 'src/client/unityRoutes'
+import {getAccounts, getMe as apiGetQuartzMe} from 'src/client/unityRoutes'
 // Utils
 import {gaEvent, updateReportingContext} from 'src/cloud/utils/reporting'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
@@ -28,12 +28,27 @@ export const getMe = () => async (
   getState: GetState
 ) => {
   try {
-    const resp = await apiGetApiMe({})
+    let user
 
-    if (resp.status !== 200) {
-      throw new Error(resp.data.message)
+    if (
+      isFlagEnabled('multiAccount') &&
+      isFlagEnabled('avatarNameForMultiAccountFix')
+    ) {
+      const resp = await getAccounts({})
+
+      if (resp.status !== 200) {
+        throw new Error(resp.data.message)
+      }
+      user = resp.data.filter(account => account.isActive)[0]
+    } else {
+      const resp = await apiGetApiMe({})
+
+      if (resp.status !== 200) {
+        throw new Error(resp.data.message)
+      }
+      user = resp.data
     }
-    const user = resp.data
+
     updateReportingContext({userID: user.id, userEmail: user.name})
 
     gaEvent('cloudAppUserDataReady', {

--- a/src/me/actions/thunks/index.ts
+++ b/src/me/actions/thunks/index.ts
@@ -39,7 +39,7 @@ export const getMe = () => async (
       if (resp.status !== 200) {
         throw new Error(resp.data.message)
       }
-      user = resp.data.filter(account => account.isActive)[0]
+      user = resp.data.find(account => account.isActive)
     } else {
       const resp = await apiGetApiMe({})
 


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/3757
Depends on: https://github.com/influxdata/idpe/issues/13230

Bug fix is behind a feature flag. `avatarNameForMultiAccountFix`.



https://user-images.githubusercontent.com/18511823/153654020-c95c9abd-1795-45d2-96c4-7f5505532669.mov




<!-- Describe your proposed changes here. -->
