### PR TITLE
feat(sub): edit form field validation

### DIFF
--- a/src/writeData/subscriptions/components/BrokerDetails.tsx
+++ b/src/writeData/subscriptions/components/BrokerDetails.tsx
@@ -28,6 +28,7 @@ import BrokerFormContent from 'src/writeData/subscriptions/components/BrokerForm
 import {getOrg} from 'src/organizations/selectors'
 import {event} from 'src/cloud/utils/reporting'
 import {AppSettingContext} from 'src/shared/contexts/app'
+import {checkRequiredFields} from 'src/writeData/subscriptions/utils/form'
 
 // Types
 import {SUBSCRIPTIONS, LOAD_DATA} from 'src/shared/constants/routes'
@@ -60,6 +61,7 @@ const BrokerDetails: FC<Props> = ({
   const history = useHistory()
   const org = useSelector(getOrg)
   const {navbarMode} = useContext(AppSettingContext)
+  const requiredFields = checkRequiredFields(currentSubscription)
   const navbarOpen = navbarMode === 'expanded'
 
   return (
@@ -106,10 +108,8 @@ const BrokerDetails: FC<Props> = ({
                   testID="update-sub-form--cancel"
                 />
                 <Button
-                  text="Edit"
-                  color={
-                    edit ? ComponentColor.Success : ComponentColor.Secondary
-                  }
+                  text={edit ? 'Cancel' : 'Edit'}
+                  color={ComponentColor.Secondary}
                   onClick={() => {
                     event('edit button clicked', {}, {feature: 'subscriptions'})
                     setEdit(!edit)
@@ -127,6 +127,11 @@ const BrokerDetails: FC<Props> = ({
                       saveForm(currentSubscription)
                     }}
                     testID="update-sub-form--submit"
+                    status={
+                      requiredFields
+                        ? ComponentStatus.Default
+                        : ComponentStatus.Disabled
+                    }
                   />
                 ) : (
                   <Button

--- a/src/writeData/subscriptions/components/BrokerFormContent.tsx
+++ b/src/writeData/subscriptions/components/BrokerFormContent.tsx
@@ -184,6 +184,11 @@ const BrokerFormContent: FC<Props> = ({
               validationFunc={() =>
                 handleValidation('Broker Host', formContent.brokerHost)
               }
+              helpText={
+                edit
+                  ? "Changing the broker's hostname will require your broker's password to be provided again."
+                  : ''
+              }
             >
               {status => (
                 <Input
@@ -196,6 +201,11 @@ const BrokerFormContent: FC<Props> = ({
                     updateForm({
                       ...formContent,
                       brokerHost: e.target.value,
+                      // clear the password field if broker host is edited
+                      brokerPassword:
+                        className === 'create'
+                          ? formContent.brokerPassword
+                          : '',
                     })
                   }}
                   onBlur={() =>

--- a/src/writeData/subscriptions/components/BrokerFormContent.tsx
+++ b/src/writeData/subscriptions/components/BrokerFormContent.tsx
@@ -186,7 +186,7 @@ const BrokerFormContent: FC<Props> = ({
               }
               helpText={
                 edit
-                  ? "Changing the broker's hostname will require your broker's password to be provided again."
+                  ? 'Changing the hostname will require you to provide your password again.'
                   : ''
               }
             >
@@ -204,7 +204,7 @@ const BrokerFormContent: FC<Props> = ({
                       // clear the password field if broker host is edited
                       brokerPassword:
                         className === 'create'
-                          ? formContent.brokerPassword
+                          ? formContent?.brokerPassword
                           : '',
                     })
                   }}


### PR DESCRIPTION
Closes https://github.com/influxdata/data-acquisition/issues/415

Edit form field validation:
- same validation as create form - "save changes" button is disabled if form is not valid
- tweaked edit button - Edit -> Cancel
- editing broker hostname clears password
- added note that changing broker hostname will clear password


https://user-images.githubusercontent.com/6411855/178611046-835affb7-5f69-41b3-91bf-b932ead0e702.mov


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
