### PR TITLE
chore: replace `-30d` time range with `-100y` for sample data

### DIFF
--- a/src/dataExplorer/context/fields.tsx
+++ b/src/dataExplorer/context/fields.tsx
@@ -78,7 +78,7 @@ export const FieldsProvider: FC<Prop> = ({children, scope}) => {
     }
 
     let queryText = `${_source}
-      |> range(start: ${CACHING_REQUIRED_START_DATE}, stop: ${CACHING_REQUIRED_END_DATE})
+      |> range(start: -100y, stop: now())
       |> filter(fn: (r) => (r["_measurement"] == "${measurement}"))
       |> keep(columns: ["_field"])
       |> group()

--- a/src/dataExplorer/context/fields.tsx
+++ b/src/dataExplorer/context/fields.tsx
@@ -77,9 +77,8 @@ export const FieldsProvider: FC<Prop> = ({children, scope}) => {
       _source += FROM_BUCKET(bucket.name)
     }
 
-    // TODO: is 30d large enough to get all field values?
     let queryText = `${_source}
-      |> range(start: -30d, stop: now())
+      |> range(start: ${CACHING_REQUIRED_START_DATE}, stop: ${CACHING_REQUIRED_END_DATE})
       |> filter(fn: (r) => (r["_measurement"] == "${measurement}"))
       |> keep(columns: ["_field"])
       |> group()

--- a/src/dataExplorer/context/measurements.tsx
+++ b/src/dataExplorer/context/measurements.tsx
@@ -75,9 +75,8 @@ export const MeasurementProvider: FC<Prop> = ({children, scope}) => {
       _source += FROM_BUCKET(bucket.name)
     }
 
-    // TODO: is 30d large enough to get all measurement values?
     let queryText = `${_source}
-      |> range(start: -30d, stop: now())
+      |> range(start: ${CACHING_REQUIRED_START_DATE}, stop: ${CACHING_REQUIRED_END_DATE})
       |> filter(fn: (r) => true)
       |> keep(columns: ["_measurement"])
       |> group()

--- a/src/dataExplorer/context/measurements.tsx
+++ b/src/dataExplorer/context/measurements.tsx
@@ -76,7 +76,7 @@ export const MeasurementProvider: FC<Prop> = ({children, scope}) => {
     }
 
     let queryText = `${_source}
-      |> range(start: ${CACHING_REQUIRED_START_DATE}, stop: ${CACHING_REQUIRED_END_DATE})
+      |> range(start: -100y, stop: now())
       |> filter(fn: (r) => true)
       |> keep(columns: ["_measurement"])
       |> group()

--- a/src/dataExplorer/context/tags.tsx
+++ b/src/dataExplorer/context/tags.tsx
@@ -92,16 +92,16 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
     }
 
     let queryText = `${_source}
-        |> range(start: ${CACHING_REQUIRED_START_DATE}, stop: ${CACHING_REQUIRED_END_DATE})
-        |> filter(fn: (r) => true)
-        |> keys()
-        |> keep(columns: ["_value"])
-        |> distinct()
-        |> filter(fn: (r) => r._value != "_measurement" and r._value != "_field")
-        |> filter(fn: (r) => r._value != "_time" and r._value != "_start" and r._value !=  "_stop" and r._value != "_value")
-        |> limit(n: ${limit})
-        |> sort()
-      `
+      |> range(start: -100y, stop: now())
+      |> filter(fn: (r) => true)
+      |> keys()
+      |> keep(columns: ["_value"])
+      |> distinct()
+      |> filter(fn: (r) => r._value != "_measurement" and r._value != "_field")
+      |> filter(fn: (r) => r._value != "_time" and r._value != "_start" and r._value !=  "_stop" and r._value != "_value")
+      |> limit(n: ${limit})
+      |> sort()
+    `
 
     if (bucket.type !== 'sample' && isFlagEnabled('newQueryBuilder')) {
       _source = `${IMPORT_REGEXP}${IMPORT_INFLUX_SCHEMA}`
@@ -173,7 +173,7 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
     }
 
     let queryText = `${_source}
-      |> range(start: ${CACHING_REQUIRED_START_DATE}, stop: ${CACHING_REQUIRED_END_DATE})
+      |> range(start: -100y, stop: now())
       |> filter(fn: (r) => (r["_measurement"] == "${measurement}"))
       |> keep(columns: ["${tagKey}"])
       |> group()

--- a/src/dataExplorer/context/tags.tsx
+++ b/src/dataExplorer/context/tags.tsx
@@ -91,9 +91,8 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
       _source += FROM_BUCKET(bucket.name)
     }
 
-    // TODO: is 30d large enough to get all tag keys?
     let queryText = `${_source}
-        |> range(start: -30d, stop: now())
+        |> range(start: ${CACHING_REQUIRED_START_DATE}, stop: ${CACHING_REQUIRED_END_DATE})
         |> filter(fn: (r) => true)
         |> keys()
         |> keep(columns: ["_value"])
@@ -173,9 +172,8 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
       _source += FROM_BUCKET(bucket.name)
     }
 
-    // TODO: is 30d large enough to get all tag values for this key?
     let queryText = `${_source}
-      |> range(start: -30d, stop: now())
+      |> range(start: ${CACHING_REQUIRED_START_DATE}, stop: ${CACHING_REQUIRED_END_DATE})
       |> filter(fn: (r) => (r["_measurement"] == "${measurement}"))
       |> keep(columns: ["${tagKey}"])
       |> group()


### PR DESCRIPTION
Closes #4676 

~~This PR replace the `-30d` time range with constant start and end dates to speed up query.~~

This PR replace the `-30d` time range with `-100y` for sample data. See [below](https://github.com/influxdata/ui/pull/4678#issuecomment-1138944434) for the reason why query sample data is different from query real data.