### PR TITLE
fix: add guards to conditional loading in globalheader

### DIFF
--- a/src/identity/components/GlobalHeader/GlobalHeader.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeader.tsx
@@ -79,7 +79,7 @@ export const GlobalHeader: FC = () => {
 
   const shouldLoadDropdowns = activeOrg?.id && activeAccount?.id
   const shouldLoadAvatar =
-    user.firstName && user.lastName && user.email && org.id
+    user?.firstName && user?.lastName && user?.email && org?.id
   const shouldLoadGlobalHeader = shouldLoadDropdowns || shouldLoadAvatar
 
   const caretStyle = {fontSize: '18px', color: InfluxColors.Grey65}


### PR DESCRIPTION
Turning on this FF on in staging shows that some staging environments are hitting an error in globalheader's conditional logic for whether (a) the dropdowns and (b) the avatar should be loaded. 

This can be resolved by adding an optional chaining operator.

Not sure of root cause yet, as this data is provided by default redux states, but could be that environments without quartz are overwriting the value with a null, making the property on the original default object inaccessible.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - `multiOrg`
