### PR TITLE
fix: disable form if not pay as you go or free flag customer

### DIFF
--- a/src/buckets/components/CreateBucketButton.tsx
+++ b/src/buckets/components/CreateBucketButton.tsx
@@ -3,7 +3,12 @@ import React, {FC, useEffect} from 'react'
 import {connect, ConnectedProps, useDispatch} from 'react-redux'
 
 // Components
-import {Button, IconFont, ComponentColor} from '@influxdata/clockface'
+import {
+  Button,
+  IconFont,
+  ComponentColor,
+  ComponentStatus,
+} from '@influxdata/clockface'
 import AssetLimitButton from 'src/cloud/components/AssetLimitButton'
 
 // Actions
@@ -25,6 +30,7 @@ type ReduxProps = ConnectedProps<typeof connector>
 type CreateButtonProps = {
   useSimplifiedBucketForm?: boolean
   callbackAfterBucketCreation?: (bucket: OwnBucket) => void
+  disabled?: boolean
 }
 
 type Props = ReduxProps & CreateButtonProps
@@ -35,6 +41,7 @@ const CreateBucketButton: FC<Props> = ({
   onDismissOverlay,
   useSimplifiedBucketForm = false,
   callbackAfterBucketCreation = () => {},
+  disabled = false,
 }) => {
   const dispatch = useDispatch()
   useEffect(() => {
@@ -63,6 +70,7 @@ const CreateBucketButton: FC<Props> = ({
       titleText="Click to create a bucket"
       onClick={handleItemClick}
       testID="Create Bucket"
+      status={disabled ? ComponentStatus.Disabled : ComponentStatus.Default}
     />
   )
 }

--- a/src/writeData/components/WriteDataHelperBuckets.tsx
+++ b/src/writeData/components/WriteDataHelperBuckets.tsx
@@ -22,11 +22,13 @@ import {
 interface Props {
   className?: string
   useSimplifiedBucketForm?: boolean
+  disabled?: boolean
 }
 
 const WriteDataHelperBuckets: FC<Props> = ({
   className = 'write-data--details-widget-title',
   useSimplifiedBucketForm = false,
+  disabled = false,
 }) => {
   const {bucket, buckets, changeBucket} = useContext(WriteDataDetailsContext)
   const isSelected = (bucketID: string): boolean => {
@@ -68,7 +70,19 @@ const WriteDataHelperBuckets: FC<Props> = ({
     body = (
       <List
         backgroundColor={InfluxColors.Grey5}
-        style={{height: '200px'}}
+        style={
+          disabled
+            ? {
+                pointerEvents: 'none',
+                height: '200px',
+                cursor: 'not-allowed',
+                borderColor: '#1a1a2a',
+                backgroundColor: '#1a1a2a',
+                opacity: '0.5',
+                color: '#828294',
+              }
+            : {height: '200px'}
+        }
         maxHeight="200px"
         testID="buckets--list"
       >
@@ -76,9 +90,9 @@ const WriteDataHelperBuckets: FC<Props> = ({
           <List.Item
             size={ComponentSize.Small}
             key={b.id}
-            selected={isSelected(b.id)}
+            selected={disabled ? null : isSelected(b.id)}
             value={b}
-            onClick={changeBucket}
+            onClick={disabled ? () => {} : changeBucket}
             wrapText={true}
             gradient={Gradients.GundamPilot}
           >
@@ -96,6 +110,7 @@ const WriteDataHelperBuckets: FC<Props> = ({
         <CreateBucketButton
           useSimplifiedBucketForm={useSimplifiedBucketForm}
           callbackAfterBucketCreation={changeBucket}
+          disabled={disabled}
         />
       </Heading>
       {body}

--- a/src/writeData/components/WriteDataHelperBuckets.tsx
+++ b/src/writeData/components/WriteDataHelperBuckets.tsx
@@ -70,29 +70,18 @@ const WriteDataHelperBuckets: FC<Props> = ({
     body = (
       <List
         backgroundColor={InfluxColors.Grey5}
-        style={
-          disabled
-            ? {
-                pointerEvents: 'none',
-                height: '200px',
-                cursor: 'not-allowed',
-                borderColor: '#1a1a2a',
-                backgroundColor: '#1a1a2a',
-                opacity: '0.5',
-                color: '#828294',
-              }
-            : {height: '200px'}
-        }
+        style={{height: '200px'}}
         maxHeight="200px"
         testID="buckets--list"
       >
         {filteredBuckets.map(b => (
           <List.Item
+            disabled={disabled}
             size={ComponentSize.Small}
             key={b.id}
-            selected={disabled ? null : isSelected(b.id)}
+            selected={isSelected(b.id)}
             value={b}
-            onClick={disabled ? () => {} : changeBucket}
+            onClick={changeBucket}
             wrapText={true}
             gradient={Gradients.GundamPilot}
           >

--- a/src/writeData/subscriptions/components/BrokerForm.scss
+++ b/src/writeData/subscriptions/components/BrokerForm.scss
@@ -51,7 +51,7 @@
     color: $cf-white;
     padding: 0 $cf-space-xs;
     height: 40px;
-    font-weight: 500;
+    font-weight: 700;
     font-family: 'Proxima Nova', Helvetica, Arial, Tahoma, Verdana, sans-serif;
     border-style: solid;
     border-width: 0;

--- a/src/writeData/subscriptions/components/BrokerForm.scss
+++ b/src/writeData/subscriptions/components/BrokerForm.scss
@@ -72,6 +72,12 @@
   &__text {
     color: $cf-grey-95;
   }
+  &__upgrade-text {
+    background: -webkit-linear-gradient(45deg, #34bb55 0%, #00a3ff 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    font-weight: 700;
+  }
   &__container {
     .cf-flex-box__margin-lg.cf-flex-box__row.cf-flex-box__justify-flex-start
       > * {

--- a/src/writeData/subscriptions/components/BrokerForm.scss
+++ b/src/writeData/subscriptions/components/BrokerForm.scss
@@ -47,24 +47,6 @@
     -webkit-appearance: none;
     margin: 0;
   }
-  &__upgrade-button {
-    color: $cf-white;
-    padding: 0 $cf-space-xs;
-    height: 40px;
-    font-weight: 700;
-    font-family: 'Proxima Nova', Helvetica, Arial, Tahoma, Verdana, sans-serif;
-    border-style: solid;
-    border-width: 0;
-    text-decoration: none;
-    outline: none;
-    border-radius: 2px;
-    white-space: nowrap;
-    position: relative;
-    z-index: 1;
-    display: inline-flex;
-    justify-content: center;
-    align-items: center;
-  }
   &__header {
     text-transform: uppercase;
     margin: $cf-space-l 0;

--- a/src/writeData/subscriptions/components/BrokerForm.scss
+++ b/src/writeData/subscriptions/components/BrokerForm.scss
@@ -48,7 +48,6 @@
     margin: 0;
   }
   &__upgrade-button {
-    background: linear-gradient(45deg, #0098f0 0%, $c-pulsar 100%) !important;
     color: $cf-white;
     padding: 0 $cf-space-xs;
     height: 40px;
@@ -57,9 +56,6 @@
     border-style: solid;
     border-width: 0;
     text-decoration: none;
-    transition: background-color 200ms cubic-bezier(0.18, 0.16, 0.2, 1),
-      box-shadow 200ms cubic-bezier(0.18, 0.16, 0.2, 1),
-      color 200ms cubic-bezier(0.18, 0.16, 0.2, 1);
     outline: none;
     border-radius: 2px;
     white-space: nowrap;

--- a/src/writeData/subscriptions/components/BrokerForm.scss
+++ b/src/writeData/subscriptions/components/BrokerForm.scss
@@ -73,7 +73,7 @@
     color: $cf-grey-95;
   }
   &__upgrade-text {
-    background: -webkit-linear-gradient(45deg, #34bb55 0%, #00a3ff 100%);
+    background: -webkit-linear-gradient(45deg, #34bb55 0%, $c-pool 100%);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     font-weight: 700;

--- a/src/writeData/subscriptions/components/BrokerForm.tsx
+++ b/src/writeData/subscriptions/components/BrokerForm.tsx
@@ -24,18 +24,15 @@ import CloudUpgradeButton from 'src/shared/components/CloudUpgradeButton'
 
 // Utils
 import {getOrg} from 'src/organizations/selectors'
-import {
-  shouldGetCredit250Experience,
-  shouldShowUpgradeButton,
-} from 'src/me/selectors'
+import {shouldGetCredit250Experience} from 'src/me/selectors'
 import {event} from 'src/cloud/utils/reporting'
 import {checkRequiredFields} from 'src/writeData/subscriptions/utils/form'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {
   getDataLayerIdentity,
   getExperimentVariantId,
 } from 'src/cloud/utils/experiments'
 import {AppSettingContext} from 'src/shared/contexts/app'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Constants
 import {CREDIT_250_EXPERIMENT_ID} from 'src/shared/constants'
@@ -52,6 +49,7 @@ interface Props {
   updateForm: (any) => void
   saveForm: (any) => void
   onFocus?: (any) => void
+  showUpgradeButton: boolean
 }
 
 const BrokerForm: FC<Props> = ({
@@ -59,13 +57,10 @@ const BrokerForm: FC<Props> = ({
   updateForm,
   saveForm,
   onFocus,
+  showUpgradeButton,
 }) => {
   const history = useHistory()
   const org = useSelector(getOrg)
-  // enabled for PAYG accounts and specific free accounts where a flag is enabled
-  const showUpgradeButton =
-    useSelector(shouldShowUpgradeButton) &&
-    !isFlagEnabled('enableFreeSubscriptions')
   const isCredit250ExperienceActive = useSelector(shouldGetCredit250Experience)
   const requiredFields = checkRequiredFields(formContent)
   const {navbarMode} = useContext(AppSettingContext)
@@ -190,7 +185,7 @@ const BrokerForm: FC<Props> = ({
               updateForm={updateForm}
               formContent={formContent}
               className="create"
-              edit={true}
+              edit={showUpgradeButton ? false : true}
             />
           </Overlay.Body>
           <div className="create-broker-form__line"></div>

--- a/src/writeData/subscriptions/components/BrokerForm.tsx
+++ b/src/writeData/subscriptions/components/BrokerForm.tsx
@@ -103,7 +103,6 @@ const BrokerForm: FC<Props> = ({
               />
               {showUpgradeButton ? (
                 <CloudUpgradeButton
-                  className="create-broker-form__upgrade-button"
                   metric={() => {
                     const experimentVariantId = getExperimentVariantId(
                       CREDIT_250_EXPERIMENT_ID

--- a/src/writeData/subscriptions/components/BrokerForm.tsx
+++ b/src/writeData/subscriptions/components/BrokerForm.tsx
@@ -159,9 +159,17 @@ const BrokerForm: FC<Props> = ({
               weight={FontWeight.Regular}
               className="create-broker-form__text"
             >
-              {showUpgradeButton
-                ? 'Upgrade Now to create a new connection to collect data from an MQTT broker and parse messages into metrics.'
-                : 'Create a new connection to collect data from an MQTT broker and parse messages into metrics.'}
+              {showUpgradeButton ? (
+                <p>
+                  <strong className="create-broker-form__upgrade-text">
+                    Upgrade Now
+                  </strong>{' '}
+                  to create a new connection to collect data from an MQTT broker
+                  and parse messages into metrics.
+                </p>
+              ) : (
+                'Create a new connection to collect data from an MQTT broker and parse messages into metrics.'
+              )}
             </Heading>
             <p className="create-broker-form__text">
               See our{' '}

--- a/src/writeData/subscriptions/components/CreateSubscriptionPage.tsx
+++ b/src/writeData/subscriptions/components/CreateSubscriptionPage.tsx
@@ -38,7 +38,7 @@ import {
 
 // Utils
 import {getAll} from 'src/resources/selectors'
-import {getQuartzMe} from 'src/me/selectors'
+import {getQuartzMe, shouldShowUpgradeButton} from 'src/me/selectors'
 import {event} from 'src/cloud/utils/reporting'
 import {
   DEFAULT_COMPLETED_STEPS,
@@ -47,6 +47,7 @@ import {
   getFormStatus,
   SUBSCRIPTION_NAVIGATION_STEPS,
 } from 'src/writeData/subscriptions/utils/form'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Styles
 import 'src/writeData/subscriptions/components/CreateSubscriptionPage.scss'
@@ -111,6 +112,11 @@ const CreateSubscriptionPage: FC = () => {
     })
   }
 
+  // enabled for PAYG accounts and specific free accounts where a flag is enabled
+  const showUpgradeButton =
+    useSelector(shouldShowUpgradeButton) &&
+    !isFlagEnabled('enableFreeSubscriptions')
+
   return (
     <GetResources resources={[ResourceType.Buckets]}>
       <Page>
@@ -138,6 +144,7 @@ const CreateSubscriptionPage: FC = () => {
               updateForm={updateForm}
               saveForm={saveForm}
               onFocus={() => setFormActive(Steps.BrokerForm)}
+              showUpgradeButton={showUpgradeButton}
             />
             <SubscriptionForm
               formContent={formContent}
@@ -145,11 +152,13 @@ const CreateSubscriptionPage: FC = () => {
               buckets={buckets}
               bucket={bucket}
               onFocus={() => setFormActive(Steps.SubscriptionForm)}
+              showUpgradeButton={showUpgradeButton}
             />
             <ParsingForm
               formContent={formContent}
               updateForm={updateForm}
               onFocus={() => setFormActive(Steps.ParsingForm)}
+              showUpgradeButton={showUpgradeButton}
             />
           </Page.Contents>
         </SpinnerContainer>

--- a/src/writeData/subscriptions/components/JsonParsingForm.tsx
+++ b/src/writeData/subscriptions/components/JsonParsingForm.tsx
@@ -232,7 +232,7 @@ const JsonParsingForm: FC<Props> = ({formContent, updateForm, edit}) => {
                   formContent.jsonMeasurementKey.name
                 )
               }}
-              placeholder="nonDescriptName"
+              placeholder="measurement_name"
               name="name"
               onChange={e => {
                 updateForm({

--- a/src/writeData/subscriptions/components/JsonPathInput.tsx
+++ b/src/writeData/subscriptions/components/JsonPathInput.tsx
@@ -111,7 +111,7 @@ const JsonPathInput: FC<Props> = ({
                   : formContent.jsonFieldKeys[itemNum].name
               )
             }
-            placeholder="nonDescriptName"
+            placeholder={`${name}_name`.toLowerCase()}
             name={`${name}=name`}
             onChange={e => {
               let newArr

--- a/src/writeData/subscriptions/components/ParsingForm.tsx
+++ b/src/writeData/subscriptions/components/ParsingForm.tsx
@@ -25,9 +25,15 @@ interface Props {
   formContent: Subscription
   updateForm: (any) => void
   onFocus?: (any) => void
+  showUpgradeButton: boolean
 }
 
-const ParsingForm: FC<Props> = ({formContent, updateForm, onFocus}) =>
+const ParsingForm: FC<Props> = ({
+  formContent,
+  updateForm,
+  onFocus,
+  showUpgradeButton,
+}) =>
   formContent && (
     <div
       className={
@@ -58,20 +64,23 @@ const ParsingForm: FC<Props> = ({formContent, updateForm, onFocus}) =>
                 className="create"
               />
               {formContent.dataFormat === 'lineprotocol' && (
-                <LineProtocolForm edit={true} formContent={formContent} />
+                <LineProtocolForm
+                  edit={showUpgradeButton ? false : true}
+                  formContent={formContent}
+                />
               )}
               {formContent.dataFormat === 'json' && (
                 <JsonParsingForm
                   formContent={formContent}
                   updateForm={updateForm}
-                  edit={true}
+                  edit={showUpgradeButton ? false : true}
                 />
               )}
               {formContent.dataFormat === 'string' && (
                 <StringParsingForm
                   formContent={formContent}
                   updateForm={updateForm}
-                  edit={true}
+                  edit={showUpgradeButton ? false : true}
                 />
               )}
             </Grid.Row>

--- a/src/writeData/subscriptions/components/StringParsingForm.tsx
+++ b/src/writeData/subscriptions/components/StringParsingForm.tsx
@@ -225,7 +225,7 @@ const StringParsingForm: FC<Props> = ({formContent, updateForm, edit}) => {
                 formContent.stringMeasurement.name
               )
             }}
-            placeholder="nonDescriptName"
+            placeholder="measurement_name"
             name="name"
             onChange={e => {
               updateForm({

--- a/src/writeData/subscriptions/components/StringPatternInput.tsx
+++ b/src/writeData/subscriptions/components/StringPatternInput.tsx
@@ -98,7 +98,7 @@ const StringPatternInput: FC<Props> = ({
                 : formContent.stringFields[itemNum].name
             )
           }
-          placeholder="nonDescriptName"
+          placeholder={`${name}_name`.toLowerCase()}
           onChange={e => {
             let newArr
             if (tagType) {

--- a/src/writeData/subscriptions/components/SubscriptionForm.tsx
+++ b/src/writeData/subscriptions/components/SubscriptionForm.tsx
@@ -23,6 +23,7 @@ interface Props {
   buckets: any
   bucket: any
   onFocus?: (any) => void
+  showUpgradeButton: boolean
 }
 
 const SubscriptionForm: FC<Props> = ({
@@ -31,6 +32,7 @@ const SubscriptionForm: FC<Props> = ({
   buckets,
   bucket,
   onFocus,
+  showUpgradeButton,
 }) => {
   useEffect(() => {
     updateForm({...formContent, bucket: bucket.name})
@@ -63,7 +65,7 @@ const SubscriptionForm: FC<Props> = ({
               currentSubscription={formContent}
               updateForm={updateForm}
               className="create"
-              edit={true}
+              edit={showUpgradeButton ? false : true}
             />
           </Overlay.Body>
           <div className="create-subscription-form__line"></div>

--- a/src/writeData/subscriptions/components/SubscriptionFormContent.tsx
+++ b/src/writeData/subscriptions/components/SubscriptionFormContent.tsx
@@ -108,7 +108,10 @@ const SubscriptionFormContent: FC<Props> = ({
               >
                 Select a bucket to write your data to.
               </Heading>
-              <WriteDataHelperBuckets className="write-data--subscriptions-title" />
+              <WriteDataHelperBuckets
+                className="write-data--subscriptions-title"
+                disabled={!edit}
+              />
             </div>
           ) : (
             <Heading


### PR DESCRIPTION
Closes #https://github.com/influxdata/data-acquisition/issues/494 && https://github.com/influxdata/data-acquisition/issues/478

Interim change to disable subscription form for free users to alleviate some confusion.

- makes upgrade button same color as the rest of the app
- disables form elements
- adds optional variables to the shared create bucket component so that we can make it disabled but not require changes elsewhere in the codebase
- fixes placeholder text bug

Before:

https://user-images.githubusercontent.com/38860767/183917553-f72ae38e-5bd2-45ca-a2cb-80991d4b9c47.mov


After:


https://user-images.githubusercontent.com/38860767/183917606-48e0d276-bba4-4d12-9f66-f47ae656b920.mov

changed color of text and fontweight since screenrecording:
<img width="1079" alt="Screen Shot 2022-08-10 at 12 52 37 PM" src="https://user-images.githubusercontent.com/38860767/183969733-40362b99-45a8-4257-89cb-8ad750e48e7f.png">




Placeholders:
<img width="975" alt="Screen Shot 2022-08-10 at 10 25 50 AM" src="https://user-images.githubusercontent.com/38860767/183927743-fdf0fe72-d87b-47de-a7c9-e5192fa197a8.png">
<img width="931" alt="Screen Shot 2022-08-10 at 10 26 08 AM" src="https://user-images.githubusercontent.com/38860767/183927755-fd29950c-6041-4fff-9de4-8bd68a867ff8.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
