### PR TITLE
perf(GetOrganizations): memoize getAllOrgs selector

### DIFF
--- a/src/resources/selectors/index.ts
+++ b/src/resources/selectors/index.ts
@@ -1,12 +1,12 @@
 // Libraries
 import {get} from 'lodash'
+import {createSelector} from 'reselect'
 
 // Types
 import {
   AppState,
   Bucket,
   Label,
-  OrgsState,
   RemoteDataState,
   ResourceType,
   Secret,
@@ -74,10 +74,18 @@ export const getLabels = (state: AppState, labelIDs: string[]): Label[] => {
 export const getAllTokensResources = (state: AppState): PermissionTypes[] =>
   get(state, 'resources.tokens.allResources', []) || []
 
-export const getAllOrgs = (state: AppState): OrgsState => {
-  const errorOrgsState = {
-    status: RemoteDataState.Error,
-    org: {id: ''},
+export const getAllOrgs = createSelector(
+  (state: AppState) => state.resources[ResourceType.Orgs],
+  orgs => {
+    const errorOrgsState = {
+      status: RemoteDataState.Error,
+      org: {id: ''},
+    }
+
+    if (!orgs) {
+      return errorOrgsState
+    }
+
+    return orgs
   }
-  return get(state, 'resources.orgs', errorOrgsState)
-}
+)


### PR DESCRIPTION
Connects #5234 

Memoize the `getAllOrgs` selector, which is only called from `GetOrganizations` for a modest performance gain. This results in the same number of render calls for `GetOrganizations`, but fewer calls to `getAllOrgs`.

### Before
| Function Name    | Number of Calls |
|------------------|-----------------|
| getAllOrgs       | 21              |
| GetOrganizations | 10              |

### After
| Function Name    | Number of Calls |
|------------------|-----------------|
| getAllOrgs       | 4               |
| GetOrganizations | 10              |

### Before
![before](https://user-images.githubusercontent.com/146112/183140706-61ef5060-b9a8-4168-ad87-66664c63a4d8.png)

### After
![after](https://user-images.githubusercontent.com/146112/183140725-fc5e53c4-31d3-445b-9c67-f83e21e10275.png)


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- ~[ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~
- ~[ ] Feature flagged, if applicable~
