### PR TITLE
style: update styling of schema composition code block

### DIFF
--- a/src/languageSupport/languages/flux/lsp/connection.ts
+++ b/src/languageSupport/languages/flux/lsp/connection.ts
@@ -214,9 +214,9 @@ class LspConnectionManager {
     )
 
     const clickableInvisibleDiv = document.getElementById(ICON_SYNC_ID)
-    clickableInvisibleDiv.style.background = this._session.composition.synced
-      ? 'blue'
-      : 'grey'
+    clickableInvisibleDiv.className = this._session.composition.synced
+      ? 'sync-bar sync-bar--on'
+      : 'sync-bar sync-bar--off'
 
     if (removeAllStyles) {
       clickableInvisibleDiv.style.display = 'none'

--- a/src/languageSupport/languages/flux/lsp/connection.ts
+++ b/src/languageSupport/languages/flux/lsp/connection.ts
@@ -149,8 +149,7 @@ class LspConnectionManager {
         ((lowerIcon as any).offsetHeight || 0) * (endLine - startLine + 1) +
         ((upperIcon as any).offsetTop || 0)
       clickableInvisibleDiv.style.height = height + 'px'
-      clickableInvisibleDiv.style.width =
-        ((upperIcon as any).offsetWidth || 0) + 'px'
+      // width size is always the same, defined in classname "sync-bar"
 
       // add listeners
       clickableInvisibleDiv.removeEventListener('click', () =>

--- a/src/shared/components/FluxMonacoEditor.scss
+++ b/src/shared/components/FluxMonacoEditor.scss
@@ -47,6 +47,7 @@
 .sync-bar {
   z-index: 999;
   position: absolute;
+  width: 48px;
 
   .sync-icon {
     color: #0098F0;

--- a/src/shared/components/FluxMonacoEditor.scss
+++ b/src/shared/components/FluxMonacoEditor.scss
@@ -50,14 +50,14 @@
   width: 48px;
 
   .sync-icon {
-    color: #0098F0;
+    color: #0098f0;
   }
 }
 
 .sync-bar--on {
-  background: #0098F01A; // blue with 10% opacity
-  border-top: 1px solid #0098F0;
-  border-bottom: 1px solid #0098F0;
+  background: #0098f01a; // blue with 10% opacity
+  border-top: 1px solid #0098f0;
+  border-bottom: 1px solid #0098f0;
 }
 
 .sync-bar--off {

--- a/src/shared/components/FluxMonacoEditor.scss
+++ b/src/shared/components/FluxMonacoEditor.scss
@@ -43,3 +43,25 @@
     color: #bec2cc;
   }
 }
+
+.sync-bar {
+  z-index: 999;
+  position: absolute;
+
+  .sync-icon {
+    color: #0098F0;
+  }
+}
+
+.sync-bar--on {
+  background: #0098F01A; // blue with 10% opacity
+  border-top: 1px solid #0098F0;
+  border-bottom: 1px solid #0098F0;
+}
+
+.sync-bar--off {
+  opacity: 50%;
+  background-color: $cf-grey-35;
+  border-top: 1px solid $cf-white;
+  border-bottom: 1px solid $cf-white;
+}

--- a/src/shared/components/FluxMonacoEditor.tsx
+++ b/src/shared/components/FluxMonacoEditor.tsx
@@ -6,6 +6,7 @@ import classnames from 'classnames'
 // Components
 import MonacoEditor from 'react-monaco-editor'
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
+import {Icon, IconFont} from '@influxdata/clockface'
 
 // LSP
 import FLUXLANGID from 'src/languageSupport/languages/flux/monaco.flux.syntax'
@@ -131,10 +132,9 @@ const FluxEditorMonaco: FC<Props> = ({
 
   return (
     <ErrorBoundary>
-      <div
-        id={ICON_SYNC_ID}
-        style={{zIndex: 999, position: 'absolute', opacity: 0.6}}
-      />
+      <div id={ICON_SYNC_ID} className="sync-bar">
+        <Icon glyph={IconFont.Switch_New} className="sync-icon" />
+      </div>
       <div className={wrapperClassName} data-testid="flux-editor">
         <MonacoEditor
           language={FLUXLANGID}


### PR DESCRIPTION
Closes #5544 

This PR updates the styling of the schema composition code block when turning "Flux Sync" toggle on and off.

This change is behind the feature flag `schemaComposition`

## Before
<img width="1128" alt="Screen Shot 2022-08-25 at 5 18 44 PM" src="https://user-images.githubusercontent.com/14298407/186778848-711e7b5b-3d2e-428a-96fc-f85d6cb33686.png">
<img width="1112" alt="Screen Shot 2022-08-25 at 5 18 51 PM" src="https://user-images.githubusercontent.com/14298407/186778852-ecf99aab-8179-4e96-a07d-fb76cb92ff14.png">


## After

<img width="1108" alt="Screen Shot 2022-08-25 at 5 10 23 PM" src="https://user-images.githubusercontent.com/14298407/186778559-5d151a8d-a82c-4a6a-bba4-1a3334af09a6.png">

<img width="1113" alt="Screen Shot 2022-08-25 at 5 10 30 PM" src="https://user-images.githubusercontent.com/14298407/186778565-af9a8062-3b66-4470-b248-9985f361ef2d.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
~~- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~~
- [x] Feature flagged, if applicable
