### PR TITLE
feat: add writeData pages to arduino onboarding

### DIFF
--- a/src/homepageExperience/components/steps/arduino/WriteData.tsx
+++ b/src/homepageExperience/components/steps/arduino/WriteData.tsx
@@ -52,13 +52,15 @@ export const WriteData = () => {
     <>
       <h1>Write Data</h1>
       <p className="small-margins">
-        Append the lines of code to add tags to the Point, the end of void
-        setup() function like:
+        To start writing data, append the lines of code to add tags to the Point
+        at the end of the{' '}
+        <code className="homepage-wizard--code-highlight">void setup()</code>{' '}
+        function.
       </p>
       <CodeSnippet
         text={codeSnippetOne}
         onCopy={logCopyCodeSnippet}
-        language="properties"
+        language="arduino"
       />
       <p>
         Add the following{' '}
@@ -68,12 +70,37 @@ export const WriteData = () => {
       <CodeSnippet
         text={codeSnippetTwo}
         onCopy={logCopyCodeSnippet}
-        language="properties"
+        language="arduino"
       />
       <p>
         In the above code snippet, we retrive the RSSI (Received Signal Strength
         Indicator) of your wifi connection and write it to InfluxDB using the
         client.
+      </p>
+      <h2>Review data concepts</h2>
+      <p>
+        <b>Field (required)</b> <br />
+        Key-value pair for storing time-series data. For example, insect name
+        and its count. You can have one field per record (row of data), and many
+        fields per bucket. <br />
+        <i>key data type: string</i> <br />
+        <i>value data type: float, integer, string, or boolean</i>
+        <br />
+      </p>
+      <p>
+        <b>Measurement (required)</b> <br />
+        A category for your fields. In our example, it is census. You can have
+        one measurement per record (row of data), and many measurements per
+        bucket. <br />
+        <i>data type: string</i> <br />
+      </p>
+      <p style={{marginBottom: '48px'}}>
+        <b>Tag (optional)</b> <br />
+        Key-value pair for field metadata. For example, census location. You can
+        have many tags per record (row of data) and per bucket.
+        <br />
+        <i>key data type: string</i> <br />
+        <i>value data type: float, integer, string, or boolean</i>
       </p>
     </>
   )

--- a/src/homepageExperience/components/steps/arduino/WriteData.tsx
+++ b/src/homepageExperience/components/steps/arduino/WriteData.tsx
@@ -3,11 +3,21 @@ import React from 'react'
 
 // Components
 import CodeSnippet from 'src/shared/components/CodeSnippet'
+import DataListening from 'src/homepageExperience/components/DataListening'
+import {InfluxColors, Panel} from '@influxdata/clockface'
 
 // Utils
+import {DEFAULT_BUCKET} from 'src/writeData/components/WriteDataDetailsContext'
 import {event} from 'src/cloud/utils/reporting'
 
-export const WriteData = () => {
+type OwnProps = {
+  bucket: string
+}
+
+export const WriteData = (props: OwnProps) => {
+  const {bucket} = props
+  const bucketName = bucket === DEFAULT_BUCKET ? 'sample-bucket' : bucket
+
   const codeSnippetOne = `void setup() {
     // ... code in setup() from Initialize Client
    
@@ -77,6 +87,14 @@ export const WriteData = () => {
         Indicator) of your wifi connection and write it to InfluxDB using the
         client.
       </p>
+      <p>
+        Once the data is finished writing, you will see a confirmation below.
+      </p>
+      <Panel backgroundColor={InfluxColors.Grey15}>
+        <Panel.Body>
+          <DataListening bucket={bucketName} />
+        </Panel.Body>
+      </Panel>
       <h2>Review data concepts</h2>
       <p>
         <b>Field (required)</b> <br />

--- a/src/homepageExperience/containers/ArduinoWizard.tsx
+++ b/src/homepageExperience/containers/ArduinoWizard.tsx
@@ -142,7 +142,7 @@ export class ArduinoWizard extends PureComponent<{}, State> {
         )
       }
       case 5: {
-        return <WriteData bucket={this.state.selectedBucket} />
+        return <WriteData />
       }
       case 6: {
         return <ExecuteQuery bucket={this.state.selectedBucket} />

--- a/src/homepageExperience/containers/ArduinoWizard.tsx
+++ b/src/homepageExperience/containers/ArduinoWizard.tsx
@@ -142,7 +142,7 @@ export class ArduinoWizard extends PureComponent<{}, State> {
         )
       }
       case 5: {
-        return <WriteData />
+        return <WriteData bucket={this.state.selectedBucket} />
       }
       case 6: {
         return <ExecuteQuery bucket={this.state.selectedBucket} />


### PR DESCRIPTION
Closes #5215 

Adds writeData pages to the Arduino onboarding.

<img width="1437" alt="Screen Shot 2022-08-16 at 9 50 10 AM" src="https://user-images.githubusercontent.com/106361125/184896273-e7a80dd5-70da-4496-8678-a626ff4e739e.png">
<img width="1437" alt="Screen Shot 2022-08-16 at 9 50 17 AM" src="https://user-images.githubusercontent.com/106361125/184896293-ddd23636-1675-413a-bfbb-10e0e9310409.png">
<img width="1437" alt="Screen Shot 2022-08-16 at 9 50 22 AM" src="https://user-images.githubusercontent.com/106361125/184896323-9c12b570-8082-4921-ab4a-2ec0a9f4469b.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
