### PR TITLE
feat: Enable convert to contract for direct payg accounts

### DIFF
--- a/cypress/e2e/cloud/operator.test.ts
+++ b/cypress/e2e/cloud/operator.test.ts
@@ -145,7 +145,7 @@ describe('Operator Page', () => {
     cy.getByTestID('account-view--header').contains('operator1 (1)')
     // should not be able to delete undeletable accounts
     cy.getByTestID('account-delete--button').should('be.disabled')
-    // should not be able to convert acancelled accounts to contract
+    // should not be able to convert cancelled accounts to contract
     cy.getByTestID('account-convert-to-contract--button').should('be.disabled')
 
     // Associated Users Section

--- a/cypress/e2e/cloud/operator.test.ts
+++ b/cypress/e2e/cloud/operator.test.ts
@@ -145,7 +145,7 @@ describe('Operator Page', () => {
     cy.getByTestID('account-view--header').contains('operator1 (1)')
     // should not be able to delete undeletable accounts
     cy.getByTestID('account-delete--button').should('be.disabled')
-    // should not be able to convert non-free accounts to contract
+    // should not be able to convert acancelled accounts to contract
     cy.getByTestID('account-convert-to-contract--button').should('be.disabled')
 
     // Associated Users Section

--- a/src/operator/account/AccountViewHeader.tsx
+++ b/src/operator/account/AccountViewHeader.tsx
@@ -26,6 +26,9 @@ const AccountViewHeader: FC = () => {
     deleteOverlayVisible,
   } = useContext(AccountContext)
   const {hasWritePermissions} = useContext(OperatorContext)
+  const canConvertToContract =
+    account.type === 'free' ||
+    (account.type === 'pay_as_you_go' && account.zuoraAccountId !== null)
 
   return (
     <FlexBox
@@ -47,7 +50,7 @@ const AccountViewHeader: FC = () => {
             setConvertToContractOverlayVisible(!convertToContractOverlayVisible)
           }
           status={
-            account.type === 'free'
+            canConvertToContract
               ? ComponentStatus.Default
               : ComponentStatus.Disabled
           }


### PR DESCRIPTION
This enables the convert to contract operator UI feature for direct payg accounts. Previously this was only available to free accounts.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
