### PR TITLE
fix: wrap long words in pinned items titles into multiple lines

### DIFF
--- a/src/me/components/PinnedItems.scss
+++ b/src/me/components/PinnedItems.scss
@@ -23,6 +23,11 @@ $dashboard-grid-gap: $cf-space-2xs;
   background: $cf-grey-25;
 }
 
+.pinneditems--link {
+  word-break: break-word;
+  max-width: fit-content;
+}
+
 @media screen and (max-width: $cf-grid--breakpoint-md) {
   .pinneditems--container {
     grid-template-columns: minmax(0px, 1fr);

--- a/src/me/components/PinnedItems.tsx
+++ b/src/me/components/PinnedItems.tsx
@@ -112,6 +112,7 @@ const PinnedItems: FC = () => {
                 name={item.metadata.name ?? ''}
                 onClick={() => followMetadataToRoute(item)}
                 testID="pinneditems--link"
+                className="pinneditems--link"
               />
             </ResourceCard>
           ))


### PR DESCRIPTION
Closes #3860 

This PR fixed the pinned item titles overflow issue. 

## Before

<img width="751" alt="Screen Shot 2022-02-15 at 2 40 02 PM" src="https://user-images.githubusercontent.com/14298407/154160983-3f6b67d0-5373-45e7-98e3-433d72ba5ef0.png">

## After

<img width="846" alt="Screen Shot 2022-02-15 at 4 33 54 PM" src="https://user-images.githubusercontent.com/14298407/154161057-1b6c5cc0-33e3-4cd0-88b8-6eb7e27dc2f1.png">
