### PR TITLE
chore: update menu style for subscriptions

### DIFF
--- a/src/writeData/subscriptions/components/CreateSubscriptionPage.scss
+++ b/src/writeData/subscriptions/components/CreateSubscriptionPage.scss
@@ -12,97 +12,20 @@
   &__progress {
     float: left;
     width: 25%;
-    &__logo {
-      padding-top: $cf-space-l;
-      img {
-        margin-right: $cf-space-m;
-      }
-      &--lg {
-        font-size: $cf-space-m;
-        line-height: $cf-space-m;
-        color: $cf-white;
-      }
-      &--sm {
-        font-size: $cf-space-xs;
-        line-height: $cf-space-xs;
-        color: $cf-white;
-      }
-    }
-    &__bar {
-      margin-top: $cf-space-2xl;
-      &__wrap {
-        margin-top: $cf-space-l;
-        width: 100%;
-        .cf-icon {
-          background: $cf-white;
-          -webkit-background-clip: text;
-          -webkit-text-fill-color: transparent;
-          border: 1px solid $cf-white;
-          border-radius: 50%;
-          padding: $cf-space-xs;
-          font-size: 1.5em;
-          &--selected {
-            border: 1px solid $c-pool;
-          }
+    margin-top: $cf-space-l;
+
+    .subway-navigation-title {
+      margin-bottom: $cf-space-3xl;
+
+      .subway-navigation-title-text {
+        h3 {
+          font-size: $cf-space-m;
+          line-height: $cf-space-m;
         }
-        &__btn {
-          display: flex;
-          align-items: center;
-          .title {
-            font-size: $cf-space-xs;
-            line-height: $cf-space-s;
-            margin-left: $cf-space-m;
-            color: $cf-grey-85;
-            &--selected {
-              color: $c-pool;
-              font-size: $cf-space-xs;
-              line-height: $cf-space-s;
-              margin-left: $cf-space-m;
-            }
-          }
-          &:hover {
-            .title {
-              color: $c-pool;
-            }
-            .cf-icon {
-              border: 1px solid $c-pool;
-              background: $c-pool;
-              -webkit-background-clip: text;
-              -webkit-text-fill-color: transparent;
-            }
-          }
-        }
-        &--selected {
-          margin-top: $cf-space-l;
-          width: 100%;
-          .btn {
-            display: flex;
-            align-items: center;
-            .title {
-              font-size: $cf-space-xs;
-              line-height: $cf-space-s;
-              margin-left: $cf-space-m;
-              color: $cf-grey-85;
-              &--selected {
-                color: $c-pool;
-                font-size: $cf-space-xs;
-                line-height: $cf-space-s;
-                margin-left: $cf-space-m;
-              }
-            }
-          }
-          .cf-icon {
-            background: $c-pool;
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
-            border: 1px solid $cf-white;
-            border-radius: 50%;
-            padding: $cf-space-xs;
-            font-size: 1.5em;
-            &--selected {
-              border: 1px solid $c-pool;
-            }
-          }
+
+        h6 {
+          font-size: $cf-space-xs;
+          line-height: 20px;
         }
       }
     }

--- a/src/writeData/subscriptions/components/CreateSubscriptionPage.tsx
+++ b/src/writeData/subscriptions/components/CreateSubscriptionPage.tsx
@@ -59,17 +59,17 @@ enum Steps {
 const navigationSteps: SubscriptionNavigationModel[] = [
   {
     glyph: IconFont.UploadOutline,
-    name: 'Connect to Broker',
+    name: 'Connect \n to Broker',
     type: Steps.BrokerForm,
   },
   {
     glyph: IconFont.Subscribe,
-    name: 'Subscribe to Topic',
+    name: 'Subscribe \n to Topic',
     type: Steps.SubscriptionForm,
   },
   {
     glyph: IconFont.Braces,
-    name: 'Define Data Parsing Rules',
+    name: 'Define Data \n Parsing Rules',
     type: Steps.ParsingForm,
   },
 ]

--- a/src/writeData/subscriptions/graphics/FormLogo.tsx
+++ b/src/writeData/subscriptions/graphics/FormLogo.tsx
@@ -2,8 +2,8 @@ import React from 'react'
 
 export const FormLogo = (
   <svg
-    width="65"
-    height="65"
+    width="39"
+    height="39"
     viewBox="0 0 39 39"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
We're now using the shared subway component but the styling differs in our design to do with spacing/sizing. This updates the svg size, adds line breaks to our steps and hands in styling only affecting the subscriptions page. 
This makes no changes to the shared component. Also removes unneeded previous styling.

before:
<img width="507" alt="Screen Shot 2022-03-29 at 12 19 01 PM" src="https://user-images.githubusercontent.com/38860767/160659444-ea2ed498-0dfd-46a0-8e2d-d0359b322c6e.png">


after:
<img width="493" alt="Screen Shot 2022-03-29 at 12 21 28 PM" src="https://user-images.githubusercontent.com/38860767/160659458-a4d7cccd-0142-4353-98d9-0d6f3754ac1d.png">

