### PR TITLE
chore(telegrafs): make event measurements non-unique

### DIFF
--- a/src/telegrafs/actions/thunks.ts
+++ b/src/telegrafs/actions/thunks.ts
@@ -184,13 +184,17 @@ export const updateTelegraf = (telegraf: Telegraf) => async (
     )
 
     dispatch(editTelegraf(normTelegraf))
-    event(`telegraf.config.${normalizeEventName(telegraf.name)}.edit.success`, {
-      id: telegraf.id,
-    })
+    event(
+      'telegraf.config.edit.success',
+      {id: telegraf.id},
+      {name: normalizeEventName(telegraf.name)}
+    )
   } catch (error) {
-    event(`telegraf.config.${normalizeEventName(telegraf.name)}.edit.failure`, {
-      id: telegraf.id,
-    })
+    event(
+      'telegraf.config.edit.failure',
+      {id: telegraf.id},
+      {name: normalizeEventName(telegraf.name)}
+    )
     console.error(error)
     dispatch(notify(telegrafUpdateFailed(telegraf.name)))
   }
@@ -207,9 +211,17 @@ export const deleteTelegraf = (id: string, name: string) => async (
     }
 
     dispatch(removeTelegraf(id))
-    event(`telegraf.config.${normalizeEventName(name)}.delete.success`, {id})
+    event(
+      'telegraf.config.delete.success',
+      {id},
+      {name: normalizeEventName(name)}
+    )
   } catch (error) {
-    event(`telegraf.config.${normalizeEventName(name)}.delete.failure`, {id})
+    event(
+      'telegraf.config.delete.failure',
+      {id},
+      {name: normalizeEventName(name)}
+    )
     console.error(error)
     dispatch(notify(telegrafDeleteFailed(name)))
   }

--- a/src/writeData/containers/TelegrafPluginsPage.tsx
+++ b/src/writeData/containers/TelegrafPluginsPage.tsx
@@ -45,11 +45,11 @@ const TelegrafPluginsPage: FC<RouteComponentProps<{orgID: string}>> = props => {
 
   const eventName = normalizeEventName(name)
   useEffect(() => {
-    event(`telegraf_tile.${eventName}.config_viewed`, {id: contentID, name})
+    event('telegraf_tile.config_viewed', {id: contentID, name, eventName})
   }, [eventName, contentID, name])
 
   const onCopy = () => {
-    event(`telegraf_tile.${eventName}.config_copied`, {id: contentID, name})
+    event('telegraf_tile.config_copied', {id: contentID, name, eventName})
   }
   const codeRenderer: any = (props: any): any => (
     <CodeSnippet text={props.value} label={props.language} onCopy={onCopy} />


### PR DESCRIPTION
Closes #5015

Removes variable values from events generated from the telegrafs configuration section of the app.

**old behavior:**
```ts
event(`telegraf.config.${normalizeEventName(name)}.delete.success`, {id})
```
**new behavior:**
```ts
event('telegraf.config.delete.success', {id}, {name: normalizeEventName(name)})
```

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- ~[ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~
- ~[ ] Feature flagged, if applicable~
