### PR TITLE
feat(schemaBrowser): add disable logic to "Flux Sync" toggle

### DIFF
--- a/src/dataExplorer/components/SchemaBrowserHeading.tsx
+++ b/src/dataExplorer/components/SchemaBrowserHeading.tsx
@@ -12,13 +12,20 @@ import SelectorTitle from 'src/dataExplorer/components/SelectorTitle'
 
 // Context
 import {FluxQueryBuilderContext} from 'src/dataExplorer/context/fluxQueryBuilder'
+import {PersistanceContext} from 'src/dataExplorer/context/persistance'
 
 const FLUX_SYNC_TOOLTIP = `Flux Sync autopopulates the script editor to help you \
 start a query. You can turn this feature on and off, but typing within this \
 section will disable synchronization.`
 
+const FLUX_SYNC_DISABLE_TEXT = `Schema Sync is no longer available because the \
+code block has been edited.`
+
 const SchemaBrowserHeading: FC = () => {
   const {fluxSync, toggleFluxSync} = useContext(FluxQueryBuilderContext)
+  const {selection} = useContext(PersistanceContext)
+
+  const disableToggle: boolean = selection.composition?.diverged
 
   const handleFluxSyncToggle = () => {
     toggleFluxSync(!fluxSync)
@@ -37,6 +44,8 @@ const SchemaBrowserHeading: FC = () => {
             active={fluxSync}
             onChange={handleFluxSyncToggle}
             testID="flux-sync--toggle"
+            disabled={disableToggle}
+            tooltipText={disableToggle ? FLUX_SYNC_DISABLE_TEXT : ''}
           />
           <InputLabel className="flux-sync--label">
             <SelectorTitle


### PR DESCRIPTION
Closes #5536 

This PR adds the disable logic and hover tooltip to the "Flux Sync" toggle. 

This change is behind the feature flag `schemaComposition`.

## After

https://user-images.githubusercontent.com/14298407/186526032-6a599b2f-f97d-457d-9737-d6d73e88898b.mov




### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
~~- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~~
- [x] Feature flagged, if applicable
