### PR TITLE
feat: Make `Account ID`link to the account details

### DIFF
--- a/src/operator/constants.tsx
+++ b/src/operator/constants.tsx
@@ -92,6 +92,9 @@ export const organizationColumnInfo: CellInfo[] = [
     path: 'account.id',
     name: 'account-id',
     defaultValue: '',
+    renderValue: value => (
+      <Link to={`/operator/accounts/${value}`}>{value}</Link>
+    ),
   },
   {
     path: 'account.balance',


### PR DESCRIPTION
In the operator UI, when viewing organizations, the account ID will now link the to associated account's details page.

![image](https://user-images.githubusercontent.com/31899323/156650036-a586888d-803b-4220-8f3f-f7ab990e568d.png)