### PR TITLE
chore(ecommerce): Add commas to Operator UI Limits

### DIFF
--- a/src/operator/LimitsField.tsx
+++ b/src/operator/LimitsField.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FC, useContext} from 'react'
+import React, {FC, useContext, useState} from 'react'
 import {Input, InputType} from '@influxdata/clockface'
 import {get} from 'lodash'
 import {set} from 'lodash/fp'
@@ -18,13 +18,17 @@ interface Props {
 }
 
 const LimitsField: FC<Props> = ({type, name, limits, onChangeLimits}) => {
+  const [hasFocus, setHasFocus] = useState(false)
   const {hasWritePermissions} = useContext(OperatorContext)
   const value = get(limits, name, '')
+  const csv = isNaN(value)
+    ? value
+    : Intl.NumberFormat(navigator.language).format(value)
 
   if (!hasWritePermissions) {
     return (
       <p data-testid={`limits-${name}--p`} className="operator-limits-label">
-        {value}
+        {csv}
       </p>
     )
   }
@@ -36,12 +40,35 @@ const LimitsField: FC<Props> = ({type, name, limits, onChangeLimits}) => {
     onChangeLimits(newLimits)
   }
 
+  if (type == InputType.Number) {
+    return hasFocus ? (
+      <Input
+        type={type}
+        name={name}
+        value={value}
+        onChange={onChange}
+        onBlur={() => setHasFocus(false)}
+        testID={`limits-${name}--input`}
+      />
+    ) : (
+      <Input
+        type={InputType.Text}
+        name={name}
+        value={csv}
+        onChange={onChange}
+        onFocus={() => setHasFocus(true)}
+        testID={`limits-${name}--input`}
+      />
+    )
+  }
+
   return (
     <Input
       type={type}
       name={name}
       value={value}
       onChange={onChange}
+      onBlur={() => setHasFocus(false)}
       testID={`limits-${name}--input`}
     />
   )

--- a/src/operator/LimitsField.tsx
+++ b/src/operator/LimitsField.tsx
@@ -21,14 +21,15 @@ const LimitsField: FC<Props> = ({type, name, limits, onChangeLimits}) => {
   const [hasFocus, setHasFocus] = useState(false)
   const {hasWritePermissions} = useContext(OperatorContext)
   const value = get(limits, name, '')
-  const csv = isNaN(value)
-    ? value
-    : Intl.NumberFormat(navigator.language).format(value)
+  const formatted_value =
+    type === InputType.Number
+      ? Intl.NumberFormat(navigator.language).format(value)
+      : value
 
   if (!hasWritePermissions) {
     return (
       <p data-testid={`limits-${name}--p`} className="operator-limits-label">
-        {csv}
+        {formatted_value}
       </p>
     )
   }
@@ -40,7 +41,7 @@ const LimitsField: FC<Props> = ({type, name, limits, onChangeLimits}) => {
     onChangeLimits(newLimits)
   }
 
-  if (type == InputType.Number) {
+  if (type === InputType.Number) {
     return hasFocus ? (
       <Input
         type={type}
@@ -54,7 +55,7 @@ const LimitsField: FC<Props> = ({type, name, limits, onChangeLimits}) => {
       <Input
         type={InputType.Text}
         name={name}
-        value={csv}
+        value={formatted_value}
         onChange={onChange}
         onFocus={() => setHasFocus(true)}
         testID={`limits-${name}--input`}


### PR DESCRIPTION
In the Operator UI for organization limits, some larger numbers are difficult to read without commas to break apart the places. For example, one million is easier to read as `1,000,000` than `1000000`. 

This adds these separators, based on region, to the rate limits screen.