### PR TITLE
fix: refit the graph on the value axis when the query results change

### DIFF
--- a/src/visualization/utils/useVisDomainSettings.ts
+++ b/src/visualization/utils/useVisDomainSettings.ts
@@ -185,10 +185,10 @@ export const useZoomRequeryXDomainSettings = (args: ZoomRequeryArgs) => {
    *   - can be changed by user action: zooming or unzooming
    *   - zooming will trigger a new query if the windowPeriod changes
    *   - unzooming will revert the query results back to its original state
-   *     (before zooming), and does not query when unzooming
+   *     (before zooming), but does not query
    *
-   *   - can be changed also by the preZoomDomain, because they should stay synced
-   *     to keep the graph fitted, and does not query when syncing
+   *   - can be changed also by the preZoomDomain, by syncing,
+   *     to keep the graph fitted, and does not query
    */
   const [domain, setDomain] = useState(initialDomain)
 
@@ -234,7 +234,7 @@ export const useZoomRequeryXDomainSettings = (args: ZoomRequeryArgs) => {
   }, [domain]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // sync preZoomDomain and domain
-  //   - when query results change to re-fit the graph
+  //   - when query results change to refit the graph
   //   - except when it is the time axis to prevent a shrunken graph
   useEffect(() => {
     if (!timeRange && isNotEqual(preZoomDomain, domain)) {
@@ -302,10 +302,10 @@ export const useZoomRequeryYDomainSettings = (args: ZoomRequeryArgs) => {
    *   - can be changed by user action: zooming or unzooming
    *   - zooming will trigger a new query if the windowPeriod changes
    *   - unzooming will revert the query results back to its original state
-   *     (before zooming), and does not query when unzooming
+   *     (before zooming), but does not query
    *
-   *   - can be changed also by the preZoomDomain, because they should stay synced
-   *     to keep the graph fitted, and does not query when syncing
+   *   - can be changed also by the preZoomDomain, by syncing,
+   *     to keep the graph fitted, and does not query
    */
   const [domain, setDomain] = useState(initialDomain)
 
@@ -351,7 +351,7 @@ export const useZoomRequeryYDomainSettings = (args: ZoomRequeryArgs) => {
   }, [domain]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // sync preZoomDomain and domain
-  //   - when query results change to re-fit the graph
+  //   - when query results change to refit the graph
   //   - except when it is the time axis to prevent a shrunken graph
   useEffect(() => {
     if (!timeRange && isNotEqual(preZoomDomain, domain)) {

--- a/src/visualization/utils/useVisDomainSettings.ts
+++ b/src/visualization/utils/useVisDomainSettings.ts
@@ -173,8 +173,24 @@ export const useZoomRequeryXDomainSettings = (args: ZoomRequeryArgs) => {
     return getValidRange(data, timeRange)
   }, [storedDomain, data]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  const [domain, setDomain] = useState(initialDomain)
+  /*
+   * preZoomDomain:
+   *   - can be changed only by the query results
+   *   - uses one-way state to capture the very first set of values
+   */
   const [preZoomDomain] = useOneWayState(initialDomain)
+
+  /*
+   * domain:
+   *   - can be changed by user action: zooming or unzooming
+   *   - zooming will trigger a new query if the windowPeriod changes
+   *   - unzooming will revert the query results back to its original state
+   *     (before zooming), and does not query when unzooming
+   *
+   *   - can be changed also by the preZoomDomain, because they should stay synced
+   *     to keep the graph fitted, and does not query when syncing
+   */
+  const [domain, setDomain] = useState(initialDomain)
 
   const getAllVariablesWithTimeDomain = (state: AppState) =>
     getAllVariablesForZoomRequery(state, timeRange ? domain : [])
@@ -185,13 +201,6 @@ export const useZoomRequeryXDomainSettings = (args: ZoomRequeryArgs) => {
     getWindowPeriodFromVariables(query, variables)
   )
 
-  /*
-   * When the user zooms in, re-run the query
-   * When the user un-zooms, do not re-run but revert back to old data
-   * Hence re-run the query only when both conditions are met:
-   * - the window period changes from the domain changing (zooming in)
-   * - the domain does not equal the original pre-zoom domain (unzooming)
-   */
   useEffect(() => {
     const updatedWindowPeriod = getWindowPeriodFromVariables(query, variables)
     if (isNotEqual(windowPeriod, updatedWindowPeriod)) {
@@ -223,6 +232,15 @@ export const useZoomRequeryXDomainSettings = (args: ZoomRequeryArgs) => {
       }
     }
   }, [domain]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // sync preZoomDomain and domain
+  //   - when query results change to re-fit the graph
+  //   - except when it is the time axis to prevent a shrunken graph
+  useEffect(() => {
+    if (!timeRange && isNotEqual(preZoomDomain, domain)) {
+      setDomain(preZoomDomain)
+    }
+  }, [preZoomDomain]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const setZoomDomain = (updatedDomain: number[]) => {
     setRequeryStatus(RemoteDataState.NotStarted)
@@ -272,8 +290,24 @@ export const useZoomRequeryYDomainSettings = (args: ZoomRequeryArgs) => {
     return storedDomain
   }, [storedDomain, data]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  const [domain, setDomain] = useState(initialDomain)
+  /*
+   * preZoomDomain:
+   *   - can be changed only by the query results
+   *   - uses one-way state to capture the very first set of values
+   */
   const [preZoomDomain] = useOneWayState(initialDomain)
+
+  /*
+   * domain:
+   *   - can be changed by user action: zooming or unzooming
+   *   - zooming will trigger a new query if the windowPeriod changes
+   *   - unzooming will revert the query results back to its original state
+   *     (before zooming), and does not query when unzooming
+   *
+   *   - can be changed also by the preZoomDomain, because they should stay synced
+   *     to keep the graph fitted, and does not query when syncing
+   */
+  const [domain, setDomain] = useState(initialDomain)
 
   const getAllVariablesWithTimeDomain = (state: AppState) =>
     getAllVariablesForZoomRequery(state, timeRange ? domain : [])
@@ -284,13 +318,6 @@ export const useZoomRequeryYDomainSettings = (args: ZoomRequeryArgs) => {
     getWindowPeriodFromVariables(query, variables)
   )
 
-  /*
-   * When the user zooms in, re-run the query
-   * When the user un-zooms, do not re-run but revert back to old data
-   * Hence re-run the query only when both conditions are met:
-   * - the window period changes from the domain changing (zooming in)
-   * - the domain does not equal the original pre-zoom domain (unzooming)
-   */
   useEffect(() => {
     const updatedWindowPeriod = getWindowPeriodFromVariables(query, variables)
     if (isNotEqual(windowPeriod, updatedWindowPeriod)) {
@@ -322,6 +349,15 @@ export const useZoomRequeryYDomainSettings = (args: ZoomRequeryArgs) => {
       }
     }
   }, [domain]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // sync preZoomDomain and domain
+  //   - when query results change to re-fit the graph
+  //   - except when it is the time axis to prevent a shrunken graph
+  useEffect(() => {
+    if (!timeRange && isNotEqual(preZoomDomain, domain)) {
+      setDomain(preZoomDomain)
+    }
+  }, [preZoomDomain]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const setZoomDomain = (updatedDomain: number[]) => {
     setRequeryStatus(RemoteDataState.NotStarted)


### PR DESCRIPTION
Part of EAR 2422

- refits the graph on the value axis when the query results change
- adds documentation on the differences between "preZoomDomain" and "domain"


https://user-images.githubusercontent.com/10736577/178601526-07cd553d-ecbe-451d-aa1e-12cccb94ff5d.mp4


