### PR TITLE
fix: notification endpoint Dropdown width to extend all the way

### DIFF
--- a/cypress/e2e/shared/notificationRules.test.ts
+++ b/cypress/e2e/shared/notificationRules.test.ts
@@ -218,10 +218,9 @@ describe('NotificationRules', () => {
 
     cy.get<SlackNotificationEndpoint>('@selectedEndpoint').then(({id}) => {
       cy.getByTestID(`endpoint--dropdown-item ${id}`).click()
-      cy.getByTestID('endpoint--dropdown--button')
-        .within(() => {
-          cy.contains(name2)
-        })
+      cy.getByTestID('endpoint--dropdown--button').within(() => {
+        cy.contains(name2)
+      })
     })
 
     const message = `

--- a/cypress/e2e/shared/notificationRules.test.ts
+++ b/cypress/e2e/shared/notificationRules.test.ts
@@ -155,7 +155,7 @@ describe('NotificationRules', () => {
     })
   })
 
-  it('can create a notification rule', () => {
+  it.only('can create a notification rule', () => {
     // User can only see all panels at once on large screens
     cy.getByTestID('alerting-tab--rules').click({force: true})
 
@@ -222,7 +222,6 @@ describe('NotificationRules', () => {
         .within(() => {
           cy.contains(name2)
         })
-        .click()
     })
 
     const message = `

--- a/cypress/e2e/shared/notificationRules.test.ts
+++ b/cypress/e2e/shared/notificationRules.test.ts
@@ -155,7 +155,7 @@ describe('NotificationRules', () => {
     })
   })
 
-  it.only('can create a notification rule', () => {
+  it('can create a notification rule', () => {
     // User can only see all panels at once on large screens
     cy.getByTestID('alerting-tab--rules').click({force: true})
 

--- a/src/notifications/rules/components/RuleEndpointDropdown.tsx
+++ b/src/notifications/rules/components/RuleEndpointDropdown.tsx
@@ -61,11 +61,7 @@ const RuleEndpointDropdown: FC<Props> = ({
   )
 
   return (
-    <Dropdown
-      button={button}
-      menu={menu}
-      testID="endpoint-change--dropdown"
-    />
+    <Dropdown button={button} menu={menu} testID="endpoint-change--dropdown" />
   )
 }
 

--- a/src/notifications/rules/components/RuleEndpointDropdown.tsx
+++ b/src/notifications/rules/components/RuleEndpointDropdown.tsx
@@ -64,7 +64,6 @@ const RuleEndpointDropdown: FC<Props> = ({
     <Dropdown
       button={button}
       menu={menu}
-      style={{width: '160px'}}
       testID="endpoint-change--dropdown"
     />
   )


### PR DESCRIPTION
Closes #4345 

Prev 
<img width="844" alt="Screen Shot 2022-04-07 at 1 12 47 PM" src="https://user-images.githubusercontent.com/18511823/162288103-468902b1-1f1a-440c-9366-8491ec1802dc.png">

After fix
<img width="824" alt="Screen Shot 2022-04-07 at 1 12 22 PM" src="https://user-images.githubusercontent.com/18511823/162288048-ac153bc1-c1ea-4080-86e7-9e67d4ea6872.png">


<!-- Describe your proposed changes here. -->
