### PR TITLE
feat: add html titles to the nav links so the label shows up on hover

### DIFF
--- a/src/pageLayout/containers/TreeNav.tsx
+++ b/src/pageLayout/containers/TreeNav.tsx
@@ -48,7 +48,7 @@ const TreeSidebar: FC = () => {
       >
         {generateNavItems().map((item: NavItem) => {
           const linkElement = (className: string): JSX.Element => (
-            <Link to={item.link} className={className} />
+            <Link to={item.link} className={className} title={item.label} />
           )
           return (
             <TreeNav.Item


### PR DESCRIPTION
Closes #2992

adds html `title` to the links on the nav, which renders a browser-defined hover label. The label only appears on navigation items without subnav, but it seems okay from a usability perspective since the subnavs provide the missing context that `title` provides, albeit in a different way.

https://user-images.githubusercontent.com/146112/157900201-d7fcba63-ebfb-4387-a593-c4e0dc6ff49c.mov


