### PR TITLE
feat(HelpBar): add content to payg support overlay

### DIFF
--- a/src/support/components/PayGSupportOverlay.tsx
+++ b/src/support/components/PayGSupportOverlay.tsx
@@ -128,16 +128,22 @@ const PayGSupportOverlay: FC<OwnProps> = () => {
                 indicator={DropdownItemType.None}
               />
             </Form.Element>
-            <Form.ValidationElement label="Description" required={true} value={input} validationFunc={handleValidation}>
-              {status => 
-              <TextArea
-                status={status}
-                rows={10}
-                testID="support-description--textarea"
-                name="description"
-                value={input}
-                onChange={handleInputChange}
-              />}
+            <Form.ValidationElement
+              label="Description"
+              required={true}
+              value={input}
+              validationFunc={handleValidation}
+            >
+              {status => (
+                <TextArea
+                  status={status}
+                  rows={10}
+                  testID="support-description--textarea"
+                  name="description"
+                  value={input}
+                  onChange={handleInputChange}
+                />
+              )}
             </Form.ValidationElement>
             <Overlay.Footer>
               <Button

--- a/src/support/components/PayGSupportOverlay.tsx
+++ b/src/support/components/PayGSupportOverlay.tsx
@@ -31,7 +31,7 @@ interface OwnProps {
 
 const PayGSupportOverlay: FC<OwnProps> = () => {
   const [severity, setSeverity] = useState('')
-  const [input, setInput] = useState('')
+  const [textInput, setTextInput] = useState('')
   const {onClose} = useContext(OverlayContext)
 
   const severityLevel = [
@@ -41,8 +41,13 @@ const PayGSupportOverlay: FC<OwnProps> = () => {
     '4 - Request',
   ]
 
+  const submitButtonStatus =
+    textInput.length && severity.length
+      ? ComponentStatus.Default
+      : ComponentStatus.Disabled
+
   const handleInputChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
-    setInput(e.target.value)
+    setTextInput(e.target.value)
   }
   const handleSubmit = (): void => {
     // submit support form
@@ -58,16 +63,9 @@ const PayGSupportOverlay: FC<OwnProps> = () => {
     }
 
     if (value.length >= 2500) {
-      return 'Must be 2500 characters or less'
+      return 'Must be 2500 characters or fewer'
     }
     return null
-  }
-
-  const submitButtonStatus = (): ComponentStatus => {
-    if (!input.length || !severity) {
-      return ComponentStatus.Disabled
-    }
-    return ComponentStatus.Default
   }
 
   const severityTip = (): JSX.Element => {
@@ -110,12 +108,12 @@ const PayGSupportOverlay: FC<OwnProps> = () => {
         to see if there is an outage impacting your region.
       </p>
       <ErrorBoundary>
-        <Overlay.Body>
-          <Form
-            onSubmit={handleSubmit}
-            action="https://influxdata--full.my.salesforce.com/servlet/servlet.WebToCase?encoding=UTF-8"
-            method={Method.Post}
-          >
+        <Form
+          onSubmit={handleSubmit}
+          action="https://influxdata--full.my.salesforce.com/servlet/servlet.WebToCase?encoding=UTF-8"
+          method={Method.Post}
+        >
+          <Overlay.Body>
             <Form.Element
               label="Severity"
               required={true}
@@ -131,7 +129,7 @@ const PayGSupportOverlay: FC<OwnProps> = () => {
             <Form.ValidationElement
               label="Description"
               required={true}
-              value={input}
+              value={textInput}
               validationFunc={handleValidation}
             >
               {status => (
@@ -140,29 +138,29 @@ const PayGSupportOverlay: FC<OwnProps> = () => {
                   rows={10}
                   testID="support-description--textarea"
                   name="description"
-                  value={input}
+                  value={textInput}
                   onChange={handleInputChange}
                 />
               )}
             </Form.ValidationElement>
-            <Overlay.Footer>
-              <Button
-                text="Cancel"
-                color={ComponentColor.Tertiary}
-                onClick={onClose}
-                type={ButtonType.Button}
-                testID="payg-contact-support--cancel"
-              />
-              <Button
-                text="Submit"
-                color={ComponentColor.Success}
-                type={ButtonType.Submit}
-                testID="payg-contact-support--submit"
-                status={submitButtonStatus()}
-              />
-            </Overlay.Footer>
-          </Form>
-        </Overlay.Body>
+          </Overlay.Body>
+          <Overlay.Footer>
+            <Button
+              text="Cancel"
+              color={ComponentColor.Tertiary}
+              onClick={onClose}
+              type={ButtonType.Button}
+              testID="payg-contact-support--cancel"
+            />
+            <Button
+              text="Submit"
+              color={ComponentColor.Success}
+              type={ButtonType.Submit}
+              testID="payg-contact-support--submit"
+              status={submitButtonStatus}
+            />
+          </Overlay.Footer>
+        </Form>
       </ErrorBoundary>
     </Overlay.Container>
   )

--- a/src/support/components/PayGSupportOverlay.tsx
+++ b/src/support/components/PayGSupportOverlay.tsx
@@ -5,6 +5,7 @@ import {
   Button,
   ButtonType,
   ComponentColor,
+  ComponentStatus,
   DropdownItemType,
   Form,
   Icon,
@@ -49,6 +50,24 @@ const PayGSupportOverlay: FC<OwnProps> = () => {
 
   const handleChangeSeverity = (severity): void => {
     setSeverity(severity)
+  }
+
+  const handleValidation = (value: string): string | null => {
+    if (value.trim() === '') {
+      return 'This field cannot be empty'
+    }
+
+    if (value.length >= 2500) {
+      return 'Must be 2500 characters or less'
+    }
+    return null
+  }
+
+  const submitButtonStatus = (): ComponentStatus => {
+    if (!input.length || !severity) {
+      return ComponentStatus.Disabled
+    }
+    return ComponentStatus.Default
   }
 
   const severityTip = (): JSX.Element => {
@@ -109,16 +128,17 @@ const PayGSupportOverlay: FC<OwnProps> = () => {
                 indicator={DropdownItemType.None}
               />
             </Form.Element>
-            <Form.Element label="Description" required={true}>
+            <Form.ValidationElement label="Description" required={true} value={input} validationFunc={handleValidation}>
+              {status => 
               <TextArea
+                status={status}
                 rows={10}
                 testID="support-description--textarea"
                 name="description"
-                maxLength={2500}
                 value={input}
                 onChange={handleInputChange}
-              />
-            </Form.Element>
+              />}
+            </Form.ValidationElement>
             <Overlay.Footer>
               <Button
                 text="Cancel"
@@ -132,6 +152,7 @@ const PayGSupportOverlay: FC<OwnProps> = () => {
                 color={ComponentColor.Success}
                 type={ButtonType.Submit}
                 testID="payg-contact-support--submit"
+                status={submitButtonStatus()}
               />
             </Overlay.Footer>
           </Form>

--- a/src/support/components/PayGSupportOverlay.tsx
+++ b/src/support/components/PayGSupportOverlay.tsx
@@ -1,7 +1,21 @@
-import React, {FC, useContext} from 'react'
+import React, {FC, ChangeEvent, useContext, useState} from 'react'
 
 // Components
-import {Overlay} from '@influxdata/clockface'
+import {
+  Button,
+  ButtonType,
+  ComponentColor,
+  DropdownItemType,
+  Form,
+  Icon,
+  IconFont,
+  Method,
+  Overlay,
+  QuestionMarkTooltip,
+  SelectDropdown,
+  TextArea,
+} from '@influxdata/clockface'
+import {SafeBlankLink} from 'src/utils/SafeBlankLink'
 
 // Contexts
 import {OverlayContext} from 'src/overlays/components/OverlayController'
@@ -9,23 +23,119 @@ import {OverlayContext} from 'src/overlays/components/OverlayController'
 // Types
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
 
+import './ContactSupport.scss'
 interface OwnProps {
   onClose: () => void
 }
 
 const PayGSupportOverlay: FC<OwnProps> = () => {
+  const [severity, setSeverity] = useState('')
+  const [input, setInput] = useState('')
   const {onClose} = useContext(OverlayContext)
 
+  const severityLevel = [
+    '1 - Critical',
+    '2 - High',
+    '3 - Standard',
+    '4 - Request',
+  ]
+
+  const handleInputChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    setInput(e.target.value)
+  }
+  const handleSubmit = (): void => {
+    // submit support form
+  }
+
+  const handleChangeSeverity = (severity): void => {
+    setSeverity(severity)
+  }
+
+  const severityTip = (): JSX.Element => {
+    const tooltipContent = (
+      <div>
+        Please refer to our severity levels in our
+        <SafeBlankLink href="https://www.influxdata.com/legal/support-policy">
+          {' '}
+          support policy{' '}
+        </SafeBlankLink>
+        website
+      </div>
+    )
+    return (
+      <QuestionMarkTooltip
+        diameter={14}
+        tooltipContents={tooltipContent}
+        tooltipStyle={{fontSize: '13px'}}
+        style={{marginLeft: '420px'}}
+      />
+    )
+  }
+
   return (
-    <Overlay.Container maxWidth={500}>
+    <Overlay.Container maxWidth={550}>
       <Overlay.Header
         testID="payg-support-overlay-header"
         title="Contact Support"
         onDismiss={onClose}
       />
-
+      <p className="status-page-text">
+        <span>
+          {' '}
+          <Icon glyph={IconFont.Info_New} />{' '}
+        </span>
+        Check our{' '}
+        <SafeBlankLink href="https://status.influxdata.com">
+          status page
+        </SafeBlankLink>{' '}
+        to see if there is an outage impacting your region.
+      </p>
       <ErrorBoundary>
-        <Overlay.Body></Overlay.Body>
+        <Overlay.Body>
+          <Form
+            onSubmit={handleSubmit}
+            action="https://influxdata--full.my.salesforce.com/servlet/servlet.WebToCase?encoding=UTF-8"
+            method={Method.Post}
+          >
+            <Form.Element
+              label="Severity"
+              required={true}
+              labelAddOn={severityTip}
+            >
+              <SelectDropdown
+                options={severityLevel}
+                selectedOption={severity}
+                onSelect={handleChangeSeverity}
+                indicator={DropdownItemType.None}
+              />
+            </Form.Element>
+            <Form.Element label="Description" required={true}>
+              <TextArea
+                rows={10}
+                testID="support-description--textarea"
+                name="description"
+                maxLength={2500}
+                value={input}
+                onChange={handleInputChange}
+              />
+            </Form.Element>
+            <Overlay.Footer>
+              <Button
+                text="Cancel"
+                color={ComponentColor.Tertiary}
+                onClick={onClose}
+                type={ButtonType.Button}
+                testID="payg-contact-support--cancel"
+              />
+              <Button
+                text="Submit"
+                color={ComponentColor.Success}
+                type={ButtonType.Submit}
+                testID="payg-contact-support--submit"
+              />
+            </Overlay.Footer>
+          </Form>
+        </Overlay.Body>
       </ErrorBoundary>
     </Overlay.Container>
   )


### PR DESCRIPTION
Closes #3452 

pr adds the following to the payg support overlay

- A status page link is displayed at the top of the modal with verbiage

- Severity dropdown, with description values in dropdown (with integers assigned behind those values)

- A Tooltip is displayed next to severity dropdown to provide a link to the support policy website for definitions of severity.

- Description, a text field with a limit of 2500 characters.


https://user-images.githubusercontent.com/66275100/163423777-bf7d3acf-20c5-412e-8db9-bbef534abce2.mov



