### PR TITLE
feat: adds wizard nav to the cli onboarding

### DIFF
--- a/src/homepageExperience/containers/CliWizard.test.tsx
+++ b/src/homepageExperience/containers/CliWizard.test.tsx
@@ -32,5 +32,17 @@ describe('Navigation', () => {
       const prevButton = screen.getByTestId('cli-prev-button')
       expect(prevButton).toHaveAttribute('disabled')
     })
+    it('can click next on the first step', async () => {
+      setup()
+      await fireEvent.click(screen.getByText('Overview'))
+      const prevButton = screen.getByTestId('cli-next-button')
+      expect(prevButton).not.toHaveAttribute('disabled')
+    })
+    it('can click previous on the last step', async () => {
+      setup()
+      await fireEvent.click(screen.getByText('Finished!'))
+      const prevButton = screen.getByTestId('cli-prev-button')
+      expect(prevButton).not.toHaveAttribute('disabled')
+    })
   })
 })

--- a/src/homepageExperience/containers/CliWizard.test.tsx
+++ b/src/homepageExperience/containers/CliWizard.test.tsx
@@ -22,13 +22,13 @@ describe('Navigation', () => {
   describe('Next and Previous Buttons', () => {
     it('cannot click next on final step', async () => {
       setup()
-      fireEvent.click(screen.getByText('Finished!'))
+      await fireEvent.click(screen.getByText('Finished!'))
       const nextButton = screen.getByTestId('cli-next-button')
       expect(nextButton).toHaveAttribute('disabled')
     })
     it('cannot click previous on first step', async () => {
       setup()
-      fireEvent.click(screen.getByText('Overview'))
+      await fireEvent.click(screen.getByText('Overview'))
       const prevButton = screen.getByTestId('cli-prev-button')
       expect(prevButton).toHaveAttribute('disabled')
     })

--- a/src/homepageExperience/containers/CliWizard.test.tsx
+++ b/src/homepageExperience/containers/CliWizard.test.tsx
@@ -1,0 +1,36 @@
+// Libraries
+import React from 'react'
+import {fireEvent, screen} from '@testing-library/react'
+import {renderWithRedux} from 'src/mockState'
+
+// Components
+import {CliWizard} from 'src/homepageExperience/containers/CliWizard'
+
+jest.mock('canvas-confetti')
+jest.mock('src/homepageExperience/assets/sample.csv', () => {
+  return 'csv, csv, csv'
+})
+jest.mock('assets/images/sample-csv.png', () => {
+  return 'csv screenshot'
+})
+
+const setup = () => {
+  return renderWithRedux(<CliWizard />)
+}
+
+describe('Navigation', () => {
+  describe('Next and Previous Buttons', () => {
+    it('cannot click next on final step', async () => {
+      setup()
+      fireEvent.click(screen.getByText('Finished!'))
+      const nextButton = screen.getByTestId('cli-next-button')
+      expect(nextButton).toHaveAttribute('disabled')
+    })
+    it('cannot click previous on first step', async () => {
+      setup()
+      fireEvent.click(screen.getByText('Overview'))
+      const prevButton = screen.getByTestId('cli-prev-button')
+      expect(prevButton).toHaveAttribute('disabled')
+    })
+  })
+})

--- a/src/homepageExperience/containers/CliWizard.tsx
+++ b/src/homepageExperience/containers/CliWizard.tsx
@@ -147,8 +147,6 @@ export class CliWizard extends PureComponent<{}, State> {
   }
 
   render() {
-    const {currentStep} = this.state
-
     return (
       <Page>
         <Page.Header fullWidth={false}>
@@ -194,7 +192,7 @@ export class CliWizard extends PureComponent<{}, State> {
                   size={ComponentSize.Large}
                   color={ComponentColor.Tertiary}
                   status={
-                    currentStep > 1
+                    this.state.currentStep > 1
                       ? ComponentStatus.Default
                       : ComponentStatus.Disabled
                   }
@@ -206,7 +204,7 @@ export class CliWizard extends PureComponent<{}, State> {
                   size={ComponentSize.Large}
                   color={ComponentColor.Primary}
                   status={
-                    currentStep < 7
+                    this.state.currentStep < 7
                       ? ComponentStatus.Default
                       : ComponentStatus.Disabled
                   }

--- a/src/homepageExperience/containers/CliWizard.tsx
+++ b/src/homepageExperience/containers/CliWizard.tsx
@@ -1,0 +1,222 @@
+// Libraries
+import React, {PureComponent} from 'react'
+import classnames from 'classnames'
+
+// Components
+import {
+  Button,
+  ComponentColor,
+  ComponentSize,
+  ComponentStatus,
+  Page,
+  SubwayNav,
+} from '@influxdata/clockface'
+import {CLIIcon} from 'src/homepageExperience/components/HomepageIcons'
+
+// Steps
+import {ExecuteAggregateQuery} from 'src/homepageExperience/components/steps/cli/ExecuteAggregateQuery'
+import {ExecuteQuery} from 'src/homepageExperience/components/steps/cli/ExecuteQuery'
+import {Finish} from 'src/homepageExperience/components/steps/Finish'
+import {InitializeClient} from 'src/homepageExperience/components/steps/cli/InitializeClient'
+import {InstallDependencies} from 'src/homepageExperience/components/steps/cli/InstallDependencies'
+import {Overview} from 'src/homepageExperience/components/steps/Overview'
+import {WriteData} from 'src/homepageExperience/components/steps/cli/WriteData'
+import WriteDataDetailsContextProvider from 'src/writeData/components/WriteDataDetailsContext'
+
+// Utils
+import {event} from 'src/cloud/utils/reporting'
+import {HOMEPAGE_NAVIGATION_STEPS_CLI} from 'src/homepageExperience/utils'
+import RateLimitAlert from 'src/cloud/components/RateLimitAlert'
+
+interface State {
+  currentStep: number
+  selectedBucket: string
+  finishStepCompleted: boolean
+  tokenValue: string
+  finalFeedback: number
+}
+
+export class CliWizard extends PureComponent<{}, State> {
+  state = {
+    currentStep: 1,
+    selectedBucket: 'sample-bucket',
+    finishStepCompleted: false,
+    tokenValue: null,
+    finalFeedback: null,
+  }
+
+  private handleSelectBucket = (bucketName: string) => {
+    this.setState({selectedBucket: bucketName})
+  }
+
+  private handleMarkStepAsCompleted = () => {
+    this.setState({finishStepCompleted: true})
+  }
+
+  private setTokenValue = (tokenValue: string) => {
+    this.setState({tokenValue: tokenValue})
+  }
+
+  private setFinalFeedback = (feedbackValue: number) => {
+    this.setState({finalFeedback: feedbackValue})
+  }
+
+  handleNextClick = () => {
+    this.setState(
+      {
+        currentStep: Math.min(
+          this.state.currentStep + 1,
+          HOMEPAGE_NAVIGATION_STEPS_CLI.length
+        ),
+      },
+      () => {
+        event(
+          'firstMile.cliWizard.next.clicked',
+          {},
+          {
+            clickedButtonAtStep: this.state.currentStep - 1,
+            currentStep: this.state.currentStep,
+          }
+        )
+      }
+    )
+  }
+
+  handlePreviousClick = () => {
+    this.setState(
+      {currentStep: Math.max(this.state.currentStep - 1, 1)},
+      () => {
+        event(
+          'firstMile.cliWizard.previous.clicked',
+          {},
+          {
+            clickedButtonAtStep: this.state.currentStep + 1,
+            currentStep: this.state.currentStep,
+          }
+        )
+      }
+    )
+  }
+
+  handleNavClick = (clickedStep: number) => {
+    this.setState({currentStep: clickedStep})
+  }
+
+  renderStep = () => {
+    switch (this.state.currentStep) {
+      case 1: {
+        return <Overview wizard="cliWizard" />
+      }
+      case 2: {
+        return <InstallDependencies />
+      }
+      case 3: {
+        return (
+          <InitializeClient
+            wizardEventName="cliWizard"
+            setTokenValue={this.setTokenValue}
+            tokenValue={this.state.tokenValue}
+            onSelectBucket={this.handleSelectBucket}
+          />
+        )
+      }
+      case 4: {
+        return <WriteData bucket={this.state.selectedBucket} />
+      }
+      case 5: {
+        return <ExecuteQuery bucket={this.state.selectedBucket} />
+      }
+      case 6: {
+        return <ExecuteAggregateQuery bucket={this.state.selectedBucket} />
+      }
+      case 7: {
+        return (
+          <Finish
+            wizardEventName="cliWizard"
+            markStepAsCompleted={this.handleMarkStepAsCompleted}
+            finishStepCompleted={this.state.finishStepCompleted}
+            finalFeedback={this.state.finalFeedback}
+            setFinalFeedback={this.setFinalFeedback}
+          />
+        )
+      }
+      default: {
+        return <Overview wizard="cliWizard" />
+      }
+    }
+  }
+
+  render() {
+    const {currentStep} = this.state
+
+    return (
+      <Page>
+        <Page.Header fullWidth={false}>
+          {/* Need an empty div so the upgrade button aligns to the right. (Because clockface uses space-between to justifyContent)*/}
+          <div />
+          <RateLimitAlert location="firstMile.homepage" />
+        </Page.Header>
+        <Page.Contents scrollable={true}>
+          <div className="homepage-wizard-container">
+            <aside className="homepage-wizard-container--subway">
+              <div style={{width: '100%'}} data-testid="subway-nav">
+                <SubwayNav
+                  currentStep={this.state.currentStep}
+                  onStepClick={this.handleNavClick}
+                  navigationSteps={HOMEPAGE_NAVIGATION_STEPS_CLI}
+                  settingUpIcon={CLIIcon}
+                  settingUpText="InfluxCLI"
+                  setupTime="5 minutes"
+                />
+              </div>
+            </aside>
+            <div className="homepage-wizard-container--main">
+              <div
+                className={classnames(
+                  'homepage-wizard-container--main-wrapper',
+                  {
+                    verticallyCentered:
+                      this.state.currentStep === 1 ||
+                      this.state.currentStep ===
+                        HOMEPAGE_NAVIGATION_STEPS_CLI.length,
+                  }
+                )}
+              >
+                <WriteDataDetailsContextProvider>
+                  {this.renderStep()}
+                </WriteDataDetailsContextProvider>
+              </div>
+
+              <div className="homepage-wizard-container-footer">
+                <Button
+                  onClick={this.handlePreviousClick}
+                  text="Previous"
+                  size={ComponentSize.Large}
+                  color={ComponentColor.Tertiary}
+                  status={
+                    currentStep > 1
+                      ? ComponentStatus.Default
+                      : ComponentStatus.Disabled
+                  }
+                  testID={'cli-prev-button'}
+                />
+                <Button
+                  onClick={this.handleNextClick}
+                  text="Next"
+                  size={ComponentSize.Large}
+                  color={ComponentColor.Primary}
+                  status={
+                    currentStep < 7
+                      ? ComponentStatus.Default
+                      : ComponentStatus.Disabled
+                  }
+                  testID={'cli-next-button'}
+                />
+              </div>
+            </div>
+          </div>
+        </Page.Contents>
+      </Page>
+    )
+  }
+}

--- a/src/homepageExperience/containers/CliWizard.tsx
+++ b/src/homepageExperience/containers/CliWizard.tsx
@@ -198,7 +198,7 @@ export class CliWizard extends PureComponent<{}, State> {
                       ? ComponentStatus.Default
                       : ComponentStatus.Disabled
                   }
-                  testID={'cli-prev-button'}
+                  testID="cli-prev-button"
                 />
                 <Button
                   onClick={this.handleNextClick}
@@ -210,7 +210,7 @@ export class CliWizard extends PureComponent<{}, State> {
                       ? ComponentStatus.Default
                       : ComponentStatus.Disabled
                   }
-                  testID={'cli-next-button'}
+                  testID="cli-next-button"
                 />
               </div>
             </div>

--- a/src/homepageExperience/containers/CliWizard.tsx
+++ b/src/homepageExperience/containers/CliWizard.tsx
@@ -152,7 +152,7 @@ export class CliWizard extends PureComponent<{}, State> {
         <Page.Header fullWidth={false}>
           {/* Need an empty div so the upgrade button aligns to the right. (Because clockface uses space-between to justifyContent)*/}
           <div />
-          <RateLimitAlert location="firstMile.homepage" />
+          <RateLimitAlert location="firstMile.cliWizard" />
         </Page.Header>
         <Page.Contents scrollable={true}>
           <div className="homepage-wizard-container">

--- a/src/homepageExperience/utils.ts
+++ b/src/homepageExperience/utils.ts
@@ -6,7 +6,7 @@ export const HOMEPAGE_NAVIGATION_STEPS = [
     glyph: IconFont.BookOutline,
   },
   {
-    name: 'Install \n Dependencies',
+    name: 'Install\nDependencies',
     glyph: IconFont.Install,
   },
   {
@@ -14,19 +14,19 @@ export const HOMEPAGE_NAVIGATION_STEPS = [
     glyph: IconFont.CopperCoin,
   },
   {
-    name: 'Initialize \n Client',
+    name: 'Initialize\nClient',
     glyph: IconFont.FileSettings,
   },
   {
-    name: 'Write \n Data',
+    name: 'Write\nData',
     glyph: IconFont.Pencil,
   },
   {
-    name: 'Execute a \n Simple Query',
+    name: 'Execute a\nSimple Query',
     glyph: IconFont.PlayOutline,
   },
   {
-    name: 'Execute an \n Aggregate Query',
+    name: 'Execute an\nAggregate Query',
     glyph: IconFont.PlayOutline,
   },
   {
@@ -41,23 +41,23 @@ export const HOMEPAGE_NAVIGATION_STEPS_CLI = [
     glyph: IconFont.BookOutline,
   },
   {
-    name: 'Install \n Dependencies',
+    name: 'Install\nDependencies',
     glyph: IconFont.Install,
   },
   {
-    name: 'Initialize \n Client',
+    name: 'Initialize\nClient',
     glyph: IconFont.FileSettings,
   },
   {
-    name: 'Write \n Data',
+    name: 'Write\nData',
     glyph: IconFont.Pencil,
   },
   {
-    name: 'Execute \n Flux Query',
+    name: 'Execute\nFlux Query',
     glyph: IconFont.PlayOutline,
   },
   {
-    name: 'Execute \n Aggregate',
+    name: 'Execute\nAggregate',
     glyph: IconFont.PlayOutline,
   },
   {

--- a/src/homepageExperience/utils.ts
+++ b/src/homepageExperience/utils.ts
@@ -34,3 +34,34 @@ export const HOMEPAGE_NAVIGATION_STEPS = [
     glyph: IconFont.StarSmile,
   },
 ]
+
+export const HOMEPAGE_NAVIGATION_STEPS_CLI = [
+  {
+    name: 'Overview',
+    glyph: IconFont.BookOutline,
+  },
+  {
+    name: 'Install \n Dependencies',
+    glyph: IconFont.Install,
+  },
+  {
+    name: 'Initialize \n Client',
+    glyph: IconFont.FileSettings,
+  },
+  {
+    name: 'Write \n Data',
+    glyph: IconFont.Pencil,
+  },
+  {
+    name: 'Execute \n Flux Query',
+    glyph: IconFont.PlayOutline,
+  },
+  {
+    name: 'Execute \n Aggregate',
+    glyph: IconFont.PlayOutline,
+  },
+  {
+    name: 'Finished!',
+    glyph: IconFont.StarSmile,
+  },
+]


### PR DESCRIPTION
Closes #4762 
Closes #4763 

Adds the CLI Wizard navigation. This adds the container for the pages previously added, but it is still not routed. The next PR will add the route for it and hide this feature behind a feature flag. Below, there is a demo video of the wizard nav going through each page.
 
Demo:

https://user-images.githubusercontent.com/106361125/180865570-bdbb84b1-889b-4e13-b4dd-1183e05fa501.mov



### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
