### PR TITLE
feat: allow users to select bucket in cli wizard

### DIFF
--- a/src/homepageExperience/components/steps/cli/CliSteps.scss
+++ b/src/homepageExperience/components/steps/cli/CliSteps.scss
@@ -1,0 +1,9 @@
+.small-margins {
+  margin-top: 0px;
+  margin-bottom: 8px;
+}
+
+.large-margins {
+  margin-top: 48px;
+  margin-bottom: 8px;
+}

--- a/src/homepageExperience/components/steps/cli/InitializeClient.tsx
+++ b/src/homepageExperience/components/steps/cli/InitializeClient.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FC, useEffect, useMemo, useContext} from 'react'
+import React, {FC, useContext, useEffect, useMemo} from 'react'
 import {useDispatch, useSelector} from 'react-redux'
 
 // Actions
@@ -19,11 +19,11 @@ import {getBuckets} from 'src/buckets/actions/thunks'
 // Helper Components
 import CodeSnippet from 'src/shared/components/CodeSnippet'
 import {
-  Panel,
+  Columns,
+  ComponentSize,
   Grid,
   InfluxColors,
-  ComponentSize,
-  Columns,
+  Panel,
 } from '@influxdata/clockface'
 import WriteDataHelperBuckets from 'src/writeData/components/WriteDataHelperBuckets'
 import {WriteDataDetailsContext} from 'src/writeData/components/WriteDataDetailsContext'
@@ -35,17 +35,14 @@ import {event} from 'src/cloud/utils/reporting'
 // Types
 import {AppState, Authorization} from 'src/types'
 
+// Styles
+import './CliSteps.scss'
+
 type OwnProps = {
   wizardEventName: string
   setTokenValue: (tokenValue: string) => void
   tokenValue: string
   onSelectBucket: (bucketName: string) => void
-}
-
-// Style
-const inlineStyle = {
-  marginTop: '0px',
-  marginBottom: '8px',
 }
 
 const collator = new Intl.Collator(navigator.language || 'en-US')
