### PR TITLE
fix: disabling eslint warnings

### DIFF
--- a/src/accounts/SwitchAccountOverlay.tsx
+++ b/src/accounts/SwitchAccountOverlay.tsx
@@ -126,7 +126,7 @@ export const SwitchAccountOverlay: FC<Props> = ({onDismissOverlay}) => {
           : ComponentStatus.Default
       setDefaultButtonStatus(defaultSwitchStatus)
     }
-  }, [newAccountId])
+  }, [newAccountId]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const disabledTitleText =
     'Select a Different Account to Enable the Switch Button'

--- a/src/accounts/context/userAccount.tsx
+++ b/src/accounts/context/userAccount.tsx
@@ -102,7 +102,7 @@ export const UserAccountProvider: FC<Props> = React.memo(({children}) => {
     } catch (error) {
       event('multiAccount.retrieveAccounts.error', {error})
     }
-  }, [dispatch, defaultAccountId])
+  }, [dispatch, defaultAccountId]) // eslint-disable-line react-hooks/exhaustive-deps
 
   async function handleSetDefaultAccount(newDefaultAcctId) {
     const accountName = getAccountNameById(newDefaultAcctId)

--- a/src/authorizations/components/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/CustomApiTokenOverlay.tsx
@@ -81,7 +81,7 @@ const CustomApiTokenOverlay: FC<Props> = props => {
   useEffect(() => {
     props.getBuckets()
     props.getTelegrafs()
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (!isEmpty(props.bucketPermissions.sublevelPermissions)) {
@@ -109,7 +109,7 @@ const CustomApiTokenOverlay: FC<Props> = props => {
     // BUT, code inside the hook won't run until remoteDataState is 'Done'.
     // Only then will props.bucketPermissions.sublevelPermissions will have value.
     // Consequently, we update the permissions state.
-  }, [props.remoteDataState])
+  }, [props.remoteDataState]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleDismiss = () => {
     props.onClose()

--- a/src/authorizations/components/EditTokenOverlay.tsx
+++ b/src/authorizations/components/EditTokenOverlay.tsx
@@ -61,7 +61,7 @@ const EditTokenOverlay: FC<Props> = props => {
     if (_.isEmpty(permissions)) {
       formatPermissions()
     }
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const formatPermissions = async () => {
     const {

--- a/src/buckets/components/createBucketForm/MeasurementSchemaSection.tsx
+++ b/src/buckets/components/createBucketForm/MeasurementSchemaSection.tsx
@@ -616,7 +616,7 @@ export const MeasurementSchemaSection: FC<Props> = ({
   // this fixes that by only remaking panels when one is deleted or added.
   // only re-making them when one is added or removed removes the need for debouncing the update
   // (it was debounced to prevent re-renderings with each keystroke when the name was being entered)
-  const addPanels = useMemo(() => makeAddPanels(), [
+  const addPanels = useMemo(() => makeAddPanels(), [ // eslint-disable-line react-hooks/exhaustive-deps
     newSchemas.length,
     showSchemaValidation,
   ])

--- a/src/checkout/context/checkout.tsx
+++ b/src/checkout/context/checkout.tsx
@@ -321,7 +321,7 @@ export const CheckoutProvider: FC<Props> = React.memo(({children}) => {
         setIsSubmitting(false)
       }
     },
-    [dispatch, getInvalidFields, handleSetErrors, inputs, isDirty]
+    [dispatch, getInvalidFields, handleSetErrors, inputs, isDirty] // eslint-disable-line react-hooks/exhaustive-deps
   )
 
   const history = useHistory()

--- a/src/cloud/components/experiments/DatalessEmptyState.tsx
+++ b/src/cloud/components/experiments/DatalessEmptyState.tsx
@@ -51,7 +51,7 @@ const DatalessEmptyState: FC<Props> = ({orgID, buckets, children}) => {
         setUserHasData(true)
         throw new Error(error)
       })
-  }, [buckets])
+  }, [buckets]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const checkBucketsHaveData = async (
     userBuckets,

--- a/src/cloud/components/experiments/GoogleOptimizeExperiment.tsx
+++ b/src/cloud/components/experiments/GoogleOptimizeExperiment.tsx
@@ -31,7 +31,7 @@ export const GoogleOptimizeExperiment: FC<Props> = ({
   const me = useSelector(getMe)
   const org = useSelector(getOrg)
 
-  useEffect(() => {
+  useEffect(() => { // eslint-disable-line react-hooks/exhaustive-deps
     setExperimentVariantId(
       getExperimentVariantId(experimentID, activationEvent)
     )

--- a/src/cloud/components/onboarding/EngagementLink.tsx
+++ b/src/cloud/components/onboarding/EngagementLink.tsx
@@ -31,7 +31,7 @@ const EngagementLink: FC = () => {
       sendToUserPilot()
       userpilot.reload()
     }
-  }, [pathname, org, me])
+  }, [pathname, org, me]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const sendToUserPilot = (): void => {
     const host = window?.location?.hostname.split('.')

--- a/src/dashboards/components/DashboardContainer.tsx
+++ b/src/dashboards/components/DashboardContainer.tsx
@@ -86,7 +86,7 @@ const DashboardContainer: FC = () => {
     } else if (document.visibilityState === 'visible') {
       GlobalAutoRefresher.poll(autoRefresh, stopFunc)
     }
-  }, [autoRefresh.status, stopFunc])
+  }, [autoRefresh.status, stopFunc]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (isEditing) {
@@ -112,7 +112,7 @@ const DashboardContainer: FC = () => {
       GlobalAutoRefresher.stopPolling()
       document.removeEventListener('visibilitychange', visChangeHandler)
     }
-  }, [
+  }, [ // eslint-disable-line react-hooks/exhaustive-deps
     autoRefresh.interval,
     autoRefresh?.status,
     autoRefresh.inactivityTimeout,

--- a/src/dashboards/components/DashboardHeader.tsx
+++ b/src/dashboards/components/DashboardHeader.tsx
@@ -133,7 +133,7 @@ const DashboardHeader: FC<Props> = ({
     // We want to invalidate the existing cache when a user manually refreshes the dashboard
     resetQueryCache()
     onManualRefresh()
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const isActive =
     autoRefresh?.status && autoRefresh.status === AutoRefreshStatus.Active

--- a/src/dataExplorer/components/FieldSelector.tsx
+++ b/src/dataExplorer/components/FieldSelector.tsx
@@ -82,7 +82,7 @@ const FieldSelector: FC = () => {
         </div>
       </Accordion>
     )
-  }, [fields, list])
+  }, [fields, list]) // eslint-disable-line react-hooks/exhaustive-deps
 }
 
 export default FieldSelector

--- a/src/dataExplorer/components/FluxBrowser.tsx
+++ b/src/dataExplorer/components/FluxBrowser.tsx
@@ -34,14 +34,14 @@ const FluxBrowser: FC = () => {
     if (fluxFunctions.length === 0) {
       dispatch(getFluxPackages())
     }
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleSelectItem = useCallback(
     (func: FluxFunction) => {
       injectFunction(getFluxExample(func), _ => null)
       event('flux.function.injected', {name: `${func.package}.${func.name}`})
     },
-    [injectFunction, editor]
+    [injectFunction, editor] // eslint-disable-line react-hooks/exhaustive-deps
   )
 
   const render = useCallback(
@@ -57,7 +57,7 @@ const FluxBrowser: FC = () => {
         ToolTipContent={FluxDocsTooltipContent}
       />
     ),
-    [handleSelectItem, editor]
+    [handleSelectItem, editor] // eslint-disable-line react-hooks/exhaustive-deps
   )
 
   return useMemo(
@@ -75,7 +75,7 @@ const FluxBrowser: FC = () => {
         />
       </div>
     ),
-    [editor, render, fluxFunctions, injectFunction]
+    [editor, render, fluxFunctions, injectFunction] // eslint-disable-line react-hooks/exhaustive-deps
   )
 }
 

--- a/src/dataExplorer/components/Schema.tsx
+++ b/src/dataExplorer/components/Schema.tsx
@@ -38,7 +38,7 @@ const FieldsTags: FC = () => {
 
   useEffect(() => {
     setSearchTerm('')
-  }, [selectedBucket, selectedMeasurement])
+  }, [selectedBucket, selectedMeasurement]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleSearchFieldsTags = (searchTerm: string): void => {
     setSearchTerm(searchTerm)
@@ -61,7 +61,7 @@ const FieldsTags: FC = () => {
         <TagSelector />
       </div>
     )
-  }, [selectedBucket, selectedMeasurement, searchTerm])
+  }, [selectedBucket, selectedMeasurement, searchTerm]) // eslint-disable-line react-hooks/exhaustive-deps
 }
 
 const Schema: FC = () => {

--- a/src/dataExplorer/components/TagSelector.tsx
+++ b/src/dataExplorer/components/TagSelector.tsx
@@ -111,7 +111,7 @@ const TagValues: FC<Prop> = ({loading, tagKey, tagValues}) => {
         </div>
       </Accordion>
     )
-  }, [list])
+  }, [list]) // eslint-disable-line react-hooks/exhaustive-deps
 }
 
 const TagSelector: FC = () => {
@@ -159,7 +159,7 @@ const TagSelector: FC = () => {
         <div className="container-side-bar">{list}</div>
       </Accordion>
     ),
-    [tags, loadingTagKeys, loadingTagValues, list]
+    [tags, loadingTagKeys, loadingTagValues, list] // eslint-disable-line react-hooks/exhaustive-deps
   )
 }
 

