### PR TITLE
style: change font weight of h1 headers

### DIFF
--- a/src/homepageExperience/components/HomepageExperience.scss
+++ b/src/homepageExperience/components/HomepageExperience.scss
@@ -32,7 +32,7 @@ h1#first-mile--header {
 .homepage-wizard-container--main-wrapper {
   h1 {
     margin-top: 0;
-    font-weight: normal;
+    font-weight: 600;
   }
 
   p {


### PR DESCRIPTION
Closes #5424

Makes all `h1` headers have a font weight of 600 in the onboarding wizards, so it matches the `h2` headers.

Before:
<img width="1437" alt="Screen Shot 2022-08-16 at 2 25 18 PM" src="https://user-images.githubusercontent.com/106361125/184960128-ad48be85-7481-46c0-8bf4-c9751d7d1991.png">

After:
<img width="1437" alt="Screen Shot 2022-08-16 at 2 59 39 PM" src="https://user-images.githubusercontent.com/106361125/184960291-a07423d6-3f81-49a5-a187-dd81e79c515c.png">



### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
