### PR TITLE
chore: cancel all in-flight queries when switching versions

### DIFF
--- a/src/flows/components/VersionSidebar.tsx
+++ b/src/flows/components/VersionSidebar.tsx
@@ -53,6 +53,8 @@ const VersionSidebarListItem: FC<Props> = ({version}) => {
 
   const handleClick = () => {
     cancel()
+
+    event('click version history')
     history.push(
       `/orgs/${orgID}/${PROJECT_NAME_PLURAL.toLowerCase()}/${
         flow.id
@@ -169,8 +171,11 @@ export const VersionSidebar: FC = () => {
   const {flow} = useContext(FlowContext)
   const history = useHistory()
   const {id: orgID} = useSelector(getOrg)
+  const {cancel} = useContext(QueryContext)
 
   const handleClose = () => {
+    cancel()
+
     event('close version history')
     history.push(
       `/orgs/${orgID}/${PROJECT_NAME_PLURAL.toLowerCase()}/${flow.id}`

--- a/src/flows/components/VersionSidebar.tsx
+++ b/src/flows/components/VersionSidebar.tsx
@@ -37,6 +37,7 @@ import {serialize} from 'src/flows/context/flow.list'
 // Constants
 import './Sidebar.scss'
 import {PROJECT_NAME, PROJECT_NAME_PLURAL} from 'src/flows'
+import {QueryContext} from 'src/shared/contexts/query'
 
 interface Props {
   version: VersionHistory
@@ -48,8 +49,10 @@ const VersionSidebarListItem: FC<Props> = ({version}) => {
   const {id} = useParams<{id: string}>()
   const {flow} = useContext(FlowContext)
   const {id: orgID} = useSelector(getOrg)
+  const {cancel} = useContext(QueryContext)
 
   const handleClick = () => {
+    cancel()
     history.push(
       `/orgs/${orgID}/${PROJECT_NAME_PLURAL.toLowerCase()}/${
         flow.id


### PR DESCRIPTION
Cancel all in-flight queries when switching notebooks versions

**My Query Time**
![Query](https://user-images.githubusercontent.com/1637395/165553336-03d2833e-3e78-490b-9bc5-601afcdf08b8.gif)

**Working Query Cancellation**
![AFTER](https://user-images.githubusercontent.com/1637395/165553406-949ee9a5-a277-487f-97ed-a45aa0399ba2.gif)

