### PR TITLE
feat: FirstMile tiles "view more"

### DIFF
--- a/src/homepageExperience/containers/HomepageContainer.tsx
+++ b/src/homepageExperience/containers/HomepageContainer.tsx
@@ -1,5 +1,5 @@
-import React, {FC, useEffect} from 'react'
-import {useSelector, useDispatch} from 'react-redux'
+import React, {CSSProperties, FC, useEffect} from 'react'
+import {useDispatch, useSelector} from 'react-redux'
 import {Link} from 'react-router-dom'
 
 import {
@@ -14,6 +14,7 @@ import {
   Icon,
   IconFont,
   InfluxColors,
+  JustifyContent,
   Page,
   ResourceCard,
   SquareGrid,
@@ -64,6 +65,11 @@ export const HomepageContainer: FC = () => {
   const cardStyle = {minWidth: '200px'}
   const linkStyle = {color: InfluxColors.Grey75}
   const moreStyle = {height: '100%', ...linkStyle}
+  // checks for
+  const inlineViewMoreStyle = {
+    marginTop: '8px',
+    visibility: isFlagEnabled('onboardArduino') ? 'visible' : 'hidden',
+  } as CSSProperties
 
   const squareGridCardSize = '200px'
 
@@ -188,23 +194,34 @@ export const HomepageContainer: FC = () => {
                         </Link>
                       </ResourceCard>
                     )}
-                    <ResourceCard style={cardStyle}>
-                      <Link
-                        to={loadDataSourcesLink}
-                        style={moreStyle}
-                        onClick={logMoreButtonClick}
-                      >
-                        <div className="homepage-wizard-language-tile">
-                          <span>
-                            <h5>
-                              MORE <Icon glyph={IconFont.ArrowRight_New} />
-                            </h5>
-                          </span>
-                        </div>
-                      </Link>
-                    </ResourceCard>
+                    {!isFlagEnabled('onboardArduino') && (
+                      <ResourceCard style={cardStyle}>
+                        <Link
+                          to={loadDataSourcesLink}
+                          style={moreStyle}
+                          onClick={logMoreButtonClick}
+                        >
+                          <div className="homepage-wizard-language-tile">
+                            <span>
+                              <h5>
+                                MORE <Icon glyph={IconFont.ArrowRight_New} />
+                              </h5>
+                            </span>
+                          </div>
+                        </Link>
+                      </ResourceCard>
+                    )}
                   </SquareGrid>
-                  <hr style={{marginTop: '32px'}} />
+                  <FlexBox justifyContent={JustifyContent.FlexStart}>
+                    <Link
+                      to={loadDataSourcesLink}
+                      onClick={logMoreButtonClick}
+                      style={inlineViewMoreStyle}
+                    >
+                      + View more
+                    </Link>
+                  </FlexBox>
+                  <hr style={{marginTop: '8px'}} />
                   <Link
                     to={cliPageLink}
                     style={linkStyle}

--- a/src/homepageExperience/containers/HomepageContainer.tsx
+++ b/src/homepageExperience/containers/HomepageContainer.tsx
@@ -218,7 +218,7 @@ export const HomepageContainer: FC = () => {
                       onClick={logMoreButtonClick}
                       style={inlineViewMoreStyle}
                     >
-                      + View more
+                      View more
                     </Link>
                   </FlexBox>
                   <hr style={{marginTop: '8px'}} />


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/5440

I put a flag check because we want the View More option when we publish the Arduino changes. (i.e Turn on the onboardArduino flag.) without it, there would be a blank space instead of the MORE tile and looks weird.

https://user-images.githubusercontent.com/18511823/185492586-1ff24b8d-fa3a-4caa-ab9e-d6c4717097c9.mov



<!-- Describe your proposed changes here. -->
<!-- Including screenshots or visuals is very helpful - a picture is worth a thousand words. -->

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
