### PR TITLE
fix(3945): mailgun exported alert task

### DIFF
--- a/src/flows/pipes/Notification/endpoints/Mailgun/index.ts
+++ b/src/flows/pipes/Notification/endpoints/Mailgun/index.ts
@@ -26,7 +26,10 @@ export default register => {
       const subject = encodeURIComponent('InfluxDB Alert')
       const fromEmail = `mailgun@${data.domain}`
 
-      return `task_data
+      return `apiKey = secrets.get(key: "${data.apiKey}")
+auth = http.basicAuth(u: "api", p: "\${apiKey}")
+
+task_data
 	|> schema["fieldsAsCols"]()
       |> set(key: "_notebook_link", value: "${window.location.href}")
 	|> monitor["check"](
@@ -36,27 +39,22 @@ export default register => {
 	)
 	|> monitor["notify"](
     data: notification,
-    endpoint: ((r) => {
-      apiKey = secrets.get(key: "${data.apiKey}")
-      auth = http.basicAuth(u: "api", p: "\${apiKey}")
-      url = "https://api.mailgun.net/v3/${data.domain}/messages"
-      data = strings.joinStr(arr: [
-          "from=${fromEmail}",
-          "to=${data.email}",
-          "subject=${subject}",
-          "text=\${r._message}"
-        ], v: "&"
-      )
-      http.post(
-        url: url,
-        headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
-          "Authorization": "\${auth}"
-        },
-        data: bytes(v: data)
-      )
-      array.from(rows: [{value: 0}])
-          |> yield(name: "ignore")
+    endpoint: http.endpoint(url: "https://api.mailgun.net/v3/${data.domain}/messages")(
+      mapFn: (r) => {
+        data = strings.joinStr(arr: [
+            "from=${fromEmail}",
+            "to=${data.email}",
+            "subject=${subject}",
+            "text=\${r._message}"
+          ], v: "&"
+        )
+        return {
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Authorization": "\${auth}"
+          },
+          data: bytes(v: data)
+        }
       })
     )`
     },


### PR DESCRIPTION
Closes #3945 

### Description of bug:
* Notebook alert, for mailgun, gets exported to a task.
   * This export succeeds --> because no validation before export (a.k.a. task creation).
* But when you try running the task --> it gives an error.

### Done:
fixed the flux script.

### Visual proof:
task succeeds (runs successfully)
<img width="1266" alt="Screen Shot 2022-03-09 at 12 10 07 PM" src="https://user-images.githubusercontent.com/10232835/157526594-bf03a22e-fd87-48c9-96a0-8bd7299a1314.png">
see the flux exported
<img width="858" alt="Screen Shot 2022-03-09 at 12 09 58 PM" src="https://user-images.githubusercontent.com/10232835/157526637-84dba756-2e2f-4ebb-bc30-3ab9393074b8.png">

**do not have a mailgun account** so cannot confirm that roundtrip. Can only confirm that the flux query runs.
