### PR TITLE
test: deeplink tests for firstmile

### DIFF
--- a/cypress/e2e/shared/deepLinks.test.ts
+++ b/cypress/e2e/shared/deepLinks.test.ts
@@ -79,6 +79,24 @@ describe('Deep linking', () => {
         cy.visit('/me/secrets')
         cy.location('pathname').should('eq', `/orgs/${org.id}/settings/secrets`)
 
+        cy.visit('/me/setup-golang')
+        cy.location('pathname').should(
+          'eq',
+          `/orgs/${org.id}/new-user-setup/golang`
+        )
+
+        cy.visit('/me/setup-nodejs')
+        cy.location('pathname').should(
+          'eq',
+          `/orgs/${org.id}/new-user-setup/nodejs`
+        )
+
+        cy.visit('/me/setup-python')
+        cy.location('pathname').should(
+          'eq',
+          `/orgs/${org.id}/new-user-setup/python`
+        )
+
         cy.visit('/me/tasks')
         cy.location('pathname').should('eq', `/orgs/${org.id}/tasks`)
 


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/4604

Adds the e2e tests for first mile deep links. 

<!-- Describe your proposed changes here. -->