--- a/src/dataExplorer/context/fields.tsx
+++ b/src/dataExplorer/context/fields.tsx
@@ -139,6 +139,6 @@ export const FieldsProvider: FC<Prop> = ({children, scope}) => {
         {children}
       </FieldsContext.Provider>
     ),
-    [fields, loading]
+    [fields, loading] // eslint-disable-line react-hooks/exhaustive-deps
   )
 }

--- a/src/dataExplorer/context/fluxQueryBuilder.tsx
+++ b/src/dataExplorer/context/fluxQueryBuilder.tsx
@@ -112,7 +112,7 @@ export const FluxQueryBuilderProvider: FC = ({children}) => {
         {children}
       </FluxQueryBuilderContext.Provider>
     ),
-    [
+    [ // eslint-disable-line react-hooks/exhaustive-deps
       // Schema
       selectedBucket,
       selectedMeasurement,

--- a/src/dataExplorer/context/measurements.tsx
+++ b/src/dataExplorer/context/measurements.tsx
@@ -120,6 +120,6 @@ export const MeasurementsProvider: FC<Prop> = ({children, scope}) => {
         {children}
       </MeasurementsContext.Provider>
     ),
-    [measurements, loading, children]
+    [measurements, loading, children] // eslint-disable-line react-hooks/exhaustive-deps
   )
 }

--- a/src/dataExplorer/context/tags.tsx
+++ b/src/dataExplorer/context/tags.tsx
@@ -250,6 +250,6 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
         {children}
       </TagsContext.Provider>
     ),
-    [tags, loadingTagKeys, loadingTagValues]
+    [tags, loadingTagKeys, loadingTagValues] // eslint-disable-line react-hooks/exhaustive-deps
   )
 }

--- a/src/flows/components/FlowKeyboardPreview.tsx
+++ b/src/flows/components/FlowKeyboardPreview.tsx
@@ -15,7 +15,7 @@ const FlowKeyboardPreview = () => {
   useEffect(() => {
     window.addEventListener('keypress', runPreview)
     return () => window.removeEventListener('keypress', runPreview)
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   return null
 }

--- a/src/flows/components/FlowPage.tsx
+++ b/src/flows/components/FlowPage.tsx
@@ -27,7 +27,7 @@ const RunOnMount = () => {
     if (flow.readOnly) {
       queryAll()
     }
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   return null
 }

--- a/src/flows/components/Pipe.tsx
+++ b/src/flows/components/Pipe.tsx
@@ -17,7 +17,7 @@ const Pipe: FC<PipeProp> = props => {
     }
 
     return createElement(PIPE_DEFINITIONS[data.type].component, props)
-  }, [data.type, props.readOnly])
+  }, [data.type, props.readOnly]) // eslint-disable-line react-hooks/exhaustive-deps
 }
 
 export default Pipe

--- a/src/flows/components/ReadOnly.tsx
+++ b/src/flows/components/ReadOnly.tsx
@@ -70,7 +70,7 @@ const RunPipeResults: FC = () => {
         })
     })
     event('Visited Shared Notebook', {accessID: accessID})
-  }, [flow])
+  }, [flow]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return null
 }

--- a/src/flows/components/Sidebar.tsx
+++ b/src/flows/components/Sidebar.tsx
@@ -101,7 +101,7 @@ export const MenuButton: FC<ButtonProps> = ({id}) => {
     return () => {
       document.removeEventListener('mousedown', clickoutside)
     }
-  }, [focused, submenu])
+  }, [focused, submenu]) // eslint-disable-line react-hooks/exhaustive-deps
 
   let dropdown
 

