### PR TITLE
feat: install dependencies page for CLI

### DIFF
--- a/src/homepageExperience/components/steps/cli/InstallDependencies.tsx
+++ b/src/homepageExperience/components/steps/cli/InstallDependencies.tsx
@@ -56,8 +56,9 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
   `
 
   type CurrentOSSelection = 'Linux' | 'Mac' | 'Windows'
-  const [currentSelection, setCurrentSelection] = useState<CurrentOSSelection>('Mac')
-
+  const [currentSelection, setCurrentSelection] = useState<CurrentOSSelection>(
+    'Mac'
+  )
 
   return (
     <>
@@ -65,21 +66,33 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
       <ButtonGroup orientation={Orientation.Horizontal}>
         <Button
           text="mac OS"
-          color={currentSelection === 'Mac' ? ComponentColor.Primary : ComponentColor.Default}
+          color={
+            currentSelection === 'Mac'
+              ? ComponentColor.Primary
+              : ComponentColor.Default
+          }
           onClick={() => {
             setCurrentSelection('Mac')
           }}
         />
         <Button
           text="windows"
-          color={currentSelection === 'Windows' ? ComponentColor.Primary : ComponentColor.Default}
+          color={
+            currentSelection === 'Windows'
+              ? ComponentColor.Primary
+              : ComponentColor.Default
+          }
           onClick={() => {
             setCurrentSelection('Windows')
           }}
         />
         <Button
           text="linux"
-          color={currentSelection === 'Linux' ? ComponentColor.Primary : ComponentColor.Default}
+          color={
+            currentSelection === 'Linux'
+              ? ComponentColor.Primary
+              : ComponentColor.Default
+          }
           onClick={() => {
             setCurrentSelection('Linux')
           }}
@@ -100,9 +113,7 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
               documentation.
             </SafeBlankLink>{' '}
           </p>
-          <h2 style={headingWithMargin}>
-            Useful InfluxCLI commands
-          </h2>
+          <h2 style={headingWithMargin}>Useful InfluxCLI commands</h2>
           <p>
             To invoke a command, use the following format in the command line:
           </p>
@@ -145,18 +156,14 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
       )}
       {currentSelection === 'Windows' && (
         <>
-          <h2 style={headingWithMargin}>
-            Download the CLI package
-          </h2>
+          <h2 style={headingWithMargin}>Download the CLI package</h2>
           <p>
             {' '}
             <SafeBlankLink href="https://docs.influxdata.com/influxdb/cloud/tools/influx-cli/?t=Windows">
               Download via our documentation.
             </SafeBlankLink>{' '}
           </p>
-          <h2 style={headingWithMargin}>
-            Expand the downloaded archive
-          </h2>
+          <h2 style={headingWithMargin}>Expand the downloaded archive</h2>
           <p>
             Expand the downloaded archive into C:\Program Files\InfluxData\ and
             rename it if desired
@@ -166,15 +173,11 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
             onCopy={logCopyCodeSnippetWindows}
             language="properties"
           />
-          <h2 style={headingWithMargin}>
-            Grant network access (optional)
-          </h2>
+          <h2 style={headingWithMargin}>Grant network access (optional)</h2>
           <p>To grant the InfluxCLI the required access, do the following:</p>
           <p>1. Select Private networks, such as my home or work network </p>
           <p>2. Click Allow access</p>
-          <h2 style={headingWithMargin}>
-            Useful InfluxCLI commands
-          </h2>
+          <h2 style={headingWithMargin}>Useful InfluxCLI commands</h2>
           <p>
             To invoke a command, use the following format in the command line:
           </p>
@@ -217,9 +220,7 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
       )}
       {currentSelection === 'Linux' && (
         <>
-          <h2 style={headingWithMargin}>
-            Download from the command line
-          </h2>
+          <h2 style={headingWithMargin}>Download from the command line</h2>
           <CodeSnippet
             text={linuxCodeSnippetA}
             onCopy={logCopyCodeSnippetLinux}
@@ -232,9 +233,7 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
               documentation.
             </SafeBlankLink>{' '}
           </p>
-          <h2 style={headingWithMargin}>
-            Unpackage the downloaded package
-          </h2>
+          <h2 style={headingWithMargin}>Unpackage the downloaded package</h2>
           <p>
             Install the downloaded InfluxDB client package. Adjust filenames,
             paths, and utilities as needed.
@@ -256,9 +255,7 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
             onCopy={logCopyCodeSnippetLinux}
             language="properties"
           />
-          <h2 style={headingWithMargin}>
-            Useful InfluxCLI commands
-          </h2>
+          <h2 style={headingWithMargin}>Useful InfluxCLI commands</h2>
           <p>
             To invoke a command, use the following format in the command line:
           </p>

--- a/src/homepageExperience/components/steps/cli/InstallDependencies.tsx
+++ b/src/homepageExperience/components/steps/cli/InstallDependencies.tsx
@@ -1,0 +1,312 @@
+import CodeSnippet from 'src/shared/components/CodeSnippet'
+import {SafeBlankLink} from 'src/utils/SafeBlankLink'
+import {
+  ComponentColor,
+  Button,
+  ButtonGroup,
+  Orientation,
+  Table,
+  BorderType,
+} from '@influxdata/clockface'
+
+import React, {useEffect, useState} from 'react'
+import {useDispatch} from 'react-redux'
+import {getBuckets} from 'src/buckets/actions/thunks'
+import {event} from 'src/cloud/utils/reporting'
+
+export const InstallDependencies = () => {
+  const dispatch = useDispatch()
+
+  useEffect(() => {
+    dispatch(getBuckets())
+  }, [])
+
+  const logCopyCodeSnippetMac = () => {
+    event('firstMile.cliWizard.installDependenciesMac.code.copied')
+  }
+  const logCopyCodeSnippetWindows = () => {
+    event('firstMile.cliWizard.installDependenciesWindows.code.copied')
+  }
+  const logCopyCodeSnippetLinux = () => {
+    event('firstMile.cliWizard.installDependenciesLinux.code.copied')
+  }
+
+  const windowsCodeSnippet =
+    "> Expand-Archive .\\influxdb2-client-latest-amd64.zip -DestinationPath 'C:\\Program Files\\InfluxData\\'\n" +
+    "> mv 'C:\\Program Files\\InfluxData\\influxdb2-client-latest-windows-amd64' 'C:\\Program Files\\InfluxData\\influx'"
+  const linuxCodeSnippetA = `# amd64
+wget https://dl.influxdata.com/influxdb/releases/influxdb2-client-latest-linux-amd64.tar.gz
+  
+# arm
+wget https://dl.influxdata.com/influxdb/releases/influxdb2-client-latest-linux-arm64.tar.gz
+  `
+  const linuxCodeSnippetB = `# amd64
+tar xvzf path/to/influxdb2-client-latest-linux-amd64.tar.gz
+  
+# arm
+tar xvzf path/to/influxdb2-client-latest-linux-arm64.tar.gz
+  `
+  const linuxCodeSnippetC = `# amd64
+sudo cp influxdb2-client-latest-linux-amd64/influx /usr/local/bin/
+            
+# arm
+sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
+  `
+
+  const [macSelected, setMacSelected] = useState(true)
+  const [windowsSelected, setWindowsSelected] = useState(false)
+  const [linuxSelected, setLinuxSelected] = useState(false)
+
+  return (
+    <>
+      <h1>Install Dependencies</h1>
+      <ButtonGroup orientation={Orientation.Horizontal}>
+        <Button
+          text="mac OS"
+          color={macSelected ? ComponentColor.Primary : ComponentColor.Default}
+          onClick={() => {
+            setMacSelected(true)
+            setWindowsSelected(false)
+            setLinuxSelected(false)
+          }}
+        />
+        <Button
+          text="windows"
+          color={
+            windowsSelected ? ComponentColor.Primary : ComponentColor.Default
+          }
+          onClick={() => {
+            setMacSelected(false)
+            setWindowsSelected(true)
+            setLinuxSelected(false)
+          }}
+        />
+        <Button
+          text="linux"
+          color={
+            linuxSelected ? ComponentColor.Primary : ComponentColor.Default
+          }
+          onClick={() => {
+            setMacSelected(false)
+            setWindowsSelected(false)
+            setLinuxSelected(true)
+          }}
+        />
+      </ButtonGroup>
+      {macSelected && (
+        <>
+          <h2 style={{marginTop: '48px', marginBottom: '0px'}}>Use Homebrew</h2>
+          <CodeSnippet
+            text="brew install influxdb-cli"
+            onCopy={logCopyCodeSnippetMac}
+            language="properties"
+          />
+          <p>
+            If you prefer to manually download and install the CLI package,
+            follow our{' '}
+            <SafeBlankLink href="https://docs.influxdata.com/influxdb/cloud/tools/influx-cli/">
+              documentation.
+            </SafeBlankLink>{' '}
+          </p>
+          <h2 style={{marginTop: '48px', marginBottom: '0px'}}>
+            Useful InfluxCLI commands
+          </h2>
+          <p>
+            To invoke a command, use the following format in the command line:
+          </p>
+          <p style={{marginLeft: '40px'}}>influx [command]</p>
+          <Table borders={BorderType.All}>
+            <Table.Body>
+              <Table.Row>
+                <Table.Cell>bucket</Table.Cell>
+                <Table.Cell>Bucket management commands</Table.Cell>
+              </Table.Row>
+              <Table.Row>
+                <Table.Cell>export</Table.Cell>
+                <Table.Cell>Export resources as a template</Table.Cell>
+              </Table.Row>
+              <Table.Row>
+                <Table.Cell>help</Table.Cell>
+                <Table.Cell>List all commands</Table.Cell>
+              </Table.Row>
+              <Table.Row>
+                <Table.Cell>help [command]</Table.Cell>
+                <Table.Cell>Get help with an individual command</Table.Cell>
+              </Table.Row>
+              <Table.Row>
+                <Table.Cell>query</Table.Cell>
+                <Table.Cell>Execute a Flux query</Table.Cell>
+              </Table.Row>
+              <Table.Row>
+                <Table.Cell>write</Table.Cell>
+                <Table.Cell>Write points to InfluxDB</Table.Cell>
+              </Table.Row>
+            </Table.Body>
+          </Table>
+          <p>
+            Full list of commands is available in our{' '}
+            <SafeBlankLink href="https://docs.influxdata.com/influxdb/cloud/reference/cli/influx/">
+              documentation.
+            </SafeBlankLink>{' '}
+          </p>
+        </>
+      )}
+      {windowsSelected && (
+        <>
+          <h2 style={{marginTop: '48px', marginBottom: '0px'}}>
+            Download the CLI package
+          </h2>
+          <p>
+            {' '}
+            <SafeBlankLink href="https://docs.influxdata.com/influxdb/cloud/tools/influx-cli/?t=Windows">
+              Download via our documentation.
+            </SafeBlankLink>{' '}
+          </p>
+          <h2 style={{marginTop: '48px', marginBottom: '0px'}}>
+            Expand the downloaded archive
+          </h2>
+          <p>
+            Expand the downloaded archive into C:\Program Files\InfluxData\ and
+            rename it if desired
+          </p>
+          <CodeSnippet
+            text={windowsCodeSnippet}
+            onCopy={logCopyCodeSnippetWindows}
+            language="properties"
+          />
+          <h2 style={{marginTop: '48px', marginBottom: '0px'}}>
+            Grant network access (optional)
+          </h2>
+          <p>To grant the InfluxCLI the required access, do the following:</p>
+          <p>1. Select Private networks, such as my home or work network </p>
+          <p>2. Click Allow access</p>
+          <h2 style={{marginTop: '48px', marginBottom: '0px'}}>
+            Useful InfluxCLI commands
+          </h2>
+          <p>
+            To invoke a command, use the following format in the command line:
+          </p>
+          <p style={{marginLeft: '40px'}}>influx [command]</p>
+          <Table borders={BorderType.All}>
+            <Table.Body>
+              <Table.Row>
+                <Table.Cell>bucket</Table.Cell>
+                <Table.Cell>Bucket management commands</Table.Cell>
+              </Table.Row>
+              <Table.Row>
+                <Table.Cell>export</Table.Cell>
+                <Table.Cell>Export resources as a template</Table.Cell>
+              </Table.Row>
+              <Table.Row>
+                <Table.Cell>help</Table.Cell>
+                <Table.Cell>List all commands</Table.Cell>
+              </Table.Row>
+              <Table.Row>
+                <Table.Cell>help [command]</Table.Cell>
+                <Table.Cell>Get help with an individual command</Table.Cell>
+              </Table.Row>
+              <Table.Row>
+                <Table.Cell>query</Table.Cell>
+                <Table.Cell>Execute a Flux query</Table.Cell>
+              </Table.Row>
+              <Table.Row>
+                <Table.Cell>write</Table.Cell>
+                <Table.Cell>Write points to InfluxDB</Table.Cell>
+              </Table.Row>
+            </Table.Body>
+          </Table>
+          <p>
+            Full list of commands is available in our{' '}
+            <SafeBlankLink href="https://docs.influxdata.com/influxdb/cloud/reference/cli/influx/">
+              documentation.
+            </SafeBlankLink>{' '}
+          </p>
+        </>
+      )}
+      {linuxSelected && (
+        <>
+          <h2 style={{marginTop: '48px', marginBottom: '0px'}}>
+            Download from the command line
+          </h2>
+          <CodeSnippet
+            text={linuxCodeSnippetA}
+            onCopy={logCopyCodeSnippetLinux}
+            language="properties"
+          />
+          <p>
+            If you prefer to manually download and install the CLI package,
+            follow our{' '}
+            <SafeBlankLink href="https://docs.influxdata.com/influxdb/cloud/tools/influx-cli/?t=Linux">
+              documentation.
+            </SafeBlankLink>{' '}
+          </p>
+          <h2 style={{marginTop: '48px', marginBottom: '0px'}}>
+            Unpackage the downloaded package
+          </h2>
+          <p>
+            Install the downloaded InfluxDB client package. Adjust filenames,
+            paths, and utilities as needed.
+          </p>
+          <CodeSnippet
+            text={linuxCodeSnippetB}
+            onCopy={logCopyCodeSnippetLinux}
+            language="properties"
+          />
+          <h2 style={{marginTop: '48px', marginBottom: '0px'}}>
+            Place the executable in your $PATH (optional)
+          </h2>
+          <p>
+            If you do not move the influx binary into your $PATH, prefix the
+            executable ./ to run it in place.
+          </p>
+          <CodeSnippet
+            text={linuxCodeSnippetC}
+            onCopy={logCopyCodeSnippetLinux}
+            language="properties"
+          />
+          <h2 style={{marginTop: '48px', marginBottom: '0px'}}>
+            Useful InfluxCLI commands
+          </h2>
+          <p>
+            To invoke a command, use the following format in the command line:
+          </p>
+          <p style={{marginLeft: '40px'}}>influx [command]</p>
+          <Table borders={BorderType.All}>
+            <Table.Body>
+              <Table.Row>
+                <Table.Cell>bucket</Table.Cell>
+                <Table.Cell>Bucket management commands</Table.Cell>
+              </Table.Row>
+              <Table.Row>
+                <Table.Cell>export</Table.Cell>
+                <Table.Cell>Export resources as a template</Table.Cell>
+              </Table.Row>
+              <Table.Row>
+                <Table.Cell>help</Table.Cell>
+                <Table.Cell>List all commands</Table.Cell>
+              </Table.Row>
+              <Table.Row>
+                <Table.Cell>help [command]</Table.Cell>
+                <Table.Cell>Get help with an individual command</Table.Cell>
+              </Table.Row>
+              <Table.Row>
+                <Table.Cell>query</Table.Cell>
+                <Table.Cell>Execute a Flux query</Table.Cell>
+              </Table.Row>
+              <Table.Row>
+                <Table.Cell>write</Table.Cell>
+                <Table.Cell>Write points to InfluxDB</Table.Cell>
+              </Table.Row>
+            </Table.Body>
+          </Table>
+          <p>
+            Full list of commands is available in our{' '}
+            <SafeBlankLink href="https://docs.influxdata.com/influxdb/cloud/reference/cli/influx/">
+              documentation.
+            </SafeBlankLink>{' '}
+          </p>
+        </>
+      )}
+    </>
+  )
+}

--- a/src/homepageExperience/components/steps/cli/InstallDependencies.tsx
+++ b/src/homepageExperience/components/steps/cli/InstallDependencies.tsx
@@ -55,10 +55,6 @@ sudo cp influxdb2-client-latest-linux-amd64/influx /usr/local/bin/
 sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
   `
 
