### PR TITLE
fix(firstMile): fix typo - InitalizeClient => InitializeClient

### DIFF
--- a/cypress/e2e/shared/firstmile.tests.ts
+++ b/cypress/e2e/shared/firstmile.tests.ts
@@ -27,7 +27,7 @@ describe('First mile experience', () => {
       cy.getByTestID('python-next-button').click()
       cy.contains('Tokens')
 
-      // fourth page is initalize client
+      // fourth page is initialize client
       cy.getByTestID('python-next-button').click()
       cy.contains('Initialize Client')
 

--- a/src/homepageExperience/components/steps/go/InitializeClient.tsx
+++ b/src/homepageExperience/components/steps/go/InitializeClient.tsx
@@ -10,7 +10,7 @@ const logCopyCodeSnippet = () => {
   event('firstMile.goWizard.initializeClient.code.copied')
 }
 
-export const InitalizeClient = () => {
+export const InitializeClient = () => {
   const me = useSelector(getMe)
 
   const url =

--- a/src/homepageExperience/components/steps/nodejs/InitializeClient.tsx
+++ b/src/homepageExperience/components/steps/nodejs/InitializeClient.tsx
@@ -4,51 +4,47 @@ import {useSelector} from 'react-redux'
 import CodeSnippet from 'src/shared/components/CodeSnippet'
 import {event} from 'src/cloud/utils/reporting'
 
-import {getOrg} from 'src/organizations/selectors'
 import {getMe} from 'src/me/selectors'
 
 const logCopyCodeSnippet = () => {
-  event('firstMile.pythonWizard.initializeClient.code.copied')
+  event('firstMile.nodejsWizard.initializeClient.code.copied')
 }
 
-export const InitalizeClient = () => {
-  const org = useSelector(getOrg)
+export const InitializeClient = () => {
   const me = useSelector(getMe)
 
   const url =
     me.quartzMe?.clusterHost || 'https://us-west-2-1.aws.cloud2.influxdata.com/'
 
-  const pythonCode = `import influxdb_client, os, time
-from influxdb_client import InfluxDBClient, Point, WritePrecision
-from influxdb_client.client.write_api import SYNCHRONOUS
+  const codeSnippet = `repl.repl.ignoreUndefined=true
 
-token = os.environ.get("INFLUXDB_TOKEN")
-org = "${org.name}"
-url = "${url}"
+const {InfluxDB, Point} = require('@influxdata/influxdb-client')
 
-client = influxdb_client.InfluxDBClient(url=url, token=token, org=org)
-`
+const token = process.env.INFLUXDB_TOKEN
+const url = '${url}'
+
+const client = new InfluxDB({url, token})`
 
   return (
     <>
       <h1>Initialize Client</h1>
       <p>
-        Run this command in your terminal to open the interactive Python shell:
+        Run this command in your terminal to open the interactive Nodejs shell:
       </p>
-      <CodeSnippet text="python3" language="properties" />
+      <CodeSnippet text="node" language="properties" />
       <p style={{marginTop: '40px'}}>
-        Paste the following code after the prompt (>>>) and press Enter.
+        Paste the following code after the prompt (>) and press Enter.
       </p>
       <CodeSnippet
-        text={pythonCode}
+        text={codeSnippet}
         onCopy={logCopyCodeSnippet}
-        language="python"
+        language="javascript"
       />
       <p style={{marginTop: '42px'}}>
         Here, we initialize the token, organization info, and server url that
         are needed to set up the initial connection to InfluxDB. The client
         connection is then established with the{' '}
-        <code className="homepage-wizard--code-highlight">InfluxDBClient</code>{' '}
+        <code className="homepage-wizard--code-highlight">InfluxDB</code>{' '}
         initialization.
       </p>
     </>

--- a/src/homepageExperience/components/steps/python/InitializeClient.tsx
+++ b/src/homepageExperience/components/steps/python/InitializeClient.tsx
@@ -4,47 +4,51 @@ import {useSelector} from 'react-redux'
 import CodeSnippet from 'src/shared/components/CodeSnippet'
 import {event} from 'src/cloud/utils/reporting'
 
+import {getOrg} from 'src/organizations/selectors'
 import {getMe} from 'src/me/selectors'
 
 const logCopyCodeSnippet = () => {
-  event('firstMile.nodejsWizard.initializeClient.code.copied')
+  event('firstMile.pythonWizard.initializeClient.code.copied')
 }
 
-export const InitalizeClient = () => {
+export const InitializeClient = () => {
+  const org = useSelector(getOrg)
   const me = useSelector(getMe)
 
   const url =
     me.quartzMe?.clusterHost || 'https://us-west-2-1.aws.cloud2.influxdata.com/'
 
-  const codeSnippet = `repl.repl.ignoreUndefined=true
+  const pythonCode = `import influxdb_client, os, time
+from influxdb_client import InfluxDBClient, Point, WritePrecision
+from influxdb_client.client.write_api import SYNCHRONOUS
 
-const {InfluxDB, Point} = require('@influxdata/influxdb-client')
+token = os.environ.get("INFLUXDB_TOKEN")
+org = "${org.name}"
+url = "${url}"
 
-const token = process.env.INFLUXDB_TOKEN
-const url = '${url}'
-
-const client = new InfluxDB({url, token})`
+client = influxdb_client.InfluxDBClient(url=url, token=token, org=org)
+`
 
   return (
     <>
       <h1>Initialize Client</h1>
       <p>
-        Run this command in your terminal to open the interactive Nodejs shell:
+        Run this command in your terminal to open the interactive Python shell:
       </p>
-      <CodeSnippet text="node" language="properties" />
+      <CodeSnippet text="python3" language="properties" />
       <p style={{marginTop: '40px'}}>
-        Paste the following code after the prompt (>) and press Enter.
+        Paste the following code after the prompt (>>>) and press Enter.
       </p>
       <CodeSnippet
-        text={codeSnippet}
+        text={pythonCode}
         onCopy={logCopyCodeSnippet}
-        language="javascript"
+        language="python"
       />
       <p style={{marginTop: '42px'}}>
         Here, we initialize the token, organization info, and server url that
         are needed to set up the initial connection to InfluxDB. The client
         connection is then established with the{' '}
-        <code className="homepage-wizard--code-highlight">InfluxDB</code>{' '}
+        <code className="homepage-wizard--code-highlight">InfluxDBClient</code>{' '}
         initialization.
       </p>
     </>

--- a/src/homepageExperience/containers/GoWizard.tsx
+++ b/src/homepageExperience/containers/GoWizard.tsx
@@ -13,7 +13,7 @@ import {
 import {InstallDependencies} from 'src/homepageExperience/components/steps/go/InstallDependencies'
 import {Overview} from 'src/homepageExperience/components/steps/Overview'
 import {Tokens} from 'src/homepageExperience/components/steps/Tokens'
-import {InitalizeClient} from 'src/homepageExperience/components/steps/go/InitalizeClient'
+import {InitializeClient} from 'src/homepageExperience/components/steps/go/InitializeClient'
 import {WriteData} from 'src/homepageExperience/components/steps/go/WriteData'
 import {ExecuteQuery} from 'src/homepageExperience/components/steps/go/ExecuteQuery'
 import {Finish} from 'src/homepageExperience/components/steps/Finish'
@@ -120,7 +120,7 @@ export class GoWizard extends PureComponent<null, State> {
         )
       }
       case 4: {
-        return <InitalizeClient />
+        return <InitializeClient />
       }
       case 5: {
         return <WriteData onSelectBucket={this.handleSelectBucket} />

--- a/src/homepageExperience/containers/NodejsWizard.tsx
+++ b/src/homepageExperience/containers/NodejsWizard.tsx
@@ -13,7 +13,7 @@ import {
 import {InstallDependencies} from 'src/homepageExperience/components/steps/nodejs/InstallDependencies'
 import {Overview} from 'src/homepageExperience/components/steps/Overview'
 import {Tokens} from 'src/homepageExperience/components/steps/Tokens'
-import {InitalizeClient} from 'src/homepageExperience/components/steps/nodejs/InitalizeClient'
+import {InitializeClient} from 'src/homepageExperience/components/steps/nodejs/InitializeClient'
 import {WriteData} from 'src/homepageExperience/components/steps/nodejs/WriteData'
 import {ExecuteQuery} from 'src/homepageExperience/components/steps/nodejs/ExecuteQuery'
 import {Finish} from 'src/homepageExperience/components/steps/Finish'
@@ -120,7 +120,7 @@ export class NodejsWizard extends PureComponent<null, State> {
         )
       }
       case 4: {
-        return <InitalizeClient />
+        return <InitializeClient />
       }
       case 5: {
         return <WriteData onSelectBucket={this.handleSelectBucket} />

--- a/src/homepageExperience/containers/PythonWizard.tsx
+++ b/src/homepageExperience/containers/PythonWizard.tsx
@@ -15,7 +15,7 @@ import WriteDataDetailsContextProvider from 'src/writeData/components/WriteDataD
 import {InstallDependencies} from 'src/homepageExperience/components/steps/python/InstallDependencies'
 import {Overview} from 'src/homepageExperience/components/steps/Overview'
 import {Tokens} from 'src/homepageExperience/components/steps/Tokens'
-import {InitalizeClient} from 'src/homepageExperience/components/steps/python/InitalizeClient'
+import {InitializeClient} from 'src/homepageExperience/components/steps/python/InitializeClient'
 import {WriteData} from 'src/homepageExperience/components/steps/python/WriteData'
 import {ExecuteQuery} from 'src/homepageExperience/components/steps/python/ExecuteQuery'
 import {Finish} from 'src/homepageExperience/components/steps/Finish'
@@ -121,7 +121,7 @@ export class PythonWizard extends PureComponent<null, State> {
         )
       }
       case 4: {
-        return <InitalizeClient />
+        return <InitializeClient />
       }
       case 5: {
         return <WriteData onSelectBucket={this.handleSelectBucket} />


### PR DESCRIPTION
Closes #5358

Minor refactor to change `InitalizeClient` => `InitializeClient`.

- Renamed files called `InitalizeClient` => `InitializeClient`
- Renamed components in said files from `InitalizeClient` => `InitializeClient`
- Updated imports that referenced above files to use new component and file name

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
