### PR TITLE
chore: update help bar faq link

### DIFF
--- a/src/pageLayout/containers/TreeNav.tsx
+++ b/src/pageLayout/containers/TreeNav.tsx
@@ -181,7 +181,7 @@ const TreeSidebar: FC<ReduxProps & RouteComponentProps> = () =>
                   label="FAQs"
                   testID="nav-subitem-faqs"
                   linkElement={() => (
-                    <SafeBlankLink href="https://docs.influxdata.com/influxdb/v1.8/troubleshooting/frequently-asked-questions/" />
+                    <SafeBlankLink href="https://docs.influxdata.com/influxdb/cloud/reference/faq/" />
                   )}
                 />
                 {/* <TreeNav.SubItem


### PR DESCRIPTION

PR updates Help Bar's FAQ link for InfluxDB Cloud and OSS 2.2+. The previous link directed users to InfluxDB 1.8 FAQ therefore needed changing
