### PR TITLE
fix: display flux correctly in firefox

### DIFF
--- a/src/tasks/components/RunLogRowFlux.tsx
+++ b/src/tasks/components/RunLogRowFlux.tsx
@@ -21,7 +21,7 @@ class RunLogRowFlux extends PureComponent<Props> {
     const {run} = this.props
 
     return (
-      <IndexList.Row>
+      <IndexList.Row className="run-log--list-row">
         <IndexList.Cell>
           <span className="run-logs--list-time">
             {this.dateTimeString(run.startedAt)}

--- a/src/tasks/components/RunLogsList.scss
+++ b/src/tasks/components/RunLogsList.scss
@@ -1,6 +1,7 @@
 .run-logs--list {
   width: 100%;
   max-width: calc(100% - 60px) !important;
+  height: 100%;
 }
 
 .run-logs--list-time {
@@ -17,5 +18,15 @@
   white-space: pre-wrap;
   word-break: break-all;
   width: 100%;
+  height: 30vh;
+}
+
+@supports (-moz-appearance:none) {
+  tr.run-log--list-row td {
+    height: 100%;
+  }
+}
+
+tr.run-log--list-row {
   height: 30vh;
 }

--- a/src/tasks/components/RunLogsList.scss
+++ b/src/tasks/components/RunLogsList.scss
@@ -21,7 +21,7 @@
   height: 30vh;
 }
 
-@supports (-moz-appearance:none) {
+@supports (-moz-appearance: none) {
   tr.run-log--list-row td {
     height: 100%;
   }


### PR DESCRIPTION
Closes #4971 

Ensures flux is displayed correctly on all browsers in the task run logs. Screenshots for each browser below:

Firefox:

<img width="1220" alt="Screen Shot 2022-07-06 at 2 46 59 PM" src="https://user-images.githubusercontent.com/106361125/177621601-e5ec4001-a496-4845-afb8-eb07799d469c.png">

Chrome:
<img width="1342" alt="Screen Shot 2022-07-06 at 2 47 49 PM" src="https://user-images.githubusercontent.com/106361125/177621635-c9b3af8b-d750-49fd-a59d-cfd4cea4f33e.png">

Safari:

<img width="1375" alt="Screen Shot 2022-07-06 at 2 48 29 PM" src="https://user-images.githubusercontent.com/106361125/177621662-938bb9f1-098d-480f-815b-d4083edbe25f.png">

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
