### PR TITLE
 chore: hide support and feedback code for Help panel phase 1 release

### DIFF
--- a/src/pageLayout/containers/TreeNav.tsx
+++ b/src/pageLayout/containers/TreeNav.tsx
@@ -30,192 +30,192 @@ import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
 
 type ReduxProps = ConnectedProps<typeof connector>
 
-const TreeSidebar: FC<ReduxProps & RouteComponentProps> = (
+const TreeSidebar: FC<ReduxProps & RouteComponentProps> = () =>
+  // {
+  //   showOverlay,
+  //   dismissOverlay,
+  //   quartzMe,
+  // }
   {
-    // showOverlay,
-    // dismissOverlay,
-    // quartzMe,
-  }
-) => {
-  const {presentationMode, navbarMode, setNavbarMode} = useContext(
-    AppSettingContext
-  )
-  const org = useSelector(getOrg)
+    const {presentationMode, navbarMode, setNavbarMode} = useContext(
+      AppSettingContext
+    )
+    const org = useSelector(getOrg)
 
-  useEffect(() => {
-    if (isFlagEnabled('helpBar')) {
-      const helpBarMenu = document.querySelectorAll<HTMLElement>(
-        '.cf-tree-nav--sub-menu-trigger'
-      )[3]
+    useEffect(() => {
+      if (isFlagEnabled('helpBar')) {
+        const helpBarMenu = document.querySelectorAll<HTMLElement>(
+          '.cf-tree-nav--sub-menu-trigger'
+        )[3]
+        if (navbarMode === 'expanded') {
+          helpBarMenu.style.display = 'block'
+          helpBarMenu.style.width = '243px'
+        } else {
+          helpBarMenu.style.width = '44px'
+        }
+      }
+    }, [setNavbarMode, navbarMode])
+
+    if (presentationMode || !org) {
+      return null
+    }
+
+    const handleToggleNavExpansion = (): void => {
       if (navbarMode === 'expanded') {
-        helpBarMenu.style.display = 'block'
-        helpBarMenu.style.width = '243px'
+        setNavbarMode('collapsed')
       } else {
-        helpBarMenu.style.width = '44px'
+        setNavbarMode('expanded')
       }
     }
-  }, [setNavbarMode, navbarMode])
 
-  if (presentationMode || !org) {
-    return null
-  }
+    // Hiding Contact Support and Feedback code for Help Bar phase 1 release
+    // https://github.com/influxdata/ui/issues/3457
+    // https://github.com/influxdata/ui/issues/3454
+    // const handleSelect = (): void => {
+    //   const accountType = quartzMe?.accountType ?? 'free'
+    //   const isPayGCustomer = accountType !== 'free'
 
-  const handleToggleNavExpansion = (): void => {
-    if (navbarMode === 'expanded') {
-      setNavbarMode('collapsed')
-    } else {
-      setNavbarMode('expanded')
-    }
-  }
+    //   if (isPayGCustomer) {
+    //     showOverlay('payg-support', null, dismissOverlay)
+    //   } else {
+    //     showOverlay('free-account-support', null, dismissOverlay)
+    //   }
+    // }
 
-  // Hiding Contact Support and Feedback code for Help Bar phase 1 release
-  // https://github.com/influxdata/ui/issues/3457
-  // https://github.com/influxdata/ui/issues/3454
-  // const handleSelect = (): void => {
-  //   const accountType = quartzMe?.accountType ?? 'free'
-  //   const isPayGCustomer = accountType !== 'free'
+    // const openFeedbackOverlay = (): void => {
+    //   showOverlay('feedback-questions', null, dismissOverlay)
+    // }
 
-  //   if (isPayGCustomer) {
-  //     showOverlay('payg-support', null, dismissOverlay)
-  //   } else {
-  //     showOverlay('free-account-support', null, dismissOverlay)
-  //   }
-  // }
+    return (
+      <OrgSettings>
+        <TreeNav
+          expanded={navbarMode === 'expanded'}
+          headerElement={<NavHeader link={`/orgs/${org.id}`} />}
+          userElement={<UserWidget />}
+          onToggleClick={handleToggleNavExpansion}
+        >
+          {generateNavItems().map((item: NavItem) => {
+            const linkElement = (className: string): JSX.Element => (
+              <Link
+                to={item.link}
+                className={className}
+                title={item.label}
+                onClick={() => {
+                  event('nav clicked', {which: item.id})
+                }}
+              />
+            )
+            return (
+              <TreeNav.Item
+                key={item.id}
+                id={item.id}
+                testID={item.testID}
+                icon={<Icon glyph={item.icon} />}
+                label={item.label}
+                shortLabel={item.shortLabel}
+                active={getNavItemActivation(
+                  item.activeKeywords,
+                  location.pathname
+                )}
+                linkElement={linkElement}
+              >
+                {Boolean(item.menu) && (
+                  <TreeNav.SubMenu>
+                    {item.menu.map((menuItem: NavSubItem) => {
+                      const linkElement = (className: string): JSX.Element => (
+                        <Link
+                          to={menuItem.link}
+                          className={className}
+                          onClick={() => {
+                            event('nav clicked', {
+                              which: `${item.id} - ${menuItem.id}`,
+                            })
+                          }}
+                        />
+                      )
 
-  // const openFeedbackOverlay = (): void => {
-  //   showOverlay('feedback-questions', null, dismissOverlay)
-  // }
-
-  return (
-    <OrgSettings>
-      <TreeNav
-        expanded={navbarMode === 'expanded'}
-        headerElement={<NavHeader link={`/orgs/${org.id}`} />}
-        userElement={<UserWidget />}
-        onToggleClick={handleToggleNavExpansion}
-      >
-        {generateNavItems().map((item: NavItem) => {
-          const linkElement = (className: string): JSX.Element => (
-            <Link
-              to={item.link}
-              className={className}
-              title={item.label}
-              onClick={() => {
-                event('nav clicked', {which: item.id})
-              }}
-            />
-          )
-          return (
+                      return (
+                        <TreeNav.SubItem
+                          key={menuItem.id}
+                          id={menuItem.id}
+                          testID={menuItem.testID}
+                          active={getNavItemActivation(
+                            [menuItem.id],
+                            location.pathname
+                          )}
+                          label={menuItem.label}
+                          linkElement={linkElement}
+                        />
+                      )
+                    })}
+                  </TreeNav.SubMenu>
+                )}
+              </TreeNav.Item>
+            )
+          })}
+          {isFlagEnabled('helpBar') ? (
             <TreeNav.Item
-              key={item.id}
-              id={item.id}
-              testID={item.testID}
-              icon={<Icon glyph={item.icon} />}
-              label={item.label}
-              shortLabel={item.shortLabel}
-              active={getNavItemActivation(
-                item.activeKeywords,
-                location.pathname
-              )}
-              linkElement={linkElement}
+              id="support"
+              testID="nav-item-support"
+              icon={<Icon glyph={IconFont.QuestionMark_New} />}
+              label="Help & Support"
+              shortLabel="Support"
             >
-              {Boolean(item.menu) && (
-                <TreeNav.SubMenu>
-                  {item.menu.map((menuItem: NavSubItem) => {
-                    const linkElement = (className: string): JSX.Element => (
-                      <Link
-                        to={menuItem.link}
-                        className={className}
-                        onClick={() => {
-                          event('nav clicked', {
-                            which: `${item.id} - ${menuItem.id}`,
-                          })
-                        }}
-                      />
-                    )
-
-                    return (
-                      <TreeNav.SubItem
-                        key={menuItem.id}
-                        id={menuItem.id}
-                        testID={menuItem.testID}
-                        active={getNavItemActivation(
-                          [menuItem.id],
-                          location.pathname
-                        )}
-                        label={menuItem.label}
-                        linkElement={linkElement}
-                      />
-                    )
-                  })}
-                </TreeNav.SubMenu>
-              )}
-            </TreeNav.Item>
-          )
-        })}
-        {isFlagEnabled('helpBar') ? (
-          <TreeNav.Item
-            id="support"
-            testID="nav-item-support"
-            icon={<Icon glyph={IconFont.QuestionMark_New} />}
-            label="Help & Support"
-            shortLabel="Support"
-          >
-            <TreeNav.SubMenu>
-              <TreeNav.SubHeading label="Support" />
-              <TreeNav.SubItem
-                id="documentation"
-                label="Documentation"
-                testID="nav-subitem-documentation"
-                linkElement={() => (
-                  <SafeBlankLink href="https://docs.influxdata.com/" />
-                )}
-              />
-              <TreeNav.SubItem
-                id="faqs"
-                label="FAQs"
-                testID="nav-subitem-faqs"
-                linkElement={() => (
-                  <SafeBlankLink href="https://docs.influxdata.com/influxdb/v1.8/troubleshooting/frequently-asked-questions/" />
-                )}
-              />
-              {/* <TreeNav.SubItem
+              <TreeNav.SubMenu>
+                <TreeNav.SubHeading label="Support" />
+                <TreeNav.SubItem
+                  id="documentation"
+                  label="Documentation"
+                  testID="nav-subitem-documentation"
+                  linkElement={() => (
+                    <SafeBlankLink href="https://docs.influxdata.com/" />
+                  )}
+                />
+                <TreeNav.SubItem
+                  id="faqs"
+                  label="FAQs"
+                  testID="nav-subitem-faqs"
+                  linkElement={() => (
+                    <SafeBlankLink href="https://docs.influxdata.com/influxdb/v1.8/troubleshooting/frequently-asked-questions/" />
+                  )}
+                />
+                {/* <TreeNav.SubItem
                 id="contactSupport"
                 label="Contact Support"
                 testID="nav-subitem-contact-support"
                 onClick={handleSelect}
               /> */}
-              <TreeNav.SubHeading label="Community" />
-              <TreeNav.SubItem
-                id="offcialForum"
-                label="Official Forum"
-                testID="nav-subitem-forum"
-                linkElement={() => (
-                  <SafeBlankLink href="https://community.influxdata.com" />
-                )}
-              />
-              <TreeNav.SubItem
-                id="influxdbSlack"
-                label="InfluxDB Slack"
-                testID="nav-subitem-influxdb-slack"
-                linkElement={() => (
-                  <SafeBlankLink href="https://influxcommunity.slack.com/join/shared_invite/zt-156zm7ult-LcIW2T4TwLYeS8rZbCP1mw#/shared-invite/email" />
-                )}
-              />
-              {/* <TreeNav.SubHeading label="Feedback" />
+                <TreeNav.SubHeading label="Community" />
+                <TreeNav.SubItem
+                  id="offcialForum"
+                  label="Official Forum"
+                  testID="nav-subitem-forum"
+                  linkElement={() => (
+                    <SafeBlankLink href="https://community.influxdata.com" />
+                  )}
+                />
+                <TreeNav.SubItem
+                  id="influxdbSlack"
+                  label="InfluxDB Slack"
+                  testID="nav-subitem-influxdb-slack"
+                  linkElement={() => (
+                    <SafeBlankLink href="https://influxcommunity.slack.com/join/shared_invite/zt-156zm7ult-LcIW2T4TwLYeS8rZbCP1mw#/shared-invite/email" />
+                  )}
+                />
+                {/* <TreeNav.SubHeading label="Feedback" />
               <TreeNav.SubItem
                 id="feedback"
                 label="Feedback & Questions"
                 testID="nav-subitem-feedback-questions"
                 onClick={openFeedbackOverlay}
               /> */}
-            </TreeNav.SubMenu>
-          </TreeNav.Item>
-        ) : null}
-      </TreeNav>
-    </OrgSettings>
-  )
-}
+              </TreeNav.SubMenu>
+            </TreeNav.Item>
+          ) : null}
+        </TreeNav>
+      </OrgSettings>
+    )
+  }
 
 const mstp = (state: AppState) => {
   return {quartzMe: state.me.quartzMe}

--- a/src/pageLayout/containers/TreeNav.tsx
+++ b/src/pageLayout/containers/TreeNav.tsx
@@ -31,9 +31,9 @@ import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
 type ReduxProps = ConnectedProps<typeof connector>
 
 const TreeSidebar: FC<ReduxProps & RouteComponentProps> = ({
-  showOverlay,
-  dismissOverlay,
-  quartzMe,
+  // showOverlay,
+  // dismissOverlay,
+  // quartzMe,
 }) => {
   const {presentationMode, navbarMode, setNavbarMode} = useContext(
     AppSettingContext
@@ -66,20 +66,23 @@ const TreeSidebar: FC<ReduxProps & RouteComponentProps> = ({
     }
   }
 
-  const handleSelect = (): void => {
-    const accountType = quartzMe?.accountType ?? 'free'
-    const isPayGCustomer = accountType !== 'free'
+  // Hiding Contact Support and Feedback code for Help Bar phase 1 release
+  // https://github.com/influxdata/ui/issues/3457
+  // https://github.com/influxdata/ui/issues/3454
+  // const handleSelect = (): void => {
+  //   const accountType = quartzMe?.accountType ?? 'free'
+  //   const isPayGCustomer = accountType !== 'free'
 
-    if (isPayGCustomer) {
-      showOverlay('payg-support', null, dismissOverlay)
-    } else {
-      showOverlay('free-account-support', null, dismissOverlay)
-    }
-  }
+  //   if (isPayGCustomer) {
+  //     showOverlay('payg-support', null, dismissOverlay)
+  //   } else {
+  //     showOverlay('free-account-support', null, dismissOverlay)
+  //   }
+  // }
 
-  const openFeedbackOverlay = (): void => {
-    showOverlay('feedback-questions', null, dismissOverlay)
-  }
+  // const openFeedbackOverlay = (): void => {
+  //   showOverlay('feedback-questions', null, dismissOverlay)
+  // }
 
   return (
     <OrgSettings>
@@ -174,12 +177,12 @@ const TreeSidebar: FC<ReduxProps & RouteComponentProps> = ({
                   <SafeBlankLink href="https://docs.influxdata.com/influxdb/v1.8/troubleshooting/frequently-asked-questions/" />
                 )}
               />
-              <TreeNav.SubItem
+              {/* <TreeNav.SubItem
                 id="contactSupport"
                 label="Contact Support"
                 testID="nav-subitem-contact-support"
                 onClick={handleSelect}
-              />
+              /> */}
               <TreeNav.SubHeading label="Community" />
               <TreeNav.SubItem
                 id="offcialForum"
@@ -197,13 +200,13 @@ const TreeSidebar: FC<ReduxProps & RouteComponentProps> = ({
                   <SafeBlankLink href="https://influxcommunity.slack.com/join/shared_invite/zt-156zm7ult-LcIW2T4TwLYeS8rZbCP1mw#/shared-invite/email" />
                 )}
               />
-              <TreeNav.SubHeading label="Feedback" />
+              {/* <TreeNav.SubHeading label="Feedback" />
               <TreeNav.SubItem
                 id="feedback"
                 label="Feedback & Questions"
                 testID="nav-subitem-feedback-questions"
                 onClick={openFeedbackOverlay}
-              />
+              /> */}
             </TreeNav.SubMenu>
           </TreeNav.Item>
         ) : null}

--- a/src/pageLayout/containers/TreeNav.tsx
+++ b/src/pageLayout/containers/TreeNav.tsx
@@ -30,11 +30,13 @@ import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
 
 type ReduxProps = ConnectedProps<typeof connector>
 
-const TreeSidebar: FC<ReduxProps & RouteComponentProps> = ({
-  // showOverlay,
-  // dismissOverlay,
-  // quartzMe,
-}) => {
+const TreeSidebar: FC<ReduxProps & RouteComponentProps> = (
+  {
+    // showOverlay,
+    // dismissOverlay,
+    // quartzMe,
+  }
+) => {
   const {presentationMode, navbarMode, setNavbarMode} = useContext(
     AppSettingContext
   )


### PR DESCRIPTION
Closes #4557 

PR uncomments Contact Support and Feedback code for phase 1 release. 
This is only temporary, as we will need both nav items once backend work is complete. 
