### PR TITLE
fix: remove unnecessary variable from useEffect dependency array

### DIFF
--- a/src/visualization/components/internal/ThresholdsSettings.tsx
+++ b/src/visualization/components/internal/ThresholdsSettings.tsx
@@ -137,7 +137,7 @@ const ThresholdsSettings: FunctionComponent<Props> = ({
     if (state.isDirty && state.isValid) {
       onSetThresholds(state.thresholds)
     }
-  }, [state, onSetThresholds])
+  }, [state])
 
   return (
     <FlexBox


### PR DESCRIPTION
Closes #3343
closes #3864 

When customizing color threshold of a table in Data Explorer page, the UI crashes and outputs a `maximum update depth exceeded` error in the console. This error is caused by a UseEffect hook that updates a variable in its own dependency array, causing an infinite re-render loop. 

fix: remove `onSetThresholds` from Effect's dependency array to stop the infinite re-rending.

https://user-images.githubusercontent.com/66275100/156592203-b349162a-0b70-473a-9870-85289c9504ed.mov

 