### PR TITLE
fix: updates Giraffe to use the correct "caret down" icon hex value

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "@docsearch/react": "^3.0.0-alpha.37",
     "@influxdata/clockface": "^5.2.0",
     "@influxdata/flux-lsp-browser": "0.8.28",
-    "@influxdata/giraffe": "^2.33.2",
+    "@influxdata/giraffe": "^2.33.3",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",
     "abortcontroller-polyfill": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1471,10 +1471,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/flux-lsp-browser/-/flux-lsp-browser-0.8.28.tgz#4f9e4d878c45d1f84efd15d0d8727356655d0517"
   integrity sha512-TcRW4p+uCaKS3dS7Si+VqvS+bVuE4hE/WigtfuzL3leerT/YGkWXLIKchoCx7N1/J8T/rrFH0/iZuyJz+m9NDg==
 
-"@influxdata/giraffe@^2.33.2":
-  version "2.33.2"
-  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.33.2.tgz#ea0d23507adf874e3e042fd4f1b7e3f25fd1cf44"
-  integrity sha512-AtPUmBohkpLwckcsH0WGVWmENXvPpkPtGedGdHdktSbG3ouWyIHI/WdV3fCzDwOXx/gx+vI7dfui9j5HfFApPw==
+"@influxdata/giraffe@^2.33.3":
+  version "2.33.3"
+  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.33.3.tgz#4947fb7de361af301fbf3fef7ee9408b6bd821f2"
+  integrity sha512-Xpxy45JMNOKB5+eo2Srck/f9i+1kCDgmxzn9Z9lAfeHVYjPMMj7iHVxbU/uI96AX/L6ZT94pCdzsn6NUN1vEXA==
   dependencies:
     merge-images "^2.0.0"
 


### PR DESCRIPTION
Closes #5276  

FIXED, ascending:
<img width="1728" alt="Screen Shot 2022-08-03 at 10 10 35 AM" src="https://user-images.githubusercontent.com/10736577/182680748-e42a86bc-8e6d-441d-b3a9-81d221bca709.png">


FIXED, descending:
<img width="1728" alt="Screen Shot 2022-08-03 at 10 11 19 AM" src="https://user-images.githubusercontent.com/10736577/182680782-d3df2480-146a-43e6-afc2-6155fef521cc.png">
