### PR TITLE
chore(sub): remove createdby, updatedby for update

### DIFF
--- a/src/types/subscriptions.ts
+++ b/src/types/subscriptions.ts
@@ -26,6 +26,8 @@ export interface Subscription {
   qos?: number
   createdAt?: Date
   updatedAt?: Date
+  createdBy?: string
+  updatedBy?: string
   tokenID?: string
   token?: string
   isActive?: string

--- a/src/writeData/subscriptions/utils/form.ts
+++ b/src/writeData/subscriptions/utils/form.ts
@@ -80,12 +80,6 @@ export const checkJSONPathStarts$ = (firstChar, formVal): string | null => {
 }
 
 export const sanitizeForm = (form: Subscription): Subscription => {
-  // if (!form.stringMeasurement.name) {
-  //   form.stringMeasurement.name = 'measurement'
-  // }
-  // if (!form.jsonMeasurementKey.name) {
-  //   form.jsonMeasurementKey.name = 'measurement'
-  // }
   // add $. if not at start of input for json paths
   if (form.jsonMeasurementKey.path) {
     const startChar = form.jsonMeasurementKey?.path.charAt(0) ?? ''
@@ -137,12 +131,6 @@ export const sanitizeForm = (form: Subscription): Subscription => {
 }
 
 export const sanitizeUpdateForm = (form: Subscription): Subscription => {
-  // if (!form.stringMeasurement.name) {
-  //   form.stringMeasurement.name = 'measurement'
-  // }
-  // if (!form.jsonMeasurementKey.name) {
-  //   form.jsonMeasurementKey.name = 'measurement'
-  // }
   if (form.jsonMeasurementKey.path) {
     const startChar = form.jsonMeasurementKey?.path.charAt(0) ?? ''
     const newVal = checkJSONPathStarts$(startChar, form.jsonMeasurementKey.path)
@@ -196,6 +184,8 @@ export const sanitizeUpdateForm = (form: Subscription): Subscription => {
   delete form.processGroupID
   delete form.createdAt
   delete form.updatedAt
+  delete form.createdBy
+  delete form.updatedBy
   delete form.tokenID
   delete form.isActive
   delete form.status


### PR DESCRIPTION
Helps https://github.com/influxdata/data-acquisition/issues/425

Removes the `createdBy` and `updatedBy` properties that might exist before making an update request. These audit columns are managed by the backend and the UI should not attempt to provide them in the PUT request.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
