### PR TITLE
chore: add guardrails in case there arent fields

### DIFF
--- a/src/flows/pipes/Visualization/ErrorThresholds/FieldColumnDropdown.tsx
+++ b/src/flows/pipes/Visualization/ErrorThresholds/FieldColumnDropdown.tsx
@@ -37,8 +37,9 @@ const FieldColumnDropdown: FC<Props> = ({threshold, index}) => {
         return c.name === '_value'
       })
 
-      const fields = (results.parsed.table.columns['_field']
-        .data as any).reduce((acc, curr, index) => {
+      const fields = (
+        (results.parsed.table.columns['_field'].data as any) ?? []
+      ).reduce((acc, curr, index) => {
         const type = values.find(d => {
           return d.data[index] !== undefined
         })?.type

--- a/src/flows/pipes/Visualization/view.tsx
+++ b/src/flows/pipes/Visualization/view.tsx
@@ -193,7 +193,7 @@ const Visualization: FC<PipeProp> = ({Context}) => {
     const {columns} = results.parsed.table
 
     let triggeredErrorThresholdMessage = ''
-    const fields: any[] = columns['_field'].data
+    const fields: any[] = columns['_field']?.data ?? []
 
     const values = getValueColumn(columns)
 


### PR DESCRIPTION
There's an assumption that fields will exist in results from a query. This adds guardrails against that. We should iterate on this so that we can make sure the error threshold work is still applicable after this gets in. For context, check out the conversation around the issue [here](https://influxdata.slack.com/archives/CLHATC50E/p1649348887581009)