### PR TITLE
chore: clean up migration

### DIFF
--- a/src/dataExplorer/components/FluxQueryBuilder.tsx
+++ b/src/dataExplorer/components/FluxQueryBuilder.tsx
@@ -1,5 +1,4 @@
-import React, {FC, useEffect} from 'react'
-import {createLocalStorageStateHook} from 'use-local-storage-state'
+import React, {FC} from 'react'
 
 // Components
 import {DraggableResizer, Orientation} from '@influxdata/clockface'
@@ -15,22 +14,11 @@ import {useSessionStorage} from 'src/dataExplorer/shared/utils'
 // Styles
 import './FluxQueryBuilder.scss'
 
-const useResizeState = createLocalStorageStateHook(
-  'dataExplorer.resize.vertical',
-  [0.25, 0.8]
-)
 const FluxQueryBuilder: FC = () => {
-  const [oldVertDragPosition, oldSetVertDragPosition] = useResizeState()
-  const [vertDragPosition, setVertDragPosition] = useSessionStorage(
-    'dataExplorer.resize.vertical',
-    oldVertDragPosition
-  )
-
-  // migration to allow people to keep their last used settings
-  // immediately after rollout
-  useEffect(() => {
-    oldSetVertDragPosition([0.25, 0.8])
-  }, [])
+  const [
+    vertDragPosition,
+    setVertDragPosition,
+  ] = useSessionStorage('dataExplorer.resize.vertical', [0.25, 0.8])
 
   return (
     <QueryProvider>

--- a/src/dataExplorer/components/ResultsContext.tsx
+++ b/src/dataExplorer/components/ResultsContext.tsx
@@ -1,5 +1,4 @@
 import React, {FC, createContext, useState, useRef, useEffect} from 'react'
-import {createLocalStorageStateHook} from 'use-local-storage-state'
 
 import {useSessionStorage} from 'src/dataExplorer/shared/utils'
 import {FluxResult} from 'src/types/flows'
@@ -14,17 +13,6 @@ interface View {
   state: 'table' | 'graph'
   properties: ViewProperties
 }
-
-const useLocalStorageState = createLocalStorageStateHook(
-  'dataExplorer.results',
-  {
-    state: 'table',
-    properties: {
-      type: 'simple-table',
-      showAll: false,
-    } as SimpleTableViewProperties,
-  } as View
-)
 
 interface ResultsContextType {
   status: RemoteDataState
@@ -62,20 +50,13 @@ export const ResultsProvider: FC = ({children}) => {
   )
 
   // for display, should be moved
-  const [oldView, setOldView] = useLocalStorageState()
-  const [view, setView] = useSessionStorage('dataExplorer.results', oldView)
-
-  // migration to allow people to keep their last used settings
-  // immediately after rollout
-  useEffect(() => {
-    setOldView({
-      state: 'table',
-      properties: {
-        type: 'simple-table',
-        showAll: false,
-      } as SimpleTableViewProperties,
-    })
-  }, [])
+  const [view, setView] = useSessionStorage('dataExplorer.results', {
+    state: 'table',
+    properties: {
+      type: 'simple-table',
+      showAll: false,
+    } as SimpleTableViewProperties,
+  })
 
   useEffect(() => {
     let running = false

--- a/src/dataExplorer/components/ResultsPane.tsx
+++ b/src/dataExplorer/components/ResultsPane.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FC, lazy, Suspense, useContext, useEffect} from 'react'
+import React, {FC, lazy, Suspense, useContext} from 'react'
 import {
   DraggableResizer,
   Orientation,
@@ -15,7 +15,6 @@ import {
   JustifyContent,
   AlignItems,
 } from '@influxdata/clockface'
-import {createLocalStorageStateHook} from 'use-local-storage-state'
 
 // Contexts
 import {ResultsContext} from 'src/dataExplorer/components/ResultsContext'
@@ -44,18 +43,6 @@ import {useSessionStorage} from '../shared/utils'
 
 const FluxMonacoEditor = lazy(() =>
   import('src/shared/components/FluxMonacoEditor')
-)
-const useQueryState = createLocalStorageStateHook<string>(
-  'dataExplorer.query',
-  ''
-)
-const useRangeState = createLocalStorageStateHook<TimeRange>(
-  'dataExplorer.range',
-  DEFAULT_TIME_RANGE
-)
-const useResizeState = createLocalStorageStateHook(
-  'dataExplorer.resize.horizontal',
-  [0.2]
 )
 
 const fakeNotify = notify
@@ -95,26 +82,15 @@ const ResultsPane: FC = () => {
   const {basic, query} = useContext(QueryContext)
   const {status, setStatus, setResult} = useContext(ResultsContext)
 
-  const [oldHorizDragPosition, setOldHorizDragPosition] = useResizeState()
-  const [horizDragPosition, setHorizDragPosition] = useSessionStorage(
-    'dataExplorer.resize.horizontal',
-    oldHorizDragPosition
-  )
-  const [oldText, setOldText] = useQueryState()
-  const [text, setText] = useSessionStorage('dataExplorer.query', oldText)
-  const [oldTimeRange, setOldTimeRange] = useRangeState()
+  const [
+    horizDragPosition,
+    setHorizDragPosition,
+  ] = useSessionStorage('dataExplorer.resize.horizontal', [0.2])
+  const [text, setText] = useSessionStorage('dataExplorer.query', '')
   const [timeRange, setTimeRange] = useSessionStorage(
     'dataExplorer.range',
-    oldTimeRange
+    DEFAULT_TIME_RANGE
   )
-
-  // migration to allow people to keep their last used settings
-  // immediately after rollout
-  useEffect(() => {
-    setOldHorizDragPosition([0.2])
-    setOldText('')
-    setOldTimeRange(DEFAULT_TIME_RANGE)
-  }, [])
 
   const download = () => {
     event('CSV Download Initiated')

--- a/src/dataExplorer/context/fluxQueryBuilder.tsx
+++ b/src/dataExplorer/context/fluxQueryBuilder.tsx
@@ -5,9 +5,7 @@ import React, {
   useMemo,
   useContext,
   useCallback,
-  useEffect,
 } from 'react'
-import {createLocalStorageStateHook} from 'use-local-storage-state'
 
 // Context
 import {MeasurementsContext} from 'src/dataExplorer/context/measurements'
@@ -26,14 +24,6 @@ import {
   ExecuteCommandInjectField,
 } from 'src/languageSupport/languages/flux/lsp/utils'
 import {useSessionStorage} from 'src/dataExplorer/shared/utils'
-
-const useLocalStorageState = createLocalStorageStateHook(
-  'dataExplorer.schema',
-  {
-    bucket: null,
-    measurement: null,
-  }
-)
 
 const DEBOUNCE_TIMEOUT = 500
 let timer
@@ -82,21 +72,11 @@ export const FluxQueryBuilderProvider: FC = ({children}) => {
   const {injectViaLsp} = useContext(EditorContext)
 
   // States
-  const [oldSelection, setOldSelection] = useLocalStorageState()
-  const [selection, setSelection] = useSessionStorage(
-    'dataExplorer.schema',
-    oldSelection
-  )
+  const [selection, setSelection] = useSessionStorage('dataExplorer.schema', {
+    bucket: null,
+    measurement: null,
+  })
   const [searchTerm, setSearchTerm] = useState('')
-
-  // migration to allow people to keep their last used settings
-  // immediately after rollout
-  useEffect(() => {
-    setOldSelection({
-      bucket: null,
-      measurement: null,
-    })
-  }, [])
 
   const handleSelectBucket = (bucket: Bucket): void => {
     selection.bucket = bucket


### PR DESCRIPTION
removes the migration for #4906, to be delivered after people have had a chance to let their migration run (EOW or so)