### PR TITLE
fix: cap the estimated height to the screen height

### DIFF
--- a/src/visualization/types/SimpleTable/PagedTable.tsx
+++ b/src/visualization/types/SimpleTable/PagedTable.tsx
@@ -278,7 +278,9 @@ const PagedTable: FC<Props> = ({result, properties}) => {
 
       timeout = setTimeout(() => {
         animationFrameID = requestAnimationFrame(() => {
-          setHeight(entries[0].contentRect.height)
+          setHeight(
+            Math.min(entries[0].contentRect.height, window.screen.height)
+          )
         })
       }, 200)
     })
@@ -290,7 +292,7 @@ const PagedTable: FC<Props> = ({result, properties}) => {
     const rect = curr?.getBoundingClientRect()
 
     if (rect && rect.height !== height) {
-      setHeight(rect.height)
+      setHeight(Math.min(rect.height, window.screen.height))
     }
 
     return () => {


### PR DESCRIPTION
Closes #5317  

Cap the estimated initial height. This prevents further calculations on ridiculously large heights that wouldn't fit everything on the screen anyways.