### PR TITLE
fix: remove import statement for universe pkg

### DIFF
--- a/src/flows/pipes/RawFluxEditor/view.tsx
+++ b/src/flows/pipes/RawFluxEditor/view.tsx
@@ -84,7 +84,7 @@ const Query: FC<PipeProp> = ({Context}) => {
 
       const getHeader = fn => {
         let importStatement = null
-        
+
         // universe packages are loaded by deafult. Don't need import statement
         if (fn.package && fn.package !== 'universe') {
           importStatement = `import "${fn.package}"`

--- a/src/flows/pipes/RawFluxEditor/view.tsx
+++ b/src/flows/pipes/RawFluxEditor/view.tsx
@@ -84,8 +84,9 @@ const Query: FC<PipeProp> = ({Context}) => {
 
       const getHeader = fn => {
         let importStatement = null
-
-        if (fn.package) {
+        
+        // universe packages are loaded by deafult. Don't need import statement
+        if (fn.package && fn.package !== 'universe') {
           importStatement = `import "${fn.package}"`
           if (isFlagEnabled('fluxDynamicDocs') && fn.path.includes('/')) {
             importStatement = `import "${fn.path}"`

--- a/src/shared/utils/fluxExample.ts
+++ b/src/shared/utils/fluxExample.ts
@@ -17,7 +17,10 @@ export const getFluxExample = (func: FluxFunction) => {
         injectedParameters = `${injectedParameters} `
       }
     }
-    example = `${packageName}.${name}(${injectedParameters})`
+    example =
+      packageName === 'universe'
+        ? `${name}(${injectedParameters})`
+        : `${packageName}.${name}(${injectedParameters})`
   }
   return {...func, example}
 }

--- a/src/timeMachine/utils/insertFunction.ts
+++ b/src/timeMachine/utils/insertFunction.ts
@@ -35,7 +35,11 @@ export const generateImport = (
     }
   }
 
-  if (!funcPackage || script.includes(importStatement)) {
+  if (
+    !funcPackage ||
+    funcPackage === 'universe' ||
+    script.includes(importStatement)
+  ) {
     return false
   }
 


### PR DESCRIPTION
Closes #4534 

The `universe` package is loaded by default and does not require an import statement or functions in that package to be prepended with universe. PR removes import statements for all universe packages and removes `universe` prefix from the injected flux function.

Before Fix: 

https://user-images.githubusercontent.com/66275100/167665421-88edc5b8-9f26-4626-89d6-9ea119605012.mov



After Fix:

https://user-images.githubusercontent.com/66275100/167665161-869f6471-9815-4cab-837a-7f3d3d3af94d.mov


