### PR TITLE
chore: hide switch account button in old account page when multiOrg is enabled

### DIFF
--- a/src/accounts/AccountPage.tsx
+++ b/src/accounts/AccountPage.tsx
@@ -133,17 +133,19 @@ const AccountAboutPage: FC = () => {
   return (
     <AccountTabContainer activeTab="about">
       <>
-        {userAccounts && userAccounts.length >= 2 && (
-          <div>
-            <Button
-              text="Switch Account"
-              icon={IconFont.Switch_New}
-              onClick={showSwitchAccountDialog}
-              testID="user-account-switch-btn"
-            />
-            <hr style={dividerStyle} />
-          </div>
-        )}
+        {userAccounts &&
+          userAccounts.length >= 2 &&
+          !isFlagEnabled('multiOrg') && (
+            <div>
+              <Button
+                text="Switch Account"
+                icon={IconFont.Switch_New}
+                onClick={showSwitchAccountDialog}
+                testID="user-account-switch-btn"
+              />
+              <hr style={dividerStyle} />
+            </div>
+          )}
 
         <h4
           data-testid="account-settings--header"


### PR DESCRIPTION
Closes #5475 

This PR hides the 'switch account' button in the old 'switch account' page when the user has access to the switch-account functionality provided by the 'global header' in multi-org phase 1.


https://user-images.githubusercontent.com/91283923/185956941-7f32f783-7d9f-4808-b16a-a863cc56f26f.mov



### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - `multiOrg`
