### PR TITLE
feat: separate the flow list from the current flow

### DIFF
--- a/cypress/e2e/cloud/pinned.test.ts
+++ b/cypress/e2e/cloud/pinned.test.ts
@@ -206,7 +206,7 @@ from(bucket: "${name}"{rightarrow}
     })
   })
 
-  describe('Pin flow tests', () => {
+  describe.only('Pin flow tests', () => {
     beforeEach(() => {
       cy.setFeatureFlags({
         pinnedItems: true,
@@ -227,14 +227,31 @@ from(bucket: "${name}"{rightarrow}
         .first()
         .click()
 
-      cy.getByTestID('time-machine-submit-button').should('be.visible')
       cy.getByTestID('page-title')
         .first()
         .click()
+      cy.intercept('PATCH', '**/notebooks/*').as('updateNotebook')
       cy.getByTestID('renamable-page-title--input')
         .clear()
         .type('Flow')
         .type('{enter}')
+      // TODO(ariel): fix this part of the test so that the intercept can do its thing
+      cy.wait('@updateNotebook')
+      cy.getByTestID('time-machine-submit-button')
+        .should('be.visible')
+        .and('be.disabled')
+      cy.getByTestID('enable-auto-refresh-button').should('be.disabled')
+      cy.getByTestID('dropdown-menu--contents').should('not.exist')
+      cy.getByTestID('timezone-dropdown').click()
+      cy.getByTestID('dropdown-menu--contents')
+        .should('be.visible')
+        .within(() => {
+          cy.getByTestID('dropdown-item').should('have.length.gte', 2)
+          cy.getByTestID('dropdown-item')
+            .last()
+            .click()
+        })
+      cy.wait('@updateNotebook')
       cy.visit(`/orgs/${orgID}/notebooks`)
     })
 
@@ -256,6 +273,7 @@ from(bucket: "${name}"{rightarrow}
         cy.getByTestID('context-menu-flow').click()
       })
       cy.getByTestID('context-pin-flow').click()
+      cy.getByTestID('notification-success--children').should('exist')
 
       cy.getByTestID('resource-editable-name')
         .first()
@@ -271,6 +289,8 @@ from(bucket: "${name}"{rightarrow}
         .focus()
         .type('Bucks In Six')
         .type('{enter}')
+      cy.getByTestID('notification-success--children').should('exist')
+      cy.wait('@updateNotebook')
       cy.wait('@updatePinned')
       cy.visit('/')
       cy.getByTestID('tree-nav')

--- a/cypress/e2e/cloud/pinned.test.ts
+++ b/cypress/e2e/cloud/pinned.test.ts
@@ -235,7 +235,7 @@ from(bucket: "${name}"{rightarrow}
         .clear()
         .type('Flow')
         .type('{enter}')
-      // TODO(ariel): fix this part of the test so that the intercept can do its thing
+
       cy.wait('@updateNotebook')
       cy.getByTestID('time-machine-submit-button')
         .should('be.visible')

--- a/cypress/e2e/cloud/pinned.test.ts
+++ b/cypress/e2e/cloud/pinned.test.ts
@@ -206,7 +206,7 @@ from(bucket: "${name}"{rightarrow}
     })
   })
 
-  describe.only('Pin flow tests', () => {
+  describe('Pin flow tests', () => {
     beforeEach(() => {
       cy.setFeatureFlags({
         pinnedItems: true,

--- a/src/flows/components/FlowPage.tsx
+++ b/src/flows/components/FlowPage.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {FC, useContext, useEffect} from 'react'
-import {useParams} from 'react-router-dom'
 import {Page} from '@influxdata/clockface'
 import {DapperScrollbars} from '@influxdata/clockface'
 
@@ -8,7 +7,6 @@ import {DapperScrollbars} from '@influxdata/clockface'
 import CurrentFlowProvider, {FlowContext} from 'src/flows/context/flow.current'
 import QueryProvider from 'src/shared/contexts/query'
 import {FlowQueryProvider, FlowQueryContext} from 'src/flows/context/flow.query'
-import {FlowListContext} from 'src/flows/context/flow.list'
 import {PopupDrawer, PopupProvider} from 'src/flows/context/popup'
 import {ResultsProvider} from 'src/flows/context/results'
 import {SidebarProvider} from 'src/flows/context/sidebar'
@@ -29,23 +27,15 @@ import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 import {event} from 'src/cloud/utils/reporting'
 
 const FlowFromRoute = () => {
-  const {id} = useParams<{id: string}>()
-  const {change, flows, currentID} = useContext(FlowListContext)
+  const {flow} = useContext(FlowContext)
 
   useEffect(() => {
-    change(id)
-  }, [id, change])
-
-  useEffect(() => {
-    if (currentID !== null) {
-      event('Notebook Accessed', {notebookID: currentID})
+    if (flow?.id != null) {
+      event('Notebook Accessed', {notebookID: flow.id})
     }
-  }, [currentID])
+  }, [flow.id])
 
-  document.title = pageTitleSuffixer([
-    flows[currentID]?.name,
-    PROJECT_NAME_PLURAL,
-  ])
+  document.title = pageTitleSuffixer([flow?.name, PROJECT_NAME_PLURAL])
 
   return null
 }

--- a/src/flows/components/FlowPage.tsx
+++ b/src/flows/components/FlowPage.tsx
@@ -17,28 +17,7 @@ import {SubSideBar} from 'src/flows/components/Sidebar'
 import FlowHeader from 'src/flows/components/header'
 import FlowKeyboardPreview from 'src/flows/components/FlowKeyboardPreview'
 
-// Constants
-import {PROJECT_NAME_PLURAL} from 'src/flows'
-
 import 'src/flows/style.scss'
-
-// Utils
-import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
-import {event} from 'src/cloud/utils/reporting'
-
-const FlowFromRoute = () => {
-  const {flow} = useContext(FlowContext)
-
-  useEffect(() => {
-    if (flow?.id != null) {
-      event('Notebook Accessed', {notebookID: flow.id})
-    }
-  }, [flow.id])
-
-  document.title = pageTitleSuffixer([flow?.name, PROJECT_NAME_PLURAL])
-
-  return null
-}
 
 const RunOnMount = () => {
   const {queryAll} = useContext(FlowQueryContext)
@@ -87,7 +66,6 @@ export const FlowPage: FC = () => (
 export default () => (
   <QueryProvider>
     <CurrentFlowProvider>
-      <FlowFromRoute />
       <FlowPage />
     </CurrentFlowProvider>
   </QueryProvider>

--- a/src/flows/components/header/MenuButton.tsx
+++ b/src/flows/components/header/MenuButton.tsx
@@ -38,35 +38,41 @@ const MenuButton: FC<Props> = ({handleResetShare}) => {
   const {flow, cloneNotebook, deleteNotebook} = useContext(FlowContext)
   const {handlePublish, versions} = useContext(VersionPublishContext)
   const {id: orgID} = useSelector(getOrg)
-  const [cloneLoading, setCloneLoading] = useState(RemoteDataState.Done)
+  const [loading, setLoading] = useState(RemoteDataState.Done)
 
   const triggerRef: RefObject<HTMLButtonElement> = createRef()
   const history = useHistory()
 
   const handleClone = async () => {
     try {
-      setCloneLoading(RemoteDataState.Loading)
+      setLoading(RemoteDataState.Loading)
       event('clone_notebook', {
         context: 'notebook',
       })
       const clonedId = await cloneNotebook()
       handleResetShare()
-      setCloneLoading(RemoteDataState.Done)
+      setLoading(RemoteDataState.Done)
       history.push(
         `/orgs/${orgID}/${PROJECT_NAME_PLURAL.toLowerCase()}/${clonedId}`
       )
     } catch {
-      setCloneLoading(RemoteDataState.Done)
+      setLoading(RemoteDataState.Done)
     }
   }
 
-  const handleDelete = () => {
-    event('delete_notebook', {
-      context: 'notebook',
-    })
-    deletePinnedItemByParam(flow.id)
-    deleteNotebook()
-    history.push(`/orgs/${orgID}/${PROJECT_NAME_PLURAL.toLowerCase()}`)
+  const handleDelete = async () => {
+    try {
+      setLoading(RemoteDataState.Loading)
+      event('delete_notebook', {
+        context: 'notebook',
+      })
+      deletePinnedItemByParam(flow.id)
+      await deleteNotebook()
+      setLoading(RemoteDataState.Done)
+      history.push(`/orgs/${orgID}/${PROJECT_NAME_PLURAL.toLowerCase()}`)
+    } catch {
+      setLoading(RemoteDataState.Error)
+    }
   }
 
   const canvasOptions = {
@@ -225,7 +231,7 @@ const MenuButton: FC<Props> = ({handleResetShare}) => {
 
   return (
     <SpinnerContainer
-      loading={cloneLoading}
+      loading={loading}
       spinnerComponent={<TechnoSpinner style={{width: 20, height: 20}} />}
       style={{width: 20, height: 20}}
     >

--- a/src/flows/components/header/MenuButton.tsx
+++ b/src/flows/components/header/MenuButton.tsx
@@ -12,7 +12,6 @@ import {useSelector} from 'react-redux'
 
 // Contexts
 import {FlowContext} from 'src/flows/context/flow.current'
-import {FlowListContext} from 'src/flows/context/flow.list'
 import {VersionPublishContext} from 'src/flows/context/version.publish'
 import {useHistory} from 'react-router-dom'
 
@@ -33,8 +32,7 @@ type Props = {
 }
 
 const MenuButton: FC<Props> = ({handleResetShare}) => {
-  const {remove, clone} = useContext(FlowListContext)
-  const {flow} = useContext(FlowContext)
+  const {flow, cloneNotebook, deleteNotebook} = useContext(FlowContext)
   const {handlePublish, versions} = useContext(VersionPublishContext)
   const {id: orgID} = useSelector(getOrg)
 
@@ -45,7 +43,7 @@ const MenuButton: FC<Props> = ({handleResetShare}) => {
     event('clone_notebook', {
       context: 'notebook',
     })
-    const clonedId = await clone(flow.id)
+    const clonedId = await cloneNotebook()
     handleResetShare()
     history.push(
       `/orgs/${orgID}/${PROJECT_NAME_PLURAL.toLowerCase()}/${clonedId}`
@@ -57,7 +55,7 @@ const MenuButton: FC<Props> = ({handleResetShare}) => {
       context: 'notebook',
     })
     deletePinnedItemByParam(flow.id)
-    remove(flow.id)
+    deleteNotebook()
     history.push(`/orgs/${orgID}/${PROJECT_NAME_PLURAL.toLowerCase()}`)
   }
 

--- a/src/flows/context/flow.current.tsx
+++ b/src/flows/context/flow.current.tsx
@@ -348,22 +348,23 @@ export const FlowProvider: FC = ({children}) => {
       return
     }
 
-    currentFlow.data.byID[id] = initial
-    currentFlow.meta.byID[id] = {
+    const flowCopy = JSON.parse(JSON.stringify(currentFlow))
+
+    flowCopy.data.byID[id] = initial
+    flowCopy.meta.byID[id] = {
       title,
       visible: true,
     }
 
     if (typeof index !== 'undefined') {
-      currentFlow.data.allIDs.splice(index + 1, 0, id)
-      currentFlow.meta.allIDs.splice(index + 1, 0, id)
+      flowCopy.data.allIDs.splice(index + 1, 0, id)
+      flowCopy.meta.allIDs.splice(index + 1, 0, id)
     } else {
-      currentFlow.data.allIDs.push(id)
-      currentFlow.meta.allIDs.push(id)
+      flowCopy.data.allIDs.push(id)
+      flowCopy.meta.allIDs.push(id)
     }
 
-    updateData(id, {})
-    updateMeta(id, {})
+    update(flowCopy)
 
     return id
   }
@@ -405,14 +406,15 @@ export const FlowProvider: FC = ({children}) => {
       return
     }
 
-    currentFlow.meta.allIDs = currentFlow.meta.allIDs.filter(_id => _id !== id)
-    currentFlow.data.allIDs = currentFlow.data.allIDs.filter(_id => _id !== id)
+    const flowCopy = JSON.parse(JSON.stringify(currentFlow))
 
-    delete currentFlow.data.byID[id]
-    delete currentFlow.meta.byID[id]
+    flowCopy.meta.allIDs = flowCopy.meta.allIDs.filter(_id => _id !== id)
+    flowCopy.data.allIDs = flowCopy.data.allIDs.filter(_id => _id !== id)
 
-    updateData(id, {})
-    updateMeta(id, {})
+    delete flowCopy.data.byID[id]
+    delete flowCopy.meta.byID[id]
+
+    update(flowCopy)
   }
 
   if (!currentFlow) {

--- a/src/flows/context/flow.current.tsx
+++ b/src/flows/context/flow.current.tsx
@@ -18,6 +18,11 @@ import {
   notebookDeleteFail,
   notebookDeleteSuccess,
 } from 'src/shared/copy/notifications'
+import {
+  RemoteDataState,
+  SpinnerContainer,
+  TechnoSpinner,
+} from '@influxdata/clockface'
 
 const prettyid = customAlphabet('abcdefghijklmnop0123456789', 12)
 
@@ -415,6 +420,15 @@ export const FlowProvider: FC = ({children}) => {
     delete flowCopy.meta.byID[id]
 
     update(flowCopy)
+  }
+
+  if (!currentFlow) {
+    return (
+      <SpinnerContainer
+        loading={RemoteDataState.Loading}
+        spinnerComponent={<TechnoSpinner />}
+      />
+    )
   }
 
   return (

--- a/src/flows/context/flow.current.tsx
+++ b/src/flows/context/flow.current.tsx
@@ -75,7 +75,9 @@ export const FlowProvider: FC = ({children}) => {
       if (response.status !== 204) {
         throw new Error(response.data.message)
       }
+
       dispatch(notify(notebookDeleteSuccess()))
+      return id
     } catch (error) {
       dispatch(notify(notebookDeleteFail()))
     }

--- a/src/flows/context/flow.current.tsx
+++ b/src/flows/context/flow.current.tsx
@@ -1,7 +1,7 @@
 import React, {FC, useCallback, useRef, useState, useEffect} from 'react'
 import {Flow, PipeData, PipeMeta} from 'src/types/flows'
 import {customAlphabet} from 'nanoid'
-import {PIPE_DEFINITIONS} from 'src/flows'
+import {PIPE_DEFINITIONS, PROJECT_NAME_PLURAL} from 'src/flows'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {Doc} from 'yjs'
 import {WebsocketProvider} from 'y-websocket'
@@ -23,6 +23,7 @@ import {
   SpinnerContainer,
   TechnoSpinner,
 } from '@influxdata/clockface'
+import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 
 const prettyid = customAlphabet('abcdefghijklmnop0123456789', 12)
 
@@ -118,6 +119,7 @@ export const FlowProvider: FC = ({children}) => {
 
   useEffect(() => {
     if (id) {
+      event('Notebook Accessed', {notebookID: id})
       handleGetNotebook(id)
     }
   }, [handleGetNotebook, id])
@@ -430,6 +432,8 @@ export const FlowProvider: FC = ({children}) => {
       />
     )
   }
+
+  document.title = pageTitleSuffixer([currentFlow?.name, PROJECT_NAME_PLURAL])
 
   return (
     <FlowContext.Provider

--- a/src/flows/context/flow.current.tsx
+++ b/src/flows/context/flow.current.tsx
@@ -76,7 +76,6 @@ export const FlowProvider: FC = ({children}) => {
   }, [dispatch, id])
 
   const handleCloneNotebook = useCallback(async () => {
-    event('clone_notebook')
     try {
       const {flows} = await getAllAPI(orgID)
 
@@ -349,20 +348,18 @@ export const FlowProvider: FC = ({children}) => {
       return
     }
 
-    const flowCopy = JSON.parse(JSON.stringify(currentFlow))
-
-    flowCopy.data.byID[id] = initial
-    flowCopy.meta.byID[id] = {
+    currentFlow.data.byID[id] = initial
+    currentFlow.meta.byID[id] = {
       title,
       visible: true,
     }
 
     if (typeof index !== 'undefined') {
-      flowCopy.data.allIDs.splice(index + 1, 0, id)
-      flowCopy.meta.allIDs.splice(index + 1, 0, id)
+      currentFlow.data.allIDs.splice(index + 1, 0, id)
+      currentFlow.meta.allIDs.splice(index + 1, 0, id)
     } else {
-      flowCopy.data.allIDs.push(id)
-      flowCopy.meta.allIDs.push(id)
+      currentFlow.data.allIDs.push(id)
+      currentFlow.meta.allIDs.push(id)
     }
 
     updateData(id, {})
@@ -408,13 +405,11 @@ export const FlowProvider: FC = ({children}) => {
       return
     }
 
-    const flowCopy = JSON.parse(JSON.stringify(currentFlow))
+    currentFlow.meta.allIDs = currentFlow.meta.allIDs.filter(_id => _id !== id)
+    currentFlow.data.allIDs = currentFlow.data.allIDs.filter(_id => _id !== id)
 
-    flowCopy.meta.allIDs = flowCopy.meta.allIDs.filter(_id => _id !== id)
-    flowCopy.data.allIDs = flowCopy.data.allIDs.filter(_id => _id !== id)
-
-    delete flowCopy.data.byID[id]
-    delete flowCopy.meta.byID[id]
+    delete currentFlow.data.byID[id]
+    delete currentFlow.meta.byID[id]
 
     updateData(id, {})
     updateMeta(id, {})

--- a/src/flows/context/flow.current.tsx
+++ b/src/flows/context/flow.current.tsx
@@ -417,10 +417,6 @@ export const FlowProvider: FC = ({children}) => {
     update(flowCopy)
   }
 
-  if (!currentFlow) {
-    return null
-  }
-
   return (
     <FlowContext.Provider
       value={{

--- a/src/flows/context/flow.list.tsx
+++ b/src/flows/context/flow.list.tsx
@@ -35,8 +35,6 @@ export interface FlowListContextType extends FlowList {
   clone: (id: string) => Promise<string | void>
   update: (id: string, flow: Partial<Flow>) => void
   remove: (id: string) => void
-  currentID: string | null
-  change: (id: string) => void
   getAll: () => void
 }
 
@@ -61,9 +59,7 @@ export const DEFAULT_CONTEXT: FlowListContextType = {
   clone: (_id: string) => {},
   update: (_id: string, _flow: Partial<Flow>) => {},
   remove: (_id: string) => {},
-  change: (_id: string) => {},
   getAll: () => {},
-  currentID: null,
 } as FlowListContextType
 
 const useLocalStorageState = createLocalStorageStateHook(
@@ -169,7 +165,7 @@ export function hydrate(data) {
 
 export const FlowListProvider: FC = ({children}) => {
   const [flows, setFlows] = useLocalStorageState()
-  const [currentID, setCurrentID] = useState(DEFAULT_CONTEXT.currentID)
+  const [currentID, setCurrentID] = useState(null)
   const org = useSelector(getOrg)
 
   const dispatch = useDispatch()
@@ -287,16 +283,6 @@ export const FlowListProvider: FC = ({children}) => {
     }
   }, [org.id, setFlows])
 
-  const change = useCallback(
-    (id: string) => {
-      if (!Object.keys(flows).length) {
-        getAll()
-      }
-      setCurrentID(id)
-    },
-    [setCurrentID, flows]
-  )
-
   const migrate = async () => {
     const localFlows = Object.keys(flows).filter(id => id.includes('local'))
     if (!localFlows.length) {
@@ -325,8 +311,6 @@ export const FlowListProvider: FC = ({children}) => {
         update,
         remove,
         getAll,
-        currentID,
-        change,
       }}
     >
       {children}

--- a/src/flows/context/flow.list.tsx
+++ b/src/flows/context/flow.list.tsx
@@ -29,7 +29,6 @@ import {
   notebookDeleteSuccess,
 } from 'src/shared/copy/notifications'
 import {incrementCloneName} from 'src/utils/naming'
-import {getNotebook} from 'src/client/notebooksRoutes'
 
 export interface FlowListContextType extends FlowList {
   add: (flow?: Flow) => Promise<string | void>
@@ -185,16 +184,8 @@ export const FlowListProvider: FC = ({children}) => {
     const allFlowNames = Object.values(flows).map(value => value.name)
     const clonedName = incrementCloneName(allFlowNames, flow.name)
 
-    const resp = await getNotebook({id})
-
-    if (resp.status !== 200) {
-      throw new Error(resp.data.message)
-    }
-
-    const _flow = hydrate(resp.data)
-
     const data = {
-      ..._flow,
+      ...flow,
       name: clonedName,
     }
 
@@ -285,13 +276,8 @@ export const FlowListProvider: FC = ({children}) => {
     const data = await getAllAPI(org.id)
     if (data && data.flows) {
       const _flows = {}
-      data.flows.forEach(flow => {
-        _flows[flow.id] = {
-          name: flow.name || EMPTY_NOTEBOOK.name,
-          createdAt: flow.createdAt,
-          updatedAt: flow.updatedAt,
-          createdBy: flow.createdBy,
-        }
+      data.flows.forEach(f => {
+        _flows[f.id] = hydrate(f)
       })
       setFlows(_flows)
     }

--- a/src/flows/context/flow.list.tsx
+++ b/src/flows/context/flow.list.tsx
@@ -29,6 +29,7 @@ import {
   notebookDeleteSuccess,
 } from 'src/shared/copy/notifications'
 import {incrementCloneName} from 'src/utils/naming'
+import {getNotebook} from 'src/client/notebooksRoutes'
 
 export interface FlowListContextType extends FlowList {
   add: (flow?: Flow) => Promise<string | void>
@@ -184,8 +185,16 @@ export const FlowListProvider: FC = ({children}) => {
     const allFlowNames = Object.values(flows).map(value => value.name)
     const clonedName = incrementCloneName(allFlowNames, flow.name)
 
+    const resp = await getNotebook({id})
+
+    if (resp.status !== 200) {
+      throw new Error(resp.data.message)
+    }
+
+    const _flow = hydrate(resp.data)
+
     const data = {
-      ...flow,
+      ..._flow,
       name: clonedName,
     }
 

--- a/src/flows/context/flow.list.tsx
+++ b/src/flows/context/flow.list.tsx
@@ -276,8 +276,13 @@ export const FlowListProvider: FC = ({children}) => {
     const data = await getAllAPI(org.id)
     if (data && data.flows) {
       const _flows = {}
-      data.flows.forEach(f => {
-        _flows[f.id] = hydrate(f)
+      data.flows.forEach(flow => {
+        _flows[flow.id] = {
+          name: flow.name || EMPTY_NOTEBOOK.name,
+          createdAt: flow.createdAt,
+          updatedAt: flow.updatedAt,
+          createdBy: flow.createdBy,
+        }
       })
       setFlows(_flows)
     }

--- a/src/flows/context/shared.tsx
+++ b/src/flows/context/shared.tsx
@@ -1,7 +1,6 @@
 import React, {FC, useEffect, useState} from 'react'
 import {FlowContext} from 'src/flows/context/flow.current'
 import {useParams} from 'react-router'
-import {DEFAULT_PROJECT_NAME} from 'src/flows'
 import PageSpinner from 'src/perf/components/PageSpinner'
 
 import {hydrate} from 'src/flows/context/flow.list'
@@ -30,9 +29,10 @@ export const FlowProvider: FC = ({children}) => {
     <PageSpinner loading={loading}>
       <FlowContext.Provider
         value={{
-          name: DEFAULT_PROJECT_NAME,
           flow,
           add: (_, __) => '',
+          cloneNotebook: () => {},
+          deleteNotebook: () => {},
           remove: () => '',
           updateData: _ => {},
           updateMeta: _ => {},

--- a/src/flows/context/version.read.tsx
+++ b/src/flows/context/version.read.tsx
@@ -1,7 +1,6 @@
 import React, {FC, useCallback, useEffect, useState} from 'react'
 import {FlowContext} from 'src/flows/context/flow.current'
 import {useParams} from 'react-router'
-import {DEFAULT_PROJECT_NAME} from 'src/flows'
 import PageSpinner from 'src/perf/components/PageSpinner'
 
 import {RemoteDataState} from 'src/types'
@@ -39,9 +38,10 @@ export const VersionFlowProvider: FC = ({children}) => {
     <PageSpinner loading={loading}>
       <FlowContext.Provider
         value={{
-          name: DEFAULT_PROJECT_NAME,
           flow,
           add: (_, __) => '',
+          cloneNotebook: () => {},
+          deleteNotebook: () => {},
           remove: () => '',
           updateData: _ => {},
           updateMeta: _ => {},

--- a/src/shared/components/TimeZoneDropdown.tsx
+++ b/src/shared/components/TimeZoneDropdown.tsx
@@ -34,6 +34,7 @@ const TimeZoneDropdown: FC = () => {
       onSelect={onSelect}
       buttonIcon={IconFont.Annotate_New}
       style={{width: '115px'}}
+      testID="timezone-dropdown"
     />
   )
 }


### PR DESCRIPTION
This PR separates the flows list context from the current flow context. The rationale behind this move is so that we can keep the list page a dumb list, and make each flow a source of truth in and of itself. This renders a few methods from the list page irrelevant while making sure that the current functionality still exists. 

Since the list is now no longer the source of truth, we should update the API for the getAllNotebooks so restrict the data that's sent so that we don't end up with a potentially bloated list page. 

![current-flow](https://user-images.githubusercontent.com/19984220/159994394-3a959be2-97d0-4ee0-90b9-e3579ba736b9.gif)
