### PR TITLE
perf: memoize flag selector using reselect

### DIFF
--- a/src/shared/containers/GetFlags.tsx
+++ b/src/shared/containers/GetFlags.tsx
@@ -8,21 +8,20 @@ import GetOrganizations from 'src/shared/containers/GetOrganizations'
 import {SpinnerContainer, TechnoSpinner} from '@influxdata/clockface'
 
 // Types
-import {RemoteDataState, AppState} from 'src/types'
+import {RemoteDataState} from 'src/types'
 
 // Actions
 import {getFlags} from 'src/shared/thunks/flags'
 
 // Utils
-import {activeFlags} from 'src/shared/selectors/flags'
+import {activeFlags, getFlagStatus} from 'src/shared/selectors/flags'
 import {updateReportingContext} from 'src/cloud/utils/reporting'
 
 const GetFlags: FC = () => {
   const dispatch = useDispatch()
   const flags = useSelector(activeFlags)
-  const status = useSelector(
-    (state: AppState) => state.flags.status || RemoteDataState.NotStarted
-  )
+  const status = useSelector(getFlagStatus)
+
   useEffect(() => {
     if (status === RemoteDataState.NotStarted) {
       dispatch(getFlags())

--- a/src/shared/selectors/flags.ts
+++ b/src/shared/selectors/flags.ts
@@ -1,4 +1,6 @@
-import {AppState} from 'src/types'
+import {createSelector} from 'reselect'
+
+import {AppState, RemoteDataState} from 'src/types'
 import {FlagMap} from 'src/shared/actions/flags'
 import {CLOUD} from 'src/shared/constants'
 
@@ -54,14 +56,21 @@ export const CLOUD_FLAGS = {
   leadWithFlows: false,
 }
 
-export const activeFlags = (state: AppState): FlagMap => {
-  const localState = CLOUD ? CLOUD_FLAGS : OSS_FLAGS
-  const networkState = state.flags.original || {}
-  const override = state.flags.override || {}
+const getConfigCatFlags = (state: AppState) => state.flags.original || {}
+const getLocalFlagOverrides = (state: AppState) => state.flags.override || {}
 
-  return {
-    ...localState,
-    ...networkState,
-    ...override,
+export const activeFlags = createSelector(
+  getConfigCatFlags,
+  getLocalFlagOverrides,
+  (configCatFlags, localFlagOverrides): FlagMap => {
+    const localFlags = CLOUD ? CLOUD_FLAGS : OSS_FLAGS
+    return {
+      ...localFlags,
+      ...configCatFlags,
+      ...localFlagOverrides,
+    }
   }
-}
+)
+
+export const getFlagStatus = (state: AppState) =>
+  state.flags.status || RemoteDataState.NotStarted


### PR DESCRIPTION
Connects #5234 

Using reselect, memoize the `activeFlags` selector.

### Before
| Page                   | GetFlags.tsx Render Count |
|------------------------|---------------------------|
| Homepage               | 25                        |
| Dashboard With 4 Cells | 45                        |

### After
| Page                   | GetFlags.tsx Render Count |
|------------------------|---------------------------|
| Homepage               | 3                         |
| Dashboard With 4 Cells | 5                         |

Homepage: 25 => 3
Dashboard: 45 => 5

### Homepage Before
![Screen Shot 2022-08-02 at 1 01 12 PM](https://user-images.githubusercontent.com/146112/182433206-9c8fd725-7923-4213-833e-c0ff6db0902a.png)

### Hompeage After
![Screen Shot 2022-08-02 at 1 01 45 PM](https://user-images.githubusercontent.com/146112/182433211-9c0c50c8-3d81-48de-982a-6b910fbaef5b.png)

### Dashboard with 4 Cells Before
![Screen Shot 2022-08-02 at 1 04 24 PM](https://user-images.githubusercontent.com/146112/182433224-6ce560b5-00e4-42de-9755-3b9e289463af.png)

### Dashboard with 4 Cells After
![Screen Shot 2022-08-02 at 1 04 02 PM](https://user-images.githubusercontent.com/146112/182433220-ba2bdc10-1d3e-460f-ad45-c9861bc67498.png)


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- ~[ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~
- ~[ ] Feature flagged, if applicable~
