### PR TITLE
fix: change from certProvided to certCreation

### DIFF
--- a/src/types/subscriptions.ts
+++ b/src/types/subscriptions.ts
@@ -43,7 +43,7 @@ export interface Subscription {
   brokerClientCert?: string
   brokerCACert?: string
   authType: BrokerAuthTypes
-  certProvidedAt?: string
+  brokerCertCreationDate?: string
 }
 
 export interface SubscriptionStatus {

--- a/src/writeData/subscriptions/components/CertificateInput.tsx
+++ b/src/writeData/subscriptions/components/CertificateInput.tsx
@@ -147,7 +147,7 @@ export const ReplaceCertificateOverlay: FC<ReplaceCertificateModalProps> = () =>
     params: {subscription, updateForm},
   } = useContext(OverlayContext)
   const handleReplaceCert = useCallback(() => {
-    updateForm({...subscription, certProvidedAt: null})
+    updateForm({...subscription, brokerCertCreationDate: null})
     onClose()
   }, [subscription, updateForm, onClose])
   return (
@@ -202,7 +202,7 @@ const CertificateDetails: FC<OwnProps> = ({subscription, updateForm, edit}) => {
             Certificate
           </InputLabel>
           <InputLabel size={ComponentSize.Small}>
-            {subscription.certProvidedAt}
+            {subscription.brokerCertCreationDate}
           </InputLabel>
         </FlexBox>
       </FlexBoxChild>
@@ -232,7 +232,7 @@ const CertificateDetails: FC<OwnProps> = ({subscription, updateForm, edit}) => {
 const CertificateInput: FC<OwnProps> = ({subscription, updateForm, edit}) => {
   if (
     subscription.authType === BrokerAuthTypes.Certificate &&
-    subscription.certProvidedAt
+    subscription.brokerCertCreationDate
   ) {
     return (
       <CertificateDetails


### PR DESCRIPTION
related https://github.com/influxdata/data-acquisition/issues/442

nifid will be storing brokerCertCreationDate so updating this key in the UI as currently you cannot edit the certificate even when the flag is on and a certificate is created

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
