### PR TITLE
feat(ecommerce): Add Account Type Dropdown to Operator UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "cy": "CYPRESS_dexUrl=https://$INGRESS_HOST:$PORT_HTTPS CYPRESS_baseUrl=http://localhost:9999 cypress open",
     "cy:dev": "source ../monitor-ci/.env && CYPRESS_dexUrl=CLOUD CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{cloud,shared}/**/*.*'",
     "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_dexUrl=OSS CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{oss,shared}/**/*.*'",
-    "generate": "export SHA=8823ef7b35fe7096856fa903649f7986ff31ef2e && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
+    "generate": "export SHA=1a800fb92ad8ed86e28365c4fd5ac43ff193c303 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-meta": "if [ -z \"${CLOUD_URL}\" ]; then yarn generate-meta-oss; else yarn generate-meta-cloud; fi",
     "generate-meta-oss": "yarn oss-api && yarn notebooks && yarn unity && yarn annotations-oss && yarn pinned && yarn mapsd-oss && yarn cloudPriv && yarn fluxdocs && yarn subscriptions-oss",

--- a/src/operator/ResourcesAccountType.tsx
+++ b/src/operator/ResourcesAccountType.tsx
@@ -12,7 +12,7 @@ const ResourcesAccountType: FC = () => {
   const availableTypes: AccountType[] = allAccountTypes
 
   const handleSelect = (selectedOption: string): void =>
-    accountTypes.includes(JSON.parse(selectedOption))
+    accountTypes.includes(selectedOption as AccountType)
       ? setAccountTypes(
           accountTypes.filter(x => x !== (selectedOption as AccountType))
         )

--- a/src/operator/ResourcesAccountType.tsx
+++ b/src/operator/ResourcesAccountType.tsx
@@ -12,7 +12,7 @@ const ResourcesAccountType: FC = () => {
   const availableTypes: AccountType[] = allAccountTypes
 
   const handleSelect = (selectedOption: string): void =>
-    accountTypes.includes(selectedOption)
+    accountTypes.includes(JSON.parse(selectedOption))
       ? setAccountTypes(
           accountTypes.filter(x => x !== (selectedOption as AccountType))
         )

--- a/src/operator/ResourcesAccountType.tsx
+++ b/src/operator/ResourcesAccountType.tsx
@@ -7,23 +7,27 @@ import React, {FC, useContext} from 'react'
 import {OperatorContext} from './context/operator'
 import {AccountType} from 'src/types'
 
+const allAccountTypes: AccountType[] = [
+  'cancelled',
+  'contract',
+  'free',
+  'pay_as_you_go',
+]
+
 const ResourcesAccountType: FC = () => {
   const {accountTypes, setAccountTypes} = useContext(OperatorContext)
-  const availableTypes: AccountType[] = allAccountTypes
 
-  const handleSelect = (selectedOption: string): void =>
-    accountTypes.includes(selectedOption as AccountType)
-      ? setAccountTypes(
-          accountTypes.filter(x => x !== (selectedOption as AccountType))
-        )
-      : setAccountTypes([selectedOption as AccountType, ...accountTypes])
+  const handleSelect = (selectedOption: AccountType): void =>
+    accountTypes.includes(selectedOption)
+      ? setAccountTypes(prev => prev.filter(x => x !== selectedOption))
+      : setAccountTypes(prev => [selectedOption, ...prev])
 
   return (
     <MultiSelectDropdown
       style={{width: '220px', marginRight: '20px'}}
-      options={availableTypes}
+      options={allAccountTypes}
       selectedOptions={accountTypes}
-      onSelect={handleSelect}
+      onSelect={(value: AccountType) => handleSelect(value)}
       menuTheme={DropdownMenuTheme.Onyx}
       emptyText="Account Types"
       buttonColor={ComponentColor.Primary}
@@ -32,10 +36,3 @@ const ResourcesAccountType: FC = () => {
 }
 
 export default ResourcesAccountType
-
-const allAccountTypes: AccountType[] = [
-  'cancelled',
-  'contract',
-  'free',
-  'pay_as_you_go',
-]

--- a/src/operator/ResourcesAccountType.tsx
+++ b/src/operator/ResourcesAccountType.tsx
@@ -1,0 +1,38 @@
+import {
+  ComponentColor,
+  DropdownMenuTheme,
+  MultiSelectDropdown,
+} from '@influxdata/clockface'
+import React, {FC, useContext} from 'react'
+import {OperatorContext} from './context/operator'
+
+const ResourcesAccountType: FC = () => {
+  const {accountTypes, setAccountTypes} = useContext(OperatorContext)
+  const availableTypes: string[] = allAccountTypes
+
+  const handleSelect = (selectedOption: string): void =>
+    accountTypes.includes(selectedOption)
+      ? setAccountTypes(accountTypes.filter(x => x !== selectedOption))
+      : setAccountTypes([selectedOption, ...accountTypes])
+
+  return (
+    <MultiSelectDropdown
+      style={{width: '220px'}}
+      options={availableTypes}
+      selectedOptions={accountTypes}
+      onSelect={handleSelect}
+      menuTheme={DropdownMenuTheme.Onyx}
+      emptyText="Account Types"
+      buttonColor={ComponentColor.Primary}
+    />
+  )
+}
+
+const allAccountTypes: string[] = [
+  'cancelled',
+  'contract',
+  'free',
+  'pay_as_you_go',
+]
+
+export default ResourcesAccountType

--- a/src/operator/ResourcesAccountType.tsx
+++ b/src/operator/ResourcesAccountType.tsx
@@ -5,15 +5,18 @@ import {
 } from '@influxdata/clockface'
 import React, {FC, useContext} from 'react'
 import {OperatorContext} from './context/operator'
+import {AccountType} from 'src/types'
 
 const ResourcesAccountType: FC = () => {
   const {accountTypes, setAccountTypes} = useContext(OperatorContext)
-  const availableTypes: string[] = allAccountTypes
+  const availableTypes: AccountType[] = allAccountTypes
 
   const handleSelect = (selectedOption: string): void =>
     accountTypes.includes(selectedOption)
-      ? setAccountTypes(accountTypes.filter(x => x !== selectedOption))
-      : setAccountTypes([selectedOption, ...accountTypes])
+      ? setAccountTypes(
+          accountTypes.filter(x => x !== (selectedOption as AccountType))
+        )
+      : setAccountTypes([selectedOption as AccountType, ...accountTypes])
 
   return (
     <MultiSelectDropdown
@@ -28,11 +31,11 @@ const ResourcesAccountType: FC = () => {
   )
 }
 
-const allAccountTypes: string[] = [
+export default ResourcesAccountType
+
+const allAccountTypes: AccountType[] = [
   'cancelled',
   'contract',
   'free',
   'pay_as_you_go',
 ]
-
-export default ResourcesAccountType

--- a/src/operator/ResourcesAccountType.tsx
+++ b/src/operator/ResourcesAccountType.tsx
@@ -17,7 +17,7 @@ const ResourcesAccountType: FC = () => {
 
   return (
     <MultiSelectDropdown
-      style={{width: '220px'}}
+      style={{width: '220px', marginRight: '20px'}}
       options={availableTypes}
       selectedOptions={accountTypes}
       onSelect={handleSelect}

--- a/src/operator/ResourcesTable.tsx
+++ b/src/operator/ResourcesTable.tsx
@@ -6,6 +6,8 @@ import {
   ComponentSize,
   Tabs,
   Orientation,
+  FlexBox,
+  FlexDirection,
 } from '@influxdata/clockface'
 
 // Components
@@ -47,8 +49,10 @@ const ResourcesTable: FC = () => {
     <Tabs.Container orientation={Orientation.Horizontal}>
       <OperatorTabs />
       <Tabs.TabContents>
-        <ResourcesSearchbar />
-        <ResourcesAccountType />
+        <FlexBox direction={FlexDirection.Row}>
+          <ResourcesAccountType />
+          <ResourcesSearchbar />
+        </FlexBox>
         <PageSpinner loading={status}>
           {resources?.length ? (
             <Table>

--- a/src/operator/ResourcesTable.tsx
+++ b/src/operator/ResourcesTable.tsx
@@ -26,6 +26,7 @@ import {OperatorRoutes} from 'src/operator/constants'
 
 // Types
 import {OperatorOrg, OperatorAccount} from 'src/types'
+import ResourcesAccountType from './ResourcesAccountType'
 
 const ResourcesTable: FC = () => {
   const {pathname, accounts, organizations, status} = useContext(
@@ -47,6 +48,7 @@ const ResourcesTable: FC = () => {
       <OperatorTabs />
       <Tabs.TabContents>
         <ResourcesSearchbar />
+        <ResourcesAccountType />
         <PageSpinner loading={status}>
           {resources?.length ? (
             <Table>

--- a/src/operator/context/operator.tsx
+++ b/src/operator/context/operator.tsx
@@ -21,6 +21,8 @@ export type Props = {
 
 export interface OperatorContextType {
   accounts: OperatorAccount[]
+  accountTypes: string[]
+  setAccountTypes: (acountTypes: string[]) => void
   handleGetAccounts: () => void
   handleGetOrgs: () => void
   organizations: OperatorOrg[]
@@ -33,6 +35,8 @@ export interface OperatorContextType {
 
 export const DEFAULT_CONTEXT: OperatorContextType = {
   accounts: [],
+  accountTypes: [],
+  setAccountTypes: () => {},
   handleGetAccounts: () => {},
   handleGetOrgs: () => {},
   organizations: [],
@@ -52,6 +56,7 @@ export const OperatorProvider: FC<Props> = React.memo(({children}) => {
   const [accountStatus, setAccountStatus] = useState(RemoteDataState.NotStarted)
   const [orgsStatus, setOrgsStatus] = useState(RemoteDataState.NotStarted)
   const [searchTerm, setSearchTerm] = useState('')
+  const [accountTypes, setAccountTypes] = useState([])
   const dispatch = useDispatch()
   const quartzMe = useSelector(getQuartzMe)
 
@@ -63,6 +68,7 @@ export const OperatorProvider: FC<Props> = React.memo(({children}) => {
       const resp = await getOperatorAccounts({
         query: {
           query: searchTerm,
+          accountTypes: accountTypes,
         },
       })
 
@@ -77,7 +83,7 @@ export const OperatorProvider: FC<Props> = React.memo(({children}) => {
       dispatch(notify(getAccountsError()))
       console.error({error})
     }
-  }, [searchTerm, dispatch])
+  }, [accountTypes, searchTerm, dispatch])
 
   const handleGetOrgs = useCallback(async () => {
     try {
@@ -134,6 +140,8 @@ export const OperatorProvider: FC<Props> = React.memo(({children}) => {
     <OperatorContext.Provider
       value={{
         accounts,
+        accountTypes,
+        setAccountTypes,
         handleGetAccounts,
         handleGetOrgs,
         organizations,

--- a/src/operator/context/operator.tsx
+++ b/src/operator/context/operator.tsx
@@ -88,7 +88,9 @@ export const OperatorProvider: FC<Props> = React.memo(({children}) => {
   const handleGetOrgs = useCallback(async () => {
     try {
       setOrgsStatus(RemoteDataState.Loading)
-      const resp = await getOperatorOrgs({query: {query: searchTerm}})
+      const resp = await getOperatorOrgs({
+        query: {query: searchTerm, accountTypes: accountTypes},
+      })
 
       if (resp.status !== 200) {
         throw new Error(resp.data.message)
@@ -101,7 +103,7 @@ export const OperatorProvider: FC<Props> = React.memo(({children}) => {
       setOrgsStatus(RemoteDataState.Error)
       dispatch(notify(getOrgsError()))
     }
-  }, [searchTerm, dispatch])
+  }, [accountTypes, searchTerm, dispatch])
 
   const {pathname} = useLocation()
 

--- a/src/operator/context/operator.tsx
+++ b/src/operator/context/operator.tsx
@@ -27,7 +27,9 @@ export type Props = {
 export interface OperatorContextType {
   accounts: OperatorAccount[]
   accountTypes: AccountType[]
-  setAccountTypes: (accountTypes: AccountType[]) => void
+  setAccountTypes: (
+    accountTypes: AccountType[] | ((prevState: AccountType[]) => AccountType[])
+  ) => void
   handleGetAccounts: () => void
   handleGetOrgs: () => void
   organizations: OperatorOrg[]
@@ -73,7 +75,7 @@ export const OperatorProvider: FC<Props> = React.memo(({children}) => {
       const resp = await getOperatorAccounts({
         query: {
           query: searchTerm,
-          accountTypes: accountTypes,
+          accountTypes,
         },
       })
 
@@ -94,7 +96,7 @@ export const OperatorProvider: FC<Props> = React.memo(({children}) => {
     try {
       setOrgsStatus(RemoteDataState.Loading)
       const resp = await getOperatorOrgs({
-        query: {query: searchTerm, accountTypes: accountTypes},
+        query: {query: searchTerm, accountTypes},
       })
 
       if (resp.status !== 200) {

--- a/src/operator/context/operator.tsx
+++ b/src/operator/context/operator.tsx
@@ -26,7 +26,7 @@ export type Props = {
 
 export interface OperatorContextType {
   accounts: OperatorAccount[]
-  accountTypes: string[]
+  accountTypes: AccountType[]
   setAccountTypes: (accountTypes: AccountType[]) => void
   handleGetAccounts: () => void
   handleGetOrgs: () => void

--- a/src/operator/context/operator.tsx
+++ b/src/operator/context/operator.tsx
@@ -56,7 +56,7 @@ export const OperatorProvider: FC<Props> = React.memo(({children}) => {
   const [accountStatus, setAccountStatus] = useState(RemoteDataState.NotStarted)
   const [orgsStatus, setOrgsStatus] = useState(RemoteDataState.NotStarted)
   const [searchTerm, setSearchTerm] = useState('')
-  const [accountTypes, setAccountTypes] = useState([])
+  const [accountTypes, setAccountTypes] = useState<string[]>([])
   const dispatch = useDispatch()
   const quartzMe = useSelector(getQuartzMe)
 

--- a/src/operator/context/operator.tsx
+++ b/src/operator/context/operator.tsx
@@ -10,7 +10,12 @@ import {getAccountsError, getOrgsError} from 'src/shared/copy/notifications'
 import {getQuartzMe} from 'src/me/selectors'
 
 // Types
-import {OperatorAccount, OperatorOrg, RemoteDataState} from 'src/types'
+import {
+  AccountType,
+  OperatorAccount,
+  OperatorOrg,
+  RemoteDataState,
+} from 'src/types'
 
 // Constants
 import {OperatorRoutes} from 'src/operator/constants'
@@ -22,7 +27,7 @@ export type Props = {
 export interface OperatorContextType {
   accounts: OperatorAccount[]
   accountTypes: string[]
-  setAccountTypes: (acountTypes: string[]) => void
+  setAccountTypes: (accountTypes: AccountType[]) => void
   handleGetAccounts: () => void
   handleGetOrgs: () => void
   organizations: OperatorOrg[]
@@ -56,7 +61,7 @@ export const OperatorProvider: FC<Props> = React.memo(({children}) => {
   const [accountStatus, setAccountStatus] = useState(RemoteDataState.NotStarted)
   const [orgsStatus, setOrgsStatus] = useState(RemoteDataState.NotStarted)
   const [searchTerm, setSearchTerm] = useState('')
-  const [accountTypes, setAccountTypes] = useState<string[]>([])
+  const [accountTypes, setAccountTypes] = useState<AccountType[]>([])
   const dispatch = useDispatch()
   const quartzMe = useSelector(getQuartzMe)
 


### PR DESCRIPTION
This adds a dropdown to the operator UI which will allow for filtering based on account-type. By default, none will be selected al all accounts will be shown. After the operator selects one or many types, the results will be filtered based on the types chosen.

<img width="1587" alt="image" src="https://user-images.githubusercontent.com/31899323/160191494-bbc5aaeb-2bd2-47b2-a87c-3167417329b5.png">
