### PR TITLE
chore: fixing linter warnings in arduino

### DIFF
--- a/src/homepageExperience/components/steps/arduino/InitializeClient.tsx
+++ b/src/homepageExperience/components/steps/arduino/InitializeClient.tsx
@@ -86,7 +86,7 @@ export const InitializeClient: FC<OwnProps> = ({
       dispatch(createAuthorization(authorization))
       event(`firstMile.arduinoWizard.tokens.tokenCreated`)
     }
-  }, [dispatch, me.id, org.id, sortedPermissionTypes, tokenValue])
+  }, [dispatch, me?.id, org?.id, sortedPermissionTypes, tokenValue])
 
   // when token generated, save it to the parent component
   useEffect(() => {

--- a/src/homepageExperience/components/steps/arduino/InitializeClient.tsx
+++ b/src/homepageExperience/components/steps/arduino/InitializeClient.tsx
@@ -69,7 +69,7 @@ export const InitializeClient: FC<OwnProps> = ({
   useEffect(() => {
     dispatch(getBuckets())
     dispatch(getAllResources())
-  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [dispatch])
 
   useEffect(() => {
     onSelectBucket(bucket.name)
@@ -86,14 +86,14 @@ export const InitializeClient: FC<OwnProps> = ({
       dispatch(createAuthorization(authorization))
       event(`firstMile.arduinoWizard.tokens.tokenCreated`)
     }
-  }, [sortedPermissionTypes.length])
+  }, [dispatch, me.id, org.id, sortedPermissionTypes, tokenValue])
 
   // when token generated, save it to the parent component
   useEffect(() => {
     if (currentAuth.token) {
       setTokenValue(currentAuth.token)
     }
-  }, [currentAuth.token])
+  }, [currentAuth.token, setTokenValue])
 
   useEffect(() => {
     const fireKeyboardCopyEvent = event => {


### PR DESCRIPTION
Closes #5488 

Fixes eslint warnings on Arduino page. Its also important to note with this PR, especially having it have been done previously, that we have to be careful while reusing/copy and pasting code from other components that they are completely bug free. This is an extremely easy way to multiply small bugs into bigger problems. All homepage lint warnings had previously been fixed but now came back up because of code reuse.

Showing that the behaviour is still as expected:

https://user-images.githubusercontent.com/13280708/186968526-c5dcb386-604d-4f2a-aa4a-5fcf3c67080c.mov



### Checklist

Authors and Reviewer(s), please verify the following:

- [ ] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [ ] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
