### PR TITLE
fix: provide usersProvider context to the AccountPage.tsx for self removal to work

### DIFF
--- a/src/accounts/AccountPage.tsx
+++ b/src/accounts/AccountPage.tsx
@@ -18,7 +18,7 @@ import {
 } from '@influxdata/clockface'
 
 import {getMe} from 'src/me/selectors'
-import {UsersContext} from 'src/users/context/users'
+import {UsersContext, UsersProvider} from 'src/users/context/users'
 
 // Utils
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
@@ -210,9 +210,11 @@ const AccountPage: FC = () => {
   return (
     <Page titleTag={pageTitleSuffixer(['Account Settings Page'])}>
       <AccountHeader testID="account-page--header" />
-      <UserAccountProvider>
-        <AccountAboutPage />
-      </UserAccountProvider>
+      <UsersProvider>
+        <UserAccountProvider>
+          <AccountAboutPage />
+        </UserAccountProvider>
+      </UsersProvider>
     </Page>
   )
 }


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/4061

The context was missing from the page, so the `users` were coming back as an empty array. This caused the self-removal button to not be visible.

https://user-images.githubusercontent.com/18511823/157530403-3ecb3182-6656-4fae-b395-f0ca51893dea.mov