@@ -62,7 +59,6 @@ export const InitializeClient: FC<OwnProps> = ({
   const dispatch = useDispatch()
   const url =
     me.quartzMe?.clusterHost || 'https://us-west-2-1.aws.cloud2.influxdata.com/'
-  const orgName = org.name
   const currentAuth = useSelector((state: AppState) => {
     return state.resources.tokens.currentAuth.item
   })
@@ -70,7 +66,7 @@ export const InitializeClient: FC<OwnProps> = ({
 
   const codeSnippet = `influx config create --config-name onboarding 
   --host-url "${url}" 
-  --org "${orgName}" 
+  --org "${org.id}" 
   --token "${token}" 
   --active`
 
@@ -84,11 +80,11 @@ export const InitializeClient: FC<OwnProps> = ({
 
   useEffect(() => {
     dispatch(getBuckets())
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     onSelectBucket(bucket.name)
-  }, [bucket])
+  }, [bucket, onSelectBucket])
 
   useEffect(() => {
     const fetchResources = async () => {
@@ -125,8 +121,8 @@ export const InitializeClient: FC<OwnProps> = ({
   return (
     <>
       <h1>Initialize Client</h1>
-      <h2 style={inlineStyle}>Configure an InfluxDB profile</h2>
-      <p style={inlineStyle}>
+      <h2 className="small-margins">Configure an InfluxDB profile</h2>
+      <p className="small-margins">
         Next we'll need to configure the client and its initial connection to
         InfluxDB.
       </p>
@@ -145,10 +141,8 @@ export const InitializeClient: FC<OwnProps> = ({
         recommend using a token with more specific permissions in the long-term.
         You can edit your tokens anytime from the app.
       </p>
-      <h2 style={{marginTop: '48px', marginBottom: '8px'}}>
-        Select or Create a bucket
-      </h2>
-      <p style={inlineStyle}>
+      <h2 className="large-margins">Select or Create a bucket</h2>
+      <p className="small-margins">
         A <b>bucket</b> is used to store time-series data. Here is a list of
         your existing buckets. You can select one to use for the rest of the
         tutorial, or create one below.
@@ -158,16 +152,13 @@ export const InitializeClient: FC<OwnProps> = ({
           <Grid>
             <Grid.Row>
               <Grid.Column widthSM={Columns.Twelve}>
-                <WriteDataHelperBuckets
-                  useSimplifiedBucketForm={true}
-                  showCreateButton={false}
-                />
+                <WriteDataHelperBuckets useSimplifiedBucketForm={true} />
               </Grid.Column>
             </Grid.Row>
           </Grid>
         </Panel.Body>
       </Panel>
-      <p style={{marginTop: '48px', marginBottom: '8px'}}>
+      <p className="large-margins">
         We can also create a bucket using the InfluxCLI. We'll link the bucket
         to the profile you created.
       </p>

--- a/src/writeData/components/WriteDataHelperBuckets.tsx
+++ b/src/writeData/components/WriteDataHelperBuckets.tsx
@@ -22,11 +22,13 @@ import {
 interface Props {
   className?: string
   useSimplifiedBucketForm?: boolean
+  showCreateButton?: boolean
 }
 
 const WriteDataHelperBuckets: FC<Props> = ({
   className = 'write-data--details-widget-title',
   useSimplifiedBucketForm = false,
+  showCreateButton,
 }) => {
   const {bucket, buckets, changeBucket} = useContext(WriteDataDetailsContext)
   const isSelected = (bucketID: string): boolean => {
@@ -93,10 +95,12 @@ const WriteDataHelperBuckets: FC<Props> = ({
     <>
       <Heading element={HeadingElement.H6} className={className}>
         Bucket
-        <CreateBucketButton
-          useSimplifiedBucketForm={useSimplifiedBucketForm}
-          callbackAfterBucketCreation={changeBucket}
-        />
+        {showCreateButton && (
+          <CreateBucketButton
+            useSimplifiedBucketForm={useSimplifiedBucketForm}
+            callbackAfterBucketCreation={changeBucket}
+          />
+        )}
       </Heading>
       {body}
     </>

--- a/src/writeData/components/WriteDataHelperBuckets.tsx
+++ b/src/writeData/components/WriteDataHelperBuckets.tsx
@@ -22,13 +22,11 @@ import {
 interface Props {
   className?: string
   useSimplifiedBucketForm?: boolean
-  showCreateButton?: boolean
 }
 
 const WriteDataHelperBuckets: FC<Props> = ({
   className = 'write-data--details-widget-title',
   useSimplifiedBucketForm = false,
-  showCreateButton,
 }) => {
   const {bucket, buckets, changeBucket} = useContext(WriteDataDetailsContext)
   const isSelected = (bucketID: string): boolean => {
@@ -95,12 +93,10 @@ const WriteDataHelperBuckets: FC<Props> = ({
     <>
       <Heading element={HeadingElement.H6} className={className}>
         Bucket
-        {showCreateButton && (
-          <CreateBucketButton
-            useSimplifiedBucketForm={useSimplifiedBucketForm}
-            callbackAfterBucketCreation={changeBucket}
-          />
-        )}
+        <CreateBucketButton
+          useSimplifiedBucketForm={useSimplifiedBucketForm}
+          callbackAfterBucketCreation={changeBucket}
+        />
       </Heading>
       {body}
     </>


### PR DESCRIPTION
Since free users have a limited number of free buckets to use, we should give them an option to select an existing bucket in the `Initialize Client` section of the CLI onboarding. If users select a bucket here, it will use that bucket to auto-populate the commands in later steps. If they create a bucket rather than selecting one, the rest of the steps will still show `sample-bucket` in the command. 

Below is a screenshot of the proposed menu and a demo of it updating the commands.

EDIT: Added back the `Create Bucket` button to align with other onboarding flows, updated screenshots below.

Note: more pages need to be added, but they will come in separate PRs!

![Screen Shot 2022-07-21 at 1 12 53 PM](https://user-images.githubusercontent.com/106361125/180275245-5d5890ef-aec4-458d-bd0c-baf4d15e338d.png)
![Screen Shot 2022-07-21 at 1 13 11 PM](https://user-images.githubusercontent.com/106361125/180275252-065f43d6-e001-4a99-b9ba-eef8c5c92539.png)



https://user-images.githubusercontent.com/106361125/180059593-832a13ae-fae9-42be-b3dd-3b5ad080d9f7.mov



### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
