### PR TITLE
feat(SetOrg): update url to match page title

### DIFF
--- a/cypress/e2e/cloud/about.test.ts
+++ b/cypress/e2e/cloud/about.test.ts
@@ -10,7 +10,7 @@ describe.skip('About Page for free users with only 1 user', () => {
             accountType: 'free',
             hasUsers: false,
           }).then(() => {
-            cy.visit(`/orgs/${id}/about`)
+            cy.visit(`/orgs/${id}/org-settings`)
             cy.getByTestID('about-page--header').should('be.visible')
           })
         })
@@ -27,7 +27,7 @@ describe.skip('About Page for free users with only 1 user', () => {
 
     cy.location()
       .should(loc => {
-        expect(loc.pathname).to.include(`/about/delete`)
+        expect(loc.pathname).to.include(`/org-settings/delete`)
       })
       .then(() => {
         cy.getByTestID('delete-org--overlay').should('exist')
@@ -56,7 +56,7 @@ describe('About Page for free users with multiple users', () => {
             accountType: 'free',
             hasUsers: true,
           }).then(() => {
-            cy.visit(`/orgs/${id}/about`)
+            cy.visit(`/orgs/${id}/org-settings`)
             cy.getByTestID('about-page--header').should('be.visible')
           })
         })
@@ -75,7 +75,7 @@ describe('About Page for free users with multiple users', () => {
       })
 
     cy.location().should(loc => {
-      expect(loc.pathname).to.include(`/users`)
+      expect(loc.pathname).to.include(`/members`)
     })
   })
 })
@@ -88,7 +88,7 @@ describe('About Page for PAYG users', () => {
           cy.quartzProvision({
             accountType: 'pay_as_you_go',
           }).then(() => {
-            cy.visit(`/orgs/${id}/about`)
+            cy.visit(`/orgs/${id}/org-settings`)
             cy.getByTestID('about-page--header').should('be.visible')
           })
         })

