### PR TITLE
chore: upgrade immer to 9.0.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
     "history": "^4.7.2",
     "honeybadger-js": "^1.0.2",
     "html2canvas": "^1.3.2",
-    "immer": "^9.0.6",
+    "immer": "^9.0.15",
     "intersection-observer": "^0.7.0",
     "jsonlint-mod": "^1.7.5",
     "jsonpath": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6685,10 +6685,10 @@ immediate@^3.2.3:
   resolved "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz"
   integrity sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==
 
-immer@^9.0.6:
-  version "9.0.7"
-  resolved "https://registry.npmjs.org/immer/-/immer-9.0.7.tgz"
-  integrity sha512-KGllzpbamZDvOIxnmJ0jI840g7Oikx58lBPWV0hUh7dtAyZpFqqrBZdKka5GlTwMTZ1Tjc/bKKW4VSFAt6BqMA==
+immer@^9.0.15:
+  version "9.0.15"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.15.tgz#0b9169e5b1d22137aba7d43f8a81a495dd1b62dc"
+  integrity sha512-2eB/sswms9AEUSkOm4SbV5Y7Vmt/bKRwByd52jfLkW4OLYeaTP3EEiJ9agqU0O/tq6Dk62Zfj+TJSqfm1rLVGQ==
 
 "immutable@^3.8.1 || ^4.0.0", immutable@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Running `yarn outdated` yielded a list of outdated packages.
Exhaustive list [HERE](https://docs.google.com/spreadsheets/d/1g1ie5AdCwbqRnErLIa8j9b9V_POqSTxToWm_MYxz7b0/edit#gid=0)

update `immer` to 9.0.15.
Customer shouldn't see any impact from this change.


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
