### PR TITLE
test: press {enter} explicitly in tasks test to avoid invalid query in cypress test

### DIFF
--- a/cypress/e2e/shared/tasks.test.ts
+++ b/cypress/e2e/shared/tasks.test.ts
@@ -52,7 +52,7 @@ from(bucket: "${name}")
   it('can create a task using http.post', () => {
     const taskName = 'Task'
     cy.createTaskFromEmpty(taskName, () => {
-      return `import "http"
+      return `import "http" {enter}
 http.post(url: "https://foo.bar/baz", data: bytes(v: "body"))`
     })
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1056,7 +1056,7 @@ export const createTaskFromEmpty = (
   interval: string = '24h',
   offset: string = '20m',
   force: boolean = true,
-  delay: number = 10
+  delay: number = 15
 ) => {
   cy.getByTestID('create-task--button')
     .first()

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1056,7 +1056,7 @@ export const createTaskFromEmpty = (
   interval: string = '24h',
   offset: string = '20m',
   force: boolean = true,
-  delay: number = 15
+  delay: number = 0
 ) => {
   cy.getByTestID('create-task--button')
     .first()


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/4707

### The cause

The problem is with the `cy.type` and how monaco editor is responding with the auto-complete. 

When cypress test types `import "` the monaco editor attempts to autocomplete with `import ""` (auto closing the double quotes). Sometimes monaco editor seems to glitch out and misplace the cursor, causing cypress to enter an invalid query. 

<img width="1019" alt="Screen Shot 2022-05-31 at 12 13 28 PM" src="https://user-images.githubusercontent.com/18511823/171266812-98864e3e-64c3-4329-bb13-f60a34e540f0.png">

<img width="1035" alt="Screen Shot 2022-05-31 at 11 36 08 AM" src="https://user-images.githubusercontent.com/18511823/171269588-2f9c72cb-1fb5-4dd2-a211-e324bba9ad52.png">

(note the missing end quote)

--- 

### The Solution: 

My attempt to fix it does two things: 

1. Force an `{enter}` after the first line so that it is explicit.
2. Make the `delay` between keystrokes to be 0, this seems to fix the autocomplete issue because it doesn't give monaco editor / lsp the time to think too much (?). The reasoning of why it works is a hypothesis of mine. 


Proof of it working: (50 runs with no flakes)

 
<img width="1276" alt="Screen Shot 2022-05-31 at 12 16 35 PM" src="https://user-images.githubusercontent.com/18511823/171267365-488976ff-58a8-4729-a520-ca51204a315b.png">




<!-- Describe your proposed changes here. -->
