### PR TITLE
feat(helpBar): add request poc link to helpbar

### DIFF
--- a/src/pageLayout/containers/TreeNav.tsx
+++ b/src/pageLayout/containers/TreeNav.tsx
@@ -19,6 +19,7 @@ import {getNavItemActivation} from 'src/pageLayout/utils'
 import {getOrg} from 'src/organizations/selectors'
 import {AppSettingContext} from 'src/shared/contexts/app'
 import {event} from 'src/cloud/utils/reporting'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {SafeBlankLink} from 'src/utils/SafeBlankLink'
 
 // Types
@@ -240,6 +241,22 @@ const TreeSidebar: FC<ReduxProps> = ({
                 />
               )}
             />
+            {CLOUD && isFlagEnabled('requestPoc') && (
+              <>
+                <TreeNav.SubHeading label="Useful Links" />
+                <TreeNav.SubItem
+                  id="requestpoc"
+                  label="Request Proof of Concept"
+                  testID="nav-subitem-request-poc"
+                  linkElement={() => (
+                    <SafeBlankLink
+                      href="https://www.influxdata.com/proof-of-concept/"
+                      onClick={() => handleEventing('requestPOC')}
+                    />
+                  )}
+                />
+              </>
+            )}
           </TreeNav.SubMenu>
         </TreeNav.Item>
       </TreeNav>

--- a/src/pageLayout/containers/TreeNav.tsx
+++ b/src/pageLayout/containers/TreeNav.tsx
@@ -245,7 +245,7 @@ const TreeSidebar: FC<ReduxProps> = ({
               <>
                 <TreeNav.SubHeading label="Useful Links" />
                 <TreeNav.SubItem
-                  id="requestpoc"
+                  id="request-poc"
                   label="Request Proof of Concept"
                   testID="nav-subitem-request-poc"
                   linkElement={() => (


### PR DESCRIPTION
Closes #5120 
Closes #5119 

New feature inside Help Bar that allows user to request POC via this [link](https://www.influxdata.com/proof-of-concept/).
It's currently behind a feature flag `requestPoc`

https://user-images.githubusercontent.com/66275100/181284747-2e429d39-bb95-4f06-98e9-e1bf50061504.mov

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
