### PR TITLE
Update Account to UserAccount

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "cy": "CYPRESS_dexUrl=https://$INGRESS_HOST:$PORT_HTTPS CYPRESS_baseUrl=http://localhost:9999 cypress open",
     "cy:dev": "source ../monitor-ci/.env && CYPRESS_dexUrl=CLOUD CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{cloud,shared}/**/*.*'",
     "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_dexUrl=OSS CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{oss,shared}/**/*.*'",
-    "generate": "export SHA=65ca23669c55b381acc585d9e5e688a635b81754 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
+    "generate": "export SHA=b983e6ecc75f9b9852401e5585f2706890b10bb3 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-meta": "if [ -z \"${CLOUD_URL}\" ]; then yarn generate-meta-oss; else yarn generate-meta-cloud; fi",
     "generate-meta-oss": "yarn oss-api && yarn notebooks && yarn unity && yarn annotations-oss && yarn pinned && yarn mapsd-oss && yarn cloudPriv && yarn fluxdocs && yarn subscriptions-oss",

--- a/src/accounts/context/userAccount.tsx
+++ b/src/accounts/context/userAccount.tsx
@@ -3,7 +3,7 @@ import React, {FC, useCallback, useEffect, useState} from 'react'
 import {useDispatch} from 'react-redux'
 
 // Types
-import {Account as UserAccount} from 'src/client/unityRoutes'
+import {UserAccount} from 'src/client/unityRoutes'
 
 // Notifications
 import {notify} from 'src/shared/actions/notifications'


### PR DESCRIPTION
Updates `Account` to `UserAccount` in accordance with the openapi change made here: https://github.com/influxdata/openapi/commit/b983e6ecc75f9b9852401e5585f2706890b10bb3

`Account` was already being aliased as `UserAccount` so the only change needed was in the type.

The plural `Accounts` was not being used so no change was needed to reflect the openapi rename from `Accounts` to `UserAccounts`. (UI just uses an array of `UserAccount`).

Part of quartz #6138 changes for multi org.
