### PR TITLE
refactor: use getTime instead of valueOf for the epoch time

### DIFF
--- a/src/shared/utils/dateTimeUtils.ts
+++ b/src/shared/utils/dateTimeUtils.ts
@@ -58,5 +58,5 @@ export const convertStringToEpoch = (date: string): number => {
   if (convertedDate.toDateString() === 'Invalid Date') {
     return NaN
   }
-  return convertedDate.valueOf()
+  return convertedDate.getTime()
 }


### PR DESCRIPTION
Part of #4464 

Based on this comment: https://github.com/influxdata/quartz/pull/6414#discussion_r880633233 the correct function is actually `getTime` which specifies the return value as epoch time in milliseconds. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTime

`.valueOf` is only coincidentally correct. While it does currently give the time in epoch milliseconds, its return value is actually the primitive value of the `Date` object. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/valueOf
