### PR TITLE
chore: remove cloneToOtherBoards feature flag

### DIFF
--- a/cypress/e2e/shared/dashboardsView.test.ts
+++ b/cypress/e2e/shared/dashboardsView.test.ts
@@ -1304,8 +1304,6 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
             cy.getByTestID('tree-nav')
           })
         })
-        // TODO: remove when feature flag is removed
-        cy.setFeatureFlags({cloneToOtherBoards: true})
         cy.createBucket(orgID, name, 'schmucket')
         const now = Date.now()
         cy.writeData(

--- a/src/shared/components/cells/CellContext.tsx
+++ b/src/shared/components/cells/CellContext.tsx
@@ -18,7 +18,6 @@ import {
 } from '@influxdata/clockface'
 import CellContextItem from 'src/shared/components/cells/CellContextItem'
 import CellContextDangerItem from 'src/shared/components/cells/CellContextDangerItem'
-import {FeatureFlag} from 'src/shared/utils/featureFlag'
 
 // Actions
 import {deleteCellAndView, createCellWithView} from 'src/cells/actions/thunks'
@@ -106,24 +105,22 @@ const CellContext: FC<Props> = ({
             onHide={onHide}
             testID="cell-context--clone"
           />
-          <FeatureFlag name="cloneToOtherBoards">
-            <CellContextItem
-              label="Move"
-              onClick={() =>
-                onShowOverlay(
-                  'cell-copy-overlay',
-                  {
-                    view,
-                    cell,
-                  },
-                  onDismissOverlay
-                )
-              }
-              icon={IconFont.Export_New}
-              onHide={onHide}
-              testID="cell-context--copy"
-            />
-          </FeatureFlag>
+          <CellContextItem
+            label="Move"
+            onClick={() =>
+              onShowOverlay(
+                'cell-copy-overlay',
+                {
+                  view,
+                  cell,
+                },
+                onDismissOverlay
+              )
+            }
+            icon={IconFont.Export_New}
+            onHide={onHide}
+            testID="cell-context--copy"
+          />
           <CellContextDangerItem
             label="Delete"
             onClick={handleDeleteCell}
@@ -179,24 +176,22 @@ const CellContext: FC<Props> = ({
           onHide={onHide}
           testID="cell-context--pause"
         />
-        <FeatureFlag name="cloneToOtherBoards">
-          <CellContextItem
-            label="Move"
-            onClick={() =>
-              onShowOverlay(
-                'cell-copy-overlay',
-                {
-                  view,
-                  cell,
-                },
-                onDismissOverlay
-              )
-            }
-            icon={IconFont.Export_New}
-            onHide={onHide}
-            testID="cell-context--copy"
-          />
-        </FeatureFlag>
+        <CellContextItem
+          label="Move"
+          onClick={() =>
+            onShowOverlay(
+              'cell-copy-overlay',
+              {
+                view,
+                cell,
+              },
+              onDismissOverlay
+            )
+          }
+          icon={IconFont.Export_New}
+          onHide={onHide}
+          testID="cell-context--copy"
+        />
       </div>
     )
   }


### PR DESCRIPTION
This feature has been enabled for quite some time in the UI. It's time to rip out the feature flag now that we're certain that this is a feature we want to maintain