### PR TITLE
chore: org rename exclusively done in quartz

### DIFF
--- a/cypress/e2e/shared/about.test.ts
+++ b/cypress/e2e/shared/about.test.ts
@@ -42,9 +42,7 @@ describe('About Page', () => {
     const newOrgName = `hard@knock.life${Math.random()}`
 
     const patchOrgPath =
-      Cypress.env('dexUrl') === 'CLOUD'
-        ? 'api/v2/quartz/orgs/*'
-        : 'api/v2/orgs/*'
+      Cypress.env('dexUrl') === 'OSS' ? 'api/v2/orgs/*' : 'api/v2/quartz/orgs/*'
 
     cy.intercept('PATCH', patchOrgPath).as('patchOrg')
     cy.getByTestID('create-org-name-input').type(newOrgName)

--- a/cypress/e2e/shared/about.test.ts
+++ b/cypress/e2e/shared/about.test.ts
@@ -1,4 +1,4 @@
-import {CLOUD} from 'src/shared/constants'
+import {CLOUD} from '../../../src/shared/constants'
 import {Organization} from '../../../src/types'
 
 describe('About Page', () => {

--- a/cypress/e2e/shared/about.test.ts
+++ b/cypress/e2e/shared/about.test.ts
@@ -1,4 +1,3 @@
-import {CLOUD} from '../../../src/shared/constants'
 import {Organization} from '../../../src/types'
 
 describe('About Page', () => {
@@ -42,7 +41,10 @@ describe('About Page', () => {
 
     const newOrgName = `hard@knock.life${Math.random()}`
 
-    const patchOrgPath = CLOUD ? 'api/v2/quartz/orgs/*' : 'api/v2/orgs/*'
+    const patchOrgPath =
+      Cypress.env('DEX_URL_VAR') === 'CLOUD'
+        ? 'api/v2/quartz/orgs/*'
+        : 'api/v2/orgs/*'
 
     cy.intercept('PATCH', patchOrgPath).as('patchOrg')
     cy.getByTestID('create-org-name-input').type(newOrgName)

--- a/cypress/e2e/shared/about.test.ts
+++ b/cypress/e2e/shared/about.test.ts
@@ -1,3 +1,4 @@
+import {CLOUD} from 'src/shared/constants'
 import {Organization} from '../../../src/types'
 
 describe('About Page', () => {
@@ -41,7 +42,9 @@ describe('About Page', () => {
 
     const newOrgName = `hard@knock.life${Math.random()}`
 
-    cy.intercept('PATCH', 'api/v2/quartz/orgs/*').as('patchOrg')
+    const patchOrgPath = CLOUD ? 'api/v2/quartz/orgs/*' : 'api/v2/orgs/*'
+
+    cy.intercept('PATCH', patchOrgPath).as('patchOrg')
     cy.getByTestID('create-org-name-input').type(newOrgName)
     cy.getByTestID('rename-org-submit--button')
       .should('not.be.disabled')

--- a/cypress/e2e/shared/about.test.ts
+++ b/cypress/e2e/shared/about.test.ts
@@ -41,7 +41,7 @@ describe('About Page', () => {
 
     const newOrgName = `hard@knock.life${Math.random()}`
 
-    cy.intercept('PATCH', 'api/v2/orgs/*').as('patchOrg')
+    cy.intercept('PATCH', 'api/v2/quartz/orgs/*').as('patchOrg')
 
     cy.getByTestID('create-org-name-input').type(newOrgName)
     cy.getByTestID('rename-org-submit--button')

--- a/cypress/e2e/shared/about.test.ts
+++ b/cypress/e2e/shared/about.test.ts
@@ -41,14 +41,12 @@ describe('About Page', () => {
 
     const newOrgName = `hard@knock.life${Math.random()}`
 
-    cy.intercept('PATCH', 'api/v2/quartz/orgs/*').as('patchOrg')
-
     cy.getByTestID('create-org-name-input').type(newOrgName)
     cy.getByTestID('rename-org-submit--button')
       .should('not.be.disabled')
       .click()
 
-    cy.wait('@patchOrg')
+    cy.intercept('PATCH', 'api/v2/quartz/orgs/*')
 
     cy.getByTestID('notification-success')
       .should('be.visible')

--- a/cypress/e2e/shared/about.test.ts
+++ b/cypress/e2e/shared/about.test.ts
@@ -42,9 +42,9 @@ describe('About Page', () => {
     const newOrgName = `hard@knock.life${Math.random()}`
 
     const patchOrgPath =
-      Cypress.env('DEX_URL_VAR') === 'OSS'
-        ? 'api/v2/orgs/*'
-        : 'api/v2/quartz/orgs/*'
+      Cypress.env('dexUrl') === 'CLOUD'
+        ? 'api/v2/quartz/orgs/*'
+        : 'api/v2/orgs/*'
 
     cy.intercept('PATCH', patchOrgPath).as('patchOrg')
     cy.getByTestID('create-org-name-input').type(newOrgName)

--- a/cypress/e2e/shared/about.test.ts
+++ b/cypress/e2e/shared/about.test.ts
@@ -41,12 +41,13 @@ describe('About Page', () => {
 
     const newOrgName = `hard@knock.life${Math.random()}`
 
+    cy.intercept('PATCH', 'api/v2/quartz/orgs/*').as('patchOrg')
     cy.getByTestID('create-org-name-input').type(newOrgName)
     cy.getByTestID('rename-org-submit--button')
       .should('not.be.disabled')
       .click()
 
-    cy.intercept('PATCH', 'api/v2/quartz/orgs/*')
+    cy.wait('@patchOrg')
 
     cy.getByTestID('notification-success')
       .should('be.visible')

--- a/cypress/e2e/shared/about.test.ts
+++ b/cypress/e2e/shared/about.test.ts
@@ -42,9 +42,9 @@ describe('About Page', () => {
     const newOrgName = `hard@knock.life${Math.random()}`
 
     const patchOrgPath =
-      Cypress.env('DEX_URL_VAR') === 'CLOUD'
-        ? 'api/v2/quartz/orgs/*'
-        : 'api/v2/orgs/*'
+      Cypress.env('DEX_URL_VAR') === 'OSS'
+        ? 'api/v2/orgs/*'
+        : 'api/v2/quartz/orgs/*'
 
     cy.intercept('PATCH', patchOrgPath).as('patchOrg')
     cy.getByTestID('create-org-name-input').type(newOrgName)

--- a/docker/Dockerfile.cypress
+++ b/docker/Dockerfile.cypress
@@ -14,6 +14,7 @@ COPY ./cypress ./cypress
 COPY ./src/types ./src/types
 COPY ./src/timeMachine/constants ./src/timeMachine/constants
 COPY ./src/shared/constants/fluxFunctions.ts ./src/shared/constants/fluxFunctions.ts
+COPY ./src/shared/constants/index.ts ./src/shared/constants/index.ts
 COPY ./src/shared/actions/flags.ts ./src/shared/actions/flags.ts
 COPY ./src/utils/datetime/constants.ts ./src/utils/datetime/constants.ts
 

--- a/docker/Dockerfile.cypress
+++ b/docker/Dockerfile.cypress
@@ -12,10 +12,9 @@ RUN yarn add cypress-circleci-reporter
 COPY ./cypress.json .
 COPY ./cypress ./cypress
 COPY ./src/types ./src/types
-COPY ./src/client/index.ts ./src/client/index.ts
+COPY ./src/client ./src/client
 COPY ./src/timeMachine/constants ./src/timeMachine/constants
-COPY ./src/shared/constants/fluxFunctions.ts ./src/shared/constants/fluxFunctions.ts
-COPY ./src/shared/constants/index.ts ./src/shared/constants/index.ts
+COPY ./src/shared/constants ./src/shared/constants
 COPY ./src/shared/actions/flags.ts ./src/shared/actions/flags.ts
 COPY ./src/utils/datetime/constants.ts ./src/utils/datetime/constants.ts
 

--- a/docker/Dockerfile.cypress
+++ b/docker/Dockerfile.cypress
@@ -12,7 +12,6 @@ RUN yarn add cypress-circleci-reporter
 COPY ./cypress.json ./cypress.json
 COPY ./cypress ./cypress
 COPY ./src/types ./src/types
-COPY ./src/client ./src/client
 COPY ./src/timeMachine/constants ./src/timeMachine/constants
 COPY ./src/shared/constants ./src/shared/constants
 COPY ./src/shared/actions/flags.ts ./src/shared/actions/flags.ts

--- a/docker/Dockerfile.cypress
+++ b/docker/Dockerfile.cypress
@@ -12,6 +12,7 @@ RUN yarn add cypress-circleci-reporter
 COPY ./cypress.json .
 COPY ./cypress ./cypress
 COPY ./src/types ./src/types
+COPY ./src/client/index.ts ./src/client/index.ts
 COPY ./src/timeMachine/constants ./src/timeMachine/constants
 COPY ./src/shared/constants/fluxFunctions.ts ./src/shared/constants/fluxFunctions.ts
 COPY ./src/shared/constants/index.ts ./src/shared/constants/index.ts

--- a/docker/Dockerfile.cypress
+++ b/docker/Dockerfile.cypress
@@ -9,7 +9,7 @@ COPY ./package.json .
 
 RUN yarn add cypress-circleci-reporter
 
-COPY ./cypress.json .
+COPY ./cypress.json ./cypress.json
 COPY ./cypress ./cypress
 COPY ./src/types ./src/types
 COPY ./src/client ./src/client

--- a/docker/Dockerfile.cypress
+++ b/docker/Dockerfile.cypress
@@ -13,6 +13,7 @@ COPY ./cypress.json ./cypress.json
 COPY ./cypress ./cypress
 COPY ./src/types ./src/types
 COPY ./src/client ./src/client
+COPY ./src/client/generatedRoutes.ts ./src/client/generatedRoutes.ts
 COPY ./src/timeMachine/constants ./src/timeMachine/constants
 COPY ./src/shared/constants ./src/shared/constants
 COPY ./src/shared/actions/flags.ts ./src/shared/actions/flags.ts

--- a/docker/Dockerfile.cypress
+++ b/docker/Dockerfile.cypress
@@ -13,7 +13,6 @@ COPY ./cypress.json ./cypress.json
 COPY ./cypress ./cypress
 COPY ./src/types ./src/types
 COPY ./src/client ./src/client
-COPY ./src/client/generatedRoutes.ts ./src/client/generatedRoutes.ts
 COPY ./src/timeMachine/constants ./src/timeMachine/constants
 COPY ./src/shared/constants ./src/shared/constants
 COPY ./src/shared/actions/flags.ts ./src/shared/actions/flags.ts

--- a/src/organizations/actions/thunks.ts
+++ b/src/organizations/actions/thunks.ts
@@ -182,39 +182,23 @@ export const updateOrg = (org: Organization) => async (
   dispatch: Dispatch<Action | NotificationAction>
 ) => {
   try {
-    if (CLOUD) {
-      const resp = await patchOrg({orgId: org.id, data: org})
+    const resp = CLOUD
+      ? await patchOrg({orgId: org.id, data: org})
+      : await api.patchOrg({orgID: org.id, data: org})
 
-      if (resp.status !== 200) {
-        throw new Error(resp.data.message)
-      }
-
-      const updatedOrg = resp.data
-      const normOrg = normalize<Organization, OrgEntities, string>(
-        updatedOrg,
-        orgSchema
-      )
-
-      dispatch(editOrg(normOrg))
-
-      dispatch(notify(orgEditSuccess()))
-    } else {
-      const resp = await api.patchOrg({orgID: org.id, data: org})
-
-      if (resp.status !== 200) {
-        throw new Error(resp.data.message)
-      }
-
-      const updatedOrg = resp.data
-      const normOrg = normalize<Organization, OrgEntities, string>(
-        updatedOrg,
-        orgSchema
-      )
-
-      dispatch(editOrg(normOrg))
-
-      dispatch(notify(orgEditSuccess()))
+    if (resp.status !== 200) {
+      throw new Error(resp.data.message)
     }
+
+    const updatedOrg = resp.data
+    const normOrg = normalize<Organization, OrgEntities, string>(
+      updatedOrg,
+      orgSchema
+    )
+
+    dispatch(editOrg(normOrg))
+
+    dispatch(notify(orgEditSuccess()))
   } catch (error) {
     dispatch(notify(orgEditFailed()))
     console.error(error)
@@ -228,43 +212,28 @@ export const renameOrg = (
   dispatch: Dispatch<Action | NotificationAction>
 ) => {
   try {
-    if (CLOUD) {
-      const resp = await patchOrg({
-        orgId: org.id,
-        data: {name: org.name, description: org.description},
-      })
+    const resp = CLOUD
+      ? await patchOrg({
+          orgId: org.id,
+          data: {name: org.name, description: org.description},
+        })
+      : await api.patchOrg({
+          orgID: org.id,
+          data: org,
+        })
 
-      if (resp.status !== 200) {
-        throw new Error(resp.data.message)
-      }
-      const updatedOrg = resp.data
-
-      const normOrg = normalize<Organization, OrgEntities, string>(
-        updatedOrg,
-        orgSchema
-      )
-
-      dispatch(editOrg(normOrg))
-      dispatch(notify(orgRenameSuccess(updatedOrg.name)))
-    } else {
-      const resp = await api.patchOrg({
-        orgID: org.id,
-        data: org,
-      })
-
-      if (resp.status !== 200) {
-        throw new Error(resp.data.message)
-      }
-      const updatedOrg = resp.data
-
-      const normOrg = normalize<Organization, OrgEntities, string>(
-        updatedOrg,
-        orgSchema
-      )
-
-      dispatch(editOrg(normOrg))
-      dispatch(notify(orgRenameSuccess(updatedOrg.name)))
+    if (resp.status !== 200) {
+      throw new Error(resp.data.message)
     }
+    const updatedOrg = resp.data
+
+    const normOrg = normalize<Organization, OrgEntities, string>(
+      updatedOrg,
+      orgSchema
+    )
+
+    dispatch(editOrg(normOrg))
+    dispatch(notify(orgRenameSuccess(updatedOrg.name)))
   } catch (error) {
     dispatch(notify(orgRenameFailed(originalName)))
     console.error(error)

--- a/src/organizations/actions/thunks.ts
+++ b/src/organizations/actions/thunks.ts
@@ -182,9 +182,7 @@ export const updateOrg = (org: Organization) => async (
   dispatch: Dispatch<Action | NotificationAction>
 ) => {
   try {
-    const resp = CLOUD
-      ? await patchOrg({orgId: org.id, data: org})
-      : await api.patchOrg({orgID: org.id, data: org})
+    const resp = await api.patchOrg({orgID: org.id, data: org})
 
     if (resp.status !== 200) {
       throw new Error(resp.data.message)

--- a/src/organizations/actions/thunks.ts
+++ b/src/organizations/actions/thunks.ts
@@ -32,6 +32,8 @@ import {gaEvent} from 'src/cloud/utils/reporting'
 
 import {getOrg} from 'src/organizations/selectors'
 
+import {patchOrg} from 'src/client/unityRoutes'
+
 // Schemas
 import {orgSchema, arrayOfOrgs} from 'src/schemas'
 
@@ -177,7 +179,7 @@ export const updateOrg = (org: Organization) => async (
   dispatch: Dispatch<Action | NotificationAction>
 ) => {
   try {
-    const resp = await api.patchOrg({orgID: org.id, data: org})
+    const resp = await patchOrg({orgId: org.id, data: org})
 
     if (resp.status !== 200) {
       throw new Error(resp.data.message)
@@ -205,7 +207,7 @@ export const renameOrg = (
   dispatch: Dispatch<Action | NotificationAction>
 ) => {
   try {
-    const resp = await api.patchOrg({orgID: org.id, data: org})
+    const resp = await patchOrg({orgId: org.id, data: org})
 
     if (resp.status !== 200) {
       throw new Error(resp.data.message)

--- a/src/organizations/actions/thunks.ts
+++ b/src/organizations/actions/thunks.ts
@@ -182,21 +182,39 @@ export const updateOrg = (org: Organization) => async (
   dispatch: Dispatch<Action | NotificationAction>
 ) => {
   try {
-    const resp = await patchOrg({orgId: org.id, data: org})
+    if (CLOUD) {
+      const resp = await patchOrg({orgId: org.id, data: org})
 
-    if (resp.status !== 200) {
-      throw new Error(resp.data.message)
+      if (resp.status !== 200) {
+        throw new Error(resp.data.message)
+      }
+
+      const updatedOrg = resp.data
+      const normOrg = normalize<Organization, OrgEntities, string>(
+        updatedOrg,
+        orgSchema
+      )
+
+      dispatch(editOrg(normOrg))
+
+      dispatch(notify(orgEditSuccess()))
+    } else {
+      const resp = await api.patchOrg({orgID: org.id, data: org})
+
+      if (resp.status !== 200) {
+        throw new Error(resp.data.message)
+      }
+
+      const updatedOrg = resp.data
+      const normOrg = normalize<Organization, OrgEntities, string>(
+        updatedOrg,
+        orgSchema
+      )
+
+      dispatch(editOrg(normOrg))
+
+      dispatch(notify(orgEditSuccess()))
     }
-
-    const updatedOrg = resp.data
-    const normOrg = normalize<Organization, OrgEntities, string>(
-      updatedOrg,
-      orgSchema
-    )
-
-    dispatch(editOrg(normOrg))
-
-    dispatch(notify(orgEditSuccess()))
   } catch (error) {
     dispatch(notify(orgEditFailed()))
     console.error(error)

--- a/src/organizations/actions/thunks.ts
+++ b/src/organizations/actions/thunks.ts
@@ -207,7 +207,7 @@ export const renameOrg = (
   dispatch: Dispatch<Action | NotificationAction>
 ) => {
   try {
-    const resp = await patchOrg({orgId: org.id, data: org})
+    const resp = await patchOrg({orgId: org.id, data: {name: org.name}})
 
     if (resp.status !== 200) {
       throw new Error(resp.data.message)


### PR DESCRIPTION
[Quartz #6173](https://github.com/influxdata/quartz/issues/6173)

This implements the new route for renaming `org`; org renames for Cloud users will now run exclusively through Quartz. UI currently doesn't support `org description` but it remains an optional parameter in the event it becomes available.
