### PR TITLE
fix: do not effect the number input on scroll

### DIFF
--- a/src/writeData/subscriptions/components/BrokerFormContent.tsx
+++ b/src/writeData/subscriptions/components/BrokerFormContent.tsx
@@ -53,10 +53,15 @@ const BrokerFormContent: FC<Props> = ({
   useEffect(() => {
     updateForm({...formContent, protocol: protocol.toLowerCase()})
   }, [protocol])
-  const numberInput = document.getElementById(`${className}-broker-form--port`)
-  numberInput?.addEventListener('mousewheel', function(evt) {
-    evt.preventDefault()
-  })
+
+  useEffect(() => {
+    const numberInput = document.getElementById(
+      `${className}-broker-form--port`
+    )
+    numberInput?.addEventListener('mousewheel', function(evt) {
+      evt.preventDefault()
+    })
+  }, [])
   return (
     <Grid>
       <Grid.Row>

--- a/src/writeData/subscriptions/components/BrokerFormContent.tsx
+++ b/src/writeData/subscriptions/components/BrokerFormContent.tsx
@@ -53,6 +53,10 @@ const BrokerFormContent: FC<Props> = ({
   useEffect(() => {
     updateForm({...formContent, protocol: protocol.toLowerCase()})
   }, [protocol])
+  const numberInput = document.getElementById(`${className}-broker-form--port`)
+  numberInput?.addEventListener('mousewheel', function(evt) {
+    evt.preventDefault()
+  })
   return (
     <Grid>
       <Grid.Row>
@@ -181,7 +185,7 @@ const BrokerFormContent: FC<Props> = ({
                   type={InputType.Text}
                   placeholder="0.0.0.0"
                   name="host"
-                  autoFocus={true}
+                  autoFocus={false}
                   value={formContent.brokerHost}
                   onChange={e => {
                     updateForm({
@@ -214,7 +218,7 @@ const BrokerFormContent: FC<Props> = ({
                   type={InputType.Number}
                   placeholder="1883"
                   name="port"
-                  autoFocus={true}
+                  autoFocus={false}
                   value={formContent.brokerPort}
                   onChange={e => {
                     updateForm({
@@ -232,6 +236,7 @@ const BrokerFormContent: FC<Props> = ({
                   status={edit ? status : ComponentStatus.Disabled}
                   maxLength={5}
                   testID={`${className}-broker-form--port`}
+                  id={`${className}-broker-form--port`}
                 />
               )}
             </Form.ValidationElement>


### PR DESCRIPTION
Closes https://github.com/influxdata/data-acquisition/issues/411

The default behavior of a number input is if it's focused to go up/down on scroll. This makes our port field behave oddly in the case of our single page scrolling form.

This prevents the number from going up or down on scroll for our create/edit view.
Also removes the auto focus on the ip and port so as the user lands on the page they are focused on the name field.

before:

https://user-images.githubusercontent.com/38860767/177419080-53ae3ac5-9d67-46a4-b8d6-88dcfe19fd25.mov

now:

https://user-images.githubusercontent.com/38860767/177419106-bd5c8c48-4cbe-4df2-9abe-8e57d70d8a2f.mov


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
