### PR TITLE
chore: tells users to skip cli bucket creation

### DIFF
--- a/src/homepageExperience/components/steps/cli/InitializeClient.tsx
+++ b/src/homepageExperience/components/steps/cli/InitializeClient.tsx
@@ -170,7 +170,8 @@ export const InitializeClient: FC<OwnProps> = ({
       </Panel>
       <p className="large-margins">
         We can also create a bucket using the InfluxDB CLI. We'll link the
-        bucket to the profile you created.
+        bucket to the profile you created. If you have selected a bucket above,
+        skip this step and proceed to the next.
       </p>
       <CodeSnippet
         text={bucketSnippet}


### PR DESCRIPTION
Closes #5384

Users do not have to create a bucket using the CLI if they have selected or created one using the bucket list above the code snippet, so I added a small sentence telling them to skip that step if they already selected a bucket.

<img width="1437" alt="Screen Shot 2022-08-12 at 10 25 46 AM" src="https://user-images.githubusercontent.com/106361125/184375788-9218fcbd-0259-4e20-a167-8370c69464d9.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
