### PR TITLE
fix(4882): change docs link used for csv.from(), to get closer to what works.

### DIFF
--- a/src/writeData/components/fileUploads/AnnotatedCSV.md
+++ b/src/writeData/components/fileUploads/AnnotatedCSV.md
@@ -1,4 +1,4 @@
-For more detailed and up to date information check out the [Annotated CSV Documentation](https://docs.influxdata.com/influxdb/v2.3/reference/syntax/annotated-csv/#annotated-csv-in-flux)
+For more detailed and up to date information check out the [Annotated CSV Documentation](https://docs.influxdata.com/influxdb/cloud/reference/syntax/annotated-csv/#annotated-csv-in-flux)
 
 ##### Getting Started
 

--- a/src/writeData/components/fileUploads/AnnotatedCSV.md
+++ b/src/writeData/components/fileUploads/AnnotatedCSV.md
@@ -1,4 +1,4 @@
-For more detailed and up to date information check out the [Annotated CSV Documentation](https://docs.influxdata.com/influxdb/v2.0/write-data/developer-tools/csv/#csv-annotations)
+For more detailed and up to date information check out the [Annotated CSV Documentation](https://docs.influxdata.com/influxdb/v2.3/reference/syntax/annotated-csv/#annotated-csv-in-flux)
 
 ##### Getting Started
 


### PR DESCRIPTION
Part of #4882 

## Error message in honeybadger:
* `uploadCsv function: error in csv.from()...`
* There is a whole set of these errors coming from when the csv uploaded (via flux query to backend) is invalid.
  * Expected error. This information is already surfaced to the user.
* However, there is ALSO a big spike in these errors starting April 12th.
  * <img width="500" alt="Screen Shot 2022-07-11 at 6 24 26 PM" src="https://user-images.githubusercontent.com/10232835/178387951-ebceb780-4681-439d-bb26-d8e841a06a28.png">
  * the vast majority of these are `error in csv.from(): failed to read metadata: missing expected annotation datatype. consider using the mode: "raw" for csv`

## Observation from use:
* the example provided at the link does not work.
  * is both out of date (older flux version). And points out a bunch of annotated csv examples which does not works. (Because we need ALL header and annotation rows.)
  * Will get the "raw" error seen in honeybadger.
* This example does work.
  * https://docs.influxdata.com/influxdb/cloud/reference/syntax/annotated-csv/#annotated-csv-in-flux
    * this is actually what we use to upload the csv anyways. We are using annotated-csv-in-flux (in our hardcoded flux). 
  * NOTE: the user will still have to add in the `_field`. Since adding to a bucket. (This explicit message will be surfaced to the user.)

## Followup:
- [x] file ticket with docs, to get the `_field` added to that example too. So it will work on copy/paste.
    * https://github.com/influxdata/docs-v2/pull/4206