### PR TITLE
chore(firstMile): golang wizard - add 1 second sleep between point writes

### DIFF
--- a/src/homepageExperience/components/steps/go/WriteData.tsx
+++ b/src/homepageExperience/components/steps/go/WriteData.tsx
@@ -62,6 +62,7 @@ for value := 0; value < 5; value++ {
 		"field1": value,
 	}
 	point := write.NewPoint("measurement1", tags, fields, time.Now())
+	time.Sleep(1 * time.Second) // separate points by 1 second
 
 	if err := writeAPI.WritePoint(context.Background(), point); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Closes #4489

What it says on the tin - adds one second sleep in the golang wizard so that the points being written are one second apart

