### PR TITLE
feat(DocSearch): add poc link under Useful Links

### DIFF
--- a/src/me/components/DocSearchWidget.tsx
+++ b/src/me/components/DocSearchWidget.tsx
@@ -34,6 +34,11 @@ const supportLinks = [
       'https://github.com/influxdata/influxdb/issues/new?template=feature_request.md',
     title: 'Feature Requests',
   },
+  {
+    link:
+      'https://www.influxdata.com/proof-of-concept/',
+    title: 'Request Proof of Concept',
+  },
 ]
 
 const DocSearchWidget: FC = () => {

--- a/src/me/components/DocSearchWidget.tsx
+++ b/src/me/components/DocSearchWidget.tsx
@@ -13,7 +13,7 @@ import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 import 'src/me/components/DocSearchWidget.scss'
 
-let supportLinks = [
+const supportLinks = [
   {
     link: `https://docs.influxdata.com/influxdb/${DOCS_URL_VERSION}/query-data/get-started/`,
     title: 'Get Started with Flux',

--- a/src/me/components/DocSearchWidget.tsx
+++ b/src/me/components/DocSearchWidget.tsx
@@ -4,12 +4,12 @@ import React, {FC} from 'react'
 // Components
 import DocSearch, {DocSearchType} from 'src/shared/search/DocSearch'
 
-// Utils
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
-
 // Constants
 import {CLOUD} from 'src/shared/constants'
 import {DOCS_URL_VERSION} from 'src/shared/constants/fluxFunctions'
+
+// Utils
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 import 'src/me/components/DocSearchWidget.scss'
 

--- a/src/me/components/DocSearchWidget.tsx
+++ b/src/me/components/DocSearchWidget.tsx
@@ -4,10 +4,16 @@ import React, {FC} from 'react'
 // Components
 import DocSearch, {DocSearchType} from 'src/shared/search/DocSearch'
 
+// Utils
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+
+// Constants
+import {CLOUD} from 'src/shared/constants'
+import {DOCS_URL_VERSION} from 'src/shared/constants/fluxFunctions'
+
 import 'src/me/components/DocSearchWidget.scss'
 
-import {DOCS_URL_VERSION} from 'src/shared/constants/fluxFunctions'
-const supportLinks = [
+let supportLinks = [
   {
     link: `https://docs.influxdata.com/influxdb/${DOCS_URL_VERSION}/query-data/get-started/`,
     title: 'Get Started with Flux',
@@ -35,11 +41,16 @@ const supportLinks = [
     title: 'Feature Requests',
   },
   {
-    link:
-      'https://www.influxdata.com/proof-of-concept/',
+    link: 'https://www.influxdata.com/proof-of-concept/',
     title: 'Request Proof of Concept',
   },
 ]
+
+if (CLOUD && !isFlagEnabled('requestPoc')) {
+  supportLinks = supportLinks.filter(
+    item => item.title !== 'Request Proof of Concept'
+  )
+}
 
 const DocSearchWidget: FC = () => {
   return (

--- a/src/me/components/DocSearchWidget.tsx
+++ b/src/me/components/DocSearchWidget.tsx
@@ -40,16 +40,13 @@ let supportLinks = [
       'https://github.com/influxdata/influxdb/issues/new?template=feature_request.md',
     title: 'Feature Requests',
   },
-  {
-    link: 'https://www.influxdata.com/proof-of-concept/',
-    title: 'Request Proof of Concept',
-  },
 ]
 
-if (CLOUD && !isFlagEnabled('requestPoc')) {
-  supportLinks = supportLinks.filter(
-    item => item.title !== 'Request Proof of Concept'
-  )
+if (CLOUD && isFlagEnabled('requestPoc')) {
+  supportLinks.push({
+    link: 'https://www.influxdata.com/proof-of-concept/',
+    title: 'Request Proof of Concept',
+  })
 }
 
 const DocSearchWidget: FC = () => {


### PR DESCRIPTION
Closes #5120 

Adds `Request Proof of Concept` under Useful Links of UI homepage. 
behind `requestpoc` feature flag. 
<img width="1616" alt="Screen Shot 2022-07-29 at 11 56 12 AM" src="https://user-images.githubusercontent.com/66275100/181811626-bd56387c-370c-4d21-95db-02b4812872e7.png">



### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
