### PR TITLE
fix: subscriptions header

### DIFF
--- a/src/writeData/subscriptions/components/BrokerDetails.scss
+++ b/src/writeData/subscriptions/components/BrokerDetails.scss
@@ -7,10 +7,8 @@
     position: fixed;
     background-color: $cf-grey-5;
     background-attachment: fixed;
-    width: calc(61%);
     z-index: 10;
     padding-bottom: 20px;
-    right: 0;
 
     &__broker-buttons {
       padding-top: 46px;

--- a/src/writeData/subscriptions/components/BrokerDetails.scss
+++ b/src/writeData/subscriptions/components/BrokerDetails.scss
@@ -7,9 +7,10 @@
     position: fixed;
     background-color: $cf-grey-5;
     background-attachment: fixed;
-    width: 61%;
-    z-index: 9999;
+    width: calc(61%);
+    z-index: 10;
     padding-bottom: 20px;
+    right: 0;
 
     &__broker-buttons {
       padding-top: 46px;

--- a/src/writeData/subscriptions/components/BrokerDetails.tsx
+++ b/src/writeData/subscriptions/components/BrokerDetails.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FC} from 'react'
+import React, {FC, useContext} from 'react'
 import {useHistory} from 'react-router-dom'
 import {useSelector} from 'react-redux'
 
@@ -27,6 +27,7 @@ import BrokerFormContent from 'src/writeData/subscriptions/components/BrokerForm
 // Utils
 import {getOrg} from 'src/organizations/selectors'
 import {event} from 'src/cloud/utils/reporting'
+import {AppSettingContext} from 'src/shared/contexts/app'
 
 // Types
 import {SUBSCRIPTIONS, LOAD_DATA} from 'src/shared/constants/routes'
@@ -56,11 +57,18 @@ const BrokerDetails: FC<Props> = ({
 }) => {
   const history = useHistory()
   const org = useSelector(getOrg)
+  const {navbarMode} = useContext(AppSettingContext)
+  const navbarOpen = navbarMode === 'expanded'
   return (
     <div className="update-broker-form" id="broker">
       <SpinnerContainer spinnerComponent={<TechnoSpinner />} loading={loading}>
         <Form onSubmit={() => {}} testID="update-broker-form-overlay">
-          <div className="update-broker-form__fixed">
+          <div
+            className="update-broker-form__fixed"
+            style={{
+              width: navbarOpen ? 'calc(75% - 235px)' : 'calc(100% - 374px)',
+            }}
+          >
             <FlexBox
               className="update-broker-form__fixed__broker-buttons"
               direction={FlexDirection.Row}

--- a/src/writeData/subscriptions/components/BrokerDetails.tsx
+++ b/src/writeData/subscriptions/components/BrokerDetails.tsx
@@ -66,7 +66,7 @@ const BrokerDetails: FC<Props> = ({
           <div
             className="update-broker-form__fixed"
             style={{
-              width: navbarOpen ? 'calc(75% - 235px)' : 'calc(100% - 374px)',
+              width: navbarOpen ? '61%' : '69%',
             }}
           >
             <FlexBox

--- a/src/writeData/subscriptions/components/BrokerForm.scss
+++ b/src/writeData/subscriptions/components/BrokerForm.scss
@@ -7,7 +7,6 @@
     position: fixed;
     background-color: $cf-grey-5;
     background-attachment: fixed;
-    // width: 70%;
     z-index: 10;
     padding-bottom: 20px;
     right: 0;

--- a/src/writeData/subscriptions/components/BrokerForm.scss
+++ b/src/writeData/subscriptions/components/BrokerForm.scss
@@ -7,9 +7,10 @@
     position: fixed;
     background-color: $cf-grey-5;
     background-attachment: fixed;
-    width: 61%;
-    z-index: 9999;
+    // width: 70%;
+    z-index: 10;
     padding-bottom: 20px;
+    right: 0;
 
     &__broker-buttons {
       padding-top: 46px;
@@ -33,6 +34,11 @@
   }
   .cf-overlay--header {
     justify-content: unset;
+  }
+
+  &__broker-header {
+    padding-top: 150px;
+    margin-bottom: 25px;
   }
   .cf-select-group.cf-select-group__stretch {
     margin-bottom: $cf-space-l;

--- a/src/writeData/subscriptions/components/BrokerForm.tsx
+++ b/src/writeData/subscriptions/components/BrokerForm.tsx
@@ -68,12 +68,7 @@ const BrokerForm: FC<Props> = ({formContent, updateForm, saveForm}) => {
     formContent && (
       <div className="create-broker-form" id="broker">
         <Form onSubmit={() => {}} testID="create-broker-form-overlay">
-          <div
-            className="create-broker-form__fixed"
-            style={{
-              width: navbarOpen ? 'calc(75% - 235px)' : 'calc(100% - 374px)',
-            }}
-          >
+          <div className="create-broker-form__fixed" style={{width: navbarOpen ? 'calc(75% - 235px)' : 'calc(100% - 374px)'}}>
             <FlexBox
               className="create-broker-form__fixed__broker-buttons"
               direction={FlexDirection.Row}
@@ -143,10 +138,7 @@ const BrokerForm: FC<Props> = ({formContent, updateForm, saveForm}) => {
               )}
             </FlexBox>
           </div>
-          <Overlay.Header
-            className="create-broker-form__broker-header"
-            title="Connect to Broker"
-          ></Overlay.Header>
+          <Overlay.Header className='create-broker-form__broker-header' title="Connect to Broker"></Overlay.Header>
           <Overlay.Body>
             <Heading
               element={HeadingElement.H5}

--- a/src/writeData/subscriptions/components/BrokerForm.tsx
+++ b/src/writeData/subscriptions/components/BrokerForm.tsx
@@ -68,7 +68,12 @@ const BrokerForm: FC<Props> = ({formContent, updateForm, saveForm}) => {
     formContent && (
       <div className="create-broker-form" id="broker">
         <Form onSubmit={() => {}} testID="create-broker-form-overlay">
-          <div className="create-broker-form__fixed" style={{width: navbarOpen ? 'calc(75% - 235px)' : 'calc(100% - 374px)'}}>
+          <div
+            className="create-broker-form__fixed"
+            style={{
+              width: navbarOpen ? 'calc(75% - 235px)' : 'calc(100% - 374px)',
+            }}
+          >
             <FlexBox
               className="create-broker-form__fixed__broker-buttons"
               direction={FlexDirection.Row}
@@ -138,7 +143,10 @@ const BrokerForm: FC<Props> = ({formContent, updateForm, saveForm}) => {
               )}
             </FlexBox>
           </div>
-          <Overlay.Header className='create-broker-form__broker-header' title="Connect to Broker"></Overlay.Header>
+          <Overlay.Header
+            className="create-broker-form__broker-header"
+            title="Connect to Broker"
+          ></Overlay.Header>
           <Overlay.Body>
             <Heading
               element={HeadingElement.H5}

--- a/src/writeData/subscriptions/components/BrokerForm.tsx
+++ b/src/writeData/subscriptions/components/BrokerForm.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FC} from 'react'
+import React, {FC, useContext} from 'react'
 import {useHistory} from 'react-router-dom'
 import {useSelector} from 'react-redux'
 
@@ -35,6 +35,7 @@ import {
   getDataLayerIdentity,
   getExperimentVariantId,
 } from 'src/cloud/utils/experiments'
+import {AppSettingContext} from 'src/shared/contexts/app'
 
 // Constants
 import {CREDIT_250_EXPERIMENT_ID} from 'src/shared/constants'
@@ -61,11 +62,18 @@ const BrokerForm: FC<Props> = ({formContent, updateForm, saveForm}) => {
     !isFlagEnabled('enableFreeSubscriptions')
   const isCredit250ExperienceActive = useSelector(shouldGetCredit250Experience)
   const requiredFields = checkRequiredFields(formContent)
+  const {navbarMode} = useContext(AppSettingContext)
+  const navbarOpen = navbarMode === 'expanded'
   return (
     formContent && (
       <div className="create-broker-form" id="broker">
         <Form onSubmit={() => {}} testID="create-broker-form-overlay">
-          <div className="create-broker-form__fixed">
+          <div
+            className="create-broker-form__fixed"
+            style={{
+              width: navbarOpen ? 'calc(75% - 235px)' : 'calc(100% - 374px)',
+            }}
+          >
             <FlexBox
               className="create-broker-form__fixed__broker-buttons"
               direction={FlexDirection.Row}
@@ -135,7 +143,10 @@ const BrokerForm: FC<Props> = ({formContent, updateForm, saveForm}) => {
               )}
             </FlexBox>
           </div>
-          <Overlay.Header title="Connect to Broker"></Overlay.Header>
+          <Overlay.Header
+            className="create-broker-form__broker-header"
+            title="Connect to Broker"
+          ></Overlay.Header>
           <Overlay.Body>
             <Heading
               element={HeadingElement.H5}


### PR DESCRIPTION
Closes https://github.com/influxdata/data-acquisition/issues/398

Lowers z-index so errs are shown above the fixed header.
Fixes width to account for whether the side nav is toggled or not.
Adds padding so we aren't losing the header / text at the top of the page.


https://user-images.githubusercontent.com/38860767/176711677-d950a466-c021-4af3-9df6-529a581dc274.mov

<img width="1320" alt="Screen Shot 2022-06-30 at 10 56 05 AM" src="https://user-images.githubusercontent.com/38860767/176711685-87f0d440-6d0a-4968-a14f-70e2eb6a7e12.png">

<img width="1538" alt="Screen Shot 2022-06-30 at 10 57 31 AM" src="https://user-images.githubusercontent.com/38860767/176711694-b3d1c4bb-a20d-4bb0-8628-70dcfba227ba.png">

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
