### PR TITLE
feat: save a query as a notebook

### DIFF
--- a/src/dataExplorer/components/FluxQueryBuilder.scss
+++ b/src/dataExplorer/components/FluxQueryBuilder.scss
@@ -30,3 +30,7 @@
   border-top: 1px solid $cf-grey-15;
   border-bottom: 1px solid $cf-grey-15;
 }
+
+.flux-query-builder__save-button {
+  margin-left: $cf-space-s;
+}

--- a/src/dataExplorer/components/FluxQueryBuilder.tsx
+++ b/src/dataExplorer/components/FluxQueryBuilder.tsx
@@ -1,5 +1,6 @@
 import React, {FC, useContext, useCallback} from 'react'
 import {RemoteDataState} from 'src/types'
+import {useHistory, useLocation} from 'react-router-dom'
 
 // Components
 import {
@@ -11,6 +12,7 @@ import {
   IconFont,
   AlignItems,
   JustifyContent,
+  ComponentColor,
 } from '@influxdata/clockface'
 import {QueryProvider, QueryContext} from 'src/shared/contexts/query'
 import {EditorProvider} from 'src/shared/contexts/editor'
@@ -30,11 +32,14 @@ import Schema from 'src/dataExplorer/components/Schema'
 
 // Styles
 import './FluxQueryBuilder.scss'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 const FluxQueryBuilder: FC = () => {
   const {vertical, setVertical, setQuery, setSelection} = useContext(
     PersistanceContext
   )
+  const history = useHistory()
+  const {pathname} = useLocation()
   const {cancel} = useContext(QueryContext)
   const {setStatus, setResult} = useContext(ResultsContext)
 
@@ -45,6 +50,10 @@ const FluxQueryBuilder: FC = () => {
     setQuery('')
     setSelection(JSON.parse(JSON.stringify(DEFAULT_SCHEMA)))
   }, [setQuery, setStatus, setResult, setSelection, cancel])
+
+  const handleShowOverlay = () => {
+    history.push(`${pathname}/save`)
+  }
 
   return (
     <EditorProvider>
@@ -64,6 +73,16 @@ const FluxQueryBuilder: FC = () => {
               text="New Script"
               icon={IconFont.Plus_New}
             />
+            {isFlagEnabled('saveLoadFeature') && (
+              <Button
+                className="flux-query-builder__save-button"
+                icon={IconFont.Save}
+                onClick={handleShowOverlay}
+                color={ComponentColor.Default}
+                titleText="Save your query as a Script, Cell, Notebook or Task"
+                text="Save"
+              />
+            )}
           </div>
           <DraggableResizer
             handleOrientation={Orientation.Vertical}

--- a/src/dataExplorer/components/SaveAsOverlay.tsx
+++ b/src/dataExplorer/components/SaveAsOverlay.tsx
@@ -17,10 +17,12 @@ import {
 // Utils
 import {event} from 'src/cloud/utils/reporting'
 import {PROJECT_NAME} from 'src/flows'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 enum SaveAsOption {
   Dashboard = 'dashboard',
   Notebook = 'notebook',
+  Script = 'script',
   Task = 'task',
   Variable = 'variable',
 }
@@ -44,6 +46,11 @@ const SaveAsOverlay: FC = () => {
     saveAsForm = <SaveAsVariable onHideOverlay={hide} />
   } else if (saveAsOption === SaveAsOption.Notebook) {
     saveAsForm = <SaveAsNotebookForm dismiss={hide} />
+  } else if (
+    saveAsOption === SaveAsOption.Script &&
+    isFlagEnabled('saveLoadFeature')
+  ) {
+    saveAsForm = <SaveAsNotebookForm dismiss={hide} />
   }
 
   return (
@@ -64,6 +71,15 @@ const SaveAsOverlay: FC = () => {
                 onClick={() => setSaveAsOption(SaveAsOption.Notebook)}
                 active={saveAsOption === SaveAsOption.Notebook}
               />
+              {isFlagEnabled('saveLoadFeature') && (
+                <Tabs.Tab
+                  id={SaveAsOption.Script}
+                  text="Script"
+                  testID="cell--radio-button"
+                  onClick={() => setSaveAsOption(SaveAsOption.Script)}
+                  active={saveAsOption === SaveAsOption.Script}
+                />
+              )}
               <Tabs.Tab
                 id={SaveAsOption.Dashboard}
                 text="Dashboard Cell"

--- a/src/shared/copy/notifications/categories/notebooks.ts
+++ b/src/shared/copy/notifications/categories/notebooks.ts
@@ -62,3 +62,8 @@ export const publishNotebookFailed = (name: string): Notification => ({
   ...defaultErrorNotification,
   message: `Failed to save this version to ${name}'s version history`,
 })
+
+export const savedAsNotebookSucceeded = (): Notification => ({
+  ...defaultSuccessNotification,
+  message: `Successfully saved the Notebook! Click here to check out your Notebook`,
+})


### PR DESCRIPTION
Closes #

This work is the initial work being done to integrate "save / load" functionality into the new query builder, where a user should be able to save their editor text as an external resource. More specifically, this PR integrates the existing infrastructure and iterates upon that existing design until we can get new designs for the `Save As` functionality. This PR will be one in a long-line of PRs to introduce these changes incrementally so we can test them out as and when without needing to worry about introducing too large a body of work and making sure that the scope is well-defined for each leg of the work

<!-- Describe your proposed changes here. -->
<!-- Including screenshots or visuals is very helpful - a picture is worth a thousand words. -->

### Checklist

Authors and Reviewer(s), please verify the following:

- [ ] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [ ] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
