### PR TITLE
chore: remove telegrafUiRefresh feature flag

### DIFF
--- a/cypress/e2e/shared/buckets.test.ts
+++ b/cypress/e2e/shared/buckets.test.ts
@@ -135,9 +135,6 @@ describe('Buckets', () => {
     const TELEGRAF_SYSTEMS_PLUGINS_ORIGINAL_COUNT = 5
 
     it('configure telegraf agent', () => {
-      cy.setFeatureFlags({
-        telegrafUiRefresh: true,
-      })
       // click "add data" and choose Configure Telegraf Agent
       cy.getByTestID('add-data--button').click()
       cy.get('.bucket-add-data--option')

--- a/cypress/e2e/shared/telegrafPlugins.test.ts
+++ b/cypress/e2e/shared/telegrafPlugins.test.ts
@@ -12,23 +12,11 @@ describe('Sources > Telegraf Plugins', () => {
     )
   })
 
-  it('can select a plugin and see details without an option to add to a configuration when feature is off', () => {
-    const examplePlugin = 'aerospike'
-    cy.setFeatureFlags({
-      telegrafUiRefresh: false,
-    })
-    cy.getByTestID('sources-telegraf-plugins').should('exist')
-    cy.getByTestID(`load-data-item ${examplePlugin}`).click()
-    cy.getByTestID('add-plugin-to-configuration--dropdown').should('not.exist')
-  })
-
-  it('can create a new telegraf configuration and a new bucket from a plugin when feature is on', () => {
+  it('can create a new telegraf configuration and a new bucket from a plugin', () => {
     const examplePlugin = 'aerospike'
     const configurationName = 'test configuration name'
     const bucketName = 'test configuration create new bucket'
-    cy.setFeatureFlags({
-      telegrafUiRefresh: true,
-    })
+
     cy.getByTestID('sources-telegraf-plugins').should('exist')
     cy.getByTestID(`load-data-item ${examplePlugin}`).click()
     cy.getByTestID('add-plugin-to-configuration--dropdown')
@@ -85,9 +73,7 @@ describe('Sources > Telegraf Plugins', () => {
     const configurationName = `configuration with two ${examplePlugin}`
     const configurationDescription =
       'an example with the same plugin twice in one config'
-    cy.setFeatureFlags({
-      telegrafUiRefresh: true,
-    })
+
     // Create the config
     cy.getByTestID('sources-telegraf-plugins').should('exist')
     cy.getByTestID(`load-data-item ${examplePlugin}`).click()
@@ -182,9 +168,7 @@ describe('Sources > Telegraf Plugins', () => {
     const configurationName = `configuration with ${plugin1} and ${plugin2}`
     const configurationDescription =
       'an example with the two plugins in one config'
-    cy.setFeatureFlags({
-      telegrafUiRefresh: true,
-    })
+
     // Create the config with plugin1
     cy.getByTestID('sources-telegraf-plugins').should('exist')
     cy.getByTestID(`load-data-item ${plugin1}`).click()

--- a/cypress/e2e/shared/telegrafs.test.ts
+++ b/cypress/e2e/shared/telegrafs.test.ts
@@ -20,51 +20,10 @@ describe('Collectors', () => {
 
   describe('from the org view', () => {
     it('can create a telegraf config', () => {
-      const newConfig = 'New Config'
-      const configDescription = 'This is a new config testing'
-
-      cy.setFeatureFlags({
-        telegrafUiRefresh: false,
-      })
       cy.getByTestID('table-row').should('have.length', 0)
       cy.contains('Create Configuration').click()
       cy.getByTestID('overlay--container').within(() => {
-        cy.getByTestID('telegraf-plugins--System').click()
-        cy.getByTestID('next').click()
-        cy.getByInputName('name')
-          .clear()
-          .type(newConfig)
-        cy.getByInputName('description')
-          .clear()
-          .type(configDescription)
-        cy.get('.cf-button')
-          .contains('Create and Verify')
-          .click()
-        cy.getByTestID('streaming').within(() => {
-          cy.get('.cf-button')
-            .contains('Listen for Data')
-            .click()
-        })
-        cy.get('.cf-button')
-          .contains('Finish')
-          .click()
-      })
-
-      cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
-        cy.getByTestID('resource-card')
-          .should('have.length', 1)
-          .and('contain', newConfig)
-          .and('contain', defaultBucket)
-      })
-    })
-
-    it('can create a telegraf config in new system', () => {
-      cy.setFeatureFlags({telegrafUiRefresh: true}).then(() => {
-        cy.getByTestID('table-row').should('have.length', 0)
-        cy.contains('Create Configuration').click()
-        cy.getByTestID('overlay--container').within(() => {
-          cy.getByTestID('telegraf-plugins--Aerospike').click()
-        })
+        cy.getByTestID('telegraf-plugins--Aerospike').click()
       })
     })
 
@@ -245,6 +204,7 @@ describe('Collectors', () => {
       const telegrafs = ['bad', 'apple', 'cookie']
       const bucketz = ['MO_buckets', 'EZ_buckets', 'Bucky']
       const [firstTelegraf, secondTelegraf, thirdTelegraf] = telegrafs
+
       beforeEach(() => {
         const description = 'Config Description'
         const [firstBucket, secondBucket, thirdBucket] = bucketz
@@ -256,7 +216,7 @@ describe('Collectors', () => {
         cy.reload()
         cy.get('[data-testid="resource-list--body"]', {timeout: PAGE_LOAD_SLA})
       })
-      // filter by name
+
       it('can filter telegraf configs and sort by name', () => {
         // fixes https://github.com/influxdata/influxdb/issues/15246
         cy.getByTestID('search-widget').type(firstTelegraf)
@@ -320,131 +280,6 @@ describe('Collectors', () => {
             })
           })
       })
-    })
-  })
-
-  describe('configuring plugins', () => {
-    // fix for https://github.com/influxdata/influxdb/issues/15500
-    describe('configuring nginx', () => {
-      beforeEach(() => {
-        cy.setFeatureFlags({
-          telegrafUiRefresh: false,
-        })
-        // These clicks launch move through configuration modals rather than navigate to new pages
-        cy.contains('Create Configuration').click()
-        cy.contains('NGINX').click()
-        cy.contains('Continue').click()
-        cy.contains('nginx').click()
-      })
-
-      it('can add and delete urls', () => {
-        cy.getByTestID('input-field').type('http://localhost:9999')
-        cy.contains('Add').click()
-
-        cy.contains('http://localhost:9999').should('exist', () => {
-          cy.getByTestID('input-field').type('http://example.com')
-          cy.contains('Add').click()
-
-          cy.contains('http://example.com')
-            .should('exist')
-            .then($example => {
-              $example.contains('Delete').click()
-              $example.contains('Confirm').click()
-
-              cy.contains('http://example').should('not.exist')
-
-              cy.contains('Done').click()
-              cy.get('.cf-icon.checkmark-new').should('exist')
-            })
-        })
-      })
-
-      it('handles busted input', () => {
-        // do nothing when clicking done with no urls
-        cy.contains('Done').click()
-        cy.contains('nginx').should('exist')
-        cy.get('.cf-icon.circle-thick').should('exist')
-
-        cy.contains('nginx').click()
-        cy.getByTestID('input-field').type('youre mom')
-        cy.contains('Add').click()
-        cy.contains('Done').click()
-        cy.get('.cf-icon.remove-new').should('exist')
-      })
-    })
-  })
-
-  // redis was affected by the change that was written to address https://github.com/influxdata/influxdb/issues/15500
-  describe('configuring redis', () => {
-    beforeEach(() => {
-      cy.setFeatureFlags({
-        telegrafUiRefresh: false,
-      })
-      // These clicks launch move through configuration modals rather than navigate to new pages
-      cy.contains('Create Configuration').click()
-      cy.contains('Redis').click()
-      cy.contains('Continue').click()
-      cy.contains('redis').click()
-    })
-
-    it('can add and delete urls', () => {
-      cy.get('input[title="servers"]').type('michael collins')
-      cy.contains('Add').click()
-
-      cy.contains('michael collins').should('exist', () => {
-        cy.get('input[title="servers"]').type('alan bean')
-        cy.contains('Add').click()
-
-        cy.contains('alan bean')
-          .should('exist')
-          .then($server => {
-            $server.contains('Delete').click()
-            $server.contains('Confirm').click()
-            cy.contains('alan bean').should('not.exist')
-
-            cy.contains('Done').click()
-            cy.get('.cf-icon.checkmark-new').should('exist')
-          })
-      })
-    })
-
-    it('does nothing when clicking done with no urls', () => {
-      cy.contains('Done').click()
-      cy.contains('redis').should('exist')
-    })
-  })
-
-  // fix for https://github.com/influxdata/influxdb/issues/15730
-  it('creates a configuration with a unique label and opens it', () => {
-    cy.setFeatureFlags({
-      telegrafUiRefresh: false,
-    })
-    cy.contains('Create Configuration').click()
-
-    cy.contains('Docker').click()
-
-    cy.contains('Continue').click()
-
-    cy.contains('docker').click()
-
-    cy.get('[name="endpoint"]').type('http://localhost')
-
-    cy.contains('Done').click()
-    cy.get('input[title="Telegraf Configuration Name"]').type(
-      '{selectall}Label 1'
-    )
-    cy.get('input[title="Telegraf Configuration Description"]').type(
-      'Description 1'
-    )
-
-    cy.contains('Create and Verify').click()
-    cy.contains('Finish').click()
-    cy.contains('Your configurations have been saved')
-
-    cy.contains('Label 1').click()
-
-    cy.getByTestID('telegraf-overlay').within(() => {
-      cy.contains('Label 1').should('exist')
     })
   })
 

--- a/src/dataLoaders/actions/dataLoaders.ts
+++ b/src/dataLoaders/actions/dataLoaders.ts
@@ -73,7 +73,7 @@ export type Action =
   | SetActiveTelegrafPlugin
   | UpdateTelegrafPlugin
   | AddPluginBundle
-  | AddTelegrafPluginsTelegrafUiRefresh
+  | ReplaceBundleWithPlugin
   | AddTelegrafPlugins
   | RemoveBundlePlugins
   | RemovePluginBundle
@@ -244,8 +244,8 @@ interface AddTelegrafPlugins {
   type: 'ADD_TELEGRAF_PLUGINS'
   payload: {telegrafPlugins: TelegrafPlugin[]}
 }
-interface AddTelegrafPluginsTelegrafUiRefresh {
-  type: 'ADD_TELEGRAF_PLUGINS_telegrafUiRefresh'
+interface ReplaceBundleWithPlugin {
+  type: 'REPLACE_BUNDLE_WITH_PLUGIN'
   payload: {telegrafPlugins: TelegrafPlugin}
 }
 
@@ -256,10 +256,10 @@ export const addTelegrafPlugins = (
   payload: {telegrafPlugins},
 })
 
-export const addTelegrafPlugins_telegrafUiRefresh = (
+export const replaceBundleWithPlugin = (
   telegrafPlugins: TelegrafPlugin
-): AddTelegrafPluginsTelegrafUiRefresh => ({
-  type: 'ADD_TELEGRAF_PLUGINS_telegrafUiRefresh',
+): ReplaceBundleWithPlugin => ({
+  type: 'REPLACE_BUNDLE_WITH_PLUGIN',
   payload: {telegrafPlugins},
 })
 
@@ -348,10 +348,10 @@ export const addPluginBundleWithPlugins = (bundle: BundleName) => dispatch => {
   )
 }
 
-export const addTelegrafPlugin_telegrafUiRefresh = (
+export const addTelegrafPluginAsBundle = (
   plugin: TelegrafPlugin
 ) => dispatch => {
-  dispatch(addTelegrafPlugins_telegrafUiRefresh(plugin))
+  dispatch(replaceBundleWithPlugin(plugin))
 }
 
 export const removePluginBundleWithPlugins = (

--- a/src/dataLoaders/actions/dataLoaders.ts
+++ b/src/dataLoaders/actions/dataLoaders.ts
@@ -73,7 +73,6 @@ export type Action =
   | SetActiveTelegrafPlugin
   | UpdateTelegrafPlugin
   | AddPluginBundle
-  | AddTelegrafTelegrafUiRefresh
   | AddTelegrafPluginsTelegrafUiRefresh
   | AddTelegrafPlugins
   | RemoveBundlePlugins
@@ -227,21 +226,9 @@ interface AddPluginBundle {
   payload: {bundle: BundleName}
 }
 
-interface AddTelegrafTelegrafUiRefresh {
-  type: 'ADD_TELEGRAF_telegrafUiRefresh'
-  payload: {plugin: TelegrafPlugin}
-}
-
 export const addPluginBundle = (bundle: BundleName): AddPluginBundle => ({
   type: 'ADD_PLUGIN_BUNDLE',
   payload: {bundle},
-})
-
-export const addTelegraf_telegrafUiRefresh = (
-  plugin: TelegrafPlugin
-): AddTelegrafTelegrafUiRefresh => ({
-  type: 'ADD_TELEGRAF_telegrafUiRefresh',
-  payload: {plugin},
 })
 
 interface RemovePluginBundle {
@@ -364,7 +351,6 @@ export const addPluginBundleWithPlugins = (bundle: BundleName) => dispatch => {
 export const addTelegrafPlugin_telegrafUiRefresh = (
   plugin: TelegrafPlugin
 ) => dispatch => {
-  dispatch(addTelegraf_telegrafUiRefresh(plugin))
   dispatch(addTelegrafPlugins_telegrafUiRefresh(plugin))
 }
 

--- a/src/dataLoaders/components/collectorsWizard/select/TelegrafUIRefreshCollectorsStep.tsx
+++ b/src/dataLoaders/components/collectorsWizard/select/TelegrafUIRefreshCollectorsStep.tsx
@@ -9,7 +9,7 @@ import TelegrafUIRefreshSelector from 'src/dataLoaders/components/collectorsWiza
 
 // Actions
 import {
-  addTelegrafPlugin_telegrafUiRefresh,
+  addTelegrafPluginAsBundle,
   removePluginBundleWithPlugins,
 } from 'src/dataLoaders/actions/dataLoaders'
 import {setBucketInfo} from 'src/dataLoaders/actions/steps'
@@ -133,7 +133,7 @@ const mstp = (state: AppState) => {
 }
 
 const mdtp = {
-  onAddPluginBundle: addTelegrafPlugin_telegrafUiRefresh,
+  onAddPluginBundle: addTelegrafPluginAsBundle,
   onRemovePluginBundle: removePluginBundleWithPlugins,
   setBucketInfo,
 }

--- a/src/dataLoaders/reducers/dataLoaders.ts
+++ b/src/dataLoaders/reducers/dataLoaders.ts
@@ -92,7 +92,7 @@ export default (state = INITIAL_STATE, action: Action): DataLoadersState => {
         ),
       }
 
-    case 'ADD_TELEGRAF_PLUGINS_telegrafUiRefresh':
+    case 'REPLACE_BUNDLE_WITH_PLUGIN':
       const telegrafPlugins = [action.payload.telegrafPlugins]
       return {
         ...state,

--- a/src/telegrafs/containers/TelegrafsPage.tsx
+++ b/src/telegrafs/containers/TelegrafsPage.tsx
@@ -10,7 +10,6 @@ import Collectors from 'src/telegrafs/components/Collectors'
 import GetResources from 'src/resources/components/GetResources'
 import LimitChecker from 'src/cloud/components/LimitChecker'
 import TelegrafInstructionsOverlay from 'src/telegrafs/components/TelegrafInstructionsOverlay'
-import CollectorsWizard from 'src/dataLoaders/components/collectorsWizard/CollectorsWizard'
 import TelegrafUIRefreshWizard from 'src/dataLoaders/components/collectorsWizard/TelegrafUIRefreshWizard'
 import {Page} from '@influxdata/clockface'
 import OverlayHandler, {
@@ -34,7 +33,6 @@ const TelegrafOutputOverlay = RouteOverlay(
 
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Types
 import {ResourceType} from 'src/types'
@@ -76,11 +74,7 @@ class TelegrafsPage extends PureComponent {
           />
           <Route
             path={`${telegrafsPath}/new`}
-            component={
-              isFlagEnabled('telegrafUiRefresh')
-                ? TelegrafUIRefreshWizard
-                : CollectorsWizard
-            }
+            component={TelegrafUIRefreshWizard}
           />
         </Switch>
       </>

--- a/src/writeData/containers/TelegrafPluginsPage.tsx
+++ b/src/writeData/containers/TelegrafPluginsPage.tsx
@@ -22,7 +22,6 @@ import placeholderLogo from 'src/writeData/graphics/placeholderLogo.svg'
 
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {event, normalizeEventName} from 'src/cloud/utils/reporting'
 
 // Styles
@@ -92,27 +91,13 @@ const TelegrafPluginsPage: FC<RouteComponentProps<{orgID: string}>> = props => {
               <Page.Title title={name} />
             </Page.Header>
             <Page.Contents fullWidth={false} scrollable={true}>
-              {isFlagEnabled('telegrafUiRefresh') ? (
-                <AddPluginToConfigurationCTA
-                  contentID={contentID}
-                  history={history}
-                  orgID={orgID}
-                  thumbnail={thumbnail}
-                  pageContent={pageContent}
-                />
-              ) : (
-                <div className="write-data--details">
-                  <div className="write-data--details-thumbnail">
-                    {thumbnail}
-                  </div>
-                  <div
-                    className="write-data--details-content markdown-format"
-                    data-testid="load-data-details-content"
-                  >
-                    {pageContent}
-                  </div>
-                </div>
-              )}
+              <AddPluginToConfigurationCTA
+                contentID={contentID}
+                history={history}
+                orgID={orgID}
+                thumbnail={thumbnail}
+                pageContent={pageContent}
+              />
             </Page.Contents>
           </Page>
         </WriteDataDetailsContextProvider>


### PR DESCRIPTION
Part of #3747 

- removes the feature flag `telegrafUiRefresh`
- removes tests for code that no longer exists
- drastically reduce the usage of `telegrafUiRefresh` in naming
