### PR TITLE
chore: add more context to init client

### DIFF
--- a/src/homepageExperience/components/steps/arduino/InitializeClient.tsx
+++ b/src/homepageExperience/components/steps/arduino/InitializeClient.tsx
@@ -177,7 +177,12 @@ export const InitializeClient: FC<OwnProps> = ({
   return (
     <>
       <h1>Initialize Client</h1>
-      <p>Select or create a bucket to initialize the arduino client with.</p>
+      <h2 className="large-margins">Select or Create a bucket</h2>
+      <p className="small-margins">
+        A <b>bucket</b> is used to store time-series data. Here is a list of
+        your existing buckets. You can select one to use for the rest of the
+        tutorial, or create one below.
+      </p>
       <Panel backgroundColor={InfluxColors.Grey15}>
         <Panel.Body size={ComponentSize.ExtraSmall}>
           <Grid>
@@ -189,6 +194,12 @@ export const InitializeClient: FC<OwnProps> = ({
           </Grid>
         </Panel.Body>
       </Panel>
+      <h2>Configure an InfluxDB profile</h2>
+      <p className="small-margins">
+        Next we'll need to configure the client and its initial connection to
+        InfluxDB. InfluxDB Cloud uses Tokens to authenticate API access. We've
+        created an all-access token for you for this set up process.
+      </p>
       <p className="small-margins">
         Paste the following snippet into a blank Arduino sketch file.
       </p>


### PR DESCRIPTION
Closes #5405

Adds more context to the `Initialize Client` page of the arduino onboarding wizard to give users more information and direction. 

<img width="1437" alt="Screen Shot 2022-08-15 at 4 08 09 PM" src="https://user-images.githubusercontent.com/106361125/184709700-f5f7b9b6-dd7d-4d34-8957-4bd8a5e00b39.png">
<img width="1437" alt="Screen Shot 2022-08-15 at 4 08 32 PM" src="https://user-images.githubusercontent.com/106361125/184709761-4fdff0af-cfaa-432b-9507-b5a7ee8325b2.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
