### PR TITLE
fix: datepicker time format on input should stay the same when calendar selection is made

### DIFF
--- a/src/shared/components/dateRangePicker/DatePicker.tsx
+++ b/src/shared/components/dateRangePicker/DatePicker.tsx
@@ -77,7 +77,7 @@ class DatePicker extends PureComponent<Props, State> {
   private inCurrentMonth: boolean = false
   state = {
     inputValue: null,
-    inputFormat: 'YYYY-MM-DD HH:mm',
+    inputFormat: 'YYYY-MM-DD HH:mm:ss',
   }
 
   public componentDidUpdate() {

--- a/src/shared/components/dateRangePicker/DatePicker.tsx
+++ b/src/shared/components/dateRangePicker/DatePicker.tsx
@@ -77,7 +77,7 @@ class DatePicker extends PureComponent<Props, State> {
   private inCurrentMonth: boolean = false
   state = {
     inputValue: null,
-    inputFormat: null,
+    inputFormat: 'YYYY-MM-DD HH:mm',
   }
 
   public componentDidUpdate() {
@@ -198,19 +198,6 @@ class DatePicker extends PureComponent<Props, State> {
     return 'range-picker--day'
   }
 
-  private overrideInputState = (): void => {
-    const {dateTime, timeZone} = this.props
-    const {inputFormat} = this.state
-
-    let value = new Date(dateTime).toISOString()
-    if (inputFormat) {
-      const formatter = createDateTimeFormatter(inputFormat, timeZone)
-      value = formatter.format(dateTime)
-    }
-
-    this.setState({inputValue: value, inputFormat: getFormat(value)})
-  }
-
   private handleSelectDate = (date: Date): void => {
     const {onSelectDate, timeZone} = this.props
 
@@ -223,7 +210,6 @@ class DatePicker extends PureComponent<Props, State> {
     }
 
     onSelectDate(date.toISOString())
-    this.overrideInputState()
   }
 
   private handleChangeInput = (e: ChangeEvent<HTMLInputElement>): void => {

--- a/src/shared/components/dateRangePicker/DatePicker.tsx
+++ b/src/shared/components/dateRangePicker/DatePicker.tsx
@@ -77,7 +77,7 @@ class DatePicker extends PureComponent<Props, State> {
   private inCurrentMonth: boolean = false
   state = {
     inputValue: null,
-    inputFormat: 'YYYY-MM-DD HH:mm:ss',
+    inputFormat: DEFAULT_TIME_FORMAT,
   }
 
   public componentDidUpdate() {

--- a/src/shared/components/dateRangePicker/DateRangePicker.test.tsx
+++ b/src/shared/components/dateRangePicker/DateRangePicker.test.tsx
@@ -36,4 +36,22 @@ describe('Date Range Picker', function() {
     expect(screen.getByTitle('Start')).toHaveValue('2022-03-10 18:00')
     expect(screen.getByTitle('Stop')).toHaveValue('2022-03-10 21:00')
   })
+
+  test.only('should have the `Apply Time Range` Button disabled on invalid input', () => {
+    const {getAllByTestId, getByTestId} = renderWithReduxAndRouter(
+      <DateRangePicker
+        timeRange={convertTimeRangeToCustom(pastHourTimeRange)}
+        onSetTimeRange={() => {}}
+        onClose={() => {}}
+        position={{position: 'relative'}}
+      />
+    )
+    const lowerInput = getAllByTestId('timerange--input')[0]
+
+    fireEvent.change(lowerInput, {target: {value: 'iampumpkinthecat;)'}})
+
+    const applyButton = getByTestId('daterange--apply-btn')
+
+    expect(applyButton).toBeDisabled()
+  })
 })

--- a/src/shared/components/dateRangePicker/DateRangePicker.test.tsx
+++ b/src/shared/components/dateRangePicker/DateRangePicker.test.tsx
@@ -8,7 +8,7 @@ import {renderWithReduxAndRouter} from 'src/mockState'
 import {screen} from '@testing-library/dom'
 import {fireEvent} from '@testing-library/react'
 
-jest.useFakeTimers().setSystemTime(new Date('2022-03-10 20:00').getTime())
+jest.useFakeTimers().setSystemTime(new Date('2022-03-10 20:00:00').getTime())
 
 describe('Date Range Picker', function() {
   test('should have input values in the correct format after user changes the date selection', () => {
@@ -22,8 +22,8 @@ describe('Date Range Picker', function() {
     )
 
     // YYYY-MM-DD HH:mm format by default
-    expect(screen.getByTitle('Start')).toHaveValue('2022-03-10 19:00')
-    expect(screen.getByTitle('Stop')).toHaveValue('2022-03-10 20:00')
+    expect(screen.getByTitle('Start')).toHaveValue('2022-03-10 19:00:00')
+    expect(screen.getByTitle('Stop')).toHaveValue('2022-03-10 20:00:00')
 
     // change the time and the format should stay the same
 
@@ -33,8 +33,8 @@ describe('Date Range Picker', function() {
     fireEvent.click(lowerTime)
     fireEvent.click(upperTime)
 
-    expect(screen.getByTitle('Start')).toHaveValue('2022-03-10 18:00')
-    expect(screen.getByTitle('Stop')).toHaveValue('2022-03-10 21:00')
+    expect(screen.getByTitle('Start')).toHaveValue('2022-03-10 18:00:00')
+    expect(screen.getByTitle('Stop')).toHaveValue('2022-03-10 21:00:00')
   })
 
   test.only('should have the `Apply Time Range` Button disabled on invalid input', () => {

--- a/src/shared/components/dateRangePicker/DateRangePicker.test.tsx
+++ b/src/shared/components/dateRangePicker/DateRangePicker.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+
+import DateRangePicker from './DateRangePicker'
+import {convertTimeRangeToCustom} from 'src/shared/utils/duration'
+import {pastHourTimeRange} from 'src/shared/constants/timeRanges'
+import {renderWithReduxAndRouter} from 'src/mockState'
+
+import {screen} from '@testing-library/dom'
+import {fireEvent} from '@testing-library/react'
+
+jest
+  .useFakeTimers()
+  .setSystemTime(new Date('2022-03-10 20:00').getTime());
+
+describe('Date Range Picker', function() {
+  test('should have input values in the correct format after user changes the date selection', () => {
+    const {getAllByText} = renderWithReduxAndRouter(<DateRangePicker
+      timeRange={convertTimeRangeToCustom(pastHourTimeRange)}
+    onSetTimeRange={() => {}}
+    onClose={() => {}}
+    position={{position: 'relative'}}
+    />)
+
+    // YYYY-MM-DD HH:mm format by default
+    expect(screen.getByTitle("Start")).toHaveValue("2022-03-10 19:00");
+    expect(screen.getByTitle("Stop")).toHaveValue("2022-03-10 20:00");
+
+    // change the time and the format should stay the same
+
+    const lowerTime = getAllByText("18:00")[0]
+    const upperTime = getAllByText("21:00")[1]
+
+    fireEvent.click(lowerTime)
+    fireEvent.click(upperTime)
+
+    expect(screen.getByTitle("Start")).toHaveValue("2022-03-10 18:00");
+    expect(screen.getByTitle("Stop")).toHaveValue("2022-03-10 21:00");
+
+
+
+  })
+})

--- a/src/shared/components/dateRangePicker/DateRangePicker.test.tsx
+++ b/src/shared/components/dateRangePicker/DateRangePicker.test.tsx
@@ -11,7 +11,7 @@ import {fireEvent} from '@testing-library/react'
 jest.useFakeTimers().setSystemTime(new Date('2022-03-10 20:00:00').getTime())
 
 describe('Date Range Picker', function() {
-  test('should have input values in the correct format after user changes the date selection', () => {
+  it('should have input values in the correct format after user changes the date selection', () => {
     const {getAllByText} = renderWithReduxAndRouter(
       <DateRangePicker
         timeRange={convertTimeRangeToCustom(pastHourTimeRange)}
@@ -37,7 +37,7 @@ describe('Date Range Picker', function() {
     expect(screen.getByTitle('Stop')).toHaveValue('2022-03-10 21:00:00')
   })
 
-  test('should have the `Apply Time Range` Button disabled on invalid input', () => {
+  it('should have the `Apply Time Range` Button disabled on invalid input', () => {
     const {getAllByTestId, getByTestId} = renderWithReduxAndRouter(
       <DateRangePicker
         timeRange={convertTimeRangeToCustom(pastHourTimeRange)}

--- a/src/shared/components/dateRangePicker/DateRangePicker.test.tsx
+++ b/src/shared/components/dateRangePicker/DateRangePicker.test.tsx
@@ -8,35 +8,32 @@ import {renderWithReduxAndRouter} from 'src/mockState'
 import {screen} from '@testing-library/dom'
 import {fireEvent} from '@testing-library/react'
 
-jest
-  .useFakeTimers()
-  .setSystemTime(new Date('2022-03-10 20:00').getTime());
+jest.useFakeTimers().setSystemTime(new Date('2022-03-10 20:00').getTime())
 
 describe('Date Range Picker', function() {
   test('should have input values in the correct format after user changes the date selection', () => {
-    const {getAllByText} = renderWithReduxAndRouter(<DateRangePicker
-      timeRange={convertTimeRangeToCustom(pastHourTimeRange)}
-    onSetTimeRange={() => {}}
-    onClose={() => {}}
-    position={{position: 'relative'}}
-    />)
+    const {getAllByText} = renderWithReduxAndRouter(
+      <DateRangePicker
+        timeRange={convertTimeRangeToCustom(pastHourTimeRange)}
+        onSetTimeRange={() => {}}
+        onClose={() => {}}
+        position={{position: 'relative'}}
+      />
+    )
 
     // YYYY-MM-DD HH:mm format by default
-    expect(screen.getByTitle("Start")).toHaveValue("2022-03-10 19:00");
-    expect(screen.getByTitle("Stop")).toHaveValue("2022-03-10 20:00");
+    expect(screen.getByTitle('Start')).toHaveValue('2022-03-10 19:00')
+    expect(screen.getByTitle('Stop')).toHaveValue('2022-03-10 20:00')
 
     // change the time and the format should stay the same
 
-    const lowerTime = getAllByText("18:00")[0]
-    const upperTime = getAllByText("21:00")[1]
+    const lowerTime = getAllByText('18:00')[0]
+    const upperTime = getAllByText('21:00')[1]
 
     fireEvent.click(lowerTime)
     fireEvent.click(upperTime)
 
-    expect(screen.getByTitle("Start")).toHaveValue("2022-03-10 18:00");
-    expect(screen.getByTitle("Stop")).toHaveValue("2022-03-10 21:00");
-
-
-
+    expect(screen.getByTitle('Start')).toHaveValue('2022-03-10 18:00')
+    expect(screen.getByTitle('Stop')).toHaveValue('2022-03-10 21:00')
   })
 })

--- a/src/shared/components/dateRangePicker/DateRangePicker.test.tsx
+++ b/src/shared/components/dateRangePicker/DateRangePicker.test.tsx
@@ -37,7 +37,7 @@ describe('Date Range Picker', function() {
     expect(screen.getByTitle('Stop')).toHaveValue('2022-03-10 21:00:00')
   })
 
-  test.only('should have the `Apply Time Range` Button disabled on invalid input', () => {
+  test('should have the `Apply Time Range` Button disabled on invalid input', () => {
     const {getAllByTestId, getByTestId} = renderWithReduxAndRouter(
       <DateRangePicker
         timeRange={convertTimeRangeToCustom(pastHourTimeRange)}


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/4335
Connects https://github.com/influxdata/ui/issues/2350

* the `overrideInputState` is not necessary and was causing console log errors so I removed it
* made the default `inputFormat` state of the component to be `YYYY-MM-DD HH:mm:ss`
* added two integration tests

https://user-images.githubusercontent.com/18511823/162237629-349fb188-9c43-4910-beef-f91df0503954.mov




<!-- Describe your proposed changes here. -->
