### PR TITLE
feat(multi-org): add user profile icon and popover menu

### DIFF
--- a/src/identity/components/GlobalHeader/GlobalHeader.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeader.tsx
@@ -28,6 +28,7 @@ import {
   emptyOrg,
 } from 'src/identity/components/GlobalHeader/DefaultEntities'
 import {alphaSortSelectedFirst} from 'src/identity/utils/alphaSortSelectedFirst'
+import IdentityUserAvatar from './IdentityUserAvatar'
 
 export const GlobalHeader: FC = () => {
   const dispatch = useDispatch()
@@ -85,6 +86,7 @@ export const GlobalHeader: FC = () => {
             />
             <Icon glyph={IconFont.CaretRight} />
             <OrgDropdown activeOrg={activeOrg} orgsList={sortedOrgs} />
+            <IdentityUserAvatar user={identity.currentIdentity.user} />
           </>
         )}
       </FlexBox>

--- a/src/identity/components/GlobalHeader/GlobalHeader.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeader.tsx
@@ -86,10 +86,10 @@ export const GlobalHeader: FC = () => {
             />
             <Icon glyph={IconFont.CaretRight} />
             <OrgDropdown activeOrg={activeOrg} orgsList={sortedOrgs} />
-            <IdentityUserAvatar user={identity.currentIdentity.user} />
           </>
         )}
       </FlexBox>
+      <IdentityUserAvatar user={identity.currentIdentity.user} />
     </FlexBox>
   )
 }

