### PR TITLE
chore: use built-in functions in flux schema package to query

### DIFF
--- a/src/dataExplorer/context/fields.tsx
+++ b/src/dataExplorer/context/fields.tsx
@@ -90,15 +90,14 @@ export const FieldsProvider: FC<Prop> = ({children, scope}) => {
     if (bucket.type !== 'sample' && isFlagEnabled('newQueryBuilder')) {
       _source = `${IMPORT_REGEXP}${IMPORT_INFLUX_SCHEMA}`
       queryText = `${_source}
-        schema.tagValues(
+        schema.measurementFieldKeys(
           bucket: "${bucket.name}",
-          tag: "_field",
-          predicate: (r) => (r["_measurement"] == "${measurement}"),
+          measurement: "${measurement}",
           start: ${CACHING_REQUIRED_START_DATE},
           stop: ${CACHING_REQUIRED_END_DATE},
         )
-          |> limit(n: ${limit})
           |> sort()
+          |> limit(n: ${limit})
       `
     }
 

--- a/src/dataExplorer/context/fields.tsx
+++ b/src/dataExplorer/context/fields.tsx
@@ -83,8 +83,8 @@ export const FieldsProvider: FC<Prop> = ({children, scope}) => {
       |> keep(columns: ["_field"])
       |> group()
       |> distinct(column: "_field")
-      |> limit(n: ${limit})
       |> sort()
+      |> limit(n: ${limit})
     `
 
     if (bucket.type !== 'sample' && isFlagEnabled('newQueryBuilder')) {

--- a/src/dataExplorer/context/measurements.tsx
+++ b/src/dataExplorer/context/measurements.tsx
@@ -88,7 +88,11 @@ export const MeasurementProvider: FC<Prop> = ({children, scope}) => {
     if (bucket.type !== 'sample' && isFlagEnabled('newQueryBuilder')) {
       _source = `${IMPORT_REGEXP}${IMPORT_INFLUX_SCHEMA}`
       queryText = `${_source}
-        schema.measurements(bucket: "${bucket.name}")
+        schema.measurements(
+          bucket: "${bucket.name}",
+          start: ${CACHING_REQUIRED_START_DATE},
+          stop: ${CACHING_REQUIRED_END_DATE},
+        )
           |> sort()
           |> limit(n: ${limit})
         `

--- a/src/dataExplorer/context/measurements.tsx
+++ b/src/dataExplorer/context/measurements.tsx
@@ -88,15 +88,9 @@ export const MeasurementProvider: FC<Prop> = ({children, scope}) => {
     if (bucket.type !== 'sample' && isFlagEnabled('newQueryBuilder')) {
       _source = `${IMPORT_REGEXP}${IMPORT_INFLUX_SCHEMA}`
       queryText = `${_source}
-        schema.tagValues(
-          bucket: "${bucket.name}",
-          tag: "_measurement",
-          predicate: (r) => true,
-          start: ${CACHING_REQUIRED_START_DATE},
-          stop: ${CACHING_REQUIRED_END_DATE},
-        )
-          |> limit(n: ${limit})
+        schema.measurements(bucket: "${bucket.name}")
           |> sort()
+          |> limit(n: ${limit})
         `
     }
 

--- a/src/dataExplorer/context/measurements.tsx
+++ b/src/dataExplorer/context/measurements.tsx
@@ -81,8 +81,8 @@ export const MeasurementProvider: FC<Prop> = ({children, scope}) => {
       |> keep(columns: ["_measurement"])
       |> group()
       |> distinct(column: "_measurement")
-      |> limit(n: ${limit})
       |> sort()
+      |> limit(n: ${limit})
     `
 
     if (bucket.type !== 'sample' && isFlagEnabled('newQueryBuilder')) {

--- a/src/dataExplorer/context/tags.tsx
+++ b/src/dataExplorer/context/tags.tsx
@@ -113,7 +113,7 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
           stop: ${CACHING_REQUIRED_END_DATE},
         )
           |> filter(fn: (r) => r._value != "_measurement" and r._value != "_field")
-          |> filter(fn: (r) => r._value != "_time" and r._value != "_start" and r._value != "_stop" and r._value != "_value")
+          |> filter(fn: (r) => r._value != "_start" and r._value != "_stop")
           |> sort()
           |> limit(n: ${limit})
       `

--- a/src/dataExplorer/context/tags.tsx
+++ b/src/dataExplorer/context/tags.tsx
@@ -185,15 +185,15 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
     if (bucket.type !== 'sample' && isFlagEnabled('newQueryBuilder')) {
       _source = `${IMPORT_REGEXP}${IMPORT_INFLUX_SCHEMA}`
       queryText = `${_source}
-        schema.tagValues(
+        schema.measurementTagValues(
           bucket: "${bucket.name}",
+          measurement: "${measurement}",
           tag: "${tagKey}",
-          predicate: (r) => (r["_measurement"] == "${measurement}"),
           start: ${CACHING_REQUIRED_START_DATE},
           stop: ${CACHING_REQUIRED_END_DATE},
         )
-        |> limit(n: ${limit})
         |> sort()
+        |> limit(n: ${limit})
       `
     }
 

--- a/src/dataExplorer/context/tags.tsx
+++ b/src/dataExplorer/context/tags.tsx
@@ -106,17 +106,17 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
     if (bucket.type !== 'sample' && isFlagEnabled('newQueryBuilder')) {
       _source = `${IMPORT_REGEXP}${IMPORT_INFLUX_SCHEMA}`
       queryText = `${_source}
-          schema.tagKeys(
-            bucket: "${bucket.name}",
-            predicate: (r) => true,
-            start: ${CACHING_REQUIRED_START_DATE},
-            stop: ${CACHING_REQUIRED_END_DATE},
-            )
-            |> filter(fn: (r) => r._value != "_measurement" and r._value != "_field")
-            |> filter(fn: (r) => r._value != "_time" and r._value != "_start" and r._value != "_stop" and r._value != "_value")
-            |> limit(n: ${limit})
-            |> sort()
-        `
+        schema.measurementTagKeys(
+          bucket: "${bucket.name}",
+          measurement: "${measurement}",
+          start: ${CACHING_REQUIRED_START_DATE},
+          stop: ${CACHING_REQUIRED_END_DATE},
+        )
+          |> filter(fn: (r) => r._value != "_measurement" and r._value != "_field")
+          |> filter(fn: (r) => r._value != "_time" and r._value != "_start" and r._value != "_stop" and r._value != "_value")
+          |> sort()
+          |> limit(n: ${limit})
+      `
     }
 
     const newTags: Tags = {}

--- a/src/dataExplorer/context/tags.tsx
+++ b/src/dataExplorer/context/tags.tsx
@@ -99,8 +99,8 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
       |> distinct()
       |> filter(fn: (r) => r._value != "_measurement" and r._value != "_field")
       |> filter(fn: (r) => r._value != "_time" and r._value != "_start" and r._value !=  "_stop" and r._value != "_value")
-      |> limit(n: ${limit})
       |> sort()
+      |> limit(n: ${limit})
     `
 
     if (bucket.type !== 'sample' && isFlagEnabled('newQueryBuilder')) {
@@ -178,8 +178,8 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
       |> keep(columns: ["${tagKey}"])
       |> group()
       |> distinct(column: "${tagKey}")
-      |> limit(n: ${limit})
       |> sort()
+      |> limit(n: ${limit})
     `
 
     if (bucket.type !== 'sample' && isFlagEnabled('newQueryBuilder')) {


### PR DESCRIPTION
This PR updates queries to use the built-in functions in [flux schema package](https://docs.influxdata.com/flux/v0.x/stdlib/influxdata/influxdb/schema/) to get values for measurements, fields, tag keys, and tag values. 

## What got changed

1. Replace the generic function `tagKeys()` and `tagValues()` with the built-in functions `measurements()`, `measurementFieldKeys()`, `measurementTagKeys()`, `measurementTagValues()`
2. Swap the order of `sort()` and `limit()`. Now the query do sort first, then limit


