### PR TITLE
chore: remove unnecessary text-transform for clarity

### DIFF
--- a/src/visualization/types/SimpleTable/style.scss
+++ b/src/visualization/types/SimpleTable/style.scss
@@ -33,7 +33,6 @@
   .cf-table--header-cell label {
     display: block;
     font-size: 10px;
-    text-transform: uppercase;
     color: $cf-grey-45;
     font-weight: 500;
 


### PR DESCRIPTION
Left over from https://github.com/influxdata/ui/issues/3064
Part of https://github.com/influxdata/giraffe/issues/777

Originally, https://github.com/influxdata/ui/pull/3065 addressed https://github.com/influxdata/ui/issues/3064 and everything worked as expected.

However, we should also remove extraneous code that makes it hard to understand why the casing for header cells are styled 3 times which makes it difficult for maintainers to understand the intent, and consequently much harder to move the code, as is the situation now. We are trying to move this into Giraffe while keeping the same look and feel.

To summarize:
1. Clockface transforms table header cells into uppercase.
2. Simple Table originally had uppercase table header cells, similar to what clockface uses.
3. A design decision was made to let table header cells have no forced casing, because Flux is case sensitive and it was confusing to users that table header cell names were always uppercase rather than their actual case-sensitive names.
4. A fix was made to override 1 and 2. See https://github.com/influxdata/ui/blob/master/src/visualization/types/SimpleTable/InnerTable.tsx#L16 and https://github.com/influxdata/ui/blob/master/src/visualization/types/SimpleTable/InnerTable.tsx#L24

We are now removing 2. because it's easier to read and catch than having 1, 2, and 4. We are left with just 1 and 4, which is easier to understand.
