### PR TITLE
fix: wrap strings in double quotes so strings with commas can render in Table / SimpleTable

### DIFF
--- a/src/timeMachine/utils/rawFluxDataTable.ts
+++ b/src/timeMachine/utils/rawFluxDataTable.ts
@@ -72,6 +72,9 @@ export const parseFromFluxResults = (
       ) {
         columnData = new Date(columnData).toISOString()
       }
+      if (typeof columnData === 'string') {
+        columnData = `"${columnData}"`
+      }
       if (column === 'result') {
         // setting the column data for result as an empty string since the default
         // value given is set in the default headers:


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/4583

https://user-images.githubusercontent.com/18511823/171056239-9f6b6868-9a72-4094-b3d3-9e4f3459b67d.mov