--- a/src/flows/components/header/AutoRefreshButton.tsx
+++ b/src/flows/components/header/AutoRefreshButton.tsx
@@ -70,7 +70,7 @@ const AutoRefreshButton: FC = () => {
       GlobalAutoRefresher.onDisconnect()
       GlobalAutoRefresher.stopPolling()
     }
-  }, [
+  }, [ // eslint-disable-line react-hooks/exhaustive-deps
     autoRefresh.interval,
     autoRefresh?.status,
     autoRefresh.inactivityTimeout,

--- a/src/flows/components/panel/FlowPanel.tsx
+++ b/src/flows/components/panel/FlowPanel.tsx
@@ -134,7 +134,7 @@ const FlowPanel: FC<Props> = ({
     updateMeta(id, {
       height: size,
     })
-  }, [flow, size])
+  }, [flow, size]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const title = PIPE_DEFINITIONS[flow.data.byID[id]?.type] ? (
     <FlowPanelTitle id={id} />

--- a/src/flows/context/flow.current.tsx
+++ b/src/flows/context/flow.current.tsx
@@ -104,7 +104,7 @@ export const FlowProvider: FC = ({children}) => {
     } catch (error) {
       console.error({error})
     }
-  }, [currentFlow, orgID])
+  }, [currentFlow, orgID]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleGetNotebook = useCallback(async notebookId => {
     try {
@@ -171,7 +171,7 @@ export const FlowProvider: FC = ({children}) => {
       }
       doc.off('update', onUpdate)
     }
-  }, [id])
+  }, [id]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const update = useCallback(
     (flow: Flow) => {

--- a/src/flows/context/flow.list.tsx
+++ b/src/flows/context/flow.list.tsx
@@ -177,7 +177,7 @@ export const FlowListProvider: FC = ({children}) => {
   useEffect(() => {
     migrate()
     getAll()
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const clone = async (id: string): Promise<string | void> => {
     if (!flows.hasOwnProperty(id)) {

--- a/src/flows/context/flow.query.tsx
+++ b/src/flows/context/flow.query.tsx
@@ -72,13 +72,13 @@ export const FlowQueryProvider: FC = ({children}) => {
     }
     _generateMap()
     queryAll()
-  }, [flow?.range?.lower, flow?.range?.upper])
+  }, [flow?.range?.lower, flow?.range?.upper]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (flow?.readOnly) {
       queryAll()
     }
-  }, [flow?.readOnly])
+  }, [flow?.readOnly]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Share querying event across tabs
   const handleStorageEvent = e => {
@@ -175,7 +175,7 @@ export const FlowQueryProvider: FC = ({children}) => {
 
   useEffect(() => {
     _generateMap()
-  }, [flow])
+  }, [flow]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const generateMap = (doubleForceUpdate?: boolean): Stage[] => {
     // this is to get around an issue where a panel is added, which triggers the useEffect that updates

--- a/src/flows/context/pipe.tsx
+++ b/src/flows/context/pipe.tsx
@@ -66,7 +66,7 @@ export const PipeProvider: FC<PipeContextProps> = ({id, children}) => {
     (data: Partial<PipeData>) => {
       updateData(id, data)
     },
-    [flow, updateData]
+    [flow, updateData] // eslint-disable-line react-hooks/exhaustive-deps
   )
 
   const scope = getPanelQueries(id)?.scope

--- a/src/flows/context/results.tsx
+++ b/src/flows/context/results.tsx
@@ -70,7 +70,7 @@ export const ResultsProvider: FC = ({children}) => {
     }
 
     setInc(inc + 1)
-  }, [inc])
+  }, [inc]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const value = {
     results,

--- a/src/flows/context/shared.tsx
+++ b/src/flows/context/shared.tsx
@@ -23,7 +23,7 @@ export const FlowProvider: FC = ({children}) => {
         console.error('failed to get notebook', error)
         setLoading(RemoteDataState.Error)
       })
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <PageSpinner loading={loading}>

--- a/src/flows/pipes/MetricSelector/FieldSelectors.tsx
+++ b/src/flows/pipes/MetricSelector/FieldSelectors.tsx
@@ -31,7 +31,7 @@ const FieldSelectors: FC<Props> = ({fields}) => {
       }
       update({field: updated})
     },
-    [update, selectedField]
+    [update, selectedField] // eslint-disable-line react-hooks/exhaustive-deps
   )
 
   return (

--- a/src/flows/pipes/MetricSelector/MeasurementSelectors.tsx
+++ b/src/flows/pipes/MetricSelector/MeasurementSelectors.tsx
@@ -32,7 +32,7 @@ const MeasurementSelectors: FC<Props> = ({measurements}) => {
 
       update({measurement: updated})
     },
-    [update, selectedMeasurement]
+    [update, selectedMeasurement] // eslint-disable-line react-hooks/exhaustive-deps
   )
   return (
     <>

--- a/src/flows/pipes/MetricSelector/TagSelectors.tsx
+++ b/src/flows/pipes/MetricSelector/TagSelectors.tsx
@@ -56,7 +56,7 @@ const TagSelectors: FC<Props> = ({tags}) => {
         tags: updatedTags,
       })
     },
-    [update]
+    [update] // eslint-disable-line react-hooks/exhaustive-deps
   )
 
   const handleSubListItemClick = useCallback(
@@ -88,7 +88,7 @@ const TagSelectors: FC<Props> = ({tags}) => {
         tags: updatedTags,
       })
     },
