### PR TITLE
feat: add status page in help bar sub menu

### DIFF
--- a/src/pageLayout/containers/TreeNav.tsx
+++ b/src/pageLayout/containers/TreeNav.tsx
@@ -188,7 +188,17 @@ const TreeSidebar: FC<ReduxProps & RouteComponentProps> = ({
                   />
                 )}
               />
-
+              <TreeNav.SubItem
+                id="status-page"
+                label="Status Page"
+                testID="nav-subitem-status"
+                linkElement={() => (
+                  <SafeBlankLink
+                    href="https://status.influxdata.com"
+                    onClick={() => handleEventing('status-page')}
+                  />
+                )}
+              />
               {isFlagEnabled('helpBarSfdcIntegration') && (
                 <TreeNav.SubItem
                   id="contactSupport"


### PR DESCRIPTION
Closes #4730 

Pr adds Status Page to Help Bar so that users can see information about regional uptime and incident management. 

https://user-images.githubusercontent.com/66275100/172636606-f3e3f3ae-507b-48de-b43e-9ad1c1e35c3b.mov



