### PR TITLE
fix: add missing events for node.js wizard and go wizard

### DIFF
--- a/src/homepageExperience/containers/HomepageContainer.tsx
+++ b/src/homepageExperience/containers/HomepageContainer.tsx
@@ -54,7 +54,15 @@ export const HomepageContainer: FC = () => {
   const squareGridCardSize = '200px'
 
   // events handling
-  const logPythonEvent = () => {
+  const logGoWizardClick = () => {
+    event('firstMile.goWizard.clicked')
+  }
+
+  const logNodeWizardClick = () => {
+    event('firstMile.goWizard.clicked')
+  }
+
+  const logPythonWizardClick = () => {
     event('firstMile.pythonWizard.clicked')
   }
 
@@ -91,7 +99,7 @@ export const HomepageContainer: FC = () => {
                       <Link
                         to={pythonWizardLink}
                         style={linkStyle}
-                        onClick={logPythonEvent}
+                        onClick={logPythonWizardClick}
                       >
                         <div
                           className="homepage-wizard-language-tile"
@@ -103,7 +111,11 @@ export const HomepageContainer: FC = () => {
                       </Link>
                     </ResourceCard>
                     <ResourceCard style={cardStyle}>
-                      <Link to={javaScriptNodeLink} style={linkStyle}>
+                      <Link
+                        to={javaScriptNodeLink}
+                        style={linkStyle}
+                        onClick={logNodeWizardClick}
+                      >
                         <div className="homepage-wizard-language-tile">
                           <h5>JavaScript/Node.js</h5>
                           {NodejsIcon}
@@ -111,7 +123,11 @@ export const HomepageContainer: FC = () => {
                       </Link>
                     </ResourceCard>
                     <ResourceCard style={cardStyle}>
-                      <Link to={golangLink} style={linkStyle}>
+                      <Link
+                        to={golangLink}
+                        style={linkStyle}
+                        onClick={logGoWizardClick}
+                      >
                         <div className="homepage-wizard-language-tile">
                           <h5>Go</h5>
                           {GoIcon}

--- a/src/homepageExperience/containers/HomepageContainer.tsx
+++ b/src/homepageExperience/containers/HomepageContainer.tsx
@@ -58,12 +58,16 @@ export const HomepageContainer: FC = () => {
     event('firstMile.goWizard.clicked')
   }
 
-  const logNodeWizardClick = () => {
-    event('firstMile.goWizard.clicked')
+  const logNodeJSWizardClick = () => {
+    event('firstMile.nodejsWizard.clicked')
   }
 
   const logPythonWizardClick = () => {
     event('firstMile.pythonWizard.clicked')
+  }
+
+  const logMoreButtonClick = () => {
+    event('firstMile.moreButton.clicked')
   }
 
   return (
@@ -114,7 +118,7 @@ export const HomepageContainer: FC = () => {
                       <Link
                         to={javaScriptNodeLink}
                         style={linkStyle}
-                        onClick={logNodeWizardClick}
+                        onClick={logNodeJSWizardClick}
                       >
                         <div className="homepage-wizard-language-tile">
                           <h5>JavaScript/Node.js</h5>
@@ -135,7 +139,11 @@ export const HomepageContainer: FC = () => {
                       </Link>
                     </ResourceCard>
                     <ResourceCard style={cardStyle}>
-                      <Link to={loadDataSourcesLink} style={moreStyle}>
+                      <Link
+                        to={loadDataSourcesLink}
+                        style={moreStyle}
+                        onClick={logMoreButtonClick}
+                      >
                         <div className="homepage-wizard-language-tile">
                           <span>
                             <h5>


### PR DESCRIPTION
Closes  #4584

Eventing in onboarding was set up for users clicking the python wizard icon, but not for users clicking the node wizard or go wizard icons.

Fix adds eventing, and changes function name to be more semantic: e.g., `logPythonWizardClick` instead of `logPythonEvent`

![Screen Shot 2022-05-18 at 12 28 45 PM](https://user-images.githubusercontent.com/91283923/169094853-95c2ffa9-c6ad-41e2-8221-187987e3bf75.png)

