### PR TITLE
fix: refactor global header e2e test

### DIFF
--- a/cypress/e2e/cloud/globalHeader.test.ts
+++ b/cypress/e2e/cloud/globalHeader.test.ts
@@ -101,6 +101,7 @@ describe('change-account change-org global header', () => {
       })
 
       it('navigates to the org settings page', () => {
+        makeQuartzUseIDPEOrgID()
         cy.getByTestID('globalheader--org-dropdown')
           .should('be.visible')
           .click()
@@ -116,6 +117,8 @@ describe('change-account change-org global header', () => {
       })
 
       it('navigates to the org members page', () => {
+        makeQuartzUseIDPEOrgID()
+        makeQuartzUseIDPEOrgID()
         cy.getByTestID('globalheader--org-dropdown')
           .should('be.visible')
           .click()
@@ -139,13 +142,14 @@ describe('change-account change-org global header', () => {
         cy.getByTestID('globalheader--org-dropdown-main-Usage')
           .should('be.visible')
           .click()
-        cy.location('pathname').should('eq', `orgs/${idpeOrgID}/usage`)
+        cy.location('pathname').should('eq', `/orgs/${idpeOrgID}/usage`)
         cy.getByTestID('tabs--container')
           .should('be.visible')
           .and('contain', 'Billing Stats')
       })
 
       it('can change change the active org', () => {
+        makeQuartzUseIDPEOrgID()
         cy.getByTestID('globalheader--org-dropdown')
           .should('exist')
           .click()
@@ -212,6 +216,10 @@ describe('change-account change-org global header', () => {
         cy.getByTestID('globalheader--account-dropdown-main-Billing')
           .should('be.visible')
           .click()
+
+        cy.getByTestID('accounts-billing-tab')
+          .should('be.visible')
+          .and('contain', 'Billing')
       })
 
       it('can change change the active account', () => {

--- a/cypress/e2e/cloud/globalHeader.test.ts
+++ b/cypress/e2e/cloud/globalHeader.test.ts
@@ -87,9 +87,8 @@ describe('change-account change-org global header', () => {
       mockQuartzOutage()
       interceptPageReload()
       cy.setFeatureFlags(globalHeaderFeatureFlags).then(() => {
-        cy.wait(500)
         cy.visit('/')
-        cy.wait(['@getQuartzIdentity', '@getQuartzAccounts'])
+        cy.wait('@getQuartzAccounts')
         cy.getByTestID('global-header--container').should('not.exist')
       })
     })

--- a/cypress/e2e/cloud/globalHeader.test.ts
+++ b/cypress/e2e/cloud/globalHeader.test.ts
@@ -101,7 +101,6 @@ describe('change-account change-org global header', () => {
       })
 
       it('navigates to the org settings page', () => {
-        makeQuartzUseIDPEOrgID()
         cy.getByTestID('globalheader--org-dropdown')
           .should('be.visible')
           .click()
@@ -117,7 +116,6 @@ describe('change-account change-org global header', () => {
       })
 
       it('navigates to the org members page', () => {
-        makeQuartzUseIDPEOrgID()
         cy.getByTestID('globalheader--org-dropdown')
           .should('be.visible')
           .click()
@@ -133,7 +131,6 @@ describe('change-account change-org global header', () => {
       })
 
       it('navigates to the org usage page', () => {
-        makeQuartzUseIDPEOrgID()
         cy.getByTestID('globalheader--org-dropdown')
           .should('exist')
           .click()
@@ -142,23 +139,13 @@ describe('change-account change-org global header', () => {
         cy.getByTestID('globalheader--org-dropdown-main-Usage')
           .should('be.visible')
           .click()
-        cy.location('pathname').should('eq', `/orgs/${idpeOrgID}/usage`)
+        cy.location('pathname').should('eq', `orgs/${idpeOrgID}/usage`)
         cy.getByTestID('tabs--container')
           .should('be.visible')
           .and('contain', 'Billing Stats')
       })
 
       it('can change change the active org', () => {
-        makeQuartzUseIDPEOrgID()
-        // No real quartz, so we can't handle this redirect in testing. But we can
-        // intercept the request and send the user to another page to confirm
-        // that we've targeted the right URL.
-        // Other interception methods - like sending back a JSON object on success -
-        // appear to work only in Chrome, and not Firefox.
-        cy.intercept('GET', 'auth/orgs/58fafbb4f68e05e5', req => {
-          req.redirect(`/orgs/${idpeOrgID}/org-settings`)
-        })
-
         cy.getByTestID('globalheader--org-dropdown')
           .should('exist')
           .click()
@@ -176,11 +163,12 @@ describe('change-account change-org global header', () => {
         cy.getByTestID('globalheader--org-dropdown-main--contents')
           .contains('Org 5')
           .should('be.visible')
-          .click()
 
-        cy.getByTestID('tabs--tab-contents')
-          .should('be.visible')
-          .and('contain', 'Organization Profile')
+        // Absent real quartz, testing this redirect will not work, and Firefox doesn't play nicely
+        // with being asked to intercept the route. So expect the org id as the button's id
+        // which is where this component pulls the link from.
+        cy.get('button#58fafbb4f68e05e5').should('contain', 'Test Org 5')
+        cy.getByTestID('globalheader--org-dropdown').click()
       })
     })
 
@@ -228,12 +216,6 @@ describe('change-account change-org global header', () => {
 
       it('can change change the active account', () => {
         makeQuartzUseIDPEOrgID()
-
-        // See earlier comment - cannot handle this quartz redirect, so must intercept.
-        cy.intercept('GET', 'auth/accounts/415', req => {
-          req.redirect(`/orgs/${idpeOrgID}/accounts/settings`)
-        })
-
         cy.getByTestID('globalheader--account-dropdown')
           .should('exist')
           .click()
@@ -253,9 +235,11 @@ describe('change-account change-org global header', () => {
         cy.getByTestID('globalheader--account-dropdown-main--contents')
           .contains('Veganomicon')
           .should('be.visible')
-          .click()
 
-        cy.getByTestID('account-settings--header').should('be.visible')
+        // See earlier comment re: no quartz, so testing based on ID, which generates the URL for
+        // the redirect link in production.
+        cy.get('button#415').should('contain', 'Veganomicon')
+        cy.getByTestID('globalheader--account-dropdown').click()
       })
     })
   })

--- a/cypress/fixtures/multiOrgIdentity.json
+++ b/cypress/fixtures/multiOrgIdentity.json
@@ -1,0 +1,24 @@
+{
+  "user": {
+    "id": "03b0f952abf7e5ce",
+    "email": "test@influxdata.com",
+    "firstName": "Marty",
+    "lastName": "McFly",
+    "operatorRole": null,
+    "accountCount": 2,
+    "orgCount": 20
+  },
+  "org": {
+    "id": "a12eb3c74e6c3azc",
+    "name": "Test Organization",
+    "clusterHost": "https://us-west1.iamzuora.cloud2.influxdata.com"
+  },
+
+  "account": {
+    "id": 416,
+    "name": "Influx",
+    "type": "free",
+    "accountCreatedAt": "Tue Jun 01 2022 08:49:14 GMT-0400 (Eastern Daylight Time)",
+    "billing_provider": "zuora"
+  }
+}

--- a/cypress/fixtures/orgDetails.json
+++ b/cypress/fixtures/orgDetails.json
@@ -1,0 +1,12 @@
+{
+  "id": "03b0f952abf7e5ce",
+  "name": "Test Organization",
+  "description": "A test organization for the new org endpoint.",
+  "creationDate": "2019-08-24T14:15:22Z",
+
+  "regionName": "Oregon",
+  "regionCode": "us-west1",
+  "provider": "AWS",
+  "isRegionBeta": false,
+  "clusterHost": "https://us-west1.iamzuora.cloud2.influxdata.com"
+}


### PR DESCRIPTION
Closes #5498 

Refactors global header e2e test to resolve flakiness, particularly in Firefox.

The primary issue is that Firefox doesn't play well with the work-around for syncing quartz IDs to IDPE IDs that is necessary to use the URIs targeted by global header. I.e., intercepting requests to quartz-mock and replacing the returned org id with the org ID from IDPE.  That works fine in Chrome, but Firefox often generates a network error. Changing the headers and CORS mode doesn't fix it, and we can't change web security settings for Firefox. 

Firefox also doesn't play nice when attempting to intercept calls to `/logout` or the quartz redirects for changing accounts or orgs.

The fix proposed here is to use fixtures mimicking quartz and injecting the IDPE org id into that, instead of trying to intercept the request to quartz-mock in-flight and do the same. 

For links like `/logout`, I've refactored the test to simply check for the validity of the url or ID to be used as a link, in lieu of actually clicking the link (which doesn't send us to the right page without production quartz).

[Passes Chrome (20x) and Firefox (20x). ](https://app.circleci.com/pipelines/github/influxdata/ui/15808/workflows/4c2ff3d0-0f3f-4762-bfa7-b147c89f82d9/jobs/90838)

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - `multiOrg`
