### PR TITLE
fix: auditing more events

### DIFF
--- a/src/annotations/components/annotationForm/AnnotationForm.tsx
+++ b/src/annotations/components/annotationForm/AnnotationForm.tsx
@@ -141,20 +141,25 @@ export const AnnotationForm: FC<Props> = (props: Props) => {
 
     try {
       dispatch(deleteAnnotations(editedAnnotation))
-      event(`${props.eventPrefix}.annotations.delete_annotation.success`)
+      event(`annotations.delete_annotation.success`, {
+        prefix: props.eventPrefix,
+      })
       dispatch(notify(deleteAnnotationSuccess(editedAnnotation.summary)))
       props.onClose()
     } catch (err) {
-      event(`${props.eventPrefix}.annotations.delete_annotation.failure`)
+      event(`annotations.delete_annotation.failure`, {
+        prefix: props.eventPrefix,
+      })
       dispatch(notify(deleteAnnotationFailed(err)))
     }
   }
 
   const handleCancel = () => {
     const annoMode = isEditing ? 'edit' : 'create'
-    event(
-      `${props.eventPrefix}.dashboards.annotations.${annoMode}_annotation.cancel`
-    )
+    event(`dashboards.annotations.cancel`, {
+      prefix: eventPrefix,
+      mode: annoMode,
+    })
     props.onClose()
   }
 

--- a/src/annotations/components/annotationForm/AnnotationForm.tsx
+++ b/src/annotations/components/annotationForm/AnnotationForm.tsx
@@ -157,7 +157,7 @@ export const AnnotationForm: FC<Props> = (props: Props) => {
   const handleCancel = () => {
     const annoMode = isEditing ? 'edit' : 'create'
     event(`dashboards.annotations.cancel`, {
-      prefix: eventPrefix,
+      prefix: props.eventPrefix,
       mode: annoMode,
     })
     props.onClose()

--- a/src/dataExplorer/components/SaveAsCellForm.tsx
+++ b/src/dataExplorer/components/SaveAsCellForm.tsx
@@ -208,17 +208,13 @@ class SaveAsCellForm extends PureComponent<Props, State> {
         )
       })
       this.props.setActiveTimeMachine('de', initialStateHelper())
