### PR TITLE
chore: fixing the next button in arduino wizard

### DIFF
--- a/src/homepageExperience/containers/ArduinoWizard.tsx
+++ b/src/homepageExperience/containers/ArduinoWizard.tsx
@@ -217,7 +217,8 @@ export class ArduinoWizard extends PureComponent<{}, State> {
                   size={ComponentSize.Large}
                   color={ComponentColor.Primary}
                   status={
-                    this.state.currentStep < 8
+                    this.state.currentStep <
+                    HOMEPAGE_NAVIGATION_STEPS_ARDUINO.length
                       ? ComponentStatus.Default
                       : ComponentStatus.Disabled
                   }

--- a/src/homepageExperience/containers/ArduinoWizard.tsx
+++ b/src/homepageExperience/containers/ArduinoWizard.tsx
@@ -64,12 +64,6 @@ export class ArduinoWizard extends PureComponent<{}, State> {
   }
 
   handleNextClick = () => {
-    this.setState({
-      currentStep: Math.min(
-        this.state.currentStep + 1,
-        HOMEPAGE_NAVIGATION_STEPS_ARDUINO.length
-      ),
-    })
     event(
       'firstMile.arduinoWizard.next.clicked',
       {},
@@ -82,10 +76,15 @@ export class ArduinoWizard extends PureComponent<{}, State> {
         ),
       }
     )
+    this.setState({
+      currentStep: Math.min(
+        this.state.currentStep + 1,
+        HOMEPAGE_NAVIGATION_STEPS_ARDUINO.length
+      ),
+    })
   }
 
   handlePreviousClick = () => {
-    this.setState({currentStep: Math.max(this.state.currentStep - 1, 1)})
     event(
       'firstMile.arduinoWizard.previous.clicked',
       {},
@@ -98,6 +97,7 @@ export class ArduinoWizard extends PureComponent<{}, State> {
         ),
       }
     )
