### PR TITLE
feat: add prepare ide step to arduino onboarding

### DIFF
--- a/src/homepageExperience/components/steps/arduino/PrepareIde.tsx
+++ b/src/homepageExperience/components/steps/arduino/PrepareIde.tsx
@@ -29,7 +29,7 @@ export const PrepareIde = () => {
           it.
         </li>
         <li>Click OK.</li>
-        <li>Then under Tools {'>'} Boards: , click on Boards Manager.</li>
+        <li>Then under Tools &rarr; Boards: , click on Boards Manager.</li>
         <li>Search for ESP8266 in the boards.</li>
         <li>Install the ESP8266 board by ESP8266 Community.</li>
       </ol>
@@ -44,7 +44,7 @@ export const PrepareIde = () => {
           in it.
         </li>
         <li>Click OK.</li>
-        <li>Then under Tools {'>'} Boards: , click on Boards Manager.</li>
+        <li>Then under Tools &rarr; Boards: , click on Boards Manager.</li>
         <li>Search for ESP32 in the boards.</li>
         <li>Install the ESP32 board by ESP32 Community.</li>
       </ol>

--- a/src/homepageExperience/components/steps/arduino/PrepareIde.tsx
+++ b/src/homepageExperience/components/steps/arduino/PrepareIde.tsx
@@ -22,7 +22,7 @@ export const PrepareIde = () => {
         <b>For ESP8266:</b>
       </p>
       <ol style={listStyle}>
-        <li>Open the Arduino Preferences (Arduino {'>'} Preferences) </li>
+        <li>Open the Arduino Preferences (Arduino &rarr; Preferences) </li>
         <li>
           Look for "Additional Boards Manager URLs" input box and paste
           "http://arduino.esp8266.com/stable/package_esp8266com_index.json" in
@@ -37,7 +37,7 @@ export const PrepareIde = () => {
         <b>For ESP32:</b>
       </p>
       <ol style={listStyle}>
-        <li>Open the Arduino Preferences (Arduino {'>'} Preferences) </li>
+        <li>Open the Arduino Preferences (Arduino &rarr; Preferences) </li>
         <li>
           Look for "Additional Boards Manager URLs" input box and paste
           "https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json"

--- a/src/homepageExperience/components/steps/arduino/PrepareIde.tsx
+++ b/src/homepageExperience/components/steps/arduino/PrepareIde.tsx
@@ -1,0 +1,44 @@
+// Libraries
+import React from 'react'
+
+export const PrepareIde = () => {
+  return (
+    <>
+      <h1>Prepare Arduino IDE</h1>
+      <p>
+        The easiest way to get started with the InfluxDB Arduino client is with
+        the ESP8266 or ESP32 board.
+      </p>
+      <p>
+        If you haven't already, add the board you wish to use (ESP8266 or ESP32)
+        to the Arduino IDE by following these steps:
+      </p>
+      <p>For ESP8266:</p>
+      <ol style={{fontSize: '16px'}}>
+        <li>Open the Arduino Preferences (Arduino {'>'} Preferences) </li>
+        <li>
+          Look for "Additional Boards Manager URLs" input box and paste
+          "http://arduino.esp8266.com/stable/package_esp8266com_index.json" in
+          it.
+        </li>
+        <li>Click OK.</li>
+        <li>Then under Tools {'>'} Boards: , click on Boards Manager.</li>
+        <li>Search for ESP8266 in the boards.</li>
+        <li>Install the ESP8266 board by ESP8266 Community.</li>
+      </ol>
+      <p>For ESP32:</p>
+      <ol style={{fontSize: '16px'}}>
+        <li>Open the Arduino Preferences (Arduino {'>'} Preferences) </li>
+        <li>
+          Look for "Additional Boards Manager URLs" input box and paste
+          "https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json"
+          in it.
+        </li>
+        <li>Click OK.</li>
+        <li>Then under Tools {'>'} Boards: , click on Boards Manager.</li>
+        <li>Search for ESP32 in the boards.</li>
+        <li>Install the ESP32 board by ESP32 Community.</li>
+      </ol>
+    </>
+  )
+}

--- a/src/homepageExperience/components/steps/arduino/PrepareIde.tsx
+++ b/src/homepageExperience/components/steps/arduino/PrepareIde.tsx
@@ -1,6 +1,11 @@
 // Libraries
 import React from 'react'
 
+const listStyle = {
+  fontSize: '16px',
+  fontWeight: 'normal',
+}
+
 export const PrepareIde = () => {
   return (
     <>
@@ -13,8 +18,10 @@ export const PrepareIde = () => {
         If you haven't already, add the board you wish to use (ESP8266 or ESP32)
         to the Arduino IDE by following these steps:
       </p>
-      <p>For ESP8266:</p>
-      <ol style={{fontSize: '16px'}}>
+      <p>
+        <b>For ESP8266:</b>
+      </p>
+      <ol style={listStyle}>
         <li>Open the Arduino Preferences (Arduino {'>'} Preferences) </li>
         <li>
           Look for "Additional Boards Manager URLs" input box and paste
@@ -26,8 +33,10 @@ export const PrepareIde = () => {
         <li>Search for ESP8266 in the boards.</li>
         <li>Install the ESP8266 board by ESP8266 Community.</li>
       </ol>
-      <p>For ESP32:</p>
-      <ol style={{fontSize: '16px'}}>
+      <p>
+        <b>For ESP32:</b>
+      </p>
+      <ol style={listStyle}>
         <li>Open the Arduino Preferences (Arduino {'>'} Preferences) </li>
         <li>
           Look for "Additional Boards Manager URLs" input box and paste

--- a/src/homepageExperience/containers/ArduinoWizard.tsx
+++ b/src/homepageExperience/containers/ArduinoWizard.tsx
@@ -20,12 +20,13 @@ import {Finish} from 'src/homepageExperience/components/steps/Finish'
 import {InitializeClient} from 'src/homepageExperience/components/steps/arduino/InitializeClient'
 import {InstallDependencies} from 'src/homepageExperience/components/steps/arduino/InstallDependencies'
 import {Overview} from 'src/homepageExperience/components/steps/Overview'
+import {PrepareIde} from 'src/homepageExperience/components/steps/arduino/PrepareIde'
 import {WriteData} from 'src/homepageExperience/components/steps/arduino/WriteData'
 import WriteDataDetailsContextProvider from 'src/writeData/components/WriteDataDetailsContext'
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'
-import {HOMEPAGE_NAVIGATION_STEPS_SHORT} from 'src/homepageExperience/utils'
+import {HOMEPAGE_NAVIGATION_STEPS_ARDUINO} from 'src/homepageExperience/utils'
 import {normalizeEventName} from 'src/cloud/utils/reporting'
 import RateLimitAlert from 'src/cloud/components/RateLimitAlert'
 
@@ -67,7 +68,7 @@ export class ArduinoWizard extends PureComponent<{}, State> {
       {
         currentStep: Math.min(
           this.state.currentStep + 1,
-          HOMEPAGE_NAVIGATION_STEPS_SHORT.length
+          HOMEPAGE_NAVIGATION_STEPS_ARDUINO.length
         ),
       },
       () => {
@@ -76,10 +77,10 @@ export class ArduinoWizard extends PureComponent<{}, State> {
           {},
           {
             clickedButtonAtStep: normalizeEventName(
-              HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep - 1].name
+              HOMEPAGE_NAVIGATION_STEPS_ARDUINO[this.state.currentStep - 1].name
             ),
             currentStep: normalizeEventName(
-              HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep].name
+              HOMEPAGE_NAVIGATION_STEPS_ARDUINO[this.state.currentStep].name
             ),
           }
         )
@@ -96,10 +97,10 @@ export class ArduinoWizard extends PureComponent<{}, State> {
           {},
           {
             clickedButtonAtStep: normalizeEventName(
-              HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep - 1].name
+              HOMEPAGE_NAVIGATION_STEPS_ARDUINO[this.state.currentStep - 1].name
             ),
             currentStep: normalizeEventName(
-              HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep].name
+              HOMEPAGE_NAVIGATION_STEPS_ARDUINO[this.state.currentStep].name
             ),
           }
         )
@@ -114,7 +115,7 @@ export class ArduinoWizard extends PureComponent<{}, State> {
       {},
       {
         currentStep: normalizeEventName(
-          HOMEPAGE_NAVIGATION_STEPS_SHORT[clickedStep - 1].name
+          HOMEPAGE_NAVIGATION_STEPS_ARDUINO[clickedStep - 1].name
         ),
       }
     )
@@ -126,9 +127,12 @@ export class ArduinoWizard extends PureComponent<{}, State> {
         return <Overview wizard="arduinoWizard" />
       }
       case 2: {
-        return <InstallDependencies />
+        return <PrepareIde />
       }
       case 3: {
+        return <InstallDependencies />
+      }
+      case 4: {
         return (
           <InitializeClient
             setTokenValue={this.setTokenValue}
@@ -137,16 +141,16 @@ export class ArduinoWizard extends PureComponent<{}, State> {
           />
         )
       }
-      case 4: {
+      case 5: {
         return <WriteData bucket={this.state.selectedBucket} />
       }
-      case 5: {
+      case 6: {
         return <ExecuteQuery bucket={this.state.selectedBucket} />
       }
-      case 6: {
+      case 7: {
         return <ExecuteAggregateQuery bucket={this.state.selectedBucket} />
       }
-      case 7: {
+      case 8: {
         return (
           <Finish
             wizardEventName="arduinoWizard"
@@ -178,7 +182,7 @@ export class ArduinoWizard extends PureComponent<{}, State> {
                 <SubwayNav
                   currentStep={this.state.currentStep}
                   onStepClick={this.handleNavClick}
-                  navigationSteps={HOMEPAGE_NAVIGATION_STEPS_SHORT}
+                  navigationSteps={HOMEPAGE_NAVIGATION_STEPS_ARDUINO}
                   settingUpIcon={ArduinoIcon}
                   settingUpText="Arduino"
                   setupTime="5 minutes"
@@ -193,7 +197,7 @@ export class ArduinoWizard extends PureComponent<{}, State> {
                     verticallyCentered:
                       this.state.currentStep === 1 ||
                       this.state.currentStep ===
-                        HOMEPAGE_NAVIGATION_STEPS_SHORT.length,
+                        HOMEPAGE_NAVIGATION_STEPS_ARDUINO.length,
                   }
                 )}
               >

--- a/src/homepageExperience/utils.ts
+++ b/src/homepageExperience/utils.ts
@@ -65,3 +65,38 @@ export const HOMEPAGE_NAVIGATION_STEPS_SHORT = [
     glyph: IconFont.StarSmile,
   },
 ]
+
+export const HOMEPAGE_NAVIGATION_STEPS_ARDUINO = [
+  {
+    name: 'Overview',
+    glyph: IconFont.BookOutline,
+  },
+  {
+    name: 'Prepare\n Arduino IDE',
+    glyph: IconFont.Braces,
+  },
+  {
+    name: 'Install\n Dependencies',
+    glyph: IconFont.Install,
+  },
+  {
+    name: 'Initialize\n Client',
+    glyph: IconFont.CogSolid_New,
+  },
+  {
+    name: 'Write\n Data',
+    glyph: IconFont.Pencil,
+  },
+  {
+    name: 'Execute\n Flux Query',
+    glyph: IconFont.Play,
+  },
+  {
+    name: 'Execute\n Aggregate',
+    glyph: IconFont.Play,
+  },
+  {
+    name: 'Finished!',
+    glyph: IconFont.StarSmile,
+  },
+]


### PR DESCRIPTION
Closes #5355 

Adds `Prepare Arduino IDE` step to the onboarding flow. This step takes users through the steps of adding an arduino board to the arduino ide. Screen shots below:
Updated images:
<img width="1437" alt="Screen Shot 2022-08-10 at 10 53 05 AM" src="https://user-images.githubusercontent.com/106361125/183935434-b1608bd5-aebc-4d47-b2af-cd155450261a.png">
<img width="1437" alt="Screen Shot 2022-08-10 at 10 53 08 AM" src="https://user-images.githubusercontent.com/106361125/183935452-54c21be2-f4db-4930-9df4-8f30ac0029f2.png">




### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
