### PR TITLE
fix: force value to string before calling trim

### DIFF
--- a/src/cloud/utils/reporting.ts
+++ b/src/cloud/utils/reporting.ts
@@ -70,7 +70,7 @@ export const cleanTags = (data: Point): Point => {
       }
 
       // if it's made it this far, it's a string, cast it explicitly so typescript will stfu
-      acc[key] = (val as string).trim()
+      acc[key] = String(val).trim()
       return acc
     }, {}),
   }

--- a/src/cloud/utils/reporting.ts
+++ b/src/cloud/utils/reporting.ts
@@ -69,7 +69,6 @@ export const cleanTags = (data: Point): Point => {
         return acc
       }
 
-      // if it's made it this far, it's a string, cast it explicitly so typescript will stfu
       acc[key] = String(val).trim()
       return acc
     }, {}),


### PR DESCRIPTION
Part of #4313 

Fixes the `a.trim is not a function` by guaranteeing the value is a string before calling `.trim()`

<img width="1728" alt="Screen Shot 2022-05-18 at 2 16 15 PM" src="https://user-images.githubusercontent.com/10736577/169158032-b6645fb7-b5e5-4174-9327-8276345c6737.png">


