### PR TITLE
fix: remove state update for telegraf config id

### DIFF
--- a/src/dataLoaders/actions/dataLoaders.ts
+++ b/src/dataLoaders/actions/dataLoaders.ts
@@ -419,6 +419,7 @@ export const createOrUpdateTelegrafConfigAsync = () => async (
     )
 
     dispatch(editTelegraf(normTelegraf))
+    dispatch(setTelegrafConfigID(telegrafConfigID))
     event(`telegraf.config.edit.success`, {
       id: telegraf?.id,
       name: normalizeEventName(telegrafConfigName),
@@ -574,6 +575,7 @@ const createTelegraf = async (dispatch, getState: GetState, plugins) => {
       telegrafSchema
     )
 
+    dispatch(setTelegrafConfigID(tc.id))
     dispatch(addTelegraf(normTelegraf))
     dispatch(notify(TelegrafConfigCreationSuccess))
     event(`telegraf.config.create.success`, {

--- a/src/dataLoaders/actions/dataLoaders.ts
+++ b/src/dataLoaders/actions/dataLoaders.ts
@@ -419,7 +419,6 @@ export const createOrUpdateTelegrafConfigAsync = () => async (
     )
 
     dispatch(editTelegraf(normTelegraf))
-    dispatch(setTelegrafConfigID(telegrafConfigID))
     event(`telegraf.config.edit.success`, {
       id: telegraf?.id,
       name: normalizeEventName(telegrafConfigName),
@@ -575,7 +574,6 @@ const createTelegraf = async (dispatch, getState: GetState, plugins) => {
       telegrafSchema
     )
 
-    dispatch(setTelegrafConfigID(tc.id))
     dispatch(addTelegraf(normTelegraf))
     dispatch(notify(TelegrafConfigCreationSuccess))
     event(`telegraf.config.create.success`, {

--- a/src/dataLoaders/components/collectorsWizard/verify/VerifyCollectorsStep.tsx
+++ b/src/dataLoaders/components/collectorsWizard/verify/VerifyCollectorsStep.tsx
@@ -20,6 +20,7 @@ import {AppState} from 'src/types'
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
 import {RouteComponentProps, withRouter} from 'react-router-dom'
+import {clearDataLoaders} from 'src/dataLoaders/actions/dataLoaders'
 
 type OwnProps = CollectorsStepProps
 
@@ -31,7 +32,14 @@ interface StateProps {
   token: string
 }
 
-export type Props = StateProps & OwnProps & RouteComponentProps<{orgID: string}>
+interface DispatchProps {
+  onClearDataLoaders: () => void
+}
+
+export type Props = StateProps &
+  DispatchProps &
+  OwnProps &
+  RouteComponentProps<{orgID: string}>
 
 @ErrorHandling
 export class VerifyCollectorStep extends PureComponent<Props> {
@@ -76,7 +84,9 @@ export class VerifyCollectorStep extends PureComponent<Props> {
       match: {
         params: {orgID},
       },
+      onClearDataLoaders,
     } = this.props
+    onClearDataLoaders()
     this.props.history.push(`/orgs/${orgID}/load-data/telegrafs`)
   }
 }
@@ -95,6 +105,10 @@ const mstp = ({
   token,
 })
 
-const connector = connect<StateProps>(mstp)
+const mdtp = {
+  onClearDataLoaders: clearDataLoaders,
+}
+
+const connector = connect<StateProps, DispatchProps>(mstp, mdtp)
 
 export default connector(withRouter(VerifyCollectorStep))


### PR DESCRIPTION
Closes #4114 

<!-- Describe your proposed changes here. -->
When we are creating a telegraf, we are storing the telegraf config id in the state. So, when we create another telegraf, that id still exists and doesn't get into the `if(!telegrafConfig)` in the action to actually create a new one. Therefore, in the `VerifyCollectorsStep` we have added a call to action `clearDataLoaders` so that when we create new telegraf, the dataloader state is back to original state.