### PR TITLE
chore(schemBrowser): update to clockface sync icon

### DIFF
--- a/src/dataExplorer/components/SchemaBrowserHeading.tsx
+++ b/src/dataExplorer/components/SchemaBrowserHeading.tsx
@@ -51,7 +51,7 @@ const SchemaBrowserHeading: FC = () => {
             <SelectorTitle
               title="Flux Sync"
               info={FLUX_SYNC_TOOLTIP}
-              icon={IconFont.Switch_New}
+              icon={IconFont.Sync}
             />
           </InputLabel>
         </FlexBox>

--- a/src/shared/components/FluxMonacoEditor.tsx
+++ b/src/shared/components/FluxMonacoEditor.tsx
@@ -133,7 +133,7 @@ const FluxEditorMonaco: FC<Props> = ({
   return (
     <ErrorBoundary>
       <div id={ICON_SYNC_ID} className="sync-bar">
-        <Icon glyph={IconFont.Switch_New} className="sync-icon" />
+        <Icon glyph={IconFont.Sync} className="sync-icon" />
       </div>
       <div className={wrapperClassName} data-testid="flux-editor">
         <MonacoEditor


### PR DESCRIPTION
This PR updates the "Flux Sync" icon to the new sync icon in clockface

This change is behind the feature flag `schemaComposition`

## Before
<img width="238" alt="Screen Shot 2022-08-26 at 1 51 24 PM" src="https://user-images.githubusercontent.com/14298407/186973034-89d39d31-e132-47d4-ac95-834d2b419d04.png">

## After
<img width="241" alt="Screen Shot 2022-08-26 at 1 53 35 PM" src="https://user-images.githubusercontent.com/14298407/186973020-21e53bb7-ba38-40a2-927f-84f38b41110d.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
~~- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~~
- [x] Feature flagged, if applicable
