### PR TITLE
feat: update InfluxCLI to InfluxDB CLI

### DIFF
--- a/src/homepageExperience/components/steps/cli/ExecuteAggregateQuery.tsx
+++ b/src/homepageExperience/components/steps/cli/ExecuteAggregateQuery.tsx
@@ -3,6 +3,7 @@ import CodeSnippet from 'src/shared/components/CodeSnippet'
 
 import {SafeBlankLink} from 'src/utils/SafeBlankLink'
 import {event} from 'src/cloud/utils/reporting'
+import {onboardingName} from 'src/homepageExperience/containers/CliWizard'
 
 const logCopyCodeSnippet = () => {
   event('firstMile.cliWizard.executeAggregateQuery.code.copied')
@@ -50,7 +51,7 @@ export const ExecuteAggregateQuery = (props: OwnProps) => {
         onCopy={logCopyCodeSnippet}
         language="properties"
       />
-      <p>In the InfluxCLI, run the following:</p>
+      <p>In the {onboardingName}, run the following:</p>
       <CodeSnippet
         text={codeSnippet}
         onCopy={logCopyCodeSnippet}

--- a/src/homepageExperience/components/steps/cli/ExecuteAggregateQuery.tsx
+++ b/src/homepageExperience/components/steps/cli/ExecuteAggregateQuery.tsx
@@ -3,7 +3,6 @@ import CodeSnippet from 'src/shared/components/CodeSnippet'
 
 import {SafeBlankLink} from 'src/utils/SafeBlankLink'
 import {event} from 'src/cloud/utils/reporting'
-import {onboardingName} from 'src/homepageExperience/containers/CliWizard'
 
 const logCopyCodeSnippet = () => {
   event('firstMile.cliWizard.executeAggregateQuery.code.copied')
@@ -51,7 +50,7 @@ export const ExecuteAggregateQuery = (props: OwnProps) => {
         onCopy={logCopyCodeSnippet}
         language="properties"
       />
-      <p>In the {onboardingName}, run the following:</p>
+      <p>In the InfluxDB CLI, run the following:</p>
       <CodeSnippet
         text={codeSnippet}
         onCopy={logCopyCodeSnippet}

--- a/src/homepageExperience/components/steps/cli/InitializeClient.tsx
+++ b/src/homepageExperience/components/steps/cli/InitializeClient.tsx
@@ -27,6 +27,7 @@ import {
 } from '@influxdata/clockface'
 import WriteDataHelperBuckets from 'src/writeData/components/WriteDataHelperBuckets'
 import {WriteDataDetailsContext} from 'src/writeData/components/WriteDataDetailsContext'
+import {onboardingName} from 'src/homepageExperience/containers/CliWizard'
 
 // Utils
 import {allAccessPermissions} from 'src/authorizations/utils/permissions'
@@ -159,8 +160,8 @@ export const InitializeClient: FC<OwnProps> = ({
         </Panel.Body>
       </Panel>
       <p className="large-margins">
-        We can also create a bucket using the InfluxCLI. We'll link the bucket
-        to the profile you created.
+        We can also create a bucket using the {onboardingName}. We'll link the
+        bucket to the profile you created.
       </p>
       <CodeSnippet
         text={bucketSnippet}

--- a/src/homepageExperience/components/steps/cli/InitializeClient.tsx
+++ b/src/homepageExperience/components/steps/cli/InitializeClient.tsx
@@ -27,7 +27,6 @@ import {
 } from '@influxdata/clockface'
 import WriteDataHelperBuckets from 'src/writeData/components/WriteDataHelperBuckets'
 import {WriteDataDetailsContext} from 'src/writeData/components/WriteDataDetailsContext'
-import {onboardingName} from 'src/homepageExperience/containers/CliWizard'
 
 // Utils
 import {allAccessPermissions} from 'src/authorizations/utils/permissions'
@@ -160,7 +159,7 @@ export const InitializeClient: FC<OwnProps> = ({
         </Panel.Body>
       </Panel>
       <p className="large-margins">
-        We can also create a bucket using the {onboardingName}. We'll link the
+        We can also create a bucket using the InfluxDB CLI. We'll link the
         bucket to the profile you created.
       </p>
       <CodeSnippet

--- a/src/homepageExperience/components/steps/cli/InstallDependencies.tsx
+++ b/src/homepageExperience/components/steps/cli/InstallDependencies.tsx
@@ -13,6 +13,7 @@ import React, {FC, useEffect, useState} from 'react'
 import {useDispatch} from 'react-redux'
 import {getBuckets} from 'src/buckets/actions/thunks'
 import {event} from 'src/cloud/utils/reporting'
+import {onboardingName} from 'src/homepageExperience/containers/CliWizard'
 
 export const InstallDependencies: FC = () => {
   const dispatch = useDispatch()
@@ -113,7 +114,7 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
               documentation.
             </SafeBlankLink>{' '}
           </p>
-          <h2 style={headingWithMargin}>Useful InfluxCLI commands</h2>
+          <h2 style={headingWithMargin}>Useful {onboardingName} commands</h2>
           <p>
             To invoke a command, use the following format in the command line:
           </p>
@@ -174,10 +175,12 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
             language="properties"
           />
           <h2 style={headingWithMargin}>Grant network access (optional)</h2>
-          <p>To grant the InfluxCLI the required access, do the following:</p>
+          <p>
+            To grant the {onboardingName} the required access, do the following:
+          </p>
           <p>1. Select Private networks, such as my home or work network </p>
           <p>2. Click Allow access</p>
-          <h2 style={headingWithMargin}>Useful InfluxCLI commands</h2>
+          <h2 style={headingWithMargin}>Useful {onboardingName} commands</h2>
           <p>
             To invoke a command, use the following format in the command line:
           </p>
@@ -255,7 +258,7 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
             onCopy={logCopyCodeSnippetLinux}
             language="properties"
           />
-          <h2 style={headingWithMargin}>Useful InfluxCLI commands</h2>
+          <h2 style={headingWithMargin}>Useful {onboardingName} commands</h2>
           <p>
             To invoke a command, use the following format in the command line:
           </p>

--- a/src/homepageExperience/components/steps/cli/InstallDependencies.tsx
+++ b/src/homepageExperience/components/steps/cli/InstallDependencies.tsx
@@ -13,7 +13,6 @@ import React, {FC, useEffect, useState} from 'react'
 import {useDispatch} from 'react-redux'
 import {getBuckets} from 'src/buckets/actions/thunks'
 import {event} from 'src/cloud/utils/reporting'
-import {onboardingName} from 'src/homepageExperience/containers/CliWizard'
 
 export const InstallDependencies: FC = () => {
   const dispatch = useDispatch()
@@ -114,7 +113,7 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
               documentation.
             </SafeBlankLink>{' '}
           </p>
-          <h2 style={headingWithMargin}>Useful {onboardingName} commands</h2>
+          <h2 style={headingWithMargin}>Useful InfluxDB CLI commands</h2>
           <p>
             To invoke a command, use the following format in the command line:
           </p>
@@ -176,11 +175,11 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
           />
           <h2 style={headingWithMargin}>Grant network access (optional)</h2>
           <p>
-            To grant the {onboardingName} the required access, do the following:
+            To grant the InfluxDB CLI the required access, do the following:
           </p>
           <p>1. Select Private networks, such as my home or work network </p>
           <p>2. Click Allow access</p>
-          <h2 style={headingWithMargin}>Useful {onboardingName} commands</h2>
+          <h2 style={headingWithMargin}>Useful InfluxDB CLI commands</h2>
           <p>
             To invoke a command, use the following format in the command line:
           </p>
@@ -258,7 +257,7 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
             onCopy={logCopyCodeSnippetLinux}
             language="properties"
           />
-          <h2 style={headingWithMargin}>Useful {onboardingName} commands</h2>
+          <h2 style={headingWithMargin}>Useful InfluxDB CLI commands</h2>
           <p>
             To invoke a command, use the following format in the command line:
           </p>

--- a/src/homepageExperience/containers/CliWizard.tsx
+++ b/src/homepageExperience/containers/CliWizard.tsx
@@ -28,8 +28,6 @@ import {event} from 'src/cloud/utils/reporting'
 import {HOMEPAGE_NAVIGATION_STEPS_CLI} from 'src/homepageExperience/utils'
 import RateLimitAlert from 'src/cloud/components/RateLimitAlert'
 
-export const onboardingName = `InfluxDB CLI`
-
 interface State {
   currentStep: number
   selectedBucket: string
@@ -165,7 +163,7 @@ export class CliWizard extends PureComponent<{}, State> {
                   onStepClick={this.handleNavClick}
                   navigationSteps={HOMEPAGE_NAVIGATION_STEPS_CLI}
                   settingUpIcon={CLIIcon}
-                  settingUpText={onboardingName}
+                  settingUpText="InfluxDB CLI"
                   setupTime="5 minutes"
                 />
               </div>

--- a/src/homepageExperience/containers/CliWizard.tsx
+++ b/src/homepageExperience/containers/CliWizard.tsx
@@ -28,6 +28,8 @@ import {event} from 'src/cloud/utils/reporting'
 import {HOMEPAGE_NAVIGATION_STEPS_CLI} from 'src/homepageExperience/utils'
 import RateLimitAlert from 'src/cloud/components/RateLimitAlert'
 
+export const onboardingName = `InfluxDB CLI`
+
 interface State {
   currentStep: number
   selectedBucket: string
@@ -163,7 +165,7 @@ export class CliWizard extends PureComponent<{}, State> {
                   onStepClick={this.handleNavClick}
                   navigationSteps={HOMEPAGE_NAVIGATION_STEPS_CLI}
                   settingUpIcon={CLIIcon}
-                  settingUpText="InfluxCLI"
+                  settingUpText={onboardingName}
                   setupTime="5 minutes"
                 />
               </div>

--- a/src/homepageExperience/containers/HomepageContainer.tsx
+++ b/src/homepageExperience/containers/HomepageContainer.tsx
@@ -194,9 +194,9 @@ export const HomepageContainer: FC = () => {
                       <div className="tile-icon-text-wrapper">
                         <div className="icon">{CLIIcon}</div>
                         <div>
-                          <h4>InfluxCLI</h4>
+                          <h4>InfluxDB CLI</h4>
                           <h6>
-                            Write and query data using the Influx Command Line
+                            Write and query data using the InfluxDB Command Line
                             Interface. Supports CSV and Line Protocol.
                           </h6>
                         </div>


### PR DESCRIPTION
Closes #5163

Updated naming convention from `InfluxCLI` to `InfluxDB CLI`. Saved the name to an exported variable in `CliWizard.tsx`.

Example screenshot:
<img width="1440" alt="Screen Shot 2022-07-26 at 1 41 50 PM" src="https://user-images.githubusercontent.com/106361125/181074742-ac5ae6ab-532e-4497-9255-a54ec847c8d7.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
