### PR TITLE
feat: less visual weight

### DIFF
--- a/src/flows/components/panel/FlowPanel.tsx
+++ b/src/flows/components/panel/FlowPanel.tsx
@@ -22,7 +22,7 @@ import {MenuButton} from 'src/flows/components/Sidebar'
 
 // Constants
 import {PIPE_DEFINITIONS} from 'src/flows'
-import {FeatureFlag} from 'src/shared/utils/featureFlag'
+import {FeatureFlag, isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Types
 import {PipeContextProps} from 'src/types/flows'
@@ -59,6 +59,7 @@ const FlowPanel: FC<Props> = ({
   const panelClassName = classnames('flow-panel', {
     [`flow-panel__${isVisible ? 'visible' : 'hidden'}`]: true,
     'flow-panel__focus': focused === id,
+    'small-insert': isFlagEnabled('smallInsert'),
   })
 
   const [size, updateSize] = useState<number>(

--- a/src/flows/components/panel/InsertCellButton.scss
+++ b/src/flows/components/panel/InsertCellButton.scss
@@ -3,6 +3,41 @@
 
 $cf-radius-lg: $cf-radius + 4px;
 
+.small-flow-divider {
+  position: relative;
+  margin-bottom: 4px;
+  text-align: right;
+
+  .insert-wrap {
+    padding: 8px 0;
+    display: inline-block;
+    cursor: pointer;
+
+    &:active,
+    &:hover {
+      .cf-button.flow-divider--button {
+        background: linear-gradient(45deg, #5c10a0 0%, #8e1fc3 100%);
+        color: #fff;
+      }
+      span {
+        color: #fff;
+      }
+    }
+  }
+
+  .cf-button.flow-divider--button {
+    position: static;
+    transform: none;
+    margin: -4px 8px 0;
+    background: inherit;
+  }
+
+  span {
+    font-size: 12px;
+    color: #68687b;
+  }
+}
+
 .flow-divider {
   position: relative;
   width: 100%;

--- a/src/flows/components/panel/InsertCellButton.tsx
+++ b/src/flows/components/panel/InsertCellButton.tsx
@@ -52,10 +52,7 @@ const InsertCellButton: FC<Props> = ({id}) => {
       dividerRef.current.classList.remove('flow-divider__popped')
   }
 
-  if (
-    isFlagEnabled('showLastInsert') &&
-    index === flow.data.allIDs.length - 1
-  ) {
+  if (index === flow.data.allIDs.length - 1) {
     return (
       <FlexBox
         direction={FlexDirection.Column}
@@ -66,6 +63,67 @@ const InsertCellButton: FC<Props> = ({id}) => {
         <p className="insert-cell-menu--title">Add Another Panel</p>
         <AddButtons index={index} />
       </FlexBox>
+    )
+  }
+
+  if (isFlagEnabled('smallInsert')) {
+    let button
+    if (index === -1) {
+      button = (
+        <div className="insert-wrap">
+          <span>Insert Panel Here</span>
+          <SquareButton
+            icon={IconFont.Plus_New}
+            size={ComponentSize.ExtraSmall}
+            ref={buttonRef}
+            color={ComponentColor.Secondary}
+            testID={`panel-add-btn-${index}`}
+            className="flow-divider--button"
+            active={popoverVisible.current}
+          />
+        </div>
+      )
+    } else {
+      button = (
+        <div className="insert-wrap">
+          <span>Insert Panel Below</span>
+          <SquareButton
+            icon={IconFont.ArrowDown_New}
+            size={ComponentSize.ExtraSmall}
+            ref={buttonRef}
+            color={ComponentColor.Secondary}
+            testID={`panel-add-btn-${index}`}
+            className="flow-divider--button"
+            active={popoverVisible.current}
+          />
+        </div>
+      )
+    }
+    return (
+      <div className="small-flow-divider" ref={dividerRef}>
+        {button}
+
+        <Popover
+          enableDefaultStyles={false}
+          appearance={Appearance.Outline}
+          color={ComponentColor.Secondary}
+          triggerRef={buttonRef}
+          position={PopoverPosition.ToTheRight}
+          onShow={handlePopoverShow}
+          onHide={handlePopoverHide}
+          contents={onHide => (
+            <FlexBox
+              direction={FlexDirection.Column}
+              alignItems={AlignItems.Stretch}
+              margin={ComponentSize.Small}
+              className="insert-cell-menu"
+            >
+              <p className="insert-cell-menu--title">Insert Panel Here</p>
+              <AddButtons index={index} onInsert={onHide} />
+            </FlexBox>
+          )}
+        />
+      </div>
     )
   }
 

--- a/src/flows/components/panel/InsertCellButton.tsx
+++ b/src/flows/components/panel/InsertCellButton.tsx
@@ -70,12 +70,11 @@ const InsertCellButton: FC<Props> = ({id}) => {
     let button
     if (index === -1) {
       button = (
-        <div className="insert-wrap">
+        <div className="insert-wrap" ref={buttonRef}>
           <span>Insert Panel Here</span>
           <SquareButton
             icon={IconFont.Plus_New}
             size={ComponentSize.ExtraSmall}
-            ref={buttonRef}
             color={ComponentColor.Secondary}
             testID={`panel-add-btn-${index}`}
             className="flow-divider--button"
@@ -85,12 +84,11 @@ const InsertCellButton: FC<Props> = ({id}) => {
       )
     } else {
       button = (
-        <div className="insert-wrap">
+        <div className="insert-wrap" ref={buttonRef}>
           <span>Insert Panel Below</span>
           <SquareButton
             icon={IconFont.ArrowDown_New}
             size={ComponentSize.ExtraSmall}
-            ref={buttonRef}
             color={ComponentColor.Secondary}
             testID={`panel-add-btn-${index}`}
             className="flow-divider--button"

--- a/src/flows/components/panel/InsertCellButton.tsx
+++ b/src/flows/components/panel/InsertCellButton.tsx
@@ -31,7 +31,8 @@ interface Props {
 const InsertCellButton: FC<Props> = ({id}) => {
   const {flow} = useContext(FlowContext)
   const dividerRef = useRef<HTMLDivElement>(null)
-  const buttonRef = useRef<HTMLButtonElement | HTMLDivElement>(null)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  const smallButtonRef = useRef<HTMLDivElement>(null)
   const popoverVisible = useRef<boolean>(false)
   const index = flow.data.allIDs.indexOf(id)
 
@@ -70,7 +71,7 @@ const InsertCellButton: FC<Props> = ({id}) => {
     let button
     if (index === -1) {
       button = (
-        <div className="insert-wrap" ref={buttonRef}>
+        <div className="insert-wrap" ref={smallButtonRef}>
           <span>Insert Panel Here</span>
           <SquareButton
             icon={IconFont.Plus_New}
@@ -84,7 +85,7 @@ const InsertCellButton: FC<Props> = ({id}) => {
       )
     } else {
       button = (
-        <div className="insert-wrap" ref={buttonRef}>
+        <div className="insert-wrap" ref={smallButtonRef}>
           <span>Insert Panel Below</span>
           <SquareButton
             icon={IconFont.ArrowDown_New}
@@ -105,7 +106,7 @@ const InsertCellButton: FC<Props> = ({id}) => {
           enableDefaultStyles={false}
           appearance={Appearance.Outline}
           color={ComponentColor.Secondary}
-          triggerRef={buttonRef}
+          triggerRef={smallButtonRef}
           position={PopoverPosition.ToTheRight}
           onShow={handlePopoverShow}
           onHide={handlePopoverHide}

--- a/src/flows/components/panel/InsertCellButton.tsx
+++ b/src/flows/components/panel/InsertCellButton.tsx
@@ -31,7 +31,7 @@ interface Props {
 const InsertCellButton: FC<Props> = ({id}) => {
   const {flow} = useContext(FlowContext)
   const dividerRef = useRef<HTMLDivElement>(null)
-  const buttonRef = useRef<HTMLButtonElement>(null)
+  const buttonRef = useRef<HTMLButtonElement | HTMLDivElement>(null)
   const popoverVisible = useRef<boolean>(false)
   const index = flow.data.allIDs.indexOf(id)
 

--- a/src/flows/style.scss
+++ b/src/flows/style.scss
@@ -56,6 +56,19 @@ $cf-radius-lg: $cf-radius + 4px;
   &:first-child::after {
     top: ($flow-header-height - $flow-panel--node-dot) * 0.5;
   }
+
+  &.small-insert {
+    .flow-panel--node-wrapper {
+      display: none;
+    }
+    .flow-panel--body {
+      padding-left: inherit;
+    }
+
+    &:after {
+      display: none;
+    }
+  }
 }
 
 .flow-panel__readonly {


### PR DESCRIPTION
now that we're encouraging people to insert more panels in their notebooks, and they're getting introduced to the concept, lets dedicate less visual space to the edge cases of that process. 

query development in notebooks is predominately a top to bottom kind of thing. we want them to start, find something interesting, move on to finding something else interesting, and have a record of that whole exploration. if we think of the notebook as a chronological exploration and not as an artifact, inserting panels between each other becomes an edge case, predominately used for polishing an exploration into an artifact. because we want to focus on that initial exploratory interaction, even though we still need to give the user the affordances to do these actions for later, we dont need to make it a first level interaction.

starts to look a bit like this:
![Screenshot 2022-03-11 8 38 58 AM](https://user-images.githubusercontent.com/1434802/157911135-e0c9dcc5-213c-46fa-bc98-e9b1edc549be.png)


hover state makes it pop a little more  when you get close to the button:
![Screenshot 2022-03-11 8 49 47 AM](https://user-images.githubusercontent.com/1434802/157911306-0d9ab832-7475-4325-a32d-55be91de6656.png)
