### PR TITLE
fix(3873/3874/3876): secrets in http alerts

### DIFF
--- a/cypress/e2e/shared/flowsAlerts.test.ts
+++ b/cypress/e2e/shared/flowsAlerts.test.ts
@@ -219,8 +219,9 @@ describe('flows alert panel', () => {
     cy.getByTestID('dropdown-item--http').click()
     cy.getByTestID('option--bearer').click()
     cy.getByTestID('input--url').clear()
-    cy.getByTestID('input--url').type(fakeUrl)
-    cy.getByTestID('input--token').type('fake-token')
+    cy.getByTestID('input--url').click()
+    cy.getByTestID('dropdown--token').click()
+    cy.getByTestID('dropdown-item--mySecret').click()
 
     cy.getByTestID('task-form-save').click()
     /* NOTE: we used to be able to test that the generated flux contained the the

--- a/src/flows/pipes/Notification/endpoints/HTTP/view.tsx
+++ b/src/flows/pipes/Notification/endpoints/HTTP/view.tsx
@@ -10,10 +10,11 @@ import {
   AlignItems,
 } from '@influxdata/clockface'
 
+import SecretsDropdown from 'src/secrets/components/SecretsDropdown'
 import {PipeContext} from 'src/flows/context/pipe'
 import {EndpointProps} from 'src/types'
 
-const View: FC<EndpointProps> = () => {
+const View: FC<EndpointProps> = ({createSecret, secrets}) => {
   const {data, update} = useContext(PipeContext)
 
   const updater = (field, value) => {
@@ -33,16 +34,16 @@ const View: FC<EndpointProps> = () => {
     updater('auth', auth)
   }
 
-  const updateUsername = evt => {
-    updater('username', evt.target.value)
+  const updateUsername = val => {
+    updater('username', val)
   }
 
-  const updatePassword = evt => {
-    updater('password', evt.target.value)
+  const updatePassword = val => {
+    updater('password', val)
   }
 
-  const updateToken = evt => {
-    updater('token', evt.target.value)
+  const updateToken = val => {
+    updater('token', val)
   }
 
   let submenu
@@ -51,23 +52,21 @@ const View: FC<EndpointProps> = () => {
     submenu = (
       <>
         <Form.Element label="Username">
-          <Input
-            name="username"
-            testID="input--username"
-            type={InputType.Text}
-            value={data.endpointData.username}
-            onChange={updateUsername}
-            size={ComponentSize.Medium}
+          <SecretsDropdown
+            testID="username"
+            selected={data.endpointData.username}
+            secrets={secrets}
+            onCreate={createSecret}
+            onSelect={updateUsername}
           />
         </Form.Element>
         <Form.Element label="Password">
-          <Input
-            name="password"
-            testID="input--password"
-            type={InputType.Text}
-            value={data.endpointData.password}
-            onChange={updatePassword}
-            size={ComponentSize.Medium}
+          <SecretsDropdown
+            testID="password"
+            selected={data.endpointData.password}
+            secrets={secrets}
+            onCreate={createSecret}
+            onSelect={updatePassword}
           />
         </Form.Element>
       </>
@@ -75,13 +74,12 @@ const View: FC<EndpointProps> = () => {
   } else if (data.endpointData.auth === 'bearer') {
     submenu = (
       <Form.Element label="Token">
-        <Input
-          name="token"
-          testID="input--token"
-          type={InputType.Text}
-          value={data.endpointData.token}
-          onChange={updateToken}
-          size={ComponentSize.Medium}
+        <SecretsDropdown
+          testID="token"
+          selected={data.endpointData.token}
+          secrets={secrets}
+          onCreate={createSecret}
+          onSelect={updateToken}
         />
       </Form.Element>
     )


### PR DESCRIPTION
Closes #3873
Closes #3874 
Closes #3876 

### Issue summary:
* tickets 3873, 3874, and 3876 were all an artifact of the http notifications **basic auth** not yet using the secrets flux API. That has now been updated for notebook alerts.
* also then did the same for the http notifications **tokens**.

.

### Evidence for fix using in basic auth (http notifications):

Test alert uses secrets, for basic auth:
<img width="1515" alt="Screen Shot 2022-02-16 at 2 54 22 PM" src="https://user-images.githubusercontent.com/10232835/154375393-624f95d4-e8fa-43c2-852d-78d712cd5bde.png">

Exported task uses secrets, for basic auth:
<img width="1406" alt="Screen Shot 2022-02-16 at 2 59 44 PM" src="https://user-images.githubusercontent.com/10232835/154375424-839a853a-5124-4314-9d3d-59c3bdcae01f.png">

Exported task successfully runs:
<img width="1466" alt="Screen Shot 2022-02-16 at 2 58 35 PM" src="https://user-images.githubusercontent.com/10232835/154375408-ec5c6d01-9982-4cab-8fdc-ce3a8c76edf7.png">

.

### Evidence for fix using tokens (http notifications):

Test alert uses secrets, for token:
<img width="1511" alt="Screen Shot 2022-02-16 at 3 46 56 PM" src="https://user-images.githubusercontent.com/10232835/154376791-6f0f2e14-80c7-427b-9e04-73ae4d0a5770.png">


Exported task uses secrets, for token:
<img width="1288" alt="Screen Shot 2022-02-16 at 3 48 00 PM" src="https://user-images.githubusercontent.com/10232835/154376797-915f3d9f-2d76-4ba6-b0f4-9cf0aa95f71e.png">


Exported task successfully runs:
<img width="1349" alt="Screen Shot 2022-02-16 at 3 48 15 PM" src="https://user-images.githubusercontent.com/10232835/154376808-eebed5e8-8b0e-4a43-b096-74b2af5efa5f.png">


.