### PR TITLE
fix(3880): surface errors from query endpoint response, to the testNotification panel

### DIFF
--- a/src/flows/pipes/Notification/view.tsx
+++ b/src/flows/pipes/Notification/view.tsx
@@ -55,6 +55,7 @@ import {notify} from 'src/shared/actions/notifications'
 import {
   testNotificationSuccess,
   testNotificationFailure,
+  invalidFluxQuery,
 } from 'src/shared/copy/notifications'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {getSecrets} from 'src/secrets/actions/thunks'
@@ -277,8 +278,9 @@ const Notification: FC<PipeProp> = ({Context}) => {
 
       setStatus(RemoteDataState.Done)
       dispatch(notify(testNotificationSuccess(data.endpoint)))
-    } catch {
+    } catch (e) {
       setStatus(RemoteDataState.Error)
+      dispatch(notify(invalidFluxQuery(e.message)))
       dispatch(notify(testNotificationFailure(data.endpoint)))
     }
   }

--- a/src/flows/pipes/Notification/view.tsx
+++ b/src/flows/pipes/Notification/view.tsx
@@ -55,7 +55,6 @@ import {notify} from 'src/shared/actions/notifications'
 import {
   testNotificationSuccess,
   testNotificationFailure,
-  invalidFluxQuery,
 } from 'src/shared/copy/notifications'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {getSecrets} from 'src/secrets/actions/thunks'
@@ -280,8 +279,7 @@ const Notification: FC<PipeProp> = ({Context}) => {
       dispatch(notify(testNotificationSuccess(data.endpoint)))
     } catch (e) {
       setStatus(RemoteDataState.Error)
-      dispatch(notify(invalidFluxQuery(e.message)))
-      dispatch(notify(testNotificationFailure(data.endpoint)))
+      dispatch(notify(testNotificationFailure(e.message)))
     }
   }
 

--- a/src/shared/copy/notifications.ts
+++ b/src/shared/copy/notifications.ts
@@ -1467,17 +1467,10 @@ export const testNotificationSuccess = (
 })
 
 export const testNotificationFailure = (
-  source: 'slack' | 'pagerduty' | 'https'
+  reason: string = 'flux was invalid.'
 ): Notification => ({
   ...defaultErrorNotification,
-  message: `Failed to send the test alert to ${source}. Please try again.`,
-})
-
-export const invalidFluxQuery = (
-  reason: string = 'error not recognized.'
-): Notification => ({
-  ...defaultErrorNotification,
-  message: `Flux query was invalid: ${JSON.stringify(reason)}`,
+  message: `Test failed: ${reason}`,
 })
 
 export const exportAlertToTaskSuccess = (

--- a/src/shared/copy/notifications.ts
+++ b/src/shared/copy/notifications.ts
@@ -1470,7 +1470,14 @@ export const testNotificationFailure = (
   source: 'slack' | 'pagerduty' | 'https'
 ): Notification => ({
   ...defaultErrorNotification,
-  message: `Failed to send the test alert to ${source}. Please try again`,
+  message: `Failed to send the test alert to ${source}. Please try again.`,
+})
+
+export const invalidFluxQuery = (
+  reason: string = 'error not recognized.'
+): Notification => ({
+  ...defaultErrorNotification,
+  message: `Flux query was invalid: ${JSON.stringify(reason)}`,
 })
 
 export const exportAlertToTaskSuccess = (


### PR DESCRIPTION
Part of #3880 

### Issue:
* errors are surfaced when using bad creds for HTTP post notification
      * cannot fix this specific one. the backend returns a 2xx, and nothing significant in the response body.
* general case: when the backend returns an error, we are not surfacing that specific error.
      * note: backend has updated itself to throw when there is a badURL used.
      * we need to surface that exact error returned.   

### Done:
* error from the API call is already processed here: https://github.com/influxdata/ui/blob/master/src/shared/contexts/query.tsx#L509-L522
* then is caught, and only the message (which we want) is passed up: https://github.com/influxdata/ui/blob/master/src/shared/contexts/query.tsx#L562-L569
* therefore, we should only have to pass along this message to a UI view element

.

### Visual evidence:

https://user-images.githubusercontent.com/10232835/156675016-fd3d7ed5-03ef-45cb-899a-824f9889bab5.mov


