### PR TITLE
feat(multi-org): smaller height for page headers with multi-org flag on

### DIFF
--- a/cypress/e2e/shared/dashboardsVariables.test.ts
+++ b/cypress/e2e/shared/dashboardsVariables.test.ts
@@ -832,7 +832,7 @@ csv.from(csv: data) |> filter(fn: (r) => r.bucket == v.bucketsCSV)`
 |> filter(fn: (r) => r["_measurement"] == "test")
 |> filter(fn: (r) => r["_field"] == "dopeness")
 |> filter(fn: (r) => r["container_name"] == v.dependent)`)
-      cy.getByTestID('save-cell--button').click()
+      cy.getByTestID('save-cell--button').click({force: true})
 
       // the default bucket selection should have no results
       cy.getByTestID('variable-dropdown--static--typeAhead-input').should(

--- a/cypress/e2e/shared/simpleTable.test.ts
+++ b/cypress/e2e/shared/simpleTable.test.ts
@@ -53,7 +53,7 @@ describe('simple table interactions', () => {
     // verify correct number of pages
     cy.getByTestID('pagination-item')
       .last()
-      .contains('50')
+      .contains('100')
 
     // show raw data view of data with 10 pages
     cy.getByTestID(`selector-list ${simpleSmall}`).should('be.visible')
@@ -84,7 +84,7 @@ describe('simple table interactions', () => {
       .should('be.visible')
     cy.getByTestID('pagination-item')
       .last()
-      .contains('15')
+      .contains('10')
   })
 
   it('should render correctly after switching from a dataset with fewer pages to one with more', () => {
@@ -117,7 +117,7 @@ describe('simple table interactions', () => {
     // verify correct number of pages
     cy.getByTestID('pagination-item')
       .last()
-      .contains('5')
+      .contains('10')
 
     // show raw data view of data with 100 pages
     cy.getByTestID(`selector-list ${simpleLarge}`).should('be.visible')
@@ -148,7 +148,7 @@ describe('simple table interactions', () => {
       .should('be.visible')
     cy.getByTestID('pagination-item')
       .last()
-      .contains('150')
+      .contains('100')
   })
 
   it('should not duplicate records from the n-1 page on the nth page', () => {
@@ -181,7 +181,7 @@ describe('simple table interactions', () => {
     // verify correct number of pages
     cy.getByTestID('pagination-item')
       .last()
-      .contains('6')
+      .contains('11')
     // verify only record 31 is on last page
     cy.getByTestID('table-cell 30').should('not.exist')
     cy.getByTestID('table-cell 31').should('be.visible')
@@ -229,8 +229,8 @@ describe('simple table interactions', () => {
     cy.getByTestID('pagination-item')
       .eq(3)
       .click()
+    cy.getByTestID('table-cell 26').should('be.visible')
     cy.getByTestID('table-cell 27').should('be.visible')
-    cy.getByTestID('table-cell 28').should('be.visible')
     cy.getByTestID('pagination-item')
       .last()
       .click()
@@ -239,8 +239,8 @@ describe('simple table interactions', () => {
     cy.getByTestID('pagination-item')
       .eq(2)
       .click()
-    cy.getByTestID('table-cell 25').should('be.visible')
-    cy.getByTestID('table-cell 26').should('be.visible')
+    cy.getByTestID('table-cell 23').should('be.visible')
+    cy.getByTestID('table-cell 24').should('be.visible')
     cy.getByTestID('pagination-item')
       .last()
       .click()
@@ -249,8 +249,8 @@ describe('simple table interactions', () => {
     cy.getByTestID('pagination-item')
       .eq(1)
       .click()
-    cy.getByTestID('table-cell 23').should('be.visible')
-    cy.getByTestID('table-cell 24').should('be.visible')
+    cy.getByTestID('table-cell 20').should('be.visible')
+    cy.getByTestID('table-cell 21').should('be.visible')
     cy.getByTestID('pagination-item')
       .last()
       .click()

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,9 @@ import {CLOUD} from 'src/shared/constants'
 import {shouldUseQuartzIdentity} from 'src/identity/utils/shouldUseQuartzIdentity'
 import {executeVWO} from 'src/utils/vwo'
 
+if (isFlagEnabled('multiOrg')) {
+  require('./MultiOrgOverrideStyles.scss')
+}
 // Styles
 const fullScreen = {height: '100%', width: '100%'}
 

--- a/src/MultiOrgOverrideStyles.scss
+++ b/src/MultiOrgOverrideStyles.scss
@@ -1,0 +1,4 @@
+.cf-page-header {
+  height: 50px !important;
+  flex: 0 0 50px !important;
+}

--- a/src/MultiOrgOverrideStyles.scss
+++ b/src/MultiOrgOverrideStyles.scss
@@ -1,4 +1,5 @@
 .cf-page-header {
-  height: 50px !important;
-  flex: 0 0 50px !important;
+  height: 45px !important;
+  flex: 0 0 45px !important;
+  margin-bottom: 12px !important;
 }

--- a/src/homepageExperience/containers/HomepageContainer.tsx
+++ b/src/homepageExperience/containers/HomepageContainer.tsx
@@ -280,10 +280,10 @@ export const HomepageContainer: FC = () => {
               >
                 {CLOUD ? (
                   <UsageProvider>
-                    <Resources style={{backgroundColor: InfluxColors.Grey5}} />
+                    <Resources style={{backgroundColor: InfluxColors.Grey5, paddingRight: 0}} />
                   </UsageProvider>
                 ) : (
-                  <Resources style={{backgroundColor: InfluxColors.Grey5}} />
+                  <Resources style={{backgroundColor: InfluxColors.Grey5, paddingRight: 0}} />
                 )}
               </Grid.Column>
             </Grid.Row>

--- a/src/homepageExperience/containers/HomepageContainer.tsx
+++ b/src/homepageExperience/containers/HomepageContainer.tsx
@@ -280,10 +280,20 @@ export const HomepageContainer: FC = () => {
               >
                 {CLOUD ? (
                   <UsageProvider>
-                    <Resources style={{backgroundColor: InfluxColors.Grey5, paddingRight: 0}} />
+                    <Resources
+                      style={{
+                        backgroundColor: InfluxColors.Grey5,
+                        paddingRight: 0,
+                      }}
+                    />
                   </UsageProvider>
                 ) : (
-                  <Resources style={{backgroundColor: InfluxColors.Grey5, paddingRight: 0}} />
+                  <Resources
+                    style={{
+                      backgroundColor: InfluxColors.Grey5,
+                      paddingRight: 0,
+                    }}
+                  />
                 )}
               </Grid.Column>
             </Grid.Row>


### PR DESCRIPTION
Closes [#5431](https://github.com/influxdata/ui/issues/5431)

Conditionally imports Override Styles based on toggle state of `multiOrg` flag.

Flag off: 

<img width="1648" alt="Screen Shot 2022-08-16 at 9 45 23 PM" src="https://user-images.githubusercontent.com/18511823/185036789-3ce6646e-96cf-4b4a-8f44-1ed414bb2269.png">


Flag on: 

<img width="1648" alt="Screen Shot 2022-08-16 at 9 45 42 PM" src="https://user-images.githubusercontent.com/18511823/185036805-793fb7ee-2b26-41fb-b775-22782fb8b15a.png">


<!-- Describe your proposed changes here. -->
<!-- Including screenshots or visuals is very helpful - a picture is worth a thousand words. -->

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
