### PR TITLE
fix(firstMile): makes the nodejs examples write ints instead of floats

### DIFF
--- a/src/homepageExperience/components/steps/nodejs/WriteData.tsx
+++ b/src/homepageExperience/components/steps/nodejs/WriteData.tsx
@@ -57,7 +57,7 @@ let writeClient = client.getWriteApi(org, bucket, 'ns')
 for (let i = 0; i < 5; i++) {
   let point = new Point('measurement1')
     .tag('tagname1', 'tagvalue1')
-    .floatField('field1', i)
+    .intField('field1', i)
 
   void setTimeout(() => {
     writeClient.writePoint(point)

--- a/src/homepageExperience/containers/HomepageContainer.tsx
+++ b/src/homepageExperience/containers/HomepageContainer.tsx
@@ -45,11 +45,7 @@ export const HomepageContainer: FC = () => {
   const telegrafPageLink = `/orgs/${org.id}/load-data/telegrafs`
   const golangLink = `/orgs/${org.id}/new-user-wizard/go`
   const loadDataSourcesLink = `/orgs/${org.id}/load-data/sources`
-  let javaScriptNodeLink = `/orgs/${org.id}/new-user-wizard/nodejs`
-
-  // currently the nodejs library has an intermittent issue writing to buckets
-  // go to the current node library until we fix that bug
-  javaScriptNodeLink = `/orgs/${org.id}/load-data/client-libraries/javascript-node`
+  const javaScriptNodeLink = `/orgs/${org.id}/new-user-wizard/nodejs`
 
   const cardStyle = {minWidth: '200px'}
   const linkStyle = {color: InfluxColors.Grey75}


### PR DESCRIPTION
Closes #4485

When writing to a measurement with an existing name, the types have to match. The Python and Go libraries both wrote integers, but I copied an example for nodejs that wrote floats. Since all the examples write to `measurement1`, python and go worked, but nodejs would fail. Changing the write example for nodejs to create an `intField` instead of `floatField` allowed me to write to a bucket that would previously fail.

I tested this with a new bucket and all the wizards. They all wrote to it correctly.
