### PR TITLE
fix: remove old token and bucket linking

### DIFF
--- a/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
+++ b/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
@@ -1,4 +1,3 @@
-import {Authorization} from 'src/client'
 import {Organization} from 'src/types'
 
 const openCopyAs = () => {

--- a/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
+++ b/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
@@ -125,9 +125,6 @@ describe('Flows', () => {
       cy.signin()
       cy.get('@org').then(({id}: Organization) => {
         cy.fixture('routes').then(({orgs}) => {
-          cy.request('api/v2/authorizations').then(({body}) => {
-            cy.wrap(body.authorizations).as('tokens')
-          })
           cy.visit(`${orgs}/${id}`)
         })
       })
@@ -144,10 +141,8 @@ describe('Flows', () => {
       openCopyAs()
 
       cy.get('@org').then(({name}: Organization) => {
-        cy.get<Authorization[]>('@tokens').then(tokens => {
-          getClients(name, query).forEach(client => {
-            verifyClientCode(client)
-          })
+        getClients(name, query).forEach(client => {
+          verifyClientCode(client)
         })
       })
     })
@@ -161,10 +156,8 @@ describe('Flows', () => {
       openCopyAs()
 
       cy.get('@org').then(({name}: Organization) => {
-        cy.get<Authorization[]>('@tokens').then(tokens => {
-          getClients(name, tokens[0].token, query).forEach(client => {
-            verifyClientCode(client)
-          })
+        getClients(name, query).forEach(client => {
+          verifyClientCode(client)
         })
       })
     })

--- a/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
+++ b/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
@@ -48,10 +48,6 @@ const verifyClientCode = (client: any) => {
   cy.getByTestID('code-snippet')
     .children()
     .find('code')
-    .contains(client.token)
-  cy.getByTestID('code-snippet')
-    .children()
-    .find('code')
     .contains(client.org)
   cy.getByTestID('code-snippet')
     .children()
@@ -61,71 +57,60 @@ const verifyClientCode = (client: any) => {
   cy.get('.cf-overlay--dismiss').click()
 }
 
-const getClients = (org: string, token: string, query: string) => {
+const getClients = (org: string, query: string) => {
   return [
     {
       name: 'arduino',
-      token: `"<INFLUX_TOKEN>"`,
       org: `"${org}"`,
       query: query.replace(/"/g, '\\"'),
     },
     {
       name: 'csharp',
-      token: `const string token = "${token}";`,
       org: `const string org = "${org}";`,
       query: query.replace(/"/g, '""'),
     },
     {
       name: 'go',
-      token: `"${token}"`,
       org: `client.QueryAPI("${org}")`,
       query,
     },
     {
       name: 'java',
-      token: `String token = "${token}";`,
       org: `String org = "${org}";`,
       query: query.replace(/"/g, '\\"'),
     },
     {
       name: 'javascript-node',
-      token: `const token = '${token}'`,
       org: `const org = '${org}'`,
       query,
     },
     {
       name: 'kotlin',
-      token: `val token = "${token}"`,
       org: `val org = "${org}"`,
       query,
     },
     {
       name: 'php',
-      token: `$token = '${token}';`,
       org: `$org = '${org}';`,
       query: query.replace(/"/g, '\\"'),
     },
     {
       name: 'python',
-      token: `token = "${token}"`,
       org: `org = "${org}"`,
       query,
     },
     {
       name: 'ruby',
-      token: `token = '${token}'`,
       org: `org = '${org}'`,
       query,
     },
     {
       name: 'scala',
-      token: `val token = "${token}"`,
       org: `val org = "${org}"`,
       query,
     },
     {
       name: 'swift',
-      token: `let token = "${token}"`,
       org: `let org = "${org}"`,
       query,
     },
@@ -160,7 +145,7 @@ describe('Flows', () => {
 
       cy.get('@org').then(({name}: Organization) => {
         cy.get<Authorization[]>('@tokens').then(tokens => {
-          getClients(name, tokens[0].token, query).forEach(client => {
+          getClients(name, query).forEach(client => {
             verifyClientCode(client)
           })
         })

--- a/src/writeData/components/ClientCodeCopyPage/index.tsx
+++ b/src/writeData/components/ClientCodeCopyPage/index.tsx
@@ -9,14 +9,8 @@ import InstallPackageHelper from 'src/writeData/components/ClientCodeCopyPage/In
 // Constants
 import {CLIENT_DEFINITIONS} from 'src/writeData'
 
-// Types
-import {ResourceType} from 'src/types'
-
 // Styles
 import 'src/writeData/components/WriteDataDetailsView.scss'
-
-// Utils
-import GetResources from 'src/resources/components/GetResources'
 
 const codeRenderer: any = (props: any): any => {
   return <CodeSnippet text={props.value} label={props.language} />
@@ -35,28 +29,24 @@ const ClientCodeCopyPage: FC<Props> = ({contentID, onCopy}) => {
     sampleCode = `${def.executeFull}`
   }
   return (
-    <GetResources
-      resources={[ResourceType.Authorizations, ResourceType.Buckets]}
-    >
-      <div className="write-data--details">
-        <div
-          className="write-data--details-content markdown-format"
-          data-testid="load-data-details-content"
-        >
-          {!!def.description && (
-            <InstallPackageHelper
-              text={def.description}
-              codeRenderer={codeRenderer}
-            />
-          )}
-          <CodeSampleBlock
-            name="Initialize and Execute Flux"
-            sample={sampleCode}
-            onCopy={onCopy}
+    <div className="write-data--details">
+      <div
+        className="write-data--details-content markdown-format"
+        data-testid="load-data-details-content"
+      >
+        {!!def.description && (
+          <InstallPackageHelper
+            text={def.description}
+            codeRenderer={codeRenderer}
           />
-        </div>
+        )}
+        <CodeSampleBlock
+          name="Initialize and Execute Flux"
+          sample={sampleCode}
+          onCopy={onCopy}
+        />
       </div>
-    </GetResources>
+    </div>
   )
 }
 

--- a/src/writeData/components/ClientCodeQueryHelper.tsx
+++ b/src/writeData/components/ClientCodeQueryHelper.tsx
@@ -9,7 +9,7 @@ import {WriteDataDetailsContext} from 'src/writeData/components/WriteDataDetails
 
 // Constants
 import {CLIENT_DEFINITIONS} from 'src/writeData'
-import {Bucket, File} from 'src/types'
+import {File} from 'src/types'
 
 interface Props {
   clientQuery?: string
@@ -30,20 +30,9 @@ const updateBucketInAST = (ast: File, name: string) => {
   )
 }
 
-const getBucketsFromAST = (ast: File) => {
-  return find(
-    ast,
-    node =>
-      node?.type === 'CallExpression' &&
-      node?.callee?.type === 'Identifier' &&
-      node?.callee?.name === 'from' &&
-      node?.arguments[0]?.properties[0]?.key?.name === 'bucket'
-  ).map(node => node?.arguments[0]?.properties[0]?.value.value)
-}
-
 const ClientCodeQueryHelper: FC<Props> = ({clientQuery, contentID}) => {
   const def = CLIENT_DEFINITIONS[contentID]
-  const {changeBucket, changeQuery} = useContext(WriteDataDetailsContext)
+  const {changeQuery} = useContext(WriteDataDetailsContext)
 
   useEffect(() => {
     if (!clientQuery) {
@@ -52,17 +41,13 @@ const ClientCodeQueryHelper: FC<Props> = ({clientQuery, contentID}) => {
     }
 
     const ast = parse(clientQuery)
-    const queryBucket = getBucketsFromAST(ast)[0]
-    if (queryBucket) {
-      changeBucket({name: queryBucket} as Bucket)
-    }
     updateBucketInAST(ast, '<%= bucket %>')
     let query = format_from_js_file(ast)
     if (def.querySanitize) {
       query = def.querySanitize(query)
     }
     changeQuery(query)
-  }, [clientQuery, def.query, changeBucket, changeQuery])
+  }, [clientQuery, def.query, changeQuery])
 
   return null
 }

--- a/src/writeData/components/ClientCodeQueryHelper.tsx
+++ b/src/writeData/components/ClientCodeQueryHelper.tsx
@@ -9,7 +9,7 @@ import {WriteDataDetailsContext} from 'src/writeData/components/WriteDataDetails
 
 // Constants
 import {CLIENT_DEFINITIONS} from 'src/writeData'
-import {File} from 'src/types'
+import {Bucket, File} from 'src/types'
 
 interface Props {
   clientQuery?: string
@@ -30,9 +30,20 @@ const updateBucketInAST = (ast: File, name: string) => {
   )
 }
 
+const getBucketsFromAST = (ast: File) => {
+  return find(
+    ast,
+    node =>
+      node?.type === 'CallExpression' &&
+      node?.callee?.type === 'Identifier' &&
+      node?.callee?.name === 'from' &&
+      node?.arguments[0]?.properties[0]?.key?.name === 'bucket'
+  ).map(node => node?.arguments[0]?.properties[0]?.value.value)
+}
+
 const ClientCodeQueryHelper: FC<Props> = ({clientQuery, contentID}) => {
   const def = CLIENT_DEFINITIONS[contentID]
-  const {changeQuery} = useContext(WriteDataDetailsContext)
+  const {changeBucket, changeQuery} = useContext(WriteDataDetailsContext)
 
   useEffect(() => {
     if (!clientQuery) {
@@ -41,13 +52,17 @@ const ClientCodeQueryHelper: FC<Props> = ({clientQuery, contentID}) => {
     }
 
     const ast = parse(clientQuery)
+    const queryBucket = getBucketsFromAST(ast)[0]
+    if (queryBucket) {
+      changeBucket({name: queryBucket} as Bucket)
+    }
     updateBucketInAST(ast, '<%= bucket %>')
     let query = format_from_js_file(ast)
     if (def.querySanitize) {
       query = def.querySanitize(query)
     }
     changeQuery(query)
-  }, [clientQuery, def.query, changeQuery])
+  }, [clientQuery, def.query, changeBucket, changeQuery])
 
   return null
 }

--- a/src/writeData/components/WriteDataDetailsContext.tsx
+++ b/src/writeData/components/WriteDataDetailsContext.tsx
@@ -13,26 +13,20 @@ import {
   transform,
 } from 'src/shared/components/CodeSnippet'
 // Utils
-import {getAll} from 'src/resources/selectors'
 import {getOrg} from 'src/organizations/selectors'
 
 // Types
-import {AppState, ResourceType, Bucket, Authorization} from 'src/types'
+import {AppState, ResourceType} from 'src/types'
+
+const DEFAULT_TOKEN = '<INFLUX TOKEN>'
+const DEFAULT_BUCKET = '<BUCKET>'
 
 interface WriteDataDetailsContextType {
-  bucket: Bucket
-  changeBucket: (bucket: Bucket) => void
-  token: Authorization
-  changeToken: (token: Authorization) => void
   query: string
   changeQuery: (query: string) => void
 }
 
 export const DEFAULT_WRITE_DATA_DETAILS_CONTEXT: WriteDataDetailsContextType = {
-  bucket: null,
-  changeBucket: () => {},
-  token: null,
-  changeToken: () => {},
   query: null,
   changeQuery: () => {},
 }
@@ -41,35 +35,13 @@ export const WriteDataDetailsContext = createContext<
 >(DEFAULT_WRITE_DATA_DETAILS_CONTEXT)
 const WriteDataDetailsProvider: FC = ({children}) => {
   const {variables, update} = useContext(TemplateContext)
-  const buckets = useSelector((state: AppState) =>
-    getAll<Bucket>(state, ResourceType.Buckets).filter(b => b.type === 'user')
-  )
-  const tokens = useSelector((state: AppState) =>
-    getAll<Authorization>(state, ResourceType.Authorizations)
-  )
   const org = useSelector(getOrg)
-  const bucketname = useSelector(
-    (state: AppState) => state.dataLoading?.steps?.bucket
-  )
   const server = window.location.origin
-  const toLoadBucket = buckets?.find(b => b.name === bucketname)
-  const [bucket, setBucket] = useState(
-    toLoadBucket ?? buckets[0] ?? ({name: '<BUCKET>'} as Bucket)
-  )
-  const [token, setToken] = useState(tokens[0] ?? {token: '<INFLUX_TOKEN>'})
   const [query, setQuery] = useState(null)
 
-  const changeBucket = useCallback(
-    (toChangeBucket: Bucket) => setBucket(toChangeBucket),
-    [setBucket]
-  )
   const changeQuery = useCallback(
     (toChangeQuery: string) => setQuery(toChangeQuery),
     [setQuery]
-  )
-  const changeToken = useCallback(
-    (toChangeToken: Authorization) => setToken(toChangeToken),
-    [setToken]
   )
 
   useEffect(() => {
@@ -101,33 +73,27 @@ const WriteDataDetailsProvider: FC = ({children}) => {
     })
   }, [variables, org?.name, update])
   useEffect(() => {
-    if (bucket?.name === variables.bucket) {
+    if (DEFAULT_BUCKET === variables.bucket) {
       return
     }
     update({
       ...variables,
-      bucket: bucket.name,
+      bucket: DEFAULT_BUCKET,
     })
-  }, [variables, bucket?.name, bucket, update])
-
+  }, [variables, update])
   useEffect(() => {
-    if (token?.token === variables.token) {
+    if (DEFAULT_TOKEN === variables.token) {
       return
     }
-
     update({
       ...variables,
-      token: token.token,
+      token: DEFAULT_TOKEN,
     })
-  }, [variables, token?.token, token, update])
+  }, [variables, update])
 
   return (
     <WriteDataDetailsContext.Provider
       value={{
-        bucket,
-        changeBucket,
-        token,
-        changeToken,
         query,
         changeQuery,
       }}

--- a/src/writeData/components/WriteDataDetailsContext.tsx
+++ b/src/writeData/components/WriteDataDetailsContext.tsx
@@ -19,7 +19,7 @@ import {getOrg} from 'src/organizations/selectors'
 // Types
 import {AppState, ResourceType, Bucket} from 'src/types'
 
-const DEFAULT_TOKEN = '<INFLUX TOKEN>'
+const DEFAULT_TOKEN = '<INFLUX_TOKEN>'
 const DEFAULT_BUCKET = '<BUCKET>'
 
 interface WriteDataDetailsContextType {


### PR DESCRIPTION
we used to have a mechanism that would autoselect the first bucket and auth token, then load it for people into the template for their client code examples. we removed that feature, but kept in the mechanism, leading to weird behavior as the page lived on and tokens were loaded behind the scene. this removes those mechanisms.