### PR TITLE
fix: force cancel

### DIFF
--- a/src/dataExplorer/components/ResultsPane.tsx
+++ b/src/dataExplorer/components/ResultsPane.tsx
@@ -92,7 +92,7 @@ const rangeToParam = (timeRange: TimeRange) => {
 }
 
 const ResultsPane: FC = () => {
-  const {basic, query} = useContext(QueryContext)
+  const {basic, query, cancel} = useContext(QueryContext)
   const {status, setStatus, setResult} = useContext(ResultsContext)
 
   const [oldHorizDragPosition, setOldHorizDragPosition] = useResizeState()
@@ -222,7 +222,9 @@ const ResultsPane: FC = () => {
                 onSubmit={submit}
                 onNotify={fakeNotify}
                 queryID=""
-                cancelAllRunningQueries={() => {}}
+                cancelAllRunningQueries={() => {
+                  cancel()
+                }}
               />
             </FlexBox>
           </div>


### PR DESCRIPTION
Closes #5001

force cancels all running queries on the page when the cancel button is pressed.