### PR TITLE
fix: allow alerts with imports

### DIFF
--- a/src/flows/components/header/AutoRefreshButton.tsx
+++ b/src/flows/components/header/AutoRefreshButton.tsx
@@ -1,6 +1,6 @@
 import React, {FC, useCallback, useContext, useEffect} from 'react'
 import {useDispatch, useSelector} from 'react-redux'
-import {Button, ComponentColor} from '@influxdata/clockface'
+import {Button, ComponentColor, ComponentStatus} from '@influxdata/clockface'
 import {PROJECT_NAME} from 'src/flows'
 import {AppState, AutoRefreshStatus} from 'src/types'
 import {resetAutoRefresh} from 'src/shared/actions/autoRefresh'
@@ -15,7 +15,7 @@ import {FlowQueryContext} from 'src/flows/context/flow.query'
 
 const AutoRefreshButton: FC = () => {
   const {flow} = useContext(FlowContext)
-  const {queryAll} = useContext(FlowQueryContext)
+  const {queryAll, generateMap} = useContext(FlowQueryContext)
   const dispatch = useDispatch()
 
   const autoRefresh = useSelector(
@@ -85,11 +85,17 @@ const AutoRefreshButton: FC = () => {
   }, [queryAll])
 
   const isActive = autoRefresh?.status === AutoRefreshStatus.Active
+  const hasQueries = generateMap().filter(s => !!s.source).length > 0
 
   return (
     <Button
       text={
         isActive ? `Refreshing Every ${autoRefresh?.label}` : 'Set Auto Refresh'
+      }
+      status={
+        hasQueries === false
+          ? ComponentStatus.Disabled
+          : ComponentStatus.Default
       }
       color={isActive ? ComponentColor.Secondary : ComponentColor.Default}
       onClick={

--- a/src/flows/components/header/Submit.tsx
+++ b/src/flows/components/header/Submit.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FC, useContext, useMemo} from 'react'
+import React, {FC, useContext} from 'react'
 import {IconFont} from '@influxdata/clockface'
 
 import {SubmitQueryButton} from 'src/timeMachine/components/SubmitQueryButton'
@@ -19,7 +19,7 @@ export const Submit: FC = () => {
   const {cancel} = useContext(QueryContext)
   const {generateMap, queryAll, status} = useContext(FlowQueryContext)
 
-  const hasQueries = useMemo(() => generateMap().length > 0, [generateMap])
+  const hasQueries = generateMap().filter(s => !!s.source).length > 0
 
   const handleSubmit = () => {
     event('Notebook Submit Button Clicked')


### PR DESCRIPTION
when trying to reproduce this one: https://github.com/influxdata/ui/issues/3919
i found out that our imports are all messed up, and if you try  to use a query that implements an import, we just fail silently
this normalizes the imports for the task generation mechanisms and combines them with the user defined  query's imports