### PR TITLE
feat: upgrade clockface, add name and hide checkmark in subscriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
   },
   "dependencies": {
     "@docsearch/react": "^3.0.0-alpha.37",
-    "@influxdata/clockface": "^3.6.0",
+    "@influxdata/clockface": "^3.11.0",
     "@influxdata/flux-lsp-browser": "0.8.8",
     "@influxdata/giraffe": "^2.25.0",
     "@influxdata/influxdb-templates": "0.9.0",

--- a/src/writeData/subscriptions/components/SinglePageSubDetails.tsx
+++ b/src/writeData/subscriptions/components/SinglePageSubDetails.tsx
@@ -133,6 +133,8 @@ const SinglePageSubDetails: FC = () => {
                 navigationSteps={navigationSteps}
                 settingUpIcon={FormLogo}
                 settingUpText="MQTT Connector"
+                settingUpHeader={currentSubscription.name}
+                showCheckmark={false}
               />
             </div>
             <SinglePageBrokerDetails

--- a/src/writeData/subscriptions/components/SubscriptionDetailsPage.tsx
+++ b/src/writeData/subscriptions/components/SubscriptionDetailsPage.tsx
@@ -130,6 +130,7 @@ const SubscriptionDetailsPage: FC = () => {
                 navigationSteps={navigationSteps}
                 settingUpIcon={FormLogo}
                 settingUpText="MQTT Connector"
+                settingUpHeader={currentSubscription.name}
               />
             </div>
             {active === Steps.BrokerForm && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -1437,10 +1437,10 @@
     gud "^1.0.0"
     warning "^4.0.3"
 
-"@influxdata/clockface@^3.6.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-3.6.0.tgz#02c3683c578ad3878a85918ddd1c1dc3f46e9923"
-  integrity sha512-LrjsHB+VxsDWEq41+vfrhcbcMhNSilWIR1QvF0RoOS7hEoem7yl5yLytxgKKTeibV4EwRfI0B+qsQ6I3KhXBIA==
+"@influxdata/clockface@^3.11.0":
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-3.11.0.tgz#c4e4d7a073495b8ecca07348befd264355b560df"
+  integrity sha512-Pcd3bq0qqnUMJgwErHRtzFY82EOaqjGKvJz+a5WE/umVt5jxZ0TiNO5Dyd5KkLE7NCQnHe4yR3kZdcJ5LWBONg==
 
 "@influxdata/flux-lsp-browser@0.8.8":
   version "0.8.8"


### PR DESCRIPTION
Closes https://github.com/influxdata/data-acquisition/issues/240

Upgrades clockface from 3.6.0 to 3.11.0 this brings in the new props for subway nav so on click our details view doesn't show checkmarks and include the subscription name. 


https://user-images.githubusercontent.com/38860767/163867096-d31d76ea-c897-4b68-85b2-09b85353cac1.mov


