### PR TITLE
fix(4882): reduce ResizerObserver looping even further

### DIFF
--- a/src/visualization/types/SimpleTable/PagedTable.tsx
+++ b/src/visualization/types/SimpleTable/PagedTable.tsx
@@ -239,13 +239,14 @@ const PagedTable: FC<Props> = ({result, properties}) => {
     }
 
     let timeout
+    let animationFrameID
     const resizer = new ResizeObserver(entries => {
       if (timeout) {
         clearTimeout(timeout)
       }
 
       timeout = setTimeout(() => {
-        requestAnimationFrame(() => {
+        animationFrameID = requestAnimationFrame(() => {
           setHeight(entries[0].contentRect.height)
         })
       }, 200)
@@ -263,6 +264,7 @@ const PagedTable: FC<Props> = ({result, properties}) => {
 
     return () => {
       resizer.disconnect()
+      cancelAnimationFrame(animationFrameID)
       if (timeout) {
         clearTimeout(timeout)
       }


### PR DESCRIPTION
Part of #4882 

Part of bug squashing mission.

## Bug:
* general window.onerror triggered via the ResizeObserver
* What this is:
  * Excessive recursion upon resize. But is a know issue because of how this window API should be used, and is chrome-specific behavior (matching what we see in honeybadger for the browsers).
  * This is expected, and highly reported elsewhere:
    * https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded
    * `https://github.com/WICG/resize-observer/issues/38`
* Previously done:
  * we are already doing 2 (out of 3) code patterns to reduce the triggering occurrences. We can also do the 3rd one too (cancel animation frame).

In addition to this PR, going to be requesting permission to start filtering out (ignoring) this error in honeybadger.

