### PR TITLE
style: change sync icon to gray when sync is off

### DIFF
--- a/src/shared/components/FluxMonacoEditor.scss
+++ b/src/shared/components/FluxMonacoEditor.scss
@@ -54,12 +54,12 @@
   }
 
   .sync-bar--on {
-    background: #0098f01a; // blue with 10% opacity
-    border-top: 1px solid #0098f0;
-    border-bottom: 1px solid #0098f0;
+    background: #00a3ff26; // blue with 15% opacity
+    border-top: 1px solid $c-pool;
+    border-bottom: 1px solid $c-pool;
 
     .sync-icon {
-      color: #0098f0;
+      color: $c-pool;
     }
   }
 

--- a/src/shared/components/FluxMonacoEditor.scss
+++ b/src/shared/components/FluxMonacoEditor.scss
@@ -48,16 +48,16 @@
   z-index: 999;
   position: absolute;
   width: 48px;
-
-  .sync-icon {
-    color: #0098f0;
-  }
 }
 
 .sync-bar--on {
   background: #0098f01a; // blue with 10% opacity
   border-top: 1px solid #0098f0;
   border-bottom: 1px solid #0098f0;
+
+  .sync-icon {
+    color: #0098f0;
+  }
 }
 
 .sync-bar--off {
@@ -65,4 +65,8 @@
   background-color: $cf-grey-35;
   border-top: 1px solid $cf-white;
   border-bottom: 1px solid $cf-white;
+
+  .sync-icon {
+    color: $cf-white;
+  }
 }


### PR DESCRIPTION
This PR updates the sync icon color. If sync is turned off the icon should be gray, not blue.

This change is behind the feature flag `schemaComposition`

## Before
<img width="452" alt="Screen Shot 2022-08-29 at 10 43 44 AM" src="https://user-images.githubusercontent.com/14298407/187240805-f3589f21-2ec5-4cbf-abb6-5df149893a2e.png">

## After
<img width="343" alt="Screen Shot 2022-08-29 at 10 27 23 AM" src="https://user-images.githubusercontent.com/14298407/187240791-c2ac207b-76c7-4be5-a3d4-dae3783e1f86.png">

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
~~- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~~
- [x] Feature flagged, if applicable
