### PR TITLE
feat: add e2e tests for user profile avatar

### DIFF
--- a/cypress/e2e/cloud/globalHeader.ts
+++ b/cypress/e2e/cloud/globalHeader.ts
@@ -1,0 +1,59 @@
+describe('multi-account multi-org global header', () => {
+  const globalHeaderFeatureFlags = {
+    quartzIdentity: true,
+    multiOrg: true,
+  }
+
+  beforeEach(() => {
+    // Maintain the same session for all tests so that further logins aren't required.
+    Cypress.Cookies.preserveOnce('sid')
+  })
+
+  before(() => {
+    cy.flush().then(() =>
+      cy.signin().then(() => {
+        cy.get('@org').then(() => {
+          cy.getByTestID('home-page--header').should('be.visible')
+          cy.setFeatureFlags(globalHeaderFeatureFlags).then(() => {
+            // cy.wait(400) is necessary to ensure sufficient time for the feature flag override.
+            // The feature flag reset happens in redux, (it's not a network request), so we can't cy.wait an intercepted route.
+            cy.wait(400).then(() => {
+              cy.visit('/')
+            })
+          })
+        })
+      })
+    )
+  })
+
+  describe('user profile avatar', () => {
+    it('displays the `user profile` avatar', () => {
+      cy.getByTestID('global-header--user-avatar').should('be.visible')
+    })
+
+    it('displays the popover links', () => {
+      cy.getByTestID('global-header--user-avatar').click()
+      cy.getByTestID('global-header--user-popover-profile-button').should(
+        'be.visible'
+      )
+
+      cy.getByTestID('global-header--user-popover-logout-button').should(
+        'be.visible'
+      )
+      cy.getByTestID('global-header--user-avatar').click()
+    })
+
+    it('navigates to the `user profile` page', () => {
+      cy.getByTestID('global-header--user-avatar').click()
+      cy.getByTestID('global-header--user-popover-profile-button').click()
+      cy.getByTestID('user-profile--page').should('be.visible')
+    })
+
+    it('allows the user to log out', () => {
+      cy.getByTestID('global-header--user-avatar').click()
+      cy.getByTestID('global-header--user-popover-logout-button').click()
+      // Logout in remocal looks like a 404 because there is no quartz. This tests the logout URL.
+      cy.location('pathname').should('eq', '/logout')
+    })
+  })
+})

--- a/src/identity/components/GlobalHeader/IdentityUserAvatar.tsx
+++ b/src/identity/components/GlobalHeader/IdentityUserAvatar.tsx
@@ -68,6 +68,7 @@ class IdentityUserAvatar extends React.Component<Props, State> {
             <Icon
               glyph={IconFont.User}
               className="user-popover-footer--button-icon"
+              testID="global-header--user-popover-profile-button"
             />
             Profile
           </Link>
@@ -75,6 +76,7 @@ class IdentityUserAvatar extends React.Component<Props, State> {
             <Icon
               glyph={IconFont.Logout}
               className="user-popover-footer--button-icon"
+              testID="global-header--user-popover-logout-button"
             />
             Log Out
           </Link>
@@ -98,18 +100,22 @@ class IdentityUserAvatar extends React.Component<Props, State> {
         <div>
           {/* Button shape is ButtonShape.Square to make the height and width the same
             so we can use the border radius to make it a circle  */}
-          <Button
-            text={this.getInitials()}
-            shape={ButtonShape.Square}
-            color={
-              isPopoverOpen ? ComponentColor.Default : ComponentColor.Tertiary
-            }
-            onClick={this.togglePopoverState}
-            className={userAvatarButtonClassName}
-          />
+          {this.getInitials() && (
+            <Button
+              text={this.getInitials()}
+              shape={ButtonShape.Square}
+              color={
+                isPopoverOpen ? ComponentColor.Default : ComponentColor.Tertiary
+              }
+              onClick={this.togglePopoverState}
+              className={userAvatarButtonClassName}
+              testID="global-header--user-avatar"
+            />
+          )}
           <FlexBox
             className={userPopoverClassName}
             direction={FlexDirection.Column}
+            testID="global-header--user-popover"
           >
             {this.getUserPopoverContents()}
           </FlexBox>

--- a/src/identity/components/userprofile/UserProfilePage.tsx
+++ b/src/identity/components/userprofile/UserProfilePage.tsx
@@ -17,7 +17,7 @@ export const UserProfilePage: FC = () => {
   return (
     <Page titleTag={pageTitleSuffixer(['User Profile'])}>
       <Page.Header fullWidth={true}>
-        <Page.Title title="User Profile" />
+        <Page.Title title="User Profile" testID="user-profile--page" />
       </Page.Header>
       <Page.Contents fullWidth={true}>
         <UserDetails />


### PR DESCRIPTION
Connects #4053 

The e2e tests for multi-org phase 1 will be broken into a couple chunks. 

This PR adds e2e tests for the user profile avatar portion of the multi-org global header:

- the avatar should be visible
- respond to clicks
- allow the user to navigate to the 'user profile' 
- allow the user to log out.

Due to the absence of quartz in remocal and the CI environment, log out is tested by whether hitting the 'log out' button directs the user to `cy.location(pathname)`.

Approx. duration: 11.2s

https://user-images.githubusercontent.com/91283923/184250341-9f2e857a-c23b-4c77-8d72-aeb9f4f96048.mov

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - `multiOrg`
