### PR TITLE
feat(cliWizard): additional eventing for cli

### DIFF
--- a/src/homepageExperience/components/steps/cli/ExecuteQuery.tsx
+++ b/src/homepageExperience/components/steps/cli/ExecuteQuery.tsx
@@ -48,7 +48,12 @@ export const ExecuteQuery = (props: OwnProps) => {
       <p>
         Now let's query the data we wrote into the database. We use the Flux
         scripting language to query data.{' '}
-        <SafeBlankLink href="https://docs.influxdata.com/influxdb/v2.2/reference/syntax/flux/">
+        <SafeBlankLink
+          href="https://docs.influxdata.com/influxdb/v2.2/reference/syntax/flux/"
+          onClick={() =>
+            event('firstMile.cliWizard.documentation.link.clicked')
+          }
+        >
           Flux
         </SafeBlankLink>{' '}
         is designed for querying, analyzing, and acting on data.

--- a/src/homepageExperience/components/steps/cli/InstallDependencies.tsx
+++ b/src/homepageExperience/components/steps/cli/InstallDependencies.tsx
@@ -24,7 +24,7 @@ export const InstallDependencies: FC = () => {
 
   const headingWithMargin = {marginTop: '48px', marginBottom: '0px'}
 
-  const logCopyCodeSnippet = (OS) => {
+  const logCopyCodeSnippet = OS => {
     event(`firstMile.cliWizard.installDependencies${OS}.code.copied`)
   }
 
@@ -65,14 +65,14 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
         keyboardCopyTriggered(event) &&
         userSelection().includes('brew install')
       ) {
-        logCopyCodeSnippetMac()
+        logCopyCodeSnippet('Mac')
       }
       if (
         keyboardCopyTriggered(event) &&
         (userSelection().includes('Expand-Archive') ||
           userSelection().includes('mv'))
       ) {
-        logCopyCodeSnippetWindows()
+        logCopyCodeSnippet('Windows')
       }
       if (
         keyboardCopyTriggered(event) &&
@@ -80,7 +80,7 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
           userSelection().includes('tar') ||
           userSelection().includes('sudo'))
       ) {
-        logCopyCodeSnippetLinux()
+        logCopyCodeSnippet('Linux')
       }
     }
     document.addEventListener('keydown', fireKeyboardCopyEvent)
@@ -136,7 +136,7 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
           <p>
             If you prefer to manually download and install the CLI package,
             follow our{' '}
-            <SafeBlankLink 
+            <SafeBlankLink
               href="https://docs.influxdata.com/influxdb/cloud/tools/influx-cli/"
               onClick={handleEventing}
             >
@@ -178,7 +178,7 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
           </Table>
           <p>
             Full list of commands is available in our{' '}
-            <SafeBlankLink 
+            <SafeBlankLink
               href="https://docs.influxdata.com/influxdb/cloud/reference/cli/influx/"
               onClick={handleEventing}
             >
@@ -192,7 +192,7 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
           <h2 style={headingWithMargin}>Download the CLI package</h2>
           <p>
             {' '}
-            <SafeBlankLink 
+            <SafeBlankLink
               href="https://docs.influxdata.com/influxdb/cloud/tools/influx-cli/?t=Windows"
               onClick={handleEventing}
             >
@@ -250,7 +250,7 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
           </Table>
           <p>
             Full list of commands is available in our{' '}
-            <SafeBlankLink 
+            <SafeBlankLink
               href="https://docs.influxdata.com/influxdb/cloud/reference/cli/influx/"
               onClick={handleEventing}
             >
@@ -270,7 +270,7 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
           <p>
             If you prefer to manually download and install the CLI package,
             follow our{' '}
-            <SafeBlankLink 
+            <SafeBlankLink
               href="https://docs.influxdata.com/influxdb/cloud/tools/influx-cli/?t=Linux"
               onClick={handleEventing}
             >
@@ -334,7 +334,7 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
           </Table>
           <p>
             Full list of commands is available in our{' '}
