### PR TITLE
chore: remove withRouter from variables

### DIFF
--- a/src/variables/components/RenameVariableForm.tsx
+++ b/src/variables/components/RenameVariableForm.tsx
@@ -1,7 +1,6 @@
 // Libraries
 import React, {PureComponent, ChangeEvent, FormEvent} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
 import {Form, Input, Button, Overlay} from '@influxdata/clockface'
@@ -31,8 +30,7 @@ interface State {
 }
 
 type ReduxProps = ConnectedProps<typeof connector>
-type RouterProps = RouteComponentProps<{orgID: string; id: string}>
-type Props = OwnProps & RouterProps & ReduxProps
+type Props = OwnProps & ReduxProps
 
 class RenameVariableOverlayForm extends PureComponent<Props, State> {
   public state: State = {
@@ -132,4 +130,4 @@ const mdtp = {
 
 const connector = connect(mstp, mdtp)
 
-export default withRouter(connector(RenameVariableOverlayForm))
+export default connector(RenameVariableOverlayForm)

--- a/src/variables/components/RenameVariableOverlay.tsx
+++ b/src/variables/components/RenameVariableOverlay.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {useContext, FC, memo} from 'react'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
 import {OverlayContext} from 'src/overlays/components/OverlayController'
 
 // Components
@@ -15,9 +14,7 @@ const effectedItems = (): string[] => {
   return ['Queries', 'Dashboards', 'Telegraf Configurations', 'Templates']
 }
 
-const RenameVariableOverlay: FC<RouteComponentProps<{
-  orgID: string
-}>> = () => {
+const RenameVariableOverlay: FC = () => {
   const {onClose} = useContext(OverlayContext)
 
   return (
@@ -33,4 +30,4 @@ const RenameVariableOverlay: FC<RouteComponentProps<{
   )
 }
 
-export default withRouter(memo(RenameVariableOverlay))
+export default memo(RenameVariableOverlay)

--- a/src/variables/components/UpdateVariableOverlay.tsx
+++ b/src/variables/components/UpdateVariableOverlay.tsx
@@ -1,7 +1,6 @@
 // Libraries
 import React, {PureComponent, FormEvent} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
 import {
@@ -44,9 +43,8 @@ interface State {
   hasValidArgs: boolean
 }
 
-type RouterProps = RouteComponentProps<{orgID: string; id: string}>
 type ReduxProps = ConnectedProps<typeof connector>
-type Props = RouterProps & ReduxProps
+type Props = ReduxProps
 
 class UpdateVariableOverlay extends PureComponent<Props, State> {
   public state: State = {
@@ -274,4 +272,4 @@ const mdtp = {
 
 const connector = connect(mstp, mdtp)
 
-export default withRouter(connector(UpdateVariableOverlay))
+export default connector(UpdateVariableOverlay)

--- a/src/variables/components/VariableImportOverlay.tsx
+++ b/src/variables/components/VariableImportOverlay.tsx
@@ -1,6 +1,6 @@
-import React, {PureComponent} from 'react'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect, ConnectedProps} from 'react-redux'
+import React, {FC, useState} from 'react'
+import {useHistory} from 'react-router-dom'
+import {useDispatch} from 'react-redux'
 
 // Components
 import ImportOverlay from 'src/shared/components/ImportOverlay'
@@ -9,11 +9,8 @@ import ImportOverlay from 'src/shared/components/ImportOverlay'
 import {invalidJSON} from 'src/shared/copy/notifications'
 
 // Actions
-import {
-  createVariableFromTemplate as createVariableFromTemplateAction,
-  getVariables as getVariablesAction,
-} from 'src/variables/actions/thunks'
-import {notify as notifyAction} from 'src/shared/actions/notifications'
+import {createVariableFromTemplate} from 'src/variables/actions/thunks'
+import {notify} from 'src/shared/actions/notifications'
 
 // Types
 import {ComponentStatus} from '@influxdata/clockface'
@@ -21,64 +18,44 @@ import {ComponentStatus} from '@influxdata/clockface'
 // Utils
 import jsonlint from 'jsonlint-mod'
 
-interface State {
-  status: ComponentStatus
-}
+const VariableImportOverlay: FC = () => {
+  const dispatch = useDispatch()
+  const [status, setStatus] = useState(ComponentStatus.Default)
+  const history = useHistory()
 
-type ReduxProps = ConnectedProps<typeof connector>
-type Props = RouteComponentProps<{orgID: string}> & ReduxProps
-
-class VariableImportOverlay extends PureComponent<Props> {
-  public state: State = {
-    status: ComponentStatus.Default,
-  }
-
-  public render() {
-    return (
-      <ImportOverlay
-        onDismissOverlay={this.onDismiss}
-        resourceName="Variable"
-        onSubmit={this.handleImportVariable}
-        status={this.state.status}
-        updateStatus={this.updateOverlayStatus}
-      />
-    )
-  }
-
-  private onDismiss = () => {
-    const {history} = this.props
-
+  const onDismiss = () => {
     history.goBack()
   }
 
-  private updateOverlayStatus = (status: ComponentStatus) =>
-    this.setState(() => ({status}))
+  const updateOverlayStatus = (overlayStatus: ComponentStatus) => {
+    setStatus(overlayStatus)
+  }
 
-  private handleImportVariable = (uploadContent: string) => {
-    const {createVariableFromTemplate, notify} = this.props
-
+  const handleImportVariable = (uploadContent: string) => {
     let template
-    this.updateOverlayStatus(ComponentStatus.Default)
+    updateOverlayStatus(ComponentStatus.Default)
     try {
       template = jsonlint.parse(uploadContent)
     } catch (error) {
-      this.updateOverlayStatus(ComponentStatus.Error)
-      notify(invalidJSON(error.message))
+      updateOverlayStatus(ComponentStatus.Error)
+      dispatch(notify(invalidJSON(error.message)))
       return
     }
 
-    createVariableFromTemplate(template)
+    dispatch(createVariableFromTemplate(template))
 
-    this.onDismiss()
+    onDismiss()
   }
+
+  return (
+    <ImportOverlay
+      onDismissOverlay={onDismiss}
+      resourceName="Variable"
+      onSubmit={handleImportVariable}
+      status={status}
+      updateStatus={updateOverlayStatus}
+    />
+  )
 }
 
-const mdtp = {
-  createVariableFromTemplate: createVariableFromTemplateAction,
-  getVariables: getVariablesAction,
-  notify: notifyAction,
-}
-
-const connector = connect(null, mdtp)
-
-export default connector(withRouter(VariableImportOverlay))
+export default VariableImportOverlay

--- a/src/variables/components/VariableList.tsx
+++ b/src/variables/components/VariableList.tsx
@@ -16,7 +16,6 @@ import {getSortedResources} from 'src/shared/utils/sort'
 interface Props {
   variables: Variable[]
   emptyState: JSX.Element
-  onDeleteVariable: (variable: Variable) => void
   onFilterChange: (searchTerm: string) => void
   sortKey: string
   sortDirection: Sort
@@ -30,7 +29,6 @@ const VariableList: FC<Props> = props => {
     sortKey,
     sortDirection,
     sortType,
-    onDeleteVariable,
     onFilterChange,
   } = props
 
@@ -47,7 +45,6 @@ const VariableList: FC<Props> = props => {
             <VariableCard
               key={variable.id || `variable-${index}`}
               variable={variable}
-              onDeleteVariable={onDeleteVariable}
               onFilterChange={onFilterChange}
             />
           ))}


### PR DESCRIPTION
This PR is related to some work that needs to be done to get us to a point where we can transition to React 18. Taking this one step at a time so that things are scoped out. The benefit in us moving to React 18 would be a lot better responsiveness in batched updates on the UI