### PR TITLE
feat: add executeQuery page for arduino wizard

### DIFF
--- a/src/homepageExperience/components/steps/arduino/ExecuteQuery.tsx
+++ b/src/homepageExperience/components/steps/arduino/ExecuteQuery.tsx
@@ -3,6 +3,7 @@ import React, {useEffect} from 'react'
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'
+import CodeSnippet from 'src/shared/components/CodeSnippet'
 
 import {keyboardCopyTriggered, userSelection} from 'src/utils/crossPlatform'
 
@@ -17,6 +18,59 @@ type OwnProps = {
 export const ExecuteQuery = (props: OwnProps) => {
   const {bucket} = props
 
+  const codeSnippet = `void loop() {
+    // ... code from Write Data step 
+    
+    // Query will find the RSSI values for last minute for each connected WiFi network with this device
+     String query = "from(bucket: \"apis\")\n\
+   |> range(start: -1m)\n\
+   |> filter(fn: (r) => r._measurement == \"wifi_status\" and r._field == \"rssi\")";
+   
+     // Print composed query
+     Serial.println("Querying for RSSI values written to the \"apis\" bucket in the last 1 min... ");
+     Serial.println(query);
+   
+     // Send query to the server and get result
+     FluxQueryResult result = client.query(query);
+   
+     Serial.println("Results : ");
+     // Iterate over rows.
+     while (result.next()) {
+       // Get converted value for flux result column 'SSID'
+       String ssid = result.getValueByName("SSID").getString();
+       Serial.print("SSID '");
+       Serial.print(ssid);
+   
+       Serial.print("' with RSSI ");
+       // Get value of column named '_value'
+       long value = result.getValueByName("_value").getLong();
+       Serial.print(value);
+   
+       // Get value for the _time column
+       FluxDateTime time = result.getValueByName("_time").getDateTime();
+   
+       String timeStr = time.format("%F %T");
+   
+       Serial.print(" at ");
+       Serial.print(timeStr);
+   
+       Serial.println();
+     }
+   
+     // Report any error
+     if (result.getError() != "") {
+       Serial.print("Query result error: ");
+       Serial.println(result.getError());
+     }
+   
+     // Close the result
+     result.close();
+   
+     Serial.println("==========");
+   
+     delay(5000);
+   }`
+
   useEffect(() => {
     const fireKeyboardCopyEvent = event => {
       if (
@@ -30,5 +84,19 @@ export const ExecuteQuery = (props: OwnProps) => {
     return () => document.removeEventListener('keydown', fireKeyboardCopyEvent)
   }, [])
 
-  return <h1>Execute a Flux Query on {bucket}</h1>
+  return (
+    <>
+      <h1>Execute a Flux Query on {bucket}</h1>
+      <p className="small-margins">
+        In this query, we are looking for data points within the last 1 minute
+        with a measurement of{' '}
+        <code className="homepage-wizard--code-highlight">"wifi_status"</code>.
+      </p>
+      <CodeSnippet
+        text={codeSnippet}
+        onCopy={logCopyCodeSnippet}
+        language="properties"
+      />
+    </>
+  )
 }

--- a/src/homepageExperience/components/steps/arduino/ExecuteQuery.tsx
+++ b/src/homepageExperience/components/steps/arduino/ExecuteQuery.tsx
@@ -1,10 +1,13 @@
 // Libraries
 import React, {useEffect} from 'react'
 
+// Components
+import CodeSnippet from 'src/shared/components/CodeSnippet'
+import {DEFAULT_BUCKET} from 'src/writeData/components/WriteDataDetailsContext'
+import {SafeBlankLink} from 'src/utils/SafeBlankLink'
+
 // Utils
 import {event} from 'src/cloud/utils/reporting'
-import CodeSnippet from 'src/shared/components/CodeSnippet'
-
 import {keyboardCopyTriggered, userSelection} from 'src/utils/crossPlatform'
 
 const logCopyCodeSnippet = () => {
@@ -17,17 +20,18 @@ type OwnProps = {
 
 export const ExecuteQuery = (props: OwnProps) => {
   const {bucket} = props
+  const bucketName = bucket === DEFAULT_BUCKET ? 'sample-bucket' : bucket
 
   const codeSnippet = `void loop() {
     // ... code from Write Data step 
     
     // Query will find the RSSI values for last minute for each connected WiFi network with this device
-     String query = "from(bucket: \"apis\")\n\
+     String query = "from(bucket: \"${bucketName}\")\n\
    |> range(start: -1m)\n\
    |> filter(fn: (r) => r._measurement == \"wifi_status\" and r._field == \"rssi\")";
    
      // Print composed query
-     Serial.println("Querying for RSSI values written to the \"apis\" bucket in the last 1 min... ");
+     Serial.println("Querying for RSSI values written to the \"${bucketName}\" bucket in the last 1 min... ");
      Serial.println(query);
    
      // Send query to the server and get result
@@ -71,6 +75,10 @@ export const ExecuteQuery = (props: OwnProps) => {
      delay(5000);
    }`
 
+  const fluxExample = `from(bucket: “weather-data”)
+  |> range(start: -10m)
+  |> filter(fn: (r) => r._measurement == “temperature”)`
+
   useEffect(() => {
     const fireKeyboardCopyEvent = event => {
       if (
@@ -86,7 +94,28 @@ export const ExecuteQuery = (props: OwnProps) => {
 
   return (
     <>
-      <h1>Execute a Flux Query on {bucket}</h1>
+      <h1>Execute a Flux Query</h1>
+      <p>
+        Now let's query the data we wrote into the database. We use the Flux
+        scripting language to query data.{' '}
+        <SafeBlankLink
+          href="https://docs.influxdata.com/influxdb/v2.2/reference/syntax/flux/"
+          onClick={() =>
+            event('firstMile.arduinoWizard.documentation.link.clicked')
+          }
+        >
+          Flux
+        </SafeBlankLink>{' '}
+        is designed for querying, analyzing, and acting on data.
+        <br />
+        <br />
+        Here's an example of a basic Flux script:
+      </p>
+      <CodeSnippet
+        text={fluxExample}
+        showCopyControl={false}
+        language="properties"
+      ></CodeSnippet>
       <p className="small-margins">
         In this query, we are looking for data points within the last 1 minute
         with a measurement of{' '}
@@ -95,7 +124,7 @@ export const ExecuteQuery = (props: OwnProps) => {
       <CodeSnippet
         text={codeSnippet}
         onCopy={logCopyCodeSnippet}
-        language="properties"
+        language="arduino"
       />
     </>
   )


### PR DESCRIPTION
Closes #5216 

Adds executeQuery page to arduino onboarding. 

![Screen Shot 2022-08-15 at 11 48 21 AM](https://user-images.githubusercontent.com/13280708/184696962-e0ae14fd-2632-4067-87bf-06b9e9242916.png)

Updated Screenshots:
<img width="1437" alt="Screen Shot 2022-08-16 at 9 36 03 AM" src="https://user-images.githubusercontent.com/106361125/184893659-2c455c64-7132-4579-a2a7-36680f322d89.png">
<img width="1437" alt="Screen Shot 2022-08-16 at 9 36 11 AM" src="https://user-images.githubusercontent.com/106361125/184893672-372102c8-99c3-4389-aa69-9725c5062e4e.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