--- a/cypress/e2e/cloud/deepLinks.test.ts
+++ b/cypress/e2e/cloud/deepLinks.test.ts
@@ -12,8 +12,8 @@ describe('Deep linking', () => {
   // so you'll probably need to follow-up with the docs and/or marketing teams.
   it('should be redirected to the approprate page from a shortened link', () => {
     cy.get('@org').then((org: Organization) => {
-      cy.visit('/me/about')
-      cy.location('pathname').should('eq', `/orgs/${org.id}/about`)
+      cy.visit('/me/org-settings')
+      cy.location('pathname').should('eq', `/orgs/${org.id}/org-settings`)
 
       cy.visit('/me/alerts')
       cy.location('pathname').should('eq', `/orgs/${org.id}/alerting`)
@@ -123,8 +123,8 @@ describe('Deep linking', () => {
       cy.visit('/me/usage')
       cy.location('pathname').should('eq', `/orgs/${org.id}/usage`)
 
-      cy.visit('/me/users')
-      cy.location('pathname').should('eq', `/orgs/${org.id}/users`)
+      cy.visit('/me/members')
+      cy.location('pathname').should('eq', `/orgs/${org.id}/members`)
 
       cy.visit('/me/variables')
       cy.location('pathname').should('eq', `/orgs/${org.id}/settings/variables`)

--- a/cypress/e2e/cloud/globalHeader.ts
+++ b/cypress/e2e/cloud/globalHeader.ts
@@ -108,7 +108,7 @@ describe('change-account change-org global header', () => {
           .should('be.visible')
           .click()
 
-        cy.location('pathname').should('eq', `/orgs/${idpeOrgID}/about`)
+        cy.location('pathname').should('eq', `/orgs/${idpeOrgID}/org-settings`)
         cy.getByTestID('org-profile--panel')
           .should('be.visible')
           .and('contain', 'Organization Profile')
@@ -123,7 +123,7 @@ describe('change-account change-org global header', () => {
           .should('be.visible')
           .click()
 
-        cy.location('pathname').should('eq', `/orgs/${idpeOrgID}/users`)
+        cy.location('pathname').should('eq', `/orgs/${idpeOrgID}/members`)
         cy.getByTestID('tabs--container')
           .should('be.visible')
           .and('contain', 'Add a new user to your organization')

--- a/cypress/e2e/cloud/users.test.ts
+++ b/cypress/e2e/cloud/users.test.ts
@@ -8,7 +8,7 @@ describe('Users Page', () => {
           cy.quartzProvision({
             hasUsers: true,
           }).then(() => {
-            cy.visit(`/orgs/${id}/users`)
+            cy.visit(`/orgs/${id}/members`)
             cy.getByTestID('users-page--header').should('be.visible')
           })
         })

--- a/cypress/e2e/shared/about.test.ts
+++ b/cypress/e2e/shared/about.test.ts
@@ -6,7 +6,7 @@ describe('About Page', () => {
     cy.signin()
 
     cy.get('@org').then((org: Organization) => {
-      cy.visit(`/orgs/${org.id}/about`)
+      cy.visit(`/orgs/${org.id}/org-settings`)
       cy.getByTestID('about-page--header').should('be.visible')
     })
   })

--- a/cypress/e2e/shared/nav.test.ts
+++ b/cypress/e2e/shared/nav.test.ts
@@ -67,8 +67,7 @@ describe('navigation', () => {
     cy.getByTestID('user-nav').click()
     cy.getByTestID('user-nav-item-about').click()
     cy.getByTestID('about-page--header').should('exist')
-    const url =
-      Cypress.env('dexUrl') === 'OSS' ? 'about' : 'org-settings'
+    const url = Cypress.env('dexUrl') === 'OSS' ? 'about' : 'org-settings'
     cy.url().should('contain', url)
 
     /** \

--- a/cypress/e2e/shared/nav.test.ts
+++ b/cypress/e2e/shared/nav.test.ts
@@ -63,11 +63,11 @@ describe('navigation', () => {
 
      \**/
 
-    // User Nav -- About
+    // User Nav -- Settings
     cy.getByTestID('user-nav').click()
     cy.getByTestID('user-nav-item-about').click()
     cy.getByTestID('about-page--header').should('exist')
-    cy.url().should('contain', 'about')
+    cy.url().should('contain', 'org-settings')
 
     /** \
 

--- a/cypress/e2e/shared/nav.test.ts
+++ b/cypress/e2e/shared/nav.test.ts
@@ -67,7 +67,9 @@ describe('navigation', () => {
     cy.getByTestID('user-nav').click()
     cy.getByTestID('user-nav-item-about').click()
     cy.getByTestID('about-page--header').should('exist')
-    cy.url().should('contain', 'org-settings')
+    const url =
+      Cypress.env('dexUrl') === 'OSS' ? 'about' : 'org-settings'
+    cy.url().should('contain', url)
 
     /** \
 

--- a/src/checkout/SuccessOverlay.tsx
+++ b/src/checkout/SuccessOverlay.tsx
@@ -19,7 +19,7 @@ const SuccessOverlay: FC = () => {
   const orgId = useSelector(getOrg)?.id
 
   const handleClick = () => {
-    history.push(`/orgs/${orgId}/users`)
+    history.push(`/orgs/${orgId}/members`)
   }
 
   return (

--- a/src/identity/components/GlobalHeader/OrgDropdown.tsx
+++ b/src/identity/components/GlobalHeader/OrgDropdown.tsx
@@ -33,12 +33,12 @@ export const OrgDropdown: FC<Props> = ({activeOrg, orgsList}) => {
     {
       name: 'Settings',
       iconFont: IconFont.CogSolid_New,
-      href: `/orgs/${activeOrg.id}/about`,
+      href: `/orgs/${activeOrg.id}/org-settings`,
     },
     {
       name: 'Members',
       iconFont: IconFont.Group,
-      href: `/orgs/${activeOrg.id}/users`,
+      href: `/orgs/${activeOrg.id}/members`,
     },
     {
       name: 'Usage',

--- a/src/organizations/components/OrgNavigation.tsx
+++ b/src/organizations/components/OrgNavigation.tsx
@@ -44,13 +44,13 @@ const OrgNavigation: FC<Props> = ({activeTab}) => {
       text: 'Settings',
       id: Tab.About,
       enabled: () => CLOUD,
-      link: `/orgs/${orgID}/about`,
+      link: `/orgs/${orgID}/org-settings`,
     },
     {
       text: 'Members',
       id: Tab.Users,
       enabled: () => CLOUD,
-      link: `/orgs/${orgID}/users`,
+      link: `/orgs/${orgID}/members`,
     },
     {
       text: 'About',

--- a/src/organizations/components/OrgProfileTab/CopyableLabeledData.tsx
+++ b/src/organizations/components/OrgProfileTab/CopyableLabeledData.tsx
@@ -48,7 +48,7 @@ const CopyableLabeledData: FC<Props> = ({
   }
 
   const handleShowEditOverlay = () => {
-    history.push(`/orgs/${org.id}/about/rename`)
+    history.push(`/orgs/${org.id}/org-settings/rename`)
   }
 
   return (

--- a/src/organizations/components/OrgProfileTab/DeletePanel.tsx
+++ b/src/organizations/components/OrgProfileTab/DeletePanel.tsx
@@ -43,12 +43,12 @@ const DeletePanel: FC = () => {
       track('DeleteOrgInitiation', payload)
     }
 
-    history.push(`/orgs/${org.id}/about/delete`)
+    history.push(`/orgs/${org.id}/org-settings/delete`)
   }
 
   const handleShowWarning = () => {
     const buttonElement: NotificationButtonElement = onDismiss =>
-      getDeleteAccountWarningButton(`/orgs/${org.id}/users`, onDismiss)
+      getDeleteAccountWarningButton(`/orgs/${org.id}/members`, onDismiss)
     dispatch(notify(deleteAccountWarning(buttonElement)))
   }
 

--- a/src/organizations/components/RenameOrgForm.tsx
+++ b/src/organizations/components/RenameOrgForm.tsx
@@ -112,7 +112,7 @@ class RenameOrgForm extends PureComponent<Props, State> {
   }
 
   private handleGoBack = () => {
-    this.props.history.push(`/orgs/${this.props.startOrg.id}/about`)
+    this.props.history.push(`/orgs/${this.props.startOrg.id}/org-settings`)
   }
 
   private handleValidation = (orgName: string): string | null => {

--- a/src/organizations/containers/OrgProfilePage.tsx
+++ b/src/organizations/containers/OrgProfilePage.tsx
@@ -31,7 +31,10 @@ const OrgProfilePage: FC = () => {
         </OrgTabbedPage>
       </Page>
       <Switch>
-        <Route path="/orgs/:orgID/org-settings/rename" component={RenameOrgOverlay} />
+        <Route
+          path="/orgs/:orgID/org-settings/rename"
+          component={RenameOrgOverlay}
+        />
         {CLOUD && quartzMe?.accountType === 'free' && (
           <DeleteOrgProvider>
             <Route

--- a/src/organizations/containers/OrgProfilePage.tsx
+++ b/src/organizations/containers/OrgProfilePage.tsx
@@ -31,11 +31,11 @@ const OrgProfilePage: FC = () => {
         </OrgTabbedPage>
       </Page>
       <Switch>
-        <Route path="/orgs/:orgID/about/rename" component={RenameOrgOverlay} />
+        <Route path="/orgs/:orgID/org-settings/rename" component={RenameOrgOverlay} />
         {CLOUD && quartzMe?.accountType === 'free' && (
           <DeleteOrgProvider>
             <Route
-              path="/orgs/:orgID/about/delete"
+              path="/orgs/:orgID/org-settings/delete"
               component={DeleteOrgOverlay}
             />
           </DeleteOrgProvider>

--- a/src/pageLayout/components/UserWidget.tsx
+++ b/src/pageLayout/components/UserWidget.tsx
@@ -63,7 +63,7 @@ const UserWidget: FC<Props> = ({
           label="Settings"
           testID="user-nav-item-about"
           linkElement={className => (
-            <Link className={className} to={`${orgPrefix}/about`} />
+            <Link className={className} to={`${orgPrefix}/org-settings`} />
           )}
         />
         <TreeNav.UserItem
@@ -71,7 +71,7 @@ const UserWidget: FC<Props> = ({
           label="Members"
           testID="user-nav-item-users"
           linkElement={className => (
-            <Link className={className} to={`${orgPrefix}/users`} />
+            <Link className={className} to={`${orgPrefix}/members`} />
           )}
         />
         <TreeNav.UserItem

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -107,7 +107,6 @@ export const CLOUD_CHECKOUT_PATH = '/checkout'
 export const CLOUD_BILLING_PATH = '/billing'
 export const CLOUD_USAGE_PATH = '/usage'
 export const CLOUD_LOGOUT_PATH = '/logout'
-export const CLOUD_USERS_PATH = '/members'
 
 export const FLUX_RESPONSE_BYTES_LIMIT = CLOUD
   ? 27 * 1024 * 1024 // 27 MiB  (desa: this was determined by looking at queries responses in the cloud app)

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -107,7 +107,7 @@ export const CLOUD_CHECKOUT_PATH = '/checkout'
 export const CLOUD_BILLING_PATH = '/billing'
 export const CLOUD_USAGE_PATH = '/usage'
 export const CLOUD_LOGOUT_PATH = '/logout'
-export const CLOUD_USERS_PATH = '/users'
+export const CLOUD_USERS_PATH = '/members'
 
 export const FLUX_RESPONSE_BYTES_LIMIT = CLOUD
   ? 27 * 1024 * 1024 // 27 MiB  (desa: this was determined by looking at queries responses in the cloud app)

--- a/src/shared/containers/SetOrg.tsx
+++ b/src/shared/containers/SetOrg.tsx
@@ -254,7 +254,7 @@ const SetOrg: FC = () => {
             path={`${orgPath}/${SETTINGS}`}
             component={VariablesIndex}
           />
-          {/* Users */}
+          {/* Users - route has multiple paths to ensure backwards compatibility while https://github.com/influxdata/ui/issues/5396 is being worked on*/}
           {CLOUD && (
             <Route
               path={[`${orgPath}/users`, `${orgPath}/members`]}
@@ -271,7 +271,7 @@ const SetOrg: FC = () => {
           {!CLOUD && (
             <Route path={`${orgPath}/members`} component={MembersIndex} />
           )}
-          {/* About */}
+          {/* About - route has multiple paths to ensure backwards compatibility while https://github.com/influxdata/ui/issues/5396 is being worked on*/}
           <Route
             path={[`${orgPath}/about`, `${orgPath}/org-settings`]}
             component={OrgProfilePage}

--- a/src/shared/containers/SetOrg.tsx
+++ b/src/shared/containers/SetOrg.tsx
@@ -255,7 +255,7 @@ const SetOrg: FC = () => {
             component={VariablesIndex}
           />
           {/* Users */}
-          {CLOUD && <Route path={`${orgPath}/users`} component={UsersPage} />}
+          {CLOUD && <Route path={[`${orgPath}/users`, `${orgPath}/members`]} component={UsersPage} />}
           {/* Billing */}
           {CLOUD && (
             <Route path={`${orgPath}/billing`} component={BillingPage} />
@@ -267,7 +267,7 @@ const SetOrg: FC = () => {
             <Route path={`${orgPath}/members`} component={MembersIndex} />
           )}
           {/* About */}
-          <Route path={`${orgPath}/about`} component={OrgProfilePage} />
+          <Route path={[`${orgPath}/about`, `${orgPath}/org-settings`]} component={OrgProfilePage} />
           {/* account settings page */}
           <Route
             path={`${orgPath}/accounts/settings`}

--- a/src/shared/containers/SetOrg.tsx
+++ b/src/shared/containers/SetOrg.tsx
@@ -255,7 +255,12 @@ const SetOrg: FC = () => {
             component={VariablesIndex}
           />
           {/* Users */}
-          {CLOUD && <Route path={[`${orgPath}/users`, `${orgPath}/members`]} component={UsersPage} />}
+          {CLOUD && (
+            <Route
+              path={[`${orgPath}/users`, `${orgPath}/members`]}
+              component={UsersPage}
+            />
+          )}
           {/* Billing */}
           {CLOUD && (
             <Route path={`${orgPath}/billing`} component={BillingPage} />
@@ -267,7 +272,10 @@ const SetOrg: FC = () => {
             <Route path={`${orgPath}/members`} component={MembersIndex} />
           )}
           {/* About */}
-          <Route path={[`${orgPath}/about`, `${orgPath}/org-settings`]} component={OrgProfilePage} />
+          <Route
+            path={[`${orgPath}/about`, `${orgPath}/org-settings`]}
+            component={OrgProfilePage}
+          />
           {/* account settings page */}
           <Route
             path={`${orgPath}/accounts/settings`}

--- a/src/utils/deepLinks.ts
+++ b/src/utils/deepLinks.ts
@@ -1,6 +1,7 @@
 import {PROJECT_NAME_PLURAL} from 'src/flows'
 
 export const buildDeepLinkingMap = (orgId: string) => ({
+  '/me/about': `/orgs/${orgId}/about`,
   '/me/org-settings': `/orgs/${orgId}/org-settings`,
   '/me/alerts': `/orgs/${orgId}/alerting`,
   '/me/billing': `/orgs/${orgId}/billing`,
@@ -30,6 +31,7 @@ export const buildDeepLinkingMap = (orgId: string) => ({
   '/me/templates': `/orgs/${orgId}/settings/templates`,
   '/me/tokens': `/orgs/${orgId}/load-data/tokens`,
   '/me/usage': `/orgs/${orgId}/usage`,
+  '/me/users': `/orgs/${orgId}/users`,
   '/me/members': `/orgs/${orgId}/members`,
   '/me/variables': `/orgs/${orgId}/settings/variables`,
 })

--- a/src/utils/deepLinks.ts
+++ b/src/utils/deepLinks.ts
@@ -1,7 +1,7 @@
 import {PROJECT_NAME_PLURAL} from 'src/flows'
 
 export const buildDeepLinkingMap = (orgId: string) => ({
-  '/me/about': `/orgs/${orgId}/about`,
+  '/me/about': `/orgs/${orgId}/org-settings`,
   '/me/org-settings': `/orgs/${orgId}/org-settings`,
   '/me/alerts': `/orgs/${orgId}/alerting`,
   '/me/billing': `/orgs/${orgId}/billing`,
@@ -31,7 +31,7 @@ export const buildDeepLinkingMap = (orgId: string) => ({
   '/me/templates': `/orgs/${orgId}/settings/templates`,
   '/me/tokens': `/orgs/${orgId}/load-data/tokens`,
   '/me/usage': `/orgs/${orgId}/usage`,
-  '/me/users': `/orgs/${orgId}/users`,
+  '/me/users': `/orgs/${orgId}/members`,
   '/me/members': `/orgs/${orgId}/members`,
   '/me/variables': `/orgs/${orgId}/settings/variables`,
 })

--- a/src/utils/deepLinks.ts
+++ b/src/utils/deepLinks.ts
@@ -1,7 +1,7 @@
 import {PROJECT_NAME_PLURAL} from 'src/flows'
 
 export const buildDeepLinkingMap = (orgId: string) => ({
-  '/me/about': `/orgs/${orgId}/about`,
+  '/me/org-settings': `/orgs/${orgId}/org-settings`,
   '/me/alerts': `/orgs/${orgId}/alerting`,
   '/me/billing': `/orgs/${orgId}/billing`,
   '/me/buckets': `/orgs/${orgId}/load-data/buckets`,
@@ -30,6 +30,6 @@ export const buildDeepLinkingMap = (orgId: string) => ({
   '/me/templates': `/orgs/${orgId}/settings/templates`,
   '/me/tokens': `/orgs/${orgId}/load-data/tokens`,
   '/me/usage': `/orgs/${orgId}/usage`,
-  '/me/users': `/orgs/${orgId}/users`,
+  '/me/members': `/orgs/${orgId}/members`,
   '/me/variables': `/orgs/${orgId}/settings/variables`,
 })


### PR DESCRIPTION
Closes #5396 

Inside organization page, navigating to Settings tab takes user to `/orgs/:orgId/org-settings` 
navigating to Members tab takes user to `/orgs/:orgId/members`

Pr adds new paths `/org-settings` and `/members` inside `SetOrg.tsx` and updates links to point to the newly added routes. 
For now, old routes `/about` and `/users` will remain in the codebase to maintain backwards compatibility. 


https://user-images.githubusercontent.com/66275100/184909555-8ad967bd-5d32-46b7-84f0-a057e222c470.mov

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
