### PR TITLE
fix: stopgap error messages

### DIFF
--- a/src/dataExplorer/components/QueryTime.scss
+++ b/src/dataExplorer/components/QueryTime.scss
@@ -2,6 +2,7 @@
 
 .query-status {
   flex-grow: 1;
+  margin-top: 14px;
 
   .status {
     width: 12px;
@@ -25,5 +26,11 @@
     &.done {
       background: $c-rainforest;
     }
+  }
+
+  pre {
+    color: $c-fire;
+    font-family: $cf-code-font;
+    margin: $cf-space-2xs;
   }
 }

--- a/src/dataExplorer/components/QueryTime.tsx
+++ b/src/dataExplorer/components/QueryTime.tsx
@@ -9,7 +9,7 @@ const humanReadable = (time: number): string => {
 }
 
 const QueryTime: FC = () => {
-  const {status, time} = useContext(ResultsContext)
+  const {result, status, time} = useContext(ResultsContext)
 
   if (status === RemoteDataState.Done) {
     return (
@@ -42,6 +42,7 @@ const QueryTime: FC = () => {
       <div className="query-status">
         <div className="status error" />
         <label>Error ({humanReadable(time)})</label>
+        <pre>{result.error}</pre>
       </div>
     )
   }

--- a/src/dataExplorer/components/ResultsPane.tsx
+++ b/src/dataExplorer/components/ResultsPane.tsx
@@ -13,6 +13,7 @@ import {
   FlexBox,
   FlexDirection,
   JustifyContent,
+  AlignItems,
 } from '@influxdata/clockface'
 import {createLocalStorageStateHook} from 'use-local-storage-state'
 
@@ -122,7 +123,12 @@ const ResultsPane: FC = () => {
         setResult(r)
         setStatus(RemoteDataState.Done)
       })
-      .catch(() => {
+      .catch(e => {
+        setResult({
+          source: text,
+          parsed: null,
+          error: e.message,
+        })
         event('resultReceived', {status: 'error'})
         setStatus(RemoteDataState.Error)
       })
@@ -172,6 +178,7 @@ const ResultsPane: FC = () => {
             <FlexBox
               direction={FlexDirection.Row}
               justifyContent={JustifyContent.FlexEnd}
+              alignItems={AlignItems.FlexStart}
               margin={ComponentSize.Small}
             >
               <QueryTime />


### PR DESCRIPTION
we gotta show people error messages in the ui when their query fails

here's a quick stab while we wait for design to get a few free cycles to decouple the presentation from the layout shifting. @juliajames12 

![Peek 2022-06-30 09-39](https://user-images.githubusercontent.com/1434802/176732125-1ff053a6-be9c-4ee6-87ea-fb5410974d71.gif)
