### PR TITLE
chore: update design for cloning cells across dashboards

### DIFF
--- a/cypress/e2e/shared/dashboardsView.test.ts
+++ b/cypress/e2e/shared/dashboardsView.test.ts
@@ -1353,7 +1353,7 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
     it('moves a cell to another dashboard and removes it from the current one', () => {
       cy.getByTestID('clone-to-other-dashboard').click()
       cy.getByTestID(`other-dashboard-${otherBoardID}`).click()
-      cy.getByTestID('clone-cell-type-toggle').click()
+      cy.getByTestID('cell-clone-move-cell').click()
       cy.intercept('PATCH', '/api/v2/dashboards/*/cells/*/view').as('setView')
       cy.getByTestID('confirm-clone-cell-button').click()
       cy.wait('@setView')

--- a/src/dashboards/components/AutoRefresh.scss
+++ b/src/dashboards/components/AutoRefresh.scss
@@ -47,10 +47,6 @@
   width: 100px;
 }
 
-.refresh-form-time-label {
-  font-size: 13px;
-}
-
 .timerange-dropdown {
   justify-self: end;
   width: 100%;

--- a/src/shared/components/cells/Cell.scss
+++ b/src/shared/components/cells/Cell.scss
@@ -274,9 +274,9 @@ $cell--header-button-active-color: $c-pool;
 }
 
 .dashboard-clonecell--dropdownopen {
-  align-items: center !important;
-  width: 80%;
+  width: 70% !important;
 }
+
 .dashboard-clonecell--removecurrent {
   justify-content: center;
   flex-direction: row !important;

--- a/src/shared/components/cells/Cell.scss
+++ b/src/shared/components/cells/Cell.scss
@@ -277,23 +277,8 @@ $cell--header-button-active-color: $c-pool;
   width: 70% !important;
 }
 
-.dashboard-clonecell--removecurrent {
-  justify-content: center;
-  flex-direction: row !important;
-  align-items: center !important;
-  padding-top: $form-sm-padding;
-}
-
 .dashboard-clonecell--overlayopen {
   display: flex;
   flex-direction: column;
   align-items: center;
-}
-
-.dashboard-clonecell--movetype {
-  margin-right: 15px;
-}
-
-.dashboard-clonecell--typetoggle {
-  margin: 5px;
 }

--- a/src/shared/components/cells/CellCloneOverlay.tsx
+++ b/src/shared/components/cells/CellCloneOverlay.tsx
@@ -9,7 +9,6 @@ import {
   ButtonShape,
   Overlay,
   ComponentColor,
-  SlideToggle,
   Form,
   ComponentStatus,
   TypeAheadDropDown,

--- a/src/shared/components/cells/CellCloneOverlay.tsx
+++ b/src/shared/components/cells/CellCloneOverlay.tsx
@@ -160,8 +160,11 @@ const CellCloneOverlay: FC = () => {
   )
 
   return (
-    <Overlay.Container maxWidth={400}>
-      <Overlay.Header title="Move Cell" onDismiss={onClose} />
+    <Overlay.Container maxWidth={500}>
+      <Overlay.Header
+        title="Move or Copy Cell to Dashboard"
+        onDismiss={onClose}
+      />
       <Overlay.Body className="dashboard-clonecell--overlayopen">
         <Form.Element label="" className="dashboard-clonecell--dropdownopen">
           {typeAheadDropdown}

--- a/src/shared/components/cells/CellCloneOverlay.tsx
+++ b/src/shared/components/cells/CellCloneOverlay.tsx
@@ -154,8 +154,9 @@ const CellCloneOverlay: FC = () => {
       itemTestIdPrefix="other-dashboard"
       sortNames={true}
       selectedOption={selectedDashboard as SelectableItem}
-      placeholderText="Choose a Destination Dashboard"
+      placeholderText="Choose Dashboard"
       defaultNameText="Name this Dashboard"
+      className="dashboard-clonecell--dropdownopen"
     />
   )
 
@@ -166,7 +167,12 @@ const CellCloneOverlay: FC = () => {
         onDismiss={onClose}
       />
       <Overlay.Body className="dashboard-clonecell--overlayopen">
-        <Form.Element label="" className="dashboard-clonecell--dropdownopen">
+        <Form.Element
+          label="Dashboard"
+          helpText={`Where do you want to ${
+            removeFromCurrentBoard ? 'move' : 'copy'
+          } your cell to?`}
+        >
           {typeAheadDropdown}
         </Form.Element>
         <Form.Element label="" className="dashboard-clonecell--removecurrent">

--- a/src/shared/components/cells/CellCloneOverlay.tsx
+++ b/src/shared/components/cells/CellCloneOverlay.tsx
@@ -6,14 +6,15 @@ import {OverlayContext} from 'src/overlays/components/OverlayController'
 // Clockface
 import {
   Button,
+  ButtonShape,
   Overlay,
   ComponentColor,
-  InputLabel,
   SlideToggle,
   Form,
   ComponentStatus,
   TypeAheadDropDown,
   SelectableItem,
+  SelectGroup,
 } from '@influxdata/clockface'
 
 // Actions
@@ -145,6 +146,30 @@ const CellCloneOverlay: FC = () => {
     setDestinationDashboardID(item?.id)
   }
 
+  const selectGroupOptions = [
+    {
+      id: 'cell-clone-move-cell',
+      title: 'Move',
+      removeFromCurrentBoard: removeFromCurrentBoard,
+    },
+    {
+      id: 'cell-clone-copy-cell',
+      title: 'Copy',
+      removeFromCurrentBoard: !removeFromCurrentBoard,
+    },
+  ].map(option => (
+    <SelectGroup.Option
+      key={option.id}
+      id={option.id}
+      active={option.removeFromCurrentBoard}
+      value={option.removeFromCurrentBoard}
+      onClick={() => setRemoveFromCurrentBoard(prevState => !prevState)}
+      testID={option.id}
+    >
+      {option.title}
+    </SelectGroup.Option>
+  ))
+
   const typeAheadDropdown = (
     <TypeAheadDropDown
       items={dashItems}
@@ -167,6 +192,11 @@ const CellCloneOverlay: FC = () => {
         onDismiss={onClose}
       />
       <Overlay.Body className="dashboard-clonecell--overlayopen">
+        <Form.Element label="">
+          <SelectGroup shape={ButtonShape.StretchToFit}>
+            {selectGroupOptions}
+          </SelectGroup>
+        </Form.Element>
         <Form.Element
           label="Dashboard"
           helpText={`Where do you want to ${
@@ -174,27 +204,6 @@ const CellCloneOverlay: FC = () => {
           } your cell to?`}
         >
           {typeAheadDropdown}
-        </Form.Element>
-        <Form.Element label="" className="dashboard-clonecell--removecurrent">
-          <span className="dashboard-clonecell--movetype">Move type: </span>
-          <InputLabel
-            active={!removeFromCurrentBoard}
-            className="refresh-form-time-label"
-          >
-            Copy
-          </InputLabel>
-          <SlideToggle
-            active={removeFromCurrentBoard}
-            onChange={() => setRemoveFromCurrentBoard(!removeFromCurrentBoard)}
-            testID="clone-cell-type-toggle"
-            className="dashboard-clonecell--typetoggle"
-          />
-          <InputLabel
-            active={removeFromCurrentBoard}
-            className="refresh-form-time-label"
-          >
-            Move
-          </InputLabel>
         </Form.Element>
       </Overlay.Body>
       <Overlay.Footer>

--- a/src/shared/components/cells/CellContext.tsx
+++ b/src/shared/components/cells/CellContext.tsx
@@ -108,7 +108,7 @@ const CellContext: FC<Props> = ({
           />
           <FeatureFlag name="cloneToOtherBoards">
             <CellContextItem
-              label="Relocate"
+              label="Move"
               onClick={() =>
                 onShowOverlay(
                   'cell-copy-overlay',
@@ -181,7 +181,7 @@ const CellContext: FC<Props> = ({
         />
         <FeatureFlag name="cloneToOtherBoards">
           <CellContextItem
-            label="Relocate"
+            label="Move"
             onClick={() =>
               onShowOverlay(
                 'cell-copy-overlay',


### PR DESCRIPTION
Closes #3934 

This PR updated the UI design for cloning cells across dashboards because we would like to release the ability to clone cells across dashboards to production (https://github.com/influxdata/ui/issues/3678). 

## Before
<img width="125" alt="153626740-c37f2aa2-b3ce-406c-a314-372fefcab140" src="https://user-images.githubusercontent.com/14298407/155388329-b63ec268-8574-46de-b87b-ea6b3e54dae8.png">
<img width="486" alt="153626765-c5f55946-aa30-4eeb-8440-b287d3dc4622" src="https://user-images.githubusercontent.com/14298407/155388336-812690e1-9fad-4c73-b4c5-50ecc45c5310.png">

## After
https://user-images.githubusercontent.com/14298407/155388378-1ea09410-b650-4bba-95cd-20ed10b9202a.mov


