### PR TITLE
feat(telegrafPage): use OverlayController to open instructions overlay

### DIFF
--- a/src/overlays/components/OverlayController.tsx
+++ b/src/overlays/components/OverlayController.tsx
@@ -18,6 +18,7 @@ import NoteEditorOverlay from 'src/dashboards/components/NoteEditorOverlay'
 import AllAccessTokenOverlay from 'src/authorizations/components/AllAccessTokenOverlay'
 import TelegrafConfigOverlay from 'src/telegrafs/components/TelegrafConfigOverlay'
 import TelegrafOutputOverlay from 'src/telegrafs/components/TelegrafOutputOverlay'
+import TelegrafInstructionsOverlay from 'src/telegrafs/components/TelegrafInstructionsOverlay'
 import OrgSwitcherOverlay from 'src/pageLayout/components/OrgSwitcherOverlay'
 import CreateBucketOverlay from 'src/buckets/components/createBucketForm/CreateBucketOverlay'
 import AssetLimitOverlay from 'src/cloud/components/AssetLimitOverlay'
@@ -94,6 +95,11 @@ export const OverlayController: FunctionComponent = () => {
         break
       case 'telegraf-output':
         activeOverlay.current = <TelegrafOutputOverlay onClose={onClose} />
+        break
+      case 'telegraf-instructions':
+        activeOverlay.current = (
+          <TelegrafInstructionsOverlay onClose={onClose} />
+        )
         break
       case 'switch-organizations':
         activeOverlay.current = <OrgSwitcherOverlay onClose={onClose} />

--- a/src/overlays/components/index.tsx
+++ b/src/overlays/components/index.tsx
@@ -52,6 +52,14 @@ export const TelegrafOutputOverlay = RouteOverlay(
   }
 )
 
