### PR TITLE
fix: improve quartzOrganizations reducer compatibility with quartz

### DIFF
--- a/src/identity/quartzOrganizations/actions/creators/index.ts
+++ b/src/identity/quartzOrganizations/actions/creators/index.ts
@@ -24,12 +24,8 @@ export const setQuartzOrganizationsStatus = (status: RemoteDataState) =>
     status: status,
   } as const)
 
-export const setQuartzDefaultOrg = (
-  oldDefaultOrgId: string,
-  newDefaultOrgId: string
-) =>
+export const setQuartzDefaultOrg = (newDefaultOrgId: string) =>
   ({
     type: SET_QUARTZ_DEFAULT_ORG,
-    oldDefaultOrgId: oldDefaultOrgId,
     newDefaultOrgId: newDefaultOrgId,
   } as const)

--- a/src/identity/quartzOrganizations/actions/thunks/index.ts
+++ b/src/identity/quartzOrganizations/actions/thunks/index.ts
@@ -42,16 +42,16 @@ export const getQuartzOrganizationsThunk = () => async (
   }
 }
 
-export const updateDefaultOrgThunk = (
-  oldDefaultOrg: DefaultOrg,
-  newDefaultOrg: DefaultOrg
-) => async (dispatch: Dispatch<Actions>, getState: GetState) => {
+export const updateDefaultOrgThunk = (newDefaultOrg: DefaultOrg) => async (
+  dispatch: Dispatch<Actions>,
+  getState: GetState
+) => {
   try {
     dispatch(setQuartzOrganizationsStatus(RemoteDataState.Loading))
 
     await updateDefaultQuartzOrg(newDefaultOrg.id)
 
-    dispatch(setQuartzDefaultOrg(oldDefaultOrg.id, newDefaultOrg.id))
+    dispatch(setQuartzDefaultOrg(newDefaultOrg.id))
 
     dispatch(setQuartzOrganizationsStatus(RemoteDataState.Done))
   } catch (err) {

--- a/src/identity/quartzOrganizations/reducers/index.ts
+++ b/src/identity/quartzOrganizations/reducers/index.ts
@@ -60,7 +60,7 @@ export default (state = initialState, action: Actions): QuartzOrganizations =>
 
         if (newIdCount !== 1) {
           throw new OrgValidationError(
-            'Error: Did not find one old and one new default org.'
+            'Error: Failed to identify new default org.'
           )
         }
 


### PR DESCRIPTION
Closes #5103 

This PR resolves two issues with the current `quartzOrganizations` reducer, which is to be used by GlobalHeader.

1. quartz allows for the possibility that there is no current 'default' organization. The reducer needs to not `return state` or `throw Error` in that case.

2. the _current_ default org shouldn't need to be part of the action dispatched to the reducer. The reducer already has that information available to it in the list of organizations. Having this property in the action just leaves room for error.

This fix resolves both issues.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable [YES - MULTIORG]
