### PR TITLE
fix: use the explicit quartz login url

### DIFF
--- a/src/Signin.tsx
+++ b/src/Signin.tsx
@@ -26,7 +26,7 @@ import {
   CLOUD,
   CLOUD_LOGIN_PATHNAME,
   CLOUD_SIGNIN_PATHNAME,
-  CLOUD_URL,
+  CLOUD_QUARTZ_URL,
 } from 'src/shared/constants'
 
 // Types
@@ -120,7 +120,7 @@ export class Signin extends PureComponent<Props, State> {
           process.env.NODE_ENV &&
           process.env.NODE_ENV !== 'development'
         ) {
-          window.location.href = CLOUD_URL
+          window.location.href = CLOUD_QUARTZ_URL
           return
         }
 

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -100,6 +100,7 @@ export const CLOUD_SIGNIN_PATHNAME = '/api/v2/signin'
 export const CLOUD_SIGNOUT_PATHNAME = '/api/v2/signout'
 export const CLOUD_LOGIN_PATHNAME = '/login'
 export const CLOUD_URL = formatConstant(process.env.CLOUD_URL)
+export const CLOUD_QUARTZ_URL = 'https://cloud2.influxdata.com/login'
 export const CLOUD_CHECKOUT_PATH = '/checkout'
 export const CLOUD_BILLING_PATH = '/billing'
 export const CLOUD_USAGE_PATH = '/usage'


### PR DESCRIPTION
Part of #4657 

Production also sets `CLOUD_URL` to something other than what we want. We will have to be explicit.
