### PR TITLE
test: skip flaky test for search bar

### DIFF
--- a/cypress/e2e/shared/fluxQueryBuilder.test.ts
+++ b/cypress/e2e/shared/fluxQueryBuilder.test.ts
@@ -80,7 +80,7 @@ describe('FluxQueryBuilder', () => {
       cy.getByTestID('tag-selector-key').should('be.visible')
     })
 
-    it('search bar can search fields and tag keys dynamically', () => {
+    it.skip('search bar can search fields and tag keys dynamically', () => {
       // select a bucket
       cy.getByTestID('bucket-selector--dropdown-button').click()
       cy.getByTestID(`searchable-dropdown--item ${bucketName}`).click()


### PR DESCRIPTION
This PR temporally skip the flaky test to unblock monitor-ci-test. The flaky test may related to local storage. I will fix it in another PR. 