### PR TITLE
fix(firstMile): no sample app or boilerplate app for arduino onboarding

### DIFF
--- a/src/homepageExperience/components/steps/Finish.tsx
+++ b/src/homepageExperience/components/steps/Finish.tsx
@@ -151,7 +151,8 @@ export const Finish = (props: OwnProps) => {
             </ResourceCard>
           )}
         </FlexBox>
-        {props.wizardEventName !== 'cliWizard' ? (
+        {props.wizardEventName !== 'cliWizard' &&
+        props.wizardEventName !== 'arduinoWizard' ? (
           <SampleAppCard
             handleNextStepEvent={handleNextStepEvent}
             wizardEventName={props.wizardEventName}


### PR DESCRIPTION
Closes [#5443](https://github.com/influxdata/ui/issues/5443)

We don't want to show the sample app and the boilerplate for MVP of arduino onboarding. We hide it.

https://user-images.githubusercontent.com/18511823/185498454-33dffb7e-2044-436e-ac80-7d9694fc454d.mov


<!-- Describe your proposed changes here. -->
<!-- Including screenshots or visuals is very helpful - a picture is worth a thousand words. -->

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
