### PR TITLE
feat(firstMileCLI): add execute aggregate query page

### DIFF
--- a/src/homepageExperience/components/steps/cli/ExecuteAggregateQuery.tsx
+++ b/src/homepageExperience/components/steps/cli/ExecuteAggregateQuery.tsx
@@ -12,13 +12,19 @@ const logDocsOpened = () => {
   event('firstMile.cliWizard.executeAggregateQuery.docs.opened')
 }
 
-export const ExecuteAggregateQuery = () => {
+type OwnProps = {
+  bucket: string
+}
+
+export const ExecuteAggregateQuery = (props: OwnProps) => {
+  const {bucket} = props
+
   const fromBucketSnippet = `from(bucket: "weather-data")
   |> range(start: -10m)
   |> filter(fn: (r) => r.measurement == "temperature")
   |> mean()`
 
-  const codeSnippet = `influx query 'from(bucket:"example-bucket") |> range(start:-10m) |> mean()' --raw`
+  const codeSnippet = `influx query 'from(bucket:"${bucket}") |> range(start:-10m) |> mean()' --raw`
 
   return (
     <>

--- a/src/homepageExperience/components/steps/cli/ExecuteAggregateQuery.tsx
+++ b/src/homepageExperience/components/steps/cli/ExecuteAggregateQuery.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import CodeSnippet from 'src/shared/components/CodeSnippet'
+
+import {SafeBlankLink} from 'src/utils/SafeBlankLink'
+import {event} from 'src/cloud/utils/reporting'
+
+const logCopyCodeSnippet = () => {
+  event('firstMile.cliWizard.executeAggregateQuery.code.copied')
+}
+
+const logDocsOpened = () => {
+  event('firstMile.cliWizard.executeAggregateQuery.docs.opened')
+}
+
+export const ExecuteAggregateQuery = () => {
+  const fromBucketSnippet = `from(bucket: "weather-data")
+  |> range(start: -10m)
+  |> filter(fn: (r) => r.measurement == "temperature")
+  |> mean()`
+
+  const codeSnippet = `influx query 'from(bucket:"example-bucket") |> range(start:-10m) |> mean()' --raw`
+
+  return (
+    <>
+      <h1>Execute a Flux Aggregate Query</h1>
+      <p>
+        An{' '}
+        <SafeBlankLink
+          href="https://docs.influxdata.com/flux/v0.x/function-types/#aggregates"
+          onClick={logDocsOpened}
+        >
+          aggregate
+        </SafeBlankLink>{' '}
+        function is a powerful method for returning combined, summarized data
+        about a set of time-series data.
+      </p>
+      <p>
+        An aggregation is applied after the time range and filters, as seen in
+        the example below.
+      </p>
+      <CodeSnippet
+        text={fromBucketSnippet}
+        showCopyControl={false}
+        onCopy={logCopyCodeSnippet}
+        language="properties"
+      />
+      <p>In the InfluxCLI, run the following:</p>
+      <CodeSnippet
+        text={codeSnippet}
+        onCopy={logCopyCodeSnippet}
+        language="properties"
+      />
+      <p style={{marginTop: '20px'}}>
+        This will return the mean of the insect counts from the census data.
+      </p>
+    </>
+  )
+}


### PR DESCRIPTION
Closes #4772 
Pr adds `Execute a Flux Aggregate Query` step to influx CLI Onboarding. 
Not behind a feature flag currently. Will be behind `onboardCLI` once all components are linked to the homepage. 
![Screen Shot 2022-07-20 at 11 25 53 AM](https://user-images.githubusercontent.com/66275100/180023258-6cd4702a-b395-4b95-bd75-c54d0689317d.png)

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
