### PR TITLE
feat: add help & support item to nav bar behind feature flag

### DIFF
--- a/src/pageLayout/constants/navigationHierarchy.ts
+++ b/src/pageLayout/constants/navigationHierarchy.ts
@@ -202,6 +202,16 @@ export const generateNavItems = (): NavItem[] => {
       link: `/operator`,
       activeKeywords: ['operator'],
     },
+    {
+      id: 'support',
+      testID: 'nav-item-support',
+      icon: IconFont.QuestionMark_New,
+      label: 'Help & Support',
+      shortLabel: 'Support',
+      link: '',
+      activeKeywords: [''],
+      enabled: () => isFlagEnabled('helpBar'),
+    },
   ]
 
   navItems = navItems.filter(item => {


### PR DESCRIPTION
Closes #3447

`Help & Support` item is now added onto the nav, is hidden behind a feature flag `helpBar`.

<!-- Describe your proposed changes here. -->
![Screen Shot 2022-03-21 at 4 02 00 PM](https://user-images.githubusercontent.com/26464594/159377057-5fbdfb01-f68b-4dda-8b17-343581c017b9.png)

