### PR TITLE
fix(sub): remove flowVersion before update

### DIFF
--- a/src/types/subscriptions.ts
+++ b/src/types/subscriptions.ts
@@ -27,6 +27,7 @@ export interface Subscription {
   tokenID?: string
   token?: string
   isActive?: string
+  flowVersion?: number
 }
 
 export interface JsonSpec {

--- a/src/writeData/subscriptions/utils/form.ts
+++ b/src/writeData/subscriptions/utils/form.ts
@@ -131,6 +131,7 @@ export const sanitizeUpdateForm = (form: Subscription): Subscription => {
   delete form.tokenID
   delete form.isActive
   delete form.status
+  delete form.flowVersion
   return form
 }
 


### PR DESCRIPTION
Fixes a bug blocking pipelines at the moment. The new property `flowVersion` must be removed before updating a subscription
