### PR TITLE
fix(notebook): enable map to show in pdf/png download

### DIFF
--- a/src/flows/components/header/index.tsx
+++ b/src/flows/components/header/index.tsx
@@ -204,6 +204,8 @@ const FlowHeader: FC = () => {
         .querySelectorAll('[data-download-hide]')
         .forEach(d => (d.style.display = 'block'))
     },
+    // Enable map background
+    useCORS: true,
   }
 
   const handleDownloadAsPNG = () => {

--- a/src/flows/pipes/Visualization/view.tsx
+++ b/src/flows/pipes/Visualization/view.tsx
@@ -35,10 +35,14 @@ import {downloadImage} from 'src/shared/utils/download'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
 
+const canvasOption = {
+  useCORS: true,
+}
+
 const downloadAsImage = (pipeID: string) => {
   const canvas = document.getElementById(pipeID)
   import('html2canvas').then((module: any) =>
-    module.default(canvas as HTMLDivElement).then(result => {
+    module.default(canvas as HTMLDivElement, canvasOption).then(result => {
       downloadImage(result.toDataURL(), 'visualization.png')
     })
   )
@@ -47,7 +51,7 @@ const downloadAsImage = (pipeID: string) => {
 const downloadAsPDF = (pipeID: string) => {
   const canvas = document.getElementById(pipeID)
   import('html2canvas').then((module: any) =>
-    module.default(canvas as HTMLDivElement).then(result => {
+    module.default(canvas as HTMLDivElement, canvasOption).then(result => {
       import('jspdf').then((jsPDF: any) => {
         const doc = new jsPDF.default({
           orientation: 'l',

--- a/src/flows/pipes/Visualization/view.tsx
+++ b/src/flows/pipes/Visualization/view.tsx
@@ -35,6 +35,7 @@ import {downloadImage} from 'src/shared/utils/download'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
 
+// Enable map background
 const canvasOption = {
   useCORS: true,
 }


### PR DESCRIPTION
Closes #3829

Map background is not shown in the downloaded PDF/PNG files when the graph panel is set to 'Map' in Notebook. This PR fixes this issue. These features are behind the feature flags `downloadNotebookPDF` and `pdfImageDownload`.

## Before
![visualization](https://user-images.githubusercontent.com/14298407/155740653-d610fa22-4c1a-4eb1-b85e-85414ee838c5.png)

## After
https://user-images.githubusercontent.com/14298407/155740767-0292d84c-2384-4179-95d9-1b196720c658.mov


