### PR TITLE
fix: update statuses after promise resolves 

### DIFF
--- a/src/checks/components/CheckHistoryVisualization.tsx
+++ b/src/checks/components/CheckHistoryVisualization.tsx
@@ -23,11 +23,14 @@ const CheckHistoryVisualization: FC = () => {
   }
 
   return (
-    <TimeSeries submitToken={0} queries={[query]} key={0} check={{id: id}} updateStatuses={updateStatuses}>
-      {({giraffeResult, loading, errorMessage, isInitialFetch, statuses}) => {
-        
-            // updateStatuses(statuses) // here is the problem
-      
+    <TimeSeries
+      submitToken={0}
+      queries={[query]}
+      key={0}
+      check={{id: id}}
+      updateStatuses={updateStatuses}
+    >
+      {({giraffeResult, loading, errorMessage, isInitialFetch}) => {
         // handle edge case where deadman check has non-numeric value
         if (
           giraffeResult &&

--- a/src/checks/components/CheckHistoryVisualization.tsx
+++ b/src/checks/components/CheckHistoryVisualization.tsx
@@ -23,10 +23,11 @@ const CheckHistoryVisualization: FC = () => {
   }
 
   return (
-    <TimeSeries submitToken={0} queries={[query]} key={0} check={{id: id}}>
+    <TimeSeries submitToken={0} queries={[query]} key={0} check={{id: id}} updateStatuses={updateStatuses}>
       {({giraffeResult, loading, errorMessage, isInitialFetch, statuses}) => {
-        updateStatuses(statuses)
-
+        
+            // updateStatuses(statuses) // here is the problem
+      
         // handle edge case where deadman check has non-numeric value
         if (
           giraffeResult &&

--- a/src/shared/components/TimeSeries.tsx
+++ b/src/shared/components/TimeSeries.tsx
@@ -158,7 +158,7 @@ class TimeSeries extends Component<Props, State> {
       this.pendingReload = true
     }
 
-    if(this.props.updateStatuses) {
+    if (this.props.updateStatuses) {
       this.props.updateStatuses(this.state.statuses)
     }
   }

--- a/src/shared/components/TimeSeries.tsx
+++ b/src/shared/components/TimeSeries.tsx
@@ -117,7 +117,6 @@ class TimeSeries extends Component<Props, State> {
   private pendingCheckStatuses: CancelBox<StatusRow[][]> = null
   public componentDidMount() {
     const {cellID, setCellMount} = this.props
-    
 
     this.observer = new IntersectionObserver(entries => {
       entries.forEach(entry => {
@@ -158,15 +157,10 @@ class TimeSeries extends Component<Props, State> {
     if (shouldReloadWhenVisible) {
       this.pendingReload = true
     }
-    
-  // when the statuses state has changed, I want to call updateStatuses prop to update the state in checkContext
-  // everytime the DOM updates (this.reload), the statuses state gets updated, so then we want to call setState to in turn 
-  // update it in check context
-  //https://stackoverflow.com/questions/38759703/when-to-use-componentdidupdate-method
-    if(this.state.statuses !== prevState.statuses) {
+
+    if (this.state.statuses !== prevState.statuses) {
       this.props.updateStatuses(this.state.statuses)
     }
-
   }
 
   public componentWillUnmount() {
@@ -281,9 +275,7 @@ class TimeSeries extends Component<Props, State> {
           check.id,
           extern
         )
-        // console.log('statuses before promise ', statuses)
         statuses = await this.pendingCheckStatuses.promise // TODO handle errors
-        // console.log('statuses after promise ', statuses)
       }
 
       const duration = Date.now() - startTime

--- a/src/shared/components/TimeSeries.tsx
+++ b/src/shared/components/TimeSeries.tsx
@@ -67,6 +67,7 @@ interface OwnProps {
   implicitSubmit?: boolean
   children: (r: QueriesState) => JSX.Element
   check?: Partial<Check>
+  updateStatuses?: (statuses: StatusRow[][]) => void
 }
 
 type ReduxProps = ConnectedProps<typeof connector>
@@ -114,9 +115,10 @@ class TimeSeries extends Component<Props, State> {
 
   private pendingResults: Array<CancelBox<RunQueryResult>> = []
   private pendingCheckStatuses: CancelBox<StatusRow[][]> = null
-
   public componentDidMount() {
     const {cellID, setCellMount} = this.props
+    
+
     this.observer = new IntersectionObserver(entries => {
       entries.forEach(entry => {
         const {isIntersecting} = entry
@@ -138,7 +140,7 @@ class TimeSeries extends Component<Props, State> {
     this.observer.observe(this.ref.current)
   }
 
-  public componentDidUpdate(prevProps: Props) {
+  public componentDidUpdate(prevProps: Props, prevState: State) {
     const {setCellMount, cellID} = this.props
     const prevPropsIndicateReload = this.shouldReload(prevProps)
     const shouldReloadNow = prevPropsIndicateReload && this.isIntersecting
@@ -156,6 +158,15 @@ class TimeSeries extends Component<Props, State> {
     if (shouldReloadWhenVisible) {
       this.pendingReload = true
     }
+    
+  // when the statuses state has changed, I want to call updateStatuses prop to update the state in checkContext
+  // everytime the DOM updates (this.reload), the statuses state gets updated, so then we want to call setState to in turn 
+  // update it in check context
+  //https://stackoverflow.com/questions/38759703/when-to-use-componentdidupdate-method
+    if(this.state.statuses !== prevState.statuses) {
+      this.props.updateStatuses(this.state.statuses)
+    }
+
   }
 
   public componentWillUnmount() {
@@ -270,7 +281,9 @@ class TimeSeries extends Component<Props, State> {
           check.id,
           extern
         )
+        // console.log('statuses before promise ', statuses)
         statuses = await this.pendingCheckStatuses.promise // TODO handle errors
+        // console.log('statuses after promise ', statuses)
       }
 
       const duration = Date.now() - startTime
@@ -297,7 +310,6 @@ class TimeSeries extends Component<Props, State> {
       const giraffeResult = fromFlux(files.join('\n\n'))
 
       this.pendingReload = false
-
       // this check prevents a memory leak https://github.com/influxdata/ui/issues/2137
       if (!this.isUnmounting) {
         this.setState({

--- a/src/shared/components/TimeSeries.tsx
+++ b/src/shared/components/TimeSeries.tsx
@@ -139,7 +139,7 @@ class TimeSeries extends Component<Props, State> {
     this.observer.observe(this.ref.current)
   }
 
-  public componentDidUpdate(prevProps: Props, prevState: State) {
+  public componentDidUpdate(prevProps: Props) {
     const {setCellMount, cellID} = this.props
     const prevPropsIndicateReload = this.shouldReload(prevProps)
     const shouldReloadNow = prevPropsIndicateReload && this.isIntersecting
@@ -158,7 +158,7 @@ class TimeSeries extends Component<Props, State> {
       this.pendingReload = true
     }
 
-    if (this.state.statuses !== prevState.statuses) {
+    if(this.props.updateStatuses) {
       this.props.updateStatuses(this.state.statuses)
     }
   }


### PR DESCRIPTION
Closes #4517 

Inside `CheckHistoryVisualization` component, we are attempting to update a state  (statuses) before the component `CheckProvider` mounts. I believe this is what’s causing the bad state error in the console. I don’t understand the reason behind the need to update statuses inside `CheckHistoryVisualization`, when it can be updated in the parent component (TimeSeries). 

In my pr, I passed setState `updateStatuses` as a prop to `TimeSeries`. Once this line `statuses = await this.pendingCheckStatuses.promise` is resolved, inside componentDidUpdate(), we can set the state to the new value. 
