### PR TITLE
feat(schemaBrowser): add disabled and hover tooltip to "Run" button when no selected measurement

### DIFF
--- a/src/dataExplorer/components/ResultsPane.tsx
+++ b/src/dataExplorer/components/ResultsPane.tsx
@@ -88,7 +88,14 @@ const ResultsPane: FC = () => {
     setQuery,
     range,
     setRange,
+    selection,
   } = useContext(PersistanceContext)
+
+  const submitButtonDisabled = !text || !selection.measurement
+
+  const disabledTitleText = submitButtonDisabled
+    ? 'Select measurement before running script'
+    : ''
 
   const download = () => {
     event('CSV Download Initiated')
@@ -197,7 +204,8 @@ const ResultsPane: FC = () => {
                 className="submit-btn"
                 text="Run"
                 icon={IconFont.Play}
-                submitButtonDisabled={!text}
+                submitButtonDisabled={submitButtonDisabled}
+                disabledTitleText={disabledTitleText}
                 queryStatus={status}
                 onSubmit={submit}
                 onNotify={fakeNotify}

--- a/src/timeMachine/components/SubmitQueryButton.tsx
+++ b/src/timeMachine/components/SubmitQueryButton.tsx
@@ -35,6 +35,7 @@ interface OwnProps {
   icon?: IconFont
   testID?: string
   className?: string
+  disabledTitleText?: string // Text to be displayed on hover tooltip when the button is disabled
 }
 
 type ReduxProps = ConnectedProps<typeof connector>
@@ -86,7 +87,15 @@ class SubmitQueryButton extends PureComponent<Props> {
   }
 
   public render() {
-    const {color, text, queryStatus, icon, testID, className} = this.props
+    const {
+      color,
+      text,
+      queryStatus,
+      icon,
+      testID,
+      className,
+      disabledTitleText,
+    } = this.props
     if (queryStatus === RemoteDataState.Loading && this.state.timer) {
       return (
         <Button
@@ -112,6 +121,7 @@ class SubmitQueryButton extends PureComponent<Props> {
         color={color ?? ComponentColor.Primary}
         testID={testID}
         style={{minWidth: '100px'}}
+        disabledTitleText={disabledTitleText}
       />
     )
   }


### PR DESCRIPTION
Close #5495

This PR adds the disabled and hover tooltip to "Run" button when the user has not selected a measurement. The disabled tooltip text is suggested by Julia in [figma design](https://www.figma.com/file/0qAntPk5LVangAHguWT74X/Query-Experience-Project?node-id=1719%3A71011)

## After

https://user-images.githubusercontent.com/14298407/186033200-dee98792-5bd6-435c-a327-6fbfb282e541.mov

<img width="1512" alt="after" src="https://user-images.githubusercontent.com/14298407/186033596-ff5a531e-8ddd-470f-a780-2d8a2f2b672a.png">



### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
~~- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~~
~~- [ ] Feature flagged, if applicable~~
