### PR TITLE
fix(4448): editor service worker loads in prod

### DIFF
--- a/docker/Dockerfile.chronograf.prod
+++ b/docker/Dockerfile.chronograf.prod
@@ -55,7 +55,7 @@ RUN apk \
 # makes big steps like yarn install expensive
 RUN yarn install --production=false && \
     yarn generate && \
-    $(npm bin)/webpack --config ./webpack.${WEBPACK_FILE}.ts && \
+    $(npm bin)/webpack --config ./webpack.prod.ts && \
     rm -rf ./node_modules
 
 RUN mkdir /includes

--- a/docker/Dockerfile.chronograf.prod
+++ b/docker/Dockerfile.chronograf.prod
@@ -55,7 +55,7 @@ RUN apk \
 # makes big steps like yarn install expensive
 RUN yarn install --production=false && \
     yarn generate && \
-    $(npm bin)/webpack --config ./webpack.prod.ts && \
+    $(npm bin)/webpack --config ./webpack.${WEBPACK_FILE}.ts && \
     rm -rf ./node_modules
 
 RUN mkdir /includes

--- a/webpack.common.ts
+++ b/webpack.common.ts
@@ -165,8 +165,7 @@ module.exports = {
     }),
     new MonacoWebpackPlugin({
       languages: ['json', 'markdown'],
-      filename: '[name].worker.[contenthash].js',
-      publicPath: `${STATIC_DIRECTORY}`,
+      filename: `${STATIC_DIRECTORY}[name].worker.[contenthash].js`,
       globalAPI: true,
     }),
   ],

--- a/webpack.vendor.ts
+++ b/webpack.vendor.ts
@@ -78,7 +78,7 @@ module.exports = {
     }),
     new MonacoWebpackPlugin({
       languages: ['json', 'markdown'],
-      filename: '[name].worker.[contenthash].js',
+      filename: `${STATIC_DIRECTORY}[name].worker.[contenthash].js`,
       globalAPI: true,
     }),
   ],

--- a/webpack.vendor.ts
+++ b/webpack.vendor.ts
@@ -3,6 +3,7 @@ const webpack = require('webpack')
 const path = require('path')
 const {dependencies} = require('./package.json')
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin')
+const {STATIC_DIRECTORY} = require('./src/utils/env')
 
 // only dll infrequently updated dependencies
 const vendor = Object.keys(dependencies).filter(


### PR DESCRIPTION
Closes #4448 

## Solution:
Do not override publicPath for the webpack-plugin-monaco-editor. Keep the same as the project route.

.

**Visual evidence:**
Deployed remocal with prod build (ui-acceptance quay image).

<img width="400" alt="Screen Shot 2022-04-21 at 10 39 52 PM" src="https://user-images.githubusercontent.com/10232835/164610501-fff7b8ac-ee59-4865-97ce-f0806440ed95.png">

<img width="900" alt="Screen Shot 2022-04-21 at 10 40 07 PM" src="https://user-images.githubusercontent.com/10232835/164610505-0b7f7ce4-7a5a-4e20-9904-e4235d277fba.png">



**See for yourself:**
Currently deployed remocal cluster is using the commit with the prod ui-acceptance image.
https://twodotoh-dev-denisewiedl20220405130506.remocal.influxdev.co
