### PR TITLE
fix: queryBuilder tag key & value gets

### DIFF
--- a/src/timeMachine/apis/queryBuilder.ts
+++ b/src/timeMachine/apis/queryBuilder.ts
@@ -75,7 +75,7 @@ import "influxdata/influxdb/schema"
 
 schema.tagKeys(
   bucket: "${bucket}",
-  predicate: (r) => ${tagFilters},
+  predicate: ${tagFilters},
   start: ${CACHING_REQUIRED_START_DATE},
   stop: ${CACHING_REQUIRED_END_DATE},
 )${searchFilter}${previousKeyFilter}
@@ -140,9 +140,10 @@ export function findValues({
     query = `import "regexp"
 import "influxdata/influxdb/schema"
 
-schema.tagKeys(
+schema.tagValues(
   bucket: "${bucket}",
-  predicate: (r) => ${tagFilters},
+  tag: "${key}",
+  predicate: ${tagFilters},
   start: ${CACHING_REQUIRED_START_DATE},
   stop: ${CACHING_REQUIRED_END_DATE},
 )${searchFilter}


### PR DESCRIPTION
This is just me cleaning up a sloppy copy job on my part and not bothering to look at the root of what the existing query was doing. The solution here was a few things:

1. not prepending a `(r) => ` onto the predicate since the tagFilters already does that through a function
2. Changing the `tagKeys` to `tagValues` for the values 🤦🏽 
3. Adding in the selected tag `key` for the tagValues

Visual proof here is that the query doesn't error out:

![query-builder-fix](https://user-images.githubusercontent.com/19984220/169386256-c0729a2b-ac94-4ce3-b380-3017e225167b.gif)

