### PR TITLE
feat(ecommerce): Add Email to Update Billing Contact

### DIFF
--- a/src/billing/components/BillingContactDisplay.tsx
+++ b/src/billing/components/BillingContactDisplay.tsx
@@ -13,6 +13,9 @@ const BillingContactDisplay: FC = () => {
     <Panel.Body size={ComponentSize.Large} testID="billing-contact">
       <Grid>
         <Grid.Row>
+          <BillingContactItem header="Email Address" value={contact?.email} />
+        </Grid.Row>
+        <Grid.Row>
           <BillingContactItem header="First Name" value={contact?.firstName} />
           <BillingContactItem header="Last Name" value={contact?.lastName} />
         </Grid.Row>

--- a/src/billing/components/Checkout/BillingContactForm.tsx
+++ b/src/billing/components/Checkout/BillingContactForm.tsx
@@ -13,6 +13,8 @@ import {
   ComponentSize,
   FlexBox,
   JustifyContent,
+  InputType,
+  ButtonType,
 } from '@influxdata/clockface'
 import {useDispatch} from 'react-redux'
 
@@ -43,6 +45,7 @@ const BillingContactForm: FC<Props> = ({toggleEditingOff}) => {
   const dispatch = useDispatch()
 
   const [inputs, setInputs] = useState({
+    email: contact.email,
     firstName: contact.firstName,
     lastName: contact.lastName,
     companyName: contact.companyName,
@@ -65,6 +68,7 @@ const BillingContactForm: FC<Props> = ({toggleEditingOff}) => {
   const requiredErrorText = 'This is a required field'
 
   const requiredFields = [
+    'email',
     'firstName',
     'lastName',
     'city',
@@ -116,6 +120,7 @@ const BillingContactForm: FC<Props> = ({toggleEditingOff}) => {
 
   const handleConfirmContactInfo = async () => {
     const contact = {
+      email: inputs.email,
       firstName: inputs.firstName,
       lastName: inputs.lastName,
       companyName: inputs.companyName,
@@ -140,144 +145,158 @@ const BillingContactForm: FC<Props> = ({toggleEditingOff}) => {
   }
 
   return (
-    <>
+    <Form onSubmit={handleConfirmContactInfo}>
       <Panel.Body size={ComponentSize.Large}>
-        <Form>
-          <Grid>
-            <Grid.Row>
-              <Grid.Column widthXS={Columns.Twelve} widthSM={Columns.Four}>
-                <Form.Element
-                  label="First Name"
-                  required={true}
-                  errorMessage={errorType === 'firstName' && requiredErrorText}
-                >
-                  <Input
-                    autoFocus={true}
-                    onChange={handleInputChange}
-                    name="firstName"
-                    titleText="First Name"
-                    value={inputs.firstName}
-                    testID="form-input--firstname"
-                  />
-                </Form.Element>
-              </Grid.Column>
-              <Grid.Column widthXS={Columns.Twelve} widthSM={Columns.Four}>
-                <Form.Element
-                  label="Last Name"
-                  required={true}
-                  errorMessage={errorType === 'lastName' && requiredErrorText}
-                >
-                  <Input
-                    onChange={handleInputChange}
-                    name="lastName"
-                    titleText="Last Name"
-                    value={inputs.lastName}
-                    testID="form-input--lastname"
-                  />
-                </Form.Element>
-              </Grid.Column>
-            </Grid.Row>
-            <Grid.Row>
-              <Grid.Column widthXS={Columns.Twelve} widthSM={Columns.Four}>
-                <Form.Element
-                  label="Company Name"
-                  required={true}
-                  errorMessage={
-                    errorType === 'companyName' && requiredErrorText
-                  }
-                >
-                  <Input
-                    onChange={handleInputChange}
-                    name="companyName"
-                    titleText="Company Name"
-                    value={inputs.companyName}
-                  />
-                </Form.Element>
-              </Grid.Column>
-              <Grid.Column widthXS={Columns.Twelve} widthSM={Columns.Four}>
-                <Form.Element
-                  label="Country"
-                  required={true}
-                  errorMessage={countryError && requiredErrorText}
-                >
-                  <SelectDropdown
-                    options={countries}
-                    selectedOption={country}
-                    onSelect={handleChangeCountry}
-                    buttonColor={ComponentColor.Default}
-                  />
-                </Form.Element>
-              </Grid.Column>
-            </Grid.Row>
-            <Grid.Row>
-              <Grid.Column widthXS={Columns.Twelve} widthSM={Columns.Four}>
-                <Form.Element label="Address Street 1">
-                  <Input
-                    onChange={handleInputChange}
-                    name="street1"
-                    titleText="Address Street 1"
-                    value={inputs.street1}
-                  />
-                </Form.Element>
-              </Grid.Column>
-              <Grid.Column widthXS={Columns.Twelve} widthSM={Columns.Four}>
-                <Form.Element label="Address Street 2">
-                  <Input
-                    onChange={handleInputChange}
-                    name="street2"
-                    titleText="Address Street 2"
-                    value={inputs.street2}
-                  />
-                </Form.Element>
-              </Grid.Column>
-            </Grid.Row>
-            <Grid.Row>
-              <Grid.Column widthXS={Columns.Twelve} widthSM={Columns.Four}>
-                <Form.Element
-                  label="City"
-                  required={true}
-                  errorMessage={errorType === 'city' && requiredErrorText}
-                >
-                  <Input
-                    onChange={handleInputChange}
-                    name="city"
-                    titleText="City"
-                    value={inputs.city}
-                  />
-                </Form.Element>
-              </Grid.Column>
-              <Grid.Column widthXS={Columns.Twelve} widthSM={Columns.Four}>
-                <BillingContactSubdivision
-                  states={states}
-                  country={country}
-                  subdivision={subdivision}
-                  errorMessage={subdivisionError && requiredErrorText}
-                  onChange={handleChangeSubdivision}
+        <Grid>
+          <Grid.Row>
+            <Grid.Column widthXS={Columns.Twelve} widthSM={Columns.Eight}>
+              <Form.Element
+                label="Email Address"
+                required={true}
+                errorMessage={errorType === 'email' && requiredErrorText}
+              >
+                <Input
+                  autoFocus={true}
+                  onChange={handleInputChange}
+                  name="email"
+                  titleText="Email Address"
+                  value={inputs.email}
+                  type={InputType.Email}
+                  testID="form-input--email"
                 />
-              </Grid.Column>
-              <Grid.Column widthXS={Columns.Twelve} widthSM={Columns.Four}>
-                <Form.Element
-                  label="Postal Code"
-                  required={true}
-                  errorMessage={errorType === 'postalCode' && requiredErrorText}
-                >
-                  <Input
-                    onChange={handleInputChange}
-                    name="postalCode"
-                    titleText="Postal Code"
-                    value={inputs.postalCode}
-                  />
-                </Form.Element>
-              </Grid.Column>
-            </Grid.Row>
-          </Grid>
-        </Form>
+              </Form.Element>
+            </Grid.Column>
+          </Grid.Row>
+          <Grid.Row>
+            <Grid.Column widthXS={Columns.Twelve} widthSM={Columns.Four}>
+              <Form.Element
+                label="First Name"
+                required={true}
+                errorMessage={errorType === 'firstName' && requiredErrorText}
+              >
+                <Input
+                  onChange={handleInputChange}
+                  name="firstName"
+                  titleText="First Name"
+                  value={inputs.firstName}
+                  testID="form-input--firstname"
+                />
+              </Form.Element>
+            </Grid.Column>
+            <Grid.Column widthXS={Columns.Twelve} widthSM={Columns.Four}>
+              <Form.Element
+                label="Last Name"
+                required={true}
+                errorMessage={errorType === 'lastName' && requiredErrorText}
+              >
+                <Input
+                  onChange={handleInputChange}
+                  name="lastName"
+                  titleText="Last Name"
+                  value={inputs.lastName}
+                  testID="form-input--lastname"
+                />
+              </Form.Element>
+            </Grid.Column>
+          </Grid.Row>
+          <Grid.Row>
+            <Grid.Column widthXS={Columns.Twelve} widthSM={Columns.Four}>
+              <Form.Element
+                label="Company Name"
+                required={true}
+                errorMessage={errorType === 'companyName' && requiredErrorText}
+              >
+                <Input
+                  onChange={handleInputChange}
+                  name="companyName"
+                  titleText="Company Name"
+                  value={inputs.companyName}
+                />
+              </Form.Element>
+            </Grid.Column>
+            <Grid.Column widthXS={Columns.Twelve} widthSM={Columns.Four}>
+              <Form.Element
+                label="Country"
+                required={true}
+                errorMessage={countryError && requiredErrorText}
+              >
+                <SelectDropdown
+                  options={countries}
+                  selectedOption={country}
+                  onSelect={handleChangeCountry}
+                  buttonColor={ComponentColor.Default}
+                />
+              </Form.Element>
+            </Grid.Column>
+          </Grid.Row>
+          <Grid.Row>
+            <Grid.Column widthXS={Columns.Twelve} widthSM={Columns.Four}>
+              <Form.Element label="Address Street 1">
+                <Input
+                  onChange={handleInputChange}
+                  name="street1"
+                  titleText="Address Street 1"
+                  value={inputs.street1}
+                />
+              </Form.Element>
+            </Grid.Column>
+            <Grid.Column widthXS={Columns.Twelve} widthSM={Columns.Four}>
+              <Form.Element label="Address Street 2">
+                <Input
+                  onChange={handleInputChange}
+                  name="street2"
+                  titleText="Address Street 2"
+                  value={inputs.street2}
+                />
+              </Form.Element>
+            </Grid.Column>
+          </Grid.Row>
+          <Grid.Row>
+            <Grid.Column widthXS={Columns.Twelve} widthSM={Columns.Four}>
+              <Form.Element
+                label="City"
+                required={true}
+                errorMessage={errorType === 'city' && requiredErrorText}
+              >
+                <Input
+                  onChange={handleInputChange}
+                  name="city"
+                  titleText="City"
+                  value={inputs.city}
+                />
+              </Form.Element>
+            </Grid.Column>
+            <Grid.Column widthXS={Columns.Twelve} widthSM={Columns.Four}>
+              <BillingContactSubdivision
+                states={states}
+                country={country}
+                subdivision={subdivision}
+                errorMessage={subdivisionError && requiredErrorText}
+                onChange={handleChangeSubdivision}
+              />
+            </Grid.Column>
+            <Grid.Column widthXS={Columns.Twelve} widthSM={Columns.Four}>
+              <Form.Element
+                label="Postal Code"
+                required={true}
+                errorMessage={errorType === 'postalCode' && requiredErrorText}
+              >
+                <Input
+                  onChange={handleInputChange}
+                  name="postalCode"
+                  titleText="Postal Code"
+                  value={inputs.postalCode}
+                />
+              </Form.Element>
+            </Grid.Column>
+          </Grid.Row>
+        </Grid>
       </Panel.Body>
       <Panel.Footer>
         <FlexBox justifyContent={JustifyContent.Center}>
           <Button
             text="Save Contact Info"
-            onClick={handleConfirmContactInfo}
+            type={ButtonType.Submit}
             color={ComponentColor.Primary}
             size={ComponentSize.Large}
             status={
@@ -289,7 +308,7 @@ const BillingContactForm: FC<Props> = ({toggleEditingOff}) => {
           />
         </FlexBox>
       </Panel.Footer>
-    </>
+    </Form>
   )
 }
 


### PR DESCRIPTION
### Description 

Currently, Quartz updated the billing contact's email address to the current user's email every time there is a change to the billing information. The Quartz API will be updated to receive an Email Address an a parameter in the `handleConfirmContactInfo` request.

**NOTE:** It looks like there were a lot of changes to this, but the main change is that I added the field for email. Additionally, I raised the `<Form>` element higher in the dom so that it would contain the submit `<Button>`. I did this so that we could have email validation for the new `type={InputType.Email}` `<FormInput>`.


### Screenshots

Image of the contact information display:
<img width="864" alt="image" src="https://user-images.githubusercontent.com/31899323/165381938-d89cfa9e-59bd-43a5-8045-5caea28cb213.png">

Image of the contact information update
<img width="1029" alt="image" src="https://user-images.githubusercontent.com/31899323/165381986-23401793-db05-4484-bd52-e36470dd86cc.png">
