### PR TITLE
fix(5342): with flux-LSP composition released, test and debug coordination (UI vs LSP vs editor)

### DIFF
--- a/src/dataExplorer/components/SchemaBrowserHeading.tsx
+++ b/src/dataExplorer/components/SchemaBrowserHeading.tsx
@@ -57,7 +57,7 @@ const SchemaBrowserHeading: FC = () => {
         </FlexBox>
       </FlexBox>
     ),
-    [fluxSync]
+    [fluxSync, toggleFluxSync]
   )
 }
 

--- a/src/dataExplorer/context/fluxQueryBuilder.tsx
+++ b/src/dataExplorer/context/fluxQueryBuilder.tsx
@@ -261,6 +261,8 @@ export const FluxQueryBuilderProvider: FC = ({children}) => {
 
       // Schema
       selection,
+      selection.fields,
+      selection.tagValues,
       searchTerm,
 
       children,

--- a/src/dataExplorer/context/persistance.tsx
+++ b/src/dataExplorer/context/persistance.tsx
@@ -3,7 +3,6 @@ import {TimeRange, RecursivePartial} from 'src/types'
 import {DEFAULT_TIME_RANGE} from 'src/shared/constants/timeRanges'
 import {useSessionStorage} from 'src/dataExplorer/shared/utils'
 import {Bucket, TagKeyValuePair} from 'src/types'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {
   RESOURCES,
   ResourceConnectedQuery,
@@ -100,11 +99,7 @@ export const PersistanceProvider: FC = ({children}) => {
 
   const setSchemaSelection = useCallback(
     schema => {
-      if (
-        isFlagEnabled('schemaComposition') &&
-        selection.composition?.diverged
-      ) {
-        // TODO: how message to user?
+      if (selection.composition?.diverged && schema.composition.synced) {
         return
       }
       const nextState: SchemaSelection = {
@@ -117,7 +112,7 @@ export const PersistanceProvider: FC = ({children}) => {
       }
       setSelection(nextState)
     },
-    [selection, selection.composition, setSelection]
+    [selection.composition, selection.fields, selection.tagValues, setSelection]
   )
 
   const save = () => {

--- a/src/languageSupport/languages/flux/lsp/connection.ts
+++ b/src/languageSupport/languages/flux/lsp/connection.ts
@@ -415,9 +415,12 @@ class LspConnectionManager {
       ...this._session,
       composition: {...this._session?.composition},
     }
-    // always update size of block denoted in the UI styles.
-    // Even if it's an unsynced block. (e.g. we are turning off the sync style)
+
+    // Even when not synced:
+    // 1. update styles (e.g. turn off synced style, if not unsynced)
+    // 2. update block sync toggle state, using this._session.composition.synced
     if (previousState.composition != schema.composition) {
+      this._session.composition = {...schema.composition}
       this._setEditorBlockStyle(schema)
     }
 

--- a/src/languageSupport/languages/flux/lsp/utils.ts
+++ b/src/languageSupport/languages/flux/lsp/utils.ts
@@ -71,9 +71,17 @@ export interface ExecuteCommandInjectTagValue extends ExecuteCommandInjectTag {
 
 export type ExecuteCommandInjectField = ExecuteCommandInjectMeasurement
 
-export interface ExecuteCommandCompositionInit {
+export interface CompositionInitParams {
   bucket: string
   measurement?: string
+}
+
+interface CompositionValueParams extends ExecuteCommandParams {
+  value: string
+}
+
+interface CompositionTagValueParams extends CompositionValueParams {
+  tag: string
 }
 
 export type ExecuteCommandArgument =
@@ -81,13 +89,20 @@ export type ExecuteCommandArgument =
   | ExecuteCommandInjectTag
   | ExecuteCommandInjectTagValue
   | ExecuteCommandInjectField
-  | ExecuteCommandCompositionInit
+  | CompositionInitParams
+  | CompositionValueParams
 
 export type ExecuteCommandT =
   | [ExecuteCommand.InjectionMeasurement, ExecuteCommandInjectMeasurement]
   | [ExecuteCommand.InjectTag, ExecuteCommandInjectTag]
   | [ExecuteCommand.InjectTagValue, ExecuteCommandInjectTagValue]
   | [ExecuteCommand.InjectField, ExecuteCommandInjectField]
+  | [ExecuteCommand.CompositionInit, CompositionInitParams]
+  | [ExecuteCommand.CompositionAddMeasurement, CompositionValueParams]
+  | [ExecuteCommand.CompositionAddField, CompositionValueParams]
+  | [ExecuteCommand.CompositionRemoveField, CompositionValueParams]
+  | [ExecuteCommand.CompositionAddTagValue, CompositionTagValueParams]
+  | [ExecuteCommand.CompositionRemoveTagValue, CompositionTagValueParams]
 
 function validateExecuteCommandPayload([command, arg]: ExecuteCommandT):
   | boolean
@@ -113,6 +128,15 @@ function validateExecuteCommandPayload([command, arg]: ExecuteCommandT):
         checkIsString(arg, 'name') &&
         checkIsString(arg, 'value')
       )
+    case ExecuteCommand.CompositionInit:
+      return checkIsString(arg, 'bucket')
+    case ExecuteCommand.CompositionAddMeasurement:
+    case ExecuteCommand.CompositionAddField:
+    case ExecuteCommand.CompositionRemoveField:
+      return checkIsString(arg, 'value')
+    case ExecuteCommand.CompositionAddTagValue:
+    case ExecuteCommand.CompositionRemoveTagValue:
+      return checkIsString(arg, 'tag') && checkIsString(arg, 'value')
     default:
       throw new Error(`unrecognized ExecuteCommand`)
   }
@@ -153,5 +177,10 @@ export enum ExecuteCommand {
   InjectField = 'injectFieldFilter',
   InjectTag = 'injectTagFilter',
   InjectTagValue = 'injectTagValueFilter',
-  CompositionInit = 'composition/initialize',
+  CompositionInit = 'fluxComposition/initialize',
+  CompositionAddMeasurement = 'fluxComposition/addMeasurementFilter',
+  CompositionAddField = 'fluxComposition/addFieldFilter',
+  CompositionRemoveField = 'fluxComposition/removeFieldFilter',
+  CompositionAddTagValue = 'fluxComposition/addTagValueFilter',
+  CompositionRemoveTagValue = 'fluxComposition/removeTagValueFilter',
 }

--- a/src/shared/contexts/editor/index.tsx
+++ b/src/shared/contexts/editor/index.tsx
@@ -66,14 +66,14 @@ export const EditorProvider: FC = ({children}) => {
   const injectViaLsp = useCallback(
     (cmd, data: Omit<ExecuteCommandArgument, 'textDocument'>) => {
       try {
-        if (connection.current && !isFlagEnabled('schemaComposition')) {
+        if (connection?.current && !isFlagEnabled('schemaComposition')) {
           connection.current.inject(cmd, data)
         }
       } catch (e) {
         console.error(e)
       }
     },
-    [editor, connection]
+    [editor, connection?.current]
   )
 
   const inject = useCallback(


### PR DESCRIPTION
Fix for #5342 
Closes #5539 


## Vid:

https://user-images.githubusercontent.com/10232835/186798228-77e5bf25-d45b-4d2a-817b-f0c8ecc76711.mp4




## Tasks Done:
- [x] found and fixed race conditions:
  * on page reload with existing schema composition:
      1. LspConnectionManager detects the schema, and sends jsonrpc to init the composition
      2. editor has not yet sent the `didOpen` for the file
      3. the schema composition init will fail, on no File being found yet.
  * on re-syncing, (or reload) with existing schema composition:
      1. all the executeCommands get sent to the Lsp too fast.
      2. Lsp spec assumes atomic changes, without a reliance on order.
           *composition looks at most recent text....and then make the applyEdit.
          * so our next read (of the current text), must occur after the previous edit has been applied
- [x] fix bugs with previous code:
  * need to resize the `clickableInvisibleDiv` each time we update the block size:
      1. change in editor text (or other event) triggers `this._setEditorBlockStyle()`
      5. it recalcs the size of the current composition block
      6. we then need to resize the `clickableInvisibleDiv` --> `this._alignInvisibleDivToEditorBlock()`
  * when no composition block is present:
      * `this._getCompositionBlockLines()` should return null. NOT a block size of 1 (on the first line).
      * Have downstream consumers of this^^ method, handle the null case.
- [x] make change per request of design:
  * when we have diverged and can no longer sync --> remove all block styles