### PR TITLE
chore(sub): handle errors from GET and DELETE endpoints

### DIFF
--- a/src/shared/copy/notifications/categories/subscriptions.ts
+++ b/src/shared/copy/notifications/categories/subscriptions.ts
@@ -16,3 +16,13 @@ export const subscriptionStatusUpdateFail = (): Notification => ({
   ...defaultErrorNotification,
   message: `Failed to update Subscription status, please try again.`,
 })
+
+export const subscriptionsGetFail = (): Notification => ({
+  ...defaultErrorNotification,
+  message: `Failed to get Subscriptions, please try again.`,
+})
+
+export const subscriptionsDeleteFail = (): Notification => ({
+  ...defaultErrorNotification,
+  message: `Failed to delete the Subscription, please try again.`,
+})

--- a/src/writeData/subscriptions/components/SubscriptionsLanding.tsx
+++ b/src/writeData/subscriptions/components/SubscriptionsLanding.tsx
@@ -95,9 +95,12 @@ const SubscriptionsLanding: FC = () => {
       className="subscriptions-landing"
       titleTag={pageTitleSuffixer(['Cloud Native Subscriptions', 'Load Data'])}
     >
-      <SpinnerContainer spinnerComponent={<TechnoSpinner />} loading={loading}>
-        <LoadDataHeader />
-        <LoadDataTabbedPage activeTab="subscriptions">
+      <LoadDataHeader />
+      <LoadDataTabbedPage activeTab="subscriptions">
+        <SpinnerContainer
+          spinnerComponent={<TechnoSpinner />}
+          loading={loading}
+        >
           <Page.ControlBar fullWidth={true}>
             <Page.ControlBarLeft>
               <SearchWidget
@@ -141,8 +144,8 @@ const SubscriptionsLanding: FC = () => {
           ) : (
             <EmptySubscriptionState />
           )}
-        </LoadDataTabbedPage>
-      </SpinnerContainer>
+        </SpinnerContainer>
+      </LoadDataTabbedPage>
     </Page>
   )
 }

--- a/src/writeData/subscriptions/context/subscription.list.tsx
+++ b/src/writeData/subscriptions/context/subscription.list.tsx
@@ -1,8 +1,14 @@
 // Libraries
 import React, {FC, useCallback, useEffect, useState} from 'react'
+import {useDispatch} from 'react-redux'
 
 // Utils
 import {deleteAPI, getAllAPI} from 'src/writeData/subscriptions/context/api'
+import {notify} from 'src/shared/actions/notifications'
+import {
+  subscriptionsDeleteFail,
+  subscriptionsGetFail,
+} from 'src/shared/copy/notifications'
 
 // Types
 import {Subscription} from 'src/types/subscriptions'
@@ -36,19 +42,30 @@ export const SubscriptionListProvider: FC = ({children}) => {
   const [loading, setLoading] = useState<RemoteDataState>(
     RemoteDataState.NotStarted
   )
+  const dispatch = useDispatch()
   const getAll = useCallback(async (): Promise<void> => {
     setLoading(RemoteDataState.Loading)
-    const data = await getAllAPI()
-    if (Array.isArray(data)) {
-      setSubscriptions(data)
+    try {
+      const data = await getAllAPI()
+      if (Array.isArray(data)) {
+        setSubscriptions(data)
+      }
+    } catch (err) {
+      dispatch(notify(subscriptionsGetFail()))
+    } finally {
+      setLoading(RemoteDataState.Done)
     }
-    setLoading(RemoteDataState.Done)
   }, [])
   const deleteSubscription = async (id: string): Promise<void> => {
     setLoading(RemoteDataState.Loading)
-    await deleteAPI(id)
-    setSubscriptions(subscriptions.filter(s => s.id !== id))
-    setLoading(RemoteDataState.Done)
+    try {
+      await deleteAPI(id)
+      setSubscriptions(subscriptions.filter(s => s.id !== id))
+    } catch (err) {
+      dispatch(notify(subscriptionsDeleteFail()))
+    } finally {
+      setLoading(RemoteDataState.Done)
+    }
   }
   const change = useCallback(
     async (id: string): Promise<void> => {


### PR DESCRIPTION
Closes https://github.com/influxdata/data-acquisition/issues/261

If errors are thrown from GET or DELETE endpoints, we should show a notification and disable the loader. Also moves the loading spinner inside the tabs, rather than the whole page. 

<img width="908" alt="image" src="https://user-images.githubusercontent.com/6411855/163284936-414b6173-bcad-4e4c-8542-e1a3133cdc45.png">
