### PR TITLE
chore: Add name back to user list

### DIFF
--- a/src/users/components/InviteListItem.tsx
+++ b/src/users/components/InviteListItem.tsx
@@ -25,8 +25,7 @@ const InviteListItem: FC<Props> = ({invite}) => {
       <IndexList.Cell>
         <span className="user-list-email">{email}</span>
       </IndexList.Cell>
-      {/* TODO: add back in once https://github.com/influxdata/quartz/issues/2389 back-filling of names is complete */}
-      {/* <IndexList.Cell /> */}
+      <IndexList.Cell />
       <IndexList.Cell className="user-list-cell-role" testID="invite-list-role">
         {capitalize(role)}
       </IndexList.Cell>

--- a/src/users/components/UserList.tsx
+++ b/src/users/components/UserList.tsx
@@ -40,8 +40,7 @@ const UserList: FC = () => {
       <IndexList>
         <IndexList.Header>
           <IndexList.HeaderCell width="30%" columnName="email" />
-          {/* TODO: add back in once https://github.com/influxdata/quartz/issues/2389 back-filling of names is complete */}
-          {/* <IndexList.HeaderCell width="30%" columnName="name" />*/}
+          <IndexList.HeaderCell width="30%" columnName="name" />
           <IndexList.HeaderCell width="10%" columnName="role" />
           <IndexList.HeaderCell width="20%" columnName="status" />
           <IndexList.HeaderCell width="10%" columnName="" />

--- a/src/users/components/UserListItem.tsx
+++ b/src/users/components/UserListItem.tsx
@@ -23,23 +23,21 @@ interface Props {
   isDeletable: boolean
 }
 
-// TODO: add back in once https://github.com/influxdata/quartz/issues/2389 back-filling of names is complete
+const formatName = (firstName: string | null, lastName: string | null) => {
+  if (firstName && lastName) {
+    return `${firstName} ${lastName}`
+  }
 
-// const formatName = (firstName: string | null, lastName: string | null) => {
-//   if (firstName && lastName) {
-//     return `${firstName} ${lastName}`
-//   }
-//
-//   if (firstName) {
-//     return firstName
-//   }
-//
-//   if (lastName) {
-//     return lastName
-//   }
-//
-//   return ''
-// }
+  if (firstName) {
+    return firstName
+  }
+
+  if (lastName) {
+    return lastName
+  }
+
+  return ''
+}
 
 const UserListItem: FC<Props> = ({user, isDeletable}) => {
   const {email, role} = user

--- a/src/users/components/UserListItem.tsx
+++ b/src/users/components/UserListItem.tsx
@@ -40,7 +40,7 @@ const formatName = (firstName: string | null, lastName: string | null) => {
 }
 
 const UserListItem: FC<Props> = ({user, isDeletable}) => {
-  const {email, role} = user
+  const {email, firstName, lastName, role} = user
   const {handleRemoveUser, removeUserStatus} = useContext(UsersContext)
 
   const [revealOnHover, toggleRevealOnHover] = useState(true)
@@ -71,12 +71,11 @@ const UserListItem: FC<Props> = ({user, isDeletable}) => {
       <IndexList.Cell>
         <span className="user-list-email">{email}</span>
       </IndexList.Cell>
-      {/* TODO: add back in once https://github.com/influxdata/quartz/issues/2389 back-filling of names is complete */}
-      {/* <IndexList.Cell>
+      <IndexList.Cell>
         <span className="user-list-name">
           {formatName(firstName, lastName)}
         </span>
-      </IndexList.Cell>*/}
+      </IndexList.Cell>
       <IndexList.Cell className="user-list-cell-role">
         {capitalize(role)}
       </IndexList.Cell>


### PR DESCRIPTION
In https://github.com/influxdata/quartz/pull/2486 we removed name from the user list until we had backfilled all names for users. We have completed that work in https://github.com/influxdata/quartz/issues/2389 so this PR adds the names back in.

Part of https://github.com/influxdata/quartz/issues/2389

### Checklist

Authors and Reviewer(s), please verify the following:

- [ x ] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [ x ] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ x ] Documentation updated or issue created (provide link to issue/PR)
- [ x ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ x ] Feature flagged, if applicable
