### PR TITLE
chore: disable the add button if there is nothing to add

### DIFF
--- a/src/flows/pipes/Visualization/ErrorThresholds/ErrorThresholds.tsx
+++ b/src/flows/pipes/Visualization/ErrorThresholds/ErrorThresholds.tsx
@@ -7,6 +7,7 @@ import {
   Button,
   ComponentColor,
   ComponentSize,
+  ComponentStatus,
   IconFont,
   FlexBox,
   FlexDirection,
@@ -22,7 +23,11 @@ import {ErrorThreshold} from 'src/flows/pipes/Visualization/threshold'
 import './ErrorThresholds.scss'
 
 const ErrorThresholds: FC = () => {
-  const {data, update} = useContext(PipeContext)
+  const {data, results, update} = useContext(PipeContext)
+
+  const fields = Array.from(
+    new Set(results.parsed.table.columns['_field']?.data as string[])
+  )
 
   const errorThresholds = useMemo(() => data?.errorThresholds ?? [], [
     data?.errorThresholds,
@@ -120,6 +125,11 @@ const ErrorThresholds: FC = () => {
             text="Add Threshold"
             icon={IconFont.Plus_New}
             size={ComponentSize.Small}
+            status={
+              fields.length > 0
+                ? ComponentStatus.Default
+                : ComponentStatus.Disabled
+            }
             onClick={handleAddThreshold}
             color={ComponentColor.Primary}
             className="add-error-threshold--button"


### PR DESCRIPTION
Closes #4365

Offlined with @garylfowler about the best approach for this feature at this stage w/r/t to the linked. The crux of the issue can be boiled down to two separate issues:

1. Do we want to broaden setting error thresholds when the user doesn’t have a field (meaning, support measurements as an error threshold), or do we want to maintain the current dynamic of a field being required for setting a threshold. For example, I want to set an alert for when the field data for the measurement doesn’t have a value returned (meaning, that some data might not be coming through)
2. If i have an error threshold set for a field, and I update the original query so now that field is no longer being returned, do I automatically want to remove the existing error threshold, or do I want to keep it as a record for the user just in case they ever want to bring it back (the condition should never be hit since they don’t have that data being returned any longer)

The solution that's been settled on is that:

1. We want to stick with keeping error thresholds strictly a `_fields`-based design, meaning not expanding the functionality to data checks against `_measurements`.
2. Keep the error threshold until it is explicitly removed from the data by the user, so that they maintain a reference to previous checks.

As such, the only real change happening in this PR is to disable the `Add Threshold` Button when there are no fields available to the user

<!-- Describe your proposed changes here. -->
