### PR TITLE
fix: add newline to flux output, after bucket src and before range

### DIFF
--- a/src/flows/pipes/MetricSelector/index.ts
+++ b/src/flows/pipes/MetricSelector/index.ts
@@ -28,7 +28,7 @@ export default register => {
         return ''
       }
 
-      let text = `from(bucket: "${bucket.name}") |> range(start: v.timeRangeStart, stop: v.timeRangeStop)`
+      let text = `from(bucket: "${bucket.name}")\n\t|> range(start: v.timeRangeStart, stop: v.timeRangeStop)`
       if (measurement) {
         text += ` |> filter(fn: (r) => r["_measurement"] == "${measurement}")`
       }

--- a/src/flows/pipes/QueryBuilder/index.ts
+++ b/src/flows/pipes/QueryBuilder/index.ts
@@ -70,7 +70,7 @@ export default register => {
         _source = `from(bucket: "${data.buckets[0].name}")`
       }
 
-      return `${_source} |> range(start: v.timeRangeStart, stop: v.timeRangeStop)${tags}`
+      return `${_source}\n\t|> range(start: v.timeRangeStart, stop: v.timeRangeStop)${tags}`
     },
   })
 }


### PR DESCRIPTION
No ticket. (Found while using. Fast fix.)

### Issue observed:
* no newline inserted when going queryBuilder --> output to flux.


https://user-images.githubusercontent.com/10232835/153931604-8b09791e-4691-4eec-868d-30e6dba60be4.mov




### Fixed

https://user-images.githubusercontent.com/10232835/153931336-962e42c3-a9c4-42b4-b0bc-68c002f7ed90.mov


