### PR TITLE
fix: adjust notebooks margins and header size when multi-Org is enabled

### DIFF
--- a/src/MultiOrgOverrideStyles.scss
+++ b/src/MultiOrgOverrideStyles.scss
@@ -1,30 +1,57 @@
 @use 'src/identity/components/GlobalHeader/GlobalHeaderStyle.scss' as gh;
 @import '@influxdata/clockface/dist/variables.scss';
 
-// Reduce size of page headers
+// These are custom per-page adjustments to certain styles that are currently
+// necessary to accomodate the space taken up by the multi-org header in Cloud2.
+
+/* Page Headers Generally */
 .multi-org .cf-page-header {
   height: 46px !important;
   flex: 0 0 46px !important;
   margin-bottom: 14px !important;
 }
 
-// Adjust most pages for multi-org by changing the size of the Dapper Scroll Bar wrapper.
+/* Page Size Generally */
+// Adjusts Dapper Scrollbars height.
 .multi-org .cf-page-contents > .ScrollbarsCustom-Wrapper {
   height: calc(100% - gh.$globalheader-height);
 }
 
-// Page-specific fix for Data Explorer - Classic
+// Data Explorer - Classic
 .multi-org .data-explorer > .time-machine > .cf-draggable-resizer {
   height: calc(100% - gh.$globalheader-height);
 }
 
-// Page-specific fix for Data Explorer - New
+// Data Explorer - New
 .multi-org .flux-query-builder--container {
   height: calc(100% - gh.$globalheader-height);
 }
 
+/* Notebooks */
+// Browser
+.multi-org .cf-page.flows-index {
+  height: calc(100% - gh.$globalheader-height);
+}
+
+// Page Title
+.multi-org
+  .flows-index
+  > .cf-page-header
+  > .cf-page-header--fixed
+  > .cf-flex-box {
+  height: 32px !important;
+  margin-bottom: 10px !important;
+}
+
+// Header Block
+.multi-org .cf-page-header.withButtonHeader {
+  height: 140px !important;
+}
+
+/* Notifications */
 // When removing multi-org flags, consider whether this override
 // should become a permanent change for all users in Clockface.
+
 .cf-notification-container {
   &.cf-notification__top {
     top: $cf-space-2xs;


### PR DESCRIPTION
Closes #5649 

The notebooks browser isn't behaving correctly with `multiOrg` on when the user has more than a few notebooks - the top and bottom of the page are squished. The style adjustments for other pages were not working with notebooks, as there is custom logic on the page that adds more content into the header if the user needs to scroll into more pages of notebooks.  

This PR fixes that issue by adjusting the size of the page title, header, and size of the notebooks (flows) page specifically. 

Note
--
PR #5651 (not yet merged) would change the app structure to have a page element instead of a div. This PR is probably unaffected because its selectors are so specific, but this PR should be rebased and retested if that PR is merged first.

Before
--
https://user-images.githubusercontent.com/91283923/188735287-f288debb-c838-4a68-a9b5-ae4fd8c1ba73.mov

After
--
https://user-images.githubusercontent.com/91283923/188735298-5a0c5e25-235e-4b64-b6b3-b052b592f63f.mov



### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable
