### PR TITLE
fix(HelpBar): return early if helpBarMenu doesn't yet exist

### DIFF
--- a/src/pageLayout/containers/TreeNav.tsx
+++ b/src/pageLayout/containers/TreeNav.tsx
@@ -47,6 +47,9 @@ const TreeSidebar: FC<ReduxProps & RouteComponentProps> = () =>
         const helpBarMenu = document.querySelectorAll<HTMLElement>(
           '.cf-tree-nav--sub-menu-trigger'
         )[3]
+        if (!helpBarMenu) {
+          return
+        }
         if (navbarMode === 'expanded') {
           helpBarMenu.style.display = 'block'
           helpBarMenu.style.width = '243px'

--- a/src/pageLayout/containers/TreeNav.tsx
+++ b/src/pageLayout/containers/TreeNav.tsx
@@ -57,7 +57,7 @@ const TreeSidebar: FC<ReduxProps & RouteComponentProps> = () =>
           helpBarMenu.style.width = '44px'
         }
       }
-    }, [setNavbarMode, navbarMode])
+    }, [navbarMode])
 
     if (presentationMode || !org) {
       return null


### PR DESCRIPTION
fix for Help Bar feature crashing UI when user signs out and signs in again. 

`useEffect` hook in `TreeNav` component targets the help and support nav element and adjusts the style depending on the mode of the nav bar.
The purpose behind this code is to keep the sub nav items rendering on the side whether the nav is expanded or collapsed 

Error we see in the console in prod reads `cannot read properties of undefined`. This error occurs only when user switches orgs. Pr introduces a fix -  an `if` statement inside hook that returns early if targeted element doesn't exist. 