### PR TITLE
fix: only add visualization for active query

### DIFF
--- a/src/dataExplorer/components/SaveAsNotebookForm.tsx
+++ b/src/dataExplorer/components/SaveAsNotebookForm.tsx
@@ -41,7 +41,7 @@ interface Props {
 const SaveAsNotebookForm: FC<Props> = ({dismiss}) => {
   const [notebookName, setNotebookName] = useState('')
   const orgID = useSelector(getOrg).id
-  const {draftQueries, autoRefresh, timeRange} = useSelector(
+  const {draftQueries, autoRefresh, timeRange, activeQueryIndex} = useSelector(
     getActiveTimeMachine
   )
   const {properties} = useSelector(getSaveableView)
@@ -73,7 +73,7 @@ const SaveAsNotebookForm: FC<Props> = ({dismiss}) => {
       const pipes: any = []
 
       for (let i = 0; i < draftQueries.length; i++) {
-        const draftQuery = draftQueries[i]
+        const draftQuery = JSON.parse(JSON.stringify(draftQueries[i]))
         let pipe: any = {
           id: `local_${nanoid()}`,
           visible: !draftQuery.hidden,
@@ -99,16 +99,19 @@ const SaveAsNotebookForm: FC<Props> = ({dismiss}) => {
         }
 
         pipes.push(pipe)
-        pipes.push({
-          id: `local_${nanoid()}`,
-          properties: {
-            ...properties,
-            builderConfig: draftQuery.builderConfig,
-          },
-          title: `Visualize the Result ${i + 1}`,
-          type: 'visualization',
-          visible: true,
-        })
+
+        if (i === activeQueryIndex) {
+          pipes.push({
+            id: `local_${nanoid()}`,
+            properties: {
+              ...properties,
+              builderConfig: draftQuery.builderConfig,
+            },
+            title: `Visualize the Result ${i + 1}`,
+            type: 'visualization',
+            visible: true,
+          })
+        }
       }
 
       const flow = hydrate({


### PR DESCRIPTION
this pr addresses some of the product weirdness around exporting notebooks from data explorer that i found while verifying that an EAR was indeed closed. there is one strange artifact from the EAR that i cannot reproduce (though it's totally in the user's data), where the query defined in draftQuery between the two pipes.push references back to back was different. that i can only assume came from a reference error cause by some external mutation so i dropped in a deep clone there to isolate it just in case.