### PR TITLE
chore(cliWizard): hardcode cliWizard as event name

### DIFF
--- a/src/homepageExperience/components/steps/cli/InitializeClient.tsx
+++ b/src/homepageExperience/components/steps/cli/InitializeClient.tsx
@@ -39,7 +39,6 @@ import {AppState, Authorization} from 'src/types'
 import './CliSteps.scss'
 
 type OwnProps = {
-  wizardEventName: string
   setTokenValue: (tokenValue: string) => void
   tokenValue: string
   onSelectBucket: (bucketName: string) => void
@@ -48,7 +47,6 @@ type OwnProps = {
 const collator = new Intl.Collator(navigator.language || 'en-US')
 
 export const InitializeClient: FC<OwnProps> = ({
-  wizardEventName,
   setTokenValue,
   tokenValue,
   onSelectBucket,
@@ -97,12 +95,12 @@ export const InitializeClient: FC<OwnProps> = ({
     if (sortedPermissionTypes.length && tokenValue === null) {
       const authorization: Authorization = {
         orgID: org.id,
-        description: `onboarding-${wizardEventName}-token-${Date.now()}`,
+        description: `onboarding-cliWizard-token-${Date.now()}`,
         permissions: allAccessPermissions(sortedPermissionTypes, org.id, me.id),
       }
 
       dispatch(createAuthorization(authorization))
-      event(`firstMile.${wizardEventName}.tokens.tokenCreated`)
+      event(`firstMile.cliWizard.tokens.tokenCreated`)
     }
   }, [sortedPermissionTypes.length])
 
@@ -115,7 +113,7 @@ export const InitializeClient: FC<OwnProps> = ({
 
   // Events log handling
   const logCopyCodeSnippet = () => {
-    event(`firstMile.${wizardEventName}.buckets.code.copied`)
+    event(`firstMile.cliWizard.buckets.code.copied`)
   }
 
   return (

--- a/src/homepageExperience/containers/CliWizard.tsx
+++ b/src/homepageExperience/containers/CliWizard.tsx
@@ -113,7 +113,6 @@ export class CliWizard extends PureComponent<{}, State> {
       case 3: {
         return (
           <InitializeClient
-            wizardEventName="cliWizard"
             setTokenValue={this.setTokenValue}
             tokenValue={this.state.tokenValue}
             onSelectBucket={this.handleSelectBucket}


### PR DESCRIPTION
Closes #5177 

Since `InitializeClient` file is only being used by CLI Wizard, there is no need to pass `cliWizard` as a prop. The event name should simply be hardcoded. 

The rest of the component mentioned in the ticked linked above (`Overview` and `Finish` ) are being consumed by python, go, and node wizard. Therefore, event names have to be passed as prop. 

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
