### PR TITLE
test: fix undefined variable in annotation test setup

### DIFF
--- a/cypress/e2e/util/annotationsSetup.ts
+++ b/cypress/e2e/util/annotationsSetup.ts
@@ -10,7 +10,7 @@ export const EDIT_RANGE_ANNOTATION_TEXT =
 export const setupData = (cy: Cypress.Chainable, plotTypeSuffix = '') =>
   cy.flush().then(() =>
     cy.signin().then(() =>
-      cy.get('@org').then(({id: orgID}: Organization) =>
+      cy.get('@org').then(({id: orgID, name}: Organization) =>
         cy.createDashboard(orgID).then(({body}) =>
           cy.fixture('routes').then(({orgs}) => {
             cy.visit(`${orgs}/${orgID}/dashboards/${body.id}`)


### PR DESCRIPTION
Just housekeeping to clean up something i noticed in my code editor.

While there have not been any recent issues with the annotation e2e tests, i noticed that the function call `cy.createBucket(orgID, name, 'devbucket')` is actually referencing an undefined variable called `name`. A quick search in the file will confirm this.

This looks like the code was originally copied over without the `name` variable being destructured from an outer function call. We fix this by doing that now.