### PR TITLE
chore(flow/timeMachine): update search bar placeholder

### DIFF
--- a/src/flows/pipes/QueryBuilder/BucketSelector.tsx
+++ b/src/flows/pipes/QueryBuilder/BucketSelector.tsx
@@ -60,7 +60,7 @@ const BucketSelector: FC = () => {
         <BuilderCard.Menu>
           <Input
             value={search}
-            placeholder="Search for a bucket"
+            placeholder="Search buckets"
             className="tag-selector--search"
             onChange={e => setSearch(e.target.value)}
           />
@@ -109,7 +109,7 @@ const BucketSelector: FC = () => {
       <BuilderCard.Menu>
         <Input
           value={search}
-          placeholder="Search for a bucket"
+          placeholder="Search buckets"
           className="tag-selector--search"
           onChange={e => setSearch(e.target.value)}
           onClear={() => setSearch('')}

--- a/src/flows/pipes/QueryBuilder/CardList.tsx
+++ b/src/flows/pipes/QueryBuilder/CardList.tsx
@@ -272,6 +272,14 @@ const Card: FC<Props> = ({idx}) => {
     )
   }
 
+  let placeholderValue = `${card.keys.selected[0]} tag values`
+
+  if (card.keys.selected[0] === '_measurement') {
+    placeholderValue = 'measurements'
+  } else if (card.keys.selected[0] === '_field') {
+    placeholderValue = 'fields'
+  }
+
   if (card.aggregateFunctionType === 'group') {
     return (
       <BuilderCard>
@@ -284,7 +292,7 @@ const Card: FC<Props> = ({idx}) => {
         <BuilderCard.Menu>
           <Input
             value={valueSearches[idx] || ''}
-            placeholder={`Search ${card.keys.selected[0]} tag values`}
+            placeholder={`Search ${placeholderValue}`}
             className="tag-selector--search"
             onChange={evt => {
               valueSearch(evt.target.value)
@@ -337,7 +345,7 @@ const Card: FC<Props> = ({idx}) => {
         )}
         <Input
           value={valueSearches[idx] || ''}
-          placeholder={`Search ${card.keys.selected[0]} tag values`}
+          placeholder={`Search ${placeholderValue}`}
           className="tag-selector--search"
           onChange={evt => {
             valueSearch(evt.target.value)

--- a/src/flows/pipes/QueryBuilder/CardList.tsx
+++ b/src/flows/pipes/QueryBuilder/CardList.tsx
@@ -274,10 +274,12 @@ const Card: FC<Props> = ({idx}) => {
 
   let placeholderValue = `${card.keys.selected[0]} tag values`
 
-  if (card.keys.selected[0] === '_measurement') {
-    placeholderValue = 'measurements'
-  } else if (card.keys.selected[0] === '_field') {
-    placeholderValue = 'fields'
+  if (isFlagEnabled('newQueryBuilder')) {
+    if (card.keys.selected[0] === '_measurement') {
+      placeholderValue = 'measurements'
+    } else if (card.keys.selected[0] === '_field') {
+      placeholderValue = 'fields'
+    }
   }
 
   if (card.aggregateFunctionType === 'group') {

--- a/src/timeMachine/components/TagSelector.tsx
+++ b/src/timeMachine/components/TagSelector.tsx
@@ -135,10 +135,12 @@ class TagSelector extends PureComponent<Props> {
 
     let placeholderValue = `${tag} tag values`
 
-    if (tag === '_measurement') {
-      placeholderValue = 'measurements'
-    } else if (tag === '_field') {
-      placeholderValue = 'fields'
+    if (isFlagEnabled('newQueryBuilder')) {
+      if (tag === '_measurement') {
+        placeholderValue = 'measurements'
+      } else if (tag === '_field') {
+        placeholderValue = 'fields'
+      }
     }
 
     const placeholderText =

--- a/src/timeMachine/components/TagSelector.tsx
+++ b/src/timeMachine/components/TagSelector.tsx
@@ -133,10 +133,19 @@ class TagSelector extends PureComponent<Props> {
       tag = '_measurement'
     }
 
+    let placeholderValue = `${tag} tag values`
+
+    if (tag === '_measurement') {
+      placeholderValue = 'measurements'
+    } else if (tag === '_field') {
+      placeholderValue = 'fields'
+    }
+
     const placeholderText =
       aggregateFunctionType === 'group'
         ? 'Search group column values'
-        : `Search ${tag} tag values`
+        : `Search ${placeholderValue}`
+
     return (
       <>
         {!this.isCompliant && (

--- a/src/timeMachine/components/queryBuilder/BucketsSelector.tsx
+++ b/src/timeMachine/components/queryBuilder/BucketsSelector.tsx
@@ -64,7 +64,7 @@ const BucketSelector: FunctionComponent<Props> = ({
       <BuilderCard.Menu>
         <Input
           value={searchTerm}
-          placeholder="Search for a bucket"
+          placeholder="Search buckets"
           className="tag-selector--search"
           onChange={e => setSearchTerm(e.target.value)}
           onClear={() => setSearchTerm('')}


### PR DESCRIPTION
Closes #5332 

This PR updates the placeholder text to be consistent to the new Data Explorer. See the original issue for suggested format.

This change only affects the UI behind the feature flag `newQueryBuilder`

## Before
<img width="1082" alt="Screen Shot 2022-08-17 at 3 49 17 PM" src="https://user-images.githubusercontent.com/14298407/185242198-dc3f4539-bf97-42a1-b16f-fe582d4907dc.png">

## After
<img width="1092" alt="Screen Shot 2022-08-17 at 3 47 10 PM" src="https://user-images.githubusercontent.com/14298407/185242211-a3386d3b-31ae-4cb9-81fa-c68121cb6f71.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
~~- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~~
- [x] Feature flagged, if applicable 
