### PR TITLE
feat: add unit tests to quartzOrganizations reducer

### DIFF
--- a/src/identity/quartzOrganizations/mockOrgData.ts
+++ b/src/identity/quartzOrganizations/mockOrgData.ts
@@ -1,0 +1,32 @@
+export const mockOrgData = [
+  {
+    id: '9296169091c64567',
+    name: 'Test Co. 1',
+    isDefault: true,
+    isActive: true,
+  },
+  {
+    id: 'a71ced2b8238902b',
+    name: 'Test Corp. 2',
+    isDefault: false,
+    isActive: false,
+  },
+  {
+    id: 'ac3d3c04b8f1a545',
+    name: 'Test GmbH 3',
+    isDefault: false,
+    isActive: false,
+  },
+  {
+    id: 'fc734484afa0fcac',
+    name: 'Test Inc. 4',
+    isDefault: false,
+    isActive: false,
+  },
+  {
+    id: '62cba0af4760ce02',
+    name: 'Test SA 5',
+    isDefault: false,
+    isActive: false,
+  },
+]

--- a/src/identity/quartzOrganizations/reducers/index.test.ts
+++ b/src/identity/quartzOrganizations/reducers/index.test.ts
@@ -85,17 +85,6 @@ describe('identity reducer for quartz organizations', () => {
 
       expect(oldState).toStrictEqual(newState)
     })
-
-    it('does not require any existing `default` org to set a new default', () => {
-      const mockOrgClone = cloneDeep(mockOrgData)
-      mockOrgClone[0].isDefault = false
-
-      const newOrgId = mockOrgClone[3].id
-      const newState = reducer(oldState, setQuartzDefaultOrg(newOrgId))
-
-      expect(newState.orgs[0].isDefault).toEqual(false)
-      expect(newState.orgs[3].isDefault).toEqual(true)
-    })
   })
 
   describe('sets an appropriate `status` based on whether or not the new default org could be set', () => {
@@ -117,6 +106,20 @@ describe('identity reducer for quartz organizations', () => {
       const newState = reducer(oldState, setQuartzDefaultOrg(newId))
 
       expect(newState.status).toEqual(RemoteDataState.Error)
+    })
+
+    it('sets an `Error` state if there is no existing `default` org', () => {
+      const mockOrgClone = cloneDeep(mockOrgData)
+      mockOrgClone[0].isDefault = false
+
+      const newOrgId = mockOrgClone[3].id
+
+      oldState = reducer(oldState, setQuartzOrganizations(mockOrgClone))
+      const newState = reducer(oldState, setQuartzDefaultOrg(newOrgId))
+
+      expect(newState.status).toEqual(RemoteDataState.Error)
+      expect(newState.orgs[0].isDefault).toEqual(false)
+      expect(newState.orgs[3].isDefault).toEqual(false)
     })
   })
 })

