### PR TITLE
feat(bucket-list): allow filtering by bucket id

### DIFF
--- a/src/buckets/components/BucketsTab.tsx
+++ b/src/buckets/components/BucketsTab.tsx
@@ -115,7 +115,12 @@ class BucketsTab extends PureComponent<Props, State> {
             >
               <FilterBuckets
                 searchTerm={searchTerm}
-                searchKeys={['name', 'readableRetention', 'labels[].name']}
+                searchKeys={[
+                  'id',
+                  'labels[].name',
+                  'name',
+                  'readableRetention',
+                ]}
                 list={buckets}
               >
                 {bs => (

--- a/src/buckets/pagination/BucketsTab.tsx
+++ b/src/buckets/pagination/BucketsTab.tsx
@@ -158,9 +158,10 @@ class BucketsTab extends PureComponent<Props, State> {
                     <FilterBuckets
                       searchTerm={searchTerm}
                       searchKeys={[
+                        'id',
+                        'labels[].name',
                         'name',
                         'readableRetention',
-                        'labels[].name',
                       ]}
                       list={buckets}
                     >


### PR DESCRIPTION
Closes https://github.com/influxdata/idpe/issues/12739

Buckets list: allows filtering of bucket by bucket id. Works in paginated and non-paginated versions.


https://user-images.githubusercontent.com/146112/158209375-17992bd7-1888-4677-a3a8-f3cff058af9b.mov


