### PR TITLE
test: debug tasks test, to unblock CI pipeline

### DIFF
--- a/cypress/e2e/shared/tasks.test.ts
+++ b/cypress/e2e/shared/tasks.test.ts
@@ -34,7 +34,7 @@ describe('Tasks', () => {
   it('can create a task', () => {
     const taskName = 'Task'
     cy.createTaskFromEmpty(taskName, ({name}) => {
-      return `import "influxdata/influxdb/v1"{esc}
+      return `import "influxdata/influxdb/v1"
 v1.tagValues(bucket: "${name}", tag: "_field")
 from(bucket: "${name}")
    |> range(start: -2m)`

--- a/src/tasks/reducers/index.ts
+++ b/src/tasks/reducers/index.ts
@@ -65,7 +65,7 @@ export default (
       }
 
       case CLEAR_TASK: {
-        draftState.taskOptions = defaultOptions
+        draftState.taskOptions = {...defaultOptions}
         draftState.currentScript = ''
         draftState.newScript = ''
 


### PR DESCRIPTION
Unblock CI pipeline.
Part of #4673 

Does not fix all of the shared state issues in the Tasks part of the application. But hits at single the single biggest culprit.



## Change made:
* We are using a global store to fill out the form.
   * The form gets filled out, depending on which task cypress test, as either 'Task' or '🦄ask.
   * When the tests failed locally, they did it when it was expecting 'Task' but got '🦄ask'.
* Usually I try to keep form state as local state (react hooks or stateful components), and keep it out of any global store (e.g. redux). Because it can easily cause shared state issues.
   * The specific error here was a mutable default object.
