### PR TITLE
feat: move publish button to check for added engagement

### DIFF
--- a/src/flows/components/header/MenuButton.tsx
+++ b/src/flows/components/header/MenuButton.tsx
@@ -27,6 +27,7 @@ import {downloadImage} from 'src/shared/utils/download'
 // Constants
 import {PROJECT_NAME_PLURAL} from 'src/flows'
 import {CLOUD} from 'src/shared/constants'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 const backgroundColor = '#07070E'
 
@@ -175,12 +176,6 @@ const MenuButton: FC<Props> = ({handleResetShare}) => {
   const menuItems: any[] = [
     {
       type: 'menuitem',
-      title: 'Save to version history',
-      onClick: handlePublish,
-      icon: IconFont.Save,
-    },
-    {
-      type: 'menuitem',
       title: 'Version history',
       onClick: handleViewPublish,
       icon: IconFont.History,
@@ -215,6 +210,15 @@ const MenuButton: FC<Props> = ({handleResetShare}) => {
       testID: 'flow-menu-button-delete',
     },
   ]
+
+  if (!isFlagEnabled('flowPublishButton')) {
+    menuItems.splice(0, 0, {
+      type: 'menuitem',
+      title: 'Save to version history',
+      onClick: handlePublish,
+      icon: IconFont.Save,
+    })
+  }
 
   if (CLOUD) {
     menuItems.splice(3, 0, {

--- a/src/flows/components/header/index.tsx
+++ b/src/flows/components/header/index.tsx
@@ -165,6 +165,14 @@ const FlowHeader: FC = () => {
           <PresentationMode />
           <TimeZoneDropdown />
           <TimeRangeDropdown />
+          <FeatureFlag name="flowPublishButton">
+            <SquareButton
+              icon={IconFont.Save}
+              onClick={handlePublish}
+              color={ComponentColor.Default}
+              titleText="Save to version history"
+            />
+          </FeatureFlag>
           {flow?.id && (
             <>
               <SquareButton


### PR DESCRIPTION
This PR follows-up on the original publish lifecycle work to see if there's added engagement among users that have the publish button visible rather than hidden behind the dropdown