### PR TITLE
feat: moving query time over to new status

### DIFF
--- a/src/dataExplorer/components/QueryTime.scss
+++ b/src/dataExplorer/components/QueryTime.scss
@@ -1,0 +1,29 @@
+@import '@influxdata/clockface/dist/variables.scss';
+
+.query-status {
+  flex-grow: 1;
+
+  .status {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: $g10-wolf;
+
+    display: inline-block;
+    margin-right: 10px;
+    margin-bottom: -2px;
+
+    &.loading {
+      background: $c-rainforest;
+      filter: drop-shadow(0 0 4px $c-rainforest);
+    }
+
+    &.error {
+      background: $c-fire;
+    }
+
+    &.done {
+      background: $c-rainforest;
+    }
+  }
+}

--- a/src/dataExplorer/components/QueryTime.tsx
+++ b/src/dataExplorer/components/QueryTime.tsx
@@ -1,0 +1,56 @@
+import React, {FC, useContext} from 'react'
+import {ResultsContext} from 'src/dataExplorer/components/ResultsContext'
+import {RemoteDataState} from 'src/types'
+
+import 'src/dataExplorer/components/QueryTime.scss'
+
+const humanReadable = (time: number): string => {
+  return '' + time + 'ms'
+}
+
+const QueryTime: FC = () => {
+  const {status, time} = useContext(ResultsContext)
+
+  if (status === RemoteDataState.Done) {
+    return (
+      <div className="query-status">
+        <div className="status done" />
+        <label>Ready ({humanReadable(time)})</label>
+      </div>
+    )
+  }
+
+  if (status === RemoteDataState.Loading) {
+    if (time < 1000) {
+      return (
+        <div className="query-status">
+          <div className="status loading" />
+          <label>Running...</label>
+        </div>
+      )
+    }
+    return (
+      <div className="query-status">
+        <div className="status loading" />
+        <label>Running ({humanReadable(time)})...</label>
+      </div>
+    )
+  }
+
+  if (status === RemoteDataState.Error) {
+    return (
+      <div className="query-status">
+        <div className="status error" />
+        <label>Error ({humanReadable(time)})</label>
+      </div>
+    )
+  }
+
+  return (
+    <div className="query-status">
+      <div className="status pending" />
+    </div>
+  )
+}
+
+export default QueryTime

--- a/src/dataExplorer/components/Results.tsx
+++ b/src/dataExplorer/components/Results.tsx
@@ -12,7 +12,7 @@ import './Results.scss'
 
 // simplified version migrated from src/flows/pipes/Table/view.tsx
 const QueryStat: FC = () => {
-  const {result, time} = useContext(ResultsContext)
+  const {result} = useContext(ResultsContext)
 
   const tableColumn = result?.parsed?.table?.getColumn('table') || []
   const lastTableValue = tableColumn[tableColumn.length - 1] || -1
@@ -33,7 +33,6 @@ const QueryStat: FC = () => {
       <span className="query-stat--bold">{`${tableNum} tables`}</span>
       <span className="query-stat--bold">{`${result?.parsed?.table?.length ||
         0} rows`}</span>
-      <span className="query-stat--normal">{`${time} ms`}</span>
     </div>
   )
 }

--- a/src/dataExplorer/components/ResultsPane.tsx
+++ b/src/dataExplorer/components/ResultsPane.tsx
@@ -26,6 +26,7 @@ import {notify} from 'src/shared/actions/notifications'
 import {TIME_RANGE_START, TIME_RANGE_STOP} from 'src/variables/constants'
 import {getRangeVariable} from 'src/variables/utils/getTimeRangeVars'
 import {getWindowPeriodVariableFromVariables} from 'src/variables/utils/getWindowVars'
+import QueryTime from 'src/dataExplorer/components/QueryTime'
 
 import {DEFAULT_TIME_RANGE} from 'src/shared/constants/timeRanges'
 
@@ -41,7 +42,7 @@ const ResultsPane: FC = () => {
     INITIAL_HORIZ_RESIZER_HANDLE,
   ])
   const {basic, query} = useContext(QueryContext)
-  const {status, setStatus, setResult, setTime} = useContext(ResultsContext)
+  const {status, setStatus, setResult} = useContext(ResultsContext)
 
   const [text, setText] = useState('')
   const [timeRange, setTimeRange] = useState<TimeRange>(DEFAULT_TIME_RANGE)
@@ -83,7 +84,6 @@ const ResultsPane: FC = () => {
     }
 
     setStatus(RemoteDataState.Loading)
-    const time = Date.now()
     query(text, {
       vars: {
         timeRangeStart,
@@ -93,11 +93,9 @@ const ResultsPane: FC = () => {
       .then(r => {
         setResult(r)
         setStatus(RemoteDataState.Done)
-        setTime(Date.now() - time)
       })
       .catch(() => {
         setStatus(RemoteDataState.Error)
-        setTime(0)
       })
   }
 
@@ -145,6 +143,7 @@ const ResultsPane: FC = () => {
               justifyContent={JustifyContent.FlexEnd}
               margin={ComponentSize.Small}
             >
+              <QueryTime />
               <Button
                 titleText="Download query results as a .CSV file"
                 text="CSV"


### PR DESCRIPTION
moves the query time status information into the space between the editor and the viz

![Peek 2022-06-06 10-40](https://user-images.githubusercontent.com/1434802/172217008-216079eb-3684-42b5-a133-087f761da867.gif)
