### PR TITLE
chore: Remove list item for requesting archival of data from support

### DIFF
--- a/src/billing/components/PayAsYouGo/TermsCancellationOverlay.tsx
+++ b/src/billing/components/PayAsYouGo/TermsCancellationOverlay.tsx
@@ -41,10 +41,6 @@ const TermsCancellationOverlay: FC<Props> = ({
         You will be responsible for exporting all your content including
         dashboards, tasks, variables from the user interface.
       </li>
-      <li>
-        You can request support@influxdata.com for an archive of your Time
-        series data.
-      </li>
     </ul>
     <span onClick={onAgreedToTerms} data-testid="agree-terms--input">
       <FlexBox


### PR DESCRIPTION
We want to remove this option until bulk export is available.

This is in response to [EAR #3232](https://github.com/influxdata/EAR/issues/3232)
