### PR TITLE
chore(identity): tweak getCurrentOrgDetailsThunk signature and when it's called

### DIFF
--- a/src/cloud/components/OrgSettings.tsx
+++ b/src/cloud/components/OrgSettings.tsx
@@ -1,11 +1,9 @@
 // Libraries
 import {FC, useEffect} from 'react'
-import {useSelector, useDispatch} from 'react-redux'
+import {useSelector} from 'react-redux'
 
 // Utils
 import {updateReportingContext} from 'src/cloud/utils/reporting'
-import {getCurrentOrgDetailsThunk} from 'src/identity/actions/thunks'
-import {shouldUseQuartzIdentity} from 'src/identity/utils/shouldUseQuartzIdentity'
 import {getQuartzMe} from 'src/me/selectors'
 
 // Constants
@@ -16,20 +14,9 @@ interface Props {
 }
 
 const OrgSettings: FC<Props> = ({children}) => {
-  const dispatch = useDispatch()
-
   const quartzMe = useSelector(getQuartzMe)
   const isRegionBeta = quartzMe?.isRegionBeta ?? false
   const accountType = quartzMe?.accountType ?? 'free'
-
-  useEffect(() => {
-    if (!CLOUD) {
-      return
-    }
-    if (shouldUseQuartzIdentity() && !quartzMe?.isRegionBeta) {
-      dispatch(getCurrentOrgDetailsThunk())
-    }
-  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (CLOUD) {

--- a/src/identity/actions/thunks/index.ts
+++ b/src/identity/actions/thunks/index.ts
@@ -90,15 +90,12 @@ export const getBillingProviderThunk = () => async (
   }
 }
 
-export const getCurrentOrgDetailsThunk = () => async (
+export const getCurrentOrgDetailsThunk = (orgId: string) => async (
   dispatch: any,
   getState: GetState
 ) => {
   try {
     dispatch(setQuartzIdentityStatus(RemoteDataState.Loading))
-
-    const state = getState()
-    const orgId = state.identity.currentIdentity.org.id
 
     const orgDetails = await fetchOrgDetails(orgId)
 

--- a/src/organizations/components/OrgProfileTab/index.tsx
+++ b/src/organizations/components/OrgProfileTab/index.tsx
@@ -38,14 +38,16 @@ const OrgProfileTab: FC = () => {
 
   const dispatch = useDispatch()
 
+  const identityOrgId = identity.currentIdentity.org.id
+
   useEffect(() => {
-    if (CLOUD && shouldUseQuartzIdentity()) {
+    if (identityOrgId && CLOUD && shouldUseQuartzIdentity()) {
       if (
         !me.quartzMe.regionCode ||
         !me.quartzMe.regionName ||
         !identity.currentIdentity.org.provider
       ) {
-        dispatch(getCurrentOrgDetailsThunk())
+        dispatch(getCurrentOrgDetailsThunk(identityOrgId))
       }
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps

--- a/src/shared/containers/GetOrganizations.tsx
+++ b/src/shared/containers/GetOrganizations.tsx
@@ -20,6 +20,7 @@ import RouteToOrg from 'src/shared/containers/RouteToOrg'
 // Selectors
 import {getAllOrgs} from 'src/resources/selectors'
 import {getMe, getQuartzMe} from 'src/me/selectors'
+import {selectQuartzIdentity} from 'src/identity/selectors'
 
 // Constants
 import {CLOUD} from 'src/shared/constants'
@@ -47,6 +48,7 @@ const canAccessCheckout = (me: Me): boolean => {
 
 const GetOrganizations: FunctionComponent = () => {
   const {status, org} = useSelector(getAllOrgs)
+  const identity = useSelector(selectQuartzIdentity)
 
   const quartzMeStatus = useSelector(
     (state: AppState) => state.me.quartzMeStatus
@@ -60,11 +62,18 @@ const GetOrganizations: FunctionComponent = () => {
   const {id: meId = '', name: email = ''} = useSelector(getMe)
   const dispatch = useDispatch()
 
+  const identityOrgId = identity.currentIdentity.org.id
+
   useEffect(() => {
-    if (CLOUD && shouldUseQuartzIdentity() && quartzMe?.isRegionBeta === null) {
-      dispatch(getCurrentOrgDetailsThunk())
+    if (
+      identityOrgId &&
+      CLOUD &&
+      shouldUseQuartzIdentity() &&
+      !quartzMe?.isRegionBeta
+    ) {
+      dispatch(getCurrentOrgDetailsThunk(identityOrgId))
     }
-  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [identityOrgId]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // This doesn't require another API call.
   useEffect(() => {


### PR DESCRIPTION
While working on reducing re-renders, it became apparent that the call to `getCurrentOrgDetailsThunk` in `GetOrganizations` wasn't currently doing anything and was called later in the component tree. This PR removes the later call and tweaks the call in `GetOrganizations` so that it relies on `org.id`. This has the effect of making call slightly more obvious, and reducing re-renders, since `GetOrganizations` doesn't have to wait on deeper component to populate data.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- ~[ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~
- ~[ ] Feature flagged, if applicable~
