### PR TITLE
chore: remove the increasedMeasurementLimit flag

### DIFF
--- a/src/dataExplorer/context/fields.tsx
+++ b/src/dataExplorer/context/fields.tsx
@@ -7,7 +7,7 @@ import {
   CACHING_REQUIRED_END_DATE,
   CACHING_REQUIRED_START_DATE,
 } from 'src/utils/datetime/constants'
-import {DEFAULT_LIMIT, EXTENDED_LIMIT} from 'src/shared/constants/queryBuilder'
+import {DEFAULT_LIMIT} from 'src/shared/constants/queryBuilder'
 
 // Contexts
 import {QueryContext, QueryScope} from 'src/shared/contexts/query'
@@ -55,11 +55,6 @@ export const FieldsProvider: FC<Prop> = ({children, scope}) => {
     RemoteDataState.NotStarted
   )
 
-  // Constant
-  const limit = isFlagEnabled('increasedMeasurmentTagLimit')
-    ? EXTENDED_LIMIT
-    : DEFAULT_LIMIT
-
   const getFields = async (
     bucket: Bucket,
     measurement: string,
@@ -93,7 +88,7 @@ export const FieldsProvider: FC<Prop> = ({children, scope}) => {
       |> distinct(column: "_field")
       ${searchTerm ? SEARCH_STRING(searchTerm) : ''}
       |> sort()
-      |> limit(n: ${limit})
+      |> limit(n: ${DEFAULT_LIMIT})
     `
 
     if (bucket.type !== 'sample' && isFlagEnabled('newQueryBuilder')) {
@@ -108,7 +103,7 @@ export const FieldsProvider: FC<Prop> = ({children, scope}) => {
         ${searchTerm ? SEARCH_STRING(searchTerm) : ''}
         |> map(fn: (r) => ({r with lowercase: strings.toLower(v: r._value)}))
         |> sort(columns: ["lowercase"])
-        |> limit(n: ${limit})
+        |> limit(n: ${DEFAULT_LIMIT})
       `
     }
 

--- a/src/dataExplorer/context/measurements.tsx
+++ b/src/dataExplorer/context/measurements.tsx
@@ -6,7 +6,7 @@ import {
   CACHING_REQUIRED_END_DATE,
   CACHING_REQUIRED_START_DATE,
 } from 'src/utils/datetime/constants'
-import {DEFAULT_LIMIT, EXTENDED_LIMIT} from 'src/shared/constants/queryBuilder'
+import {DEFAULT_LIMIT} from 'src/shared/constants/queryBuilder'
 
 // Contexts
 import {QueryContext, QueryScope} from 'src/shared/contexts/query'
@@ -51,11 +51,6 @@ export const MeasurementsProvider: FC<Prop> = ({children, scope}) => {
   const [measurements, setMeasurements] = useState<Array<string>>([])
   const [loading, setLoading] = useState(RemoteDataState.NotStarted)
 
-  // Constant
-  const limit = isFlagEnabled('increasedMeasurmentTagLimit')
-    ? EXTENDED_LIMIT
-    : DEFAULT_LIMIT
-
   const getMeasurements = async bucket => {
     if (!bucket) {
       return
@@ -79,7 +74,7 @@ export const MeasurementsProvider: FC<Prop> = ({children, scope}) => {
       |> group()
       |> distinct(column: "_measurement")
       |> sort()
-      |> limit(n: ${limit})
+      |> limit(n: ${DEFAULT_LIMIT})
     `
 
     if (bucket.type !== 'sample' && isFlagEnabled('newQueryBuilder')) {
@@ -92,7 +87,7 @@ export const MeasurementsProvider: FC<Prop> = ({children, scope}) => {
         )
         |> map(fn: (r) => ({r with lowercase: strings.toLower(v: r._value)}))
         |> sort(columns: ["lowercase"])
-        |> limit(n: ${limit})
+        |> limit(n: ${DEFAULT_LIMIT})
       `
     }
 

--- a/src/dataExplorer/context/tags.tsx
+++ b/src/dataExplorer/context/tags.tsx
@@ -7,7 +7,7 @@ import {
   CACHING_REQUIRED_END_DATE,
   CACHING_REQUIRED_START_DATE,
 } from 'src/utils/datetime/constants'
-import {DEFAULT_LIMIT, EXTENDED_LIMIT} from 'src/shared/constants/queryBuilder'
+import {DEFAULT_LIMIT} from 'src/shared/constants/queryBuilder'
 
 // Contexts
 import {QueryContext, QueryScope} from 'src/shared/contexts/query'
@@ -69,11 +69,6 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
     Hash<RemoteDataState>
   >(INITIAL_LOADING_TAG_VALUES)
 
-  // Constant
-  const limit = isFlagEnabled('increasedMeasurmentTagLimit')
-    ? EXTENDED_LIMIT
-    : DEFAULT_LIMIT
-
   const getTagKeys = async (
     bucket: Bucket,
     measurement: string,
@@ -104,7 +99,7 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
       |> filter(fn: (r) => r._value != "_measurement" and r._value != "_field")
       |> filter(fn: (r) => r._value != "_time" and r._value != "_start" and r._value !=  "_stop" and r._value != "_value")
       |> sort()
-      |> limit(n: ${limit})
+      |> limit(n: ${DEFAULT_LIMIT})
     `
 
     if (bucket.type !== 'sample' && isFlagEnabled('newQueryBuilder')) {
@@ -121,7 +116,7 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
         ${searchTerm ? SEARCH_STRING(searchTerm) : ''}
         |> map(fn: (r) => ({r with lowercase: strings.toLower(v: r._value)}))
         |> sort(columns: ["lowercase"])
-        |> limit(n: ${limit})
+        |> limit(n: ${DEFAULT_LIMIT})
       `
     }
 
@@ -185,7 +180,7 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
       |> group()
       |> distinct(column: "${tagKey}")
       |> sort()
-      |> limit(n: ${limit})
+      |> limit(n: ${DEFAULT_LIMIT})
     `
 
     if (bucket.type !== 'sample' && isFlagEnabled('newQueryBuilder')) {
@@ -200,7 +195,7 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
         )
         |> map(fn: (r) => ({r with lowercase: strings.toLower(v: r._value)}))
         |> sort(columns: ["lowercase"])
-        |> limit(n: ${limit})
+        |> limit(n: ${DEFAULT_LIMIT})
       `
     }
 

--- a/src/flows/pipes/QueryBuilder/context.tsx
+++ b/src/flows/pipes/QueryBuilder/context.tsx
@@ -22,7 +22,7 @@ import {
   CACHING_REQUIRED_END_DATE,
   CACHING_REQUIRED_START_DATE,
 } from 'src/utils/datetime/constants'
-import {DEFAULT_LIMIT, EXTENDED_LIMIT} from 'src/shared/constants/queryBuilder'
+import {DEFAULT_LIMIT} from 'src/shared/constants/queryBuilder'
 
 interface APIResultArray<T> {
   selected: T[]
@@ -268,10 +268,6 @@ export const QueryBuilderProvider: FC = ({children}) => {
       _source += `from(bucket: "${data.buckets[0].name}")`
     }
 
-    const limit = isFlagEnabled('increasedMeasurmentTagLimit')
-      ? EXTENDED_LIMIT
-      : DEFAULT_LIMIT
-
     let queryText = `${_source}
     |> range(${formatTimeRangeArguments(range)})
     |> filter(fn: (r) => ${tagString})
@@ -280,7 +276,7 @@ export const QueryBuilderProvider: FC = ({children}) => {
     |> distinct()${searchString}${previousTagString}
     |> filter(fn: (r) => r._value != "_time" and r._value != "_start" and r._value !=  "_stop" and r._value != "_value")
     |> sort()
-    |> limit(n: ${limit})`
+    |> limit(n: ${DEFAULT_LIMIT})`
 
     if (data.buckets[0].type !== 'sample' && isFlagEnabled('newQueryBuilder')) {
       _source = `import "regexp"
@@ -294,7 +290,7 @@ export const QueryBuilderProvider: FC = ({children}) => {
   )${searchString}${previousTagString}
     |> filter(fn: (r) => r._value != "_time" and r._value != "_start" and r._value !=  "_stop" and r._value != "_value")
     |> sort()
-    |> limit(n: ${limit})`
+    |> limit(n: ${DEFAULT_LIMIT})`
     }
 
     const result = query(queryText, scope)
@@ -395,16 +391,13 @@ export const QueryBuilderProvider: FC = ({children}) => {
       _source += `from(bucket: "${data.buckets[0].name}")`
     }
 
-    const limit = isFlagEnabled('increasedMeasurmentTagLimit')
-      ? EXTENDED_LIMIT
-      : DEFAULT_LIMIT
     let queryText = `${_source}
     |> range(${formatTimeRangeArguments(range)})
     |> filter(fn: (r) => ${tagString})
     |> keep(columns: ["${cards[idx].keys.selected[0]}"])
     |> group()
     |> distinct(column: "${cards[idx].keys.selected[0]}")${searchString}
-    |> limit(n: ${limit})
+    |> limit(n: ${DEFAULT_LIMIT})
     |> sort()`
 
     if (data.buckets[0].type !== 'sample' && isFlagEnabled('newQueryBuilder')) {
@@ -418,7 +411,7 @@ export const QueryBuilderProvider: FC = ({children}) => {
     start: ${CACHING_REQUIRED_START_DATE},
     stop: ${CACHING_REQUIRED_END_DATE},
   )${searchString}
-  |> limit(n: ${limit})
+  |> limit(n: ${DEFAULT_LIMIT})
   |> sort()`
     }
 

--- a/src/shared/constants/queryBuilder.ts
+++ b/src/shared/constants/queryBuilder.ts
@@ -1,2 +1,1 @@
-export const DEFAULT_LIMIT = 200
-export const EXTENDED_LIMIT = 1000
+export const DEFAULT_LIMIT = 1000

--- a/src/timeMachine/apis/queryBuilder.ts
+++ b/src/timeMachine/apis/queryBuilder.ts
@@ -14,7 +14,7 @@ import {
   CACHING_REQUIRED_END_DATE,
   CACHING_REQUIRED_START_DATE,
 } from 'src/utils/datetime/constants'
-import {DEFAULT_LIMIT, EXTENDED_LIMIT} from 'src/shared/constants/queryBuilder'
+import {DEFAULT_LIMIT} from 'src/shared/constants/queryBuilder'
 
 // Types
 import {TimeRange, BuilderConfig} from 'src/types'
@@ -50,10 +50,6 @@ export function findKeys({
     ? ''
     : `\n  |> filter(fn: (r) => r._value =~ regexp.compile(v: "(?i:" + regexp.quoteMeta(v: "${searchTerm}") + ")"))`
 
-  const adjustedLimit = isFlagEnabled('increasedMeasurmentTagLimit')
-    ? EXTENDED_LIMIT
-    : limit
-
   // TODO: Use the `v1.tagKeys` function from the Flux standard library once
   // this issue is resolved: https://github.com/influxdata/flux/issues/1071
   let query = `import "regexp"
@@ -66,7 +62,7 @@ export function findKeys({
   |> distinct()${searchFilter}${previousKeyFilter}
   |> filter(fn: (r) => r._value != "_time" and r._value != "_start" and r._value !=  "_stop" and r._value != "_value")
   |> sort()
-  |> limit(n: ${adjustedLimit})`
+  |> limit(n: ${limit})`
 
   if (bucket !== 'sample' && isFlagEnabled('newQueryBuilder')) {
     query = `import "regexp"
@@ -118,10 +114,6 @@ export function findValues({
     ? ''
     : `\n  |> filter(fn: (r) => r._value =~ regexp.compile(v: "(?i:" + regexp.quoteMeta(v: "${searchTerm}") + ")"))`
 
-  const adjustedLimit = isFlagEnabled('increasedMeasurmentTagLimit')
-    ? EXTENDED_LIMIT
-    : limit
-
   // TODO: Use the `v1.tagValues` function from the Flux standard library once
   // this issue is resolved: https://github.com/influxdata/flux/issues/1071
   let query = `import "regexp"
@@ -132,7 +124,7 @@ export function findValues({
   |> keep(columns: ["${key}"])
   |> group()
   |> distinct(column: "${key}")${searchFilter}
-  |> limit(n: ${adjustedLimit})
+  |> limit(n: ${limit})
   |> sort()`
 
   if (bucket !== 'sample' && isFlagEnabled('newQueryBuilder')) {


### PR DESCRIPTION
There was previously concern that bumping the number of measurements returned to the UI would make the app unperformant. Due to performance improvements in the UI, those concerns have been addressed and this seems to be a permanent part of our application until we want to bump the number up again