### PR TITLE
chore: remove the save ephemeral notebook when the publish lifecycle is set

### DIFF
--- a/src/flows/components/FromTemplatePage.tsx
+++ b/src/flows/components/FromTemplatePage.tsx
@@ -59,7 +59,10 @@ const Template: FC = () => {
         return hydrate(data)
       })
       .then(data => {
-        if (isFlagEnabled('ephemeralNotebook')) {
+        if (
+          isFlagEnabled('ephemeralNotebook') &&
+          !isFlagEnabled('flowPublishLifecycle')
+        ) {
           populate(data)
         } else {
           add(data).then(id => {
@@ -86,7 +89,10 @@ const Template: FC = () => {
 }
 
 const FromTemplatePage: FC = () => {
-  if (isFlagEnabled('ephemeralNotebook')) {
+  if (
+    isFlagEnabled('ephemeralNotebook') &&
+    !isFlagEnabled('flowPublishLifecycle')
+  ) {
     return (
       <AppWrapper>
         <AppSettingProvider>

--- a/src/flows/components/header/SaveState.tsx
+++ b/src/flows/components/header/SaveState.tsx
@@ -29,7 +29,10 @@ const SaveState: FC = () => {
     })
   }
 
-  if (!isFlagEnabled('ephemeralNotebook')) {
+  if (
+    !isFlagEnabled('ephemeralNotebook') ||
+    isFlagEnabled('flowPublishLifecycle')
+  ) {
     return null
   }
 

--- a/src/flows/components/header/index.tsx
+++ b/src/flows/components/header/index.tsx
@@ -376,7 +376,7 @@ const FlowHeader: FC = () => {
           <Page.ControlBarLeft>
             <Submit />
             <AutoRefreshButton />
-            <SaveState />
+            {!isFlagEnabled('flowPublishLifecycle') && <SaveState />}
           </Page.ControlBarLeft>
           <Page.ControlBarRight>
             <PresentationMode />

--- a/src/flows/context/flow.current.tsx
+++ b/src/flows/context/flow.current.tsx
@@ -124,7 +124,11 @@ export const FlowProvider: FC = ({children}) => {
         }
         return
       }
-      if (isFlagEnabled('ephemeralNotebook') && !currentFlow.id) {
+      if (
+        !isFlagEnabled('flowPublishLifecycle') &&
+        isFlagEnabled('ephemeralNotebook') &&
+        !currentFlow.id
+      ) {
         currentFlow.data.byID[id] = {
           ...(currentFlow.data.byID[id] || {}),
           ...data,
@@ -166,7 +170,11 @@ export const FlowProvider: FC = ({children}) => {
         }
         return
       }
-      if (isFlagEnabled('ephemeralNotebook') && !currentFlow.id) {
+      if (
+        !isFlagEnabled('flowPublishLifecycle') &&
+        isFlagEnabled('ephemeralNotebook') &&
+        !currentFlow.id
+      ) {
         currentFlow.meta.byID[id] = {
           title: '',
           visible: true,
@@ -208,7 +216,11 @@ export const FlowProvider: FC = ({children}) => {
         }
         return
       }
-      if (isFlagEnabled('ephemeralNotebook') && !currentFlow.id) {
+      if (
+        !isFlagEnabled('flowPublishLifecycle') &&
+        isFlagEnabled('ephemeralNotebook') &&
+        !currentFlow.id
+      ) {
         for (const ni in flow) {
           currentFlow[ni] = flow[ni]
         }
@@ -257,7 +269,11 @@ export const FlowProvider: FC = ({children}) => {
         .set('flowUpdateData', serialize(flowCopy))
       return
     }
-    if (isFlagEnabled('ephemeralNotebook') && !currentFlow.id) {
+    if (
+      !isFlagEnabled('flowPublishLifecycle') &&
+      isFlagEnabled('ephemeralNotebook') &&
+      !currentFlow.id
+    ) {
       currentFlow.data.byID[id] = initial
       currentFlow.meta.byID[id] = {
         title,
@@ -313,7 +329,11 @@ export const FlowProvider: FC = ({children}) => {
         .set('flowUpdateData', serialize(flowCopy))
       return
     }
-    if (isFlagEnabled('ephemeralNotebook') && !currentFlow.id) {
+    if (
+      !isFlagEnabled('flowPublishLifecycle') &&
+      isFlagEnabled('ephemeralNotebook') &&
+      !currentFlow.id
+    ) {
       currentFlow.meta.allIDs = currentFlow.meta.allIDs.filter(
         _id => _id !== id
       )


### PR DESCRIPTION
Having the two enabled at the same time was confusing folks. Shutting this off to capture the fact that ephemeral notebooks should be removed if the publish lifecycle stuff gets prioritized