### PR TITLE
fix(TypeAheadDropdown): dropdown hugs the item's list

### DIFF
--- a/src/identity/components/GlobalHeader/GlobalHeaderDropdown/GlobalHeaderTypeAheadMenu.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeaderDropdown/GlobalHeaderTypeAheadMenu.tsx
@@ -19,6 +19,7 @@ type State = {
 }
 
 export class GlobalHeaderTypeAheadMenu extends React.Component<Props, State> {
+  private listItemHeight = 50
   constructor(props: Props) {
     super(props)
     this.state = {
@@ -98,14 +99,18 @@ export class GlobalHeaderTypeAheadMenu extends React.Component<Props, State> {
       />
     )
 
+    // max height should be 150, so we take the min of calculated and 150
+    const calculateDropdownHeight = () =>
+      Math.min(queryResults.length * this.listItemHeight, 150)
+
     return (
       <div>
         {filterSearchInput}
         {queryResults && queryResults.length > 0 ? (
           <List
-            height={style?.height ?? 150}
+            height={style?.height ?? calculateDropdownHeight()}
             itemCount={queryResults.length}
-            itemSize={50}
+            itemSize={this.listItemHeight}
             width="100%"
             layout="vertical"
             itemData={queryResults}

--- a/src/identity/components/GlobalHeader/GlobalHeaderDropdown/GlobalHeaderTypeAheadMenu.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeaderDropdown/GlobalHeaderTypeAheadMenu.tsx
@@ -20,6 +20,7 @@ type State = {
 
 export class GlobalHeaderTypeAheadMenu extends React.Component<Props, State> {
   private listItemHeight = 50
+  private maxDropdownHeight = 150
   constructor(props: Props) {
     super(props)
     this.state = {
@@ -83,6 +84,9 @@ export class GlobalHeaderTypeAheadMenu extends React.Component<Props, State> {
     }
   }
 
+  private calculateDropdownHeight = (numberOfItems: number) =>
+    Math.min(numberOfItems * this.listItemHeight, this.maxDropdownHeight)
+
   render() {
     const {typeAheadPlaceHolder = 'Type here to search', style} = this.props
     const {searchTerm, queryResults, selectedItem} = this.state
@@ -99,16 +103,14 @@ export class GlobalHeaderTypeAheadMenu extends React.Component<Props, State> {
       />
     )
 
-    // max height should be 150, so we take the min of calculated and 150
-    const calculateDropdownHeight = () =>
-      Math.min(queryResults.length * this.listItemHeight, 150)
-
     return (
       <div>
         {filterSearchInput}
         {queryResults && queryResults.length > 0 ? (
           <List
-            height={style?.height ?? calculateDropdownHeight()}
+            height={
+              style?.height ?? this.calculateDropdownHeight(queryResults.length)
+            }
             itemCount={queryResults.length}
             itemSize={this.listItemHeight}
             width="100%"


### PR DESCRIPTION
Connects #5307 

Added some logic to dynamically calculate the height of the dropdown. 

https://user-images.githubusercontent.com/18511823/184192436-90fef23a-ee85-42cb-80f3-709618fa5e24.mov

### Checklist

Authors and Reviewer(s), please verify the following:

- [ ] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [ ] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
