### PR TITLE
chore: update clockface to 6.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
   "dependencies": {
     "@codingame/monaco-jsonrpc": "^0.3.1",
     "@docsearch/react": "^3.0.0-alpha.37",
-    "@influxdata/clockface": "^6.1.0",
+    "@influxdata/clockface": "^6.1.1",
     "@influxdata/flux-lsp-browser": "0.8.28",
     "@influxdata/giraffe": "^2.33.5",
     "@influxdata/influxdb-templates": "0.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1458,10 +1458,10 @@
     gud "^1.0.0"
     warning "^4.0.3"
 
-"@influxdata/clockface@^6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-6.1.0.tgz#e79ca58d9027590ed8240b9d05693181aab6ce44"
-  integrity sha512-HCaQXkQ4Av9rGeqBSznmhi2OmJuQzj92LRQEgs3MHAeCUjWNci2wk5NBkwsIuFagbMJx83NhgSU8EIOL1p47nQ==
+"@influxdata/clockface@^6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-6.1.1.tgz#1af121883cd3fa6c2310559b3cb4a33a4cdc2f34"
+  integrity sha512-mImBIjE+1K5KWZBUI+tHbwFLE/qUFj9NqDrt4S9UiHR+6AiGNocZNLfi0gVSJihjYE0p5uYPS7CSCRrAfRiKjg==
   dependencies:
     "@types/react-window" "^1.8.5"
     react-window "^1.8.7"


### PR DESCRIPTION
Bring this release in: https://github.com/influxdata/clockface/releases/tag/v6.1.1

This helps with the TypeAhead dropdown selecting all text in the input upon click, for safari.