### PR TITLE
fix: add missing eventing for CLI and telegraf buttons

### DIFF
--- a/src/homepageExperience/containers/HomepageContainer.tsx
+++ b/src/homepageExperience/containers/HomepageContainer.tsx
@@ -70,6 +70,14 @@ export const HomepageContainer: FC = () => {
     event('firstMile.moreButton.clicked')
   }
 
+  const logCLIButtonClick = () => {
+    event('firstMile.CLIButton.clicked')
+  }
+
+  const logTelegrafButtonClick = () => {
+    event('firstMile.telegrafButton.clicked')
+  }
+
   return (
     <>
       <Page titleTag={pageTitleSuffixer(['Get Started'])}>
@@ -155,7 +163,11 @@ export const HomepageContainer: FC = () => {
                     </ResourceCard>
                   </SquareGrid>
                   <hr style={{marginTop: '32px'}} />
-                  <Link to={cliPageLink} style={linkStyle}>
+                  <Link
+                    to={cliPageLink}
+                    style={linkStyle}
+                    onClick={logCLIButtonClick}
+                  >
                     <div className="homepage-write-data-tile">
                       <div className="tile-icon-text-wrapper">
                         <div className="icon">{CLIIcon}</div>
@@ -174,7 +186,11 @@ export const HomepageContainer: FC = () => {
                       />
                     </div>
                   </Link>
-                  <Link to={telegrafPageLink} style={linkStyle}>
+                  <Link
+                    to={telegrafPageLink}
+                    style={linkStyle}
+                    onClick={logTelegrafButtonClick}
+                  >
                     <div className="homepage-write-data-tile">
                       <div className="tile-icon-text-wrapper">
                         <div className="icon">{TelegrafIcon}</div>


### PR DESCRIPTION
Closes #4618

Eventing was present for python, node, go, and 'more' buttons on firstMile, but not the CLI or telegraf buttons.

Fix adds eventing for these buttons (below image has streamEvents turned on to illustrate).

Note that the click handlers all have identical functionality with different event names. Another approach would be to combine them into one, and pass the event (firstMile.nameOfEvent.clicked) as an argument to a single handler when the function is invoked in each `<Link />`. On balance, I'd propose keeping separate event handlers, since this is a little easier to debug if we have to add or change event names.

![Screen Shot 2022-05-19 at 12 30 17 PM](https://user-images.githubusercontent.com/91283923/169351461-29a8c4c9-c9a7-4361-b39d-7f251cb2e9b4.png)

