### PR TITLE
chore: allow globalheader to serve typeahead independently

### DIFF
--- a/src/identity/components/GlobalHeader/GlobalHeaderDropdown/index.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeaderDropdown/index.tsx
@@ -40,7 +40,7 @@ export interface Props extends StandardFunctionProps {
   mainMenuHeaderText?: string
   mainMenuHeaderIcon?: IconFont
   mainMenuOptions: MainMenuItem[]
-  typeAheadOnly?: boolean
+  onlyRenderSubmenu?: boolean
   typeAheadSelectedOption?: TypeAheadMenuItem
   typeAheadMenuOptions: TypeAheadMenuItem[]
   typeAheadInputPlaceholder?: string
@@ -56,7 +56,7 @@ export class GlobalHeaderDropdown extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props)
     this.state = {
-      showTypeAheadMenu: this.props.typeAheadOnly ?? false,
+      showTypeAheadMenu: this.props.onlyRenderSubmenu ?? false,
       selectedItem: this.props.typeAheadSelectedOption || null,
     }
   }
@@ -141,7 +141,7 @@ export class GlobalHeaderDropdown extends React.Component<Props, State> {
       dropdownMenuTheme = DropdownMenuTheme.None,
       dropdownMenuStyle,
       typeAheadMenuOptions,
-      typeAheadOnly = false,
+      onlyRenderSubmenu = false,
     } = this.props
     const {showTypeAheadMenu} = this.state
 
@@ -155,7 +155,7 @@ export class GlobalHeaderDropdown extends React.Component<Props, State> {
     return (
       <Dropdown.Menu theme={dropdownMenuTheme} style={dropdownMenuStyle}>
         {/* Multi-org UI tickets #4051 and #4047, when user only has 1 account or 1 org, switch button is disabled */}
-        {typeAheadOnly === false && typeAheadMenuOptions.length > 1 && (
+        {!onlyRenderSubmenu && typeAheadMenuOptions.length > 1 && (
           <Dropdown.Item onClick={this.toggleShowTypeAheadMenu}>
             <FlexBox
               justifyContent={JustifyContent.SpaceBetween}

--- a/src/identity/components/GlobalHeader/GlobalHeaderDropdown/index.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeaderDropdown/index.tsx
@@ -40,6 +40,7 @@ export interface Props extends StandardFunctionProps {
   mainMenuHeaderText?: string
   mainMenuHeaderIcon?: IconFont
   mainMenuOptions: MainMenuItem[]
+  typeAheadOnly?: boolean
   typeAheadSelectedOption?: TypeAheadMenuItem
   typeAheadMenuOptions: TypeAheadMenuItem[]
   typeAheadInputPlaceholder?: string
@@ -55,7 +56,7 @@ export class GlobalHeaderDropdown extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props)
     this.state = {
-      showTypeAheadMenu: false,
+      showTypeAheadMenu: this.props.typeAheadOnly ?? false,
       selectedItem: this.props.typeAheadSelectedOption || null,
     }
   }
@@ -140,6 +141,7 @@ export class GlobalHeaderDropdown extends React.Component<Props, State> {
       dropdownMenuTheme = DropdownMenuTheme.None,
       dropdownMenuStyle,
       typeAheadMenuOptions,
+      typeAheadOnly = false,
     } = this.props
     const {showTypeAheadMenu} = this.state
 
@@ -153,7 +155,7 @@ export class GlobalHeaderDropdown extends React.Component<Props, State> {
     return (
       <Dropdown.Menu theme={dropdownMenuTheme} style={dropdownMenuStyle}>
         {/* Multi-org UI tickets #4051 and #4047, when user only has 1 account or 1 org, switch button is disabled */}
-        {typeAheadMenuOptions.length > 1 && (
+        {typeAheadOnly === false && typeAheadMenuOptions.length > 1 && (
           <Dropdown.Item onClick={this.toggleShowTypeAheadMenu}>
             <FlexBox
               justifyContent={JustifyContent.SpaceBetween}


### PR DESCRIPTION
Part of [UI #4049](https://github.com/influxdata/ui/issues/4049)

The multi-org figma uses the same design for the globalheader (which has a menu menu, and typeahead sub-menu) as for the dropdown typeahead on the user profile page (which is just the typeahead submenu). This tweaks the globalheader by adding an optional property `typeAheadOnly`, which will cause only the submenu to render.

With `typeAheadOnly` not set (or `false`), the main menu renders. Here's an example from GlobalHeader.
![Screen Shot 2022-08-02 at 11 01 00 AM](https://user-images.githubusercontent.com/91283923/182406959-4f061190-acc6-4ab2-a01e-708f83b10b99.png)


With `typeAheadOnly` set to `true`, main menu doesn't render, and goes straight to typeahead, to be used on the user profile page.
![Screen Shot 2022-08-02 at 11 00 49 AM](https://user-images.githubusercontent.com/91283923/182407001-31a34d8d-8172-408f-810b-4885e39dc28a.png)

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - `multiOrg`
