### PR TITLE
fix: hide the view timer in flux schema builder

### DIFF
--- a/src/dataExplorer/components/Results.tsx
+++ b/src/dataExplorer/components/Results.tsx
@@ -153,12 +153,18 @@ const Results: FC = () => {
             } as SimpleTableViewProperties
           }
           result={res}
+          hideTimer
         />
       )
     } else {
       resultView = (
         <div style={{height: '100%', width: '100%', padding: 12}}>
-          <View loading={status} properties={view.properties} result={res} />
+          <View
+            loading={status}
+            properties={view.properties}
+            result={res}
+            hideTimer
+          />
         </div>
       )
     }

--- a/src/visualization/components/View.tsx
+++ b/src/visualization/components/View.tsx
@@ -24,6 +24,7 @@ interface Props {
   timeRange?: TimeRange
   annotations?: AnnotationsList
   cellID?: string
+  hideTimer?: boolean
 }
 
 const InnerView: FC<Props> = ({
@@ -68,7 +69,9 @@ const InnerView: FC<Props> = ({
 
 const View: FC<Props> = props => (
   <ErrorBoundary>
-    <ViewLoadingSpinner loading={props.loading || RemoteDataState.Done} />
+    {!props.hideTimer && (
+      <ViewLoadingSpinner loading={props.loading || RemoteDataState.Done} />
+    )}
     <InnerView {...props} />
   </ErrorBoundary>
 )


### PR DESCRIPTION
Closes #5002

adds an optional parameter to not display the default loading indicator in a visualization