### PR TITLE
test: type into the textarea to satisfy Firefox

### DIFF
--- a/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
+++ b/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
@@ -17,8 +17,8 @@ const addFluxQueryInNotebook = (query: string) => {
    *   - do not use .monacoType
    *   - must select the first visible line
    */
-  cy.get('.monaco-editor .view-line:first').should('be.visible')
-  cy.get('.monaco-editor .view-line:first').type(
+  cy.get('.monaco-editor .view-line:first').click()
+  cy.get('textarea.inputarea.monaco-mouse-cursor-text').type(
     `{downarrow}{downarrow}${query}`
   )
 }


### PR DESCRIPTION
Closes #4811 

- select the first line to activate the `textarea` or else it is considered disabled
- type into the `textarea` activated by the previous action