-  const [macSelected, setMacSelected] = useState(true)
-  const [windowsSelected, setWindowsSelected] = useState(false)
-  const [linuxSelected, setLinuxSelected] = useState(false)
-
   type CurrentOSSelection = 'Linux' | 'Mac' | 'Windows'
   const [currentSelection, setCurrentSelection] = useState<CurrentOSSelection>('Mac')
 

--- a/src/homepageExperience/components/steps/cli/InstallDependencies.tsx
+++ b/src/homepageExperience/components/steps/cli/InstallDependencies.tsx
@@ -9,17 +9,19 @@ import {
   BorderType,
 } from '@influxdata/clockface'
 
-import React, {useEffect, useState} from 'react'
+import React, {FC, useEffect, useState} from 'react'
 import {useDispatch} from 'react-redux'
 import {getBuckets} from 'src/buckets/actions/thunks'
 import {event} from 'src/cloud/utils/reporting'
 
-export const InstallDependencies = () => {
+export const InstallDependencies: FC = () => {
   const dispatch = useDispatch()
 
   useEffect(() => {
     dispatch(getBuckets())
   }, [])
+
+  const headingWithMargin = {marginTop: '48px', marginBottom: '0px'}
 
   const logCopyCodeSnippetMac = () => {
     event('firstMile.cliWizard.installDependenciesMac.code.copied')
@@ -57,45 +59,39 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
   const [windowsSelected, setWindowsSelected] = useState(false)
   const [linuxSelected, setLinuxSelected] = useState(false)
 
+  type CurrentOSSelection = 'Linux' | 'Mac' | 'Windows'
+  const [currentSelection, setCurrentSelection] = useState<CurrentOSSelection>('Mac')
+
+
   return (
     <>
       <h1>Install Dependencies</h1>
       <ButtonGroup orientation={Orientation.Horizontal}>
         <Button
           text="mac OS"
-          color={macSelected ? ComponentColor.Primary : ComponentColor.Default}
+          color={currentSelection === 'Mac' ? ComponentColor.Primary : ComponentColor.Default}
           onClick={() => {
-            setMacSelected(true)
-            setWindowsSelected(false)
-            setLinuxSelected(false)
+            setCurrentSelection('Mac')
           }}
         />
         <Button
           text="windows"
-          color={
-            windowsSelected ? ComponentColor.Primary : ComponentColor.Default
-          }
+          color={currentSelection === 'Windows' ? ComponentColor.Primary : ComponentColor.Default}
           onClick={() => {
-            setMacSelected(false)
-            setWindowsSelected(true)
-            setLinuxSelected(false)
+            setCurrentSelection('Windows')
           }}
         />
         <Button
           text="linux"
-          color={
-            linuxSelected ? ComponentColor.Primary : ComponentColor.Default
-          }
+          color={currentSelection === 'Linux' ? ComponentColor.Primary : ComponentColor.Default}
           onClick={() => {
-            setMacSelected(false)
-            setWindowsSelected(false)
-            setLinuxSelected(true)
+            setCurrentSelection('Linux')
           }}
         />
       </ButtonGroup>
-      {macSelected && (
+      {currentSelection === 'Mac' && (
         <>
-          <h2 style={{marginTop: '48px', marginBottom: '0px'}}>Use Homebrew</h2>
+          <h2 style={headingWithMargin}>Use Homebrew</h2>
           <CodeSnippet
             text="brew install influxdb-cli"
             onCopy={logCopyCodeSnippetMac}
@@ -108,7 +104,7 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
               documentation.
             </SafeBlankLink>{' '}
           </p>
-          <h2 style={{marginTop: '48px', marginBottom: '0px'}}>
+          <h2 style={headingWithMargin}>
             Useful InfluxCLI commands
           </h2>
           <p>
@@ -151,9 +147,9 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
           </p>
         </>
       )}
-      {windowsSelected && (
+      {currentSelection === 'Windows' && (
         <>
-          <h2 style={{marginTop: '48px', marginBottom: '0px'}}>
+          <h2 style={headingWithMargin}>
             Download the CLI package
           </h2>
           <p>
@@ -162,7 +158,7 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
               Download via our documentation.
             </SafeBlankLink>{' '}
           </p>
-          <h2 style={{marginTop: '48px', marginBottom: '0px'}}>
+          <h2 style={headingWithMargin}>
             Expand the downloaded archive
           </h2>
           <p>
@@ -174,13 +170,13 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
             onCopy={logCopyCodeSnippetWindows}
             language="properties"
           />
-          <h2 style={{marginTop: '48px', marginBottom: '0px'}}>
+          <h2 style={headingWithMargin}>
             Grant network access (optional)
           </h2>
           <p>To grant the InfluxCLI the required access, do the following:</p>
           <p>1. Select Private networks, such as my home or work network </p>
           <p>2. Click Allow access</p>
-          <h2 style={{marginTop: '48px', marginBottom: '0px'}}>
+          <h2 style={headingWithMargin}>
             Useful InfluxCLI commands
           </h2>
           <p>
@@ -223,9 +219,9 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
           </p>
         </>
       )}
-      {linuxSelected && (
+      {currentSelection === 'Linux' && (
         <>
-          <h2 style={{marginTop: '48px', marginBottom: '0px'}}>
+          <h2 style={headingWithMargin}>
             Download from the command line
           </h2>
           <CodeSnippet
@@ -240,7 +236,7 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
               documentation.
             </SafeBlankLink>{' '}
           </p>
-          <h2 style={{marginTop: '48px', marginBottom: '0px'}}>
+          <h2 style={headingWithMargin}>
             Unpackage the downloaded package
           </h2>
           <p>
@@ -252,7 +248,7 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
             onCopy={logCopyCodeSnippetLinux}
             language="properties"
           />
-          <h2 style={{marginTop: '48px', marginBottom: '0px'}}>
+          <h2 style={headingWithMargin}>
             Place the executable in your $PATH (optional)
           </h2>
           <p>
@@ -264,7 +260,7 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
             onCopy={logCopyCodeSnippetLinux}
             language="properties"
           />
-          <h2 style={{marginTop: '48px', marginBottom: '0px'}}>
+          <h2 style={headingWithMargin}>
             Useful InfluxCLI commands
           </h2>
           <p>


### PR DESCRIPTION
Closes #4765, #4766, #4767

Adds the install dependencies page on the new CLI walkthrough.

### Checklist

Authors and Reviewer(s), please verify the following:

- [ ] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [ ] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
