### PR TITLE
feat(FirstMile): add Go sample app and boilerplate code to finish page

### DIFF
--- a/src/homepageExperience/components/steps/Finish.tsx
+++ b/src/homepageExperience/components/steps/Finish.tsx
@@ -130,10 +130,10 @@ export const Finish = (props: OwnProps) => {
             </p>
           </ResourceCard>
         </FlexBox>
-          <SampleAppCard
-            handleNextStepEvent={handleNextStepEvent}
-            wizardEventName={props.wizardEventName}
-          />
+        <SampleAppCard
+          handleNextStepEvent={handleNextStepEvent}
+          wizardEventName={props.wizardEventName}
+        />
       </FlexBox>
     </>
   )

--- a/src/homepageExperience/components/steps/Finish.tsx
+++ b/src/homepageExperience/components/steps/Finish.tsx
@@ -81,10 +81,6 @@ export const Finish = (props: OwnProps) => {
     }
   }, [])
 
-  const showSampleAppAndBoilerplate =
-    props.wizardEventName === 'pythonWizard' ||
-    props.wizardEventName === 'nodejsWizard'
-
   return (
     <>
       <h1>Congrats!</h1>
@@ -134,12 +130,10 @@ export const Finish = (props: OwnProps) => {
             </p>
           </ResourceCard>
         </FlexBox>
-        {showSampleAppAndBoilerplate && (
           <SampleAppCard
             handleNextStepEvent={handleNextStepEvent}
             wizardEventName={props.wizardEventName}
           />
-        )}
       </FlexBox>
     </>
   )

--- a/src/homepageExperience/components/steps/SampleAppCard.tsx
+++ b/src/homepageExperience/components/steps/SampleAppCard.tsx
@@ -18,15 +18,23 @@ type Props = {
 }
 
 const SampleAppCard: FC<Props> = ({wizardEventName, handleNextStepEvent}) => {
+
+  const client = {
+    pythonWizard: 'Python', 
+    nodejsWizard: 'Node.js', 
+    goWizard: 'Go',
+  }
+
   const resources = [
     {
       title: 'Sample App',
       textContent: `View an IoT sample application written in ${
-        wizardEventName === 'pythonWizard' ? 'Python' : 'Node.js'
+        client[wizardEventName]
       }.`,
       links: {
         pythonWizard: 'https://github.com/influxdata/iot-api-python',
         nodejsWizard: 'https://github.com/influxdata/iot-api-js',
+        goWizard: 'https://github.com/influxdata/go-samples/tree/master/cmd/iot_app'
       },
     },
     {
@@ -37,6 +45,7 @@ const SampleAppCard: FC<Props> = ({wizardEventName, handleNextStepEvent}) => {
         pythonWizard:
           'https://github.com/InfluxCommunity/sample-flask/blob/main/app.py',
         nodejsWizard: 'https://github.com/influxdata/nodejs-samples/',
+        goWizard: 'https://github.com/influxdata/go-samples/tree/master/cmd/boilerplate'
       },
     },
   ]

--- a/src/homepageExperience/components/steps/SampleAppCard.tsx
+++ b/src/homepageExperience/components/steps/SampleAppCard.tsx
@@ -18,23 +18,21 @@ type Props = {
 }
 
 const SampleAppCard: FC<Props> = ({wizardEventName, handleNextStepEvent}) => {
-
-  const client = {
-    pythonWizard: 'Python', 
-    nodejsWizard: 'Node.js', 
+  const clientLibrary = {
+    pythonWizard: 'Python',
+    nodejsWizard: 'Node.js',
     goWizard: 'Go',
   }
 
   const resources = [
     {
       title: 'Sample App',
-      textContent: `View an IoT sample application written in ${
-        client[wizardEventName]
-      }.`,
+      textContent: `View an IoT sample application written in ${clientLibrary[wizardEventName]}.`,
       links: {
         pythonWizard: 'https://github.com/influxdata/iot-api-python',
         nodejsWizard: 'https://github.com/influxdata/iot-api-js',
-        goWizard: 'https://github.com/influxdata/go-samples/tree/master/cmd/iot_app'
+        goWizard:
+          'https://github.com/influxdata/go-samples/tree/master/cmd/iot_app',
       },
     },
     {
@@ -45,7 +43,8 @@ const SampleAppCard: FC<Props> = ({wizardEventName, handleNextStepEvent}) => {
         pythonWizard:
           'https://github.com/InfluxCommunity/sample-flask/blob/main/app.py',
         nodejsWizard: 'https://github.com/influxdata/nodejs-samples/',
-        goWizard: 'https://github.com/influxdata/go-samples/tree/master/cmd/boilerplate'
+        goWizard:
+          'https://github.com/influxdata/go-samples/tree/master/cmd/boilerplate',
       },
     },
   ]


### PR DESCRIPTION
Closes #4987 
Closes #4986 

PR adds the following to the Go First Mile Finish page:

- Sample App [https://github.com/influxdata/go-samples/tree/master/cmd/iot_app]
- Boilerplate Code [https://github.com/influxdata/go-samples/tree/master/cmd/boilerplate]
- removes code conditionally rendering sample app and boiler plate code.
<img width="1115" alt="Screen Shot 2022-07-13 at 7 19 40 PM" src="https://user-images.githubusercontent.com/66275100/178858634-6c04bf44-27a4-494c-ac3e-488b210bfc75.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
