### PR TITLE
fix(5073): enable handling of empty LSP responses

### DIFF
--- a/src/languageSupport/languages/flux/lsp/worker/utils.ts
+++ b/src/languageSupport/languages/flux/lsp/worker/utils.ts
@@ -1,5 +1,9 @@
 export const respond = (msg, cb) => {
   try {
+    // LSP spec permits a blank response
+    if (!msg) {
+      return
+    }
     const d = JSON.parse(msg)
     cb(d)
   } catch (e) {


### PR DESCRIPTION
Closes #5073 

We have JSON.parse() errors in the console. It's because we are not handling the use case of no response sent from the LSP.


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
