### PR TITLE
fix: handle lsp method throw

### DIFF
--- a/src/languageSupport/languages/flux/lsp/prelude.ts
+++ b/src/languageSupport/languages/flux/lsp/prelude.ts
@@ -25,20 +25,22 @@ class Prelude {
     this._variables = variables
     const previousValue = this._preludeModel.getValue()
 
-    const file = buildUsedVarsOption(this._model.getValue(), variables)
-    const query = format_from_js_file(file)
+    try {
+      const file = buildUsedVarsOption(this._model.getValue(), variables)
+      const query = format_from_js_file(file)
 
-    this._preludeModel.setValue(query)
-    if (query != previousValue) {
       this._preludeModel.setValue(query)
-      this._worker.postMessage(
-        didChange(
-          this._preludeModel.uri.toString(),
-          query,
-          this._preludeModel.getVersionId()
+      if (query != previousValue) {
+        this._preludeModel.setValue(query)
+        this._worker.postMessage(
+          didChange(
+            this._preludeModel.uri.toString(),
+            query,
+            this._preludeModel.getVersionId()
+          )
         )
-      )
-    }
+      }
+    } catch (_) {}
   }
 
   subscribeToModel(editor: EditorType) {


### PR DESCRIPTION
Had unwrapped external method; needed to handle throws.

Noticed when working on another PR. Was not handling the occasional throw. It will error with the black screen and general "InfluxDB error occurred". (Note this is a rare event, and is not the root of all other errors which also trigger the black screen of doom.)