### PR TITLE
feat: add documenation links, cleanup styling, timestamp header

### DIFF
--- a/src/writeData/subscriptions/components/BrokerDetails.scss
+++ b/src/writeData/subscriptions/components/BrokerDetails.scss
@@ -21,6 +21,10 @@
     }
   }
 
+  &__link {
+    margin-bottom: 24px;
+  }
+
   .cf-overlay--body {
     padding-top: 50px;
   }

--- a/src/writeData/subscriptions/components/BrokerDetails.tsx
+++ b/src/writeData/subscriptions/components/BrokerDetails.tsx
@@ -176,7 +176,7 @@ const BrokerDetails: FC<Props> = ({
               <p className="update-broker-form__link">
                 Reference our{' '}
                 <a
-                  href={`https://docs.influxdata.com/influxdb/cloud/write-data/no-code/load-data/?t=JSON#set-up-a-native-subscription`}
+                  href="https://docs.influxdata.com/influxdb/cloud/write-data/no-code/load-data/?t=JSON#set-up-a-native-subscription"
                   target="_blank"
                   rel="noreferrer"
                 >

--- a/src/writeData/subscriptions/components/BrokerDetails.tsx
+++ b/src/writeData/subscriptions/components/BrokerDetails.tsx
@@ -172,6 +172,19 @@ const BrokerDetails: FC<Props> = ({
             >
               Broker details
             </Heading>
+            {edit && (
+              <p className="update-broker-form__link">
+                Reference our{' '}
+                <a
+                  href={`https://docs.influxdata.com/influxdb/cloud/write-data/no-code/load-data/?t=JSON#set-up-a-native-subscription`}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  native subscription documentation
+                </a>{' '}
+                for configuration options.
+              </p>
+            )}
             <BrokerFormContent
               formContent={currentSubscription}
               updateForm={updateForm}

--- a/src/writeData/subscriptions/components/BrokerForm.tsx
+++ b/src/writeData/subscriptions/components/BrokerForm.tsx
@@ -168,6 +168,17 @@ const BrokerForm: FC<Props> = ({
                 ? 'Upgrade Now to create a new connection to collect data from an MQTT broker and parse messages into metrics.'
                 : 'Create a new connection to collect data from an MQTT broker and parse messages into metrics.'}
             </Heading>
+            <p className="create-broker-form__text">
+              See our{' '}
+              <a
+                href={`https://docs.influxdata.com/influxdb/cloud/write-data/no-code/load-data/?t=JSON#set-up-a-native-subscription`}
+                target="_blank"
+                rel="noreferrer"
+              >
+                native subscription documentation
+              </a>{' '}
+              for help getting started.
+            </p>
             <Heading
               element={HeadingElement.H3}
               weight={FontWeight.Bold}

--- a/src/writeData/subscriptions/components/BrokerForm.tsx
+++ b/src/writeData/subscriptions/components/BrokerForm.tsx
@@ -171,7 +171,7 @@ const BrokerForm: FC<Props> = ({
             <p className="create-broker-form__text">
               See our{' '}
               <a
-                href={`https://docs.influxdata.com/influxdb/cloud/write-data/no-code/load-data/?t=JSON#set-up-a-native-subscription`}
+                href="https://docs.influxdata.com/influxdb/cloud/write-data/no-code/load-data/?t=JSON#set-up-a-native-subscription"
                 target="_blank"
                 rel="noreferrer"
               >

--- a/src/writeData/subscriptions/components/JsonParsingForm.scss
+++ b/src/writeData/subscriptions/components/JsonParsingForm.scss
@@ -3,7 +3,7 @@
   .cf-grid--column {
     margin-top: $cf-space-2xs;
     &:first-child {
-      margin-top: $cf-space-l;
+      margin-top: $cf-space-m;
     }
   }
   .cf-grid--column:last-child {
@@ -16,6 +16,9 @@
       }
     }
   }
+  &__link {
+    margin-top: 0;
+  }
   .line {
     background: linear-gradient(
       256.11deg,
@@ -25,14 +28,9 @@
     height: 3px;
     margin-top: $cf-space-l;
   }
-  &__header-wrap {
-    margin-bottom: $cf-space-l;
-    margin-top: $cf-space-l;
-    &__form-header {
-      text-transform: uppercase;
-      margin-top: $cf-space-2xl;
-      margin-bottom: $cf-space-l;
-    }
+  &__header {
+    text-transform: uppercase;
+    margin: $cf-space-l 0;
   }
   &__container {
     .cf-form--element {

--- a/src/writeData/subscriptions/components/JsonParsingForm.tsx
+++ b/src/writeData/subscriptions/components/JsonParsingForm.tsx
@@ -75,6 +75,29 @@ const JsonParsingForm: FC<Props> = ({formContent, updateForm, edit}) => {
   return (
     <div className="json-parsing-form">
       <Grid.Column>
+        {edit && (
+          <p className="json-parsing-form__link">
+            See our{' '}
+            <a
+              href={`https://docs.influxdata.com/influxdb/cloud/write-data/no-code/load-data/?t=JSON#define-parsing-rules`}
+              target="_blank"
+              rel="noreferrer"
+            >
+              parsing documentation
+            </a>{' '}
+            for examples, or validate your parsing rules using{' '}
+            <a href={`https://jsonpath.com/`} target="_blank" rel="noreferrer">
+              JSONPath.
+            </a>{' '}
+          </p>
+        )}
+        <Heading
+          element={HeadingElement.H3}
+          weight={FontWeight.Bold}
+          className="json-parsing-form__header"
+        >
+          Timestamp
+        </Heading>
         <FlexBox
           alignItems={AlignItems.FlexStart}
           direction={FlexDirection.Row}
@@ -161,20 +184,13 @@ const JsonParsingForm: FC<Props> = ({formContent, updateForm, edit}) => {
         </FlexBox>
       </Grid.Column>
       <Grid.Column>
-        <FlexBox
-          alignItems={AlignItems.Center}
-          direction={FlexDirection.Row}
-          margin={ComponentSize.Large}
-          className="json-parsing-form__header-wrap"
+        <Heading
+          element={HeadingElement.H3}
+          weight={FontWeight.Bold}
+          className="json-parsing-form__header"
         >
-          <Heading
-            element={HeadingElement.H3}
-            weight={FontWeight.Bold}
-            className="json-parsing-form__header-wrap__header"
-          >
-            Measurement
-          </Heading>
-        </FlexBox>
+          Measurement
+        </Heading>
         <FlexBox
           direction={FlexDirection.Row}
           alignItems={AlignItems.Center}

--- a/src/writeData/subscriptions/components/JsonParsingForm.tsx
+++ b/src/writeData/subscriptions/components/JsonParsingForm.tsx
@@ -79,14 +79,14 @@ const JsonParsingForm: FC<Props> = ({formContent, updateForm, edit}) => {
           <p className="json-parsing-form__link">
             See our{' '}
             <a
-              href={`https://docs.influxdata.com/influxdb/cloud/write-data/no-code/load-data/?t=JSON#define-parsing-rules`}
+              href="https://docs.influxdata.com/influxdb/cloud/write-data/no-code/load-data/?t=JSON#define-parsing-rules"
               target="_blank"
               rel="noreferrer"
             >
               parsing documentation
             </a>{' '}
             for examples, or validate your parsing rules using{' '}
-            <a href={`https://jsonpath.com/`} target="_blank" rel="noreferrer">
+            <a href="https://jsonpath.com/" target="_blank" rel="noreferrer">
               JSONPath.
             </a>{' '}
           </p>

--- a/src/writeData/subscriptions/components/JsonPathInput.tsx
+++ b/src/writeData/subscriptions/components/JsonPathInput.tsx
@@ -54,48 +54,42 @@ const JsonPathInput: FC<Props> = ({
   return (
     <div>
       <Grid.Column>
-        <FlexBox
-          alignItems={AlignItems.Center}
-          direction={FlexDirection.Row}
-          margin={ComponentSize.Medium}
-          className="header-wrap"
+        <Heading
+          element={HeadingElement.H3}
+          weight={FontWeight.Bold}
+          className="json-parsing-form__header"
         >
-          <Heading
-            element={HeadingElement.H3}
-            weight={FontWeight.Bold}
-            className="json-parsing-form__header-wrap__header"
-          >
-            {name}
-          </Heading>
-          {(tagType
-            ? !(formContent.jsonTagKeys.length === 0)
-            : !(formContent.jsonFieldKeys.length === 1)) && (
-            <ConfirmationButton
-              color={ComponentColor.Colorless}
-              icon={IconFont.Trash_New}
-              shape={ButtonShape.Square}
-              size={ComponentSize.ExtraSmall}
-              confirmationLabel={`Yes, delete this ${name}`}
-              onConfirm={() => {
-                event(
-                  'removed json parsing rule',
-                  {
-                    ruleType: tagType ? 'tag' : 'field',
-                  },
-                  {feature: 'subscriptions'}
-                )
-                if (tagType) {
-                  formContent.jsonTagKeys.splice(itemNum, 1)
-                } else {
-                  formContent.jsonFieldKeys.splice(itemNum, 1)
-                }
-                updateForm({...formContent})
-              }}
-              confirmationButtonText="Confirm"
-              testID={`${tagType}-json-delete-label`}
-            />
-          )}
-        </FlexBox>
+          {name}
+        </Heading>
+        {(tagType
+          ? !(formContent.jsonTagKeys.length === 0)
+          : !(formContent.jsonFieldKeys.length === 1)) && (
+          <ConfirmationButton
+            color={ComponentColor.Colorless}
+            icon={IconFont.Trash_New}
+            shape={ButtonShape.Square}
+            size={ComponentSize.ExtraSmall}
+            confirmationLabel={`Yes, delete this ${name}`}
+            onConfirm={() => {
+              event(
+                'removed json parsing rule',
+                {
+                  ruleType: tagType ? 'tag' : 'field',
+                },
+                {feature: 'subscriptions'}
+              )
+              if (tagType) {
+                formContent.jsonTagKeys.splice(itemNum, 1)
+              } else {
+                formContent.jsonFieldKeys.splice(itemNum, 1)
+              }
+              updateForm({...formContent})
+            }}
+            confirmationButtonText="Confirm"
+            testID={`${tagType}-json-delete-label`}
+          />
+        )}
+        {/* </FlexBox> */}
         <FlexBox
           alignItems={AlignItems.FlexStart}
           direction={FlexDirection.Row}

--- a/src/writeData/subscriptions/components/JsonPathInput.tsx
+++ b/src/writeData/subscriptions/components/JsonPathInput.tsx
@@ -89,7 +89,6 @@ const JsonPathInput: FC<Props> = ({
             testID={`${tagType}-json-delete-label`}
           />
         )}
-        {/* </FlexBox> */}
         <FlexBox
           alignItems={AlignItems.FlexStart}
           direction={FlexDirection.Row}

--- a/src/writeData/subscriptions/components/StringParsingForm.scss
+++ b/src/writeData/subscriptions/components/StringParsingForm.scss
@@ -12,7 +12,7 @@
   .cf-grid--column {
     margin-top: $cf-space-2xs;
     &:first-child {
-      margin-top: $cf-space-l;
+      margin-top: $cf-space-m;
     }
   }
   .cf-grid--column:last-child {
@@ -25,14 +25,12 @@
       }
     }
   }
-  &__header-wrap {
-    margin-bottom: $cf-space-l;
-    margin-top: $cf-space-l;
-    &__header {
-      text-transform: uppercase;
-      margin-top: $cf-space-2xl;
-      margin-bottom: $cf-space-l;
-    }
+  &__link {
+    margin-top: 0;
+  }
+  &__header {
+    text-transform: uppercase;
+    margin: $cf-space-l 0;
   }
 
   &__container {

--- a/src/writeData/subscriptions/components/StringParsingForm.tsx
+++ b/src/writeData/subscriptions/components/StringParsingForm.tsx
@@ -71,6 +71,29 @@ const StringParsingForm: FC<Props> = ({formContent, updateForm, edit}) => {
   return (
     <div className="string-parsing-form">
       <Grid.Column>
+        {edit && (
+          <p className="string-parsing-form__link">
+            See our{' '}
+            <a
+              href={`https://docs.influxdata.com/influxdb/cloud/write-data/no-code/load-data/?t=String#define-parsing-rules`}
+              target="_blank"
+              rel="noreferrer"
+            >
+              parsing documentation
+            </a>{' '}
+            for examples, or validate your parsing rules using{' '}
+            <a href={`https://regex101.com/`} target="_blank" rel="noreferrer">
+              regex 101.
+            </a>{' '}
+          </p>
+        )}
+        <Heading
+          element={HeadingElement.H3}
+          weight={FontWeight.Bold}
+          className="string-parsing-form__header"
+        >
+          Timestamp
+        </Heading>
         <FlexBox
           alignItems={AlignItems.FlexStart}
           direction={FlexDirection.Row}
@@ -160,20 +183,13 @@ const StringParsingForm: FC<Props> = ({formContent, updateForm, edit}) => {
         </FlexBox>
       </Grid.Column>
       <Grid.Column>
-        <FlexBox
-          alignItems={AlignItems.Center}
-          direction={FlexDirection.Row}
-          margin={ComponentSize.Medium}
-          className="string-parsing-form__header-wrap"
+        <Heading
+          element={HeadingElement.H3}
+          weight={FontWeight.Bold}
+          className="string-parsing-form__header"
         >
-          <Heading
-            element={HeadingElement.H3}
-            weight={FontWeight.Bold}
-            className="string-parsing-form__section__header-wrap__header"
-          >
-            Measurement
-          </Heading>
-        </FlexBox>
+          Measurement
+        </Heading>
         <FlexBox
           direction={FlexDirection.Row}
           alignItems={AlignItems.Center}

--- a/src/writeData/subscriptions/components/StringParsingForm.tsx
+++ b/src/writeData/subscriptions/components/StringParsingForm.tsx
@@ -75,14 +75,14 @@ const StringParsingForm: FC<Props> = ({formContent, updateForm, edit}) => {
           <p className="string-parsing-form__link">
             See our{' '}
             <a
-              href={`https://docs.influxdata.com/influxdb/cloud/write-data/no-code/load-data/?t=String#define-parsing-rules`}
+              href="https://docs.influxdata.com/influxdb/cloud/write-data/no-code/load-data/?t=String#define-parsing-rules"
               target="_blank"
               rel="noreferrer"
             >
               parsing documentation
             </a>{' '}
             for examples, or validate your parsing rules using{' '}
-            <a href={`https://regex101.com/`} target="_blank" rel="noreferrer">
+            <a href="https://regex101.com/" target="_blank" rel="noreferrer">
               regex 101.
             </a>{' '}
           </p>

--- a/src/writeData/subscriptions/components/StringPatternInput.tsx
+++ b/src/writeData/subscriptions/components/StringPatternInput.tsx
@@ -11,10 +11,7 @@ import {
   Heading,
   HeadingElement,
   FontWeight,
-  AlignItems,
   ComponentSize,
-  FlexDirection,
-  FlexBox,
 } from '@influxdata/clockface'
 
 // Types
@@ -48,46 +45,39 @@ const StringPatternInput: FC<Props> = ({
   return (
     <div>
       <Grid.Column>
-        <FlexBox
-          alignItems={AlignItems.Center}
-          direction={FlexDirection.Row}
-          margin={ComponentSize.Medium}
-          className="header-wrap"
+        <Heading
+          element={HeadingElement.H3}
+          weight={FontWeight.Bold}
+          className="string-parsing-form__header"
         >
-          <Heading
-            element={HeadingElement.H3}
-            weight={FontWeight.Bold}
-            className="header-wrap__header"
-          >
-            {name}
-          </Heading>
-          {(tagType
-            ? !(formContent.stringTags.length === 0)
-            : !(formContent.stringFields.length === 1)) && (
-            <ConfirmationButton
-              color={ComponentColor.Colorless}
-              icon={IconFont.Trash_New}
-              shape={ButtonShape.Square}
-              size={ComponentSize.ExtraSmall}
-              confirmationLabel={`Yes, delete this ${name}`}
-              onConfirm={() => {
-                event(
-                  'removed string parsing rule',
-                  {ruleType: tagType ? 'tag' : 'field'},
-                  {feature: 'subscriptions'}
-                )
-                if (tagType) {
-                  formContent.stringTags.splice(itemNum, 1)
-                } else {
-                  formContent.stringFields.splice(itemNum, 1)
-                }
-                updateForm({...formContent})
-              }}
-              confirmationButtonText="Confirm"
-              testID={`${name}-string-delete-label`}
-            />
-          )}
-        </FlexBox>
+          {name}
+        </Heading>
+        {(tagType
+          ? !(formContent.stringTags.length === 0)
+          : !(formContent.stringFields.length === 1)) && (
+          <ConfirmationButton
+            color={ComponentColor.Colorless}
+            icon={IconFont.Trash_New}
+            shape={ButtonShape.Square}
+            size={ComponentSize.ExtraSmall}
+            confirmationLabel={`Yes, delete this ${name}`}
+            onConfirm={() => {
+              event(
+                'removed string parsing rule',
+                {ruleType: tagType ? 'tag' : 'field'},
+                {feature: 'subscriptions'}
+              )
+              if (tagType) {
+                formContent.stringTags.splice(itemNum, 1)
+              } else {
+                formContent.stringFields.splice(itemNum, 1)
+              }
+              updateForm({...formContent})
+            }}
+            confirmationButtonText="Confirm"
+            testID={`${name}-string-delete-label`}
+          />
+        )}
         <ValidationInputWithTooltip
           label="Name"
           name="name"


### PR DESCRIPTION
Closes https://github.com/influxdata/data-acquisition/issues/218

- Adds links to documentation for native subs, json parsing and string parsing. Doc links shown on create and edit but not on details view.

- Links to our documentation, json path and regex101.

- Adds timestamp headers as I noticed they were missing while editing.

- Cleans up styling discrepancies.

**Video:**

https://user-images.githubusercontent.com/38860767/181568328-e74dad17-8bc2-4070-a63e-958ce8562846.mov

**Screenshots:**

Create subscription:
<img width="1496" alt="Screen Shot 2022-07-28 at 10 29 56 AM" src="https://user-images.githubusercontent.com/38860767/181567040-5f1d97f9-5014-4000-b97f-04901b3cdf35.png">

Create json parsing:
<img width="1490" alt="Screen Shot 2022-07-28 at 10 30 13 AM" src="https://user-images.githubusercontent.com/38860767/181567096-5057d6d4-7a73-4df3-89f7-4387e03eaa76.png">

Create string parsing:
<img width="1418" alt="Screen Shot 2022-07-28 at 10 45 40 AM" src="https://user-images.githubusercontent.com/38860767/181567141-c114466c-ea6c-43b2-9e75-93bd7c876342.png">

Edit view subscription:
<img width="1452" alt="Screen Shot 2022-07-28 at 10 40 35 AM" src="https://user-images.githubusercontent.com/38860767/181567302-de4c39f6-d35e-4197-b135-dac256e76796.png">

Edit view string parsing:
<img width="1418" alt="Screen Shot 2022-07-28 at 10 45 40 AM" src="https://user-images.githubusercontent.com/38860767/181567419-029aaa2b-347d-4b02-a352-bc944801fdd8.png">

Edit view json parsing:
<img width="1150" alt="Screen Shot 2022-07-28 at 10 51 36 AM" src="https://user-images.githubusercontent.com/38860767/181567648-84d9203f-bccb-4769-904a-99ef905c50db.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
