### PR TITLE
chore(4646/4836): helper function to calculate a windowPeriod from a duration.

### DIFF
--- a/src/shared/utils/windowPeriod/fromDuration.test.ts
+++ b/src/shared/utils/windowPeriod/fromDuration.test.ts
@@ -1,0 +1,24 @@
+import {convertMillisecondDurationToWindowPeriod} from './fromDuration'
+import {SELECTABLE_TIME_RANGES} from 'src/shared/constants/timeRanges'
+
+describe('Getting a windowPeriod number, from time ranges', () => {
+  describe('can detect preset selectable timeRange', () => {
+    SELECTABLE_TIME_RANGES.forEach(range => {
+      it('can provide the proper windowPeriod', () => {
+        const actual = convertMillisecondDurationToWindowPeriod(
+          range.seconds * 1000
+        )
+        const expected = range.windowPeriod
+        expect(actual).toEqual(expected)
+      })
+    })
+  })
+  describe('can calculate based on custom time', () => {
+    it('returns a number', () => {
+      const actual = convertMillisecondDurationToWindowPeriod(
+        Math.floor(Math.random() * 10000)
+      )
+      expect(Number.isInteger(actual)).toEqual(true)
+    })
+  })
+})

--- a/src/shared/utils/windowPeriod/fromDuration.ts
+++ b/src/shared/utils/windowPeriod/fromDuration.ts
@@ -1,0 +1,27 @@
+import {
+  SELECTABLE_TIME_RANGES,
+  DESIRED_POINTS_PER_GRAPH,
+} from 'src/shared/constants/timeRanges'
+
+function calcWindowPeriodForRangeDuration(rangeDuration: number) {
+  return Math.round(rangeDuration / DESIRED_POINTS_PER_GRAPH) // duration in ms
+}
+
+/**
+ * Determining the `windowPeriod`
+ * from the timeRange numerical duration (a.k.a. upper - lower) in milliseconds.
+ *
+ * @param rangeDuration -- given the duration in milliseconds
+ * @returns {number} -- numeric value of windowPeriod
+ */
+export function convertMillisecondDurationToWindowPeriod(
+  rangeDuration: number
+): number {
+  const foundDuration = SELECTABLE_TIME_RANGES.find(
+    tr => tr.seconds * 1000 === rangeDuration
+  )
+  if (foundDuration) {
+    return foundDuration.windowPeriod
+  }
+  return calcWindowPeriodForRangeDuration(rangeDuration)
+}

--- a/src/shared/utils/windowPeriod/index.ts
+++ b/src/shared/utils/windowPeriod/index.ts
@@ -1,0 +1,1 @@
+export * from './fromDuration'


### PR DESCRIPTION
Precondition for #4646 and #4836 .


Will need to be able to calculate a windowPeriod, when given a duration.