### PR TITLE
fix: move param to correct scope

### DIFF
--- a/src/flows/pipes/RawFluxEditor/FunctionsList/perFunction/FluxDocsTooltipContent.tsx
+++ b/src/flows/pipes/RawFluxEditor/FunctionsList/perFunction/FluxDocsTooltipContent.tsx
@@ -25,8 +25,8 @@ const FluxDocsTooltipContent: FC<TooltipProps> = ({
   }, [])
   const argComponent = () => {
     if (func.fluxParameters.length > 0) {
-      let param = 'Optional'
       return func.fluxParameters.map(arg => {
+        let param = 'Optional'
         const description = arg.headline.slice(arg.name.length + 1)
         arg.required ? (param = 'Required') : param
 

--- a/src/timeMachine/components/dynamicFluxFunctionsToolbar/TooltipArguments.tsx
+++ b/src/timeMachine/components/dynamicFluxFunctionsToolbar/TooltipArguments.tsx
@@ -23,8 +23,8 @@ class TooltipArguments extends PureComponent<Props> {
     const {argsList} = this.props
 
     if (argsList.length > 0) {
-      let param = 'Optional'
       return argsList.map(argument => {
+        let param = 'Optional'
         const description = argument.headline.slice(argument.name.length + 1)
         argument.required ? (param = 'Required') : param
 


### PR DESCRIPTION
Bug fix for #4342 

`param` needs to be reset back to the default "Optional" or else all params become "Required" after the first "Required".


BEFORE:

https://user-images.githubusercontent.com/10736577/162499349-db907123-ac9a-4eef-b033-1ba8abe68dbf.mp4



AFTER:

https://user-images.githubusercontent.com/10736577/162499377-d144c407-8840-46b3-8241-ed6c95ab39fa.mp4


