### PR TITLE
style: update exit button and remove gaps in Notebook side panel

### DIFF
--- a/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
+++ b/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
@@ -62,7 +62,7 @@ const verifyClientCode = (client: any) => {
     .find('code')
     .contains(client.query)
 
-  cy.get('.cf-overlay--dismiss').click()
+  cy.get('.cf-overlay--header .cf-overlay--dismiss').click()
 }
 
 const getClients = (org: string, query: string) => {

--- a/src/flows/components/ClientList.tsx
+++ b/src/flows/components/ClientList.tsx
@@ -1,7 +1,12 @@
 import React, {FC, useContext} from 'react'
 import {SidebarContext} from 'src/flows/context/sidebar'
 import {CLIENT_DEFINITIONS} from 'src/writeData'
-import {FlexBox, SelectableCard, ComponentSize} from '@influxdata/clockface'
+import {
+  FlexBox,
+  SelectableCard,
+  ComponentSize,
+  JustifyContent,
+} from '@influxdata/clockface'
 import placeholderLogo from 'src/writeData/graphics/placeholderLogo.svg'
 import PanelQueryOverlay from 'src/flows/components/panel/PanelQueryOverlay'
 import {PopupContext} from 'src/flows/context/popup'
@@ -16,7 +21,7 @@ const ClientList: FC = () => {
   return (
     <FlexBox
       style={{flexWrap: 'wrap', gap: '8px'}}
-      className="flow-sidebar--client-list"
+      justifyContent={JustifyContent.Center}
     >
       {Object.values(CLIENT_DEFINITIONS).map(item => {
         const click = (client: string) => {
@@ -31,7 +36,7 @@ const ClientList: FC = () => {
         const thumb = <img src={item.logo ? item.logo : placeholderLogo} />
 
         return (
-          <FlexBox.Child key={item.id}>
+          <FlexBox.Child key={item.id} grow={0}>
             <SelectableCard
               id={item.id}
               formName="load-data-cards"

--- a/src/flows/components/Sidebar.scss
+++ b/src/flows/components/Sidebar.scss
@@ -62,7 +62,6 @@
   text-align: right;
 }
 
-.flow-sidebar--client-list,
 .flow-sidebar--secrets-list {
   margin-right: -16px;
 }

--- a/src/flows/components/Sidebar.scss
+++ b/src/flows/components/Sidebar.scss
@@ -66,3 +66,10 @@
 .flow-sidebar--secrets-list {
   margin-right: -16px;
 }
+
+.cf-overlay--dismiss {
+  &:before,
+  &:after {
+    background-color: $cf-grey-65;
+  }
+}

--- a/src/flows/components/Sidebar.tsx
+++ b/src/flows/components/Sidebar.tsx
@@ -41,15 +41,14 @@ export const SubSideBar: FC = () => {
   return (
     <div className="flow-sidebar">
       <div className="flow-sidebar--buttons">
-        <Button
-          icon={IconFont.Remove_New}
+        <button
+          className="cf-overlay--dismiss"
+          type="button"
           onClick={() => {
             event('Closing Submenu')
             hideSub()
           }}
-        >
-          Back
-        </Button>
+        ></button>
       </div>
       <div className="flow-sidebar--submenu">
         <DapperScrollbars


### PR DESCRIPTION
Closes #3438 

This PR updates the exit button for Notebook side panel, and removes the awkward gaps between client libraries.

## Before
<img width="1011" alt="Screen Shot 2022-03-08 at 1 43 17 PM" src="https://user-images.githubusercontent.com/14298407/157313225-ec7c462e-c4bf-4ee6-8ec4-86cbad79f5dc.png">


## After
<img width="965" alt="Screen Shot 2022-03-08 at 1 44 54 PM" src="https://user-images.githubusercontent.com/14298407/157313237-90398b4e-be6c-47ca-bf8e-ace33f7d4215.png">


<!-- Describe your proposed changes here. -->