-    [update]
+    [update] // eslint-disable-line react-hooks/exhaustive-deps
   )
 
   const _tags = tags.reduce((acc, tag) => {

--- a/src/flows/pipes/Notification/ExportTask.tsx
+++ b/src/flows/pipes/Notification/ExportTask.tsx
@@ -156,7 +156,7 @@ ${ENDPOINT_DEFINITIONS[data.endpoint]?.generateQuery(
     newAST.body.unshift(taskHeader.body[0])
 
     return format_from_js_file(newAST)
-  }, [
+  }, [ // eslint-disable-line react-hooks/exhaustive-deps
     id,
     queryText,
     data.every,
@@ -289,7 +289,7 @@ ${ENDPOINT_DEFINITIONS[data.endpoint]?.generateQuery(
     newAST.body.unshift(taskHeader.body[0])
 
     return format_from_js_file(newAST)
-  }, [
+  }, [ // eslint-disable-line react-hooks/exhaustive-deps
     id,
     queryText,
     data.every,

--- a/src/flows/pipes/Notification/Expressions.tsx
+++ b/src/flows/pipes/Notification/Expressions.tsx
@@ -98,7 +98,7 @@ const Expressions: FC<Props> = ({parsed, onSelect}) => {
     e => {
       setSearch(e.target.value)
     },
-    [search, setSearch]
+    [search, setSearch] // eslint-disable-line react-hooks/exhaustive-deps
   )
 
   const schemaExpressions = useMemo(

--- a/src/flows/pipes/Notification/Measurement.tsx
+++ b/src/flows/pipes/Notification/Measurement.tsx
@@ -32,7 +32,7 @@ const Measurement: FC<Props> = ({readOnly}) => {
       event('Changed Notification Measurement')
       update({measurement})
     },
-    [measurements, update]
+    [measurements, update] // eslint-disable-line react-hooks/exhaustive-deps
   )
 
   const menuItems = measurements.map(key => (

--- a/src/flows/pipes/Notification/Threshold.tsx
+++ b/src/flows/pipes/Notification/Threshold.tsx
@@ -133,7 +133,7 @@ const Threshold: FC<Props> = ({readOnly}) => {
       )
       return <Dropdown menu={menu} button={menuButton} />
     },
-    [setThresholdType]
+    [setThresholdType] // eslint-disable-line react-hooks/exhaustive-deps
   )
 
   const columnDropdown = useCallback(
@@ -167,7 +167,7 @@ const Threshold: FC<Props> = ({readOnly}) => {
       )
       return <Dropdown menu={menu} button={menuButton} />
     },
-    [fields, setColumn]
+    [fields, setColumn] // eslint-disable-line react-hooks/exhaustive-deps
   )
 
   const updateMin = (event: ChangeEvent<HTMLInputElement>, index: number) => {

--- a/src/flows/pipes/Notification/view.tsx
+++ b/src/flows/pipes/Notification/view.tsx
@@ -84,7 +84,7 @@ const Notification: FC<PipeProp> = ({Context}) => {
 
   useEffect(() => {
     dispatch(getSecrets())
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const createSecret = (callback: (id: string) => void) => {
     if (showId !== id) {
@@ -146,7 +146,7 @@ const Notification: FC<PipeProp> = ({Context}) => {
           return acc
         }, {})
       ).length,
-    [queryText]
+    [queryText] // eslint-disable-line react-hooks/exhaustive-deps
   )
 
   const numericColumns = (results?.parsed?.table?.columnKeys || []).filter(
@@ -210,7 +210,7 @@ const Notification: FC<PipeProp> = ({Context}) => {
       updateMessage(editorInstance.getValue())
       event('Injecting Expression into Alert Message')
     },
-    [editorInstance]
+    [editorInstance] // eslint-disable-line react-hooks/exhaustive-deps
   )
 
   const warningMessage = useMemo(() => {

--- a/src/flows/pipes/QueryBuilder/BucketSelector.tsx
+++ b/src/flows/pipes/QueryBuilder/BucketSelector.tsx
@@ -29,7 +29,7 @@ const BucketSelector: FC = () => {
     missingBuckets.forEach(b => {
       addBucket(b as Bucket)
     })
-  }, [loading, buckets, data.buckets])
+  }, [loading, buckets, data.buckets]) // eslint-disable-line react-hooks/exhaustive-deps
 
   if (loading === RemoteDataState.Done && !buckets.length) {
     return (

--- a/src/flows/pipes/QueryBuilder/CardList.tsx
+++ b/src/flows/pipes/QueryBuilder/CardList.tsx
@@ -99,7 +99,7 @@ const Card: FC<Props> = ({idx}) => {
         loadKeys(idx, search)
       })
     },
-    [loadKeys, card.keys, idx]
+    [loadKeys, card.keys, idx] // eslint-disable-line react-hooks/exhaustive-deps
   )
 
   const keySelect = val => {
@@ -184,7 +184,7 @@ const Card: FC<Props> = ({idx}) => {
     return () => {
       cancelKey(idx)
     }
-  }, [data.buckets, card.keys.loading])
+  }, [data.buckets, card.keys.loading]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     let promise
@@ -204,7 +204,7 @@ const Card: FC<Props> = ({idx}) => {
     return () => {
       cancelValue(idx)
     }
-  }, [card.keys.loading, card.values.loading])
+  }, [card.keys.loading, card.values.loading]) // eslint-disable-line react-hooks/exhaustive-deps
 
   if (card.keys.loading === RemoteDataState.NotStarted) {
     let emptyText = 'Select a value first'

--- a/src/flows/pipes/RawFluxEditor/SecretsList.tsx
+++ b/src/flows/pipes/RawFluxEditor/SecretsList.tsx
@@ -57,7 +57,7 @@ const SecretsList: FC<Props> = ({inject, cbOnInject}) => {
 
   useEffect(() => {
     dispatch(getSecrets())
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const header = () => (
     <FlexBox
@@ -100,7 +100,7 @@ const SecretsList: FC<Props> = ({inject, cbOnInject}) => {
         />
       </div>
     ),
-    [onSelect, secrets]
+    [onSelect, secrets] // eslint-disable-line react-hooks/exhaustive-deps
   )
 }
 

--- a/src/flows/pipes/RawFluxEditor/view.tsx
+++ b/src/flows/pipes/RawFluxEditor/view.tsx
@@ -69,7 +69,7 @@ const Query: FC<PipeProp> = ({Context}) => {
         },
       ])
     }
-  }, [id, inject])
+  }, [id, inject]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const updateText = useCallback(
     text => {
@@ -81,7 +81,7 @@ const Query: FC<PipeProp> = ({Context}) => {
 
       update({queries: _queries})
     },
-    [queries, activeQuery]
+    [queries, activeQuery] // eslint-disable-line react-hooks/exhaustive-deps
   )
 
   const injectIntoEditor = useCallback(
@@ -104,7 +104,7 @@ const Query: FC<PipeProp> = ({Context}) => {
         showSub(<Functions onSelect={injectIntoEditor} />)
       }
     }
-  }, [injectIntoEditor, showId])
+  }, [injectIntoEditor, showId]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const controls = (
     <Button
@@ -139,8 +139,8 @@ const Query: FC<PipeProp> = ({Context}) => {
         </Suspense>
       </Context>
     ),
-    [
-      RemoteDataState.Loading,
+    [ // eslint-disable-line react-hooks/exhaustive-deps
+      RemoteDataState.Loading, 
       query.text,
       updateText,
       editorContext.editor,

--- a/src/flows/pipes/Region/view.tsx
+++ b/src/flows/pipes/Region/view.tsx
@@ -154,7 +154,7 @@ const Source: FC<PipeProp> = ({Context}) => {
     data.region = window.location.origin
 
     return [options, REGIONS[REGIONS.length - 2]]
-  }, [data.source, data.region, flags])
+  }, [data.source, data.region, flags]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (data.region === window.location.origin) {
@@ -198,7 +198,7 @@ const Source: FC<PipeProp> = ({Context}) => {
         })
       })
     })
