### PR TITLE
chore(HelpBar): move text inside overlay body

### DIFF
--- a/src/support/components/FreeAccountSupportOverlay.tsx
+++ b/src/support/components/FreeAccountSupportOverlay.tsx
@@ -39,19 +39,18 @@ const FreeAccountSupportOverlay: FC<OwnProps> = () => {
         title="Contact Support"
         onDismiss={onClose}
       />
-
-      <p className="status-page-text">
-        <span>
-          {' '}
-          <Icon glyph={IconFont.Info_New} />{' '}
-        </span>
-        Check our{' '}
-        <SafeBlankLink href="https://status.influxdata.com">
-          status page
-        </SafeBlankLink>{' '}
-        to see if there is an outage impacting your region.
-      </p>
       <Overlay.Body>
+        <p className="status-page-text">
+          <span>
+            {' '}
+            <Icon glyph={IconFont.Info_New} />{' '}
+          </span>
+          Check our{' '}
+          <SafeBlankLink href="https://status.influxdata.com">
+            status page
+          </SafeBlankLink>{' '}
+          to see if there is an outage impacting your region.
+        </p>
         <p>
           Contact support is currently only available for Usage-Based Plan and
           Annual customers. Please try our community resources below to recieve


### PR DESCRIPTION
New info icon inside free-tier support overlay needs to be correctly aligned. 
Pr moves the `p` tag containing status text and icon inside `Overlay.Body`. Check out screenshot below to see the change. 

Before: 
![icon](https://user-images.githubusercontent.com/66275100/171193227-1d803472-c25e-412e-95dc-52276bae632e.png)


After: 
![Screen Shot 2022-05-31 at 9 07 54 AM](https://user-images.githubusercontent.com/66275100/171193365-dc93fa61-9eab-4c99-975f-6f86d390c8db.png)

