### PR TITLE
feat(5591): schema composition cypress tests.

### DIFF
--- a/cypress/e2e/shared/editor.test.ts
+++ b/cypress/e2e/shared/editor.test.ts
@@ -92,6 +92,8 @@ describe('Editor+LSP communication', () => {
         cy.setFeatureFlags({
           newDataExplorer: true,
         }).then(() => {
+          // cy.wait($time) is necessary to consistently ensure sufficient time for the feature flag override.
+          // The flag reset happens via redux, (it's not a network request), so we can't cy.wait($intercepted_route).
           cy.wait(1200)
           cy.getByTestID('flux-query-builder-toggle').then($toggle => {
             cy.wrap($toggle).should('be.visible')

--- a/cypress/e2e/shared/editor.test.ts
+++ b/cypress/e2e/shared/editor.test.ts
@@ -81,4 +81,31 @@ describe('Editor+LSP communication', () => {
 
     runTest('time-machine--bottom')
   })
+
+  describe('in Script Editor', () => {
+    before(() => {
+      cy.flush()
+      cy.signin()
+      cy.get('@org').then(({id}: Organization) => {
+        cy.visit(`/orgs/${id}/data-explorer`)
+        cy.getByTestID('tree-nav').should('be.visible')
+        cy.setFeatureFlags({
+          newDataExplorer: true,
+        }).then(() => {
+          cy.wait(1200)
+          cy.getByTestID('flux-query-builder-toggle').then($toggle => {
+            cy.wrap($toggle).should('be.visible')
+            // Switch to Flux Query Builder if not yet
+            if (!$toggle.hasClass('active')) {
+              // hasClass is a jQuery function
+              $toggle.click()
+              cy.getByTestID('flux-query-builder--menu').contains('New Script')
+            }
+          })
+        })
+      })
+    })
+
+    runTest('flux-editor')
+  })
 })

--- a/cypress/e2e/shared/fluxQueryBuilder.test.ts
+++ b/cypress/e2e/shared/fluxQueryBuilder.test.ts
@@ -1,6 +1,10 @@
 import {Organization} from '../../../src/types'
+import {
+  DEFAULT_SCHEMA,
+  DEFAULT_CONTEXT,
+} from '../../../src/dataExplorer/context/persistance'
 
-describe('FluxQueryBuilder', () => {
+describe('Script Builder', () => {
   beforeEach(() => {
     cy.flush().then(() => {
       cy.signin().then(() => {
@@ -174,6 +178,163 @@ describe('FluxQueryBuilder', () => {
       // not recommend to assert for searchTagKey value
       // since it will expand all the tag keys, which triggers
       // numbers of API calls that are time consuming and unnecessary
+    })
+  })
+
+  describe('Schema Composition', () => {
+    beforeEach(() => {
+      window.sessionStorage.setItem(
+        'dataExplorer.schema',
+        JSON.parse(JSON.stringify(DEFAULT_SCHEMA))
+      )
+      window.sessionStorage.setItem('dataExplorer.query', DEFAULT_CONTEXT.query)
+
+      cy.setFeatureFlags({
+        schemaComposition: true,
+      }).then(() => {
+        cy.wait(1200).then(() => {
+          cy.reload()
+          cy.getByTestID('flux-sync--toggle')
+        })
+      })
+    })
+
+    const bucketName = 'defbuck'
+    const measurement = 'ndbc'
+
+    const selectSchema = () => {
+      cy.log('select bucket')
+      cy.getByTestID('bucket-selector--dropdown-button').click()
+      cy.getByTestID('bucket-selector--search-bar').type(bucketName)
+      cy.getByTestID(`bucket-selector--dropdown--${bucketName}`).click()
+      cy.getByTestID('bucket-selector--dropdown-button').should(
+        'contain',
+        bucketName
+      )
+
+      cy.log('select measurement')
+      cy.getByTestID('measurement-selector--dropdown-button')
+        .should('be.visible')
+        .should('contain', 'Select measurement')
+        .click()
+      cy.getByTestID('measurement-selector--dropdown--menu').type(measurement)
+      cy.getByTestID(`searchable-dropdown--item ${measurement}`)
+        .should('be.visible')
+        .click()
+      cy.getByTestID('measurement-selector--dropdown-button').should(
+        'contain',
+        measurement
+      )
+    }
+
+    const confirmSchemaComposition = () => {
+      cy.getByTestID('flux-editor', {timeout: 30000})
+        // we set a manual delay on page load, for composition initialization
+        .contains(`from(bucket: "${bucketName}")`, {timeout: 30000})
+      cy.getByTestID('flux-editor').contains(
+        `|> filter(fn: (r) => r._measurement == "${measurement}")`
+      )
+      cy.getByTestID('flux-editor').contains(
+        `|> yield(name: "_editor_composition")`
+      )
+    }
+
+    describe('basic ability:', () => {
+      it('can make a composition block', () => {
+        cy.getByTestID('flux-editor', {timeout: 30000})
+
+        cy.log('modify schema browser')
+        selectSchema()
+
+        cy.log('editor text contains the composition')
+        confirmSchemaComposition()
+      })
+    })
+
+    describe('default sync and resetting behavior:', () => {
+      it('sync defaults to on. Can be toggled on/off. And can diverge (be disabled).', () => {
+        cy.log('starts as synced')
+        cy.getByTestID('flux-sync--toggle').should('have.class', 'active')
+
+        cy.log('sync toggles on and off')
+        cy.getByTestID('flux-sync--toggle')
+          .should('have.class', 'active')
+          .click()
+          .should('not.have.class', 'active')
+          .click()
+          .should('have.class', 'active')
+
+        cy.log('can diverge from sync')
+        selectSchema()
+        confirmSchemaComposition()
+        cy.getByTestID('flux-editor').monacoType(
+          '{upArrow}{upArrow} // make diverge'
+        )
+
+        cy.log('toggle is now disabled')
+        cy.getByTestID('flux-sync--toggle').should('have.class', 'disabled')
+      })
+
+      it('should clear the editor text, and schema browser, with a new script', () => {
+        cy.getByTestID('flux-editor', {timeout: 30000})
+
+        cy.log('modify schema browser')
+        selectSchema()
+
+        cy.log('editor text contains the composition')
+        cy.getByTestID('flux-editor').contains(
+          `|> yield(name: "_editor_composition")`
+        )
+
+        cy.log('click new script, and choose to delete current script')
+        cy.getByTestID('flux-query-builder--new-script').click({force: true})
+        cy.getByTestID('overlay--container')
+          .should('be.visible')
+          .within(() => {
+            cy.getByTestID('flux-query-builder--no-save').click()
+          })
+
+        cy.log('editor text is now empty')
+        cy.getByTestID('flux-editor').within(() => {
+          cy.get('textarea.inputarea').should('have.value', '')
+        })
+
+        cy.log('schema browser has been cleared')
+        cy.getByTestID('bucket-selector--dropdown-button').contains(
+          'Select bucket'
+        )
+      })
+
+      it('should not be able to modify the composition when unsynced, yet still modify the saved schema -- which updates the composition when re-synced', () => {
+        cy.log('start with empty editor text')
+        cy.getByTestID('flux-editor', {timeout: 30000}).within(() => {
+          cy.get('textarea.inputarea').should('have.value', '')
+        })
+
+        cy.log('turn off sync')
+        cy.getByTestID('flux-sync--toggle')
+          .should('have.class', 'active')
+          .click()
+        cy.getByTestID('flux-sync--toggle').should('not.have.class', 'active')
+
+        cy.log('modify schema browser')
+        selectSchema()
+
+        cy.log('editor text is still empty')
+        cy.getByTestID('flux-editor').within(() => {
+          cy.get('textarea.inputarea').should('have.value', '')
+        })
+
+        cy.log('turn on sync')
+        cy.getByTestID('flux-sync--toggle')
+          .should('not.have.class', 'active')
+          .click()
+        cy.getByTestID('flux-sync--toggle').should('have.class', 'active')
+
+        cy.log('editor text contains the composition')
+        cy.wait(3000)
+        confirmSchemaComposition()
+      })
     })
   })
 })

--- a/cypress/e2e/shared/fluxQueryBuilder.test.ts
+++ b/cypress/e2e/shared/fluxQueryBuilder.test.ts
@@ -198,7 +198,10 @@ describe('Script Builder', () => {
 
       cy.setFeatureFlags({
         schemaComposition: true,
+        saveAsScript: true,
       }).then(() => {
+        // cy.wait($time) is necessary to consistently ensure sufficient time for the feature flag override.
+        // The flag reset happens via redux, (it's not a network request), so we can't cy.wait($intercepted_route).
         cy.wait(1200).then(() => {
           cy.reload()
           cy.getByTestID('flux-sync--toggle')
@@ -237,6 +240,7 @@ describe('Script Builder', () => {
     const confirmSchemaComposition = () => {
       cy.getByTestID('flux-editor', {timeout: 30000})
         // we set a manual delay on page load, for composition initialization
+        // https://github.com/influxdata/ui/blob/e76f934c6af60e24c6356f4e4ce9b067e5a9d0d5/src/languageSupport/languages/flux/lsp/connection.ts#L435-L440
         .contains(`from(bucket: "${bucketName}")`, {timeout: 30000})
       cy.getByTestID('flux-editor').contains(
         `|> filter(fn: (r) => r._measurement == "${measurement}")`
@@ -245,18 +249,6 @@ describe('Script Builder', () => {
         `|> yield(name: "_editor_composition")`
       )
     }
-
-    describe('basic ability:', () => {
-      it('can make a composition block', () => {
-        cy.getByTestID('flux-editor', {timeout: 30000})
-
-        cy.log('modify schema browser')
-        selectSchema()
-
-        cy.log('editor text contains the composition')
-        confirmSchemaComposition()
-      })
-    })
 
     describe('default sync and resetting behavior:', () => {
       it('sync defaults to on. Can be toggled on/off. And can diverge (be disabled).', () => {
@@ -339,6 +331,8 @@ describe('Script Builder', () => {
         cy.getByTestID('flux-sync--toggle').should('have.class', 'active')
 
         cy.log('editor text contains the composition')
+        // we set a manual delay for composition initialization
+        // https://github.com/influxdata/ui/blob/e76f934c6af60e24c6356f4e4ce9b067e5a9d0d5/src/languageSupport/languages/flux/lsp/connection.ts#L435-L440
         cy.wait(3000)
         confirmSchemaComposition()
       })

--- a/cypress/e2e/shared/fluxQueryBuilder.test.ts
+++ b/cypress/e2e/shared/fluxQueryBuilder.test.ts
@@ -1,8 +1,15 @@
 import {Organization} from '../../../src/types'
-import {
-  DEFAULT_SCHEMA,
-  DEFAULT_CONTEXT,
-} from '../../../src/dataExplorer/context/persistance'
+
+const DEFAULT_SCHEMA = {
+  bucket: null,
+  measurement: null,
+  fields: [],
+  tagValues: [],
+  composition: {
+    synced: true,
+    diverged: false,
+  },
+}
 
 describe('Script Builder', () => {
   beforeEach(() => {
@@ -187,7 +194,7 @@ describe('Script Builder', () => {
         'dataExplorer.schema',
         JSON.parse(JSON.stringify(DEFAULT_SCHEMA))
       )
-      window.sessionStorage.setItem('dataExplorer.query', DEFAULT_CONTEXT.query)
+      window.sessionStorage.setItem('dataExplorer.query', '')
 
       cy.setFeatureFlags({
         schemaComposition: true,

--- a/src/dataExplorer/components/FluxQueryBuilder.tsx
+++ b/src/dataExplorer/components/FluxQueryBuilder.tsx
@@ -78,6 +78,7 @@ const FluxQueryBuilder: FC = () => {
                   ? ComponentStatus.Disabled
                   : ComponentStatus.Default
               }
+              testID="flux-query-builder--new-script"
             />
             {isFlagEnabled('saveAsScript') && (
               <Button

--- a/src/dataExplorer/components/SaveAsScript.tsx
+++ b/src/dataExplorer/components/SaveAsScript.tsx
@@ -149,6 +149,7 @@ const SaveAsScript: FC<Props> = ({onClose, onClear, type}) => {
             color={ComponentColor.Default}
             onClick={clear}
             text="No, Delete"
+            testID="flux-query-builder--no-save"
           />
         )}
         {CLOUD && (

--- a/src/dataExplorer/context/persistance.tsx
+++ b/src/dataExplorer/context/persistance.tsx
@@ -51,7 +51,7 @@ export const DEFAULT_SCHEMA: SchemaSelection = {
   },
 }
 
-const DEFAULT_CONTEXT = {
+export const DEFAULT_CONTEXT = {
   horizontal: [0.2],
   vertical: [0.25, 0.8],
   range: DEFAULT_TIME_RANGE,

--- a/src/dataExplorer/context/persistance.tsx
+++ b/src/dataExplorer/context/persistance.tsx
@@ -51,7 +51,7 @@ export const DEFAULT_SCHEMA: SchemaSelection = {
   },
 }
 
-export const DEFAULT_CONTEXT = {
+const DEFAULT_CONTEXT = {
   horizontal: [0.2],
   vertical: [0.25, 0.8],
   range: DEFAULT_TIME_RANGE,


### PR DESCRIPTION
Closes #5591 


## Done:
* extend existing `editor.tests.js`: 
   * to also cover new Script builder 
* add new Schema Composition tests in `fluxQueryBuilder.test.js`:
   * these test how schema composition fits into the rest of the UI
   * e.g. schema composition versus the session versus the UI sync versus the "New Script" functionality.

## Not a part of this:
Note: is not the integration (non-cypress) tests we plan to add later, for the UI vs LSP coordination (e.g. middleware etc). 
