### PR TITLE
test: assert the graph and not the icon

### DIFF
--- a/cypress/e2e/shared/explorerVisualizations.test.ts
+++ b/cypress/e2e/shared/explorerVisualizations.test.ts
@@ -406,7 +406,7 @@ describe('visualizations', () => {
           cy.getByTestID('view-type--dropdown').click()
           cy.getByTestID(`view-type--band`).click()
           cy.getByTestID('time-machine-submit-button').click()
-          cy.getByTestID(`vis-graphic--band`).should('exist')
+          cy.getByTestID('giraffe-layer-band-chart').should('be.visible')
 
           cy.get('button.cf-button[title="Customize"').click()
           cy.getByTestID('dropdown--button-main-column').within(() => {

--- a/cypress/e2e/shared/flows.test.ts
+++ b/cypress/e2e/shared/flows.test.ts
@@ -613,7 +613,7 @@ describe('Flows', () => {
     cy.get(
       '.flow-panel--persistent-control > button.cf-button[title="Run"'
     ).click()
-    cy.getByTestID(`vis-graphic--band`).should('exist')
+    cy.getByTestID('giraffe-layer-band-chart').should('be.visible')
 
     cy.get('button.cf-button[title="Configure Visualization"]').click()
     cy.getByTestID('dropdown--button-main-column').within(() => {


### PR DESCRIPTION
Fixes the flakiness with the Band tests.

- assert the visibility of the graph, which means the query has completed
- do not assert the icon, which is always there even before the query is submitted
