### PR TITLE
feat: update name cloning conventions and update tests

### DIFF
--- a/cypress/e2e/cloud/flows.test.ts
+++ b/cypress/e2e/cloud/flows.test.ts
@@ -33,7 +33,6 @@ describe('Flows', () => {
     )
 
     const flowName = 'Flowbooks'
-    const clone = `${flowName} (clone 1)`
 
     cy.getByTestID('preset-new')
       .first()
@@ -117,6 +116,9 @@ describe('Flows', () => {
 
     cy.getByTestID('resource-editable-name').contains(`${flowName}`)
 
+    const d = Date.UTC(2018, 10, 30)
+    cy.clock(d, ['Date'])
+
     cy.getByTestID(`flow-card--${flowName}`).within(() => {
       cy.getByTestID(`context-menu-flow`).click()
     })
@@ -124,6 +126,8 @@ describe('Flows', () => {
     cy.getByTestID(`context-clone-flow`).click()
 
     cy.getByTestID('time-machine-submit-button').should('be.visible')
+
+    const clone = `${flowName} (cloned at 11-30-2018:00:00:00)`
 
     // Should redirect the user to the newly cloned flow
     // Validates that the selected clone is the clone
@@ -141,9 +145,6 @@ describe('Flows', () => {
       cy.getByTestID(`context-delete-menu--button`).click()
     })
     cy.getByTestID(`context-delete-menu--confirm-button`).click()
-
-    cy.getByTestID('notification-success').should('be.visible')
-    cy.getByTestID('notification-success--dismiss').click()
 
     cy.get('.cf-resource-card').should('have.length', 1)
     cy.getByTestID('resource-editable-name').contains(`${flowName}`)
@@ -164,11 +165,10 @@ describe('Flows', () => {
     cy.getByTestID('flow-menu-button-delete').should('be.visible')
     cy.getByTestID('flow-menu-button-delete').click()
 
-    cy.getByTestID('notification-success').should('be.visible')
-
     cy.get('.cf-resource-card').should('have.length', 1)
     cy.get('.cf-resource-editable-name').should('have.length', 1)
     cy.get('.cf-resource-editable-name').contains(`${flowName}`)
+    cy.clock().invoke('restore')
   })
 
   it('can use the dynamic flux function selector to build a query', () => {

--- a/cypress/e2e/shared/checks.test.ts
+++ b/cypress/e2e/shared/checks.test.ts
@@ -1000,7 +1000,9 @@ describe('Checks', () => {
   describe('Clone checks', () => {
     it('can clone and delete a deadman check', () => {
       cy.intercept('POST', '/api/v2/checks*').as('createCheck')
-      const cloneName = `${deadmanCheck.name} (clone 1)`
+      const d = Date.UTC(2018, 10, 30)
+      cy.clock(d, ['Date'])
+      const cloneName = `${deadmanCheck.name} (cloned at 11-30-2018:00:00:00)`
       // 1. create deadman over API
       initCheck(deadmanCheck)
       cy.reload()
@@ -1015,6 +1017,7 @@ describe('Checks', () => {
       cy.getByTestID('context-menu-task').click()
       cy.getByTestID('context-clone-task').click()
       cy.wait('@createCheck')
+      cy.clock().invoke('restore')
       // 3. Asserts
       cy.get<GenCheck>('@check').then(check => {
         cy.getByTestID(`check-card ${cloneName}`).within(() => {

--- a/cypress/e2e/shared/dashboardsIndex.test.ts
+++ b/cypress/e2e/shared/dashboardsIndex.test.ts
@@ -208,14 +208,16 @@ describe('Dashboards', () => {
           cy.getByTestID('context-menu-dashboard').click()
         })
 
+      const d = Date.UTC(2018, 10, 30)
+      cy.clock(d, ['Date'])
+      const cloneName = `${localDashName} (cloned at 11-30-2018:00:00:00)`
+
       cy.getByTestID('context-clone-dashboard').click()
 
+      cy.clock().invoke('restore')
       // Verify cloned dashboard contents
 
-      cy.getByTestID('page-title').should(
-        'contain.text',
-        `${localDashName} (clone 1)`
-      )
+      cy.getByTestID('page-title').should('contain.text', cloneName)
       cy.getByTestID('variable-dropdown--Power').should('be.visible')
       cy.getByTestID('variable-dropdown-input-typeAhead--Power').should(
         'have.value',
@@ -258,10 +260,7 @@ describe('Dashboards', () => {
         .eq(1)
         .within(() => {
           cy.getByTestID(`label--pill ${labelName}`).should('be.visible')
-          cy.getByTestID('dashboard-card--name').should(
-            'contain',
-            `${localDashName} (clone 1)`
-          )
+          cy.getByTestID('dashboard-card--name').should('contain', cloneName)
           cy.getByTestID('inline-labels--add').click()
         })
 

--- a/cypress/e2e/shared/dashboardsView.test.ts
+++ b/cypress/e2e/shared/dashboardsView.test.ts
@@ -536,27 +536,35 @@ describe('Dashboard', () => {
     })
 
     it('clones a cell to another dashboard and displays it there', () => {
+      const d = Date.UTC(2018, 10, 30)
+      cy.clock(d, ['Date'])
+      const cloneName = 'cell blah (cloned at 11-30-2018:00:00:00)'
       cy.getByTestID('clone-to-other-dashboard').click()
       cy.getByTestID(`other-dashboard-${otherBoardID}`).click()
       cy.intercept('PATCH', '/api/v2/dashboards/*/cells/*/view').as('setView')
       cy.getByTestID('confirm-clone-cell-button').click()
 
       cy.wait('@setView')
+      cy.clock().invoke('restore')
       cy.visit(`${allOrgs}/${orgId}/dashboards/${otherBoardID}`)
       cy.getByTestID('tree-nav')
-      cy.getByTestID('cell blah (clone 1)').should('be.visible')
+      cy.getByTestID(cloneName).should('be.visible')
     })
 
     it('moves a cell to another dashboard and removes it from the current one', () => {
+      const d = Date.UTC(2018, 10, 30)
+      cy.clock(d, ['Date'])
+      const cloneName = 'cell blah (cloned at 11-30-2018:00:00:00)'
       cy.getByTestID('clone-to-other-dashboard').click()
       cy.getByTestID(`other-dashboard-${otherBoardID}`).click()
       cy.getByTestID('cell-clone-move-cell').click()
       cy.intercept('PATCH', '/api/v2/dashboards/*/cells/*/view').as('setView')
       cy.getByTestID('confirm-clone-cell-button').click()
       cy.wait('@setView')
+      cy.clock().invoke('restore')
       cy.visit(`${allOrgs}/${orgId}/dashboards/${otherBoardID}`)
       cy.getByTestID('tree-nav')
-      cy.getByTestID('cell blah (clone 1)').should('be.visible')
+      cy.getByTestID(cloneName).should('be.visible')
       cy.go('back')
       cy.getByTestID('tree-nav')
       cy.getByTestID('empty-state--text').should('be.visible')

--- a/cypress/e2e/shared/flows.test.ts
+++ b/cypress/e2e/shared/flows.test.ts
@@ -1,4 +1,4 @@
-import {Organization} from '../../src/types'
+import {Organization} from '../../../src/types'
 
 describe('Flows', () => {
   beforeEach(() => {

--- a/cypress/e2e/shared/notificationRules.test.ts
+++ b/cypress/e2e/shared/notificationRules.test.ts
@@ -1030,6 +1030,9 @@ describe('NotificationRules', () => {
 
     it('can clone, modify and delete a notification rule', () => {
       cy.log('clone rule')
+      const d = Date.UTC(2018, 10, 30)
+      cy.clock(d, ['Date'])
+      const cloneName = `${rule2Clone.name} (cloned at 11-30-2018:00:00:00)`
       cy.getByTestID(`rule-card ${rule2Clone.name}`).within(() => {
         cy.getByTestID('context-menu-task').click()
       })
@@ -1045,9 +1048,10 @@ describe('NotificationRules', () => {
           ).as('TargetTaskID')
         })
       })
+      cy.clock().invoke('restore')
 
       cy.log('=== verify basic identifying parameters')
-      cy.getByTestID(`rule-card ${rule2Clone.name} (clone 1)`).within(() => {
+      cy.getByTestID(`rule-card ${cloneName}`).within(() => {
         cy.getByTestID('copy-resource-id').then(elem => {
           cy.wrap(
             elem
@@ -1071,10 +1075,7 @@ describe('NotificationRules', () => {
       })
 
       cy.log('=== verify then change cloned values')
-      cy.getByTestID('rule-name--input').should(
-        'have.value',
-        `${rule2Clone.name} (clone 1)`
-      )
+      cy.getByTestID('rule-name--input').should('have.value', cloneName)
 
       cy.getByTestID('rule-name--input')
         .clear()

--- a/cypress/e2e/shared/tasks.test.ts
+++ b/cypress/e2e/shared/tasks.test.ts
@@ -258,6 +258,9 @@ from(bucket: "defbuck")
 
     it('can clone a task and edit it', () => {
       // clone a task
+      const d = Date.UTC(2018, 10, 30)
+      cy.clock(d, ['Date'])
+      const cloneName = '🦄ask (cloned at 11-30-2018:00:00:00)'
       cy.getByTestID('task-card').then(() => {
         cy.getByTestID('context-menu-task').click()
         cy.getByTestID('context-clone-task')
@@ -266,9 +269,10 @@ from(bucket: "defbuck")
       })
 
       cy.getByTestID('task-card').should('have.length', 2)
+      cy.clock().invoke('restore')
 
       // assert the values of the task and change them
-      cy.getByTestID('task-card--name').contains('🦄ask (clone 1)')
+      cy.getByTestID('task-card--name').contains(cloneName)
 
       cy.getByTestID('task-card').then(() => {
         cy.getByTestID('context-menu-task')
@@ -284,7 +288,7 @@ from(bucket: "defbuck")
 
       cy.getByTestID('flux-editor').should('be.visible')
 
-      cy.getByTestID('task-form-name').should('have.value', '🦄ask (clone 1)')
+      cy.getByTestID('task-form-name').should('have.value', cloneName)
       cy.getByTestID('task-form-name')
         .focus()
         .clear()

--- a/cypress/e2e/shared/telegrafs.test.ts
+++ b/cypress/e2e/shared/telegrafs.test.ts
@@ -189,14 +189,18 @@ describe('Collectors', () => {
         cy.getByTestID(`label--pill ${secondLabel}`).should('be.visible')
 
         // clone the telegraf
+        const d = Date.UTC(2018, 10, 30)
+        cy.clock(d, ['Date'])
+        const cloneName = 'New Config (cloned at 11-30-2018:00:00:00)'
         cy.getByTestID('context-menu-telegraf').click()
         cy.getByTestID('context-clone-telegraf').click()
         cy.getByTestID(`label--pill ${firstLabel}`).should('have.length', 2)
         cy.getByTestID(`label--pill ${secondLabel}`).should('have.length', 2)
         cy.getByTestID('resource-card').should('have.length', 2)
         cy.getByTestID('collector-card--name').then(el => {
-          expect(el[1].innerText).to.equal('New Config (clone 1)')
+          expect(el[1].innerText).to.equal(cloneName)
         })
+        cy.clock().invoke('restore')
       })
     })
 

--- a/src/authorizations/components/TokenRow.tsx
+++ b/src/authorizations/components/TokenRow.tsx
@@ -32,14 +32,14 @@ import {
 } from '@influxdata/clockface'
 
 // Types
-import {Authorization, AppState} from 'src/types'
+import {Authorization} from 'src/types'
 import {
   UPDATED_AT_TIME_FORMAT,
   DEFAULT_TOKEN_DESCRIPTION,
 } from 'src/dashboards/constants'
 
 import {relativeTimestampFormatter} from 'src/shared/utils/relativeTimestampFormatter'
-import {incrementCloneName} from 'src/utils/naming'
+import {setCloneName} from 'src/utils/naming'
 import {event} from 'src/cloud/utils/reporting'
 
 interface OwnProps {
@@ -146,14 +146,11 @@ class TokensRow extends PureComponent<Props> {
 
   private handleClone = async () => {
     const {description} = this.props.auth
-    const allTokenDescriptions = Object.values(this.props.authorizations).map(
-      auth => auth.description
-    )
 
     try {
       await this.props.createAuthorization({
         ...this.props.auth,
-        description: incrementCloneName(allTokenDescriptions, description),
+        description: setCloneName(description),
       })
       event('token.clone.success', {id: this.props.auth.id, name: description})
       this.props.showOverlay('access-cloned-token', null, () =>
@@ -180,11 +177,6 @@ class TokensRow extends PureComponent<Props> {
   }
 }
 
-const mstp = (state: AppState) => {
-  const authorizations = state.resources.tokens.byID
-  return {authorizations}
-}
-
 const mdtp = {
   deleteAuthorization,
   updateAuthorization,
@@ -193,6 +185,6 @@ const mdtp = {
   dismissOverlay,
 }
 
-const connector = connect(mstp, mdtp)
+const connector = connect(null, mdtp)
 
 export const TokenRow = connector(withRouter(TokensRow))

--- a/src/checks/actions/thunks.ts
+++ b/src/checks/actions/thunks.ts
@@ -13,12 +13,12 @@ import * as api from 'src/client'
 import {checkSchema, arrayOfChecks} from 'src/schemas/checks'
 
 // Utils
-import {incrementCloneName} from 'src/utils/naming'
+import {setCloneName} from 'src/utils/naming'
 import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
 import {createView} from 'src/views/helpers'
 import {getOrg} from 'src/organizations/selectors'
 import {toPostCheck, builderToPostCheck} from 'src/checks/utils'
-import {getAll, getStatus} from 'src/resources/selectors'
+import {getStatus} from 'src/resources/selectors'
 import {getErrorMessage} from 'src/utils/api'
 
 // Actions
@@ -309,16 +309,13 @@ export const deleteCheckLabel = (checkID: string, labelID: string) => async (
 export const cloneCheck = (check: Check) => async (
   dispatch: Dispatch<
     Action | NotificationAction | ReturnType<typeof checkChecksLimits>
-  >,
-  getState: GetState
+  >
 ): Promise<void> => {
   try {
-    const state = getState()
-    const checks = getAll<Check>(state, ResourceType.Checks)
-    const allCheckNames = checks.map(c => c.name)
-    const clonedName = incrementCloneName(allCheckNames, check.name)
-
-    const data = toPostCheck({...check, name: clonedName})
+    const data = toPostCheck({
+      ...check,
+      name: setCloneName(check.name),
+    })
 
     const resp = await api.postCheck({data})
 

--- a/src/dashboards/actions/thunks.ts
+++ b/src/dashboards/actions/thunks.ts
@@ -46,10 +46,10 @@ import {createView} from 'src/views/helpers'
 
 // Utils
 import {getSaveableView} from 'src/timeMachine/selectors'
-import {incrementCloneName} from 'src/utils/naming'
+import {setCloneName} from 'src/utils/naming'
 import {isLimitError} from 'src/cloud/utils/limits'
 import {getOrg} from 'src/organizations/selectors'
-import {getAll, getByID, getStatus} from 'src/resources/selectors'
+import {getByID, getStatus} from 'src/resources/selectors'
 
 // Constants
 import * as copy from 'src/shared/copy/notifications'
@@ -125,9 +125,6 @@ export const cloneDashboard = (
     const state = getState()
 
     const org = getOrg(state)
-    const dashboards = getAll<Dashboard>(state, ResourceType.Dashboards)
-    const allDashboardNames = dashboards.map(d => d.name)
-    const clonedName = incrementCloneName(allDashboardNames, dashboardName)
 
     const getResp = await api.getDashboard({
       dashboardID,
@@ -149,7 +146,7 @@ export const cloneDashboard = (
     const postResp = await api.postDashboard({
       data: {
         orgID: org.id,
-        name: clonedName,
+        name: setCloneName(dashboardName),
         description: dash.description || '',
       },
     })

--- a/src/flows/components/VersionSidebar.tsx
+++ b/src/flows/components/VersionSidebar.tsx
@@ -31,8 +31,7 @@ import {
   postNotebook,
   VersionHistory,
 } from 'src/client/notebooksRoutes'
-import {getAllAPI} from 'src/flows/context/api'
-import {incrementCloneName} from 'src/utils/naming'
+import {setCloneName} from 'src/utils/naming'
 import {serialize} from 'src/flows/context/flow.list'
 
 // Constants
@@ -79,12 +78,10 @@ const VersionSidebarListItem: FC<Props> = ({version}) => {
   const handleClone = async () => {
     event('clone_notebook_version')
     try {
-      const {flows} = await getAllAPI(orgID)
-
-      const allFlowNames = Object.values(flows).map(value => value.name)
-      const clonedName = incrementCloneName(allFlowNames, flow.name)
-
-      const _flow = serialize({...flow, name: clonedName})
+      const _flow = serialize({
+        ...flow,
+        name: setCloneName(flow.name),
+      })
       delete _flow.data.id
 
       const response = await postNotebook(_flow)

--- a/src/flows/context/flow.current.tsx
+++ b/src/flows/context/flow.current.tsx
@@ -11,11 +11,9 @@ import {
   deleteNotebook,
   getNotebook,
   postNotebook,
-  postNotebooksClone,
 } from 'src/client/notebooksRoutes'
 import {event} from 'src/cloud/utils/reporting'
-import {incrementCloneName} from 'src/utils/naming'
-import {getAllAPI, pooledUpdateAPI} from 'src/flows/context/api'
+import {pooledUpdateAPI} from 'src/flows/context/api'
 import {useDispatch} from 'react-redux'
 import {notify} from 'src/shared/actions/notifications'
 import {
@@ -25,7 +23,7 @@ import {
 import PageSpinner from 'src/perf/components/PageSpinner'
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 import {RemoteDataState} from '@influxdata/clockface'
-import {CLOUD} from 'src/shared/constants'
+import {setCloneName} from 'src/utils/naming'
 
 const prettyid = customAlphabet('abcdefghijklmnop0123456789', 12)
 
@@ -90,36 +88,19 @@ export const FlowProvider: FC = ({children}) => {
 
   const handleCloneNotebook = useCallback(async () => {
     try {
-      if (CLOUD) {
-        const response = await postNotebooksClone({
-          id: currentFlow.id,
-          data: {
-            orgID,
-          },
-        })
+      const _flow = serialize({
+        ...currentFlow,
+        name: setCloneName(currentFlow.name),
+      })
+      delete _flow.data.id
 
-        if (response.status !== 200) {
-          throw new Error(response.data.message)
-        }
+      const response = await postNotebook(_flow)
 
-        return response.data.id
-      } else {
-        const {flows} = await getAllAPI(orgID)
-
-        const allFlowNames = Object.values(flows).map(value => value.name)
-        const clonedName = incrementCloneName(allFlowNames, currentFlow.name)
-
-        const _flow = serialize({...currentFlow, name: clonedName})
-        delete _flow.data.id
-
-        const response = await postNotebook(_flow)
-
-        if (response.status !== 200) {
-          throw new Error(response.data.message)
-        }
-
-        return response.data.id
+      if (response.status !== 200) {
+        throw new Error(response.data.message)
       }
+
+      return response.data.id
     } catch (error) {
       console.error({error})
     }

--- a/src/notifications/endpoints/actions/thunks.ts
+++ b/src/notifications/endpoints/actions/thunks.ts
@@ -25,9 +25,9 @@ import {labelSchema} from 'src/schemas/labels'
 import * as api from 'src/client'
 
 // Utils
-import {incrementCloneName} from 'src/utils/naming'
+import {setCloneName} from 'src/utils/naming'
 import {getOrg} from 'src/organizations/selectors'
-import {getAll, getStatus} from 'src/resources/selectors'
+import {getStatus} from 'src/resources/selectors'
 import {toPostNotificationEndpoint} from 'src/notifications/endpoints/utils'
 import * as copy from 'src/shared/copy/notifications'
 
@@ -232,24 +232,13 @@ export const deleteEndpointLabel = (
 export const cloneEndpoint = (endpoint: NotificationEndpoint) => async (
   dispatch: Dispatch<
     Action | NotificationAction | ReturnType<typeof checkEndpointsLimits>
-  >,
-  getState: GetState
+  >
 ): Promise<void> => {
   try {
-    const state = getState()
-    const endpoints = getAll<NotificationEndpoint>(
-      state,
-      ResourceType.NotificationEndpoints
-    )
-
-    const allEndpointNames = endpoints.map(r => r.name)
-
-    const clonedName = incrementCloneName(allEndpointNames, endpoint.name)
-
     const resp = await api.postNotificationEndpoint({
       data: {
         ...toPostNotificationEndpoint(endpoint),
-        name: clonedName,
+        name: setCloneName(endpoint.name),
       },
     })
 

--- a/src/notifications/rules/actions/thunks.ts
+++ b/src/notifications/rules/actions/thunks.ts
@@ -31,8 +31,8 @@ import {setLabelOnResource} from 'src/labels/actions/creators'
 // Utils
 import {draftRuleToPostRule} from 'src/notifications/rules/utils'
 import {getOrg} from 'src/organizations/selectors'
-import {getAll, getStatus} from 'src/resources/selectors'
-import {incrementCloneName} from 'src/utils/naming'
+import {getStatus} from 'src/resources/selectors'
+import {setCloneName} from 'src/utils/naming'
 
 // Types
 import {
@@ -263,24 +263,16 @@ export const deleteRuleLabel = (ruleID: string, labelID: string) => async (
 export const cloneRule = (draftRule: NotificationRuleDraft) => async (
   dispatch: Dispatch<
     Action | NotificationAction | ReturnType<typeof checkRulesLimits>
-  >,
-  getState: GetState
+  >
 ): Promise<void> => {
   try {
-    const state = getState()
-    const rules = getAll<NotificationRule>(
-      state,
-      ResourceType.NotificationRules
-    )
-
     const rule = draftRuleToPostRule(draftRule)
 
-    const allRuleNames = rules.map(r => r.name)
-
-    const clonedName = incrementCloneName(allRuleNames, rule.name)
-
     const resp = await api.postNotificationRule({
-      data: {...rule, name: clonedName},
+      data: {
+        ...rule,
+        name: setCloneName(rule.name),
+      },
     })
 
     if (resp.status !== 201) {

--- a/src/shared/components/cells/CellCloneOverlay.tsx
+++ b/src/shared/components/cells/CellCloneOverlay.tsx
@@ -19,10 +19,7 @@ import {
 // Actions
 import {createCellWithView, deleteCellAndView} from 'src/cells/actions/thunks'
 import {getOverlayParams} from 'src/overlays/selectors'
-import {
-  getDashboardIDs,
-  getNewDashboardViewNames,
-} from 'src/dashboards/utils/getDashboardData'
+import {getDashboardIDs} from 'src/dashboards/utils/getDashboardData'
 import {getOrg} from 'src/organizations/selectors'
 
 // Types
@@ -35,10 +32,9 @@ import {notify} from 'src/shared/actions/notifications'
 import {
   dashboardsGetFailed,
   cellCloneSuccess,
-  cellCopyFailed,
 } from 'src/shared/copy/notifications'
 
-import {incrementCloneName} from 'src/utils/naming'
+import {setCloneName} from 'src/utils/naming'
 
 const CellCloneOverlay: FC = () => {
   const [otherDashboards, setOtherDashboards] = useState<Dashboard[]>([])
@@ -48,9 +44,6 @@ const CellCloneOverlay: FC = () => {
   const currentDashboardID = useSelector(
     (state: AppState) => state.currentDashboard.id
   )
-
-  const allViews =
-    useSelector((state: AppState) => state.resources.views.byID) ?? {}
 
   useEffect(() => {
     getDashboardIDs(orgID)
@@ -83,28 +76,7 @@ const CellCloneOverlay: FC = () => {
   }
 
   const copyCellToDashboard = async () => {
-    let destinationViewNames
-    const viewsForDashboard = Object.values(allViews)?.filter(
-      view => view.dashboardID === destinationDashboardID
-    )
-
-    if (!viewsForDashboard?.length) {
-      try {
-        destinationViewNames = await getNewDashboardViewNames(
-          destinationDashboardID
-        )
-      } catch (err) {
-        dispatch(notify(cellCopyFailed(err.message)))
-        return
-      }
-    } else {
-      destinationViewNames = viewsForDashboard.map(v => v.name)
-    }
-
-    const newName = incrementCloneName(
-      destinationViewNames ?? [view.name],
-      view.name
-    )
+    const newName = setCloneName(view.name)
 
     await dispatch(
       createCellWithView(

--- a/src/tasks/actions/thunks.ts
+++ b/src/tasks/actions/thunks.ts
@@ -54,8 +54,8 @@ import {insertPreambleInScript} from 'src/shared/utils/insertPreambleInScript'
 import {isLimitError} from 'src/cloud/utils/limits'
 import {checkTaskLimits} from 'src/cloud/actions/limits'
 import {getOrg} from 'src/organizations/selectors'
-import {getAll, getStatus} from 'src/resources/selectors'
-import {incrementCloneName} from 'src/utils/naming'
+import {getStatus} from 'src/resources/selectors'
+import {setCloneName} from 'src/utils/naming'
 import {event} from 'src/cloud/utils/reporting'
 
 // Types
@@ -362,14 +362,10 @@ const refreshTask = (task: Task) => async (dispatch: Dispatch<Action>) => {
   }
 }
 
-export const cloneTask = (task: Task) => async (
-  dispatch: Dispatch<Action>,
-  getState: GetState
-) => {
+export const cloneTask = (task: Task) => async (dispatch: Dispatch<Action>) => {
   let newTask: Task
 
   try {
-    const state = getState()
     const resp = await api.getTask({taskID: task.id})
 
     if (resp.status !== 200) {
@@ -377,9 +373,7 @@ export const cloneTask = (task: Task) => async (
     }
 
     const taskName = resp.data.name
-    const tasks = getAll<Task>(state, ResourceType.Tasks)
-    const allTaskNames = tasks.map(d => d.name)
-    const clonedName = incrementCloneName(allTaskNames, taskName)
+    const clonedName = setCloneName(taskName)
     const {flux} = resp.data
 
     const ast = parse(flux)

--- a/src/telegrafs/components/CollectorCard.tsx
+++ b/src/telegrafs/components/CollectorCard.tsx
@@ -36,7 +36,7 @@ import {DEFAULT_COLLECTOR_NAME} from 'src/dashboards/constants'
 import {AppState, Label, Telegraf} from 'src/types'
 
 // Utils
-import {incrementCloneName} from 'src/utils/naming'
+import {setCloneName} from 'src/utils/naming'
 
 interface OwnProps {
   collector: Telegraf
@@ -184,12 +184,9 @@ class CollectorRow extends PureComponent<
   }
 
   private cloneTelegraf = (): void => {
-    const allTelegrafNames = Object.values(this.props.telegrafs).map(
-      t => t.name
-    )
     this.props.cloneTelegraf({
       ...this.props.collector,
-      name: incrementCloneName(allTelegrafNames, this.props.collector.name),
+      name: setCloneName(this.props.collector.name),
     })
   }
   private handleDeleteConfig = (): void => {
@@ -199,8 +196,7 @@ class CollectorRow extends PureComponent<
 
 const mstp = (state: AppState) => {
   const org = getOrg(state)
-  const telegrafs = state.resources.telegrafs.byID
-  return {org, telegrafs}
+  return {org}
 }
 
 const mdtp = {

--- a/src/utils/naming.test.ts
+++ b/src/utils/naming.test.ts
@@ -1,17 +1,21 @@
-import {incrementCloneName} from 'src/utils/naming'
+import {setCloneName} from 'src/utils/naming'
 
 describe('The naming of a newly cloned resource', () => {
   it('clones a resource with the same name', () => {
-    const namesList = ['duplicate this']
-    expect(incrementCloneName(namesList, 'duplicate this')).toBe(
-      'duplicate this (clone 1)'
-    )
+    expect(
+      setCloneName(
+        'duplicate this',
+        new Date(Date.UTC(2020, 11, 1, 12, 30, 45))
+      )
+    ).toBe('duplicate this (cloned at 12-01-2020:12:30:45)')
   })
 
   it("clones a clone, but doesn't add any extra spaces", () => {
-    const namesList = ['duplicate this', 'duplicate this  (clone 1)']
-    expect(incrementCloneName(namesList, 'duplicate this  (clone 1)')).toBe(
-      'duplicate this (clone 2)'
-    )
+    expect(
+      setCloneName(
+        'duplicate this  ',
+        new Date(Date.UTC(2020, 11, 1, 12, 30, 45))
+      )
+    ).toBe('duplicate this (cloned at 12-01-2020:12:30:45)')
   })
 })

--- a/src/utils/naming.ts
+++ b/src/utils/naming.ts
@@ -1,32 +1,23 @@
-export const incrementCloneName = (
-  namesList: string[],
-  cloneName: string
-): string => {
-  const root = cloneName.replace(/\s\(clone\s(\d)+\)/g, '').replace(/\)/, '')
-
-  const filteredNames = namesList.filter(n => n.includes(root))
-
-  const highestNumberedClone = filteredNames.reduce((acc, name) => {
-    if (name.match(/\(clone(\s|\d)+\)/)) {
-      const strippedName = name
-        .replace(root, '')
-        .replace(/\(clone/, '')
-        .replace(/\)/, '')
-
-      const cloneNumber = Number(strippedName)
-
-      return cloneNumber >= acc ? cloneNumber : acc
-    }
-
-    return acc
-  }, 0)
-
-  if (highestNumberedClone) {
-    const newCloneNumber = highestNumberedClone + 1
-    return `${cloneName
-      .replace(/\(clone\s(\d)+\)/, '')
-      .trim()} (clone ${newCloneNumber})`
+function prependZero(number) {
+  if (number < 10) {
+    return `0${number}`
   }
+  return number
+}
 
-  return `${cloneName.trim()} (clone 1)`
+// The date parameter here is to help with testing so that we can easily mock a date
+// without having to worry about the overhead of testing time
+export const setCloneName = (name: string, date?: Date): string => {
+  const d = date ? date : new Date()
+  const year = d.getUTCFullYear()
+  const month = d.getUTCMonth() + 1
+  const day = d.getUTCDate()
+  const hour = d.getUTCHours()
+  const minutes = d.getUTCMinutes()
+  const seconds = d.getUTCSeconds()
+  return `${name.trim()} (cloned at ${prependZero(month)}-${prependZero(
+    day
+  )}-${year}:${prependZero(hour)}:${prependZero(minutes)}:${prependZero(
+    seconds
+  )})`
 }


### PR DESCRIPTION
Closes #4241

### Background

Naming a cloned resource was a pretty resource intensive operation that typically involved getting ALL of the resources, flat mapping them to get the name, then using regex to determine an incremented clone value for the new name.

### Solution

Simplify the process so that cloning assigns a UTC-based time appended to the clone so that the naming convention is `name (cloned at month-day-year:hour:minute:second)`. For example:

`flow (cloned at 04-20-2022:06:17:32)`

### Changes

- Updates the `naming` utility to `setCloneName` that trims the name parameter and appends a ` (cloned at ...`) based on the current UTC date
- updates the tests to account for these changes

### Noteworthy

The `setCloneName` takes in a second parameter to make testing dates easier and predictable

<!-- Describe your proposed changes here. -->
