### PR TITLE
feat: show task name in notification message

### DIFF
--- a/src/shared/copy/notifications/categories/tasks.ts
+++ b/src/shared/copy/notifications/categories/tasks.ts
@@ -81,9 +81,14 @@ export const taskCloneFailed = (
   message: `Failed to clone task ${taskName}: ${additionalMessage} `,
 })
 
-export const taskUpdateFailed = (additionalMessage: string, taskName?: string): Notification => ({
+export const taskUpdateFailed = (
+  additionalMessage: string,
+  taskName?: string
+): Notification => ({
   ...defaultErrorNotification,
-  message: `Failed to update task ${taskName ? taskName : ''}: ${additionalMessage}`,
+  message: `Failed to update task ${
+    taskName ? taskName : ''
+  }: ${additionalMessage}`,
 })
 
 export const taskUpdateSuccess = (taskName?: string): Notification => ({

--- a/src/shared/copy/notifications/categories/tasks.ts
+++ b/src/shared/copy/notifications/categories/tasks.ts
@@ -81,14 +81,14 @@ export const taskCloneFailed = (
   message: `Failed to clone task ${taskName}: ${additionalMessage} `,
 })
 
-export const taskUpdateFailed = (additionalMessage: string): Notification => ({
+export const taskUpdateFailed = (additionalMessage: string, taskName?: string): Notification => ({
   ...defaultErrorNotification,
-  message: `Failed to update task: ${additionalMessage}`,
+  message: `Failed to update task ${taskName ? taskName : ''}: ${additionalMessage}`,
 })
 
-export const taskUpdateSuccess = (): Notification => ({
+export const taskUpdateSuccess = (taskName?: string): Notification => ({
   ...defaultSuccessNotification,
-  message: 'Task was updated successfully',
+  message: `Task ${taskName ? taskName : ''} was updated successfully`,
 })
 
 export const taskImportFailed = (errorMessage: string): Notification => ({

--- a/src/tasks/actions/thunks.test.ts
+++ b/src/tasks/actions/thunks.test.ts
@@ -116,7 +116,7 @@ describe('Tasks.Actions.Thunks', () => {
 
     expect(dispatch.mock.calls[2][0].type).toBe('PUBLISH_NOTIFICATION')
     expect(dispatch.mock.calls[2][0].payload.notification).toEqual(
-      taskUpdateSuccess()
+      taskUpdateSuccess(sampleTask.name)
     )
   })
 })

--- a/src/tasks/actions/thunks.ts
+++ b/src/tasks/actions/thunks.ts
@@ -231,11 +231,11 @@ export const updateTaskStatus = (task: Task) => async (
 
     dispatch(editTask(normTask))
     dispatch(setCurrentTask(normTask))
-    dispatch(notify(copy.taskUpdateSuccess()))
+    dispatch(notify(copy.taskUpdateSuccess(task.name)))
   } catch (e) {
     console.error(e)
     const message = getErrorMessage(e)
-    dispatch(notify(copy.taskUpdateFailed(message)))
+    dispatch(notify(copy.taskUpdateFailed(message, task.name)))
   }
 }
 
@@ -255,11 +255,11 @@ export const updateTaskName = (name: string, taskID: string) => async (
     )
 
     dispatch(editTask(normTask))
-    dispatch(notify(copy.taskUpdateSuccess()))
+    dispatch(notify(copy.taskUpdateSuccess(name)))
   } catch (e) {
     console.error(e)
     const message = getErrorMessage(e)
-    dispatch(notify(copy.taskUpdateFailed(message)))
+    dispatch(notify(copy.taskUpdateFailed(message, name)))
   }
 }
 


### PR DESCRIPTION
Closes #4898 

When updating tasks in task page (active/inactive or name update), success or error notification that pops up doesn't indicate which task was updated. This can be troublesome for users performing mass updates (read linked ticket for in-depth explanation). 

PR adds an optional parameter `task.name` to `taskUpdateSuccess` and `taskUpdateFailed` so the task name can be visible in the notification message. 

https://user-images.githubusercontent.com/66275100/177643431-38b9d99e-2f5a-454e-a535-11b75938018f.mov


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
