### PR TITLE
feat(client_libs): add Scala WriteAPI example

### DIFF
--- a/src/writeData/clients/Java/description.md
+++ b/src/writeData/clients/Java/description.md
@@ -8,7 +8,7 @@ Build with Maven
 <dependency>
   <groupId>com.influxdb</groupId>
   <artifactId>influxdb-client-java</artifactId>
-  <version>4.3.0</version>
+  <version>6.1.0</version>
 </dependency>
 ```
 
@@ -16,6 +16,6 @@ Build with Gradle
 
 ```
 dependencies {
-  implementation "com.influxdb:influxdb-client-java:4.3.0"
+  implementation "com.influxdb:influxdb-client-java:6.1.0"
 }
 ```

--- a/src/writeData/clients/Java/description.md
+++ b/src/writeData/clients/Java/description.md
@@ -8,7 +8,7 @@ Build with Maven
 <dependency>
   <groupId>com.influxdb</groupId>
   <artifactId>influxdb-client-java</artifactId>
-  <version>6.1.0</version>
+  <version>6.3.0</version>
 </dependency>
 ```
 
@@ -16,6 +16,6 @@ Build with Gradle
 
 ```
 dependencies {
-  implementation "com.influxdb:influxdb-client-java:6.1.0"
+  implementation "com.influxdb:influxdb-client-java:6.3.0"
 }
 ```

--- a/src/writeData/clients/Kotlin/description.md
+++ b/src/writeData/clients/Kotlin/description.md
@@ -8,7 +8,7 @@ Build with Maven
 <dependency>
   <groupId>com.influxdb</groupId>
   <artifactId>influxdb-client-kotlin</artifactId>
-  <version>4.3.0</version>
+  <version>6.1.0</version>
 </dependency>
 ```
 
@@ -16,6 +16,6 @@ Build with Gradle
 
 ```
 dependencies {
-  implementation "com.influxdb:influxdb-client-kotlin:4.3.0"
+  implementation "com.influxdb:influxdb-client-kotlin:6.1.0"
 }
 ```

--- a/src/writeData/clients/Kotlin/description.md
+++ b/src/writeData/clients/Kotlin/description.md
@@ -8,7 +8,7 @@ Build with Maven
 <dependency>
   <groupId>com.influxdb</groupId>
   <artifactId>influxdb-client-kotlin</artifactId>
-  <version>6.1.0</version>
+  <version>6.3.0</version>
 </dependency>
 ```
 
@@ -16,6 +16,6 @@ Build with Gradle
 
 ```
 dependencies {
-  implementation "com.influxdb:influxdb-client-kotlin:6.1.0"
+  implementation "com.influxdb:influxdb-client-kotlin:6.3.0"
 }
 ```

