### PR TITLE
fix(firstMile): newlines at the end for python code snippets

### DIFF
--- a/src/homepageExperience/components/steps/python/ExecuteAggregateQuery.tsx
+++ b/src/homepageExperience/components/steps/python/ExecuteAggregateQuery.tsx
@@ -36,7 +36,8 @@ tables = query_api.query(query, org="${org.name}")
 
 for table in tables:
     for record in table.records:
-        print(record)`
+        print(record)
+`
 
   return (
     <>

--- a/src/homepageExperience/components/steps/python/ExecuteQuery.tsx
+++ b/src/homepageExperience/components/steps/python/ExecuteQuery.tsx
@@ -28,7 +28,8 @@ tables = query_api.query(query, org="${org.name}")
 
 for table in tables:
   for record in table.records:
-    print(record)`
+    print(record)
+`
 
   return (
     <>

--- a/src/homepageExperience/components/steps/python/InitalizeClient.tsx
+++ b/src/homepageExperience/components/steps/python/InitalizeClient.tsx
@@ -26,7 +26,8 @@ token = os.environ.get("INFLUXDB_TOKEN")
 org = "${org.name}"
 url = "${url}"
 
-client = influxdb_client.InfluxDBClient(url=url, token=token, org=org)`
+client = influxdb_client.InfluxDBClient(url=url, token=token, org=org)
+`
 
   return (
     <>

--- a/src/homepageExperience/components/steps/python/WriteData.tsx
+++ b/src/homepageExperience/components/steps/python/WriteData.tsx
@@ -50,8 +50,7 @@ export const WriteDataComponent = (props: OwnProps) => {
     onSelectBucket(bucket.name)
   }, [bucket])
 
-  const codeSnippet = `
-bucket="${bucket.name}"
+  const codeSnippet = `bucket="${bucket.name}"
 
 write_api = client.write_api(write_options=SYNCHRONOUS)
    
@@ -62,7 +61,8 @@ for value in range(5):
     .field("field1", value)
   )
   write_api.write(bucket=bucket, org="${org.name}", record=point)
-  time.sleep(1) # separate points by 1 second`
+  time.sleep(1) # separate points by 1 second
+`
 
   return (
     <>


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/4458

adds new lines to the end of all the python scripts in the firstmile. this makes it work well with the python interpreter.


<!-- Describe your proposed changes here. -->
