### PR TITLE
fix: use standard dashboard card height when alert is first in a row

### DIFF
--- a/src/cloud/components/AssetLimitAlert.tsx
+++ b/src/cloud/components/AssetLimitAlert.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FC} from 'react'
+import React, {CSSProperties, FC} from 'react'
 
 // Components
 import {
@@ -34,15 +34,22 @@ interface Props {
   limitStatus: LimitStatus['status']
   resourceName: string
   className?: string
+  style?: CSSProperties
 }
 
-const AssetLimitAlert: FC<Props> = ({limitStatus, resourceName, className}) => {
+const AssetLimitAlert: FC<Props> = ({
+  limitStatus,
+  resourceName,
+  className,
+  style = {},
+}) => {
   if (CLOUD && limitStatus === 'exceeded') {
     return (
       <GradientBox
         borderGradient={Gradients.MiyazakiSky}
         borderColor={InfluxColors.Grey5}
         className={className}
+        style={{...style}}
       >
         <Panel backgroundColor={InfluxColors.Grey5} className="asset-alert">
           <Panel.Header>

--- a/src/dashboards/components/dashboard_index/DashboardCards.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardCards.tsx
@@ -5,7 +5,7 @@ import memoizeOne from 'memoize-one'
 
 // Components
 import DashboardCard from 'src/dashboards/components/dashboard_index/DashboardCard'
-import {TechnoSpinner} from '@influxdata/clockface'
+import {ResourceCard, TechnoSpinner} from '@influxdata/clockface'
 import AssetLimitAlert from 'src/cloud/components/AssetLimitAlert'
 
 // Selectors
@@ -60,6 +60,9 @@ class DashboardCards extends PureComponent<Props> {
   private _observer
   private _isMounted = true
   private _spinner
+  private _assetLimitAlertStyle = {
+    height: 'inherit',
+  }
 
   private memGetSortedResources = memoizeOne<typeof getSortedResources>(
     getSortedResources
@@ -69,6 +72,7 @@ class DashboardCards extends PureComponent<Props> {
     pages: 1,
     windowSize: 0,
     pinnedItems: [],
+    dashboardCardHeight: 'inherit',
   }
 
   public componentDidMount() {
@@ -76,6 +80,17 @@ class DashboardCards extends PureComponent<Props> {
       this.updatePinnedItems()
     }
     this.setState(prev => ({...prev, windowSize: 15}))
+  }
+
+  public componentDidUpdate() {
+    const card = document.querySelector<HTMLElement>(
+      '.dashboards-card-grid > .cf-resource-card'
+    )
+    if (card?.offsetHeight) {
+      this.setState({
+        dashboardCardHeight: `${card.offsetHeight}px`,
+      })
+    }
   }
 
   public componentWillUnmount() {
@@ -205,11 +220,16 @@ class DashboardCards extends PureComponent<Props> {
                 }
               />
             ))}
-          <AssetLimitAlert
-            className="dashboards--asset-alert"
-            resourceName="dashboards"
-            limitStatus={this.props.limitStatus}
-          />
+          {this.props.limitStatus === 'exceeded' && (
+            <ResourceCard style={{height: this.state.dashboardCardHeight}}>
+              <AssetLimitAlert
+                className="dashboards--asset-alert"
+                resourceName="dashboards"
+                limitStatus={this.props.limitStatus}
+                style={this._assetLimitAlertStyle}
+              />
+            </ResourceCard>
+          )}
         </div>
         {windowSize * pages < dashboards.length && (
           <div


### PR DESCRIPTION
Closes #4596 

Sets the resource card with the asset limit alert with the correct height when the card is the first one in the row

<img width="1728" alt="Screen Shot 2022-05-20 at 12 58 12 PM" src="https://user-images.githubusercontent.com/10736577/169602745-8f15e138-9ae1-4e25-ba67-eb95b68017af.png">
