### PR TITLE
fix: do not display provider if account type is PAYG

### DIFF
--- a/src/organizations/components/OrgProfileTab/index.tsx
+++ b/src/organizations/components/OrgProfileTab/index.tsx
@@ -85,9 +85,10 @@ const OrgProfileTab: FC = () => {
             stretchToFitWidth={true}
             style={{width: '85%'}}
           >
-            {me.quartzMe?.billingProvider && (
+            {me.quartzMe?.billingProvider &&
+            me.quartzMe?.accountType !== 'pay_as_you_go' ? (
               <LabeledData label="Provider" src={me.quartzMe.billingProvider} />
-            )}
+            ) : null}
             {me.quartzMe?.regionCode && (
               <LabeledData label="Region" src={me.quartzMe.regionCode} />
             )}


### PR DESCRIPTION
Closes #4597 

Organization settings page currently displays Provider information (zuora, aws, gcm, azure) when user has a pay-as-you-go account type. The valid strings for type `AccountType` are `'cancelled' | 'contract' | 'free' | 'pay_as_you_go'` (src/client/unityRoutes.ts).
![168848872-c3b39112-eb6c-42b9-b6a8-e045008cfa94](https://user-images.githubusercontent.com/91283923/169107105-53bdb80e-c127-4279-8e3a-eb767764d2cf.png)

The fix adjusts conditional render of Provider component (`<LabeledData label="Provider" />`), so that the component does not render if quartz identifies the user's `accountType` as `pay_as_you_go'.

![Screen Shot 2022-05-18 at 1 42 38 PM](https://user-images.githubusercontent.com/91283923/169107891-d040aa36-8439-4146-bde1-a38ae2c17294.png)