### PR TITLE
chore: audit some features that are behind flags to determine their usage

### DIFF
--- a/src/checks/components/CheckMatchingRulesCard.tsx
+++ b/src/checks/components/CheckMatchingRulesCard.tsx
@@ -31,11 +31,15 @@ import {
 import {EmptyState, ComponentSize, RemoteDataState} from '@influxdata/clockface'
 import BuilderCard from 'src/timeMachine/components/builderCard/BuilderCard'
 import {getActiveTimeMachine} from 'src/timeMachine/selectors'
+import {event} from 'src/cloud/utils/reporting'
 
 type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps
 
 const CheckMatchingRulesCard: FC<Props> = ({orgID, tags, queryResults}) => {
+  React.useEffect(() => {
+    event('CheckMatchingRulesCard')
+  })
   const getMatchingRules = async (): Promise<NotificationRule[]> => {
     const checkTags = tags
       .filter(t => t.key && t.value)

--- a/src/shared/components/TimeSeries.tsx
+++ b/src/shared/components/TimeSeries.tsx
@@ -26,6 +26,7 @@ import {getOrgIDFromBuckets} from 'src/timeMachine/actions/queries'
 import {hashCode} from 'src/shared/apis/queryCache'
 import {RunQueryPromiseMutex} from 'src/shared/apis/singleQuery'
 import {parseASTIM} from 'src/variables/utils/astim'
+import {event} from 'src/cloud/utils/reporting'
 
 // Constants
 import {rateLimitReached, resultTooLarge} from 'src/shared/copy/notifications'
@@ -48,7 +49,6 @@ import {
   AppState,
   CancelBox,
 } from 'src/types'
-import {event} from 'src/cloud/utils/reporting'
 
 interface QueriesState {
   files: string[] | null
@@ -299,6 +299,7 @@ class TimeSeries extends Component<Props, State> {
       let giraffeResult
 
       if (isFlagEnabled('fluxParser')) {
+        event('fluxParserFlag')
         giraffeResult = fromFlux(files.join('\n\n'))
       } else {
         giraffeResult = fromFluxGiraffe(files.join('\n\n'))

--- a/src/timeMachine/actions/queries.ts
+++ b/src/timeMachine/actions/queries.ts
@@ -340,6 +340,7 @@ export const executeQueries = (abortController?: AbortController) => async (
       }
 
       if (isFlagEnabled('fluxParser')) {
+        event('fluxParserFlag')
         // TODO: this is just here for validation. since we are already eating
         // the cost of parsing the results, we should store the output instead
         // of the raw input
@@ -424,6 +425,7 @@ export const executeCheckQuery = () => async (dispatch, getState: GetState) => {
     }
 
     if (isFlagEnabled('fluxParser')) {
+      event('fluxParserFlag')
       // TODO: this is just here for validation. since we are already eating
       // the cost of parsing the results, we should store the output instead
       // of the raw input

--- a/src/timeMachine/components/CustomizeCheckQueryButton.tsx
+++ b/src/timeMachine/components/CustomizeCheckQueryButton.tsx
@@ -7,6 +7,7 @@ import {Button} from '@influxdata/clockface'
 
 // Actions
 import {loadCustomCheckQueryState} from 'src/timeMachine/actions'
+import {event} from 'src/cloud/utils/reporting'
 
 interface DispatchProps {
   onLoadCustomCheckQueryState: typeof loadCustomCheckQueryState
@@ -15,6 +16,9 @@ interface DispatchProps {
 const CustomizeCheckQueryButton: FC<DispatchProps> = ({
   onLoadCustomCheckQueryState,
 }) => {
+  React.useEffect(() => {
+    event('CustomizeCheckQueryButton')
+  }, [])
   const switchToEditor = () => {
     onLoadCustomCheckQueryState()
   }


### PR DESCRIPTION
We've got some codepaths behind feature flags that are .... outdated. This PR adds some events to the areas of our codebase that are feature flagged in order to get a better sense of whether they're being used or not