### PR TITLE
chore: remove old quartz routes for getting orgs, setting default orgs

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "cy": "CYPRESS_dexUrl=https://$INGRESS_HOST:$PORT_HTTPS CYPRESS_baseUrl=http://localhost:9999 cypress open",
     "cy:dev": "source ../monitor-ci/.env && CYPRESS_dexUrl=CLOUD CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{cloud,shared}/**/*.*'",
     "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_dexUrl=OSS CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{oss,shared}/**/*.*'",
-    "generate": "export SHA=fae7b1adb67f961e5818ea62e2c02becaaca30cb && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
+    "generate": "export SHA=152e315e8ac269b268f1b8095cae1c83f65c261f && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-local-cloud": "export REMOTE=../openapi/ && yarn generate-meta-cloud",
     "generate-meta": "if [ -z \"${CLOUD_URL}\" ]; then yarn generate-meta-oss; else yarn generate-meta-cloud; fi",

--- a/src/identity/apis/auth.ts
+++ b/src/identity/apis/auth.ts
@@ -5,8 +5,6 @@ import {
   getIdentity,
   getMe as getMeQuartz,
   getOrg,
-  getOrgs,
-  putOrgsDefault,
   putAccountsDefault,
   putAccountsOrgsDefault,
   Account,
@@ -234,37 +232,6 @@ export const fetchOrgDetails = async (orgId: string): Promise<Organization> => {
 
   const orgDetails = response.data
   return orgDetails
-}
-
-// fetch the list of organizations in the user's currently active account
-export const fetchQuartzOrgs = async (): Promise<OrganizationSummaries> => {
-  const response = await getOrgs({})
-
-  if (response.status === 401) {
-    throw new UnauthorizedError(response.data.message)
-  }
-
-  if (response.status === 500) {
-    throw new ServerError(response.data.message)
-  }
-
-  return response.data
-}
-
-// change the default organization for the user's currently active account
-export const updateDefaultQuartzOrg = async (orgId: string) => {
-  const response = await putOrgsDefault({
-    data: {
-      id: orgId,
-    },
-  })
-
-  // Only status codes thrown at moment are 204 and 5xx.
-  if (response.status !== 204) {
-    throw new ServerError(response.data.message)
-  }
-
-  return response.data
 }
 
 // fetch the list of organizations associated with a given account ID


### PR DESCRIPTION
Closes #5183 

This ticket removes `updateDefaultQuartzOrg` (`PUT` /quartz/orgs/default ) and `fetchQuartzOrgs` (`GET` /quartz/orgs) from the UI's API layer, because they were removed from quartz and openAPI. See [/quartz/orgs/](https://github.com/influxdata/quartz/pull/6651), [/quartz/orgs/default](https://github.com/influxdata/quartz/pull/6650).

These routes are replaced in the UI API layer by `fetchOrgsByAccountID` (/quartz/accounts/:accountId/orgs) and `updateDefaultOrgByAccountID` (/quartz/accounts/:accountId/orgs/default).

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - N/A
