### PR TITLE
fix: hide the composition sync bar inside the Monaco editor

### DIFF
--- a/src/shared/components/FluxMonacoEditor.scss
+++ b/src/shared/components/FluxMonacoEditor.scss
@@ -44,25 +44,29 @@
   }
 }
 
-.sync-bar {
-  z-index: 999;
-  position: absolute;
-  width: 48px;
+.flux-editor--monaco {
+  position: relative;
+  overflow: hidden;
 
-  .sync-icon {
-    color: #0098f0;
+  .sync-bar {
+    position: absolute;
+    width: 48px;
+
+    .sync-icon {
+      color: #0098f0;
+    }
   }
-}
 
-.sync-bar--on {
-  background: #0098f01a; // blue with 10% opacity
-  border-top: 1px solid #0098f0;
-  border-bottom: 1px solid #0098f0;
-}
+  .sync-bar--on {
+    background: #0098f01a; // blue with 10% opacity
+    border-top: 1px solid #0098f0;
+    border-bottom: 1px solid #0098f0;
+  }
 
-.sync-bar--off {
-  opacity: 50%;
-  background-color: $cf-grey-35;
-  border-top: 1px solid $cf-white;
-  border-bottom: 1px solid $cf-white;
+  .sync-bar--off {
+    opacity: 50%;
+    background-color: $cf-grey-35;
+    border-top: 1px solid $cf-white;
+    border-bottom: 1px solid $cf-white;
+  }
 }

--- a/src/shared/components/FluxMonacoEditor.tsx
+++ b/src/shared/components/FluxMonacoEditor.tsx
@@ -132,9 +132,6 @@ const FluxEditorMonaco: FC<Props> = ({
 
   return (
     <ErrorBoundary>
-      <div id={ICON_SYNC_ID} className="sync-bar">
-        <Icon glyph={IconFont.Switch_New} className="sync-icon" />
-      </div>
       <div className={wrapperClassName} data-testid="flux-editor">
         <MonacoEditor
           language={FLUXLANGID}
@@ -158,6 +155,9 @@ const FluxEditorMonaco: FC<Props> = ({
           }}
           editorDidMount={editorDidMount}
         />
+        <div id={ICON_SYNC_ID} className="sync-bar">
+          <Icon glyph={IconFont.Switch_New} className="sync-icon" />
+        </div>
       </div>
     </ErrorBoundary>
   )


### PR DESCRIPTION
This PR fixes the bug that composition highlighting sync bar went outside of the Monaco editor.

This fix is behind the feature flag `schemaComposition`

## Before

https://user-images.githubusercontent.com/14298407/186984219-f243e5d0-785d-47e1-8fe0-c124bbf97a83.mov


## After

https://user-images.githubusercontent.com/14298407/186984187-2348e6cb-b51c-4b44-8055-36e3f0028aea.mov


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
~~- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~~
- [x] Feature flagged, if applicable
