### PR TITLE
feat(HelpBar): Display support overlays for payg and free accounts 

### DIFF
--- a/src/overlays/components/OverlayController.tsx
+++ b/src/overlays/components/OverlayController.tsx
@@ -39,6 +39,8 @@ import NewRuleOverlay from 'src/notifications/rules/components/NewRuleOverlay'
 import CreateSecretOverlay from 'src/secrets/components/CreateSecret/CreateSecretOverlay'
 import VariableImportOverlay from 'src/variables/components/VariableImportOverlay'
 import ShareOverlay from 'src/flows/components/ShareOverlay'
+import PayGSupportOverlay from 'src/support/components/PayGSupportOverlay'
+import FreeAccountSupportOverlay from 'src/support/components/FreeAccountSupportOverlay'
 
 // Actions
 import {dismissOverlay} from 'src/overlays/actions/overlays'
@@ -146,6 +148,12 @@ export const OverlayController: FunctionComponent = () => {
         break
       case 'share-overlay':
         activeOverlay.current = <ShareOverlay />
+        break
+      case 'payg-support':
+        activeOverlay.current = <PayGSupportOverlay onClose={onClose} />
+        break
+      case 'free-account-support':
+        activeOverlay.current = <FreeAccountSupportOverlay onClose={onClose} />
         break
       default:
         activeOverlay.current = null

--- a/src/overlays/components/index.tsx
+++ b/src/overlays/components/index.tsx
@@ -139,3 +139,19 @@ export const ExportVariableOverlay = RouteOverlay(
     history.push(`/orgs/${params.orgID}/settings/variables`)
   }
 )
+
+export const PayGSupportOverlay = RouteOverlay(
+  OverlayHandler,
+  'payg-support',
+  (history, params) => {
+    history.push(`/orgs/${params.orgID}/support`)
+  }
+)
+
+export const FreeAccountSupportOverlay = RouteOverlay(
+  OverlayHandler,
+  'free-account-support',
+  (history, params) => {
+    history.push(`/orgs/${params.orgID}/support`)
+  }
+)

--- a/src/overlays/reducers/overlays.ts
+++ b/src/overlays/reducers/overlays.ts
@@ -30,6 +30,8 @@ export type OverlayID =
   | 'create-rule'
   | 'create-secret'
   | 'share-overlay'