-  }, [data.region, data.token])
+  }, [data.region, data.token]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <Context>

--- a/src/flows/pipes/RemoteCSV/view.tsx
+++ b/src/flows/pipes/RemoteCSV/view.tsx
@@ -67,7 +67,7 @@ const RemoteCSV: FC<PipeProp> = ({Context}) => {
         }, {})
       )
     })
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <Context>

--- a/src/flows/pipes/Schedule/History.tsx
+++ b/src/flows/pipes/Schedule/History.tsx
@@ -171,7 +171,7 @@ const Run: FC<RunProps> = ({task, run}) => {
         clearInterval(timer.current)
       }
     }
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const format = (date: string) => {
     try {

--- a/src/flows/pipes/Schedule/view.tsx
+++ b/src/flows/pipes/Schedule/view.tsx
@@ -192,7 +192,7 @@ const Schedule: FC<PipeProp> = ({Context}) => {
           return acc
         }, {})
       ).length,
-    [queryText]
+    [queryText] // eslint-disable-line react-hooks/exhaustive-deps
   )
   const taskText = useMemo(() => {
     const ast = parse(simplify(queryText))
@@ -237,7 +237,7 @@ const Schedule: FC<PipeProp> = ({Context}) => {
     ast.body.unshift(header.body[0])
 
     return format_from_js_file(ast)
-  }, [queryText, data.interval, data.offset])
+  }, [queryText, data.interval, data.offset]) // eslint-disable-line react-hooks/exhaustive-deps
   const hasChanges = taskText !== latestTask?.flux ?? ''
 
   const updateInterval = evt => {
@@ -339,7 +339,7 @@ const Schedule: FC<PipeProp> = ({Context}) => {
         ],
       },
     ])
-  }, [id, data.task, hasChanges])
+  }, [id, data.task, hasChanges]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const persist = (
     <ExportTaskButton

--- a/src/flows/pipes/Spotify/embedded.tsx
+++ b/src/flows/pipes/Spotify/embedded.tsx
@@ -20,7 +20,7 @@ const Embedded: FC<Props> = ({visible}) => {
           allow="encrypted-media"
         />
       ),
-    [visible, parts[1], parts[2]]
+    [visible, parts[1], parts[2]]  // eslint-disable-line react-hooks/exhaustive-deps
   )
 }
 

--- a/src/flows/pipes/Spotify/view.tsx
+++ b/src/flows/pipes/Spotify/view.tsx
@@ -34,7 +34,7 @@ const Spotify: FC<PipeProp> = ({Context}) => {
         ],
       },
     ])
-  }, [id, toggleEdit])
+  }, [id, toggleEdit]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const showEditing = isEditing || !data.uri
 

--- a/src/flows/pipes/Table/view.tsx
+++ b/src/flows/pipes/Table/view.tsx
@@ -137,7 +137,7 @@ const Table: FC<PipeProp> = ({Context}) => {
         ],
       },
     ])
-  }, [id, data.properties, results.parsed, range])
+  }, [id, data.properties, results.parsed, range]) // eslint-disable-line react-hooks/exhaustive-deps
 
   if (results.error) {
     return (

--- a/src/flows/pipes/Visualization/view.tsx
+++ b/src/flows/pipes/Visualization/view.tsx
@@ -137,7 +137,7 @@ const Visualization: FC<PipeProp> = ({Context}) => {
         ],
       },
     ])
-  }, [id, data.properties, results.parsed, range])
+  }, [id, data.properties, results.parsed, range]) // eslint-disable-line react-hooks/exhaustive-deps
 
   if (results.error) {
     return (

--- a/src/flows/pipes/Youtube/view.tsx
+++ b/src/flows/pipes/Youtube/view.tsx
@@ -37,7 +37,7 @@ const Youtube: FC<PipeProp> = ({Context}) => {
         ],
       },
     ])
-  }, [id, toggleEdit])
+  }, [id, toggleEdit]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const showEditing = isEditing || !data.uri
 

