### PR TITLE
fix: update it so that readonly pipelists cant be resized

### DIFF
--- a/src/flows/components/ReadOnlyPipeList.tsx
+++ b/src/flows/components/ReadOnlyPipeList.tsx
@@ -116,6 +116,9 @@ const ReadOnlyPipeList: FC = () => {
         useCSSTransforms={false}
         containerPadding={[0, 0]}
         margin={[LAYOUT_MARGIN, LAYOUT_MARGIN]}
+        isDraggable={false}
+        isResizable={false}
+        draggableHandle=".cell--draggable"
       >
         {flow.data.allIDs
           .filter(

--- a/src/flows/components/VersionPage.tsx
+++ b/src/flows/components/VersionPage.tsx
@@ -39,7 +39,7 @@ const ReadOnlyFlowPage: FC = () => {
   const {flow} = useContext(FlowContext)
 
   return (
-    <Page titleTag={flow.name + ' (Shared) | InfluxDB Cloud'}>
+    <Page titleTag={`${flow.name} | InfluxDB Cloud`}>
       <VersionHeader />
       <Page.Contents fullWidth={true} scrollable={false} className="flow-page">
         <PopupProvider>


### PR DESCRIPTION
This PR is some general clean-up around notebooks where a shared version of a notebook in presentation mode AND a versioned notebook in presentation mode both had the ability to resize the panel (albeit those changes weren't stored anywhere, and so the operation did nothing but update the state). This caused a weird user expectation on what they could actually do in a notebook in that state when it had the draggable styling attached to it