### PR TITLE
fix(firstMile): data listening component clear old interval id's when bucket changed

### DIFF
--- a/src/homepageExperience/components/DataListening.tsx
+++ b/src/homepageExperience/components/DataListening.tsx
@@ -120,7 +120,11 @@ class DataListening extends PureComponent<Props, State> {
     } = this.props
 
     this.setState({loading: LoadingState.Loading})
-    this.intervalID = continuouslyCheckForData(orgID, bucket, this.updateResponse)
+    this.intervalID = continuouslyCheckForData(
+      orgID,
+      bucket,
+      this.updateResponse
+    )
   }
 }
 

--- a/src/homepageExperience/components/DataListening.tsx
+++ b/src/homepageExperience/components/DataListening.tsx
@@ -120,7 +120,7 @@ class DataListening extends PureComponent<Props, State> {
     } = this.props
 
     this.setState({loading: LoadingState.Loading})
-    continuouslyCheckForData(orgID, bucket, this.updateResponse)
+    this.intervalID = continuouslyCheckForData(orgID, bucket, this.updateResponse)
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/4491

When we changed bucket, i.e. component was updated, we didn't clear out the old timer that was running, this was causing the component to send extra queries even after data was found in the bucket. 

After fix: 

https://user-images.githubusercontent.com/18511823/165746914-6ea647a6-1e01-4c52-8282-1ee04e6398aa.mov




<!-- Describe your proposed changes here. -->
