### PR TITLE
fix: auditing some events

### DIFF
--- a/src/dataLoaders/components/collectorsWizard/select/TelegrafUIRefreshSelector.tsx
+++ b/src/dataLoaders/components/collectorsWizard/select/TelegrafUIRefreshSelector.tsx
@@ -171,7 +171,6 @@ class TelegrafUIRefreshSelector extends PureComponent<Props, State> {
                   name={item.name}
                   image={item.image}
                   style={item.style}
-                  url={`${item.id}`}
                   selected={this.isCardChecked(item.id)}
                   onClick={this.handleToggle}
                   testID={`telegraf-plugins--${item.name}`}

--- a/src/flows/context/flow.query.tsx
+++ b/src/flows/context/flow.query.tsx
@@ -240,8 +240,6 @@ export const FlowQueryProvider: FC = ({children}) => {
   }
 
   const query = (text: string, override?: QueryScope): Promise<FluxResult> => {
-    event('runQuery', {context: 'flows'})
-
     const _override: QueryScope = {
       region: window.location.origin,
       org: org.id,

--- a/src/flows/pipes/MetricSelector/index.ts
+++ b/src/flows/pipes/MetricSelector/index.ts
@@ -11,7 +11,7 @@ export default register => {
     component: View,
     readOnlyComponent: ReadOnly,
     button: 'Metric Selector',
-    disabled: true,
+    featureFlag: 'flow-panel--metric-selector',
     initial: {
       field: '',
       measurement: '',

--- a/src/flows/pipes/QueryBuilder/AddButton.tsx
+++ b/src/flows/pipes/QueryBuilder/AddButton.tsx
@@ -5,10 +5,13 @@ import {RemoteDataState} from 'src/types'
 
 import {QueryBuilderContext} from 'src/flows/pipes/QueryBuilder/context'
 
+import {event} from 'src/cloud/utils/reporting'
+
 const AddButton: FC = () => {
   const {cards, add} = useContext(QueryBuilderContext)
 
   const onClick = useCallback(() => {
+    event('Query Builder Card Added')
     add()
   }, [add])
 

--- a/src/flows/pipes/QueryBuilder/BucketSelector.tsx
+++ b/src/flows/pipes/QueryBuilder/BucketSelector.tsx
@@ -8,6 +8,8 @@ import BuilderCard from 'src/timeMachine/components/builderCard/BuilderCard'
 import {BucketContext} from 'src/flows/context/bucket.scoped'
 import {PipeContext} from 'src/flows/context/pipe'
 
+import {event} from 'src/cloud/utils/reporting'
+
 // this is used by notebooks
 const BucketSelector: FC = () => {
   const {data, update} = useContext(PipeContext)
@@ -42,6 +44,9 @@ const BucketSelector: FC = () => {
     } else if (item !== selected) {
       data.buckets = [buckets.find(b => b.name === item)]
       bucket = item
+      event('Query Builder Bucket Selected', {
+        usedSearch: !!search.length ? 'yus' : 'nah',
+      })
     } else {
       data.buckets = []
       bucket = null

--- a/src/flows/pipes/QueryBuilder/CardList.tsx
+++ b/src/flows/pipes/QueryBuilder/CardList.tsx
@@ -32,6 +32,8 @@ import WaitingText from 'src/shared/components/WaitingText'
 import BuilderCard from 'src/timeMachine/components/builderCard/BuilderCard'
 import SelectorList from 'src/timeMachine/components/SelectorList'
 
+import {event} from 'src/cloud/utils/reporting'
+
 const DEBOUNCE_TIMEOUT = 500
 const debounce_array = []
 type NOOP = () => void
@@ -69,6 +71,7 @@ const Card: FC<Props> = ({idx}) => {
   const _remove =
     idx !== 0 &&
     (() => {
+      event('Query Builder Card Removed')
       remove(idx)
     })
 
@@ -90,6 +93,10 @@ const Card: FC<Props> = ({idx}) => {
   )
 
   const keySelect = val => {
+    if (card.keys.selected[0] === val) {
+      return
+    }
+    event('Query Builder key selected')
     update(idx, {
       keys: {
         ...card.keys,
@@ -110,8 +117,10 @@ const Card: FC<Props> = ({idx}) => {
     const _vals = [...card.values.selected]
     const index = _vals.indexOf(val)
     if (index === -1) {
+      event('Query Builder Value Selected')
       _vals.push(val)
     } else {
+      event('Query Builder Value Unselected')
       _vals.splice(index, 1)
     }
     update(idx, {

--- a/src/writeData/components/ClientLibrarySection.tsx
+++ b/src/writeData/components/ClientLibrarySection.tsx
@@ -1,7 +1,13 @@
 // Libraries
 import React, {useContext} from 'react'
-import {CLIENT_LIBS} from 'src/shared/constants/routes'
+import {useSelector} from 'react-redux'
+import {useHistory} from 'react-router-dom'
+import {ORGS, CLIENT_LIBS} from 'src/shared/constants/routes'
 import {searchClients} from 'src/writeData'
+
+// Utils
+import {getOrg} from 'src/organizations/selectors'
+import {event} from 'src/cloud/utils/reporting'
 
 // Contexts
 import {WriteDataSearchContext} from 'src/writeData/containers/WriteDataPage'
@@ -19,6 +25,9 @@ import WriteDataItem from 'src/writeData/components/WriteDataItem'
 const ClientLibrarySection = () => {
   const {searchTerm} = useContext(WriteDataSearchContext)
   const items = searchClients(searchTerm)
+
+  const history = useHistory()
+  const org = useSelector(getOrg)
 
   if (!items.length) {
     return null
@@ -44,15 +53,24 @@ const ClientLibrarySection = () => {
         Back-end, front-end, and mobile applications
       </Heading>
       <SquareGrid cardSize="170px" gutter={ComponentSize.Small}>
-        {items.map(item => (
-          <WriteDataItem
-            key={item.id}
-            id={item.id}
-            name={item.name}
-            image={item.logo}
-            url={`${CLIENT_LIBS}/${item.id}`}
-          />
-        ))}
+        {items.map(item => {
+          const goto = () => {
+            event('Load data client library clicked', {type: item.name})
+            history.push(
+              `/${ORGS}/${org.id}/load-data/${CLIENT_LIBS}/${item.id}`
+            )
+          }
+
+          return (
+            <WriteDataItem
+              key={item.id}
+              id={item.id}
+              name={item.name}
+              image={item.logo}
+              onClick={goto}
+            />
+          )
+        })}
       </SquareGrid>
     </div>
   )

--- a/src/writeData/components/FileUploadSection.tsx
+++ b/src/writeData/components/FileUploadSection.tsx
@@ -1,7 +1,13 @@
 // Libraries
 import React, {useContext} from 'react'
-import {FILE_UPLOAD} from 'src/shared/constants/routes'
+import {useSelector} from 'react-redux'
+import {useHistory} from 'react-router-dom'
+import {ORGS, FILE_UPLOAD} from 'src/shared/constants/routes'
 import {search} from 'src/writeData/constants/contentFileUploads'
+
+// Utils
+import {getOrg} from 'src/organizations/selectors'
+import {event} from 'src/cloud/utils/reporting'
 
 // Contexts
 import {WriteDataSearchContext} from 'src/writeData/containers/WriteDataPage'
@@ -19,6 +25,9 @@ import WriteDataItem from 'src/writeData/components/WriteDataItem'
 const FileUploadSection = () => {
   const {searchTerm} = useContext(WriteDataSearchContext)
   const items = search(searchTerm)
+
+  const history = useHistory()
+  const org = useSelector(getOrg)
 
   if (!items.length) {
     return null
@@ -44,15 +53,24 @@ const FileUploadSection = () => {
         Upload line protocol or Annotated CSVs
       </Heading>
       <SquareGrid cardSize="170px" gutter={ComponentSize.Small}>
-        {items.map(item => (
-          <WriteDataItem
-            key={item.id}
-            id={item.id}
-            name={item.name}
-            image={item.image}
-            url={`${FILE_UPLOAD}/${item.id}`}
-          />
-        ))}
+        {items.map(item => {
+          const goto = () => {
+            event('Load data file upload clicked', {type: item.name})
+            history.push(
+              `/${ORGS}/${org.id}/load-data/${FILE_UPLOAD}/${item.id}`
+            )
+          }
+
+          return (
+            <WriteDataItem
+              key={item.id}
+              id={item.id}
+              name={item.name}
+              image={item.image}
+              onClick={goto}
+            />
+          )
+        })}
       </SquareGrid>
     </div>
   )

--- a/src/writeData/components/TelegrafPluginSection.tsx
+++ b/src/writeData/components/TelegrafPluginSection.tsx
@@ -1,7 +1,13 @@
 // Libraries
 import React, {useContext} from 'react'
-import {TELEGRAF_PLUGINS} from 'src/shared/constants/routes'
+import {useSelector} from 'react-redux'
+import {useHistory} from 'react-router-dom'
+import {ORGS, TELEGRAF_PLUGINS} from 'src/shared/constants/routes'
 import {search} from 'src/writeData/constants/contentTelegrafPlugins'
+
+// Utils
+import {getOrg} from 'src/organizations/selectors'
+import {event} from 'src/cloud/utils/reporting'
 
 // Contexts
 import {WriteDataSearchContext} from 'src/writeData/containers/WriteDataPage'
@@ -19,6 +25,9 @@ import WriteDataItem from 'src/writeData/components/WriteDataItem'
 const TelegrafPluginSection = () => {
   const {searchTerm} = useContext(WriteDataSearchContext)
   const items = search(searchTerm)
+
+  const history = useHistory()
+  const org = useSelector(getOrg)
 
   if (!items.length) {
     return null
@@ -46,16 +55,25 @@ const TelegrafPluginSection = () => {
         vast library of plugins
       </Heading>
       <SquareGrid cardSize="170px" gutter={ComponentSize.Small}>
-        {items.map(item => (
-          <WriteDataItem
-            key={item.id}
-            id={item.id}
-            name={item.name}
-            image={item.image}
-            style={item.style}
-            url={`${TELEGRAF_PLUGINS}/${item.id}`}
-          />
-        ))}
+        {items.map(item => {
+          const goto = () => {
+            event('Load data Telegraf Plugin clicked', {type: item.name})
+            history.push(
+              `/${ORGS}/${org.id}/load-data/${TELEGRAF_PLUGINS}/${item.id}`
+            )
+          }
+
+          return (
+            <WriteDataItem
+              key={item.id}
+              id={item.id}
+              name={item.name}
+              image={item.image}
+              style={item.style}
+              onClick={goto}
+            />
+          )
+        })}
       </SquareGrid>
     </div>
   )

--- a/src/writeData/components/WriteDataItem.tsx
+++ b/src/writeData/components/WriteDataItem.tsx
@@ -17,7 +17,7 @@ interface Props {
   image?: string
   style?: CSSProperties
   selected?: boolean
-  onClick?: any
+  onClick: any
   testID?: string
 }
 

--- a/src/writeData/components/WriteDataItem.tsx
+++ b/src/writeData/components/WriteDataItem.tsx
@@ -1,21 +1,12 @@
 // Libraries
 import React, {CSSProperties, FC, Suspense} from 'react'
-import {useSelector} from 'react-redux'
-import {useHistory} from 'react-router-dom'
 
 // Components
 import {SelectableCard, SquareGrid, ComponentSize} from '@influxdata/clockface'
 const LazySVG = React.lazy(() => import('src/perf/components/LazySVG'))
 
-// Utils
-import {getOrg} from 'src/organizations/selectors'
-import {event} from 'src/cloud/utils/reporting'
-
 // Graphics
 import placeholderLogo from 'src/writeData/graphics/placeholderLogo.svg'
-
-// Constants
-import {ORGS} from 'src/shared/constants/routes'
 
 // Styles
 import 'src/writeData/components/WriteDataItem.scss'
@@ -23,7 +14,6 @@ import 'src/writeData/components/WriteDataItem.scss'
 interface Props {
   id: string
   name: string
-  url: string
   image?: string
   style?: CSSProperties
   selected?: boolean
@@ -34,21 +24,12 @@ interface Props {
 const WriteDataItem: FC<Props> = ({
   id,
   name,
-  url,
   image,
   style,
   selected,
   onClick,
   testID,
 }) => {
-  const history = useHistory()
-  const org = useSelector(getOrg)
-
-  const handleClick = (): void => {
-    event(`sources.load_data.${name}.clicked`)
-    history.push(`/${ORGS}/${org.id}/load-data/${url}`)
-  }
-
   let thumb = <img src={placeholderLogo} />
   const svgStyle = style ? style : ({} as CSSProperties)
 
@@ -60,34 +41,15 @@ const WriteDataItem: FC<Props> = ({
     )
   }
 
-  if (onClick) {
-    return (
-      <SquareGrid.Card key={id}>
-        <SelectableCard
-          id={id}
-          formName="load-data-cards"
-          label={name}
-          selected={selected}
-          onClick={onClick}
-          testID={testID}
-          fontSize={ComponentSize.ExtraSmall}
-          className="write-data--item"
-        >
-          <div className="write-data--item-thumb">{thumb}</div>
-        </SelectableCard>
-      </SquareGrid.Card>
-    )
-  }
-
   return (
     <SquareGrid.Card key={id}>
       <SelectableCard
         id={id}
         formName="load-data-cards"
         label={name}
-        testID={`load-data-item ${id}`}
-        selected={false}
-        onClick={handleClick}
+        selected={selected}
+        onClick={onClick}
+        testID={testID || `load-data-item ${id}`}
         fontSize={ComponentSize.ExtraSmall}
         className="write-data--item"
       >


### PR DESCRIPTION
as part of this: https://github.com/influxdata/ui/issues/3941 and a greater question about user interaction with the query builder, i found out that we dont have a lot of data around the query builder interaction. While i was auditing in there, i found that we also dont have great events around the data sources page (the current version of the event prevents any kind of grouping), which triggered some rework of the module layout to allow for the different types of interactions to be segmented properly. 
also moved metric selector back behind a flag because product needed to review it