### PR TITLE
chore: update to pipeline env vars passed to monitor-ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
     steps:
       - run:
           name: Run monitor-ci tests
-          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="feat-CI-quartz-mock" UI_BRANCH=${CIRCLE_BRANCH} UI_SHA=${CIRCLE_SHA1} SHA=${CIRCLE_SHA1} RUN_WORKFLOW="build" /run-monitor-ci-tests.bash
+          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="master" UI_BRANCH=${CIRCLE_BRANCH} UI_SHA=${CIRCLE_SHA1} SHA=${CIRCLE_SHA1} RUN_WORKFLOW="build" /run-monitor-ci-tests.bash
       - store_artifacts:
           path: monitor-ci/test-artifacts/results/build-oss-image
           destination: test_artifacts/results/build-oss-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
     steps:
       - run:
           name: Run monitor-ci tests
-          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="master" QUARTZ_MOCK_BRANCH="master" UI_BRANCH=${CIRCLE_BRANCH} UI_SHA=${CIRCLE_SHA1} SHA=${CIRCLE_SHA1} /run-monitor-ci-tests.bash
+          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="master" UI_BRANCH=${CIRCLE_BRANCH} UI_SHA=${CIRCLE_SHA1} SHA=${CIRCLE_SHA1} RUN_WORKFLOW="build" /run-monitor-ci-tests.bash
       - store_artifacts:
           path: monitor-ci/test-artifacts/results/build-oss-image
           destination: test_artifacts/results/build-oss-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,14 +137,14 @@ jobs:
 
   monitor-ci-tests:
     docker:
-      - image: quay.io/influxdb/ui-pipeline:latest
+      - image: quay.io/influxdb/ui-pipeline:quartz-mock-test
         auth:
           username: $QUAY_CD_USER
           password: $QUAY_CD_PASSWORD
     steps:
       - run:
           name: Run monitor-ci tests
-          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="master" UI_BRANCH=${CIRCLE_BRANCH} UI_SHA=${CIRCLE_SHA1} SHA=${CIRCLE_SHA1} RUN_WORKFLOW="build" /run-monitor-ci-tests.bash
+          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="feat-CI-quartz-mock" UI_BRANCH=${CIRCLE_BRANCH} UI_SHA=${CIRCLE_SHA1} SHA=${CIRCLE_SHA1} RUN_WORKFLOW="build" /run-monitor-ci-tests.bash
       - store_artifacts:
           path: monitor-ci/test-artifacts/results/build-oss-image
           destination: test_artifacts/results/build-oss-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
     steps:
       - run:
           name: Run monitor-ci tests
-          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="master" UI_BRANCH=${CIRCLE_BRANCH} SHA=${CIRCLE_SHA1} /run-monitor-ci-tests.bash
+          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="master" QUARTZ_MOCK_BRANCH="master" UI_BRANCH=${CIRCLE_BRANCH} SHA=${CIRCLE_SHA1} /run-monitor-ci-tests.bash
       - store_artifacts:
           path: monitor-ci/test-artifacts/results/build-oss-image
           destination: test_artifacts/results/build-oss-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,14 +137,14 @@ jobs:
 
   monitor-ci-tests:
     docker:
-      - image: quay.io/influxdb/ui-pipeline:quartz-mock-test
+      - image: quay.io/influxdb/ui-pipeline:latest
         auth:
           username: $QUAY_CD_USER
           password: $QUAY_CD_PASSWORD
     steps:
       - run:
           name: Run monitor-ci tests
-          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="feat-CI-quartz-mock" UI_BRANCH=${CIRCLE_BRANCH} UI_SHA=${CIRCLE_SHA1} SHA=${CIRCLE_SHA1} RUN_WORKFLOW="build" /run-monitor-ci-tests.bash
+          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="master" UI_BRANCH=${CIRCLE_BRANCH} UI_SHA=${CIRCLE_SHA1} SHA=${CIRCLE_SHA1} RUN_WORKFLOW="build" /run-monitor-ci-tests.bash
       - store_artifacts:
           path: monitor-ci/test-artifacts/results/build-oss-image
           destination: test_artifacts/results/build-oss-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
     steps:
       - run:
           name: Run monitor-ci tests
-          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="master" UI_BRANCH=${CIRCLE_BRANCH} UI_SHA=${CIRCLE_SHA1} SHA=${CIRCLE_SHA1} RUN_WORKFLOW="build" /run-monitor-ci-tests.bash
+          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="feat-CI-quartz-mock" UI_BRANCH=${CIRCLE_BRANCH} UI_SHA=${CIRCLE_SHA1} SHA=${CIRCLE_SHA1} RUN_WORKFLOW="build" /run-monitor-ci-tests.bash
       - store_artifacts:
           path: monitor-ci/test-artifacts/results/build-oss-image
           destination: test_artifacts/results/build-oss-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
     steps:
       - run:
           name: Run monitor-ci tests
-          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="master" QUARTZ_MOCK_BRANCH="master" UI_BRANCH=${CIRCLE_BRANCH} SHA=${CIRCLE_SHA1} /run-monitor-ci-tests.bash
+          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="master" QUARTZ_MOCK_BRANCH="master" UI_BRANCH=${CIRCLE_BRANCH} UI_SHA=${CIRCLE_SHA1} SHA=${CIRCLE_SHA1} /run-monitor-ci-tests.bash
       - store_artifacts:
           path: monitor-ci/test-artifacts/results/build-oss-image
           destination: test_artifacts/results/build-oss-image


### PR DESCRIPTION
Part of: https://github.com/influxdata/ui/issues/3565

### Purpose:
* When making changes in quartz-mock PR, incorporate CI tests including e2e with UI.
* Make it such that bad mock bad (in quartz-mock), does not break our CI pipeline.


### Done in this PR:
* explicitly set the workflow enum which is run.
* have both a SHA and UI_SHA.
* confirmed it works by testing against a temporarily published ui-pipeline quay image, paired with the monitor-ci PR branch:
   * https://github.com/influxdata/ui/pull/3988/commits/43668daa25ac3046177404e3330036228a66d9f9 

### TODO: before merging
- [x] merge monitor-ci PR.
    * https://github.com/influxdata/monitor-ci/pull/349
- [x]  revert commit done to test against monitor-ci branch, with temp quay image
   * revert: https://github.com/influxdata/ui/pull/3988/commits/43668daa25ac3046177404e3330036228a66d9f9 
