### PR TITLE
feat(CLIWizard): add cli commands resource card

### DIFF
--- a/src/homepageExperience/components/steps/Finish.tsx
+++ b/src/homepageExperience/components/steps/Finish.tsx
@@ -129,11 +129,26 @@ export const Finish = (props: OwnProps) => {
               InfluxDB.
             </p>
           </ResourceCard>
+          {props.wizardEventName === 'cliWizard' && (
+            <ResourceCard className="homepage-wizard-next-steps">
+              <SafeBlankLink
+                href="https://docs.influxdata.com/influxdb/cloud/reference/cli/influx/"
+                onClick={() =>
+                  handleNextStepEvent(props.wizardEventName, 'cliCommands')
+                }
+              >
+                <h4>{BookIcon}CLI Commands</h4>
+              </SafeBlankLink>
+              <p>See the full list of CLI commands and how to use them.</p>
+            </ResourceCard>
+          )}
         </FlexBox>
-        <SampleAppCard
-          handleNextStepEvent={handleNextStepEvent}
-          wizardEventName={props.wizardEventName}
-        />
+        {props.wizardEventName !== 'cliWizard' ? (
+          <SampleAppCard
+            handleNextStepEvent={handleNextStepEvent}
+            wizardEventName={props.wizardEventName}
+          />
+        ) : null}
       </FlexBox>
     </>
   )


### PR DESCRIPTION
Closes #4773 

Finish page from cli onboarding is missing a resource card (CLI Commands) that should link users to the docs page. 
Pr adds this resource card and code to make sure no sample cards are shown on the page. 

<img width="1508" alt="Screen Shot 2022-07-27 at 11 44 42 AM" src="https://user-images.githubusercontent.com/66275100/181303393-5e9bf90a-2dfb-41cc-ac4c-5a7a70f7ee33.png">

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
