### PR TITLE
feat(4646/4836): from a given flux AST, extract the proper scoped windowPeriod.

### DIFF
--- a/src/shared/utils/windowPeriod/ast_fixtures.json
+++ b/src/shared/utils/windowPeriod/ast_fixtures.json
@@ -1,0 +1,5125 @@
+{
+  "empty_query": {
+    "type": "File",
+    "metadata": "parser-type=rust",
+    "package": null,
+    "imports": [],
+    "body": []
+  },
+  "time_range": {
+    "type": "File",
+    "location": {
+      "start": {"line": 1, "column": 1},
+      "end": {"line": 4, "column": 40},
+      "source": "import \"influxdata/influxdb/sample\"\nsample.data(set: \"airSensor\")\n    |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n    |> yield(name: \"${v.windowPeriod}\")"
+    },
+    "metadata": "parser-type=rust",
+    "package": null,
+    "imports": [
+      {
+        "type": "ImportDeclaration",
+        "location": {
+          "start": {"line": 1, "column": 1},
+          "end": {"line": 1, "column": 36},
+          "source": "import \"influxdata/influxdb/sample\""
+        },
+        "as": null,
+        "path": {
+          "location": {
+            "start": {"line": 1, "column": 8},
+            "end": {"line": 1, "column": 36},
+            "source": "\"influxdata/influxdb/sample\""
+          },
+          "value": "influxdata/influxdb/sample"
+        }
+      }
+    ],
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "location": {
+          "start": {"line": 2, "column": 1},
+          "end": {"line": 4, "column": 40},
+          "source": "sample.data(set: \"airSensor\")\n    |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n    |> yield(name: \"${v.windowPeriod}\")"
+        },
+        "expression": {
+          "type": "PipeExpression",
+          "location": {
+            "start": {"line": 2, "column": 1},
+            "end": {"line": 4, "column": 40},
+            "source": "sample.data(set: \"airSensor\")\n    |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n    |> yield(name: \"${v.windowPeriod}\")"
+          },
+          "argument": {
+            "type": "PipeExpression",
+            "location": {
+              "start": {"line": 2, "column": 1},
+              "end": {"line": 3, "column": 61},
+              "source": "sample.data(set: \"airSensor\")\n    |> range(start: v.timeRangeStart, stop: v.timeRangeStop)"
+            },
+            "argument": {
+              "type": "CallExpression",
+              "location": {
+                "start": {"line": 2, "column": 1},
+                "end": {"line": 2, "column": 30},
+                "source": "sample.data(set: \"airSensor\")"
+              },
+              "callee": {
+                "type": "MemberExpression",
+                "location": {
+                  "start": {"line": 2, "column": 1},
+                  "end": {"line": 2, "column": 12},
+                  "source": "sample.data"
+                },
+                "object": {
+                  "type": "Identifier",
+                  "location": {
+                    "start": {"line": 2, "column": 1},
+                    "end": {"line": 2, "column": 7},
+                    "source": "sample"
+                  },
+                  "name": "sample"
+                },
+                "property": {
+                  "type": "Identifier",
+                  "location": {
+                    "start": {"line": 2, "column": 8},
+                    "end": {"line": 2, "column": 12},
+                    "source": "data"
+                  },
+                  "name": "data"
+                }
+              },
+              "arguments": [
+                {
+                  "type": "ObjectExpression",
+                  "location": {
+                    "start": {"line": 2, "column": 13},
+                    "end": {"line": 2, "column": 29},
+                    "source": "set: \"airSensor\""
+                  },
+                  "properties": [
+                    {
+                      "type": "Property",
+                      "location": {
+                        "start": {"line": 2, "column": 13},
+                        "end": {"line": 2, "column": 29},
+                        "source": "set: \"airSensor\""
+                      },
+                      "key": {
+                        "type": "Identifier",
+                        "location": {
+                          "start": {"line": 2, "column": 13},
+                          "end": {"line": 2, "column": 16},
+                          "source": "set"
+                        },
+                        "name": "set"
+                      },
+                      "value": {
+                        "type": "StringLiteral",
+                        "location": {
+                          "start": {"line": 2, "column": 18},
+                          "end": {"line": 2, "column": 29},
+                          "source": "\"airSensor\""
+                        },
+                        "value": "airSensor"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "call": {
+              "location": {
+                "start": {"line": 3, "column": 8},
+                "end": {"line": 3, "column": 61},
+                "source": "range(start: v.timeRangeStart, stop: v.timeRangeStop)"
+              },
+              "callee": {
+                "type": "Identifier",
+                "location": {
+                  "start": {"line": 3, "column": 8},
+                  "end": {"line": 3, "column": 13},
+                  "source": "range"
+                },
+                "name": "range"
+              },
+              "arguments": [
+                {
+                  "type": "ObjectExpression",
+                  "location": {
+                    "start": {"line": 3, "column": 14},
+                    "end": {"line": 3, "column": 60},
+                    "source": "start: v.timeRangeStart, stop: v.timeRangeStop"
+                  },
+                  "properties": [
+                    {
+                      "type": "Property",
+                      "location": {
+                        "start": {"line": 3, "column": 14},
+                        "end": {"line": 3, "column": 37},
+                        "source": "start: v.timeRangeStart"
+                      },
+                      "key": {
+                        "type": "Identifier",
+                        "location": {
+                          "start": {"line": 3, "column": 14},
+                          "end": {"line": 3, "column": 19},
+                          "source": "start"
+                        },
+                        "name": "start"
+                      },
+                      "value": {
+                        "type": "MemberExpression",
+                        "location": {
+                          "start": {"line": 3, "column": 21},
+                          "end": {"line": 3, "column": 37},
+                          "source": "v.timeRangeStart"
+                        },
+                        "object": {
+                          "type": "Identifier",
+                          "location": {
+                            "start": {"line": 3, "column": 21},
+                            "end": {"line": 3, "column": 22},
+                            "source": "v"
+                          },
+                          "name": "v"
+                        },
+                        "property": {
+                          "type": "Identifier",
+                          "location": {
+                            "start": {"line": 3, "column": 23},
+                            "end": {"line": 3, "column": 37},
+                            "source": "timeRangeStart"
+                          },
+                          "name": "timeRangeStart"
+                        }
+                      }
+                    },
+                    {
+                      "type": "Property",
+                      "location": {
+                        "start": {"line": 3, "column": 39},
+                        "end": {"line": 3, "column": 60},
+                        "source": "stop: v.timeRangeStop"
+                      },
+                      "key": {
+                        "type": "Identifier",
+                        "location": {
+                          "start": {"line": 3, "column": 39},
+                          "end": {"line": 3, "column": 43},
+                          "source": "stop"
+                        },
+                        "name": "stop"
+                      },
+                      "value": {
+                        "type": "MemberExpression",
+                        "location": {
+                          "start": {"line": 3, "column": 45},
+                          "end": {"line": 3, "column": 60},
+                          "source": "v.timeRangeStop"
+                        },
+                        "object": {
+                          "type": "Identifier",
+                          "location": {
+                            "start": {"line": 3, "column": 45},
+                            "end": {"line": 3, "column": 46},
+                            "source": "v"
+                          },
+                          "name": "v"
+                        },
+                        "property": {
+                          "type": "Identifier",
+                          "location": {
+                            "start": {"line": 3, "column": 47},
+                            "end": {"line": 3, "column": 60},
+                            "source": "timeRangeStop"
+                          },
+                          "name": "timeRangeStop"
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "call": {
+            "location": {
+              "start": {"line": 4, "column": 8},
+              "end": {"line": 4, "column": 40},
+              "source": "yield(name: \"${v.windowPeriod}\")"
+            },
+            "callee": {
+              "type": "Identifier",
+              "location": {
+                "start": {"line": 4, "column": 8},
+                "end": {"line": 4, "column": 13},
+                "source": "yield"
+              },
+              "name": "yield"
+            },
+            "arguments": [
+              {
+                "type": "ObjectExpression",
+                "location": {
+                  "start": {"line": 4, "column": 14},
+                  "end": {"line": 4, "column": 39},
+                  "source": "name: \"${v.windowPeriod}\""
+                },
+                "properties": [
+                  {
+                    "type": "Property",
+                    "location": {
+                      "start": {"line": 4, "column": 14},
+                      "end": {"line": 4, "column": 39},
+                      "source": "name: \"${v.windowPeriod}\""
+                    },
+                    "key": {
+                      "type": "Identifier",
+                      "location": {
+                        "start": {"line": 4, "column": 14},
+                        "end": {"line": 4, "column": 18},
+                        "source": "name"
+                      },
+                      "name": "name"
+                    },
+                    "value": {
+                      "type": "StringExpression",
+                      "location": {
+                        "start": {"line": 4, "column": 20},
+                        "end": {"line": 4, "column": 39},
+                        "source": "\"${v.windowPeriod}\""
+                      },
+                      "parts": [
+                        {
+                          "type": "InterpolatedPart",
+                          "location": {
+                            "start": {"line": 4, "column": 21},
+                            "end": {"line": 4, "column": 38},
+                            "source": "${v.windowPeriod}"
+                          },
+                          "expression": {
+                            "type": "MemberExpression",
+                            "location": {
+                              "start": {"line": 4, "column": 23},
+                              "end": {"line": 4, "column": 37},
+                              "source": "v.windowPeriod"
+                            },
+                            "object": {
+                              "type": "Identifier",
+                              "location": {
+                                "start": {"line": 4, "column": 23},
+                                "end": {"line": 4, "column": 24},
+                                "source": "v"
+                              },
+                              "name": "v"
+                            },
+                            "property": {
+                              "type": "Identifier",
+                              "location": {
+                                "start": {"line": 4, "column": 25},
+                                "end": {"line": 4, "column": 37},
+                                "source": "windowPeriod"
+                              },
+                              "name": "windowPeriod"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "user_declared": {
+    "type": "File",
+    "location": {
+      "start": {"line": 1, "column": 1},
+      "end": {"line": 3, "column": 40},
+      "source": "import \"array\"\nv = {windowPeriod: 2444}\narray.from(rows: [{x: v.windowPeriod}])"
+    },
+    "metadata": "parser-type=rust",
+    "package": null,
+    "imports": [
+      {
+        "type": "ImportDeclaration",
+        "location": {
+          "start": {"line": 1, "column": 1},
+          "end": {"line": 1, "column": 15},
+          "source": "import \"array\""
+        },
+        "as": null,
+        "path": {
+          "location": {
+            "start": {"line": 1, "column": 8},
+            "end": {"line": 1, "column": 15},
+            "source": "\"array\""
+          },
+          "value": "array"
+        }
+      }
+    ],
+    "body": [
+      {
+        "type": "VariableAssignment",
+        "location": {
+          "start": {"line": 2, "column": 1},
+          "end": {"line": 2, "column": 25},
+          "source": "v = {windowPeriod: 2444}"
+        },
+        "id": {
+          "location": {
+            "start": {"line": 2, "column": 1},
+            "end": {"line": 2, "column": 2},
+            "source": "v"
+          },
+          "name": "v"
+        },
+        "init": {
+          "type": "ObjectExpression",
+          "location": {
+            "start": {"line": 2, "column": 5},
+            "end": {"line": 2, "column": 25},
+            "source": "{windowPeriod: 2444}"
+          },
+          "properties": [
+            {
+              "type": "Property",
+              "location": {
+                "start": {"line": 2, "column": 6},
+                "end": {"line": 2, "column": 24},
+                "source": "windowPeriod: 2444"
+              },
+              "key": {
+                "type": "Identifier",
+                "location": {
+                  "start": {"line": 2, "column": 6},
+                  "end": {"line": 2, "column": 18},
+                  "source": "windowPeriod"
+                },
+                "name": "windowPeriod"
+              },
+              "value": {
+                "type": "IntegerLiteral",
+                "location": {
+                  "start": {"line": 2, "column": 20},
+                  "end": {"line": 2, "column": 24},
+                  "source": "2444"
+                },
+                "value": "2444"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "type": "ExpressionStatement",
+        "location": {
+          "start": {"line": 3, "column": 1},
+          "end": {"line": 3, "column": 40},
+          "source": "array.from(rows: [{x: v.windowPeriod}])"
+        },
+        "expression": {
+          "type": "CallExpression",
+          "location": {
+            "start": {"line": 3, "column": 1},
+            "end": {"line": 3, "column": 40},
+            "source": "array.from(rows: [{x: v.windowPeriod}])"
+          },
+          "callee": {
+            "type": "MemberExpression",
+            "location": {
+              "start": {"line": 3, "column": 1},
+              "end": {"line": 3, "column": 11},
+              "source": "array.from"
+            },
+            "object": {
+              "type": "Identifier",
+              "location": {
+                "start": {"line": 3, "column": 1},
+                "end": {"line": 3, "column": 6},
+                "source": "array"
+              },
+              "name": "array"
+            },
+            "property": {
+              "type": "Identifier",
+              "location": {
+                "start": {"line": 3, "column": 7},
+                "end": {"line": 3, "column": 11},
+                "source": "from"
+              },
+              "name": "from"
+            }
+          },
+          "arguments": [
+            {
+              "type": "ObjectExpression",
+              "location": {
+                "start": {"line": 3, "column": 12},
+                "end": {"line": 3, "column": 39},
+                "source": "rows: [{x: v.windowPeriod}]"
+              },
+              "properties": [
+                {
+                  "type": "Property",
+                  "location": {
+                    "start": {"line": 3, "column": 12},
+                    "end": {"line": 3, "column": 39},
+                    "source": "rows: [{x: v.windowPeriod}]"
+                  },
+                  "key": {
+                    "type": "Identifier",
+                    "location": {
+                      "start": {"line": 3, "column": 12},
+                      "end": {"line": 3, "column": 16},
+                      "source": "rows"
+                    },
+                    "name": "rows"
+                  },
+                  "value": {
+                    "type": "ArrayExpression",
+                    "location": {
+                      "start": {"line": 3, "column": 18},
+                      "end": {"line": 3, "column": 39},
+                      "source": "[{x: v.windowPeriod}]"
+                    },
+                    "elements": [
+                      {
+                        "type": "ObjectExpression",
+                        "location": {
+                          "start": {"line": 3, "column": 19},
+                          "end": {"line": 3, "column": 38},
+                          "source": "{x: v.windowPeriod}"
+                        },
+                        "properties": [
+                          {
+                            "type": "Property",
+                            "location": {
+                              "start": {"line": 3, "column": 20},
+                              "end": {"line": 3, "column": 37},
+                              "source": "x: v.windowPeriod"
+                            },
+                            "key": {
+                              "type": "Identifier",
+                              "location": {
+                                "start": {"line": 3, "column": 20},
+                                "end": {"line": 3, "column": 21},
+                                "source": "x"
+                              },
+                              "name": "x"
+                            },
+                            "value": {
+                              "type": "MemberExpression",
+                              "location": {
+                                "start": {"line": 3, "column": 23},
+                                "end": {"line": 3, "column": 37},
+                                "source": "v.windowPeriod"
+                              },
+                              "object": {
+                                "type": "Identifier",
+                                "location": {
+                                  "start": {"line": 3, "column": 23},
+                                  "end": {"line": 3, "column": 24},
+                                  "source": "v"
+                                },
+                                "name": "v"
+                              },
+                              "property": {
+                                "type": "Identifier",
+                                "location": {
+                                  "start": {"line": 3, "column": 25},
+                                  "end": {"line": 3, "column": 37},
+                                  "source": "windowPeriod"
+                                },
+                                "name": "windowPeriod"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "user_declared_option": {
+    "type": "File",
+    "location": {
+      "start": {"line": 1, "column": 1},
+      "end": {"line": 3, "column": 40},
+      "source": "import \"array\"\noption v = {windowPeriod: 2444}\narray.from(rows: [{x: v.windowPeriod}])"
+    },
+    "metadata": "parser-type=rust",
+    "package": null,
+    "imports": [
+      {
+        "type": "ImportDeclaration",
+        "location": {
+          "start": {"line": 1, "column": 1},
+          "end": {"line": 1, "column": 15},
+          "source": "import \"array\""
+        },
+        "as": null,
+        "path": {
+          "location": {
+            "start": {"line": 1, "column": 8},
+            "end": {"line": 1, "column": 15},
+            "source": "\"array\""
+          },
+          "value": "array"
+        }
+      }
+    ],
+    "body": [
+      {
+        "type": "OptionStatement",
+        "location": {
+          "start": {"line": 2, "column": 1},
+          "end": {"line": 2, "column": 32},
+          "source": "option v = {windowPeriod: 2444}"
+        },
+        "assignment": {
+          "type": "VariableAssignment",
+          "location": {
+            "start": {"line": 2, "column": 8},
+            "end": {"line": 2, "column": 32},
+            "source": "v = {windowPeriod: 2444}"
+          },
+          "id": {
+            "location": {
+              "start": {"line": 2, "column": 8},
+              "end": {"line": 2, "column": 9},
+              "source": "v"
+            },
+            "name": "v"
+          },
+          "init": {
+            "type": "ObjectExpression",
+            "location": {
+              "start": {"line": 2, "column": 12},
+              "end": {"line": 2, "column": 32},
+              "source": "{windowPeriod: 2444}"
+            },
+            "properties": [
+              {
+                "type": "Property",
+                "location": {
+                  "start": {"line": 2, "column": 13},
+                  "end": {"line": 2, "column": 31},
+                  "source": "windowPeriod: 2444"
+                },
+                "key": {
+                  "type": "Identifier",
+                  "location": {
+                    "start": {"line": 2, "column": 13},
+                    "end": {"line": 2, "column": 25},
+                    "source": "windowPeriod"
+                  },
+                  "name": "windowPeriod"
+                },
+                "value": {
+                  "type": "IntegerLiteral",
+                  "location": {
+                    "start": {"line": 2, "column": 27},
+                    "end": {"line": 2, "column": 31},
+                    "source": "2444"
+                  },
+                  "value": "2444"
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "ExpressionStatement",
+        "location": {
+          "start": {"line": 3, "column": 1},
+          "end": {"line": 3, "column": 40},
+          "source": "array.from(rows: [{x: v.windowPeriod}])"
+        },
+        "expression": {
+          "type": "CallExpression",
+          "location": {
+            "start": {"line": 3, "column": 1},
+            "end": {"line": 3, "column": 40},
+            "source": "array.from(rows: [{x: v.windowPeriod}])"
+          },
+          "callee": {
+            "type": "MemberExpression",
+            "location": {
+              "start": {"line": 3, "column": 1},
+              "end": {"line": 3, "column": 11},
+              "source": "array.from"
+            },
+            "object": {
+              "type": "Identifier",
+              "location": {
+                "start": {"line": 3, "column": 1},
+                "end": {"line": 3, "column": 6},
+                "source": "array"
+              },
+              "name": "array"
+            },
+            "property": {
+              "type": "Identifier",
+              "location": {
+                "start": {"line": 3, "column": 7},
+                "end": {"line": 3, "column": 11},
+                "source": "from"
+              },
+              "name": "from"
+            }
+          },
+          "arguments": [
+            {
+              "type": "ObjectExpression",
+              "location": {
+                "start": {"line": 3, "column": 12},
+                "end": {"line": 3, "column": 39},
+                "source": "rows: [{x: v.windowPeriod}]"
+              },
+              "properties": [
+                {
+                  "type": "Property",
+                  "location": {
+                    "start": {"line": 3, "column": 12},
+                    "end": {"line": 3, "column": 39},
+                    "source": "rows: [{x: v.windowPeriod}]"
+                  },
+                  "key": {
+                    "type": "Identifier",
+                    "location": {
+                      "start": {"line": 3, "column": 12},
+                      "end": {"line": 3, "column": 16},
+                      "source": "rows"
+                    },
+                    "name": "rows"
+                  },
+                  "value": {
+                    "type": "ArrayExpression",
+                    "location": {
+                      "start": {"line": 3, "column": 18},
+                      "end": {"line": 3, "column": 39},
+                      "source": "[{x: v.windowPeriod}]"
+                    },
+                    "elements": [
+                      {
+                        "type": "ObjectExpression",
+                        "location": {
+                          "start": {"line": 3, "column": 19},
+                          "end": {"line": 3, "column": 38},
+                          "source": "{x: v.windowPeriod}"
+                        },
+                        "properties": [
+                          {
+                            "type": "Property",
+                            "location": {
+                              "start": {"line": 3, "column": 20},
+                              "end": {"line": 3, "column": 37},
+                              "source": "x: v.windowPeriod"
+                            },
+                            "key": {
+                              "type": "Identifier",
+                              "location": {
+                                "start": {"line": 3, "column": 20},
+                                "end": {"line": 3, "column": 21},
+                                "source": "x"
+                              },
+                              "name": "x"
+                            },
+                            "value": {
+                              "type": "MemberExpression",
+                              "location": {
+                                "start": {"line": 3, "column": 23},
+                                "end": {"line": 3, "column": 37},
+                                "source": "v.windowPeriod"
+                              },
+                              "object": {
+                                "type": "Identifier",
+                                "location": {
+                                  "start": {"line": 3, "column": 23},
+                                  "end": {"line": 3, "column": 24},
+                                  "source": "v"
+                                },
+                                "name": "v"
+                              },
+                              "property": {
+                                "type": "Identifier",
+                                "location": {
+                                  "start": {"line": 3, "column": 25},
+                                  "end": {"line": 3, "column": 37},
+                                  "source": "windowPeriod"
+                                },
+                                "name": "windowPeriod"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "fallback": {
+    "type": "File",
+    "location": {
+      "start": {"line": 1, "column": 1},
+      "end": {"line": 3, "column": 40},
+      "source": "import \"array\"\nv = {windowPeriod: 'gerbils'}\narray.from(rows: [{x: v.windowPeriod}])"
+    },
+    "metadata": "parser-type=rust",
+    "package": null,
+    "imports": [
+      {
+        "type": "ImportDeclaration",
+        "location": {
+          "start": {"line": 1, "column": 1},
+          "end": {"line": 1, "column": 15},
+          "source": "import \"array\""
+        },
+        "as": null,
+        "path": {
+          "location": {
+            "start": {"line": 1, "column": 8},
+            "end": {"line": 1, "column": 15},
+            "source": "\"array\""
+          },
+          "value": "array"
+        }
+      }
+    ],
+    "body": [
+      {
+        "type": "VariableAssignment",
+        "location": {
+          "start": {"line": 2, "column": 1},
+          "end": {"line": 2, "column": 30},
+          "source": "v = {windowPeriod: 'gerbils'}"
+        },
+        "id": {
+          "location": {
+            "start": {"line": 2, "column": 1},
+            "end": {"line": 2, "column": 2},
+            "source": "v"
+          },
+          "name": "v"
+        },
+        "init": {
+          "type": "ObjectExpression",
+          "location": {
+            "start": {"line": 2, "column": 5},
+            "end": {"line": 2, "column": 30},
+            "source": "{windowPeriod: 'gerbils'}"
+          },
+          "properties": [
+            {
+              "type": "Property",
+              "location": {
+                "start": {"line": 2, "column": 6},
+                "end": {"line": 2, "column": 28},
+                "source": "windowPeriod: 'gerbils"
+              },
+              "errors": [{"msg": "invalid expression @2:28-2:29: '"}],
+              "key": {
+                "type": "Identifier",
+                "location": {
+                  "start": {"line": 2, "column": 6},
+                  "end": {"line": 2, "column": 18},
+                  "source": "windowPeriod"
+                },
+                "name": "windowPeriod"
+              },
+              "value": {
+                "type": "Identifier",
+                "location": {
+                  "start": {"line": 2, "column": 21},
+                  "end": {"line": 2, "column": 28},
+                  "source": "gerbils"
+                },
+                "errors": [{"msg": "invalid expression @2:20-2:21: '"}],
+                "name": "gerbils"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "type": "ExpressionStatement",
+        "location": {
+          "start": {"line": 3, "column": 1},
+          "end": {"line": 3, "column": 40},
+          "source": "array.from(rows: [{x: v.windowPeriod}])"
+        },
+        "expression": {
+          "type": "CallExpression",
+          "location": {
+            "start": {"line": 3, "column": 1},
+            "end": {"line": 3, "column": 40},
+            "source": "array.from(rows: [{x: v.windowPeriod}])"
+          },
+          "callee": {
+            "type": "MemberExpression",
+            "location": {
+              "start": {"line": 3, "column": 1},
+              "end": {"line": 3, "column": 11},
+              "source": "array.from"
+            },
+            "object": {
+              "type": "Identifier",
+              "location": {
+                "start": {"line": 3, "column": 1},
+                "end": {"line": 3, "column": 6},
+                "source": "array"
+              },
+              "name": "array"
+            },
+            "property": {
+              "type": "Identifier",
+              "location": {
+                "start": {"line": 3, "column": 7},
+                "end": {"line": 3, "column": 11},
+                "source": "from"
+              },
+              "name": "from"
+            }
+          },
+          "arguments": [
+            {
+              "type": "ObjectExpression",
+              "location": {
+                "start": {"line": 3, "column": 12},
+                "end": {"line": 3, "column": 39},
+                "source": "rows: [{x: v.windowPeriod}]"
+              },
+              "properties": [
+                {
+                  "type": "Property",
+                  "location": {
+                    "start": {"line": 3, "column": 12},
+                    "end": {"line": 3, "column": 39},
+                    "source": "rows: [{x: v.windowPeriod}]"
+                  },
+                  "key": {
+                    "type": "Identifier",
+                    "location": {
+                      "start": {"line": 3, "column": 12},
+                      "end": {"line": 3, "column": 16},
+                      "source": "rows"
+                    },
+                    "name": "rows"
+                  },
+                  "value": {
+                    "type": "ArrayExpression",
+                    "location": {
+                      "start": {"line": 3, "column": 18},
+                      "end": {"line": 3, "column": 39},
+                      "source": "[{x: v.windowPeriod}]"
+                    },
+                    "elements": [
+                      {
+                        "type": "ObjectExpression",
+                        "location": {
+                          "start": {"line": 3, "column": 19},
+                          "end": {"line": 3, "column": 38},
+                          "source": "{x: v.windowPeriod}"
+                        },
+                        "properties": [
+                          {
+                            "type": "Property",
+                            "location": {
+                              "start": {"line": 3, "column": 20},
+                              "end": {"line": 3, "column": 37},
+                              "source": "x: v.windowPeriod"
+                            },
+                            "key": {
+                              "type": "Identifier",
+                              "location": {
+                                "start": {"line": 3, "column": 20},
+                                "end": {"line": 3, "column": 21},
+                                "source": "x"
+                              },
+                              "name": "x"
+                            },
+                            "value": {
+                              "type": "MemberExpression",
+                              "location": {
+                                "start": {"line": 3, "column": 23},
+                                "end": {"line": 3, "column": 37},
+                                "source": "v.windowPeriod"
+                              },
+                              "object": {
+                                "type": "Identifier",
+                                "location": {
+                                  "start": {"line": 3, "column": 23},
+                                  "end": {"line": 3, "column": 24},
+                                  "source": "v"
+                                },
+                                "name": "v"
+                              },
+                              "property": {
+                                "type": "Identifier",
+                                "location": {
+                                  "start": {"line": 3, "column": 25},
+                                  "end": {"line": 3, "column": 37},
+                                  "source": "windowPeriod"
+                                },
+                                "name": "windowPeriod"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "UI_scope": {
+    "type": "File",
+    "location": {
+      "start": {"line": 1, "column": 1},
+      "end": {"line": 2, "column": 40},
+      "source": "import \"array\"\narray.from(rows: [{x: v.windowPeriod}])"
+    },
+    "metadata": "parser-type=rust",
+    "package": null,
+    "imports": [
+      {
+        "type": "ImportDeclaration",
+        "location": {
+          "start": {"line": 1, "column": 1},
+          "end": {"line": 1, "column": 15},
+          "source": "import \"array\""
+        },
+        "as": null,
+        "path": {
+          "location": {
+            "start": {"line": 1, "column": 8},
+            "end": {"line": 1, "column": 15},
+            "source": "\"array\""
+          },
+          "value": "array"
+        }
+      }
+    ],
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "location": {
+          "start": {"line": 2, "column": 1},
+          "end": {"line": 2, "column": 40},
+          "source": "array.from(rows: [{x: v.windowPeriod}])"
+        },
+        "expression": {
+          "type": "CallExpression",
+          "location": {
+            "start": {"line": 2, "column": 1},
+            "end": {"line": 2, "column": 40},
+            "source": "array.from(rows: [{x: v.windowPeriod}])"
+          },
+          "callee": {
+            "type": "MemberExpression",
+            "location": {
+              "start": {"line": 2, "column": 1},
+              "end": {"line": 2, "column": 11},
+              "source": "array.from"
+            },
+            "object": {
+              "type": "Identifier",
+              "location": {
+                "start": {"line": 2, "column": 1},
+                "end": {"line": 2, "column": 6},
+                "source": "array"
+              },
+              "name": "array"
+            },
+            "property": {
+              "type": "Identifier",
+              "location": {
+                "start": {"line": 2, "column": 7},
+                "end": {"line": 2, "column": 11},
+                "source": "from"
+              },
+              "name": "from"
+            }
+          },
+          "arguments": [
+            {
+              "type": "ObjectExpression",
+              "location": {
+                "start": {"line": 2, "column": 12},
+                "end": {"line": 2, "column": 39},
+                "source": "rows: [{x: v.windowPeriod}]"
+              },
+              "properties": [
+                {
+                  "type": "Property",
+                  "location": {
+                    "start": {"line": 2, "column": 12},
+                    "end": {"line": 2, "column": 39},
+                    "source": "rows: [{x: v.windowPeriod}]"
+                  },
+                  "key": {
+                    "type": "Identifier",
+                    "location": {
+                      "start": {"line": 2, "column": 12},
+                      "end": {"line": 2, "column": 16},
+                      "source": "rows"
+                    },
+                    "name": "rows"
+                  },
+                  "value": {
+                    "type": "ArrayExpression",
+                    "location": {
+                      "start": {"line": 2, "column": 18},
+                      "end": {"line": 2, "column": 39},
+                      "source": "[{x: v.windowPeriod}]"
+                    },
+                    "elements": [
+                      {
+                        "type": "ObjectExpression",
+                        "location": {
+                          "start": {"line": 2, "column": 19},
+                          "end": {"line": 2, "column": 38},
+                          "source": "{x: v.windowPeriod}"
+                        },
+                        "properties": [
+                          {
+                            "type": "Property",
+                            "location": {
+                              "start": {"line": 2, "column": 20},
+                              "end": {"line": 2, "column": 37},
+                              "source": "x: v.windowPeriod"
+                            },
+                            "key": {
+                              "type": "Identifier",
+                              "location": {
+                                "start": {"line": 2, "column": 20},
+                                "end": {"line": 2, "column": 21},
+                                "source": "x"
+                              },
+                              "name": "x"
+                            },
+                            "value": {
+                              "type": "MemberExpression",
+                              "location": {
+                                "start": {"line": 2, "column": 23},
+                                "end": {"line": 2, "column": 37},
+                                "source": "v.windowPeriod"
+                              },
+                              "object": {
+                                "type": "Identifier",
+                                "location": {
+                                  "start": {"line": 2, "column": 23},
+                                  "end": {"line": 2, "column": 24},
+                                  "source": "v"
+                                },
+                                "name": "v"
+                              },
+                              "property": {
+                                "type": "Identifier",
+                                "location": {
+                                  "start": {"line": 2, "column": 25},
+                                  "end": {"line": 2, "column": 37},
+                                  "source": "windowPeriod"
+                                },
+                                "name": "windowPeriod"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "UI_scope_range": {
+    "type": "File",
+    "location": {
+      "start": {"line": 1, "column": 1},
+      "end": {"line": 4, "column": 40},
+      "source": "import \"influxdata/influxdb/sample\"\nsample.data(set: \"airSensor\")\n    |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n    |> yield(name: \"${v.windowPeriod}\")"
+    },
+    "metadata": "parser-type=rust",
+    "package": null,
+    "imports": [
+      {
+        "type": "ImportDeclaration",
+        "location": {
+          "start": {"line": 1, "column": 1},
+          "end": {"line": 1, "column": 36},
+          "source": "import \"influxdata/influxdb/sample\""
+        },
+        "as": null,
+        "path": {
+          "location": {
+            "start": {"line": 1, "column": 8},
+            "end": {"line": 1, "column": 36},
+            "source": "\"influxdata/influxdb/sample\""
+          },
+          "value": "influxdata/influxdb/sample"
+        }
+      }
+    ],
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "location": {
+          "start": {"line": 2, "column": 1},
+          "end": {"line": 4, "column": 40},
+          "source": "sample.data(set: \"airSensor\")\n    |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n    |> yield(name: \"${v.windowPeriod}\")"
+        },
+        "expression": {
+          "type": "PipeExpression",
+          "location": {
+            "start": {"line": 2, "column": 1},
+            "end": {"line": 4, "column": 40},
+            "source": "sample.data(set: \"airSensor\")\n    |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n    |> yield(name: \"${v.windowPeriod}\")"
+          },
+          "argument": {
+            "type": "PipeExpression",
+            "location": {
+              "start": {"line": 2, "column": 1},
+              "end": {"line": 3, "column": 61},
+              "source": "sample.data(set: \"airSensor\")\n    |> range(start: v.timeRangeStart, stop: v.timeRangeStop)"
+            },
+            "argument": {
+              "type": "CallExpression",
+              "location": {
+                "start": {"line": 2, "column": 1},
+                "end": {"line": 2, "column": 30},
+                "source": "sample.data(set: \"airSensor\")"
+              },
+              "callee": {
+                "type": "MemberExpression",
+                "location": {
+                  "start": {"line": 2, "column": 1},
+                  "end": {"line": 2, "column": 12},
+                  "source": "sample.data"
+                },
+                "object": {
+                  "type": "Identifier",
+                  "location": {
+                    "start": {"line": 2, "column": 1},
+                    "end": {"line": 2, "column": 7},
+                    "source": "sample"
+                  },
+                  "name": "sample"
+                },
+                "property": {
+                  "type": "Identifier",
+                  "location": {
+                    "start": {"line": 2, "column": 8},
+                    "end": {"line": 2, "column": 12},
+                    "source": "data"
+                  },
+                  "name": "data"
+                }
+              },
+              "arguments": [
+                {
+                  "type": "ObjectExpression",
+                  "location": {
+                    "start": {"line": 2, "column": 13},
+                    "end": {"line": 2, "column": 29},
+                    "source": "set: \"airSensor\""
+                  },
+                  "properties": [
+                    {
+                      "type": "Property",
+                      "location": {
+                        "start": {"line": 2, "column": 13},
+                        "end": {"line": 2, "column": 29},
+                        "source": "set: \"airSensor\""
+                      },
+                      "key": {
+                        "type": "Identifier",
+                        "location": {
+                          "start": {"line": 2, "column": 13},
+                          "end": {"line": 2, "column": 16},
+                          "source": "set"
+                        },
+                        "name": "set"
+                      },
+                      "value": {
+                        "type": "StringLiteral",
+                        "location": {
+                          "start": {"line": 2, "column": 18},
+                          "end": {"line": 2, "column": 29},
+                          "source": "\"airSensor\""
+                        },
+                        "value": "airSensor"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "call": {
+              "location": {
+                "start": {"line": 3, "column": 8},
+                "end": {"line": 3, "column": 61},
+                "source": "range(start: v.timeRangeStart, stop: v.timeRangeStop)"
+              },
+              "callee": {
+                "type": "Identifier",
+                "location": {
+                  "start": {"line": 3, "column": 8},
+                  "end": {"line": 3, "column": 13},
+                  "source": "range"
+                },
+                "name": "range"
+              },
+              "arguments": [
+                {
+                  "type": "ObjectExpression",
+                  "location": {
+                    "start": {"line": 3, "column": 14},
+                    "end": {"line": 3, "column": 60},
+                    "source": "start: v.timeRangeStart, stop: v.timeRangeStop"
+                  },
+                  "properties": [
+                    {
+                      "type": "Property",
+                      "location": {
+                        "start": {"line": 3, "column": 14},
+                        "end": {"line": 3, "column": 37},
+                        "source": "start: v.timeRangeStart"
+                      },
+                      "key": {
+                        "type": "Identifier",
+                        "location": {
+                          "start": {"line": 3, "column": 14},
+                          "end": {"line": 3, "column": 19},
+                          "source": "start"
+                        },
+                        "name": "start"
+                      },
+                      "value": {
+                        "type": "MemberExpression",
+                        "location": {
+                          "start": {"line": 3, "column": 21},
+                          "end": {"line": 3, "column": 37},
+                          "source": "v.timeRangeStart"
+                        },
+                        "object": {
+                          "type": "Identifier",
+                          "location": {
+                            "start": {"line": 3, "column": 21},
+                            "end": {"line": 3, "column": 22},
+                            "source": "v"
+                          },
+                          "name": "v"
+                        },
+                        "property": {
+                          "type": "Identifier",
+                          "location": {
+                            "start": {"line": 3, "column": 23},
+                            "end": {"line": 3, "column": 37},
+                            "source": "timeRangeStart"
+                          },
+                          "name": "timeRangeStart"
+                        }
+                      }
+                    },
+                    {
+                      "type": "Property",
+                      "location": {
+                        "start": {"line": 3, "column": 39},
+                        "end": {"line": 3, "column": 60},
+                        "source": "stop: v.timeRangeStop"
+                      },
+                      "key": {
+                        "type": "Identifier",
+                        "location": {
+                          "start": {"line": 3, "column": 39},
+                          "end": {"line": 3, "column": 43},
+                          "source": "stop"
+                        },
+                        "name": "stop"
+                      },
+                      "value": {
+                        "type": "MemberExpression",
+                        "location": {
+                          "start": {"line": 3, "column": 45},
+                          "end": {"line": 3, "column": 60},
+                          "source": "v.timeRangeStop"
+                        },
+                        "object": {
+                          "type": "Identifier",
+                          "location": {
+                            "start": {"line": 3, "column": 45},
+                            "end": {"line": 3, "column": 46},
+                            "source": "v"
+                          },
+                          "name": "v"
+                        },
+                        "property": {
+                          "type": "Identifier",
+                          "location": {
+                            "start": {"line": 3, "column": 47},
+                            "end": {"line": 3, "column": 60},
+                            "source": "timeRangeStop"
+                          },
+                          "name": "timeRangeStop"
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "call": {
+            "location": {
+              "start": {"line": 4, "column": 8},
+              "end": {"line": 4, "column": 40},
+              "source": "yield(name: \"${v.windowPeriod}\")"
+            },
+            "callee": {
+              "type": "Identifier",
+              "location": {
+                "start": {"line": 4, "column": 8},
+                "end": {"line": 4, "column": 13},
+                "source": "yield"
+              },
+              "name": "yield"
+            },
+            "arguments": [
+              {
+                "type": "ObjectExpression",
+                "location": {
+                  "start": {"line": 4, "column": 14},
+                  "end": {"line": 4, "column": 39},
+                  "source": "name: \"${v.windowPeriod}\""
+                },
+                "properties": [
+                  {
+                    "type": "Property",
+                    "location": {
+                      "start": {"line": 4, "column": 14},
+                      "end": {"line": 4, "column": 39},
+                      "source": "name: \"${v.windowPeriod}\""
+                    },
+                    "key": {
+                      "type": "Identifier",
+                      "location": {
+                        "start": {"line": 4, "column": 14},
+                        "end": {"line": 4, "column": 18},
+                        "source": "name"
+                      },
+                      "name": "name"
+                    },
+                    "value": {
+                      "type": "StringExpression",
+                      "location": {
+                        "start": {"line": 4, "column": 20},
+                        "end": {"line": 4, "column": 39},
+                        "source": "\"${v.windowPeriod}\""
+                      },
+                      "parts": [
+                        {
+                          "type": "InterpolatedPart",
+                          "location": {
+                            "start": {"line": 4, "column": 21},
+                            "end": {"line": 4, "column": 38},
+                            "source": "${v.windowPeriod}"
+                          },
+                          "expression": {
+                            "type": "MemberExpression",
+                            "location": {
+                              "start": {"line": 4, "column": 23},
+                              "end": {"line": 4, "column": 37},
+                              "source": "v.windowPeriod"
+                            },
+                            "object": {
+                              "type": "Identifier",
+                              "location": {
+                                "start": {"line": 4, "column": 23},
+                                "end": {"line": 4, "column": 24},
+                                "source": "v"
+                              },
+                              "name": "v"
+                            },
+                            "property": {
+                              "type": "Identifier",
+                              "location": {
+                                "start": {"line": 4, "column": 25},
+                                "end": {"line": 4, "column": 37},
+                                "source": "windowPeriod"
+                              },
+                              "name": "windowPeriod"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "query_scope_range": {
+    "type": "File",
+    "location": {
+      "start": {"line": 1, "column": 1},
+      "end": {"line": 4, "column": 40},
+      "source": "import \"influxdata/influxdb/sample\"\nsample.data(set: \"airSensor\")\n    |> range(start: -12h, stop: now())\n    |> yield(name: \"${v.windowPeriod}\")"
+    },
+    "metadata": "parser-type=rust",
+    "package": null,
+    "imports": [
+      {
+        "type": "ImportDeclaration",
+        "location": {
+          "start": {"line": 1, "column": 1},
+          "end": {"line": 1, "column": 36},
+          "source": "import \"influxdata/influxdb/sample\""
+        },
+        "as": null,
+        "path": {
+          "location": {
+            "start": {"line": 1, "column": 8},
+            "end": {"line": 1, "column": 36},
+            "source": "\"influxdata/influxdb/sample\""
+          },
+          "value": "influxdata/influxdb/sample"
+        }
+      }
+    ],
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "location": {
+          "start": {"line": 2, "column": 1},
+          "end": {"line": 4, "column": 40},
+          "source": "sample.data(set: \"airSensor\")\n    |> range(start: -12h, stop: now())\n    |> yield(name: \"${v.windowPeriod}\")"
+        },
+        "expression": {
+          "type": "PipeExpression",
+          "location": {
+            "start": {"line": 2, "column": 1},
+            "end": {"line": 4, "column": 40},
+            "source": "sample.data(set: \"airSensor\")\n    |> range(start: -12h, stop: now())\n    |> yield(name: \"${v.windowPeriod}\")"
+          },
+          "argument": {
+            "type": "PipeExpression",
+            "location": {
+              "start": {"line": 2, "column": 1},
+              "end": {"line": 3, "column": 39},
+              "source": "sample.data(set: \"airSensor\")\n    |> range(start: -12h, stop: now())"
+            },
+            "argument": {
+              "type": "CallExpression",
+              "location": {
+                "start": {"line": 2, "column": 1},
+                "end": {"line": 2, "column": 30},
+                "source": "sample.data(set: \"airSensor\")"
+              },
+              "callee": {
+                "type": "MemberExpression",
+                "location": {
+                  "start": {"line": 2, "column": 1},
+                  "end": {"line": 2, "column": 12},
+                  "source": "sample.data"
+                },
+                "object": {
+                  "type": "Identifier",
+                  "location": {
+                    "start": {"line": 2, "column": 1},
+                    "end": {"line": 2, "column": 7},
+                    "source": "sample"
+                  },
+                  "name": "sample"
+                },
+                "property": {
+                  "type": "Identifier",
+                  "location": {
+                    "start": {"line": 2, "column": 8},
+                    "end": {"line": 2, "column": 12},
+                    "source": "data"
+                  },
+                  "name": "data"
+                }
+              },
+              "arguments": [
+                {
+                  "type": "ObjectExpression",
+                  "location": {
+                    "start": {"line": 2, "column": 13},
+                    "end": {"line": 2, "column": 29},
+                    "source": "set: \"airSensor\""
+                  },
+                  "properties": [
+                    {
+                      "type": "Property",
+                      "location": {
+                        "start": {"line": 2, "column": 13},
+                        "end": {"line": 2, "column": 29},
+                        "source": "set: \"airSensor\""
+                      },
+                      "key": {
+                        "type": "Identifier",
+                        "location": {
+                          "start": {"line": 2, "column": 13},
+                          "end": {"line": 2, "column": 16},
+                          "source": "set"
+                        },
+                        "name": "set"
+                      },
+                      "value": {
+                        "type": "StringLiteral",
+                        "location": {
+                          "start": {"line": 2, "column": 18},
+                          "end": {"line": 2, "column": 29},
+                          "source": "\"airSensor\""
+                        },
+                        "value": "airSensor"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "call": {
+              "location": {
+                "start": {"line": 3, "column": 8},
+                "end": {"line": 3, "column": 39},
+                "source": "range(start: -12h, stop: now())"
+              },
+              "callee": {
+                "type": "Identifier",
+                "location": {
+                  "start": {"line": 3, "column": 8},
+                  "end": {"line": 3, "column": 13},
+                  "source": "range"
+                },
+                "name": "range"
+              },
+              "arguments": [
+                {
+                  "type": "ObjectExpression",
+                  "location": {
+                    "start": {"line": 3, "column": 14},
+                    "end": {"line": 3, "column": 38},
+                    "source": "start: -12h, stop: now()"
+                  },
+                  "properties": [
+                    {
+                      "type": "Property",
+                      "location": {
+                        "start": {"line": 3, "column": 14},
+                        "end": {"line": 3, "column": 25},
+                        "source": "start: -12h"
+                      },
+                      "key": {
+                        "type": "Identifier",
+                        "location": {
+                          "start": {"line": 3, "column": 14},
+                          "end": {"line": 3, "column": 19},
+                          "source": "start"
+                        },
+                        "name": "start"
+                      },
+                      "value": {
+                        "type": "UnaryExpression",
+                        "location": {
+                          "start": {"line": 3, "column": 21},
+                          "end": {"line": 3, "column": 25},
+                          "source": "-12h"
+                        },
+                        "operator": "-",
+                        "argument": {
+                          "type": "DurationLiteral",
+                          "location": {
+                            "start": {"line": 3, "column": 22},
+                            "end": {"line": 3, "column": 25},
+                            "source": "12h"
+                          },
+                          "values": [{"magnitude": 12, "unit": "h"}]
+                        }
+                      }
+                    },
+                    {
+                      "type": "Property",
+                      "location": {
+                        "start": {"line": 3, "column": 27},
+                        "end": {"line": 3, "column": 38},
+                        "source": "stop: now()"
+                      },
+                      "key": {
+                        "type": "Identifier",
+                        "location": {
+                          "start": {"line": 3, "column": 27},
+                          "end": {"line": 3, "column": 31},
+                          "source": "stop"
+                        },
+                        "name": "stop"
+                      },
+                      "value": {
+                        "type": "CallExpression",
+                        "location": {
+                          "start": {"line": 3, "column": 33},
+                          "end": {"line": 3, "column": 38},
+                          "source": "now()"
+                        },
+                        "callee": {
+                          "type": "Identifier",
+                          "location": {
+                            "start": {"line": 3, "column": 33},
+                            "end": {"line": 3, "column": 36},
+                            "source": "now"
+                          },
+                          "name": "now"
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "call": {
+            "location": {
+              "start": {"line": 4, "column": 8},
+              "end": {"line": 4, "column": 40},
+              "source": "yield(name: \"${v.windowPeriod}\")"
+            },
+            "callee": {
+              "type": "Identifier",
+              "location": {
+                "start": {"line": 4, "column": 8},
+                "end": {"line": 4, "column": 13},
+                "source": "yield"
+              },
+              "name": "yield"
+            },
+            "arguments": [
+              {
+                "type": "ObjectExpression",
+                "location": {
+                  "start": {"line": 4, "column": 14},
+                  "end": {"line": 4, "column": 39},
+                  "source": "name: \"${v.windowPeriod}\""
+                },
+                "properties": [
+                  {
+                    "type": "Property",
+                    "location": {
+                      "start": {"line": 4, "column": 14},
+                      "end": {"line": 4, "column": 39},
+                      "source": "name: \"${v.windowPeriod}\""
+                    },
+                    "key": {
+                      "type": "Identifier",
+                      "location": {
+                        "start": {"line": 4, "column": 14},
+                        "end": {"line": 4, "column": 18},
+                        "source": "name"
+                      },
+                      "name": "name"
+                    },
+                    "value": {
+                      "type": "StringExpression",
+                      "location": {
+                        "start": {"line": 4, "column": 20},
+                        "end": {"line": 4, "column": 39},
+                        "source": "\"${v.windowPeriod}\""
+                      },
+                      "parts": [
+                        {
+                          "type": "InterpolatedPart",
+                          "location": {
+                            "start": {"line": 4, "column": 21},
+                            "end": {"line": 4, "column": 38},
+                            "source": "${v.windowPeriod}"
+                          },
+                          "expression": {
+                            "type": "MemberExpression",
+                            "location": {
+                              "start": {"line": 4, "column": 23},
+                              "end": {"line": 4, "column": 37},
+                              "source": "v.windowPeriod"
+                            },
+                            "object": {
+                              "type": "Identifier",
+                              "location": {
+                                "start": {"line": 4, "column": 23},
+                                "end": {"line": 4, "column": 24},
+                                "source": "v"
+                              },
+                              "name": "v"
+                            },
+                            "property": {
+                              "type": "Identifier",
+                              "location": {
+                                "start": {"line": 4, "column": 25},
+                                "end": {"line": 4, "column": 37},
+                                "source": "windowPeriod"
+                              },
+                              "name": "windowPeriod"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "inner_query_scope": {
+    "type": "File",
+    "location": {
+      "start": {"line": 1, "column": 1},
+      "end": {"line": 7, "column": 7},
+      "source": "import \"influxdata/influxdb/sample\"\nsample.data(set: \"airSensor\")\n    |> range(start: -12h, stop: now())\n    |> map(fn: (r) => {\n        v = {windowPeriod: 2444}\n        return ({ r with _value: v.windowPeriod })\n    })"
+    },
+    "metadata": "parser-type=rust",
+    "package": null,
+    "imports": [
+      {
+        "type": "ImportDeclaration",
+        "location": {
+          "start": {"line": 1, "column": 1},
+          "end": {"line": 1, "column": 36},
+          "source": "import \"influxdata/influxdb/sample\""
+        },
+        "as": null,
+        "path": {
+          "location": {
+            "start": {"line": 1, "column": 8},
+            "end": {"line": 1, "column": 36},
+            "source": "\"influxdata/influxdb/sample\""
+          },
+          "value": "influxdata/influxdb/sample"
+        }
+      }
+    ],
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "location": {
+          "start": {"line": 2, "column": 1},
+          "end": {"line": 7, "column": 7},
+          "source": "sample.data(set: \"airSensor\")\n    |> range(start: -12h, stop: now())\n    |> map(fn: (r) => {\n        v = {windowPeriod: 2444}\n        return ({ r with _value: v.windowPeriod })\n    })"
+        },
+        "expression": {
+          "type": "PipeExpression",
+          "location": {
+            "start": {"line": 2, "column": 1},
+            "end": {"line": 7, "column": 7},
+            "source": "sample.data(set: \"airSensor\")\n    |> range(start: -12h, stop: now())\n    |> map(fn: (r) => {\n        v = {windowPeriod: 2444}\n        return ({ r with _value: v.windowPeriod })\n    })"
+          },
+          "argument": {
+            "type": "PipeExpression",
+            "location": {
+              "start": {"line": 2, "column": 1},
+              "end": {"line": 3, "column": 39},
+              "source": "sample.data(set: \"airSensor\")\n    |> range(start: -12h, stop: now())"
+            },
+            "argument": {
+              "type": "CallExpression",
+              "location": {
+                "start": {"line": 2, "column": 1},
+                "end": {"line": 2, "column": 30},
+                "source": "sample.data(set: \"airSensor\")"
+              },
+              "callee": {
+                "type": "MemberExpression",
+                "location": {
+                  "start": {"line": 2, "column": 1},
+                  "end": {"line": 2, "column": 12},
+                  "source": "sample.data"
+                },
+                "object": {
+                  "type": "Identifier",
+                  "location": {
+                    "start": {"line": 2, "column": 1},
+                    "end": {"line": 2, "column": 7},
+                    "source": "sample"
+                  },
+                  "name": "sample"
+                },
+                "property": {
+                  "type": "Identifier",
+                  "location": {
+                    "start": {"line": 2, "column": 8},
+                    "end": {"line": 2, "column": 12},
+                    "source": "data"
+                  },
+                  "name": "data"
+                }
+              },
+              "arguments": [
+                {
+                  "type": "ObjectExpression",
+                  "location": {
+                    "start": {"line": 2, "column": 13},
+                    "end": {"line": 2, "column": 29},
+                    "source": "set: \"airSensor\""
+                  },
+                  "properties": [
+                    {
+                      "type": "Property",
+                      "location": {
+                        "start": {"line": 2, "column": 13},
+                        "end": {"line": 2, "column": 29},
+                        "source": "set: \"airSensor\""
+                      },
+                      "key": {
+                        "type": "Identifier",
+                        "location": {
+                          "start": {"line": 2, "column": 13},
+                          "end": {"line": 2, "column": 16},
+                          "source": "set"
+                        },
+                        "name": "set"
+                      },
+                      "value": {
+                        "type": "StringLiteral",
+                        "location": {
+                          "start": {"line": 2, "column": 18},
+                          "end": {"line": 2, "column": 29},
+                          "source": "\"airSensor\""
+                        },
+                        "value": "airSensor"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "call": {
+              "location": {
+                "start": {"line": 3, "column": 8},
+                "end": {"line": 3, "column": 39},
+                "source": "range(start: -12h, stop: now())"
+              },
+              "callee": {
+                "type": "Identifier",
+                "location": {
+                  "start": {"line": 3, "column": 8},
+                  "end": {"line": 3, "column": 13},
+                  "source": "range"
+                },
+                "name": "range"
+              },
+              "arguments": [
+                {
+                  "type": "ObjectExpression",
+                  "location": {
+                    "start": {"line": 3, "column": 14},
+                    "end": {"line": 3, "column": 38},
+                    "source": "start: -12h, stop: now()"
+                  },
+                  "properties": [
+                    {
+                      "type": "Property",
+                      "location": {
+                        "start": {"line": 3, "column": 14},
+                        "end": {"line": 3, "column": 25},
+                        "source": "start: -12h"
+                      },
+                      "key": {
+                        "type": "Identifier",
+                        "location": {
+                          "start": {"line": 3, "column": 14},
+                          "end": {"line": 3, "column": 19},
+                          "source": "start"
+                        },
+                        "name": "start"
+                      },
+                      "value": {
+                        "type": "UnaryExpression",
+                        "location": {
+                          "start": {"line": 3, "column": 21},
+                          "end": {"line": 3, "column": 25},
+                          "source": "-12h"
+                        },
+                        "operator": "-",
+                        "argument": {
+                          "type": "DurationLiteral",
+                          "location": {
+                            "start": {"line": 3, "column": 22},
+                            "end": {"line": 3, "column": 25},
+                            "source": "12h"
+                          },
+                          "values": [{"magnitude": 12, "unit": "h"}]
+                        }
+                      }
+                    },
+                    {
+                      "type": "Property",
+                      "location": {
+                        "start": {"line": 3, "column": 27},
+                        "end": {"line": 3, "column": 38},
+                        "source": "stop: now()"
+                      },
+                      "key": {
+                        "type": "Identifier",
+                        "location": {
+                          "start": {"line": 3, "column": 27},
+                          "end": {"line": 3, "column": 31},
+                          "source": "stop"
+                        },
+                        "name": "stop"
+                      },
+                      "value": {
+                        "type": "CallExpression",
+                        "location": {
+                          "start": {"line": 3, "column": 33},
+                          "end": {"line": 3, "column": 38},
+                          "source": "now()"
+                        },
+                        "callee": {
+                          "type": "Identifier",
+                          "location": {
+                            "start": {"line": 3, "column": 33},
+                            "end": {"line": 3, "column": 36},
+                            "source": "now"
+                          },
+                          "name": "now"
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "call": {
+            "location": {
+              "start": {"line": 4, "column": 8},
+              "end": {"line": 7, "column": 7},
+              "source": "map(fn: (r) => {\n        v = {windowPeriod: 2444}\n        return ({ r with _value: v.windowPeriod })\n    })"
+            },
+            "callee": {
+              "type": "Identifier",
+              "location": {
+                "start": {"line": 4, "column": 8},
+                "end": {"line": 4, "column": 11},
+                "source": "map"
+              },
+              "name": "map"
+            },
+            "arguments": [
+              {
+                "type": "ObjectExpression",
+                "location": {
+                  "start": {"line": 4, "column": 12},
+                  "end": {"line": 7, "column": 6},
+                  "source": "fn: (r) => {\n        v = {windowPeriod: 2444}\n        return ({ r with _value: v.windowPeriod })\n    }"
+                },
+                "properties": [
+                  {
+                    "type": "Property",
+                    "location": {
+                      "start": {"line": 4, "column": 12},
+                      "end": {"line": 7, "column": 6},
+                      "source": "fn: (r) => {\n        v = {windowPeriod: 2444}\n        return ({ r with _value: v.windowPeriod })\n    }"
+                    },
+                    "key": {
+                      "type": "Identifier",
+                      "location": {
+                        "start": {"line": 4, "column": 12},
+                        "end": {"line": 4, "column": 14},
+                        "source": "fn"
+                      },
+                      "name": "fn"
+                    },
+                    "value": {
+                      "type": "FunctionExpression",
+                      "location": {
+                        "start": {"line": 4, "column": 16},
+                        "end": {"line": 7, "column": 6},
+                        "source": "(r) => {\n        v = {windowPeriod: 2444}\n        return ({ r with _value: v.windowPeriod })\n    }"
+                      },
+                      "params": [
+                        {
+                          "type": "Property",
+                          "location": {
+                            "start": {"line": 4, "column": 17},
+                            "end": {"line": 4, "column": 18},
+                            "source": "r"
+                          },
+                          "key": {
+                            "type": "Identifier",
+                            "location": {
+                              "start": {"line": 4, "column": 17},
+                              "end": {"line": 4, "column": 18},
+                              "source": "r"
+                            },
+                            "name": "r"
+                          },
+                          "value": null
+                        }
+                      ],
+                      "body": {
+                        "type": "Block",
+                        "location": {
+                          "start": {"line": 4, "column": 23},
+                          "end": {"line": 7, "column": 6},
+                          "source": "{\n        v = {windowPeriod: 2444}\n        return ({ r with _value: v.windowPeriod })\n    }"
+                        },
+                        "body": [
+                          {
+                            "type": "VariableAssignment",
+                            "location": {
+                              "start": {"line": 5, "column": 9},
+                              "end": {"line": 5, "column": 33},
+                              "source": "v = {windowPeriod: 2444}"
+                            },
+                            "id": {
+                              "location": {
+                                "start": {"line": 5, "column": 9},
+                                "end": {"line": 5, "column": 10},
+                                "source": "v"
+                              },
+                              "name": "v"
+                            },
+                            "init": {
+                              "type": "ObjectExpression",
+                              "location": {
+                                "start": {"line": 5, "column": 13},
+                                "end": {"line": 5, "column": 33},
+                                "source": "{windowPeriod: 2444}"
+                              },
+                              "properties": [
+                                {
+                                  "type": "Property",
+                                  "location": {
+                                    "start": {"line": 5, "column": 14},
+                                    "end": {"line": 5, "column": 32},
+                                    "source": "windowPeriod: 2444"
+                                  },
+                                  "key": {
+                                    "type": "Identifier",
+                                    "location": {
+                                      "start": {"line": 5, "column": 14},
+                                      "end": {"line": 5, "column": 26},
+                                      "source": "windowPeriod"
+                                    },
+                                    "name": "windowPeriod"
+                                  },
+                                  "value": {
+                                    "type": "IntegerLiteral",
+                                    "location": {
+                                      "start": {"line": 5, "column": 28},
+                                      "end": {"line": 5, "column": 32},
+                                      "source": "2444"
+                                    },
+                                    "value": "2444"
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "ReturnStatement",
+                            "location": {
+                              "start": {"line": 6, "column": 9},
+                              "end": {"line": 6, "column": 51},
+                              "source": "return ({ r with _value: v.windowPeriod })"
+                            },
+                            "argument": {
+                              "type": "ParenExpression",
+                              "location": {
+                                "start": {"line": 6, "column": 16},
+                                "end": {"line": 6, "column": 51},
+                                "source": "({ r with _value: v.windowPeriod })"
+                              },
+                              "expression": {
+                                "type": "ObjectExpression",
+                                "location": {
+                                  "start": {"line": 6, "column": 17},
+                                  "end": {"line": 6, "column": 50},
+                                  "source": "{ r with _value: v.windowPeriod }"
+                                },
+                                "with": {
+                                  "location": {
+                                    "start": {"line": 6, "column": 19},
+                                    "end": {"line": 6, "column": 20},
+                                    "source": "r"
+                                  },
+                                  "name": "r"
+                                },
+                                "properties": [
+                                  {
+                                    "type": "Property",
+                                    "location": {
+                                      "start": {"line": 6, "column": 26},
+                                      "end": {"line": 6, "column": 48},
+                                      "source": "_value: v.windowPeriod"
+                                    },
+                                    "key": {
+                                      "type": "Identifier",
+                                      "location": {
+                                        "start": {"line": 6, "column": 26},
+                                        "end": {"line": 6, "column": 32},
+                                        "source": "_value"
+                                      },
+                                      "name": "_value"
+                                    },
+                                    "value": {
+                                      "type": "MemberExpression",
+                                      "location": {
+                                        "start": {"line": 6, "column": 34},
+                                        "end": {"line": 6, "column": 48},
+                                        "source": "v.windowPeriod"
+                                      },
+                                      "object": {
+                                        "type": "Identifier",
+                                        "location": {
+                                          "start": {"line": 6, "column": 34},
+                                          "end": {"line": 6, "column": 35},
+                                          "source": "v"
+                                        },
+                                        "name": "v"
+                                      },
+                                      "property": {
+                                        "type": "Identifier",
+                                        "location": {
+                                          "start": {"line": 6, "column": 36},
+                                          "end": {"line": 6, "column": 48},
+                                          "source": "windowPeriod"
+                                        },
+                                        "name": "windowPeriod"
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "inner_vs_outer_query": {
+    "type": "File",
+    "location": {
+      "start": {"line": 1, "column": 1},
+      "end": {"line": 9, "column": 40},
+      "source": "import \"influxdata/influxdb/sample\"\nimport \"array\"\nsample.data(set: \"airSensor\")\n    |> range(start: -12h, stop: now())\n    |> map(fn: (r) => {\n        v = {windowPeriod: 2444}\n        return ({ r with _value: \"foo\" })\n    })\narray.from(rows: [{x: v.windowPeriod}])"
+    },
+    "metadata": "parser-type=rust",
+    "package": null,
+    "imports": [
+      {
+        "type": "ImportDeclaration",
+        "location": {
+          "start": {"line": 1, "column": 1},
+          "end": {"line": 1, "column": 36},
+          "source": "import \"influxdata/influxdb/sample\""
+        },
+        "as": null,
+        "path": {
+          "location": {
+            "start": {"line": 1, "column": 8},
+            "end": {"line": 1, "column": 36},
+            "source": "\"influxdata/influxdb/sample\""
+          },
+          "value": "influxdata/influxdb/sample"
+        }
+      },
+      {
+        "type": "ImportDeclaration",
+        "location": {
+          "start": {"line": 2, "column": 1},
+          "end": {"line": 2, "column": 15},
+          "source": "import \"array\""
+        },
+        "as": null,
+        "path": {
+          "location": {
+            "start": {"line": 2, "column": 8},
+            "end": {"line": 2, "column": 15},
+            "source": "\"array\""
+          },
+          "value": "array"
+        }
+      }
+    ],
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "location": {
+          "start": {"line": 3, "column": 1},
+          "end": {"line": 8, "column": 7},
+          "source": "sample.data(set: \"airSensor\")\n    |> range(start: -12h, stop: now())\n    |> map(fn: (r) => {\n        v = {windowPeriod: 2444}\n        return ({ r with _value: \"foo\" })\n    })"
+        },
+        "expression": {
+          "type": "PipeExpression",
+          "location": {
+            "start": {"line": 3, "column": 1},
+            "end": {"line": 8, "column": 7},
+            "source": "sample.data(set: \"airSensor\")\n    |> range(start: -12h, stop: now())\n    |> map(fn: (r) => {\n        v = {windowPeriod: 2444}\n        return ({ r with _value: \"foo\" })\n    })"
+          },
+          "argument": {
+            "type": "PipeExpression",
+            "location": {
+              "start": {"line": 3, "column": 1},
+              "end": {"line": 4, "column": 39},
+              "source": "sample.data(set: \"airSensor\")\n    |> range(start: -12h, stop: now())"
+            },
+            "argument": {
+              "type": "CallExpression",
+              "location": {
+                "start": {"line": 3, "column": 1},
+                "end": {"line": 3, "column": 30},
+                "source": "sample.data(set: \"airSensor\")"
+              },
+              "callee": {
+                "type": "MemberExpression",
+                "location": {
+                  "start": {"line": 3, "column": 1},
+                  "end": {"line": 3, "column": 12},
+                  "source": "sample.data"
+                },
+                "object": {
+                  "type": "Identifier",
+                  "location": {
+                    "start": {"line": 3, "column": 1},
+                    "end": {"line": 3, "column": 7},
+                    "source": "sample"
+                  },
+                  "name": "sample"
+                },
+                "property": {
+                  "type": "Identifier",
+                  "location": {
+                    "start": {"line": 3, "column": 8},
+                    "end": {"line": 3, "column": 12},
+                    "source": "data"
+                  },
+                  "name": "data"
+                }
+              },
+              "arguments": [
+                {
+                  "type": "ObjectExpression",
+                  "location": {
+                    "start": {"line": 3, "column": 13},
+                    "end": {"line": 3, "column": 29},
+                    "source": "set: \"airSensor\""
+                  },
+                  "properties": [
+                    {
+                      "type": "Property",
+                      "location": {
+                        "start": {"line": 3, "column": 13},
+                        "end": {"line": 3, "column": 29},
+                        "source": "set: \"airSensor\""
+                      },
+                      "key": {
+                        "type": "Identifier",
+                        "location": {
+                          "start": {"line": 3, "column": 13},
+                          "end": {"line": 3, "column": 16},
+                          "source": "set"
+                        },
+                        "name": "set"
+                      },
+                      "value": {
+                        "type": "StringLiteral",
+                        "location": {
+                          "start": {"line": 3, "column": 18},
+                          "end": {"line": 3, "column": 29},
+                          "source": "\"airSensor\""
+                        },
+                        "value": "airSensor"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "call": {
+              "location": {
+                "start": {"line": 4, "column": 8},
+                "end": {"line": 4, "column": 39},
+                "source": "range(start: -12h, stop: now())"
+              },
+              "callee": {
+                "type": "Identifier",
+                "location": {
+                  "start": {"line": 4, "column": 8},
+                  "end": {"line": 4, "column": 13},
+                  "source": "range"
+                },
+                "name": "range"
+              },
+              "arguments": [
+                {
+                  "type": "ObjectExpression",
+                  "location": {
+                    "start": {"line": 4, "column": 14},
+                    "end": {"line": 4, "column": 38},
+                    "source": "start: -12h, stop: now()"
+                  },
+                  "properties": [
+                    {
+                      "type": "Property",
+                      "location": {
+                        "start": {"line": 4, "column": 14},
+                        "end": {"line": 4, "column": 25},
+                        "source": "start: -12h"
+                      },
+                      "key": {
+                        "type": "Identifier",
+                        "location": {
+                          "start": {"line": 4, "column": 14},
+                          "end": {"line": 4, "column": 19},
+                          "source": "start"
+                        },
+                        "name": "start"
+                      },
+                      "value": {
+                        "type": "UnaryExpression",
+                        "location": {
+                          "start": {"line": 4, "column": 21},
+                          "end": {"line": 4, "column": 25},
+                          "source": "-12h"
+                        },
+                        "operator": "-",
+                        "argument": {
+                          "type": "DurationLiteral",
+                          "location": {
+                            "start": {"line": 4, "column": 22},
+                            "end": {"line": 4, "column": 25},
+                            "source": "12h"
+                          },
+                          "values": [{"magnitude": 12, "unit": "h"}]
+                        }
+                      }
+                    },
+                    {
+                      "type": "Property",
+                      "location": {
+                        "start": {"line": 4, "column": 27},
+                        "end": {"line": 4, "column": 38},
+                        "source": "stop: now()"
+                      },
+                      "key": {
+                        "type": "Identifier",
+                        "location": {
+                          "start": {"line": 4, "column": 27},
+                          "end": {"line": 4, "column": 31},
+                          "source": "stop"
+                        },
+                        "name": "stop"
+                      },
+                      "value": {
+                        "type": "CallExpression",
+                        "location": {
+                          "start": {"line": 4, "column": 33},
+                          "end": {"line": 4, "column": 38},
+                          "source": "now()"
+                        },
+                        "callee": {
+                          "type": "Identifier",
+                          "location": {
+                            "start": {"line": 4, "column": 33},
+                            "end": {"line": 4, "column": 36},
+                            "source": "now"
+                          },
+                          "name": "now"
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "call": {
+            "location": {
+              "start": {"line": 5, "column": 8},
+              "end": {"line": 8, "column": 7},
+              "source": "map(fn: (r) => {\n        v = {windowPeriod: 2444}\n        return ({ r with _value: \"foo\" })\n    })"
+            },
+            "callee": {
+              "type": "Identifier",
+              "location": {
+                "start": {"line": 5, "column": 8},
+                "end": {"line": 5, "column": 11},
+                "source": "map"
+              },
+              "name": "map"
+            },
+            "arguments": [
+              {
+                "type": "ObjectExpression",
+                "location": {
+                  "start": {"line": 5, "column": 12},
+                  "end": {"line": 8, "column": 6},
+                  "source": "fn: (r) => {\n        v = {windowPeriod: 2444}\n        return ({ r with _value: \"foo\" })\n    }"
+                },
+                "properties": [
+                  {
+                    "type": "Property",
+                    "location": {
+                      "start": {"line": 5, "column": 12},
+                      "end": {"line": 8, "column": 6},
+                      "source": "fn: (r) => {\n        v = {windowPeriod: 2444}\n        return ({ r with _value: \"foo\" })\n    }"
+                    },
+                    "key": {
+                      "type": "Identifier",
+                      "location": {
+                        "start": {"line": 5, "column": 12},
+                        "end": {"line": 5, "column": 14},
+                        "source": "fn"
+                      },
+                      "name": "fn"
+                    },
+                    "value": {
+                      "type": "FunctionExpression",
+                      "location": {
+                        "start": {"line": 5, "column": 16},
+                        "end": {"line": 8, "column": 6},
+                        "source": "(r) => {\n        v = {windowPeriod: 2444}\n        return ({ r with _value: \"foo\" })\n    }"
+                      },
+                      "params": [
+                        {
+                          "type": "Property",
+                          "location": {
+                            "start": {"line": 5, "column": 17},
+                            "end": {"line": 5, "column": 18},
+                            "source": "r"
+                          },
+                          "key": {
+                            "type": "Identifier",
+                            "location": {
+                              "start": {"line": 5, "column": 17},
+                              "end": {"line": 5, "column": 18},
+                              "source": "r"
+                            },
+                            "name": "r"
+                          },
+                          "value": null
+                        }
+                      ],
+                      "body": {
+                        "type": "Block",
+                        "location": {
+                          "start": {"line": 5, "column": 23},
+                          "end": {"line": 8, "column": 6},
+                          "source": "{\n        v = {windowPeriod: 2444}\n        return ({ r with _value: \"foo\" })\n    }"
+                        },
+                        "body": [
+                          {
+                            "type": "VariableAssignment",
+                            "location": {
+                              "start": {"line": 6, "column": 9},
+                              "end": {"line": 6, "column": 33},
+                              "source": "v = {windowPeriod: 2444}"
+                            },
+                            "id": {
+                              "location": {
+                                "start": {"line": 6, "column": 9},
+                                "end": {"line": 6, "column": 10},
+                                "source": "v"
+                              },
+                              "name": "v"
+                            },
+                            "init": {
+                              "type": "ObjectExpression",
+                              "location": {
+                                "start": {"line": 6, "column": 13},
+                                "end": {"line": 6, "column": 33},
+                                "source": "{windowPeriod: 2444}"
+                              },
+                              "properties": [
+                                {
+                                  "type": "Property",
+                                  "location": {
+                                    "start": {"line": 6, "column": 14},
+                                    "end": {"line": 6, "column": 32},
+                                    "source": "windowPeriod: 2444"
+                                  },
+                                  "key": {
+                                    "type": "Identifier",
+                                    "location": {
+                                      "start": {"line": 6, "column": 14},
+                                      "end": {"line": 6, "column": 26},
+                                      "source": "windowPeriod"
+                                    },
+                                    "name": "windowPeriod"
+                                  },
+                                  "value": {
+                                    "type": "IntegerLiteral",
+                                    "location": {
+                                      "start": {"line": 6, "column": 28},
+                                      "end": {"line": 6, "column": 32},
+                                      "source": "2444"
+                                    },
+                                    "value": "2444"
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "ReturnStatement",
+                            "location": {
+                              "start": {"line": 7, "column": 9},
+                              "end": {"line": 7, "column": 42},
+                              "source": "return ({ r with _value: \"foo\" })"
+                            },
+                            "argument": {
+                              "type": "ParenExpression",
+                              "location": {
+                                "start": {"line": 7, "column": 16},
+                                "end": {"line": 7, "column": 42},
+                                "source": "({ r with _value: \"foo\" })"
+                              },
+                              "expression": {
+                                "type": "ObjectExpression",
+                                "location": {
+                                  "start": {"line": 7, "column": 17},
+                                  "end": {"line": 7, "column": 41},
+                                  "source": "{ r with _value: \"foo\" }"
+                                },
+                                "with": {
+                                  "location": {
+                                    "start": {"line": 7, "column": 19},
+                                    "end": {"line": 7, "column": 20},
+                                    "source": "r"
+                                  },
+                                  "name": "r"
+                                },
+                                "properties": [
+                                  {
+                                    "type": "Property",
+                                    "location": {
+                                      "start": {"line": 7, "column": 26},
+                                      "end": {"line": 7, "column": 39},
+                                      "source": "_value: \"foo\""
+                                    },
+                                    "key": {
+                                      "type": "Identifier",
+                                      "location": {
+                                        "start": {"line": 7, "column": 26},
+                                        "end": {"line": 7, "column": 32},
+                                        "source": "_value"
+                                      },
+                                      "name": "_value"
+                                    },
+                                    "value": {
+                                      "type": "StringLiteral",
+                                      "location": {
+                                        "start": {"line": 7, "column": 34},
+                                        "end": {"line": 7, "column": 39},
+                                        "source": "\"foo\""
+                                      },
+                                      "value": "foo"
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "ExpressionStatement",
+        "location": {
+          "start": {"line": 9, "column": 1},
+          "end": {"line": 9, "column": 40},
+          "source": "array.from(rows: [{x: v.windowPeriod}])"
+        },
+        "expression": {
+          "type": "CallExpression",
+          "location": {
+            "start": {"line": 9, "column": 1},
+            "end": {"line": 9, "column": 40},
+            "source": "array.from(rows: [{x: v.windowPeriod}])"
+          },
+          "callee": {
+            "type": "MemberExpression",
+            "location": {
+              "start": {"line": 9, "column": 1},
+              "end": {"line": 9, "column": 11},
+              "source": "array.from"
+            },
+            "object": {
+              "type": "Identifier",
+              "location": {
+                "start": {"line": 9, "column": 1},
+                "end": {"line": 9, "column": 6},
+                "source": "array"
+              },
+              "name": "array"
+            },
+            "property": {
+              "type": "Identifier",
+              "location": {
+                "start": {"line": 9, "column": 7},
+                "end": {"line": 9, "column": 11},
+                "source": "from"
+              },
+              "name": "from"
+            }
+          },
+          "arguments": [
+            {
+              "type": "ObjectExpression",
+              "location": {
+                "start": {"line": 9, "column": 12},
+                "end": {"line": 9, "column": 39},
+                "source": "rows: [{x: v.windowPeriod}]"
+              },
+              "properties": [
+                {
+                  "type": "Property",
+                  "location": {
+                    "start": {"line": 9, "column": 12},
+                    "end": {"line": 9, "column": 39},
+                    "source": "rows: [{x: v.windowPeriod}]"
+                  },
+                  "key": {
+                    "type": "Identifier",
+                    "location": {
+                      "start": {"line": 9, "column": 12},
+                      "end": {"line": 9, "column": 16},
+                      "source": "rows"
+                    },
+                    "name": "rows"
+                  },
+                  "value": {
+                    "type": "ArrayExpression",
+                    "location": {
+                      "start": {"line": 9, "column": 18},
+                      "end": {"line": 9, "column": 39},
+                      "source": "[{x: v.windowPeriod}]"
+                    },
+                    "elements": [
+                      {
+                        "type": "ObjectExpression",
+                        "location": {
+                          "start": {"line": 9, "column": 19},
+                          "end": {"line": 9, "column": 38},
+                          "source": "{x: v.windowPeriod}"
+                        },
+                        "properties": [
+                          {
+                            "type": "Property",
+                            "location": {
+                              "start": {"line": 9, "column": 20},
+                              "end": {"line": 9, "column": 37},
+                              "source": "x: v.windowPeriod"
+                            },
+                            "key": {
+                              "type": "Identifier",
+                              "location": {
+                                "start": {"line": 9, "column": 20},
+                                "end": {"line": 9, "column": 21},
+                                "source": "x"
+                              },
+                              "name": "x"
+                            },
+                            "value": {
+                              "type": "MemberExpression",
+                              "location": {
+                                "start": {"line": 9, "column": 23},
+                                "end": {"line": 9, "column": 37},
+                                "source": "v.windowPeriod"
+                              },
+                              "object": {
+                                "type": "Identifier",
+                                "location": {
+                                  "start": {"line": 9, "column": 23},
+                                  "end": {"line": 9, "column": 24},
+                                  "source": "v"
+                                },
+                                "name": "v"
+                              },
+                              "property": {
+                                "type": "Identifier",
+                                "location": {
+                                  "start": {"line": 9, "column": 25},
+                                  "end": {"line": 9, "column": 37},
+                                  "source": "windowPeriod"
+                                },
+                                "name": "windowPeriod"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "inner_lambda": {
+    "type": "File",
+    "location": {
+      "start": {"line": 1, "column": 1},
+      "end": {"line": 6, "column": 7},
+      "source": "import \"influxdata/influxdb/sample\"\nsample.data(set: \"airSensor\")\n    |> range(start: -12h, stop: now())\n    |> map(fn: (r) => {\n        return ({ r with _value: \"${v.windowPeriod}\" })\n    })"
+    },
+    "metadata": "parser-type=rust",
+    "package": null,
+    "imports": [
+      {
+        "type": "ImportDeclaration",
+        "location": {
+          "start": {"line": 1, "column": 1},
+          "end": {"line": 1, "column": 36},
+          "source": "import \"influxdata/influxdb/sample\""
+        },
+        "as": null,
+        "path": {
+          "location": {
+            "start": {"line": 1, "column": 8},
+            "end": {"line": 1, "column": 36},
+            "source": "\"influxdata/influxdb/sample\""
+          },
+          "value": "influxdata/influxdb/sample"
+        }
+      }
+    ],
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "location": {
+          "start": {"line": 2, "column": 1},
+          "end": {"line": 6, "column": 7},
+          "source": "sample.data(set: \"airSensor\")\n    |> range(start: -12h, stop: now())\n    |> map(fn: (r) => {\n        return ({ r with _value: \"${v.windowPeriod}\" })\n    })"
+        },
+        "expression": {
+          "type": "PipeExpression",
+          "location": {
+            "start": {"line": 2, "column": 1},
+            "end": {"line": 6, "column": 7},
+            "source": "sample.data(set: \"airSensor\")\n    |> range(start: -12h, stop: now())\n    |> map(fn: (r) => {\n        return ({ r with _value: \"${v.windowPeriod}\" })\n    })"
+          },
+          "argument": {
+            "type": "PipeExpression",
+            "location": {
+              "start": {"line": 2, "column": 1},
+              "end": {"line": 3, "column": 39},
+              "source": "sample.data(set: \"airSensor\")\n    |> range(start: -12h, stop: now())"
+            },
+            "argument": {
+              "type": "CallExpression",
+              "location": {
+                "start": {"line": 2, "column": 1},
+                "end": {"line": 2, "column": 30},
+                "source": "sample.data(set: \"airSensor\")"
+              },
+              "callee": {
+                "type": "MemberExpression",
+                "location": {
+                  "start": {"line": 2, "column": 1},
+                  "end": {"line": 2, "column": 12},
+                  "source": "sample.data"
+                },
+                "object": {
+                  "type": "Identifier",
+                  "location": {
+                    "start": {"line": 2, "column": 1},
+                    "end": {"line": 2, "column": 7},
+                    "source": "sample"
+                  },
+                  "name": "sample"
+                },
+                "property": {
+                  "type": "Identifier",
+                  "location": {
+                    "start": {"line": 2, "column": 8},
+                    "end": {"line": 2, "column": 12},
+                    "source": "data"
+                  },
+                  "name": "data"
+                }
+              },
+              "arguments": [
+                {
+                  "type": "ObjectExpression",
+                  "location": {
+                    "start": {"line": 2, "column": 13},
+                    "end": {"line": 2, "column": 29},
+                    "source": "set: \"airSensor\""
+                  },
+                  "properties": [
+                    {
+                      "type": "Property",
+                      "location": {
+                        "start": {"line": 2, "column": 13},
+                        "end": {"line": 2, "column": 29},
+                        "source": "set: \"airSensor\""
+                      },
+                      "key": {
+                        "type": "Identifier",
+                        "location": {
+                          "start": {"line": 2, "column": 13},
+                          "end": {"line": 2, "column": 16},
+                          "source": "set"
+                        },
+                        "name": "set"
+                      },
+                      "value": {
+                        "type": "StringLiteral",
+                        "location": {
+                          "start": {"line": 2, "column": 18},
+                          "end": {"line": 2, "column": 29},
+                          "source": "\"airSensor\""
+                        },
+                        "value": "airSensor"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "call": {
+              "location": {
+                "start": {"line": 3, "column": 8},
+                "end": {"line": 3, "column": 39},
+                "source": "range(start: -12h, stop: now())"
+              },
+              "callee": {
+                "type": "Identifier",
+                "location": {
+                  "start": {"line": 3, "column": 8},
+                  "end": {"line": 3, "column": 13},
+                  "source": "range"
+                },
+                "name": "range"
+              },
+              "arguments": [
+                {
+                  "type": "ObjectExpression",
+                  "location": {
+                    "start": {"line": 3, "column": 14},
+                    "end": {"line": 3, "column": 38},
+                    "source": "start: -12h, stop: now()"
+                  },
+                  "properties": [
+                    {
+                      "type": "Property",
+                      "location": {
+                        "start": {"line": 3, "column": 14},
+                        "end": {"line": 3, "column": 25},
+                        "source": "start: -12h"
+                      },
+                      "key": {
+                        "type": "Identifier",
+                        "location": {
+                          "start": {"line": 3, "column": 14},
+                          "end": {"line": 3, "column": 19},
+                          "source": "start"
+                        },
+                        "name": "start"
+                      },
+                      "value": {
+                        "type": "UnaryExpression",
+                        "location": {
+                          "start": {"line": 3, "column": 21},
+                          "end": {"line": 3, "column": 25},
+                          "source": "-12h"
+                        },
+                        "operator": "-",
+                        "argument": {
+                          "type": "DurationLiteral",
+                          "location": {
+                            "start": {"line": 3, "column": 22},
+                            "end": {"line": 3, "column": 25},
+                            "source": "12h"
+                          },
+                          "values": [{"magnitude": 12, "unit": "h"}]
+                        }
+                      }
+                    },
+                    {
+                      "type": "Property",
+                      "location": {
+                        "start": {"line": 3, "column": 27},
+                        "end": {"line": 3, "column": 38},
+                        "source": "stop: now()"
+                      },
+                      "key": {
+                        "type": "Identifier",
+                        "location": {
+                          "start": {"line": 3, "column": 27},
+                          "end": {"line": 3, "column": 31},
+                          "source": "stop"
+                        },
+                        "name": "stop"
+                      },
+                      "value": {
+                        "type": "CallExpression",
+                        "location": {
+                          "start": {"line": 3, "column": 33},
+                          "end": {"line": 3, "column": 38},
+                          "source": "now()"
+                        },
+                        "callee": {
+                          "type": "Identifier",
+                          "location": {
+                            "start": {"line": 3, "column": 33},
+                            "end": {"line": 3, "column": 36},
+                            "source": "now"
+                          },
+                          "name": "now"
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "call": {
+            "location": {
+              "start": {"line": 4, "column": 8},
+              "end": {"line": 6, "column": 7},
+              "source": "map(fn: (r) => {\n        return ({ r with _value: \"${v.windowPeriod}\" })\n    })"
+            },
+            "callee": {
+              "type": "Identifier",
+              "location": {
+                "start": {"line": 4, "column": 8},
+                "end": {"line": 4, "column": 11},
+                "source": "map"
+              },
+              "name": "map"
+            },
+            "arguments": [
+              {
+                "type": "ObjectExpression",
+                "location": {
+                  "start": {"line": 4, "column": 12},
+                  "end": {"line": 6, "column": 6},
+                  "source": "fn: (r) => {\n        return ({ r with _value: \"${v.windowPeriod}\" })\n    }"
+                },
+                "properties": [
+                  {
+                    "type": "Property",
+                    "location": {
+                      "start": {"line": 4, "column": 12},
+                      "end": {"line": 6, "column": 6},
+                      "source": "fn: (r) => {\n        return ({ r with _value: \"${v.windowPeriod}\" })\n    }"
+                    },
+                    "key": {
+                      "type": "Identifier",
+                      "location": {
+                        "start": {"line": 4, "column": 12},
+                        "end": {"line": 4, "column": 14},
+                        "source": "fn"
+                      },
+                      "name": "fn"
+                    },
+                    "value": {
+                      "type": "FunctionExpression",
+                      "location": {
+                        "start": {"line": 4, "column": 16},
+                        "end": {"line": 6, "column": 6},
+                        "source": "(r) => {\n        return ({ r with _value: \"${v.windowPeriod}\" })\n    }"
+                      },
+                      "params": [
+                        {
+                          "type": "Property",
+                          "location": {
+                            "start": {"line": 4, "column": 17},
+                            "end": {"line": 4, "column": 18},
+                            "source": "r"
+                          },
+                          "key": {
+                            "type": "Identifier",
+                            "location": {
+                              "start": {"line": 4, "column": 17},
+                              "end": {"line": 4, "column": 18},
+                              "source": "r"
+                            },
+                            "name": "r"
+                          },
+                          "value": null
+                        }
+                      ],
+                      "body": {
+                        "type": "Block",
+                        "location": {
+                          "start": {"line": 4, "column": 23},
+                          "end": {"line": 6, "column": 6},
+                          "source": "{\n        return ({ r with _value: \"${v.windowPeriod}\" })\n    }"
+                        },
+                        "body": [
+                          {
+                            "type": "ReturnStatement",
+                            "location": {
+                              "start": {"line": 5, "column": 9},
+                              "end": {"line": 5, "column": 56},
+                              "source": "return ({ r with _value: \"${v.windowPeriod}\" })"
+                            },
+                            "argument": {
+                              "type": "ParenExpression",
+                              "location": {
+                                "start": {"line": 5, "column": 16},
+                                "end": {"line": 5, "column": 56},
+                                "source": "({ r with _value: \"${v.windowPeriod}\" })"
+                              },
+                              "expression": {
+                                "type": "ObjectExpression",
+                                "location": {
+                                  "start": {"line": 5, "column": 17},
+                                  "end": {"line": 5, "column": 55},
+                                  "source": "{ r with _value: \"${v.windowPeriod}\" }"
+                                },
+                                "with": {
+                                  "location": {
+                                    "start": {"line": 5, "column": 19},
+                                    "end": {"line": 5, "column": 20},
+                                    "source": "r"
+                                  },
+                                  "name": "r"
+                                },
+                                "properties": [
+                                  {
+                                    "type": "Property",
+                                    "location": {
+                                      "start": {"line": 5, "column": 26},
+                                      "end": {"line": 5, "column": 53},
+                                      "source": "_value: \"${v.windowPeriod}\""
+                                    },
+                                    "key": {
+                                      "type": "Identifier",
+                                      "location": {
+                                        "start": {"line": 5, "column": 26},
+                                        "end": {"line": 5, "column": 32},
+                                        "source": "_value"
+                                      },
+                                      "name": "_value"
+                                    },
+                                    "value": {
+                                      "type": "StringExpression",
+                                      "location": {
+                                        "start": {"line": 5, "column": 34},
+                                        "end": {"line": 5, "column": 53},
+                                        "source": "\"${v.windowPeriod}\""
+                                      },
+                                      "parts": [
+                                        {
+                                          "type": "InterpolatedPart",
+                                          "location": {
+                                            "start": {"line": 5, "column": 35},
+                                            "end": {"line": 5, "column": 52},
+                                            "source": "${v.windowPeriod}"
+                                          },
+                                          "expression": {
+                                            "type": "MemberExpression",
+                                            "location": {
+                                              "start": {
+                                                "line": 5,
+                                                "column": 37
+                                              },
+                                              "end": {"line": 5, "column": 51},
+                                              "source": "v.windowPeriod"
+                                            },
+                                            "object": {
+                                              "type": "Identifier",
+                                              "location": {
+                                                "start": {
+                                                  "line": 5,
+                                                  "column": 37
+                                                },
+                                                "end": {
+                                                  "line": 5,
+                                                  "column": 38
+                                                },
+                                                "source": "v"
+                                              },
+                                              "name": "v"
+                                            },
+                                            "property": {
+                                              "type": "Identifier",
+                                              "location": {
+                                                "start": {
+                                                  "line": 5,
+                                                  "column": 39
+                                                },
+                                                "end": {
+                                                  "line": 5,
+                                                  "column": 51
+                                                },
+                                                "source": "windowPeriod"
+                                              },
+                                              "name": "windowPeriod"
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "multiple_ranges": {
+    "type": "File",
+    "location": {
+      "start": {"line": 1, "column": 1},
+      "end": {"line": 6, "column": 39},
+      "source": "import \"influxdata/influxdb/sample\"\nsample.data(set: \"airSensor\")\n    |> range(start: -12h, stop: now())\n    |> yield(name: \"${v.windowPeriod}\")\nsample.data(set: \"airSensor\")\n    |> range(start: -15m, stop: now())"
+    },
+    "metadata": "parser-type=rust",
+    "package": null,
+    "imports": [
+      {
+        "type": "ImportDeclaration",
+        "location": {
+          "start": {"line": 1, "column": 1},
+          "end": {"line": 1, "column": 36},
+          "source": "import \"influxdata/influxdb/sample\""
+        },
+        "as": null,
+        "path": {
+          "location": {
+            "start": {"line": 1, "column": 8},
+            "end": {"line": 1, "column": 36},
+            "source": "\"influxdata/influxdb/sample\""
+          },
+          "value": "influxdata/influxdb/sample"
+        }
+      }
+    ],
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "location": {
+          "start": {"line": 2, "column": 1},
+          "end": {"line": 4, "column": 40},
+          "source": "sample.data(set: \"airSensor\")\n    |> range(start: -12h, stop: now())\n    |> yield(name: \"${v.windowPeriod}\")"
+        },
+        "expression": {
+          "type": "PipeExpression",
+          "location": {
+            "start": {"line": 2, "column": 1},
+            "end": {"line": 4, "column": 40},
+            "source": "sample.data(set: \"airSensor\")\n    |> range(start: -12h, stop: now())\n    |> yield(name: \"${v.windowPeriod}\")"
+          },
+          "argument": {
+            "type": "PipeExpression",
+            "location": {
+              "start": {"line": 2, "column": 1},
+              "end": {"line": 3, "column": 39},
+              "source": "sample.data(set: \"airSensor\")\n    |> range(start: -12h, stop: now())"
+            },
+            "argument": {
+              "type": "CallExpression",
+              "location": {
+                "start": {"line": 2, "column": 1},
+                "end": {"line": 2, "column": 30},
+                "source": "sample.data(set: \"airSensor\")"
+              },
+              "callee": {
+                "type": "MemberExpression",
+                "location": {
+                  "start": {"line": 2, "column": 1},
+                  "end": {"line": 2, "column": 12},
+                  "source": "sample.data"
+                },
+                "object": {
+                  "type": "Identifier",
+                  "location": {
+                    "start": {"line": 2, "column": 1},
+                    "end": {"line": 2, "column": 7},
+                    "source": "sample"
+                  },
+                  "name": "sample"
+                },
+                "property": {
+                  "type": "Identifier",
+                  "location": {
+                    "start": {"line": 2, "column": 8},
+                    "end": {"line": 2, "column": 12},
+                    "source": "data"
+                  },
+                  "name": "data"
+                }
+              },
+              "arguments": [
+                {
+                  "type": "ObjectExpression",
+                  "location": {
+                    "start": {"line": 2, "column": 13},
+                    "end": {"line": 2, "column": 29},
+                    "source": "set: \"airSensor\""
+                  },
+                  "properties": [
+                    {
+                      "type": "Property",
+                      "location": {
+                        "start": {"line": 2, "column": 13},
+                        "end": {"line": 2, "column": 29},
+                        "source": "set: \"airSensor\""
+                      },
+                      "key": {
+                        "type": "Identifier",
+                        "location": {
+                          "start": {"line": 2, "column": 13},
+                          "end": {"line": 2, "column": 16},
+                          "source": "set"
+                        },
+                        "name": "set"
+                      },
+                      "value": {
+                        "type": "StringLiteral",
+                        "location": {
+                          "start": {"line": 2, "column": 18},
+                          "end": {"line": 2, "column": 29},
+                          "source": "\"airSensor\""
+                        },
+                        "value": "airSensor"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "call": {
+              "location": {
+                "start": {"line": 3, "column": 8},
+                "end": {"line": 3, "column": 39},
+                "source": "range(start: -12h, stop: now())"
+              },
+              "callee": {
+                "type": "Identifier",
+                "location": {
+                  "start": {"line": 3, "column": 8},
+                  "end": {"line": 3, "column": 13},
+                  "source": "range"
+                },
+                "name": "range"
+              },
+              "arguments": [
+                {
+                  "type": "ObjectExpression",
+                  "location": {
+                    "start": {"line": 3, "column": 14},
+                    "end": {"line": 3, "column": 38},
+                    "source": "start: -12h, stop: now()"
+                  },
+                  "properties": [
+                    {
+                      "type": "Property",
+                      "location": {
+                        "start": {"line": 3, "column": 14},
+                        "end": {"line": 3, "column": 25},
+                        "source": "start: -12h"
+                      },
+                      "key": {
+                        "type": "Identifier",
+                        "location": {
+                          "start": {"line": 3, "column": 14},
+                          "end": {"line": 3, "column": 19},
+                          "source": "start"
+                        },
+                        "name": "start"
+                      },
+                      "value": {
+                        "type": "UnaryExpression",
+                        "location": {
+                          "start": {"line": 3, "column": 21},
+                          "end": {"line": 3, "column": 25},
+                          "source": "-12h"
+                        },
+                        "operator": "-",
+                        "argument": {
+                          "type": "DurationLiteral",
+                          "location": {
+                            "start": {"line": 3, "column": 22},
+                            "end": {"line": 3, "column": 25},
+                            "source": "12h"
+                          },
+                          "values": [{"magnitude": 12, "unit": "h"}]
+                        }
+                      }
+                    },
+                    {
+                      "type": "Property",
+                      "location": {
+                        "start": {"line": 3, "column": 27},
+                        "end": {"line": 3, "column": 38},
+                        "source": "stop: now()"
+                      },
+                      "key": {
+                        "type": "Identifier",
+                        "location": {
+                          "start": {"line": 3, "column": 27},
+                          "end": {"line": 3, "column": 31},
+                          "source": "stop"
+                        },
+                        "name": "stop"
+                      },
+                      "value": {
+                        "type": "CallExpression",
+                        "location": {
+                          "start": {"line": 3, "column": 33},
+                          "end": {"line": 3, "column": 38},
+                          "source": "now()"
+                        },
+                        "callee": {
+                          "type": "Identifier",
+                          "location": {
+                            "start": {"line": 3, "column": 33},
+                            "end": {"line": 3, "column": 36},
+                            "source": "now"
+                          },
+                          "name": "now"
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "call": {
+            "location": {
+              "start": {"line": 4, "column": 8},
+              "end": {"line": 4, "column": 40},
+              "source": "yield(name: \"${v.windowPeriod}\")"
+            },
+            "callee": {
+              "type": "Identifier",
+              "location": {
+                "start": {"line": 4, "column": 8},
+                "end": {"line": 4, "column": 13},
+                "source": "yield"
+              },
+              "name": "yield"
+            },
+            "arguments": [
+              {
+                "type": "ObjectExpression",
+                "location": {
+                  "start": {"line": 4, "column": 14},
+                  "end": {"line": 4, "column": 39},
+                  "source": "name: \"${v.windowPeriod}\""
+                },
+                "properties": [
+                  {
+                    "type": "Property",
+                    "location": {
+                      "start": {"line": 4, "column": 14},
+                      "end": {"line": 4, "column": 39},
+                      "source": "name: \"${v.windowPeriod}\""
+                    },
+                    "key": {
+                      "type": "Identifier",
+                      "location": {
+                        "start": {"line": 4, "column": 14},
+                        "end": {"line": 4, "column": 18},
+                        "source": "name"
+                      },
+                      "name": "name"
+                    },
+                    "value": {
+                      "type": "StringExpression",
+                      "location": {
+                        "start": {"line": 4, "column": 20},
+                        "end": {"line": 4, "column": 39},
+                        "source": "\"${v.windowPeriod}\""
+                      },
+                      "parts": [
+                        {
+                          "type": "InterpolatedPart",
+                          "location": {
+                            "start": {"line": 4, "column": 21},
+                            "end": {"line": 4, "column": 38},
+                            "source": "${v.windowPeriod}"
+                          },
+                          "expression": {
+                            "type": "MemberExpression",
+                            "location": {
+                              "start": {"line": 4, "column": 23},
+                              "end": {"line": 4, "column": 37},
+                              "source": "v.windowPeriod"
+                            },
+                            "object": {
+                              "type": "Identifier",
+                              "location": {
+                                "start": {"line": 4, "column": 23},
+                                "end": {"line": 4, "column": 24},
+                                "source": "v"
+                              },
+                              "name": "v"
+                            },
+                            "property": {
+                              "type": "Identifier",
+                              "location": {
+                                "start": {"line": 4, "column": 25},
+                                "end": {"line": 4, "column": 37},
+                                "source": "windowPeriod"
+                              },
+                              "name": "windowPeriod"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "ExpressionStatement",
+        "location": {
+          "start": {"line": 5, "column": 1},
+          "end": {"line": 6, "column": 39},
+          "source": "sample.data(set: \"airSensor\")\n    |> range(start: -15m, stop: now())"
+        },
+        "expression": {
+          "type": "PipeExpression",
+          "location": {
+            "start": {"line": 5, "column": 1},
+            "end": {"line": 6, "column": 39},
+            "source": "sample.data(set: \"airSensor\")\n    |> range(start: -15m, stop: now())"
+          },
+          "argument": {
+            "type": "CallExpression",
+            "location": {
+              "start": {"line": 5, "column": 1},
+              "end": {"line": 5, "column": 30},
+              "source": "sample.data(set: \"airSensor\")"
+            },
+            "callee": {
+              "type": "MemberExpression",
+              "location": {
+                "start": {"line": 5, "column": 1},
+                "end": {"line": 5, "column": 12},
+                "source": "sample.data"
+              },
+              "object": {
+                "type": "Identifier",
+                "location": {
+                  "start": {"line": 5, "column": 1},
+                  "end": {"line": 5, "column": 7},
+                  "source": "sample"
+                },
+                "name": "sample"
+              },
+              "property": {
+                "type": "Identifier",
+                "location": {
+                  "start": {"line": 5, "column": 8},
+                  "end": {"line": 5, "column": 12},
+                  "source": "data"
+                },
+                "name": "data"
+              }
+            },
+            "arguments": [
+              {
+                "type": "ObjectExpression",
+                "location": {
+                  "start": {"line": 5, "column": 13},
+                  "end": {"line": 5, "column": 29},
+                  "source": "set: \"airSensor\""
+                },
+                "properties": [
+                  {
+                    "type": "Property",
+                    "location": {
+                      "start": {"line": 5, "column": 13},
+                      "end": {"line": 5, "column": 29},
+                      "source": "set: \"airSensor\""
+                    },
+                    "key": {
+                      "type": "Identifier",
+                      "location": {
+                        "start": {"line": 5, "column": 13},
+                        "end": {"line": 5, "column": 16},
+                        "source": "set"
+                      },
+                      "name": "set"
+                    },
+                    "value": {
+                      "type": "StringLiteral",
+                      "location": {
+                        "start": {"line": 5, "column": 18},
+                        "end": {"line": 5, "column": 29},
+                        "source": "\"airSensor\""
+                      },
+                      "value": "airSensor"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "call": {
+            "location": {
+              "start": {"line": 6, "column": 8},
+              "end": {"line": 6, "column": 39},
+              "source": "range(start: -15m, stop: now())"
+            },
+            "callee": {
+              "type": "Identifier",
+              "location": {
+                "start": {"line": 6, "column": 8},
+                "end": {"line": 6, "column": 13},
+                "source": "range"
+              },
+              "name": "range"
+            },
+            "arguments": [
+              {
+                "type": "ObjectExpression",
+                "location": {
+                  "start": {"line": 6, "column": 14},
+                  "end": {"line": 6, "column": 38},
+                  "source": "start: -15m, stop: now()"
+                },
+                "properties": [
+                  {
+                    "type": "Property",
+                    "location": {
+                      "start": {"line": 6, "column": 14},
+                      "end": {"line": 6, "column": 25},
+                      "source": "start: -15m"
+                    },
+                    "key": {
+                      "type": "Identifier",
+                      "location": {
+                        "start": {"line": 6, "column": 14},
+                        "end": {"line": 6, "column": 19},
+                        "source": "start"
+                      },
+                      "name": "start"
+                    },
+                    "value": {
+                      "type": "UnaryExpression",
+                      "location": {
+                        "start": {"line": 6, "column": 21},
+                        "end": {"line": 6, "column": 25},
+                        "source": "-15m"
+                      },
+                      "operator": "-",
+                      "argument": {
+                        "type": "DurationLiteral",
+                        "location": {
+                          "start": {"line": 6, "column": 22},
+                          "end": {"line": 6, "column": 25},
+                          "source": "15m"
+                        },
+                        "values": [{"magnitude": 15, "unit": "m"}]
+                      }
+                    }
+                  },
+                  {
+                    "type": "Property",
+                    "location": {
+                      "start": {"line": 6, "column": 27},
+                      "end": {"line": 6, "column": 38},
+                      "source": "stop: now()"
+                    },
+                    "key": {
+                      "type": "Identifier",
+                      "location": {
+                        "start": {"line": 6, "column": 27},
+                        "end": {"line": 6, "column": 31},
+                        "source": "stop"
+                      },
+                      "name": "stop"
+                    },
+                    "value": {
+                      "type": "CallExpression",
+                      "location": {
+                        "start": {"line": 6, "column": 33},
+                        "end": {"line": 6, "column": 38},
+                        "source": "now()"
+                      },
+                      "callee": {
+                        "type": "Identifier",
+                        "location": {
+                          "start": {"line": 6, "column": 33},
+                          "end": {"line": 6, "column": 36},
+                          "source": "now"
+                        },
+                        "name": "now"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "when_to_inject": {
+    "type": "File",
+    "location": {
+      "start": {"line": 1, "column": 1},
+      "end": {"line": 5, "column": 40},
+      "source": "import \"influxdata/influxdb/sample\"\nv = {windowPeriod: 2444}\nsample.data(set: \"airSensor\")\n    |> range(start: -12h, stop: now())\n    |> yield(name: \"${v.windowPeriod}\")"
+    },
+    "metadata": "parser-type=rust",
+    "package": null,
+    "imports": [
+      {
+        "type": "ImportDeclaration",
+        "location": {
+          "start": {"line": 1, "column": 1},
+          "end": {"line": 1, "column": 36},
+          "source": "import \"influxdata/influxdb/sample\""
+        },
+        "as": null,
+        "path": {
+          "location": {
+            "start": {"line": 1, "column": 8},
+            "end": {"line": 1, "column": 36},
+            "source": "\"influxdata/influxdb/sample\""
+          },
+          "value": "influxdata/influxdb/sample"
+        }
+      }
+    ],
+    "body": [
+      {
+        "type": "VariableAssignment",
+        "location": {
+          "start": {"line": 2, "column": 1},
+          "end": {"line": 2, "column": 25},
+          "source": "v = {windowPeriod: 2444}"
+        },
+        "id": {
+          "location": {
+            "start": {"line": 2, "column": 1},
+            "end": {"line": 2, "column": 2},
+            "source": "v"
+          },
+          "name": "v"
+        },
+        "init": {
+          "type": "ObjectExpression",
+          "location": {
+            "start": {"line": 2, "column": 5},
+            "end": {"line": 2, "column": 25},
+            "source": "{windowPeriod: 2444}"
+          },
+          "properties": [
+            {
+              "type": "Property",
+              "location": {
+                "start": {"line": 2, "column": 6},
+                "end": {"line": 2, "column": 24},
+                "source": "windowPeriod: 2444"
+              },
+              "key": {
+                "type": "Identifier",
+                "location": {
+                  "start": {"line": 2, "column": 6},
+                  "end": {"line": 2, "column": 18},
+                  "source": "windowPeriod"
+                },
+                "name": "windowPeriod"
+              },
+              "value": {
+                "type": "IntegerLiteral",
+                "location": {
+                  "start": {"line": 2, "column": 20},
+                  "end": {"line": 2, "column": 24},
+                  "source": "2444"
+                },
+                "value": "2444"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "type": "ExpressionStatement",
+        "location": {
+          "start": {"line": 3, "column": 1},
+          "end": {"line": 5, "column": 40},
+          "source": "sample.data(set: \"airSensor\")\n    |> range(start: -12h, stop: now())\n    |> yield(name: \"${v.windowPeriod}\")"
+        },
+        "expression": {
+          "type": "PipeExpression",
+          "location": {
+            "start": {"line": 3, "column": 1},
+            "end": {"line": 5, "column": 40},
+            "source": "sample.data(set: \"airSensor\")\n    |> range(start: -12h, stop: now())\n    |> yield(name: \"${v.windowPeriod}\")"
+          },
+          "argument": {
+            "type": "PipeExpression",
+            "location": {
+              "start": {"line": 3, "column": 1},
+              "end": {"line": 4, "column": 39},
+              "source": "sample.data(set: \"airSensor\")\n    |> range(start: -12h, stop: now())"
+            },
+            "argument": {
+              "type": "CallExpression",
+              "location": {
+                "start": {"line": 3, "column": 1},
+                "end": {"line": 3, "column": 30},
+                "source": "sample.data(set: \"airSensor\")"
+              },
+              "callee": {
+                "type": "MemberExpression",
+                "location": {
+                  "start": {"line": 3, "column": 1},
+                  "end": {"line": 3, "column": 12},
+                  "source": "sample.data"
+                },
+                "object": {
+                  "type": "Identifier",
+                  "location": {
+                    "start": {"line": 3, "column": 1},
+                    "end": {"line": 3, "column": 7},
+                    "source": "sample"
+                  },
+                  "name": "sample"
+                },
+                "property": {
+                  "type": "Identifier",
+                  "location": {
+                    "start": {"line": 3, "column": 8},
+                    "end": {"line": 3, "column": 12},
+                    "source": "data"
+                  },
+                  "name": "data"
+                }
+              },
+              "arguments": [
+                {
+                  "type": "ObjectExpression",
+                  "location": {
+                    "start": {"line": 3, "column": 13},
+                    "end": {"line": 3, "column": 29},
+                    "source": "set: \"airSensor\""
+                  },
+                  "properties": [
+                    {
+                      "type": "Property",
+                      "location": {
+                        "start": {"line": 3, "column": 13},
+                        "end": {"line": 3, "column": 29},
+                        "source": "set: \"airSensor\""
+                      },
+                      "key": {
+                        "type": "Identifier",
+                        "location": {
+                          "start": {"line": 3, "column": 13},
+                          "end": {"line": 3, "column": 16},
+                          "source": "set"
+                        },
+                        "name": "set"
+                      },
+                      "value": {
+                        "type": "StringLiteral",
+                        "location": {
+                          "start": {"line": 3, "column": 18},
+                          "end": {"line": 3, "column": 29},
+                          "source": "\"airSensor\""
+                        },
+                        "value": "airSensor"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "call": {
+              "location": {
+                "start": {"line": 4, "column": 8},
+                "end": {"line": 4, "column": 39},
+                "source": "range(start: -12h, stop: now())"
+              },
+              "callee": {
+                "type": "Identifier",
+                "location": {
+                  "start": {"line": 4, "column": 8},
+                  "end": {"line": 4, "column": 13},
+                  "source": "range"
+                },
+                "name": "range"
+              },
+              "arguments": [
+                {
+                  "type": "ObjectExpression",
+                  "location": {
+                    "start": {"line": 4, "column": 14},
+                    "end": {"line": 4, "column": 38},
+                    "source": "start: -12h, stop: now()"
+                  },
+                  "properties": [
+                    {
+                      "type": "Property",
+                      "location": {
+                        "start": {"line": 4, "column": 14},
+                        "end": {"line": 4, "column": 25},
+                        "source": "start: -12h"
+                      },
+                      "key": {
+                        "type": "Identifier",
+                        "location": {
+                          "start": {"line": 4, "column": 14},
+                          "end": {"line": 4, "column": 19},
+                          "source": "start"
+                        },
+                        "name": "start"
+                      },
+                      "value": {
+                        "type": "UnaryExpression",
+                        "location": {
+                          "start": {"line": 4, "column": 21},
+                          "end": {"line": 4, "column": 25},
+                          "source": "-12h"
+                        },
+                        "operator": "-",
+                        "argument": {
+                          "type": "DurationLiteral",
+                          "location": {
+                            "start": {"line": 4, "column": 22},
+                            "end": {"line": 4, "column": 25},
+                            "source": "12h"
+                          },
+                          "values": [{"magnitude": 12, "unit": "h"}]
+                        }
+                      }
+                    },
+                    {
+                      "type": "Property",
+                      "location": {
+                        "start": {"line": 4, "column": 27},
+                        "end": {"line": 4, "column": 38},
+                        "source": "stop: now()"
+                      },
+                      "key": {
+                        "type": "Identifier",
+                        "location": {
+                          "start": {"line": 4, "column": 27},
+                          "end": {"line": 4, "column": 31},
+                          "source": "stop"
+                        },
+                        "name": "stop"
+                      },
+                      "value": {
+                        "type": "CallExpression",
+                        "location": {
+                          "start": {"line": 4, "column": 33},
+                          "end": {"line": 4, "column": 38},
+                          "source": "now()"
+                        },
+                        "callee": {
+                          "type": "Identifier",
+                          "location": {
+                            "start": {"line": 4, "column": 33},
+                            "end": {"line": 4, "column": 36},
+                            "source": "now"
+                          },
+                          "name": "now"
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "call": {
+            "location": {
+              "start": {"line": 5, "column": 8},
+              "end": {"line": 5, "column": 40},
+              "source": "yield(name: \"${v.windowPeriod}\")"
+            },
+            "callee": {
+              "type": "Identifier",
+              "location": {
+                "start": {"line": 5, "column": 8},
+                "end": {"line": 5, "column": 13},
+                "source": "yield"
+              },
+              "name": "yield"
+            },
+            "arguments": [
+              {
+                "type": "ObjectExpression",
+                "location": {
+                  "start": {"line": 5, "column": 14},
+                  "end": {"line": 5, "column": 39},
+                  "source": "name: \"${v.windowPeriod}\""
+                },
+                "properties": [
+                  {
+                    "type": "Property",
+                    "location": {
+                      "start": {"line": 5, "column": 14},
+                      "end": {"line": 5, "column": 39},
+                      "source": "name: \"${v.windowPeriod}\""
+                    },
+                    "key": {
+                      "type": "Identifier",
+                      "location": {
+                        "start": {"line": 5, "column": 14},
+                        "end": {"line": 5, "column": 18},
+                        "source": "name"
+                      },
+                      "name": "name"
+                    },
+                    "value": {
+                      "type": "StringExpression",
+                      "location": {
+                        "start": {"line": 5, "column": 20},
+                        "end": {"line": 5, "column": 39},
+                        "source": "\"${v.windowPeriod}\""
+                      },
+                      "parts": [
+                        {
+                          "type": "InterpolatedPart",
+                          "location": {
+                            "start": {"line": 5, "column": 21},
+                            "end": {"line": 5, "column": 38},
+                            "source": "${v.windowPeriod}"
+                          },
+                          "expression": {
+                            "type": "MemberExpression",
+                            "location": {
+                              "start": {"line": 5, "column": 23},
+                              "end": {"line": 5, "column": 37},
+                              "source": "v.windowPeriod"
+                            },
+                            "object": {
+                              "type": "Identifier",
+                              "location": {
+                                "start": {"line": 5, "column": 23},
+                                "end": {"line": 5, "column": 24},
+                                "source": "v"
+                              },
+                              "name": "v"
+                            },
+                            "property": {
+                              "type": "Identifier",
+                              "location": {
+                                "start": {"line": 5, "column": 25},
+                                "end": {"line": 5, "column": 37},
+                                "source": "windowPeriod"
+                              },
+                              "name": "windowPeriod"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "alias_range": {
+    "type": "File",
+    "location": {
+      "start": {"line": 1, "column": 1},
+      "end": {"line": 5, "column": 40},
+      "source": "import \"influxdata/influxdb/sample\"\nsplitPoint = -1m\nsample.data(set: \"airSensor\")\n    |> range(start: -12h, stop: splitPoint)\n    |> yield(name: \"${v.windowPeriod}\")"
+    },
+    "metadata": "parser-type=rust",
+    "package": null,
+    "imports": [
+      {
+        "type": "ImportDeclaration",
+        "location": {
+          "start": {"line": 1, "column": 1},
+          "end": {"line": 1, "column": 36},
+          "source": "import \"influxdata/influxdb/sample\""
+        },
+        "as": null,
+        "path": {
+          "location": {
+            "start": {"line": 1, "column": 8},
+            "end": {"line": 1, "column": 36},
+            "source": "\"influxdata/influxdb/sample\""
+          },
+          "value": "influxdata/influxdb/sample"
+        }
+      }
+    ],
+    "body": [
+      {
+        "type": "VariableAssignment",
+        "location": {
+          "start": {"line": 2, "column": 1},
+          "end": {"line": 2, "column": 17},
+          "source": "splitPoint = -1m"
+        },
+        "id": {
+          "location": {
+            "start": {"line": 2, "column": 1},
+            "end": {"line": 2, "column": 11},
+            "source": "splitPoint"
+          },
+          "name": "splitPoint"
+        },
+        "init": {
+          "type": "UnaryExpression",
+          "location": {
+            "start": {"line": 2, "column": 14},
+            "end": {"line": 2, "column": 17},
+            "source": "-1m"
+          },
+          "operator": "-",
+          "argument": {
+            "type": "DurationLiteral",
+            "location": {
+              "start": {"line": 2, "column": 15},
+              "end": {"line": 2, "column": 17},
+              "source": "1m"
+            },
+            "values": [{"magnitude": 1, "unit": "m"}]
+          }
+        }
+      },
+      {
+        "type": "ExpressionStatement",
+        "location": {
+          "start": {"line": 3, "column": 1},
+          "end": {"line": 5, "column": 40},
+          "source": "sample.data(set: \"airSensor\")\n    |> range(start: -12h, stop: splitPoint)\n    |> yield(name: \"${v.windowPeriod}\")"
+        },
+        "expression": {
+          "type": "PipeExpression",
+          "location": {
+            "start": {"line": 3, "column": 1},
+            "end": {"line": 5, "column": 40},
+            "source": "sample.data(set: \"airSensor\")\n    |> range(start: -12h, stop: splitPoint)\n    |> yield(name: \"${v.windowPeriod}\")"
+          },
+          "argument": {
+            "type": "PipeExpression",
+            "location": {
+              "start": {"line": 3, "column": 1},
+              "end": {"line": 4, "column": 44},
+              "source": "sample.data(set: \"airSensor\")\n    |> range(start: -12h, stop: splitPoint)"
+            },
+            "argument": {
+              "type": "CallExpression",
+              "location": {
+                "start": {"line": 3, "column": 1},
+                "end": {"line": 3, "column": 30},
+                "source": "sample.data(set: \"airSensor\")"
+              },
+              "callee": {
+                "type": "MemberExpression",
+                "location": {
+                  "start": {"line": 3, "column": 1},
+                  "end": {"line": 3, "column": 12},
+                  "source": "sample.data"
+                },
+                "object": {
+                  "type": "Identifier",
+                  "location": {
+                    "start": {"line": 3, "column": 1},
+                    "end": {"line": 3, "column": 7},
+                    "source": "sample"
+                  },
+                  "name": "sample"
+                },
+                "property": {
+                  "type": "Identifier",
+                  "location": {
+                    "start": {"line": 3, "column": 8},
+                    "end": {"line": 3, "column": 12},
+                    "source": "data"
+                  },
+                  "name": "data"
+                }
+              },
+              "arguments": [
+                {
+                  "type": "ObjectExpression",
+                  "location": {
+                    "start": {"line": 3, "column": 13},
+                    "end": {"line": 3, "column": 29},
+                    "source": "set: \"airSensor\""
+                  },
+                  "properties": [
+                    {
+                      "type": "Property",
+                      "location": {
+                        "start": {"line": 3, "column": 13},
+                        "end": {"line": 3, "column": 29},
+                        "source": "set: \"airSensor\""
+                      },
+                      "key": {
+                        "type": "Identifier",
+                        "location": {
+                          "start": {"line": 3, "column": 13},
+                          "end": {"line": 3, "column": 16},
+                          "source": "set"
+                        },
+                        "name": "set"
+                      },
+                      "value": {
+                        "type": "StringLiteral",
+                        "location": {
+                          "start": {"line": 3, "column": 18},
+                          "end": {"line": 3, "column": 29},
+                          "source": "\"airSensor\""
+                        },
+                        "value": "airSensor"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "call": {
+              "location": {
+                "start": {"line": 4, "column": 8},
+                "end": {"line": 4, "column": 44},
+                "source": "range(start: -12h, stop: splitPoint)"
+              },
+              "callee": {
+                "type": "Identifier",
+                "location": {
+                  "start": {"line": 4, "column": 8},
+                  "end": {"line": 4, "column": 13},
+                  "source": "range"
+                },
+                "name": "range"
+              },
+              "arguments": [
+                {
+                  "type": "ObjectExpression",
+                  "location": {
+                    "start": {"line": 4, "column": 14},
+                    "end": {"line": 4, "column": 43},
+                    "source": "start: -12h, stop: splitPoint"
+                  },
+                  "properties": [
+                    {
+                      "type": "Property",
+                      "location": {
+                        "start": {"line": 4, "column": 14},
+                        "end": {"line": 4, "column": 25},
+                        "source": "start: -12h"
+                      },
+                      "key": {
+                        "type": "Identifier",
+                        "location": {
+                          "start": {"line": 4, "column": 14},
+                          "end": {"line": 4, "column": 19},
+                          "source": "start"
+                        },
+                        "name": "start"
+                      },
+                      "value": {
+                        "type": "UnaryExpression",
+                        "location": {
+                          "start": {"line": 4, "column": 21},
+                          "end": {"line": 4, "column": 25},
+                          "source": "-12h"
+                        },
+                        "operator": "-",
+                        "argument": {
+                          "type": "DurationLiteral",
+                          "location": {
+                            "start": {"line": 4, "column": 22},
+                            "end": {"line": 4, "column": 25},
+                            "source": "12h"
+                          },
+                          "values": [{"magnitude": 12, "unit": "h"}]
+                        }
+                      }
+                    },
+                    {
+                      "type": "Property",
+                      "location": {
+                        "start": {"line": 4, "column": 27},
+                        "end": {"line": 4, "column": 43},
+                        "source": "stop: splitPoint"
+                      },
+                      "key": {
+                        "type": "Identifier",
+                        "location": {
+                          "start": {"line": 4, "column": 27},
+                          "end": {"line": 4, "column": 31},
+                          "source": "stop"
+                        },
+                        "name": "stop"
+                      },
+                      "value": {
+                        "type": "Identifier",
+                        "location": {
+                          "start": {"line": 4, "column": 33},
+                          "end": {"line": 4, "column": 43},
+                          "source": "splitPoint"
+                        },
+                        "name": "splitPoint"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "call": {
+            "location": {
+              "start": {"line": 5, "column": 8},
+              "end": {"line": 5, "column": 40},
+              "source": "yield(name: \"${v.windowPeriod}\")"
+            },
+            "callee": {
+              "type": "Identifier",
+              "location": {
+                "start": {"line": 5, "column": 8},
+                "end": {"line": 5, "column": 13},
+                "source": "yield"
+              },
+              "name": "yield"
+            },
+            "arguments": [
+              {
+                "type": "ObjectExpression",
+                "location": {
+                  "start": {"line": 5, "column": 14},
+                  "end": {"line": 5, "column": 39},
+                  "source": "name: \"${v.windowPeriod}\""
+                },
+                "properties": [
+                  {
+                    "type": "Property",
+                    "location": {
+                      "start": {"line": 5, "column": 14},
+                      "end": {"line": 5, "column": 39},
+                      "source": "name: \"${v.windowPeriod}\""
+                    },
+                    "key": {
+                      "type": "Identifier",
+                      "location": {
+                        "start": {"line": 5, "column": 14},
+                        "end": {"line": 5, "column": 18},
+                        "source": "name"
+                      },
+                      "name": "name"
+                    },
+                    "value": {
+                      "type": "StringExpression",
+                      "location": {
+                        "start": {"line": 5, "column": 20},
+                        "end": {"line": 5, "column": 39},
+                        "source": "\"${v.windowPeriod}\""
+                      },
+                      "parts": [
+                        {
+                          "type": "InterpolatedPart",
+                          "location": {
+                            "start": {"line": 5, "column": 21},
+                            "end": {"line": 5, "column": 38},
+                            "source": "${v.windowPeriod}"
+                          },
+                          "expression": {
+                            "type": "MemberExpression",
+                            "location": {
+                              "start": {"line": 5, "column": 23},
+                              "end": {"line": 5, "column": 37},
+                              "source": "v.windowPeriod"
+                            },
+                            "object": {
+                              "type": "Identifier",
+                              "location": {
+                                "start": {"line": 5, "column": 23},
+                                "end": {"line": 5, "column": 24},
+                                "source": "v"
+                              },
+                              "name": "v"
+                            },
+                            "property": {
+                              "type": "Identifier",
+                              "location": {
+                                "start": {"line": 5, "column": 25},
+                                "end": {"line": 5, "column": 37},
+                                "source": "windowPeriod"
+                              },
+                              "name": "windowPeriod"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "alias_range_variable": {
+    "type": "File",
+    "location": {
+      "start": {"line": 1, "column": 1},
+      "end": {"line": 6, "column": 40},
+      "source": "import \"influxdata/influxdb/sample\"\nsplitPoint = -1m\nv = {timeRangeStop: splitPoint}\nsample.data(set: \"airSensor\")\n    |> range(start: -12h, stop: v.timeRangeStop)\n    |> yield(name: \"${v.windowPeriod}\")"
+    },
+    "metadata": "parser-type=rust",
+    "package": null,
+    "imports": [
+      {
+        "type": "ImportDeclaration",
+        "location": {
+          "start": {"line": 1, "column": 1},
+          "end": {"line": 1, "column": 36},
+          "source": "import \"influxdata/influxdb/sample\""
+        },
+        "as": null,
+        "path": {
+          "location": {
+            "start": {"line": 1, "column": 8},
+            "end": {"line": 1, "column": 36},
+            "source": "\"influxdata/influxdb/sample\""
+          },
+          "value": "influxdata/influxdb/sample"
+        }
+      }
+    ],
+    "body": [
+      {
+        "type": "VariableAssignment",
+        "location": {
+          "start": {"line": 2, "column": 1},
+          "end": {"line": 2, "column": 17},
+          "source": "splitPoint = -1m"
+        },
+        "id": {
+          "location": {
+            "start": {"line": 2, "column": 1},
+            "end": {"line": 2, "column": 11},
+            "source": "splitPoint"
+          },
+          "name": "splitPoint"
+        },
+        "init": {
+          "type": "UnaryExpression",
+          "location": {
+            "start": {"line": 2, "column": 14},
+            "end": {"line": 2, "column": 17},
+            "source": "-1m"
+          },
+          "operator": "-",
+          "argument": {
+            "type": "DurationLiteral",
+            "location": {
+              "start": {"line": 2, "column": 15},
+              "end": {"line": 2, "column": 17},
+              "source": "1m"
+            },
+            "values": [{"magnitude": 1, "unit": "m"}]
+          }
+        }
+      },
+      {
+        "type": "VariableAssignment",
+        "location": {
+          "start": {"line": 3, "column": 1},
+          "end": {"line": 3, "column": 32},
+          "source": "v = {timeRangeStop: splitPoint}"
+        },
+        "id": {
+          "location": {
+            "start": {"line": 3, "column": 1},
+            "end": {"line": 3, "column": 2},
+            "source": "v"
+          },
+          "name": "v"
+        },
+        "init": {
+          "type": "ObjectExpression",
+          "location": {
+            "start": {"line": 3, "column": 5},
+            "end": {"line": 3, "column": 32},
+            "source": "{timeRangeStop: splitPoint}"
+          },
+          "properties": [
+            {
+              "type": "Property",
+              "location": {
+                "start": {"line": 3, "column": 6},
+                "end": {"line": 3, "column": 31},
+                "source": "timeRangeStop: splitPoint"
+              },
+              "key": {
+                "type": "Identifier",
+                "location": {
+                  "start": {"line": 3, "column": 6},
+                  "end": {"line": 3, "column": 19},
+                  "source": "timeRangeStop"
+                },
+                "name": "timeRangeStop"
+              },
+              "value": {
+                "type": "Identifier",
+                "location": {
+                  "start": {"line": 3, "column": 21},
+                  "end": {"line": 3, "column": 31},
+                  "source": "splitPoint"
+                },
+                "name": "splitPoint"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "type": "ExpressionStatement",
+        "location": {
+          "start": {"line": 4, "column": 1},
+          "end": {"line": 6, "column": 40},
+          "source": "sample.data(set: \"airSensor\")\n    |> range(start: -12h, stop: v.timeRangeStop)\n    |> yield(name: \"${v.windowPeriod}\")"
+        },
+        "expression": {
+          "type": "PipeExpression",
+          "location": {
+            "start": {"line": 4, "column": 1},
+            "end": {"line": 6, "column": 40},
+            "source": "sample.data(set: \"airSensor\")\n    |> range(start: -12h, stop: v.timeRangeStop)\n    |> yield(name: \"${v.windowPeriod}\")"
+          },
+          "argument": {
+            "type": "PipeExpression",
+            "location": {
+              "start": {"line": 4, "column": 1},
+              "end": {"line": 5, "column": 49},
+              "source": "sample.data(set: \"airSensor\")\n    |> range(start: -12h, stop: v.timeRangeStop)"
+            },
+            "argument": {
+              "type": "CallExpression",
+              "location": {
+                "start": {"line": 4, "column": 1},
+                "end": {"line": 4, "column": 30},
+                "source": "sample.data(set: \"airSensor\")"
+              },
+              "callee": {
+                "type": "MemberExpression",
+                "location": {
+                  "start": {"line": 4, "column": 1},
+                  "end": {"line": 4, "column": 12},
+                  "source": "sample.data"
+                },
+                "object": {
+                  "type": "Identifier",
+                  "location": {
+                    "start": {"line": 4, "column": 1},
+                    "end": {"line": 4, "column": 7},
+                    "source": "sample"
+                  },
+                  "name": "sample"
+                },
+                "property": {
+                  "type": "Identifier",
+                  "location": {
+                    "start": {"line": 4, "column": 8},
+                    "end": {"line": 4, "column": 12},
+                    "source": "data"
+                  },
+                  "name": "data"
+                }
+              },
+              "arguments": [
+                {
+                  "type": "ObjectExpression",
+                  "location": {
+                    "start": {"line": 4, "column": 13},
+                    "end": {"line": 4, "column": 29},
+                    "source": "set: \"airSensor\""
+                  },
+                  "properties": [
+                    {
+                      "type": "Property",
+                      "location": {
+                        "start": {"line": 4, "column": 13},
+                        "end": {"line": 4, "column": 29},
+                        "source": "set: \"airSensor\""
+                      },
+                      "key": {
+                        "type": "Identifier",
+                        "location": {
+                          "start": {"line": 4, "column": 13},
+                          "end": {"line": 4, "column": 16},
+                          "source": "set"
+                        },
+                        "name": "set"
+                      },
+                      "value": {
+                        "type": "StringLiteral",
+                        "location": {
+                          "start": {"line": 4, "column": 18},
+                          "end": {"line": 4, "column": 29},
+                          "source": "\"airSensor\""
+                        },
+                        "value": "airSensor"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "call": {
+              "location": {
+                "start": {"line": 5, "column": 8},
+                "end": {"line": 5, "column": 49},
+                "source": "range(start: -12h, stop: v.timeRangeStop)"
+              },
+              "callee": {
+                "type": "Identifier",
+                "location": {
+                  "start": {"line": 5, "column": 8},
+                  "end": {"line": 5, "column": 13},
+                  "source": "range"
+                },
+                "name": "range"
+              },
+              "arguments": [
+                {
+                  "type": "ObjectExpression",
+                  "location": {
+                    "start": {"line": 5, "column": 14},
+                    "end": {"line": 5, "column": 48},
+                    "source": "start: -12h, stop: v.timeRangeStop"
+                  },
+                  "properties": [
+                    {
+                      "type": "Property",
+                      "location": {
+                        "start": {"line": 5, "column": 14},
+                        "end": {"line": 5, "column": 25},
+                        "source": "start: -12h"
+                      },
+                      "key": {
+                        "type": "Identifier",
+                        "location": {
+                          "start": {"line": 5, "column": 14},
+                          "end": {"line": 5, "column": 19},
+                          "source": "start"
+                        },
+                        "name": "start"
+                      },
+                      "value": {
+                        "type": "UnaryExpression",
+                        "location": {
+                          "start": {"line": 5, "column": 21},
+                          "end": {"line": 5, "column": 25},
+                          "source": "-12h"
+                        },
+                        "operator": "-",
+                        "argument": {
+                          "type": "DurationLiteral",
+                          "location": {
+                            "start": {"line": 5, "column": 22},
+                            "end": {"line": 5, "column": 25},
+                            "source": "12h"
+                          },
+                          "values": [{"magnitude": 12, "unit": "h"}]
+                        }
+                      }
+                    },
+                    {
+                      "type": "Property",
+                      "location": {
+                        "start": {"line": 5, "column": 27},
+                        "end": {"line": 5, "column": 48},
+                        "source": "stop: v.timeRangeStop"
+                      },
+                      "key": {
+                        "type": "Identifier",
+                        "location": {
+                          "start": {"line": 5, "column": 27},
+                          "end": {"line": 5, "column": 31},
+                          "source": "stop"
+                        },
+                        "name": "stop"
+                      },
+                      "value": {
+                        "type": "MemberExpression",
+                        "location": {
+                          "start": {"line": 5, "column": 33},
+                          "end": {"line": 5, "column": 48},
+                          "source": "v.timeRangeStop"
+                        },
+                        "object": {
+                          "type": "Identifier",
+                          "location": {
+                            "start": {"line": 5, "column": 33},
+                            "end": {"line": 5, "column": 34},
+                            "source": "v"
+                          },
+                          "name": "v"
+                        },
+                        "property": {
+                          "type": "Identifier",
+                          "location": {
+                            "start": {"line": 5, "column": 35},
+                            "end": {"line": 5, "column": 48},
+                            "source": "timeRangeStop"
+                          },
+                          "name": "timeRangeStop"
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "call": {
+            "location": {
+              "start": {"line": 6, "column": 8},
+              "end": {"line": 6, "column": 40},
+              "source": "yield(name: \"${v.windowPeriod}\")"
+            },
+            "callee": {
+              "type": "Identifier",
+              "location": {
+                "start": {"line": 6, "column": 8},
+                "end": {"line": 6, "column": 13},
+                "source": "yield"
+              },
+              "name": "yield"
+            },
+            "arguments": [
+              {
+                "type": "ObjectExpression",
+                "location": {
+                  "start": {"line": 6, "column": 14},
+                  "end": {"line": 6, "column": 39},
+                  "source": "name: \"${v.windowPeriod}\""
+                },
+                "properties": [
+                  {
+                    "type": "Property",
+                    "location": {
+                      "start": {"line": 6, "column": 14},
+                      "end": {"line": 6, "column": 39},
+                      "source": "name: \"${v.windowPeriod}\""
+                    },
+                    "key": {
+                      "type": "Identifier",
+                      "location": {
+                        "start": {"line": 6, "column": 14},
+                        "end": {"line": 6, "column": 18},
+                        "source": "name"
+                      },
+                      "name": "name"
+                    },
+                    "value": {
+                      "type": "StringExpression",
+                      "location": {
+                        "start": {"line": 6, "column": 20},
+                        "end": {"line": 6, "column": 39},
+                        "source": "\"${v.windowPeriod}\""
+                      },
+                      "parts": [
+                        {
+                          "type": "InterpolatedPart",
+                          "location": {
+                            "start": {"line": 6, "column": 21},
+                            "end": {"line": 6, "column": 38},
+                            "source": "${v.windowPeriod}"
+                          },
+                          "expression": {
+                            "type": "MemberExpression",
+                            "location": {
+                              "start": {"line": 6, "column": 23},
+                              "end": {"line": 6, "column": 37},
+                              "source": "v.windowPeriod"
+                            },
+                            "object": {
+                              "type": "Identifier",
+                              "location": {
+                                "start": {"line": 6, "column": 23},
+                                "end": {"line": 6, "column": 24},
+                                "source": "v"
+                              },
+                              "name": "v"
+                            },
+                            "property": {
+                              "type": "Identifier",
+                              "location": {
+                                "start": {"line": 6, "column": 25},
+                                "end": {"line": 6, "column": 37},
+                                "source": "windowPeriod"
+                              },
+                              "name": "windowPeriod"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "alias_window_variable": {
+    "type": "File",
+    "location": {
+      "start": {"line": 1, "column": 1},
+      "end": {"line": 6, "column": 40},
+      "source": "import \"array\"\nimport \"influxdata/influxdb/sample\"\nsplit = 2444\nchunk = split\nv = {windowPeriod: chunk}\narray.from(rows: [{x: v.windowPeriod}])"
+    },
+    "metadata": "parser-type=rust",
+    "package": null,
+    "imports": [
+      {
+        "type": "ImportDeclaration",
+        "location": {
+          "start": {"line": 1, "column": 1},
+          "end": {"line": 1, "column": 15},
+          "source": "import \"array\""
+        },
+        "as": null,
+        "path": {
+          "location": {
+            "start": {"line": 1, "column": 8},
+            "end": {"line": 1, "column": 15},
+            "source": "\"array\""
+          },
+          "value": "array"
+        }
+      },
+      {
+        "type": "ImportDeclaration",
+        "location": {
+          "start": {"line": 2, "column": 1},
+          "end": {"line": 2, "column": 36},
+          "source": "import \"influxdata/influxdb/sample\""
+        },
+        "as": null,
+        "path": {
+          "location": {
+            "start": {"line": 2, "column": 8},
+            "end": {"line": 2, "column": 36},
+            "source": "\"influxdata/influxdb/sample\""
+          },
+          "value": "influxdata/influxdb/sample"
+        }
+      }
+    ],
+    "body": [
+      {
+        "type": "VariableAssignment",
+        "location": {
+          "start": {"line": 3, "column": 1},
+          "end": {"line": 3, "column": 13},
+          "source": "split = 2444"
+        },
+        "id": {
+          "location": {
+            "start": {"line": 3, "column": 1},
+            "end": {"line": 3, "column": 6},
+            "source": "split"
+          },
+          "name": "split"
+        },
+        "init": {
+          "type": "IntegerLiteral",
+          "location": {
+            "start": {"line": 3, "column": 9},
+            "end": {"line": 3, "column": 13},
+            "source": "2444"
+          },
+          "value": "2444"
+        }
+      },
+      {
+        "type": "VariableAssignment",
+        "location": {
+          "start": {"line": 4, "column": 1},
+          "end": {"line": 4, "column": 14},
+          "source": "chunk = split"
+        },
+        "id": {
+          "location": {
+            "start": {"line": 4, "column": 1},
+            "end": {"line": 4, "column": 6},
+            "source": "chunk"
+          },
+          "name": "chunk"
+        },
+        "init": {
+          "type": "Identifier",
+          "location": {
+            "start": {"line": 4, "column": 9},
+            "end": {"line": 4, "column": 14},
+            "source": "split"
+          },
+          "name": "split"
+        }
+      },
+      {
+        "type": "VariableAssignment",
+        "location": {
+          "start": {"line": 5, "column": 1},
+          "end": {"line": 5, "column": 26},
+          "source": "v = {windowPeriod: chunk}"
+        },
+        "id": {
+          "location": {
+            "start": {"line": 5, "column": 1},
+            "end": {"line": 5, "column": 2},
+            "source": "v"
+          },
+          "name": "v"
+        },
+        "init": {
+          "type": "ObjectExpression",
+          "location": {
+            "start": {"line": 5, "column": 5},
+            "end": {"line": 5, "column": 26},
+            "source": "{windowPeriod: chunk}"
+          },
+          "properties": [
+            {
+              "type": "Property",
+              "location": {
+                "start": {"line": 5, "column": 6},
+                "end": {"line": 5, "column": 25},
+                "source": "windowPeriod: chunk"
+              },
+              "key": {
+                "type": "Identifier",
+                "location": {
+                  "start": {"line": 5, "column": 6},
+                  "end": {"line": 5, "column": 18},
+                  "source": "windowPeriod"
+                },
+                "name": "windowPeriod"
+              },
+              "value": {
+                "type": "Identifier",
+                "location": {
+                  "start": {"line": 5, "column": 20},
+                  "end": {"line": 5, "column": 25},
+                  "source": "chunk"
+                },
+                "name": "chunk"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "type": "ExpressionStatement",
+        "location": {
+          "start": {"line": 6, "column": 1},
+          "end": {"line": 6, "column": 40},
+          "source": "array.from(rows: [{x: v.windowPeriod}])"
+        },
+        "expression": {
+          "type": "CallExpression",
+          "location": {
+            "start": {"line": 6, "column": 1},
+            "end": {"line": 6, "column": 40},
+            "source": "array.from(rows: [{x: v.windowPeriod}])"
+          },
+          "callee": {
+            "type": "MemberExpression",
+            "location": {
+              "start": {"line": 6, "column": 1},
+              "end": {"line": 6, "column": 11},
+              "source": "array.from"
+            },
+            "object": {
+              "type": "Identifier",
+              "location": {
+                "start": {"line": 6, "column": 1},
+                "end": {"line": 6, "column": 6},
+                "source": "array"
+              },
+              "name": "array"
+            },
+            "property": {
+              "type": "Identifier",
+              "location": {
+                "start": {"line": 6, "column": 7},
+                "end": {"line": 6, "column": 11},
+                "source": "from"
+              },
+              "name": "from"
+            }
+          },
+          "arguments": [
+            {
+              "type": "ObjectExpression",
+              "location": {
+                "start": {"line": 6, "column": 12},
+                "end": {"line": 6, "column": 39},
+                "source": "rows: [{x: v.windowPeriod}]"
+              },
+              "properties": [
+                {
+                  "type": "Property",
+                  "location": {
+                    "start": {"line": 6, "column": 12},
+                    "end": {"line": 6, "column": 39},
+                    "source": "rows: [{x: v.windowPeriod}]"
+                  },
+                  "key": {
+                    "type": "Identifier",
+                    "location": {
+                      "start": {"line": 6, "column": 12},
+                      "end": {"line": 6, "column": 16},
+                      "source": "rows"
+                    },
+                    "name": "rows"
+                  },
+                  "value": {
+                    "type": "ArrayExpression",
+                    "location": {
+                      "start": {"line": 6, "column": 18},
+                      "end": {"line": 6, "column": 39},
+                      "source": "[{x: v.windowPeriod}]"
+                    },
+                    "elements": [
+                      {
+                        "type": "ObjectExpression",
+                        "location": {
+                          "start": {"line": 6, "column": 19},
+                          "end": {"line": 6, "column": 38},
+                          "source": "{x: v.windowPeriod}"
+                        },
+                        "properties": [
+                          {
+                            "type": "Property",
+                            "location": {
+                              "start": {"line": 6, "column": 20},
+                              "end": {"line": 6, "column": 37},
+                              "source": "x: v.windowPeriod"
+                            },
+                            "key": {
+                              "type": "Identifier",
+                              "location": {
+                                "start": {"line": 6, "column": 20},
+                                "end": {"line": 6, "column": 21},
+                                "source": "x"
+                              },
+                              "name": "x"
+                            },
+                            "value": {
+                              "type": "MemberExpression",
+                              "location": {
+                                "start": {"line": 6, "column": 23},
+                                "end": {"line": 6, "column": 37},
+                                "source": "v.windowPeriod"
+                              },
+                              "object": {
+                                "type": "Identifier",
+                                "location": {
+                                  "start": {"line": 6, "column": 23},
+                                  "end": {"line": 6, "column": 24},
+                                  "source": "v"
+                                },
+                                "name": "v"
+                              },
+                              "property": {
+                                "type": "Identifier",
+                                "location": {
+                                  "start": {"line": 6, "column": 25},
+                                  "end": {"line": 6, "column": 37},
+                                  "source": "windowPeriod"
+                                },
+                                "name": "windowPeriod"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/src/shared/utils/windowPeriod/ast_fixtures.json
+++ b/src/shared/utils/windowPeriod/ast_fixtures.json
@@ -5121,5 +5121,1017 @@
         }
       }
     ]
+  },
+  "variable_bound_function": {
+    "type": "File",
+    "location": {
+      "start": {"line": 1, "column": 1},
+      "end": {"line": 13, "column": 6},
+      "source": "RAW = () => {\n    from(bucket: \"sample_data\")\n    |> range(start: -12h, stop: now())\n    |> filter(fn: (r) => r[\"_measurement\"] == \"airSensors\")\n    |> filter(fn: (r) => r[\"_field\"] == \"co\")\n    |> group()\n    |> sort(columns:[\"_time\"])\n    |> aggregateWindow(fn: mean, every:v.windowPeriod)\n    |> drop(columns:[\"_measurement\",\"_field\",\"_start\",\"_stop\"])\n    |> yield(name:\"raw ${v.windowPeriod}\")\n    return true\n}\nRAW()"
+    },
+    "metadata": "parser-type=rust",
+    "package": null,
+    "imports": [],
+    "body": [
+      {
+        "type": "VariableAssignment",
+        "location": {
+          "start": {"line": 1, "column": 1},
+          "end": {"line": 12, "column": 2},
+          "source": "RAW = () => {\n    from(bucket: \"sample_data\")\n    |> range(start: -12h, stop: now())\n    |> filter(fn: (r) => r[\"_measurement\"] == \"airSensors\")\n    |> filter(fn: (r) => r[\"_field\"] == \"co\")\n    |> group()\n    |> sort(columns:[\"_time\"])\n    |> aggregateWindow(fn: mean, every:v.windowPeriod)\n    |> drop(columns:[\"_measurement\",\"_field\",\"_start\",\"_stop\"])\n    |> yield(name:\"raw ${v.windowPeriod}\")\n    return true\n}"
+        },
+        "id": {
+          "location": {
+            "start": {"line": 1, "column": 1},
+            "end": {"line": 1, "column": 4},
+            "source": "RAW"
+          },
+          "name": "RAW"
+        },
+        "init": {
+          "type": "FunctionExpression",
+          "location": {
+            "start": {"line": 1, "column": 7},
+            "end": {"line": 12, "column": 2},
+            "source": "() => {\n    from(bucket: \"sample_data\")\n    |> range(start: -12h, stop: now())\n    |> filter(fn: (r) => r[\"_measurement\"] == \"airSensors\")\n    |> filter(fn: (r) => r[\"_field\"] == \"co\")\n    |> group()\n    |> sort(columns:[\"_time\"])\n    |> aggregateWindow(fn: mean, every:v.windowPeriod)\n    |> drop(columns:[\"_measurement\",\"_field\",\"_start\",\"_stop\"])\n    |> yield(name:\"raw ${v.windowPeriod}\")\n    return true\n}"
+          },
+          "params": [],
+          "body": {
+            "type": "Block",
+            "location": {
+              "start": {"line": 1, "column": 13},
+              "end": {"line": 12, "column": 2},
+              "source": "{\n    from(bucket: \"sample_data\")\n    |> range(start: -12h, stop: now())\n    |> filter(fn: (r) => r[\"_measurement\"] == \"airSensors\")\n    |> filter(fn: (r) => r[\"_field\"] == \"co\")\n    |> group()\n    |> sort(columns:[\"_time\"])\n    |> aggregateWindow(fn: mean, every:v.windowPeriod)\n    |> drop(columns:[\"_measurement\",\"_field\",\"_start\",\"_stop\"])\n    |> yield(name:\"raw ${v.windowPeriod}\")\n    return true\n}"
+            },
+            "body": [
+              {
+                "type": "ExpressionStatement",
+                "location": {
+                  "start": {"line": 2, "column": 5},
+                  "end": {"line": 10, "column": 43},
+                  "source": "from(bucket: \"sample_data\")\n    |> range(start: -12h, stop: now())\n    |> filter(fn: (r) => r[\"_measurement\"] == \"airSensors\")\n    |> filter(fn: (r) => r[\"_field\"] == \"co\")\n    |> group()\n    |> sort(columns:[\"_time\"])\n    |> aggregateWindow(fn: mean, every:v.windowPeriod)\n    |> drop(columns:[\"_measurement\",\"_field\",\"_start\",\"_stop\"])\n    |> yield(name:\"raw ${v.windowPeriod}\")"
+                },
+                "expression": {
+                  "type": "PipeExpression",
+                  "location": {
+                    "start": {"line": 2, "column": 5},
+                    "end": {"line": 10, "column": 43},
+                    "source": "from(bucket: \"sample_data\")\n    |> range(start: -12h, stop: now())\n    |> filter(fn: (r) => r[\"_measurement\"] == \"airSensors\")\n    |> filter(fn: (r) => r[\"_field\"] == \"co\")\n    |> group()\n    |> sort(columns:[\"_time\"])\n    |> aggregateWindow(fn: mean, every:v.windowPeriod)\n    |> drop(columns:[\"_measurement\",\"_field\",\"_start\",\"_stop\"])\n    |> yield(name:\"raw ${v.windowPeriod}\")"
+                  },
+                  "argument": {
+                    "type": "PipeExpression",
+                    "location": {
+                      "start": {"line": 2, "column": 5},
+                      "end": {"line": 9, "column": 64},
+                      "source": "from(bucket: \"sample_data\")\n    |> range(start: -12h, stop: now())\n    |> filter(fn: (r) => r[\"_measurement\"] == \"airSensors\")\n    |> filter(fn: (r) => r[\"_field\"] == \"co\")\n    |> group()\n    |> sort(columns:[\"_time\"])\n    |> aggregateWindow(fn: mean, every:v.windowPeriod)\n    |> drop(columns:[\"_measurement\",\"_field\",\"_start\",\"_stop\"])"
+                    },
+                    "argument": {
+                      "type": "PipeExpression",
+                      "location": {
+                        "start": {"line": 2, "column": 5},
+                        "end": {"line": 8, "column": 55},
+                        "source": "from(bucket: \"sample_data\")\n    |> range(start: -12h, stop: now())\n    |> filter(fn: (r) => r[\"_measurement\"] == \"airSensors\")\n    |> filter(fn: (r) => r[\"_field\"] == \"co\")\n    |> group()\n    |> sort(columns:[\"_time\"])\n    |> aggregateWindow(fn: mean, every:v.windowPeriod)"
+                      },
+                      "argument": {
+                        "type": "PipeExpression",
+                        "location": {
+                          "start": {"line": 2, "column": 5},
+                          "end": {"line": 7, "column": 31},
+                          "source": "from(bucket: \"sample_data\")\n    |> range(start: -12h, stop: now())\n    |> filter(fn: (r) => r[\"_measurement\"] == \"airSensors\")\n    |> filter(fn: (r) => r[\"_field\"] == \"co\")\n    |> group()\n    |> sort(columns:[\"_time\"])"
+                        },
+                        "argument": {
+                          "type": "PipeExpression",
+                          "location": {
+                            "start": {"line": 2, "column": 5},
+                            "end": {"line": 6, "column": 15},
+                            "source": "from(bucket: \"sample_data\")\n    |> range(start: -12h, stop: now())\n    |> filter(fn: (r) => r[\"_measurement\"] == \"airSensors\")\n    |> filter(fn: (r) => r[\"_field\"] == \"co\")\n    |> group()"
+                          },
+                          "argument": {
+                            "type": "PipeExpression",
+                            "location": {
+                              "start": {"line": 2, "column": 5},
+                              "end": {"line": 5, "column": 46},
+                              "source": "from(bucket: \"sample_data\")\n    |> range(start: -12h, stop: now())\n    |> filter(fn: (r) => r[\"_measurement\"] == \"airSensors\")\n    |> filter(fn: (r) => r[\"_field\"] == \"co\")"
+                            },
+                            "argument": {
+                              "type": "PipeExpression",
+                              "location": {
+                                "start": {"line": 2, "column": 5},
+                                "end": {"line": 4, "column": 60},
+                                "source": "from(bucket: \"sample_data\")\n    |> range(start: -12h, stop: now())\n    |> filter(fn: (r) => r[\"_measurement\"] == \"airSensors\")"
+                              },
+                              "argument": {
+                                "type": "PipeExpression",
+                                "location": {
+                                  "start": {"line": 2, "column": 5},
+                                  "end": {"line": 3, "column": 39},
+                                  "source": "from(bucket: \"sample_data\")\n    |> range(start: -12h, stop: now())"
+                                },
+                                "argument": {
+                                  "type": "CallExpression",
+                                  "location": {
+                                    "start": {"line": 2, "column": 5},
+                                    "end": {"line": 2, "column": 32},
+                                    "source": "from(bucket: \"sample_data\")"
+                                  },
+                                  "callee": {
+                                    "type": "Identifier",
+                                    "location": {
+                                      "start": {"line": 2, "column": 5},
+                                      "end": {"line": 2, "column": 9},
+                                      "source": "from"
+                                    },
+                                    "name": "from"
+                                  },
+                                  "arguments": [
+                                    {
+                                      "type": "ObjectExpression",
+                                      "location": {
+                                        "start": {"line": 2, "column": 10},
+                                        "end": {"line": 2, "column": 31},
+                                        "source": "bucket: \"sample_data\""
+                                      },
+                                      "properties": [
+                                        {
+                                          "type": "Property",
+                                          "location": {
+                                            "start": {"line": 2, "column": 10},
+                                            "end": {"line": 2, "column": 31},
+                                            "source": "bucket: \"sample_data\""
+                                          },
+                                          "key": {
+                                            "type": "Identifier",
+                                            "location": {
+                                              "start": {
+                                                "line": 2,
+                                                "column": 10
+                                              },
+                                              "end": {"line": 2, "column": 16},
+                                              "source": "bucket"
+                                            },
+                                            "name": "bucket"
+                                          },
+                                          "value": {
+                                            "type": "StringLiteral",
+                                            "location": {
+                                              "start": {
+                                                "line": 2,
+                                                "column": 18
+                                              },
+                                              "end": {"line": 2, "column": 31},
+                                              "source": "\"sample_data\""
+                                            },
+                                            "value": "sample_data"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                "call": {
+                                  "location": {
+                                    "start": {"line": 3, "column": 8},
+                                    "end": {"line": 3, "column": 39},
+                                    "source": "range(start: -12h, stop: now())"
+                                  },
+                                  "callee": {
+                                    "type": "Identifier",
+                                    "location": {
+                                      "start": {"line": 3, "column": 8},
+                                      "end": {"line": 3, "column": 13},
+                                      "source": "range"
+                                    },
+                                    "name": "range"
+                                  },
+                                  "arguments": [
+                                    {
+                                      "type": "ObjectExpression",
+                                      "location": {
+                                        "start": {"line": 3, "column": 14},
+                                        "end": {"line": 3, "column": 38},
+                                        "source": "start: -12h, stop: now()"
+                                      },
+                                      "properties": [
+                                        {
+                                          "type": "Property",
+                                          "location": {
+                                            "start": {"line": 3, "column": 14},
+                                            "end": {"line": 3, "column": 25},
+                                            "source": "start: -12h"
+                                          },
+                                          "key": {
+                                            "type": "Identifier",
+                                            "location": {
+                                              "start": {
+                                                "line": 3,
+                                                "column": 14
+                                              },
+                                              "end": {"line": 3, "column": 19},
+                                              "source": "start"
+                                            },
+                                            "name": "start"
+                                          },
+                                          "value": {
+                                            "type": "UnaryExpression",
+                                            "location": {
+                                              "start": {
+                                                "line": 3,
+                                                "column": 21
+                                              },
+                                              "end": {"line": 3, "column": 25},
+                                              "source": "-12h"
+                                            },
+                                            "operator": "-",
+                                            "argument": {
+                                              "type": "DurationLiteral",
+                                              "location": {
+                                                "start": {
+                                                  "line": 3,
+                                                  "column": 22
+                                                },
+                                                "end": {
+                                                  "line": 3,
+                                                  "column": 25
+                                                },
+                                                "source": "12h"
+                                              },
+                                              "values": [
+                                                {"magnitude": 12, "unit": "h"}
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "type": "Property",
+                                          "location": {
+                                            "start": {"line": 3, "column": 27},
+                                            "end": {"line": 3, "column": 38},
+                                            "source": "stop: now()"
+                                          },
+                                          "key": {
+                                            "type": "Identifier",
+                                            "location": {
+                                              "start": {
+                                                "line": 3,
+                                                "column": 27
+                                              },
+                                              "end": {"line": 3, "column": 31},
+                                              "source": "stop"
+                                            },
+                                            "name": "stop"
+                                          },
+                                          "value": {
+                                            "type": "CallExpression",
+                                            "location": {
+                                              "start": {
+                                                "line": 3,
+                                                "column": 33
+                                              },
+                                              "end": {"line": 3, "column": 38},
+                                              "source": "now()"
+                                            },
+                                            "callee": {
+                                              "type": "Identifier",
+                                              "location": {
+                                                "start": {
+                                                  "line": 3,
+                                                  "column": 33
+                                                },
+                                                "end": {
+                                                  "line": 3,
+                                                  "column": 36
+                                                },
+                                                "source": "now"
+                                              },
+                                              "name": "now"
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              },
+                              "call": {
+                                "location": {
+                                  "start": {"line": 4, "column": 8},
+                                  "end": {"line": 4, "column": 60},
+                                  "source": "filter(fn: (r) => r[\"_measurement\"] == \"airSensors\")"
+                                },
+                                "callee": {
+                                  "type": "Identifier",
+                                  "location": {
+                                    "start": {"line": 4, "column": 8},
+                                    "end": {"line": 4, "column": 14},
+                                    "source": "filter"
+                                  },
+                                  "name": "filter"
+                                },
+                                "arguments": [
+                                  {
+                                    "type": "ObjectExpression",
+                                    "location": {
+                                      "start": {"line": 4, "column": 15},
+                                      "end": {"line": 4, "column": 59},
+                                      "source": "fn: (r) => r[\"_measurement\"] == \"airSensors\""
+                                    },
+                                    "properties": [
+                                      {
+                                        "type": "Property",
+                                        "location": {
+                                          "start": {"line": 4, "column": 15},
+                                          "end": {"line": 4, "column": 59},
+                                          "source": "fn: (r) => r[\"_measurement\"] == \"airSensors\""
+                                        },
+                                        "key": {
+                                          "type": "Identifier",
+                                          "location": {
+                                            "start": {"line": 4, "column": 15},
+                                            "end": {"line": 4, "column": 17},
+                                            "source": "fn"
+                                          },
+                                          "name": "fn"
+                                        },
+                                        "value": {
+                                          "type": "FunctionExpression",
+                                          "location": {
+                                            "start": {"line": 4, "column": 19},
+                                            "end": {"line": 4, "column": 59},
+                                            "source": "(r) => r[\"_measurement\"] == \"airSensors\""
+                                          },
+                                          "params": [
+                                            {
+                                              "type": "Property",
+                                              "location": {
+                                                "start": {
+                                                  "line": 4,
+                                                  "column": 20
+                                                },
+                                                "end": {
+                                                  "line": 4,
+                                                  "column": 21
+                                                },
+                                                "source": "r"
+                                              },
+                                              "key": {
+                                                "type": "Identifier",
+                                                "location": {
+                                                  "start": {
+                                                    "line": 4,
+                                                    "column": 20
+                                                  },
+                                                  "end": {
+                                                    "line": 4,
+                                                    "column": 21
+                                                  },
+                                                  "source": "r"
+                                                },
+                                                "name": "r"
+                                              },
+                                              "value": null
+                                            }
+                                          ],
+                                          "body": {
+                                            "type": "BinaryExpression",
+                                            "location": {
+                                              "start": {
+                                                "line": 4,
+                                                "column": 26
+                                              },
+                                              "end": {"line": 4, "column": 59},
+                                              "source": "r[\"_measurement\"] == \"airSensors\""
+                                            },
+                                            "operator": "==",
+                                            "left": {
+                                              "type": "MemberExpression",
+                                              "location": {
+                                                "start": {
+                                                  "line": 4,
+                                                  "column": 26
+                                                },
+                                                "end": {
+                                                  "line": 4,
+                                                  "column": 43
+                                                },
+                                                "source": "r[\"_measurement\"]"
+                                              },
+                                              "object": {
+                                                "type": "Identifier",
+                                                "location": {
+                                                  "start": {
+                                                    "line": 4,
+                                                    "column": 26
+                                                  },
+                                                  "end": {
+                                                    "line": 4,
+                                                    "column": 27
+                                                  },
+                                                  "source": "r"
+                                                },
+                                                "name": "r"
+                                              },
+                                              "property": {
+                                                "type": "StringLiteral",
+                                                "location": {
+                                                  "start": {
+                                                    "line": 4,
+                                                    "column": 28
+                                                  },
+                                                  "end": {
+                                                    "line": 4,
+                                                    "column": 42
+                                                  },
+                                                  "source": "\"_measurement\""
+                                                },
+                                                "value": "_measurement"
+                                              }
+                                            },
+                                            "right": {
+                                              "type": "StringLiteral",
+                                              "location": {
+                                                "start": {
+                                                  "line": 4,
+                                                  "column": 47
+                                                },
+                                                "end": {
+                                                  "line": 4,
+                                                  "column": 59
+                                                },
+                                                "source": "\"airSensors\""
+                                              },
+                                              "value": "airSensors"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            },
+                            "call": {
+                              "location": {
+                                "start": {"line": 5, "column": 8},
+                                "end": {"line": 5, "column": 46},
+                                "source": "filter(fn: (r) => r[\"_field\"] == \"co\")"
+                              },
+                              "callee": {
+                                "type": "Identifier",
+                                "location": {
+                                  "start": {"line": 5, "column": 8},
+                                  "end": {"line": 5, "column": 14},
+                                  "source": "filter"
+                                },
+                                "name": "filter"
+                              },
+                              "arguments": [
+                                {
+                                  "type": "ObjectExpression",
+                                  "location": {
+                                    "start": {"line": 5, "column": 15},
+                                    "end": {"line": 5, "column": 45},
+                                    "source": "fn: (r) => r[\"_field\"] == \"co\""
+                                  },
+                                  "properties": [
+                                    {
+                                      "type": "Property",
+                                      "location": {
+                                        "start": {"line": 5, "column": 15},
+                                        "end": {"line": 5, "column": 45},
+                                        "source": "fn: (r) => r[\"_field\"] == \"co\""
+                                      },
+                                      "key": {
+                                        "type": "Identifier",
+                                        "location": {
+                                          "start": {"line": 5, "column": 15},
+                                          "end": {"line": 5, "column": 17},
+                                          "source": "fn"
+                                        },
+                                        "name": "fn"
+                                      },
+                                      "value": {
+                                        "type": "FunctionExpression",
+                                        "location": {
+                                          "start": {"line": 5, "column": 19},
+                                          "end": {"line": 5, "column": 45},
+                                          "source": "(r) => r[\"_field\"] == \"co\""
+                                        },
+                                        "params": [
+                                          {
+                                            "type": "Property",
+                                            "location": {
+                                              "start": {
+                                                "line": 5,
+                                                "column": 20
+                                              },
+                                              "end": {"line": 5, "column": 21},
+                                              "source": "r"
+                                            },
+                                            "key": {
+                                              "type": "Identifier",
+                                              "location": {
+                                                "start": {
+                                                  "line": 5,
+                                                  "column": 20
+                                                },
+                                                "end": {
+                                                  "line": 5,
+                                                  "column": 21
+                                                },
+                                                "source": "r"
+                                              },
+                                              "name": "r"
+                                            },
+                                            "value": null
+                                          }
+                                        ],
+                                        "body": {
+                                          "type": "BinaryExpression",
+                                          "location": {
+                                            "start": {"line": 5, "column": 26},
+                                            "end": {"line": 5, "column": 45},
+                                            "source": "r[\"_field\"] == \"co\""
+                                          },
+                                          "operator": "==",
+                                          "left": {
+                                            "type": "MemberExpression",
+                                            "location": {
+                                              "start": {
+                                                "line": 5,
+                                                "column": 26
+                                              },
+                                              "end": {"line": 5, "column": 37},
+                                              "source": "r[\"_field\"]"
+                                            },
+                                            "object": {
+                                              "type": "Identifier",
+                                              "location": {
+                                                "start": {
+                                                  "line": 5,
+                                                  "column": 26
+                                                },
+                                                "end": {
+                                                  "line": 5,
+                                                  "column": 27
+                                                },
+                                                "source": "r"
+                                              },
+                                              "name": "r"
+                                            },
+                                            "property": {
+                                              "type": "StringLiteral",
+                                              "location": {
+                                                "start": {
+                                                  "line": 5,
+                                                  "column": 28
+                                                },
+                                                "end": {
+                                                  "line": 5,
+                                                  "column": 36
+                                                },
+                                                "source": "\"_field\""
+                                              },
+                                              "value": "_field"
+                                            }
+                                          },
+                                          "right": {
+                                            "type": "StringLiteral",
+                                            "location": {
+                                              "start": {
+                                                "line": 5,
+                                                "column": 41
+                                              },
+                                              "end": {"line": 5, "column": 45},
+                                              "source": "\"co\""
+                                            },
+                                            "value": "co"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          },
+                          "call": {
+                            "location": {
+                              "start": {"line": 6, "column": 8},
+                              "end": {"line": 6, "column": 15},
+                              "source": "group()"
+                            },
+                            "callee": {
+                              "type": "Identifier",
+                              "location": {
+                                "start": {"line": 6, "column": 8},
+                                "end": {"line": 6, "column": 13},
+                                "source": "group"
+                              },
+                              "name": "group"
+                            }
+                          }
+                        },
+                        "call": {
+                          "location": {
+                            "start": {"line": 7, "column": 8},
+                            "end": {"line": 7, "column": 31},
+                            "source": "sort(columns:[\"_time\"])"
+                          },
+                          "callee": {
+                            "type": "Identifier",
+                            "location": {
+                              "start": {"line": 7, "column": 8},
+                              "end": {"line": 7, "column": 12},
+                              "source": "sort"
+                            },
+                            "name": "sort"
+                          },
+                          "arguments": [
+                            {
+                              "type": "ObjectExpression",
+                              "location": {
+                                "start": {"line": 7, "column": 13},
+                                "end": {"line": 7, "column": 30},
+                                "source": "columns:[\"_time\"]"
+                              },
+                              "properties": [
+                                {
+                                  "type": "Property",
+                                  "location": {
+                                    "start": {"line": 7, "column": 13},
+                                    "end": {"line": 7, "column": 30},
+                                    "source": "columns:[\"_time\"]"
+                                  },
+                                  "key": {
+                                    "type": "Identifier",
+                                    "location": {
+                                      "start": {"line": 7, "column": 13},
+                                      "end": {"line": 7, "column": 20},
+                                      "source": "columns"
+                                    },
+                                    "name": "columns"
+                                  },
+                                  "value": {
+                                    "type": "ArrayExpression",
+                                    "location": {
+                                      "start": {"line": 7, "column": 21},
+                                      "end": {"line": 7, "column": 30},
+                                      "source": "[\"_time\"]"
+                                    },
+                                    "elements": [
+                                      {
+                                        "type": "StringLiteral",
+                                        "location": {
+                                          "start": {"line": 7, "column": 22},
+                                          "end": {"line": 7, "column": 29},
+                                          "source": "\"_time\""
+                                        },
+                                        "value": "_time"
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "call": {
+                        "location": {
+                          "start": {"line": 8, "column": 8},
+                          "end": {"line": 8, "column": 55},
+                          "source": "aggregateWindow(fn: mean, every:v.windowPeriod)"
+                        },
+                        "callee": {
+                          "type": "Identifier",
+                          "location": {
+                            "start": {"line": 8, "column": 8},
+                            "end": {"line": 8, "column": 23},
+                            "source": "aggregateWindow"
+                          },
+                          "name": "aggregateWindow"
+                        },
+                        "arguments": [
+                          {
+                            "type": "ObjectExpression",
+                            "location": {
+                              "start": {"line": 8, "column": 24},
+                              "end": {"line": 8, "column": 54},
+                              "source": "fn: mean, every:v.windowPeriod"
+                            },
+                            "properties": [
+                              {
+                                "type": "Property",
+                                "location": {
+                                  "start": {"line": 8, "column": 24},
+                                  "end": {"line": 8, "column": 32},
+                                  "source": "fn: mean"
+                                },
+                                "key": {
+                                  "type": "Identifier",
+                                  "location": {
+                                    "start": {"line": 8, "column": 24},
+                                    "end": {"line": 8, "column": 26},
+                                    "source": "fn"
+                                  },
+                                  "name": "fn"
+                                },
+                                "value": {
+                                  "type": "Identifier",
+                                  "location": {
+                                    "start": {"line": 8, "column": 28},
+                                    "end": {"line": 8, "column": 32},
+                                    "source": "mean"
+                                  },
+                                  "name": "mean"
+                                }
+                              },
+                              {
+                                "type": "Property",
+                                "location": {
+                                  "start": {"line": 8, "column": 34},
+                                  "end": {"line": 8, "column": 54},
+                                  "source": "every:v.windowPeriod"
+                                },
+                                "key": {
+                                  "type": "Identifier",
+                                  "location": {
+                                    "start": {"line": 8, "column": 34},
+                                    "end": {"line": 8, "column": 39},
+                                    "source": "every"
+                                  },
+                                  "name": "every"
+                                },
+                                "value": {
+                                  "type": "MemberExpression",
+                                  "location": {
+                                    "start": {"line": 8, "column": 40},
+                                    "end": {"line": 8, "column": 54},
+                                    "source": "v.windowPeriod"
+                                  },
+                                  "object": {
+                                    "type": "Identifier",
+                                    "location": {
+                                      "start": {"line": 8, "column": 40},
+                                      "end": {"line": 8, "column": 41},
+                                      "source": "v"
+                                    },
+                                    "name": "v"
+                                  },
+                                  "property": {
+                                    "type": "Identifier",
+                                    "location": {
+                                      "start": {"line": 8, "column": 42},
+                                      "end": {"line": 8, "column": 54},
+                                      "source": "windowPeriod"
+                                    },
+                                    "name": "windowPeriod"
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    "call": {
+                      "location": {
+                        "start": {"line": 9, "column": 8},
+                        "end": {"line": 9, "column": 64},
+                        "source": "drop(columns:[\"_measurement\",\"_field\",\"_start\",\"_stop\"])"
+                      },
+                      "callee": {
+                        "type": "Identifier",
+                        "location": {
+                          "start": {"line": 9, "column": 8},
+                          "end": {"line": 9, "column": 12},
+                          "source": "drop"
+                        },
+                        "name": "drop"
+                      },
+                      "arguments": [
+                        {
+                          "type": "ObjectExpression",
+                          "location": {
+                            "start": {"line": 9, "column": 13},
+                            "end": {"line": 9, "column": 63},
+                            "source": "columns:[\"_measurement\",\"_field\",\"_start\",\"_stop\"]"
+                          },
+                          "properties": [
+                            {
+                              "type": "Property",
+                              "location": {
+                                "start": {"line": 9, "column": 13},
+                                "end": {"line": 9, "column": 63},
+                                "source": "columns:[\"_measurement\",\"_field\",\"_start\",\"_stop\"]"
+                              },
+                              "key": {
+                                "type": "Identifier",
+                                "location": {
+                                  "start": {"line": 9, "column": 13},
+                                  "end": {"line": 9, "column": 20},
+                                  "source": "columns"
+                                },
+                                "name": "columns"
+                              },
+                              "value": {
+                                "type": "ArrayExpression",
+                                "location": {
+                                  "start": {"line": 9, "column": 21},
+                                  "end": {"line": 9, "column": 63},
+                                  "source": "[\"_measurement\",\"_field\",\"_start\",\"_stop\"]"
+                                },
+                                "elements": [
+                                  {
+                                    "type": "StringLiteral",
+                                    "location": {
+                                      "start": {"line": 9, "column": 22},
+                                      "end": {"line": 9, "column": 36},
+                                      "source": "\"_measurement\""
+                                    },
+                                    "value": "_measurement"
+                                  },
+                                  {
+                                    "type": "StringLiteral",
+                                    "location": {
+                                      "start": {"line": 9, "column": 37},
+                                      "end": {"line": 9, "column": 45},
+                                      "source": "\"_field\""
+                                    },
+                                    "value": "_field"
+                                  },
+                                  {
+                                    "type": "StringLiteral",
+                                    "location": {
+                                      "start": {"line": 9, "column": 46},
+                                      "end": {"line": 9, "column": 54},
+                                      "source": "\"_start\""
+                                    },
+                                    "value": "_start"
+                                  },
+                                  {
+                                    "type": "StringLiteral",
+                                    "location": {
+                                      "start": {"line": 9, "column": 55},
+                                      "end": {"line": 9, "column": 62},
+                                      "source": "\"_stop\""
+                                    },
+                                    "value": "_stop"
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  "call": {
+                    "location": {
+                      "start": {"line": 10, "column": 8},
+                      "end": {"line": 10, "column": 43},
+                      "source": "yield(name:\"raw ${v.windowPeriod}\")"
+                    },
+                    "callee": {
+                      "type": "Identifier",
+                      "location": {
+                        "start": {"line": 10, "column": 8},
+                        "end": {"line": 10, "column": 13},
+                        "source": "yield"
+                      },
+                      "name": "yield"
+                    },
+                    "arguments": [
+                      {
+                        "type": "ObjectExpression",
+                        "location": {
+                          "start": {"line": 10, "column": 14},
+                          "end": {"line": 10, "column": 42},
+                          "source": "name:\"raw ${v.windowPeriod}\""
+                        },
+                        "properties": [
+                          {
+                            "type": "Property",
+                            "location": {
+                              "start": {"line": 10, "column": 14},
+                              "end": {"line": 10, "column": 42},
+                              "source": "name:\"raw ${v.windowPeriod}\""
+                            },
+                            "key": {
+                              "type": "Identifier",
+                              "location": {
+                                "start": {"line": 10, "column": 14},
+                                "end": {"line": 10, "column": 18},
+                                "source": "name"
+                              },
+                              "name": "name"
+                            },
+                            "value": {
+                              "type": "StringExpression",
+                              "location": {
+                                "start": {"line": 10, "column": 19},
+                                "end": {"line": 10, "column": 42},
+                                "source": "\"raw ${v.windowPeriod}\""
+                              },
+                              "parts": [
+                                {
+                                  "type": "TextPart",
+                                  "location": {
+                                    "start": {"line": 10, "column": 20},
+                                    "end": {"line": 10, "column": 24},
+                                    "source": "raw "
+                                  },
+                                  "value": "raw "
+                                },
+                                {
+                                  "type": "InterpolatedPart",
+                                  "location": {
+                                    "start": {"line": 10, "column": 24},
+                                    "end": {"line": 10, "column": 41},
+                                    "source": "${v.windowPeriod}"
+                                  },
+                                  "expression": {
+                                    "type": "MemberExpression",
+                                    "location": {
+                                      "start": {"line": 10, "column": 26},
+                                      "end": {"line": 10, "column": 40},
+                                      "source": "v.windowPeriod"
+                                    },
+                                    "object": {
+                                      "type": "Identifier",
+                                      "location": {
+                                        "start": {"line": 10, "column": 26},
+                                        "end": {"line": 10, "column": 27},
+                                        "source": "v"
+                                      },
+                                      "name": "v"
+                                    },
+                                    "property": {
+                                      "type": "Identifier",
+                                      "location": {
+                                        "start": {"line": 10, "column": 28},
+                                        "end": {"line": 10, "column": 40},
+                                        "source": "windowPeriod"
+                                      },
+                                      "name": "windowPeriod"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "type": "ReturnStatement",
+                "location": {
+                  "start": {"line": 11, "column": 5},
+                  "end": {"line": 11, "column": 16},
+                  "source": "return true"
+                },
+                "argument": {
+                  "type": "Identifier",
+                  "location": {
+                    "start": {"line": 11, "column": 12},
+                    "end": {"line": 11, "column": 16},
+                    "source": "true"
+                  },
+                  "name": "true"
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "ExpressionStatement",
+        "location": {
+          "start": {"line": 13, "column": 1},
+          "end": {"line": 13, "column": 6},
+          "source": "RAW()"
+        },
+        "expression": {
+          "type": "CallExpression",
+          "location": {
+            "start": {"line": 13, "column": 1},
+            "end": {"line": 13, "column": 6},
+            "source": "RAW()"
+          },
+          "callee": {
+            "type": "Identifier",
+            "location": {
+              "start": {"line": 13, "column": 1},
+              "end": {"line": 13, "column": 4},
+              "source": "RAW"
+            },
+            "name": "RAW"
+          }
+        }
+      }
+    ]
   }
 }

--- a/src/shared/utils/windowPeriod/fromAST.test.ts
+++ b/src/shared/utils/windowPeriod/fromAST.test.ts
@@ -237,6 +237,26 @@ describe('Getting a windowPeriod from a flux query AST', () => {
     })
   })
 
+  describe('can handle inner scope of functions bound to variables', () => {
+    /*
+        RAW = () => {
+          from(bucket: "sample_data")
+            |> range(start: -12h, stop: now())
+            |> filter(fn: (r) => r["_measurement"] == "airSensors")
+            |> filter(fn: (r) => r["_field"] == "co")
+            |> group()
+            |> sort(columns:["_time"])
+            |> aggregateWindow(fn: mean, every:v.windowPeriod)
+            |> drop(columns:["_measurement","_field","_start","_stop"])
+            |> yield(name:"raw ${v.windowPeriod}")
+          return true
+        }
+        RAW()
+        */
+    const ast = textFixtures['variable_bound_function']
+    runTest(ast, true, 120000)
+  })
+
   // TODO: https://github.com/influxdata/ui/issues/4695
   describe.skip('Can handle complex inner expressions:', () => {
     describe('for windowPeriod:', () => {

--- a/src/shared/utils/windowPeriod/fromAST.test.ts
+++ b/src/shared/utils/windowPeriod/fromAST.test.ts
@@ -1,0 +1,285 @@
+import {
+  getWindowPeriodVariableAssignment,
+  getWindowPeriodFromAST,
+} from './fromAST'
+import {getRangeVariable} from 'src/variables/utils/getTimeRangeVars'
+import {Package} from 'src/types/ast'
+import {TimeRange} from 'src/types'
+import {asAssignment} from 'src/variables/selectors'
+import {buildVarsOption} from 'src/variables/utils/buildVarsOption'
+import {TIME_RANGE_START, TIME_RANGE_STOP} from 'src/variables/constants'
+import {FALLBACK_WINDOW_PERIOD} from 'src/shared/constants/timeRanges'
+
+import textFixtures from './ast_fixtures.json'
+
+describe('Getting a windowPeriod from a flux query AST', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  const outerWindowPeriod = 60000
+  const range: TimeRange = {
+    seconds: 10800,
+    lower: 'now() - 3h',
+    upper: null,
+    label: 'Past 3h',
+    duration: '3h',
+    type: 'selectable-duration',
+    windowPeriod: 60000,
+  }
+  const outerVariablesFromUI = [
+    getRangeVariable(TIME_RANGE_START, range),
+    getRangeVariable(TIME_RANGE_STOP, range),
+  ]
+
+  const runTest = (ast, shouldInject, expected) => {
+    const varAssignmentNodes = outerVariablesFromUI.map(v => asAssignment(v))
+    const outerScopeAst: Package = {
+      package: '',
+      type: 'Package',
+      files: [buildVarsOption(varAssignmentNodes)],
+    }
+    it('correctly determines if should inject in extern', () => {
+      const {toInject} = getWindowPeriodVariableAssignment(ast, outerScopeAst)
+      expect(toInject).toEqual(shouldInject)
+    })
+    it('finds the correct value', () => {
+      const windowPeriodMillisec = getWindowPeriodFromAST(ast, outerScopeAst)
+      expect(windowPeriodMillisec).toEqual(expected)
+    })
+  }
+
+  describe('Basic reading of inputs:', () => {
+    describe('empty query', () => {
+      const ast = textFixtures['empty_query']
+      runTest(ast, false, outerWindowPeriod)
+    })
+
+    describe('query with timeRange, and no windowPeriod', () => {
+      /*
+          import "influxdata/influxdb/sample"
+          sample.data(set: "airSensor")
+              |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+              |> yield(name: "${v.windowPeriod}")
+          */
+      const ast = textFixtures['time_range']
+      runTest(ast, true, outerWindowPeriod)
+    })
+
+    describe('user declared v.windowPeriod', () => {
+      /*
+          import "array"
+          v = {windowPeriod: 2444}
+          array.from(rows: [{x: v.windowPeriod}])
+          */
+      const ast = textFixtures['user_declared']
+      runTest(ast, false, 2444)
+    })
+
+    describe('user declared option v.windowPeriod', () => {
+      /*
+          import "array"
+          option v = {windowPeriod: 2444}
+          array.from(rows: [{x: v.windowPeriod}])
+          */
+      const ast = textFixtures['user_declared_option']
+      runTest(ast, false, 2444)
+    })
+
+    describe('returns fallback windowPeriod, when cannot understand the result', () => {
+      /*
+          import "array"
+          v = {windowPeriod: 'gerbils'}
+          array.from(rows: [{x: v.windowPeriod}])
+          */
+      const ast = textFixtures['fallback']
+      runTest(ast, false, FALLBACK_WINDOW_PERIOD)
+    })
+  })
+
+  describe('Can handle scoping:', () => {
+    describe('use outerScope windowPeriod, without a range in the query', () => {
+      /*
+          import "array"
+          array.from(rows: [{x: v.windowPeriod}])
+          */
+      const ast = textFixtures['UI_scope']
+      runTest(ast, true, outerWindowPeriod)
+    })
+
+    describe('use v.windowPeriod from outer UI scope range', () => {
+      /*
+          import "influxdata/influxdb/sample"
+          sample.data(set: "airSensor")
+              |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+              |> yield(name: "${v.windowPeriod}")
+          */
+      const ast = textFixtures['UI_scope_range']
+      runTest(ast, true, outerWindowPeriod)
+    })
+
+    describe('use v.windowPeriod extracted from range transformation', () => {
+      /*
+          import "influxdata/influxdb/sample"
+          sample.data(set: "airSensor")
+              |> range(start: -12h, stop: now())
+              |> yield(name: "${v.windowPeriod}")
+          */
+
+      const ast = textFixtures['query_scope_range']
+      runTest(ast, true, 120000)
+    })
+
+    describe('use v.windowPeriod from inner scope', () => {
+      /*
+          import "influxdata/influxdb/sample"
+          sample.data(set: "airSensor")
+          |> range(start: -12h, stop: now())
+          |> map(fn: (r) => {
+              v = {windowPeriod: 2444}
+              return ({ r with _value: v.windowPeriod })
+          })
+          */
+      const ast = textFixtures['inner_query_scope']
+      runTest(ast, false, 2444)
+    })
+
+    describe('v.windowPeriod from inner scope, does not overwrite outer scope', () => {
+      /*
+          import "influxdata/influxdb/sample"
+          import "array"
+          sample.data(set: "airSensor")
+          |> range(start: -12h, stop: now())
+          |> map(fn: (r) => {
+              v = {windowPeriod: 2444}
+              return ({ r with _value: "foo" })
+          })
+          array.from(rows: [{x: v.windowPeriod}])
+          */
+      const ast = textFixtures['inner_vs_outer_query']
+      runTest(ast, true, outerWindowPeriod)
+    })
+
+    describe('detect use of v.windowPeriod in the inner lambda', () => {
+      /*
+          import "influxdata/influxdb/sample"
+          sample.data(set: "airSensor")
+              |> range(start: -12h, stop: now())
+              |> map(fn: (r) => {
+                  return ({ r with _value: "${v.windowPeriod}" })
+              })
+          */
+      const ast = textFixtures['inner_lambda']
+      runTest(ast, true, 120000)
+    })
+
+    describe('two timeRanges used. Should grab the proper one for windowPeriod.', () => {
+      /*
+          import "influxdata/influxdb/sample"
+          sample.data(set: "airSensor")
+              |> range(start: -12h, stop: now())
+              |> yield(name: "${v.windowPeriod}")
+          sample.data(set: "airSensor")
+              |> range(start: -15m, stop: now())
+          */
+      const ast = textFixtures['multiple_ranges']
+      runTest(ast, true, 120000)
+    })
+
+    describe("when encountering a range node, only add a v.windowPeriod to the global scope if it doesn't already exist", () => {
+      /*
+          import "influxdata/influxdb/sample"
+          v = {windowPeriod: 2444}
+          sample.data(set: "airSensor")
+              |> range(start: -12h, stop: now())
+              |> yield(name: "${v.windowPeriod}")
+          */
+      const ast = textFixtures['when_to_inject']
+      runTest(ast, false, 2444)
+    })
+  })
+
+  describe('Can handle aliasing:', () => {
+    describe('of the timeRange property', () => {
+      /*
+          import "influxdata/influxdb/sample"
+          splitPoint = -1m
+          sample.data(set: "airSensor")
+              |> range(start: -12h, stop: splitPoint)
+              |> yield(name: "${v.windowPeriod}")
+          */
+      const ast = textFixtures['alias_range']
+      runTest(ast, true, 119833)
+    })
+    describe('of the timeRange variable', () => {
+      /*
+          import "influxdata/influxdb/sample"
+          splitPoint = -1m
+          v = {timeRangeStop: splitPoint}
+          sample.data(set: "airSensor")
+              |> range(start: -12h, stop: v.timeRangeStop)
+              |> yield(name: "${v.windowPeriod}")
+          */
+      const ast = textFixtures['alias_range_variable']
+      runTest(ast, true, 119833)
+    })
+    describe('of the windowPeriod variable', () => {
+      /*
+          import "array"
+          import "influxdata/influxdb/sample"
+          split = 2444
+          chunk = split
+          v = {windowPeriod: chunk}
+          array.from(rows: [{x: v.windowPeriod}])
+          */
+      const ast = textFixtures['alias_window_variable']
+      runTest(ast, false, 2444)
+    })
+  })
+
+  // TODO: https://github.com/influxdata/ui/issues/4695
+  describe.skip('Can handle complex inner expressions:', () => {
+    describe('for windowPeriod:', () => {
+      describe('as an inline expression', () => {
+        /*
+            import "array"
+            v = {windowPeriod: 2 * 3 * 4 * 5}
+            array.from(rows: [{x: v.windowPeriod}])
+            */
+        const ast = {}
+        runTest(ast, false, 2 * 3 * 4 * 5)
+      })
+    })
+
+    describe('for timeRange:', () => {
+      describe('as an inline expression', () => {
+        /*
+              import "influxdata/influxdb/sample"
+              import "date"
+              import "experimental"
+              sample.data(set: "airSensor")
+                  |> range(start: -12h, stop: "-${2 * 3 * 4 * 5}m")
+                  |> yield(name: "${v.windowPeriod}")
+              */
+        const ast = {}
+
+        runTest(ast, true, 7180)
+      })
+      describe('use v.timeRangeStart as pre-bound Identifier, to an innerExpr', () => {
+        /*
+              import "influxdata/influxdb/sample"
+              import "date"
+              import "experimental"
+              truncated = date.truncate(t:v.timeRangeStop,unit:1m)
+              splitPoint = experimental.subDuration(d: 10m, from: truncated)
+              sample.data(set: "airSensor")
+                  |> range(start: -12h, stop: splitPoint)
+                  |> yield(name: "${v.windowPeriod}")
+              */
+        const ast = {}
+
+        runTest(ast, true, 'TODO')
+      })
+    })
+  })
+})

--- a/src/shared/utils/windowPeriod/fromAST.ts
+++ b/src/shared/utils/windowPeriod/fromAST.ts
@@ -1,0 +1,117 @@
+import {
+  Node,
+  Package,
+  Property,
+  VariableAssignment,
+  DurationLiteral,
+  Expression,
+} from 'src/types'
+import {
+  WINDOW_PERIOD,
+  TIME_RANGE_START,
+  TIME_RANGE_STOP,
+} from 'src/variables/constants'
+import {FALLBACK_WINDOW_PERIOD} from 'src/shared/constants/timeRanges'
+import {
+  isWindowPeriodVariableNode,
+  findNodeScope,
+  constructWindowVarAssignmentFromTimes,
+  constructWindowVarAssignmentFromExpression,
+} from 'src/shared/utils/ast'
+
+/**
+ * Determining the AST subtree for `v.windowPeriod`.
+ *
+ * @param ast -- root of AST tree, representing a query
+ * @param outerContext -- outer context, including any UI defined variables.
+ * @returns {{toInject: boolean; node: VariableAssignment}} -- Identified windowPeriod AST node, and if it needs to be injected.
+ */
+export function getWindowPeriodVariableAssignment(
+  ast: Node,
+  outerContext: Package
+): {toInject: boolean; node: VariableAssignment} {
+  const whenFound = (_, acc) => {
+    if (
+      !acc.scope[`v.${WINDOW_PERIOD}`] &&
+      acc.scope[`v.${TIME_RANGE_START}`]
+    ) {
+      // construct v.windowPeriod from flux query range
+      acc.scope[`v.${WINDOW_PERIOD}`] = constructWindowVarAssignmentFromTimes(
+        acc.scope,
+        acc.scope[`v.${TIME_RANGE_START}`] as Property,
+        acc.scope[`v.${TIME_RANGE_STOP}`] as Property | undefined
+      )
+      acc.toInjectWindowVar = true
+    }
+    return acc
+  }
+
+  const {scope: outerScope} = findNodeScope(
+    outerContext,
+    _ => false,
+    (_, acc) => acc
+  )
+
+  const {scope, toInjectWindowVar} = findNodeScope(
+    ast,
+    isWindowPeriodVariableNode,
+    whenFound,
+    {
+      scope: outerScope,
+      halted: false,
+    }
+  )
+
+  let astSubTreeToUse
+  if (scope[`v.${WINDOW_PERIOD}`]) {
+    astSubTreeToUse = scope[`v.${WINDOW_PERIOD}`]
+  } else if (scope[`v.${TIME_RANGE_START}`]) {
+    astSubTreeToUse = constructWindowVarAssignmentFromTimes(
+      scope,
+      scope[`v.${TIME_RANGE_START}`],
+      scope[`v.${TIME_RANGE_STOP}`]
+    )
+  }
+
+  const node =
+    astSubTreeToUse.type === 'VariableAssignment'
+      ? astSubTreeToUse
+      : constructWindowVarAssignmentFromExpression(
+          astSubTreeToUse as Expression,
+          scope
+        )
+
+  return {
+    toInject: !!toInjectWindowVar,
+    node,
+  }
+}
+
+/**
+ * Determining the `v.windowPeriod` from the AST subtree, then returning only the numeric value.
+ * Must always return a numeric value.
+ *
+ * @param ast -- root of AST tree, representing a query
+ * @param outerContext -- outer context, including any UI defined variables.
+ * @returns {number} -- numeric value of windowPeriod
+ */
+export function getWindowPeriodFromAST(
+  ast: Node,
+  outerContext: Package
+): number {
+  const {
+    node: windowVariableAssignmentNode,
+  } = getWindowPeriodVariableAssignment(ast, outerContext)
+
+  if (!windowVariableAssignmentNode) {
+    throw new Error('windowPeriod not found in neither query nor outer scope')
+  } else if (
+    windowVariableAssignmentNode.init &&
+    windowVariableAssignmentNode.init.hasOwnProperty('values')
+  ) {
+    return (windowVariableAssignmentNode.init as DurationLiteral).values[0]
+      .magnitude
+  }
+
+  return FALLBACK_WINDOW_PERIOD
+}


### PR DESCRIPTION
Part of  #4646 
Part of  #4836 

Using the scoped node visitor, (which returns the namespace scope captured at the node we are seeking) -- determine the windowPeriod for a given flux AST.

## Details
* line count is actually `+402`. The rest is all a giant test fixture.
* Has 2 major functions:
  * return the AST node for windowPeriod:
    * to be used for the extern, send to the backend during flux queries.
  * return a single numeric value. always.
    * to be used for areas of the UI which requires a numeric windowPeriod (in seconds) be available.


## Not in this PR, but in the next PR:
* the next PR will include updates to `src/variables/utils/getWindowVars.ts`
  * these changes will include:
    * whenever cannot parse query to AST --> return windowPeriod based on outerContext UI (a.k.a. context outside the flux query itself).     