### PR TITLE
test(task): type esc to avoid auto complete

### DIFF
--- a/cypress/e2e/shared/tasks.test.ts
+++ b/cypress/e2e/shared/tasks.test.ts
@@ -30,7 +30,7 @@ describe('Tasks', () => {
       })
     })
   })
-  
+
   it('can create a task', () => {
     const taskName = 'Task'
     cy.createTaskFromEmpty(taskName, ({name}) => {

--- a/cypress/e2e/shared/tasks.test.ts
+++ b/cypress/e2e/shared/tasks.test.ts
@@ -30,11 +30,11 @@ describe('Tasks', () => {
       })
     })
   })
-
+  
   it('can create a task', () => {
     const taskName = 'Task'
     cy.createTaskFromEmpty(taskName, ({name}) => {
-      return `import "influxdata/influxdb/v1"
+      return `import "influxdata/influxdb/v1"{esc}
 v1.tagValues(bucket: "${name}", tag: "_field")
 from(bucket: "${name}")
    |> range(start: -2m)`


### PR DESCRIPTION
Addresses #2887 
Addresses #3942 

while creating a task, cypress interprets new line in template literal as enter, which causes autocomplete to populate flux editor (adding an unnecessary syntax) 

fix ->  added an escape command `{esc}` to avoid auto completion. 
