### PR TITLE
fix: call color mapping code after the render cycle in Vis.tsx

### DIFF
--- a/src/timeMachine/components/Vis.tsx
+++ b/src/timeMachine/components/Vis.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FC, memo} from 'react'
+import React, {FC, memo, useEffect} from 'react'
 import {connect, ConnectedProps, useDispatch} from 'react-redux'
 import classnames from 'classnames'
 import {createGroupIDColumn, fromFlux} from '@influxdata/giraffe'
@@ -95,26 +95,28 @@ const TimeMachineVis: FC<Props> = ({
       giraffeResult.table.getColumnType('_value') !== 'number' &&
       !!giraffeResult.table.length)
 
-  if (
-    isFlagEnabled('graphColorMapping') &&
-    viewProperties.hasOwnProperty('colors')
-  ) {
-    const groupKey = [...giraffeResult.fluxGroupKeyUnion, 'result']
-    const [, fillColumnMap] = createGroupIDColumn(giraffeResult.table, groupKey)
-    const {colorMappingForIDPE, needsToSaveToIDPE} = getColorMappingObjects(
-      fillColumnMap,
-      viewProperties as XYViewProperties
-    )
-
-    if (loading === RemoteDataState.Done && needsToSaveToIDPE) {
-      dispatch(
-        setViewProperties({
-          ...viewProperties,
-          colorMapping: colorMappingForIDPE,
-        } as XYViewProperties)
+  useEffect(() => {
+    if (
+      isFlagEnabled('graphColorMapping') &&
+      viewProperties.hasOwnProperty('colors')
+    ) {
+      const groupKey = [...giraffeResult.fluxGroupKeyUnion, 'result']
+      const [, fillColumnMap] = createGroupIDColumn(giraffeResult.table, groupKey)
+      const {colorMappingForIDPE, needsToSaveToIDPE} = getColorMappingObjects(
+        fillColumnMap,
+        viewProperties as XYViewProperties
       )
+
+      if (loading === RemoteDataState.Done && needsToSaveToIDPE) {
+        dispatch(
+          setViewProperties({
+            ...viewProperties,
+            colorMapping: colorMappingForIDPE,
+          } as XYViewProperties)
+        )
+      }
     }
-  }
+  })
 
   // Handles deadman check edge case to allow non-numeric values
   if (viewRawData && files && files?.length) {

--- a/src/timeMachine/components/Vis.tsx
+++ b/src/timeMachine/components/Vis.tsx
@@ -101,7 +101,10 @@ const TimeMachineVis: FC<Props> = ({
       viewProperties.hasOwnProperty('colors')
     ) {
       const groupKey = [...giraffeResult.fluxGroupKeyUnion, 'result']
-      const [, fillColumnMap] = createGroupIDColumn(giraffeResult.table, groupKey)
+      const [, fillColumnMap] = createGroupIDColumn(
+        giraffeResult.table,
+        groupKey
+      )
       const {colorMappingForIDPE, needsToSaveToIDPE} = getColorMappingObjects(
         fillColumnMap,
         viewProperties as XYViewProperties


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/3790

Video: 


https://user-images.githubusercontent.com/18511823/160547676-ebc3bf6c-27b1-400c-a5c2-a6e01af9c10b.mov



<!-- Describe your proposed changes here. -->
