### PR TITLE
fix(multi-org): Avatar Profile popover hide via visibility

### DIFF
--- a/src/identity/components/GlobalHeader/UserPopoverStyles.scss
+++ b/src/identity/components/GlobalHeader/UserPopoverStyles.scss
@@ -13,7 +13,7 @@
 }
 
 .user-popover {
-  opacity: 0;
+  visibility: hidden;
   position: absolute;
   top: 60px;
   right: 32px;
@@ -23,10 +23,10 @@
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
   backdrop-filter: blur(42px);
   border-radius: 2px;
-  transition: opacity 0.1s ease-in-out;
+  transition: visibility 0.1s ease-in-out;
 
   &.user-popover--open {
-    opacity: 100;
+    visibility: visible;
   }
 
   .user-popover-header-email {


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/5480

Using visibility instead of opacity fixes the issue where the hidden element is still clickable. 

<!-- Describe your proposed changes here. -->
<!-- Including screenshots or visuals is very helpful - a picture is worth a thousand words. -->

https://user-images.githubusercontent.com/18511823/185682604-9508e304-f13e-4664-a396-0b73647337c8.mov


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
