### PR TITLE
chore: use Intl.NumberFormat

### DIFF
--- a/src/billing/components/Free/PAYGConversion.tsx
+++ b/src/billing/components/Free/PAYGConversion.tsx
@@ -109,7 +109,10 @@ export const PAYGConversion: FC = () => {
                       <li>Unlimited tasks</li>
                       <li>Unlimited alert checks and notification rules</li>
                       <li>HTTP and PagerDuty notifications</li>
-                      <li>Up to 1,000,000 series cardinality</li>
+                      <li>
+                        Up to {Intl.NumberFormat().format(ONE_MILLION)} series
+                        cardinality
+                      </li>
                     </ul>
                   </div>
                 </div>

--- a/src/billing/components/Free/PAYGConversion.tsx
+++ b/src/billing/components/Free/PAYGConversion.tsx
@@ -17,7 +17,7 @@ import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {GoogleOptimizeExperiment} from 'src/cloud/components/experiments/GoogleOptimizeExperiment'
 import {CREDIT_250_EXPERIMENT_ID} from 'src/shared/constants'
 
-const ONE_MILLION = 1_000_000
+const CARDINALITY_LIMIT = 1_000_000
 
 export const Credit250PAYGConversion: FC = () => {
   if (isFlagEnabled('credit250Experiment')) {
@@ -60,7 +60,7 @@ export const Credit250PAYGConversion: FC = () => {
                   <li>Unlimited alert checks and notification rules</li>
                   <li>HTTP and PagerDuty notifications</li>
                   <li>
-                    Up to {Intl.NumberFormat().format(ONE_MILLION)} series
+                    Up to {Intl.NumberFormat().format(CARDINALITY_LIMIT)} series
                     cardinality
                   </li>
                 </ul>
@@ -110,8 +110,8 @@ export const PAYGConversion: FC = () => {
                       <li>Unlimited alert checks and notification rules</li>
                       <li>HTTP and PagerDuty notifications</li>
                       <li>
-                        Up to {Intl.NumberFormat().format(ONE_MILLION)} series
-                        cardinality
+                        Up to {Intl.NumberFormat().format(CARDINALITY_LIMIT)}{' '}
+                        series cardinality
                       </li>
                     </ul>
                   </div>


### PR DESCRIPTION
This should have been included in https://github.com/influxdata/ui/pull/4551

When the feature is off, we still want to use `Intl.NumberFormat` to display large numbers that use grouping.

<img width="1728" alt="Screen Shot 2022-05-12 at 3 49 49 PM" src="https://user-images.githubusercontent.com/10736577/168180643-d0c7dc71-3815-438c-bc19-b59c8dd0cf30.png">

