### PR TITLE
feat: always on insert

### DIFF
--- a/src/flows/components/PipeList.tsx
+++ b/src/flows/components/PipeList.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FC, useContext} from 'react'
+import React, {FC, Fragment, useContext} from 'react'
 import {useSelector} from 'react-redux'
 import ReactGridLayout, {WidthProvider, Layout} from 'react-grid-layout'
 
@@ -133,9 +133,12 @@ const PipeList: FC = () => {
     )
   }
 
-  const _pipes = flow.data.allIDs.map(id => {
-    return <FlowPipe key={`pipe-${id}`} id={id} />
-  })
+  const _pipes = flow.data.allIDs.map(id => (
+    <Fragment key={`pipe-${id}`}>
+      <FlowPipe id={id} />
+      <InsertCellButton id={id} />
+    </Fragment>
+  ))
 
   return (
     <div className="flow" id={flow?.id}>

--- a/src/flows/components/panel/FlowPanel.tsx
+++ b/src/flows/components/panel/FlowPanel.tsx
@@ -17,7 +17,6 @@ import {
 
 // Components
 import Handle from 'src/flows/components/panel/Handle'
-import InsertCellButton from 'src/flows/components/panel/InsertCellButton'
 import FlowPanelTitle from 'src/flows/components/panel/FlowPanelTitle'
 import {MenuButton} from 'src/flows/components/Sidebar'
 
@@ -155,61 +154,58 @@ const FlowPanel: FC<Props> = ({
   }
 
   return (
-    <>
-      <div className={panelClassName} id={id}>
-        <div className="flow-panel--header">
-          <div className="flow-panel--node-wrapper">
-            <div className="flow-panel--node" />
-          </div>
-          {title}
-          {!flow.readOnly && (
-            <>
-              <div className="flow-panel--hover-control">{controls}</div>
-              <div className="flow-panel--persistent-control">
-                {persistentControls}
-                <FeatureFlag name="flow-debug-queries">
-                  <SquareButton
-                    icon={IconFont.BookCode}
-                    onClick={() => printMap(id)}
-                    color={ComponentColor.Default}
-                    titleText="Debug Notebook Queries"
-                    className="flows-config-panel-button"
-                  />
-                </FeatureFlag>
-                {isVisible && showPreviewButton && (
-                  <Button
-                    onClick={() => queryDependents(id)}
-                    icon={IconFont.Play}
-                    text="Run"
-                  />
-                )}
-                <MenuButton id={id} />
-              </div>
-            </>
-          )}
+    <div className={panelClassName} id={id}>
+      <div className="flow-panel--header">
+        <div className="flow-panel--node-wrapper">
+          <div className="flow-panel--node" />
         </div>
-        {isVisible && (
-          <div
-            className="flow-panel--body"
-            ref={bodyRef}
-            style={resizes ? {height: `${size}px`} : {}}
-          >
-            {children}
-          </div>
+        {title}
+        {!flow.readOnly && (
+          <>
+            <div className="flow-panel--hover-control">{controls}</div>
+            <div className="flow-panel--persistent-control">
+              {persistentControls}
+              <FeatureFlag name="flow-debug-queries">
+                <SquareButton
+                  icon={IconFont.BookCode}
+                  onClick={() => printMap(id)}
+                  color={ComponentColor.Default}
+                  titleText="Debug Notebook Queries"
+                  className="flows-config-panel-button"
+                />
+              </FeatureFlag>
+              {isVisible && showPreviewButton && (
+                <Button
+                  onClick={() => queryDependents(id)}
+                  icon={IconFont.Play}
+                  text="Run"
+                />
+              )}
+              <MenuButton id={id} />
+            </div>
+          </>
         )}
-        <div className="flow-panel--footer">
-          <div></div>
-          {isVisible && resizes && (
-            <Handle
-              dragRef={handleRef}
-              onStartDrag={handleMouseDown}
-              dragging={isDragging === 2}
-            />
-          )}
-        </div>
       </div>
-      {!flow.readOnly && <InsertCellButton id={id} />}
-    </>
+      {isVisible && (
+        <div
+          className="flow-panel--body"
+          ref={bodyRef}
+          style={resizes ? {height: `${size}px`} : {}}
+        >
+          {children}
+        </div>
+      )}
+      <div className="flow-panel--footer">
+        <div></div>
+        {isVisible && resizes && (
+          <Handle
+            dragRef={handleRef}
+            onStartDrag={handleMouseDown}
+            dragging={isDragging === 2}
+          />
+        )}
+      </div>
+    </div>
   )
 }
 

--- a/src/flows/components/panel/InsertCellButton.scss
+++ b/src/flows/components/panel/InsertCellButton.scss
@@ -1,6 +1,8 @@
 @import '@influxdata/clockface/dist/variables.scss';
 @import '~src/flows/FlowVariables.scss';
 
+$cf-radius-lg: $cf-radius + 4px;
+
 .flow-divider {
   position: relative;
   width: 100%;
@@ -110,6 +112,12 @@
   flex-direction: column;
   align-items: center;
   font-size: 14px;
+
+  &.always-on {
+    margin: 32px auto 60px;
+    border-radius: $cf-radius-lg;
+    background-color: $flow-panel--bg;
+  }
 }
 
 .insert-cell-menu--title {

--- a/src/flows/components/panel/InsertCellButton.tsx
+++ b/src/flows/components/panel/InsertCellButton.tsx
@@ -19,6 +19,7 @@ import {FlowContext} from 'src/flows/context/flow.current'
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Styles
 import 'src/flows/components/panel/InsertCellButton.scss'
@@ -49,6 +50,23 @@ const InsertCellButton: FC<Props> = ({id}) => {
     popoverVisible.current = false
     dividerRef.current &&
       dividerRef.current.classList.remove('flow-divider__popped')
+  }
+
+  if (
+    isFlagEnabled('showLastInsert') &&
+    index === flow.data.allIDs.length - 1
+  ) {
+    return (
+      <FlexBox
+        direction={FlexDirection.Column}
+        alignItems={AlignItems.Stretch}
+        margin={ComponentSize.Small}
+        className="insert-cell-menu always-on"
+      >
+        <p className="insert-cell-menu--title">Add Another Cell</p>
+        <AddButtons index={index} />
+      </FlexBox>
+    )
   }
 
   return (


### PR DESCRIPTION
people aren't adding cells into their notebooks. this has a bunch of problems like having people lean on the limited templating system and limiting a lot of the potential of notebooks to morph with people's needs and follow them along the journey of their data discovery. It turns out that 84% of users will never click on that little purple plus button. The edit queries and run them, but dont extend them. Of those who DO click on that button, 70% of the users find something useful in there.
<img width="1115" alt="Screen Shot 2022-03-01 at 11 30 11 AM" src="https://user-images.githubusercontent.com/1434802/156236408-6b25d707-d33f-44f2-8aa7-139562cc71c6.png">

this PR exposes the panel insertion interface right on the top level, which doesn't just make insertion a lot easier / quicker, but will hopefully get those 80% of users exposed to whatever those limited users found was useful in there. i'd expect the total number of users who add a panel to raise above 11.6% and even see the little plus button see more love once people know you can actually add panels in a notebook somehow.

looks like this
![Kapture 2022-03-01 at 11 25 53](https://user-images.githubusercontent.com/1434802/156237087-2b93ab27-5d3d-4e05-b763-7ed9d49822f8.gif)