--- a/src/flows/shared/BucketSelector/index.tsx
+++ b/src/flows/shared/BucketSelector/index.tsx
@@ -43,7 +43,7 @@ const BucketSelector: FC<Props> = ({
     }
 
     onSelect(null)
-  }, [buckets])
+  }, [buckets]) // eslint-disable-line react-hooks/exhaustive-deps
 
   let menuItems = (
     <Dropdown.ItemEmpty>

--- a/src/homepageExperience/components/steps/Finish.tsx
+++ b/src/homepageExperience/components/steps/Finish.tsx
@@ -77,7 +77,7 @@ export const Finish = (props: OwnProps) => {
       props.markStepAsCompleted()
       fireConfetti()
     }
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const showSampleApp = props.wizardEventName === 'pythonWizard'
   return (

--- a/src/homepageExperience/components/steps/Overview.tsx
+++ b/src/homepageExperience/components/steps/Overview.tsx
@@ -23,7 +23,7 @@ export const Overview: FC<Props> = ({wizard}) => {
       }
     }
     window.addEventListener('blur', checkVidClick)
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <div>

--- a/src/homepageExperience/components/steps/Tokens.tsx
+++ b/src/homepageExperience/components/steps/Tokens.tsx
@@ -66,7 +66,7 @@ export const Tokens: FC<OwnProps> = ({
       await dispatch(getAllResources())
     }
     fetchResources()
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (sortedPermissionTypes.length && tokenValue === null) {
@@ -79,14 +79,14 @@ export const Tokens: FC<OwnProps> = ({
       dispatch(createAuthorization(authorization))
       event(`firstMile.${wizardEventName}.tokens.tokenCreated`)
     }
-  }, [sortedPermissionTypes.length])
+  }, [sortedPermissionTypes.length]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // when token generated, save it to the parent component
   useEffect(() => {
     if (currentAuth.token) {
       setTokenValue(currentAuth.token)
     }
-  }, [currentAuth.token])
+  }, [currentAuth.token]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // when tokenValue in the parent component is not null, set text box value to tokenValue
   useEffect(() => {

--- a/src/homepageExperience/components/steps/go/WriteData.tsx
+++ b/src/homepageExperience/components/steps/go/WriteData.tsx
@@ -37,7 +37,7 @@ export const WriteDataComponent = (props: OwnProps) => {
 
   useEffect(() => {
     dispatch(getBuckets())
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const {bucket} = useContext(WriteDataDetailsContext)
 
@@ -46,7 +46,7 @@ export const WriteDataComponent = (props: OwnProps) => {
   useEffect(() => {
     setSelectedBucket(bucket)
     onSelectBucket(bucket.name)
-  }, [bucket])
+  }, [bucket]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const codeSnippet = `org := "${org.name}"
 bucket := "${bucket.name}"

--- a/src/homepageExperience/components/steps/nodejs/WriteData.tsx
+++ b/src/homepageExperience/components/steps/nodejs/WriteData.tsx
@@ -37,7 +37,7 @@ export const WriteDataComponent = (props: OwnProps) => {
 
   useEffect(() => {
     dispatch(getBuckets())
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const {bucket} = useContext(WriteDataDetailsContext)
 
@@ -46,7 +46,7 @@ export const WriteDataComponent = (props: OwnProps) => {
   useEffect(() => {
     setSelectedBucket(bucket)
     onSelectBucket(bucket.name)
-  }, [bucket])
+  }, [bucket]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const codeSnippet = `let org = \`${org.name}\`
 let bucket = \`${bucket.name}\`

--- a/src/homepageExperience/components/steps/python/WriteData.tsx
+++ b/src/homepageExperience/components/steps/python/WriteData.tsx
@@ -37,7 +37,7 @@ export const WriteDataComponent = (props: OwnProps) => {
 
   useEffect(() => {
     dispatch(getBuckets())
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const {bucket} = useContext(WriteDataDetailsContext)
 
@@ -46,7 +46,7 @@ export const WriteDataComponent = (props: OwnProps) => {
   useEffect(() => {
     setSelectedBucket(bucket)
     onSelectBucket(bucket.name)
-  }, [bucket])
+  }, [bucket]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const codeSnippet = `bucket="${bucket.name}"
 

--- a/src/secrets/components/SecretsTab.tsx
+++ b/src/secrets/components/SecretsTab.tsx
@@ -81,7 +81,8 @@ const SecretsTab: FC = () => {
   useEffect(() => {
     if (searchTerm) {
       secretsEmptyState = (
-        <EmptyState size={ComponentSize.Medium}>
+        <EmptyState size= // eslint-disable-line react-hooks/exhaustive-deps
+        {ComponentSize.Medium}> 
           <EmptyState.Text>No Secrets match your query</EmptyState.Text>
         </EmptyState>
       )

--- a/src/shared/components/FilterList/FilterList.tsx
+++ b/src/shared/components/FilterList/FilterList.tsx
@@ -54,7 +54,7 @@ const FilterList: FC<Props> = ({
         </>
       )
     }
-  }, [search, items, renderItem])
+  }, [search, items, renderItem]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return useMemo(
     () => (
@@ -73,7 +73,7 @@ const FilterList: FC<Props> = ({
         </div>
       </div>
     ),
-    [list, setSearch]
+    [list, setSearch] // eslint-disable-line react-hooks/exhaustive-deps
   )
 }
 

--- a/src/shared/components/cells/CellCloneOverlay.tsx
+++ b/src/shared/components/cells/CellCloneOverlay.tsx
@@ -58,7 +58,7 @@ const CellCloneOverlay: FC = () => {
         })
         dispatch(notify(dashboardsGetFailed(err)))
       })
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const {onClose} = useContext(OverlayContext)
 

--- a/src/shared/components/functions/FunctionsList/DynamicFunctionsList.tsx
+++ b/src/shared/components/functions/FunctionsList/DynamicFunctionsList.tsx
@@ -35,7 +35,7 @@ const DynamicFunctionsList: FC<Props> = ({onSelect}) => {
     if (fluxFunctions.length === 0) {
       dispatch(getFluxPackages())
     }
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (tooltipPopup && eventSearchTerm !== termRecorded) {
@@ -51,12 +51,12 @@ const DynamicFunctionsList: FC<Props> = ({onSelect}) => {
       }
       hoveredFunctions.add(hoveredFunction)
     }
-  }, [hoveredFunction, tooltipPopup, eventSearchTerm])
+  }, [hoveredFunction, tooltipPopup, eventSearchTerm]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleSelectItem = useCallback((func: FluxFunction) => {
     onSelect(getFluxExample(func))
     event('flux.function.injected', {name: `${func.package}.${func.name}`})
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const render = fn => (
     <Fn

--- a/src/shared/components/functions/FunctionsList/GroupedFunctionsList.tsx
+++ b/src/shared/components/functions/FunctionsList/GroupedFunctionsList.tsx
@@ -21,7 +21,7 @@ const GroupedFunctionsList: FC<Props> = ({onSelect}) => {
     text => {
       setSearch(text)
     },
-    [search, setSearch]
+    [search, setSearch] // eslint-disable-line react-hooks/exhaustive-deps
   )
 
   const filteredFunctions: FilteredFn = useMemo(

--- a/src/shared/components/functions/perFunction/FluxDocsTooltipContent.tsx
+++ b/src/shared/components/functions/perFunction/FluxDocsTooltipContent.tsx
@@ -22,7 +22,7 @@ const FluxDocsTooltipContent: FC<TooltipProps> = ({
   useEffect(() => {
     setToolTipPopup && setToolTipPopup(true)
     setHoverdFunction && setHoverdFunction(`${func.package}.${func.name}`)
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
   const argComponent = () => {
     if (func.fluxParameters.length > 0) {
       return func.fluxParameters.map(arg => {

--- a/src/shared/containers/RouteToOrg.tsx
+++ b/src/shared/containers/RouteToOrg.tsx
@@ -32,7 +32,7 @@ const RouteToOrg: FC<Props> = ({orgs, history, org}) => {
 
     // else default to first org
     history.push(`/orgs/${orgs[0].id}`)
-  }, [orgs, org])
+  }, [orgs, org]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return <></>
 }

--- a/src/shared/contexts/buckets.tsx
+++ b/src/shared/contexts/buckets.tsx
@@ -95,7 +95,7 @@ export const BucketProvider: FC<Props> = ({children, scope}) => {
         )
       )
     )
-  }, [buckets])
+  }, [buckets]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // TODO: load bucket creation limits on org change
   // expose limits to frontend
@@ -213,7 +213,7 @@ export const BucketProvider: FC<Props> = ({children, scope}) => {
     } else if (loading === RemoteDataState.NotStarted) {
       fetchBuckets()
     }
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const createBucket = (bucket: ExtendedBucket) => {
     bucket.orgID = scope.org
@@ -318,6 +318,6 @@ export const BucketProvider: FC<Props> = ({children, scope}) => {
         {children}
       </BucketContext.Provider>
     ),
-    [data.bucket, loading, buckets]
+    [data.bucket, loading, buckets] // eslint-disable-line react-hooks/exhaustive-deps
   )
 }

--- a/src/shared/contexts/editor/index.tsx
+++ b/src/shared/contexts/editor/index.tsx
@@ -136,7 +136,7 @@ export const EditorProvider: FC = ({children}) => {
       }
       inject(options)
     },
-    [inject]
+    [inject] // eslint-disable-line react-hooks/exhaustive-deps
   )
 
   const injectVariable = useCallback(

--- a/src/shared/search/DocSearch.tsx
+++ b/src/shared/search/DocSearch.tsx
@@ -36,7 +36,7 @@ const DocSearch: FC<DocSearchProps> = ({type}) => {
         searchBar.removeEventListener('click', logClickSearchEvent)
       }
     }
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const facetFilters = useMemo(
     () => ({

--- a/src/tasks/components/TaskRunsCard.tsx
+++ b/src/tasks/components/TaskRunsCard.tsx
@@ -73,7 +73,7 @@ const TaskRunsCard: FC<Props> = ({task, isTaskEditable}) => {
 
   useEffect(() => {
     dispatch(getMembers())
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (!isFlagEnabled('createWithFlows')) {
@@ -108,7 +108,7 @@ const TaskRunsCard: FC<Props> = ({task, isTaskEditable}) => {
       .catch(() => {
         setRoute(`/notebook/from/task/${task.id}`)
       })
-  }, [isFlagEnabled('createWithFlows'), org.id, task])
+  }, [isFlagEnabled('createWithFlows'), org.id, task]) // eslint-disable-line react-hooks/exhaustive-deps
 
   if (!task) {
     return null

--- a/src/timeMachine/components/TimeMachineFluxEditor.tsx
+++ b/src/timeMachine/components/TimeMachineFluxEditor.tsx
@@ -104,7 +104,7 @@ const TMFluxEditor: FC<{variables: Variable[]}> = props => {
         </div>
       </div>
     )
-  }, [activeQueryText, activeQueryIndex, props.variables, editorContext.editor])
+  }, [activeQueryText, activeQueryIndex, props.variables, editorContext.editor]) // eslint-disable-line react-hooks/exhaustive-deps
 }
 
 const TimeMachineFluxEditor = props => (

--- a/src/timeMachine/components/dynamicFluxFunctionsToolbar/FluxFunctionsToolbar.tsx
+++ b/src/timeMachine/components/dynamicFluxFunctionsToolbar/FluxFunctionsToolbar.tsx
@@ -75,7 +75,7 @@ const DynamicFluxFunctionsToolbar: FC<Props> = (props: Props) => {
       }
       hoveredFunctions.add(hoveredFunction)
     }
-  }, [hoveredFunction, searchTerm, tooltipPopup])
+  }, [hoveredFunction, searchTerm, tooltipPopup]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const {onInsertFluxFunction, fluxFunctions, getFluxPackages} = props
 