+  | 'payg-support'
+  | 'free-account-support'
 
 export interface OverlayState {
   id: OverlayID | null

--- a/src/pageLayout/containers/TreeNav.tsx
+++ b/src/pageLayout/containers/TreeNav.tsx
@@ -2,7 +2,7 @@
 import React, {FC, useContext, useEffect} from 'react'
 import {Link} from 'react-router-dom'
 import {useSelector} from 'react-redux'
-import {connect, ConnectedProps, useDispatch} from 'react-redux'
+import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
@@ -26,7 +26,6 @@ import {SafeBlankLink} from 'src/utils/SafeBlankLink'
 import {NavItem, NavSubItem} from 'src/pageLayout/constants/navigationHierarchy'
 import {AppState} from 'src/types'
 
-import {getStore} from 'src/store/configureStore'
 import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
 
 type ReduxProps = ConnectedProps<typeof connector>
@@ -35,19 +34,16 @@ const TreeSidebar: FC<ReduxProps & RouteComponentProps> = ({
   showOverlay,
   dismissOverlay,
 }) => {
-  const org = useSelector(getOrg)
-  const orgID = org?.id
   const {presentationMode, navbarMode, setNavbarMode} = useContext(
     AppSettingContext
   )
-
-  // const state: AppState = getStore().getState()
-  // const orgID = state?.resources?.orgs?.org?.id ?? ''
-  // const orgPrefix = `/orgs/${orgID}`
-
-  const supportLink = {
-    link: `/orgs/${orgID}/support`,
+  const userAccount = (state: AppState): boolean => {
+    const {quartzMe} = state.me
+    const accountType = quartzMe?.accountType ?? 'free'
+    return accountType !== 'free'
   }
+  const isPayGCustomer = useSelector(userAccount)
+  const org = useSelector(getOrg)
 
   useEffect(() => {
     if (isFlagEnabled('helpBar')) {
@@ -75,25 +71,12 @@ const TreeSidebar: FC<ReduxProps & RouteComponentProps> = ({
     }
   }
 
-  const isPayingCustomer = (state: AppState): boolean => {
-    const {quartzMe} = state.me
-    const accountType = quartzMe?.accountType ?? 'free'
-    return accountType !== 'free'
-  }
-  const ans = useSelector(isPayingCustomer)
-
   const handleSelect = (): void => {
-    // check if cusomter is a free user
-    // open free support overlay
-    // console.log('is paying customer ', ans)
-    if (!ans) {
-      console.log('is paying customer ', ans)
+    if (isPayGCustomer) {
       showOverlay('payg-support', null, dismissOverlay)
     } else {
       showOverlay('free-account-support', null, dismissOverlay)
     }
-    // if customer is paying user
-    // open pay support overlay
   }
 
   return (
@@ -193,7 +176,6 @@ const TreeSidebar: FC<ReduxProps & RouteComponentProps> = ({
                 id="contactSupport"
                 label="Contact Support"
                 testID="nav-subitem-contact-support"
-                // linkElement={className => <Link className={className} onClick={handleSelect} to=''/>}
                 onClick={handleSelect}
               />
               <TreeNav.SubHeading label="Community" />

--- a/src/pageLayout/containers/TreeNav.tsx
+++ b/src/pageLayout/containers/TreeNav.tsx
@@ -33,16 +33,11 @@ type ReduxProps = ConnectedProps<typeof connector>
 const TreeSidebar: FC<ReduxProps & RouteComponentProps> = ({
   showOverlay,
   dismissOverlay,
+  quartzMe,
 }) => {
   const {presentationMode, navbarMode, setNavbarMode} = useContext(
     AppSettingContext
   )
-  const userAccount = (state: AppState): boolean => {
-    const {quartzMe} = state.me
-    const accountType = quartzMe?.accountType ?? 'free'
-    return accountType !== 'free'
-  }
-  const isPayGCustomer = useSelector(userAccount)
   const org = useSelector(getOrg)
 
   useEffect(() => {
@@ -72,6 +67,9 @@ const TreeSidebar: FC<ReduxProps & RouteComponentProps> = ({
   }
 
   const handleSelect = (): void => {
+    const accountType = quartzMe?.accountType ?? 'free'
+    const isPayGCustomer = accountType !== 'free'
+
     if (isPayGCustomer) {
       showOverlay('payg-support', null, dismissOverlay)
     } else {
@@ -210,11 +208,15 @@ const TreeSidebar: FC<ReduxProps & RouteComponentProps> = ({
   )
 }
 
+const mstp = (state: AppState) => {
+  return {quartzMe: state.me.quartzMe}
+}
+
 const mdtp = {
   showOverlay,
   dismissOverlay,
 }
 
-const connector = connect(null, mdtp)
+const connector = connect(mstp, mdtp)
 
 export default connector(withRouter(TreeSidebar))

--- a/src/support/components/FreeAccountSupportOverlay.tsx
+++ b/src/support/components/FreeAccountSupportOverlay.tsx
@@ -1,0 +1,63 @@
+import React, {FC, useContext} from 'react'
+
+// Components
+import {Overlay, List} from '@influxdata/clockface'
+
+// Contexts
+import {OverlayContext} from 'src/overlays/components/OverlayController'
+
+// Components
+import CloudUpgradeButton from 'src/shared/components/CloudUpgradeButton'
+import {SafeBlankLink} from 'src/utils/SafeBlankLink'
+
+interface OwnProps {
+  onClose: () => void
+}
+
+const FreeAccountSupportOverlay: FC<OwnProps> = () => {
+  const {onClose} = useContext(OverlayContext)
+
+  return (
+    <Overlay.Container maxWidth={600}>
+      <Overlay.Header
+        testID="free-support-overlay-header"
+        title="Contact Support"
+        onDismiss={onClose}
+      />
+      <Overlay.Body>
+        <p>
+          Check our{' '}
+          <SafeBlankLink href="https://status.influxdata.com">
+            status page
+          </SafeBlankLink>{' '}
+          to see if there is an outage impacting your region.
+        </p>
+        <p>
+          Contact support is currently only available for Usage-Based Plan and
+          Annual customers. Please try our community resources below to recieve
+          help or file a feedback & questions form.
+        </p>
+        <List>
+          <List.Item>
+            <SafeBlankLink href="https://community.influxdata.com">
+              InfluxDB Community Forums
+            </SafeBlankLink>
+          </List.Item>
+          <List.Item>
+            <SafeBlankLink href="https://influxcommunity.slack.com/join/shared_invite/zt-156zm7ult-LcIW2T4TwLYeS8rZbCP1mw#/shared-invite/email">
+              InfluxDB Slack
+            </SafeBlankLink>
+          </List.Item>
+          <List.Item>
+            <SafeBlankLink href="">Feedback & Questions Form</SafeBlankLink>
+          </List.Item>
+        </List>
+      </Overlay.Body>
+      <Overlay.Footer className="overlay-footer">
+        <CloudUpgradeButton />
+      </Overlay.Footer>
+    </Overlay.Container>
+  )
+}
+
+export default FreeAccountSupportOverlay

--- a/src/support/components/FreeAccountSupportOverlay.tsx
+++ b/src/support/components/FreeAccountSupportOverlay.tsx
@@ -1,14 +1,13 @@
 import React, {FC, useContext} from 'react'
 
 // Components
-import {Overlay, List} from '@influxdata/clockface'
+import {Overlay} from '@influxdata/clockface'
 
 // Contexts
 import {OverlayContext} from 'src/overlays/components/OverlayController'
 
 // Components
 import CloudUpgradeButton from 'src/shared/components/CloudUpgradeButton'
-import {SafeBlankLink} from 'src/utils/SafeBlankLink'
 
 interface OwnProps {
   onClose: () => void
@@ -18,42 +17,15 @@ const FreeAccountSupportOverlay: FC<OwnProps> = () => {
   const {onClose} = useContext(OverlayContext)
 
   return (
-    <Overlay.Container maxWidth={600}>
+    <Overlay.Container maxWidth={550}>
       <Overlay.Header
         testID="free-support-overlay-header"
         title="Contact Support"
         onDismiss={onClose}
       />
-      <Overlay.Body>
-        <p>
-          Check our{' '}
-          <SafeBlankLink href="https://status.influxdata.com">
-            status page
-          </SafeBlankLink>{' '}
-          to see if there is an outage impacting your region.
-        </p>
-        <p>
-          Contact support is currently only available for Usage-Based Plan and
-          Annual customers. Please try our community resources below to recieve
-          help or file a feedback & questions form.
-        </p>
-        <List>
-          <List.Item>
-            <SafeBlankLink href="https://community.influxdata.com">
-              InfluxDB Community Forums
-            </SafeBlankLink>
-          </List.Item>
-          <List.Item>
-            <SafeBlankLink href="https://influxcommunity.slack.com/join/shared_invite/zt-156zm7ult-LcIW2T4TwLYeS8rZbCP1mw#/shared-invite/email">
-              InfluxDB Slack
-            </SafeBlankLink>
-          </List.Item>
-          <List.Item>
-            <SafeBlankLink href="">Feedback & Questions Form</SafeBlankLink>
-          </List.Item>
-        </List>
-      </Overlay.Body>
-      <Overlay.Footer className="overlay-footer">
+
+      <Overlay.Body></Overlay.Body>
+      <Overlay.Footer>
         <CloudUpgradeButton />
       </Overlay.Footer>
     </Overlay.Container>

--- a/src/support/components/PayGSupportOverlay.tsx
+++ b/src/support/components/PayGSupportOverlay.tsx
@@ -1,0 +1,135 @@
+import React, {FC, useContext, useState} from 'react'
+
+// Components
+import {
+  Overlay,
+  Button,
+  ButtonType,
+  ComponentColor,
+  Columns,
+  Form,
+  Input,
+  Dropdown,
+  Grid,
+  TextArea,
+} from '@influxdata/clockface'
+import {SafeBlankLink} from 'src/utils/SafeBlankLink'
+
+// Contexts
+import {OverlayContext} from 'src/overlays/components/OverlayController'
+
+// Types
+import ErrorBoundary from 'src/shared/components/ErrorBoundary'
+
+interface OwnProps {
+  onClose: () => void
+}
+
+const PayGSupportOverlay: FC<OwnProps> = () => {
+  const [subject, setSubject] = useState('')
+  const {onClose} = useContext(OverlayContext)
+
+  const handleSubmit = (): void => {
+    // submit support form
+  }
+
+  const handleSubjectValidation = (): void => {
+    // validate user input
+  }
+
+  const handleChangeInput = e => {
+    const {value} = e.target
+    setSubject(value)
+  }
+
+  return (
+    <Overlay.Container maxWidth={600}>
+      <Overlay.Header
+        testID="payg-support-overlay-header"
+        title="Contact Support"
+        onDismiss={onClose}
+      />
+      <ErrorBoundary>
+        <Overlay.Body>
+          <p>
+            Check our{' '}
+            <SafeBlankLink href="https://status.influxdata.com">
+              status page
+            </SafeBlankLink>{' '}
+            to see if there is an outage impacting your region.
+          </p>
+          <Form onSubmit={handleSubmit}>
+            <div>
+              <Form.ValidationElement
+                label="Subject"
+                value={subject}
+                required={true}
+                prevalidate={true}
+                validationFunc={handleSubjectValidation}
+              >
+                {status => (
+                  <Input
+                    testID="subject-input"
+                    name="subject"
+                    autoFocus={true}
+                    value={subject}
+                    onChange={handleChangeInput}
+                    status={status}
+                  />
+                )}
+              </Form.ValidationElement>
+            </div>
+            <Form.Element label="Severity" required={true}>
+              <Dropdown
+                button={(active, onClick) => (
+                  <Dropdown.Button
+                    active={active}
+                    onClick={onClick}
+                    testID="support-dropdown--button"
+                  ></Dropdown.Button>
+                )}
+                // menu={onCollapse => (
+                //   <Dropdown.Menu onCollapse={onCollapse}>))</Dropdown.Menu>
+                // )}
+              />
+            </Form.Element>
+            {/* <Grid.Column widthSM={Columns.Twelve}> */}
+            <Form.Element label="Description" required={true}>
+              <TextArea
+                rows={10}
+                //   className="endpoint-description--textarea"
+                testID="endpoint-description--textarea"
+                name="description"
+                //   value={endpoint.description}
+                //   onChange={handleChange}
+              />
+            </Form.Element>
+            {/* </Grid.Column> */}
+
+            <Overlay.Footer className="overlay-footer">
+              <Button
+                text="Cancel"
+                color={ComponentColor.Tertiary}
+                onClick={onClose}
+                // titleText="Cancel creation of Label and return to list"
+                type={ButtonType.Button}
+                testID="payg-contact-support--cancel"
+              />
+              <Button
+                text="Submit"
+                color={ComponentColor.Success}
+                type={ButtonType.Submit}
+                testID="payg-contact-support--submit"
+                // status={
+                //   isFormValid ? ComponentStatus.Default : ComponentStatus.Disabled
+                // }
+              />
+            </Overlay.Footer>
+          </Form>
+        </Overlay.Body>
+      </ErrorBoundary>
+    </Overlay.Container>
+  )
+}
+
+export default PayGSupportOverlay

--- a/src/support/components/PayGSupportOverlay.tsx
+++ b/src/support/components/PayGSupportOverlay.tsx
@@ -1,19 +1,7 @@
-import React, {FC, useContext, useState} from 'react'
+import React, {FC, useContext} from 'react'
 
 // Components
-import {
-  Overlay,
-  Button,
-  ButtonType,
-  ComponentColor,
-  Columns,
-  Form,
-  Input,
-  Dropdown,
-  Grid,
-  TextArea,
-} from '@influxdata/clockface'
-import {SafeBlankLink} from 'src/utils/SafeBlankLink'
+import {Overlay} from '@influxdata/clockface'
 
 // Contexts
 import {OverlayContext} from 'src/overlays/components/OverlayController'
@@ -26,107 +14,18 @@ interface OwnProps {
 }
 
 const PayGSupportOverlay: FC<OwnProps> = () => {
-  const [subject, setSubject] = useState('')
   const {onClose} = useContext(OverlayContext)
 
-  const handleSubmit = (): void => {
-    // submit support form
-  }
-
-  const handleSubjectValidation = (): void => {
-    // validate user input
-  }
-
-  const handleChangeInput = e => {
-    const {value} = e.target
-    setSubject(value)
-  }
-
   return (
-    <Overlay.Container maxWidth={600}>
+    <Overlay.Container maxWidth={500}>
       <Overlay.Header
         testID="payg-support-overlay-header"
         title="Contact Support"
         onDismiss={onClose}
       />
-      <ErrorBoundary>
-        <Overlay.Body>
-          <p>
-            Check our{' '}
-            <SafeBlankLink href="https://status.influxdata.com">
-              status page
-            </SafeBlankLink>{' '}
-            to see if there is an outage impacting your region.
-          </p>
-          <Form onSubmit={handleSubmit}>
-            <div>
-              <Form.ValidationElement
-                label="Subject"
-                value={subject}
-                required={true}
-                prevalidate={true}
-                validationFunc={handleSubjectValidation}
-              >
-                {status => (
-                  <Input
-                    testID="subject-input"
-                    name="subject"
-                    autoFocus={true}
-                    value={subject}
-                    onChange={handleChangeInput}
-                    status={status}
-                  />
-                )}
-              </Form.ValidationElement>
-            </div>
-            <Form.Element label="Severity" required={true}>
-              <Dropdown
-                button={(active, onClick) => (
-                  <Dropdown.Button
-                    active={active}
-                    onClick={onClick}
-                    testID="support-dropdown--button"
-                  ></Dropdown.Button>
-                )}
-                // menu={onCollapse => (
-                //   <Dropdown.Menu onCollapse={onCollapse}>))</Dropdown.Menu>
-                // )}
-              />
-            </Form.Element>
-            {/* <Grid.Column widthSM={Columns.Twelve}> */}
-            <Form.Element label="Description" required={true}>
-              <TextArea
-                rows={10}
-                //   className="endpoint-description--textarea"
-                testID="endpoint-description--textarea"
-                name="description"
-                //   value={endpoint.description}
-                //   onChange={handleChange}
-              />
-            </Form.Element>
-            {/* </Grid.Column> */}
 
-            <Overlay.Footer className="overlay-footer">
-              <Button
-                text="Cancel"
-                color={ComponentColor.Tertiary}
-                onClick={onClose}
-                // titleText="Cancel creation of Label and return to list"
-                type={ButtonType.Button}
-                testID="payg-contact-support--cancel"
-              />
-              <Button
-                text="Submit"
-                color={ComponentColor.Success}
-                type={ButtonType.Submit}
-                testID="payg-contact-support--submit"
-                // status={
-                //   isFormValid ? ComponentStatus.Default : ComponentStatus.Disabled
-                // }
-              />
-            </Overlay.Footer>
-          </Form>
-        </Overlay.Body>
+      <ErrorBoundary>
+        <Overlay.Body></Overlay.Body>
       </ErrorBoundary>
     </Overlay.Container>
   )


### PR DESCRIPTION
Closes #3450 

- adds `PayGSupportOverlay` and `FreeAccountOverlay` to overlay controller file. So when `Contact Support` is clicked, depending on the account type, we direct user to the correct support overlay. 
