### PR TITLE
fix: keep navigation buttons for the firstMile in the same place

### DIFF
--- a/src/homepageExperience/components/HomepageExperience.scss
+++ b/src/homepageExperience/components/HomepageExperience.scss
@@ -12,7 +12,6 @@ $pool-fill: #00a3ff;
   padding-right: 85px;
 
   overflow-y: scroll;
-  padding-bottom: 185px;
 }
 
 .homepage-wizard-container--subway {


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/4118

Prev:

https://user-images.githubusercontent.com/18511823/158647313-02deb72f-d45f-492c-a5e1-e8aa1a0b66f3.mov

After:




https://user-images.githubusercontent.com/18511823/158647348-d9287d38-e4f5-4713-99d0-8bea3ff100ea.mov


