### PR TITLE
fix: InitalizeClient code snippet for python

### DIFF
--- a/src/homepageExperience/components/steps/python/InitalizeClient.tsx
+++ b/src/homepageExperience/components/steps/python/InitalizeClient.tsx
@@ -18,9 +18,9 @@ export const InitalizeClient = () => {
   const url =
     me.quartzMe?.clusterHost || 'https://us-west-2-1.aws.cloud2.influxdata.com/'
 
-  const pythonCode = `import os
+  const pythonCode = `import influxdb_client, os, time
 from influxdb_client import InfluxDBClient, Point, WritePrecision
-from influxdb_client.client import SYNCHRONOUS
+from influxdb_client.client.write_api import SYNCHRONOUS
 
 token = os.environ.get("INFLUXDB_TOKEN")
 org = "${org.name}"


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/4402

Need to update the code snippet so that it that works. The previous one is missing or has incorrect import statements.

Figma says the code should be : 
<img width="838" alt="Screen Shot 2022-04-13 at 5 24 07 PM" src="https://user-images.githubusercontent.com/18511823/163291741-315b319c-4540-4c68-baad-bbc1bc2dbde8.png">

After fix the code snippet says this (identical to the latest figma) : 
<img width="960" alt="Screen Shot 2022-04-13 at 5 38 43 PM" src="https://user-images.githubusercontent.com/18511823/163291734-450f1cc6-fb23-432e-8597-690543c76e33.png">



<!-- Describe your proposed changes here. -->
