### PR TITLE
fix(client_libs): installation instruction for Gradle

### DIFF
--- a/src/writeData/clients/Java/description.md
+++ b/src/writeData/clients/Java/description.md
@@ -16,6 +16,6 @@ Build with Gradle
 
 ```
 dependencies {
-  compile "com.influxdb:influxdb-client-java:3.1.0"
+  implementation "com.influxdb:influxdb-client-java:3.1.0"
 }
 ```

--- a/src/writeData/clients/Java/description.md
+++ b/src/writeData/clients/Java/description.md
@@ -8,7 +8,7 @@ Build with Maven
 <dependency>
   <groupId>com.influxdb</groupId>
   <artifactId>influxdb-client-java</artifactId>
-  <version>3.1.0</version>
+  <version>4.3.0</version>
 </dependency>
 ```
 
@@ -16,6 +16,6 @@ Build with Gradle
 
 ```
 dependencies {
-  implementation "com.influxdb:influxdb-client-java:3.1.0"
+  implementation "com.influxdb:influxdb-client-java:4.3.0"
 }
 ```

--- a/src/writeData/clients/Kotlin/description.md
+++ b/src/writeData/clients/Kotlin/description.md
@@ -16,6 +16,6 @@ Build with Gradle
 
 ```
 dependencies {
-  compile "com.influxdb:influxdb-client-kotlin:3.1.0"
+  implementation "com.influxdb:influxdb-client-kotlin:3.1.0"
 }
 ```

--- a/src/writeData/clients/Kotlin/description.md
+++ b/src/writeData/clients/Kotlin/description.md
@@ -8,7 +8,7 @@ Build with Maven
 <dependency>
   <groupId>com.influxdb</groupId>
   <artifactId>influxdb-client-kotlin</artifactId>
-  <version>3.1.0</version>
+  <version>4.3.0</version>
 </dependency>
 ```
 
@@ -16,6 +16,6 @@ Build with Gradle
 
 ```
 dependencies {
-  implementation "com.influxdb:influxdb-client-kotlin:3.1.0"
+  implementation "com.influxdb:influxdb-client-kotlin:4.3.0"
 }
 ```

--- a/src/writeData/clients/Scala/description.md
+++ b/src/writeData/clients/Scala/description.md
@@ -5,7 +5,7 @@ For more detailed and up to date information check out the [GitHub Repository](h
 Build with sbt
 
 ```
-libraryDependencies += "com.influxdb" % "influxdb-client-scala" % "3.1.0"
+libraryDependencies += "com.influxdb" % "influxdb-client-scala" % "4.3.0"
 ```
 
 Build with Maven
@@ -14,7 +14,7 @@ Build with Maven
 <dependency>
   <groupId>com.influxdb</groupId>
   <artifactId>influxdb-client-scala</artifactId>
-  <version>3.1.0</version>
+  <version>4.3.0</version>
 </dependency>
 ```
 
@@ -22,6 +22,6 @@ Build with Gradle
 
 ```
 dependencies {
-  implementation "com.influxdb:influxdb-client-scala:3.1.0"
+  implementation "com.influxdb:influxdb-client-scala:4.3.0"
 }
 ```

--- a/src/writeData/clients/Scala/description.md
+++ b/src/writeData/clients/Scala/description.md
@@ -22,6 +22,6 @@ Build with Gradle
 
 ```
 dependencies {
-  compile "com.influxdb:influxdb-client-scala:3.1.0"
+  implementation "com.influxdb:influxdb-client-scala:3.1.0"
 }
 ```


### PR DESCRIPTION
1. From the Gradle 7.0 the `compile` configuration is not supported anymore. The correct configuration is `implementation`.
2. Update JVM clients to latest version.