### PR TITLE
chore(schemaBrowser): clear old measurement search term when select a new bucket

### DIFF
--- a/src/dataExplorer/components/MeasurementSelector.tsx
+++ b/src/dataExplorer/components/MeasurementSelector.tsx
@@ -1,4 +1,11 @@
-import React, {FC, useCallback, useContext, useMemo, useState} from 'react'
+import React, {
+  FC,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
 
 // Components
 import {ComponentStatus} from '@influxdata/clockface'
@@ -36,6 +43,10 @@ const MeasurementSelector: FC = () => {
   )
   const {measurements, loading} = useContext(MeasurementsContext)
   const [searchTerm, setSearchTerm] = useState('')
+
+  useEffect(() => {
+    setSearchTerm('')
+  }, [selectedBucket])
 
   const handleSelect = useCallback(
     (option: string): void => {

--- a/src/shared/components/SearchableDropdown.scss
+++ b/src/shared/components/SearchableDropdown.scss
@@ -1,7 +1,6 @@
 .searchable-dropdown--input-container {
   width: 100%;
   padding: $cf-space-2xs 0;
-  padding-right: $cf-space-xs;
   border-bottom: $ix-border solid $cf-grey-25;
 }
 

--- a/src/shared/components/SearchableDropdown.scss
+++ b/src/shared/components/SearchableDropdown.scss
@@ -1,6 +1,7 @@
 .searchable-dropdown--input-container {
   width: 100%;
   padding: $cf-space-2xs 0;
+  padding-right: $cf-space-xs;
   border-bottom: $ix-border solid $cf-grey-25;
 }
 


### PR DESCRIPTION
This PR fixes a bug that the old measurement search term still remains when a new bucket is selected.

## Before

https://user-images.githubusercontent.com/14298407/179556747-4da7c07a-6d04-4d9a-a8e3-ba43428fceeb.mov


## After

https://user-images.githubusercontent.com/14298407/179556771-7e7e5e0a-90d9-47cd-ab5c-dd541654cf53.mov


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
