### PR TITLE
fix(multi-org): conditionally applying CSS to page header correctly

### DIFF
--- a/cypress/e2e/shared/simpleTable.test.ts
+++ b/cypress/e2e/shared/simpleTable.test.ts
@@ -53,7 +53,7 @@ describe('simple table interactions', () => {
     // verify correct number of pages
     cy.getByTestID('pagination-item')
       .last()
-      .contains('100')
+      .contains('50')
 
     // show raw data view of data with 10 pages
     cy.getByTestID(`selector-list ${simpleSmall}`).should('be.visible')
@@ -84,7 +84,7 @@ describe('simple table interactions', () => {
       .should('be.visible')
     cy.getByTestID('pagination-item')
       .last()
-      .contains('10')
+      .contains('15')
   })
 
   it('should render correctly after switching from a dataset with fewer pages to one with more', () => {
@@ -117,7 +117,7 @@ describe('simple table interactions', () => {
     // verify correct number of pages
     cy.getByTestID('pagination-item')
       .last()
-      .contains('10')
+      .contains('5')
 
     // show raw data view of data with 100 pages
     cy.getByTestID(`selector-list ${simpleLarge}`).should('be.visible')
@@ -148,7 +148,7 @@ describe('simple table interactions', () => {
       .should('be.visible')
     cy.getByTestID('pagination-item')
       .last()
-      .contains('100')
+      .contains('150')
   })
 
   it('should not duplicate records from the n-1 page on the nth page', () => {
@@ -181,7 +181,7 @@ describe('simple table interactions', () => {
     // verify correct number of pages
     cy.getByTestID('pagination-item')
       .last()
-      .contains('11')
+      .contains('6')
     // verify only record 31 is on last page
     cy.getByTestID('table-cell 30').should('not.exist')
     cy.getByTestID('table-cell 31').should('be.visible')
@@ -229,8 +229,8 @@ describe('simple table interactions', () => {
     cy.getByTestID('pagination-item')
       .eq(3)
       .click()
-    cy.getByTestID('table-cell 26').should('be.visible')
     cy.getByTestID('table-cell 27').should('be.visible')
+    cy.getByTestID('table-cell 28').should('be.visible')
     cy.getByTestID('pagination-item')
       .last()
       .click()
@@ -239,8 +239,8 @@ describe('simple table interactions', () => {
     cy.getByTestID('pagination-item')
       .eq(2)
       .click()
-    cy.getByTestID('table-cell 23').should('be.visible')
-    cy.getByTestID('table-cell 24').should('be.visible')
+    cy.getByTestID('table-cell 25').should('be.visible')
+    cy.getByTestID('table-cell 26').should('be.visible')
     cy.getByTestID('pagination-item')
       .last()
       .click()
@@ -249,8 +249,8 @@ describe('simple table interactions', () => {
     cy.getByTestID('pagination-item')
       .eq(1)
       .click()
-    cy.getByTestID('table-cell 20').should('be.visible')
-    cy.getByTestID('table-cell 21').should('be.visible')
+    cy.getByTestID('table-cell 23').should('be.visible')
+    cy.getByTestID('table-cell 24').should('be.visible')
     cy.getByTestID('pagination-item')
       .last()
       .click()

--- a/cypress/e2e/shared/simpleTable.test.ts
+++ b/cypress/e2e/shared/simpleTable.test.ts
@@ -8,7 +8,7 @@ describe('simple table interactions', () => {
   beforeEach(() => {
     cy.flush()
     cy.signin()
-    cy.setFeatureFlags({multiOrg: true}).then(() => {
+    cy.setFeatureFlags({multiOrg: true, quartzIdentity: true}).then(() => {
       cy.get('@org').then(({id: orgID}: Organization) => {
         cy.fixture('routes').then(({orgs, explorer}) => {
           cy.visit(`${orgs}/${orgID}${explorer}`)

--- a/cypress/e2e/shared/simpleTable.test.ts
+++ b/cypress/e2e/shared/simpleTable.test.ts
@@ -8,18 +8,20 @@ describe('simple table interactions', () => {
   beforeEach(() => {
     cy.flush()
     cy.signin()
-    cy.get('@org').then(({id: orgID}: Organization) => {
-      cy.fixture('routes').then(({orgs, explorer}) => {
-        cy.visit(`${orgs}/${orgID}${explorer}`)
+    cy.setFeatureFlags({multiOrg: true}).then(() => {
+      cy.get('@org').then(({id: orgID}: Organization) => {
+        cy.fixture('routes').then(({orgs, explorer}) => {
+          cy.visit(`${orgs}/${orgID}${explorer}`)
+        })
+        cy.getByTestID('tree-nav')
+        cy.createBucket(orgID, name, simpleLarge)
+        cy.writeData(points(300), simpleLarge)
+        cy.createBucket(orgID, name, simpleSmall)
+        cy.writeData(points(30), simpleSmall)
+        cy.createBucket(orgID, name, simpleOverflow)
+        cy.writeData(points(31), simpleOverflow)
+        cy.reload()
       })
-      cy.getByTestID('tree-nav')
-      cy.createBucket(orgID, name, simpleLarge)
-      cy.writeData(points(300), simpleLarge)
-      cy.createBucket(orgID, name, simpleSmall)
-      cy.writeData(points(30), simpleSmall)
-      cy.createBucket(orgID, name, simpleOverflow)
-      cy.writeData(points(31), simpleOverflow)
-      cy.reload()
     })
   })
 

--- a/cypress/e2e/shared/simpleTable.test.ts
+++ b/cypress/e2e/shared/simpleTable.test.ts
@@ -8,20 +8,18 @@ describe('simple table interactions', () => {
   beforeEach(() => {
     cy.flush()
     cy.signin()
-    cy.setFeatureFlags({multiOrg: true, quartzIdentity: true}).then(() => {
-      cy.get('@org').then(({id: orgID}: Organization) => {
-        cy.fixture('routes').then(({orgs, explorer}) => {
-          cy.visit(`${orgs}/${orgID}${explorer}`)
-        })
-        cy.getByTestID('tree-nav')
-        cy.createBucket(orgID, name, simpleLarge)
-        cy.writeData(points(300), simpleLarge)
-        cy.createBucket(orgID, name, simpleSmall)
-        cy.writeData(points(30), simpleSmall)
-        cy.createBucket(orgID, name, simpleOverflow)
-        cy.writeData(points(31), simpleOverflow)
-        cy.reload()
+    cy.get('@org').then(({id: orgID}: Organization) => {
+      cy.fixture('routes').then(({orgs, explorer}) => {
+        cy.visit(`${orgs}/${orgID}${explorer}`)
       })
+      cy.getByTestID('tree-nav')
+      cy.createBucket(orgID, name, simpleLarge)
+      cy.writeData(points(300), simpleLarge)
+      cy.createBucket(orgID, name, simpleSmall)
+      cy.writeData(points(30), simpleSmall)
+      cy.createBucket(orgID, name, simpleOverflow)
+      cy.writeData(points(31), simpleOverflow)
+      cy.reload()
     })
   })
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,7 +52,7 @@ const App: FC = () => {
 
   const appWrapperClass = classnames('', {
     'dashboard-light-mode': currentPage === 'dashboard' && theme === 'light',
-    'multi-org': isFlagEnabled('multiOrg')
+    'multi-org': isFlagEnabled('multiOrg'),
   })
 
   useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,10 +42,8 @@ import {CLOUD} from 'src/shared/constants'
 import {shouldUseQuartzIdentity} from 'src/identity/utils/shouldUseQuartzIdentity'
 import {executeVWO} from 'src/utils/vwo'
 
-if (isFlagEnabled('multiOrg')) {
-  require('./MultiOrgOverrideStyles.scss')
-}
 // Styles
+import './MultiOrgOverrideStyles.scss'
 const fullScreen = {height: '100%', width: '100%'}
 
 const App: FC = () => {
@@ -54,6 +52,7 @@ const App: FC = () => {
 
   const appWrapperClass = classnames('', {
     'dashboard-light-mode': currentPage === 'dashboard' && theme === 'light',
+    'multi-org': isFlagEnabled('multiOrg')
   })
 
   useEffect(() => {

--- a/src/MultiOrgOverrideStyles.scss
+++ b/src/MultiOrgOverrideStyles.scss
@@ -1,4 +1,4 @@
-.cf-page-header {
+.multi-org .cf-page-header {
   height: 45px !important;
   flex: 0 0 45px !important;
   margin-bottom: 12px !important;


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/5431

Instead of conditionally importing the CSS file, we're conditionally _applying_ the styles to the header. This is much more reliable way of doing it. 

Solution credit: @hoorayimhelping 


https://user-images.githubusercontent.com/18511823/186476969-f181f685-73ab-4011-a3f7-f327eb68a2b5.mov



<!-- Describe your proposed changes here. -->
<!-- Including screenshots or visuals is very helpful - a picture is worth a thousand words. -->

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
