### PR TITLE
fix: language fixes for first mile

### DIFF
--- a/src/homepageExperience/components/steps/Tokens.tsx
+++ b/src/homepageExperience/components/steps/Tokens.tsx
@@ -39,7 +39,7 @@ type OwnProps = {
 
 const collator = new Intl.Collator(navigator.language || 'en-US')
 
-export const CreateToken: FC<OwnProps> = ({
+export const Tokens: FC<OwnProps> = ({
   wizardEventName,
   setTokenValue,
   tokenValue,
@@ -77,7 +77,7 @@ export const CreateToken: FC<OwnProps> = ({
       }
 
       dispatch(createAuthorization(authorization))
-      event(`firstMile.${wizardEventName}.createToken.tokenCreated`)
+      event(`firstMile.${wizardEventName}.tokens.tokenCreated`)
     }
   }, [sortedPermissionTypes.length])
 
@@ -97,16 +97,16 @@ export const CreateToken: FC<OwnProps> = ({
 
   // Events log handling
   const logCopyCodeSnippet = () => {
-    event(`firstMile.${wizardEventName}.createToken.code.copied`)
+    event(`firstMile.${wizardEventName}.tokens.code.copied`)
   }
 
   const logDocsOpened = () => {
-    event(`firstMile.${wizardEventName}.createToken.docs.opened`)
+    event(`firstMile.${wizardEventName}.tokens.docs.opened`)
   }
 
   return (
     <>
-      <h1>Create a Token</h1>
+      <h1>Tokens</h1>
       <p>
         InfluxDB Cloud uses Tokens to authenticate API access. We've created an
         all-access token for you for this set up process.

--- a/src/homepageExperience/components/steps/Tokens.tsx
+++ b/src/homepageExperience/components/steps/Tokens.tsx
@@ -119,15 +119,15 @@ export const Tokens: FC<OwnProps> = ({
       <FlexBox margin={ComponentSize.Large} alignItems={AlignItems.Center}>
         <Icon glyph={IconFont.Info_New} style={{fontSize: '30px'}} />
         <p>
-          Creating an all-access tokens is not the best security practice! We
-          recommend you to delete this token in the{' '}
+          Creating an all-access token is not the best security practice! We
+          recommend you delete this token in the{' '}
           <SafeBlankLink
             href={`orgs/${org.id}/load-data/tokens`}
             onClick={logDocsOpened}
           >
             Token page
           </SafeBlankLink>{' '}
-          after setting up, and creating your own token with specific set of
+          after setting up, and create your own token with a specific set of
           permissions later.
         </p>
       </FlexBox>

--- a/src/homepageExperience/components/steps/go/ExecuteAggregateQuery.tsx
+++ b/src/homepageExperience/components/steps/go/ExecuteAggregateQuery.tsx
@@ -60,7 +60,7 @@ if err := results.Err(); err != nil {
       />
       <p>
         In this example, we use the mean() function to calculate the average of
-        data points in last 10 minutes.
+        data points in the last 10 minutes.
         <br />
         <br />
         Add the following to your <code>main</code> function:

--- a/src/homepageExperience/components/steps/go/ExecuteQuery.tsx
+++ b/src/homepageExperience/components/steps/go/ExecuteQuery.tsx
@@ -49,7 +49,7 @@ if err := results.Err(); err != nil {
         onCopy={logCopyCodeSnippet}
       />
       <p>
-        In this query, we are looking for data points within last 10 minutes
+        In this query, we are looking for data points within the last 10 minutes
         with field key of "field1".
         <br />
         <br />

--- a/src/homepageExperience/components/steps/go/WriteData.tsx
+++ b/src/homepageExperience/components/steps/go/WriteData.tsx
@@ -72,7 +72,7 @@ for value := 0; value < 5; value++ {
     <>
       <h1>Write Data</h1>
       <p>
-        To start writing data, we need a place to our time-series store data. We
+        To start writing data, we need a place to store our time-series data. We
         call these{' '}
         <SafeBlankLink
           href={`orgs/${org.id}/load-data/buckets`}

--- a/src/homepageExperience/components/steps/nodejs/ExecuteAggregateQuery.tsx
+++ b/src/homepageExperience/components/steps/nodejs/ExecuteAggregateQuery.tsx
@@ -63,7 +63,7 @@ queryClient.queryRows(fluxQuery, {
       />
       <p>
         In this example, we use the mean() function to calculate the average of
-        data points in last 10 minutes.
+        data points in the last 10 minutes.
         <br />
         <br />
         Run the following:

--- a/src/homepageExperience/components/steps/nodejs/ExecuteQuery.tsx
+++ b/src/homepageExperience/components/steps/nodejs/ExecuteQuery.tsx
@@ -52,7 +52,7 @@ queryClient.queryRows(fluxQuery, {
         onCopy={logCopyCodeSnippet}
       />
       <p>
-        In this query, we are looking for data points within last 10 minutes
+        In this query, we are looking for data points within the last 10 minutes
         with field key of "field1".
         <br />
         <br />

--- a/src/homepageExperience/components/steps/nodejs/WriteData.tsx
+++ b/src/homepageExperience/components/steps/nodejs/WriteData.tsx
@@ -51,13 +51,13 @@ export const WriteDataComponent = (props: OwnProps) => {
   }, [bucket])
 
   const codeSnippet = `
-const org = \`${org.name}\`
-const bucket = \`${bucket.name}\`
+let org = \`${org.name}\`
+let bucket = \`${bucket.name}\`
 
-const writeClient = client.getWriteApi(org, bucket, 'ns')
+let writeClient = client.getWriteApi(org, bucket, 'ns')
 
 for (let i = 0; i < 5; i++) {
-  const point = new Point('measurement1')
+  let point = new Point('measurement1')
     .tag('tagname1', 'tagvalue1')
     .floatField('field1', i)
 

--- a/src/homepageExperience/components/steps/nodejs/WriteData.tsx
+++ b/src/homepageExperience/components/steps/nodejs/WriteData.tsx
@@ -51,13 +51,13 @@ export const WriteDataComponent = (props: OwnProps) => {
   }, [bucket])
 
   const codeSnippet = `
-let org = \`${org.name}\`
-let bucket = \`${bucket.name}\`
+const org = \`${org.name}\`
+const bucket = \`${bucket.name}\`
 
-let writeClient = client.getWriteApi(org, bucket, 'ns')
+const writeClient = client.getWriteApi(org, bucket, 'ns')
 
 for (let i = 0; i < 5; i++) {
-  let point = new Point('measurement1')
+  const point = new Point('measurement1')
     .tag('tagname1', 'tagvalue1')
     .floatField('field1', i)
 

--- a/src/homepageExperience/components/steps/nodejs/WriteData.tsx
+++ b/src/homepageExperience/components/steps/nodejs/WriteData.tsx
@@ -74,7 +74,7 @@ for (let i = 0; i < 5; i++) {
     <>
       <h1>Write Data</h1>
       <p>
-        To start writing data, we need a place to our time-series store data. We
+        To start writing data, we need a place to store our time-series data. We
         call these{' '}
         <SafeBlankLink
           href={`orgs/${org.id}/load-data/buckets`}

--- a/src/homepageExperience/components/steps/python/ExecuteAggregateQuery.tsx
+++ b/src/homepageExperience/components/steps/python/ExecuteAggregateQuery.tsx
@@ -59,7 +59,7 @@ for table in tables:
       />
       <p>
         In this example, we use the mean() function to calculate the average of
-        data points in last 10 minutes.
+        data points in the last 10 minutes.
         <br />
         <br />
         Run the following:

--- a/src/homepageExperience/containers/GoWizard.tsx
+++ b/src/homepageExperience/containers/GoWizard.tsx
@@ -12,7 +12,7 @@ import {
 
 import {InstallDependencies} from 'src/homepageExperience/components/steps/go/InstallDependencies'
 import {Overview} from 'src/homepageExperience/components/steps/Overview'
-import {CreateToken} from 'src/homepageExperience/components/steps/CreateToken'
+import {Tokens} from 'src/homepageExperience/components/steps/CreateToken'
 import {InitalizeClient} from 'src/homepageExperience/components/steps/go/InitalizeClient'
 import {WriteData} from 'src/homepageExperience/components/steps/go/WriteData'
 import {ExecuteQuery} from 'src/homepageExperience/components/steps/go/ExecuteQuery'
@@ -91,7 +91,7 @@ export class GoWizard extends PureComponent<null, State> {
       }
       case 3: {
         return (
-          <CreateToken
+          <Tokens
             wizardEventName="goWizard"
             setTokenValue={this.setTokenValue}
             tokenValue={this.state.tokenValue}

--- a/src/homepageExperience/containers/GoWizard.tsx
+++ b/src/homepageExperience/containers/GoWizard.tsx
@@ -12,7 +12,7 @@ import {
 
 import {InstallDependencies} from 'src/homepageExperience/components/steps/go/InstallDependencies'
 import {Overview} from 'src/homepageExperience/components/steps/Overview'
-import {Tokens} from 'src/homepageExperience/components/steps/CreateToken'
+import {Tokens} from 'src/homepageExperience/components/steps/Tokens'
 import {InitalizeClient} from 'src/homepageExperience/components/steps/go/InitalizeClient'
 import {WriteData} from 'src/homepageExperience/components/steps/go/WriteData'
 import {ExecuteQuery} from 'src/homepageExperience/components/steps/go/ExecuteQuery'

--- a/src/homepageExperience/containers/NodejsWizard.tsx
+++ b/src/homepageExperience/containers/NodejsWizard.tsx
@@ -12,7 +12,7 @@ import {
 
 import {InstallDependencies} from 'src/homepageExperience/components/steps/nodejs/InstallDependencies'
 import {Overview} from 'src/homepageExperience/components/steps/Overview'
-import {CreateToken} from 'src/homepageExperience/components/steps/CreateToken'
+import {Tokens} from 'src/homepageExperience/components/steps/CreateToken'
 import {InitalizeClient} from 'src/homepageExperience/components/steps/nodejs/InitalizeClient'
 import {WriteData} from 'src/homepageExperience/components/steps/nodejs/WriteData'
 import {ExecuteQuery} from 'src/homepageExperience/components/steps/nodejs/ExecuteQuery'
@@ -91,7 +91,7 @@ export class NodejsWizard extends PureComponent<null, State> {
       }
       case 3: {
         return (
-          <CreateToken
+          <Tokens
             wizardEventName="nodejsWizard"
             setTokenValue={this.setTokenValue}
             tokenValue={this.state.tokenValue}

--- a/src/homepageExperience/containers/NodejsWizard.tsx
+++ b/src/homepageExperience/containers/NodejsWizard.tsx
@@ -12,7 +12,7 @@ import {
 
 import {InstallDependencies} from 'src/homepageExperience/components/steps/nodejs/InstallDependencies'
 import {Overview} from 'src/homepageExperience/components/steps/Overview'
-import {Tokens} from 'src/homepageExperience/components/steps/CreateToken'
+import {Tokens} from 'src/homepageExperience/components/steps/Tokens'
 import {InitalizeClient} from 'src/homepageExperience/components/steps/nodejs/InitalizeClient'
 import {WriteData} from 'src/homepageExperience/components/steps/nodejs/WriteData'
 import {ExecuteQuery} from 'src/homepageExperience/components/steps/nodejs/ExecuteQuery'

--- a/src/homepageExperience/containers/PythonWizard.tsx
+++ b/src/homepageExperience/containers/PythonWizard.tsx
@@ -12,7 +12,7 @@ import {
 
 import {InstallDependencies} from 'src/homepageExperience/components/steps/python/InstallDependencies'
 import {Overview} from 'src/homepageExperience/components/steps/Overview'
-import {CreateToken} from 'src/homepageExperience/components/steps/CreateToken'
+import {Tokens} from 'src/homepageExperience/components/steps/CreateToken'
 import {InitalizeClient} from 'src/homepageExperience/components/steps/python/InitalizeClient'
 import {WriteData} from 'src/homepageExperience/components/steps/python/WriteData'
 import {ExecuteQuery} from 'src/homepageExperience/components/steps/python/ExecuteQuery'
@@ -91,7 +91,7 @@ export class PythonWizard extends PureComponent<null, State> {
       }
       case 3: {
         return (
-          <CreateToken
+          <Tokens
             wizardEventName="pythonWizard"
             setTokenValue={this.setTokenValue}
             tokenValue={this.state.tokenValue}

--- a/src/homepageExperience/containers/PythonWizard.tsx
+++ b/src/homepageExperience/containers/PythonWizard.tsx
@@ -12,7 +12,7 @@ import {
 
 import {InstallDependencies} from 'src/homepageExperience/components/steps/python/InstallDependencies'
 import {Overview} from 'src/homepageExperience/components/steps/Overview'
-import {Tokens} from 'src/homepageExperience/components/steps/CreateToken'
+import {Tokens} from 'src/homepageExperience/components/steps/Tokens'
 import {InitalizeClient} from 'src/homepageExperience/components/steps/python/InitalizeClient'
 import {WriteData} from 'src/homepageExperience/components/steps/python/WriteData'
 import {ExecuteQuery} from 'src/homepageExperience/components/steps/python/ExecuteQuery'

--- a/src/homepageExperience/utils.ts
+++ b/src/homepageExperience/utils.ts
@@ -10,7 +10,7 @@ export const HOMEPAGE_NAVIGATION_STEPS = [
     glyph: IconFont.Install,
   },
   {
-    name: 'Create a \n Token',
+    name: 'Tokens',
     glyph: IconFont.CopperCoin,
   },
   {


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/4483

<!-- Describe your proposed changes here. -->

- [x]     The "Create a Token" page should be changed to "Tokens" since we create the token for the user. 
- [x]      Tokens page: Edit this english "Creating an all-access tokens is not the best security practice! We recommend you to delete this token in the [Token page](https://stag-us-east-1-4.aws.cloud2.influxdata.com/orgs/8db586cb7136141c/load-data/tokens) after setting up, and creating your own token with a specific set of permissions later."
- [ ]     Initialize Client page: Edit this english "Here, we initialize the token, organization info, and server url that is needed to set up the initial connection to InfluxDB. The client connection is then established with InfluxDBClient initialization."
- [x]     Write data: fix this english: "we need a place to our time-series store data. We call these [buckets.](https://stag-us-east-1-4.aws.cloud2.influxdata.com/orgs/8db586cb7136141c/load-data/buckets)"
- [ ]     Write data: fix this english: "In this code, we define five data points and write each one for InfluxDB." ... and this one "In the above code snippet, we define five data points and write each on the InfluxDB."
- [x]     Execute a Simple Query page: Fix this english: "In this query, we are looking for data points within last 10 minutes with field key of "field1"."
- [x]     Execute an Aggregate Query page - fix this english: "In this example, we use the mean() function to calculate the average of data points in last 10 minutes."