### PR TITLE
feat: keep draft state button accessible always

### DIFF
--- a/src/flows/components/VersionSidebar.tsx
+++ b/src/flows/components/VersionSidebar.tsx
@@ -203,14 +203,12 @@ export const VersionSidebar: FC = () => {
           thumbStartColor="gray"
         >
           <div className="version-sidebar--submenu-wrapper">
-            {hasDraft && (
-              <Button
-                icon={IconFont.ArrowLeft_New}
-                text="Back to Current Version"
-                onClick={handleClose}
-                className="version-sidebar--back-btn"
-              />
-            )}
+            <Button
+              icon={IconFont.ArrowLeft_New}
+              text="Back to Current Version"
+              onClick={handleClose}
+              className="version-sidebar--back-btn"
+            />
             <List>
               {trimmedVersions.map(version => (
                 <React.Fragment key={version.id}>

--- a/src/flows/components/header/MenuButton.tsx
+++ b/src/flows/components/header/MenuButton.tsx
@@ -198,10 +198,13 @@ const MenuButton: FC<Props> = ({handleResetShare}) => {
         onClick: handleViewPublish,
         icon: IconFont.History,
         disabled: () => {
-          if (versions.length > 1) {
-            return false
+          const [first, second] = versions
+          // accounts for the draft state
+          let versionId = first?.id
+          if (first?.id === 'draft' && second?.id) {
+            versionId = second?.id
           }
-          return versions[0]?.id === 'draft'
+          return !(versionId !== 'draft' && typeof versionId !== undefined)
         },
       },
       {title: 'divider', type: 'divider'}


### PR DESCRIPTION
Closes #4120

This PR removes the conditional rendering of the back button for the publish history so that the draft version is always accessible from the version history. It also updates the view history button to be a bit better guarded against race 

![publish-history](https://user-images.githubusercontent.com/19984220/158655546-ee7839e2-306c-4ec8-8f25-fe8758420a2f.gif)
conditions 