### PR TITLE
test(multi-account): add remove account from org

### DIFF
--- a/cypress/e2e/cloud/userAccounts.test.ts
+++ b/cypress/e2e/cloud/userAccounts.test.ts
@@ -2,6 +2,8 @@ import {Organization} from '../../../src/types'
 
 import * as Wrapper from '../../../src/utils/wrappers'
 
+const redirectStub = cy.stub(Wrapper, 'redirect')
+
 const setup = (cy, numAccounts: number) => {
   cy.flush().then(() => {
     cy.signin().then(() => {
@@ -108,9 +110,7 @@ describe('Account Page tests', () => {
   })
 
   describe('User with one account', () => {
-    let redirectStub
     beforeEach(() => {
-      redirectStub = cy.stub(Wrapper, 'redirect')
       setup(cy, 1)
     })
 

--- a/cypress/e2e/cloud/userAccounts.test.ts
+++ b/cypress/e2e/cloud/userAccounts.test.ts
@@ -1,6 +1,6 @@
 import {Organization} from '../../../src/types'
 
-const doSetup = (cy, numAccounts: number) => {
+const setup = (cy, numAccounts: number) => {
   cy.flush().then(() => {
     cy.signin().then(() => {
       cy.get('@org').then(({id}: Organization) => {
@@ -24,7 +24,7 @@ const prefix = 'accountSwitch-toggle-choice'
 
 describe('Account Page tests', () => {
   describe('User with 4 accounts', () => {
-    beforeEach(() => doSetup(cy, 4))
+    beforeEach(() => setup(cy, 4))
 
     it('can change the default account', () => {
       const defaultMarker = '(default)'
@@ -106,7 +106,7 @@ describe('Account Page tests', () => {
   })
 
   describe('User with one account', () => {
-    beforeEach(() => doSetup(cy, 1))
+    beforeEach(() => setup(cy, 1))
 
     it('can get to the page and get the accounts, and the switch button is NOT showing', () => {
       cy.getByTestID('account-settings--header').should('be.visible')
@@ -115,10 +115,40 @@ describe('Account Page tests', () => {
         .should('have.length.greaterThan', 0)
       cy.getByTestID('user-account-switch-btn').should('not.exist')
     })
+
+    it('can delete the account from the organization', () => {
+      cy.get('@org').then(({id}: Organization) => {
+        cy.visit(`/orgs/${id}/about`)
+        cy.getByTestID('delete-org--button')
+          .should('be.visible')
+          .click()
+
+        cy.getByTestID('overlay--container')
+          .should('be.visible')
+          .then($overlayContainer => {
+            cy.wrap($overlayContainer).contains('Delete Organization')
+
+            cy.wrap($overlayContainer)
+              .getByTestID('agree-terms--input')
+              .should('be.visible')
+              .click()
+
+            cy.wrap($overlayContainer)
+              .getByTestID('delete-organization--button')
+              .should('be.visible')
+              .click()
+          })
+
+        cy.location('href').should(
+          'eq',
+          'https://www.influxdata.com/free_cancel/'
+        )
+      })
+    })
   })
 
   describe('User with two accounts', () => {
-    beforeEach(() => doSetup(cy, 2))
+    beforeEach(() => setup(cy, 2))
 
     it('can get to the account page and rename the active account', () => {
       // first ensure that we get 2 accounts from Quartz

--- a/cypress/e2e/cloud/userAccounts.test.ts
+++ b/cypress/e2e/cloud/userAccounts.test.ts
@@ -2,8 +2,6 @@ import {Organization} from '../../../src/types'
 
 import * as Wrapper from '../../../src/utils/wrappers'
 
-const redirectStub = cy.stub(Wrapper, 'redirect')
-
 const setup = (cy, numAccounts: number) => {
   cy.flush().then(() => {
     cy.signin().then(() => {
@@ -123,6 +121,7 @@ describe('Account Page tests', () => {
     })
 
     it('can delete the account from the organization', () => {
+      const redirectStub = cy.stub(Wrapper, 'redirect')
       cy.get('@org').then(({id}: Organization) => {
         cy.visit(`/orgs/${id}/about`)
 

--- a/cypress/e2e/cloud/userAccounts.test.ts
+++ b/cypress/e2e/cloud/userAccounts.test.ts
@@ -106,7 +106,11 @@ describe('Account Page tests', () => {
   })
 
   describe('User with one account', () => {
-    beforeEach(() => setup(cy, 1))
+    let assignStub
+    beforeEach(() => {
+      assignStub = cy.stub(window.location, 'assign')
+      setup(cy, 1)
+    })
 
     it('can get to the page and get the accounts, and the switch button is NOT showing', () => {
       cy.getByTestID('account-settings--header').should('be.visible')
@@ -119,6 +123,7 @@ describe('Account Page tests', () => {
     it('can delete the account from the organization', () => {
       cy.get('@org').then(({id}: Organization) => {
         cy.visit(`/orgs/${id}/about`)
+
         cy.getByTestID('delete-org--button')
           .should('be.visible')
           .click()
@@ -139,8 +144,8 @@ describe('Account Page tests', () => {
               .click()
           })
 
-        cy.location('href').should(
-          'eq',
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        expect(assignStub).to.be.calledWith(
           'https://www.influxdata.com/free_cancel/'
         )
       })

--- a/cypress/e2e/cloud/userAccounts.test.ts
+++ b/cypress/e2e/cloud/userAccounts.test.ts
@@ -122,7 +122,7 @@ describe('Account Page tests', () => {
       cy.getByTestID('user-account-switch-btn').should('not.exist')
     })
 
-    it.only('can delete the account from the organization', () => {
+    it('can delete the account from the organization', () => {
       cy.get('@org').then(({id}: Organization) => {
         cy.visit(`/orgs/${id}/about`)
 

--- a/cypress/e2e/cloud/userAccounts.test.ts
+++ b/cypress/e2e/cloud/userAccounts.test.ts
@@ -144,12 +144,13 @@ describe('Account Page tests', () => {
               .getByTestID('delete-organization--button')
               .should('be.visible')
               .click()
+              .then(() => {
+                // eslint-disable-next-line @typescript-eslint/unbound-method
+                expect(redirectStub).to.be.calledWith(
+                  'https://www.influxdata.com/free_cancel/'
+                )
+              })
           })
-
-        // eslint-disable-next-line @typescript-eslint/unbound-method
-        expect(redirectStub).to.be.calledWith(
-          'https://www.influxdata.com/free_cancel/'
-        )
       })
     })
   })

--- a/cypress/e2e/cloud/userAccounts.test.ts
+++ b/cypress/e2e/cloud/userAccounts.test.ts
@@ -1,5 +1,7 @@
 import {Organization} from '../../../src/types'
 
+import * as Wrapper from '../../../src/utils/wrappers'
+
 const setup = (cy, numAccounts: number) => {
   cy.flush().then(() => {
     cy.signin().then(() => {
@@ -106,9 +108,9 @@ describe('Account Page tests', () => {
   })
 
   describe('User with one account', () => {
-    let assignStub
+    let redirectStub
     beforeEach(() => {
-      assignStub = cy.stub(window.location, 'assign')
+      redirectStub = cy.stub(Wrapper, 'redirect')
       setup(cy, 1)
     })
 
@@ -120,7 +122,7 @@ describe('Account Page tests', () => {
       cy.getByTestID('user-account-switch-btn').should('not.exist')
     })
 
-    it('can delete the account from the organization', () => {
+    it.only('can delete the account from the organization', () => {
       cy.get('@org').then(({id}: Organization) => {
         cy.visit(`/orgs/${id}/about`)
 
@@ -145,7 +147,7 @@ describe('Account Page tests', () => {
           })
 
         // eslint-disable-next-line @typescript-eslint/unbound-method
-        expect(assignStub).to.be.calledWith(
+        expect(redirectStub).to.be.calledWith(
           'https://www.influxdata.com/free_cancel/'
         )
       })

--- a/cypress/e2e/cloud/userAccounts.test.ts
+++ b/cypress/e2e/cloud/userAccounts.test.ts
@@ -1,6 +1,6 @@
 import {Organization} from '../../../src/types'
 
-import * as Wrapper from '../../../src/utils/wrappers'
+import {redirect} from '../../../src/utils/wrappers'
 
 const setup = (cy, numAccounts: number) => {
   cy.flush().then(() => {
@@ -14,6 +14,7 @@ const setup = (cy, numAccounts: number) => {
             accountType: 'free',
             numAccounts,
           }).then(() => {
+            redirect = cy.stub()
             cy.visit(`/orgs/${id}/accounts/settings`)
           })
         })
@@ -121,7 +122,6 @@ describe('Account Page tests', () => {
     })
 
     it('can delete the account from the organization', () => {
-      const redirectStub = cy.stub(Wrapper, 'redirect')
       cy.get('@org').then(({id}: Organization) => {
         cy.visit(`/orgs/${id}/about`)
 
@@ -145,7 +145,7 @@ describe('Account Page tests', () => {
               .click()
               .then(() => {
                 // eslint-disable-next-line @typescript-eslint/unbound-method
-                expect(redirectStub).to.be.calledWith(
+                expect(redirect).to.be.calledWith(
                   'https://www.influxdata.com/free_cancel/'
                 )
               })

--- a/docker/Dockerfile.cypress
+++ b/docker/Dockerfile.cypress
@@ -16,6 +16,7 @@ COPY ./src/timeMachine/constants ./src/timeMachine/constants
 COPY ./src/shared/constants/fluxFunctions.ts ./src/shared/constants/fluxFunctions.ts
 COPY ./src/shared/actions/flags.ts ./src/shared/actions/flags.ts
 COPY ./src/utils/datetime/constants.ts ./src/utils/datetime/constants.ts
+COPY ./src/utils/wrappers.ts ./src/utils/wrappers.ts
 
 ENTRYPOINT []
 CMD []

--- a/src/organizations/components/DeleteOrgOverlay.tsx
+++ b/src/organizations/components/DeleteOrgOverlay.tsx
@@ -105,9 +105,9 @@ const DeleteOrgOverlay: FC = () => {
         throw new Error(resp.data.message)
       }
       if (isFlagEnabled('trackCancellations')) {
-        window.location.href = getRedirectLocation()
+        window.location.assign(getRedirectLocation())
       } else {
-        window.location.href = `https://www.influxdata.com/free_cancel/`
+        window.location.assign('https://www.influxdata.com/free_cancel/')
       }
     } catch {
       dispatch(notify(accountSelfDeletionFailed()))

--- a/src/organizations/components/DeleteOrgOverlay.tsx
+++ b/src/organizations/components/DeleteOrgOverlay.tsx
@@ -27,6 +27,7 @@ import {accountSelfDeletionFailed} from 'src/shared/copy/notifications'
 import DeleteOrgReasonsForm from 'src/organizations/components/DeleteOrgReasonsForm'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {event} from 'src/cloud/utils/reporting'
+import {redirect} from 'src/utils/wrappers'
 
 // Selectors
 import {
@@ -105,9 +106,9 @@ const DeleteOrgOverlay: FC = () => {
         throw new Error(resp.data.message)
       }
       if (isFlagEnabled('trackCancellations')) {
-        window.location.assign(getRedirectLocation())
+        redirect(getRedirectLocation())
       } else {
-        window.location.assign('https://www.influxdata.com/free_cancel/')
+        redirect('https://www.influxdata.com/free_cancel/')
       }
     } catch {
       dispatch(notify(accountSelfDeletionFailed()))

--- a/src/organizations/components/DeleteOrgReasonsForm.tsx
+++ b/src/organizations/components/DeleteOrgReasonsForm.tsx
@@ -46,7 +46,7 @@ function DeleteOrgReasonsForm() {
             <Dropdown.Button
               active={active}
               onClick={onClick}
-              testID="variable-type-dropdown--button"
+              testID="cancellation--primary-reason"
             >
               {VariableItems[reason]}
             </Dropdown.Button>

--- a/src/utils/wrappers.ts
+++ b/src/utils/wrappers.ts
@@ -9,5 +9,5 @@ export function getDeep<T = any>(
 }
 
 export const redirect = (location: string) => {
-   window.location.assign(location)
+  window.location.assign(location)
 }

--- a/src/utils/wrappers.ts
+++ b/src/utils/wrappers.ts
@@ -7,3 +7,7 @@ export function getDeep<T = any>(
 ): T {
   return get<T>(obj, path, fallback)
 }
+
+export const redirect = (location: string) => {
+   window.location.assign(location)
+}


### PR DESCRIPTION
Adds a test for removing an account from an organization

This is identical to https://github.com/influxdata/ui/pull/4072, but that branch got closed and deleted when I renamed the branch.
