### PR TITLE
fix: calculate the correct heights for the header and rows in SimpleTable

### DIFF
--- a/src/visualization/types/SimpleTable/InnerTable.tsx
+++ b/src/visualization/types/SimpleTable/InnerTable.tsx
@@ -1,17 +1,17 @@
-import React, {FC} from 'react'
+import React, {FC, Ref} from 'react'
 import {ComponentSize, Table, VerticalAlignment} from '@influxdata/clockface'
 import {SubsetTable} from 'src/visualization/types/SimpleTable'
 
 interface InnerProps {
   table: SubsetTable
-  pagedTableIds: {
-    pagedTableHeaderId: string
-    pagedTableBodyId: string
+  pagedTableRefs: {
+    pagedTableHeaderRef: Ref<HTMLTableSectionElement>
+    pagedTableBodyRef: Ref<HTMLTableSectionElement>
   }
 }
 
 const InnerTable: FC<InnerProps> = ({
-  pagedTableIds: {pagedTableHeaderId, pagedTableBodyId},
+  pagedTableRefs: {pagedTableHeaderRef, pagedTableBodyRef},
   table,
 }) => {
   const headers = Object.values(table.cols).map(c => {
@@ -68,10 +68,10 @@ const InnerTable: FC<InnerProps> = ({
       highlight
       testID="simple-table"
     >
-      <Table.Header id={pagedTableHeaderId}>
+      <Table.Header ref={pagedTableHeaderRef}>
         <Table.Row>{headers}</Table.Row>
       </Table.Header>
-      <Table.Body id={pagedTableBodyId}>{rows}</Table.Body>
+      <Table.Body ref={pagedTableBodyRef}>{rows}</Table.Body>
     </Table>
   )
 }

--- a/src/visualization/types/SimpleTable/InnerTable.tsx
+++ b/src/visualization/types/SimpleTable/InnerTable.tsx
@@ -4,9 +4,16 @@ import {SubsetTable} from 'src/visualization/types/SimpleTable'
 
 interface InnerProps {
   table: SubsetTable
+  pagedTableIds: {
+    pagedTableHeaderId: string
+    pagedTableBodyId: string
+  }
 }
 
-const InnerTable: FC<InnerProps> = ({table}) => {
+const InnerTable: FC<InnerProps> = ({
+  pagedTableIds: {pagedTableHeaderId, pagedTableBodyId},
+  table,
+}) => {
   const headers = Object.values(table.cols).map(c => {
     if (c.name === 'table') {
       return (
@@ -61,10 +68,10 @@ const InnerTable: FC<InnerProps> = ({table}) => {
       highlight
       testID="simple-table"
     >
-      <Table.Header>
+      <Table.Header id={pagedTableHeaderId}>
         <Table.Row>{headers}</Table.Row>
       </Table.Header>
-      <Table.Body>{rows}</Table.Body>
+      <Table.Body id={pagedTableBodyId}>{rows}</Table.Body>
     </Table>
   )
 }

--- a/src/visualization/types/SimpleTable/PagedTable.tsx
+++ b/src/visualization/types/SimpleTable/PagedTable.tsx
@@ -6,6 +6,7 @@ import React, {
   useEffect,
   useState,
 } from 'react'
+import {nanoid} from 'nanoid'
 import {DapperScrollbars} from '@influxdata/clockface'
 import {FluxDataType} from '@influxdata/giraffe'
 import {
@@ -221,9 +222,6 @@ interface Props {
   result: FluxResult['parsed']
 }
 
-const pagedTableHeaderId = 'pagedTableRowId'
-const pagedTableBodyId = 'pagedTabledBodyId'
-
 const PagedTable: FC<Props> = ({result, properties}) => {
   const {
     offset,
@@ -233,31 +231,39 @@ const PagedTable: FC<Props> = ({result, properties}) => {
     setPage,
     setTotalPages,
   } = useContext(PaginationContext)
+  const [pagedTableHeaderId] = useState<string>(nanoid())
+  const [pagedTableBodyId] = useState<string>(nanoid())
   const [height, setHeight] = useState(0)
   const [headerHeight, setHeaderHeight] = useState(0)
   const [rowHeight, setRowHeight] = useState(0)
   const ref = useRef()
 
-  if (headerHeight === 0) {
-    const calculatedHeaderHeight =
-      document.querySelector<HTMLElement>(`#${pagedTableHeaderId}`)
-        ?.offsetHeight ?? 0
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    if (headerHeight === 0) {
+      const calculatedHeaderHeight =
+        document.querySelector<HTMLElement>(`#${pagedTableHeaderId}`)
+          ?.offsetHeight ?? 0
 
-    if (calculatedHeaderHeight !== headerHeight) {
-      setHeaderHeight(calculatedHeaderHeight)
+      if (calculatedHeaderHeight !== headerHeight) {
+        setHeaderHeight(calculatedHeaderHeight)
+      }
     }
-  }
+  })
 
-  if (rowHeight === 0) {
-    const calculatedRowHeight =
-      document.querySelector<HTMLElement>(
-        `#${pagedTableBodyId} > .cf-table--row`
-      )?.offsetHeight ?? 0
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    if (rowHeight === 0) {
+      const calculatedRowHeight =
+        document.querySelector<HTMLElement>(
+          `#${pagedTableBodyId} > .cf-table--row`
+        )?.offsetHeight ?? 0
 
-    if (calculatedRowHeight !== rowHeight) {
-      setRowHeight(calculatedRowHeight)
+      if (calculatedRowHeight !== rowHeight) {
+        setRowHeight(calculatedRowHeight)
+      }
     }
-  }
+  })
 
   // this makes sure that the table is always filling it's parent container
   useEffect(() => {

--- a/src/visualization/types/SimpleTable/PagedTable.tsx
+++ b/src/visualization/types/SimpleTable/PagedTable.tsx
@@ -24,13 +24,12 @@ interface ExtendedColumn {
   data: any[]
 }
 
-const HEADER_HEIGHT = 51
-const ROW_HEIGHT = 25
-
 const measurePage = (
   result: FluxResult['parsed'],
   offset: number,
-  height: number
+  height: number,
+  headerHeight: number,
+  rowHeight: number
 ): number => {
   if (height === 0) {
     return 0
@@ -54,7 +53,7 @@ const measurePage = (
         .join('|')
 
       if (signature !== lastSignature) {
-        runningHeight += HEADER_HEIGHT
+        runningHeight += headerHeight
 
         if (currentTable !== undefined) {
           runningHeight += 10
@@ -72,7 +71,7 @@ const measurePage = (
       continue
     }
 
-    runningHeight += ROW_HEIGHT
+    runningHeight += rowHeight
 
     if (runningHeight >= height) {
       break
@@ -222,6 +221,9 @@ interface Props {
   result: FluxResult['parsed']
 }
 
+const pagedTableHeaderId = 'pagedTableRowId'
+const pagedTableBodyId = 'pagedTabledBodyId'
+
 const PagedTable: FC<Props> = ({result, properties}) => {
   const {
     offset,
@@ -232,7 +234,30 @@ const PagedTable: FC<Props> = ({result, properties}) => {
     setTotalPages,
   } = useContext(PaginationContext)
   const [height, setHeight] = useState(0)
+  const [headerHeight, setHeaderHeight] = useState(0)
+  const [rowHeight, setRowHeight] = useState(0)
   const ref = useRef()
+
+  if (headerHeight === 0) {
+    const calculatedHeaderHeight =
+      document.querySelector<HTMLElement>(`#${pagedTableHeaderId}`)
+        ?.offsetHeight ?? 0
+
+    if (calculatedHeaderHeight !== headerHeight) {
+      setHeaderHeight(calculatedHeaderHeight)
+    }
+  }
+
+  if (rowHeight === 0) {
+    const calculatedRowHeight =
+      document.querySelector<HTMLElement>(
+        `#${pagedTableBodyId} > .cf-table--row`
+      )?.offsetHeight ?? 0
+
+    if (calculatedRowHeight !== rowHeight) {
+      setRowHeight(calculatedRowHeight)
+    }
+  }
 
   // this makes sure that the table is always filling it's parent container
   useEffect(() => {
@@ -274,8 +299,8 @@ const PagedTable: FC<Props> = ({result, properties}) => {
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const size = useMemo(() => {
-    return measurePage(result, offset, height)
-  }, [result, offset, height])
+    return measurePage(result, offset, height, headerHeight, rowHeight)
+  }, [result, offset, height, headerHeight, rowHeight])
   const tables = useMemo(() => {
     return subsetResult(result, offset, size, properties.showAll)
   }, [result, offset, size]) // eslint-disable-line react-hooks/exhaustive-deps
@@ -285,8 +310,8 @@ const PagedTable: FC<Props> = ({result, properties}) => {
   }, [size]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
-    setMaxSize(measurePage(result, 0, height))
-  }, [height, result]) // eslint-disable-line react-hooks/exhaustive-deps
+    setMaxSize(measurePage(result, 0, height, headerHeight, rowHeight))
+  }, [result, height, headerHeight, rowHeight]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     setPage(1)
@@ -300,7 +325,16 @@ const PagedTable: FC<Props> = ({result, properties}) => {
 
   const inner =
     !!size &&
-    tables.map((t, tIdx) => <InnerTable table={t} key={`table${tIdx}`} />)
+    tables.map((t, tIdx) => (
+      <InnerTable
+        table={t}
+        pagedTableIds={{
+          pagedTableHeaderId,
+          pagedTableBodyId,
+        }}
+        key={`table${tIdx}`}
+      />
+    ))
 
   return (
     <div className="visualization--simple-table--results" ref={ref}>

--- a/src/visualization/types/SimpleTable/PagedTable.tsx
+++ b/src/visualization/types/SimpleTable/PagedTable.tsx
@@ -231,8 +231,8 @@ const PagedTable: FC<Props> = ({result, properties}) => {
     setPage,
     setTotalPages,
   } = useContext(PaginationContext)
-  const [pagedTableHeaderId] = useState<string>(nanoid())
-  const [pagedTableBodyId] = useState<string>(nanoid())
+  const [pagedTableHeaderId] = useState<string>(`pTH-${nanoid()}`)
+  const [pagedTableBodyId] = useState<string>(`pTB-${nanoid()}`)
   const [height, setHeight] = useState(0)
   const [headerHeight, setHeaderHeight] = useState(0)
   const [rowHeight, setRowHeight] = useState(0)

--- a/src/visualization/types/SimpleTable/PagedTable.tsx
+++ b/src/visualization/types/SimpleTable/PagedTable.tsx
@@ -73,7 +73,7 @@ const measurePage = (
 
     runningHeight += rowHeight
 
-    if (runningHeight >= height) {
+    if (runningHeight + 0.25 * rowHeight >= height) {
       break
     }
 

--- a/src/visualization/types/SimpleTable/PagedTable.tsx
+++ b/src/visualization/types/SimpleTable/PagedTable.tsx
@@ -1,12 +1,11 @@
 import React, {
   FC,
   useContext,
+  useEffect,
   useMemo,
   useRef,
-  useEffect,
   useState,
 } from 'react'
-import {nanoid} from 'nanoid'
 import {DapperScrollbars} from '@influxdata/clockface'
 import {FluxDataType} from '@influxdata/giraffe'
 import {
@@ -231,19 +230,18 @@ const PagedTable: FC<Props> = ({result, properties}) => {
     setPage,
     setTotalPages,
   } = useContext(PaginationContext)
-  const [pagedTableHeaderId] = useState<string>(`pTH-${nanoid()}`)
-  const [pagedTableBodyId] = useState<string>(`pTB-${nanoid()}`)
-  const [height, setHeight] = useState(0)
-  const [headerHeight, setHeaderHeight] = useState(0)
-  const [rowHeight, setRowHeight] = useState(0)
-  const ref = useRef()
+  const [height, setHeight] = useState<number>(0)
+  const [headerHeight, setHeaderHeight] = useState<number>(0)
+  const [rowHeight, setRowHeight] = useState<number>(0)
+  const ref = useRef<HTMLDivElement>()
+  const pagedTableHeaderRef = useRef<HTMLTableSectionElement>()
+  const pagedTableBodyRef = useRef<HTMLTableSectionElement>()
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
-    if (headerHeight === 0) {
+    if (headerHeight === 0 && pagedTableHeaderRef?.current) {
       const calculatedHeaderHeight =
-        document.querySelector<HTMLElement>(`#${pagedTableHeaderId}`)
-          ?.offsetHeight ?? 0
+        pagedTableHeaderRef.current.clientHeight ?? 0
 
       if (calculatedHeaderHeight !== headerHeight) {
         setHeaderHeight(calculatedHeaderHeight)
@@ -253,11 +251,9 @@ const PagedTable: FC<Props> = ({result, properties}) => {
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
-    if (rowHeight === 0) {
+    if (rowHeight === 0 && pagedTableBodyRef?.current) {
       const calculatedRowHeight =
-        document.querySelector<HTMLElement>(
-          `#${pagedTableBodyId} > .cf-table--row`
-        )?.offsetHeight ?? 0
+        pagedTableBodyRef.current?.children?.[0].clientHeight ?? 0
 
       if (calculatedRowHeight !== rowHeight) {
         setRowHeight(calculatedRowHeight)
@@ -334,11 +330,8 @@ const PagedTable: FC<Props> = ({result, properties}) => {
     tables.map((t, tIdx) => (
       <InnerTable
         table={t}
-        pagedTableIds={{
-          pagedTableHeaderId,
-          pagedTableBodyId,
-        }}
         key={`table${tIdx}`}
+        pagedTableRefs={{pagedTableHeaderRef, pagedTableBodyRef}}
       />
     ))
 


### PR DESCRIPTION
Closes #5239  

- Instead of using old and incorrect values for the header and row heights of the SimpleTable, calculate them.
- This allows SimpleTable to make all rows visible without relying on vertical scrolling.
- **_There must be enough vertical space to fit at least 25% of the height of the next row for that row to render._**


https://user-images.githubusercontent.com/10736577/181658050-05cc838a-e5a1-4823-95e4-89a8c8eaeb32.mp4

