### PR TITLE
chore: remove trackCancellations flag

### DIFF
--- a/cypress/e2e/cloud/billing.test.ts
+++ b/cypress/e2e/cloud/billing.test.ts
@@ -228,6 +228,11 @@ describe('Billing Page PAYG Users', () => {
 
     cy.getByTestID('agree-terms--input').click()
     cy.getByTestID('agree-terms--checkbox').should('be.checked')
+    cy.getByTestID('variable-type-dropdown--button')
+      .click()
+      .then(() => {
+        cy.getByTestID('variable-type-dropdown-USE_CASE_DIFFERENT').click()
+      })
     cy.getByTestID('cancel-service-confirmation--button')
       .should('not.be.disabled')
       .click()

--- a/cypress/e2e/cloud/zuoraOutage.test.ts
+++ b/cypress/e2e/cloud/zuoraOutage.test.ts
@@ -193,6 +193,11 @@ describe('Billing Page PAYG Users', () => {
 
     cy.getByTestID('agree-terms--input').click()
     cy.getByTestID('agree-terms--checkbox').should('be.checked')
+    cy.getByTestID('variable-type-dropdown--button')
+      .click()
+      .then(() => {
+        cy.getByTestID('variable-type-dropdown-USE_CASE_DIFFERENT').click()
+      })
     cy.getByTestID('cancel-service-confirmation--button')
       .should('not.be.disabled')
       .click()

--- a/src/accounts/CancellationOverlay.tsx
+++ b/src/accounts/CancellationOverlay.tsx
@@ -59,21 +59,16 @@ const CancellationOverlay: FC<Props> = ({onHideOverlay}) => {
     }
     event('CancelServiceExecuted Event', payload)
 
-    if (
-      isFlagEnabled('rudderstackReporting') &&
-      isFlagEnabled('trackCancellations')
-    ) {
+    if (isFlagEnabled('rudderstackReporting')) {
       // Send to Rudderstack
       track('CancelServiceExecuted', payload)
     }
 
     handleCancelAccount()
 
-    if (isFlagEnabled('trackCancellations')) {
-      postSignout({}).then(() => {
-        window.location.href = getRedirectLocation()
-      })
-    }
+    postSignout({}).then(() => {
+      window.location.href = getRedirectLocation()
+    })
 
     event('Cancel Service Executed', payload)
   }
@@ -86,10 +81,7 @@ const CancellationOverlay: FC<Props> = ({onHideOverlay}) => {
     }
     event('CancelServiceDismissed Event', payload)
 
-    if (
-      isFlagEnabled('rudderstackReporting') &&
-      isFlagEnabled('trackCancellations')
-    ) {
+    if (isFlagEnabled('rudderstackReporting')) {
       // Send to Rudderstack
       track('CancelServiceDismissed', payload)
     }
@@ -99,10 +91,6 @@ const CancellationOverlay: FC<Props> = ({onHideOverlay}) => {
   }
 
   const isFormValid = useMemo(() => {
-    if (!isFlagEnabled('trackCancellations')) {
-      return hasAgreedToTerms
-    }
-
     // Has Agreed to Terms & Conditions
     // as well as
     // Selected an option from the Reasons Dropdown

--- a/src/accounts/CancellationOverlay.tsx
+++ b/src/accounts/CancellationOverlay.tsx
@@ -57,7 +57,6 @@ const CancellationOverlay: FC<Props> = ({onHideOverlay}) => {
       event('Subscription cancellation success')
     } catch (error) {
       const message = getErrorMessage(error)
-      console.error({error})
       event('Subscription cancellation failed', {message})
       dispatch(notify(accountCancellationError(message)))
     }

--- a/src/accounts/context/userAccount.tsx
+++ b/src/accounts/context/userAccount.tsx
@@ -3,12 +3,11 @@ import React, {FC, useCallback, useEffect, useState} from 'react'
 import {useDispatch} from 'react-redux'
 
 // Types
-import {Account as UserAccount, postCancel} from 'src/client/unityRoutes'
+import {Account as UserAccount} from 'src/client/unityRoutes'
 
 // Notifications
 import {notify} from 'src/shared/actions/notifications'
 import {
-  accountCancellationError,
   accountDefaultSettingError,
   accountDefaultSettingSuccess,
   accountRenameError,
@@ -25,8 +24,6 @@ import {
 // Metrics
 import {event} from 'src/cloud/utils/reporting'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
-import {useHistory} from 'react-router-dom'
-import {getErrorMessage} from 'src/utils/api'
 
 // Actions
 import {setMe} from 'src/me/actions/creators'
@@ -37,7 +34,6 @@ export type Props = {
 }
 export interface UserAccountContextType {
   userAccounts: UserAccount[]
-  handleCancelAccount: () => void
   handleGetAccounts: () => void
   handleSetDefaultAccount: (newId: number) => void
   handleRenameActiveAccount: (accountId: number, newName: string) => void
@@ -49,7 +45,6 @@ export const DEFAULT_CONTEXT: UserAccountContextType = {
   userAccounts: [],
   defaultAccountId: -1,
   activeAccountId: -1,
-  handleCancelAccount: () => {},
   handleGetAccounts: () => {},
   handleSetDefaultAccount: () => {},
   handleRenameActiveAccount: () => {},
@@ -65,7 +60,6 @@ export const UserAccountProvider: FC<Props> = React.memo(({children}) => {
   const [activeAccountId, setActiveAccountId] = useState<number>(null)
 
   const dispatch = useDispatch()
-  const history = useHistory()
 
   /**
    * get the name of the account as specified by ID
@@ -80,20 +74,6 @@ export const UserAccountProvider: FC<Props> = React.memo(({children}) => {
       return selectedAcctArray[0].name
     }
   }
-
-  const handleCancelAccount = useCallback(async () => {
-    try {
-      const resp = await postCancel({})
-
-      if (resp.status !== 204) {
-        throw new Error(resp.data.message)
-      }
-    } catch (error) {
-      const message = getErrorMessage(error)
-      console.error({error})
-      dispatch(notify(accountCancellationError(message)))
-    }
-  }, [dispatch, history])
 
   const handleGetAccounts = useCallback(async () => {
     try {
@@ -181,7 +161,6 @@ export const UserAccountProvider: FC<Props> = React.memo(({children}) => {
         userAccounts,
         defaultAccountId,
         activeAccountId,
-        handleCancelAccount,
         handleGetAccounts,
         handleSetDefaultAccount,
         handleRenameActiveAccount,

--- a/src/accounts/context/userAccount.tsx
+++ b/src/accounts/context/userAccount.tsx
@@ -88,10 +88,6 @@ export const UserAccountProvider: FC<Props> = React.memo(({children}) => {
       if (resp.status !== 204) {
         throw new Error(resp.data.message)
       }
-
-      if (!isFlagEnabled('trackCancellations')) {
-        history.push(`/logout`)
-      }
     } catch (error) {
       const message = getErrorMessage(error)
       console.error({error})

--- a/src/billing/components/PayAsYouGo/CancellationOverlay.tsx
+++ b/src/billing/components/PayAsYouGo/CancellationOverlay.tsx
@@ -58,21 +58,16 @@ const CancellationOverlay: FC<Props> = ({onHideOverlay}) => {
     }
     event('CancelServiceExecuted Event', payload)
 
-    if (
-      isFlagEnabled('rudderstackReporting') &&
-      isFlagEnabled('trackCancellations')
-    ) {
+    if (isFlagEnabled('rudderstackReporting')) {
       // Send to Rudderstack
       track('CancelServiceExecuted', payload)
     }
 
     handleCancelAccount()
 
-    if (isFlagEnabled('trackCancellations')) {
-      postSignout({}).then(() => {
-        window.location.href = getRedirectLocation()
-      })
-    }
+    postSignout({}).then(() => {
+      window.location.href = getRedirectLocation()
+    })
 
     event('Cancel Service Executed', payload)
   }
@@ -85,10 +80,7 @@ const CancellationOverlay: FC<Props> = ({onHideOverlay}) => {
     }
     event('CancelServiceDismissed Event', payload)
 
-    if (
-      isFlagEnabled('rudderstackReporting') &&
-      isFlagEnabled('trackCancellations')
-    ) {
+    if (isFlagEnabled('rudderstackReporting')) {
       // Send to Rudderstack
       track('CancelServiceDismissed', payload)
     }
@@ -98,10 +90,6 @@ const CancellationOverlay: FC<Props> = ({onHideOverlay}) => {
   }
 
   const isFormValid = useMemo(() => {
-    if (!isFlagEnabled('trackCancellations')) {
-      return hasAgreedToTerms
-    }
-
     // Has Agreed to Terms & Conditions
     // as well as
     // Selected an option from the Reasons Dropdown

--- a/src/billing/components/PayAsYouGo/CancellationOverlay.tsx
+++ b/src/billing/components/PayAsYouGo/CancellationOverlay.tsx
@@ -55,7 +55,6 @@ const CancellationOverlay: FC<Props> = ({onHideOverlay}) => {
       event('Cancel account success')
     } catch (error) {
       const message = getErrorMessage(error)
-      console.error({error})
       event('Cancel account failed', {message})
       dispatch(notify(accountCancellationError(message)))
     }

--- a/src/billing/components/PayAsYouGo/CancellationPanel.tsx
+++ b/src/billing/components/PayAsYouGo/CancellationPanel.tsx
@@ -32,10 +32,7 @@ const CancellationPanel: FC = () => {
     }
     event('CancelServiceInitiation Event', payload)
 
-    if (
-      isFlagEnabled('trackCancellations') &&
-      isFlagEnabled('rudderstackReporting')
-    ) {
+    if (isFlagEnabled('rudderstackReporting')) {
       track('CancelServiceInitiation', payload)
     }
 

--- a/src/billing/components/PayAsYouGo/TermsCancellationOverlay.tsx
+++ b/src/billing/components/PayAsYouGo/TermsCancellationOverlay.tsx
@@ -11,7 +11,6 @@ import {
   AlignItems,
 } from '@influxdata/clockface'
 import CancelServiceReasonsForm from './CancelServiceReasonsForm'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 interface Props {
   hasAgreedToTerms: boolean

--- a/src/billing/components/PayAsYouGo/TermsCancellationOverlay.tsx
+++ b/src/billing/components/PayAsYouGo/TermsCancellationOverlay.tsx
@@ -68,16 +68,14 @@ const TermsCancellationOverlay: FC<Props> = ({
         </InputLabel>
       </FlexBox>
     </span>
-    {isFlagEnabled('trackCancellations') && (
-      <FlexBox
-        alignItems={AlignItems.Center}
-        direction={FlexDirection.Column}
-        justifyContent={JustifyContent.Center}
-        margin={ComponentSize.Large}
-      >
-        <CancelServiceReasonsForm />
-      </FlexBox>
-    )}
+    <FlexBox
+      alignItems={AlignItems.Center}
+      direction={FlexDirection.Column}
+      justifyContent={JustifyContent.Center}
+      margin={ComponentSize.Large}
+    >
+      <CancelServiceReasonsForm />
+    </FlexBox>
   </div>
 )
 

--- a/src/billing/context/billing.tsx
+++ b/src/billing/context/billing.tsx
@@ -1,7 +1,6 @@
 // Libraries
 import React, {FC, useCallback, useState} from 'react'
 import {useDispatch, useSelector} from 'react-redux'
-import {useHistory} from 'react-router-dom'
 
 // Utils
 import {notify} from 'src/shared/actions/notifications'
@@ -11,14 +10,12 @@ import {
   getMarketplace,
   getPaymentForm,
   getSettingsNotifications,
-  postCancel,
   putBillingPaymentMethod,
   putSettingsNotifications,
   putBillingContact,
 } from 'src/client/unityRoutes'
 import {getQuartzMe} from 'src/me/selectors'
 import {
-  accountCancellationError,
   getBillingInfoError,
   getBillingSettingsError,
   getInvoicesError,
@@ -56,7 +53,6 @@ export interface BillingContextType {
   billingInfoStatus: RemoteDataState
   billingSettings: BillingNotifySettings
   billingSettingsStatus: RemoteDataState
-  handleCancelAccount: () => void
   handleGetBillingInfo: () => void
   handleGetBillingSettings: () => void
   handleGetInvoices: () => void
@@ -92,7 +88,6 @@ export const DEFAULT_CONTEXT: BillingContextType = {
   billingInfoStatus: RemoteDataState.NotStarted,
   billingSettings: null,
   billingSettingsStatus: RemoteDataState.NotStarted,
-  handleCancelAccount: () => {},
   handleGetBillingInfo: () => {},
   handleGetBillingSettings: () => {},
   handleGetInvoices: () => {},
@@ -190,22 +185,6 @@ export const BillingProvider: FC<Props> = React.memo(({children}) => {
     },
     [dispatch]
   )
-
-  const history = useHistory()
-
-  const handleCancelAccount = useCallback(async () => {
-    try {
-      const resp = await postCancel({})
-
-      if (resp.status !== 204) {
-        throw new Error(resp.data.message)
-      }
-    } catch (error) {
-      const message = getErrorMessage(error)
-      console.error({error})
-      dispatch(notify(accountCancellationError(message)))
-    }
-  }, [dispatch, history])
 
   const handleGetInvoices = useCallback(async () => {
     try {
@@ -339,7 +318,6 @@ export const BillingProvider: FC<Props> = React.memo(({children}) => {
         billingInfoStatus,
         billingSettings,
         billingSettingsStatus,
-        handleCancelAccount,
         handleGetBillingInfo,
         handleGetBillingSettings,
         handleGetInvoices,

--- a/src/billing/context/billing.tsx
+++ b/src/billing/context/billing.tsx
@@ -201,10 +201,6 @@ export const BillingProvider: FC<Props> = React.memo(({children}) => {
       if (resp.status !== 204) {
         throw new Error(resp.data.message)
       }
-
-      if (!isFlagEnabled('trackCancellations')) {
-        history.push(`/logout`)
-      }
     } catch (error) {
       const message = getErrorMessage(error)
       console.error({error})

--- a/src/billing/context/billing.tsx
+++ b/src/billing/context/billing.tsx
@@ -46,7 +46,6 @@ import {
 } from 'src/types'
 import {CreditCardParams} from 'src/types/billing'
 import {getErrorMessage} from 'src/utils/api'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 export type Props = {
   children: JSX.Element

--- a/src/organizations/components/DeleteOrgOverlay.tsx
+++ b/src/organizations/components/DeleteOrgOverlay.tsx
@@ -57,10 +57,7 @@ const DeleteOrgOverlay: FC = () => {
     }
     event('DeleteOrgDismissed Event', payload)
 
-    if (
-      isFlagEnabled('rudderstackReporting') &&
-      isFlagEnabled('trackCancellations')
-    ) {
+    if (isFlagEnabled('rudderstackReporting')) {
       // Send to Rudderstack
       track('DeleteOrgDismissed', payload)
     }
@@ -69,10 +66,6 @@ const DeleteOrgOverlay: FC = () => {
   }
 
   const isFormValid = useMemo(() => {
-    if (!isFlagEnabled('trackCancellations')) {
-      return hasAgreedToTerms
-    }
-
     // Has Agreed to Terms & Conditions
     // as well as
     // Selected an option from the Reasons Dropdown
@@ -90,10 +83,7 @@ const DeleteOrgOverlay: FC = () => {
     }
     event('DeleteOrgExecuted Event', payload)
 
-    if (
-      isFlagEnabled('rudderstackReporting') &&
-      isFlagEnabled('trackCancellations')
-    ) {
+    if (isFlagEnabled('rudderstackReporting')) {
       track('DeleteOrgExecuted', payload)
     }
 
@@ -104,11 +94,8 @@ const DeleteOrgOverlay: FC = () => {
       if (resp.status !== 204) {
         throw new Error(resp.data.message)
       }
-      if (isFlagEnabled('trackCancellations')) {
-        window.location.href = getRedirectLocation()
-      } else {
-        window.location.href = `https://www.influxdata.com/free_cancel/`
-      }
+
+      window.location.href = getRedirectLocation()
     } catch {
       dispatch(notify(accountSelfDeletionFailed()))
     }
@@ -122,16 +109,14 @@ const DeleteOrgOverlay: FC = () => {
           <Alert color={ComponentColor.Danger} icon={IconFont.AlertTriangle}>
             This action cannot be undone
           </Alert>
-          {isFlagEnabled('trackCancellations') && (
-            <FlexBox
-              alignItems={AlignItems.Center}
-              direction={FlexDirection.Row}
-              justifyContent={JustifyContent.FlexStart}
-              margin={ComponentSize.Medium}
-            >
-              <DeleteOrgReasonsForm />
-            </FlexBox>
-          )}
+          <FlexBox
+            alignItems={AlignItems.Center}
+            direction={FlexDirection.Row}
+            justifyContent={JustifyContent.FlexStart}
+            margin={ComponentSize.Medium}
+          >
+            <DeleteOrgReasonsForm />
+          </FlexBox>
           <ul style={{margin: '32px 0'}}>
             <li>
               The account for this Organization will be deleted immediately.

--- a/src/organizations/components/OrgProfileTab/DeletePanel.tsx
+++ b/src/organizations/components/OrgProfileTab/DeletePanel.tsx
@@ -39,10 +39,7 @@ const DeletePanel: FC = () => {
     }
     event('DeleteOrgInitiation Event', payload)
 
-    if (
-      isFlagEnabled('trackCancellations') &&
-      isFlagEnabled('rudderstackReporting')
-    ) {
+    if (isFlagEnabled('rudderstackReporting')) {
       track('DeleteOrgInitiation', payload)
     }
 


### PR DESCRIPTION
closes #4166 

`trackCancellations` got enabled on Nov 23rd 2021 in production. Thus we need to remove this flag.