### PR TITLE
chore: remove feature flag `paygCheckoutCredit`

### DIFF
--- a/src/checkout/context/checkout.tsx
+++ b/src/checkout/context/checkout.tsx
@@ -31,7 +31,6 @@ import {PAYG_CREDIT_EXPERIMENT_ID} from 'src/shared/constants'
 // Types
 import {CreditCardParams, RemoteDataState} from 'src/types'
 import {getErrorMessage} from 'src/utils/api'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {event} from 'src/cloud/utils/reporting'
 
 export type Props = {
@@ -262,7 +261,6 @@ export const CheckoutProvider: FC<Props> = React.memo(({children}) => {
   const query = new URLSearchParams(window.location.search)
   const checkoutCode = query.get('c')
   const isPaygCreditActive =
-    isFlagEnabled('paygCheckoutCredit') &&
     getExperimentVariantId(PAYG_CREDIT_EXPERIMENT_ID) === '1' &&
     checkoutCode === CHECKOUT_PARAM_CODE
 

--- a/src/me/components/Resources.tsx
+++ b/src/me/components/Resources.tsx
@@ -40,9 +40,9 @@ const ResourceLists: FC = () => {
           <DocSearchWidget />
         </Panel.Body>
       </Panel>
-      {isFlagEnabled('uiUnificationFlag') &&
-        isFlagEnabled('paygCheckoutCredit') &&
-        paygCreditEnabled && <UsagePanel />}
+      {isFlagEnabled('uiUnificationFlag') && paygCreditEnabled && (
+        <UsagePanel />
+      )}
       <Panel>
         <Panel.Footer>
           <VersionInfo />

--- a/src/me/containers/MePage.tsx
+++ b/src/me/containers/MePage.tsx
@@ -129,8 +129,7 @@ export class MePage extends PureComponent<Props> {
                 </FlexBox>
               </Grid.Column>
               <Grid.Column widthSM={Columns.Four} widthMD={Columns.Three}>
-                {isFlagEnabled('uiUnificationFlag') &&
-                isFlagEnabled('paygCheckoutCredit') ? (
+                {isFlagEnabled('uiUnificationFlag') ? (
                   <UsageProvider>
                     <Resources />
                   </UsageProvider>


### PR DESCRIPTION
UI part of removing the flag `paygCheckoutCredit` mentioned in #3686.

This PR removes the feature flag `paygCheckoutCredit` for PAYG Credit Test. 

Once this PR is merged, I'm going to remove this flag in IDPE. 