### PR TITLE
chore: replace `react-copy-to-clipboard` with native JS

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,7 +168,6 @@
     "chroma-js": "^1.3.6",
     "classnames": "^2.2.3",
     "connected-react-router": "^6.8.0",
-    "copy-to-clipboard": "^3.3.1",
     "d3-dsv": "^3.0.1",
     "deep-object-diff": "^1.1.0",
     "fix-date": "^1.1.6",

--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
     "chroma-js": "^1.3.6",
     "classnames": "^2.2.3",
     "connected-react-router": "^6.8.0",
+    "copy-to-clipboard": "^3.3.1",
     "d3-dsv": "^3.0.1",
     "deep-object-diff": "^1.1.0",
     "fix-date": "^1.1.6",

--- a/package.json
+++ b/package.json
@@ -193,7 +193,6 @@
     "qrcode.react": "^1.0.1",
     "react": "^17.0.2",
     "react-beautiful-dnd": "^13.0.0",
-    "react-copy-to-clipboard": "^5.0.1",
     "react-datepicker": "^2.1.0",
     "react-dnd": "^9.3.2",
     "react-dnd-html5-backend": "^9.3.2",

--- a/src/buckets/components/BucketCardMeta.tsx
+++ b/src/buckets/components/BucketCardMeta.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {FC} from 'react'
-import CopyToClipboard from 'react-copy-to-clipboard'
 import {capitalize} from 'lodash'
 import {connect, ConnectedProps} from 'react-redux'
 
@@ -16,6 +15,7 @@ import {notify as notifyAction} from 'src/shared/actions/notifications'
 
 // Components
 import {ResourceCard} from '@influxdata/clockface'
+import CopyToClipboard from 'src/shared/components/CopyToClipboard'
 
 // Types
 import {OwnBucket} from 'src/types'

--- a/src/secrets/components/SecretContextMenu.tsx
+++ b/src/secrets/components/SecretContextMenu.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {FC} from 'react'
-import CopyToClipboard from 'react-copy-to-clipboard'
 import {useDispatch} from 'react-redux'
 
 // Components
@@ -13,6 +12,7 @@ import {
   IconFont,
   SquareButton,
 } from '@influxdata/clockface'
+import CopyToClipboard from 'src/shared/components/CopyToClipboard'
 
 // Actions
 import {notify} from 'src/shared/actions/notifications'

