### PR TITLE
fix(CSVExportButton): convert : into _ when downloading a CSV

### DIFF
--- a/src/shared/components/CSVExportButton.tsx
+++ b/src/shared/components/CSVExportButton.tsx
@@ -54,7 +54,7 @@ class CSVExportButton extends PureComponent<StateProps, {}> {
     const {files} = this.props
     const formatter = createDateTimeFormatter('YYYY-MM-DD HH:mm')
     const csv = files.join('\n\n')
-    const now = formatter.format(new Date()).replace(/\s+/gi, '_')
+    const now = formatter.format(new Date()).replace(/[:\s]+/gi, '_')
     const filename = `${now} InfluxDB Data`
 
     downloadTextFile(csv, filename, '.csv', 'text/csv')


### PR DESCRIPTION
Closes #5371

When downloading a CSV of a query built in Data Explorer, when creating the file, the script would insert a space character when replacing `:`. This changes it so that it replaces `:` with `_`

*Previously*:
`2022-08-11_09 09_influxdb_data`

*New*:
`2022-08-11_09_09_influxdb_data`

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- ~[ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~
- ~[ ] Feature flagged, if applicable~
