### PR TITLE
fix: use honeybadger over toast for identity error reporting

### DIFF
--- a/src/identity/actions/thunks/index.ts
+++ b/src/identity/actions/thunks/index.ts
@@ -48,11 +48,11 @@ export const getQuartzIdentityThunk = () => async (
     const legacyMe = convertIdentityToMe(quartzIdentity)
     dispatch(setQuartzMe(legacyMe, RemoteDataState.Done))
     dispatch(setQuartzMeStatus(RemoteDataState.Done))
-  } catch (error) {
+  } catch (err) {
     dispatch(setQuartzIdentityStatus(RemoteDataState.Error))
     dispatch(setQuartzMeStatus(RemoteDataState.Error))
 
-    reportErrorThroughHoneyBadger(error, {
+    reportErrorThroughHoneyBadger(err, {
       name: 'Failed to fetch /quartz/identity',
       context: {state: getState()},
     })
@@ -77,11 +77,11 @@ export const getBillingProviderThunk = () => async (
     const legacyMe = convertIdentityToMe(updatedState.identity.currentIdentity)
     dispatch(setQuartzMe(legacyMe, RemoteDataState.Done))
     dispatch(setQuartzMeStatus(RemoteDataState.Done))
-  } catch (error) {
+  } catch (err) {
     dispatch(setQuartzIdentityStatus(RemoteDataState.Error))
     dispatch(setQuartzMeStatus(RemoteDataState.Error))
 
-    reportErrorThroughHoneyBadger(error, {
+    reportErrorThroughHoneyBadger(err, {
       name: 'Failed to fetch /quartz/accounts/',
       context: {state: getState()},
     })
@@ -107,11 +107,11 @@ export const getCurrentOrgDetailsThunk = () => async (
     const legacyMe = convertIdentityToMe(updatedState.identity.currentIdentity)
     dispatch(setQuartzMe(legacyMe, RemoteDataState.Done))
     dispatch(setQuartzMeStatus(RemoteDataState.Done))
-  } catch (error) {
+  } catch (err) {
     dispatch(setQuartzIdentityStatus(RemoteDataState.Error))
     dispatch(setQuartzMeStatus(RemoteDataState.Error))
 
-    reportErrorThroughHoneyBadger(error, {
+    reportErrorThroughHoneyBadger(err, {
       name: 'Failed to fetch /quartz/orgs/:orgId',
       context: {state: getState()},
     })

--- a/src/identity/actions/thunks/index.ts
+++ b/src/identity/actions/thunks/index.ts
@@ -32,6 +32,7 @@ import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Thunks
 import {getQuartzMeThunk} from 'src/me/actions/thunks'
+import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
 
 export const getQuartzIdentityThunk = () => async dispatch => {
   if (!isFlagEnabled('quartzIdentity')) {
@@ -53,7 +54,10 @@ export const getQuartzIdentityThunk = () => async dispatch => {
   } catch (error) {
     dispatch(setQuartzIdentityStatus(RemoteDataState.Error))
     dispatch(setQuartzMeStatus(RemoteDataState.Error))
-    dispatch(notify(updateIdentityFailed()))
+
+    reportErrorThroughHoneyBadger(error, {
+      name: 'Unauthorized to Access /quartz/identity',
+    })
   }
 }
 
@@ -78,7 +82,10 @@ export const getBillingProviderThunk = () => async (
   } catch (error) {
     dispatch(setQuartzIdentityStatus(RemoteDataState.Error))
     dispatch(setQuartzMeStatus(RemoteDataState.Error))
-    dispatch(notify(updateBillingFailed()))
+
+    reportErrorThroughHoneyBadger(error, {
+      name: 'Unauthorized to access /quartz/accounts/',
+    })
   }
 }
 
@@ -104,6 +111,9 @@ export const getCurrentOrgDetailsThunk = () => async (
   } catch (error) {
     dispatch(setQuartzIdentityStatus(RemoteDataState.Error))
     dispatch(setQuartzMeStatus(RemoteDataState.Error))
-    dispatch(notify(updateOrgFailed()))
+
+    reportErrorThroughHoneyBadger(error, {
+      name: 'Unauthorized to access /quartz/orgs/',
+    })
   }
 }

--- a/src/identity/actions/thunks/index.ts
+++ b/src/identity/actions/thunks/index.ts
@@ -6,12 +6,6 @@ import {
   setQuartzIdentity,
   setQuartzIdentityStatus,
 } from 'src/identity/actions/creators'
-import {notify} from 'src/shared/actions/notifications'
-import {
-  updateBillingFailed,
-  updateIdentityFailed,
-  updateOrgFailed,
-} from 'src/shared/copy/notifications'
 
 // Types
 import {RemoteDataState, GetState, NotificationAction} from 'src/types'
@@ -34,7 +28,10 @@ import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {getQuartzMeThunk} from 'src/me/actions/thunks'
 import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
 
-export const getQuartzIdentityThunk = () => async dispatch => {
+export const getQuartzIdentityThunk = () => async (
+  dispatch: Dispatch<any>,
+  getState: GetState
+) => {
   if (!isFlagEnabled('quartzIdentity')) {
     dispatch(getQuartzMeThunk())
     return
@@ -56,7 +53,8 @@ export const getQuartzIdentityThunk = () => async dispatch => {
     dispatch(setQuartzMeStatus(RemoteDataState.Error))
 
     reportErrorThroughHoneyBadger(error, {
-      name: 'Unauthorized to Access /quartz/identity',
+      name: 'Failed to fetch /quartz/identity',
+      context: {state: getState()},
     })
   }
 }
@@ -84,7 +82,7 @@ export const getBillingProviderThunk = () => async (
     dispatch(setQuartzMeStatus(RemoteDataState.Error))
 
     reportErrorThroughHoneyBadger(error, {
-      name: 'Unauthorized to access /quartz/accounts/',
+      name: 'Failed to fetch /quartz/accounts/',
     })
   }
 }
@@ -113,7 +111,7 @@ export const getCurrentOrgDetailsThunk = () => async (
     dispatch(setQuartzMeStatus(RemoteDataState.Error))
 
     reportErrorThroughHoneyBadger(error, {
-      name: 'Unauthorized to access /quartz/orgs/',
+      name: 'Failed to fetch /quartz/orgs/:orgId',
     })
   }
 }

--- a/src/identity/actions/thunks/index.ts
+++ b/src/identity/actions/thunks/index.ts
@@ -26,6 +26,8 @@ import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Thunks
 import {getQuartzMeThunk} from 'src/me/actions/thunks'
+
+// Error Reporting
 import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
 
 export const getQuartzIdentityThunk = () => async (

--- a/src/identity/actions/thunks/index.ts
+++ b/src/identity/actions/thunks/index.ts
@@ -83,6 +83,7 @@ export const getBillingProviderThunk = () => async (
 
     reportErrorThroughHoneyBadger(error, {
       name: 'Failed to fetch /quartz/accounts/',
+      context: {state: getState()},
     })
   }
 }
@@ -112,6 +113,7 @@ export const getCurrentOrgDetailsThunk = () => async (
 
     reportErrorThroughHoneyBadger(error, {
       name: 'Failed to fetch /quartz/orgs/:orgId',
+      context: {state: getState()},
     })
   }
 }

--- a/src/identity/quartzOrganizations/actions/thunks/index.ts
+++ b/src/identity/quartzOrganizations/actions/thunks/index.ts
@@ -19,9 +19,8 @@ import {OrganizationSummaries} from 'src/client/unityRoutes'
 type Actions = QuartzOrganizationActions | PublishNotificationAction
 type DefaultOrg = OrganizationSummaries[number]
 
-// Notifications
-import {notify} from 'src/shared/actions/notifications'
-import {updateQuartzOrganizationsFailed} from 'src/shared/copy/notifications'
+// Error Reporting
+import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
 
 export const getQuartzOrganizationsThunk = () => async (
   dispatch: Dispatch<Actions>
@@ -32,9 +31,12 @@ export const getQuartzOrganizationsThunk = () => async (
 
     dispatch(setQuartzOrganizations(quartzOrganizations))
     dispatch(setQuartzOrganizationsStatus(RemoteDataState.Done))
-  } catch (error) {
+  } catch (err) {
     dispatch(setQuartzOrganizationsStatus(RemoteDataState.Error))
-    dispatch(notify(updateQuartzOrganizationsFailed()))
+
+    reportErrorThroughHoneyBadger(err, {
+      name: 'Failed to fetch /quartz/orgs/',
+    })
   }
 }
 
@@ -52,6 +54,9 @@ export const updateDefaultOrgThunk = (
     dispatch(setQuartzOrganizationsStatus(RemoteDataState.Done))
   } catch (err) {
     dispatch(setQuartzOrganizationsStatus(RemoteDataState.Error))
-    throw Error(err)
+
+    reportErrorThroughHoneyBadger(err, {
+      name: 'Failed to update /quartz/orgs/default',
+    })
   }
 }

--- a/src/identity/quartzOrganizations/actions/thunks/index.ts
+++ b/src/identity/quartzOrganizations/actions/thunks/index.ts
@@ -13,7 +13,7 @@ import {
 import {PublishNotificationAction} from 'src/shared/actions/notifications'
 
 // Types
-import {RemoteDataState} from 'src/types'
+import {GetState, RemoteDataState} from 'src/types'
 import {OrganizationSummaries} from 'src/client/unityRoutes'
 
 type Actions = QuartzOrganizationActions | PublishNotificationAction
@@ -23,7 +23,8 @@ type DefaultOrg = OrganizationSummaries[number]
 import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
 
 export const getQuartzOrganizationsThunk = () => async (
-  dispatch: Dispatch<Actions>
+  dispatch: Dispatch<Actions>,
+  getState: GetState
 ) => {
   try {
     dispatch(setQuartzOrganizationsStatus(RemoteDataState.Loading))
@@ -36,6 +37,7 @@ export const getQuartzOrganizationsThunk = () => async (
 
     reportErrorThroughHoneyBadger(err, {
       name: 'Failed to fetch /quartz/orgs/',
+      context: {state: getState()},
     })
   }
 }
@@ -43,7 +45,7 @@ export const getQuartzOrganizationsThunk = () => async (
 export const updateDefaultOrgThunk = (
   oldDefaultOrg: DefaultOrg,
   newDefaultOrg: DefaultOrg
-) => async (dispatch: Dispatch<Actions>) => {
+) => async (dispatch: Dispatch<Actions>, getState: GetState) => {
   try {
     dispatch(setQuartzOrganizationsStatus(RemoteDataState.Loading))
 
@@ -57,6 +59,7 @@ export const updateDefaultOrgThunk = (
 
     reportErrorThroughHoneyBadger(err, {
       name: 'Failed to update /quartz/orgs/default',
+      context: {state: getState()},
     })
   }
 }

--- a/src/shared/copy/notifications/categories/accounts-users-orgs.ts
+++ b/src/shared/copy/notifications/categories/accounts-users-orgs.ts
@@ -131,23 +131,6 @@ export const removeUserSuccessful = (): Notification => ({
   message: `User Removed`,
 })
 
-export const updateBillingFailed = (): Notification => ({
-  ...defaultErrorNotification,
-  message:
-    'Error retrieving account billing provider. Please refresh this page.',
-})
-
-export const updateIdentityFailed = (): Notification => ({
-  ...defaultErrorNotification,
-  message: 'Error retrieving user identity. Please refresh this page.',
-})
-
-export const updateOrgFailed = (): Notification => ({
-  ...defaultErrorNotification,
-  message:
-    'Error retrieving new organization information. Please refresh this page.',
-})
-
 export const updateQuartzOrganizationsFailed = (): Notification => ({
   ...defaultErrorNotification,
   message:

--- a/src/shared/copy/notifications/categories/accounts-users-orgs.ts
+++ b/src/shared/copy/notifications/categories/accounts-users-orgs.ts
@@ -130,9 +130,3 @@ export const removeUserSuccessful = (): Notification => ({
   ...defaultSuccessNotification,
   message: `User Removed`,
 })
-
-export const updateQuartzOrganizationsFailed = (): Notification => ({
-  ...defaultErrorNotification,
-  message:
-    'We were unable to retrieve the list of your InfluxData organizations. Please refresh this page.',
-})


### PR DESCRIPTION
Closes #5067

There are still cloud environments without quartz access, and those environments request data from /`quartz`. Previously, those requests could return a `401`, and the data would not be provided, but no error was reported. With the upgrade to the `identity` endpoint, they are now handled but produce a toast notification for the user. This PR changes the error reporting so that requests to `/quartz/identity` that fail are sent to honeybadger for tracking, instead of generating a toast.

This PR proposes adding this reporting only for `/quartz/identity`, not `/quartz/me`, since the latter endpoint is being deprecated, and will be unused once the feature flag for `quartzIdentity` is switched on.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed) N/A
- [X] Feature flagged, if applicable
