### PR TITLE
test(flows): clear input before typing

### DIFF
--- a/cypress/e2e/cloud/flows.test.ts
+++ b/cypress/e2e/cloud/flows.test.ts
@@ -13,7 +13,7 @@ describe('Flows', () => {
       })
     })
   })
-
+  
   it('can create, clone a flow and persist selected data in the clone, and delete a flow from the list page', () => {
     cy.intercept('PATCH', '/api/v2private/notebooks/*').as('updateNotebook')
 
@@ -45,7 +45,7 @@ describe('Flows', () => {
       .first()
       .click()
 
-    cy.getByTestID('renamable-page-title--input').type(`${flowName}{enter}`)
+    cy.getByTestID('renamable-page-title--input').type(`{backspace}${flowName}{enter}`)
     cy.wait('@updateNotebook')
 
     cy.getByTestID('page-title').contains(flowName)

--- a/cypress/e2e/cloud/flows.test.ts
+++ b/cypress/e2e/cloud/flows.test.ts
@@ -13,7 +13,7 @@ describe('Flows', () => {
       })
     })
   })
-  
+
   it('can create, clone a flow and persist selected data in the clone, and delete a flow from the list page', () => {
     cy.intercept('PATCH', '/api/v2private/notebooks/*').as('updateNotebook')
 
@@ -45,7 +45,9 @@ describe('Flows', () => {
       .first()
       .click()
 
-    cy.getByTestID('renamable-page-title--input').type(`{backspace}${flowName}{enter}`)
+    cy.getByTestID('renamable-page-title--input').type(
+      `{backspace}${flowName}{enter}`
+    )
     cy.wait('@updateNotebook')
 
     cy.getByTestID('page-title').contains(flowName)


### PR DESCRIPTION
Closes #5279 

Cloud's Flows test fails with `Expected to find content: 'Flowbooks' within the element` error.

Issue is coming from cypress adding text to an already populated input field. And later, when it tries to find this new text on the page, it doesn't exist. 
To fix this, clear the input field first before adding new text.

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
