### PR TITLE
feat: auto selects users os

### DIFF
--- a/src/homepageExperience/components/steps/cli/InstallDependencies.tsx
+++ b/src/homepageExperience/components/steps/cli/InstallDependencies.tsx
@@ -11,7 +11,12 @@ import {
 
 import React, {FC, useEffect, useState} from 'react'
 import {event} from 'src/cloud/utils/reporting'
-import {keyboardCopyTriggered, userSelection} from 'src/utils/crossPlatform'
+import {
+  isUsingLinux,
+  isUsingWindows,
+  keyboardCopyTriggered,
+  userSelection,
+} from 'src/utils/crossPlatform'
 
 export const InstallDependencies: FC = () => {
   const headingWithMargin = {marginTop: '48px', marginBottom: '0px'}
@@ -47,8 +52,17 @@ sudo cp influxdb2-client-latest-linux-arm64/influx /usr/local/bin/
   `
 
   type CurrentOSSelection = 'Linux' | 'Mac' | 'Windows'
+  const initSelection = () => {
+    if (isUsingWindows()) {
+      return 'Windows'
+    } else if (isUsingLinux()) {
+      return 'Linux'
+    } else {
+      return 'Mac'
+    }
+  }
   const [currentSelection, setCurrentSelection] = useState<CurrentOSSelection>(
-    'Mac'
+    initSelection()
   )
 
   useEffect(() => {


### PR DESCRIPTION
Closes #5435

Automatically detects which OS the suer is using and displays the correct install dependencies tab accordingly. 

Enhancement was suggested by @wojciechka, thanks!

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
