### PR TITLE
fix: get measurement list on page refresh

### DIFF
--- a/src/dataExplorer/context/fluxQueryBuilder.tsx
+++ b/src/dataExplorer/context/fluxQueryBuilder.tsx
@@ -5,6 +5,7 @@ import React, {
   useMemo,
   useContext,
   useCallback,
+  useEffect,
 } from 'react'
 
 // Context
@@ -74,6 +75,15 @@ export const FluxQueryBuilderProvider: FC = ({children}) => {
   // States
   const {selection, setSelection} = useContext(PersistanceContext)
   const [searchTerm, setSearchTerm] = useState('')
+
+  useEffect(() => {
+    if (selection.bucket && selection.measurement) {
+      // On page refresh, measurements become empty even though
+      // a bucket and a measurement are selected,
+      // so we should get measurements here
+      getMeasurements(selection.bucket)
+    }
+  }, [selection.bucket])
 
   const handleSelectBucket = (bucket: Bucket): void => {
     selection.bucket = bucket


### PR DESCRIPTION
Closes #5280 

This PR fixes the bug that measurement selector becomes disabled on page refresh.

## Before

https://user-images.githubusercontent.com/14298407/182942026-62726dc3-e63f-41ba-b067-37ef9e603244.mov


## After

https://user-images.githubusercontent.com/14298407/182942036-124e702f-85b5-47e5-ac91-a06c6b4bd4c7.mov


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
~~- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~~
~~- [ ] Feature flagged, if applicable~~
