### PR TITLE
chore(usage,operator): fix typo and units

### DIFF
--- a/src/operator/OrgOverlay.tsx
+++ b/src/operator/OrgOverlay.tsx
@@ -120,7 +120,7 @@ const OrgOverlay: FC = () => {
                   <Grid.Row>
                     <h4>Limits</h4>
                     <Grid.Column widthMD={Columns.Four}>
-                      <Form.Label label="Read (KBs)" testID="read-kbs" />
+                      <Form.Label label="Read (KB/s)" testID="read-kbs" />
                       <LimitsField
                         type={InputType.Number}
                         name="rate.readKBs"
@@ -129,7 +129,7 @@ const OrgOverlay: FC = () => {
                       />
                     </Grid.Column>
                     <Grid.Column widthMD={Columns.Four}>
-                      <Form.Label label="Write (KBs)" />
+                      <Form.Label label="Write (KB/s)" />
                       <LimitsField
                         type={InputType.Number}
                         name="rate.writeKBs"

--- a/src/usage/BillingStatsPanel.tsx
+++ b/src/usage/BillingStatsPanel.tsx
@@ -42,7 +42,7 @@ const BillingStatsPanel: FC = () => {
         >
           <h4 className="usage--billing-date-range">
             {billingDate
-              ? `Billing Stats For ${billingDate} to Today`
+              ? `Billing Stats for ${billingDate} to Today`
               : 'Billing Stats'}
           </h4>
         </ReflessPopover>


### PR DESCRIPTION
Closes #

no ticket - capitalization typo and wrong units on the operator page. The rate limit units are _per second_, not _-seconds_. 

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [na] Feature flagged, if applicable
