### PR TITLE
fix: wraps page elements in a flexbox to give SimpleTable correct height

### DIFF
--- a/src/dataExplorer/components/FluxQueryBuilder.scss
+++ b/src/dataExplorer/components/FluxQueryBuilder.scss
@@ -1,5 +1,9 @@
 @import '@influxdata/clockface/dist/variables.scss';
 
+.flux-query-builder--container {
+  height: 100%;
+}
+
 .new-data-explorer-rightside {
   .cf-draggable-resizer--handle > .cf-draggable-resizer--handle-pill1,
   .cf-draggable-resizer--handle > .cf-draggable-resizer--handle-pill2,

--- a/src/dataExplorer/components/FluxQueryBuilder.tsx
+++ b/src/dataExplorer/components/FluxQueryBuilder.tsx
@@ -4,9 +4,13 @@ import {RemoteDataState} from 'src/types'
 // Components
 import {
   DraggableResizer,
+  FlexBox,
+  FlexDirection,
   Orientation,
   Button,
   IconFont,
+  AlignItems,
+  JustifyContent,
 } from '@influxdata/clockface'
 import {QueryProvider, QueryContext} from 'src/shared/contexts/query'
 import {EditorProvider} from 'src/shared/contexts/editor'
@@ -44,27 +48,38 @@ const FluxQueryBuilder: FC = () => {
   return (
     <EditorProvider>
       <SidebarProvider>
-        <div className="flux-query-builder--menu">
-          <Button onClick={clear} text="New Script" icon={IconFont.Plus_New} />
-        </div>
-        <DraggableResizer
-          handleOrientation={Orientation.Vertical}
-          handlePositions={vertical}
-          onChangePositions={setVertical}
+        <FlexBox
+          direction={FlexDirection.Column}
+          justifyContent={JustifyContent.SpaceBetween}
+          alignItems={AlignItems.Stretch}
+          style={{height: '100%'}}
         >
-          <DraggableResizer.Panel>
-            <Schema />
-          </DraggableResizer.Panel>
-          <DraggableResizer.Panel
-            testID="flux-query-builder-middle-panel"
-            className="new-data-explorer-rightside"
+          <div className="flux-query-builder--menu" style={{width: '100%'}}>
+            <Button
+              onClick={clear}
+              text="New Script"
+              icon={IconFont.Plus_New}
+            />
+          </div>
+          <DraggableResizer
+            handleOrientation={Orientation.Vertical}
+            handlePositions={vertical}
+            onChangePositions={setVertical}
           >
-            <ResultsPane />
-          </DraggableResizer.Panel>
-          <DraggableResizer.Panel>
-            <Sidebar />
-          </DraggableResizer.Panel>
-        </DraggableResizer>
+            <DraggableResizer.Panel>
+              <Schema />
+            </DraggableResizer.Panel>
+            <DraggableResizer.Panel
+              testID="flux-query-builder-middle-panel"
+              className="new-data-explorer-rightside"
+            >
+              <ResultsPane />
+            </DraggableResizer.Panel>
+            <DraggableResizer.Panel>
+              <Sidebar />
+            </DraggableResizer.Panel>
+          </DraggableResizer>
+        </FlexBox>
       </SidebarProvider>
     </EditorProvider>
   )

--- a/src/dataExplorer/components/FluxQueryBuilder.tsx
+++ b/src/dataExplorer/components/FluxQueryBuilder.tsx
@@ -49,12 +49,12 @@ const FluxQueryBuilder: FC = () => {
     <EditorProvider>
       <SidebarProvider>
         <FlexBox
+          className="flux-query-builder--container"
           direction={FlexDirection.Column}
           justifyContent={JustifyContent.SpaceBetween}
           alignItems={AlignItems.Stretch}
-          style={{height: '100%'}}
         >
-          <div className="flux-query-builder--menu" style={{width: '100%'}}>
+          <div className="flux-query-builder--menu">
             <Button
               onClick={clear}
               text="New Script"

--- a/src/visualization/types/SimpleTable/PagedTable.tsx
+++ b/src/visualization/types/SimpleTable/PagedTable.tsx
@@ -41,6 +41,8 @@ const measurePage = (
   let lastSignature
   let signature
 
+  const lastVisibleRowMinimumHeight = 0.2 * rowHeight
+
   while (rowIdx < result.table.length) {
     if (result.table.columns?.table?.data?.[rowIdx] !== currentTable) {
       signature = Object.values(result.table.columns)
@@ -73,7 +75,7 @@ const measurePage = (
 
     runningHeight += rowHeight
 
-    if (runningHeight + 0.25 * rowHeight >= height) {
+    if (runningHeight + lastVisibleRowMinimumHeight >= height) {
       break
     }
 

--- a/src/visualization/types/SimpleTable/PagedTable.tsx
+++ b/src/visualization/types/SimpleTable/PagedTable.tsx
@@ -255,7 +255,7 @@ const PagedTable: FC<Props> = ({result, properties}) => {
   useEffect(() => {
     if (rowHeight === 0 && pagedTableBodyRef?.current) {
       const calculatedRowHeight =
-        pagedTableBodyRef.current?.children?.[0].clientHeight ?? 0
+        pagedTableBodyRef.current.children?.[0]?.clientHeight ?? 0
 
       if (calculatedRowHeight !== rowHeight) {
         setRowHeight(calculatedRowHeight)


### PR DESCRIPTION
Closes #5256    

This guy:
<img width="1728" alt="Screen Shot 2022-08-01 at 7 14 30 PM" src="https://user-images.githubusercontent.com/10736577/182278116-9cfd54c8-808f-4ac7-afbe-5613c17df3d5.png">

And this guy:
<img width="1728" alt="Screen Shot 2022-08-01 at 7 14 36 PM" src="https://user-images.githubusercontent.com/10736577/182278146-8697d8a7-5256-45e7-8a10-88286d85e9d5.png">


should be wrapped in a flexbox. This fixes the issue of the hidden navigation in SimpleTable for New Data Explorer.


BEFORE: hidden navigation

<img width="1627" alt="Screen Shot 2022-08-01 at 6 25 29 AM" src="https://user-images.githubusercontent.com/10736577/182278033-f43c5c09-7199-43e8-a2c7-83e0090a5881.png">



AFTER: all fixed

https://user-images.githubusercontent.com/10736577/182278279-7ace3b11-fdbd-482a-9e67-eac017f9195b.mp4

