### PR TITLE
chore: update flux search panel placeholder

### DIFF
--- a/src/flows/pipes/RawFluxEditor/FunctionsList/DynamicFunctionsList.tsx
+++ b/src/flows/pipes/RawFluxEditor/FunctionsList/DynamicFunctionsList.tsx
@@ -80,7 +80,7 @@ const DynamicFunctionsList: FC<Props> = ({onSelect}) => {
 
   return (
     <FilterList
-      placeholder="Filter Functions..."
+      placeholder="Filter by Package or Function"
       emptyMessage="No functions match your search"
       extractor={fn =>
         `${(fn as FluxFunction).name} ${(fn as FluxFunction).package}`

--- a/src/timeMachine/components/dynamicFluxFunctionsToolbar/FluxFunctionsToolbar.tsx
+++ b/src/timeMachine/components/dynamicFluxFunctionsToolbar/FluxFunctionsToolbar.tsx
@@ -97,7 +97,7 @@ const DynamicFluxFunctionsToolbar: FC<Props> = (props: Props) => {
         spinnerComponent={<TechnoSpinner />}
       >
         <ErrorBoundary>
-          <FluxToolbarSearch onSearch={handleSearch} resourceName="Functions" />
+          <FluxToolbarSearch onSearch={handleSearch} resourceName="by Package or Function" />
           <DapperScrollbars className="flux-toolbar--scroll-area">
             <div
               className="flux-toolbar--list"

--- a/src/timeMachine/components/dynamicFluxFunctionsToolbar/FluxFunctionsToolbar.tsx
+++ b/src/timeMachine/components/dynamicFluxFunctionsToolbar/FluxFunctionsToolbar.tsx
@@ -97,7 +97,10 @@ const DynamicFluxFunctionsToolbar: FC<Props> = (props: Props) => {
         spinnerComponent={<TechnoSpinner />}
       >
         <ErrorBoundary>
-          <FluxToolbarSearch onSearch={handleSearch} resourceName="by Package or Function" />
+          <FluxToolbarSearch
+            onSearch={handleSearch}
+            resourceName="by Package or Function"
+          />
           <DapperScrollbars className="flux-toolbar--scroll-area">
             <div
               className="flux-toolbar--list"


### PR DESCRIPTION
Closes #4524 

UI's flux panel isn't clear on how users can search for flux functions. Search widget only filters functions when given package name OR function name. PR clears this up by adding a more descriptive placeholder _Filter by Package or Function_
Data Explorer: 
![Screen Shot 2022-05-11 at 10 00 17 AM](https://user-images.githubusercontent.com/66275100/167882021-cd1442b3-a8b9-48f2-abe7-7b9a1f54e669.png)

Notebooks: 
![Screen Shot 2022-05-11 at 10 01 15 AM](https://user-images.githubusercontent.com/66275100/167882263-9915b660-9fc8-453b-af7f-431b9ff57349.png)

