### PR TITLE
chore: refactor first mile sample app code

### DIFF
--- a/src/homepageExperience/components/steps/Finish.tsx
+++ b/src/homepageExperience/components/steps/Finish.tsx
@@ -85,7 +85,7 @@ export const Finish = (props: OwnProps) => {
     props.wizardEventName === 'nodejsWizard'
   const sampleAppLink =
     props.wizardEventName === 'pythonWizard'
-      ? 'https://github.com/InfluxCommunity/sample-flask/blob/main/app.py'
+      ? 'https://github.com/influxdata/iot-api-python' 
       : 'https://github.com/influxdata/iot-api-js'
   const showBoilerplate = props.wizardEventName === 'nodejsWizard'
 

--- a/src/homepageExperience/components/steps/Finish.tsx
+++ b/src/homepageExperience/components/steps/Finish.tsx
@@ -85,7 +85,7 @@ export const Finish = (props: OwnProps) => {
     props.wizardEventName === 'nodejsWizard'
   const sampleAppLink =
     props.wizardEventName === 'pythonWizard'
-      ? 'https://github.com/influxdata/iot-api-python' 
+      ? 'https://github.com/influxdata/iot-api-python'
       : 'https://github.com/influxdata/iot-api-js'
   const showBoilerplate = props.wizardEventName === 'nodejsWizard'
 

--- a/src/homepageExperience/components/steps/Finish.tsx
+++ b/src/homepageExperience/components/steps/Finish.tsx
@@ -17,7 +17,7 @@ import {SafeBlankLink} from 'src/utils/SafeBlankLink'
 
 import {event} from 'src/cloud/utils/reporting'
 import FeedbackBar from 'src/homepageExperience/components/FeedbackBar'
-import SampleCode from 'src/homepageExperience/components/steps/SampleCode'
+import SampleAppCard from 'src/homepageExperience/components/steps/SampleAppCard'
 
 type OwnProps = {
   wizardEventName: string
@@ -135,7 +135,7 @@ export const Finish = (props: OwnProps) => {
           </ResourceCard>
         </FlexBox>
         {showSampleAppAndBoilerplate && (
-          <SampleCode
+          <SampleAppCard
             handleNextStepEvent={handleNextStepEvent}
             wizardEventName={props.wizardEventName}
           />

--- a/src/homepageExperience/components/steps/Finish.tsx
+++ b/src/homepageExperience/components/steps/Finish.tsx
@@ -155,8 +155,7 @@ export const Finish = (props: OwnProps) => {
               </SafeBlankLink>
               {props.wizardEventName === 'pythonWizard' ? (
                 <p>
-                  Play around with our template code of sample app to streamline
-                  your own data into InfluxData.
+                  View an IoT sample application written in Python.
                 </p>
               ) : (
                 // nodejs sample app

--- a/src/homepageExperience/components/steps/Finish.tsx
+++ b/src/homepageExperience/components/steps/Finish.tsx
@@ -17,6 +17,7 @@ import {SafeBlankLink} from 'src/utils/SafeBlankLink'
 
 import {event} from 'src/cloud/utils/reporting'
 import FeedbackBar from 'src/homepageExperience/components/FeedbackBar'
+import SampleCode from 'src/homepageExperience/components/steps/SampleCode'
 
 type OwnProps = {
   wizardEventName: string
@@ -80,14 +81,9 @@ export const Finish = (props: OwnProps) => {
     }
   }, [])
 
-  const showSampleApp =
+  const showSampleAppAndBoilerplate =
     props.wizardEventName === 'pythonWizard' ||
     props.wizardEventName === 'nodejsWizard'
-  const sampleAppLink =
-    props.wizardEventName === 'pythonWizard'
-      ? 'https://github.com/influxdata/iot-api-python'
-      : 'https://github.com/influxdata/iot-api-js'
-  const showBoilerplate = props.wizardEventName === 'nodejsWizard'
 
   return (
     <>
@@ -138,49 +134,12 @@ export const Finish = (props: OwnProps) => {
             </p>
           </ResourceCard>
         </FlexBox>
-        <FlexBox
-          margin={ComponentSize.Large}
-          alignItems={AlignItems.Stretch}
-          direction={FlexDirection.Row}
-        >
-          {showSampleApp && (
-            <ResourceCard
-              className="homepage-wizard-next-steps"
-              onClick={() =>
-                handleNextStepEvent(props.wizardEventName, 'sampleApp')
-              }
-            >
-              <SafeBlankLink href={sampleAppLink}>
-                <h4>{CodeTerminalIcon}Sample App</h4>
-              </SafeBlankLink>
-              {props.wizardEventName === 'pythonWizard' ? (
-                <p>
-                  View an IoT sample application written in Python.
-                </p>
-              ) : (
-                // nodejs sample app
-                <p>View an IoT sample application written in Node.js.</p>
-              )}
-            </ResourceCard>
-          )}
-          {showBoilerplate && (
-            <ResourceCard
-              className="homepage-wizard-next-steps"
-              onClick={() =>
-                handleNextStepEvent(props.wizardEventName, 'Boilerplate')
-              }
-            >
-              <SafeBlankLink href="https://github.com/influxdata/nodejs-samples/">
-                <h4>{CodeTerminalIcon}Boilerplate Snippets</h4>
-              </SafeBlankLink>
-
-              <p>
-                Get started writing and querying your own data using our code
-                snippets.
-              </p>
-            </ResourceCard>
-          )}
-        </FlexBox>
+        {showSampleAppAndBoilerplate && (
+          <SampleCode
+            handleNextStepEvent={handleNextStepEvent}
+            wizardEventName={props.wizardEventName}
+          />
+        )}
       </FlexBox>
     </>
   )

--- a/src/homepageExperience/components/steps/SampleAppCard.tsx
+++ b/src/homepageExperience/components/steps/SampleAppCard.tsx
@@ -17,7 +17,7 @@ type Props = {
   handleNextStepEvent: (wizardEventName: string, nextStepName: string) => void
 }
 
-const SampleCode: FC<Props> = ({wizardEventName, handleNextStepEvent}) => {
+const SampleAppCard: FC<Props> = ({wizardEventName, handleNextStepEvent}) => {
   const resources = [
     {
       title: 'Sample App',
@@ -67,4 +67,4 @@ const SampleCode: FC<Props> = ({wizardEventName, handleNextStepEvent}) => {
   )
 }
 
-export default SampleCode
+export default SampleAppCard

--- a/src/homepageExperience/components/steps/SampleAppCard.tsx
+++ b/src/homepageExperience/components/steps/SampleAppCard.tsx
@@ -59,7 +59,6 @@ const SampleAppCard: FC<Props> = ({wizardEventName, handleNextStepEvent}) => {
               {app.title}
             </h4>
           </SafeBlankLink>
-
           <p>{app.textContent}</p>
         </ResourceCard>
       ))}

--- a/src/homepageExperience/components/steps/SampleCode.tsx
+++ b/src/homepageExperience/components/steps/SampleCode.tsx
@@ -1,0 +1,70 @@
+import React, {FC} from 'react'
+
+import {
+  AlignItems,
+  ComponentSize,
+  FlexBox,
+  FlexDirection,
+  ResourceCard,
+} from '@influxdata/clockface'
+
+import {SafeBlankLink} from 'src/utils/SafeBlankLink'
+
+import {CodeTerminalIcon} from 'src/homepageExperience/components/HomepageIcons'
+
+type Props = {
+  wizardEventName: string
+  handleNextStepEvent: (wizardEventName: string, nextStepName: string) => void
+}
+
+const SampleCode: FC<Props> = ({wizardEventName, handleNextStepEvent}) => {
+  const resources = [
+    {
+      title: 'Sample App',
+      textContent: `View an IoT sample application written in ${
+        wizardEventName === 'pythonWizard' ? 'Python' : 'Node.js'
+      }.`,
+      links: {
+        pythonWizard: 'https://github.com/influxdata/iot-api-python',
+        nodejsWizard: 'https://github.com/influxdata/iot-api-js',
+      },
+    },
+    {
+      title: 'Boilerplate Snippets',
+      textContent:
+        'Get started writing and querying your own data using our code snippets.',
+      links: {
+        pythonWizard:
+          'https://github.com/InfluxCommunity/sample-flask/blob/main/app.py',
+        nodejsWizard: 'https://github.com/influxdata/nodejs-samples/',
+      },
+    },
+  ]
+
+  return (
+    <FlexBox
+      margin={ComponentSize.Large}
+      alignItems={AlignItems.Stretch}
+      direction={FlexDirection.Row}
+    >
+      {resources.map(app => (
+        <ResourceCard
+          className="homepage-wizard-next-steps"
+          onClick={() => handleNextStepEvent(wizardEventName, app.title)}
+          key={app.links[wizardEventName]}
+        >
+          <SafeBlankLink href={app.links[wizardEventName]}>
+            <h4>
+              {CodeTerminalIcon}
+              {app.title}
+            </h4>
+          </SafeBlankLink>
+
+          <p>{app.textContent}</p>
+        </ResourceCard>
+      ))}
+    </FlexBox>
+  )
+}
+
+export default SampleCode


### PR DESCRIPTION
Closes #4891 
Closes #4893 
Closes #4894 

Changes introduced in PR 

-  updated first mile python's sample app link 
- Added boilerplate code link for python 
- refactors `finish.tsx` by creating a new component `SampleAppCard` to render sample apps and boileplate codes

<img width="1405" alt="Screen Shot 2022-06-30 at 9 43 48 AM" src="https://user-images.githubusercontent.com/66275100/176706671-eb3f678f-62bd-4c80-8647-d49be6cb6efb.png">

<img width="1392" alt="Screen Shot 2022-06-30 at 9 44 02 AM" src="https://user-images.githubusercontent.com/66275100/176706698-e90a1d0f-11f0-4a35-b3b9-384a66ec2293.png">

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
