### PR TITLE
fix: deep linking to a notebook pipe

### DIFF
--- a/src/flows/context/flow.current.tsx
+++ b/src/flows/context/flow.current.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
   useEffect,
 } from 'react'
-import {useLocation} from 'react-router-dom'
+import {useHistory, useLocation} from 'react-router-dom'
 import {Flow, PipeData, PipeMeta} from 'src/types/flows'
 import {FlowListContext, FlowListProvider} from 'src/flows/context/flow.list'
 import {customAlphabet} from 'nanoid'
@@ -55,15 +55,23 @@ export const FlowProvider: FC = ({children}) => {
     }
   }
 
+  const history = useHistory()
   const {search} = useLocation()
 
   const panel = new URLSearchParams(search).get('panel')
 
   useEffect(() => {
     if (document && panel && currentFlow) {
-      document.getElementById(panel)?.scrollIntoView()
+      // TODO(ariel): only deep link when the results have been run and the panels have expanded
+      setTimeout(() => {
+        document.getElementById(panel)?.scrollIntoView()
+      }, 1000)
+      setTimeout(() => {
+        // then remove the deep linked panel from the URL?
+        history.push(window.location.pathname)
+      }, 2000)
     }
-  }, [panel, currentFlow])
+  }, [history, currentFlow, panel])
 
   // NOTE this is a pretty awful mechanism, as it duplicates the source of
   // truth for the definition of the current flow, but i can't see a good

--- a/src/flows/context/flow.current.tsx
+++ b/src/flows/context/flow.current.tsx
@@ -6,7 +6,6 @@ import React, {
   useState,
   useEffect,
 } from 'react'
-import {useHistory, useLocation} from 'react-router-dom'
 import {Flow, PipeData, PipeMeta} from 'src/types/flows'
 import {FlowListContext, FlowListProvider} from 'src/flows/context/flow.list'
 import {customAlphabet} from 'nanoid'
@@ -54,24 +53,6 @@ export const FlowProvider: FC = ({children}) => {
       provider.current.disconnect()
     }
   }
-
-  const history = useHistory()
-  const {search} = useLocation()
-
-  const panel = new URLSearchParams(search).get('panel')
-
-  useEffect(() => {
-    if (document && panel && currentFlow) {
-      // TODO(ariel): only deep link when the results have been run and the panels have expanded
-      setTimeout(() => {
-        document.getElementById(panel)?.scrollIntoView()
-      }, 1000)
-      setTimeout(() => {
-        // then remove the deep linked panel from the URL?
-        history.push(window.location.pathname)
-      }, 2000)
-    }
-  }, [history, currentFlow, panel])
 
   // NOTE this is a pretty awful mechanism, as it duplicates the source of
   // truth for the definition of the current flow, but i can't see a good

--- a/src/flows/context/pipe.tsx
+++ b/src/flows/context/pipe.tsx
@@ -1,8 +1,9 @@
-import React, {FC, useContext, useMemo, useCallback} from 'react'
+import React, {FC, useContext, useEffect, useMemo, useCallback} from 'react'
 import {PipeData, FluxResult} from 'src/types/flows'
 import {FlowContext} from 'src/flows/context/flow.current'
 import {ResultsContext} from 'src/flows/context/results'
 import {RemoteDataState, TimeRange} from 'src/types'
+import {useHistory, useLocation} from 'react-router-dom'
 
 export interface PipeContextType {
   id: string
@@ -38,6 +39,24 @@ export const PipeProvider: FC<PipeContextProps> = ({id, children}) => {
   const {results, statuses} = useContext(ResultsContext)
   const result = results[id]
   const status = statuses[id]
+
+  const history = useHistory()
+  const {search} = useLocation()
+
+  const panel = new URLSearchParams(search).get('panel')
+  const statusValues = Object.values(statuses).every(
+    stat => stat !== undefined && stat !== RemoteDataState.Loading
+  )
+
+  useEffect(() => {
+    if (panel && statusValues) {
+      document.getElementById(panel)?.scrollIntoView()
+      setTimeout(() => {
+        // then remove the deep linked panel from the URL?
+        history.push(window.location.pathname)
+      }, 1000)
+    }
+  }, [history, panel, statusValues])
 
   const updater = useCallback(
     (data: Partial<PipeData>) => {


### PR DESCRIPTION
Closes #3826

Previously there were two issues with deep-linking to a panel. Firstly, the deep linking would happen prior to the results being loaded in, rendering the deep link ineffective because the results would expand the previous panels and all context as to which panel was being linked to would be lost. Finally, since the deep-linking is in a useEffect, toggles and little interactions with a deep-linked panel would reset the location of the user to that panel, making the notebook frustratingly difficult to use once a panel query parameter was set in the URL. 

### Solution

This PR resolves the aforementioned issues by:

1. Moving the deep linking to the panel level to check the status of the panels and only deep link to a panel once the panels have finished loading
2. Remove the query parameter in a timeout after the panel has been linked to.

I'm not sure if the latter part of this is what we want to clean up the last issue since it seems a bit hacked and doesn't address the root issue of having a panel query parameter in the URL making interaction with the notebook frustratingly difficult

<!-- Describe your proposed changes here. -->
