### PR TITLE
fix(dashboards): only notify when a pinned item is actually deleted

### DIFF
--- a/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -231,11 +231,13 @@ class DashboardCard extends PureComponent<Props> {
   private handleDeleteDashboard = async () => {
     const {id, name, onDeleteDashboard} = this.props
     onDeleteDashboard(id, name)
-    try {
-      await deletePinnedItemByParam(id)
-      this.props.sendNotification(pinnedItemSuccess('task', 'deleted'))
-    } catch (error) {
-      this.props.sendNotification(pinnedItemFailure(error.message, 'delete'))
+    if (isFlagEnabled('pinnedItems') && CLOUD && this.props.isPinned) {
+      try {
+        await deletePinnedItemByParam(id)
+        this.props.sendNotification(pinnedItemSuccess('dashboard', 'deleted'))
+      } catch (error) {
+        this.props.sendNotification(pinnedItemFailure(error.message, 'delete'))
+      }
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/5263

- When deleting a dashboard, only notify that a pinned dashboard has been deleted if that dashboard was actually pinned
- Fix notification text to say dashboard, not task

![Screen Shot 2022-08-02 at 3 29 42 PM](https://user-images.githubusercontent.com/146112/182457883-7c468bdf-d7a8-4956-afce-0b87e43d91d0.png)

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- ~[] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~
- ~[ ] Feature flagged, if applicable~
