### PR TITLE
chore: remove component drilling for logout

### DIFF
--- a/src/Logout.tsx
+++ b/src/Logout.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import {FC, useEffect} from 'react'
 import {useDispatch} from 'react-redux'
-import {RouteComponentProps} from 'react-router-dom'
+import {useHistory} from 'react-router-dom'
 
 // APIs
 import {postSignout} from 'src/client'
@@ -18,9 +18,8 @@ import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 // Components
 import {reset} from 'src/shared/actions/flags'
 
-type Props = RouteComponentProps
-
-const Logout: FC<Props> = ({history}) => {
+const Logout: FC = () => {
+  const history = useHistory()
   const dispatch = useDispatch()
 
   useEffect(() => {


### PR DESCRIPTION
This is just some minor clean-up in the way we're getting `history` in the Logout component. The change basically makes things more explicit so that we're not left wondering where `history` comes from, since it definitely isn't being drilled into the component. 