### PR TITLE
chore: remove the `...` in search bar placeholder

### DIFF
--- a/src/flows/pipes/QueryBuilder/CardList.tsx
+++ b/src/flows/pipes/QueryBuilder/CardList.tsx
@@ -319,7 +319,7 @@ const Card: FC<Props> = ({idx}) => {
               <SearchableDropdown
                 searchTerm={keySearches[idx] || ''}
                 emptyText="No Tags Found"
-                searchPlaceholder="Search keys..."
+                searchPlaceholder="Search keys"
                 selectedOption={card.keys.selected[0]}
                 onSelect={keySelect}
                 buttonStatus={toComponentStatus(card.keys.loading)}

--- a/src/timeMachine/components/TagSelector.tsx
+++ b/src/timeMachine/components/TagSelector.tsx
@@ -164,7 +164,7 @@ class TagSelector extends PureComponent<Props> {
                       <SearchableDropdown
                         searchTerm={keysSearchTerm}
                         emptyText="No Tags Found"
-                        searchPlaceholder="Search keys..."
+                        searchPlaceholder="Search keys"
                         buttonStatus={toComponentStatus(keysStatus)}
                         selectedOption={selectedKey}
                         onSelect={this.handleSelectTag}


### PR DESCRIPTION
This PR removes the `...` in the search bar placeholder to keep the UI consistent with the design [here](https://www.figma.com/proto/0qAntPk5LVangAHguWT74X/Query-Experience-Project?page-id=191%3A13710&node-id=567%3A21115&viewport=241%2C48%2C0.15&scaling=min-zoom&starting-point-node-id=567%3A21115).