### PR TITLE
feat(operatorUI): add css to make orgid selectable

### DIFF
--- a/src/operator/OrgOverlay.scss
+++ b/src/operator/OrgOverlay.scss
@@ -1,5 +1,10 @@
-.overlay-header--color {
+.overlay-header--color.overlay-header--title {
   color: #fff;
+  user-select: text !important;
+  -moz-user-select: text !important;
+  -webkit-user-select: text !important;
+  -ms-user-select: text !important;
+  -o-user-select: text !important;
 }
 
 .cf-overlay--body {

--- a/src/operator/OrgOverlay.tsx
+++ b/src/operator/OrgOverlay.tsx
@@ -79,7 +79,7 @@ const OrgOverlay: FC = () => {
       <Overlay.Container maxWidth={1000}>
         <Overlay.Header
           title={orgID}
-          className="overlay-header--color"
+          className="overlay-header--color overlay-header--title"
           onDismiss={() => history.goBack()}
         />
         <SpinnerContainer


### PR DESCRIPTION
see #[14853](https://github.com/influxdata/idpe/issues/14853)

PR edits `OrgOverlay.scss` to override overly header style to make title (OrgID) selectable.  

After Change: 


https://user-images.githubusercontent.com/66275100/177415033-db1a31b5-e209-4278-b014-673ecb3b8999.mov


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
