### PR TITLE
fix(alert): keep alert description saved after an alert is edited

### DIFF
--- a/src/alerting/reducers/alertBuilder.test.ts
+++ b/src/alerting/reducers/alertBuilder.test.ts
@@ -59,6 +59,7 @@ const mockState = (): AlertBuilderState => ({
   level: 'OK',
   thresholds: [],
   status: RemoteDataState.Done,
+  description: 'mock test',
 })
 
 describe('alertBuilderReducer', () => {

--- a/src/alerting/reducers/alertBuilder.ts
+++ b/src/alerting/reducers/alertBuilder.ts
@@ -17,7 +17,7 @@ import {
 } from 'src/alerting/constants'
 
 type FromBase = Required<
-  Pick<CheckBase, 'name' | 'id' | 'activeStatus' | 'status'>
+  Pick<CheckBase, 'name' | 'id' | 'activeStatus' | 'status' | 'description'>
 >
 
 type FromThreshold = Required<
@@ -53,6 +53,7 @@ export const initialState = (): AlertBuilderState => ({
   staleTime: '10m',
   level: DEFAULT_DEADMAN_LEVEL,
   thresholds: [],
+  description: '',
 })
 
 export default (
@@ -73,7 +74,7 @@ export default (
     }
 
     case 'SET_ALERT_BUILDER_CHECK': {
-      const {id, type, name, query} = action.payload.check
+      const {id, type, name, query, description} = action.payload.check
 
       const newState = {
         ...initialState(),
@@ -82,6 +83,7 @@ export default (
         name,
         query: {...query},
         type,
+        description,
       }
 
       if (action.payload.check.type === 'custom') {

--- a/src/checks/utils/index.ts
+++ b/src/checks/utils/index.ts
@@ -112,7 +112,7 @@ const validateBuilder = (alertBuilder: AlertBuilder) => {
 }
 
 const genCheckBase = (state: AppState): Check => {
-  const {type, id, status, activeStatus, name} = state.alertBuilder
+  const {type, id, status, activeStatus, name, description} = state.alertBuilder
   const {draftQueries} = getActiveTimeMachine(state)
   const {id: orgID} = getOrg(state)
 
@@ -125,5 +125,6 @@ const genCheckBase = (state: AppState): Check => {
     query: draftQueries[0],
     orgID,
     labels: [],
+    description,
   } as Check
 }


### PR DESCRIPTION
Closes #4348 

This PR fixed a bug in alert description where the description of an alert got erased after the alert was edited.

## Before

https://user-images.githubusercontent.com/14298407/164305163-96ca83fa-a927-45d7-a811-fc0851f6c074.mov

## After

https://user-images.githubusercontent.com/14298407/164304776-ebd0df5e-caf1-439d-83c7-59cf41017a23.mov


