### PR TITLE
chore(firstMile): point nodejs homepage card to library page, not wizard

### DIFF
--- a/src/homepageExperience/containers/HomepageContainer.tsx
+++ b/src/homepageExperience/containers/HomepageContainer.tsx
@@ -43,9 +43,13 @@ export const HomepageContainer: FC = () => {
   const pythonWizardLink = `/orgs/${org.id}/new-user-wizard/python`
   const cliPageLink = `/orgs/${org.id}/load-data/file-upload/csv`
   const telegrafPageLink = `/orgs/${org.id}/load-data/telegrafs`
-  const javaScriptNodeLink = `/orgs/${org.id}/new-user-wizard/nodejs`
   const golangLink = `/orgs/${org.id}/new-user-wizard/go`
   const loadDataSourcesLink = `/orgs/${org.id}/load-data/sources`
+  let javaScriptNodeLink = `/orgs/${org.id}/new-user-wizard/nodejs`
+
+  // currently the nodejs library has an intermittent issue writing to buckets
+  // go to the current node library until we fix that bug
+  javaScriptNodeLink = `/orgs/${org.id}/load-data/client-libraries/javascript-node`
 
   const cardStyle = {minWidth: '200px'}
   const linkStyle = {color: InfluxColors.Grey75}


### PR DESCRIPTION
To keep us from holding up the prod release while we diagnose what's causing the issue of writing to buckets from the nodejs client library