### PR TITLE
chore(firstMile): cleanup - props naming; passing in event name to Finish component

### DIFF
--- a/src/homepageExperience/components/steps/Finish.tsx
+++ b/src/homepageExperience/components/steps/Finish.tsx
@@ -16,9 +16,13 @@ import {SafeBlankLink} from 'src/utils/SafeBlankLink'
 
 import {event} from 'src/cloud/utils/reporting'
 
-export const Finish = () => {
+type OwnProps = {
+  wizardEventName: string
+}
+
+export const Finish = (props: OwnProps) => {
   useEffect(() => {
-    event('firstMile.pythonWizard.finished')
+    event(`firstMile.${props.wizardEventName}.finished`)
   }, [])
   return (
     <>

--- a/src/homepageExperience/components/steps/nodejs/ExecuteAggregateQuery.tsx
+++ b/src/homepageExperience/components/steps/nodejs/ExecuteAggregateQuery.tsx
@@ -12,11 +12,11 @@ const logDocsOpened = () => {
   event('firstMile.nodejsWizard.executeAggregateQuery.docs.opened')
 }
 
-type ExecuteAggregateQueryProps = {
+type OwnProps = {
   bucket: string
 }
 
-export const ExecuteAggregateQuery = (props: ExecuteAggregateQueryProps) => {
+export const ExecuteAggregateQuery = (props: OwnProps) => {
   const {bucket} = props
 
   const fromBucketSnippet = `from(bucket: "${bucket}")

--- a/src/homepageExperience/components/steps/nodejs/ExecuteQuery.tsx
+++ b/src/homepageExperience/components/steps/nodejs/ExecuteQuery.tsx
@@ -7,11 +7,11 @@ const logCopyCodeSnippet = () => {
   event('firstMile.nodejsWizard.executeQuery.code.copied')
 }
 
-type ExecuteQueryProps = {
+type OwnProps = {
   bucket: string
 }
 
-export const ExecuteQuery = (props: ExecuteQueryProps) => {
+export const ExecuteQuery = (props: OwnProps) => {
   const {bucket} = props
 
   const fromBucketSnippet = `from(bucket: "${bucket}")

--- a/src/homepageExperience/components/steps/nodejs/WriteData.tsx
+++ b/src/homepageExperience/components/steps/nodejs/WriteData.tsx
@@ -28,11 +28,11 @@ const logDocsOpened = () => {
   event('firstMile.nodejsWizard.writeData.docs.opened')
 }
 
-type WriteDataProps = {
+type OwnProps = {
   onSelectBucket: (bucketName: string) => void
 }
 
-export const WriteDataComponent = (props: WriteDataProps) => {
+export const WriteDataComponent = (props: OwnProps) => {
   const org = useSelector(getOrg)
   const dispatch = useDispatch()
   const {onSelectBucket} = props

--- a/src/homepageExperience/components/steps/python/ExecuteAggregateQuery.tsx
+++ b/src/homepageExperience/components/steps/python/ExecuteAggregateQuery.tsx
@@ -14,11 +14,11 @@ const logDocsOpened = () => {
   event('firstMile.pythonWizard.executeAggregateQuery.docs.opened')
 }
 
-type ExecuteAggregateQueryProps = {
+type OwnProps = {
   bucket: string
 }
 
-export const ExecuteAggregateQuery = (props: ExecuteAggregateQueryProps) => {
+export const ExecuteAggregateQuery = (props: OwnProps) => {
   const org = useSelector(getOrg)
   const {bucket} = props
 

--- a/src/homepageExperience/components/steps/python/ExecuteQuery.tsx
+++ b/src/homepageExperience/components/steps/python/ExecuteQuery.tsx
@@ -8,11 +8,11 @@ const logCopyCodeSnippet = () => {
   event('firstMile.pythonWizard.executeQuery.code.copied')
 }
 
-type ExecuteQueryProps = {
+type OwnProps = {
   bucket: string
 }
 
-export const ExecuteQuery = (props: ExecuteQueryProps) => {
+export const ExecuteQuery = (props: OwnProps) => {
   const org = useSelector(getOrg)
   const {bucket} = props
 

--- a/src/homepageExperience/components/steps/python/WriteData.tsx
+++ b/src/homepageExperience/components/steps/python/WriteData.tsx
@@ -28,11 +28,11 @@ const logDocsOpened = () => {
   event('firstMile.pythonWizard.writeData.docs.opened')
 }
 
-type WriteDataProps = {
+type OwnProps = {
   onSelectBucket: (bucketName: string) => void
 }
 
-export const WriteDataComponent = (props: WriteDataProps) => {
+export const WriteDataComponent = (props: OwnProps) => {
   const org = useSelector(getOrg)
   const dispatch = useDispatch()
   const {onSelectBucket} = props

--- a/src/homepageExperience/containers/NodejsWizard.tsx
+++ b/src/homepageExperience/containers/NodejsWizard.tsx
@@ -91,7 +91,7 @@ export class NodejsWizard extends PureComponent<null, State> {
         return <ExecuteAggregateQuery bucket={this.state.selectedBucket} />
       }
       case 8: {
-        return <Finish />
+        return <Finish wizardEventName="nodejsWizard" />
       }
       default: {
         return <Overview />

--- a/src/homepageExperience/containers/PythonWizard.tsx
+++ b/src/homepageExperience/containers/PythonWizard.tsx
@@ -91,7 +91,7 @@ export class PythonWizard extends PureComponent<null, State> {
         return <ExecuteAggregateQuery bucket={this.state.selectedBucket} />
       }
       case 8: {
-        return <Finish />
+        return <Finish wizardEventName="pythonWizard" />
       }
       default: {
         return <Overview />


### PR DESCRIPTION
A minor cleanup PR

- renames individual props to `OwnProps` to follow our loose conventions for props names
- allow passing of event name into the `Finsh.tsx` component so that each experience can send a unique event upon completion