### PR TITLE
fix: update usage panel to use Credit 250 experiment

### DIFF
--- a/src/checkout/CheckoutForm.tsx
+++ b/src/checkout/CheckoutForm.tsx
@@ -39,10 +39,7 @@ import {CheckoutContext} from 'src/checkout/context/checkout'
 import {event} from 'src/cloud/utils/reporting'
 
 // Constants
-import {
-  CREDIT_250_EXPERIMENT_ID,
-  PAYG_CREDIT_EXPERIMENT_ID,
-} from 'src/shared/constants'
+import {CREDIT_250_EXPERIMENT_ID} from 'src/shared/constants'
 
 // Utils
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
@@ -124,7 +121,7 @@ const CheckoutForm: FC = () => {
 
               {isPaygCreditActive && (
                 <GoogleOptimizeExperiment
-                  experimentID={PAYG_CREDIT_EXPERIMENT_ID}
+                  experimentID={CREDIT_250_EXPERIMENT_ID}
                   variants={[
                     <div
                       className="checkout-form--banner"

--- a/src/checkout/CheckoutForm.tsx
+++ b/src/checkout/CheckoutForm.tsx
@@ -79,7 +79,7 @@ const CheckoutForm: FC = () => {
           >
             Upgrade to Usage-Based Account
           </h1>
-          {isFlagEnabled('credit250Experiment') && (
+          {isFlagEnabled('credit250Experiment') && !isPaygCreditActive && (
             <GoogleOptimizeExperiment
               experimentID={CREDIT_250_EXPERIMENT_ID}
               variants={[

--- a/src/checkout/context/checkout.tsx
+++ b/src/checkout/context/checkout.tsx
@@ -24,9 +24,9 @@ import {
 } from 'src/shared/copy/notifications'
 import {
   BALANCE_THRESHOLD_DEFAULT,
+  CREDIT_250_EXPERIMENT_ID,
   EMPTY_ZUORA_PARAMS,
 } from 'src/shared/constants'
-import {PAYG_CREDIT_EXPERIMENT_ID} from 'src/shared/constants'
 
 // Types
 import {CreditCardParams, RemoteDataState} from 'src/types'
@@ -86,8 +86,6 @@ export const DEFAULT_CONTEXT: CheckoutContextType = {
 export const CheckoutContext = React.createContext<CheckoutContextType>(
   DEFAULT_CONTEXT
 )
-
-const CHECKOUT_PARAM_CODE = '757vMPJiCMdTFkO4'
 
 export const CheckoutProvider: FC<Props> = React.memo(({children}) => {
   const dispatch = useDispatch()
@@ -258,11 +256,8 @@ export const CheckoutProvider: FC<Props> = React.memo(({children}) => {
     return errs.length
   }
 
-  const query = new URLSearchParams(window.location.search)
-  const checkoutCode = query.get('c')
   const isPaygCreditActive =
-    getExperimentVariantId(PAYG_CREDIT_EXPERIMENT_ID) === '1' &&
-    checkoutCode === CHECKOUT_PARAM_CODE
+    getExperimentVariantId(CREDIT_250_EXPERIMENT_ID) === '1'
 
   const handleSubmit = useCallback(
     async (paymentMethodId: string) => {

--- a/src/usage/context/usage.test.ts
+++ b/src/usage/context/usage.test.ts
@@ -1,0 +1,47 @@
+import {calculateCreditDaysUsed} from 'src/usage/context/usage'
+
+describe('calculateCreditDaysUsed', () => {
+  const ONE_DAY_MILLSECONDS = 1000 * 60 * 60 * 24
+
+  it('handles falsy values as invalid date', () => {
+    expect(calculateCreditDaysUsed(undefined)).toEqual(-1)
+    expect(calculateCreditDaysUsed(null)).toEqual(-1)
+    expect(calculateCreditDaysUsed('')).toEqual(-1)
+  })
+
+  it('handles valid dates in the past', () => {
+    const yesterday = new Date(Date.now() - ONE_DAY_MILLSECONDS).toISOString()
+    const twoDaysAgo = new Date(
+      Date.now() - 2 * ONE_DAY_MILLSECONDS
+    ).toISOString()
+    const oneWeekAgo = new Date(
+      Date.now() - 7 * ONE_DAY_MILLSECONDS
+    ).toISOString()
+    const thirtyDaysAgo = new Date(
+      Date.now() - 30 * ONE_DAY_MILLSECONDS
+    ).toISOString()
+
+    expect(calculateCreditDaysUsed(yesterday)).toEqual(1)
+    expect(calculateCreditDaysUsed(twoDaysAgo)).toEqual(2)
+    expect(calculateCreditDaysUsed(oneWeekAgo)).toEqual(7)
+    expect(calculateCreditDaysUsed(thirtyDaysAgo)).toEqual(30)
+  })
+
+  it('handles valid dates in the future', () => {
+    const tomorrow = new Date(Date.now() + ONE_DAY_MILLSECONDS).toISOString()
+    const twoDaysFromNow = new Date(
+      Date.now() + 2 * ONE_DAY_MILLSECONDS
+    ).toISOString()
+    const oneWeekFromNow = new Date(
+      Date.now() + 7 * ONE_DAY_MILLSECONDS
+    ).toISOString()
+    const thirtyDaysFromNow = new Date(
+      Date.now() + 30 * ONE_DAY_MILLSECONDS
+    ).toISOString()
+
+    expect(calculateCreditDaysUsed(tomorrow)).toEqual(-1)
+    expect(calculateCreditDaysUsed(twoDaysFromNow)).toEqual(-2)
+    expect(calculateCreditDaysUsed(oneWeekFromNow)).toEqual(-7)
+    expect(calculateCreditDaysUsed(thirtyDaysFromNow)).toEqual(-30)
+  })
+})

--- a/src/usage/context/usage.test.ts
+++ b/src/usage/context/usage.test.ts
@@ -4,9 +4,9 @@ describe('calculateCreditDaysUsed', () => {
   const ONE_DAY_MILLSECONDS = 1000 * 60 * 60 * 24
 
   it('handles falsy values as invalid date', () => {
-    expect(calculateCreditDaysUsed(undefined)).toEqual(-1)
-    expect(calculateCreditDaysUsed(null)).toEqual(-1)
-    expect(calculateCreditDaysUsed('')).toEqual(-1)
+    expect(calculateCreditDaysUsed(undefined)).toEqual(NaN)
+    expect(calculateCreditDaysUsed(null)).toEqual(NaN)
+    expect(calculateCreditDaysUsed('')).toEqual(NaN)
   })
 
   it('handles valid dates in the past', () => {

--- a/src/usage/context/usage.tsx
+++ b/src/usage/context/usage.tsx
@@ -16,6 +16,7 @@ import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 // Constants
 import {PAYG_CREDIT_DAYS} from 'src/shared/constants'
 import {DEFAULT_USAGE_TIME_RANGE} from 'src/shared/constants/timeRanges'
+import {MILLISECONDS_IN_ONE_DAY} from 'src/utils/datetime/constants'
 
 // Types
 import {
@@ -80,7 +81,6 @@ export const UsageContext = React.createContext<UsageContextType>(
 )
 
 export const calculateCreditDaysUsed = (creditStartDate: string): number => {
-  const MILLISECONDS_IN_ONE_DAY = 1000 * 60 * 60 * 24
   if (!creditStartDate) {
     return NaN
   }

--- a/src/usage/context/usage.tsx
+++ b/src/usage/context/usage.tsx
@@ -82,7 +82,7 @@ export const UsageContext = React.createContext<UsageContextType>(
 export const calculateCreditDaysUsed = (creditStartDate: string): number => {
   const MILLISECONDS_IN_ONE_DAY = 1000 * 60 * 60 * 24
   if (!creditStartDate) {
-    return -1
+    return NaN
   }
   const startDate = new Date(creditStartDate)
   const current = new Date()

--- a/src/usage/context/usage.tsx
+++ b/src/usage/context/usage.tsx
@@ -79,6 +79,17 @@ export const UsageContext = React.createContext<UsageContextType>(
   DEFAULT_CONTEXT
 )
 
+export const calculateCreditDaysUsed = (creditStartDate: string): number => {
+  const MILLISECONDS_IN_ONE_DAY = 1000 * 60 * 60 * 24
+  if (!creditStartDate) {
+    return -1
+  }
+  const startDate = new Date(creditStartDate)
+  const current = new Date()
+  const diffTime = current.getTime() - startDate.getTime()
+  return Math.floor(diffTime / MILLISECONDS_IN_ONE_DAY)
+}
+
 export const UsageProvider: FC<Props> = React.memo(({children}) => {
   const [billingDateTime, setBillingDateTime] = useState('')
   const [usageVectors, setUsageVectors] = useState([])
@@ -103,12 +114,12 @@ export const UsageProvider: FC<Props> = React.memo(({children}) => {
   const {quartzMe} = useSelector(getMe)
   const parser = isFlagEnabled('fastFromFlux') ? fastFromFlux : fromFlux
 
-  const creditDaysUsed = useMemo(() => {
-    const startDate = new Date(quartzMe?.paygCreditStartDate)
-    const current = new Date()
-    const diffTime = Math.abs(current.getTime() - startDate.getTime())
-    return Math.floor(diffTime / (1000 * 60 * 60 * 24))
-  }, [quartzMe?.paygCreditStartDate])
+  const paygCreditStartDate = quartzMe?.paygCreditStartDate ?? ''
+
+  const creditDaysUsed = useMemo(
+    () => calculateCreditDaysUsed(paygCreditStartDate),
+    [paygCreditStartDate]
+  )
 
   const paygCreditEnabled =
     creditDaysUsed >= 0 && creditDaysUsed < PAYG_CREDIT_DAYS

--- a/src/utils/datetime/constants.ts
+++ b/src/utils/datetime/constants.ts
@@ -5,3 +5,5 @@ export const RFC3339_PATTERN = /(\d\d\d\d)(-)?(\d\d)(-)?(\d\d)(\s|T)?(\d\d)(:)?(
 // Hard-coded dates required by the backend for caching purposes
 export const CACHING_REQUIRED_START_DATE = '1677-09-21T00:12:43.145224194Z'
 export const CACHING_REQUIRED_END_DATE = '2262-04-11T23:47:16.854775806Z'
+
+export const MILLISECONDS_IN_ONE_DAY = 1000 * 60 * 60 * 24


### PR DESCRIPTION
Closes #4385 
Also part of quartz 6164

- Updates the Usage Panel to work with the Credit 250 Experiment

<img width="1728" alt="Screen Shot 2022-05-17 at 5 03 32 PM" src="https://user-images.githubusercontent.com/10736577/168935049-95907ec6-a904-455d-a16f-4bfc9ec54987.png">

