### PR TITLE
chore: remove config for semantic-pull-requests, add call to influx w…

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,4 +1,0 @@
-# docs: https://github.com/probot/semantic-pull-requests#configuration
-allowMergeCommits: true
-allowRevertCommits: true
-titleOnly: true

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -1,0 +1,10 @@
+---
+name: "Semantic PR and Commit Messages"
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited]
+
+jobs:
+  semantic:
+    uses: influxdata/validate-semantic-github-messages/.github/workflows/semantic.yml@main

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -8,3 +8,6 @@ on:
 jobs:
   semantic:
     uses: influxdata/validate-semantic-github-messages/.github/workflows/semantic.yml@main
+    with:
+      COMMITS_HISTORY: 0
+


### PR DESCRIPTION
…orkflow to replace.

<!-- Describe your proposed changes here. -->
We are removing semantic-pull-requests org wide. Influxdata has its own semantic validator that runs as a workflow triggered by GH Actions.  To address the settings in the semantic-pull-requests config file, the following will be done:

allowMergeCommits: true -> this is already allowed
allowRevertCommits: true -> this is already allowed
titleOnly: true -> this is configurable and will be noted in the commit referring to COMMITS_HISTORY: 0

If the team would prefer that the PR title was only validated when merging into master, this is also achievable.  Please comment and mention @tysonkamp to have this functionality configured (it would be in  the semantic.yml).