### PR TITLE
fix: make tsc run as part of CI pipeline, to avoid merging tsc errors…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,10 @@ jobs:
           name: 'Install Dependencies'
       - run: yarn generate
       - run:
+          name: parallel tsc
+          command: |
+            yarn tsc
+      - run:
           name: parallel eslint
           command: |
             set +e
@@ -115,6 +119,10 @@ jobs:
             yarn install
           name: 'Install Dependencies'
       - run: CLOUD_URL="/auth" yarn generate
+      - run:
+          name: parallel tsc
+          command: |
+            yarn tsc
       - run:
           name: parallel eslint
           command: |


### PR DESCRIPTION
Fix current issue with CI pipeline.
Where we can merge in code that has failing tsc check. Where the commit will merge, but then fail the prod build.

### Issue
Merged commit, which failed in prod build:
https://app.circleci.com/pipelines/github/influxdata/monitor-ci/9235/workflows/bc325e91-97ea-4ac2-afd8-7774c271e114/jobs/434614

Tsc check was removed as part of webpack dev build:
https://github.com/influxdata/ui/pull/3440/files

But we need to explicitly add it to the CI pipeline then (since not part of webpack build).


### Note:
* Right now we have a tsc bug on master. So we expect this CI tests to fail...which is our test-of-the-CI-tests. 😆 
    * it fails!  https://app.circleci.com/pipelines/github/influxdata/ui/11131/workflows/f4ad5dbf-cb82-4b92-9376-182f0e03ece4/jobs/68409
    * it fails!  https://app.circleci.com/pipelines/github/influxdata/ui/11131/workflows/f4ad5dbf-cb82-4b92-9376-182f0e03ece4/jobs/68413
* Then once the tsc fix is in master (another PR)...we should then see this passing.


