### PR TITLE
fix: improve error handling around vwo-script anti-flicker

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,7 +83,27 @@ const App: FC = () => {
     }
 
     if (CLOUD && isFlagEnabled('vwoAbTesting')) {
-      executeVWO()
+      const removeHideStyleTag = () => {
+        // This id must correspond to the id of the <style> tag set in the VWO script.
+        const hideStyleTag = document.getElementById('_vis_opt_path_hides')
+        if (hideStyleTag) {
+          hideStyleTag.remove()
+        }
+      }
+
+      try {
+        setTimeout(() => {
+          removeHideStyleTag()
+        }, 2000)
+
+        executeVWO()
+      } catch (err) {
+        removeHideStyleTag()
+
+        reportErrorThroughHoneyBadger(err, {
+          name: 'VWO script failed to execute successfully',
+        })
+      }
     }
 
     setAutoFreeze(false)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,22 +83,22 @@ const App: FC = () => {
     }
 
     if (CLOUD && isFlagEnabled('vwoAbTesting')) {
-      const removeHideStyleTag = () => {
+      const removeAntiFlickerStyle = () => {
         // This id must correspond to the id of the <style> tag set in the VWO script.
-        const hideStyleTag = document.getElementById('_vis_opt_path_hides')
-        if (hideStyleTag) {
-          hideStyleTag.remove()
+        const antiFlickerStyle = document.getElementById('_vis_opt_path_hides')
+        if (antiFlickerStyle) {
+          antiFlickerStyle.remove()
         }
       }
 
       try {
         setTimeout(() => {
-          removeHideStyleTag()
+          removeAntiFlickerStyle()
         }, 2000)
 
         executeVWO()
       } catch (err) {
-        removeHideStyleTag()
+        removeAntiFlickerStyle()
 
         reportErrorThroughHoneyBadger(err, {
           name: 'VWO script failed to execute successfully',

--- a/src/utils/vwo.ts
+++ b/src/utils/vwo.ts
@@ -1,4 +1,6 @@
 // this code is related to implementing the A/B testing tool VMO: https://vwo.com/
+// Whenever this script is updated, ensure that any changes are reflected in the
+// error handling in App.tsx, especially for any elements that change opacity of the page.
 /* eslint-disable */
 // @ts-nocheck
 export const executeVWO = () => {

--- a/src/utils/vwo.ts
+++ b/src/utils/vwo.ts
@@ -12,7 +12,7 @@ export const executeVWO = () => {
         library_tolerance = 2500,
         use_existing_jquery = false,
         is_spa = 1,
-        hide_element = 'body',
+        hide_element = '',
         /* DO NOT EDIT BELOW THIS LINE */
         f = false,
         d = document,


### PR DESCRIPTION
Closes #5545 

The VWO analytics script has an anti-flicker function that temporarily sets `<body>` opacity to zero using a `<style>` element. The script is behind the `vwoAbTesting` flag, which is currently `false` in prod.

The element is supposed to be removed if the remote VWO script (a) doesn't load, (b) finishes loading, or (c) fails to finish loading after a given time period (default, 2s). As explained in EAR 3553, the VWO script doesn't have sufficient error handling to deal with failures in the script itself, so errors can cause the opacity-zero `<style />` tag to remain on the DOM.

Proposed Changes
--

1. Change the value of the `hide_element` variable in the script from `body` to an empty string. 

This is endorsed by VWO for situations where the anti-flicker script isn't working correctly, and having a brief flicker on load is acceptable. [Customizing Your VWO SmartCode](https://help.vwo.com/hc/en-us/articles/360037883434-Customizing-your-VWO-SmartCode) 

2. Add custom error handling around the VWO script.

This is still necessary regardless of whether or not we apply fix 1 because (a) the VWO script can otherwise still throw uncaught errors and (b) even when `hide_element` is set to an empty string, it still adds a `style` element with opacity zero to the DOM (the CSS just doesn't specify that the style applies to the body tag).

Now, App will remove the `<style>` tag with `id` of `_vis_opt_path_hides` whenever the VWO script throws an error, or, regardless, after 2 seconds have elapsed. Any error will be reported to honeybadger.

Before Fix
--
Errors thrown by the VWO script are not caught.

https://user-images.githubusercontent.com/91283923/187460562-24fbdeca-1263-4088-b7f2-87226fae39d2.mov

Failure of the VWO script to remove the opacity-zero `style` element leaves all DOM elements invisible indefinitely.

https://user-images.githubusercontent.com/91283923/187460774-4481f296-e613-443e-828a-70cb9f34831c.mov

After Fix
--
Failures in the VWO script are caught, and `<App>` removes the `style` element itself.

Logs are added for illustration, and are not part of the PR. First log shows that the zero-opacity style element, in the case of an error, is on the DOM, even though `hide_element` is set to empty string. Second log shows that we successfully removed the element when an error was thrown, so there was nothing to remove when our fallback `setTimeout` fired.

https://user-images.githubusercontent.com/91283923/187460978-b8826140-59e9-4134-831e-db8e19f85c00.mov


### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - YES - `vwoAbTesting`
