### PR TITLE
chore: remove usages of RouteComponentProps in functional components

### DIFF
--- a/mocks/dummyData.ts
+++ b/mocks/dummyData.ts
@@ -12,7 +12,6 @@ import {
   Authorization,
 } from 'src/types'
 import {OnboardingStepProps} from 'src/onboarding/containers/OnboardingWizard'
-import {RouteComponentProps} from 'react-router-dom'
 import {NumericColumnData} from '@influxdata/giraffe'
 import {CLOUD} from 'src/shared/constants'
 
@@ -239,7 +238,7 @@ const match: match<{orgID: string}> = {
   },
 }
 
-export const withRouterProps: RouteComponentProps<{orgID: string}> = {
+export const withRouterProps = {
   match,
   location: null,
   history: null,

--- a/src/Logout.tsx
+++ b/src/Logout.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import {FC, useEffect} from 'react'
 import {useDispatch} from 'react-redux'
-import {RouteComponentProps} from 'react-router-dom'
+import {useHistory} from 'react-router-dom'
 
 // APIs
 import {postSignout} from 'src/client'
@@ -18,9 +18,8 @@ import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 // Components
 import {reset} from 'src/shared/actions/flags'
 
-type Props = RouteComponentProps
-
-const Logout: FC<Props> = ({history}) => {
+const Logout: FC = () => {
+  const history = useHistory()
   const dispatch = useDispatch()
 
   useEffect(() => {

--- a/src/Setup.tsx
+++ b/src/Setup.tsx
@@ -107,20 +107,20 @@ export class Setup extends PureComponent<Props, State> {
           {allowed && (
             <Route
               path="/onboarding/:stepID"
-              element={<OnboardingWizardPage />>}
+              component={OnboardingWizardPage}
             />
           )}
           {!allowed && (
             <Switch>
               <Route
                 path="/onboarding/:stepID"
-                element={<OnboardingWizardPage />}
+                component={OnboardingWizardPage}
               />
-              <Route path="/share/:accessID" element={<ReadOnlyNotebook />} />
-              <Route path={LOGIN} element={<LoginPage />} />
-              <Route path={SIGNIN} element={<SigninPage />} />
-              <Route path={LOGOUT} element={<Logout />} />
-              <Route element={<Signin />} />
+              <Route path="/share/:accessID" component={ReadOnlyNotebook} />
+              <Route path={LOGIN} component={LoginPage} />
+              <Route path={SIGNIN} component={SigninPage} />
+              <Route path={LOGOUT} component={Logout} />
+              <Route component={Signin} />
             </Switch>
           )}
         </Suspense>

--- a/src/Setup.tsx
+++ b/src/Setup.tsx
@@ -107,20 +107,20 @@ export class Setup extends PureComponent<Props, State> {
           {allowed && (
             <Route
               path="/onboarding/:stepID"
-              component={OnboardingWizardPage}
+              element={<OnboardingWizardPage />>}
             />
           )}
           {!allowed && (
             <Switch>
               <Route
                 path="/onboarding/:stepID"
-                component={OnboardingWizardPage}
+                element={<OnboardingWizardPage />}
               />
-              <Route path="/share/:accessID" component={ReadOnlyNotebook} />
-              <Route path={LOGIN} component={LoginPage} />
-              <Route path={SIGNIN} component={SigninPage} />
-              <Route path={LOGOUT} component={Logout} />
-              <Route component={Signin} />
+              <Route path="/share/:accessID" element={<ReadOnlyNotebook />} />
+              <Route path={LOGIN} element={<LoginPage />} />
+              <Route path={SIGNIN} element={<SigninPage />} />
+              <Route path={LOGOUT} element={<Logout />} />
+              <Route element={<Signin />} />
             </Switch>
           )}
         </Suspense>

--- a/src/alerting/components/AlertHistoryIndex.tsx
+++ b/src/alerting/components/AlertHistoryIndex.tsx
@@ -1,7 +1,8 @@
 // Libraries
 import React, {useMemo, useState, FC, createContext} from 'react'
 import {Page} from '@influxdata/clockface'
-import {connect} from 'react-redux'
+import {useSelector} from 'react-redux'
+import {useParams} from 'react-router-dom'
 
 // Components
 import EventViewer from 'src/eventViewer/components/EventViewer'
@@ -31,24 +32,23 @@ import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 
 // Types
 import {ResourceIDs} from 'src/checks/reducers'
-import {ResourceType, AlertHistoryType, AppState} from 'src/types'
-import {RouteComponentProps} from 'react-router-dom'
+import {ResourceType, AlertHistoryType} from 'src/types'
 import TimeZoneDropdown from 'src/shared/components/TimeZoneDropdown'
 
 export const ResourceIDsContext = createContext<ResourceIDs>(null)
 
-interface StateProps {
-  resourceIDs: ResourceIDs
-}
+const AlertHistoryIndex: FC = () => {
+  const checkIDs = useSelector(getCheckIDs)
+  const endpointIDs = useSelector(getEndpointIDs)
+  const ruleIDs = useSelector(getRuleIDs)
 
-type Props = RouteComponentProps<{orgID: string}> & StateProps
+  const resourceIDs = {
+    checkIDs,
+    endpointIDs,
+    ruleIDs,
+  }
 
-const AlertHistoryIndex: FC<Props> = ({
-  match: {
-    params: {orgID},
-  },
-  resourceIDs,
-}) => {
+  const {orgID} = useParams<{orgID: string}>()
   const [historyType, setHistoryType] = useState<AlertHistoryType>(
     getInitialHistoryType()
   )
@@ -115,18 +115,4 @@ const AlertHistoryIndex: FC<Props> = ({
   )
 }
 
-const mstp = (state: AppState) => {
-  const checkIDs = getCheckIDs(state)
-  const endpointIDs = getEndpointIDs(state)
-  const ruleIDs = getRuleIDs(state)
-
-  const resourceIDs = {
-    checkIDs,
-    endpointIDs,
-    ruleIDs,
-  }
-
-  return {resourceIDs}
-}
-
-export default connect<StateProps>(mstp)(AlertHistoryIndex)
+export default AlertHistoryIndex

--- a/src/authorizations/components/GenerateTokenDropdown.tsx
+++ b/src/authorizations/components/GenerateTokenDropdown.tsx
@@ -1,7 +1,6 @@
 // Libraries
 import React, {FC} from 'react'
-import {connect, ConnectedProps, useDispatch} from 'react-redux'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
+import {useDispatch} from 'react-redux'
 
 // Components
 import {Dropdown} from '@influxdata/clockface'
@@ -17,14 +16,7 @@ import {getResourcesTokensFailure} from 'src/shared/copy/notifications'
 // Utils
 import {event} from 'src/cloud/utils/reporting'
 
-type GenerateTokenProps = RouteComponentProps
-type ReduxProps = ConnectedProps<typeof connector>
-
-const GenerateTokenDropdown: FC<ReduxProps & GenerateTokenProps> = ({
-  showOverlay,
-  dismissOverlay,
-  getAllResources,
-}) => {
+const GenerateTokenDropdown: FC = () => {
   const dispatch = useDispatch()
   const allAccessOption = 'All Access API Token'
 
@@ -32,8 +24,8 @@ const GenerateTokenDropdown: FC<ReduxProps & GenerateTokenProps> = ({
 
   const handleAllAccess = async () => {
     try {
-      await getAllResources()
-      showOverlay('add-master-token', null, dismissOverlay)
+      await dispatch(getAllResources())
+      dispatch(showOverlay('add-master-token', null, dispatch(dismissOverlay)))
       event('generate_token_dropdown.all_access_overlay.opened')
     } catch (e) {
       dispatch(notify(getResourcesTokensFailure('all access token')))
@@ -43,8 +35,8 @@ const GenerateTokenDropdown: FC<ReduxProps & GenerateTokenProps> = ({
 
   const handleCustomApi = async () => {
     try {
-      await getAllResources()
-      showOverlay('add-custom-token', null, dismissOverlay)
+      await dispatch(getAllResources())
+      dispatch(showOverlay('add-custom-token', null, dispatch(dismissOverlay)))
       event('generate_token_dropdown.custom_API_token_overlay.opened')
     } catch (e) {
       dispatch(notify(getResourcesTokensFailure('custom api token')))
@@ -102,12 +94,4 @@ const GenerateTokenDropdown: FC<ReduxProps & GenerateTokenProps> = ({
   )
 }
 
-const mdtp = {
-  showOverlay,
-  dismissOverlay,
-  getAllResources,
-}
-
-const connector = connect(null, mdtp)
-
-export default connector(withRouter(GenerateTokenDropdown))
+export default GenerateTokenDropdown

--- a/src/authorizations/components/TokenRow.tsx
+++ b/src/authorizations/components/TokenRow.tsx
@@ -1,8 +1,7 @@
 // Libraries
-import React, {createRef, PureComponent, RefObject} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
+import React, {createRef, FC, RefObject} from 'react'
+import {useSelector, useDispatch} from 'react-redux'
 import {createDateTimeFormatter} from 'src/utils/datetime/formatters'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Actions
 import {
@@ -42,157 +41,140 @@ import {relativeTimestampFormatter} from 'src/shared/utils/relativeTimestampForm
 import {incrementCloneName} from 'src/utils/naming'
 import {event} from 'src/cloud/utils/reporting'
 
-interface OwnProps {
+const formatter = createDateTimeFormatter(UPDATED_AT_TIME_FORMAT)
+
+interface Props {
   auth: Authorization
-  onClickDescription: (authID: string) => void
 }
 
-type ReduxProps = ConnectedProps<typeof connector>
+const ContextMenu: FC<Props> = ({auth}) => {
+  const dispatch = useDispatch()
+  const authorizations = useSelector(
+    (state: AppState) => state.resources.tokens.byID
+  )
 
-type Props = ReduxProps & OwnProps & RouteComponentProps<{orgID: string}>
-
-const formatter = createDateTimeFormatter(UPDATED_AT_TIME_FORMAT)
-class TokensRow extends PureComponent<Props> {
-  public render() {
-    const {description} = this.props.auth
-    const {auth} = this.props
-    const date = new Date(auth.createdAt)
-
-    return (
-      <ResourceCard
-        contextMenu={this.contextMenu}
-        disabled={!this.isTokenActive}
-        testID={`token-card ${auth.description}`}
-        direction={FlexDirection.Row}
-        justifyContent={JustifyContent.SpaceBetween}
-        alignItems={AlignItems.Center}
-        margin={ComponentSize.Large}
-      >
-        <FlexBox
-          alignItems={AlignItems.FlexStart}
-          direction={FlexDirection.Column}
-          margin={ComponentSize.Large}
-        >
-          <ResourceCard.EditableName
-            onUpdate={this.handleUpdateName}
-            onClick={this.handleClickDescription}
-            name={description}
-            noNameString={DEFAULT_TOKEN_DESCRIPTION}
-            testID={`token-name ${auth.description}`}
-          />
-          <ResourceCard.Meta>
-            <>Created at: {formatter.format(date)}</>
-            <>Owner: {auth.user}</>
-            <>Last Used: {relativeTimestampFormatter(auth.updatedAt)}</>
-          </ResourceCard.Meta>
-        </FlexBox>
-      </ResourceCard>
-    )
+  const handleDelete = () => {
+    dispatch(deleteAuthorization(auth.id, auth.description))
   }
 
-  private get contextMenu(): JSX.Element {
-    const settingsRef: RefObject<HTMLButtonElement> = createRef()
-
-    return (
-      <FlexBox margin={ComponentSize.ExtraSmall}>
-        <ConfirmationButton
-          color={ComponentColor.Colorless}
-          icon={IconFont.Trash_New}
-          shape={ButtonShape.Square}
-          size={ComponentSize.ExtraSmall}
-          confirmationLabel="Yes, delete this token"
-          onConfirm={this.handleDelete}
-          confirmationButtonText="Confirm"
-          testID="context-delete-menu"
-        />
-        <SquareButton
-          ref={settingsRef}
-          size={ComponentSize.ExtraSmall}
-          icon={IconFont.CogSolid_New}
-          color={ComponentColor.Colorless}
-          testID="context-menu-token"
-        />
-        <Popover
-          appearance={Appearance.Outline}
-          enableDefaultStyles={false}
-          style={{minWidth: '112px'}}
-          contents={() => (
-            <List>
-              <List.Item
-                onClick={this.handleClone}
-                size={ComponentSize.Small}
-                style={{fontWeight: 500}}
-                testID="context-clone-token"
-              >
-                Clone
-              </List.Item>
-            </List>
-          )}
-          triggerRef={settingsRef}
-        />
-      </FlexBox>
-    )
-  }
-
-  private get isTokenActive(): boolean {
-    const {auth} = this.props
-    return auth.status === 'active'
-  }
-
-  private handleDelete = () => {
-    const {id, description} = this.props.auth
-    this.props.deleteAuthorization(id, description)
-  }
-
-  private handleClone = async () => {
-    const {description} = this.props.auth
-    const allTokenDescriptions = Object.values(this.props.authorizations).map(
+  const handleClone = async () => {
+    const {description} = auth
+    const allTokenDescriptions = Object.values(authorizations).map(
       auth => auth.description
     )
 
     try {
-      await this.props.createAuthorization({
-        ...this.props.auth,
-        description: incrementCloneName(allTokenDescriptions, description),
-      })
-      event('token.clone.success', {id: this.props.auth.id, name: description})
-      this.props.showOverlay('access-cloned-token', null, () =>
-        dismissOverlay()
+      await dispatch(
+        createAuthorization({
+          ...auth,
+          description: incrementCloneName(allTokenDescriptions, description),
+        })
       )
+      event('token.clone.success', {id: auth.id, name: description})
+      dispatch(showOverlay('access-cloned-token', null, () => dismissOverlay()))
     } catch {
-      event('token.clone.failure', {id: this.props.auth.id, name: description})
+      event('token.clone.failure', {id: auth.id, name: description})
     }
   }
 
-  private handleClickDescription = () => {
-    const {onClickDescription, auth} = this.props
+  const settingsRef: RefObject<HTMLButtonElement> = createRef()
+
+  return (
+    <FlexBox margin={ComponentSize.ExtraSmall}>
+      <ConfirmationButton
+        color={ComponentColor.Colorless}
+        icon={IconFont.Trash_New}
+        shape={ButtonShape.Square}
+        size={ComponentSize.ExtraSmall}
+        confirmationLabel="Yes, delete this token"
+        onConfirm={handleDelete}
+        confirmationButtonText="Confirm"
+        testID="context-delete-menu"
+      />
+      <SquareButton
+        ref={settingsRef}
+        size={ComponentSize.ExtraSmall}
+        icon={IconFont.CogSolid_New}
+        color={ComponentColor.Colorless}
+        testID="context-menu-token"
+      />
+      <Popover
+        appearance={Appearance.Outline}
+        enableDefaultStyles={false}
+        style={{minWidth: '112px'}}
+        contents={() => (
+          <List>
+            <List.Item
+              onClick={handleClone}
+              size={ComponentSize.Small}
+              style={{fontWeight: 500}}
+              testID="context-clone-token"
+            >
+              Clone
+            </List.Item>
+          </List>
+        )}
+        triggerRef={settingsRef}
+      />
+    </FlexBox>
+  )
+}
+
+interface TokenProps {
+  onClickDescription: (authID: string) => void
+}
+
+export const TokenRow: FC<Props & TokenProps> = ({
+  auth,
+  onClickDescription,
+}) => {
+  const dispatch = useDispatch()
+
+  const handleClickDescription = () => {
     event('token_row.edit_overlay.opened')
     onClickDescription(auth.id)
   }
 
-  private handleUpdateName = (value: string) => {
-    const {auth, updateAuthorization} = this.props
-    updateAuthorization({...auth, description: value})
+  const handleUpdateName = (value: string) => {
+    dispatch(updateAuthorization({...auth, description: value}))
     event('token.desciption.edited', {
-      id: this.props.auth.id,
+      id: auth.id,
       description: value,
     })
   }
+  const {description} = auth
+  const date = new Date(auth.createdAt)
+
+  return (
+    <ResourceCard
+      contextMenu={<ContextMenu auth={auth} />}
+      disabled={auth.status !== 'active'}
+      testID={`token-card ${auth.description}`}
+      direction={FlexDirection.Row}
+      justifyContent={JustifyContent.SpaceBetween}
+      alignItems={AlignItems.Center}
+      margin={ComponentSize.Large}
+    >
+      <FlexBox
+        alignItems={AlignItems.FlexStart}
+        direction={FlexDirection.Column}
+        margin={ComponentSize.Large}
+      >
+        <ResourceCard.EditableName
+          onUpdate={handleUpdateName}
+          onClick={handleClickDescription}
+          name={description}
+          noNameString={DEFAULT_TOKEN_DESCRIPTION}
+          testID={`token-name ${auth.description}`}
+        />
+        <ResourceCard.Meta>
+          <>Created at: {formatter.format(date)}</>
+          <>Owner: {auth.user}</>
+          <>Last Used: {relativeTimestampFormatter(auth.updatedAt)}</>
+        </ResourceCard.Meta>
+      </FlexBox>
+    </ResourceCard>
+  )
 }
 
-const mstp = (state: AppState) => {
-  const authorizations = state.resources.tokens.byID
-  return {authorizations}
-}
-
-const mdtp = {
-  deleteAuthorization,
-  updateAuthorization,
-  createAuthorization,
-  showOverlay,
-  dismissOverlay,
-}
-
-const connector = connect(mstp, mdtp)
-
-export const TokenRow = connector(withRouter(TokensRow))
+export default TokenRow

--- a/src/buckets/components/BucketCard.tsx
+++ b/src/buckets/components/BucketCard.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC} from 'react'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
+import {useHistory, useParams} from 'react-router-dom'
 
 // Components
 import {ResourceCard} from '@influxdata/clockface'
@@ -26,16 +26,14 @@ interface Props {
   onFilterChange: (searchTerm: string) => void
 }
 
-const BucketCard: FC<Props & RouteComponentProps<{orgID: string}>> = ({
+const BucketCard: FC<Props> = ({
   bucket,
   onDeleteBucket,
   onFilterChange,
   onGetBucketSchema,
-  history,
-  match: {
-    params: {orgID},
-  },
 }) => {
+  const history = useHistory()
+  const {orgID} = useParams<{orgID: string}>()
   const handleNameClick = () => {
     if (isFlagEnabled('exploreWithFlows')) {
       history.push(`/${PROJECT_NAME.toLowerCase()}/from/bucket/${bucket.name}`)
@@ -70,4 +68,4 @@ const BucketCard: FC<Props & RouteComponentProps<{orgID: string}>> = ({
   )
 }
 
-export default withRouter(BucketCard)
+export default BucketCard

--- a/src/buckets/components/BucketCardActions.tsx
+++ b/src/buckets/components/BucketCardActions.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FC} from 'react'
-import {RouteComponentProps, withRouter} from 'react-router-dom'
-import {connect, ConnectedProps} from 'react-redux'
+import {useHistory} from 'react-router-dom'
+import {useDispatch} from 'react-redux'
 
 // Components
 import {
@@ -28,7 +28,7 @@ import {DataLoaderType} from 'src/types/dataLoaders'
 
 import {CLOUD} from 'src/shared/constants'
 
-interface OwnProps {
+interface Props {
   bucket: OwnBucket
   bucketType: 'user' | 'system'
   orgID: string
@@ -36,33 +36,26 @@ interface OwnProps {
   onGetSchema: (b: OwnBucket) => void
 }
 
-type ReduxProps = ConnectedProps<typeof connector>
-type RouterProps = RouteComponentProps<{orgID: string}>
-type Props = OwnProps & ReduxProps & RouterProps
-
 const BucketCardActions: FC<Props> = ({
   bucket,
   bucketType,
   orgID,
   onFilterChange,
   onGetSchema,
-  onAddBucketLabel,
-  onDeleteBucketLabel,
-  history,
-  onSetDataLoadersBucket,
-  onSetDataLoadersType,
-  setLocationOnDismiss,
 }) => {
+  const history = useHistory()
+  const dispatch = useDispatch()
+
   if (bucketType === 'system') {
     return null
   }
 
   const handleAddLabel = (label: Label) => {
-    onAddBucketLabel(bucket.id, label)
+    dispatch(addBucketLabel(bucket.id, label))
   }
 
   const handleRemoveLabel = (label: Label) => {
-    onDeleteBucketLabel(bucket.id, label)
+    dispatch(deleteBucketLabel(bucket.id, label))
   }
 
   const handleClickSettings = () => {
@@ -77,36 +70,36 @@ const BucketCardActions: FC<Props> = ({
   }
 
   const handleAddCollector = () => {
-    onSetDataLoadersBucket(orgID, bucket.name, bucket.id)
+    dispatch(setBucketInfo(orgID, bucket.name, bucket.id))
 
-    onSetDataLoadersType(DataLoaderType.Streaming)
-    setLocationOnDismiss(`/orgs/${orgID}/load-data/buckets`)
+    dispatch(setDataLoadersType(DataLoaderType.Streaming))
+    dispatch(setLocationOnDismiss(`/orgs/${orgID}/load-data/buckets`))
     history.push(`/orgs/${orgID}/load-data/telegrafs/new`)
   }
 
   const handleAddLineProtocol = () => {
-    onSetDataLoadersBucket(orgID, bucket.name, bucket.id)
+    dispatch(setBucketInfo(orgID, bucket.name, bucket.id))
 
     history.push(`/orgs/${orgID}/load-data/file-upload/lp`)
   }
 
   const handleCSVUploader = () => {
-    onSetDataLoadersBucket(orgID, bucket.name, bucket.id)
+    dispatch(setBucketInfo(orgID, bucket.name, bucket.id))
 
     history.push(`/orgs/${orgID}/load-data/file-upload/annotated_csv`)
   }
 
   const handleAddClientLibrary = (): void => {
-    onSetDataLoadersBucket(orgID, bucket.name, bucket.id)
-    onSetDataLoadersType(DataLoaderType.ClientLibrary)
+    dispatch(setBucketInfo(orgID, bucket.name, bucket.id))
+    dispatch(setDataLoadersType(DataLoaderType.ClientLibrary))
 
     history.push(`/orgs/${orgID}/load-data/`)
   }
 
   const handleAddScraper = () => {
-    onSetDataLoadersBucket(orgID, bucket.name, bucket.id)
+    dispatch(setBucketInfo(orgID, bucket.name, bucket.id))
 
-    onSetDataLoadersType(DataLoaderType.Scraping)
+    dispatch(setDataLoadersType(DataLoaderType.Scraping))
     history.push(`/orgs/${orgID}/load-data/buckets/${bucket.id}/scrapers/new`)
   }
 
@@ -153,14 +146,4 @@ const BucketCardActions: FC<Props> = ({
   )
 }
 
-const mdtp = {
-  onAddBucketLabel: addBucketLabel,
-  onDeleteBucketLabel: deleteBucketLabel,
-  onSetDataLoadersBucket: setBucketInfo,
-  onSetDataLoadersType: setDataLoadersType,
-  setLocationOnDismiss,
-}
-
-const connector = connect(null, mdtp)
-
-export default connector(withRouter(BucketCardActions))
+export default BucketCardActions

--- a/src/buckets/components/createBucketForm/UpdateBucketOverlay.tsx
+++ b/src/buckets/components/createBucketForm/UpdateBucketOverlay.tsx
@@ -7,8 +7,8 @@ import React, {
   FormEvent,
   useCallback,
 } from 'react'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect, ConnectedProps, useDispatch} from 'react-redux'
+import {useHistory, useParams} from 'react-router-dom'
+import {useDispatch} from 'react-redux'
 import {get} from 'lodash'
 
 // Components
@@ -58,25 +58,9 @@ if (CLOUD) {
     .MeasurementSchemaCreateRequest
 }
 
-interface DispatchProps {
-  onUpdateBucket: typeof updateBucket
-  getSchema: typeof getBucketSchema
-  onAddMeasurementSchemaToBucket: typeof addSchemaToBucket
-  updateSchema: typeof updateMeasurementSchema
-}
-
-type ReduxProps = ConnectedProps<typeof connector>
-type Props = ReduxProps & RouteComponentProps<{bucketID: string; orgID: string}>
-
-const UpdateBucketOverlay: FunctionComponent<Props> = ({
-  onUpdateBucket,
-  getSchema,
-  onAddMeasurementSchemaToBucket,
-  updateSchema,
-  match,
-  history,
-}) => {
-  const {orgID, bucketID} = match.params
+const UpdateBucketOverlay: FunctionComponent = () => {
+  const history = useHistory()
+  const {orgID, bucketID} = useParams<{bucketID: string; orgID: string}>()
   const dispatch = useDispatch()
   const [bucketDraft, setBucketDraft] = useState<OwnBucket>(null)
 
@@ -114,7 +98,7 @@ const UpdateBucketOverlay: FunctionComponent<Props> = ({
       setSchemaType(resp.data.schemaType)
 
       if ('explicit' === resp.data.schemaType) {
-        const schema = await getSchema(bucketID)
+        const schema = await dispatch(getBucketSchema(bucketID))
         setMeasurementSchemaList(schema)
       }
 
@@ -192,7 +176,7 @@ const UpdateBucketOverlay: FunctionComponent<Props> = ({
     e.preventDefault()
 
     if (isValid()) {
-      onUpdateBucket(bucketDraft)
+      dispatch(updateBucket(bucketDraft))
 
       if (newMeasurementSchemaRequests?.length) {
         newMeasurementSchemaRequests.forEach(item => {
@@ -202,11 +186,13 @@ const UpdateBucketOverlay: FunctionComponent<Props> = ({
           }
 
           event('bucket.schema.explicit.editing.uploadSchema')
-          onAddMeasurementSchemaToBucket(
-            bucketDraft.id,
-            bucketDraft.orgID,
-            bucketDraft.name,
-            createRequest
+          dispatch(
+            addSchemaToBucket(
+              bucketDraft.id,
+              bucketDraft.orgID,
+              bucketDraft.name,
+              createRequest
+            )
           )
         })
       }
@@ -219,7 +205,9 @@ const UpdateBucketOverlay: FunctionComponent<Props> = ({
             const {bucketID, id, name, orgID} = currentSchema
             const updateRequest = {columns}
             event('bucket.schema.explicit.editing.updateSchema')
-            updateSchema(bucketID, id, name, updateRequest, orgID)
+            dispatch(
+              updateMeasurementSchema(bucketID, id, name, updateRequest, orgID)
+            )
           })
       }
 
@@ -278,16 +266,4 @@ const UpdateBucketOverlay: FunctionComponent<Props> = ({
   )
 }
 
-const mdtp = {
-  onUpdateBucket: updateBucket,
-  getSchema: getBucketSchema,
-  onAddMeasurementSchemaToBucket: addSchemaToBucket,
-  updateSchema: updateMeasurementSchema,
-}
-
-const connector = connect(null, mdtp)
-
-export default connect<{}, DispatchProps>(
-  null,
-  mdtp
-)(withRouter(UpdateBucketOverlay))
+export default UpdateBucketOverlay

--- a/src/checks/components/CheckCard.tsx
+++ b/src/checks/components/CheckCard.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FC} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
+import {useParams, useHistory} from 'react-router-dom'
+import {useDispatch} from 'react-redux'
 
 // Components
 import {
@@ -47,59 +47,47 @@ import ErrorBoundary from 'src/shared/components/ErrorBoundary'
 import {event} from 'src/cloud/utils/reporting'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
-interface OwnProps {
+interface Props {
   check: Check
 }
 
-type ReduxProps = ConnectedProps<typeof connector>
-type Props = OwnProps & ReduxProps & RouteComponentProps<{orgID: string}>
-
-const CheckCard: FC<Props> = ({
-  onRemoveCheckLabel,
-  onAddCheckLabel,
-  onCloneCheck,
-  onNotify,
-  check,
-  onUpdateCheckDisplayProperties,
-  deleteCheck,
-  match: {
-    params: {orgID},
-  },
-  history,
-}) => {
+const CheckCard: FC<Props> = ({check}) => {
+  const dispatch = useDispatch()
+  const history = useHistory()
+  const {orgID} = useParams<{orgID: string}>()
   const {activeStatus, description, id, name, taskID} = check
 
   const onUpdateName = (name: string) => {
     try {
-      onUpdateCheckDisplayProperties(check.id, {name})
+      dispatch(updateCheckDisplayProperties(check.id, {name}))
     } catch (error) {
-      onNotify(updateCheckFailed(error.message))
+      dispatch(notify(updateCheckFailed(error.message)))
     }
   }
 
   const onUpdateDescription = (description: string) => {
     try {
-      onUpdateCheckDisplayProperties(check.id, {description})
+      dispatch(updateCheckDisplayProperties(check.id, {description}))
     } catch (e) {
-      onNotify(updateCheckFailed(e.message))
+      dispatch(notify(updateCheckFailed(e.message)))
     }
   }
 
   const onDelete = () => {
-    deleteCheck(check.id)
+    dispatch(deleteCheck(check.id))
   }
 
   const onClone = () => {
-    onCloneCheck(check)
+    dispatch(cloneCheck(check))
   }
 
   const onToggle = () => {
     const status = activeStatus === 'active' ? 'inactive' : 'active'
 
     try {
-      onUpdateCheckDisplayProperties(id, {status})
+      dispatch(updateCheckDisplayProperties(id, {status}))
     } catch (error) {
-      onNotify(updateCheckFailed(error.message))
+      dispatch(notify(updateCheckFailed(error.message)))
     }
   }
 
@@ -116,16 +104,16 @@ const CheckCard: FC<Props> = ({
   }
 
   const handleAddCheckLabel = (label: Label) => {
-    onAddCheckLabel(id, label)
+    dispatch(addCheckLabel(id, label))
   }
 
   const handleRemoveCheckLabel = (label: Label) => {
-    onRemoveCheckLabel(id, label.id)
+    dispatch(deleteCheckLabel(id, label.id))
   }
 
   const onEditTask = () => {
     history.push(`/orgs/${orgID}/tasks/${check.taskID}/edit`)
-    onNotify(editCheckCodeWarning())
+    dispatch(notify(editCheckCodeWarning()))
   }
 
   return (
@@ -211,15 +199,4 @@ const CheckCard: FC<Props> = ({
   )
 }
 
-const mdtp = {
-  onUpdateCheckDisplayProperties: updateCheckDisplayProperties,
-  deleteCheck: deleteCheck,
-  onAddCheckLabel: addCheckLabel,
-  onRemoveCheckLabel: deleteCheckLabel,
-  onCloneCheck: cloneCheck,
-  onNotify: notify,
-}
-
-const connector = connect(null, mdtp)
-
-export default connector(withRouter(CheckCard))
+export default CheckCard

--- a/src/checks/components/ChecksColumn.tsx
+++ b/src/checks/components/ChecksColumn.tsx
@@ -127,4 +127,4 @@ const mstp = (state: AppState) => {
 
 const connector = connect(mstp)
 
-export default ChecksColumn
+export default connector(ChecksColumn)

--- a/src/checks/components/ChecksColumn.tsx
+++ b/src/checks/components/ChecksColumn.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
+import {useHistory, useParams} from 'react-router-dom'
 import {connect, ConnectedProps} from 'react-redux'
 
 // Selectors
@@ -34,19 +34,17 @@ interface OwnProps {
 }
 
 type ReduxProps = ConnectedProps<typeof connector>
-type Props = OwnProps & ReduxProps & RouteComponentProps<{orgID: string}>
+type Props = OwnProps & ReduxProps
 
 const ChecksColumn: FunctionComponent<Props> = ({
   checks,
-  history,
-  match: {
-    params: {orgID},
-  },
   rules,
   endpoints,
   limitStatus,
   tabIndex,
 }) => {
+  const history = useHistory()
+  const {orgID} = useParams<{orgID: string}>()
   const handleCreateThreshold = () => {
     history.push(`/orgs/${orgID}/alerting/checks/new-threshold`)
   }
@@ -129,4 +127,4 @@ const mstp = (state: AppState) => {
 
 const connector = connect(mstp)
 
-export default connector(withRouter(ChecksColumn))
+export default ChecksColumn

--- a/src/checks/components/EditCheckEO.tsx
+++ b/src/checks/components/EditCheckEO.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent, useEffect} from 'react'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
+import {useHistory, useParams} from 'react-router-dom'
 import {connect, ConnectedProps, useDispatch} from 'react-redux'
 import {get} from 'lodash'
 
@@ -24,7 +24,7 @@ import {resetAlertBuilder, updateName} from 'src/alerting/actions/alertBuilder'
 import {AppState, RemoteDataState} from 'src/types'
 
 type ReduxProps = ConnectedProps<typeof connector>
-type Props = RouteComponentProps<{orgID: string; checkID: string}> & ReduxProps
+type Props = ReduxProps
 
 const EditCheckEditorOverlay: FunctionComponent<Props> = ({
   onUpdateAlertBuilderName,
@@ -32,14 +32,12 @@ const EditCheckEditorOverlay: FunctionComponent<Props> = ({
   onSaveCheckFromTimeMachine,
   activeTimeMachineID,
   status,
-  history,
-  match: {
-    params: {checkID, orgID},
-  },
   checkName,
   loadedCheckID,
   view,
 }) => {
+  const history = useHistory()
+  const {orgID, checkID} = useParams<{orgID: string; checkID: string}>()
   const dispatch = useDispatch()
   const query = get(view, 'properties.queries[0]', null)
 
@@ -116,4 +114,4 @@ const mdtp = {
 
 const connector = connect(mstp, mdtp)
 
-export default connector(withRouter(EditCheckEditorOverlay))
+export default connector(EditCheckEditorOverlay)

--- a/src/dashboards/components/DashboardHeader.tsx
+++ b/src/dashboards/components/DashboardHeader.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FC, useCallback, useContext} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
-import {RouteComponentProps, withRouter} from 'react-router-dom'
+import {useHistory} from 'react-router-dom'
 
 // Components
 import AutoRefreshDropdown from 'src/shared/components/dropdown_auto_refresh/AutoRefreshDropdown'
@@ -74,7 +74,7 @@ interface OwnProps {
 }
 
 type ReduxProps = ConnectedProps<typeof connector>
-type Props = OwnProps & ReduxProps & RouteComponentProps<{orgID: string}>
+type Props = OwnProps & ReduxProps
 
 const DashboardHeader: FC<Props> = ({
   dashboard,
@@ -86,13 +86,13 @@ const DashboardHeader: FC<Props> = ({
   updateDashboard,
   updateQueryParams,
   setDashboardTimeRange,
-  history,
   org,
   autoRefresh,
   resetAutoRefresh,
   showOverlay,
   dismissOverlay,
 }) => {
+  const history = useHistory()
   const handleAddNote = () => {
     history.push(`/orgs/${org.id}/dashboards/${dashboard.id}/notes/new`)
   }
@@ -320,4 +320,4 @@ const mdtp = {
 
 const connector = connect(mstp, mdtp)
 
-export default connector(withRouter(DashboardHeader))
+export default connector(DashboardHeader)

--- a/src/dashboards/components/EditVEO.tsx
+++ b/src/dashboards/components/EditVEO.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FunctionComponent, useEffect} from 'react'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect, ConnectedProps, useDispatch} from 'react-redux'
+import {useHistory, useParams} from 'react-router-dom'
+import {useSelector, useDispatch} from 'react-redux'
 import {get} from 'lodash'
 
 // Components
@@ -21,20 +21,17 @@ import {getActiveTimeMachine} from 'src/timeMachine/selectors'
 // Types
 import {AppState, RemoteDataState} from 'src/types'
 
-type ReduxProps = ConnectedProps<typeof connector>
-type Props = ReduxProps &
-  RouteComponentProps<{orgID: string; cellID: string; dashboardID: string}>
-
-const EditViewVEO: FunctionComponent<Props> = ({
-  activeTimeMachineID,
-  onSaveView,
-  onSetName,
-  match: {
-    params: {orgID, cellID, dashboardID},
-  },
-  history,
-  view,
-}) => {
+const EditViewVEO: FunctionComponent = () => {
+  const history = useHistory()
+  const {view} = useSelector(getActiveTimeMachine)
+  const {activeTimeMachineID} = useSelector(
+    (state: AppState) => state.timeMachines
+  )
+  const {dashboardID, cellID, orgID} = useParams<{
+    orgID: string
+    cellID: string
+    dashboardID: string
+  }>()
   const dispatch = useDispatch()
   useEffect(() => {
     // TODO split this up into "loadView" "setActiveTimeMachine"
@@ -50,7 +47,7 @@ const EditViewVEO: FunctionComponent<Props> = ({
 
   const handleSave = () => {
     try {
-      onSaveView(dashboardID)
+      dispatch(saveVEOView(dashboardID))
       handleClose()
     } catch (e) {}
   }
@@ -70,9 +67,9 @@ const EditViewVEO: FunctionComponent<Props> = ({
           loading={loadingState}
         >
           <VEOHeader
-            key={view && view.name}
-            name={view && view.name}
-            onSetName={onSetName}
+            key={view?.name}
+            name={view?.name}
+            onSetName={dispatch(setName)}
             onCancel={handleClose}
             onSave={handleSave}
           />
@@ -85,18 +82,4 @@ const EditViewVEO: FunctionComponent<Props> = ({
   )
 }
 
-const mstp = (state: AppState) => {
-  const {activeTimeMachineID} = state.timeMachines
-  const {view} = getActiveTimeMachine(state)
-
-  return {view, activeTimeMachineID}
-}
-
-const mdtp = {
-  onSetName: setName,
-  onSaveView: saveVEOView,
-}
-
-const connector = connect(mstp, mdtp)
-
-export default connector(withRouter(EditViewVEO))
+export default EditViewVEO

--- a/src/dashboards/components/GetTimeRange.tsx
+++ b/src/dashboards/components/GetTimeRange.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FC, useEffect} from 'react'
 import {useDispatch, useSelector} from 'react-redux'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
+import {useLocation, useParams} from 'react-router-dom'
 import {getTimeRange} from 'src/dashboards/selectors'
 
 // Actions
@@ -10,10 +10,10 @@ import {
   updateQueryParams,
 } from 'src/dashboards/actions/ranges'
 
-type Props = RouteComponentProps<{dashboardID: string}>
-
-const GetTimeRange: FC<Props> = ({location, match}: Props) => {
+const GetTimeRange: FC = () => {
   const dispatch = useDispatch()
+  const {dashboardID} = useParams<{dashboardID}>()
+  const location = useLocation()
   const timeRange = useSelector(getTimeRange)
   const isEditing = location.pathname.includes('edit')
   const isNew = location.pathname.includes('new')
@@ -24,7 +24,7 @@ const GetTimeRange: FC<Props> = ({location, match}: Props) => {
     }
 
     // TODO: map this to current contextID
-    dispatch(setDashboardTimeRange(match.params.dashboardID, timeRange))
+    dispatch(setDashboardTimeRange(dashboardID, timeRange))
     const {lower, upper} = timeRange
     dispatch(
       updateQueryParams({
@@ -32,9 +32,9 @@ const GetTimeRange: FC<Props> = ({location, match}: Props) => {
         upper,
       })
     )
-  }, [dispatch, isEditing, isNew, match.params.dashboardID, timeRange])
+  }, [dispatch, isEditing, isNew, dashboardID, timeRange])
 
   return <div />
 }
 
-export default withRouter(GetTimeRange)
+export default GetTimeRange

--- a/src/dashboards/components/NewVEO.tsx
+++ b/src/dashboards/components/NewVEO.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FunctionComponent, useEffect} from 'react'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect, ConnectedProps, useDispatch} from 'react-redux'
+import {useHistory, useParams} from 'react-router-dom'
+import {useSelector, useDispatch} from 'react-redux'
 import {get} from 'lodash'
 
 // Components
@@ -20,20 +20,13 @@ import {getActiveTimeMachine} from 'src/timeMachine/selectors'
 // Types
 import {AppState, RemoteDataState} from 'src/types'
 
-type ReduxProps = ConnectedProps<typeof connector>
-type Props = ReduxProps &
-  RouteComponentProps<{orgID: string; dashboardID: string}>
-
-const NewViewVEO: FunctionComponent<Props> = ({
-  activeTimeMachineID,
-  onSaveView,
-  onSetName,
-  match: {
-    params: {orgID, dashboardID},
-  },
-  history,
-  view,
-}) => {
+const NewViewVEO: FunctionComponent = () => {
+  const {activeTimeMachineID} = useSelector(
+    (state: AppState) => state.timeMachines
+  )
+  const {view} = useSelector(getActiveTimeMachine)
+  const history = useHistory()
+  const {orgID, dashboardID} = useParams<{orgID: string; dashboardID: string}>()
   const dispatch = useDispatch()
   useEffect(() => {
     dispatch(loadNewVEO())
@@ -45,7 +38,7 @@ const NewViewVEO: FunctionComponent<Props> = ({
 
   const handleSave = () => {
     try {
-      onSaveView(dashboardID)
+      dispatch(saveVEOView(dashboardID))
       handleClose()
     } catch (error) {
       console.error(error)
@@ -68,7 +61,7 @@ const NewViewVEO: FunctionComponent<Props> = ({
           <VEOHeader
             key={view && view.name}
             name={view && view.name}
-            onSetName={onSetName}
+            onSetName={dispatch(setName)}
             onCancel={handleClose}
             onSave={handleSave}
           />
@@ -81,18 +74,4 @@ const NewViewVEO: FunctionComponent<Props> = ({
   )
 }
 
-const mstp = (state: AppState) => {
-  const {activeTimeMachineID} = state.timeMachines
-  const {view} = getActiveTimeMachine(state)
-
-  return {view, activeTimeMachineID}
-}
-
-const mdtp = {
-  onSetName: setName,
-  onSaveView: saveVEOView,
-}
-
-const connector = connect(mstp, mdtp)
-
-export default connector(withRouter(NewViewVEO))
+export default NewViewVEO

--- a/src/dashboards/components/RouteToDashboardList.tsx
+++ b/src/dashboards/components/RouteToDashboardList.tsx
@@ -1,11 +1,10 @@
 import {FC} from 'react'
-import {RouteComponentProps} from 'react-router-dom'
+import {useHistory, useParams} from 'react-router-dom'
 
-const RouteToDashboardList: FC<RouteComponentProps<{orgID: string}>> = ({
-  history,
-  match,
-}) => {
-  history.push(`/orgs/${match.params.orgID}/dashboards-list`)
+const RouteToDashboardList: FC = () => {
+  const history = useHistory()
+  const {orgID} = useParams<{orgID: string}>()
+  history.push(`/orgs/${orgID}/dashboards-list`)
   return null
 }
 

--- a/src/dataExplorer/components/SaveAsButton.tsx
+++ b/src/dataExplorer/components/SaveAsButton.tsx
@@ -1,33 +1,28 @@
 // Libraries
-import React, {PureComponent} from 'react'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
+import React, {FC} from 'react'
+import {useLocation, useHistory} from 'react-router-dom'
 
 // Components
 import {IconFont, Button, ComponentColor} from '@influxdata/clockface'
 
-class SaveAsButton extends PureComponent<RouteComponentProps, {}> {
-  public render() {
-    return (
-      <>
-        <Button
-          icon={IconFont.Export_New}
-          text="Save As"
-          onClick={this.handleShowOverlay}
-          color={ComponentColor.Primary}
-          titleText="Save your query as a Dashboard Cell or a Task"
-          testID="save-query-as"
-        />
-      </>
-    )
+const SaveAsButton: FC = () => {
+  const {pathname} = useLocation()
+  const history = useHistory()
+  const handleShowOverlay = () => {
+    history.push(`${pathname}/save`)
   }
-
-  private handleShowOverlay = () => {
-    const {
-      location: {pathname},
-    } = this.props
-
-    this.props.history.push(`${pathname}/save`)
-  }
+  return (
+    <>
+      <Button
+        icon={IconFont.Export_New}
+        text="Save As"
+        onClick={handleShowOverlay}
+        color={ComponentColor.Primary}
+        titleText="Save your query as a Dashboard Cell or a Task"
+        testID="save-query-as"
+      />
+    </>
+  )
 }
 
-export default withRouter(SaveAsButton)
+export default SaveAsButton

--- a/src/homepageExperience/components/steps/CreateToken.tsx
+++ b/src/homepageExperience/components/steps/CreateToken.tsx
@@ -3,7 +3,6 @@ import React, {FC} from 'react'
 import CodeSnippet from 'src/shared/components/CodeSnippet'
 import {Button, ComponentColor, ComponentSize} from '@influxdata/clockface'
 import {connect, ConnectedProps, useDispatch, useSelector} from 'react-redux'
-import {RouteComponentProps, withRouter} from 'react-router-dom'
 
 // Selectors
 import {notify} from 'src/shared/actions/notifications'
@@ -22,7 +21,7 @@ type OwnProps = {
   wizardEventName: string
 }
 
-const CreateTokenComponent: FC<ReduxProps & RouteComponentProps & OwnProps> = ({
+const CreateTokenComponent: FC<ReduxProps & OwnProps> = ({
   showOverlay,
   dismissOverlay,
   getAllResources,
@@ -90,4 +89,4 @@ const mdtp = {
 }
 
 const connector = connect(null, mdtp)
-export const CreateToken = connector(withRouter(CreateTokenComponent))
+export const CreateToken = connector(CreateTokenComponent)

--- a/src/me/components/GettingStarted.tsx
+++ b/src/me/components/GettingStarted.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FunctionComponent, useState} from 'react'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect, ConnectedProps} from 'react-redux'
+import {useHistory} from 'react-router-dom'
+import {useSelector} from 'react-redux'
 
 // Components
 import {
@@ -15,16 +15,12 @@ import CollectorGraphic from 'src/me/graphics/CollectorGraphic'
 import DashboardingGraphic from 'src/me/graphics/DashboardingGraphic'
 import ExploreGraphic from 'src/me/graphics/ExploreGraphic'
 
-// Types
-import {AppState} from 'src/types'
-
 // Selectors
 import {getOrg} from 'src/organizations/selectors'
 
-type ReduxProps = ConnectedProps<typeof connector>
-type Props = RouteComponentProps & ReduxProps
-
-const GettingStarted: FunctionComponent<Props> = ({orgID, history}) => {
+const GettingStarted: FunctionComponent = () => {
+  const history = useHistory()
+  const {id: orgID} = useSelector(getOrg)
   const [loadDataAnimating, setLoadDataAnimation] = useState<boolean>(false)
   const handleLoadDataClick = (): void => {
     history.push(`/orgs/${orgID}/load-data/sources`)
@@ -127,13 +123,4 @@ const GettingStarted: FunctionComponent<Props> = ({orgID, history}) => {
   )
 }
 
-const mstp = (state: AppState) => {
-  const {id} = getOrg(state)
-  return {
-    orgID: id,
-  }
-}
-
-const connector = connect(mstp)
-
-export default withRouter(connector(GettingStarted))
+export default GettingStarted

--- a/src/notifications/endpoints/components/EditEndpointOverlay.tsx
+++ b/src/notifications/endpoints/components/EditEndpointOverlay.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FC} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
+import {useSelector, useDispatch} from 'react-redux'
+import {useParams, useHistory} from 'react-router-dom'
 
 // Constants
 import {getEndpointFailed} from 'src/shared/copy/notifications'
@@ -21,29 +21,29 @@ import {NotificationEndpoint, AppState, ResourceType} from 'src/types'
 // Utils
 import {getByID} from 'src/resources/selectors'
 
-type ReduxProps = ConnectedProps<typeof connector>
-type RouterProps = RouteComponentProps<{orgID: string; endpointID: string}>
-type Props = RouterProps & ReduxProps
-
-const EditEndpointOverlay: FC<Props> = ({
-  match,
-  history,
-  onUpdateEndpoint,
-  onNotify,
-  endpoint,
-}) => {
+const EditEndpointOverlay: FC = () => {
+  const dispatch = useDispatch()
+  const {orgID, endpointID} = useParams<{orgID: string; endpointID: string}>()
+  const endpoint = useSelector((state: AppState) =>
+    getByID<NotificationEndpoint>(
+      state,
+      ResourceType.NotificationEndpoints,
+      endpointID
+    )
+  )
+  const history = useHistory()
   const handleDismiss = () => {
-    history.push(`/orgs/${match.params.orgID}/alerting`)
+    history.push(`/orgs/${orgID}/alerting`)
   }
 
   if (!endpoint) {
-    onNotify(getEndpointFailed(match.params.endpointID))
+    dispatch(notify(getEndpointFailed(endpointID)))
     handleDismiss()
     return null
   }
 
   const handleEditEndpoint = (endpoint: NotificationEndpoint) => {
-    onUpdateEndpoint(endpoint)
+    dispatch(updateEndpoint(endpoint))
 
     handleDismiss()
   }
@@ -68,21 +68,4 @@ const EditEndpointOverlay: FC<Props> = ({
   )
 }
 
-const mdtp = {
-  onUpdateEndpoint: updateEndpoint,
-  onNotify: notify,
-}
-
-const mstp = (state: AppState, {match}: RouterProps) => {
-  const endpoint = getByID<NotificationEndpoint>(
-    state,
-    ResourceType.NotificationEndpoints,
-    match.params.endpointID
-  )
-
-  return {endpoint}
-}
-
-const connector = connect(mstp, mdtp)
-
-export default withRouter(connector(EditEndpointOverlay))
+export default EditEndpointOverlay

--- a/src/notifications/endpoints/components/EndpointCard.tsx
+++ b/src/notifications/endpoints/components/EndpointCard.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FC} from 'react'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect, ConnectedProps} from 'react-redux'
+import {useHistory, useParams} from 'react-router-dom'
+import {useDispatch} from 'react-redux'
 
 // Actions
 import {
@@ -38,29 +38,18 @@ import {NotificationEndpoint, Label, AlertHistoryType} from 'src/types'
 import {relativeTimestampFormatter} from 'src/shared/utils/relativeTimestampFormatter'
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
 
-interface OwnProps {
+interface Props {
   endpoint: NotificationEndpoint
 }
 
-type ReduxProps = ConnectedProps<typeof connector>
-type Props = OwnProps & RouteComponentProps<{orgID: string}> & ReduxProps
-
-const EndpointCard: FC<Props> = ({
-  history,
-  match: {
-    params: {orgID},
-  },
-  endpoint,
-  onUpdateEndpointProperties,
-  onCloneEndpoint,
-  onDeleteEndpoint,
-  onAddEndpointLabel,
-  onRemoveEndpointLabel,
-}) => {
+const EndpointCard: FC<Props> = ({endpoint}) => {
+  const dispatch = useDispatch()
+  const history = useHistory()
+  const {orgID} = useParams<{orgID: string}>()
   const {id, name, description, activeStatus} = endpoint
 
   const handleUpdateName = (name: string) => {
-    onUpdateEndpointProperties(id, {name})
+    dispatch(updateEndpointProperties(id, {name}))
   }
 
   const handleClick = () => {
@@ -69,7 +58,7 @@ const EndpointCard: FC<Props> = ({
 
   const handleToggle = () => {
     const toStatus = activeStatus === 'active' ? 'inactive' : 'active'
-    onUpdateEndpointProperties(id, {status: toStatus})
+    dispatch(updateEndpointProperties(id, {status: toStatus}))
   }
 
   const handleView = () => {
@@ -83,10 +72,10 @@ const EndpointCard: FC<Props> = ({
     history.push(`/orgs/${orgID}/alert-history?${queryParams}`)
   }
   const handleDelete = () => {
-    onDeleteEndpoint(id)
+    dispatch(deleteEndpoint(id))
   }
   const handleClone = () => {
-    onCloneEndpoint(endpoint)
+    dispatch(cloneEndpoint(endpoint))
   }
   const contextMenu = (
     <EndpointCardMenu
@@ -97,14 +86,14 @@ const EndpointCard: FC<Props> = ({
   )
 
   const handleAddEndpointLabel = (label: Label) => {
-    onAddEndpointLabel(id, label)
+    dispatch(addEndpointLabel(id, label))
   }
   const handleRemoveEndpointLabel = (label: Label) => {
-    onRemoveEndpointLabel(id, label.id)
+    dispatch(deleteEndpointLabel(id, label.id))
   }
 
   const handleUpdateDescription = (description: string) => {
-    onUpdateEndpointProperties(id, {description})
+    dispatch(updateEndpointProperties(id, {description}))
   }
 
   return (
@@ -161,14 +150,4 @@ const EndpointCard: FC<Props> = ({
   )
 }
 
-const mdtp = {
-  onDeleteEndpoint: deleteEndpoint,
-  onAddEndpointLabel: addEndpointLabel,
-  onRemoveEndpointLabel: deleteEndpointLabel,
-  onUpdateEndpointProperties: updateEndpointProperties,
-  onCloneEndpoint: cloneEndpoint,
-}
-
-const connector = connect(null, mdtp)
-
-export default connector(withRouter(EndpointCard))
+export default EndpointCard

--- a/src/notifications/endpoints/components/EndpointsColumn.tsx
+++ b/src/notifications/endpoints/components/EndpointsColumn.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FC} from 'react'
-import {connect} from 'react-redux'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
+import {useSelector} from 'react-redux'
+import {useHistory, useParams} from 'react-router-dom'
 
 // Components
 import {Button, IconFont, ComponentColor} from '@influxdata/clockface'
@@ -16,18 +16,18 @@ import {DOCS_URL_VERSION} from 'src/shared/constants/fluxFunctions'
 import {getAll} from 'src/resources/selectors'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
-interface StateProps {
-  endpoints: NotificationEndpoint[]
-}
-interface OwnProps {
+interface Props {
   tabIndex: number
 }
 
-type Props = OwnProps & RouteComponentProps<{orgID: string}> & StateProps
-
-const EndpointsColumn: FC<Props> = ({history, match, endpoints, tabIndex}) => {
+const EndpointsColumn: FC<Props> = ({tabIndex}) => {
+  const history = useHistory()
+  const endpoints = useSelector((state: AppState) =>
+    getAll<NotificationEndpoint>(state, ResourceType.NotificationEndpoints)
+  )
+  const {orgID} = useParams<{orgID: string}>()
   const handleOpenOverlay = () => {
-    const newRuleRoute = `/orgs/${match.params.orgID}/alerting/endpoints/new`
+    const newRuleRoute = `/orgs/${orgID}/alerting/endpoints/new`
     history.push(newRuleRoute)
   }
 
@@ -80,13 +80,4 @@ const EndpointsColumn: FC<Props> = ({history, match, endpoints, tabIndex}) => {
   )
 }
 
-const mstp = (state: AppState) => {
-  const endpoints = getAll<NotificationEndpoint>(
-    state,
-    ResourceType.NotificationEndpoints
-  )
-
-  return {endpoints}
-}
-
-export default connect<StateProps>(mstp)(withRouter(EndpointsColumn))
+export default EndpointsColumn

--- a/src/notifications/endpoints/components/NewEndpointOverlay.tsx
+++ b/src/notifications/endpoints/components/NewEndpointOverlay.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FC, useMemo} from 'react'
-import {connect, ConnectedProps} from 'react-redux'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
+import {useDispatch} from 'react-redux'
+import {useHistory, useParams} from 'react-router-dom'
 
 // Actions
 import {createEndpoint} from 'src/notifications/endpoints/actions/thunks'
@@ -16,18 +16,17 @@ import {NEW_ENDPOINT_DRAFT} from 'src/alerting/constants'
 import {NotificationEndpoint} from 'src/types'
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
 
-type ReduxProps = ConnectedProps<typeof connector>
-type Props = RouteComponentProps<{orgID: string}> & ReduxProps
-
-const NewRuleOverlay: FC<Props> = ({match, history, onCreateEndpoint}) => {
-  const {orgID} = match.params
+const NewRuleOverlay: FC = () => {
+  const history = useHistory()
+  const dispatch = useDispatch()
+  const {orgID} = useParams<{orgID: string}>()
 
   const handleDismiss = () => {
     history.push(`/orgs/${orgID}/alerting`)
   }
 
   const handleCreateEndpoint = (endpoint: NotificationEndpoint) => {
-    onCreateEndpoint(endpoint)
+    dispatch(createEndpoint(endpoint))
     handleDismiss()
   }
 
@@ -54,10 +53,4 @@ const NewRuleOverlay: FC<Props> = ({match, history, onCreateEndpoint}) => {
   )
 }
 
-const mdtp = {
-  onCreateEndpoint: createEndpoint,
-}
-
-const connector = connect(null, mdtp)
-
-export default connector(withRouter(NewRuleOverlay))
+export default NewRuleOverlay

--- a/src/notifications/rules/components/EditRuleOverlay.tsx
+++ b/src/notifications/rules/components/EditRuleOverlay.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FC} from 'react'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect, ConnectedProps} from 'react-redux'
+import {useParams, useHistory} from 'react-router-dom'
+import {useDispatch, useSelector} from 'react-redux'
 
 // Constants
 import {getNotificationRuleFailed} from 'src/shared/copy/notifications'
@@ -21,29 +21,29 @@ import {getByID} from 'src/resources/selectors'
 // Types
 import {NotificationRuleDraft, AppState, ResourceType} from 'src/types'
 
-type ReduxProps = ConnectedProps<typeof connector>
-type RouterProps = RouteComponentProps<{orgID: string; ruleID: string}>
-type Props = RouterProps & ReduxProps
-
-const EditRuleOverlay: FC<Props> = ({
-  match,
-  history,
-  stateRule,
-  onUpdateRule,
-  onNotify,
-}) => {
+const EditRuleOverlay: FC = () => {
+  const dispatch = useDispatch()
+  const history = useHistory()
+  const {orgID, ruleID} = useParams<{orgID: string; ruleID: string}>()
+  const stateRule = useSelector((state: AppState) =>
+    getByID<NotificationRuleDraft>(
+      state,
+      ResourceType.NotificationRules,
+      ruleID
+    )
+  )
   const handleDismiss = () => {
-    history.push(`/orgs/${match.params.orgID}/alerting`)
+    history.push(`/orgs/${orgID}/alerting`)
   }
 
   if (!stateRule) {
-    onNotify(getNotificationRuleFailed(match.params.ruleID))
+    dispatch(notify(getNotificationRuleFailed(ruleID)))
     handleDismiss()
     return null
   }
 
   const handleUpdateRule = async (rule: NotificationRuleDraft) => {
-    await onUpdateRule(rule)
+    await dispatch(updateRule(rule))
 
     handleDismiss()
   }
@@ -69,25 +69,4 @@ const EditRuleOverlay: FC<Props> = ({
   )
 }
 
-const mstp = (state: AppState, {match}: RouterProps) => {
-  const {ruleID} = match.params
-
-  const stateRule = getByID<NotificationRuleDraft>(
-    state,
-    ResourceType.NotificationRules,
-    ruleID
-  )
-
-  return {
-    stateRule,
-  }
-}
-
-const mdtp = {
-  onNotify: notify,
-  onUpdateRule: updateRule,
-}
-
-const connector = connect(mstp, mdtp)
-
-export default connector(withRouter(EditRuleOverlay))
+export default EditRuleOverlay

--- a/src/notifications/rules/components/RuleCard.tsx
+++ b/src/notifications/rules/components/RuleCard.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FC} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
+import {useHistory, useParams} from 'react-router-dom'
 
 // Components
 import {
@@ -52,7 +52,7 @@ interface OwnProps {
 }
 
 type ReduxProps = ConnectedProps<typeof connector>
-type Props = OwnProps & RouteComponentProps<{orgID: string}> & ReduxProps
+type Props = OwnProps & ReduxProps
 
 const RuleCard: FC<Props> = ({
   rule,
@@ -62,11 +62,9 @@ const RuleCard: FC<Props> = ({
   onNotify,
   onAddRuleLabel,
   onRemoveRuleLabel,
-  match: {
-    params: {orgID},
-  },
-  history,
 }) => {
+  const history = useHistory()
+  const {orgID} = useParams<{orgID: string}>()
   const {
     activeStatus,
     description,
@@ -222,4 +220,4 @@ const mdtp = {
 
 const connector = connect(null, mdtp)
 
-export default connector(withRouter(RuleCard))
+export default connector(RuleCard)

--- a/src/organizations/containers/NoOrgsPage.tsx
+++ b/src/organizations/containers/NoOrgsPage.tsx
@@ -1,16 +1,15 @@
 // Libraries
 import React, {FC} from 'react'
 import {FunnelPage, Button, ComponentColor} from '@influxdata/clockface'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect, ConnectedProps} from 'react-redux'
+import {useHistory} from 'react-router-dom'
+import {useSelector} from 'react-redux'
 
 // Types
 import {AppState} from 'src/types'
 
-type ReduxProps = ConnectedProps<typeof connector>
-type Props = ReduxProps & RouteComponentProps
-
-const NoOrgsPage: FC<Props> = ({history, me}) => {
+const NoOrgsPage: FC = () => {
+  const me = useSelector((state: AppState) => state.me)
+  const history = useHistory()
   const handleClick = () => {
     history.push('/signin')
   }
@@ -39,10 +38,4 @@ const NoOrgsPage: FC<Props> = ({history, me}) => {
   )
 }
 
-const mstp = ({me}: AppState) => {
-  return {me}
-}
-
-const connector = connect(mstp)
-
-export default connector(withRouter(NoOrgsPage))
+export default NoOrgsPage

--- a/src/overlays/components/RouteOverlay.tsx
+++ b/src/overlays/components/RouteOverlay.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC, Component, ComponentClass, useEffect} from 'react'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
+import {useHistory, useParams} from 'react-router-dom'
 import {useDispatch} from 'react-redux'
 import {OverlayID} from 'src/overlays/reducers/overlays'
 
@@ -11,7 +11,7 @@ import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
 // but it doesn't include params on an injected router upon route resolution
 
 export type OverlayDismissalWithRoute = (
-  history: RouteComponentProps['history'],
+  history: any,
   params: {[x: string]: string}
 ) => void
 
@@ -20,18 +20,21 @@ interface OwnProps {
   onClose: OverlayDismissalWithRoute
 }
 
-type OverlayHandlerProps = OwnProps & RouteComponentProps
+type OverlayHandlerProps = OwnProps
 
 const OverlayHandler: FC<OverlayHandlerProps> = props => {
-  const {overlayID, onClose, match, history} = props
+  const history = useHistory()
+  const params = useParams()
+
+  const {overlayID, onClose} = props
   const dispatch = useDispatch()
 
   useEffect(() => {
     const closer = () => {
-      onClose(history, match.params)
+      onClose(history, params)
     }
 
-    dispatch(showOverlay(overlayID, match.params, closer))
+    dispatch(showOverlay(overlayID, params, closer))
 
     return () => {
       dispatch(dismissOverlay())
@@ -41,7 +44,7 @@ const OverlayHandler: FC<OverlayHandlerProps> = props => {
   return null
 }
 
-const routedComponent = withRouter(OverlayHandler)
+const routedComponent = OverlayHandler
 
 export default routedComponent
 

--- a/src/pageLayout/components/OrgSwitcherItem.tsx
+++ b/src/pageLayout/components/OrgSwitcherItem.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FC} from 'react'
 import classnames from 'classnames'
-import {RouteComponentProps, withRouter} from 'react-router-dom'
+import {useHistory} from 'react-router-dom'
 
 // Components
 import {IconFont, Icon} from '@influxdata/clockface'
@@ -13,15 +13,10 @@ interface ComponentProps {
   onDismiss: () => void
 }
 
-type Props = ComponentProps & RouteComponentProps
+type Props = ComponentProps
 
-const OrgSwitcherItem: FC<Props> = ({
-  orgName,
-  selected,
-  onDismiss,
-  orgID,
-  history,
-}) => {
+const OrgSwitcherItem: FC<Props> = ({orgName, selected, onDismiss, orgID}) => {
+  const history = useHistory()
   const orgSwitcherItemClass = classnames('org-switcher--item', {
     'org-switcher--item__selected': selected,
   })
@@ -50,4 +45,4 @@ const OrgSwitcherItem: FC<Props> = ({
   )
 }
 
-export default withRouter(OrgSwitcherItem)
+export default OrgSwitcherItem

--- a/src/shared/components/cells/CellContext.tsx
+++ b/src/shared/components/cells/CellContext.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC, useRef, RefObject, useState} from 'react'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
+import {useHistory, useLocation} from 'react-router-dom'
 import {connect, ConnectedProps} from 'react-redux'
 import {get} from 'lodash'
 import classnames from 'classnames'
@@ -39,12 +39,10 @@ interface OwnProps {
 }
 
 type ReduxProps = ConnectedProps<typeof connector>
-type Props = OwnProps & ReduxProps & RouteComponentProps<{orgID: string}>
+type Props = OwnProps & ReduxProps
 
 const CellContext: FC<Props> = ({
   view,
-  history,
-  location,
   cell,
   onCloneCell,
   onDeleteCell,
@@ -54,6 +52,8 @@ const CellContext: FC<Props> = ({
   onShowOverlay,
   onDismissOverlay,
 }) => {
+  const history = useHistory()
+  const location = useLocation()
   const [popoverVisible, setPopoverVisibility] = useState<boolean>(false)
   const editNoteText = !!get(view, 'properties.note') ? 'Edit Note' : 'Add Note'
   const triggerRef: RefObject<HTMLButtonElement> = useRef<HTMLButtonElement>(
@@ -244,4 +244,4 @@ const mdtp = {
 
 const connector = connect(mstp, mdtp)
 
-export default withRouter(connector(CellContext))
+export default connector(CellContext)

--- a/src/shared/containers/RouteToOrg.tsx
+++ b/src/shared/containers/RouteToOrg.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FC, useEffect} from 'react'
-import {connect} from 'react-redux'
-import {RouteComponentProps} from 'react-router-dom'
+import {useSelector} from 'react-redux'
+import {useHistory} from 'react-router-dom'
 
 // Types
 import {AppState, Organization, ResourceType} from 'src/types'
@@ -10,14 +10,13 @@ import {AppState, Organization, ResourceType} from 'src/types'
 import {getAll} from 'src/resources/selectors'
 import {getOrg} from 'src/organizations/selectors'
 
-interface StateProps {
-  orgs: Organization[]
-  org: {id?: string}
-}
+const RouteToOrg: FC = () => {
+  const org = useSelector(getOrg)
+  const orgs = useSelector((state: AppState) =>
+    getAll<Organization>(state, ResourceType.Orgs)
+  )
 
-type Props = StateProps & RouteComponentProps
-
-const RouteToOrg: FC<Props> = ({orgs, history, org}) => {
+  const history = useHistory()
   useEffect(() => {
     if (!orgs || !orgs.length) {
       history.push(`/no-orgs`)
@@ -37,11 +36,4 @@ const RouteToOrg: FC<Props> = ({orgs, history, org}) => {
   return <></>
 }
 
-const mstp = (state: AppState) => {
-  const org = getOrg(state)
-  const orgs = getAll<Organization>(state, ResourceType.Orgs)
-
-  return {orgs, org}
-}
-
-export default connect<StateProps>(mstp)(RouteToOrg)
+export default RouteToOrg

--- a/src/variables/components/RenameVariableOverlay.tsx
+++ b/src/variables/components/RenameVariableOverlay.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {useContext, FC, memo} from 'react'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
 import {OverlayContext} from 'src/overlays/components/OverlayController'
 
 // Components
@@ -15,9 +14,7 @@ const effectedItems = (): string[] => {
   return ['Queries', 'Dashboards', 'Telegraf Configurations', 'Templates']
 }
 
-const RenameVariableOverlay: FC<RouteComponentProps<{
-  orgID: string
-}>> = () => {
+const RenameVariableOverlay: FC = () => {
   const {onClose} = useContext(OverlayContext)
 
   return (
@@ -33,4 +30,4 @@ const RenameVariableOverlay: FC<RouteComponentProps<{
   )
 }
 
-export default withRouter(memo(RenameVariableOverlay))
+export default memo(RenameVariableOverlay)

--- a/src/writeData/containers/TelegrafPluginsPage.tsx
+++ b/src/writeData/containers/TelegrafPluginsPage.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC, useEffect} from 'react'
-import {RouteComponentProps, useParams} from 'react-router-dom'
+import {useHistory, useParams} from 'react-router-dom'
 
 // Components
 import {Page} from '@influxdata/clockface'
@@ -32,13 +32,9 @@ type ParamsType = {
   [param: string]: string
 }
 
-const TelegrafPluginsPage: FC<RouteComponentProps<{orgID: string}>> = props => {
-  const {
-    history,
-    match: {
-      params: {orgID},
-    },
-  } = props
+const TelegrafPluginsPage: FC = () => {
+  const history = useHistory()
+  const {orgID} = useParams<{orgID: string}>()
   const {contentID} = useParams<ParamsType>()
   const {name = '', markdown = '', image = '', style = {}} =
     WRITE_DATA_TELEGRAF_PLUGINS.find(item => item.id === contentID) || {}


### PR DESCRIPTION
As part of a process to get us to React 18, we're going to need to do away with RouteComponentProps since it's deprecated in future versions of react-dom. This PR takes an initial slash at replacing all functional component instances where the history is passed in with `withRouter` wrapper instead of using the `useHistory` hook