### PR TITLE
fix: refactor user profile test to avoid flake

### DIFF
--- a/cypress/e2e/cloud/userProfile.test.ts
+++ b/cypress/e2e/cloud/userProfile.test.ts
@@ -8,11 +8,12 @@ export const setupProfile = (): Promise<any> => {
             method: 'PUT',
             url: 'api/v2/quartz/accounts/resetAllAccountOrgs',
           })
+          cy.visit('/')
           cy.getByTestID('home-page--header').should('be.visible')
           cy.setFeatureFlags(userProfileFeatureFlags).then(() => {
             // cy.wait($time) is necessary to consistently ensure sufficient time for the feature flag override.
             // The flag reset happens via redux, (it's not a network request), so we can't cy.wait($intercepted_route).
-            cy.wait(300).then(() => {
+            cy.wait(1200).then(() => {
               cy.visit('/me/profile')
             })
           })
@@ -96,6 +97,12 @@ describe('User profile page', () => {
   })
 
   it("displays the user's name and email", () => {
+    cy.fixture('multiOrgAccounts1.json').then(quartzAccounts => {
+      cy.intercept('GET', '/api/v2/quartz/accounts', quartzAccounts).as(
+        'getAccounts'
+      )
+    })
+
     cy.getByTestID('user-profile--page')
       .contains('User Profile')
       .should('be.visible')
@@ -133,9 +140,15 @@ describe('User profile page', () => {
 
   describe('multi-org users', () => {
     it('allows the user to change their default account', () => {
-      cy.intercept({
-        path: '/api/v2/quartz/accounts/default',
-        method: 'PUT',
+      cy.fixture('multiOrgAccounts1.json').then(quartzAccounts => {
+        cy.intercept('GET', '/api/v2/quartz/accounts', quartzAccounts).as(
+          'getAccounts'
+        )
+      })
+
+      cy.intercept('PUT', '/api/v2/quartz/accounts/default', {
+        statusCode: 204,
+        data: '',
       }).as('putQuartzDefaultAccount')
 
       cy.getByTestID('user-profile--save-button').should(
@@ -143,7 +156,6 @@ describe('User profile page', () => {
         'disabled'
       )
 
-      // Confirm that the user can change default accounts solely by clicking in the dropdown.
       cy.getByTestID('user-profile--change-account-header')
         .contains('Default Account')
         .should('be.visible')
@@ -156,6 +168,15 @@ describe('User profile page', () => {
         .getByTestID('dropdown-item')
         .contains('Influx')
         .click()
+
+      cy.fixture('multiOrgAccounts1.json').then(quartzAccounts => {
+        quartzAccounts[0].isDefault = true
+        quartzAccounts[1].isDefault = false
+
+        cy.intercept('GET', '/api/v2/quartz/accounts', quartzAccounts).as(
+          'getAccounts'
+        )
+      })
 
       cy.getByTestID('user-profile--save-button')
         .should('be.visible')
@@ -194,6 +215,13 @@ describe('User profile page', () => {
           .contains('Veganomicon')
           .click()
 
+        // Reset to default fixture, where Veganomicon is default.
+        cy.fixture('multiOrgAccounts1.json').then(quartzAccounts => {
+          cy.intercept('GET', '/api/v2/quartz/accounts', quartzAccounts).as(
+            'getAccounts'
+          )
+        })
+
         cy.getByTestID('user-profile--save-button')
           .should('be.visible')
           .click()
@@ -222,9 +250,9 @@ describe('User profile page', () => {
     })
 
     it('allows the user to change their default org', () => {
-      cy.intercept({
-        path: '/api/v2/quartz/accounts/**/orgs/default',
-        method: 'PUT',
+      cy.intercept('PUT', '/api/v2/quartz/accounts/**/orgs/default', {
+        statusCode: 204,
+        data: '',
       }).as('putQuartzDefaultOrg')
 
       cy.getByTestID('user-profile--current-account-header')
@@ -309,14 +337,14 @@ describe('User profile page', () => {
     })
 
     it('allows the user to change both their default account and org', () => {
-      cy.intercept({
-        path: '/api/v2/quartz/accounts/default',
-        method: 'PUT',
+      cy.intercept('PUT', '/api/v2/quartz/accounts/default', {
+        statusCode: 204,
+        data: '',
       }).as('putQuartzDefaultAccount')
 
-      cy.intercept({
-        path: '/api/v2/quartz/accounts/**/orgs/default',
-        method: 'PUT',
+      cy.intercept('PUT', '/api/v2/quartz/accounts/**/orgs/default', {
+        statusCode: 204,
+        data: '',
       }).as('putQuartzDefaultOrg')
 
       cy.getByTestID('user-profile--change-account-dropdown').type('Inf')
@@ -334,6 +362,15 @@ describe('User profile page', () => {
         .getByTestID('dropdown-item')
         .contains('Test Org 1')
         .click()
+
+      cy.fixture('multiOrgAccounts1.json').then(quartzAccounts => {
+        quartzAccounts[0].isDefault = true
+        quartzAccounts[1].isDefault = false
+
+        cy.intercept('GET', '/api/v2/quartz/accounts', quartzAccounts).as(
+          'getAccounts'
+        )
+      })
 
       cy.getByTestID('user-profile--save-button').click()
 

--- a/cypress/fixtures/multiOrgAccounts1.json
+++ b/cypress/fixtures/multiOrgAccounts1.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": 416,
+    "isActive": true,
+    "isDefault": false,
+    "name": "Influx"
+  },
+  {
+    "id": 415,
+    "isActive": false,
+    "isDefault": true,
+    "name": "Veganomicon"
+  }
+]

--- a/cypress/fixtures/multiOrgOrgs1.json
+++ b/cypress/fixtures/multiOrgOrgs1.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "9296169091c64567",
+    "name": "Test Org 0",
+    "isDefault": true,
+    "isActive": true
+  },
+  {
+    "id": "a71ced2b8238902b",
+    "name": "Test Org 1",
+    "isDefault": false,
+    "isActive": false
+  },
+  {
+    "id": "ac3d3c04b8f1a545",
+    "name": "Test Org 2",
+    "isDefault": false,
+    "isActive": false
+  },
+  {
+    "id": "fc734484afa0fcac",
+    "name": "Test Org 3",
+    "isDefault": false,
+    "isActive": false
+  },
+  {
+    "id": "62cba0af4760ce02",
+    "name": "Test Org 4",
+    "isDefault": false,
+    "isActive": false
+  },
+  {
+    "id": "58fafbb4f68e05e5",
+    "name": "Test Org 5",
+    "isDefault": false,
+    "isActive": false
+  },
+  {
+    "id": "3f3fd71611a4a0fe",
+    "name": "Test Org 6",
+    "isDefault": false,
+    "isActive": false
+  },
+  {
+    "id": "1232a0085d2af2dd",
+    "name": "Test Org 7",
+    "isDefault": false,
+    "isActive": false
+  },
+  {
+    "id": "e337e5c5ee6439a2",
+    "name": "Test Org 8",
+    "isDefault": false,
+    "isActive": false
+  },
+  {
+    "id": "3b3ca09032853015",
+    "name": "Test Org 9",
+    "isDefault": false,
+    "isActive": false
+  }
+]


### PR DESCRIPTION
Connects #5498 

The user profile tests weren't passing CI, because the tests run in parallel and were simultaneously updating default orgs on the quartz-mock backend out of sync with each other. 

This PR resolves that issue by intercepting the network requests with a fixture. In also slightly increases the initial wait time before running all tests, to avoid performance issues during slow CI runs.

[The test now passes 20x runs of Chrome and 20x runs of Firefox](https://app.circleci.com/pipelines/github/influxdata/ui/15749/workflows/d42f20fc-9fdd-41b7-aeb1-01424800525e/jobs/90529/steps)

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - `multiOrg`
