### PR TITLE
fix: set share to null to reset the state

### DIFF
--- a/src/flows/components/header/index.tsx
+++ b/src/flows/components/header/index.tsx
@@ -317,6 +317,7 @@ const FlowHeader: FC = () => {
   const handleClone = async () => {
     event('clone_notebook')
     const clonedId = await clone(flow.id)
+    setShare(null)
     history.push(
       `/orgs/${orgID}/${PROJECT_NAME_PLURAL.toLowerCase()}/${clonedId}`
     )


### PR DESCRIPTION
Closes #3766

This is a weird edge case where navigating to a newly cloned notebook after sharing and cancelling out of the shared state would keep a reference to the original share in the state. Clearing it out seems to do the trick, but this kind of seems indicative that there's some sort of memoization happening where data isn't being properly cleared when the state changes for the component. 

<!-- Describe your proposed changes here. -->
