### PR TITLE
feat: replacing created by with owner

### DIFF
--- a/src/authorizations/components/TokenRow.tsx
+++ b/src/authorizations/components/TokenRow.tsx
@@ -82,7 +82,7 @@ class TokensRow extends PureComponent<Props> {
           />
           <ResourceCard.Meta>
             <>Created at: {formatter.format(date)}</>
-            <>Created by: {auth.user}</>
+            <>Owner: {auth.user}</>
             <>Last Used: {relativeTimestampFormatter(auth.updatedAt)}</>
           </ResourceCard.Meta>
         </FlexBox>


### PR DESCRIPTION
Closes #3868 

pr replaces `created by` with `owner` in Token's resource card meta data 
