### PR TITLE
fix(alerts): navigate to task runs

### DIFF
--- a/src/checks/components/CheckCard.tsx
+++ b/src/checks/components/CheckCard.tsx
@@ -44,6 +44,8 @@ import {Check, Label} from 'src/types'
 // Utilities
 import {relativeTimestampFormatter} from 'src/shared/utils/relativeTimestampFormatter'
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
+import {event} from 'src/cloud/utils/reporting'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 interface OwnProps {
   check: Check
@@ -161,6 +163,16 @@ const CheckCard: FC<Props> = ({
             key={2}
             lastRunError={check.lastRunError}
             lastRunStatus={check.lastRunStatus}
+            statusButtonClickHandler={() => {
+              event('check status button clicked', {
+                lastRunError: check.lastRunError,
+                lastRunStatus: check.lastRunStatus,
+                from: 'alert card',
+              })
+              if (isFlagEnabled('navToTaskRuns')) {
+                history.push(`/orgs/${orgID}/tasks/${check.taskID}/runs`)
+              }
+            }}
           />
         </FlexBox>
         <FlexBox

--- a/src/notifications/rules/components/RuleCard.tsx
+++ b/src/notifications/rules/components/RuleCard.tsx
@@ -44,6 +44,7 @@ import {NotificationRuleDraft, Label, AlertHistoryType} from 'src/types'
 // Utilities
 import {relativeTimestampFormatter} from 'src/shared/utils/relativeTimestampFormatter'
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
+import {event} from 'src/cloud/utils/reporting'
 
 interface OwnProps {
   rule: NotificationRuleDraft
@@ -161,6 +162,16 @@ const RuleCard: FC<Props> = ({
             key={2}
             lastRunError={lastRunError}
             lastRunStatus={lastRunStatus}
+            statusButtonClickHandler={() => {
+              event('check status button clicked', {
+                lastRunError,
+                lastRunStatus,
+                from: 'rules card',
+              })
+              if (isFlagEnabled('navToTaskRuns')) {
+                history.push(`/orgs/${orgID}/tasks/${taskID}/runs`)
+              }
+            }}
           />
         </FlexBox>
         <FlexBox

--- a/src/notifications/rules/components/RuleCard.tsx
+++ b/src/notifications/rules/components/RuleCard.tsx
@@ -45,6 +45,7 @@ import {NotificationRuleDraft, Label, AlertHistoryType} from 'src/types'
 import {relativeTimestampFormatter} from 'src/shared/utils/relativeTimestampFormatter'
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
 import {event} from 'src/cloud/utils/reporting'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 interface OwnProps {
   rule: NotificationRuleDraft

--- a/src/shared/components/lastRunTaskStatus/LastRunTaskStatus.scss
+++ b/src/shared/components/lastRunTaskStatus/LastRunTaskStatus.scss
@@ -11,6 +11,7 @@
   background-color: rgba($cf-grey-25, 0.5);
   border-radius: 50%;
   transition: color 0.25s ease, text-shadow 0.25s ease;
+  cursor: pointer;
 
   &.last-run-task-status__danger {
     color: $c-curacao;

--- a/src/shared/components/lastRunTaskStatus/LastRunTaskStatus.tsx
+++ b/src/shared/components/lastRunTaskStatus/LastRunTaskStatus.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FC, useRef, useState} from 'react'
+import React, {FC, useRef, useState, MouseEventHandler} from 'react'
 import classnames from 'classnames'
 
 // Components
@@ -18,9 +18,14 @@ import './LastRunTaskStatus.scss'
 interface PassedProps {
   lastRunError?: string
   lastRunStatus: string
+  statusButtonClickHandler: MouseEventHandler
 }
 
-const LastRunTaskStatus: FC<PassedProps> = ({lastRunError, lastRunStatus}) => {
+const LastRunTaskStatus: FC<PassedProps> = ({
+  lastRunError,
+  lastRunStatus,
+  statusButtonClickHandler,
+}) => {
   const triggerRef = useRef<HTMLDivElement>(null)
   const [highlight, setHighlight] = useState<boolean>(false)
 
@@ -58,6 +63,7 @@ const LastRunTaskStatus: FC<PassedProps> = ({lastRunError, lastRunStatus}) => {
         data-testid="last-run-status--icon"
         className={statusClassName}
         ref={triggerRef}
+        onClick={statusButtonClickHandler}
       >
         <Icon glyph={icon} />
       </div>

--- a/src/tasks/actions/thunks.ts
+++ b/src/tasks/actions/thunks.ts
@@ -104,7 +104,7 @@ export const getTasks = (limit: number = TASK_LIMIT) => async (
   }
 }
 
-export const getAllTasks = () => async (
+export const getAllTasks = (name?: string) => async (
   dispatch: Dispatch<TaskAction | NotifyAction>,
   getState: GetState
 ): Promise<void> => {
@@ -118,6 +118,10 @@ export const getAllTasks = () => async (
     // fetching 500 tasks at once strikes a balance between large requests and many requests
     const limit = 500
     const query: GetTasksParams['query'] = {orgID: org.id, limit}
+    // filter by tasks with a particular name, if provided
+    if (name) {
+      query.name = name
+    }
     const resp = await fetchTasks(query)
 
     let nonNormalizedTasks = resp.data.tasks

--- a/src/tasks/components/TaskCard.tsx
+++ b/src/tasks/components/TaskCard.tsx
@@ -48,6 +48,7 @@ import {
 } from 'src/shared/copy/notifications'
 import {notify} from 'src/shared/actions/notifications'
 import {downloadTaskTemplate} from 'src/tasks/apis'
+import {event} from 'src/cloud/utils/reporting'
 
 interface PassedProps {
   task: Task
@@ -69,7 +70,7 @@ export class TaskCard extends PureComponent<
   Props & RouteComponentProps<{orgID: string}>
 > {
   public render() {
-    const {task} = this.props
+    const {task, history} = this.props
 
     return (
       <ResourceCard
@@ -83,6 +84,16 @@ export class TaskCard extends PureComponent<
         <LastRunTaskStatus
           lastRunError={task.lastRunError}
           lastRunStatus={task.lastRunStatus}
+          statusButtonClickHandler={() => {
+            event('check status button clicked', {
+              lastRunError: task.lastRunError,
+              lastRunStatus: task.lastRunStatus,
+              from: 'task card',
+            })
+            if (isFlagEnabled('navToTaskRuns')) {
+              history.push(`/orgs/${task.orgID}/tasks/${task.id}/runs`)
+            }
+          }}
         />
         <FlexBox
           alignItems={AlignItems.FlexStart}

--- a/src/tasks/components/TaskRunsCard.tsx
+++ b/src/tasks/components/TaskRunsCard.tsx
@@ -34,9 +34,10 @@ import {FormattedDateTime} from 'src/utils/datetime/FormattedDateTime'
 
 interface Props {
   task: Task
+  isTaskEditable: boolean
 }
 
-const TaskRunsCard: FC<Props> = ({task}) => {
+const TaskRunsCard: FC<Props> = ({task, isTaskEditable}) => {
   const dispatch = useDispatch()
   const members = useSelector((state: AppState) => state.resources.members.byID)
   const org = useSelector(getOrg)
@@ -135,6 +136,7 @@ const TaskRunsCard: FC<Props> = ({task}) => {
               size={ComponentSize.ExtraSmall}
               onChange={changeToggle}
               testID="task-card--slide-toggle"
+              disabled={!isTaskEditable}
             />
             <InputLabel active={task.status === 'active'}>
               {task.status === 'active' ? 'Active' : 'Inactive'}
@@ -153,14 +155,16 @@ const TaskRunsCard: FC<Props> = ({task}) => {
         </ResourceCard.Meta>
       </FlexBox>
 
-      <FlexBox margin={ComponentSize.Medium} direction={FlexDirection.Row}>
-        <Button onClick={handleRunTask} text="Run Task" />
-        <Button
-          onClick={handleEditTask}
-          text="Edit Task"
-          color={ComponentColor.Primary}
-        />
-      </FlexBox>
+      {isTaskEditable && (
+        <FlexBox margin={ComponentSize.Medium} direction={FlexDirection.Row}>
+          <Button onClick={handleRunTask} text="Run Task" />
+          <Button
+            onClick={handleEditTask}
+            text="Edit Task"
+            color={ComponentColor.Primary}
+          />
+        </FlexBox>
+      )}
     </ResourceCard>
   )
 }

--- a/src/tasks/components/TaskRunsPage.test.tsx
+++ b/src/tasks/components/TaskRunsPage.test.tsx
@@ -223,6 +223,13 @@ jest.mock('src/client', () => ({
       },
     })
   }),
+  getTasks: jest.fn(() => {
+    return Promise.resolve({
+      status: 200,
+      headers: {},
+      data: tasks,
+    })
+  }),
   getTask: jest.fn(() => {
     return {
       data: tasks[0],
@@ -257,6 +264,9 @@ jest.mock('src/resources/selectors', () => {
     }),
     getStatus: jest.fn(() => {
       return RemoteDataState.NotStarted
+    }),
+    getAll: jest.fn(() => {
+      return tasks
     }),
   }
 })

--- a/src/tasks/components/TaskRunsPage.tsx
+++ b/src/tasks/components/TaskRunsPage.tsx
@@ -130,8 +130,6 @@ const mstp = (state: AppState) => {
 
   // this task is only editable if the /tasks API returns it.
   // tasks created by an Alert are uneditable and are not returned from /tasks API.
-  console.log({currentTask})
-  console.log({tasksFilteredByName})
   const isTaskEditable = currentTask
     ? !!tasksFilteredByName.find(t => t.id === currentTask.id)
     : false

--- a/src/tasks/components/TaskRunsPage.tsx
+++ b/src/tasks/components/TaskRunsPage.tsx
@@ -11,11 +11,11 @@ import {TaskRunsCard} from 'src/tasks/components/TaskRunsCard'
 import {PageBreadcrumbs} from 'src/tasks/components/PageBreadcrumbs'
 
 // Types
-import {AppState, Run} from 'src/types'
+import {AppState, ResourceType, Run, Task} from 'src/types'
 import {SpinnerContainer, TechnoSpinner} from '@influxdata/clockface'
 
 // Actions
-import {getRuns, runTask} from 'src/tasks/actions/thunks'
+import {getRuns, runTask, getAllTasks} from 'src/tasks/actions/thunks'
 
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
@@ -23,6 +23,7 @@ import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 // Types
 import {SortTypes} from 'src/shared/utils/sort'
 import TimeZoneDropdown from 'src/shared/components/TimeZoneDropdown'
+import {getAll} from 'src/resources/selectors'
 
 type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps & RouteComponentProps<{id: string; orgID: string}>
@@ -46,7 +47,7 @@ class TaskRunsPage extends PureComponent<Props, State> {
   }
 
   public render() {
-    const {match, runs, currentTask} = this.props
+    const {match, runs, currentTask, isTaskEditable} = this.props
     const {sortKey, sortDirection, sortType} = this.state
 
     return (
@@ -70,7 +71,7 @@ class TaskRunsPage extends PureComponent<Props, State> {
             <RateLimitAlert location="task runs" />
           </Page.Header>
           <Page.ControlBar fullWidth={false}>
-            <TaskRunsCard task={currentTask} />
+            <TaskRunsCard task={currentTask} isTaskEditable={isTaskEditable} />
           </Page.ControlBar>
           <Page.ControlBar fullWidth={false}>
             <Page.ControlBarRight>
@@ -96,6 +97,13 @@ class TaskRunsPage extends PureComponent<Props, State> {
     this.props.getRuns(this.props.match.params.id)
   }
 
+  public componentDidUpdate(prevProps: Readonly<Props>): void {
+    if (!prevProps.currentTask && !!this.props.currentTask) {
+      // once we have the currentTask, ask the /tasks API if this task is editable
+      this.props.getAllTasks(this.props.currentTask.name)
+    }
+  }
+
   private handleClickColumn = (nextSort: Sort, sortKey: SortKey) => {
     let sortType = SortTypes.String
 
@@ -117,17 +125,28 @@ class TaskRunsPage extends PureComponent<Props, State> {
 }
 
 const mstp = (state: AppState) => {
+  const tasksFilteredByName = getAll<Task>(state, ResourceType.Tasks)
   const {currentTask, runs, runStatus} = state.resources.tasks
+
+  // this task is only editable if the /tasks API returns it.
+  // tasks created by an Alert are uneditable and are not returned from /tasks API.
+  console.log({currentTask})
+  console.log({tasksFilteredByName})
+  const isTaskEditable = currentTask
+    ? !!tasksFilteredByName.find(t => t.id === currentTask.id)
+    : false
 
   return {
     runs,
     runStatus,
     currentTask,
+    isTaskEditable,
   }
 }
 
 const mdtp = {
   getRuns,
+  getAllTasks,
   onRunTask: runTask,
 }
 


### PR DESCRIPTION
Helps https://github.com/influxdata/ui/issues/4356

Ever had a failed alert and wanted to know why? Well today's your lucky day! Now you can click the warning symbol and be taken to the associated task's runs page and view the logs!

If the user navigates to the task runs page, we now confirm the task is editable before letting them edit it. We can confirm the task is editable by checking if it exists in the response from the `/tasks?name={task name}` API. Tasks created by Alerts are not returned in this API response. I used the `name` filter because the Task created by an Alert always shares the same name as the Alert. From this list, I set `isTaskEditable=true` iff I can find a task in the response with the matching task ID from the Alert.

All of this is behind flag `navToTasksRuns`




https://user-images.githubusercontent.com/6411855/162501555-3c91f852-ca19-4733-a17c-31d38c262a06.mov


