### PR TITLE
test: fix labels test to limit input name to 30 characters

### DIFF
--- a/cypress/e2e/shared/labels.test.ts
+++ b/cypress/e2e/shared/labels.test.ts
@@ -25,7 +25,8 @@ describe('labels', () => {
 
   it('can create a label', () => {
     const newLabelName = 'Substantia'
-    const labelNameWith43Characters = 'Substantia Substantia Substantia Substantia'
+    const labelNameWith43Characters =
+      'Substantia Substantia Substantia Substantia'
 
     const newLabelDescription =
       '(\u03943) quod in se est et per se concipitur hoc est id cujus conceptus non indiget conceptu alterius rei a quo formari debeat. '
@@ -60,10 +61,12 @@ describe('labels', () => {
     // Try to save without name (required field) button should be disabled
     cy.getByTestID('create-label-form--submit').should('be.disabled')
 
-
     // check that input limits name to 30 characters
     cy.getByTestID('create-label-form--name').type(labelNameWith43Characters)
-    cy.getByTestID('create-label-form--name').should('not.have.value', labelNameWith43Characters)
+    cy.getByTestID('create-label-form--name').should(
+      'not.have.value',
+      labelNameWith43Characters
+    )
     cy.getByTestID('create-label-form--name').clear()
 
     // enter name

--- a/cypress/e2e/shared/labels.test.ts
+++ b/cypress/e2e/shared/labels.test.ts
@@ -149,6 +149,88 @@ describe('labels', () => {
       .should('contain', hex2BgColor(newLabelColor))
   })
 
+  it.only('fails when creating a label that exceeds name length more than 30 bytes', () => {
+    const newLabelName = 'Substantia: adding more than 30 bytes (48 bytes)'
+    const newLabelDescription =
+      '(\u03943) quod in se est et per se concipitur hoc est id cujus conceptus non indiget conceptu alterius rei a quo formari debeat. '
+    const newLabelColor = '#D4AF37'
+
+    cy.getByTestID('table-row').should('have.length', 0)
+
+    // open create - first button
+    cy.getByTestID('button-create-initial').click()
+
+    cy.getByTestID('overlay--container').within(() => {
+      cy.getByTestID('overlay--header')
+        .contains('Create Label')
+        .should('be.visible')
+      // dismiss
+      cy.getByTestID('overlay--header')
+        .children('button')
+        .click()
+    })
+
+    // open create
+    cy.getByTestID('button-create-initial').click()
+
+    // Try to save without name (required field) button should be disabled
+    cy.getByTestID('create-label-form--submit').should('be.disabled')
+
+    // enter name
+    cy.getByTestID('create-label-form--name').type(newLabelName)
+    // enter description
+    cy.getByTestID('create-label-form--description').type(newLabelDescription)
+    // select color
+    cy.getByTestID('color-picker--input')
+      .invoke('attr', 'value')
+      .should('contain', '#326BBA')
+    cy.getByTestID('color-picker--swatch').should('have.length', 50)
+    cy.getByTestID('color-picker--swatch')
+      .eq(23)
+      .trigger('mouseover')
+    cy.getByTestID('color-picker--swatch')
+      .eq(23)
+      .invoke('attr', 'title')
+      .should('contain', 'Honeydew')
+    cy.getByTestID('color-picker--swatch')
+      .eq(33)
+      .trigger('mouseover')
+    cy.getByTestID('color-picker--swatch')
+      .eq(33)
+      .invoke('attr', 'title')
+      .should('contain', 'Thunder')
+    cy.getByTestID('color-picker--swatch')
+      .eq(33)
+      .click()
+    cy.getByTestID('color-picker--input')
+      .invoke('attr', 'value')
+      .should('equal', '#FFD255')
+    cy.getByTestID('color-picker--input')
+      .parent()
+      .parent()
+      .children('div.cf-color-preview')
+      .invoke('attr', 'style')
+      .should('equal', 'background-color: rgb(255, 210, 85);')
+
+
+    // enter color
+    cy.getByTestID('color-picker--input').clear()
+    cy.getByTestID('color-picker--input').type(newLabelColor)
+    cy.getByTestID('color-picker--input').invoke('val')
+    cy.getByTestID('color-picker--input')
+      .parent()
+      .parent()
+      .children('div.cf-color-preview')
+      .invoke('attr', 'style')
+      .should('equal', hex2BgColor(newLabelColor))
+
+    // save
+    cy.getByTestID('create-label-form--submit').click()
+
+    // verify name, descr, color
+
+  })
+
   describe('updating', () => {
     const oldLabelName = 'attributum (атрибут)'
     const oldLabelDescription =

--- a/cypress/e2e/shared/labels.test.ts
+++ b/cypress/e2e/shared/labels.test.ts
@@ -25,6 +25,8 @@ describe('labels', () => {
 
   it('can create a label', () => {
     const newLabelName = 'Substantia'
+    const labelNameWith43Characters = 'Substantia Substantia Substantia Substantia'
+
     const newLabelDescription =
       '(\u03943) quod in se est et per se concipitur hoc est id cujus conceptus non indiget conceptu alterius rei a quo formari debeat. '
     const newLabelColor = '#D4AF37'
@@ -57,6 +59,12 @@ describe('labels', () => {
 
     // Try to save without name (required field) button should be disabled
     cy.getByTestID('create-label-form--submit').should('be.disabled')
+
+
+    // check that input limits name to 30 characters
+    cy.getByTestID('create-label-form--name').type(labelNameWith43Characters)
+    cy.getByTestID('create-label-form--name').should('not.have.value', labelNameWith43Characters)
+    cy.getByTestID('create-label-form--name').clear()
 
     // enter name
     cy.getByTestID('create-label-form--name').type(newLabelName)
@@ -147,88 +155,6 @@ describe('labels', () => {
       .children('div.cf-label')
       .invoke('attr', 'style')
       .should('contain', hex2BgColor(newLabelColor))
-  })
-
-  it.only('fails when creating a label that exceeds name length more than 30 bytes', () => {
-    const newLabelName = 'Substantia: adding more than 30 bytes (48 bytes)'
-    const newLabelDescription =
-      '(\u03943) quod in se est et per se concipitur hoc est id cujus conceptus non indiget conceptu alterius rei a quo formari debeat. '
-    const newLabelColor = '#D4AF37'
-
-    cy.getByTestID('table-row').should('have.length', 0)
-
-    // open create - first button
-    cy.getByTestID('button-create-initial').click()
-
-    cy.getByTestID('overlay--container').within(() => {
-      cy.getByTestID('overlay--header')
-        .contains('Create Label')
-        .should('be.visible')
-      // dismiss
-      cy.getByTestID('overlay--header')
-        .children('button')
-        .click()
-    })
-
-    // open create
-    cy.getByTestID('button-create-initial').click()
-
-    // Try to save without name (required field) button should be disabled
-    cy.getByTestID('create-label-form--submit').should('be.disabled')
-
-    // enter name
-    cy.getByTestID('create-label-form--name').type(newLabelName)
-    // enter description
-    cy.getByTestID('create-label-form--description').type(newLabelDescription)
-    // select color
-    cy.getByTestID('color-picker--input')
-      .invoke('attr', 'value')
-      .should('contain', '#326BBA')
-    cy.getByTestID('color-picker--swatch').should('have.length', 50)
-    cy.getByTestID('color-picker--swatch')
-      .eq(23)
-      .trigger('mouseover')
-    cy.getByTestID('color-picker--swatch')
-      .eq(23)
-      .invoke('attr', 'title')
-      .should('contain', 'Honeydew')
-    cy.getByTestID('color-picker--swatch')
-      .eq(33)
-      .trigger('mouseover')
-    cy.getByTestID('color-picker--swatch')
-      .eq(33)
-      .invoke('attr', 'title')
-      .should('contain', 'Thunder')
-    cy.getByTestID('color-picker--swatch')
-      .eq(33)
-      .click()
-    cy.getByTestID('color-picker--input')
-      .invoke('attr', 'value')
-      .should('equal', '#FFD255')
-    cy.getByTestID('color-picker--input')
-      .parent()
-      .parent()
-      .children('div.cf-color-preview')
-      .invoke('attr', 'style')
-      .should('equal', 'background-color: rgb(255, 210, 85);')
-
-
-    // enter color
-    cy.getByTestID('color-picker--input').clear()
-    cy.getByTestID('color-picker--input').type(newLabelColor)
-    cy.getByTestID('color-picker--input').invoke('val')
-    cy.getByTestID('color-picker--input')
-      .parent()
-      .parent()
-      .children('div.cf-color-preview')
-      .invoke('attr', 'style')
-      .should('equal', hex2BgColor(newLabelColor))
-
-    // save
-    cy.getByTestID('create-label-form--submit').click()
-
-    // verify name, descr, color
-
   })
 
   describe('updating', () => {

--- a/cypress/e2e/shared/labels.test.ts
+++ b/cypress/e2e/shared/labels.test.ts
@@ -23,7 +23,7 @@ describe('labels', () => {
     return `background-color: rgb(${red}, ${green}, ${blue});`
   }
 
-  it.skip('can create a label', () => {
+  it('can create a label', () => {
     const newLabelName = 'Substantia'
     const newLabelDescription =
       '(\u03943) quod in se est et per se concipitur hoc est id cujus conceptus non indiget conceptu alterius rei a quo formari debeat. '

--- a/cypress/e2e/shared/labels.test.ts
+++ b/cypress/e2e/shared/labels.test.ts
@@ -24,7 +24,7 @@ describe('labels', () => {
   }
 
   it.skip('can create a label', () => {
-    const newLabelName = 'Substantia (サブスタンス)'
+    const newLabelName = 'Substantia'
     const newLabelDescription =
       '(\u03943) quod in se est et per se concipitur hoc est id cujus conceptus non indiget conceptu alterius rei a quo formari debeat. '
     const newLabelColor = '#D4AF37'

--- a/src/labels/components/LabelOverlayForm.tsx
+++ b/src/labels/components/LabelOverlayForm.tsx
@@ -23,8 +23,7 @@ import {
 } from '@influxdata/clockface'
 
 // Constants
-import {INPUT_ERROR_COLOR} from 'src/labels/constants'
-const MAX_LABEL_CHARS = 50
+import {INPUT_ERROR_COLOR, LABEL_NAME_MAX_LENGTH} from 'src/labels/constants'
 
 // Utils
 import {validateHexCode} from 'src/labels/utils/'
@@ -98,7 +97,7 @@ export default class LabelOverlayForm extends PureComponent<Props> {
                       value={name}
                       onChange={onInputChange}
                       status={status}
-                      maxLength={MAX_LABEL_CHARS}
+                      maxLength={LABEL_NAME_MAX_LENGTH}
                       testID="create-label-form--name"
                     />
                   )}

--- a/src/labels/constants/index.ts
+++ b/src/labels/constants/index.ts
@@ -210,3 +210,5 @@ export const PRESET_LABEL_COLORS: LabelColor[] = [
 ]
 
 export const INPUT_ERROR_COLOR = '#0F0E15'
+
+export const LABEL_NAME_MAX_LENGTH = 30

--- a/src/shared/components/inlineLabels/InlineLabelPopover.tsx
+++ b/src/shared/components/inlineLabels/InlineLabelPopover.tsx
@@ -12,6 +12,7 @@ import InlineLabelsList from 'src/shared/components/inlineLabels/InlineLabelsLis
 
 // Constants
 import {ADD_NEW_LABEL_ITEM_ID} from 'src/shared/components/inlineLabels/InlineLabelsEditor'
+import {LABEL_NAME_MAX_LENGTH} from 'src/labels/constants'
 
 // Types
 import {Label} from 'src/types'
@@ -84,7 +85,7 @@ export default class InlineLabelPopover extends PureComponent<Props> {
               autoFocus={true}
               onBlur={this.handleRefocusInput}
               testID="inline-labels--popover-field"
-              maxLength={30}
+              maxLength={LABEL_NAME_MAX_LENGTH}
             />
             <InlineLabelsList
               searchTerm={searchTerm}


### PR DESCRIPTION
Closes: https://github.com/influxdata/ui/issues/5482

1. Made a constant that contains the label name max length.
2. In the test, we reduce the label name length to less than 30 chars
3. Also adds a test case to make sure you cant type a name more than 30 chars.

<!-- Describe your proposed changes here. -->
<!-- Including screenshots or visuals is very helpful - a picture is worth a thousand words. -->

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
