### PR TITLE
fix: only show notification for pinned items

### DIFF
--- a/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -126,7 +126,7 @@ class DashboardCard extends PureComponent<Props> {
 
     onUpdateDashboard(id, {name})
 
-    if (isFlagEnabled('pinnedItems') && CLOUD) {
+    if (isFlagEnabled('pinnedItems') && CLOUD && this.props.isPinned) {
       try {
         updatePinnedItemByParam(id, {name})
         this.props.sendNotification(pinnedItemSuccess('dashboard', 'updated'))
@@ -251,10 +251,12 @@ class DashboardCard extends PureComponent<Props> {
     const {id, onUpdateDashboard} = this.props
 
     onUpdateDashboard(id, {description})
-    try {
-      updatePinnedItemByParam(id, {description})
-    } catch (err) {
-      this.props.sendNotification(pinnedItemFailure(err.message, 'update'))
+    if (isFlagEnabled('pinnedItems') && CLOUD && this.props.isPinned) {
+      try {
+        updatePinnedItemByParam(id, {description})
+      } catch (err) {
+        this.props.sendNotification(pinnedItemFailure(err.message, 'update'))
+      }
     }
   }
 

--- a/src/flows/components/FlowCard.tsx
+++ b/src/flows/components/FlowCard.tsx
@@ -46,7 +46,7 @@ const FlowCard: FC<Props> = ({id, isPinned}) => {
 
   const handleRenameNotebook = (name: string) => {
     update(id, {...flow, name})
-    if (isFlagEnabled('pinnedItems') && CLOUD) {
+    if (isFlagEnabled('pinnedItems') && CLOUD && isPinned) {
       try {
         updatePinnedItemByParam(id, {name})
         dispatch(notify(pinnedItemSuccess('notebook', 'updated')))

--- a/src/tasks/components/TaskCard.tsx
+++ b/src/tasks/components/TaskCard.tsx
@@ -276,7 +276,7 @@ export class TaskCard extends PureComponent<
       task: {id},
     } = this.props
     onUpdate(name, id)
-    if (isFlagEnabled('pinnedItems') && CLOUD) {
+    if (isFlagEnabled('pinnedItems') && CLOUD && this.props.isPinned) {
       try {
         updatePinnedItemByParam(id, {name})
         this.props.sendNotification(pinnedItemSuccess('task', 'updated'))


### PR DESCRIPTION
Closes #4009 

This PR fixes the bug that showing notification for non-pinned items.

## Before

https://user-images.githubusercontent.com/14298407/157329339-9fc23692-4e2d-41e4-bb80-7879af8356f2.mov

## After

https://user-images.githubusercontent.com/14298407/157330485-4f354883-6016-466f-b7e3-c35c35188b66.mov





