### PR TITLE
chore: use resolutions for cross-fetch

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -35,5 +35,5 @@ module.exports = {
   coverageDirectory: './coverage',
   coverageReporters: ['html', 'cobertura'],
   reporters: ['default', 'jest-junit'],
-  testEnvironment: 'jsdom',
+  testEnvironment: './jsdom-custom.js',
 }

--- a/jsdom-custom.js
+++ b/jsdom-custom.js
@@ -1,0 +1,16 @@
+const Environment = require('jest-environment-jsdom')
+
+/**
+ * A custom environment to set the TextEncoder that is required by our tests
+ * https://github.com/jsdom/whatwg-url/issues/209
+ */
+module.exports = class CustomTestEnvironment extends Environment {
+  async setup() {
+    await super.setup()
+    if (typeof this.global.TextEncoder === 'undefined') {
+      const {TextEncoder, TextDecoder} = require('util')
+      this.global.TextEncoder = TextEncoder
+      this.global.TextDecoder = TextDecoder
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -238,6 +238,7 @@
     "table/**/ansi-regex": "^4.1.1",
     "webpack-dev-server/**/ansi-regex": "^6.0.1",
     "webpack-dev-server/**/async": "^2.6.4",
-    "optimize-css-assets-webpack-plugin/**/nanoid": "^3.1.31"
+    "optimize-css-assets-webpack-plugin/**/nanoid": "^3.1.31",
+    "cross-fetch": "^3.1.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4118,12 +4118,12 @@ cross-env@^5.2.0:
   dependencies:
     cross-spawn "^6.0.5"
 
-cross-fetch@^3.0.4:
-  version "3.1.4"
-  resolved "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz"
-  integrity sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==
+cross-fetch@^3.0.4, cross-fetch@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
+  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
   dependencies:
-    node-fetch "2.6.1"
+    node-fetch "2.6.7"
 
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
@@ -8551,10 +8551,12 @@ no-case@^2.2.0:
   dependencies:
     lower-case "^1.1.1"
 
-node-fetch@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+node-fetch@2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-forge@^0.10.0:
   version "0.10.0"
@@ -11553,6 +11555,11 @@ tr46@^3.0.0:
   dependencies:
     punycode "^2.1.1"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
 trough@^1.0.0:
   version "1.0.5"
   resolved "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz"
@@ -12121,6 +12128,11 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   dependencies:
     minimalistic-assert "^1.0.0"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
 webidl-conversions@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz"
@@ -12308,6 +12320,14 @@ whatwg-url@^10.0.0:
   dependencies:
     tr46 "^3.0.0"
     webidl-conversions "^7.0.0"
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 whatwg-url@^8.0.0, whatwg-url@^8.5.0:
   version "8.7.0"


### PR DESCRIPTION
* chore: use resolution to resolve cross-fetch to 3.1.5
* chore: use jsdom-custom.js to re-add TextEncoder and TextDecoder

It seems that the newer `cross-fetch` pulls in changes that break builds: https://app.circleci.com/pipelines/github/influxdata/ui/13386/workflows/befcfefa-441f-47c7-9979-60c13eb40f3c/jobs/79358. This appears related to https://github.com/jsdom/whatwg-url/issues/209 and is related to using `jsdom` as the `testEnvironment` where `TextEncoder` and `TextDecoder` are removed from the environment at some point and no longer available in the environment. This can be worked around by using a custom environment based on jsdom that conditionally extends the environment to add back `TextEncoder` and `TextDecoder`.

With a fresh checkout, I see errors with `yarn test`:
```
$ yarn test
...
 FAIL  src/timeMachine/selectors/index.test.ts
  ● Test suite failed to run

    src/shared/utils/vis.ts:23:5 - error TS2367: This condition will always return 'false' since the types '"line" | "stacked" | "bar"' and '"stepBefore"' have no overlap.

    23     geom === 'stepBefore' ||
           ~~~~~~~~~~~~~~~~~~~~~
    src/shared/utils/vis.ts:24:5 - error TS2367: This condition will always return 'false' since the types '"line" | "stacked" | "bar"' and '"stepAfter"' have no overlap.

    24     geom === 'stepAfter'
           ~~~~~~~~~~~~~~~~~~~~
    src/shared/utils/vis.ts:40:10 - error TS2678: Type '"stepBefore"' is not comparable to type 'XYGeom'.

    40     case 'stepBefore':
                ~~~~~~~~~~~~
    src/shared/utils/vis.ts:42:10 - error TS2678: Type '"stepAfter"' is not comparable to type 'XYGeom'.

    42     case 'stepAfter':
                ~~~~~~~~~~~
...
Test Suites: 45 failed, 113 passed, 158 total
Tests:       26 skipped, 570 passed, 596 total
Snapshots:   0 total
Time:        94.857 s
Ran all test suites.
```

After updating `cross-fetch` in the first commit, I then saw regressions (different errors) with `yarn test` that are the same as I saw with the CI builds:
```
$ yarn test
...
 FAIL  src/clockface/components/inputs/multipleInput/Row.test.tsx
  ● Test suite failed to run

    ReferenceError: TextEncoder is not defined

      2 | import 'intersection-observer'
      3 | import MutationObserver from 'mutation-observer'
    > 4 | import fetchMock from 'jest-fetch-mock'
        | ^
      5 | import '@testing-library/jest-dom'
      6 | import {getMockedParse} from 'src/shared/utils/mocks/mockedParse'
      7 | import 'setimmediate'

      at Object.<anonymous> (node_modules/whatwg-url/lib/encoding.js:2:21)
      at Object.<anonymous> (node_modules/whatwg-url/lib/url-state-machine.js:5:34)
      at Object.<anonymous> (node_modules/whatwg-url/lib/URL-impl.js:2:13)
      at Object.<anonymous> (node_modules/whatwg-url/lib/URL.js:442:14)
      at Object.<anonymous> (node_modules/whatwg-url/webidl2js-wrapper.js:3:13)
      at Object.<anonymous> (node_modules/whatwg-url/index.js:3:34)
      at Object.<anonymous> (node_modules/node-fetch/lib/index.js:10:33)
      at Object.<anonymous> (node_modules/cross-fetch/dist/node-ponyfill.js:1:101)
      at Object.<anonymous> (node_modules/jest-fetch-mock/src/index.js:1:102)
      at Object.<anonymous> (jestSetup.ts:4:1)
...
Test Suites: 158 failed, 158 total
Tests:       0 total
Snapshots:   0 total
Time:        22.923 s
Ran all test suites.
```

After applying the second commit, I'm back to seeing the original errors:
```
$ yarn test
...
 FAIL  src/timeMachine/selectors/index.test.ts
  ● Test suite failed to run

    src/shared/utils/vis.ts:23:5 - error TS2367: This condition will always return 'false' since the types '"line" | "stacked" | "bar"' and '"stepBefore"' have no overlap.

    23     geom === 'stepBefore' ||
           ~~~~~~~~~~~~~~~~~~~~~
    src/shared/utils/vis.ts:24:5 - error TS2367: This condition will always return 'false' since the types '"line" | "stacked" | "bar"' and '"stepAfter"' have no overlap.

    24     geom === 'stepAfter'
           ~~~~~~~~~~~~~~~~~~~~
    src/shared/utils/vis.ts:40:10 - error TS2678: Type '"stepBefore"' is not comparable to type 'XYGeom'.

    40     case 'stepBefore':
                ~~~~~~~~~~~~
    src/shared/utils/vis.ts:42:10 - error TS2678: Type '"stepAfter"' is not comparable to type 'XYGeom'.

    42     case 'stepAfter':
                ~~~~~~~~~~~


Test Suites: 45 failed, 113 passed, 158 total
Tests:       26 skipped, 570 passed, 596 total
Snapshots:   0 total
Time:        53.54 s, estimated 72 s
Ran all test suites.
```