### PR TITLE
fix: fixes most of the windows commands

### DIFF
--- a/src/homepageExperience/components/steps/cli/ExecuteAggregateQuery.tsx
+++ b/src/homepageExperience/components/steps/cli/ExecuteAggregateQuery.tsx
@@ -73,9 +73,9 @@ export const ExecuteAggregateQuery = (props: OwnProps) => {
       <p>In the InfluxDB CLI, run the following:</p>
       <CodeSnippet
         text={
-          window?.navigator?.userAgent.includes('Mac')
-            ? codeSnippetMac
-            : codeSnippetWindows
+          window?.navigator?.userAgent.includes('Windows')
+            ? codeSnippetWindows
+            : codeSnippetMac
         }
         onCopy={logCopyCodeSnippet}
         language="properties"

--- a/src/homepageExperience/components/steps/cli/ExecuteAggregateQuery.tsx
+++ b/src/homepageExperience/components/steps/cli/ExecuteAggregateQuery.tsx
@@ -8,7 +8,11 @@ import {DEFAULT_BUCKET} from 'src/writeData/components/WriteDataDetailsContext'
 // Utils
 import {SafeBlankLink} from 'src/utils/SafeBlankLink'
 import {event} from 'src/cloud/utils/reporting'
-import {keyboardCopyTriggered, userSelection} from 'src/utils/crossPlatform'
+import {
+  isUsingWindows,
+  keyboardCopyTriggered,
+  userSelection,
+} from 'src/utils/crossPlatform'
 
 const logCopyCodeSnippet = () => {
   event('firstMile.cliWizard.executeAggregateQuery.code.copied')
@@ -72,11 +76,7 @@ export const ExecuteAggregateQuery = (props: OwnProps) => {
       />
       <p>In the InfluxDB CLI, run the following:</p>
       <CodeSnippet
-        text={
-          window?.navigator?.userAgent.includes('Windows')
-            ? codeSnippetWindows
-            : codeSnippetMac
-        }
+        text={isUsingWindows() ? codeSnippetWindows : codeSnippetMac}
         onCopy={logCopyCodeSnippet}
         language="properties"
       />

--- a/src/homepageExperience/components/steps/cli/ExecuteAggregateQuery.tsx
+++ b/src/homepageExperience/components/steps/cli/ExecuteAggregateQuery.tsx
@@ -30,7 +30,8 @@ export const ExecuteAggregateQuery = (props: OwnProps) => {
   |> filter(fn: (r) => r.measurement == "temperature")
   |> mean()`
 
-  const codeSnippet = `influx query 'from(bucket:"${bucketName}") |> range(start:-30m) |> mean()' --raw`
+  const codeSnippetMac = `influx query 'from(bucket:"${bucketName}") |> range(start:-30m) |> mean()' --raw`
+  const codeSnippetWindows = `.\\influx query 'from(bucket:"${bucketName}") |> range(start:-30m) |> mean()' --raw`
 
   useEffect(() => {
     const fireKeyboardCopyEvent = event => {
@@ -71,7 +72,11 @@ export const ExecuteAggregateQuery = (props: OwnProps) => {
       />
       <p>In the InfluxDB CLI, run the following:</p>
       <CodeSnippet
-        text={codeSnippet}
+        text={
+          window?.navigator?.userAgent.includes('Mac')
+            ? codeSnippetMac
+            : codeSnippetWindows
+        }
         onCopy={logCopyCodeSnippet}
         language="properties"
       />

--- a/src/homepageExperience/components/steps/cli/ExecuteQuery.tsx
+++ b/src/homepageExperience/components/steps/cli/ExecuteQuery.tsx
@@ -10,7 +10,11 @@ import {DEFAULT_BUCKET} from 'src/writeData/components/WriteDataDetailsContext'
 // Utils
 import {event} from 'src/cloud/utils/reporting'
 import {SafeBlankLink} from 'src/utils/SafeBlankLink'
-import {keyboardCopyTriggered, userSelection} from 'src/utils/crossPlatform'
+import {
+  isUsingWindows,
+  keyboardCopyTriggered,
+  userSelection,
+} from 'src/utils/crossPlatform'
 
 const logCopyCodeSnippet = () => {
   event('firstMile.cliWizard.executeQuery.code.copied')
@@ -73,11 +77,7 @@ export const ExecuteQuery = (props: OwnProps) => {
         the InfluxDB CLI.
       </p>
       <CodeSnippet
-        text={
-          window?.navigator?.userAgent.includes('Windows')
-            ? queryWindows
-            : queryMac
-        }
+        text={isUsingWindows() ? queryWindows : queryMac}
         onCopy={logCopyCodeSnippet}
         language="properties"
       />

--- a/src/homepageExperience/components/steps/cli/ExecuteQuery.tsx
+++ b/src/homepageExperience/components/steps/cli/ExecuteQuery.tsx
@@ -23,7 +23,8 @@ type OwnProps = {
 export const ExecuteQuery = (props: OwnProps) => {
   const {bucket} = props
   const bucketName = bucket === DEFAULT_BUCKET ? 'sample-bucket' : bucket
-  const query = `influx query 'from(bucket:"${bucketName}") |> range(start:-30m)' --raw`
+  const queryMac = `influx query 'from(bucket:"${bucketName}") |> range(start:-30m)' --raw`
+  const queryWindows = `.\\influx query 'from(bucket:"${bucketName}") |> range(start:-30m)' --raw`
 
   const fluxExample = `from(bucket: “weather-data”)
   |> range(start: -10m)
@@ -72,7 +73,9 @@ export const ExecuteQuery = (props: OwnProps) => {
         the InfluxDB CLI.
       </p>
       <CodeSnippet
-        text={query}
+        text={
+          window?.navigator?.userAgent.includes('Mac') ? queryMac : queryWindows
+        }
         onCopy={logCopyCodeSnippet}
         language="properties"
       />

--- a/src/homepageExperience/components/steps/cli/ExecuteQuery.tsx
+++ b/src/homepageExperience/components/steps/cli/ExecuteQuery.tsx
@@ -74,7 +74,9 @@ export const ExecuteQuery = (props: OwnProps) => {
       </p>
       <CodeSnippet
         text={
-          window?.navigator?.userAgent.includes('Mac') ? queryMac : queryWindows
+          window?.navigator?.userAgent.includes('Windows')
+            ? queryWindows
+            : queryMac
         }
         onCopy={logCopyCodeSnippet}
         language="properties"

--- a/src/homepageExperience/components/steps/cli/InitializeClient.tsx
+++ b/src/homepageExperience/components/steps/cli/InitializeClient.tsx
@@ -63,13 +63,21 @@ export const InitializeClient: FC<OwnProps> = ({
   })
   const token = currentAuth.token
 
-  const codeSnippet = `influx config create --config-name onboarding \\
+  const codeSnippetMac = `influx config create --config-name onboarding \\
     --host-url "${url}" \\
     --org "${org.id}" \\
     --token "${token}" \\
     --active`
 
-  const bucketSnippet = `influx bucket create --name sample-bucket -c onboarding`
+  const bucketSnippetMac = `influx bucket create --name sample-bucket -c onboarding`
+
+  const codeSnippetWindows = `.\\influx config create --config-name onboarding \`
+  --host-url "${url}" \`
+  --org "${org.id}" \`
+  --token "${token}" \`
+  --active`
+
+  const bucketSnippetWindows = `.\\influx bucket create --name sample-bucket -c onboarding`
 
   const sortedPermissionTypes = useMemo(
     () => allPermissionTypes.sort((a, b) => collator.compare(a, b)),
@@ -142,7 +150,11 @@ export const InitializeClient: FC<OwnProps> = ({
         profile using a different token for working with your own data.
       </p>
       <CodeSnippet
-        text={codeSnippet}
+        text={
+          window?.navigator?.userAgent.includes('Mac')
+            ? codeSnippetMac
+            : codeSnippetWindows
+        }
         onCopy={logCopyCodeSnippet}
         language="properties"
       />
@@ -174,7 +186,11 @@ export const InitializeClient: FC<OwnProps> = ({
         skip this step and proceed to the next.
       </p>
       <CodeSnippet
-        text={bucketSnippet}
+        text={
+          window?.navigator?.userAgent.includes('Mac')
+            ? bucketSnippetMac
+            : bucketSnippetWindows
+        }
         onCopy={logCopyCodeSnippet}
         language="properties"
       />

--- a/src/homepageExperience/components/steps/cli/InitializeClient.tsx
+++ b/src/homepageExperience/components/steps/cli/InitializeClient.tsx
@@ -151,9 +151,9 @@ export const InitializeClient: FC<OwnProps> = ({
       </p>
       <CodeSnippet
         text={
-          window?.navigator?.userAgent.includes('Mac')
-            ? codeSnippetMac
-            : codeSnippetWindows
+          window?.navigator?.userAgent.includes('Windows')
+            ? codeSnippetWindows
+            : codeSnippetMac
         }
         onCopy={logCopyCodeSnippet}
         language="properties"
@@ -187,9 +187,9 @@ export const InitializeClient: FC<OwnProps> = ({
       </p>
       <CodeSnippet
         text={
-          window?.navigator?.userAgent.includes('Mac')
-            ? bucketSnippetMac
-            : bucketSnippetWindows
+          window?.navigator?.userAgent.includes('Windows')
+            ? bucketSnippetWindows
+            : bucketSnippetMac
         }
         onCopy={logCopyCodeSnippet}
         language="properties"

--- a/src/homepageExperience/components/steps/cli/InitializeClient.tsx
+++ b/src/homepageExperience/components/steps/cli/InitializeClient.tsx
@@ -31,7 +31,11 @@ import {WriteDataDetailsContext} from 'src/writeData/components/WriteDataDetails
 // Utils
 import {allAccessPermissions} from 'src/authorizations/utils/permissions'
 import {event} from 'src/cloud/utils/reporting'
-import {keyboardCopyTriggered, userSelection} from 'src/utils/crossPlatform'
+import {
+  isUsingWindows,
+  keyboardCopyTriggered,
+  userSelection,
+} from 'src/utils/crossPlatform'
 
 // Types
 import {AppState, Authorization} from 'src/types'
@@ -150,11 +154,7 @@ export const InitializeClient: FC<OwnProps> = ({
         profile using a different token for working with your own data.
       </p>
       <CodeSnippet
-        text={
-          window?.navigator?.userAgent.includes('Windows')
-            ? codeSnippetWindows
-            : codeSnippetMac
-        }
+        text={isUsingWindows() ? codeSnippetWindows : codeSnippetMac}
         onCopy={logCopyCodeSnippet}
         language="properties"
       />
@@ -186,11 +186,7 @@ export const InitializeClient: FC<OwnProps> = ({
         skip this step and proceed to the next.
       </p>
       <CodeSnippet
-        text={
-          window?.navigator?.userAgent.includes('Windows')
-            ? bucketSnippetWindows
-            : bucketSnippetMac
-        }
+        text={isUsingWindows() ? bucketSnippetWindows : bucketSnippetMac}
         onCopy={logCopyCodeSnippet}
         language="properties"
       />

--- a/src/homepageExperience/components/steps/cli/InstallDependencies.tsx
+++ b/src/homepageExperience/components/steps/cli/InstallDependencies.tsx
@@ -218,9 +218,10 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
           <p>2. Click Allow access</p>
           <h2 style={headingWithMargin}>Useful InfluxDB CLI commands</h2>
           <p>
-            To invoke a command, use the following format in the command line:
+            To invoke a command, move into the directory where the CLI package
+            is installed and use the following format in the command line:
           </p>
-          <p style={{marginLeft: '40px'}}>influx [command]</p>
+          <p style={{marginLeft: '40px'}}>.\influx [command]</p>
           <Table borders={BorderType.All}>
             <Table.Body>
               <Table.Row>

--- a/src/homepageExperience/components/steps/cli/WriteData.tsx
+++ b/src/homepageExperience/components/steps/cli/WriteData.tsx
@@ -12,7 +12,11 @@ import {DEFAULT_BUCKET} from 'src/writeData/components/WriteDataDetailsContext'
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'
-import {keyboardCopyTriggered, userSelection} from 'src/utils/crossPlatform'
+import {
+  isUsingWindows,
+  keyboardCopyTriggered,
+  userSelection,
+} from 'src/utils/crossPlatform'
 
 // Assets
 import sampleCsv from 'assets/images/sample-csv.png'
@@ -121,9 +125,7 @@ export const WriteDataComponent = (props: OwnProps) => {
           </p>
           <CodeSnippet
             text={
-              window?.navigator?.userAgent.includes('Windows')
-                ? writeDataCodeCsvWindows
-                : writeDataCodeCsvMac
+              isUsingWindows() ? writeDataCodeCsvWindows : writeDataCodeCsvMac
             }
             onCopy={logCopyCodeSnippet}
             language="properties"
@@ -186,9 +188,7 @@ export const WriteDataComponent = (props: OwnProps) => {
           </p>
           <CodeSnippet
             text={
-              window?.navigator?.userAgent.includes('Windows')
-                ? writeDataCodeUrlWindows
-                : writeDataCodeUrlMac
+              isUsingWindows() ? writeDataCodeUrlWindows : writeDataCodeUrlMac
             }
             onCopy={logCopyCodeSnippet}
             language="properties"

--- a/src/homepageExperience/components/steps/cli/WriteData.tsx
+++ b/src/homepageExperience/components/steps/cli/WriteData.tsx
@@ -121,9 +121,9 @@ export const WriteDataComponent = (props: OwnProps) => {
           </p>
           <CodeSnippet
             text={
-              window?.navigator?.userAgent.includes('Mac')
-                ? writeDataCodeCsvMac
-                : writeDataCodeCsvWindows
+              window?.navigator?.userAgent.includes('Windows')
+                ? writeDataCodeCsvWindows
+                : writeDataCodeCsvMac
             }
             onCopy={logCopyCodeSnippet}
             language="properties"
@@ -186,9 +186,9 @@ export const WriteDataComponent = (props: OwnProps) => {
           </p>
           <CodeSnippet
             text={
-              window?.navigator?.userAgent.includes('Mac')
-                ? writeDataCodeUrlMac
-                : writeDataCodeUrlWindows
+              window?.navigator?.userAgent.includes('Windows')
+                ? writeDataCodeUrlWindows
+                : writeDataCodeUrlMac
             }
             onCopy={logCopyCodeSnippet}
             language="properties"

--- a/src/homepageExperience/components/steps/cli/WriteData.tsx
+++ b/src/homepageExperience/components/steps/cli/WriteData.tsx
@@ -36,8 +36,10 @@ export const WriteDataComponent = (props: OwnProps) => {
 
   const sampleDataUrl =
     'https://influx-testdata.s3.amazonaws.com/air-sensor-data-annotated.csv'
-  const writeDataCodeCsv = `influx write --bucket ${bucketName} --file downloads/air-sensor-data-annotated.csv`
-  const writeDataCodeUrl = `influx write --bucket ${bucketName} --url ${sampleDataUrl}`
+  const writeDataCodeCsvMac = `influx write --bucket ${bucketName} --file downloads/air-sensor-data-annotated.csv`
+  const writeDataCodeCsvWindows = `.\\influx write --bucket ${bucketName} --file <YOUR_PATH>/air-sensor-data-annotated.csv`
+  const writeDataCodeUrlMac = `influx write --bucket ${bucketName} --url ${sampleDataUrl}`
+  const writeDataCodeUrlWindows = `.\\influx write --bucket ${bucketName} --url ${sampleDataUrl}`
 
   const [currentDataSelection, setCurrentDataSelection] = useState<
     CurrentDataSelection
@@ -118,7 +120,11 @@ export const WriteDataComponent = (props: OwnProps) => {
             bucket.
           </p>
           <CodeSnippet
-            text={writeDataCodeCsv}
+            text={
+              window?.navigator?.userAgent.includes('Mac')
+                ? writeDataCodeCsvMac
+                : writeDataCodeCsvWindows
+            }
             onCopy={logCopyCodeSnippet}
             language="properties"
           />
@@ -179,7 +185,11 @@ export const WriteDataComponent = (props: OwnProps) => {
             bucket.
           </p>
           <CodeSnippet
-            text={writeDataCodeUrl}
+            text={
+              window?.navigator?.userAgent.includes('Mac')
+                ? writeDataCodeUrlMac
+                : writeDataCodeUrlWindows
+            }
             onCopy={logCopyCodeSnippet}
             language="properties"
           />

--- a/src/utils/crossPlatform.test.ts
+++ b/src/utils/crossPlatform.test.ts
@@ -2,6 +2,9 @@ import {
   shouldOpenLinkInNewTab,
   keyboardCopyTriggered,
   userSelection,
+  isUsingWindows,
+  isUsingMac,
+  isUsingLinux,
 } from 'src/utils/crossPlatform'
 
 let userAgentGetter
@@ -194,5 +197,35 @@ describe('checking whether a link should be opened in a new tab', () => {
     it('gets the correct selection', () => {
       expect(userSelection()).toBe('test')
     })
+  })
+})
+
+describe('which operating system', () => {
+  beforeEach(() => {
+    userAgentGetter = jest.spyOn(global.window.navigator, 'userAgent', 'get')
+  })
+  it('is windows', () => {
+    userAgentGetter.mockReturnValue('5.0 Windows')
+    expect(isUsingWindows()).toBeTruthy()
+  })
+  it('is mac', () => {
+    userAgentGetter.mockReturnValue('5.0 Macintosh')
+    expect(isUsingMac()).toBeTruthy()
+  })
+  it('is linux', () => {
+    userAgentGetter.mockReturnValue('5.0 Linux')
+    expect(isUsingLinux()).toBeTruthy()
+  })
+  it('is not windows', () => {
+    userAgentGetter.mockReturnValue('5.0 Macintosh')
+    expect(isUsingWindows()).toBeFalsy()
+  })
+  it('is not mac', () => {
+    userAgentGetter.mockReturnValue('5.0 Windows')
+    expect(isUsingMac()).toBeFalsy()
+  })
+  it('is not linux', () => {
+    userAgentGetter.mockReturnValue('5.0 Macintosh')
+    expect(isUsingLinux()).toBeFalsy()
   })
 })

--- a/src/utils/crossPlatform.ts
+++ b/src/utils/crossPlatform.ts
@@ -70,3 +70,24 @@ export const keyboardCopyTriggered = (
 export const userSelection = () => {
   return window.getSelection().toString()
 }
+
+export const isUsingWindows = () => {
+  if (window?.navigator?.userAgent.includes('Windows')) {
+    return true
+  }
+  return false
+}
+
+export const isUsingMac = () => {
+  if (window?.navigator?.userAgent.includes('Mac')) {
+    return true
+  }
+  return false
+}
+
+export const isUsingLinux = () => {
+  if (window?.navigator?.userAgent.includes('Linux')) {
+    return true
+  }
+  return false
+}


### PR DESCRIPTION
Closes #5390

Displays commands based on which OS the user is using. Now windows commands are correct and the directions are more clear. More work needs to be done to figure out why the queries are not identifying the buckets in windows.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
