### PR TITLE
fix: advanced bucket selector onCreate callback

### DIFF
--- a/src/buckets/components/CreateBucketButton.tsx
+++ b/src/buckets/components/CreateBucketButton.tsx
@@ -42,15 +42,13 @@ const CreateBucketButton: FC<Props> = ({
     dispatch(checkBucketLimits())
   }, [dispatch])
 
-  const overlayParams = useSimplifiedBucketForm
-    ? {
-        useSimplifiedBucketForm: true,
-        callbackAfterBucketCreation,
-      }
-    : null
   const handleItemClick = (): void => {
     event('create bucket clicked')
-    onShowOverlay('create-bucket', overlayParams, onDismissOverlay)
+    onShowOverlay(
+      'create-bucket',
+      {useSimplifiedBucketForm, callbackAfterBucketCreation},
+      onDismissOverlay
+    )
   }
 
   if (CLOUD && limitStatus === 'exceeded') {

--- a/src/writeData/components/WriteDataHelperBuckets.tsx
+++ b/src/writeData/components/WriteDataHelperBuckets.tsx
@@ -46,7 +46,7 @@ const WriteDataHelperBuckets: FC<Props> = ({
   const buckets = useSelector((state: AppState) =>
     getAll<Bucket>(state, ResourceType.Buckets)
       .filter(b => b.type === 'user')
-      // sort by selected and then recently created
+      // sort by selected and then by name
       .sort((a, b) => {
         if (isSelected(a.id)) {
           return -1
@@ -54,7 +54,7 @@ const WriteDataHelperBuckets: FC<Props> = ({
         if (isSelected(b.id)) {
           return 1
         }
-        return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+        return a.name.localeCompare(b.name)
       })
   )
 

--- a/src/writeData/components/WriteDataHelperBuckets.tsx
+++ b/src/writeData/components/WriteDataHelperBuckets.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {FC, useContext} from 'react'
-import {useSelector} from 'react-redux'
 
 // Contexts
 import {WriteDataDetailsContext} from 'src/writeData/components/WriteDataDetailsContext'
@@ -8,9 +7,6 @@ import CreateBucketButton from 'src/buckets/components/CreateBucketButton'
 
 // Constants
 import {DOCS_URL_VERSION} from 'src/shared/constants/fluxFunctions'
-
-// Utils
-import {getAll} from 'src/resources/selectors'
 
 // Components
 import {
@@ -23,9 +19,6 @@ import {
   EmptyState,
 } from '@influxdata/clockface'
 
-// Types
-import {AppState, ResourceType, Bucket} from 'src/types'
-
 interface Props {
   className?: string
   useSimplifiedBucketForm?: boolean
@@ -35,7 +28,7 @@ const WriteDataHelperBuckets: FC<Props> = ({
   className = 'write-data--details-widget-title',
   useSimplifiedBucketForm = false,
 }) => {
-  const {bucket, changeBucket} = useContext(WriteDataDetailsContext)
+  const {bucket, buckets, changeBucket} = useContext(WriteDataDetailsContext)
   const isSelected = (bucketID: string): boolean => {
     if (!bucket) {
       return false
@@ -43,20 +36,18 @@ const WriteDataHelperBuckets: FC<Props> = ({
     return bucketID === bucket.id
   }
 
-  const buckets = useSelector((state: AppState) =>
-    getAll<Bucket>(state, ResourceType.Buckets)
-      .filter(b => b.type === 'user')
-      // sort by selected and then by name
-      .sort((a, b) => {
-        if (isSelected(a.id)) {
-          return -1
-        }
-        if (isSelected(b.id)) {
-          return 1
-        }
-        return a.name.localeCompare(b.name)
-      })
-  )
+  const filteredBuckets = buckets
+    .filter(b => b.type === 'user')
+    // sort by selected and then by name
+    .sort((a, b) => {
+      if (isSelected(a.id)) {
+        return -1
+      }
+      if (isSelected(b.id)) {
+        return 1
+      }
+      return a.name.localeCompare(b.name)
+    })
 
   let body = (
     <EmptyState className="write-data--details-empty-state">
@@ -73,7 +64,7 @@ const WriteDataHelperBuckets: FC<Props> = ({
     </EmptyState>
   )
 
-  if (buckets.length) {
+  if (filteredBuckets.length) {
     body = (
       <List
         backgroundColor={InfluxColors.Grey5}
@@ -81,7 +72,7 @@ const WriteDataHelperBuckets: FC<Props> = ({
         maxHeight="200px"
         testID="buckets--list"
       >
-        {buckets.map(b => (
+        {filteredBuckets.map(b => (
           <List.Item
             size={ComponentSize.Small}
             key={b.id}

--- a/src/writeData/components/WriteDataHelperBuckets.tsx
+++ b/src/writeData/components/WriteDataHelperBuckets.tsx
@@ -35,10 +35,28 @@ const WriteDataHelperBuckets: FC<Props> = ({
   className = 'write-data--details-widget-title',
   useSimplifiedBucketForm = false,
 }) => {
-  const buckets = useSelector((state: AppState) =>
-    getAll<Bucket>(state, ResourceType.Buckets).filter(b => b.type === 'user')
-  )
   const {bucket, changeBucket} = useContext(WriteDataDetailsContext)
+  const isSelected = (bucketID: string): boolean => {
+    if (!bucket) {
+      return false
+    }
+    return bucketID === bucket.id
+  }
+
+  const buckets = useSelector((state: AppState) =>
+    getAll<Bucket>(state, ResourceType.Buckets)
+      .filter(b => b.type === 'user')
+      // sort by selected and then recently created
+      .sort((a, b) => {
+        if (isSelected(a.id)) {
+          return -1
+        }
+        if (isSelected(b.id)) {
+          return 1
+        }
+        return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+      })
+  )
 
   let body = (
     <EmptyState className="write-data--details-empty-state">
@@ -54,14 +72,6 @@ const WriteDataHelperBuckets: FC<Props> = ({
       </span>
     </EmptyState>
   )
-
-  const isSelected = (bucketID: string): boolean => {
-    if (!bucket) {
-      return false
-    }
-
-    return bucketID === bucket.id
-  }
 
   if (buckets.length) {
     body = (

--- a/src/writeData/subscriptions/components/SubscriptionFormContent.tsx
+++ b/src/writeData/subscriptions/components/SubscriptionFormContent.tsx
@@ -49,7 +49,7 @@ const SubscriptionFormContent: FC<Props> = ({
     if (found) {
       changeBucket(found)
     }
-  }, [])
+  }, [buckets.length])
 
   return (
     <Grid>


### PR DESCRIPTION
Closes https://github.com/influxdata/data-acquisition/issues/324

* If advanced `CreateBucketOverlay` is used, `callbackAfterBucketCreation` should still be invoked
* `useEffect` for `SubscriptionFormContent` should run whenever list of bucket is added or removed
* `WriteDataHelperBuckets` sorts buckets by 1) if they are selected and 2) name

Bug is fixed:


https://user-images.githubusercontent.com/6411855/171730415-210f84db-9a6e-49d5-b2c6-69c5d38c9126.mov



`usgs` is last alphabetically, but is at the top because it's selected:

<img width="493" alt="image" src="https://user-images.githubusercontent.com/6411855/171733842-e3a78b27-9227-487d-b27f-55b83e717e71.png">

