### PR TITLE
feat: sync quartzOrganizations thunks to new API layer for new quartz organizations routes

### DIFF
--- a/src/identity/components/GlobalHeader/GlobalHeader.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeader.tsx
@@ -45,8 +45,10 @@ export const GlobalHeader: FC = () => {
   const [activeAccount, setActiveAccount] = useState(emptyAccount)
 
   useEffect(() => {
-    dispatch(getQuartzOrganizationsThunk())
-  }, [dispatch])
+    if (activeAccount.id !== emptyAccount.id) {
+      dispatch(getQuartzOrganizationsThunk(activeAccount.id))
+    }
+  }, [dispatch, activeAccount.id])
 
   useEffect(() => {
     if (accountsList[0].id !== 0) {

--- a/src/identity/quartzOrganizations/actions/thunks/index.ts
+++ b/src/identity/quartzOrganizations/actions/thunks/index.ts
@@ -29,7 +29,7 @@ interface UpdateOrgParams {
 // Utils
 import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
 
-export enum ThunkErrorNames {
+export enum OrganizationThunkErrors {
   DefaultOrgStateError = 'DefaultOrgStateError',
   DefaultOrgNetworkError = 'DefaultOrgNetworkError',
 }
@@ -37,14 +37,14 @@ export enum ThunkErrorNames {
 export class DefaultOrgStateError extends Error {
   constructor(message) {
     super(message)
-    this.name = ThunkErrorNames.DefaultOrgStateError
+    this.name = OrganizationThunkErrors.DefaultOrgStateError
   }
 }
 
 export class DefaultOrgNetworkError extends Error {
   constructor(message) {
     super(message)
-    this.name = ThunkErrorNames.DefaultOrgNetworkError
+    this.name = OrganizationThunkErrors.DefaultOrgNetworkError
   }
 }
 
@@ -88,7 +88,9 @@ export const updateDefaultOrgThunk = ({
     const orgStatus = state.identity.currentIdentity.status
 
     if (orgStatus === RemoteDataState.Error) {
-      throw new DefaultOrgStateError(ThunkErrorNames.DefaultOrgStateError)
+      throw new DefaultOrgStateError(
+        OrganizationThunkErrors.DefaultOrgStateError
+      )
     }
   } catch (err) {
     reportErrorThroughHoneyBadger(err, {
@@ -100,11 +102,6 @@ export const updateDefaultOrgThunk = ({
       },
     })
 
-    switch (err.name) {
-      case ThunkErrorNames.DefaultOrgStateError:
-        throw new DefaultOrgStateError(err)
-      default:
-        throw new DefaultOrgNetworkError(err)
-    }
+    throw Error(err)
   }
 }

--- a/src/identity/quartzOrganizations/actions/thunks/index.ts
+++ b/src/identity/quartzOrganizations/actions/thunks/index.ts
@@ -1,7 +1,10 @@
 import {Dispatch} from 'react'
 
 // API
-import {fetchQuartzOrgs, updateDefaultQuartzOrg} from 'src/identity/apis/auth'
+import {
+  fetchOrgsByAccountID,
+  updateDefaultOrgByAccountID,
+} from 'src/identity/apis/auth'
 
 // Actions
 import {
@@ -13,34 +16,50 @@ import {
 import {PublishNotificationAction} from 'src/shared/actions/notifications'
 
 // Types
-import {GetState, RemoteDataState} from 'src/types'
+import {AppThunk, GetState, RemoteDataState} from 'src/types'
 import {OrganizationSummaries} from 'src/client/unityRoutes'
-
 type Actions = QuartzOrganizationActions | PublishNotificationAction
 type DefaultOrg = OrganizationSummaries[number]
 
-class OrgNotFoundError extends Error {
+interface UpdateOrgParams {
+  accountId: number
+  newDefaultOrg: DefaultOrg
+}
+
+// Utils
+import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
+
+export enum ThunkErrorNames {
+  DefaultOrgStateError = 'DefaultOrgStateError',
+  DefaultOrgNetworkError = 'DefaultOrgNetworkError',
+}
+
+export class DefaultOrgStateError extends Error {
   constructor(message) {
     super(message)
-    this.name = 'DefaultOrgNotFoundError'
+    this.name = ThunkErrorNames.DefaultOrgStateError
   }
 }
 
-// Error Reporting
-import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
+export class DefaultOrgNetworkError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = ThunkErrorNames.DefaultOrgNetworkError
+  }
+}
 
-export const getQuartzOrganizationsThunk = () => async (
+// Thunks
+export const getQuartzOrganizationsThunk = (accountId: number) => async (
   dispatch: Dispatch<Actions>,
   getState: GetState
 ) => {
   try {
     dispatch(setQuartzOrganizationsStatus(RemoteDataState.Loading))
-    const quartzOrganizations = await fetchQuartzOrgs()
+
+    const quartzOrganizations = await fetchOrgsByAccountID(accountId)
 
     dispatch(setQuartzOrganizations(quartzOrganizations))
   } catch (err) {
-    dispatch(setQuartzOrganizationsStatus(RemoteDataState.Error))
-
     reportErrorThroughHoneyBadger(err, {
       name: 'Failed to fetch /quartz/orgs/',
       context: {state: getState()},
@@ -48,14 +67,20 @@ export const getQuartzOrganizationsThunk = () => async (
   }
 }
 
-export const updateDefaultOrgThunk = (newDefaultOrg: DefaultOrg) => async (
+export const updateDefaultOrgThunk = ({
+  accountId,
+  newDefaultOrg,
+}: UpdateOrgParams): AppThunk<Promise<void>> => async (
   dispatch: Dispatch<Actions>,
   getState: GetState
-) => {
+): Promise<void> => {
   try {
     dispatch(setQuartzOrganizationsStatus(RemoteDataState.Loading))
 
-    await updateDefaultQuartzOrg(newDefaultOrg.id)
+    await updateDefaultOrgByAccountID({
+      accountNum: accountId,
+      orgId: newDefaultOrg.id,
+    })
 
     dispatch(setQuartzDefaultOrg(newDefaultOrg.id))
 
@@ -63,23 +88,23 @@ export const updateDefaultOrgThunk = (newDefaultOrg: DefaultOrg) => async (
     const orgStatus = state.identity.currentIdentity.status
 
     if (orgStatus === RemoteDataState.Error) {
-      const defaultOrgErrMsg =
-        'quartzOrganizations state does not contain requested default organization'
-
-      reportErrorThroughHoneyBadger(new OrgNotFoundError(defaultOrgErrMsg), {
-        name: defaultOrgErrMsg,
-        context: {
-          org: newDefaultOrg,
-          state: getState(),
-        },
-      })
+      throw new DefaultOrgStateError(ThunkErrorNames.DefaultOrgStateError)
     }
   } catch (err) {
-    dispatch(setQuartzOrganizationsStatus(RemoteDataState.Error))
-
     reportErrorThroughHoneyBadger(err, {
-      name: 'Failed to update /quartz/orgs/default',
-      context: {state: getState()},
+      name: err.name,
+      context: {
+        message: err.message,
+        org: newDefaultOrg,
+        state: getState(),
+      },
     })
+
+    switch (err.name) {
+      case ThunkErrorNames.DefaultOrgStateError:
+        throw new DefaultOrgStateError(err)
+      default:
+        throw new DefaultOrgNetworkError(err)
+    }
   }
 }


### PR DESCRIPTION
Part of [#4049](https://github.com/influxdata/ui/issues/4049)

UI PR [#5197](https://github.com/influxdata/ui/pull/5197) added API layer support for new backend routes that can (1) retrieve the orgs associated with any given account id and (2) set the default org for any given account. 

This PR makes corresponding updates to the quartzOrganizations thunks to use these new routes, as the old ones will be deprecated. The new user profile page is based on these updates.

This PR also improves error handling in the thunk for setting a new default org, distinguishing for reporting purposes whether the failure resulted from a state management problem or a network error. 

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed) 
- [X] Feature flagged, if applicable - FLAGGED BEHIND `quartzIdentity` and `multiOrg`
