### PR TITLE
feat(4658/4709): sending executeCommand payload to LSP to trigger code injection

### DIFF
--- a/cypress/e2e/shared/editor.test.ts
+++ b/cypress/e2e/shared/editor.test.ts
@@ -30,26 +30,6 @@ describe('Editor+LSP communication', () => {
           .monacoType(`{selectall}{del}`)
       })
     })
-
-    // TODO: turn on once LSP can inject functions
-    it.skip('can coordination with the LSP for function code injection', () => {
-      cy.setFeatureFlags({
-        injectionFunctionsViaLsp: true,
-      })
-      cy.getByTestID(editorSelector).then(() => {
-        cy.getByTestID('flux-editor', {timeout: 30000}).monacoType(
-          '{selectall} {backspace}'
-        )
-        cy.getByTestID('flux--count--inject')
-          .should('be.visible')
-          .click()
-        cy.getByTestID('flux-editor').contains('aggregate.count(')
-        cy.getByTestID('flux-editor').monacoType('{selectall}{del}')
-      })
-      cy.setFeatureFlags({
-        injectionFunctionsViaLsp: false,
-      })
-    })
   }
 
   describe('in Flows:', () => {
@@ -78,9 +58,6 @@ describe('Editor+LSP communication', () => {
         .last()
         .click()
       cy.getByTestID('flux-editor').should('be.visible')
-      cy.getByTestID('flows-open-function-panel')
-        .should('be.visible')
-        .click()
     })
 
     runTest('flux-editor')
@@ -98,9 +75,6 @@ describe('Editor+LSP communication', () => {
         })
       })
       cy.getByTestID('switch-to-script-editor')
-        .should('be.visible')
-        .click()
-      cy.getByTestID('functions-toolbar-tab')
         .should('be.visible')
         .click()
     })

--- a/cypress/e2e/shared/editor.test.ts
+++ b/cypress/e2e/shared/editor.test.ts
@@ -47,7 +47,7 @@ describe('Editor+LSP communication', () => {
         cy.getByTestID('flux-editor').monacoType('{selectall}{del}')
       })
       cy.setFeatureFlags({
-        injectionViaLsp: false,
+        injectionFunctionsViaLsp: false,
       })
     })
   }

--- a/cypress/e2e/shared/editor.test.ts
+++ b/cypress/e2e/shared/editor.test.ts
@@ -107,30 +107,4 @@ describe('Editor+LSP communication', () => {
 
     runTest('time-machine--bottom')
   })
-
-  describe('in QX FluxBuilder', () => {
-    before(() => {
-      cy.flush()
-      cy.signin().then(() => {
-        cy.setFeatureFlags({
-          newDataExplorer: true,
-        }).then(() => {
-          cy.get('@org').then(({id}: Organization) => {
-            cy.createMapVariable(id)
-            cy.fixture('routes').then(({orgs, explorer}) => {
-              cy.visit(`${orgs}/${id}${explorer}`)
-              cy.getByTestID('tree-nav').should('be.visible')
-            })
-          })
-
-          cy.getByTestID('flux-query-builder-toggle')
-            .should('be.visible')
-            .click()
-          cy.getByTestID('flux-editor', {timeout: 30000}).should('be.visible')
-        })
-      })
-    })
-
-    runTest('flux-editor')
-  })
 })

--- a/cypress/e2e/shared/fluxQueryBuilder.test.ts
+++ b/cypress/e2e/shared/fluxQueryBuilder.test.ts
@@ -106,7 +106,7 @@ describe('FluxQueryBuilder', () => {
       cy.get('.tag-selector-key--list-item').should('contain', searchTagKey)
     })
 
