### PR TITLE
fix: the way notebooks are updated

### DIFF
--- a/cypress/e2e/cloud/flows.test.ts
+++ b/cypress/e2e/cloud/flows.test.ts
@@ -1,0 +1,173 @@
+import {Organization} from '../../src/types'
+
+describe('Flows', () => {
+  beforeEach(() => {
+    cy.flush()
+    cy.signin()
+    cy.get('@org').then(({id}: Organization) =>
+      cy.fixture('routes').then(({orgs}) => {
+        cy.visit(`${orgs}/${id}`)
+      })
+    )
+    cy.getByTestID('version-info')
+    cy.getByTestID('nav-item-flows').should('be.visible')
+    cy.getByTestID('nav-item-flows').click()
+  })
+
+  it('can create, clone a flow and persist selected data in the clone, and delete a flow from the list page', () => {
+    cy.intercept('PATCH', '/api/v2private/notebooks/*').as('updateNotebook')
+
+    const newBucketName = 'shmucket'
+    const now = Date.now()
+    cy.get<Organization>('@org').then(({id, name}: Organization) => {
+      cy.createBucket(id, name, newBucketName)
+    })
+    cy.writeData(
+      [
+        `test,container_name=cool dopeness=12 ${now - 1000}000000`,
+        `test,container_name=beans dopeness=18 ${now - 1200}000000`,
+        `test,container_name=cool dopeness=14 ${now - 1400}000000`,
+        `test,container_name=beans dopeness=10 ${now - 1600}000000`,
+      ],
+      newBucketName
+    )
+
+    const flowName = 'Flowbooks'
+    const clone = `${flowName} (clone 1)`
+
+    cy.getByTestID('preset-new')
+      .first()
+      .click()
+
+    cy.getByTestID('time-machine-submit-button').should('be.visible')
+
+    cy.getByTestID('page-title')
+      .first()
+      .click()
+
+    cy.getByTestID('renamable-page-title--input').type(`${flowName}{enter}`)
+    cy.wait('@updateNotebook')
+
+    cy.getByTestID('page-title').contains(flowName)
+
+    cy.getByTestID('sidebar-button')
+      .first()
+      .click()
+    cy.getByTestID('Delete--list-item').click()
+    cy.wait('@updateNotebook')
+
+    cy.get('.flow-divider--button')
+      .first()
+      .click()
+
+    // Opening the menu adds another Query Builder button
+    cy.getByTestID('add-flow-btn--queryBuilder').should('have.length', 2)
+
+    // Click the newest Query Builder button
+    cy.getByTestID('add-flow-btn--queryBuilder')
+      .last()
+      .click()
+    cy.wait('@updateNotebook')
+
+    // select our bucket
+    cy.getByTestID('bucket-selector').within(() => {
+      cy.getByTestID(`selector-list ${newBucketName}`).click()
+    })
+    cy.wait('@updateNotebook')
+
+    // select measurement and field
+    cy.getByTestID('builder-card')
+      .eq(0)
+      .within(() => {
+        cy.getByTestID(`selector-list test`).click()
+      })
+    cy.wait('@updateNotebook')
+
+    cy.getByTestID('builder-card')
+      .eq(1)
+      .within(() => {
+        cy.getByTestID(`selector-list dopeness`).click()
+      })
+    cy.wait('@updateNotebook')
+
+    // select beans tag and click preview
+    cy.getByTestID('builder-card')
+      .eq(2)
+      .within(() => {
+        cy.getByTestID(`selector-list beans`).click()
+      })
+    cy.wait('@updateNotebook')
+
+    cy.getByTestID('time-machine-submit-button').click()
+
+    // we should only see beans in the table
+    cy.getByTestID('simple-table').should('be.visible')
+    cy.getByTestID('table-cell beans')
+      .first()
+      .should('be.visible')
+    cy.getByTestID('table-cell cool').should('not.exist')
+
+    // This is a random validator that the autorefresh option doesn't pop up
+    // In Flows again without explicit changes
+    cy.getByTestID('autorefresh-dropdown--button').should('not.exist')
+
+    cy.clickNavBarItem('nav-item-flows')
+
+    cy.get('.cf-resource-card').should('have.length', 1)
+
+    cy.getByTestID('resource-editable-name').contains(`${flowName}`)
+
+    cy.getByTestID(`flow-card--${flowName}`).within(() => {
+      cy.getByTestID(`context-menu-flow`).click()
+    })
+
+    cy.getByTestID(`context-clone-flow`).click()
+
+    cy.getByTestID('time-machine-submit-button').should('be.visible')
+
+    // Should redirect the user to the newly cloned flow
+    // Validates that the selected clone is the clone
+    cy.getByTestID('page-title').contains(`${clone}`)
+
+    cy.clickNavBarItem('nav-item-flows')
+
+    cy.get('.cf-resource-card').should('have.length', 2)
+    cy.get('.cf-resource-editable-name')
+      .first()
+      .contains(`${clone}`)
+
+    // Delete the cloned flow
+    cy.getByTestID(`flow-card--${clone}`).within(() => {
+      cy.getByTestID(`context-delete-menu--button`).click()
+    })
+    cy.getByTestID(`context-delete-menu--confirm-button`).click()
+
+    cy.getByTestID('notification-success').should('be.visible')
+    cy.getByTestID('notification-success--dismiss').click()
+
+    cy.get('.cf-resource-card').should('have.length', 1)
+    cy.getByTestID('resource-editable-name').contains(`${flowName}`)
+
+    // Clone a flow again
+    cy.getByTestID(`flow-card--${flowName}`).within(() => {
+      cy.getByTestID(`context-menu-flow`).click()
+    })
+    cy.getByTestID(`context-clone-flow`).click()
+
+    // Should redirect the user to the newly cloned flow
+    cy.getByTestID('time-machine-submit-button').should('be.visible')
+    cy.wait('@updateNotebook')
+    cy.getByTestID('page-title').contains(`${clone}`)
+
+    // Delete the cloned flow inside the notebook
+    cy.getByTestID('flow-menu-button').click()
+    cy.getByTestID('flow-menu-button-delete').should('be.visible')
+    cy.getByTestID('flow-menu-button-delete').click()
+
+    cy.getByTestID('notification-success').should('be.visible')
+
+    cy.get('.cf-resource-card').should('have.length', 1)
+    cy.get('.cf-resource-editable-name').should('have.length', 1)
+    cy.get('.cf-resource-editable-name').contains(`${flowName}`)
+  })
+})

