### PR TITLE
fix: updated rename org setting and Host Name

### DIFF
--- a/cypress/e2e/shared/about.test.ts
+++ b/cypress/e2e/shared/about.test.ts
@@ -57,6 +57,6 @@ describe('About Page', () => {
       .contains(newOrgName)
 
     cy.getByTestID('org-profile--name').contains(newOrgName)
-    cy.getByTestID('danger-zone--org-name').should('have.value', newOrgName)
+    cy.getByTestID('code-snippet--orgName').contains(newOrgName)
   })
 })

--- a/src/organizations/components/OrgProfileTab/CopyableLabeledData.tsx
+++ b/src/organizations/components/OrgProfileTab/CopyableLabeledData.tsx
@@ -29,7 +29,7 @@ interface Props {
   label: string
   src: string
   name?: string
-  renameableOrg?: boolean
+  isRenameableOrg?: boolean
 }
 
 const CopyableLabeledData: FC<Props> = ({
@@ -37,7 +37,7 @@ const CopyableLabeledData: FC<Props> = ({
   label,
   src,
   name,
-  renameableOrg,
+  isRenameableOrg,
 }) => {
   const dispatch = useDispatch()
   const org = useSelector(getOrg)
@@ -80,7 +80,7 @@ const CopyableLabeledData: FC<Props> = ({
             testID={`copy-btn--${id}`}
             onCopy={generateCopyText}
           />
-          {renameableOrg && (
+          {isRenameableOrg && (
             <Button
               testID="rename-org--button"
               text="Rename"

--- a/src/organizations/components/OrgProfileTab/CopyableLabeledData.tsx
+++ b/src/organizations/components/OrgProfileTab/CopyableLabeledData.tsx
@@ -32,7 +32,13 @@ interface Props {
   renameableOrg?: boolean
 }
 
-const CopyableLabeledData: FC<Props> = ({id, label, src, name, renameableOrg}) => {
+const CopyableLabeledData: FC<Props> = ({
+  id,
+  label,
+  src,
+  name,
+  renameableOrg,
+}) => {
   const dispatch = useDispatch()
   const org = useSelector(getOrg)
   const history = useHistory()
@@ -74,7 +80,7 @@ const CopyableLabeledData: FC<Props> = ({id, label, src, name, renameableOrg}) =
             testID={`copy-btn--${id}`}
             onCopy={generateCopyText}
           />
-          {renameableOrg && 
+          {renameableOrg && (
             <Button
               testID="rename-org--button"
               text="Rename"
@@ -82,7 +88,7 @@ const CopyableLabeledData: FC<Props> = ({id, label, src, name, renameableOrg}) =
               onClick={handleShowEditOverlay}
               size={ComponentSize.ExtraSmall}
             />
-          }
+          )}
           {name && (
             <label
               className="code-snippet--label"

--- a/src/organizations/components/OrgProfileTab/CopyableLabeledData.tsx
+++ b/src/organizations/components/OrgProfileTab/CopyableLabeledData.tsx
@@ -1,6 +1,7 @@
 // Libraries
 import React, {FC} from 'react'
-import {useDispatch} from 'react-redux'
+import {useDispatch, useSelector} from 'react-redux'
+import {useHistory} from 'react-router-dom'
 
 // Components
 import {
@@ -10,6 +11,8 @@ import {
   HeadingElement,
   FontWeight,
   JustifyContent,
+  Button,
+  IconFont,
 } from '@influxdata/clockface'
 import CopyButton from 'src/shared/components/CopyButton'
 
@@ -19,18 +22,27 @@ import {notify} from 'src/shared/actions/notifications'
 // Utils
 import {copyToClipboardSuccess} from 'src/shared/copy/notifications'
 import 'src/organizations/components/OrgProfileTab/style.scss'
+import {getOrg} from 'src/organizations/selectors'
 
 interface Props {
   id: string
   label: string
   src: string
   name?: string
+  renameableOrg?: boolean
 }
 
-const CopyableLabeledData: FC<Props> = ({id, label, src, name}) => {
+const CopyableLabeledData: FC<Props> = ({id, label, src, name, renameableOrg}) => {
   const dispatch = useDispatch()
+  const org = useSelector(getOrg)
+  const history = useHistory()
+
   const generateCopyText = () => {
     dispatch(notify(copyToClipboardSuccess(label, src)))
+  }
+
+  const handleShowEditOverlay = () => {
+    history.push(`/orgs/${org.id}/about/rename`)
   }
 
   return (
@@ -62,6 +74,15 @@ const CopyableLabeledData: FC<Props> = ({id, label, src, name}) => {
             testID={`copy-btn--${id}`}
             onCopy={generateCopyText}
           />
+          {renameableOrg && 
+            <Button
+              testID="rename-org--button"
+              text="Rename"
+              icon={IconFont.Pencil}
+              onClick={handleShowEditOverlay}
+              size={ComponentSize.ExtraSmall}
+            />
+          }
           {name && (
             <label
               className="code-snippet--label"

--- a/src/organizations/components/OrgProfileTab/index.tsx
+++ b/src/organizations/components/OrgProfileTab/index.tsx
@@ -42,12 +42,12 @@ const OrgProfileTab: FC = () => {
       testID="org-profile--panel"
     >
       <h4>Organization Profile</h4>
-        <CopyableLabeledData
-          id='orgName'
-          label='Name'
-          src={org.name}
-          renameableOrg={true}
-        />
+      <CopyableLabeledData
+        id="orgName"
+        label="Name"
+        src={org.name}
+        renameableOrg={true}
+      />
       {expectQuartzData && hasSomeQuartzOrgData && (
         <>
           <FlexBox

--- a/src/organizations/components/OrgProfileTab/index.tsx
+++ b/src/organizations/components/OrgProfileTab/index.tsx
@@ -46,7 +46,7 @@ const OrgProfileTab: FC = () => {
         id="orgName"
         label="Name"
         src={org.name}
-        renameableOrg={true}
+        isRenameableOrg={true}
       />
       {expectQuartzData && hasSomeQuartzOrgData && (
         <>

--- a/src/organizations/components/OrgProfileTab/index.tsx
+++ b/src/organizations/components/OrgProfileTab/index.tsx
@@ -1,20 +1,13 @@
 // Libraries
 import React, {FC} from 'react'
 import {useSelector} from 'react-redux'
-import {useHistory} from 'react-router-dom'
 
 // Components
 import {
-  Button,
-  IconFont,
   FlexBox,
   AlignItems,
   FlexDirection,
   ComponentSize,
-  Input,
-  Heading,
-  HeadingElement,
-  FontWeight,
   JustifyContent,
 } from '@influxdata/clockface'
 import UsersProvider from 'src/users/context/users'
@@ -35,11 +28,6 @@ import 'src/organizations/components/OrgProfileTab/style.scss'
 const OrgProfileTab: FC = () => {
   const me = useSelector(getMe)
   const org = useSelector(getOrg)
-  const history = useHistory()
-
-  const handleShowEditOverlay = () => {
-    history.push(`/orgs/${org.id}/about/rename`)
-  }
 
   const expectQuartzData = CLOUD && isFlagEnabled('uiUnificationFlag')
 
@@ -54,28 +42,12 @@ const OrgProfileTab: FC = () => {
       testID="org-profile--panel"
     >
       <h4>Organization Profile</h4>
-      <Heading
-        className="org-profile-tab--heading"
-        element={HeadingElement.H4}
-        weight={FontWeight.Regular}
-      >
-        Name
-      </Heading>
-      <FlexBox direction={FlexDirection.Row} margin={ComponentSize.Medium}>
-        <Input
-          value={org.name}
-          onChange={() => {}}
-          style={{width: 'max-content'}}
-          data-testid="danger-zone--org-name"
-          testID="danger-zone--org-name"
-        ></Input>
-        <Button
-          testID="rename-org--button"
-          text="Rename"
-          icon={IconFont.Pencil}
-          onClick={handleShowEditOverlay}
+        <CopyableLabeledData
+          id='orgName'
+          label='Name'
+          src={org.name}
+          renameableOrg={true}
         />
-      </FlexBox>
       {expectQuartzData && hasSomeQuartzOrgData && (
         <>
           <FlexBox
@@ -98,7 +70,7 @@ const OrgProfileTab: FC = () => {
           {expectQuartzData && me.quartzMe?.clusterHost && (
             <CopyableLabeledData
               id="clusterUrl"
-              label="Cluster URL"
+              label="Cluster URL (Host Name)"
               src={me.quartzMe.clusterHost}
             />
           )}


### PR DESCRIPTION
Closes #4791 
Closes #4052 

Closes both of the issues above. Made an optional prop on `CopyableLabeledData` to toggle the rename org button being visible. Left the Copy button to say "Copy to Clipboard" for upcoming facelift. Also adds "(Host Name)" next to Cluster URL to make it clear to users.


https://user-images.githubusercontent.com/106361125/173078264-5e72d5c8-2696-4f8f-a037-df720b765254.mov






