### PR TITLE
feat: add save as notebook option from data explorer

### DIFF
--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -757,6 +757,7 @@ describe('DataExplorer', () => {
       cy.get('[id="variable"]').click()
       cy.getByTestID('flux-editor').should('be.visible')
       cy.get('[id="dashboard"]').click()
+      cy.getByTestID('cell--radio-button').click()
       cy.getByTestID('save-as-dashboard-cell--dropdown').should('be.visible')
 
       // close save as
@@ -790,6 +791,7 @@ describe('DataExplorer', () => {
       it('can save as cell into multiple dashboards', () => {
         // input dashboards and cell name
         dashboardNames.forEach(name => {
+          cy.getByTestID('cell--radio-button').click()
           cy.getByTestID('save-as-dashboard-cell--dropdown').click()
           cy.getByTestID('save-as-dashboard-cell--dropdown-menu').within(() => {
             cy.contains(name).click()
@@ -816,6 +818,7 @@ describe('DataExplorer', () => {
 
       it('can create new dashboard as saving target', () => {
         // select and input new dashboard name and cell name
+        cy.getByTestID('cell--radio-button').click()
         cy.getByTestID('save-as-dashboard-cell--dropdown').click()
         cy.getByTestID('save-as-dashboard-cell--dropdown-menu').within(() => {
           cy.getByTestID('save-as-dashboard-cell--create-new-dash').click()

--- a/cypress/e2e/shared/legends.test.ts
+++ b/cypress/e2e/shared/legends.test.ts
@@ -332,6 +332,7 @@ describe('Legends', () => {
             // Without submitting the query, save it to a dashboard
             cy.getByTestID('save-query-as').click()
             cy.getByTestID('overlay--container').should('exist')
+            cy.getByTestID('cell--radio-button').click()
             cy.getByTestID('save-as-dashboard-cell--dropdown').click()
             cy.getByTestID('save-as-dashboard-cell--create-new-dash').click()
             cy.getByTestID('save-as-dashboard-cell--dashboard-name')
@@ -392,6 +393,7 @@ describe('Legends', () => {
             // Save it to a dashboard
             cy.getByTestID('save-query-as').click()
             cy.getByTestID('overlay--container').should('exist')
+            cy.getByTestID('cell--radio-button').click()
             cy.getByTestID('save-as-dashboard-cell--dropdown').click()
             cy.getByTestID('save-as-dashboard-cell--create-new-dash').click()
             cy.getByTestID('save-as-dashboard-cell--dashboard-name')

--- a/cypress/e2e/shared/queryBuilder.test.ts
+++ b/cypress/e2e/shared/queryBuilder.test.ts
@@ -45,6 +45,7 @@ describe('The Query Builder', () => {
       cy.getByTestID('save-query-as').click()
 
       // open the dashboard selector dropdown
+      cy.getByTestID('cell--radio-button').click()
       cy.getByTestID('save-as-dashboard-cell--dropdown').click()
       cy.getByTestID('save-as-dashboard-cell--create-new-dash').click()
       cy.getByTestID('save-as-overlay--header').click() // close the blast door i mean dropdown

--- a/src/dataExplorer/components/SaveAsNotebookForm.tsx
+++ b/src/dataExplorer/components/SaveAsNotebookForm.tsx
@@ -75,14 +75,13 @@ const SaveAsNotebookForm: FC<Props> = ({dismiss}) => {
       for (let i = 0; i < draftQueries.length; i++) {
         const draftQuery = draftQueries[i]
         let pipe: any = {
-          family: 'inputs',
           id: `local_${nanoid()}`,
           visible: !draftQuery.hidden,
         }
         if (draftQuery.editMode === 'builder') {
           const bucket = completeBuckets.splice(0, 1)
 
-          pipe.name = 'Build a Query'
+          pipe.title = `Build a Query ${i + 1}`
           pipe.type = 'queryBuilder'
           pipe = {
             ...pipe,
@@ -91,7 +90,7 @@ const SaveAsNotebookForm: FC<Props> = ({dismiss}) => {
           }
         } else {
           pipe.title = 'Query to Run'
-          pipe.queries = properties.queries
+          pipe.queries = draftQuery.builderConfig
           pipe.activeQuery = 0
           pipe.type = 'rawFluxEditor'
         }
@@ -99,8 +98,11 @@ const SaveAsNotebookForm: FC<Props> = ({dismiss}) => {
         pipes.push(pipe)
         pipes.push({
           id: `local_${nanoid()}`,
-          properties,
-          title: `Visualize the Result ${i}`,
+          properties: {
+            ...properties,
+            builderConfig: draftQuery.builderConfig,
+          },
+          title: `Visualize the Result ${i + 1}`,
           type: 'visualization',
           visible: true,
         })

--- a/src/dataExplorer/components/SaveAsNotebookForm.tsx
+++ b/src/dataExplorer/components/SaveAsNotebookForm.tsx
@@ -1,0 +1,171 @@
+// Libraries
+import React, {FC, ChangeEvent, useState} from 'react'
+import {useSelector} from 'react-redux'
+import {useHistory} from 'react-router-dom'
+
+// Selectors
+import {getActiveTimeMachine, getSaveableView} from 'src/timeMachine/selectors'
+import {getOrg} from 'src/organizations/selectors'
+import {postNotebook} from 'src/client/notebooksRoutes'
+
+// Components
+import {Form, Input, Button, Grid} from '@influxdata/clockface'
+import {AUTOREFRESH_DEFAULT} from 'src/shared/constants'
+
+// Types
+import {
+  Columns,
+  InputType,
+  ButtonType,
+  ComponentColor,
+  ComponentStatus,
+} from '@influxdata/clockface'
+
+// Utils
+import {event, normalizeEventName} from 'src/cloud/utils/reporting'
+import {chartTypeName} from 'src/visualization/utils/chartTypeName'
+import {
+  PROJECT_NAME,
+  DEFAULT_PROJECT_NAME,
+  PROJECT_NAME_PLURAL,
+} from 'src/flows'
+import {hydrate, serialize} from 'src/flows/context/flow.list'
+
+interface Props {
+  dismiss: () => void
+}
+
+const SaveAsNotebookForm: FC<Props> = ({dismiss}) => {
+  const [notebookName, setNotebookName] = useState('')
+  const orgID = useSelector(getOrg).id
+  const stuff = useSelector(getActiveTimeMachine)
+  const {draftQueries, autoRefresh, timeRange} = stuff
+  const {properties} = useSelector(getSaveableView)
+  const history = useHistory()
+
+  const handleChangeNotebookName = (event: ChangeEvent<HTMLInputElement>) => {
+    setNotebookName(event.target.value)
+  }
+
+  const handleSubmit = async () => {
+    event(`Data Explorer Save as ${PROJECT_NAME} Submitted`)
+
+    try {
+      event(`data_explorer.save.as_${PROJECT_NAME.toLowerCase()}.success`, {
+        which: normalizeEventName(chartTypeName(properties?.type ?? 'xy')),
+      })
+      const pipes: any = []
+
+      const visualization = {
+        title: 'Visualize the Result',
+        visible: true,
+        type: 'visualization',
+        properties,
+      }
+      for (let i = 0; i < draftQueries.length; i++) {
+        const draftQuery = draftQueries[i]
+
+        let pipe: any = {
+          family: 'inputs',
+          visible: !draftQuery.hidden,
+        }
+        if (draftQuery.editMode === 'builder') {
+          pipe.name = 'Build a Query'
+          pipe.type = 'queryBuilder'
+          pipe = {
+            ...pipe,
+            ...draftQuery.builderConfig,
+            buckets: [
+              {
+                // id: TODO(ariel): get the id
+                name: draftQuery.builderConfig.buckets[0],
+                orgID,
+                type: 'user',
+              },
+            ],
+          }
+        } else {
+          pipe.title = 'Query to Run'
+          pipe.queries = properties.queries
+          pipe.activeQuery = i
+          pipe.type = 'rawFluxEditor'
+        }
+
+        pipes.push(pipe)
+        pipes.push(visualization)
+      }
+
+      const flow = hydrate({
+        name: notebookName || DEFAULT_PROJECT_NAME,
+        range: timeRange,
+        orgID,
+        spec: {
+          readOnly: false,
+          range: timeRange,
+          refresh: autoRefresh || AUTOREFRESH_DEFAULT,
+          pipes,
+        },
+      })
+
+      const response = await postNotebook(serialize(flow))
+
+      if (response.status !== 200) {
+        throw new Error(response.data.message)
+      }
+
+      const {id} = response.data
+
+      // redirect to the notebook
+      history.push(`/orgs/${orgID}/${PROJECT_NAME_PLURAL.toLowerCase()}/${id}`)
+    } catch (error) {
+      event(`data_explorer.save.as_${PROJECT_NAME.toLowerCase()}.failure`, {
+        which: normalizeEventName(chartTypeName(properties?.type)),
+      })
+      console.error(error)
+      dismiss()
+    } finally {
+      setNotebookName('')
+    }
+  }
+
+  return (
+    <Grid>
+      <Grid.Row>
+        <Grid.Column widthXS={Columns.Twelve}>
+          <Form.Element label={`${PROJECT_NAME} Name`}>
+            <Input
+              type={InputType.Text}
+              placeholder={`Add optional ${PROJECT_NAME.toLowerCase()} name`}
+              name="notebookName"
+              value={notebookName}
+              onChange={handleChangeNotebookName}
+              testID={`save-as-${PROJECT_NAME.toLowerCase()}--name`}
+            />
+          </Form.Element>
+        </Grid.Column>
+        <Grid.Column widthXS={Columns.Twelve}>
+          <Form.Footer>
+            <Button
+              text="Cancel"
+              onClick={dismiss}
+              titleText="Cancel"
+              type={ButtonType.Button}
+              color={ComponentColor.Tertiary}
+              testID={`save-as-${PROJECT_NAME.toLowerCase()}--cancel`}
+            />
+            <Button
+              text={`Save as ${PROJECT_NAME}`}
+              testID={`save-as-${PROJECT_NAME.toLowerCase()}--submit`}
+              color={ComponentColor.Success}
+              type={ButtonType.Submit}
+              onClick={handleSubmit}
+              status={ComponentStatus.Default}
+            />
+          </Form.Footer>
+        </Grid.Column>
+      </Grid.Row>
+    </Grid>
+  )
+}
+
+export default SaveAsNotebookForm

--- a/src/dataExplorer/components/SaveAsOverlay.tsx
+++ b/src/dataExplorer/components/SaveAsOverlay.tsx
@@ -60,7 +60,7 @@ const SaveAsOverlay: FC = () => {
               <Tabs.Tab
                 id={SaveAsOption.Notebook}
                 text={`${PROJECT_NAME}`}
-                testID="cell--radio-button"
+                testID={`${PROJECT_NAME.toLowerCase()}--radio-button`}
                 onClick={() => setSaveAsOption(SaveAsOption.Notebook)}
                 active={saveAsOption === SaveAsOption.Notebook}
               />

--- a/src/dataExplorer/components/SaveAsOverlay.tsx
+++ b/src/dataExplorer/components/SaveAsOverlay.tsx
@@ -3,6 +3,7 @@ import {useHistory} from 'react-router-dom'
 
 // Components
 import SaveAsCellForm from 'src/dataExplorer/components/SaveAsCellForm'
+import SaveAsNotebookForm from 'src/dataExplorer/components/SaveAsNotebookForm'
 import SaveAsTaskForm from 'src/dataExplorer/components/SaveAsTaskForm'
 import SaveAsVariable from 'src/dataExplorer/components/SaveAsVariable'
 import {
@@ -15,16 +16,18 @@ import {
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'
+import {PROJECT_NAME} from 'src/flows'
 
 enum SaveAsOption {
   Dashboard = 'dashboard',
+  Notebook = 'notebook',
   Task = 'task',
   Variable = 'variable',
 }
 
 const SaveAsOverlay: FC = () => {
   const history = useHistory()
-  const [saveAsOption, setSaveAsOption] = useState(SaveAsOption.Dashboard)
+  const [saveAsOption, setSaveAsOption] = useState(SaveAsOption.Notebook)
   const hide = useCallback(() => {
     history.goBack()
   }, [history])
@@ -39,6 +42,8 @@ const SaveAsOverlay: FC = () => {
     saveAsForm = <SaveAsTaskForm dismiss={hide} />
   } else if (saveAsOption === SaveAsOption.Variable) {
     saveAsForm = <SaveAsVariable onHideOverlay={hide} />
+  } else if (saveAsOption === SaveAsOption.Notebook) {
+    saveAsForm = <SaveAsNotebookForm dismiss={hide} />
   }
 
   return (
@@ -52,6 +57,13 @@ const SaveAsOverlay: FC = () => {
         <Overlay.Body>
           <Tabs.Container orientation={Orientation.Horizontal}>
             <Tabs alignment={Alignment.Center} size={ComponentSize.Medium}>
+              <Tabs.Tab
+                id={SaveAsOption.Notebook}
+                text={`${PROJECT_NAME}`}
+                testID="cell--radio-button"
+                onClick={() => setSaveAsOption(SaveAsOption.Notebook)}
+                active={saveAsOption === SaveAsOption.Notebook}
+              />
               <Tabs.Tab
                 id={SaveAsOption.Dashboard}
                 text="Dashboard Cell"


### PR DESCRIPTION
This work stems from frustration trying to debug the differences between the way data explorer handles the gauge and histogram visualizations vs notebooks. I figured if I could save the data correctly, then things should work as a like-for-like replacement. 
![save_as](https://user-images.githubusercontent.com/19984220/162448995-27248779-79dc-4992-89f7-7aa7f5c689be.gif)
