### PR TITLE
fix(multiOrg/dropdown): margins on the horizontal divider

### DIFF
--- a/src/identity/components/GlobalHeader/GlobalHeaderDropdown/GlobalHeaderDropdown.scss
+++ b/src/identity/components/GlobalHeader/GlobalHeaderDropdown/GlobalHeaderDropdown.scss
@@ -47,7 +47,7 @@
 }
 
 .line-break {
-  margin: 8px;
+  margin: 6px 0;
   background-color: rgba(241, 241, 243, 0.1);
 }
 


### PR DESCRIPTION
Closes [#5595](https://github.com/influxdata/ui/issues/5595)

Simple CSS fix, fixes a two things:

1. The extra scrollbar
2. The HR now spans until all the rectangular elements, looks more cohesive.


### Before:

![image](https://user-images.githubusercontent.com/18511823/187519425-8eea5820-7f8a-4cf2-b457-02fae288253f.png)

### After: 

<img width="298" alt="Screen Shot 2022-08-30 at 11 52 11 AM" src="https://user-images.githubusercontent.com/18511823/187519162-230f427d-cad1-47f5-a176-cbed6a14f287.png">
<img width="312" alt="Screen Shot 2022-08-30 at 11 52 07 AM" src="https://user-images.githubusercontent.com/18511823/187519164-d0282497-6e7f-43b5-8b8c-185de26230bf.png">


<!-- Describe your proposed changes here. -->
<!-- Including screenshots or visuals is very helpful - a picture is worth a thousand words. -->

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
