### PR TITLE
feat: add generic script loader

### DIFF
--- a/src/dataExplorer/components/resources/index.ts
+++ b/src/dataExplorer/components/resources/index.ts
@@ -23,7 +23,7 @@ interface Resources {
 
 export const RESOURCES: Resources = {}
   // eslint-disable-next-line no-extra-semi
-;[].forEach(mod => {
+;[require('./types/script')].forEach(mod => {
   mod.default((def: ResourceRegistration) => {
     if (RESOURCES.hasOwnProperty(def.type)) {
       throw new Error(

--- a/src/dataExplorer/components/resources/types/script/editor.tsx
+++ b/src/dataExplorer/components/resources/types/script/editor.tsx
@@ -1,0 +1,3 @@
+import React from 'react'
+
+export default () => <h1>script editor</h1>

--- a/src/dataExplorer/components/resources/types/script/index.ts
+++ b/src/dataExplorer/components/resources/types/script/index.ts
@@ -1,6 +1,6 @@
 import {ResourceType} from 'src/types/resources'
 import editor from './editor'
-import {getScript, patchScript, postScript} from 'src/client/scriptsRoutes.ts'
+import {getScript, patchScript, postScript} from 'src/client/scriptsRoutes'
 
 export default function script(register) {
   register({

--- a/src/dataExplorer/components/resources/types/script/index.ts
+++ b/src/dataExplorer/components/resources/types/script/index.ts
@@ -1,0 +1,61 @@
+import {ResourceType} from 'src/types/resources'
+import editor from './editor'
+import {getScript, patchScript, postScript} from 'src/client/scriptsRoutes.ts'
+
+export default function script(register) {
+  register({
+    type: ResourceType.Scripts,
+    editor,
+    init: id => {
+      if (!id) {
+        return Promise.resolve({
+          type: ResourceType.Scripts,
+          flux: '',
+          data: {
+            name: `Untitled Script: ${new Date().toISOString()}`,
+            description: 'default description',
+          },
+        })
+      }
+
+      return getScript({
+        scriptID: id,
+      }).then(resp => {
+        return {
+          type: ResourceType.Scripts,
+          flux: resp.script,
+          data: resp,
+        }
+      })
+    },
+    persist: resource => {
+      const data = JSON.parse(JSON.stringify(resource.data))
+      data.script = resource.flux
+
+      if (data.id) {
+        return patchScript({
+          scriptID: data.id,
+          description: data.description,
+          script: data.script,
+        }).then(() => {
+          return resource
+        })
+      }
+
+      return postScript({
+        name: data.name,
+        description: data.description,
+        script: data.script,
+        language: 'flux',
+      }).then(resp => {
+        return {
+          ...resource,
+          data: {
+            ...data,
+            id: resp.id,
+          },
+        }
+      })
+    },
+  })
+}

--- a/src/dataExplorer/components/resources/types/script/index.ts
+++ b/src/dataExplorer/components/resources/types/script/index.ts
@@ -1,6 +1,6 @@
 import {ResourceType} from 'src/types/resources'
 import editor from './editor'
-import {getScript, patchScript, postScript} from 'src/client/scriptsRoutes'
+import * as api from 'src/client/scriptsRoutes'
 
 export default function script(register) {
   register({
@@ -18,44 +18,70 @@ export default function script(register) {
         })
       }
 
-      return getScript({
-        scriptID: id,
-      }).then(resp => {
-        return {
-          type: ResourceType.Scripts,
-          flux: resp.script,
-          data: resp,
-        }
-      })
+      return api
+        .getScript({
+          scriptID: id,
+        })
+        .then(resp => {
+          if (resp.status === 200) {
+            return {
+              type: ResourceType.Scripts,
+              flux: resp.data.script,
+              data: resp.data,
+            }
+          }
+
+          return {
+            type: ResourceType.Scripts,
+            flux: '',
+            data: {
+              name: `Untitled Script: ${new Date().toISOString()}`,
+              description: 'default description',
+            },
+          }
+        })
     },
     persist: resource => {
       const data = JSON.parse(JSON.stringify(resource.data))
       data.script = resource.flux
 
       if (data.id) {
-        return patchScript({
-          scriptID: data.id,
-          description: data.description,
-          script: data.script,
-        }).then(() => {
-          return resource
-        })
+        return api
+          .patchScript({
+            scriptID: data.id,
+            data: {
+              name: data.name,
+              description: data.description,
+              script: data.script,
+            },
+          })
+          .then(() => {
+            return resource
+          })
       }
 
-      return postScript({
-        name: data.name,
-        description: data.description,
-        script: data.script,
-        language: 'flux',
-      }).then(resp => {
-        return {
-          ...resource,
+      return api
+        .postScript({
           data: {
-            ...data,
-            id: resp.id,
+            name: data.name,
+            description: data.description,
+            script: data.script,
+            language: 'flux',
           },
-        }
-      })
+        })
+        .then(resp => {
+          if (resp.status === 201) {
+            return {
+              ...resource,
+              data: {
+                ...data,
+                id: resp.data.id,
+              },
+            }
+          }
+
+          return resource
+        })
     },
   })
 }

--- a/src/dataExplorer/components/resources/types/script/index.ts
+++ b/src/dataExplorer/components/resources/types/script/index.ts
@@ -1,13 +1,21 @@
 import {ResourceType} from 'src/types/resources'
 import editor from './editor'
-import * as api from 'src/client/scriptsRoutes'
+import {CLOUD} from 'src/shared/constants'
+
+const {getScript, patchScript, postScript} = CLOUD
+  ? require('src/client/scriptsRoutes')
+  : {
+      getScript: false,
+      patchScript: false,
+      postScript: false,
+    }
 
 export default function script(register) {
   register({
     type: ResourceType.Scripts,
     editor,
     init: id => {
-      if (!id) {
+      if (!id || !CLOUD) {
         return Promise.resolve({
           type: ResourceType.Scripts,
           flux: '',
@@ -18,70 +26,68 @@ export default function script(register) {
         })
       }
 
-      return api
-        .getScript({
-          scriptID: id,
-        })
-        .then(resp => {
-          if (resp.status === 200) {
-            return {
-              type: ResourceType.Scripts,
-              flux: resp.data.script,
-              data: resp.data,
-            }
-          }
-
+      return getScript({
+        scriptID: id,
+      }).then(resp => {
+        if (resp.status === 200) {
           return {
             type: ResourceType.Scripts,
-            flux: '',
-            data: {
-              name: `Untitled Script: ${new Date().toISOString()}`,
-              description: 'default description',
-            },
+            flux: resp.data.script,
+            data: resp.data,
           }
-        })
+        }
+
+        return {
+          type: ResourceType.Scripts,
+          flux: '',
+          data: {
+            name: `Untitled Script: ${new Date().toISOString()}`,
+            description: 'default description',
+          },
+        }
+      })
     },
     persist: resource => {
       const data = JSON.parse(JSON.stringify(resource.data))
       data.script = resource.flux
 
-      if (data.id) {
-        return api
-          .patchScript({
-            scriptID: data.id,
-            data: {
-              name: data.name,
-              description: data.description,
-              script: data.script,
-            },
-          })
-          .then(() => {
-            return resource
-          })
+      if (!CLOUD) {
+        return resource
       }
 
-      return api
-        .postScript({
+      if (data.id) {
+        return patchScript({
+          scriptID: data.id,
           data: {
             name: data.name,
             description: data.description,
             script: data.script,
-            language: 'flux',
           },
-        })
-        .then(resp => {
-          if (resp.status === 201) {
-            return {
-              ...resource,
-              data: {
-                ...data,
-                id: resp.data.id,
-              },
-            }
-          }
-
+        }).then(() => {
           return resource
         })
+      }
+
+      return postScript({
+        data: {
+          name: data.name,
+          description: data.description,
+          script: data.script,
+          language: 'flux',
+        },
+      }).then(resp => {
+        if (resp.status === 201) {
+          return {
+            ...resource,
+            data: {
+              ...data,
+              id: resp.data.id,
+            },
+          }
+        }
+
+        return resource
+      })
     },
   })
 }


### PR DESCRIPTION
this is part of splitting up the big PR at https://github.com/influxdata/ui/pull/5540/files in order to make the review cycle more digestible. this piece adds the generic interface for loading and saving scripts into the persistance layer of the new data explorer