### PR TITLE
fix: use correct overlay behavior for All Access API token creation

### DIFF
--- a/src/authorizations/components/AllAccessTokenOverlay.tsx
+++ b/src/authorizations/components/AllAccessTokenOverlay.tsx
@@ -63,10 +63,11 @@ const AllAccessTokenOverlay: FC<OwnProps> = props => {
       description,
       permissions: allAccessPermissions(sortedPermissionTypes, orgID, meID),
     }
-    dispatch(createAuthorization(token))
-    handleDismiss()
-    event('token.allAccess.create.success', {meID, name: description})
-    dispatch(showOverlay('access-token', null, () => dismissOverlay()))
+
+    Promise.resolve(dispatch(createAuthorization(token))).then(() => {
+      event('token.allAccess.create.success', {meID, name: description})
+      dispatch(showOverlay('access-token', null, () => dismissOverlay()))
+    }, handleDismiss)
   }
 
   const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
Closes #4992 

Fixes the token overlay behavior when there is an error on creation.


Error behavior:

https://user-images.githubusercontent.com/10736577/178867454-dae61700-a5b7-4661-b5cb-0d512da86033.mp4



Success behavior (no change):

https://user-images.githubusercontent.com/10736577/178867492-d1c8675e-0bea-4042-a9d2-157ecfc0281c.mp4

