### PR TITLE
feat(HelpBar): connect feedback form with feedback link

### DIFF
--- a/src/support/components/FreeAccountSupportOverlay.tsx
+++ b/src/support/components/FreeAccountSupportOverlay.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC, useContext} from 'react'
-import {useSelector} from 'react-redux'
+import {useDispatch, useSelector} from 'react-redux'
 
 // Components
 import {Icon, IconFont, List, Overlay} from '@influxdata/clockface'
@@ -19,6 +19,9 @@ import {
 import {SafeBlankLink} from 'src/utils/SafeBlankLink'
 import {shouldGetCredit250Experience} from 'src/me/selectors'
 
+// Actions
+import {dismissOverlay, showOverlay} from 'src/overlays/actions/overlays'
+
 // Constants
 import {CREDIT_250_EXPERIMENT_ID} from 'src/shared/constants'
 
@@ -31,6 +34,15 @@ interface OwnProps {
 const FreeAccountSupportOverlay: FC<OwnProps> = () => {
   const {onClose} = useContext(OverlayContext)
   const isCredit250ExperienceActive = useSelector(shouldGetCredit250Experience)
+
+  const dispatch = useDispatch()
+
+  const openFeedbackOverlay = (event): void => {
+    event.preventDefault()
+    dispatch(
+      showOverlay('feedback-questions', null, () => dispatch(dismissOverlay))
+    )
+  }
 
   return (
     <Overlay.Container maxWidth={550}>
@@ -71,7 +83,9 @@ const FreeAccountSupportOverlay: FC<OwnProps> = () => {
           </List.Item>
           <List.Item>
             <div className="help-logo feedback" />
-            <SafeBlankLink href="">Feedback & Questions Form</SafeBlankLink>
+            <SafeBlankLink href="" onClick={openFeedbackOverlay}>
+              Feedback & Questions Form
+            </SafeBlankLink>
           </List.Item>
         </List>
       </Overlay.Body>

--- a/src/support/components/FreeAccountSupportOverlay.tsx
+++ b/src/support/components/FreeAccountSupportOverlay.tsx
@@ -25,6 +25,10 @@ import {dismissOverlay, showOverlay} from 'src/overlays/actions/overlays'
 // Constants
 import {CREDIT_250_EXPERIMENT_ID} from 'src/shared/constants'
 
+// Selectors
+import {getOrg} from 'src/organizations/selectors'
+import {getMe} from 'src/me/selectors'
+
 import './ContactSupport.scss'
 
 interface OwnProps {
@@ -32,6 +36,8 @@ interface OwnProps {
 }
 
 const FreeAccountSupportOverlay: FC<OwnProps> = () => {
+  const {id: orgID} = useSelector(getOrg)
+  const {id: meID} = useSelector(getMe)
   const {onClose} = useContext(OverlayContext)
   const isCredit250ExperienceActive = useSelector(shouldGetCredit250Experience)
 
@@ -39,6 +45,11 @@ const FreeAccountSupportOverlay: FC<OwnProps> = () => {
 
   const openFeedbackOverlay = (event): void => {
     event.preventDefault()
+    event(
+      'helpBar.feedbackAndQuestions.supportOverlay.shown',
+      {},
+      {userID: meID, orgID: orgID}
+    )
     dispatch(
       showOverlay('feedback-questions', null, () => dispatch(dismissOverlay))
     )


### PR DESCRIPTION
Inside free tier contact support, the link directing user to feedback and questions form has an empty href. 
Pr adds an `onClick` property that opens the Feedback and Questions form. 


https://user-images.githubusercontent.com/66275100/171212858-97e0329c-ebb1-46e6-ac53-2b2a5f1b4738.mov


