### PR TITLE
fix: fix mailgun alert

### DIFF
--- a/src/flows/pipes/Notification/endpoints/Mailgun/index.ts
+++ b/src/flows/pipes/Notification/endpoints/Mailgun/index.ts
@@ -24,6 +24,8 @@ export default register => {
         .join('\n'),
     generateQuery: data => {
       const subject = encodeURIComponent('InfluxDB Alert')
+      const fromEmail = `InfluxDB via Mailgun <mailgun@${data.domain}>`
+
       return `task_data
 	|> schema["fieldsAsCols"]()
       |> set(key: "_notebook_link", value: "${window.location.href}")
@@ -39,7 +41,7 @@ export default register => {
       auth = http.basicAuth(u: "api", p: "\${apiKey}")
       url = "https://api.mailgun.net/v3/${data.domain}/messages"
       data = strings.joinStr(arr: [
-          "from=Username mailgun@${data.domain}",
+          "from=${fromEmail}",
           "to=${data.email}",
           "subject=${subject}",
           "text=\${r._message}"
@@ -61,12 +63,13 @@ export default register => {
     generateTestQuery: data => {
       const subject = encodeURIComponent('InfluxDB Alert')
       const message = encodeURIComponent(TEST_NOTIFICATION)
+      const fromEmail = `InfluxDB via Mailgun <mailgun@${data.domain}>`
 
       return `apiKey = secrets.get(key: "${data.apiKey}")
 auth = http.basicAuth(u: "api", p: "\${apiKey}")
 url = "https://api.mailgun.net/v3/${data.domain}/messages"
 data = strings.joinStr(arr: [
-  "from=Username mailgun@${data.domain}",
+  "from=${fromEmail}",
   "to=${data.email}",
   "subject=${subject}",
   "text=${message}"

--- a/src/flows/pipes/Notification/endpoints/Mailgun/index.ts
+++ b/src/flows/pipes/Notification/endpoints/Mailgun/index.ts
@@ -24,7 +24,7 @@ export default register => {
         .join('\n'),
     generateQuery: data => {
       const subject = encodeURIComponent('InfluxDB Alert')
-      const fromEmail = `InfluxDB via Mailgun <mailgun@${data.domain}>`
+      const fromEmail = `mailgun@${data.domain}`
 
       return `task_data
 	|> schema["fieldsAsCols"]()
@@ -63,7 +63,7 @@ export default register => {
     generateTestQuery: data => {
       const subject = encodeURIComponent('InfluxDB Alert')
       const message = encodeURIComponent(TEST_NOTIFICATION)
-      const fromEmail = `InfluxDB via Mailgun <mailgun@${data.domain}>`
+      const fromEmail = `mailgun@${data.domain}`
 
       return `apiKey = secrets.get(key: "${data.apiKey}")
 auth = http.basicAuth(u: "api", p: "\${apiKey}")

--- a/src/flows/pipes/Notification/endpoints/Mailgun/index.ts
+++ b/src/flows/pipes/Notification/endpoints/Mailgun/index.ts
@@ -15,11 +15,11 @@ export default register => {
     component: View,
     readOnlyComponent: ReadOnly,
     generateImports: () =>
-      ['http', 'influxdata/influxdb/secrets', 'json']
+      ['http', 'influxdata/influxdb/secrets']
         .map(i => `import "${i}"`)
         .join('\n'),
     generateTestImports: () =>
-      ['array', 'http', 'influxdata/influxdb/secrets', 'json']
+      ['array', 'http', 'influxdata/influxdb/secrets']
         .map(i => `import "${i}"`)
         .join('\n'),
     generateQuery: data => {


### PR DESCRIPTION
Closes #3805 

**Error**
<img width="613" alt="image" src="https://user-images.githubusercontent.com/1637395/154304156-420acb97-542c-44e7-bdd0-645b1c5eb5e2.png">


There were a couple of underlying causes. The first cause was with the existing escape sequence. The second cause was that the http post was not conforming to what mailgun expects.
Updated to send the payload expected by mailgun. Because we aren't escaping much, there's no issue of escape sequence anymore.