+    this.setState({currentStep: Math.max(this.state.currentStep - 1, 1)})
   }
 
   handleNavClick = (clickedStep: number) => {

--- a/src/homepageExperience/containers/ArduinoWizard.tsx
+++ b/src/homepageExperience/containers/ArduinoWizard.tsx
@@ -64,38 +64,38 @@ export class ArduinoWizard extends PureComponent<{}, State> {
   }
 
   handleNextClick = () => {
-    this.setState(
+    this.setState({
+      currentStep: Math.min(
+        this.state.currentStep + 1,
+        HOMEPAGE_NAVIGATION_STEPS_ARDUINO.length
+      ),
+    })
+    event(
+      'firstMile.arduinoWizard.next.clicked',
+      {},
       {
-        currentStep: Math.min(
-          this.state.currentStep + 1,
-          HOMEPAGE_NAVIGATION_STEPS_ARDUINO.length
+        clickedButtonAtStep: normalizeEventName(
+          HOMEPAGE_NAVIGATION_STEPS_ARDUINO[this.state.currentStep - 1].name
         ),
-      },
-      () => {
-        event(
-          'firstMile.arduinoWizard.next.clicked',
-          {},
-          {
-            clickedButtonAtStep: this.state.currentStep - 1,
-            currentStep: this.state.currentStep,
-          }
-        )
+        currentStep: normalizeEventName(
+          HOMEPAGE_NAVIGATION_STEPS_ARDUINO[this.state.currentStep].name
+        ),
       }
     )
   }
 
   handlePreviousClick = () => {
-    this.setState(
-      {currentStep: Math.max(this.state.currentStep - 1, 1)},
-      () => {
-        event(
-          'firstMile.arduinoWizard.previous.clicked',
-          {},
-          {
-            clickedButtonAtStep: this.state.currentStep + 1,
-            currentStep: this.state.currentStep,
-          }
-        )
+    this.setState({currentStep: Math.max(this.state.currentStep - 1, 1)})
+    event(
+      'firstMile.arduinoWizard.previous.clicked',
+      {},
+      {
+        clickedButtonAtStep: normalizeEventName(
+          HOMEPAGE_NAVIGATION_STEPS_ARDUINO[this.state.currentStep - 1].name
+        ),
+        currentStep: normalizeEventName(
+          HOMEPAGE_NAVIGATION_STEPS_ARDUINO[this.state.currentStep - 2].name
+        ),
       }
     )
   }

--- a/src/homepageExperience/containers/ArduinoWizard.tsx
+++ b/src/homepageExperience/containers/ArduinoWizard.tsx
@@ -64,42 +64,40 @@ export class ArduinoWizard extends PureComponent<{}, State> {
   }
 
   handleNextClick = () => {
-    event(
-      'firstMile.arduinoWizard.next.clicked',
-      {},
+    this.setState(
       {
-        clickedButtonAtStep: normalizeEventName(
-          HOMEPAGE_NAVIGATION_STEPS_ARDUINO[this.state.currentStep - 1].name
+        currentStep: Math.min(
+          this.state.currentStep + 1,
+          HOMEPAGE_NAVIGATION_STEPS_ARDUINO.length
         ),
-        currentStep: normalizeEventName(
-          HOMEPAGE_NAVIGATION_STEPS_ARDUINO[this.state.currentStep].name
-        ),
+      },
+      () => {
+        event(
+          'firstMile.arduinoWizard.next.clicked',
+          {},
+          {
+            clickedButtonAtStep: this.state.currentStep - 1,
+            currentStep: this.state.currentStep,
+          }
+        )
       }
     )
-
-    this.setState({
-      currentStep: Math.min(
-        this.state.currentStep + 1,
-        HOMEPAGE_NAVIGATION_STEPS_ARDUINO.length
-      ),
-    })
   }
 
   handlePreviousClick = () => {
-    event(
-      'firstMile.arduinoWizard.previous.clicked',
-      {},
-      {
-        clickedButtonAtStep: normalizeEventName(
-          HOMEPAGE_NAVIGATION_STEPS_ARDUINO[this.state.currentStep - 1].name
-        ),
-        currentStep: normalizeEventName(
-          HOMEPAGE_NAVIGATION_STEPS_ARDUINO[this.state.currentStep].name
-        ),
+    this.setState(
+      {currentStep: Math.max(this.state.currentStep - 1, 1)},
+      () => {
+        event(
+          'firstMile.arduinoWizard.previous.clicked',
+          {},
+          {
+            clickedButtonAtStep: this.state.currentStep + 1,
+            currentStep: this.state.currentStep,
+          }
+        )
       }
     )
-
-    this.setState({currentStep: Math.max(this.state.currentStep - 1, 1)})
   }
 
   handleNavClick = (clickedStep: number) => {

--- a/src/homepageExperience/containers/ArduinoWizard.tsx
+++ b/src/homepageExperience/containers/ArduinoWizard.tsx
@@ -64,46 +64,38 @@ export class ArduinoWizard extends PureComponent<{}, State> {
   }
 
   handleNextClick = () => {
-    this.setState(
+    this.setState({
+      currentStep: Math.min(
+        this.state.currentStep + 1,
+        HOMEPAGE_NAVIGATION_STEPS_ARDUINO.length
+      ),
+    })
+    event(
+      'firstMile.arduinoWizard.next.clicked',
+      {},
       {
-        currentStep: Math.min(
-          this.state.currentStep + 1,
-          HOMEPAGE_NAVIGATION_STEPS_ARDUINO.length
+        clickedButtonAtStep: normalizeEventName(
+          HOMEPAGE_NAVIGATION_STEPS_ARDUINO[this.state.currentStep - 1].name
         ),
-      },
-      () => {
-        event(
-          'firstMile.arduinoWizard.next.clicked',
-          {},
-          {
-            clickedButtonAtStep: normalizeEventName(
-              HOMEPAGE_NAVIGATION_STEPS_ARDUINO[this.state.currentStep - 1].name
-            ),
-            currentStep: normalizeEventName(
-              HOMEPAGE_NAVIGATION_STEPS_ARDUINO[this.state.currentStep].name
-            ),
-          }
-        )
+        currentStep: normalizeEventName(
+          HOMEPAGE_NAVIGATION_STEPS_ARDUINO[this.state.currentStep].name
+        ),
       }
     )
   }
 
   handlePreviousClick = () => {
-    this.setState(
-      {currentStep: Math.max(this.state.currentStep - 1, 1)},
-      () => {
-        event(
-          'firstMile.arduinoWizard.previous.clicked',
-          {},
-          {
-            clickedButtonAtStep: normalizeEventName(
-              HOMEPAGE_NAVIGATION_STEPS_ARDUINO[this.state.currentStep - 1].name
-            ),
-            currentStep: normalizeEventName(
-              HOMEPAGE_NAVIGATION_STEPS_ARDUINO[this.state.currentStep].name
-            ),
-          }
-        )
+    this.setState({currentStep: Math.max(this.state.currentStep - 1, 1)})
+    event(
+      'firstMile.arduinoWizard.previous.clicked',
+      {},
+      {
+        clickedButtonAtStep: normalizeEventName(
+          HOMEPAGE_NAVIGATION_STEPS_ARDUINO[this.state.currentStep - 1].name
+        ),
+        currentStep: normalizeEventName(
+          HOMEPAGE_NAVIGATION_STEPS_ARDUINO[this.state.currentStep].name
+        ),
       }
     )
   }
@@ -225,7 +217,7 @@ export class ArduinoWizard extends PureComponent<{}, State> {
                   size={ComponentSize.Large}
                   color={ComponentColor.Primary}
                   status={
-                    this.state.currentStep < 7
+                    this.state.currentStep < 8
                       ? ComponentStatus.Default
                       : ComponentStatus.Disabled
                   }

--- a/src/homepageExperience/containers/ArduinoWizard.tsx
+++ b/src/homepageExperience/containers/ArduinoWizard.tsx
@@ -64,12 +64,6 @@ export class ArduinoWizard extends PureComponent<{}, State> {
   }
 
   handleNextClick = () => {
-    this.setState({
-      currentStep: Math.min(
-        this.state.currentStep + 1,
-        HOMEPAGE_NAVIGATION_STEPS_ARDUINO.length
-      ),
-    })
     event(
       'firstMile.arduinoWizard.next.clicked',
       {},
@@ -82,10 +76,16 @@ export class ArduinoWizard extends PureComponent<{}, State> {
         ),
       }
     )
+
+    this.setState({
+      currentStep: Math.min(
+        this.state.currentStep + 1,
+        HOMEPAGE_NAVIGATION_STEPS_ARDUINO.length
+      ),
+    })
   }
 
   handlePreviousClick = () => {
-    this.setState({currentStep: Math.max(this.state.currentStep - 1, 1)})
     event(
       'firstMile.arduinoWizard.previous.clicked',
       {},
@@ -98,6 +98,8 @@ export class ArduinoWizard extends PureComponent<{}, State> {
         ),
       }
     )
+
+    this.setState({currentStep: Math.max(this.state.currentStep - 1, 1)})
   }
 
   handleNavClick = (clickedStep: number) => {

--- a/src/homepageExperience/containers/ArduinoWizard.tsx
+++ b/src/homepageExperience/containers/ArduinoWizard.tsx
@@ -64,40 +64,48 @@ export class ArduinoWizard extends PureComponent<{}, State> {
   }
 
   handleNextClick = () => {
-    event(
-      'firstMile.arduinoWizard.next.clicked',
-      {},
+    this.setState(
       {
-        clickedButtonAtStep: normalizeEventName(
-          HOMEPAGE_NAVIGATION_STEPS_ARDUINO[this.state.currentStep - 1].name
+        currentStep: Math.min(
+          this.state.currentStep + 1,
+          HOMEPAGE_NAVIGATION_STEPS_ARDUINO.length
         ),
-        currentStep: normalizeEventName(
-          HOMEPAGE_NAVIGATION_STEPS_ARDUINO[this.state.currentStep].name
-        ),
+      },
+      () => {
+        event(
+          'firstMile.arduinoWizard.next.clicked',
+          {},
+          {
+            clickedButtonAtStep: normalizeEventName(
+              HOMEPAGE_NAVIGATION_STEPS_ARDUINO[this.state.currentStep - 2].name
+            ),
+            currentStep: normalizeEventName(
+              HOMEPAGE_NAVIGATION_STEPS_ARDUINO[this.state.currentStep - 1].name
+            ),
+          }
+        )
       }
     )
-    this.setState({
-      currentStep: Math.min(
-        this.state.currentStep + 1,
-        HOMEPAGE_NAVIGATION_STEPS_ARDUINO.length
-      ),
-    })
   }
 
   handlePreviousClick = () => {
-    event(
-      'firstMile.arduinoWizard.previous.clicked',
-      {},
-      {
-        clickedButtonAtStep: normalizeEventName(
-          HOMEPAGE_NAVIGATION_STEPS_ARDUINO[this.state.currentStep - 1].name
-        ),
-        currentStep: normalizeEventName(
-          HOMEPAGE_NAVIGATION_STEPS_ARDUINO[this.state.currentStep - 2].name
-        ),
+    this.setState(
+      {currentStep: Math.max(this.state.currentStep - 1, 1)},
+      () => {
+        event(
+          'firstMile.arduinoWizard.previous.clicked',
+          {},
+          {
+            clickedButtonAtStep: normalizeEventName(
+              HOMEPAGE_NAVIGATION_STEPS_ARDUINO[this.state.currentStep].name
+            ),
+            currentStep: normalizeEventName(
+              HOMEPAGE_NAVIGATION_STEPS_ARDUINO[this.state.currentStep - 1].name
+            ),
+          }
+        )
       }
     )
-    this.setState({currentStep: Math.max(this.state.currentStep - 1, 1)})
   }
 
   handleNavClick = (clickedStep: number) => {

--- a/src/homepageExperience/containers/CliWizard.tsx
+++ b/src/homepageExperience/containers/CliWizard.tsx
@@ -63,38 +63,38 @@ export class CliWizard extends PureComponent<{}, State> {
   }
 
   handleNextClick = () => {
-    this.setState(
+    this.setState({
+      currentStep: Math.min(
+        this.state.currentStep + 1,
+        HOMEPAGE_NAVIGATION_STEPS_SHORT.length
+      ),
+    })
+    event(
+      'firstMile.cliWizard.next.clicked',
+      {},
       {
-        currentStep: Math.min(
-          this.state.currentStep + 1,
-          HOMEPAGE_NAVIGATION_STEPS_SHORT.length
+        clickedButtonAtStep: normalizeEventName(
+          HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep - 1].name
         ),
-      },
-      () => {
-        event(
-          'firstMile.cliWizard.next.clicked',
-          {},
-          {
-            clickedButtonAtStep: this.state.currentStep - 1,
-            currentStep: this.state.currentStep,
-          }
-        )
+        currentStep: normalizeEventName(
+          HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep].name
+        ),
       }
     )
   }
 
   handlePreviousClick = () => {
-    this.setState(
-      {currentStep: Math.max(this.state.currentStep - 1, 1)},
-      () => {
-        event(
-          'firstMile.cliWizard.previous.clicked',
-          {},
-          {
-            clickedButtonAtStep: this.state.currentStep + 1,
-            currentStep: this.state.currentStep,
-          }
-        )
+    this.setState({currentStep: Math.max(this.state.currentStep - 1, 1)})
+    event(
+      'firstMile.cliWizard.previous.clicked',
+      {},
+      {
+        clickedButtonAtStep: normalizeEventName(
+          HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep - 1].name
+        ),
+        currentStep: normalizeEventName(
+          HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep - 2].name
+        ),
       }
     )
   }

--- a/src/homepageExperience/containers/CliWizard.tsx
+++ b/src/homepageExperience/containers/CliWizard.tsx
@@ -63,6 +63,13 @@ export class CliWizard extends PureComponent<{}, State> {
   }
 
   handleNextClick = () => {
+    this.setState({
+      currentStep: Math.min(
+        this.state.currentStep + 1,
+        HOMEPAGE_NAVIGATION_STEPS_SHORT.length
+      ),
+    })
+
     event(
       'firstMile.cliWizard.next.clicked',
       {},
@@ -75,28 +82,22 @@ export class CliWizard extends PureComponent<{}, State> {
         ),
       }
     )
-    this.setState({
-      currentStep: Math.min(
-        this.state.currentStep + 1,
-        HOMEPAGE_NAVIGATION_STEPS_SHORT.length
-      ),
-    })
   }
 
   handlePreviousClick = () => {
+    this.setState({currentStep: Math.max(this.state.currentStep - 1, 1)})
     event(
       'firstMile.cliWizard.previous.clicked',
       {},
       {
         clickedButtonAtStep: normalizeEventName(
-          HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep - 1].name
+          HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep + 1].name
         ),
         currentStep: normalizeEventName(
-          HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep - 2].name
+          HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep].name
         ),
       }
     )
-    this.setState({currentStep: Math.max(this.state.currentStep - 1, 1)})
   }
 
   handleNavClick = (clickedStep: number) => {
@@ -213,8 +214,7 @@ export class CliWizard extends PureComponent<{}, State> {
                   size={ComponentSize.Large}
                   color={ComponentColor.Primary}
                   status={
-                    this.state.currentStep <
-                    HOMEPAGE_NAVIGATION_STEPS_SHORT.length
+                    this.state.currentStep < 7
                       ? ComponentStatus.Default
                       : ComponentStatus.Disabled
                   }

--- a/src/homepageExperience/containers/CliWizard.tsx
+++ b/src/homepageExperience/containers/CliWizard.tsx
@@ -63,42 +63,40 @@ export class CliWizard extends PureComponent<{}, State> {
   }
 
   handleNextClick = () => {
-    event(
-      'firstMile.cliWizard.next.clicked',
-      {},
+    this.setState(
       {
-        clickedButtonAtStep: normalizeEventName(
-          HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep - 1].name
+        currentStep: Math.min(
+          this.state.currentStep + 1,
+          HOMEPAGE_NAVIGATION_STEPS_SHORT.length
         ),
-        currentStep: normalizeEventName(
-          HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep].name
-        ),
+      },
+      () => {
+        event(
+          'firstMile.cliWizard.next.clicked',
+          {},
+          {
+            clickedButtonAtStep: this.state.currentStep - 1,
+            currentStep: this.state.currentStep,
+          }
+        )
       }
     )
-
-    this.setState({
-      currentStep: Math.min(
-        this.state.currentStep + 1,
-        HOMEPAGE_NAVIGATION_STEPS_SHORT.length
-      ),
-    })
   }
 
   handlePreviousClick = () => {
-    event(
-      'firstMile.cliWizard.previous.clicked',
-      {},
-      {
-        clickedButtonAtStep: normalizeEventName(
-          HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep + 1].name
-        ),
-        currentStep: normalizeEventName(
-          HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep].name
-        ),
+    this.setState(
+      {currentStep: Math.max(this.state.currentStep - 1, 1)},
+      () => {
+        event(
+          'firstMile.cliWizard.previous.clicked',
+          {},
+          {
+            clickedButtonAtStep: this.state.currentStep + 1,
+            currentStep: this.state.currentStep,
+          }
+        )
       }
     )
-    
-    this.setState({currentStep: Math.max(this.state.currentStep - 1, 1)})
   }
 
   handleNavClick = (clickedStep: number) => {

--- a/src/homepageExperience/containers/CliWizard.tsx
+++ b/src/homepageExperience/containers/CliWizard.tsx
@@ -63,13 +63,6 @@ export class CliWizard extends PureComponent<{}, State> {
   }
 
   handleNextClick = () => {
-    this.setState({
-      currentStep: Math.min(
-        this.state.currentStep + 1,
-        HOMEPAGE_NAVIGATION_STEPS_SHORT.length
-      ),
-    })
-
     event(
       'firstMile.cliWizard.next.clicked',
       {},
@@ -82,10 +75,16 @@ export class CliWizard extends PureComponent<{}, State> {
         ),
       }
     )
+
+    this.setState({
+      currentStep: Math.min(
+        this.state.currentStep + 1,
+        HOMEPAGE_NAVIGATION_STEPS_SHORT.length
+      ),
+    })
   }
 
   handlePreviousClick = () => {
-    this.setState({currentStep: Math.max(this.state.currentStep - 1, 1)})
     event(
       'firstMile.cliWizard.previous.clicked',
       {},
@@ -98,6 +97,8 @@ export class CliWizard extends PureComponent<{}, State> {
         ),
       }
     )
+    
+    this.setState({currentStep: Math.max(this.state.currentStep - 1, 1)})
   }
 
   handleNavClick = (clickedStep: number) => {

--- a/src/homepageExperience/containers/CliWizard.tsx
+++ b/src/homepageExperience/containers/CliWizard.tsx
@@ -214,7 +214,8 @@ export class CliWizard extends PureComponent<{}, State> {
                   size={ComponentSize.Large}
                   color={ComponentColor.Primary}
                   status={
-                    this.state.currentStep < 7
+                    this.state.currentStep <
+                    HOMEPAGE_NAVIGATION_STEPS_SHORT.length
                       ? ComponentStatus.Default
                       : ComponentStatus.Disabled
                   }

--- a/src/homepageExperience/containers/CliWizard.tsx
+++ b/src/homepageExperience/containers/CliWizard.tsx
@@ -63,12 +63,6 @@ export class CliWizard extends PureComponent<{}, State> {
   }
 
   handleNextClick = () => {
-    this.setState({
-      currentStep: Math.min(
-        this.state.currentStep + 1,
-        HOMEPAGE_NAVIGATION_STEPS_SHORT.length
-      ),
-    })
     event(
       'firstMile.cliWizard.next.clicked',
       {},
@@ -81,10 +75,15 @@ export class CliWizard extends PureComponent<{}, State> {
         ),
       }
     )
+    this.setState({
+      currentStep: Math.min(
+        this.state.currentStep + 1,
+        HOMEPAGE_NAVIGATION_STEPS_SHORT.length
+      ),
+    })
   }
 
   handlePreviousClick = () => {
-    this.setState({currentStep: Math.max(this.state.currentStep - 1, 1)})
     event(
       'firstMile.cliWizard.previous.clicked',
       {},
@@ -97,6 +96,7 @@ export class CliWizard extends PureComponent<{}, State> {
         ),
       }
     )
+    this.setState({currentStep: Math.max(this.state.currentStep - 1, 1)})
   }
 
   handleNavClick = (clickedStep: number) => {


### PR DESCRIPTION
Closes #5449

Allowing the next button to be used in the aggregate query page.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
