### PR TITLE
feat: add onFocus for subscription sections

### DIFF
--- a/src/writeData/subscriptions/components/BrokerDetails.tsx
+++ b/src/writeData/subscriptions/components/BrokerDetails.tsx
@@ -44,6 +44,7 @@ interface Props {
   loading: any
   saveForm: (any) => void
   setStatus: (any) => void
+  onFocus?: () => void
 }
 
 const BrokerDetails: FC<Props> = ({
@@ -54,13 +55,20 @@ const BrokerDetails: FC<Props> = ({
   loading,
   saveForm,
   setStatus,
+  onFocus,
 }) => {
   const history = useHistory()
   const org = useSelector(getOrg)
   const {navbarMode} = useContext(AppSettingContext)
   const navbarOpen = navbarMode === 'expanded'
+
   return (
-    <div className="update-broker-form" id="broker">
+    <div
+      className="update-broker-form"
+      id="broker"
+      onFocus={onFocus}
+      tabIndex={-1}
+    >
       <SpinnerContainer spinnerComponent={<TechnoSpinner />} loading={loading}>
         <Form onSubmit={() => {}} testID="update-broker-form-overlay">
           <div

--- a/src/writeData/subscriptions/components/BrokerForm.tsx
+++ b/src/writeData/subscriptions/components/BrokerForm.tsx
@@ -51,9 +51,15 @@ interface Props {
   formContent: Subscription
   updateForm: (any) => void
   saveForm: (any) => void
+  onFocus?: (any) => void
 }
 
-const BrokerForm: FC<Props> = ({formContent, updateForm, saveForm}) => {
+const BrokerForm: FC<Props> = ({
+  formContent,
+  updateForm,
+  saveForm,
+  onFocus,
+}) => {
   const history = useHistory()
   const org = useSelector(getOrg)
   // enabled for PAYG accounts and specific free accounts where a flag is enabled
@@ -66,7 +72,12 @@ const BrokerForm: FC<Props> = ({formContent, updateForm, saveForm}) => {
   const navbarOpen = navbarMode === 'expanded'
   return (
     formContent && (
-      <div className="create-broker-form" id="broker">
+      <div
+        className="create-broker-form"
+        id="broker"
+        onFocus={onFocus}
+        tabIndex={-1}
+      >
         <Form onSubmit={() => {}} testID="create-broker-form-overlay">
           <div
             className="create-broker-form__fixed"

--- a/src/writeData/subscriptions/components/CreateSubscriptionPage.tsx
+++ b/src/writeData/subscriptions/components/CreateSubscriptionPage.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FC, useState, useContext, useEffect} from 'react'
+import React, {FC, useState, useContext, useEffect, useCallback} from 'react'
 import {useSelector} from 'react-redux'
 
 // Components
@@ -99,9 +99,9 @@ const CreateSubscriptionPage: FC = () => {
       {feature: 'subscriptions'}
     )
     document
-      .getElementById(stepsWithIsCompletedStatus[step - 1].type)
+      .getElementById(SUBSCRIPTION_NAVIGATION_STEPS[step - 1].type)
       ?.scrollIntoView({behavior: 'smooth', block: 'center'})
-    setFormActive(stepsWithIsCompletedStatus[step - 1].type as Steps)
+    setFormActive(SUBSCRIPTION_NAVIGATION_STEPS[step - 1].type as Steps)
     setCompletedSteps({
       [Steps.BrokerForm]: stepsStatus.brokerStepCompleted === 'true',
       [Steps.SubscriptionForm]:
@@ -136,14 +136,20 @@ const CreateSubscriptionPage: FC = () => {
               formContent={formContent}
               updateForm={updateForm}
               saveForm={saveForm}
+              onFocus={() => setFormActive(Steps.BrokerForm)}
             />
             <SubscriptionForm
               formContent={formContent}
               updateForm={updateForm}
               buckets={buckets}
               bucket={bucket}
+              onFocus={() => setFormActive(Steps.SubscriptionForm)}
             />
-            <ParsingForm formContent={formContent} updateForm={updateForm} />
+            <ParsingForm
+              formContent={formContent}
+              updateForm={updateForm}
+              onFocus={() => setFormActive(Steps.ParsingForm)}
+            />
           </Page.Contents>
         </SpinnerContainer>
       </Page>

--- a/src/writeData/subscriptions/components/CreateSubscriptionPage.tsx
+++ b/src/writeData/subscriptions/components/CreateSubscriptionPage.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FC, useState, useContext, useEffect, useCallback} from 'react'
+import React, {FC, useState, useContext, useEffect} from 'react'
 import {useSelector} from 'react-redux'
 
 // Components

--- a/src/writeData/subscriptions/components/DetailsSubscriptionPage.tsx
+++ b/src/writeData/subscriptions/components/DetailsSubscriptionPage.tsx
@@ -147,6 +147,7 @@ const DetailsSubscriptionPage: FC = () => {
               loading={loading}
               setStatus={setStatus}
               saveForm={saveForm}
+              onFocus={() => setFormActive(Steps.BrokerForm)}
             />
             <SubscriptionDetails
               currentSubscription={currentSubscription}
@@ -154,11 +155,13 @@ const DetailsSubscriptionPage: FC = () => {
               buckets={buckets}
               bucket={bucket}
               edit={isEditEnabled}
+              onFocus={() => setFormActive(Steps.SubscriptionForm)}
             />
             <ParsingDetails
               currentSubscription={currentSubscription}
               updateForm={updateForm}
               edit={isEditEnabled}
+              onFocus={() => setFormActive(Steps.ParsingForm)}
             />
           </Page.Contents>
         </SpinnerContainer>

--- a/src/writeData/subscriptions/components/ParsingDetails.tsx
+++ b/src/writeData/subscriptions/components/ParsingDetails.tsx
@@ -19,9 +19,15 @@ interface Props {
   currentSubscription: Subscription
   updateForm: (any) => void
   edit: boolean
+  onFocus?: () => void
 }
 
-const ParsingDetails: FC<Props> = ({currentSubscription, updateForm, edit}) => (
+const ParsingDetails: FC<Props> = ({
+  currentSubscription,
+  updateForm,
+  edit,
+  onFocus,
+}) => (
   <div
     className={
       currentSubscription.dataFormat === 'lineprotocol'
@@ -29,6 +35,8 @@ const ParsingDetails: FC<Props> = ({currentSubscription, updateForm, edit}) => (
         : 'update-parsing-form'
     }
     id="parsing"
+    onFocus={onFocus}
+    tabIndex={-1}
   >
     <Form onSubmit={() => {}} testID="update-parsing-form-overlay">
       <Overlay.Header title="Define Data Parsing Rules"></Overlay.Header>

--- a/src/writeData/subscriptions/components/ParsingForm.tsx
+++ b/src/writeData/subscriptions/components/ParsingForm.tsx
@@ -24,9 +24,10 @@ import 'src/writeData/subscriptions/components/ParsingForm.scss'
 interface Props {
   formContent: Subscription
   updateForm: (any) => void
+  onFocus?: (any) => void
 }
 
-const ParsingForm: FC<Props> = ({formContent, updateForm}) =>
+const ParsingForm: FC<Props> = ({formContent, updateForm, onFocus}) =>
   formContent && (
     <div
       className={
@@ -35,6 +36,8 @@ const ParsingForm: FC<Props> = ({formContent, updateForm}) =>
           : 'create-parsing-form'
       }
       id="parsing"
+      onFocus={onFocus}
+      tabIndex={-1}
     >
       <Form onSubmit={() => {}} testID="create-parsing-form-overlay">
         <Overlay.Header title="Define Data Parsing Rules"></Overlay.Header>

--- a/src/writeData/subscriptions/components/SubscriptionDetails.tsx
+++ b/src/writeData/subscriptions/components/SubscriptionDetails.tsx
@@ -20,6 +20,7 @@ interface Props {
   buckets: any
   bucket: any
   edit: boolean
+  onFocus?: () => void
 }
 
 const SubscriptionDetails: FC<Props> = ({
@@ -28,18 +29,26 @@ const SubscriptionDetails: FC<Props> = ({
   buckets,
   bucket,
   edit,
+  onFocus,
 }) => {
   useEffect(() => {
     event('visited subscription details page', {}, {feature: 'subscriptions'})
   }, [])
+
   useEffect(() => {
     if (edit) {
       updateForm({...currentSubscription, bucket: bucket.name})
     }
   }, [bucket])
+
   return (
     buckets && (
-      <div className="update-subscription-form" id="subscription">
+      <div
+        className="update-subscription-form"
+        id="subscription"
+        onFocus={onFocus}
+        tabIndex={-1}
+      >
         <Form
           onSubmit={() => {}}
           testID="update-subscription-form--overlay-form"

--- a/src/writeData/subscriptions/components/SubscriptionForm.tsx
+++ b/src/writeData/subscriptions/components/SubscriptionForm.tsx
@@ -22,6 +22,7 @@ interface Props {
   updateForm: (any) => void
   buckets: any
   bucket: any
+  onFocus?: (any) => void
 }
 
 const SubscriptionForm: FC<Props> = ({
@@ -29,14 +30,21 @@ const SubscriptionForm: FC<Props> = ({
   updateForm,
   buckets,
   bucket,
+  onFocus,
 }) => {
   useEffect(() => {
     updateForm({...formContent, bucket: bucket.name})
   }, [bucket])
+
   return (
     formContent &&
     buckets && (
-      <div className="create-subscription-form" id="subscription">
+      <div
+        className="create-subscription-form"
+        id="subscription"
+        onFocus={onFocus}
+        tabIndex={-1}
+      >
         <Form
           onSubmit={() => {}}
           testID="create-subscription-form--overlay-form"


### PR DESCRIPTION
Closes https://github.com/influxdata/data-acquisition/issues/409

## Proposed Solution
When the parent div or any of its children of Subscription sections receive focus, the Subway Nav step should be updated with the currently active step(in which the focus was just received).

## BEFORE
![177202666-9640d3b2-f77d-4827-9543-c44660c92960](https://user-images.githubusercontent.com/1637395/177832002-e4abcf8b-13d1-4df5-8bf9-71ee2c624f1b.gif)

## AFTER
![Kapture 2022-07-07 at 13 16 21](https://user-images.githubusercontent.com/1637395/177832241-bb2c3337-3637-485e-ac33-b11662b6fc43.gif)


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
