### PR TITLE
chore: normalizing eventing between all wizard next and previous navigation

### DIFF
--- a/src/homepageExperience/containers/CliWizard.tsx
+++ b/src/homepageExperience/containers/CliWizard.tsx
@@ -221,7 +221,8 @@ export class CliWizard extends PureComponent<{}, State> {
                   size={ComponentSize.Large}
                   color={ComponentColor.Primary}
                   status={
-                    this.state.currentStep < HOMEPAGE_NAVIGATION_STEPS_SHORT.length
+                    this.state.currentStep <
+                    HOMEPAGE_NAVIGATION_STEPS_SHORT.length
                       ? ComponentStatus.Default
                       : ComponentStatus.Disabled
                   }

--- a/src/homepageExperience/containers/CliWizard.tsx
+++ b/src/homepageExperience/containers/CliWizard.tsx
@@ -63,39 +63,46 @@ export class CliWizard extends PureComponent<{}, State> {
   }
 
   handleNextClick = () => {
-    this.setState({
-      currentStep: Math.min(
-        this.state.currentStep + 1,
-        HOMEPAGE_NAVIGATION_STEPS_SHORT.length
-      ),
-    })
-
-    event(
-      'firstMile.cliWizard.next.clicked',
-      {},
+    this.setState(
       {
-        clickedButtonAtStep: normalizeEventName(
-          HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep - 1].name
+        currentStep: Math.min(
+          this.state.currentStep + 1,
+          HOMEPAGE_NAVIGATION_STEPS_SHORT.length
         ),
-        currentStep: normalizeEventName(
-          HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep].name
-        ),
+      },
+      () => {
+        event(
+          'firstMile.cliWizard.next.clicked',
+          {},
+          {
+            clickedButtonAtStep: normalizeEventName(
+              HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep - 2].name
+            ),
+            currentStep: normalizeEventName(
+              HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep - 1].name
+            ),
+          }
+        )
       }
     )
   }
 
   handlePreviousClick = () => {
-    this.setState({currentStep: Math.max(this.state.currentStep - 1, 1)})
-    event(
-      'firstMile.cliWizard.previous.clicked',
-      {},
-      {
-        clickedButtonAtStep: normalizeEventName(
-          HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep + 1].name
-        ),
-        currentStep: normalizeEventName(
-          HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep].name
-        ),
+    this.setState(
+      {currentStep: Math.max(this.state.currentStep - 1, 1)},
+      () => {
+        event(
+          'firstMile.cliWizard.previous.clicked',
+          {},
+          {
+            clickedButtonAtStep: normalizeEventName(
+              HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep].name
+            ),
+            currentStep: normalizeEventName(
+              HOMEPAGE_NAVIGATION_STEPS_SHORT[this.state.currentStep - 1].name
+            ),
+          }
+        )
       }
     )
   }