--- a/src/timeMachine/components/dynamicFluxFunctionsToolbar/FunctionTooltipContents.tsx
+++ b/src/timeMachine/components/dynamicFluxFunctionsToolbar/FunctionTooltipContents.tsx
@@ -23,7 +23,7 @@ const FunctionTooltipContents: FunctionComponent<Props> = ({
   useEffect(() => {
     setToolTipPopup(true)
     setHoverdFunction(`${packageName}.${name}`)
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
   return (
     <div className="flux-function-docs" data-testid={`flux-docs--${name}`}>
       <DapperScrollbars autoHide={false}>

--- a/src/timeMachine/components/fluxFunctionsToolbar/FluxFunctionsToolbar.tsx
+++ b/src/timeMachine/components/fluxFunctionsToolbar/FluxFunctionsToolbar.tsx
@@ -29,7 +29,7 @@ const FluxFunctionsToolbar: FC<OwnProps> = (props: OwnProps) => {
     (func: FluxToolbarFunction) => {
       props.onInsertFluxFunction(func)
     },
-    [props.onInsertFluxFunction]
+    [props.onInsertFluxFunction] // eslint-disable-line react-hooks/exhaustive-deps
   )
 
   return useMemo(() => {

--- a/src/usage/context/usage.tsx
+++ b/src/usage/context/usage.tsx
@@ -241,7 +241,7 @@ export const UsageProvider: FC<Props> = React.memo(({children}) => {
         status: RemoteDataState.Done,
       }))
     }
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     handleGetCreditUsage()
@@ -266,7 +266,7 @@ export const UsageProvider: FC<Props> = React.memo(({children}) => {
       console.error(error)
       setBillingStatsStatus(RemoteDataState.Error)
     }
-  }, [setBillingStats])
+  }, [setBillingStats]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     handleGetBillingStats()
@@ -328,7 +328,7 @@ export const UsageProvider: FC<Props> = React.memo(({children}) => {
       console.error(error)
       setRateLimits(null)
     }
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     handleGetRateLimits(timeRange.duration)

--- a/src/users/context/users.tsx
+++ b/src/users/context/users.tsx
@@ -234,7 +234,7 @@ export const UsersProvider: FC<Props> = React.memo(({children}) => {
         })
       }
     },
-    [dispatch, orgId, users]
+    [dispatch, orgId, users] // eslint-disable-line react-hooks/exhaustive-deps
   )
 
   return (

--- a/src/visualization/components/internal/ThresholdsSettings.tsx
+++ b/src/visualization/components/internal/ThresholdsSettings.tsx
@@ -137,7 +137,7 @@ const ThresholdsSettings: FunctionComponent<Props> = ({
     if (state.isDirty && state.isValid) {
       onSetThresholds(state.thresholds)
     }
-  }, [state])
+  }, [state]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <FlexBox

--- a/src/visualization/types/SimpleTable/PagedTable.tsx
+++ b/src/visualization/types/SimpleTable/PagedTable.tsx
@@ -267,7 +267,7 @@ const PagedTable: FC<Props> = ({result, properties}) => {
         clearTimeout(timeout)
       }
     }
