### PR TITLE
fix(AccountTabs): reorder tabs in account and org page

### DIFF
--- a/src/accounts/AccountTabs.tsx
+++ b/src/accounts/AccountTabs.tsx
@@ -30,16 +30,16 @@ const AccountTabs: FC<Props> = ({activeTab}) => {
 
   const tabs: AccountPageTab[] = [
     {
-      text: 'Billing',
-      id: Tab.Billing,
-      testID: 'accounts-billing-tab',
-      link: `/orgs/${orgID}/billing`,
-    },
-    {
       text: 'Settings',
       id: Tab.About,
       testID: 'accounts-setting-tab',
       link: `/orgs/${orgID}/accounts/settings`,
+    },
+    {
+      text: 'Billing',
+      id: Tab.Billing,
+      testID: 'accounts-billing-tab',
+      link: `/orgs/${orgID}/billing`,
     },
   ]
 

--- a/src/organizations/components/OrgNavigation.tsx
+++ b/src/organizations/components/OrgNavigation.tsx
@@ -41,16 +41,16 @@ const OrgNavigation: FC<Props> = ({activeTab}) => {
       link: `/orgs/${orgID}/members`,
     },
     {
-      text: 'Members',
-      id: Tab.Users,
-      enabled: () => CLOUD,
-      link: `/orgs/${orgID}/users`,
-    },
-    {
       text: 'Settings',
       id: Tab.About,
       enabled: () => CLOUD,
       link: `/orgs/${orgID}/about`,
+    },
+    {
+      text: 'Members',
+      id: Tab.Users,
+      enabled: () => CLOUD,
+      link: `/orgs/${orgID}/users`,
     },
     {
       text: 'About',

--- a/src/pageLayout/components/UserWidget.tsx
+++ b/src/pageLayout/components/UserWidget.tsx
@@ -42,14 +42,6 @@ const UserWidget: FC<Props> = ({
       <CloudOnly>
         <TreeNav.SubHeading label="Account" />
         <TreeNav.UserItem
-          id="billing"
-          label="Billing"
-          testID="user-nav-item-billing"
-          linkElement={className => (
-            <Link className={className} to={`${orgPrefix}/billing`} />
-          )}
-        />
-        <TreeNav.UserItem
           id="account"
           label="Settings"
           testID="user-account-switching-page"
@@ -57,21 +49,29 @@ const UserWidget: FC<Props> = ({
             <Link className={className} to={`${orgPrefix}/accounts/settings`} />
           )}
         />
-        <TreeNav.SubHeading label="Organization" />
         <TreeNav.UserItem
-          id="users"
-          label="Members"
-          testID="user-nav-item-users"
+          id="billing"
+          label="Billing"
+          testID="user-nav-item-billing"
           linkElement={className => (
-            <Link className={className} to={`${orgPrefix}/users`} />
+            <Link className={className} to={`${orgPrefix}/billing`} />
           )}
         />
+        <TreeNav.SubHeading label="Organization" />
         <TreeNav.UserItem
           id="about"
           label="Settings"
           testID="user-nav-item-about"
           linkElement={className => (
             <Link className={className} to={`${orgPrefix}/about`} />
+          )}
+        />
+        <TreeNav.UserItem
+          id="users"
+          label="Members"
+          testID="user-nav-item-users"
+          linkElement={className => (
+            <Link className={className} to={`${orgPrefix}/users`} />
           )}
         />
         <TreeNav.UserItem


### PR DESCRIPTION
Closes #5309 
pr reorders 

- Account page from Billing > Setting to Setting > Billing.
- Organization page from Members > Settings > Usage to Settings > Members > Usage. 
- User Widget items to lead with Settings page

https://user-images.githubusercontent.com/66275100/184663659-7c493ff8-94f4-4cb2-b687-fbf0a9d2ba5b.mov


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
