### PR TITLE
test: remove problematic right arrows in explorer tests

### DIFF
--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -543,15 +543,15 @@ describe('DataExplorer', () => {
       const taskName = 'tax'
       // begin flux
       cy.getByTestID('flux-editor').should('be.visible')
-        .monacoType(`from(bucket: "defbuck"{rightarrow}
-  |> range(start: -15m, stop: now({rightarrow}{rightarrow}
-  |> filter(fn: (r{rightarrow} => r._measurement ==`)
+        .monacoType(`from(bucket: "defbuck")
+  |> range(start: -15m, stop: now())
+  |> filter(fn: (r) => r._measurement == `)
 
       cy.getByTestID('toolbar-tab').click()
       // checks to see if the default variables exist
-      cy.getByTestID('variable--timeRangeStart')
-      cy.getByTestID('variable--timeRangeStop')
-      cy.getByTestID('variable--windowPeriod')
+      cy.getByTestID('variable--timeRangeStart').should('exist')
+      cy.getByTestID('variable--timeRangeStop').should('exist')
+      cy.getByTestID('variable--windowPeriod').should('exist')
       // insert variable name by clicking on variable
       cy.get('.flux-toolbar--variable')
         .first()

--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -530,9 +530,9 @@ describe('DataExplorer', () => {
     it('shows the empty state when the query returns no results', () => {
       cy.getByTestID('time-machine--bottom').within(() => {
         cy.getByTestID('flux-editor').should('be.visible')
-          .monacoType(`from(bucket: "defbuck"{rightarrow}
-  |> range(start: -10s{rightarrow}
-  |> filter(fn: (r{rightarrow} => r._measurement == "no exist"{rightarrow}`)
+          .monacoType(`from(bucket: "defbuck")
+  |> range(start: -10s)
+  |> filter(fn: (r) => r._measurement == "no exist")`)
         cy.getByTestID('time-machine-submit-button').click()
       })
 


### PR DESCRIPTION
Don't use `{rightarrow}` in these places. They are creating spaces that are problematic.