### PR TITLE
chore: update jspdf package to 2.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
     "intersection-observer": "^0.7.0",
     "jsonlint-mod": "^1.7.5",
     "jsonpath": "^1.1.1",
-    "jspdf": "^2.4.0",
+    "jspdf": "2.5.1",
     "lodash": "^4.17.21",
     "luxon": "^3.0.1",
     "memoize-one": "^4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7802,10 +7802,10 @@ jsonpath@^1.1.1:
     static-eval "2.0.2"
     underscore "1.12.1"
 
-jspdf@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.npmjs.org/jspdf/-/jspdf-2.4.0.tgz"
-  integrity sha512-nsZ92YfbNG/EimR1yqmOkxf2D4iJRypBsw7pvP1aPiIEnoGITaLl6XDR/GYA36/R29vMZSBedpEhBCzutSGytA==
+jspdf@2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/jspdf/-/jspdf-2.5.1.tgz#00c85250abf5447a05f3b32ab9935ab4a56592cc"
+  integrity sha512-hXObxz7ZqoyhxET78+XR34Xu2qFGrJJ2I2bE5w4SM8eFaFEkW2xcGRVUss360fYelwRSid/jT078kbNvmoW0QA==
   dependencies:
     "@babel/runtime" "^7.14.0"
     atob "^2.1.2"


### PR DESCRIPTION
Running `yarn outdated` yielded a list of outdated packages.
Exhaustive list [HERE](https://docs.google.com/spreadsheets/d/1g1ie5AdCwbqRnErLIa8j9b9V_POqSTxToWm_MYxz7b0/edit#gid=0)

Updating `jspdf` to v2.5.1 in this PR.
Customer shouldn't see any impact of this change.


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
