### PR TITLE
feat(annotations): create and use more broad scoped annotation

### DIFF
--- a/src/annotations/components/AddAnnotationOverlay.tsx
+++ b/src/annotations/components/AddAnnotationOverlay.tsx
@@ -10,8 +10,6 @@ import {OverlayContext} from 'src/overlays/components/OverlayController'
 
 // Selectors
 import {getOverlayParams} from 'src/overlays/selectors'
-import {getTimeFormatForView} from 'src/views/selectors'
-import {AppState} from 'src/types'
 
 export const AddAnnotationOverlay: FC = () => {
   const {onClose} = useContext(OverlayContext)
@@ -21,12 +19,16 @@ export const AddAnnotationOverlay: FC = () => {
     endTime,
     range,
     eventPrefix,
-    cellID,
   } = useSelector(getOverlayParams)
 
-  const timeFormat = useSelector((state: AppState) =>
-    getTimeFormatForView(state, cellID)
-  )
+  // const dashboardID = useSelector((state: AppState) =>
+  // state.currentDashboard.id
+  // )
+
+  // todo: need the to get the proper time; hopefully the time format is the same dashboard wide :crossed_fingers:
+  // const timeFormat = useSelector((state: AppState) =>
+  // getTimeFormatForView(state, state.currentDashboard.id)
+  // )
 
   const handleSubmit = (modifiedAnnotation): void => {
     createAnnotation(modifiedAnnotation)
@@ -44,7 +46,8 @@ export const AddAnnotationOverlay: FC = () => {
       startTime={startTime}
       endTime={endTime}
       eventPrefix={eventPrefix}
-      timeFormat={timeFormat}
+      // timeFormat={timeFormat}
+      // stream={dashboardID}
     />
   )
 }

--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -326,7 +326,7 @@ const XYPlot: FC<Props> = ({
   addAnnotationLayer(
     config,
     inAnnotationMode,
-    cellID,
+    view.dashboardID,
     xColumn,
     yColumn,
     groupKey,

--- a/src/visualization/utils/annotationUtils.ts
+++ b/src/visualization/utils/annotationUtils.ts
@@ -24,7 +24,7 @@ import {
 
 const makeCreateMethod = (
   dispatch: Dispatch<any>,
-  cellID: string,
+  streamName: string,
   eventPrefix = 'xyplot'
 ) => {
   const createAnnotation = async userModifiedAnnotation => {
@@ -37,7 +37,7 @@ const makeCreateMethod = (
         writeThenFetchAndSetAnnotations([
           {
             summary,
-            stream: cellID,
+            stream: streamName,
             startTime: new Date(startTime).getTime(),
             endTime: new Date(actualEndTime).getTime(),
           },
@@ -63,10 +63,10 @@ const makeCreateMethod = (
 // (initially, the user can then change to a range once the dialog is up)
 const makeAnnotationClickListener = (
   dispatch: Dispatch<any>,
-  cellID: string,
+  streamName: string,
   eventPrefix = 'xyplot'
 ) => {
-  const createAnnotation = makeCreateMethod(dispatch, cellID, eventPrefix)
+  const createAnnotation = makeCreateMethod(dispatch, streamName, eventPrefix)
 
   const singleClickHandler = (plotInteraction: InteractionHandlerArguments) => {
     event(`annotations.create_annotation.show_overlay`, {prefix: eventPrefix})
@@ -78,7 +78,7 @@ const makeAnnotationClickListener = (
           createAnnotation,
           startTime: plotInteraction?.clampedValueX ?? plotInteraction.valueX,
           eventPrefix,
-          cellID,
+          streamName,
         },
         () => {
           dismissOverlay()
@@ -92,10 +92,10 @@ const makeAnnotationClickListener = (
 
 const makeAnnotationRangeListener = (
   dispatch: Dispatch<any>,
-  cellID: string,
+  streamName: string,
   eventPrefix = 'xyplot'
 ) => {
-  const createAnnotation = makeCreateMethod(dispatch, cellID, eventPrefix)
+  const createAnnotation = makeCreateMethod(dispatch, streamName, eventPrefix)
 
   const rangeHandler = (start: number | string, end: number | string) => {
     event(`annotations.create_range_annotation.show_overlay`, {
@@ -110,7 +110,7 @@ const makeAnnotationRangeListener = (
           endTime: end,
           range: true,
           eventPrefix,
-          cellID,
+          streamName,
         },
         () => {
           dismissOverlay()
@@ -134,13 +134,13 @@ const makeAnnotationRangeListener = (
  *  so just need one handler for both types of annotations
  * */
 const makeAnnotationClickHandler = (
-  cellID: string,
+  streamName: string,
   dispatch: Dispatch<any>,
   annotations: AnnotationsList,
   eventPrefix = 'xyplot'
 ) => {
   const clickHandler = (id: string) => {
-    const annotationToEdit = annotations[cellID].find(
+    const annotationToEdit = annotations[streamName].find(
       annotation => annotation.id === id
     )
     if (annotationToEdit) {
@@ -153,10 +153,10 @@ const makeAnnotationClickHandler = (
           {
             clickedAnnotation: {
               ...annotationToEdit,
-              stream: cellID,
+              stream: streamName,
               eventPrefix,
             },
-            cellID,
+            streamName,
           },
           () => {
             dismissOverlay()
@@ -182,7 +182,7 @@ export const sortAnnotations = (anno1, anno2) => {
   return anno1Value - anno2Value
 }
 const makeAnnotationLayer = (
-  cellID: string,
+  streamName: string,
   xColumn: string,
   yColumn: string,
   groupKey: string[],
@@ -191,7 +191,7 @@ const makeAnnotationLayer = (
   dispatch: Dispatch<any>,
   eventPrefix = 'xyplot'
 ) => {
-  const cellAnnotations = annotations ? annotations[cellID] ?? [] : []
+  const cellAnnotations = annotations ? annotations[streamName] ?? [] : []
 
   const annotationsToRender: any[] = cellAnnotations
     .sort(sortAnnotations)
@@ -203,7 +203,7 @@ const makeAnnotationLayer = (
     })
 
   const handleAnnotationClick = makeAnnotationClickHandler(
-    cellID,
+    streamName,
     dispatch,
     annotations,
     eventPrefix
@@ -238,7 +238,7 @@ const makeAnnotationLayer = (
 export const addAnnotationLayer = (
   config: Config,
   inAnnotationMode: boolean,
-  cellID: string,
+  streamName: string,
   xColumn: string,
   yColumn: string,
   groupKey: string[],
@@ -246,23 +246,23 @@ export const addAnnotationLayer = (
   dispatch: Dispatch<any>,
   eventPrefix = 'xyplot'
 ) => {
-  if (inAnnotationMode && cellID) {
+  if (inAnnotationMode && streamName) {
     config.interactionHandlers = {
       singleShiftClick: makeAnnotationClickListener(
         dispatch,
-        cellID,
+        streamName,
         eventPrefix
       ),
     }
     config.interactionHandlers.onXBrush = makeAnnotationRangeListener(
       dispatch,
-      cellID,
+      streamName,
       eventPrefix
     )
   }
 
   const annotationLayer: AnnotationLayerConfig = makeAnnotationLayer(
-    cellID,
+    streamName,
     xColumn,
     yColumn,
     groupKey,


### PR DESCRIPTION
This changes the annotation stream used from an individual cell-id stream to a dashboard wide-stream.

This is in no way release-ready, cells will still have to request annotations from streams named with the cell's id for backwards compatibility. It would also be more ideal to specify which stream to show annotations from (inclusive list) so they can be shared across dashboards. This is, imo, better than the current implementation where an annotation is restricted to a single cell.

A non-react developer's attempt at #4952 to get the ball finally rolling on it.

![image](https://user-images.githubusercontent.com/2653109/176969875-86fe355e-7948-44c0-b037-a837ec31316f.png)

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
