### PR TITLE
fix(updateBucket): set labels to [] if reponse is null

### DIFF
--- a/src/buckets/actions/thunks.ts
+++ b/src/buckets/actions/thunks.ts
@@ -225,7 +225,7 @@ export const updateBucket = (bucket: OwnBucket) => async (
     }
 
     const newBucket = normalize<Bucket, BucketEntities, string>(
-      Object.assign(resp.data, {labels: labelsResponse.data.labels}),
+      Object.assign(resp.data, {labels: labelsResponse.data.labels || []}),
       bucketSchema
     )
 

--- a/src/shared/components/inlineLabels/InlineLabels.tsx
+++ b/src/shared/components/inlineLabels/InlineLabels.tsx
@@ -114,11 +114,7 @@ class InlineLabels extends Component<Props> {
 
 const mstp = (state: AppState, props: OwnProps) => {
   const labels = getAll<Label>(state, ResourceType.Labels)
-
-  let selectedLabels = []
-  if (props.selectedLabelIDs) {
-    selectedLabels = getLabels(state, props.selectedLabelIDs)
-  }
+  const selectedLabels = getLabels(state, props.selectedLabelIDs)
 
   return {labels, selectedLabels}
 }


### PR DESCRIPTION
see #5439 

Due to recent changes made to the labels API, `getBucketsLabels` returns  `null` instead of `[]` for buckets with no labels. This response is incongruent with what the UI expects and causes the crash mentioned in the ticket linked. 

Pr adds a guard forcing `labels` to be an empty array when the api responds with a `null`. 

after fix: 


https://user-images.githubusercontent.com/66275100/185214225-7ccec46f-3b59-40bc-81b0-d6ca574ccdd4.mov


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
