### PR TITLE
fix: adjust top-right notification margins for multi-org

### DIFF
--- a/src/MultiOrgOverrideStyles.scss
+++ b/src/MultiOrgOverrideStyles.scss
@@ -23,6 +23,8 @@
   height: calc(100% - gh.$globalheader-height);
 }
 
+// When removing multi-org flags, consider whether this override
+// should become a permanent change for all users in Clockface.
 .cf-notification-container {
   &.cf-notification__top {
     top: $cf-space-2xs;

--- a/src/MultiOrgOverrideStyles.scss
+++ b/src/MultiOrgOverrideStyles.scss
@@ -1,4 +1,5 @@
 @use 'src/identity/components/GlobalHeader/GlobalHeaderStyle.scss' as gh;
+@import '@influxdata/clockface/dist/variables.scss';
 
 // Reduce size of page headers
 .multi-org .cf-page-header {
@@ -20,4 +21,13 @@
 // Page-specific fix for Data Explorer - New
 .multi-org .flux-query-builder--container {
   height: calc(100% - gh.$globalheader-height);
+}
+
+.cf-notification-container {
+  &.cf-notification__top {
+    top: $cf-space-2xs;
+  }
+  &.cf-notification__right {
+    right: $cf-space-2xs;
+  }
 }


### PR DESCRIPTION
Closes #5594 

This PR reduces top and right margins on top-right notifications because those notifications' slight overlap with the user avatar from multi-org isn't visually appealing.
![Screen Shot 2022-08-30 at 11 06 26 AM](https://user-images.githubusercontent.com/91283923/187509648-1f98cfa6-e1b4-43a4-a7e6-78b7ad862c5e.png)

Ideally we'd apply the style conditionally. But we can't apply conditional styles to the notifications in the UI code using `classNames` without more significant restructuring of the notification code than this change warrants, because the notification container and its `className` properties are created by Clockface using a React Portal that lives in a separate DOM element outside of `React.root`.

![Screen Shot 2022-08-30 at 12 29 04 PM](https://user-images.githubusercontent.com/91283923/187510103-b26ee578-9248-4fa5-92c4-d5df2aa336ff.png)

Once multi-org is no longer being tweaked, we could consider making this change in clockface for everyone, instead of doing a css override. 

Before:
--
Multi-Org Off
--
https://user-images.githubusercontent.com/91283923/188015102-41dbdb5d-c125-4045-8cf8-67e4a63fffa6.mov

Multi-Org On
--
https://user-images.githubusercontent.com/91283923/188015112-29632623-74d4-4e81-807d-20677b6fa6fe.mov


After: 
--
Multi-Org Off
--
https://user-images.githubusercontent.com/91283923/188015122-6c43de2d-e7c9-4358-8e6a-d4f897d2a554.mov

Multi-Org On
--
https://user-images.githubusercontent.com/91283923/188015129-ac32016f-98b5-45c3-b983-018d566cc4ad.mov



### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - Not flagged.
