### PR TITLE
chore: update webpack bundle analyzer

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "tslib": "^2.0.3",
     "typescript": "3.8.3",
     "webpack": "^4.46.0",
-    "webpack-bundle-analyzer": "^4.5.0",
+    "webpack-bundle-analyzer": "^4.6.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.1.1",
     "webpack-merge": "^4.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12320,10 +12320,10 @@ webidl-conversions@^7.0.0:
   resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz"
   integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
 
-webpack-bundle-analyzer@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.5.0.tgz"
-  integrity sha512-GUMZlM3SKwS8Z+CKeIFx7CVoHn3dXFcUAjT/dcZQQmfSZGvitPfMob2ipjai7ovFFqPvTqkEZ/leL4O0YOdAYQ==
+webpack-bundle-analyzer@^4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.6.1.tgz#bee2ee05f4ba4ed430e4831a319126bb4ed9f5a6"
+  integrity sha512-oKz9Oz9j3rUciLNfpGFjOb49/jEpXNmWdVH8Ls//zNcnLlQdTGXQQMsBbb/gR7Zl8WNLxVCq+0Hqbx3zv6twBw==
   dependencies:
     acorn "^8.0.4"
     acorn-walk "^8.0.0"


### PR DESCRIPTION
Running `yarn outdated` yielded a list of outdated packages.
Exhaustive list [HERE](https://docs.google.com/spreadsheets/d/1g1ie5AdCwbqRnErLIa8j9b9V_POqSTxToWm_MYxz7b0/edit#gid=0)

update `webpack-bundle-analyzer` to 4.6.1
Customer shouldn't see any impact from this change.

## BEFORE
<img width="1791" alt="BEFORE" src="https://user-images.githubusercontent.com/1637395/187527176-59793e54-7d05-41ed-83b9-684f9631d3fa.png">



## AFTER
<img width="1792" alt="AFTER" src="https://user-images.githubusercontent.com/1637395/187527199-82772b18-7902-4203-8b90-8b5e9ebe4a26.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