@@ -214,7 +221,7 @@ export class CliWizard extends PureComponent<{}, State> {
                   size={ComponentSize.Large}
                   color={ComponentColor.Primary}
                   status={
-                    this.state.currentStep < 7
+                    this.state.currentStep < HOMEPAGE_NAVIGATION_STEPS_SHORT.length
                       ? ComponentStatus.Default
                       : ComponentStatus.Disabled
                   }

--- a/src/homepageExperience/containers/GoWizard.tsx
+++ b/src/homepageExperience/containers/GoWizard.tsx
@@ -19,6 +19,7 @@ import {ExecuteQuery} from 'src/homepageExperience/components/steps/go/ExecuteQu
 import {Finish} from 'src/homepageExperience/components/steps/Finish'
 import {ExecuteAggregateQuery} from 'src/homepageExperience/components/steps/go/ExecuteAggregateQuery'
 import WriteDataDetailsContextProvider from 'src/writeData/components/WriteDataDetailsContext'
+import {normalizeEventName} from 'src/cloud/utils/reporting'
 
 import {GoIcon} from 'src/homepageExperience/components/HomepageIcons'
 
@@ -62,38 +63,38 @@ export class GoWizard extends PureComponent<null, State> {
   }
 
   handleNextClick = () => {
-    this.setState(
+    event(
+      'firstMile.goWizard.next.clicked',
+      {},
       {
-        currentStep: Math.min(
-          this.state.currentStep + 1,
-          HOMEPAGE_NAVIGATION_STEPS.length
+        clickedButtonAtStep: normalizeEventName(
+          HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep - 1].name
         ),
-      },
-      () => {
-        event(
-          'firstMile.goWizard.next.clicked',
-          {},
-          {
-            clickedButtonAtStep: this.state.currentStep - 1,
-            currentStep: this.state.currentStep,
-          }
-        )
+        currentStep: normalizeEventName(
+          HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep].name
+        ),
       }
     )
+    this.setState({
+      currentStep: Math.min(
+        this.state.currentStep + 1,
+        HOMEPAGE_NAVIGATION_STEPS.length
+      ),
+    })
   }
 
   handlePreviousClick = () => {
-    this.setState(
-      {currentStep: Math.max(this.state.currentStep - 1, 1)},
-      () => {
-        event(
-          'firstMile.goWizard.previous.clicked',
-          {},
-          {
-            clickedButtonAtStep: this.state.currentStep + 1,
-            currentStep: this.state.currentStep,
-          }
-        )
+    this.setState({currentStep: Math.max(this.state.currentStep - 1, 1)})
+    event(
+      'firstMile.goWizard.previous.clicked',
+      {},
+      {
+        clickedButtonAtStep: normalizeEventName(
+          HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep - 1].name
+        ),
+        currentStep: normalizeEventName(
+          HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep - 2].name
+        ),
       }
     )
   }
@@ -205,7 +206,7 @@ export class GoWizard extends PureComponent<null, State> {
                   size={ComponentSize.Large}
                   color={ComponentColor.Primary}
                   status={
-                    this.state.currentStep < 8
+                    this.state.currentStep < HOMEPAGE_NAVIGATION_STEPS.length
                       ? ComponentStatus.Default
                       : ComponentStatus.Disabled
                   }

--- a/src/homepageExperience/containers/GoWizard.tsx
+++ b/src/homepageExperience/containers/GoWizard.tsx
@@ -63,44 +63,61 @@ export class GoWizard extends PureComponent<null, State> {
   }
 
   handleNextClick = () => {
-    event(
-      'firstMile.goWizard.next.clicked',
-      {},
+    this.setState(
       {
-        clickedButtonAtStep: normalizeEventName(
-          HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep - 1].name
+        currentStep: Math.min(
+          this.state.currentStep + 1,
+          HOMEPAGE_NAVIGATION_STEPS.length
         ),
-        currentStep: normalizeEventName(
-          HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep].name
-        ),
+      },
+      () => {
+        event(
+          'firstMile.goWizard.next.clicked',
+          {},
+          {
+            clickedButtonAtStep: normalizeEventName(
+              HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep - 2].name
+            ),
+            currentStep: normalizeEventName(
+              HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep - 1].name
+            ),
+          }
+        )
       }
     )
-    this.setState({
-      currentStep: Math.min(
-        this.state.currentStep + 1,
-        HOMEPAGE_NAVIGATION_STEPS.length
-      ),
-    })
   }
 
   handlePreviousClick = () => {
-    this.setState({currentStep: Math.max(this.state.currentStep - 1, 1)})
-    event(
-      'firstMile.goWizard.previous.clicked',
-      {},
-      {
-        clickedButtonAtStep: normalizeEventName(
-          HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep - 1].name
-        ),
-        currentStep: normalizeEventName(
-          HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep - 2].name
-        ),
+    this.setState(
+      {currentStep: Math.max(this.state.currentStep - 1, 1)},
+      () => {
+        event(
+          'firstMile.goWizard.previous.clicked',
+          {},
+          {
+            clickedButtonAtStep: normalizeEventName(
+              HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep].name
+            ),
+            currentStep: normalizeEventName(
+              HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep - 1].name
+            ),
+          }
+        )
       }
     )
   }
 
   handleNavClick = (clickedStep: number) => {
     this.setState({currentStep: clickedStep})
+    event(
+      'firstMile.goWizard.subNav.clicked',
+      {},
+      {
+        currentStep: normalizeEventName(
+          HOMEPAGE_NAVIGATION_STEPS[clickedStep - 1].name
+        ),
+      }
+    )
   }
 
   renderStep = () => {

--- a/src/homepageExperience/containers/NodejsWizard.tsx
+++ b/src/homepageExperience/containers/NodejsWizard.tsx
@@ -19,6 +19,7 @@ import {ExecuteQuery} from 'src/homepageExperience/components/steps/nodejs/Execu
 import {Finish} from 'src/homepageExperience/components/steps/Finish'
 import {ExecuteAggregateQuery} from 'src/homepageExperience/components/steps/nodejs/ExecuteAggregateQuery'
 import WriteDataDetailsContextProvider from 'src/writeData/components/WriteDataDetailsContext'
+import {normalizeEventName} from 'src/cloud/utils/reporting'
 
 import {NodejsIcon} from 'src/homepageExperience/components/HomepageIcons'
 
@@ -62,38 +63,38 @@ export class NodejsWizard extends PureComponent<null, State> {
   }
 
   handleNextClick = () => {
-    this.setState(
+    event(
+      'firstMile.NodejsWizard.next.clicked',
+      {},
       {
-        currentStep: Math.min(
-          this.state.currentStep + 1,
-          HOMEPAGE_NAVIGATION_STEPS.length
+        clickedButtonAtStep: normalizeEventName(
+          HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep - 1].name
         ),
-      },
-      () => {
-        event(
-          'firstMile.nodejsWizard.next.clicked',
-          {},
-          {
-            clickedButtonAtStep: this.state.currentStep - 1,
-            currentStep: this.state.currentStep,
-          }
-        )
+        currentStep: normalizeEventName(
+          HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep].name
+        ),
       }
     )
+    this.setState({
+      currentStep: Math.min(
+        this.state.currentStep + 1,
+        HOMEPAGE_NAVIGATION_STEPS.length
+      ),
+    })
   }
 
   handlePreviousClick = () => {
-    this.setState(
-      {currentStep: Math.max(this.state.currentStep - 1, 1)},
-      () => {
-        event(
-          'firstMile.nodejsWizard.previous.clicked',
-          {},
-          {
-            clickedButtonAtStep: this.state.currentStep + 1,
-            currentStep: this.state.currentStep,
-          }
-        )
+    this.setState({currentStep: Math.max(this.state.currentStep - 1, 1)})
+    event(
+      'firstMile.NodejsWizard.previous.clicked',
+      {},
+      {
+        clickedButtonAtStep: normalizeEventName(
+          HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep - 1].name
+        ),
+        currentStep: normalizeEventName(
+          HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep - 2].name
+        ),
       }
     )
   }
@@ -206,7 +207,7 @@ export class NodejsWizard extends PureComponent<null, State> {
                   size={ComponentSize.Large}
                   color={ComponentColor.Primary}
                   status={
-                    this.state.currentStep < 8
+                    this.state.currentStep < HOMEPAGE_NAVIGATION_STEPS.length
                       ? ComponentStatus.Default
                       : ComponentStatus.Disabled
                   }

--- a/src/homepageExperience/containers/NodejsWizard.tsx
+++ b/src/homepageExperience/containers/NodejsWizard.tsx
@@ -63,44 +63,61 @@ export class NodejsWizard extends PureComponent<null, State> {
   }
 
   handleNextClick = () => {
-    event(
-      'firstMile.NodejsWizard.next.clicked',
-      {},
+    this.setState(
       {
-        clickedButtonAtStep: normalizeEventName(
-          HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep - 1].name
+        currentStep: Math.min(
+          this.state.currentStep + 1,
+          HOMEPAGE_NAVIGATION_STEPS.length
         ),
-        currentStep: normalizeEventName(
-          HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep].name
-        ),
+      },
+      () => {
+        event(
+          'firstMile.nodejsWizard.next.clicked',
+          {},
+          {
+            clickedButtonAtStep: normalizeEventName(
+              HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep - 2].name
+            ),
+            currentStep: normalizeEventName(
+              HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep - 1].name
+            ),
+          }
+        )
       }
     )
-    this.setState({
-      currentStep: Math.min(
-        this.state.currentStep + 1,
-        HOMEPAGE_NAVIGATION_STEPS.length
-      ),
-    })
   }
 
   handlePreviousClick = () => {
-    this.setState({currentStep: Math.max(this.state.currentStep - 1, 1)})
-    event(
-      'firstMile.NodejsWizard.previous.clicked',
-      {},
-      {
-        clickedButtonAtStep: normalizeEventName(
-          HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep - 1].name
-        ),
-        currentStep: normalizeEventName(
-          HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep - 2].name
-        ),
+    this.setState(
+      {currentStep: Math.max(this.state.currentStep - 1, 1)},
+      () => {
+        event(
+          'firstMile.nodejsWizard.previous.clicked',
+          {},
+          {
+            clickedButtonAtStep: normalizeEventName(
+              HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep].name
+            ),
+            currentStep: normalizeEventName(
+              HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep - 1].name
+            ),
+          }
+        )
       }
     )
   }
 
   handleNavClick = (clickedStep: number) => {
     this.setState({currentStep: clickedStep})
+    event(
+      'firstMile.nodejsWizard.subNav.clicked',
+      {},
+      {
+        currentStep: normalizeEventName(
+          HOMEPAGE_NAVIGATION_STEPS[clickedStep - 1].name
+        ),
+      }
+    )
   }
 
   renderStep = () => {

--- a/src/homepageExperience/containers/PythonWizard.tsx
+++ b/src/homepageExperience/containers/PythonWizard.tsx
@@ -64,44 +64,61 @@ export class PythonWizard extends PureComponent<null, State> {
   }
 
   handleNextClick = () => {
-    event(
-      'firstMile.pythonWizard.next.clicked',
-      {},
+    this.setState(
       {
-        clickedButtonAtStep: normalizeEventName(
-          HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep - 1].name
+        currentStep: Math.min(
+          this.state.currentStep + 1,
+          HOMEPAGE_NAVIGATION_STEPS.length
         ),
-        currentStep: normalizeEventName(
-          HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep].name
-        ),
+      },
+      () => {
+        event(
+          'firstMile.pythonWizard.next.clicked',
+          {},
+          {
+            clickedButtonAtStep: normalizeEventName(
+              HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep - 2].name
+            ),
+            currentStep: normalizeEventName(
+              HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep - 1].name
+            ),
+          }
+        )
       }
     )
