### PR TITLE
fix: force null return from global header until all values loaded

### DIFF
--- a/src/identity/components/GlobalHeader/GlobalHeader.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeader.tsx
@@ -77,42 +77,40 @@ export const GlobalHeader: FC = () => {
     }
   }, [orgsList])
 
-  const shouldLoadDropdowns = activeOrg?.id && activeAccount?.id
+  const shouldLoadDropdowns = !!activeOrg?.id && !!activeAccount?.id
   const shouldLoadAvatar =
-    user?.firstName && user?.lastName && user?.email && org?.id
-  const shouldLoadGlobalHeader = shouldLoadDropdowns || shouldLoadAvatar
+    !!user?.firstName && !!user?.lastName && !!user?.email && !!org?.id
+  const shouldLoadGlobalHeader = !!shouldLoadDropdowns || !!shouldLoadAvatar
 
   const caretStyle = {fontSize: '18px', color: InfluxColors.Grey65}
 
-  return (
-    shouldLoadGlobalHeader && (
-      <FlexBox
-        className="multiaccountorg--header"
-        justifyContent={JustifyContent.SpaceBetween}
-        margin={ComponentSize.Large}
-        testID="global-header--container"
-      >
-        {shouldLoadDropdowns && (
-          <FlexBox margin={ComponentSize.Medium}>
-            <AccountDropdown
-              activeAccount={activeAccount}
-              activeOrg={activeOrg}
-              accountsList={sortedAccounts}
-            />
-            <Icon glyph={IconFont.CaretOutlineRight} style={caretStyle} />
-            <OrgDropdown activeOrg={activeOrg} orgsList={sortedOrgs} />
-          </FlexBox>
-        )}
-
-        {shouldLoadAvatar && (
-          <IdentityUserAvatar
-            email={user.email}
-            firstName={user.firstName}
-            lastName={user.lastName}
-            orgId={org.id}
+  return !!shouldLoadGlobalHeader ? (
+    <FlexBox
+      className="multiaccountorg--header"
+      justifyContent={JustifyContent.SpaceBetween}
+      margin={ComponentSize.Large}
+      testID="global-header--container"
+    >
+      {shouldLoadDropdowns && (
+        <FlexBox margin={ComponentSize.Medium}>
+          <AccountDropdown
+            activeAccount={activeAccount}
+            activeOrg={activeOrg}
+            accountsList={sortedAccounts}
           />
-        )}
-      </FlexBox>
-    )
-  )
+          <Icon glyph={IconFont.CaretOutlineRight} style={caretStyle} />
+          <OrgDropdown activeOrg={activeOrg} orgsList={sortedOrgs} />
+        </FlexBox>
+      )}
+
+      {shouldLoadAvatar && (
+        <IdentityUserAvatar
+          email={user.email}
+          firstName={user.firstName}
+          lastName={user.lastName}
+          orgId={org.id}
+        />
+      )}
+    </FlexBox>
+  ) : null
 }

--- a/src/identity/components/GlobalHeader/GlobalHeader.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeader.tsx
@@ -77,14 +77,18 @@ export const GlobalHeader: FC = () => {
     }
   }, [orgsList])
 
-  const shouldLoadDropdowns = !!activeOrg?.id && !!activeAccount?.id
-  const shouldLoadAvatar =
-    !!user?.firstName && !!user?.lastName && !!user?.email && !!org?.id
-  const shouldLoadGlobalHeader = !!shouldLoadDropdowns || !!shouldLoadAvatar
+  const shouldLoadDropdowns = !!(activeOrg?.id && activeAccount?.id)
+  const shouldLoadAvatar = !!(
+    user?.firstName &&
+    user?.lastName &&
+    user?.email &&
+    org?.id
+  )
+  const shouldLoadGlobalHeader = !!(shouldLoadDropdowns || shouldLoadAvatar)
 
   const caretStyle = {fontSize: '18px', color: InfluxColors.Grey65}
 
-  return !!shouldLoadGlobalHeader ? (
+  return shouldLoadGlobalHeader ? (
     <FlexBox
       className="multiaccountorg--header"
       justifyContent={JustifyContent.SpaceBetween}

--- a/src/identity/components/GlobalHeader/GlobalHeader.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeader.tsx
@@ -77,14 +77,13 @@ export const GlobalHeader: FC = () => {
     }
   }, [orgsList])
 
-  const shouldLoadDropdowns = !!(activeOrg?.id && activeAccount?.id)
-  const shouldLoadAvatar = !!(
-    user?.firstName &&
-    user?.lastName &&
-    user?.email &&
-    org?.id
+  const shouldLoadDropdowns = Boolean(activeOrg?.id && activeAccount?.id)
+  const shouldLoadAvatar = Boolean(
+    user?.firstName && user?.lastName && user?.email && org?.id
   )
-  const shouldLoadGlobalHeader = !!(shouldLoadDropdowns || shouldLoadAvatar)
+  const shouldLoadGlobalHeader = Boolean(
+    shouldLoadDropdowns || shouldLoadAvatar
+  )
 
   const caretStyle = {fontSize: '18px', color: InfluxColors.Grey65}
 


### PR DESCRIPTION
Closes #5526

This fixes a bug where globalheader could throw minified react error #152 - `Nothing was returned from render.` This was identified in Electron environments in staging, but I'm able to reproduce it elsewhere by manually setting values associated with the user's identity to `undefined`.

The cause of the issue is that the expressions used for checking whether the data associated with the header and user avatar weren't type cast to `boolean`.

When at least one element in _both_ the guards against loading the avatar and dropdown was `undefined` - for example, when the optional chaining operator cast the value to `undefined` because the property didn't exist yet - `shouldLoadGlobalHeader` also evaluated to undefined, a value that the functional component can't return, throwing an error before the user-associated data loaded.

The fix type casts to `boolean` each of the guards against loading the dropdowns; avatar; and header, and explicitly forces a `null` return if the header should not yet load.

Pre-Fix: Error thrown before header loads
--
![Screen Shot 2022-08-24 at 4 18 38 PM](https://user-images.githubusercontent.com/91283923/186519500-3d11a322-0107-4719-896f-84325480f642.png)


Post-Fix: Header only loads after all values present
--
Pre-load - some values still `undefined`
![Screen Shot 2022-08-24 at 4 47 04 PM](https://user-images.githubusercontent.com/91283923/186520456-b45059cb-632e-4822-8651-eb1f39f78865.png)

Post-load
![Screen Shot 2022-08-24 at 4 47 49 PM](https://user-images.githubusercontent.com/91283923/186520463-a055d721-5ed5-4372-a465-c2ec55234975.png)


### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - `multiOrg`
