### PR TITLE
chore: remove variables that never used

### DIFF
--- a/src/dataExplorer/context/fluxQueryBuilder.tsx
+++ b/src/dataExplorer/context/fluxQueryBuilder.tsx
@@ -34,10 +34,6 @@ interface FluxQueryBuilderContextType {
   selectBucket: (bucket: Bucket) => void
   selectMeasurement: (measurement: string) => void
   setSearchTerm: (str: string) => void
-
-  // Query building
-  query: string
-  updateQuery: (q: string) => void
 }
 
 const DEFAULT_CONTEXT: FluxQueryBuilderContextType = {
@@ -48,10 +44,6 @@ const DEFAULT_CONTEXT: FluxQueryBuilderContextType = {
   selectBucket: (_b: Bucket) => {},
   selectMeasurement: (_m: string) => {},
   setSearchTerm: (_s: string) => {},
-
-  // Query building
-  query: '',
-  updateQuery: _q => {},
 }
 
 export const FluxQueryBuilderContext = createContext<
@@ -67,7 +59,6 @@ export const FluxQueryBuilderProvider: FC = ({children}) => {
   // States
   const [selectedBucket, setSelectedBucket] = useState(null)
   const [selectedMeasurement, setSelectedMeasurement] = useState('')
-  const [query, setQuery] = useState('')
   const [searchTerm, setSearchTerm] = useState('')
 
   const handleSelectBucket = (bucket: Bucket): void => {
@@ -116,10 +107,6 @@ export const FluxQueryBuilderProvider: FC = ({children}) => {
           selectBucket: handleSelectBucket,
           selectMeasurement: handleSelectMeasurement,
           setSearchTerm: handleSearchTerm,
-
-          // Query building
-          query,
-          updateQuery: setQuery,
         }}
       >
         {children}
@@ -131,8 +118,6 @@ export const FluxQueryBuilderProvider: FC = ({children}) => {
       selectedMeasurement,
       searchTerm,
 
-      // Query building
-      query,
       children,
     ]
   )


### PR DESCRIPTION
This PR removes the variables that never used in `FluxQueryBuilderContext` to prepare for the schema injection code
