### PR TITLE
chore: update clockface to 6.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
   "dependencies": {
     "@codingame/monaco-jsonrpc": "^0.3.1",
     "@docsearch/react": "^3.0.0-alpha.37",
-    "@influxdata/clockface": "^6.1.1",
+    "@influxdata/clockface": "^6.3.0",
     "@influxdata/flux-lsp-browser": "0.8.29",
     "@influxdata/giraffe": "^2.33.5",
     "@influxdata/influxdb-templates": "0.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1508,10 +1508,10 @@
     gud "^1.0.0"
     warning "^4.0.3"
 
-"@influxdata/clockface@^6.1.1":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-6.1.1.tgz#1af121883cd3fa6c2310559b3cb4a33a4cdc2f34"
-  integrity sha512-mImBIjE+1K5KWZBUI+tHbwFLE/qUFj9NqDrt4S9UiHR+6AiGNocZNLfi0gVSJihjYE0p5uYPS7CSCRrAfRiKjg==
+"@influxdata/clockface@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-6.3.0.tgz#92baecff3f9ee23ddf1e44eeb7cb828e6ceba633"
+  integrity sha512-+3tQbgwDtbfhQJa6OnO5lJS8D+1/FFIfpVxTHU4oR/oiebGJAOkuLmB7G7S3a515HL3HNhcy323zkWT3IPBQrQ==
   dependencies:
     "@types/react-window" "^1.8.5"
     react-window "^1.8.7"


### PR DESCRIPTION
Update clockface version to 6.3.0 release https://github.com/influxdata/clockface/releases/tag/v6.3.0

This brings in new Sync icon and the collapse functionality in the Draggable Resizer Component.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
~~- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~~
~~- [ ] Feature flagged, if applicable~~
