### PR TITLE
feat: add hotkey for rerunning a query

### DIFF
--- a/src/dataExplorer/components/ResultsPane.tsx
+++ b/src/dataExplorer/components/ResultsPane.tsx
@@ -41,8 +41,8 @@ import {getWindowPeriodVariableFromVariables} from 'src/variables/utils/getWindo
 // Constants
 import {TIME_RANGE_START, TIME_RANGE_STOP} from 'src/variables/constants'
 
-const FluxMonacoEditor = lazy(() =>
-  import('src/shared/components/FluxMonacoEditor')
+const FluxMonacoEditor = lazy(
+  () => import('src/shared/components/FluxMonacoEditor')
 )
 
 const fakeNotify = notify
@@ -101,7 +101,7 @@ const ResultsPane: FC = () => {
     event('CSV Download Initiated')
     basic(text, {
       vars: rangeToParam(range),
-    }).promise.then(response => {
+    }).promise.then((response) => {
       if (response.type !== 'SUCCESS') {
         return
       }
@@ -115,14 +115,14 @@ const ResultsPane: FC = () => {
     query(text, {
       vars: rangeToParam(range),
     })
-      .then(r => {
+      .then((r) => {
         event('resultReceived', {
           status: r.parsed.table.length === 0 ? 'empty' : 'good',
         })
         setResult(r)
         setStatus(RemoteDataState.Done)
       })
-      .catch(e => {
+      .catch((e) => {
         setResult({
           source: text,
           parsed: null,

--- a/src/dataExplorer/components/ResultsPane.tsx
+++ b/src/dataExplorer/components/ResultsPane.tsx
@@ -169,6 +169,7 @@ const ResultsPane: FC = () => {
                   variables={variables}
                   script={text}
                   onChangeScript={setQuery}
+                  onSubmitScript={submit}
                 />
               </Suspense>
             </div>


### PR DESCRIPTION
Closes #5652

by popular demand, this adds the same submit hotkey found in the original data explorer into the new one!