### PR TITLE
fix: clear search term when change bucket or measurement

### DIFF
--- a/src/dataExplorer/components/Schema.tsx
+++ b/src/dataExplorer/components/Schema.tsx
@@ -1,4 +1,4 @@
-import React, {FC, useContext, useMemo} from 'react'
+import React, {FC, useContext, useEffect, useMemo} from 'react'
 import {useSelector} from 'react-redux'
 
 // Components
@@ -36,6 +36,10 @@ const FieldsTags: FC = () => {
     setSearchTerm,
   } = useContext(FluxQueryBuilderContext)
 
+  useEffect(() => {
+    setSearchTerm('')
+  }, [selectedBucket, selectedMeasurement])
+
   const handleSearchFieldsTags = (searchTerm: string): void => {
     setSearchTerm(searchTerm)
   }
@@ -57,7 +61,7 @@ const FieldsTags: FC = () => {
         <TagSelector />
       </div>
     )
-  }, [selectedBucket, selectedMeasurement])
+  }, [selectedBucket, selectedMeasurement, searchTerm])
 }
 
 const Schema: FC = () => {


### PR DESCRIPTION
Related #4804 

This PR fixes a bug in search bar for fields and tag keys. The search term wasn't cleared out when a bucket or a measurement got changed.

## Before

https://user-images.githubusercontent.com/14298407/173865031-0d6dd279-3bfc-4e8f-82d8-fff77e38a6a1.mov

## After

https://user-images.githubusercontent.com/14298407/173865050-3eddafc4-6e46-4531-9805-cd50164a842c.mov


