### PR TITLE
refactor: rename to `MeasurementsContext` and `MeasurementsProvider` with plural

### DIFF
--- a/src/dataExplorer/components/MeasurementSelector.tsx
+++ b/src/dataExplorer/components/MeasurementSelector.tsx
@@ -7,7 +7,7 @@ import SearchableDropdown from 'src/shared/components/SearchableDropdown'
 
 // Context
 import {NewDataExplorerContext} from 'src/dataExplorer/context/newDataExplorer'
-import {MeasurementContext} from 'src/dataExplorer/context/measurements'
+import {MeasurementsContext} from 'src/dataExplorer/context/measurements'
 
 // Types
 import {RemoteDataState} from 'src/types'
@@ -33,7 +33,7 @@ const MeasurementSelector: FC = () => {
   const {selectedBucket, selectedMeasurement, selectMeasurement} = useContext(
     NewDataExplorerContext
   )
-  const {measurements, loading} = useContext(MeasurementContext)
+  const {measurements, loading} = useContext(MeasurementsContext)
   const [searchTerm, setSearchTerm] = useState('')
 
   const handleSelect = (option: string): void => {

--- a/src/dataExplorer/components/Schema.tsx
+++ b/src/dataExplorer/components/Schema.tsx
@@ -16,7 +16,7 @@ import {
 } from 'src/dataExplorer/context/newDataExplorer'
 import QueryProvider from 'src/shared/contexts/query'
 import {BucketProvider} from 'src/shared/contexts/buckets'
-import {MeasurementProvider} from 'src/dataExplorer/context/measurements'
+import {MeasurementsProvider} from 'src/dataExplorer/context/measurements'
 import {FieldsProvider} from 'src/dataExplorer/context/fields'
 import {TagsProvider} from 'src/dataExplorer/context/tags'
 
@@ -69,7 +69,7 @@ const Schema: FC = () => {
 
   return (
     <QueryProvider>
-      <MeasurementProvider scope={scope}>
+      <MeasurementsProvider scope={scope}>
         <FieldsProvider scope={scope}>
           <TagsProvider scope={scope}>
             <NewDataExplorerProvider>
@@ -89,7 +89,7 @@ const Schema: FC = () => {
             </NewDataExplorerProvider>
           </TagsProvider>
         </FieldsProvider>
-      </MeasurementProvider>
+      </MeasurementsProvider>
     </QueryProvider>
   )
 }

--- a/src/dataExplorer/context/measurements.tsx
+++ b/src/dataExplorer/context/measurements.tsx
@@ -26,19 +26,19 @@ import {QueryScope, RemoteDataState} from 'src/types'
 // Utils
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
-interface MeasurementContextType {
+interface MeasurementsContextType {
   measurements: string[]
   loading: RemoteDataState
   getMeasurements: (bucket: any) => void
 }
 
-const DEFAULT_CONTEXT: MeasurementContextType = {
+const DEFAULT_CONTEXT: MeasurementsContextType = {
   measurements: [],
   loading: RemoteDataState.NotStarted,
   getMeasurements: (_: any) => {},
 }
 
-export const MeasurementContext = createContext<MeasurementContextType>(
+export const MeasurementsContext = createContext<MeasurementsContextType>(
   DEFAULT_CONTEXT
 )
 
@@ -46,7 +46,7 @@ interface Prop {
   scope: QueryScope
 }
 
-export const MeasurementProvider: FC<Prop> = ({children, scope}) => {
+export const MeasurementsProvider: FC<Prop> = ({children, scope}) => {
   // Contexts
   const {query: queryAPI} = useContext(QueryContext)
 
@@ -115,11 +115,11 @@ export const MeasurementProvider: FC<Prop> = ({children, scope}) => {
 
   return useMemo(
     () => (
-      <MeasurementContext.Provider
+      <MeasurementsContext.Provider
         value={{measurements, loading, getMeasurements}}
       >
         {children}
-      </MeasurementContext.Provider>
+      </MeasurementsContext.Provider>
     ),
     [measurements, loading, children]
   )

--- a/src/dataExplorer/context/newDataExplorer.tsx
+++ b/src/dataExplorer/context/newDataExplorer.tsx
@@ -1,7 +1,7 @@
 import React, {FC, createContext, useState, useMemo, useContext} from 'react'
 
 // Context
-import {MeasurementContext} from 'src/dataExplorer/context/measurements'
+import {MeasurementsContext} from 'src/dataExplorer/context/measurements'
 import {FieldsContext} from 'src/dataExplorer/context/fields'
 import {TagsContext} from 'src/dataExplorer/context/tags'
 
@@ -50,7 +50,7 @@ export const NewDataExplorerContext = createContext<NewDataExplorerContextType>(
 
 export const NewDataExplorerProvider: FC = ({children}) => {
   // Contexts
-  const {getMeasurements} = useContext(MeasurementContext)
+  const {getMeasurements} = useContext(MeasurementsContext)
   const {getFields, resetFields} = useContext(FieldsContext)
   const {getTagKeys, resetTags} = useContext(TagsContext)
 


### PR DESCRIPTION
This PR renames components to `MeasurementsContext` and `MeasurementsProvider` with "measurements" in plural.

## Reason

`MeasurementsContext` is a place to keep track of *all* the measurements in a specific bucket, instead of which *one* of the measurements that is selected by a user. Changing the name to use plural can avoid confusion.

This change is related to a discussion from [here](https://github.com/influxdata/ui/pull/4650#issuecomment-1140050696)