### PR TITLE
fix: show search bar for bucket even when no bucket is found

### DIFF
--- a/src/dataExplorer/components/BucketSelector.tsx
+++ b/src/dataExplorer/components/BucketSelector.tsx
@@ -85,59 +85,49 @@ const BucketSelector: FC = () => {
     )
   }
 
-  if (!_buckets.length) {
-    return (
-      <div>
-        <SelectorTitle title="Bucket" info={BUCKET_TOOLTIP} />
-        <Dropdown
-          button={button}
-          menu={onCollapse => (
-            <Dropdown.Menu onCollapse={onCollapse}>
-              <Dropdown.ItemEmpty>No Buckets Available</Dropdown.ItemEmpty>
-            </Dropdown.Menu>
-          )}
-        />
-      </div>
-    )
-  }
+  let body: JSX.Element | JSX.Element[] = (
+    <Dropdown.ItemEmpty>No Buckets Found</Dropdown.ItemEmpty>
+  )
 
-  const body = Object.entries(
-    _buckets.reduce((acc, curr) => {
-      if (!acc[curr.type]) {
-        acc[curr.type] = []
+  if (_buckets.length) {
+    body = Object.entries(
+      _buckets.reduce((acc, curr) => {
+        if (!acc[curr.type]) {
+          acc[curr.type] = []
+        }
+
+        acc[curr.type].push(curr)
+        return acc
+      }, {}) as Record<string, Bucket[]>
+    ).map(([k, v]) => {
+      const items = v.map(bucket => (
+        <Dropdown.Item
+          key={bucket.name}
+          value={bucket}
+          onClick={handleSelectBucket}
+          selected={bucket.name === selectedBucket?.name}
+          title={bucket.name}
+          wrapText={true}
+          testID={`bucket-selector--dropdown--${bucket.name}`}
+        >
+          {bucket.name}
+        </Dropdown.Item>
+      ))
+
+      let name = k
+
+      if (REMAP_BUCKET_TYPES.hasOwnProperty(k)) {
+        name = REMAP_BUCKET_TYPES[k]
       }
 
-      acc[curr.type].push(curr)
-      return acc
-    }, {}) as Record<string, Bucket[]>
-  ).map(([k, v]) => {
-    const items = v.map(bucket => (
-      <Dropdown.Item
-        key={bucket.name}
-        value={bucket}
-        onClick={handleSelectBucket}
-        selected={bucket.name === selectedBucket?.name}
-        title={bucket.name}
-        wrapText={true}
-        testID={`bucket-selector--dropdown--${bucket.name}`}
-      >
-        {bucket.name}
-      </Dropdown.Item>
-    ))
-
-    let name = k
-
-    if (REMAP_BUCKET_TYPES.hasOwnProperty(k)) {
-      name = REMAP_BUCKET_TYPES[k]
-    }
-
-    return (
-      <Fragment key={name}>
-        <Dropdown.Divider text={name} />
-        {items}
-      </Fragment>
-    )
-  })
+      return (
+        <Fragment key={name}>
+          <Dropdown.Divider text={name} />
+          {items}
+        </Fragment>
+      )
+    })
+  }
 
   return (
     <div>

--- a/src/shared/components/SearchableDropdown.scss
+++ b/src/shared/components/SearchableDropdown.scss
@@ -3,13 +3,3 @@
   padding: $cf-space-2xs 0;
   border-bottom: $ix-border solid $cf-grey-25;
 }
-
-.searchable-dropdown--empty {
-  padding: $cf-space-2xs;
-  text-align: center;
-  opacity: 0.75;
-  user-select: none;
-  font-style: italic;
-  font-weight: 500;
-  font-size: 12px;
-}

--- a/src/shared/components/SearchableDropdown.tsx
+++ b/src/shared/components/SearchableDropdown.tsx
@@ -54,7 +54,7 @@ const SearchableDropdown: FC<Props> = ({
   )
 
   let body: JSX.Element | JSX.Element[] = (
-    <div className="searchable-dropdown--empty">{emptyText}</div>
+    <Dropdown.ItemEmpty>{emptyText}</Dropdown.ItemEmpty>
   )
 
   if (filteredOptions.length) {


### PR DESCRIPTION
Closes #5072 

This PR fixes the bug that search bar disappears when there is no found buckets.
 
## Before

![image](https://user-images.githubusercontent.com/14298407/179553009-ff3b5035-1a80-4eb3-adcf-ee6e4d7c0ee8.png)

## After

<img width="322" alt="Screen Shot 2022-07-18 at 11 00 16 AM" src="https://user-images.githubusercontent.com/14298407/179553287-ee7f4feb-3b78-450b-8e8b-ad2a62c96b67.png">



### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
