### PR TITLE
fix: atomic query builder actions

### DIFF
--- a/src/flows/pipes/QueryBuilder/AddButton.tsx
+++ b/src/flows/pipes/QueryBuilder/AddButton.tsx
@@ -4,6 +4,7 @@ import {SquareButton, IconFont} from '@influxdata/clockface'
 import {RemoteDataState} from 'src/types'
 
 import {QueryBuilderContext} from 'src/flows/pipes/QueryBuilder/context'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 import {event} from 'src/cloud/utils/reporting'
 
@@ -16,6 +17,14 @@ const AddButton: FC = () => {
   }, [add])
 
   if (!cards.length) {
+    return null
+  }
+
+  if (
+    isFlagEnabled('newQueryBuilder') &&
+    !cards[0]?.values?.selected?.length &&
+    cards.length < 2
+  ) {
     return null
   }
 

--- a/src/flows/pipes/QueryBuilder/CardList.tsx
+++ b/src/flows/pipes/QueryBuilder/CardList.tsx
@@ -148,18 +148,10 @@ const Card: FC<Props> = ({idx}) => {
 
     if (index === -1) {
       event('Query Builder Value Selected')
-      if (isCompliant) {
-        _vals = [val]
-      } else {
-        _vals.push(val)
-      }
+      _vals.push(val)
     } else {
       event('Query Builder Value Unselected')
-      if (isCompliant) {
-        _vals = []
-      } else {
-        _vals.splice(index, 1)
-      }
+      _vals.splice(index, 1)
     }
 
     update(idx, {

--- a/src/flows/pipes/QueryBuilder/CardList.tsx
+++ b/src/flows/pipes/QueryBuilder/CardList.tsx
@@ -131,7 +131,7 @@ const Card: FC<Props> = ({idx}) => {
     card.values.selected.length <= 1
 
   const valueSelect = val => {
-    let _vals = [...card.values.selected]
+    const _vals = [...card.values.selected]
     const index = _vals.indexOf(val)
 
     if (isCompliant) {

--- a/src/flows/pipes/QueryBuilder/CardList.tsx
+++ b/src/flows/pipes/QueryBuilder/CardList.tsx
@@ -55,9 +55,15 @@ interface Props {
 }
 
 const Card: FC<Props> = ({idx}) => {
-  const {cards, add, update, remove, loadKeys, loadValues} = useContext(
-    QueryBuilderContext
-  )
+  const {
+    cards,
+    selectMeasurement,
+    add,
+    update,
+    remove,
+    loadKeys,
+    loadValues,
+  } = useContext(QueryBuilderContext)
   const {data} = useContext(PipeContext)
   const card = cards[idx]
   const [keySearches, setKeySearches] = useState([])
@@ -127,6 +133,18 @@ const Card: FC<Props> = ({idx}) => {
   const valueSelect = val => {
     let _vals = [...card.values.selected]
     const index = _vals.indexOf(val)
+
+    if (isCompliant) {
+      if (index === -1) {
+        event('Query Builder Value Selected')
+        selectMeasurement(val)
+      } else {
+        event('Query Builder Value Unselected')
+        selectMeasurement(null)
+      }
+
+      return
+    }
 
     if (index === -1) {
       event('Query Builder Value Selected')

--- a/src/flows/pipes/QueryBuilder/context.tsx
+++ b/src/flows/pipes/QueryBuilder/context.tsx
@@ -149,7 +149,40 @@ export const QueryBuilderProvider: FC = ({children}) => {
     ])
   }
 
-  const selectMeasurement = (_measurement?: string) => {}
+  const selectMeasurement = (measurement?: string) => {
+    if (measurement) {
+      update({
+        tags: [
+          {
+            ...data.tags[0],
+            values: [measurement],
+          },
+          toBuilderConfig(getDefaultCard()),
+        ],
+      })
+
+      setCardMeta([
+        cardMeta[0],
+        {
+          keys: [],
+          values: [],
+          loadingKeys: RemoteDataState.NotStarted,
+          loadingValues: RemoteDataState.NotStarted,
+        },
+      ])
+    } else {
+      update({
+        tags: [
+          {
+            ...data.tags[0],
+            values: [],
+          },
+        ],
+      })
+
+      setCardMeta([cardMeta[0]])
+    }
+  }
 
   const cards = useMemo(
     () => data.tags.map((tag, idx) => fromBuilderConfig(tag, cardMeta[idx])),

--- a/src/flows/pipes/QueryBuilder/context.tsx
+++ b/src/flows/pipes/QueryBuilder/context.tsx
@@ -6,7 +6,6 @@ import React, {
   useState,
   useCallback,
   useMemo,
-  useEffect,
 } from 'react'
 
 // Contexts
@@ -63,6 +62,9 @@ const getDefaultCard = (): QueryBuilderCard => ({
 interface QueryBuilderContextType {
   cards: QueryBuilderCard[]
 
+  selectBucket: (bucket?: string) => void
+  selectMeasurement: (measurement?: string) => void
+
   add: () => void
   remove: (idx: number) => void
   update: (idx: number, card: Partial<QueryBuilderCard>) => void
@@ -72,6 +74,10 @@ interface QueryBuilderContextType {
 
 export const DEFAULT_CONTEXT: QueryBuilderContextType = {
   cards: [getDefaultCard()],
+
+  selectBucket: _ => {},
+  selectMeasurement: _ => {},
+
   add: () => {},
   remove: (_idx: number) => {},
   update: (_idx: number, _card: QueryBuilderCard) => {},
@@ -120,33 +126,19 @@ export const QueryBuilderProvider: FC = ({children}) => {
     })
   )
 
-  useEffect(() => {
-    // Migrate old data
-    if (typeof data.buckets[0] === 'string') {
-      const buck = buckets.find(b => b.name === data.buckets[0])
-
-      if (!buck) {
-        update({
-          buckets: [{type: 'user', name: data.buckets[0]}],
-        })
-
-        return
-      }
-
-      update({
-        buckets: [buck],
-      })
-
-      return
-    }
-
-    if (data.tags.length) {
-      return
-    }
-
+  const selectBucket = (bucket?: string) => {
     const card = getDefaultCard()
-    card.keys.selected = ['_measurement']
-    update({tags: [card].map(toBuilderConfig)})
+
+    if (!bucket || bucket === data?.buckets[0]?.name) {
+      update({buckets: [], tags: [card].map(toBuilderConfig)})
+    } else {
+      card.keys.selected = ['_measurement']
+      update({
+        buckets: [buckets.find(b => b.name === bucket)],
+        tags: [card].map(toBuilderConfig),
+      })
+    }
+
     setCardMeta([
       {
         keys: [],
@@ -155,7 +147,9 @@ export const QueryBuilderProvider: FC = ({children}) => {
         loadingValues: RemoteDataState.NotStarted,
       },
     ])
-  }, [data.buckets])
+  }
+
+  const selectMeasurement = (_measurement?: string) => {}
 
   const cards = useMemo(
     () => data.tags.map((tag, idx) => fromBuilderConfig(tag, cardMeta[idx])),
@@ -442,6 +436,10 @@ export const QueryBuilderProvider: FC = ({children}) => {
     <QueryBuilderContext.Provider
       value={{
         cards,
+
+        selectBucket,
+        selectMeasurement,
+
         add,
         remove,
         update: updater,

--- a/src/flows/pipes/QueryBuilder/index.ts
+++ b/src/flows/pipes/QueryBuilder/index.ts
@@ -29,8 +29,6 @@ export default register => {
         return ''
       }
 
-      console.log('generating', data.tags)
-
       const tags = data.tags
         .map(tag => {
           if (!tag.key) {

--- a/src/flows/pipes/QueryBuilder/index.ts
+++ b/src/flows/pipes/QueryBuilder/index.ts
@@ -29,6 +29,8 @@ export default register => {
         return ''
       }
 
+      console.log('generating', data.tags)
+
       const tags = data.tags
         .map(tag => {
           if (!tag.key) {


### PR DESCRIPTION
Got some feedback on the "always select a measurement first" product change made in #4286. measurement selection should mirror bucket selection for a product perspective in that it should clear the query and start over again when you select a new one.

this involved some clean up on bucket selection as well. we used some useEffects to sniff on changes to the data.buckets property to see if the bucket had changed, and thus we should perform some action on the data. Now that we wanted that action to also be connected to a measurement, but only if there was a flag on, the useEffect got a bit... tangled. In order to make the code a bit more straight forward, the useEffect logic for clearing a query when a bucket gets selected got moved to it's own function on the context. once this proved a bit more forward, since we wanted a product change that mirrored this behavior, the technique was mirrored for measurement selection. this mechanism is a bit more rough because, for backwards compatibility reasons, we need to say that a measurement is the first card, and only if deemed 'compliant'.