### PR TITLE
fix: centralize the getter for the query needed by adaptive zoom

### DIFF
--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -45,6 +45,7 @@ import {useAxisTicksGenerator} from 'src/visualization/utils/useAxisTicksGenerat
 import {getFormatter} from 'src/visualization/utils/getFormatter'
 import {useLegendOpacity} from 'src/visualization/utils/useLegendOpacity'
 import {useStaticLegend} from 'src/visualization/utils/useStaticLegend'
+import {useZoomQuery} from 'src/visualization/utils/useZoomQuery'
 import {
   useVisXDomainSettings,
   useVisYDomainSettings,
@@ -181,13 +182,14 @@ const XYPlot: FC<Props> = ({
     return useVisYDomainSettings(storedDomain, memoizedYColumnData)
   }
 
+  const zoomQuery = useZoomQuery(properties)
   if (isFlagEnabled('zoomRequery')) {
     useXDomainSettings = ({storedDomain, parsedResult, timeRange}) =>
       useZoomRequeryXDomainSettings({
         data: parsedResult.table.getColumn(xColumn, 'number'),
         parsedResult,
         preZoomResult,
-        query: properties?.queries?.[0]?.text ?? '',
+        query: zoomQuery,
         setPreZoomResult,
         setRequeryStatus,
         setResult: setResultState,
@@ -199,7 +201,7 @@ const XYPlot: FC<Props> = ({
         data: memoizedYColumnData,
         parsedResult,
         preZoomResult,
-        query: properties?.queries?.[0]?.text ?? '',
+        query: zoomQuery,
         setPreZoomResult,
         setRequeryStatus,
         setResult: setResultState,

--- a/src/visualization/utils/useZoomQuery.ts
+++ b/src/visualization/utils/useZoomQuery.ts
@@ -12,10 +12,6 @@ export const useZoomQuery = (properties): string => {
   const {getPanelQueries} = useContext(FlowQueryContext)
   const queryTextFromProperties = properties?.queries?.[0]?.text ?? ''
 
-  console.log('Pipe id:', id)
-  console.log('queryTextFromProperties:', queryTextFromProperties)
-  console.log('persistance query:', query)
-
   let zoomQuery = ''
 
   if (id) {

--- a/src/visualization/utils/useZoomQuery.ts
+++ b/src/visualization/utils/useZoomQuery.ts
@@ -1,0 +1,30 @@
+// Libraries
+import {useContext} from 'react'
+
+// Context
+import {PipeContext} from 'src/flows/context/pipe'
+import {FlowQueryContext} from 'src/flows/context/flow.query'
+import {PersistanceContext} from 'src/dataExplorer/context/persistance'
+
+export const useZoomQuery = (properties): string => {
+  const {query} = useContext(PersistanceContext)
+  const {id} = useContext(PipeContext)
+  const {getPanelQueries} = useContext(FlowQueryContext)
+  const queryTextFromProperties = properties?.queries?.[0]?.text ?? ''
+
+  console.log('Pipe id:', id)
+  console.log('queryTextFromProperties:', queryTextFromProperties)
+  console.log('persistance query:', query)
+
+  let zoomQuery = ''
+
+  if (id) {
+    zoomQuery = getPanelQueries(id)?.visual ?? ''
+  } else if (queryTextFromProperties) {
+    zoomQuery = queryTextFromProperties
+  } else {
+    zoomQuery = query
+  }
+
+  return zoomQuery
+}


### PR DESCRIPTION
Closes #5319  

- allows adaptive zoom to be used in Notebooks by getting the right context to access the query
- allows adaptive zoom to be used in New Data Explorer by getting the right context to access the query


Here are the 3 different primary ways to visualize a graph and the adaptive zoom working in all of them:


https://user-images.githubusercontent.com/10736577/185716360-d560f815-2ed9-4424-95a5-ed37081135f9.mp4

