### PR TITLE
fix: add disable style on "Flux Sync" label

### DIFF
--- a/src/dataExplorer/components/Schema.scss
+++ b/src/dataExplorer/components/Schema.scss
@@ -35,6 +35,10 @@
   .flux-sync--label {
     padding-left: $cf-space-2xs;
 
+    .disabled {
+      opacity: 50%;
+    }
+
     .selector-title {
       padding-bottom: 0;
     }

--- a/src/dataExplorer/components/SchemaBrowserHeading.tsx
+++ b/src/dataExplorer/components/SchemaBrowserHeading.tsx
@@ -26,6 +26,7 @@ const SchemaBrowserHeading: FC = () => {
   const {selection} = useContext(PersistanceContext)
 
   const disableToggle: boolean = selection.composition?.diverged
+  const disableTooltipText = disableToggle ? FLUX_SYNC_DISABLE_TEXT : ''
 
   const handleFluxSyncToggle = () => {
     toggleFluxSync(!fluxSync)
@@ -45,14 +46,19 @@ const SchemaBrowserHeading: FC = () => {
             onChange={handleFluxSyncToggle}
             testID="flux-sync--toggle"
             disabled={disableToggle}
-            tooltipText={disableToggle ? FLUX_SYNC_DISABLE_TEXT : ''}
+            tooltipText={disableTooltipText}
           />
           <InputLabel className="flux-sync--label">
-            <SelectorTitle
-              title="Flux Sync"
-              info={FLUX_SYNC_TOOLTIP}
-              icon={IconFont.Sync}
-            />
+            <div
+              className={`${disableToggle ? 'disabled' : ''}`}
+              title={disableTooltipText}
+            >
+              <SelectorTitle
+                title="Flux Sync"
+                info={FLUX_SYNC_TOOLTIP}
+                icon={IconFont.Sync}
+              />
+            </div>
           </InputLabel>
         </FlexBox>
       </FlexBox>

--- a/src/dataExplorer/components/SchemaBrowserHeading.tsx
+++ b/src/dataExplorer/components/SchemaBrowserHeading.tsx
@@ -25,6 +25,7 @@ const SchemaBrowserHeading: FC = () => {
   const {fluxSync, toggleFluxSync} = useContext(FluxQueryBuilderContext)
   const {selection} = useContext(PersistanceContext)
 
+  // Disable means diverged, used to not allow turning on or off the toggle
   const disableToggle: boolean = selection.composition?.diverged
   const disableTooltipText = disableToggle ? FLUX_SYNC_DISABLE_TEXT : ''
 


### PR DESCRIPTION
Related to #5573 

This PR updates the styling of "Flux Sync" toggle when it is disabled. 

This change is behind the feature flag `schemaComposition`

## Before

<img width="398" alt="Screen Shot 2022-08-29 at 4 00 54 PM" src="https://user-images.githubusercontent.com/14298407/187298115-b1aa7f5e-0888-4ea2-a730-5e6c2d502717.png">


## After

https://user-images.githubusercontent.com/14298407/187297893-f4185009-24e7-40dd-9a85-85aaa7c98f99.mov



### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
~~- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~~
- [x] Feature flagged, if applicable
