### PR TITLE
fix: adjust page-specific styles for globalheader

### DIFF
--- a/src/MultiOrgOverrideStyles.scss
+++ b/src/MultiOrgOverrideStyles.scss
@@ -12,7 +12,12 @@
   height: calc(100% - gh.$globalheader-height);
 }
 
-// Page-specific fix for Data Explorer
+// Page-specific fix for Data Explorer - Classic
 .multi-org .data-explorer > .time-machine > .cf-draggable-resizer {
+  height: calc(100% - gh.$globalheader-height);
+}
+
+// Page-specific fix for Data Explorer - New
+.multi-org .flux-query-builder--container {
   height: calc(100% - gh.$globalheader-height);
 }

--- a/src/MultiOrgOverrideStyles.scss
+++ b/src/MultiOrgOverrideStyles.scss
@@ -1,5 +1,18 @@
+@use 'src/identity/components/GlobalHeader/GlobalHeaderStyle.scss' as gh;
+
+// Reduce size of page headers
 .multi-org .cf-page-header {
-  height: 45px !important;
-  flex: 0 0 45px !important;
-  margin-bottom: 12px !important;
+  height: 46px !important;
+  flex: 0 0 46px !important;
+  margin-bottom: 14px !important;
+}
+
+// Adjust most pages for multi-org by changing the size of the Dapper Scroll Bar wrapper.
+.multi-org .cf-page-contents > .ScrollbarsCustom-Wrapper {
+  height: calc(100% - gh.$globalheader-height);
+}
+
+// Page-specific fix for Data Explorer
+.multi-org .data-explorer > .time-machine > .cf-draggable-resizer {
+  height: calc(100% - gh.$globalheader-height);
 }

--- a/src/authorizations/components/TokensTab.tsx
+++ b/src/authorizations/components/TokensTab.tsx
@@ -41,6 +41,9 @@ import './TokensTabStyles.scss'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {event} from 'src/cloud/utils/reporting'
 
+// Constants
+import {GLOBAL_HEADER_HEIGHT} from 'src/identity/components/GlobalHeader/constants'
+
 enum AuthSearchKeys {
   Description = 'description',
   Status = 'status',
@@ -209,7 +212,11 @@ class TokensTab extends PureComponent<Props, State> {
                 DEFAULT_TAB_NAVIGATION_HEIGHT +
                 DEFAULT_ALERT_HEIGHT
 
-            const adjustedHeight = height - heightWithPagination
+            const adjustedHeight =
+              height -
+              heightWithPagination -
+              (isFlagEnabled('multiOrg') ? GLOBAL_HEADER_HEIGHT : 0)
+
             return (
               <>
                 <div style={{margin: '10px 0px'}}>

--- a/src/buckets/components/BucketsTab.tsx
+++ b/src/buckets/components/BucketsTab.tsx
@@ -38,10 +38,14 @@ import {checkBucketLimits as checkBucketLimitsAction} from 'src/cloud/actions/li
 import {getBucketLimitStatus} from 'src/cloud/utils/limits'
 import {getAll} from 'src/resources/selectors'
 import {SortTypes} from 'src/shared/utils/sort'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Types
 import {AppState, Bucket, OwnBucket, ResourceType} from 'src/types'
 import {BucketSortKey} from 'src/shared/components/resource_sort_dropdown/generateSortItems'
+
+// Constants
+import {GLOBAL_HEADER_HEIGHT} from 'src/identity/components/GlobalHeader/constants'
 
 interface State {
   searchTerm: string
@@ -138,7 +142,11 @@ class BucketsTab extends PureComponent<Props, State> {
               DEFAULT_TAB_NAVIGATION_HEIGHT ||
             DEFAULT_PAGINATION_CONTROL_HEIGHT + DEFAULT_TAB_NAVIGATION_HEIGHT
 
-          const adjustedHeight = height - heightWithPagination
+          const adjustedHeight =
+            height -
+            heightWithPagination -
+            (isFlagEnabled('multiOrg') ? GLOBAL_HEADER_HEIGHT : 0)
+
           return (
             <>
               <TabbedPageHeader

--- a/src/flows/components/FlowPage.tsx
+++ b/src/flows/components/FlowPage.tsx
@@ -11,6 +11,12 @@ import {PopupDrawer, PopupProvider} from 'src/flows/context/popup'
 import {ResultsProvider} from 'src/flows/context/results'
 import {SidebarProvider} from 'src/flows/context/sidebar'
 
+// Utils
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+
+// Constants
+import {GLOBAL_HEADER_HEIGHT} from 'src/identity/components/GlobalHeader/constants'
+
 // Components
 import PipeList from 'src/flows/components/PipeList'
 import {SubSideBar} from 'src/flows/components/Sidebar'
@@ -32,13 +38,19 @@ const RunOnMount = () => {
   return null
 }
 
+const flowPageHeight = {
+  height: isFlagEnabled('multiOrg')
+    ? `calc(100% - ${GLOBAL_HEADER_HEIGHT}px)`
+    : '100%',
+}
+
 export const FlowPage: FC = () => (
   <ResultsProvider>
     <FlowQueryProvider>
       <RunOnMount />
       <FlowKeyboardPreview />
       <SidebarProvider>
-        <Page>
+        <Page style={flowPageHeight}>
           <FlowHeader />
           <Page.Contents
             fullWidth={true}

--- a/src/identity/components/GlobalHeader/GlobalHeaderStyle.scss
+++ b/src/identity/components/GlobalHeader/GlobalHeaderStyle.scss
@@ -1,10 +1,13 @@
+// If this height is changed also change GLOBAL_HEADER_HEIGHT constant.
+$globalheader-height: 60px;
+
 .multiaccountorg--header {
-  height: 60px;
-  padding-top: 0px;
+  height: $globalheader-height;
+  padding-top: 12px;
   padding-right: 32px;
   padding-bottom: 12px;
   padding-left: 22px;
-  margin-top: 12px;
+  margin-top: 0px;
   margin-right: 0px;
   margin-bottom: 0px;
   margin-left: 0px;

--- a/src/identity/components/GlobalHeader/constants/index.ts
+++ b/src/identity/components/GlobalHeader/constants/index.ts
@@ -1,0 +1,1 @@
+export const GLOBAL_HEADER_HEIGHT = 60

--- a/src/identity/components/GlobalHeader/constants/index.ts
+++ b/src/identity/components/GlobalHeader/constants/index.ts
@@ -1,1 +1,2 @@
+// If this height is changed, also change $globalheader-height sass variable.
 export const GLOBAL_HEADER_HEIGHT = 60


### PR DESCRIPTION
Connects #5607  
Closes #5603 

When multi-org is on, the bottom of certain pages is being clipped. The primary cause is that our existing `Page` components and `DapperScrollBars` presume that 100% of the viewport is available for rendering the page. The `GlobalHeader` component is out of `Page`, so we end up with a slight overflow on certain pages beyond the viewport (equal in size to the height of `GlobalHeader`).

Adjusting `Page` size conditionally does not work consistently on all pages due to minor formatting differences, so some custom page-specific adjustments are needed.

This PR resolves the cutoff on all pages on which I've located this problem except for pages using `MonacoEditor`. I'll make that the subject of a separate PR, as it requires more investigation, and need not hold up this fix.

Classic UI (#5607)
--
https://user-images.githubusercontent.com/91283923/187976452-e2af7790-1806-425a-b1d1-47f62190e4a0.mov

New Data Explorer & Script Editor (#5603)
--
https://user-images.githubusercontent.com/91283923/187992538-d8a19ae2-fb65-46e8-828d-a57918578241.mov





### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - `multiOrg`
