### PR TITLE
chore: invalidate error thresholds when the query has changed and they are no longer relevant

### DIFF
--- a/src/flows/pipes/Visualization/view.tsx
+++ b/src/flows/pipes/Visualization/view.tsx
@@ -77,10 +77,8 @@ const Visualization: FC<PipeProp> = ({Context}) => {
 
   const invalidateField = React.useCallback(
     (field: string) => {
-      const copy = data?.errorThresholds.slice()
-      const index = data?.errorThresholds.findIndex(
-        threshold => threshold.field === field
-      )
+      const copy = (data?.errorThresholds ?? []).slice()
+      const index = copy.findIndex(threshold => threshold.field === field)
 
       if (index === -1) {
         return
@@ -100,7 +98,7 @@ const Visualization: FC<PipeProp> = ({Context}) => {
     (fields: any[]) => {
       const dedupedFields = new Set([...fields])
 
-      const errorFields = data?.errorThresholds
+      const errorFields = (data?.errorThresholds ?? [])
         .map(error => error.field)
         .filter(error => error !== undefined)
 
@@ -238,7 +236,7 @@ const Visualization: FC<PipeProp> = ({Context}) => {
     const values: any = Object.values(columns).filter(
       column => column.name === '_value'
     )
-    const fields = columns['_field'].data
+    const fields = columns['_field'].data ?? []
 
     const realValues = fields.map((_, index) =>
       values.reduce((acc, curr) => {


### PR DESCRIPTION
Closes #3828

This PR adds a lifecycle method to listen for changes to the results in the visualization. That listener then triggers a callback to check to see whether the existing error thresholds are still relevant to the given data set, and if not, then the error thresholds are updated to remove the no-longer-relevant error threshold

<!-- Describe your proposed changes here. -->
