### PR TITLE
feat(sub): toggle between static and dynamic measurement

### DIFF
--- a/src/writeData/subscriptions/components/JsonParsingForm.scss
+++ b/src/writeData/subscriptions/components/JsonParsingForm.scss
@@ -44,3 +44,6 @@
     }
   }
 }
+.static-toggle {
+  padding-bottom: $cf-space-m;
+}

--- a/src/writeData/subscriptions/components/StringParsingForm.tsx
+++ b/src/writeData/subscriptions/components/StringParsingForm.tsx
@@ -15,6 +15,8 @@ import {
   ComponentSize,
   FlexDirection,
   FlexBox,
+  InputLabel,
+  SlideToggle,
 } from '@influxdata/clockface'
 import StringPatternInput from 'src/writeData/subscriptions/components/StringPatternInput'
 
@@ -43,6 +45,9 @@ interface Props {
 const StringParsingForm: FC<Props> = ({formContent, updateForm, edit}) => {
   const ruleList = ['field', 'tag']
   const [rule, setRule] = useState('')
+  const [useStaticMeasurement, setUseStaticMeasurement] = useState(
+    !!formContent.stringMeasurement.name
+  )
   const defaultStringFieldTag = {
     name: '',
     pattern: '',
@@ -169,42 +174,104 @@ const StringParsingForm: FC<Props> = ({formContent, updateForm, edit}) => {
             Measurement
           </Heading>
         </FlexBox>
-        <ValidationInputWithTooltip
-          label="Regex Pattern to find Measurement"
-          value={formContent.stringMeasurement.pattern}
-          required={true}
-          validationFunc={() => {
-            const pattern = formContent.stringMeasurement.pattern
-            return (
-              handleValidation('Pattern', pattern) ??
-              handleRegexValidation(pattern)
-            )
-          }}
-          placeholder="eg. a=(\d)"
-          name="regex"
-          onChange={e => {
-            updateForm({
-              ...formContent,
-              stringMeasurement: {
-                ...formContent.stringMeasurement,
-                pattern: e.target.value,
-              },
-            })
-          }}
-          onBlur={() =>
-            event(
-              'completed form field',
-              {
-                formField: 'stringMeasurement.pattern',
-              },
-              {feature: 'subscriptions'}
-            )
-          }
-          edit={edit}
-          maxLength={255}
-          testID="measurment-string-parsing-pattern"
-          tooltip={REGEX_TOOLTIP}
-        />
+        <FlexBox
+          direction={FlexDirection.Row}
+          alignItems={AlignItems.Center}
+          margin={ComponentSize.Medium}
+          className="static-toggle"
+        >
+          <InputLabel>Regex</InputLabel>
+          <SlideToggle
+            active={useStaticMeasurement}
+            onChange={() => {
+              setUseStaticMeasurement(!useStaticMeasurement)
+              updateForm({
+                ...formContent,
+                stringMeasurement: {
+                  ...formContent.stringMeasurement,
+                  name: '',
+                  pattern: '',
+                },
+              })
+            }}
+            disabled={!edit}
+          />
+          <InputLabel>Name</InputLabel>
+        </FlexBox>
+        {useStaticMeasurement ? (
+          <ValidationInputWithTooltip
+            label="Name"
+            value={formContent.stringMeasurement.name}
+            required={true}
+            validationFunc={() => {
+              return handleValidation(
+                'Measurement Name',
+                formContent.stringMeasurement.name
+              )
+            }}
+            placeholder="nonDescriptName"
+            name="name"
+            onChange={e => {
+              updateForm({
+                ...formContent,
+                stringMeasurement: {
+                  ...formContent.stringMeasurement,
+                  name: e.target.value,
+                },
+              })
+            }}
+            onBlur={() =>
+              event(
+                'completed form field',
+                {
+                  formField: 'stringMeasurement.name',
+                },
+                {feature: 'subscriptions'}
+              )
+            }
+            edit={edit}
+            maxLength={255}
+            testID="measurment-string-parsing-name"
+            tooltip="Provide a static measurement for your messages."
+          />
+        ) : (
+          <ValidationInputWithTooltip
+            label="Regex Pattern to find Measurement"
+            value={formContent.stringMeasurement.pattern}
+            required={true}
+            validationFunc={() => {
+              const pattern = formContent.stringMeasurement.pattern
+              return (
+                handleValidation('Pattern', pattern) ??
+                handleRegexValidation(pattern)
+              )
+            }}
+            placeholder="eg. a=(\d)"
+            name="regex"
+            onChange={e => {
+              updateForm({
+                ...formContent,
+                stringMeasurement: {
+                  ...formContent.stringMeasurement,
+                  pattern: e.target.value,
+                },
+              })
+            }}
+            onBlur={() =>
+              event(
+                'completed form field',
+                {
+                  formField: 'stringMeasurement.pattern',
+                },
+                {feature: 'subscriptions'}
+              )
+            }
+            edit={edit}
+            maxLength={255}
+            testID="measurment-string-parsing-pattern"
+            tooltip={REGEX_TOOLTIP}
+          />
+        )}
         <div className="line"></div>
       </Grid.Column>
       {formContent.stringTags.map((_, key) => (

--- a/src/writeData/subscriptions/context/subscription.create.tsx
+++ b/src/writeData/subscriptions/context/subscription.create.tsx
@@ -39,7 +39,7 @@ export const DEFAULT_CONTEXT: SubscriptionCreateContextType = {
     topic: '',
     dataFormat: 'lineprotocol',
     jsonMeasurementKey: {
-      name: 'measurement',
+      name: '',
       path: '',
       type: 'string',
     },
@@ -58,7 +58,7 @@ export const DEFAULT_CONTEXT: SubscriptionCreateContextType = {
     },
     stringMeasurement: {
       pattern: '',
-      name: 'measurement',
+      name: '',
     },
     stringFields: [
       {

--- a/src/writeData/subscriptions/utils/form.ts
+++ b/src/writeData/subscriptions/utils/form.ts
@@ -80,17 +80,24 @@ export const checkJSONPathStarts$ = (firstChar, formVal): string | null => {
 }
 
 export const sanitizeForm = (form: Subscription): Subscription => {
+  // if (!form.stringMeasurement.name) {
+  //   form.stringMeasurement.name = 'measurement'
+  // }
+  // if (!form.jsonMeasurementKey.name) {
+  //   form.jsonMeasurementKey.name = 'measurement'
+  // }
   // add $. if not at start of input for json paths
-  if (form.jsonMeasurementKey) {
+  if (form.jsonMeasurementKey.path) {
     const startChar = form.jsonMeasurementKey?.path.charAt(0) ?? ''
     const newVal = checkJSONPathStarts$(startChar, form.jsonMeasurementKey.path)
     if (newVal) {
       form.jsonMeasurementKey.path = newVal
     }
-    if (form.jsonMeasurementKey.type === 'number') {
-      form.jsonMeasurementKey.type = 'double'
-    }
   }
+  if (form.jsonMeasurementKey.type === 'number') {
+    form.jsonMeasurementKey.type = 'double'
+  }
+
   if (form.jsonFieldKeys) {
     form.jsonFieldKeys.map(f => {
       const startChar = f.path?.charAt(0) ?? ''
@@ -131,15 +138,21 @@ export const sanitizeForm = (form: Subscription): Subscription => {
 }
 
 export const sanitizeUpdateForm = (form: Subscription): Subscription => {
+  // if (!form.stringMeasurement.name) {
+  //   form.stringMeasurement.name = 'measurement'
+  // }
+  // if (!form.jsonMeasurementKey.name) {
+  //   form.jsonMeasurementKey.name = 'measurement'
+  // }
   if (form.jsonMeasurementKey.path) {
     const startChar = form.jsonMeasurementKey?.path.charAt(0) ?? ''
     const newVal = checkJSONPathStarts$(startChar, form.jsonMeasurementKey.path)
     if (newVal) {
       form.jsonMeasurementKey.path = newVal
     }
-    if (form.jsonMeasurementKey.type === 'number') {
-      form.jsonMeasurementKey.type = 'double'
-    }
+  }
+  if (form.jsonMeasurementKey.type === 'number') {
+    form.jsonMeasurementKey.type = 'double'
   }
   if (form.jsonFieldKeys) {
     form.jsonFieldKeys.map(f => {
@@ -214,12 +227,18 @@ export const checkRequiredStringFields = (form: Subscription): boolean => {
     return true
   }
   return (
-    !!form.stringMeasurement.pattern &&
-    validateRegex(form.stringMeasurement.pattern) &&
+    checkStringMeasurement(form.stringMeasurement) &&
     checkStringTimestamp(form.stringTimestamp) &&
     form.stringFields?.length > 0 &&
     form.stringFields?.every(f => checkStringObjRequiredFields(f)) &&
     form.stringTags?.every(t => checkStringObjRequiredFields(t))
+  )
+}
+
+const checkStringMeasurement = (stringMeasurement: StringObjectParams) => {
+  return (
+    !!stringMeasurement.name ||
+    (!!stringMeasurement.pattern && validateRegex(stringMeasurement.pattern))
   )
 }
 
@@ -264,13 +283,19 @@ export const checkRequiredJsonFields = (form: Subscription): boolean => {
     return true
   }
   return (
-    !!form.jsonMeasurementKey?.path &&
-    !!form.jsonMeasurementKey?.type &&
-    validateJsonPath(form.jsonMeasurementKey.path) &&
+    checkJsonMeasurement(form.jsonMeasurementKey) &&
     checkJsonTimestamp(form.jsonTimestamp) &&
     form.jsonFieldKeys?.length > 0 &&
     form.jsonFieldKeys?.every(f => checkJsonObjRequiredFields(f)) &&
     form.jsonTagKeys?.every(t => checkJsonObjRequiredFields(t))
+  )
+}
+
+const checkJsonMeasurement = (jsonMeasurement: JsonSpec) => {
+  return (
+    !!jsonMeasurement.type &&
+    (!!jsonMeasurement.name ||
+      (!!jsonMeasurement.path && validateJsonPath(jsonMeasurement.path)))
   )
 }
 


### PR DESCRIPTION
Closes https://github.com/influxdata/data-acquisition/issues/405
Helps https://github.com/influxdata/data-acquisition/issues/400

Allows users to switch between providing a static measurement name and using jsonpath or regex to pull the measurement from their message. Totally works 😱 

Regex

<img width="503" alt="image" src="https://user-images.githubusercontent.com/6411855/178918389-f498c249-31bc-428d-90db-d260b79c9978.png">

<img width="390" alt="image" src="https://user-images.githubusercontent.com/6411855/178918432-fa3fb668-c0bc-4644-ae16-1bb98d42968f.png">

Json

<img width="338" alt="image" src="https://user-images.githubusercontent.com/6411855/178918479-bdd22cf5-af6f-4b36-9eaf-a6d037006a42.png">
<img width="375" alt="image" src="https://user-images.githubusercontent.com/6411855/178918503-6e3d0f11-c58f-4f3a-a8d5-56af3f49da13.png">




Merge first:
- https://github.com/influxdata/idpe/pull/15161

Manually tested create & update with json & string. Also manually tested switching from static to dynamic and vice verse for json & string.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
