### PR TITLE
test: close the brackets on the cypress selector

### DIFF
--- a/cypress/e2e/shared/explorerVisualizations.test.ts
+++ b/cypress/e2e/shared/explorerVisualizations.test.ts
@@ -408,7 +408,7 @@ describe('visualizations', () => {
           cy.getByTestID('time-machine-submit-button').click()
           cy.getByTestID('giraffe-layer-band-chart').should('be.visible')
 
-          cy.get('button.cf-button[title="Customize"').click()
+          cy.get('button.cf-button[title="Customize"]').click()
           cy.getByTestID('dropdown--button-main-column').within(() => {
             cy.get('.cf-dropdown--selected').contains(AGGREGATE_FUNCTION)
           })

--- a/cypress/e2e/shared/flows.test.ts
+++ b/cypress/e2e/shared/flows.test.ts
@@ -611,7 +611,7 @@ describe('Flows', () => {
     cy.getByTestID('view-type--dropdown').click()
     cy.getByTestID('view-type--band').click()
     cy.get(
-      '.flow-panel--persistent-control > button.cf-button[title="Run"'
+      '.flow-panel--persistent-control > button.cf-button[title="Run"]'
     ).click()
     cy.getByTestID('giraffe-layer-band-chart').should('be.visible')
 


### PR DESCRIPTION
Not sure if this is the cause of all the other tests randomly failing. Probably not, but still. Let's close the brackets here.