--- a/src/identity/quartzOrganizations/reducers/index.test.ts
+++ b/src/identity/quartzOrganizations/reducers/index.test.ts
@@ -1,0 +1,122 @@
+// Reducer
+import reducer from 'src/identity/quartzOrganizations/reducers'
+import {initialState} from 'src/identity/quartzOrganizations/reducers'
+
+// Actions
+import {
+  setQuartzDefaultOrg,
+  setQuartzOrganizations,
+} from 'src/identity/quartzOrganizations/actions/creators'
+
+// Mocks
+import {mockOrgData} from 'src/identity/quartzOrganizations/mockOrgData'
+
+// Types
+import {RemoteDataState} from 'src/types'
+
+// Utils
+import {cloneDeep} from 'lodash'
+
+describe('identity reducer for quartz organizations', () => {
+  describe('loads orgs into state', () => {
+    it('initializes a default state', () => {
+      const oldState = reducer(
+        undefined,
+        setQuartzOrganizations(initialState.orgs)
+      )
+      expect(oldState.orgs).toStrictEqual(initialState.orgs)
+    })
+
+    it('initializes a state that includes an array of orgs', () => {
+      const oldState = reducer(
+        initialState,
+        setQuartzOrganizations(mockOrgData)
+      )
+
+      expect(oldState.orgs).toStrictEqual(mockOrgData)
+    })
+
+    it('sets a `Done` state when the organization array is loaded into state', () => {
+      const newState = reducer(undefined, setQuartzOrganizations(mockOrgData))
+
+      expect(newState.status).toEqual(RemoteDataState.Done)
+    })
+  })
+
+  describe('changes default orgs', () => {
+    let oldState
+
+    beforeEach(() => {
+      oldState = reducer(initialState, setQuartzOrganizations(mockOrgData))
+    })
+
+    describe('changes which org is the default org', () => {
+      it('sets a new org as the `default` org', () => {
+        const newDefaultOrg = oldState.orgs[1]
+
+        const newState = reducer(
+          oldState,
+          setQuartzDefaultOrg(newDefaultOrg.id)
+        )
+
+        expect(newState.orgs[0].isDefault).toEqual(false)
+        expect(newState.orgs[1].isDefault).toEqual(true)
+      })
+
+      it('sets one - and only one - default org at once', () => {
+        let currentState = oldState
+
+        mockOrgData.forEach(org => {
+          const nextOrgId = org.id
+          currentState = reducer(currentState, setQuartzDefaultOrg(nextOrgId))
+
+          const numDefaultOrgs = currentState.orgs.reduce((acc, org) => {
+            return org.isDefault === true ? acc + 1 : acc
+          }, 0)
+
+          expect(numDefaultOrgs).toEqual(1)
+        })
+      })
+    })
+
+    it('leaves state unchanged if the `new` default org `is` the existing default', () => {
+      const newOrgId = mockOrgData[0].id
+      const newState = reducer(oldState, setQuartzDefaultOrg(newOrgId))
+
+      expect(oldState).toStrictEqual(newState)
+    })
+
+    it('does not require any existing `default` org to set a new default', () => {
+      const mockOrgClone = cloneDeep(mockOrgData)
+      mockOrgClone[0].isDefault = false
+
+      const newOrgId = mockOrgClone[3].id
+      const newState = reducer(oldState, setQuartzDefaultOrg(newOrgId))
+
+      expect(newState.orgs[0].isDefault).toEqual(false)
+      expect(newState.orgs[3].isDefault).toEqual(true)
+    })
+  })
+
+  describe('sets an appropriate `status` based on whether or not the new default org could be set', () => {
+    let oldState
+
+    beforeEach(() => {
+      oldState = reducer(undefined, setQuartzOrganizations(mockOrgData))
+    })
+
+    it('sets a `Done` state if the current default org was updated', () => {
+      const newId = mockOrgData[2].id
+      const newState = reducer(oldState, setQuartzDefaultOrg(newId))
+
+      expect(newState.status).toEqual(RemoteDataState.Done)
+    })
+
+    it('sets an `Error` state if the current default org was `not` updated', () => {
+      const newId = 'fake id'
+      const newState = reducer(oldState, setQuartzDefaultOrg(newId))
+
+      expect(newState.status).toEqual(RemoteDataState.Error)
+    })
+  })
+})

--- a/src/identity/quartzOrganizations/reducers/index.ts
+++ b/src/identity/quartzOrganizations/reducers/index.ts
@@ -12,8 +12,10 @@ import produce from 'immer'
 
 import {OrganizationSummaries} from 'src/client/unityRoutes'
 import {RemoteDataState} from 'src/types'
+
 export const initialState = {
   orgs: [emptyOrg] as OrganizationSummaries,
+  status: RemoteDataState.NotStarted,
 } as QuartzOrganizations
 
 export default (state = initialState, action: Actions): QuartzOrganizations =>

--- a/src/identity/quartzOrganizations/reducers/index.ts
+++ b/src/identity/quartzOrganizations/reducers/index.ts
@@ -34,11 +34,15 @@ export default (state = initialState, action: Actions): QuartzOrganizations =>
       }
 
       case SET_QUARTZ_DEFAULT_ORG: {
-        // No existing default org is acceptable; oldDefaultOrg may be undefined.
         const oldDefaultOrg = draftState.orgs.find(
           org => org.isDefault === true
         )
-        const oldDefaultOrgId = oldDefaultOrg?.id
+        if (oldDefaultOrg === undefined) {
+          draftState.status = RemoteDataState.Error
+          return
+        }
+
+        const oldDefaultOrgId = oldDefaultOrg.id
         const {newDefaultOrgId} = action
 
         if (oldDefaultOrgId === newDefaultOrgId) {


### PR DESCRIPTION
Closes #5136 
Closes #5160

Adds unit test coverage for the quartzOrganizations reducer to check if:

1. Organizations are correctly loaded into state.
2. User can set a new default.
3. `status` of redux state corresponds to whether data was loaded or not.

Also fixes an inconsistency between the reducer and quartz. Quartz doesn't allow an account with orgs to have _no_ default org. That's unexpected, so we should be setting an error in redux state if that happens, and can then use that state for error handling in the UI.