### PR TITLE
chore(homePage): add eventing for helpful links

### DIFF
--- a/src/me/components/DocSearchWidget.tsx
+++ b/src/me/components/DocSearchWidget.tsx
@@ -50,9 +50,9 @@ if (CLOUD && isFlagEnabled('requestPoc')) {
   })
 }
 
-const handleEventing = title => {
-  const eventDescription = normalizeEventName(title)
-  event(`HomePage.${eventDescription}.clicked`)
+const handleEventing = eventName => {
+  const normalizedEventName = normalizeEventName(eventName)
+  event(`HomePage.${normalizedEventName}.clicked`)
 }
 
 const DocSearchWidget: FC = () => {

--- a/src/me/components/DocSearchWidget.tsx
+++ b/src/me/components/DocSearchWidget.tsx
@@ -10,7 +10,7 @@ import {DOCS_URL_VERSION} from 'src/shared/constants/fluxFunctions'
 
 // Utils
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
-import {event, normalizeEventName} from 'src/cloud/utils/reporting'
+import {event} from 'src/cloud/utils/reporting'
 
 import 'src/me/components/DocSearchWidget.scss'
 

--- a/src/me/components/DocSearchWidget.tsx
+++ b/src/me/components/DocSearchWidget.tsx
@@ -18,28 +18,38 @@ const supportLinks = [
   {
     link: `https://docs.influxdata.com/influxdb/${DOCS_URL_VERSION}/query-data/get-started/`,
     title: 'Get Started with Flux',
+    eventName: 'QueryData',
   },
   {
     link: `https://docs.influxdata.com/influxdb/${DOCS_URL_VERSION}/query-data/execute-queries/data-explorer/`,
     title: 'Explore Metrics',
+    eventName: 'DataExplorer',
   },
   {
     link: `https://docs.influxdata.com/influxdb/${DOCS_URL_VERSION}/visualize-data/dashboards/`,
     title: 'Build a Dashboard',
+    eventName: 'Dashboards',
   },
   {
     link: `https://docs.influxdata.com/influxdb/${DOCS_URL_VERSION}/process-data/get-started/`,
     title: 'Write a Task',
+    eventName: 'WriteTask',
   },
   {
     link: 'https://github.com/influxdata/ui/issues/new',
     title: 'Report a bug',
+    eventName: 'GitBugs',
   },
-  {link: 'https://community.influxdata.com', title: 'Community Forum'},
+  {
+    link: 'https://community.influxdata.com',
+    title: 'Community Forum',
+    eventName: 'Community',
+  },
   {
     link:
       'https://github.com/influxdata/influxdb/issues/new?template=feature_request.md',
     title: 'Feature Requests',
+    eventName: 'FeatureRequest',
   },
 ]
 
@@ -47,12 +57,12 @@ if (CLOUD && isFlagEnabled('requestPoc')) {
   supportLinks.push({
     link: 'https://www.influxdata.com/proof-of-concept/',
     title: 'Request Proof of Concept',
+    eventName: 'POC',
   })
 }
 
 const handleEventing = eventName => {
-  const normalizedEventName = normalizeEventName(eventName)
-  event(`HomePage.${normalizedEventName}.clicked`)
+  event(`HomePage.${eventName}.clicked`)
 }
 
 const DocSearchWidget: FC = () => {
@@ -63,13 +73,13 @@ const DocSearchWidget: FC = () => {
       <div className="useful-links">
         <h4 style={{textTransform: 'uppercase'}}>Useful Links</h4>
         <ul className="docslinks-list">
-          {supportLinks.map(({link, title}) => (
+          {supportLinks.map(({link, title, eventName}) => (
             <li key={title}>
               <a
                 href={link}
                 target="_blank"
                 rel="noreferrer"
-                onClick={() => handleEventing(title)}
+                onClick={() => handleEventing(eventName)}
               >
                 {title}
               </a>

--- a/src/me/components/DocSearchWidget.tsx
+++ b/src/me/components/DocSearchWidget.tsx
@@ -10,6 +10,7 @@ import {DOCS_URL_VERSION} from 'src/shared/constants/fluxFunctions'
 
 // Utils
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import {event, normalizeEventName} from 'src/cloud/utils/reporting'
 
 import 'src/me/components/DocSearchWidget.scss'
 
@@ -49,6 +50,11 @@ if (CLOUD && isFlagEnabled('requestPoc')) {
   })
 }
 
+const handleEventing = title => {
+  const eventDescription = normalizeEventName(title)
+  event(`HomePage.${eventDescription}.clicked`)
+}
+
 const DocSearchWidget: FC = () => {
   return (
     <div className="WidgetSearch">
@@ -59,7 +65,12 @@ const DocSearchWidget: FC = () => {
         <ul className="docslinks-list">
           {supportLinks.map(({link, title}) => (
             <li key={title}>
-              <a href={link} target="_blank" rel="noreferrer">
+              <a
+                href={link}
+                target="_blank"
+                rel="noreferrer"
+                onClick={() => handleEventing(title)}
+              >
                 {title}
               </a>
             </li>


### PR DESCRIPTION
Closes #5286 

Adds eventing in homepage for the following links:

- Get Started with Flux
- Explore Metrics
- Build a Dashboard
- Write a Task
- Report a bug
- Community Forum
- Feature Requests
- Request Proof of Concept

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
