### PR TITLE
feat(telegrafsPage): use OverlayController to trigger telegraf output overlay

### DIFF
--- a/src/telegrafs/components/Collectors.test.tsx
+++ b/src/telegrafs/components/Collectors.test.tsx
@@ -18,6 +18,8 @@ const setup = (override = {}) => {
     buckets: [],
     onUpdateTelegraf: jest.fn(),
     onDeleteTelegraf: jest.fn(),
+    showOverlay: jest.fn(),
+    dismissOverlay: jest.fn(),
     ...override,
   }
 

--- a/src/telegrafs/components/Collectors.tsx
+++ b/src/telegrafs/components/Collectors.tsx
@@ -26,6 +26,7 @@ import ResourceSortDropdown from 'src/shared/components/resource_sort_dropdown/R
 
 // Actions
 import {updateTelegraf, deleteTelegraf} from 'src/telegrafs/actions/thunks'
+import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
 
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
@@ -42,9 +43,6 @@ import {getAll} from 'src/resources/selectors'
 // Utils
 import {event} from 'src/cloud/utils/reporting'
 
-type ReduxProps = ConnectedProps<typeof connector>
-type Props = ReduxProps & RouteComponentProps<{orgID: string}>
-
 interface State {
   dataLoaderOverlay: OverlayState
   searchTerm: string
@@ -54,7 +52,12 @@ interface State {
   sortDirection: Sort
   sortType: SortTypes
 }
+interface DispatchProps {
+  showOverlay: (arg1: string, arg2: any, any) => {}
+}
 
+type ReduxProps = ConnectedProps<typeof connector>
+type Props = ReduxProps & RouteComponentProps<{orgID: string}> & DispatchProps
 @ErrorHandling
 export class Collectors extends PureComponent<Props, State> {
   constructor(props: Props) {
@@ -203,14 +206,8 @@ export class Collectors extends PureComponent<Props, State> {
   }
 
   private handleJustTheOutput = () => {
-    const {
-      history,
-      match: {
-        params: {orgID},
-      },
-    } = this.props
-
-    history.push(`/orgs/${orgID}/load-data/telegrafs/output`)
+    const {showOverlay, dismissOverlay} = this.props
+    showOverlay('telegraf-output', null, () => dismissOverlay())
     event('load_data.telegrafs.influxdb_output_plugin_button.clicked')
   }
 
@@ -270,6 +267,8 @@ const mstp = (state: AppState) => {
 const mdtp = {
   onUpdateTelegraf: updateTelegraf,
   onDeleteTelegraf: deleteTelegraf,
+  showOverlay,
+  dismissOverlay,
 }
 
 const connector = connect(mstp, mdtp)

--- a/src/telegrafs/components/TelegrafOutputOverlay.tsx
+++ b/src/telegrafs/components/TelegrafOutputOverlay.tsx
@@ -164,7 +164,7 @@ class TelegrafOutputOverlay extends PureComponent<Props> {
             </Link>
             .
           </p>
-          <p>{bucket_dd}</p>
+          <div style={{marginBottom: '13px'}}>{bucket_dd}</div>
           <div className="output-overlay">
             <TemplateProvider
               variables={{

--- a/src/telegrafs/components/TelegrafOutputOverlay.tsx
+++ b/src/telegrafs/components/TelegrafOutputOverlay.tsx
@@ -156,7 +156,10 @@ class TelegrafOutputOverlay extends PureComponent<Props> {
         <Overlay.Body>
           <p style={{marginTop: '-18px'}}>
             The $INFLUX_TOKEN can be generated on the
-            <Link to={`/orgs/${orgID}/load-data/tokens`}>
+            <Link
+              to={`/orgs/${orgID}/load-data/tokens`}
+              onClick={this.handleDismiss}
+            >
               &nbsp;API Tokens tab
             </Link>
             .

--- a/src/telegrafs/containers/TelegrafsPage.tsx
+++ b/src/telegrafs/containers/TelegrafsPage.tsx
@@ -23,13 +23,6 @@ const TelegrafConfigOverlay = RouteOverlay(
     history.push(`/orgs/${params.orgID}/load-data/telegrafs`)
   }
 )
-const TelegrafOutputOverlay = RouteOverlay(
-  OverlayHandler as any,
-  'telegraf-output',
-  (history, params) => {
-    history.push(`/orgs/${params.orgID}/load-data/telegrafs`)
-  }
-)
 
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
@@ -67,10 +60,6 @@ class TelegrafsPage extends PureComponent {
           <Route
             path={`${telegrafsPath}/:id/instructions`}
             component={TelegrafInstructionsOverlay}
-          />
-          <Route
-            path={`${telegrafsPath}/output`}
-            component={TelegrafOutputOverlay}
           />
           <Route
             path={`${telegrafsPath}/new`}


### PR DESCRIPTION
Part of #3970 

This is a part of a bigger pr that refactors `TelegrafsPage` to use overlay controller instead of React Router. 
This pr removes the `/output` route for `TelegrafOutputOverlay` and connects it to the overlaycontroller so it can be triggered without route change. 

https://user-images.githubusercontent.com/66275100/188188026-928987ab-42d9-46b6-9c69-9db2f9c35999.mov

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
