### PR TITLE
fix(firstMile): render routes as array to fix react warning

### DIFF
--- a/src/shared/containers/SetOrg.tsx
+++ b/src/shared/containers/SetOrg.tsx
@@ -302,25 +302,26 @@ const SetOrg: FC = () => {
             <Route exact path="/orgs/:orgID" component={MePage} />
           )}
 
-          {isFlagEnabled('firstMile') && (
-            <>
-              <Route
-                exact
-                path="/orgs/:orgID/new-user-setup/python"
-                component={PythonWizard}
-              />
-              <Route
-                exact
-                path="/orgs/:orgID/new-user-setup/nodejs"
-                component={NodejsWizard}
-              />
-              <Route
-                exact
-                path="/orgs/:orgID/new-user-setup/golang"
-                component={GoWizard}
-              />
-            </>
-          )}
+          {isFlagEnabled('firstMile') && [
+            <Route
+              exact
+              path="/orgs/:orgID/new-user-setup/python"
+              key="/python"
+              component={PythonWizard}
+            />,
+            <Route
+              exact
+              path="/orgs/:orgID/new-user-setup/nodejs"
+              key="/nodejs"
+              component={NodejsWizard}
+            />,
+            <Route
+              exact
+              path="/orgs/:orgID/new-user-setup/golang"
+              key="/golang"
+              component={GoWizard}
+            />,
+          ]}
 
           <Route component={NotFound} />
         </Switch>


### PR DESCRIPTION
**Issue:** 
Every time I get redirected to one of the onboarding pages (python, go, node), I see a react router warning in the console. 
`React Router Warning: <Route> elements should not change from controlled to uncontrolled (or vice versa)`

The issue was in SetOrg.tsx, when conditionally rendering onboading components, we only wrap routes with fragments `<></>`. 

https://user-images.githubusercontent.com/66275100/179791597-a99d2a9c-8f3b-4219-bb77-f5ee6d23c599.mov



**Fix:** 
According to https://v5.reactrouter.com/web/api/Switch/children-node  `all children of a <Switch> should be <Route> or <Redirect> elements.  `
Alternative solution is to wrap first mile components with additional `Route` and `Switch`. Or just render routes as array, like shown in this pr. 

https://user-images.githubusercontent.com/66275100/179791642-83123fee-ca12-468a-ab6e-64d80a8b061c.mov




Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
