### PR TITLE
feat: add eventing for helpbar

### DIFF
--- a/src/pageLayout/containers/TreeNav.tsx
+++ b/src/pageLayout/containers/TreeNav.tsx
@@ -185,7 +185,7 @@ const TreeSidebar: FC<ReduxProps & RouteComponentProps> = () =>
                   linkElement={() => (
                     <SafeBlankLink
                       href="https://community.influxdata.com"
-                      onClick={() => handleEventing('OfficialForum')}
+                      onClick={() => handleEventing('officialForum')}
                     />
                   )}
                 />

--- a/src/pageLayout/containers/TreeNav.tsx
+++ b/src/pageLayout/containers/TreeNav.tsx
@@ -42,7 +42,7 @@ const TreeSidebar: FC<ReduxProps & RouteComponentProps> = () =>
       AppSettingContext
     )
     const org = useSelector(getOrg)
-    let location = useLocation()
+    const location = useLocation()
     useEffect(() => {
       if (isFlagEnabled('helpBar')) {
         const helpBarMenu = document.querySelectorAll<HTMLElement>(

--- a/src/pageLayout/containers/TreeNav.tsx
+++ b/src/pageLayout/containers/TreeNav.tsx
@@ -72,29 +72,10 @@ const TreeSidebar: FC<ReduxProps & RouteComponentProps> = () =>
       }
     }
 
-    const handleEventing = (): void => {
+    const handleEventing = (link: string): void => {
       const currentPage = location.pathname
-      event('help.and.support.clicked', {from: currentPage})
+      event(`helpBar.${link}.opened`, {}, {from: currentPage})
     }
-
-    // Hiding Contact Support and Feedback code for Help Bar phase 1 release
-    // https://github.com/influxdata/ui/issues/3457
-    // https://github.com/influxdata/ui/issues/3454
-    // const handleSelect = (): void => {
-    //   const accountType = quartzMe?.accountType ?? 'free'
-    //   const isPayGCustomer = accountType !== 'free'
-
-    //   if (isPayGCustomer) {
-    //     showOverlay('payg-support', null, dismissOverlay)
-    //   } else {
-    //     showOverlay('free-account-support', null, dismissOverlay)
-    //   }
-    // }
-
-    // const openFeedbackOverlay = (): void => {
-    //   showOverlay('feedback-questions', null, dismissOverlay)
-    //   console.log('opened feedback overlay')
-    // }
 
     return (
       <OrgSettings>
@@ -181,7 +162,7 @@ const TreeSidebar: FC<ReduxProps & RouteComponentProps> = () =>
                   linkElement={() => (
                     <SafeBlankLink
                       href="https://docs.influxdata.com/"
-                      onClick={handleEventing}
+                      onClick={() => handleEventing('documentation')}
                     />
                   )}
                 />
@@ -192,16 +173,10 @@ const TreeSidebar: FC<ReduxProps & RouteComponentProps> = () =>
                   linkElement={() => (
                     <SafeBlankLink
                       href="https://docs.influxdata.com/influxdb/cloud/reference/faq/"
-                      onClick={handleEventing}
+                      onClick={() => handleEventing('faq')}
                     />
                   )}
                 />
-                {/* <TreeNav.SubItem
-                  id="contactSupport"
-                  label="Contact Support"
-                  testID="nav-subitem-contact-support"
-                  onClick={handleSelect}
-                /> */}
                 <TreeNav.SubHeading label="Community" />
                 <TreeNav.SubItem
                   id="offcialForum"
@@ -210,7 +185,7 @@ const TreeSidebar: FC<ReduxProps & RouteComponentProps> = () =>
                   linkElement={() => (
                     <SafeBlankLink
                       href="https://community.influxdata.com"
-                      onClick={handleEventing}
+                      onClick={() => handleEventing('OfficialForum')}
                     />
                   )}
                 />
@@ -222,13 +197,6 @@ const TreeSidebar: FC<ReduxProps & RouteComponentProps> = () =>
                     <SafeBlankLink href="https://influxcommunity.slack.com/join/shared_invite/zt-156zm7ult-LcIW2T4TwLYeS8rZbCP1mw#/shared-invite/email" />
                   )}
                 />
-                {/* <TreeNav.SubHeading label="Feedback" /> */}
-                {/* <TreeNav.SubItem
-                  id="feedback"
-                  label="Feedback & Questions"
-                  testID="nav-subitem-feedback-questions"
-                  onClick={openFeedbackOverlay}
-                /> */}
               </TreeNav.SubMenu>
             </TreeNav.Item>
           ) : null}

