### PR TITLE
chore(5062): missing variables in dashboard

### DIFF
--- a/src/variables/utils/astim.ts
+++ b/src/variables/utils/astim.ts
@@ -23,7 +23,7 @@ export const parseASTIM = (query: string): ASTIM => {
   try {
     ast = parse(query)
   } catch (e) {
-    console.error(e)
+    console.error(`ERROR: parseASTIM errored on script ${query} with error:`, e)
   }
   const variables: MemberExpression[] = ast ? parseAllVariables(ast) : []
   const variableNames = new Set()

--- a/src/variables/utils/astim.ts
+++ b/src/variables/utils/astim.ts
@@ -23,7 +23,10 @@ export const parseASTIM = (query: string): ASTIM => {
   try {
     ast = parse(query)
   } catch (e) {
-    console.error(`ERROR: parseASTIM errored on script ${query} with error:`, e)
+    console.error(
+      `ERROR: parseASTIM errored on script:\n ${query}\n with error:`,
+      e
+    )
   }
   const variables: MemberExpression[] = ast ? parseAllVariables(ast) : []
   const variableNames = new Set()

--- a/src/variables/utils/astim.ts
+++ b/src/variables/utils/astim.ts
@@ -23,10 +23,8 @@ export const parseASTIM = (query: string): ASTIM => {
   try {
     ast = parse(query)
   } catch (e) {
-    console.error(
-      `ERROR: parseASTIM errored on script:\n ${query}\n with error:`,
-      e
-    )
+    console.error(`ERROR: parseASTIM errored on script:\n ${query}`)
+    console.error(`ERROR: parseASTIM:`, e)
   }
   const variables: MemberExpression[] = ast ? parseAllVariables(ast) : []
   const variableNames = new Set()

--- a/src/variables/utils/buildVarsOption.ts
+++ b/src/variables/utils/buildVarsOption.ts
@@ -2,7 +2,13 @@
 import {OPTION_NAME} from 'src/variables/constants'
 
 // Types
-import {File, Property, VariableAssignment, Variable} from 'src/types'
+import {
+  File,
+  Statement,
+  Property,
+  VariableAssignment,
+  Variable,
+} from 'src/types'
 
 // Utils
 import {filterUnusedVarsBasedOnQuery} from 'src/shared/utils/filterUnusedVars'
@@ -28,27 +34,33 @@ export const buildUsedVarsOption = (
   return buildVarsOption([...filteredAssignmentVars, ...(windowVars ?? [])])
 }
 
-export const buildVarsOption = (variables: VariableAssignment[]): File => ({
-  type: 'File',
-  package: null,
-  imports: null,
-  body: [
-    {
-      type: 'OptionStatement',
-      assignment: {
-        type: 'VariableAssignment',
-        id: {
-          type: 'Identifier',
-          name: OPTION_NAME,
+export const buildVarsOption = (variables: VariableAssignment[]): File => {
+  const body: Statement[] = !variables.length
+    ? []
+    : [
+        {
+          type: 'OptionStatement',
+          assignment: {
+            type: 'VariableAssignment',
+            id: {
+              type: 'Identifier',
+              name: OPTION_NAME,
+            },
+            init: {
+              type: 'ObjectExpression',
+              properties: variables.filter(v => !!v).map(assignmentToProperty),
+            },
+          },
         },
-        init: {
-          type: 'ObjectExpression',
-          properties: variables.filter(v => !!v).map(assignmentToProperty),
-        },
-      },
-    },
-  ],
-})
+      ]
+
+  return {
+    type: 'File',
+    package: null,
+    imports: null,
+    body,
+  }
+}
 
 const assignmentToProperty = (variable: VariableAssignment): Property => {
   return {

--- a/src/variables/utils/buildVarsOption.ts
+++ b/src/variables/utils/buildVarsOption.ts
@@ -2,13 +2,7 @@
 import {OPTION_NAME} from 'src/variables/constants'
 
 // Types
-import {
-  File,
-  Statement,
-  Property,
-  VariableAssignment,
-  Variable,
-} from 'src/types'
+import {File, Property, VariableAssignment, Variable} from 'src/types'
 
 // Utils
 import {filterUnusedVarsBasedOnQuery} from 'src/shared/utils/filterUnusedVars'
@@ -34,33 +28,27 @@ export const buildUsedVarsOption = (
   return buildVarsOption([...filteredAssignmentVars, ...(windowVars ?? [])])
 }
 
-export const buildVarsOption = (variables: VariableAssignment[]): File => {
-  const body: Statement[] = !variables.length
-    ? []
-    : [
-        {
-          type: 'OptionStatement',
-          assignment: {
-            type: 'VariableAssignment',
-            id: {
-              type: 'Identifier',
-              name: OPTION_NAME,
-            },
-            init: {
-              type: 'ObjectExpression',
-              properties: variables.filter(v => !!v).map(assignmentToProperty),
-            },
-          },
+export const buildVarsOption = (variables: VariableAssignment[]): File => ({
+  type: 'File',
+  package: null,
+  imports: null,
+  body: [
+    {
+      type: 'OptionStatement',
+      assignment: {
+        type: 'VariableAssignment',
+        id: {
+          type: 'Identifier',
+          name: OPTION_NAME,
         },
-      ]
-
-  return {
-    type: 'File',
-    package: null,
-    imports: null,
-    body,
-  }
-}
+        init: {
+          type: 'ObjectExpression',
+          properties: variables.filter(v => !!v).map(assignmentToProperty),
+        },
+      },
+    },
+  ],
+})
 
 const assignmentToProperty = (variable: VariableAssignment): Property => {
   return {


### PR DESCRIPTION
Part of #5062 

## Bug:
* missing variables in dashboard. Intermittent error which correlates with errors in the lsp library utils methods, starting with a stacktrace from the UI `parseASTIM()`.
* root cause is unknown. lsp module fails, which causes all future calls to fail.

## Done here:
* provide more data on why it fails.
* Additional observation, now fixed:
   * ~don't send an empty `option v = {}` as the extern, taking up namespace, when we don't have any variables injected as an extern.~
   * faced objections. did not do.

