### PR TITLE
chore: remove bucket name from metadata

### DIFF
--- a/cypress/e2e/shared/buckets.test.ts
+++ b/cypress/e2e/shared/buckets.test.ts
@@ -326,9 +326,6 @@ describe('Buckets', () => {
         'contain',
         'This is a telegraf description'
       )
-      cy.get<string>('@defaultBucket').then((defaultBucket: string) => {
-        cy.getByTestID('bucket-name').should('contain', defaultBucket)
-      })
     })
   })
 

--- a/src/telegrafs/components/CollectorCard.tsx
+++ b/src/telegrafs/components/CollectorCard.tsx
@@ -75,10 +75,6 @@ class CollectorRow extends PureComponent<
           placeholder={`Describe ${collector.name}`}
         />
         <ResourceCard.Meta>
-          <span key={`bucket-key--${collector.id}`} data-testid="bucket-name">
-            {/* todo(glinton): verify what sets this. It seems like it is using the 'config' section of 'influxdb_v2' output?? */}
-            Bucket: {collector.metadata.buckets.join(', ')}
-          </span>
           <Link
             to={`/orgs/${org.id}/load-data/telegrafs/${collector.id}/instructions`}
             data-testid="setup-instructions-link"


### PR DESCRIPTION
Closes #4818 

PR removes bucket name from telegraf card's metadata. 
After a telegraf configuration is created, the UI sets the bucket name once on the configuration card and it never changes. Even if user edits configuration to use a different bucket, the original bucket name will always be what's displayed in the card. Instead of constantly updating bucket's name, we will be removing it all together from the card. 

To see which bucket(s) is being used in a telegraf config, users can click on the edit button and view on the edit page. 

Before:
<img width="1224" alt="Screen Shot 2022-06-30 at 9 59 43 AM" src="https://user-images.githubusercontent.com/66275100/176710409-3f5c8f46-cdfa-4303-8593-16d7620c3e05.png">

After: 
<img width="1218" alt="Screen Shot 2022-06-30 at 9 59 11 AM" src="https://user-images.githubusercontent.com/66275100/176710326-21d119a6-6a02-41ce-8528-133bc16b5aed.png">

 
