### PR TITLE
feat: make a cell editor it's own page

### DIFF
--- a/src/dashboards/components/DashboardPage.tsx
+++ b/src/dashboards/components/DashboardPage.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {Component} from 'react'
+import React, {FC, Component} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
 import {Switch, Route} from 'react-router-dom'
 
@@ -13,8 +13,8 @@ import {HoverTimeProvider} from 'src/dashboards/utils/hoverTime'
 import VariablesControlBar from 'src/dashboards/components/variablesControlBar/VariablesControlBar'
 import LimitChecker from 'src/cloud/components/LimitChecker'
 import RateLimitAlert from 'src/cloud/components/RateLimitAlert'
-import EditVEO from 'src/dashboards/components/EditVEO'
-import NewVEO from 'src/dashboards/components/NewVEO'
+import {EditViewVEO} from 'src/dashboards/components/EditVEO'
+import {NewViewVEO} from 'src/dashboards/components/NewVEO'
 import {
   AddNoteOverlay,
   EditNoteOverlay,
@@ -49,6 +49,22 @@ import ErrorBoundary from 'src/shared/components/ErrorBoundary'
 
 const dashRoute = `/${ORGS}/${ORG_ID}/${DASHBOARDS}/${DASHBOARD_ID}`
 
+const SingleDashboardPage: FC<ManualRefreshProps> = ({
+  manualRefresh,
+  onManualRefresh,
+}) => {
+  return (
+    <>
+      <DashboardHeader onManualRefresh={onManualRefresh} />
+      <RateLimitAlert alertOnly={true} location="dashboard page" />
+      <VariablesControlBar />
+      <ErrorBoundary>
+        <DashboardComponent manualRefresh={manualRefresh} />
+      </ErrorBoundary>
+    </>
+  )
+}
+
 @ErrorHandling
 class DashboardPage extends Component<Props> {
   public componentDidMount() {
@@ -72,31 +88,41 @@ class DashboardPage extends Component<Props> {
           <Page titleTag={this.pageTitle} testID="dashboard-page">
             <LimitChecker>
               <HoverTimeProvider>
-                <DashboardHeader onManualRefresh={onManualRefresh} />
-                <RateLimitAlert alertOnly={true} location="dashboard page" />
-                <VariablesControlBar />
-                <ErrorBoundary>
-                  <DashboardComponent manualRefresh={manualRefresh} />
-                </ErrorBoundary>
+                <Switch>
+                  <Route
+                    path={dashRoute}
+                    render={() => (
+                      <SingleDashboardPage
+                        manualRefresh={manualRefresh}
+                        onManualRefresh={onManualRefresh}
+                      />
+                    )}
+                    exact
+                  />
+                  <Route
+                    path={`${dashRoute}/cells/new`}
+                    component={NewViewVEO}
+                  />
+                  <Route
+                    path={`${dashRoute}/cells/:cellID/edit`}
+                    component={EditViewVEO}
+                  />
+                  <Route
+                    path={`${dashRoute}/notes/new`}
+                    component={AddNoteOverlay}
+                  />
+                  <Route
+                    path={`${dashRoute}/notes/:cellID/edit`}
+                    component={EditNoteOverlay}
+                  />
+                  <Route
+                    path={`${dashRoute}/edit-annotation`}
+                    component={EditAnnotationDashboardOverlay}
+                  />
+                </Switch>
               </HoverTimeProvider>
             </LimitChecker>
           </Page>
-          <Switch>
-            <Route path={`${dashRoute}/cells/new`} component={NewVEO} />
-            <Route
-              path={`${dashRoute}/cells/:cellID/edit`}
-              component={EditVEO}
-            />
-            <Route path={`${dashRoute}/notes/new`} component={AddNoteOverlay} />
-            <Route
-              path={`${dashRoute}/notes/:cellID/edit`}
-              component={EditNoteOverlay}
-            />
-            <Route
-              path={`${dashRoute}/edit-annotation`}
-              component={EditAnnotationDashboardOverlay}
-            />
-          </Switch>
         </ErrorBoundary>
       </>
     )

--- a/src/dashboards/components/NewVEO.tsx
+++ b/src/dashboards/components/NewVEO.tsx
@@ -1,8 +1,7 @@
 // Libraries
-import React, {FunctionComponent, useEffect} from 'react'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {connect, ConnectedProps, useDispatch} from 'react-redux'
-import {get} from 'lodash'
+import React, {FC, useEffect} from 'react'
+import {useParams, useHistory} from 'react-router-dom'
+import {useSelector, useDispatch} from 'react-redux'
 
 // Components
 import {Overlay, SpinnerContainer, TechnoSpinner} from '@influxdata/clockface'
@@ -16,83 +15,62 @@ import {saveVEOView} from 'src/dashboards/actions/thunks'
 
 // Utils
 import {getActiveTimeMachine} from 'src/timeMachine/selectors'
+import {getOrg} from 'src/organizations/selectors'
 
 // Types
-import {AppState, RemoteDataState} from 'src/types'
+import {AppState} from 'src/types'
 
-type ReduxProps = ConnectedProps<typeof connector>
-type Props = ReduxProps &
-  RouteComponentProps<{orgID: string; dashboardID: string}>
+const NewViewVEO: FC = () => {
+  const {dashboardID} = useParams()
 
-const NewViewVEO: FunctionComponent<Props> = ({
-  activeTimeMachineID,
-  onSaveView,
-  onSetName,
-  match: {
-    params: {orgID, dashboardID},
-  },
-  history,
-  view,
-}) => {
+  const org = useSelector(getOrg)
+  const {view} = useSelector((state: AppState) => getActiveTimeMachine(state))
+
   const dispatch = useDispatch()
+  const history = useHistory()
+
   useEffect(() => {
     dispatch(loadNewVEO())
   }, [dispatch, dashboardID])
 
   const handleClose = () => {
-    history.push(`/orgs/${orgID}/dashboards/${dashboardID}`)
+    history.push(`/orgs/${org.id}/dashboards/${dashboardID}`)
   }
 
   const handleSave = () => {
     try {
-      onSaveView(dashboardID)
+      dispatch(saveVEOView(dashboardID))
       handleClose()
     } catch (error) {
       console.error(error)
     }
   }
 
-  let loadingState = RemoteDataState.Loading
-  const viewIsNew = !get(view, 'id', null)
-  if (activeTimeMachineID === 'veo' && viewIsNew) {
-    loadingState = RemoteDataState.Done
-  }
-
   return (
-    <Overlay visible={true} className="veo-overlay">
-      <div className="veo">
-        <SpinnerContainer
-          spinnerComponent={<TechnoSpinner />}
-          loading={loadingState}
-        >
-          <VEOHeader
-            key={view && view.name}
-            name={view && view.name}
-            onSetName={onSetName}
-            onCancel={handleClose}
-            onSave={handleSave}
-          />
-          <div className="veo-contents">
-            <TimeMachine />
-          </div>
-        </SpinnerContainer>
-      </div>
-    </Overlay>
+    <div className="veo">
+      <SpinnerContainer
+        spinnerComponent={<TechnoSpinner />}
+        loading={view.status}
+      >
+        <VEOHeader
+          key={view && view.name}
+          name={view && view.name}
+          onSetName={(name: string) => dispatch(setName(name))}
+          onCancel={handleClose}
+          onSave={handleSave}
+        />
+        <div className="veo-contents">
+          <TimeMachine />
+        </div>
+      </SpinnerContainer>
+    </div>
   )
 }
 
-const mstp = (state: AppState) => {
-  const {activeTimeMachineID} = state.timeMachines
-  const {view} = getActiveTimeMachine(state)
+export {NewViewVEO}
 
-  return {view, activeTimeMachineID}
-}
-
-const mdtp = {
-  onSetName: setName,
-  onSaveView: saveVEOView,
-}
-
-const connector = connect(mstp, mdtp)
-
-export default connector(withRouter(NewViewVEO))
+export default () => (
+  <Overlay visible={true} className="veo-overlay">
+    <NewViewVEO />
+  </Overlay>
+)


### PR DESCRIPTION
this removes the overlay experience of the dashboard nav, saving huge on perf when we're re-rendering a bunch of graphs that the user can't even see.

still todo:
dont rerun cells on navigation back from editing