### PR TITLE
chore: full width pages for everything but Notebooks

### DIFF
--- a/cypress/e2e/cloud/billing.test.ts
+++ b/cypress/e2e/cloud/billing.test.ts
@@ -74,7 +74,7 @@ describe('Billing Page PAYG Users', () => {
 
   it('should display the free billing page for PAYG users', () => {
     // The implication here is that there is no Upgrade Now button
-    cy.get('.cf-page-header--fixed')
+    cy.get('.cf-page-header--fluid')
       .children()
       .should('have.length', 1)
 

--- a/cypress/e2e/cloud/usage.test.ts
+++ b/cypress/e2e/cloud/usage.test.ts
@@ -26,7 +26,7 @@ describe('Usage Page Free User No Data', () => {
 
   it('should display the usage page common features', () => {
     // Display the upgrade button when the user is a free user
-    cy.get('.cf-page-header--fixed')
+    cy.get('.cf-page-header--fluid')
       .children()
       .should('have.length', 2)
     cy.getByTestID('cloud-upgrade--button').should('be.visible')
@@ -128,7 +128,7 @@ describe('Usage Page PAYG With Data', () => {
 
   it('should display the usage page with data for a PAYG user', () => {
     // The implication here is that there is no Upgrade Now button
-    cy.get('.cf-page-header--fixed')
+    cy.get('.cf-page-header--fluid')
       .children()
       .should('have.length', 1)
 

--- a/cypress/e2e/cloud/zuoraOutage.test.ts
+++ b/cypress/e2e/cloud/zuoraOutage.test.ts
@@ -55,7 +55,7 @@ describe('Billing Page PAYG Users', () => {
 
   it('should display the zuora outage panel', () => {
     // The implication here is that there is no Upgrade Now button
-    cy.get('.cf-page-header--fixed')
+    cy.get('.cf-page-header--fluid')
       .children()
       .should('have.length', 1)
 

--- a/src/accounts/AccountHeader.tsx
+++ b/src/accounts/AccountHeader.tsx
@@ -10,7 +10,7 @@ type Props = {
 }
 
 const AccountHeader: FC<Props> = ({testID = 'member-page--header'}) => (
-  <Page.Header fullWidth={false} testID={testID}>
+  <Page.Header fullWidth={true} testID={testID}>
     <Page.Title title="Account" />
     <LimitChecker>
       <RateLimitAlert location="account" />

--- a/src/accounts/AccountTabContainer.tsx
+++ b/src/accounts/AccountTabContainer.tsx
@@ -19,7 +19,7 @@ class AccountTabContainer extends PureComponent<Props> {
     const {activeTab, children} = this.props
 
     return (
-      <Page.Contents fullWidth={false} scrollable={true}>
+      <Page.Contents fullWidth={true} scrollable={true}>
         <Tabs.Container orientation={Orientation.Horizontal}>
           <AccountTabs activeTab={activeTab} />
           <Tabs.TabContents>{children}</Tabs.TabContents>

--- a/src/billing/components/BillingPage.tsx
+++ b/src/billing/components/BillingPage.tsx
@@ -16,7 +16,7 @@ const BillingPage: FC = () => {
   return (
     <BillingProvider>
       <Page titleTag={pageTitleSuffixer(['Billing'])}>
-        <Page.Header fullWidth={false} testID="billing-page--header">
+        <Page.Header fullWidth={true} testID="billing-page--header">
           <Page.Title title="Account" />
           <LimitChecker>
             <RateLimitAlert location="billing" />

--- a/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
@@ -118,11 +118,11 @@ class DashboardIndex extends PureComponent<Props, State> {
           testID="empty-dashboards-list"
           titleTag={pageTitleSuffixer(['Dashboards'])}
         >
-          <Page.Header fullWidth={false}>
+          <Page.Header fullWidth={true}>
             <Page.Title title="Dashboards" />
             <RateLimitAlert location="dashboards" />
           </Page.Header>
-          <Page.ControlBar fullWidth={false}>
+          <Page.ControlBar fullWidth={true}>
             <ErrorBoundary>
               <Page.ControlBarLeft>
                 <SearchWidget

--- a/src/homepageExperience/containers/HomepageContainer.tsx
+++ b/src/homepageExperience/containers/HomepageContainer.tsx
@@ -109,7 +109,7 @@ export const HomepageContainer: FC = () => {
   return (
     <>
       <Page titleTag={pageTitleSuffixer(['Get Started'])}>
-        <Page.Header fullWidth={false}>
+        <Page.Header fullWidth={true}>
           <Heading
             id="first-mile--header"
             element={HeadingElement.H1}
@@ -119,7 +119,7 @@ export const HomepageContainer: FC = () => {
           </Heading>
           <RateLimitAlert location="firstMile.homepage" />
         </Page.Header>
-        <Page.Contents scrollable={true} fullWidth={false}>
+        <Page.Contents scrollable={true} fullWidth={true}>
           <Grid>
             <Grid.Row>
               <Grid.Column widthSM={Columns.Eight} widthMD={Columns.Nine}>

--- a/src/operator/AppPageHeader.tsx
+++ b/src/operator/AppPageHeader.tsx
@@ -10,7 +10,7 @@ interface Props {
 
 const AppPageHeader: FC<Props> = ({title, children}) => {
   return (
-    <Page.Header fullWidth={false}>
+    <Page.Header fullWidth={true}>
       <Page.Title title={title} />
       {children}
     </Page.Header>

--- a/src/organizations/components/OrgHeader.tsx
+++ b/src/organizations/components/OrgHeader.tsx
@@ -9,7 +9,7 @@ type Props = {
 }
 
 const OrgHeader: FC<Props> = ({testID = 'member-page--header'}) => (
-  <Page.Header fullWidth={false} testID={testID}>
+  <Page.Header fullWidth={true} testID={testID}>
     <Page.Title title="Organization" />
     <RateLimitAlert location="organization" />
   </Page.Header>

--- a/src/organizations/components/OrgTabbedPage.tsx
+++ b/src/organizations/components/OrgTabbedPage.tsx
@@ -18,7 +18,7 @@ class OrgTabbedPage extends PureComponent<Props> {
     const {activeTab, children} = this.props
 
     return (
-      <Page.Contents fullWidth={false} scrollable={true}>
+      <Page.Contents fullWidth={true} scrollable={true}>
         <Tabs.Container orientation={Orientation.Horizontal}>
           <OrgNavigation activeTab={activeTab} />
           <Tabs.TabContents>{children}</Tabs.TabContents>

--- a/src/settings/components/LoadDataHeader.tsx
+++ b/src/settings/components/LoadDataHeader.tsx
@@ -6,7 +6,7 @@ import RateLimitAlert from 'src/cloud/components/RateLimitAlert'
 
 const LoadDataHeader: FC = () => {
   return (
-    <Page.Header fullWidth={false} testID="load-data--header">
+    <Page.Header fullWidth={true} testID="load-data--header">
       <Page.Title title="Load Data" />
       <RateLimitAlert location="load data" />
     </Page.Header>

--- a/src/settings/components/LoadDataTabbedPage.tsx
+++ b/src/settings/components/LoadDataTabbedPage.tsx
@@ -14,7 +14,7 @@ interface Props {
 const LoadDataTabbedPage: FC<Props> = ({activeTab, children}) => {
   return (
     <Page.Contents
-      fullWidth={false}
+      fullWidth={true}
       scrollable={shouldPageBeScrollable(activeTab)}
       scrollbarSize={ComponentSize.Large}
       autoHideScrollbar={true}

--- a/src/settings/components/SettingsHeader.tsx
+++ b/src/settings/components/SettingsHeader.tsx
@@ -7,7 +7,7 @@ import RateLimitAlert from 'src/cloud/components/RateLimitAlert'
 class SettingsHeader extends Component {
   public render() {
     return (
-      <Page.Header fullWidth={false}>
+      <Page.Header fullWidth={true}>
         <Page.Title title="Settings" testID="settings-page--header" />
         <RateLimitAlert location="settings" />
       </Page.Header>

--- a/src/settings/components/SettingsTabbedPage.tsx
+++ b/src/settings/components/SettingsTabbedPage.tsx
@@ -19,7 +19,7 @@ class SettingsTabbedPage extends PureComponent<Props> {
 
     return (
       <Page.Contents
-        fullWidth={false}
+        fullWidth={true}
         scrollable={true}
         scrollbarSize={ComponentSize.Large}
         autoHideScrollbar={true}

--- a/src/tasks/components/TaskRunsPage.tsx
+++ b/src/tasks/components/TaskRunsPage.tsx
@@ -56,7 +56,7 @@ class TaskRunsPage extends PureComponent<Props, State> {
         spinnerComponent={<TechnoSpinner />}
       >
         <Page titleTag={pageTitleSuffixer(['Task Runs'])}>
-          <Page.Header fullWidth={false}>
+          <Page.Header fullWidth={true}>
             <PageBreadcrumbs
               pages={[
                 {
@@ -70,15 +70,15 @@ class TaskRunsPage extends PureComponent<Props, State> {
             />
             <RateLimitAlert location="task runs" />
           </Page.Header>
-          <Page.ControlBar fullWidth={false}>
+          <Page.ControlBar fullWidth={true}>
             <TaskRunsCard task={currentTask} isTaskEditable={isTaskEditable} />
           </Page.ControlBar>
-          <Page.ControlBar fullWidth={false}>
+          <Page.ControlBar fullWidth={true}>
             <Page.ControlBarRight>
               <TimeZoneDropdown />
             </Page.ControlBarRight>
           </Page.ControlBar>
-          <Page.Contents fullWidth={false} scrollable={true}>
+          <Page.Contents fullWidth={true} scrollable={true}>
             <TaskRunsList
               taskID={match.params.id}
               runs={runs}

--- a/src/tasks/components/TasksHeader.tsx
+++ b/src/tasks/components/TasksHeader.tsx
@@ -81,7 +81,7 @@ const TasksHeader: FC<Props> = ({
   }
   return (
     <>
-      <Page.Header fullWidth={false} testID="tasks-page--header">
+      <Page.Header fullWidth={true} testID="tasks-page--header">
         <Page.Title title="Tasks" />
         <RateLimitAlert location="task list" />
       </Page.Header>
@@ -102,7 +102,7 @@ const TasksHeader: FC<Props> = ({
           </div>
         </FeatureFlag>
       )}
-      <Page.ControlBar fullWidth={false}>
+      <Page.ControlBar fullWidth={true}>
         <Page.ControlBarLeft>
           <SearchWidget
             placeholderText="Filter tasks..."

--- a/src/tasks/containers/TasksPage.tsx
+++ b/src/tasks/containers/TasksPage.tsx
@@ -143,7 +143,7 @@ class TasksPage extends PureComponent<Props, State> {
             sortType={sortType}
             onSort={this.handleSort}
           />
-          <Page.Contents fullWidth={false} scrollable={false}>
+          <Page.Contents fullWidth={true} scrollable={false}>
             <AutoSizer>
               {({width, height}) => {
                 return (

--- a/src/writeData/components/fileUploads/UploadDataDetailsView.tsx
+++ b/src/writeData/components/fileUploads/UploadDataDetailsView.tsx
@@ -77,10 +77,10 @@ const UploadDataDetailsView: FC = () => {
               'Load Data',
             ])}
           >
-            <Page.Header fullWidth={false}>
+            <Page.Header fullWidth={true}>
               <Page.Title title={name} />
             </Page.Header>
-            <Page.Contents fullWidth={false} scrollable={true}>
+            <Page.Contents fullWidth={true} scrollable={true}>
               <div className="write-data--details">
                 <div className="write-data--details-thumbnail">{thumbnail}</div>
                 <div

--- a/src/writeData/containers/ClientLibrariesPage.tsx
+++ b/src/writeData/containers/ClientLibrariesPage.tsx
@@ -107,10 +107,10 @@ const ClientLibrariesPage: FC = () => {
               'Load Data',
             ])}
           >
-            <Page.Header fullWidth={false}>
+            <Page.Header fullWidth={true}>
               <Page.Title title={name} />
             </Page.Header>
-            <Page.Contents fullWidth={false} scrollable={true}>
+            <Page.Contents fullWidth={true} scrollable={true}>
               <div className="write-data--details">
                 <div className="write-data--details-thumbnail">{thumbnail}</div>
                 <div

--- a/src/writeData/containers/TelegrafPluginsPage.tsx
+++ b/src/writeData/containers/TelegrafPluginsPage.tsx
@@ -88,10 +88,10 @@ const TelegrafPluginsPage: FC<RouteComponentProps<{orgID: string}>> = props => {
               'Load Data',
             ])}
           >
-            <Page.Header fullWidth={false}>
+            <Page.Header fullWidth={true}>
               <Page.Title title={name} />
             </Page.Header>
-            <Page.Contents fullWidth={false} scrollable={true}>
+            <Page.Contents fullWidth={true} scrollable={true}>
               <AddPluginToConfigurationCTA
                 contentID={contentID}
                 history={history}


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/5456

For consistency across all pages, this sets a full width for all pages. The effect of this PR will only be visible on larger screens.

The Notebooks section still needs some work. It has some inconsistencies causing it to distort the UI. I'll put a separate PR to address that section.

Some examples:

Without: 

<img width="1536" alt="Screen Shot 2022-08-18 at 12 58 17 AM" src="https://user-images.githubusercontent.com/18511823/185342696-4b1828bd-7f86-4c79-ab29-499ab60374fd.png">

With: 

<img width="1536" alt="Screen Shot 2022-08-18 at 1 04 26 AM" src="https://user-images.githubusercontent.com/18511823/185343158-6b70b1ce-b934-4c04-b83b-910c3a03385b.png">


The consistent page layout just looks better.


<!-- Describe your proposed changes here. -->
<!-- Including screenshots or visuals is very helpful - a picture is worth a thousand words. -->

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
