### PR TITLE
feat(schemaBrowser): add "Flux Sync" toggle button

### DIFF
--- a/src/dataExplorer/components/Schema.scss
+++ b/src/dataExplorer/components/Schema.scss
@@ -24,10 +24,10 @@
   }
 }
 
-.schema-browser--heading {
+.schema-browser-heading {
   padding-bottom: $cf-space-2xs;
 
-  .schema-browser--text {
+  .schema-browser-heading--text {
     font-size: 16px;
     font-weight: $cf-font-weight--bold;
   }

--- a/src/dataExplorer/components/Schema.scss
+++ b/src/dataExplorer/components/Schema.scss
@@ -24,6 +24,23 @@
   }
 }
 
+.schema-browser--heading {
+  padding-bottom: $cf-space-2xs;
+
+  .schema-browser--text {
+    font-size: 16px;
+    font-weight: $cf-font-weight--bold;
+  }
+
+  .flux-sync--label {
+    padding-left: $cf-space-2xs;
+
+    .selector-title {
+      padding-bottom: 0;
+    }
+  }
+}
+
 .container-side-bar,
 .container-side-bar--fields,
 .container-side-bar--tag-keys,
@@ -35,14 +52,18 @@
 
 .selector-title {
   padding-bottom: $cf-space-2xs;
-}
 
-.selector-title--icon {
-  padding-left: $cf-space-2xs;
-}
+  .selector-title--question-mark {
+    padding-left: $cf-space-2xs;
+  }
 
-.selector-title--icon .cf-question-mark-tooltip {
-  background-color: $cf-grey-35;
+  .selector-title--question-mark .cf-question-mark-tooltip {
+    background-color: $cf-grey-35;
+  }
+
+  .selector-title--icon {
+    padding-right: 2px;
+  }
 }
 
 .field-selector,

--- a/src/dataExplorer/components/Schema.tsx
+++ b/src/dataExplorer/components/Schema.tsx
@@ -8,7 +8,7 @@ import {
   InputLabel,
   SlideToggle,
   JustifyContent,
-  QuestionMarkTooltip,
+  IconFont,
 } from '@influxdata/clockface'
 import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
 import BucketSelector from 'src/dataExplorer/components/BucketSelector'
@@ -48,12 +48,24 @@ const Heading: FC = () => {
   }
 
   return (
-    <FlexBox justifyContent={JustifyContent.SpaceBetween}>
-      <div>Schema Browser</div>
-      <FlexBox>
-        <SlideToggle active={fluxSyncOn} onChange={handleFluxSyncToggle} />
-        <InputLabel>
-          <SelectorTitle title="Flux Sync" info={FLUX_SYNC_TOOLTIP} />
+    <FlexBox
+      className="schema-browser--heading"
+      justifyContent={JustifyContent.SpaceBetween}
+    >
+      <div className="schema-browser--text">Schema Browser</div>
+      <FlexBox className="flux-sync">
+        <SlideToggle
+          className="flux-sync--toggle"
+          active={fluxSyncOn}
+          onChange={handleFluxSyncToggle}
+          testID="flux-sync--toggle"
+        />
+        <InputLabel className="flux-sync--label">
+          <SelectorTitle
+            title="Flux Sync"
+            info={FLUX_SYNC_TOOLTIP}
+            icon={IconFont.Switch_New}
+          />
         </InputLabel>
       </FlexBox>
     </FlexBox>

--- a/src/dataExplorer/components/Schema.tsx
+++ b/src/dataExplorer/components/Schema.tsx
@@ -1,13 +1,21 @@
-import React, {FC, useContext, useEffect, useMemo} from 'react'
+import React, {FC, useContext, useEffect, useMemo, useState} from 'react'
 import {useSelector} from 'react-redux'
 
 // Components
-import {DapperScrollbars} from '@influxdata/clockface'
+import {
+  DapperScrollbars,
+  FlexBox,
+  InputLabel,
+  SlideToggle,
+  JustifyContent,
+  QuestionMarkTooltip,
+} from '@influxdata/clockface'
 import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
 import BucketSelector from 'src/dataExplorer/components/BucketSelector'
 import MeasurementSelector from 'src/dataExplorer/components/MeasurementSelector'
 import FieldSelector from 'src/dataExplorer/components/FieldSelector'
 import TagSelector from 'src/dataExplorer/components/TagSelector'
+import SelectorTitle from 'src/dataExplorer/components/SelectorTitle'
 
 // Context
 import {
@@ -27,6 +35,30 @@ import {getOrg} from 'src/organizations/selectors'
 
 // Style
 import './Schema.scss'
+
+const FLUX_SYNC_TOOLTIP = `Flux Sync autopopulates the script editor to help you \
+start a query. You can turn this feature on and off, but typing within this \
+section will disable synchronization.`
+
+const Heading: FC = () => {
+  const [fluxSyncOn, setFluxSyncOn] = useState(true)
+
+  const handleFluxSyncToggle = () => {
+    setFluxSyncOn(!fluxSyncOn)
+  }
+
+  return (
+    <FlexBox justifyContent={JustifyContent.SpaceBetween}>
+      <div>Schema Browser</div>
+      <FlexBox>
+        <SlideToggle active={fluxSyncOn} onChange={handleFluxSyncToggle} />
+        <InputLabel>
+          <SelectorTitle title="Flux Sync" info={FLUX_SYNC_TOOLTIP} />
+        </InputLabel>
+      </FlexBox>
+    </FlexBox>
+  )
+}
 
 const FieldsTags: FC = () => {
   const {
@@ -80,6 +112,7 @@ const Schema: FC = () => {
               <div className="scroll--container">
                 <DapperScrollbars>
                   <div className="schema-browser" data-testid="schema-browser">
+                    <Heading />
                     <BucketSelector />
                     <div className="container-side-bar">
                       <MeasurementSelector />

--- a/src/dataExplorer/components/Schema.tsx
+++ b/src/dataExplorer/components/Schema.tsx
@@ -1,21 +1,14 @@
-import React, {FC, useContext, useEffect, useMemo, useState} from 'react'
+import React, {FC, useContext, useEffect, useMemo} from 'react'
 import {useSelector} from 'react-redux'
 
 // Components
-import {
-  DapperScrollbars,
-  FlexBox,
-  InputLabel,
-  SlideToggle,
-  JustifyContent,
-  IconFont,
-} from '@influxdata/clockface'
+import {DapperScrollbars} from '@influxdata/clockface'
 import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
 import BucketSelector from 'src/dataExplorer/components/BucketSelector'
 import MeasurementSelector from 'src/dataExplorer/components/MeasurementSelector'
 import FieldSelector from 'src/dataExplorer/components/FieldSelector'
 import TagSelector from 'src/dataExplorer/components/TagSelector'
-import SelectorTitle from 'src/dataExplorer/components/SelectorTitle'
+import SchemaBrowserHeading from 'src/dataExplorer/components/SchemaBrowserHeading'
 
 // Context
 import {
@@ -35,42 +28,6 @@ import {getOrg} from 'src/organizations/selectors'
 
 // Style
 import './Schema.scss'
-
-const FLUX_SYNC_TOOLTIP = `Flux Sync autopopulates the script editor to help you \
-start a query. You can turn this feature on and off, but typing within this \
-section will disable synchronization.`
-
-const Heading: FC = () => {
-  const [fluxSyncOn, setFluxSyncOn] = useState(true)
-
-  const handleFluxSyncToggle = () => {
-    setFluxSyncOn(!fluxSyncOn)
-  }
-
-  return (
-    <FlexBox
-      className="schema-browser--heading"
-      justifyContent={JustifyContent.SpaceBetween}
-    >
-      <div className="schema-browser--text">Schema Browser</div>
-      <FlexBox className="flux-sync">
-        <SlideToggle
-          className="flux-sync--toggle"
-          active={fluxSyncOn}
-          onChange={handleFluxSyncToggle}
-          testID="flux-sync--toggle"
-        />
-        <InputLabel className="flux-sync--label">
-          <SelectorTitle
-            title="Flux Sync"
-            info={FLUX_SYNC_TOOLTIP}
-            icon={IconFont.Switch_New}
-          />
-        </InputLabel>
-      </FlexBox>
-    </FlexBox>
-  )
-}
 
 const FieldsTags: FC = () => {
   const {
@@ -124,7 +81,7 @@ const Schema: FC = () => {
               <div className="scroll--container">
                 <DapperScrollbars>
                   <div className="schema-browser" data-testid="schema-browser">
-                    <Heading />
+                    <SchemaBrowserHeading />
                     <BucketSelector />
                     <div className="container-side-bar">
                       <MeasurementSelector />

--- a/src/dataExplorer/components/SchemaBrowserHeading.tsx
+++ b/src/dataExplorer/components/SchemaBrowserHeading.tsx
@@ -26,10 +26,10 @@ const SchemaBrowserHeading: FC = () => {
 
   return (
     <FlexBox
-      className="schema-browser--heading"
+      className="schema-browser-heading"
       justifyContent={JustifyContent.SpaceBetween}
     >
-      <div className="schema-browser--text">Schema Browser</div>
+      <div className="schema-browser-heading--text">Schema Browser</div>
       <FlexBox className="flux-sync">
         <SlideToggle
           className="flux-sync--toggle"

--- a/src/dataExplorer/components/SchemaBrowserHeading.tsx
+++ b/src/dataExplorer/components/SchemaBrowserHeading.tsx
@@ -1,0 +1,52 @@
+import React, {FC, useContext} from 'react'
+
+// Components
+import {
+  FlexBox,
+  InputLabel,
+  SlideToggle,
+  JustifyContent,
+  IconFont,
+} from '@influxdata/clockface'
+import SelectorTitle from 'src/dataExplorer/components/SelectorTitle'
+
+// Context
+import {FluxQueryBuilderContext} from 'src/dataExplorer/context/fluxQueryBuilder'
+
+const FLUX_SYNC_TOOLTIP = `Flux Sync autopopulates the script editor to help you \
+start a query. You can turn this feature on and off, but typing within this \
+section will disable synchronization.`
+
+const SchemaBrowserHeading: FC = () => {
+  const {fluxSync, toggleFluxSync} = useContext(FluxQueryBuilderContext)
+
+  const handleFluxSyncToggle = () => {
+    toggleFluxSync()
+  }
+
+  return (
+    <FlexBox
+      className="schema-browser--heading"
+      justifyContent={JustifyContent.SpaceBetween}
+    >
+      <div className="schema-browser--text">Schema Browser</div>
+      <FlexBox className="flux-sync">
+        <SlideToggle
+          className="flux-sync--toggle"
+          active={fluxSync}
+          onChange={handleFluxSyncToggle}
+          testID="flux-sync--toggle"
+        />
+        <InputLabel className="flux-sync--label">
+          <SelectorTitle
+            title="Flux Sync"
+            info={FLUX_SYNC_TOOLTIP}
+            icon={IconFont.Switch_New}
+          />
+        </InputLabel>
+      </FlexBox>
+    </FlexBox>
+  )
+}
+
+export default SchemaBrowserHeading

--- a/src/dataExplorer/components/SchemaBrowserHeading.tsx
+++ b/src/dataExplorer/components/SchemaBrowserHeading.tsx
@@ -1,4 +1,4 @@
-import React, {FC, useContext} from 'react'
+import React, {FC, useContext, useMemo} from 'react'
 
 // Components
 import {
@@ -21,31 +21,34 @@ const SchemaBrowserHeading: FC = () => {
   const {fluxSync, toggleFluxSync} = useContext(FluxQueryBuilderContext)
 
   const handleFluxSyncToggle = () => {
-    toggleFluxSync()
+    toggleFluxSync(!fluxSync)
   }
 
-  return (
-    <FlexBox
-      className="schema-browser-heading"
-      justifyContent={JustifyContent.SpaceBetween}
-    >
-      <div className="schema-browser-heading--text">Schema Browser</div>
-      <FlexBox className="flux-sync">
-        <SlideToggle
-          className="flux-sync--toggle"
-          active={fluxSync}
-          onChange={handleFluxSyncToggle}
-          testID="flux-sync--toggle"
-        />
-        <InputLabel className="flux-sync--label">
-          <SelectorTitle
-            title="Flux Sync"
-            info={FLUX_SYNC_TOOLTIP}
-            icon={IconFont.Switch_New}
+  return useMemo(
+    () => (
+      <FlexBox
+        className="schema-browser-heading"
+        justifyContent={JustifyContent.SpaceBetween}
+      >
+        <div className="schema-browser-heading--text">Schema Browser</div>
+        <FlexBox className="flux-sync">
+          <SlideToggle
+            className="flux-sync--toggle"
+            active={fluxSync}
+            onChange={handleFluxSyncToggle}
+            testID="flux-sync--toggle"
           />
-        </InputLabel>
+          <InputLabel className="flux-sync--label">
+            <SelectorTitle
+              title="Flux Sync"
+              info={FLUX_SYNC_TOOLTIP}
+              icon={IconFont.Switch_New}
+            />
+          </InputLabel>
+        </FlexBox>
       </FlexBox>
-    </FlexBox>
+    ),
+    [fluxSync]
   )
 }
 

--- a/src/dataExplorer/components/SelectorTitle.tsx
+++ b/src/dataExplorer/components/SelectorTitle.tsx
@@ -13,7 +13,7 @@ import './Schema.scss'
 
 interface TitleProps {
   title: string
-  info?: string // TODO: markdon? since there might be link
+  info?: string
   icon?: IconFont
 }
 

--- a/src/dataExplorer/components/SelectorTitle.tsx
+++ b/src/dataExplorer/components/SelectorTitle.tsx
@@ -1,7 +1,12 @@
 import React, {FC} from 'react'
 
 // Componnents
-import {FlexBox, QuestionMarkTooltip} from '@influxdata/clockface'
+import {
+  FlexBox,
+  QuestionMarkTooltip,
+  Icon,
+  IconFont,
+} from '@influxdata/clockface'
 
 // Styles
 import './Schema.scss'
@@ -9,14 +14,16 @@ import './Schema.scss'
 interface TitleProps {
   title: string
   info?: string // TODO: markdon? since there might be link
+  icon?: IconFont
 }
 
-const SelectorTitle: FC<TitleProps> = ({title, info = ''}) => {
+const SelectorTitle: FC<TitleProps> = ({title, info = '', icon = null}) => {
   return (
     <FlexBox className="selector-title">
+      {icon && <Icon glyph={icon} className="selector-title--icon" />}
       <div>{title}</div>
       {info && (
-        <div className="selector-title--icon">
+        <div className="selector-title--question-mark">
           <QuestionMarkTooltip
             tooltipContents={info}
             diameter={14}

--- a/src/dataExplorer/context/fluxQueryBuilder.tsx
+++ b/src/dataExplorer/context/fluxQueryBuilder.tsx
@@ -94,7 +94,7 @@ export const FluxQueryBuilderProvider: FC = ({children}) => {
   }, [selection.bucket])
 
   const handleToggleFluxSync = (synced: boolean): void => {
-    setSelection({composition: {synced: synced}})
+    setSelection({composition: {synced}})
   }
 
   const handleSelectBucket = (bucket: Bucket): void => {

--- a/src/dataExplorer/context/fluxQueryBuilder.tsx
+++ b/src/dataExplorer/context/fluxQueryBuilder.tsx
@@ -40,7 +40,7 @@ const debouncer = (action: NOOP): void => {
 interface FluxQueryBuilderContextType {
   // Flux Sync
   fluxSync: boolean
-  toggleFluxSync: () => void
+  toggleFluxSync: (synced: boolean) => void
 
   // Schema
   selectedBucket: Bucket
@@ -56,7 +56,7 @@ interface FluxQueryBuilderContextType {
 const DEFAULT_CONTEXT: FluxQueryBuilderContextType = {
   // Flux Sync
   fluxSync: true,
-  toggleFluxSync: () => {},
+  toggleFluxSync: _s => {},
 
   // Schema
   selectedBucket: null,
@@ -93,8 +93,8 @@ export const FluxQueryBuilderProvider: FC = ({children}) => {
     }
   }, [selection.bucket])
 
-  const handleToggleFluxSync = (): void => {
-    setSelection({composition: {synced: !selection.composition?.synced}})
+  const handleToggleFluxSync = (synced: boolean): void => {
+    setSelection({composition: {synced: synced}})
   }
 
   const handleSelectBucket = (bucket: Bucket): void => {

--- a/src/dataExplorer/context/fluxQueryBuilder.tsx
+++ b/src/dataExplorer/context/fluxQueryBuilder.tsx
@@ -38,6 +38,10 @@ const debouncer = (action: NOOP): void => {
 }
 
 interface FluxQueryBuilderContextType {
+  // Flux Sync
+  fluxSync: boolean
+  toggleFluxSync: () => void
+
   // Schema
   selectedBucket: Bucket
   selectedMeasurement: string
@@ -50,6 +54,10 @@ interface FluxQueryBuilderContextType {
 }
 
 const DEFAULT_CONTEXT: FluxQueryBuilderContextType = {
+  // Flux Sync
+  fluxSync: true,
+  toggleFluxSync: () => {},
+
   // Schema
   selectedBucket: null,
   selectedMeasurement: '',
@@ -84,6 +92,10 @@ export const FluxQueryBuilderProvider: FC = ({children}) => {
       getMeasurements(selection.bucket)
     }
   }, [selection.bucket])
+
+  const handleToggleFluxSync = (): void => {
+    setSelection({composition: {synced: !selection.composition?.synced}})
+  }
 
   const handleSelectBucket = (bucket: Bucket): void => {
     setSelection({bucket, measurement: ''})
@@ -155,6 +167,10 @@ export const FluxQueryBuilderProvider: FC = ({children}) => {
     () => (
       <FluxQueryBuilderContext.Provider
         value={{
+          // Flux Sync
+          fluxSync: selection.composition?.synced,
+          toggleFluxSync: handleToggleFluxSync,
+
           // Schema
           selectedBucket: selection.bucket,
           selectedMeasurement: selection.measurement,
@@ -170,6 +186,9 @@ export const FluxQueryBuilderProvider: FC = ({children}) => {
       </FluxQueryBuilderContext.Provider>
     ),
     [
+      // Flux Sync
+      selection.composition?.synced,
+
       // Schema
       selection.bucket,
       selection.measurement,


### PR DESCRIPTION
Closes #5501

This PR adds a toggle button in schema browser for controlling the sync of query composition between schema browser and the text editor.

## After

https://user-images.githubusercontent.com/14298407/186187033-74f62768-a8cb-4c84-8a4f-6d89b99bfda3.mov

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
~~- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~~
~~- [ ] Feature flagged, if applicable~~
