### PR TITLE
fix(3742): pagerduty test alerts

### DIFF
--- a/src/flows/pipes/Notification/endpoints/PagerDuty/index.ts
+++ b/src/flows/pipes/Notification/endpoints/PagerDuty/index.ts
@@ -46,7 +46,7 @@ export default register => {
       routingKey: "${data.key}",
       client: "influxdata",
       clientURL: "${data.url}",
-      dedupKey: "${(new Date()).toISOString()}",
+      dedupKey: "${new Date().toISOString()}",
       class: "check_name",
       group: "test_measurement",
       severity: "critical",
@@ -54,7 +54,7 @@ export default register => {
       source: "Notebook Generated Test Notification",
       component: "example-component",
       summary: "${TEST_NOTIFICATION}",
-      timestamp: "${(new Date()).toISOString()}",
+      timestamp: "${new Date().toISOString()}",
       customDetails: {}
     )
     array.from(rows: [{value: 0}])


### PR DESCRIPTION
Closes #3742

### Done:
* make pagerduty test alerts work.
* also update syntax for the pagerduty alerts exported to tasks.

### Visual proof:

https://user-images.githubusercontent.com/10232835/153685092-3f3f8134-6b8b-4597-8fd3-a372c4f48174.mov


