### PR TITLE
test: e2e testing for CLI and firstMile

### DIFF
--- a/cypress/e2e/shared/firstmile.tests.ts
+++ b/cypress/e2e/shared/firstmile.tests.ts
@@ -1,85 +1,86 @@
-describe('First mile experience', () => {
-  beforeEach(() => {
-    cy.flush()
-    cy.signin()
-    cy.setFeatureFlags({firstMile: true})
-  })
-
-  it('should load the main home-page that has the language tiles', function() {
-    cy.getByTestID('home-page--header').should('exist')
-    cy.getByTestID('language-tiles--scrollbox').should('exist')
-  })
-
-  describe('Python', () => {
+for (let i = 0; i < 20; i++) {
+  describe('First mile experience', () => {
     beforeEach(() => {
-      cy.getByTestID('homepage-wizard-language-tile--python').click()
-    })
-    it("runs through the python's wizard pages", function() {
-      cy.getByTestID('subway-nav').should('exist')
-
-      // first page is overview
-      cy.contains('Hello, Time-Series World!')
-
-      // second page is install dependencies
-      cy.contains('Next').click()
-      cy.contains('Install Dependencies')
-
-      // third page is create token
-      cy.contains('Next').click()
-      cy.contains('Create a Token')
-
-      // fourth page is initalize client
-      cy.contains('Next').click()
-      cy.contains('Initalize Client')
-
-      // fifth page is write data
-      cy.contains('Next').click()
-      cy.contains('Write Data')
-
-      // sixth page is execute query
-      cy.contains('Next').click()
-      cy.contains('Execute a Flux Query')
-
-      // seventh page is execute aggregate query
-      cy.contains('Next').click()
-      cy.contains('Execute an Aggregate Query')
-
-      // eight page is finish
-      cy.contains('Next').click()
-      cy.contains('Congrats!')
+      cy.flush()
+      cy.signin()
+      cy.setFeatureFlags({firstMile: true})
     })
 
-    describe('Subway Nav Bar', () => {
-      it('navigates to the correct page when the respective navigation button is clicked', function() {
-        cy.get('h1').contains('Hello, Time-Series World!')
+    it('should load the main home-page that has the language tiles', function() {
+      cy.getByTestID('home-page--header').should('exist')
+    })
 
-        cy.contains('Previous').should('be.disabled')
+    describe('Python', () => {
+      beforeEach(() => {
+        cy.getByTestID('homepage-wizard-language-tile--python').click()
+      })
+      it("runs through the python's wizard pages", function() {
+        cy.getByTestID('subway-nav').should('exist')
 
-        cy.contains('Install Dependencies').click()
-        cy.get('h1').contains('Install Dependencies')
+        // first page is overview
+        cy.contains('Hello, Time-Series World!')
 
-        cy.contains('Previous').should('not.be.disabled')
+        // second page is install dependencies
+        cy.getByTestID('python-next-button').click()
+        cy.contains('Install Dependencies')
 
-        cy.contains('Create a Token').click()
-        cy.get('h1').contains('Create a Token')
+        // third page is create token
+        cy.getByTestID('python-next-button').click()
+        cy.contains('Tokens')
 
-        cy.contains('Initialize Client').click()
-        cy.get('h1').contains('Initialize Client')
+        // fourth page is initalize client
+        cy.getByTestID('python-next-button').click()
+        cy.contains('Initialize Client')
 
-        cy.contains('Write Data').click()
-        cy.get('h1').contains('Write Data')
+        // fifth page is write data
+        cy.getByTestID('python-next-button').click()
+        cy.contains('Write Data')
 
-        cy.contains('Execute a Simple Query').click()
+        // sixth page is execute query
+        cy.getByTestID('python-next-button').click()
         cy.contains('Execute a Flux Query')
 
-        cy.contains('Execute an Aggregate Query').click()
-        cy.get('h1').contains('Execute an Aggregate Query')
+        // seventh page is execute aggregate query
+        cy.getByTestID('python-next-button').click()
+        cy.contains('Execute an Aggregate Query')
 
-        cy.contains('Finish').click()
+        // eight page is finish
+        cy.getByTestID('python-next-button').click()
         cy.contains('Congrats!')
+      })
 
-        cy.contains('Next').should('be.disabled')
+      describe('Subway Nav Bar', () => {
+        it('navigates to the correct page when the respective navigation button is clicked', function() {
+          cy.get('h1').contains('Hello, Time-Series World!')
+
+          cy.getByTestID('python-prev-button').should('be.disabled')
+
+          cy.contains(/^Install Dependencies$/).click()
+          cy.get('h1').contains('Install Dependencies')
+
+          cy.contains('Previous').should('not.be.disabled')
+
+          cy.contains(/^Tokens$/).click()
+          cy.get('h1').contains('Tokens')
+
+          cy.contains(/^Initialize Client$/).click()
+          cy.get('h1').contains('Initialize Client')
+
+          cy.contains(/^Write Data$/).click()
+          cy.get('h1').contains('Write Data')
+
+          cy.contains(/^Execute a Simple Query$/).click()
+          cy.contains('Execute a Flux Query')
+
+          cy.contains(/^Execute an Aggregate Query$/).click()
+          cy.get('h1').contains('Execute an Aggregate Query')
+
+          cy.contains(/^Finish$/).click()
+          cy.contains('Congrats!')
+
+          cy.getByTestID('python-next-button').should('be.disabled')
+        })
       })
     })
   })
-})
+}

--- a/cypress/e2e/shared/firstmile.tests.ts
+++ b/cypress/e2e/shared/firstmile.tests.ts
@@ -1,86 +1,84 @@
-for (let i = 0; i < 20; i++) {
-  describe('First mile experience', () => {
+describe('First mile experience', () => {
+  beforeEach(() => {
+    cy.flush()
+    cy.signin()
+    cy.setFeatureFlags({firstMile: true})
+  })
+
+  it('should load the main home-page that has the language tiles', function() {
+    cy.getByTestID('home-page--header').should('exist')
+  })
+
+  describe('Python', () => {
     beforeEach(() => {
-      cy.flush()
-      cy.signin()
-      cy.setFeatureFlags({firstMile: true})
+      cy.getByTestID('homepage-wizard-language-tile--python').click()
+    })
+    it("runs through the python's wizard pages", function() {
+      cy.getByTestID('subway-nav').should('exist')
+
+      // first page is overview
+      cy.contains('Hello, Time-Series World!')
+
+      // second page is install dependencies
+      cy.getByTestID('python-next-button').click()
+      cy.contains('Install Dependencies')
+
+      // third page is create token
+      cy.getByTestID('python-next-button').click()
+      cy.contains('Tokens')
+
+      // fourth page is initalize client
+      cy.getByTestID('python-next-button').click()
+      cy.contains('Initialize Client')
+
+      // fifth page is write data
+      cy.getByTestID('python-next-button').click()
+      cy.contains('Write Data')
+
+      // sixth page is execute query
+      cy.getByTestID('python-next-button').click()
+      cy.contains('Execute a Flux Query')
+
+      // seventh page is execute aggregate query
+      cy.getByTestID('python-next-button').click()
+      cy.contains('Execute an Aggregate Query')
+
+      // eight page is finish
+      cy.getByTestID('python-next-button').click()
+      cy.contains('Congrats!')
     })
 
-    it('should load the main home-page that has the language tiles', function() {
-      cy.getByTestID('home-page--header').should('exist')
-    })
+    describe('Subway Nav Bar', () => {
+      it('navigates to the correct page when the respective navigation button is clicked', function() {
+        cy.get('h1').contains('Hello, Time-Series World!')
 
-    describe('Python', () => {
-      beforeEach(() => {
-        cy.getByTestID('homepage-wizard-language-tile--python').click()
-      })
-      it("runs through the python's wizard pages", function() {
-        cy.getByTestID('subway-nav').should('exist')
+        cy.getByTestID('python-prev-button').should('be.disabled')
 
-        // first page is overview
-        cy.contains('Hello, Time-Series World!')
+        cy.contains(/^Install Dependencies$/).click()
+        cy.get('h1').contains('Install Dependencies')
 
-        // second page is install dependencies
-        cy.getByTestID('python-next-button').click()
-        cy.contains('Install Dependencies')
+        cy.contains('Previous').should('not.be.disabled')
 
-        // third page is create token
-        cy.getByTestID('python-next-button').click()
-        cy.contains('Tokens')
+        cy.contains(/^Tokens$/).click()
+        cy.get('h1').contains('Tokens')
 
-        // fourth page is initalize client
-        cy.getByTestID('python-next-button').click()
-        cy.contains('Initialize Client')
+        cy.contains(/^Initialize Client$/).click()
+        cy.get('h1').contains('Initialize Client')
 
-        // fifth page is write data
-        cy.getByTestID('python-next-button').click()
-        cy.contains('Write Data')
+        cy.contains(/^Write Data$/).click()
+        cy.get('h1').contains('Write Data')
 
-        // sixth page is execute query
-        cy.getByTestID('python-next-button').click()
+        cy.contains(/^Execute a Simple Query$/).click()
         cy.contains('Execute a Flux Query')
 
-        // seventh page is execute aggregate query
-        cy.getByTestID('python-next-button').click()
-        cy.contains('Execute an Aggregate Query')
+        cy.contains(/^Execute an Aggregate Query$/).click()
+        cy.get('h1').contains('Execute an Aggregate Query')
 
-        // eight page is finish
-        cy.getByTestID('python-next-button').click()
+        cy.contains(/^Finish$/).click()
         cy.contains('Congrats!')
-      })
 
-      describe('Subway Nav Bar', () => {
-        it('navigates to the correct page when the respective navigation button is clicked', function() {
-          cy.get('h1').contains('Hello, Time-Series World!')
-
-          cy.getByTestID('python-prev-button').should('be.disabled')
-
-          cy.contains(/^Install Dependencies$/).click()
-          cy.get('h1').contains('Install Dependencies')
-
-          cy.contains('Previous').should('not.be.disabled')
-
-          cy.contains(/^Tokens$/).click()
-          cy.get('h1').contains('Tokens')
-
-          cy.contains(/^Initialize Client$/).click()
-          cy.get('h1').contains('Initialize Client')
-
-          cy.contains(/^Write Data$/).click()
-          cy.get('h1').contains('Write Data')
-
-          cy.contains(/^Execute a Simple Query$/).click()
-          cy.contains('Execute a Flux Query')
-
-          cy.contains(/^Execute an Aggregate Query$/).click()
-          cy.get('h1').contains('Execute an Aggregate Query')
-
-          cy.contains(/^Finish$/).click()
-          cy.contains('Congrats!')
-
-          cy.getByTestID('python-next-button').should('be.disabled')
-        })
+        cy.getByTestID('python-next-button').should('be.disabled')
       })
     })
   })
-}
+})

--- a/cypress/e2e/shared/influxCLI.test.ts
+++ b/cypress/e2e/shared/influxCLI.test.ts
@@ -2,18 +2,75 @@ describe('Influx CLI onboarding', () => {
   beforeEach(() => {
     cy.flush()
     cy.signin()
-    cy.setFeatureFlags({firstMile: true})
-    cy.setFeatureFlags({onboardCLI: true})
+    cy.setFeatureFlags({firstMile: true, onboardCLI: true})
   })
 
-  it('should load the main home-page that has the language tiles', function() {
+  it('should load the main home-page that has the cli tile', function() {
     cy.getByTestID('home-page--header').should('exist')
-    cy.getByTestID('language-tiles--scrollbox').should('exist')
   })
 
   describe('InfluxCLI', () => {
     beforeEach(() => {
       cy.getByTestID('homepage-wizard-tile--cli').click()
+    })
+    it('runs through the cli wizard pages', function() {
+      cy.getByTestID('subway-nav').should('exist')
+
+      // first page is overview
+      cy.contains('Hello, Time-Series World!')
+
+      // second page is install dependencies
+      cy.getByTestID('cli-next-button').click()
+      cy.contains('Install Dependencies')
+
+      // third page is initialize client
+      cy.getByTestID('cli-next-button').click()
+      cy.contains('Initialize Client')
+
+      // fourth page is write data
+      cy.getByTestID('cli-next-button').click()
+      cy.contains('Write Data')
+
+      // fifth page is execute query
+      cy.getByTestID('cli-next-button').click()
+      cy.contains('Execute a Flux Query')
+
+      // sixth page is execute aggregate query
+      cy.getByTestID('cli-next-button').click()
+      cy.contains('Execute a Flux Aggregate Query')
+
+      // seventh page is finish
+      cy.getByTestID('cli-next-button').click()
+      cy.contains('Congrats!')
+    })
+    describe('Subway Nav Bar', () => {
+      it('navigates to the correct page when the respective navigation button is clicked', function() {
+        cy.get('h1').contains('Hello, Time-Series World!')
+
+        cy.getByTestID('cli-prev-button').should('be.disabled')
+
+        cy.contains(/^Install Dependencies$/).click()
+        cy.get('h1').contains('Install Dependencies')
+
+        cy.getByTestID('cli-prev-button').should('not.be.disabled')
+
+        cy.contains(/^Initialize Client$/).click()
+        cy.get('h1').contains('Initialize Client')
+
+        cy.contains(/^Write Data$/).click()
+        cy.get('h1').contains('Write Data')
+
+        cy.contains(/^Execute Flux Query$/).click()
+        cy.contains('Execute a Flux Query')
+
+        cy.contains(/^Execute Aggregate$/).click()
+        cy.get('h1').contains('Execute a Flux Aggregate Query')
+
+        cy.contains(/^Finished!$/).click()
+        cy.contains('Congrats!')
+
+        cy.getByTestID('cli-next-button').should('be.disabled')
+      })
     })
   })
 })

--- a/cypress/e2e/shared/influxCLI.test.ts
+++ b/cypress/e2e/shared/influxCLI.test.ts
@@ -1,7 +1,19 @@
 describe('Influx CLI onboarding', () => {
-    beforeEach(() => {
-        cy.flush()
+  beforeEach(() => {
+    cy.flush()
     cy.signin()
+    cy.setFeatureFlags({firstMile: true})
     cy.setFeatureFlags({onboardCLI: true})
+  })
+
+  it('should load the main home-page that has the language tiles', function() {
+    cy.getByTestID('home-page--header').should('exist')
+    cy.getByTestID('language-tiles--scrollbox').should('exist')
+  })
+
+  describe('InfluxCLI', () => {
+    beforeEach(() => {
+      cy.getByTestID('homepage-wizard-tile--cli').click()
     })
+  })
 })

--- a/cypress/e2e/shared/influxCLI.test.ts
+++ b/cypress/e2e/shared/influxCLI.test.ts
@@ -1,0 +1,7 @@
+describe('Influx CLI onboarding', () => {
+    beforeEach(() => {
+        cy.flush()
+    cy.signin()
+    cy.setFeatureFlags({onboardCLI: true})
+    })
+})

--- a/src/homepageExperience/containers/HomepageContainer.tsx
+++ b/src/homepageExperience/containers/HomepageContainer.tsx
@@ -190,7 +190,10 @@ export const HomepageContainer: FC = () => {
                     style={linkStyle}
                     onClick={logCLIButtonClick}
                   >
-                    <div className="homepage-write-data-tile">
+                    <div
+                      className="homepage-write-data-tile"
+                      data-testid="homepage-wizard-tile--cli"
+                    >
                       <div className="tile-icon-text-wrapper">
                         <div className="icon">{CLIIcon}</div>
                         <div>

--- a/src/homepageExperience/containers/PythonWizard.tsx
+++ b/src/homepageExperience/containers/PythonWizard.tsx
@@ -201,6 +201,7 @@ export class PythonWizard extends PureComponent<null, State> {
                       ? ComponentStatus.Default
                       : ComponentStatus.Disabled
                   }
+                  testID="python-prev-button"
                 />
                 <Button
                   onClick={this.handleNextClick}
@@ -212,6 +213,7 @@ export class PythonWizard extends PureComponent<null, State> {
                       ? ComponentStatus.Default
                       : ComponentStatus.Disabled
                   }
+                  testID="python-next-button"
                 />
               </div>
             </div>

--- a/src/homepageExperience/utils.ts
+++ b/src/homepageExperience/utils.ts
@@ -6,7 +6,7 @@ export const HOMEPAGE_NAVIGATION_STEPS = [
     glyph: IconFont.BookOutline,
   },
   {
-    name: 'Install\nDependencies',
+    name: `Install\n Dependencies`,
     glyph: IconFont.Install,
   },
   {
@@ -14,19 +14,19 @@ export const HOMEPAGE_NAVIGATION_STEPS = [
     glyph: IconFont.CopperCoin,
   },
   {
-    name: 'Initialize\nClient',
+    name: 'Initialize\n Client',
     glyph: IconFont.CogSolid_New,
   },
   {
-    name: 'Write\nData',
+    name: 'Write\n Data',
     glyph: IconFont.Pencil,
   },
   {
-    name: 'Execute a\nSimple Query',
+    name: 'Execute a\n Simple Query',
     glyph: IconFont.Play,
   },
   {
-    name: 'Execute an\nAggregate Query',
+    name: 'Execute an\n Aggregate Query',
     glyph: IconFont.Play,
   },
   {
@@ -41,23 +41,23 @@ export const HOMEPAGE_NAVIGATION_STEPS_CLI = [
     glyph: IconFont.BookOutline,
   },
   {
-    name: 'Install\nDependencies',
+    name: 'Install\n Dependencies',
     glyph: IconFont.Install,
   },
   {
-    name: 'Initialize\nClient',
+    name: 'Initialize\n Client',
     glyph: IconFont.CogSolid_New,
   },
   {
-    name: 'Write\nData',
+    name: 'Write\n Data',
     glyph: IconFont.Pencil,
   },
   {
-    name: 'Execute\nFlux Query',
+    name: 'Execute\n Flux Query',
     glyph: IconFont.Play,
   },
   {
-    name: 'Execute\nAggregate',
+    name: 'Execute\n Aggregate',
     glyph: IconFont.Play,
   },
   {

--- a/src/homepageExperience/utils.ts
+++ b/src/homepageExperience/utils.ts
@@ -6,7 +6,7 @@ export const HOMEPAGE_NAVIGATION_STEPS = [
     glyph: IconFont.BookOutline,
   },
   {
-    name: `Install\n Dependencies`,
+    name: 'Install\n Dependencies',
     glyph: IconFont.Install,
   },
   {


### PR DESCRIPTION
Closes #4776

 - Added e2e tests for the CLI onboarding flow and updated the firstMile e2e tests, now both use regex for navigation to avoid flakiness. 
 - Added test ids to the next/previous buttons on the python flow. 
 - Also updated the spacing on the names for the subnav on the onboarding wizards.

<!-- Including screenshots or visuals is very helpful - a picture is worth a thousand words. -->

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
