### PR TITLE
fix(TasksPage): remove showInactive setState from constructor

### DIFF
--- a/src/tasks/actions/thunks.ts
+++ b/src/tasks/actions/thunks.ts
@@ -125,7 +125,7 @@ export const getAllTasks = (name?: string) => async (
     const resp = await fetchTasks(query)
 
     let nonNormalizedTasks = resp.data.tasks
-    let next = resp.data.links?.next
+    let next = resp.data?.links?.next
     while (next && next.includes('after=')) {
       const afterAndExtras = next.split('after=')
       if (afterAndExtras.length < 2) {

--- a/src/tasks/actions/thunks.ts
+++ b/src/tasks/actions/thunks.ts
@@ -125,7 +125,7 @@ export const getAllTasks = (name?: string) => async (
     const resp = await fetchTasks(query)
 
     let nonNormalizedTasks = resp.data.tasks
-    let next = resp.data.links.next
+    let next = resp.data.links?.next
     while (next && next.includes('after=')) {
       const afterAndExtras = next.split('after=')
       if (afterAndExtras.length < 2) {

--- a/src/tasks/containers/TasksPage.test.tsx
+++ b/src/tasks/containers/TasksPage.test.tsx
@@ -14,6 +14,7 @@ import TasksPage from './TasksPage'
 import {deleteTask, patchTask, postTask, getTask} from 'src/client'
 import {parse} from 'src/languageSupport/languages/flux/parser'
 import {mocked} from 'ts-jest/utils'
+import {initialState} from 'src/tasks/reducers/helpers'
 
 const sampleScript =
   'option task = {\n  name: "beetle",\n  every: 1h,\n}\n' +
@@ -151,6 +152,7 @@ const setup = (override = {}) => {
         status: RemoteDataState.Done,
       },
       tasks: {
+        ...initialState(),
         byID: {
           [localTasks[0].id]: localTasks[0],
           [localTasks[1].id]: localTasks[1],

--- a/src/tasks/containers/TasksPage.tsx
+++ b/src/tasks/containers/TasksPage.tsx
@@ -67,10 +67,6 @@ class TasksPage extends PureComponent<Props, State> {
   constructor(props: Props) {
     super(props)
 
-    if (!props.showInactive) {
-      props.setShowInactive()
-    }
-
     this.state = {
       isImporting: false,
       taskLabelsEdit: null,


### PR DESCRIPTION
Closes #4897 

Bug: show inactive toggle inside Tasks page resets back to true when user leaves and returns to page. 
fix: removed setState responsible for re-setting `showInactive` to true.  
https://user-images.githubusercontent.com/66275100/177883487-ea85201c-4ba3-41bb-8ecb-14fe25bb63e5.mov


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
