### PR TITLE
fix: schema composition sync and resetting

### DIFF
--- a/src/dataExplorer/components/FluxQueryBuilder.tsx
+++ b/src/dataExplorer/components/FluxQueryBuilder.tsx
@@ -37,7 +37,13 @@ export enum OverlayType {
 }
 
 const FluxQueryBuilder: FC = () => {
-  const {query, vertical, setVertical} = useContext(PersistanceContext)
+  const {
+    query,
+    setQuery,
+    vertical,
+    setVertical,
+    clearSchemaSelection,
+  } = useContext(PersistanceContext)
   const [overlayType, setOverlayType] = useState<OverlayType | null>(null)
 
   return (
@@ -47,6 +53,10 @@ const FluxQueryBuilder: FC = () => {
           <SaveAsScript
             type={overlayType}
             onClose={() => setOverlayType(null)}
+            onClear={() => {
+              clearSchemaSelection()
+              setQuery('')
+            }}
           />
         </Overlay>
         <FlexBox

--- a/src/dataExplorer/components/SaveAsScript.tsx
+++ b/src/dataExplorer/components/SaveAsScript.tsx
@@ -27,11 +27,12 @@ import {getOrg} from 'src/organizations/selectors'
 import OpenScript from 'src/dataExplorer/components/OpenScript'
 
 interface Props {
+  onClear: () => void
   onClose: () => void
   type: OverlayType | null
 }
 
-const SaveAsScript: FC<Props> = ({onClose, type}) => {
+const SaveAsScript: FC<Props> = ({onClose, onClear, type}) => {
   const dispatch = useDispatch()
   const history = useHistory()
   const {query, resource, setResource, save} = useContext(PersistanceContext)
@@ -63,6 +64,7 @@ const SaveAsScript: FC<Props> = ({onClose, type}) => {
     cancel()
     setStatus(RemoteDataState.NotStarted)
     setResult(null)
+    onClear()
 
     history.replace(`/orgs/${org.id}/data-explorer/from/script`)
     if (type !== OverlayType.OPEN) {

--- a/src/dataExplorer/components/resources/TemplatePage.tsx
+++ b/src/dataExplorer/components/resources/TemplatePage.tsx
@@ -5,7 +5,6 @@ import {RemoteDataState} from 'src/types'
 
 import {getOrg} from 'src/organizations/selectors'
 
-import {DEFAULT_SCHEMA} from 'src/dataExplorer/context/persistance'
 import {RESOURCES} from 'src/dataExplorer/components/resources'
 import {
   PersistanceContext,
@@ -13,7 +12,9 @@ import {
 } from 'src/dataExplorer/context/persistance'
 
 const Template: FC = () => {
-  const {setQuery, setResource, setSelection} = useContext(PersistanceContext)
+  const {setQuery, setResource, clearSchemaSelection} = useContext(
+    PersistanceContext
+  )
   const params = useParams()[0].split('/')
   const org = useSelector(getOrg)
   const history = useHistory()
@@ -34,7 +35,7 @@ const Template: FC = () => {
     }
 
     setLoading(RemoteDataState.Loading)
-    setSelection(JSON.parse(JSON.stringify(DEFAULT_SCHEMA)))
+    clearSchemaSelection()
     setQuery('')
     setResource(null)
 

--- a/src/dataExplorer/context/persistance.tsx
+++ b/src/dataExplorer/context/persistance.tsx
@@ -46,7 +46,7 @@ export const DEFAULT_SCHEMA: SchemaSelection = {
   fields: [] as string[],
   tagValues: [] as TagKeyValuePair[],
   composition: {
-    synced: false,
+    synced: true,
     diverged: false,
   },
 }

--- a/src/dataExplorer/context/persistance.tsx
+++ b/src/dataExplorer/context/persistance.tsx
@@ -35,6 +35,7 @@ interface ContextType {
   setQuery: (val: string) => void
   setResource: (val: ResourceConnectedQuery<any>) => void
   setSelection: (val: RecursivePartial<SchemaSelection>) => void
+  clearSchemaSelection: () => void
 
   save: () => Promise<ResourceConnectedQuery<any>>
 }
@@ -56,7 +57,7 @@ const DEFAULT_CONTEXT = {
   range: DEFAULT_TIME_RANGE,
   query: '',
   resource: null,
-  selection: DEFAULT_SCHEMA,
+  selection: JSON.parse(JSON.stringify(DEFAULT_SCHEMA)),
 
   setHorizontal: (_: number[]) => {},
   setVertical: (_: number[]) => {},
@@ -64,7 +65,7 @@ const DEFAULT_CONTEXT = {
   setQuery: (_: string) => {},
   setResource: (_: any) => {},
   setSelection: (_: RecursivePartial<SchemaSelection>) => {},
-
+  clearSchemaSelection: () => {},
   save: () => Promise.resolve(null),
 }
 
@@ -100,6 +101,10 @@ export const PersistanceProvider: FC = ({children}) => {
     'dataExplorer.schema',
     JSON.parse(JSON.stringify(DEFAULT_CONTEXT.selection))
   )
+
+  const clearSchemaSelection = () => {
+    setSelection(JSON.parse(JSON.stringify(DEFAULT_SCHEMA)))
+  }
 
   const setSchemaSelection = useCallback(
     schema => {
@@ -148,6 +153,7 @@ export const PersistanceProvider: FC = ({children}) => {
         setQuery,
         setResource,
         setSelection: setSchemaSelection,
+        clearSchemaSelection,
 
         save,
       }}


### PR DESCRIPTION
Part of #5575.
(Line item: turn on sync by default.)

Fixes error introduced here:
https://github.com/influxdata/ui/commit/34920a77d765a939edb5e292a6827c481715f137#diff-dc45f9353f4973afb51830453f2b9afd104ab1b0057ab80ba84b9f4cf2b09f7d

## Done:
* single line change, to make the default for sync be true
* rest of lines is to fix this found bug:
    * introduced because 2 different  groups pushing code (without tests yet)
    * Add back in schema resetting behavior for new script, which got accidentally removed [with this commit/merge](https://github.com/influxdata/ui/commit/34920a77d765a939edb5e292a6827c481715f137#diff-dc45f9353f4973afb51830453f2b9afd104ab1b0057ab80ba84b9f4cf2b09f7d).