### PR TITLE
fix: update linux install link

### DIFF
--- a/src/homepageExperience/components/steps/cli/InstallDependencies.tsx
+++ b/src/homepageExperience/components/steps/cli/InstallDependencies.tsx
@@ -33,10 +33,10 @@ export const InstallDependencies: FC = () => {
     "> Expand-Archive .\\influxdb2-client-latest-amd64.zip -DestinationPath 'C:\\Program Files\\InfluxData\\'\n" +
     "> mv 'C:\\Program Files\\InfluxData\\influxdb2-client-latest-windows-amd64' 'C:\\Program Files\\InfluxData\\influx'"
   const linuxCodeSnippetA = `# amd64
-wget https://dl.influxdata.com/influxdb/releases/influxdb2-client-latest-linux-amd64.tar.gz
+wget https://dl.influxdata.com/influxdb/releases/influxdb2-client-2.3.0-linux-amd64.tar.gz
   
 # arm
-wget https://dl.influxdata.com/influxdb/releases/influxdb2-client-latest-linux-arm64.tar.gz
+wget https://dl.influxdata.com/influxdb/releases/influxdb2-client-2.3.0-linux-arm64.tar.gz
   `
   const linuxCodeSnippetB = `# amd64
 tar xvzf path/to/influxdb2-client-latest-linux-amd64.tar.gz


### PR DESCRIPTION
Closes #5453

Updates the `wget` links to be correct for linux.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