+export const TelegrafInstructionsOverlay = RouteOverlay(
+  OverlayHandler,
+  'telegraf-instructions',
+  (history, params) => {
+    history.push(`/orgs/${params.orgID}/load-data/telegrafs`)
+  }
+)
+
 export const AddAnnotationDEOverlay = RouteOverlay(
   OverlayHandler,
   'add-annotation',

--- a/src/overlays/reducers/overlays.ts
+++ b/src/overlays/reducers/overlays.ts
@@ -15,6 +15,7 @@ export type OverlayID =
   | 'add-token'
   | 'telegraf-config'
   | 'telegraf-output'
+  | 'telegraf-instructions'
   | 'switch-organizations'
   | 'create-bucket'
   | 'asset-limit'

--- a/src/telegrafs/components/CollectorCard.scss
+++ b/src/telegrafs/components/CollectorCard.scss
@@ -1,0 +1,7 @@
+.setup-instructions {
+  cursor: pointer;
+  color: #00a3ff;
+}
+.setup-instructions:hover {
+  color: #00c9ff;
+}

--- a/src/telegrafs/components/CollectorCard.tsx
+++ b/src/telegrafs/components/CollectorCard.tsx
@@ -24,6 +24,7 @@ import {
   addTelegrafLabelAsync,
   removeTelegrafLabelAsync,
 } from 'src/telegrafs/actions/thunks'
+import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
 
 import {cloneTelegraf} from 'src/telegrafs/actions/thunks'
 // Selectors
@@ -52,7 +53,7 @@ class CollectorRow extends PureComponent<
   Props & RouteComponentProps<{orgID: string}>
 > {
   public render() {
-    const {collector, org} = this.props
+    const {collector} = this.props
 
     return (
       <ResourceCard
@@ -76,8 +77,9 @@ class CollectorRow extends PureComponent<
         />
         <ResourceCard.Meta>
           <Link
-            to={`/orgs/${org.id}/load-data/telegrafs/${collector.id}/instructions`}
+            to={''}
             data-testid="setup-instructions-link"
+            onClick={this.openInstructions}
           >
             Setup Instructions
           </Link>
@@ -128,6 +130,16 @@ class CollectorRow extends PureComponent<
           triggerRef={settingsRef}
         />
       </FlexBox>
+    )
+  }
+
+  private openInstructions = e => {
+    e.preventDefault()
+    const {showOverlay, dismissOverlay, collector} = this.props
+    return showOverlay(
+      'telegraf-instructions',
+      {collectorId: collector.id},
+      dismissOverlay
     )
   }
 
@@ -199,6 +211,8 @@ const mdtp = {
   cloneTelegraf,
   onAddLabel: addTelegrafLabelAsync,
   onRemoveLabel: removeTelegrafLabelAsync,
+  showOverlay,
+  dismissOverlay,
 }
 
 const connector = connect(mstp, mdtp)

--- a/src/telegrafs/components/CollectorCard.tsx
+++ b/src/telegrafs/components/CollectorCard.tsx
@@ -77,7 +77,7 @@ class CollectorRow extends PureComponent<
         />
         <ResourceCard.Meta>
           <Link
-            to={''}
+            to=""
             data-testid="setup-instructions-link"
             onClick={this.openInstructionsOverlay}
           >

--- a/src/telegrafs/components/CollectorCard.tsx
+++ b/src/telegrafs/components/CollectorCard.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, {PureComponent, MouseEvent, RefObject, createRef} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
-import {withRouter, RouteComponentProps, Link} from 'react-router-dom'
+import {withRouter, RouteComponentProps} from 'react-router-dom'
 
 // Components
 import {
@@ -38,6 +38,9 @@ import {AppState, Label, Telegraf} from 'src/types'
 
 // Utils
 import {setCloneName} from 'src/utils/naming'
+
+// Styles
+import './CollectorCard.scss'
 
 interface OwnProps {
   collector: Telegraf
@@ -76,13 +79,13 @@ class CollectorRow extends PureComponent<
           placeholder={`Describe ${collector.name}`}
         />
         <ResourceCard.Meta>
-          <Link
-            to=""
+          <span
+            className="setup-instructions"
             data-testid="setup-instructions-link"
             onClick={this.openInstructionsOverlay}
           >
             Setup Instructions
-          </Link>
+          </span>
         </ResourceCard.Meta>
         {this.labels}
       </ResourceCard>

--- a/src/telegrafs/components/CollectorCard.tsx
+++ b/src/telegrafs/components/CollectorCard.tsx
@@ -79,7 +79,7 @@ class CollectorRow extends PureComponent<
           <Link
             to={''}
             data-testid="setup-instructions-link"
-            onClick={this.openInstructions}
+            onClick={this.openInstructionsOverlay}
           >
             Setup Instructions
           </Link>
@@ -133,7 +133,7 @@ class CollectorRow extends PureComponent<
     )
   }
 
-  private openInstructions = e => {
+  private openInstructionsOverlay = e => {
     e.preventDefault()
     const {showOverlay, dismissOverlay, collector} = this.props
     return showOverlay(

--- a/src/telegrafs/containers/TelegrafsPage.tsx
+++ b/src/telegrafs/containers/TelegrafsPage.tsx
@@ -9,7 +9,6 @@ import LoadDataHeader from 'src/settings/components/LoadDataHeader'
 import Collectors from 'src/telegrafs/components/Collectors'
 import GetResources from 'src/resources/components/GetResources'
 import LimitChecker from 'src/cloud/components/LimitChecker'
-import TelegrafInstructionsOverlay from 'src/telegrafs/components/TelegrafInstructionsOverlay'
 import TelegrafUIRefreshWizard from 'src/dataLoaders/components/collectorsWizard/TelegrafUIRefreshWizard'
 import {Page} from '@influxdata/clockface'
 import OverlayHandler, {
@@ -58,8 +57,8 @@ class TelegrafsPage extends PureComponent {
             component={TelegrafConfigOverlay}
           />
           <Route
-            path={`${telegrafsPath}/:id/instructions`}
-            component={TelegrafInstructionsOverlay}
+            path={`${telegrafsPath}/output`}
+            component={TelegrafOutputOverlay}
           />
           <Route
             path={`${telegrafsPath}/new`}

--- a/src/telegrafs/containers/TelegrafsPage.tsx
+++ b/src/telegrafs/containers/TelegrafsPage.tsx
@@ -57,10 +57,6 @@ class TelegrafsPage extends PureComponent {
             component={TelegrafConfigOverlay}
           />
           <Route
-            path={`${telegrafsPath}/output`}
-            component={TelegrafOutputOverlay}
-          />
-          <Route
             path={`${telegrafsPath}/new`}
             component={TelegrafUIRefreshWizard}
           />


### PR DESCRIPTION
Part of #3970 

This is a part of a bigger pr that refactors `TelegrafsPage` to use overlay controller instead of React Router.
This pr removes the `/instructions` route for `TelegrafInstructionsOverlay` and connects it to the overlay controller so it can be triggered without route change.

https://user-images.githubusercontent.com/66275100/188704485-238274d8-cf39-4273-bbfd-103590364092.mov


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
