### PR TITLE
WIP: test: guard with attach assertion rather than visible

### DIFF
--- a/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
+++ b/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
@@ -17,8 +17,8 @@ const addFluxQueryInNotebook = (query: string) => {
    *   - do not use .monacoType
    *   - must select the first visible line
    */
-  cy.get('.monaco-editor .view-line:first').click()
-  cy.get('textarea.inputarea.monaco-mouse-cursor-text').type(
+  cy.get('.monaco-editor .view-line:first').clickAttached()
+  cy.get('.monaco-editor .view-line:first').type(
     `{downarrow}{downarrow}${query}`
   )
 }

--- a/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
+++ b/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
@@ -20,6 +20,7 @@ const addFluxQueryInNotebook = (query: string) => {
   cy.get('.monaco-editor .view-line:first')
     .should($el => {
       expect(Cypress.dom.isDetached($el)).to.be.false
+      expect($el).not.to.be.disabled
     })
     .type(`{downarrow}{downarrow}${query}`)
 }

--- a/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
+++ b/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
@@ -17,10 +17,11 @@ const addFluxQueryInNotebook = (query: string) => {
    *   - do not use .monacoType
    *   - must select the first visible line
    */
-  cy.get('.monaco-editor .view-line:first').clickAttached()
-  cy.get('.monaco-editor .view-line:first').type(
-    `{downarrow}{downarrow}${query}`
-  )
+  cy.get('.monaco-editor .view-line:first')
+    .should($el => {
+      expect(Cypress.dom.isDetached($el)).to.be.false
+    })
+    .type(`{downarrow}{downarrow}${query}`)
 }
 
 const createEmptyNotebook = () => {


### PR DESCRIPTION
Closes #4936  

Q: Run the tests. Is the flakiness confirmed?
A: Yes, unfortunately we reached flakiness at **119/120** test runs with the existing code

Proposal: since the flakiness is due to interacted elements being detached, let's assert to ensure our element is attached before interacting with it. We can also try going back to typing into the `.view-line`
