### PR TITLE
chore: upgrade prettier to 2.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "moment": "^2.29.4",
     "mutation-observer": "^1.0.3",
     "optimize-css-assets-webpack-plugin": "^6.0.1",
-    "prettier": "^1.19.1",
+    "prettier": "^2.7.1",
     "pretty-quick": "^3.1.0",
     "raw-loader": "^4.0.2",
     "sass": "^1.22.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9850,10 +9850,10 @@ prepend-http@^1.0.0:
   resolved "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
 
-prettier@^1.19.1:
-  version "1.19.1"
-  resolved "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+prettier@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
+  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
 pretty-bytes@^5.6.0:
   version "5.6.0"


### PR DESCRIPTION
Running `yarn outdated` yielded a list of outdated packages.
Exhaustive list [HERE](https://docs.google.com/spreadsheets/d/1g1ie5AdCwbqRnErLIa8j9b9V_POqSTxToWm_MYxz7b0/edit#gid=0)

update `prettier` to 2.7.1.
Customer shouldn't see any impact from this change.


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
