### PR TITLE
fix: force recalc of child component size

### DIFF
--- a/src/dataExplorer/components/Results.scss
+++ b/src/dataExplorer/components/Results.scss
@@ -4,6 +4,8 @@ $cf-radius-lg: $cf-radius + 4px;
 
 .data-explorer-results {
   height: 100%;
+  width: 100%;
+  position: absolute;
   border-radius: $cf-radius-lg;
   border: 2px solid transparent;
   background-color: $cf-grey-15;
@@ -37,6 +39,18 @@ $cf-radius-lg: $cf-radius + 4px;
   p {
     margin: 0;
   }
+}
+
+.data-explorer--monaco-outer {
+  flex-grow: 1;
+  position: relative;
+  width: 100%;
+}
+
+.data-explorer--monaco-wrap {
+  position: absolute;
+  width: 100%;
+  height: 100%;
 }
 
 .query-stat {

--- a/src/dataExplorer/components/ResultsPane.tsx
+++ b/src/dataExplorer/components/ResultsPane.tsx
@@ -145,21 +145,23 @@ const ResultsPane: FC = () => {
           margin={ComponentSize.Small}
           style={{height: '100%'}}
         >
-          <div style={{height: '100%', width: '100%', position: 'relative'}}>
-            <Suspense
-              fallback={
-                <SpinnerContainer
-                  loading={RemoteDataState.Loading}
-                  spinnerComponent={<TechnoSpinner />}
+          <div className="data-explorer--monaco-outer">
+            <div className="data-explorer--monaco-wrap">
+              <Suspense
+                fallback={
+                  <SpinnerContainer
+                    loading={RemoteDataState.Loading}
+                    spinnerComponent={<TechnoSpinner />}
+                  />
+                }
+              >
+                <FluxMonacoEditor
+                  variables={variables}
+                  script={text}
+                  onChangeScript={setText}
                 />
-              }
-            >
-              <FluxMonacoEditor
-                variables={variables}
-                script={text}
-                onChangeScript={setText}
-              />
-            </Suspense>
+              </Suspense>
+            </div>
           </div>
           <div style={{width: '100%'}}>
             <FlexBox

--- a/src/timeMachine/components/TimeMachineFluxEditor.scss
+++ b/src/timeMachine/components/TimeMachineFluxEditor.scss
@@ -23,7 +23,7 @@
 }
 
 .flux-editor--monaco {
-  position: relative;
+  position: absolute;
   width: 100%;
   height: 100%;
 


### PR DESCRIPTION
Closes #4904

the flux display property has some cool abilities to resize it's children based on their content, but when a child gets a fixed dimension (width: px or height: px) then it prevents the flex parent from shrinking to consume the extra space. this caused our resizing component to collide with our monaco component creating a condition where the editor could only become bigger. at first this just looked like bizarre resizing behavior, but soon induced a state where the editor was the only component on the screen.

turns out the logic was fine for the resizer as long as there weren't these fixed children, we just needed a way to force the child component to be decoupled from the sizing calculations being made for the parent component during rending the IE box model hierarchy. the technique used ended up being having a wrapper component that set up a condition between a flex child (the parent in this situation) which gets resized automatically by it's parent to fill the space desired with the flex-grow property and a position: relative to anchor a new coordinate space for the child in relation to the parent. the wrapper then sets that new coordinate space with a `position: absolute', and sizes that space to fill the parent container with width: 100%, height: 100%

css errors suck