### PR TITLE
fix: always return options

### DIFF
--- a/src/shared/contexts/query.tsx
+++ b/src/shared/contexts/query.tsx
@@ -369,7 +369,6 @@ const updateWindowPeriod = (
       return optionAST
     }
 
-    // TODO write window period back out to json object
     return options
   }
   try {

--- a/src/shared/contexts/query.tsx
+++ b/src/shared/contexts/query.tsx
@@ -365,7 +365,12 @@ const updateWindowPeriod = (
         node?.property?.name === 'windowPeriod'
     ).length
   ) {
-    return
+    if (mode === 'ast') {
+      return optionAST
+    }
+
+    // TODO write window period back out to json object
+    return options
   }
   try {
     const _optionAST = JSON.parse(JSON.stringify(optionAST))


### PR DESCRIPTION
Closes #5310 

in addressing some PR comments for #5270, i lost a few return conditions. adding them back here to ensure that options is always populated, even if windowPeriod isn't detected