### PR TITLE
WIP: test: reassert on every character typed

### DIFF
--- a/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
+++ b/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
@@ -17,7 +17,12 @@ const addFluxQueryInNotebook = (query: string) => {
    *   - do not use .monacoType
    *   - must select the first visible line
    */
-  cy.get('.monaco-editor .view-line:first').click()
+  cy.get('.monaco-editor .view-line:first')
+    .should($el => {
+      expect(Cypress.dom.isDetached($el)).to.be.false
+      expect($el).not.to.be.disabled
+    })
+    .click()
   cy.get('textarea.inputarea.monaco-mouse-cursor-text')
     .should($el => {
       expect(Cypress.dom.isDetached($el)).to.be.false

--- a/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
+++ b/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
@@ -17,10 +17,12 @@ const addFluxQueryInNotebook = (query: string) => {
    *   - do not use .monacoType
    *   - must select the first visible line
    */
-  cy.get('.monaco-editor .view-line:first').click()
-  cy.get('textarea.inputarea.monaco-mouse-cursor-text').type(
-    `{downarrow}{downarrow}${query}`
-  )
+  cy.get('.monaco-editor .view-line:first')
+    .should($el => {
+      expect($el).be.visible
+      expect(Cypress.dom.isDetached($el)).to.be.false
+    })
+    .type(`{downarrow}{downarrow}${query}`)
 }
 
 const createEmptyNotebook = () => {

--- a/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
+++ b/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
@@ -20,7 +20,7 @@ const addFluxQueryInNotebook = (query: string) => {
   cy.get('.monaco-editor .view-line:first')
     .should($el => {
       expect(Cypress.dom.isDetached($el)).to.be.false
-      expect($el).not.to.be.visible
+      expect($el).to.be.visible
     })
     .click()
   cy.get('textarea.inputarea.monaco-mouse-cursor-text')

--- a/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
+++ b/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
@@ -17,12 +17,53 @@ const addFluxQueryInNotebook = (query: string) => {
    *   - do not use .monacoType
    *   - must select the first visible line
    */
-  cy.get('.monaco-editor .view-line:first')
+  cy.get('.monaco-editor .view-line:first').click()
+  cy.get('textarea.inputarea.monaco-mouse-cursor-text')
     .should($el => {
-      expect($el).be.visible
       expect(Cypress.dom.isDetached($el)).to.be.false
+      expect($el).not.to.be.disabled
     })
-    .type(`{downarrow}{downarrow}${query}`)
+    .type('{downarrow}')
+  cy.get('textarea.inputarea.monaco-mouse-cursor-text')
+    .should($el => {
+      expect(Cypress.dom.isDetached($el)).to.be.false
+      expect($el).not.to.be.disabled
+    })
+    .type('{downarrow}')
+
+  if (query) {
+    let isCharacterSequence = false
+    let sequence = ''
+    for (let index = 0; index < query.length; index += 1) {
+      if (query.charAt(index) === '{' && isCharacterSequence === false) {
+        isCharacterSequence = true
+        continue
+      }
+
+      if (query.charAt(index) === '}' && isCharacterSequence === true) {
+        cy.get('textarea.inputarea.monaco-mouse-cursor-text')
+          .should($el => {
+            expect(Cypress.dom.isDetached($el)).to.be.false
+            expect($el).not.to.be.disabled
+          })
+          .type(`{${sequence}}`)
+        sequence = ''
+        isCharacterSequence = false
+        continue
+      }
+
+      if (isCharacterSequence) {
+        sequence += query.charAt(index)
+      } else {
+        cy.get('textarea.inputarea.monaco-mouse-cursor-text')
+          .should($el => {
+            expect(Cypress.dom.isDetached($el)).to.be.false
+            expect($el).not.to.be.disabled
+          })
+          .type(query.charAt(index))
+      }
+    }
+  }
 }
 
 const createEmptyNotebook = () => {

--- a/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
+++ b/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
@@ -20,7 +20,7 @@ const addFluxQueryInNotebook = (query: string) => {
   cy.get('.monaco-editor .view-line:first')
     .should($el => {
       expect(Cypress.dom.isDetached($el)).to.be.false
-      expect($el).not.to.be.disabled
+      expect($el).not.to.be.visible
     })
     .click()
   cy.get('textarea.inputarea.monaco-mouse-cursor-text')


### PR DESCRIPTION
Closes #4936  

Q: Run the tests. Is the flakiness confirmed?
A: Yes, unfortunately we reached flakiness at **119/120** test runs with the existing code

Proposal: since the flakiness is due to interacted elements being detached, let's assert to ensure our element is attached before interacting with it. We can also try going back to typing into the `.view-line`

- on each character or character sequence, find the `textarea` again and assert it is attached and not disabled
