### PR TITLE
chore(sub): change subscriptions feature flag

### DIFF
--- a/src/authorizations/components/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/CustomApiTokenOverlay.tsx
@@ -47,7 +47,7 @@ import {
   generateDescription,
 } from 'src/authorizations/utils/permissions'
 import {event} from 'src/cloud/utils/reporting'
-
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
 
 interface OwnProps {
@@ -88,15 +88,18 @@ const CustomApiTokenOverlay: FC<Props> = props => {
       const perms = {
         otherResources: {read: false, write: false},
       }
-      props.allResources.forEach(resource => {
-        if (resource === ResourceType.Telegrafs) {
-          perms[resource] = props.telegrafPermissions
-        } else if (resource === ResourceType.Buckets) {
-          perms[resource] = props.bucketPermissions
-        } else {
-          perms[resource] = {read: false, write: false}
-        }
-      })
+      props.allResources
+        // filter out Subsriptions resource type if the UI is not enabled
+        .filter(p => !isFlagEnabled('subscriptionsUI') && p !== 'subscriptions')
+        .forEach(resource => {
+          if (resource === ResourceType.Telegrafs) {
+            perms[resource] = props.telegrafPermissions
+          } else if (resource === ResourceType.Buckets) {
+            perms[resource] = props.bucketPermissions
+          } else {
+            perms[resource] = {read: false, write: false}
+          }
+        })
       setPermissions(perms)
     }
     // Each time remoteDataState changes, the useEffect hook will be called.

--- a/src/authorizations/components/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/CustomApiTokenOverlay.tsx
@@ -90,7 +90,10 @@ const CustomApiTokenOverlay: FC<Props> = props => {
       }
       props.allResources
         // filter out Subsriptions resource type if the UI is not enabled
-        .filter(p => !isFlagEnabled('subscriptionsUI') && p !== 'subscriptions')
+        .filter(
+          p =>
+            p !== ResourceType.Subscriptions || isFlagEnabled('subscriptionsUI')
+        )
         .forEach(resource => {
           if (resource === ResourceType.Telegrafs) {
             perms[resource] = props.telegrafPermissions

--- a/src/authorizations/utils/permissions.ts
+++ b/src/authorizations/utils/permissions.ts
@@ -1,5 +1,6 @@
 import {Permission, ResourceType} from 'src/types'
 import {capitalize} from 'lodash'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 export type PermissionTypes = Permission['resource']['type']
 
@@ -53,7 +54,11 @@ export const allAccessPermissions = (
 
 export const formatResources = resourceNames => {
   const resources = resourceNames.filter(
-    item => item !== ResourceType.Buckets && item !== ResourceType.Telegrafs
+    item =>
+      item !== ResourceType.Buckets &&
+      item !== ResourceType.Telegrafs &&
+      // filter out Subsriptions resource type if the UI is not enabled
+      (item !== ResourceType.Subscriptions || isFlagEnabled('subscriptionsUI'))
   )
   resources.sort()
   resources.unshift(ResourceType.Telegrafs)

--- a/src/pageLayout/constants/navigationHierarchy.ts
+++ b/src/pageLayout/constants/navigationHierarchy.ts
@@ -77,7 +77,7 @@ export const generateNavItems = (): NavItem[] => {
           testID: 'nav-subitem-subscriptions',
           label: 'Cloud Native Subscriptions',
           link: `${orgPrefix}/load-data/subscriptions`,
-          enabled: () => CLOUD && isFlagEnabled('subscriptionsResourceType'),
+          enabled: () => CLOUD && isFlagEnabled('subscriptionsUI'),
         },
         {
           id: 'tokens',

--- a/src/settings/components/LoadDataNavigation.tsx
+++ b/src/settings/components/LoadDataNavigation.tsx
@@ -61,7 +61,7 @@ class LoadDataNavigation extends PureComponent<Props> {
         id: 'subscriptions',
         cloudExclude: false,
         cloudOnly: true,
-        featureFlag: 'subscriptionsResourceType',
+        featureFlag: 'subscriptionsUI',
       },
       {
         text: 'API Tokens',

--- a/src/shared/containers/SetOrg.tsx
+++ b/src/shared/containers/SetOrg.tsx
@@ -232,14 +232,14 @@ const SetOrg: FC = () => {
             />
           )}
 
-          {CLOUD && isFlagEnabled('subscriptionsResourceType') && (
+          {CLOUD && isFlagEnabled('subscriptionsUI') && (
             <Route
               path={`${orgPath}/${LOAD_DATA}/${SUBSCRIPTIONS}/create`}
               component={CreateSubscriptionForm}
             />
           )}
 
-          {CLOUD && isFlagEnabled('subscriptionsResourceType') && (
+          {CLOUD && isFlagEnabled('subscriptionsUI') && (
             <Route
               path={`${orgPath}/${LOAD_DATA}/${SUBSCRIPTIONS}`}
               component={SubscriptionsLanding}

--- a/src/writeData/components/WriteDataSections.tsx
+++ b/src/writeData/components/WriteDataSections.tsx
@@ -41,9 +41,7 @@ const WriteDataSections: FC = () => {
     <>
       <FileUploadSection />
       <ClientLibrarySection />
-      {CLOUD && isFlagEnabled('subscriptionsResourceType') && (
-        <CloudNativeSources />
-      )}
+      {CLOUD && isFlagEnabled('subscriptionsUI') && <CloudNativeSources />}
       <TelegrafPluginSection />
     </>
   )


### PR DESCRIPTION
This PR includes two changes:
1. Change subscriptions feature flag from `subscriptionsResourceType` to `subscriptionsUI`
2. Filters out `subscriptions` from the Custom API Token overlay unless `subscriptionsUI` flag is on

Due to some limitations on deployment's side of things we need to be able to turn on `subscriptionsResourceType` in all clusters now even tho Cloud Native Subscriptions will not be enabled in all clusters yet. We also want to be able to include `subscriptions` in the All Access tokens that are generated (again, for deployment reasons). But we don't want `subscriptions` permission to show up in the Custom API Token permissions list until the UI is turned on.

New flag has already been added to IDPE and config cat

`subscriptionsUI` enabled:
<img width="839" alt="image" src="https://user-images.githubusercontent.com/6411855/159077941-22414601-ff7f-477c-a93e-b73aa3c5f582.png">

`subscriptionsUI` disabled:
<img width="827" alt="image" src="https://user-images.githubusercontent.com/6411855/159078981-593de095-cd9e-4d0d-b857-44459dcbaa69.png">
