### PR TITLE
chore: remove fluxDynamicDocs feature flag

### DIFF
--- a/cypress/e2e/cloud/explorer.test.ts
+++ b/cypress/e2e/cloud/explorer.test.ts
@@ -52,7 +52,7 @@ describe('DataExplorer', () => {
       // inject function into script editor
       cy.getByTestID('flux--microsecond--inject').click()
 
-      getTimeMachineText().then((text) => {
+      getTimeMachineText().then(text => {
         const expected = 'import "date"  date.microsecond(t: )'
         cy.fluxEqual(text, expected).should('be.true')
       })
@@ -63,7 +63,7 @@ describe('DataExplorer', () => {
 
       cy.getByTestID('flux-toolbar-search--input').click().type('filter')
 
-        cy.getByTestID('flux-toolbar-search--input').click().type('filter')
+      cy.getByTestID('flux-toolbar-search--input').click().type('filter')
 
       cy.get('.flux-toolbar--search').within(() => {
         cy.getByTestID('dismiss-button').click()
@@ -71,13 +71,13 @@ describe('DataExplorer', () => {
 
       cy.getByTestID('flux-toolbar-search--input')
         .invoke('val')
-        .then((value) => {
+        .then(value => {
           expect(value).to.equal('')
         })
 
       cy.getByTestID('flux-toolbar-search--input').click().type('array')
 
-        cy.getByTestID('flux-toolbar-search--input').click().type('array')
+      cy.getByTestID('flux-toolbar-search--input').click().type('array')
 
       cy.get('.flux-toolbar--search').within(() => {
         cy.getByTestID('dismiss-button').click()
@@ -85,7 +85,7 @@ describe('DataExplorer', () => {
 
       cy.getByTestID('flux-toolbar-search--input')
         .invoke('val')
-        .then((value) => {
+        .then(value => {
           expect(value).to.equal('')
         })
     })

--- a/cypress/e2e/cloud/explorer.test.ts
+++ b/cypress/e2e/cloud/explorer.test.ts
@@ -33,73 +33,61 @@ describe('DataExplorer', () => {
     })
 
     it('can use the dynamic flux function selector to build a query', () => {
-      cy.setFeatureFlags({
-        fluxDynamicDocs: true,
-      }).then(() => {
-        cy.get('.view-line').should('be.visible')
+      cy.get('.view-line').should('be.visible')
 
-        cy.getByTestID('flux-toolbar-search--input')
-          .click()
-          .type('microsecondd') // purposefully misspell "microsecond" so all functions are filtered out
+      cy.getByTestID('flux-toolbar-search--input').click().type('microsecondd') // purposefully misspell "microsecond" so all functions are filtered out
 
-        cy.getByTestID('flux-toolbar--list').within(() => {
-          cy.getByTestID('empty-state').should('be.visible')
-        })
-        cy.getByTestID('flux-toolbar-search--input').type('{backspace}')
+      cy.getByTestID('flux-toolbar--list').within(() => {
+        cy.getByTestID('empty-state').should('be.visible')
+      })
+      cy.getByTestID('flux-toolbar-search--input').type('{backspace}')
 
-        cy.get('.flux-toolbar--list-item').should('contain', 'microsecond')
-        cy.get('.flux-toolbar--list-item').should('have.length', 1)
+      cy.get('.flux-toolbar--list-item').should('contain', 'microsecond')
+      cy.get('.flux-toolbar--list-item').should('have.length', 1)
 
-        // hovers over function and see a tooltip
-        cy.get('.flux-toolbar--list-item').trigger('mouseover')
-        cy.getByTestID('flux-docs--microsecond').should('be.visible')
+      // hovers over function and see a tooltip
+      cy.get('.flux-toolbar--list-item').trigger('mouseover')
+      cy.getByTestID('flux-docs--microsecond').should('be.visible')
 
-        // inject function into script editor
-        cy.getByTestID('flux--microsecond--inject').click()
+      // inject function into script editor
+      cy.getByTestID('flux--microsecond--inject').click()
 
-        getTimeMachineText().then(text => {
-          const expected = 'import "date"  date.microsecond(t: )'
-          cy.fluxEqual(text, expected).should('be.true')
-        })
+      getTimeMachineText().then((text) => {
+        const expected = 'import "date"  date.microsecond(t: )'
+        cy.fluxEqual(text, expected).should('be.true')
       })
     })
 
     it('can use the dynamic flux function search bar to search by package or function name', () => {
-      cy.setFeatureFlags({
-        fluxDynamicDocs: true,
-      }).then(() => {
-        cy.get('.view-line').should('be.visible')
+      cy.get('.view-line').should('be.visible')
+
+      cy.getByTestID('flux-toolbar-search--input').click().type('filter')
 
         cy.getByTestID('flux-toolbar-search--input').click().type('filter')
 
-        cy.get('.flux-toolbar--list-item').should('have.length.greaterThan', 1)
-        cy.getByTestID('flux--filter').contains('filter')
+      cy.get('.flux-toolbar--search').within(() => {
+        cy.getByTestID('dismiss-button').click()
+      })
 
-        cy.get('.flux-toolbar--search').within(() => {
-          cy.getByTestID('dismiss-button').click()
+      cy.getByTestID('flux-toolbar-search--input')
+        .invoke('val')
+        .then((value) => {
+          expect(value).to.equal('')
         })
 
-        cy.getByTestID('flux-toolbar-search--input')
-          .invoke('val')
-          .then(value => {
-            expect(value).to.equal('')
-          })
+      cy.getByTestID('flux-toolbar-search--input').click().type('array')
 
         cy.getByTestID('flux-toolbar-search--input').click().type('array')
 
-        cy.get('.flux-toolbar--list-item').should('have.length.greaterThan', 1)
-        cy.getByTestID('flux--filter').contains('filter')
-
-        cy.get('.flux-toolbar--search').within(() => {
-          cy.getByTestID('dismiss-button').click()
-        })
-
-        cy.getByTestID('flux-toolbar-search--input')
-          .invoke('val')
-          .then(value => {
-            expect(value).to.equal('')
-          })
+      cy.get('.flux-toolbar--search').within(() => {
+        cy.getByTestID('dismiss-button').click()
       })
+
+      cy.getByTestID('flux-toolbar-search--input')
+        .invoke('val')
+        .then((value) => {
+          expect(value).to.equal('')
+        })
     })
   })
 })

--- a/cypress/e2e/cloud/flows.test.ts
+++ b/cypress/e2e/cloud/flows.test.ts
@@ -119,7 +119,7 @@ describe('Flows', () => {
     // Validates that the selected clone is the clone
     cy.getByTestID('page-title')
       .first()
-      .then((cloneNameElement) => {
+      .then(cloneNameElement => {
         const cloneName = cloneNameElement.text()
         const cloneTime = cloneName.slice(
           flowCloneNamePrefix.length,
@@ -158,7 +158,7 @@ describe('Flows', () => {
     cy.wait('@updateNotebook')
     cy.getByTestID('page-title')
       .first()
-      .then((cloneNameElement) => {
+      .then(cloneNameElement => {
         const cloneName = cloneNameElement.text()
         const cloneTime = cloneName.slice(
           flowCloneNamePrefix.length,
@@ -188,8 +188,8 @@ describe('Flows', () => {
 
     cy.get('button[title="Function Reference"]').click()
 
-      // search for a function
-      cy.getByTestID('flux-toolbar-search--input').click().type('microsecondd') // purposefully misspell "microsecond" so all functions are filtered out
+    // search for a function
+    cy.getByTestID('flux-toolbar-search--input').click().type('microsecondd') // purposefully misspell "microsecond" so all functions are filtered out
 
     cy.getByTestID('flux-toolbar--list').within(() => {
       cy.getByTestID('empty-state').should('be.visible')
@@ -220,7 +220,7 @@ describe('Flows', () => {
 
     cy.getByTestID('flux-toolbar-search--input').click().type('filter')
 
-      cy.getByTestID('flux-toolbar-search--input').click().type('filter')
+    cy.getByTestID('flux-toolbar-search--input').click().type('filter')
 
     cy.get('.flux-toolbar--search').within(() => {
       cy.getByTestID('dismiss-button').click()
@@ -228,13 +228,13 @@ describe('Flows', () => {
 
     cy.getByTestID('flux-toolbar-search--input')
       .invoke('val')
-      .then((value) => {
+      .then(value => {
         expect(value).to.equal('')
       })
 
     cy.getByTestID('flux-toolbar-search--input').click().type('array')
 
-      cy.getByTestID('flux-toolbar-search--input').click().type('array')
+    cy.getByTestID('flux-toolbar-search--input').click().type('array')
 
     cy.get('.flux-toolbar--search').within(() => {
       cy.getByTestID('dismiss-button').click()
@@ -242,7 +242,7 @@ describe('Flows', () => {
 
     cy.getByTestID('flux-toolbar-search--input')
       .invoke('val')
-      .then((value) => {
+      .then(value => {
         expect(value).to.equal('')
       })
   })
@@ -369,7 +369,7 @@ describe('Flows with newQueryBuilder flag on', () => {
     // Validates that the selected clone is the clone
     cy.getByTestID('page-title')
       .first()
-      .then((cloneNameElement) => {
+      .then(cloneNameElement => {
         const cloneName = cloneNameElement.text()
         const cloneTime = cloneName.slice(
           flowCloneNamePrefix.length,
@@ -408,7 +408,7 @@ describe('Flows with newQueryBuilder flag on', () => {
     cy.wait('@updateNotebook')
     cy.getByTestID('page-title')
       .first()
-      .then((cloneNameElement) => {
+      .then(cloneNameElement => {
         const cloneName = cloneNameElement.text()
         const cloneTime = cloneName.slice(
           flowCloneNamePrefix.length,

--- a/cypress/e2e/cloud/flows.test.ts
+++ b/cypress/e2e/cloud/flows.test.ts
@@ -119,7 +119,7 @@ describe('Flows', () => {
     // Validates that the selected clone is the clone
     cy.getByTestID('page-title')
       .first()
-      .then(cloneNameElement => {
+      .then((cloneNameElement) => {
         const cloneName = cloneNameElement.text()
         const cloneTime = cloneName.slice(
           flowCloneNamePrefix.length,
@@ -158,7 +158,7 @@ describe('Flows', () => {
     cy.wait('@updateNotebook')
     cy.getByTestID('page-title')
       .first()
-      .then(cloneNameElement => {
+      .then((cloneNameElement) => {
         const cloneName = cloneNameElement.text()
         const cloneTime = cloneName.slice(
           flowCloneNamePrefix.length,
@@ -182,79 +182,69 @@ describe('Flows', () => {
   })
 
   it('can use the dynamic flux function selector to build a query', () => {
-    cy.setFeatureFlags({
-      fluxDynamicDocs: true,
-    }).then(() => {
-      cy.getByTestID('preset-script').first().click()
+    cy.getByTestID('preset-script').first().click()
 
-      cy.get('.view-line').should('be.visible')
+    cy.get('.view-line').should('be.visible')
 
-      cy.get('button[title="Function Reference"]').click()
+    cy.get('button[title="Function Reference"]').click()
 
       // search for a function
       cy.getByTestID('flux-toolbar-search--input').click().type('microsecondd') // purposefully misspell "microsecond" so all functions are filtered out
 
-      cy.getByTestID('flux-toolbar--list').within(() => {
-        cy.getByTestID('empty-state').should('be.visible')
-      })
-      cy.getByTestID('flux-toolbar-search--input').type('{backspace}')
-
-      cy.get('.flux-toolbar--list-item').should('contain', 'microsecond')
-      cy.get('.flux-toolbar--list-item').should('have.length', 1)
-
-      // hovers over function and see a tooltip
-      cy.get('.flux-toolbar--list-item').trigger('mouseover')
-      cy.getByTestID('flux-docs--microsecond').should('be.visible')
-
-      // inject function into script editor
-      cy.getByTestID('flux--microsecond--inject').click({force: true})
-
-      // At minimium two lines: import and a function call
-      cy.get('.view-line').should('have.length.at.least', 2)
-      cy.get('.view-line').last().contains('microsecond')
+    cy.getByTestID('flux-toolbar--list').within(() => {
+      cy.getByTestID('empty-state').should('be.visible')
     })
+    cy.getByTestID('flux-toolbar-search--input').type('{backspace}')
+
+    cy.get('.flux-toolbar--list-item').should('contain', 'microsecond')
+    cy.get('.flux-toolbar--list-item').should('have.length', 1)
+
+    // hovers over function and see a tooltip
+    cy.get('.flux-toolbar--list-item').trigger('mouseover')
+    cy.getByTestID('flux-docs--microsecond').should('be.visible')
+
+    // inject function into script editor
+    cy.getByTestID('flux--microsecond--inject').click({force: true})
+
+    // At minimium two lines: import and a function call
+    cy.get('.view-line').should('have.length.at.least', 2)
+    cy.get('.view-line').last().contains('microsecond')
   })
 
   it('can use the dynamic flux function search bar to search by package or function name', () => {
-    cy.setFeatureFlags({
-      fluxDynamicDocs: true,
-    }).then(() => {
-      cy.getByTestID('preset-script').first().click()
+    cy.getByTestID('preset-script').first().click()
 
-      cy.get('.view-line').should('be.visible')
+    cy.get('.view-line').should('be.visible')
 
-      cy.get('button[title="Function Reference"]').click()
+    cy.get('button[title="Function Reference"]').click()
+
+    cy.getByTestID('flux-toolbar-search--input').click().type('filter')
 
       cy.getByTestID('flux-toolbar-search--input').click().type('filter')
 
-      cy.get('.flux-toolbar--list-item').should('have.length.greaterThan', 1)
-      cy.getByTestID('flux--filter').contains('filter')
+    cy.get('.flux-toolbar--search').within(() => {
+      cy.getByTestID('dismiss-button').click()
+    })
 
-      cy.get('.flux-toolbar--search').within(() => {
-        cy.getByTestID('dismiss-button').click()
+    cy.getByTestID('flux-toolbar-search--input')
+      .invoke('val')
+      .then((value) => {
+        expect(value).to.equal('')
       })
 
-      cy.getByTestID('flux-toolbar-search--input')
-        .invoke('val')
-        .then(value => {
-          expect(value).to.equal('')
-        })
+    cy.getByTestID('flux-toolbar-search--input').click().type('array')
 
       cy.getByTestID('flux-toolbar-search--input').click().type('array')
 
-      cy.get('.flux-toolbar--list-item').should('have.length.greaterThan', 1)
-      cy.getByTestID('flux--filter').contains('filter')
-
-      cy.get('.flux-toolbar--search').within(() => {
-        cy.getByTestID('dismiss-button').click()
-      })
-
-      cy.getByTestID('flux-toolbar-search--input')
-        .invoke('val')
-        .then(value => {
-          expect(value).to.equal('')
-        })
+    cy.get('.flux-toolbar--search').within(() => {
+      cy.getByTestID('dismiss-button').click()
     })
+
+    cy.getByTestID('flux-toolbar-search--input')
+      .invoke('val')
+      .then((value) => {
+        expect(value).to.equal('')
+      })
   })
 })
 
@@ -379,7 +369,7 @@ describe('Flows with newQueryBuilder flag on', () => {
     // Validates that the selected clone is the clone
     cy.getByTestID('page-title')
       .first()
-      .then(cloneNameElement => {
+      .then((cloneNameElement) => {
         const cloneName = cloneNameElement.text()
         const cloneTime = cloneName.slice(
           flowCloneNamePrefix.length,
@@ -418,7 +408,7 @@ describe('Flows with newQueryBuilder flag on', () => {
     cy.wait('@updateNotebook')
     cy.getByTestID('page-title')
       .first()
-      .then(cloneNameElement => {
+      .then((cloneNameElement) => {
         const cloneName = cloneNameElement.text()
         const cloneTime = cloneName.slice(
           flowCloneNamePrefix.length,

--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -1,28 +1,5 @@
 import {Organization} from '../../../src/types'
 import {points} from '../../support/commands'
-import {
-  FROM,
-  RANGE,
-  MEAN,
-  MATH_ABS,
-  MATH_FLOOR,
-  STRINGS_TITLE,
-  STRINGS_TRIM,
-} from '../../../src/shared/constants/fluxFunctions'
-
-function getTimeMachineText() {
-  return cy
-    .wrap({
-      text: () => {
-        const store = cy.state().window.store.getState().timeMachines
-        const timeMachine = store.timeMachines[store.activeTimeMachineID]
-        const query =
-          timeMachine.draftQueries[timeMachine.activeQueryIndex].text
-        return query
-      },
-    })
-    .invoke('text')
-}
 
 describe('DataExplorer', () => {
   beforeEach(() => {
@@ -431,75 +408,6 @@ describe('DataExplorer', () => {
 
       cy.getByTestID('time-machine-submit-button').should('not.be.disabled')
       cy.getByTestID('flux-editor').monacoType('{selectall}{del}')
-    })
-
-    it('imports the appropriate packages to build a query', () => {
-      cy.getByTestID('flux-editor', {timeout: 30000}).should('be.visible')
-      cy.getByTestID('functions-toolbar-contents--functions').should('exist')
-      cy.getByTestID('flux--from--inject').click({force: true})
-      cy.getByTestID('flux--range--inject').click({force: true})
-      cy.getByTestID('flux--math.abs--inject').click({force: true})
-      cy.getByTestID('flux--math.floor--inject').click({force: true})
-      cy.getByTestID('flux--strings.title--inject').click({force: true})
-      cy.getByTestID('flux--strings.trim--inject').click({force: true})
-
-      cy.wait(100)
-
-      getTimeMachineText().then(text => {
-        const expected = `
-        import"${STRINGS_TITLE.package}"
-        import"${MATH_ABS.package}"
-        ${FROM.example}|>
-        ${RANGE.example}|>
-        ${MATH_ABS.example}|>
-        ${MATH_FLOOR.example}|>
-        ${STRINGS_TITLE.example}|>
-        ${STRINGS_TRIM.example}`
-
-        cy.fluxEqual(text, expected).should('be.true')
-      })
-    })
-
-    it('can use the function selector to build a query', () => {
-      // wait for monaco to load so focus is not taken from flux-toolbar-search--input
-      cy.get('.view-line').should('be.visible')
-
-      cy.getByTestID('flux-toolbar-search--input').clear().type('covarianced') // purposefully misspell "covariance" so all functions are filtered out
-
-      cy.getByTestID('flux-toolbar--list').within(() => {
-        cy.getByTestID('empty-state').should('be.visible')
-      })
-
-      cy.getByTestID('flux-toolbar-search--input').type('{backspace}')
-
-      cy.get('.flux-toolbar--list-item').should('contain', 'covariance')
-      cy.get('.flux-toolbar--list-item').should('have.length', 1)
-
-      cy.getByTestID('flux-toolbar-search--input').clear()
-
-      cy.getByTestID('flux--from--inject').click()
-
-      getTimeMachineText().then(text => {
-        const expected = FROM.example
-
-        cy.fluxEqual(text, expected).should('be.true')
-      })
-
-      cy.getByTestID('flux--range--inject').click()
-
-      getTimeMachineText().then(text => {
-        const expected = `${FROM.example}|>${RANGE.example}`
-
-        cy.fluxEqual(text, expected).should('be.true')
-      })
-
-      cy.getByTestID('flux--mean--inject').click()
-
-      getTimeMachineText().then(text => {
-        const expected = `${FROM.example}|>${RANGE.example}|>${MEAN.example}`
-
-        cy.fluxEqual(text, expected).should('be.true')
-      })
     })
 
     it('shows the empty state when the query returns no results', () => {

--- a/cypress/e2e/shared/explorerVisualizations.test.ts
+++ b/cypress/e2e/shared/explorerVisualizations.test.ts
@@ -79,11 +79,8 @@ describe('visualizations', () => {
           cy.getByTestID('switch-to-script-editor').should('be.visible').click()
           cy.getByTestID('flux--mean--inject').first().click()
 
-          cy.log('check to see if import is defaulted to the top')
-          cy.get('.view-line').first().contains('import')
-
-          cy.log('check to see if new aggregate mean is at the bottom')
-          cy.get('.view-line').last().contains('aggregate.')
+          cy.log('check to see if new mean is at the bottom')
+          cy.get('.view-line').last().contains('mean')
           cy.getByTestID('flux-editor').should('exist')
           cy.getByTestID('flux-editor').monacoType(`yoyoyoyoyo`)
 

--- a/cypress/e2e/shared/explorerVisualizations.test.ts
+++ b/cypress/e2e/shared/explorerVisualizations.test.ts
@@ -77,7 +77,7 @@ describe('visualizations', () => {
 
           cy.log('can revert back to query builder mode (with confirmation)')
           cy.getByTestID('switch-to-script-editor').should('be.visible').click()
-          cy.getByTestID('flux--aggregate.rate--inject').click()
+          cy.getByTestID('flux--rate--inject').click()
 
           cy.log('check to see if import is defaulted to the top')
           cy.get('.view-line').first().contains('import')

--- a/cypress/e2e/shared/explorerVisualizations.test.ts
+++ b/cypress/e2e/shared/explorerVisualizations.test.ts
@@ -77,13 +77,13 @@ describe('visualizations', () => {
 
           cy.log('can revert back to query builder mode (with confirmation)')
           cy.getByTestID('switch-to-script-editor').should('be.visible').click()
-          cy.getByTestID('flux--rate--inject').click()
+          cy.getByTestID('flux--mean--inject').first().click()
 
           cy.log('check to see if import is defaulted to the top')
           cy.get('.view-line').first().contains('import')
 
-          cy.log('check to see if new aggregate rate is at the bottom')
-          cy.get('.view-line').last().prev().contains('aggregate.')
+          cy.log('check to see if new aggregate mean is at the bottom')
+          cy.get('.view-line').last().contains('aggregate.')
           cy.getByTestID('flux-editor').should('exist')
           cy.getByTestID('flux-editor').monacoType(`yoyoyoyoyo`)
 

--- a/cypress/e2e/shared/explorerVisualizations.test.ts
+++ b/cypress/e2e/shared/explorerVisualizations.test.ts
@@ -77,10 +77,10 @@ describe('visualizations', () => {
 
           cy.log('can revert back to query builder mode (with confirmation)')
           cy.getByTestID('switch-to-script-editor').should('be.visible').click()
-          cy.getByTestID('flux--mean--inject').first().click()
+          cy.getByTestID('flux--bottom--inject').click()
 
-          cy.log('check to see if new mean is at the bottom')
-          cy.get('.view-line').last().contains('mean')
+          cy.log('check to see if new flux function is at the bottom')
+          cy.get('.view-line').last().prev().contains('bottom')
           cy.getByTestID('flux-editor').should('exist')
           cy.getByTestID('flux-editor').monacoType(`yoyoyoyoyo`)
 

--- a/src/dataExplorer/components/Sidebar.tsx
+++ b/src/dataExplorer/components/Sidebar.tsx
@@ -16,7 +16,6 @@ import {FluxFunction, FluxToolbarFunction} from 'src/types'
 // Utils
 import {event} from 'src/cloud/utils/reporting'
 import {CLOUD} from 'src/shared/constants'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 import './Sidebar.scss'
 
@@ -41,7 +40,7 @@ const Sidebar: FC = () => {
 
   let browser = <Functions onSelect={inject} />
 
-  if (CLOUD && isFlagEnabled('fluxDynamicDocs')) {
+  if (CLOUD) {
     browser = <DynamicFunctions onSelect={inject} />
   }
 

--- a/src/flows/pipes/RawFluxEditor/view.tsx
+++ b/src/flows/pipes/RawFluxEditor/view.tsx
@@ -96,7 +96,7 @@ const Query: FC<PipeProp> = ({Context}) => {
   }, [id, inject])
 
   const updateText = useCallback(
-    text => {
+    (text) => {
       const _queries = [...queries]
       _queries[activeQuery] = {
         ...queries[activeQuery],
@@ -122,7 +122,7 @@ const Query: FC<PipeProp> = ({Context}) => {
     } else {
       event('Flux Panel (Notebooks) - Toggle Functions - On')
       show(id)
-      if (CLOUD && isFlagEnabled('fluxDynamicDocs')) {
+      if (CLOUD) {
         showSub(<DynamicFunctions onSelect={injectIntoEditor} />)
       } else {
         showSub(<Functions onSelect={injectIntoEditor} />)

--- a/src/flows/pipes/RawFluxEditor/view.tsx
+++ b/src/flows/pipes/RawFluxEditor/view.tsx
@@ -96,7 +96,7 @@ const Query: FC<PipeProp> = ({Context}) => {
   }, [id, inject])
 
   const updateText = useCallback(
-    (text) => {
+    text => {
       const _queries = [...queries]
       _queries[activeQuery] = {
         ...queries[activeQuery],

--- a/src/shared/contexts/editor/index.tsx
+++ b/src/shared/contexts/editor/index.tsx
@@ -43,8 +43,8 @@ export interface EditorContextType {
 
 const DEFAULT_CONTEXT: EditorContextType = {
   editor: null,
-  setEditor: _ => {},
-  inject: _ => {},
+  setEditor: (_) => {},
+  inject: (_) => {},
   injectFunction: (_, __) => {},
   injectVariable: (_, __) => {},
   injectViaLsp: (_, __) => {},
@@ -124,7 +124,7 @@ export const EditorProvider: FC = ({children}) => {
       editor.executeEdits('', edits)
       cbParentOnUpdateText(editor.getValue())
 
-      if (isFlagEnabled('fluxDynamicDocs') && triggerSuggest) {
+      if (triggerSuggest) {
         moveCursorAndTriggerSuggest(
           editor,
           injectionPosition,
@@ -141,10 +141,9 @@ export const EditorProvider: FC = ({children}) => {
       rawFn: FluxToolbarFunction | FluxFunction,
       cbParentOnUpdateText: (t: string) => void
     ): void => {
-      const fn =
-        CLOUD && isFlagEnabled('fluxDynamicDocs')
-          ? getFluxExample(rawFn as FluxFunction)
-          : (rawFn as FluxFunction)
+      const fn = CLOUD
+        ? getFluxExample(rawFn as FluxFunction)
+        : (rawFn as FluxFunction)
 
       const text = isPipeTransformation(fn)
         ? `  |> ${fn.example.trimRight()}`

--- a/src/shared/contexts/editor/index.tsx
+++ b/src/shared/contexts/editor/index.tsx
@@ -43,8 +43,8 @@ export interface EditorContextType {
 
 const DEFAULT_CONTEXT: EditorContextType = {
   editor: null,
-  setEditor: (_) => {},
-  inject: (_) => {},
+  setEditor: _ => {},
+  inject: _ => {},
   injectFunction: (_, __) => {},
   injectVariable: (_, __) => {},
   injectViaLsp: (_, __) => {},

--- a/src/shared/contexts/editor/insertFunction.ts
+++ b/src/shared/contexts/editor/insertFunction.ts
@@ -4,13 +4,10 @@ import {CLOUD} from 'src/shared/constants'
 // Types
 import {FluxFunction} from 'src/types/shared'
 
-// Utils
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
-
 export const generateImport = (func: FluxFunction, script: string): string => {
   let importStatement = `import "${func.package}"`
 
-  if (CLOUD && isFlagEnabled('fluxDynamicDocs')) {
+  if (CLOUD) {
     // if package is nested, use func.path to import.
     if (func.path.includes('/')) {
       importStatement = `import "${func.path}"`

--- a/src/shared/utils/fluxFunctions.ts
+++ b/src/shared/utils/fluxFunctions.ts
@@ -1,10 +1,9 @@
 import {FluxFunction} from 'src/types/shared'
 import {CLOUD} from 'src/shared/constants'
 import {FROM, UNION} from 'src/shared/constants/fluxFunctions'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 export const isPipeTransformation = (func: FluxFunction) => {
-  if (CLOUD && isFlagEnabled('fluxDynamicDocs')) {
+  if (CLOUD) {
     return func.fluxType.startsWith('<-', 1)
   }
   return !['from', 'union'].includes(func.name)

--- a/src/timeMachine/components/FluxToolbar.tsx
+++ b/src/timeMachine/components/FluxToolbar.tsx
@@ -15,7 +15,6 @@ import {FluxFunction, FluxToolbarFunction} from 'src/types'
 // Utils
 import {event} from 'src/cloud/utils/reporting'
 import {CLOUD} from 'src/shared/constants'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 type FluxToolbarTabs = 'functions' | 'variables' | 'none'
 
@@ -45,7 +44,7 @@ const FluxToolbar: FC = () => {
   }
 
   if (activeTab === 'functions') {
-    if (CLOUD && isFlagEnabled('fluxDynamicDocs')) {
+    if (CLOUD) {
       activeToolbar = <DynamicFunctions onSelect={onInsertFluxFunction} />
     } else {
       activeToolbar = <Functions onSelect={onInsertFluxFunction} />


### PR DESCRIPTION
Closes #5660 

Pr removes `fluxDynamicDocs` from the UI. 
This means `Cloud` UI will be leveraging dynamic flux service in all areas of UI where script editor is used. 

Removal of this ff means `Cloud` and `OSS` will no longer have the same logic behind displaying and injecting flux functions into the`Script Editor`. `OSS` uses static flux docs to display flux functions while cloud uses dynamic flux. This means the e2e tests for injecting flux functions into script editor need to be moved from shared folder to `cloud` and `oss` respectively. 

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
