### PR TITLE
fix(flux-4720): temporary fix to hardcode top20 examples, plus add cursor awarenss in function injection

### DIFF
--- a/cypress/e2e/shared/explorerVisualizations.test.ts
+++ b/cypress/e2e/shared/explorerVisualizations.test.ts
@@ -89,6 +89,7 @@ describe('visualizations', () => {
           cy.log('check to see if new aggregate rate is at the bottom')
           cy.get('.view-line')
             .last()
+            .prev()
             .contains('aggregate.')
           cy.getByTestID('flux-editor').should('exist')
           cy.getByTestID('flux-editor').monacoType(`yoyoyoyoyo`)

--- a/src/flows/context/editor.tsx
+++ b/src/flows/context/editor.tsx
@@ -18,6 +18,7 @@ export interface InjectionOptions {
   header?: string | null
   text: string
   type: InjectionType
+  typeParansAfter?: boolean
 }
 
 export interface EditorContextType {
@@ -72,7 +73,7 @@ export const EditorProvider: FC = ({children}) => {
         return {}
       }
 
-      const {header, text: initT, type} = options
+      const {header, text: initT, type, typeParansAfter} = options
       const {
         row,
         column: initC,
@@ -88,7 +89,7 @@ export const EditorProvider: FC = ({children}) => {
       }
 
       if (shouldEndInNewLine) {
-        text = `${text}\n`
+        text = `${text.trim()}\n`
       }
 
       const column = type == InjectionType.OnOwnLine ? 1 : initC
@@ -115,6 +116,16 @@ export const EditorProvider: FC = ({children}) => {
 
       editor.executeEdits('', edits)
       updateText(editor.getValue())
+      if (typeParansAfter) {
+        setTimeout(() => {
+          editor.focus()
+          editor.setPosition({
+            lineNumber: row,
+            column: column + text.length - 1,
+          })
+          editor.trigger('', 'editor.action.triggerSuggest', {})
+        }, 0)
+      }
     },
     [editor, calcInjectiontPosition, updateText]
   )

--- a/src/flows/context/editor.tsx
+++ b/src/flows/context/editor.tsx
@@ -7,18 +7,12 @@ import React, {
 } from 'react'
 import {EditorType} from 'src/types'
 import {PipeContext} from 'src/flows/context/pipe'
-
-export enum InjectionType {
-  OnOwnLine = 'onOwnLine',
-  SameLine = 'sameLine',
-}
-
-interface InjectionPosition {
-  row: number
-  column: number
-  shouldStartWithNewLine: boolean
-  shouldEndInNewLine: boolean
-}
+import {
+  InjectionType,
+  InjectionPosition,
+  calcInjectionPosition,
+} from 'src/shared/utils/fluxFunctions'
+export {InjectionType, InjectionPosition} from 'src/shared/utils/fluxFunctions'
 
 export interface InjectionOptions {
   header?: string | null
@@ -67,58 +61,7 @@ export const EditorProvider: FC = ({children}) => {
       if (!editor) {
         return {}
       }
-      const {lineNumber, column: col} = editor.getPosition()
-      let row = lineNumber
-      let column = col
-
-      const queryText = editor.getModel().getValue()
-      const split = queryText.split('\n')
-      const getCurrentLineText = () => {
-        // row is not zero indexed in monaco editor. 1..N
-        return (split[row - 1] || split[split.length - 1]).trimEnd()
-      }
-
-      let currentLineText = getCurrentLineText()
-      // column is not zero indexed in monnao editor. 1..N
-      let textAheadOfCursor = currentLineText.slice(0, column - 1).trim()
-      let textBehindCursor = currentLineText.slice(column - 1).trim()
-
-      // if cursor has text in front of it, and should be onOwnRow
-      if (type == InjectionType.OnOwnLine && textAheadOfCursor) {
-        row++
-        column = 1
-      }
-      // edge case for when user toggles to the script editor
-      // this defaults the cursor to the initial position (top-left, 1:1 position)
-      const [currentRange] = editor.getVisibleRanges()
-      if (row === 1 && column === 1) {
-        row = currentRange.endLineNumber + 1
-      }
-
-      if (row !== lineNumber) {
-        currentLineText = getCurrentLineText()
-        textAheadOfCursor = currentLineText.slice(0, column - 1).trim()
-        textBehindCursor = currentLineText.slice(column - 1).trim()
-      }
-
-      let shouldEndInNewLine = false
-      // if cursor has text behind it, and should be onOwnRow
-      if (type == InjectionType.OnOwnLine && textBehindCursor) {
-        shouldEndInNewLine = true
-      }
-
-      const cursorInMiddleOfText = textAheadOfCursor && textBehindCursor
-      if (type == InjectionType.OnOwnLine && cursorInMiddleOfText) {
-        row++
-        column = 1
-        shouldEndInNewLine = true
-      }
-
-      // if we asked to insert on a row out-of-range
-      // then need to manually append newline to front of row
-      const shouldStartWithNewLine = row > currentRange.endLineNumber
-
-      return {row, column, shouldStartWithNewLine, shouldEndInNewLine}
+      return calcInjectionPosition(editor, type)
     },
     [editor]
   )

--- a/src/flows/context/editor.tsx
+++ b/src/flows/context/editor.tsx
@@ -81,16 +81,13 @@ export const EditorProvider: FC = ({children}) => {
         shouldStartWithNewLine,
         shouldEndInNewLine,
       } = calcInjectiontPosition(type)
-      let text = ''
 
+      let text = initT.trimRight()
       if (shouldStartWithNewLine) {
-        text = `\n${initT}`
-      } else {
-        text = initT
+        text = `\n${text}`
       }
-
       if (shouldEndInNewLine) {
-        text = `${text.trim()}\n`
+        text = `${text}\n`
       }
 
       const column = type == InjectionType.OnOwnLine ? 1 : initC
@@ -102,13 +99,13 @@ export const EditorProvider: FC = ({children}) => {
         },
       ]
 
-      if (
+      const addHeader =
         header &&
         !editor
           .getModel()
           .getValue()
           .includes(header)
-      ) {
+      if (addHeader) {
         edits.unshift({
           range: new monaco.Range(1, 1, 1, 1),
           text: `${header}\n`,
@@ -119,11 +116,18 @@ export const EditorProvider: FC = ({children}) => {
       updateText(editor.getValue())
 
       if (isFlagEnabled('fluxDynamicDocs') && triggerSuggest) {
+        let columnOffset = 1
+        if (shouldStartWithNewLine) {
+          columnOffset++
+        }
+        if (shouldEndInNewLine) {
+          columnOffset++
+        }
         setTimeout(() => {
           editor.focus()
           editor.setPosition({
-            lineNumber: row,
-            column: column + text.length - 1,
+            lineNumber: addHeader ? row + 1 : row,
+            column: column + text.length - columnOffset,
           })
           editor.trigger('', 'editor.action.triggerSuggest', {})
         }, 0)

--- a/src/flows/context/editor.tsx
+++ b/src/flows/context/editor.tsx
@@ -13,12 +13,13 @@ import {
   calcInjectionPosition,
 } from 'src/shared/utils/fluxFunctions'
 export {InjectionType, InjectionPosition} from 'src/shared/utils/fluxFunctions'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 export interface InjectionOptions {
   header?: string | null
   text: string
   type: InjectionType
-  typeParansAfter?: boolean
+  triggerSuggest?: boolean
 }
 
 export interface EditorContextType {
@@ -73,7 +74,7 @@ export const EditorProvider: FC = ({children}) => {
         return {}
       }
 
-      const {header, text: initT, type, typeParansAfter} = options
+      const {header, text: initT, type, triggerSuggest} = options
       const {
         row,
         column: initC,
@@ -116,7 +117,8 @@ export const EditorProvider: FC = ({children}) => {
 
       editor.executeEdits('', edits)
       updateText(editor.getValue())
-      if (typeParansAfter) {
+
+      if (isFlagEnabled('fluxDynamicDocs') && triggerSuggest) {
         setTimeout(() => {
           editor.focus()
           editor.setPosition({

--- a/src/flows/pipes/RawFluxEditor/view.tsx
+++ b/src/flows/pipes/RawFluxEditor/view.tsx
@@ -38,6 +38,10 @@ import DynamicFunctions from 'src/flows/pipes/RawFluxEditor/FunctionsList/Dynami
 import 'src/flows/pipes/RawFluxEditor/style.scss'
 
 // Utils
+import {
+  isPipeTransformation,
+  functionRequiresNewLine,
+} from 'src/shared/utils/fluxFunctions'
 import {event} from 'src/cloud/utils/reporting'
 import {CLOUD} from 'src/shared/constants'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
@@ -75,19 +79,9 @@ const Query: FC<PipeProp> = ({Context}) => {
 
   const injectIntoEditor = useCallback(
     (fn): void => {
-      let text = ''
-      if (CLOUD && isFlagEnabled('fluxDynamicDocs')) {
-        // only fluxTypes with <- sign require a pipe forward sign
-        text = fn.fluxType.startsWith('<-', 1)
-          ? `  |> ${fn.example}`
-          : `${fn.example}`
-      } else {
-        if (fn.name === 'from' || fn.name === 'union') {
-          text = `${fn.example}`
-        } else {
-          text = `  |> ${fn.example}`
-        }
-      }
+      const text = isPipeTransformation(fn)
+        ? `  |> ${fn.example}`
+        : `${fn.example}`
 
       const getHeader = fn => {
         let importStatement = null
@@ -106,9 +100,14 @@ const Query: FC<PipeProp> = ({Context}) => {
         return importStatement
       }
 
+      const type =
+        isPipeTransformation(fn) || functionRequiresNewLine(fn)
+          ? InjectionType.OnOwnLine
+          : InjectionType.SameLine
+
       const options = {
         text,
-        type: InjectionType.OnOwnLine,
+        type,
         header: getHeader(fn),
       }
       inject(options)

--- a/src/flows/pipes/RawFluxEditor/view.tsx
+++ b/src/flows/pipes/RawFluxEditor/view.tsx
@@ -109,6 +109,7 @@ const Query: FC<PipeProp> = ({Context}) => {
         text,
         type,
         header: getHeader(fn),
+        typeParansAfter: true,
       }
       inject(options)
     },

--- a/src/flows/pipes/RawFluxEditor/view.tsx
+++ b/src/flows/pipes/RawFluxEditor/view.tsx
@@ -109,7 +109,7 @@ const Query: FC<PipeProp> = ({Context}) => {
         text,
         type,
         header: getHeader(fn),
-        typeParansAfter: true,
+        triggerSuggest: true,
       }
       inject(options)
     },

--- a/src/shared/utils/fluxExample.test.ts
+++ b/src/shared/utils/fluxExample.test.ts
@@ -62,7 +62,7 @@ describe('Flux example functions and values', () => {
     }
 
     expect(getFluxExample(exampleFunc).example).toEqual(
-      `${exampleFunc.package}.${exampleFunc.name}(  )`
+      `${exampleFunc.package}.${exampleFunc.name}()`
     )
   })
 

--- a/src/shared/utils/fluxExample.ts
+++ b/src/shared/utils/fluxExample.ts
@@ -1,9 +1,46 @@
 import {FluxFunction} from 'src/types/shared'
 
+// temporary solution, for the top 20 functions
+// longterm solution requires changes in the payload from the backend (flux docs)
+const TOP_20 = {
+  'universe.filter': 'filter(fn: (r) => r._measurement == "cpu")',
+  'universe.range': 'range(start: -15m, stop: now())',
+  'universe.sort': 'sort(columns: ["_value"], desc: false)',
+  'universe.keep': 'keep(columns: ["col1", "col2"])',
+  'universe.yield': 'yield(name: "custom-name")',
+  'universe.map': 'map(fn: (r) => ({ r with _value: r._value * r._value }))',
+  'universe.pivot':
+    'pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")',
+  'universe.last': 'last()',
+  'universe.fill': 'fill(column: "_value", usePrevious: true)',
+  'universe.time': 'time(v: r._value)',
+  'universe.union': 'union(tables: [table1, table2])',
+  'universe.int': 'int(v: r._value)',
+  'events.duration': `events.duration(
+    unit: 1ns,
+    columnName: "duration",
+    timeColumn: "_time",
+    stopColumn: "_stop",
+    stop: 2020-01-01T00:00:00Z
+)`,
+  'universe.group': 'group(columns: ["host", "_measurement"], mode:"by")',
+  'universe.aggregateWindow':
+    'aggregateWindow(every: v.windowPeriod, fn: mean)',
+  'universe.limit': 'limit(n:10, offset: 0)',
+  'universe.now': 'now()',
+  'universe.distinct': 'distinct(column: "host")',
+  'universe.sum': 'sum(column: "_value")',
+}
+
 export const getFluxExample = (func: FluxFunction) => {
   const {fluxParameters = [], kind, name, package: packageName} = func
 
   let example = `${packageName}.${name}`
+
+  if (!!TOP_20[example]) {
+    return {...func, example: TOP_20[example]}
+  }
+
   if (kind.toLowerCase() === 'function') {
     let injectedParameters = ''
     for (const parameter of fluxParameters) {

--- a/src/shared/utils/fluxExample.ts
+++ b/src/shared/utils/fluxExample.ts
@@ -56,8 +56,8 @@ export const getFluxExample = (func: FluxFunction) => {
     }
     example =
       packageName === 'universe'
-        ? `${name}(${injectedParameters})`
-        : `${packageName}.${name}(${injectedParameters})`
+        ? `${name}(${injectedParameters.trim()})`
+        : `${packageName}.${name}(${injectedParameters.trim()})`
   }
   return {...func, example}
 }

--- a/src/shared/utils/fluxExample.ts
+++ b/src/shared/utils/fluxExample.ts
@@ -54,10 +54,13 @@ export const getFluxExample = (func: FluxFunction) => {
         injectedParameters = `${injectedParameters} `
       }
     }
+    injectedParameters = injectedParameters.trim().length
+      ? injectedParameters
+      : injectedParameters.trim()
     example =
       packageName === 'universe'
-        ? `${name}(${injectedParameters.trim()})`
-        : `${packageName}.${name}(${injectedParameters.trim()})`
+        ? `${name}(${injectedParameters})`
+        : `${packageName}.${name}(${injectedParameters})`
   }
   return {...func, example}
 }

--- a/src/shared/utils/fluxExample.ts
+++ b/src/shared/utils/fluxExample.ts
@@ -55,7 +55,7 @@ export const getFluxExample = (func: FluxFunction) => {
       }
     }
     injectedParameters = injectedParameters.trim().length
-      ? injectedParameters
+      ? injectedParameters.trimLeft()
       : injectedParameters.trim()
     example =
       packageName === 'universe'

--- a/src/shared/utils/fluxFunctions.ts
+++ b/src/shared/utils/fluxFunctions.ts
@@ -20,3 +20,70 @@ export const functionRequiresNewLine = (funcName: string): boolean => {
       return false
   }
 }
+
+export enum InjectionType {
+  OnOwnLine = 'onOwnLine',
+  SameLine = 'sameLine',
+}
+
+export interface InjectionPosition {
+  row: number
+  column: number
+  shouldStartWithNewLine: boolean
+  shouldEndInNewLine: boolean
+}
+
+export function calcInjectionPosition(editor, type: InjectionType) {
+  const {lineNumber, column: col} = editor.getPosition()
+  let row = lineNumber
+  let column = col
+
+  const queryText = editor.getModel().getValue()
+  const split = queryText.split('\n')
+  const getCurrentLineText = () => {
+    // row is not zero indexed in monaco editor. 1..N
+    return (split[row - 1] || split[split.length - 1]).trimEnd()
+  }
+
+  let currentLineText = getCurrentLineText()
+  // column is not zero indexed in monnao editor. 1..N
+  let textAheadOfCursor = currentLineText.slice(0, column - 1).trim()
+  let textBehindCursor = currentLineText.slice(column - 1).trim()
+
+  // if cursor has text in front of it, and should be onOwnRow
+  if (type == InjectionType.OnOwnLine && textAheadOfCursor) {
+    row++
+    column = 1
+  }
+  // edge case for when user toggles to the script editor
+  // this defaults the cursor to the initial position (top-left, 1:1 position)
+  const [currentRange] = editor.getVisibleRanges()
+  if (row === 1 && column === 1) {
+    row = currentRange.endLineNumber + 1
+  }
+
+  if (row !== lineNumber) {
+    currentLineText = getCurrentLineText()
+    textAheadOfCursor = currentLineText.slice(0, column - 1).trim()
+    textBehindCursor = currentLineText.slice(column - 1).trim()
+  }
+
+  let shouldEndInNewLine = false
+  // if cursor has text behind it, and should be onOwnRow
+  if (type == InjectionType.OnOwnLine && textBehindCursor) {
+    shouldEndInNewLine = true
+  }
+
+  const cursorInMiddleOfText = textAheadOfCursor && textBehindCursor
+  if (type == InjectionType.OnOwnLine && cursorInMiddleOfText) {
+    row++
+    column = 1
+    shouldEndInNewLine = true
+  }
+
+  // if we asked to insert on a row out-of-range
+  // then need to manually append newline to front of row
+  const shouldStartWithNewLine = row > currentRange.endLineNumber
+
+  return {row, column, shouldStartWithNewLine, shouldEndInNewLine}
+}

--- a/src/shared/utils/fluxFunctions.ts
+++ b/src/shared/utils/fluxFunctions.ts
@@ -33,7 +33,10 @@ export interface InjectionPosition {
   shouldEndInNewLine: boolean
 }
 
-export function calcInjectionPosition(editor, type: InjectionType) {
+export function calcInjectionPosition(
+  editor,
+  type: InjectionType
+): InjectionPosition {
   const {lineNumber, column: col} = editor.getPosition()
   let row = lineNumber
   let column = col
@@ -77,8 +80,10 @@ export function calcInjectionPosition(editor, type: InjectionType) {
   const cursorInMiddleOfText = textAheadOfCursor && textBehindCursor
   if (type == InjectionType.OnOwnLine && cursorInMiddleOfText) {
     row++
-    column = 1
     shouldEndInNewLine = true
+  }
+  if (type == InjectionType.OnOwnLine) {
+    column = 1
   }
 
   // if we asked to insert on a row out-of-range
@@ -86,4 +91,27 @@ export function calcInjectionPosition(editor, type: InjectionType) {
   const shouldStartWithNewLine = row > currentRange.endLineNumber
 
   return {row, column, shouldStartWithNewLine, shouldEndInNewLine}
+}
+
+export const moveCursorAndTriggerSuggest = (
+  editor,
+  {row, column, shouldStartWithNewLine, shouldEndInNewLine},
+  hasHeader,
+  textLength
+) => {
+  let columnOffset = 1
+  if (shouldStartWithNewLine) {
+    columnOffset++
+  }
+  if (shouldEndInNewLine) {
+    columnOffset++
+  }
+  setTimeout(() => {
+    editor.focus()
+    editor.setPosition({
+      lineNumber: hasHeader ? row + 1 : row,
+      column: column + textLength - columnOffset,
+    })
+    editor.trigger('', 'editor.action.triggerSuggest', {})
+  }, 0)
 }

--- a/src/shared/utils/fluxFunctions.ts
+++ b/src/shared/utils/fluxFunctions.ts
@@ -1,0 +1,22 @@
+import {FluxFunction} from 'src/types/shared'
+import {CLOUD} from 'src/shared/constants'
+import {FROM, UNION} from 'src/shared/constants/fluxFunctions'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+
+export const isPipeTransformation = (func: FluxFunction) => {
+  if (CLOUD && isFlagEnabled('fluxDynamicDocs')) {
+    return func.fluxType.startsWith('<-', 1)
+  }
+  return !['from', 'union'].includes(func.name)
+}
+
+export const functionRequiresNewLine = (funcName: string): boolean => {
+  switch (funcName) {
+    case FROM.name:
+    case UNION.name: {
+      return true
+    }
+    default:
+      return false
+  }
+}

--- a/src/timeMachine/utils/insertFunction.ts
+++ b/src/timeMachine/utils/insertFunction.ts
@@ -1,23 +1,11 @@
 // Constants
 import {CLOUD} from 'src/shared/constants'
-import {FROM, UNION} from 'src/shared/constants/fluxFunctions'
 
 // Types
 import {FluxFunction} from 'src/types/shared'
 
 // Utils
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
-
-export const functionRequiresNewLine = (funcName: string): boolean => {
-  switch (funcName) {
-    case FROM.name:
-    case UNION.name: {
-      return true
-    }
-    default:
-      return false
-  }
-}
 
 export const generateImport = (
   funcPackage: string,


### PR DESCRIPTION
Temporary fix for https://github.com/influxdata/flux/issues/4720

## Bug:
* Pro: have dynamic list of available flux functions, served from the backend.
* Con: we lost the hardcoded examples for flux functions.
  * suggestions from LSP are not sufficient. 

## Solution:
* Hardcode the top 20 flux functions, with an example.
  * future plans are to have the backend (or LSP) provide data for examples. But not yet ready. 
* Make sure the example insertion considers the cursor position, versus the type of insertion (e.g. on the same line, or another line).
    * This just meant using existing code for `calcInjectionPosition()`.
    * knows when the flux function should be injected on the same line, vs different line. Then does the math.
    * For different line (on own line), injects based on where cursor is in line --> will inject in line before or after (cursor awareness).
* After insert, poke the LSP for suggestions.
    * We can readily turn this off, if it’s not liked by people. See the vids.


## Tradeoffs made:
* Did not include the top20 function `universe.from`, since we don’t use it as an injected function.
   * Injected from is only package-scoped `csv.from()`, and not the universe.from().
* Did not include all possible parameter arguments (completeness) per example.
    * Otherwise, we have a lot of `tables: [table1, table2]` for many functions.
    * And this may imply (incorrectly) that these arguments are mandatory for the function.
* Instead, used the previously hardcoded functions as a guide of what is useful.



## Future work (not this PR):
* The TimeMachineFluxEditor is not yet using the editor.context.
    * It’s almost to the point that it can use this context. 
    * Except that we have the EditorContext still consuming from the PipeContext. So cannot use in timeMachine yet.
* As a result of this^^ we have:
    * Tight coupling between the `src/shared/utils/fluxFunctions` and the `src/flows/context/editor`


## Visual evidence:

timeMachine, in top 20:

https://user-images.githubusercontent.com/10232835/168706296-d3f612ec-36e4-4d43-9437-92453af45d45.mp4


timeMachine, not top 20:

https://user-images.githubusercontent.com/10232835/168706177-00c38a6e-1cbd-4018-b14d-5db1cd14edce.mp4

notebooks, in top 20:

https://user-images.githubusercontent.com/10232835/168707206-3a8d63ce-a226-4079-9b34-88caa095f0a5.mp4



