### PR TITLE
chore: do not escape backslashes in measurements and fields regex

### DIFF
--- a/src/writeData/subscriptions/components/StringParsingForm.tsx
+++ b/src/writeData/subscriptions/components/StringParsingForm.tsx
@@ -138,7 +138,7 @@ const StringParsingForm: FC<Props> = ({formContent, updateForm, edit}) => {
           {status => (
             <Input
               type={InputType.Text}
-              placeholder="eg. a=(\\d)"
+              placeholder="eg. a=(\d)"
               name="regex"
               autoFocus={true}
               value={formContent.stringMeasurement.pattern}

--- a/src/writeData/subscriptions/components/StringParsingForm.tsx
+++ b/src/writeData/subscriptions/components/StringParsingForm.tsx
@@ -79,7 +79,7 @@ const StringParsingForm: FC<Props> = ({formContent, updateForm, edit}) => {
           {status => (
             <Input
               type={InputType.Text}
-              placeholder="eg. regexExample"
+              placeholder="eg.(\d{10})"
               name="timestamp"
               autoFocus={true}
               value={formContent.stringTimestamp.pattern}

--- a/src/writeData/subscriptions/components/StringPatternInput.tsx
+++ b/src/writeData/subscriptions/components/StringPatternInput.tsx
@@ -178,7 +178,7 @@ const StringPatternInput: FC<Props> = ({
           {status => (
             <Input
               type={InputType.Text}
-              placeholder="eg. a=(\\d)"
+              placeholder="eg. a=(\d)"
               name="regex"
               autoFocus={true}
               value={

--- a/src/writeData/subscriptions/utils/form.ts
+++ b/src/writeData/subscriptions/utils/form.ts
@@ -77,24 +77,7 @@ export const sanitizeForm = (form: Subscription): Subscription => {
       form.jsonTimestamp.path = newVal
     }
   }
-  if (form.stringMeasurement?.pattern) {
-    form.stringMeasurement.pattern =
-      form.stringMeasurement?.pattern.replace(/\\\\/g, '\\') ?? ''
-  }
-  if (form.stringFields) {
-    form.stringFields.map(f => {
-      f.pattern = f.pattern?.replace(/\\\\/g, '\\') ?? ''
-    })
-  }
-  if (form.stringTags) {
-    form.stringTags.map(t => {
-      t.pattern = t.pattern?.replace(/\\\\/g, '\\') ?? ''
-    })
-  }
-  if (form.stringTimestamp?.pattern) {
-    form.stringTimestamp.pattern =
-      form.stringTimestamp?.pattern.replace(/\\\\/g, '\\') ?? ''
-  }
+
   if (form.brokerPassword === '' || form.brokerUsername === '') {
     delete form.brokerUsername
     delete form.brokerPassword
@@ -150,24 +133,7 @@ export const sanitizeUpdateForm = (form: Subscription): Subscription => {
       form.jsonTimestamp.type = 'string'
     }
   }
-  if (form.stringMeasurement?.pattern) {
-    form.stringMeasurement.pattern =
-      form.stringMeasurement?.pattern.replace(/\\\\/g, '\\') ?? ''
-  }
-  if (form.stringFields) {
-    form.stringFields.map(f => {
-      f.pattern = f.pattern?.replace(/\\\\/g, '\\') ?? ''
-    })
-  }
-  if (form.stringTags) {
-    form.stringTags.map(t => {
-      t.pattern = t.pattern?.replace(/\\\\/g, '\\') ?? ''
-    })
-  }
-  if (form.stringTimestamp?.pattern) {
-    form.stringTimestamp.pattern =
-      form.stringTimestamp?.pattern.replace(/\\\\/g, '\\') ?? ''
-  }
+
   delete form.id
   delete form.orgID
   delete form.processGroupID


### PR DESCRIPTION
Closes https://github.com/influxdata/data-acquisition/issues/403

Currently, we are adding extra complexity and confusion by replacing `\\` to be `\` in a regular expression. We don't need it, thus removing the functionality.


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
