### PR TITLE
chore: update prettier config to keep previous behavior

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -2,5 +2,6 @@
   "singleQuote": true,
   "semi": false,
   "trailingComma": "es5",
-  "bracketSpacing": false
+  "bracketSpacing": false,
+  "arrowParens": "avoid"
 }


### PR DESCRIPTION
Prettier upgrade changed the behavior of `arrowParens` to `always` by-default. This will cause our touched files to be modified when prettier is run which may cause some confusion as well as frustration due to changes in expectation.
Changing the config to `avoid` instead to avoid the above mentioned issues.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