-  }, [ref?.current])
+  }, [ref?.current]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const size = useMemo(() => {
     return measurePage(result, offset, height)

--- a/src/visualization/types/Table/Table.tsx
+++ b/src/visualization/types/Table/Table.tsx
@@ -49,13 +49,13 @@ const Table: FC<Props> = ({properties, sort, updateSort, table}) => {
         properties.timeFormat,
         properties.decimalPlaces
       ),
-    [
+    [ // eslint-disable-line react-hooks/exhaustive-deps
       table.data,
       sort,
       properties.fieldOptions,
       properties.timeFormat,
       properties.decimalPlaces,
-    ]
+    ] 
   )
 
   const {theme, timeZone} = useContext(AppSettingContext)

--- a/src/visualization/types/Table/options.tsx
+++ b/src/visualization/types/Table/options.tsx
@@ -188,7 +188,7 @@ const TableViewOptions: FC<Props> = ({properties, results, update}) => {
             onMoveColumn={moveColumn}
           />
         )),
-    [fieldOptions]
+    [fieldOptions] // eslint-disable-line react-hooks/exhaustive-deps
   )
 
   return (

--- a/src/writeData/components/ClientCodeQueryHelper.tsx
+++ b/src/writeData/components/ClientCodeQueryHelper.tsx
@@ -65,7 +65,7 @@ const ClientCodeQueryHelper: FC<Props> = ({clientQuery, contentID}) => {
     } catch (e) {
       console.error(e)
     }
-  }, [clientQuery, def.query, changeBucket, changeQuery])
+  }, [clientQuery, def.query, changeBucket, changeQuery]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return null
 }

--- a/src/writeData/subscriptions/components/BrokerFormContent.tsx
+++ b/src/writeData/subscriptions/components/BrokerFormContent.tsx
@@ -52,7 +52,7 @@ const BrokerFormContent: FC<Props> = ({
   const [security, setSecurity] = useState('none')
   useEffect(() => {
     updateForm({...formContent, protocol: protocol.toLowerCase()})
-  }, [protocol])
+  }, [protocol]) // eslint-disable-line react-hooks/exhaustive-deps
   return (
     <Grid>
       <Grid.Row>

--- a/src/writeData/subscriptions/components/CreateSubscriptionPage.tsx
+++ b/src/writeData/subscriptions/components/CreateSubscriptionPage.tsx
@@ -102,7 +102,7 @@ const CreateSubscriptionPage: FC = () => {
       {userAccountType: quartzMe?.accountType ?? 'unknown'},
       {feature: 'subscriptions'}
     )
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleClick = (step: number) => {
     event(

--- a/src/writeData/subscriptions/components/JsonParsingForm.tsx
+++ b/src/writeData/subscriptions/components/JsonParsingForm.tsx
@@ -68,7 +68,7 @@ const JsonParsingForm: FC<Props> = ({formContent, updateForm, edit}) => {
     }
     updateForm({...formContent})
     setRule('')
-  }, [rule])
+  }, [rule]) // eslint-disable-line react-hooks/exhaustive-deps
   return (
     <div className="json-parsing-form">
       <Grid.Column>

--- a/src/writeData/subscriptions/components/StringParsingForm.tsx
+++ b/src/writeData/subscriptions/components/StringParsingForm.tsx
@@ -62,7 +62,7 @@ const StringParsingForm: FC<Props> = ({formContent, updateForm, edit}) => {
     }
     updateForm({...formContent})
     setRule('')
-  }, [rule])
+  }, [rule]) // eslint-disable-line react-hooks/exhaustive-deps
   return (
     <div className="string-parsing-form">
       <Grid.Column>

--- a/src/writeData/subscriptions/components/SubscriptionDetails.tsx
+++ b/src/writeData/subscriptions/components/SubscriptionDetails.tsx
@@ -53,7 +53,7 @@ const SubscriptionDetails: FC<Props> = ({
     if (edit) {
       updateForm({...currentSubscription, bucket: bucket.name})
     }
-  }, [bucket])
+  }, [bucket]) // eslint-disable-line react-hooks/exhaustive-deps
   return (
     buckets && (
       <div className="update-subscription-form" id="subscription">

--- a/src/writeData/subscriptions/components/SubscriptionForm.tsx
+++ b/src/writeData/subscriptions/components/SubscriptionForm.tsx
@@ -55,7 +55,7 @@ const SubscriptionForm: FC<Props> = ({
   const org = useSelector(getOrg)
   useEffect(() => {
     updateForm({...formContent, bucket: bucket.name})
-  }, [bucket])
+  }, [bucket]) // eslint-disable-line react-hooks/exhaustive-deps
   return (
     formContent &&
     buckets && (

--- a/src/writeData/subscriptions/components/SubscriptionFormContent.tsx
+++ b/src/writeData/subscriptions/components/SubscriptionFormContent.tsx
@@ -49,7 +49,7 @@ const SubscriptionFormContent: FC<Props> = ({
     if (found) {
       changeBucket(found)
     }
-  }, [buckets.length])
+  }, [buckets.length]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <Grid>

--- a/src/writeData/subscriptions/context/subscription.list.tsx
+++ b/src/writeData/subscriptions/context/subscription.list.tsx
@@ -55,7 +55,7 @@ export const SubscriptionListProvider: FC = ({children}) => {
     } finally {
       setLoading(RemoteDataState.Done)
     }
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
   const deleteSubscription = async (id: string): Promise<void> => {
     setLoading(RemoteDataState.Loading)
     try {
@@ -76,11 +76,11 @@ export const SubscriptionListProvider: FC = ({children}) => {
       setCurrentID(id)
       setLoading(RemoteDataState.Done)
     },
-    [setCurrentID, subscriptions]
+    [setCurrentID, subscriptions] // eslint-disable-line react-hooks/exhaustive-deps
   )
   useEffect(() => {
     getAll()
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
   return (
     <SubscriptionListContext.Provider
       value={{

--- a/src/writeData/subscriptions/context/subscription.update.tsx
+++ b/src/writeData/subscriptions/context/subscription.update.tsx
@@ -114,7 +114,7 @@ export const SubscriptionUpdateProvider: FC = ({children}) => {
       setCurrentSubscription(current)
       setLoading(RemoteDataState.Done)
     }
-  }, [currentID])
+  }, [currentID]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const [loading, setLoading] = useState(RemoteDataState.Done)
   const history = useHistory()


### PR DESCRIPTION
Closes #4815

Disables eslint warning coming from react-hooks/exhaustive-deps.