### PR TITLE
chore: use resolutions for sec fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -227,6 +227,7 @@
     "mocha-junit-reporter/**/ansi-regex": "^3.0.1",
     "strip-ansi/**/ansi-regex": "^5.0.1",
     "table/**/ansi-regex": "^4.1.1",
-    "webpack-dev-server/**/ansi-regex": "^6.0.1"
+    "webpack-dev-server/**/ansi-regex": "^6.0.1",
+    "optimize-css-assets-webpack-plugin/**/nanoid": "^3.1.31"
   }
 }

--- a/package.json
+++ b/package.json
@@ -217,5 +217,9 @@
     "worker-plugin": "^5.0.1",
     "y-websocket": "^1.3.16",
     "yjs": "^13.5.13"
+  },
+  "resolutions": {
+    "mocha/**/minimist": "^0.0.8",
+    "minimist": "^1.2.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -220,6 +220,13 @@
   },
   "resolutions": {
     "mocha/**/minimist": "^0.0.8",
-    "minimist": "^1.2.6"
+    "minimist": "^1.2.6",
+    "eslint/**/ansi-regex": "^4.1.1",
+    "jest-junit/**/ansi-regex": "^4.1.1",
+    "pretty-format/**/ansi-regex": "^5.0.1",
+    "mocha-junit-reporter/**/ansi-regex": "^3.0.1",
+    "strip-ansi/**/ansi-regex": "^5.0.1",
+    "table/**/ansi-regex": "^4.1.1",
+    "webpack-dev-server/**/ansi-regex": "^6.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2397,15 +2397,15 @@ ansi-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
   integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
 
-ansi-regex@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
-  integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
+ansi-regex@^3.0.0, ansi-regex@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.1.tgz#123d6479e92ad45ad897d4054e3c7ca7db4944e1"
+  integrity sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==
 
-ansi-regex@^4.0.0, ansi-regex@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
-  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
+ansi-regex@^4.0.0, ansi-regex@^4.1.0, ansi-regex@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
+  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
 
 ansi-regex@^5.0.1:
   version "5.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8181,10 +8181,10 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
   integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
 
-nanoid@^3.1.30:
-  version "3.1.30"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.30.tgz#63f93cc548d2a113dc5dfbc63bfa09e2b9b64362"
-  integrity sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==
+nanoid@^3.1.30, nanoid@^3.1.31:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.2.tgz#c89622fafb4381cd221421c69ec58547a1eec557"
+  integrity sha512-CuHBogktKwpm5g2sRgv83jEy2ijFzBwMoYA60orPDR7ynsLijJDqgsi4RDGj3OJpy3Ieb+LYwiRmIOGyytgITA==
 
 nanoid@^3.2.0:
   version "3.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7939,15 +7939,15 @@ minimatch@3.0.4, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8:
+minimist@0.0.8, minimist@^0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
-minimist@^1.2.0, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 minipass-collect@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Since (some of) the less urgent updates for the dependabot alerts have been lingering due to our dependencies not pulling in updated versions, I decided to explore other options and came across: https://classic.yarnpkg.com/en/docs/selective-version-resolutions/. This should resolve all dependabot alerts except `clean-css`. There are 3 different commits:

* chore: resolve minimist to 1.2.6
* chore: resolve ansi-regex to 4.1.1 (ansi-regex is used in a number of places. The 4.0.0 series should use 4.1.1 though, so use 'yarn why ansi-regex' to pick out what to resolve to the various differently fixed versions). The others use 3.0.1, 5.0.1 and 6.0.1 since those are the ones that have the fix
* chore: resolve nanoid to 3.1.31 (first with the fix)

Each commit consisted of a) updating `resolutions` in `package.json` for the dependency, running `yarn install`, examining `git diff` and then committing.

Please be advised that the mimimist update resolves a high issue (but I've not triaged it to see if it is actually high for us yet). I did not test this beyond eyeballing that the semvers looked right.