### PR TITLE
chore: correctly align question mark tooltip in help bar 

### DIFF
--- a/src/support/components/ContactSupport.scss
+++ b/src/support/components/ContactSupport.scss
@@ -27,7 +27,19 @@
 .status-page-text {
   font-weight: lighter;
   margin-top: 0px;
+
+  .info-new {
+    bottom: 1px;
+    position: relative;
+  }
 }
-.cf-question-mark-tooltip {
-  margin-left: 412px !important;
+
+div.cf-form--label {
+  position: relative;
+
+  .cf-question-mark-tooltip {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+  }
 }

--- a/src/support/components/ContactSupport.scss
+++ b/src/support/components/ContactSupport.scss
@@ -26,7 +26,8 @@
 
 .status-page-text {
   font-weight: lighter;
-  margin-left: 25px;
   margin-top: 0px;
-  margin-bottom: 25px;
+}
+.cf-question-mark-tooltip {
+  margin-left: 412px !important;
 }

--- a/src/support/components/PayGSupportOverlay.tsx
+++ b/src/support/components/PayGSupportOverlay.tsx
@@ -102,6 +102,13 @@ const PayGSupportOverlay: FC<OwnProps> = () => {
         title="Contact Support"
         onDismiss={onClose}
       />
+      <ErrorBoundary>
+        <Form
+          onSubmit={handleSubmit}
+          action="https://influxdata--full.my.salesforce.com/servlet/servlet.WebToCase?encoding=UTF-8"
+          method={Method.Post}
+        >
+          <Overlay.Body>
       <p className="status-page-text">
         <span>
           {' '}
@@ -113,13 +120,6 @@ const PayGSupportOverlay: FC<OwnProps> = () => {
         </SafeBlankLink>{' '}
         to see if there is an outage impacting your region.
       </p>
-      <ErrorBoundary>
-        <Form
-          onSubmit={handleSubmit}
-          action="https://influxdata--full.my.salesforce.com/servlet/servlet.WebToCase?encoding=UTF-8"
-          method={Method.Post}
-        >
-          <Overlay.Body>
             <Form.Element label="Subject" required={true}>
               <Input
                 name="subject"

--- a/src/support/components/PayGSupportOverlay.tsx
+++ b/src/support/components/PayGSupportOverlay.tsx
@@ -109,17 +109,17 @@ const PayGSupportOverlay: FC<OwnProps> = () => {
           method={Method.Post}
         >
           <Overlay.Body>
-      <p className="status-page-text">
-        <span>
-          {' '}
-          <Icon glyph={IconFont.Info_New} />{' '}
-        </span>
-        Check our{' '}
-        <SafeBlankLink href="https://status.influxdata.com">
-          status page
-        </SafeBlankLink>{' '}
-        to see if there is an outage impacting your region.
-      </p>
+            <p className="status-page-text">
+              <span>
+                {' '}
+                <Icon glyph={IconFont.Info_New} />{' '}
+              </span>
+              Check our{' '}
+              <SafeBlankLink href="https://status.influxdata.com">
+                status page
+              </SafeBlankLink>{' '}
+              to see if there is an outage impacting your region.
+            </p>
             <Form.Element label="Subject" required={true}>
               <Input
                 name="subject"

--- a/src/support/components/PayGSupportOverlay.tsx
+++ b/src/support/components/PayGSupportOverlay.tsx
@@ -90,7 +90,6 @@ const PayGSupportOverlay: FC<OwnProps> = () => {
         diameter={14}
         tooltipContents={tooltipContent}
         tooltipStyle={{fontSize: '13px'}}
-        style={{marginLeft: '420px'}}
       />
     )
   }


### PR DESCRIPTION


PR adjusts the margin of the question tooltip to properly align it with the severity field. 
And moves the status page text inside the overlay body. 

Before 
![Screen Shot 2022-05-24 at 9 04 21 AM](https://user-images.githubusercontent.com/66275100/170055626-daa492d4-5b1a-42cf-9550-b344634f2319.png)

After 
![after](https://user-images.githubusercontent.com/66275100/170056070-adb0a098-ab12-475f-9565-345125612ff0.png)



