### PR TITLE
feat: add $250 credit message to upgrade button

### DIFF
--- a/src/cloud/components/RateLimitAlertContent.tsx
+++ b/src/cloud/components/RateLimitAlertContent.tsx
@@ -93,7 +93,7 @@ export const UpgradeContent: FC<UpgradeProps> = ({
         <UpgradeMessage {...{limitText, link, type}} />
         <CloudUpgradeButton
           className="upgrade-payg--button__rate-alert"
-          hidePromoMessage={true}
+          showPromoMessage={false}
           metric={() => event(`user.limits.${type}.upgrade`, {location})}
         />
       </FlexBox>

--- a/src/cloud/components/RateLimitAlertContent.tsx
+++ b/src/cloud/components/RateLimitAlertContent.tsx
@@ -93,6 +93,7 @@ export const UpgradeContent: FC<UpgradeProps> = ({
         <UpgradeMessage {...{limitText, link, type}} />
         <CloudUpgradeButton
           className="upgrade-payg--button__rate-alert"
+          hidePromoMessage={true}
           metric={() => event(`user.limits.${type}.upgrade`, {location})}
         />
       </FlexBox>

--- a/src/shared/components/CloudUpgradeButton.tsx
+++ b/src/shared/components/CloudUpgradeButton.tsx
@@ -20,16 +20,16 @@ import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 interface OwnProps {
   buttonText?: string
   className?: string
-  hidePromoMessage?: boolean
   metric?: () => void
+  showPromoMessage?: boolean
   size?: ComponentSize
 }
 
 const CloudUpgradeButton: FC<OwnProps> = ({
   buttonText = 'Upgrade Now',
   className,
-  hidePromoMessage = false,
   metric,
+  showPromoMessage = true,
   size = ComponentSize.Small,
 }) => {
   const showUpgradeButton = useSelector(shouldShowUpgradeButton)
@@ -47,8 +47,8 @@ const CloudUpgradeButton: FC<OwnProps> = ({
     history.push('/checkout')
   }
 
-  const credit250Message =
-    isFlagEnabled('credit250Experiment') && !hidePromoMessage ? (
+  const promoMessage =
+    isFlagEnabled('credit250Experiment') && showPromoMessage ? (
       <span className="credit-250-experiment-upgrade-button--text">
         Get $250 free credit
       </span>
@@ -58,7 +58,7 @@ const CloudUpgradeButton: FC<OwnProps> = ({
     <CloudOnly>
       {showUpgradeButton && (
         <span>
-          {credit250Message}
+          {promoMessage}
           <Button
             icon={IconFont.CrownSolid_New}
             className={cloudUpgradeButtonClass}
@@ -66,10 +66,6 @@ const CloudUpgradeButton: FC<OwnProps> = ({
             shape={ButtonShape.Default}
             onClick={handleClick}
             text={buttonText}
-            style={{
-              background:
-                'linear-gradient(45deg, rgb(52, 187, 85) 0%, rgb(0, 163, 255) 100%)',
-            }}
             testID="cloud-upgrade--button"
           />
         </span>

--- a/src/shared/components/CloudUpgradeButton.tsx
+++ b/src/shared/components/CloudUpgradeButton.tsx
@@ -15,19 +15,22 @@ import CloudOnly from 'src/shared/components/cloud/CloudOnly'
 
 // Utils
 import {shouldShowUpgradeButton} from 'src/me/selectors'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 interface OwnProps {
-  className?: string
   buttonText?: string
-  size?: ComponentSize
+  className?: string
+  hidePromoMessage?: boolean
   metric?: () => void
+  size?: ComponentSize
 }
 
 const CloudUpgradeButton: FC<OwnProps> = ({
-  size = ComponentSize.Small,
-  className,
   buttonText = 'Upgrade Now',
+  className,
+  hidePromoMessage = false,
   metric,
+  size = ComponentSize.Small,
 }) => {
   const showUpgradeButton = useSelector(shouldShowUpgradeButton)
 
@@ -44,22 +47,32 @@ const CloudUpgradeButton: FC<OwnProps> = ({
     history.push('/checkout')
   }
 
+  const credit250Message =
+    isFlagEnabled('credit250Experiment') && !hidePromoMessage ? (
+      <span className="credit-250-experiment-upgrade-button--text">
+        Get $250 free credit
+      </span>
+    ) : null
+
   return (
     <CloudOnly>
       {showUpgradeButton && (
-        <Button
-          icon={IconFont.CrownSolid_New}
-          className={cloudUpgradeButtonClass}
-          size={size}
-          shape={ButtonShape.Default}
-          onClick={handleClick}
-          text={buttonText}
-          style={{
-            background:
-              'linear-gradient(45deg, rgb(52, 187, 85) 0%, rgb(0, 163, 255) 100%)',
-          }}
-          testID="cloud-upgrade--button"
-        />
+        <span>
+          {credit250Message}
+          <Button
+            icon={IconFont.CrownSolid_New}
+            className={cloudUpgradeButtonClass}
+            size={size}
+            shape={ButtonShape.Default}
+            onClick={handleClick}
+            text={buttonText}
+            style={{
+              background:
+                'linear-gradient(45deg, rgb(52, 187, 85) 0%, rgb(0, 163, 255) 100%)',
+            }}
+            testID="cloud-upgrade--button"
+          />
+        </span>
       )}
     </CloudOnly>
   )

--- a/src/shared/components/cloud/CloudOnly.scss
+++ b/src/shared/components/cloud/CloudOnly.scss
@@ -91,6 +91,10 @@ a.upgrade-payg--button {
   background-image: url('~assets/images/dashboard-empty--dark.svg');
 }
 
+.credit-250-experiment-upgrade-button--text {
+  margin: $cf-marg-c;
+}
+
 @media screen and (min-width: $cf-nav-menu--breakpoint) {
   .rate-alert {
     margin-left: $cf-space-l;

--- a/src/shared/components/cloud/CloudOnly.scss
+++ b/src/shared/components/cloud/CloudOnly.scss
@@ -91,6 +91,14 @@ a.upgrade-payg--button {
   background-image: url('~assets/images/dashboard-empty--dark.svg');
 }
 
+button.upgrade-payg--button {
+  background: linear-gradient(
+    45deg,
+    rgb(52, 187, 85) 0%,
+    rgb(0, 163, 255) 100%
+  );
+}
+
 .credit-250-experiment-upgrade-button--text {
   margin: $cf-marg-c;
 }


### PR DESCRIPTION
Closes #4309 

Adds "Get $250 free credit" to the Upgrade Now button in most, but not all, contexts.

<img width="1728" alt="Screen Shot 2022-04-21 at 4 54 21 PM" src="https://user-images.githubusercontent.com/10736577/164575990-9e9b652a-3ae4-4a1e-946e-3cd458db36d9.png">


<img width="559" alt="Screen Shot 2022-04-21 at 4 54 30 PM" src="https://user-images.githubusercontent.com/10736577/164576001-4f2f0bea-2ede-4dcf-9846-d8d8aab4ce59.png">


<img width="1728" alt="Screen Shot 2022-04-21 at 4 56 08 PM" src="https://user-images.githubusercontent.com/10736577/164576003-895a9cec-83c5-4cc1-a67d-dd8d37bfe128.png">


<img width="1728" alt="Screen Shot 2022-04-21 at 4 56 15 PM" src="https://user-images.githubusercontent.com/10736577/164576009-5e525927-fc39-4367-aedc-565b059bd6b1.png">


<img width="1728" alt="Screen Shot 2022-04-21 at 4 57 28 PM" src="https://user-images.githubusercontent.com/10736577/164576015-118af053-d522-4127-a9de-f40b1e5da5e1.png">


<img width="1728" alt="Screen Shot 2022-04-21 at 5 45 18 PM" src="https://user-images.githubusercontent.com/10736577/164576024-7045c2da-2e44-4f75-bc3f-189e6d6929d4.png">


<img width="607" alt="Screen Shot 2022-04-21 at 5 45 24 PM" src="https://user-images.githubusercontent.com/10736577/164576026-47dbd6e4-761a-48f2-b7b9-08f5b9bad585.png">

