### PR TITLE
fix(schemaComposition): remove editor styles when sync is disabled

### DIFF
--- a/src/languageSupport/languages/flux/lsp/connection.ts
+++ b/src/languageSupport/languages/flux/lsp/connection.ts
@@ -248,7 +248,7 @@ class LspConnectionManager {
       },
     ]
 
-    const removeAllStyles = !compositionBlock && schema.composition.diverged
+    const removeAllStyles = schema.composition.diverged
 
     this._compositionStyle = this._editor.deltaDecorations(
       this._compositionStyle,
@@ -263,6 +263,8 @@ class LspConnectionManager {
 
     if (removeAllStyles) {
       clickableInvisibleDiv.style.display = 'none'
+    } else {
+      clickableInvisibleDiv.style.display = 'block'
     }
   }
 

--- a/src/languageSupport/languages/flux/lsp/connection.ts
+++ b/src/languageSupport/languages/flux/lsp/connection.ts
@@ -334,9 +334,9 @@ class LspConnectionManager {
         payload['fields'] = toAdd.fields || this._session.fields
       }
       if (toAdd.tagValues || this._session.tagValues) {
-        payload['tagValues'] = (
-          toAdd.tagValues || this._session.tagValues
-        ).map(({key, value}) => [key, value])
+        payload['tagValues'] = (toAdd.tagValues || this._session.tagValues).map(
+          ({key, value}) => [key, value]
+        )
       }
       this._insertBuffer([ExecuteCommand.CompositionInit, payload])
       return // re-initialize full block. no more requests needed.

--- a/src/languageSupport/languages/flux/lsp/connection.ts
+++ b/src/languageSupport/languages/flux/lsp/connection.ts
@@ -248,7 +248,7 @@ class LspConnectionManager {
       },
     ]
 
-    const removeAllStyles = schema.composition.diverged
+    const removeAllStyles = !compositionBlock || schema.composition.diverged
 
     this._compositionStyle = this._editor.deltaDecorations(
       this._compositionStyle,


### PR DESCRIPTION
This PR fixes a bug listed in #5573. When the sync is disabled, the icon and highlight shouldn't be shown.

This fix is behind the feature flag `schemaComposition`

## Before

https://user-images.githubusercontent.com/14298407/189156754-e3f130ec-98c8-48f4-bfa9-f87a5a315746.mov


## After

https://user-images.githubusercontent.com/14298407/189156702-5d1327fb-6976-468e-8da6-992f541b8c93.mov


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
~~- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~~
- [x] Feature flagged, if applicable
