### PR TITLE
fix: allow StaticLegend to work with Notebooks pipe context

### DIFF
--- a/cypress/fixtures/routes.json
+++ b/cypress/fixtures/routes.json
@@ -6,6 +6,7 @@
   "endpoints": "/endpoints",
   "explorer": "/data-explorer",
   "flows": "/flows",
+  "notebooks": "/notebooks",
   "orgs": "/orgs",
   "rules": "/rules",
   "sources": "/load-data/sources",

--- a/src/visualization/components/View.test.tsx
+++ b/src/visualization/components/View.test.tsx
@@ -67,6 +67,19 @@ jest.doMock('src/visualization/contextLoader', () => {
   }
 })
 
+jest.mock('src/flows/index', () => {
+  return {
+    PROJECT_NAME: 'NoteBook',
+    DEFAULT_PROJECT_NAME: 'Untitled Notebook',
+  }
+})
+
+jest.mock('src/flows/templates/index', () => {
+  return {
+    TEMPLATES: {},
+  }
+})
+
 import {View, SUPPORTED_VISUALIZATIONS} from 'src/visualization'
 
 const setup = properties => {

--- a/src/visualization/utils/useStaticLegend.ts
+++ b/src/visualization/utils/useStaticLegend.ts
@@ -91,7 +91,6 @@ export const useStaticLegend = (properties): StaticLegendConfig => {
   if (id) {
     updateStaticLegendProperties = (updatedProperties: StaticLegendAPI) =>
       update({
-        ...data,
         properties: {
           ...notebookViewProperties,
           staticLegend: {...notebookStaticLegend, ...updatedProperties},

--- a/src/visualization/utils/useStaticLegend.ts
+++ b/src/visualization/utils/useStaticLegend.ts
@@ -1,6 +1,9 @@
 // Libraries
-import {useMemo, useCallback} from 'react'
+import {useMemo, useContext, useCallback} from 'react'
 import {useDispatch, useSelector} from 'react-redux'
+
+// Context
+import {PipeContext} from 'src/flows/context/pipe'
 
 // Actions
 import {setStaticLegend} from 'src/timeMachine/actions'
@@ -66,9 +69,11 @@ const convertShowToHide = (showState: boolean): boolean => !showState
 const eventPrefix = 'visualization.customize.staticlegend'
 
 export const useStaticLegend = (properties): StaticLegendConfig => {
+  const {id, data, update} = useContext(PipeContext)
+
   const {isViewingVisOptions} = useSelector(getActiveTimeMachine)
   const dispatch = useDispatch()
-  const update = useCallback(
+  const timeMachineUpdate = useCallback(
     (staticLegend: StaticLegendAPI) => {
       dispatch(
         setStaticLegend({
@@ -79,6 +84,21 @@ export const useStaticLegend = (properties): StaticLegendConfig => {
     },
     [dispatch, properties.staticLegend]
   )
+
+  let updateStaticLegendProperties
+  if (id) {
+    updateStaticLegendProperties = (staticLegend: StaticLegendAPI) =>
+      update({
+        ...data,
+        properties: {
+          ...data.properties,
+          staticLegend: {...data.properties?.staticLegend, ...staticLegend},
+        },
+      })
+  } else {
+    updateStaticLegendProperties = timeMachineUpdate
+  }
+
   return useMemo(() => {
     const {
       legendColorizeRows = LEGEND_COLORIZE_ROWS_DEFAULT,
@@ -132,7 +152,7 @@ export const useStaticLegend = (properties): StaticLegendConfig => {
         validThreshold = LEGEND_ORIENTATION_THRESHOLD_VERTICAL
       }
 
-      update({
+      updateStaticLegendProperties({
         colorizeRows: legendColorizeRows,
         opacity: validOpacity,
         orientationThreshold: validThreshold,
@@ -199,11 +219,11 @@ export const useStaticLegend = (properties): StaticLegendConfig => {
             updatedHeightRatio,
           })
 
-          update({
+          updateStaticLegendProperties({
             heightRatio: updatedHeightRatio,
           })
         }
       },
     }
-  }, [properties, isViewingVisOptions, update])
+  }, [properties, isViewingVisOptions, updateStaticLegendProperties])
 }

--- a/src/visualization/utils/useStaticLegend.ts
+++ b/src/visualization/utils/useStaticLegend.ts
@@ -86,13 +86,15 @@ export const useStaticLegend = (properties): StaticLegendConfig => {
   )
 
   let updateStaticLegendProperties
+  const notebookViewProperties = data?.properties || {}
+  const notebookStaticLegend = notebookViewProperties.staticLegend || {}
   if (id) {
-    updateStaticLegendProperties = (staticLegend: StaticLegendAPI) =>
+    updateStaticLegendProperties = (updatedProperties: StaticLegendAPI) =>
       update({
         ...data,
         properties: {
-          ...data.properties,
-          staticLegend: {...data.properties?.staticLegend, ...staticLegend},
+          ...notebookViewProperties,
+          staticLegend: {...notebookStaticLegend, ...updatedProperties},
         },
       })
   } else {


### PR DESCRIPTION
Closes #3962 

Static Legend now selects the correct context, either Notebooks or Time Machine, and does its magic in auto calculating the initial height for the size of the legend box.


https://user-images.githubusercontent.com/10736577/158919514-a808583d-f3ca-4bbb-8e93-5392e3ffbc39.mp4


