### PR TITLE
fix: make `schemaComposition` feature flag responsive

### DIFF
--- a/src/dataExplorer/components/Schema.tsx
+++ b/src/dataExplorer/components/Schema.tsx
@@ -25,7 +25,6 @@ import {QueryScope} from 'src/shared/contexts/query'
 
 // Utils
 import {getOrg} from 'src/organizations/selectors'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Style
 import './Schema.scss'
@@ -82,9 +81,7 @@ const Schema: FC = () => {
               <div className="scroll--container">
                 <DapperScrollbars>
                   <div className="schema-browser" data-testid="schema-browser">
-                    {isFlagEnabled('schemaComposition') && (
-                      <SchemaBrowserHeading />
-                    )}
+                    <SchemaBrowserHeading />
                     <BucketSelector />
                     <div className="container-side-bar">
                       <MeasurementSelector />

--- a/src/dataExplorer/components/SchemaBrowserHeading.tsx
+++ b/src/dataExplorer/components/SchemaBrowserHeading.tsx
@@ -14,6 +14,9 @@ import SelectorTitle from 'src/dataExplorer/components/SelectorTitle'
 import {FluxQueryBuilderContext} from 'src/dataExplorer/context/fluxQueryBuilder'
 import {PersistanceContext} from 'src/dataExplorer/context/persistance'
 
+// Utils
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+
 const FLUX_SYNC_DISABLE_TEXT = `Schema Sync is no longer available because the \
 code block has been edited.`
 
@@ -42,6 +45,10 @@ const SchemaBrowserHeading: FC = () => {
       </span>
     </div>
   )
+
+  if (!isFlagEnabled('schemaComposition')) {
+    return null
+  }
 
   return (
     <FlexBox

--- a/src/dataExplorer/components/SchemaBrowserHeading.tsx
+++ b/src/dataExplorer/components/SchemaBrowserHeading.tsx
@@ -1,4 +1,4 @@
-import React, {FC, useContext, useMemo} from 'react'
+import React, {FC, useContext} from 'react'
 
 // Components
 import {
@@ -43,38 +43,35 @@ const SchemaBrowserHeading: FC = () => {
     </div>
   )
 
-  return useMemo(
-    () => (
-      <FlexBox
-        className="schema-browser-heading"
-        justifyContent={JustifyContent.SpaceBetween}
-      >
-        <div className="schema-browser-heading--text">Schema Browser</div>
-        <FlexBox className="flux-sync">
-          <SlideToggle
-            className="flux-sync--toggle"
-            active={fluxSync}
-            onChange={handleFluxSyncToggle}
-            testID="flux-sync--toggle"
-            disabled={disableToggle}
-            tooltipText={disableTooltipText}
-          />
-          <InputLabel className="flux-sync--label">
-            <div
-              className={`${disableToggle ? 'disabled' : ''}`}
-              title={disableTooltipText}
-            >
-              <SelectorTitle
-                label="Flux Sync"
-                tooltipContents={tooltipContents}
-                icon={IconFont.Sync}
-              />
-            </div>
-          </InputLabel>
-        </FlexBox>
+  return (
+    <FlexBox
+      className="schema-browser-heading"
+      justifyContent={JustifyContent.SpaceBetween}
+    >
+      <div className="schema-browser-heading--text">Schema Browser</div>
+      <FlexBox className="flux-sync">
+        <SlideToggle
+          className="flux-sync--toggle"
+          active={fluxSync}
+          onChange={handleFluxSyncToggle}
+          testID="flux-sync--toggle"
+          disabled={disableToggle}
+          tooltipText={disableTooltipText}
+        />
+        <InputLabel className="flux-sync--label">
+          <div
+            className={`${disableToggle ? 'disabled' : ''}`}
+            title={disableTooltipText}
+          >
+            <SelectorTitle
+              label="Flux Sync"
+              tooltipContents={tooltipContents}
+              icon={IconFont.Sync}
+            />
+          </div>
+        </InputLabel>
       </FlexBox>
-    ),
-    [fluxSync, toggleFluxSync]
+    </FlexBox>
   )
 }
 


### PR DESCRIPTION
This PR fixes a bug where `schemaComposition` feature flag wasn't responsive. With the bug, the users have to refresh the page in order to see the feature behind the flag. Now, no need to refresh the page.

## Before

https://user-images.githubusercontent.com/14298407/187776906-739f2e6f-7316-4461-815a-65f872d9d888.mov


## After

https://user-images.githubusercontent.com/14298407/187776641-6ac505dc-ae51-4f82-8114-5573c2a8bc78.mov


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
~~- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~~
- [x] Feature flagged, if applicable