--- a/src/shared/components/CopyButton.tsx
+++ b/src/shared/components/CopyButton.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {PureComponent, MouseEvent} from 'react'
-import CopyToClipboard from 'react-copy-to-clipboard'
 
 // Components
 import {
@@ -9,6 +8,7 @@ import {
   ComponentSize,
   ButtonShape,
 } from '@influxdata/clockface'
+import CopyToClipboard from 'src/shared/components/CopyToClipboard'
 
 interface Props {
   text: string

--- a/src/shared/components/CopyResourceID.tsx
+++ b/src/shared/components/CopyResourceID.tsx
@@ -1,6 +1,5 @@
 import React, {FC} from 'react'
 import {useDispatch} from 'react-redux'
-import CopyToClipboard from 'react-copy-to-clipboard'
 
 // Notifications
 import {notify} from 'src/shared/actions/notifications'
@@ -8,6 +7,9 @@ import {
   copyToClipboardSuccess,
   copyToClipboardFailed,
 } from 'src/shared/copy/notifications'
+
+// Components
+import CopyToClipboard from 'src/shared/components/CopyToClipboard'
 
 interface ResourceWithID {
   id?: string

--- a/src/shared/components/CopyToClipboard.tsx
+++ b/src/shared/components/CopyToClipboard.tsx
@@ -4,14 +4,14 @@ import copy from 'copy-to-clipboard'
 
 interface Props {
   text: string
-  onCopy: (copiedText: string, copyWasSuccessful: boolean) => void
-  children?: JSX.Element
+  children: JSX.Element
+  onCopy?: (copiedText: string, copyWasSuccessful: boolean) => void
 }
 
-const CopyToClipboard: FC<Props> = ({text, onCopy, children, ...props}) => {
-  const onClick = (event: ChangeEvent<HTMLInputElement>) => {
-    const elem = React.Children.only(children)
+const CopyToClipboard: FC<Props> = ({text, children, onCopy, ...props}) => {
+  const elem = React.Children.only(children)
 
+  const onClick = (event: ChangeEvent<HTMLInputElement>) => {
     const result = copy(text)
 
     if (onCopy) {
@@ -23,8 +23,6 @@ const CopyToClipboard: FC<Props> = ({text, onCopy, children, ...props}) => {
       elem.props.onClick(event)
     }
   }
-
-  const elem = React.Children.only(children)
 
   return React.cloneElement(elem, {...props, onClick})
 }

--- a/src/shared/components/CopyToClipboard.tsx
+++ b/src/shared/components/CopyToClipboard.tsx
@@ -1,7 +1,25 @@
 // Libraries
 import React, {FC, ChangeEvent} from 'react'
-import copy from 'copy-to-clipboard'
 
+const copy = async (text: string): Promise<boolean> => {
+  let result: boolean
+  try {
+    if (navigator.clipboard) {
+      // All browsers except IE
+      await navigator.clipboard.writeText(text)
+    } else {
+      // IE
+      const successful = document.execCommand('copy')
+      if (!successful) {
+        throw new Error('Copy command was unsuccessful using execCommand')
+      }
+    }
+    result = true
+  } catch (err) {
+    result = false
+  }
+  return result
+}
 interface Props {
   text: string
   children: JSX.Element
@@ -11,8 +29,8 @@ interface Props {
 const CopyToClipboard: FC<Props> = ({text, children, onCopy, ...props}) => {
   const elem = React.Children.only(children)
 
-  const onClick = (event: ChangeEvent<HTMLInputElement>) => {
-    const result = copy(text)
+  const onClick = async (event: ChangeEvent<HTMLInputElement>) => {
+    const result = await copy(text)
 
     if (onCopy) {
       onCopy(text, result)

--- a/src/shared/components/CopyToClipboard.tsx
+++ b/src/shared/components/CopyToClipboard.tsx
@@ -1,0 +1,32 @@
+// Libraries
+import React, {FC, ChangeEvent} from 'react'
+import copy from 'copy-to-clipboard'
+
+interface Props {
+  text: string
+  onCopy: (copiedText: string, copyWasSuccessful: boolean) => void
+  children?: JSX.Element
+}
+
+const CopyToClipboard: FC<Props> = ({text, onCopy, children, ...props}) => {
+  const onClick = (event: ChangeEvent<HTMLInputElement>) => {
+    const elem = React.Children.only(children)
+
+    const result = copy(text)
+
+    if (onCopy) {
+      onCopy(text, result)
+    }
+
+    // Bypass onClick if it was present
+    if (elem && elem.props && typeof elem.props.onClick === 'function') {
+      elem.props.onClick(event)
+    }
+  }
+
+  const elem = React.Children.only(children)
+
+  return React.cloneElement(elem, {...props, onClick})
+}
+
+export default CopyToClipboard

--- a/src/shared/components/EmptyGraphError.tsx
+++ b/src/shared/components/EmptyGraphError.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {useState, FunctionComponent} from 'react'
-import CopyToClipboard from 'react-copy-to-clipboard'
 
 // Components
 import {
@@ -11,6 +10,7 @@ import {
   IconFont,
   DapperScrollbars,
 } from '@influxdata/clockface'
+import CopyToClipboard from 'src/shared/components/CopyToClipboard'
 
 interface Props {
   message: string

--- a/src/shared/components/EmptyGraphErrorTooltip.tsx
+++ b/src/shared/components/EmptyGraphErrorTooltip.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {FC, useRef, useState} from 'react'
-import CopyToClipboard from 'react-copy-to-clipboard'
 
 // Components
 import {
@@ -13,6 +12,7 @@ import {
   PopoverInteraction,
   Appearance,
 } from '@influxdata/clockface'
+import CopyToClipboard from 'src/shared/components/CopyToClipboard'
 
 interface Props {
   message: string

--- a/yarn.lock
+++ b/yarn.lock
@@ -3766,7 +3766,7 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-copy-to-clipboard@^3:
+copy-to-clipboard@^3, copy-to-clipboard@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz#115aa1a9998ffab6196f93076ad6da3b913662ae"
   integrity sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3766,7 +3766,7 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-copy-to-clipboard@^3, copy-to-clipboard@^3.3.1:
+copy-to-clipboard@^3:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz#115aa1a9998ffab6196f93076ad6da3b913662ae"
   integrity sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3766,13 +3766,6 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-copy-to-clipboard@^3:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz#115aa1a9998ffab6196f93076ad6da3b913662ae"
-  integrity sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==
-  dependencies:
-    toggle-selection "^1.0.6"
-
 core-js-compat@^3.18.0, core-js-compat@^3.19.1:
   version "3.19.3"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.19.3.tgz#de75e5821c5ce924a0a1e7b7d5c2cb973ff388aa"
@@ -9229,7 +9222,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@15.x, prop-types@^15.5.0, prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@15.x, prop-types@^15.5.0, prop-types@^15.5.10, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -9450,14 +9443,6 @@ react-beautiful-dnd@^13.0.0:
     react-redux "^7.2.0"
     redux "^4.0.4"
     use-memo-one "^1.1.1"
-
-react-copy-to-clipboard@^5.0.1:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/react-copy-to-clipboard/-/react-copy-to-clipboard-5.0.4.tgz#42ec519b03eb9413b118af92d1780c403a5f19bf"
-  integrity sha512-IeVAiNVKjSPeGax/Gmkqfa/+PuMTBhutEvFUaMQLwE2tS0EXrAdgOpWDX26bWTXF3HrioorR7lr08NqeYUWQCQ==
-  dependencies:
-    copy-to-clipboard "^3"
-    prop-types "^15.5.8"
 
 react-datepicker@^2.1.0:
   version "2.16.0"
@@ -11131,11 +11116,6 @@ to-space-case@^1.0.0:
   integrity sha1-sFLar7Gysp3HcM6gFj5ewOvJ/Bc=
   dependencies:
     to-no-case "^1.0.0"
-
-toggle-selection@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
-  integrity sha1-bkWxJj8gF/oKzH2J14sVuL932jI=
 
 toidentifier@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Closes #3591 

This PR removed the dependency library `react-copy-to-clipboard` and replaced it with native JS. 