### PR TITLE
fix(Bug): remove unnecesary state setting to stop multiple re-renderings

### DIFF
--- a/src/visualization/utils/useStaticLegend.ts
+++ b/src/visualization/utils/useStaticLegend.ts
@@ -136,8 +136,9 @@ export const useStaticLegend = (properties): StaticLegendConfig => {
       !show &&
       heightRatio === STATIC_LEGEND_HEIGHT_RATIO_NOT_SET
 
-    if (!shouldStaticLegendPropertiesBeUpdated) return
-
+    if (!shouldStaticLegendPropertiesBeUpdated) {
+      return
+    }
     const validOpacity =
       typeof legendOpacity === 'number' &&
       legendOpacity === legendOpacity &&

--- a/src/visualization/utils/useStaticLegend.ts
+++ b/src/visualization/utils/useStaticLegend.ts
@@ -74,36 +74,6 @@ export const useStaticLegend = (properties): StaticLegendConfig => {
   const {isViewingVisOptions} = useSelector(getActiveTimeMachine)
   const dispatch = useDispatch()
 
-  const timeMachineUpdate = useCallback(
-    (staticLegend: StaticLegendAPI) => {
-      dispatch(
-        setStaticLegend({
-          ...properties.staticLegend,
-          ...staticLegend,
-        })
-      )
-    },
-    [dispatch, properties.staticLegend]
-  )
-
-  const notebooksUpdate = (updatedProperties: StaticLegendAPI) => {
-    const notebookViewProperties = data?.properties || {}
-    const notebookStaticLegend = notebookViewProperties.staticLegend || {}
-
-    update({
-      properties: {
-        ...notebookViewProperties,
-        staticLegend: {...notebookStaticLegend, ...updatedProperties},
-      },
-    })
-  }
-
-  const updateStaticLegendProperties = useCallback(
-    (staticLegend: StaticLegendAPI) =>
-      !id ? timeMachineUpdate(staticLegend) : notebooksUpdate(staticLegend),
-    [id]
-  )
-
   const {
     legendColorizeRows = LEGEND_COLORIZE_ROWS_DEFAULT,
     legendOpacity = LEGEND_OPACITY_DEFAULT,
@@ -160,6 +130,36 @@ export const useStaticLegend = (properties): StaticLegendConfig => {
       orientationThreshold: validThreshold,
     })
   }, [isViewingVisOptions, show, heightRatio])
+
+  const timeMachineUpdate = useCallback(
+    (staticLegend: StaticLegendAPI) => {
+      dispatch(
+        setStaticLegend({
+          ...properties.staticLegend,
+          ...staticLegend,
+        })
+      )
+    },
+    [dispatch, properties.staticLegend]
+  )
+
+  const notebooksUpdate = (updatedProperties: StaticLegendAPI) => {
+    const notebookViewProperties = data?.properties || {}
+    const notebookStaticLegend = notebookViewProperties.staticLegend || {}
+
+    update({
+      properties: {
+        ...notebookViewProperties,
+        staticLegend: {...notebookStaticLegend, ...updatedProperties},
+      },
+    })
+  }
+
+  const updateStaticLegendProperties = useCallback(
+    (staticLegend: StaticLegendAPI) =>
+      !id ? timeMachineUpdate(staticLegend) : notebooksUpdate(staticLegend),
+    [id, show]
+  )
 
   return useMemo(() => {
     return {


### PR DESCRIPTION
Closes #4451 

problem pr fixes: function inside `useStaticLegend` component gets executed (unnecessarily) each time a render happens. Causing a bad setState error in the console. 

solution: wrap function in a useEffect hook so state only gets updated when one of the three values in dependency array change. 


on the second rendering (when `XYPlot` isn't rendered yet), `updateStaticLegends` gets executed one too many times.
On each render, the three values in the dependency array, `[isViewingVisOptions, show, heightRatioget]` get evaluated and in turn cause `updateStaticLegends` to get executed. This execution happens during a particular render where `XYPlot` was not already mounted on the DOM. This here is why pr executed this inside a `useEffect` so the only way function gets called is if one of the variables in the dependency array change. 

