### PR TITLE
test(buckets): add a guard before clicking

### DIFF
--- a/cypress/e2e/cloud/buckets.test.ts
+++ b/cypress/e2e/cloud/buckets.test.ts
@@ -45,7 +45,11 @@ const testSchemaFiles = (
   cy.getByTestID(`bucket-card ${bucketName}`)
     .should('exist')
     .within(() => {
-      cy.getByTestID('bucket-settings').click()
+      cy.getByTestID('bucket-settings')
+        .should($el => {
+          expect(Cypress.dom.isDetached($el)).to.eq(false)
+        })
+        .click()
     })
 
   cy.getByTestID('bucket-form').should('be.visible')
@@ -68,7 +72,11 @@ const testSchemaFiles = (
   cy.getByTestID(`bucket-card ${bucketName}`)
     .should('exist')
     .within(() => {
-      cy.getByTestID('bucket-settings').click()
+      cy.getByTestID('bucket-settings')
+        .should($el => {
+          expect(Cypress.dom.isDetached($el)).to.eq(false)
+        })
+        .click()
     })
 
   cy.getByTestID('bucket-form').should('be.visible')
@@ -135,7 +143,11 @@ describe('Explicit Buckets', () => {
       cy.getByTestID('bucket-showSchema').contains('Show Schema')
 
       // click on settings; open up the advanced section, and should see the "explicit" as the bucket schema type:
-      cy.getByTestID('bucket-settings').click()
+      cy.getByTestID('bucket-settings')
+        .should($el => {
+          expect(Cypress.dom.isDetached($el)).to.eq(false)
+        })
+        .click()
     })
     cy.getByTestID('overlay--container').within(() => {
       cy.getByTestID('schemaBucketToggle').click()
@@ -185,7 +197,11 @@ describe('Explicit Buckets', () => {
       cy.getByTestID('bucket-showSchema').should('not.exist')
 
       // click on settings; open up the advanced section, and should see the "implicit" as the bucket schema type:
-      cy.getByTestID('bucket-settings').click()
+      cy.getByTestID('bucket-settings')
+        .should($el => {
+          expect(Cypress.dom.isDetached($el)).to.eq(false)
+        })
+        .click()
     })
     cy.getByTestID('overlay--container').within(() => {
       cy.getByTestID('schemaBucketToggle').click()
@@ -228,7 +244,11 @@ describe('Explicit Buckets', () => {
     cy.getByTestID(`bucket-card ${bucketName}`)
       .should('exist')
       .within(() => {
-        cy.getByTestID('bucket-settings').click()
+        cy.getByTestID('bucket-settings')
+          .should($el => {
+            expect(Cypress.dom.isDetached($el)).to.eq(false)
+          })
+          .click()
       })
 
     cy.getByTestID('bucket-form').should('be.visible')
@@ -321,7 +341,11 @@ fsRead,field,float`
     cy.getByTestID(`bucket-card ${bucketName}`)
       .should('exist')
       .within(() => {
-        cy.getByTestID('bucket-settings').click()
+        cy.getByTestID('bucket-settings')
+          .should($el => {
+            expect(Cypress.dom.isDetached($el)).to.eq(false)
+          })
+          .click()
       })
 
     const schemaName = 'updated schema'
@@ -347,10 +371,11 @@ fsRead,field,float`
     cy.getByTestID(`bucket-card ${bucketName}`)
       .should('exist')
       .within(() => {
-        cy.getByTestID('bucket-settings').should($el => {
-          expect(Cypress.dom.isDetached($el)).to.eq(false)
-        })
-        .click()
+        cy.getByTestID('bucket-settings')
+          .should($el => {
+            expect(Cypress.dom.isDetached($el)).to.eq(false)
+          })
+          .click()
       })
 
     cy.getByTestID('bucket-form').should('be.visible')
@@ -389,7 +414,11 @@ fsRead,field,float`
     cy.getByTestID(`bucket-card ${bucketName}`)
       .should('exist')
       .within(() => {
-        cy.getByTestID('bucket-settings').click()
+        cy.getByTestID('bucket-settings')
+          .should($el => {
+            expect(Cypress.dom.isDetached($el)).to.eq(false)
+          })
+          .click()
       })
 
     cy.getByTestID('bucket-form').should('be.visible')

--- a/cypress/e2e/cloud/buckets.test.ts
+++ b/cypress/e2e/cloud/buckets.test.ts
@@ -347,7 +347,10 @@ fsRead,field,float`
     cy.getByTestID(`bucket-card ${bucketName}`)
       .should('exist')
       .within(() => {
-        cy.getByTestID('bucket-settings').click()
+        cy.getByTestID('bucket-settings').should($el => {
+          expect(Cypress.dom.isDetached($el)).to.eq(false)
+        })
+        .click()
       })
 
     cy.getByTestID('bucket-form').should('be.visible')


### PR DESCRIPTION
Closes #5434 

Pr uses `Cypress.dom.isDetached`, which returns a boolean indicating whether an element is detached from the DOM as a guard before clicking bucket settings button.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
