### PR TITLE
fix: update tag values when a tag key is clicked

### DIFF
--- a/src/dataExplorer/components/TagSelector.tsx
+++ b/src/dataExplorer/components/TagSelector.tsx
@@ -96,11 +96,11 @@ const TagValues: FC<Prop> = ({loading, tagKey, tagValues}) => {
 
     return (
       <Accordion className="tag-selector-value">
-        <Accordion.AccordionHeader className="tag-selector-value--header">
-          <div onClick={() => handleSelectTagKey(tagKey)}>
+        <div onClick={() => handleSelectTagKey(tagKey)}>
+          <Accordion.AccordionHeader className="tag-selector-value--header">
             <SelectorTitle title={tagKey} />
-          </div>
-        </Accordion.AccordionHeader>
+          </Accordion.AccordionHeader>
+        </div>
         <div className="container-side-bar">
           {list}
           {loadMoreButton}


### PR DESCRIPTION
This PR fixes a bug in schema browser. When a tag key is clicked on, it keeps showing "Loading tag values" but no value is loaded. Now this bug is fixed and the expanded area shows the corresponding tag values or error message.

## Before

https://user-images.githubusercontent.com/14298407/170730185-bc091ea9-5b09-46ce-bff8-c6d863dde50d.mov

## After

https://user-images.githubusercontent.com/14298407/170730678-f0be7aca-8628-401b-a132-a35177dbb896.mov


