### PR TITLE
chore: remove user banner when multiOrg is enabled

### DIFF
--- a/src/pageLayout/components/UserWidget.tsx
+++ b/src/pageLayout/components/UserWidget.tsx
@@ -90,7 +90,6 @@ const UserWidget: FC<Props> = ({
             <Link className={className} to={`${orgPrefix}/usage`} />
           )}
         />
-        )}
       </CloudOnly>
       <CloudExclude>
         <TreeNav.UserItem

--- a/src/pageLayout/components/UserWidget.tsx
+++ b/src/pageLayout/components/UserWidget.tsx
@@ -18,6 +18,10 @@ import {AppState} from 'src/types'
 import {getOrg} from 'src/organizations/selectors'
 import {getNavItemActivation} from '../utils'
 
+// Utils
+import {CLOUD} from 'src/shared/constants'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+
 type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps
 
@@ -36,6 +40,10 @@ const UserWidget: FC<Props> = ({
   }
 
   const orgPrefix = `/orgs/${org.id}`
+
+  if (CLOUD && isFlagEnabled('multiOrg')) {
+    return null
+  }
 
   return (
     <TreeNav.User username={me.name} team={org.name} testID="user-nav">
@@ -82,6 +90,7 @@ const UserWidget: FC<Props> = ({
             <Link className={className} to={`${orgPrefix}/usage`} />
           )}
         />
+        )}
       </CloudOnly>
       <CloudExclude>
         <TreeNav.UserItem

--- a/src/pageLayout/components/UserWidget.tsx
+++ b/src/pageLayout/components/UserWidget.tsx
@@ -18,10 +18,6 @@ import {AppState} from 'src/types'
 import {getOrg} from 'src/organizations/selectors'
 import {getNavItemActivation} from '../utils'
 
-// Utils
-import {CLOUD} from 'src/shared/constants'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
-
 type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps
 
@@ -40,10 +36,6 @@ const UserWidget: FC<Props> = ({
   }
 
   const orgPrefix = `/orgs/${org.id}`
-
-  if (CLOUD && isFlagEnabled('multiOrg')) {
-    return null
-  }
 
   return (
     <TreeNav.User username={me.name} team={org.name} testID="user-nav">

--- a/src/pageLayout/containers/TreeNav.tsx
+++ b/src/pageLayout/containers/TreeNav.tsx
@@ -24,6 +24,9 @@ import {SafeBlankLink} from 'src/utils/SafeBlankLink'
 import {NavItem, NavSubItem} from 'src/pageLayout/constants/navigationHierarchy'
 import {AppState} from 'src/types'
 
+// Utils
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+
 import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
 import './TreeNav.scss'
 
@@ -90,7 +93,7 @@ const TreeSidebar: FC<ReduxProps> = ({
     <TreeNav
       expanded={navbarMode === 'expanded'}
       headerElement={<NavHeader link={`/orgs/${org.id}`} />}
-      userElement={<UserWidget />}
+      userElement={CLOUD && isFlagEnabled('multiOrg') ? null : <UserWidget />}
       onToggleClick={handleToggleNavExpansion}
     >
       {generateNavItems().map((item: NavItem) => {


### PR DESCRIPTION
Closes #5564 

In cloud environments, removes the user-widget, and user-specific account and org links, from the lefthand nav bar when multi-org is `true`. The user will already have access to the same links through the multi-org phase 1 header. 

- These links will only fail to appear when the `multiOrg` flag is `true`. When `multiOrg` is false, the old left-hand links will be displayed. 
- Toggling the flag immediately changes the state of the navbar without a hard refresh, as the change in flags state results in a different prop value for `<TreeNav />`. 
- No changes will occur in non-cloud environments. 

Old structure of `<TreeNav />` is in blue; new structure includes the path shown in green.

![Screen Shot 2022-08-29 at 10 35 10 AM](https://user-images.githubusercontent.com/91283923/187226740-2b98cd13-4800-4fb0-8a52-e3fd4e1ab82e.png)

https://user-images.githubusercontent.com/91283923/187227071-fbda7d14-e8c9-4faa-b389-0873a988b8c9.mov


1. User Widget : Replaced by User Profile Avatar
Old: 
![Screen Shot 2022-08-29 at 9 19 11 AM](https://user-images.githubusercontent.com/91283923/187218797-9ad3d114-5ff9-42f9-836f-1d4826deed38.png)
New: 
![Screen Shot 2022-08-29 at 9 59 33 AM](https://user-images.githubusercontent.com/91283923/187219003-786b3cfd-0b19-48d9-b545-6903e1ab4740.png)

2. Account Links :  Replaced by GlobalHeader Account Settings, Billing
Old: 
![Screen Shot 2022-08-29 at 9 59 08 AM](https://user-images.githubusercontent.com/91283923/187219084-88711fa2-e45a-421b-b9d8-b761f7451b87.png)
New:
![Screen Shot 2022-08-29 at 9 59 47 AM](https://user-images.githubusercontent.com/91283923/187219560-f1a96238-7d2d-41b9-92b4-c62cebfed49a.png)

4. Org Links : Replaced by GlobalHeader Org Settings, Members, Usage
Old: 
![Screen Shot 2022-08-29 at 9 59 14 AM](https://user-images.githubusercontent.com/91283923/187219107-d1a8bdc9-1d7c-48b6-a474-95d601408326.png)
New:
![Screen Shot 2022-08-29 at 9 59 52 AM](https://user-images.githubusercontent.com/91283923/187219587-caca7f1b-b0b2-45fe-b509-e99031125020.png)


6. Logout Button : Replaced by User Profile Logout Button
7. Old:
![Screen Shot 2022-08-29 at 9 59 20 AM](https://user-images.githubusercontent.com/91283923/187219130-57d8cde7-42db-415e-9fe4-c3803408d9a7.png)
New:
![Screen Shot 2022-08-29 at 9 59 39 AM](https://user-images.githubusercontent.com/91283923/187219492-9f31b9b3-68e7-4d79-ae1e-626d5376ffca.png)


### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable
