### PR TITLE
chore: update code font and hover color to match Monaco editor

### DIFF
--- a/cypress/e2e/shared/fluxQueryBuilder.test.ts
+++ b/cypress/e2e/shared/fluxQueryBuilder.test.ts
@@ -91,7 +91,7 @@ describe('FluxQueryBuilder', () => {
 
       // search a feild, should contain only the feild, no tag keys
       cy.getByTestID('field-tag-key-search-bar').type(searchField)
-      cy.get('.field-selector--list-item--wrapper').should(
+      cy.get('.field-selector--list-item--selectable').should(
         'contain',
         searchField
       )
@@ -120,7 +120,7 @@ describe('FluxQueryBuilder', () => {
       cy.getByTestID(`searchable-dropdown--item ${measurementA}`).click()
 
       // less than 8 items, no "Load More" button
-      cy.get('.field-selector--list-item--wrapper').should(
+      cy.get('.field-selector--list-item--selectable').should(
         'have.length.at.most',
         8
       )
@@ -137,7 +137,7 @@ describe('FluxQueryBuilder', () => {
       cy.getByTestID(`searchable-dropdown--item ${measurement}`).click()
 
       // more than 8 items, show 'Load More' button
-      cy.get('.field-selector--list-item--wrapper').should('have.length', 8)
+      cy.get('.field-selector--list-item--selectable').should('have.length', 8)
       cy.get('.load-more-button')
         .should('exist')
         .click()
@@ -145,11 +145,11 @@ describe('FluxQueryBuilder', () => {
       cy.get('.load-more-button', {timeout: 10000}).should('not.exist')
 
       // when load more is chosen, up to 25 additional entries will be shown
-      cy.get('.field-selector--list-item--wrapper').should(
+      cy.get('.field-selector--list-item--selectable').should(
         'have.length.above',
         8
       )
-      cy.get('.field-selector--list-item--wrapper').should(
+      cy.get('.field-selector--list-item--selectable').should(
         'have.length.at.most',
         33
       ) // 8 + 25

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
   "dependencies": {
     "@codingame/monaco-jsonrpc": "^0.3.1",
     "@docsearch/react": "^3.0.0-alpha.37",
-    "@influxdata/clockface": "^4.2.1",
+    "@influxdata/clockface": "^4.6.0",
     "@influxdata/flux-lsp-browser": "0.8.19",
     "@influxdata/giraffe": "^2.29.0",
     "@influxdata/influxdb-templates": "0.9.0",

--- a/src/dataExplorer/components/FieldSelector.tsx
+++ b/src/dataExplorer/components/FieldSelector.tsx
@@ -1,7 +1,7 @@
 import React, {FC, useContext, useEffect, useMemo, useState} from 'react'
 
 // Components
-import {Accordion} from '@influxdata/clockface'
+import {Accordion, ComponentSize, TextBlock} from '@influxdata/clockface'
 import SelectorTitle from 'src/dataExplorer/components/SelectorTitle'
 import WaitingText from 'src/shared/components/WaitingText'
 
@@ -48,8 +48,8 @@ const FieldSelector: FC = () => {
     list = <WaitingText text="Loading fields" />
   } else if (loading === RemoteDataState.Done && fieldsToShow.length) {
     list = fieldsToShow.map(field => (
-      <div key={field} className="field-selector--list-item--wrapper">
-        <div className="field-selector--list-item--selectable">{field}</div>
+      <div key={field} className="field-selector--list-item--selectable">
+        <TextBlock text={field} size={ComponentSize.ExtraSmall} />
       </div>
     ))
   }

--- a/src/dataExplorer/components/Schema.scss
+++ b/src/dataExplorer/components/Schema.scss
@@ -86,7 +86,7 @@
 .field-selector--list-item--selectable:hover,
 .tag-selector-value--list-item--selectable:hover {
   cursor: pointer;
-  color: $c-krypton;
+  color: #7CE490;
   background-color: $cf-grey-15;
   border-radius: 2px;
   width: fit-content;

--- a/src/dataExplorer/components/Schema.scss
+++ b/src/dataExplorer/components/Schema.scss
@@ -85,7 +85,7 @@
 
     &:hover {
       cursor: pointer;
-      color: #7ce490; // color suggested in https://github.com/influxdata/ui/issues/4905
+      color: $c-krypton;
       background: $cf-grey-15;
       border-radius: 2px;
 

--- a/src/dataExplorer/components/Schema.scss
+++ b/src/dataExplorer/components/Schema.scss
@@ -85,7 +85,7 @@
 
     &:hover {
       cursor: pointer;
-      color: #7CE490; // color suggested in https://github.com/influxdata/ui/issues/4905
+      color: #7ce490; // color suggested in https://github.com/influxdata/ui/issues/4905
       background: $cf-grey-15;
       border-radius: 2px;
 

--- a/src/dataExplorer/components/Schema.scss
+++ b/src/dataExplorer/components/Schema.scss
@@ -62,13 +62,38 @@
 }
 
 .field-selector--list-item,
-.field-selector--list-item--selectable,
-.tag-selector-value--list-item,
-.tag-selector-value--list-item--selectable {
+.tag-selector-value--list-item {
   padding: $cf-space-2xs 0 $cf-space-2xs $cf-space-2xs;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.field-selector--list-item--selectable,
+.tag-selector-value--list-item--selectable {
+  white-space: nowrap;
+  overflow: hidden;
+
+  .cf-text-block {
+    text-overflow: ellipsis;
+    width: fit-content;
+    font-family: $cf-code-font;
+    font-weight: 400;
+    background-color: inherit;
+    color: $cf-white;
+    transition-property: color;
+
+    &:hover {
+      cursor: pointer;
+      color: #7CE490; // color suggested in https://github.com/influxdata/ui/issues/4905
+      background: $cf-grey-15;
+      border-radius: 2px;
+
+      &:after {
+        content: ' +';
+      }
+    }
+  }
 }
 
 .tag-selector-key--list-item {
@@ -76,25 +101,6 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.field-selector--list-item--wrapper,
-.tag-selector-value--list-item--wrapper {
-  width: fit-content;
-}
-
-.field-selector--list-item--selectable:hover,
-.tag-selector-value--list-item--selectable:hover {
-  cursor: pointer;
-  color: #7CE490;
-  background-color: $cf-grey-15;
-  border-radius: 2px;
-  width: fit-content;
-  padding: $cf-space-2xs;
-
-  &:after {
-    content: ' +';
-  }
 }
 
 .field-selector .container-side-bar,

--- a/src/dataExplorer/components/TagSelector.tsx
+++ b/src/dataExplorer/components/TagSelector.tsx
@@ -1,7 +1,7 @@
 import React, {FC, useContext, useEffect, useMemo, useState} from 'react'
 
 // Components
-import {Accordion} from '@influxdata/clockface'
+import {Accordion, ComponentSize, TextBlock} from '@influxdata/clockface'
 import SelectorTitle from 'src/dataExplorer/components/SelectorTitle'
 import WaitingText from 'src/shared/components/WaitingText'
 
@@ -74,13 +74,12 @@ const TagValues: FC<Prop> = ({loading, tagKey, tagValues}) => {
     list = <WaitingText text="Loading tag values" />
   } else if (loading === RemoteDataState.Done && tagValues.length) {
     list = valuesToShow.map(value => (
-      <div key={value} className="tag-selector-value--list-item--wrapper">
-        <div
-          className="tag-selector-value--list-item--selectable"
-          onClick={() => handleSelectTagValue(value)}
-        >
-          {value}
-        </div>
+      <div
+        key={value}
+        className="tag-selector-value--list-item--selectable"
+        onClick={() => handleSelectTagValue(value)}
+      >
+        <TextBlock text={value} size={ComponentSize.ExtraSmall} />
       </div>
     ))
   }

--- a/src/shared/components/FilterList/MinimalistInjectionOption.scss
+++ b/src/shared/components/FilterList/MinimalistInjectionOption.scss
@@ -8,7 +8,7 @@
   .cf-text-block {
     width: fit-content;
     font-size: $cf-form-sm-font;
-    font-family: 'Roboto Mono';
+    font-family: $cf-code-font;
     font-style: normal;
     font-weight: 400;
     background-color: inherit;

--- a/src/timeMachine/components/FluxToolbar.scss
+++ b/src/timeMachine/components/FluxToolbar.scss
@@ -152,7 +152,7 @@ $flux-toolbar--gap: $cf-space-2xs;
     &:hover {
       > code {
         background-color: $cf-grey-15;
-        color: $c-comet;
+        color: $c-galaxy;
 
         &:after {
           content: '+';


### PR DESCRIPTION
Closes #4905 

This PR updates the font of the field and tag values to "Roboto Mono", and update the hover color of function injectable elements to match with the color in Monaco editor

Note that this PR doesn't change the hover color of fields and tag values in schema browser to match with the green in Monaco editor because of the reason mentioned by Julia [below](https://github.com/influxdata/ui/pull/4912#issuecomment-1168959947)

## Before 

<img width="234" alt="Screen Shot 2022-06-27 at 5 27 32 PM" src="https://user-images.githubusercontent.com/14298407/176046411-a505a3ca-bf78-4f42-93d1-2077888675c8.png">


## After

<img width="246" alt="Screen Shot 2022-06-27 at 5 22 32 PM" src="https://user-images.githubusercontent.com/14298407/176045661-84d7bd7a-a565-4297-9477-1bfeea91c74d.png">

<img width="273" alt="Screen Shot 2022-06-28 at 2 17 11 PM" src="https://user-images.githubusercontent.com/14298407/176266922-f6a23584-27ca-432b-9a92-ffdde721d36d.png">

