### PR TITLE
feat: add install dependencies page for Arduino wizard

### DIFF
--- a/src/homepageExperience/components/steps/arduino/InstallDependencies.tsx
+++ b/src/homepageExperience/components/steps/arduino/InstallDependencies.tsx
@@ -1,115 +1,28 @@
-import {
-  ComponentColor,
-  Button,
-  ButtonGroup,
-  Orientation,
-} from '@influxdata/clockface'
-
-import React, {FC, useEffect, useState} from 'react'
-import {useDispatch} from 'react-redux'
-import {getBuckets} from 'src/buckets/actions/thunks'
-import {event} from 'src/cloud/utils/reporting'
-import {keyboardCopyTriggered, userSelection} from 'src/utils/crossPlatform'
+import React, {FC} from 'react'
+import {SafeBlankLink} from 'src/utils/SafeBlankLink'
 
 export const InstallDependencies: FC = () => {
-  const dispatch = useDispatch()
-
-  useEffect(() => {
-    dispatch(getBuckets())
-  }, [])
-
-  const headingWithMargin = {marginTop: '48px', marginBottom: '0px'}
-
-  const logCopyCodeSnippet = OS => {
-    event(`firstMile.cliWizard.installDependencies${OS}.code.copied`)
-  }
-
-  type CurrentOSSelection = 'Linux' | 'Mac' | 'Windows'
-  const [currentSelection, setCurrentSelection] = useState<CurrentOSSelection>(
-    'Mac'
-  )
-
-  useEffect(() => {
-    const fireKeyboardCopyEvent = event => {
-      if (
-        keyboardCopyTriggered(event) &&
-        userSelection().includes('brew install')
-      ) {
-        logCopyCodeSnippet('Mac')
-      }
-      if (
-        keyboardCopyTriggered(event) &&
-        (userSelection().includes('Expand-Archive') ||
-          userSelection().includes('mv'))
-      ) {
-        logCopyCodeSnippet('Windows')
-      }
-      if (
-        keyboardCopyTriggered(event) &&
-        (userSelection().includes('wget') ||
-          userSelection().includes('tar') ||
-          userSelection().includes('sudo'))
-      ) {
-        logCopyCodeSnippet('Linux')
-      }
-    }
-    document.addEventListener('keydown', fireKeyboardCopyEvent)
-    return () => document.removeEventListener('keydown', fireKeyboardCopyEvent)
-  }, [])
-
   return (
     <>
       <h1>Install Dependencies</h1>
-      <ButtonGroup orientation={Orientation.Horizontal}>
-        <Button
-          text="mac OS"
-          color={
-            currentSelection === 'Mac'
-              ? ComponentColor.Primary
-              : ComponentColor.Default
-          }
-          onClick={() => {
-            setCurrentSelection('Mac')
-          }}
-        />
-        <Button
-          text="windows"
-          color={
-            currentSelection === 'Windows'
-              ? ComponentColor.Primary
-              : ComponentColor.Default
-          }
-          onClick={() => {
-            setCurrentSelection('Windows')
-          }}
-        />
-        <Button
-          text="linux"
-          color={
-            currentSelection === 'Linux'
-              ? ComponentColor.Primary
-              : ComponentColor.Default
-          }
-          onClick={() => {
-            setCurrentSelection('Linux')
-          }}
-        />
-      </ButtonGroup>
-      {currentSelection === 'Mac' && (
-        <>
-          <h2 style={headingWithMargin}>Use Homebrew</h2>
-        </>
-      )}
-      {currentSelection === 'Windows' && (
-        <>
-          <h2 style={headingWithMargin}>Download the CLI package</h2>
-        </>
-      )}
-      {currentSelection === 'Linux' && (
-        <>
-          <h2 style={headingWithMargin}>Download from the command line</h2>
-        </>
-      )}
+      <p>
+        You can install the required InfluxDB Client for Arduino library from
+        the library manager
+      </p>
+      <ol style={{fontSize: '16px', fontWeight: 'normal'}}>
+        <li>
+          Under Sketch &rarr; Include Libraries, click on Manage Libraries.
+        </li>
+        <li>Search for 'influxdb' in the search box.</li>
+        <li>Install 'InfluxDB Client for Arduino' library.</li>
+      </ol>
+      <p>
+        You'll need to have{' '}
+        <SafeBlankLink href="https://www.arduino.cc/en/software">
+          Arduino
+        </SafeBlankLink>{' '}
+        installed.
+      </p>
     </>
   )
 }


### PR DESCRIPTION
Closes #5212 

Adds Install Dependencies page to Arduino onboarding.

![Screen Shot 2022-08-15 at 11 41 30 AM](https://user-images.githubusercontent.com/13280708/184695902-2f944801-ca1b-4cb1-afa6-d2e687244f9f.png)

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
