### PR TITLE
feat: add dark background to Results table and graph

### DIFF
--- a/src/dataExplorer/components/Results.scss
+++ b/src/dataExplorer/components/Results.scss
@@ -31,6 +31,14 @@ $cf-radius-lg: $cf-radius + 4px;
   height: 100%;
   width: 100%;
   padding: 12;
+
+  .visualization--simple-table--results {
+    margin-top: $cf-space-s;
+  }
+
+  table, canvas {
+    background-color: black;
+  }
 }
 
 .data-explorer-results--empty-header {

--- a/src/dataExplorer/components/Results.scss
+++ b/src/dataExplorer/components/Results.scss
@@ -36,7 +36,8 @@ $cf-radius-lg: $cf-radius + 4px;
     margin-top: $cf-space-s;
   }
 
-  table, canvas {
+  table,
+  .giraffe-plot {
     background-color: black;
   }
 }


### PR DESCRIPTION
Closes #5285 

This PR adds dark background to the table and graph to new data explorer results. 

## Before
<img width="762" alt="before 2" src="https://user-images.githubusercontent.com/14298407/182720021-cd6d6ac7-3485-4e24-a131-a812e95059d4.png">
<img width="761" alt="before 3" src="https://user-images.githubusercontent.com/14298407/182720025-ed1ef223-1467-45a2-8972-56589d867865.png">

## After
<img width="763" alt="after 2" src="https://user-images.githubusercontent.com/14298407/182720041-f6758808-9569-40fb-9552-e10d64889f57.png">
<img width="757" alt="after 3" src="https://user-images.githubusercontent.com/14298407/182720050-4e68c524-f0c2-4ed7-8f0d-098a48c6beb1.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
~~- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~~
~~- [ ] Feature flagged, if applicable~~
