### PR TITLE
fix: remove unnecessary set state

### DIFF
--- a/src/writeData/components/PluginAddToExistingConfiguration/Configure.tsx
+++ b/src/writeData/components/PluginAddToExistingConfiguration/Configure.tsx
@@ -62,12 +62,6 @@ const ConfigureComponent: FC<Props> = props => {
     telegraf => telegraf.id === telegrafConfigID
   )
 
-  if (!selectedTelegraf) {
-    setIsValidConfiguration(false)
-  } else {
-    setIsValidConfiguration(true)
-  }
-
   const selectedName = selectedTelegraf
     ? selectedTelegraf.name
     : 'Select a configuration'


### PR DESCRIPTION
Closes #5661 

When selecting a telegraf to add a plugin to an existing configuration, we see a bad set state warning in the console. 
The issue is coming from `Configure.tsx` - an if statement that updates `isValidConfiguration` state (a state maintained inside parent component `Wizard.tsx`) based on whether user has selected a telegraf or not. If a telegraf is selected, it updates the `isValidConfiguration` state to true which activates the `ADD TO EXISTING CONFIG` button in the footer of the overlay. Otherwise, if a telegraf is not selected, it updates the state to false. 
But because `isValidConfiguration` is initialized with a false value, there is no need to update it to false again. Whenever user selects a telegraf, the `onClick` function will update this state to be true which will activate the `ADD TO EXISTING CONFIG` button to allow users to move on to the step. 

Based on this reasoning, pr removes the if statement block. 

Before fix: 

https://user-images.githubusercontent.com/66275100/188921423-08c57bbb-2ee6-4a22-ae69-e952840b81f7.mov


After fix: 
https://user-images.githubusercontent.com/66275100/188916619-cec145e8-18b1-47d4-a3f4-36a0a00a99d0.mov

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
