### PR TITLE
fix: use optional chaining and fix dependency array for SimpleTable

### DIFF
--- a/src/visualization/types/SimpleTable/PagedTable.tsx
+++ b/src/visualization/types/SimpleTable/PagedTable.tsx
@@ -43,7 +43,7 @@ const measurePage = (
   let signature
 
   while (rowIdx < result.table.length) {
-    if (result.table.columns.table.data[rowIdx] !== currentTable) {
+    if (result.table.columns?.table?.data?.[rowIdx] !== currentTable) {
       signature = Object.values(result.table.columns)
         .map(
           c =>
@@ -110,26 +110,28 @@ const subsetResult = (
     }, {})
 
   const tables: SubsetTable[] = []
-  let lastTable
+  let lastTable = ''
 
   // group by table id (series)
   for (let ni = 0; ni < size; ni++) {
     if (
-      `y${subset['result'][0].data[ni]}:t${subset['table'][0].data[ni]}` ===
+      `y${subset['result']?.[0]?.data?.[ni]}:t${subset['table']?.[0]?.data?.[ni]}` ===
       lastTable
     ) {
       continue
     }
 
-    lastTable = `y${subset['result'][0].data[ni]}:t${subset['table'][0].data[ni]}`
+    if (subset['result']?.[0]?.data?.[ni] && subset['table']?.[0]?.data?.[ni]) {
+      lastTable = `y${subset['result'][0].data[ni]}:t${subset['table'][0].data[ni]}`
+    }
 
     if (tables.length) {
       tables[tables.length - 1].end = ni
     }
 
     tables.push({
-      idx: subset['table'][0].data[ni],
-      yield: subset['result'][0].data[ni],
+      idx: subset['table']?.[0]?.data?.[ni] ?? -1,
+      yield: subset['result']?.[0]?.data?.[ni] ?? '',
       cols: [],
       signature: '',
       start: ni,
@@ -269,7 +271,7 @@ const PagedTable: FC<Props> = ({result, properties}) => {
         clearTimeout(timeout)
       }
     }
-  }, [ref?.current])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const size = useMemo(() => {
     return measurePage(result, offset, height)

--- a/src/visualization/types/SimpleTable/PagedTable.tsx
+++ b/src/visualization/types/SimpleTable/PagedTable.tsx
@@ -67,7 +67,7 @@ const measurePage = (
         lastSignature = signature
       }
 
-      currentTable = result.table.columns.table.data[rowIdx]
+      currentTable = result.table.columns?.table?.data?.[rowIdx]
 
       continue
     }


### PR DESCRIPTION
Part of https://github.com/influxdata/giraffe/issues/781

- Use optional chaining in a few places to prevent a console error when the results are an empty data set (blank csv)
- Remove `ref.current` as a dependency because `ref` is mutable and has no effect on the hook, see https://stackoverflow.com/questions/60476155/is-it-safe-to-use-ref-current-as-useeffects-dependency-when-ref-points-to-a-dom

NOTE: the above fixes will be implemented in Giraffe also.