### PR TITLE
chore(package.json): use node engine 14.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "github:influxdata/ui"
   },
   "engines": {
-    "node": ">=12.13.0",
+    "node": ">=14.17.0",
     "yarn": ">=1.16.0"
   },
   "alias": {


### PR DESCRIPTION
Per https://nodejs.org/en/about/releases/, nodejs v12 is going EOL on
2022-04-30. package.json currently specifies >=12.13.0, so update it to
14.17.0 (14 is also an LTS and supported until April 2023).
    
Ideally we would update this to the latest LTS (16.14.2), but images
used in CI/CD generated from this repo's docker/Dockerfile.cypress
currently specify quay.io/influxdb/cypress-slim:9.5.2-included which
uses:
```
FROM cypress/base:14.17.0 AS original
```
When https://github.com/influxdata/cypress-slim/blob/main/Dockerfile#L2
is updated to use node 16, then we can update the node engine in this
repo's package.json accordingly.

'yarn clean && yarn build' succeeds. I have not tested this beyond
these yarn commands.