### PR TITLE
fix(4669/4671/4696/4697): template notebook generated from bucket, must also include retentionRules.

### DIFF
--- a/cypress/e2e/shared/buckets.test.ts
+++ b/cypress/e2e/shared/buckets.test.ts
@@ -164,6 +164,73 @@ describe('Buckets', () => {
     })
   })
 
+  describe('explore a newly created bucket', () => {
+    beforeEach(() => {
+      cy.setFeatureFlags({
+        exploreWithFlows: true,
+        uiUnificationFlag: true,
+      })
+    })
+    it('with redirect to notebooks', () => {
+      const newBucket = 'Bucket for templating'
+      cy.getByTestID(`bucket--card--name ${newBucket}`).should('not.exist')
+
+      cy.getByTestID('Create Bucket').click()
+      cy.getByTestID('overlay--container').within(() => {
+        cy.getByInputName('name').type(newBucket)
+        cy.get('.cf-button')
+          .contains('Create')
+          .click()
+      })
+
+      cy.getByTestID(`bucket--card--name ${newBucket}`)
+        .should('exist')
+        .click()
+
+      cy.getByTestID('page-title').contains(newBucket)
+    })
+    it('with notebooks using the bucket crud object', () => {
+      const newBucket = 'Bucket for templating 1'
+      cy.getByTestID(`bucket--card--name ${newBucket}`).should('not.exist')
+
+      cy.getByTestID('Create Bucket').click()
+      cy.getByTestID('overlay--container').within(() => {
+        cy.getByInputName('name').type(newBucket)
+        cy.get('.cf-button')
+          .contains('Create')
+          .click()
+      })
+
+      cy.getByTestID(`bucket--card--name ${newBucket}`).should('exist')
+      cy.log('Bucket created')
+
+      cy.intercept('PATCH', '/api/v2private/notebooks/*').as('updateNotebook')
+
+      cy.getByTestID(`bucket--card--name ${newBucket}`)
+        .parent()
+        .parent()
+        .within(() => {
+          cy.get('.copy-bucket-id')
+            .invoke('text')
+            .then(text => {
+              const bucketId = text.split('ID:')[0].trim()
+              cy.getByTestID(`bucket--card--name ${newBucket}`)
+                .should('exist')
+                .click()
+
+              cy.wait('@updateNotebook').then(interception => {
+                expect(JSON.stringify(interception.response?.body)).to.include(
+                  newBucket
+                )
+                expect(JSON.stringify(interception.response?.body)).to.include(
+                  bucketId
+                )
+              })
+            })
+        })
+    })
+  })
+
   describe('routing directly to the edit overlay', () => {
     it('reroutes to buckets view if bucket does not exist', () => {
       cy.get('@org').then(({id}: Organization) => {

--- a/cypress/e2e/shared/buckets.test.ts
+++ b/cypress/e2e/shared/buckets.test.ts
@@ -168,7 +168,6 @@ describe('Buckets', () => {
     beforeEach(() => {
       cy.setFeatureFlags({
         exploreWithFlows: true,
-        uiUnificationFlag: true,
       })
     })
     it('with redirect to notebooks', () => {

--- a/src/buckets/components/BucketCard.tsx
+++ b/src/buckets/components/BucketCard.tsx
@@ -38,7 +38,9 @@ const BucketCard: FC<Props & RouteComponentProps<{orgID: string}>> = ({
 }) => {
   const handleNameClick = () => {
     if (isFlagEnabled('exploreWithFlows')) {
-      history.push(`/${PROJECT_NAME.toLowerCase()}/from/bucket/${bucket.name}`)
+      history.push(
+        `/${PROJECT_NAME.toLowerCase()}/from/bucket/${bucket.name}/${bucket.id}`
+      )
     } else {
       history.push(`/orgs/${orgID}/data-explorer?bucket=${bucket.name}`)
     }

--- a/src/flows/pipes/QueryBuilder/BucketSelector.tsx
+++ b/src/flows/pipes/QueryBuilder/BucketSelector.tsx
@@ -25,15 +25,10 @@ const BucketSelector: FC = () => {
       return
     }
     const allBuckets = new Set(buckets.map(b => b.name))
-    data.buckets
-      .filter(b => !allBuckets.has(b.name))
-      .forEach(b => {
-        addBucket({
-          name: b.name,
-          type: b.type,
-          retentionRules: b.retentionRules,
-        } as Bucket)
-      })
+    const missingBuckets = data.buckets.filter(b => !allBuckets.has(b.name))
+    missingBuckets.forEach(b => {
+      addBucket(b as Bucket)
+    })
   }, [loading, buckets, data.buckets])
 
   if (loading === RemoteDataState.Done && !buckets.length) {

--- a/src/flows/pipes/QueryBuilder/BucketSelector.tsx
+++ b/src/flows/pipes/QueryBuilder/BucketSelector.tsx
@@ -31,6 +31,7 @@ const BucketSelector: FC = () => {
         addBucket({
           name: b.name,
           type: b.type,
+          retentionRules: b.retentionRules,
         } as Bucket)
       })
   }, [loading, buckets, data.buckets])

--- a/src/flows/templates/types/bucket.ts
+++ b/src/flows/templates/types/bucket.ts
@@ -1,6 +1,7 @@
 import {DEFAULT_TIME_RANGE} from 'src/shared/constants/timeRanges'
 import {AUTOREFRESH_DEFAULT} from 'src/shared/constants'
 import {PIPE_DEFINITIONS} from 'src/flows'
+import {Bucket as GenBucket} from 'src/client'
 
 export default register =>
   register({
@@ -20,7 +21,7 @@ export default register =>
               ...JSON.parse(
                 JSON.stringify(PIPE_DEFINITIONS['queryBuilder'].initial)
               ),
-              buckets: [{name, type: 'user'}],
+              buckets: [{name, type: 'user', retentionRules: []} as GenBucket],
             },
             {
               title: 'Validate the Data',

--- a/src/flows/templates/types/bucket.ts
+++ b/src/flows/templates/types/bucket.ts
@@ -1,42 +1,61 @@
 import {DEFAULT_TIME_RANGE} from 'src/shared/constants/timeRanges'
 import {AUTOREFRESH_DEFAULT} from 'src/shared/constants'
 import {PIPE_DEFINITIONS} from 'src/flows'
-import {Bucket as GenBucket} from 'src/client'
+import {getBucket, getBuckets, Buckets} from 'src/client'
 
 export default register =>
   register({
     type: 'bucket',
-    init: name =>
-      Promise.resolve({
-        name: `Explore the ${name} bucket`,
-        spec: {
-          readOnly: false,
-          range: DEFAULT_TIME_RANGE,
-          refresh: AUTOREFRESH_DEFAULT,
-          pipes: [
-            {
-              type: 'queryBuilder',
-              title: 'Build a Query',
-              visible: true,
-              ...JSON.parse(
-                JSON.stringify(PIPE_DEFINITIONS['queryBuilder'].initial)
-              ),
-              buckets: [{name, type: 'user', retentionRules: []} as GenBucket],
+    init: (name: string, bucketID: string | undefined) =>
+      getBucket({bucketID})
+        .then(res => {
+          if (res.status == 200) {
+            return Promise.resolve({
+              ...res,
+              data: {buckets: [res.data]} as Buckets,
+            })
+          }
+          return getBuckets({query: {name}})
+        })
+        .then(res => {
+          // handle both get request payloads
+          const data = (res.data as Buckets).buckets
+          const name =
+            res.status == 200
+              ? `Explore the ${data[0].name} bucket`
+              : `Select a bucket`
+          const buckets = res.status == 200 ? data : []
+          return Promise.resolve({
+            name,
+            spec: {
+              readOnly: false,
+              range: DEFAULT_TIME_RANGE,
+              refresh: AUTOREFRESH_DEFAULT,
+              pipes: [
+                {
+                  type: 'queryBuilder',
+                  title: 'Build a Query',
+                  visible: true,
+                  ...JSON.parse(
+                    JSON.stringify(PIPE_DEFINITIONS['queryBuilder'].initial)
+                  ),
+                  buckets,
+                },
+                {
+                  title: 'Validate the Data',
+                  visible: true,
+                  type: 'table',
+                },
+                {
+                  title: 'Visualize the Result',
+                  visible: true,
+                  type: 'visualization',
+                  ...JSON.parse(
+                    JSON.stringify(PIPE_DEFINITIONS['visualization'].initial)
+                  ),
+                },
+              ],
             },
-            {
-              title: 'Validate the Data',
-              visible: true,
-              type: 'table',
-            },
-            {
-              title: 'Visualize the Result',
-              visible: true,
-              type: 'visualization',
-              ...JSON.parse(
-                JSON.stringify(PIPE_DEFINITIONS['visualization'].initial)
-              ),
-            },
-          ],
-        },
-      }),
+          })
+        }),
   })

--- a/src/writeData/components/fileUploads/CsvMethod.tsx
+++ b/src/writeData/components/fileUploads/CsvMethod.tsx
@@ -51,7 +51,9 @@ const CsvMethod: FC = () => {
 
   const handleSeeUploadedData = () => {
     if (isFlagEnabled('exploreWithFlows')) {
-      history.push(`/${PROJECT_NAME.toLowerCase()}/from/bucket/${bucket.name}`)
+      history.push(
+        `/${PROJECT_NAME.toLowerCase()}/from/bucket/${bucket.name}/${bucket.id}`
+      )
     } else {
       history.push(`/orgs/${orgId}/data-explorer?bucket=${bucket.name}`)
     }


### PR DESCRIPTION
Closes #4669 
Closes #4671 
Closes #4696 
Closes #4697 


## Debugging data shown:
* steps as identified by Will Baker.
   1. make new bucket
   2. click on new bucket name
   3. --> it tries to generate a template notebook (when `influx.set('exploreWithFlows’, true)` as in prod)
   4. black screen of doom.
        * local ts-node dev server: `TypeError: bucket.retentionRules is undefined.` 
        * transpiled js code error: Error for `find()` on the expected array.
* Issue:
  * Was generating a template notebook with only the passed in name (and a hard-coded type=='user'). Then failing on an expectation of retention values in getReadableRetention().
  * fix: provide template array. Page now loads without error.
* Issue:
  * BucketContext is out of sync with the generated new bucket in the reducer entities.
  * This is because the TEMPLATE.init uses the passed init structure, and gives preference to this init structure.
     * the init structure is only black templating items. Not the bucket crud object. 
  * fix: fetch the actual bucket object
     * handle if only have bucket name (since `bucket.id` is optional prop in openapi...presumably for older/legacy buckets).
