### PR TITLE
feat: Add redux and API layer support for User Profile

### DIFF
--- a/src/accounts/context/userAccount.tsx
+++ b/src/accounts/context/userAccount.tsx
@@ -24,6 +24,8 @@ import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 // Actions
 import {setMe} from 'src/me/actions/creators'
 import {MeState} from 'src/me/reducers'
+
+// API
 import {putDefaultQuartzAccount} from 'src/identity/apis/auth'
 
 export type Props = {

--- a/src/accounts/context/userAccount.tsx
+++ b/src/accounts/context/userAccount.tsx
@@ -15,11 +15,7 @@ import {
 } from 'src/shared/copy/notifications'
 
 // Utils
-import {
-  getAccounts,
-  putAccountsDefault,
-  patchAccount,
-} from 'src/client/unityRoutes'
+import {getAccounts, patchAccount} from 'src/client/unityRoutes'
 
 // Metrics
 import {event} from 'src/cloud/utils/reporting'
@@ -28,6 +24,7 @@ import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 // Actions
 import {setMe} from 'src/me/actions/creators'
 import {MeState} from 'src/me/reducers'
+import {putDefaultQuartzAccount} from 'src/identity/apis/auth'
 
 export type Props = {
   children: JSX.Element
@@ -108,14 +105,9 @@ export const UserAccountProvider: FC<Props> = React.memo(({children}) => {
     const accountName = getAccountNameById(newDefaultAcctId)
 
     try {
-      const resp = await putAccountsDefault({data: {id: newDefaultAcctId}})
+      await putDefaultQuartzAccount(newDefaultAcctId)
       setDefaultAccountId(newDefaultAcctId)
-
-      if (resp.status !== 204) {
-        dispatch(notify(accountDefaultSettingError(accountName)))
-      } else {
-        dispatch(notify(accountDefaultSettingSuccess(accountName)))
-      }
+      dispatch(notify(accountDefaultSettingSuccess(accountName)))
     } catch (error) {
       dispatch(notify(accountDefaultSettingError(accountName)))
     }

--- a/src/accounts/context/userAccount.tsx
+++ b/src/accounts/context/userAccount.tsx
@@ -26,7 +26,7 @@ import {setMe} from 'src/me/actions/creators'
 import {MeState} from 'src/me/reducers'
 
 // API
-import {putDefaultQuartzAccount} from 'src/identity/apis/auth'
+import {updateDefaultQuartzAccount} from 'src/identity/apis/auth'
 
 export type Props = {
   children: JSX.Element
@@ -107,7 +107,7 @@ export const UserAccountProvider: FC<Props> = React.memo(({children}) => {
     const accountName = getAccountNameById(newDefaultAcctId)
 
     try {
-      await putDefaultQuartzAccount(newDefaultAcctId)
+      await updateDefaultQuartzAccount(newDefaultAcctId)
       setDefaultAccountId(newDefaultAcctId)
       dispatch(notify(accountDefaultSettingSuccess(accountName)))
     } catch (error) {

--- a/src/identity/apis/auth.ts
+++ b/src/identity/apis/auth.ts
@@ -66,6 +66,13 @@ export interface CurrentIdentity {
   status?: RemoteDataState
 }
 
+export enum NetworkErrorTypes {
+  UnauthorizedError = 'UnauthorizedError',
+  NotFoundError = 'NotFoundError',
+  ServerError = 'ServerError',
+  GenericError = 'GenericError',
+}
+
 // 401 error
 export class UnauthorizedError extends Error {
   constructor(message) {
@@ -108,6 +115,42 @@ export const fetchIdentity = async () => {
   }
 
   return fetchQuartzMe()
+}
+
+const identityRetryDelay = 30000 // 30 seconds
+const retryLimit = 5
+
+export const retryFetchIdentity = async (
+  retryAttempts = 1,
+  retryDelay = identityRetryDelay
+) => {
+  try {
+    return await fetchIdentity()
+  } catch (error) {
+    if (
+      error.name === NetworkErrorTypes.UnauthorizedError ||
+      error.name === NetworkErrorTypes.GenericError
+    ) {
+      throw error
+    }
+
+    if (error.name === NetworkErrorTypes.ServerError) {
+      if (retryAttempts >= retryLimit) {
+        throw error
+      }
+      return new Promise((resolve, reject) => {
+        setTimeout(() => {
+          retryFetchIdentity(retryAttempts + 1, retryDelay)
+            .then(user => {
+              resolve(user)
+            })
+            .catch(error => {
+              reject(error)
+            })
+        }, retryAttempts * retryDelay)
+      })
+    }
+  }
 }
 
 // fetch user identity from /quartz/identity.
@@ -246,5 +289,6 @@ export const putDefaultQuartzOrg = async (orgId: string) => {
   if (response.status !== 204) {
     throw new ServerError(response.data.message)
   }
+
   return response.data
 }

--- a/src/identity/apis/auth.ts
+++ b/src/identity/apis/auth.ts
@@ -229,9 +229,9 @@ export const fetchAccountDetails = async (
 }
 
 // change the user's default account
-export const putDefaultQuartzAccount = async (
+export const updateDefaultQuartzAccount = async (
   accountId: number
-): Promise<Organization> => {
+): Promise<void> => {
   const response = await putAccountsDefault({
     data: {
       id: accountId,
@@ -242,9 +242,7 @@ export const putDefaultQuartzAccount = async (
     throw new ServerError(response.data.message)
   }
 
-  // success status code is 204; no response in body is expected.
-  const responseEmpty = response.data
-  return responseEmpty
+  // success status code is 204; no data in response.body is expected.
 }
 
 // fetch details about user's current organization

--- a/src/identity/apis/auth.ts
+++ b/src/identity/apis/auth.ts
@@ -277,7 +277,7 @@ export const fetchQuartzOrgs = async (): Promise<OrganizationSummaries> => {
 }
 
 // change default organization for a given account
-export const putDefaultQuartzOrg = async (orgId: string) => {
+export const updateDefaultQuartzOrg = async (orgId: string) => {
   const response = await putOrgsDefault({
     data: {
       id: orgId,

--- a/src/identity/apis/auth.ts
+++ b/src/identity/apis/auth.ts
@@ -239,7 +239,7 @@ export const putDefaultQuartzAccount = async (
   })
 
   if (response.status === 500) {
-    throw new UnauthorizedError(response.data.message)
+    throw new ServerError(response.data.message)
   }
 
   const responseEmpty = response.data

--- a/src/identity/apis/auth.ts
+++ b/src/identity/apis/auth.ts
@@ -242,6 +242,7 @@ export const putDefaultQuartzAccount = async (
     throw new ServerError(response.data.message)
   }
 
+  // success status code is 204; no response in body is expected.
   const responseEmpty = response.data
   return responseEmpty
 }

--- a/src/identity/quartzOrganizations/actions/creators/index.ts
+++ b/src/identity/quartzOrganizations/actions/creators/index.ts
@@ -3,10 +3,10 @@ import {RemoteDataState} from 'src/types'
 
 export const SET_QUARTZ_ORGANIZATIONS = 'SET_QUARTZ_ORGANIZATIONS'
 export const SET_QUARTZ_ORGANIZATIONS_STATUS = 'SET_QUARTZ_ORGANIZATIONS_STATUS'
-export const SET_DEFAULT_QUARTZ_ORG = 'SET_DEFAULT_QUARTZ_ORG'
+export const SET_QUARTZ_DEFAULT_ORG = 'SET_QUARTZ_DEFAULT_ORG'
 
 export type Actions =
-  | ReturnType<typeof setDefaultOrg>
+  | ReturnType<typeof setQuartzDefaultOrg>
   | ReturnType<typeof setQuartzOrganizations>
   | ReturnType<typeof setQuartzOrganizationsStatus>
 
@@ -24,12 +24,12 @@ export const setQuartzOrganizationsStatus = (status: RemoteDataState) =>
     status: status,
   } as const)
 
-export const setDefaultOrg = (
+export const setQuartzDefaultOrg = (
   oldDefaultOrgId: string,
   newDefaultOrgId: string
 ) =>
   ({
-    type: SET_DEFAULT_QUARTZ_ORG,
+    type: SET_QUARTZ_DEFAULT_ORG,
     oldDefaultOrgId: oldDefaultOrgId,
     newDefaultOrgId: newDefaultOrgId,
   } as const)

--- a/src/identity/quartzOrganizations/actions/creators/index.ts
+++ b/src/identity/quartzOrganizations/actions/creators/index.ts
@@ -3,8 +3,10 @@ import {RemoteDataState} from 'src/types'
 
 export const SET_QUARTZ_ORGANIZATIONS = 'SET_QUARTZ_ORGANIZATIONS'
 export const SET_QUARTZ_ORGANIZATIONS_STATUS = 'SET_QUARTZ_ORGANIZATIONS_STATUS'
+export const SET_DEFAULT_QUARTZ_ORG = 'SET_DEFAULT_QUARTZ_ORG'
 
 export type Actions =
+  | ReturnType<typeof setDefaultOrg>
   | ReturnType<typeof setQuartzOrganizations>
   | ReturnType<typeof setQuartzOrganizationsStatus>
 
@@ -20,4 +22,14 @@ export const setQuartzOrganizationsStatus = (status: RemoteDataState) =>
   ({
     type: SET_QUARTZ_ORGANIZATIONS_STATUS,
     status: status,
+  } as const)
+
+export const setDefaultOrg = (
+  oldDefaultOrgId: string,
+  newDefaultOrgId: string
+) =>
+  ({
+    type: SET_DEFAULT_QUARTZ_ORG,
+    oldDefaultOrgId: oldDefaultOrgId,
+    newDefaultOrgId: newDefaultOrgId,
   } as const)

--- a/src/identity/quartzOrganizations/actions/thunks/index.ts
+++ b/src/identity/quartzOrganizations/actions/thunks/index.ts
@@ -21,11 +21,7 @@ type DefaultOrg = OrganizationSummaries[number]
 
 // Notifications
 import {notify} from 'src/shared/actions/notifications'
-import {
-  accountDefaultSettingSuccess,
-  accountDefaultSettingError,
-  updateQuartzOrganizationsFailed,
-} from 'src/shared/copy/notifications'
+import {updateQuartzOrganizationsFailed} from 'src/shared/copy/notifications'
 
 export const getQuartzOrganizationsThunk = () => async (
   dispatch: Dispatch<Actions>
@@ -48,13 +44,14 @@ export const updateDefaultOrgThunk = (
 ) => async (dispatch: Dispatch<Actions>) => {
   try {
     dispatch(setQuartzOrganizationsStatus(RemoteDataState.Loading))
+
     await putDefaultQuartzOrg(newDefaultOrg.id)
+
     dispatch(setQuartzDefaultOrg(oldDefaultOrg.id, newDefaultOrg.id))
 
     dispatch(setQuartzOrganizationsStatus(RemoteDataState.Done))
-    dispatch(notify(accountDefaultSettingSuccess(newDefaultOrg.name)))
   } catch (err) {
     dispatch(setQuartzOrganizationsStatus(RemoteDataState.Error))
-    dispatch(notify(accountDefaultSettingError(newDefaultOrg.name)))
+    throw Error(err)
   }
 }

--- a/src/identity/quartzOrganizations/actions/thunks/index.ts
+++ b/src/identity/quartzOrganizations/actions/thunks/index.ts
@@ -6,7 +6,7 @@ import {fetchQuartzOrgs, putDefaultQuartzOrg} from 'src/identity/apis/auth'
 // Actions
 import {
   Actions as QuartzOrganizationActions,
-  setDefaultOrg,
+  setQuartzDefaultOrg,
   setQuartzOrganizations,
   setQuartzOrganizationsStatus,
 } from 'src/identity/quartzOrganizations/actions/creators'
@@ -14,16 +14,18 @@ import {PublishNotificationAction} from 'src/shared/actions/notifications'
 
 // Types
 import {RemoteDataState} from 'src/types'
+import {OrganizationSummaries} from 'src/client/unityRoutes'
+
 type Actions = QuartzOrganizationActions | PublishNotificationAction
+type DefaultOrg = OrganizationSummaries[number]
 
 // Notifications
 import {notify} from 'src/shared/actions/notifications'
 import {
-  updateQuartzOrganizationsFailed,
   accountDefaultSettingSuccess,
   accountDefaultSettingError,
+  updateQuartzOrganizationsFailed,
 } from 'src/shared/copy/notifications'
-import {OrganizationSummaries} from 'src/client/unityRoutes'
 
 export const getQuartzOrganizationsThunk = () => async (
   dispatch: Dispatch<Actions>
@@ -41,13 +43,13 @@ export const getQuartzOrganizationsThunk = () => async (
 }
 
 export const updateDefaultOrgThunk = (
-  oldDefaultOrg: OrganizationSummaries[number],
-  newDefaultOrg: OrganizationSummaries[number]
-) => async (dispatch: any) => {
+  oldDefaultOrg: DefaultOrg,
+  newDefaultOrg: DefaultOrg
+) => async (dispatch: Dispatch<Actions>) => {
   try {
     dispatch(setQuartzOrganizationsStatus(RemoteDataState.Loading))
     await putDefaultQuartzOrg(newDefaultOrg.id)
-    dispatch(setDefaultOrg(oldDefaultOrg.id, newDefaultOrg.id))
+    dispatch(setQuartzDefaultOrg(oldDefaultOrg.id, newDefaultOrg.id))
 
     dispatch(setQuartzOrganizationsStatus(RemoteDataState.Done))
     dispatch(notify(accountDefaultSettingSuccess(newDefaultOrg.name)))

--- a/src/identity/quartzOrganizations/actions/thunks/index.ts
+++ b/src/identity/quartzOrganizations/actions/thunks/index.ts
@@ -1,11 +1,12 @@
 import {Dispatch} from 'react'
 
 // API
-import {fetchQuartzOrgs} from 'src/identity/apis/auth'
+import {fetchQuartzOrgs, putDefaultQuartzOrg} from 'src/identity/apis/auth'
 
 // Actions
 import {
   Actions as QuartzOrganizationActions,
+  setDefaultOrg,
   setQuartzOrganizations,
   setQuartzOrganizationsStatus,
 } from 'src/identity/quartzOrganizations/actions/creators'
@@ -17,7 +18,12 @@ type Actions = QuartzOrganizationActions | PublishNotificationAction
 
 // Notifications
 import {notify} from 'src/shared/actions/notifications'
-import {updateQuartzOrganizationsFailed} from 'src/shared/copy/notifications'
+import {
+  updateQuartzOrganizationsFailed,
+  accountDefaultSettingSuccess,
+  accountDefaultSettingError,
+} from 'src/shared/copy/notifications'
+import {OrganizationSummaries} from 'src/client/unityRoutes'
 
 export const getQuartzOrganizationsThunk = () => async (
   dispatch: Dispatch<Actions>
@@ -31,5 +37,22 @@ export const getQuartzOrganizationsThunk = () => async (
   } catch (error) {
     dispatch(setQuartzOrganizationsStatus(RemoteDataState.Error))
     dispatch(notify(updateQuartzOrganizationsFailed()))
+  }
+}
+
+export const updateDefaultOrgThunk = (
+  oldDefaultOrg: OrganizationSummaries[number],
+  newDefaultOrg: OrganizationSummaries[number]
+) => async (dispatch: any) => {
+  try {
+    dispatch(setQuartzOrganizationsStatus(RemoteDataState.Loading))
+    await putDefaultQuartzOrg(newDefaultOrg.id)
+    dispatch(setDefaultOrg(oldDefaultOrg.id, newDefaultOrg.id))
+
+    dispatch(setQuartzOrganizationsStatus(RemoteDataState.Done))
+    dispatch(notify(accountDefaultSettingSuccess(newDefaultOrg.name)))
+  } catch (err) {
+    dispatch(setQuartzOrganizationsStatus(RemoteDataState.Error))
+    dispatch(notify(accountDefaultSettingError(newDefaultOrg.name)))
   }
 }

--- a/src/identity/quartzOrganizations/actions/thunks/index.ts
+++ b/src/identity/quartzOrganizations/actions/thunks/index.ts
@@ -1,7 +1,7 @@
 import {Dispatch} from 'react'
 
 // API
-import {fetchQuartzOrgs, putDefaultQuartzOrg} from 'src/identity/apis/auth'
+import {fetchQuartzOrgs, updateDefaultQuartzOrg} from 'src/identity/apis/auth'
 
 // Actions
 import {
@@ -45,7 +45,7 @@ export const updateDefaultOrgThunk = (
   try {
     dispatch(setQuartzOrganizationsStatus(RemoteDataState.Loading))
 
-    await putDefaultQuartzOrg(newDefaultOrg.id)
+    await updateDefaultQuartzOrg(newDefaultOrg.id)
 
     dispatch(setQuartzDefaultOrg(oldDefaultOrg.id, newDefaultOrg.id))
 

--- a/src/identity/quartzOrganizations/reducers/index.ts
+++ b/src/identity/quartzOrganizations/reducers/index.ts
@@ -3,6 +3,7 @@ import {
   Actions,
   SET_QUARTZ_ORGANIZATIONS,
   SET_QUARTZ_ORGANIZATIONS_STATUS,
+  SET_DEFAULT_QUARTZ_ORG,
 } from 'src/identity/quartzOrganizations/actions/creators'
 import {emptyOrg} from 'src/identity/components/GlobalHeader/DefaultEntities'
 import produce from 'immer'
@@ -22,6 +23,23 @@ export default (state = initialState, action: Actions): QuartzOrganizations =>
       }
       case SET_QUARTZ_ORGANIZATIONS_STATUS: {
         draftState.status = action.status
+        return
+      }
+
+      case SET_DEFAULT_QUARTZ_ORG: {
+        const {oldDefaultOrgId, newDefaultOrgId} = action
+
+        if (oldDefaultOrgId !== newDefaultOrgId) {
+          draftState.orgs.forEach(org => {
+            if (org.id === oldDefaultOrgId) {
+              org.isDefault = false
+            }
+
+            if (org.id === newDefaultOrgId) {
+              org.isDefault = true
+            }
+          })
+        }
         return
       }
     }

--- a/src/identity/quartzOrganizations/reducers/index.ts
+++ b/src/identity/quartzOrganizations/reducers/index.ts
@@ -3,7 +3,7 @@ import {
   Actions,
   SET_QUARTZ_ORGANIZATIONS,
   SET_QUARTZ_ORGANIZATIONS_STATUS,
-  SET_DEFAULT_QUARTZ_ORG,
+  SET_QUARTZ_DEFAULT_ORG,
 } from 'src/identity/quartzOrganizations/actions/creators'
 import {emptyOrg} from 'src/identity/components/GlobalHeader/DefaultEntities'
 import produce from 'immer'
@@ -26,7 +26,7 @@ export default (state = initialState, action: Actions): QuartzOrganizations =>
         return
       }
 
-      case SET_DEFAULT_QUARTZ_ORG: {
+      case SET_QUARTZ_DEFAULT_ORG: {
         const {oldDefaultOrgId, newDefaultOrgId} = action
 
         if (oldDefaultOrgId !== newDefaultOrgId) {

--- a/src/shared/copy/notifications/categories/accounts-users-orgs.ts
+++ b/src/shared/copy/notifications/categories/accounts-users-orgs.ts
@@ -71,6 +71,29 @@ export const orgRenameFailed = (orgName): Notification => ({
   message: `Failed to update organization "${orgName}"`,
 })
 
+export const updateIdentityFailed = (): Notification => ({
+  ...defaultErrorNotification,
+  message: 'Error retrieving user identity. Please refresh this page.',
+})
+
+export const updateBillingFailed = (): Notification => ({
+  ...defaultErrorNotification,
+  message:
+    'Error retrieving account billing provider. Please refresh this page.',
+})
+
+export const updateOrgFailed = (): Notification => ({
+  ...defaultErrorNotification,
+  message:
+    'Error retrieving new organization information. Please refresh this page.',
+})
+
+export const updateQuartzOrganizationsFailed = (): Notification => ({
+  ...defaultErrorNotification,
+  message:
+    'We were unable to retrieve the list of your InfluxData organizations. Please refresh this page.',
+})
+
 export const memberAddSuccess = (username: string): Notification => ({
   ...defaultSuccessNotification,
   message: `Member "${username}" was added successfully`,
@@ -130,28 +153,4 @@ export const removeUserSuccessful = (): Notification => ({
 export const removeUserFailed = (): Notification => ({
   ...defaultErrorNotification,
   message: `Error removing user, try again`,
-})
-
-// These should be removed from the users section and go further up in this file.
-export const updateIdentityFailed = (): Notification => ({
-  ...defaultErrorNotification,
-  message: 'Error retrieving user identity. Please refresh this page.',
-})
-
-export const updateBillingFailed = (): Notification => ({
-  ...defaultErrorNotification,
-  message:
-    'Error retrieving account billing provider. Please refresh this page.',
-})
-
-export const updateOrgFailed = (): Notification => ({
-  ...defaultErrorNotification,
-  message:
-    'Error retrieving new organization information. Please refresh this page.',
-})
-
-export const updateQuartzOrganizationsFailed = (): Notification => ({
-  ...defaultErrorNotification,
-  message:
-    'We were unable to retrieve the list of your InfluxData organizations. Please refresh this page.',
 })

--- a/src/shared/copy/notifications/categories/accounts-users-orgs.ts
+++ b/src/shared/copy/notifications/categories/accounts-users-orgs.ts
@@ -4,6 +4,13 @@ import {
   defaultSuccessNotification,
 } from 'src/shared/copy/notifications'
 
+export const accountDefaultSettingError = (
+  accountName: string
+): Notification => ({
+  ...defaultErrorNotification,
+  message: `Account "${accountName}" was not set as the default account. The default is unchanged.`,
+})
+
 export const accountDefaultSettingSuccess = (
   accountName: string
 ): Notification => ({
@@ -11,11 +18,9 @@ export const accountDefaultSettingSuccess = (
   message: `Account "${accountName}" was successfully set as the default account`,
 })
 
-export const accountDefaultSettingError = (
-  accountName: string
-): Notification => ({
+export const accountRenameError = (accountName: string): Notification => ({
   ...defaultErrorNotification,
-  message: `Account "${accountName}" was not set as the default account. The default is unchanged.`,
+  message: `Account "${accountName}" was not renamed; the rename update failed`,
 })
 
 export const accountRenameSuccess = (
@@ -26,14 +31,54 @@ export const accountRenameSuccess = (
   message: `Account "${oldAccountName}" was successfully renamed to "${newAccountName}"`,
 })
 
-export const accountRenameError = (accountName: string): Notification => ({
+export const inviteFailed = (): Notification => ({
   ...defaultErrorNotification,
-  message: `Account "${accountName}" was not renamed; the rename update failed`,
+  message: `invite failed`,
 })
 
-export const orgCreateSuccess = (): Notification => ({
+export const invitationResentFailed = (): Notification => ({
+  ...defaultErrorNotification,
+  message: `Error sending invitation`,
+})
+
+export const invitationResentSuccessful = (): Notification => ({
   ...defaultSuccessNotification,
-  message: 'Organization was successfully created',
+  message: `Invitation Re-sent`,
+})
+
+export const inviteSent = (): Notification => ({
+  ...defaultSuccessNotification,
+  message: `Invitation Sent`,
+})
+
+export const invitationWithdrawnFailed = (): Notification => ({
+  ...defaultErrorNotification,
+  message: `Error withdrawing invite, try again`,
+})
+
+export const invitationWithdrawnSuccessful = (): Notification => ({
+  ...defaultSuccessNotification,
+  message: `Invitation Withdrawn`,
+})
+
+export const memberAddFailed = (message: string): Notification => ({
+  ...defaultErrorNotification,
+  message: `Failed to add members: "${message}"`,
+})
+
+export const memberAddSuccess = (username: string): Notification => ({
+  ...defaultSuccessNotification,
+  message: `Member "${username}" was added successfully`,
+})
+
+export const memberRemoveFailed = (message: string): Notification => ({
+  ...defaultErrorNotification,
+  message: `Failed to remove members: "${message}"`,
+})
+
+export const memberRemoveSuccess = (memberName: string): Notification => ({
+  ...defaultSuccessNotification,
+  message: `Member "${memberName}" was removed successfully`,
 })
 
 export const orgCreateFailed = (): Notification => ({
@@ -41,9 +86,9 @@ export const orgCreateFailed = (): Notification => ({
   message: 'Failed to create organization',
 })
 
-export const orgDefaultSettingSuccess = (orgName: string): Notification => ({
+export const orgCreateSuccess = (): Notification => ({
   ...defaultSuccessNotification,
-  message: `Organization "${orgName}" was successfully set as the default organization`,
+  message: 'Organization was successfully created',
 })
 
 export const orgDefaultSettingError = (orgName: string): Notification => ({
@@ -51,9 +96,9 @@ export const orgDefaultSettingError = (orgName: string): Notification => ({
   message: `Organization "${orgName}" could not be set as the default organization. Please try again.`,
 })
 
-export const orgEditSuccess = (): Notification => ({
+export const orgDefaultSettingSuccess = (orgName: string): Notification => ({
   ...defaultSuccessNotification,
-  message: 'Organization was successfully updated',
+  message: `Organization "${orgName}" was successfully set as the default organization`,
 })
 
 export const orgEditFailed = (): Notification => ({
@@ -61,9 +106,9 @@ export const orgEditFailed = (): Notification => ({
   message: 'Failed to update organization',
 })
 
-export const orgRenameSuccess = (orgName: string): Notification => ({
+export const orgEditSuccess = (): Notification => ({
   ...defaultSuccessNotification,
-  message: `Organization was successfully renamed "${orgName}"`,
+  message: 'Organization was successfully updated',
 })
 
 export const orgRenameFailed = (orgName): Notification => ({
@@ -71,15 +116,30 @@ export const orgRenameFailed = (orgName): Notification => ({
   message: `Failed to update organization "${orgName}"`,
 })
 
-export const updateIdentityFailed = (): Notification => ({
+export const orgRenameSuccess = (orgName: string): Notification => ({
+  ...defaultSuccessNotification,
+  message: `Organization was successfully renamed "${orgName}"`,
+})
+
+export const removeUserFailed = (): Notification => ({
   ...defaultErrorNotification,
-  message: 'Error retrieving user identity. Please refresh this page.',
+  message: `Error removing user, try again`,
+})
+
+export const removeUserSuccessful = (): Notification => ({
+  ...defaultSuccessNotification,
+  message: `User Removed`,
 })
 
 export const updateBillingFailed = (): Notification => ({
   ...defaultErrorNotification,
   message:
     'Error retrieving account billing provider. Please refresh this page.',
+})
+
+export const updateIdentityFailed = (): Notification => ({
+  ...defaultErrorNotification,
+  message: 'Error retrieving user identity. Please refresh this page.',
 })
 
 export const updateOrgFailed = (): Notification => ({
@@ -92,65 +152,4 @@ export const updateQuartzOrganizationsFailed = (): Notification => ({
   ...defaultErrorNotification,
   message:
     'We were unable to retrieve the list of your InfluxData organizations. Please refresh this page.',
-})
-
-export const memberAddSuccess = (username: string): Notification => ({
-  ...defaultSuccessNotification,
-  message: `Member "${username}" was added successfully`,
-})
-
-export const memberAddFailed = (message: string): Notification => ({
-  ...defaultErrorNotification,
-  message: `Failed to add members: "${message}"`,
-})
-
-export const memberRemoveSuccess = (memberName: string): Notification => ({
-  ...defaultSuccessNotification,
-  message: `Member "${memberName}" was removed successfully`,
-})
-
-export const memberRemoveFailed = (message: string): Notification => ({
-  ...defaultErrorNotification,
-  message: `Failed to remove members: "${message}"`,
-})
-
-/* USERS NOTIFICATIONS */
-export const inviteSent = (): Notification => ({
-  ...defaultSuccessNotification,
-  message: `Invitation Sent`,
-})
-
-export const inviteFailed = (): Notification => ({
-  ...defaultErrorNotification,
-  message: `invite failed`,
-})
-
-export const invitationResentSuccessful = (): Notification => ({
-  ...defaultSuccessNotification,
-  message: `Invitation Re-sent`,
-})
-
-export const invitationResentFailed = (): Notification => ({
-  ...defaultErrorNotification,
-  message: `Error sending invitation`,
-})
-
-export const invitationWithdrawnSuccessful = (): Notification => ({
-  ...defaultSuccessNotification,
-  message: `Invitation Withdrawn`,
-})
-
-export const invitationWithdrawnFailed = (): Notification => ({
-  ...defaultErrorNotification,
-  message: `Error withdrawing invite, try again`,
-})
-
-export const removeUserSuccessful = (): Notification => ({
-  ...defaultSuccessNotification,
-  message: `User Removed`,
-})
-
-export const removeUserFailed = (): Notification => ({
-  ...defaultErrorNotification,
-  message: `Error removing user, try again`,
 })

--- a/src/shared/copy/notifications/categories/accounts-users-orgs.ts
+++ b/src/shared/copy/notifications/categories/accounts-users-orgs.ts
@@ -11,11 +11,13 @@ export const accountDefaultSettingSuccess = (
   message: `Account "${accountName}" was successfully set as the default account`,
 })
 
+// There could be more than one error here. In one case, the account isn't already teh default account
+// But there could be other errors resulting from states other than starting with a non-default account.
 export const accountDefaultSettingError = (
   accountName: string
 ): Notification => ({
   ...defaultErrorNotification,
-  message: `Account "${accountName}" was not set as the default account; the default is unchanged`,
+  message: `Account "${accountName}" was not set as the default account. The default is unchanged.`,
 })
 
 export const accountRenameSuccess = (
@@ -39,6 +41,16 @@ export const orgCreateSuccess = (): Notification => ({
 export const orgCreateFailed = (): Notification => ({
   ...defaultErrorNotification,
   message: 'Failed to create organization',
+})
+
+export const orgDefaultSettingSuccess = (orgName: string): Notification => ({
+  ...defaultSuccessNotification,
+  message: `Organization "${orgName}" was successfully set as the default organization`,
+})
+
+export const orgDefaultSettingError = (orgName: string): Notification => ({
+  ...defaultErrorNotification,
+  message: `Organization "${orgName}" could not be set as the default organization. Please try again.`,
 })
 
 export const orgEditSuccess = (): Notification => ({
@@ -122,6 +134,7 @@ export const removeUserFailed = (): Notification => ({
   message: `Error removing user, try again`,
 })
 
+// These should be removed from the users section and go further up in this file.
 export const updateIdentityFailed = (): Notification => ({
   ...defaultErrorNotification,
   message: 'Error retrieving user identity. Please refresh this page.',

--- a/src/shared/copy/notifications/categories/accounts-users-orgs.ts
+++ b/src/shared/copy/notifications/categories/accounts-users-orgs.ts
@@ -11,8 +11,6 @@ export const accountDefaultSettingSuccess = (
   message: `Account "${accountName}" was successfully set as the default account`,
 })
 
-// There could be more than one error here. In one case, the account isn't already teh default account
-// But there could be other errors resulting from states other than starting with a non-default account.
 export const accountDefaultSettingError = (
   accountName: string
 ): Notification => ({


### PR DESCRIPTION
This PR provides a framework that will be used to support the user profile page: UI #4049. Specifically, it

1. Adds a thunk and a reducer to handle changing the user's default organization.
2. Adds a method in the API layer to clean up error handling for changing the user's default account
     * (switch-account functionality is handled by context, not redux)
3. Adds error notifications if the request to change the user's default organization fails. 

Also cleaned up error notifications for failure to change the default account.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed) - N/A
- [X] Feature flagged, if applicable
