### PR TITLE
feat: use DurationLiteral or DateTimeLiteral depending on the type of timeRange

### DIFF
--- a/src/variables/selectors/index.tsx
+++ b/src/variables/selectors/index.tsx
@@ -140,13 +140,14 @@ export const getAllVariables = (
 export const getAllVariablesForZoomRequery = (
   state: AppState,
   domain: number[],
+  timeRangeType: string,
   contextID?: string
 ): Variable[] => {
   const vars = getUserVariableNames(state, contextID || currentContext(state))
     .concat([TIME_RANGE_START, TIME_RANGE_STOP])
     .map(variableID => {
       if (domain?.length) {
-        return getVariableForZoomRequery(variableID, domain)
+        return getVariableForZoomRequery(variableID, domain, timeRangeType)
       }
       return getVariable(state, variableID)
     })

--- a/src/visualization/utils/useVisDomainSettings.ts
+++ b/src/visualization/utils/useVisDomainSettings.ts
@@ -7,15 +7,16 @@ import {isEqual} from 'lodash'
 // API
 import {runQuery, RunQueryResult} from 'src/shared/apis/query'
 
+// Selectors
+import {getOrg} from 'src/organizations/selectors'
+import {getStartTime, getEndTime} from 'src/timeMachine/selectors/index'
+import {getAllVariablesForZoomRequery} from 'src/variables/selectors'
+
 // Utils
 import {useOneWayState} from 'src/shared/utils/useOneWayState'
 import {extent} from 'src/shared/utils/vis'
-import {getStartTime, getEndTime} from 'src/timeMachine/selectors/index'
-import {getOrg} from 'src/organizations/selectors'
-import {getAllVariablesForZoomRequery} from 'src/variables/selectors'
 import {buildUsedVarsOption} from 'src/variables/utils/buildVarsOption'
 import {event} from 'src/cloud/utils/reporting'
-
 import {
   getWindowPeriodFromVariables,
   getWindowVarsFromVariables,
@@ -26,6 +27,7 @@ import {
 // Types
 import {AppState, InternalFromFluxResult, TimeRange} from 'src/types'
 import {RemoteDataState} from '@influxdata/clockface'
+
 /*
   This hook helps map the domain setting stored for line graph to the
   appropriate settings on a @influxdata/giraffe `Config` object.
@@ -167,6 +169,7 @@ export const useZoomRequeryXDomainSettings = (args: ZoomRequeryArgs) => {
     timeRange = null,
   } = args
 
+  const {type: timeRangeType} = timeRange ? timeRange : {type: 'duration'}
   const [selectedTimeRange, setSelectedTimeRange] = useState(timeRange)
   const initialDomain = useMemo(() => {
     if (storedDomain) {
@@ -197,7 +200,7 @@ export const useZoomRequeryXDomainSettings = (args: ZoomRequeryArgs) => {
   const [domain, setDomain] = useState(initialDomain)
 
   const getAllVariablesWithTimeDomain = (state: AppState) =>
-    getAllVariablesForZoomRequery(state, timeRange ? domain : [])
+    getAllVariablesForZoomRequery(state, timeRange ? domain : [], timeRangeType)
   const orgId = useSelector(getOrg)?.id
   const variables = useSelector(getAllVariablesWithTimeDomain)
 
@@ -297,6 +300,7 @@ export const useZoomRequeryYDomainSettings = (args: ZoomRequeryArgs) => {
     timeRange = null,
   } = args
 
+  const {type: timeRangeType} = timeRange ? timeRange : {type: 'duration'}
   const [selectedTimeRange, setSelectedTimeRange] = useState(timeRange)
   const initialDomain = useMemo(() => {
     if (
@@ -332,7 +336,7 @@ export const useZoomRequeryYDomainSettings = (args: ZoomRequeryArgs) => {
   const [domain, setDomain] = useState(initialDomain)
 
   const getAllVariablesWithTimeDomain = (state: AppState) =>
-    getAllVariablesForZoomRequery(state, timeRange ? domain : [])
+    getAllVariablesForZoomRequery(state, timeRange ? domain : [], timeRangeType)
   const orgId = useSelector(getOrg)?.id
   const variables = useSelector(getAllVariablesWithTimeDomain)
 


### PR DESCRIPTION
Closes #5354  

- Change the `timeRangeStart` variable to a `DurationLiteral` if the type of timeRange selected by the user is a duration
- Handle the case of `Infinity` when normalizing


Here is a video showing the user selecting both a duration (Last 1hr) and a custom time range successfully using the adaptive zoom feature


https://user-images.githubusercontent.com/10736577/185463821-f7eec55c-a019-4877-b870-211df37744d5.mp4


