### PR TITLE
fix: update Checkout page for experiment to remove the sash and use t…

### DIFF
--- a/src/checkout/CheckoutForm.tsx
+++ b/src/checkout/CheckoutForm.tsx
@@ -51,7 +51,6 @@ const CheckoutForm: FC = () => {
     handleSubmit,
     setIsDirty,
     isSubmitting,
-    isPaygCreditActive,
   } = useContext(CheckoutContext)
 
   const onSubmit = () => {
@@ -79,7 +78,7 @@ const CheckoutForm: FC = () => {
           >
             Upgrade to Usage-Based Account
           </h1>
-          {isFlagEnabled('credit250Experiment') && !isPaygCreditActive && (
+          {isFlagEnabled('credit250Experiment') && (
             <GoogleOptimizeExperiment
               experimentID={CREDIT_250_EXPERIMENT_ID}
               variants={[
@@ -118,21 +117,6 @@ const CheckoutForm: FC = () => {
                 </SafeBlankLink>
                 .
               </p>
-
-              {isPaygCreditActive && (
-                <GoogleOptimizeExperiment
-                  experimentID={CREDIT_250_EXPERIMENT_ID}
-                  variants={[
-                    <div
-                      className="checkout-form--banner"
-                      key="checkout-form-banner"
-                    >
-                      <strong className="checkout-banner--credit">$250</strong>
-                      <p>credit applied</p>
-                    </div>,
-                  ]}
-                />
-              )}
             </Panel.Body>
           </Panel>
           <Panel>


### PR DESCRIPTION
Part of idpe 14140

Use the banner instead of the sash.


Not this:
<img width="1728" alt="Screen Shot 2022-05-20 at 9 47 49 AM" src="https://user-images.githubusercontent.com/10736577/169610997-375878e2-7d7d-4474-bb95-5eabd8ded09a.png">


But this:
<img width="1728" alt="Screen Shot 2022-05-20 at 10 17 47 AM" src="https://user-images.githubusercontent.com/10736577/169611020-5b760b65-a5bc-46c3-9ee0-f7e40b450b0a.png">

