### PR TITLE
fix: optional bucket retention

### DIFF
--- a/src/buckets/components/createBucketForm/CreateBucketForm.tsx
+++ b/src/buckets/components/createBucketForm/CreateBucketForm.tsx
@@ -69,7 +69,7 @@ export const CreateBucketForm: FC<CreateBucketFormProps> = props => {
   ] = useState(null)
   const [showSchemaValidation, setShowSchemaValidation] = useState(false)
 
-  const retentionRule = state.retentionRules.find(
+  const retentionRule = state.retentionRules?.find(
     (rule: RetentionRule) => rule.type === 'expire'
   )
   const retentionSeconds = retentionRule ? retentionRule.everySeconds : 3600

--- a/src/schemas/buckets.ts
+++ b/src/schemas/buckets.ts
@@ -9,7 +9,7 @@ import {labelSchema} from './labels'
 import {ruleToString} from 'src/utils/formatting'
 
 export const getReadableRetention = (bucket: GenBucket): string => {
-  const expire = bucket.retentionRules.find(rule => rule.type === 'expire')
+  const expire = bucket.retentionRules?.find(rule => rule.type === 'expire')
 
   if (!expire) {
     return 'forever'

--- a/src/timeMachine/components/SelectorListCreateBucket.tsx
+++ b/src/timeMachine/components/SelectorListCreateBucket.tsx
@@ -83,7 +83,7 @@ const SelectorListCreateBucket: FC<Props> = ({
     buttonDisabled = true
   }
 
-  const retentionRule = state.retentionRules.find(r => r.type === 'expire')
+  const retentionRule = state.retentionRules?.find(r => r.type === 'expire')
   const retentionSeconds = retentionRule ? retentionRule.everySeconds : 3600
 
   const handleChangeRuleType = (ruleType: RuleType): void => {


### PR DESCRIPTION
Addresses [#](https://github.com/influxdata/ui/issues/5127)

i can't reproduce this one, but there's only one place in the code that matches the pattern from the referenced issue. it's a path where the shared bucket context loads a bucket into the redux store that doesn't have a retention rule. technically, the line just under this updated guard says "dont worry about it, it's cool" so it seems that this state is supported, just not guarded correctly