### PR TITLE
fix: adding navigation events

### DIFF
--- a/src/accounts/AccountHeader.tsx
+++ b/src/accounts/AccountHeader.tsx
@@ -13,7 +13,7 @@ const AccountHeader: FC<Props> = ({testID = 'member-page--header'}) => (
   <Page.Header fullWidth={false} testID={testID}>
     <Page.Title title="Account" />
     <LimitChecker>
-      <RateLimitAlert />
+      <RateLimitAlert location="account" />
     </LimitChecker>
   </Page.Header>
 )

--- a/src/alerting/components/AlertingIndex.tsx
+++ b/src/alerting/components/AlertingIndex.tsx
@@ -65,7 +65,7 @@ const AlertingIndex: FunctionComponent = () => {
         <Page.Header fullWidth={true} testID="alerts-page--header">
           <Page.Title title="Alerts" />
           <ErrorBoundary>
-            <RateLimitAlert />
+            <RateLimitAlert location="alerting" />
           </ErrorBoundary>
         </Page.Header>
         <Page.Contents

--- a/src/annotations/containers/AnnotationsIndex.tsx
+++ b/src/annotations/containers/AnnotationsIndex.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {FC} from 'react'
-import {useSelector} from 'react-redux'
 
 // Components
 import SettingsTabbedPage from 'src/settings/components/SettingsTabbedPage'
@@ -8,15 +7,10 @@ import SettingsHeader from 'src/settings/components/SettingsHeader'
 import {Page} from '@influxdata/clockface'
 import {AnnotationsTab} from 'src/annotations/components/AnnotationsTab'
 
-// Selectors
-import {getOrg} from 'src/organizations/selectors'
-
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 
 export const AnnotationsIndex: FC = () => {
-  const org = useSelector(getOrg)
-
   return (
     <>
       <Page titleTag={pageTitleSuffixer(['Annotations', 'Settings'])}>

--- a/src/annotations/containers/AnnotationsIndex.tsx
+++ b/src/annotations/containers/AnnotationsIndex.tsx
@@ -21,7 +21,7 @@ export const AnnotationsIndex: FC = () => {
     <>
       <Page titleTag={pageTitleSuffixer(['Annotations', 'Settings'])}>
         <SettingsHeader />
-        <SettingsTabbedPage activeTab="annotations" orgID={org.id}>
+        <SettingsTabbedPage activeTab="annotations">
           {/*
               TODO: GetResources with ResourceType.AnnotationStreams
             */}

--- a/src/billing/components/BillingPage.tsx
+++ b/src/billing/components/BillingPage.tsx
@@ -19,7 +19,7 @@ const BillingPage: FC = () => {
         <Page.Header fullWidth={false} testID="billing-page--header">
           <Page.Title title="Account" />
           <LimitChecker>
-            <RateLimitAlert />
+            <RateLimitAlert location="billing" />
           </LimitChecker>
         </Page.Header>
         <AccountTabContainer activeTab="billing">

--- a/src/checks/components/CheckHistory.tsx
+++ b/src/checks/components/CheckHistory.tsx
@@ -57,7 +57,7 @@ const CheckHistory: FC = () => {
                   title="Check Statuses"
                   testID="alert-history-title"
                 />
-                <RateLimitAlert />
+                <RateLimitAlert location="check history" />
               </Page.Header>
               <Page.ControlBar fullWidth={true}>
                 <Page.ControlBarLeft>

--- a/src/cloud/components/AssetLimitOverlay.tsx
+++ b/src/cloud/components/AssetLimitOverlay.tsx
@@ -16,6 +16,7 @@ import CloudUpgradeButton from 'src/shared/components/CloudUpgradeButton'
 
 // Types
 import {AppState} from 'src/types'
+import {event} from 'src/cloud/utils/reporting'
 
 interface OwnProps {
   onClose: () => void
@@ -57,6 +58,9 @@ const AssetLimitOverlay: FC<OwnProps & StateProps> = ({assetName, onClose}) => {
             <CloudUpgradeButton
               size={ComponentSize.Large}
               className="upgrade-payg--button__asset-create"
+              metric={() => {
+                event('asset limit upgrade', {asset: assetName})
+              }}
             />
           </Overlay.Footer>
         </div>

--- a/src/cloud/components/RateLimitAlertContent.tsx
+++ b/src/cloud/components/RateLimitAlertContent.tsx
@@ -22,6 +22,7 @@ import {event} from 'src/cloud/utils/reporting'
 
 interface Props {
   className?: string
+  location?: string
 }
 
 interface UpgradeProps {
@@ -29,6 +30,7 @@ interface UpgradeProps {
   link: string
   className?: string
   limitText?: string
+  location?: string
 }
 
 export const UpgradeContent: FC<UpgradeProps> = ({
@@ -36,6 +38,7 @@ export const UpgradeContent: FC<UpgradeProps> = ({
   link,
   className,
   limitText,
+  location,
 }) => {
   return (
     <div className={`${className} rate-alert--content__free`}>
@@ -58,14 +61,14 @@ export const UpgradeContent: FC<UpgradeProps> = ({
       >
         <CloudUpgradeButton
           className="upgrade-payg--button__rate-alert"
-          metric={() => event(`user.limits.${type}.upgrade`)}
+          metric={() => event(`user.limits.${type}.upgrade`, {location})}
         />
       </FlexBox>
     </div>
   )
 }
 
-const RateLimitAlertContent: FC<Props> = ({className}) => {
+const RateLimitAlertContent: FC<Props> = ({className, location}) => {
   const dispatch = useDispatch()
   const showUpgradeButton = useSelector(shouldShowUpgradeButton)
   const rateLimitAlertContentClass = classnames('rate-alert--content', {
@@ -82,6 +85,7 @@ const RateLimitAlertContent: FC<Props> = ({className}) => {
         type="series cardinality"
         link="https://docs.influxdata.com/influxdb/v2.0/write-data/best-practices/resolve-high-cardinality/"
         className={rateLimitAlertContentClass}
+        location={location}
       />
     )
   }

--- a/src/dashboards/components/DashboardPage.tsx
+++ b/src/dashboards/components/DashboardPage.tsx
@@ -73,7 +73,7 @@ class DashboardPage extends Component<Props> {
             <LimitChecker>
               <HoverTimeProvider>
                 <DashboardHeader onManualRefresh={onManualRefresh} />
-                <RateLimitAlert alertOnly={true} />
+                <RateLimitAlert alertOnly={true} location="dashboard page" />
                 <VariablesControlBar />
                 <ErrorBoundary>
                   <DashboardComponent manualRefresh={manualRefresh} />

--- a/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
@@ -64,7 +64,7 @@ class DashboardIndex extends PureComponent<Props, State> {
         >
           <Page.Header fullWidth={false}>
             <Page.Title title="Dashboards" />
-            <RateLimitAlert />
+            <RateLimitAlert location="dashboards" />
           </Page.Header>
           <Page.ControlBar fullWidth={false}>
             <ErrorBoundary>

--- a/src/dashboards/components/dashboard_index/DashboardsIndexPaginated.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardsIndexPaginated.tsx
@@ -120,7 +120,7 @@ class DashboardIndex extends PureComponent<Props, State> {
         >
           <Page.Header fullWidth={false}>
             <Page.Title title="Dashboards" />
-            <RateLimitAlert />
+            <RateLimitAlert location="dashboards paginated" />
           </Page.Header>
           <Page.ControlBar fullWidth={false}>
             <ErrorBoundary>

--- a/src/dataExplorer/components/DataExplorerPage.tsx
+++ b/src/dataExplorer/components/DataExplorerPage.tsx
@@ -58,7 +58,7 @@ const DataExplorerPage: FC = () => {
       <GetResources resources={[ResourceType.Variables]}>
         <Page.Header fullWidth={true} testID="data-explorer--header">
           <Page.Title title="Data Explorer" />
-          <RateLimitAlert />
+          <RateLimitAlert location="data explorer" />
         </Page.Header>
         {flowsCTA.explorer && (
           <FeatureFlag name="flowsCTA">

--- a/src/flows/components/FlowsIndex.tsx
+++ b/src/flows/components/FlowsIndex.tsx
@@ -149,7 +149,7 @@ const FlowsIndex = () => {
             stretchToFitWidth
           >
             <Page.Title title={PROJECT_NAME_PLURAL} />
-            <RateLimitAlert />
+            <RateLimitAlert location="flows" />
           </FlexBox>
         )}
         {showButtonMode &&

--- a/src/labels/containers/LabelsIndex.tsx
+++ b/src/labels/containers/LabelsIndex.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
 
 // Components
 import {ErrorHandling} from 'src/shared/decorators/errors'
@@ -12,25 +11,20 @@ import GetResources from 'src/resources/components/GetResources'
 
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
-import {getOrg} from 'src/organizations/selectors'
 
 // Types
-import {AppState, Organization, ResourceType} from 'src/types'
-
-interface StateProps {
-  org: Organization
-}
+import {ResourceType} from 'src/types'
 
 @ErrorHandling
-class LabelsIndex extends PureComponent<StateProps> {
+class LabelsIndex extends PureComponent {
   public render() {
-    const {org, children} = this.props
+    const {children} = this.props
 
     return (
       <>
         <Page titleTag={pageTitleSuffixer(['Labels', 'Settings'])}>
           <SettingsHeader />
-          <SettingsTabbedPage activeTab="labels" orgID={org.id}>
+          <SettingsTabbedPage activeTab="labels">
             <GetResources resources={[ResourceType.Labels]}>
               <LabelsTab />
             </GetResources>
@@ -42,6 +36,4 @@ class LabelsIndex extends PureComponent<StateProps> {
   }
 }
 
-const mstp = (state: AppState) => ({org: getOrg(state)})
-
-export default connect<StateProps>(mstp)(LabelsIndex)
+export default LabelsIndex

--- a/src/me/containers/MePage.tsx
+++ b/src/me/containers/MePage.tsx
@@ -102,7 +102,7 @@ export class MePage extends PureComponent<Props> {
       <Page titleTag={pageTitleSuffixer(['Home'])}>
         <Page.Header fullWidth={false}>
           <Page.Title title="Getting Started" testID="home-page--header" />
-          <RateLimitAlert />
+          <RateLimitAlert location="me page" />
         </Page.Header>
         <Page.Contents fullWidth={false} scrollable={true}>
           <Grid>

--- a/src/organizations/components/OrgHeader.tsx
+++ b/src/organizations/components/OrgHeader.tsx
@@ -11,7 +11,7 @@ type Props = {
 const OrgHeader: FC<Props> = ({testID = 'member-page--header'}) => (
   <Page.Header fullWidth={false} testID={testID}>
     <Page.Title title="Organization" />
-    <RateLimitAlert />
+    <RateLimitAlert location="organization" />
   </Page.Header>
 )
 

--- a/src/pageLayout/containers/TreeNav.tsx
+++ b/src/pageLayout/containers/TreeNav.tsx
@@ -16,6 +16,7 @@ import {generateNavItems} from 'src/pageLayout/constants/navigationHierarchy'
 import {getNavItemActivation} from 'src/pageLayout/utils'
 import {getOrg} from 'src/organizations/selectors'
 import {AppSettingContext} from 'src/shared/contexts/app'
+import {event} from 'src/cloud/utils/reporting'
 
 // Types
 import {NavItem, NavSubItem} from 'src/pageLayout/constants/navigationHierarchy'
@@ -48,7 +49,14 @@ const TreeSidebar: FC = () => {
       >
         {generateNavItems().map((item: NavItem) => {
           const linkElement = (className: string): JSX.Element => (
-            <Link to={item.link} className={className} title={item.label} />
+            <Link
+              to={item.link}
+              className={className}
+              title={item.label}
+              onClick={() => {
+                event('nav clicked', {which: item.id})
+              }}
+            />
           )
           return (
             <TreeNav.Item
@@ -68,7 +76,15 @@ const TreeSidebar: FC = () => {
                 <TreeNav.SubMenu>
                   {item.menu.map((menuItem: NavSubItem) => {
                     const linkElement = (className: string): JSX.Element => (
-                      <Link to={menuItem.link} className={className} />
+                      <Link
+                        to={menuItem.link}
+                        className={className}
+                        onClick={() => {
+                          event('nav clicked', {
+                            which: `${item.id} - ${menuItem.id}`,
+                          })
+                        }}
+                      />
                     )
 
                     return (

--- a/src/resources/components/GetResources.tsx
+++ b/src/resources/components/GetResources.tsx
@@ -19,7 +19,6 @@ import {getVariables} from 'src/variables/actions/thunks'
 import {getSecrets} from 'src/secrets/actions/thunks'
 
 // Utils
-import {event} from 'src/cloud/utils/reporting'
 
 // Types
 import {AppState, ResourceType} from 'src/types'
@@ -44,22 +43,12 @@ class GetResources extends PureComponent<Props> {
   public componentDidMount() {
     const {resources} = this.props
     const promises = []
-    const startTime = Date.now()
+
     resources.forEach(resource => {
       promises.push(this.getResourceDetails(resource))
     })
 
-    const gotResources = resources.join(', ')
-    Promise.all(promises).then(() => {
-      event(
-        'GetResources',
-        {
-          time: startTime,
-          resource: gotResources,
-        },
-        {duration: Date.now() - startTime}
-      )
-    })
+    Promise.all(promises)
   }
 
   private getResourceDetails(resource: ResourceType) {

--- a/src/secrets/containers/SecretsIndex.tsx
+++ b/src/secrets/containers/SecretsIndex.tsx
@@ -25,7 +25,7 @@ const SecretsIndex: FC = () => {
     <>
       <Page titleTag={pageTitleSuffixer(['Secrets', 'Settings'])}>
         <SettingsHeader />
-        <SettingsTabbedPage activeTab="secrets" orgID={org.id}>
+        <SettingsTabbedPage activeTab="secrets">
           <GetResources resources={[ResourceType.Secrets]}>
             <SecretsTab />
           </GetResources>

--- a/src/settings/components/LoadDataHeader.tsx
+++ b/src/settings/components/LoadDataHeader.tsx
@@ -8,7 +8,7 @@ const LoadDataHeader: FC = () => {
   return (
     <Page.Header fullWidth={false} testID="load-data--header">
       <Page.Title title="Load Data" />
-      <RateLimitAlert />
+      <RateLimitAlert location="load data" />
     </Page.Header>
   )
 }

--- a/src/settings/components/LoadDataNavigation.tsx
+++ b/src/settings/components/LoadDataNavigation.tsx
@@ -10,6 +10,7 @@ import {FeatureFlag} from 'src/shared/utils/featureFlag'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 import CloudExclude from 'src/shared/components/cloud/CloudExclude'
 import CloudOnly from 'src/shared/components/cloud/CloudOnly'
+import {event} from 'src/cloud/utils/reporting'
 
 interface OwnProps {
   activeTab: string
@@ -24,6 +25,7 @@ class LoadDataNavigation extends PureComponent<Props> {
     const {activeTab, orgID, history} = this.props
 
     const handleTabClick = (id: string): void => {
+      event('page-nav clicked', {which: `load-data--${id}`})
       history.push(`/orgs/${orgID}/load-data/${id}`)
     }
 

--- a/src/settings/components/SettingsHeader.tsx
+++ b/src/settings/components/SettingsHeader.tsx
@@ -9,7 +9,7 @@ class SettingsHeader extends Component {
     return (
       <Page.Header fullWidth={false}>
         <Page.Title title="Settings" testID="settings-page--header" />
-        <RateLimitAlert />
+        <RateLimitAlert location="settings" />
       </Page.Header>
     )
   }

--- a/src/settings/components/SettingsNavigation.tsx
+++ b/src/settings/components/SettingsNavigation.tsx
@@ -12,6 +12,7 @@ import {TabbedPageTab} from 'src/shared/tabbedPage/TabbedPageTabs'
 
 //  Selectors
 import {getOrg} from 'src/organizations/selectors'
+import {event} from 'src/cloud/utils/reporting'
 
 interface Props {
   activeTab: string
@@ -22,6 +23,7 @@ const SettingsNavigation: FC<Props> = ({activeTab}) => {
   const org = useSelector(getOrg)
 
   const handleTabClick = (id: string): void => {
+    event('page-nav clicked', {which: `settings--${id}`})
     history.push(`/orgs/${org.id}/settings/${id}`)
   }
 

--- a/src/settings/components/SettingsNavigation.tsx
+++ b/src/settings/components/SettingsNavigation.tsx
@@ -1,59 +1,58 @@
 // Libraries
-import React, {PureComponent} from 'react'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
+import React, {FC} from 'react'
+import {useHistory} from 'react-router-dom'
+import {useSelector} from 'react-redux'
 
 // Components
 import TabbedPageTabs from 'src/shared/tabbedPage/TabbedPageTabs'
+import ErrorBoundary from 'src/shared/components/ErrorBoundary'
 
 // Types
 import {TabbedPageTab} from 'src/shared/tabbedPage/TabbedPageTabs'
 
-// Decorators
-import {ErrorHandling} from 'src/shared/decorators/errors'
+//  Selectors
+import {getOrg} from 'src/organizations/selectors'
 
-interface OwnProps {
+interface Props {
   activeTab: string
-  orgID: string
 }
 
-type Props = OwnProps & RouteComponentProps<{orgID: string}>
+const SettingsNavigation: FC<Props> = ({activeTab}) => {
+  const history = useHistory()
+  const org = useSelector(getOrg)
 
-@ErrorHandling
-class SettingsNavigation extends PureComponent<Props> {
-  public render() {
-    const {activeTab, orgID, history} = this.props
+  const handleTabClick = (id: string): void => {
+    history.push(`/orgs/${org.id}/settings/${id}`)
+  }
 
-    const handleTabClick = (id: string): void => {
-      history.push(`/orgs/${orgID}/settings/${id}`)
-    }
+  const tabs: TabbedPageTab[] = [
+    {
+      text: 'Variables',
+      id: 'variables',
+    },
+    {
+      text: 'Templates',
+      id: 'templates',
+    },
+    {
+      text: 'Labels',
+      id: 'labels',
+    },
+    {
+      text: 'Secrets',
+      id: 'secrets',
+    },
+  ]
 
-    const tabs: TabbedPageTab[] = [
-      {
-        text: 'Variables',
-        id: 'variables',
-      },
-      {
-        text: 'Templates',
-        id: 'templates',
-      },
-      {
-        text: 'Labels',
-        id: 'labels',
-      },
-      {
-        text: 'Secrets',
-        id: 'secrets',
-      },
-    ]
-
-    return (
+  return (
+    <ErrorBoundary>
       <TabbedPageTabs
         tabs={tabs}
         activeTab={activeTab}
         onTabClick={handleTabClick}
       />
-    )
-  }
+    </ErrorBoundary>
+  )
 }
 
-export default withRouter(SettingsNavigation)
+export default SettingsNavigation

--- a/src/settings/components/SettingsTabbedPage.tsx
+++ b/src/settings/components/SettingsTabbedPage.tsx
@@ -10,13 +10,12 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface Props {
   activeTab: string
-  orgID: string
 }
 
 @ErrorHandling
 class SettingsTabbedPage extends PureComponent<Props> {
   public render() {
-    const {activeTab, orgID, children} = this.props
+    const {activeTab, children} = this.props
 
     return (
       <Page.Contents
@@ -26,7 +25,7 @@ class SettingsTabbedPage extends PureComponent<Props> {
         autoHideScrollbar={true}
       >
         <Tabs.Container orientation={Orientation.Horizontal}>
-          <SettingsNavigation activeTab={activeTab} orgID={orgID} />
+          <SettingsNavigation activeTab={activeTab} />
           <Tabs.TabContents>{children}</Tabs.TabContents>
         </Tabs.Container>
       </Page.Contents>

--- a/src/shared/components/NotFound.tsx
+++ b/src/shared/components/NotFound.tsx
@@ -25,6 +25,7 @@ import {AppState, Organization} from 'src/types'
 // Utils
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {buildDeepLinkingMap} from 'src/utils/deepLinks'
+import {event} from 'src/cloud/utils/reporting'
 
 // Components
 import LogoWithCubo from 'src/checkout/LogoWithCubo'
@@ -161,6 +162,7 @@ class NotFound extends Component<Props> {
       const deepLinkingMap = buildDeepLinkingMap(org)
 
       if (deepLinkingMap.hasOwnProperty(this.props.location.pathname)) {
+        event('deeplink', {from: this.props.location.pathname})
         this.props.history.replace(deepLinkingMap[this.props.location.pathname])
         return
       }

--- a/src/tasks/components/TaskHeader.tsx
+++ b/src/tasks/components/TaskHeader.tsx
@@ -24,7 +24,7 @@ export default class TaskHeader extends PureComponent<Props> {
       <>
         <Page.Header fullWidth={true}>
           <Page.Title title={title} />
-          <RateLimitAlert />
+          <RateLimitAlert location="tasks" />
         </Page.Header>
         <Page.ControlBar fullWidth={true}>
           <Page.ControlBarRight>

--- a/src/tasks/components/TaskRunsPage.tsx
+++ b/src/tasks/components/TaskRunsPage.tsx
@@ -67,7 +67,7 @@ class TaskRunsPage extends PureComponent<Props, State> {
                 },
               ]}
             />
-            <RateLimitAlert />
+            <RateLimitAlert location="task runs" />
           </Page.Header>
           <Page.ControlBar fullWidth={false}>
             <TaskRunsCard task={currentTask} />

--- a/src/tasks/components/TasksHeader.tsx
+++ b/src/tasks/components/TasksHeader.tsx
@@ -83,7 +83,7 @@ const TasksHeader: FC<Props> = ({
     <>
       <Page.Header fullWidth={false} testID="tasks-page--header">
         <Page.Title title="Tasks" />
-        <RateLimitAlert />
+        <RateLimitAlert location="task list" />
       </Page.Header>
       {flowsCTA.tasks && (
         <FeatureFlag name="flowsCTA">

--- a/src/templates/containers/CommunityTemplatesIndex.tsx
+++ b/src/templates/containers/CommunityTemplatesIndex.tsx
@@ -109,7 +109,7 @@ class UnconnectedCommunityTemplatesIndex extends Component<Props, State> {
       <>
         <Page titleTag={pageTitleSuffixer(['Templates', 'Settings'])}>
           <SettingsHeader />
-          <SettingsTabbedPage activeTab="templates" orgID={org.id}>
+          <SettingsTabbedPage activeTab="templates">
             <FlexBox
               direction={FlexDirection.Column}
               margin={ComponentSize.Small}

--- a/src/variables/containers/VariablesIndex.tsx
+++ b/src/variables/containers/VariablesIndex.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {Component} from 'react'
-import {connect} from 'react-redux'
 import {Switch, Route} from 'react-router-dom'
 
 // Components
@@ -23,26 +22,20 @@ import {
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 
 // Types
-import {AppState, Organization, ResourceType} from 'src/types'
-
-interface StateProps {
-  org: Organization
-}
+import {ResourceType} from 'src/types'
 
 import {ORGS, ORG_ID, SETTINGS, VARIABLES} from 'src/shared/constants/routes'
 
 const varsPath = `/${ORGS}/${ORG_ID}/${SETTINGS}/${VARIABLES}`
 
 @ErrorHandling
-class VariablesIndex extends Component<StateProps> {
+class VariablesIndex extends Component {
   public render() {
-    const {org} = this.props
-
     return (
       <>
         <Page titleTag={pageTitleSuffixer(['Variables', 'Settings'])}>
           <SettingsHeader />
-          <SettingsTabbedPage activeTab="variables" orgID={org.id}>
+          <SettingsTabbedPage activeTab="variables">
             <GetResources resources={[ResourceType.Variables]}>
               <VariablesTab />
             </GetResources>
@@ -72,8 +65,4 @@ class VariablesIndex extends Component<StateProps> {
   }
 }
 
-const mstp = (state: AppState) => {
-  return {org: state.resources.orgs.org}
-}
-
-export default connect<StateProps>(mstp)(VariablesIndex)
+export default VariablesIndex

--- a/src/writeData/subscriptions/components/CreateSubscriptionPage.tsx
+++ b/src/writeData/subscriptions/components/CreateSubscriptionPage.tsx
@@ -39,6 +39,7 @@ import {AppState, ResourceType, Bucket} from 'src/types'
 
 // Utils
 import {getAll} from 'src/resources/selectors'
+import {event} from 'src/cloud/utils/reporting'
 
 // Actions
 import {shouldShowUpgradeButton} from 'src/me/selectors'
@@ -77,7 +78,11 @@ const CreateSubscriptionPage: FC = () => {
                 alignItems={AlignItems.FlexEnd}
                 stretchToFitHeight={true}
               >
-                <CloudUpgradeButton />
+                <CloudUpgradeButton
+                  metric={() => {
+                    event('subscription upgrade')
+                  }}
+                />
               </FlexBox>
             )}
             {/* TODO: swap out for clockface svg when available */}

--- a/src/writeData/subscriptions/components/ParsingForm.tsx
+++ b/src/writeData/subscriptions/components/ParsingForm.tsx
@@ -29,6 +29,7 @@ import CloudUpgradeButton from 'src/shared/components/CloudUpgradeButton'
 
 // Utils
 import {getOrg} from 'src/organizations/selectors'
+import {event} from 'src/cloud/utils/reporting'
 
 // Types
 import {SUBSCRIPTIONS, LOAD_DATA} from 'src/shared/constants/routes'
@@ -189,7 +190,12 @@ const ParsingForm: FC<Props> = ({
               testID="create-parsing-form--back"
             />
             {showUpgradeButton ? (
-              <CloudUpgradeButton className="create-parsing-form__upgrade-button" />
+              <CloudUpgradeButton
+                className="create-parsing-form__upgrade-button"
+                metric={() => {
+                  event('parsing form upgrade')
+                }}
+              />
             ) : (
               <Button
                 text="Next"


### PR DESCRIPTION
we had no visibility into how many people are clicking the upgrade button or where they were when they click it, so i added that event so that we an start looking closer at those funnels. hoping we can optimize that workflow a bit. also added some events to the tree nav as we have very little insight into how many people are using that crucial piece of navigation.

sparked by the observation that the "happy path" for our users who want to sign up and aren't sold by the "trust us it's easy" text on the top of the checkout form is a loop to nowhere.

![d65be39125](https://user-images.githubusercontent.com/1434802/159765986-144bea5b-01f4-4163-a41d-d5a9269860ba.gif)
