### PR TITLE
feat: convert account_created_at to epoch time

### DIFF
--- a/src/shared/containers/GetOrganizations.tsx
+++ b/src/shared/containers/GetOrganizations.tsx
@@ -30,6 +30,7 @@ import {CLOUD} from 'src/shared/constants'
 
 // Utils
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import {convertStringToEpoch} from 'src/shared/utils/dateTimeUtils'
 
 // Types
 import {Me} from 'src/client/unityRoutes'
@@ -81,7 +82,7 @@ const GetOrganizations: FunctionComponent = () => {
       window.dataLayer.push({
         identity: {
           account_type,
-          account_created_at,
+          account_created_at: convertStringToEpoch(account_created_at),
           id: meId,
           email,
           organization_id: orgId,

--- a/src/shared/utils/dateTimeUtils.test.ts
+++ b/src/shared/utils/dateTimeUtils.test.ts
@@ -1,4 +1,8 @@
-import {addDurationToDate, isISODate} from './dateTimeUtils'
+import {
+  addDurationToDate,
+  convertStringToEpoch,
+  isISODate,
+} from './dateTimeUtils'
 
 // July 4th, 1983, 20:00:00 UTC ===> 1983-07-04T20:00:00.000Z
 const timestamp = 426196800000
@@ -44,5 +48,23 @@ describe('isISODate', function() {
   })
   it('should return false for an empty string', function() {
     expect(isISODate('')).toBeFalsy()
+  })
+})
+
+describe('convertStringToEpoch', () => {
+  it('handles invalid date strings', () => {
+    expect(convertStringToEpoch('')).toEqual(NaN)
+    expect(convertStringToEpoch('not a date string')).toEqual(NaN)
+    expect(
+      convertStringToEpoch(new Date(`${timestamp}`).toDateString())
+    ).toEqual(NaN)
+  })
+
+  it('converts a valid date string to epoch time', () => {
+    let validDate = new Date()
+    expect(convertStringToEpoch(validDate.toDateString())).not.toEqual(NaN)
+
+    validDate = new Date(timestamp)
+    expect(convertStringToEpoch(validDate.toDateString())).not.toEqual(NaN)
   })
 })

--- a/src/shared/utils/dateTimeUtils.ts
+++ b/src/shared/utils/dateTimeUtils.ts
@@ -52,3 +52,11 @@ export function isISODate(dateString: string): boolean {
     return false
   }
 }
+
+export const convertStringToEpoch = (date: string): number => {
+  const convertedDate = new Date(date)
+  if (convertedDate.toDateString() === 'Invalid Date') {
+    return NaN
+  }
+  return convertedDate.valueOf()
+}


### PR DESCRIPTION
Part of #4313 

Change `account_created_at` to epoch time, because it is easier to manage as a number in the Google Optimize experiment dashboard.

<img width="1728" alt="Screen Shot 2022-05-19 at 2 37 46 PM" src="https://user-images.githubusercontent.com/10736577/169409021-bb6b78fe-70cf-4151-ab35-28535ee6c79c.png">
