### PR TITLE
refactor: don't use parse to check for valid query

### DIFF
--- a/src/flows/pipes/Visualization/index.ts
+++ b/src/flows/pipes/Visualization/index.ts
@@ -12,12 +12,8 @@ export default register => {
     initial: {
       properties: SUPPORTED_VISUALIZATIONS['xy'].initial,
     },
-    visual: (data, query) => {
+    visual: (data, query: String) => {
       if (!query) {
-        return ''
-      }
-
-      if (query.length === 0) {
         return ''
       }
 

--- a/src/flows/pipes/Visualization/index.ts
+++ b/src/flows/pipes/Visualization/index.ts
@@ -1,8 +1,5 @@
 import View from './view'
 import './style.scss'
-import {parse} from '@influxdata/flux-lsp-browser'
-import {parseQuery} from 'src/shared/contexts/query'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 import {SUPPORTED_VISUALIZATIONS} from 'src/visualization'
 

--- a/src/flows/pipes/Visualization/index.ts
+++ b/src/flows/pipes/Visualization/index.ts
@@ -12,7 +12,7 @@ export default register => {
     initial: {
       properties: SUPPORTED_VISUALIZATIONS['xy'].initial,
     },
-    visual: (data, query: String) => {
+    visual: (data, query: string) => {
       if (!query) {
         return ''
       }

--- a/src/flows/pipes/Visualization/index.ts
+++ b/src/flows/pipes/Visualization/index.ts
@@ -20,14 +20,7 @@ export default register => {
         return ''
       }
 
-      try {
-        const ast = isFlagEnabled('fastFlows')
-          ? parseQuery(query)
-          : parse(query)
-        if (!ast.body.length) {
-          return ''
-        }
-      } catch {
+      if (query.length === 0) {
         return ''
       }
 


### PR DESCRIPTION
This patch removes the use of `parse` from `flux-lsp` as a way to
determine if the query is valid. Instead, it opts for checking to see if
its length is zero. The issue with using `parse` here is that there is
no validity check; the queries `a = 0`, `b =` and `from(bucket: ` will
all return an ast with a non-zero body length.