### PR TITLE
feat: Move help bar nav item to bottom of nav bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
   },
   "dependencies": {
     "@docsearch/react": "^3.0.0-alpha.37",
-    "@influxdata/clockface": "^4.0.1",
+    "@influxdata/clockface": "^4.2.0",
     "@influxdata/flux-lsp-browser": "0.8.8",
     "@influxdata/giraffe": "^2.25.0",
     "@influxdata/influxdb-templates": "0.9.0",

--- a/src/pageLayout/containers/TreeNav.scss
+++ b/src/pageLayout/containers/TreeNav.scss
@@ -1,16 +1,3 @@
-
-// .ScrollbarsCustom-Wrapper .cf-dapper-scrollbars--wrapper {
-//     position: relative;
-// }
-
 .helpBarStyle {
-    margin-top: 365px !important;
-    // position: absolute !important;
-    // bottom: 0 !important;
-}
-
-*:last-of-type > .cf-tree-nav--sub-menu-trigger:last-of-type {
-    height: 225px;
-    bottom: 0;
-    top: unset;
+    margin-top: auto !important;
 }

--- a/src/pageLayout/containers/TreeNav.scss
+++ b/src/pageLayout/containers/TreeNav.scss
@@ -1,0 +1,16 @@
+
+// .ScrollbarsCustom-Wrapper .cf-dapper-scrollbars--wrapper {
+//     position: relative;
+// }
+
+.helpBarStyle {
+    margin-top: 365px !important;
+    // position: absolute !important;
+    // bottom: 0 !important;
+}
+
+*:last-of-type > .cf-tree-nav--sub-menu-trigger:last-of-type {
+    height: 225px;
+    bottom: 0;
+    top: unset;
+}

--- a/src/pageLayout/containers/TreeNav.scss
+++ b/src/pageLayout/containers/TreeNav.scss
@@ -1,3 +1,3 @@
 .helpBarStyle {
-    margin-top: auto !important;
+  margin-top: auto !important;
 }

--- a/src/pageLayout/containers/TreeNav.tsx
+++ b/src/pageLayout/containers/TreeNav.tsx
@@ -6,7 +6,7 @@ import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
-import {Icon, IconFont, TreeNav, PopoverPosition} from '@influxdata/clockface'
+import {Icon, IconFont, PopoverPosition, TreeNav} from '@influxdata/clockface'
 import UserWidget from 'src/pageLayout/components/UserWidget'
 import NavHeader from 'src/pageLayout/components/NavHeader'
 import OrgSettings from 'src/cloud/components/OrgSettings'

--- a/src/pageLayout/containers/TreeNav.tsx
+++ b/src/pageLayout/containers/TreeNav.tsx
@@ -27,6 +27,7 @@ import {NavItem, NavSubItem} from 'src/pageLayout/constants/navigationHierarchy'
 import {AppState} from 'src/types'
 
 import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
+import './TreeNav.scss'
 
 type ReduxProps = ConnectedProps<typeof connector>
 
@@ -70,7 +71,7 @@ const TreeSidebar: FC<ReduxProps & RouteComponentProps> = () =>
         setNavbarMode('expanded')
       }
     }
-
+  
     // Hiding Contact Support and Feedback code for Help Bar phase 1 release
     // https://github.com/influxdata/ui/issues/3457
     // https://github.com/influxdata/ui/issues/3454
@@ -163,6 +164,7 @@ const TreeSidebar: FC<ReduxProps & RouteComponentProps> = () =>
               icon={<Icon glyph={IconFont.QuestionMark_New} />}
               label="Help & Support"
               shortLabel="Support"
+              className="helpBarStyle" // margin-top is 365px or position: absolute bottom: 0
             >
               <TreeNav.SubMenu>
                 <TreeNav.SubHeading label="Support" />

--- a/src/pageLayout/containers/TreeNav.tsx
+++ b/src/pageLayout/containers/TreeNav.tsx
@@ -6,7 +6,7 @@ import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
-import {Icon, IconFont, TreeNav} from '@influxdata/clockface'
+import {Icon, IconFont, TreeNav, PopoverPosition} from '@influxdata/clockface'
 import UserWidget from 'src/pageLayout/components/UserWidget'
 import NavHeader from 'src/pageLayout/components/NavHeader'
 import OrgSettings from 'src/cloud/components/OrgSettings'
@@ -71,7 +71,7 @@ const TreeSidebar: FC<ReduxProps & RouteComponentProps> = () =>
         setNavbarMode('expanded')
       }
     }
-  
+
     // Hiding Contact Support and Feedback code for Help Bar phase 1 release
     // https://github.com/influxdata/ui/issues/3457
     // https://github.com/influxdata/ui/issues/3454
@@ -166,7 +166,7 @@ const TreeSidebar: FC<ReduxProps & RouteComponentProps> = () =>
               shortLabel="Support"
               className="helpBarStyle" // margin-top is 365px or position: absolute bottom: 0
             >
-              <TreeNav.SubMenu>
+              <TreeNav.SubMenu position={PopoverPosition.ToTheRight}>
                 <TreeNav.SubHeading label="Support" />
                 <TreeNav.SubItem
                   id="documentation"

--- a/src/pageLayout/containers/TreeNav.tsx
+++ b/src/pageLayout/containers/TreeNav.tsx
@@ -164,7 +164,7 @@ const TreeSidebar: FC<ReduxProps & RouteComponentProps> = () =>
               icon={<Icon glyph={IconFont.QuestionMark_New} />}
               label="Help & Support"
               shortLabel="Support"
-              className="helpBarStyle" // margin-top is 365px or position: absolute bottom: 0
+              className="helpBarStyle"
             >
               <TreeNav.SubMenu position={PopoverPosition.ToTheRight}>
                 <TreeNav.SubHeading label="Support" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1444,10 +1444,10 @@
     gud "^1.0.0"
     warning "^4.0.3"
 
-"@influxdata/clockface@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-4.0.1.tgz#fe9175301b3c7914bf2165e15f0a904572aadeff"
-  integrity sha512-c4tFxs1/9zR3kc7/Y77mZdo6NsThznfYz+q6O64PqOykqDClgpfCzbpVmG+Tfm06Je4jF4Om3Ssek3cC6lYodw==
+"@influxdata/clockface@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-4.2.0.tgz#f41aba10b00bb21f24075bffe7b48a95507dfd24"
+  integrity sha512-DXReWwAOqMM+GqfP3pMiskPpOJRflHlymxgfaxpQkLOkXVeaK5UcQBaV1MKdgNFlPS8vAb1nE0KTnbg7/25SAw==
 
 "@influxdata/flux-lsp-browser@0.8.8":
   version "0.8.8"


### PR DESCRIPTION
Closes #


Pr introduces the following changes 

- moves `Help & Support` nav item to the bottom of the nav bar. 
- adjusts the position of popover modal 

Before 
![before](https://user-images.githubusercontent.com/66275100/169577072-e95d92ca-6c95-4c79-a36e-eb3a970e78fa.png)

After

![after](https://user-images.githubusercontent.com/66275100/169576494-081ca77c-1c71-4969-a9cd-42b47eee09ae.png)