### PR TITLE
chore: freeze timerange changes from triggering background queries in dashboards

### DIFF
--- a/src/buckets/components/BucketCard.tsx
+++ b/src/buckets/components/BucketCard.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC} from 'react'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
+import {useHistory, useParams} from 'react-router-dom'
 
 // Components
 import {ResourceCard} from '@influxdata/clockface'
@@ -26,16 +26,14 @@ interface Props {
   onFilterChange: (searchTerm: string) => void
 }
 
-const BucketCard: FC<Props & RouteComponentProps<{orgID: string}>> = ({
+const BucketCard: FC<Props> = ({
   bucket,
   onDeleteBucket,
   onFilterChange,
   onGetBucketSchema,
-  history,
-  match: {
-    params: {orgID},
-  },
 }) => {
+  const history = useHistory()
+  const {orgID} = useParams<{orgID: string}>()
   const handleNameClick = () => {
     if (isFlagEnabled('exploreWithFlows')) {
       history.push(
@@ -72,4 +70,4 @@ const BucketCard: FC<Props & RouteComponentProps<{orgID: string}>> = ({
   )
 }
 
-export default withRouter(BucketCard)
+export default BucketCard

--- a/src/dashboards/components/DashboardHeader.tsx
+++ b/src/dashboards/components/DashboardHeader.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FC, useCallback, useContext} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
-import {RouteComponentProps, withRouter} from 'react-router-dom'
+import {useHistory} from 'react-router-dom'
 
 // Components
 import AutoRefreshDropdown from 'src/shared/components/dropdown_auto_refresh/AutoRefreshDropdown'
@@ -74,7 +74,7 @@ interface OwnProps {
 }
 
 type ReduxProps = ConnectedProps<typeof connector>
-type Props = OwnProps & ReduxProps & RouteComponentProps<{orgID: string}>
+type Props = OwnProps & ReduxProps
 
 const DashboardHeader: FC<Props> = ({
   dashboard,
@@ -86,13 +86,13 @@ const DashboardHeader: FC<Props> = ({
   updateDashboard,
   updateQueryParams,
   setDashboardTimeRange,
-  history,
   org,
   autoRefresh,
   resetAutoRefresh,
   showOverlay,
   dismissOverlay,
 }) => {
+  const history = useHistory()
   const handleAddNote = () => {
     history.push(`/orgs/${org.id}/dashboards/${dashboard.id}/notes/new`)
   }
@@ -320,4 +320,4 @@ const mdtp = {
 
 const connector = connect(mstp, mdtp)
 
-export default connector(withRouter(DashboardHeader))
+export default connector(DashboardHeader)

--- a/src/dashboards/components/EditVEO.tsx
+++ b/src/dashboards/components/EditVEO.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent, useEffect} from 'react'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
+import {useHistory, useParams} from 'react-router-dom'
 import {connect, ConnectedProps, useDispatch} from 'react-redux'
 import {get} from 'lodash'
 
@@ -10,7 +10,6 @@ import TimeMachine from 'src/timeMachine/components/TimeMachine'
 import VEOHeader from 'src/dashboards/components/VEOHeader'
 
 // Actions
-import {disableUpdatedTimeRangeInVEO} from 'src/shared/actions/app'
 import {setName} from 'src/timeMachine/actions'
 import {saveVEOView} from 'src/dashboards/actions/thunks'
 import {getViewAndResultsForVEO} from 'src/views/actions/thunks'
@@ -21,21 +20,21 @@ import {getActiveTimeMachine} from 'src/timeMachine/selectors'
 // Types
 import {AppState, RemoteDataState} from 'src/types'
 
-type ReduxProps = ConnectedProps<typeof connector>
-type Props = ReduxProps &
-  RouteComponentProps<{orgID: string; cellID: string; dashboardID: string}>
+type Props = ConnectedProps<typeof connector>
 
 const EditViewVEO: FunctionComponent<Props> = ({
   activeTimeMachineID,
   onSaveView,
   onSetName,
-  match: {
-    params: {orgID, cellID, dashboardID},
-  },
-  history,
   view,
 }) => {
   const dispatch = useDispatch()
+  const history = useHistory()
+  const {cellID, orgID, dashboardID} = useParams<{
+    orgID: string
+    cellID: string
+    dashboardID: string
+  }>()
   useEffect(() => {
     // TODO split this up into "loadView" "setActiveTimeMachine"
     // and something to tell the component to pull from the context
@@ -45,7 +44,6 @@ const EditViewVEO: FunctionComponent<Props> = ({
 
   const handleClose = () => {
     history.push(`/orgs/${orgID}/dashboards/${dashboardID}`)
-    dispatch(disableUpdatedTimeRangeInVEO())
   }
 
   const handleSave = () => {
@@ -99,4 +97,4 @@ const mdtp = {
 
 const connector = connect(mstp, mdtp)
 
-export default connector(withRouter(EditViewVEO))
+export default connector(EditViewVEO)

--- a/src/dashboards/components/GetTimeRange.tsx
+++ b/src/dashboards/components/GetTimeRange.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {FC, useEffect} from 'react'
 import {useDispatch, useSelector} from 'react-redux'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
+import {useParams, useLocation} from 'react-router-dom'
 import {getTimeRange} from 'src/dashboards/selectors'
 
 // Actions
@@ -10,9 +10,9 @@ import {
   updateQueryParams,
 } from 'src/dashboards/actions/ranges'
 
-type Props = RouteComponentProps<{dashboardID: string}>
-
-const GetTimeRange: FC<Props> = ({location, match}: Props) => {
+const GetTimeRange: FC = () => {
+  const {dashboardID} = useParams<{dashboardID: string}>()
+  const location = useLocation()
   const dispatch = useDispatch()
   const timeRange = useSelector(getTimeRange)
   const isEditing = location.pathname.includes('edit')
@@ -24,7 +24,7 @@ const GetTimeRange: FC<Props> = ({location, match}: Props) => {
     }
 
     // TODO: map this to current contextID
-    dispatch(setDashboardTimeRange(match.params.dashboardID, timeRange))
+    dispatch(setDashboardTimeRange(dashboardID, timeRange))
     const {lower, upper} = timeRange
     dispatch(
       updateQueryParams({
@@ -32,9 +32,9 @@ const GetTimeRange: FC<Props> = ({location, match}: Props) => {
         upper,
       })
     )
-  }, [dispatch, isEditing, isNew, match.params.dashboardID, timeRange])
+  }, [dispatch, isEditing, isNew, dashboardID, timeRange])
 
   return <div />
 }
 
-export default withRouter(GetTimeRange)
+export default GetTimeRange

--- a/src/dashboards/components/NewVEO.tsx
+++ b/src/dashboards/components/NewVEO.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FunctionComponent, useEffect} from 'react'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
+import {useParams, useHistory} from 'react-router-dom'
 import {connect, ConnectedProps, useDispatch} from 'react-redux'
 import {get} from 'lodash'
 
@@ -20,20 +20,16 @@ import {getActiveTimeMachine} from 'src/timeMachine/selectors'
 // Types
 import {AppState, RemoteDataState} from 'src/types'
 
-type ReduxProps = ConnectedProps<typeof connector>
-type Props = ReduxProps &
-  RouteComponentProps<{orgID: string; dashboardID: string}>
+type Props = ConnectedProps<typeof connector>
 
 const NewViewVEO: FunctionComponent<Props> = ({
   activeTimeMachineID,
   onSaveView,
   onSetName,
-  match: {
-    params: {orgID, dashboardID},
-  },
-  history,
   view,
 }) => {
+  const {orgID, dashboardID} = useParams<{orgID: string; dashboardID: string}>()
+  const history = useHistory()
   const dispatch = useDispatch()
   useEffect(() => {
     dispatch(loadNewVEO())
@@ -95,4 +91,4 @@ const mdtp = {
 
 const connector = connect(mstp, mdtp)
 
-export default connector(withRouter(NewViewVEO))
+export default connector(NewViewVEO)

--- a/src/dashboards/selectors/index.test.ts
+++ b/src/dashboards/selectors/index.test.ts
@@ -103,7 +103,6 @@ describe('Dashboards.Selector', () => {
     const app: AppPresentationState = {
       ephemeral: {
         inPresentationMode: false,
-        hasUpdatedTimeRangeInVEO: false,
       },
       persisted: {
         autoRefresh: 0,
@@ -128,7 +127,6 @@ describe('Dashboards.Selector', () => {
     const app: AppPresentationState = {
       ephemeral: {
         inPresentationMode: false,
-        hasUpdatedTimeRangeInVEO: false,
       },
       persisted: {
         autoRefresh: 0,
@@ -161,7 +159,6 @@ describe('Dashboards.Selector', () => {
     const app: AppPresentationState = {
       ephemeral: {
         inPresentationMode: false,
-        hasUpdatedTimeRangeInVEO: false,
       },
       persisted: {
         autoRefresh: 0,
@@ -194,7 +191,6 @@ describe('Dashboards.Selector', () => {
     const app: AppPresentationState = {
       ephemeral: {
         inPresentationMode: false,
-        hasUpdatedTimeRangeInVEO: false,
       },
       persisted: {
         autoRefresh: 0,
@@ -223,7 +219,6 @@ describe('Dashboards.Selector', () => {
     const app: AppPresentationState = {
       ephemeral: {
         inPresentationMode: false,
-        hasUpdatedTimeRangeInVEO: false,
       },
       persisted: {
         autoRefresh: 0,

--- a/src/dataExplorer/components/SaveAsButton.tsx
+++ b/src/dataExplorer/components/SaveAsButton.tsx
@@ -1,33 +1,28 @@
 // Libraries
-import React, {PureComponent} from 'react'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
+import React, {FC} from 'react'
+import {useHistory, useLocation} from 'react-router-dom'
 
 // Components
 import {IconFont, Button, ComponentColor} from '@influxdata/clockface'
 
-class SaveAsButton extends PureComponent<RouteComponentProps, {}> {
-  public render() {
-    return (
-      <>
-        <Button
-          icon={IconFont.Export_New}
-          text="Save As"
-          onClick={this.handleShowOverlay}
-          color={ComponentColor.Primary}
-          titleText="Save your query as a Dashboard Cell or a Task"
-          testID="save-query-as"
-        />
-      </>
-    )
+const SaveAsButton: FC = () => {
+  const history = useHistory()
+  const {pathname} = useLocation()
+
+  const handleShowOverlay = () => {
+    history.push(`${pathname}/save`)
   }
 
-  private handleShowOverlay = () => {
-    const {
-      location: {pathname},
-    } = this.props
-
-    this.props.history.push(`${pathname}/save`)
-  }
+  return (
+    <Button
+      icon={IconFont.Export_New}
+      text="Save As"
+      onClick={handleShowOverlay}
+      color={ComponentColor.Primary}
+      titleText="Save your query as a Dashboard Cell or a Task"
+      testID="save-query-as"
+    />
+  )
 }
 
-export default withRouter(SaveAsButton)
+export default SaveAsButton

--- a/src/mockState.tsx
+++ b/src/mockState.tsx
@@ -22,7 +22,6 @@ export const localState: LocalStorage = {
   app: {
     ephemeral: {
       inPresentationMode: false,
-      hasUpdatedTimeRangeInVEO: false,
     },
     persisted: {
       autoRefresh: 0,

--- a/src/shared/actions/app.ts
+++ b/src/shared/actions/app.ts
@@ -3,8 +3,6 @@ import {TimeZone, Theme, NavBarState, VersionInfo, FlowsCTA} from 'src/types'
 export enum ActionTypes {
   EnablePresentationMode = 'ENABLE_PRESENTATION_MODE',
   DisablePresentationMode = 'DISABLE_PRESENTATION_MODE',
-  EnableUpdatedTimeRangeInVEO = 'ENABLE_UPDATED_TIMERANGE_IN_VEO',
-  DisableUpdatedTimeRangeInVEO = 'DISABLE_UPDATED_TIMERANGE_IN_VEO',
   SetNavBarState = 'SET_NAV_BAR_STATE',
   SetFluxQueryBuilder = 'SET_FLUX_QUERY_BUILDER',
   SetAutoRefresh = 'SET_AUTOREFRESH',
@@ -18,8 +16,6 @@ export enum ActionTypes {
 export type Action =
   | ReturnType<typeof enablePresentationMode>
   | ReturnType<typeof disablePresentationMode>
-  | ReturnType<typeof enableUpdatedTimeRangeInVEO>
-  | ReturnType<typeof disableUpdatedTimeRangeInVEO>
   | ReturnType<typeof setFluxQueryBuilder>
   | ReturnType<typeof setNavBarState>
   | ReturnType<typeof setAutoRefresh>
@@ -38,16 +34,6 @@ export const enablePresentationMode = () =>
 export const disablePresentationMode = () =>
   ({
     type: ActionTypes.DisablePresentationMode,
-  } as const)
-
-export const enableUpdatedTimeRangeInVEO = () =>
-  ({
-    type: ActionTypes.EnableUpdatedTimeRangeInVEO,
-  } as const)
-
-export const disableUpdatedTimeRangeInVEO = () =>
-  ({
-    type: ActionTypes.DisableUpdatedTimeRangeInVEO,
   } as const)
 
 // persistent state action creators

--- a/src/shared/components/TimeSeries.tsx
+++ b/src/shared/components/TimeSeries.tsx
@@ -32,7 +32,6 @@ import {TIME_RANGE_START, TIME_RANGE_STOP} from 'src/variables/constants'
 // Actions & Selectors
 import {getAll} from 'src/resources/selectors'
 import {notify as notifyAction} from 'src/shared/actions/notifications'
-import {hasUpdatedTimeRangeInVEO} from 'src/shared/selectors/app'
 import {setCellMount as setCellMountAction} from 'src/perf/actions'
 
 // Types
@@ -334,13 +333,20 @@ class TimeSeries extends Component<Props, State> {
   }
 
   private shouldReload(prevProps: Props) {
-    if (this.props.hasUpdatedTimeRangeInVEO) {
+    if (
+      this.props.location.pathname.includes('cells') &&
+      this.props.location.pathname.includes('edit')
+    ) {
       return false
     }
 
     if (
-      prevProps.hasUpdatedTimeRangeInVEO &&
-      !this.props.hasUpdatedTimeRangeInVEO
+      prevProps.location.pathname.includes('cells') &&
+      prevProps.location.pathname.includes('edit') &&
+      !(
+        this.props.location.pathname.includes('cells') &&
+        this.props.location.pathname.includes('edit')
+      )
     ) {
       return true
     }
@@ -390,9 +396,7 @@ const mstp = (state: AppState, props: OwnProps) => {
   ]
 
   return {
-    hasUpdatedTimeRangeInVEO: hasUpdatedTimeRangeInVEO(state),
     isCurrentPageDashboard: isCurrentPageDashboardSelector(state),
-    queryLink: '/api/v2/query',
     buckets: getAll<Bucket>(state, ResourceType.Buckets),
     variables,
   }

--- a/src/shared/components/cells/CellContext.tsx
+++ b/src/shared/components/cells/CellContext.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC, useRef, RefObject, useState} from 'react'
-import {withRouter, RouteComponentProps} from 'react-router-dom'
+import {useHistory, useLocation} from 'react-router-dom'
 import {connect, ConnectedProps} from 'react-redux'
 import {get} from 'lodash'
 import classnames from 'classnames'
@@ -39,12 +39,10 @@ interface OwnProps {
 }
 
 type ReduxProps = ConnectedProps<typeof connector>
-type Props = OwnProps & ReduxProps & RouteComponentProps<{orgID: string}>
+type Props = OwnProps & ReduxProps
 
 const CellContext: FC<Props> = ({
   view,
-  history,
-  location,
   cell,
   onCloneCell,
   onDeleteCell,
@@ -54,6 +52,8 @@ const CellContext: FC<Props> = ({
   onShowOverlay,
   onDismissOverlay,
 }) => {
+  const history = useHistory()
+  const location = useLocation()
   const [popoverVisible, setPopoverVisibility] = useState<boolean>(false)
   const editNoteText = !!get(view, 'properties.note') ? 'Edit Note' : 'Add Note'
   const triggerRef: RefObject<HTMLButtonElement> = useRef<HTMLButtonElement>(
@@ -244,4 +244,4 @@ const mdtp = {
 
 const connector = connect(mstp, mdtp)
 
-export default withRouter(connector(CellContext))
+export default connector(CellContext)

--- a/src/shared/reducers/app.test.ts
+++ b/src/shared/reducers/app.test.ts
@@ -14,7 +14,6 @@ describe('Shared.Reducers.appReducer', () => {
   const initialState: AppPresentationState = {
     ephemeral: {
       inPresentationMode: false,
-      hasUpdatedTimeRangeInVEO: false,
     },
     persisted: {
       autoRefresh: 0,

--- a/src/shared/reducers/app.ts
+++ b/src/shared/reducers/app.ts
@@ -8,7 +8,6 @@ import {TimeZone, NavBarState, Theme, VersionInfo, FlowsCTA} from 'src/types'
 export interface AppState {
   ephemeral: {
     inPresentationMode: boolean
-    hasUpdatedTimeRangeInVEO: boolean
   }
   persisted: {
     autoRefresh: number
@@ -25,7 +24,6 @@ export interface AppState {
 const initialState: AppState = {
   ephemeral: {
     inPresentationMode: false,
-    hasUpdatedTimeRangeInVEO: false,
   },
   persisted: {
     theme: 'dark',
@@ -60,20 +58,6 @@ const appEphemeralReducer = (
       return {
         ...state,
         inPresentationMode: false,
-      }
-    }
-
-    case ActionTypes.EnableUpdatedTimeRangeInVEO: {
-      return {
-        ...state,
-        hasUpdatedTimeRangeInVEO: true,
-      }
-    }
-
-    case ActionTypes.DisableUpdatedTimeRangeInVEO: {
-      return {
-        ...state,
-        hasUpdatedTimeRangeInVEO: false,
       }
     }
 

--- a/src/shared/selectors/app.ts
+++ b/src/shared/selectors/app.ts
@@ -23,9 +23,6 @@ export const fluxQueryBuilder = (state: AppState): boolean =>
 export const getVersionInfo = (state: AppState): VersionInfo =>
   state.app.persisted.versionInfo || ({} as VersionInfo)
 
-export const hasUpdatedTimeRangeInVEO = (state: AppState): boolean =>
-  state.app.ephemeral.hasUpdatedTimeRangeInVEO || false
-
 export const getPresentationMode = (state: AppState): boolean =>
   state.app.ephemeral.inPresentationMode || false
 

--- a/src/timeMachine/components/Queries.tsx
+++ b/src/timeMachine/components/Queries.tsx
@@ -1,7 +1,6 @@
 // Libraries
 import React, {FC} from 'react'
 import {useSelector, useDispatch} from 'react-redux'
-import {useRouteMatch} from 'react-router-dom'
 
 // Components
 import TimeMachineFluxEditor from 'src/timeMachine/components/TimeMachineFluxEditor'
@@ -27,7 +26,6 @@ import {
   setTimeMachineTimeRange,
   setTimeRange,
 } from 'src/timeMachine/actions'
-import {enableUpdatedTimeRangeInVEO} from 'src/shared/actions/app'
 import {getAllVariables} from 'src/variables/selectors'
 
 // Utils
@@ -53,14 +51,7 @@ const TimeMachineQueries: FC<Props> = ({maxHeight}) => {
   const isInCheckOverlay = useSelector(getIsInCheckOverlay)
   const variables = useSelector(getAllVariables)
 
-  const isEditing = useRouteMatch(
-    '/orgs/:orgID/dashboards/:dashboardID/cells/:cellID/edit'
-  )
-
   const handleSetTimeRange = (timeRange: TimeRange) => {
-    if (isEditing) {
-      dispatch(enableUpdatedTimeRangeInVEO())
-    }
     dispatch(setTimeRange(timeRange))
     dispatch(setTimeMachineTimeRange(timeRange))
     if (timeRange.type === 'custom') {


### PR DESCRIPTION
This PR resolves an issue where changing the timerange in a cell editor overlay would trigger a the background cells to update as well. Not entirely sure when this mechanism broke, but somewhere along the way this stopped work. 

The crux of the issue was that we referencing the wrong route, `cell` vs `cells`. Not sure when that change happened but it looks like this has been broken and unreported for a while.

There was a bunch of state setting that I cleaned up to just derive values off of existing information that's available in the TimeSeries component

![cell-editor](https://user-images.githubusercontent.com/19984220/172629866-27bb7b2c-4905-457a-83b9-8a1b76942a59.gif)
