### PR TITLE
feat: remove feature flag from working alerts and add eventing for successful exports

### DIFF
--- a/src/flows/pipes/Notification/ExportTask.tsx
+++ b/src/flows/pipes/Notification/ExportTask.tsx
@@ -291,6 +291,9 @@ ${ENDPOINT_DEFINITIONS[data.endpoint]?.generateQuery(data.endpointData)}`
   }, [generateDeadmanTask, generateThresholdTask, data.thresholds])
 
   const handleTaskCreation = _ => {
+    event('Alert panel exported', {
+      type: data.endpoint,
+    })
     dispatch(notify(exportAlertToTaskSuccess(data.endpoint)))
   }
 

--- a/src/flows/pipes/Notification/ExportTask.tsx
+++ b/src/flows/pipes/Notification/ExportTask.tsx
@@ -291,9 +291,6 @@ ${ENDPOINT_DEFINITIONS[data.endpoint]?.generateQuery(data.endpointData)}`
   }, [generateDeadmanTask, generateThresholdTask, data.thresholds])
 
   const handleTaskCreation = _ => {
-    event('Alert panel exported', {
-      type: data.endpoint,
-    })
     dispatch(notify(exportAlertToTaskSuccess(data.endpoint)))
   }
 

--- a/src/flows/pipes/Notification/endpoints/AWS/index.ts
+++ b/src/flows/pipes/Notification/endpoints/AWS/index.ts
@@ -16,7 +16,6 @@ export default register => {
       calcSignature: '',
       email: '',
     },
-    featureFlag: 'notebooksNewEndpoints',
     component: View,
     readOnlyComponent: ReadOnly,
     generateImports: () =>

--- a/src/flows/pipes/Notification/endpoints/Mailgun/index.ts
+++ b/src/flows/pipes/Notification/endpoints/Mailgun/index.ts
@@ -11,7 +11,6 @@ export default register => {
       apiKey: '',
       email: '',
     },
-    featureFlag: 'notebooksNewEndpoints',
     component: View,
     readOnlyComponent: ReadOnly,
     generateImports: () =>

--- a/src/flows/pipes/Schedule/ExportTaskButton.tsx
+++ b/src/flows/pipes/Schedule/ExportTaskButton.tsx
@@ -57,7 +57,7 @@ const ExportTaskButton: FC<Props> = ({
   const onClick = async () => {
     const query = generate ? generate() : data.query
 
-    event('Export Task Modal Skipped', {from: type})
+    event('Export Task Modal Skipped', {from: type, type: data.endpoint})
     let taskid
 
     // we can soft delete the previously connected task by marking the old one inactive


### PR DESCRIPTION
Closes #4159

This PR enables a few endpoints that are proven to work in the UI by removing their feature flags. It also adds eventing around successfully exported alerts so that we can gain an understanding of which exported alerts users are gravitating towards

<!-- Describe your proposed changes here. -->
