### PR TITLE
fix: use idpe /me in lieu of quartz for auth polling

### DIFF
--- a/src/Signin.tsx
+++ b/src/Signin.tsx
@@ -33,7 +33,7 @@ import {
 import {RemoteDataState} from 'src/types'
 
 // APIs
-import {fetchIdentity} from './identity/apis/auth'
+import {fetchLegacyIdentity} from './identity/apis/auth'
 
 interface State {
   loading: RemoteDataState
@@ -97,7 +97,7 @@ export class Signin extends PureComponent<Props, State> {
 
   private checkForLogin = async () => {
     try {
-      await fetchIdentity()
+      await fetchLegacyIdentity()
       this.setState({auth: true})
       const redirectIsSet = !!getFromLocalStorage('redirectTo')
       if (redirectIsSet) {

--- a/src/identity/apis/auth.ts
+++ b/src/identity/apis/auth.ts
@@ -189,7 +189,7 @@ export const fetchQuartzMe = async (): Promise<MeQuartz> => {
 }
 
 // fetch user identity from /me (used in OSS and environments without Quartz)
-const fetchLegacyIdentity = async (): Promise<UserResponseIdpe> => {
+export const fetchLegacyIdentity = async (): Promise<UserResponseIdpe> => {
   const response = await getMeIdpe({})
 
   if (response.status === 401) {

--- a/src/onboarding/containers/LoginPage.tsx
+++ b/src/onboarding/containers/LoginPage.tsx
@@ -12,7 +12,7 @@ import Notifications from 'src/shared/components/notifications/Notifications'
 import {CloudLogoWithCubo} from 'src/onboarding/components/CloudLogoWithCubo'
 
 // APIs
-import {fetchIdentity} from 'src/identity/apis/auth'
+import {fetchLegacyIdentity} from 'src/identity/apis/auth'
 
 // Components
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
@@ -25,7 +25,7 @@ export const LoginPage: FC = () => {
 
   const getSessionValidity = useCallback(async () => {
     try {
-      await fetchIdentity()
+      await fetchLegacyIdentity()
       setHasValidSession(true)
     } catch {
       setHasValidSession(false)


### PR DESCRIPTION
Closes [IDPE #15135](https://github.com/influxdata/idpe/issues/15135)

As implemented in [this PR](https://github.com/influxdata/ui/pull/4896/files), the UI currently decides whether to check for session validity using quartz or IDPE based on whether the user is a cloud user. But there are a limited number of cloud environments that do not yet have access to quartz. This is in the process of being resolved in [quartz](https://github.com/influxdata/quartz/issues/6458). For now, it can't be inferred with certainty that a cloud user can check session validity using a quartz endpoint.

This patches the issue by reverting to the behavior of always using IDPE `/me` to check the user's session validity. I will add a new issue to remind us to return to using quartz endpoints once the quartz backfill is completed.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed) N/A
- [X] Feature flagged, if applicable N/A
