### PR TITLE
fix: Error handling for pinned items

### DIFF
--- a/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -228,10 +228,15 @@ class DashboardCard extends PureComponent<Props> {
     )
   }
 
-  private handleDeleteDashboard = () => {
+  private handleDeleteDashboard = async () => {
     const {id, name, onDeleteDashboard} = this.props
     onDeleteDashboard(id, name)
-    deletePinnedItemByParam(id)
+    try {
+      await deletePinnedItemByParam(id)
+      this.props.sendNotification(pinnedItemSuccess('task', 'deleted'))
+    } catch (error) {
+      this.props.sendNotification(pinnedItemFailure(error.message, 'delete'))
+    }
   }
 
   private handleClickDashboard = event => {

--- a/src/flows/components/header/MenuButton.tsx
+++ b/src/flows/components/header/MenuButton.tsx
@@ -66,7 +66,7 @@ const MenuButton: FC<Props> = ({handleResetShare}) => {
       event('delete_notebook', {
         context: 'notebook',
       })
-      deletePinnedItemByParam(flow.id)
+      await deletePinnedItemByParam(flow.id)
       await deleteNotebook()
       setLoading(RemoteDataState.Done)
       history.push(`/orgs/${orgID}/${PROJECT_NAME_PLURAL.toLowerCase()}`)

--- a/src/tasks/components/TaskCard.tsx
+++ b/src/tasks/components/TaskCard.tsx
@@ -161,8 +161,8 @@ export class TaskCard extends PureComponent<
     this.props.onDelete(task)
     try {
       await deletePinnedItemByParam(task.id)
-    } catch (err) {
-      this.props.sendNotification(pinnedItemFailure(err.message, 'delete'))
+    } catch (error) {
+      this.props.sendNotification(pinnedItemFailure(error.message, 'delete'))
     }
   }
   private get contextMenu(): JSX.Element {

--- a/src/tasks/components/TaskCard.tsx
+++ b/src/tasks/components/TaskCard.tsx
@@ -157,9 +157,14 @@ export class TaskCard extends PureComponent<
     }
   }
 
-  private handleOnDelete = task => {
+  private handleOnDelete = async (task) => {
     this.props.onDelete(task)
-    deletePinnedItemByParam(task.id)
+    try {
+     await deletePinnedItemByParam(task.id)
+    }
+    catch (err) {
+      this.props.sendNotification(pinnedItemFailure(err.message, 'delete'))
+    }
   }
   private get contextMenu(): JSX.Element {
     const {task, onClone, isPinned} = this.props

--- a/src/tasks/components/TaskCard.tsx
+++ b/src/tasks/components/TaskCard.tsx
@@ -157,12 +157,11 @@ export class TaskCard extends PureComponent<
     }
   }
 
-  private handleOnDelete = async (task) => {
+  private handleOnDelete = async task => {
     this.props.onDelete(task)
     try {
-     await deletePinnedItemByParam(task.id)
-    }
-    catch (err) {
+      await deletePinnedItemByParam(task.id)
+    } catch (err) {
       this.props.sendNotification(pinnedItemFailure(err.message, 'delete'))
     }
   }


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/5110

The `deletePinnedItemByParam` was being called without catching the error it potentially throws, in some places of the app. This caused our tests to flake out. This should fix it. 

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
