### PR TITLE
fix(bug): use path property to import nested package

### DIFF
--- a/src/flows/pipes/RawFluxEditor/view.tsx
+++ b/src/flows/pipes/RawFluxEditor/view.tsx
@@ -82,12 +82,12 @@ const Query: FC<PipeProp> = ({Context}) => {
         text = `  |> ${fn.example}`
       }
 
-      const getHeader = (fn) => {
-        let importStatement 
+      const getHeader = fn => {
+        let importStatement
 
         if (fn.package) {
           importStatement = `import "${fn.package}"`
-          if(isFlagEnabled('fluxDynamicDocs') && fn.path.includes('/')) {
+          if (isFlagEnabled('fluxDynamicDocs') && fn.path.includes('/')) {
             importStatement = `import "${fn.path}"`
           }
           return importStatement
@@ -98,7 +98,7 @@ const Query: FC<PipeProp> = ({Context}) => {
       const options = {
         text,
         type: InjectionType.OnOwnLine,
-        header: getHeader(fn)
+        header: getHeader(fn),
       }
       inject(options)
     },

--- a/src/flows/pipes/RawFluxEditor/view.tsx
+++ b/src/flows/pipes/RawFluxEditor/view.tsx
@@ -82,10 +82,23 @@ const Query: FC<PipeProp> = ({Context}) => {
         text = `  |> ${fn.example}`
       }
 
+      const getHeader = (fn) => {
+        let importStatement 
+
+        if (fn.package) {
+          importStatement = `import "${fn.package}"`
+          if(isFlagEnabled('fluxDynamicDocs') && fn.path.includes('/')) {
+            importStatement = `import "${fn.path}"`
+          }
+          return importStatement
+        }
+        return null
+      }
+
       const options = {
         text,
         type: InjectionType.OnOwnLine,
-        header: !!fn.package ? `import "${fn.package}"` : null,
+        header: getHeader(fn)
       }
       inject(options)
     },

--- a/src/flows/pipes/RawFluxEditor/view.tsx
+++ b/src/flows/pipes/RawFluxEditor/view.tsx
@@ -83,16 +83,15 @@ const Query: FC<PipeProp> = ({Context}) => {
       }
 
       const getHeader = fn => {
-        let importStatement
+        let importStatement = null
 
         if (fn.package) {
           importStatement = `import "${fn.package}"`
           if (isFlagEnabled('fluxDynamicDocs') && fn.path.includes('/')) {
             importStatement = `import "${fn.path}"`
           }
-          return importStatement
         }
-        return null
+        return importStatement
       }
 
       const options = {

--- a/src/timeMachine/components/TimeMachineFluxEditor.tsx
+++ b/src/timeMachine/components/TimeMachineFluxEditor.tsx
@@ -143,7 +143,8 @@ const TimeMachineFluxEditor: FC = () => {
     ]
     const importStatement = generateImport(
       func.package,
-      editorInstance.getValue()
+      editorInstance.getValue(),
+      func as FluxFunction
     )
     if (importStatement) {
       edits.unshift({

--- a/src/timeMachine/utils/insertFunction.ts
+++ b/src/timeMachine/utils/insertFunction.ts
@@ -1,5 +1,12 @@
 // Constants
+import {CLOUD} from 'src/shared/constants'
 import {FROM, UNION} from 'src/shared/constants/fluxFunctions'
+
+// Types
+import {FluxFunction} from 'src/types/shared'
+
+// Utils
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 export const functionRequiresNewLine = (funcName: string): boolean => {
   switch (funcName) {
@@ -14,9 +21,19 @@ export const functionRequiresNewLine = (funcName: string): boolean => {
 
 export const generateImport = (
   funcPackage: string,
-  script: string
-): false | string => {
-  const importStatement = `import "${funcPackage}"`
+  script: string,
+  func?: FluxFunction
+): false | string | FluxFunction => {
+  let importStatement
+
+  importStatement = `import "${funcPackage}"`
+
+  if(CLOUD && isFlagEnabled('fluxDynamicDocs')) {
+    // if package is nested, use func.path to import.
+    if(func.path.includes('/')) {
+      importStatement = `import "${func.path}"`
+    }
+  }
 
   if (!funcPackage || script.includes(importStatement)) {
     return false

--- a/src/timeMachine/utils/insertFunction.ts
+++ b/src/timeMachine/utils/insertFunction.ts
@@ -28,9 +28,9 @@ export const generateImport = (
 
   importStatement = `import "${funcPackage}"`
 
-  if(CLOUD && isFlagEnabled('fluxDynamicDocs')) {
+  if (CLOUD && isFlagEnabled('fluxDynamicDocs')) {
     // if package is nested, use func.path to import.
-    if(func.path.includes('/')) {
+    if (func.path.includes('/')) {
       importStatement = `import "${func.path}"`
     }
   }


### PR DESCRIPTION
Closes #4525 

For nested flux packages, the import statement needs to use the path property instead of func.package. One way to check if a package is nested is by checking out the path property. If path contains `/` sign, it means it's nested. If so, pr re-assigns the importStatement variable to use the path value instead of package. 

Before fix: 

https://user-images.githubusercontent.com/66275100/165997033-8ccc5ca6-95ba-4f85-b282-6ea649d4e4fa.mov

After fix: 

https://user-images.githubusercontent.com/66275100/165997250-0f9a5b66-b098-4c92-8ee3-890002ff0797.mov


