### PR TITLE
chore: perform case-insensitive sort in schema browser

### DIFF
--- a/src/dataExplorer/context/fields.tsx
+++ b/src/dataExplorer/context/fields.tsx
@@ -18,7 +18,7 @@ import {QueryContext} from 'src/shared/contexts/query'
 // Utils
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {
-  IMPORT_REGEXP,
+  IMPORT_STRINGS,
   IMPORT_INFLUX_SCHEMA,
   SAMPLE_DATA_SET,
   FROM_BUCKET,
@@ -80,7 +80,7 @@ export const FieldsProvider: FC<Prop> = ({children, scope}) => {
     //   Here is the source code for handling sample data:
     //   https://github.com/influxdata/flux/blob/master/stdlib/influxdata/influxdb/sample/sample.flux
     //   That is why _source and query script for sample data is different
-    let _source = IMPORT_REGEXP
+    let _source = ''
     if (bucket.type === 'sample') {
       _source += SAMPLE_DATA_SET(bucket.id)
     } else {
@@ -99,7 +99,7 @@ export const FieldsProvider: FC<Prop> = ({children, scope}) => {
     `
 
     if (bucket.type !== 'sample' && isFlagEnabled('newQueryBuilder')) {
-      _source = `${IMPORT_REGEXP}${IMPORT_INFLUX_SCHEMA}`
+      _source = `${IMPORT_STRINGS}${IMPORT_INFLUX_SCHEMA}`
       queryText = `${_source}
         schema.measurementFieldKeys(
           bucket: "${bucket.name}",
@@ -107,9 +107,11 @@ export const FieldsProvider: FC<Prop> = ({children, scope}) => {
           start: ${CACHING_REQUIRED_START_DATE},
           stop: ${CACHING_REQUIRED_END_DATE},
         )
-          ${searchTerm ? SEARCH_STRING(searchTerm) : ''}
-          |> sort()
-          |> limit(n: ${limit})
+        ${searchTerm ? SEARCH_STRING(searchTerm) : ''}
+        |> map(fn: (r) => ({r with lowercase: strings.toLower(v: r._value)}))
+        |> sort(columns: ["lowercase"])
+        |> drop(columns: ["lowercase"])
+        |> limit(n: ${limit})
       `
     }
 

--- a/src/dataExplorer/context/fields.tsx
+++ b/src/dataExplorer/context/fields.tsx
@@ -111,7 +111,6 @@ export const FieldsProvider: FC<Prop> = ({children, scope}) => {
         ${searchTerm ? SEARCH_STRING(searchTerm) : ''}
         |> map(fn: (r) => ({r with lowercase: strings.toLower(v: r._value)}))
         |> sort(columns: ["lowercase"])
-        |> drop(columns: ["lowercase"])
         |> limit(n: ${limit})
       `
     }

--- a/src/dataExplorer/context/fields.tsx
+++ b/src/dataExplorer/context/fields.tsx
@@ -18,6 +18,7 @@ import {QueryContext} from 'src/shared/contexts/query'
 // Utils
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {
+  IMPORT_REGEXP,
   IMPORT_STRINGS,
   IMPORT_INFLUX_SCHEMA,
   SAMPLE_DATA_SET,
@@ -80,7 +81,7 @@ export const FieldsProvider: FC<Prop> = ({children, scope}) => {
     //   Here is the source code for handling sample data:
     //   https://github.com/influxdata/flux/blob/master/stdlib/influxdata/influxdb/sample/sample.flux
     //   That is why _source and query script for sample data is different
-    let _source = ''
+    let _source = IMPORT_REGEXP
     if (bucket.type === 'sample') {
       _source += SAMPLE_DATA_SET(bucket.id)
     } else {
@@ -99,7 +100,7 @@ export const FieldsProvider: FC<Prop> = ({children, scope}) => {
     `
 
     if (bucket.type !== 'sample' && isFlagEnabled('newQueryBuilder')) {
-      _source = `${IMPORT_STRINGS}${IMPORT_INFLUX_SCHEMA}`
+      _source = `${IMPORT_REGEXP}${IMPORT_INFLUX_SCHEMA}${IMPORT_STRINGS}`
       queryText = `${_source}
         schema.measurementFieldKeys(
           bucket: "${bucket.name}",

--- a/src/dataExplorer/context/measurements.tsx
+++ b/src/dataExplorer/context/measurements.tsx
@@ -86,7 +86,7 @@ export const MeasurementsProvider: FC<Prop> = ({children, scope}) => {
     `
 
     if (bucket.type !== 'sample' && isFlagEnabled('newQueryBuilder')) {
-      _source = `${IMPORT_INFLUX_SCHEMA}${IMPORT_STRINGS}`
+      _source = `${IMPORT_STRINGS}${IMPORT_INFLUX_SCHEMA}`
       queryText = `${_source}
         schema.measurements(
           bucket: "${bucket.name}",

--- a/src/dataExplorer/context/measurements.tsx
+++ b/src/dataExplorer/context/measurements.tsx
@@ -86,7 +86,7 @@ export const MeasurementsProvider: FC<Prop> = ({children, scope}) => {
     `
 
     if (bucket.type !== 'sample' && isFlagEnabled('newQueryBuilder')) {
-      _source = `${IMPORT_STRINGS}${IMPORT_INFLUX_SCHEMA}`
+      _source = `${IMPORT_INFLUX_SCHEMA}${IMPORT_STRINGS}`
       queryText = `${_source}
         schema.measurements(
           bucket: "${bucket.name}",

--- a/src/dataExplorer/context/measurements.tsx
+++ b/src/dataExplorer/context/measurements.tsx
@@ -95,7 +95,6 @@ export const MeasurementsProvider: FC<Prop> = ({children, scope}) => {
         )
         |> map(fn: (r) => ({r with lowercase: strings.toLower(v: r._value)}))
         |> sort(columns: ["lowercase"])
-        |> drop(columns: ["lowercase"])
         |> limit(n: ${limit})
       `
     }

--- a/src/dataExplorer/context/tags.tsx
+++ b/src/dataExplorer/context/tags.tsx
@@ -124,7 +124,6 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
         ${searchTerm ? SEARCH_STRING(searchTerm) : ''}
         |> map(fn: (r) => ({r with lowercase: strings.toLower(v: r._value)}))
         |> sort(columns: ["lowercase"])
-        |> drop(columns: ["lowercase"])
         |> limit(n: ${limit})
       `
     }
@@ -204,7 +203,6 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
         )
         |> map(fn: (r) => ({r with lowercase: strings.toLower(v: r._value)}))
         |> sort(columns: ["lowercase"])
-        |> drop(columns: ["lowercase"])
         |> limit(n: ${limit})
       `
     }

--- a/src/dataExplorer/context/tags.tsx
+++ b/src/dataExplorer/context/tags.tsx
@@ -18,6 +18,7 @@ import {QueryContext} from 'src/shared/contexts/query'
 // Utils
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {
+  IMPORT_REGEXP,
   IMPORT_STRINGS,
   IMPORT_INFLUX_SCHEMA,
   SAMPLE_DATA_SET,
@@ -89,7 +90,7 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
 
     // Simplified version of query from this file:
     //   src/flows/pipes/QueryBuilder/context.tsx
-    let _source = ''
+    let _source = IMPORT_REGEXP
     if (bucket.type === 'sample') {
       _source += SAMPLE_DATA_SET(bucket.id)
     } else {
@@ -110,7 +111,7 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
     `
 
     if (bucket.type !== 'sample' && isFlagEnabled('newQueryBuilder')) {
-      _source = `${IMPORT_STRINGS}${IMPORT_INFLUX_SCHEMA}`
+      _source = `${IMPORT_INFLUX_SCHEMA}${IMPORT_REGEXP}${IMPORT_STRINGS}`
       queryText = `${_source}
         schema.measurementTagKeys(
           bucket: "${bucket.name}",
@@ -192,7 +193,7 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
     `
 
     if (bucket.type !== 'sample' && isFlagEnabled('newQueryBuilder')) {
-      _source = `${IMPORT_STRINGS}${IMPORT_INFLUX_SCHEMA}`
+      _source = `${IMPORT_INFLUX_SCHEMA}${IMPORT_STRINGS}`
       queryText = `${_source}
         schema.measurementTagValues(
           bucket: "${bucket.name}",

--- a/src/dataExplorer/context/tags.tsx
+++ b/src/dataExplorer/context/tags.tsx
@@ -111,7 +111,7 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
     `
 
     if (bucket.type !== 'sample' && isFlagEnabled('newQueryBuilder')) {
-      _source = `${IMPORT_INFLUX_SCHEMA}${IMPORT_REGEXP}${IMPORT_STRINGS}`
+      _source = `${IMPORT_REGEXP}${IMPORT_INFLUX_SCHEMA}${IMPORT_STRINGS}`
       queryText = `${_source}
         schema.measurementTagKeys(
           bucket: "${bucket.name}",
@@ -193,7 +193,7 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
     `
 
     if (bucket.type !== 'sample' && isFlagEnabled('newQueryBuilder')) {
-      _source = `${IMPORT_INFLUX_SCHEMA}${IMPORT_STRINGS}`
+      _source = `${IMPORT_STRINGS}${IMPORT_INFLUX_SCHEMA}`
       queryText = `${_source}
         schema.measurementTagValues(
           bucket: "${bucket.name}",

--- a/src/dataExplorer/shared/utils.ts
+++ b/src/dataExplorer/shared/utils.ts
@@ -1,6 +1,7 @@
 export const LOCAL_LIMIT = 8
 export const IMPORT_REGEXP = 'import "regexp"\n'
-export const IMPORT_INFLUX_SCHEMA = 'import "influxdata/influxdb/schema"'
+export const IMPORT_STRINGS = 'import "strings"\n'
+export const IMPORT_INFLUX_SCHEMA = 'import "influxdata/influxdb/schema"\n'
 
 // Sample data always has bucket id. Here is the code for sample bucket list
 //  Src/shared/contexts/buckets.tsx


### PR DESCRIPTION
This PR adds case-insensitive sort in schema browser query to get the values of measurements, fields, tag keys, and tag values. 

This is a suggestion from @jsternberg (on [slack](https://influxdata.slack.com/archives/C030G5783M3/p1653681553393739))
