### PR TITLE
fix(operatorUI): improve orgOverlay grid design

### DIFF
--- a/src/operator/OrgOverlay.scss
+++ b/src/operator/OrgOverlay.scss
@@ -1,5 +1,6 @@
 .overlay-header--color.overlay-header--title {
   color: #fff;
+  justify-content: center;
   user-select: text !important;
   -moz-user-select: text !important;
   -webkit-user-select: text !important;

--- a/src/operator/OrgOverlay.tsx
+++ b/src/operator/OrgOverlay.tsx
@@ -15,6 +15,7 @@ import {
   LinkButton,
   LinkTarget,
   Overlay,
+  Panel,
   RemoteDataState,
   SpinnerContainer,
   TechnoSpinner,
@@ -87,156 +88,158 @@ const OrgOverlay: FC = () => {
           spinnerComponent={<TechnoSpinner diameterPixels={100} />}
         >
           <Overlay.Body>
-            <Grid>
-              <Grid.Row>
-                <Grid.Column widthMD={Columns.Four}>
-                  <label>Organization Name</label>
-                  <p>{organization?.name ?? ''}</p>
-                </Grid.Column>
-                <Grid.Column widthMD={Columns.Four}>
-                  <label>Account Type</label>
-                  <p>{organization?.account?.type ?? ''}</p>
-                </Grid.Column>
-                <Grid.Column widthMD={Columns.Four}>
-                  <LinkButton
-                    color={ComponentColor.Secondary}
-                    size={ComponentSize.Medium}
-                    shape={ButtonShape.Default}
-                    testID="usage-button"
-                    text="View Usage Dashboard"
-                    target={LinkTarget.Blank}
-                    className="overlay-button--link"
-                    href={`https://influxdb.aws.influxdata.io/orgs/844910ece80be8bc/dashboards/0649b03029c49000?vars%5Borgid%5D=${orgID}`}
-                  />
-                </Grid.Column>
-              </Grid.Row>
-              <SpinnerContainer
-                loading={limitsStatus}
-                spinnerComponent={<TechnoSpinner diameterPixels={100} />}
-                testID="limits-spinner-container"
-              >
+            <Panel.Body>
+              <Grid>
                 <Grid.Row>
-                  <h4>Limits</h4>
-                  <Grid.Column widthMD={Columns.Three}>
-                    <Form.Label label="Read (KBs)" testID="read-kbs" />
-                    <LimitsField
-                      type={InputType.Number}
-                      name="rate.readKBs"
-                      limits={limits}
-                      onChangeLimits={setLimits}
-                    />
+                  <Grid.Column widthMD={Columns.Four}>
+                    <label>Organization Name</label>
+                    <p>{organization?.name ?? ''}</p>
                   </Grid.Column>
-                  <Grid.Column widthMD={Columns.Three}>
-                    <Form.Label label="Write (KBs)" />
-                    <LimitsField
-                      type={InputType.Number}
-                      name="rate.writeKBs"
-                      limits={limits}
-                      onChangeLimits={setLimits}
-                    />
+                  <Grid.Column widthMD={Columns.Four}>
+                    <label>Account Type</label>
+                    <p>{organization?.account?.type ?? ''}</p>
                   </Grid.Column>
-                  <Grid.Column widthMD={Columns.Three}>
-                    <Form.Label label="Series Cardinality" />
-                    <LimitsField
-                      type={InputType.Number}
-                      name="rate.cardinality"
-                      limits={limits}
-                      onChangeLimits={setLimits}
+                  <Grid.Column widthMD={Columns.Four}>
+                    <LinkButton
+                      color={ComponentColor.Secondary}
+                      size={ComponentSize.Medium}
+                      shape={ButtonShape.Default}
+                      testID="usage-button"
+                      text="View Usage Dashboard"
+                      target={LinkTarget.Blank}
+                      className="overlay-button--link"
+                      href={`https://influxdb.aws.influxdata.io/orgs/844910ece80be8bc/dashboards/0649b03029c49000?vars%5Borgid%5D=${orgID}`}
                     />
                   </Grid.Column>
                 </Grid.Row>
-                <Grid.Row>
-                  <Grid.Column widthMD={Columns.Three}>
-                    <Form.Label label="Query Time (seconds)" />
-                    <LimitsField
-                      type={InputType.Number}
-                      name="rate.queryTime"
-                      limits={limits}
-                      onChangeLimits={setLimits}
-                    />
-                  </Grid.Column>
-                </Grid.Row>
-                <Grid.Row>
-                  <Grid.Column widthMD={Columns.Three}>
-                    <Form.Label label="Max Buckets" />
-                    <LimitsField
-                      type={InputType.Number}
-                      name="bucket.maxBuckets"
-                      limits={limits}
-                      onChangeLimits={setLimits}
-                    />
-                  </Grid.Column>
-                  <Grid.Column widthMD={Columns.Three}>
-                    <Form.Label label="Max Retention Duration (hours)" />
-                    <LimitsField
-                      type={InputType.Number}
-                      name="bucket.maxRetentionDuration"
-                      limits={limits}
-                      onChangeLimits={setLimits}
-                    />
-                  </Grid.Column>
-                  <Grid.Column widthMD={Columns.Three}>
-                    <Form.Label label="Max Notifications" />
-                    <LimitsField
-                      type={InputType.Number}
-                      name="notificationRule.maxNotifications"
-                      limits={limits}
-                      onChangeLimits={setLimits}
-                    />
-                  </Grid.Column>
-                </Grid.Row>
-                <Grid.Row>
-                  <Grid.Column widthMD={Columns.Three}>
-                    <Form.Label label="Max Dashboards" />
-                    <LimitsField
-                      type={InputType.Number}
-                      name="dashboard.maxDashboards"
-                      limits={limits}
-                      onChangeLimits={setLimits}
-                    />
-                  </Grid.Column>
-                  <Grid.Column widthMD={Columns.Three}>
-                    <Form.Label label="Max Tasks" />
-                    <LimitsField
-                      type={InputType.Number}
-                      name="task.maxTasks"
-                      limits={limits}
-                      onChangeLimits={setLimits}
-                    />
-                  </Grid.Column>
-                  <Grid.Column widthMD={Columns.Three}>
-                    <Form.Label label="Max Checks" />
-                    <LimitsField
-                      type={InputType.Number}
-                      name="check.maxChecks"
-                      limits={limits}
-                      onChangeLimits={setLimits}
-                    />
-                  </Grid.Column>
-                </Grid.Row>
-                <Grid.Row>
-                  <h4>Notification Rules</h4>
-                  <Grid.Column widthMD={Columns.Three}>
-                    <Form.Label label="Blocked Notification Rules" />
-                    <LimitsField
-                      type={InputType.Text}
-                      name="notificationRule.blockedNotificationRules"
-                      limits={limits}
-                      onChangeLimits={setLimits}
-                    />
-                  </Grid.Column>
-                  <Grid.Column widthMD={Columns.Three}>
-                    <Form.Label label="Blocked Notification Endpoints" />
-                    <LimitsField
-                      type={InputType.Text}
-                      name="notificationEndpoint.blockedNotificationEndpoints"
-                      limits={limits}
-                      onChangeLimits={setLimits}
-                    />
-                  </Grid.Column>
-                </Grid.Row>
-              </SpinnerContainer>
-            </Grid>
+                <SpinnerContainer
+                  loading={limitsStatus}
+                  spinnerComponent={<TechnoSpinner diameterPixels={100} />}
+                  testID="limits-spinner-container"
+                >
+                  <Grid.Row>
+                    <h4>Limits</h4>
+                    <Grid.Column widthMD={Columns.Four}>
+                      <Form.Label label="Read (KBs)" testID="read-kbs" />
+                      <LimitsField
+                        type={InputType.Number}
+                        name="rate.readKBs"
+                        limits={limits}
+                        onChangeLimits={setLimits}
+                      />
+                    </Grid.Column>
+                    <Grid.Column widthMD={Columns.Four}>
+                      <Form.Label label="Write (KBs)" />
+                      <LimitsField
+                        type={InputType.Number}
+                        name="rate.writeKBs"
+                        limits={limits}
+                        onChangeLimits={setLimits}
+                      />
+                    </Grid.Column>
+                    <Grid.Column widthMD={Columns.Four}>
+                      <Form.Label label="Series Cardinality" />
+                      <LimitsField
+                        type={InputType.Number}
+                        name="rate.cardinality"
+                        limits={limits}
+                        onChangeLimits={setLimits}
+                      />
+                    </Grid.Column>
+                  </Grid.Row>
+                  <Grid.Row>
+                    <Grid.Column widthMD={Columns.Four}>
+                      <Form.Label label="Query Time (seconds)" />
+                      <LimitsField
+                        type={InputType.Number}
+                        name="rate.queryTime"
+                        limits={limits}
+                        onChangeLimits={setLimits}
+                      />
+                    </Grid.Column>
+                  </Grid.Row>
+                  <Grid.Row>
+                    <Grid.Column widthMD={Columns.Four}>
+                      <Form.Label label="Max Buckets" />
+                      <LimitsField
+                        type={InputType.Number}
+                        name="bucket.maxBuckets"
+                        limits={limits}
+                        onChangeLimits={setLimits}
+                      />
+                    </Grid.Column>
+                    <Grid.Column widthMD={Columns.Four}>
+                      <Form.Label label="Max Retention Duration (hours)" />
+                      <LimitsField
+                        type={InputType.Number}
+                        name="bucket.maxRetentionDuration"
+                        limits={limits}
+                        onChangeLimits={setLimits}
+                      />
+                    </Grid.Column>
+                    <Grid.Column widthMD={Columns.Four}>
+                      <Form.Label label="Max Notifications" />
+                      <LimitsField
+                        type={InputType.Number}
+                        name="notificationRule.maxNotifications"
+                        limits={limits}
+                        onChangeLimits={setLimits}
+                      />
+                    </Grid.Column>
+                  </Grid.Row>
+                  <Grid.Row>
+                    <Grid.Column widthMD={Columns.Four}>
+                      <Form.Label label="Max Dashboards" />
+                      <LimitsField
+                        type={InputType.Number}
+                        name="dashboard.maxDashboards"
+                        limits={limits}
+                        onChangeLimits={setLimits}
+                      />
+                    </Grid.Column>
+                    <Grid.Column widthMD={Columns.Four}>
+                      <Form.Label label="Max Tasks" />
+                      <LimitsField
+                        type={InputType.Number}
+                        name="task.maxTasks"
+                        limits={limits}
+                        onChangeLimits={setLimits}
+                      />
+                    </Grid.Column>
+                    <Grid.Column widthMD={Columns.Four}>
+                      <Form.Label label="Max Checks" />
+                      <LimitsField
+                        type={InputType.Number}
+                        name="check.maxChecks"
+                        limits={limits}
+                        onChangeLimits={setLimits}
+                      />
+                    </Grid.Column>
+                  </Grid.Row>
+                  <Grid.Row>
+                    <h4>Notification Rules</h4>
+                    <Grid.Column widthMD={Columns.Four}>
+                      <Form.Label label="Blocked Notification Rules" />
+                      <LimitsField
+                        type={InputType.Text}
+                        name="notificationRule.blockedNotificationRules"
+                        limits={limits}
+                        onChangeLimits={setLimits}
+                      />
+                    </Grid.Column>
+                    <Grid.Column widthMD={Columns.Four}>
+                      <Form.Label label="Blocked Notification Endpoints" />
+                      <LimitsField
+                        type={InputType.Text}
+                        name="notificationEndpoint.blockedNotificationEndpoints"
+                        limits={limits}
+                        onChangeLimits={setLimits}
+                      />
+                    </Grid.Column>
+                  </Grid.Row>
+                </SpinnerContainer>
+              </Grid>
+            </Panel.Body>
           </Overlay.Body>
           <Overlay.Footer>
             {hasWritePermissions && (


### PR DESCRIPTION
PR touches Org overlay of Operator UI in an attempt to fix the styling of the overlay grid. 

Before fix: 
<img width="618" alt="Screen Shot 2022-07-11 at 11 24 47 AM" src="https://user-images.githubusercontent.com/66275100/178311905-b077654f-de5b-4e32-9e89-1d060c0688ab.png">

After fix: 

<img width="1012" alt="orgoverlay-redesign" src="https://user-images.githubusercontent.com/66275100/178119568-e9768ffe-eedd-438e-9833-99d706a5ccde.png">

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
