### PR TITLE
chore: increase measurement limit to 1000

### DIFF
--- a/src/dataExplorer/context/fields.tsx
+++ b/src/dataExplorer/context/fields.tsx
@@ -7,10 +7,7 @@ import {
   CACHING_REQUIRED_END_DATE,
   CACHING_REQUIRED_START_DATE,
 } from 'src/utils/datetime/constants'
-import {
-  DEFAULT_TAG_LIMIT,
-  EXTENDED_TAG_LIMIT,
-} from 'src/shared/constants/queryBuilder'
+import {DEFAULT_LIMIT, EXTENDED_LIMIT} from 'src/shared/constants/queryBuilder'
 
 // Contexts
 import {QueryContext} from 'src/shared/contexts/query'
@@ -60,8 +57,8 @@ export const FieldsProvider: FC<Prop> = ({children, scope}) => {
 
   // Constant
   const limit = isFlagEnabled('increasedMeasurmentTagLimit')
-    ? EXTENDED_TAG_LIMIT
-    : DEFAULT_TAG_LIMIT
+    ? EXTENDED_LIMIT
+    : DEFAULT_LIMIT
 
   const getFields = async (
     bucket: Bucket,

--- a/src/dataExplorer/context/measurements.tsx
+++ b/src/dataExplorer/context/measurements.tsx
@@ -6,10 +6,7 @@ import {
   CACHING_REQUIRED_END_DATE,
   CACHING_REQUIRED_START_DATE,
 } from 'src/utils/datetime/constants'
-import {
-  DEFAULT_TAG_LIMIT,
-  EXTENDED_TAG_LIMIT,
-} from 'src/shared/constants/queryBuilder'
+import {DEFAULT_LIMIT, EXTENDED_LIMIT} from 'src/shared/constants/queryBuilder'
 
 // Contexts
 import {QueryContext} from 'src/shared/contexts/query'
@@ -56,8 +53,8 @@ export const MeasurementsProvider: FC<Prop> = ({children, scope}) => {
 
   // Constant
   const limit = isFlagEnabled('increasedMeasurmentTagLimit')
-    ? EXTENDED_TAG_LIMIT
-    : DEFAULT_TAG_LIMIT
+    ? EXTENDED_LIMIT
+    : DEFAULT_LIMIT
 
   const getMeasurements = async bucket => {
     if (!bucket) {

--- a/src/dataExplorer/context/tags.tsx
+++ b/src/dataExplorer/context/tags.tsx
@@ -7,10 +7,7 @@ import {
   CACHING_REQUIRED_END_DATE,
   CACHING_REQUIRED_START_DATE,
 } from 'src/utils/datetime/constants'
-import {
-  DEFAULT_TAG_LIMIT,
-  EXTENDED_TAG_LIMIT,
-} from 'src/shared/constants/queryBuilder'
+import {DEFAULT_LIMIT, EXTENDED_LIMIT} from 'src/shared/constants/queryBuilder'
 
 // Contexts
 import {QueryContext} from 'src/shared/contexts/query'
@@ -74,8 +71,8 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
 
   // Constant
   const limit = isFlagEnabled('increasedMeasurmentTagLimit')
-    ? EXTENDED_TAG_LIMIT
-    : DEFAULT_TAG_LIMIT
+    ? EXTENDED_LIMIT
+    : DEFAULT_LIMIT
 
   const getTagKeys = async (
     bucket: Bucket,

--- a/src/flows/pipes/QueryBuilder/context.tsx
+++ b/src/flows/pipes/QueryBuilder/context.tsx
@@ -22,10 +22,7 @@ import {
   CACHING_REQUIRED_END_DATE,
   CACHING_REQUIRED_START_DATE,
 } from 'src/utils/datetime/constants'
-import {
-  DEFAULT_TAG_LIMIT,
-  EXTENDED_TAG_LIMIT,
-} from 'src/shared/constants/queryBuilder'
+import {DEFAULT_LIMIT, EXTENDED_LIMIT} from 'src/shared/constants/queryBuilder'
 
 interface APIResultArray<T> {
   selected: T[]
@@ -272,8 +269,8 @@ export const QueryBuilderProvider: FC = ({children}) => {
     }
 
     const limit = isFlagEnabled('increasedMeasurmentTagLimit')
-      ? EXTENDED_TAG_LIMIT
-      : DEFAULT_TAG_LIMIT
+      ? EXTENDED_LIMIT
+      : DEFAULT_LIMIT
 
     let queryText = `${_source}
     |> range(${formatTimeRangeArguments(range)})
@@ -399,8 +396,8 @@ export const QueryBuilderProvider: FC = ({children}) => {
     }
 
     const limit = isFlagEnabled('increasedMeasurmentTagLimit')
-      ? EXTENDED_TAG_LIMIT
-      : DEFAULT_TAG_LIMIT
+      ? EXTENDED_LIMIT
+      : DEFAULT_LIMIT
     let queryText = `${_source}
     |> range(${formatTimeRangeArguments(range)})
     |> filter(fn: (r) => ${tagString})

--- a/src/shared/constants/queryBuilder.ts
+++ b/src/shared/constants/queryBuilder.ts
@@ -1,2 +1,2 @@
-export const DEFAULT_TAG_LIMIT = 200
-export const EXTENDED_TAG_LIMIT = 500
+export const DEFAULT_LIMIT = 200
+export const EXTENDED_LIMIT = 500

--- a/src/shared/constants/queryBuilder.ts
+++ b/src/shared/constants/queryBuilder.ts
@@ -1,2 +1,2 @@
 export const DEFAULT_LIMIT = 200
-export const EXTENDED_LIMIT = 500
+export const EXTENDED_LIMIT = 1000

--- a/src/timeMachine/apis/queryBuilder.ts
+++ b/src/timeMachine/apis/queryBuilder.ts
@@ -14,6 +14,10 @@ import {
   CACHING_REQUIRED_END_DATE,
   CACHING_REQUIRED_START_DATE,
 } from 'src/utils/datetime/constants'
+import {
+  DEFAULT_LIMIT,
+  EXTENDED_LIMIT,
+} from 'src/shared/constants/queryBuilder'
 
 // Types
 import {TimeRange, BuilderConfig} from 'src/types'
@@ -21,8 +25,6 @@ import {CancelBox} from 'src/types/promises'
 import {pastThirtyDaysTimeRange} from 'src/shared/constants/timeRanges'
 
 const DEFAULT_TIME_RANGE: TimeRange = pastThirtyDaysTimeRange
-const DEFAULT_LIMIT = 200
-const EXTENDED_LIMIT = 500
 
 export interface FindKeysOptions {
   url: string

--- a/src/timeMachine/apis/queryBuilder.ts
+++ b/src/timeMachine/apis/queryBuilder.ts
@@ -14,10 +14,7 @@ import {
   CACHING_REQUIRED_END_DATE,
   CACHING_REQUIRED_START_DATE,
 } from 'src/utils/datetime/constants'
-import {
-  DEFAULT_LIMIT,
-  EXTENDED_LIMIT,
-} from 'src/shared/constants/queryBuilder'
+import {DEFAULT_LIMIT, EXTENDED_LIMIT} from 'src/shared/constants/queryBuilder'
 
 // Types
 import {TimeRange, BuilderConfig} from 'src/types'


### PR DESCRIPTION
Closes #5047 

This PR increases the measurement (and tag) limit from `500` to `1000` when the feature flag  `increasedMeasurmentTagLimit` is on. The constant names are also updated to more general names since the limit applies to both measurements and tags.

I will turn on the feature flag in monitor301, tools, and production once this is merged into master

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
