### PR TITLE
chore(notebook): update button name to "Test Endpoint"

### DIFF
--- a/src/flows/pipes/Notification/view.tsx
+++ b/src/flows/pipes/Notification/view.tsx
@@ -256,7 +256,7 @@ const Notification: FC<PipeProp> = ({Context}) => {
     ))
 
   const handleTestEndpoint = async () => {
-    event('Alert Panel (Notebooks) - Test Alert Clicked')
+    event('Alert Panel (Notebooks) - Test Endpoint Clicked')
 
     const queryText = `
       import "strings"
@@ -409,7 +409,7 @@ const Notification: FC<PipeProp> = ({Context}) => {
                     </FlexBox.Child>
                     <FlexBox.Child grow={0} shrink={0}>
                       <Button
-                        text="Test Alert"
+                        text="Test Endpoint"
                         status={
                           status === RemoteDataState.Loading
                             ? ComponentStatus.Loading


### PR DESCRIPTION
Closes #3927 

This PR updates the button name to "Test Endpoint" in Notebook alert panel.

## Before
<img width="1380" alt="Screen Shot 2022-02-23 at 1 29 56 PM" src="https://user-images.githubusercontent.com/14298407/155393947-d6a457c1-5c50-4bfa-a70f-2d42617f4f10.png">

## After
<img width="1385" alt="Screen Shot 2022-02-23 at 1 28 52 PM" src="https://user-images.githubusercontent.com/14298407/155393966-b2a70ecc-577e-4669-b371-596621461203.png">

