### PR TITLE
fix: re-fetch bucket labels when updating bucket retention

### DIFF
--- a/src/buckets/actions/thunks.ts
+++ b/src/buckets/actions/thunks.ts
@@ -216,8 +216,16 @@ export const updateBucket = (bucket: OwnBucket) => async (
       throw new Error(resp.data.message)
     }
 
+    const labelsResponse = await api.getBucketsLabels({
+      bucketID: bucket.id,
+    })
+
+    if (labelsResponse.status !== 200) {
+      throw new Error(labelsResponse.data.message)
+    }
+
     const newBucket = normalize<Bucket, BucketEntities, string>(
-      resp.data,
+      Object.assign(resp.data, {labels: labelsResponse.data.labels}),
       bucketSchema
     )
 


### PR DESCRIPTION
Closes #4592 

Re-fetch the bucket labels when updating the bucket retention, because the api does not include labels on `PATCH` operation to buckets. It requires a separate call to get the bucket labels.


https://user-images.githubusercontent.com/10736577/169623950-c090aed0-9362-4437-8ada-556fdd3b9e35.mp4