--- a/src/identity/components/GlobalHeader/IdentityUserAvatar.tsx
+++ b/src/identity/components/GlobalHeader/IdentityUserAvatar.tsx
@@ -6,7 +6,6 @@ import {
   ClickOutside,
   ComponentColor,
   FlexBox,
-  FlexDirection,
   Icon,
   IconFont,
   InfluxColors,
@@ -83,10 +82,10 @@ class IdentityUserAvatar extends React.Component<Props, State> {
           </a>
           <a className="user-popover-footer--button">
             <Icon
-              glyph={IconFont.UserOutline_New}
+              glyph={IconFont.Logout_New}
               className="user-popover-footer--button-icon"
             />
-            Profile
+            Log Out
           </a>
         </div>
       </div>
@@ -96,7 +95,7 @@ class IdentityUserAvatar extends React.Component<Props, State> {
   private getPopoverStyle = () => {
     return {
       position: 'absolute',
-      top: 50,
+      top: 60,
       right: 32,
       opacity: this.state.isPopoverOpen ? 100 : 0,
     } as CSSProperties

--- a/src/identity/components/GlobalHeader/IdentityUserAvatar.tsx
+++ b/src/identity/components/GlobalHeader/IdentityUserAvatar.tsx
@@ -3,10 +3,16 @@ import {IdentityUser} from 'src/client/unityRoutes'
 import {
   Button,
   ButtonShape,
+  ClickOutside,
   ComponentColor,
+  FlexBox,
+  FlexDirection,
+  Icon,
+  IconFont,
   InfluxColors,
-  Popover,
 } from '@influxdata/clockface'
+
+import './UserPopoverStyles.scss'
 
 type Props = {
   user: IdentityUser
@@ -24,10 +30,6 @@ class IdentityUserAvatar extends React.Component<Props, State> {
     }
   }
 
-  private popoverTriggerRef: React.RefObject<
-    HTMLButtonElement
-  > = React.createRef()
-
   private getInitials = (): string => {
     const {user} = this.props
     const firstName = user.firstName
@@ -41,6 +43,7 @@ class IdentityUserAvatar extends React.Component<Props, State> {
     const {isPopoverOpen} = this.state
 
     const style: CSSProperties = {
+      margin: 0,
       borderRadius: '50%',
       border: isPopoverOpen ? 'none' : `2px solid ${InfluxColors.Grey65}`,
       background: isPopoverOpen
@@ -50,12 +53,13 @@ class IdentityUserAvatar extends React.Component<Props, State> {
     return style
   }
 
-  private setPopoverStateClosed = () => {
-    this.setState({isPopoverOpen: false})
+  private togglePopoverState = () => {
+    const {isPopoverOpen} = this.state
+    this.setState({isPopoverOpen: !isPopoverOpen})
   }
 
-  private setPopoverStateOpen = () => {
-    this.setState({isPopoverOpen: true})
+  private setPopoverStateClosed = () => {
+    this.setState({isPopoverOpen: false})
   }
 
   private getUserPopoverContents = () => {
@@ -67,46 +71,59 @@ class IdentityUserAvatar extends React.Component<Props, State> {
             {user.firstName} {user.lastName}
           </div>
           <div className="user-popover-header-email">{user.email}</div>
+          <hr />
         </div>
-        <hr />
         <div className="user-popover-footer">
-          <Button
-            shape={ButtonShape.StretchToFit}
-            color={ComponentColor.Default}
-            text="Profile"
-          />
-          <Button
-            shape={ButtonShape.StretchToFit}
-            color={ComponentColor.Default}
-            text="Logout"
-          />
+          <a className="user-popover-footer--button">
+            <Icon
+              glyph={IconFont.UserOutline_New}
+              className="user-popover-footer--button-icon"
+            />
+            Profile
+          </a>
+          <a className="user-popover-footer--button">
+            <Icon
+              glyph={IconFont.UserOutline_New}
+              className="user-popover-footer--button-icon"
+            />
+            Profile
+          </a>
         </div>
       </div>
     )
   }
 
+  private getPopoverStyle = () => {
+    return {
+      position: 'absolute',
+      top: 50,
+      right: 32,
+      opacity: this.state.isPopoverOpen ? 100 : 0,
+    } as CSSProperties
+  }
+
   render() {
     const {isPopoverOpen} = this.state
     return (
-      <>
-        {/* Button shape is ButtonShape.Square to make the height and width the same
+      <ClickOutside onClickOutside={this.setPopoverStateClosed}>
+        <div>
+          {/* Button shape is ButtonShape.Square to make the height and width the same
             so we can use the border radius to make it a circle  */}
-        <Button
-          text={this.getInitials()}
-          style={this.getButtonStyle()}
-          shape={ButtonShape.Square}
-          color={
-            isPopoverOpen ? ComponentColor.Default : ComponentColor.Tertiary
-          }
-          ref={this.popoverTriggerRef}
-        />
-        <Popover
-          triggerRef={this.popoverTriggerRef}
-          onShow={this.setPopoverStateOpen}
-          onHide={this.setPopoverStateClosed}
-          contents={this.getUserPopoverContents}
-        />
-      </>
+          <Button
+            text={this.getInitials()}
+            style={this.getButtonStyle()}
+            shape={ButtonShape.Square}
+            color={
+              isPopoverOpen ? ComponentColor.Default : ComponentColor.Tertiary
+            }
+            onClick={this.togglePopoverState}
+            className="user-avatar-button"
+          />
+          <FlexBox style={this.getPopoverStyle()}>
+            {this.getUserPopoverContents()}
+          </FlexBox>
+        </div>
+      </ClickOutside>
     )
   }
 }

--- a/src/identity/components/GlobalHeader/IdentityUserAvatar.tsx
+++ b/src/identity/components/GlobalHeader/IdentityUserAvatar.tsx
@@ -12,6 +12,7 @@ import {
 } from '@influxdata/clockface'
 
 import './UserPopoverStyles.scss'
+import {Link} from 'react-router-dom'
 
 type Props = {
   user: IdentityUser
@@ -73,20 +74,20 @@ class IdentityUserAvatar extends React.Component<Props, State> {
           <hr />
         </div>
         <div className="user-popover-footer">
-          <a className="user-popover-footer--button">
+          <Link className="user-popover-footer--button" to="/">
             <Icon
               glyph={IconFont.UserOutline_New}
               className="user-popover-footer--button-icon"
             />
             Profile
-          </a>
-          <a className="user-popover-footer--button">
+          </Link>
+          <Link className="user-popover-footer--button" to="/logout">
             <Icon
               glyph={IconFont.Logout_New}
               className="user-popover-footer--button-icon"
             />
             Log Out
-          </a>
+          </Link>
         </div>
       </div>
     )

--- a/src/identity/components/GlobalHeader/IdentityUserAvatar.tsx
+++ b/src/identity/components/GlobalHeader/IdentityUserAvatar.tsx
@@ -1,0 +1,114 @@
+import React, {CSSProperties} from 'react'
+import {IdentityUser} from 'src/client/unityRoutes'
+import {
+  Button,
+  ButtonShape,
+  ComponentColor,
+  InfluxColors,
+  Popover,
+} from '@influxdata/clockface'
+
+type Props = {
+  user: IdentityUser
+}
+
+type State = {
+  isPopoverOpen: boolean
+}
+
+class IdentityUserAvatar extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = {
+      isPopoverOpen: false,
+    }
+  }
+
+  private popoverTriggerRef: React.RefObject<
+    HTMLButtonElement
+  > = React.createRef()
+
+  private getInitials = (): string => {
+    const {user} = this.props
+    const firstName = user.firstName
+    const lastName = user.lastName
+    const initials = `${firstName.charAt(0)}${lastName.charAt(0)}`
+    return initials
+  }
+
+  // get button style based on whether popover is open or not
+  private getButtonStyle = (): CSSProperties => {
+    const {isPopoverOpen} = this.state
+
+    const style: CSSProperties = {
+      borderRadius: '50%',
+      border: isPopoverOpen ? 'none' : `2px solid ${InfluxColors.Grey65}`,
+      background: isPopoverOpen
+        ? `linear-gradient(75.66deg, #0098F0 0%, ${InfluxColors.Amethyst} 79.64%)`
+        : 'none',
+    }
+    return style
+  }
+
+  private setPopoverStateClosed = () => {
+    this.setState({isPopoverOpen: false})
+  }
+
+  private setPopoverStateOpen = () => {
+    this.setState({isPopoverOpen: true})
+  }
+
+  private getUserPopoverContents = () => {
+    const {user} = this.props
+    return (
+      <div className="user-popover">
+        <div className="user-popover-header">
+          <div className="user-popover-header-name">
+            {user.firstName} {user.lastName}
+          </div>
+          <div className="user-popover-header-email">{user.email}</div>
+        </div>
+        <hr />
+        <div className="user-popover-footer">
+          <Button
+            shape={ButtonShape.StretchToFit}
+            color={ComponentColor.Default}
+            text="Profile"
+          />
+          <Button
+            shape={ButtonShape.StretchToFit}
+            color={ComponentColor.Default}
+            text="Logout"
+          />
+        </div>
+      </div>
+    )
+  }
+
+  render() {
+    const {isPopoverOpen} = this.state
+    return (
+      <>
+        {/* Button shape is ButtonShape.Square to make the height and width the same
+            so we can use the border radius to make it a circle  */}
+        <Button
+          text={this.getInitials()}
+          style={this.getButtonStyle()}
+          shape={ButtonShape.Square}
+          color={
+            isPopoverOpen ? ComponentColor.Default : ComponentColor.Tertiary
+          }
+          ref={this.popoverTriggerRef}
+        />
+        <Popover
+          triggerRef={this.popoverTriggerRef}
+          onShow={this.setPopoverStateOpen}
+          onHide={this.setPopoverStateClosed}
+          contents={this.getUserPopoverContents}
+        />
+      </>
+    )
+  }
+}
+
+export default IdentityUserAvatar

--- a/src/identity/components/GlobalHeader/UserPopoverStyles.scss
+++ b/src/identity/components/GlobalHeader/UserPopoverStyles.scss
@@ -6,6 +6,7 @@
   background: rgba(241, 241, 243, 0.1);
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
   backdrop-filter: blur(42px);
+  border-radius: 2px;
 
   .user-popover-header-email {
     margin-top: 2px;

--- a/src/identity/components/GlobalHeader/UserPopoverStyles.scss
+++ b/src/identity/components/GlobalHeader/UserPopoverStyles.scss
@@ -1,0 +1,51 @@
+@import '@influxdata/clockface/dist/variables.scss';
+
+.user-popover {
+  z-index: 9999;
+  min-width: 250px;
+  background: rgba(241, 241, 243, 0.1);
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  backdrop-filter: blur(42px);
+
+  .user-popover-header-email {
+    margin-top: 2px;
+    color: $cf-grey-65;
+  }
+
+  hr {
+    background: $cf-grey-65;
+    opacity: 20%;
+    margin: 0;
+    margin-top: 10px;
+  }
+
+  .user-popover-header {
+    padding: 16px 16px 0 16px;
+  }
+
+  .user-popover-footer {
+    padding: 0px 16px 16px 16px;
+    display: inline-flex;
+    flex-direction: column;
+
+    a {
+      margin-top: 10px;
+      cursor: pointer;
+
+      :hover {
+        text-decoration: none;
+        color: inherit;re
+      }
+    }
+
+    .user-popover-footer--button-icon {
+      font-size: 18px;
+      color: $cf-grey-65;
+      margin-right: 11px;
+    }
+  }
+}
+
+.user-avatar-button {
+  box-shadow: none !important;
+}

--- a/src/identity/components/GlobalHeader/UserPopoverStyles.scss
+++ b/src/identity/components/GlobalHeader/UserPopoverStyles.scss
@@ -28,14 +28,13 @@
     display: inline-flex;
     flex-direction: column;
 
-    a {
+    .user-popover-footer--button {
       margin-top: 10px;
       cursor: pointer;
+    }
 
-      :hover {
-        text-decoration: none;
-        color: inherit;re
-      }
+    a:hover {
+      color: $cf-grey-75;
     }
 
     .user-popover-footer--button-icon {

--- a/src/identity/components/GlobalHeader/UserPopoverStyles.scss
+++ b/src/identity/components/GlobalHeader/UserPopoverStyles.scss
@@ -31,6 +31,7 @@
     .user-popover-footer--button {
       margin-top: 10px;
       cursor: pointer;
+      color: inherit;
     }
 
     a:hover {


### PR DESCRIPTION
Closes [#4048](https://github.com/influxdata/ui/issues/4048)
Depends on: #4049 

Figma requirements: 

<img width="499" alt="Screen Shot 2022-07-12 at 9 09 36 AM" src="https://user-images.githubusercontent.com/18511823/178542015-cc03ace5-61de-473d-897f-02d4bc19f8f0.png">

Developed screenshot: 

### Checklist

Authors and Reviewer(s), please verify the following:

- [ ] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [ ] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
