### PR TITLE
chore: update the icon and complete the feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
   },
   "dependencies": {
     "@docsearch/react": "^3.0.0-alpha.37",
-    "@influxdata/clockface": "^3.4.1",
+    "@influxdata/clockface": "^3.5.2",
     "@influxdata/flux-lsp-browser": "^0.8.5",
     "@influxdata/giraffe": "^2.24.3",
     "@influxdata/influxdb-templates": "0.9.0",

--- a/src/flows/components/header/MenuButton.tsx
+++ b/src/flows/components/header/MenuButton.tsx
@@ -194,7 +194,7 @@ const MenuButton: FC<Props> = ({handleResetShare}) => {
         type: 'menuitem',
         title: 'Version history',
         onClick: handleViewPublish,
-        icon: IconFont.UploadOutline, // TODO(ariel): update the icon when its available
+        icon: IconFont.History,
         disabled: () => {
           if (versions.length > 1) {
             return false

--- a/src/flows/context/version.publish.tsx
+++ b/src/flows/context/version.publish.tsx
@@ -27,6 +27,7 @@ import {
   publishNotebookFailed,
   publishNotebookSuccessful,
 } from 'src/shared/copy/notifications'
+import {event} from 'src/cloud/utils/reporting'
 
 // Types
 import {RemoteDataState} from 'src/types'
@@ -94,6 +95,7 @@ export const VersionPublishProvider: FC = ({children}) => {
 
   const handlePublish = useCallback(async () => {
     try {
+      event('publish_notebook')
       const response = await postNotebooksVersion({id: flow.id})
 
       if (response.status !== 200) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1187,10 +1187,10 @@
     gud "^1.0.0"
     warning "^4.0.3"
 
-"@influxdata/clockface@^3.4.1":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-3.4.1.tgz#a450241f75b86e36b6626283ee1085f237725137"
-  integrity sha512-CY7KLvxpFHLlceaSsK1u5BEZZd18YcfMV3M9j42S/DUJDHLF9jlupo5rrpUKFotgRwzMLULTVlORpxo7SuDq5w==
+"@influxdata/clockface@^3.5.2":
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-3.5.2.tgz#e019f39b3e0807b5cceb5bd4c5aa4a65f84d4ed5"
+  integrity sha512-Mr2nwZkHayp1ZTu3yAKKtPHtaH8E/kBwOxP5rFKiIUJsytlNx+4i1/LoEmapewpa8n8DRONTvCD18IhQ3ab0vw==
 
 "@influxdata/flux-lsp-browser@^0.8.5":
   version "0.8.5"


### PR DESCRIPTION
By bumping the clockface library and updating the icon to match the design, this _should_ mark the feature as complete

<img width="314" alt="Screen Shot 2022-03-14 at 9 46 56 AM" src="https://user-images.githubusercontent.com/19984220/158220492-16b21fee-ec9f-4a2c-93bd-7e8d3ed63af0.png">
