### PR TITLE
fix(inLineLabels): handle null prop in selector

### DIFF
--- a/src/shared/components/inlineLabels/InlineLabels.tsx
+++ b/src/shared/components/inlineLabels/InlineLabels.tsx
@@ -114,7 +114,11 @@ class InlineLabels extends Component<Props> {
 
 const mstp = (state: AppState, props: OwnProps) => {
   const labels = getAll<Label>(state, ResourceType.Labels)
-  const selectedLabels = getLabels(state, props.selectedLabelIDs)
+
+  let selectedLabels = []
+  if (props.selectedLabelIDs) {
+    selectedLabels = getLabels(state, props.selectedLabelIDs)
+  }
 
   return {labels, selectedLabels}
 }


### PR DESCRIPTION
Closes #5439 

Pr adds a check in `mstp` in order to prevent null value `props.selectedLabelIDs` from being used in selector. 

Before fix: 

https://user-images.githubusercontent.com/66275100/185191639-e0407a4d-130b-499f-96d2-21a7d66e412d.mov


After fix: 

https://user-images.githubusercontent.com/66275100/185191722-7b2d2ece-2504-4edf-bdc1-b98ad12c8b93.mov



### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
