### PR TITLE
feat: when using group aggregate function, set default to all grouping tag values

### DIFF
--- a/src/timeMachine/reducers/index.ts
+++ b/src/timeMachine/reducers/index.ts
@@ -840,9 +840,20 @@ export const timeMachineReducer = (
           // we want to clear out any previously selected values
           draftQuery.builderConfig.tags[index].values = []
 
+          // but for the group aggregate, want to set default values
+          if (builderAggregateFunctionType === 'group') {
+            draftQuery.builderConfig.tags[
+              index
+            ].values = draftQuery.builderConfig.tags
+              .map(t => t.key)
+              .filter(x => !!x)
+          }
+
           draftQuery.builderConfig.tags[
             index
           ].aggregateFunctionType = builderAggregateFunctionType
+
+          buildActiveQuery(draftState)
         }
       })
     }


### PR DESCRIPTION
Closes #4635 
Applies to Dashboard and DataExplorer.

## Presumptions made:
* The `|> keys()` transformation will only return those items which are a group key.
* See video of presumed, expected interaction (a.k.a. changes to flux query constructed).

## Not touched:
* Notebooks query builder. 
* New QX flux builder.


## Video evidence:

https://user-images.githubusercontent.com/10232835/171297109-f17a06f5-d238-4460-bc1b-3823c219f286.mp4