-    this.setState({
-      currentStep: Math.min(
-        this.state.currentStep + 1,
-        HOMEPAGE_NAVIGATION_STEPS.length
-      ),
-    })
   }
 
   handlePreviousClick = () => {
-    this.setState({currentStep: Math.max(this.state.currentStep - 1, 1)})
-    event(
-      'firstMile.pythonWizard.previous.clicked',
-      {},
-      {
-        clickedButtonAtStep: normalizeEventName(
-          HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep - 1].name
-        ),
-        currentStep: normalizeEventName(
-          HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep - 2].name
-        ),
+    this.setState(
+      {currentStep: Math.max(this.state.currentStep - 1, 1)},
+      () => {
+        event(
+          'firstMile.pythonWizard.previous.clicked',
+          {},
+          {
+            clickedButtonAtStep: normalizeEventName(
+              HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep].name
+            ),
+            currentStep: normalizeEventName(
+              HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep - 1].name
+            ),
+          }
+        )
       }
     )
   }
 
   handleNavClick = (clickedStep: number) => {
     this.setState({currentStep: clickedStep})
+    event(
+      'firstMile.pythonWizard.subNav.clicked',
+      {},
+      {
+        currentStep: normalizeEventName(
+          HOMEPAGE_NAVIGATION_STEPS[clickedStep - 1].name
+        ),
+      }
+    )
   }
 
   renderStep = () => {

--- a/src/homepageExperience/containers/PythonWizard.tsx
+++ b/src/homepageExperience/containers/PythonWizard.tsx
@@ -20,6 +20,7 @@ import {WriteData} from 'src/homepageExperience/components/steps/python/WriteDat
 import {ExecuteQuery} from 'src/homepageExperience/components/steps/python/ExecuteQuery'
 import {Finish} from 'src/homepageExperience/components/steps/Finish'
 import {ExecuteAggregateQuery} from 'src/homepageExperience/components/steps/python/ExecuteAggregateQuery'
+import {normalizeEventName} from 'src/cloud/utils/reporting'
 
 import {PythonIcon} from 'src/homepageExperience/components/HomepageIcons'
 
@@ -63,38 +64,38 @@ export class PythonWizard extends PureComponent<null, State> {
   }
 
   handleNextClick = () => {
-    this.setState(
+    event(
+      'firstMile.pythonWizard.next.clicked',
+      {},
       {
-        currentStep: Math.min(
-          this.state.currentStep + 1,
-          HOMEPAGE_NAVIGATION_STEPS.length
+        clickedButtonAtStep: normalizeEventName(
+          HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep - 1].name
         ),
-      },
-      () => {
-        event(
-          'firstMile.pythonWizard.next.clicked',
-          {},
-          {
-            clickedButtonAtStep: this.state.currentStep - 1,
-            currentStep: this.state.currentStep,
-          }
-        )
+        currentStep: normalizeEventName(
+          HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep].name
+        ),
       }
     )
+    this.setState({
+      currentStep: Math.min(
+        this.state.currentStep + 1,
+        HOMEPAGE_NAVIGATION_STEPS.length
+      ),
+    })
   }
 
   handlePreviousClick = () => {
-    this.setState(
-      {currentStep: Math.max(this.state.currentStep - 1, 1)},
-      () => {
-        event(
-          'firstMile.pythonWizard.previous.clicked',
-          {},
-          {
-            clickedButtonAtStep: this.state.currentStep + 1,
-            currentStep: this.state.currentStep,
-          }
-        )
+    this.setState({currentStep: Math.max(this.state.currentStep - 1, 1)})
+    event(
+      'firstMile.pythonWizard.previous.clicked',
+      {},
+      {
+        clickedButtonAtStep: normalizeEventName(
+          HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep - 1].name
+        ),
+        currentStep: normalizeEventName(
+          HOMEPAGE_NAVIGATION_STEPS[this.state.currentStep - 2].name
+        ),
       }
     )
   }
@@ -209,7 +210,7 @@ export class PythonWizard extends PureComponent<null, State> {
                   size={ComponentSize.Large}
                   color={ComponentColor.Primary}
                   status={
-                    currentStep < 8
+                    currentStep < HOMEPAGE_NAVIGATION_STEPS.length
                       ? ComponentStatus.Default
                       : ComponentStatus.Disabled
                   }


### PR DESCRIPTION
Closes #5469 

Here we plan on changing all wizards to have the same eventing for the next, previous, and nav button clicks. Previously, the Go, Nodejs, and Python wizards all had less descriptive (number of page rather than name) eventing for the next and previous functions and no eventing for the nav clicks. The CLI had a differently structured eventing that was incorrect and led to inconsistencies because of the asynchronous nature of the setState function. This PR plans on standardizing all of them to be the same as the newly updated Arduino eventing.

### Checklist

Authors and Reviewer(s), please verify the following:

- [ ] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [ ] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
