### PR TITLE
feat(LoadData): direct go/python/node clicks to onboarding page

### DIFF
--- a/src/writeData/components/ClientLibrarySection.tsx
+++ b/src/writeData/components/ClientLibrarySection.tsx
@@ -63,14 +63,13 @@ const ClientLibrarySection = () => {
           const goto = () => {
             event('Load data client library clicked', {type: item.name})
             if (onBoardingItems.hasOwnProperty(`${item.id}`)) {
-              history.push(
+              return history.push(
                 `/${ORGS}/${org.id}/new-user-setup/${onBoardingItems[item.id]}`
               )
-            } else {
-              history.push(
-                `/${ORGS}/${org.id}/load-data/${CLIENT_LIBS}/${item.id}`
-              )
             }
+            return history.push(
+              `/${ORGS}/${org.id}/load-data/${CLIENT_LIBS}/${item.id}`
+            )
           }
 
           return (

--- a/src/writeData/components/ClientLibrarySection.tsx
+++ b/src/writeData/components/ClientLibrarySection.tsx
@@ -30,15 +30,15 @@ const ClientLibrarySection = () => {
   const org = useSelector(getOrg)
 
   const onBoardingItems = {
-    'python': 'python', 
-    'javascript-node': 'nodejs', 
-    'go': 'golang',
+    python: 'python',
+    'javascript-node': 'nodejs',
+    go: 'golang',
   }
 
   if (!items.length) {
     return null
   }
-  
+
   return (
     <div
       className="write-data--section"
@@ -62,7 +62,7 @@ const ClientLibrarySection = () => {
         {items.map(item => {
           const goto = () => {
             event('Load data client library clicked', {type: item.name})
-            if(onBoardingItems.hasOwnProperty(`${item.id}`)) {
+            if (onBoardingItems.hasOwnProperty(`${item.id}`)) {
               history.push(
                 `/${ORGS}/${org.id}/new-user-setup/${onBoardingItems[item.id]}`
               )

--- a/src/writeData/components/ClientLibrarySection.tsx
+++ b/src/writeData/components/ClientLibrarySection.tsx
@@ -29,10 +29,16 @@ const ClientLibrarySection = () => {
   const history = useHistory()
   const org = useSelector(getOrg)
 
+  const onBoardingItems = {
+    'python': 'python', 
+    'javascript-node': 'nodejs', 
+    'go': 'golang',
+  }
+
   if (!items.length) {
     return null
   }
-
+  
   return (
     <div
       className="write-data--section"
@@ -56,9 +62,15 @@ const ClientLibrarySection = () => {
         {items.map(item => {
           const goto = () => {
             event('Load data client library clicked', {type: item.name})
-            history.push(
-              `/${ORGS}/${org.id}/load-data/${CLIENT_LIBS}/${item.id}`
-            )
+            if(onBoardingItems.hasOwnProperty(`${item.id}`)) {
+              history.push(
+                `/${ORGS}/${org.id}/new-user-setup/${onBoardingItems[item.id]}`
+              )
+            } else {
+              history.push(
+                `/${ORGS}/${org.id}/load-data/${CLIENT_LIBS}/${item.id}`
+              )
+            }
           }
 
           return (


### PR DESCRIPTION
Closes #4903

Navigate users to new onboarding wizards if GO, Python, or Node.js is clicked on the Load Data page.

https://user-images.githubusercontent.com/66275100/179632518-8fb304ea-d4b9-49b9-bc1d-3f23d9d6ae5b.mov


Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
