### PR TITLE
fix: fix access of optional parameter issue

### DIFF
--- a/src/writeData/subscriptions/components/BrokerFormContent.tsx
+++ b/src/writeData/subscriptions/components/BrokerFormContent.tsx
@@ -114,7 +114,7 @@ const BrokerFormContent: FC<Props> = ({
               type={InputType.Text}
               placeholder="Describe this connection"
               name="description"
-              value={formContent.description}
+              value={formContent.description ?? ''}
               onChange={e =>
                 updateForm({
                   ...formContent,

--- a/src/writeData/subscriptions/components/StringParsingForm.tsx
+++ b/src/writeData/subscriptions/components/StringParsingForm.tsx
@@ -102,10 +102,10 @@ const StringParsingForm: FC<Props> = ({formContent, updateForm, edit}) => {
         >
           <ValidationInputWithTooltip
             label="Regex Pattern to find Timestamp"
-            value={formContent.stringTimestamp.pattern}
+            value={formContent?.stringTimestamp?.pattern}
             required={false}
             validationFunc={() =>
-              !!formContent.stringTimestamp.pattern
+              !!formContent?.stringTimestamp?.pattern
                 ? handleRegexValidation(formContent.stringTimestamp.pattern)
                 : null
             }

--- a/src/writeData/subscriptions/utils/form.ts
+++ b/src/writeData/subscriptions/utils/form.ts
@@ -250,7 +250,7 @@ const checkStringObjRequiredFields = (
   validateRegex(stringObjParams?.pattern)
 
 const checkStringTimestamp = (stringObjParams: StringObjectParams): boolean => {
-  if (!stringObjParams.pattern) {
+  if (!stringObjParams?.pattern) {
     return true
   }
   return validateRegex(stringObjParams.pattern)
@@ -272,7 +272,7 @@ const checkJsonObjRequiredFields = (jsonObjParams: JsonSpec): boolean =>
   validateJsonPath(jsonObjParams.path)
 
 const checkJsonTimestamp = (jsonObjParams: JsonSpec): boolean => {
-  if (!jsonObjParams.path) {
+  if (!jsonObjParams?.path) {
     return true
   }
   return validateJsonPath(jsonObjParams.path)


### PR DESCRIPTION
Closes https://github.com/influxdata/data-acquisition/issues/476

Optional parameter chaining was happening without the use of `?` thus resulting in an error.

## BEFORE
![image](https://user-images.githubusercontent.com/1637395/182473487-00ffd6d5-e1c9-4ae9-88ab-c591ceecc805.png)
![image](https://user-images.githubusercontent.com/1637395/182473630-ea41bde9-2d66-4b14-a02b-f084dc93e991.png)
## Unrelated Issue
![image](https://user-images.githubusercontent.com/1637395/182476930-2e217cc6-113a-4165-8d56-40a5421f80cb.png)


## AFTER
Subscription details page should be loading fine.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
