### PR TITLE
fix(3928): remove exportTask validation via hitting the queryEndpoint. Use heuristic instead.

### DIFF
--- a/src/flows/pipes/Schedule/ExportTaskButton.tsx
+++ b/src/flows/pipes/Schedule/ExportTaskButton.tsx
@@ -13,6 +13,7 @@ import {
   resourceLimitReached,
   taskCreatedSuccess,
   taskNotCreated,
+  testNotificationFailure,
 } from 'src/shared/copy/notifications'
 import {ASSET_LIMIT_ERROR_STATUS} from 'src/cloud/constants/index'
 import {postTask, patchTask} from 'src/client'
@@ -36,7 +37,7 @@ interface Props {
   text: string
   type: string
   generate?: () => string
-  validate?: (query: string) => boolean
+  validate?: (query: string) => boolean // throws or return false, versus return true
   onCreate?: (task: any) => void
   disabled?: boolean
   loading?: boolean
@@ -59,10 +60,16 @@ const ExportTaskButton: FC<Props> = ({
   const org = useSelector(getOrg)
 
   const onClick = async () => {
-    const query = generate ? generate() : data.query
-    const valid = validate ? validate(query) : true
-
-    if (!valid) {
+    let query
+    let validQuery
+    try {
+      query = generate ? generate() : data.query
+      validQuery = validate ? validate(query) : true
+      if (!validQuery) {
+        throw new Error('Invalid query.')
+      }
+    } catch (e) {
+      dispatch(notify(testNotificationFailure(e.message)))
       return
     }
 

--- a/src/flows/pipes/Schedule/ExportTaskButton.tsx
+++ b/src/flows/pipes/Schedule/ExportTaskButton.tsx
@@ -36,7 +36,7 @@ interface Props {
   text: string
   type: string
   generate?: () => string
-  validate?: (query: string) => Promise<boolean>
+  validate?: (query: string) => boolean
   onCreate?: (task: any) => void
   disabled?: boolean
   loading?: boolean
@@ -60,7 +60,7 @@ const ExportTaskButton: FC<Props> = ({
 
   const onClick = async () => {
     const query = generate ? generate() : data.query
-    const valid = validate ? await validate(query) : true
+    const valid = validate ? validate(query) : true
 
     if (!valid) {
       return

--- a/src/shared/copy/notifications.ts
+++ b/src/shared/copy/notifications.ts
@@ -1470,7 +1470,7 @@ export const testNotificationFailure = (
   reason: string = 'flux was invalid.'
 ): Notification => ({
   ...defaultErrorNotification,
-  message: `Test failed: ${reason}`,
+  message: `Failure detected: ${reason}`,
 })
 
 export const exportAlertToTaskSuccess = (


### PR DESCRIPTION
Closes #3928 

### Issue:
* we had a previous issue (https://github.com/influxdata/ui/pull/3916) of invalid Alert Tasks being produced.
     * We solved this by hitting the query endpoint first (which gives us errors if the flux is bad), BEFORE doing the crud call to export the task.
* Now we have a new ticket #3928 , about the running of the phantom query.

### Done:
* an imperfect compromise.
* we do not have semantic validation available yet
     * still TBD here https://github.com/influxdata/ui/issues/3926
* in the meantime:
    * remove phantom query (no hitting of the query endpoint)
    *  do a heuristic check of our most common semantic errors.


### Visual:
You will see:
* attempted export of bad query:
   * the query endpoint does not get triggered. (only the metrics collection API call)
   * an error notification is still surfaced to the user.
* fix it, and export a correct query: 
   * no error.
   * successfully exports the task.



https://user-images.githubusercontent.com/10232835/156840186-bce4738d-a227-461e-b6d3-9fded44d9089.mov




