### PR TITLE
feat: cancel queries in query builder when toggling between values

### DIFF
--- a/src/flows/pipes/QueryBuilder/CardList.tsx
+++ b/src/flows/pipes/QueryBuilder/CardList.tsx
@@ -133,8 +133,7 @@ const Card: FC<Props> = ({idx}) => {
     card.values.selected.length <= 1
 
   const valueSelect = val => {
-    const _vals = [...card.values.selected]
-    const index = _vals.indexOf(val)
+    const index = card.values.selected.indexOf(val)
 
     if (isCompliant) {
       if (index === -1) {
@@ -150,30 +149,23 @@ const Card: FC<Props> = ({idx}) => {
 
     if (index === -1) {
       event('Query Builder Value Selected')
-      _vals.push(val)
+      card.values.selected.push(val)
     } else {
       event('Query Builder Value Unselected')
-      _vals.splice(index, 1)
+      card.values.selected.splice(index, 1)
     }
 
-    update(idx, {
-      values: {
-        ...card.values,
-        selected: _vals,
-      },
-    })
+    update(idx, card)
 
-    if (index === -1 && _vals.length === 1 && idx === cards.length - 1) {
+    if (
+      index === -1 &&
+      card.values.selected.length === 1 &&
+      idx === cards.length - 1
+    ) {
       add()
     } else {
       for (let ni = idx + 1; ni < cards.length; ni++) {
-        if (_vals.length === 0) {
-          // A user selects and deselects a value - this should invoke the remove(ni) condition
-          remove(ni)
-        } else {
-          // A user selects two values - this should invoke the loadKeys(ni) condition
-          loadKeys(ni)
-        }
+        loadKeys(ni)
       }
     }
   }

--- a/src/flows/pipes/QueryBuilder/CardList.tsx
+++ b/src/flows/pipes/QueryBuilder/CardList.tsx
@@ -167,7 +167,13 @@ const Card: FC<Props> = ({idx}) => {
       add()
     } else {
       for (let ni = idx + 1; ni < cards.length; ni++) {
-        loadKeys(ni)
+        if (_vals.length === 0) {
+          // A user selects and deselects a value - this should invoke the remove(ni) condition
+          remove(ni)
+        } else {
+          // A user selects two values - this should invoke the loadKeys(ni) condition
+          loadKeys(ni)
+        }
       }
     }
   }

--- a/src/flows/pipes/QueryBuilder/CardList.tsx
+++ b/src/flows/pipes/QueryBuilder/CardList.tsx
@@ -59,6 +59,8 @@ const Card: FC<Props> = ({idx}) => {
     cards,
     selectMeasurement,
     add,
+    cancelKey,
+    cancelValue,
     update,
     remove,
     loadKeys,
@@ -171,17 +173,38 @@ const Card: FC<Props> = ({idx}) => {
   }
 
   useEffect(() => {
+    let promise
     if (data.buckets[0] && card.keys.loading === RemoteDataState.NotStarted) {
-      loadKeys(idx)
+      promise = loadKeys(idx)
+      if (promise instanceof Promise) {
+        promise.finally(() => {
+          promise = null
+        })
+      }
+    }
+
+    return () => {
+      cancelKey(idx)
     }
   }, [data.buckets, card.keys.loading])
 
   useEffect(() => {
+    let promise
     if (
       card.keys.loading === RemoteDataState.Done &&
       card.values.loading !== RemoteDataState.Done
     ) {
-      loadValues(idx)
+      promise = loadValues(idx)
+
+      if (promise instanceof Promise) {
+        promise.finally(() => {
+          promise = null
+        })
+      }
+    }
+
+    return () => {
+      cancelValue(idx)
     }
   }, [card.keys.loading, card.values.loading])
 

--- a/src/flows/pipes/QueryBuilder/context.tsx
+++ b/src/flows/pipes/QueryBuilder/context.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FC, createContext, useContext, useState, useMemo} from 'react'
+import React, {FC, createContext, useContext, useState} from 'react'
 
 // Contexts
 import {PipeContext} from 'src/flows/context/pipe'
@@ -187,9 +187,8 @@ export const QueryBuilderProvider: FC = ({children}) => {
     }
   }
 
-  const cards = useMemo(
-    () => data.tags.map((tag, idx) => fromBuilderConfig(tag, cardMeta[idx])),
-    [data.tags, cardMeta]
+  const cards = data.tags.map((tag, idx) =>
+    fromBuilderConfig(tag, cardMeta[idx])
   )
 
   const add = () => {
@@ -314,16 +313,17 @@ export const QueryBuilderProvider: FC = ({children}) => {
         )[0]?.data ?? []) as string[]
       })
       .then(keys => {
-        if (!cards[idx].keys.selected[0]) {
+        const currentCards = data.tags.map(fromBuilderConfig)
+        if (!currentCards[idx].keys.selected[0]) {
           if (idx === 0 && keys.includes('_measurement')) {
-            cards[idx].keys.selected = ['_measurement']
+            currentCards[idx].keys.selected = ['_measurement']
           } else {
-            cards[idx].keys.selected = [keys[0]]
+            currentCards[idx].keys.selected = [keys[0]]
           }
 
-          update({tags: cards.map(toBuilderConfig)})
-        } else if (!keys.includes(cards[idx].keys.selected[0])) {
-          keys.unshift(cards[idx].keys.selected[0])
+          update({tags: currentCards.map(toBuilderConfig)})
+        } else if (!keys.includes(currentCards[idx].keys.selected[0])) {
+          keys.unshift(currentCards[idx].keys.selected[0])
         }
 
         cardMeta.splice(idx, 1, {
@@ -512,7 +512,9 @@ export const QueryBuilderProvider: FC = ({children}) => {
       ..._card,
     }
 
-    update({tags: cards.map(toBuilderConfig)})
+    data.tags = cards.map(toBuilderConfig)
+
+    update({tags: data.tags})
   }
 
   return (

--- a/src/flows/pipes/QueryBuilder/context.tsx
+++ b/src/flows/pipes/QueryBuilder/context.tsx
@@ -300,7 +300,14 @@ export const QueryBuilderProvider: FC = ({children}) => {
     |> limit(n: ${limit})`
     }
 
-    query(queryText, scope)
+    const result = query(queryText, scope)
+
+    setCancelKey(prev => ({
+      ...prev,
+      [idx]: (result as any).cancel,
+    }))
+
+    return result
       .then(resp => {
         return (Object.values(resp.parsed.table.columns).filter(
           c => c.name === '_value' && c.type === 'string'
@@ -420,7 +427,14 @@ export const QueryBuilderProvider: FC = ({children}) => {
   |> sort()`
     }
 
-    query(queryText, scope)
+    const result = query(queryText, scope)
+
+    setCancelValue(prev => ({
+      ...prev,
+      [idx]: (result as any).cancel,
+    }))
+
+    return result
       .then(resp => {
         return (Object.values(resp.parsed.table.columns).filter(
           c => c.name === '_value' && c.type === 'string'

--- a/src/flows/pipes/QueryBuilder/context.tsx
+++ b/src/flows/pipes/QueryBuilder/context.tsx
@@ -63,10 +63,12 @@ interface QueryBuilderContextType {
   selectMeasurement: (measurement?: string) => void
 
   add: () => void
+  cancelKey: (idx: number) => void
+  cancelValue: (idx: number) => void
   remove: (idx: number) => void
   update: (idx: number, card: Partial<QueryBuilderCard>) => void
-  loadKeys: (idx: number, search?: string) => void
-  loadValues: (idx: number, search?: string) => void
+  loadKeys: (idx: number, search?: string) => void | Promise<any>
+  loadValues: (idx: number, search?: string) => void | Promise<any>
 }
 
 export const DEFAULT_CONTEXT: QueryBuilderContextType = {
@@ -76,6 +78,8 @@ export const DEFAULT_CONTEXT: QueryBuilderContextType = {
   selectMeasurement: _ => {},
 
   add: () => {},
+  cancelKey: (_idx: number) => {},
+  cancelValue: (_idx: number) => {},
   remove: (_idx: number) => {},
   update: (_idx: number, _card: QueryBuilderCard) => {},
   loadKeys: (_idx: number, _search?: string) => {},
@@ -113,6 +117,8 @@ export const QueryBuilderProvider: FC = ({children}) => {
   const {id, data, range, update} = useContext(PipeContext)
   const {query, getPanelQueries} = useContext(FlowQueryContext)
   const {buckets} = useContext(BucketContext)
+  const [cancelKey, setCancelKey] = useState({})
+  const [cancelValue, setCancelValue] = useState({})
 
   const [cardMeta, setCardMeta] = useState<QueryBuilderMeta[]>(
     Array(data.tags.length).fill({
@@ -326,6 +332,18 @@ export const QueryBuilderProvider: FC = ({children}) => {
       })
   }
 
+  const handleCancelKey = idx => {
+    if (idx in cancelKey) {
+      cancelKey[idx]()
+    }
+  }
+
+  const handleCancelValue = idx => {
+    if (idx in cancelValue) {
+      cancelValue[idx]()
+    }
+  }
+
   const loadValues = (idx, search) => {
     if (
       cardMeta[idx].loadingValues === RemoteDataState.Loading ||
@@ -490,7 +508,8 @@ export const QueryBuilderProvider: FC = ({children}) => {
 
         selectBucket,
         selectMeasurement,
-
+        cancelKey: handleCancelKey,
+        cancelValue: handleCancelValue,
         add,
         remove,
         update: updater,

--- a/src/shared/contexts/query.tsx
+++ b/src/shared/contexts/query.tsx
@@ -7,7 +7,7 @@ import {getOrg} from 'src/organizations/selectors'
 import {getBuckets} from 'src/buckets/actions/thunks'
 import {getSortedBuckets} from 'src/buckets/selectors'
 import {getStatus} from 'src/resources/selectors'
-import {fromFlux, FromFluxResult} from '@influxdata/giraffe'
+import {fromFlux} from '@influxdata/giraffe'
 import {
   FluxResult,
   QueryScope,

--- a/src/shared/contexts/query.tsx
+++ b/src/shared/contexts/query.tsx
@@ -7,7 +7,7 @@ import {getOrg} from 'src/organizations/selectors'
 import {getBuckets} from 'src/buckets/actions/thunks'
 import {getSortedBuckets} from 'src/buckets/selectors'
 import {getStatus} from 'src/resources/selectors'
-import {fromFlux} from '@influxdata/giraffe'
+import {fromFlux, FromFluxResult} from '@influxdata/giraffe'
 import {
   FluxResult,
   QueryScope,
@@ -564,7 +564,7 @@ export const QueryProvider: FC = ({children}) => {
   const query = (text: string, override?: QueryScope): Promise<FluxResult> => {
     const result = basic(text, override)
 
-    return result.promise
+    const promise: any = result.promise
       .then(raw => {
         if (raw.type !== 'SUCCESS') {
           throw new Error(raw.message)
@@ -586,6 +586,9 @@ export const QueryProvider: FC = ({children}) => {
             error: null,
           } as FluxResult)
       )
+
+    promise.cancel = result.cancel
+    return promise
   }
 
   if (bucketsLoadingState !== RemoteDataState.Done) {


### PR DESCRIPTION
Closes #4282

### Background

There's currently an issue where whenever a user toggles between buckets / measurements / fields / tags in the query builder, a query will fire off and continue processing even when a user toggles away from that previously selected value. 

### Solution

This PR aims to resolve this by canceling existing pending queries when they are toggled away from. This is achieved by:

1. Prior to returning the promised fromFlux result in the query context, we set the `cancel` property onto it (since this was previously being wiped away in the promise chain sequence)
2. We set that promise (with the cancel property) onto the query builder context state for the specific key / value that's being loaded so that we have access to it in the event that we need to cancel the query
3. If the CardList unmounts and there's a pending promise for a given card, we fire off the cancel query
4. Updating the `selectValue` method to remove the cardList from the cards if the selected value is singular and being deselected

Visual Proof:

![cancel-queries](https://user-images.githubusercontent.com/19984220/164896407-019b1875-2277-41aa-8dcb-604f62a56f43.gif)




<!-- Describe your proposed changes here. -->
