### PR TITLE
feat: changed aggregate text and add bucket logic

### DIFF
--- a/src/homepageExperience/components/steps/cli/ExecuteAggregateQuery.tsx
+++ b/src/homepageExperience/components/steps/cli/ExecuteAggregateQuery.tsx
@@ -3,6 +3,7 @@ import CodeSnippet from 'src/shared/components/CodeSnippet'
 
 import {SafeBlankLink} from 'src/utils/SafeBlankLink'
 import {event} from 'src/cloud/utils/reporting'
+import {DEFAULT_BUCKET} from 'src/writeData/components/WriteDataDetailsContext'
 
 const logCopyCodeSnippet = () => {
   event('firstMile.cliWizard.executeAggregateQuery.code.copied')
@@ -18,27 +19,27 @@ type OwnProps = {
 
 export const ExecuteAggregateQuery = (props: OwnProps) => {
   const {bucket} = props
-
+  const bucketName = bucket === DEFAULT_BUCKET ? 'sample-bucket' : bucket
   const fromBucketSnippet = `from(bucket: "weather-data")
   |> range(start: -10m)
   |> filter(fn: (r) => r.measurement == "temperature")
   |> mean()`
 
-  const codeSnippet = `influx query 'from(bucket:"${bucket}") |> range(start:-10m) |> mean()' --raw`
+  const codeSnippet = `influx query 'from(bucket:"${bucketName}") |> range(start:-10m) |> mean()' --raw`
 
   return (
     <>
       <h1>Execute a Flux Aggregate Query</h1>
       <p>
-        An{' '}
         <SafeBlankLink
           href="https://docs.influxdata.com/flux/v0.x/function-types/#aggregates"
           onClick={logDocsOpened}
         >
-          aggregate
+          Aggregate functions
         </SafeBlankLink>{' '}
-        function is a powerful method for returning combined, summarized data
-        about a set of time-series data.
+        take the values of all rows in a table and use them to perform an
+        aggregate operation. The result is output as a new value in a single-row
+        table.
       </p>
       <p>
         An aggregation is applied after the time range and filters, as seen in
@@ -57,7 +58,7 @@ export const ExecuteAggregateQuery = (props: OwnProps) => {
         language="properties"
       />
       <p style={{marginTop: '20px'}}>
-        This will return the mean of the insect counts from the census data.
+        This will return the mean of the sample data.
       </p>
     </>
   )

--- a/src/homepageExperience/components/steps/go/ExecuteAggregateQuery.tsx
+++ b/src/homepageExperience/components/steps/go/ExecuteAggregateQuery.tsx
@@ -42,15 +42,15 @@ if err := results.Err(); err != nil {
     <>
       <h1>Execute an Aggregate Query</h1>
       <p>
-        An{' '}
         <SafeBlankLink
           href="https://docs.influxdata.com/flux/v0.x/function-types/#aggregates"
           onClick={logDocsOpened}
         >
-          aggregate
+          Aggregate functions
         </SafeBlankLink>{' '}
-        function is a powerful method for returning combined, summarized data
-        about a set of time-series data.
+        take the values of all rows in a table and use them to perform an
+        aggregate operation. The result is output as a new value in a single-row
+        table.
       </p>
       <CodeSnippet
         text={fromBucketSnippet}

--- a/src/homepageExperience/components/steps/nodejs/ExecuteAggregateQuery.tsx
+++ b/src/homepageExperience/components/steps/nodejs/ExecuteAggregateQuery.tsx
@@ -46,15 +46,15 @@ queryClient.queryRows(fluxQuery, {
     <>
       <h1>Execute an Aggregate Query</h1>
       <p>
-        An{' '}
         <SafeBlankLink
           href="https://docs.influxdata.com/flux/v0.x/function-types/#aggregates"
           onClick={logDocsOpened}
         >
-          aggregate
+          Aggregate functions
         </SafeBlankLink>{' '}
-        function is a powerful method for returning combined, summarized data
-        about a set of time-series data.
+        take the values of all rows in a table and use them to perform an
+        aggregate operation. The result is output as a new value in a single-row
+        table.
       </p>
       <CodeSnippet
         text={fromBucketSnippet}

--- a/src/homepageExperience/components/steps/python/ExecuteAggregateQuery.tsx
+++ b/src/homepageExperience/components/steps/python/ExecuteAggregateQuery.tsx
@@ -43,15 +43,15 @@ for table in tables:
     <>
       <h1>Execute an Aggregate Query</h1>
       <p>
-        An{' '}
         <SafeBlankLink
           href="https://docs.influxdata.com/flux/v0.x/function-types/#aggregates"
           onClick={logDocsOpened}
         >
-          aggregate
+          Aggregate functions
         </SafeBlankLink>{' '}
-        function is a powerful method for returning combined, summarized data
-        about a set of time-series data.
+        take the values of all rows in a table and use them to perform an
+        aggregate operation. The result is output as a new value in a single-row
+        table.
       </p>
       <CodeSnippet
         text={fromBucketSnippet}


### PR DESCRIPTION
Closes #5193 

Updates text on all `Execute Aggregate` pages.

Screenshot:
<img width="1440" alt="Screen Shot 2022-07-28 at 9 48 44 AM" src="https://user-images.githubusercontent.com/106361125/181521837-6816d426-fbc7-4df2-9e22-cf64243a50da.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
