### PR TITLE
fix: use one-way state to capture the initial, pre-zoom domain

### DIFF
--- a/src/visualization/utils/useVisDomainSettings.ts
+++ b/src/visualization/utils/useVisDomainSettings.ts
@@ -171,7 +171,7 @@ export const useZoomRequeryXDomainSettings = (args: ZoomRequeryArgs) => {
   }, [storedDomain, data]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const [domain, setDomain] = useState(initialDomain)
-  const [preZoomDomain, setPreZoomDomain] = useState<Array<number>>(null)
+  const [preZoomDomain] = useOneWayState(initialDomain)
 
   const getAllVariablesWithTimeDomain = (state: AppState) =>
     getAllVariablesForZoomRequery(state, timeRange ? domain : [])
@@ -218,7 +218,6 @@ export const useZoomRequeryXDomainSettings = (args: ZoomRequeryArgs) => {
 
   const setZoomDomain = (updatedDomain: number[]) => {
     if (!preZoomResult) {
-      setPreZoomDomain(initialDomain)
       setPreZoomResult(parsedResult)
     }
     setDomain(updatedDomain)
@@ -263,7 +262,7 @@ export const useZoomRequeryYDomainSettings = (args: ZoomRequeryArgs) => {
   }, [storedDomain, data]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const [domain, setDomain] = useState(initialDomain)
-  const [preZoomDomain, setPreZoomDomain] = useState<Array<number>>(null)
+  const [preZoomDomain] = useOneWayState(initialDomain)
 
   const getAllVariablesWithTimeDomain = (state: AppState) =>
     getAllVariablesForZoomRequery(state, timeRange ? domain : [])
@@ -310,7 +309,6 @@ export const useZoomRequeryYDomainSettings = (args: ZoomRequeryArgs) => {
 
   const setZoomDomain = (updatedDomain: number[]) => {
     if (!preZoomResult) {
-      setPreZoomDomain(initialDomain)
       setPreZoomResult(parsedResult)
     }
     setDomain(updatedDomain)


### PR DESCRIPTION
Part of idpe 14803

Fixes a bug where the initial, pre-zoom domain is not equal to the selected time range.
Here is a video of the bug:

https://user-images.githubusercontent.com/10736577/175443825-e236284d-7939-499b-ac1f-aba1a2fe09d7.mp4




  
  
With the fix, we use one-way state to lock in the pre-zoom domain which is equal to the selected time range.
Here is a video of the fix:

https://user-images.githubusercontent.com/10736577/175444116-44d0a682-1d74-4604-9971-6dcec66c5d56.mp4


