### PR TITLE
chore: remove fastFromFlux flag

### DIFF
--- a/src/alerting/utils/activity.ts
+++ b/src/alerting/utils/activity.ts
@@ -1,8 +1,7 @@
 // Utils
 import {runQuery} from 'src/shared/apis/query'
-import {fromFlux, fastFromFlux} from '@influxdata/giraffe'
+import {fromFlux} from '@influxdata/giraffe'
 import {event} from 'src/cloud/utils/reporting'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Constants
 import {MONITORING_BUCKET} from 'src/alerting/constants'
@@ -55,9 +54,7 @@ export const processResponse = ({
       return Promise.reject(new Error(resp.message))
     }
 
-    const {table} = isFlagEnabled('fastFromFlux')
-      ? fastFromFlux(resp.csv)
-      : fromFlux(resp.csv)
+    const {table} = fromFlux(resp.csv)
     const rows: Row[] = []
 
     for (let i = 0; i < table.length; i++) {

--- a/src/alerting/utils/history.test.ts
+++ b/src/alerting/utils/history.test.ts
@@ -6,7 +6,6 @@ import {runQuery} from 'src/shared/apis/query'
 
 jest.mock('@influxdata/giraffe', () => ({
   fromFlux: jest.fn(),
-  fastFromFlux: jest.fn(),
   // todo: test will fails on binaryPrefixFormatter not a function in src/shared/copy/notifications.ts:22:24 this mock can be removed after this will be fixed
   binaryPrefixFormatter: jest.fn(),
 }))

--- a/src/alerting/utils/history.ts
+++ b/src/alerting/utils/history.ts
@@ -1,12 +1,11 @@
 // Libraries
-import {fromFlux, fastFromFlux} from '@influxdata/giraffe'
+import {fromFlux} from '@influxdata/giraffe'
 
 // Utils
 import {runQuery, RunQueryResult} from 'src/shared/apis/query'
 import {parseSearchInput, searchExprToFlux} from 'src/eventViewer/utils/search'
 import {findNodes} from 'src/shared/utils/ast'
 import {event} from 'src/cloud/utils/reporting'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Constants
 import {
@@ -150,9 +149,7 @@ export const processResponse = ({
       return Promise.reject(new Error(resp.message))
     }
 
-    const {table} = isFlagEnabled('fastFromFlux')
-      ? fastFromFlux(resp.csv)
-      : fromFlux(resp.csv)
+    const {table} = fromFlux(resp.csv)
     const rows: Row[] = []
 
     for (let i = 0; i < table.length; i++) {

--- a/src/alerting/utils/statusEvents.test.ts
+++ b/src/alerting/utils/statusEvents.test.ts
@@ -5,7 +5,6 @@ import {mocked} from 'ts-jest/utils'
 
 jest.mock('@influxdata/giraffe', () => ({
   fromFlux: jest.fn(),
-  fastFromFlux: jest.fn(),
   // todo: test will fails on binaryPrefixFormatter not a function in src/shared/copy/notifications.ts:22:24 this mock can be removed after this will be fixed
   binaryPrefixFormatter: jest.fn(),
 }))

--- a/src/alerting/utils/statusEvents.ts
+++ b/src/alerting/utils/statusEvents.ts
@@ -1,8 +1,7 @@
 // Utils
 import {runQuery} from 'src/shared/apis/query'
-import {fromFlux, fastFromFlux} from '@influxdata/giraffe'
+import {fromFlux} from '@influxdata/giraffe'
 import {event} from 'src/cloud/utils/reporting'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Constants
 import {MONITORING_BUCKET} from 'src/alerting/constants'
@@ -51,9 +50,7 @@ export const processStatusesResponse = ({
       return Promise.reject(new Error(resp.message))
     }
 
-    const {table} = isFlagEnabled(resp.csv)
-      ? fastFromFlux(resp.csv)
-      : fromFlux(resp.csv)
+    const {table} = fromFlux(resp.csv)
 
     const rows: Row[][] = [[]]
 

--- a/src/cloud/components/onboarding/useGetUserStatus.ts
+++ b/src/cloud/components/onboarding/useGetUserStatus.ts
@@ -1,4 +1,4 @@
-import {fromFlux, fastFromFlux} from '@influxdata/giraffe'
+import {fromFlux} from '@influxdata/giraffe'
 import {event} from 'src/cloud/utils/reporting'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {Table} from '@influxdata/giraffe'
@@ -92,8 +92,7 @@ export const queryUsage = async (orgID: string, range?: string) => {
     csvToParse = usageStatsCsv
   }
 
-  const parser = isFlagEnabled('fastFromFlux') ? fastFromFlux : fromFlux
-  const {table} = parser(csvToParse)
+  const {table} = fromFlux(csvToParse)
   return table
 }
 

--- a/src/flows/components/ReadOnly.tsx
+++ b/src/flows/components/ReadOnly.tsx
@@ -2,8 +2,7 @@
 import React, {FC, useContext, useEffect} from 'react'
 import {AppWrapper, DapperScrollbars, Page} from '@influxdata/clockface'
 import {useParams} from 'react-router'
-import {fromFlux, fastFromFlux} from '@influxdata/giraffe'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import {fromFlux} from '@influxdata/giraffe'
 
 // Contexts
 import {FlowProvider} from 'src/flows/context/shared'
@@ -48,9 +47,7 @@ const RunPipeResults: FC = () => {
         .then(res =>
           res.text().then(resp => {
             if (res.status == 200) {
-              const csv = isFlagEnabled('fastFromFlux')
-                ? fastFromFlux(resp)
-                : fromFlux(resp)
+              const csv = fromFlux(resp)
               setResult(id, {parsed: csv, source: ''})
               setStatuses({[id]: RemoteDataState.Done})
             } else {

--- a/src/shared/components/TimeSeries.tsx
+++ b/src/shared/components/TimeSeries.tsx
@@ -3,7 +3,7 @@ import React, {Component, RefObject, CSSProperties} from 'react'
 import {isEqual} from 'lodash'
 import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
-import {fromFlux, fastFromFlux, FromFluxResult} from '@influxdata/giraffe'
+import {fromFlux, FromFluxResult} from '@influxdata/giraffe'
 
 // API
 import {RunQueryResult, RunQuerySuccessResult} from 'src/shared/apis/query'
@@ -46,7 +46,6 @@ import {
   CancelBox,
 } from 'src/types'
 import {event} from 'src/cloud/utils/reporting'
-import {isFlagEnabled} from '../utils/featureFlag'
 
 interface QueriesState {
   files: string[] | null
@@ -299,8 +298,7 @@ class TimeSeries extends Component<Props, State> {
       }
 
       const files = (results as RunQuerySuccessResult[]).map(r => r.csv)
-      const parser = isFlagEnabled('fastFromFlux') ? fastFromFlux : fromFlux
-      const giraffeResult = parser(files.join('\n\n'))
+      const giraffeResult = fromFlux(files.join('\n\n'))
 
       this.pendingReload = false
       // this check prevents a memory leak https://github.com/influxdata/ui/issues/2137

--- a/src/shared/contexts/query.tsx
+++ b/src/shared/contexts/query.tsx
@@ -8,7 +8,7 @@ import {
 } from 'src/cloud/constants'
 
 import {getOrg} from 'src/organizations/selectors'
-import {fromFlux, fastFromFlux} from '@influxdata/giraffe'
+import {fromFlux} from '@influxdata/giraffe'
 import {FluxResult} from 'src/types/flows'
 import {propertyTime} from 'src/shared/utils/getMinDurationFromAST'
 
@@ -611,12 +611,7 @@ export const QueryProvider: FC = ({children}) => {
 
         return raw
       })
-      .then(raw => {
-        if (isFlagEnabled('fastFromFlux')) {
-          return fastFromFlux(raw.csv)
-        }
-        return fromFlux(raw.csv)
-      })
+      .then(raw => fromFlux(raw.csv))
       .then(
         parsed =>
           ({

--- a/src/timeMachine/apis/queryBuilder.ts
+++ b/src/timeMachine/apis/queryBuilder.ts
@@ -1,5 +1,5 @@
 // Libraries
-import {fromFlux, fastFromFlux} from '@influxdata/giraffe'
+import {fromFlux} from '@influxdata/giraffe'
 
 // APIs
 import {runQuery, RunQueryResult} from 'src/shared/apis/query'
@@ -174,9 +174,7 @@ export function extractBoxedCol(
 }
 
 export function extractCol(csv: string, colName: string): string[] {
-  const {table} = isFlagEnabled('fastFromFlux')
-    ? fastFromFlux(csv)
-    : fromFlux(csv)
+  const {table} = fromFlux(csv)
   return table.getColumn(colName, 'string') || []
 }
 

--- a/src/timeMachine/components/Vis.tsx
+++ b/src/timeMachine/components/Vis.tsx
@@ -2,7 +2,7 @@
 import React, {FC, memo, useEffect} from 'react'
 import {connect, ConnectedProps, useDispatch} from 'react-redux'
 import classnames from 'classnames'
-import {createGroupIDColumn, fromFlux, fastFromFlux} from '@influxdata/giraffe'
+import {createGroupIDColumn, fromFlux} from '@influxdata/giraffe'
 import {isEqual} from 'lodash'
 
 // Components
@@ -25,7 +25,6 @@ import {
   getYSeriesColumns,
 } from 'src/timeMachine/selectors'
 import {getTimeRangeWithTimezone} from 'src/dashboards/selectors'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {getColorMappingObjects} from 'src/visualization/utils/colorMappingUtils'
 
 // Types
@@ -120,8 +119,7 @@ const TimeMachineVis: FC<Props> = ({
 
   // Handles deadman check edge case to allow non-numeric values
   if (viewRawData && files && files?.length) {
-    const parser = isFlagEnabled('fastFromFlux') ? fastFromFlux : fromFlux
-    const [parsedResults] = files.flatMap(parser)
+    const [parsedResults] = files.flatMap(fromFlux)
     return (
       <div className={timeMachineViewClassName}>
         <ErrorBoundary>

--- a/src/timeMachine/selectors/index.ts
+++ b/src/timeMachine/selectors/index.ts
@@ -1,7 +1,7 @@
 // Libraries
 import memoizeOne from 'memoize-one'
 import {get} from 'lodash'
-import {fromFlux, fastFromFlux, Table} from '@influxdata/giraffe'
+import {fromFlux, Table} from '@influxdata/giraffe'
 
 // Utils
 import {
@@ -13,7 +13,6 @@ import {
   getStringColumns as getStringColumnsUtil,
   getMainColumnName,
 } from 'src/shared/utils/vis'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 import {
   calcWindowPeriodForDuration,
@@ -112,9 +111,7 @@ export const getWindowPeriodFromTimeRange = (state: AppState): string => {
   )
 }
 
-const getVisTableMemoized = isFlagEnabled('fastFromFlux')
-  ? memoizeOne(fastFromFlux)
-  : memoizeOne(fromFlux)
+const getVisTableMemoized = memoizeOne(fromFlux)
 
 export const getVisTable = (
   state: AppState

--- a/src/usage/context/usage.tsx
+++ b/src/usage/context/usage.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC, useCallback, useEffect, useMemo, useState} from 'react'
-import {fromFlux, fastFromFlux, FromFluxResult} from '@influxdata/giraffe'
+import {fromFlux, FromFluxResult} from '@influxdata/giraffe'
 import {useSelector} from 'react-redux'
 
 // Utils
@@ -11,7 +11,6 @@ import {
   getUsageVectors,
   getUsageRateLimits,
 } from 'src/client/unityRoutes'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Constants
 import {PAYG_CREDIT_DAYS} from 'src/shared/constants'
@@ -112,7 +111,6 @@ export const UsageProvider: FC<Props> = React.memo(({children}) => {
     DEFAULT_USAGE_TIME_RANGE
   )
   const {quartzMe} = useSelector(getMe)
-  const parser = isFlagEnabled('fastFromFlux') ? fastFromFlux : fromFlux
 
   const paygCreditStartDate = quartzMe?.paygCreditStartDate ?? ''
 
@@ -192,7 +190,7 @@ export const UsageProvider: FC<Props> = React.memo(({children}) => {
       query_count: v => (v * 0.01) / 100,
     }
 
-    const values = parser(csvData).table.getColumn(vector_name) as Array<any>
+    const values = fromFlux(csvData).table.getColumn(vector_name) as Array<any>
     if (!values) {
       return 0
     }
@@ -258,7 +256,7 @@ export const UsageProvider: FC<Props> = React.memo(({children}) => {
 
       const csv = resp.data?.trim().replace(/\r\n/g, '\n')
 
-      const csvs = csv.split('\n\n').map(c => parser(c))
+      const csvs = csv.split('\n\n').map(c => fromFlux(c))
 
       setBillingStatsStatus(RemoteDataState.Done)
       setBillingStats(csvs)
@@ -319,7 +317,7 @@ export const UsageProvider: FC<Props> = React.memo(({children}) => {
         throw new Error(resp.data.message)
       }
 
-      const fromFluxResult = parser(resp.data)
+      const fromFluxResult = fromFlux(resp.data)
 
       setRateLimits(fromFluxResult)
       setRateLimitsStatus(RemoteDataState.Done)

--- a/src/variables/utils/ValueFetcher.ts
+++ b/src/variables/utils/ValueFetcher.ts
@@ -1,13 +1,12 @@
 // APIs
 import {runQuery} from 'src/shared/apis/query'
-import {fromFlux, fastFromFlux} from '@influxdata/giraffe'
+import {fromFlux} from '@influxdata/giraffe'
 
 // Utils
 import {resolveSelectedKey} from 'src/variables/utils/resolveSelectedValue'
 import {formatVarsOption} from 'src/variables/utils/formatVarsOption'
 import {buildUsedVarsOption} from 'src/variables/utils/buildVarsOption'
 import {event} from 'src/cloud/utils/reporting'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Types
 import {
@@ -41,9 +40,7 @@ export const extractValues = (
   prevSelection?: string,
   defaultSelection?: string
 ): VariableValues => {
-  const {table} = isFlagEnabled('fastFromFlux')
-    ? fastFromFlux(csv)
-    : fromFlux(csv)
+  const {table} = fromFlux(csv)
   if (!table || !table.getColumn('_value', 'string')) {
     return {
       values: [],


### PR DESCRIPTION
This PR removes the fastFromFlux feature flag. The purpose of this feature flag was to allow ongoing performance work to the fromFlux CSV parser without breaking UI functionality. This work gave us the opportunity to iterate upon the fromFlux parser incrementally without introducing new breaking changes, while also enabling us to have a failsafe in case something did go wrong with the new implementation. Since the performance gains have been significant, have been ported over to the fromFlux parser, AND since there are no plans in the foreseeable future to iterate on the fromFlux parser after the latest changes, this PR simply removes the conditional logic that was put in place to support the stability of the UI