### PR TITLE
chore(firstMile): use docstrings in python examples

### DIFF
--- a/src/homepageExperience/components/steps/ExecuteAggregateQuery.tsx
+++ b/src/homepageExperience/components/steps/ExecuteAggregateQuery.tsx
@@ -6,10 +6,6 @@ import {event} from 'src/cloud/utils/reporting'
 import {useSelector} from 'react-redux'
 import {getOrg} from 'src/organizations/selectors'
 
-const fromBucketSnippet = `from(bucket: “my-bucket”)
-  |> range(start: -10m) # find data points in last 10 minutes
-  |> mean()`
-
 const logCopyCodeSnippet = () => {
   event('firstMile.pythonWizard.executeAggregateQuery.code.copied')
 }
@@ -26,9 +22,16 @@ export const ExecuteAggregateQuery = (props: ExecuteAggregateQueryProps) => {
   const org = useSelector(getOrg)
   const {bucket} = props
 
+  const fromBucketSnippet = `from(bucket: "${bucket}")
+  |> range(start: -10m) # find data points in last 10 minutes
+  |> mean()`
+
   const codeSnippet = `query_api = client.query_api()
 
-query = 'from(bucket: "${bucket}") |> range(start: -10m) |> filter(fn: (r) => r._measurement == "measurement1") |> mean()'
+query = """from(bucket: "${bucket}")
+  |> range(start: -10m)
+  |> filter(fn: (r) => r._measurement == "measurement1")
+  |> mean()"""
 tables = query_api.query(query, org="${org.name}")
 
 for table in tables:

--- a/src/homepageExperience/components/steps/ExecuteQuery.tsx
+++ b/src/homepageExperience/components/steps/ExecuteQuery.tsx
@@ -4,9 +4,6 @@ import {event} from 'src/cloud/utils/reporting'
 import {useSelector} from 'react-redux'
 import {getOrg} from 'src/organizations/selectors'
 
-const fromBucketSnippet = `from(bucket: “my-bucket”)
-  |> range(start: -10m)`
-
 const logCopyCodeSnippet = () => {
   event('firstMile.pythonWizard.executeQuery.code.copied')
 }
@@ -18,9 +15,15 @@ type ExecuteQueryProps = {
 export const ExecuteQuery = (props: ExecuteQueryProps) => {
   const org = useSelector(getOrg)
   const {bucket} = props
+
+  const fromBucketSnippet = `from(bucket: "${bucket}")
+  |> range(start: -10m)`
+
   const query = `query_api = client.query_api()
 
-query = 'from(bucket: "${bucket}") |> range(start: -10m) |> filter(fn: (r) => r._measurement == "measurement1")'
+query = """from(bucket: "${bucket}")
+ |> range(start: -10m)
+ |> filter(fn: (r) => r._measurement == "measurement1")"""
 tables = query_api.query(query, org="${org.name}")
 
 for table in tables:

--- a/src/homepageExperience/containers/HomepagePythonWizard.tsx
+++ b/src/homepageExperience/containers/HomepagePythonWizard.tsx
@@ -33,7 +33,7 @@ interface State {
 export class HomepagePythonWizard extends PureComponent<null, State> {
   state = {
     currentStep: 1,
-    selectedBucket: '',
+    selectedBucket: 'my-bucket',
   }
 
   private handleSelectBucket = (bucketName: string) => {


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/4275

- Uses docstrings:
![Screen Shot 2022-03-31 at 10 11 46 AM](https://user-images.githubusercontent.com/146112/161108000-b5867225-cfef-40fb-a523-b939c919930f.png)

- Use the bucket the user selected in the query example text
![Screen Shot 2022-03-31 at 10 13 19 AM](https://user-images.githubusercontent.com/146112/161108074-e66b5395-2c85-46e2-b90a-03e61690b911.png)
 
- Default empty buckets to `my-bucket`, rather than `""`
![Screen Shot 2022-03-31 at 10 15 27 AM](https://user-images.githubusercontent.com/146112/161108157-12f6cab0-bee1-4a07-bca6-94bd1dd6b85c.png)