--- a/cypress/e2e/cloud/pinned.test.ts
+++ b/cypress/e2e/cloud/pinned.test.ts
@@ -211,6 +211,7 @@ from(bucket: "${name}"{rightarrow}
       cy.setFeatureFlags({
         pinnedItems: true,
       })
+      cy.intercept('GET', '**/notebooks').as('getNotebooks')
       cy.getByTestID('nav-item-flows').should('be.visible')
       cy.clickNavBarItem('nav-item-flows')
       const now = Date.now()
@@ -230,6 +231,7 @@ from(bucket: "${name}"{rightarrow}
       cy.getByTestID('page-title')
         .first()
         .click()
+      cy.intercept('GET', '**/notebooks').as('getNotebooks')
       cy.intercept('PATCH', '**/notebooks/*').as('updateNotebook')
       cy.getByTestID('renamable-page-title--input')
         .clear()
@@ -253,6 +255,7 @@ from(bucket: "${name}"{rightarrow}
         })
       cy.wait('@updateNotebook')
       cy.visit(`/orgs/${orgID}/notebooks`)
+      cy.wait('@getNotebooks')
     })
 
     it('pins a notebook to the homepage', () => {
@@ -290,8 +293,8 @@ from(bucket: "${name}"{rightarrow}
         .type('Bucks In Six')
         .type('{enter}')
       cy.getByTestID('notification-success--children').should('exist')
-      cy.wait('@updateNotebook')
       cy.wait('@updatePinned')
+      cy.wait('@updateNotebook')
       cy.visit('/')
       cy.getByTestID('tree-nav')
       cy.getByTestID('pinneditems--container').within(() => {
@@ -311,16 +314,11 @@ from(bucket: "${name}"{rightarrow}
         .first()
         .click()
 
-      cy.get('.cf-input-field')
-        .last()
-        .focus()
-        .type('Bucks In Six')
-        .type('{enter}')
-      cy.getByTestID('flow-card--Bucks In Six').within(() => {
+      cy.getByTestID('flow-card--Flow').within(() => {
         cy.getByTestID('context-menu-flow').click()
       })
       cy.getByTestID('context-pin-flow').click()
-      cy.getByTestID('flow-card--Bucks In Six').within(() => {
+      cy.getByTestID('flow-card--Flow').within(() => {
         cy.getByTestID(`context-delete-menu--button`).click()
       })
       cy.getByTestID(`context-delete-menu--confirm-button`).click()

--- a/cypress/e2e/shared/flows.test.ts
+++ b/cypress/e2e/shared/flows.test.ts
@@ -167,7 +167,7 @@ describe('Flows', () => {
       .should('be.visible')
   })
 
-  it('can create, clone a flow and persist selected data in the clone, and delete a flow from the list page', () => {
+  it('can create and delete a flow from the list page', () => {
     cy.intercept('PATCH', '/api/v2private/notebooks/*').as('updateNotebook')
 
     const newBucketName = 'shmucket'
@@ -186,7 +186,6 @@ describe('Flows', () => {
     )
 
     const flowName = 'Flowbooks'
-    const clone = `${flowName} (clone 1)`
 
     cy.getByTestID('preset-new')
       .first()
@@ -269,59 +268,6 @@ describe('Flows', () => {
     cy.get('.cf-resource-card').should('have.length', 1)
 
     cy.getByTestID('resource-editable-name').contains(`${flowName}`)
-
-    cy.getByTestID(`flow-card--${flowName}`).within(() => {
-      cy.getByTestID(`context-menu-flow`).click()
-    })
-
-    cy.getByTestID(`context-clone-flow`).click()
-
-    cy.getByTestID('time-machine-submit-button').should('be.visible')
-
-    // Should redirect the user to the newly cloned flow
-    // Validates that the selected clone is the clone
-    cy.getByTestID('page-title').contains(`${clone}`)
-
-    cy.clickNavBarItem('nav-item-flows')
-
-    cy.get('.cf-resource-card').should('have.length', 2)
-    cy.get('.cf-resource-editable-name')
-      .first()
-      .contains(`${clone}`)
-
-    // Delete the cloned flow
-    cy.getByTestID(`flow-card--${clone}`).within(() => {
-      cy.getByTestID(`context-delete-menu--button`).click()
-    })
-    cy.getByTestID(`context-delete-menu--confirm-button`).click()
-
-    cy.getByTestID('notification-success').should('be.visible')
-    cy.getByTestID('notification-success--dismiss').click()
-
-    cy.get('.cf-resource-card').should('have.length', 1)
-    cy.getByTestID('resource-editable-name').contains(`${flowName}`)
-
-    // Clone a flow again
-    cy.getByTestID(`flow-card--${flowName}`).within(() => {
-      cy.getByTestID(`context-menu-flow`).click()
-    })
-    cy.getByTestID(`context-clone-flow`).click()
-
-    // Should redirect the user to the newly cloned flow
-    cy.getByTestID('time-machine-submit-button').should('be.visible')
-    cy.wait('@updateNotebook')
-    cy.getByTestID('page-title').contains(`${clone}`)
-
-    // Delete the cloned flow inside the notebook
-    cy.getByTestID('flow-menu-button').click()
-    cy.getByTestID('flow-menu-button-delete').should('be.visible')
-    cy.getByTestID('flow-menu-button-delete').click()
-
-    cy.getByTestID('notification-success').should('be.visible')
-
-    cy.get('.cf-resource-card').should('have.length', 1)
-    cy.get('.cf-resource-editable-name').should('have.length', 1)
-    cy.get('.cf-resource-editable-name').contains(`${flowName}`)
   })
 
   it('should have the same number of flow panels and no presentation panel when presentation mode is off', () => {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "cy": "CYPRESS_dexUrl=https://$INGRESS_HOST:$PORT_HTTPS CYPRESS_baseUrl=http://localhost:9999 cypress open",
     "cy:dev": "source ../monitor-ci/.env && CYPRESS_dexUrl=CLOUD CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{cloud,shared}/**/*.*'",
     "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_dexUrl=OSS CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{oss,shared}/**/*.*'",
-    "generate": "export SHA=912fc1474b63f022231dbd068c935451ca0f677a && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
+    "generate": "export SHA=8823ef7b35fe7096856fa903649f7986ff31ef2e && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-meta": "if [ -z \"${CLOUD_URL}\" ]; then yarn generate-meta-oss; else yarn generate-meta-cloud; fi",
     "generate-meta-oss": "yarn oss-api && yarn notebooks && yarn unity && yarn annotations-oss && yarn pinned && yarn mapsd-oss && yarn cloudPriv && yarn fluxdocs && yarn subscriptions-oss",

--- a/src/flows/components/FlowCard.tsx
+++ b/src/flows/components/FlowCard.tsx
@@ -45,7 +45,7 @@ const FlowCard: FC<Props> = ({id, isPinned}) => {
   )
 
   const handleRenameNotebook = (name: string) => {
-    update(id, {...flow, name})
+    update(id, name)
     if (isFlagEnabled('pinnedItems') && CLOUD && isPinned) {
       try {
         updatePinnedItemByParam(id, {name})

--- a/src/flows/components/FlowCard.tsx
+++ b/src/flows/components/FlowCard.tsx
@@ -44,8 +44,8 @@ const FlowCard: FC<Props> = ({id, isPinned}) => {
     <FlowContextMenu id={id} name={flow.name} isPinned={isPinned} />
   )
 
-  const handleRenameNotebook = (name: string) => {
-    update(id, name)
+  const handleRenameNotebook = async (name: string) => {
+    await update(id, name)
     if (isFlagEnabled('pinnedItems') && CLOUD && isPinned) {
       try {
         updatePinnedItemByParam(id, {name})

--- a/src/flows/components/FlowContextMenu.tsx
+++ b/src/flows/components/FlowContextMenu.tsx
@@ -120,44 +120,48 @@ const FlowContextMenu: FC<Props> = ({id, name, isPinned}) => {
         confirmationButtonText="Confirm"
         testID="context-delete-menu"
       />
-      <SquareButton
-        ref={settingsRef}
-        size={ComponentSize.ExtraSmall}
-        icon={IconFont.CogSolid_New}
-        color={ComponentColor.Colorless}
-        testID="context-menu-flow"
-      />
-      <Popover
-        appearance={Appearance.Outline}
-        enableDefaultStyles={false}
-        style={{minWidth: '112px'}}
-        triggerRef={settingsRef}
-        contents={onHide => (
-          <List>
-            <List.Item
-              onClick={handleClone}
-              size={ComponentSize.Small}
-              style={{fontWeight: 500}}
-              testID="context-clone-flow"
-            >
-              Clone
-            </List.Item>
-            {isFlagEnabled('pinnedItems') && CLOUD && (
-              <List.Item
-                onClick={() => {
-                  handlePinFlow()
-                  onHide()
-                }}
-                size={ComponentSize.Small}
-                style={{fontWeight: 500}}
-                testID="context-pin-flow"
-              >
-                {isPinned ? 'Unpin' : 'Pin'}
-              </List.Item>
+      {CLOUD && (
+        <>
+          <SquareButton
+            ref={settingsRef}
+            size={ComponentSize.ExtraSmall}
+            icon={IconFont.CogSolid_New}
+            color={ComponentColor.Colorless}
+            testID="context-menu-flow"
+          />
+          <Popover
+            appearance={Appearance.Outline}
+            enableDefaultStyles={false}
+            style={{minWidth: '112px'}}
+            triggerRef={settingsRef}
+            contents={onHide => (
+              <List>
+                <List.Item
+                  onClick={handleClone}
+                  size={ComponentSize.Small}
+                  style={{fontWeight: 500}}
+                  testID="context-clone-flow"
+                >
+                  Clone
+                </List.Item>
+                {isFlagEnabled('pinnedItems') && CLOUD && (
+                  <List.Item
+                    onClick={() => {
+                      handlePinFlow()
+                      onHide()
+                    }}
+                    size={ComponentSize.Small}
+                    style={{fontWeight: 500}}
+                    testID="context-pin-flow"
+                  >
+                    {isPinned ? 'Unpin' : 'Pin'}
+                  </List.Item>
+                )}
+              </List>
             )}
-          </List>
-        )}
-      />
+          />
+        </>
+      )}
     </FlexBox>
   )
 }

--- a/src/flows/components/header/MenuButton.tsx
+++ b/src/flows/components/header/MenuButton.tsx
@@ -27,6 +27,7 @@ import {downloadImage} from 'src/shared/utils/download'
 
 // Constants
 import {PROJECT_NAME_PLURAL} from 'src/flows'
+import {CLOUD} from 'src/shared/constants'
 
 const backgroundColor = '#07070E'
 
@@ -175,12 +176,6 @@ const MenuButton: FC<Props> = ({handleResetShare}) => {
   const menuItems: any[] = [
     {
       type: 'menuitem',
-      title: 'Clone',
-      onClick: handleClone,
-      icon: IconFont.Duplicate_New,
-    },
-    {
-      type: 'menuitem',
       title: 'Download as PNG',
       onClick: handleDownloadAsPNG,
       icon: IconFont.Download_New,
@@ -199,6 +194,15 @@ const MenuButton: FC<Props> = ({handleResetShare}) => {
       testID: 'flow-menu-button-delete',
     },
   ]
+
+  if (CLOUD) {
+    menuItems.splice(0, 0, {
+      type: 'menuitem',
+      title: 'Clone',
+      onClick: handleClone,
+      icon: IconFont.Duplicate_New,
+    })
+  }
 
   if (isFlagEnabled('flowPublishLifecycle')) {
     menuItems.splice(

--- a/src/flows/context/flow.current.tsx
+++ b/src/flows/context/flow.current.tsx
@@ -7,10 +7,10 @@ import {Doc} from 'yjs'
 import {WebsocketProvider} from 'y-websocket'
 import {serialize, hydrate} from 'src/flows/context/flow.list'
 import {useParams} from 'react-router-dom'
-import {getNotebook, postNotebook} from 'src/client/notebooksRoutes'
+import {getNotebook, postNotebooksClone} from 'src/client/notebooksRoutes'
 import {event} from 'src/cloud/utils/reporting'
 import {deleteNotebook} from 'src/client/notebooksRoutes'
-import {getAllAPI, pooledUpdateAPI} from 'src/flows/context/api'
+import {pooledUpdateAPI} from 'src/flows/context/api'
 import {useDispatch} from 'react-redux'
 import {notify} from 'src/shared/actions/notifications'
 import {
@@ -20,7 +20,6 @@ import {
 import PageSpinner from 'src/perf/components/PageSpinner'
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 import {RemoteDataState} from '@influxdata/clockface'
-import {incrementCloneName} from 'src/utils/naming'
 
 const prettyid = customAlphabet('abcdefghijklmnop0123456789', 12)
 
@@ -85,15 +84,12 @@ export const FlowProvider: FC = ({children}) => {
 
   const handleCloneNotebook = useCallback(async () => {
     try {
-      const {flows} = await getAllAPI(orgID)
-
-      const allFlowNames = Object.values(flows).map(value => value.name)
-      const clonedName = incrementCloneName(allFlowNames, currentFlow.name)
-
-      const _flow = serialize({...currentFlow, name: clonedName})
-      delete _flow.data.id
-
-      const response = await postNotebook(_flow)
+      const response = await postNotebooksClone({
+        id: currentFlow.id,
+        data: {
+          orgID,
+        },
+      })
 
       if (response.status !== 200) {
         throw new Error(response.data.message)

--- a/src/flows/context/flow.current.tsx
+++ b/src/flows/context/flow.current.tsx
@@ -20,7 +20,7 @@ import {
 import PageSpinner from 'src/perf/components/PageSpinner'
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 import {RemoteDataState} from '@influxdata/clockface'
-import { incrementCloneName } from 'src/utils/naming';
+import {incrementCloneName} from 'src/utils/naming'
 
 const prettyid = customAlphabet('abcdefghijklmnop0123456789', 12)
 

--- a/src/flows/context/flow.current.tsx
+++ b/src/flows/context/flow.current.tsx
@@ -7,9 +7,7 @@ import {Doc} from 'yjs'
 import {WebsocketProvider} from 'y-websocket'
 import {serialize, hydrate} from 'src/flows/context/flow.list'
 import {useParams} from 'react-router-dom'
-import {getNotebook, postNotebook,
-  // postNotebooksClone
-} from 'src/client/notebooksRoutes'
+import {getNotebook, postNotebook} from 'src/client/notebooksRoutes'
 import {event} from 'src/cloud/utils/reporting'
 import {deleteNotebook} from 'src/client/notebooksRoutes'
 import {getAllAPI, pooledUpdateAPI} from 'src/flows/context/api'
@@ -96,9 +94,6 @@ export const FlowProvider: FC = ({children}) => {
       delete _flow.data.id
 
       const response = await postNotebook(_flow)
-      // const response = await postNotebooksClone({id: currentFlow.id, data: {
-      //   orgID
-      // }})
 
       if (response.status !== 200) {
         throw new Error(response.data.message)

--- a/src/flows/context/flow.list.tsx
+++ b/src/flows/context/flow.list.tsx
@@ -251,7 +251,13 @@ export const FlowListProvider: FC = ({children}) => {
           throw new Error(resp.data.message)
         }
 
-        return id
+        setFlows(prevFlows => ({
+          ...prevFlows,
+          [id]: {
+            ...prevFlows[id],
+            name,
+          },
+        }))
       } catch (error) {
         console.error({error})
       }

--- a/src/flows/context/flow.list.tsx
+++ b/src/flows/context/flow.list.tsx
@@ -304,14 +304,20 @@ export const FlowListProvider: FC = ({children}) => {
     const data = await getAllAPI(org.id)
     if (data && data.flows) {
       const _flows = {}
-      data.flows.forEach(flow => {
-        _flows[flow.id] = {
-          name: flow.name,
-          createdAt: flow.createdAt,
-          createdBy: flow.createdBy,
-          updatedAt: flow.updatedAt,
-        }
-      })
+      if (CLOUD) {
+        data.flows.forEach(flow => {
+          _flows[flow.id] = {
+            name: flow.name,
+            createdAt: flow.createdAt,
+            createdBy: flow.createdBy,
+            updatedAt: flow.updatedAt,
+          }
+        })
+      } else {
+        data.flows.forEach(f => {
+          _flows[f.id] = hydrate(f)
+        })
+      }
       setFlows(_flows)
     }
   }, [org.id, setFlows])

--- a/src/flows/context/flow.list.tsx
+++ b/src/flows/context/flow.list.tsx
@@ -16,12 +16,12 @@ import {AUTOREFRESH_DEFAULT} from 'src/shared/constants'
 import {DEFAULT_PROJECT_NAME, PROJECT_NAME} from 'src/flows'
 import {TEMPLATES} from 'src/flows/templates'
 import {
-  pooledUpdateAPI,
   createAPI,
   deleteAPI,
   getAllAPI,
   migrateLocalFlowsToAPI,
 } from 'src/flows/context/api'
+import {patchNotebook} from 'src/client/notebooksRoutes'
 import {notify} from 'src/shared/actions/notifications'
 import {
   notebookCreateFail,
@@ -33,7 +33,7 @@ import {incrementCloneName} from 'src/utils/naming'
 export interface FlowListContextType extends FlowList {
   add: (flow?: Flow) => Promise<string | void>
   clone: (id: string) => Promise<string | void>
-  update: (id: string, flow: Partial<Flow>) => void
+  update: (id: string, name: string) => void
   remove: (id: string) => void
   getAll: () => void
 }
@@ -57,7 +57,7 @@ export const DEFAULT_CONTEXT: FlowListContextType = {
   flows: {},
   add: (_flow?: Flow) => {},
   clone: (_id: string) => {},
-  update: (_id: string, _flow: Partial<Flow>) => {},
+  update: (_id: string, _name: string) => {},
   remove: (_id: string) => {},
   getAll: () => {},
 } as FlowListContextType
@@ -230,25 +230,27 @@ export const FlowListProvider: FC = ({children}) => {
   }
 
   const update = useCallback(
-    (id: string, flow: Partial<Flow>) => {
-      if (!flows.hasOwnProperty(id)) {
-        throw new Error(`${PROJECT_NAME} not found`)
+    async (id: string, name: string) => {
+      try {
+        if (!flows.hasOwnProperty(id)) {
+          throw new Error(`${PROJECT_NAME} not found`)
+        }
+
+        const resp = await patchNotebook({
+          id,
+          data: {
+            name,
+          },
+        })
+
+        if (resp.status !== 200) {
+          throw new Error(resp.data.message)
+        }
+
+        return id
+      } catch (error) {
+        console.error({error})
       }
-
-      setFlows(prevFlows => ({
-        ...prevFlows,
-        [id]: {
-          ...prevFlows[id],
-          ...flow,
-        },
-      }))
-
-      const apiFlow = serialize({
-        ...flows[id],
-        ...flow,
-      })
-
-      pooledUpdateAPI({id, ...apiFlow})
     },
     [setFlows, org.id, flows] // eslint-disable-line react-hooks/exhaustive-deps
   )
@@ -276,8 +278,13 @@ export const FlowListProvider: FC = ({children}) => {
     const data = await getAllAPI(org.id)
     if (data && data.flows) {
       const _flows = {}
-      data.flows.forEach(f => {
-        _flows[f.id] = hydrate(f)
+      data.flows.forEach(flow => {
+        _flows[flow.id] = {
+          name: flow.name,
+          createdAt: flow.createdAt,
+          createdBy: flow.createdBy,
+          updatedAt: flow.updatedAt,
+        }
       })
       setFlows(_flows)
     }

--- a/src/flows/context/flow.query.tsx
+++ b/src/flows/context/flow.query.tsx
@@ -72,7 +72,7 @@ export const FlowQueryProvider: FC = ({children}) => {
     }
     _generateMap()
     queryAll()
-  }, [flow?.range])
+  }, [flow?.range?.lower, flow?.range?.upper])
 
   useEffect(() => {
     if (flow?.readOnly) {

--- a/src/flows/context/version.read.tsx
+++ b/src/flows/context/version.read.tsx
@@ -21,8 +21,7 @@ export const VersionFlowProvider: FC = ({children}) => {
       if (response.status !== 200) {
         throw new Error(response.data.message)
       }
-      // TODO(ariel): update the definition to match the API
-      setFlow(hydrate((response.data as any).notebookVersion))
+      setFlow(hydrate(response.data.notebookVersion))
       setLoading(RemoteDataState.Done)
     } catch (error) {
       console.error({error})

--- a/src/pageLayout/components/RenamablePageTitle.tsx
+++ b/src/pageLayout/components/RenamablePageTitle.tsx
@@ -68,6 +68,11 @@ const RenamablePageTitle: FC<Props> = ({
       setEditingState(false)
       setWorkingName(name)
     }
+
+    if (e.key === 'Tab') {
+      onRename(workingName)
+      setEditingState(false)
+    }
   }
 
   const handleInputFocus = (e: ChangeEvent<InputRef>): void => {

--- a/src/pageLayout/components/RenamablePageTitle.tsx
+++ b/src/pageLayout/components/RenamablePageTitle.tsx
@@ -59,7 +59,7 @@ const RenamablePageTitle: FC<Props> = ({
   }
 
   const handleKeyDown = (e: KeyboardEvent<InputRef>): void => {
-    if (e.key === 'Enter') {
+    if (e.key === 'Enter' || e.key === 'Tab') {
       onRename(workingName)
       setEditingState(false)
     }
@@ -67,11 +67,6 @@ const RenamablePageTitle: FC<Props> = ({
     if (e.key === 'Escape') {
       setEditingState(false)
       setWorkingName(name)
-    }
-
-    if (e.key === 'Tab') {
-      onRename(workingName)
-      setEditingState(false)
     }
   }
 


### PR DESCRIPTION
Closes #4258
Closes #4259
Closes #4255

This PR updates the way that notebook updates are handled. Whereas beforehand a deep copy was created and used as a reference to update the flow, this PR ensures that the only data that's being updated should be passed into the current flow so that the update registers the most recent changes and doesn't have stale data.

In addition, this issue resolves a previously unreported bug with our renaming where if a user tabs out of naming a resource, those name changes didn't get registered

<!-- Describe your proposed changes here. -->
