### PR TITLE
test: move userAccount tests into a single root describe and flush during setup

### DIFF
--- a/cypress/e2e/cloud/userAccounts.test.ts
+++ b/cypress/e2e/cloud/userAccounts.test.ts
@@ -1,161 +1,171 @@
 import {Organization} from '../../../src/types'
 
 const doSetup = (cy, numAccounts: number) => {
-  cy.signin().then(() => {
-    cy.get('@org').then(({id}: Organization) => {
-      cy.setFeatureFlags({
-        uiUnificationFlag: true,
-        multiAccount: true,
-      }).then(() => {
-        cy.quartzProvision({
-          accountType: 'free',
-          numAccounts,
+  cy.flush().then(() => {
+    cy.signin().then(() => {
+      cy.get('@org').then(({id}: Organization) => {
+        cy.setFeatureFlags({
+          uiUnificationFlag: true,
+          multiAccount: true,
         }).then(() => {
-          cy.visit(`/orgs/${id}/accounts/settings`)
+          cy.quartzProvision({
+            accountType: 'free',
+            numAccounts,
+          }).then(() => {
+            cy.visit(`/orgs/${id}/accounts/settings`)
+          })
         })
       })
     })
   })
 }
 
-describe('Account Page; user with 4 accounts', () => {
-  beforeEach(() => doSetup(cy, 4))
+describe('Account Page tests', () => {
+  describe('User with 4 accounts', () => {
+    beforeEach(() => doSetup(cy, 4))
 
-  it('can change the default account, and then see that it changed on the switch dialog; also checks that the switch button is enabled and disabled correctly', () => {
-    cy.getByTestID('account-settings--header').should('be.visible')
-    cy.getByTestID('user-account-switch-btn').should('be.visible')
-    cy.getByTestID('input--active-account-name').should('have.value', 'Influx')
+    it('can change the default account, and then see that it changed on the switch dialog; also checks that the switch button is enabled and disabled correctly', () => {
+      cy.getByTestID('account-settings--header').should('be.visible')
+      cy.getByTestID('user-account-switch-btn').should('be.visible')
+      cy.getByTestID('input--active-account-name').should(
+        'have.value',
+        'Influx'
+      )
 
-    cy.getByTestID('user-account-switch-btn').click()
+      cy.getByTestID('user-account-switch-btn').click()
 
-    const prefix = 'accountSwitch-toggle-choice'
+      const prefix = 'accountSwitch-toggle-choice'
 
-    cy.getByTestID('switch-account--dialog').within(() => {
-      cy.getByTestID(`${prefix}-0-ID`).should('be.visible')
-      cy.getByTestID(`${prefix}-0-ID`).contains('Influx')
-      cy.getByTestID(`${prefix}-0-ID--input`).should('be.checked')
+      cy.getByTestID('switch-account--dialog').within(() => {
+        cy.getByTestID(`${prefix}-0-ID`).should('be.visible')
+        cy.getByTestID(`${prefix}-0-ID`).contains('Influx')
+        cy.getByTestID(`${prefix}-0-ID--input`).should('be.checked')
 
-      cy.getByTestID(`${prefix}-1-ID`).should('be.visible')
-      cy.getByTestID(`${prefix}-1-ID`).contains('Veganomicon (default)')
+        cy.getByTestID(`${prefix}-1-ID`).should('be.visible')
+        cy.getByTestID(`${prefix}-1-ID`).contains('Veganomicon (default)')
 
-      cy.getByTestID(`${prefix}-2-ID`).should('be.visible')
-      cy.getByTestID(`${prefix}-2-ID`).contains('Stradivarius')
+        cy.getByTestID(`${prefix}-2-ID`).should('be.visible')
+        cy.getByTestID(`${prefix}-2-ID`).contains('Stradivarius')
 
-      cy.getByTestID(`${prefix}-3-ID`).should('be.visible')
-      cy.getByTestID(`${prefix}-3-ID`).contains('Yamaha')
+        cy.getByTestID(`${prefix}-3-ID`).should('be.visible')
+        cy.getByTestID(`${prefix}-3-ID`).contains('Yamaha')
 
-      // at first; the switch button should be disabled:
-      cy.getByTestID('actually-switch-account--btn').should('be.disabled')
+        // at first; the switch button should be disabled:
+        cy.getByTestID('actually-switch-account--btn').should('be.disabled')
 
-      // the set default button should be *enabled*
-      cy.getByTestID('switch-default-account--btn').should('be.enabled')
+        // the set default button should be *enabled*
+        cy.getByTestID('switch-default-account--btn').should('be.enabled')
 
-      // now:  select another option:
-      cy.getByTestID(`${prefix}-1-ID`).click()
+        // now:  select another option:
+        cy.getByTestID(`${prefix}-1-ID`).click()
 
-      // check that it is selected before checking the button enabled state:
-      cy.getByTestID(`${prefix}-1-ID--input`).should('be.checked')
+        // check that it is selected before checking the button enabled state:
+        cy.getByTestID(`${prefix}-1-ID--input`).should('be.checked')
 
-      // now; the button should be enabled:
-      cy.getByTestID('actually-switch-account--btn').should('be.enabled')
+        // now; the button should be enabled:
+        cy.getByTestID('actually-switch-account--btn').should('be.enabled')
 
-      // and the default button should be *disabled* b/c just chose the default acct:
-      cy.getByTestID('switch-default-account--btn').should('be.disabled')
+        // and the default button should be *disabled* b/c just chose the default acct:
+        cy.getByTestID('switch-default-account--btn').should('be.disabled')
 
-      // ok; now pick the third option:
-      cy.getByTestID(`${prefix}-2-ID`).click()
+        // ok; now pick the third option:
+        cy.getByTestID(`${prefix}-2-ID`).click()
 
-      // check that it is selected before going to the next step:
-      cy.getByTestID(`${prefix}-2-ID--input`).should('be.checked')
-      cy.getByTestID('switch-default-account--btn').should('be.enabled')
+        // check that it is selected before going to the next step:
+        cy.getByTestID(`${prefix}-2-ID--input`).should('be.checked')
+        cy.getByTestID('switch-default-account--btn').should('be.enabled')
 
-      cy.getByTestID('switch-default-account--btn').click()
-    })
-    // test that the notification is up:
-    cy.getByTestID('notification-success').should('be.visible')
+        cy.getByTestID('switch-default-account--btn').click()
+      })
+      // test that the notification is up:
+      cy.getByTestID('notification-success').should('be.visible')
 
-    // now; bring up the dialog again, the default one should be changed:
-    cy.getByTestID('user-account-switch-btn').click()
+      // now; bring up the dialog again, the default one should be changed:
+      cy.getByTestID('user-account-switch-btn').click()
 
-    cy.getByTestID('switch-account--dialog').within(() => {
-      cy.getByTestID(`${prefix}-0-ID`).should('be.visible')
-      cy.getByTestID(`${prefix}-0-ID`).contains('Influx')
-      cy.getByTestID(`${prefix}-0-ID--input`).should('be.checked')
+      cy.getByTestID('switch-account--dialog').within(() => {
+        cy.getByTestID(`${prefix}-0-ID`).should('be.visible')
+        cy.getByTestID(`${prefix}-0-ID`).contains('Influx')
+        cy.getByTestID(`${prefix}-0-ID--input`).should('be.checked')
 
-      cy.getByTestID(`${prefix}-1-ID`).should('be.visible')
-      cy.getByTestID(`${prefix}-1-ID`).contains('Veganomicon')
+        cy.getByTestID(`${prefix}-1-ID`).should('be.visible')
+        cy.getByTestID(`${prefix}-1-ID`).contains('Veganomicon')
 
-      cy.getByTestID(`${prefix}-2-ID`).should('be.visible')
-      cy.getByTestID(`${prefix}-2-ID`).contains('Stradivarius (default)')
+        cy.getByTestID(`${prefix}-2-ID`).should('be.visible')
+        cy.getByTestID(`${prefix}-2-ID`).contains('Stradivarius (default)')
+      })
     })
   })
-})
 
-describe('Account Page; user with one account', () => {
-  beforeEach(() => cy.flush().then(() => doSetup(cy, 1)))
+  describe('User with one account', () => {
+    beforeEach(() => doSetup(cy, 1))
 
-  it('can get to the page and get the accounts, and the switch button is NOT showing', () => {
-    cy.getByTestID('account-settings--header').should('be.visible')
-    cy.getByTestID('user-account-switch-btn').should('not.exist')
+    it('can get to the page and get the accounts, and the switch button is NOT showing', () => {
+      cy.getByTestID('account-settings--header').should('be.visible')
+      cy.getByTestID('user-account-switch-btn').should('not.exist')
 
-    cy.getByTestID('input--active-account-name').should(
-      'have.value',
-      'Veganomicon'
-    )
-  })
-})
-
-describe('Account Page; user with two accounts', () => {
-  beforeEach(() => cy.flush().then(() => doSetup(cy, 2)))
-
-  it('can get to the account page and rename the active account', () => {
-    cy.getByTestID('account-settings--header').should('be.visible')
-
-    cy.getByTestID('input--active-account-name').should('have.value', 'Influx')
-
-    cy.getByTestID('input--active-account-name').clear()
-    cy.getByTestID('input--active-account-name').should('have.value', '')
-
-    // what can I say?  i am a fan
-    const newName = 'Bruno-no-no-no'
-    cy.getByTestID('input--active-account-name').type(newName)
-    cy.getByTestID('rename-account--button').click()
-
-    // test that the notification is up:
-    cy.getByTestID('notification-success').should('be.visible')
-
-    // now; bring up the dialog, the active name should be changed:
-    cy.getByTestID('user-account-switch-btn').click()
-
-    const prefix = 'accountSwitch-toggle-choice'
-
-    cy.getByTestID('switch-account--dialog').within(() => {
-      cy.getByTestID(`${prefix}-0-ID`).should('be.visible')
-      cy.getByTestID(`${prefix}-0-ID`).contains(newName)
-      cy.getByTestID(`${prefix}-0-ID--input`).should('be.checked')
-      cy.getByTestID('multi-account-switch-cancel').click()
+      cy.getByTestID('input--active-account-name').should(
+        'have.value',
+        'Veganomicon'
+      )
     })
+  })
 
-    // circle-ci and e2e tests got unstable, so best to put all the toys back
-    // (reset the name)
-    cy.getByTestID('account-settings--header').should('be.visible')
+  describe('User with two accounts', () => {
+    beforeEach(() => doSetup(cy, 2))
 
-    cy.getByTestID('input--active-account-name')
-      .clear()
-      .type('Influx')
-    cy.getByTestID('rename-account--button').click()
+    it('can get to the account page and rename the active account', () => {
+      cy.getByTestID('account-settings--header').should('be.visible')
 
-    // test that the notification is up:
-    cy.getByTestID('notification-success').should('be.visible')
+      cy.getByTestID('input--active-account-name').should(
+        'have.value',
+        'Influx'
+      )
 
-    // now; bring up the dialog again, the active name should be changed:
-    cy.getByTestID('user-account-switch-btn').click()
+      cy.getByTestID('input--active-account-name').clear()
+      cy.getByTestID('input--active-account-name').should('have.value', '')
 
-    cy.getByTestID('switch-account--dialog').within(() => {
-      cy.getByTestID(`${prefix}-0-ID`).should('be.visible')
-      cy.getByTestID(`${prefix}-0-ID`).contains('Influx')
-      cy.getByTestID(`${prefix}-0-ID--input`).should('be.checked')
-      cy.getByTestID('multi-account-switch-cancel').click()
+      // what can I say?  i am a fan
+      const newName = 'Bruno-no-no-no'
+      cy.getByTestID('input--active-account-name').type(newName)
+      cy.getByTestID('rename-account--button').click()
+
+      // test that the notification is up:
+      cy.getByTestID('notification-success').should('be.visible')
+
+      // now; bring up the dialog, the active name should be changed:
+      cy.getByTestID('user-account-switch-btn').click()
+
+      const prefix = 'accountSwitch-toggle-choice'
+
+      cy.getByTestID('switch-account--dialog').within(() => {
+        cy.getByTestID(`${prefix}-0-ID`).should('be.visible')
+        cy.getByTestID(`${prefix}-0-ID`).contains(newName)
+        cy.getByTestID(`${prefix}-0-ID--input`).should('be.checked')
+        cy.getByTestID('multi-account-switch-cancel').click()
+      })
+
+      // circle-ci and e2e tests got unstable, so best to put all the toys back
+      // (reset the name)
+      cy.getByTestID('account-settings--header').should('be.visible')
+
+      cy.getByTestID('input--active-account-name')
+        .clear()
+        .type('Influx')
+      cy.getByTestID('rename-account--button').click()
+
+      // test that the notification is up:
+      cy.getByTestID('notification-success').should('be.visible')
+
+      // now; bring up the dialog again, the active name should be changed:
+      cy.getByTestID('user-account-switch-btn').click()
+
+      cy.getByTestID('switch-account--dialog').within(() => {
+        cy.getByTestID(`${prefix}-0-ID`).should('be.visible')
+        cy.getByTestID(`${prefix}-0-ID`).contains('Influx')
+        cy.getByTestID(`${prefix}-0-ID--input`).should('be.checked')
+        cy.getByTestID('multi-account-switch-cancel').click()
+      })
     })
   })
 })


### PR DESCRIPTION
- moves all userAccount tests into a single `describe` block
- does the `cy.flush` during the setup instead of randomly for one block
