### PR TITLE
fix: handle JSON Objects in parseFromFluxResults

### DIFF
--- a/src/timeMachine/utils/rawFluxDataTable.ts
+++ b/src/timeMachine/utils/rawFluxDataTable.ts
@@ -29,16 +29,12 @@ export const parseFromFluxResults = (
   const groupSet = new Set(fluxGroupKeyUnion)
   let max = 0
 
+  // checks whether the string is valid JSON object or not
   const isJsonObject = jsonString => {
     try {
-      const o = JSON.parse(jsonString)
-
-      // Handle non-exception-throwing cases:
-      // Neither JSON.parse(false) or JSON.parse(1234) throw errors, hence the type-checking,
-      // but... JSON.parse(null) returns null, and typeof null === "object",
-      // so we must check for that, too. Thankfully, null is falsey, so this suffices:
-      if (o && typeof o === 'object') {
-        return o
+      const object = JSON.parse(jsonString)
+      if (object && typeof object === 'object') {
+        return object
       }
     } catch (_) {}
 

--- a/src/timeMachine/utils/rawFluxDataTable.ts
+++ b/src/timeMachine/utils/rawFluxDataTable.ts
@@ -34,9 +34,9 @@ export const parseFromFluxResults = (
     try {
       const object = JSON.parse(jsonString)
       if (object && typeof object === 'object') {
-        return object
+        return true
       }
-    } catch (_) {}
+    } catch {}
 
     return false
   }
@@ -90,8 +90,8 @@ export const parseFromFluxResults = (
       // 1. it's a JSON Object
       // 2. It's a string of CSV
       if (isJsonObject(columnData)) {
-        // replace Double quotes \" with single quotes \' in a json object
-        // columnData = `"${columnData.replace(/['"]+/g, '\'')}"`
+        // 1. replace Double quotes \" with Single quotes \' in a json object
+        // 2. then wrap the JSON object in double quotes
         columnData = `"${columnData.replace(/['"]+/g, "'")}"`
       } else if (typeof columnData === 'string' && columnData.includes(',')) {
         columnData = `"${columnData}"`


### PR DESCRIPTION
Closes #3637 

In https://github.com/influxdata/ui/pull/4700, we handled a special case where the data in the column can be a string of `CSV` data. 

In this one, we handle the case when the data is a `JSON` object. 

The approach is to take the JSON string, remove all the double quotes and replace them with single quotes, (this saves the csvParser from being thrown off) and then wrap the JSON object in double quotes. 

Example
-> `{"key" : "value"}` came in from the flux query
-> `{'key': 'value'}` : we replace double quotes with single quotes
-> `"{'key': 'value'}"` : we wrap the string form of the JSON object in double quotes so we can display it.

----

### Proof of it working:

Please look at the `_value` column in all the screenshots for the demo of JSON and CSV strings working.

**Simple CSV in Simple Table:** 

<img width="1132" alt="Screen Shot 2022-06-02 at 4 01 23 PM" src="https://user-images.githubusercontent.com/18511823/171751915-4c5e02fa-5062-4f22-a51b-afb4ed65ed81.png">

<img width="1241" alt="Screen Shot 2022-06-02 at 4 05 17 PM" src="https://user-images.githubusercontent.com/18511823/171752236-00d83306-2ccf-4613-9e63-3591a93cca40.png">

**Simple String in Simple Table:** 

<img width="1222" alt="Screen Shot 2022-06-02 at 4 04 22 PM" src="https://user-images.githubusercontent.com/18511823/171752180-fbba88ee-6754-4e4b-b123-a540ebb2d8b6.png">


**JSON in Simple table:** 

<img width="1141" alt="Screen Shot 2022-06-02 at 4 01 18 PM" src="https://user-images.githubusercontent.com/18511823/171751934-2b9b23f7-105b-44e5-b6c8-eb483e12e659.png">

<img width="2478" alt="Screen Shot 2022-06-02 at 4 06 50 PM" src="https://user-images.githubusercontent.com/18511823/171752406-cf23d9a8-b95d-4f3c-8aec-9d4e92a8362e.png">


**Complex result with multiple JSON objects and normal strings**

<img width="1191" alt="Screen Shot 2022-06-02 at 4 01 09 PM" src="https://user-images.githubusercontent.com/18511823/171751937-8b710d05-08e7-4b32-86f4-87b0b7b5ab35.png">