-            <SafeBlankLink 
+            <SafeBlankLink
               href="https://docs.influxdata.com/influxdb/cloud/reference/cli/influx/"
               onClick={handleEventing}
             >

--- a/src/homepageExperience/components/steps/cli/InstallDependencies.tsx
+++ b/src/homepageExperience/components/steps/cli/InstallDependencies.tsx
@@ -24,14 +24,12 @@ export const InstallDependencies: FC = () => {
 
   const headingWithMargin = {marginTop: '48px', marginBottom: '0px'}
 
-  const logCopyCodeSnippetMac = () => {
-    event('firstMile.cliWizard.installDependenciesMac.code.copied')
+  const logCopyCodeSnippet = (OS) => {
+    event(`firstMile.cliWizard.installDependencies${OS}.code.copied`)
   }
-  const logCopyCodeSnippetWindows = () => {
-    event('firstMile.cliWizard.installDependenciesWindows.code.copied')
-  }
-  const logCopyCodeSnippetLinux = () => {
-    event('firstMile.cliWizard.installDependenciesLinux.code.copied')
+
+  const handleEventing = () => {
+    event('firstMile.cliWizard.documentation.link.clicked')
   }
 
   const windowsCodeSnippet =
@@ -132,13 +130,16 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
           <h2 style={headingWithMargin}>Use Homebrew</h2>
           <CodeSnippet
             text="brew install influxdb-cli"
-            onCopy={logCopyCodeSnippetMac}
+            onCopy={() => logCopyCodeSnippet(currentSelection)}
             language="properties"
           />
           <p>
             If you prefer to manually download and install the CLI package,
             follow our{' '}
-            <SafeBlankLink href="https://docs.influxdata.com/influxdb/cloud/tools/influx-cli/">
+            <SafeBlankLink 
+              href="https://docs.influxdata.com/influxdb/cloud/tools/influx-cli/"
+              onClick={handleEventing}
+            >
               documentation.
             </SafeBlankLink>{' '}
           </p>
@@ -177,7 +178,10 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
           </Table>
           <p>
             Full list of commands is available in our{' '}
-            <SafeBlankLink href="https://docs.influxdata.com/influxdb/cloud/reference/cli/influx/">
+            <SafeBlankLink 
+              href="https://docs.influxdata.com/influxdb/cloud/reference/cli/influx/"
+              onClick={handleEventing}
+            >
               documentation.
             </SafeBlankLink>{' '}
           </p>
@@ -188,7 +192,10 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
           <h2 style={headingWithMargin}>Download the CLI package</h2>
           <p>
             {' '}
-            <SafeBlankLink href="https://docs.influxdata.com/influxdb/cloud/tools/influx-cli/?t=Windows">
+            <SafeBlankLink 
+              href="https://docs.influxdata.com/influxdb/cloud/tools/influx-cli/?t=Windows"
+              onClick={handleEventing}
+            >
               Download via our documentation.
             </SafeBlankLink>{' '}
           </p>
@@ -199,7 +206,7 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
           </p>
           <CodeSnippet
             text={windowsCodeSnippet}
-            onCopy={logCopyCodeSnippetWindows}
+            onCopy={() => logCopyCodeSnippet(currentSelection)}
             language="properties"
           />
           <h2 style={headingWithMargin}>Grant network access (optional)</h2>
@@ -243,7 +250,10 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
           </Table>
           <p>
             Full list of commands is available in our{' '}
-            <SafeBlankLink href="https://docs.influxdata.com/influxdb/cloud/reference/cli/influx/">
+            <SafeBlankLink 
+              href="https://docs.influxdata.com/influxdb/cloud/reference/cli/influx/"
+              onClick={handleEventing}
+            >
               documentation.
             </SafeBlankLink>{' '}
           </p>
@@ -254,13 +264,16 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
           <h2 style={headingWithMargin}>Download from the command line</h2>
           <CodeSnippet
             text={linuxCodeSnippetA}
-            onCopy={logCopyCodeSnippetLinux}
+            onCopy={() => logCopyCodeSnippet(currentSelection)}
             language="properties"
           />
           <p>
             If you prefer to manually download and install the CLI package,
             follow our{' '}
-            <SafeBlankLink href="https://docs.influxdata.com/influxdb/cloud/tools/influx-cli/?t=Linux">
+            <SafeBlankLink 
+              href="https://docs.influxdata.com/influxdb/cloud/tools/influx-cli/?t=Linux"
+              onClick={handleEventing}
+            >
               documentation.
             </SafeBlankLink>{' '}
           </p>
@@ -271,7 +284,7 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
           </p>
           <CodeSnippet
             text={linuxCodeSnippetB}
-            onCopy={logCopyCodeSnippetLinux}
+            onCopy={() => logCopyCodeSnippet(currentSelection)}
             language="properties"
           />
           <h2 style={headingWithMargin}>
@@ -283,7 +296,7 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
           </p>
           <CodeSnippet
             text={linuxCodeSnippetC}
-            onCopy={logCopyCodeSnippetLinux}
+            onCopy={() => logCopyCodeSnippet(currentSelection)}
             language="properties"
           />
           <h2 style={headingWithMargin}>Useful InfluxDB CLI commands</h2>
@@ -321,7 +334,10 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
           </Table>
           <p>
             Full list of commands is available in our{' '}
-            <SafeBlankLink href="https://docs.influxdata.com/influxdb/cloud/reference/cli/influx/">
+            <SafeBlankLink 
+              href="https://docs.influxdata.com/influxdb/cloud/reference/cli/influx/"
+              onClick={handleEventing}
+            >
               documentation.
             </SafeBlankLink>{' '}
           </p>

--- a/src/homepageExperience/containers/CliWizard.tsx
+++ b/src/homepageExperience/containers/CliWizard.tsx
@@ -26,6 +26,7 @@ import WriteDataDetailsContextProvider from 'src/writeData/components/WriteDataD
 // Utils
 import {event} from 'src/cloud/utils/reporting'
 import {HOMEPAGE_NAVIGATION_STEPS_SHORT} from 'src/homepageExperience/utils'
+import {normalizeEventName} from 'src/cloud/utils/reporting'
 import RateLimitAlert from 'src/cloud/components/RateLimitAlert'
 
 interface State {
@@ -74,7 +75,7 @@ export class CliWizard extends PureComponent<{}, State> {
           'firstMile.cliWizard.next.clicked',
           {},
           {
-            clickedButtonAtStep: this.state.currentStep - 1,
+            clickedButtonAtStep: normalizeEventName(HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep - 1].name),
             currentStep: this.state.currentStep,
           }
         )
@@ -90,7 +91,7 @@ export class CliWizard extends PureComponent<{}, State> {
           'firstMile.cliWizard.previous.clicked',
           {},
           {
-            clickedButtonAtStep: this.state.currentStep + 1,
+            clickedButtonAtStep: normalizeEventName(HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep - 1].name),
             currentStep: this.state.currentStep,
           }
         )
@@ -100,6 +101,7 @@ export class CliWizard extends PureComponent<{}, State> {
 
   handleNavClick = (clickedStep: number) => {
     this.setState({currentStep: clickedStep})
+    event('firstMile.cliWizard.subNav.clicked', {}, {currentStep: normalizeEventName(HOMEPAGE_NAVIGATION_STEPS_SHORT[clickedStep - 1].name)}) 
   }
 
   renderStep = () => {

--- a/src/homepageExperience/containers/CliWizard.tsx
+++ b/src/homepageExperience/containers/CliWizard.tsx
@@ -96,7 +96,7 @@ export class CliWizard extends PureComponent<{}, State> {
           {},
           {
             clickedButtonAtStep: normalizeEventName(
-              HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep - 1].name
+              HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep + 1].name
             ),
             currentStep: normalizeEventName(
               HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep].name

--- a/src/homepageExperience/containers/CliWizard.tsx
+++ b/src/homepageExperience/containers/CliWizard.tsx
@@ -63,46 +63,39 @@ export class CliWizard extends PureComponent<{}, State> {
   }
 
   handleNextClick = () => {
-    this.setState(
+    this.setState({
+      currentStep: Math.min(
+        this.state.currentStep + 1,
+        HOMEPAGE_NAVIGATION_STEPS_SHORT.length
+      ),
+    })
+
+    event(
+      'firstMile.cliWizard.next.clicked',
+      {},
       {
-        currentStep: Math.min(
-          this.state.currentStep + 1,
-          HOMEPAGE_NAVIGATION_STEPS_SHORT.length
+        clickedButtonAtStep: normalizeEventName(
+          HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep - 1].name
         ),
-      },
-      () => {
-        event(
-          'firstMile.cliWizard.next.clicked',
-          {},
-          {
-            clickedButtonAtStep: normalizeEventName(
-              HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep - 1].name
-            ),
-            currentStep: normalizeEventName(
-              HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep].name
-            ),
-          }
-        )
+        currentStep: normalizeEventName(
+          HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep].name
+        ),
       }
     )
   }
 
   handlePreviousClick = () => {
-    this.setState(
-      {currentStep: Math.max(this.state.currentStep - 1, 1)},
-      () => {
-        event(
-          'firstMile.cliWizard.previous.clicked',
-          {},
-          {
-            clickedButtonAtStep: normalizeEventName(
-              HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep + 1].name
-            ),
-            currentStep: normalizeEventName(
-              HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep].name
-            ),
-          }
-        )
+    this.setState({currentStep: Math.max(this.state.currentStep - 1, 1)})
+    event(
+      'firstMile.cliWizard.previous.clicked',
+      {},
+      {
+        clickedButtonAtStep: normalizeEventName(
+          HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep + 1].name
+        ),
+        currentStep: normalizeEventName(
+          HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep].name
+        ),
       }
     )
   }

