### PR TITLE
fix(sub): max lengths

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,5 @@
 # Changes to any file in this repo require approval from a member of the InfluxData ui-team
+
+/src/writeData/subscriptions/ @influxdata/data-acquisition
+/src/types/subscriptions.ts @influxdata/data-acquisition
 *   @influxdata/ui-team

--- a/src/writeData/subscriptions/components/BrokerForm.tsx
+++ b/src/writeData/subscriptions/components/BrokerForm.tsx
@@ -130,7 +130,6 @@ const BrokerForm: FC<Props> = ({
                           })
                         }}
                         status={status}
-                        maxLength={16}
                         testID="create-broker-form--name"
                       />
                     )}
@@ -213,7 +212,6 @@ const BrokerForm: FC<Props> = ({
                             })
                           }}
                           status={status}
-                          maxLength={16}
                           testID="create-broker-form--host"
                         />
                       )}
@@ -243,7 +241,7 @@ const BrokerForm: FC<Props> = ({
                             })
                           }}
                           status={status}
-                          maxLength={16}
+                          maxLength={5}
                           testID="create-broker-form--port"
                         />
                       )}


### PR DESCRIPTION
Quick bug fix to the Subscriptions form regarding the max length properties

Also includes a change to the CODEOWNERS file that sets the data acquisition team as owners of the Subscriptions related code in this repo