### PR TITLE
fix: remove aggregate function from the Execute query page (first mile)

### DIFF
--- a/src/homepageExperience/components/steps/ExecuteQuery.tsx
+++ b/src/homepageExperience/components/steps/ExecuteQuery.tsx
@@ -6,7 +6,7 @@ const fromBucketSnippet = `from(bucket: “my-bucket”)
 
 const query = `query_api = client.query_api()
 
-query = "from(bucket: \\"bucket1\\") |> range(start: -10m)"
+query = "from(bucket: \\"bucket1\\") |> range(start: -10m) |> filter(fn: (r) => r._measurement == "measurement1")"
 tables = query_api.query(query, org=org)
 
 for table in tables:

--- a/src/homepageExperience/components/steps/ExecuteQuery.tsx
+++ b/src/homepageExperience/components/steps/ExecuteQuery.tsx
@@ -6,7 +6,7 @@ const fromBucketSnippet = `from(bucket: “my-bucket”)
 
 const query = `query_api = client.query_api()
 
-query = "from(bucket: \\"bucket1\\") |> range(start: -10m) |> mean()"
+query = "from(bucket: \\"bucket1\\") |> range(start: -10m)"
 tables = query_api.query(query, org=org)
 
 for table in tables:


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/4135
Connects: https://github.com/influxdata/ui/issues/4140

The other half of the #4140 is addressed in #4142 

Somehow the `mean()` slipped into the query!



<!-- Describe your proposed changes here. -->
