### PR TITLE
fix(4229/4021/3707/4080): notebook alert threshold validations

### DIFF
--- a/src/flows/pipes/Notification/ExportTask.tsx
+++ b/src/flows/pipes/Notification/ExportTask.tsx
@@ -72,6 +72,11 @@ const ExportTask: FC = () => {
       return acc
     }, {})
 
+    if (!data.measurement) {
+      throw new Error('please select a measurement.')
+    }
+    const measurement = `(r) => r["_measurement"] == "${data.measurement}"`
+
     const conditions = THRESHOLD_TYPES[deadmanType].condition(deadman)
     const imports = parse(`
 import "strings"
@@ -114,7 +119,10 @@ task_data = ${format_from_js_file(ast)}
 trigger = ${conditions}
 messageFn = (r) => ("${data.message}")
 
-${ENDPOINT_DEFINITIONS[data.endpoint]?.generateQuery(data.endpointData)}
+${ENDPOINT_DEFINITIONS[data.endpoint]?.generateQuery(
+  data.endpointData,
+  measurement
+)}
 |> monitor["deadman"](t: experimental["subDuration"](from: now(), d: ${
       deadman.deadmanCheckValue
     }))`
@@ -155,6 +163,7 @@ ${ENDPOINT_DEFINITIONS[data.endpoint]?.generateQuery(data.endpointData)}
     data.offset,
     data.endpointData,
     data.endpoint,
+    data.measurement,
     data.thresholds,
     data.message,
   ])
@@ -195,12 +204,15 @@ ${ENDPOINT_DEFINITIONS[data.endpoint]?.generateQuery(data.endpointData)}
       return acc
     }, {})
 
+    if (!data.measurement) {
+      throw new Error('please select a measurement.')
+    }
+    const measurement = `(r) => r["_measurement"] == "${data.measurement}"`
+
     const conditions = data.thresholds
       .map(threshold => THRESHOLD_TYPES[threshold.type].condition(threshold))
       .map((cond, i) => (i > 0 ? cond.split(lambdaPrefix)[1] : cond))
       .join(' and ')
