### PR TITLE
chore: add placeholder files for garden-based development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,8 @@ src/client/pinnedItemRoutes.ts
 src/client/subscriptionsRoutes.ts
 src/client/uiproxydRoutes.ts
 src/client/unityRoutes.ts
+
+# Garden related items
+/.garden
+/error.log
+/*.generated.garden.yml

--- a/project.garden.yml
+++ b/project.garden.yml
@@ -7,12 +7,12 @@ environments:
       namespace: ${local.env.TWODOTOH_NAMESPACE}
 providers:
   - name: kubernetes
-    environments: ["dev"]
-    context:  ${var.context-name}
+    environments: ['dev']
+    context: ${var.context-name}
     namespace:
       name: ${var.namespace}
     kaniko:
-      extraFlags: ["--use-new-run", "--log-timestamp"]
+      extraFlags: ['--use-new-run', '--log-timestamp']
       image: gcr.io/kaniko-project/executor:debug-v1.2.0
       namespace: ${var.namespace}
     buildMode: kaniko

--- a/project.garden.yml
+++ b/project.garden.yml
@@ -1,0 +1,18 @@
+kind: Project
+name: idpe
+environments:
+  - name: dev
+    variables:
+      context-name: ${local.env.CONTEXT_NAME}
+      namespace: ${local.env.TWODOTOH_NAMESPACE}
+providers:
+  - name: kubernetes
+    environments: ["dev"]
+    context:  ${var.context-name}
+    namespace:
+      name: ${var.namespace}
+    kaniko:
+      extraFlags: ["--use-new-run", "--log-timestamp"]
+      image: gcr.io/kaniko-project/executor:debug-v1.2.0
+      namespace: ${var.namespace}
+    buildMode: kaniko


### PR DESCRIPTION
Placeholder files for using `garden dev --local-mode` (reverse proxy mechanism) to work with UI.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
