### PR TITLE
test(pinned): wait for element to be visible before accessing

### DIFF
--- a/cypress/e2e/cloud/pinned.test.ts
+++ b/cypress/e2e/cloud/pinned.test.ts
@@ -42,9 +42,11 @@ describe('Pinned Items', () => {
 
       cy.visit('/')
       cy.getByTestID('tree-nav')
-      cy.getByTestID('pinneditems--container').within(() => {
-        cy.getByTestID('pinneditems--card').should('exist')
-      })
+      cy.getByTestID('pinneditems--container')
+        .should('be.visible')
+        .within(() => {
+          cy.getByTestID('pinneditems--card').should('exist')
+        })
     })
 
     it('reflects an edit to the dashboard name on the dashboard card', () => {
@@ -72,12 +74,14 @@ describe('Pinned Items', () => {
       cy.wait('@updatePinned')
       cy.visit('/')
       cy.getByTestID('tree-nav')
-      cy.getByTestID('pinneditems--container').within(() => {
-        cy.getByTestID('pinneditems--link').should(
-          'contain.text',
-          'Bucks In Six'
-        )
-      })
+      cy.getByTestID('pinneditems--container')
+        .should('be.visible')
+        .within(() => {
+          cy.getByTestID('pinneditems--link').should(
+            'contain.text',
+            'Bucks In Six'
+          )
+        })
     })
 
     it('unpins a card which removes it from the pinned list', () => {
@@ -117,10 +121,9 @@ describe('Pinned Items', () => {
 
       cy.visit('/')
       cy.getByTestID('tree-nav')
-      cy.getByTestID('pinneditems--emptystate').should(
-        'contain.text',
-        'Pin a task, dashboard, or notebook here'
-      )
+      cy.getByTestID('pinneditems--emptystate')
+        .should('be.visible')
+        .should('contain.text', 'Pin a task, dashboard, or notebook here')
     })
   })
 
@@ -197,12 +200,14 @@ from(bucket: "${name}"{rightarrow}
       cy.wait('@updatePinned')
       cy.visit('/')
       cy.getByTestID('tree-nav')
-      cy.getByTestID('pinneditems--container').within(() => {
-        cy.getByTestID('pinneditems--link').should(
-          'contain.text',
-          'Bucks In Six'
-        )
-      })
+      cy.getByTestID('pinneditems--container')
+        .should('be.visible')
+        .within(() => {
+          cy.getByTestID('pinneditems--link').should(
+            'contain.text',
+            'Bucks In Six'
+          )
+        })
     })
 
     it('unpins when the underlying resource is removed', () => {
@@ -212,10 +217,9 @@ from(bucket: "${name}"{rightarrow}
 
       cy.visit('/')
       cy.getByTestID('tree-nav')
-      cy.getByTestID('pinneditems--emptystate').should(
-        'contain.text',
-        'Pin a task, dashboard, or notebook here'
-      )
+      cy.getByTestID('pinneditems--emptystate')
+        .should('be.visible')
+        .should('contain.text', 'Pin a task, dashboard, or notebook here')
     })
   })
 
@@ -283,9 +287,11 @@ from(bucket: "${name}"{rightarrow}
 
       cy.visit('/')
       cy.getByTestID('tree-nav')
-      cy.getByTestID('pinneditems--container').within(() => {
-        cy.getByTestID('pinneditems--type').should('contain.text', 'NOTEBOOK')
-      })
+      cy.getByTestID('pinneditems--container')
+        .should('be.visible')
+        .within(() => {
+          cy.getByTestID('pinneditems--type').should('contain.text', 'NOTEBOOK')
+        })
     })
 
     it('updates the name when the notebook name is updated', () => {
@@ -316,9 +322,14 @@ from(bucket: "${name}"{rightarrow}
       cy.wait('@updateNotebook')
       cy.visit('/')
       cy.getByTestID('tree-nav')
-      cy.getByTestID('pinneditems--container').within(() => {
-        cy.getByTestID('pinneditems--link').should('contain.text', updatedName)
-      })
+      cy.getByTestID('pinneditems--container')
+        .should('be.visible')
+        .within(() => {
+          cy.getByTestID('pinneditems--link').should(
+            'contain.text',
+            updatedName
+          )
+        })
     })
 
     it('unpins when the resource it is pointing to is deleted', () => {
@@ -337,10 +348,9 @@ from(bucket: "${name}"{rightarrow}
 
       cy.visit('/')
       cy.getByTestID('tree-nav')
-      cy.getByTestID('pinneditems--emptystate').should(
-        'contain.text',
-        'Pin a task, dashboard, or notebook here'
-      )
+      cy.getByTestID('pinneditems--emptystate')
+        .should('be.visible')
+        .should('contain.text', 'Pin a task, dashboard, or notebook here')
     })
   })
 })


### PR DESCRIPTION
related to #5149 

PR adds code to all individual tests in `Pinned.test.ts` to wait on UI elements to be visible before accessing said element. 

I ran each test at least 10 times to check for flaky behavior. No issues observed. 


Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
