### PR TITLE
fix: work on some flakey tests

### DIFF
--- a/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
+++ b/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
@@ -12,7 +12,7 @@ const openCopyAs = () => {
 const addFluxQueryInNotebook = (query: string) => {
   cy.getByTestID('add-flow-btn--rawFluxEditor').click()
   cy.getByTestID('flux-editor').clear()
-  cy.getByTestID('flux-editor').monacoType(`${query}`)
+  cy.getByTestID('flux-editor').monacoType(query)
 }
 
 const createEmptyNotebook = () => {

--- a/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
+++ b/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
@@ -11,7 +11,8 @@ const openCopyAs = () => {
 
 const addFluxQueryInNotebook = (query: string) => {
   cy.getByTestID('add-flow-btn--rawFluxEditor').click()
-  cy.getByTestID('flux-editor').monacoType(`{selectall}{del}${query}`)
+  cy.getByTestID('flux-editor').clear()
+  cy.getByTestID('flux-editor').monacoType(`${query}`)
 }
 
 const createEmptyNotebook = () => {

--- a/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
+++ b/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
@@ -11,8 +11,7 @@ const openCopyAs = () => {
 
 const addFluxQueryInNotebook = (query: string) => {
   cy.getByTestID('add-flow-btn--rawFluxEditor').click()
-  cy.getByTestID('flux-editor').clear()
-  cy.getByTestID('flux-editor').monacoType(query)
+  cy.getByTestID('flux-editor').monacoType(`{selectall}{del}${query}`)
 }
 
 const createEmptyNotebook = () => {

--- a/cypress/e2e/shared/tasks.test.ts
+++ b/cypress/e2e/shared/tasks.test.ts
@@ -259,11 +259,6 @@ from(bucket: "defbuck")
 
       // focused() waits for monoco editor to get input focus
       cy.focused()
-      cy.getByTestID('flux-editor')
-        .should('be.visible')
-        .contains(
-          'option task = {name: "🦄ask (clone 1)", every: 24h, offset: 20m}'
-        )
 
       cy.getByTestID('task-form-name').should('have.value', '🦄ask (clone 1)')
       cy.getByTestID('task-form-name')
@@ -282,6 +277,10 @@ from(bucket: "defbuck")
         .clear()
         .type('10m')
       cy.getByTestID('task-form-offset-input').should('have.value', '10m')
+
+      cy.getByTestID('flux-editor')
+        .should('be.visible')
+        .contains('option task = {')
 
       cy.getByTestID('task-save-btn').click()
 

--- a/cypress/e2e/shared/tasks.test.ts
+++ b/cypress/e2e/shared/tasks.test.ts
@@ -34,10 +34,10 @@ describe('Tasks', () => {
   it('can create a task', () => {
     const taskName = 'Task'
     cy.createTaskFromEmpty(taskName, ({name}) => {
-      return `import "influxdata/influxdb/v1{rightarrow}
-v1.tagValues(bucket: "${name}", tag: "_field"{rightarrow}
-from(bucket: "${name}"{rightarrow}
-   |> range(start: -2m{rightarrow}`
+      return `import "influxdata/influxdb/v1"
+v1.tagValues(bucket: "${name}", tag: "_field")
+from(bucket: "${name}")
+   |> range(start: -2m)`
     })
 
     cy.getByTestID('task-save-btn').click()
@@ -67,8 +67,8 @@ http.post(url: "https://foo.bar/baz", data: bytes(v: "body"))`
     const taskName = 'Cron task test'
 
     cy.createTaskFromEmpty(taskName, ({name}) => {
-      return `from(bucket: "${name}"){rightarrow}
-   |> range(start: -2m{rightarrow}`
+      return `from(bucket: "${name}")
+   |> range(start: -2m)`
     })
 
     cy.getByTestID('task-card-cron-btn').click()
@@ -402,10 +402,10 @@ from(bucket: "defbuck")
       cy.createTaskFromEmpty(
         taskName,
         ({name}) => {
-          return `import "influxdata/influxdb/v1{rightarrow}
-  v1.tagValues(bucket: "${name}", tag: "_field"{rightarrow}
-  from(bucket: "${name}"{rightarrow}
-    |> range(start: -2m{rightarrow}`
+          return `import "influxdata/influxdb/v1"
+  v1.tagValues(bucket: "${name}", tag: "_field")
+  from(bucket: "${name}")
+    |> range(start: -2m)`
         },
         interval,
         offset

--- a/cypress/e2e/shared/tasks.test.ts
+++ b/cypress/e2e/shared/tasks.test.ts
@@ -261,7 +261,9 @@ from(bucket: "defbuck")
       cy.focused()
       cy.getByTestID('flux-editor')
         .should('be.visible')
-        .contains('option task = {')
+        .contains(
+          'option task = {name: "🦄ask (clone 1)", every: 24h, offset: 20m}'
+        )
 
       cy.getByTestID('task-form-name').should('have.value', '🦄ask (clone 1)')
       cy.getByTestID('task-form-name')


### PR DESCRIPTION
Related #3898
Closes #2887

This PR updates a couple of the flakey tests since there seemed to be weirdness with the autocomplete type functionality that we were using in the tests. We lose out on testing that stuff out in these changes, but their inconsistency was leading to a level of flakiness that warranted something more predictable that wouldn't cause errors.

<!-- Describe your proposed changes here. -->
