### PR TITLE
fix(4882): set default for Gauge input

### DIFF
--- a/src/visualization/types/Gauge/constants.ts
+++ b/src/visualization/types/Gauge/constants.ts
@@ -68,4 +68,5 @@ export const GAUGE_THEME_DARK: GaugeTheme = {
 }
 
 export const GAUGE_ARC_LENGTH_DEFAULT = 1.5 * Math.PI
+export const GAUGE_VALUE_POSITION_X_OFFSET_DEFAULT = 1.5
 export const GAUGE_VALUE_POSITION_Y_OFFSET_DEFAULT = 1.5

--- a/src/visualization/types/Gauge/view.tsx
+++ b/src/visualization/types/Gauge/view.tsx
@@ -9,6 +9,7 @@ import {VisualizationProps} from 'src/visualization'
 
 import {
   GAUGE_ARC_LENGTH_DEFAULT,
+  GAUGE_VALUE_POSITION_X_OFFSET_DEFAULT,
   GAUGE_VALUE_POSITION_Y_OFFSET_DEFAULT,
 } from './constants'
 
@@ -39,6 +40,7 @@ const GaugeChart: FC<Props> = ({result, properties}) => {
         gaugeColors: colors,
         gaugeSize: GAUGE_ARC_LENGTH_DEFAULT,
         gaugeTheme: {
+          valuePositionXOffset: GAUGE_VALUE_POSITION_X_OFFSET_DEFAULT,
           valuePositionYOffset: GAUGE_VALUE_POSITION_Y_OFFSET_DEFAULT,
         },
       },


### PR DESCRIPTION
Part of #4882 

## Bug:
* error in honeybadger:
  * <img width="718" alt="Screen Shot 2022-07-18 at 2 31 29 PM" src="https://user-images.githubusercontent.com/10232835/179621882-807ed2f0-ae60-4984-b633-bfc1400d3f40.png">
* is this code:
  * https://github.com/influxdata/giraffe/blob/master/giraffe/src/components/Gauge.tsx#L364-L372
* is missing a default, which we provide for the Y (not the X)  