### PR TITLE
fix: better error message display in data explorer

### DIFF
--- a/src/shared/components/EmptyGraphError.scss
+++ b/src/shared/components/EmptyGraphError.scss
@@ -1,6 +1,8 @@
 .empty-graph-error {
   width: 100%;
   height: 100%;
+  display: flex;
+  justify-content: space-between;
   border-radius: $cf-radius;
   background-color: $cf-grey-5;
   color: $c-dreamsicle;
@@ -25,5 +27,6 @@
 }
 
 .empty-graph-error--scroll {
+  width: 90% !important;
   margin-top: $cf-space-s;
 }

--- a/src/shared/components/EmptyGraphError.tsx
+++ b/src/shared/components/EmptyGraphError.tsx
@@ -20,7 +20,7 @@ interface Props {
 const EmptyGraphError: FunctionComponent<Props> = ({message, testID}) => {
   const [didCopy, setDidCopy] = useState(false)
 
-  const buttonText = didCopy ? 'Copied!' : 'Copy'
+  const buttonText = didCopy ? 'Copied' : 'Copy'
   const buttonColor = didCopy ? ComponentColor.Success : ComponentColor.Default
 
   const onClick = () => {
@@ -31,22 +31,24 @@ const EmptyGraphError: FunctionComponent<Props> = ({message, testID}) => {
   return (
     <div className="cell--view-empty" data-testid={testID}>
       <div className="empty-graph-error" data-testid="empty-graph-error">
-        <CopyToClipboard text={message}>
-          <Button
-            size={ComponentSize.ExtraSmall}
-            color={buttonColor}
-            titleText={buttonText}
-            text={buttonText}
-            onClick={onClick}
-            className="empty-graph-error--copy"
-          />
-        </CopyToClipboard>
         <DapperScrollbars className="empty-graph-error--scroll" autoHide={true}>
           <pre>
             <Icon glyph={IconFont.AlertTriangle} />
             <code className="cell--error-message"> {message}</code>
           </pre>
         </DapperScrollbars>
+        <CopyToClipboard text={message}>
+          <Button
+            size={ComponentSize.ExtraSmall}
+            color={buttonColor}
+            titleText={buttonText}
+            text={buttonText}
+            icon={didCopy ? IconFont.Checkmark_New : null}
+            placeIconAfterText={true}
+            onClick={onClick}
+            className="empty-graph-error--copy"
+          />
+        </CopyToClipboard>
       </div>
     </div>
   )

--- a/src/shared/components/EmptyGraphError.tsx
+++ b/src/shared/components/EmptyGraphError.tsx
@@ -20,7 +20,7 @@ interface Props {
 const EmptyGraphError: FunctionComponent<Props> = ({message, testID}) => {
   const [didCopy, setDidCopy] = useState(false)
 
-  const buttonText = didCopy ? 'Copied' : 'Copy'
+  const buttonText = didCopy ? 'Copied!' : 'Copy'
   const buttonColor = didCopy ? ComponentColor.Success : ComponentColor.Default
 
   const onClick = () => {
@@ -43,7 +43,6 @@ const EmptyGraphError: FunctionComponent<Props> = ({message, testID}) => {
             color={buttonColor}
             titleText={buttonText}
             text={buttonText}
-            icon={didCopy ? IconFont.Checkmark_New : null}
             placeIconAfterText={true}
             onClick={onClick}
             className="empty-graph-error--copy"

--- a/src/shared/components/EmptyGraphError.tsx
+++ b/src/shared/components/EmptyGraphError.tsx
@@ -43,7 +43,6 @@ const EmptyGraphError: FunctionComponent<Props> = ({message, testID}) => {
             color={buttonColor}
             titleText={buttonText}
             text={buttonText}
-            placeIconAfterText={true}
             onClick={onClick}
             className="empty-graph-error--copy"
           />


### PR DESCRIPTION
Closes [#4694](https://github.com/influxdata/ui/issues/4694)

Before: 

<img width="1834" alt="Screen Shot 2022-06-01 at 8 23 26 AM" src="https://user-images.githubusercontent.com/18511823/171440864-caa428bd-4ae7-4502-a0ee-3dc3dee07747.png">

After: 

https://user-images.githubusercontent.com/18511823/171439831-5e516139-236a-4edf-a810-d110e18166a2.mov


