### PR TITLE
fix: add specific error reporting around default-selected-variable code

### DIFF
--- a/src/variables/selectors/index.tsx
+++ b/src/variables/selectors/index.tsx
@@ -218,12 +218,13 @@ export const getVariable = (state: AppState, variableID: string): Variable => {
       reportErrorThroughHoneyBadger(err, {
         name: 'Failed to set selected variable to default, zero-indexed value',
         context: {
+          identityState: state.identity,
+          resourceState: state.resources,
           variable: vari,
           variableType: vari.arguments.type,
           normalizedVariable: vals,
           variableLenth: vari.selected.length,
           normalizedVariableLength: vals.length,
-          appState: state,
         },
       })
     }

--- a/src/variables/selectors/index.tsx
+++ b/src/variables/selectors/index.tsx
@@ -223,7 +223,7 @@ export const getVariable = (state: AppState, variableID: string): Variable => {
           variable: vari,
           variableType: vari.arguments.type,
           normalizedVariable: vals,
-          variableLenth: vari.selected.length,
+          variableLength: vari.selected.length,
           normalizedVariableLength: vals.length,
         },
       })

--- a/src/variables/selectors/index.tsx
+++ b/src/variables/selectors/index.tsx
@@ -28,6 +28,7 @@ import {AppState, VariableArgumentType, Variable} from 'src/types'
 
 // Utils
 import {filterUnusedVars} from 'src/shared/utils/filterUnusedVars'
+import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
 
 export const extractVariableEditorName = (state: AppState): string => {
   return state.variableEditor.name
@@ -210,7 +211,22 @@ export const getVariable = (state: AppState, variableID: string): Variable => {
   }
 
   if (!vari.selected.length && vals.length) {
-    vari.selected.push(vals[0])
+    try {
+      vari.selected.push(vals[0])
+    } catch (err) {
+      // Temporary measure to resolve errors relating to pushing into non-extensible object.
+      reportErrorThroughHoneyBadger(err, {
+        name: 'Failed to set selected variable to default, zero-indexed value',
+        context: {
+          variable: vari,
+          variableType: vari.arguments.type,
+          normalizedVariable: vals,
+          variableLenth: vari.selected.length,
+          normalizedVariableLength: vals.length,
+          appState: state,
+        },
+      })
+    }
   }
 
   return vari


### PR DESCRIPTION
Connects #5523 

I'm unable to reproduce the `object not extensible` error caused by the app trying to push into a frozen array (`vari.selected`) when there is no currently selected variable, either in remocal or in the environment in which we actually see the error (New Tools). 

This PR adds specific error reporting around this code block, so that we can actually see which variable is causing the issue, and what the state of the app is at that time. The current top-level error reporting doesn't provide that level of detail.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - NO
