### PR TITLE
feat: unpinning an item from the resource location

### DIFF
--- a/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -67,6 +67,7 @@ interface OwnProps {
   labels: string[]
   onFilterChange: (searchTerm: string) => void
   onPinDashboard: () => void
+  onUnpinDashboard: (DashboardID: string) => void
   isPinned: boolean
 }
 
@@ -163,23 +164,10 @@ class DashboardCard extends PureComponent<Props> {
     }
   }
 
-  private onDeletePinnedItem = async () => {
-    const {id} = this.props
-
-    // delete from pinned item list
-    try {
-      await deletePinnedItemByParam(id)
-      this.props.sendNotification(pinnedItemSuccess('dashboard', 'deleted'))
-      this.props.onPinDashboard()
-    } catch (err) {
-      this.props.sendNotification(pinnedItemFailure(err.message, 'delete'))
-    }
-  }
-
   private handlePinDashboard = () => {
-    const {isPinned} = this.props
+    const {isPinned, id} = this.props
     if (isPinned) {
-      this.onDeletePinnedItem()
+      this.props.onUnpinDashboard(id)
     } else {
       this.onAddPinnedItem()
     }

--- a/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -129,7 +129,7 @@ class DashboardCard extends PureComponent<Props> {
         updatePinnedItemByParam(id, {name})
         this.props.sendNotification(pinnedItemSuccess('dashboard', 'updated'))
       } catch (err) {
-        this.props.sendNotification(pinnedItemFailure(err.message, 'dashboard'))
+        this.props.sendNotification(pinnedItemFailure(err.message, 'update'))
       }
     }
   }
@@ -141,21 +141,32 @@ class DashboardCard extends PureComponent<Props> {
   }
 
   private handlePinDashboard = () => {
-    try {
-      addPinnedItem({
-        orgID: this.props.org.id,
-        userID: this.props.me.id,
-        metadata: {
-          dashboardID: this.props.id,
-          name: this.props.name,
-          description: this.props.description,
-        },
-
-        type: PinnedItemTypes.Dashboard,
-      })
-      this.props.sendNotification(pinnedItemSuccess('dashboard', 'added'))
-    } catch (err) {
-      this.props.sendNotification(pinnedItemFailure(err.message, 'dashboard'))
+    const {org, me, id, name, description, isPinned} = this.props
+    if (isPinned) {
+      // delete from pinned item
+      try {
+        deletePinnedItemByParam(id)
+        this.props.sendNotification(pinnedItemSuccess('dashboard', 'deleted'))
+      } catch (err) {
+        this.props.sendNotification(pinnedItemFailure(err.message, 'delete'))
+      }
+    } else {
+      // add to pinned item
+      try {
+        addPinnedItem({
+          orgID: org.id,
+          userID: me.id,
+          metadata: {
+            dashboardID: id,
+            name: name,
+            description: description,
+          },
+          type: PinnedItemTypes.Dashboard,
+        })
+        this.props.sendNotification(pinnedItemSuccess('dashboard', 'added'))
+      } catch (err) {
+        this.props.sendNotification(pinnedItemFailure(err.message, 'add'))
+      }
     }
   }
 
@@ -209,12 +220,11 @@ class DashboardCard extends PureComponent<Props> {
                     this.handlePinDashboard()
                     onHide()
                   }}
-                  disabled={this.props.isPinned}
                   size={ComponentSize.Small}
                   style={fontWeight}
                   testID="context-pin-dashboard"
                 >
-                  Pin
+                  {this.props.isPinned ? 'Unpin' : 'Pin'}
                 </List.Item>
               )}
             </List>
@@ -263,7 +273,7 @@ class DashboardCard extends PureComponent<Props> {
     try {
       updatePinnedItemByParam(id, {description})
     } catch (err) {
-      this.props.sendNotification(pinnedItemFailure(err.message, 'dashboard'))
+      this.props.sendNotification(pinnedItemFailure(err.message, 'update'))
     }
   }
 

--- a/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -66,6 +66,7 @@ interface OwnProps {
   updatedAt: string
   labels: string[]
   onFilterChange: (searchTerm: string) => void
+  onPinTask: () => void
   isPinned: boolean
 }
 
@@ -140,20 +141,21 @@ class DashboardCard extends PureComponent<Props> {
     onCloneDashboard(id, name)
   }
 
