### PR TITLE
feat: remove deepLinking feature flag (it's on)

### DIFF
--- a/cypress/e2e/shared/deepLinks.test.ts
+++ b/cypress/e2e/shared/deepLinks.test.ts
@@ -12,127 +12,111 @@ describe('Deep linking', () => {
   // so you'll probably need to follow-up with the docs and/or marketing teams.
   it('should be redirected to the approprate page from a shortened link', () => {
     cy.get('@org').then((org: Organization) => {
-      cy.setFeatureFlags({
-        deepLinking: true,
-      }).then(() => {
-        cy.wait(1000)
-        cy.visit('/me/about')
-        cy.location('pathname').should('eq', `/orgs/${org.id}/about`)
+      cy.wait(1000)
+      cy.visit('/me/about')
+      cy.location('pathname').should('eq', `/orgs/${org.id}/about`)
 
-        cy.visit('/me/alerts')
-        cy.location('pathname').should('eq', `/orgs/${org.id}/alerting`)
+      cy.visit('/me/alerts')
+      cy.location('pathname').should('eq', `/orgs/${org.id}/alerting`)
 
-        cy.visit('/me/billing')
-        cy.location('pathname').should('eq', `/orgs/${org.id}/billing`)
+      cy.visit('/me/billing')
+      cy.location('pathname').should('eq', `/orgs/${org.id}/billing`)
 
-        cy.visit('/me/buckets')
-        cy.location('pathname').should(
-          'eq',
-          `/orgs/${org.id}/load-data/buckets`
-        )
+      cy.visit('/me/buckets')
+      cy.location('pathname').should('eq', `/orgs/${org.id}/load-data/buckets`)
 
-        cy.visit('/me/csharpclient')
-        cy.location('pathname').should(
-          'eq',
-          `/orgs/${org.id}/load-data/client-libraries/csharp`
-        )
+      cy.visit('/me/csharpclient')
+      cy.location('pathname').should(
+        'eq',
+        `/orgs/${org.id}/load-data/client-libraries/csharp`
+      )
 
-        cy.visit('/me/dashboards')
-        cy.location('pathname').should('eq', `/orgs/${org.id}/dashboards-list`)
+      cy.visit('/me/dashboards')
+      cy.location('pathname').should('eq', `/orgs/${org.id}/dashboards-list`)
 
-        cy.visit('/me/data-explorer')
-        cy.location('pathname').should('eq', `/orgs/${org.id}/data-explorer`)
+      cy.visit('/me/data-explorer')
+      cy.location('pathname').should('eq', `/orgs/${org.id}/data-explorer`)
 
-        cy.visit('/me/goclient')
-        cy.location('pathname').should(
-          'eq',
-          `/orgs/${org.id}/load-data/client-libraries/go`
-        )
+      cy.visit('/me/goclient')
+      cy.location('pathname').should(
+        'eq',
+        `/orgs/${org.id}/load-data/client-libraries/go`
+      )
 
-        cy.visit('/me/home')
-        cy.location('pathname').should('eq', `/orgs/${org.id}`)
+      cy.visit('/me/home')
+      cy.location('pathname').should('eq', `/orgs/${org.id}`)
 
-        cy.visit('/me/labels')
-        cy.location('pathname').should('eq', `/orgs/${org.id}/settings/labels`)
+      cy.visit('/me/labels')
+      cy.location('pathname').should('eq', `/orgs/${org.id}/settings/labels`)
 
-        cy.visit('/me/load-data')
-        cy.location('pathname').should(
-          'eq',
-          `/orgs/${org.id}/load-data/sources`
-        )
+      cy.visit('/me/load-data')
+      cy.location('pathname').should('eq', `/orgs/${org.id}/load-data/sources`)
 
-        cy.visit('/me/nodejsclient')
-        cy.location('pathname').should(
-          'eq',
-          `/orgs/${org.id}/load-data/client-libraries/javascript-node`
-        )
+      cy.visit('/me/nodejsclient')
+      cy.location('pathname').should(
+        'eq',
+        `/orgs/${org.id}/load-data/client-libraries/javascript-node`
+      )
 
-        cy.visit('/me/notebooks')
-        cy.location('pathname').should('eq', `/orgs/${org.id}/notebooks`)
+      cy.visit('/me/notebooks')
+      cy.location('pathname').should('eq', `/orgs/${org.id}/notebooks`)
 
-        cy.visit('/me/pythonclient')
-        cy.location('pathname').should(
-          'eq',
-          `/orgs/${org.id}/load-data/client-libraries/python`
-        )
+      cy.visit('/me/pythonclient')
+      cy.location('pathname').should(
+        'eq',
+        `/orgs/${org.id}/load-data/client-libraries/python`
+      )
 
-        cy.visit('/me/secrets')
-        cy.location('pathname').should('eq', `/orgs/${org.id}/settings/secrets`)
+      cy.visit('/me/secrets')
+      cy.location('pathname').should('eq', `/orgs/${org.id}/settings/secrets`)
 
-        cy.visit('/me/setup-golang')
-        cy.location('pathname').should(
-          'eq',
-          `/orgs/${org.id}/new-user-setup/golang`
-        )
+      cy.visit('/me/setup-golang')
+      cy.location('pathname').should(
+        'eq',
+        `/orgs/${org.id}/new-user-setup/golang`
+      )
 
-        cy.visit('/me/setup-nodejs')
-        cy.location('pathname').should(
-          'eq',
-          `/orgs/${org.id}/new-user-setup/nodejs`
-        )
+      cy.visit('/me/setup-nodejs')
+      cy.location('pathname').should(
+        'eq',
+        `/orgs/${org.id}/new-user-setup/nodejs`
+      )
 
-        cy.visit('/me/setup-python')
-        cy.location('pathname').should(
-          'eq',
-          `/orgs/${org.id}/new-user-setup/python`
-        )
+      cy.visit('/me/setup-python')
+      cy.location('pathname').should(
+        'eq',
+        `/orgs/${org.id}/new-user-setup/python`
+      )
 
-        cy.visit('/me/tasks')
-        cy.location('pathname').should('eq', `/orgs/${org.id}/tasks`)
+      cy.visit('/me/tasks')
+      cy.location('pathname').should('eq', `/orgs/${org.id}/tasks`)
 
-        cy.visit('/me/telegraf-mqtt')
-        cy.location('pathname').should(
-          'eq',
-          `/orgs/${org.id}/load-data/telegraf-plugins/mqtt_consumer`
-        )
+      cy.visit('/me/telegraf-mqtt')
+      cy.location('pathname').should(
+        'eq',
+        `/orgs/${org.id}/load-data/telegraf-plugins/mqtt_consumer`
+      )
 
-        cy.visit('/me/telegrafs')
-        cy.location('pathname').should(
-          'eq',
-          `/orgs/${org.id}/load-data/telegrafs`
-        )
+      cy.visit('/me/telegrafs')
+      cy.location('pathname').should(
+        'eq',
+        `/orgs/${org.id}/load-data/telegrafs`
+      )
 
-        cy.visit('/me/templates')
-        cy.location('pathname').should(
-          'eq',
-          `/orgs/${org.id}/settings/templates`
-        )
+      cy.visit('/me/templates')
+      cy.location('pathname').should('eq', `/orgs/${org.id}/settings/templates`)
 
-        cy.visit('/me/tokens')
-        cy.location('pathname').should('eq', `/orgs/${org.id}/load-data/tokens`)
+      cy.visit('/me/tokens')
+      cy.location('pathname').should('eq', `/orgs/${org.id}/load-data/tokens`)
 
-        cy.visit('/me/usage')
-        cy.location('pathname').should('eq', `/orgs/${org.id}/usage`)
+      cy.visit('/me/usage')
+      cy.location('pathname').should('eq', `/orgs/${org.id}/usage`)
 
-        cy.visit('/me/users')
-        cy.location('pathname').should('eq', `/orgs/${org.id}/users`)
+      cy.visit('/me/users')
+      cy.location('pathname').should('eq', `/orgs/${org.id}/users`)
 
-        cy.visit('/me/variables')
-        cy.location('pathname').should(
-          'eq',
-          `/orgs/${org.id}/settings/variables`
-        )
-      })
+      cy.visit('/me/variables')
+      cy.location('pathname').should('eq', `/orgs/${org.id}/settings/variables`)
     })
   })
 })

--- a/src/shared/components/NotFound.tsx
+++ b/src/shared/components/NotFound.tsx
@@ -19,7 +19,6 @@ import {getOrg} from 'src/organizations/selectors'
 import {getOrg as fetchOrg} from 'src/organizations/apis'
 
 // Utils
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {buildDeepLinkingMap} from 'src/utils/deepLinks'
 import {event} from 'src/cloud/utils/reporting'
 
@@ -149,9 +148,7 @@ const NotFound: FC = () => {
   }, [history, location.pathname])
 
   useEffect(() => {
-    if (isFlagEnabled('deepLinking')) {
-      handleDeepLink()
-    }
+    handleDeepLink()
   }, [handleDeepLink])
 
   if (isFetchingOrg) {


### PR DESCRIPTION
Connects #5091

removes the `isFlagEnabled()` calls for the feature flag `deepLinking`.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
