### PR TITLE
chore: update giraffe from 2.31.1 to 2.32.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "@docsearch/react": "^3.0.0-alpha.37",
     "@influxdata/clockface": "^4.7.4",
     "@influxdata/flux-lsp-browser": "0.8.21",
-    "@influxdata/giraffe": "^2.31.1",
+    "@influxdata/giraffe": "^2.32.0",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",
     "abortcontroller-polyfill": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1471,10 +1471,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/flux-lsp-browser/-/flux-lsp-browser-0.8.21.tgz#28b1ab5d2b9f3130a616628f8da95fc4b886dfc6"
   integrity sha512-N/O9ZfePb7TjgVjecFekBkU5iIW2Ld1FPDE8iuirg5WQMdka9ZLvpCn0jcfUUD3C8mJyBt5gj5+VQe+oSgH49Q==
 
-"@influxdata/giraffe@^2.31.1":
-  version "2.31.1"
-  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.31.1.tgz#c16211e93c392b612401d208950f0d01925efb74"
-  integrity sha512-DhJzm7e3Yk9pTE+y3g4qrcCbfDwMpduGKKmcR9mQjaErEnqLGCtyCgNi6Uo1qMppxRJ0CdZyHkIXV4D1oT8syg==
+"@influxdata/giraffe@^2.32.0":
+  version "2.32.0"
+  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.32.0.tgz#212eb7f1d8db905b0924f149284547f33601fd03"
+  integrity sha512-VoOU0/+otWtZyUd4hHgj2Z52F9vKfKNjUyAyf/3OZi/NrF2nT1oSBXD3E8xI+fUxX1UGqgebiytV8soVFVf7uQ==
   dependencies:
     merge-images "^2.0.0"
 


### PR DESCRIPTION

PR updates `package.json` with newest giraffe version to include ability to properly scale large data points on the y-axis 

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
