### PR TITLE
chore: Update Operator Types Names

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "cy": "CYPRESS_dexUrl=https://$INGRESS_HOST:$PORT_HTTPS CYPRESS_baseUrl=http://localhost:9999 cypress open",
     "cy:dev": "source ../monitor-ci/.env && CYPRESS_dexUrl=CLOUD CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{cloud,shared}/**/*.*'",
     "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_dexUrl=OSS CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{oss,shared}/**/*.*'",
-    "generate": "export SHA=1a800fb92ad8ed86e28365c4fd5ac43ff193c303 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
+    "generate": "export SHA=4e27f5d5e552e962164d1455d5249ec2d6d0588b && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-meta": "if [ -z \"${CLOUD_URL}\" ]; then yarn generate-meta-oss; else yarn generate-meta-cloud; fi",
     "generate-meta-oss": "yarn oss-api && yarn notebooks && yarn unity && yarn annotations-oss && yarn pinned && yarn mapsd-oss && yarn cloudPriv && yarn fluxdocs && yarn subscriptions-oss",

--- a/src/types/operator.ts
+++ b/src/types/operator.ts
@@ -2,8 +2,8 @@ export {
   OperatorAccount,
   OperatorAccounts,
   OperatorOrgLimits,
-  Organization as OperatorOrg,
-  Organizations,
+  OperatorOrganization as OperatorOrg,
+  OperatorOrganizations as OperatorOrgs,
   OrgLimits,
   User as OperatorUser,
 } from 'src/client/unityRoutes'


### PR DESCRIPTION
Updates Operator Organization type names to avoid conflicts with multi org changes.

Corresponding openapi changes can be found here: https://github.com/influxdata/openapi/commit/4e27f5d5e552e962164d1455d5249ec2d6d0588b

Updates Organization to OperatorOrganization
Updated Organizations to OperatorOrganizations

OperatorOrganization will continue to be aliased as OperatorOrg
OperatorOrganizations will now be aliased as OperatorOrgs

The `Organizations` type was not used anywhere so it did not require any updates (Only `OperatorOrg[]` was used).
Since `Organization` was already aliased, we only needed to update the `type` file.

Co-authored-by: Grace Spletzer <gspletzer@influxdata.com>
Part of https://github.com/influxdata/quartz/issues/6138
