### PR TITLE
feat: added ability to export tasks using v2 template

### DIFF
--- a/cypress/e2e/shared/tasks.test.ts
+++ b/cypress/e2e/shared/tasks.test.ts
@@ -101,9 +101,8 @@ http.post(url: "https://foo.bar/baz", data: bytes(v: "body"))`
   })
 
   it('can create a task with an option parameter', () => {
-    cy.getByTestID('create-task--button')
-      .first()
-      .click()
+    cy.getByTestID('add-resource-dropdown--button').click()
+    cy.getByTestID('add-resource-dropdown--new').click()
 
     cy.focused()
 
@@ -633,9 +632,8 @@ from(bucket: "defbuck")
     ]
 
     tasks.forEach(task => {
-      cy.getByTestID('create-task--button')
-        .first()
-        .click()
+      cy.getByTestID('add-resource-dropdown--button').click()
+      cy.getByTestID('add-resource-dropdown--new').click()
 
       // Fill Task Form
       // focused() waits for monoco editor to get input focus

--- a/src/shared/components/AddResourceDropdown.tsx
+++ b/src/shared/components/AddResourceDropdown.tsx
@@ -47,7 +47,7 @@ class AddResourceDropdown extends PureComponent<Props> {
     const {titleText, status} = this.props
     return (
       <Dropdown
-        style={{width: '232px'}}
+        style={{width: this.props.resourceName === 'Task' ? '180px' : '232px'}}
         testID="add-resource-dropdown"
         button={(active, onClick) => (
           <Dropdown.Button

--- a/src/shared/components/AddResourceDropdown.tsx
+++ b/src/shared/components/AddResourceDropdown.tsx
@@ -47,7 +47,7 @@ class AddResourceDropdown extends PureComponent<Props> {
     const {titleText, status} = this.props
     return (
       <Dropdown
-        style={{width: this.props.resourceName === 'Task' ? '180px' : '232px'}}
+        style={{width: 'fit-content'}}
         testID="add-resource-dropdown"
         button={(active, onClick) => (
           <Dropdown.Button

--- a/src/shared/containers/SetOrg.tsx
+++ b/src/shared/containers/SetOrg.tsx
@@ -31,6 +31,7 @@ import {
   ScrapersIndex,
   SecretsIndex,
   TaskEditPage,
+  TaskImportOverlay,
   TaskPage,
   TaskRunsPage,
   TasksPage,
@@ -129,6 +130,10 @@ const SetOrg: FC = () => {
           <Route path={`${orgPath}/tasks/:id/runs`} component={TaskRunsPage} />
           <Route path={`${orgPath}/tasks/:id/edit`} component={TaskEditPage} />
           <Route path={`${orgPath}/tasks/new`} component={TaskPage} />
+          <Route
+            path={`${orgPath}/tasks/import`}
+            component={TaskImportOverlay}
+          />
           <Route path={`${orgPath}/tasks`} component={TasksPage} />
           {/* Data Explorer */}
           <Route

--- a/src/shared/containers/index.tsx
+++ b/src/shared/containers/index.tsx
@@ -16,6 +16,9 @@ export const TaskRunsPage = lazy(() =>
 export const TaskEditPage = lazy(() =>
   import('src/tasks/containers/TaskEditPage')
 )
+export const TaskImportOverlay = lazy(() =>
+  import('src/tasks/components/TaskImportOverlay')
+)
 export const DashboardsIndex = lazy(() =>
   import('src/dashboards/components/dashboard_index/DashboardsIndex')
 )

--- a/src/tasks/apis/index.ts
+++ b/src/tasks/apis/index.ts
@@ -1,0 +1,24 @@
+// Utils
+import {downloadTextFile} from 'src/shared/utils/download'
+
+import {postTemplatesExport} from 'src/client'
+
+export const downloadTaskTemplate = async (task): Promise<void> => {
+  const resp = await postTemplatesExport({
+    data: {
+      resources: [
+        {
+          kind: 'Task',
+          id: task.id,
+        },
+      ],
+    },
+  })
+
+  if (resp.status === 500) {
+    throw new Error(resp.data.message)
+  }
+
+  const data = await resp.data
+  downloadTextFile(JSON.stringify(data), task.name, '.json', 'text/json')
+}

--- a/src/tasks/components/TaskCard.tsx
+++ b/src/tasks/components/TaskCard.tsx
@@ -51,6 +51,7 @@ import {
   pinnedItemSuccess,
 } from 'src/shared/copy/notifications'
 import {notify} from 'src/shared/actions/notifications'
+import {downloadTaskTemplate} from 'src/tasks/apis'
 
 interface PassedProps {
   task: Task
@@ -293,12 +294,8 @@ export class TaskCard extends PureComponent<
   }
 
   private handleExport = () => {
-    const {
-      history,
-      task,
-      location: {pathname},
-    } = this.props
-    history.push(`${pathname}/${task.id}/export`)
+    const {task} = this.props
+    downloadTaskTemplate(task)
   }
 
   private get labels(): JSX.Element {

--- a/src/tasks/components/TaskImportOverlay.tsx
+++ b/src/tasks/components/TaskImportOverlay.tsx
@@ -1,0 +1,80 @@
+import React, {PureComponent} from 'react'
+import {withRouter, RouteComponentProps} from 'react-router-dom'
+import {connect, ConnectedProps} from 'react-redux'
+
+// Components
+import ImportOverlay from 'src/shared/components/ImportOverlay'
+
+// Copy
+import {invalidJSON} from 'src/shared/copy/notifications'
+
+// Actions
+import {createTaskFromTemplate as createTaskFromTemplateAction} from 'src/tasks/actions/thunks'
+import {notify as notifyAction} from 'src/shared/actions/notifications'
+
+// Types
+import {ComponentStatus} from '@influxdata/clockface'
+
+// Utils
+import jsonlint from 'jsonlint-mod'
+
+interface State {
+  status: ComponentStatus
+}
+
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = RouteComponentProps<{orgID: string}> & ReduxProps
+
+class TaskImportOverlay extends PureComponent<Props> {
+  public state: State = {
+    status: ComponentStatus.Default,
+  }
+
+  public render() {
+    return (
+      <ImportOverlay
+        onDismissOverlay={this.onDismiss}
+        resourceName="Task"
+        onSubmit={this.handleImportTask}
+        status={this.state.status}
+        updateStatus={this.updateOverlayStatus}
+      />
+    )
+  }
+
+  private onDismiss = () => {
+    const {history} = this.props
+
+    history.goBack()
+  }
+
+  private updateOverlayStatus = (status: ComponentStatus) =>
+    this.setState(() => ({status}))
+
+  private handleImportTask = (uploadContent: string) => {
+    const {createTaskFromTemplate, notify} = this.props
+
+    let template
+    this.updateOverlayStatus(ComponentStatus.Default)
+    try {
+      template = jsonlint.parse(uploadContent)
+    } catch (error) {
+      this.updateOverlayStatus(ComponentStatus.Error)
+      notify(invalidJSON(error.message))
+      return
+    }
+
+    createTaskFromTemplate(template)
+
+    this.onDismiss()
+  }
+}
+
+const mdtp = {
+  createTaskFromTemplate: createTaskFromTemplateAction,
+  notify: notifyAction,
+}
+
+const connector = connect(null, mdtp)
+
+export default connector(withRouter(TaskImportOverlay))

--- a/src/tasks/components/TasksHeader.tsx
+++ b/src/tasks/components/TasksHeader.tsx
@@ -4,8 +4,6 @@ import {Link} from 'react-router-dom'
 
 // Components
 import {
-  Button,
-  ComponentColor,
   InputLabel,
   SlideToggle,
   ComponentSize,
@@ -16,6 +14,7 @@ import {
   Icon,
   IconFont,
 } from '@influxdata/clockface'
+import AddResourceDropdown from 'src/shared/components/AddResourceDropdown'
 import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
 import ResourceSortDropdown from 'src/shared/components/resource_sort_dropdown/ResourceSortDropdown'
 import RateLimitAlert from 'src/cloud/components/RateLimitAlert'
@@ -36,6 +35,7 @@ import 'src/shared/components/cta.scss'
 
 interface Props {
   onCreateTask: () => void
+  onImportTask: () => void
   setShowInactive: () => void
   showInactive: boolean
   searchTerm: string
@@ -59,12 +59,17 @@ const TasksHeader: FC<Props> = ({
   sortKey,
   sortType,
   sortDirection,
+  onImportTask,
   onSort,
 }) => {
   const {flowsCTA, setFlowsCTA} = useContext(AppSettingContext)
   const creator = () => {
     event('Task Created From Dropdown', {source: 'header'})
     onCreateTask()
+  }
+
+  const handleOpenImportOverlay = () => {
+    onImportTask()
   }
 
   const recordClick = () => {
@@ -121,13 +126,10 @@ const TasksHeader: FC<Props> = ({
               onChange={setShowInactive}
             />
           </FlexBox>
-          <Button
-            icon={IconFont.Plus_New}
-            color={ComponentColor.Primary}
-            text="Create Task"
-            titleText="Click to create a Task"
-            onClick={creator}
-            testID="create-task--button"
+          <AddResourceDropdown
+            resourceName="Task"
+            onSelectNew={creator}
+            onSelectImport={handleOpenImportOverlay}
           />
         </Page.ControlBarRight>
       </Page.ControlBar>

--- a/src/tasks/containers/TasksPage.test.tsx
+++ b/src/tasks/containers/TasksPage.test.tsx
@@ -218,7 +218,13 @@ describe('Tasks.Containers.TasksPage', () => {
 
   describe('create tasks', () => {
     it('triggers create a new task', () => {
-      fireEvent.click(screen.getByTestId('create-task--button'))
+      const dropdownCreateButton = ui.getByTestId(
+        'add-resource-dropdown--button'
+      )
+      fireEvent.click(dropdownCreateButton)
+
+      const newInstallButton = ui.getByTestId('add-resource-dropdown--new')
+      fireEvent.click(newInstallButton)
 
       expect(localHistory.entries).toEqual(
         expect.arrayContaining([

--- a/src/tasks/containers/TasksPage.test.tsx
+++ b/src/tasks/containers/TasksPage.test.tsx
@@ -223,8 +223,8 @@ describe('Tasks.Containers.TasksPage', () => {
       )
       fireEvent.click(dropdownCreateButton)
 
-      const newInstallButton = ui.getByTestId('add-resource-dropdown--new')
-      fireEvent.click(newInstallButton)
+      const newTaskButton = ui.getByTestId('add-resource-dropdown--new')
+      fireEvent.click(newTaskButton)
 
       expect(localHistory.entries).toEqual(
         expect.arrayContaining([

--- a/src/tasks/containers/TasksPage.tsx
+++ b/src/tasks/containers/TasksPage.tsx
@@ -137,6 +137,7 @@ class TasksPage extends PureComponent<Props, State> {
         <Page titleTag={pageTitleSuffixer(['Tasks'])}>
           <TasksHeader
             onCreateTask={this.handleCreateTask}
+            onImportTask={this.onHandleOpenImportOverlay}
             setShowInactive={setShowInactive}
             showInactive={showInactive}
             searchTerm={searchTerm}
@@ -240,6 +241,17 @@ class TasksPage extends PureComponent<Props, State> {
     } else {
       history.push(`/orgs/${orgID}/tasks/new`)
     }
+  }
+
+  private onHandleOpenImportOverlay = () => {
+    const {
+      history,
+      match: {
+        params: {orgID},
+      },
+    } = this.props
+
+    history.push(`/orgs/${orgID}/tasks/import`)
   }
 
   private get filteredTasks(): Task[] {


### PR DESCRIPTION
Closes #3848 

PR fixes a bug in Tasks page of UI. The export button no longer works as the export overlay was removed.  
UI before fix: 
https://user-images.githubusercontent.com/66275100/156034490-2a40c88d-0611-423c-bfa0-85ba385f04db.mov

UI after fix: 
https://user-images.githubusercontent.com/66275100/156049806-e666d0ef-cf51-4f2e-b901-d697a95bc55e.mov
