### PR TITLE
perf(GetOrganizations): move selector creation to outside of component

### DIFF
--- a/src/identity/selectors/index.ts
+++ b/src/identity/selectors/index.ts
@@ -1,9 +1,13 @@
 // Types
 import {AppState} from 'src/types'
+import {RemoteDataState} from '@influxdata/clockface'
 
 export const selectQuartzIdentity = (state: AppState): AppState['identity'] => {
   return state.identity
 }
+
+export const selectQuartzIdentityStatus = (state: AppState): RemoteDataState =>
+  state.identity.currentIdentity.status
 
 export const selectQuartzOrgs = (
   state: AppState

--- a/src/me/selectors/index.ts
+++ b/src/me/selectors/index.ts
@@ -1,5 +1,6 @@
 // Types
 import {AppState, Me} from 'src/types'
+import {RemoteDataState} from '@influxdata/clockface'
 
 // Utils
 import {convertStringToEpoch} from 'src/shared/utils/dateTimeUtils'
@@ -11,7 +12,9 @@ export const getMe = (state: AppState): AppState['me'] => {
   return state.me
 }
 
-export const getQuartzMe = (state: AppState): Me => state.me.quartzMe
+export const getQuartzMe = (state: AppState): Me => state?.me?.quartzMe
+export const getQuartzMeStatus = (state: AppState): RemoteDataState =>
+  state?.me?.quartzMeStatus
 
 export const shouldGetCredit250Experience = (state: AppState): boolean => {
   const accountType = state.me.quartzMe?.accountType ?? ''

--- a/src/shared/containers/GetOrganizations.tsx
+++ b/src/shared/containers/GetOrganizations.tsx
@@ -19,8 +19,11 @@ import RouteToOrg from 'src/shared/containers/RouteToOrg'
 
 // Selectors
 import {getAllOrgs} from 'src/resources/selectors'
-import {getMe, getQuartzMe} from 'src/me/selectors'
-import {selectQuartzIdentity} from 'src/identity/selectors'
+import {getMe, getQuartzMe, getQuartzMeStatus} from 'src/me/selectors'
+import {
+  selectQuartzIdentity,
+  selectQuartzIdentityStatus,
+} from 'src/identity/selectors'
 
 // Constants
 import {CLOUD} from 'src/shared/constants'
@@ -28,16 +31,18 @@ import {CLOUD} from 'src/shared/constants'
 // Utils
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {convertStringToEpoch} from 'src/shared/utils/dateTimeUtils'
+import {shouldUseQuartzIdentity} from 'src/identity/utils/shouldUseQuartzIdentity'
 
 // Types
 import {Me} from 'src/client/unityRoutes'
 import {PROJECT_NAME} from 'src/flows'
-import {getCurrentOrgDetailsThunk} from 'src/identity/actions/thunks'
-import {shouldUseQuartzIdentity} from 'src/identity/utils/shouldUseQuartzIdentity'
-import {RemoteDataState, AppState} from 'src/types'
+import {RemoteDataState} from 'src/types'
 
 // Thunks
-import {getQuartzIdentityThunk} from 'src/identity/actions/thunks'
+import {
+  getCurrentOrgDetailsThunk,
+  getQuartzIdentityThunk,
+} from 'src/identity/actions/thunks'
 
 const canAccessCheckout = (me: Me): boolean => {
   if (!!me?.isRegionBeta) {
@@ -49,17 +54,11 @@ const canAccessCheckout = (me: Me): boolean => {
 const GetOrganizations: FunctionComponent = () => {
   const {status, org} = useSelector(getAllOrgs)
   const identity = useSelector(selectQuartzIdentity)
-
-  const quartzMeStatus = useSelector(
-    (state: AppState) => state.me.quartzMeStatus
-  )
+  const quartzMeStatus = useSelector(getQuartzMeStatus)
   const quartzMe = useSelector(getQuartzMe)
-
-  const quartzIdentityStatus = useSelector(
-    (state: AppState) => state.identity.currentIdentity.status
-  )
-
+  const quartzIdentityStatus = useSelector(selectQuartzIdentityStatus)
   const {id: meId = '', name: email = ''} = useSelector(getMe)
+
   const dispatch = useDispatch()
 
   const identityOrgId = identity.currentIdentity.org.id


### PR DESCRIPTION
Connects #5234

Moves selectors created in `GetOrganizations.tsx` into their own selector files. There probably isn't any performance to be gained from this, but it makes things easier and simpler in general, especially for future work when trying to memoize selectors.

From the react-redux docs:

>When using `useSelector` with an inline selector as shown above, a new instance of the selector is created whenever the component is rendered. This works as long as the selector does not maintain any state.

https://react-redux.js.org/api/hooks

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- ~[ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~
- ~[ ] Feature flagged, if applicable~
