### PR TITLE
chore: changing finished to finish on CLI and arduino wizards

### DIFF
--- a/cypress/e2e/shared/influxCLI.test.ts
+++ b/cypress/e2e/shared/influxCLI.test.ts
@@ -66,7 +66,7 @@ describe('Influx CLI onboarding', () => {
         cy.contains(/^Execute Aggregate$/).click()
         cy.get('h1').contains('Execute a Flux Aggregate Query')
 
-        cy.contains(/^Finished!$/).click()
+        cy.contains(/^Finish$/).click()
         cy.contains('Congrats!')
 
         cy.getByTestID('cli-next-button').should('be.disabled')

--- a/src/homepageExperience/containers/CliWizard.test.tsx
+++ b/src/homepageExperience/containers/CliWizard.test.tsx
@@ -19,7 +19,7 @@ describe('Navigation', () => {
   describe('Next and Previous Buttons', () => {
     it('cannot click next on final step', async () => {
       setup()
-      await fireEvent.click(screen.getByText('Finished!'))
+      await fireEvent.click(screen.getByText('Finish'))
       const nextButton = screen.getByTestId('cli-next-button')
       expect(nextButton).toHaveAttribute('disabled')
     })
@@ -37,7 +37,7 @@ describe('Navigation', () => {
     })
     it('can click previous on the last step', async () => {
       setup()
-      await fireEvent.click(screen.getByText('Finished!'))
+      await fireEvent.click(screen.getByText('Finish'))
       const prevButton = screen.getByTestId('cli-prev-button')
       expect(prevButton).not.toHaveAttribute('disabled')
     })

--- a/src/homepageExperience/utils.ts
+++ b/src/homepageExperience/utils.ts
@@ -61,7 +61,7 @@ export const HOMEPAGE_NAVIGATION_STEPS_SHORT = [
     glyph: IconFont.Play,
   },
   {
-    name: 'Finished!',
+    name: 'Finish',
     glyph: IconFont.StarSmile,
   },
 ]
@@ -96,7 +96,7 @@ export const HOMEPAGE_NAVIGATION_STEPS_ARDUINO = [
     glyph: IconFont.Play,
   },
   {
-    name: 'Finished!',
+    name: 'Finish',
     glyph: IconFont.StarSmile,
   },
 ]


### PR DESCRIPTION
Closes #5441 

Changes the Finished! text to just Finish on both the Arduino and CLI pages.

### Checklist

Authors and Reviewer(s), please verify the following:

- [ ] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [ ] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
