### PR TITLE
feat: add time series video to the overview page

### DIFF
--- a/src/homepageExperience/components/steps/Overview.tsx
+++ b/src/homepageExperience/components/steps/Overview.tsx
@@ -1,4 +1,5 @@
 import React, {PureComponent} from 'react'
+import {SafeBlankLink} from '../../../utils/SafeBlankLink'
 
 export class Overview extends PureComponent {
   render() {
@@ -13,7 +14,24 @@ export class Overview extends PureComponent {
             and write and execute some basic queries.
           </p>
 
-          <p>Without further ado, let’s get started.</p>
+          <iframe
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/KZwr1xBDbBQ"
+            title="YouTube video player"
+            frameBorder="0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+            style={{marginBottom: '20px'}}
+          />
+
+          <p>
+            Join our{' '}
+            <SafeBlankLink href="https://www.influxdata.com/slack">
+              community slack{' '}
+            </SafeBlankLink>{' '}
+            to ask any questions you have along the way!
+          </p>
         </article>
       </div>
     )

--- a/src/homepageExperience/components/steps/Overview.tsx
+++ b/src/homepageExperience/components/steps/Overview.tsx
@@ -1,5 +1,5 @@
 import React, {PureComponent} from 'react'
-import {SafeBlankLink} from '../../../utils/SafeBlankLink'
+import {SafeBlankLink} from 'src/utils/SafeBlankLink'
 
 export class Overview extends PureComponent {
   render() {

--- a/src/homepageExperience/components/steps/Overview.tsx
+++ b/src/homepageExperience/components/steps/Overview.tsx
@@ -18,7 +18,7 @@ export class Overview extends PureComponent {
             width="560"
             height="315"
             src="https://www.youtube.com/embed/KZwr1xBDbBQ"
-            title="YouTube video player"
+            title="InfluxData - What is Time Series"
             frameBorder="0"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
             allowFullScreen


### PR DESCRIPTION
Connects https://github.com/influxdata/ui/issues/4372

Waiting on design to add the videos for the finish page.

<img width="1454" alt="Screen Shot 2022-04-19 at 11 15 27 AM" src="https://user-images.githubusercontent.com/18511823/164069243-6bf65132-4139-4be9-8397-9d1da215f9cd.png">

