### PR TITLE
feat: add accountCreatedAt to dataLayer

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "cy": "CYPRESS_dexUrl=https://$INGRESS_HOST:$PORT_HTTPS CYPRESS_baseUrl=http://localhost:9999 cypress open",
     "cy:dev": "source ../monitor-ci/.env && CYPRESS_dexUrl=CLOUD CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{cloud,shared}/**/*.*'",
     "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_dexUrl=OSS CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{oss,shared}/**/*.*'",
-    "generate": "export SHA=b983e6ecc75f9b9852401e5585f2706890b10bb3 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
+    "generate": "export SHA=870f6545652f86c675f9802d6f6f21bd3150fb0f && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-meta": "if [ -z \"${CLOUD_URL}\" ]; then yarn generate-meta-oss; else yarn generate-meta-cloud; fi",
     "generate-meta-oss": "yarn oss-api && yarn notebooks && yarn unity && yarn annotations-oss && yarn pinned && yarn mapsd-oss && yarn uiproxyd-oss && yarn cloudPriv && yarn fluxdocs && yarn subscriptions-oss",

--- a/src/shared/containers/GetOrganizations.tsx
+++ b/src/shared/containers/GetOrganizations.tsx
@@ -18,8 +18,11 @@ import {RemoteDataState, AppState} from 'src/types'
 
 // Actions
 import {getOrganizations} from 'src/organizations/actions/thunks'
-import {getQuartzMe} from 'src/me/actions/thunks'
+import {getQuartzMe as apiGetQuartzMe} from 'src/me/actions/thunks'
 import RouteToOrg from 'src/shared/containers/RouteToOrg'
+
+// Selectors
+import {getQuartzMe} from 'src/me/selectors'
 
 // Constants
 import {CLOUD} from 'src/shared/constants'
@@ -43,7 +46,7 @@ const GetOrganizations: FunctionComponent = () => {
   const quartzMeStatus = useSelector(
     (state: AppState) => state.me.quartzMeStatus
   )
-  const me = useSelector((state: AppState) => state.me.quartzMe)
+  const me = useSelector(getQuartzMe)
   const dispatch = useDispatch()
   useEffect(() => {
     if (status === RemoteDataState.NotStarted) {
@@ -56,9 +59,18 @@ const GetOrganizations: FunctionComponent = () => {
       isFlagEnabled('uiUnificationFlag') &&
       quartzMeStatus === RemoteDataState.NotStarted
     ) {
-      dispatch(getQuartzMe())
+      dispatch(apiGetQuartzMe())
     }
-  }, [dispatch, quartzMeStatus])
+
+    if (
+      isFlagEnabled('credit250Experiment') &&
+      quartzMeStatus === RemoteDataState.Done
+    ) {
+      const {accountCreatedAt = ''} = me
+      window.dataLayer = window.dataLayer ?? []
+      window.dataLayer.push({accountCreatedAt})
+    }
+  }, [dispatch, me, quartzMeStatus])
 
   return (
     <PageSpinner loading={status}>


### PR DESCRIPTION
Closes #4464 

- uses the updated openapi definition for `Me` which was updated by https://github.com/influxdata/openapi/pull/318
- adds the `accountCreatedAt` property to `window.dataLayer`
