### PR TITLE
chore(firstMile): tweak naming and structure after adding nodejs

### DIFF
--- a/src/homepageExperience/components/steps/Finish.tsx
+++ b/src/homepageExperience/components/steps/Finish.tsx
@@ -7,7 +7,10 @@ import {
   IconFont,
   ResourceCard,
 } from '@influxdata/clockface'
-import {InfluxDBUniversityIcon, VSCodePluginIcon} from 'src/homepageExperience/components/HomepageIcons'
+import {
+  InfluxDBUniversityIcon,
+  VSCodePluginIcon,
+} from 'src/homepageExperience/components/HomepageIcons'
 import {event} from 'src/cloud/utils/reporting'
 
 export const Finish = () => {

--- a/src/homepageExperience/components/steps/Finish.tsx
+++ b/src/homepageExperience/components/steps/Finish.tsx
@@ -7,7 +7,7 @@ import {
   IconFont,
   ResourceCard,
 } from '@influxdata/clockface'
-import {InfluxDBUniversityIcon, VSCodePluginIcon} from '../HomepageIcons'
+import {InfluxDBUniversityIcon, VSCodePluginIcon} from 'src/homepageExperience/components/HomepageIcons'
 import {event} from 'src/cloud/utils/reporting'
 
 export const Finish = () => {

--- a/src/homepageExperience/containers/NodejsWizard.tsx
+++ b/src/homepageExperience/containers/NodejsWizard.tsx
@@ -30,7 +30,7 @@ interface State {
   selectedBucket: string
 }
 
-export class HomepageNodejsWizard extends PureComponent<null, State> {
+export class NodejsWizard extends PureComponent<null, State> {
   state = {
     currentStep: 1,
     selectedBucket: 'my-bucket',

--- a/src/homepageExperience/containers/PythonWizard.tsx
+++ b/src/homepageExperience/containers/PythonWizard.tsx
@@ -30,7 +30,7 @@ interface State {
   selectedBucket: string
 }
 
-export class HomepagePythonWizard extends PureComponent<null, State> {
+export class PythonWizard extends PureComponent<null, State> {
   state = {
     currentStep: 1,
     selectedBucket: 'my-bucket',

--- a/src/shared/containers/SetOrg.tsx
+++ b/src/shared/containers/SetOrg.tsx
@@ -21,7 +21,7 @@ import {
   FlowPage,
   FlowsIndex,
   HomepageContainer,
-  HomepageNodejsWizard,
+  NodejsWizard,
   HomepagePythonWizard,
   LabelsIndex,
   MembersIndex,
@@ -313,7 +313,7 @@ const SetOrg: FC = () => {
               <Route
                 exact
                 path="/orgs/:orgID/new-user-wizard/nodejs"
-                component={HomepageNodejsWizard}
+                component={NodejsWizard}
               />
             </>
           )}

--- a/src/shared/containers/SetOrg.tsx
+++ b/src/shared/containers/SetOrg.tsx
@@ -22,7 +22,7 @@ import {
   FlowsIndex,
   HomepageContainer,
   NodejsWizard,
-  HomepagePythonWizard,
+  PythonWizard,
   LabelsIndex,
   MembersIndex,
   MePage,
@@ -308,7 +308,7 @@ const SetOrg: FC = () => {
               <Route
                 exact
                 path="/orgs/:orgID/new-user-wizard/python"
-                component={HomepagePythonWizard}
+                component={PythonWizard}
               />
               <Route
                 exact

--- a/src/shared/containers/index.tsx
+++ b/src/shared/containers/index.tsx
@@ -114,13 +114,13 @@ export const HomepageContainer = lazy(() =>
 )
 
 export const PythonWizard = lazy(() =>
-  import(
-    'src/homepageExperience/containers/PythonWizard'
-  ).then(module => ({default: module.PythonWizard}))
+  import('src/homepageExperience/containers/PythonWizard').then(module => ({
+    default: module.PythonWizard,
+  }))
 )
 
 export const NodejsWizard = lazy(() =>
-  import(
-    'src/homepageExperience/containers/NodejsWizard'
-  ).then(module => ({default: module.NodejsWizard}))
+  import('src/homepageExperience/containers/NodejsWizard').then(module => ({
+    default: module.NodejsWizard,
+  }))
 )

--- a/src/shared/containers/index.tsx
+++ b/src/shared/containers/index.tsx
@@ -103,24 +103,24 @@ export const CreateSubscriptionForm = lazy(() =>
   import('src/writeData/subscriptions/components/CreateSubscriptionPage')
 )
 
+export const SubscriptionDetailsPage = lazy(() =>
+  import('src/writeData/subscriptions/components/SubscriptionDetailsPage')
+)
+
 export const HomepageContainer = lazy(() =>
   import(
     'src/homepageExperience/containers/HomepageContainer'
   ).then(module => ({default: module.HomepageContainer}))
 )
 
-export const HomepagePythonWizard = lazy(() =>
+export const PythonWizard = lazy(() =>
   import(
-    'src/homepageExperience/containers/HomepagePythonWizard'
-  ).then(module => ({default: module.HomepagePythonWizard}))
+    'src/homepageExperience/containers/PythonWizard'
+  ).then(module => ({default: module.PythonWizard}))
 )
 
 export const NodejsWizard = lazy(() =>
   import(
     'src/homepageExperience/containers/NodejsWizard'
   ).then(module => ({default: module.NodejsWizard}))
-)
-
-export const SubscriptionDetailsPage = lazy(() =>
-  import('src/writeData/subscriptions/components/SubscriptionDetailsPage')
 )

--- a/src/shared/containers/index.tsx
+++ b/src/shared/containers/index.tsx
@@ -115,12 +115,12 @@ export const HomepagePythonWizard = lazy(() =>
   ).then(module => ({default: module.HomepagePythonWizard}))
 )
 
-export const SubscriptionDetailsPage = lazy(() =>
-  import('src/writeData/subscriptions/components/SubscriptionDetailsPage')
+export const NodejsWizard = lazy(() =>
+  import(
+    'src/homepageExperience/containers/NodejsWizard'
+  ).then(module => ({default: module.NodejsWizard}))
 )
 
-export const HomepageNodejsWizard = lazy(() =>
-  import(
-    'src/homepageExperience/containers/HomepageNodejsWizard'
-  ).then(module => ({default: module.HomepageNodejsWizard}))
+export const SubscriptionDetailsPage = lazy(() =>
+  import('src/writeData/subscriptions/components/SubscriptionDetailsPage')
 )


### PR DESCRIPTION
This is a small refactor - it tweaks the names of the first mile homepage containers just to keep things a little bit easier to follow