### PR TITLE
feat(deepLinks): add deep links for mqtt subscriptions index and creation

### DIFF
--- a/cypress/e2e/cloud/deepLinks.test.ts
+++ b/cypress/e2e/cloud/deepLinks.test.ts
@@ -51,6 +51,18 @@ describe('Deep linking', () => {
       cy.visit('/me/load-data')
       cy.location('pathname').should('eq', `/orgs/${org.id}/load-data/sources`)
 
+      cy.visit('/me/load-data/subscriptions')
+      cy.location('pathname').should(
+        'eq',
+        `/orgs/${org.id}/load-data/subscriptions`
+      )
+
+      cy.visit('/me/load-data/subscriptions/create')
+      cy.location('pathname').should(
+        'eq',
+        `/orgs/${org.id}/load-data/subscriptions/create`
+      )
+
       cy.visit('/me/nodejsclient')
       cy.location('pathname').should(
         'eq',

--- a/src/utils/deepLinks.ts
+++ b/src/utils/deepLinks.ts
@@ -14,6 +14,8 @@ export const buildDeepLinkingMap = (orgId: string) => ({
   '/me/javaclient': `/orgs/${orgId}/load-data/client-libraries/java`,
   '/me/labels': `/orgs/${orgId}/settings/labels`,
   '/me/load-data': `/orgs/${orgId}/load-data/sources`,
+  '/me/load-data/subscriptions': `/orgs/${orgId}/load-data/subscriptions`,
+  '/me/load-data/subscriptions/create': `/orgs/${orgId}/load-data/subscriptions/create`,
   '/me/nodejsclient': `/orgs/${orgId}/load-data/client-libraries/javascript-node`,
   [`/me/${PROJECT_NAME_PLURAL.toLowerCase()}`]: `/orgs/${orgId}/${PROJECT_NAME_PLURAL.toLowerCase()}`,
   '/me/notebooks': `/orgs/${orgId}/${PROJECT_NAME_PLURAL.toLowerCase()}`,


### PR DESCRIPTION
Closes #5483

Adds two new deep links
- mqtt subscriptions: `/me/load-data/subscriptions -> /orgs/:orgId/load-data/subscriptions`
- mqtt create flow:  `/me/load-data/subscriptions/create -> orgs/:orgId/load-data/subscriptions/create`

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- ~[ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~
- ~[ ] Feature flagged, if applicable~
