### PR TITLE
chore: update "Load More" to show 25 additional items each time

### DIFF
--- a/src/dataExplorer/components/FieldSelector.tsx
+++ b/src/dataExplorer/components/FieldSelector.tsx
@@ -15,7 +15,10 @@ import {RemoteDataState} from 'src/types'
 import './Schema.scss'
 
 // Utils
-import {LOAD_MORE_LIMIT_INITIAL} from 'src/dataExplorer/shared/utils'
+import {
+  LOAD_MORE_LIMIT_INITIAL,
+  LOAD_MORE_LIMIT,
+} from 'src/dataExplorer/shared/utils'
 
 const FIELD_TOOLTIP = `Fields and Field Values are non-indexed \
 key values pairs within a measurement. For SQL users, this is \
@@ -52,7 +55,7 @@ const FieldSelector: FC = () => {
   }
 
   const handleLoadMore = () => {
-    const newIndex = fieldsToShow.length + LOAD_MORE_LIMIT_INITIAL
+    const newIndex = fieldsToShow.length + LOAD_MORE_LIMIT
     setFieldsToShow(fields.slice(0, newIndex))
   }
 

--- a/src/dataExplorer/components/FieldSelector.tsx
+++ b/src/dataExplorer/components/FieldSelector.tsx
@@ -15,7 +15,7 @@ import {RemoteDataState} from 'src/types'
 import './Schema.scss'
 
 // Utils
-import {LOCAL_LIMIT} from 'src/dataExplorer/shared/utils'
+import {LOAD_MORE_LIMIT_INITIAL} from 'src/dataExplorer/shared/utils'
 
 const FIELD_TOOLTIP = `Fields and Field Values are non-indexed \
 key values pairs within a measurement. For SQL users, this is \
@@ -27,7 +27,7 @@ const FieldSelector: FC = () => {
 
   useEffect(() => {
     // Reset
-    setFieldsToShow(fields.slice(0, LOCAL_LIMIT))
+    setFieldsToShow(fields.slice(0, LOAD_MORE_LIMIT_INITIAL))
   }, [fields])
 
   let list: JSX.Element | JSX.Element[] = (
@@ -52,7 +52,7 @@ const FieldSelector: FC = () => {
   }
 
   const handleLoadMore = () => {
-    const newIndex = fieldsToShow.length + LOCAL_LIMIT
+    const newIndex = fieldsToShow.length + LOAD_MORE_LIMIT_INITIAL
     setFieldsToShow(fields.slice(0, newIndex))
   }
 

--- a/src/dataExplorer/components/TagSelector.tsx
+++ b/src/dataExplorer/components/TagSelector.tsx
@@ -13,7 +13,7 @@ import {TagsContext} from 'src/dataExplorer/context/tags'
 import {RemoteDataState} from 'src/types'
 
 // Utils
-import {LOCAL_LIMIT} from 'src/dataExplorer/shared/utils'
+import {LOAD_MORE_LIMIT_INITIAL} from 'src/dataExplorer/shared/utils'
 
 const TAG_KEYS_TOOLTIP = `Tags and Tag Values are indexed key values \
 pairs within a measurement. For SQL users, this is conceptually \
@@ -34,7 +34,7 @@ const TagValues: FC<Prop> = ({loading, tagKey, tagValues}) => {
 
   useEffect(() => {
     // Reset
-    setValuesToShow(tagValues.slice(0, LOCAL_LIMIT))
+    setValuesToShow(tagValues.slice(0, LOAD_MORE_LIMIT_INITIAL))
   }, [tagValues])
 
   const handleSelectTagValue = (value: string) => {
@@ -83,7 +83,7 @@ const TagValues: FC<Prop> = ({loading, tagKey, tagValues}) => {
   }
 
   const handleLoadMore = () => {
-    const newIndex = valuesToShow.length + LOCAL_LIMIT
+    const newIndex = valuesToShow.length + LOAD_MORE_LIMIT_INITIAL
     setValuesToShow(tagValues.slice(0, newIndex))
   }
 

--- a/src/dataExplorer/components/TagSelector.tsx
+++ b/src/dataExplorer/components/TagSelector.tsx
@@ -13,7 +13,10 @@ import {TagsContext} from 'src/dataExplorer/context/tags'
 import {RemoteDataState} from 'src/types'
 
 // Utils
-import {LOAD_MORE_LIMIT_INITIAL} from 'src/dataExplorer/shared/utils'
+import {
+  LOAD_MORE_LIMIT_INITIAL,
+  LOAD_MORE_LIMIT,
+} from 'src/dataExplorer/shared/utils'
 
 const TAG_KEYS_TOOLTIP = `Tags and Tag Values are indexed key values \
 pairs within a measurement. For SQL users, this is conceptually \
@@ -83,7 +86,7 @@ const TagValues: FC<Prop> = ({loading, tagKey, tagValues}) => {
   }
 
   const handleLoadMore = () => {
-    const newIndex = valuesToShow.length + LOAD_MORE_LIMIT_INITIAL
+    const newIndex = valuesToShow.length + LOAD_MORE_LIMIT
     setValuesToShow(tagValues.slice(0, newIndex))
   }
 

--- a/src/dataExplorer/shared/utils.ts
+++ b/src/dataExplorer/shared/utils.ts
@@ -1,4 +1,4 @@
-export const LOCAL_LIMIT = 8
+export const LOAD_MORE_LIMIT_INITIAL = 8
 export const IMPORT_REGEXP = 'import "regexp"\n'
 export const IMPORT_INFLUX_SCHEMA = 'import "influxdata/influxdb/schema"'
 

--- a/src/dataExplorer/shared/utils.ts
+++ b/src/dataExplorer/shared/utils.ts
@@ -1,4 +1,5 @@
 export const LOAD_MORE_LIMIT_INITIAL = 8
+export const LOAD_MORE_LIMIT = 25
 export const IMPORT_REGEXP = 'import "regexp"\n'
 export const IMPORT_INFLUX_SCHEMA = 'import "influxdata/influxdb/schema"'
 


### PR DESCRIPTION
This PR updates the number of showing items from 8 to 25 when the "Load More" button is clicked. The initial number of showing is still the same, 8.

Here is the requirement mentioned in #4510:

> When Load More is chosen, up to 25 additional entries will be shown to the user; if more than 25 more exists in the list, the user will again have the option to load more which will result in an additional 25

## After

https://user-images.githubusercontent.com/14298407/172711855-6c38358e-6081-456b-ba60-01bcba16b2d3.mov
