### PR TITLE
fix: user avatar renders a default avatar for users with no name

### DIFF
--- a/src/identity/components/GlobalHeader/GlobalHeader.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeader.tsx
@@ -80,8 +80,10 @@ export const GlobalHeader: FC = () => {
   const shouldLoadDropdowns = Boolean(activeOrg?.id && activeAccount?.id)
 
   const shouldLoadAvatar = Boolean(user?.email && org?.id)
-  const avatarFirstName = user?.firstName ?? ''
-  const avatarLastName = user?.lastName ?? ''
+  const avatarFirstName =
+    typeof user?.firstName === 'string' ? user.firstName.trim() : ''
+  const avatarLastName =
+    typeof user?.lastName === 'string' ? user.lastName.trim() : ''
 
   const shouldLoadGlobalHeader = Boolean(
     shouldLoadDropdowns || shouldLoadAvatar

--- a/src/identity/components/GlobalHeader/GlobalHeader.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeader.tsx
@@ -78,9 +78,11 @@ export const GlobalHeader: FC = () => {
   }, [orgsList])
 
   const shouldLoadDropdowns = Boolean(activeOrg?.id && activeAccount?.id)
-  const shouldLoadAvatar = Boolean(
-    user?.firstName && user?.lastName && user?.email && org?.id
-  )
+
+  const shouldLoadAvatar = Boolean(user?.email && org?.id)
+  const avatarFirstName = user?.firstName ?? ''
+  const avatarLastName = user?.lastName ?? ''
+
   const shouldLoadGlobalHeader = Boolean(
     shouldLoadDropdowns || shouldLoadAvatar
   )
@@ -109,8 +111,8 @@ export const GlobalHeader: FC = () => {
       {shouldLoadAvatar && (
         <IdentityUserAvatar
           email={user.email}
-          firstName={user.firstName}
-          lastName={user.lastName}
+          firstName={avatarFirstName}
+          lastName={avatarLastName}
           orgId={org.id}
         />
       )}

--- a/src/identity/components/GlobalHeader/IdentityUserAvatar.tsx
+++ b/src/identity/components/GlobalHeader/IdentityUserAvatar.tsx
@@ -55,7 +55,7 @@ class IdentityUserAvatar extends React.Component<Props, State> {
       <>
         <div className="user-popover-header">
           <div className="user-popover-header-name">
-            {firstName} {lastName}
+            {firstName ?? null} {lastName ?? null}
           </div>
           <div className="user-popover-header-email">{email}</div>
           <hr />
@@ -94,6 +94,8 @@ class IdentityUserAvatar extends React.Component<Props, State> {
       'user-popover--open': this.state.isPopoverOpen,
     })
 
+    const avatarInitials = this.getInitials()
+
     const {isPopoverOpen} = this.state
     return (
       <ClickOutside onClickOutside={this.setPopoverStateClosed}>
@@ -101,7 +103,7 @@ class IdentityUserAvatar extends React.Component<Props, State> {
           {/* Button shape is ButtonShape.Square to make the height and width the same
             so we can use the border radius to make it a circle  */}
           <Button
-            text={this.getInitials()}
+            text={avatarInitials}
             shape={ButtonShape.Square}
             color={
               isPopoverOpen ? ComponentColor.Default : ComponentColor.Tertiary
@@ -109,7 +111,7 @@ class IdentityUserAvatar extends React.Component<Props, State> {
             onClick={this.togglePopoverState}
             className={userAvatarButtonClassName}
             testID="global-header--user-avatar"
-            icon={!this.getInitials() ? IconFont.User : null}
+            icon={avatarInitials === '' ? IconFont.User : null}
           />
           <FlexBox
             className={userPopoverClassName}


### PR DESCRIPTION
Closes #5520 
Connects #5444, #5494 

If a user doesn't have a `firstName` or `lastName` (`null` or `undefined`), guards around the profile avatar prevent it from loading. We want the avatar to load and render a default image if the user doesn't have a name.

This PR removes the requirement that `firstName` and `lastName` be set before the user avatar renders. If `firstName` or `lastName` are `null` or `undefined`, the values will be set to empty `string`. Here is the new behavior:

- Both names: image using the user's initials is rendered
- Only one name: image using the one initial is rendered
- No names: default image renders.

User Has First and Last Name
--
![Screen Shot 2022-08-25 at 9 22 15 AM](https://user-images.githubusercontent.com/91283923/186677062-0556b49f-6f2b-4b3c-b83a-c4af68d6f009.png)

One Name Null
--
![Screen Shot 2022-08-25 at 9 23 27 AM](https://user-images.githubusercontent.com/91283923/186677246-4876cede-bd6e-4355-8f9f-6cdd8254ec10.png)

One Name Undefined
--
![Screen Shot 2022-08-25 at 9 24 19 AM](https://user-images.githubusercontent.com/91283923/186677283-618f3ad5-50a7-43d1-99b6-a8fefdf40ccf.png)

Both Names Null
--
![Screen Shot 2022-08-25 at 9 25 36 AM](https://user-images.githubusercontent.com/91283923/186677341-6f97bfbf-a4b1-4103-8867-8681e717af25.png)

Both Names Undefined
--

![Screen Shot 2022-08-25 at 9 25 07 AM](https://user-images.githubusercontent.com/91283923/186677309-78162e61-536e-46e5-a58a-b509055ec9ce.png)

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - `multiOrg`
