### PR TITLE
feat: notify users with M chip to install rosetta

### DIFF
--- a/src/homepageExperience/components/steps/cli/InstallDependencies.tsx
+++ b/src/homepageExperience/components/steps/cli/InstallDependencies.tsx
@@ -120,6 +120,15 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
       {currentSelection === 'Mac' && (
         <>
           <h2 style={headingWithMargin}>Use Homebrew</h2>
+          <p style={{fontSize: '14px'}}>
+            Note: if your Mac is equipped with an{' '}
+            <code className="homepage-wizard--code-highlight">M</code> chip,
+            ensure you have{' '}
+            <SafeBlankLink href="https://support.apple.com/en-us/HT211861">
+              Rosetta
+            </SafeBlankLink>{' '}
+            downloaded and installed before continuing.
+          </p>
           <CodeSnippet
             text="brew install influxdb-cli"
             onCopy={() => logCopyCodeSnippet(currentSelection)}


### PR DESCRIPTION
Closes #5377

Adds a note telling users that if they have an M chip, they will need Rosetta before continuing.

<img width="1437" alt="Screen Shot 2022-08-12 at 10 10 21 AM" src="https://user-images.githubusercontent.com/106361125/184371455-e06c85a9-bc27-40b1-8e4c-c3147dbb494e.png">

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
