### PR TITLE
fix(4677): lsp helper methods need to be error handled.

### DIFF
--- a/src/flows/pipes/Notification/view.tsx
+++ b/src/flows/pipes/Notification/view.tsx
@@ -42,6 +42,7 @@ import {
 } from 'src/flows/pipes/Notification/endpoints'
 import {SidebarContext} from 'src/flows/context/sidebar'
 import ExportTask from 'src/flows/pipes/Notification/ExportTask'
+import ErrorBoundary from 'src/shared/components/ErrorBoundary'
 const NotificationMonacoEditor = lazy(() =>
   import('src/flows/pipes/Notification/NotificationMonacoEditor')
 )
@@ -481,7 +482,9 @@ const Notification: FC<PipeProp> = ({Context}) => {
         </FlexBox>
         <Panel.Footer justifyContent={JustifyContent.FlexEnd}>
           <FlexBox margin={ComponentSize.Medium}>
-            <ExportTask />
+            <ErrorBoundary>
+              <ExportTask />
+            </ErrorBoundary>
           </FlexBox>
         </Panel.Footer>
       </div>

--- a/src/languageSupport/languages/flux/lsp/prelude.ts
+++ b/src/languageSupport/languages/flux/lsp/prelude.ts
@@ -40,7 +40,9 @@ class Prelude {
           )
         )
       }
-    } catch (_) {}
+    } catch (e) {
+      console.error(e)
+    }
   }
 
   subscribeToModel(editor: EditorType) {

--- a/src/languageSupport/languages/flux/lsp/worker/utils.ts
+++ b/src/languageSupport/languages/flux/lsp/worker/utils.ts
@@ -2,5 +2,7 @@ export const respond = (msg, cb) => {
   try {
     const d = JSON.parse(msg)
     cb(d)
-  } catch (_) {}
+  } catch (e) {
+    console.warn(e)
+  }
 }

--- a/src/timeMachine/actions/queries.ts
+++ b/src/timeMachine/actions/queries.ts
@@ -81,15 +81,19 @@ export const getOrgIDFromBuckets = (
   text: string,
   allBuckets: Bucket[]
 ): string | null => {
-  const ast = parse(text)
-  const bucketsInQuery: string[] = findNodes(ast, isFromBucket).map(node =>
-    get(node, 'arguments.0.properties.0.value.value', '')
-  )
+  try {
+    const ast = parse(text)
+    const bucketsInQuery: string[] = findNodes(ast, isFromBucket).map(node =>
+      get(node, 'arguments.0.properties.0.value.value', '')
+    )
 
-  // if there are buckets from multiple orgs in a query, query will error, and user will receive error from query
-  const bucketMatch = allBuckets.find(a => bucketsInQuery.includes(a.name))
+    // if there are buckets from multiple orgs in a query, query will error, and user will receive error from query
+    const bucketMatch = allBuckets.find(a => bucketsInQuery.includes(a.name))
 
-  return get(bucketMatch, 'orgID', null)
+    return get(bucketMatch, 'orgID', null)
+  } catch (_) {
+    return null
+  }
 }
 
 // We only need a minimum of one bucket, function, and tag,

--- a/src/timeMachine/actions/queries.ts
+++ b/src/timeMachine/actions/queries.ts
@@ -91,7 +91,8 @@ export const getOrgIDFromBuckets = (
     const bucketMatch = allBuckets.find(a => bucketsInQuery.includes(a.name))
 
     return get(bucketMatch, 'orgID', null)
-  } catch (_) {
+  } catch (e) {
+    console.error(e)
     return null
   }
 }

