### PR TITLE
feat: make opening links with modifiers work cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
   },
   "dependencies": {
     "@docsearch/react": "^3.0.0-alpha.37",
-    "@influxdata/clockface": "^3.11.0",
+    "@influxdata/clockface": "^3.12.0",
     "@influxdata/flux-lsp-browser": "0.8.8",
     "@influxdata/giraffe": "^2.25.0",
     "@influxdata/influxdb-templates": "0.9.0",

--- a/src/checks/components/CheckCard.tsx
+++ b/src/checks/components/CheckCard.tsx
@@ -46,6 +46,8 @@ import {relativeTimestampFormatter} from 'src/shared/utils/relativeTimestampForm
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
 import {event} from 'src/cloud/utils/reporting'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import {shouldOpenLinkInNewTab} from 'src/utils/crossPlatform'
+import {safeBlankLinkOpen} from 'src/utils/safeBlankLinkOpen'
 
 interface OwnProps {
   check: Check
@@ -68,6 +70,8 @@ const CheckCard: FC<Props> = ({
   history,
 }) => {
   const {activeStatus, description, id, name, taskID} = check
+
+  const checkUrl = `/orgs/${orgID}/alerting/checks/${id}/edit`
 
   const onUpdateName = (name: string) => {
     try {
@@ -104,7 +108,11 @@ const CheckCard: FC<Props> = ({
   }
 
   const onCheckClick = () => {
-    history.push(`/orgs/${orgID}/alerting/checks/${id}/edit`)
+    if (shouldOpenLinkInNewTab(event as MouseEvent)) {
+      safeBlankLinkOpen(checkUrl)
+    } else {
+      history.push(checkUrl)
+    }
   }
 
   const onView = () => {
@@ -188,6 +196,7 @@ const CheckCard: FC<Props> = ({
             testID="check-card--name"
             buttonTestID="check-card--name-button"
             inputTestID="check-card--input"
+            href={checkUrl}
           />
           <ResourceCard.EditableDescription
             onUpdate={onUpdateDescription}

--- a/src/checks/components/CheckCard.tsx
+++ b/src/checks/components/CheckCard.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FC} from 'react'
+import React, {MouseEvent, FC} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
@@ -107,8 +107,8 @@ const CheckCard: FC<Props> = ({
     }
   }
 
-  const onCheckClick = () => {
-    if (shouldOpenLinkInNewTab(event as MouseEvent)) {
+  const onCheckClick = (event: MouseEvent) => {
+    if (shouldOpenLinkInNewTab(event)) {
       safeBlankLinkOpen(checkUrl)
     } else {
       history.push(checkUrl)

--- a/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -39,6 +39,8 @@ import {DEFAULT_DASHBOARD_NAME} from 'src/dashboards/constants'
 
 // Utilities
 import {relativeTimestampFormatter} from 'src/shared/utils/relativeTimestampFormatter'
+import {shouldOpenLinkInNewTab} from 'src/utils/crossPlatform'
+import {safeBlankLinkOpen} from 'src/utils/safeBlankLinkOpen'
 
 import {
   pinnedItemFailure,
@@ -86,7 +88,16 @@ class DashboardCard extends PureComponent<Props> {
       onFilterChange,
       labels,
       updatedAt,
+      match: {
+        params: {orgID},
+      },
     } = this.props
+
+    let dashboardUrl = `/orgs/${orgID}/dashboards/${id}`
+
+    if (isFlagEnabled('boardWithFlows')) {
+      dashboardUrl = `/${PROJECT_NAME.toLowerCase()}/from/dashboard/${id}`
+    }
 
     return (
       <ResourceCard
@@ -102,6 +113,7 @@ class DashboardCard extends PureComponent<Props> {
           testID="dashboard-card--name"
           buttonTestID="dashboard-card--name-button"
           inputTestID="dashboard-card--input"
+          href={dashboardUrl}
         />
         <ResourceCard.EditableDescription
           onUpdate={this.handleUpdateDescription}
@@ -222,7 +234,7 @@ class DashboardCard extends PureComponent<Props> {
     deletePinnedItemByParam(id)
   }
 
-  private handleClickDashboard = e => {
+  private handleClickDashboard = event => {
     const {
       onResetViews,
       history,
@@ -232,16 +244,16 @@ class DashboardCard extends PureComponent<Props> {
       },
     } = this.props
 
-    let dest = `/${PROJECT_NAME.toLowerCase()}/from/dashboard/${id}`
+    let dashboardUrl = `/orgs/${orgID}/dashboards/${id}`
 
-    if (!isFlagEnabled('boardWithFlows')) {
-      dest = `/orgs/${orgID}/dashboards/${id}`
+    if (isFlagEnabled('boardWithFlows')) {
+      dashboardUrl = `/${PROJECT_NAME.toLowerCase()}/from/dashboard/${id}`
     }
 
-    if (e.metaKey) {
-      window.open(dest, '_blank')
+    if (shouldOpenLinkInNewTab(event)) {
+      safeBlankLinkOpen(dashboardUrl)
     } else {
-      history.push(dest)
+      history.push(dashboardUrl)
     }
 
     onResetViews()

--- a/src/flows/components/FlowCard.tsx
+++ b/src/flows/components/FlowCard.tsx
@@ -33,12 +33,13 @@ const FlowCard: FC<Props> = ({id, isPinned}) => {
   const history = useHistory()
   const dispatch = useDispatch()
 
+  const flowUrl = `/orgs/${orgID}/${PROJECT_NAME_PLURAL.toLowerCase()}/${id}`
+
   const handleClick = event => {
-    const url = `/orgs/${orgID}/${PROJECT_NAME_PLURAL.toLowerCase()}/${id}`
     if (shouldOpenLinkInNewTab(event)) {
-      safeBlankLinkOpen(url)
+      safeBlankLinkOpen(flowUrl)
     } else {
-      history.push(url)
+      history.push(flowUrl)
     }
   }
 
@@ -96,6 +97,7 @@ const FlowCard: FC<Props> = ({id, isPinned}) => {
         onClick={handleClick}
         onUpdate={handleRenameNotebook}
         buttonTestID="flow-card--name-button"
+        href={flowUrl}
       />
       <ResourceCard.Meta>{meta}</ResourceCard.Meta>
     </ResourceCard>

--- a/src/flows/components/FlowCard.tsx
+++ b/src/flows/components/FlowCard.tsx
@@ -17,6 +17,8 @@ import {
   pinnedItemSuccess,
 } from 'src/shared/copy/notifications'
 import {notify} from 'src/shared/actions/notifications'
+import {shouldOpenLinkInNewTab} from 'src/utils/crossPlatform'
+import {safeBlankLinkOpen} from 'src/utils/safeBlankLinkOpen'
 
 interface Props {
   id: string
@@ -33,8 +35,8 @@ const FlowCard: FC<Props> = ({id, isPinned}) => {
 
   const handleClick = event => {
     const url = `/orgs/${orgID}/${PROJECT_NAME_PLURAL.toLowerCase()}/${id}`
-    if (event.metaKey) {
-      window.open(url, '_blank', 'noopener')
+    if (shouldOpenLinkInNewTab(event)) {
+      safeBlankLinkOpen(url)
     } else {
       history.push(url)
     }

--- a/src/tasks/components/TaskCard.tsx
+++ b/src/tasks/components/TaskCard.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {PureComponent, MouseEvent, RefObject, createRef} from 'react'
+import React, {PureComponent, RefObject, createRef} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
@@ -49,6 +49,8 @@ import {
 import {notify} from 'src/shared/actions/notifications'
 import {downloadTaskTemplate} from 'src/tasks/apis'
 import {event} from 'src/cloud/utils/reporting'
+import {shouldOpenLinkInNewTab} from 'src/utils/crossPlatform'
+import {safeBlankLinkOpen} from 'src/utils/safeBlankLinkOpen'
 
 interface PassedProps {
   task: Task
@@ -70,7 +72,15 @@ export class TaskCard extends PureComponent<
   Props & RouteComponentProps<{orgID: string}>
 > {
   public render() {
-    const {task, history} = this.props
+    const {
+      task,
+      history,
+      match: {
+        params: {orgID},
+      },
+    } = this.props
+
+    const taskUrl = `/orgs/${orgID}/tasks/${task.id}/runs`
 
     return (
       <ResourceCard
@@ -108,6 +118,7 @@ export class TaskCard extends PureComponent<
             testID="task-card--name"
             buttonTestID="task-card--name-button"
             inputTestID="task-card--input"
+            href={taskUrl}
           />
           <ResourceCard.Meta>
             {this.activeToggle}
@@ -236,7 +247,7 @@ export class TaskCard extends PureComponent<
     )
   }
 
-  private handleNameClick = (event: MouseEvent) => {
+  private handleNameClick = (event: React.MouseEvent) => {
     const {
       history,
       task,
@@ -244,12 +255,12 @@ export class TaskCard extends PureComponent<
         params: {orgID},
       },
     } = this.props
-    const url = `/orgs/${orgID}/tasks/${task.id}/runs`
+    const taskUrl = `/orgs/${orgID}/tasks/${task.id}/runs`
 
-    if (event.metaKey) {
-      window.open(url, '_blank', 'noopener')
+    if (shouldOpenLinkInNewTab(event as MouseEvent)) {
+      safeBlankLinkOpen(taskUrl)
     } else {
-      history.push(url)
+      history.push(taskUrl)
     }
   }
 

--- a/src/tasks/components/TaskCard.tsx
+++ b/src/tasks/components/TaskCard.tsx
@@ -257,7 +257,7 @@ export class TaskCard extends PureComponent<
     } = this.props
     const taskUrl = `/orgs/${orgID}/tasks/${task.id}/runs`
 
-    if (shouldOpenLinkInNewTab(event as MouseEvent)) {
+    if (shouldOpenLinkInNewTab(event)) {
       safeBlankLinkOpen(taskUrl)
     } else {
       history.push(taskUrl)

--- a/src/utils/crossPlatform.test.ts
+++ b/src/utils/crossPlatform.test.ts
@@ -1,0 +1,72 @@
+import {shouldOpenLinkInNewTab} from 'src/utils/crossPlatform'
+
+let appVersionGetter
+
+describe('checking whether a link should be opened in a new tab', () => {
+  beforeEach(() => {
+    appVersionGetter = jest.spyOn(global.window.navigator, 'appVersion', 'get')
+  })
+
+  describe('checking on MacOS', () => {
+    beforeEach(() => {
+      appVersionGetter.mockReturnValue('5.0 Macintosh')
+    })
+
+    it('opens the link in a new tab when the meta key is pressed', () => {
+      const mouseEvent = new MouseEvent('click', {metaKey: true})
+      expect(shouldOpenLinkInNewTab(mouseEvent)).toBeTruthy()
+    })
+
+    it('does not open the link in a new tab when the control key is pressed', () => {
+      const mouseEvent = new MouseEvent('click', {ctrlKey: true})
+      expect(shouldOpenLinkInNewTab(mouseEvent)).toBeFalsy()
+    })
+
+    it('does not open the link in a new tab when no modifier key is pressed', () => {
+      const mouseEvent = new MouseEvent('click')
+      expect(shouldOpenLinkInNewTab(mouseEvent)).toBeFalsy()
+    })
+  })
+
+  describe('checking on Windows', () => {
+    beforeEach(() => {
+      appVersionGetter.mockReturnValue('5.0 Windows')
+    })
+
+    it('opens the link in a new tab when the control key is pressed', () => {
+      const mouseEvent = new MouseEvent('click', {ctrlKey: true})
+      expect(shouldOpenLinkInNewTab(mouseEvent)).toBeTruthy()
+    })
+
+    it('does not open the link in a new tab when the meta key is pressed', () => {
+      const mouseEvent = new MouseEvent('click', {metaKey: true})
+      expect(shouldOpenLinkInNewTab(mouseEvent)).toBeFalsy()
+    })
+
+    it('does not open the link in a new tab when no modifier key is pressed', () => {
+      const mouseEvent = new MouseEvent('click')
+      expect(shouldOpenLinkInNewTab(mouseEvent)).toBeFalsy()
+    })
+  })
+
+  describe('checking on GNU/Linux', () => {
+    beforeEach(() => {
+      appVersionGetter.mockReturnValue('5.0 Linux')
+    })
+
+    it('opens the link in a new tab when the control key is pressed', () => {
+      const mouseEvent = new MouseEvent('click', {ctrlKey: true})
+      expect(shouldOpenLinkInNewTab(mouseEvent)).toBeTruthy()
+    })
+
+    it('does not open the link in a new tab when the meta key is pressed', () => {
+      const mouseEvent = new MouseEvent('click', {metaKey: true})
+      expect(shouldOpenLinkInNewTab(mouseEvent)).toBeFalsy()
+    })
+
+    it('does not open the link in a new tab when no modifier key is pressed', () => {
+      const mouseEvent = new MouseEvent('click')
+      expect(shouldOpenLinkInNewTab(mouseEvent)).toBeFalsy()
+    })
+  })
+})

--- a/src/utils/crossPlatform.ts
+++ b/src/utils/crossPlatform.ts
@@ -1,10 +1,14 @@
+import React from 'react'
+
 enum OperatingSystems {
   Mac = 'MacOS',
   Windows = 'Windows',
   Linux = 'Linux',
 }
 
-export const shouldOpenLinkInNewTab = (event: MouseEvent): boolean => {
+export const shouldOpenLinkInNewTab = (
+  event: MouseEvent | React.MouseEvent
+): boolean => {
   // default behavior at the time of writing this function only supports MacOS
   let OS = OperatingSystems.Mac
 

--- a/src/utils/crossPlatform.ts
+++ b/src/utils/crossPlatform.ts
@@ -1,0 +1,31 @@
+enum OperatingSystems {
+  Mac = 'MacOS',
+  Windows = 'Windows',
+  Linux = 'Linux',
+}
+
+export const shouldOpenLinkInNewTab = (event: MouseEvent): boolean => {
+  // default behavior at the time of writing this function only supports MacOS
+  let OS = OperatingSystems.Mac
+
+  if (window?.navigator?.appVersion.includes('Windows')) {
+    OS = OperatingSystems.Windows
+  }
+
+  if (window?.navigator?.appVersion.includes('Linux')) {
+    OS = OperatingSystems.Linux
+  }
+
+  if (OS === OperatingSystems.Mac && event.metaKey) {
+    return true
+  }
+
+  if (
+    (OS === OperatingSystems.Windows || OS === OperatingSystems.Linux) &&
+    event.ctrlKey
+  ) {
+    return true
+  }
+
+  return false
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1437,10 +1437,10 @@
     gud "^1.0.0"
     warning "^4.0.3"
 
-"@influxdata/clockface@^3.11.0":
-  version "3.11.0"
-  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-3.11.0.tgz#c4e4d7a073495b8ecca07348befd264355b560df"
-  integrity sha512-Pcd3bq0qqnUMJgwErHRtzFY82EOaqjGKvJz+a5WE/umVt5jxZ0TiNO5Dyd5KkLE7NCQnHe4yR3kZdcJ5LWBONg==
+"@influxdata/clockface@^3.12.0":
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-3.12.0.tgz#707715f935e81c65e18f59409af48602fe731a9f"
+  integrity sha512-p2n0QkHeDINhK2ryt2YRuBbmE7LU5I9swyV/VH4m9s20gG3gQ+JubrPhCNWdC007Lw//0UnYtCJlA5qPAOJ5dw==
 
 "@influxdata/flux-lsp-browser@0.8.8":
   version "0.8.8"


### PR DESCRIPTION
Closes https://github.com/influxdata/clockface/issues/723

Previously, we only recognized the `metaKey` being pressed when handling click events. This maps to `command` on MacOS, which allows links to be opened in new tabs. This doesn't work for Windows or Linux though. This change recognizes the modifier keys (ctrl+click and clicking with the middle-mouse button on Windows and Linux) for those platforms and modifies existing `metaKey` handlers to work cross platform. It also adds the proper browser context menu for links, by passing in an `href` argument.

I tested this on my personal Windows PC and got Will Cooke to test it on his Linux machine.

- Adds a function `shouldOpenLinkInNewTab` which abstracts checking the current platform and key combination on click events
  - Makes existing handlers for `metaKey` use `shouldOpenLinkInNewTab` to work cross-platform
    - `DashboardCard`, `TaskCard`, `FlowsCard`
  - Adds a handler for `CheckCard` to be opened with a `ctrl`|`cmd` click
- Adds unit tests for `shouldOpenLinkInNewTab`
- Pulls in Clockface `3.12.0` which adds an `href` property to `ResourceCard.EditableName`, which adds the link context menu and allows `cmd`|`ctrl` clicking and middle mouse clicking


![Screen Shot 2022-04-19 at 12 14 13 PM](https://user-images.githubusercontent.com/146112/164490356-acb862a4-a3a8-4c28-a5b1-4d461d213a27.png)

