### PR TITLE
feat: add sample app to node.js finish page

### DIFF
--- a/src/homepageExperience/components/steps/Finish.tsx
+++ b/src/homepageExperience/components/steps/Finish.tsx
@@ -79,7 +79,9 @@ export const Finish = (props: OwnProps) => {
     }
   }, [])
 
-  const showSampleApp = props.wizardEventName === 'pythonWizard'
+  const showSampleApp = props.wizardEventName === 'pythonWizard' || props.wizardEventName === 'nodejsWizard'
+  const sampleAppLink = props.wizardEventName === 'pythonWizard' ? "https://github.com/InfluxCommunity/sample-flask/blob/main/app.py" : "https://github.com/influxdata/nodejs-samples"
+
   return (
     <>
       <h1>Congrats!</h1>
@@ -100,13 +102,19 @@ export const Finish = (props: OwnProps) => {
               handleNextStepEvent(props.wizardEventName, 'sampleApp')
             }
           >
-            <SafeBlankLink href="https://github.com/InfluxCommunity/sample-flask/blob/main/app.py">
+            <SafeBlankLink href={sampleAppLink}>
               <h4>{CodeTerminalIcon}Sample App</h4>
             </SafeBlankLink>
+            {props.wizardEventName === 'pythonWizard' ? 
             <p>
               Play around with our template code of sample app to streamline
               your own data into InfluxData.
             </p>
+            : 
+            <p>
+              Write and query your own data by viewing boilerplate app files and sample code.
+            </p>
+            }
           </ResourceCard>
         )}
         <ResourceCard

--- a/src/homepageExperience/components/steps/Finish.tsx
+++ b/src/homepageExperience/components/steps/Finish.tsx
@@ -79,8 +79,13 @@ export const Finish = (props: OwnProps) => {
     }
   }, [])
 
-  const showSampleApp = props.wizardEventName === 'pythonWizard' || props.wizardEventName === 'nodejsWizard'
-  const sampleAppLink = props.wizardEventName === 'pythonWizard' ? "https://github.com/InfluxCommunity/sample-flask/blob/main/app.py" : "https://github.com/influxdata/nodejs-samples"
+  const showSampleApp =
+    props.wizardEventName === 'pythonWizard' ||
+    props.wizardEventName === 'nodejsWizard'
+  const sampleAppLink =
+    props.wizardEventName === 'pythonWizard'
+      ? 'https://github.com/InfluxCommunity/sample-flask/blob/main/app.py'
+      : 'https://github.com/influxdata/nodejs-samples'
 
   return (
     <>
@@ -105,16 +110,17 @@ export const Finish = (props: OwnProps) => {
             <SafeBlankLink href={sampleAppLink}>
               <h4>{CodeTerminalIcon}Sample App</h4>
             </SafeBlankLink>
-            {props.wizardEventName === 'pythonWizard' ? 
-            <p>
-              Play around with our template code of sample app to streamline
-              your own data into InfluxData.
-            </p>
-            : 
-            <p>
-              Write and query your own data by viewing boilerplate app files and sample code.
-            </p>
-            }
+            {props.wizardEventName === 'pythonWizard' ? (
+              <p>
+                Play around with our template code of sample app to streamline
+                your own data into InfluxData.
+              </p>
+            ) : (
+              <p>
+                Write and query your own data by viewing boilerplate app files
+                and sample code.
+              </p>
+            )}
           </ResourceCard>
         )}
         <ResourceCard

--- a/src/homepageExperience/components/steps/Finish.tsx
+++ b/src/homepageExperience/components/steps/Finish.tsx
@@ -3,6 +3,7 @@ import {
   AlignItems,
   ComponentSize,
   FlexBox,
+  FlexDirection,
   ResourceCard,
 } from '@influxdata/clockface'
 
