### PR TITLE
chore: add eventing for query builder / script editor

### DIFF
--- a/src/timeMachine/components/TimeMachineFluxEditor.tsx
+++ b/src/timeMachine/components/TimeMachineFluxEditor.tsx
@@ -20,6 +20,7 @@ import {
   functionRequiresNewLine,
   generateImport,
 } from 'src/timeMachine/utils/insertFunction'
+import {event} from 'src/cloud/utils/reporting'
 
 // Types
 import {AppState, FluxToolbarFunction, EditorType} from 'src/types'
@@ -142,6 +143,17 @@ const TimeMachineFluxEditor: FC<Props> = ({
     onSetActiveQueryText(editorInstance.getValue())
   }
 
+  const handleActiveQuery = text => {
+    const currentText = activeQueryText.replace(
+      `\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: "mean")`,
+      ''
+    )
+    if (currentText.trim() === text.trim()) {
+      event('Aggregate window removed')
+    }
+    onSetActiveQueryText(text)
+  }
+
   return useMemo(() => {
     return (
       <div className="flux-editor">
@@ -156,7 +168,7 @@ const TimeMachineFluxEditor: FC<Props> = ({
           >
             <FluxEditor
               script={activeQueryText}
-              onChangeScript={onSetActiveQueryText}
+              onChangeScript={handleActiveQuery}
               onSubmitScript={onSubmitQueries}
               setEditorInstance={setEditorInstance}
               autofocus

--- a/src/timeMachine/components/TimeMachineFluxEditor.tsx
+++ b/src/timeMachine/components/TimeMachineFluxEditor.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC, lazy, Suspense, useState, useMemo} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
+import {useSelector, useDispatch} from 'react-redux'
 import {
   RemoteDataState,
   SpinnerContainer,
@@ -23,22 +23,28 @@ import {
 import {event} from 'src/cloud/utils/reporting'
 
 // Types
-import {AppState, FluxToolbarFunction, EditorType} from 'src/types'
+import {FluxToolbarFunction, EditorType} from 'src/types'
 import * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api'
 
 const FluxEditor = lazy(() => import('src/shared/components/FluxMonacoEditor'))
 
-type ReduxProps = ConnectedProps<typeof connector>
-type Props = ReduxProps
-
-const TimeMachineFluxEditor: FC<Props> = ({
-  activeQueryText,
-  onSubmitQueries,
-  onSetActiveQueryText,
-  activeTab,
-  activeQueryIndex,
-}) => {
+const TimeMachineFluxEditor: FC = () => {
+  const dispatch = useDispatch()
+  const activeQueryText = useSelector(getActiveQuery).text
+  const {activeTab, activeQueryIndex} = useSelector(getActiveTimeMachine)
   const [editorInstance, setEditorInstance] = useState<EditorType>(null)
+
+  const handleSetActiveQueryText = React.useCallback(
+    (text: string) => {
+      dispatch(setActiveQueryText(text))
+    },
+    [dispatch]
+  )
+
+  const handleSubmitQueries = () => {
+    dispatch(saveAndExecuteQueries())
+  }
+
   const handleInsertVariable = (variableName: string): void => {
     if (!editorInstance) {
       return null
@@ -55,7 +61,7 @@ const TimeMachineFluxEditor: FC<Props> = ({
         text: `v.${variableName}`,
       },
     ])
-    onSetActiveQueryText(editorInstance.getValue())
+    handleSetActiveQueryText(editorInstance.getValue())
   }
 
   const getInsertLineNumber = (currentLineNumber: number): number => {
@@ -140,19 +146,28 @@ const TimeMachineFluxEditor: FC<Props> = ({
       })
     }
     editorInstance.executeEdits('', edits)
-    onSetActiveQueryText(editorInstance.getValue())
+    handleSetActiveQueryText(editorInstance.getValue())
   }
 
-  const handleActiveQuery = text => {
-    const currentText = activeQueryText.replace(
-      `\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: "mean")`,
-      ''
-    )
-    if (currentText.trim() === text.trim()) {
-      event('Aggregate window removed')
-    }
-    onSetActiveQueryText(text)
-  }
+  const handleActiveQuery = React.useCallback(
+    (text: string) => {
+      const aggregateWindowText =
+        '|> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)'
+      const [currentText] = activeQueryText.split(
+        `\n  ${aggregateWindowText}\n`
+      )
+
+      if (
+        activeQueryText.includes(aggregateWindowText) &&
+        !text.trim().includes(aggregateWindowText) &&
+        text.trim().includes(currentText.trim())
+      ) {
+        event('Aggregate window removed')
+      }
+      handleSetActiveQueryText(text)
+    },
+    [activeQueryText, handleSetActiveQueryText]
+  )
 
   return useMemo(() => {
     return (
@@ -169,7 +184,7 @@ const TimeMachineFluxEditor: FC<Props> = ({
             <FluxEditor
               script={activeQueryText}
               onChangeScript={handleActiveQuery}
-              onSubmitScript={onSubmitQueries}
+              onSubmitScript={handleSubmitQueries}
               setEditorInstance={setEditorInstance}
               autofocus
             />
@@ -184,23 +199,9 @@ const TimeMachineFluxEditor: FC<Props> = ({
         </div>
       </div>
     )
-  }, [editorInstance, activeQueryIndex])
+  }, [activeQueryText, editorInstance, activeQueryIndex])
 }
 
 export {TimeMachineFluxEditor}
 
-const mstp = (state: AppState) => {
-  const activeQueryText = getActiveQuery(state).text
-  const {activeTab, activeQueryIndex} = getActiveTimeMachine(state)
-
-  return {activeQueryText, activeTab, activeQueryIndex}
-}
-
-const mdtp = {
-  onSetActiveQueryText: setActiveQueryText,
-  onSubmitQueries: saveAndExecuteQueries,
-}
-
-const connector = connect(mstp, mdtp)
-
-export default connector(TimeMachineFluxEditor)
+export default TimeMachineFluxEditor


### PR DESCRIPTION
We want to get an idea of how many users are ripping out the aggregateWindow that's baked into the query builder. By adding these events, we get a better idea of the feature's functionality and make some progressive developments based on that