### PR TITLE
build(lsp): upgrade flux-lsp to 0.8.33

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "@codingame/monaco-jsonrpc": "^0.3.1",
     "@docsearch/react": "^3.0.0-alpha.37",
     "@influxdata/clockface": "^6.3.0",
-    "@influxdata/flux-lsp-browser": "0.8.32",
+    "@influxdata/flux-lsp-browser": "0.8.33",
     "@influxdata/giraffe": "^2.34.1",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1428,10 +1428,10 @@
     "@types/react-window" "^1.8.5"
     react-window "^1.8.7"
 
-"@influxdata/flux-lsp-browser@0.8.32":
-  version "0.8.32"
-  resolved "https://registry.yarnpkg.com/@influxdata/flux-lsp-browser/-/flux-lsp-browser-0.8.32.tgz#ae60cdb6f1c4ac2cf06bb9d3ed9f3e0548575489"
-  integrity sha512-LUSQMO8mYQmzARdqxP5w/L2MRv5oH8986zn9034YowMEzIZmjMowJujm/kt40jorqOy9t+ier5qxgutUFKmfXA==
+"@influxdata/flux-lsp-browser@0.8.33":
+  version "0.8.33"
+  resolved "https://registry.yarnpkg.com/@influxdata/flux-lsp-browser/-/flux-lsp-browser-0.8.33.tgz#2d97603cbd352fdb4602447ebcdf4f7bbe4584ce"
+  integrity sha512-sOdqggVje91W9EZ1UDMrOdrA2TndGuqPxz8fSB+Le6JRnlzxxWFZ4HXPl+gSW3MtA7U/saiGCITdwMZl3D9Hxg==
 
 "@influxdata/giraffe@^2.34.1":
   version "2.34.1"


### PR DESCRIPTION
## Before
Changes in composition block, would duplicate code outside the block. Could not copy/paste subqueries below, and then keep editing the block.
https://github.com/influxdata/ui/issues/5634

## After LSP patch:

https://user-images.githubusercontent.com/10232835/188196185-b585210c-8e25-4524-8827-45f1d8e884d9.mov


## Bug still not fixed:
It does still keep chopping of the first letter of the text below. But that's a smaller bug, and we can fix it after this major patch goes in.