### PR TITLE
fix: add fallback OrgsState for getAllOrgs

### DIFF
--- a/src/resources/selectors/index.ts
+++ b/src/resources/selectors/index.ts
@@ -79,5 +79,5 @@ export const getAllOrgs = (state: AppState): OrgsState => {
     status: RemoteDataState.Error,
     org: {id: ''},
   }
-  return get(state, 'resources.orgs', errorOrgsState) || errorOrgsState
+  return get(state, 'resources.orgs', errorOrgsState)
 }

--- a/src/resources/selectors/index.ts
+++ b/src/resources/selectors/index.ts
@@ -74,5 +74,10 @@ export const getLabels = (state: AppState, labelIDs: string[]): Label[] => {
 export const getAllTokensResources = (state: AppState): PermissionTypes[] =>
   get(state, 'resources.tokens.allResources', []) || []
 
-export const getAllOrgs = (state: AppState): OrgsState =>
-  get(state, 'resources.orgs', {}) || {}
+export const getAllOrgs = (state: AppState): OrgsState => {
+  const errorOrgsState = {
+    status: RemoteDataState.Error,
+    org: {id: ''},
+  }
+  return get(state, 'resources.orgs', errorOrgsState) || errorOrgsState
+}

--- a/src/shared/containers/GetOrganizations.tsx
+++ b/src/shared/containers/GetOrganizations.tsx
@@ -76,7 +76,7 @@ const GetOrganizations: FunctionComponent = () => {
         accountType: account_type,
         accountCreatedAt: account_created_at = '',
       } = quartzMe
-      const {id: orgId = ''} = org
+      const orgId = org?.id ?? ''
       window.dataLayer = window.dataLayer ?? []
       window.dataLayer.push({
         identity: {


### PR DESCRIPTION
Part of #4464 

Adds an error state to `OrgsState` when `resources.orgs` cannot be found. Initially, `OrgsState` is set by the reducer, which should not use this fallback unless `resources.orgs` was modified by something else.