### PR TITLE
fix: normalize windowPeriod when null for zoom re-query feature

### DIFF
--- a/src/variables/utils/getWindowVars.ts
+++ b/src/variables/utils/getWindowVars.ts
@@ -1,3 +1,6 @@
+// Libraries
+import {NumericColumnData} from '@influxdata/giraffe'
+
 // APIs
 import {parse} from 'src/languageSupport/languages/flux/parser'
 
@@ -17,11 +20,12 @@ import {
 
 // Types
 import {VariableAssignment, Package} from 'src/types/ast'
-import {RemoteDataState, Variable} from 'src/types'
+import {RemoteDataState, TimeRange, Variable} from 'src/types'
 import {SELECTABLE_TIME_RANGES} from 'src/shared/constants/timeRanges'
 
 const DESIRED_POINTS_PER_GRAPH = 360
 const FALLBACK_WINDOW_PERIOD = 15000
+const MINIMUM_WINDOW_PERIOD = 1
 
 /*
   Compute the `v.windowPeriod` variable assignment for a query.
@@ -226,4 +230,80 @@ export const getVariableForZoomRequery = (
     default:
       return variable
   }
+}
+
+/*
+ * Prevents the windowPeriod from being null for the time axis
+ *   this fallback is used only for the zoom re-query feature
+ *   if the windowPeriod cannot be found, apply the user-selected domain
+ *   to the original data set and divide by the optimal number of graph points
+ *   to get the estimated windowPeriod
+ */
+export const normalizeWindowPeriodForZoomRequery = (
+  windowPeriod: number | null,
+  timeRange: TimeRange,
+  domain: Array<number>,
+  column: NumericColumnData | string[]
+): number => {
+  if (windowPeriod || !timeRange || !column) {
+    return windowPeriod
+  }
+
+  if (column.length === 0 || domain.length !== 2) {
+    return FALLBACK_WINDOW_PERIOD
+  }
+
+  let counter = 0
+  let startIndex = counter
+  let endIndex = counter
+
+  while (counter < column.length) {
+    if (domain[0] > column[counter]) {
+      startIndex = counter
+    }
+    if (domain[1] > column[counter]) {
+      endIndex = counter
+    }
+    counter += 1
+  }
+
+  const duration =
+    (Number(column[endIndex]) - Number(column[startIndex])) /
+    DESIRED_POINTS_PER_GRAPH
+
+  return Math.max(duration, MINIMUM_WINDOW_PERIOD)
+}
+
+/*
+ * Prevents the windowPeriod assignment from being empty
+ *   this fallback is used only for the zoom re-query feature
+ *   re-querying should include the windowPeriod assignment as a literal
+ *   even if the backend ignores it due to an override in the Flux script
+ */
+export const normalizeWindowPeriodVariableForZoomRequery = (
+  variableAssignment: VariableAssignment[],
+  windowPeriod: number
+): VariableAssignment[] => {
+  if (Array.isArray(variableAssignment) && variableAssignment.length) {
+    return variableAssignment
+  }
+
+  const assignedWindowPeriod = Math.max(
+    Math.min(Math.round(windowPeriod), FALLBACK_WINDOW_PERIOD),
+    MINIMUM_WINDOW_PERIOD
+  )
+
+  return [
+    {
+      type: 'VariableAssignment',
+      id: {
+        type: 'Identifier',
+        name: WINDOW_PERIOD,
+      },
+      init: {
+        type: 'DurationLiteral',
+        values: [{magnitude: assignedWindowPeriod, unit: 'ms'}],
+      },
+    },
+  ]
 }

--- a/src/visualization/utils/useVisDomainSettings.ts
+++ b/src/visualization/utils/useVisDomainSettings.ts
@@ -19,6 +19,8 @@ import {event} from 'src/cloud/utils/reporting'
 import {
   getWindowPeriodFromVariables,
   getWindowVarsFromVariables,
+  normalizeWindowPeriodForZoomRequery,
+  normalizeWindowPeriodVariableForZoomRequery,
 } from 'src/variables/utils/getWindowVars'
 
 // Types
@@ -198,19 +200,31 @@ export const useZoomRequeryXDomainSettings = (args: ZoomRequeryArgs) => {
   const variables = useSelector(getAllVariablesWithTimeDomain)
 
   const [windowPeriod, setWindowPeriod] = useState<number>(
-    getWindowPeriodFromVariables(query, variables)
+    normalizeWindowPeriodForZoomRequery(
+      getWindowPeriodFromVariables(query, variables),
+      timeRange,
+      domain,
+      data
+    )
   )
 
   useEffect(() => {
-    const updatedWindowPeriod = getWindowPeriodFromVariables(query, variables)
+    const updatedWindowPeriod = normalizeWindowPeriodForZoomRequery(
+      getWindowPeriodFromVariables(query, variables),
+      timeRange,
+      domain,
+      data
+    )
+
     if (isNotEqual(windowPeriod, updatedWindowPeriod)) {
-      setWindowPeriod(getWindowPeriodFromVariables(query, variables))
+      setWindowPeriod(updatedWindowPeriod)
 
       if (isNotEqual(preZoomDomain, domain)) {
-        const zoomQueryWindowVariable = getWindowVarsFromVariables(
-          query,
-          variables
+        const zoomQueryWindowVariable = normalizeWindowPeriodVariableForZoomRequery(
+          getWindowVarsFromVariables(query, variables),
+          updatedWindowPeriod
         )
+
         const extern = buildUsedVarsOption(
           query,
           variables,
@@ -315,19 +329,31 @@ export const useZoomRequeryYDomainSettings = (args: ZoomRequeryArgs) => {
   const variables = useSelector(getAllVariablesWithTimeDomain)
 
   const [windowPeriod, setWindowPeriod] = useState<number>(
-    getWindowPeriodFromVariables(query, variables)
+    normalizeWindowPeriodForZoomRequery(
+      getWindowPeriodFromVariables(query, variables),
+      timeRange,
+      domain,
+      data
+    )
   )
 
   useEffect(() => {
-    const updatedWindowPeriod = getWindowPeriodFromVariables(query, variables)
+    const updatedWindowPeriod = normalizeWindowPeriodForZoomRequery(
+      getWindowPeriodFromVariables(query, variables),
+      timeRange,
+      domain,
+      data
+    )
+
     if (isNotEqual(windowPeriod, updatedWindowPeriod)) {
-      setWindowPeriod(getWindowPeriodFromVariables(query, variables))
+      setWindowPeriod(updatedWindowPeriod)
 
       if (isNotEqual(preZoomDomain, domain)) {
-        const zoomQueryWindowVariable = getWindowVarsFromVariables(
-          query,
-          variables
+        const zoomQueryWindowVariable = normalizeWindowPeriodVariableForZoomRequery(
+          getWindowVarsFromVariables(query, variables),
+          updatedWindowPeriod
         )
+
         const extern = buildUsedVarsOption(
           query,
           variables,


### PR DESCRIPTION
Part of EAR 2422

- allows the zoom re-query feature to work properly on complex Flux functions or whenever the `windowPeriod` is `null`
- apply a fallback method for calculating `windowPeriod` when `null` by using the user selected domain (zoom domain) and the original data set to estimate the `windowPeriod` over the optimal number of graph points


Here is a video of the zoom re-query working with a complex Flux script:


https://user-images.githubusercontent.com/10736577/178856359-a4909ccb-1bdf-4c68-a6ad-f196c8848916.mp4

