### PR TITLE
fix: update the query results for adaptive zoom only for a non-empty response

### DIFF
--- a/src/visualization/utils/useVisDomainSettings.ts
+++ b/src/visualization/utils/useVisDomainSettings.ts
@@ -242,10 +242,11 @@ export const useZoomRequeryXDomainSettings = (args: ZoomRequeryArgs) => {
         setRequeryStatus(RemoteDataState.Loading)
         runQuery(orgId, query, extern).promise.then(
           (result: RunQueryResult) => {
-            if (result.type === 'SUCCESS') {
+            if (result?.type === 'SUCCESS') {
               setRequeryStatus(RemoteDataState.Done)
-              const parsed = fromFlux(result.csv)
-              setResult(parsed)
+              if (result?.csv?.trim().length > 0) {
+                setResult(fromFlux(result.csv))
+              }
             } else {
               setRequeryStatus(RemoteDataState.Error)
             }
@@ -393,10 +394,11 @@ export const useZoomRequeryYDomainSettings = (args: ZoomRequeryArgs) => {
         setRequeryStatus(RemoteDataState.Loading)
         runQuery(orgId, query, extern).promise.then(
           (result: RunQueryResult) => {
-            if (result.type === 'SUCCESS') {
+            if (result?.type === 'SUCCESS') {
               setRequeryStatus(RemoteDataState.Done)
-              const parsed = fromFlux(result.csv)
-              setResult(parsed)
+              if (result?.csv?.trim().length > 0) {
+                setResult(fromFlux(result.csv))
+              }
             } else {
               setRequeryStatus(RemoteDataState.Error)
             }


### PR DESCRIPTION
Closes #5627 

Updates the query results for an adaptive zoom only when the response is non-empty. This prevents the graph from erroring out.


Adaptive Zoom over empty time period:

https://user-images.githubusercontent.com/10736577/188025067-0ff43a23-48fa-4f81-a2ea-4ae16f28f23d.mp4


