### PR TITLE
feat: inject pipe-forward operator only when necessary 

### DIFF
--- a/cypress/e2e/cloud/explorer.test.ts
+++ b/cypress/e2e/cloud/explorer.test.ts
@@ -60,7 +60,7 @@ describe('DataExplorer', () => {
         cy.getByTestID('flux--microsecond--inject').click()
 
         getTimeMachineText().then(text => {
-          const expected = 'import "date" |> date.microsecond(t: )'
+          const expected = 'import "date"  date.microsecond(t: )'
           cy.fluxEqual(text, expected).should('be.true')
         })
       })

--- a/src/flows/pipes/RawFluxEditor/view.tsx
+++ b/src/flows/pipes/RawFluxEditor/view.tsx
@@ -76,10 +76,15 @@ const Query: FC<PipeProp> = ({Context}) => {
   const injectIntoEditor = useCallback(
     (fn): void => {
       let text = ''
-      if (fn.name === 'from' || fn.name === 'union') {
-        text = `${fn.example}`
+      if (isFlagEnabled('fluxDynamicDocs')) {
+        // only fluxTypes with <- sign require a pipe forward sign
+        text = fn.fluxType[1] === '<' ? `  |> ${fn.example}` : `${fn.example}`
       } else {
-        text = `  |> ${fn.example}`
+        if (fn.name === 'from' || fn.name === 'union') {
+          text = `${fn.example}`
+        } else {
+          text = `  |> ${fn.example}`
+        }
       }
 
       const getHeader = fn => {

--- a/src/flows/pipes/RawFluxEditor/view.tsx
+++ b/src/flows/pipes/RawFluxEditor/view.tsx
@@ -76,9 +76,11 @@ const Query: FC<PipeProp> = ({Context}) => {
   const injectIntoEditor = useCallback(
     (fn): void => {
       let text = ''
-      if (isFlagEnabled('fluxDynamicDocs')) {
+      if (CLOUD && isFlagEnabled('fluxDynamicDocs')) {
         // only fluxTypes with <- sign require a pipe forward sign
-        text = fn.fluxType.startsWith('<-', 1) ? `  |> ${fn.example}` : `${fn.example}`
+        text = fn.fluxType.startsWith('<-', 1)
+          ? `  |> ${fn.example}`
+          : `${fn.example}`
       } else {
         if (fn.name === 'from' || fn.name === 'union') {
           text = `${fn.example}`
@@ -93,7 +95,11 @@ const Query: FC<PipeProp> = ({Context}) => {
         // universe packages are loaded by deafult. Don't need import statement
         if (fn.package && fn.package !== 'universe') {
           importStatement = `import "${fn.package}"`
-          if (isFlagEnabled('fluxDynamicDocs') && fn.path.includes('/')) {
+          if (
+            CLOUD &&
+            isFlagEnabled('fluxDynamicDocs') &&
+            fn.path.includes('/')
+          ) {
             importStatement = `import "${fn.path}"`
           }
         }

--- a/src/flows/pipes/RawFluxEditor/view.tsx
+++ b/src/flows/pipes/RawFluxEditor/view.tsx
@@ -78,7 +78,7 @@ const Query: FC<PipeProp> = ({Context}) => {
       let text = ''
       if (isFlagEnabled('fluxDynamicDocs')) {
         // only fluxTypes with <- sign require a pipe forward sign
-        text = fn.fluxType[1] === '<' ? `  |> ${fn.example}` : `${fn.example}`
+        text = fn.fluxType.startsWith('<-', 1) ? `  |> ${fn.example}` : `${fn.example}`
       } else {
         if (fn.name === 'from' || fn.name === 'union') {
           text = `${fn.example}`

--- a/src/timeMachine/components/TimeMachineFluxEditor.tsx
+++ b/src/timeMachine/components/TimeMachineFluxEditor.tsx
@@ -106,13 +106,19 @@ const TimeMachineFluxEditor: FC = () => {
     if (shouldInsertOnNextLine) {
       if (CLOUD && isFlagEnabled('fluxDynamicDocs')) {
         // only fluxTypes with <- sign require a pipe forward sign
-        text = func.fluxType[1] === '<' ? `\n  |> ${func.example}` : `\n   ${func.example}`
+        text =
+          func.fluxType[1] === '<'
+            ? `\n  |> ${func.example}`
+            : `\n   ${func.example}`
       } else {
         text = `\n  |> ${func.example}`
       }
     } else {
       if (CLOUD && isFlagEnabled('fluxDynamicDocs')) {
-        text = func.fluxType[1] === '<' ? `  |> ${func.example}\n` : `   ${func.example}\n`
+        text =
+          func.fluxType[1] === '<'
+            ? `  |> ${func.example}\n`
+            : `   ${func.example}\n`
       } else {
         text = `  |> ${func.example}\n`
       }

--- a/src/timeMachine/components/TimeMachineFluxEditor.tsx
+++ b/src/timeMachine/components/TimeMachineFluxEditor.tsx
@@ -106,19 +106,17 @@ const TimeMachineFluxEditor: FC = () => {
     if (shouldInsertOnNextLine) {
       if (CLOUD && isFlagEnabled('fluxDynamicDocs')) {
         // only fluxTypes with <- sign require a pipe forward sign
-        text =
-          func.fluxType.startsWith('<-', 1)
-            ? `\n  |> ${func.example}`
-            : `\n   ${func.example}`
+        text = func.fluxType.startsWith('<-', 1)
+          ? `\n  |> ${func.example}`
+          : `\n   ${func.example}`
       } else {
         text = `\n  |> ${func.example}`
       }
     } else {
       if (CLOUD && isFlagEnabled('fluxDynamicDocs')) {
-        text =
-          func.fluxType.startsWith('<-', 1)
-            ? `  |> ${func.example}\n`
-            : `   ${func.example}\n`
+        text = func.fluxType.startsWith('<-', 1)
+          ? `  |> ${func.example}\n`
+          : `   ${func.example}\n`
       } else {
         text = `  |> ${func.example}\n`
       }

--- a/src/timeMachine/components/TimeMachineFluxEditor.tsx
+++ b/src/timeMachine/components/TimeMachineFluxEditor.tsx
@@ -104,9 +104,18 @@ const TimeMachineFluxEditor: FC = () => {
 
     let text = ''
     if (shouldInsertOnNextLine) {
-      text = `\n  |> ${func.example}`
+      if (CLOUD && isFlagEnabled('fluxDynamicDocs')) {
+        // only fluxTypes with <- sign require a pipe forward sign
+        text = func.fluxType[1] === '<' ? `\n  |> ${func.example}` : `\n   ${func.example}`
+      } else {
+        text = `\n  |> ${func.example}`
+      }
     } else {
-      text = `  |> ${func.example}\n`
+      if (CLOUD && isFlagEnabled('fluxDynamicDocs')) {
+        text = func.fluxType[1] === '<' ? `  |> ${func.example}\n` : `   ${func.example}\n`
+      } else {
+        text = `  |> ${func.example}\n`
+      }
     }
 
     if (functionRequiresNewLine(func.name)) {

--- a/src/timeMachine/components/TimeMachineFluxEditor.tsx
+++ b/src/timeMachine/components/TimeMachineFluxEditor.tsx
@@ -107,7 +107,7 @@ const TimeMachineFluxEditor: FC = () => {
       if (CLOUD && isFlagEnabled('fluxDynamicDocs')) {
         // only fluxTypes with <- sign require a pipe forward sign
         text =
-          func.fluxType[1] === '<'
+          func.fluxType.startsWith('<-', 1)
             ? `\n  |> ${func.example}`
             : `\n   ${func.example}`
       } else {
@@ -116,7 +116,7 @@ const TimeMachineFluxEditor: FC = () => {
     } else {
       if (CLOUD && isFlagEnabled('fluxDynamicDocs')) {
         text =
-          func.fluxType[1] === '<'
+          func.fluxType.startsWith('<-', 1)
             ? `  |> ${func.example}\n`
             : `   ${func.example}\n`
       } else {


### PR DESCRIPTION
Closes #4535 

In both current and older flux panel UI, all flux functions get injected in the editor with a pipe-forward operator `|>`. 
This isn't correct. Not all functions require `|>`. Pr leverages the `fluxType` property for each flux function to determine whether pipe-forward sign is needed. All functions that require this operator contain a pipe-receive operator `<-` in the fluxType property. 

Before: 

https://user-images.githubusercontent.com/66275100/167695593-fad8c98e-ab12-4971-8428-ac8b2d4a269f.mov


After: 

https://user-images.githubusercontent.com/66275100/167695446-a3ac26e0-e7e1-408e-b8cf-be18115584a5.mov



