### PR TITLE
feat(sub): tooltips explaining jsonpath and regex inputs

### DIFF
--- a/src/writeData/subscriptions/components/JsonParsingForm.scss
+++ b/src/writeData/subscriptions/components/JsonParsingForm.scss
@@ -37,7 +37,6 @@
   &__container {
     .cf-form--element {
       margin-bottom: $cf-space-l;
-      width: 75%;
     }
     &__dropdown {
       width: 25%;

--- a/src/writeData/subscriptions/components/JsonParsingForm.tsx
+++ b/src/writeData/subscriptions/components/JsonParsingForm.tsx
@@ -3,10 +3,8 @@ import React, {FC, useState, useEffect} from 'react'
 
 // Components
 import {
-  Input,
   Grid,
   Form,
-  InputType,
   Dropdown,
   Icon,
   IconFont,
@@ -29,11 +27,13 @@ import {
   sanitizeType,
   handleValidation,
   handleJsonPathValidation,
+  JSON_TOOLTIP,
 } from 'src/writeData/subscriptions/utils/form'
 import {event} from 'src/cloud/utils/reporting'
 
 // Styles
 import 'src/writeData/subscriptions/components/JsonParsingForm.scss'
+import ValidationInputWithTooltip from './ValidationInputWithTooltip'
 
 interface Props {
   formContent: Subscription
@@ -78,7 +78,7 @@ const JsonParsingForm: FC<Props> = ({formContent, updateForm, edit}) => {
           margin={ComponentSize.Large}
           className="json-parsing-form__container"
         >
-          <Form.ValidationElement
+          <ValidationInputWithTooltip
             label="JSON Path to Timestamp"
             value={formContent.jsonTimestamp?.path}
             required={false}
@@ -87,35 +87,29 @@ const JsonParsingForm: FC<Props> = ({formContent, updateForm, edit}) => {
                 ? handleJsonPathValidation(formContent.jsonTimestamp?.path)
                 : null
             }
-          >
-            {status => (
-              <Input
-                type={InputType.Text}
-                placeholder="eg. $.myJSON.myObject[0].timestampKey"
-                name="timestamp"
-                autoFocus={true}
-                value={formContent.jsonTimestamp?.path}
-                onChange={e => {
-                  updateForm({
-                    ...formContent,
-                    jsonTimestamp: {
-                      ...formContent.jsonTimestamp,
-                      path: e.target.value,
-                    },
-                  })
-                }}
-                onBlur={() =>
-                  event(
-                    'completed form field',
-                    {formField: 'jsonTimestamp.path'},
-                    {feature: 'subscriptions'}
-                  )
-                }
-                testID="timestamp-json-parsing"
-                status={edit ? status : ComponentStatus.Disabled}
-              />
-            )}
-          </Form.ValidationElement>
+            placeholder="eg. $.myJSON.myObject[0].timestampKey"
+            name="timestamp"
+            onChange={e => {
+              updateForm({
+                ...formContent,
+                jsonTimestamp: {
+                  ...formContent.jsonTimestamp,
+                  path: e.target.value,
+                },
+              })
+            }}
+            onBlur={() =>
+              event(
+                'completed form field',
+                {formField: 'jsonTimestamp.path'},
+                {feature: 'subscriptions'}
+              )
+            }
+            testID="timestamp-json-parsing"
+            edit={edit}
+            tooltip={JSON_TOOLTIP}
+            width="75%"
+          />
           <div className="json-parsing-form__container__dropdown">
             <Form.Label label="Timestamp precision" />
             <Dropdown
@@ -184,7 +178,7 @@ const JsonParsingForm: FC<Props> = ({formContent, updateForm, edit}) => {
           margin={ComponentSize.Large}
           className="json-parsing-form__container"
         >
-          <Form.ValidationElement
+          <ValidationInputWithTooltip
             label="JSON Path"
             value={formContent.jsonMeasurementKey.path}
             required={true}
@@ -195,35 +189,29 @@ const JsonParsingForm: FC<Props> = ({formContent, updateForm, edit}) => {
                 handleJsonPathValidation(path)
               )
             }}
-          >
-            {status => (
-              <Input
-                type={InputType.Text}
-                placeholder="eg. $.myJSON.myObject[0].myKey"
-                name="jsonpath"
-                autoFocus={true}
-                value={formContent.jsonMeasurementKey.path}
-                onChange={e => {
-                  updateForm({
-                    ...formContent,
-                    jsonMeasurementKey: {
-                      ...formContent.jsonMeasurementKey,
-                      path: e.target.value,
-                    },
-                  })
-                }}
-                onBlur={() =>
-                  event(
-                    'completed form field',
-                    {formField: 'jsonMeasurementKey.path'},
-                    {feature: 'subscriptions'}
-                  )
-                }
-                status={edit ? status : ComponentStatus.Disabled}
-                testID="measurement-json-parsing-path"
-              />
-            )}
-          </Form.ValidationElement>
+            placeholder="eg. $.myJSON.myObject[0].myKey"
+            name="jsonpath"
+            onChange={e => {
+              updateForm({
+                ...formContent,
+                jsonMeasurementKey: {
+                  ...formContent.jsonMeasurementKey,
+                  path: e.target.value,
+                },
+              })
+            }}
+            onBlur={() =>
+              event(
+                'completed form field',
+                {formField: 'jsonMeasurementKey.path'},
+                {feature: 'subscriptions'}
+              )
+            }
+            edit={edit}
+            testID="measurement-json-parsing-path"
+            tooltip={JSON_TOOLTIP}
+            width="75%"
+          />
           <div className="json-parsing-form__container__dropdown">
             <Form.Label label="Data Type" />
             <Dropdown

--- a/src/writeData/subscriptions/components/JsonPathInput.tsx
+++ b/src/writeData/subscriptions/components/JsonPathInput.tsx
@@ -3,10 +3,8 @@ import React, {FC, useState} from 'react'
 
 // Components
 import {
-  Input,
   Grid,
   Form,
-  InputType,
   Dropdown,
   ButtonShape,
   IconFont,
@@ -29,9 +27,11 @@ import {Subscription} from 'src/types/subscriptions'
 import {
   handleJsonPathValidation,
   handleValidation,
+  JSON_TOOLTIP,
   sanitizeType,
 } from 'src/writeData/subscriptions/utils/form'
 import {event} from 'src/cloud/utils/reporting'
+import ValidationInputWithTooltip from './ValidationInputWithTooltip'
 
 interface Props {
   name: string
@@ -102,7 +102,7 @@ const JsonPathInput: FC<Props> = ({
           margin={ComponentSize.Large}
           className="json-parsing-form__container"
         >
-          <Form.ValidationElement
+          <ValidationInputWithTooltip
             label="Name"
             value={
               tagType
@@ -118,54 +118,46 @@ const JsonPathInput: FC<Props> = ({
                   : formContent.jsonFieldKeys[itemNum].name
               )
             }
-          >
-            {status => (
-              <Input
-                type={InputType.Text}
-                placeholder="nonDescriptName"
-                name={`${name}=name`}
-                autoFocus={true}
-                value={
-                  tagType
-                    ? formContent.jsonTagKeys[itemNum].name
-                    : formContent.jsonFieldKeys[itemNum].name
-                }
-                onChange={e => {
-                  let newArr
-                  if (tagType) {
-                    newArr = Object.assign([...formContent.jsonTagKeys], {
-                      [itemNum]: {
-                        ...formContent.jsonTagKeys[itemNum],
-                        name: e.target.value,
-                      },
-                    })
-                    updateForm({...formContent, jsonTagKeys: newArr})
-                  } else {
-                    newArr = Object.assign([...formContent.jsonFieldKeys], {
-                      [itemNum]: {
-                        ...formContent.jsonFieldKeys[itemNum],
-                        name: e.target.value,
-                      },
-                    })
-                    updateForm({...formContent, jsonFieldKeys: newArr})
-                  }
-                }}
-                onBlur={() =>
-                  event(
-                    'completed form field',
-                    {
-                      formField: `${
-                        tagType ? 'jsonTagKeys' : 'jsonFieldKeys'
-                      }.name`,
-                    },
-                    {feature: 'subscriptions'}
-                  )
-                }
-                status={edit ? status : ComponentStatus.Disabled}
-                testID={`${tagType}-json-parsing-name`}
-              />
-            )}
-          </Form.ValidationElement>
+            placeholder="nonDescriptName"
+            name={`${name}=name`}
+            onChange={e => {
+              let newArr
+              if (tagType) {
+                newArr = Object.assign([...formContent.jsonTagKeys], {
+                  [itemNum]: {
+                    ...formContent.jsonTagKeys[itemNum],
+                    name: e.target.value,
+                  },
+                })
+                updateForm({...formContent, jsonTagKeys: newArr})
+              } else {
+                newArr = Object.assign([...formContent.jsonFieldKeys], {
+                  [itemNum]: {
+                    ...formContent.jsonFieldKeys[itemNum],
+                    name: e.target.value,
+                  },
+                })
+                updateForm({...formContent, jsonFieldKeys: newArr})
+              }
+            }}
+            onBlur={() =>
+              event(
+                'completed form field',
+                {
+                  formField: `${
+                    tagType ? 'jsonTagKeys' : 'jsonFieldKeys'
+                  }.name`,
+                },
+                {feature: 'subscriptions'}
+              )
+            }
+            edit={edit}
+            testID={`${tagType}-json-parsing-name`}
+            tooltip={`This will become the the ${
+              tagType ? 'tag' : 'field'
+            }'s key`}
+            width="75%"
+          />
           <div className="json-parsing-form__container__dropdown">
             <Form.Label label="Data Type" />
             <Dropdown
@@ -225,7 +217,7 @@ const JsonPathInput: FC<Props> = ({
         </FlexBox>
       </Grid.Column>
       <Grid.Column>
-        <Form.ValidationElement
+        <ValidationInputWithTooltip
           label="JSON Path"
           value={
             tagType
@@ -242,54 +234,41 @@ const JsonPathInput: FC<Props> = ({
               handleJsonPathValidation(path)
             )
           }}
-        >
-          {status => (
-            <Input
-              type={InputType.Text}
-              placeholder="eg. $.myJSON.myObject[0].myKey"
-              name="jsonpath"
-              autoFocus={true}
-              value={
-                tagType
-                  ? formContent.jsonTagKeys[itemNum].path
-                  : formContent.jsonFieldKeys[itemNum].path
-              }
-              onChange={e => {
-                let newArr
-                if (tagType) {
-                  newArr = Object.assign([...formContent.jsonTagKeys], {
-                    [itemNum]: {
-                      ...formContent.jsonTagKeys[itemNum],
-                      path: e.target.value,
-                    },
-                  })
-                  updateForm({...formContent, jsonTagKeys: newArr})
-                } else {
-                  newArr = Object.assign([...formContent.jsonFieldKeys], {
-                    [itemNum]: {
-                      ...formContent.jsonFieldKeys[itemNum],
-                      path: e.target.value,
-                    },
-                  })
-                  updateForm({...formContent, jsonFieldKeys: newArr})
-                }
-              }}
-              onBlur={() =>
-                event(
-                  'completed form field',
-                  {
-                    formField: `${
-                      tagType ? 'jsonTagKeys' : 'jsonFieldKeys'
-                    }.path`,
-                  },
-                  {feature: 'subscriptions'}
-                )
-              }
-              status={edit ? status : ComponentStatus.Disabled}
-              testID={`${tagType}-json-parsing-path`}
-            />
-          )}
-        </Form.ValidationElement>
+          placeholder="eg. $.myJSON.myObject[0].myKey"
+          name="jsonpath"
+          onChange={e => {
+            let newArr
+            if (tagType) {
+              newArr = Object.assign([...formContent.jsonTagKeys], {
+                [itemNum]: {
+                  ...formContent.jsonTagKeys[itemNum],
+                  path: e.target.value,
+                },
+              })
+              updateForm({...formContent, jsonTagKeys: newArr})
+            } else {
+              newArr = Object.assign([...formContent.jsonFieldKeys], {
+                [itemNum]: {
+                  ...formContent.jsonFieldKeys[itemNum],
+                  path: e.target.value,
+                },
+              })
+              updateForm({...formContent, jsonFieldKeys: newArr})
+            }
+          }}
+          onBlur={() =>
+            event(
+              'completed form field',
+              {
+                formField: `${tagType ? 'jsonTagKeys' : 'jsonFieldKeys'}.path`,
+              },
+              {feature: 'subscriptions'}
+            )
+          }
+          edit={edit}
+          testID={`${tagType}-json-parsing-path`}
+          tooltip={JSON_TOOLTIP}
+        />
         <div className="line"></div>
       </Grid.Column>
     </div>

--- a/src/writeData/subscriptions/components/StringParsingForm.scss
+++ b/src/writeData/subscriptions/components/StringParsingForm.scss
@@ -38,7 +38,6 @@
   &__container {
     .cf-form--element {
       margin-bottom: $cf-space-l;
-      width: 75%;
     }
     &__dropdown {
       width: 25%;

--- a/src/writeData/subscriptions/components/StringParsingForm.tsx
+++ b/src/writeData/subscriptions/components/StringParsingForm.tsx
@@ -3,10 +3,8 @@ import React, {FC, useState, useEffect} from 'react'
 
 // Components
 import {
-  Input,
   Grid,
   Form,
-  InputType,
   Dropdown,
   IconFont,
   Icon,
@@ -27,12 +25,14 @@ import {Subscription, PrecisionTypes} from 'src/types/subscriptions'
 import {
   handleRegexValidation,
   handleValidation,
+  REGEX_TOOLTIP,
 } from 'src/writeData/subscriptions/utils/form'
 
 // Styles
 import 'src/writeData/subscriptions/components/StringParsingForm.scss'
 import {event} from 'src/cloud/utils/reporting'
 import {ComponentStatus} from 'src/clockface'
+import ValidationInputWithTooltip from './ValidationInputWithTooltip'
 
 interface Props {
   formContent: Subscription
@@ -72,7 +72,7 @@ const StringParsingForm: FC<Props> = ({formContent, updateForm, edit}) => {
           margin={ComponentSize.Large}
           className="string-parsing-form__container"
         >
-          <Form.ValidationElement
+          <ValidationInputWithTooltip
             label="Regex Pattern to find Timestamp"
             value={formContent.stringTimestamp.pattern}
             required={false}
@@ -81,38 +81,32 @@ const StringParsingForm: FC<Props> = ({formContent, updateForm, edit}) => {
                 ? handleRegexValidation(formContent.stringTimestamp.pattern)
                 : null
             }
-          >
-            {status => (
-              <Input
-                type={InputType.Text}
-                placeholder="eg.(\d{10})"
-                name="timestamp"
-                autoFocus={true}
-                value={formContent.stringTimestamp.pattern}
-                onChange={e => {
-                  updateForm({
-                    ...formContent,
-                    stringTimestamp: {
-                      ...formContent.stringTimestamp,
-                      pattern: e.target.value,
-                    },
-                  })
-                }}
-                onBlur={() =>
-                  event(
-                    'completed form field',
-                    {
-                      formField: 'stringTimestamp.pattern',
-                    },
-                    {feature: 'subscriptions'}
-                  )
-                }
-                maxLength={255}
-                testID="timestamp-string-parsing"
-                status={edit ? status : ComponentStatus.Disabled}
-              />
-            )}
-          </Form.ValidationElement>
+            placeholder="eg.(\d{10})"
+            name="timestamp"
+            onChange={e => {
+              updateForm({
+                ...formContent,
+                stringTimestamp: {
+                  ...formContent.stringTimestamp,
+                  pattern: e.target.value,
+                },
+              })
+            }}
+            onBlur={() =>
+              event(
+                'completed form field',
+                {
+                  formField: 'stringTimestamp.pattern',
+                },
+                {feature: 'subscriptions'}
+              )
+            }
+            maxLength={255}
+            testID="timestamp-string-parsing"
+            edit={edit}
+            tooltip={REGEX_TOOLTIP}
+            width="75%"
+          />
           <div className="string-parsing-form__container__dropdown">
             <Form.Label label="Timestamp precision" />
             <Dropdown
@@ -175,7 +169,7 @@ const StringParsingForm: FC<Props> = ({formContent, updateForm, edit}) => {
             Measurement
           </Heading>
         </FlexBox>
-        <Form.ValidationElement
+        <ValidationInputWithTooltip
           label="Regex Pattern to find Measurement"
           value={formContent.stringMeasurement.pattern}
           required={true}
@@ -186,38 +180,31 @@ const StringParsingForm: FC<Props> = ({formContent, updateForm, edit}) => {
               handleRegexValidation(pattern)
             )
           }}
-        >
-          {status => (
-            <Input
-              type={InputType.Text}
-              placeholder="eg. a=(\d)"
-              name="regex"
-              autoFocus={true}
-              value={formContent.stringMeasurement.pattern}
-              onChange={e => {
-                updateForm({
-                  ...formContent,
-                  stringMeasurement: {
-                    ...formContent.stringMeasurement,
-                    pattern: e.target.value,
-                  },
-                })
-              }}
-              onBlur={() =>
-                event(
-                  'completed form field',
-                  {
-                    formField: 'stringMeasurement.pattern',
-                  },
-                  {feature: 'subscriptions'}
-                )
-              }
-              status={edit ? status : ComponentStatus.Disabled}
-              maxLength={255}
-              testID="measurment-string-parsing-pattern"
-            />
-          )}
-        </Form.ValidationElement>
+          placeholder="eg. a=(\d)"
+          name="regex"
+          onChange={e => {
+            updateForm({
+              ...formContent,
+              stringMeasurement: {
+                ...formContent.stringMeasurement,
+                pattern: e.target.value,
+              },
+            })
+          }}
+          onBlur={() =>
+            event(
+              'completed form field',
+              {
+                formField: 'stringMeasurement.pattern',
+              },
+              {feature: 'subscriptions'}
+            )
+          }
+          edit={edit}
+          maxLength={255}
+          testID="measurment-string-parsing-pattern"
+          tooltip={REGEX_TOOLTIP}
+        />
         <div className="line"></div>
       </Grid.Column>
       {formContent.stringTags.map((_, key) => (

--- a/src/writeData/subscriptions/components/StringPatternInput.tsx
+++ b/src/writeData/subscriptions/components/StringPatternInput.tsx
@@ -3,10 +3,7 @@ import React, {FC} from 'react'
 
 // Components
 import {
-  Input,
   Grid,
-  Form,
-  InputType,
   ButtonShape,
   IconFont,
   ComponentColor,
@@ -18,7 +15,6 @@ import {
   ComponentSize,
   FlexDirection,
   FlexBox,
-  ComponentStatus,
 } from '@influxdata/clockface'
 
 // Types
@@ -28,8 +24,10 @@ import {Subscription} from 'src/types/subscriptions'
 import {
   handleRegexValidation,
   handleValidation,
+  REGEX_TOOLTIP,
 } from 'src/writeData/subscriptions/utils/form'
 import {event} from 'src/cloud/utils/reporting'
+import ValidationInputWithTooltip from './ValidationInputWithTooltip'
 
 interface Props {
   name: string
@@ -90,14 +88,18 @@ const StringPatternInput: FC<Props> = ({
             />
           )}
         </FlexBox>
-        <Form.ValidationElement
+        <ValidationInputWithTooltip
           label="Name"
+          name="name"
           value={
             tagType
               ? formContent.stringTags[itemNum].name
               : formContent.stringFields[itemNum].name
           }
           required={true}
+          tooltip={`This will become the the ${
+            tagType ? 'tag' : 'field'
+          }'s key`}
           validationFunc={() =>
             handleValidation(
               `${name}`,
@@ -106,65 +108,53 @@ const StringPatternInput: FC<Props> = ({
                 : formContent.stringFields[itemNum].name
             )
           }
-        >
-          {status => (
-            <Input
-              type={InputType.Text}
-              placeholder="nonDescriptName"
-              name="name"
-              autoFocus={true}
-              value={
-                tagType
-                  ? formContent.stringTags[itemNum].name
-                  : formContent.stringFields[itemNum].name
-              }
-              onChange={e => {
-                let newArr
-                if (tagType) {
-                  newArr = Object.assign([...formContent.stringTags], {
-                    [itemNum]: {
-                      ...formContent.stringTags[itemNum],
-                      name: e.target.value,
-                    },
-                  })
-                  updateForm({...formContent, stringTags: newArr})
-                } else {
-                  newArr = Object.assign([...formContent.stringFields], {
-                    [itemNum]: {
-                      ...formContent.stringFields[itemNum],
-                      name: e.target.value,
-                    },
-                  })
-                  updateForm({...formContent, stringFields: newArr})
-                }
-              }}
-              onBlur={() =>
-                event(
-                  'completed form field',
-                  {
-                    formField: `${
-                      tagType ? 'stringTags' : 'stringFields'
-                    }.name`,
-                  },
-                  {feature: 'subscriptions'}
-                )
-              }
-              status={edit ? status : ComponentStatus.Disabled}
-              maxLength={56}
-              testID={`${name}-string-parsing-name`}
-            />
-          )}
-        </Form.ValidationElement>
+          placeholder="nonDescriptName"
+          onChange={e => {
+            let newArr
+            if (tagType) {
+              newArr = Object.assign([...formContent.stringTags], {
+                [itemNum]: {
+                  ...formContent.stringTags[itemNum],
+                  name: e.target.value,
+                },
+              })
+              updateForm({...formContent, stringTags: newArr})
+            } else {
+              newArr = Object.assign([...formContent.stringFields], {
+                [itemNum]: {
+                  ...formContent.stringFields[itemNum],
+                  name: e.target.value,
+                },
+              })
+              updateForm({...formContent, stringFields: newArr})
+            }
+          }}
+          onBlur={() =>
+            event(
+              'completed form field',
+              {
+                formField: `${tagType ? 'stringTags' : 'stringFields'}.name`,
+              },
+              {feature: 'subscriptions'}
+            )
+          }
+          edit={edit}
+          maxLength={56}
+          testID={`${name}-string-parsing-name`}
+        />
       </Grid.Column>
       <Grid.Column>
-        <Form.ValidationElement
+        <ValidationInputWithTooltip
           label="Regex pattern"
+          name="regex"
           value={
             tagType
               ? formContent.stringTags[itemNum].pattern
               : formContent.stringFields[itemNum].pattern
           }
           required={true}
+          tooltip={REGEX_TOOLTIP}
+          placeholder="eg. a=(\d)"
           validationFunc={() => {
             const pattern = tagType
               ? formContent.stringTags[itemNum].pattern
@@ -174,55 +164,39 @@ const StringPatternInput: FC<Props> = ({
               handleRegexValidation(pattern)
             )
           }}
-        >
-          {status => (
-            <Input
-              type={InputType.Text}
-              placeholder="eg. a=(\d)"
-              name="regex"
-              autoFocus={true}
-              value={
-                tagType
-                  ? formContent.stringTags[itemNum].pattern
-                  : formContent.stringFields[itemNum].pattern
-              }
-              onChange={e => {
-                let newArr
-                if (tagType) {
-                  newArr = Object.assign([...formContent.stringTags], {
-                    [itemNum]: {
-                      ...formContent.stringTags[itemNum],
-                      pattern: e.target.value,
-                    },
-                  })
-                  updateForm({...formContent, stringTags: newArr})
-                } else {
-                  newArr = Object.assign([...formContent.stringFields], {
-                    [itemNum]: {
-                      ...formContent.stringFields[itemNum],
-                      pattern: e.target.value,
-                    },
-                  })
-                  updateForm({...formContent, stringFields: newArr})
-                }
-              }}
-              onBlur={() =>
-                event(
-                  'completed form field',
-                  {
-                    formField: `${
-                      tagType ? 'stringTags' : 'stringFields'
-                    }.pattern`,
-                  },
-                  {feature: 'subscriptions'}
-                )
-              }
-              status={edit ? status : ComponentStatus.Disabled}
-              maxLength={255}
-              testID={`${name}-string-parsing-pattern`}
-            />
-          )}
-        </Form.ValidationElement>
+          onChange={e => {
+            let newArr
+            if (tagType) {
+              newArr = Object.assign([...formContent.stringTags], {
+                [itemNum]: {
+                  ...formContent.stringTags[itemNum],
+                  pattern: e.target.value,
+                },
+              })
+              updateForm({...formContent, stringTags: newArr})
+            } else {
+              newArr = Object.assign([...formContent.stringFields], {
+                [itemNum]: {
+                  ...formContent.stringFields[itemNum],
+                  pattern: e.target.value,
+                },
+              })
+              updateForm({...formContent, stringFields: newArr})
+            }
+          }}
+          onBlur={() =>
+            event(
+              'completed form field',
+              {
+                formField: `${tagType ? 'stringTags' : 'stringFields'}.pattern`,
+              },
+              {feature: 'subscriptions'}
+            )
+          }
+          edit={edit}
+          maxLength={255}
+          testID={`${name}-string-parsing-pattern`}
+        />
         <div className="line"></div>
       </Grid.Column>
     </div>

--- a/src/writeData/subscriptions/components/ValidationInputWithTooltip.scss
+++ b/src/writeData/subscriptions/components/ValidationInputWithTooltip.scss
@@ -1,0 +1,13 @@
+@import '@influxdata/clockface/dist/variables.scss';
+
+.required-indicator {
+  color: $c-curacao !important;
+}
+
+.validation-tooltip {
+  margin-left: $cf-space-2xs;
+}
+
+.validation-input {
+  padding-top: $cf-space-2xs;
+}

--- a/src/writeData/subscriptions/components/ValidationInputWithTooltip.tsx
+++ b/src/writeData/subscriptions/components/ValidationInputWithTooltip.tsx
@@ -1,0 +1,88 @@
+// Libraries
+import React, {FC} from 'react'
+
+// Components
+import {
+  Input,
+  Form,
+  InputType,
+  ComponentSize,
+  ComponentStatus,
+  InputLabel,
+  QuestionMarkTooltip,
+} from '@influxdata/clockface'
+
+// Styles
+import 'src/writeData/subscriptions/components/ValidationInputWithTooltip.scss'
+
+interface Props {
+  label: string
+  name: string
+  value: string
+  required: boolean
+  tooltip: string
+  placeholder: string
+  maxLength?: number
+  edit: boolean
+  validationFunc: Function
+  onChange: Function
+  onBlur: Function
+  testID: string
+  width?: string
+}
+
+const ValidationInputWithTooltip: FC<Props> = ({
+  label,
+  value,
+  required,
+  tooltip,
+  placeholder,
+  name,
+  maxLength,
+  edit,
+  validationFunc,
+  onChange,
+  onBlur,
+  testID,
+  width,
+}) => (
+  <div style={{width: width ?? '100%'}}>
+    <InputLabel size={ComponentSize.Medium}>{label}</InputLabel>
+    {required && (
+      <InputLabel className="required-indicator" size={ComponentSize.Large}>
+        *
+      </InputLabel>
+    )}
+    <QuestionMarkTooltip
+      className="validation-tooltip"
+      tooltipContents={tooltip}
+      diameter={14}
+    />
+    <Form.ValidationElement
+      label=""
+      value={value}
+      required={required}
+      validationFunc={() => validationFunc()}
+    >
+      {status => (
+        <div>
+          <Input
+            className="validation-input"
+            type={InputType.Text}
+            placeholder={placeholder}
+            name={name}
+            autoFocus={true}
+            value={value}
+            onChange={e => onChange(e)}
+            onBlur={e => onBlur(e)}
+            status={edit ? status : ComponentStatus.Disabled}
+            maxLength={maxLength}
+            testID={testID}
+          />
+        </div>
+      )}
+    </Form.ValidationElement>
+  </div>
+)
+
+export default ValidationInputWithTooltip

--- a/src/writeData/subscriptions/utils/form.ts
+++ b/src/writeData/subscriptions/utils/form.ts
@@ -45,6 +45,11 @@ export const SUBSCRIPTION_NAVIGATION_STEPS: SubscriptionNavigationModel[] = [
   },
 ]
 
+export const REGEX_TOOLTIP =
+  'Java flavor regular expressions expected. Use a capture group if desired. See https://regex101.com for more info.'
+export const JSON_TOOLTIP =
+  'JsonPath expression that returns a singular value expected. See http://jsonpath.com for more info.'
+
 export const handleValidation = (
   property: string,
   formVal: string


### PR DESCRIPTION
Closes https://github.com/influxdata/data-acquisition/issues/418

Adds a component `ValidationInputWithTooltips` that creates an input box with validation and has a tooltip next to the label. This was required because the typical validation input only allows strings as the label instead of react components.

The other changes utilize this new component to add tooltips explaining what's expected in each of the jsonpath and regex inputs for CNS. Some minor CSS changes were required to keep the layout the same.

<img width="1595" alt="image" src="https://user-images.githubusercontent.com/6411855/178627208-108fb8d4-5889-4df1-888c-b7091a8da984.png">

<img width="1475" alt="image" src="https://user-images.githubusercontent.com/6411855/178627222-35832ca6-4ef8-4a18-b611-42d68c246bb5.png">

<img width="387" alt="image" src="https://user-images.githubusercontent.com/6411855/178627251-5f6e323e-176a-434b-a3c4-928604fd6fdc.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
