### PR TITLE
fix: Update LoginPage.tsx to include kubo logo.

### DIFF
--- a/src/onboarding/components/LogoWithCubo.scss
+++ b/src/onboarding/components/LogoWithCubo.scss
@@ -1,0 +1,15 @@
+.logo-with-cubo {
+  display: flex;
+
+  > .cubo-logo {
+    font-size: $cf-text-base-4;
+    padding-right: $cf-space-2xs;
+    color: #fff;
+    line-height: 1.5;
+  }
+  > .influx-cloud-logo {
+    width: 150px;
+    height: 50px;
+    display: flex;
+  }
+}

--- a/src/onboarding/components/LogoWithCubo.tsx
+++ b/src/onboarding/components/LogoWithCubo.tsx
@@ -1,0 +1,20 @@
+import {
+  Icon,
+  IconFont,
+  InfluxColors,
+  InfluxDBCloudLogo,
+} from '@influxdata/clockface'
+import React, {FC} from 'react'
+
+const LogoWithCubo: FC = () => (
+  <div className="logo-with-cubo">
+    <Icon glyph={IconFont.CuboSolid} className="cubo-logo" />
+    <InfluxDBCloudLogo
+      fill={InfluxColors.White}
+      cloud={true}
+      className="influx-cloud-logo"
+    />
+  </div>
+)
+
+export default LogoWithCubo

--- a/src/onboarding/containers/LoginPage.tsx
+++ b/src/onboarding/containers/LoginPage.tsx
@@ -6,11 +6,11 @@ import {
   FunnelPage,
   Heading,
   HeadingElement,
-  InfluxDBCloudLogo,
   Typeface,
 } from '@influxdata/clockface'
 import {useHistory} from 'react-router-dom'
 import Notifications from 'src/shared/components/notifications/Notifications'
+import LogoWithCubo from 'src/onboarding/components/LogoWithCubo'
 
 // Types
 import {getMe} from 'src/client'
@@ -58,10 +58,7 @@ export const LoginPage: FC = () => {
     <ErrorBoundary>
       <AppWrapper>
         <Notifications />
-        <FunnelPage
-          enableGraphic={true}
-          logo={<InfluxDBCloudLogo cloud={true} className="login-page--logo" />}
-        >
+        <FunnelPage enableGraphic={true} logo={<LogoWithCubo />}>
           <Heading
             element={HeadingElement.H1}
             type={Typeface.Rubik}


### PR DESCRIPTION
Closes #4443 

When directed to the login page for a specific region ( e.g. [East](https://us-east-1-1.aws.cloud2.influxdata.com/login) or [West](https://us-west-2-1.aws.cloud2.influxdata.com/login)) the influxdb cloud logo does not display the Kubo. But the Kubo **is** present on the generic login page that is not region-specific. [Generic Login](http://cloud2.influxdata.com/). This PR fixes the issue, so that the Kubo is present on both login pages.

1. Regional Login (not correct)
![regional-login-no-kubo](https://user-images.githubusercontent.com/91283923/167498052-d7541828-d1b9-44a9-8430-3de4ea494283.png)

2. Generic Login (correct)
![Screen Shot 2022-05-09 at 5 40 46 PM](https://user-images.githubusercontent.com/91283923/167503273-449fbb9b-80a9-448d-aa3e-5e66c510f26e.png)

The cause of the issue appears to be that src/onboarding/containers/LoginPage.tsx uses the [<InfluxDBCloudLogo />](https://influxdata.github.io/clockface/?path=/story/components-logos--influxdb-cloud) Clockface component as the page logo, but <pre><InfluxDBCloudLogo /></pre> does not itself include the Kubo. LoginPage.tsx appears to be the only page where the Kubo is missing from the influxdbcloud logo. Elsewhere in the UI, the absence of the Kubo logo was fixed in these ways:

- src/checkout/utils/CheckoutForm.tsx: by importing a custom component (<LogoWithCubo />) that includes the Kubo <pre> <Icon /></pre> component and the influxdbcloud logo
- src/onboarding/containers/SignInPage.tsx: by prepending a div with an applied class that renders the Kubo SVG.
- src/pageLayout/components/NavHeader.tsx: by passing the Kubo <pre><Icon /></pre> component through the "icon" prop within the <pre><TreeNav.Header /></pre> component.

Ideally, we should have a single Clockface component that renders the influxdbcloud logo + cubo identically in all places. For now, I've copied the custom component and scss for <LogoWithCubo /> from the **src/checkout** hierarchy into the **src/onboarding** hierarchy, as that seems the cleanest of the three solutions for rendering the Kubo. I'll submit a separate issue proposing a Clockface component.

Note: I don't think this fix is testable using remocal/remocal-quartz. However, I was able to test it ([see separate test branch if interested](https://github.com/influxdata/ui/tree/billOC_sprint9_loginPG_add_kubo_testEnv)) by making temporary changes to index.tsx to route the user directly to the login page:

3. Regional login before fix
![Screen Shot 2022-05-09 at 6 04 26 PM](https://user-images.githubusercontent.com/91283923/167506714-2a2636c5-7381-43b2-817c-2ff9f113dbfb.png)

4. Regional login after fix
![Screen Shot 2022-05-09 at 6 04 40 PM](https://user-images.githubusercontent.com/91283923/167506734-226a85cb-cda6-4244-ba67-ac0e523a8acf.png)

