### PR TITLE
chore: remove the feature flag for error thresholds

### DIFF
--- a/src/flows/pipes/Visualization/Controls.tsx
+++ b/src/flows/pipes/Visualization/Controls.tsx
@@ -16,7 +16,6 @@ import {event} from 'src/cloud/utils/reporting'
 import ErrorThresholds from 'src/flows/pipes/Visualization/ErrorThresholds/ErrorThresholds'
 import {SidebarContext} from 'src/flows/context/sidebar'
 import {PipeContext, PipeProvider} from 'src/flows/context/pipe'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
 
 const WrappedViewOptions: FC = () => {
@@ -36,7 +35,7 @@ const WrappedViewOptions: FC = () => {
 
   return (
     <ErrorBoundary>
-      {isFlagEnabled('flowErrorThresholds') && <ErrorThresholds />}
+      <ErrorThresholds />
       <ViewOptions
         properties={data.properties}
         results={results.parsed}

--- a/src/flows/pipes/Visualization/view.tsx
+++ b/src/flows/pipes/Visualization/view.tsx
@@ -173,10 +173,7 @@ const Visualization: FC<PipeProp> = ({Context}) => {
     )
   }
 
-  if (
-    isFlagEnabled('flowErrorThresholds') &&
-    data?.errorThresholds?.length > 0
-  ) {
+  if (data?.errorThresholds?.length > 0) {
     const fieldIndices = {}
 
     data?.errorThresholds.forEach(threshold => {


### PR DESCRIPTION
This PR is follow-up on the error threshold work for notebooks. We've got eventing to track the feature usage and it's been stable for a while. Removing the feature flag and committing to the feature