### PR TITLE
chore: update radial-power-level.svg with the correct one

### DIFF
--- a/assets/images/radial-power-level.svg
+++ b/assets/images/radial-power-level.svg
@@ -1,1311 +1,799 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 24.1.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 820 620" style="enable-background:new 0 0 820 620;" xml:space="preserve">
-<style type="text/css">
-	.st0{opacity:0.74;fill:url(#SVGID_1_);enable-background:new    ;}
-	.st1{fill:url(#SVGID_2_);}
-	.st2{fill:url(#SVGID_3_);}
-	.st3{fill:url(#SVGID_4_);}
-	.st4{opacity:0.65;}
-	.st5{opacity:0.2;}
-	.st6{opacity:0.63;fill:#020A47;enable-background:new    ;}
-	.st7{fill:url(#SVGID_5_);}
-	.st8{fill:url(#SVGID_6_);}
-	.st9{opacity:0.6;}
-	.st10{fill:url(#SVGID_7_);}
-	.st11{fill:url(#SVGID_8_);}
-	.st12{fill:url(#SVGID_9_);}
-	.st13{fill:url(#SVGID_10_);}
-	.st14{fill:url(#SVGID_11_);}
-	.st15{fill:url(#SVGID_12_);}
-	.st16{fill:url(#SVGID_13_);}
-	.st17{fill:url(#SVGID_14_);}
-	.st18{fill:url(#SVGID_15_);}
-	.st19{fill:url(#SVGID_16_);}
-	.st20{fill:url(#SVGID_17_);}
-	.st21{opacity:0.44;fill:url(#SVGID_18_);enable-background:new    ;}
-	.st22{opacity:0.5;fill:url(#SVGID_19_);enable-background:new    ;}
-	.st23{fill:url(#SVGID_20_);}
-	.st24{fill:#020A47;}
-	.st25{fill:url(#SVGID_21_);}
-	.st26{fill:url(#SVGID_22_);}
-	.st27{fill:url(#SVGID_23_);}
-	.st28{fill:url(#SVGID_24_);}
-	.st29{fill:url(#SVGID_25_);}
-	.st30{fill:url(#SVGID_26_);}
-	.st31{opacity:0.44;fill:url(#SVGID_27_);enable-background:new    ;}
-	.st32{opacity:0.5;fill:url(#SVGID_28_);enable-background:new    ;}
-	.st33{fill:url(#SVGID_29_);}
-	.st34{fill:url(#SVGID_30_);}
-	.st35{fill:url(#SVGID_31_);}
-	.st36{fill:url(#SVGID_32_);}
-	.st37{opacity:0.39;fill:url(#SVGID_33_);enable-background:new    ;}
-	.st38{fill:url(#SVGID_34_);}
-	.st39{opacity:0.44;fill:url(#SVGID_35_);enable-background:new    ;}
-	.st40{opacity:0.5;fill:url(#SVGID_36_);enable-background:new    ;}
-	.st41{opacity:0.8;fill:url(#SVGID_37_);enable-background:new    ;}
-	.st42{fill:url(#SVGID_38_);}
-	.st43{fill:url(#SVGID_39_);}
-	.st44{opacity:0.6;fill:url(#SVGID_40_);enable-background:new    ;}
-	.st45{opacity:0.72;}
-	.st46{opacity:0.6;fill:url(#SVGID_41_);enable-background:new    ;}
-	.st47{fill:url(#SVGID_42_);}
-	.st48{fill:url(#SVGID_43_);}
-	.st49{fill:url(#SVGID_44_);}
-	.st50{opacity:0.65;fill:url(#SVGID_45_);enable-background:new    ;}
-	.st51{fill:url(#SVGID_46_);}
-	.st52{fill:url(#SVGID_47_);}
-	.st53{opacity:0.44;fill:url(#SVGID_48_);enable-background:new    ;}
-	.st54{fill:url(#SVGID_49_);}
-	.st55{opacity:0.49;fill:url(#SVGID_50_);enable-background:new    ;}
-	.st56{opacity:0.33;fill:url(#SVGID_51_);enable-background:new    ;}
-	.st57{fill:url(#SVGID_52_);}
-	.st58{opacity:0.5;fill:url(#SVGID_53_);enable-background:new    ;}
-	.st59{opacity:0.5;}
-	.st60{opacity:0.48;fill:url(#SVGID_54_);enable-background:new    ;}
-	.st61{opacity:0.73;fill:url(#SVGID_55_);enable-background:new    ;}
-	.st62{fill:url(#SVGID_56_);}
-	.st63{fill:url(#SVGID_57_);}
-	.st64{fill:url(#SVGID_58_);}
-	.st65{opacity:0.6;fill:url(#SVGID_59_);enable-background:new    ;}
-	.st66{opacity:0.6;fill:url(#SVGID_60_);enable-background:new    ;}
-	.st67{opacity:0.6;fill:url(#SVGID_61_);enable-background:new    ;}
-	.st68{opacity:0.6;fill:url(#SVGID_62_);enable-background:new    ;}
-	.st69{opacity:0.6;fill:url(#SVGID_63_);enable-background:new    ;}
-	.st70{opacity:0.77;fill:url(#SVGID_64_);}
-	.st71{opacity:0.69;fill:url(#SVGID_65_);enable-background:new    ;}
-	.st72{opacity:0.76;fill:url(#SVGID_66_);enable-background:new    ;}
-	.st73{opacity:0.76;fill:url(#SVGID_67_);enable-background:new    ;}
-	.st74{fill:#5EE4E4;}
-	.st75{opacity:0.36;}
-	.st76{fill:url(#SVGID_68_);}
-	.st77{fill:url(#SVGID_69_);}
-	.st78{fill:url(#SVGID_70_);}
-	.st79{fill:url(#SVGID_71_);}
-	.st80{opacity:0.6;fill:url(#SVGID_72_);enable-background:new    ;}
-	.st81{opacity:0.6;fill:url(#SVGID_73_);enable-background:new    ;}
-	.st82{opacity:0.6;fill:url(#SVGID_74_);enable-background:new    ;}
-	.st83{opacity:0.22;}
-	.st84{opacity:0.6;fill:url(#SVGID_75_);enable-background:new    ;}
-	.st85{opacity:0.6;fill:url(#SVGID_76_);enable-background:new    ;}
-	.st86{opacity:0.6;fill:url(#SVGID_77_);enable-background:new    ;}
-	.st87{opacity:0.6;fill:url(#SVGID_78_);enable-background:new    ;}
-	.st88{opacity:0.4;fill:url(#SVGID_79_);enable-background:new    ;}
-	.st89{fill:url(#SVGID_80_);}
-	.st90{opacity:0.6;fill:url(#SVGID_81_);enable-background:new    ;}
-	.st91{opacity:0.6;fill:url(#SVGID_82_);enable-background:new    ;}
-	.st92{opacity:0.6;fill:url(#SVGID_83_);enable-background:new    ;}
-	.st93{opacity:0.6;fill:url(#SVGID_84_);enable-background:new    ;}
-	.st94{opacity:0.6;fill:url(#SVGID_85_);enable-background:new    ;}
-	.st95{opacity:0.6;fill:url(#SVGID_86_);enable-background:new    ;}
-	.st96{opacity:0.6;fill:url(#SVGID_87_);enable-background:new    ;}
-	.st97{opacity:0.6;fill:url(#SVGID_88_);enable-background:new    ;}
-	.st98{opacity:0.6;fill:url(#SVGID_89_);enable-background:new    ;}
-	.st99{fill:url(#SVGID_90_);}
-	.st100{fill:url(#SVGID_91_);}
-	.st101{fill:url(#SVGID_92_);}
-	.st102{opacity:0.4;}
-	.st103{opacity:0.6;fill:url(#SVGID_93_);enable-background:new    ;}
-	.st104{opacity:0.6;fill:url(#SVGID_94_);enable-background:new    ;}
-	.st105{opacity:0.6;fill:url(#SVGID_95_);enable-background:new    ;}
-	.st106{fill:url(#SVGID_96_);}
-	.st107{opacity:0.39;fill:url(#SVGID_97_);enable-background:new    ;}
-	.st108{fill:url(#SVGID_98_);}
-	.st109{opacity:0.5;fill:url(#SVGID_99_);enable-background:new    ;}
-	.st110{fill:url(#SVGID_100_);}
-	.st111{fill:url(#SVGID_101_);}
-	.st112{fill:url(#SVGID_102_);}
-	.st113{fill:url(#SVGID_103_);}
-	.st114{fill:url(#SVGID_104_);}
-	.st115{fill:url(#SVGID_105_);}
-	.st116{fill:url(#SVGID_106_);}
-	.st117{fill:url(#SVGID_107_);}
-	.st118{opacity:0.39;fill:url(#SVGID_108_);enable-background:new    ;}
-	.st119{fill:url(#SVGID_109_);}
-	.st120{fill:url(#SVGID_110_);}
-	.st121{opacity:0.2;fill:url(#SVGID_111_);enable-background:new    ;}
-	.st122{fill:url(#SVGID_112_);}
-	.st123{fill:url(#SVGID_113_);}
-	.st124{opacity:0.77;fill:url(#SVGID_114_);}
-	.st125{opacity:0.69;fill:url(#SVGID_115_);enable-background:new    ;}
-	.st126{fill:none;stroke:#231F20;stroke-miterlimit:10;}
-	.st127{fill:url(#SVGID_116_);}
-	.st128{fill:url(#SVGID_117_);}
-	.st129{opacity:0.71;}
-	.st130{opacity:0.77;fill:url(#SVGID_118_);}
-	.st131{opacity:0.69;fill:url(#SVGID_119_);enable-background:new    ;}
-</style>
-<g id="back">
+<svg width="820" height="478" viewBox="0 0 820 478" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path opacity="0.74" d="M397.6 218.3C385.6 211.4 385.6 200.2 397.5 193.3C409.4 186.4 428.7 186.4 440.7 193.3C452.7 200.2 452.7 211.4 440.8 218.3C428.9 225.2 409.5 225.2 397.6 218.3ZM475.5 173C444.1 154.9 393.4 154.9 362.2 173C331 191.1 331.2 220.5 362.6 238.6C394 256.7 444.7 256.7 475.9 238.6C507.1 220.5 506.9 191.1 475.5 173Z" fill="url(#paint0_linear_606_12100)"/>
+<path d="M475.5 173C444.1 154.9 393.4 154.9 362.2 173C331 191.1 331.2 220.5 362.6 238.6C394 256.7 444.7 256.7 475.8 238.6C507.1 220.5 506.9 191.1 475.5 173Z" fill="url(#paint1_radial_606_12100)"/>
+<path d="M440.6 193.3C428.6 186.4 409.3 186.4 397.4 193.3C385.5 200.2 385.6 211.4 397.5 218.3C409.5 225.2 428.8 225.2 440.7 218.3C452.7 211.4 452.6 200.2 440.6 193.3Z" fill="url(#paint2_linear_606_12100)"/>
+<path d="M440.6 193.3C428.6 186.4 409.3 186.4 397.4 193.3C385.5 200.2 385.6 211.4 397.5 218.3C409.5 225.2 428.8 225.2 440.7 218.3C452.7 211.4 452.6 200.2 440.6 193.3Z" fill="url(#paint3_radial_606_12100)"/>
+<g opacity="0.65">
+<g opacity="0.2">
+<path opacity="0.63" d="M789 82.8V290.6L716.3 335L716.6 124.3L789 82.8Z" fill="#020A47"/>
+<path opacity="0.2" d="M644.9 83.1L644.8 291.7L716.8 335V124.3L644.9 83.1Z" fill="url(#paint4_linear_606_12100)"/>
+<path opacity="0.2" d="M646.7 78.3L709.3 41.5C713.2 39.2 718 39.2 722 41.5L786.5 78.8C789.6 80.6 789.6 85.2 786.5 87L723.2 123.3C719.3 125.5 714.6 125.5 710.7 123.3L646.8 86.5C643.6 84.7 643.6 80.2 646.7 78.3Z" fill="url(#paint5_linear_606_12100)"/>
 </g>
-<g id="Layer_6_2_">
-	
-		<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="344.0103" y1="347.0736" x2="554.4346" y2="372.6656" gradientTransform="matrix(1 0 0 -1 0 620)">
-		<stop  offset="0" style="stop-color:#5EE4E4"/>
-		<stop  offset="1" style="stop-color:#9B2AFF"/>
-	</linearGradient>
-	<path class="st0" d="M397.6,276.3c-12-6.9-12-18.1-0.1-25s31.2-6.9,43.2,0s12,18.1,0.1,25C428.9,283.2,409.5,283.2,397.6,276.3
-		L397.6,276.3z M475.5,231c-31.4-18.1-82.1-18.1-113.3,0s-31,47.5,0.4,65.6s82.1,18.1,113.3,0S506.9,249.1,475.5,231L475.5,231z"/>
-	
-		<radialGradient id="SVGID_2_" cx="417.7258" cy="477.5575" r="81.3998" gradientTransform="matrix(1 8.256974e-03 4.632554e-03 -0.561 -0.8946 528.2606)" gradientUnits="userSpaceOnUse">
-		<stop  offset="0" style="stop-color:#020A47"/>
-		<stop  offset="1" style="stop-color:#020A47;stop-opacity:0"/>
-	</radialGradient>
-	<path class="st1" d="M475.5,231c-31.4-18.1-82.1-18.1-113.3,0s-31,47.5,0.4,65.6s82.1,18.1,113.2,0
-		C507.1,278.5,506.9,249.1,475.5,231L475.5,231z"/>
-	
-		<linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="390.4567" y1="352.7224" x2="470.7226" y2="362.4845" gradientTransform="matrix(1 0 0 -1 0 620)">
-		<stop  offset="0" style="stop-color:#5EE4E4"/>
-		<stop  offset="1" style="stop-color:#9B2AFF"/>
-	</linearGradient>
-	<path class="st2" d="M440.6,251.3c-12-6.9-31.3-6.9-43.2,0c-11.9,6.9-11.8,18.1,0.1,25c12,6.9,31.3,6.9,43.2,0
-		C452.7,269.4,452.6,258.2,440.6,251.3L440.6,251.3z"/>
-	
-		<radialGradient id="SVGID_4_" cx="417.7698" cy="477.5576" r="41.3786" gradientTransform="matrix(1 8.256974e-03 4.632554e-03 -0.561 -0.8946 528.2606)" gradientUnits="userSpaceOnUse">
-		<stop  offset="0" style="stop-color:#020A47"/>
-		<stop  offset="1" style="stop-color:#020A47;stop-opacity:0"/>
-	</radialGradient>
-	<path class="st3" d="M440.6,251.3c-12-6.9-31.3-6.9-43.2,0c-11.9,6.9-11.8,18.1,0.1,25c12,6.9,31.3,6.9,43.2,0
-		C452.7,269.4,452.6,258.2,440.6,251.3L440.6,251.3z"/>
-	<g class="st4">
-		<g class="st5">
-			<polygon class="st6" points="789,140.8 789,348.6 716.3,393 716.6,182.3 			"/>
-			
-				<linearGradient id="SVGID_5_" gradientUnits="userSpaceOnUse" x1="-572.7378" y1="470.6479" x2="-563.8357" y2="272.5761" gradientTransform="matrix(1 0 0 -1 1248.2952 620)">
-				<stop  offset="0" style="stop-color:#4E547D"/>
-				<stop  offset="1" style="stop-color:#020A47"/>
-			</linearGradient>
-			<polygon class="st7" points="644.9,141.1 644.8,349.7 716.8,393 716.8,182.3 			"/>
-			
-				<linearGradient id="SVGID_6_" gradientUnits="userSpaceOnUse" x1="-603.9078" y1="479.6375" x2="-459.4702" y2="479.6375" gradientTransform="matrix(1 0 0 -1 1248.2952 620)">
-				<stop  offset="0" style="stop-color:#111952"/>
-				<stop  offset="1" style="stop-color:#020A47"/>
-			</linearGradient>
-			<path class="st8" d="M646.7,136.3l62.6-36.8c3.9-2.3,8.7-2.3,12.7,0l64.5,37.3c3.1,1.8,3.1,6.4,0,8.2l-63.3,36.3
-				c-3.9,2.2-8.6,2.2-12.5,0l-63.9-36.8C643.6,142.7,643.6,138.2,646.7,136.3z"/>
-		</g>
-		<g>
-			<g class="st9">
-				
-					<linearGradient id="SVGID_7_" gradientUnits="userSpaceOnUse" x1="-594.4312" y1="471.1667" x2="-570.4901" y2="429.6995" gradientTransform="matrix(1 0 0 -1 1227.1415 620)">
-					<stop  offset="0" style="stop-color:#4E547D"/>
-					<stop  offset="0.3005" style="stop-color:#494E79;stop-opacity:0.7295"/>
-					<stop  offset="0.7471" style="stop-color:#373B6B;stop-opacity:0.3276"/>
-					<stop  offset="1" style="stop-color:#2A2F62;stop-opacity:0.1"/>
-				</linearGradient>
-				<path class="st10" d="M645.2,142.5c0-0.3-0.2-0.5-0.5-0.5s-0.5,0.2-0.5,0.5v54.2c0,0.3,0.2,0.5,0.5,0.5s0.5-0.2,0.5-0.5"/>
-			</g>
-			<g class="st9">
-				
-					<linearGradient id="SVGID_8_" gradientUnits="userSpaceOnUse" x1="2452.4631" y1="513.2817" x2="2491.937" y2="444.9114" gradientTransform="matrix(-1 0 0 -1 3189.4924 620)">
-					<stop  offset="0" style="stop-color:#2A2F62;stop-opacity:0.1"/>
-					<stop  offset="0.3328" style="stop-color:#333768;stop-opacity:0.3995"/>
-					<stop  offset="0.8939" style="stop-color:#494E79;stop-opacity:0.9045"/>
-					<stop  offset="1" style="stop-color:#4E547D"/>
-				</linearGradient>
-				<path class="st11" d="M710.2,182.2L647,145.9c-1.6-0.9-2.6-2.6-2.6-4.5s1-3.6,2.6-4.5l64.5-37.3c4.1-2.4,9.1-2.3,13.2,0
-					l62.6,36.8c1.6,1,2.6,2.6,2.6,4.5s-1,3.6-2.6,4.5l-63.9,36.8c-2,1.2-4.3,1.7-6.5,1.7C714.5,183.9,712.3,183.3,710.2,182.2z
-					 M724.1,100.4c-3.7-2.2-8.4-2.2-12.2,0l-64.5,37.3c-1.3,0.8-2.1,2.1-2.1,3.7c0,1.5,0.8,2.9,2.1,3.7l63.3,36.3
-					c3.7,2.1,8.3,2.1,12,0l63.9-36.8c1.3-0.8,2.1-2.1,2.1-3.6s-0.8-2.9-2.1-3.7L724.1,100.4z"/>
-			</g>
-		</g>
-	</g>
-	<g>
-		
-			<linearGradient id="SVGID_9_" gradientUnits="userSpaceOnUse" x1="442.8891" y1="377.5055" x2="538.0804" y2="377.5055" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#9B2AFF;stop-opacity:0"/>
-			<stop  offset="0.5829" style="stop-color:#5EE4E4;stop-opacity:0.5829"/>
-			<stop  offset="1" style="stop-color:#5EE4E4"/>
-		</linearGradient>
-		<path class="st12" d="M529.3,289.2c-0.3,0-0.6-0.1-0.8-0.2c-0.7-0.4-0.9-1.4-0.5-2.1c6.5-10.2,8.6-21.3,6-32.1
-			c-3.5-14.4-14.9-27.5-32.8-37.9c-15.7-9.1-35.4-15.3-57-18.1c-0.8-0.1-1.4-0.9-1.3-1.7s0.9-1.4,1.7-1.3c22,2.8,42,9.2,58.1,18.5
-			c18.7,10.8,30.5,24.5,34.2,39.7c2.8,11.6,0.6,23.5-6.4,34.4C530.3,289,529.8,289.2,529.3,289.2z"/>
-	</g>
-	<g class="st4">
-		<g class="st5">
-			<polygon class="st6" points="18,140.8 18,348.6 90.7,393 90.4,182.3 			"/>
-			
-				<linearGradient id="SVGID_10_" gradientUnits="userSpaceOnUse" x1="565.5479" y1="470.6468" x2="574.45" y2="272.575" gradientTransform="matrix(-1 0 0 -1 696.9904 620)">
-				<stop  offset="0" style="stop-color:#4E547D"/>
-				<stop  offset="1" style="stop-color:#020A47"/>
-			</linearGradient>
-			<polygon class="st13" points="162.1,141.1 162.2,349.7 90.2,393 90.2,182.3 			"/>
-			
-				<linearGradient id="SVGID_11_" gradientUnits="userSpaceOnUse" x1="534.3777" y1="479.6375" x2="678.8154" y2="479.6375" gradientTransform="matrix(-1 0 0 -1 696.9904 620)">
-				<stop  offset="0" style="stop-color:#111952"/>
-				<stop  offset="1" style="stop-color:#020A47"/>
-			</linearGradient>
-			<path class="st14" d="M160.3,136.3L97.7,99.5c-3.9-2.3-8.7-2.3-12.7,0l-64.5,37.3c-3.1,1.8-3.1,6.4,0,8.2l63.3,36.3
-				c3.9,2.2,8.6,2.2,12.5,0l63.9-36.8C163.4,142.7,163.4,138.2,160.3,136.3z"/>
-		</g>
-		<g>
-			<g class="st9">
-				
-					<linearGradient id="SVGID_12_" gradientUnits="userSpaceOnUse" x1="550.1234" y1="471.6094" x2="574.0645" y2="430.1422" gradientTransform="matrix(-1 0 0 -1 724.7799 620)">
-					<stop  offset="0" style="stop-color:#4E547D"/>
-					<stop  offset="0.3005" style="stop-color:#494E79;stop-opacity:0.7295"/>
-					<stop  offset="0.7471" style="stop-color:#373B6B;stop-opacity:0.3276"/>
-					<stop  offset="1" style="stop-color:#2A2F62;stop-opacity:0.1"/>
-				</linearGradient>
-				<path class="st15" d="M162.7,196.7c-0.3,0-0.5-0.2-0.5-0.5V142c0-0.3,0.2-0.5,0.5-0.5s0.5,0.2,0.5,0.5v54.2
-					C163.2,196.5,163,196.7,162.7,196.7z"/>
-			</g>
-			<g class="st9">
-				
-					<linearGradient id="SVGID_13_" gradientUnits="userSpaceOnUse" x1="1308.0411" y1="513.7833" x2="1347.5156" y2="445.4114" gradientTransform="matrix(1 0 0 -1 -1237.5712 620)">
-					<stop  offset="0" style="stop-color:#2A2F62;stop-opacity:0.1"/>
-					<stop  offset="0.3328" style="stop-color:#333768;stop-opacity:0.3995"/>
-					<stop  offset="0.8939" style="stop-color:#494E79;stop-opacity:0.9045"/>
-					<stop  offset="1" style="stop-color:#4E547D"/>
-				</linearGradient>
-				<path class="st16" d="M90.6,183.4c-2.3,0-4.5-0.6-6.5-1.7l-63.9-36.8c-1.6-0.9-2.6-2.6-2.6-4.5s1-3.6,2.6-4.5l62.6-36.8
-					c4-2.4,9.1-2.4,13.2,0l64.5,37.3c1.6,0.9,2.6,2.6,2.6,4.5s-1,3.6-2.6,4.5l-63.3,36.3C95.1,182.8,92.8,183.4,90.6,183.4z
-					 M20.7,136.8c-1.3,0.8-2.1,2.1-2.1,3.7c0,1.5,0.8,2.9,2.1,3.6l63.9,36.8c3.7,2.1,8.3,2.1,12,0l63.3-36.3
-					c1.3-0.8,2.1-2.1,2.1-3.7c0-1.5-0.8-2.9-2.1-3.7L95.4,99.9c-3.8-2.2-8.4-2.2-12.2,0L20.7,136.8z"/>
-			</g>
-		</g>
-	</g>
-	<g>
-		
-			<linearGradient id="SVGID_14_" gradientUnits="userSpaceOnUse" x1="573.3314" y1="484.7981" x2="637.7182" y2="315.5116" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#4E547D"/>
-			<stop  offset="0.2454" style="stop-color:#414773"/>
-			<stop  offset="0.7167" style="stop-color:#0A114D"/>
-			<stop  offset="1" style="stop-color:#020A47"/>
-		</linearGradient>
-		<polygon class="st17" points="700.4,202.1 700.4,453.2 612.9,506.6 613.2,252.1 		"/>
-		<g>
-			
-				<linearGradient id="SVGID_15_" gradientUnits="userSpaceOnUse" x1="563.3571" y1="408.1583" x2="574.1271" y2="168.5243" gradientTransform="matrix(1 0 0 -1 0 620)">
-				<stop  offset="0" style="stop-color:#4E547D"/>
-				<stop  offset="1" style="stop-color:#020A47"/>
-			</linearGradient>
-			<polygon class="st18" points="526,201.8 525.9,453.9 613.5,506.6 613.5,252 			"/>
-			
-				<linearGradient id="SVGID_16_" gradientUnits="userSpaceOnUse" x1="471.6396" y1="346.3833" x2="565.7792" y2="270.2009" gradientTransform="matrix(1 0 0 -1 0 620)">
-				<stop  offset="0" style="stop-color:#9B2AFF;stop-opacity:0.3"/>
-				<stop  offset="1" style="stop-color:#9B2AFF;stop-opacity:0"/>
-			</linearGradient>
-			<polygon class="st19" points="526,201.8 525.9,453.9 613.5,506.6 613.5,252 			"/>
-		</g>
-		
-			<linearGradient id="SVGID_17_" gradientUnits="userSpaceOnUse" x1="525.95" y1="418.6438" x2="700.45" y2="418.6438" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#4E547D"/>
-			<stop  offset="1" style="stop-color:#0F1650"/>
-		</linearGradient>
-		<path class="st20" d="M528.8,196.5l75.6-44.5c4.7-2.8,10.6-2.8,15.3-0.1l77.9,45.1c3.8,2.2,3.8,7.7,0,9.9l-76.5,43.9
-			c-4.7,2.7-10.4,2.7-15.1,0l-77.2-44.4C525,204.1,525,198.7,528.8,196.5z"/>
-		
-			<linearGradient id="SVGID_18_" gradientUnits="userSpaceOnUse" x1="548.3661" y1="373.1257" x2="604.4467" y2="412.2011" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#9B2AFF;stop-opacity:0.3"/>
-			<stop  offset="1" style="stop-color:#9B2AFF;stop-opacity:0"/>
-		</linearGradient>
-		<path class="st21" d="M528.8,196.5l75.6-44.5c4.7-2.8,10.6-2.8,15.3-0.1l77.9,45.1c3.8,2.2,3.8,7.7,0,9.9l-76.5,43.9
-			c-4.7,2.7-10.4,2.7-15.1,0l-77.2-44.4C525,204.1,525,198.7,528.8,196.5z"/>
-		<g class="st9">
-			<linearGradient id="SVGID_19_" gradientUnits="userSpaceOnUse" x1="699.7186" y1="200.9185" x2="699.8969" y2="254.0274">
-				<stop  offset="0" style="stop-color:#4E547D"/>
-				<stop  offset="0.1061" style="stop-color:#494E79;stop-opacity:0.9045"/>
-				<stop  offset="0.6672" style="stop-color:#333768;stop-opacity:0.3995"/>
-				<stop  offset="1" style="stop-color:#2A2F62;stop-opacity:0.1"/>
-			</linearGradient>
-			<path class="st22" d="M700.5,201.9v135.8h-1V205.2C700.1,204.2,700.5,203.1,700.5,201.9z"/>
-		</g>
-		<linearGradient id="SVGID_20_" gradientUnits="userSpaceOnUse" x1="651.1646" y1="219.3812" x2="550.4993" y2="172.0093">
-			<stop  offset="0" style="stop-color:#4E547D;stop-opacity:0.7"/>
-			<stop  offset="1" style="stop-color:#4E547D"/>
-		</linearGradient>
-		<path class="st23" d="M612.1,150.9L612.1,150.9c2.5,0,4.9,0.7,7.1,1.9l77.9,45.1c1.5,0.9,2.4,2.4,2.4,4.1c0,1.7-0.9,3.2-2.3,4.1
-			l-76.5,43.9c-2.2,1.2-4.6,1.9-7.1,1.9c-2.5,0-4.9-0.7-7.1-1.9l-77.2-44.4c-1.5-0.9-2.4-2.5-2.4-4.2c0-1.7,0.9-3.2,2.4-4l75.6-44.5
-			C607.1,151.6,609.6,150.9,612.1,150.9 M612.1,149.9c-2.7,0-5.4,0.7-7.7,2.1l-75.6,44.5c-3.8,2.2-3.8,7.6,0,9.9l77.2,44.4
-			c2.3,1.4,4.9,2,7.5,2c2.6,0,5.2-0.7,7.5-2l76.5-43.9c3.8-2.2,3.8-7.7,0-9.9l-77.9-45.1C617.4,150.6,614.7,149.9,612.1,149.9
-			L612.1,149.9z"/>
-	</g>
-	<g>
-		<polygon class="st24" points="784.1,265.2 784.1,535.2 728.4,535.8 728.6,297 		"/>
-		
-			<linearGradient id="SVGID_21_" gradientUnits="userSpaceOnUse" x1="616.5718" y1="402.1508" x2="693.2315" y2="272.3883" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#2C3164"/>
-			<stop  offset="1" style="stop-color:#020A47"/>
-		</linearGradient>
-		<polygon class="st25" points="673.6,265.3 673.6,425.3 728.8,458.5 728.8,296.9 		"/>
-		
-			<linearGradient id="SVGID_22_" gradientUnits="userSpaceOnUse" x1="673.2" y1="355.1875" x2="783.9001" y2="355.1875" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#111952"/>
-			<stop  offset="1" style="stop-color:#020A47"/>
-		</linearGradient>
-		<path class="st26" d="M675,261.7l48-28.2c3-1.8,6.7-1.8,9.7,0l49.4,28.6c2.4,1.4,2.4,4.9,0,6.3l-48.5,27.8c-3,1.7-6.6,1.7-9.6,0
-			L675,268C672.6,266.6,672.6,263.1,675,261.7z"/>
-	</g>
-	<g>
-		
-			<linearGradient id="SVGID_23_" gradientUnits="userSpaceOnUse" x1="445.8728" y1="484.7981" x2="510.2596" y2="315.5116" gradientTransform="matrix(-1 0 0 -1 686.1006 620)">
-			<stop  offset="0" style="stop-color:#4E547D"/>
-			<stop  offset="0.2454" style="stop-color:#414773"/>
-			<stop  offset="0.7167" style="stop-color:#0A114D"/>
-			<stop  offset="1" style="stop-color:#020A47"/>
-		</linearGradient>
-		<polygon class="st27" points="200.4,252.1 200.7,506.6 113.1,453.2 113.1,202.1 		"/>
-		<g>
-			
-				<linearGradient id="SVGID_24_" gradientUnits="userSpaceOnUse" x1="435.8985" y1="408.1583" x2="446.6685" y2="168.5243" gradientTransform="matrix(-1 0 0 -1 686.1006 620)">
-				<stop  offset="0" style="stop-color:#4E547D"/>
-				<stop  offset="1" style="stop-color:#020A47"/>
-			</linearGradient>
-			<polygon class="st28" points="200.1,252 200.1,506.6 287.7,453.9 287.6,201.8 			"/>
-			
-				<linearGradient id="SVGID_25_" gradientUnits="userSpaceOnUse" x1="344.1827" y1="346.3818" x2="438.3224" y2="270.1994" gradientTransform="matrix(-1 0 0 -1 686.1006 620)">
-				<stop  offset="0" style="stop-color:#5EE4E4;stop-opacity:0.35"/>
-				<stop  offset="0.9944" style="stop-color:#5EE4E4;stop-opacity:0"/>
-			</linearGradient>
-			<polygon class="st29" points="200.1,252 200.1,506.6 287.7,453.9 287.6,201.8 			"/>
-		</g>
-		
-			<linearGradient id="SVGID_26_" gradientUnits="userSpaceOnUse" x1="398.4914" y1="418.6438" x2="572.9914" y2="418.6438" gradientTransform="matrix(-1 0 0 -1 686.1006 620)">
-			<stop  offset="0" style="stop-color:#4E547D"/>
-			<stop  offset="1" style="stop-color:#0F1650"/>
-		</linearGradient>
-		<path class="st30" d="M284.8,206.4l-77.2,44.4c-4.7,2.7-10.4,2.7-15.1,0L116,206.9c-3.8-2.2-3.8-7.7,0-9.9l77.9-45.1
-			c4.7-2.7,10.6-2.7,15.3,0.1l75.6,44.5C288.6,198.7,288.6,204.1,284.8,206.4z"/>
-		
-			<linearGradient id="SVGID_27_" gradientUnits="userSpaceOnUse" x1="420.9096" y1="373.1271" x2="476.99" y2="412.2025" gradientTransform="matrix(-1 0 0 -1 686.1006 620)">
-			<stop  offset="0" style="stop-color:#5EE4E4;stop-opacity:0.3"/>
-			<stop  offset="1" style="stop-color:#5EE4E4;stop-opacity:0"/>
-		</linearGradient>
-		<path class="st31" d="M284.8,206.4l-77.2,44.4c-4.7,2.7-10.4,2.7-15.1,0L116,206.9c-3.8-2.2-3.8-7.7,0-9.9l77.9-45.1
-			c4.7-2.7,10.6-2.7,15.3,0.1l75.6,44.5C288.6,198.7,288.6,204.1,284.8,206.4z"/>
-		<g class="st9">
-			<linearGradient id="SVGID_28_" gradientUnits="userSpaceOnUse" x1="113.4147" y1="202.1697" x2="113.5929" y2="265.7043">
-				<stop  offset="0" style="stop-color:#4E547D"/>
-				<stop  offset="0.1061" style="stop-color:#494E79;stop-opacity:0.9045"/>
-				<stop  offset="0.6672" style="stop-color:#333768;stop-opacity:0.3995"/>
-				<stop  offset="1" style="stop-color:#2A2F62;stop-opacity:0.1"/>
-			</linearGradient>
-			<path class="st32" d="M113.1,201.9v135.8h1V205.2C113.4,204.2,113.1,203.1,113.1,201.9z"/>
-		</g>
-		
-			<linearGradient id="SVGID_29_" gradientUnits="userSpaceOnUse" x1="523.7059" y1="219.3812" x2="423.0407" y2="172.0093" gradientTransform="matrix(-1 0 0 1 686.1006 0)">
-			<stop  offset="0" style="stop-color:#4E547D;stop-opacity:0.7"/>
-			<stop  offset="1" style="stop-color:#4E547D"/>
-		</linearGradient>
-		<path class="st33" d="M201.4,150.9c2.6,0,5,0.7,7.2,2l75.6,44.5c1.5,0.8,2.3,2.3,2.4,4c0,1.7-0.9,3.3-2.4,4.2l-77.2,44.4
-			c-2.2,1.2-4.6,1.9-7.1,1.9c-2.5,0-4.9-0.7-7.1-1.9L116.5,206c-1.5-0.9-2.3-2.4-2.3-4.1c0-1.7,0.9-3.2,2.4-4.1l77.9-45.1
-			C196.5,151.5,198.9,150.9,201.4,150.9L201.4,150.9 M201.4,149.9c-2.6,0-5.2,0.7-7.6,2L116,197c-3.8,2.2-3.8,7.7,0,9.9l76.5,43.9
-			c2.3,1.4,5,2,7.5,2c2.6,0,5.2-0.7,7.5-2l77.2-44.4c3.8-2.3,3.8-7.7,0-9.9L209.2,152C206.8,150.6,204.1,149.9,201.4,149.9
-			L201.4,149.9z"/>
-	</g>
-	<g class="st9">
-		
-			<linearGradient id="SVGID_30_" gradientUnits="userSpaceOnUse" x1="1228.9321" y1="381.5346" x2="1259.2828" y2="328.9655" gradientTransform="matrix(-1 0 0 -1 1972.7986 620)">
-			<stop  offset="0" style="stop-color:#2A2F62;stop-opacity:0.1"/>
-			<stop  offset="0.3328" style="stop-color:#333768;stop-opacity:0.3995"/>
-			<stop  offset="0.8939" style="stop-color:#494E79;stop-opacity:0.9045"/>
-			<stop  offset="1" style="stop-color:#4E547D"/>
-		</linearGradient>
-		<path class="st34" d="M728.3,297.9c-1.7,0-3.5-0.4-5-1.3l-48.5-27.8c-1.3-0.7-2.1-2.1-2.1-3.6s0.8-2.8,2.1-3.6l49.4-28.6
-			c3.2-1.8,7.1-1.8,10.2,0l48,28.2c1.3,0.8,2,2.1,2,3.6s-0.8,2.8-2.1,3.5l-49,28.2C731.8,297.5,730.1,297.9,728.3,297.9z
-			 M729.3,232.7c-1.6,0-3.2,0.4-4.6,1.2l-49.4,28.6c-1,0.6-1.6,1.6-1.6,2.7s0.6,2.1,1.6,2.7l48.5,27.8c2.8,1.6,6.3,1.6,9.1,0
-			l49-28.2c1-0.6,1.6-1.6,1.6-2.7s-0.6-2.1-1.5-2.7l-48-28.2C732.5,233.1,730.9,232.7,729.3,232.7z"/>
-	</g>
-	<linearGradient id="SVGID_31_" gradientUnits="userSpaceOnUse" x1="665.6298" y1="296.7583" x2="680.7202" y2="270.6208">
-		<stop  offset="0" style="stop-color:#333768;stop-opacity:0.3995"/>
-		<stop  offset="1" style="stop-color:#4E547D;stop-opacity:0.7"/>
-	</linearGradient>
-	<path class="st35" d="M673.8,268v32.9h-1V266C672.9,266.8,673.3,267.5,673.8,268z"/>
-	<g>
-		
-			<linearGradient id="SVGID_32_" gradientUnits="userSpaceOnUse" x1="504.3684" y1="264.4018" x2="462.8143" y2="131.7613" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#4E547D"/>
-			<stop  offset="0.2454" style="stop-color:#414773"/>
-			<stop  offset="0.7167" style="stop-color:#0A114D"/>
-			<stop  offset="1" style="stop-color:#020A47"/>
-		</linearGradient>
-		<polygon class="st36" points="438.9,397.2 438.8,534.9 500.6,535 500.6,432.6 		"/>
-		<polygon class="st24" points="562.5,397 562.5,535.3 500.1,535.2 500.4,432.6 		"/>
-		
-			<linearGradient id="SVGID_33_" gradientUnits="userSpaceOnUse" x1="414.3889" y1="232.2225" x2="453.0347" y2="165.2366" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#75BFE6;stop-opacity:0.3"/>
-			<stop  offset="1" style="stop-color:#75BFE6;stop-opacity:0"/>
-		</linearGradient>
-		<polygon class="st37" points="438.9,397.2 438.8,534.7 500.6,535.8 500.6,432.6 		"/>
-		
-			<linearGradient id="SVGID_34_" gradientUnits="userSpaceOnUse" x1="479.0956" y1="251.1916" x2="506.2312" y2="215.3725" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#4E547D"/>
-			<stop  offset="1" style="stop-color:#2A2F62"/>
-		</linearGradient>
-		<path class="st38" d="M440.4,393.2l53.7-31.6c3.3-2,7.5-2,10.9,0l55.3,32c2.7,1.6,2.7,5.5,0,7L506,431.7c-3.3,1.9-7.4,1.9-10.7,0
-			l-54.8-31.5C437.7,398.6,437.7,394.7,440.4,393.2z"/>
-		
-			<linearGradient id="SVGID_35_" gradientUnits="userSpaceOnUse" x1="499.0441" y1="266.0896" x2="500.4913" y2="218.6925" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#9550EA;stop-opacity:0.3"/>
-			<stop  offset="1" style="stop-color:#9550EA;stop-opacity:0"/>
-		</linearGradient>
-		<path class="st39" d="M440.4,393.2l53.7-31.6c3.3-2,7.5-2,10.9,0l55.3,32c2.7,1.6,2.7,5.5,0,7L506,431.7c-3.3,1.9-7.4,1.9-10.7,0
-			l-54.8-31.5C437.7,398.6,437.7,394.7,440.4,393.2z"/>
-	</g>
-	<g class="st9">
-		
-			<linearGradient id="SVGID_36_" gradientUnits="userSpaceOnUse" x1="536.7819" y1="208.629" x2="587.2181" y2="121.271" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#383846"/>
-			<stop  offset="0.1061" style="stop-color:#323340;stop-opacity:0.9045"/>
-			<stop  offset="0.6672" style="stop-color:#181B27;stop-opacity:0.3995"/>
-			<stop  offset="1" style="stop-color:#0E121D;stop-opacity:0.1"/>
-		</linearGradient>
-		<rect x="561.5" y="397.1" class="st40" width="1" height="115.9"/>
-	</g>
-	<g class="st9">
-		
-			<linearGradient id="SVGID_37_" gradientUnits="userSpaceOnUse" x1="481.7215" y1="177.0665" x2="517.4785" y2="115.1335" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#383846"/>
-			<stop  offset="0.1061" style="stop-color:#323340;stop-opacity:0.9045"/>
-			<stop  offset="0.6672" style="stop-color:#181B27;stop-opacity:0.3995"/>
-			<stop  offset="1" style="stop-color:#0E121D;stop-opacity:0.1"/>
-		</linearGradient>
-		<rect x="499.1" y="432.9" class="st41" width="1" height="82"/>
-	</g>
-	<g class="st9">
-		
-			<linearGradient id="SVGID_38_" gradientUnits="userSpaceOnUse" x1="483.2532" y1="252.7126" x2="517.1628" y2="193.9793" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#383846"/>
-			<stop  offset="1" style="stop-color:#383846"/>
-		</linearGradient>
-		<path class="st42" d="M500.6,433.6c-1.9,0-3.9-0.5-5.6-1.5l-54.8-31.5c-1.4-0.8-2.3-2.3-2.3-3.9s0.8-3.1,2.2-3.9l53.7-31.6
-			c3.5-2.1,7.8-2.1,11.4,0l55.3,32c1.4,0.8,2.3,2.3,2.3,3.9s-0.9,3.1-2.3,3.9l-54.3,31.2C504.5,433.1,502.5,433.6,500.6,433.6z
-			 M499.6,360.6c-1.8,0-3.6,0.5-5.2,1.4l-53.7,31.6c-1.1,0.6-1.8,1.8-1.8,3.1c0,1.3,0.7,2.4,1.8,3.1l54.8,31.5
-			c3.2,1.8,7.1,1.8,10.2,0l54.3-31.2c1.1-0.6,1.8-1.8,1.8-3.1c0-1.3-0.7-2.4-1.8-3.1l-55.3-32C503.1,361.1,501.3,360.6,499.6,360.6z
-			"/>
-	</g>
-	<g>
-		
-			<linearGradient id="SVGID_39_" gradientUnits="userSpaceOnUse" x1="275.9" y1="358.0719" x2="454.7109" y2="358.0719" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#5EE4E4"/>
-			<stop  offset="0.4171" style="stop-color:#5EE4E4;stop-opacity:0.5829"/>
-			<stop  offset="1" style="stop-color:#9B2AFF;stop-opacity:0"/>
-		</linearGradient>
-		<path class="st43" d="M419.7,343.2c-37.5,0-73.6-8.5-101.1-24.4s-42.7-37.1-42.7-59.7c0-22.5,14.9-43.5,42.1-59.3
-			c14.7-8.5,32-15,51.3-19.1c0.8-0.2,1.6,0.3,1.8,1.2c0.2,0.8-0.3,1.6-1.2,1.8c-19,4.1-36,10.4-50.4,18.8
-			c-26.2,15.2-40.6,35.4-40.6,56.7c0,21.5,14.7,41.8,41.2,57.1c35.1,20.2,84.7,28.3,132.9,21.7c0.8-0.1,1.6,0.5,1.7,1.3
-			s-0.5,1.6-1.3,1.7C442.2,342.5,430.9,343.2,419.7,343.2z"/>
-	</g>
-	<linearGradient id="SVGID_40_" gradientUnits="userSpaceOnUse" x1="279.7" y1="293.1481" x2="401.7325" y2="293.1481">
-		<stop  offset="0" style="stop-color:#60E4E4"/>
-		<stop  offset="0.4171" style="stop-color:#5EE4E4;stop-opacity:0.5829"/>
-		<stop  offset="1" style="stop-color:#9B2AFF;stop-opacity:0"/>
-	</linearGradient>
-	<path class="st44" d="M324.9,315.5c-0.6,0.8-1.2,1.6-1.7,2.5c-0.1,0.2-0.2,0.3-0.3,0.5c-1.4-0.9-2.7-1.9-4-2.9
-		c-0.2-0.1-0.4-0.3-0.6-0.5c-2.4-1.8-4.6-3.1-6.7-4.2c-17.8-12.3-28.9-27.1-31.9-43c0,0,0-0.1,0-0.1c0.5,0.2,1.1,0.3,1.8,0.3h0.1
-		c0.5,0,0.8,0,1,0.7c0,0.1,0.1,0.1,0.1,0.2c0,0.1,0.1,0.2,0.1,0.3c0,0.1,0.1,0.2,0.1,0.3c0.1,0.4,0.2,1,0.3,1.7
-		c0.1,0.4,0.1,0.8,0.2,1.2c0,0.3,0.1,0.6,0.2,1c0,0.1,0.1,0.3,0.1,0.4c0,0.2,0.1,0.5,0.2,0.7c0.3,1.2,0.7,2.4,1.4,3.7
-		c0.1,0.2,0.2,0.5,0.4,0.7c0.1,0.3,0.3,0.5,0.5,0.8c0.1,0.1,0.2,0.3,0.3,0.4c0.6,1,1.4,1.9,2.3,2.8c2.3,2.3,4.4,2.9,6.2,3.4
-		c2.5,0.7,4.9,1.4,8.5,6.6c1.1,1.6,1.3,2.3,1.5,2.8c0.5,1.3,0.9,2.2,4.4,5.9c3.7,4,6.9,4.5,9.5,5c1.6,0.3,2.8,0.5,4,1.5
-		c0.7,0.6,0.9,1.4,1.3,2.9c0.2,1.1,0.5,2.4,1.2,3.9C325.2,315.1,325.4,314.9,324.9,315.5z"/>
-	<g class="st45">
-		<linearGradient id="SVGID_41_" gradientUnits="userSpaceOnUse" x1="275.9889" y1="219.6676" x2="371.8" y2="219.6676">
-			<stop  offset="0" style="stop-color:#60E4E4"/>
-			<stop  offset="0.4171" style="stop-color:#5EE4E4;stop-opacity:0.5829"/>
-			<stop  offset="1" style="stop-color:#9B2AFF;stop-opacity:0"/>
-		</linearGradient>
-		<path class="st46" d="M352.2,182.9c-3.6,0.4-9.1,0.1-10.1,0c-2.7-0.3-4.7-1.3-6.6-2.4c-1.7-1-3.2-1.8-4.6-1.1
-			c-1.3,0.7-1.7,2.3-1.8,3.6c-0.5,4.9-5,6.4-5.9,6.6c-1.4-0.1-2.8-0.6-4.3-1.3c-3-1.3-6.8-2.9-12.6-0.8c-10.3,3.7-12,11.5-13.2,16.7
-			c-0.5,2.1-1,4.1-1.8,4.7c-0.4,0.3-0.7,0.4-0.8,0.4c-0.2-0.4-0.5-1.6-0.7-2.4c-0.5-2.2-1.1-4.6-3.2-5.4c-1.6-0.6-3.6,0-6.1,2
-			c-1,0.8-3.3,2.6-4.2,28.2c-0.4,12.4-0.3,24.5-0.3,24.6c0,0.7,0.6,1.4,1.3,1.5c0,0,0,0,0,0s0,1.2,0,2.4c0-1.2,0.1-2.4,0.1-2.4
-			c0,0,0,0,0,0c0,0,0.1,0,0.1,0c0.9,0,1.5-0.7,1.6-1.6c0-3.3,0-6.7,0-10c4.5-16.5,17.7-32.4,39.6-45.1c9.8-5.7,20.7-10.4,32.4-14.1
-			c0,0,10.4-3.3,20.7-6.6C364.7,181.4,357.6,182.2,352.2,182.9z"/>
-		<g>
-			
-				<linearGradient id="SVGID_42_" gradientUnits="userSpaceOnUse" x1="278.2729" y1="353.4157" x2="347.3835" y2="353.4157" gradientTransform="matrix(0.9999 -1.390573e-02 -1.914182e-02 -1.3764 3.9993 709.1858)">
-				<stop  offset="0" style="stop-color:#60E4E4"/>
-				<stop  offset="0.4171" style="stop-color:#5EE4E4;stop-opacity:0.5829"/>
-				<stop  offset="1" style="stop-color:#9B2AFF;stop-opacity:0"/>
-			</linearGradient>
-			<path class="st47" d="M277.5,257.8c-0.8,0-1.5-0.7-1.5-1.5c0-0.1-0.1-12.2,0.3-24.6c0.9-25.6,3.2-27.4,4.2-28.2
-				c2.5-2,4.5-2.6,6.1-2c2.1,0.8,2.7,3.2,3.2,5.4c0.2,0.8,0.5,2,0.7,2.4c0.1,0,0.4-0.1,0.8-0.4c0.8-0.6,1.3-2.6,1.8-4.7
-				c1.2-5.2,2.9-13,13.2-16.7c5.8-2.1,9.6-0.5,12.6,0.8c1.5,0.7,2.9,1.2,4.3,1.3c0.9-0.2,5.4-1.7,5.9-6.6c0.1-1.3,0.5-2.9,1.8-3.6
-				c1.4-0.7,2.9,0.1,4.6,1.1c1.9,1.1,4.2,2.4,6.9,2c0.8-0.1,1.6,0.5,1.7,1.3s-0.5,1.6-1.3,1.7c-3.7,0.4-6.6-1.2-8.7-2.4
-				c-0.6-0.3-1.3-0.7-1.7-0.9c-0.1,0.2-0.1,0.5-0.2,1.1c-0.6,6-5.8,8.7-8.4,9.2h-0.3h-0.1c-2.1,0-3.8-0.8-5.5-1.5
-				c-2.8-1.2-5.7-2.5-10.4-0.8c-8.7,3.1-10.1,9.4-11.3,14.5c-0.6,2.8-1.2,5.3-3,6.5c-0.5,0.3-2,1.4-3.6,0.8
-				c-1.7-0.7-2.1-2.7-2.6-4.6c-0.3-1.1-0.7-3-1.3-3.2c-0.1,0-0.9-0.2-3.2,1.6c-2.4,2.2-3.6,27.4-3.4,50.4
-				C279,257.1,278.4,257.8,277.5,257.8L277.5,257.8z"/>
-		</g>
-	</g>
-	<g>
-		<linearGradient id="SVGID_43_" gradientUnits="userSpaceOnUse" x1="275.9" y1="291.6981" x2="338.1919" y2="291.6981">
-			<stop  offset="0" style="stop-color:#60E4E4"/>
-			<stop  offset="0.4171" style="stop-color:#5EE4E4;stop-opacity:0.5829"/>
-			<stop  offset="1" style="stop-color:#9B2AFF;stop-opacity:0"/>
-		</linearGradient>
-		<path class="st48" d="M337.9,324.7c0,0.1-0.1,0.2-0.2,0.2c-0.2,0.3-0.6,0.5-1,0.5c-0.3,0-0.5-0.1-0.8-0.2c-1.7-1-3.2-2.1-4.5-3
-			c-6-4.6-6.9-8.4-7.5-11.1c-0.4-1.5-0.6-2.3-1.3-2.9c-1.2-1-2.4-1.2-4-1.5c-2.6-0.5-5.8-1-9.5-5c-3.5-3.7-3.9-4.6-4.4-5.9
-			c-0.2-0.5-0.4-1.2-1.5-2.8c-3.6-5.2-6-5.9-8.5-6.6c-1.8-0.5-3.9-1.1-6.2-3.4c-4.1-4.1-4.9-8.7-5.4-11.6c-0.5-3.1-0.7-3.2-1.6-3.2
-			h-0.1c-0.6,0-1.2-0.1-1.8-0.3c-1.5-0.5-2.7-1.6-3.4-3.3c0-0.1-0.1-0.2-0.1-0.4c0,0,0-0.1,0-0.1c-0.2-1.6-0.3-3.2-0.3-4.8
-			c0.1-0.3,0.2-0.5,0.4-0.6l0.7-0.7l1,0.4c0.5,0.2,0.8,0.6,0.9,1.5c0.1,0.4,0.1,1,0.1,1.7c0,0.4,0,0.8-0.1,1.3
-			c0,0.2,0.1,0.4,0.2,0.6c0.1,0.3,0.3,0.6,0.5,0.9c0.5,0.6,1.1,0.9,1.9,0.8h0.1c3.6,0,4,3,4.5,5.7c0.5,2.9,1.1,6.5,4.5,10
-			c1.7,1.7,3.2,2.2,4.9,2.7c2.7,0.8,5.9,1.7,10.1,7.8c1.3,1.9,1.6,2.8,1.9,3.5s0.5,1.3,3.7,4.8c3.1,3.2,5.5,3.7,7.9,4.1
-			c1.8,0.3,3.7,0.6,5.4,2.1c1.6,1.3,2,3,2.3,4.6c0.7,2.9,1.6,6.9,10.6,12.2C338.1,323,338.3,323.9,337.9,324.7z"/>
-	</g>
-	
-		<linearGradient id="SVGID_44_" gradientUnits="userSpaceOnUse" x1="435.1232" y1="239.4525" x2="646.902" y2="409.0203" gradientTransform="matrix(1 0 0 -1 0 620)">
-		<stop  offset="0" style="stop-color:#5EE4E4"/>
-		<stop  offset="0.3286" style="stop-color:#5EE4E4;stop-opacity:0.5829"/>
-		<stop  offset="0.7877" style="stop-color:#9B2AFF;stop-opacity:0"/>
-	</linearGradient>
-	<path class="st49" d="M428.7,389.8c-0.7,0-1.3,0-2,0c-1.2,0-2.2-1-2.2-2.2s1-2.2,2.2-2.2l0,0c52.9,0.3,102.5-11.5,139.8-33.1
-		c36.2-21.1,56.2-48.9,56.1-78.4c0-29.7-20.3-57.8-57-79c-1-0.6-1.4-1.9-0.8-3c0.6-1,1.9-1.4,3-0.8c38.1,22,59.1,51.4,59.2,82.8
-		c0,31.2-20.7,60.4-58.3,82.2C531.2,377.9,481.6,389.8,428.7,389.8z"/>
-	<g>
-		
-			<linearGradient id="SVGID_45_" gradientUnits="userSpaceOnUse" x1="370.1369" y1="301.5038" x2="336.7755" y2="147.779" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#4E547D"/>
-			<stop  offset="0.1886" style="stop-color:#434974"/>
-			<stop  offset="0.703" style="stop-color:#0C144E"/>
-			<stop  offset="1" style="stop-color:#020A47"/>
-		</linearGradient>
-		<polygon class="st50" points="371.4,340.9 371.4,535 309.1,535.2 309.3,377 309.3,376.5 309.5,376.4 371.2,341.1 		"/>
-		
-			<linearGradient id="SVGID_46_" gradientUnits="userSpaceOnUse" x1="205.9074" y1="355.324" x2="257.5465" y2="219.554" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#4E547D"/>
-			<stop  offset="0.2454" style="stop-color:#414773"/>
-			<stop  offset="0.7167" style="stop-color:#0A114D"/>
-			<stop  offset="1" style="stop-color:#020A47"/>
-		</linearGradient>
-		<polygon class="st51" points="309.5,376.5 309.5,535.2 272.8,535.2 247.7,535.2 247.8,342.4 247.8,341.1 309.5,376.4 		"/>
-		
-			<linearGradient id="SVGID_47_" gradientUnits="userSpaceOnUse" x1="247.3873" y1="279.4375" x2="371.325" y2="279.4375" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#303567"/>
-			<stop  offset="1" style="stop-color:#4E547D"/>
-		</linearGradient>
-		<path class="st52" d="M249.4,337.1l53.7-31.6c3.3-2,7.5-2,10.9,0l55.3,32c2.7,1.6,2.7,5.5,0,7L315,375.7c-3.3,1.9-7.4,1.9-10.7,0
-			l-54.8-31.5C246.7,342.5,246.7,338.7,249.4,337.1z"/>
-		
-			<linearGradient id="SVGID_48_" gradientUnits="userSpaceOnUse" x1="320.5135" y1="313.2185" x2="306.0412" y2="269.0779" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#45A8DD;stop-opacity:0.3"/>
-			<stop  offset="0.1112" style="stop-color:#4CABDE;stop-opacity:0.2666"/>
-			<stop  offset="0.4829" style="stop-color:#63B6E2;stop-opacity:0.1551"/>
-			<stop  offset="0.7925" style="stop-color:#70BCE5;stop-opacity:6.224951e-02"/>
-			<stop  offset="1" style="stop-color:#74BEE6;stop-opacity:0"/>
-		</linearGradient>
-		<path class="st53" d="M249.4,337.1l53.7-31.6c3.3-2,7.5-2,10.9,0l55.3,32c2.7,1.6,2.7,5.5,0,7L315,375.7c-3.3,1.9-7.4,1.9-10.7,0
-			l-54.8-31.5C246.7,342.5,246.7,338.7,249.4,337.1z"/>
-		<g class="st9">
-			
-				<linearGradient id="SVGID_49_" gradientUnits="userSpaceOnUse" x1="292.2531" y1="308.8126" x2="326.1629" y2="250.0792" gradientTransform="matrix(1 0 0 -1 0 620)">
-				<stop  offset="0" style="stop-color:#4E547D"/>
-				<stop  offset="1" style="stop-color:#4E547D"/>
-			</linearGradient>
-			<path class="st54" d="M309.6,377.5c-1.9,0-3.9-0.5-5.6-1.5l-54.8-31.5c-1.4-0.8-2.3-2.3-2.3-3.9s0.8-3.1,2.2-3.9l53.7-31.6
-				c3.5-2.1,7.8-2.1,11.4,0l55.3,32c1.4,0.8,2.3,2.3,2.3,3.9s-0.9,3.1-2.3,3.9l-54.3,31.2C313.4,377,311.5,377.5,309.6,377.5z
-				 M308.5,304.5c-1.8,0-3.6,0.5-5.2,1.4l-53.7,31.6c-1.1,0.6-1.8,1.8-1.8,3.1c0,1.3,0.7,2.4,1.8,3.1l54.8,31.5
-				c3.2,1.8,7.1,1.8,10.2,0L369,344c1.1-0.6,1.8-1.8,1.8-3.1c0-1.3-0.7-2.4-1.8-3.1l-55.3-32C312.1,305,310.3,304.5,308.5,304.5z"/>
-		</g>
-	</g>
-	
-		<linearGradient id="SVGID_50_" gradientUnits="userSpaceOnUse" x1="451.7" y1="300.2501" x2="622.6" y2="300.2501" gradientTransform="matrix(1 0 0 -1 0 620)">
-		<stop  offset="0" style="stop-color:#22ADF6"/>
-		<stop  offset="0.3705" style="stop-color:#4C8CF2;stop-opacity:0.5829"/>
-		<stop  offset="0.8883" style="stop-color:#9B2AFF;stop-opacity:0"/>
-	</linearGradient>
-	<path class="st55" d="M622.6,273.9c0,29.5-19.9,57.4-56.1,78.4c-31.3,18.2-71.4,29.4-114.8,32.3c2.8-2.4,4.9-5.2,6.6-7.7
-		c1.7-2.3,3.2-4.5,5-5.7c1.3-0.9,2.9-0.8,5.4-0.6c5.9,0.5,14.1,1.2,22-16.9c1.9-4.3,2.8-8.4,3.6-12.1c1.9-8.4,3.2-14.5,14.1-18.6
-		c7-2.7,9.7,2.1,13.5,10c3.1,6.4,6.6,13.6,14.6,11.9c8.2-1.8,9.1-4.9,9.5-9.1c0.2-2.7,0.5-5.4,5-9c5.2-4.1,7.9-2.6,10.9-1.1
-		c2.4,1.3,6,3.2,9.6-1c4.1-4.8,7.1-3.8,11.3-2.4c3.9,1.4,8.7,3,13.8-1.7c5.7-5.4,3.6-10.9,1.9-15.4c-1.6-4.3-2.5-7.1-0.3-10.2
-		c2.4-3.2,5.1-3.1,7.7-3.1c1.9,0.1,4,0.1,5.3-1.5c1.2-1.5,1.3-3.6,0.4-7.3c-1-3.9-2.3-7.3-3.3-10c-1.1-2.8-2.3-5.9-1.8-6.8
-		c0.1-0.2,0.6-0.5,1.2-0.7c4.9-1.3,10.8-5.5,12.2-10.7C621.6,261.2,622.6,267.5,622.6,273.9z"/>
-	
-		<linearGradient id="SVGID_51_" gradientUnits="userSpaceOnUse" x1="433.9" y1="283.6894" x2="651.2097" y2="283.6894" gradientTransform="matrix(1 0 0 -1 0 620)">
-		<stop  offset="0" style="stop-color:#60E4E4"/>
-		<stop  offset="0.4171" style="stop-color:#5EE4E4;stop-opacity:0.5829"/>
-		<stop  offset="1" style="stop-color:#9B2AFF;stop-opacity:0"/>
-	</linearGradient>
-	<path class="st56" d="M590.5,341.1c4.1-6.4,10.9-10.7,16.8-15.2c0.3-1.3,0.7-2.5,1.1-3.9c2.9-9.3,8.3-18.1,11.4-27.4
-		c0.7-2.6,2.2-7,2.7-9.6c-2.8,1.3-8,2.2-10.3,1.7c-3.2-0.8-5.6-1.4-9.2,1.9c-4.2,3.9-3.9,8.1-3.5,12.5c0.3,3.9,0.7,8-2.2,11.5
-		c-3.5,4.3-7.1,2.3-9.6,1.1c-3-1.6-5.8-3-10.9,1c-4.5,3.6-4.8,6.3-5,9c-0.4,4.2-1.3,7.4-9.5,9.1c-7.8,1.7-10.9,0.9-13.8-4
-		c-3.8-6.3-8.2-9.6-13.1-8.5c-11.8,2.8-17.2,17.4-18.9,21.3c-7.9,18.2-15.5,24.8-27.4,17.5c-1.8-1.1-6.9-14-18.3,0.8
-		c-21,27.4-33.8,11.9-36.9,27.5c39.4,2.7,119.1-19.7,156.2-45.7C590.2,341.6,590.4,341.4,590.5,341.1z"/>
-	<g>
-		
-			<linearGradient id="SVGID_52_" gradientUnits="userSpaceOnUse" x1="371.6041" y1="147.5419" x2="375.9079" y2="250.833" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#020A47"/>
-			<stop  offset="1" style="stop-color:#4D527B"/>
-		</linearGradient>
-		<path class="st57" d="M329.1,443.6l39-22.9c2.4-1.4,5.4-1.4,7.9,0l40.1,23.2c2,1.1,2.3,3.9,0,5.1l-39.4,22.6
-			c-2.4,1.4-5.4,1.4-7.8,0l-39.8-22.9C327.2,447.5,327.2,444.7,329.1,443.6z"/>
-		<g>
-			<g class="st9">
-				<linearGradient id="SVGID_53_" gradientUnits="userSpaceOnUse" x1="405.6849" y1="494.6311" x2="429.4908" y2="453.3981">
-					<stop  offset="0" style="stop-color:#2A2F62;stop-opacity:0.1"/>
-					<stop  offset="0.3328" style="stop-color:#333768;stop-opacity:0.3995"/>
-					<stop  offset="0.8939" style="stop-color:#494E79;stop-opacity:0.9045"/>
-					<stop  offset="1" style="stop-color:#4E547D"/>
-				</linearGradient>
-				<path class="st58" d="M416.7,448.6c0.7-0.8,1-1.1,1-2V501h-1V448.6z"/>
-			</g>
-			<g class="st59">
-				
-					<linearGradient id="SVGID_54_" gradientUnits="userSpaceOnUse" x1="366.834" y1="143.8865" x2="379.9469" y2="121.1744" gradientTransform="matrix(1 0 0 -1 0 620)">
-					<stop  offset="0" style="stop-color:#4E547D"/>
-					<stop  offset="0.1061" style="stop-color:#494E79;stop-opacity:0.9045"/>
-					<stop  offset="0.6672" style="stop-color:#333768;stop-opacity:0.3995"/>
-					<stop  offset="1" style="stop-color:#2A2F62;stop-opacity:0.1"/>
-				</linearGradient>
-				<polygon class="st60" points="372.9,472.7 373.9,472.6 373.9,502.4 372.9,502.4 				"/>
-			</g>
-		</g>
-		<linearGradient id="SVGID_55_" gradientUnits="userSpaceOnUse" x1="356.14" y1="448.3913" x2="403.3921" y2="441.8791">
-			<stop  offset="0" style="stop-color:#2A2F62;stop-opacity:0.1"/>
-			<stop  offset="1" style="stop-color:#4E547D;stop-opacity:0.7"/>
-		</linearGradient>
-		<path class="st61" d="M372,420.4c1.3,0,2.5,0.3,3.6,0.9l40.1,23.2c0.8,0.4,1.2,1.2,1.2,2c0,0.8-0.4,1.4-1.2,1.8L376.3,471
-			c-1.1,0.6-2.3,0.9-3.5,0.9s-2.5-0.3-3.5-1l-39.8-22.9c-0.7-0.4-1.1-1.2-1.1-2c0-0.8,0.4-1.4,1.1-1.8l39-22.9
-			C369.5,420.7,370.8,420.4,372,420.4 M372,419.7c-1.4,0-2.7,0.4-3.9,1l-39,22.9c-1.9,1.1-1.9,3.9,0,5.1l39.8,22.9
-			c1.2,0.7,2.5,1,3.9,1s2.7-0.4,3.9-1l39.4-22.6c2.3-1.2,2-4,0-5.1L376,420.7C374.8,420,373.4,419.7,372,419.7L372,419.7z"/>
-	</g>
-	
-		<linearGradient id="SVGID_56_" gradientUnits="userSpaceOnUse" x1="407.1801" y1="354.7442" x2="440.5872" y2="358.8072" gradientTransform="matrix(1 0 0 -1 0 620)">
-		<stop  offset="0.2691" style="stop-color:#5EE4E4"/>
-		<stop  offset="0.3452" style="stop-color:#64D9E4"/>
-		<stop  offset="0.4773" style="stop-color:#73BDE4"/>
-		<stop  offset="0.6498" style="stop-color:#8B8FE4"/>
-		<stop  offset="0.8537" style="stop-color:#AC4FE5"/>
-		<stop  offset="0.9472" style="stop-color:#BD30E5"/>
-		<stop  offset="0.9518" style="stop-color:#9B2AFF"/>
-	</linearGradient>
-	<path class="st62" d="M428.1,258.6c-5-2.9-13-2.9-18,0c-4.9,2.9-4.9,7.5,0.1,10.4s13,2.9,18,0C433.1,266.1,433,261.5,428.1,258.6
-		L428.1,258.6z"/>
-	
-		<linearGradient id="SVGID_57_" gradientUnits="userSpaceOnUse" x1="419.1" y1="523.8291" x2="419.1" y2="352.6552" gradientTransform="matrix(1 0 0 -1 0 620)">
-		<stop  offset="0" style="stop-color:#9B2AFF;stop-opacity:0"/>
-		<stop  offset="1" style="stop-color:#5EE4E4"/>
-	</linearGradient>
-	<path class="st63" d="M419.1,265.6c-1.4,0-2.5-1.1-2.5-2.5V98.9c0-1.4,1.1-2.5,2.5-2.5s2.5,1.1,2.5,2.5v164.3
-		C421.6,264.5,420.5,265.6,419.1,265.6z"/>
-	<g>
-		
-			<linearGradient id="SVGID_58_" gradientUnits="userSpaceOnUse" x1="429.6693" y1="308.1605" x2="619.9802" y2="308.1605" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#60E4E4"/>
-			<stop  offset="0.1399" style="stop-color:#5EE4E4;stop-opacity:0.8406"/>
-			<stop  offset="0.3566" style="stop-color:#60E4E4;stop-opacity:0.5935"/>
-			<stop  offset="0.6214" style="stop-color:#5EE4E4;stop-opacity:0.2915"/>
-			<stop  offset="0.8771" style="stop-color:#8C58EB;stop-opacity:0"/>
-		</linearGradient>
-		<path class="st64" d="M436.3,389.8c-1.5,0-3.1-0.1-4.9-0.3c-1.1-0.1-1.9-1.1-1.7-2.2c0.1-1.1,1.2-1.9,2.2-1.7
-			c13.8,1.8,18.5-4.7,23-10.9c1.9-2.6,3.6-5,6-6.7c2.6-1.8,5.4-1.6,8.2-1.3c5.5,0.5,11.1,1,17.8-14.4c1.7-3.9,2.5-7.7,3.3-11.3
-			c1.9-8.6,3.7-16.7,16.7-21.6c10.9-4.2,15.3,4.8,18.8,12.1c3.2,6.6,5.4,10.6,9.9,9.6c5.8-1.3,5.9-2.6,6.2-5.4
-			c0.3-3.1,0.7-7.2,6.6-11.9c7.3-5.8,12.2-3.2,15.4-1.5c2.6,1.4,3.2,1.5,4.4,0c6-7,11.5-5.1,15.8-3.6c3.7,1.3,6.3,2.2,9.6-0.9
-			c3.5-3.3,2.6-6.1,0.8-10.9c-1.5-4-3.5-9.1,0.3-14.2c3.7-5,8.4-4.9,11.2-4.8c0.7,0,1.6,0.1,2,0c0.1-0.3,0.2-1.2-0.5-3.6
-			c-0.9-3.7-2.1-6.8-3.2-9.5c-1.7-4.4-2.9-7.6-1.6-10.2c0.7-1.4,2-2.3,3.9-2.8c3.8-1,8.5-4.4,9.3-7.8c0.4-1.7-0.2-3.2-1.8-4.8
-			c-6.1-5.6-9.4-10.2-6.2-14.5c0.7-0.9,1.9-1.1,2.8-0.4c0.9,0.7,1.1,1.9,0.4,2.8c-0.5,0.7-1.8,2.3,5.7,9.2c3.5,3.2,3.6,6.5,3,8.6
-			c-1.3,5.2-7.2,9.4-12.1,10.7c-0.4,0.1-1.2,0.4-1.4,0.7c-0.5,1,0.7,4,1.8,6.9c1,2.7,2.4,6.1,3.3,10c0.9,3.7,0.8,5.7-0.3,7.1
-			c-1.3,1.6-3.3,1.5-5.2,1.5c-2.7-0.1-5.4-0.2-7.8,3.1c-2.5,3.3-1.2,6.6,0.2,10.4c1.7,4.4,3.8,10-1.8,15.2c-5,4.7-9.8,3-13.6,1.7
-			c-4.2-1.5-7.3-2.5-11.5,2.4c-3.4,4.1-6.9,2.3-9.3,1c-3-1.6-5.8-3.1-11.1,1.1c-4.6,3.6-4.9,6.4-5.1,9.2c-0.4,4.2-1.3,7.2-9.3,9
-			c-7.8,1.7-11.3-5.5-14.4-11.8c-3.9-8-6.6-12.8-13.7-10.1c-11,4.2-12.4,10.3-14.2,18.7c-0.8,3.6-1.7,7.8-3.6,12
-			c-7.8,18-15.9,17.3-21.8,16.8c-2.6-0.2-4.2-0.3-5.5,0.6c-1.8,1.2-3.3,3.4-5,5.7C454.2,382.4,448.9,389.8,436.3,389.8z"/>
-	</g>
-	<g>
-		
-			<linearGradient id="SVGID_59_" gradientUnits="userSpaceOnUse" x1="507.9" y1="297.8191" x2="507.9" y2="237.3066" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#22ADF6"/>
-			<stop  offset="0.3705" style="stop-color:#4C8CF2;stop-opacity:0.5829"/>
-			<stop  offset="0.8883" style="stop-color:#8C58EB;stop-opacity:0"/>
-		</linearGradient>
-		<path class="st65" d="M507.9,325.8c-0.2,0-0.4-0.2-0.4-0.4v-1.6c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v1.6
-			C508.3,325.6,508.1,325.8,507.9,325.8z"/>
-		
-			<linearGradient id="SVGID_60_" gradientUnits="userSpaceOnUse" x1="507.9" y1="297.8191" x2="507.9" y2="237.3066" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#22ADF6"/>
-			<stop  offset="0.3705" style="stop-color:#4C8CF2;stop-opacity:0.5829"/>
-			<stop  offset="0.8883" style="stop-color:#8C58EB;stop-opacity:0"/>
-		</linearGradient>
-		<path class="st66" d="M507.9,371.6c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-			C508.3,371.4,508.1,371.6,507.9,371.6z M507.9,365.1c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-			C508.3,364.9,508.1,365.1,507.9,365.1z M507.9,358.5c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-			C508.3,358.3,508.1,358.5,507.9,358.5z M507.9,352c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-			C508.3,351.8,508.1,352,507.9,352z M507.9,345.4c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-			C508.3,345.2,508.1,345.4,507.9,345.4z M507.9,338.9c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-			C508.3,338.7,508.1,338.9,507.9,338.9z M507.9,332.3c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-			C508.3,332.1,508.1,332.3,507.9,332.3z"/>
-		
-			<linearGradient id="SVGID_61_" gradientUnits="userSpaceOnUse" x1="507.9" y1="297.8191" x2="507.9" y2="237.3066" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#22ADF6"/>
-			<stop  offset="0.3705" style="stop-color:#4C8CF2;stop-opacity:0.5829"/>
-			<stop  offset="0.8883" style="stop-color:#8C58EB;stop-opacity:0"/>
-		</linearGradient>
-		<path class="st67" d="M507.9,376.5c-0.2,0-0.4-0.2-0.4-0.4v-1.6c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v1.6
-			C508.3,376.3,508.1,376.5,507.9,376.5z"/>
-	</g>
-	<g>
-		
-			<linearGradient id="SVGID_62_" gradientUnits="userSpaceOnUse" x1="539.3" y1="275.9297" x2="539.3" y2="215.4171" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#60E4E4"/>
-			<stop  offset="0.3705" style="stop-color:#5EE4E4;stop-opacity:0.5829"/>
-			<stop  offset="0.8883" style="stop-color:#8C58EB;stop-opacity:0"/>
-		</linearGradient>
-		<path class="st68" d="M539.3,347.6c-0.2,0-0.4-0.2-0.4-0.4v-1.6c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v1.6
-			C539.7,347.5,539.5,347.6,539.3,347.6z"/>
-		
-			<linearGradient id="SVGID_63_" gradientUnits="userSpaceOnUse" x1="539.3" y1="272.2856" x2="539.3" y2="248.3087" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#60E4E4"/>
-			<stop  offset="0.3705" style="stop-color:#5EE4E4;stop-opacity:0.5829"/>
-			<stop  offset="0.8883" style="stop-color:#8C58EB;stop-opacity:0"/>
-		</linearGradient>
-		<path class="st69" d="M539.3,367.3c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-			C539.7,367.1,539.5,367.3,539.3,367.3z M539.3,360.8c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-			C539.7,360.6,539.5,360.8,539.3,360.8z M539.3,354.2c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-			C539.7,354,539.5,354.2,539.3,354.2z"/>
-	</g>
-	<g>
-		
-			<radialGradient id="SVGID_64_" cx="255.0289" cy="330.5916" r="33.0391" gradientTransform="matrix(0.604 4.243705e-03 -2.495099e-03 -0.5861 274.2171 580.1904)" gradientUnits="userSpaceOnUse">
-			<stop  offset="0" style="stop-color:#5EE4E4"/>
-			<stop  offset="1" style="stop-color:#5EE4E4;stop-opacity:0"/>
-		</radialGradient>
-		<path class="st70" d="M441.8,373.7c-8-7.6-20.9-7.6-28.8,0s-7.9,20,0.1,27.6s20.9,7.6,28.8,0S449.7,381.3,441.8,373.7L441.8,373.7
-			z"/>
-		
-			<radialGradient id="SVGID_65_" cx="256.6562" cy="352.105" r="8.6663" gradientTransform="matrix(0.604 0 0 -0.5722 272.378 588.9745)" gradientUnits="userSpaceOnUse">
-			<stop  offset="0" style="stop-color:#FFFFFF"/>
-			<stop  offset="1" style="stop-color:#FFFFFF;stop-opacity:0"/>
-		</radialGradient>
-		<path class="st71" d="M431.3,383.8c-2.1-2-5.6-2-7.7,0s-2.1,5.4,0,7.4s5.6,2,7.7,0C433.4,389.2,433.4,385.9,431.3,383.8
-			L431.3,383.8z"/>
-	</g>
-	<g>
-		
-			<radialGradient id="SVGID_66_" cx="507.7496" cy="299.2362" r="7.8404" gradientTransform="matrix(1 0 0 -1 0 620)" gradientUnits="userSpaceOnUse">
-			<stop  offset="0" style="stop-color:#020A47"/>
-			<stop  offset="1" style="stop-color:#5EE4E4"/>
-		</radialGradient>
-		<circle class="st72" cx="507.7" cy="320.8" r="7.8"/>
-		
-			<radialGradient id="SVGID_67_" cx="507.7191" cy="299.2139" r="3.0155" gradientTransform="matrix(1 0 0 -1 0 620)" gradientUnits="userSpaceOnUse">
-			<stop  offset="0" style="stop-color:#020A47"/>
-			<stop  offset="1" style="stop-color:#5EE4E4"/>
-		</radialGradient>
-		<circle class="st73" cx="507.7" cy="320.8" r="3"/>
-		<circle class="st74" cx="507.7" cy="320.8" r="1.2"/>
-	</g>
-	<g class="st75">
-		
-			<linearGradient id="SVGID_68_" gradientUnits="userSpaceOnUse" x1="548.8755" y1="288.85" x2="557.4006" y2="288.85" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#60E4E4"/>
-			<stop  offset="0.4171" style="stop-color:#5EE4E4;stop-opacity:0.5829"/>
-			<stop  offset="1" style="stop-color:#8C58EB;stop-opacity:0"/>
-		</linearGradient>
-		<path class="st76" d="M557.4,329.6V329c0-0.7-0.7-1.1-1.3-0.7l-6.7,3.9c-0.3,0.2-0.5,0.5-0.5,0.9v0.2c0,0.7,0.7,1.1,1.3,0.7
-			l7.1-4.1C557.4,329.8,557.4,329.7,557.4,329.6z"/>
-		
-			<linearGradient id="SVGID_69_" gradientUnits="userSpaceOnUse" x1="549.1816" y1="281.7209" x2="558.5111" y2="281.7209" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#60E4E4"/>
-			<stop  offset="0.4171" style="stop-color:#5EE4E4;stop-opacity:0.5829"/>
-			<stop  offset="1" style="stop-color:#8C58EB;stop-opacity:0"/>
-		</linearGradient>
-		<path class="st77" d="M558.5,336L558.5,336c0-0.7-0.7-1.1-1.3-0.8l-7.5,4.3c-0.4,0.2-0.6,0.6-0.6,1v0.1c0,0.7,0.7,1.1,1.3,0.7
-			l7.5-4.3C558.3,336.8,558.5,336.4,558.5,336z"/>
-		
-			<linearGradient id="SVGID_70_" gradientUnits="userSpaceOnUse" x1="548.9485" y1="286.4" x2="561.9484" y2="286.4" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#60E4E4"/>
-			<stop  offset="0.4171" style="stop-color:#5EE4E4;stop-opacity:0.5829"/>
-			<stop  offset="1" style="stop-color:#8C58EB;stop-opacity:0"/>
-		</linearGradient>
-		<path class="st78" d="M562,330.4v-0.2c0-0.7-0.7-1.1-1.3-0.7l-11.1,6.4c-0.4,0.2-0.6,0.7-0.6,1.1l0,0c0,0.7,0.7,1.1,1.3,0.7
-			l11.2-6.5C561.8,331.1,562,330.8,562,330.4z"/>
-	</g>
-	<g>
-		
-			<linearGradient id="SVGID_71_" gradientUnits="userSpaceOnUse" x1="130.4691" y1="264.9654" x2="625.2853" y2="264.9654" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#5EE4E4;stop-opacity:0.3"/>
-			<stop  offset="0.4022" style="stop-color:#5EE4E4"/>
-			<stop  offset="0.6166" style="stop-color:#5EE4E4;stop-opacity:0.5829"/>
-			<stop  offset="0.9162" style="stop-color:#9B2AFF;stop-opacity:0"/>
-		</linearGradient>
-		<path class="st79" d="M420,432.6c-77.3,0-150-17.4-204.9-49.1c-48-27.7-78.1-64.6-84.6-103.7c-0.2-1.1,0.6-2.1,1.6-2.3
-			c1.1-0.2,2.1,0.6,2.3,1.6c6.3,37.9,35.7,73.8,82.7,100.9c112.1,64.7,293.8,64.7,405.2,0c1-0.6,2.2-0.2,2.7,0.7
-			c0.6,1,0.2,2.2-0.7,2.7C569.8,415.2,497.3,432.6,420,432.6L420,432.6z"/>
-	</g>
-	
-		<linearGradient id="SVGID_72_" gradientUnits="userSpaceOnUse" x1="432.678" y1="232.4128" x2="440.9879" y2="232.4128" gradientTransform="matrix(1 0 0 -1 0 620)">
-		<stop  offset="0" style="stop-color:#22ADF6"/>
-		<stop  offset="0.3705" style="stop-color:#4C8CF2;stop-opacity:0.5829"/>
-		<stop  offset="0.8883" style="stop-color:#8C58EB;stop-opacity:0"/>
-	</linearGradient>
-	<path class="st80" d="M441,387.4c-2.4,0.4-5.1,0.5-8.3,0.2C435.4,387.6,438.2,387.5,441,387.4z"/>
-	<g>
-		
-			<linearGradient id="SVGID_73_" gradientUnits="userSpaceOnUse" x1="480.6" y1="252.3217" x2="480.6" y2="191.8091" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#60E4E4"/>
-			<stop  offset="0.3705" style="stop-color:#5EE4E4;stop-opacity:0.5829"/>
-			<stop  offset="0.8883" style="stop-color:#8C58EB;stop-opacity:0"/>
-		</linearGradient>
-		<path class="st81" d="M480.6,371.3c-0.2,0-0.4-0.2-0.4-0.4v-1.6c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v1.6
-			C481,371.1,480.8,371.3,480.6,371.3z"/>
-		
-			<linearGradient id="SVGID_74_" gradientUnits="userSpaceOnUse" x1="480.6" y1="247.7664" x2="480.6" y2="232.9242" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#60E4E4"/>
-			<stop  offset="0.3705" style="stop-color:#5EE4E4;stop-opacity:0.5829"/>
-			<stop  offset="0.8883" style="stop-color:#8C58EB;stop-opacity:0"/>
-		</linearGradient>
-		<path class="st82" d="M480.6,384.4c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-			C481,384.2,480.8,384.4,480.6,384.4z M480.6,377.8c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-			C481,377.6,480.8,377.8,480.6,377.8z"/>
-	</g>
-	<g class="st83">
-		
-			<linearGradient id="SVGID_75_" gradientUnits="userSpaceOnUse" x1="584.6" y1="297.6081" x2="584.6" y2="237.0955" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#22ADF6"/>
-			<stop  offset="0.3705" style="stop-color:#4C8CF2;stop-opacity:0.5829"/>
-			<stop  offset="0.8883" style="stop-color:#8C58EB;stop-opacity:0"/>
-		</linearGradient>
-		<path class="st84" d="M584.6,326c-0.2,0-0.4-0.2-0.4-0.4V324c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v1.6
-			C585,325.8,584.8,326,584.6,326z"/>
-		
-			<linearGradient id="SVGID_76_" gradientUnits="userSpaceOnUse" x1="584.6" y1="294.8749" x2="584.6" y2="261.7649" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#22ADF6"/>
-			<stop  offset="0.3705" style="stop-color:#4C8CF2;stop-opacity:0.5829"/>
-			<stop  offset="0.8883" style="stop-color:#8C58EB;stop-opacity:0"/>
-		</linearGradient>
-		<path class="st85" d="M584.6,352.2c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-			C585,352,584.8,352.2,584.6,352.2z M584.6,345.6c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-			C585,345.4,584.8,345.6,584.6,345.6z M584.6,339.1c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-			C585,338.9,584.8,339.1,584.6,339.1z M584.6,332.5c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-			C585,332.3,584.8,332.5,584.6,332.5z"/>
-	</g>
-	<g class="st9">
-		
-			<linearGradient id="SVGID_77_" gradientUnits="userSpaceOnUse" x1="563.5" y1="295.4385" x2="563.5" y2="262.3271" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#22ADF6"/>
-			<stop  offset="0.3705" style="stop-color:#4C8CF2;stop-opacity:0.5829"/>
-			<stop  offset="0.8883" style="stop-color:#8C58EB;stop-opacity:0"/>
-		</linearGradient>
-		<path class="st86" d="M563.5,351.6c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-			C563.9,351.4,563.7,351.6,563.5,351.6z M563.5,345.1c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-			C563.9,344.9,563.7,345.1,563.5,345.1z M563.5,338.5c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-			C563.9,338.3,563.7,338.5,563.5,338.5z M563.5,332c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-			C563.9,331.8,563.7,332,563.5,332z"/>
-		
-			<linearGradient id="SVGID_78_" gradientUnits="userSpaceOnUse" x1="563.5" y1="311.274" x2="563.5" y2="250.7615" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#22ADF6"/>
-			<stop  offset="0.3705" style="stop-color:#4C8CF2;stop-opacity:0.5829"/>
-			<stop  offset="0.8883" style="stop-color:#8C58EB;stop-opacity:0"/>
-		</linearGradient>
-		<path class="st87" d="M563.5,363.1c-0.2,0-0.4-0.2-0.4-0.4V361c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v1.6
-			C563.9,362.9,563.7,363.1,563.5,363.1z"/>
-	</g>
-	<g>
-		
-			<linearGradient id="SVGID_79_" gradientUnits="userSpaceOnUse" x1="143.9116" y1="337.1147" x2="449.4266" y2="166.3857" gradientTransform="matrix(1 0 0 -1 0 620)">
-			<stop  offset="0" style="stop-color:#60E4E4;stop-opacity:0.1"/>
-			<stop  offset="0.3743" style="stop-color:#60E4E4"/>
-			<stop  offset="0.6353" style="stop-color:#5EE4E4;stop-opacity:0.5829"/>
-			<stop  offset="1" style="stop-color:#9B2AFF;stop-opacity:0"/>
-		</linearGradient>
-		<path class="st88" d="M494.2,422.7c-95.5,14.8-201.9,0.4-276.9-42.9c-45.8-26.5-74.9-61.2-82.1-98.2c0.3,0,0.7-0.1,1-0.1
-			c0.8,1.6,1.9,2.6,3.1,3.3l0,0c2.5,1.8,5.6,2.2,8.4,2.5c4.4,0.5,9,1.1,12.8,6.3c5.5,7.6,11.1,6.2,15.9,5c4.6-1.2,8.9-2.2,14.6,3.1
-			c6.6,6.1,6,12.5,5.5,19.3c-0.5,5.5-0.9,11.2,3,16c4.2,5.2,8.1,4.6,11.9,4c4.2-0.7,8.9-1.4,17.1,5.2c2.7,2.2,4.2,4.8,5.7,7.6
-			c2.2,3.9,4.5,8,10.2,10.7c1.5,0.8,3.3,1.5,5.5,2c1.7,0.4,3.3,0.5,4.8,0.3c7.8-0.1,12.1-5.6,16.4-10.9c5-6.3,9.8-12.2,20.5-10.8
-			c14.5,2,16.9,9,21.3,21.8c1.3,3.9,2.8,8.2,4.9,12.9c11.2,25.8,22.6,24.8,31,24c3.5-0.3,6.4-0.6,8.7,1.1
-			c14.8,10.3,29.6,14,44.2,10.9c9.9-2.1,20.4-1.7,30.3,1.1c9.8,2.8,22,5.7,32.5,6.7c2.4,0.4,4.7,0.6,6.9,0.6c2,0,3.8-0.1,5.5-0.3
-			C483.1,423,489.1,422.7,494.2,422.7z"/>
-		<g>
-			
-				<linearGradient id="SVGID_80_" gradientUnits="userSpaceOnUse" x1="845.1696" y1="274.7385" x2="1259.2806" y2="274.7385" gradientTransform="matrix(-1 0 0 -1 1358.2036 620)">
-				<stop  offset="0" style="stop-color:#9B2AFF;stop-opacity:0"/>
-				<stop  offset="0.3484" style="stop-color:#5EE4E4;stop-opacity:0.5829"/>
-				<stop  offset="0.5978" style="stop-color:#60E4E4"/>
-				<stop  offset="1" style="stop-color:#60E4E4;stop-opacity:0"/>
-			</linearGradient>
-			<path class="st89" d="M471.2,424.1c-11.5,0-27.3-3.7-39.4-7.1c-10-2.8-20.5-3.2-30.3-1.1c-14.5,3.1-29.4-0.6-44.2-10.9
-				c-2.3-1.6-5.1-1.4-8.7-1.1c-8.3,0.7-19.8,1.7-31-24c-2-4.7-3.5-9.1-4.9-12.9c-4.4-12.8-6.8-19.8-21.3-21.8
-				c-10.7-1.5-15.5,4.5-20.5,10.8s-10.2,12.8-21.2,10.4c-10-2.2-12.9-7.4-15.7-12.5c-1.6-2.8-3-5.4-5.7-7.6
-				c-8.2-6.6-13-5.9-17.1-5.2c-3.7,0.6-7.6,1.2-11.9-4c-3.9-4.8-3.5-10.5-3-16c0.6-6.8,1.1-13.2-5.5-19.3c-5.7-5.3-10-4.2-14.6-3.1
-				c-4.9,1.2-10.4,2.6-15.9-5c-3.8-5.2-8.3-5.7-12.7-6.3c-5.6-0.7-11.9-1.5-13.4-12.7c-0.5-3.6-11.1-3.5-18.8-3.4
-				c-5.8,0.1-11.3,0.1-15-0.9c-1.1-0.3-1.7-1.4-1.4-2.5c0.3-1.1,1.4-1.7,2.5-1.4c3.2,0.9,8.6,0.8,13.9,0.8
-				c10.8-0.1,21.9-0.2,22.8,6.9c1.1,8.2,4.4,8.6,9.9,9.2c4.8,0.6,10.7,1.3,15.5,7.9c4,5.4,7.1,4.6,11.7,3.5c4.9-1.2,11-2.8,18.3,4
-				c8,7.5,7.3,15.5,6.7,22.6c-0.4,5.1-0.8,9.5,2.1,13.1c2.8,3.4,4.7,3.1,8.1,2.6c4.5-0.7,10.7-1.7,20.3,6.1c3.3,2.7,5,5.7,6.7,8.7
-				c2.6,4.7,4.9,8.7,13.1,10.5c8.5,1.9,12.3-2.9,17.2-9c5.2-6.6,11.2-14,24.2-12.2c16.9,2.3,20.1,11.6,24.5,24.5
-				c1.3,3.8,2.8,8.1,4.8,12.6c10.1,23.1,19,22.3,26.9,21.6c3.8-0.3,7.8-0.7,11.3,1.8c13.8,9.7,27.6,13.1,41.1,10.3
-				c10.5-2.2,21.7-1.8,32.2,1.2c13.7,3.9,32.3,8.2,43.2,6.7c19.6-2.7,34.7-0.1,35.4,0c1.1,0.2,1.8,1.2,1.6,2.3
-				c-0.2,1.1-1.2,1.8-2.3,1.6c-0.2,0-15.1-2.6-34.1,0C475,424,473.2,424.1,471.2,424.1z"/>
-		</g>
-		<g>
-			
-				<linearGradient id="SVGID_81_" gradientUnits="userSpaceOnUse" x1="291.4" y1="269.4488" x2="291.4" y2="208.9362" gradientTransform="matrix(1 0 0 -1 0 620)">
-				<stop  offset="0" style="stop-color:#60E4E4"/>
-				<stop  offset="0.3705" style="stop-color:#5EE4E4;stop-opacity:0.5829"/>
-				<stop  offset="0.8883" style="stop-color:#9B2AFF;stop-opacity:0"/>
-			</linearGradient>
-			<path class="st90" d="M291.4,354.1c-0.2,0-0.4-0.2-0.4-0.4v-1.6c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v1.6
-				C291.8,353.9,291.6,354.1,291.4,354.1z"/>
-			
-				<linearGradient id="SVGID_82_" gradientUnits="userSpaceOnUse" x1="291.4" y1="269.4488" x2="291.4" y2="208.9362" gradientTransform="matrix(1 0 0 -1 0 620)">
-				<stop  offset="0" style="stop-color:#60E4E4"/>
-				<stop  offset="0.3705" style="stop-color:#5EE4E4;stop-opacity:0.5829"/>
-				<stop  offset="0.8883" style="stop-color:#9B2AFF;stop-opacity:0"/>
-			</linearGradient>
-			<path class="st91" d="M291.4,400c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-				C291.8,399.8,291.6,400,291.4,400z M291.4,393.4c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-				C291.8,393.3,291.6,393.4,291.4,393.4z M291.4,386.9c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-				C291.8,386.7,291.6,386.9,291.4,386.9z M291.4,380.3c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-				C291.8,380.2,291.6,380.3,291.4,380.3z M291.4,373.8c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-				C291.8,373.6,291.6,373.8,291.4,373.8z M291.4,367.2c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-				C291.8,367,291.6,367.2,291.4,367.2z M291.4,360.7c-0.2,0-0.4-0.2-0.4-0.4V357c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-				C291.8,360.5,291.6,360.7,291.4,360.7z"/>
-			
-				<linearGradient id="SVGID_83_" gradientUnits="userSpaceOnUse" x1="291.4" y1="269.4488" x2="291.4" y2="208.9362" gradientTransform="matrix(1 0 0 -1 0 620)">
-				<stop  offset="0" style="stop-color:#60E4E4"/>
-				<stop  offset="0.3705" style="stop-color:#5EE4E4;stop-opacity:0.5829"/>
-				<stop  offset="0.8883" style="stop-color:#9B2AFF;stop-opacity:0"/>
-			</linearGradient>
-			<path class="st92" d="M291.4,404.9c-0.2,0-0.4-0.2-0.4-0.4v-1.6c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v1.6
-				C291.8,404.7,291.6,404.9,291.4,404.9z"/>
-		</g>
-		<g>
-			
-				<linearGradient id="SVGID_84_" gradientUnits="userSpaceOnUse" x1="202.6" y1="280.0618" x2="202.6" y2="219.5493" gradientTransform="matrix(1 0 0 -1 0 620)">
-				<stop  offset="0" style="stop-color:#60E4E4"/>
-				<stop  offset="0.3705" style="stop-color:#5EE4E4;stop-opacity:0.5829"/>
-				<stop  offset="0.8883" style="stop-color:#9B2AFF;stop-opacity:0"/>
-			</linearGradient>
-			<path class="st93" d="M202.6,343.5c-0.2,0-0.4-0.2-0.4-0.4v-1.6c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v1.6
-				C203,343.3,202.8,343.5,202.6,343.5z"/>
-			
-				<linearGradient id="SVGID_85_" gradientUnits="userSpaceOnUse" x1="202.6" y1="280.0618" x2="202.6" y2="219.5493" gradientTransform="matrix(1 0 0 -1 0 620)">
-				<stop  offset="0" style="stop-color:#60E4E4"/>
-				<stop  offset="0.3705" style="stop-color:#5EE4E4;stop-opacity:0.5829"/>
-				<stop  offset="0.8883" style="stop-color:#9B2AFF;stop-opacity:0"/>
-			</linearGradient>
-			<path class="st94" d="M202.6,389.4c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-				C203,389.2,202.8,389.4,202.6,389.4z M202.6,382.8c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-				C203,382.6,202.8,382.8,202.6,382.8z M202.6,376.3c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-				C203,376.1,202.8,376.3,202.6,376.3z M202.6,369.7c-0.2,0-0.4-0.2-0.4-0.4V366c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-				C203,369.5,202.8,369.7,202.6,369.7z M202.6,363.2c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-				C203,363,202.8,363.2,202.6,363.2z M202.6,356.6c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-				C203,356.4,202.8,356.6,202.6,356.6z M202.6,350.1c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-				C203,349.9,202.8,350.1,202.6,350.1z"/>
-			
-				<linearGradient id="SVGID_86_" gradientUnits="userSpaceOnUse" x1="202.6" y1="280.0618" x2="202.6" y2="219.5493" gradientTransform="matrix(1 0 0 -1 0 620)">
-				<stop  offset="0" style="stop-color:#60E4E4"/>
-				<stop  offset="0.3705" style="stop-color:#5EE4E4;stop-opacity:0.5829"/>
-				<stop  offset="0.8883" style="stop-color:#9B2AFF;stop-opacity:0"/>
-			</linearGradient>
-			<path class="st95" d="M202.6,394.3c-0.2,0-0.4-0.2-0.4-0.4v-1.6c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v1.6
-				C203,394.1,202.8,394.3,202.6,394.3z"/>
-		</g>
-		<g>
-			
-				<linearGradient id="SVGID_87_" gradientUnits="userSpaceOnUse" x1="246.6" y1="255.2176" x2="246.6" y2="194.705" gradientTransform="matrix(1 0 0 -1 0 620)">
-				<stop  offset="0" style="stop-color:#60E4E4"/>
-				<stop  offset="0.3705" style="stop-color:#5EE4E4;stop-opacity:0.5829"/>
-				<stop  offset="0.8883" style="stop-color:#9B2AFF;stop-opacity:0"/>
-			</linearGradient>
-			<path class="st96" d="M246.6,368.4c-0.2,0-0.4-0.2-0.4-0.4v-1.6c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v1.6
-				C247,368.2,246.9,368.4,246.6,368.4z"/>
-			
-				<linearGradient id="SVGID_88_" gradientUnits="userSpaceOnUse" x1="246.6" y1="252.4845" x2="246.6" y2="219.3744" gradientTransform="matrix(1 0 0 -1 0 620)">
-				<stop  offset="0" style="stop-color:#60E4E4"/>
-				<stop  offset="0.3705" style="stop-color:#5EE4E4;stop-opacity:0.5829"/>
-				<stop  offset="0.8883" style="stop-color:#9B2AFF;stop-opacity:0"/>
-			</linearGradient>
-			<path class="st97" d="M246.6,394.6c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-				C247,394.4,246.9,394.6,246.6,394.6z M246.6,388c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-				C247,387.8,246.9,388,246.6,388z M246.6,381.5c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-				C247,381.3,246.9,381.5,246.6,381.5z M246.6,374.9c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-				C247,374.7,246.9,374.9,246.6,374.9z"/>
-		</g>
-		<g>
-			
-				<linearGradient id="SVGID_89_" gradientUnits="userSpaceOnUse" x1="331" y1="219.8549" x2="331" y2="195.8781" gradientTransform="matrix(1 0 0 -1 0 620)">
-				<stop  offset="0" style="stop-color:#60E4E4"/>
-				<stop  offset="0.3705" style="stop-color:#5EE4E4;stop-opacity:0.5829"/>
-				<stop  offset="0.8883" style="stop-color:#9B2AFF;stop-opacity:0"/>
-			</linearGradient>
-			<path class="st98" d="M331,419.7c-0.2,0-0.4-0.2-0.4-0.4V416c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-				C331.4,419.6,331.2,419.7,331,419.7z M331,413.2c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-				C331.4,413,331.2,413.2,331,413.2z M331,406.6c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-				C331.4,406.4,331.2,406.6,331,406.6z"/>
-		</g>
-		<g class="st75">
-			
-				<linearGradient id="SVGID_90_" gradientUnits="userSpaceOnUse" x1="609.4928" y1="242.55" x2="617.6382" y2="242.55" gradientTransform="matrix(-1 0 0 -1 875.3781 620)">
-				<stop  offset="0" style="stop-color:#9B2AFF;stop-opacity:0"/>
-				<stop  offset="0.5829" style="stop-color:#5EE4E4;stop-opacity:0.5829"/>
-				<stop  offset="1" style="stop-color:#60E4E4"/>
-			</linearGradient>
-			<path class="st99" d="M257.7,375.7v-0.2c0-0.7,0.8-1.2,1.4-0.8l6.1,3.5c0.4,0.2,0.7,0.7,0.7,1.2l0,0c0,0.7-0.8,1.2-1.4,0.8
-				l-6.2-3.6C257.9,376.5,257.7,376.1,257.7,375.7z"/>
-			
-				<linearGradient id="SVGID_91_" gradientUnits="userSpaceOnUse" x1="603.4781" y1="236.5" x2="617.6456" y2="236.5" gradientTransform="matrix(-1 0 0 -1 875.3781 620)">
-				<stop  offset="0" style="stop-color:#9B2AFF;stop-opacity:0"/>
-				<stop  offset="0.5829" style="stop-color:#5EE4E4;stop-opacity:0.5829"/>
-				<stop  offset="1" style="stop-color:#60E4E4"/>
-			</linearGradient>
-			<path class="st100" d="M257.7,380v-0.2c0-0.7,0.8-1.2,1.4-0.8l12.1,7c0.4,0.2,0.7,0.7,0.7,1.2l0,0c0,0.7-0.8,1.2-1.4,0.8l-12.2-7
-				C257.9,380.7,257.7,380.4,257.7,380z"/>
-			
-				<linearGradient id="SVGID_92_" gradientUnits="userSpaceOnUse" x1="608.5781" y1="234.1" x2="617.6361" y2="234.1" gradientTransform="matrix(-1 0 0 -1 875.3781 620)">
-				<stop  offset="0" style="stop-color:#9B2AFF;stop-opacity:0"/>
-				<stop  offset="0.5829" style="stop-color:#5EE4E4;stop-opacity:0.5829"/>
-				<stop  offset="1" style="stop-color:#60E4E4"/>
-			</linearGradient>
-			<path class="st101" d="M257.7,383.9v-0.2c0-0.7,0.8-1.2,1.4-0.8l7,4c0.4,0.2,0.7,0.7,0.7,1.2l0,0c0,0.7-0.8,1.2-1.4,0.8l-7.1-4.1
-				C257.9,384.7,257.7,384.3,257.7,383.9z"/>
-		</g>
-		<g class="st102">
-			
-				<linearGradient id="SVGID_93_" gradientUnits="userSpaceOnUse" x1="167.8" y1="321.6497" x2="167.8" y2="261.1372" gradientTransform="matrix(1 0 0 -1 0 620)">
-				<stop  offset="0" style="stop-color:#60E4E4"/>
-				<stop  offset="0.3705" style="stop-color:#5EE4E4;stop-opacity:0.5829"/>
-				<stop  offset="0.8883" style="stop-color:#9B2AFF;stop-opacity:0"/>
-			</linearGradient>
-			<path class="st103" d="M167.8,301.9c-0.2,0-0.4-0.2-0.4-0.4v-1.6c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v1.6
-				C168.2,301.7,168,301.9,167.8,301.9z"/>
-			
-				<linearGradient id="SVGID_94_" gradientUnits="userSpaceOnUse" x1="167.8" y1="321.6497" x2="167.8" y2="261.1372" gradientTransform="matrix(1 0 0 -1 0 620)">
-				<stop  offset="0" style="stop-color:#60E4E4"/>
-				<stop  offset="0.3705" style="stop-color:#5EE4E4;stop-opacity:0.5829"/>
-				<stop  offset="0.8883" style="stop-color:#9B2AFF;stop-opacity:0"/>
-			</linearGradient>
-			<path class="st104" d="M167.8,347.8c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-				C168.2,347.6,168,347.8,167.8,347.8z M167.8,341.2c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-				C168.2,341.1,168,341.2,167.8,341.2z M167.8,334.7c-0.2,0-0.4-0.2-0.4-0.4V331c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-				C168.2,334.5,168,334.7,167.8,334.7z M167.8,328.1c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-				C168.2,328,168,328.1,167.8,328.1z M167.8,321.6c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-				C168.2,321.4,168,321.6,167.8,321.6z M167.8,315c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-				C168.2,314.8,168,315,167.8,315z M167.8,308.5c-0.2,0-0.4-0.2-0.4-0.4v-3.3c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v3.3
-				C168.2,308.3,168,308.5,167.8,308.5z"/>
-			
-				<linearGradient id="SVGID_95_" gradientUnits="userSpaceOnUse" x1="167.8" y1="321.6497" x2="167.8" y2="261.1372" gradientTransform="matrix(1 0 0 -1 0 620)">
-				<stop  offset="0" style="stop-color:#60E4E4"/>
-				<stop  offset="0.3705" style="stop-color:#5EE4E4;stop-opacity:0.5829"/>
-				<stop  offset="0.8883" style="stop-color:#9B2AFF;stop-opacity:0"/>
-			</linearGradient>
-			<path class="st105" d="M167.8,352.7c-0.2,0-0.4-0.2-0.4-0.4v-1.6c0-0.2,0.2-0.4,0.4-0.4s0.4,0.2,0.4,0.4v1.6
-				C168.2,352.5,168,352.7,167.8,352.7z"/>
-		</g>
-	</g>
-	<g>
-		<g>
-			<polygon class="st24" points="741.1,342.1 741.1,535 701.7,535.2 658,535.2 658.2,390.2 658.2,389.6 658.4,389.4 740.8,342.2 			
-				"/>
-			
-				<linearGradient id="SVGID_96_" gradientUnits="userSpaceOnUse" x1="611.3514" y1="290.0057" x2="620.0836" y2="95.7141" gradientTransform="matrix(1 0 0 -1 0 620)">
-				<stop  offset="0" style="stop-color:#4E547D"/>
-				<stop  offset="9.419907e-02" style="stop-color:#494E79"/>
-				<stop  offset="0.4271" style="stop-color:#141B54"/>
-				<stop  offset="0.7372" style="stop-color:#070F4B"/>
-				<stop  offset="1" style="stop-color:#020A47"/>
-			</linearGradient>
-			<polygon class="st106" points="658.5,389.5 658.5,535.2 576.1,535.2 576.2,344.1 576.2,342.3 658.4,389.4 			"/>
-			
-				<linearGradient id="SVGID_97_" gradientUnits="userSpaceOnUse" x1="541.0029" y1="289.8982" x2="594.3493" y2="197.4312" gradientTransform="matrix(1 0 0 -1 0 620)">
-				<stop  offset="0" style="stop-color:#9550EA;stop-opacity:0.3"/>
-				<stop  offset="1" style="stop-color:#9550EA;stop-opacity:0"/>
-			</linearGradient>
-			<polygon class="st107" points="658.5,389.5 658.5,535.2 576.1,535.2 576.2,344.1 576.2,342.3 658.4,389.4 			"/>
-			
-				<linearGradient id="SVGID_98_" gradientUnits="userSpaceOnUse" x1="575.5995" y1="278.4438" x2="768.9365" y2="278.4438" gradientTransform="matrix(1 0 0 -1 0 620)">
-				<stop  offset="0" style="stop-color:#4D527B"/>
-				<stop  offset="1" style="stop-color:#020A47"/>
-			</linearGradient>
-			<path class="st108" d="M578.2,336.9l71.7-42.1c4.5-2.6,10-2.6,14.5-0.1l73.8,42.7c3.6,2.1,3.6,7.3,0,9.4l-72.4,41.6
-				c-4.4,2.5-9.9,2.5-14.3,0l-73.1-42.1C574.7,344.2,574.7,339,578.2,336.9z"/>
-		</g>
-		<g class="st9">
-			<linearGradient id="SVGID_99_" gradientUnits="userSpaceOnUse" x1="711.16" y1="463.9473" x2="770.59" y2="361.0119">
-				<stop  offset="0" style="stop-color:#2A2F62;stop-opacity:0.1"/>
-				<stop  offset="0.3328" style="stop-color:#333768;stop-opacity:0.3995"/>
-				<stop  offset="0.8939" style="stop-color:#494E79;stop-opacity:0.9045"/>
-				<stop  offset="1" style="stop-color:#4E547D"/>
-			</linearGradient>
-			<path class="st109" d="M741,343.9v136.7h-1V345.8C740.5,345.2,740.8,344.6,741,343.9z"/>
-		</g>
-		<g class="st9">
-			<linearGradient id="SVGID_100_" gradientUnits="userSpaceOnUse" x1="629.0207" y1="509.1246" x2="687.775" y2="407.3591">
-				<stop  offset="0" style="stop-color:#2A2F62;stop-opacity:0.1"/>
-				<stop  offset="0.3328" style="stop-color:#333768;stop-opacity:0.3995"/>
-				<stop  offset="0.8939" style="stop-color:#494E79;stop-opacity:0.9045"/>
-				<stop  offset="1" style="stop-color:#4E547D"/>
-			</linearGradient>
-			<path class="st110" d="M658.9,390.7v135.1h-1V390.7c0.2,0,0.4,0,0.6,0C658.6,390.7,658.8,390.7,658.9,390.7z"/>
-		</g>
-		<g class="st9">
-			<linearGradient id="SVGID_101_" gradientUnits="userSpaceOnUse" x1="546.2739" y1="462.9821" x2="605.2762" y2="360.7871">
-				<stop  offset="0" style="stop-color:#2A2F62;stop-opacity:0.1"/>
-				<stop  offset="0.3328" style="stop-color:#333768;stop-opacity:0.3995"/>
-				<stop  offset="0.8939" style="stop-color:#494E79;stop-opacity:0.9045"/>
-				<stop  offset="1" style="stop-color:#4E547D"/>
-			</linearGradient>
-			<path class="st111" d="M576.4,345.3v134.5h-1V343.5C575.6,344.2,576,344.8,576.4,345.3z"/>
-		</g>
-		<g class="st9">
-			
-				<linearGradient id="SVGID_102_" gradientUnits="userSpaceOnUse" x1="635.4987" y1="317.459" x2="680.5369" y2="239.4504" gradientTransform="matrix(1 0 0 -1 0 620)">
-				<stop  offset="0" style="stop-color:#4E547D"/>
-				<stop  offset="1" style="stop-color:#4E547D"/>
-			</linearGradient>
-			<path class="st112" d="M658.5,390.7c-2.6,0-5.1-0.7-7.4-2l-73.1-42c-1.8-1.1-2.9-3-3-5.1s1.1-4,2.9-5.1l71.7-42.1
-				c4.6-2.7,10.4-2.7,15-0.1l73.8,42.7c1.8,1.1,2.9,3,2.9,5.1s-1.1,4-3,5.1l-72.4,41.6C663.7,390.1,661.1,390.7,658.5,390.7z
-				 M578.5,337.4c-1.5,0.9-2.4,2.5-2.4,4.3s0.9,3.3,2.5,4.2l73.1,42.1c4.3,2.5,9.6,2.5,13.8,0l72.4-41.6c1.5-0.9,2.5-2.5,2.5-4.2
-				s-0.9-3.4-2.4-4.3l-73.8-42.7c-4.3-2.5-9.7-2.5-14,0L578.5,337.4z"/>
-		</g>
-	</g>
-	<g>
-		<g>
-			<polygon class="st24" points="27.5,265.2 27.5,535.2 83.2,535.2 83,297 			"/>
-			
-				<linearGradient id="SVGID_103_" gradientUnits="userSpaceOnUse" x1="599.4559" y1="219.9603" x2="545.1846" y2="384.2217" gradientTransform="matrix(-1 0 0 -1 696.9904 620)">
-				<stop  offset="0" style="stop-color:#020A47"/>
-				<stop  offset="1" style="stop-color:#2C3164"/>
-			</linearGradient>
-			<polygon class="st113" points="138,265.3 138,425.3 82.8,458.5 82.8,296.9 			"/>
-			
-				<linearGradient id="SVGID_104_" gradientUnits="userSpaceOnUse" x1="558.5904" y1="355.1875" x2="669.2904" y2="355.1875" gradientTransform="matrix(-1 0 0 -1 696.9904 620)">
-				<stop  offset="0" style="stop-color:#111952"/>
-				<stop  offset="1" style="stop-color:#020A47"/>
-			</linearGradient>
-			<path class="st114" d="M136.6,261.7l-48-28.2c-3-1.8-6.7-1.8-9.7,0l-49.4,28.6c-2.4,1.4-2.4,4.9,0,6.3L78,296.2
-				c3,1.7,6.6,1.7,9.6,0l49-28.2C139,266.6,139,263.1,136.6,261.7z"/>
-		</g>
-		<g>
-			<g class="st9">
-				
-					<linearGradient id="SVGID_105_" gradientUnits="userSpaceOnUse" x1="1358.4846" y1="381.4441" x2="1388.8345" y2="328.8765" gradientTransform="matrix(1 0 0 -1 -1290.9347 620)">
-					<stop  offset="0" style="stop-color:#2A2F62;stop-opacity:0.1"/>
-					<stop  offset="0.3328" style="stop-color:#333768;stop-opacity:0.3995"/>
-					<stop  offset="0.8939" style="stop-color:#494E79;stop-opacity:0.9045"/>
-					<stop  offset="1" style="stop-color:#4E547D"/>
-				</linearGradient>
-				<path class="st115" d="M83.2,297.9c-1.7,0-3.5-0.4-5.1-1.3l-49-28.2c-1.3-0.7-2.1-2.1-2.1-3.5c0-1.5,0.8-2.8,2-3.6l48-28.2
-					c3.1-1.8,7.1-1.9,10.2,0l49.4,28.6c1.3,0.7,2.1,2.1,2.1,3.6s-0.8,2.8-2.1,3.6l-48.5,27.8C86.6,297.5,84.9,297.9,83.2,297.9z
-					 M29.6,262.1c-1,0.6-1.5,1.6-1.5,2.7s0.6,2.1,1.6,2.7l49,28.2c2.8,1.6,6.3,1.6,9.1,0l48.5-27.8c1-0.6,1.6-1.6,1.6-2.7
-					s-0.6-2.1-1.6-2.7l-49.4-28.6c-2.8-1.6-6.4-1.6-9.2,0L29.6,262.1z"/>
-			</g>
-			<g class="st9">
-				
-					<linearGradient id="SVGID_106_" gradientUnits="userSpaceOnUse" x1="132.2023" y1="349.9883" x2="144.2303" y2="329.1553" gradientTransform="matrix(1 0 0 -1 0 620)">
-					<stop  offset="0" style="stop-color:#4E547D"/>
-					<stop  offset="0.2966" style="stop-color:#4B507A;stop-opacity:0.7331"/>
-					<stop  offset="0.6311" style="stop-color:#3D4370;stop-opacity:0.432"/>
-					<stop  offset="0.9829" style="stop-color:#2A2F62;stop-opacity:0.1154"/>
-					<stop  offset="1" style="stop-color:#2A2F62;stop-opacity:0.1"/>
-				</linearGradient>
-				<rect x="137.7" y="266.8" class="st116" width="1" height="27.2"/>
-			</g>
-		</g>
-	</g>
-	<g>
-		<g>
-			<polygon class="st24" points="145,535.2 62.4,535.2 62.4,369.8 62.7,369.9 63.4,370.4 144.4,416.8 144.6,416.9 144.8,417 
-				144.8,417.7 			"/>
-			
-				<linearGradient id="SVGID_107_" gradientUnits="userSpaceOnUse" x1="243.9653" y1="330.5707" x2="186.3864" y2="146.7792" gradientTransform="matrix(1 0 0 -1 0 620)">
-				<stop  offset="0" style="stop-color:#484D79"/>
-				<stop  offset="0.2454" style="stop-color:#3B416F"/>
-				<stop  offset="0.7167" style="stop-color:#0A114D"/>
-				<stop  offset="1" style="stop-color:#020A47"/>
-			</linearGradient>
-			<polygon class="st117" points="226.5,535.2 144.5,535.2 144.5,416.9 144.6,416.9 144.8,416.8 226.3,370.1 226.3,370.1 
-				226.4,370.1 226.4,371.8 			"/>
-			
-				<linearGradient id="SVGID_108_" gradientUnits="userSpaceOnUse" x1="150.0783" y1="228.6608" x2="186.8223" y2="164.9713" gradientTransform="matrix(1 0 0 -1 0 620)">
-				<stop  offset="0" style="stop-color:#5EE4E4;stop-opacity:0.3"/>
-				<stop  offset="1" style="stop-color:#5EE4E4;stop-opacity:0"/>
-			</linearGradient>
-			<polygon class="st118" points="226.5,535.2 226.4,371.8 226.4,370.1 226.3,370.1 226.3,370.1 144.8,416.8 144.6,416.9 
-				144.5,416.9 144.5,417.7 144.5,535.2 145,535.2 			"/>
-			
-				<linearGradient id="SVGID_109_" gradientUnits="userSpaceOnUse" x1="232.7358" y1="279.9435" x2="64.4033" y2="223.8327" gradientTransform="matrix(1 0 0 -1 0 620)">
-				<stop  offset="0" style="stop-color:#464B77"/>
-				<stop  offset="1" style="stop-color:#020A47"/>
-			</linearGradient>
-			<path class="st119" d="M224.4,364.7l-71.3-41.9c-4.4-2.6-9.9-2.6-14.4-0.1l-73.4,42.5c-3.6,2.1-3.6,7.2,0,9.3l72,41.3
-				c4.4,2.5,9.8,2.5,14.3,0l72.7-41.8C227.9,371.9,227.9,366.8,224.4,364.7z"/>
-			<g class="st9">
-				
-					<linearGradient id="SVGID_110_" gradientUnits="userSpaceOnUse" x1="122.7967" y1="288.7341" x2="166.9072" y2="212.3324" gradientTransform="matrix(1 0 0 -1 0 620)">
-					<stop  offset="0" style="stop-color:#484D79;stop-opacity:0"/>
-					<stop  offset="1" style="stop-color:#484D79"/>
-				</linearGradient>
-				<path class="st120" d="M144.5,418.2c-2.5,0-5.1-0.7-7.4-2l-72-41.3c-1.8-1.1-2.9-3-2.9-5.1s1.1-4,2.9-5.1l73.4-42.5
-					c4.6-2.7,10.3-2.6,14.9,0.1l71.3,41.9c1.8,1.1,2.9,3,2.9,5.1s-1.1,4-2.9,5L152,416.1C149.6,417.5,147.1,418.2,144.5,418.2z
-					 M145.9,321.3c-2.4,0-4.8,0.6-6.9,1.9l-73.4,42.5c-1.5,0.9-2.4,2.5-2.4,4.2s0.9,3.3,2.5,4.2l72,41.3c4.2,2.4,9.5,2.4,13.8,0
-					l72.7-41.8c1.5-0.9,2.4-2.5,2.4-4.2c0-1.8-0.9-3.3-2.4-4.2l-71.3-41.9C150.7,321.9,148.3,321.3,145.9,321.3z"/>
-			</g>
-		</g>
-		<g class="st9">
-			<linearGradient id="SVGID_111_" gradientUnits="userSpaceOnUse" x1="34.3426" y1="484.9146" x2="90.8199" y2="387.093">
-				<stop  offset="0" style="stop-color:#23295D;stop-opacity:0.1"/>
-				<stop  offset="0.3328" style="stop-color:#2C3263;stop-opacity:0.3995"/>
-				<stop  offset="0.8939" style="stop-color:#424774;stop-opacity:0.9045"/>
-				<stop  offset="1" style="stop-color:#484D79"/>
-			</linearGradient>
-			<path class="st121" d="M63.2,373.1V501h-1V370.6h0C62.4,371.5,62.7,372.3,63.2,373.1z"/>
-		</g>
-		<g class="st9">
-			<linearGradient id="SVGID_112_" gradientUnits="userSpaceOnUse" x1="119.0394" y1="520.7871" x2="169.9606" y2="432.5891">
-				<stop  offset="0" style="stop-color:#23295D;stop-opacity:0.1"/>
-				<stop  offset="0.3328" style="stop-color:#2C3263;stop-opacity:0.3995"/>
-				<stop  offset="0.8939" style="stop-color:#424774;stop-opacity:0.9045"/>
-				<stop  offset="1" style="stop-color:#484D79"/>
-			</linearGradient>
-			<path class="st122" d="M145,418.2v117h-1v-117c0.2,0,0.3,0,0.5,0S144.8,418.2,145,418.2z"/>
-		</g>
-		<g class="st9">
-			<linearGradient id="SVGID_113_" gradientUnits="userSpaceOnUse" x1="199.1903" y1="482.935" x2="254.1289" y2="387.7787">
-				<stop  offset="0" style="stop-color:#23295D;stop-opacity:0.1"/>
-				<stop  offset="0.3328" style="stop-color:#2C3263;stop-opacity:0.3995"/>
-				<stop  offset="0.8939" style="stop-color:#424774;stop-opacity:0.9045"/>
-				<stop  offset="1" style="stop-color:#484D79"/>
-			</linearGradient>
-			<path class="st123" d="M226.9,372.1v126.2h-1.1V373.5C226.3,373.1,226.6,372.6,226.9,372.1z"/>
-		</g>
-	</g>
-	<g>
-		
-			<radialGradient id="SVGID_114_" cx="1128.5707" cy="390.0894" r="44.6033" gradientTransform="matrix(-0.6081 4.243705e-03 2.512137e-03 -0.5861 976.1116 567.0577)" gradientUnits="userSpaceOnUse">
-			<stop  offset="0" style="stop-color:#5EE4E4"/>
-			<stop  offset="1" style="stop-color:#5EE4E4;stop-opacity:0"/>
-		</radialGradient>
-		<path class="st124" d="M271.3,324.6c10.8-10.3,28.3-10.3,39.1,0c10.8,10.3,10.7,27-0.1,37.2c-10.8,10.3-28.3,10.3-39.1,0
-			C260.4,351.6,260.5,334.9,271.3,324.6L271.3,324.6z"/>
-		
-			<radialGradient id="SVGID_115_" cx="1130.3163" cy="396.4079" r="11.6829" gradientTransform="matrix(-0.6081 0 0 -0.5722 978.1663 570.0246)" gradientUnits="userSpaceOnUse">
-			<stop  offset="0" style="stop-color:#FFFFFF"/>
-			<stop  offset="1" style="stop-color:#FFFFFF;stop-opacity:0"/>
-		</radialGradient>
-		<path class="st125" d="M285.6,338.2c2.9-2.8,7.6-2.8,10.5,0s2.9,7.2,0,10s-7.6,2.8-10.5,0C282.7,345.5,282.7,341,285.6,338.2
-			L285.6,338.2z"/>
-	</g>
-	<path class="st126" d="M226.5,535.2L226.5,535.2L226.5,535.2z"/>
-	<g>
-		<linearGradient id="SVGID_116_" gradientUnits="userSpaceOnUse" x1="279.7" y1="268.3031" x2="282.6342" y2="268.3031">
-			<stop  offset="0" style="stop-color:#60E4E4"/>
-			<stop  offset="0.4171" style="stop-color:#5EE4E4;stop-opacity:0.5829"/>
-			<stop  offset="1" style="stop-color:#8C58EB;stop-opacity:0"/>
-		</linearGradient>
-		<path class="st127" d="M282.6,268.8c-0.2-0.6-0.5-0.6-1-0.6h-0.1c-0.6,0-1.2-0.1-1.8-0.3c0,0,0-0.1,0-0.1c0.5,0.2,1.1,0.3,1.8,0.3
-			h0.1C282.1,268.1,282.4,268.1,282.6,268.8z"/>
-		<linearGradient id="SVGID_117_" gradientUnits="userSpaceOnUse" x1="282.87" y1="271.0381" x2="283.4008" y2="271.0381">
-			<stop  offset="0" style="stop-color:#60E4E4"/>
-			<stop  offset="0.4171" style="stop-color:#5EE4E4;stop-opacity:0.5829"/>
-			<stop  offset="1" style="stop-color:#8C58EB;stop-opacity:0"/>
-		</linearGradient>
-		<path class="st128" d="M283.2,271.3c0.1,0.4,0.1,0.8,0.2,1.2C283.3,272.1,283.3,271.7,283.2,271.3c-0.1-0.7-0.2-1.3-0.3-1.7
-			C283,270,283.1,270.6,283.2,271.3z"/>
-	</g>
-	<g class="st129">
-		
-			<radialGradient id="SVGID_118_" cx="204.1531" cy="535.9681" r="23.4412" gradientTransform="matrix(0.6134 4.243705e-03 -2.534169e-03 -0.5861 245.2107 495.4857)" gradientUnits="userSpaceOnUse">
-			<stop  offset="0" style="stop-color:#5EE4E4"/>
-			<stop  offset="1" style="stop-color:#5EE4E4;stop-opacity:0"/>
-		</radialGradient>
-		<path class="st130" d="M379.4,172.4c-5.7-5.4-15-5.4-20.7,0s-5.7,14.2,0.1,19.6c5.7,5.4,15,5.4,20.7,0
-			C385.2,186.5,385.1,177.8,379.4,172.4L379.4,172.4z"/>
-		
-			<radialGradient id="SVGID_119_" cx="205.8011" cy="557.4621" r="6.1399" gradientTransform="matrix(0.6134 0 0 -0.5722 242.824 501.1298)" gradientUnits="userSpaceOnUse">
-			<stop  offset="0" style="stop-color:#FFFFFF"/>
-			<stop  offset="1" style="stop-color:#FFFFFF;stop-opacity:0"/>
-		</radialGradient>
-		<path class="st131" d="M371.8,179.5c-1.5-1.5-4-1.5-5.6,0c-1.5,1.5-1.5,3.8,0,5.3s4,1.5,5.6,0S373.4,181,371.8,179.5L371.8,179.5z
-			"/>
-	</g>
+<g opacity="0.65">
+<g opacity="0.6">
+<path opacity="0.6" d="M645.2 84.5001C645.2 84.2001 645 84.0001 644.7 84.0001C644.4 84.0001 644.2 84.2001 644.2 84.5001V138.7C644.2 139 644.4 139.2 644.7 139.2C645 139.2 645.2 139 645.2 138.7" fill="url(#paint6_linear_606_12100)"/>
 </g>
+<g opacity="0.6">
+<path opacity="0.6" d="M710.2 124.2L647 87.9C645.4 87 644.4 85.3 644.4 83.4C644.4 81.5 645.4 79.8 647 78.9L711.5 41.6C715.6 39.2 720.6 39.3 724.7 41.6L787.3 78.4C788.9 79.4 789.9 81 789.9 82.9C789.9 84.8 788.9 86.5 787.3 87.4L723.4 124.2C721.4 125.4 719.1 125.9 716.9 125.9C714.5 125.9 712.3 125.3 710.2 124.2ZM724.1 42.4C720.4 40.2 715.7 40.2 711.9 42.4L647.4 79.7C646.1 80.5 645.3 81.8 645.3 83.4C645.3 84.9 646.1 86.3 647.4 87.1L710.7 123.4C714.4 125.5 719 125.5 722.7 123.4L786.6 86.6C787.9 85.8 788.7 84.5 788.7 83C788.7 81.5 787.9 80.1 786.6 79.3L724.1 42.4Z" fill="url(#paint7_linear_606_12100)"/>
+</g>
+</g>
+</g>
+<path d="M529.3 231.2C529 231.2 528.7 231.1 528.5 231C527.8 230.6 527.6 229.6 528 228.9C534.5 218.7 536.6 207.6 534 196.8C530.5 182.4 519.1 169.3 501.2 158.9C485.5 149.8 465.8 143.6 444.2 140.8C443.4 140.7 442.8 139.9 442.9 139.1C443 138.3 443.8 137.7 444.6 137.8C466.6 140.6 486.6 147 502.7 156.3C521.4 167.1 533.2 180.8 536.9 196C539.7 207.6 537.5 219.5 530.5 230.4C530.3 231 529.8 231.2 529.3 231.2Z" fill="url(#paint8_linear_606_12100)"/>
+<g opacity="0.65">
+<g opacity="0.2">
+<path opacity="0.63" d="M18 82.8V290.6L90.7 335L90.4 124.3L18 82.8Z" fill="#020A47"/>
+<path opacity="0.2" d="M162.1 83.1L162.2 291.7L90.2 335V124.3L162.1 83.1Z" fill="url(#paint9_linear_606_12100)"/>
+<path opacity="0.2" d="M160.3 78.3L97.7 41.5C93.8 39.2 89 39.2 85 41.5L20.5 78.8C17.4 80.6 17.4 85.2 20.5 87L83.8 123.3C87.7 125.5 92.4 125.5 96.3 123.3L160.2 86.5C163.4 84.7 163.4 80.2 160.3 78.3Z" fill="url(#paint10_linear_606_12100)"/>
+</g>
+<g opacity="0.65">
+<g opacity="0.6">
+<path opacity="0.6" d="M162.7 138.7C162.4 138.7 162.2 138.5 162.2 138.2V84.0001C162.2 83.7001 162.4 83.5001 162.7 83.5001C163 83.5001 163.2 83.7001 163.2 84.0001V138.2C163.2 138.5 163 138.7 162.7 138.7Z" fill="url(#paint11_linear_606_12100)"/>
+</g>
+<g opacity="0.6">
+<path opacity="0.6" d="M90.6 125.4C88.3 125.4 86.1 124.8 84.1 123.7L20.2 86.9C18.6 86 17.6 84.3 17.6 82.4C17.6 80.5 18.6 78.8 20.2 77.9L82.8 41.1C86.8 38.7 91.9 38.7 96 41.1L160.5 78.4C162.1 79.3 163.1 81 163.1 82.9C163.1 84.8 162.1 86.5 160.5 87.4L97.2 123.7C95.1 124.8 92.8 125.4 90.6 125.4ZM20.7 78.8001C19.4 79.6001 18.6 80.9 18.6 82.5C18.6 84 19.4 85.4001 20.7 86.1001L84.6 122.9C88.3 125 92.9 125 96.6 122.9L159.9 86.6001C161.2 85.8001 162 84.5 162 82.9C162 81.4 161.2 80 159.9 79.2L95.4 41.9001C91.6 39.7001 87 39.7001 83.2 41.9001L20.7 78.8001Z" fill="url(#paint12_linear_606_12100)"/>
+</g>
+</g>
+</g>
+<path d="M700.4 144.1V395.2L612.9 448.6L613.2 194.1L700.4 144.1Z" fill="url(#paint13_linear_606_12100)"/>
+<path d="M526 143.8L525.9 395.9L613.5 448.6V194L526 143.8Z" fill="url(#paint14_linear_606_12100)"/>
+<path d="M526 143.8L525.9 395.9L613.5 448.6V194L526 143.8Z" fill="url(#paint15_linear_606_12100)"/>
+<path d="M528.8 138.5L604.4 94C609.1 91.2 615 91.2 619.7 93.9L697.6 139C701.4 141.2 701.4 146.7 697.6 148.9L621.1 192.8C616.4 195.5 610.7 195.5 606 192.8L528.8 148.4C525 146.1 525 140.7 528.8 138.5Z" fill="url(#paint16_linear_606_12100)"/>
+<path opacity="0.44" d="M528.8 138.5L604.4 94C609.1 91.2 615 91.2 619.7 93.9L697.6 139C701.4 141.2 701.4 146.7 697.6 148.9L621.1 192.8C616.4 195.5 610.7 195.5 606 192.8L528.8 148.4C525 146.1 525 140.7 528.8 138.5Z" fill="url(#paint17_linear_606_12100)"/>
+<g opacity="0.6">
+<path opacity="0.5" d="M700.5 143.9V279.7H699.5V147.2C700.1 146.2 700.5 145.1 700.5 143.9Z" fill="url(#paint18_linear_606_12100)"/>
+</g>
+<path d="M612.1 92.9C614.6 92.9 617 93.6 619.2 94.8L697.1 139.9C698.6 140.8 699.5 142.3 699.5 144C699.5 145.7 698.6 147.2 697.2 148.1L620.7 192C618.5 193.2 616.1 193.9 613.6 193.9C611.1 193.9 608.7 193.2 606.5 192L529.3 147.6C527.8 146.7 526.9 145.1 526.9 143.4C526.9 141.7 527.8 140.2 529.3 139.4L604.9 94.9C607.1 93.6 609.6 92.9 612.1 92.9ZM612.1 91.9C609.4 91.9 606.7 92.6 604.4 94L528.8 138.5C525 140.7 525 146.1 528.8 148.4L606 192.8C608.3 194.2 610.9 194.8 613.5 194.8C616.1 194.8 618.7 194.1 621 192.8L697.5 148.9C701.3 146.7 701.3 141.2 697.5 139L619.6 93.9C617.4 92.6 614.7 91.9 612.1 91.9Z" fill="url(#paint19_linear_606_12100)"/>
+<path d="M784.1 207.2V477.2L728.4 477.8L728.6 239L784.1 207.2Z" fill="#020A47"/>
+<path d="M673.6 207.3V367.3L728.8 400.5V238.9L673.6 207.3Z" fill="url(#paint20_linear_606_12100)"/>
+<path d="M675 203.7L723 175.5C726 173.7 729.7 173.7 732.7 175.5L782.1 204.1C784.5 205.5 784.5 209 782.1 210.4L733.6 238.2C730.6 239.9 727 239.9 724 238.2L675 210C672.6 208.6 672.6 205.1 675 203.7Z" fill="url(#paint21_linear_606_12100)"/>
+<path d="M200.4 194.1L200.7 448.6L113.1 395.2V144.1L200.4 194.1Z" fill="url(#paint22_linear_606_12100)"/>
+<path d="M200.1 194V448.6L287.7 395.9L287.6 143.8L200.1 194Z" fill="url(#paint23_linear_606_12100)"/>
+<path d="M200.1 194V448.6L287.7 395.9L287.6 143.8L200.1 194Z" fill="url(#paint24_linear_606_12100)"/>
+<path d="M284.8 148.4L207.6 192.8C202.9 195.5 197.2 195.5 192.5 192.8L116 148.9C112.2 146.7 112.2 141.2 116 139L193.9 93.9C198.6 91.2 204.5 91.2 209.2 94L284.8 138.5C288.6 140.7 288.6 146.1 284.8 148.4Z" fill="url(#paint25_linear_606_12100)"/>
+<path opacity="0.44" d="M284.8 148.4L207.6 192.8C202.9 195.5 197.2 195.5 192.5 192.8L116 148.9C112.2 146.7 112.2 141.2 116 139L193.9 93.9C198.6 91.2 204.5 91.2 209.2 94L284.8 138.5C288.6 140.7 288.6 146.1 284.8 148.4Z" fill="url(#paint26_linear_606_12100)"/>
+<g opacity="0.6">
+<path opacity="0.5" d="M113.1 143.9V279.7H114.1V147.2C113.4 146.2 113.1 145.1 113.1 143.9Z" fill="url(#paint27_linear_606_12100)"/>
+</g>
+<path d="M201.4 92.9C204 92.9 206.4 93.6 208.6 94.9L284.2 139.4C285.7 140.2 286.5 141.7 286.6 143.4C286.6 145.1 285.7 146.7 284.2 147.6L207 192C204.8 193.2 202.4 193.9 199.9 193.9C197.4 193.9 195 193.2 192.8 192L116.5 148C115 147.1 114.2 145.6 114.2 143.9C114.2 142.2 115.1 140.7 116.6 139.8L194.5 94.7C196.5 93.5 198.9 92.9 201.4 92.9ZM201.4 91.9C198.8 91.9 196.2 92.6 193.8 93.9L116 139C112.2 141.2 112.2 146.7 116 148.9L192.5 192.8C194.8 194.2 197.5 194.8 200 194.8C202.6 194.8 205.2 194.1 207.5 192.8L284.7 148.4C288.5 146.1 288.5 140.7 284.7 138.5L209.2 94C206.8 92.6 204.1 91.9 201.4 91.9Z" fill="url(#paint28_linear_606_12100)"/>
+<g opacity="0.6">
+<path opacity="0.6" d="M728.3 239.9C726.6 239.9 724.8 239.5 723.3 238.6L674.8 210.8C673.5 210.1 672.7 208.7 672.7 207.2C672.7 205.7 673.5 204.4 674.8 203.6L724.2 175C727.4 173.2 731.3 173.2 734.4 175L782.4 203.2C783.7 204 784.4 205.3 784.4 206.8C784.4 208.3 783.6 209.6 782.3 210.3L733.3 238.5C731.8 239.5 730.1 239.9 728.3 239.9ZM729.3 174.7C727.7 174.7 726.1 175.1 724.7 175.9L675.3 204.5C674.3 205.1 673.7 206.1 673.7 207.2C673.7 208.3 674.3 209.3 675.3 209.9L723.8 237.7C726.6 239.3 730.1 239.3 732.9 237.7L781.9 209.5C782.9 208.9 783.5 207.9 783.5 206.8C783.5 205.7 782.9 204.7 782 204.1L734 175.9C732.5 175.1 730.9 174.7 729.3 174.7Z" fill="url(#paint29_linear_606_12100)"/>
+</g>
+<path d="M673.8 210V242.9H672.8V208C672.9 208.8 673.3 209.5 673.8 210Z" fill="url(#paint30_linear_606_12100)"/>
+<path d="M438.9 339.2L438.8 476.9L500.6 477V374.6L438.9 339.2Z" fill="url(#paint31_linear_606_12100)"/>
+<path d="M562.5 339V477.3L500.1 477.2L500.4 374.6L562.5 339Z" fill="#020A47"/>
+<path opacity="0.39" d="M438.9 339.2L438.8 476.7L500.6 477.8V374.6L438.9 339.2Z" fill="url(#paint32_linear_606_12100)"/>
+<path d="M440.4 335.2L494.1 303.6C497.4 301.6 501.6 301.6 505 303.6L560.3 335.6C563 337.2 563 341.1 560.3 342.6L506 373.7C502.7 375.6 498.6 375.6 495.3 373.7L440.5 342.2C437.7 340.6 437.7 336.7 440.4 335.2Z" fill="url(#paint33_linear_606_12100)"/>
+<path opacity="0.44" d="M440.4 335.2L494.1 303.6C497.4 301.6 501.6 301.6 505 303.6L560.3 335.6C563 337.2 563 341.1 560.3 342.6L506 373.7C502.7 375.6 498.6 375.6 495.3 373.7L440.5 342.2C437.7 340.6 437.7 336.7 440.4 335.2Z" fill="url(#paint34_linear_606_12100)"/>
+<g opacity="0.6">
+<path opacity="0.5" d="M562.5 339.1H561.5V455H562.5V339.1Z" fill="url(#paint35_linear_606_12100)"/>
+</g>
+<g opacity="0.6">
+<path opacity="0.8" d="M500.1 374.9H499.1V456.9H500.1V374.9Z" fill="url(#paint36_linear_606_12100)"/>
+</g>
+<g opacity="0.6">
+<path opacity="0.6" d="M500.6 375.6C498.7 375.6 496.7 375.1 495 374.1L440.2 342.6C438.8 341.8 437.9 340.3 437.9 338.7C437.9 337.1 438.7 335.6 440.1 334.8L493.8 303.2C497.3 301.1 501.6 301.1 505.2 303.2L560.5 335.2C561.9 336 562.8 337.5 562.8 339.1C562.8 340.7 561.9 342.2 560.5 343L506.2 374.2C504.5 375.1 502.5 375.6 500.6 375.6ZM499.6 302.6C497.8 302.6 496 303.1 494.4 304L440.7 335.6C439.6 336.2 438.9 337.4 438.9 338.7C438.9 340 439.6 341.1 440.7 341.8L495.5 373.3C498.7 375.1 502.6 375.1 505.7 373.3L560 342.1C561.1 341.5 561.8 340.3 561.8 339C561.8 337.7 561.1 336.6 560 335.9L504.7 303.9C503.1 303.1 501.3 302.6 499.6 302.6Z" fill="url(#paint37_linear_606_12100)"/>
+</g>
+<path d="M419.7 285.2C382.2 285.2 346.1 276.7 318.6 260.8C291.1 244.9 275.9 223.7 275.9 201.1C275.9 178.6 290.8 157.6 318 141.8C332.7 133.3 350 126.8 369.3 122.7C370.1 122.5 370.9 123 371.1 123.9C371.3 124.7 370.8 125.5 369.9 125.7C350.9 129.8 333.9 136.1 319.5 144.5C293.3 159.7 278.9 179.9 278.9 201.2C278.9 222.7 293.6 243 320.1 258.3C355.2 278.5 404.8 286.6 453 280C453.8 279.9 454.6 280.5 454.7 281.3C454.8 282.1 454.2 282.9 453.4 283C442.2 284.5 430.9 285.2 419.7 285.2Z" fill="url(#paint38_linear_606_12100)"/>
+<path opacity="0.6" d="M324.9 257.5C324.3 258.3 323.7 259.1 323.2 260C323.1 260.2 323 260.3 322.9 260.5C321.5 259.6 320.2 258.6 318.9 257.6C318.7 257.5 318.5 257.3 318.3 257.1C315.9 255.3 313.7 254 311.6 252.9C293.8 240.6 282.7 225.8 279.7 209.9V209.8C280.2 210 280.8 210.1 281.5 210.1H281.6C282.1 210.1 282.4 210.1 282.6 210.8C282.6 210.9 282.7 210.9 282.7 211C282.7 211.1 282.8 211.2 282.8 211.3C282.8 211.4 282.9 211.5 282.9 211.6C283 212 283.1 212.6 283.2 213.3C283.3 213.7 283.3 214.1 283.4 214.5C283.4 214.8 283.5 215.1 283.6 215.5C283.6 215.6 283.7 215.8 283.7 215.9C283.7 216.1 283.8 216.4 283.9 216.6C284.2 217.8 284.6 219 285.3 220.3C285.4 220.5 285.5 220.8 285.7 221C285.8 221.3 286 221.5 286.2 221.8C286.3 221.9 286.4 222.1 286.5 222.2C287.1 223.2 287.9 224.1 288.8 225C291.1 227.3 293.2 227.9 295 228.4C297.5 229.1 299.9 229.8 303.5 235C304.6 236.6 304.8 237.3 305 237.8C305.5 239.1 305.9 240 309.4 243.7C313.1 247.7 316.3 248.2 318.9 248.7C320.5 249 321.7 249.2 322.9 250.2C323.6 250.8 323.8 251.6 324.2 253.1C324.4 254.2 324.7 255.5 325.4 257C325.2 257.1 325.4 256.9 324.9 257.5Z" fill="url(#paint39_linear_606_12100)"/>
+<g opacity="0.72">
+<path opacity="0.6" d="M352.2 124.9C348.6 125.3 343.1 125 342.1 124.9C339.4 124.6 337.4 123.6 335.5 122.5C333.8 121.5 332.3 120.7 330.9 121.4C329.6 122.1 329.2 123.7 329.1 125C328.6 129.9 324.1 131.4 323.2 131.6C321.8 131.5 320.4 131 318.9 130.3C315.9 129 312.1 127.4 306.3 129.5C296 133.2 294.3 141 293.1 146.2C292.6 148.3 292.1 150.3 291.3 150.9C290.9 151.2 290.6 151.3 290.5 151.3C290.3 150.9 290 149.7 289.8 148.9C289.3 146.7 288.7 144.3 286.6 143.5C285 142.9 283 143.5 280.5 145.5C279.5 146.3 277.2 148.1 276.3 173.7C275.9 186.1 276 198.2 276 198.3C276 199 276.6 199.7 277.3 199.8C277.3 199.8 277.3 201 277.3 202.2C277.3 201 277.4 199.8 277.4 199.8H277.5C278.4 199.8 279 199.1 279.1 198.2C279.1 194.9 279.1 191.5 279.1 188.2C283.6 171.7 296.8 155.8 318.7 143.1C328.5 137.4 339.4 132.7 351.1 129C351.1 129 361.5 125.7 371.8 122.4C364.7 123.4 357.6 124.2 352.2 124.9Z" fill="url(#paint40_linear_606_12100)"/>
+<g opacity="0.72">
+<path opacity="0.72" d="M277.5 199.8C276.7 199.8 276 199.1 276 198.3C276 198.2 275.9 186.1 276.3 173.7C277.2 148.1 279.5 146.3 280.5 145.5C283 143.5 285 142.9 286.6 143.5C288.7 144.3 289.3 146.7 289.8 148.9C290 149.7 290.3 150.9 290.5 151.3C290.6 151.3 290.9 151.2 291.3 150.9C292.1 150.3 292.6 148.3 293.1 146.2C294.3 141 296 133.2 306.3 129.5C312.1 127.4 315.9 129 318.9 130.3C320.4 131 321.8 131.5 323.2 131.6C324.1 131.4 328.6 129.9 329.1 125C329.2 123.7 329.6 122.1 330.9 121.4C332.3 120.7 333.8 121.5 335.5 122.5C337.4 123.6 339.7 124.9 342.4 124.5C343.2 124.4 344 125 344.1 125.8C344.2 126.6 343.6 127.4 342.8 127.5C339.1 127.9 336.2 126.3 334.1 125.1C333.5 124.8 332.8 124.4 332.4 124.2C332.3 124.4 332.3 124.7 332.2 125.3C331.6 131.3 326.4 134 323.8 134.5H323.5H323.4C321.3 134.5 319.6 133.7 317.9 133C315.1 131.8 312.2 130.5 307.5 132.2C298.8 135.3 297.4 141.6 296.2 146.7C295.6 149.5 295 152 293.2 153.2C292.7 153.5 291.2 154.6 289.6 154C287.9 153.3 287.5 151.3 287 149.4C286.7 148.3 286.3 146.4 285.7 146.2C285.6 146.2 284.8 146 282.5 147.8C280.1 150 278.9 175.2 279.1 198.2C279 199.1 278.4 199.8 277.5 199.8Z" fill="url(#paint41_linear_606_12100)"/>
+</g>
+</g>
+<path d="M337.9 266.7C337.9 266.8 337.8 266.9 337.7 266.9C337.5 267.2 337.1 267.4 336.7 267.4C336.4 267.4 336.2 267.3 335.9 267.2C334.2 266.2 332.7 265.1 331.4 264.2C325.4 259.6 324.5 255.8 323.9 253.1C323.5 251.6 323.3 250.8 322.6 250.2C321.4 249.2 320.2 249 318.6 248.7C316 248.2 312.8 247.7 309.1 243.7C305.6 240 305.2 239.1 304.7 237.8C304.5 237.3 304.3 236.6 303.2 235C299.6 229.8 297.2 229.1 294.7 228.4C292.9 227.9 290.8 227.3 288.5 225C284.4 220.9 283.6 216.3 283.1 213.4C282.6 210.3 282.4 210.2 281.5 210.2H281.4C280.8 210.2 280.2 210.1 279.6 209.9C278.1 209.4 276.9 208.3 276.2 206.6C276.2 206.5 276.1 206.4 276.1 206.2V206.1C275.9 204.5 275.8 202.9 275.8 201.3C275.9 201 276 200.8 276.2 200.7L276.9 200L277.9 200.4C278.4 200.6 278.7 201 278.8 201.9C278.9 202.3 278.9 202.9 278.9 203.6C278.9 204 278.9 204.4 278.8 204.9C278.8 205.1 278.9 205.3 279 205.5C279.1 205.8 279.3 206.1 279.5 206.4C280 207 280.6 207.3 281.4 207.2H281.5C285.1 207.2 285.5 210.2 286 212.9C286.5 215.8 287.1 219.4 290.5 222.9C292.2 224.6 293.7 225.1 295.4 225.6C298.1 226.4 301.3 227.3 305.5 233.4C306.8 235.3 307.1 236.2 307.4 236.9C307.7 237.6 307.9 238.2 311.1 241.7C314.2 244.9 316.6 245.4 319 245.8C320.8 246.1 322.7 246.4 324.4 247.9C326 249.2 326.4 250.9 326.7 252.5C327.4 255.4 328.3 259.4 337.3 264.7C338.1 265 338.3 265.9 337.9 266.7Z" fill="url(#paint42_linear_606_12100)"/>
+<path d="M428.7 331.8C428 331.8 427.4 331.8 426.7 331.8C425.5 331.8 424.5 330.8 424.5 329.6C424.5 328.4 425.5 327.4 426.7 327.4C479.6 327.7 529.2 315.9 566.5 294.3C602.7 273.2 622.7 245.4 622.6 215.9C622.6 186.2 602.3 158.1 565.6 136.9C564.6 136.3 564.2 135 564.8 133.9C565.4 132.9 566.7 132.5 567.8 133.1C605.9 155.1 626.9 184.5 627 215.9C627 247.1 606.3 276.3 568.7 298.1C531.2 319.9 481.6 331.8 428.7 331.8Z" fill="url(#paint43_linear_606_12100)"/>
+<path opacity="0.65" d="M371.4 282.9V477L309.1 477.2L309.3 319V318.5L309.5 318.4L371.2 283.1L371.4 282.9Z" fill="url(#paint44_linear_606_12100)"/>
+<path d="M309.5 318.5V477.2H272.8H247.7L247.8 284.4V283.1L309.5 318.4V318.5Z" fill="url(#paint45_linear_606_12100)"/>
+<path d="M249.4 279.1L303.1 247.5C306.4 245.5 310.6 245.5 314 247.5L369.3 279.5C372 281.1 372 285 369.3 286.5L315 317.7C311.7 319.6 307.6 319.6 304.3 317.7L249.5 286.2C246.7 284.5 246.7 280.7 249.4 279.1Z" fill="url(#paint46_linear_606_12100)"/>
+<path opacity="0.44" d="M249.4 279.1L303.1 247.5C306.4 245.5 310.6 245.5 314 247.5L369.3 279.5C372 281.1 372 285 369.3 286.5L315 317.7C311.7 319.6 307.6 319.6 304.3 317.7L249.5 286.2C246.7 284.5 246.7 280.7 249.4 279.1Z" fill="url(#paint47_linear_606_12100)"/>
+<g opacity="0.6">
+<path opacity="0.6" d="M309.6 319.5C307.7 319.5 305.7 319 304 318L249.2 286.5C247.8 285.7 246.9 284.2 246.9 282.6C246.9 281 247.7 279.5 249.1 278.7L302.8 247.1C306.3 245 310.6 245 314.2 247.1L369.5 279.1C370.9 279.9 371.8 281.4 371.8 283C371.8 284.6 370.9 286.1 369.5 286.9L315.2 318.1C313.4 319 311.5 319.5 309.6 319.5ZM308.5 246.5C306.7 246.5 304.9 247 303.3 247.9L249.6 279.5C248.5 280.1 247.8 281.3 247.8 282.6C247.8 283.9 248.5 285 249.6 285.7L304.4 317.2C307.6 319 311.5 319 314.6 317.2L369 286C370.1 285.4 370.8 284.2 370.8 282.9C370.8 281.6 370.1 280.5 369 279.8L313.7 247.8C312.1 247 310.3 246.5 308.5 246.5Z" fill="url(#paint48_linear_606_12100)"/>
+</g>
+<path opacity="0.49" d="M622.6 215.9C622.6 245.4 602.7 273.3 566.5 294.3C535.2 312.5 495.1 323.7 451.7 326.6C454.5 324.2 456.6 321.4 458.3 318.9C460 316.6 461.5 314.4 463.3 313.2C464.6 312.3 466.2 312.4 468.7 312.6C474.6 313.1 482.8 313.8 490.7 295.7C492.6 291.4 493.5 287.3 494.3 283.6C496.2 275.2 497.5 269.1 508.4 265C515.4 262.3 518.1 267.1 521.9 275C525 281.4 528.5 288.6 536.5 286.9C544.7 285.1 545.6 282 546 277.8C546.2 275.1 546.5 272.4 551 268.8C556.2 264.7 558.9 266.2 561.9 267.7C564.3 269 567.9 270.9 571.5 266.7C575.6 261.9 578.6 262.9 582.8 264.3C586.7 265.7 591.5 267.3 596.6 262.6C602.3 257.2 600.2 251.7 598.5 247.2C596.9 242.9 596 240.1 598.2 237C600.6 233.8 603.3 233.9 605.9 233.9C607.8 234 609.9 234 611.2 232.4C612.4 230.9 612.5 228.8 611.6 225.1C610.6 221.2 609.3 217.8 608.3 215.1C607.2 212.3 606 209.2 606.5 208.3C606.6 208.1 607.1 207.8 607.7 207.6C612.6 206.3 618.5 202.1 619.9 196.9C621.6 203.2 622.6 209.5 622.6 215.9Z" fill="url(#paint49_linear_606_12100)"/>
+<path opacity="0.33" d="M590.5 283.1C594.6 276.7 601.4 272.4 607.3 267.9C607.6 266.6 608 265.4 608.4 264C611.3 254.7 616.7 245.9 619.8 236.6C620.5 234 622 229.6 622.5 227C619.7 228.3 614.5 229.2 612.2 228.7C609 227.9 606.6 227.3 603 230.6C598.8 234.5 599.1 238.7 599.5 243.1C599.8 247 600.2 251.1 597.3 254.6C593.8 258.9 590.2 256.9 587.7 255.7C584.7 254.1 581.9 252.7 576.8 256.7C572.3 260.3 572 263 571.8 265.7C571.4 269.9 570.5 273.1 562.3 274.8C554.5 276.5 551.4 275.7 548.5 270.8C544.7 264.5 540.3 261.2 535.4 262.3C523.6 265.1 518.2 279.7 516.5 283.6C508.6 301.8 501 308.4 489.1 301.1C487.3 300 482.2 287.1 470.8 301.9C449.8 329.3 437 313.8 433.9 329.4C473.3 332.1 553 309.7 590.1 283.7C590.2 283.6 590.4 283.4 590.5 283.1Z" fill="url(#paint50_linear_606_12100)"/>
+<path d="M329.1 385.6L368.1 362.7C370.5 361.3 373.5 361.3 376 362.7L416.1 385.9C418.1 387 418.4 389.8 416.1 391L376.7 413.6C374.3 415 371.3 415 368.9 413.6L329.1 390.7C327.2 389.5 327.2 386.7 329.1 385.6Z" fill="url(#paint51_linear_606_12100)"/>
+<g opacity="0.6">
+<path opacity="0.5" d="M416.7 390.6C417.4 389.8 417.7 389.5 417.7 388.6V443H416.7V390.6Z" fill="url(#paint52_linear_606_12100)"/>
+</g>
+<g opacity="0.5">
+<path opacity="0.48" d="M372.9 414.7L373.9 414.6V444.4H372.9V414.7Z" fill="url(#paint53_linear_606_12100)"/>
+</g>
+<path opacity="0.73" d="M372 362.4C373.3 362.4 374.5 362.7 375.6 363.3L415.7 386.5C416.5 386.9 416.9 387.7 416.9 388.5C416.9 389.3 416.5 389.9 415.7 390.3L376.3 413C375.2 413.6 374 413.9 372.8 413.9C371.6 413.9 370.3 413.6 369.3 412.9L329.5 390C328.8 389.6 328.4 388.8 328.4 388C328.4 387.2 328.8 386.6 329.5 386.2L368.5 363.3C369.5 362.7 370.8 362.4 372 362.4ZM372 361.7C370.6 361.7 369.3 362.1 368.1 362.7L329.1 385.6C327.2 386.7 327.2 389.5 329.1 390.7L368.9 413.6C370.1 414.3 371.4 414.6 372.8 414.6C374.2 414.6 375.5 414.2 376.7 413.6L416.1 391C418.4 389.8 418.1 387 416.1 385.9L376 362.7C374.8 362 373.4 361.7 372 361.7Z" fill="url(#paint54_linear_606_12100)"/>
+<path d="M428.1 200.6C423.1 197.7 415.1 197.7 410.1 200.6C405.2 203.5 405.2 208.1 410.2 211C415.2 213.9 423.2 213.9 428.2 211C433.1 208.1 433 203.5 428.1 200.6Z" fill="url(#paint55_linear_606_12100)"/>
+<path d="M419.1 207.6C417.7 207.6 416.6 206.5 416.6 205.1V40.9C416.6 39.5 417.7 38.4 419.1 38.4C420.5 38.4 421.6 39.5 421.6 40.9V205.2C421.6 206.5 420.5 207.6 419.1 207.6Z" fill="url(#paint56_linear_606_12100)"/>
+<path d="M436.3 331.8C434.8 331.8 433.2 331.7 431.4 331.5C430.3 331.4 429.5 330.4 429.7 329.3C429.8 328.2 430.9 327.4 431.9 327.6C445.7 329.4 450.4 322.9 454.9 316.7C456.8 314.1 458.5 311.7 460.9 310C463.5 308.2 466.3 308.4 469.1 308.7C474.6 309.2 480.2 309.7 486.9 294.3C488.6 290.4 489.4 286.6 490.2 283C492.1 274.4 493.9 266.3 506.9 261.4C517.8 257.2 522.2 266.2 525.7 273.5C528.9 280.1 531.1 284.1 535.6 283.1C541.4 281.8 541.5 280.5 541.8 277.7C542.1 274.6 542.5 270.5 548.4 265.8C555.7 260 560.6 262.6 563.8 264.3C566.4 265.7 567 265.8 568.2 264.3C574.2 257.3 579.7 259.2 584 260.7C587.7 262 590.3 262.9 593.6 259.8C597.1 256.5 596.2 253.7 594.4 248.9C592.9 244.9 590.9 239.8 594.7 234.7C598.4 229.7 603.1 229.8 605.9 229.9C606.6 229.9 607.5 230 607.9 229.9C608 229.6 608.1 228.7 607.4 226.3C606.5 222.6 605.3 219.5 604.2 216.8C602.5 212.4 601.3 209.2 602.6 206.6C603.3 205.2 604.6 204.3 606.5 203.8C610.3 202.8 615 199.4 615.8 196C616.2 194.3 615.6 192.8 614 191.2C607.9 185.6 604.6 181 607.8 176.7C608.5 175.8 609.7 175.6 610.6 176.3C611.5 177 611.7 178.2 611 179.1C610.5 179.8 609.2 181.4 616.7 188.3C620.2 191.5 620.3 194.8 619.7 196.9C618.4 202.1 612.5 206.3 607.6 207.6C607.2 207.7 606.4 208 606.2 208.3C605.7 209.3 606.9 212.3 608 215.2C609 217.9 610.4 221.3 611.3 225.2C612.2 228.9 612.1 230.9 611 232.3C609.7 233.9 607.7 233.8 605.8 233.8C603.1 233.7 600.4 233.6 598 236.9C595.5 240.2 596.8 243.5 598.2 247.3C599.9 251.7 602 257.3 596.4 262.5C591.4 267.2 586.6 265.5 582.8 264.2C578.6 262.7 575.5 261.7 571.3 266.6C567.9 270.7 564.4 268.9 562 267.6C559 266 556.2 264.5 550.9 268.7C546.3 272.3 546 275.1 545.8 277.9C545.4 282.1 544.5 285.1 536.5 286.9C528.7 288.6 525.2 281.4 522.1 275.1C518.2 267.1 515.5 262.3 508.4 265C497.4 269.2 496 275.3 494.2 283.7C493.4 287.3 492.5 291.5 490.6 295.7C482.8 313.7 474.7 313 468.8 312.5C466.2 312.3 464.6 312.2 463.3 313.1C461.5 314.3 460 316.5 458.3 318.8C454.2 324.4 448.9 331.8 436.3 331.8Z" fill="url(#paint57_linear_606_12100)"/>
+<path opacity="0.6" d="M507.9 267.8C507.7 267.8 507.5 267.6 507.5 267.4V265.8C507.5 265.6 507.7 265.4 507.9 265.4C508.1 265.4 508.3 265.6 508.3 265.8V267.4C508.3 267.6 508.1 267.8 507.9 267.8Z" fill="url(#paint58_linear_606_12100)"/>
+<path opacity="0.6" d="M507.9 313.6C507.7 313.6 507.5 313.4 507.5 313.2V309.9C507.5 309.7 507.7 309.5 507.9 309.5C508.1 309.5 508.3 309.7 508.3 309.9V313.2C508.3 313.4 508.1 313.6 507.9 313.6ZM507.9 307.1C507.7 307.1 507.5 306.9 507.5 306.7V303.4C507.5 303.2 507.7 303 507.9 303C508.1 303 508.3 303.2 508.3 303.4V306.7C508.3 306.9 508.1 307.1 507.9 307.1ZM507.9 300.5C507.7 300.5 507.5 300.3 507.5 300.1V296.8C507.5 296.6 507.7 296.4 507.9 296.4C508.1 296.4 508.3 296.6 508.3 296.8V300.1C508.3 300.3 508.1 300.5 507.9 300.5ZM507.9 294C507.7 294 507.5 293.8 507.5 293.6V290.3C507.5 290.1 507.7 289.9 507.9 289.9C508.1 289.9 508.3 290.1 508.3 290.3V293.6C508.3 293.8 508.1 294 507.9 294ZM507.9 287.4C507.7 287.4 507.5 287.2 507.5 287V283.7C507.5 283.5 507.7 283.3 507.9 283.3C508.1 283.3 508.3 283.5 508.3 283.7V287C508.3 287.2 508.1 287.4 507.9 287.4ZM507.9 280.9C507.7 280.9 507.5 280.7 507.5 280.5V277.2C507.5 277 507.7 276.8 507.9 276.8C508.1 276.8 508.3 277 508.3 277.2V280.5C508.3 280.7 508.1 280.9 507.9 280.9ZM507.9 274.3C507.7 274.3 507.5 274.1 507.5 273.9V270.6C507.5 270.4 507.7 270.2 507.9 270.2C508.1 270.2 508.3 270.4 508.3 270.6V273.9C508.3 274.1 508.1 274.3 507.9 274.3Z" fill="url(#paint59_linear_606_12100)"/>
+<path opacity="0.6" d="M507.9 318.5C507.7 318.5 507.5 318.3 507.5 318.1V316.5C507.5 316.3 507.7 316.1 507.9 316.1C508.1 316.1 508.3 316.3 508.3 316.5V318.1C508.3 318.3 508.1 318.5 507.9 318.5Z" fill="url(#paint60_linear_606_12100)"/>
+<path opacity="0.6" d="M539.3 289.6C539.1 289.6 538.9 289.4 538.9 289.2V287.6C538.9 287.4 539.1 287.2 539.3 287.2C539.5 287.2 539.7 287.4 539.7 287.6V289.2C539.7 289.5 539.5 289.6 539.3 289.6Z" fill="url(#paint61_linear_606_12100)"/>
+<path opacity="0.6" d="M539.3 309.3C539.1 309.3 538.9 309.1 538.9 308.9V305.6C538.9 305.4 539.1 305.2 539.3 305.2C539.5 305.2 539.7 305.4 539.7 305.6V308.9C539.7 309.1 539.5 309.3 539.3 309.3ZM539.3 302.8C539.1 302.8 538.9 302.6 538.9 302.4V299.1C538.9 298.9 539.1 298.7 539.3 298.7C539.5 298.7 539.7 298.9 539.7 299.1V302.4C539.7 302.6 539.5 302.8 539.3 302.8ZM539.3 296.2C539.1 296.2 538.9 296 538.9 295.8V292.5C538.9 292.3 539.1 292.1 539.3 292.1C539.5 292.1 539.7 292.3 539.7 292.5V295.8C539.7 296 539.5 296.2 539.3 296.2Z" fill="url(#paint62_linear_606_12100)"/>
+<path opacity="0.77" d="M441.8 315.7C433.8 308.1 420.9 308.1 413 315.7C405.1 323.3 405.1 335.7 413.1 343.3C421.1 350.9 434 350.9 441.9 343.3C449.8 335.7 449.7 323.3 441.8 315.7Z" fill="url(#paint63_radial_606_12100)"/>
+<path opacity="0.69" d="M431.3 325.8C429.2 323.8 425.7 323.8 423.6 325.8C421.5 327.8 421.5 331.2 423.6 333.2C425.7 335.2 429.2 335.2 431.3 333.2C433.4 331.2 433.4 327.9 431.3 325.8Z" fill="url(#paint64_radial_606_12100)"/>
+<path opacity="0.76" d="M507.7 270.6C512.008 270.6 515.5 267.108 515.5 262.8C515.5 258.492 512.008 255 507.7 255C503.392 255 499.9 258.492 499.9 262.8C499.9 267.108 503.392 270.6 507.7 270.6Z" fill="url(#paint65_radial_606_12100)"/>
+<path opacity="0.76" d="M507.7 265.8C509.357 265.8 510.7 264.457 510.7 262.8C510.7 261.143 509.357 259.8 507.7 259.8C506.043 259.8 504.7 261.143 504.7 262.8C504.7 264.457 506.043 265.8 507.7 265.8Z" fill="url(#paint66_radial_606_12100)"/>
+<path d="M507.7 264C508.363 264 508.9 263.463 508.9 262.8C508.9 262.137 508.363 261.6 507.7 261.6C507.037 261.6 506.5 262.137 506.5 262.8C506.5 263.463 507.037 264 507.7 264Z" fill="#5EE4E4"/>
+<g opacity="0.36">
+<path opacity="0.36" d="M557.4 271.6V271C557.4 270.3 556.7 269.9 556.1 270.3L549.4 274.2C549.1 274.4 548.9 274.7 548.9 275.1V275.3C548.9 276 549.6 276.4 550.2 276L557.3 271.9C557.4 271.8 557.4 271.7 557.4 271.6Z" fill="url(#paint67_linear_606_12100)"/>
+<path opacity="0.36" d="M558.5 278C558.5 277.3 557.8 276.9 557.2 277.2L549.7 281.5C549.3 281.7 549.1 282.1 549.1 282.5V282.6C549.1 283.3 549.8 283.7 550.4 283.3L557.9 279C558.3 278.8 558.5 278.4 558.5 278Z" fill="url(#paint68_linear_606_12100)"/>
+<path opacity="0.36" d="M562 272.4V272.2C562 271.5 561.3 271.1 560.7 271.5L549.6 277.9C549.2 278.1 549 278.6 549 279C549 279.7 549.7 280.1 550.3 279.7L561.5 273.2C561.8 273.1 562 272.8 562 272.4Z" fill="url(#paint69_linear_606_12100)"/>
+</g>
+<path d="M420 374.6C342.7 374.6 270 357.2 215.1 325.5C167.1 297.8 137 260.9 130.5 221.8C130.3 220.7 131.1 219.7 132.1 219.5C133.2 219.3 134.2 220.1 134.4 221.1C140.7 259 170.1 294.9 217.1 322C329.2 386.7 510.9 386.7 622.3 322C623.3 321.4 624.5 321.8 625 322.7C625.6 323.7 625.2 324.9 624.3 325.4C569.8 357.2 497.3 374.6 420 374.6Z" fill="url(#paint70_linear_606_12100)"/>
+<path opacity="0.6" d="M441 329.4C438.6 329.8 435.9 329.9 432.7 329.6C435.4 329.6 438.2 329.5 441 329.4Z" fill="url(#paint71_linear_606_12100)"/>
+<path opacity="0.6" d="M480.6 313.3C480.4 313.3 480.2 313.1 480.2 312.9V311.3C480.2 311.1 480.4 310.9 480.6 310.9C480.8 310.9 481 311.1 481 311.3V312.9C481 313.1 480.8 313.3 480.6 313.3Z" fill="url(#paint72_linear_606_12100)"/>
+<path opacity="0.6" d="M480.6 326.4C480.4 326.4 480.2 326.2 480.2 326V322.7C480.2 322.5 480.4 322.3 480.6 322.3C480.8 322.3 481 322.5 481 322.7V326C481 326.2 480.8 326.4 480.6 326.4ZM480.6 319.8C480.4 319.8 480.2 319.6 480.2 319.4V316.1C480.2 315.9 480.4 315.7 480.6 315.7C480.8 315.7 481 315.9 481 316.1V319.4C481 319.6 480.8 319.8 480.6 319.8Z" fill="url(#paint73_linear_606_12100)"/>
+<g opacity="0.22">
+<path opacity="0.6" d="M584.6 268C584.4 268 584.2 267.8 584.2 267.6V266C584.2 265.8 584.4 265.6 584.6 265.6C584.8 265.6 585 265.8 585 266V267.6C585 267.8 584.8 268 584.6 268Z" fill="url(#paint74_linear_606_12100)"/>
+<path opacity="0.6" d="M584.6 294.2C584.4 294.2 584.2 294 584.2 293.8V290.5C584.2 290.3 584.4 290.1 584.6 290.1C584.8 290.1 585 290.3 585 290.5V293.8C585 294 584.8 294.2 584.6 294.2ZM584.6 287.6C584.4 287.6 584.2 287.4 584.2 287.2V283.9C584.2 283.7 584.4 283.5 584.6 283.5C584.8 283.5 585 283.7 585 283.9V287.2C585 287.4 584.8 287.6 584.6 287.6ZM584.6 281.1C584.4 281.1 584.2 280.9 584.2 280.7V277.4C584.2 277.2 584.4 277 584.6 277C584.8 277 585 277.2 585 277.4V280.7C585 280.9 584.8 281.1 584.6 281.1ZM584.6 274.5C584.4 274.5 584.2 274.3 584.2 274.1V270.8C584.2 270.6 584.4 270.4 584.6 270.4C584.8 270.4 585 270.6 585 270.8V274.1C585 274.3 584.8 274.5 584.6 274.5Z" fill="url(#paint75_linear_606_12100)"/>
+</g>
+<g opacity="0.6">
+<path opacity="0.6" d="M563.5 293.6C563.3 293.6 563.1 293.4 563.1 293.2V289.9C563.1 289.7 563.3 289.5 563.5 289.5C563.7 289.5 563.9 289.7 563.9 289.9V293.2C563.9 293.4 563.7 293.6 563.5 293.6ZM563.5 287.1C563.3 287.1 563.1 286.9 563.1 286.7V283.4C563.1 283.2 563.3 283 563.5 283C563.7 283 563.9 283.2 563.9 283.4V286.7C563.9 286.9 563.7 287.1 563.5 287.1ZM563.5 280.5C563.3 280.5 563.1 280.3 563.1 280.1V276.8C563.1 276.6 563.3 276.4 563.5 276.4C563.7 276.4 563.9 276.6 563.9 276.8V280.1C563.9 280.3 563.7 280.5 563.5 280.5ZM563.5 274C563.3 274 563.1 273.8 563.1 273.6V270.3C563.1 270.1 563.3 269.9 563.5 269.9C563.7 269.9 563.9 270.1 563.9 270.3V273.6C563.9 273.8 563.7 274 563.5 274Z" fill="url(#paint76_linear_606_12100)"/>
+<path opacity="0.6" d="M563.5 305.1C563.3 305.1 563.1 304.9 563.1 304.7V303C563.1 302.8 563.3 302.6 563.5 302.6C563.7 302.6 563.9 302.8 563.9 303V304.6C563.9 304.9 563.7 305.1 563.5 305.1Z" fill="url(#paint77_linear_606_12100)"/>
+</g>
+<path opacity="0.4" d="M494.2 364.7C398.7 379.5 292.3 365.1 217.3 321.8C171.5 295.3 142.4 260.6 135.2 223.6C135.5 223.6 135.9 223.5 136.2 223.5C137 225.1 138.1 226.1 139.3 226.8C141.8 228.6 144.9 229 147.7 229.3C152.1 229.8 156.7 230.4 160.5 235.6C166 243.2 171.6 241.8 176.4 240.6C181 239.4 185.3 238.4 191 243.7C197.6 249.8 197 256.2 196.5 263C196 268.5 195.6 274.2 199.5 279C203.7 284.2 207.6 283.6 211.4 283C215.6 282.3 220.3 281.6 228.5 288.2C231.2 290.4 232.7 293 234.2 295.8C236.4 299.7 238.7 303.8 244.4 306.5C245.9 307.3 247.7 308 249.9 308.5C251.6 308.9 253.2 309 254.7 308.8C262.5 308.7 266.8 303.2 271.1 297.9C276.1 291.6 280.9 285.7 291.6 287.1C306.1 289.1 308.5 296.1 312.9 308.9C314.2 312.8 315.7 317.1 317.8 321.8C329 347.6 340.4 346.6 348.8 345.8C352.3 345.5 355.2 345.2 357.5 346.9C372.3 357.2 387.1 360.9 401.7 357.8C411.6 355.7 422.1 356.1 432 358.9C441.8 361.7 454 364.6 464.5 365.6C466.9 366 469.2 366.2 471.4 366.2C473.4 366.2 475.2 366.1 476.9 365.9C483.1 365 489.1 364.7 494.2 364.7Z" fill="url(#paint78_linear_606_12100)"/>
+<path d="M471.2 366.1C459.7 366.1 443.9 362.4 431.8 359C421.8 356.2 411.3 355.8 401.5 357.9C387 361 372.1 357.3 357.3 347C355 345.4 352.2 345.6 348.6 345.9C340.3 346.6 328.8 347.6 317.6 321.9C315.6 317.2 314.1 312.8 312.7 309C308.3 296.2 305.9 289.2 291.4 287.2C280.7 285.7 275.9 291.7 270.9 298C265.9 304.3 260.7 310.8 249.7 308.4C239.7 306.2 236.8 301 234 295.9C232.4 293.1 231 290.5 228.3 288.3C220.1 281.7 215.3 282.4 211.2 283.1C207.5 283.7 203.6 284.3 199.3 279.1C195.4 274.3 195.8 268.6 196.3 263.1C196.9 256.3 197.4 249.9 190.8 243.8C185.1 238.5 180.8 239.6 176.2 240.7C171.3 241.9 165.8 243.3 160.3 235.7C156.5 230.5 152 230 147.6 229.4C142 228.7 135.7 227.9 134.2 216.7C133.7 213.1 123.1 213.2 115.4 213.3C109.6 213.4 104.1 213.4 100.4 212.4C99.2999 212.1 98.6999 211 98.9999 209.9C99.2999 208.8 100.4 208.2 101.5 208.5C104.7 209.4 110.1 209.3 115.4 209.3C126.2 209.2 137.3 209.1 138.2 216.2C139.3 224.4 142.6 224.8 148.1 225.4C152.9 226 158.8 226.7 163.6 233.3C167.6 238.7 170.7 237.9 175.3 236.8C180.2 235.6 186.3 234 193.6 240.8C201.6 248.3 200.9 256.3 200.3 263.4C199.9 268.5 199.5 272.9 202.4 276.5C205.2 279.9 207.1 279.6 210.5 279.1C215 278.4 221.2 277.4 230.8 285.2C234.1 287.9 235.8 290.9 237.5 293.9C240.1 298.6 242.4 302.6 250.6 304.4C259.1 306.3 262.9 301.5 267.8 295.4C273 288.8 279 281.4 292 283.2C308.9 285.5 312.1 294.8 316.5 307.7C317.8 311.5 319.3 315.8 321.3 320.3C331.4 343.4 340.3 342.6 348.2 341.9C352 341.6 356 341.2 359.5 343.7C373.3 353.4 387.1 356.8 400.6 354C411.1 351.8 422.3 352.2 432.8 355.2C446.5 359.1 465.1 363.4 476 361.9C495.6 359.2 510.7 361.8 511.4 361.9C512.5 362.1 513.2 363.1 513 364.2C512.8 365.3 511.8 366 510.7 365.8C510.5 365.8 495.6 363.2 476.6 365.8C475 366 473.2 366.1 471.2 366.1Z" fill="url(#paint79_linear_606_12100)"/>
+<path opacity="0.6" d="M291.4 296.1C291.2 296.1 291 295.9 291 295.7V294.1C291 293.9 291.2 293.7 291.4 293.7C291.6 293.7 291.8 293.9 291.8 294.1V295.7C291.8 295.9 291.6 296.1 291.4 296.1Z" fill="url(#paint80_linear_606_12100)"/>
+<path opacity="0.6" d="M291.4 342C291.2 342 291 341.8 291 341.6V338.3C291 338.1 291.2 337.9 291.4 337.9C291.6 337.9 291.8 338.1 291.8 338.3V341.6C291.8 341.8 291.6 342 291.4 342ZM291.4 335.4C291.2 335.4 291 335.2 291 335V331.7C291 331.5 291.2 331.3 291.4 331.3C291.6 331.3 291.8 331.5 291.8 331.7V335C291.8 335.3 291.6 335.4 291.4 335.4ZM291.4 328.9C291.2 328.9 291 328.7 291 328.5V325.2C291 325 291.2 324.8 291.4 324.8C291.6 324.8 291.8 325 291.8 325.2V328.5C291.8 328.7 291.6 328.9 291.4 328.9ZM291.4 322.3C291.2 322.3 291 322.1 291 321.9V318.6C291 318.4 291.2 318.2 291.4 318.2C291.6 318.2 291.8 318.4 291.8 318.6V321.9C291.8 322.2 291.6 322.3 291.4 322.3ZM291.4 315.8C291.2 315.8 291 315.6 291 315.4V312.1C291 311.9 291.2 311.7 291.4 311.7C291.6 311.7 291.8 311.9 291.8 312.1V315.4C291.8 315.6 291.6 315.8 291.4 315.8ZM291.4 309.2C291.2 309.2 291 309 291 308.8V305.5C291 305.3 291.2 305.1 291.4 305.1C291.6 305.1 291.8 305.3 291.8 305.5V308.8C291.8 309 291.6 309.2 291.4 309.2ZM291.4 302.7C291.2 302.7 291 302.5 291 302.3V299C291 298.8 291.2 298.6 291.4 298.6C291.6 298.6 291.8 298.8 291.8 299V302.3C291.8 302.5 291.6 302.7 291.4 302.7Z" fill="url(#paint81_linear_606_12100)"/>
+<path opacity="0.6" d="M291.4 346.9C291.2 346.9 291 346.7 291 346.5V344.9C291 344.7 291.2 344.5 291.4 344.5C291.6 344.5 291.8 344.7 291.8 344.9V346.5C291.8 346.7 291.6 346.9 291.4 346.9Z" fill="url(#paint82_linear_606_12100)"/>
+<path opacity="0.6" d="M202.6 285.5C202.4 285.5 202.2 285.3 202.2 285.1V283.5C202.2 283.3 202.4 283.1 202.6 283.1C202.8 283.1 203 283.3 203 283.5V285.1C203 285.3 202.8 285.5 202.6 285.5Z" fill="url(#paint83_linear_606_12100)"/>
+<path opacity="0.6" d="M202.6 331.4C202.4 331.4 202.2 331.2 202.2 331V327.7C202.2 327.5 202.4 327.3 202.6 327.3C202.8 327.3 203 327.5 203 327.7V331C203 331.2 202.8 331.4 202.6 331.4ZM202.6 324.8C202.4 324.8 202.2 324.6 202.2 324.4V321.1C202.2 320.9 202.4 320.7 202.6 320.7C202.8 320.7 203 320.9 203 321.1V324.4C203 324.6 202.8 324.8 202.6 324.8ZM202.6 318.3C202.4 318.3 202.2 318.1 202.2 317.9V314.6C202.2 314.4 202.4 314.2 202.6 314.2C202.8 314.2 203 314.4 203 314.6V317.9C203 318.1 202.8 318.3 202.6 318.3ZM202.6 311.7C202.4 311.7 202.2 311.5 202.2 311.3V308C202.2 307.8 202.4 307.6 202.6 307.6C202.8 307.6 203 307.8 203 308V311.3C203 311.5 202.8 311.7 202.6 311.7ZM202.6 305.2C202.4 305.2 202.2 305 202.2 304.8V301.5C202.2 301.3 202.4 301.1 202.6 301.1C202.8 301.1 203 301.3 203 301.5V304.8C203 305 202.8 305.2 202.6 305.2ZM202.6 298.6C202.4 298.6 202.2 298.4 202.2 298.2V294.9C202.2 294.7 202.4 294.5 202.6 294.5C202.8 294.5 203 294.7 203 294.9V298.2C203 298.4 202.8 298.6 202.6 298.6ZM202.6 292.1C202.4 292.1 202.2 291.9 202.2 291.7V288.4C202.2 288.2 202.4 288 202.6 288C202.8 288 203 288.2 203 288.4V291.7C203 291.9 202.8 292.1 202.6 292.1Z" fill="url(#paint84_linear_606_12100)"/>
+<path opacity="0.6" d="M202.6 336.3C202.4 336.3 202.2 336.1 202.2 335.9V334.3C202.2 334.1 202.4 333.9 202.6 333.9C202.8 333.9 203 334.1 203 334.3V335.9C203 336.1 202.8 336.3 202.6 336.3Z" fill="url(#paint85_linear_606_12100)"/>
+<path opacity="0.6" d="M246.6 310.4C246.4 310.4 246.2 310.2 246.2 310V308.4C246.2 308.2 246.4 308 246.6 308C246.8 308 247 308.2 247 308.4V310C247 310.2 246.9 310.4 246.6 310.4Z" fill="url(#paint86_linear_606_12100)"/>
+<path opacity="0.6" d="M246.6 336.6C246.4 336.6 246.2 336.4 246.2 336.2V332.9C246.2 332.7 246.4 332.5 246.6 332.5C246.8 332.5 247 332.7 247 332.9V336.2C247 336.4 246.9 336.6 246.6 336.6ZM246.6 330C246.4 330 246.2 329.8 246.2 329.6V326.3C246.2 326.1 246.4 325.9 246.6 325.9C246.8 325.9 247 326.1 247 326.3V329.6C247 329.8 246.9 330 246.6 330ZM246.6 323.5C246.4 323.5 246.2 323.3 246.2 323.1V319.8C246.2 319.6 246.4 319.4 246.6 319.4C246.8 319.4 247 319.6 247 319.8V323.1C247 323.3 246.9 323.5 246.6 323.5ZM246.6 316.9C246.4 316.9 246.2 316.7 246.2 316.5V313.2C246.2 313 246.4 312.8 246.6 312.8C246.8 312.8 247 313 247 313.2V316.5C247 316.7 246.9 316.9 246.6 316.9Z" fill="url(#paint87_linear_606_12100)"/>
+<path opacity="0.6" d="M331 361.7C330.8 361.7 330.6 361.5 330.6 361.3V358C330.6 357.8 330.8 357.6 331 357.6C331.2 357.6 331.4 357.8 331.4 358V361.3C331.4 361.6 331.2 361.7 331 361.7ZM331 355.2C330.8 355.2 330.6 355 330.6 354.8V351.5C330.6 351.3 330.8 351.1 331 351.1C331.2 351.1 331.4 351.3 331.4 351.5V354.8C331.4 355 331.2 355.2 331 355.2ZM331 348.6C330.8 348.6 330.6 348.4 330.6 348.2V344.9C330.6 344.7 330.8 344.5 331 344.5C331.2 344.5 331.4 344.7 331.4 344.9V348.2C331.4 348.4 331.2 348.6 331 348.6Z" fill="url(#paint88_linear_606_12100)"/>
+<g opacity="0.36">
+<path opacity="0.36" d="M257.7 317.7V317.5C257.7 316.8 258.5 316.3 259.1 316.7L265.2 320.2C265.6 320.4 265.9 320.9 265.9 321.4C265.9 322.1 265.1 322.6 264.5 322.2L258.3 318.6C257.9 318.5 257.7 318.1 257.7 317.7Z" fill="url(#paint89_linear_606_12100)"/>
+<path opacity="0.36" d="M257.7 322V321.8C257.7 321.1 258.5 320.6 259.1 321L271.2 328C271.6 328.2 271.9 328.7 271.9 329.2C271.9 329.9 271.1 330.4 270.5 330L258.3 323C257.9 322.7 257.7 322.4 257.7 322Z" fill="url(#paint90_linear_606_12100)"/>
+<path opacity="0.36" d="M257.7 325.9V325.7C257.7 325 258.5 324.5 259.1 324.9L266.1 328.9C266.5 329.1 266.8 329.6 266.8 330.1C266.8 330.8 266 331.3 265.4 330.9L258.3 326.8C257.9 326.7 257.7 326.3 257.7 325.9Z" fill="url(#paint91_linear_606_12100)"/>
+</g>
+<g opacity="0.4">
+<path opacity="0.6" d="M167.8 243.9C167.6 243.9 167.4 243.7 167.4 243.5V241.9C167.4 241.7 167.6 241.5 167.8 241.5C168 241.5 168.2 241.7 168.2 241.9V243.5C168.2 243.7 168 243.9 167.8 243.9Z" fill="url(#paint92_linear_606_12100)"/>
+<path opacity="0.6" d="M167.8 289.8C167.6 289.8 167.4 289.6 167.4 289.4V286.1C167.4 285.9 167.6 285.7 167.8 285.7C168 285.7 168.2 285.9 168.2 286.1V289.4C168.2 289.6 168 289.8 167.8 289.8ZM167.8 283.2C167.6 283.2 167.4 283 167.4 282.8V279.5C167.4 279.3 167.6 279.1 167.8 279.1C168 279.1 168.2 279.3 168.2 279.5V282.8C168.2 283.1 168 283.2 167.8 283.2ZM167.8 276.7C167.6 276.7 167.4 276.5 167.4 276.3V273C167.4 272.8 167.6 272.6 167.8 272.6C168 272.6 168.2 272.8 168.2 273V276.3C168.2 276.5 168 276.7 167.8 276.7ZM167.8 270.1C167.6 270.1 167.4 269.9 167.4 269.7V266.4C167.4 266.2 167.6 266 167.8 266C168 266 168.2 266.2 168.2 266.4V269.7C168.2 270 168 270.1 167.8 270.1ZM167.8 263.6C167.6 263.6 167.4 263.4 167.4 263.2V259.9C167.4 259.7 167.6 259.5 167.8 259.5C168 259.5 168.2 259.7 168.2 259.9V263.2C168.2 263.4 168 263.6 167.8 263.6ZM167.8 257C167.6 257 167.4 256.8 167.4 256.6V253.3C167.4 253.1 167.6 252.9 167.8 252.9C168 252.9 168.2 253.1 168.2 253.3V256.6C168.2 256.8 168 257 167.8 257ZM167.8 250.5C167.6 250.5 167.4 250.3 167.4 250.1V246.8C167.4 246.6 167.6 246.4 167.8 246.4C168 246.4 168.2 246.6 168.2 246.8V250.1C168.2 250.3 168 250.5 167.8 250.5Z" fill="url(#paint93_linear_606_12100)"/>
+<path opacity="0.6" d="M167.8 294.7C167.6 294.7 167.4 294.5 167.4 294.3V292.7C167.4 292.5 167.6 292.3 167.8 292.3C168 292.3 168.2 292.5 168.2 292.7V294.3C168.2 294.5 168 294.7 167.8 294.7Z" fill="url(#paint94_linear_606_12100)"/>
+</g>
+<path d="M741.1 284.1V477L701.7 477.2H658L658.2 332.2V331.6L658.4 331.4L740.8 284.2L741.1 284.1Z" fill="#020A47"/>
+<path d="M658.5 331.5V477.2H576.1L576.2 286.1V284.3L658.4 331.4L658.5 331.5Z" fill="url(#paint95_linear_606_12100)"/>
+<path opacity="0.39" d="M658.5 331.5V477.2H576.1L576.2 286.1V284.3L658.4 331.4L658.5 331.5Z" fill="url(#paint96_linear_606_12100)"/>
+<path d="M578.2 278.9L649.9 236.8C654.4 234.2 659.9 234.2 664.4 236.7L738.2 279.4C741.8 281.5 741.8 286.7 738.2 288.8L665.8 330.4C661.4 332.9 655.9 332.9 651.5 330.4L578.4 288.3C574.7 286.2 574.7 281 578.2 278.9Z" fill="url(#paint97_linear_606_12100)"/>
+<g opacity="0.6">
+<path opacity="0.5" d="M741 285.9V422.6H740V287.8C740.5 287.2 740.8 286.6 741 285.9Z" fill="url(#paint98_linear_606_12100)"/>
+</g>
+<g opacity="0.6">
+<path opacity="0.6" d="M658.9 332.7V467.8H657.9V332.7C658.1 332.7 658.3 332.7 658.5 332.7C658.6 332.7 658.8 332.7 658.9 332.7Z" fill="url(#paint99_linear_606_12100)"/>
+</g>
+<g opacity="0.6">
+<path opacity="0.6" d="M576.4 287.3V421.8H575.4V285.5C575.6 286.2 576 286.8 576.4 287.3Z" fill="url(#paint100_linear_606_12100)"/>
+</g>
+<g opacity="0.6">
+<path opacity="0.6" d="M658.5 332.7C655.9 332.7 653.4 332 651.1 330.7L578 288.7C576.2 287.6 575.1 285.7 575 283.6C574.9 281.5 576.1 279.6 577.9 278.5L649.6 236.4C654.2 233.7 660 233.7 664.6 236.3L738.4 279C740.2 280.1 741.3 282 741.3 284.1C741.3 286.2 740.2 288.1 738.3 289.2L665.9 330.8C663.7 332.1 661.1 332.7 658.5 332.7ZM578.5 279.4C577 280.3 576.1 281.9 576.1 283.7C576.1 285.5 577 287 578.6 287.9L651.7 330C656 332.5 661.3 332.5 665.5 330L737.9 288.4C739.4 287.5 740.4 285.9 740.4 284.2C740.4 282.5 739.5 280.8 738 279.9L664.2 237.2C659.9 234.7 654.5 234.7 650.2 237.2L578.5 279.4Z" fill="url(#paint101_linear_606_12100)"/>
+</g>
+<path d="M27.5 207.2V477.2H83.2L83 239L27.5 207.2Z" fill="#020A47"/>
+<path d="M138 207.3V367.3L82.8 400.5V238.9L138 207.3Z" fill="url(#paint102_linear_606_12100)"/>
+<path d="M136.6 203.7L88.5999 175.5C85.5999 173.7 81.9 173.7 78.9 175.5L29.5 204.1C27.1 205.5 27.1 209 29.5 210.4L78 238.2C81 239.9 84.5999 239.9 87.5999 238.2L136.6 210C139 208.6 139 205.1 136.6 203.7Z" fill="url(#paint103_linear_606_12100)"/>
+<g opacity="0.6">
+<path opacity="0.6" d="M83.2 239.9C81.5 239.9 79.7 239.5 78.1 238.6L29.1 210.4C27.8 209.7 27 208.3 27 206.9C27 205.4 27.8 204.1 29 203.3L77 175.1C80.1 173.3 84.1 173.2 87.2 175.1L136.6 203.7C137.9 204.4 138.7 205.8 138.7 207.3C138.7 208.8 137.9 210.1 136.6 210.9L88.1 238.7C86.6 239.5 84.9 239.9 83.2 239.9ZM29.6 204.1C28.6 204.7 28.1 205.7 28.1 206.8C28.1 207.9 28.7 208.9 29.7 209.5L78.7 237.7C81.5 239.3 85 239.3 87.8 237.7L136.3 209.9C137.3 209.3 137.9 208.3 137.9 207.2C137.9 206.1 137.3 205.1 136.3 204.5L86.9 175.9C84.1 174.3 80.5 174.3 77.7 175.9L29.6 204.1Z" fill="url(#paint104_linear_606_12100)"/>
+</g>
+<g opacity="0.6">
+<path opacity="0.6" d="M138.7 208.8H137.7V236H138.7V208.8Z" fill="url(#paint105_linear_606_12100)"/>
+</g>
+<path d="M145 477.2H62.3999V311.8L62.6999 311.9L63.3999 312.4L144.4 358.8L144.6 358.9L144.8 359V359.7L145 477.2Z" fill="#020A47"/>
+<path d="M226.5 477.2H144.5V358.9H144.6L144.8 358.8L226.3 312.1H226.4V313.8L226.5 477.2Z" fill="url(#paint106_linear_606_12100)"/>
+<path opacity="0.39" d="M226.5 477.2L226.4 313.8V312.1H226.3L144.8 358.8L144.6 358.9H144.5V359.7V477.2H145H226.5Z" fill="url(#paint107_linear_606_12100)"/>
+<path d="M224.4 306.7L153.1 264.8C148.7 262.2 143.2 262.2 138.7 264.7L65.3 307.2C61.7 309.3 61.7 314.4 65.3 316.5L137.3 357.8C141.7 360.3 147.1 360.3 151.6 357.8L224.3 316C227.9 313.9 227.9 308.8 224.4 306.7Z" fill="url(#paint108_linear_606_12100)"/>
+<g opacity="0.6">
+<path opacity="0.6" d="M144.5 360.2C142 360.2 139.4 359.5 137.1 358.2L65.0999 316.9C63.2999 315.8 62.2 313.9 62.2 311.8C62.2 309.7 63.2999 307.8 65.0999 306.7L138.5 264.2C143.1 261.5 148.8 261.6 153.4 264.3L224.7 306.2C226.5 307.3 227.6 309.2 227.6 311.3C227.6 313.4 226.5 315.3 224.7 316.3L152 358.1C149.6 359.5 147.1 360.2 144.5 360.2ZM145.9 263.3C143.5 263.3 141.1 263.9 139 265.2L65.5999 307.7C64.0999 308.6 63.2 310.2 63.2 311.9C63.2 313.6 64.0999 315.2 65.6999 316.1L137.7 357.4C141.9 359.8 147.2 359.8 151.5 357.4L224.2 315.6C225.7 314.7 226.6 313.1 226.6 311.4C226.6 309.6 225.7 308.1 224.2 307.2L152.9 265.3C150.7 263.9 148.3 263.3 145.9 263.3Z" fill="url(#paint109_linear_606_12100)"/>
+</g>
+<g opacity="0.6">
+<path opacity="0.2" d="M63.2 315.1V443H62.2V312.6C62.4 313.5 62.7 314.3 63.2 315.1Z" fill="url(#paint110_linear_606_12100)"/>
+</g>
+<g opacity="0.6">
+<path opacity="0.6" d="M145 360.2V477.2H144V360.2C144.2 360.2 144.3 360.2 144.5 360.2C144.7 360.2 144.8 360.2 145 360.2Z" fill="url(#paint111_linear_606_12100)"/>
+</g>
+<g opacity="0.6">
+<path opacity="0.6" d="M226.9 314.1V440.3H225.8V315.5C226.3 315.1 226.6 314.6 226.9 314.1Z" fill="url(#paint112_linear_606_12100)"/>
+</g>
+<path opacity="0.77" d="M271.3 266.6C282.1 256.3 299.6 256.3 310.4 266.6C321.2 276.9 321.1 293.6 310.3 303.8C299.5 314.1 282 314.1 271.2 303.8C260.4 293.6 260.5 276.9 271.3 266.6Z" fill="url(#paint113_radial_606_12100)"/>
+<path opacity="0.69" d="M285.6 280.2C288.5 277.4 293.2 277.4 296.1 280.2C299 283 299 287.4 296.1 290.2C293.2 293 288.5 293 285.6 290.2C282.7 287.5 282.7 283 285.6 280.2Z" fill="url(#paint114_radial_606_12100)"/>
+<path d="M282.6 210.8C282.4 210.2 282.1 210.2 281.6 210.2H281.5C280.9 210.2 280.3 210.1 279.7 209.9V209.8C280.2 210 280.8 210.1 281.5 210.1H281.6C282.1 210.1 282.4 210.1 282.6 210.8Z" fill="url(#paint115_linear_606_12100)"/>
+<path d="M283.2 213.3C283.3 213.7 283.3 214.1 283.4 214.5C283.3 214.1 283.3 213.7 283.2 213.3C283.1 212.6 283 212 282.9 211.6C283 212 283.1 212.6 283.2 213.3Z" fill="url(#paint116_linear_606_12100)"/>
+<g opacity="0.71">
+<path opacity="0.77" d="M379.4 114.4C373.7 109 364.4 109 358.7 114.4C353 119.8 353 128.6 358.8 134C364.5 139.4 373.8 139.4 379.5 134C385.2 128.5 385.1 119.8 379.4 114.4Z" fill="url(#paint117_radial_606_12100)"/>
+<path opacity="0.69" d="M371.8 121.5C370.3 120 367.8 120 366.2 121.5C364.7 123 364.7 125.3 366.2 126.8C367.7 128.3 370.2 128.3 371.8 126.8C373.4 125.3 373.4 123 371.8 121.5Z" fill="url(#paint118_radial_606_12100)"/>
+</g>
+<rect width="820" height="477" fill="url(#paint119_radial_606_12100)"/>
+<defs>
+<linearGradient id="paint0_linear_606_12100" x1="344.01" y1="214.926" x2="554.435" y2="189.334" gradientUnits="userSpaceOnUse">
+<stop stop-color="#5EE4E4"/>
+<stop offset="1" stop-color="#9B2AFF"/>
+</linearGradient>
+<radialGradient id="paint1_radial_606_12100" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(419.043 205.8) rotate(0.473079) scale(81.4026 45.6668)">
+<stop stop-color="#020A47"/>
+<stop offset="1" stop-color="#020A47" stop-opacity="0"/>
+</radialGradient>
+<linearGradient id="paint2_linear_606_12100" x1="390.457" y1="209.278" x2="470.723" y2="199.515" gradientUnits="userSpaceOnUse">
+<stop stop-color="#5EE4E4"/>
+<stop offset="1" stop-color="#9B2AFF"/>
+</linearGradient>
+<radialGradient id="paint3_radial_606_12100" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(419.087 205.8) rotate(0.473079) scale(41.38 23.2142)">
+<stop stop-color="#020A47"/>
+<stop offset="1" stop-color="#020A47" stop-opacity="0"/>
+</radialGradient>
+<linearGradient id="paint4_linear_606_12100" x1="675.557" y1="91.3521" x2="684.459" y2="289.424" gradientUnits="userSpaceOnUse">
+<stop stop-color="#4E547D"/>
+<stop offset="1" stop-color="#020A47"/>
+</linearGradient>
+<linearGradient id="paint5_linear_606_12100" x1="644.387" y1="82.3625" x2="788.825" y2="82.3625" gradientUnits="userSpaceOnUse">
+<stop stop-color="#111952"/>
+<stop offset="1" stop-color="#020A47"/>
+</linearGradient>
+<linearGradient id="paint6_linear_606_12100" x1="632.71" y1="90.8334" x2="656.651" y2="132.301" gradientUnits="userSpaceOnUse">
+<stop stop-color="#4E547D"/>
+<stop offset="0.3005" stop-color="#494E79" stop-opacity="0.7295"/>
+<stop offset="0.7471" stop-color="#373B6B" stop-opacity="0.3276"/>
+<stop offset="1" stop-color="#2A2F62" stop-opacity="0.1"/>
+</linearGradient>
+<linearGradient id="paint7_linear_606_12100" x1="737.029" y1="48.7183" x2="697.555" y2="117.089" gradientUnits="userSpaceOnUse">
+<stop stop-color="#2A2F62" stop-opacity="0.1"/>
+<stop offset="0.3328" stop-color="#333768" stop-opacity="0.3995"/>
+<stop offset="0.8939" stop-color="#494E79" stop-opacity="0.9045"/>
+<stop offset="1" stop-color="#4E547D"/>
+</linearGradient>
+<linearGradient id="paint8_linear_606_12100" x1="442.889" y1="184.495" x2="538.08" y2="184.495" gradientUnits="userSpaceOnUse">
+<stop stop-color="#9B2AFF" stop-opacity="0"/>
+<stop offset="0.5829" stop-color="#5EE4E4" stop-opacity="0.5829"/>
+<stop offset="1" stop-color="#5EE4E4"/>
+</linearGradient>
+<linearGradient id="paint9_linear_606_12100" x1="131.442" y1="91.3532" x2="122.54" y2="289.425" gradientUnits="userSpaceOnUse">
+<stop stop-color="#4E547D"/>
+<stop offset="1" stop-color="#020A47"/>
+</linearGradient>
+<linearGradient id="paint10_linear_606_12100" x1="162.613" y1="82.3625" x2="18.175" y2="82.3625" gradientUnits="userSpaceOnUse">
+<stop stop-color="#111952"/>
+<stop offset="1" stop-color="#020A47"/>
+</linearGradient>
+<linearGradient id="paint11_linear_606_12100" x1="174.656" y1="90.3907" x2="150.715" y2="131.858" gradientUnits="userSpaceOnUse">
+<stop stop-color="#4E547D"/>
+<stop offset="0.3005" stop-color="#494E79" stop-opacity="0.7295"/>
+<stop offset="0.7471" stop-color="#373B6B" stop-opacity="0.3276"/>
+<stop offset="1" stop-color="#2A2F62" stop-opacity="0.1"/>
+</linearGradient>
+<linearGradient id="paint12_linear_606_12100" x1="70.4699" y1="48.2167" x2="109.944" y2="116.589" gradientUnits="userSpaceOnUse">
+<stop stop-color="#2A2F62" stop-opacity="0.1"/>
+<stop offset="0.3328" stop-color="#333768" stop-opacity="0.3995"/>
+<stop offset="0.8939" stop-color="#494E79" stop-opacity="0.9045"/>
+<stop offset="1" stop-color="#4E547D"/>
+</linearGradient>
+<linearGradient id="paint13_linear_606_12100" x1="573.331" y1="77.2019" x2="637.718" y2="246.488" gradientUnits="userSpaceOnUse">
+<stop stop-color="#4E547D"/>
+<stop offset="0.2454" stop-color="#414773"/>
+<stop offset="0.7167" stop-color="#0A114D"/>
+<stop offset="1" stop-color="#020A47"/>
+</linearGradient>
+<linearGradient id="paint14_linear_606_12100" x1="563.357" y1="153.842" x2="574.127" y2="393.476" gradientUnits="userSpaceOnUse">
+<stop stop-color="#4E547D"/>
+<stop offset="1" stop-color="#020A47"/>
+</linearGradient>
+<linearGradient id="paint15_linear_606_12100" x1="471.64" y1="215.617" x2="565.779" y2="291.799" gradientUnits="userSpaceOnUse">
+<stop stop-color="#9B2AFF" stop-opacity="0.3"/>
+<stop offset="1" stop-color="#9B2AFF" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint16_linear_606_12100" x1="525.95" y1="143.356" x2="700.45" y2="143.356" gradientUnits="userSpaceOnUse">
+<stop stop-color="#4E547D"/>
+<stop offset="1" stop-color="#0F1650"/>
+</linearGradient>
+<linearGradient id="paint17_linear_606_12100" x1="548.366" y1="188.874" x2="604.447" y2="149.799" gradientUnits="userSpaceOnUse">
+<stop stop-color="#9B2AFF" stop-opacity="0.3"/>
+<stop offset="1" stop-color="#9B2AFF" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint18_linear_606_12100" x1="699.719" y1="142.919" x2="699.897" y2="196.027" gradientUnits="userSpaceOnUse">
+<stop stop-color="#4E547D"/>
+<stop offset="0.1061" stop-color="#494E79" stop-opacity="0.9045"/>
+<stop offset="0.6672" stop-color="#333768" stop-opacity="0.3995"/>
+<stop offset="1" stop-color="#2A2F62" stop-opacity="0.1"/>
+</linearGradient>
+<linearGradient id="paint19_linear_606_12100" x1="651.165" y1="161.381" x2="550.499" y2="114.009" gradientUnits="userSpaceOnUse">
+<stop stop-color="#4E547D" stop-opacity="0.7"/>
+<stop offset="1" stop-color="#4E547D"/>
+</linearGradient>
+<linearGradient id="paint20_linear_606_12100" x1="616.572" y1="159.849" x2="693.231" y2="289.612" gradientUnits="userSpaceOnUse">
+<stop stop-color="#2C3164"/>
+<stop offset="1" stop-color="#020A47"/>
+</linearGradient>
+<linearGradient id="paint21_linear_606_12100" x1="673.2" y1="206.813" x2="783.9" y2="206.813" gradientUnits="userSpaceOnUse">
+<stop stop-color="#111952"/>
+<stop offset="1" stop-color="#020A47"/>
+</linearGradient>
+<linearGradient id="paint22_linear_606_12100" x1="240.228" y1="77.2019" x2="175.841" y2="246.488" gradientUnits="userSpaceOnUse">
+<stop stop-color="#4E547D"/>
+<stop offset="0.2454" stop-color="#414773"/>
+<stop offset="0.7167" stop-color="#0A114D"/>
+<stop offset="1" stop-color="#020A47"/>
+</linearGradient>
+<linearGradient id="paint23_linear_606_12100" x1="250.202" y1="153.842" x2="239.432" y2="393.476" gradientUnits="userSpaceOnUse">
+<stop stop-color="#4E547D"/>
+<stop offset="1" stop-color="#020A47"/>
+</linearGradient>
+<linearGradient id="paint24_linear_606_12100" x1="341.918" y1="215.618" x2="247.778" y2="291.801" gradientUnits="userSpaceOnUse">
+<stop stop-color="#5EE4E4" stop-opacity="0.35"/>
+<stop offset="0.9944" stop-color="#5EE4E4" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint25_linear_606_12100" x1="287.609" y1="143.356" x2="113.109" y2="143.356" gradientUnits="userSpaceOnUse">
+<stop stop-color="#4E547D"/>
+<stop offset="1" stop-color="#0F1650"/>
+</linearGradient>
+<linearGradient id="paint26_linear_606_12100" x1="265.191" y1="188.873" x2="209.111" y2="149.798" gradientUnits="userSpaceOnUse">
+<stop stop-color="#5EE4E4" stop-opacity="0.3"/>
+<stop offset="1" stop-color="#5EE4E4" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint27_linear_606_12100" x1="113.415" y1="144.17" x2="113.593" y2="207.704" gradientUnits="userSpaceOnUse">
+<stop stop-color="#4E547D"/>
+<stop offset="0.1061" stop-color="#494E79" stop-opacity="0.9045"/>
+<stop offset="0.6672" stop-color="#333768" stop-opacity="0.3995"/>
+<stop offset="1" stop-color="#2A2F62" stop-opacity="0.1"/>
+</linearGradient>
+<linearGradient id="paint28_linear_606_12100" x1="162.395" y1="161.381" x2="263.06" y2="114.009" gradientUnits="userSpaceOnUse">
+<stop stop-color="#4E547D" stop-opacity="0.7"/>
+<stop offset="1" stop-color="#4E547D"/>
+</linearGradient>
+<linearGradient id="paint29_linear_606_12100" x1="743.867" y1="180.465" x2="713.516" y2="233.035" gradientUnits="userSpaceOnUse">
+<stop stop-color="#2A2F62" stop-opacity="0.1"/>
+<stop offset="0.3328" stop-color="#333768" stop-opacity="0.3995"/>
+<stop offset="0.8939" stop-color="#494E79" stop-opacity="0.9045"/>
+<stop offset="1" stop-color="#4E547D"/>
+</linearGradient>
+<linearGradient id="paint30_linear_606_12100" x1="665.63" y1="238.758" x2="680.72" y2="212.621" gradientUnits="userSpaceOnUse">
+<stop stop-color="#333768" stop-opacity="0.3995"/>
+<stop offset="1" stop-color="#4E547D" stop-opacity="0.7"/>
+</linearGradient>
+<linearGradient id="paint31_linear_606_12100" x1="504.368" y1="297.598" x2="462.814" y2="430.239" gradientUnits="userSpaceOnUse">
+<stop stop-color="#4E547D"/>
+<stop offset="0.2454" stop-color="#414773"/>
+<stop offset="0.7167" stop-color="#0A114D"/>
+<stop offset="1" stop-color="#020A47"/>
+</linearGradient>
+<linearGradient id="paint32_linear_606_12100" x1="414.389" y1="329.778" x2="453.035" y2="396.763" gradientUnits="userSpaceOnUse">
+<stop stop-color="#75BFE6" stop-opacity="0.3"/>
+<stop offset="1" stop-color="#75BFE6" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint33_linear_606_12100" x1="479.096" y1="310.808" x2="506.231" y2="346.628" gradientUnits="userSpaceOnUse">
+<stop stop-color="#4E547D"/>
+<stop offset="1" stop-color="#2A2F62"/>
+</linearGradient>
+<linearGradient id="paint34_linear_606_12100" x1="499.044" y1="295.91" x2="500.491" y2="343.308" gradientUnits="userSpaceOnUse">
+<stop stop-color="#9550EA" stop-opacity="0.3"/>
+<stop offset="1" stop-color="#9550EA" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint35_linear_606_12100" x1="536.782" y1="353.371" x2="587.218" y2="440.729" gradientUnits="userSpaceOnUse">
+<stop stop-color="#383846"/>
+<stop offset="0.1061" stop-color="#323340" stop-opacity="0.9045"/>
+<stop offset="0.6672" stop-color="#181B27" stop-opacity="0.3995"/>
+<stop offset="1" stop-color="#0E121D" stop-opacity="0.1"/>
+</linearGradient>
+<linearGradient id="paint36_linear_606_12100" x1="481.721" y1="384.934" x2="517.478" y2="446.867" gradientUnits="userSpaceOnUse">
+<stop stop-color="#383846"/>
+<stop offset="0.1061" stop-color="#323340" stop-opacity="0.9045"/>
+<stop offset="0.6672" stop-color="#181B27" stop-opacity="0.3995"/>
+<stop offset="1" stop-color="#0E121D" stop-opacity="0.1"/>
+</linearGradient>
+<linearGradient id="paint37_linear_606_12100" x1="483.253" y1="309.287" x2="517.163" y2="368.021" gradientUnits="userSpaceOnUse">
+<stop stop-color="#383846"/>
+<stop offset="1" stop-color="#383846"/>
+</linearGradient>
+<linearGradient id="paint38_linear_606_12100" x1="275.9" y1="203.928" x2="454.711" y2="203.928" gradientUnits="userSpaceOnUse">
+<stop stop-color="#5EE4E4"/>
+<stop offset="0.4171" stop-color="#5EE4E4" stop-opacity="0.5829"/>
+<stop offset="1" stop-color="#9B2AFF" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint39_linear_606_12100" x1="279.7" y1="235.148" x2="401.732" y2="235.148" gradientUnits="userSpaceOnUse">
+<stop stop-color="#60E4E4"/>
+<stop offset="0.4171" stop-color="#5EE4E4" stop-opacity="0.5829"/>
+<stop offset="1" stop-color="#9B2AFF" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint40_linear_606_12100" x1="275.989" y1="161.668" x2="371.8" y2="161.668" gradientUnits="userSpaceOnUse">
+<stop stop-color="#60E4E4"/>
+<stop offset="0.4171" stop-color="#5EE4E4" stop-opacity="0.5829"/>
+<stop offset="1" stop-color="#9B2AFF" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint41_linear_606_12100" x1="275.479" y1="160.875" x2="344.583" y2="159.914" gradientUnits="userSpaceOnUse">
+<stop stop-color="#60E4E4"/>
+<stop offset="0.4171" stop-color="#5EE4E4" stop-opacity="0.5829"/>
+<stop offset="1" stop-color="#9B2AFF" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint42_linear_606_12100" x1="275.9" y1="233.698" x2="338.192" y2="233.698" gradientUnits="userSpaceOnUse">
+<stop stop-color="#60E4E4"/>
+<stop offset="0.4171" stop-color="#5EE4E4" stop-opacity="0.5829"/>
+<stop offset="1" stop-color="#9B2AFF" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint43_linear_606_12100" x1="435.123" y1="322.548" x2="646.902" y2="152.98" gradientUnits="userSpaceOnUse">
+<stop stop-color="#5EE4E4"/>
+<stop offset="0.3286" stop-color="#5EE4E4" stop-opacity="0.5829"/>
+<stop offset="0.7877" stop-color="#9B2AFF" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint44_linear_606_12100" x1="370.137" y1="260.496" x2="336.775" y2="414.221" gradientUnits="userSpaceOnUse">
+<stop stop-color="#4E547D"/>
+<stop offset="0.1886" stop-color="#434974"/>
+<stop offset="0.703" stop-color="#0C144E"/>
+<stop offset="1" stop-color="#020A47"/>
+</linearGradient>
+<linearGradient id="paint45_linear_606_12100" x1="205.907" y1="206.676" x2="257.546" y2="342.446" gradientUnits="userSpaceOnUse">
+<stop stop-color="#4E547D"/>
+<stop offset="0.2454" stop-color="#414773"/>
+<stop offset="0.7167" stop-color="#0A114D"/>
+<stop offset="1" stop-color="#020A47"/>
+</linearGradient>
+<linearGradient id="paint46_linear_606_12100" x1="247.387" y1="282.563" x2="371.325" y2="282.563" gradientUnits="userSpaceOnUse">
+<stop stop-color="#303567"/>
+<stop offset="1" stop-color="#4E547D"/>
+</linearGradient>
+<linearGradient id="paint47_linear_606_12100" x1="320.513" y1="248.781" x2="306.041" y2="292.922" gradientUnits="userSpaceOnUse">
+<stop stop-color="#45A8DD" stop-opacity="0.3"/>
+<stop offset="0.1112" stop-color="#4CABDE" stop-opacity="0.2666"/>
+<stop offset="0.4829" stop-color="#63B6E2" stop-opacity="0.1551"/>
+<stop offset="0.7925" stop-color="#70BCE5" stop-opacity="0.0622495"/>
+<stop offset="1" stop-color="#74BEE6" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint48_linear_606_12100" x1="292.253" y1="253.187" x2="326.163" y2="311.921" gradientUnits="userSpaceOnUse">
+<stop stop-color="#4E547D"/>
+<stop offset="1" stop-color="#4E547D"/>
+</linearGradient>
+<linearGradient id="paint49_linear_606_12100" x1="451.7" y1="261.75" x2="622.6" y2="261.75" gradientUnits="userSpaceOnUse">
+<stop stop-color="#22ADF6"/>
+<stop offset="0.3705" stop-color="#4C8CF2" stop-opacity="0.5829"/>
+<stop offset="0.8883" stop-color="#9B2AFF" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint50_linear_606_12100" x1="433.9" y1="278.311" x2="651.21" y2="278.311" gradientUnits="userSpaceOnUse">
+<stop stop-color="#60E4E4"/>
+<stop offset="0.4171" stop-color="#5EE4E4" stop-opacity="0.5829"/>
+<stop offset="1" stop-color="#9B2AFF" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint51_linear_606_12100" x1="371.604" y1="414.458" x2="375.908" y2="311.167" gradientUnits="userSpaceOnUse">
+<stop stop-color="#020A47"/>
+<stop offset="1" stop-color="#4D527B"/>
+</linearGradient>
+<linearGradient id="paint52_linear_606_12100" x1="405.685" y1="436.631" x2="429.491" y2="395.398" gradientUnits="userSpaceOnUse">
+<stop stop-color="#2A2F62" stop-opacity="0.1"/>
+<stop offset="0.3328" stop-color="#333768" stop-opacity="0.3995"/>
+<stop offset="0.8939" stop-color="#494E79" stop-opacity="0.9045"/>
+<stop offset="1" stop-color="#4E547D"/>
+</linearGradient>
+<linearGradient id="paint53_linear_606_12100" x1="366.834" y1="418.113" x2="379.947" y2="440.826" gradientUnits="userSpaceOnUse">
+<stop stop-color="#4E547D"/>
+<stop offset="0.1061" stop-color="#494E79" stop-opacity="0.9045"/>
+<stop offset="0.6672" stop-color="#333768" stop-opacity="0.3995"/>
+<stop offset="1" stop-color="#2A2F62" stop-opacity="0.1"/>
+</linearGradient>
+<linearGradient id="paint54_linear_606_12100" x1="356.14" y1="390.391" x2="403.392" y2="383.879" gradientUnits="userSpaceOnUse">
+<stop stop-color="#2A2F62" stop-opacity="0.1"/>
+<stop offset="1" stop-color="#4E547D" stop-opacity="0.7"/>
+</linearGradient>
+<linearGradient id="paint55_linear_606_12100" x1="407.18" y1="207.256" x2="440.587" y2="203.193" gradientUnits="userSpaceOnUse">
+<stop offset="0.2691" stop-color="#5EE4E4"/>
+<stop offset="0.3452" stop-color="#64D9E4"/>
+<stop offset="0.4773" stop-color="#73BDE4"/>
+<stop offset="0.6498" stop-color="#8B8FE4"/>
+<stop offset="0.8537" stop-color="#AC4FE5"/>
+<stop offset="0.9472" stop-color="#BD30E5"/>
+<stop offset="0.9518" stop-color="#9B2AFF"/>
+</linearGradient>
+<linearGradient id="paint56_linear_606_12100" x1="419.1" y1="38.1709" x2="419.1" y2="209.345" gradientUnits="userSpaceOnUse">
+<stop stop-color="#9B2AFF" stop-opacity="0"/>
+<stop offset="1" stop-color="#5EE4E4"/>
+</linearGradient>
+<linearGradient id="paint57_linear_606_12100" x1="429.669" y1="253.84" x2="619.98" y2="253.84" gradientUnits="userSpaceOnUse">
+<stop stop-color="#60E4E4"/>
+<stop offset="0.1399" stop-color="#5EE4E4" stop-opacity="0.8406"/>
+<stop offset="0.3566" stop-color="#60E4E4" stop-opacity="0.5935"/>
+<stop offset="0.6214" stop-color="#5EE4E4" stop-opacity="0.2915"/>
+<stop offset="0.8771" stop-color="#8C58EB" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint58_linear_606_12100" x1="507.9" y1="264.181" x2="507.9" y2="324.693" gradientUnits="userSpaceOnUse">
+<stop stop-color="#22ADF6"/>
+<stop offset="0.3705" stop-color="#4C8CF2" stop-opacity="0.5829"/>
+<stop offset="0.8883" stop-color="#8C58EB" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint59_linear_606_12100" x1="507.9" y1="264.181" x2="507.9" y2="324.693" gradientUnits="userSpaceOnUse">
+<stop stop-color="#22ADF6"/>
+<stop offset="0.3705" stop-color="#4C8CF2" stop-opacity="0.5829"/>
+<stop offset="0.8883" stop-color="#8C58EB" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint60_linear_606_12100" x1="507.9" y1="264.181" x2="507.9" y2="324.693" gradientUnits="userSpaceOnUse">
+<stop stop-color="#22ADF6"/>
+<stop offset="0.3705" stop-color="#4C8CF2" stop-opacity="0.5829"/>
+<stop offset="0.8883" stop-color="#8C58EB" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint61_linear_606_12100" x1="539.3" y1="286.07" x2="539.3" y2="346.583" gradientUnits="userSpaceOnUse">
+<stop stop-color="#60E4E4"/>
+<stop offset="0.3705" stop-color="#5EE4E4" stop-opacity="0.5829"/>
+<stop offset="0.8883" stop-color="#8C58EB" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint62_linear_606_12100" x1="539.3" y1="289.715" x2="539.3" y2="313.691" gradientUnits="userSpaceOnUse">
+<stop stop-color="#60E4E4"/>
+<stop offset="0.3705" stop-color="#5EE4E4" stop-opacity="0.5829"/>
+<stop offset="0.8883" stop-color="#8C58EB" stop-opacity="0"/>
+</linearGradient>
+<radialGradient id="paint63_radial_606_12100" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(427.43 329.513) rotate(0.402554) scale(19.9561 19.3631)">
+<stop stop-color="#5EE4E4"/>
+<stop offset="1" stop-color="#5EE4E4" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint64_radial_606_12100" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(427.398 329.5) scale(5.23444 4.95887)">
+<stop stop-color="white"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint65_radial_606_12100" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(507.75 262.764) scale(7.8404)">
+<stop stop-color="#020A47"/>
+<stop offset="1" stop-color="#5EE4E4"/>
+</radialGradient>
+<radialGradient id="paint66_radial_606_12100" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(507.719 262.786) scale(3.0155)">
+<stop stop-color="#020A47"/>
+<stop offset="1" stop-color="#5EE4E4"/>
+</radialGradient>
+<linearGradient id="paint67_linear_606_12100" x1="548.876" y1="273.15" x2="557.401" y2="273.15" gradientUnits="userSpaceOnUse">
+<stop stop-color="#60E4E4"/>
+<stop offset="0.4171" stop-color="#5EE4E4" stop-opacity="0.5829"/>
+<stop offset="1" stop-color="#8C58EB" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint68_linear_606_12100" x1="549.182" y1="280.279" x2="558.511" y2="280.279" gradientUnits="userSpaceOnUse">
+<stop stop-color="#60E4E4"/>
+<stop offset="0.4171" stop-color="#5EE4E4" stop-opacity="0.5829"/>
+<stop offset="1" stop-color="#8C58EB" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint69_linear_606_12100" x1="548.948" y1="275.6" x2="561.948" y2="275.6" gradientUnits="userSpaceOnUse">
+<stop stop-color="#60E4E4"/>
+<stop offset="0.4171" stop-color="#5EE4E4" stop-opacity="0.5829"/>
+<stop offset="1" stop-color="#8C58EB" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint70_linear_606_12100" x1="130.469" y1="297.035" x2="625.285" y2="297.035" gradientUnits="userSpaceOnUse">
+<stop stop-color="#5EE4E4" stop-opacity="0.3"/>
+<stop offset="0.4022" stop-color="#5EE4E4"/>
+<stop offset="0.6166" stop-color="#5EE4E4" stop-opacity="0.5829"/>
+<stop offset="0.9162" stop-color="#9B2AFF" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint71_linear_606_12100" x1="432.678" y1="329.587" x2="440.988" y2="329.587" gradientUnits="userSpaceOnUse">
+<stop stop-color="#22ADF6"/>
+<stop offset="0.3705" stop-color="#4C8CF2" stop-opacity="0.5829"/>
+<stop offset="0.8883" stop-color="#8C58EB" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint72_linear_606_12100" x1="480.6" y1="309.678" x2="480.6" y2="370.191" gradientUnits="userSpaceOnUse">
+<stop stop-color="#60E4E4"/>
+<stop offset="0.3705" stop-color="#5EE4E4" stop-opacity="0.5829"/>
+<stop offset="0.8883" stop-color="#8C58EB" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint73_linear_606_12100" x1="480.6" y1="314.234" x2="480.6" y2="329.076" gradientUnits="userSpaceOnUse">
+<stop stop-color="#60E4E4"/>
+<stop offset="0.3705" stop-color="#5EE4E4" stop-opacity="0.5829"/>
+<stop offset="0.8883" stop-color="#8C58EB" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint74_linear_606_12100" x1="584.6" y1="264.392" x2="584.6" y2="324.904" gradientUnits="userSpaceOnUse">
+<stop stop-color="#22ADF6"/>
+<stop offset="0.3705" stop-color="#4C8CF2" stop-opacity="0.5829"/>
+<stop offset="0.8883" stop-color="#8C58EB" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint75_linear_606_12100" x1="584.6" y1="267.125" x2="584.6" y2="300.235" gradientUnits="userSpaceOnUse">
+<stop stop-color="#22ADF6"/>
+<stop offset="0.3705" stop-color="#4C8CF2" stop-opacity="0.5829"/>
+<stop offset="0.8883" stop-color="#8C58EB" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint76_linear_606_12100" x1="563.5" y1="266.562" x2="563.5" y2="299.673" gradientUnits="userSpaceOnUse">
+<stop stop-color="#22ADF6"/>
+<stop offset="0.3705" stop-color="#4C8CF2" stop-opacity="0.5829"/>
+<stop offset="0.8883" stop-color="#8C58EB" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint77_linear_606_12100" x1="563.5" y1="250.726" x2="563.5" y2="311.239" gradientUnits="userSpaceOnUse">
+<stop stop-color="#22ADF6"/>
+<stop offset="0.3705" stop-color="#4C8CF2" stop-opacity="0.5829"/>
+<stop offset="0.8883" stop-color="#8C58EB" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint78_linear_606_12100" x1="143.912" y1="224.885" x2="449.427" y2="395.614" gradientUnits="userSpaceOnUse">
+<stop stop-color="#60E4E4" stop-opacity="0.1"/>
+<stop offset="0.3743" stop-color="#60E4E4"/>
+<stop offset="0.6353" stop-color="#5EE4E4" stop-opacity="0.5829"/>
+<stop offset="1" stop-color="#9B2AFF" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint79_linear_606_12100" x1="513.034" y1="287.262" x2="98.9229" y2="287.262" gradientUnits="userSpaceOnUse">
+<stop stop-color="#9B2AFF" stop-opacity="0"/>
+<stop offset="0.3484" stop-color="#5EE4E4" stop-opacity="0.5829"/>
+<stop offset="0.5978" stop-color="#60E4E4"/>
+<stop offset="1" stop-color="#60E4E4" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint80_linear_606_12100" x1="291.4" y1="292.551" x2="291.4" y2="353.064" gradientUnits="userSpaceOnUse">
+<stop stop-color="#60E4E4"/>
+<stop offset="0.3705" stop-color="#5EE4E4" stop-opacity="0.5829"/>
+<stop offset="0.8883" stop-color="#9B2AFF" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint81_linear_606_12100" x1="291.4" y1="292.551" x2="291.4" y2="353.064" gradientUnits="userSpaceOnUse">
+<stop stop-color="#60E4E4"/>
+<stop offset="0.3705" stop-color="#5EE4E4" stop-opacity="0.5829"/>
+<stop offset="0.8883" stop-color="#9B2AFF" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint82_linear_606_12100" x1="291.4" y1="292.551" x2="291.4" y2="353.064" gradientUnits="userSpaceOnUse">
+<stop stop-color="#60E4E4"/>
+<stop offset="0.3705" stop-color="#5EE4E4" stop-opacity="0.5829"/>
+<stop offset="0.8883" stop-color="#9B2AFF" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint83_linear_606_12100" x1="202.6" y1="281.938" x2="202.6" y2="342.451" gradientUnits="userSpaceOnUse">
+<stop stop-color="#60E4E4"/>
+<stop offset="0.3705" stop-color="#5EE4E4" stop-opacity="0.5829"/>
+<stop offset="0.8883" stop-color="#9B2AFF" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint84_linear_606_12100" x1="202.6" y1="281.938" x2="202.6" y2="342.451" gradientUnits="userSpaceOnUse">
+<stop stop-color="#60E4E4"/>
+<stop offset="0.3705" stop-color="#5EE4E4" stop-opacity="0.5829"/>
+<stop offset="0.8883" stop-color="#9B2AFF" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint85_linear_606_12100" x1="202.6" y1="281.938" x2="202.6" y2="342.451" gradientUnits="userSpaceOnUse">
+<stop stop-color="#60E4E4"/>
+<stop offset="0.3705" stop-color="#5EE4E4" stop-opacity="0.5829"/>
+<stop offset="0.8883" stop-color="#9B2AFF" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint86_linear_606_12100" x1="246.6" y1="306.782" x2="246.6" y2="367.295" gradientUnits="userSpaceOnUse">
+<stop stop-color="#60E4E4"/>
+<stop offset="0.3705" stop-color="#5EE4E4" stop-opacity="0.5829"/>
+<stop offset="0.8883" stop-color="#9B2AFF" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint87_linear_606_12100" x1="246.6" y1="309.516" x2="246.6" y2="342.626" gradientUnits="userSpaceOnUse">
+<stop stop-color="#60E4E4"/>
+<stop offset="0.3705" stop-color="#5EE4E4" stop-opacity="0.5829"/>
+<stop offset="0.8883" stop-color="#9B2AFF" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint88_linear_606_12100" x1="331" y1="342.145" x2="331" y2="366.122" gradientUnits="userSpaceOnUse">
+<stop stop-color="#60E4E4"/>
+<stop offset="0.3705" stop-color="#5EE4E4" stop-opacity="0.5829"/>
+<stop offset="0.8883" stop-color="#9B2AFF" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint89_linear_606_12100" x1="265.885" y1="319.45" x2="257.74" y2="319.45" gradientUnits="userSpaceOnUse">
+<stop stop-color="#9B2AFF" stop-opacity="0"/>
+<stop offset="0.5829" stop-color="#5EE4E4" stop-opacity="0.5829"/>
+<stop offset="1" stop-color="#60E4E4"/>
+</linearGradient>
+<linearGradient id="paint90_linear_606_12100" x1="271.9" y1="325.5" x2="257.732" y2="325.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#9B2AFF" stop-opacity="0"/>
+<stop offset="0.5829" stop-color="#5EE4E4" stop-opacity="0.5829"/>
+<stop offset="1" stop-color="#60E4E4"/>
+</linearGradient>
+<linearGradient id="paint91_linear_606_12100" x1="266.8" y1="327.9" x2="257.742" y2="327.9" gradientUnits="userSpaceOnUse">
+<stop stop-color="#9B2AFF" stop-opacity="0"/>
+<stop offset="0.5829" stop-color="#5EE4E4" stop-opacity="0.5829"/>
+<stop offset="1" stop-color="#60E4E4"/>
+</linearGradient>
+<linearGradient id="paint92_linear_606_12100" x1="167.8" y1="240.35" x2="167.8" y2="300.863" gradientUnits="userSpaceOnUse">
+<stop stop-color="#60E4E4"/>
+<stop offset="0.3705" stop-color="#5EE4E4" stop-opacity="0.5829"/>
+<stop offset="0.8883" stop-color="#9B2AFF" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint93_linear_606_12100" x1="167.8" y1="240.35" x2="167.8" y2="300.863" gradientUnits="userSpaceOnUse">
+<stop stop-color="#60E4E4"/>
+<stop offset="0.3705" stop-color="#5EE4E4" stop-opacity="0.5829"/>
+<stop offset="0.8883" stop-color="#9B2AFF" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint94_linear_606_12100" x1="167.8" y1="240.35" x2="167.8" y2="300.863" gradientUnits="userSpaceOnUse">
+<stop stop-color="#60E4E4"/>
+<stop offset="0.3705" stop-color="#5EE4E4" stop-opacity="0.5829"/>
+<stop offset="0.8883" stop-color="#9B2AFF" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint95_linear_606_12100" x1="611.351" y1="271.994" x2="620.084" y2="466.286" gradientUnits="userSpaceOnUse">
+<stop stop-color="#4E547D"/>
+<stop offset="0.0941991" stop-color="#494E79"/>
+<stop offset="0.4271" stop-color="#141B54"/>
+<stop offset="0.7372" stop-color="#070F4B"/>
+<stop offset="1" stop-color="#020A47"/>
+</linearGradient>
+<linearGradient id="paint96_linear_606_12100" x1="541.003" y1="272.102" x2="594.349" y2="364.569" gradientUnits="userSpaceOnUse">
+<stop stop-color="#9550EA" stop-opacity="0.3"/>
+<stop offset="1" stop-color="#9550EA" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint97_linear_606_12100" x1="575.6" y1="283.556" x2="768.937" y2="283.556" gradientUnits="userSpaceOnUse">
+<stop stop-color="#4D527B"/>
+<stop offset="1" stop-color="#020A47"/>
+</linearGradient>
+<linearGradient id="paint98_linear_606_12100" x1="711.16" y1="405.947" x2="770.59" y2="303.012" gradientUnits="userSpaceOnUse">
+<stop stop-color="#2A2F62" stop-opacity="0.1"/>
+<stop offset="0.3328" stop-color="#333768" stop-opacity="0.3995"/>
+<stop offset="0.8939" stop-color="#494E79" stop-opacity="0.9045"/>
+<stop offset="1" stop-color="#4E547D"/>
+</linearGradient>
+<linearGradient id="paint99_linear_606_12100" x1="629.021" y1="451.125" x2="687.775" y2="349.359" gradientUnits="userSpaceOnUse">
+<stop stop-color="#2A2F62" stop-opacity="0.1"/>
+<stop offset="0.3328" stop-color="#333768" stop-opacity="0.3995"/>
+<stop offset="0.8939" stop-color="#494E79" stop-opacity="0.9045"/>
+<stop offset="1" stop-color="#4E547D"/>
+</linearGradient>
+<linearGradient id="paint100_linear_606_12100" x1="546.274" y1="404.982" x2="605.276" y2="302.787" gradientUnits="userSpaceOnUse">
+<stop stop-color="#2A2F62" stop-opacity="0.1"/>
+<stop offset="0.3328" stop-color="#333768" stop-opacity="0.3995"/>
+<stop offset="0.8939" stop-color="#494E79" stop-opacity="0.9045"/>
+<stop offset="1" stop-color="#4E547D"/>
+</linearGradient>
+<linearGradient id="paint101_linear_606_12100" x1="635.499" y1="244.541" x2="680.537" y2="322.55" gradientUnits="userSpaceOnUse">
+<stop stop-color="#4E547D"/>
+<stop offset="1" stop-color="#4E547D"/>
+</linearGradient>
+<linearGradient id="paint102_linear_606_12100" x1="97.5345" y1="342.04" x2="151.806" y2="177.778" gradientUnits="userSpaceOnUse">
+<stop stop-color="#020A47"/>
+<stop offset="1" stop-color="#2C3164"/>
+</linearGradient>
+<linearGradient id="paint103_linear_606_12100" x1="138.4" y1="206.813" x2="27.7" y2="206.813" gradientUnits="userSpaceOnUse">
+<stop stop-color="#111952"/>
+<stop offset="1" stop-color="#020A47"/>
+</linearGradient>
+<linearGradient id="paint104_linear_606_12100" x1="67.5499" y1="180.556" x2="97.8998" y2="233.124" gradientUnits="userSpaceOnUse">
+<stop stop-color="#2A2F62" stop-opacity="0.1"/>
+<stop offset="0.3328" stop-color="#333768" stop-opacity="0.3995"/>
+<stop offset="0.8939" stop-color="#494E79" stop-opacity="0.9045"/>
+<stop offset="1" stop-color="#4E547D"/>
+</linearGradient>
+<linearGradient id="paint105_linear_606_12100" x1="132.202" y1="212.012" x2="144.23" y2="232.845" gradientUnits="userSpaceOnUse">
+<stop stop-color="#4E547D"/>
+<stop offset="0.2966" stop-color="#4B507A" stop-opacity="0.7331"/>
+<stop offset="0.6311" stop-color="#3D4370" stop-opacity="0.432"/>
+<stop offset="0.9829" stop-color="#2A2F62" stop-opacity="0.1154"/>
+<stop offset="1" stop-color="#2A2F62" stop-opacity="0.1"/>
+</linearGradient>
+<linearGradient id="paint106_linear_606_12100" x1="243.965" y1="231.429" x2="186.386" y2="415.221" gradientUnits="userSpaceOnUse">
+<stop stop-color="#484D79"/>
+<stop offset="0.2454" stop-color="#3B416F"/>
+<stop offset="0.7167" stop-color="#0A114D"/>
+<stop offset="1" stop-color="#020A47"/>
+</linearGradient>
+<linearGradient id="paint107_linear_606_12100" x1="150.078" y1="333.339" x2="186.822" y2="397.029" gradientUnits="userSpaceOnUse">
+<stop stop-color="#5EE4E4" stop-opacity="0.3"/>
+<stop offset="1" stop-color="#5EE4E4" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint108_linear_606_12100" x1="232.736" y1="282.057" x2="64.4033" y2="338.167" gradientUnits="userSpaceOnUse">
+<stop stop-color="#464B77"/>
+<stop offset="1" stop-color="#020A47"/>
+</linearGradient>
+<linearGradient id="paint109_linear_606_12100" x1="122.797" y1="273.266" x2="166.907" y2="349.668" gradientUnits="userSpaceOnUse">
+<stop stop-color="#484D79" stop-opacity="0"/>
+<stop offset="1" stop-color="#484D79"/>
+</linearGradient>
+<linearGradient id="paint110_linear_606_12100" x1="34.3425" y1="426.915" x2="90.8198" y2="329.093" gradientUnits="userSpaceOnUse">
+<stop stop-color="#23295D" stop-opacity="0.1"/>
+<stop offset="0.3328" stop-color="#2C3263" stop-opacity="0.3995"/>
+<stop offset="0.8939" stop-color="#424774" stop-opacity="0.9045"/>
+<stop offset="1" stop-color="#484D79"/>
+</linearGradient>
+<linearGradient id="paint111_linear_606_12100" x1="119.039" y1="462.787" x2="169.961" y2="374.589" gradientUnits="userSpaceOnUse">
+<stop stop-color="#23295D" stop-opacity="0.1"/>
+<stop offset="0.3328" stop-color="#2C3263" stop-opacity="0.3995"/>
+<stop offset="0.8939" stop-color="#424774" stop-opacity="0.9045"/>
+<stop offset="1" stop-color="#484D79"/>
+</linearGradient>
+<linearGradient id="paint112_linear_606_12100" x1="199.19" y1="424.935" x2="254.129" y2="329.779" gradientUnits="userSpaceOnUse">
+<stop stop-color="#23295D" stop-opacity="0.1"/>
+<stop offset="0.3328" stop-color="#2C3263" stop-opacity="0.3995"/>
+<stop offset="0.8939" stop-color="#424774" stop-opacity="0.9045"/>
+<stop offset="1" stop-color="#484D79"/>
+</linearGradient>
+<radialGradient id="paint113_radial_606_12100" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(290.808 285.216) rotate(179.6) scale(27.1239 26.1406)">
+<stop stop-color="#5EE4E4"/>
+<stop offset="1" stop-color="#5EE4E4" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint114_radial_606_12100" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(290.821 285.2) rotate(180) scale(7.10437 6.68496)">
+<stop stop-color="white"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</radialGradient>
+<linearGradient id="paint115_linear_606_12100" x1="279.7" y1="210.303" x2="282.634" y2="210.303" gradientUnits="userSpaceOnUse">
+<stop stop-color="#60E4E4"/>
+<stop offset="0.4171" stop-color="#5EE4E4" stop-opacity="0.5829"/>
+<stop offset="1" stop-color="#8C58EB" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint116_linear_606_12100" x1="282.87" y1="213.038" x2="283.401" y2="213.038" gradientUnits="userSpaceOnUse">
+<stop stop-color="#60E4E4"/>
+<stop offset="0.4171" stop-color="#5EE4E4" stop-opacity="0.5829"/>
+<stop offset="1" stop-color="#8C58EB" stop-opacity="0"/>
+</linearGradient>
+<radialGradient id="paint117_radial_606_12100" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(369.08 124.221) rotate(0.396385) scale(14.3792 13.7382)">
+<stop stop-color="#5EE4E4"/>
+<stop offset="1" stop-color="#5EE4E4" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint118_radial_606_12100" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(369.062 124.15) scale(3.7662 3.51325)">
+<stop stop-color="white"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint119_radial_606_12100" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(410 238.5) rotate(90) scale(256.778 441.421)">
+<stop offset="0.59375" stop-color="#11111C" stop-opacity="0"/>
+<stop offset="0.808881" stop-color="#11111C" stop-opacity="0.5"/>
+<stop offset="1" stop-color="#11111C"/>
+</radialGradient>
+</defs>
 </svg>


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/4832

Adds the correct SVG: 

<img width="1463" alt="Screen Shot 2022-06-21 at 11 36 12 AM" src="https://user-images.githubusercontent.com/18511823/174873604-2b2f1f93-fad2-4c8b-a6ab-0e3c61246f49.png">


<!-- Describe your proposed changes here. -->