--- a/src/homepageExperience/containers/CliWizard.tsx
+++ b/src/homepageExperience/containers/CliWizard.tsx
@@ -109,7 +109,15 @@ export class CliWizard extends PureComponent<{}, State> {
 
   handleNavClick = (clickedStep: number) => {
     this.setState({currentStep: clickedStep})
-    event('firstMile.cliWizard.subNav.clicked', {}, {currentStep: normalizeEventName(HOMEPAGE_NAVIGATION_STEPS_SHORT[clickedStep - 1].name)}) 
+    event(
+      'firstMile.cliWizard.subNav.clicked',
+      {},
+      {
+        currentStep: normalizeEventName(
+          HOMEPAGE_NAVIGATION_STEPS_SHORT[clickedStep - 1].name
+        ),
+      }
+    )
   }
 
   renderStep = () => {

--- a/src/homepageExperience/containers/CliWizard.tsx
+++ b/src/homepageExperience/containers/CliWizard.tsx
@@ -75,8 +75,12 @@ export class CliWizard extends PureComponent<{}, State> {
           'firstMile.cliWizard.next.clicked',
           {},
           {
-            clickedButtonAtStep: normalizeEventName(HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep - 1].name),
-            currentStep: this.state.currentStep,
+            clickedButtonAtStep: normalizeEventName(
+              HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep - 1].name
+            ),
+            currentStep: normalizeEventName(
+              HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep].name
+            ),
           }
         )
       }
@@ -91,8 +95,12 @@ export class CliWizard extends PureComponent<{}, State> {
           'firstMile.cliWizard.previous.clicked',
           {},
           {
-            clickedButtonAtStep: normalizeEventName(HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep - 1].name),
-            currentStep: this.state.currentStep,
+            clickedButtonAtStep: normalizeEventName(
+              HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep - 1].name
+            ),
+            currentStep: normalizeEventName(
+              HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep].name
+            ),
           }
         )
       }


### PR DESCRIPTION
Closes #4774 

Adding eventing in following areas: 

- Track if the user clicked the time series video on the overview page
- eventing for the previous and next buttons needs to specify the page on which it was clicked, not just the language.
- Track if a user clicked on the copy/code snippet per step/screen; where applicable
- Track if a user clicks the documentation link per step/screen

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
