### PR TITLE
fix(TypeAheadVariableDropdown): dynamic width for input bar

### DIFF
--- a/cypress/e2e/shared/dashboardsVariables.test.ts
+++ b/cypress/e2e/shared/dashboardsVariables.test.ts
@@ -653,7 +653,7 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
     })
   })
 
-  it('ensures that dependent variables load one another accordingly, even with reload and cleared local storage', () => {
+  it.only('ensures that dependent variables load one another accordingly, even with reload and cleared local storage', () => {
     cy.get<Organization>('@org').then(({id: orgID}: Organization) => {
       cy.createDashboard(orgID).then(({body: dashboard}) => {
         cy.get<string>('@defaultBucket').then((defaultBucket: string) => {

--- a/cypress/e2e/shared/dashboardsVariables.test.ts
+++ b/cypress/e2e/shared/dashboardsVariables.test.ts
@@ -653,7 +653,7 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
     })
   })
 
-  it.only('ensures that dependent variables load one another accordingly, even with reload and cleared local storage', () => {
+  it('ensures that dependent variables load one another accordingly, even with reload and cleared local storage', () => {
     cy.get<Organization>('@org').then(({id: orgID}: Organization) => {
       cy.createDashboard(orgID).then(({body: dashboard}) => {
         cy.get<string>('@defaultBucket').then((defaultBucket: string) => {

--- a/src/variables/components/TypeAheadVariableDropdown.tsx
+++ b/src/variables/components/TypeAheadVariableDropdown.tsx
@@ -41,7 +41,7 @@ class TypeAheadVariableDropdown extends PureComponent<Props> {
     // handle the case where the selected value is ""
     const calculatedWidth =
       selectedVariableValue.name.length > 0
-        ? selectedVariableValue.name.length * 8 + 95
+        ? selectedVariableValue.name.length * 8 + 110
         : 150
     const typeAheadStyle = {
       width: `${calculatedWidth}px`,

--- a/src/variables/components/TypeAheadVariableDropdown.tsx
+++ b/src/variables/components/TypeAheadVariableDropdown.tsx
@@ -38,10 +38,7 @@ class TypeAheadVariableDropdown extends PureComponent<Props> {
       name: selectedValue,
     } as SelectableItem
 
-    const calculatedWidth = Math.max(
-      selectedVariableValue.name.length * 8 + 95,
-      150
-    )
+    const calculatedWidth = selectedVariableValue.name.length > 0 ? selectedVariableValue.name.length * 8 + 95 : 150
     const typeAheadStyle = {
       width: `${calculatedWidth}px`,
     }

--- a/src/variables/components/TypeAheadVariableDropdown.tsx
+++ b/src/variables/components/TypeAheadVariableDropdown.tsx
@@ -38,7 +38,9 @@ class TypeAheadVariableDropdown extends PureComponent<Props> {
       name: selectedValue,
     } as SelectableItem
 
-    const typeAheadStyle = {width: '150px'}
+    const typeAheadStyle = {
+      width: `${selectedVariableValue.name.length * 8 + 95}px`,
+    }
     return (
       <TypeAheadDropDown
         style={typeAheadStyle}

--- a/src/variables/components/TypeAheadVariableDropdown.tsx
+++ b/src/variables/components/TypeAheadVariableDropdown.tsx
@@ -38,8 +38,12 @@ class TypeAheadVariableDropdown extends PureComponent<Props> {
       name: selectedValue,
     } as SelectableItem
 
+    const calculatedWidth = Math.max(
+      selectedVariableValue.name.length * 8 + 95,
+      150
+    )
     const typeAheadStyle = {
-      width: `${selectedVariableValue.name.length * 8 + 95}px`,
+      width: `${calculatedWidth}px`,
     }
     return (
       <TypeAheadDropDown

--- a/src/variables/components/TypeAheadVariableDropdown.tsx
+++ b/src/variables/components/TypeAheadVariableDropdown.tsx
@@ -40,7 +40,7 @@ class TypeAheadVariableDropdown extends PureComponent<Props> {
 
     // handle the case where the selected value is ""
     const calculatedWidth =
-      selectedVariableValue.name.length > 0
+      selectedVariableValue.name?.length > 0
         ? selectedVariableValue.name.length * 8 + 110
         : 150
     const typeAheadStyle = {

--- a/src/variables/components/TypeAheadVariableDropdown.tsx
+++ b/src/variables/components/TypeAheadVariableDropdown.tsx
@@ -38,6 +38,7 @@ class TypeAheadVariableDropdown extends PureComponent<Props> {
       name: selectedValue,
     } as SelectableItem
 
+    // handle the case where the selected value is ""
     const calculatedWidth =
       selectedVariableValue.name.length > 0
         ? selectedVariableValue.name.length * 8 + 95

--- a/src/variables/components/TypeAheadVariableDropdown.tsx
+++ b/src/variables/components/TypeAheadVariableDropdown.tsx
@@ -38,7 +38,10 @@ class TypeAheadVariableDropdown extends PureComponent<Props> {
       name: selectedValue,
     } as SelectableItem
 
-    const calculatedWidth = selectedVariableValue.name.length > 0 ? selectedVariableValue.name.length * 8 + 95 : 150
+    const calculatedWidth =
+      selectedVariableValue.name.length > 0
+        ? selectedVariableValue.name.length * 8 + 95
+        : 150
     const typeAheadStyle = {
       width: `${calculatedWidth}px`,
     }


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/5347

I tried all sorts of ways to make it dynamic, from `width: auto`, `fit-content` etc and it won't work. this could be because of how clockface is doing styles. this was the best way to do it:

`calculate the length of the string * 8 (a character 8px is a close enough approximation) + 95 (account for paddings)`


https://user-images.githubusercontent.com/18511823/183755257-2dff5495-15da-4e56-9a4f-51662cd5d51a.mov



### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
