### PR TITLE
fix: allow All Access Tokens to use all resources

### DIFF
--- a/src/authorizations/components/AllAccessTokenOverlay.tsx
+++ b/src/authorizations/components/AllAccessTokenOverlay.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {ChangeEvent, FC, useState, useContext} from 'react'
+import React, {ChangeEvent, FC, useState, useContext, useMemo} from 'react'
 import {useDispatch, useSelector} from 'react-redux'
 
 // Components
@@ -32,6 +32,7 @@ import {event} from 'src/cloud/utils/reporting'
 // Selectors
 import {getOrg} from 'src/organizations/selectors'
 import {getMe} from 'src/me/selectors'
+import {getAllTokensResources} from 'src/resources/selectors'
 
 // Types
 import {Authorization} from 'src/types'
@@ -46,12 +47,21 @@ const AllAccessTokenOverlay: FC<OwnProps> = props => {
   const [description, setDescription] = useState<string>('')
   const {id: orgID} = useSelector(getOrg)
   const {id: meID} = useSelector(getMe)
+  const allPermissionTypes = useSelector(getAllTokensResources)
+
+  const sortedPermissionTypes = useMemo(
+    () =>
+      allPermissionTypes.sort((a, b) =>
+        a.toLowerCase().localeCompare(b.toLowerCase())
+      ),
+    [allPermissionTypes]
+  )
 
   const handleSave = () => {
     const token: Authorization = {
       orgID,
       description,
-      permissions: allAccessPermissions(orgID, meID),
+      permissions: allAccessPermissions(sortedPermissionTypes, orgID, meID),
     }
     dispatch(createAuthorization(token))
     handleDismiss()

--- a/src/authorizations/components/GenerateTokenDropdown.tsx
+++ b/src/authorizations/components/GenerateTokenDropdown.tsx
@@ -30,9 +30,15 @@ const GenerateTokenDropdown: FC<ReduxProps & GenerateTokenProps> = ({
 
   const customApiOption = 'Custom API Token'
 
-  const handleAllAccess = () => {
-    showOverlay('add-master-token', null, dismissOverlay)
-    event('generate_token_dropdown.all_access_overlay.opened')
+  const handleAllAccess = async () => {
+    try {
+      await getAllResources()
+      showOverlay('add-master-token', null, dismissOverlay)
+      event('generate_token_dropdown.all_access_overlay.opened')
+    } catch (e) {
+      dispatch(notify(getResourcesTokensFailure()))
+      event('generate_token_dropdown.all_access_overlay.failed')
+    }
   }
 
   const handleCustomApi = async () => {

--- a/src/authorizations/utils/permissions.test.ts
+++ b/src/authorizations/utils/permissions.test.ts
@@ -1,4 +1,4 @@
-import {allAccessPermissions} from './permissions'
+import {allAccessPermissions, PermissionTypes} from './permissions'
 import {CLOUD} from 'src/shared/constants'
 import {
   generateDescription,
@@ -709,10 +709,40 @@ const apiPermission5 = [
   },
 ]
 test('all-access tokens/authorizations production test', () => {
+  const allPermissions = new Set<PermissionTypes>()
+
   if (CLOUD) {
-    expect(allAccessPermissions('bulldogs', 'mario')).toMatchObject(cloudHvhs)
+    cloudHvhs.forEach(permission => {
+      allPermissions.add(permission.resource.type as PermissionTypes)
+    })
+    const sortedPermissions = Array.from(allPermissions).sort((a, b) =>
+      a.toLowerCase().localeCompare(b.toLowerCase())
+    )
+    expect(
+      allAccessPermissions(sortedPermissions, 'bulldogs', 'mario')
+    ).toMatchObject(
+      cloudHvhs.sort((a, b) =>
+        a.resource.type
+          .toLowerCase()
+          .localeCompare(b.resource.type.toLowerCase())
+      )
+    )
   } else {
-    expect(allAccessPermissions('bulldogs', 'mario')).toMatchObject(ossHvhs)
+    ossHvhs.forEach(permission => {
+      allPermissions.add(permission.resource.type as PermissionTypes)
+    })
+    const sortedPermissions = Array.from(allPermissions).sort((a, b) =>
+      a.toLowerCase().localeCompare(b.toLowerCase())
+    )
+    expect(
+      allAccessPermissions(sortedPermissions, 'bulldogs', 'mario')
+    ).toMatchObject(
+      ossHvhs.sort((a, b) =>
+        a.resource.type
+          .toLowerCase()
+          .localeCompare(b.resource.type.toLowerCase())
+      )
+    )
   }
 })
 

--- a/src/authorizations/utils/permissions.ts
+++ b/src/authorizations/utils/permissions.ts
@@ -1,47 +1,7 @@
 import {Permission, ResourceType} from 'src/types'
-import {CLOUD} from 'src/shared/constants'
 import {capitalize} from 'lodash'
 
-type PermissionTypes = Permission['resource']['type']
-
-const sharedPermissionTypes: PermissionTypes[] = [
-  'annotations',
-  'authorizations',
-  'buckets',
-  'checks',
-  'dashboards',
-  'dbrp',
-  'documents',
-  'labels',
-  'notificationRules',
-  'notificationEndpoints',
-  'orgs',
-  'secrets',
-  'tasks',
-  'telegrafs',
-  'users',
-  'variables',
-  'views',
-]
-
-const cloudPermissionTypes = ['flows', 'functions']
-
-const ossPermissionTypes = [
-  'notebooks',
-  'scrapers',
-  'sources',
-  'remotes',
-  'replications',
-]
-
-// TODO: replace this with some server side mechanism
-const allPermissionTypes: PermissionTypes[] = sharedPermissionTypes.concat(
-  (CLOUD ? cloudPermissionTypes : ossPermissionTypes) as PermissionTypes[]
-)
-
-allPermissionTypes.sort((a, b) =>
-  a.toLowerCase().localeCompare(b.toLowerCase())
-)
+export type PermissionTypes = Permission['resource']['type']
 
 const ensureT = (orgID: string, userID: string) => (
   t: PermissionTypes
@@ -70,10 +30,6 @@ const ensureT = (orgID: string, userID: string) => (
     ]
   }
 
-  if (!allPermissionTypes.includes(t)) {
-    throw new Error('Unexpected object: ' + t)
-  }
-
   return [
     {
       action: 'read' as 'read',
@@ -87,6 +43,7 @@ const ensureT = (orgID: string, userID: string) => (
 }
 
 export const allAccessPermissions = (
+  allPermissionTypes: PermissionTypes[],
   orgID: string,
   userID: string
 ): Permission[] => {

--- a/src/resources/selectors/index.ts
+++ b/src/resources/selectors/index.ts
@@ -12,6 +12,7 @@ import {
   Task,
   Telegraf,
 } from 'src/types'
+import {PermissionTypes} from 'src/authorizations/utils/permissions'
 
 export const getStatus = (
   {resources}: AppState,
@@ -68,3 +69,6 @@ export const getLabels = (state: AppState, labelIDs: string[]): Label[] => {
     .map(labelID => getByID<Label>(state, ResourceType.Labels, labelID))
     .filter(label => !!label)
 }
+
+export const getAllTokensResources = (state: AppState): PermissionTypes[] =>
+  get(state, 'resources.tokens.allResources', []) || []


### PR DESCRIPTION
Closes #3836 

Allows All Access Tokens to get all resources and use the tokens' `allResources` list to populate all the permissions.



https://user-images.githubusercontent.com/10736577/154393911-bcf63b2a-8131-4935-b412-42523ef171b0.mp4



