### PR TITLE
chore: firstMile text tweaks

### DIFF
--- a/src/homepageExperience/components/steps/ExecuteAggregateQuery.tsx
+++ b/src/homepageExperience/components/steps/ExecuteAggregateQuery.tsx
@@ -1,8 +1,13 @@
 import React from 'react'
 import CodeSnippet from 'src/shared/components/CodeSnippet'
 
-export const ExecuteAggregateQuery = () => {
-  const codeSnippet = `query_api = client.query_api()
+import {SafeBlankLink} from 'src/utils/SafeBlankLink'
+
+const fromBucketSnippet = `from(bucket: “my-bucket”)
+  |> range(start: -10m) # find data points in last 10 minutes
+  |> mean()`
+
+const codeSnippet = `query_api = client.query_api()
 
 query = "from(bucket: \\"bucket1\\") |> range(start: -10m) |> mean()"
 tables = query_api.query(query, org=org)
@@ -10,12 +15,31 @@ tables = query_api.query(query, org=org)
 for table in tables:
     for record in table.records:
         print(record)`
+
+export const ExecuteAggregateQuery = () => {
   return (
     <>
       <h1>Execute an Aggregate Query</h1>
-      <p>Paste the following code after the prompt (>>>) and press Enter.</p>
+      <p>
+        An{' '}
+        <SafeBlankLink href="https://docs.influxdata.com/flux/v0.x/function-types/#aggregates">
+          aggregate
+        </SafeBlankLink>{' '}
+        function is a powerful method for returning combined, summarized data
+        about a set of time-series data.
+      </p>
+      <CodeSnippet text={fromBucketSnippet} showCopyControl={false} />
+      <p>
+        In this example, we use the mean() function to calculate the average of
+        data points in last 10 minutes.
+        <br />
+        <br />
+        Run the following:
+      </p>
       <CodeSnippet text={codeSnippet} />
-      <p>This will return the mean of the five values. </p>
+      <p style={{marginTop: '20px'}}>
+        This will return the mean of the five values. ( (0+1+2+3+4) / 5 = 2 )
+      </p>
     </>
   )
 }

--- a/src/homepageExperience/components/steps/ExecuteQuery.tsx
+++ b/src/homepageExperience/components/steps/ExecuteQuery.tsx
@@ -1,8 +1,10 @@
 import React from 'react'
 import CodeSnippet from 'src/shared/components/CodeSnippet'
 
-export const ExecuteQuery = () => {
-  const query = `query_api = client.query_api()
+const fromBucketSnippet = `from(bucket: “my-bucket”)
+  |> range(start: -10m)`
+
+const query = `query_api = client.query_api()
 
 query = "from(bucket: \\"bucket1\\") |> range(start: -10m) |> mean()"
 tables = query_api.query(query, org=org)
@@ -11,13 +13,28 @@ for table in tables:
     for record in table.records:
         print(record)`
 
+export const ExecuteQuery = () => {
   return (
     <>
       <h1>Execute a Flux Query</h1>
       <p>
-        Now let’s query the database for the data points we just wrote. We will
-        use a short Flux query embedded in our Python. Paste the following code
-        after the prompt (>>> ) and press Enter
+        Now let’s query the numbers we wrote into the database. We use the Flux
+        scripting language to query data. Flux is designed for querying,
+        analyzing, and acting on data.
+        <br />
+        <br />
+        Here is what a simple Flux query looks like on its own:
+      </p>
+      <CodeSnippet text={fromBucketSnippet} showCopyControl={false} />
+      <p>
+        In this query, we are looking for data points within last 10 minutes
+        with field key of “field1”.
+        <br />
+        <br />
+        Let’s use that Flux query in our Python code!
+        <br />
+        <br />
+        Run the following:
       </p>
       <CodeSnippet text={query} />
     </>

--- a/src/homepageExperience/components/steps/InstallDependencies.tsx
+++ b/src/homepageExperience/components/steps/InstallDependencies.tsx
@@ -12,6 +12,9 @@ export class InstallDependencies extends PureComponent {
           the command below in your terminal.
         </p>
         <CodeSnippet text="pip3 install influxdb-client" onCopy={null} />
+        <p style={{fontStyle: 'italic'}}>
+          You’ll need to have Python 3 installed.
+        </p>
       </>
     )
   }

--- a/src/homepageExperience/components/steps/WriteData.tsx
+++ b/src/homepageExperience/components/steps/WriteData.tsx
@@ -19,10 +19,7 @@ import {getOrg} from 'src/organizations/selectors'
 import DataListening from 'src/homepageExperience/components/DataListening'
 import {getBuckets} from 'src/buckets/actions/thunks'
 
-export const WriteDataComponent = () => {
-  const org = useSelector(getOrg)
-
-  const codeSnippet = `for value in range(5):
+const codeSnippet = `for value in range(5):
     point = (
         Point("measurement1")
         .tag("tagname1", "tagvalue1")
@@ -30,6 +27,9 @@ export const WriteDataComponent = () => {
     )
     write_api.write(bucket=bucket, org=org, record=point)
     time.sleep(1)`
+
+export const WriteDataComponent = () => {
+  const org = useSelector(getOrg)
   const dispatch = useDispatch()
 
   useEffect(() => {
@@ -67,11 +67,22 @@ export const WriteDataComponent = () => {
         </Panel.Body>
       </Panel>
       <p>
-        You’re ready to write data! In this code, we define five data points and
-        write each one for InfluxDB. Paste the following code after the prompt
-        (>>>) and press Enter.
+        In this code, we define five data points and write each one for
+        InfluxDB. Run the following code in your Python shell:
       </p>
       <CodeSnippet text={codeSnippet} />
+      <p style={{marginTop: '20px'}}>
+        In the above code snippet, we define five data points and write each on
+        the InfluxDB. Each of the 5 points we write has a{' '}
+        <SafeBlankLink href="https://docs.influxdata.com/influxdb/v1.8/concepts/glossary/#field-key">
+          field
+        </SafeBlankLink>{' '}
+        and a{' '}
+        <SafeBlankLink href="https://docs.influxdata.com/influxdb/v1.8/concepts/glossary/#tag-key">
+          tag
+        </SafeBlankLink>
+        .
+      </p>
       <p style={{marginTop: '40px'}}>
         Once you write this data, you’ll begin to see the confirmation below
       </p>

--- a/src/homepageExperience/containers/HomepageContainer.tsx
+++ b/src/homepageExperience/containers/HomepageContainer.tsx
@@ -31,9 +31,13 @@ export const HomepageContainer: FC = () => {
   const pythonWizardLink = `/orgs/${org.id}/new-user-wizard/python`
   const cliPageLink = `/orgs/${org.id}/load-data/file-upload/csv`
   const telegrafPageLink = `/orgs/${org.id}/load-data/telegrafs`
+  const javaScriptNodeLink = `/orgs/${org.id}/load-data/client-libraries/javascript-node`
+  const golangLink = `/orgs/${org.id}/load-data/client-libraries/go`
+  const loadDataSourcesLink = `/orgs/${org.id}/load-data/sources`
 
   const cardStyle = {maxWidth: '250px'}
   const linkStyle = {color: InfluxColors.Grey75}
+  const moreStyle = {height: '100%'}
 
   return (
     <>
@@ -60,28 +64,31 @@ export const HomepageContainer: FC = () => {
                   </Link>
                 </ResourceCard>
                 <ResourceCard style={cardStyle}>
-                  <div className="homepage-wizard-language-tile">
-                    <h5>JavaScript/Node.js</h5>
-                    {JavascriptNodeJsIcon}
-                  </div>
+                  <Link to={javaScriptNodeLink}>
+                    <div className="homepage-wizard-language-tile">
+                      <h5>JavaScript/Node.js</h5>
+                      {JavascriptNodeJsIcon}
+                    </div>
+                  </Link>
                 </ResourceCard>
                 <ResourceCard style={cardStyle}>
-                  <div className="homepage-wizard-language-tile">
-                    <h5>Go</h5>
-                    {GoIcon}
-                  </div>
+                  <Link to={golangLink}>
+                    <div className="homepage-wizard-language-tile">
+                      <h5>Go</h5>
+                      {GoIcon}
+                    </div>
+                  </Link>
                 </ResourceCard>
                 <ResourceCard style={cardStyle}>
-                  <div
-                    className="homepage-wizard-language-tile"
-                    style={{justifyContent: 'center'}}
-                  >
-                    <span>
-                      <h5>
-                        MORE <Icon glyph={IconFont.ArrowRight_New} />
-                      </h5>
-                    </span>
-                  </div>
+                  <Link to={loadDataSourcesLink} style={moreStyle}>
+                    <div className="homepage-wizard-language-tile">
+                      <span>
+                        <h5>
+                          MORE <Icon glyph={IconFont.ArrowRight_New} />
+                        </h5>
+                      </span>
+                    </div>
+                  </Link>
                 </ResourceCard>
               </FlexBox>
               <hr style={{marginTop: '32px'}} />

--- a/src/shared/components/CodeSnippet.tsx
+++ b/src/shared/components/CodeSnippet.tsx
@@ -73,9 +73,17 @@ interface Props {
   testID?: string
   onCopy?: () => void
   type?: string
+  showCopyControl?: boolean
 }
 
-const CodeSnippet: FC<Props> = ({text, label, testID, type, onCopy}) => {
+const CodeSnippet: FC<Props> = ({
+  text,
+  label,
+  testID,
+  type,
+  onCopy,
+  showCopyControl = true,
+}) => {
   const {transform} = useContext(Context)
   const dispatch = useDispatch()
   const _text = transform(text)
@@ -107,7 +115,7 @@ const CodeSnippet: FC<Props> = ({text, label, testID, type, onCopy}) => {
         </div>
       </DapperScrollbars>
       <div className="code-snippet--footer">
-        <CopyButton text={_text} onCopy={handleCopy} />
+        {showCopyControl && <CopyButton text={_text} onCopy={handleCopy} />}
         {label && <label className="code-snippet--label">{label}</label>}
       </div>
     </div>


### PR DESCRIPTION
Closes #4100

- Updates `CodeSnippet` to take in an optional prop to hide the `Copy To Clipboard` button
- Links the homepage cards to their respective places
- Updates the firstMile copy with the text changes from feeback

![Screen Shot 2022-03-16 at 11 22 19 AM](https://user-images.githubusercontent.com/146112/158626501-cc09be86-0c5a-4d8d-a364-addb342c2472.png)
![Screen Shot 2022-03-16 at 11 22 27 AM](https://user-images.githubusercontent.com/146112/158626516-5ab9022a-43aa-4d1e-8e37-b82e5ea6b9d0.png)
![Screen Shot 2022-03-16 at 11 24 27 AM](https://user-images.githubusercontent.com/146112/158626523-b47a7d2f-27c9-420a-bb4b-871c4dce88ba.png)
![Screen Shot 2022-03-16 at 11 24 50 AM](https://user-images.githubusercontent.com/146112/158626528-ad1288da-5884-415c-829c-89d00f59fe91.png)
![Screen Shot 2022-03-16 at 11 24 53 AM](https://user-images.githubusercontent.com/146112/158626532-8ad77a2c-da4c-40fd-8584-7d344135d2ec.png)

