### PR TITLE
fix(4882): groupby values should be added to both builderConfig and queryBuilder

### DIFF
--- a/src/timeMachine/reducers/index.ts
+++ b/src/timeMachine/reducers/index.ts
@@ -842,11 +842,12 @@ export const timeMachineReducer = (
 
           // but for the group aggregate, want to set default values
           if (builderAggregateFunctionType === 'group') {
-            draftQuery.builderConfig.tags[
-              index
-            ].values = draftQuery.builderConfig.tags
+            const initValues = draftQuery.builderConfig.tags
               .map(t => t.key)
               .filter(x => !!x)
+
+            draftQuery.builderConfig.tags[index].values = initValues
+            draftState.queryBuilder.tags[index].values = initValues
           }
 
           draftQuery.builderConfig.tags[


### PR DESCRIPTION
Part of #4882 

## Bug:
* `TypeError: Cannot read properties of undefined (reading 'values')`
   *  <img width="500" alt="Screen Shot 2022-07-11 at 4 50 15 PM" src="https://user-images.githubusercontent.com/10232835/178377425-f712c59c-2316-4ed2-9290-bccf461f2061.png">

* This error first occurred on May 31st, after this PR was merged. https://github.com/influxdata/ui/pull/4716/files
   *  <img width="500" alt="Screen Shot 2022-07-11 at 4 48 49 PM" src="https://user-images.githubusercontent.com/10232835/178377276-c12d1639-313b-4dc5-ae0d-63e3f0e12531.png">
   * We added groupby tags to the builderConfig state, but not the queryBuilder state. Need both.

