### PR TITLE
fix: use correct dependencies to set page for SimpleTable

### DIFF
--- a/src/visualization/context/pagination.tsx
+++ b/src/visualization/context/pagination.tsx
@@ -59,7 +59,7 @@ export const PaginationProvider: FC<PaginationProviderProps> = ({
     } else {
       setOffset(offset + size)
     }
-  }, [offset, size, setOffset]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [offset, size, setOffset, total])
 
   const previous = useCallback(() => {
     setOffset(calcPrevPageOffset(offset, size))
@@ -69,7 +69,7 @@ export const PaginationProvider: FC<PaginationProviderProps> = ({
     (page: number) => {
       setOffset(calcOffset(page, maxSize, total))
     },
-    [offset, maxSize, setOffset] // eslint-disable-line react-hooks/exhaustive-deps
+    [maxSize, setOffset, total]
   )
 
   return (


### PR DESCRIPTION
Part of https://github.com/influxdata/giraffe/issues/781

This bug was demonstrated with Giraffe code, but it is the same code in UI's implementation of the `PaginationProvider` of SimpleTable. It's easier to reproduce in Giraffe than with the full UI and InfluxDB.

- Fixes the `PaginationProvider` by running the `useCallback` correctly when the page `total` changes, as can be the case going from one set of results to a different set of results.
- This fix will be implemented in Giraffe also.


Here is a demo of it working by going between an empty result set (no csv) and a valid result set:


https://user-images.githubusercontent.com/10736577/180324355-59bde922-e878-4c8b-9f86-c3d175456a00.mp4