--- a/src/writeData/clients/Scala/description.md
+++ b/src/writeData/clients/Scala/description.md
@@ -5,7 +5,7 @@ For more detailed and up to date information check out the [GitHub Repository](h
 Build with sbt
 
 ```
-libraryDependencies += "com.influxdb" % "influxdb-client-scala" % "6.1.0"
+libraryDependencies += "com.influxdb" % "influxdb-client-scala" % "6.3.0"
 ```
 
 Build with Maven
@@ -14,7 +14,7 @@ Build with Maven
 <dependency>
   <groupId>com.influxdb</groupId>
   <artifactId>influxdb-client-scala</artifactId>
-  <version>6.1.0</version>
+  <version>6.3.0</version>
 </dependency>
 ```
 
@@ -22,6 +22,6 @@ Build with Gradle
 
 ```
 dependencies {
-  implementation "com.influxdb:influxdb-client-scala:6.1.0"
+  implementation "com.influxdb:influxdb-client-scala:6.3.0"
 }
 ```

--- a/src/writeData/clients/Scala/description.md
+++ b/src/writeData/clients/Scala/description.md
@@ -5,7 +5,7 @@ For more detailed and up to date information check out the [GitHub Repository](h
 Build with sbt
 
 ```
-libraryDependencies += "com.influxdb" % "influxdb-client-scala" % "4.3.0"
+libraryDependencies += "com.influxdb" % "influxdb-client-scala" % "6.1.0"
 ```
 
 Build with Maven
@@ -14,7 +14,7 @@ Build with Maven
 <dependency>
   <groupId>com.influxdb</groupId>
   <artifactId>influxdb-client-scala</artifactId>
-  <version>4.3.0</version>
+  <version>6.1.0</version>
 </dependency>
 ```
 
@@ -22,6 +22,6 @@ Build with Gradle
 
 ```
 dependencies {
-  implementation "com.influxdb:influxdb-client-scala:4.3.0"
+  implementation "com.influxdb:influxdb-client-scala:6.1.0"
 }
 ```

--- a/src/writeData/clients/Scala/dispose.example
+++ b/src/writeData/clients/Scala/dispose.example
@@ -1,1 +1,2 @@
 client.close()
+system.terminate()

--- a/src/writeData/clients/Scala/execute.example
+++ b/src/writeData/clients/Scala/execute.example
@@ -10,7 +10,3 @@ val sink = results
 
 // wait to finish
 Await.result(sink, Duration.Inf)
-
-client.close()
-system.terminate()
-

--- a/src/writeData/clients/Scala/executeFull.example
+++ b/src/writeData/clients/Scala/executeFull.example
@@ -10,7 +10,7 @@ import scala.concurrent.duration.Duration
 
 object InfluxDB2ScalaExample {
 
-  implicit val system: ActorSystem = ActorSystem("it-tests")
+  implicit val system: ActorSystem = ActorSystem("examples")
 
   def main(args: Array[String]): Unit = {
 

--- a/src/writeData/clients/Scala/index.ts
+++ b/src/writeData/clients/Scala/index.ts
@@ -3,6 +3,9 @@ import description from 'src/writeData/clients/Scala/description.md'
 import initialize from 'src/writeData/clients/Scala/initialize.example'
 import execute from 'src/writeData/clients/Scala/execute.example'
 import query from 'src/writeData/clients/Scala/query.example'
+import writeLP from 'src/writeData/clients/Scala/write.0.example'
+import writePoint from 'src/writeData/clients/Scala/write.1.example'
+import writePOJO from 'src/writeData/clients/Scala/write.2.example'
 import dispose from 'src/writeData/clients/Scala/dispose.example'
 import executeFull from 'src/writeData/clients/Scala/executeFull.example'
 
@@ -15,6 +18,20 @@ export default register =>
     initialize,
     execute,
     query,
+    write: [
+      {
+        title: 'Use InfluxDB Line Protocol to write data',
+        code: writeLP,
+      },
+      {
+        title: 'Use a Data Point to write data',
+        code: writePoint,
+      },
+      {
+        title: 'Use POJO and corresponding class to write data',
+        code: writePOJO,
+      },
+    ],
     dispose,
     executeFull,
   })

--- a/src/writeData/clients/Scala/initialize.example
+++ b/src/writeData/clients/Scala/initialize.example
@@ -1,24 +1,29 @@
 package example
 
 import akka.actor.ActorSystem
-import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.{Keep, Sink, Source}
+import com.influxdb.annotations.{Column, Measurement}
+import com.influxdb.client.domain.WritePrecision
 import com.influxdb.client.scala.InfluxDBClientScalaFactory
 import com.influxdb.query.FluxRecord
+import com.influxdb.client.write.Point
 
+import java.time.Instant
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
 object InfluxDB2ScalaExample {
 
-  implicit val system: ActorSystem = ActorSystem("it-tests")
+  implicit val system: ActorSystem = ActorSystem("examples")
 
   def main(args: Array[String]): Unit = {
 
     // You can generate an API token from the "API Tokens Tab" in the UI
     val token = sys.env.get("INFLUX_TOKEN")
     val org = "<%= org %>"
+    val bucket = "<%= bucket %>"
 
-    val client = InfluxDBClientScalaFactory.create("<%= server %>", token.toCharArray, org)
+    val client = InfluxDBClientScalaFactory.create("<%= server %>", token.get.toCharArray, org, bucket)
   }
 }
 

--- a/src/writeData/clients/Scala/write.0.example
+++ b/src/writeData/clients/Scala/write.0.example
@@ -1,0 +1,7 @@
+val record = "mem,host=host1 used_percent=23.43234543"
+
+val source = Source.single(record)
+val sink = client.getWriteScalaApi.writeRecord()
+val materialized = source.toMat(sink)(Keep.right)
+
+Await.result(materialized.run(), Duration.Inf)

--- a/src/writeData/clients/Scala/write.1.example
+++ b/src/writeData/clients/Scala/write.1.example
@@ -1,0 +1,11 @@
+val point = Point
+  .measurement("mem")
+  .addTag("host", "host1")
+  .addField("used_percent", 23.43234543)
+  .time(Instant.now(), WritePrecision.NS)
+
+val source = Source.single(point)
+val sink = client.getWriteScalaApi.writePoint()
+val materialized = source.toMat(sink)(Keep.right)
+
+Await.result(materialized.run(), Duration.Inf)

--- a/src/writeData/clients/Scala/write.2.example
+++ b/src/writeData/clients/Scala/write.2.example
@@ -1,0 +1,21 @@
+val mem = new Mem()
+mem.host = "host1"
+mem.used_percent = 23.43234543
+mem.time = Instant.now
+
+val source = Source.single(mem)
+val sink = client.getWriteScalaApi.writeMeasurement()
+val materialized = source.toMat(sink)(Keep.right)
+Await.result(materialized.run(), Duration.Inf)
+
+
+
+@Measurement(name = "mem")
+class Mem() {
+  @Column(tag = true)
+  var host: String = _
+  @Column
+  var used_percent: Double = _
+  @Column(timestamp = true)
+  var time: Instant = _
+}

--- a/src/writeData/clients/Swift/description.md
+++ b/src/writeData/clients/Swift/description.md
@@ -11,7 +11,7 @@ import PackageDescription
 let package = Package(
     name: "MyPackage",
     dependencies: [
-        .package(name: "influxdb-client-swift", url: "https://github.com/influxdata/influxdb-client-swift", from: "0.6.0"),
+        .package(name: "influxdb-client-swift", url: "https://github.com/influxdata/influxdb-client-swift", from: "1.1.0"),
     ],
     targets: [
         .target(name: "MyModule", dependencies: [

--- a/src/writeData/clients/Swift/description.md
+++ b/src/writeData/clients/Swift/description.md
@@ -11,7 +11,7 @@ import PackageDescription
 let package = Package(
     name: "MyPackage",
     dependencies: [
-        .package(name: "influxdb-client-swift", url: "https://github.com/influxdata/influxdb-client-swift", from: "1.1.0"),
+        .package(name: "influxdb-client-swift", url: "https://github.com/influxdata/influxdb-client-swift", from: "1.2.0"),
     ],
     targets: [
         .target(name: "MyModule", dependencies: [


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb-client-java/pull/347

1. Added examples how to use Scala's `WriteAPI`:

<img width="583" alt="image" src="https://user-images.githubusercontent.com/455137/168233113-5805eb8a-935a-4cb6-8cdc-5fc31047f3b9.png">

2. Updated client versions
