### PR TITLE
feat: add homebrew link to cli onboarding

### DIFF
--- a/src/homepageExperience/components/steps/cli/InstallDependencies.tsx
+++ b/src/homepageExperience/components/steps/cli/InstallDependencies.tsx
@@ -121,6 +121,9 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
         <>
           <h2 style={headingWithMargin}>Use Homebrew</h2>
           <p style={{fontSize: '14px'}}>
+            If needed, use this link to download{' '}
+            <SafeBlankLink href="https://brew.sh/">Homebrew</SafeBlankLink>.{' '}
+            <br />
             Note: if your Mac is equipped with an{' '}
             <code className="homepage-wizard--code-highlight">M</code> chip,
             ensure you have{' '}


### PR DESCRIPTION
Closes #5395

Adds link to homebrew so users can install it if necessary.

<img width="1437" alt="Screen Shot 2022-08-15 at 3 36 02 PM" src="https://user-images.githubusercontent.com/106361125/184705048-5fe4560c-07bc-4fcc-9875-6af54ce7e4e6.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
