### PR TITLE
fix: codesnippet without copy button

### DIFF
--- a/src/shared/components/CodeSnippet.scss
+++ b/src/shared/components/CodeSnippet.scss
@@ -7,7 +7,6 @@
   border-radius: $cf-radius;
   overflow: hidden;
   border: $cf-border solid $cf-grey-15;
-  background-color: $cf-grey-15;
   margin-bottom: $cf-space-2xs;
 }
 
@@ -48,6 +47,7 @@
   justify-content: space-between;
   padding: $cf-space-2xs $cf-space-s;
   border-top: $cf-border solid $cf-grey-15;
+  background-color: $cf-grey-15;
 }
 
 .code-snippet--label {

--- a/src/shared/components/CodeSnippet.tsx
+++ b/src/shared/components/CodeSnippet.tsx
@@ -130,10 +130,12 @@ const CodeSnippet: FC<Props> = ({
           )}
         </div>
       </DapperScrollbars>
-      <div className="code-snippet--footer">
-        {showCopyControl && <CopyButton text={_text} onCopy={handleCopy} />}
-        {label && <label className="code-snippet--label">{label}</label>}
-      </div>
+      {(showCopyControl || label) && (
+        <div className="code-snippet--footer">
+          {showCopyControl && <CopyButton text={_text} onCopy={handleCopy} />}
+          {label && <label className="code-snippet--label">{label}</label>}
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Closes #4537 

`Codesnippet` component's footer was an empty div with styling even when the `copy to clipboard`  button/`label` were absent so we hide the entire div when none of those two elements are present. (`label` or `copy to clipboard` button).

This makes it so that the component doesn't look like the copy button is clipped when we set `showCopyControl` to false.

Before: 

<img width="1122" alt="Screen Shot 2022-06-04 at 11 09 53 AM" src="https://user-images.githubusercontent.com/18511823/172020152-bdc5287b-77e5-434e-b4c1-4eb3a2e8721d.png">

After: 

<img width="1137" alt="Screen Shot 2022-06-04 at 11 10 24 AM" src="https://user-images.githubusercontent.com/18511823/172020171-2a6fb025-e6ad-48f9-93b3-1222409e02b0.png">


<!-- Describe your proposed changes here. -->
