### PR TITLE
test: split dashboardsView into two files

### DIFF
--- a/cypress/e2e/shared/dashboardsVariables.test.ts
+++ b/cypress/e2e/shared/dashboardsVariables.test.ts
@@ -138,7 +138,7 @@ describe('Dashboard - variable interactions', () => {
     const mapTypeVarIndex = 2
 
     cy.get('@org').then(({id: orgID}: Organization) => {
-      cy.get<Dashboard>('@dashboard').then(({dashboard}) => {
+      cy.get<Dashboard>('@dashboard').then(dashboard => {
         cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
           cy.createCSVVariable(orgID, bucketVarName, [
             bucketOne,
@@ -184,7 +184,7 @@ describe('Dashboard - variable interactions', () => {
           ).should('have.value', bucketOne)
 
           cy.window()
-            .pipe(getSelectedVariable(dashboard.id, 0))
+            .pipe(getSelectedVariable(dashboard.id || '', 0))
             .should('equal', bucketOne)
 
           // testing variable controls
@@ -214,7 +214,7 @@ describe('Dashboard - variable interactions', () => {
           ).should('have.value', bucketThree)
 
           cy.window()
-            .pipe(getSelectedVariable(dashboard.id, 0))
+            .pipe(getSelectedVariable(dashboard.id || '', 0))
             .should('equal', bucketThree)
 
           // and that it updates the variable in the URL
@@ -298,7 +298,7 @@ describe('Dashboard - variable interactions', () => {
 
           // selected value in cell context is 2nd value (making sure it reverts back!)
           cy.window()
-            .pipe(getSelectedVariable(dashboard.id, 0))
+            .pipe(getSelectedVariable(dashboard.id || '', 0))
             .should('equal', bucket5)
 
           cy.getByTestID('toolbar-tab').click()
@@ -324,7 +324,7 @@ describe('Dashboard - variable interactions', () => {
 
           // selected value in cell context is 1st value
           cy.window()
-            .pipe(getSelectedVariable(dashboard.id, 0))
+            .pipe(getSelectedVariable(dashboard.id || '', 0))
             .should('equal', bucketOne)
 
           // selected value in dashboard is 1st value
@@ -333,7 +333,7 @@ describe('Dashboard - variable interactions', () => {
           ).should('have.value', bucketOne)
 
           cy.window()
-            .pipe(getSelectedVariable(dashboard.id, 0))
+            .pipe(getSelectedVariable(dashboard.id || '', 0))
             .should('equal', bucketOne)
 
           // TESTING MAP VARIABLE
@@ -342,7 +342,7 @@ describe('Dashboard - variable interactions', () => {
             `variable-dropdown-input-typeAhead--${mapTypeVarName}`
           ).should('have.value', 'k1')
           cy.window()
-            .pipe(getSelectedVariable(dashboard.id, 2))
+            .pipe(getSelectedVariable(dashboard.id || '', 2))
             .should('equal', 'v1')
 
           // select 2nd value in dashboard
@@ -356,7 +356,7 @@ describe('Dashboard - variable interactions', () => {
             `variable-dropdown-input-typeAhead--${mapTypeVarName}`
           ).should('have.value', 'k2')
           cy.window()
-            .pipe(getSelectedVariable(dashboard.id, 2))
+            .pipe(getSelectedVariable(dashboard.id || '', 2))
             .should('equal', 'v2')
 
           // open VEO
@@ -368,7 +368,7 @@ describe('Dashboard - variable interactions', () => {
 
           // selected value in cell context is 2nd value
           cy.window()
-            .pipe(getSelectedVariable(dashboard.id, 2))
+            .pipe(getSelectedVariable(dashboard.id || '', 2))
             .should('equal', 'v2')
 
           cy.getByTestID('toolbar-tab').click()
@@ -388,7 +388,7 @@ describe('Dashboard - variable interactions', () => {
 
           // selected value in cell context is 1st value
           cy.window()
-            .pipe(getSelectedVariable(dashboard.id, 2))
+            .pipe(getSelectedVariable(dashboard.id || '', 2))
             .should('equal', 'v1')
 
           // selected value in dashboard is 1st value
@@ -396,7 +396,7 @@ describe('Dashboard - variable interactions', () => {
             `variable-dropdown-input-typeAhead--${mapTypeVarName}`
           ).should('have.value', 'k1')
           cy.window()
-            .pipe(getSelectedVariable(dashboard.id, 2))
+            .pipe(getSelectedVariable(dashboard.id || '', 2))
             .should('equal', 'v1')
 
           cy.getByTestID('cell-context--toggle')

--- a/cypress/e2e/shared/dashboardsVariables.test.ts
+++ b/cypress/e2e/shared/dashboardsVariables.test.ts
@@ -449,7 +449,7 @@ describe('Dashboard - variable interactions', () => {
     const bucketVarIndex = 0
 
     cy.get('@org').then(({id: orgID}: Organization) => {
-      cy.get<Dashboard>('@dashboard').then((dashboard) => {
+      cy.get<Dashboard>('@dashboard').then(dashboard => {
         cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
           cy.createCSVVariable(orgID, bucketVarName, [
             bucketOne,

--- a/cypress/e2e/shared/dashboardsVariables.test.ts
+++ b/cypress/e2e/shared/dashboardsVariables.test.ts
@@ -449,7 +449,7 @@ describe('Dashboard - variable interactions', () => {
     const bucketVarIndex = 0
 
     cy.get('@org').then(({id: orgID}: Organization) => {
-      cy.get<Dashboard>('@dashboard').then(({dashboard}) => {
+      cy.get<Dashboard>('@dashboard').then((dashboard) => {
         cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
           cy.createCSVVariable(orgID, bucketVarName, [
             bucketOne,

--- a/cypress/e2e/shared/dashboardsVariables.test.ts
+++ b/cypress/e2e/shared/dashboardsVariables.test.ts
@@ -1,0 +1,901 @@
+import {Organization, AppState, Dashboard} from '../../../src/types'
+import {points} from '../../support/commands'
+
+const getSelectedVariable = (contextID: string, index: number) => (
+  win: any
+) => {
+  const state = win.store.getState() as AppState
+  const defaultVarOrder = state.resources.variables.allIDs
+  const defaultVarDawg =
+    state.resources.variables.byID[defaultVarOrder[index]] || {}
+  const filledVarDawg =
+    (state.resources.variables.values[contextID] || {values: {}}).values[
+      defaultVarOrder[index]
+    ] || {}
+
+  const hydratedVarDawg = {
+    ...defaultVarDawg,
+    ...filledVarDawg,
+  }
+
+  if (hydratedVarDawg.arguments.type === 'map') {
+    if (!hydratedVarDawg.selected) {
+      hydratedVarDawg.selected = [
+        Object.keys(hydratedVarDawg.arguments.values)[0],
+      ]
+    }
+
+    return hydratedVarDawg.arguments.values[hydratedVarDawg.selected[0]]
+  }
+
+  if (!hydratedVarDawg.selected) {
+    hydratedVarDawg.selected = [hydratedVarDawg.arguments.values[0]]
+  }
+
+  return hydratedVarDawg.selected[0]
+}
+
+describe('Dashboard - variable interactions', () => {
+  beforeEach(() => {
+    cy.flush()
+    cy.signin()
+    cy.fixture('routes').then(({orgs}) => {
+      cy.get('@org').then(({id: orgID}: Organization) => {
+        cy.visit(`${orgs}/${orgID}/dashboards-list`)
+        const numLines = 360
+        cy.writeData(points(numLines))
+        cy.createDashboard(orgID).then(({body: dashboard}) => {
+          cy.wrap({dashboard}).as('dashboard')
+        })
+      })
+    })
+  })
+
+  it('informs user if variables are enabled but not defined', () => {
+    cy.get<Organization>('@org').then(({id: orgID}: Organization) => {
+      cy.createDashWithViewAndVar(orgID).then(() => {
+        cy.get<string>('@defaultBucket').then(defaultBucket => {
+          cy.createCSVVariable(orgID, 'CSVVar', [
+            'FirstVar',
+            defaultBucket,
+            'SecondVar',
+          ])
+
+          cy.fixture('routes').then(({orgs, dashboards}) => {
+            cy.visit(`${orgs}/${orgID}${dashboards}/`)
+            cy.getByTestID('tree-nav')
+          })
+        })
+      })
+    })
+
+    // Select second dashboard card
+    cy.getByTestID('page-contents').within(() => {
+      cy.get('[data-testid="dashboard-card"]')
+        .eq(1)
+        .within(() => {
+          cy.getByTestID('dashboard-card--name').click()
+        })
+    })
+
+    // No defined variables
+    // Toggle off
+    cy.getByTestID('variables--button').click()
+    cy.getByTestID('variables-control-bar').should('not.exist')
+
+    // Toggle on
+    cy.getByTestID('variables--button').click()
+    cy.getByTestID('variables-control-bar')
+      .should('exist')
+      .and(
+        'contain',
+        "This dashboard doesn't have any cells with defined variables. Learn How"
+      )
+
+    // create query with variable
+    cy.getByTestID('cell-context--toggle').click()
+    cy.getByTestID('popover--contents')
+      .contains('Configure')
+      .click()
+    cy.getByTestID('buckets-list')
+      .contains('defbuck')
+      .click()
+    cy.getByTestID('selector-list m').click()
+    cy.getByTestID('selector-list v').click()
+    cy.getByTestID('selector-list tv1').click()
+    cy.getByTestID('switch-to-script-editor').click()
+    cy.getByTestID('flux-editor').should('exist')
+    cy.get('[class="view-line"]')
+      .last()
+      .type('v.CSVVar')
+    cy.getByTestID('save-cell--button').click()
+
+    // With variables
+    // Toggle off
+    cy.getByTestID('variables--button').click()
+    cy.getByTestID('variables-control-bar').should('not.exist')
+
+    // Toggle on
+    cy.getByTestID('variables--button').click()
+    cy.getByTestID('variables-control-bar')
+      .should('exist')
+      .and(
+        'not.contain',
+        "This dashboard doesn't have any cells with defined variables. Learn How"
+      )
+    cy.getByTestID('variable-dropdown--CSVVar').should('exist')
+  })
+
+  it('can manage variable state with a lot of pointing and clicking', () => {
+    const bucketOne = 'b1'
+    const bucketThree = 'b3'
+    const bucketVarName = 'bucketsCSV'
+    const bucket4 = 'anotherBucket'
+    const bucket5 = 'randomBucket'
+
+    const mapTypeVarName = 'mapTypeVar'
+    const bucketVarIndex = 0
+    const mapTypeVarIndex = 2
+
+    cy.get('@org').then(({id: orgID}: Organization) => {
+      cy.get<Dashboard>('@dashboard').then(({dashboard}) => {
+        cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
+          cy.createCSVVariable(orgID, bucketVarName, [
+            bucketOne,
+            defaultBucket,
+            bucketThree,
+            bucket4,
+            bucket5,
+          ])
+
+          cy.createQueryVariable(orgID)
+          cy.createMapVariable(orgID)
+          cy.fixture('routes').then(({orgs}) => {
+            cy.visit(`${orgs}/${orgID}/dashboards/${dashboard.id}`)
+            cy.getByTestID('tree-nav')
+          })
+          // add cell with variable in its query
+          cy.getByTestID('add-cell--button').click()
+          cy.getByTestID('switch-to-script-editor').should('be.visible')
+          cy.getByTestID('switch-to-script-editor').click()
+          cy.getByTestID('toolbar-tab').click()
+          cy.getByTestID('flux-editor').should('be.visible')
+          // check to see if the default timeRange variables are available
+          cy.get('.flux-toolbar--list-item').contains('timeRangeStart')
+          cy.get('.flux-toolbar--list-item').contains('timeRangeStop')
+
+          cy.get('.flux-toolbar--list-item')
+            .eq(bucketVarIndex)
+            .within(() => {
+              cy.get('.cf-button').click()
+            })
+          cy.getByTestID('flux-editor').monacoType(' ')
+          cy.getByTestID('save-cell--button').click()
+
+          // Make sure typeAhead input box is rendered and is visible
+          cy.getByTestID(
+            `variable-dropdown-input-typeAhead--${bucketVarName}`
+          ).should('be.visible')
+
+          // TESTING CSV VARIABLE
+          // selected value in dashboard is 1st value
+          cy.getByTestID(
+            `variable-dropdown-input-typeAhead--${bucketVarName}`
+          ).should('have.value', bucketOne)
+
+          cy.window()
+            .pipe(getSelectedVariable(dashboard.id, 0))
+            .should('equal', bucketOne)
+
+          // testing variable controls
+          cy.getByTestID(
+            `variable-dropdown-input-typeAhead--${bucketVarName}`
+          ).should('have.value', bucketOne)
+
+          cy.getByTestID('variables--button').click()
+          cy.getByTestID(`variable-dropdown--${bucketVarName}`).should(
+            'not.exist'
+          )
+          cy.getByTestID('variables--button').click()
+          cy.getByTestID(`variable-dropdown--${bucketVarName}`).should('exist')
+
+          // sanity check on the url before beginning
+          cy.location('search').should('eq', '?lower=now%28%29+-+1h')
+
+          // select 3rd value in dashboard
+          cy.getByTestID('variable-dropdown--button')
+            .first()
+            .click()
+          cy.get(`#${bucketThree}`).click()
+
+          // selected value in dashboard is 3rd value
+          cy.getByTestID(
+            `variable-dropdown-input-typeAhead--${bucketVarName}`
+          ).should('have.value', bucketThree)
+
+          cy.window()
+            .pipe(getSelectedVariable(dashboard.id, 0))
+            .should('equal', bucketThree)
+
+          // and that it updates the variable in the URL
+          cy.location('search').should(
+            'eq',
+            `?lower=now%28%29+-+1h&vars%5BbucketsCSV%5D=${bucketThree}`
+          )
+
+          // select 2nd value in dashboard
+          cy.getByTestID('variable-dropdown--button')
+            .first()
+            .click()
+          cy.get(`#${defaultBucket}`).click()
+
+          // and that it updates the variable in the URL without breaking stuff
+          cy.location('search').should(
+            'eq',
+            `?lower=now%28%29+-+1h&vars%5BbucketsCSV%5D=${defaultBucket}`
+          )
+
+          // start new stuff for typeAheadDropdown here:
+
+          // type in the input!
+          cy.getByTestID(
+            `variable-dropdown-input-typeAhead--${bucketVarName}`
+          ).clear()
+
+          cy.getByTestID(
+            `variable-dropdown-input-typeAhead--${bucketVarName}`
+          ).type('an')
+
+          // dropdown should  be showing: anotherBucket', 'randomBucket'
+
+          // hit down arrow once:
+
+          cy.getByTestID(
+            `variable-dropdown-input-typeAhead--${bucketVarName}`
+          ).type('{downarrow}')
+
+          // first element should be active (highlighted)
+          cy.get(`#anotherBucket`).should('have.class', 'active')
+
+          // hit down arrow again
+          cy.getByTestID(
+            `variable-dropdown-input-typeAhead--${bucketVarName}`
+          ).type('{downarrow}')
+
+          // next one should be active (first should NOT be active)
+          cy.get(`#anotherBucket`).should('not.have.class', 'active')
+          cy.get(`#randomBucket`).should('have.class', 'active')
+
+          // now; press return/enter to set it:
+          cy.getByTestID(
+            `variable-dropdown-input-typeAhead--${bucketVarName}`
+          ).type('{enter}')
+
+          // selected value in dashboard is 'randomBucket' value
+          cy.getByTestID(
+            `variable-dropdown-input-typeAhead--${bucketVarName}`
+          ).should('have.value', 'randomBucket')
+
+          // now:  clear the text area, write some text that doesn't match anything,
+          // then click outside; it should revert back to 'randomBucket'
+
+          // type in the input!
+          cy.getByTestID(
+            `variable-dropdown-input-typeAhead--${bucketVarName}`
+          ).clear()
+
+          cy.getByTestID(
+            `variable-dropdown-input-typeAhead--${bucketVarName}`
+          ).type('nothingM')
+
+          // end typeAhead section; rest is normal behavior
+
+          // open VEO
+          cy.getByTestID('cell-context--toggle')
+            .last()
+            .click()
+          cy.getByTestID('cell-context--configure').click()
+
+          // selected value in cell context is 2nd value (making sure it reverts back!)
+          cy.window()
+            .pipe(getSelectedVariable(dashboard.id, 0))
+            .should('equal', bucket5)
+
+          cy.getByTestID('toolbar-tab').click()
+          cy.get('.flux-toolbar--list-item')
+            .first()
+            .trigger('mouseover')
+          // toggle the variable dropdown in the VEO cell dashboard
+          cy.getByTestID('toolbar-popover--contents').within(() => {
+            cy.getByTestID('variable-dropdown--button').click()
+            // select 1st value in cell
+            cy.getByTestID('variable-dropdown--item')
+              .first()
+              .click()
+          })
+          // injecting mapTypeVar into query
+          cy.get('.flux-toolbar--list-item')
+            .eq(mapTypeVarIndex)
+            .within(() => {
+              cy.get('.cf-button').click()
+            })
+          // save cell
+          cy.getByTestID('save-cell--button').click()
+
+          // selected value in cell context is 1st value
+          cy.window()
+            .pipe(getSelectedVariable(dashboard.id, 0))
+            .should('equal', bucketOne)
+
+          // selected value in dashboard is 1st value
+          cy.getByTestID(
+            `variable-dropdown-input-typeAhead--${bucketVarName}`
+          ).should('have.value', bucketOne)
+
+          cy.window()
+            .pipe(getSelectedVariable(dashboard.id, 0))
+            .should('equal', bucketOne)
+
+          // TESTING MAP VARIABLE
+          // selected value in dashboard is 1st value
+          cy.getByTestID(
+            `variable-dropdown-input-typeAhead--${mapTypeVarName}`
+          ).should('have.value', 'k1')
+          cy.window()
+            .pipe(getSelectedVariable(dashboard.id, 2))
+            .should('equal', 'v1')
+
+          // select 2nd value in dashboard
+          cy.getByTestID('variable-dropdown--button')
+            .eq(1)
+            .click()
+          cy.get(`#k2`).click()
+
+          // selected value in dashboard is 2nd value
+          cy.getByTestID(
+            `variable-dropdown-input-typeAhead--${mapTypeVarName}`
+          ).should('have.value', 'k2')
+          cy.window()
+            .pipe(getSelectedVariable(dashboard.id, 2))
+            .should('equal', 'v2')
+
+          // open VEO
+          cy.getByTestID('cell-context--toggle')
+            .last()
+            .click()
+          cy.getByTestID('cell-context--configure').click()
+          cy.getByTestID('toolbar-tab').should('be.visible')
+
+          // selected value in cell context is 2nd value
+          cy.window()
+            .pipe(getSelectedVariable(dashboard.id, 2))
+            .should('equal', 'v2')
+
+          cy.getByTestID('toolbar-tab').click()
+          cy.get('.flux-toolbar--list-item')
+            .eq(2)
+            .trigger('mouseover')
+          // toggle the variable dropdown in the VEO cell dashboard
+          cy.getByTestID('toolbar-popover--contents').within(() => {
+            cy.getByTestID('variable-dropdown--button').click()
+            // select 1st value in cell
+            cy.getByTestID('variable-dropdown--item')
+              .first()
+              .click()
+          })
+          // save cell
+          cy.getByTestID('save-cell--button').click()
+
+          // selected value in cell context is 1st value
+          cy.window()
+            .pipe(getSelectedVariable(dashboard.id, 2))
+            .should('equal', 'v1')
+
+          // selected value in dashboard is 1st value
+          cy.getByTestID(
+            `variable-dropdown-input-typeAhead--${mapTypeVarName}`
+          ).should('have.value', 'k1')
+          cy.window()
+            .pipe(getSelectedVariable(dashboard.id, 2))
+            .should('equal', 'v1')
+
+          cy.getByTestID('cell-context--toggle')
+            .last()
+            .click()
+          cy.getByTestID('cell-context--delete').click()
+          cy.getByTestID('cell-context--delete-confirm').click()
+
+          // create a new cell
+          cy.getByTestID('add-cell--button').click()
+          cy.getByTestID('switch-to-script-editor').should('be.visible')
+          cy.getByTestID('switch-to-script-editor').click()
+
+          // query for data
+
+          cy.getByTestID('flux-editor')
+            .monacoType(`{selectall}{del}from(bucket: v.bucketsCSV)
+|> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+|> filter(fn: (r) => r["_measurement"] == "m")
+|> filter(fn: (r) => r["_field"] == "v")
+|> filter(fn: (r) => r["tk1"] == "tv1")
+|> aggregateWindow(every: v.windowPeriod, fn: max)
+|> yield(name: "max")`)
+
+          // `bucketOne` should not exist nor have data written to it
+          cy.getByTestID('save-cell--button').click()
+          cy.getByTestID('empty-graph-error').contains(`${bucketOne}`)
+
+          // select default bucket that has data
+          cy.getByTestID('variable-dropdown--button')
+            .eq(0)
+            .click()
+          cy.get(`#${defaultBucket}`).click()
+
+          // assert visualization appears
+          cy.getByTestID('giraffe-layer-line').should('exist')
+        })
+      })
+    })
+  })
+
+  it('reloads dependent variables properly', () => {
+    const bucketOne = 'b1'
+    const bucketThree = 'b3'
+    const bucketVarName = 'bucketsCSV'
+    const bucket4 = 'anotherBucket'
+    const bucket5 = 'randomBucket'
+
+    const dependentTypeVarName = 'greeting'
+    const bucketVarIndex = 0
+
+    cy.get('@org').then(({id: orgID}: Organization) => {
+      cy.get<Dashboard>('@dashboard').then(({dashboard}) => {
+        cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
+          cy.createCSVVariable(orgID, bucketVarName, [
+            bucketOne,
+            defaultBucket,
+            bucketThree,
+            bucket4,
+            bucket5,
+          ])
+
+          cy.createQueryVariable(
+            orgID,
+            'greeting',
+            `import "csv"
+data = "#group,false,false,false,false
+#datatype,string,long,string,string
+#default,_result,,,
+,result,table,_value,bucket
+,,0,hola,b1
+,,0,adios,b1
+,,0,bonjour,defbuck
+,,0,hello,b3
+,,0,goodbye,b3
+,,0,seeya,b3
+"
+csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
+          )
+
+          cy.fixture('routes').then(({orgs}) => {
+            cy.visit(`${orgs}/${orgID}/dashboards/${dashboard.id}`)
+            cy.getByTestID('tree-nav')
+          })
+          // add cell with variable in its query
+          cy.getByTestID('add-cell--button').click()
+          cy.getByTestID('switch-to-script-editor').should('be.visible')
+          cy.getByTestID('switch-to-script-editor').click()
+          cy.getByTestID('toolbar-tab').click()
+          cy.getByTestID('flux-editor')
+            .monacoType(`{selectall}{del}from(bucket: v.bucketsCSV)
+|> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+|> filter(fn: (r) => r["_field"] == v.greeting)
+|> aggregateWindow(every: v.windowPeriod, fn: max)
+|> yield(name: "max")`)
+          cy.get('.flux-toolbar--list-item')
+            .eq(bucketVarIndex)
+            .within(() => {
+              cy.get('.cf-button').click()
+            })
+          cy.getByTestID('save-cell--button').click()
+
+          // ok; now check that 'b1' is selected and 'greeting' has 'adios' selected
+          cy.getByTestID(
+            `variable-dropdown-input-typeAhead--${bucketVarName}`
+          ).should('have.value', bucketOne)
+
+          cy.getByTestID(
+            `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
+          ).should('have.value', 'adios')
+
+          // hit downarrow in the second dropdown:
+          cy.getByTestID(
+            `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
+          ).type('{downarrow}')
+
+          // check that both 'adios' and 'hola' are showing: (and with correct classes)
+          cy.get(`#hola`).should('not.have.class', 'active')
+          cy.get(`#adios`).should('have.class', 'active')
+
+          // hit the down arrow again:
+          cy.getByTestID(
+            `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
+          ).type('{downarrow}')
+
+          // check that both 'adios' and 'hola' are showing: (and with correct classes)
+          cy.get(`#hola`).should('have.class', 'active')
+
+          // 'adios' is still active b/c it is selected.....
+          cy.get(`#adios`).should('have.class', 'active')
+
+          // press enter to select:
+          cy.getByTestID(
+            `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
+          ).type('{enter}')
+
+          // 'hola' should now be selected:
+          cy.getByTestID(
+            `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
+          ).should('have.value', 'hola')
+
+          // ok!  now;  pick a different bucket:
+
+          // but first test that it only allows valid values:
+          cy.getByTestID(`variable-dropdown-input-typeAhead--${bucketVarName}`)
+            .type('b3789')
+            .type('{enter}')
+            .should('have.value', 'b1')
+
+          // while it still has the `b1' value, test the clickAwayHere functionality:
+
+          // type in a fake value, then click away, the prev value should be showing
+          cy.getByTestID(`variable-dropdown-input-typeAhead--${bucketVarName}`)
+            .clear()
+            .type('b3789')
+
+          // now click away
+          cy.getByTestID('variable-dropdown--button')
+            .eq(1)
+            .click()
+
+          cy.getByTestID(
+            `variable-dropdown-input-typeAhead--${bucketVarName}`
+          ).should('have.value', 'b1')
+
+          // type in a real value, then click away, the prev value should be showing
+          cy.getByTestID(`variable-dropdown-input-typeAhead--${bucketVarName}`)
+            .clear()
+            .type('b3')
+
+          // now click away
+          cy.getByTestID('variable-dropdown--button')
+            .eq(1)
+            .click()
+
+          cy.getByTestID(
+            `variable-dropdown-input-typeAhead--${bucketVarName}`
+          ).should('have.value', 'b1')
+
+          // now back to testing that only valid values work:
+          cy.getByTestID(`variable-dropdown-input-typeAhead--${bucketVarName}`)
+            .type('b3789')
+            .type('{enter}')
+            .should('have.value', 'b1')
+
+          // now clear it first and do it right:
+          cy.getByTestID(`variable-dropdown-input-typeAhead--${bucketVarName}`)
+            .clear()
+            .type('b3')
+            .type('{enter}')
+            .should('have.value', 'b3')
+
+          // now the 'greeting' should be empty
+          cy.getByTestID(
+            `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
+          ).should('have.value', '')
+
+          // click the dropdownbutton:
+          // select 2nd value in dashboard
+          cy.getByTestID('variable-dropdown--button')
+            .eq(1)
+            .click()
+
+          // verify they are all there and with no active class:
+          cy.get(`#hello`).should('not.have.class', 'active')
+          cy.get(`#goodbye`).should('not.have.class', 'active')
+          cy.get(`#seeya`).should('not.have.class', 'active')
+
+          cy.getByTestID(
+            `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
+          )
+            .type('el')
+            .type('{downarrow}')
+            .type('{enter}')
+
+          cy.getByTestID(
+            `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
+          ).should('have.value', 'hello')
+
+          // ok; now switch to a bucket with NO greeting vars; test that:
+
+          cy.getByTestID(`variable-dropdown-input-typeAhead--${bucketVarName}`)
+            .clear()
+            .type('random')
+            .type('{downarrow}')
+            .type('{enter}')
+            .should('have.value', bucket5)
+
+          // the greeting vars should NOT be there
+          cy.getByTestID(`variable-dropdown--${dependentTypeVarName}`).should(
+            'contain',
+            'No Values'
+          )
+
+          // now, go back to b3; 'hello' should be th eselected greeting
+          cy.getByTestID(`variable-dropdown-input-typeAhead--${bucketVarName}`)
+            .clear()
+            .type('b3')
+            .type('{downarrow}')
+            .type('{enter}')
+            .should('have.value', bucketThree)
+
+          cy.getByTestID(
+            `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
+          ).should('have.value', 'hello')
+        })
+      })
+    })
+  })
+
+  it('ensures that dependent variables load one another accordingly, even with reload and cleared local storage', () => {
+    cy.get('@org').then(({id: orgID}: Organization) => {
+      cy.createDashboard(orgID).then(({body: dashboard}) => {
+        cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
+          const now = Date.now()
+          cy.writeData([
+            `test,container_name=cool dopeness=12 ${now - 1000}000000`,
+            `test,container_name=beans dopeness=18 ${now - 1200}000000`,
+            `test,container_name=cool dopeness=14 ${now - 1400}000000`,
+            `test,container_name=beans dopeness=10 ${now - 1600}000000`,
+          ])
+          cy.createCSVVariable(orgID, 'static', ['beans', defaultBucket])
+          cy.createQueryVariable(
+            orgID,
+            'dependent',
+            `import "influxdata/influxdb/v1"
+        v1.tagValues(bucket: v.static, tag: "container_name") |> keep(columns: ["_value"])`
+          )
+          cy.createQueryVariable(
+            orgID,
+            'build',
+            `import "influxdata/influxdb/v1"
+        import "strings"
+        v1.tagValues(bucket: v.static, tag: "container_name") |> filter(fn: (r) => strings.hasSuffix(v: r._value, suffix: v.dependent))`
+          )
+
+          cy.fixture('routes').then(({orgs}) => {
+            cy.visit(`${orgs}/${orgID}/dashboards/${dashboard.id}`)
+            cy.getByTestID('tree-nav')
+          })
+
+          cy.getByTestID('add-cell--button').click()
+          cy.getByTestID('switch-to-script-editor').should('be.visible')
+          cy.getByTestID('switch-to-script-editor').click()
+          cy.getByTestID('toolbar-tab').click()
+
+          cy.getByTestID('flux-editor')
+            .monacoType(`{selectall}{del}from(bucket: v.static)
+|> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+|> filter(fn: (r) => r["_measurement"] == "test")
+|> filter(fn: (r) => r["_field"] == "dopeness")
+|> filter(fn: (r) => r["container_name"] == v.build)`)
+
+          cy.getByTestID('save-cell--button').click()
+
+          // the default bucket selection should have no results and load all three variables
+          // even though only two variables are being used (because 1 is dependent upon another)
+          cy.getByTestID('variable-dropdown-input-typeAhead--static').should(
+            'have.value',
+            'beans'
+          )
+
+          // and cause the rest to exist in loading states
+          cy.getByTestID('variable-dropdown--build').should('contain', 'Error')
+
+          // An error notification should tell the user that this failed
+          cy.getByTestID('notification-error').contains(
+            'could not find bucket "beans"'
+          )
+          cy.getByTestID('notification-error--dismiss').click({
+            multiple: true,
+          })
+
+          cy.getByTestIDSubStr('cell--view-empty')
+
+          // But selecting a nonempty bucket should load some data
+          cy.getByTestID('variable-dropdown--button')
+            .eq(0)
+            .click()
+          cy.get(`#${defaultBucket}`).click()
+
+          // default select the first result
+          cy.getByTestID('variable-dropdown-input-typeAhead--build').should(
+            'have.value',
+            'beans'
+          )
+
+          // and also load the third result
+          cy.getByTestID('variable-dropdown-input-typeAhead--dependent').should(
+            'have.value',
+            'beans'
+          )
+
+          cy.getByTestID('variable-dropdown-input-typeAhead--dependent').should(
+            'have.value',
+            'beans'
+          )
+
+          // and also load the third result
+          cy.getByTestID('variable-dropdown--button')
+            .eq(2)
+            .click()
+          cy.get(`#cool`).click()
+
+          // and also load the second result
+
+          cy.getByTestID('variable-dropdown-input-typeAhead--dependent').should(
+            'have.value',
+            'cool'
+          )
+
+          // updating the third variable should update the second
+          cy.getByTestID('variable-dropdown--button')
+            .eq(2)
+            .click()
+          cy.get(`#beans`).click()
+          cy.getByTestID('variable-dropdown-input-typeAhead--build').should(
+            'have.value',
+            'beans'
+          )
+        })
+        cy.clearLocalStorage()
+        cy.reload()
+        // the default bucket selection should have no results and load all three variables
+        // even though only two variables are being used (because 1 is dependent upon another)
+
+        cy.getByTestID('variable-dropdown-input-typeAhead--static').should(
+          'have.value',
+          'defbuck'
+        )
+
+        // and cause the rest to exist in loading states
+
+        cy.getByTestID('variable-dropdown-input-typeAhead--build').should(
+          'have.value',
+          'beans'
+        )
+
+        // and also load the second result
+
+        cy.getByTestID('variable-dropdown-input-typeAhead--build').should(
+          'have.value',
+          'beans'
+        )
+      })
+    })
+  })
+
+  /* \
+  built to approximate an instance with docker metrics,
+  operating with the variables:
+      depbuck:
+          from(bucket: v.buckets)
+              |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+              |> filter(fn: (r) => r["_measurement"] == "docker_container_cpu")
+              |> keep(columns: ["container_name"])
+              |> rename(columns: {"container_name": "_value"})
+              |> last()
+              |> group()
+      buckets:
+          buckets()
+              |> filter(fn: (r) => r.name !~ /^_/)
+              |> rename(columns: {name: "_value"})
+              |> keep(columns: ["_value"])
+  and a dashboard built of :
+      cell one:
+          from(bucket: v.buckets)
+              |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+              |> filter(fn: (r) => r["_measurement"] == "docker_container_cpu")
+              |> filter(fn: (r) => r["_field"] == "usage_percent")
+      cell two:
+          from(bucket: v.buckets)
+              |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+              |> filter(fn: (r) => r["_measurement"] == "docker_container_cpu")
+              |> filter(fn: (r) => r["_field"] == "usage_percent")
+              |> filter(fn: (r) => r["container_name"] == v.depbuck)
+  with only 4 api queries being sent to fulfill it all
+\*/
+  it('can load dependent queries without much fuss', () => {
+    cy.get('@org').then(({id: orgID}: Organization) => {
+      cy.createDashboard(orgID).then(({body: dashboard}) => {
+        cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
+          const now = Date.now()
+          cy.writeData([
+            `test,container_name=cool dopeness=12 ${now - 1000}000000`,
+            `test,container_name=beans dopeness=18 ${now - 1200}000000`,
+            `test,container_name=cool dopeness=14 ${now - 1400}000000`,
+            `test,container_name=beans dopeness=10 ${now - 1600}000000`,
+          ])
+          cy.createCSVVariable(orgID, 'static', ['beans', defaultBucket])
+          cy.createQueryVariable(
+            orgID,
+            'dependent',
+            `from(bucket: v.static)
+|> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+|> filter(fn: (r) => r["_measurement"] == "test")
+|> keep(columns: ["container_name"])
+|> rename(columns: {"container_name": "_value"})
+|> last()
+|> group()`
+          )
+
+          cy.fixture('routes').then(({orgs}) => {
+            cy.visit(`${orgs}/${orgID}/dashboards/${dashboard.id}`)
+          })
+        })
+      })
+    })
+    cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
+      cy.getByTestID('add-cell--button').click()
+      cy.getByTestID('switch-to-script-editor').should('be.visible')
+      cy.getByTestID('switch-to-script-editor').click()
+      cy.getByTestID('toolbar-tab').click()
+
+      cy.getByTestID('flux-editor')
+        .monacoType(`{selectall}{del}from(bucket: v.static)
+|> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+|> filter(fn: (r) => r["_measurement"] == "test")
+|> filter(fn: (r) => r["_field"] == "dopeness")
+|> filter(fn: (r) => r["container_name"] == v.dependent)`)
+      cy.getByTestID('save-cell--button').click()
+
+      // the default bucket selection should have no results
+      cy.getByTestID('variable-dropdown-input-typeAhead--static').should(
+        'have.value',
+        'beans'
+      )
+
+      // and cause the rest to exist in error states
+      cy.getByTestIDSubStr('variable-dropdown--dependent').should(
+        'contain',
+        'Error'
+      )
+
+      // An error notification should tell the user that this failed
+      cy.getByTestID('notification-error').contains(
+        'could not find bucket "beans"'
+      )
+      cy.getByTestID('notification-error--dismiss').click()
+
+      cy.getByTestIDSubStr('cell--view-empty')
+
+      // But selecting a nonempty bucket should load some data
+      cy.getByTestID('variable-dropdown--button')
+        .eq(0)
+        .click()
+      cy.get(`#${defaultBucket}`).click()
+
+      // default select the first result
+      cy.getByTestID('variable-dropdown-input-typeAhead--dependent').should(
+        'have.value',
+        'beans'
+      )
+
+      // and also load the second result
+      cy.getByTestID('variable-dropdown--button')
+        .eq(1)
+        .click()
+      cy.get(`#cool`).click()
+    })
+  })
+})

--- a/cypress/e2e/shared/dashboardsView.test.ts
+++ b/cypress/e2e/shared/dashboardsView.test.ts
@@ -6,7 +6,7 @@ describe('Dashboard', () => {
     cy.flush()
     cy.signin()
     cy.fixture('routes').then(({orgs}) => {
-      cy.get('@org').then(({id: orgID}: Organization) => {
+      cy.get<Organization>('@org').then(({id: orgID}: Organization) => {
         cy.visit(`${orgs}/${orgID}/dashboards-list`)
         cy.getByTestID('tree-nav')
       })
@@ -14,7 +14,7 @@ describe('Dashboard', () => {
   })
 
   it("can edit a dashboard's name", () => {
-    cy.get('@org').then(({id: orgID}: Organization) => {
+    cy.get<Organization>('@org').then(({id: orgID}: Organization) => {
       cy.createDashboard(orgID).then(({body}) => {
         cy.fixture('routes').then(({orgs}) => {
           cy.visit(`${orgs}/${orgID}/dashboards/${body.id}`)
@@ -31,7 +31,7 @@ describe('Dashboard', () => {
       .type('{enter}')
 
     cy.fixture('routes').then(({orgs}) => {
-      cy.get('@org').then(({id: orgID}: Organization) => {
+      cy.get<Organization>('@org').then(({id: orgID}: Organization) => {
         cy.visit(`${orgs}/${orgID}/dashboards-list`)
         cy.getByTestID('tree-nav')
       })
@@ -41,7 +41,7 @@ describe('Dashboard', () => {
   })
 
   it('can create, clone and destroy cells & toggle in and out of presentation mode', () => {
-    cy.get('@org').then(({id: orgID}: Organization) => {
+    cy.get<Organization>('@org').then(({id: orgID}: Organization) => {
       cy.createDashboard(orgID).then(({body}) => {
         cy.fixture('routes').then(({orgs}) => {
           cy.visit(`${orgs}/${orgID}/dashboards/${body.id}`)
@@ -225,7 +225,7 @@ describe('Dashboard', () => {
 
   // fix for https://github.com/influxdata/influxdb/issues/15239
   it('retains the cell content after canceling an edit to the cell', () => {
-    cy.get('@org').then(({id: orgID}: Organization) => {
+    cy.get<Organization>('@org').then(({id: orgID}: Organization) => {
       cy.createDashboard(orgID).then(({body}) => {
         cy.fixture('routes').then(({orgs}) => {
           cy.visit(`${orgs}/${orgID}/dashboards/${body.id}`)
@@ -259,7 +259,7 @@ describe('Dashboard', () => {
   })
 
   it('can create a view through the API', () => {
-    cy.get('@org').then(({id: orgID}: Organization) => {
+    cy.get<Organization>('@org').then(({id: orgID = ''}: Organization) => {
       cy.createDashWithViewAndVar(orgID)
       cy.fixture('routes').then(({orgs}) => {
         cy.visit(`${orgs}/${orgID}/dashboards-list`)
@@ -271,7 +271,7 @@ describe('Dashboard', () => {
   })
 
   it("should return empty table parameters when query hasn't been submitted", () => {
-    cy.get('@org').then(({id: orgID}: Organization) => {
+    cy.get<Organization>('@org').then(({id: orgID}: Organization) => {
       cy.createDashboard(orgID).then(({body}) => {
         cy.fixture('routes').then(({orgs}) => {
           cy.visit(`${orgs}/${orgID}/dashboards/${body.id}`)
@@ -304,7 +304,7 @@ describe('Dashboard', () => {
   it('should save a time format change and show in the dashboard cell card', () => {
     const numLines = 360
     cy.writeData(points(numLines))
-    cy.get('@org').then(({id: orgID}: Organization) => {
+    cy.get<Organization>('@org').then(({id: orgID}: Organization) => {
       cy.createDashboard(orgID).then(({body}) => {
         cy.fixture('routes').then(({orgs}) => {
           cy.visit(`${orgs}/${orgID}/dashboards/${body.id}`)
@@ -351,7 +351,7 @@ describe('Dashboard', () => {
   it('can sort values in a dashboard cell', () => {
     const numLines = 360
     cy.writeData(points(numLines))
-    cy.get('@org').then(({id: orgID}: Organization) => {
+    cy.get<Organization>('@org').then(({id: orgID}: Organization) => {
       cy.createDashboard(orgID).then(({body}) => {
         cy.fixture('routes').then(({orgs}) => {
           cy.visit(`${orgs}/${orgID}/dashboards/${body.id}`)
@@ -456,7 +456,7 @@ describe('Dashboard', () => {
 
   it('creates a dashboard to test light/dark mode toggle', () => {
     // dashboard creation
-    cy.get('@org').then(({id: orgID}: Organization) => {
+    cy.get<Organization>('@org').then(({id: orgID}: Organization) => {
       cy.createDashboard(orgID).then(({body}) => {
         cy.fixture('routes').then(({orgs}) => {
           cy.visit(`${orgs}/${orgID}/dashboards/${body.id}`)
@@ -486,10 +486,11 @@ describe('Dashboard', () => {
 
   describe('clone cell', () => {
     let otherBoardID: string
-    let orgId: string
+    let orgId: string | undefined
     let allOrgs: any
+
     beforeEach(() => {
-      cy.get('@org').then(({id: orgID, name}: Organization) => {
+      cy.get<Organization>('@org').then(({id: orgID, name}: Organization) => {
         orgId = orgID
         cy.createDashboard(orgID, 'other-dashboard').then(({body}) => {
           otherBoardID = body.id
@@ -533,6 +534,7 @@ describe('Dashboard', () => {
         .click()
       cy.getByTestID('cell-context--copy').click()
     })
+
     it('clones a cell to another dashboard and displays it there', () => {
       cy.getByTestID('clone-to-other-dashboard').click()
       cy.getByTestID(`other-dashboard-${otherBoardID}`).click()

--- a/cypress/e2e/shared/dashboardsView.test.ts
+++ b/cypress/e2e/shared/dashboardsView.test.ts
@@ -1,39 +1,5 @@
-import {Organization, AppState, Dashboard} from '../../../src/types'
+import {Organization} from '../../../src/types'
 import {points} from '../../support/commands'
-
-const getSelectedVariable = (contextID: string, index: number) => (
-  win: any
-) => {
-  const state = win.store.getState() as AppState
-  const defaultVarOrder = state.resources.variables.allIDs
-  const defaultVarDawg =
-    state.resources.variables.byID[defaultVarOrder[index]] || {}
-  const filledVarDawg =
-    (state.resources.variables.values[contextID] || {values: {}}).values[
-      defaultVarOrder[index]
-    ] || {}
-
-  const hydratedVarDawg = {
-    ...defaultVarDawg,
-    ...filledVarDawg,
-  }
-
-  if (hydratedVarDawg.arguments.type === 'map') {
-    if (!hydratedVarDawg.selected) {
-      hydratedVarDawg.selected = [
-        Object.keys(hydratedVarDawg.arguments.values)[0],
-      ]
-    }
-
-    return hydratedVarDawg.arguments.values[hydratedVarDawg.selected[0]]
-  }
-
-  if (!hydratedVarDawg.selected) {
-    hydratedVarDawg.selected = [hydratedVarDawg.arguments.values[0]]
-  }
-
-  return hydratedVarDawg.selected[0]
-}
 
 describe('Dashboard', () => {
   beforeEach(() => {
@@ -292,882 +258,6 @@ describe('Dashboard', () => {
       })
   })
 
-  describe('variable interactions', () => {
-    beforeEach(() => {
-      const numLines = 360
-      cy.writeData(points(numLines))
-      cy.get('@org').then(({id: orgID}: Organization) => {
-        cy.createDashboard(orgID).then(({body: dashboard}) => {
-          cy.wrap({dashboard}).as('dashboard')
-        })
-      })
-    })
-
-    it('variables visibility control, informs user if variables are enabled but not defined', () => {
-      cy.get<Organization>('@org').then(({id: orgID}: Organization) => {
-        cy.createDashWithViewAndVar(orgID).then(() => {
-          cy.get<string>('@defaultBucket').then(defaultBucket => {
-            cy.createCSVVariable(orgID, 'CSVVar', [
-              'FirstVar',
-              defaultBucket,
-              'SecondVar',
-            ])
-
-            cy.fixture('routes').then(({orgs, dashboards}) => {
-              cy.visit(`${orgs}/${orgID}${dashboards}/`)
-              cy.getByTestID('tree-nav')
-            })
-          })
-        })
-      })
-
-      // Select second dashboard card
-      cy.getByTestID('page-contents').within(() => {
-        cy.get('[data-testid="dashboard-card"]')
-          .eq(1)
-          .within(() => {
-            cy.getByTestID('dashboard-card--name').click()
-          })
-      })
-
-      // No defined variables
-      // Toggle off
-      cy.getByTestID('variables--button').click()
-      cy.getByTestID('variables-control-bar').should('not.exist')
-
-      // Toggle on
-      cy.getByTestID('variables--button').click()
-      cy.getByTestID('variables-control-bar')
-        .should('exist')
-        .and(
-          'contain',
-          "This dashboard doesn't have any cells with defined variables. Learn How"
-        )
-
-      // create query with variable
-      cy.getByTestID('cell-context--toggle').click()
-      cy.getByTestID('popover--contents')
-        .contains('Configure')
-        .click()
-      cy.getByTestID('buckets-list')
-        .contains('defbuck')
-        .click()
-      cy.getByTestID('selector-list m').click()
-      cy.getByTestID('selector-list v').click()
-      cy.getByTestID('selector-list tv1').click()
-      cy.getByTestID('switch-to-script-editor').click()
-      cy.getByTestID('flux-editor').should('exist')
-      cy.get('[class="view-line"]')
-        .last()
-        .type('v.CSVVar')
-      cy.getByTestID('save-cell--button').click()
-
-      // With variables
-      // Toggle off
-      cy.getByTestID('variables--button').click()
-      cy.getByTestID('variables-control-bar').should('not.exist')
-
-      // Toggle on
-      cy.getByTestID('variables--button').click()
-      cy.getByTestID('variables-control-bar')
-        .should('exist')
-        .and(
-          'not.contain',
-          "This dashboard doesn't have any cells with defined variables. Learn How"
-        )
-      cy.getByTestID('variable-dropdown--CSVVar').should('exist')
-    })
-
-    it('can manage variable state with a lot of pointing and clicking', () => {
-      const bucketOne = 'b1'
-      const bucketThree = 'b3'
-      const bucketVarName = 'bucketsCSV'
-      const bucket4 = 'anotherBucket'
-      const bucket5 = 'randomBucket'
-
-      const mapTypeVarName = 'mapTypeVar'
-      const bucketVarIndex = 0
-      const mapTypeVarIndex = 2
-
-      cy.get('@org').then(({id: orgID}: Organization) => {
-        cy.get<Dashboard>('@dashboard').then(({dashboard}) => {
-          cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
-            cy.createCSVVariable(orgID, bucketVarName, [
-              bucketOne,
-              defaultBucket,
-              bucketThree,
-              bucket4,
-              bucket5,
-            ])
-
-            cy.createQueryVariable(orgID)
-            cy.createMapVariable(orgID)
-            cy.fixture('routes').then(({orgs}) => {
-              cy.visit(`${orgs}/${orgID}/dashboards/${dashboard.id}`)
-              cy.getByTestID('tree-nav')
-            })
-            // add cell with variable in its query
-            cy.getByTestID('add-cell--button').click()
-            cy.getByTestID('switch-to-script-editor').should('be.visible')
-            cy.getByTestID('switch-to-script-editor').click()
-            cy.getByTestID('toolbar-tab').click()
-            cy.getByTestID('flux-editor').should('be.visible')
-            // check to see if the default timeRange variables are available
-            cy.get('.flux-toolbar--list-item').contains('timeRangeStart')
-            cy.get('.flux-toolbar--list-item').contains('timeRangeStop')
-
-            cy.get('.flux-toolbar--list-item')
-              .eq(bucketVarIndex)
-              .within(() => {
-                cy.get('.cf-button').click()
-              })
-            cy.getByTestID('flux-editor').monacoType(' ')
-            cy.getByTestID('save-cell--button').click()
-
-            // Make sure typeAhead input box is rendered and is visible
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${bucketVarName}`
-            ).should('be.visible')
-
-            // TESTING CSV VARIABLE
-            // selected value in dashboard is 1st value
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${bucketVarName}`
-            ).should('have.value', bucketOne)
-
-            cy.window()
-              .pipe(getSelectedVariable(dashboard.id, 0))
-              .should('equal', bucketOne)
-
-            // testing variable controls
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${bucketVarName}`
-            ).should('have.value', bucketOne)
-
-            cy.getByTestID('variables--button').click()
-            cy.getByTestID(`variable-dropdown--${bucketVarName}`).should(
-              'not.exist'
-            )
-            cy.getByTestID('variables--button').click()
-            cy.getByTestID(`variable-dropdown--${bucketVarName}`).should(
-              'exist'
-            )
-
-            // sanity check on the url before beginning
-            cy.location('search').should('eq', '?lower=now%28%29+-+1h')
-
-            // select 3rd value in dashboard
-            cy.getByTestID('variable-dropdown--button')
-              .first()
-              .click()
-            cy.get(`#${bucketThree}`).click()
-
-            // selected value in dashboard is 3rd value
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${bucketVarName}`
-            ).should('have.value', bucketThree)
-
-            cy.window()
-              .pipe(getSelectedVariable(dashboard.id, 0))
-              .should('equal', bucketThree)
-
-            // and that it updates the variable in the URL
-            cy.location('search').should(
-              'eq',
-              `?lower=now%28%29+-+1h&vars%5BbucketsCSV%5D=${bucketThree}`
-            )
-
-            // select 2nd value in dashboard
-            cy.getByTestID('variable-dropdown--button')
-              .first()
-              .click()
-            cy.get(`#${defaultBucket}`).click()
-
-            // and that it updates the variable in the URL without breaking stuff
-            cy.location('search').should(
-              'eq',
-              `?lower=now%28%29+-+1h&vars%5BbucketsCSV%5D=${defaultBucket}`
-            )
-
-            // start new stuff for typeAheadDropdown here:
-
-            // type in the input!
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${bucketVarName}`
-            ).clear()
-
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${bucketVarName}`
-            ).type('an')
-
-            // dropdown should  be showing: anotherBucket', 'randomBucket'
-
-            // hit down arrow once:
-
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${bucketVarName}`
-            ).type('{downarrow}')
-
-            // first element should be active (highlighted)
-            cy.get(`#anotherBucket`).should('have.class', 'active')
-
-            // hit down arrow again
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${bucketVarName}`
-            ).type('{downarrow}')
-
-            // next one should be active (first should NOT be active)
-            cy.get(`#anotherBucket`).should('not.have.class', 'active')
-            cy.get(`#randomBucket`).should('have.class', 'active')
-
-            // now; press return/enter to set it:
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${bucketVarName}`
-            ).type('{enter}')
-
-            // selected value in dashboard is 'randomBucket' value
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${bucketVarName}`
-            ).should('have.value', 'randomBucket')
-
-            // now:  clear the text area, write some text that doesn't match anything,
-            // then click outside; it should revert back to 'randomBucket'
-
-            // type in the input!
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${bucketVarName}`
-            ).clear()
-
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${bucketVarName}`
-            ).type('nothingM')
-
-            // end typeAhead section; rest is normal behavior
-
-            // open VEO
-            cy.getByTestID('cell-context--toggle')
-              .last()
-              .click()
-            cy.getByTestID('cell-context--configure').click()
-
-            // selected value in cell context is 2nd value (making sure it reverts back!)
-            cy.window()
-              .pipe(getSelectedVariable(dashboard.id, 0))
-              .should('equal', bucket5)
-
-            cy.getByTestID('toolbar-tab').click()
-            cy.get('.flux-toolbar--list-item')
-              .first()
-              .trigger('mouseover')
-            // toggle the variable dropdown in the VEO cell dashboard
-            cy.getByTestID('toolbar-popover--contents').within(() => {
-              cy.getByTestID('variable-dropdown--button').click()
-              // select 1st value in cell
-              cy.getByTestID('variable-dropdown--item')
-                .first()
-                .click()
-            })
-            // injecting mapTypeVar into query
-            cy.get('.flux-toolbar--list-item')
-              .eq(mapTypeVarIndex)
-              .within(() => {
-                cy.get('.cf-button').click()
-              })
-            // save cell
-            cy.getByTestID('save-cell--button').click()
-
-            // selected value in cell context is 1st value
-            cy.window()
-              .pipe(getSelectedVariable(dashboard.id, 0))
-              .should('equal', bucketOne)
-
-            // selected value in dashboard is 1st value
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${bucketVarName}`
-            ).should('have.value', bucketOne)
-
-            cy.window()
-              .pipe(getSelectedVariable(dashboard.id, 0))
-              .should('equal', bucketOne)
-
-            // TESTING MAP VARIABLE
-            // selected value in dashboard is 1st value
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${mapTypeVarName}`
-            ).should('have.value', 'k1')
-            cy.window()
-              .pipe(getSelectedVariable(dashboard.id, 2))
-              .should('equal', 'v1')
-
-            // select 2nd value in dashboard
-            cy.getByTestID('variable-dropdown--button')
-              .eq(1)
-              .click()
-            cy.get(`#k2`).click()
-
-            // selected value in dashboard is 2nd value
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${mapTypeVarName}`
-            ).should('have.value', 'k2')
-            cy.window()
-              .pipe(getSelectedVariable(dashboard.id, 2))
-              .should('equal', 'v2')
-
-            // open VEO
-            cy.getByTestID('cell-context--toggle')
-              .last()
-              .click()
-            cy.getByTestID('cell-context--configure').click()
-            cy.getByTestID('toolbar-tab').should('be.visible')
-
-            // selected value in cell context is 2nd value
-            cy.window()
-              .pipe(getSelectedVariable(dashboard.id, 2))
-              .should('equal', 'v2')
-
-            cy.getByTestID('toolbar-tab').click()
-            cy.get('.flux-toolbar--list-item')
-              .eq(2)
-              .trigger('mouseover')
-            // toggle the variable dropdown in the VEO cell dashboard
-            cy.getByTestID('toolbar-popover--contents').within(() => {
-              cy.getByTestID('variable-dropdown--button').click()
-              // select 1st value in cell
-              cy.getByTestID('variable-dropdown--item')
-                .first()
-                .click()
-            })
-            // save cell
-            cy.getByTestID('save-cell--button').click()
-
-            // selected value in cell context is 1st value
-            cy.window()
-              .pipe(getSelectedVariable(dashboard.id, 2))
-              .should('equal', 'v1')
-
-            // selected value in dashboard is 1st value
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${mapTypeVarName}`
-            ).should('have.value', 'k1')
-            cy.window()
-              .pipe(getSelectedVariable(dashboard.id, 2))
-              .should('equal', 'v1')
-
-            cy.getByTestID('cell-context--toggle')
-              .last()
-              .click()
-            cy.getByTestID('cell-context--delete').click()
-            cy.getByTestID('cell-context--delete-confirm').click()
-
-            // create a new cell
-            cy.getByTestID('add-cell--button').click()
-            cy.getByTestID('switch-to-script-editor').should('be.visible')
-            cy.getByTestID('switch-to-script-editor').click()
-
-            // query for data
-
-            cy.getByTestID('flux-editor')
-              .monacoType(`{selectall}{del}from(bucket: v.bucketsCSV)
-|> range(start: v.timeRangeStart, stop: v.timeRangeStop)
-|> filter(fn: (r) => r["_measurement"] == "m")
-|> filter(fn: (r) => r["_field"] == "v")
-|> filter(fn: (r) => r["tk1"] == "tv1")
-|> aggregateWindow(every: v.windowPeriod, fn: max)
-|> yield(name: "max")`)
-
-            // `bucketOne` should not exist nor have data written to it
-            cy.getByTestID('save-cell--button').click()
-            cy.getByTestID('empty-graph-error').contains(`${bucketOne}`)
-
-            // select default bucket that has data
-            cy.getByTestID('variable-dropdown--button')
-              .eq(0)
-              .click()
-            cy.get(`#${defaultBucket}`).click()
-
-            // assert visualization appears
-            cy.getByTestID('giraffe-layer-line').should('exist')
-          })
-        })
-      })
-    })
-
-    it('reloads dependent variables properly', () => {
-      const bucketOne = 'b1'
-      const bucketThree = 'b3'
-      const bucketVarName = 'bucketsCSV'
-      const bucket4 = 'anotherBucket'
-      const bucket5 = 'randomBucket'
-
-      const dependentTypeVarName = 'greeting'
-      const bucketVarIndex = 0
-
-      cy.get('@org').then(({id: orgID}: Organization) => {
-        cy.get<Dashboard>('@dashboard').then(({dashboard}) => {
-          cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
-            cy.createCSVVariable(orgID, bucketVarName, [
-              bucketOne,
-              defaultBucket,
-              bucketThree,
-              bucket4,
-              bucket5,
-            ])
-
-            cy.createQueryVariable(
-              orgID,
-              'greeting',
-              `import "csv"
-data = "#group,false,false,false,false
-#datatype,string,long,string,string
-#default,_result,,,
-,result,table,_value,bucket
-,,0,hola,b1
-,,0,adios,b1
-,,0,bonjour,defbuck
-,,0,hello,b3
-,,0,goodbye,b3
-,,0,seeya,b3
-"
-csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
-            )
-
-            cy.fixture('routes').then(({orgs}) => {
-              cy.visit(`${orgs}/${orgID}/dashboards/${dashboard.id}`)
-              cy.getByTestID('tree-nav')
-            })
-            // add cell with variable in its query
-            cy.getByTestID('add-cell--button').click()
-            cy.getByTestID('switch-to-script-editor').should('be.visible')
-            cy.getByTestID('switch-to-script-editor').click()
-            cy.getByTestID('toolbar-tab').click()
-            cy.getByTestID('flux-editor')
-              .monacoType(`{selectall}{del}from(bucket: v.bucketsCSV)
-|> range(start: v.timeRangeStart, stop: v.timeRangeStop)
-|> filter(fn: (r) => r["_field"] == v.greeting)
-|> aggregateWindow(every: v.windowPeriod, fn: max)
-|> yield(name: "max")`)
-            cy.get('.flux-toolbar--list-item')
-              .eq(bucketVarIndex)
-              .within(() => {
-                cy.get('.cf-button').click()
-              })
-            cy.getByTestID('save-cell--button').click()
-
-            // ok; now check that 'b1' is selected and 'greeting' has 'adios' selected
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${bucketVarName}`
-            ).should('have.value', bucketOne)
-
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
-            ).should('have.value', 'adios')
-
-            // hit downarrow in the second dropdown:
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
-            ).type('{downarrow}')
-
-            // check that both 'adios' and 'hola' are showing: (and with correct classes)
-            cy.get(`#hola`).should('not.have.class', 'active')
-            cy.get(`#adios`).should('have.class', 'active')
-
-            // hit the down arrow again:
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
-            ).type('{downarrow}')
-
-            // check that both 'adios' and 'hola' are showing: (and with correct classes)
-            cy.get(`#hola`).should('have.class', 'active')
-
-            // 'adios' is still active b/c it is selected.....
-            cy.get(`#adios`).should('have.class', 'active')
-
-            // press enter to select:
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
-            ).type('{enter}')
-
-            // 'hola' should now be selected:
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
-            ).should('have.value', 'hola')
-
-            // ok!  now;  pick a different bucket:
-
-            // but first test that it only allows valid values:
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${bucketVarName}`
-            )
-              .type('b3789')
-              .type('{enter}')
-              .should('have.value', 'b1')
-
-            // while it still has the `b1' value, test the clickAwayHere functionality:
-
-            // type in a fake value, then click away, the prev value should be showing
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${bucketVarName}`
-            )
-              .clear()
-              .type('b3789')
-
-            // now click away
-            cy.getByTestID('variable-dropdown--button')
-              .eq(1)
-              .click()
-
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${bucketVarName}`
-            ).should('have.value', 'b1')
-
-            // type in a real value, then click away, the prev value should be showing
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${bucketVarName}`
-            )
-              .clear()
-              .type('b3')
-
-            // now click away
-            cy.getByTestID('variable-dropdown--button')
-              .eq(1)
-              .click()
-
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${bucketVarName}`
-            ).should('have.value', 'b1')
-
-            // now back to testing that only valid values work:
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${bucketVarName}`
-            )
-              .type('b3789')
-              .type('{enter}')
-              .should('have.value', 'b1')
-
-            // now clear it first and do it right:
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${bucketVarName}`
-            )
-              .clear()
-              .type('b3')
-              .type('{enter}')
-              .should('have.value', 'b3')
-
-            // now the 'greeting' should be empty
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
-            ).should('have.value', '')
-
-            // click the dropdownbutton:
-            // select 2nd value in dashboard
-            cy.getByTestID('variable-dropdown--button')
-              .eq(1)
-              .click()
-
-            // verify they are all there and with no active class:
-            cy.get(`#hello`).should('not.have.class', 'active')
-            cy.get(`#goodbye`).should('not.have.class', 'active')
-            cy.get(`#seeya`).should('not.have.class', 'active')
-
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
-            )
-              .type('el')
-              .type('{downarrow}')
-              .type('{enter}')
-
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
-            ).should('have.value', 'hello')
-
-            // ok; now switch to a bucket with NO greeting vars; test that:
-
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${bucketVarName}`
-            )
-              .clear()
-              .type('random')
-              .type('{downarrow}')
-              .type('{enter}')
-              .should('have.value', bucket5)
-
-            // the greeting vars should NOT be there
-            cy.getByTestID(`variable-dropdown--${dependentTypeVarName}`).should(
-              'contain',
-              'No Values'
-            )
-
-            // now, go back to b3; 'hello' should be th eselected greeting
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${bucketVarName}`
-            )
-              .clear()
-              .type('b3')
-              .type('{downarrow}')
-              .type('{enter}')
-              .should('have.value', bucketThree)
-
-            cy.getByTestID(
-              `variable-dropdown-input-typeAhead--${dependentTypeVarName}`
-            ).should('have.value', 'hello')
-          })
-        })
-      })
-    })
-
-    it('ensures that dependent variables load one another accordingly, even with reload and cleared local storage', () => {
-      cy.get('@org').then(({id: orgID}: Organization) => {
-        cy.createDashboard(orgID).then(({body: dashboard}) => {
-          cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
-            const now = Date.now()
-            cy.writeData([
-              `test,container_name=cool dopeness=12 ${now - 1000}000000`,
-              `test,container_name=beans dopeness=18 ${now - 1200}000000`,
-              `test,container_name=cool dopeness=14 ${now - 1400}000000`,
-              `test,container_name=beans dopeness=10 ${now - 1600}000000`,
-            ])
-            cy.createCSVVariable(orgID, 'static', ['beans', defaultBucket])
-            cy.createQueryVariable(
-              orgID,
-              'dependent',
-              `import "influxdata/influxdb/v1"
-          v1.tagValues(bucket: v.static, tag: "container_name") |> keep(columns: ["_value"])`
-            )
-            cy.createQueryVariable(
-              orgID,
-              'build',
-              `import "influxdata/influxdb/v1"
-          import "strings"
-          v1.tagValues(bucket: v.static, tag: "container_name") |> filter(fn: (r) => strings.hasSuffix(v: r._value, suffix: v.dependent))`
-            )
-
-            cy.fixture('routes').then(({orgs}) => {
-              cy.visit(`${orgs}/${orgID}/dashboards/${dashboard.id}`)
-              cy.getByTestID('tree-nav')
-            })
-
-            cy.getByTestID('add-cell--button').click()
-            cy.getByTestID('switch-to-script-editor').should('be.visible')
-            cy.getByTestID('switch-to-script-editor').click()
-            cy.getByTestID('toolbar-tab').click()
-
-            cy.getByTestID('flux-editor')
-              .monacoType(`{selectall}{del}from(bucket: v.static)
-|> range(start: v.timeRangeStart, stop: v.timeRangeStop)
-|> filter(fn: (r) => r["_measurement"] == "test")
-|> filter(fn: (r) => r["_field"] == "dopeness")
-|> filter(fn: (r) => r["container_name"] == v.build)`)
-
-            cy.getByTestID('save-cell--button').click()
-
-            // the default bucket selection should have no results and load all three variables
-            // even though only two variables are being used (because 1 is dependent upon another)
-            cy.getByTestID('variable-dropdown-input-typeAhead--static').should(
-              'have.value',
-              'beans'
-            )
-
-            // and cause the rest to exist in loading states
-            cy.getByTestID('variable-dropdown--build').should(
-              'contain',
-              'Error'
-            )
-
-            // An error notification should tell the user that this failed
-            cy.getByTestID('notification-error').contains(
-              'could not find bucket "beans"'
-            )
-            cy.getByTestID('notification-error--dismiss').click({
-              multiple: true,
-            })
-
-            cy.getByTestIDSubStr('cell--view-empty')
-
-            // But selecting a nonempty bucket should load some data
-            cy.getByTestID('variable-dropdown--button')
-              .eq(0)
-              .click()
-            cy.get(`#${defaultBucket}`).click()
-
-            // default select the first result
-            cy.getByTestID('variable-dropdown-input-typeAhead--build').should(
-              'have.value',
-              'beans'
-            )
-
-            // and also load the third result
-            cy.getByTestID(
-              'variable-dropdown-input-typeAhead--dependent'
-            ).should('have.value', 'beans')
-
-            cy.getByTestID(
-              'variable-dropdown-input-typeAhead--dependent'
-            ).should('have.value', 'beans')
-
-            // and also load the third result
-            cy.getByTestID('variable-dropdown--button')
-              .eq(2)
-              .click()
-            cy.get(`#cool`).click()
-
-            // and also load the second result
-
-            cy.getByTestID(
-              'variable-dropdown-input-typeAhead--dependent'
-            ).should('have.value', 'cool')
-
-            // updating the third variable should update the second
-            cy.getByTestID('variable-dropdown--button')
-              .eq(2)
-              .click()
-            cy.get(`#beans`).click()
-            cy.getByTestID('variable-dropdown-input-typeAhead--build').should(
-              'have.value',
-              'beans'
-            )
-          })
-          cy.clearLocalStorage()
-          cy.reload()
-          // the default bucket selection should have no results and load all three variables
-          // even though only two variables are being used (because 1 is dependent upon another)
-
-          cy.getByTestID('variable-dropdown-input-typeAhead--static').should(
-            'have.value',
-            'defbuck'
-          )
-
-          // and cause the rest to exist in loading states
-
-          cy.getByTestID('variable-dropdown-input-typeAhead--build').should(
-            'have.value',
-            'beans'
-          )
-
-          // and also load the second result
-
-          cy.getByTestID('variable-dropdown-input-typeAhead--build').should(
-            'have.value',
-            'beans'
-          )
-        })
-      })
-    })
-
-    /* \
-    built to approximate an instance with docker metrics,
-    operating with the variables:
-        depbuck:
-            from(bucket: v.buckets)
-                |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
-                |> filter(fn: (r) => r["_measurement"] == "docker_container_cpu")
-                |> keep(columns: ["container_name"])
-                |> rename(columns: {"container_name": "_value"})
-                |> last()
-                |> group()
-        buckets:
-            buckets()
-                |> filter(fn: (r) => r.name !~ /^_/)
-                |> rename(columns: {name: "_value"})
-                |> keep(columns: ["_value"])
-    and a dashboard built of :
-        cell one:
-            from(bucket: v.buckets)
-                |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
-                |> filter(fn: (r) => r["_measurement"] == "docker_container_cpu")
-                |> filter(fn: (r) => r["_field"] == "usage_percent")
-        cell two:
-            from(bucket: v.buckets)
-                |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
-                |> filter(fn: (r) => r["_measurement"] == "docker_container_cpu")
-                |> filter(fn: (r) => r["_field"] == "usage_percent")
-                |> filter(fn: (r) => r["container_name"] == v.depbuck)
-    with only 4 api queries being sent to fulfill it all
-  \*/
-    it('can load dependent queries without much fuss', () => {
-      cy.get('@org').then(({id: orgID}: Organization) => {
-        cy.createDashboard(orgID).then(({body: dashboard}) => {
-          cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
-            const now = Date.now()
-            cy.writeData([
-              `test,container_name=cool dopeness=12 ${now - 1000}000000`,
-              `test,container_name=beans dopeness=18 ${now - 1200}000000`,
-              `test,container_name=cool dopeness=14 ${now - 1400}000000`,
-              `test,container_name=beans dopeness=10 ${now - 1600}000000`,
-            ])
-            cy.createCSVVariable(orgID, 'static', ['beans', defaultBucket])
-            cy.createQueryVariable(
-              orgID,
-              'dependent',
-              `from(bucket: v.static)
-|> range(start: v.timeRangeStart, stop: v.timeRangeStop)
-|> filter(fn: (r) => r["_measurement"] == "test")
-|> keep(columns: ["container_name"])
-|> rename(columns: {"container_name": "_value"})
-|> last()
-|> group()`
-            )
-
-            cy.fixture('routes').then(({orgs}) => {
-              cy.visit(`${orgs}/${orgID}/dashboards/${dashboard.id}`)
-            })
-          })
-        })
-      })
-      cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
-        cy.getByTestID('add-cell--button').click()
-        cy.getByTestID('switch-to-script-editor').should('be.visible')
-        cy.getByTestID('switch-to-script-editor').click()
-        cy.getByTestID('toolbar-tab').click()
-
-        cy.getByTestID('flux-editor')
-          .monacoType(`{selectall}{del}from(bucket: v.static)
-|> range(start: v.timeRangeStart, stop: v.timeRangeStop)
-|> filter(fn: (r) => r["_measurement"] == "test")
-|> filter(fn: (r) => r["_field"] == "dopeness")
-|> filter(fn: (r) => r["container_name"] == v.dependent)`)
-        cy.getByTestID('save-cell--button').click()
-
-        // the default bucket selection should have no results
-        cy.getByTestID('variable-dropdown-input-typeAhead--static').should(
-          'have.value',
-          'beans'
-        )
-
-        // and cause the rest to exist in error states
-        cy.getByTestIDSubStr('variable-dropdown--dependent').should(
-          'contain',
-          'Error'
-        )
-
-        // An error notification should tell the user that this failed
-        cy.getByTestID('notification-error').contains(
-          'could not find bucket "beans"'
-        )
-        cy.getByTestID('notification-error--dismiss').click()
-
-        cy.getByTestIDSubStr('cell--view-empty')
-
-        // But selecting a nonempty bucket should load some data
-        cy.getByTestID('variable-dropdown--button')
-          .eq(0)
-          .click()
-        cy.get(`#${defaultBucket}`).click()
-
-        // default select the first result
-        cy.getByTestID('variable-dropdown-input-typeAhead--dependent').should(
-          'have.value',
-          'beans'
-        )
-
-        // and also load the second result
-        cy.getByTestID('variable-dropdown--button')
-          .eq(1)
-          .click()
-        cy.get(`#cool`).click()
-      })
-    })
-  })
-
   it('can create a view through the API', () => {
     cy.get('@org').then(({id: orgID}: Organization) => {
       cy.createDashWithViewAndVar(orgID)
@@ -1298,6 +388,102 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
     )
   })
 
+  it('changes cell view type', () => {
+    const dashName = 'dashboard'
+    const dropdowns = [
+      'band',
+      'gauge',
+      'line-plus-single-stat',
+      'heatmap',
+      'histogram',
+      'mosaic',
+      'scatter',
+      'single-stat',
+      'table',
+    ]
+
+    cy.get<Organization>('@org').then(({id}: Organization) =>
+      cy.createDashboard(id, dashName).then(({body}) => {
+        cy.createCell(body.id).then(cell1Resp =>
+          cy.createView(body.id, cell1Resp.body.id).then(() =>
+            cy.fixture('routes').then(({orgs}) =>
+              cy.get<Organization>('@org').then(({id}: Organization) => {
+                cy.visit(`${orgs}/${id}/dashboards/${body.id}`)
+                cy.getByTestID('tree-nav').then(() =>
+                  cy
+                    .intercept('POST', '/api/v2/query?*')
+                    .as('loadQuery')
+                    .then(() =>
+                      cy
+                        .writeLPDataFromFile({
+                          filename: 'data/wumpus01.lp',
+                          offset: '20m',
+                          stagger: '1m',
+                        })
+                        .should('equal', 'success')
+                    )
+                )
+              })
+            )
+          )
+        )
+      })
+    )
+
+    // graph
+    cy.getByTestID('cell-context--toggle').click()
+    cy.getByTestID('cell-context--configure').click()
+    cy.getByTestID('page-header').should('be.visible')
+    cy.getByTestID('selector-list wumpus').click()
+    cy.getByTestID('selector-list dur').click()
+    cy.getByTestID('time-machine-submit-button').click()
+    cy.getByTestID('save-cell--button').click()
+    cy.wait('@loadQuery')
+    cy.getByTestID('giraffe-layer-line').should('be.visible')
+    for (let i: number = 0; i < dropdowns.length; i++) {
+      cy.getByTestID('cell-context--toggle').click()
+      cy.getByTestID('cell-context--configure').click()
+      cy.getByTestID('page-header').should('be.visible')
+      cy.getByTestID('view-type--dropdown').click()
+      cy.getByTestID('dropdown-menu').should('be.visible')
+      cy.getByTestID(`view-type--${dropdowns[i]}`).click()
+      cy.getByTestID('time-machine-submit-button').click()
+      cy.getByTestID('save-cell--button').click()
+      cy.wait('@loadQuery')
+      cy.getByTestID(`cell--view-empty ${dropdowns[i]}`).should('be.visible')
+    }
+  })
+
+  it('creates a dashboard to test light/dark mode toggle', () => {
+    // dashboard creation
+    cy.get('@org').then(({id: orgID}: Organization) => {
+      cy.createDashboard(orgID).then(({body}) => {
+        cy.fixture('routes').then(({orgs}) => {
+          cy.visit(`${orgs}/${orgID}/dashboards/${body.id}`)
+          cy.getByTestID('tree-nav')
+        })
+      })
+    })
+
+    cy.getByTestID('collapsible_menu').click()
+
+    cy.get('label[title="Light Mode"]').click() // light mode
+    cy.getByTestID('app-wrapper')
+      .invoke('css', 'background-color')
+      .should('equal', 'rgb(241, 241, 243)')
+    cy.getByTestID('app-wrapper')
+      .invoke('css', 'color')
+      .should('equal', 'rgb(104, 104, 123)')
+
+    cy.get('label[title="Dark Mode"]').click() // dark mode
+    cy.getByTestID('app-wrapper')
+      .invoke('css', 'background-color')
+      .should('equal', 'rgb(7, 7, 14)')
+    cy.getByTestID('app-wrapper')
+      .invoke('css', 'color')
+      .should('equal', 'rgb(241, 241, 243)')
+  })
+
   describe('clone cell', () => {
     let otherBoardID: string
     let orgId: string
@@ -1373,107 +559,5 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
       cy.getByTestID('tree-nav')
       cy.getByTestID('empty-state--text').should('be.visible')
     })
-  })
-
-  describe('light/dark Mode Toggle', () => {
-    it('creates a dashboard to test light/dark mode toggle', () => {
-      // dashboard creation
-      cy.get('@org').then(({id: orgID}: Organization) => {
-        cy.createDashboard(orgID).then(({body}) => {
-          cy.fixture('routes').then(({orgs}) => {
-            cy.visit(`${orgs}/${orgID}/dashboards/${body.id}`)
-            cy.getByTestID('tree-nav')
-          })
-        })
-      })
-
-      cy.getByTestID('collapsible_menu').click()
-
-      cy.get('label[title="Light Mode"]').click() // light mode
-      cy.getByTestID('app-wrapper')
-        .invoke('css', 'background-color')
-        .should('equal', 'rgb(241, 241, 243)')
-      cy.getByTestID('app-wrapper')
-        .invoke('css', 'color')
-        .should('equal', 'rgb(104, 104, 123)')
-
-      cy.get('label[title="Dark Mode"]').click() // dark mode
-      cy.getByTestID('app-wrapper')
-        .invoke('css', 'background-color')
-        .should('equal', 'rgb(7, 7, 14)')
-      cy.getByTestID('app-wrapper')
-        .invoke('css', 'color')
-        .should('equal', 'rgb(241, 241, 243)')
-      /*
-       */
-    })
-  })
-
-  it('changes cell view type', () => {
-    const dashName = 'dashboard'
-    const dropdowns = [
-      'band',
-      'gauge',
-      'line-plus-single-stat',
-      'heatmap',
-      'histogram',
-      'mosaic',
-      'scatter',
-      'single-stat',
-      'table',
-    ]
-
-    cy.get<Organization>('@org').then(({id}: Organization) =>
-      cy.createDashboard(id, dashName).then(({body}) => {
-        cy.createCell(body.id).then(cell1Resp =>
-          cy.createView(body.id, cell1Resp.body.id).then(() =>
-            cy.fixture('routes').then(({orgs}) =>
-              cy.get<Organization>('@org').then(({id}: Organization) => {
-                cy.visit(`${orgs}/${id}/dashboards/${body.id}`)
-                cy.getByTestID('tree-nav').then(() =>
-                  cy
-                    .intercept('POST', '/api/v2/query?*')
-                    .as('loadQuery')
-                    .then(() =>
-                      cy
-                        .writeLPDataFromFile({
-                          filename: 'data/wumpus01.lp',
-                          offset: '20m',
-                          stagger: '1m',
-                        })
-                        .should('equal', 'success')
-                    )
-                )
-              })
-            )
-          )
-        )
-      })
-    )
-
-    // graph
-    cy.getByTestID('cell-context--toggle').click()
-    cy.getByTestID('cell-context--configure').click()
-    cy.getByTestID('page-header').should('be.visible')
-    cy.getByTestID('selector-list wumpus').click()
-    cy.getByTestID('selector-list dur').click()
-    cy.getByTestID('time-machine-submit-button').click()
-    cy.getByTestID('save-cell--button').click()
-    cy.wait('@loadQuery')
-    cy.getByTestID('giraffe-layer-line').should('be.visible')
-    ;(function() {
-      for (let i: number = 0; i < dropdowns.length; i++) {
-        cy.getByTestID('cell-context--toggle').click()
-        cy.getByTestID('cell-context--configure').click()
-        cy.getByTestID('page-header').should('be.visible')
-        cy.getByTestID('view-type--dropdown').click()
-        cy.getByTestID('dropdown-menu').should('be.visible')
-        cy.getByTestID(`view-type--${dropdowns[i]}`).click()
-        cy.getByTestID('time-machine-submit-button').click()
-        cy.getByTestID('save-cell--button').click()
-        cy.wait('@loadQuery')
-        cy.getByTestID(`cell--view-empty ${dropdowns[i]}`).should('be.visible')
-      }
-    })()
   })
 })


### PR DESCRIPTION
Splits `dashboardsView.test.ts` into two files:
- `dashboardsView.test.ts`
- `dashboardsVariables.test.ts`

Cleans up unnecessary code.

No functional changes to any tests.
