### PR TITLE
feat: restrict panel adding based on previous panels

### DIFF
--- a/cypress/e2e/shared/flows.test.ts
+++ b/cypress/e2e/shared/flows.test.ts
@@ -591,17 +591,19 @@ describe('Flows', () => {
       cy.getByTestID(`add-flow-btn--${item.panel}`).should('have.length', 2)
 
       // Click the newest button from opening the panel button
-      cy.getByTestID(`add-flow-btn--${item.panel}`)
-        .last()
-        .click()
-      if (item.panel === 'queryBuilder') {
-        cy.wait('@fetchAllBuckets')
-      } else if (item.panel === 'notification') {
-        cy.wait('@fetchSecrets')
-      }
+      cy.get('.insert-cell-menu.always-on').within(() => {
+        cy.getByTestID(`add-flow-btn--${item.panel}`)
+          .last()
+          .click()
+        if (item.panel === 'queryBuilder') {
+          cy.wait('@fetchAllBuckets')
+        } else if (item.panel === 'notification') {
+          cy.wait('@fetchSecrets')
+        }
+      })
 
       cy.getByTestID('sidebar-button')
-        .first()
+        .last()
         .click()
       cy.getByTestID('dropdown-menu').should('be.visible')
       cy.getByTestID('dropdown-menu--contents')

--- a/src/flows/components/AddButtons.tsx
+++ b/src/flows/components/AddButtons.tsx
@@ -84,9 +84,7 @@ const AddButtons: FC<Props> = ({index, onInsert}) => {
 
   const pipeIds = flow.data.allIDs
   const firstQueryIndex = pipeIds.findIndex(
-    id =>
-      flow.data.byID[id].type === 'queryBuilder' ||
-      flow.data.byID[id].type === 'rawFluxEditor'
+    id => PIPE_DEFINITIONS[flow.data.byID[id].type].family === 'inputs'
   )
 
   const cellFamilies = SUPPORTED_FAMILIES.filter(fam =>

--- a/src/flows/components/AddButtons.tsx
+++ b/src/flows/components/AddButtons.tsx
@@ -2,7 +2,7 @@
 import React, {FC, useContext} from 'react'
 
 // Components
-import {Button, ComponentColor} from '@influxdata/clockface'
+import {Button, ComponentColor, ComponentStatus} from '@influxdata/clockface'
 import CellFamily from 'src/flows/components/CellFamily'
 
 // Constants
@@ -47,6 +47,8 @@ const SUPPORTED_FAMILIES = [
   },
 ]
 
+const NEED_QUERY_PANELS = ['table', 'visualization', 'notification', 'schedule']
+
 const AddButtons: FC<Props> = ({index, onInsert}) => {
   const {flow, add} = useContext(FlowContext)
   const {queryDependents} = useContext(FlowQueryContext)
@@ -80,15 +82,27 @@ const AddButtons: FC<Props> = ({index, onInsert}) => {
     return acc
   }, {})
 
+  const pipeIds = flow.data.allIDs
+  const firstQueryIndex = pipeIds.findIndex(
+    id =>
+      flow.data.byID[id].type === 'queryBuilder' ||
+      flow.data.byID[id].type === 'rawFluxEditor'
+  )
+
   const cellFamilies = SUPPORTED_FAMILIES.filter(fam =>
     pipeFamilies.hasOwnProperty(fam.family)
   ).map(fam => {
     const pipes = pipeFamilies[fam.family].map(def => {
+      let status = ComponentStatus.Default
+      if (index < firstQueryIndex && NEED_QUERY_PANELS.includes(def.type)) {
+        status = ComponentStatus.Disabled
+      }
       return (
         <Button
           className={`flows-add-cell-${def.type}`}
           key={def.type}
           text={def.button}
+          disabledTitleText="This panel is only available after you have added a data source panel."
           testID={`add-flow-btn--${def.type}`}
           onClick={() => {
             let data = def.initial
@@ -119,6 +133,7 @@ const AddButtons: FC<Props> = ({index, onInsert}) => {
               )
             )
           }}
+          status={status}
           color={ComponentColor.Secondary}
         />
       )


### PR DESCRIPTION
Closes #3777 

### Problem

Any time of panel could be added anywhere, regardless of whether a panel is dependent upon previous query results or not

### Solution 

Conditionally disabled certain panel type additions so that users are forced into a flow of valid panel insertions based on the previous pipes.

![add-panel](https://user-images.githubusercontent.com/19984220/159758961-793ff472-db87-40c2-bd52-ff5afc5040f9.gif)

<!-- Describe your proposed changes here. -->
