### PR TITLE
test: demonstrate PoC, for server events triggering UI events.

### DIFF
--- a/src/languageSupport/languages/flux/lsp/monaco.flux.lsp.ts
+++ b/src/languageSupport/languages/flux/lsp/monaco.flux.lsp.ts
@@ -26,6 +26,11 @@ import {EditorType} from 'src/types'
 // error notification
 import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
 
+// UI interaction, outside the editor
+import {notify} from 'src/shared/actions/notifications'
+import {defaultErrorNotification} from 'src/shared/copy/notifications'
+import {storeSingleton} from 'src/store/configureStore'
+
 // install Monaco language client services
 MonacoServices.install(monaco)
 
@@ -85,6 +90,14 @@ export function initLspWorker() {
   messageWriter = new BrowserMessageWriter(worker)
   const connection = createMessageConnection(messageReader, messageWriter)
   const languageClient = createLanguageClient(connection)
+  languageClient.onTelemetry((data: unknown) => {
+    storeSingleton.dispatch(
+      notify({
+        ...defaultErrorNotification,
+        message: (data as {message: string}).message,
+      })
+    )
+  })
   const disposable = languageClient.start()
   connection.onError(e => handleConnectionError(e))
   connection.onClose(() => {

--- a/src/languageSupport/languages/flux/lsp/utils.ts
+++ b/src/languageSupport/languages/flux/lsp/utils.ts
@@ -148,3 +148,9 @@ export enum ExecuteCommand {
   InjectTag = 'injectTagFilter',
   InjectTagValue = 'injectTagValueFilter',
 }
+
+// any event that we want to UI to handle, outside of the monaco-editor
+export enum ServerUIEvent {
+  Error = 'error',
+  ShowMessage = 'showMessage',
+}

--- a/src/languageSupport/languages/flux/lsp/worker/utils.ts
+++ b/src/languageSupport/languages/flux/lsp/worker/utils.ts
@@ -1,7 +1,35 @@
+import {ServerUIEvent} from 'src/languageSupport/languages/flux/lsp/utils'
+
+const code = ['Error', 'Warning', 'Info', 'Log']
+let type = 1
+
 export const respond = (msg, cb) => {
+  if (type == 5) {
+    type = 1
+  }
   try {
     const d = JSON.parse(msg)
     cb(d)
+    // Demonstrate `window/showMessage`
+    cb({
+      jsonrpc: '2.0',
+      method: 'window/showMessage',
+      params: {
+        type,
+        message: `LSP sent a '${code[type - 1]}' response.`,
+      },
+    })
+    type++
+
+    // Demonstrate `telemetry/event`
+    cb({
+      jsonrpc: '2.0',
+      method: 'telemetry/event',
+      params: {
+        type: ServerUIEvent.ShowMessage,
+        message: 'wordz wordz wordz',
+      },
+    })
   } catch (e) {
     console.error(e)
   }

--- a/src/store/configureStore.ts
+++ b/src/store/configureStore.ts
@@ -153,7 +153,7 @@ function configureStore(
   return createPersistentStore(rootReducer(history), initialState)
 }
 
-let storeSingleton
+export let storeSingleton
 export const getStore = () => {
   if (!storeSingleton) {
     storeSingleton = configureStore()


### PR DESCRIPTION
**This is a PoC only. Not intended to merge.**


## Challenge

We need a structured way, within the LSP spec, to listen to incoming message from the LSP. And act to surface that message in the UI (not monaco-editor).


## Approach

### Discarded approaches:
- Using spec method `workspace/applyEdit`
    - This posts to the browser console.
    - <img width="223" alt="Screen Shot 2022-08-03 at 3 51 19 PM" src="https://user-images.githubusercontent.com/10232835/182730166-7d43ca40-d130-47a6-bac5-4ee12e76c448.png">

    - Instead…can we listen to this traffic?
- monaco-languageclient:
    - Listening to the connection between the LSP and the monaco-editor, using the existing interfaces provided by the monaco-languageclient.
    - options:
        - Middleware
            - Are interceptors of provider features. Such as intercepting didOpen, didChange, etc. There is no intercept provider for the `window/onMessage`.
            - Also provides overrides of the workspace and window objects. This is too heavy for our use. (We are not wrapping the Monaco-editor in our own typed LSP window target.)
        - onResponse
            - This lib is an extension of the vscode-languageserver BaseLanguageClient. Neither provides the proper interface to intercept the server response. (There is no onResponse(). This has been commented upon in other github issues too.)
            - interface: https://github.com/microsoft/vscode-languageserver-node/blob/64156c6aa08be17a1475a126b0bb2d9b6c8ba1bc/client/src/common/client.ts#L429 


### Successful approach:
- Using telemetry.
- parts:
    - Server sends `telemetry/event`
    - monaco-languageclient listener interface for onTelemetry().
- This feels like the right approach:
    - https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#telemetry_event
    - Found at least one similar use case in terraform LSP.
- Did PoC, surfaced as a simple UI notification....but we are actually going to do different things (based on design).
    - <img width="759" alt="Screen Shot 2022-08-03 at 4 25 05 PM" src="https://user-images.githubusercontent.com/10232835/182730281-5b282f3a-1661-48f9-a854-753f683f6920.png">

