### PR TITLE
feat: add dark background to New Data Explorer results

### DIFF
--- a/src/dataExplorer/components/Results.scss
+++ b/src/dataExplorer/components/Results.scss
@@ -31,6 +31,7 @@ $cf-radius-lg: $cf-radius + 4px;
   height: 100%;
   width: 100%;
   padding: 12;
+  background-color: black;
 }
 
 .data-explorer-results--empty-header {


### PR DESCRIPTION
New Data Explorer uses a dark grey background for the `View` that renders the graph. This affects SimpleTable by fading out the alternating row colors.

Suggestion: use a black background for better visibility.

Left unaddressed for the future is dark/light mode.

Simple Table BEFORE vs AFTER:
<img width="1728" alt="Screen Shot 2022-08-02 at 3 56 14 PM" src="https://user-images.githubusercontent.com/10736577/182501473-f940ff0f-7528-4368-a3a7-9024b6ec03a1.png"> 
<img width="1728" alt="Screen Shot 2022-08-02 at 3 55 53 PM" src="https://user-images.githubusercontent.com/10736577/182501433-6f2964b6-8f3e-4fd5-8dde-709032e94360.png">

  
  
Line Graph BEFORE vs AFTER:
<img width="1728" alt="Screen Shot 2022-08-02 at 5 53 17 PM" src="https://user-images.githubusercontent.com/10736577/182501490-6ec3a7a7-5e52-4054-9f90-1b025d64c707.png">  
<img width="1728" alt="Screen Shot 2022-08-02 at 5 53 33 PM" src="https://user-images.githubusercontent.com/10736577/182501542-567e044f-9dd5-4370-a223-c3775dcca91b.png">

