### PR TITLE
feat: add params requirement to tool tip

### DIFF
--- a/src/flows/pipes/RawFluxEditor/FunctionsList/perFunction/FluxDocsTooltipContent.tsx
+++ b/src/flows/pipes/RawFluxEditor/FunctionsList/perFunction/FluxDocsTooltipContent.tsx
@@ -25,13 +25,13 @@ const FluxDocsTooltipContent: FC<TooltipProps> = ({
   }, [])
   const argComponent = () => {
     if (func.fluxParameters.length > 0) {
-      let param = 'optional'
+      let param = 'Optional'
       return func.fluxParameters.map(arg => {
         const description = arg.headline.slice(arg.name.length + 1)
-        arg.required ? (param = 'required') : param
+        arg.required ? (param = 'Required') : param
 
         const paramClass = classnames('param', {
-          isRequired: param === 'required' ? true : false,
+          isRequired: param === 'Required' ? true : false,
         })
         return (
           <div className="flux-function-docs--arguments" key={arg.name}>

--- a/src/flows/pipes/RawFluxEditor/FunctionsList/perFunction/FluxDocsTooltipContent.tsx
+++ b/src/flows/pipes/RawFluxEditor/FunctionsList/perFunction/FluxDocsTooltipContent.tsx
@@ -1,5 +1,6 @@
 // Libraries
 import React, {FC, useEffect} from 'react'
+import classnames from 'classnames'
 
 // Component
 import {DapperScrollbars} from '@influxdata/clockface'
@@ -24,11 +25,18 @@ const FluxDocsTooltipContent: FC<TooltipProps> = ({
   }, [])
   const argComponent = () => {
     if (func.fluxParameters.length > 0) {
+      let param = 'optional'
       return func.fluxParameters.map(arg => {
         const description = arg.headline.slice(arg.name.length + 1)
+        arg.required ? (param = 'required') : param
+
+        const paramClass = classnames('param', {
+          isRequired: param === 'required' ? true : false,
+        })
         return (
           <div className="flux-function-docs--arguments" key={arg.name}>
             <span>{arg.name}:</span>
+            <span className={paramClass}>({param})</span>
             <div>{description}</div>
           </div>
         )

--- a/src/style/chronograf.scss
+++ b/src/style/chronograf.scss
@@ -80,6 +80,7 @@
 @import 'src/timeMachine/components/TimeMachine.scss';
 @import 'src/timeMachine/components/QueryBuilder.scss';
 @import 'src/timeMachine/components/fluxFunctionsToolbar/FluxFunctionsToolbar.scss';
+@import 'src/timeMachine/components/dynamicFluxFunctionsToolbar/FluxFunctionsToolbar.scss';
 @import 'src/timeMachine/components/ViewOptions.scss';
 @import 'src/visualization/components/ViewTypeDropdown.scss';
 @import 'src/timeMachine/components/builderCard/BuilderCard.scss';

--- a/src/timeMachine/components/dynamicFluxFunctionsToolbar/FluxFunctionsToolbar.scss
+++ b/src/timeMachine/components/dynamicFluxFunctionsToolbar/FluxFunctionsToolbar.scss
@@ -33,9 +33,13 @@
   }
 
   span:nth-child(2) {
-    color: $c-rainforest;
+    color: $c-pool;
     font-style: italic;
     margin-right: $cf-border;
+
+    &.isRequired {
+      color: $c-fire;
+    }
   }
 
   div {

--- a/src/timeMachine/components/dynamicFluxFunctionsToolbar/TooltipArguments.tsx
+++ b/src/timeMachine/components/dynamicFluxFunctionsToolbar/TooltipArguments.tsx
@@ -23,13 +23,13 @@ class TooltipArguments extends PureComponent<Props> {
     const {argsList} = this.props
 
     if (argsList.length > 0) {
-      let param = 'optional'
+      let param = 'Optional'
       return argsList.map(argument => {
         const description = argument.headline.slice(argument.name.length + 1)
-        argument.required ? (param = 'required') : param
+        argument.required ? (param = 'Required') : param
 
         const paramClass = classnames('param', {
-          isRequired: param === 'required' ? true : false,
+          isRequired: param === 'Required' ? true : false,
         })
         return (
           <div className="flux-function-docs--arguments" key={argument.name}>

--- a/src/timeMachine/components/dynamicFluxFunctionsToolbar/TooltipArguments.tsx
+++ b/src/timeMachine/components/dynamicFluxFunctionsToolbar/TooltipArguments.tsx
@@ -1,5 +1,5 @@
 import React, {PureComponent} from 'react'
-
+import classnames from 'classnames'
 interface Args {
   headline: string
   name: string
@@ -23,11 +23,18 @@ class TooltipArguments extends PureComponent<Props> {
     const {argsList} = this.props
 
     if (argsList.length > 0) {
+      let param = 'optional'
       return argsList.map(argument => {
         const description = argument.headline.slice(argument.name.length + 1)
+        argument.required ? (param = 'required') : param
+
+        const paramClass = classnames('param', {
+          isRequired: param === 'required' ? true : false,
+        })
         return (
           <div className="flux-function-docs--arguments" key={argument.name}>
             <span>{argument.name}:</span>
+            <span className={paramClass}>({param})</span>
             <div>{description}</div>
           </div>
         )


### PR DESCRIPTION
Closes #4342 

- In flux functions tool tip, indicate whether a param is Required or Optional. 
- Required's color should be red. 

Before: 
<img width="432" alt="g" src="https://user-images.githubusercontent.com/66275100/162324820-0554276c-9140-46ec-adc9-452cb642a249.png">

After:
<img width="417" alt="Screen Shot 2022-04-07 at 4 43 49 PM" src="https://user-images.githubusercontent.com/66275100/162325008-cd2aa57b-0f18-41a0-a416-1c5570a06aba.png">

