### PR TITLE
feat: add generic task loader

### DIFF
--- a/src/dataExplorer/components/resources/types/tasks/editor.tsx
+++ b/src/dataExplorer/components/resources/types/tasks/editor.tsx
@@ -1,0 +1,3 @@
+import React from 'react'
+
+export default () => <h1>TASK</h1>

--- a/src/tasks/components/TaskRunsCard.tsx
+++ b/src/tasks/components/TaskRunsCard.tsx
@@ -76,6 +76,11 @@ const TaskRunsCard: FC<Props> = ({task, isTaskEditable}) => {
   }, [])
 
   useEffect(() => {
+    if (isFlagEnabled('createWithDE')) {
+      setRoute(`/orgs/${org.id}/data-explorer/from/task/${task.id}`)
+      return
+    }
+
     if (!isFlagEnabled('createWithFlows')) {
       return
     }

--- a/src/tasks/containers/TasksPage.tsx
+++ b/src/tasks/containers/TasksPage.tsx
@@ -234,6 +234,8 @@ class TasksPage extends PureComponent<Props, State> {
 
     if (isFlagEnabled('createWithFlows')) {
       history.push(`/notebook/from/task`)
+    } else if (isFlagEnabled('createWithDE')) {
+      history.push(`/orgs/${orgID}/data-explorer/from/task`)
     } else {
       history.push(`/orgs/${orgID}/tasks/new`)
     }


### PR DESCRIPTION
this is part of splitting up the big PR at https://github.com/influxdata/ui/pull/5540/files in order to make the review cycle more digestible. this piece adds the generic interface for loading and saving tasks into the persistence layer of the new data explorer