### PR TITLE
refactor: make typing in the monaco editor less aggressive

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -73,10 +73,9 @@ Cypress.Commands.add(
   {prevSubject: true},
   (subject, text: string) => {
     return cy.wrap(subject).within(() => {
-      cy.get('.monaco-editor .view-line:last')
-        .click({force: true})
-        .focused()
-        .type(text, {force: true, delay: 10})
+      cy.get('.monaco-editor .view-line:last').should('be.visible')
+      cy.get('.monaco-editor .view-line:last').click()
+      cy.get('.monaco-editor .view-line:last').type(text)
     })
   }
 )


### PR DESCRIPTION
The use of `force` as an option should be reserved for cases when we do not want Cypress to act like a user.

In all our tests that involve typing into the Monaco Editor, we _do_ want Cypress to act like a user. We want to ensure that the elements are actionable. No forcing.

Make typing in the Monaco Editor less aggressive:
- remove force clicking
- remove force typing
- do not focus
- remove chaining to avoid detached elements when Cypress retrys
