### PR TITLE
fix: (multi account) call getMe once more after flags are loaded

### DIFF
--- a/src/me/actions/thunks/index.ts
+++ b/src/me/actions/thunks/index.ts
@@ -30,18 +30,31 @@ export const getMe = () => async (
   try {
     let user
 
+    // TODO: remove these logs, just for testing.
+    // eslint-disable-next-line no-console
+    console.log(
+      'Flag evaluation: ',
+      isFlagEnabled('multiAccount'),
+      isFlagEnabled('avatarWidgetMultiAccountInfo')
+    )
+
     if (
       isFlagEnabled('multiAccount') &&
       isFlagEnabled('avatarWidgetMultiAccountInfo')
     ) {
       const resp = await getAccounts({})
 
+      // eslint-disable-next-line no-console
+      console.log('Using Quartz api', {resp})
       if (resp.status !== 200) {
         throw new Error(resp.data.message)
       }
       user = resp.data.find(account => account.isActive)
     } else {
       const resp = await apiGetApiMe({})
+
+      // eslint-disable-next-line no-console
+      console.log('Using IDPE api', {resp})
 
       if (resp.status !== 200) {
         throw new Error(resp.data.message)

--- a/src/me/actions/thunks/index.ts
+++ b/src/me/actions/thunks/index.ts
@@ -84,6 +84,8 @@ export const getMe = () => async (
       identify(user.id, {email: user.name, orgID: org.id})
     }
 
+    // eslint-disable-next-line no-console
+    console.log('Final user object dispatched to state: ', {user})
     dispatch(setMe(user as MeState))
   } catch (error) {
     console.error(error)

--- a/src/me/actions/thunks/index.ts
+++ b/src/me/actions/thunks/index.ts
@@ -51,8 +51,7 @@ export const getMe = () => async (
     } else {
       const resp = await apiGetApiMe({})
 
-      // eslint-disable-next-line no-console
-      console.log('Using IDPE api', {resp})
+      console.warn('Using IDPE api', {resp})
 
       if (resp.status !== 200) {
         throw new Error(resp.data.message)

--- a/src/me/actions/thunks/index.ts
+++ b/src/me/actions/thunks/index.ts
@@ -30,9 +30,8 @@ export const getMe = () => async (
   try {
     let user
 
-    // TODO: remove these logs, just for testing.
-    // eslint-disable-next-line no-console
-    console.log(
+    // TODO: remove these console statements, just for testing.
+    console.warn(
       'Flag evaluation: ',
       isFlagEnabled('multiAccount'),
       isFlagEnabled('avatarWidgetMultiAccountInfo')
@@ -44,8 +43,7 @@ export const getMe = () => async (
     ) {
       const resp = await getAccounts({})
 
-      // eslint-disable-next-line no-console
-      console.log('Using Quartz api', {resp})
+      console.warn('Using Quartz api', {resp})
       if (resp.status !== 200) {
         throw new Error(resp.data.message)
       }
@@ -84,8 +82,7 @@ export const getMe = () => async (
       identify(user.id, {email: user.name, orgID: org.id})
     }
 
-    // eslint-disable-next-line no-console
-    console.log('Final user object dispatched to state: ', {user})
+    console.warn('Final user object dispatched to state: ', {user})
     dispatch(setMe(user as MeState))
   } catch (error) {
     console.error(error)

--- a/src/shared/containers/GetMe.tsx
+++ b/src/shared/containers/GetMe.tsx
@@ -18,6 +18,7 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface State {
   loading: RemoteDataState
+  getMeCalledAfterFlagsLoaded: boolean
 }
 
 type ReduxProps = ConnectedProps<typeof connector>
@@ -30,6 +31,7 @@ class GetMe extends PureComponent<Props, State> {
 
     this.state = {
       loading: RemoteDataState.NotStarted,
+      getMeCalledAfterFlagsLoaded: false
     }
   }
 
@@ -48,6 +50,17 @@ class GetMe extends PureComponent<Props, State> {
   public componentDidMount() {
     this.props.getMe()
     this.setState({loading: RemoteDataState.Done})
+  }
+
+  public componentDidUpdate() {
+    // when the flags are loaded, we want to call this again so we can decide
+    // whether quartz or IDPE needs to be called to get the user information
+
+    // getMeCalledAfterFlagsLoaded state controls the call so it's only called once after flags are loaded.
+    if (this.state.getMeCalledAfterFlagsLoaded === false) {
+      this.props.getMe()
+      this.setState({getMeCalledAfterFlagsLoaded: true})
+    }
   }
 }
 

--- a/src/shared/containers/GetMe.tsx
+++ b/src/shared/containers/GetMe.tsx
@@ -31,7 +31,7 @@ class GetMe extends PureComponent<Props, State> {
 
     this.state = {
       loading: RemoteDataState.NotStarted,
-      getMeCalledAfterFlagsLoaded: false
+      getMeCalledAfterFlagsLoaded: false,
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/3757

The issue is that we're referencing the feature flags inside [getMe](https://github.com/influxdata/ui/blob/8c3ba72b41034e6faa35dffe167570094ae4fc80/src/me/actions/thunks/index.ts#L40-L44) (`multiAccount` and `avatarWidgetMultiAccountInfo`) before the flags are even loaded. The fix envolves calling the `getMe` one more time again when the `GetFlags` is finished loading the flags. This lets us use the flags inside the `getMe` function [here](https://github.com/influxdata/ui/blob/8c3ba72b41034e6faa35dffe167570094ae4fc80/src/me/actions/thunks/index.ts#L40-L44)


https://user-images.githubusercontent.com/18511823/154751210-9c4d361b-5239-4668-bb97-f10801290dfd.mov



<!-- Describe your proposed changes here. -->
