### PR TITLE
feat: add orgname to salesforce requests. futureproof for quartzident…

### DIFF
--- a/src/support/components/PayGSupportOverlay.tsx
+++ b/src/support/components/PayGSupportOverlay.tsx
@@ -127,7 +127,7 @@ const PayGSupportOverlay: FC<OwnProps> = () => {
       event(
         'helpBar.paygSupportRequest.submitted',
         {},
-        {userID: userID, orgName: orgName, orgID: orgID}
+        {userID, orgName, orgID}
       )
       dispatch(
         showOverlay('help-bar-confirmation', {type: 'PAYG'}, () =>
@@ -136,11 +136,7 @@ const PayGSupportOverlay: FC<OwnProps> = () => {
       )
     } catch {
       dispatch(notify(supportRequestError()))
-      event(
-        'helpBar.paygSupportRequest.failed',
-        {},
-        {userID: userID, orgID: orgID}
-      )
+      event('helpBar.paygSupportRequest.failed', {}, {userID, orgID})
     }
   }
 

--- a/src/support/components/PayGSupportOverlay.tsx
+++ b/src/support/components/PayGSupportOverlay.tsx
@@ -115,7 +115,7 @@ const PayGSupportOverlay: FC<OwnProps> = () => {
       orgID = quartzOrg?.id
     }
 
-    const descriptionWithOrgId = `[Org Name: ${orgName}] [Org Id: ${orgID}] \n\n ${description}`
+    const descriptionWithOrgId = `${description} \n\n [Org Name: ${orgName}] [Org Id: ${orgID}]`
     const translatedSeverity = translateSeverityLevelForSfdc(severity)
     try {
       await createSfdcSupportCase(


### PR DESCRIPTION
Closes #4585 

EDIT: Adjusted in response to @hoorayimhelping comments so that we're appending, not prepending, the `orgName` and `orgId`. 

Product requests that Help bar's SFDC ticket creation logic send the user's currently selected `orgName` and `orgId` to salesforce. 

This PR passes the user's `orgName` and `orgId` to salesforce as part of the description through `createSfdcSupportCase`. Related tweaks/inline refactors:

1. Pull `orgName` and `orgID` from quartz, not IDPE, since the IDPE endpoints are being deprecated. This is safe because this component is exclusively `CLOUD`.
2. Check feature flag status to decide whether to pull the data from `quartzMe` or `quartzIdentity`.

New format for the description portion of the ticket looks like this (edited - now appending org data at end):
![Screen Shot 2022-07-22 at 11 15 04 AM](https://user-images.githubusercontent.com/91283923/180471516-6873c68f-b66a-4b7a-880c-104b94ac4318.png)


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed). N / A
- [x] Feature flagged, if applicable  YES - `quartzIdentity` decides whether to pull user data from `/quartz/me` or `/quartz/identity`
