### PR TITLE
fix: small insert panel bugs

### DIFF
--- a/src/flows/components/FlowCards.tsx
+++ b/src/flows/components/FlowCards.tsx
@@ -45,6 +45,26 @@ const FlowCards: FC<Props> = ({flows, search}) => {
     }
   }, [flows])
 
+  const body = (
+    <ResourceList>
+      <ResourceList.Body
+        emptyState={!!search ? <NoMatches /> : <FlowsIndexEmpty />}
+      >
+        {Object.keys(flows.flows).map(id => (
+          <FlowCard
+            key={id}
+            id={id}
+            isPinned={!!pinnedItems.find(item => item?.metadata.flowID === id)}
+          />
+        ))}
+      </ResourceList.Body>
+    </ResourceList>
+  )
+
+  if (isFlagEnabled('noTutorial')) {
+    return <div className="preset--no-tutorial">{body}</div>
+  }
+
   return (
     <Grid>
       <Grid.Row>
@@ -53,21 +73,7 @@ const FlowCards: FC<Props> = ({flows, search}) => {
           widthSM={Columns.Eight}
           widthMD={Columns.Ten}
         >
-          <ResourceList>
-            <ResourceList.Body
-              emptyState={!!search ? <NoMatches /> : <FlowsIndexEmpty />}
-            >
-              {Object.keys(flows.flows).map(id => (
-                <FlowCard
-                  key={id}
-                  id={id}
-                  isPinned={
-                    !!pinnedItems.find(item => item?.metadata.flowID === id)
-                  }
-                />
-              ))}
-            </ResourceList.Body>
-          </ResourceList>
+          {body}
         </Grid.Column>
       </Grid.Row>
     </Grid>

--- a/src/flows/components/FlowContextMenu.tsx
+++ b/src/flows/components/FlowContextMenu.tsx
@@ -90,13 +90,17 @@ const FlowContextMenu: FC<Props> = ({id, name, isPinned}) => {
   }
 
   const handleDelete = () => {
-    event('delete_notebook')
+    event('delete_notebook', {
+      context: 'list',
+    })
     deletePinnedItemByParam(id)
     remove(id)
   }
 
   const handleClone = async () => {
-    event('clone_notebook')
+    event('clone_notebook', {
+      context: 'list',
+    })
     const clonedId = await clone(id)
     history.push(
       `/orgs/${orgID}/${PROJECT_NAME_PLURAL.toLowerCase()}/${clonedId}`

--- a/src/flows/components/FlowsIndex.tsx
+++ b/src/flows/components/FlowsIndex.tsx
@@ -23,6 +23,7 @@ import {event} from 'src/cloud/utils/reporting'
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 import {PROJECT_NAME_PLURAL} from 'src/flows'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Types
 import {Flow} from 'src/types/flows'
@@ -138,23 +139,91 @@ const FlowsIndex = () => {
     >
       <PageHeader
         style={{flex: 0, margin: '16px 0px'}}
-        fullWidth={false}
+        fullWidth={true}
         className={`${showButtonMode && 'withButtonHeader'}`}
       >
-        <FlexBox
-          direction={FlexDirection.Row}
-          justifyContent={JustifyContent.SpaceBetween}
-          stretchToFitWidth
+        {!isFlagEnabled('noTutorial') && (
+          <FlexBox
+            direction={FlexDirection.Row}
+            justifyContent={JustifyContent.SpaceBetween}
+            stretchToFitWidth
+          >
+            <Page.Title title={PROJECT_NAME_PLURAL} />
+            <RateLimitAlert />
+          </FlexBox>
+        )}
+        {showButtonMode &&
+          (isFlagEnabled('noTutorial') ? (
+            <div style={{flex: 1, width: '100%'}}>
+              <PresetFlowsButtons />
+              <div className="preset--no-tutorial search">
+                <SearchWidget
+                  placeholderText={`Filter ${PROJECT_NAME_PLURAL}...`}
+                  onSearch={setSearch}
+                  searchTerm={search}
+                />
+                <ResourceSortDropdown
+                  resourceType={ResourceType.Flows}
+                  sortDirection={sortOptions.sortDirection}
+                  sortKey={sortOptions.sortKey}
+                  sortType={sortOptions.sortType}
+                  onSelect={setSort}
+                />
+              </div>
+            </div>
+          ) : (
+            <>
+              <PresetFlowsButtons />
+              <Page.ControlBar
+                className="flows-index--control-bar buttonMode"
+                fullWidth={true}
+              >
+                <Page.ControlBarLeft>
+                  <SearchWidget
+                    placeholderText={`Filter ${PROJECT_NAME_PLURAL}...`}
+                    onSearch={setSearch}
+                    searchTerm={search}
+                  />
+                  <ResourceSortDropdown
+                    resourceType={ResourceType.Flows}
+                    sortDirection={sortOptions.sortDirection}
+                    sortKey={sortOptions.sortKey}
+                    sortType={sortOptions.sortType}
+                    onSelect={setSort}
+                  />
+                </Page.ControlBarLeft>
+                <Page.ControlBarRight />
+              </Page.ControlBar>
+            </>
+          ))}
+      </PageHeader>
+      <DapperScrollbars onScroll={scrollHandler}>
+        <Page.Contents
+          fullWidth={true}
+          id="fadebox"
+          ref={fadingBoxRef}
+          className="flows-index--contents"
         >
-          <Page.Title title={PROJECT_NAME_PLURAL} />
-          <RateLimitAlert />
-        </FlexBox>
-        {showButtonMode && (
-          <>
-            <PresetFlowsButtons />
+          <PresetFlows />
+          {isFlagEnabled('noTutorial') ? (
+            <div className="preset--no-tutorial search">
+              <SearchWidget
+                placeholderText={`Filter ${PROJECT_NAME_PLURAL}...`}
+                onSearch={setSearch}
+                searchTerm={search}
+              />
+              <ResourceSortDropdown
+                resourceType={ResourceType.Flows}
+                sortDirection={sortOptions.sortDirection}
+                sortKey={sortOptions.sortKey}
+                sortType={sortOptions.sortType}
+                onSelect={setSort}
+              />
+            </div>
+          ) : (
             <Page.ControlBar
-              className="flows-index--control-bar buttonMode"
-              fullWidth={false}
+              className="flows-index--control-bar"
+              fullWidth={true}
             >
               <Page.ControlBarLeft>
                 <SearchWidget
@@ -172,40 +241,10 @@ const FlowsIndex = () => {
               </Page.ControlBarLeft>
               <Page.ControlBarRight />
             </Page.ControlBar>
-          </>
-        )}
-      </PageHeader>
-      <DapperScrollbars onScroll={scrollHandler}>
-        <Page.Contents
-          fullWidth={false}
-          id="fadebox"
-          ref={fadingBoxRef}
-          className="flows-index--contents"
-        >
-          <PresetFlows />
-          <Page.ControlBar
-            className="flows-index--control-bar"
-            fullWidth={false}
-          >
-            <Page.ControlBarLeft>
-              <SearchWidget
-                placeholderText={`Filter ${PROJECT_NAME_PLURAL}...`}
-                onSearch={setSearch}
-                searchTerm={search}
-              />
-              <ResourceSortDropdown
-                resourceType={ResourceType.Flows}
-                sortDirection={sortOptions.sortDirection}
-                sortKey={sortOptions.sortKey}
-                sortType={sortOptions.sortType}
-                onSelect={setSort}
-              />
-            </Page.ControlBarLeft>
-            <Page.ControlBarRight />
-          </Page.ControlBar>
+          )}
         </Page.Contents>
 
-        <Page.Contents fullWidth={false}>
+        <Page.Contents fullWidth={true}>
           <FlowCards flows={flowList} search={search} />
         </Page.Contents>
       </DapperScrollbars>

--- a/src/flows/components/FlowsIndexEmpty.tsx
+++ b/src/flows/components/FlowsIndexEmpty.tsx
@@ -9,7 +9,7 @@ const FlowsIndexEmpty = () => {
       <div className="flow-empty">
         <div className="flow-empty--graphic" />
         <EmptyState.Text className="margin-bottom-zero">
-          You haven't created any {PROJECT_NAME_PLURAL} yet
+          {PROJECT_NAME_PLURAL} will show up here as you create them
         </EmptyState.Text>
       </div>
     </EmptyState>

--- a/src/flows/components/PresetFlows.scss
+++ b/src/flows/components/PresetFlows.scss
@@ -16,6 +16,39 @@ h3 {
   grid-template-columns: repeat(5, 1fr);
   grid-gap: 5%;
 }
+.preset--no-tutorial {
+  max-width: 1000px;
+  margin: 0 auto;
+
+  h3 {
+    display: none;
+  }
+
+  &.search {
+    margin-bottom: 12px;
+    display: flex;
+
+    .cf-input {
+      margin-right: 8px;
+    }
+  }
+
+  .flows-index--presetList {
+    grid-template-columns: repeat(4, 1fr);
+    &.buttonModeList {
+      width: auto;
+      display: block;
+      text-align: left;
+      .flows-index--presetButtons {
+        display: inline-block;
+      }
+    }
+  }
+
+  .flows-index--presetCard {
+    text-align: center;
+  }
+}
 
 .flows-index--presetCard {
   display: flex;
@@ -78,11 +111,49 @@ h3 {
     grid-template-columns: repeat(2, 1fr);
   }
 
+  .preset--no-tutorial .flows-index--presetList {
+    grid-template-columns: repeat(4, 1fr);
+  }
+
   .flows-index--presetcontainer {
     padding: 5px 40px 25px;
   }
 
   .flows-index--presetCard:nth-child(5) {
     padding-bottom: 16px;
+  }
+}
+
+@media screen and (max-width: $cf-grid--breakpoint-sm) {
+  .preset--no-tutorial .flows-index--presetContainer {
+    padding: 15px;
+  }
+
+  .preset--no-tutorial .flows-index--presetList {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .preset--no-tutorial .flows-index--presetHeader {
+    margin: 4px;
+  }
+}
+
+@media screen and (max-width: 680px) {
+  .preset--no-tutorial .flows-index--presetList.buttonModeList {
+    display: none;
+  }
+}
+
+@media screen and (max-width: 450px) {
+  .preset--no-tutorial .flows-index--presetList {
+    grid-template-columns: repeat(1, 1fr);
+    grid-gap: 2.5%;
+    max-width: 200px;
+    margin: 0 auto;
+  }
+
+  .preset--no-tutorial .flows-index--presetHeader {
+    margin: 4px;
+    text-align: center;
   }
 }

--- a/src/flows/components/PresetFlows.tsx
+++ b/src/flows/components/PresetFlows.tsx
@@ -10,9 +10,10 @@ import {
 import {useHistory} from 'react-router-dom'
 import FlowsExplainer from 'src/flows/components/FlowsExplainer'
 import {PROJECT_NAME} from 'src/flows'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 export const PRESET_MAP = [
   {
-    title: 'New Notebook',
+    title: `New ${PROJECT_NAME}`,
     href: `/${PROJECT_NAME.toLowerCase()}/from/default`,
     testID: 'new',
   },
@@ -35,6 +36,40 @@ export const PRESET_MAP = [
 
 const PresetFlows: FC = () => {
   const history = useHistory()
+  const body = (
+    <div className="flows-index--presetContainer">
+      <h3>Create a {PROJECT_NAME}</h3>
+      <div className="flows-index--presetList">
+        {PRESET_MAP.map((p, idx: number) => (
+          <div key={p.testID} className="flows-index--presetCard">
+            {idx === 0 ? (
+              <Button
+                titleText={p.title}
+                color={ComponentColor.Primary}
+                icon={IconFont.Plus_New}
+                className="flows-index--presetButton"
+                testID={`preset-${p.testID}`}
+                onClick={() => history.push(p.href)}
+              ></Button>
+            ) : (
+              <Button
+                titleText={p.title}
+                text=" "
+                className="flows-index--presetButton"
+                testID={`preset-${p.testID}`}
+                onClick={() => history.push(p.href)}
+              ></Button>
+            )}
+            <h5 className="flows-index--presetHeader">{p.title}</h5>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+
+  if (isFlagEnabled('noTutorial')) {
+    return <div className="preset--no-tutorial">{body}</div>
+  }
 
   return (
     <Grid>
@@ -44,34 +79,7 @@ const PresetFlows: FC = () => {
           widthSM={Columns.Eight}
           widthMD={Columns.Ten}
         >
-          <div className="flows-index--presetContainer">
-            <h3>Create a Notebook</h3>
-            <div className="flows-index--presetList">
-              {PRESET_MAP.map((p, idx: number) => (
-                <div key={p.testID} className="flows-index--presetCard">
-                  {idx === 0 ? (
-                    <Button
-                      titleText={p.title}
-                      color={ComponentColor.Primary}
-                      icon={IconFont.Plus_New}
-                      className="flows-index--presetButton"
-                      testID={`preset-${p.testID}`}
-                      onClick={() => history.push(p.href)}
-                    ></Button>
-                  ) : (
-                    <Button
-                      titleText={p.title}
-                      text=" "
-                      className="flows-index--presetButton"
-                      testID={`preset-${p.testID}`}
-                      onClick={() => history.push(p.href)}
-                    ></Button>
-                  )}
-                  <h5 className="flows-index--presetHeader">{p.title}</h5>
-                </div>
-              ))}
-            </div>
-          </div>
+          {body}
         </Grid.Column>
         <Grid.Column
           widthXS={Columns.Twelve}

--- a/src/flows/components/PresetFlowsButtons.tsx
+++ b/src/flows/components/PresetFlowsButtons.tsx
@@ -10,9 +10,41 @@ import {
 } from '@influxdata/clockface'
 
 import {useHistory} from 'react-router-dom'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 const PresetFlowsButtons: FC = () => {
   const history = useHistory()
+  const body = (
+    <div className="flows-index--presetList buttonModeList">
+      {PRESET_MAP.map((p, idx: number) => (
+        <div key={p.title} className="flows-index--presetButtons">
+          {idx === 0 ? (
+            <Button
+              color={ComponentColor.Primary}
+              icon={IconFont.Plus_New}
+              text={p.title}
+              testID={`preset-${p.testID}`}
+              onClick={() => history.push(p.href)}
+              className="flows-preset--buttonmode"
+            ></Button>
+          ) : (
+            <Button
+              text={p.title}
+              color={ComponentColor.Tertiary}
+              onClick={() => history.push(p.href)}
+              testID={`preset-${p.testID}`}
+              className="flows-preset--buttonmode"
+            ></Button>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+
+  if (isFlagEnabled('noTutorial')) {
+    return <div className="preset--no-tutorial">{body}</div>
+  }
+
   return (
     <Grid>
       <Grid.Row>
@@ -21,30 +53,7 @@ const PresetFlowsButtons: FC = () => {
           widthSM={Columns.Eight}
           widthMD={Columns.Ten}
         >
-          <div className="flows-index--presetList buttonModeList">
-            {PRESET_MAP.map((p, idx: number) => (
-              <div key={p.title} className="flows-index--presetButtons">
-                {idx === 0 ? (
-                  <Button
-                    color={ComponentColor.Primary}
-                    icon={IconFont.Plus_New}
-                    text={p.title}
-                    testID={`preset-${p.testID}`}
-                    onClick={() => history.push(p.href)}
-                    className="flows-preset--buttonmode"
-                  ></Button>
-                ) : (
-                  <Button
-                    text={p.title}
-                    color={ComponentColor.Tertiary}
-                    onClick={() => history.push(p.href)}
-                    testID={`preset-${p.testID}`}
-                    className="flows-preset--buttonmode"
-                  ></Button>
-                )}
-              </div>
-            ))}
-          </div>
+          {body}
         </Grid.Column>
       </Grid.Row>
     </Grid>

--- a/src/flows/components/ShareOverlay.tsx
+++ b/src/flows/components/ShareOverlay.tsx
@@ -19,6 +19,7 @@ import {
 import CopyToClipboard from 'src/shared/components/CopyToClipboard'
 import {SafeBlankLink} from 'src/utils/SafeBlankLink'
 import {OverlayContext} from 'src/overlays/components/OverlayController'
+import {PROJECT_NAME} from 'src/flows'
 
 // Actions
 import {notify} from 'src/shared/actions/notifications'
@@ -72,7 +73,7 @@ const ShareOverlay: FC = () => {
 
   return (
     <Overlay.Container maxWidth={800}>
-      <Overlay.Header title="Share Notebook" onDismiss={onClose} />
+      <Overlay.Header title={`Share ${PROJECT_NAME}`} onDismiss={onClose} />
       <Overlay.Body>
         <FlexBox
           direction={FlexDirection.Column}
@@ -122,8 +123,8 @@ const ShareOverlay: FC = () => {
             </FlexBox>
             <Icon glyph={IconFont.Eye_New} />
             <span className="share-text">
-              Anyone with this link can view this Notebook, but will not have
-              access to autorefresh updates.
+              Anyone with this link can view this {PROJECT_NAME}, but will not
+              have access to autorefresh updates.
             </span>
           </FlexBox.Child>
           <FlexBox.Child className="share-section--delete">

--- a/src/flows/components/header/MenuButton.tsx
+++ b/src/flows/components/header/MenuButton.tsx
@@ -42,7 +42,9 @@ const MenuButton: FC<Props> = ({handleResetShare}) => {
   const history = useHistory()
 
   const handleClone = async () => {
-    event('clone_notebook')
+    event('clone_notebook', {
+      context: 'notebook',
+    })
     const clonedId = await clone(flow.id)
     handleResetShare()
     history.push(
@@ -51,7 +53,9 @@ const MenuButton: FC<Props> = ({handleResetShare}) => {
   }
 
   const handleDelete = () => {
-    event('delete_notebook')
+    event('delete_notebook', {
+      context: 'notebook',
+    })
     deletePinnedItemByParam(flow.id)
     remove(flow.id)
     history.push(`/orgs/${orgID}/${PROJECT_NAME_PLURAL.toLowerCase()}`)

--- a/src/flows/components/panel/InsertCellButton.scss
+++ b/src/flows/components/panel/InsertCellButton.scss
@@ -30,6 +30,12 @@ $cf-radius-lg: $cf-radius + 4px;
     transform: none;
     margin: -4px 8px 0;
     background: inherit;
+
+    &:hover {
+      &:after {
+        display: none;
+      }
+    }
   }
 
   span {

--- a/src/flows/style.scss
+++ b/src/flows/style.scss
@@ -62,7 +62,7 @@ $cf-radius-lg: $cf-radius + 4px;
       display: none;
     }
     .flow-panel--body {
-      padding-left: inherit;
+      padding-left: 8px;
     }
 
     &:after {

--- a/src/variables/components/VariablesTab.test.tsx
+++ b/src/variables/components/VariablesTab.test.tsx
@@ -5,6 +5,10 @@ jest.mock('src/shared/components/FluxMonacoEditor', () => {
   return () => <></>
 })
 
+jest.mock('src/flows/components/ShareOverlay', () => {
+  return () => <></>
+})
+
 jest.mock('src/client/generatedRoutes.ts', () => ({
   ...jest.requireActual('src/client/generatedRoutes.ts'),
   postVariable: jest.fn(() => {


### PR DESCRIPTION
after modifying the insert button within the notebook, i found a couple of css bugs dealing with padding and hover states. once those were fixed, i found a bunch of bugs on the list page dealing with scaling and scrolling of the page and trudged on. when fighting one of the grids, i found that we're creating problems for ourselves by the way we're structuring our grids within clockface's Page rules, all in order to facilitate that tutorial text that takes up 1/3 of the page. As i was trying to find solutions to that, i started to wonder if it were not just best to remove the text instead of restructuring the page. so i made a flag to do that so that people could click around and see which way we should invest our time later.

[without flag]
![Screenshot 2022-03-18 2 51 56 PM](https://user-images.githubusercontent.com/1434802/159095403-59c0ef23-deba-49a8-8854-2ded7c5ae3a3.png)


[with flag]
![Screenshot 2022-03-18 2 52 08 PM](https://user-images.githubusercontent.com/1434802/159095439-98b5539f-602a-4683-a836-5da24f4c3837.png)
