### PR TITLE
fix: add panel around data listening cli

### DIFF
--- a/src/homepageExperience/components/steps/cli/WriteData.tsx
+++ b/src/homepageExperience/components/steps/cli/WriteData.tsx
@@ -2,7 +2,13 @@
 import React, {useEffect, useState} from 'react'
 
 // Components
-import {Button, ButtonGroup, ComponentColor} from '@influxdata/clockface'
+import {
+  Button,
+  ButtonGroup,
+  ComponentColor,
+  InfluxColors,
+  Panel,
+} from '@influxdata/clockface'
 import CodeSnippet from 'src/shared/components/CodeSnippet'
 import DataListening from 'src/homepageExperience/components/DataListening'
 import {SafeBlankLink} from 'src/utils/SafeBlankLink'
@@ -134,8 +140,11 @@ export const WriteDataComponent = (props: OwnProps) => {
             Once the data is finished writing, you will see a confirmation
             below.
           </p>
-          <DataListening bucket={bucketName} />
-
+          <Panel backgroundColor={InfluxColors.Grey15}>
+            <Panel.Body>
+              <DataListening bucket={bucketName} />
+            </Panel.Body>
+          </Panel>
           <h2>Review data concepts</h2>
           <p>
             <b>Field (required)</b> <br />
@@ -197,7 +206,11 @@ export const WriteDataComponent = (props: OwnProps) => {
             Once the data is finished writing, you will see a confirmation
             below.
           </p>
-          <DataListening bucket={bucketName} />
+          <Panel backgroundColor={InfluxColors.Grey15}>
+            <Panel.Body>
+              <DataListening bucket={bucketName} />
+            </Panel.Body>
+          </Panel>
           <h2>Review data concepts</h2>
           <p>
             <b>Field (required)</b> <br />


### PR DESCRIPTION
Closes #5458

Adds a panel around the `DataListening` component so that Users can see where they will see a confirmation, just like in the other wizards
<img width="1437" alt="Screen Shot 2022-08-18 at 8 51 15 AM" src="https://user-images.githubusercontent.com/106361125/185399052-e2fe4813-3150-47ab-8921-704d581be96c.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