-  private handlePinDashboard = () => {
+  private handlePinDashboard = async () => {
     const {org, me, id, name, description, isPinned} = this.props
     if (isPinned) {
       // delete from pinned item list
       try {
-        deletePinnedItemByParam(id)
+        await deletePinnedItemByParam(id)
         this.props.sendNotification(pinnedItemSuccess('dashboard', 'deleted'))
+        this.props.onPinTask()
       } catch (err) {
         this.props.sendNotification(pinnedItemFailure(err.message, 'delete'))
       }
     } else {
       // add to pinned item list
       try {
-        addPinnedItem({
+        await addPinnedItem({
           orgID: org.id,
           userID: me.id,
           metadata: {
@@ -164,6 +166,7 @@ class DashboardCard extends PureComponent<Props> {
           type: PinnedItemTypes.Dashboard,
         })
         this.props.sendNotification(pinnedItemSuccess('dashboard', 'added'))
+        this.props.onPinTask()
       } catch (err) {
         this.props.sendNotification(pinnedItemFailure(err.message, 'add'))
       }

--- a/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -141,35 +141,47 @@ class DashboardCard extends PureComponent<Props> {
     onCloneDashboard(id, name)
   }
 
-  private handlePinDashboard = async () => {
-    const {org, me, id, name, description, isPinned} = this.props
+  private onAddPinnedItem = async () => {
+    const {org, me, id, name, description} = this.props
+
+    // add to pinned item list
+    try {
+      await addPinnedItem({
+        orgID: org.id,
+        userID: me.id,
+        metadata: {
+          dashboardID: id,
+          name: name,
+          description: description,
+        },
+        type: PinnedItemTypes.Dashboard,
+      })
+      this.props.sendNotification(pinnedItemSuccess('dashboard', 'added'))
+      this.props.onPinDashboard()
+    } catch (err) {
+      this.props.sendNotification(pinnedItemFailure(err.message, 'add'))
+    }
+  }
+
+  private onDeletePinnedItem = async () => {
+    const {id} = this.props
+
+    // delete from pinned item list
+    try {
+      await deletePinnedItemByParam(id)
+      this.props.sendNotification(pinnedItemSuccess('dashboard', 'deleted'))
+      this.props.onPinDashboard()
+    } catch (err) {
+      this.props.sendNotification(pinnedItemFailure(err.message, 'delete'))
+    }
+  }
+
+  private handlePinDashboard = () => {
+    const {isPinned} = this.props
     if (isPinned) {
-      // delete from pinned item list
-      try {
-        await deletePinnedItemByParam(id)
-        this.props.sendNotification(pinnedItemSuccess('dashboard', 'deleted'))
-        this.props.onPinDashboard()
-      } catch (err) {
-        this.props.sendNotification(pinnedItemFailure(err.message, 'delete'))
-      }
+      this.onDeletePinnedItem()
     } else {
-      // add to pinned item list
-      try {
-        await addPinnedItem({
-          orgID: org.id,
-          userID: me.id,
-          metadata: {
-            dashboardID: id,
-            name: name,
-            description: description,
-          },
-          type: PinnedItemTypes.Dashboard,
-        })
-        this.props.sendNotification(pinnedItemSuccess('dashboard', 'added'))
-        this.props.onPinDashboard()
-      } catch (err) {
-        this.props.sendNotification(pinnedItemFailure(err.message, 'add'))
-      }
+      this.onAddPinnedItem()
     }
   }
 

--- a/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -66,7 +66,7 @@ interface OwnProps {
   updatedAt: string
   labels: string[]
   onFilterChange: (searchTerm: string) => void
-  onPinTask: () => void
+  onPinDashboard: () => void
   isPinned: boolean
 }
 
@@ -148,7 +148,7 @@ class DashboardCard extends PureComponent<Props> {
       try {
         await deletePinnedItemByParam(id)
         this.props.sendNotification(pinnedItemSuccess('dashboard', 'deleted'))
-        this.props.onPinTask()
+        this.props.onPinDashboard()
       } catch (err) {
         this.props.sendNotification(pinnedItemFailure(err.message, 'delete'))
       }
@@ -166,7 +166,7 @@ class DashboardCard extends PureComponent<Props> {
           type: PinnedItemTypes.Dashboard,
         })
         this.props.sendNotification(pinnedItemSuccess('dashboard', 'added'))
-        this.props.onPinTask()
+        this.props.onPinDashboard()
       } catch (err) {
         this.props.sendNotification(pinnedItemFailure(err.message, 'add'))
       }

--- a/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -185,7 +185,7 @@ class DashboardCard extends PureComponent<Props> {
           appearance={Appearance.Outline}
           enableDefaultStyles={false}
           style={minWidth}
-          contents={() => (
+          contents={onHide => (
             <List>
               <List.Item
                 onClick={this.handleExport}
@@ -205,7 +205,10 @@ class DashboardCard extends PureComponent<Props> {
               </List.Item>
               {isFlagEnabled('pinnedItems') && CLOUD && (
                 <List.Item
-                  onClick={this.handlePinDashboard}
+                  onClick={() => {
+                    this.handlePinDashboard()
+                    onHide()
+                  }}
                   disabled={this.props.isPinned}
                   size={ComponentSize.Small}
                   style={fontWeight}

--- a/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -143,7 +143,7 @@ class DashboardCard extends PureComponent<Props> {
   private handlePinDashboard = () => {
     const {org, me, id, name, description, isPinned} = this.props
     if (isPinned) {
-      // delete from pinned item
+      // delete from pinned item list
       try {
         deletePinnedItemByParam(id)
         this.props.sendNotification(pinnedItemSuccess('dashboard', 'deleted'))
@@ -151,7 +151,7 @@ class DashboardCard extends PureComponent<Props> {
         this.props.sendNotification(pinnedItemFailure(err.message, 'delete'))
       }
     } else {
-      // add to pinned item
+      // add to pinned item list
       try {
         addPinnedItem({
           orgID: org.id,

--- a/src/dashboards/components/dashboard_index/DashboardCards.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardCards.tsx
@@ -20,9 +20,9 @@ import {LimitStatus} from 'src/cloud/actions/limits'
 
 // Contexts
 import {
-  // addPinnedItem,
+  addPinnedItem,
   deletePinnedItemByParam,
-  // PinnedItemTypes,
+  PinnedItemTypes,
 } from 'src/shared/contexts/pinneditems'
 
 // Utils
@@ -129,8 +129,30 @@ class DashboardCards extends PureComponent<Props> {
       .catch(err => console.error(err))
   }
 
-  public handlePinDashboard = () => {
-    this.updatePinnedItems()
+  public handlePinDashboard = async (
+    dashboardID: string,
+    name: string,
+    description: string
+  ) => {
+    const {org, me} = this.props
+
+    // add to pinned item list
+    try {
+      await addPinnedItem({
+        orgID: org.id,
+        userID: me.id,
+        metadata: {
+          dashboardID,
+          name,
+          description,
+        },
+        type: PinnedItemTypes.Dashboard,
+      })
+      this.props.sendNotification(pinnedItemSuccess('dashboard', 'added'))
+      this.updatePinnedItems()
+    } catch (err) {
+      this.props.sendNotification(pinnedItemFailure(err.message, 'add'))
+    }
   }
 
   public handleUnpinDashboard = async (dashboardID: string) => {

--- a/src/dashboards/components/dashboard_index/DashboardCards.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardCards.tsx
@@ -110,6 +110,14 @@ class DashboardCards extends PureComponent<OwnProps & StateProps> {
     }
   }
 
+  public handlePinTask = () => {
+    getPinnedItems()
+      .then(res => {
+        this.setState({pinnedItems: res})
+      })
+      .catch(err => console.error(err))
+  }
+
   public render() {
     const {
       dashboards,
@@ -142,6 +150,7 @@ class DashboardCards extends PureComponent<OwnProps & StateProps> {
                 updatedAt={meta.updatedAt}
                 description={description}
                 onFilterChange={onFilterChange}
+                onPinTask={this.handlePinTask}
                 isPinned={
                   !!pinnedItems.find(item => item?.metadata.dashboardID === id)
                 }

--- a/src/dashboards/components/dashboard_index/DashboardCards.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardCards.tsx
@@ -55,18 +55,9 @@ class DashboardCards extends PureComponent<OwnProps & StateProps> {
 
   public componentDidMount() {
     if (isFlagEnabled('pinnedItems') && CLOUD) {
-      getPinnedItems()
-        .then(res => {
-          if (this._isMounted) {
-            this.setState(prev => ({...prev, pinnedItems: res, windowSize: 15}))
-          }
-        })
-        .catch(err => {
-          console.error(err)
-        })
-    } else {
-      this.setState(prev => ({...prev, windowSize: 15}))
+      this.updatePinnedItems()
     }
+    this.setState(prev => ({...prev, windowSize: 15}))
   }
 
   public componentWillUnmount() {
@@ -110,12 +101,18 @@ class DashboardCards extends PureComponent<OwnProps & StateProps> {
     }
   }
 
-  public handlePinDashboard = () => {
+  public updatePinnedItems = () => {
     getPinnedItems()
       .then(res => {
-        this.setState({pinnedItems: res})
+        if (this._isMounted) {
+          this.setState(prev => ({...prev, pinnedItems: res}))
+        }
       })
       .catch(err => console.error(err))
+  }
+
+  public handlePinDashboard = () => {
+    this.updatePinnedItems()
   }
 
   public render() {

--- a/src/dashboards/components/dashboard_index/DashboardCards.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardCards.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import memoizeOne from 'memoize-one'
 
 // Components
@@ -10,16 +10,31 @@ import AssetLimitAlert from 'src/cloud/components/AssetLimitAlert'
 
 // Selectors
 import {getSortedResources, SortTypes} from 'src/shared/utils/sort'
+import {getMe} from 'src/me/selectors'
+import {getOrg} from 'src/organizations/selectors'
 
 // Types
 import {AppState, Dashboard, RemoteDataState} from 'src/types'
 import {Sort} from 'src/clockface'
 import {LimitStatus} from 'src/cloud/actions/limits'
 
+// Contexts
+import {
+  // addPinnedItem,
+  deletePinnedItemByParam,
+  // PinnedItemTypes,
+} from 'src/shared/contexts/pinneditems'
+
 // Utils
 import {extractDashboardLimits} from 'src/cloud/utils/limits'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {CLOUD} from 'src/shared/constants'
+import {notify} from 'src/shared/actions/notifications'
+
+import {
+  pinnedItemFailure,
+  pinnedItemSuccess,
+} from 'src/shared/copy/notifications'
 
 let getPinnedItems
 if (CLOUD) {
@@ -38,7 +53,10 @@ interface OwnProps {
   onFilterChange: (searchTerm: string) => void
 }
 
-class DashboardCards extends PureComponent<OwnProps & StateProps> {
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & StateProps & ReduxProps
+
+class DashboardCards extends PureComponent<Props> {
   private _observer
   private _isMounted = true
   private _spinner
@@ -115,6 +133,17 @@ class DashboardCards extends PureComponent<OwnProps & StateProps> {
     this.updatePinnedItems()
   }
 
+  public handleUnpinDashboard = async (dashboardID: string) => {
+    // delete from pinned item list
+    try {
+      await deletePinnedItemByParam(dashboardID)
+      this.props.sendNotification(pinnedItemSuccess('dashboard', 'deleted'))
+      this.updatePinnedItems()
+    } catch (err) {
+      this.props.sendNotification(pinnedItemFailure(err.message, 'delete'))
+    }
+  }
+
   public render() {
     const {
       dashboards,
@@ -148,6 +177,7 @@ class DashboardCards extends PureComponent<OwnProps & StateProps> {
                 description={description}
                 onFilterChange={onFilterChange}
                 onPinDashboard={this.handlePinDashboard}
+                onUnpinDashboard={this.handleUnpinDashboard}
                 isPinned={
                   !!pinnedItems.find(item => item?.metadata.dashboardID === id)
                 }
@@ -172,10 +202,21 @@ class DashboardCards extends PureComponent<OwnProps & StateProps> {
   }
 }
 
+const mdtp = {
+  sendNotification: notify,
+}
+
 const mstp = (state: AppState) => {
+  const me = getMe(state)
+  const org = getOrg(state)
+
   return {
     limitStatus: extractDashboardLimits(state),
+    me,
+    org,
   }
 }
 
-export default connect(mstp)(DashboardCards)
+const connector = connect(mstp, mdtp)
+
+export default connector(DashboardCards)

--- a/src/dashboards/components/dashboard_index/DashboardCards.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardCards.tsx
@@ -110,7 +110,7 @@ class DashboardCards extends PureComponent<OwnProps & StateProps> {
     }
   }
 
-  public handlePinTask = () => {
+  public handlePinDashboard = () => {
     getPinnedItems()
       .then(res => {
         this.setState({pinnedItems: res})
@@ -150,7 +150,7 @@ class DashboardCards extends PureComponent<OwnProps & StateProps> {
                 updatedAt={meta.updatedAt}
                 description={description}
                 onFilterChange={onFilterChange}
-                onPinTask={this.handlePinTask}
+                onPinDashboard={this.handlePinDashboard}
                 isPinned={
                   !!pinnedItems.find(item => item?.metadata.dashboardID === id)
                 }

--- a/src/dashboards/components/dashboard_index/DashboardCardsPaginated.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardCardsPaginated.tsx
@@ -71,6 +71,7 @@ class DashboardCards extends PureComponent<OwnProps & StateProps> {
               updatedAt={meta.updatedAt}
               description={description}
               onFilterChange={onFilterChange}
+              onPinTask={this.handlePinTask}
               isPinned={
                 !!pinnedItems.find(item => item?.metadata.dashboardID === id)
               }
@@ -84,6 +85,14 @@ class DashboardCards extends PureComponent<OwnProps & StateProps> {
         </div>
       </div>
     )
+  }
+
+  public handlePinTask = () => {
+    getPinnedItems()
+      .then(res => {
+        this.setState({pinnedItems: res})
+      })
+      .catch(err => console.error(err))
   }
 }
 

--- a/src/dashboards/components/dashboard_index/DashboardCardsPaginated.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardCardsPaginated.tsx
@@ -16,9 +16,9 @@ import {getOrg} from 'src/organizations/selectors'
 
 // Contexts
 import {
-  // addPinnedItem,
+  addPinnedItem,
   deletePinnedItemByParam,
-  // PinnedItemTypes,
+  PinnedItemTypes,
 } from 'src/shared/contexts/pinneditems'
 
 // Utils
@@ -110,8 +110,30 @@ class DashboardCards extends PureComponent<Props> {
       .catch(err => console.error(err))
   }
 
-  public handlePinDashboard = () => {
-    this.updatePinnedItems()
+  public handlePinDashboard = async (
+    dashboardID: string,
+    name: string,
+    description: string
+  ) => {
+    const {org, me} = this.props
+
+    // add to pinned item list
+    try {
+      await addPinnedItem({
+        orgID: org.id,
+        userID: me.id,
+        metadata: {
+          dashboardID,
+          name,
+          description,
+        },
+        type: PinnedItemTypes.Dashboard,
+      })
+      this.props.sendNotification(pinnedItemSuccess('dashboard', 'added'))
+      this.updatePinnedItems()
+    } catch (err) {
+      this.props.sendNotification(pinnedItemFailure(err.message, 'add'))
+    }
   }
 
   public handleUnpinDashboard = async (dashboardID: string) => {

--- a/src/dashboards/components/dashboard_index/DashboardCardsPaginated.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardCardsPaginated.tsx
@@ -38,15 +38,7 @@ class DashboardCards extends PureComponent<OwnProps & StateProps> {
 
   public componentDidMount() {
     if (isFlagEnabled('pinnedItems') && CLOUD) {
-      getPinnedItems()
-        .then(res => {
-          if (this._isMounted) {
-            this.setState(prev => ({...prev, pinnedItems: res}))
-          }
-        })
-        .catch(err => {
-          console.error(err)
-        })
+      this.updatePinnedItems()
     }
   }
 
@@ -87,12 +79,18 @@ class DashboardCards extends PureComponent<OwnProps & StateProps> {
     )
   }
 
-  public handlePinDashboard = () => {
+  public updatePinnedItems = () => {
     getPinnedItems()
       .then(res => {
-        this.setState({pinnedItems: res})
+        if (this._isMounted) {
+          this.setState(prev => ({...prev, pinnedItems: res}))
+        }
       })
       .catch(err => console.error(err))
+  }
+
+  public handlePinDashboard = () => {
+    this.updatePinnedItems()
   }
 }
 

--- a/src/dashboards/components/dashboard_index/DashboardCardsPaginated.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardCardsPaginated.tsx
@@ -71,7 +71,7 @@ class DashboardCards extends PureComponent<OwnProps & StateProps> {
               updatedAt={meta.updatedAt}
               description={description}
               onFilterChange={onFilterChange}
-              onPinTask={this.handlePinTask}
+              onPinDashboard={this.handlePinDashboard}
               isPinned={
                 !!pinnedItems.find(item => item?.metadata.dashboardID === id)
               }
@@ -87,7 +87,7 @@ class DashboardCards extends PureComponent<OwnProps & StateProps> {
     )
   }
 
-  public handlePinTask = () => {
+  public handlePinDashboard = () => {
     getPinnedItems()
       .then(res => {
         this.setState({pinnedItems: res})

--- a/src/flows/components/FlowContextMenu.tsx
+++ b/src/flows/components/FlowContextMenu.tsx
@@ -53,31 +53,39 @@ const FlowContextMenu: FC<Props> = ({id, name, isPinned}) => {
   const history = useHistory()
   const dispatch = useDispatch()
 
+  const handleDeletePinnedItem = async () => {
+    try {
+      await deletePinnedItemByParam(id)
+      dispatch(notify(pinnedItemSuccess('notebook', 'deleted')))
+    } catch (err) {
+      dispatch(notify(pinnedItemFailure(err.message, 'delete')))
+    }
+  }
+
+  const handleAddPinnedItem = async () => {
+    try {
+      await addPinnedItem({
+        orgID: orgID,
+        userID: me.id,
+        metadata: {
+          flowID: id,
+          name,
+        },
+        type: PinnedItemTypes.Notebook,
+      })
+      dispatch(notify(pinnedItemSuccess('notebook', 'added')))
+    } catch (err) {
+      dispatch(notify(pinnedItemFailure(err.message, 'create')))
+    }
+  }
+
   const handlePinFlow = () => {
     if (isPinned) {
       // delete from pinned item list
-      try {
-        deletePinnedItemByParam(id)
-        dispatch(notify(pinnedItemSuccess('notebook', 'deleted')))
-      } catch (err) {
-        dispatch(notify(pinnedItemFailure(err.message, 'delete')))
-      }
+      handleDeletePinnedItem()
     } else {
       // add to pinned item list
-      try {
-        addPinnedItem({
-          orgID: orgID,
-          userID: me.id,
-          metadata: {
-            flowID: id,
-            name,
-          },
-          type: PinnedItemTypes.Notebook,
-        })
-        dispatch(notify(pinnedItemSuccess('notebook', 'added')))
-      } catch (err) {
-        dispatch(notify(pinnedItemFailure(err.message, 'create')))
-      }
+      handleAddPinnedItem()
     }
   }
 

--- a/src/flows/components/FlowContextMenu.tsx
+++ b/src/flows/components/FlowContextMenu.tsx
@@ -54,19 +54,30 @@ const FlowContextMenu: FC<Props> = ({id, name, isPinned}) => {
   const dispatch = useDispatch()
 
   const handlePinFlow = () => {
-    try {
-      addPinnedItem({
-        orgID: orgID,
-        userID: me.id,
-        metadata: {
-          flowID: id,
-          name,
-        },
-        type: PinnedItemTypes.Notebook,
-      })
-      dispatch(notify(pinnedItemSuccess('notebook', 'added')))
-    } catch (err) {
-      dispatch(notify(pinnedItemFailure(err.message, 'create')))
+    if (isPinned) {
+      // delete from pinned item
+      try {
+        deletePinnedItemByParam(id)
+        dispatch(notify(pinnedItemSuccess('notebook', 'deleted')))
+      } catch (err) {
+        dispatch(notify(pinnedItemFailure(err.message, 'delete')))
+      }
+    } else {
+      // add to pinned item
+      try {
+        addPinnedItem({
+          orgID: orgID,
+          userID: me.id,
+          metadata: {
+            flowID: id,
+            name,
+          },
+          type: PinnedItemTypes.Notebook,
+        })
+        dispatch(notify(pinnedItemSuccess('notebook', 'added')))
+      } catch (err) {
+        dispatch(notify(pinnedItemFailure(err.message, 'create')))
+      }
     }
   }
 
@@ -128,9 +139,8 @@ const FlowContextMenu: FC<Props> = ({id, name, isPinned}) => {
                 size={ComponentSize.Small}
                 style={{fontWeight: 500}}
                 testID="context-pin-flow"
-                disabled={isPinned}
               >
-                Pin
+                {isPinned ? 'Unpin' : 'Pin'}
               </List.Item>
             )}
           </List>

--- a/src/flows/components/FlowContextMenu.tsx
+++ b/src/flows/components/FlowContextMenu.tsx
@@ -55,7 +55,7 @@ const FlowContextMenu: FC<Props> = ({id, name, isPinned}) => {
 
   const handlePinFlow = () => {
     if (isPinned) {
-      // delete from pinned item
+      // delete from pinned item list
       try {
         deletePinnedItemByParam(id)
         dispatch(notify(pinnedItemSuccess('notebook', 'deleted')))
@@ -63,7 +63,7 @@ const FlowContextMenu: FC<Props> = ({id, name, isPinned}) => {
         dispatch(notify(pinnedItemFailure(err.message, 'delete')))
       }
     } else {
-      // add to pinned item
+      // add to pinned item list
       try {
         addPinnedItem({
           orgID: orgID,

--- a/src/tasks/components/TaskCard.test.tsx
+++ b/src/tasks/components/TaskCard.test.tsx
@@ -28,6 +28,7 @@ const setup = (override = {}) => {
     onCreateLabel: jest.fn(),
     setCurrentTasksPage: jest.fn(),
     labels: [], // all labels
+    onPinTask: jest.fn(),
     isPinned: false,
     org: {id: 'BUCKSINSIX', name: 'Milwaukee Bucks'},
     me: {

--- a/src/tasks/components/TaskCard.test.tsx
+++ b/src/tasks/components/TaskCard.test.tsx
@@ -29,6 +29,7 @@ const setup = (override = {}) => {
     setCurrentTasksPage: jest.fn(),
     labels: [], // all labels
     onPinTask: jest.fn(),
+    onUnpinTask: jest.fn(),
     isPinned: false,
     org: {id: 'BUCKSINSIX', name: 'Milwaukee Bucks'},
     me: {

--- a/src/tasks/components/TaskCard.tsx
+++ b/src/tasks/components/TaskCard.tsx
@@ -177,7 +177,7 @@ export class TaskCard extends PureComponent<
           appearance={Appearance.Outline}
           enableDefaultStyles={false}
           style={{minWidth: '112px'}}
-          contents={() => (
+          contents={onHide => (
             <List>
               <List.Item
                 onClick={this.handleExport}
@@ -215,7 +215,10 @@ export class TaskCard extends PureComponent<
               </List.Item>
               {isFlagEnabled('pinnedItems') && CLOUD && (
                 <List.Item
-                  onClick={this.handlePinTask}
+                  onClick={() => {
+                    this.handlePinTask()
+                    onHide()
+                  }}
                   disabled={isPinned}
                   size={ComponentSize.Small}
                   style={{fontWeight: 500}}

--- a/src/tasks/components/TaskCard.tsx
+++ b/src/tasks/components/TaskCard.tsx
@@ -131,7 +131,7 @@ export class TaskCard extends PureComponent<
     const {org, me, task, isPinned} = this.props
 
     if (isPinned) {
-      // delete from pinned item
+      // delete from pinned item list
       try {
         deletePinnedItemByParam(task.id)
         this.props.sendNotification(pinnedItemSuccess('task', 'deleted'))
@@ -139,7 +139,7 @@ export class TaskCard extends PureComponent<
         this.props.sendNotification(pinnedItemFailure(err.message, 'delete'))
       }
     } else {
-      // add to pinned item
+      // add to pinned item list
       try {
         addPinnedItem({
           orgID: org.id,

--- a/src/tasks/components/TaskCard.tsx
+++ b/src/tasks/components/TaskCard.tsx
@@ -125,7 +125,7 @@ export class TaskCard extends PureComponent<
     )
   }
 
-  private handlePinTask = async () => {
+  private handlePinTask = () => {
     const {task, isPinned} = this.props
 
     if (isPinned) {

--- a/src/tasks/components/TaskCard.tsx
+++ b/src/tasks/components/TaskCard.tsx
@@ -4,8 +4,6 @@ import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 import {
-  addPinnedItem,
-  PinnedItemTypes,
   deletePinnedItemByParam,
   updatePinnedItemByParam,
 } from 'src/shared/contexts/pinneditems'
@@ -37,12 +35,10 @@ import {setCurrentTasksPage} from 'src/tasks/actions/creators'
 
 // Types
 import {ComponentColor} from '@influxdata/clockface'
-import {Task, Label, AppState} from 'src/types'
+import {Task, Label} from 'src/types'
 
 // Constants
 import {DEFAULT_TASK_NAME} from 'src/dashboards/constants'
-import {getMe} from 'src/me/selectors'
-import {getOrg} from 'src/organizations/selectors'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {CLOUD} from 'src/shared/constants'
 
@@ -61,7 +57,7 @@ interface PassedProps {
   onRunTask: (taskID: string) => void
   onUpdate: (name: string, taskID: string) => void
   onFilterChange: (searchTerm: string) => void
-  onPinTask: () => void
+  onPinTask: (taskID: string, name: string) => void
   onUnpinTask: (taskID: string) => void
   isPinned: boolean
 }
@@ -130,27 +126,12 @@ export class TaskCard extends PureComponent<
   }
 
   private handlePinTask = async () => {
-    const {org, me, task, isPinned} = this.props
+    const {task, isPinned} = this.props
 
     if (isPinned) {
       this.props.onUnpinTask(task.id)
     } else {
-      // add to pinned item list
-      try {
-        await addPinnedItem({
-          orgID: org.id,
-          userID: me.id,
-          metadata: {
-            taskID: task.id,
-            name: task.name,
-          },
-          type: PinnedItemTypes.Task,
-        })
-        this.props.sendNotification(pinnedItemSuccess('task', 'added'))
-        this.props.onPinTask()
-      } catch (err) {
-        this.props.sendNotification(pinnedItemFailure(err.message, 'add'))
-      }
+      this.props.onPinTask(task.id, task.name)
     }
   }
 
@@ -372,15 +353,6 @@ const mdtp = {
   sendNotification: notify,
 }
 
-const mstp = (state: AppState) => {
-  const me = getMe(state)
-  const org = getOrg(state)
-
-  return {
-    org,
-    me,
-  }
-}
-const connector = connect(mstp, mdtp)
+const connector = connect(null, mdtp)
 
 export default connector(withRouter(TaskCard))

--- a/src/tasks/components/TaskCard.tsx
+++ b/src/tasks/components/TaskCard.tsx
@@ -128,19 +128,32 @@ export class TaskCard extends PureComponent<
   }
 
   private handlePinTask = () => {
-    try {
-      addPinnedItem({
-        orgID: this.props.org.id,
-        userID: this.props.me.id,
-        metadata: {
-          taskID: this.props.task.id,
-          name: this.props.task.name,
-        },
-        type: PinnedItemTypes.Task,
-      })
-      this.props.sendNotification(pinnedItemSuccess('task', 'added'))
-    } catch (err) {
-      this.props.sendNotification(pinnedItemFailure(err.message, 'task'))
+    const {org, me, task, isPinned} = this.props
+
+    if (isPinned) {
+      // delete from pinned item
+      try {
+        deletePinnedItemByParam(task.id)
+        this.props.sendNotification(pinnedItemSuccess('task', 'deleted'))
+      } catch (err) {
+        this.props.sendNotification(pinnedItemFailure(err.message, 'delete'))
+      }
+    } else {
+      // add to pinned item
+      try {
+        addPinnedItem({
+          orgID: org.id,
+          userID: me.id,
+          metadata: {
+            taskID: task.id,
+            name: task.name,
+          },
+          type: PinnedItemTypes.Task,
+        })
+        this.props.sendNotification(pinnedItemSuccess('task', 'added'))
+      } catch (err) {
+        this.props.sendNotification(pinnedItemFailure(err.message, 'add'))
+      }
     }
   }
 
@@ -219,12 +232,11 @@ export class TaskCard extends PureComponent<
                     this.handlePinTask()
                     onHide()
                   }}
-                  disabled={isPinned}
                   size={ComponentSize.Small}
                   style={{fontWeight: 500}}
                   testID="context-pin-task"
                 >
-                  Pin
+                  {isPinned ? 'Unpin' : 'Pin'}
                 </List.Item>
               )}
             </List>
@@ -291,7 +303,7 @@ export class TaskCard extends PureComponent<
         updatePinnedItemByParam(id, {name})
         this.props.sendNotification(pinnedItemSuccess('task', 'updated'))
       } catch (err) {
-        this.props.sendNotification(pinnedItemFailure(err.message, 'task'))
+        this.props.sendNotification(pinnedItemFailure(err.message, 'update'))
       }
     }
   }

--- a/src/tasks/components/TaskCard.tsx
+++ b/src/tasks/components/TaskCard.tsx
@@ -62,6 +62,7 @@ interface PassedProps {
   onUpdate: (name: string, taskID: string) => void
   onFilterChange: (searchTerm: string) => void
   onPinTask: () => void
+  onUnpinTask: (taskID: string) => void
   isPinned: boolean
 }
 
@@ -132,14 +133,7 @@ export class TaskCard extends PureComponent<
     const {org, me, task, isPinned} = this.props
 
     if (isPinned) {
-      // delete from pinned item list
-      try {
-        await deletePinnedItemByParam(task.id)
-        this.props.sendNotification(pinnedItemSuccess('task', 'deleted'))
-        this.props.onPinTask()
-      } catch (err) {
-        this.props.sendNotification(pinnedItemFailure(err.message, 'delete'))
-      }
+      this.props.onUnpinTask(task.id)
     } else {
       // add to pinned item list
       try {

--- a/src/tasks/components/TaskCard.tsx
+++ b/src/tasks/components/TaskCard.tsx
@@ -135,6 +135,7 @@ export class TaskCard extends PureComponent<
       try {
         deletePinnedItemByParam(task.id)
         this.props.sendNotification(pinnedItemSuccess('task', 'deleted'))
+        window.location.reload()
       } catch (err) {
         this.props.sendNotification(pinnedItemFailure(err.message, 'delete'))
       }
@@ -151,6 +152,7 @@ export class TaskCard extends PureComponent<
           type: PinnedItemTypes.Task,
         })
         this.props.sendNotification(pinnedItemSuccess('task', 'added'))
+        window.location.reload()
       } catch (err) {
         this.props.sendNotification(pinnedItemFailure(err.message, 'add'))
       }

--- a/src/tasks/components/TaskCard.tsx
+++ b/src/tasks/components/TaskCard.tsx
@@ -61,6 +61,7 @@ interface PassedProps {
   onRunTask: (taskID: string) => void
   onUpdate: (name: string, taskID: string) => void
   onFilterChange: (searchTerm: string) => void
+  onPinTask: () => void
   isPinned: boolean
 }
 
@@ -127,22 +128,22 @@ export class TaskCard extends PureComponent<
     )
   }
 
-  private handlePinTask = () => {
+  private handlePinTask = async () => {
     const {org, me, task, isPinned} = this.props
 
     if (isPinned) {
       // delete from pinned item list
       try {
-        deletePinnedItemByParam(task.id)
+        await deletePinnedItemByParam(task.id)
         this.props.sendNotification(pinnedItemSuccess('task', 'deleted'))
-        window.location.reload()
+        this.props.onPinTask()
       } catch (err) {
         this.props.sendNotification(pinnedItemFailure(err.message, 'delete'))
       }
     } else {
       // add to pinned item list
       try {
-        addPinnedItem({
+        await addPinnedItem({
           orgID: org.id,
           userID: me.id,
           metadata: {
@@ -152,7 +153,7 @@ export class TaskCard extends PureComponent<
           type: PinnedItemTypes.Task,
         })
         this.props.sendNotification(pinnedItemSuccess('task', 'added'))
-        window.location.reload()
+        this.props.onPinTask()
       } catch (err) {
         this.props.sendNotification(pinnedItemFailure(err.message, 'add'))
       }

--- a/src/tasks/components/TasksList.tsx
+++ b/src/tasks/components/TasksList.tsx
@@ -24,9 +24,9 @@ import {getOrg} from 'src/organizations/selectors'
 
 // Contexts
 import {
-  // addPinnedItem,
+  addPinnedItem,
   deletePinnedItemByParam,
-  // PinnedItemTypes,
+  PinnedItemTypes,
 } from 'src/shared/contexts/pinneditems'
 
 // Utils
@@ -180,8 +180,25 @@ class TasksList extends PureComponent<Props, State> implements Pageable {
       .catch(err => console.error(err))
   }
 
-  public handlePinTask = () => {
-    this.updatePinnedItems()
+  public handlePinTask = async (taskID: string, name: string) => {
+    const {org, me} = this.props
+
+    // add to pinned item list
+    try {
+      await addPinnedItem({
+        orgID: org.id,
+        userID: me.id,
+        metadata: {
+          taskID,
+          name,
+        },
+        type: PinnedItemTypes.Task,
+      })
+      this.props.sendNotification(pinnedItemSuccess('task', 'added'))
+      this.updatePinnedItems()
+    } catch (err) {
+      this.props.sendNotification(pinnedItemFailure(err.message, 'add'))
+    }
   }
 
   public handleUnpinTask = async (taskID: string) => {

--- a/src/tasks/components/TasksList.tsx
+++ b/src/tasks/components/TasksList.tsx
@@ -1,5 +1,6 @@
 // Libraries
 import React, {PureComponent, RefObject, createRef} from 'react'
+import {connect, ConnectedProps} from 'react-redux'
 import memoizeOne from 'memoize-one'
 
 // Styles
@@ -11,27 +12,42 @@ import TaskCard from 'src/tasks/components/TaskCard'
 
 // Types
 import EmptyTasksList from 'src/tasks/components/EmptyTasksList'
-import {Pageable, Task} from 'src/types'
+import {AppState, Pageable, Task} from 'src/types'
 import {SortTypes} from 'src/shared/utils/sort'
 import {Sort} from '@influxdata/clockface'
 import {TaskSortKey} from 'src/shared/components/resource_sort_dropdown/generateSortItems'
 
 // Selectors
 import {getSortedResources} from 'src/shared/utils/sort'
+import {getMe} from 'src/me/selectors'
+import {getOrg} from 'src/organizations/selectors'
+
+// Contexts
+import {
+  // addPinnedItem,
+  deletePinnedItemByParam,
+  // PinnedItemTypes,
+} from 'src/shared/contexts/pinneditems'
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {CLOUD} from 'src/shared/constants'
+import {notify} from 'src/shared/actions/notifications'
 
 import {PaginationNav} from '@influxdata/clockface'
+
+import {
+  pinnedItemFailure,
+  pinnedItemSuccess,
+} from 'src/shared/copy/notifications'
 
 let getPinnedItems
 if (CLOUD) {
   getPinnedItems = require('src/shared/contexts/pinneditems').getPinnedItems
 }
 
-interface Props {
+interface OwnProps {
   pageHeight: number
   pageWidth: number
   tasks: Task[]
@@ -58,10 +74,12 @@ interface State {
   pinnedItems: any[]
 }
 
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = OwnProps & ReduxProps
+
 const DEFAULT_PAGINATION_CONTROL_HEIGHT = 62
 
-export default class TasksList extends PureComponent<Props, State>
-  implements Pageable {
+class TasksList extends PureComponent<Props, State> implements Pageable {
   private memGetSortedResources = memoizeOne<typeof getSortedResources>(
     getSortedResources
   )
@@ -166,6 +184,17 @@ export default class TasksList extends PureComponent<Props, State>
     this.updatePinnedItems()
   }
 
+  public handleUnpinTask = async (taskID: string) => {
+    // delete from pinned item list
+    try {
+      await deletePinnedItemByParam(taskID)
+      this.props.sendNotification(pinnedItemSuccess('task', 'deleted'))
+      this.updatePinnedItems()
+    } catch (err) {
+      this.props.sendNotification(pinnedItemFailure(err.message, 'delete'))
+    }
+  }
+
   public paginate = page => {
     this.currentPage = page
     const url = new URL(location.href)
@@ -210,6 +239,7 @@ export default class TasksList extends PureComponent<Props, State>
             onRunTask={this.props.onRunTask}
             onFilterChange={this.props.onFilterChange}
             onPinTask={this.handlePinTask}
+            onUnpinTask={this.handleUnpinTask}
             isPinned={
               this.state.pinnedItems?.length &&
               !!this.state.pinnedItems.find(
@@ -223,3 +253,21 @@ export default class TasksList extends PureComponent<Props, State>
     return rows
   }
 }
+
+const mdtp = {
+  sendNotification: notify,
+}
+
+const mstp = (state: AppState) => {
+  const me = getMe(state)
+  const org = getOrg(state)
+
+  return {
+    me,
+    org,
+  }
+}
+
+const connector = connect(mstp, mdtp)
+
+export default connector(TasksList)

--- a/src/tasks/components/TasksList.tsx
+++ b/src/tasks/components/TasksList.tsx
@@ -158,6 +158,15 @@ export default class TasksList extends PureComponent<Props, State>
     )
   }
 
+  public handlePinTask = () => {
+    // update pinned item list
+    getPinnedItems()
+      .then(res => {
+        this.setState({pinnedItems: res})
+      })
+      .catch(err => console.error(err))
+  }
+
   public paginate = page => {
     this.currentPage = page
     const url = new URL(location.href)
@@ -201,6 +210,7 @@ export default class TasksList extends PureComponent<Props, State>
             onUpdate={this.props.onUpdate}
             onRunTask={this.props.onRunTask}
             onFilterChange={this.props.onFilterChange}
+            onPinTask={this.handlePinTask}
             isPinned={
               this.state.pinnedItems?.length &&
               !!this.state.pinnedItems.find(

--- a/src/tasks/components/TasksList.tsx
+++ b/src/tasks/components/TasksList.tsx
@@ -97,13 +97,7 @@ export default class TasksList extends PureComponent<Props, State>
 
     this.props.checkTaskLimits()
     if (CLOUD && isFlagEnabled('pinnedItems')) {
-      getPinnedItems()
-        .then(res => {
-          if (this.isComponentMounted) {
-            this.setState(prev => ({...prev, pinnedItems: res}))
-          }
-        })
-        .catch(err => console.error(err))
+      this.updatePinnedItems()
     }
   }
 
@@ -158,13 +152,18 @@ export default class TasksList extends PureComponent<Props, State>
     )
   }
 
-  public handlePinTask = () => {
-    // update pinned item list
+  public updatePinnedItems = () => {
     getPinnedItems()
       .then(res => {
-        this.setState({pinnedItems: res})
+        if (this.isComponentMounted) {
+          this.setState(prev => ({...prev, pinnedItems: res}))
+        }
       })
       .catch(err => console.error(err))
+  }
+
+  public handlePinTask = () => {
+    this.updatePinnedItems()
   }
 
   public paginate = page => {


### PR DESCRIPTION
Closes #3862 

For pinned items, the current way to remove a pinned item is to unpin it from the home page. This PR enables another way of unpinning an item from the resource list location. This applies to Notebooks, Dashboards, and Tasks.

Here is a demo for Notebook:

https://user-images.githubusercontent.com/14298407/156846371-883fa1db-b50a-4a6b-8d87-b5f390c96d32.mov


