### PR TITLE
fix(3707/4021/4479): notebooks alerts multiple predicates, don't hold pipe threshold state after pipe deletion, and have flux not spam the endpoint.

### DIFF
--- a/cypress/e2e/shared/flowsAlerts.test.ts
+++ b/cypress/e2e/shared/flowsAlerts.test.ts
@@ -234,8 +234,6 @@ describe('flows alert panel', () => {
     cy.getByTestID('notification-exp-button').scrollIntoView()
     cy.getByTestID('text-editor').should('be.visible')
 
-    selectAlertMeasurementAndField()
-
     const fakeEmail = 'super@fake.com'
     const fakeUrl = 'super-fake.com'
     const fakeChannel = 'fake-channel'
@@ -257,6 +255,12 @@ describe('flows alert panel', () => {
     cy.getByTestID('dropdown--calcSignature').click()
     cy.getByTestID('dropdown-item--mySecret').click()
     cy.getByTestID('input--email').type(fakeEmail)
+
+    cy.log('Export attempt without selecting a measurement, will error')
+    cy.getByTestID('task-form-save').click()
+    cy.getByTestID('notification-error').should('be.visible')
+    cy.getByTestID('notification-error--dismiss').click()
+    selectAlertMeasurementAndField()
 
     cy.getByTestID('task-form-save').click()
     /* NOTE: we used to be able to test that the generated flux contained the the

--- a/cypress/e2e/shared/flowsAlerts.test.ts
+++ b/cypress/e2e/shared/flowsAlerts.test.ts
@@ -1,6 +1,20 @@
 import {Organization} from '../../src/types'
 
 describe('flows alert panel', () => {
+  const selectAlertMeasurementAndField = () => {
+    cy.log('Select alert measurement')
+    cy.getByTestID('dropdown--measurements').click()
+    cy.getByTestID('dropdown-item--measurement')
+      .first()
+      .click()
+
+    cy.log('Select alert threshold field')
+    cy.getByTestID('dropdown--threshold-fields').click()
+    cy.getByTestID('dropdown-item--threshold-field')
+      .first()
+      .click()
+  }
+
   beforeEach(() =>
     cy.flush().then(() =>
       cy.signin().then(() =>
@@ -219,6 +233,8 @@ describe('flows alert panel', () => {
     cy.getByTestID('time-machine-submit-button').click()
     cy.getByTestID('notification-exp-button').scrollIntoView()
     cy.getByTestID('text-editor').should('be.visible')
+
+    selectAlertMeasurementAndField()
 
     const fakeEmail = 'super@fake.com'
     const fakeUrl = 'super-fake.com'

--- a/src/flows/context/flow.current.tsx
+++ b/src/flows/context/flow.current.tsx
@@ -272,7 +272,8 @@ export const FlowProvider: FC = ({children}) => {
     [currentFlow, update]
   )
 
-  const addPipe = (initial: PipeData, index?: number) => {
+  const addPipe = (initialTemplate: PipeData, index?: number) => {
+    const initial = JSON.parse(JSON.stringify(initialTemplate))
     const id = prettyid()
     const title =
       initial.title ||

--- a/src/flows/pipes/Notification/ExportTask.tsx
+++ b/src/flows/pipes/Notification/ExportTask.tsx
@@ -72,6 +72,11 @@ const ExportTask: FC = () => {
       return acc
     }, {})
 
+    if (!data.measurement) {
+      throw new Error('please select a measurement.')
+    }
+    const measurement = `(r) => r["_measurement"] == "${data.measurement}"`
+
     const conditions = THRESHOLD_TYPES[deadmanType].condition(deadman)
     const imports = parse(`
 import "strings"
@@ -114,7 +119,10 @@ task_data = ${format_from_js_file(ast)}
 trigger = ${conditions}
 messageFn = (r) => ("${data.message}")
 
-${ENDPOINT_DEFINITIONS[data.endpoint]?.generateQuery(data.endpointData)}
+${ENDPOINT_DEFINITIONS[data.endpoint]?.generateQuery(
+  data.endpointData,
+  measurement
+)}
 |> monitor["deadman"](t: experimental["subDuration"](from: now(), d: ${
       deadman.deadmanCheckValue
     }))`
@@ -155,6 +163,7 @@ ${ENDPOINT_DEFINITIONS[data.endpoint]?.generateQuery(data.endpointData)}
     data.offset,
     data.endpointData,
     data.endpoint,
+    data.measurement,
     data.thresholds,
     data.message,
   ])
@@ -195,12 +204,15 @@ ${ENDPOINT_DEFINITIONS[data.endpoint]?.generateQuery(data.endpointData)}
       return acc
     }, {})
 
+    if (!data.measurement) {
+      throw new Error('please select a measurement.')
+    }
+    const measurement = `(r) => r["_measurement"] == "${data.measurement}"`
+
     const conditions = data.thresholds
       .map(threshold => THRESHOLD_TYPES[threshold.type].condition(threshold))
       .map((cond, i) => (i > 0 ? cond.split(lambdaPrefix)[1] : cond))
       .join(' and ')
-
-    const measurement = `(r) => r["_measurement"] == "${data.measurement}"`
 
     const imports = parse(`
 import "strings"
@@ -283,6 +295,7 @@ ${ENDPOINT_DEFINITIONS[data.endpoint]?.generateQuery(
     data.offset,
     data.endpointData,
     data.endpoint,
+    data.measurement,
     data.thresholds,
     data.message,
   ])

--- a/src/flows/pipes/Notification/ExportTask.tsx
+++ b/src/flows/pipes/Notification/ExportTask.tsx
@@ -14,7 +14,7 @@ import {remove} from 'src/shared/contexts/query'
 // Types
 import {
   deadmanType,
-  lambdaPrefix,
+  LAMBDA_PREFIX,
   THRESHOLD_TYPES,
 } from 'src/flows/pipes/Visualization/threshold'
 import {ImportDeclaration} from 'src/types/ast'
@@ -211,7 +211,7 @@ ${ENDPOINT_DEFINITIONS[data.endpoint]?.generateQuery(
 
     const conditions = data.thresholds
       .map(threshold => THRESHOLD_TYPES[threshold.type].condition(threshold))
-      .map((cond, i) => (i > 0 ? cond.split(lambdaPrefix)[1] : cond))
+      .map((cond, i) => (i > 0 ? cond.split(LAMBDA_PREFIX)[1] : cond))
       .join(' and ')
 
     const imports = parse(`

--- a/src/flows/pipes/Notification/ExportTask.tsx
+++ b/src/flows/pipes/Notification/ExportTask.tsx
@@ -14,7 +14,6 @@ import {remove} from 'src/shared/contexts/query'
 // Types
 import {
   deadmanType,
-  LAMBDA_PREFIX,
   THRESHOLD_TYPES,
 } from 'src/flows/pipes/Visualization/threshold'
 import {ImportDeclaration} from 'src/types/ast'
@@ -77,7 +76,8 @@ const ExportTask: FC = () => {
     }
     const measurement = `(r) => r["_measurement"] == "${data.measurement}"`
 
-    const conditions = THRESHOLD_TYPES[deadmanType].condition(deadman)
+    const conditions =
+      `(r) => ` + THRESHOLD_TYPES[deadmanType].condition(deadman)
     const imports = parse(`
 import "strings"
 import "regexp"
@@ -209,10 +209,11 @@ ${ENDPOINT_DEFINITIONS[data.endpoint]?.generateQuery(
     }
     const measurement = `(r) => r["_measurement"] == "${data.measurement}"`
 
-    const conditions = data.thresholds
-      .map(threshold => THRESHOLD_TYPES[threshold.type].condition(threshold))
-      .map((cond, i) => (i > 0 ? cond.split(LAMBDA_PREFIX)[1] : cond))
-      .join(' and ')
+    const conditions =
+      `(r) => ` +
+      data.thresholds
+        .map(threshold => THRESHOLD_TYPES[threshold.type].condition(threshold))
+        .join(' and ')
 
     const imports = parse(`
 import "strings"

--- a/src/flows/pipes/Notification/ExportTask.tsx
+++ b/src/flows/pipes/Notification/ExportTask.tsx
@@ -200,6 +200,8 @@ ${ENDPOINT_DEFINITIONS[data.endpoint]?.generateQuery(data.endpointData)}
       .map((cond, i) => (i > 0 ? cond.split(lambdaPrefix)[1] : cond))
       .join(' and ')
 
+    const measurement = `(r) => r["_measurement"] == "${data.measurement}"`
+
     const imports = parse(`
 import "strings"
 import "regexp"
@@ -240,7 +242,10 @@ task_data = ${format_from_js_file(ast)}
 trigger = ${conditions}
 messageFn = (r) => ("${data.message}")
 
-${ENDPOINT_DEFINITIONS[data.endpoint]?.generateQuery(data.endpointData)}`
+${ENDPOINT_DEFINITIONS[data.endpoint]?.generateQuery(
+  data.endpointData,
+  measurement
+)}`
 
     const newAST = parse(newQuery)
 

--- a/src/flows/pipes/Notification/ExportTask.tsx
+++ b/src/flows/pipes/Notification/ExportTask.tsx
@@ -14,6 +14,7 @@ import {remove} from 'src/shared/contexts/query'
 // Types
 import {
   deadmanType,
+  lambdaPrefix,
   THRESHOLD_TYPES,
 } from 'src/flows/pipes/Visualization/threshold'
 import {ImportDeclaration} from 'src/types/ast'
@@ -196,6 +197,7 @@ ${ENDPOINT_DEFINITIONS[data.endpoint]?.generateQuery(data.endpointData)}
 
     const conditions = data.thresholds
       .map(threshold => THRESHOLD_TYPES[threshold.type].condition(threshold))
+      .map((cond, i) => (i > 0 ? cond.split(lambdaPrefix)[1] : cond))
       .join(' and ')
 
     const imports = parse(`

--- a/src/flows/pipes/Notification/Measurement.tsx
+++ b/src/flows/pipes/Notification/Measurement.tsx
@@ -1,4 +1,4 @@
-import React, {useState, FC, useCallback, useContext} from 'react'
+import React, {FC, useCallback, useContext} from 'react'
 import {
   ComponentSize,
   FlexBox,
@@ -21,7 +21,7 @@ interface Props {
 
 const Measurement: FC<Props> = ({readOnly}) => {
   const {data, update, results} = useContext(PipeContext)
-  const [measurement, setMeasurement] = useState(data.measurement || null)
+  const {measurement} = data
 
   const measurements = Array.from(
     new Set(results.parsed.table.columns['_measurement']?.data as string[])
@@ -30,7 +30,6 @@ const Measurement: FC<Props> = ({readOnly}) => {
   const onSelect = useCallback(
     (measurement: string) => {
       event('Changed Notification Measurement')
-      setMeasurement(measurement)
       update({measurement})
     },
     [measurements, update]

--- a/src/flows/pipes/Notification/Measurement.tsx
+++ b/src/flows/pipes/Notification/Measurement.tsx
@@ -38,6 +38,7 @@ const Measurement: FC<Props> = ({readOnly}) => {
 
   const menuItems = measurements.map(key => (
     <Dropdown.Item
+      testID="dropdown-item--measurement"
       key={key}
       value={key}
       onClick={() => onSelect(key)}
@@ -55,6 +56,7 @@ const Measurement: FC<Props> = ({readOnly}) => {
 
   const menuButton = (active, onClick) => (
     <Dropdown.Button
+      testID="dropdown--measurements"
       onClick={onClick}
       active={active}
       size={ComponentSize.Medium}

--- a/src/flows/pipes/Notification/Measurement.tsx
+++ b/src/flows/pipes/Notification/Measurement.tsx
@@ -1,0 +1,87 @@
+import React, {useState, FC, useCallback, useContext} from 'react'
+import {
+  ComponentSize,
+  FlexBox,
+  AlignItems,
+  TextBlock,
+  Dropdown,
+  FlexDirection,
+  ComponentStatus,
+} from '@influxdata/clockface'
+
+import {PipeContext} from 'src/flows/context/pipe'
+import 'src/flows/pipes/Notification/Threshold.scss'
+
+// Utils
+import {event} from 'src/cloud/utils/reporting'
+
+interface Props {
+  readOnly?: boolean
+}
+
+const Measurement: FC<Props> = ({readOnly}) => {
+  const {data, update, results} = useContext(PipeContext)
+  const [measurement, setMeasurement] = useState(data.measurement || null)
+
+  const measurements = Array.from(
+    new Set(results.parsed.table.columns['_measurement']?.data as string[])
+  )
+
+  const onSelect = useCallback(
+    (measurement: string) => {
+      event('Changed Notification Measurement')
+      setMeasurement(measurement)
+      update({measurement})
+    },
+    [measurements, update]
+  )
+
+  const menuItems = measurements.map(key => (
+    <Dropdown.Item
+      key={key}
+      value={key}
+      onClick={() => onSelect(key)}
+      selected={key === measurement}
+      title={key}
+      disabled={!!readOnly}
+    >
+      {key}
+    </Dropdown.Item>
+  ))
+
+  const menu = onCollapse => (
+    <Dropdown.Menu onCollapse={onCollapse}>{menuItems}</Dropdown.Menu>
+  )
+
+  const menuButton = (active, onClick) => (
+    <Dropdown.Button
+      onClick={onClick}
+      active={active}
+      size={ComponentSize.Medium}
+      status={!!readOnly ? ComponentStatus.Disabled : ComponentStatus.Default}
+    >
+      {measurement || 'Select a measurement'}
+    </Dropdown.Button>
+  )
+
+  return (
+    <FlexBox
+      direction={FlexDirection.Row}
+      margin={ComponentSize.Medium}
+      alignItems={AlignItems.FlexStart}
+      testID="component-spacer"
+      style={{padding: '24px 0'}}
+    >
+      <TextBlock
+        testID="measurement-value-text-block"
+        text="For"
+        style={{minWidth: 56, textAlign: 'center'}}
+      />
+      <FlexBox.Child grow={0}>
+        <Dropdown menu={menu} button={menuButton} />
+      </FlexBox.Child>
+    </FlexBox>
+  )
+}
+
+export default Measurement

--- a/src/flows/pipes/Notification/Threshold.tsx
+++ b/src/flows/pipes/Notification/Threshold.tsx
@@ -104,6 +104,7 @@ const Threshold: FC<Props> = ({readOnly}) => {
         })
         .map(([key, value]) => (
           <Dropdown.Item
+            testID="dropdown-item--threshold-field"
             key={key}
             value={key}
             onClick={type => setThresholdType(type, index)}
@@ -119,6 +120,7 @@ const Threshold: FC<Props> = ({readOnly}) => {
       )
       const menuButton = (active, onClick) => (
         <Dropdown.Button
+          testID="dropdown--threshold-fields"
           onClick={onClick}
           active={active}
           size={ComponentSize.Medium}

--- a/src/flows/pipes/Notification/Threshold.tsx
+++ b/src/flows/pipes/Notification/Threshold.tsx
@@ -54,7 +54,7 @@ const Threshold: FC<Props> = ({readOnly}) => {
       }
 
       threshold.type = type
-      threshold.field = threshold.field || '_value'
+      threshold.field = threshold?.field
 
       let updatedThreshold = thresholds
 
@@ -67,7 +67,7 @@ const Threshold: FC<Props> = ({readOnly}) => {
             type: deadmanType,
             deadmanCheckValue: '5s',
             deadmanStopValue: '90s',
-            field: threshold.field || '_value',
+            field: threshold.field || 'Select a numeric field',
           },
         ]
       } else {

--- a/src/flows/pipes/Notification/endpoints/AWS/index.ts
+++ b/src/flows/pipes/Notification/endpoints/AWS/index.ts
@@ -36,6 +36,8 @@ export default register => {
 		crit: trigger,
 	)
   |> filter(fn: trigger)
+  |> keep(columns: ["_value", "_time", "_measurement"])
+  |> limit(n: 1, offset: 0)
 	|> monitor["notify"](
     data: notification,
     endpoint: ((r) => {

--- a/src/flows/pipes/Notification/endpoints/AWS/index.ts
+++ b/src/flows/pipes/Notification/endpoints/AWS/index.ts
@@ -26,14 +26,16 @@ export default register => {
       ['array', 'http', 'influxdata/influxdb/secrets']
         .map(i => `import "${i}"`)
         .join('\n'),
-    generateQuery: data => `task_data
+    generateQuery: (data, measurement) => `task_data
 	|> schema["fieldsAsCols"]()
       |> set(key: "_notebook_link", value: "${window.location.href}")
+  |> filter(fn: ${measurement})
 	|> monitor["check"](
 		data: check,
 		messageFn: messageFn,
 		crit: trigger,
 	)
+  |> filter(fn: trigger)
 	|> monitor["notify"](
     data: notification,
     endpoint: ((r) => {

--- a/src/flows/pipes/Notification/endpoints/HTTP/index.ts
+++ b/src/flows/pipes/Notification/endpoints/HTTP/index.ts
@@ -62,6 +62,8 @@ export default register => {
             crit: trigger,
           )
           |> filter(fn: trigger)
+          |> keep(columns: ["_value", "_time", "_measurement"])
+          |> limit(n: 1, offset: 0)
           |> monitor["notify"](data: notification, endpoint: http.endpoint(url: "${data.url}")(
             mapFn: (r) => {
                 body = {r with _version: 1}

--- a/src/flows/pipes/Notification/endpoints/HTTP/index.ts
+++ b/src/flows/pipes/Notification/endpoints/HTTP/index.ts
@@ -23,7 +23,7 @@ export default register => {
       ['array', 'http', 'influxdata/influxdb/secrets', 'json']
         .map(i => `import "${i}"`)
         .join('\n'),
-    generateQuery: data => {
+    generateQuery: (data, measurement) => {
       const headers = [['"Content-Type"', '"application/json"']]
       let prefixSecrets = ''
 
@@ -55,11 +55,13 @@ export default register => {
         task_data
           |> schema["fieldsAsCols"]()
               |> set(key: "_notebook_link", value: "${window.location.href}")
+          |> filter(fn: ${measurement})
           |> monitor["check"](
             data: check,
             messageFn: messageFn,
             crit: trigger,
           )
+          |> filter(fn: trigger)
           |> monitor["notify"](data: notification, endpoint: http.endpoint(url: "${data.url}")(
             mapFn: (r) => {
                 body = {r with _version: 1}

--- a/src/flows/pipes/Notification/endpoints/Mailgun/index.ts
+++ b/src/flows/pipes/Notification/endpoints/Mailgun/index.ts
@@ -21,7 +21,7 @@ export default register => {
       ['array', 'http', 'influxdata/influxdb/secrets']
         .map(i => `import "${i}"`)
         .join('\n'),
-    generateQuery: data => {
+    generateQuery: (data, measurement) => {
       const subject = encodeURIComponent('InfluxDB Alert')
       const fromEmail = `mailgun@${data.domain}`
 
@@ -31,11 +31,13 @@ auth = http.basicAuth(u: "api", p: "\${apiKey}")
 task_data
 	|> schema["fieldsAsCols"]()
       |> set(key: "_notebook_link", value: "${window.location.href}")
+  |> filter(fn: ${measurement})
 	|> monitor["check"](
 		data: check,
 		messageFn: messageFn,
 		crit: trigger,
 	)
+  |> filter(fn: trigger)
 	|> monitor["notify"](
     data: notification,
     endpoint: http.endpoint(url: "https://api.mailgun.net/v3/${data.domain}/messages")(

--- a/src/flows/pipes/Notification/endpoints/Mailgun/index.ts
+++ b/src/flows/pipes/Notification/endpoints/Mailgun/index.ts
@@ -38,6 +38,8 @@ task_data
 		crit: trigger,
 	)
   |> filter(fn: trigger)
+  |> keep(columns: ["_value", "_time", "_measurement"])
+  |> limit(n: 1, offset: 0)
 	|> monitor["notify"](
     data: notification,
     endpoint: http.endpoint(url: "https://api.mailgun.net/v3/${data.domain}/messages")(

--- a/src/flows/pipes/Notification/endpoints/Mailjet/index.ts
+++ b/src/flows/pipes/Notification/endpoints/Mailjet/index.ts
@@ -34,6 +34,8 @@ export default register => {
 		crit: trigger,
 	)
   |> filter(fn: trigger)
+  |> keep(columns: ["_value", "_time", "_measurement"])
+  |> limit(n: 1, offset: 0)
 	|> monitor["notify"](
     data: notification,
     endpoint: http.endpoint(url: "${data.url}")(

--- a/src/flows/pipes/Notification/endpoints/Mailjet/index.ts
+++ b/src/flows/pipes/Notification/endpoints/Mailjet/index.ts
@@ -24,14 +24,16 @@ export default register => {
       ['array', 'http', 'influxdata/influxdb/secrets', 'json']
         .map(i => `import "${i}"`)
         .join('\n'),
-    generateQuery: data => `task_data
+    generateQuery: (data, measurement) => `task_data
 	|> schema["fieldsAsCols"]()
       |> set(key: "_notebook_link", value: "${window.location.href}")
-	|> monitor["check"](
+  |> filter(fn: ${measurement})
+  |> monitor["check"](
 		data: check,
 		messageFn: messageFn,
 		crit: trigger,
 	)
+  |> filter(fn: trigger)
 	|> monitor["notify"](
     data: notification,
     endpoint: http.endpoint(url: "${data.url}")(

--- a/src/flows/pipes/Notification/endpoints/PagerDuty/index.ts
+++ b/src/flows/pipes/Notification/endpoints/PagerDuty/index.ts
@@ -21,14 +21,16 @@ export default register => {
       ['pagerduty', 'influxdata/influxdb/secrets']
         .map(i => `import "${i}"`)
         .join('\n'),
-    generateQuery: data => `task_data
+    generateQuery: (data, measurement) => `task_data
 	|> schema["fieldsAsCols"]()
-  |> set(key: "_notebook_link", value: "${window.location.href}")  
+  |> set(key: "_notebook_link", value: "${window.location.href}")
+  |> filter(fn: ${measurement})
   |> monitor["check"](
 		data: check,
 		messageFn: messageFn,
     crit: trigger,
 	)
+  |> filter(fn: trigger)
 	|> monitor["notify"](data: notification, endpoint: pagerduty.endpoint()(mapFn: (r) => ({ r with
         routingKey: "${data.key}",
         client: "influxdata",

--- a/src/flows/pipes/Notification/endpoints/PagerDuty/index.ts
+++ b/src/flows/pipes/Notification/endpoints/PagerDuty/index.ts
@@ -31,6 +31,8 @@ export default register => {
     crit: trigger,
 	)
   |> filter(fn: trigger)
+  |> keep(columns: ["_value", "_time", "_measurement"])
+  |> limit(n: 1, offset: 0)
 	|> monitor["notify"](data: notification, endpoint: pagerduty.endpoint()(mapFn: (r) => ({ r with
         routingKey: "${data.key}",
         client: "influxdata",

--- a/src/flows/pipes/Notification/endpoints/SendGrid/index.ts
+++ b/src/flows/pipes/Notification/endpoints/SendGrid/index.ts
@@ -23,14 +23,16 @@ export default register => {
       ['array', 'http', 'influxdata/influxdb/secrets', 'json']
         .map(i => `import "${i}"`)
         .join('\n'),
-    generateQuery: data => `task_data
+    generateQuery: (data, measurement) => `task_data
 	|> schema["fieldsAsCols"]()
       |> set(key: "_notebook_link", value: "${window.location.href}")
-	|> monitor["check"](
+  |> filter(fn: ${measurement})
+  |> monitor["check"](
 		data: check,
 		messageFn: messageFn,
 		crit: trigger,
 	)
+  |> filter(fn: trigger)
   |> monitor["notify"](
     data: notification,
     endpoint: http.endpoint(url: "${data.url}")(

--- a/src/flows/pipes/Notification/endpoints/SendGrid/index.ts
+++ b/src/flows/pipes/Notification/endpoints/SendGrid/index.ts
@@ -33,6 +33,8 @@ export default register => {
 		crit: trigger,
 	)
   |> filter(fn: trigger)
+  |> keep(columns: ["_value", "_time", "_measurement"])
+  |> limit(n: 1, offset: 0)
   |> monitor["notify"](
     data: notification,
     endpoint: http.endpoint(url: "${data.url}")(

--- a/src/flows/pipes/Notification/endpoints/Slack/index.ts
+++ b/src/flows/pipes/Notification/endpoints/Slack/index.ts
@@ -16,14 +16,16 @@ export default register => {
     generateImports: () => ['slack'].map(i => `import "${i}"`).join('\n'),
     generateTestImports: () =>
       ['array', 'slack'].map(i => `import "${i}"`).join('\n'),
-    generateQuery: data => `task_data
+    generateQuery: (data, measurement) => `task_data
 	|> schema["fieldsAsCols"]()
       |> set(key: "_notebook_link", value: "${window.location.href}")
+  |> filter(fn: ${measurement})
 	|> monitor["check"](
 		data: check,
 		messageFn: messageFn,
 		crit: trigger,
 	)
+  |> filter(fn: trigger)
 	|> monitor["notify"](
     data: notification,
     endpoint: slack["endpoint"](url: "${data.url}")(mapFn: (r) => ({

--- a/src/flows/pipes/Notification/endpoints/Slack/index.ts
+++ b/src/flows/pipes/Notification/endpoints/Slack/index.ts
@@ -26,6 +26,8 @@ export default register => {
 		crit: trigger,
 	)
   |> filter(fn: trigger)
+  |> keep(columns: ["_value", "_time", "_measurement"])
+  |> limit(n: 1, offset: 0)
 	|> monitor["notify"](
     data: notification,
     endpoint: slack["endpoint"](url: "${data.url}")(mapFn: (r) => ({

--- a/src/flows/pipes/Notification/endpoints/Telegram/index.ts
+++ b/src/flows/pipes/Notification/endpoints/Telegram/index.ts
@@ -33,6 +33,8 @@ export default register => {
 		crit: trigger,
 	)
   |> filter(fn: trigger)
+  |> keep(columns: ["_value", "_time", "_measurement"])
+  |> limit(n: 1, offset: 0)
 	|> monitor["notify"](
     data: notification,
     endpoint: telegram["endpoint"](

--- a/src/flows/pipes/Notification/endpoints/Telegram/index.ts
+++ b/src/flows/pipes/Notification/endpoints/Telegram/index.ts
@@ -23,14 +23,16 @@ export default register => {
       ['array', 'contrib/sranka/telegram', 'influxdata/influxdb/secrets']
         .map(i => `import "${i}"`)
         .join('\n'),
-    generateQuery: data => `task_data
+    generateQuery: (data, measurement) => `task_data
 	|> schema["fieldsAsCols"]()
       |> set(key: "_notebook_link", value: "${window.location.href}")
+  |> filter(fn: ${measurement})
 	|> monitor["check"](
 		data: check,
 		messageFn: messageFn,
 		crit: trigger,
 	)
+  |> filter(fn: trigger)
 	|> monitor["notify"](
     data: notification,
     endpoint: telegram["endpoint"](

--- a/src/flows/pipes/Notification/endpoints/Zenoss/index.ts
+++ b/src/flows/pipes/Notification/endpoints/Zenoss/index.ts
@@ -25,14 +25,16 @@ export default register => {
       ['array', 'contrib/bonitoo-io/zenoss', 'influxdata/influxdb/secrets']
         .map(i => `import "${i}"`)
         .join('\n'),
-    generateQuery: data => `task_data
+    generateQuery: (data, measurement) => `task_data
 	|> schema["fieldsAsCols"]()
       |> set(key: "_notebook_link", value: "${window.location.href}")
+  |> filter(fn: ${measurement})
 	|> monitor["check"](
 		data: check,
 		messageFn: messageFn,
 		crit: trigger,
 	)
+  |> filter(fn: trigger)
 	|> monitor["notify"](
     data: notification,
     endpoint: zenoss["endpoint"](

--- a/src/flows/pipes/Notification/endpoints/Zenoss/index.ts
+++ b/src/flows/pipes/Notification/endpoints/Zenoss/index.ts
@@ -35,6 +35,8 @@ export default register => {
 		crit: trigger,
 	)
   |> filter(fn: trigger)
+  |> keep(columns: ["_value", "_time", "_measurement"])
+  |> limit(n: 1, offset: 0)
 	|> monitor["notify"](
     data: notification,
     endpoint: zenoss["endpoint"](

--- a/src/flows/pipes/Notification/index.ts
+++ b/src/flows/pipes/Notification/index.ts
@@ -1,10 +1,5 @@
 import View from './view'
 import ReadOnly from './readOnly'
-import {PipeData} from 'src/types'
-
-const removeNotificationThresholds = data => {
-  delete data.thresholds
-}
 
 export default register => {
   register({
@@ -31,7 +26,6 @@ export default register => {
         url: 'https://hooks.slack.com/services/X/X/X',
       },
     },
-    beforeRemove: (data: PipeData) => removeNotificationThresholds(data),
     visual: (_data, query) => {
       return query
     },

--- a/src/flows/pipes/Notification/index.ts
+++ b/src/flows/pipes/Notification/index.ts
@@ -1,5 +1,10 @@
 import View from './view'
 import ReadOnly from './readOnly'
+import {PipeData} from 'src/types'
+
+const removeNotificationThresholds = data => {
+  delete data.thresholds
+}
 
 export default register => {
   register({
@@ -26,6 +31,7 @@ export default register => {
         url: 'https://hooks.slack.com/services/X/X/X',
       },
     },
+    beforeRemove: (data: PipeData) => removeNotificationThresholds(data),
     visual: (_data, query) => {
       return query
     },

--- a/src/flows/pipes/Notification/readOnly.tsx
+++ b/src/flows/pipes/Notification/readOnly.tsx
@@ -16,6 +16,7 @@ import {
   TechnoSpinner,
   SpinnerContainer,
 } from '@influxdata/clockface'
+import Measurement from 'src/flows/pipes/Notification/Measurement'
 import Threshold from 'src/flows/pipes/Notification/Threshold'
 
 import {PipeContext} from 'src/flows/context/pipe'
@@ -99,6 +100,7 @@ const ReadOnly: FC<PipeProp> = ({Context}) => {
   return (
     <Context>
       <div className="notification">
+        <Measurement readOnly />
         <Threshold readOnly />
         <FlexBox margin={ComponentSize.Medium} style={{padding: '24px 0'}}>
           <FlexBox.Child grow={1} shrink={1}>

--- a/src/flows/pipes/Notification/view.tsx
+++ b/src/flows/pipes/Notification/view.tsx
@@ -34,6 +34,7 @@ import {PipeContext} from 'src/flows/context/pipe'
 import {FlowQueryContext} from 'src/flows/context/flow.query'
 import {remove} from 'src/shared/contexts/query'
 import Expressions from 'src/flows/pipes/Notification/Expressions'
+import Measurement from 'src/flows/pipes/Notification/Measurement'
 import Threshold from 'src/flows/pipes/Notification/Threshold'
 import {
   ENDPOINT_DEFINITIONS,
@@ -340,6 +341,7 @@ const Notification: FC<PipeProp> = ({Context}) => {
             style={{width: 25, height: 25, position: 'absolute', right: 15}}
           />
         )}
+        <Measurement />
         <Threshold />
         <FlexBox margin={ComponentSize.Medium} style={{padding: '24px 0'}}>
           <FlexBox.Child grow={1} shrink={1}>

--- a/src/flows/pipes/Schedule/ExportTaskButton.tsx
+++ b/src/flows/pipes/Schedule/ExportTaskButton.tsx
@@ -31,6 +31,7 @@ import {getErrorMessage} from 'src/utils/api'
 import {getOrg} from 'src/organizations/selectors'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {PROJECT_NAME_PLURAL} from 'src/flows'
+import {missingUserInput} from 'src/shared/copy/notifications'
 
 interface Props {
   text: string
@@ -55,7 +56,14 @@ const ExportTaskButton: FC<Props> = ({
   const org = useSelector(getOrg)
 
   const onClick = async () => {
-    const query = generate ? generate() : data.query
+    let query
+
+    try {
+      query = generate ? generate() : data.query
+    } catch (e) {
+      dispatch(notify(missingUserInput(e.message)))
+      return
+    }
 
     event('Export Task Modal Skipped', {from: type, type: data.endpoint})
     let taskid

--- a/src/flows/pipes/Visualization/threshold.ts
+++ b/src/flows/pipes/Visualization/threshold.ts
@@ -18,18 +18,18 @@ export interface ErrorThreshold extends Threshold {
   fieldType: string
 }
 
-export const lambdaPrefix = '(r) =>'
+export const LAMBDA_PREFIX = '(r) =>'
 
 export const EQUALITY_THRESHOLD_TYPES = {
   equal: {
     name: 'equal to',
     format: ThresholdFormat.Value,
-    condition: data => `${lambdaPrefix} (r["${data.field}"] == ${data.value})`,
+    condition: data => `${LAMBDA_PREFIX} (r["${data.field}"] == ${data.value})`,
   },
   'not-equal': {
     name: 'not equal to',
     format: ThresholdFormat.Value,
-    condition: data => `${lambdaPrefix} (r["${data.field}"] != ${data.value})`,
+    condition: data => `${LAMBDA_PREFIX} (r["${data.field}"] != ${data.value})`,
   },
 }
 
@@ -38,34 +38,34 @@ export const COMMON_THRESHOLD_TYPES = {
   greater: {
     name: 'greater than',
     format: ThresholdFormat.Value,
-    condition: data => `${lambdaPrefix} (r["${data.field}"] > ${data.value})`,
+    condition: data => `${LAMBDA_PREFIX} (r["${data.field}"] > ${data.value})`,
   },
   'greater-equal': {
     name: 'greater than or equal to',
     format: ThresholdFormat.Value,
-    condition: data => `${lambdaPrefix} (r["${data.field}"] >= ${data.value})`,
+    condition: data => `${LAMBDA_PREFIX} (r["${data.field}"] >= ${data.value})`,
   },
   less: {
     name: 'less than',
     format: ThresholdFormat.Value,
-    condition: data => `${lambdaPrefix} (r["${data.field}"] < ${data.value})`,
+    condition: data => `${LAMBDA_PREFIX} (r["${data.field}"] < ${data.value})`,
   },
   'less-equal': {
     name: 'less than or equal to',
     format: ThresholdFormat.Value,
-    condition: data => `${lambdaPrefix} (r["${data.field}"] <= ${data.value})`,
+    condition: data => `${LAMBDA_PREFIX} (r["${data.field}"] <= ${data.value})`,
   },
   between: {
     name: 'between',
     format: ThresholdFormat.Range,
     condition: data =>
-      `${lambdaPrefix} (r["${data.field}"] > ${data.min} and r["${data.field}"] < ${data.max})`,
+      `${LAMBDA_PREFIX} (r["${data.field}"] > ${data.min} and r["${data.field}"] < ${data.max})`,
   },
   'not-between': {
     name: 'not between',
     format: ThresholdFormat.Range,
     condition: data =>
-      `${lambdaPrefix} (r["${data.field}"] < ${data.min} or r["${data.field}"] > ${data.max})`,
+      `${LAMBDA_PREFIX} (r["${data.field}"] < ${data.min} or r["${data.field}"] > ${data.max})`,
   },
 }
 
@@ -76,6 +76,6 @@ export const THRESHOLD_TYPES = {
   [deadmanType]: {
     name: 'missing for longer than',
     format: ThresholdFormat.Deadman,
-    condition: _ => `${lambdaPrefix} (r["dead"])`,
+    condition: _ => `${LAMBDA_PREFIX} (r["dead"])`,
   },
 }

--- a/src/flows/pipes/Visualization/threshold.ts
+++ b/src/flows/pipes/Visualization/threshold.ts
@@ -18,31 +18,28 @@ export interface ErrorThreshold extends Threshold {
   fieldType: string
 }
 
+export const lambdaPrefix = '(r) =>'
+
 export const COMMON_THRESHOLD_TYPES = {
   greater: {
     name: 'greater than',
     format: ThresholdFormat.Value,
-    condition: data => `(r) => (r["${data.field}"] > ${data.value})`,
+    condition: data => `${lambdaPrefix} (r["${data.field}"] > ${data.value})`,
   },
   'greater-equal': {
     name: 'greater than or equal to',
     format: ThresholdFormat.Value,
-    condition: data => `(r) => (r["${data.field}"] >= ${data.value})`,
+    condition: data => `${lambdaPrefix} (r["${data.field}"] >= ${data.value})`,
   },
   less: {
     name: 'less than',
     format: ThresholdFormat.Value,
-    condition: data => `(r) => (r["${data.field}"] < ${data.value})`,
+    condition: data => `${lambdaPrefix} (r["${data.field}"] < ${data.value})`,
   },
   'less-equal': {
     name: 'less than or equal to',
     format: ThresholdFormat.Value,
-    condition: data => `(r) => (r["${data.field}"] <= ${data.value})`,
-  },
-  equal: {
-    name: 'equal to',
-    format: ThresholdFormat.Value,
-    condition: data => `(r) => (r["${data.field}"] == ${data.value})`,
+    condition: data => `${lambdaPrefix} (r["${data.field}"] <= ${data.value})`,
   },
   'not-equal': {
     name: 'not equal to',
@@ -53,13 +50,13 @@ export const COMMON_THRESHOLD_TYPES = {
     name: 'between',
     format: ThresholdFormat.Range,
     condition: data =>
-      `(r) => (r["${data.field}"] > ${data.min} and r["${data.field}"] < ${data.max})`,
+      `${lambdaPrefix} (r["${data.field}"] > ${data.min} and r["${data.field}"] < ${data.max})`,
   },
   'not-between': {
     name: 'not between',
     format: ThresholdFormat.Range,
     condition: data =>
-      `(r) => (r["${data.field}"] < ${data.min} or r["${data.field}"] > ${data.max})`,
+      `${lambdaPrefix} (r["${data.field}"] < ${data.min} or r["${data.field}"] > ${data.max})`,
   },
 }
 
@@ -67,12 +64,12 @@ export const EQUALITY_THRESHOLD_TYPES = {
   equal: {
     name: 'equal to',
     format: ThresholdFormat.Value,
-    condition: data => `(r) => (r["${data.field}"] == ${data.value})`,
+    condition: data => `${lambdaPrefix} (r["${data.field}"] == ${data.value})`,
   },
   'not-equal': {
     name: 'not equal to',
     format: ThresholdFormat.Value,
-    condition: data => `(r) => (r["${data.field}"] != ${data.value})`,
+    condition: data => `${lambdaPrefix} (r["${data.field}"] != ${data.value})`,
   },
 }
 
@@ -83,6 +80,6 @@ export const THRESHOLD_TYPES = {
   [deadmanType]: {
     name: 'missing for longer than',
     format: ThresholdFormat.Deadman,
-    condition: _ => `(r) => (r["dead"])`,
+    condition: _ => `${lambdaPrefix} (r["dead"])`,
   },
 }

--- a/src/flows/pipes/Visualization/threshold.ts
+++ b/src/flows/pipes/Visualization/threshold.ts
@@ -20,7 +20,21 @@ export interface ErrorThreshold extends Threshold {
 
 export const lambdaPrefix = '(r) =>'
 
+export const EQUALITY_THRESHOLD_TYPES = {
+  equal: {
+    name: 'equal to',
+    format: ThresholdFormat.Value,
+    condition: data => `${lambdaPrefix} (r["${data.field}"] == ${data.value})`,
+  },
+  'not-equal': {
+    name: 'not equal to',
+    format: ThresholdFormat.Value,
+    condition: data => `${lambdaPrefix} (r["${data.field}"] != ${data.value})`,
+  },
+}
+
 export const COMMON_THRESHOLD_TYPES = {
+  ...EQUALITY_THRESHOLD_TYPES,
   greater: {
     name: 'greater than',
     format: ThresholdFormat.Value,
@@ -41,11 +55,6 @@ export const COMMON_THRESHOLD_TYPES = {
     format: ThresholdFormat.Value,
     condition: data => `${lambdaPrefix} (r["${data.field}"] <= ${data.value})`,
   },
-  'not-equal': {
-    name: 'not equal to',
-    format: ThresholdFormat.Value,
-    condition: data => `(r) => (r["${data.field}"] != ${data.value})`,
-  },
   between: {
     name: 'between',
     format: ThresholdFormat.Range,
@@ -57,19 +66,6 @@ export const COMMON_THRESHOLD_TYPES = {
     format: ThresholdFormat.Range,
     condition: data =>
       `${lambdaPrefix} (r["${data.field}"] < ${data.min} or r["${data.field}"] > ${data.max})`,
-  },
-}
-
-export const EQUALITY_THRESHOLD_TYPES = {
-  equal: {
-    name: 'equal to',
-    format: ThresholdFormat.Value,
-    condition: data => `${lambdaPrefix} (r["${data.field}"] == ${data.value})`,
-  },
-  'not-equal': {
-    name: 'not equal to',
-    format: ThresholdFormat.Value,
-    condition: data => `${lambdaPrefix} (r["${data.field}"] != ${data.value})`,
   },
 }
 

--- a/src/flows/pipes/Visualization/threshold.ts
+++ b/src/flows/pipes/Visualization/threshold.ts
@@ -18,18 +18,16 @@ export interface ErrorThreshold extends Threshold {
   fieldType: string
 }
 
-export const LAMBDA_PREFIX = '(r) =>'
-
 export const EQUALITY_THRESHOLD_TYPES = {
   equal: {
     name: 'equal to',
     format: ThresholdFormat.Value,
-    condition: data => `${LAMBDA_PREFIX} (r["${data.field}"] == ${data.value})`,
+    condition: data => ` r["${data.field}"] == ${data.value}`,
   },
   'not-equal': {
     name: 'not equal to',
     format: ThresholdFormat.Value,
-    condition: data => `${LAMBDA_PREFIX} (r["${data.field}"] != ${data.value})`,
+    condition: data => ` r["${data.field}"] != ${data.value}`,
   },
 }
 
@@ -38,34 +36,34 @@ export const COMMON_THRESHOLD_TYPES = {
   greater: {
     name: 'greater than',
     format: ThresholdFormat.Value,
-    condition: data => `${LAMBDA_PREFIX} (r["${data.field}"] > ${data.value})`,
+    condition: data => ` r["${data.field}"] > ${data.value}`,
   },
   'greater-equal': {
     name: 'greater than or equal to',
     format: ThresholdFormat.Value,
-    condition: data => `${LAMBDA_PREFIX} (r["${data.field}"] >= ${data.value})`,
+    condition: data => ` r["${data.field}"] >= ${data.value}`,
   },
   less: {
     name: 'less than',
     format: ThresholdFormat.Value,
-    condition: data => `${LAMBDA_PREFIX} (r["${data.field}"] < ${data.value})`,
+    condition: data => ` r["${data.field}"] < ${data.value}`,
   },
   'less-equal': {
     name: 'less than or equal to',
     format: ThresholdFormat.Value,
-    condition: data => `${LAMBDA_PREFIX} (r["${data.field}"] <= ${data.value})`,
+    condition: data => ` r["${data.field}"] <= ${data.value}`,
   },
   between: {
     name: 'between',
     format: ThresholdFormat.Range,
     condition: data =>
-      `${LAMBDA_PREFIX} (r["${data.field}"] > ${data.min} and r["${data.field}"] < ${data.max})`,
+      ` (r["${data.field}"] > ${data.min} and r["${data.field}"] < ${data.max})`,
   },
   'not-between': {
     name: 'not between',
     format: ThresholdFormat.Range,
     condition: data =>
-      `${LAMBDA_PREFIX} (r["${data.field}"] < ${data.min} or r["${data.field}"] > ${data.max})`,
+      ` (r["${data.field}"] < ${data.min} or r["${data.field}"] > ${data.max})`,
   },
 }
 
@@ -76,6 +74,6 @@ export const THRESHOLD_TYPES = {
   [deadmanType]: {
     name: 'missing for longer than',
     format: ThresholdFormat.Deadman,
-    condition: _ => `${LAMBDA_PREFIX} (r["dead"])`,
+    condition: _ => ` r["dead"]`,
   },
 }


### PR DESCRIPTION
Closes #3707 
Closes #4021 
Closes #4479
Also fixed one other found bug.

## Issues/Bugs:
* bug 4021. The addition of multiple thresholds, resulted in invalid flux being exported to a task.
     * flux was writing `(r) => r["a"] > 0 and (r) => r["a"] = 0` . This is an incorrect lambda.
* Bug found. We were setting the default `threshold.field` to a string value `"_value"`.
     * this was occurring even without a user selecting a field.
     * <img width="300" alt="Screen Shot 2022-03-09 at 7 04 58 PM" src="https://user-images.githubusercontent.com/10232835/157586533-f6521a02-982d-4ab8-9c59-9c4ee546f9b6.png">
     * produced flux with `r["_value]`
* bug 3707: alerts are being received as spam
     * the filter/threshold-predicate was being given to the monitor.check() method, but never applied as a transformation in the current query
     * additionally, we have multiple rows piped to monitor.notify() --> instead of limiting to 1. For each row, a notification gets sent.
* bug 4479:
    * make threshold panel. Delete panel --> state was being persisted.
    * FIX: Delete panel --> thresholds are deleted --> re-make panel, now get blank thresholds (clean state).

## Visual proof:

https://user-images.githubusercontent.com/10232835/165164243-d6c5d10c-8771-4d87-9301-13564c27ea14.mp4

* re-check (on this new branch/PR) that we still have functional:
   * deadman checks
   * error thresholds in graph 


## Resultant Query:
Parts of the query updated/changed. (Not the full task query. See vid for that.)

```
trigger = (r) => r["co"] > 0.2 and r["humidity"] < 20 and (r["temperature"] > 0 and r["temperature"] < 100)

task_data
    |> schema["fieldsAsCols"]()
    |> set(
        key: "_notebook_link",
        value:
            "https://twodotoh-dev-denisewiedl20220405130506.remocal.influxdev.co/orgs/9c5955fc99a60b8f/notebooks/6014cd2c58952000",
    )
    |> filter(fn: (r) => r["_measurement"] == "airSensors")
    |> monitor["check"](data: check, messageFn: messageFn, crit: trigger)
    |> filter(fn: trigger)
    |> keep(columns: ["_value", "_time", "_measurement"])
    |> limit(n: 1, offset: 0)
    |> monitor["notify"](
        data: notification,
        endpoint:
            http.endpoint(url: "https://www.example.com/endpoint")(
                mapFn: (r) => {
                    body = {r with _version: 1}

                    return {headers: {"Content-Type": "application/json"}, data: json.encode(v: body)}
                },
            ),
    )
``` 

## Future work (not done in this PR):
* form validation for Notebook Alerts (issue 4229)
* use of schema (issue 4080) for:
   * form validation
   * only can select fields, which belong to the measurement chosen in the Alerts panel