### PR TITLE
fix: make it a page instead of a div with custom styling

### DIFF
--- a/src/dashboards/components/EditVEO.tsx
+++ b/src/dashboards/components/EditVEO.tsx
@@ -5,7 +5,12 @@ import {useSelector, useDispatch} from 'react-redux'
 import {get} from 'lodash'
 
 // Components
-import {Overlay, SpinnerContainer, TechnoSpinner} from '@influxdata/clockface'
+import {
+  Overlay,
+  Page,
+  SpinnerContainer,
+  TechnoSpinner,
+} from '@influxdata/clockface'
 import TimeMachine from 'src/timeMachine/components/TimeMachine'
 import VEOHeader from 'src/dashboards/components/VEOHeader'
 
@@ -63,7 +68,7 @@ const EditViewVEO: FC = () => {
 
   if (isFlagEnabled('openCellPage')) {
     return (
-      <div className="veo">
+      <Page>
         <SpinnerContainer
           spinnerComponent={<TechnoSpinner />}
           loading={view.status}
@@ -79,7 +84,7 @@ const EditViewVEO: FC = () => {
             <TimeMachine />
           </div>
         </SpinnerContainer>
-      </div>
+      </Page>
     )
   }
 

--- a/src/dashboards/components/NewVEO.tsx
+++ b/src/dashboards/components/NewVEO.tsx
@@ -5,7 +5,12 @@ import {useSelector, useDispatch} from 'react-redux'
 import {get} from 'lodash'
 
 // Components
-import {Overlay, SpinnerContainer, TechnoSpinner} from '@influxdata/clockface'
+import {
+  Overlay,
+  Page,
+  SpinnerContainer,
+  TechnoSpinner,
+} from '@influxdata/clockface'
 import TimeMachine from 'src/timeMachine/components/TimeMachine'
 import VEOHeader from 'src/dashboards/components/VEOHeader'
 
@@ -59,7 +64,7 @@ const NewViewVEO: FC = () => {
 
   if (isFlagEnabled('openCellPage')) {
     return (
-      <div className="veo">
+      <Page>
         <SpinnerContainer
           spinnerComponent={<TechnoSpinner />}
           loading={view.status}
@@ -75,7 +80,7 @@ const NewViewVEO: FC = () => {
             <TimeMachine />
           </div>
         </SpinnerContainer>
-      </div>
+      </Page>
     )
   }
 


### PR DESCRIPTION
Closes #5155 

This fixes the issue that some users were seeing with the openCellPage flag turned on where a user who's navbar was open and tried to create a new cell or edit a cell in the flux editor mode were unable to see part of the page. This is because we were applying previously relevant styles to the page that now conflicted with the flex layout and were shoving the content off the page. This PR resolves that issue

![fix-cell](https://user-images.githubusercontent.com/19984220/180439008-af8a398c-6d71-4692-88c2-75dc8a0065e1.gif)
