### PR TITLE
chore(Dockerfile.chronograf.prod): use node:lts-alpine

### DIFF
--- a/docker/Dockerfile.chronograf.prod
+++ b/docker/Dockerfile.chronograf.prod
@@ -1,5 +1,5 @@
-# from node lts alpine 3.12
-FROM node:lts-alpine3.12 AS repo
+# from node lts alpine
+FROM node:lts-alpine AS repo
 
 # env vars to configure the system
 


### PR DESCRIPTION
Currently Dockerfile.chronograf.prod specifies node:lts-alpine3.12, but
according to https://hub.docker.com/_/node this is no longer supported.
Instead of hard-coding an alpine version, simply specify lts-alpine
(which currently is the same as lts-alpine3.15 (16-alpine3.15).

Successfully built an image using:

 $ docker build -f ./docker/Dockerfile.chronograf.prod .

I have not tested this beyond building the image.