-      event(
-        `data_explorer.${normalizeEventName(
-          chartTypeName(view?.properties?.type)
-        )}.save.as_dashboard_cell.success`
-      )
+      event(`data_explorer.save.as_dashboard_cell.success`, {
+        which: normalizeEventName(chartTypeName(view?.properties?.type)),
+      })
     } catch (error) {
-      event(
-        `data_explorer.${normalizeEventName(
-          chartTypeName(view?.properties?.type)
-        )}.save.as_dashboard_cell.failure`
-      )
+      event(`data_explorer.save.as_dashboard_cell.failure`, {
+        which: normalizeEventName(chartTypeName(view?.properties?.type)),
+      })
       console.error(error)
       dismiss()
     } finally {

--- a/src/dataLoaders/actions/dataLoaders.ts
+++ b/src/dataLoaders/actions/dataLoaders.ts
@@ -420,10 +420,10 @@ export const createOrUpdateTelegrafConfigAsync = () => async (
 
     dispatch(editTelegraf(normTelegraf))
     dispatch(setTelegrafConfigID(telegrafConfigID))
-    event(
-      `telegraf.config.${normalizeEventName(telegrafConfigName)}.edit.success`,
-      {id: telegraf?.id}
-    )
+    event(`telegraf.config.edit.success`, {
+      id: telegraf?.id,
+      name: normalizeEventName(telegrafConfigName),
+    })
     return
   }
 
@@ -578,13 +578,15 @@ const createTelegraf = async (dispatch, getState: GetState, plugins) => {
     dispatch(setTelegrafConfigID(tc.id))
     dispatch(addTelegraf(normTelegraf))
     dispatch(notify(TelegrafConfigCreationSuccess))
-    event(`telegraf.config.${normalizeEventName(configName)}.create.success`, {
+    event(`telegraf.config.create.success`, {
       id: tc.id,
       bucket: bucketName,
+      name: normalizeEventName(configName),
     })
   } catch (error) {
-    event(`telegraf.config.${normalizeEventName(configName)}.create.failure`, {
+    event(`telegraf.config.create.failure`, {
       bucket: bucketName,
+      name: normalizeEventName(configName),
     })
     console.error(error.message)
     dispatch(notify(TelegrafConfigCreationError))

--- a/src/shared/components/cells/Cell.tsx
+++ b/src/shared/components/cells/Cell.tsx
@@ -55,11 +55,9 @@ class CellComponent extends Component<Props, State> {
   public componentDidMount() {
     const {view} = this.props
     if (view) {
-      event(
-        `dashboard.cell.view.${normalizeEventName(
-          chartTypeName(view?.properties?.type)
-        )}`
-      )
+      event(`dashboard.cell.view`, {
+        type: normalizeEventName(chartTypeName(view?.properties?.type)),
+      })
     }
   }
 

--- a/src/templates/components/CommunityTemplateInstallOverlay.test.tsx
+++ b/src/templates/components/CommunityTemplateInstallOverlay.test.tsx
@@ -151,7 +151,7 @@ describe('the Community Templates Install Overlay', () => {
 
       const [, , installEventCallArguments] = mocked(event).mock.calls
       const [eventName2] = installEventCallArguments
-      expect(eventName2).toBe('community_template.fn-template.install.failure')
+      expect(eventName2).toBe('community_template.install.failure')
 
       const [notifyCallArguments] = mocked(notify).mock.calls
       const [notifyMessage] = notifyCallArguments
@@ -225,7 +225,7 @@ describe('the Community Templates Install Overlay', () => {
 
       const [, , , ctInstallEventCallArguments] = mocked(event).mock.calls
       const [eventName4] = ctInstallEventCallArguments
-      expect(eventName4).toBe('community_template.fn-template.install.success')
+      expect(eventName4).toBe('community_template.install.success')
     })
   })
 })

--- a/src/templates/components/CommunityTemplateInstallOverlay.tsx
+++ b/src/templates/components/CommunityTemplateInstallOverlay.tsx
@@ -159,7 +159,7 @@ class CommunityTemplateInstallOverlayUnconnected extends PureComponent<Props> {
     } catch (err) {
       event(`community_template.install.failure`, {
         templateUrl,
-        name: normalizeEventName(templateDetails.name),
+        name: normalizeEventName(templateName),
       })
       this.props.notify(communityTemplateRenameFailed())
     } finally {

--- a/src/templates/components/CommunityTemplateInstallOverlay.tsx
+++ b/src/templates/components/CommunityTemplateInstallOverlay.tsx
@@ -152,19 +152,15 @@ class CommunityTemplateInstallOverlayUnconnected extends PureComponent<Props> {
 
       this.props.getBuckets()
       this.props.notify(communityTemplateInstallSucceeded(templateName))
-      event(
-        `community_template.${normalizeEventName(
-          templateDetails.name
-        )}.install.success`,
-        {templateUrl}
-      )
+      event(`community_template.install.success`, {
+        templateUrl,
+        name: normalizeEventName(templateDetails.name),
+      })
     } catch (err) {
-      event(
-        `community_template.${normalizeEventName(
-          templateName
-        )}.install.failure`,
-        {templateUrl}
-      )
+      event(`community_template.install.failure`, {
+        templateUrl,
+        name: normalizeEventName(templateDetails.name),
+      })
       this.props.notify(communityTemplateRenameFailed())
     } finally {
       this.props.fetchAndSetStacks(this.props.org.id)

--- a/src/visualization/utils/annotationUtils.ts
+++ b/src/visualization/utils/annotationUtils.ts
@@ -43,10 +43,16 @@ const makeCreateMethod = (
           },
         ])
       )
-      event(`${eventPrefix}.annotations.create_${type}_annotation.create`)
+      event(`annotations.create_annotation.create`, {
+        prefix: eventPrefix,
+        type,
+      })
     } catch (err) {
       dispatch(notify(createAnnotationFailed(getErrorMessage(err))))
-      event(`${eventPrefix}.annotations.create_${type}_annotation.failure`)
+      event(`annotations.create_annotation.failure`, {
+        prefix: eventPrefix,
+        type,
+      })
     }
   }
 
@@ -63,7 +69,7 @@ const makeAnnotationClickListener = (
   const createAnnotation = makeCreateMethod(dispatch, cellID, eventPrefix)
 
   const singleClickHandler = (plotInteraction: InteractionHandlerArguments) => {
-    event(`${eventPrefix}.annotations.create_annotation.show_overlay`)
+    event(`annotations.create_annotation.show_overlay`, {prefix: eventPrefix})
 
     dispatch(
       showOverlay(
@@ -92,7 +98,9 @@ const makeAnnotationRangeListener = (
   const createAnnotation = makeCreateMethod(dispatch, cellID, eventPrefix)
 
   const rangeHandler = (start: number | string, end: number | string) => {
-    event(`${eventPrefix}.annotations.create_range_annotation.show_overlay`)
+    event(`annotations.create_range_annotation.show_overlay`, {
+      prefix: eventPrefix,
+    })
     dispatch(
       showOverlay(
         'add-annotation',
@@ -136,7 +144,9 @@ const makeAnnotationClickHandler = (
       annotation => annotation.id === id
     )
     if (annotationToEdit) {
-      event(`${eventPrefix}.annotations.edit_annotation.show_overlay`)
+      event(`annotations.edit_annotation.show_overlay`, {
+        prefix: eventPrefix,
+      })
       dispatch(
         showOverlay(
           'edit-annotation',


### PR DESCRIPTION
these events were blowing up our event cardinality by having improperly formatted event names (embedding segmentation keys into the event name). too much of that and our eventing gets turned off, so i cleaned them up