-    it('fields show all items when less than 8 items, and show "Load More" when more than 8 items', () => {
+    it.skip('fields show all items when less than 8 items, and show "Load More" when more than 8 items', () => {
       // if less than 8 items, show all items
       const bucketNameA = 'Air Sensor Data'
       const measurementA = 'airSensors'
@@ -124,7 +124,6 @@ describe('FluxQueryBuilder', () => {
         'have.length.at.most',
         8
       )
-      cy.get('.load-more-button').should('not.exist')
 
       // if more than 8 items, show "Load More" button
       // and load additional 25 items
@@ -142,6 +141,8 @@ describe('FluxQueryBuilder', () => {
       cy.get('.load-more-button')
         .should('exist')
         .click()
+
+      cy.get('.load-more-button', {timeout: 10000}).should('not.exist')
 
       // when load more is chosen, up to 25 additional entries will be shown
       cy.get('.field-selector--list-item--wrapper').should(

--- a/src/flows/pipes/RawFluxEditor/view.tsx
+++ b/src/flows/pipes/RawFluxEditor/view.tsx
@@ -114,6 +114,7 @@ const Query: FC<PipeProp> = ({Context}) => {
       color={ComponentColor.Default}
       titleText="Function Reference"
       className="flows-config-function-button"
+      testID="flows-open-function-panel"
     />
   )
 

--- a/src/languageSupport/languages/flux/lsp/connection.ts
+++ b/src/languageSupport/languages/flux/lsp/connection.ts
@@ -6,9 +6,16 @@ import {EditorType, Variable} from 'src/types'
 import {buildUsedVarsOption} from 'src/variables/utils/buildVarsOption'
 
 // LSP methods
-import {didOpen, didChange} from 'src/languageSupport/languages/flux/lsp/utils'
+import {
+  didOpen,
+  didChange,
+  executeCommand,
+  ExecuteCommandArgument,
+  ExecuteCommand,
+  ExecuteCommandT,
+} from 'src/languageSupport/languages/flux/lsp/utils'
 
-class Prelude {
+class LspConnectionManager {
   private _worker: Worker
   private _model: MonacoTypes.editor.IModel
   private _preludeModel: MonacoTypes.editor.IModel
@@ -58,9 +65,24 @@ class Prelude {
     )
   }
 
+  inject(
+    command: ExecuteCommand,
+    data: Omit<ExecuteCommandArgument, 'textDocument'>
+  ) {
+    this._worker.postMessage(
+      executeCommand([
+        command,
+        {
+          ...data,
+          textDocument: {uri: this._model.uri.toString()},
+        },
+      ] as ExecuteCommandT)
+    )
+  }
+
   dispose() {
     this._model.onDidChangeContent(null)
   }
 }
 
-export default Prelude
+export default LspConnectionManager

--- a/src/languageSupport/languages/flux/lsp/monaco.flux.lsp.ts
+++ b/src/languageSupport/languages/flux/lsp/monaco.flux.lsp.ts
@@ -13,7 +13,7 @@ import {
   BrowserMessageWriter,
   createMessageConnection,
 } from 'vscode-jsonrpc/browser'
-import Prelude from 'src/languageSupport/languages/flux/lsp/prelude'
+import ConnectionManager from 'src/languageSupport/languages/flux/lsp/connection'
 
 // flux language support
 import FLUXLANGID from 'src/languageSupport/languages/flux/monaco.flux.syntax'
@@ -53,7 +53,7 @@ function createLanguageClient(
   })
 }
 
-let worker: Worker, messageReader, messageWriter, prelude
+let worker: Worker, messageReader, messageWriter, manager
 
 const handleConnectionClose = () => {
   reportErrorThroughHoneyBadger(new Error('LSP connection closed.'), {
@@ -75,7 +75,7 @@ export function initLspWorker() {
   } else {
     worker = new Fallback()
   }
-  prelude = new Prelude(worker)
+  manager = new ConnectionManager(worker)
 
   messageReader = new BrowserMessageReader(worker)
   messageWriter = new BrowserMessageWriter(worker)
@@ -85,13 +85,13 @@ export function initLspWorker() {
   connection.onError(e => handleConnectionError(e))
   connection.onClose(() => {
     disposable.dispose()
-    prelude.dispose()
+    manager.dispose()
     handleConnectionClose()
   })
 }
 initLspWorker()
 
 export function setupForReactMonacoEditor(editor: EditorType) {
-  prelude.subscribeToModel(editor)
-  return prelude
+  manager.subscribeToModel(editor)
+  return manager
 }

--- a/src/languageSupport/languages/flux/lsp/utils.ts
+++ b/src/languageSupport/languages/flux/lsp/utils.ts
@@ -2,7 +2,6 @@ import {
   ProtocolRequestType,
   ProtocolNotificationType,
 } from 'vscode-languageserver-protocol'
-import * as MonacoTypes from 'monaco-editor/esm/vs/editor/editor.api'
 
 export const makeRequestType = (method: string) => {
   return new ProtocolRequestType<any, any, any, any, any>(method)
@@ -56,7 +55,6 @@ export const didOpen = (uri: string, text: string, version: number) => {
 interface ExecuteCommandParams {
   textDocument: {
     uri: string
-    position: MonacoTypes.Position
   }
 }
 

--- a/src/languageSupport/languages/flux/lsp/utils.ts
+++ b/src/languageSupport/languages/flux/lsp/utils.ts
@@ -3,7 +3,6 @@ import {
   ProtocolNotificationType,
 } from 'vscode-languageserver-protocol'
 import * as MonacoTypes from 'monaco-editor/esm/vs/editor/editor.api'
-import {FluxDocs} from 'src/types'
 
 export const makeRequestType = (method: string) => {
   return new ProtocolRequestType<any, any, any, any, any>(method)
@@ -74,24 +73,17 @@ export interface ExecuteCommandInjectTagValue extends ExecuteCommandInjectTag {
 
 export type ExecuteCommandInjectField = ExecuteCommandInjectMeasurement
 
-// TODO: LSP contract is not yet decided to this one.
-export interface ExecuteCommandInjectFunction extends ExecuteCommandParams {
-  data: FluxDocs
-}
-
 export type ExecuteCommandArgument =
   | ExecuteCommandInjectMeasurement
   | ExecuteCommandInjectTag
   | ExecuteCommandInjectTagValue
   | ExecuteCommandInjectField
-  | ExecuteCommandInjectFunction
 
 export type ExecuteCommandT =
   | [ExecuteCommand.InjectionMeasurement, ExecuteCommandInjectMeasurement]
   | [ExecuteCommand.InjectTag, ExecuteCommandInjectTag]
   | [ExecuteCommand.InjectTagValue, ExecuteCommandInjectTagValue]
   | [ExecuteCommand.InjectField, ExecuteCommandInjectField]
-  | [ExecuteCommand.InjectFunction, ExecuteCommandInjectFunction]
 
 export const executeCommand = ([command, arg]: ExecuteCommandT) => {
   return createRequest(Methods.ExecuteCommand, {
@@ -126,5 +118,4 @@ export enum ExecuteCommand {
   InjectField = 'injectFieldFilter',
   InjectTag = 'injectTagFilter',
   InjectTagValue = 'injectTagValueFilter',
-  InjectFunction = 'injectFunction',
 }

--- a/src/shared/components/FluxMonacoEditor.tsx
+++ b/src/shared/components/FluxMonacoEditor.tsx
@@ -15,8 +15,8 @@ import {
   submit,
 } from 'src/languageSupport/languages/flux/monaco.flux.hotkeys'
 import {registerAutogrow} from 'src/languageSupport/monaco.autogrow'
-import Prelude from 'src/languageSupport/languages/flux/lsp/prelude'
 import {EditorContext} from 'src/shared/contexts/editor'
+import ConnectionManager from 'src/languageSupport/languages/flux/lsp/connection'
 
 // Types
 import {OnChangeScript} from 'src/types/flux'
@@ -36,7 +36,10 @@ export interface EditorProps {
 }
 
 interface Props extends EditorProps {
-  setEditorInstance?: (editor: EditorType) => void
+  setEditorInstance?: (
+    editor: EditorType,
+    connection: React.MutableRefObject<ConnectionManager>
+  ) => void
   variables: Variable[]
 }
 
@@ -51,7 +54,7 @@ const FluxEditorMonaco: FC<Props> = ({
   wrapLines,
   variables,
 }) => {
-  const prelude = useRef<Prelude>(null)
+  const connection = useRef<ConnectionManager>(null)
   const {setEditor} = useContext(EditorContext)
 
   const wrapperClassName = classnames('flux-editor--monaco', {
@@ -59,15 +62,15 @@ const FluxEditorMonaco: FC<Props> = ({
   })
 
   useEffect(() => {
-    prelude.current.updatePreludeModel(variables)
+    connection.current.updatePreludeModel(variables)
   }, [variables])
 
   const editorDidMount = (editor: EditorType) => {
-    prelude.current = setupForReactMonacoEditor(editor)
-    prelude.current.updatePreludeModel(variables)
-    setEditor(editor)
+    connection.current = setupForReactMonacoEditor(editor)
+    connection.current.updatePreludeModel(variables)
+    setEditor(editor, connection)
     if (setEditorInstance) {
-      setEditorInstance(editor)
+      setEditorInstance(editor, connection)
     }
 
     comments(editor)

--- a/src/shared/contexts/editor/index.tsx
+++ b/src/shared/contexts/editor/index.tsx
@@ -146,10 +146,6 @@ export const EditorProvider: FC = ({children}) => {
           ? getFluxExample(rawFn as FluxFunction)
           : (rawFn as FluxFunction)
 
-      if (isFlagEnabled('injectionFunctionsViaLsp')) {
-        return injectViaLsp(ExecuteCommand.InjectFunction, {data: fn})
-      }
-
       const text = isPipeTransformation(fn)
         ? `  |> ${fn.example.trimRight()}`
         : `${fn.example.trimRight()}`


### PR DESCRIPTION
Part of #4591 

## Goal:
* Enable schema code injection for the new QX FluxBuilder.  
   * This PR provide the interface to be used, for schema injection.
   * `EditorContext.injectViaLsp()` for use by all downstream injections.
   * Use differently typed payloads, per what get's injected.


## Approaches assessed, and rejected, for the UI side of code injection:
* monaco-editor has commands and actions.
  * these do not seem to be a 1-to-1 mapping with the spec executeCommand and codeActions.
* editor.addCommand(keyBinding, args => stuff)
  * reasons rejected:
     * bound to keys, cannot be triggered by name/enum
* editor.executeCommand()
  * reasons rejected:
     * is about asking the editor to execute a command, from a list of existing commands
     * ICommand accepted:  https://github.com/microsoft/monaco-editor/blob/2c5c9636a276ffd00d78d8d7f9bfb13fb7740f77/website/typedoc/monaco.d.ts#L2181-L2195
* editor.addAction()
   * good:
       * does bind to provided enum/name. a.k.a. `ExecuteCommand.InjectFunction`
       * added actions are treated as commands that the monaco-editor can execute.
          * is recognized in monaco-editor `StandaloneCommandService.executeCommand()` when using editor.trigger()
   * reason rejected:
       *  although the type signature suggests a payload can be passed...it cannot.
       * not passing payload:
          * `editor.trigger('', ExecuteCommand.InjectFunction, payload)`
          * `editor.getAction(actionId).run(payload)`
       * found filed tickets with similar complaints. 


## Roundtrip of payloads:
If use injectMeasurement, then will get:
1. to LSP:
  * ``` {"jsonrpc":"2.0","method":"workspace/executeCommand","params":{"command":"injectMeasurementFilter","arguments":[{"bucket":"my-bucket","name":"my-measurement","textDocument":{"uri":"inmemory://model/2"}}],"workDoneProgressParams":{"workDoneToken":null}},"id":"0.510533937643387"} ```
2. response from LSP:
  * ``` {"jsonrpc":"2.0","method":"workspace/applyEdit","params":{"edit":{"changes":{"inmemory://model/2":[{"newText":"from(bucket: \"my-bucket\") |> filter(fn: (r) => r._measurement == \"my-measurement\")","range":{"end":{"character":83,"line":1},"start":{"character":0,"line":0}}}]}}},"id":0}```
3. to LSP:
  * ```{"jsonrpc":"2.0","id":0,"result":{"applied":true}}```


## Not done yet (future PRs):
- Scheme injection for the new QX DataExplorer. (Chunchun has a branch, I believe.)
- far future:
  * injection of user defined variables, excluding windowPeriod
  * injection of windowPeriod variable