### PR TITLE
chore: change cert support flag name

### DIFF
--- a/src/writeData/subscriptions/components/CertificateInput.tsx
+++ b/src/writeData/subscriptions/components/CertificateInput.tsx
@@ -240,7 +240,7 @@ const CertificateInput: FC<OwnProps> = ({subscription, updateForm, edit}) => {
     )
   }
 
-  return isFlagEnabled('enableCertificateSupport') ? (
+  return isFlagEnabled('subscriptionsCertificateSupport') ? (
     <NewCertificateInput subscription={subscription} updateForm={updateForm} />
   ) : (
     <OldCertificateInput />


### PR DESCRIPTION
A flag `subscriptionsCertificateSupport` already exists in `idpe`. So, it doesn't make sense to add a new feature flag for the same feature. Changing the name of the flag from `enableCertificateSupport` to `subscriptionsCertificateSupport`.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
