### PR TITLE
feat: set the function up everywhere

### DIFF
--- a/cypress/e2e/cloud/flows.test.ts
+++ b/cypress/e2e/cloud/flows.test.ts
@@ -282,13 +282,13 @@ describe('Flows', () => {
   })
 })
 
-describe('Flows with queryBuilderUseMetadataCaching flag on', () => {
+describe('Flows with newQueryBuilder flag on', () => {
   beforeEach(() => {
     cy.flush()
     cy.signin()
     cy.get('@org').then(({id}: Organization) =>
       cy.fixture('routes').then(({orgs}) => {
-        cy.setFeatureFlags({queryBuilderUseMetadataCaching: true}).then(() => {
+        cy.setFeatureFlags({newQueryBuilder: true}).then(() => {
           cy.visit(`${orgs}/${id}`)
         })
       })

--- a/src/checks/reducers/checks.test.ts
+++ b/src/checks/reducers/checks.test.ts
@@ -92,7 +92,7 @@ export const CHECK_FIXTURE_3: GenDeadmanCheck = {
 describe('checksReducer', () => {
   describe('setChecks', () => {
     it('sets list and status properties of state.', () => {
-      const initialState = defaultChecksState
+      const initialState = defaultChecksState()
       const cid_1 = CHECK_FIXTURE_1.id
       const cid_2 = CHECK_FIXTURE_2.id
 
@@ -125,7 +125,7 @@ describe('checksReducer', () => {
 
   describe('setCheck', () => {
     it('adds check to list if it is new', () => {
-      const initialState = defaultChecksState
+      const initialState = defaultChecksState()
       const id = CHECK_FIXTURE_2.id
 
       const check = normalize<Check, CheckEntities, string>(
@@ -150,7 +150,7 @@ describe('checksReducer', () => {
 
   describe('removeCheck', () => {
     it('removes check from state', () => {
-      const initialState = defaultChecksState
+      const initialState = defaultChecksState()
       const id = CHECK_FIXTURE_1.id
 
       initialState.byID[id] = {

--- a/src/checks/reducers/index.ts
+++ b/src/checks/reducers/index.ts
@@ -22,11 +22,11 @@ import {
 
 export type ChecksState = ResourceState['checks']
 
-export const defaultChecksState: ChecksState = {
+export const defaultChecksState = (): ChecksState => ({
   status: RemoteDataState.NotStarted,
   byID: {},
   allIDs: [],
-}
+})
 
 export interface ResourceIDs {
   checkIDs: {[x: string]: boolean}
@@ -35,7 +35,7 @@ export interface ResourceIDs {
 }
 
 export default (
-  state: ChecksState = defaultChecksState,
+  state: ChecksState = defaultChecksState(),
   action: Action
 ): ChecksState =>
   produce(state, draftState => {

--- a/src/flows/pipes/QueryBuilder/context.tsx
+++ b/src/flows/pipes/QueryBuilder/context.tsx
@@ -281,10 +281,7 @@ export const QueryBuilderProvider: FC = ({children}) => {
     |> sort()
     |> limit(n: ${limit})`
 
-    if (
-      data.buckets[0].type !== 'sample' &&
-      isFlagEnabled('queryBuilderUseMetadataCaching')
-    ) {
+    if (data.buckets[0].type !== 'sample' && isFlagEnabled('newQueryBuilder')) {
       _source = `import "regexp"
       import "influxdata/influxdb/schema"`
       queryText = `${_source}
@@ -409,10 +406,7 @@ export const QueryBuilderProvider: FC = ({children}) => {
     |> limit(n: ${limit})
     |> sort()`
 
-    if (
-      data.buckets[0].type !== 'sample' &&
-      isFlagEnabled('queryBuilderUseMetadataCaching')
-    ) {
+    if (data.buckets[0].type !== 'sample' && isFlagEnabled('newQueryBuilder')) {
       _source = `import "regexp"
       import "influxdata/influxdb/schema"`
       queryText = `${_source}

--- a/src/timeMachine/apis/queryBuilder.ts
+++ b/src/timeMachine/apis/queryBuilder.ts
@@ -10,6 +10,10 @@ import {formatExpression} from 'src/variables/utils/formatExpression'
 import {tagToFlux} from 'src/timeMachine/utils/queryBuilder'
 import {event} from 'src/cloud/utils/reporting'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import {
+  CACHING_REQUIRED_END_DATE,
+  CACHING_REQUIRED_START_DATE,
+} from 'src/utils/datetime/constants'
 
 // Types
 import {TimeRange, BuilderConfig} from 'src/types'
@@ -53,7 +57,7 @@ export function findKeys({
 
   // TODO: Use the `v1.tagKeys` function from the Flux standard library once
   // this issue is resolved: https://github.com/influxdata/flux/issues/1071
-  const query = `import "regexp"
+  let query = `import "regexp"
 
   from(bucket: "${bucket}")
   |> range(${timeRangeArguments})
@@ -64,6 +68,21 @@ export function findKeys({
   |> filter(fn: (r) => r._value != "_time" and r._value != "_start" and r._value !=  "_stop" and r._value != "_value")
   |> sort()
   |> limit(n: ${adjustedLimit})`
+
+  if (bucket !== 'sample' && isFlagEnabled('newQueryBuilder')) {
+    query = `import "regexp"
+import "influxdata/influxdb/schema"
+
+schema.tagKeys(
+  bucket: "${bucket}",
+  predicate: (r) => ${tagFilters},
+  start: ${CACHING_REQUIRED_START_DATE},
+  stop: ${CACHING_REQUIRED_END_DATE},
+)${searchFilter}${previousKeyFilter}
+  |> filter(fn: (r) => r._value != "_time" and r._value != "_start" and r._value !=  "_stop" and r._value != "_value")
+  |> sort()
+  |> limit(n: ${limit})`
+  }
 
   event('runQuery', {
     context: 'queryBuilder-findKeys',
@@ -106,7 +125,7 @@ export function findValues({
 
   // TODO: Use the `v1.tagValues` function from the Flux standard library once
   // this issue is resolved: https://github.com/influxdata/flux/issues/1071
-  const query = `import "regexp"
+  let query = `import "regexp"
 
   from(bucket: "${bucket}")
   |> range(${timeRangeArguments})
@@ -116,6 +135,21 @@ export function findValues({
   |> distinct(column: "${key}")${searchFilter}
   |> limit(n: ${adjustedLimit})
   |> sort()`
+
+  if (bucket !== 'sample' && isFlagEnabled('newQueryBuilder')) {
+    query = `import "regexp"
+import "influxdata/influxdb/schema"
+
+schema.tagKeys(
+  bucket: "${bucket}",
+  predicate: (r) => ${tagFilters},
+  start: ${CACHING_REQUIRED_START_DATE},
+  stop: ${CACHING_REQUIRED_END_DATE},
+)${searchFilter}
+  |> filter(fn: (r) => r._value != "_time" and r._value != "_start" and r._value !=  "_stop" and r._value != "_value")
+  |> sort()
+  |> limit(n: ${limit})`
+  }
 
   event('runQuery', {
     context: 'queryBuilder-findValues',

--- a/src/timeMachine/selectors/index.ts
+++ b/src/timeMachine/selectors/index.ts
@@ -1,7 +1,7 @@
 // Libraries
 import memoizeOne from 'memoize-one'
 import {get} from 'lodash'
-import {fromFlux, Table} from '@influxdata/giraffe'
+import {fromFlux, fastFromFlux, Table} from '@influxdata/giraffe'
 
 // Utils
 import {
@@ -13,6 +13,7 @@ import {
   getStringColumns as getStringColumnsUtil,
   getMainColumnName,
 } from 'src/shared/utils/vis'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 import {
   calcWindowPeriodForDuration,
@@ -111,7 +112,9 @@ export const getWindowPeriodFromTimeRange = (state: AppState): string => {
   )
 }
 
-const getVisTableMemoized = memoizeOne(fromFlux)
+const getVisTableMemoized = isFlagEnabled('fastFromFlux')
+  ? memoizeOne(fastFromFlux)
+  : memoizeOne(fromFlux)
 
 export const getVisTable = (
   state: AppState

--- a/src/variables/utils/ValueFetcher.ts
+++ b/src/variables/utils/ValueFetcher.ts
@@ -1,12 +1,13 @@
 // APIs
 import {runQuery} from 'src/shared/apis/query'
-import {fromFlux} from '@influxdata/giraffe'
+import {fromFlux, fastFromFlux} from '@influxdata/giraffe'
 
 // Utils
 import {resolveSelectedKey} from 'src/variables/utils/resolveSelectedValue'
 import {formatVarsOption} from 'src/variables/utils/formatVarsOption'
 import {buildUsedVarsOption} from 'src/variables/utils/buildVarsOption'
 import {event} from 'src/cloud/utils/reporting'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Types
 import {
@@ -40,7 +41,9 @@ export const extractValues = (
   prevSelection?: string,
   defaultSelection?: string
 ): VariableValues => {
-  const {table} = fromFlux(csv)
+  const {table} = isFlagEnabled('fastFromFlux')
+    ? fastFromFlux(csv)
+    : fromFlux(csv)
   if (!table || !table.getColumn('_value', 'string')) {
     return {
       values: [],


### PR DESCRIPTION
Closes #4289 

This PR does three things:

- updates the tagKeys query for the query builder in data explorer to match the work done in notebook
- updates the previous `queryBuilderUseMetadataCaching` to `newQueryBuilder` since the two features go hand in hand
- updates ValueFetcher and the timeMachine/selector to use the fastFromFlux behind a feature flag

<!-- Describe your proposed changes here. -->
