### PR TITLE
chore: remove feature flag

### DIFF
--- a/src/flows/components/header/MenuButton.tsx
+++ b/src/flows/components/header/MenuButton.tsx
@@ -27,7 +27,6 @@ import {downloadImage} from 'src/shared/utils/download'
 // Constants
 import {PROJECT_NAME_PLURAL} from 'src/flows'
 import {CLOUD} from 'src/shared/constants'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 const backgroundColor = '#07070E'
 
@@ -37,7 +36,7 @@ type Props = {
 
 const MenuButton: FC<Props> = ({handleResetShare}) => {
   const {flow, cloneNotebook, deleteNotebook} = useContext(FlowContext)
-  const {handlePublish, versions} = useContext(VersionPublishContext)
+  const {versions} = useContext(VersionPublishContext)
   const {id: orgID} = useSelector(getOrg)
   const [loading, setLoading] = useState(RemoteDataState.Done)
 
@@ -210,15 +209,6 @@ const MenuButton: FC<Props> = ({handleResetShare}) => {
       testID: 'flow-menu-button-delete',
     },
   ]
-
-  if (!isFlagEnabled('flowPublishButton')) {
-    menuItems.splice(0, 0, {
-      type: 'menuitem',
-      title: 'Save to version history',
-      onClick: handlePublish,
-      icon: IconFont.Save,
-    })
-  }
 
   if (CLOUD) {
     menuItems.splice(3, 0, {

--- a/src/flows/components/header/index.tsx
+++ b/src/flows/components/header/index.tsx
@@ -165,14 +165,12 @@ const FlowHeader: FC = () => {
           <PresentationMode />
           <TimeZoneDropdown />
           <TimeRangeDropdown />
-          <FeatureFlag name="flowPublishButton">
-            <SquareButton
-              icon={IconFont.Save}
-              onClick={handlePublish}
-              color={ComponentColor.Default}
-              titleText="Save to version history"
-            />
-          </FeatureFlag>
+          <SquareButton
+            icon={IconFont.Save}
+            onClick={handlePublish}
+            color={ComponentColor.Default}
+            titleText="Save to version history"
+          />
           {flow?.id && (
             <>
               <SquareButton


### PR DESCRIPTION
This PR removes the UI feature flag for the `Save to Version History` button so that the button appears at the menu header and not the dropdown button. After leaving the flag on for a month, we've seen user engagement double with the publish feature in Notebooks after moving the button outside the dropdown list. See the analytics [here](https://analytics.amplitude.com/influxdb/chart/83f46to?source=redirect%3A%20chart%20saved?source=copy+url)
