### PR TITLE
fix: changed CLI name and description

### DIFF
--- a/src/homepageExperience/containers/HomepageContainer.tsx
+++ b/src/homepageExperience/containers/HomepageContainer.tsx
@@ -192,10 +192,10 @@ export const HomepageContainer: FC = () => {
                       <div className="tile-icon-text-wrapper">
                         <div className="icon">{CLIIcon}</div>
                         <div>
-                          <h4>CLI</h4>
+                          <h4>InfluxCLI</h4>
                           <h6>
-                            Write and query data using the Command Line
-                            Interface
+                            Write and query data using the Influx Command Line
+                            Interface. Supports CSV and Line Protocol.
                           </h6>
                         </div>
                       </div>


### PR DESCRIPTION
Closes #4761

Changed the InfluxCLI name and description as it appears on the homepage:

<img width="1433" alt="Screen Shot 2022-06-28 at 1 21 33 PM" src="https://user-images.githubusercontent.com/106361125/176244766-b171e8db-e7aa-4bcb-9bb6-9295f6661dee.png">

