### PR TITLE
fix: correct globalheader switch-account URL.

### DIFF
--- a/src/identity/components/GlobalHeader/AccountDropdown.tsx
+++ b/src/identity/components/GlobalHeader/AccountDropdown.tsx
@@ -39,12 +39,12 @@ export const AccountDropdown: FC<Props> = ({
     {
       name: 'Settings',
       iconFont: IconFont.CogSolid_New,
-      href: `${CLOUD_URL}/orgs/${activeOrg.id}/accounts/settings`,
+      href: `/orgs/${activeOrg.id}/accounts/settings`,
     },
     {
       name: 'Billing',
       iconFont: IconFont.Bill,
-      href: `${CLOUD_URL}/orgs/${activeOrg.id}/billing`,
+      href: `/orgs/${activeOrg.id}/billing`,
     },
   ]
 

--- a/src/identity/components/GlobalHeader/AccountDropdown.tsx
+++ b/src/identity/components/GlobalHeader/AccountDropdown.tsx
@@ -1,12 +1,10 @@
+// Libraries
 import React, {FC} from 'react'
 import {IconFont} from '@influxdata/clockface'
-import {OrganizationSummaries, UserAccount} from 'src/client/unityRoutes'
-import {
-  GlobalHeaderDropdown,
-  TypeAheadMenuItem,
-} from 'src/identity/components/GlobalHeader/GlobalHeaderDropdown'
 
+// Types
 type OrgSummaryItem = OrganizationSummaries[number]
+import {OrganizationSummaries, UserAccount} from 'src/client/unityRoutes'
 
 interface Props {
   activeOrg: OrgSummaryItem
@@ -14,8 +12,18 @@ interface Props {
   accountsList: UserAccount[]
 }
 
+// Styles
 const style = {width: 'auto'}
 const menuStyle = {width: '250px'}
+
+// Components
+import {
+  GlobalHeaderDropdown,
+  TypeAheadMenuItem,
+} from 'src/identity/components/GlobalHeader/GlobalHeaderDropdown'
+
+// Constants
+import {CLOUD_URL} from 'src/shared/constants'
 
 export const AccountDropdown: FC<Props> = ({
   activeOrg,
@@ -31,18 +39,18 @@ export const AccountDropdown: FC<Props> = ({
     {
       name: 'Settings',
       iconFont: IconFont.CogSolid_New,
-      href: `/orgs/${activeOrg.id}/accounts/settings`,
+      href: `${CLOUD_URL}/orgs/${activeOrg.id}/accounts/settings`,
     },
     {
       name: 'Billing',
       iconFont: IconFont.Bill,
-      href: `/orgs/${activeOrg.id}/billing`,
+      href: `${CLOUD_URL}/orgs/${activeOrg.id}/billing`,
     },
   ]
 
   // Quartz handles switching accounts by having the user hit this URL.
   const switchAccount = (account: TypeAheadMenuItem) => {
-    window.location.href = `orgs/${activeOrg.id}/accounts/${account.id}`
+    window.location.href = `${CLOUD_URL}/accounts/${account.id}`
   }
 
   return (

--- a/src/identity/components/GlobalHeader/OrgDropdown.tsx
+++ b/src/identity/components/GlobalHeader/OrgDropdown.tsx
@@ -33,17 +33,17 @@ export const OrgDropdown: FC<Props> = ({activeOrg, orgsList}) => {
     {
       name: 'Settings',
       iconFont: IconFont.CogSolid_New,
-      href: `${CLOUD_URL}/orgs/${activeOrg.id}/about`,
+      href: `/orgs/${activeOrg.id}/about`,
     },
     {
       name: 'Members',
       iconFont: IconFont.Group,
-      href: `${CLOUD_URL}/orgs/${activeOrg.id}/users`,
+      href: `/orgs/${activeOrg.id}/users`,
     },
     {
       name: 'Usage',
       iconFont: IconFont.PieChart,
-      href: `${CLOUD_URL}/orgs/${activeOrg.id}/usage`,
+      href: `/orgs/${activeOrg.id}/usage`,
     },
   ]
 

--- a/src/identity/components/GlobalHeader/OrgDropdown.tsx
+++ b/src/identity/components/GlobalHeader/OrgDropdown.tsx
@@ -1,13 +1,21 @@
+// Libraries
 import React, {FC} from 'react'
-import {OrganizationSummaries} from 'src/client/unityRoutes'
+import {IconFont} from '@influxdata/clockface'
+
+// Components
 import {
   TypeAheadMenuItem,
   GlobalHeaderDropdown,
 } from 'src/identity/components/GlobalHeader/GlobalHeaderDropdown'
-import {IconFont} from '@influxdata/clockface'
+
+// Types
+import {OrganizationSummaries} from 'src/client/unityRoutes'
+
+// Constants
+import {CLOUD_URL} from 'src/shared/constants'
 
 const switchOrg = (org: TypeAheadMenuItem) => {
-  window.location.href = `/orgs/${org.id}`
+  window.location.href = `${CLOUD_URL}/orgs/${org.id}`
 }
 
 type OrgSummaryItem = OrganizationSummaries[number]
@@ -25,17 +33,17 @@ export const OrgDropdown: FC<Props> = ({activeOrg, orgsList}) => {
     {
       name: 'Settings',
       iconFont: IconFont.CogSolid_New,
-      href: `/orgs/${activeOrg.id}/about`,
+      href: `${CLOUD_URL}/orgs/${activeOrg.id}/about`,
     },
     {
       name: 'Members',
       iconFont: IconFont.Group,
-      href: `/orgs/${activeOrg.id}/users`,
+      href: `${CLOUD_URL}/orgs/${activeOrg.id}/users`,
     },
     {
       name: 'Usage',
       iconFont: IconFont.PieChart,
-      href: `/orgs/${activeOrg.id}/usage`,
+      href: `${CLOUD_URL}/orgs/${activeOrg.id}/usage`,
     },
   ]
 


### PR DESCRIPTION
Closes #5293

Switch-account in GlobalHeader was not working because the URL the user needs to visit to change accounts should be `${CLOUD_URL}/accounts/:accountId` (not the current URL that included the org id - like `/orgs/:orgId/accounts/:accountId`. We can be confident this works effectively, since this exact URL is used on the switch account page (which works).   

The switch orgs URL should be similarly updated to `$CLOUD_URL/orgs/:orgId`.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - YES, `multiOrg`
