### PR TITLE
fix: go lang link for first mile

### DIFF
--- a/src/homepageExperience/containers/HomepageContainer.tsx
+++ b/src/homepageExperience/containers/HomepageContainer.tsx
@@ -43,7 +43,7 @@ export const HomepageContainer: FC = () => {
   const cliPageLink = `/orgs/${org.id}/load-data/file-upload/csv`
   const telegrafPageLink = `/orgs/${org.id}/load-data/telegrafs`
   const javaScriptNodeLink = `/orgs/${org.id}/new-user-wizard/nodejs`
-  const golangLink = `/orgs/${org.id}/load-data/new-user-wizard/go`
+  const golangLink = `/orgs/${org.id}/new-user-wizard/go`
   const loadDataSourcesLink = `/orgs/${org.id}/load-data/sources`
 
   const cardStyle = {minWidth: '200px'}


### PR DESCRIPTION
Somehow I keep messing up the go lang link. 

Tested thoroughly this time. 


https://user-images.githubusercontent.com/18511823/163041107-67db3901-e129-4850-8c5f-65c7d9efd353.mov



<!-- Describe your proposed changes here. -->