--- a/src/variables/utils/astim.ts
+++ b/src/variables/utils/astim.ts
@@ -19,11 +19,19 @@ const parseAllVariables = (ast: File): MemberExpression[] => {
 }
 
 export const parseASTIM = (query: string): ASTIM => {
-  const ast: File = parse(query)
-  // Using `any` to circumvent ts error
-  const variables: any = ast ? parseAllVariables(ast) : []
+  let ast: File = null
+  try {
+    ast = parse(query)
+  } catch (_) {}
+  const variables: MemberExpression[] = ast ? parseAllVariables(ast) : []
   const variableNames = new Set()
-  variables.forEach(variable => variableNames.add(variable.property.name))
+  variables.forEach(variable => {
+    if (variable.property.type === 'Identifier') {
+      variableNames.add(variable.property.name)
+    } else if (variable.property.type === 'StringLiteral') {
+      variableNames.add(variable.property.value)
+    }
+  })
 
   const hasVariable = (v: string): boolean => {
     return variableNames.has(v)

--- a/src/variables/utils/astim.ts
+++ b/src/variables/utils/astim.ts
@@ -22,7 +22,9 @@ export const parseASTIM = (query: string): ASTIM => {
   let ast: File = null
   try {
     ast = parse(query)
-  } catch (_) {}
+  } catch (e) {
+    console.error(e)
+  }
   const variables: MemberExpression[] = ast ? parseAllVariables(ast) : []
   const variableNames = new Set()
   variables.forEach(variable => {

--- a/src/writeData/components/ClientCodeQueryHelper.tsx
+++ b/src/writeData/components/ClientCodeQueryHelper.tsx
@@ -50,18 +50,19 @@ const ClientCodeQueryHelper: FC<Props> = ({clientQuery, contentID}) => {
       changeQuery(def.query)
       return
     }
-
-    const ast = parse(clientQuery)
-    const queryBucket = getBucketsFromAST(ast)[0]
-    if (queryBucket) {
-      changeBucket({name: queryBucket} as Bucket)
-    }
-    updateBucketInAST(ast, '<%= bucket %>')
-    let query = format_from_js_file(ast)
-    if (def.querySanitize) {
-      query = def.querySanitize(query)
-    }
-    changeQuery(query)
+    try {
+      const ast = parse(clientQuery)
+      const queryBucket = getBucketsFromAST(ast)[0]
+      if (queryBucket) {
+        changeBucket({name: queryBucket} as Bucket)
+      }
+      updateBucketInAST(ast, '<%= bucket %>')
+      let query = format_from_js_file(ast)
+      if (def.querySanitize) {
+        query = def.querySanitize(query)
+      }
+      changeQuery(query)
+    } catch (_) {}
   }, [clientQuery, def.query, changeBucket, changeQuery])
 
   return null

--- a/src/writeData/components/ClientCodeQueryHelper.tsx
+++ b/src/writeData/components/ClientCodeQueryHelper.tsx
@@ -62,7 +62,9 @@ const ClientCodeQueryHelper: FC<Props> = ({clientQuery, contentID}) => {
         query = def.querySanitize(query)
       }
       changeQuery(query)
-    } catch (_) {}
+    } catch (e) {
+      console.error(e)
+    }
   }, [clientQuery, def.query, changeBucket, changeQuery])
 
   return null


### PR DESCRIPTION
Part of (possibly closes) #4677 

## Bug:
* when occurs:
  * on load of the old DataExplorer, with the queryBuilder (not the flux script editor):
    * get error in the queryBuilder loading
  * on load of an existing Dashboard, once you click to open a cell:
    * this again loads DataExplorer subcomponents, with a queryBuilder (not a flux script editor). 
* console errors:
  * lsp library error.


## Debugging steps:
1. since the script editor is not loaded in these^^ views, the error is likely in an lsp helper method.
2. found downstream code in these^^ use cases:
    * which use the lsp helper methods
    * where are not error handling
3. if I manually force throw at these points --> I see the same UI error screens.
4. These errors only occur in certain use cases:
    * based upon the user query and/or the source data loaded in the query builder
    * may be why this error does not appear everywhere for everyone. 🤷🏼 


## Post-merge/depoy followup:
* Have issue reporters double check that it resolves their use cases, for their data.
* Only part of the ticket not reproduced:
  * since we are not loading the script editor (in the screenshot test cases), we are not using the editor model.
  * This means that this call stack cannot be triggered: https://github.com/influxdata/ui/issues/4677/#issuecomment-1146400724
  * Not sure if we have a separate bug going on? Will ping for more details. 

