### PR TITLE
chore: remove feature flag hydrateRelevantDashboardVariables

### DIFF
--- a/src/variables/actions/thunks.ts
+++ b/src/variables/actions/thunks.ts
@@ -33,7 +33,6 @@ import {getOrg} from 'src/organizations/selectors'
 import {getLabels, getStatus} from 'src/resources/selectors'
 import {currentContext} from 'src/shared/selectors/currentContext'
 import {event} from 'src/cloud/utils/reporting'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Constants
 import * as copy from 'src/shared/copy/notifications'
@@ -166,10 +165,7 @@ export const hydrateVariables = (
   let usedVars = vars
   if (views.length) {
     usedVars = filterUnusedVars(vars, views)
-  } else if (
-    isFlagEnabled('hydrateRelevantDashboardVariables') &&
-    activeQuery.text
-  ) {
+  } else if (activeQuery.text) {
     usedVars = filterUnusedVarsBasedOnQuery(vars, [activeQuery.text])
   }
 


### PR DESCRIPTION
Closes #5092

Removes the flag `hydrateRelevantDashboardVariables` which has been on in production for months. This flag made it so that only variables used by the dashboard being loaded were hydrated, rather than all variables in an organization.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- ~[ ] Feature flagged, if applicable~
