### PR TITLE
chore(4646/4836): calculate window period from UI type TimeRange

### DIFF
--- a/src/shared/utils/windowPeriod/fromTimeRange.test.ts
+++ b/src/shared/utils/windowPeriod/fromTimeRange.test.ts
@@ -1,0 +1,41 @@
+import {getWindowPeriodDurationFromTimeRange} from './fromTimeRange'
+import {millisecondsToDuration} from 'src/shared/utils/duration'
+import {SELECTABLE_TIME_RANGES} from 'src/shared/constants/timeRanges'
+import {TimeRange} from 'src/types'
+
+describe('Getting a windowPeriod duration string, from time ranges', () => {
+  describe('can detect preset selectable timeRange', () => {
+    SELECTABLE_TIME_RANGES.forEach(range => {
+      it('returns the windowPeriod, as a duration', () => {
+        const actual = getWindowPeriodDurationFromTimeRange(range)
+        const expected = millisecondsToDuration(range.windowPeriod)
+        expect(actual).toEqual(expected)
+      })
+    })
+  })
+
+  describe('can calculate based on custom time', () => {
+    const range = {
+      type: 'custom',
+      lower: '2022-07-01T01:00:00.501Z',
+      upper: '2022-07-01T04:00:00.501Z',
+    } as TimeRange
+    it('returns the correct string duration', () => {
+      const actual = getWindowPeriodDurationFromTimeRange(range)
+      const expected = millisecondsToDuration(60000) // "1m"
+      expect(expected).toEqual(actual)
+    })
+  })
+
+  describe('can calculate based on a duration timeRange', () => {
+    const range = {
+      type: 'duration',
+      lower: 'now() - 3h',
+    } as TimeRange
+    it('returns the correct string duration', () => {
+      const actual = getWindowPeriodDurationFromTimeRange(range)
+      const expected = millisecondsToDuration(60000) // "1m"
+      expect(expected).toEqual(actual)
+    })
+  })
+})

--- a/src/shared/utils/windowPeriod/fromTimeRange.ts
+++ b/src/shared/utils/windowPeriod/fromTimeRange.ts
@@ -1,0 +1,44 @@
+import {TimeRange} from 'src/types'
+import {
+  millisecondsToDuration,
+  durationToMilliseconds,
+  parseDuration,
+} from 'src/shared/utils/duration'
+import {convertMillisecondDurationToWindowPeriod} from 'src/shared/utils/windowPeriod'
+
+/**
+ * @param timeRange -- timeRange, UI type
+ * @returns {number} -- milliseconds of windowPeriod
+ */
+const windowPeriodFromTimeRange = (timeRange: TimeRange): number => {
+  switch (timeRange.type) {
+    case 'selectable-duration':
+      return timeRange.windowPeriod
+    case 'custom':
+      const upper = Date.parse(timeRange.upper)
+      const lower = Date.parse(timeRange.lower)
+      return convertMillisecondDurationToWindowPeriod(upper - lower)
+    case 'duration':
+      const ms = durationToMilliseconds(parseDuration(timeRange.lower))
+      return convertMillisecondDurationToWindowPeriod(ms)
+    default:
+      throw new Error(
+        'Unknown timeRange type provided to windowPeriodFromTimeRange'
+      )
+  }
+}
+
+/**
+ * @param timeRange -- timeRange, UI type
+ * @returns {string} -- string duration, for the windowPeriod. e.g. `-15m`
+ */
+export function getWindowPeriodDurationFromTimeRange(
+  timeRange: TimeRange
+): string | null {
+  try {
+    return millisecondsToDuration(windowPeriodFromTimeRange(timeRange))
+  } catch (e) {
+    console.warn(e)
+    return null
+  }
+}

--- a/src/shared/utils/windowPeriod/index.ts
+++ b/src/shared/utils/windowPeriod/index.ts
@@ -1,1 +1,2 @@
 export * from './fromDuration'
+export * from './fromTimeRange'


### PR DESCRIPTION
Precondition for #4646 and #4836 

When given a UI type TimeRange, be able to provide the windowPeriod (as either a milliseconds number, or a string duration).

These methods will be used by the visitor, and later on by the UI view layer.