@@ -85,7 +86,8 @@ export const Finish = (props: OwnProps) => {
   const sampleAppLink =
     props.wizardEventName === 'pythonWizard'
       ? 'https://github.com/InfluxCommunity/sample-flask/blob/main/app.py'
-      : 'https://github.com/influxdata/nodejs-samples'
+      : 'https://github.com/influxdata/iot-api-js'
+  const showBoilerplate = props.wizardEventName === 'nodejsWizard'
 
   return (
     <>
@@ -99,55 +101,87 @@ export const Finish = (props: OwnProps) => {
       <p style={{marginTop: '80px'}}>
         Curious to learn more? Try these next steps!
       </p>
-      <FlexBox margin={ComponentSize.Medium} alignItems={AlignItems.Stretch}>
-        {showSampleApp && (
+      <FlexBox
+        margin={ComponentSize.Large}
+        direction={FlexDirection.Column}
+        alignItems={AlignItems.FlexStart}
+      >
+        <FlexBox
+          margin={ComponentSize.Large}
+          alignItems={AlignItems.Stretch}
+          direction={FlexDirection.Row}
+        >
           <ResourceCard
             className="homepage-wizard-next-steps"
             onClick={() =>
-              handleNextStepEvent(props.wizardEventName, 'sampleApp')
+              handleNextStepEvent(props.wizardEventName, 'keyConcepts')
             }
           >
-            <SafeBlankLink href={sampleAppLink}>
-              <h4>{CodeTerminalIcon}Sample App</h4>
+            <SafeBlankLink href="https://docs.influxdata.com/influxdb/v2.2/reference/key-concepts/">
+              <h4>{BookIcon}Key Concepts</h4>
             </SafeBlankLink>
-            {props.wizardEventName === 'pythonWizard' ? (
-              <p>
-                Play around with our template code of sample app to streamline
-                your own data into InfluxData.
-              </p>
-            ) : (
-              <p>
-                Write and query your own data by viewing boilerplate app files
-                and sample code.
-              </p>
-            )}
+            <p>Learn about important concepts for writing time-series data.</p>
           </ResourceCard>
-        )}
-        <ResourceCard
-          className="homepage-wizard-next-steps"
-          onClick={() =>
-            handleNextStepEvent(props.wizardEventName, 'keyConcepts')
-          }
+          <ResourceCard
+            className="homepage-wizard-next-steps"
+            onClick={() =>
+              handleNextStepEvent(props.wizardEventName, 'influxUniversity')
+            }
+          >
+            <SafeBlankLink href="https://influxdbu.com/">
+              <h4>{CodeTerminalIcon}InfluxDB University</h4>
+            </SafeBlankLink>
+            <p>
+              Our free hands-on courses teach you the technical skills and best
+              practices to get the most out of your real-time data with
+              InfluxDB.
+            </p>
+          </ResourceCard>
+        </FlexBox>
+        <FlexBox
+          margin={ComponentSize.Large}
+          alignItems={AlignItems.Stretch}
+          direction={FlexDirection.Row}
         >
-          <SafeBlankLink href="https://docs.influxdata.com/influxdb/v2.2/reference/key-concepts/">
-            <h4>{BookIcon}Key Concepts</h4>
-          </SafeBlankLink>
-          <p>Learn about important concepts for writing time-series data.</p>
-        </ResourceCard>
-        <ResourceCard
-          className="homepage-wizard-next-steps"
-          onClick={() =>
-            handleNextStepEvent(props.wizardEventName, 'influxUniversity')
-          }
-        >
-          <SafeBlankLink href="https://influxdbu.com/">
-            <h4>{CodeTerminalIcon}InfluxDB University</h4>
-          </SafeBlankLink>
-          <p>
-            Our free hands-on courses teach you the technical skills and best
-            practices to get the most out of your real-time data with InfluxDB.
-          </p>
-        </ResourceCard>
+          {showSampleApp && (
+            <ResourceCard
+              className="homepage-wizard-next-steps"
+              onClick={() =>
+                handleNextStepEvent(props.wizardEventName, 'sampleApp')
+              }
+            >
+              <SafeBlankLink href={sampleAppLink}>
+                <h4>{CodeTerminalIcon}Sample App</h4>
+              </SafeBlankLink>
+              {props.wizardEventName === 'pythonWizard' ? (
+                <p>
+                  Play around with our template code of sample app to streamline
+                  your own data into InfluxData.
+                </p>
+              ) : (
+                // nodejs sample app
+                <p>View an IoT sample application written in Node.js.</p>
+              )}
+            </ResourceCard>
+          )}
+          {showBoilerplate && (
+            <ResourceCard
+              className="homepage-wizard-next-steps"
+              onClick={() =>
+                handleNextStepEvent(props.wizardEventName, 'Boilerplate')
+              }
+            >
+              <SafeBlankLink href="https://github.com/influxdata/nodejs-samples/">
+                <h4>{CodeTerminalIcon}Boilerplate Snippets</h4>
+              </SafeBlankLink>
+
+              <p>
+                Get started writing and querying your own data using our code
+                snippets.
+              </p>
+            </ResourceCard>
+          )}
+        </FlexBox>
       </FlexBox>
     </>
   )


### PR DESCRIPTION
Closes #4571 
Closes #4570

PR adds a sample app section to the node.js "finish" page to navigate users to a repo where users can view boilerplate code and a README.

https://user-images.githubusercontent.com/66275100/174398523-b7f9f8b6-f2ed-46c7-86ad-1718ce3e8452.mov


