### PR TITLE
perf(dashboards): add reselect, memoize cell selector

### DIFF
--- a/package.json
+++ b/package.json
@@ -218,6 +218,7 @@
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0",
     "remark-external-links": "8.0.0",
+    "reselect": "^4.1.6",
     "rudder-sdk-js": "^1.0.16",
     "s2-geometry": "^1.2.10",
     "use-local-storage-state": "^9.0.2",

--- a/src/cells/selectors/index.ts
+++ b/src/cells/selectors/index.ts
@@ -1,17 +1,23 @@
+import {createSelector} from 'reselect'
+
 import {AppState, Cell} from 'src/types'
 
-export const getCells = (
-  {resources}: AppState,
-  dashboardID: string
-): Cell[] => {
-  const dashboard = resources.dashboards.byID[dashboardID]
-  if (!dashboard || !dashboard.cells) {
-    return []
+const getResources = (state: AppState) => state.resources
+const getDashboardId = (_, dashboardID) => dashboardID
+
+export const getCells = createSelector(
+  getResources,
+  getDashboardId,
+  (resources, dashboardId): Cell[] => {
+    const dashboard = resources.dashboards.byID[dashboardId]
+    if (!dashboard || !dashboard.cells) {
+      return []
+    }
+
+    const cellIds = dashboard.cells
+
+    return cellIds
+      .filter(cellId => Boolean(resources.cells.byID[cellId]))
+      .map(cellId => resources.cells.byID[cellId])
   }
-
-  const cellIDs = dashboard.cells
-
-  return cellIDs
-    .filter(id => !!resources.cells.byID[id]) // added filter since it was returning undefined cells
-    .map(id => resources.cells.byID[id])
-}
+)

--- a/yarn.lock
+++ b/yarn.lock
@@ -10318,6 +10318,11 @@ requires-port@^1.0.0:
   resolved "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
+reselect@^4.1.6:
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.6.tgz#19ca2d3d0b35373a74dc1c98692cdaffb6602656"
+  integrity sha512-ZovIuXqto7elwnxyXbBtCPo9YFEr3uJqj2rRbcOOog1bmu2Ag85M4hixSwFWyaBMKXNgvPaJ9OSu9SkBPIeJHQ==
+
 resolve-cwd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz"


### PR DESCRIPTION
Connects #5234

- Adds reselect library
- Uses reselect's `createSelector` to memoize the dashboard cell selector

This provides minimal performance gains, but gaining performance on dashboards is going to be a marathon, not a sprint.

Attached are two screenshots which perform a very simple performance test - a console log statement - on a dashboard with 4 cells.

### Before
| Function Name | Function calls |
|---------------|----------------|
| Cell Selector | 18             |
| Cell Render   | 9 * 4 = 36     |

### After
| Function Name | Function calls |
|---------------|----------------|
| Cell Selector | 1             |
| Cell Render   | 1 * 4 = 4     |

### Before
![Screen Shot 2022-07-28 at 5 01 55 PM](https://user-images.githubusercontent.com/146112/181637617-60db2851-7ab6-4bc3-b913-681ce247d4ee.png)

### After
![Screen Shot 2022-07-28 at 5 01 08 PM](https://user-images.githubusercontent.com/146112/181637606-c80ce654-6d7a-4210-b5a9-94ec117336ad.png)


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- ~[ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~
- ~[ ] Feature flagged, if applicable~
