### PR TITLE
chore: change "Try New Data Explorer" to "Preview New Script Editor"

### DIFF
--- a/src/dataExplorer/components/DataExplorerPage.tsx
+++ b/src/dataExplorer/components/DataExplorerPage.tsx
@@ -85,7 +85,7 @@ const DataExplorerPageHeader: FC = () => {
       <FlexBox margin={ComponentSize.Large}>
         <FeatureFlag name="newDataExplorer">
           <FlexBox margin={ComponentSize.Medium}>
-            <InputLabel>&#10024; Try new Data Explorer</InputLabel>
+            <InputLabel>&#10024; Preview New Script Editor</InputLabel>
             <SlideToggle
               active={fluxQueryBuilder}
               onChange={toggleSlider}


### PR DESCRIPTION
Closes #5515 

This PR changes the text "Try New Data Explorer" to "Preview New Script Editor" as requested in the original issue

## After
<img width="1498" alt="Screen Shot 2022-08-30 at 11 24 31 AM" src="https://user-images.githubusercontent.com/14298407/187490285-2c17b42d-6e40-4427-9ec3-5ddf78bfe88c.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
~~- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~~
~~- [ ] Feature flagged, if applicable~~
