### PR TITLE
fix: string parsing

### DIFF
--- a/src/writeData/subscriptions/utils/form.ts
+++ b/src/writeData/subscriptions/utils/form.ts
@@ -44,6 +44,25 @@ export const sanitizeForm = (form: Subscription): Subscription => {
       }
     })
   }
+  if (form.stringMeasurement) {
+    form.stringMeasurement.pattern = form.stringMeasurement.pattern.replace(
+      /\\\\/g,
+      '\\'
+    )
+  }
+  if (form.stringFields) {
+    form.stringFields.map(f => {
+      f.pattern = f.pattern.replace(/\\\\/g, '\\')
+    })
+  }
+  if (form.stringTags) {
+    form.stringTags.map(t => {
+      t.pattern = t.pattern.replace(/\\\\/g, '\\')
+    })
+  }
+  if (form.stringTimestamp.pattern === '') {
+    delete form.stringTimestamp
+  }
   if (form.brokerPassword === '' || form.brokerUsername === '') {
     delete form.brokerUsername
     delete form.brokerPassword


### PR DESCRIPTION
Closes https://github.com/influxdata/data-acquisition/issues/206

Fixes the form input for string parsing to not add extra backslashes and removes the timestamp option if it's not provided as this was also causing errors with parsing.
