### PR TITLE
feat: add execute flux query page to cli wizard

### DIFF
--- a/src/homepageExperience/components/steps/cli/ExecuteQuery.tsx
+++ b/src/homepageExperience/components/steps/cli/ExecuteQuery.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+
+import CodeSnippet from 'src/shared/components/CodeSnippet'
+import {event} from 'src/cloud/utils/reporting'
+import {SafeBlankLink} from 'src/utils/SafeBlankLink'
+
+const logCopyCodeSnippet = () => {
+  event('firstMile.cliWizard.executeQuery.code.copied')
+}
+
+export const ExecuteQuery = () => {
+  const query = `influx query 'from(bucket:"sample-bucket") |> range(start:-10m)' --raw`
+
+  const fluxExample = `from(bucket: “weather-data”)
+  |> range(start: -10m)
+  |> filter(fn: (r) => r._measurement == “temperature”)`
+
+  return (
+    <>
+      <h1>Execute a Flux Query</h1>
+      <p>
+        Now let's query the data we wrote into the database. We use the Flux
+        scripting language to query data.{' '}
+        <SafeBlankLink href="https://docs.influxdata.com/influxdb/v2.2/reference/syntax/flux/">
+          Flux
+        </SafeBlankLink>{' '}
+        is designed for querying, analyzing, and acting on data.
+        <br />
+        <br />
+        Here's an example of a basic Flux script:
+      </p>
+      <CodeSnippet
+        text={fluxExample}
+        showCopyControl={false}
+        language="properties"
+      ></CodeSnippet>
+      <p style={{marginTop: '60px'}}>
+        Let's write a Flux query in the InfluxCLI to read back all of the data
+        you wrote in the previous step. Copy the code snippet below into the
+        InfluxCLI.
+      </p>
+      <CodeSnippet
+        text={query}
+        onCopy={logCopyCodeSnippet}
+        language="properties"
+      />
+    </>
+  )
+}


### PR DESCRIPTION
Closes #4771

Adds the `Execute a Flux Query` page to the CLI onboarding wizard. `Flux` hyperlinks to the docs page on Flux.

Note: The other pages will be added along with the nav wizard in separate PRs

![Screen Shot 2022-07-19 at 3 05 40 PM](https://user-images.githubusercontent.com/106361125/179829772-10897b8f-3400-4ef0-8b62-976dc6d361ff.png)


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
