### PR TITLE
test(firstMile): add the proper test id to the page to make PDT pass

### DIFF
--- a/src/homepageExperience/containers/HomepageContainer.tsx
+++ b/src/homepageExperience/containers/HomepageContainer.tsx
@@ -10,6 +10,8 @@ import {
   FlexBox,
   FlexDirection,
   Grid,
+  Heading,
+  HeadingElement,
   Icon,
   IconFont,
   InfluxColors,
@@ -64,7 +66,12 @@ export const HomepageContainer: FC = () => {
                   direction={FlexDirection.Column}
                   alignItems={AlignItems.Stretch}
                 >
-                  <h1>Get Started</h1>
+                  <Heading
+                    testID="home-page--header"
+                    element={HeadingElement.H1}
+                  >
+                    Get Started
+                  </Heading>
                   <h5>
                     Write and query data using the programming language of your
                     choice


### PR DESCRIPTION
### Background:

The Post Deployment Tests (PDT) rely on two header elements to exist on the homepage. A previous PR (https://github.com/influxdata/ui/pull/4185) added one of them, but due to a number of factors external to this code, we weren't able to test that change and see that the tests didn't pass. This PR adds the other element that the tests require to reach parity with the existing homepage.

#### Without this change, PDT fail:
![Screen Shot 2022-03-24 at 9 44 17 AM](https://user-images.githubusercontent.com/146112/159930057-e658cd62-a044-400c-b501-51d28908fcbd.png)
 
#### With this change, PDT pass:
![Screen Shot 2022-03-24 at 9 45 13 AM](https://user-images.githubusercontent.com/146112/159930131-c9e9969e-226d-41c3-b715-67fc6ffdd3ed.png)

