### PR TITLE
fix: Add missing eventing to firstMile video

### DIFF
--- a/src/homepageExperience/components/steps/Overview.tsx
+++ b/src/homepageExperience/components/steps/Overview.tsx
@@ -9,7 +9,7 @@ type Props = {
 export const Overview: FC<Props> = ({wizard}) => {
   const videoFrame = useRef<null | HTMLIFrameElement>(null)
 
-  // onClick (and related events) are unavailable for media embedded in iframes because they represented a nested browsing context. This solution, which infers a click from an onBlur event where the iframe is the active element on the DOM, is adapted from https://github.com/springload/react-iframe-click
+  // iFrames represent separate browsing context, requiring this workaround. For more, see resolution of this ticket (https://github.com/influxdata/ui/issues/4623)
 
   useEffect(() => {
     const checkVidClick = () => {

--- a/src/homepageExperience/components/steps/Overview.tsx
+++ b/src/homepageExperience/components/steps/Overview.tsx
@@ -9,30 +9,19 @@ type Props = {
 export const Overview: FC<Props> = ({wizard}) => {
   const videoFrame = useRef<null | HTMLIFrameElement>(null)
 
-  // Can't use an onClick for events because the iframe targets another site.
-  // Can use this workaround. For more info see https://github.com/springload/react-iframe-click
+  // onClick (and related events) are unavailable for media embedded in iframes because they represented a nested browsing context. This solution, which infers a click from an onBlur event where the iframe is the active element on the DOM, is adapted from https://github.com/springload/react-iframe-click
 
   useEffect(() => {
-    console.log('loaded')
     const checkVidClick = () => {
-      console.log(document.activeElement)
       if (
         document.activeElement &&
         document.activeElement.nodeName.toLowerCase() === 'iframe' &&
         videoFrame.current &&
         videoFrame.current === document.activeElement
       ) {
-        console.log(wizard)
         event(`firstMile.${wizard}Video.clicked`)
       }
-      // If we don't want this to happen for subsequent clicks on the video, remove during cleanup
-      /*
-      return () => {
-        window.removeEventListener('blur', checkVidClick)
-      }
-      */
     }
-
     window.addEventListener('blur', checkVidClick)
   }, [])
 

--- a/src/homepageExperience/components/steps/Overview.tsx
+++ b/src/homepageExperience/components/steps/Overview.tsx
@@ -1,39 +1,70 @@
-import React, {PureComponent} from 'react'
+import React, {FC, useEffect, useRef} from 'react'
 import {SafeBlankLink} from 'src/utils/SafeBlankLink'
+import {event} from 'src/cloud/utils/reporting'
 
-export class Overview extends PureComponent {
-  render() {
-    return (
-      <div>
-        <h1>Hello, Time-Series World!</h1>
-        <article>
-          <p>Welcome and thanks for checking out InfluxData!</p>
+type Props = {
+  wizard: string
+}
 
-          <p>
-            In the next 5 minutes, you will set up InfluxData on your machine
-            and write and execute some basic queries.
-          </p>
+export const Overview: FC<Props> = ({wizard}) => {
+  const videoFrame = useRef<null | HTMLIFrameElement>(null)
 
-          <iframe
-            width="560"
-            height="315"
-            src="https://www.youtube.com/embed/KZwr1xBDbBQ"
-            title="InfluxData - What is Time Series"
-            frameBorder="0"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-            allowFullScreen
-            style={{marginBottom: '20px'}}
-          />
+  // Can't use an onClick for events because the iframe targets another site.
+  // Can use this workaround. For more info see https://github.com/springload/react-iframe-click
 
-          <p>
-            Join our{' '}
-            <SafeBlankLink href="https://www.influxdata.com/slack">
-              community slack{' '}
-            </SafeBlankLink>{' '}
-            to ask any questions you have along the way!
-          </p>
-        </article>
-      </div>
-    )
-  }
+  useEffect(() => {
+    console.log('loaded')
+    const checkVidClick = () => {
+      console.log(document.activeElement)
+      if (
+        document.activeElement &&
+        document.activeElement.nodeName.toLowerCase() === 'iframe' &&
+        videoFrame.current &&
+        videoFrame.current === document.activeElement
+      ) {
+        console.log(wizard)
+        event(`firstMile.${wizard}Video.clicked`)
+      }
+      // If we don't want this to happen for subsequent clicks on the video, remove during cleanup
+      /*
+      return () => {
+        window.removeEventListener('blur', checkVidClick)
+      }
+      */
+    }
+
+    window.addEventListener('blur', checkVidClick)
+  }, [])
+
+  return (
+    <div>
+      <h1>Hello, Time-Series World!</h1>
+      <article>
+        <p>Welcome and thanks for checking out InfluxData!</p>
+
+        <p>
+          In the next 5 minutes, you will set up InfluxData on your machine and
+          write and execute some basic queries.
+        </p>
+        <iframe
+          ref={videoFrame}
+          width="560"
+          height="315"
+          src="https://www.youtube.com/embed/KZwr1xBDbBQ"
+          title="InfluxData - What is Time Series"
+          frameBorder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowFullScreen
+          style={{marginBottom: '20px'}}
+        />
+        <p>
+          Join our{' '}
+          <SafeBlankLink href="https://www.influxdata.com/slack">
+            community slack{' '}
+          </SafeBlankLink>{' '}
+          to ask any questions you have along the way!
+        </p>
+      </article>
+    </div>
+  )
 }

--- a/src/homepageExperience/containers/GoWizard.tsx
+++ b/src/homepageExperience/containers/GoWizard.tsx
@@ -91,7 +91,7 @@ export class GoWizard extends PureComponent<null, State> {
   renderStep = () => {
     switch (this.state.currentStep) {
       case 1: {
-        return <Overview />
+        return <Overview wizard="goWizard" />
       }
       case 2: {
         return <InstallDependencies />
@@ -129,7 +129,7 @@ export class GoWizard extends PureComponent<null, State> {
         )
       }
       default: {
-        return <Overview />
+        return <Overview wizard="goWizard" />
       }
     }
   }

--- a/src/homepageExperience/containers/NodejsWizard.tsx
+++ b/src/homepageExperience/containers/NodejsWizard.tsx
@@ -91,7 +91,7 @@ export class NodejsWizard extends PureComponent<null, State> {
   renderStep = () => {
     switch (this.state.currentStep) {
       case 1: {
-        return <Overview wizard="nodeWizard" />
+        return <Overview wizard="nodejsWizard" />
       }
       case 2: {
         return <InstallDependencies />
@@ -129,7 +129,7 @@ export class NodejsWizard extends PureComponent<null, State> {
         )
       }
       default: {
-        return <Overview wizard="nodeWizard" />
+        return <Overview wizard="nodejsWizard" />
       }
     }
   }

--- a/src/homepageExperience/containers/NodejsWizard.tsx
+++ b/src/homepageExperience/containers/NodejsWizard.tsx
@@ -91,7 +91,7 @@ export class NodejsWizard extends PureComponent<null, State> {
   renderStep = () => {
     switch (this.state.currentStep) {
       case 1: {
-        return <Overview />
+        return <Overview wizard="nodeWizard" />
       }
       case 2: {
         return <InstallDependencies />
@@ -129,7 +129,7 @@ export class NodejsWizard extends PureComponent<null, State> {
         )
       }
       default: {
-        return <Overview />
+        return <Overview wizard="nodeWizard" />
       }
     }
   }

--- a/src/homepageExperience/containers/PythonWizard.tsx
+++ b/src/homepageExperience/containers/PythonWizard.tsx
@@ -92,7 +92,7 @@ export class PythonWizard extends PureComponent<null, State> {
   renderStep = () => {
     switch (this.state.currentStep) {
       case 1: {
-        return <Overview />
+        return <Overview wizard="pythonWizard" />
       }
       case 2: {
         return <InstallDependencies />
@@ -130,7 +130,7 @@ export class PythonWizard extends PureComponent<null, State> {
         )
       }
       default: {
-        return <Overview />
+        return <Overview wizard="pythonWizard" />
       }
     }
   }


### PR DESCRIPTION
Closes #4623

Eventing was not present for the tutorial 'what is time series' video in the Node, Go, and Python wizards. 

`<iframe>` can't accept onClick or similar events [because iframe represents a new nested browsing context](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe). This fix is adapted from solution found [here](https://github.com/springload/react-iframe-click), which infers the click from an onBlur event in `window` when the iframe is the then-active DOM element.

This fix fires the event on every click where the user changes context to the `<iframe>`. If this behavior is only desired on first click (e.g., shouldn't refire if user pauses, clicks out, then later clicks back in), we should remove the event listener after the first fire.

https://user-images.githubusercontent.com/91283923/169846461-c58abadb-46ec-49b2-8a2c-9327b02ba7d0.mov
