### PR TITLE
feat(firstMile): add UI eventing to finish page

### DIFF
--- a/src/homepageExperience/components/steps/Finish.tsx
+++ b/src/homepageExperience/components/steps/Finish.tsx
@@ -103,24 +103,24 @@ export const Finish = (props: OwnProps) => {
           alignItems={AlignItems.Stretch}
           direction={FlexDirection.Row}
         >
-          <ResourceCard
-            className="homepage-wizard-next-steps"
-            onClick={() =>
-              handleNextStepEvent(props.wizardEventName, 'keyConcepts')
-            }
-          >
-            <SafeBlankLink href="https://docs.influxdata.com/influxdb/v2.2/reference/key-concepts/">
+          <ResourceCard className="homepage-wizard-next-steps">
+            <SafeBlankLink
+              href="https://docs.influxdata.com/influxdb/v2.2/reference/key-concepts/"
+              onClick={() =>
+                handleNextStepEvent(props.wizardEventName, 'keyConcepts')
+              }
+            >
               <h4>{BookIcon}Key Concepts</h4>
             </SafeBlankLink>
             <p>Learn about important concepts for writing time-series data.</p>
           </ResourceCard>
-          <ResourceCard
-            className="homepage-wizard-next-steps"
-            onClick={() =>
-              handleNextStepEvent(props.wizardEventName, 'influxUniversity')
-            }
-          >
-            <SafeBlankLink href="https://influxdbu.com/">
+          <ResourceCard className="homepage-wizard-next-steps">
+            <SafeBlankLink
+              href="https://influxdbu.com/"
+              onClick={() =>
+                handleNextStepEvent(props.wizardEventName, 'influxUniversity')
+              }
+            >
               <h4>{CodeTerminalIcon}InfluxDB University</h4>
             </SafeBlankLink>
             <p>

--- a/src/homepageExperience/components/steps/SampleAppCard.tsx
+++ b/src/homepageExperience/components/steps/SampleAppCard.tsx
@@ -57,10 +57,14 @@ const SampleAppCard: FC<Props> = ({wizardEventName, handleNextStepEvent}) => {
       {resources.map(app => (
         <ResourceCard
           className="homepage-wizard-next-steps"
-          onClick={() => handleNextStepEvent(wizardEventName, app.title)}
           key={app.links[wizardEventName]}
         >
-          <SafeBlankLink href={app.links[wizardEventName]}>
+          <SafeBlankLink
+            href={app.links[wizardEventName]}
+            onClick={() =>
+              handleNextStepEvent(wizardEventName, app.title.replace(/ +/g, ''))
+            }
+          >
             <h4>
               {CodeTerminalIcon}
               {app.title}

--- a/src/homepageExperience/components/steps/SampleAppCard.tsx
+++ b/src/homepageExperience/components/steps/SampleAppCard.tsx
@@ -9,6 +9,7 @@ import {
 } from '@influxdata/clockface'
 
 import {SafeBlankLink} from 'src/utils/SafeBlankLink'
+import {normalizeEventName} from 'src/cloud/utils/reporting'
 
 import {CodeTerminalIcon} from 'src/homepageExperience/components/HomepageIcons'
 
@@ -62,7 +63,10 @@ const SampleAppCard: FC<Props> = ({wizardEventName, handleNextStepEvent}) => {
           <SafeBlankLink
             href={app.links[wizardEventName]}
             onClick={() =>
-              handleNextStepEvent(wizardEventName, app.title.replace(/ +/g, ''))
+              handleNextStepEvent(
+                wizardEventName,
+                normalizeEventName(app.title)
+              )
             }
           >
             <h4>


### PR DESCRIPTION
Closes #4995 

Pr removes `onClick` property from `ResourceCard` and adds it to `SafeBlankLink`. 

Background: 
While adding eventing in `SampleAppCards` I noticed events weren't being logged properly. The assumption here was when a resource card is clicked, the `onClick` prop will fire and execute the eventing function `handleNextStepEvent`. This wasn't happening. Looking into the Clockface doc, it turns out `onClick` is a prop of `ResourceCardEditableName` and only fires when the name itself is clicked not edited. 
Clearly, we aren't using `ResourceCardEditableName` component for our purposes, so we need to move the onClick prop into `SafeBlankLink` to be able to capture `onClick` events. 


Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
