### PR TITLE
test: remove dead test code

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -65,7 +65,6 @@ export const loginViaDexUI = (username: string, password: string) => {
   cy.get('#login').type(username)
   cy.get('#password').type(password)
   cy.get('#submit-login').click()
-  cy.get('.theme-btn--success').click()
 }
 
 Cypress.Commands.add(


### PR DESCRIPTION
This PR removes 1 line of cypress test code that is no longer valid. 

Neither `theme-btn--success` nor `theme-btn` is in ui repo nor clockface repo. Removing this line of test code enables the tests in `labels.test.ts` to pass.