### PR TITLE
chore: don't allow editing of a task if it is backed by a script

### DIFF
--- a/src/tasks/containers/TaskEditPage.tsx
+++ b/src/tasks/containers/TaskEditPage.tsx
@@ -60,8 +60,49 @@ class TaskEditPage extends PureComponent<Props> {
   }
 
   public render(): JSX.Element {
-    const {currentScript, taskOptions} = this.props
+    const {currentScript, currentTask, taskOptions} = this.props
 
+    if (currentTask != null && currentTask.scriptID != null) {
+      return (
+        <Page titleTag={pageTitleSuffixer([`Edit ${taskOptions.name}`])}>
+          <TaskHeader
+            title="Scripted Task"
+            canSubmit={false}
+            onCancel={this.handleCancel}
+            onSave={this.handleCancel}
+          />
+          <Page.Contents fullWidth={true} scrollable={false}>
+            <div className="task-form">
+              <div className="task-form--options">
+                <TaskForm
+                  canSubmit={false}
+                  taskOptions={taskOptions}
+                  onChangeInput={this.handleChangeInput}
+                  onChangeScheduleType={this.handleChangeScheduleType}
+                />
+              </div>
+              <div className="task-form--editor">
+                <Suspense
+                  fallback={
+                    <SpinnerContainer
+                      loading={RemoteDataState.Loading}
+                      spinnerComponent={<TechnoSpinner />}
+                    />
+                  }
+                >
+                  <FluxMonacoEditor
+                    script={"Cannot modify or save this task while it is using a script, please use the api directly."}
+                    variables={null}
+                    onChangeScript={this.handleChangeScript}
+                    autofocus
+                  />
+                </Suspense>
+              </div>
+            </div>
+          </Page.Contents>
+        </Page>
+      )
+    }
     return (
       <Page titleTag={pageTitleSuffixer([`Edit ${taskOptions.name}`])}>
         <TaskHeader

--- a/src/tasks/containers/TaskEditPage.tsx
+++ b/src/tasks/containers/TaskEditPage.tsx
@@ -91,7 +91,7 @@ class TaskEditPage extends PureComponent<Props> {
                   }
                 >
                   <FluxMonacoEditor
-                    script={"Cannot modify or save this task while it is using a script, please use the api directly."}
+                    script="Cannot modify or save this task while it is using a script, please use the api directly."
                     variables={null}
                     onChangeScript={this.handleChangeScript}
                     autofocus

--- a/src/tasks/containers/TaskEditPage.tsx
+++ b/src/tasks/containers/TaskEditPage.tsx
@@ -62,14 +62,14 @@ class TaskEditPage extends PureComponent<Props> {
   public render(): JSX.Element {
     const {currentScript, currentTask, taskOptions} = this.props
 
-    if (currentTask != null && currentTask.scriptID != null) {
+    if (currentTask?.scriptID != null) {
       return (
         <Page titleTag={pageTitleSuffixer([`Edit ${taskOptions.name}`])}>
           <TaskHeader
             title="Scripted Task"
             canSubmit={false}
             onCancel={this.handleCancel}
-            onSave={this.handleCancel}
+            onSave={() => {}}
           />
           <Page.Contents fullWidth={true} scrollable={false}>
             <div className="task-form">
@@ -91,7 +91,8 @@ class TaskEditPage extends PureComponent<Props> {
                   }
                 >
                   <FluxMonacoEditor
-                    script="Cannot modify or save this task while it is using a script, please use the api directly."
+                    // Fill with a comment to avoid the syntax highlighting on the `or`
+                    script="// You may not modify or save this task while it is using a script. Please use the API directly."
                     variables={null}
                     onChangeScript={this.handleChangeScript}
                     autofocus

--- a/src/types/tasks.ts
+++ b/src/types/tasks.ts
@@ -3,6 +3,8 @@ import {NormalizedState, Run, RemoteDataState, LogEvent} from 'src/types'
 
 export interface Task extends Omit<ITask, 'labels'> {
   labels?: string[]
+  scriptID?: string
+  scriptParams?: string
 }
 export interface TaskOptions {
   name: string


### PR DESCRIPTION
Closes #4978

This addresses an experience concern where a task is backed by a script by blocking users from saving flux if their task is backed by a script.

This fills the flux editing area with some notice text informing the user to use the api to interact with their script-backed task. It disables the save button as well. No impact on flux-backed task editing that I found.

<!-- ![image](https://user-images.githubusercontent.com/2653109/178305120-d34b0898-b271-40cd-8be4-ca8a60f322e1.png) -->
![image](https://user-images.githubusercontent.com/2653109/178559124-afb235bb-8fbd-406b-8718-cc1e6656a7a6.png)



### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
