### PR TITLE
fix: unblock users for the weekend

### DIFF
--- a/src/flows/pipes/Notification/ExportTask.tsx
+++ b/src/flows/pipes/Notification/ExportTask.tsx
@@ -1,4 +1,4 @@
-import React, {FC, useContext, useCallback, useState} from 'react'
+import React, {FC, useContext, useCallback} from 'react'
 import {useDispatch} from 'react-redux'
 import {parse, format_from_js_file} from '@influxdata/flux-lsp-browser'
 
@@ -16,24 +16,17 @@ import {
   deadmanType,
   THRESHOLD_TYPES,
 } from 'src/flows/pipes/Visualization/threshold'
-import {RemoteDataState} from 'src/types'
 import {ImportDeclaration} from 'src/types/ast'
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'
 import {notify} from 'src/shared/actions/notifications'
-import {
-  exportAlertToTaskSuccess,
-  exportAlertToTaskFailure,
-} from 'src/shared/copy/notifications'
+import {exportAlertToTaskSuccess} from 'src/shared/copy/notifications'
 
 const ExportTask: FC = () => {
   const dispatch = useDispatch()
   const {id, data} = useContext(PipeContext)
-  const {query, simplify, getPanelQueries} = useContext(FlowQueryContext)
-  const [status, setStatus] = useState<RemoteDataState>(
-    RemoteDataState.NotStarted
-  )
+  const {simplify, getPanelQueries} = useContext(FlowQueryContext)
 
   const queryText = getPanelQueries(id)?.source
 
@@ -297,30 +290,13 @@ ${ENDPOINT_DEFINITIONS[data.endpoint]?.generateQuery(data.endpointData)}`
     }
   }, [generateDeadmanTask, generateThresholdTask, data.thresholds])
 
-  const validateTask = async (queryText: string): Promise<boolean> => {
-    try {
-      setStatus(RemoteDataState.Loading)
-      await query(queryText)
-
-      setStatus(RemoteDataState.Done)
-      dispatch(notify(exportAlertToTaskSuccess(data.endpoint)))
-      return true
-    } catch {
-      setStatus(RemoteDataState.Error)
-      dispatch(notify(exportAlertToTaskFailure(data.endpoint)))
-      return false
-    }
-  }
-
   const handleTaskCreation = _ => {
     dispatch(notify(exportAlertToTaskSuccess(data.endpoint)))
   }
 
   return (
     <ExportTaskButton
-      loading={status == RemoteDataState.Loading}
       generate={generateTask}
-      validate={validateTask}
       onCreate={handleTaskCreation}
       text="Export Alert Task"
       type="alert"

--- a/src/flows/pipes/Schedule/ExportTaskButton.tsx
+++ b/src/flows/pipes/Schedule/ExportTaskButton.tsx
@@ -36,20 +36,16 @@ interface Props {
   text: string
   type: string
   generate?: () => string
-  validate?: (query: string) => Promise<boolean>
   onCreate?: (task: any) => void
   disabled?: boolean
-  loading?: boolean
 }
 
 const ExportTaskButton: FC<Props> = ({
   text,
   type,
   generate,
-  validate,
   onCreate,
   disabled,
-  loading,
 }) => {
   const {flow} = useContext(FlowContext)
   const {add} = useContext(FlowListContext)
@@ -60,11 +56,6 @@ const ExportTaskButton: FC<Props> = ({
 
   const onClick = async () => {
     const query = generate ? generate() : data.query
-    const valid = validate ? await validate(query) : true
-
-    if (!valid) {
-      return
-    }
 
     event('Export Task Modal Skipped', {from: type})
     let taskid
@@ -169,8 +160,6 @@ const ExportTaskButton: FC<Props> = ({
   let status = ComponentStatus.Default
   if (disabled) {
     status = ComponentStatus.Disabled
-  } else if (loading) {
-    status = ComponentStatus.Loading
   }
 
   return (


### PR DESCRIPTION
based on tanking conversion numbers for alert generation while notebook utilization continues to climb, the front side validation of our notebooks alerts panel that was recently added seems to be preventing users from generating alerts over the past week. this pr is to unblock those customers trying to create an alert while we riff on the implementation to capture the intent of the original implementation.