### PR TITLE
feat(5622): reinit full composition block at once

### DIFF
--- a/src/languageSupport/languages/flux/lsp/connection.ts
+++ b/src/languageSupport/languages/flux/lsp/connection.ts
@@ -155,8 +155,7 @@ class LspConnectionManager {
   }
 
   _editorChangeIsFromLsp(change) {
-    // heuristic. Not 100% accurate.
-    return !!change.forceMoveMarkers
+    return change.text?.includes('|> yield(name: "_editor_composition")')
   }
 
   _editorChangeIsWithinComposition(change) {

--- a/src/languageSupport/languages/flux/lsp/connection.ts
+++ b/src/languageSupport/languages/flux/lsp/connection.ts
@@ -311,13 +311,34 @@ class LspConnectionManager {
                     * buffer of executeCommands, send to Lsp at a throttled pace (hack timeouts)  
                   * longterm: middleware? changes in Lsp?
     */
-    if (toAdd.bucket || toAdd.measurement) {
-      const payload = {bucket: toAdd.bucket?.name || this._session.bucket?.name}
-      if (toAdd.measurement) {
-        payload['measurement'] = toAdd.measurement
+    const numFieldChanges =
+      (toAdd.fields?.length || 0) + (toRemove.fields?.length || 0)
+    const numTagValueChanges =
+      (toAdd.tagValues?.length || 0) + (toRemove.tagValues?.length || 0)
+    const reInitBlock =
+      toAdd.bucket ||
+      toAdd.measurement ||
+      numFieldChanges + numTagValueChanges > 1
+
+    if (reInitBlock) {
+      const payload = {
+        bucket: toAdd.bucket?.name || this._session.bucket?.name,
+      }
+      if (toAdd.measurement || this._session.measurement) {
+        payload['measurement'] = toAdd.measurement || this._session.measurement
+      }
+      if (toAdd.fields || this._session.fields) {
+        payload['fields'] = toAdd.fields || this._session.fields
+      }
+      if (toAdd.tagValues || this._session.tagValues) {
+        payload['tagValues'] = (
+          toAdd.tagValues || this._session.tagValues
+        ).map(({key, value}) => [key, value])
       }
       this._insertBuffer([ExecuteCommand.CompositionInit, payload])
+      return // re-initialize full block. no more requests needed.
     }
+
     if (toRemove.fields?.length) {
       toRemove.fields.forEach(value =>
         this._insertBuffer([ExecuteCommand.CompositionRemoveField, {value}])

--- a/src/languageSupport/languages/flux/lsp/utils.ts
+++ b/src/languageSupport/languages/flux/lsp/utils.ts
@@ -74,6 +74,8 @@ export type ExecuteCommandInjectField = ExecuteCommandInjectMeasurement
 export interface CompositionInitParams {
   bucket: string
   measurement?: string
+  fields?: string[]
+  tagValues?: string[]
 }
 
 interface CompositionValueParams extends ExecuteCommandParams {


### PR DESCRIPTION
Closes #5622 

## Done:
* updated resyncing (and page reloads):
    * **Problem:** on re-sync with an entire change in the schema composition block, with new measurements + fields + tagValues, right now that's a series of request/response loops (executeCommand and applyEdits). This has a ramification of: (1) increased chance of getting out of sync, and (2) takes more time.
    * **Solution:**  instead, have a single composition block initialize command be able to handle fields and tagValues too. So is a single request/response.
* fixed heuristic used in `_editorChangeIsFromLsp()`, to be accurate (based on LSP implementation).

## Vid:

https://user-images.githubusercontent.com/10232835/188017441-4c9a602e-62da-476e-9bcd-fa655dc55e1d.mov



## Future:
We replace the composition block entirely each time, in the applyEdit from the LSP. Arguably, we could start just doing a full reinit with every session change, and send over the latest session (instead of this add versus remove 1 element). 

The only downside of this approach is that we don't have a clean failure case. Meaning, if an `addField` fails in the LSP --> the middleware could detect and simply sync the local UI session (remove the field from the session). This simple failure action would not be possible if we always do a re-init. 