### PR TITLE
chore(billing): Remove Region from Billing Info

### DIFF
--- a/cypress/e2e/cloud/billing.test.ts
+++ b/cypress/e2e/cloud/billing.test.ts
@@ -88,8 +88,6 @@ describe('Billing Page PAYG Users', () => {
 
     // PAYG section
     cy.getByTestID('payg-plan--header').contains('Pay As You Go')
-    cy.getByTestID('payg-plan--region-header').contains('Region')
-    cy.getByTestID('payg-plan--region-body').contains('aws')
 
     cy.getByTestID('payg-plan--balance-header').contains('Account Balance')
     cy.getByTestID('payg-plan--balance-body').contains('10.00')

--- a/cypress/e2e/cloud/zuoraOutage.test.ts
+++ b/cypress/e2e/cloud/zuoraOutage.test.ts
@@ -63,8 +63,6 @@ describe('Billing Page PAYG Users', () => {
 
     // PAYG section
     cy.getByTestID('payg-plan--header').contains('Pay As You Go')
-    cy.getByTestID('payg-plan--region-header').contains('Region')
-    cy.getByTestID('payg-plan--region-body').contains('aws')
 
     cy.getByTestID('payg-plan--balance-header').contains('Account Balance')
     cy.getByTestID('payg-plan--balance-body').contains('10.00')

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "cy": "CYPRESS_dexUrl=https://$INGRESS_HOST:$PORT_HTTPS CYPRESS_baseUrl=http://localhost:9999 cypress open",
     "cy:dev": "source ../monitor-ci/.env && CYPRESS_dexUrl=CLOUD CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{cloud,shared}/**/*.*'",
     "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_dexUrl=OSS CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{oss,shared}/**/*.*'",
-    "generate": "export SHA=8cfd00c5b9d7781b510d27304557d323dca0a9c6 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
+    "generate": "export SHA=fae7b1adb67f961e5818ea62e2c02becaaca30cb && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-local-cloud": "export REMOTE=../openapi/ && yarn generate-meta-cloud",
     "generate-meta": "if [ -z \"${CLOUD_URL}\" ]; then yarn generate-meta-oss; else yarn generate-meta-cloud; fi",

--- a/src/billing/components/PayAsYouGo/PlanTypePanel.tsx
+++ b/src/billing/components/PayAsYouGo/PlanTypePanel.tsx
@@ -24,23 +24,6 @@ const PlanTypePanel: FC = () => {
         >
           <Panel.Header
             size={ComponentSize.ExtraSmall}
-            testID="payg-plan--region-header"
-          >
-            <h5>Region</h5>
-          </Panel.Header>
-          <Panel.Body
-            size={ComponentSize.ExtraSmall}
-            testID="payg-plan--region-body"
-          >
-            {billingInfo?.region}
-          </Panel.Body>
-        </Panel>
-        <Panel
-          backgroundColor={InfluxColors.Grey15}
-          className="plan-type-panel--detail"
-        >
-          <Panel.Header
-            size={ComponentSize.ExtraSmall}
             testID="payg-plan--balance-header"
           >
             <h5>Account Balance</h5>


### PR DESCRIPTION
In a multi-org/account world, instead of displaying the current organization's region. We have opted to remove the region altogether.

I have to update the OpenAPI repo to remove the `region` from `BillingInfo`

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
