### PR TITLE
feat(firstmile): tabbed page for arduino prepare IDE page

### DIFF
--- a/src/homepageExperience/components/steps/arduino/PrepareIde.tsx
+++ b/src/homepageExperience/components/steps/arduino/PrepareIde.tsx
@@ -1,5 +1,11 @@
 // Libraries
-import React from 'react'
+import React, {useState} from 'react'
+import {
+  Button,
+  ButtonGroup,
+  ComponentColor,
+  Orientation,
+} from '@influxdata/clockface'
 
 const listStyle = {
   fontSize: '16px',
@@ -7,6 +13,10 @@ const listStyle = {
 }
 
 export const PrepareIde = () => {
+  type CurrentBoardSelection = 'ESP8266' | 'ESP32'
+  const [currentSelection, setCurrentSelection] = useState<
+    CurrentBoardSelection
+  >('ESP8266')
   return (
     <>
       <h1>Prepare Arduino IDE</h1>
@@ -18,36 +28,68 @@ export const PrepareIde = () => {
         If you haven't already, add the board you wish to use (ESP8266 or ESP32)
         to the Arduino IDE by following these steps:
       </p>
-      <p>
-        <b>For ESP8266:</b>
-      </p>
-      <ol style={listStyle}>
-        <li>Open the Arduino Preferences (Arduino &rarr; Preferences) </li>
-        <li>
-          Look for "Additional Boards Manager URLs" input box and paste
-          "http://arduino.esp8266.com/stable/package_esp8266com_index.json" in
-          it.
-        </li>
-        <li>Click OK.</li>
-        <li>Then under Tools &rarr; Boards: , click on Boards Manager.</li>
-        <li>Search for ESP8266 in the boards.</li>
-        <li>Install the ESP8266 board by ESP8266 Community.</li>
-      </ol>
-      <p>
-        <b>For ESP32:</b>
-      </p>
-      <ol style={listStyle}>
-        <li>Open the Arduino Preferences (Arduino &rarr; Preferences) </li>
-        <li>
-          Look for "Additional Boards Manager URLs" input box and paste
-          "https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json"
-          in it.
-        </li>
-        <li>Click OK.</li>
-        <li>Then under Tools &rarr; Boards: , click on Boards Manager.</li>
-        <li>Search for ESP32 in the boards.</li>
-        <li>Install the ESP32 board by ESP32 Community.</li>
-      </ol>
+      <ButtonGroup orientation={Orientation.Horizontal}>
+        <Button
+          text="ESP8266"
+          color={
+            currentSelection === 'ESP8266'
+              ? ComponentColor.Primary
+              : ComponentColor.Default
+          }
+          onClick={() => {
+            setCurrentSelection('ESP8266')
+          }}
+        />
+        <Button
+          text="ESP32"
+          color={
+            currentSelection === 'ESP32'
+              ? ComponentColor.Primary
+              : ComponentColor.Default
+          }
+          onClick={() => {
+            setCurrentSelection('ESP32')
+          }}
+        />
+      </ButtonGroup>
+      {currentSelection === 'ESP8266' && (
+        <>
+          <p>
+            <b>For ESP8266:</b>
+          </p>
+          <ol style={listStyle}>
+            <li>Open the Arduino Preferences (Arduino &rarr; Preferences) </li>
+            <li>
+              Look for "Additional Boards Manager URLs" input box and paste
+              "http://arduino.esp8266.com/stable/package_esp8266com_index.json"
+              in it.
+            </li>
+            <li>Click OK.</li>
+            <li>Then under Tools &rarr; Boards: , click on Boards Manager.</li>
+            <li>Search for ESP8266 in the boards.</li>
+            <li>Install the ESP8266 board by ESP8266 Community.</li>
+          </ol>
+        </>
+      )}
+      {currentSelection === 'ESP32' && (
+        <>
+          <p>
+            <b>For ESP32:</b>
+          </p>
+          <ol style={listStyle}>
+            <li>Open the Arduino Preferences (Arduino &rarr; Preferences) </li>
+            <li>
+              Look for "Additional Boards Manager URLs" input box and paste
+              "https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json"
+              in it.
+            </li>
+            <li>Click OK.</li>
+            <li>Then under Tools &rarr; Boards: , click on Boards Manager.</li>
+            <li>Search for ESP32 in the boards.</li>
+            <li>Install the ESP32 board by ESP32 Community.</li>
+          </ol>
+        </>
+      )}
     </>
   )
 }


### PR DESCRIPTION
Closes [#5442](https://github.com/influxdata/ui/issues/5442)

Instead of showing all the info, we show the board they want to see, ESP8266 or ESP32.

<img width="1469" alt="Screen Shot 2022-08-18 at 2 17 41 PM" src="https://user-images.githubusercontent.com/18511823/185496957-5af9dd17-1406-4bce-bd0d-7dce48bf7bb5.png">

<img width="1536" alt="Screen Shot 2022-08-18 at 2 17 46 PM" src="https://user-images.githubusercontent.com/18511823/185496954-b11b9c30-85a4-4efc-967a-b14586abae83.png">


<!-- Including screenshots or visuals is very helpful - a picture is worth a thousand words. -->

### Checklist

Authors and Reviewer(s), please verify the following:

- [ ] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [ ] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