--- a/src/pageLayout/containers/TreeNav.tsx
+++ b/src/pageLayout/containers/TreeNav.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC, useContext, useEffect} from 'react'
-import {Link} from 'react-router-dom'
+import {Link, useLocation} from 'react-router-dom'
 import {useSelector} from 'react-redux'
 import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
@@ -42,7 +42,7 @@ const TreeSidebar: FC<ReduxProps & RouteComponentProps> = () =>
       AppSettingContext
     )
     const org = useSelector(getOrg)
-
+    let location = useLocation()
     useEffect(() => {
       if (isFlagEnabled('helpBar')) {
         const helpBarMenu = document.querySelectorAll<HTMLElement>(
@@ -72,6 +72,11 @@ const TreeSidebar: FC<ReduxProps & RouteComponentProps> = () =>
       }
     }
 
+    const handleEventing = (): void => {
+      const currentPage = location.pathname
+      event('help.and.support.clicked', {from: currentPage})
+    }
+
     // Hiding Contact Support and Feedback code for Help Bar phase 1 release
     // https://github.com/influxdata/ui/issues/3457
     // https://github.com/influxdata/ui/issues/3454
@@ -88,6 +93,7 @@ const TreeSidebar: FC<ReduxProps & RouteComponentProps> = () =>
 
     // const openFeedbackOverlay = (): void => {
     //   showOverlay('feedback-questions', null, dismissOverlay)
+    //   console.log('opened feedback overlay')
     // }
 
     return (
@@ -173,7 +179,10 @@ const TreeSidebar: FC<ReduxProps & RouteComponentProps> = () =>
                   label="Documentation"
                   testID="nav-subitem-documentation"
                   linkElement={() => (
-                    <SafeBlankLink href="https://docs.influxdata.com/" />
+                    <SafeBlankLink
+                      href="https://docs.influxdata.com/"
+                      onClick={handleEventing}
+                    />
                   )}
                 />
                 <TreeNav.SubItem
@@ -181,22 +190,28 @@ const TreeSidebar: FC<ReduxProps & RouteComponentProps> = () =>
                   label="FAQs"
                   testID="nav-subitem-faqs"
                   linkElement={() => (
-                    <SafeBlankLink href="https://docs.influxdata.com/influxdb/cloud/reference/faq/" />
+                    <SafeBlankLink
+                      href="https://docs.influxdata.com/influxdb/cloud/reference/faq/"
+                      onClick={handleEventing}
+                    />
                   )}
                 />
                 {/* <TreeNav.SubItem
-                id="contactSupport"
-                label="Contact Support"
-                testID="nav-subitem-contact-support"
-                onClick={handleSelect}
-              /> */}
+                  id="contactSupport"
+                  label="Contact Support"
+                  testID="nav-subitem-contact-support"
+                  onClick={handleSelect}
+                /> */}
                 <TreeNav.SubHeading label="Community" />
                 <TreeNav.SubItem
                   id="offcialForum"
                   label="Official Forum"
                   testID="nav-subitem-forum"
                   linkElement={() => (
-                    <SafeBlankLink href="https://community.influxdata.com" />
+                    <SafeBlankLink
+                      href="https://community.influxdata.com"
+                      onClick={handleEventing}
+                    />
                   )}
                 />
                 <TreeNav.SubItem
@@ -207,13 +222,13 @@ const TreeSidebar: FC<ReduxProps & RouteComponentProps> = () =>
                     <SafeBlankLink href="https://influxcommunity.slack.com/join/shared_invite/zt-156zm7ult-LcIW2T4TwLYeS8rZbCP1mw#/shared-invite/email" />
                   )}
                 />
-                {/* <TreeNav.SubHeading label="Feedback" />
-              <TreeNav.SubItem
-                id="feedback"
-                label="Feedback & Questions"
-                testID="nav-subitem-feedback-questions"
-                onClick={openFeedbackOverlay}
-              /> */}
+                {/* <TreeNav.SubHeading label="Feedback" /> */}
+                {/* <TreeNav.SubItem
+                  id="feedback"
+                  label="Feedback & Questions"
+                  testID="nav-subitem-feedback-questions"
+                  onClick={openFeedbackOverlay}
+                /> */}
               </TreeNav.SubMenu>
             </TreeNav.Item>
           ) : null}

