### PR TITLE
feat: first mile events for data collection

### DIFF
--- a/src/homepageExperience/components/steps/CreateToken.tsx
+++ b/src/homepageExperience/components/steps/CreateToken.tsx
@@ -14,6 +14,7 @@ import {getOrg} from 'src/organizations/selectors'
 
 // Helper Components
 import {SafeBlankLink} from 'src/utils/SafeBlankLink'
+import {event} from '../../../cloud/utils/reporting'
 
 type ReduxProps = ConnectedProps<typeof connector>
 
@@ -33,6 +34,13 @@ const CreateTokenComponent: FC<ReduxProps & RouteComponentProps> = ({
     }
   }
 
+  const logCopyCodeSnippet = () => {
+    event('firstMile.pythonWizard.createToken.code.copied')
+  }
+
+  const logDocsOpened = () => {
+    event('firstMile.pythonWizard.createToken.docs.opened')
+  }
   return (
     <>
       <h1>Create a Token</h1>
@@ -50,10 +58,16 @@ const CreateTokenComponent: FC<ReduxProps & RouteComponentProps> = ({
         Save your token as an environment variable; you’ll use it soon. Run this
         command in your terminal:
       </p>
-      <CodeSnippet text="export INFLUXDB_TOKEN=<your token here>" />
+      <CodeSnippet
+        text="export INFLUXDB_TOKEN=<your token here>"
+        onCopy={logCopyCodeSnippet}
+      />
       <p style={{marginTop: '46px'}}>
         You can create tokens in the future in the{' '}
-        <SafeBlankLink href={`orgs/${org.id}/load-data/tokens`}>
+        <SafeBlankLink
+          href={`orgs/${org.id}/load-data/tokens`}
+          onClick={logDocsOpened}
+        >
           Token page
         </SafeBlankLink>
         .

--- a/src/homepageExperience/components/steps/CreateToken.tsx
+++ b/src/homepageExperience/components/steps/CreateToken.tsx
@@ -14,7 +14,7 @@ import {getOrg} from 'src/organizations/selectors'
 
 // Helper Components
 import {SafeBlankLink} from 'src/utils/SafeBlankLink'
-import {event} from '../../../cloud/utils/reporting'
+import {event} from 'src/cloud/utils/reporting'
 
 type ReduxProps = ConnectedProps<typeof connector>
 

--- a/src/homepageExperience/components/steps/CreateToken.tsx
+++ b/src/homepageExperience/components/steps/CreateToken.tsx
@@ -18,6 +18,15 @@ import {event} from 'src/cloud/utils/reporting'
 
 type ReduxProps = ConnectedProps<typeof connector>
 
+// Events log handling
+const logCopyCodeSnippet = () => {
+  event('firstMile.pythonWizard.createToken.code.copied')
+}
+
+const logDocsOpened = () => {
+  event('firstMile.pythonWizard.createToken.docs.opened')
+}
+
 const CreateTokenComponent: FC<ReduxProps & RouteComponentProps> = ({
   showOverlay,
   dismissOverlay,
@@ -34,13 +43,6 @@ const CreateTokenComponent: FC<ReduxProps & RouteComponentProps> = ({
     }
   }
 
-  const logCopyCodeSnippet = () => {
-    event('firstMile.pythonWizard.createToken.code.copied')
-  }
-
-  const logDocsOpened = () => {
-    event('firstMile.pythonWizard.createToken.docs.opened')
-  }
   return (
     <>
       <h1>Create a Token</h1>

--- a/src/homepageExperience/components/steps/ExecuteAggregateQuery.tsx
+++ b/src/homepageExperience/components/steps/ExecuteAggregateQuery.tsx
@@ -17,15 +17,15 @@ for table in tables:
     for record in table.records:
         print(record)`
 
+const logCopyCodeSnippet = () => {
+  event('firstMile.pythonWizard.executeAggregateQuery.code.copied')
+}
+
+const logDocsOpened = () => {
+  event('firstMile.pythonWizard.executeAggregateQuery.docs.opened')
+}
+
 export const ExecuteAggregateQuery = () => {
-  const logCopyCodeSnippet = () => {
-    event('firstMile.pythonWizard.executeAggregateQuery.code.copied')
-  }
-
-  const logDocsOpened = () => {
-    event('firstMile.pythonWizard.executeAggregateQuery.docs.opened')
-  }
-
   return (
     <>
       <h1>Execute an Aggregate Query</h1>

--- a/src/homepageExperience/components/steps/ExecuteAggregateQuery.tsx
+++ b/src/homepageExperience/components/steps/ExecuteAggregateQuery.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import CodeSnippet from 'src/shared/components/CodeSnippet'
 
 import {SafeBlankLink} from 'src/utils/SafeBlankLink'
-import {event} from '../../../cloud/utils/reporting'
+import {event} from 'src/cloud/utils/reporting'
 
 const fromBucketSnippet = `from(bucket: “my-bucket”)
   |> range(start: -10m) # find data points in last 10 minutes

--- a/src/homepageExperience/components/steps/ExecuteAggregateQuery.tsx
+++ b/src/homepageExperience/components/steps/ExecuteAggregateQuery.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import CodeSnippet from 'src/shared/components/CodeSnippet'
 
 import {SafeBlankLink} from 'src/utils/SafeBlankLink'
+import {event} from '../../../cloud/utils/reporting'
 
 const fromBucketSnippet = `from(bucket: “my-bucket”)
   |> range(start: -10m) # find data points in last 10 minutes
@@ -17,18 +18,33 @@ for table in tables:
         print(record)`
 
 export const ExecuteAggregateQuery = () => {
+  const logCopyCodeSnippet = () => {
+    event('firstMile.pythonWizard.executeAggregateQuery.code.copied')
+  }
+
+  const logDocsOpened = () => {
+    event('firstMile.pythonWizard.executeAggregateQuery.docs.opened')
+  }
+
   return (
     <>
       <h1>Execute an Aggregate Query</h1>
       <p>
         An{' '}
-        <SafeBlankLink href="https://docs.influxdata.com/flux/v0.x/function-types/#aggregates">
+        <SafeBlankLink
+          href="https://docs.influxdata.com/flux/v0.x/function-types/#aggregates"
+          onClick={logDocsOpened}
+        >
           aggregate
         </SafeBlankLink>{' '}
         function is a powerful method for returning combined, summarized data
         about a set of time-series data.
       </p>
-      <CodeSnippet text={fromBucketSnippet} showCopyControl={false} />
+      <CodeSnippet
+        text={fromBucketSnippet}
+        showCopyControl={false}
+        onCopy={logCopyCodeSnippet}
+      />
       <p>
         In this example, we use the mean() function to calculate the average of
         data points in last 10 minutes.
@@ -36,7 +52,7 @@ export const ExecuteAggregateQuery = () => {
         <br />
         Run the following:
       </p>
-      <CodeSnippet text={codeSnippet} />
+      <CodeSnippet text={codeSnippet} onCopy={logCopyCodeSnippet} />
       <p style={{marginTop: '20px'}}>
         This will return the mean of the five values. ( (0+1+2+3+4) / 5 = 2 )
       </p>

--- a/src/homepageExperience/components/steps/ExecuteQuery.tsx
+++ b/src/homepageExperience/components/steps/ExecuteQuery.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import CodeSnippet from 'src/shared/components/CodeSnippet'
+import {event} from '../../../cloud/utils/reporting'
 
 const fromBucketSnippet = `from(bucket: “my-bucket”)
   |> range(start: -10m)`
@@ -14,6 +15,10 @@ for table in tables:
         print(record)`
 
 export const ExecuteQuery = () => {
+  const logCopyCodeSnippet = () => {
+    event('firstMile.pythonWizard.executeQuery.code.copied')
+  }
+
   return (
     <>
       <h1>Execute a Flux Query</h1>
@@ -25,7 +30,11 @@ export const ExecuteQuery = () => {
         <br />
         Here is what a simple Flux query looks like on its own:
       </p>
-      <CodeSnippet text={fromBucketSnippet} showCopyControl={false} />
+      <CodeSnippet
+        text={fromBucketSnippet}
+        showCopyControl={false}
+        onCopy={logCopyCodeSnippet}
+      />
       <p>
         In this query, we are looking for data points within last 10 minutes
         with field key of “field1”.
@@ -36,7 +45,7 @@ export const ExecuteQuery = () => {
         <br />
         Run the following:
       </p>
-      <CodeSnippet text={query} />
+      <CodeSnippet text={query} onCopy={logCopyCodeSnippet} />
     </>
   )
 }

--- a/src/homepageExperience/components/steps/ExecuteQuery.tsx
+++ b/src/homepageExperience/components/steps/ExecuteQuery.tsx
@@ -14,11 +14,11 @@ for table in tables:
     for record in table.records:
         print(record)`
 
-export const ExecuteQuery = () => {
-  const logCopyCodeSnippet = () => {
-    event('firstMile.pythonWizard.executeQuery.code.copied')
-  }
+const logCopyCodeSnippet = () => {
+  event('firstMile.pythonWizard.executeQuery.code.copied')
+}
 
+export const ExecuteQuery = () => {
   return (
     <>
       <h1>Execute a Flux Query</h1>

--- a/src/homepageExperience/components/steps/ExecuteQuery.tsx
+++ b/src/homepageExperience/components/steps/ExecuteQuery.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import CodeSnippet from 'src/shared/components/CodeSnippet'
-import {event} from '../../../cloud/utils/reporting'
+import {event} from 'src/cloud/utils/reporting'
 
 const fromBucketSnippet = `from(bucket: “my-bucket”)
   |> range(start: -10m)`

--- a/src/homepageExperience/components/steps/Finish.tsx
+++ b/src/homepageExperience/components/steps/Finish.tsx
@@ -8,7 +8,7 @@ import {
   ResourceCard,
 } from '@influxdata/clockface'
 import {InfluxDBUniversityIcon, VSCodePluginIcon} from '../HomepageIcons'
-import {event} from '../../../cloud/utils/reporting'
+import {event} from 'src/cloud/utils/reporting'
 
 export const Finish = () => {
   useEffect(() => {

--- a/src/homepageExperience/components/steps/Finish.tsx
+++ b/src/homepageExperience/components/steps/Finish.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {useEffect} from 'react'
 import {
   AlignItems,
   ComponentSize,
@@ -8,8 +8,12 @@ import {
   ResourceCard,
 } from '@influxdata/clockface'
 import {InfluxDBUniversityIcon, VSCodePluginIcon} from '../HomepageIcons'
+import {event} from '../../../cloud/utils/reporting'
 
 export const Finish = () => {
+  useEffect(() => {
+    event('firstMile.pythonWizard.finished')
+  }, [])
   return (
     <>
       <h1>Congrats!</h1>

--- a/src/homepageExperience/components/steps/InitalizeClient.tsx
+++ b/src/homepageExperience/components/steps/InitalizeClient.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import CodeSnippet from 'src/shared/components/CodeSnippet'
-import {event} from '../../../cloud/utils/reporting'
+import {event} from 'src/cloud/utils/reporting'
 
 export const InitalizeClient = () => {
   const pythonCode = `import os

--- a/src/homepageExperience/components/steps/InitalizeClient.tsx
+++ b/src/homepageExperience/components/steps/InitalizeClient.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import CodeSnippet from 'src/shared/components/CodeSnippet'
+import {event} from '../../../cloud/utils/reporting'
 
 export const InitalizeClient = () => {
   const pythonCode = `import os
@@ -15,6 +16,9 @@ url = "https://us-west-2-1.aws.cloud2.influxdata.com/"
 client = influxdb_client.InfluxDBClient(url=url, token=token, org=org)
 write_api = client.write_api(write_options=SYNCHRONOUS)`
 
+  const logCopyCodeSnippet = () => {
+    event('firstMile.pythonWizard.initializeClient.code.copied')
+  }
   return (
     <>
       <h1>Initalize Client</h1>
@@ -25,7 +29,7 @@ write_api = client.write_api(write_options=SYNCHRONOUS)`
       <p style={{marginTop: '40px'}}>
         Paste the following code after the prompt (>>>) and press Enter.
       </p>
-      <CodeSnippet text={pythonCode} />
+      <CodeSnippet text={pythonCode} onCopy={logCopyCodeSnippet} />
       <p style={{marginTop: '42px'}}>
         Here, we initialize the token, organization info, and server url that is
         needed to set up the initial connection to InfluxDB. The client

--- a/src/homepageExperience/components/steps/InitalizeClient.tsx
+++ b/src/homepageExperience/components/steps/InitalizeClient.tsx
@@ -2,6 +2,10 @@ import React from 'react'
 import CodeSnippet from 'src/shared/components/CodeSnippet'
 import {event} from 'src/cloud/utils/reporting'
 
+const logCopyCodeSnippet = () => {
+  event('firstMile.pythonWizard.initializeClient.code.copied')
+}
+
 export const InitalizeClient = () => {
   const pythonCode = `import os
 from datetime import datetime
@@ -16,9 +20,6 @@ url = "https://us-west-2-1.aws.cloud2.influxdata.com/"
 client = influxdb_client.InfluxDBClient(url=url, token=token, org=org)
 write_api = client.write_api(write_options=SYNCHRONOUS)`
 
-  const logCopyCodeSnippet = () => {
-    event('firstMile.pythonWizard.initializeClient.code.copied')
-  }
   return (
     <>
       <h1>Initalize Client</h1>

--- a/src/homepageExperience/components/steps/InstallDependencies.tsx
+++ b/src/homepageExperience/components/steps/InstallDependencies.tsx
@@ -1,7 +1,11 @@
 import React, {PureComponent} from 'react'
 import CodeSnippet from 'src/shared/components/CodeSnippet'
+import {event} from '../../../cloud/utils/reporting'
 
 export class InstallDependencies extends PureComponent {
+  private logCopyCodeSnippet = () => {
+    event('firstMile.pythonWizard.installDependencies.code.copied')
+  }
   render() {
     return (
       <>
@@ -11,7 +15,10 @@ export class InstallDependencies extends PureComponent {
           <code style={{color: '#B7B8FF'}}>influxdb-client</code> module. Run
           the command below in your terminal.
         </p>
-        <CodeSnippet text="pip3 install influxdb-client" onCopy={null} />
+        <CodeSnippet
+          text="pip3 install influxdb-client"
+          onCopy={this.logCopyCodeSnippet}
+        />
         <p style={{fontStyle: 'italic'}}>
           You’ll need to have Python 3 installed.
         </p>

--- a/src/homepageExperience/components/steps/InstallDependencies.tsx
+++ b/src/homepageExperience/components/steps/InstallDependencies.tsx
@@ -1,6 +1,6 @@
 import React, {PureComponent} from 'react'
 import CodeSnippet from 'src/shared/components/CodeSnippet'
-import {event} from '../../../cloud/utils/reporting'
+import {event} from 'src/cloud/utils/reporting'
 
 export class InstallDependencies extends PureComponent {
   private logCopyCodeSnippet = () => {

--- a/src/homepageExperience/components/steps/Overview.tsx
+++ b/src/homepageExperience/components/steps/Overview.tsx
@@ -1,6 +1,10 @@
 import React, {PureComponent} from 'react'
+import {event} from 'src/cloud/utils/reporting'
 
 export class Overview extends PureComponent {
+  private logDocsOpened = () => {
+    event('firstMile.pythonWizard.overview.docs.opened')
+  }
   render() {
     return (
       <div>
@@ -23,7 +27,14 @@ export class Overview extends PureComponent {
 
           <p style={{marginTop: '150px'}}>
             Want to just look at code? Check out the code snippets involved in
-            this guide on <a href="https://github.com/influxdata/ui">Github</a>.
+            this guide on{' '}
+            <a
+              href="https://github.com/influxdata/ui"
+              onClick={this.logDocsOpened}
+            >
+              Github
+            </a>
+            .
           </p>
         </article>
       </div>

--- a/src/homepageExperience/components/steps/Step.tsx
+++ b/src/homepageExperience/components/steps/Step.tsx
@@ -42,9 +42,9 @@ const Step = (props: StepProps) => {
             color: iconAndTextColor,
           }}
         >
-          {text.split('\n').map(function(item, key) {
+          {text.split('\n').map(function(item, index) {
             return (
-              <span key={key}>
+              <span key={`${item}-${index}`}>
                 {item}
                 <br />
               </span>

--- a/src/homepageExperience/components/steps/WriteData.tsx
+++ b/src/homepageExperience/components/steps/WriteData.tsx
@@ -18,6 +18,7 @@ import WriteDataDetailsContextProvider, {
 import {getOrg} from 'src/organizations/selectors'
 import DataListening from 'src/homepageExperience/components/DataListening'
 import {getBuckets} from 'src/buckets/actions/thunks'
+import {event} from '../../../cloud/utils/reporting'
 
 const codeSnippet = `for value in range(5):
     point = (
@@ -44,13 +45,23 @@ export const WriteDataComponent = () => {
     setSelectedBucket(bucket)
   }, [bucket])
 
+  const logCopyCodeSnippet = () => {
+    event('firstMile.pythonWizard.writeData.code.copied')
+  }
+
+  const logDocsOpened = () => {
+    event('firstMile.pythonWizard.writeData.docs.opened')
+  }
   return (
     <>
       <h1>Write Data</h1>
       <p>
         To start writing data, we need a place to our time-series store data. We
         call these{' '}
-        <SafeBlankLink href={`orgs/${org.id}/load-data/buckets`}>
+        <SafeBlankLink
+          href={`orgs/${org.id}/load-data/buckets`}
+          onClick={logDocsOpened}
+        >
           buckets.
         </SafeBlankLink>
       </p>
@@ -70,15 +81,21 @@ export const WriteDataComponent = () => {
         In this code, we define five data points and write each one for
         InfluxDB. Run the following code in your Python shell:
       </p>
-      <CodeSnippet text={codeSnippet} />
+      <CodeSnippet text={codeSnippet} onCopy={logCopyCodeSnippet} />
       <p style={{marginTop: '20px'}}>
         In the above code snippet, we define five data points and write each on
         the InfluxDB. Each of the 5 points we write has a{' '}
-        <SafeBlankLink href="https://docs.influxdata.com/influxdb/v1.8/concepts/glossary/#field-key">
+        <SafeBlankLink
+          href="https://docs.influxdata.com/influxdb/v1.8/concepts/glossary/#field-key"
+          onClick={logDocsOpened}
+        >
           field
         </SafeBlankLink>{' '}
         and a{' '}
-        <SafeBlankLink href="https://docs.influxdata.com/influxdb/v1.8/concepts/glossary/#tag-key">
+        <SafeBlankLink
+          href="https://docs.influxdata.com/influxdb/v1.8/concepts/glossary/#tag-key"
+          onClick={logDocsOpened}
+        >
           tag
         </SafeBlankLink>
         .

--- a/src/homepageExperience/components/steps/WriteData.tsx
+++ b/src/homepageExperience/components/steps/WriteData.tsx
@@ -29,6 +29,14 @@ const codeSnippet = `for value in range(5):
     write_api.write(bucket=bucket, org=org, record=point)
     time.sleep(1)`
 
+const logCopyCodeSnippet = () => {
+  event('firstMile.pythonWizard.writeData.code.copied')
+}
+
+const logDocsOpened = () => {
+  event('firstMile.pythonWizard.writeData.docs.opened')
+}
+
 export const WriteDataComponent = () => {
   const org = useSelector(getOrg)
   const dispatch = useDispatch()
@@ -45,13 +53,6 @@ export const WriteDataComponent = () => {
     setSelectedBucket(bucket)
   }, [bucket])
 
-  const logCopyCodeSnippet = () => {
-    event('firstMile.pythonWizard.writeData.code.copied')
-  }
-
-  const logDocsOpened = () => {
-    event('firstMile.pythonWizard.writeData.docs.opened')
-  }
   return (
     <>
       <h1>Write Data</h1>

--- a/src/homepageExperience/components/steps/WriteData.tsx
+++ b/src/homepageExperience/components/steps/WriteData.tsx
@@ -18,7 +18,7 @@ import WriteDataDetailsContextProvider, {
 import {getOrg} from 'src/organizations/selectors'
 import DataListening from 'src/homepageExperience/components/DataListening'
 import {getBuckets} from 'src/buckets/actions/thunks'
-import {event} from '../../../cloud/utils/reporting'
+import {event} from 'src/cloud/utils/reporting'
 
 const codeSnippet = `for value in range(5):
     point = (

--- a/src/homepageExperience/containers/HomepageContainer.scss
+++ b/src/homepageExperience/containers/HomepageContainer.scss
@@ -9,6 +9,7 @@
     margin-bottom: 30px;
   }
   align-items: center;
+  justify-content: center;
   flex-direction: column;
   height: 100%;
   cursor: pointer;

--- a/src/homepageExperience/containers/HomepageContainer.tsx
+++ b/src/homepageExperience/containers/HomepageContainer.tsx
@@ -25,6 +25,7 @@ import {
 } from 'src/homepageExperience/components/HomepageIcons'
 
 import './HomepageContainer.scss'
+import {event} from 'src/cloud/utils/reporting'
 
 export const HomepageContainer: FC = () => {
   const org = useSelector(getOrg)
@@ -34,6 +35,11 @@ export const HomepageContainer: FC = () => {
 
   const cardStyle = {maxWidth: '250px'}
   const linkStyle = {color: InfluxColors.Grey75}
+
+  // events handling
+  const logPythonEvent = () => {
+    event('firstMile.pythonWizard.clicked')
+  }
 
   return (
     <>
@@ -52,7 +58,11 @@ export const HomepageContainer: FC = () => {
                 justifyContent={JustifyContent.SpaceBetween}
               >
                 <ResourceCard style={cardStyle}>
-                  <Link to={pythonWizardLink} style={linkStyle}>
+                  <Link
+                    to={pythonWizardLink}
+                    style={linkStyle}
+                    onClick={logPythonEvent}
+                  >
                     <div className="homepage-wizard-language-tile">
                       <h5>Python</h5>
                       {PythonIcon}

--- a/src/homepageExperience/containers/HomepageContainer.tsx
+++ b/src/homepageExperience/containers/HomepageContainer.tsx
@@ -38,7 +38,7 @@ export const HomepageContainer: FC = () => {
 
   const cardStyle = {maxWidth: '250px'}
   const linkStyle = {color: InfluxColors.Grey75}
-  const moreStyle = {height: '100%'}
+  const moreStyle = {height: '100%', ...linkStyle}
 
   // events handling
   const logPythonEvent = () => {
@@ -74,7 +74,7 @@ export const HomepageContainer: FC = () => {
                   </Link>
                 </ResourceCard>
                 <ResourceCard style={cardStyle}>
-                  <Link to={javaScriptNodeLink}>
+                  <Link to={javaScriptNodeLink} style={linkStyle}>
                     <div className="homepage-wizard-language-tile">
                       <h5>JavaScript/Node.js</h5>
                       {JavascriptNodeJsIcon}
@@ -82,7 +82,7 @@ export const HomepageContainer: FC = () => {
                   </Link>
                 </ResourceCard>
                 <ResourceCard style={cardStyle}>
-                  <Link to={golangLink}>
+                  <Link to={golangLink} style={linkStyle}>
                     <div className="homepage-wizard-language-tile">
                       <h5>Go</h5>
                       {GoIcon}

--- a/src/homepageExperience/containers/HomepagePythonWizard.tsx
+++ b/src/homepageExperience/containers/HomepagePythonWizard.tsx
@@ -56,7 +56,6 @@ export class HomepagePythonWizard extends PureComponent<null, State> {
   }
 
   renderStep = () => {
-    event('firstMile.pythonWizard.currentStep')
     switch (this.state.currentStep) {
       case 1: {
         return <Overview />

--- a/src/homepageExperience/containers/HomepagePythonWizard.tsx
+++ b/src/homepageExperience/containers/HomepagePythonWizard.tsx
@@ -20,6 +20,9 @@ import {Finish} from 'src/homepageExperience/components/steps/Finish'
 import {HOMEPAGE_NAVIGATION_STEPS} from 'src/homepageExperience/utils'
 import {ExecuteAggregateQuery} from '../components/steps/ExecuteAggregateQuery'
 
+// Utils
+import {event} from 'src/cloud/utils/reporting'
+
 interface State {
   currentStep: number
 }
@@ -30,19 +33,30 @@ export class HomepagePythonWizard extends PureComponent<null, State> {
   }
 
   handleNextClick = () => {
-    this.setState({
-      currentStep: Math.min(
-        this.state.currentStep + 1,
-        HOMEPAGE_NAVIGATION_STEPS.length
-      ),
-    })
+    this.setState(
+      {
+        currentStep: Math.min(
+          this.state.currentStep + 1,
+          HOMEPAGE_NAVIGATION_STEPS.length
+        ),
+      },
+      () => {
+        event('firstMile.pythonWizard.next.clicked')
+      }
+    )
   }
 
   handlePreviousClick = () => {
-    this.setState({currentStep: Math.max(this.state.currentStep - 1, 1)})
+    this.setState(
+      {currentStep: Math.max(this.state.currentStep - 1, 1)},
+      () => {
+        event('firstMile.pythonWizard.previous.clicked')
+      }
+    )
   }
 
   renderStep = () => {
+    event('firstMile.pythonWizard.currentStep')
     switch (this.state.currentStep) {
       case 1: {
         return <Overview />

--- a/src/utils/SafeBlankLink.tsx
+++ b/src/utils/SafeBlankLink.tsx
@@ -7,7 +7,7 @@ interface Props {
 
 // The purpose of this component is to provide a safe way to open links in a new tab/window
 // that aren't vulnerable to reverse tabnabbing https://owasp.org/www-community/attacks/Reverse_Tabnabbing
-export const SafeBlankLink: FC<Props> = (props) => {
+export const SafeBlankLink: FC<Props> = props => {
   const {children} = props
   return (
     <a target="_blank" rel="noopener noreferrer" {...props}>

--- a/src/utils/SafeBlankLink.tsx
+++ b/src/utils/SafeBlankLink.tsx
@@ -7,9 +7,10 @@ interface Props {
 
 // The purpose of this component is to provide a safe way to open links in a new tab/window
 // that aren't vulnerable to reverse tabnabbing https://owasp.org/www-community/attacks/Reverse_Tabnabbing
-export const SafeBlankLink: FC<Props> = ({children, href, onClick}) => {
+export const SafeBlankLink: FC<Props> = (props) => {
+  const {children} = props
   return (
-    <a href={href} target="_blank" rel="noopener noreferrer" onClick={onClick}>
+    <a target="_blank" rel="noopener noreferrer" {...props}>
       {children}
     </a>
   )

--- a/src/utils/SafeBlankLink.tsx
+++ b/src/utils/SafeBlankLink.tsx
@@ -2,13 +2,14 @@ import React, {FC} from 'react'
 
 interface Props {
   href: string
+  onClick?: any
 }
 
 // The purpose of this component is to provide a safe way to open links in a new tab/window
 // that aren't vulnerable to reverse tabnabbing https://owasp.org/www-community/attacks/Reverse_Tabnabbing
-export const SafeBlankLink: FC<Props> = ({children, href}) => {
+export const SafeBlankLink: FC<Props> = ({children, href, onClick}) => {
   return (
-    <a href={href} target="_blank" rel="noopener noreferrer">
+    <a href={href} target="_blank" rel="noopener noreferrer" onClick={onClick}>
       {children}
     </a>
   )


### PR DESCRIPTION
Connects https://github.com/influxdata/ui/issues/3897

Current progress:

   - Track # accounts per next step selection 
   - Track the time to completion per account
   - ✅ Track % accounts complete wizard (% accounts complete setup) 
   - Track time per step so that we can see where users are getting "Stuck" 
   - ✅ Track how many times the user click the "previous" button per session 
   - ✅ Track if a user clicks the documentation link per step/screen 
   - ✅ Track if a user clicked on the copy/code snippet per step/screen; where applicable 
   - Track Upgrade Now clicks before vs after completing wizard
   - ✅ how many went to Python vs other options 
   - how many dropped off at each step 
   

<!-- Describe your proposed changes here. -->
