### PR TITLE
fix: cardinality issue

### DIFF
--- a/src/telegrafs/components/TelegrafConfigOverlay.tsx
+++ b/src/telegrafs/components/TelegrafConfigOverlay.tsx
@@ -17,7 +17,7 @@ const TelegrafConfigOverlay: FC = () => {
   const {onClose} = useContext(OverlayContext)
 
   useEffect(() => {
-    event(`telegraf_page.edit_config.at.${Date.now()}`)
+    event(`telegraf_page.edit_config`)
   }, [])
 
   return (


### PR DESCRIPTION
we had a bunch of unique event names showing up in our dataset that were slowing down queries and making it hard to find things. turns out it was because there was an event that changed it's name everytime it was run, resulting in a lot of unique event names. the information it was embedding into the event name is already embedded in the event by the nature of it being an event, so it wasn't required to inject the user's browser's perspective of the time of the event into the meta data.