### PR TITLE
fix: token issue when creating specific/all buckets token

### DIFF
--- a/src/authorizations/components/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/CustomApiTokenOverlay.tsx
@@ -122,13 +122,11 @@ const CustomApiTokenOverlay: FC<Props> = props => {
     let name = resourceName.replaceAll(/\s/g, '')
     name = name.charAt(0).toLowerCase() + name.slice(1)
     const newPermValue = newPerm[name][permission]
-    const oppPermission = permission === 'write' ? 'read' : 'write'
     if (newPerm[name].sublevelPermissions) {
       Object.keys(newPerm[name].sublevelPermissions).forEach(key => {
-        newPerm[name].sublevelPermissions[key].permissions[permission] = false
         newPerm[name].sublevelPermissions[key].permissions[
-          oppPermission
-        ] = false
+          permission
+        ] = !newPermValue
       })
     }
     if (name === 'otherResources') {

--- a/src/authorizations/components/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/CustomApiTokenOverlay.tsx
@@ -122,11 +122,13 @@ const CustomApiTokenOverlay: FC<Props> = props => {
     let name = resourceName.replaceAll(/\s/g, '')
     name = name.charAt(0).toLowerCase() + name.slice(1)
     const newPermValue = newPerm[name][permission]
+    const oppPermission = permission === 'write' ? 'read' : 'write'
     if (newPerm[name].sublevelPermissions) {
       Object.keys(newPerm[name].sublevelPermissions).forEach(key => {
+        newPerm[name].sublevelPermissions[key].permissions[permission] = false
         newPerm[name].sublevelPermissions[key].permissions[
-          permission
-        ] = !newPermValue
+          oppPermission
+        ] = false
       })
     }
     if (name === 'otherResources') {

--- a/src/authorizations/components/EditResourceAccordion.tsx
+++ b/src/authorizations/components/EditResourceAccordion.tsx
@@ -21,9 +21,10 @@ const Filter = FilterList<Resource>()
 export class EditResourceAccordion extends Component<Props> {
   public render() {
     const {permissions} = this.props
-    if (!permissions) {
+    if (!permissions || isEmpty(permissions)) {
       return null
     }
+
     const allResourceNames = formatResources(Object.keys(permissions))
 
     return (

--- a/src/authorizations/components/EditResourceAccordion.tsx
+++ b/src/authorizations/components/EditResourceAccordion.tsx
@@ -38,15 +38,16 @@ export class EditResourceAccordion extends Component<Props> {
             return (
               <Accordion key={resource} expanded={true}>
                 <ResourceAccordionHeader resourceName={resourceName} />
-                {isEmpty(permissions[resource].sublevelPermissions) ? (
+                {this.hideAllAccordion(permissions[resource]) ? null : (
                   <AllAccordionBody
                     resourceName={resourceName}
                     permissions={permissions[resource]}
                     disabled={true}
                   />
-                ) : (
-                  this.getAccordionBody(resourceName, resource)
                 )}
+                {this.hideAccordionBody(permissions[resource])
+                  ? this.getAccordionBody(resourceName, resource)
+                  : null}
               </Accordion>
             )
           }
@@ -59,6 +60,24 @@ export class EditResourceAccordion extends Component<Props> {
         )}
       </>
     )
+  }
+
+  hideAllAccordion = resource => {
+    // if all resource read or all resource write is selected then don't hide all accordion body
+    if (!resource.read && !resource.write) {
+      return true
+    }
+    return false
+  }
+
+  hideAccordionBody = resource => {
+    // if all resource read and all resource write is selected then collapse accordion body
+    if (resource.read && resource.write) {
+      return false
+    } else if (isEmpty(resource.sublevelPermissions)) {
+      return false
+    }
+    return true
   }
 
   getOtherResourceAccordionBody = allResourceNames => {

--- a/src/authorizations/components/ResourceAccordion.tsx
+++ b/src/authorizations/components/ResourceAccordion.tsx
@@ -58,7 +58,7 @@ class ResourceAccordion extends Component<OwnProps> {
                   onToggleAll={onToggleAll}
                   disabled={false}
                 />
-                {!permissions[resource].read && !permissions[resource].write
+                {this.isCollapsible(resource)
                   ? !isEmpty(permissions[resource].sublevelPermissions) &&
                     this.getAccordionBody(resourceName, resource)
                   : null}
@@ -80,14 +80,22 @@ class ResourceAccordion extends Component<OwnProps> {
               onToggleAll={onToggleAll}
               disabled={false}
             />
-            {!permissions.otherResources.read &&
-            !permissions.otherResources.write
+            {this.isCollapsible('otherResources')
               ? this.otherResourcesAccordionBody()
               : null}
           </DapperScrollbars>
         </Accordion>
       </>
     )
+  }
+
+  isCollapsible = resource => {
+    const {permissions} = this.props
+    // if all resource read and all resource write is selected then collapse accordion body
+    if (permissions[resource].read && permissions[resource].write) {
+      return false
+    }
+    return true
   }
 
   otherResourcesAccordionBody = () => {

--- a/src/authorizations/utils/permissions.test.ts
+++ b/src/authorizations/utils/permissions.test.ts
@@ -805,8 +805,8 @@ const nonAllAcessAccordionPerms = {
 
 const nonAllAcessAccordionPerms2 = {
   buckets: {
-    read: true,
-    write: true,
+    read: false,
+    write: false,
     sublevelPermissions: {
       '25a6692ba25d7147': {
         id: '25a6692ba25d7147',
@@ -885,11 +885,6 @@ describe('Testing formatApiPermissions function', () => {
 describe('Testing formatPermissionsObj function', () => {
   test('for api permissions with IDs, it creates perms with sublevel permissions', () => {
     expect(formatPermissionsObj(nonAllAcessApiPerms)).toMatchObject(
-      nonAllAcessAccordionPerms2
-    )
-  })
-  test('if all sublevel permissions are true, it updates the top level perms to true', () => {
-    expect(formatPermissionsObj(nonAllAcessApiPerms)).toEqual(
       nonAllAcessAccordionPerms2
     )
   })

--- a/src/authorizations/utils/permissions.ts
+++ b/src/authorizations/utils/permissions.ts
@@ -158,14 +158,14 @@ export const formatPermissionsObj = permissions => {
         accordionPermission = {
           read: action === 'read',
           write: action === 'write',
-          sublevelPermissions: {}
+          sublevelPermissions: {},
         }
       }
     }
 
     return {...acc, [type]: accordionPermission}
   }, {})
-  
+
   return newPerms
 }
 

--- a/src/authorizations/utils/permissions.ts
+++ b/src/authorizations/utils/permissions.ts
@@ -158,34 +158,14 @@ export const formatPermissionsObj = permissions => {
         accordionPermission = {
           read: action === 'read',
           write: action === 'write',
+          sublevelPermissions: {}
         }
       }
     }
 
     return {...acc, [type]: accordionPermission}
   }, {})
-
-  Object.keys(newPerms).forEach(resource => {
-    const accordionPermission = {...newPerms[resource]}
-    if (accordionPermission.sublevelPermissions) {
-      accordionPermission.read = Object.keys(
-        accordionPermission.sublevelPermissions
-      ).every(
-        key =>
-          accordionPermission.sublevelPermissions[key].permissions.read === true
-      )
-
-      accordionPermission.write = Object.keys(
-        accordionPermission.sublevelPermissions
-      ).every(
-        key =>
-          accordionPermission.sublevelPermissions[key].permissions.write ===
-          true
-      )
-
-      newPerms[resource] = accordionPermission
-    }
-  })
+  
   return newPerms
 }
 


### PR DESCRIPTION
Closes #3600 
When creating a custom api token and a user selects `read` permissions for a specific bucket but then toggles `write` permissions for all buckets, it creates the token for `bucket: read` and `all buckets: write` and fails horribly when trying to view that token. For now, I have added the logic that when all buckets `read/write` toggle happens, we want to keep the specific read/write selections and the accordion open. We will collapse the accordion only when both toggle all for read and write are checked.. Just trying to fix this issue instead of failing terrible in the UI. This is going to be discussed with Balaji and Daniel to get proper design and a new issue will be created to track the progress.

<!-- Describe your proposed changes here. -->
<img width="836" alt="Screen Shot 2022-02-15 at 1 28 59 PM" src="https://user-images.githubusercontent.com/26464594/154152362-a7ea51fc-9e18-4160-8fea-53f96377f0c1.png">

