### PR TITLE
chore: update button name to "Customize"

### DIFF
--- a/src/flows/pipes/Visualization/Controls.tsx
+++ b/src/flows/pipes/Visualization/Controls.tsx
@@ -94,7 +94,7 @@ const Controls: FC = () => {
 
   const toggler = (
     <Button
-      text="Configure"
+      text="Customize"
       icon={IconFont.CogSolid_New}
       onClick={launcher}
       status={dataExists ? ComponentStatus.Default : ComponentStatus.Disabled}


### PR DESCRIPTION
Closes #3437 

This PR updates the button name in the Notebook graph panel to "Customize."

## Before
<img width="1397" alt="Screen Shot 2022-03-08 at 8 47 30 AM" src="https://user-images.githubusercontent.com/14298407/157262510-eb7235fc-4707-4e20-af9d-d18bbb6378a4.png">

## After
<img width="1393" alt="Screen Shot 2022-03-08 at 8 46 46 AM" src="https://user-images.githubusercontent.com/14298407/157262532-4cb3c6d1-4bd0-42c5-858b-292383ac43ee.png">

