### PR TITLE
chore: add test files in public to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ junit.xml
 npm-error.log
 yarn-error.log
 
+# test files in /public used by dev frameworks
+/public/test.*
+
 # oats generated routes
 src/client/generatedRoutes.ts
 src/client/cloudPrivRoutes.ts


### PR DESCRIPTION
Simplifies various development flows by ignoring files they may be adding.