### PR TITLE
fix: redirect to Quartz login upon session expiration

### DIFF
--- a/src/Signin.tsx
+++ b/src/Signin.tsx
@@ -112,20 +112,26 @@ export class Signin extends PureComponent<Props, State> {
       } = this.props
 
       clearInterval(this.intervalID)
-      /**
-       * We'll need this authSessionCookieOn flag off for tools until
-       * Quartz is integrated into that environment
-       */
-      if (CLOUD && isFlagEnabled('authSessionCookieOn')) {
-        const url = new URL(
-          `${window.location.origin}${CLOUD_LOGIN_PATHNAME}?redirectTo=${window.location.href}`
-        )
-        setToLocalStorage('redirectTo', window.location.href)
-        window.location.href = url.href
-        throw error
-      }
 
       if (CLOUD) {
+        if (isFlagEnabled('useQuartzLogin')) {
+          window.location.reload()
+          throw error
+        }
+
+        /**
+         * We'll need this authSessionCookieOn flag off for tools until
+         * Quartz is integrated into that environment
+         */
+        if (isFlagEnabled('authSessionCookieOn')) {
+          const url = new URL(
+            `${window.location.origin}${CLOUD_LOGIN_PATHNAME}?redirectTo=${window.location.href}`
+          )
+          setToLocalStorage('redirectTo', window.location.href)
+          window.location.href = url.href
+          throw error
+        }
+
         const url = new URL(
           `${window.location.origin}${CLOUD_SIGNIN_PATHNAME}?redirectTo=${window.location.href}`
         )

--- a/src/Signin.tsx
+++ b/src/Signin.tsx
@@ -116,7 +116,7 @@ export class Signin extends PureComponent<Props, State> {
       if (CLOUD) {
         if (isFlagEnabled('useQuartzLogin')) {
           window.location.reload()
-          throw error
+          return
         }
 
         /**


### PR DESCRIPTION
Closes #4657 

When a session expires, redirect to the Quartz login page rather than the cluster's login page.
