### PR TITLE
fix: color mapping provide default colors when none exist

### DIFF
--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -57,6 +57,7 @@ import {isFlagEnabled} from '../../../shared/utils/featureFlag'
 // Selectors
 import {getByID} from 'src/resources/selectors'
 import {updateViewAndVariables} from 'src/views/actions/thunks'
+import {DashboardColor} from '../../../client'
 
 interface Props extends VisualizationProps {
   properties: XYViewProperties
@@ -201,7 +202,12 @@ const XYPlot: FC<Props> = ({
       colorMappingForGiraffe,
       colorMappingForIDPE,
       needsToSaveToIDPE,
-    } = getColorMappingObjects(fillColumnMap, properties)
+    } = getColorMappingObjects(fillColumnMap, {
+      ...properties,
+      colors: properties.colors
+        ? properties.colors
+        : (DEFAULT_LINE_COLORS as DashboardColor[]),
+    })
     colorMapping = colorMappingForGiraffe
 
     // when the view is in a dashboard cell, and there is a need to save to IDPE, save it.


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/3989

Provide a default color map to the mapping algo when none is returned from the backend. 

<!-- Describe your proposed changes here. -->
