### PR TITLE
fix: add bucket prop back to execute query page

### DIFF
--- a/src/homepageExperience/components/steps/cli/ExecuteQuery.tsx
+++ b/src/homepageExperience/components/steps/cli/ExecuteQuery.tsx
@@ -1,6 +1,13 @@
+// Libraries
 import React from 'react'
 
+// Components
 import CodeSnippet from 'src/shared/components/CodeSnippet'
+
+// Constants
+import {DEFAULT_BUCKET} from 'src/writeData/components/WriteDataDetailsContext'
+
+// Utils
 import {event} from 'src/cloud/utils/reporting'
 import {SafeBlankLink} from 'src/utils/SafeBlankLink'
 
@@ -14,9 +21,8 @@ type OwnProps = {
 
 export const ExecuteQuery = (props: OwnProps) => {
   const {bucket} = props
-  const query = `influx query 'from(bucket:"${
-    bucket === '<BUCKET>' ? 'sample-bucket' : bucket
-  }") |> range(start:-10m)' --raw`
+  const bucketName = bucket === DEFAULT_BUCKET ? 'sample-bucket' : bucket
+  const query = `influx query 'from(bucket:"${bucketName}") |> range(start:-10m)' --raw`
 
   const fluxExample = `from(bucket: “weather-data”)
   |> range(start: -10m)
@@ -42,9 +48,9 @@ export const ExecuteQuery = (props: OwnProps) => {
         language="properties"
       ></CodeSnippet>
       <p style={{marginTop: '60px'}}>
-        Let's write a Flux query in the InfluxCLI to read back all of the data
-        you wrote in the previous step. Copy the code snippet below into the
-        InfluxCLI.
+        Let's write a Flux query in the InfluxDB CLI to read back all of the
+        data you wrote in the previous step. Copy the code snippet below into
+        the InfluxDB CLI.
       </p>
       <CodeSnippet
         text={query}

--- a/src/homepageExperience/components/steps/cli/ExecuteQuery.tsx
+++ b/src/homepageExperience/components/steps/cli/ExecuteQuery.tsx
@@ -8,8 +8,15 @@ const logCopyCodeSnippet = () => {
   event('firstMile.cliWizard.executeQuery.code.copied')
 }
 
-export const ExecuteQuery = () => {
-  const query = `influx query 'from(bucket:"sample-bucket") |> range(start:-10m)' --raw`
+type OwnProps = {
+  bucket: string
+}
+
+export const ExecuteQuery = (props: OwnProps) => {
+  const {bucket} = props
+  const query = `influx query 'from(bucket:"${
+    bucket === '<BUCKET>' ? 'sample-bucket' : bucket
+  }") |> range(start:-10m)' --raw`
 
   const fluxExample = `from(bucket: “weather-data”)
   |> range(start: -10m)


### PR DESCRIPTION
Closes #5174

Adds `bucket` prop back to `Execute Query` page so that the flux script can update the users bucket name dynamically.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
