### PR TITLE
fix: the command format when pasted in terminal

### DIFF
--- a/src/homepageExperience/components/steps/cli/InitializeClient.tsx
+++ b/src/homepageExperience/components/steps/cli/InitializeClient.tsx
@@ -63,11 +63,11 @@ export const InitializeClient: FC<OwnProps> = ({
   })
   const token = currentAuth.token
 
-  const codeSnippet = `influx config create --config-name onboarding 
-  --host-url "${url}" 
-  --org "${org.id}" 
-  --token "${token}" 
-  --active`
+  const codeSnippet = `influx config create --config-name onboarding \\
+    --host-url "${url}" \\
+    --org "${org.id}" \\
+    --token "${token}" \\
+    --active`
 
   const bucketSnippet = `influx bucket create --name sample-bucket -c onboarding`
 


### PR DESCRIPTION
Closes #5334

Fixes command in `Initialize Client` step so that it is properly pasted into the terminal without the user having to manually fix the formatting before executing.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
