### PR TITLE
fix: naming issues for notebooks referencing stale state

### DIFF
--- a/src/flows/components/FlowCard.tsx
+++ b/src/flows/components/FlowCard.tsx
@@ -45,7 +45,8 @@ const FlowCard: FC<Props> = ({id, isPinned}) => {
   )
 
   const handleRenameNotebook = async (name: string) => {
-    await update(id, name)
+    flow.name = name
+    await update(id, flow)
     if (isFlagEnabled('pinnedItems') && CLOUD && isPinned) {
       try {
         updatePinnedItemByParam(id, {name})

--- a/src/flows/components/header/index.tsx
+++ b/src/flows/components/header/index.tsx
@@ -85,7 +85,8 @@ const FlowHeader: FC = () => {
   }, [handleSave])
 
   const handleRename = (name: string) => {
-    updateOther({name})
+    flow.name = name
+    updateOther(flow)
     try {
       updatePinnedItemByParam(flow.id, {name})
     } catch (err) {

--- a/src/flows/context/flow.list.tsx
+++ b/src/flows/context/flow.list.tsx
@@ -34,7 +34,7 @@ import {CLOUD} from 'src/shared/constants'
 export interface FlowListContextType extends FlowList {
   add: (flow?: Flow) => Promise<string | void>
   clone: (id: string) => Promise<string | void>
-  update: (id: string, name: string) => void
+  update: (id: string, flow?: Flow) => void
   remove: (id: string) => void
   getAll: () => void
 }
@@ -58,7 +58,7 @@ export const DEFAULT_CONTEXT: FlowListContextType = {
   flows: {},
   add: (_flow?: Flow) => {},
   clone: (_id: string) => {},
-  update: (_id: string, _name: string) => {},
+  update: (_id: string, _flow: Partial<Flow>) => {},
   remove: (_id: string) => {},
   getAll: () => {},
 } as FlowListContextType
@@ -236,7 +236,7 @@ export const FlowListProvider: FC = ({children}) => {
   }
 
   const update = useCallback(
-    async (id: string, name: string) => {
+    async (id: string, flow: Partial<Flow>) => {
       try {
         if (!flows.hasOwnProperty(id)) {
           throw new Error(`${PROJECT_NAME} not found`)
@@ -244,9 +244,10 @@ export const FlowListProvider: FC = ({children}) => {
 
         if (CLOUD) {
           const resp = await patchNotebook({
-            id,
+            id: id,
             data: {
-              name,
+              name: flow.name,
+              orgID: org.id,
             },
           })
 
@@ -258,17 +259,17 @@ export const FlowListProvider: FC = ({children}) => {
             ...prevFlows,
             [id]: {
               ...prevFlows[id],
-              name,
+              name: flow.name,
             },
           }))
         } else {
-          const flow = flows[id]
+          const _flow = flows[id]
 
           const allFlowNames = Object.values(flows).map(value => value.name)
-          const clonedName = incrementCloneName(allFlowNames, flow.name)
+          const clonedName = incrementCloneName(allFlowNames, _flow.name)
 
           const data = {
-            ...flow,
+            ..._flow,
             name: clonedName,
           }
 


### PR DESCRIPTION
Closes #4360 

This PR closes two bugs surrounding renaming a notebook. The first, when a user renaming a notebook in the list page wouldn't have their changes reflected immediately since the state wasn't setting correctly based on the user's input. The second one being that if a user renamed a notebook from the notebook view & immediately went off to perform another update (like updating a flux script in a panel), then the user's secondary patch (with an out of sync notebook name) would overwrite the original changes. 

<!-- Describe your proposed changes here. -->
