### PR TITLE
fix(notebook): fix run button disable/enable

### DIFF
--- a/src/flows/components/header/Submit.tsx
+++ b/src/flows/components/header/Submit.tsx
@@ -19,7 +19,7 @@ export const Submit: FC = () => {
   const {cancel} = useContext(QueryContext)
   const {generateMap, queryAll, status} = useContext(FlowQueryContext)
 
-  const hasQueries = generateMap().filter(s => !!s.source).length > 0
+  const hasQueries = generateMap(true).filter(s => !!s.source).length > 0
 
   const handleSubmit = () => {
     event('Notebook Submit Button Clicked')

--- a/src/flows/context/flow.query.tsx
+++ b/src/flows/context/flow.query.tsx
@@ -25,7 +25,7 @@ export interface Stage {
 }
 
 export interface FlowQueryContextType {
-  generateMap: () => Stage[]
+  generateMap: (doubleForceUpdate?: boolean) => Stage[]
   printMap: (id?: string) => void
   query: (text: string, override?: QueryScope) => Promise<FluxResult>
   basic: (text: string, override?: QueryScope) => any
@@ -177,7 +177,7 @@ export const FlowQueryProvider: FC = ({children}) => {
     _generateMap()
   }, [flow])
 
-  const generateMap = (): Stage[] => {
+  const generateMap = (doubleForceUpdate?: boolean): Stage[] => {
     // this is to get around an issue where a panel is added, which triggers the useEffect that updates
     // _map.current and a rerender that updates the panel view components within the same render cycle
     // leading to a panel on the list without a corresponding map entry
@@ -185,7 +185,8 @@ export const FlowQueryProvider: FC = ({children}) => {
       (flow?.data?.allIDs ?? []).join(' ') !==
       (_map.current ?? []).map(m => m.id).join(' ')
 
-    if (forceUpdate) {
+    if (forceUpdate || doubleForceUpdate) {
+      // doubleForceUpdate is used to resolve react life cycle issue
       _generateMap()
     }
 


### PR DESCRIPTION
Closes #4366 

This PR fixed the bug that the "Run" button sometimes got disabled when a flux script is valid.

## Before

https://user-images.githubusercontent.com/14298407/163861127-3fb9f433-2b69-4393-9a43-4a2bf6dbd857.mov

## After

https://user-images.githubusercontent.com/14298407/163861305-df21c127-7420-4e63-83ea-1a6346a444ec.mov
