### PR TITLE
test: refactor explorer tests

### DIFF
--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -543,15 +543,15 @@ describe('DataExplorer', () => {
       const taskName = 'tax'
       // begin flux
       cy.getByTestID('flux-editor').should('be.visible')
-        .monacoType(`from(bucket: "defbuck"{rightarrow}
-  |> range(start: -15m, stop: now({rightarrow}{rightarrow}
-  |> filter(fn: (r{rightarrow} => r._measurement ==`)
+        .monacoType(`from(bucket: "defbuck")
+  |> range(start: -15m, stop: now())
+  |> filter(fn: (r) => r._measurement == `)
 
       cy.getByTestID('toolbar-tab').click()
       // checks to see if the default variables exist
-      cy.getByTestID('variable--timeRangeStart')
-      cy.getByTestID('variable--timeRangeStop')
-      cy.getByTestID('variable--windowPeriod')
+      cy.getByTestID('variable--timeRangeStart').should('exist')
+      cy.getByTestID('variable--timeRangeStop').should('exist')
+      cy.getByTestID('variable--windowPeriod').should('exist')
       // insert variable name by clicking on variable
       cy.get('.flux-toolbar--variable')
         .first()

--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -32,7 +32,7 @@ describe('DataExplorer', () => {
       cy.createMapVariable(id)
       cy.fixture('routes').then(({orgs, explorer}) => {
         cy.visit(`${orgs}/${id}${explorer}`)
-        cy.getByTestID('tree-nav')
+        cy.getByTestID('tree-nav').should('be.visible')
       })
     })
   })
@@ -54,17 +54,16 @@ describe('DataExplorer', () => {
     it('can navigate to data explorer from buckets list and override state', () => {
       const fluxCode = 'from(bucket: "_monitoring")'
       cy.getByTestID('switch-to-script-editor').click()
-      cy.getByTestID('flux-editor').monacoType(fluxCode)
+      cy.get('.monaco-editor .view-line:last').should('be.visible')
+      cy.get('.monaco-editor .view-line:last')
+        .click()
+        .type(fluxCode)
       cy.contains('Submit').click()
       cy.get('.cf-tree-nav--toggle').click()
       cy.getByTestID('nav-item-load-data').click()
-      // Can't use the testID to select this nav item because Clockface is silly and uses the same testID twice
-      // Issue: https://github.com/influxdata/clockface/issues/539
-      cy.get('.cf-tree-nav--sub-item-label')
-        .contains('Buckets')
-        .click()
+      cy.getByTestID('nav-subitem-buckets').click()
       cy.getByTestID('bucket--card--name _tasks').click()
-      cy.getByTestID('query-builder').should('exist')
+      cy.getByTestID('query-builder').should('be.visible')
     })
   })
 

--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -212,17 +212,18 @@ describe('DataExplorer', () => {
           cy.getByTestID(defaultBucketListSelector).click()
 
           cy.getByTestID('selector-list m').should('be.visible')
-          cy.getByTestID('selector-list m').clickAttached()
+          cy.getByTestID('selector-list m').click()
 
           cy.getByTestID('selector-list v').should('be.visible')
-          cy.getByTestID('selector-list v').clickAttached()
+          cy.getByTestID('selector-list v').click()
 
-          cy.getByTestID('selector-list tv1').clickAttached()
+          cy.getByTestID('selector-list tv1').should('be.visible')
+          cy.getByTestID('selector-list tv1').click()
 
           cy.getByTestID('selector-list mean')
             .scrollIntoView()
             .should('be.visible')
-            .click({force: true})
+            .click()
 
           cy.getByTestID('time-machine-submit-button').click()
           cy.get('canvas.giraffe-gauge').should('be.visible')
@@ -277,17 +278,18 @@ describe('DataExplorer', () => {
           cy.getByTestID(defaultBucketListSelector).click()
 
           cy.getByTestID('selector-list m').should('be.visible')
-          cy.getByTestID('selector-list m').clickAttached()
+          cy.getByTestID('selector-list m').click()
 
           cy.getByTestID('selector-list v').should('be.visible')
-          cy.getByTestID('selector-list v').clickAttached()
+          cy.getByTestID('selector-list v').click()
 
-          cy.getByTestID('selector-list tv1').clickAttached()
+          cy.getByTestID('selector-list tv1').should('be.visible')
+          cy.getByTestID('selector-list tv1').click()
 
           cy.getByTestID('selector-list mean')
             .scrollIntoView()
             .should('be.visible')
-            .click({force: true})
+            .click()
 
           cy.getByTestID('time-machine-submit-button').click()
           cy.get('.giraffe-gauge').should('be.visible')

--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -530,9 +530,9 @@ describe('DataExplorer', () => {
     it('shows the empty state when the query returns no results', () => {
       cy.getByTestID('time-machine--bottom').within(() => {
         cy.getByTestID('flux-editor').should('be.visible')
-          .monacoType(`from(bucket: "defbuck"{rightarrow}
-  |> range(start: -10s{rightarrow}
-  |> filter(fn: (r{rightarrow} => r._measurement == "no exist"{rightarrow}`)
+          .monacoType(`from(bucket: "defbuck")
+  |> range(start: -10s)
+  |> filter(fn: (r) => r._measurement == "no exist")`)
         cy.getByTestID('time-machine-submit-button').click()
       })
 

--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -41,10 +41,7 @@ describe('DataExplorer', () => {
     it('should persist and display last submitted script editor script ', () => {
       const fluxCode = 'from(bucket: "_monitoring")'
       cy.getByTestID('switch-to-script-editor').click()
-      cy.get('.monaco-editor .view-line:last').should('be.visible')
-      cy.get('.monaco-editor .view-line:last')
-        .click()
-        .type(fluxCode)
+      cy.getByTestID('flux-editor').monacoType(fluxCode)
       cy.contains('Submit').click()
       cy.getByTestID('nav-item-tasks').click()
       cy.getByTestID('nav-item-data-explorer').click()
@@ -54,10 +51,7 @@ describe('DataExplorer', () => {
     it('can navigate to data explorer from buckets list and override state', () => {
       const fluxCode = 'from(bucket: "_monitoring")'
       cy.getByTestID('switch-to-script-editor').click()
-      cy.get('.monaco-editor .view-line:last').should('be.visible')
-      cy.get('.monaco-editor .view-line:last')
-        .click()
-        .type(fluxCode)
+      cy.getByTestID('flux-editor').monacoType(fluxCode)
       cy.contains('Submit').click()
       cy.get('.cf-tree-nav--toggle').click()
       cy.getByTestID('nav-item-load-data').click()

--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -41,7 +41,10 @@ describe('DataExplorer', () => {
     it('should persist and display last submitted script editor script ', () => {
       const fluxCode = 'from(bucket: "_monitoring")'
       cy.getByTestID('switch-to-script-editor').click()
-      cy.getByTestID('flux-editor').monacoType(fluxCode)
+      cy.get('.monaco-editor .view-line:last').should('be.visible')
+      cy.get('.monaco-editor .view-line:last')
+        .click()
+        .type(fluxCode)
       cy.contains('Submit').click()
       cy.getByTestID('nav-item-tasks').click()
       cy.getByTestID('nav-item-data-explorer').click()


### PR DESCRIPTION
Refactors `explorer.test.ts`

- do not use `{rightarraow}` in some places
- explicitly call `.should('exist')` or `.should('be.visible')` for clarity
- updates test for manual refreshing to something simpler and more sane

