### PR TITLE
chore: event auditing

### DIFF
--- a/src/flows/components/panel/FlowPanel.tsx
+++ b/src/flows/components/panel/FlowPanel.tsx
@@ -19,6 +19,7 @@ import {
 import Handle from 'src/flows/components/panel/Handle'
 import FlowPanelTitle from 'src/flows/components/panel/FlowPanelTitle'
 import {MenuButton} from 'src/flows/components/Sidebar'
+import {event} from 'src/cloud/utils/reporting'
 
 // Constants
 import {PIPE_DEFINITIONS} from 'src/flows'
@@ -146,6 +147,10 @@ const FlowPanel: FC<Props> = ({
     getPanelQueries,
     id,
   ])
+  const runFromHere = () => {
+    event('run from panel')
+    queryDependents(id)
+  }
 
   if (
     flow.readOnly &&
@@ -176,11 +181,7 @@ const FlowPanel: FC<Props> = ({
                 />
               </FeatureFlag>
               {isVisible && showPreviewButton && (
-                <Button
-                  onClick={() => queryDependents(id)}
-                  icon={IconFont.Play}
-                  text="Run"
-                />
+                <Button onClick={runFromHere} icon={IconFont.Play} text="Run" />
               )}
               <MenuButton id={id} />
             </div>

--- a/src/flows/context/flow.query.tsx
+++ b/src/flows/context/flow.query.tsx
@@ -285,7 +285,6 @@ export const FlowQueryProvider: FC = ({children}) => {
     }
 
     map = map.slice(map.findIndex(m => m.id === startID))
-    event('Running Notebook QueryDependents')
 
     setStatuses(
       map
@@ -311,17 +310,13 @@ export const FlowQueryProvider: FC = ({children}) => {
               setStatuses({[stage.id]: RemoteDataState.Error})
             })
         })
-    )
-      .then(() => {
-        event('run_notebook_success')
-      })
-      .catch(e => {
-        event('run_notebook_fail')
-        dispatch(notify(notebookRunFail(PROJECT_NAME)))
+    ).catch(e => {
+      event('run_notebook_fail')
+      dispatch(notify(notebookRunFail(PROJECT_NAME)))
 
-        // NOTE: this shouldn't fire, but lets wrap it for completeness
-        throw e
-      })
+      // NOTE: this shouldn't fire, but lets wrap it for completeness
+      throw e
+    })
   }
   // Use localstorage to communicate query execution to other tabs
   const queryAll = () => {
@@ -339,8 +334,6 @@ export const FlowQueryProvider: FC = ({children}) => {
     if (!map.length) {
       return
     }
-
-    event('Running Notebook QueryAll')
 
     setStatuses(
       map
@@ -367,17 +360,13 @@ export const FlowQueryProvider: FC = ({children}) => {
               setStatuses({[stage.id]: RemoteDataState.Error})
             })
         })
-    )
-      .then(() => {
-        event('run_notebook_success')
-      })
-      .catch(e => {
-        event('run_notebook_fail')
-        dispatch(notify(notebookRunFail(PROJECT_NAME)))
+    ).catch(e => {
+      event('run_notebook_fail')
+      dispatch(notify(notebookRunFail(PROJECT_NAME)))
 
-        // NOTE: this shouldn't fire, but lets wrap it for completeness
-        throw e
-      })
+      // NOTE: this shouldn't fire, but lets wrap it for completeness
+      throw e
+    })
   }
 
   const simple = (text: string) => {

--- a/src/writeData/containers/TelegrafPluginsPage.tsx
+++ b/src/writeData/containers/TelegrafPluginsPage.tsx
@@ -22,7 +22,7 @@ import placeholderLogo from 'src/writeData/graphics/placeholderLogo.svg'
 
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
-import {event, normalizeEventName} from 'src/cloud/utils/reporting'
+import {event} from 'src/cloud/utils/reporting'
 
 // Styles
 import 'src/writeData/components/WriteDataDetailsView.scss'
@@ -43,13 +43,12 @@ const TelegrafPluginsPage: FC<RouteComponentProps<{orgID: string}>> = props => {
   const {name = '', markdown = '', image = '', style = {}} =
     WRITE_DATA_TELEGRAF_PLUGINS.find(item => item.id === contentID) || {}
 
-  const eventName = normalizeEventName(name)
   useEffect(() => {
-    event(`telegraf_tile.${eventName}.config_viewed`, {id: contentID, name})
-  }, [eventName, contentID, name])
+    event(`telegraf_tile.config_viewed`, {id: contentID, name})
+  }, [contentID, name])
 
   const onCopy = () => {
-    event(`telegraf_tile.${eventName}.config_copied`, {id: contentID, name})
+    event(`telegraf_tile.config_copied`, {id: contentID, name})
   }
   const codeRenderer: any = (props: any): any => (
     <CodeSnippet text={props.value} label={props.language} onCopy={onCopy} />


### PR DESCRIPTION
we have a `telegraf_tile` event that isn't properly normalized

the queryall events in notebooks weren't very useful as they get fired all the time, even if there's no user interaction and there's no query to be called. moving instead to track the discrete actions of clicking on the big run button or the per-panel run button so that we can better evaluate which the user is actively using