### PR TITLE
fix(rudderstack): move identify call later where org.id will exist

### DIFF
--- a/src/me/actions/thunks/index.ts
+++ b/src/me/actions/thunks/index.ts
@@ -1,6 +1,5 @@
 // Libraries
 import HoneyBadger from 'honeybadger-js'
-import {identify} from 'rudder-sdk-js'
 import {Dispatch} from 'react'
 
 // Functions making API calls
@@ -10,8 +9,6 @@ import {getAccounts} from 'src/client/unityRoutes'
 // Utils
 import {gaEvent, updateReportingContext} from 'src/cloud/utils/reporting'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
-import {CLOUD} from 'src/shared/constants'
-import {getOrg} from 'src/organizations/selectors'
 
 // Actions
 import {
@@ -25,14 +22,11 @@ import {
 import {MeState} from 'src/me/reducers'
 
 // Types
-import {RemoteDataState, GetState} from 'src/types'
+import {RemoteDataState} from 'src/types'
 import {Actions} from 'src/me/actions/creators'
 import {fetchQuartzMe} from 'src/identity/apis/auth'
 
-export const getIdpeMeThunk = () => async (
-  dispatch: Dispatch<Actions>,
-  getState: GetState
-) => {
+export const getIdpeMeThunk = () => async (dispatch: Dispatch<Actions>) => {
   try {
     let user
 
@@ -61,19 +55,9 @@ export const getIdpeMeThunk = () => async (
       },
     })
 
-    updateReportingContext({
-      userID: user.id,
-    })
-
     HoneyBadger.setContext({
       user_id: user.id,
     })
-
-    if (CLOUD && isFlagEnabled('rudderstackReporting')) {
-      const state = getState()
-      const org = getOrg(state)
-      identify(user.id, {email: user.name, orgID: org.id})
-    }
 
     dispatch(setMe(user as MeState))
   } catch (error) {

--- a/src/shared/containers/GetOrganizations.tsx
+++ b/src/shared/containers/GetOrganizations.tsx
@@ -2,6 +2,7 @@
 import React, {useEffect, FunctionComponent, lazy, Suspense} from 'react'
 import {useDispatch, useSelector} from 'react-redux'
 import {Route, Switch} from 'react-router-dom'
+import {identify} from 'rudder-sdk-js'
 
 // Components
 import PageSpinner from 'src/perf/components/PageSpinner'
@@ -76,6 +77,12 @@ const GetOrganizations: FunctionComponent = () => {
       dispatch(getOrganizations())
     }
   }, [dispatch, status]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (CLOUD && org?.id && isFlagEnabled('rudderstackReporting')) {
+      identify(meId, {email, orgID: org.id})
+    }
+  }, [org?.id, identify])
 
   useEffect(() => {
     if (


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/5472

Rudderstack calls `identify` with user id, user email address, and org id. The call to `identify` was using an `org` variable that didn't exist under certain circumstances, and was crashing the application. Where the call is in the flow of the application depends on `org.id` existing in local state. If it doesn't it casues the black screen shown in the referenced issue.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- ~[ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~
- ~[ ] Feature flagged, if applicable~
