### PR TITLE
fix(tokens): fetch user id before creating all access token

### DIFF
--- a/src/authorizations/components/AllAccessTokenOverlay.tsx
+++ b/src/authorizations/components/AllAccessTokenOverlay.tsx
@@ -21,6 +21,7 @@ import {
 // Actions
 import {createAuthorization} from 'src/authorizations/actions/thunks'
 import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
+import {getIdpeMeThunk} from 'src/me/actions/thunks/index'
 
 // Contexts
 import {OverlayContext} from 'src/overlays/components/OverlayController'
@@ -58,6 +59,10 @@ const AllAccessTokenOverlay: FC<OwnProps> = props => {
   )
 
   const handleSave = () => {
+    if (!meID) {
+      dispatch(getIdpeMeThunk())
+    }
+
     const token: Authorization = {
       orgID,
       description,


### PR DESCRIPTION
Closes #5277 

According to linked ticket, sometimes error `Failed to create API token: invalid json structure: id must have 16 bytes` occurs when attempting to create an all access token. To get past this problem, user has to hard refreshes the page. 
When testing the error locally, I was able to generate that same error by passing in an empty string in place of `meID`. 

fix: 
Inside `handleSave` Before constructing the tokens object, check if the value of meID is empty and dispatch an action to fetch its value. 


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