--- a/src/support/components/FeedbackQuestionsOverlay.tsx
+++ b/src/support/components/FeedbackQuestionsOverlay.tsx
@@ -1,4 +1,5 @@
 import React, {FC, ChangeEvent, useContext, useState} from 'react'
+import {useSelector} from 'react-redux'
 
 // Components
 import {
@@ -17,16 +18,26 @@ import {OverlayContext} from 'src/overlays/components/OverlayController'
 // Types
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
 
+// Selectors
+import {getOrg} from 'src/organizations/selectors'
+import {getMe} from 'src/me/selectors'
+
+// Utils
+import {event} from 'src/cloud/utils/reporting'
+
 interface OwnProps {
   onClose: () => void
 }
 
 const FeedbackQuestionsOverlay: FC<OwnProps> = () => {
   const {onClose} = useContext(OverlayContext)
+  const {id: orgID} = useSelector(getOrg)
+  const {id: meID} = useSelector(getMe)
   const [feedbackText, setFeedbackText] = useState('')
 
   const handleSubmit = () => {
     // handle form submit
+    event('feedback.and.questions.submitted', {userID: meID, orgID: orgID})
   }
 
   const handleInputChange = (e: ChangeEvent<HTMLTextAreaElement>) => {

--- a/src/support/components/FeedbackQuestionsOverlay.tsx
+++ b/src/support/components/FeedbackQuestionsOverlay.tsx
@@ -37,7 +37,11 @@ const FeedbackQuestionsOverlay: FC<OwnProps> = () => {
 
   const handleSubmit = () => {
     // handle form submit
-    event('feedback.and.questions.submitted', {userID: meID, orgID: orgID})
+    event(
+      'helpBar.feedbackAndQuestions.submitted',
+      {},
+      {userID: meID, orgID: orgID}
+    )
   }
 
   const handleInputChange = (e: ChangeEvent<HTMLTextAreaElement>) => {

--- a/src/support/components/PayGSupportOverlay.tsx
+++ b/src/support/components/PayGSupportOverlay.tsx
@@ -1,4 +1,5 @@
 import React, {FC, ChangeEvent, useContext, useState} from 'react'
+import {useSelector} from 'react-redux'
 
 // Components
 import {
@@ -25,12 +26,21 @@ import {OverlayContext} from 'src/overlays/components/OverlayController'
 // Types
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
 
+// Selectors
+import {getOrg} from 'src/organizations/selectors'
+import {getMe} from 'src/me/selectors'
+
+// Utils
+import {event} from 'src/cloud/utils/reporting'
+
 import './ContactSupport.scss'
 interface OwnProps {
   onClose: () => void
 }
 
 const PayGSupportOverlay: FC<OwnProps> = () => {
+  const {id: orgID} = useSelector(getOrg)
+  const {id: meID} = useSelector(getMe)
   const [subject, setSubject] = useState('')
   const [severity, setSeverity] = useState('')
   const [textInput, setTextInput] = useState('')
@@ -53,6 +63,7 @@ const PayGSupportOverlay: FC<OwnProps> = () => {
   }
   const handleSubmit = (): void => {
     // submit support form
+    event('support.request.submitted', {userID: meID, orgID: orgID})
   }
 
   const handleSubjectChange = (event: ChangeEvent<HTMLInputElement>) => {

--- a/src/support/components/PayGSupportOverlay.tsx
+++ b/src/support/components/PayGSupportOverlay.tsx
@@ -63,7 +63,7 @@ const PayGSupportOverlay: FC<OwnProps> = () => {
   }
   const handleSubmit = (): void => {
     // submit support form
-    event('support.request.submitted', {userID: meID, orgID: orgID})
+    event('helpBar.supportRequest.submitted', {}, {userID: meID, orgID: orgID})
   }
 
   const handleSubjectChange = (event: ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
Closes #4589 

Pr adds events for the following scenarios 

- When support request is submitted from PAYG user 
- When feedback and question is submitted 
- when help bar docs are opened (including where the user was in the UI when seeking help)
