### PR TITLE
feat: adding generic resource interface

### DIFF
--- a/src/dataExplorer/components/DataExplorerPage.tsx
+++ b/src/dataExplorer/components/DataExplorerPage.tsx
@@ -23,6 +23,7 @@ import SaveAsOverlay from 'src/dataExplorer/components/SaveAsOverlay'
 import ViewTypeDropdown from 'src/timeMachine/components/ViewTypeDropdown'
 import {AddAnnotationDEOverlay} from 'src/overlays/components/index'
 import {EditAnnotationDEOverlay} from 'src/overlays/components/index'
+import TemplatePage from 'src/dataExplorer/components/resources/TemplatePage'
 
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
@@ -67,6 +68,10 @@ const DataExplorerPage: FC = () => {
   return (
     <Page titleTag={pageTitleSuffixer(['Data Explorer'])}>
       <Switch>
+        <Route
+          path="/orgs/:orgID/data-explorer/from"
+          component={TemplatePage}
+        />
         <Route
           path="/orgs/:orgID/data-explorer/save"
           component={SaveAsOverlay}

--- a/src/dataExplorer/components/resources/TemplatePage.tsx
+++ b/src/dataExplorer/components/resources/TemplatePage.tsx
@@ -1,0 +1,65 @@
+import React, {FC, useEffect, useState, useContext} from 'react'
+import {useSelector} from 'react-redux'
+import {Switch, Route, useHistory, useParams} from 'react-router-dom'
+import {RemoteDataState} from 'src/types'
+
+import {getOrg} from 'src/organizations/selectors'
+
+import {RESOURCES} from 'src/dataExplorer/components/resources'
+import {
+  PersistanceContext,
+  PersistanceProvider,
+} from 'src/dataExplorer/context/persistance'
+
+const Template: FC = () => {
+  const {setQuery, setResource} = useContext(PersistanceContext)
+  const params = useParams()[0].split('/')
+  const org = useSelector(getOrg)
+  const history = useHistory()
+  const [loading, setLoading] = useState(RemoteDataState.NotStarted)
+
+  if (!params[0].endsWith('s')) {
+    params[0] += 's'
+  }
+
+  useEffect(() => {
+    if (!RESOURCES[params[0]] || RESOURCES[params[0]].disabled) {
+      setLoading(RemoteDataState.Error)
+      return
+    }
+
+    if (loading !== RemoteDataState.NotStarted) {
+      return
+    }
+
+    setLoading(RemoteDataState.Loading)
+    setQuery('')
+    setResource(null)
+
+    RESOURCES[params[0]].init.apply(this, params.slice(1)).then(data => {
+      setQuery(data.flux)
+      setResource(data)
+      history.replace(`/orgs/${org.id}/data-explorer`)
+    })
+  }, [params])
+
+  return <div></div>
+}
+
+const TemplatePage: FC = () => {
+  const org = useSelector(getOrg)
+
+  return (
+    <PersistanceProvider>
+      <Switch>
+        <Route
+          path={`/orgs/${org.id}/data-explorer/from/*`}
+          component={Template}
+        />
+        <Route component={() => <div />} />
+      </Switch>
+    </PersistanceProvider>
+  )
+}
+
+export default TemplatePage

--- a/src/dataExplorer/components/resources/index.ts
+++ b/src/dataExplorer/components/resources/index.ts
@@ -1,0 +1,38 @@
+import {ReactNode} from 'react'
+import {ResourceType} from 'src/types/resources'
+
+export interface ResourceConnectedQuery<T> {
+  type: ResourceType
+  flux: string
+  data: T
+}
+
+export interface ResourceRegistration {
+  type: ResourceType
+  disabled?: boolean
+  editor: ReactNode
+  init: (...args: string[]) => Promise<ResourceConnectedQuery<any>>
+  persist: (
+    query: ResourceConnectedQuery<any>
+  ) => Promise<ResourceConnectedQuery<any>>
+}
+
+interface Resources {
+  [type: string]: ResourceRegistration
+}
+
+export const RESOURCES: Resources = {}
+  // eslint-disable-next-line no-extra-semi
+;[].forEach(mod => {
+  mod.default((def: ResourceRegistration) => {
+    if (RESOURCES.hasOwnProperty(def.type)) {
+      throw new Error(
+        `Resource of type [${def.type}] has already been registered`
+      )
+    }
+
+    RESOURCES[def.type] = {
+      ...def,
+    }
+  })
+})

--- a/src/types/resources.ts
+++ b/src/types/resources.ts
@@ -36,6 +36,7 @@ export enum ResourceType {
   Plugins = 'plugins',
   Scrapers = 'scrapers',
   Secrets = 'secrets',
+  Scripts = 'scripts',
   Tasks = 'tasks',
   Templates = 'templates',
   Telegrafs = 'telegrafs',


### PR DESCRIPTION
part of the split up of the giant save/load pr (found here: https://github.com/influxdata/ui/pull/5540/files).

In this chapter, we add a generic `/from` templating system for the new data explorer that'll allow us to load any registered resource into the new flux editor and save it out again.
