### PR TITLE
fix(deepLinks): fix broken check against org reference

### DIFF
--- a/cypress/e2e/shared/deepLinks.test.ts
+++ b/cypress/e2e/shared/deepLinks.test.ts
@@ -12,7 +12,6 @@ describe('Deep linking', () => {
   // so you'll probably need to follow-up with the docs and/or marketing teams.
   it('should be redirected to the approprate page from a shortened link', () => {
     cy.get('@org').then((org: Organization) => {
-      cy.wait(1000)
       cy.visit('/me/about')
       cy.location('pathname').should('eq', `/orgs/${org.id}/about`)
 

--- a/src/shared/components/NotFound.tsx
+++ b/src/shared/components/NotFound.tsx
@@ -132,7 +132,7 @@ const NotFound: FC = () => {
   const org = useRef<Organization>(reduxOrg)
 
   const handleDeepLink = useCallback(async () => {
-    if (!org) {
+    if (!org.current) {
       setIsFetchingOrg(true)
       org.current = await fetchOrg()
     }


### PR DESCRIPTION
Closes #5130

https://github.com/influxdata/ui/pull/4826 Changed `NotFound.tsx` from a class component to a function component, and in doing so, chaged what used to be an instance variable into a React `ref`. Unfortunately, it didn't update the check if `org` existed, and so the code that handles org not being present (in the case of logged-out users) never runs, causing OSS tests to fail and the feature to be broken for logged-out users.


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- ~[ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~
- ~[ ] Feature flagged, if applicable~
