### PR TITLE
feat: add getAccountsOrgs and putAccountsOrgsDefault to api layer

### DIFF
--- a/src/identity/apis/auth.ts
+++ b/src/identity/apis/auth.ts
@@ -1,12 +1,14 @@
 // Functions calling API
 import {
   getAccount,
+  getAccountsOrgs,
   getIdentity,
   getMe as getMeQuartz,
   getOrg,
   getOrgs,
   putOrgsDefault,
   putAccountsDefault,
+  putAccountsOrgsDefault,
   Account,
   Identity,
   IdentityAccount,
@@ -31,12 +33,12 @@ import {CLOUD} from 'src/shared/constants'
 // Types
 import {RemoteDataState} from 'src/types'
 
-// These are optional properties of the current account which are not retrieved from identity.
+// Additional properties of the current account, which are not retrieved from  /quartz/identity.
 export interface CurrentAccount extends IdentityAccount {
   billingProvider?: 'zuora' | 'aws' | 'gcm' | 'azure'
 }
 
-// Optional properties of the current org, which are not retrieved from identity.
+// Additional properties of the current org, which are not retrieved from /quartz/identity.
 export interface CurrentOrg {
   id: string
   clusterHost: string
@@ -70,6 +72,7 @@ export enum NetworkErrorTypes {
   UnauthorizedError = 'UnauthorizedError',
   NotFoundError = 'NotFoundError',
   ServerError = 'ServerError',
+  UnprocessableEntity = 'UnprocessableEntity',
   GenericError = 'GenericError',
 }
 
@@ -86,6 +89,14 @@ export class NotFoundError extends Error {
   constructor(message) {
     super(message)
     this.name = 'NotFoundError'
+  }
+}
+
+// 422 error
+export class UnprocessableEntityError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'UnprocessableEntityError'
   }
 }
 
@@ -153,7 +164,7 @@ export const fetchQuartzMe = async (): Promise<MeQuartz> => {
   return user
 }
 
-// fetch user identity from /me (used in OSS and environments without Quartz)
+// fetch user identity from IDPE /me (used in OSS and environments without Quartz)
 export const fetchLegacyIdentity = async (): Promise<UserResponseIdpe> => {
   const response = await getMeIdpe({})
 
@@ -170,7 +181,7 @@ export const fetchLegacyIdentity = async (): Promise<UserResponseIdpe> => {
   return user
 }
 
-// fetch details about user's current account
+// fetch details about one of the user's accounts
 export const fetchAccountDetails = async (
   accountId: string | number
 ): Promise<Account> => {
@@ -206,10 +217,10 @@ export const updateDefaultQuartzAccount = async (
     throw new ServerError(response.data.message)
   }
 
-  // success status code is 204; no data in response.body is expected.
+  // success status code is 204; no response body expected.
 }
 
-// fetch details about user's current organization
+// fetch details about one of the user's organizations
 export const fetchOrgDetails = async (orgId: string): Promise<Organization> => {
   const response = await getOrg({orgId})
 
@@ -225,7 +236,7 @@ export const fetchOrgDetails = async (orgId: string): Promise<Organization> => {
   return orgDetails
 }
 
-// fetch list of user's current organizations
+// fetch the list of organizations in the user's currently active account
 export const fetchQuartzOrgs = async (): Promise<OrganizationSummaries> => {
   const response = await getOrgs({})
 
@@ -240,7 +251,7 @@ export const fetchQuartzOrgs = async (): Promise<OrganizationSummaries> => {
   return response.data
 }
 
-// change default organization for a given account
+// change the default organization for the user's currently active account
 export const updateDefaultQuartzOrg = async (orgId: string) => {
   const response = await putOrgsDefault({
     data: {
@@ -254,4 +265,54 @@ export const updateDefaultQuartzOrg = async (orgId: string) => {
   }
 
   return response.data
+}
+
+// fetch the list of organizations associated with a given account ID
+export const fetchOrgsByAccountID = async (
+  accountNum: number
+): Promise<OrganizationSummaries> => {
+  const accountId = accountNum.toString()
+
+  const response = await getAccountsOrgs({
+    accountId,
+  })
+
+  if (response.status === 401) {
+    throw new UnauthorizedError(response.data.message)
+  }
+
+  if (response.status === 500) {
+    throw new ServerError(response.data.message)
+  }
+
+  return response.data
+}
+
+// update the default org for a given account
+export const updateDefaultOrgByAccountID = async ({
+  accountNum,
+  orgId,
+}): Promise<void> => {
+  const accountId = accountNum.toString()
+
+  const response = await putAccountsOrgsDefault({
+    accountId,
+    data: {
+      id: orgId,
+    },
+  })
+
+  if (response.status === 404) {
+    throw new NotFoundError(response.data.message)
+  }
+
+  if (response.status === 422) {
+    throw new UnprocessableEntityError(response.data.message)
+  }
+
+  if (response.status === 500) {
+    throw new ServerError(response.data.message)
+  }
+
+  // success status code is 204; no response body expected.
 }


### PR DESCRIPTION
Closes #5182 

Adds functions to API layer to handle two new AIM endpoints, `getAccountsOrgs` (retrieve list of accounts from quartz, given an account id) and `putAccountsOrgsDefault` (given an account id and org id, set that org as the default org for the given account). 

These endpoints provide more functionality than their pre-existing counterparts (which could only `GET`/`PUT` data for the _currently active_ account). Those old functions will be removed by [UI #5183](https://github.com/influxdata/ui/issues/5183).

Also cleaned up some comments in the API layer.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - these functions in API layer are not yet used, but will be behind `quartzIdentity` and `multiOrg`