-
-    const measurement = `(r) => r["_measurement"] == "${data.measurement}"`
 
     const imports = parse(`
 import "strings"
@@ -283,6 +295,7 @@ ${ENDPOINT_DEFINITIONS[data.endpoint]?.generateQuery(
     data.offset,
     data.endpointData,
     data.endpoint,
+    data.measurement,
     data.thresholds,
     data.message,
   ])

--- a/src/flows/pipes/Notification/ExportTask.tsx
+++ b/src/flows/pipes/Notification/ExportTask.tsx
@@ -16,7 +16,7 @@ import {
   deadmanType,
   lambdaPrefix,
   THRESHOLD_TYPES,
-} from 'src/flows/pipes/Visualization/threshold'
+} from 'src/flows/shared/threshold'
 import {ImportDeclaration} from 'src/types/ast'
 
 // Utils

--- a/src/flows/pipes/Notification/ExportTask.tsx
+++ b/src/flows/pipes/Notification/ExportTask.tsx
@@ -200,6 +200,8 @@ ${ENDPOINT_DEFINITIONS[data.endpoint]?.generateQuery(data.endpointData)}
       .map((cond, i) => (i > 0 ? cond.split(lambdaPrefix)[1] : cond))
       .join(' and ')
 
+    const measurement = `(r) => r["_measurement"] == "${data.measurement}"`
+
     const imports = parse(`
 import "strings"
 import "regexp"
@@ -240,7 +242,10 @@ task_data = ${format_from_js_file(ast)}
 trigger = ${conditions}
 messageFn = (r) => ("${data.message}")
 
-${ENDPOINT_DEFINITIONS[data.endpoint]?.generateQuery(data.endpointData)}`
+${ENDPOINT_DEFINITIONS[data.endpoint]?.generateQuery(
+  data.endpointData,
+  measurement
+)}`
 
     const newAST = parse(newQuery)
 

--- a/src/flows/pipes/Notification/ExportTask.tsx
+++ b/src/flows/pipes/Notification/ExportTask.tsx
@@ -14,6 +14,7 @@ import {remove} from 'src/shared/contexts/query'
 // Types
 import {
   deadmanType,
+  lambdaPrefix,
   THRESHOLD_TYPES,
 } from 'src/flows/pipes/Visualization/threshold'
 import {ImportDeclaration} from 'src/types/ast'
@@ -196,6 +197,7 @@ ${ENDPOINT_DEFINITIONS[data.endpoint]?.generateQuery(data.endpointData)}
 
     const conditions = data.thresholds
       .map(threshold => THRESHOLD_TYPES[threshold.type].condition(threshold))
+      .map((cond, i) => (i > 0 ? cond.split(lambdaPrefix)[1] : cond))
       .join(' and ')
 
     const imports = parse(`

--- a/src/flows/pipes/Notification/Measurement.tsx
+++ b/src/flows/pipes/Notification/Measurement.tsx
@@ -1,0 +1,87 @@
+import React, {useState, FC, useCallback, useContext} from 'react'
+import {
+  ComponentSize,
+  FlexBox,
+  AlignItems,
+  TextBlock,
+  Dropdown,
+  FlexDirection,
+  ComponentStatus,
+} from '@influxdata/clockface'
+
+import {PipeContext} from 'src/flows/context/pipe'
+import 'src/flows/pipes/Notification/Threshold.scss'
+
+// Utils
+import {event} from 'src/cloud/utils/reporting'
+
+interface Props {
+  readOnly?: boolean
+}
+
+const Measurement: FC<Props> = ({readOnly}) => {
+  const {data, update, results} = useContext(PipeContext)
+  const [measurement, setMeasurement] = useState(data.measurement || null)
+
+  const measurements = Array.from(
+    new Set(results.parsed.table.columns['_measurement']?.data as string[])
+  )
+
+  const onSelect = useCallback(
+    (measurement: string) => {
+      event('Changed Notification Measurement')
+      setMeasurement(measurement)
+      update({measurement})
+    },
+    [measurements, update]
+  )
+
+  const menuItems = measurements.map(key => (
+    <Dropdown.Item
+      key={key}
+      value={key}
+      onClick={() => onSelect(key)}
+      selected={key === measurement}
+      title={key}
+      disabled={!!readOnly}
+    >
+      {key}
+    </Dropdown.Item>
+  ))
+
+  const menu = onCollapse => (
+    <Dropdown.Menu onCollapse={onCollapse}>{menuItems}</Dropdown.Menu>
+  )
+
+  const menuButton = (active, onClick) => (
+    <Dropdown.Button
+      onClick={onClick}
+      active={active}
+      size={ComponentSize.Medium}
+      status={!!readOnly ? ComponentStatus.Disabled : ComponentStatus.Default}
+    >
+      {measurement || 'Select a measurement'}
+    </Dropdown.Button>
+  )
+
+  return (
+    <FlexBox
+      direction={FlexDirection.Row}
+      margin={ComponentSize.Medium}
+      alignItems={AlignItems.FlexStart}
+      testID="component-spacer"
+      style={{padding: '24px 0'}}
+    >
+      <TextBlock
+        testID="measurement-value-text-block"
+        text="For"
+        style={{minWidth: 56, textAlign: 'center'}}
+      />
+      <FlexBox.Child grow={0}>
+        <Dropdown menu={menu} button={menuButton} />
+      </FlexBox.Child>
+    </FlexBox>
+  )
+}
+
+export default Measurement

--- a/src/flows/pipes/Notification/Threshold.tsx
+++ b/src/flows/pipes/Notification/Threshold.tsx
@@ -24,7 +24,7 @@ import {
   Threshold,
   ThresholdFormat,
   THRESHOLD_TYPES,
-} from 'src/flows/pipes/Visualization/threshold'
+} from 'src/flows/shared/threshold'
 
 interface Props {
   readOnly?: boolean
@@ -67,7 +67,8 @@ const Threshold: FC<Props> = ({readOnly}) => {
             type: deadmanType,
             deadmanCheckValue: '5s',
             deadmanStopValue: '90s',
-            field: threshold.field || 'Select a numeric field',
+            field: threshold.field || 'Select a field',
+            fieldType: '',
           },
         ]
       } else {
@@ -160,7 +161,7 @@ const Threshold: FC<Props> = ({readOnly}) => {
             !!readOnly ? ComponentStatus.Disabled : ComponentStatus.Default
           }
         >
-          {threshold?.field || 'Select a numeric field'}
+          {threshold?.field || 'Select a field'}
         </Dropdown.Button>
       )
       return <Dropdown menu={menu} button={menuButton} />

--- a/src/flows/pipes/Notification/Threshold.tsx
+++ b/src/flows/pipes/Notification/Threshold.tsx
@@ -54,7 +54,7 @@ const Threshold: FC<Props> = ({readOnly}) => {
       }
 
       threshold.type = type
-      threshold.field = threshold.field || '_value'
+      threshold.field = threshold?.field
 
       let updatedThreshold = thresholds
 
@@ -67,7 +67,7 @@ const Threshold: FC<Props> = ({readOnly}) => {
             type: deadmanType,
             deadmanCheckValue: '5s',
             deadmanStopValue: '90s',
-            field: threshold.field || '_value',
+            field: threshold.field || 'Select a numeric field',
           },
         ]
       } else {

--- a/src/flows/pipes/Notification/endpoints/AWS/index.ts
+++ b/src/flows/pipes/Notification/endpoints/AWS/index.ts
@@ -37,6 +37,8 @@ export default register => {
 		crit: trigger,
 	)
   |> filter(fn: trigger)
+  |> keep(columns: ["_value", "_time", "_measurement"])
+  |> limit(n: 1, offset: 0)
 	|> monitor["notify"](
     data: notification,
     endpoint: ((r) => {

--- a/src/flows/pipes/Notification/endpoints/AWS/index.ts
+++ b/src/flows/pipes/Notification/endpoints/AWS/index.ts
@@ -27,14 +27,16 @@ export default register => {
       ['array', 'http', 'influxdata/influxdb/secrets']
         .map(i => `import "${i}"`)
         .join('\n'),
-    generateQuery: data => `task_data
+    generateQuery: (data, measurement) => `task_data
 	|> schema["fieldsAsCols"]()
       |> set(key: "_notebook_link", value: "${window.location.href}")
+  |> filter(fn: ${measurement})
 	|> monitor["check"](
 		data: check,
 		messageFn: messageFn,
 		crit: trigger,
 	)
+  |> filter(fn: trigger)
 	|> monitor["notify"](
     data: notification,
     endpoint: ((r) => {

--- a/src/flows/pipes/Notification/endpoints/HTTP/index.ts
+++ b/src/flows/pipes/Notification/endpoints/HTTP/index.ts
@@ -62,6 +62,8 @@ export default register => {
             crit: trigger,
           )
           |> filter(fn: trigger)
+          |> keep(columns: ["_value", "_time", "_measurement"])
+          |> limit(n: 1, offset: 0)
           |> monitor["notify"](data: notification, endpoint: http.endpoint(url: "${data.url}")(
             mapFn: (r) => {
                 body = {r with _version: 1}

--- a/src/flows/pipes/Notification/endpoints/HTTP/index.ts
+++ b/src/flows/pipes/Notification/endpoints/HTTP/index.ts
@@ -23,7 +23,7 @@ export default register => {
       ['array', 'http', 'influxdata/influxdb/secrets', 'json']
         .map(i => `import "${i}"`)
         .join('\n'),
-    generateQuery: data => {
+    generateQuery: (data, measurement) => {
       const headers = [['"Content-Type"', '"application/json"']]
       let prefixSecrets = ''
 
@@ -55,11 +55,13 @@ export default register => {
         task_data
           |> schema["fieldsAsCols"]()
               |> set(key: "_notebook_link", value: "${window.location.href}")
+          |> filter(fn: ${measurement})
           |> monitor["check"](
             data: check,
             messageFn: messageFn,
             crit: trigger,
           )
+          |> filter(fn: trigger)
           |> monitor["notify"](data: notification, endpoint: http.endpoint(url: "${data.url}")(
             mapFn: (r) => {
                 body = {r with _version: 1}

--- a/src/flows/pipes/Notification/endpoints/Mailgun/index.ts
+++ b/src/flows/pipes/Notification/endpoints/Mailgun/index.ts
@@ -39,6 +39,8 @@ task_data
 		crit: trigger,
 	)
   |> filter(fn: trigger)
+  |> keep(columns: ["_value", "_time", "_measurement"])
+  |> limit(n: 1, offset: 0)
 	|> monitor["notify"](
     data: notification,
     endpoint: http.endpoint(url: "https://api.mailgun.net/v3/${data.domain}/messages")(

--- a/src/flows/pipes/Notification/endpoints/Mailgun/index.ts
+++ b/src/flows/pipes/Notification/endpoints/Mailgun/index.ts
@@ -22,7 +22,7 @@ export default register => {
       ['array', 'http', 'influxdata/influxdb/secrets']
         .map(i => `import "${i}"`)
         .join('\n'),
-    generateQuery: data => {
+    generateQuery: (data, measurement) => {
       const subject = encodeURIComponent('InfluxDB Alert')
       const fromEmail = `mailgun@${data.domain}`
 
@@ -32,11 +32,13 @@ auth = http.basicAuth(u: "api", p: "\${apiKey}")
 task_data
 	|> schema["fieldsAsCols"]()
       |> set(key: "_notebook_link", value: "${window.location.href}")
+  |> filter(fn: ${measurement})
 	|> monitor["check"](
 		data: check,
 		messageFn: messageFn,
 		crit: trigger,
 	)
+  |> filter(fn: trigger)
 	|> monitor["notify"](
     data: notification,
     endpoint: http.endpoint(url: "https://api.mailgun.net/v3/${data.domain}/messages")(

--- a/src/flows/pipes/Notification/endpoints/Mailjet/index.ts
+++ b/src/flows/pipes/Notification/endpoints/Mailjet/index.ts
@@ -34,6 +34,8 @@ export default register => {
 		crit: trigger,
 	)
   |> filter(fn: trigger)
+  |> keep(columns: ["_value", "_time", "_measurement"])
+  |> limit(n: 1, offset: 0)
 	|> monitor["notify"](
     data: notification,
     endpoint: http.endpoint(url: "${data.url}")(

--- a/src/flows/pipes/Notification/endpoints/Mailjet/index.ts
+++ b/src/flows/pipes/Notification/endpoints/Mailjet/index.ts
@@ -24,14 +24,16 @@ export default register => {
       ['array', 'http', 'influxdata/influxdb/secrets', 'json']
         .map(i => `import "${i}"`)
         .join('\n'),
-    generateQuery: data => `task_data
+    generateQuery: (data, measurement) => `task_data
 	|> schema["fieldsAsCols"]()
       |> set(key: "_notebook_link", value: "${window.location.href}")
-	|> monitor["check"](
+  |> filter(fn: ${measurement})
+  |> monitor["check"](
 		data: check,
 		messageFn: messageFn,
 		crit: trigger,
 	)
+  |> filter(fn: trigger)
 	|> monitor["notify"](
     data: notification,
     endpoint: http.endpoint(url: "${data.url}")(

--- a/src/flows/pipes/Notification/endpoints/PagerDuty/index.ts
+++ b/src/flows/pipes/Notification/endpoints/PagerDuty/index.ts
@@ -21,14 +21,16 @@ export default register => {
       ['pagerduty', 'influxdata/influxdb/secrets']
         .map(i => `import "${i}"`)
         .join('\n'),
-    generateQuery: data => `task_data
+    generateQuery: (data, measurement) => `task_data
 	|> schema["fieldsAsCols"]()
-  |> set(key: "_notebook_link", value: "${window.location.href}")  
+  |> set(key: "_notebook_link", value: "${window.location.href}")
+  |> filter(fn: ${measurement})
   |> monitor["check"](
 		data: check,
 		messageFn: messageFn,
     crit: trigger,
 	)
+  |> filter(fn: trigger)
 	|> monitor["notify"](data: notification, endpoint: pagerduty.endpoint()(mapFn: (r) => ({ r with
         routingKey: "${data.key}",
         client: "influxdata",

--- a/src/flows/pipes/Notification/endpoints/PagerDuty/index.ts
+++ b/src/flows/pipes/Notification/endpoints/PagerDuty/index.ts
@@ -31,6 +31,8 @@ export default register => {
     crit: trigger,
 	)
   |> filter(fn: trigger)
+  |> keep(columns: ["_value", "_time", "_measurement"])
+  |> limit(n: 1, offset: 0)
 	|> monitor["notify"](data: notification, endpoint: pagerduty.endpoint()(mapFn: (r) => ({ r with
         routingKey: "${data.key}",
         client: "influxdata",

--- a/src/flows/pipes/Notification/endpoints/SendGrid/index.ts
+++ b/src/flows/pipes/Notification/endpoints/SendGrid/index.ts
@@ -23,14 +23,16 @@ export default register => {
       ['array', 'http', 'influxdata/influxdb/secrets', 'json']
         .map(i => `import "${i}"`)
         .join('\n'),
-    generateQuery: data => `task_data
+    generateQuery: (data, measurement) => `task_data
 	|> schema["fieldsAsCols"]()
       |> set(key: "_notebook_link", value: "${window.location.href}")
-	|> monitor["check"](
+  |> filter(fn: ${measurement})
+  |> monitor["check"](
 		data: check,
 		messageFn: messageFn,
 		crit: trigger,
 	)
+  |> filter(fn: trigger)
   |> monitor["notify"](
     data: notification,
     endpoint: http.endpoint(url: "${data.url}")(

--- a/src/flows/pipes/Notification/endpoints/SendGrid/index.ts
+++ b/src/flows/pipes/Notification/endpoints/SendGrid/index.ts
@@ -33,6 +33,8 @@ export default register => {
 		crit: trigger,
 	)
   |> filter(fn: trigger)
+  |> keep(columns: ["_value", "_time", "_measurement"])
+  |> limit(n: 1, offset: 0)
   |> monitor["notify"](
     data: notification,
     endpoint: http.endpoint(url: "${data.url}")(

--- a/src/flows/pipes/Notification/endpoints/Slack/index.ts
+++ b/src/flows/pipes/Notification/endpoints/Slack/index.ts
@@ -16,14 +16,16 @@ export default register => {
     generateImports: () => ['slack'].map(i => `import "${i}"`).join('\n'),
     generateTestImports: () =>
       ['array', 'slack'].map(i => `import "${i}"`).join('\n'),
-    generateQuery: data => `task_data
+    generateQuery: (data, measurement) => `task_data
 	|> schema["fieldsAsCols"]()
       |> set(key: "_notebook_link", value: "${window.location.href}")
+  |> filter(fn: ${measurement})
 	|> monitor["check"](
 		data: check,
 		messageFn: messageFn,
 		crit: trigger,
 	)
+  |> filter(fn: trigger)
 	|> monitor["notify"](
     data: notification,
     endpoint: slack["endpoint"](url: "${data.url}")(mapFn: (r) => ({

--- a/src/flows/pipes/Notification/endpoints/Slack/index.ts
+++ b/src/flows/pipes/Notification/endpoints/Slack/index.ts
@@ -26,6 +26,8 @@ export default register => {
 		crit: trigger,
 	)
   |> filter(fn: trigger)
+  |> keep(columns: ["_value", "_time", "_measurement"])
+  |> limit(n: 1, offset: 0)
 	|> monitor["notify"](
     data: notification,
     endpoint: slack["endpoint"](url: "${data.url}")(mapFn: (r) => ({

--- a/src/flows/pipes/Notification/endpoints/Telegram/index.ts
+++ b/src/flows/pipes/Notification/endpoints/Telegram/index.ts
@@ -33,6 +33,8 @@ export default register => {
 		crit: trigger,
 	)
   |> filter(fn: trigger)
+  |> keep(columns: ["_value", "_time", "_measurement"])
+  |> limit(n: 1, offset: 0)
 	|> monitor["notify"](
     data: notification,
     endpoint: telegram["endpoint"](

--- a/src/flows/pipes/Notification/endpoints/Telegram/index.ts
+++ b/src/flows/pipes/Notification/endpoints/Telegram/index.ts
@@ -23,14 +23,16 @@ export default register => {
       ['array', 'contrib/sranka/telegram', 'influxdata/influxdb/secrets']
         .map(i => `import "${i}"`)
         .join('\n'),
-    generateQuery: data => `task_data
+    generateQuery: (data, measurement) => `task_data
 	|> schema["fieldsAsCols"]()
       |> set(key: "_notebook_link", value: "${window.location.href}")
+  |> filter(fn: ${measurement})
 	|> monitor["check"](
 		data: check,
 		messageFn: messageFn,
 		crit: trigger,
 	)
+  |> filter(fn: trigger)
 	|> monitor["notify"](
     data: notification,
     endpoint: telegram["endpoint"](

--- a/src/flows/pipes/Notification/endpoints/Zenoss/index.ts
+++ b/src/flows/pipes/Notification/endpoints/Zenoss/index.ts
@@ -25,14 +25,16 @@ export default register => {
       ['array', 'contrib/bonitoo-io/zenoss', 'influxdata/influxdb/secrets']
         .map(i => `import "${i}"`)
         .join('\n'),
-    generateQuery: data => `task_data
+    generateQuery: (data, measurement) => `task_data
 	|> schema["fieldsAsCols"]()
       |> set(key: "_notebook_link", value: "${window.location.href}")
+  |> filter(fn: ${measurement})
 	|> monitor["check"](
 		data: check,
 		messageFn: messageFn,
 		crit: trigger,
 	)
+  |> filter(fn: trigger)
 	|> monitor["notify"](
     data: notification,
     endpoint: zenoss["endpoint"](

--- a/src/flows/pipes/Notification/endpoints/Zenoss/index.ts
+++ b/src/flows/pipes/Notification/endpoints/Zenoss/index.ts
@@ -35,6 +35,8 @@ export default register => {
 		crit: trigger,
 	)
   |> filter(fn: trigger)
+  |> keep(columns: ["_value", "_time", "_measurement"])
+  |> limit(n: 1, offset: 0)
 	|> monitor["notify"](
     data: notification,
     endpoint: zenoss["endpoint"](

--- a/src/flows/pipes/Notification/readOnly.tsx
+++ b/src/flows/pipes/Notification/readOnly.tsx
@@ -16,6 +16,7 @@ import {
   TechnoSpinner,
   SpinnerContainer,
 } from '@influxdata/clockface'
+import Measurement from 'src/flows/pipes/Notification/Measurement'
 import Threshold from 'src/flows/pipes/Notification/Threshold'
 
 import {PipeContext} from 'src/flows/context/pipe'
@@ -99,6 +100,7 @@ const ReadOnly: FC<PipeProp> = ({Context}) => {
   return (
     <Context>
       <div className="notification">
+        <Measurement readOnly />
         <Threshold readOnly />
         <FlexBox margin={ComponentSize.Medium} style={{padding: '24px 0'}}>
           <FlexBox.Child grow={1} shrink={1}>

--- a/src/flows/pipes/Notification/view.tsx
+++ b/src/flows/pipes/Notification/view.tsx
@@ -34,6 +34,7 @@ import {PipeContext} from 'src/flows/context/pipe'
 import {FlowQueryContext} from 'src/flows/context/flow.query'
 import {remove} from 'src/shared/contexts/query'
 import Expressions from 'src/flows/pipes/Notification/Expressions'
+import Measurement from 'src/flows/pipes/Notification/Measurement'
 import Threshold from 'src/flows/pipes/Notification/Threshold'
 import {
   ENDPOINT_DEFINITIONS,
@@ -340,6 +341,7 @@ const Notification: FC<PipeProp> = ({Context}) => {
             style={{width: 25, height: 25, position: 'absolute', right: 15}}
           />
         )}
+        <Measurement />
         <Threshold />
         <FlexBox margin={ComponentSize.Medium} style={{padding: '24px 0'}}>
           <FlexBox.Child grow={1} shrink={1}>

--- a/src/flows/pipes/Schedule/ExportTaskButton.tsx
+++ b/src/flows/pipes/Schedule/ExportTaskButton.tsx
@@ -31,6 +31,7 @@ import {getErrorMessage} from 'src/utils/api'
 import {getOrg} from 'src/organizations/selectors'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {PROJECT_NAME_PLURAL} from 'src/flows'
+import {missingUserInput} from 'src/shared/copy/notifications'
 
 interface Props {
   text: string
@@ -55,7 +56,14 @@ const ExportTaskButton: FC<Props> = ({
   const org = useSelector(getOrg)
 
   const onClick = async () => {
-    const query = generate ? generate() : data.query
+    let query
+
+    try {
+      query = generate ? generate() : data.query
+    } catch (e) {
+      dispatch(notify(missingUserInput(e.message)))
+      return
+    }
 
     event('Export Task Modal Skipped', {from: type})
     let taskid

--- a/src/flows/pipes/Schedule/ExportTaskButton.tsx
+++ b/src/flows/pipes/Schedule/ExportTaskButton.tsx
@@ -31,7 +31,7 @@ import {getErrorMessage} from 'src/utils/api'
 import {getOrg} from 'src/organizations/selectors'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {PROJECT_NAME_PLURAL} from 'src/flows'
-import {missingUserInput} from 'src/shared/copy/notifications'
+import {incorrectUserInput} from 'src/shared/copy/notifications'
 
 interface Props {
   text: string
@@ -61,7 +61,7 @@ const ExportTaskButton: FC<Props> = ({
     try {
       query = generate ? generate() : data.query
     } catch (e) {
-      dispatch(notify(missingUserInput(e.message)))
+      dispatch(notify(incorrectUserInput(e.message)))
       return
     }
 

--- a/src/flows/pipes/Visualization/ErrorThresholds/ErrorThresholds.tsx
+++ b/src/flows/pipes/Visualization/ErrorThresholds/ErrorThresholds.tsx
@@ -66,49 +66,47 @@ const ErrorThresholds: FC = () => {
           testID="component-spacer"
           stretchToFitWidth
         >
-          {data?.errorThresholds?.map(
-            (threshold: Threshold, index: number) => (
-              <FlexBox
-                direction={FlexDirection.Row}
-                margin={ComponentSize.Medium}
-                stretchToFitWidth
-                testID="component-spacer"
-                key={`${threshold.type}_${index}`}
-              >
-                <FlexBox.Child grow={3} testID="component-spacer--flex-child">
-                  <FlexBox
-                    stretchToFitWidth
-                    className="error-threshold-flex--margin"
-                  >
-                    <TextBlock
-                      testID="when-value-text-block"
-                      text={index === 0 ? 'When' : 'And'}
-                      className="error-threshold--text-block"
-                    />
-                    <ColumnDropdown threshold={threshold} index={index} />
-                  </FlexBox>
-                  <FlexBox
-                    stretchToFitWidth
-                    className="error-threshold-flex--margin"
-                  >
-                    <TextBlock
-                      testID="is-value-text-block"
-                      text="is"
-                      className="error-threshold--text-block"
-                    />
-                    <FunctionDropdown threshold={threshold} index={index} />
-                  </FlexBox>
-                  <ThresholdEntryColumn threshold={threshold} index={index} />
-                </FlexBox.Child>
-                <Button
-                  icon={IconFont.Trash_New}
-                  size={ComponentSize.Small}
-                  onClick={() => handleRemoveThreshold(index)}
-                  color={ComponentColor.Tertiary}
-                />
-              </FlexBox>
-            )
-          )}
+          {data?.errorThresholds?.map((threshold: Threshold, index: number) => (
+            <FlexBox
+              direction={FlexDirection.Row}
+              margin={ComponentSize.Medium}
+              stretchToFitWidth
+              testID="component-spacer"
+              key={`${threshold.type}_${index}`}
+            >
+              <FlexBox.Child grow={3} testID="component-spacer--flex-child">
+                <FlexBox
+                  stretchToFitWidth
+                  className="error-threshold-flex--margin"
+                >
+                  <TextBlock
+                    testID="when-value-text-block"
+                    text={index === 0 ? 'When' : 'And'}
+                    className="error-threshold--text-block"
+                  />
+                  <ColumnDropdown threshold={threshold} index={index} />
+                </FlexBox>
+                <FlexBox
+                  stretchToFitWidth
+                  className="error-threshold-flex--margin"
+                >
+                  <TextBlock
+                    testID="is-value-text-block"
+                    text="is"
+                    className="error-threshold--text-block"
+                  />
+                  <FunctionDropdown threshold={threshold} index={index} />
+                </FlexBox>
+                <ThresholdEntryColumn threshold={threshold} index={index} />
+              </FlexBox.Child>
+              <Button
+                icon={IconFont.Trash_New}
+                size={ComponentSize.Small}
+                onClick={() => handleRemoveThreshold(index)}
+                color={ComponentColor.Tertiary}
+              />
+            </FlexBox>
+          ))}
         </FlexBox>
         <FlexBox
           direction={FlexDirection.Row}

--- a/src/flows/pipes/Visualization/ErrorThresholds/ErrorThresholds.tsx
+++ b/src/flows/pipes/Visualization/ErrorThresholds/ErrorThresholds.tsx
@@ -18,7 +18,7 @@ import ColumnDropdown from 'src/flows/pipes/Visualization/ErrorThresholds/FieldC
 import FunctionDropdown from 'src/flows/pipes/Visualization/ErrorThresholds/FunctionDropdown'
 import ThresholdEntryColumn from 'src/flows/pipes/Visualization/ErrorThresholds/ThresholdEntryColumn'
 import {event} from 'src/cloud/utils/reporting'
-import {ErrorThreshold} from 'src/flows/pipes/Visualization/threshold'
+import {Threshold} from 'src/flows/shared/threshold'
 import './ErrorThresholds.scss'
 
 const ErrorThresholds: FC = () => {
@@ -67,7 +67,7 @@ const ErrorThresholds: FC = () => {
           stretchToFitWidth
         >
           {data?.errorThresholds?.map(
-            (threshold: ErrorThreshold, index: number) => (
+            (threshold: Threshold, index: number) => (
               <FlexBox
                 direction={FlexDirection.Row}
                 margin={ComponentSize.Medium}

--- a/src/flows/pipes/Visualization/ErrorThresholds/FieldColumnDropdown.tsx
+++ b/src/flows/pipes/Visualization/ErrorThresholds/FieldColumnDropdown.tsx
@@ -5,10 +5,10 @@ import React, {FC, useCallback, useContext, useMemo} from 'react'
 import {ComponentSize, Dropdown} from '@influxdata/clockface'
 import {PipeContext} from 'src/flows/context/pipe'
 import {event} from 'src/cloud/utils/reporting'
-import {ErrorThreshold} from 'src/flows/pipes/Visualization/threshold'
+import {Threshold} from 'src/flows/shared/threshold'
 
 type Props = {
-  threshold: ErrorThreshold
+  threshold: Threshold
   index: number
 }
 

--- a/src/flows/pipes/Visualization/ErrorThresholds/FunctionDropdown.tsx
+++ b/src/flows/pipes/Visualization/ErrorThresholds/FunctionDropdown.tsx
@@ -5,15 +5,15 @@ import React, {FC, useCallback, useContext, useMemo} from 'react'
 import {ComponentSize, ComponentStatus, Dropdown} from '@influxdata/clockface'
 import {PipeContext} from 'src/flows/context/pipe'
 import {event} from 'src/cloud/utils/reporting'
+import {Threshold} from 'src/flows/shared/threshold'
 import {
   COMMON_THRESHOLD_TYPES,
   EQUALITY_THRESHOLD_TYPES,
-  ErrorThreshold,
   ThresholdFormat,
-} from 'src/flows/pipes/Visualization/threshold'
+} from 'src/flows/shared/threshold'
 
 type Props = {
-  threshold: ErrorThreshold
+  threshold: Threshold
   index: number
 }
 const FunctionDropdown: FC<Props> = ({threshold, index}) => {

--- a/src/flows/pipes/Visualization/ErrorThresholds/ThresholdEntryColumn.tsx
+++ b/src/flows/pipes/Visualization/ErrorThresholds/ThresholdEntryColumn.tsx
@@ -12,15 +12,15 @@ import {
 } from '@influxdata/clockface'
 import {PipeContext} from 'src/flows/context/pipe'
 import {event} from 'src/cloud/utils/reporting'
+import {Threshold} from 'src/flows/shared/threshold'
 import {
   COMMON_THRESHOLD_TYPES,
-  ErrorThreshold,
   ThresholdFormat,
-} from 'src/flows/pipes/Visualization/threshold'
+} from 'src/flows/shared/threshold'
 import './ErrorThresholds.scss'
 
 type Props = {
-  threshold: ErrorThreshold
+  threshold: Threshold
   index: number
 }
 

--- a/src/flows/pipes/Visualization/threshold.ts
+++ b/src/flows/pipes/Visualization/threshold.ts
@@ -59,18 +59,22 @@ export function validateThreshold(t: Threshold): boolean {
   return true
 }
 
+export const lambdaPrefix = '(r) =>'
+
 export const EQUALITY_THRESHOLD_TYPES = {
   [ThresholdType.Equal]: {
     name: 'equal to',
     format: ThresholdFormat.Value,
     condition: data =>
-      validateThreshold(data) && `(r) => (r["${data.field}"] == ${data.value})`,
+      validateThreshold(data) &&
+      `${lambdaPrefix} (r["${data.field}"] == ${data.value})`,
   },
   [ThresholdType.NotEqual]: {
     name: 'not equal to',
     format: ThresholdFormat.Value,
     condition: data =>
-      validateThreshold(data) && `(r) => (r["${data.field}"] != ${data.value})`,
+      validateThreshold(data) &&
+      `${lambdaPrefix} (r["${data.field}"] != ${data.value})`,
   },
 }
 
@@ -80,39 +84,43 @@ export const COMMON_THRESHOLD_TYPES = {
     name: 'greater than',
     format: ThresholdFormat.Value,
     condition: data =>
-      validateThreshold(data) && `(r) => (r["${data.field}"] > ${data.value})`,
+      validateThreshold(data) &&
+      `${lambdaPrefix} (r["${data.field}"] > ${data.value})`,
   },
   [ThresholdType.GreaterEqual]: {
     name: 'greater than or equal to',
     format: ThresholdFormat.Value,
     condition: data =>
-      validateThreshold(data) && `(r) => (r["${data.field}"] >= ${data.value})`,
+      validateThreshold(data) &&
+      `${lambdaPrefix} (r["${data.field}"] >= ${data.value})`,
   },
   [ThresholdType.Less]: {
     name: 'less than',
     format: ThresholdFormat.Value,
     condition: data =>
-      validateThreshold(data) && `(r) => (r["${data.field}"] < ${data.value})`,
+      validateThreshold(data) &&
+      `${lambdaPrefix} (r["${data.field}"] < ${data.value})`,
   },
   [ThresholdType.LessEqual]: {
     name: 'less than or equal to',
     format: ThresholdFormat.Value,
     condition: data =>
-      validateThreshold(data) && `(r) => (r["${data.field}"] <= ${data.value})`,
+      validateThreshold(data) &&
+      `${lambdaPrefix} (r["${data.field}"] <= ${data.value})`,
   },
   [ThresholdType.Between]: {
     name: 'between',
     format: ThresholdFormat.Range,
     condition: data =>
       validateThreshold(data) &&
-      `(r) => (r["${data.field}"] > ${data.min} and r["${data.field}"] < ${data.max})`,
+      `${lambdaPrefix} (r["${data.field}"] > ${data.min} and r["${data.field}"] < ${data.max})`,
   },
   [ThresholdType.NotBetween]: {
     name: 'not between',
     format: ThresholdFormat.Range,
     condition: data =>
       validateThreshold(data) &&
-      `(r) => (r["${data.field}"] < ${data.min} or r["${data.field}"] > ${data.max})`,
+      `${lambdaPrefix} (r["${data.field}"] < ${data.min} or r["${data.field}"] > ${data.max})`,
   },
 }
 
@@ -123,6 +131,6 @@ export const THRESHOLD_TYPES = {
   [deadmanType]: {
     name: 'missing for longer than',
     format: ThresholdFormat.Deadman,
-    condition: data => validateThreshold(data) && `(r) => (r["dead"])`,
+    condition: data => validateThreshold(data) && `${lambdaPrefix} (r["dead"])`,
   },
 }

--- a/src/flows/pipes/Visualization/threshold.ts
+++ b/src/flows/pipes/Visualization/threshold.ts
@@ -4,9 +4,21 @@ export enum ThresholdFormat {
   Deadman = 'deadman',
 }
 
+export enum ThresholdType {
+  Greater = 'greater',
+  GreaterEqual = 'greater-equal',
+  Less = 'less',
+  LessEqual = 'less-equal',
+  Equal = 'equal',
+  NotEqual = 'not-equal',
+  Between = 'between',
+  NotBetween = 'not-between',
+  Deadman = 'missing-for-longer-than',
+}
+
 export type Threshold = {
   value: number
-  type: string
+  type: ThresholdType
   field: string
   max?: number
   min?: number
@@ -18,71 +30,99 @@ export interface ErrorThreshold extends Threshold {
   fieldType: string
 }
 
-export const COMMON_THRESHOLD_TYPES = {
-  greater: {
-    name: 'greater than',
-    format: ThresholdFormat.Value,
-    condition: data => `(r) => (r["${data.field}"] > ${data.value})`,
-  },
-  'greater-equal': {
-    name: 'greater than or equal to',
-    format: ThresholdFormat.Value,
-    condition: data => `(r) => (r["${data.field}"] >= ${data.value})`,
-  },
-  less: {
-    name: 'less than',
-    format: ThresholdFormat.Value,
-    condition: data => `(r) => (r["${data.field}"] < ${data.value})`,
-  },
-  'less-equal': {
-    name: 'less than or equal to',
-    format: ThresholdFormat.Value,
-    condition: data => `(r) => (r["${data.field}"] <= ${data.value})`,
-  },
-  equal: {
+export function validateThreshold(t: Threshold): boolean {
+  switch (t.type) {
+    case ThresholdType.Greater:
+    case ThresholdType.GreaterEqual:
+    case ThresholdType.Less:
+    case ThresholdType.LessEqual:
+    case ThresholdType.NotEqual:
+      if (!t.field || !(t.value == 0 || !!t.value)) {
+        throw new Error(
+          `A ${t.type} comparison, requires a selected field and selected value.`
+        )
+      }
+      break
+    case ThresholdType.Between:
+    case ThresholdType.NotBetween:
+      if (!t.field || !(t.max == 0 || !!t.max) || !(t.min == 0 || !!t.min)) {
+        throw new Error(
+          `A ${t.type} comparison, requires a selected field and selected min & max.`
+        )
+      }
+      break
+    case ThresholdType.Deadman:
+      // FIXME: get input from Ari
+      return true
+  }
+
+  return true
+}
+
+export const EQUALITY_THRESHOLD_TYPES = {
+  [ThresholdType.Equal]: {
     name: 'equal to',
     format: ThresholdFormat.Value,
-    condition: data => `(r) => (r["${data.field}"] == ${data.value})`,
+    condition: data =>
+      validateThreshold(data) && `(r) => (r["${data.field}"] == ${data.value})`,
   },
-  'not-equal': {
+  [ThresholdType.NotEqual]: {
     name: 'not equal to',
     format: ThresholdFormat.Value,
-    condition: data => `(r) => (r["${data.field}"] != ${data.value})`,
+    condition: data =>
+      validateThreshold(data) && `(r) => (r["${data.field}"] != ${data.value})`,
   },
-  between: {
+}
+
+export const COMMON_THRESHOLD_TYPES = {
+  ...EQUALITY_THRESHOLD_TYPES,
+  [ThresholdType.Greater]: {
+    name: 'greater than',
+    format: ThresholdFormat.Value,
+    condition: data =>
+      validateThreshold(data) && `(r) => (r["${data.field}"] > ${data.value})`,
+  },
+  [ThresholdType.GreaterEqual]: {
+    name: 'greater than or equal to',
+    format: ThresholdFormat.Value,
+    condition: data =>
+      validateThreshold(data) && `(r) => (r["${data.field}"] >= ${data.value})`,
+  },
+  [ThresholdType.Less]: {
+    name: 'less than',
+    format: ThresholdFormat.Value,
+    condition: data =>
+      validateThreshold(data) && `(r) => (r["${data.field}"] < ${data.value})`,
+  },
+  [ThresholdType.LessEqual]: {
+    name: 'less than or equal to',
+    format: ThresholdFormat.Value,
+    condition: data =>
+      validateThreshold(data) && `(r) => (r["${data.field}"] <= ${data.value})`,
+  },
+  [ThresholdType.Between]: {
     name: 'between',
     format: ThresholdFormat.Range,
     condition: data =>
+      validateThreshold(data) &&
       `(r) => (r["${data.field}"] > ${data.min} and r["${data.field}"] < ${data.max})`,
   },
-  'not-between': {
+  [ThresholdType.NotBetween]: {
     name: 'not between',
     format: ThresholdFormat.Range,
     condition: data =>
+      validateThreshold(data) &&
       `(r) => (r["${data.field}"] < ${data.min} or r["${data.field}"] > ${data.max})`,
   },
 }
 
-export const EQUALITY_THRESHOLD_TYPES = {
-  equal: {
-    name: 'equal to',
-    format: ThresholdFormat.Value,
-    condition: data => `(r) => (r["${data.field}"] == ${data.value})`,
-  },
-  'not-equal': {
-    name: 'not equal to',
-    format: ThresholdFormat.Value,
-    condition: data => `(r) => (r["${data.field}"] != ${data.value})`,
-  },
-}
-
-export const deadmanType = 'missing-for-longer-than'
+export const deadmanType = ThresholdType.Deadman
 
 export const THRESHOLD_TYPES = {
   ...COMMON_THRESHOLD_TYPES,
   [deadmanType]: {
     name: 'missing for longer than',
     format: ThresholdFormat.Deadman,
-    condition: _ => `(r) => (r["dead"])`,
+    condition: data => validateThreshold(data) && `(r) => (r["dead"])`,
   },
 }

--- a/src/flows/shared/threshold.ts
+++ b/src/flows/shared/threshold.ts
@@ -22,14 +22,11 @@ export type Threshold = {
   value: number
   type: ThresholdType
   field: string
+  fieldType: string
   max?: number
   min?: number
   deadmanCheckValue?: string
   deadmanStopValue: string // e.g. '5 minutes'
-}
-
-export interface ErrorThreshold extends Threshold {
-  fieldType: string
 }
 
 const existenceCheck = unknown => unknown == 0 || !!unknown
@@ -67,6 +64,10 @@ export function validateThreshold(t: Threshold): boolean {
   return true
 }
 
+// hypothetically, `val` could be an object etc
+const quoteStringValues = val =>
+  isNaN(Number(val)) ? JSON.stringify(val) : val
+
 export const lambdaPrefix = '(r) =>'
 
 export const EQUALITY_THRESHOLD_TYPES = {
@@ -75,14 +76,18 @@ export const EQUALITY_THRESHOLD_TYPES = {
     format: ThresholdFormat.Value,
     condition: data =>
       validateThreshold(data) &&
-      `${lambdaPrefix} (r["${data.field}"] == ${data.value})`,
+      `${lambdaPrefix} (r["${data.field}"] == ${quoteStringValues(
+        data.value
+      )})`,
   },
   [ThresholdType.NotEqual]: {
     name: 'not equal to',
     format: ThresholdFormat.Value,
     condition: data =>
       validateThreshold(data) &&
-      `${lambdaPrefix} (r["${data.field}"] != ${data.value})`,
+      `${lambdaPrefix} (r["${data.field}"] != ${quoteStringValues(
+        data.value
+      )})`,
   },
 }
 
@@ -93,42 +98,50 @@ export const COMMON_THRESHOLD_TYPES = {
     format: ThresholdFormat.Value,
     condition: data =>
       validateThreshold(data) &&
-      `${lambdaPrefix} (r["${data.field}"] > ${data.value})`,
+      `${lambdaPrefix} (r["${data.field}"] > ${quoteStringValues(data.value)})`,
   },
   [ThresholdType.GreaterEqual]: {
     name: 'greater than or equal to',
     format: ThresholdFormat.Value,
     condition: data =>
       validateThreshold(data) &&
-      `${lambdaPrefix} (r["${data.field}"] >= ${data.value})`,
+      `${lambdaPrefix} (r["${data.field}"] >= ${quoteStringValues(
+        data.value
+      )})`,
   },
   [ThresholdType.Less]: {
     name: 'less than',
     format: ThresholdFormat.Value,
     condition: data =>
       validateThreshold(data) &&
-      `${lambdaPrefix} (r["${data.field}"] < ${data.value})`,
+      `${lambdaPrefix} (r["${data.field}"] < ${quoteStringValues(data.value)})`,
   },
   [ThresholdType.LessEqual]: {
     name: 'less than or equal to',
     format: ThresholdFormat.Value,
     condition: data =>
       validateThreshold(data) &&
-      `${lambdaPrefix} (r["${data.field}"] <= ${data.value})`,
+      `${lambdaPrefix} (r["${data.field}"] <= ${quoteStringValues(
+        data.value
+      )})`,
   },
   [ThresholdType.Between]: {
     name: 'between',
     format: ThresholdFormat.Range,
     condition: data =>
       validateThreshold(data) &&
-      `${lambdaPrefix} (r["${data.field}"] > ${data.min} and r["${data.field}"] < ${data.max})`,
+      `${lambdaPrefix} (r["${data.field}"] > ${quoteStringValues(
+        data.min
+      )} and r["${data.field}"] < ${quoteStringValues(data.max)})`,
   },
   [ThresholdType.NotBetween]: {
     name: 'not between',
     format: ThresholdFormat.Range,
     condition: data =>
       validateThreshold(data) &&
-      `${lambdaPrefix} (r["${data.field}"] < ${data.min} or r["${data.field}"] > ${data.max})`,
+      `${lambdaPrefix} (r["${data.field}"] < ${quoteStringValues(
+        data.min
+      )} or r["${data.field}"] > ${quoteStringValues(data.max)})`,
   },
 }
 

--- a/src/flows/shared/threshold.ts
+++ b/src/flows/shared/threshold.ts
@@ -31,6 +31,10 @@ export type Threshold = {
 
 const existenceCheck = unknown => unknown == 0 || !!unknown
 
+const assertSwitchIsExhaustive = (_: never): never => {
+  throw new Error('Unreachable')
+}
+
 export function validateThreshold(t: Threshold): boolean {
   switch (t.type) {
     case ThresholdType.Greater:
@@ -44,7 +48,7 @@ export function validateThreshold(t: Threshold): boolean {
           `A ${t.type} comparison, requires a selected field and value.`
         )
       }
-      break
+      return true
     case ThresholdType.Between:
     case ThresholdType.NotBetween:
       if (!t.field || !existenceCheck(t.min) || !existenceCheck(t.max)) {
@@ -52,16 +56,17 @@ export function validateThreshold(t: Threshold): boolean {
           `A ${t.type} comparison, requires a selected field and min & max.`
         )
       }
-      break
+      return true
     case ThresholdType.Deadman:
       if (!t.field || !existenceCheck(t.deadmanStopValue)) {
         throw new Error(
           `A deadman check requires a designated timespan (e.g. dead for '5 minutes').`
         )
       }
-      break
+      return true
+    default:
+      return assertSwitchIsExhaustive(t.type)
   }
-  return true
 }
 
 // hypothetically, `val` could be an object etc

--- a/src/shared/copy/notifications/common.ts
+++ b/src/shared/copy/notifications/common.ts
@@ -135,11 +135,11 @@ export const invalidJSON = (message: string): Notification => {
   }
 }
 
-export const missingUserInput = (
+export const incorrectUserInput = (
   reason: string = 'flux was invalid.'
 ): Notification => ({
   ...defaultErrorNotification,
-  message: `Missing user input: ${reason}`,
+  message: `Incorrect user input: ${reason}`,
 })
 
 export const pinnedItemFailure = (


### PR DESCRIPTION
Closes #4021 
Part of #4229 
Closes #3707 
Part of #4080 

## Issues/Bugs
* bug 4229. We have no validation of the Alerts panel form inputs.
    * partial fixed here --> form validation for the thresholds. 
* bug 4021. The addition of multiple thresholds, resulted in invalid flux being exported to a task.
     * flux was writing `(r) => r["a"] > 0 and (r) => r["a"] = 0` . This is an incorrect lambda.
* Bug found. We were setting the default `threshold.field` to a string value `"_value"`.
     * this was occurring even without a user selecting a field.
     * <img width="400" alt="Screen Shot 2022-03-09 at 7 04 58 PM" src="https://user-images.githubusercontent.com/10232835/157586533-f6521a02-982d-4ab8-9c59-9c4ee546f9b6.png">
     * produced flux with `r["_value]`
     * therefore our form validation could not tell if the user had selected a field, or if they already had a field named "_value"
* bug 3707: alerts are being received as spam
     * the is because the `|> filter()` was not being applied before the monitor.notify()
     * also because we have multiple rows piped to monitor.notify()
* Bug 4080. We export invalid alert tasks, if a single measurement is not chosen before the monitor.check(). 
     * see docs requirement: https://docs.influxdata.com/flux/v0.x/stdlib/influxdata/influxdb/monitor/check/
     * the result was a obtuse error of
         * ```
            Unexpected error from query; Err: runtime error @42:8-42:74: check: failed to evaluate map function: unsupported binary expression invalid > int: runtime error @42:8-42:74: check: failed to evaluate map function: unsupported binary expression invalid > int
            ```

.

## Done:
* commits are labeled with the issue they address.
* housekeeping: make enum type for the ThresholdType
   * use enum in threshold definitions
   * use enum in switch statement for validations
* bug 4229:
   * validate the threshold, based upon the ThresholdType
   * do not explicitly set the `threshold.field` value ourselves. (should only be set by user interaction.)
* bug 4021:
   * handle the AND joins across multiple predicates/thresholds.
* bug 4080:
   * applied the measurement filter, before the monitor.check(). To have only 1 measurement.
   * Across all endpoints.
* bug 3707:
   * applied the threshold filter, a grouping (`|> keep`), and a limit on the results.
   * before the monitor.notify()
   * Across all endpoints.
   * confirmed with flux team that we should not have unintended behaviors.

.

## Visual proof:
https://user-images.githubusercontent.com/10232835/159588986-583bda89-1fbe-4932-b3a4-6105fbd9c430.mp4



Resultant query:
<img width="1205" alt="Screen Shot 2022-03-22 at 3 49 29 PM" src="https://user-images.githubusercontent.com/10232835/159589065-dbc2474e-f85d-4d7d-a59c-cf451cefe6b3.png">


Confirmed is being send received, and only once.
(note that the data refresh rate is >5 minutes. But see unique time stamps.)
<img width="350" alt="Screen Shot 2022-03-22 at 4 52 01 PM" src="https://user-images.githubusercontent.com/10232835/159595434-0d2f6e88-cd89-43f5-b472-e2d65109e0bd.png">



Confirmed error threshold still work:

https://user-images.githubusercontent.com/10232835/159591929-9cb96145-98e2-4b13-a6e7-cdaabfacdb48.mov



Confirmed deadman task still works:
<img width="1430" alt="Screen Shot 2022-03-22 at 4 50 51 PM" src="https://user-images.githubusercontent.com/10232835/159595340-49a1010c-33d5-469b-a5fb-dd53528acd2a.png">




.

## Next PR:
* add more schema usage, in the alert panel. (finish out 4080)
* tests