### PR TITLE
feat: get the redirects to conditionally render based on the project_name

### DIFF
--- a/src/shared/containers/SetOrg.tsx
+++ b/src/shared/containers/SetOrg.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {useEffect, useState, FC, Suspense} from 'react'
 import {useDispatch, useSelector} from 'react-redux'
-import {Route, Switch, useHistory, useParams} from 'react-router-dom'
+import {Redirect, Route, Switch, useHistory, useParams} from 'react-router-dom'
 
 // Components
 import {CommunityTemplatesIndex} from 'src/templates/containers/CommunityTemplatesIndex'
@@ -117,6 +117,8 @@ const SetOrg: FC = () => {
   }, [orgID, firstOrgID, foundOrg, dispatch, history, orgs.length])
 
   const orgPath = '/orgs/:orgID'
+  const isProjectNotNamedNotebooks =
+    PROJECT_NAME_PLURAL.toLowerCase() !== 'notebooks'
 
   return (
     <PageSpinner loading={loading}>
@@ -165,6 +167,29 @@ const SetOrg: FC = () => {
             path={`${orgPath}/dashboards`}
             component={RouteToDashboardList}
           />
+
+          {/* Notebooks  */}
+          {isProjectNotNamedNotebooks &&
+            isFlagEnabled('flowPublishLifecycle') && (
+              <Redirect
+                from={`${orgPath}/notebooks/:notebookID/versions/:id`}
+                to={`${orgPath}/${PROJECT_NAME_PLURAL.toLowerCase()}/:notebookID/versions/:id`}
+              />
+            )}
+
+          {isProjectNotNamedNotebooks && (
+            <Redirect
+              from={`${orgPath}/notebooks/:id`}
+              to={`${orgPath}/${PROJECT_NAME_PLURAL.toLowerCase()}/:id`}
+            />
+          )}
+
+          {isProjectNotNamedNotebooks && (
+            <Redirect
+              from={`${orgPath}/notebooks`}
+              to={`${orgPath}/${PROJECT_NAME_PLURAL.toLowerCase()}`}
+            />
+          )}
 
           {/* Flows  */}
           {isFlagEnabled('flowPublishLifecycle') && (

--- a/src/tasks/components/TaskRunsCard.tsx
+++ b/src/tasks/components/TaskRunsCard.tsx
@@ -15,22 +15,18 @@ import {
   JustifyContent,
 } from '@influxdata/clockface'
 
-// Actions For Tasks
-import {relativeTimestampFormatter} from 'src/shared/utils/relativeTimestampFormatter'
-
 // Actions
+import {relativeTimestampFormatter} from 'src/shared/utils/relativeTimestampFormatter'
 import {runTask, getRuns, updateTaskStatus} from 'src/tasks/actions/thunks'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
-
-// Actions For Members
 import {getMembers} from 'src/members/actions/thunks'
 import {getOrg} from 'src/organizations/selectors'
-
 import {TaskPage, setCurrentTasksPage} from 'src/tasks/actions/creators'
 
 // Types
 import {ComponentColor, Button} from '@influxdata/clockface'
 import {Task, AppState} from 'src/types'
+import {DEFAULT_PROJECT_NAME} from 'src/flows'
 
 // DateTime
 import {DEFAULT_TIME_FORMAT} from 'src/utils/datetime/constants'
@@ -87,19 +83,28 @@ const TaskRunsCard: FC<Props> = ({task}) => {
       return
     }
 
-    fetch(`/api/v2private/notebooks/resources?type=tasks&resource=${task.id}`, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-        'Accept-Encoding': 'gzip',
-      },
-    })
+    fetch(
+      `/api/v2private/${DEFAULT_PROJECT_NAME.toLowerCase()}/resources?type=tasks&resource=${
+        task.id
+      }`,
+      {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept-Encoding': 'gzip',
+        },
+      }
+    )
       .then(resp => {
         return resp.json()
       })
       .then(resp => {
         if (resp.length) {
-          setRoute(`/orgs/${org.id}/notebooks/${resp[0].notebookID}`)
+          setRoute(
+            `/orgs/${org.id}/${DEFAULT_PROJECT_NAME.toLowerCase()}/${
+              resp[0].notebookID
+            }`
+          )
         } else {
           setRoute(`/notebook/from/task/${task.id}`)
         }
@@ -107,7 +112,7 @@ const TaskRunsCard: FC<Props> = ({task}) => {
       .catch(() => {
         setRoute(`/notebook/from/task/${task.id}`)
       })
-  }, [isFlagEnabled('createWithFlows'), task])
+  }, [isFlagEnabled('createWithFlows'), org.id, task])
 
   if (!task) {
     return null

--- a/src/tasks/components/TaskRunsPage.test.tsx
+++ b/src/tasks/components/TaskRunsPage.test.tsx
@@ -18,6 +18,10 @@ import {RemoteDataState} from 'src/types'
 import {DEFAULT_TIME_FORMAT} from 'src/utils/datetime/constants'
 import {createDateTimeFormatter} from 'src/utils/datetime/formatters'
 
+jest.mock('src/flows', () => {
+  return () => <></>
+})
+
 const runIDs = [
   '07a7f99e81cf2000',
   '07a7f99e81cf3000',

--- a/src/utils/deepLinks.ts
+++ b/src/utils/deepLinks.ts
@@ -18,6 +18,7 @@ export const buildDeepLinkingMap = (org: Organization) => ({
   [`/me/${PROJECT_NAME_PLURAL.toLowerCase()}`]: `/orgs/${
     org.id
   }/${PROJECT_NAME_PLURAL.toLowerCase()}`,
+  '/me/notebooks': `/orgs/${org.id}/${PROJECT_NAME_PLURAL.toLowerCase()}`,
   '/me/pythonclient': `/orgs/${org.id}/load-data/client-libraries/python`,
   '/me/secrets': `/orgs/${org.id}/settings/secrets`,
   '/me/tasks': `/orgs/${org.id}/tasks`,


### PR DESCRIPTION
This PR closes the loop on all routes going to and from notebooks so that they're dependent upon the const, in the event that we decided to switch project names in the near future. This also conditionally renders a redirect so that any users navigating to the old routes will be redirected to the new routes. This should resolve the issue where enabling the feature flag should be handled gracefully

![rename-path](https://user-images.githubusercontent.com/19984220/159481189-7c62523e-44d1-487e-9e4a-c67255a8cdb9.gif)
