### PR TITLE
fix: fix incorrect provider information

### DIFF
--- a/src/organizations/components/OrgProfileTab/index.tsx
+++ b/src/organizations/components/OrgProfileTab/index.tsx
@@ -55,7 +55,7 @@ const OrgProfileTab: FC = () => {
   const hasSomeQuartzOrgData =
     identity.org?.provider || me.quartzMe?.regionCode || me.quartzMe?.regionName
 
-  const orgProviderExists = identity.org?.provider
+  const orgProviderExists = !!identity.org?.provider
 
   const OrgProfile = () => (
     <FlexBox.Child

--- a/src/organizations/components/OrgProfileTab/index.tsx
+++ b/src/organizations/components/OrgProfileTab/index.tsx
@@ -53,9 +53,9 @@ const OrgProfileTab: FC = () => {
   const expectQuartzData = CLOUD && isFlagEnabled('uiUnificationFlag')
 
   const hasSomeQuartzOrgData =
-    identity.org.provider || me.quartzMe?.regionCode || me.quartzMe?.regionName
+    identity.org?.provider || me.quartzMe?.regionCode || me.quartzMe?.regionName
 
-  const orgProviderExists = identity?.org?.provider
+  const orgProviderExists = identity.org?.provider
 
   const OrgProfile = () => (
     <FlexBox.Child

--- a/src/organizations/components/OrgProfileTab/index.tsx
+++ b/src/organizations/components/OrgProfileTab/index.tsx
@@ -16,17 +16,18 @@ import CopyableLabeledData from 'src/organizations/components/OrgProfileTab/Copy
 import DeletePanel from 'src/organizations/components/OrgProfileTab/DeletePanel'
 
 // Utils
-import {getOrg} from 'src/organizations/selectors'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {CLOUD} from 'src/shared/constants'
-
-// Types
-import {getMe} from 'src/me/selectors'
-
-import 'src/organizations/components/OrgProfileTab/style.scss'
-import {getCurrentOrgDetailsThunk} from 'src/identity/actions/thunks'
 import {shouldUseQuartzIdentity} from 'src/identity/utils/shouldUseQuartzIdentity'
+import 'src/organizations/components/OrgProfileTab/style.scss'
+
+// Selectors
+import {getMe} from 'src/me/selectors'
+import {getOrg} from 'src/organizations/selectors'
 import {selectQuartzIdentity} from 'src/identity/selectors'
+
+// Thunks
+import {getCurrentOrgDetailsThunk} from 'src/identity/actions/thunks'
 
 const OrgProfileTab: FC = () => {
   const me = useSelector(getMe)

--- a/src/organizations/components/OrgProfileTab/index.tsx
+++ b/src/organizations/components/OrgProfileTab/index.tsx
@@ -19,7 +19,6 @@ import DeletePanel from 'src/organizations/components/OrgProfileTab/DeletePanel'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {CLOUD} from 'src/shared/constants'
 import {shouldUseQuartzIdentity} from 'src/identity/utils/shouldUseQuartzIdentity'
-import 'src/organizations/components/OrgProfileTab/style.scss'
 
 // Selectors
 import {getMe} from 'src/me/selectors'
@@ -29,14 +28,15 @@ import {selectQuartzIdentity} from 'src/identity/selectors'
 // Thunks
 import {getCurrentOrgDetailsThunk} from 'src/identity/actions/thunks'
 
+// Styles
+import 'src/organizations/components/OrgProfileTab/style.scss'
+
 const OrgProfileTab: FC = () => {
   const me = useSelector(getMe)
   const org = useSelector(getOrg)
   const identity = useSelector(selectQuartzIdentity)
 
   const dispatch = useDispatch()
-
-  const expectQuartzData = CLOUD && isFlagEnabled('uiUnificationFlag')
 
   useEffect(() => {
     if (CLOUD && shouldUseQuartzIdentity()) {
@@ -50,8 +50,12 @@ const OrgProfileTab: FC = () => {
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
+  const expectQuartzData = CLOUD && isFlagEnabled('uiUnificationFlag')
+
   const hasSomeQuartzOrgData =
     identity.org.provider || me.quartzMe?.regionCode || me.quartzMe?.regionName
+
+  const orgProviderExists = identity?.org?.provider
 
   const OrgProfile = () => (
     <FlexBox.Child
@@ -72,9 +76,9 @@ const OrgProfileTab: FC = () => {
             margin={ComponentSize.Medium}
             justifyContent={JustifyContent.SpaceBetween}
             stretchToFitWidth={true}
-            style={{width: '85%'}}
+            style={orgProviderExists ? {width: '85%'} : {width: '48%'}}
           >
-            {identity?.org?.provider && (
+            {orgProviderExists && (
               <LabeledData label="Cloud Provider" src={identity.org.provider} />
             )}
             {me.quartzMe?.regionCode && (

--- a/src/organizations/components/OrgProfileTab/index.tsx
+++ b/src/organizations/components/OrgProfileTab/index.tsx
@@ -24,34 +24,33 @@ import {CLOUD} from 'src/shared/constants'
 import {getMe} from 'src/me/selectors'
 
 import 'src/organizations/components/OrgProfileTab/style.scss'
-import {
-  getBillingProviderThunk,
-  getCurrentOrgDetailsThunk,
-} from 'src/identity/actions/thunks'
+import {getCurrentOrgDetailsThunk} from 'src/identity/actions/thunks'
 import {shouldUseQuartzIdentity} from 'src/identity/utils/shouldUseQuartzIdentity'
+import {selectQuartzIdentity} from 'src/identity/selectors'
 
 const OrgProfileTab: FC = () => {
   const me = useSelector(getMe)
   const org = useSelector(getOrg)
+  const identity = useSelector(selectQuartzIdentity)
+
   const dispatch = useDispatch()
 
   const expectQuartzData = CLOUD && isFlagEnabled('uiUnificationFlag')
 
   useEffect(() => {
     if (CLOUD && shouldUseQuartzIdentity()) {
-      if (!me.quartzMe.billingProvider) {
-        dispatch(getBillingProviderThunk())
-      }
-      if (!me.quartzMe.regionCode) {
+      if (
+        !me.quartzMe.regionCode ||
+        !me.quartzMe.regionName ||
+        !identity.org.provider
+      ) {
         dispatch(getCurrentOrgDetailsThunk())
       }
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const hasSomeQuartzOrgData =
-    me.quartzMe?.billingProvider ||
-    me.quartzMe?.regionCode ||
-    me.quartzMe?.regionName
+    identity.org.provider || me.quartzMe?.regionCode || me.quartzMe?.regionName
 
   const OrgProfile = () => (
     <FlexBox.Child
@@ -74,8 +73,8 @@ const OrgProfileTab: FC = () => {
             stretchToFitWidth={true}
             style={{width: '85%'}}
           >
-            {me.quartzMe?.billingProvider && (
-              <LabeledData label="Provider" src={me.quartzMe.billingProvider} />
+            {identity?.org?.provider && (
+              <LabeledData label="Cloud Provider" src={identity.org.provider} />
             )}
             {me.quartzMe?.regionCode && (
               <LabeledData label="Region" src={me.quartzMe.regionCode} />


### PR DESCRIPTION
Closes #4597 

When the `quartzIdentity` feature flag is true, it displays the correct cloud provider, shown here:

<img width="741" alt="Screen Shot 2022-06-27 at 11 29 33 AM" src="https://user-images.githubusercontent.com/106361125/175984356-209839c2-1641-4156-be9d-b2de164fdfce.png">

When the `quartzIdentity` feature flag is false, it doesn't display a provider, shown here:

<img width="741" alt="Screen Shot 2022-06-27 at 11 29 54 AM" src="https://user-images.githubusercontent.com/106361125/175984377-93ef03e3-b3af-4ab7-bf8f-6d7194aef401.png">

Edit (After styling update):
![Screen Shot 2022-06-27 at 4 54 28 PM](https://user-images.githubusercontent.com/106361125/176033948-279ca741-70ab-43b6-b2ac-78e01f47bf63.png)


Completed during pair programming with @alexjw3 