### PR TITLE
fix: subscriptions json bugs/ clean up

### DIFF
--- a/src/writeData/subscriptions/components/BrokerFormContent.tsx
+++ b/src/writeData/subscriptions/components/BrokerFormContent.tsx
@@ -58,11 +58,11 @@ const BrokerFormContent: FC<Props> = ({
       <Grid.Row>
         <Grid.Column widthSM={Columns.Twelve}>
           <Form.ValidationElement
-            label="Connection Name"
+            label="Subscription Name"
             value={formContent.name}
             required={true}
             validationFunc={() =>
-              handleValidation('Connection Name', formContent.name)
+              handleValidation('Subscription Name', formContent.name)
             }
             prevalidate={false}
           >

--- a/src/writeData/subscriptions/components/JsonParsingForm.tsx
+++ b/src/writeData/subscriptions/components/JsonParsingForm.tsx
@@ -78,9 +78,7 @@ const JsonParsingForm: FC<Props> = ({formContent, updateForm, edit}) => {
           name="timestamp"
           autoFocus={true}
           value={
-            formContent.jsonTimestamp && formContent.jsonTimestamp.path
-              ? formContent.jsonTimestamp.path
-              : ''
+            formContent.jsonTimestamp.path
           }
           onChange={e => {
             formContent.jsonTimestamp.path = e.target.value

--- a/src/writeData/subscriptions/components/JsonParsingForm.tsx
+++ b/src/writeData/subscriptions/components/JsonParsingForm.tsx
@@ -77,9 +77,7 @@ const JsonParsingForm: FC<Props> = ({formContent, updateForm, edit}) => {
           placeholder="eg. $.myJSON.myObject[0].timestampKey"
           name="timestamp"
           autoFocus={true}
-          value={
-            formContent.jsonTimestamp.path
-          }
+          value={formContent.jsonTimestamp.path}
           onChange={e => {
             formContent.jsonTimestamp.path = e.target.value
             updateForm({...formContent})

--- a/src/writeData/subscriptions/components/StringParsingForm.tsx
+++ b/src/writeData/subscriptions/components/StringParsingForm.tsx
@@ -69,11 +69,7 @@ const StringParsingForm: FC<Props> = ({formContent, updateForm, edit}) => {
           placeholder="eg. regexExample"
           name="timestamp"
           autoFocus={true}
-          value={
-            formContent.stringTimestamp
-              ? formContent.stringTimestamp.pattern
-              : ''
-          }
+          value={formContent.stringTimestamp.pattern}
           onChange={e => {
             formContent.stringTimestamp.pattern = e.target.value
             updateForm({...formContent})

--- a/src/writeData/subscriptions/components/SubscriptionDetailsPage.scss
+++ b/src/writeData/subscriptions/components/SubscriptionDetailsPage.scss
@@ -61,7 +61,7 @@
       color: #34bb55;
       margin-left: 10px;
     }
-    &--INVALID {
+    &--ERRORED {
       color: #e85b1c;
       margin-left: 10px;
     }

--- a/src/writeData/subscriptions/context/subscription.create.tsx
+++ b/src/writeData/subscriptions/context/subscription.create.tsx
@@ -39,6 +39,7 @@ export const DEFAULT_CONTEXT: SubscriptionCreateContextType = {
     topic: '',
     dataFormat: 'lineprotocol',
     jsonMeasurementKey: {
+      name: 'measurement',
       path: '',
       type: 'string',
     },

--- a/src/writeData/subscriptions/utils/form.ts
+++ b/src/writeData/subscriptions/utils/form.ts
@@ -60,10 +60,6 @@ export const sanitizeForm = (form: Subscription): Subscription => {
       form.jsonTimestamp.path = newVal
     }
   }
-
-  if (form.jsonTimestamp?.path === '') {
-    delete form.jsonTimestamp
-  }
   if (form.stringMeasurement) {
     form.stringMeasurement.pattern =
       form.stringMeasurement?.pattern.replace(/\\\\/g, '\\') ?? ''
@@ -78,9 +74,6 @@ export const sanitizeForm = (form: Subscription): Subscription => {
       t.pattern = t.pattern?.replace(/\\\\/g, '\\') ?? ''
     })
   }
-  if (form.stringTimestamp?.pattern === '') {
-    delete form.stringTimestamp
-  }
   if (form.brokerPassword === '' || form.brokerUsername === '') {
     delete form.brokerUsername
     delete form.brokerPassword
@@ -89,24 +82,46 @@ export const sanitizeForm = (form: Subscription): Subscription => {
 }
 
 export const sanitizeUpdateForm = (form: Subscription): Subscription => {
-  if (form.jsonMeasurementKey) {
+  if (form.jsonMeasurementKey.path) {
+    const startChar = form.jsonMeasurementKey?.path.charAt(0) ?? ''
+    const newVal = checkJSONPathStarts$(startChar, form.jsonMeasurementKey.path)
+    if (newVal) {
+      form.jsonMeasurementKey.path = newVal
+    }
     if (form.jsonMeasurementKey.type === 'number') {
       form.jsonMeasurementKey.type = 'double'
     }
   }
+  if (form.jsonFieldKeys) {
+    form.jsonFieldKeys.map(f => {
+      const startChar = f.path?.charAt(0) ?? ''
+      const newVal = checkJSONPathStarts$(startChar, f.path)
+      if (newVal) {
+        f.path = newVal
+      }
+      if (f.type === 'number') {
+        f.type = 'double'
+      }
+    })
+  }
   if (form.jsonTagKeys) {
     form.jsonTagKeys.map(t => {
+      const startChar = t.path?.charAt(0) ?? ''
+      const newVal = checkJSONPathStarts$(startChar, t.path)
+      if (newVal) {
+        t.path = newVal
+      }
       if (t.type === 'number') {
         t.type = 'double'
       }
     })
   }
-  if (form.jsonFieldKeys) {
-    form.jsonFieldKeys.map(f => {
-      if (f.type === 'number') {
-        f.type = 'double'
-      }
-    })
+  if (form.jsonTimestamp?.path) {
+    const startChar = form.jsonTimestamp.path.charAt(0)
+    const newVal = checkJSONPathStarts$(startChar, form.jsonTimestamp.path)
+    if (newVal) {
+      form.jsonTimestamp.path = newVal
+    }
   }
   delete form.id
   delete form.orgID


### PR DESCRIPTION
Closes https://github.com/influxdata/data-acquisition/issues/281
Helps with https://github.com/influxdata/data-acquisition/issues/269

- Copy change
- Makes timestamps editable
- Error state text fix
- Move handling of timestamps into nifid
- Makes sure if you edit json inputs they are sanitized with prepended $. 
