### PR TITLE
fix: make cloud/operator test more reliable

### DIFF
--- a/cypress/e2e/cloud/operator.test.ts
+++ b/cypress/e2e/cloud/operator.test.ts
@@ -21,17 +21,9 @@ describe('Operator Page', () => {
   )
 
   it('should render the Operator page and allow for RUD operations', () => {
-    // Validates that the default behavior is to open to the account tab
-    cy.getByTestID('accountTab').should('satisfy', element => {
-      const classList = Array.from(element[0].classList)
-      return classList.includes('cf-tabs--tab__active')
-    })
-
-    // Expect the org tab to be inactive
-    cy.getByTestID('orgTab').should('satisfy', element => {
-      const classList = Array.from(element[0].classList)
-      return classList.includes('cf-tabs--tab__active') === false
-    })
+    // validates that the default behavior is to open to the account tab
+    cy.getByTestID('accountTab').should('have.class', 'cf-tabs--tab__active')
+    cy.getByTestID('orgTab').should('not.have.class', 'cf-tabs--tab__active')
 
     cy.get('.cf-refless-popover--trigger').click()
 
@@ -44,33 +36,44 @@ describe('Operator Page', () => {
       cy.getByTestID('table-row').should('have.length', 6)
     })
 
-    // filter the results by email
+    // placeholder says filter by email
     cy.getByTestID('operator-resource--searchbar')
       .invoke('attr', 'placeholder')
       .should('contain', 'Filter accounts by email')
 
-    cy.focused()
-    cy.getByTestID('operator-resource--searchbar')
-      .scrollIntoView()
-      .type('asalem', {
-        force: true,
-        delay: 50,
-      })
+    // get ready to search accounts
+    cy.intercept('GET', '/api/v2/quartz/operator/accounts*').as(
+      'quartzSearchAccounts'
+    )
 
-    cy.getByTestID('table-body').within(() => {
-      cy.getByTestID('table-row').should('have.length', 1)
-    })
+    // Search for a known user
+    const knownUser = ['a', 's', 'a', 'l', 'e', 'm']
+    for (let index = 0; index < knownUser.length; index += 1) {
+      cy.getByTestID('operator-resource--searchbar').type(knownUser[index])
+      cy.wait('@quartzSearchAccounts')
+      cy.getByTestID('table-body').within(() => {
+        cy.getByTestID('table-row').should('have.length', index === 0 ? 6 : 1)
+      })
+    }
 
     // Make sure that the popover closes when clicking out
     cy.getByTestID('refless-popover--contents').should('not.exist')
 
-    cy.getByTestID('operator-resource--searchbar')
-      .clear()
-      .type('salt_bae', {force: true, delay: 50})
+    // Search for an unknown user
+    cy.getByTestID('operator-resource--searchbar').clear()
+    const unknownUser = ['s', 'a', 'l', 't', '_', 'b', 'a', 'e']
+    for (let index = 0; index < unknownUser.length; index += 1) {
+      cy.getByTestID('operator-resource--searchbar').type(unknownUser[index])
+      cy.wait('@quartzSearchAccounts')
 
-    cy.getByTestID('empty-state--text').contains(
-      'Looks like there were no accounts that matched your search'
-    )
+      // all letters up to 'sal' will match, any more will not
+      if (index > 2) {
+        cy.getByTestID('empty-state--text').should('be.visible')
+      } else {
+        cy.getByTestID('empty-state--text').should('not.exist')
+      }
+    }
+
     cy.getByTestID('operator-resource--searchbar').clear()
 
     cy.getByTestID('orgTab').click()
@@ -79,43 +82,45 @@ describe('Operator Page', () => {
       expect(loc.pathname).to.eq('/operator/orgs')
     })
 
-    // Expect the org tab to be active
-    cy.getByTestID('orgTab').should('satisfy', element => {
-      const classList = Array.from(element[0].classList)
-      return classList.includes('cf-tabs--tab__active')
-    })
-
-    // Expect the account tab to be inactive
-    cy.getByTestID('accountTab').should('satisfy', element => {
-      const classList = Array.from(element[0].classList)
-      return classList.includes('cf-tabs--tab__active') === false
-    })
+    cy.getByTestID('orgTab').should('have.class', 'cf-tabs--tab__active')
+    cy.getByTestID('accountTab').should(
+      'not.have.class',
+      'cf-tabs--tab__active'
+    )
 
     // preloads 6 organizations
     cy.getByTestID('table-body').within(() => {
       cy.getByTestID('table-row').should('have.length', 6)
     })
 
-    // filter the results by email
+    // placeholder says filter by id
     cy.getByTestID('operator-resource--searchbar')
       .invoke('attr', 'placeholder')
       .should('contain', 'Filter organizations by id')
 
-    cy.getByTestID('operator-resource--searchbar').type('678', {
-      force: true,
-      delay: 50,
-    })
-    cy.getByTestID('table-body').within(() => {
-      cy.getByTestID('table-row').should('have.length', 1)
-    })
+    // get ready to search orgs
+    cy.intercept('GET', '/api/v2/quartz/operator/orgs*').as('quartzSearchOrgs')
 
-    cy.getByTestID('operator-resource--searchbar')
-      .clear()
-      .type('invalid', {force: true, delay: 50})
+    // search for a known org
+    const knownOrg = ['6', '7', '8']
+    for (let index = 0; index < knownOrg.length; index += 1) {
+      cy.getByTestID('operator-resource--searchbar').type(knownOrg[index])
+      cy.wait('@quartzSearchOrgs')
+      cy.getByTestID('table-body').within(() => {
+        cy.getByTestID('table-row').should('have.length', 1)
+      })
+    }
 
-    cy.getByTestID('empty-state--text').contains(
-      'Looks like there were no organizations that matched your search'
-    )
+    cy.getByTestID('operator-resource--searchbar').clear()
+
+    // search for an unknown org
+    const unknownOrg = ['i', 'n', 'v', 'a', 'l', 'i', 'd']
+    for (let index = 0; index < unknownOrg.length; index += 1) {
+      cy.getByTestID('operator-resource--searchbar').type(unknownOrg[index])
+      cy.wait('@quartzSearchOrgs')
+      cy.getByTestID('empty-state--text').should('be.visible')
+    }
+
     cy.getByTestID('operator-resource--searchbar').clear()
 
     cy.getByTestID('accountTab').click()
@@ -123,6 +128,9 @@ describe('Operator Page', () => {
     cy.location().should(loc => {
       expect(loc.pathname).to.eq('/operator/accounts')
     })
+
+    cy.getByTestID('accountTab').should('have.class', 'cf-tabs--tab__active')
+    cy.getByTestID('orgTab').should('not.have.class', 'cf-tabs--tab__active')
 
     cy.getByTestID('account-id')
       .first()
@@ -149,22 +157,9 @@ describe('Operator Page', () => {
     cy.getByTestID('subscription-status--header').should('exist')
     cy.getByTestID('billing-contact--header').should('exist')
 
-    // Validate that associated users appear
-    // TODO(ariel): reenable this. Deleting the user seems to be causing issues with the data
-    // cy.getByTestID('associated-users--table-body').within(() => {
-    //   cy.getByTestID('table-row').should('have.length', 1)
-    //   cy.getByTestID('remove-user--button').click()
-    // })
-
-    // // Remove the associated user
-    // cy.getByTestID('remove-user--confirm-button').click()
-
-    // // Confirm that the associated user was deleted
-    // cy.getByTestID('empty-state').should('exist')
-
-    cy.getByTestID('associated-orgs--title')
-      .contains('Associated Organizations')
-      .scrollIntoView()
+    cy.getByTestID('associated-orgs--title').contains(
+      'Associated Organizations'
+    )
 
     cy.getByTestID('associated-orgs--table-body').within(() => {
       cy.getByTestID('table-row').should('have.length', 6)
@@ -181,51 +176,26 @@ describe('Operator Page', () => {
       expect(loc.pathname).to.eq('/operator/orgs/678')
     })
 
+    cy.getByTestID('overlay--container').should('be.visible')
     cy.getByTestID('overlay--header').contains('678')
 
     cy.getByTestID('limits-rate.readKBs--input')
       .clear()
-      .type('666', {delay: 50})
+      .type('666')
 
     cy.getByTestID('org-overlay--submit-button').click()
 
     cy.getByTestID('account-view--back-button').click()
 
-    // cy.getByTestID('operator-resource--searchbar').type('ariel', {
-    //   force: true,
-    //   delay: 50,
-    // })
-
-    // cy.getByTestID('account-id')
-    //   .last()
-    //   .within(() => {
-    //     cy.get('a').click()
-    //   })
-
-    // cy.location().should(loc => {
-    //   expect(loc.pathname).to.eq('/operator/accounts/3')
-    // })
-
-    // cy.getByTestID('account-delete--button').click()
-
-    // cy.getByTestID('cf-icon alert-triangle cf-alert--icon').should('exist')
-
-    // cy.getByTestID('delete-account--confirmation-button').click()
-
-    // redirect the operator back to the operator page once deleting an account
-    // cy.location().should(loc => {
-    //   expect(loc.pathname).to.eq('/operator')
-    // })
-
-    // cy.getByTestID('operator-resource--searchbar').type('ariel', {
-    //   force: true,
-    //   delay: 50,
-    // })
-
-    // // confirm that the account has been deleted
-    // cy.getByTestID('empty-state').should('exist')
+    cy.getByTestID('accountTab').should('have.class', 'cf-tabs--tab__active')
+    cy.getByTestID('orgTab').should('not.have.class', 'cf-tabs--tab__active')
 
     cy.getByTestID('orgTab').click()
+    cy.getByTestID('orgTab').should('have.class', 'cf-tabs--tab__active')
+    cy.getByTestID('accountTab').should(
+      'not.have.class',
+      'cf-tabs--tab__active'
+    )
 
     cy.getByTestID('org-id')
       .last()
@@ -237,6 +207,7 @@ describe('Operator Page', () => {
       expect(loc.pathname).to.eq('/operator/orgs/678')
     })
 
+    cy.getByTestID('overlay--container').should('be.visible')
     cy.getByTestID('overlay--header').contains('678')
 
     cy.getByTestID('limits-rate.readKBs--input')
@@ -245,7 +216,7 @@ describe('Operator Page', () => {
 
     // should be able to view the operator link in the navbar
     cy.visit('/')
-    cy.getByTestID('nav-item--operator').should('exist')
+    cy.getByTestID('nav-item--operator').should('be.visible')
   })
 })
 


### PR DESCRIPTION
Makes cloud/operator test more reliable

- use `cy.intercept` because every character in the search bar triggers an api call
- wait on each call and assert at will
- a few other minor fixes
