### PR TITLE
feat: upgrade clockface from 3.12.0 => 4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
   },
   "dependencies": {
     "@docsearch/react": "^3.0.0-alpha.37",
-    "@influxdata/clockface": "^3.12.0",
+    "@influxdata/clockface": "^4.0.1",
     "@influxdata/flux-lsp-browser": "0.8.8",
     "@influxdata/giraffe": "^2.25.0",
     "@influxdata/influxdb-templates": "0.9.0",

--- a/src/me/components/PinnedItems.tsx
+++ b/src/me/components/PinnedItems.tsx
@@ -104,7 +104,7 @@ const PinnedItems: FC = () => {
             >
               <ResourceCard.Meta>
                 <Heading
-                  type={Typeface.IBMPlexMono}
+                  type={Typeface.RobotoMono}
                   element={HeadingElement.H5}
                   testID="pinneditems--type"
                 >

--- a/src/onboarding/components/HelperText.tsx
+++ b/src/onboarding/components/HelperText.tsx
@@ -1,9 +1,5 @@
 import React, {FC} from 'react'
-import {
-  FontWeight,
-  Heading,
-  HeadingElement,
-} from '@influxdata/clockface'
+import {FontWeight, Heading, HeadingElement} from '@influxdata/clockface'
 
 const HelperText: FC = ({children}) => (
   <Heading

--- a/src/onboarding/components/HelperText.tsx
+++ b/src/onboarding/components/HelperText.tsx
@@ -3,13 +3,11 @@ import {
   FontWeight,
   Heading,
   HeadingElement,
-  Typeface,
 } from '@influxdata/clockface'
 
 const HelperText: FC = ({children}) => (
   <Heading
     element={HeadingElement.H6}
-    type={Typeface.Rubik}
     weight={FontWeight.Regular}
     className="helper-link-text"
     selectable={true}

--- a/src/onboarding/containers/LoginPage.tsx
+++ b/src/onboarding/containers/LoginPage.tsx
@@ -6,7 +6,6 @@ import {
   FunnelPage,
   Heading,
   HeadingElement,
-  Typeface,
 } from '@influxdata/clockface'
 import {useHistory} from 'react-router-dom'
 import Notifications from 'src/shared/components/notifications/Notifications'
@@ -61,7 +60,6 @@ export const LoginPage: FC = () => {
         <FunnelPage enableGraphic={true} logo={<CloudLogoWithCubo />}>
           <Heading
             element={HeadingElement.H1}
-            type={Typeface.Rubik}
             weight={FontWeight.Regular}
             className="cf-funnel-page--title"
           >

--- a/yarn.lock
+++ b/yarn.lock
@@ -1437,10 +1437,10 @@
     gud "^1.0.0"
     warning "^4.0.3"
 
-"@influxdata/clockface@^3.12.0":
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-3.12.0.tgz#707715f935e81c65e18f59409af48602fe731a9f"
-  integrity sha512-p2n0QkHeDINhK2ryt2YRuBbmE7LU5I9swyV/VH4m9s20gG3gQ+JubrPhCNWdC007Lw//0UnYtCJlA5qPAOJ5dw==
+"@influxdata/clockface@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-4.0.1.tgz#fe9175301b3c7914bf2165e15f0a904572aadeff"
+  integrity sha512-c4tFxs1/9zR3kc7/Y77mZdo6NsThznfYz+q6O64PqOykqDClgpfCzbpVmG+Tfm06Je4jF4Om3Ssek3cC6lYodw==
 
 "@influxdata/flux-lsp-browser@0.8.8":
   version "0.8.8"


### PR DESCRIPTION
Closes #4567

Upgrades to version `4.0.1` of clockface, which has font-face changes from [`4.0.0`](https://github.com/influxdata/clockface/releases/tag/v4.0.0) and the Subway Nav changes from [`4.0.1`](https://github.com/influxdata/clockface/releases/tag/v4.0.1)

## Screenshots (Open the screenshots in tabs right next to each other and switch back and forth to see changes)
 
#### New Homepage
![Screen Shot 2022-05-12 at 9 33 40 AM](https://user-images.githubusercontent.com/146112/168089761-ca17477e-0d07-4687-929c-986a27972835.png)

#### Old Homepage
![Screen Shot 2022-05-12 at 9 33 43 AM](https://user-images.githubusercontent.com/146112/168089774-a20397f6-a0c7-40ce-8ec4-95f4b5b180a2.png)

#### New First Mile with Subway Nav
![Screen Shot 2022-05-12 at 9 40 07 AM](https://user-images.githubusercontent.com/146112/168090276-15055e68-ac7d-4c52-9b8d-c51b16f86831.png)

#### Old First Mile with Subway Nav
![Screen Shot 2022-05-12 at 9 40 09 AM](https://user-images.githubusercontent.com/146112/168090294-0cf597fc-0b02-43ce-a2a6-db8e5dd3e60a.png)

#### New Dashboards
![Screen Shot 2022-05-12 at 9 34 17 AM](https://user-images.githubusercontent.com/146112/168089907-3938f6ee-3da0-4e47-9d57-9fe098c46e91.png)

#### Old Dashboards
![Screen Shot 2022-05-12 at 9 34 19 AM](https://user-images.githubusercontent.com/146112/168089931-870f673e-c97a-47b2-9e24-ab404171382e.png)

#### New Notebooks
![Screen Shot 2022-05-12 at 9 35 51 AM](https://user-images.githubusercontent.com/146112/168090043-3940d9ce-0af3-45a9-b7bf-779a2027ee7b.png)

#### Old Notebooks
![Screen Shot 2022-05-12 at 9 35 53 AM](https://user-images.githubusercontent.com/146112/168090056-66536687-5eef-4b56-a7d5-807f1681588f.png)

#### New Tasks
![Screen Shot 2022-05-12 at 9 38 58 AM](https://user-images.githubusercontent.com/146112/168090160-1d7e3d4e-8a89-467e-85ea-90e51c8bea03.png)

#### Old Tasks
![Screen Shot 2022-05-12 at 9 39 01 AM](https://user-images.githubusercontent.com/146112/168090174-bfe0948d-1f01-42c2-9ef5-188260c7e9d7.png)


