### PR TITLE
fix(dataLoaders): add styling to telegraf conf overlay

### DIFF
--- a/src/dataLoaders/components/DataLoadersOverlay.scss
+++ b/src/dataLoaders/components/DataLoadersOverlay.scss
@@ -43,6 +43,12 @@
   padding: $ix-marg-d;
 }
 
+.configuration-overlay--body {
+  padding: 45px !important;
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+}
+
 /*
   Telegraf Instructions Overlay
   ------------------------------------------------------------------------------

--- a/src/dataLoaders/components/collectorsWizard/TelegrafUIRefreshWizard.tsx
+++ b/src/dataLoaders/components/collectorsWizard/TelegrafUIRefreshWizard.tsx
@@ -45,6 +45,7 @@ import {isSystemBucket} from 'src/buckets/constants'
 
 // Constants
 import {getBucketOverlayWidth} from 'src/buckets/constants'
+
 const TELEGRAF_UI_REFRESH_OVERLAY_DEFAULT_WIDTH = 1200
 
 interface OwnProps {
@@ -79,7 +80,7 @@ class TelegrafUIRefreshWizard extends PureComponent<Props> {
       (currentStepIndex === 0 && substepIndex === 1) ||
       currentStepIndex === 1
     ) {
-      overlayBodyClassName = ''
+      overlayBodyClassName = 'configuration-overlay--body'
     }
 
     return (

--- a/src/writeData/components/PluginAddToExistingConfiguration/Wizard.tsx
+++ b/src/writeData/components/PluginAddToExistingConfiguration/Wizard.tsx
@@ -77,9 +77,8 @@ const Wizard: FC<Props> = props => {
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const [pluginConfig, setPluginConfig] = useState<string>('')
-  const [isValidConfiguration, setIsValidConfiguration] = useState<boolean>(
-    false
-  )
+  const [isValidConfiguration, setIsValidConfiguration] =
+    useState<boolean>(false)
   const [isVisible, setIsVisible] = useState<boolean>(true)
 
   const handleDismiss = () => {
@@ -116,8 +115,11 @@ const Wizard: FC<Props> = props => {
 
   let overlayBodyClassName = 'data-loading--overlay'
 
-  if (currentStepIndex === 0 || currentStepIndex === 1) {
+  if (currentStepIndex === 0) {
     overlayBodyClassName = ''
+  }
+  if (currentStepIndex === 1) {
+    overlayBodyClassName = 'configuration-overlay--body'
   }
 
   return (

--- a/src/writeData/components/PluginCreateConfiguration/Wizard.tsx
+++ b/src/writeData/components/PluginCreateConfiguration/Wizard.tsx
@@ -80,9 +80,8 @@ const Wizard: FC<Props> = props => {
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const [pluginConfig, setPluginConfig] = useState<string>('')
-  const [isValidConfiguration, setIsValidConfiguration] = useState<boolean>(
-    false
-  )
+  const [isValidConfiguration, setIsValidConfiguration] =
+    useState<boolean>(false)
   const [isVisible, setIsVisible] = useState<boolean>(true)
 
   const handleDismiss = () => {
@@ -112,6 +111,7 @@ const Wizard: FC<Props> = props => {
   }
 
   let title = 'Configuration Options'
+
   if (currentStepIndex === 0 && substepIndex === 1) {
     title = 'Create Bucket'
   } else if (currentStepIndex !== 0) {
@@ -129,8 +129,11 @@ const Wizard: FC<Props> = props => {
 
   let overlayBodyClassName = 'data-loading--overlay'
 
-  if (currentStepIndex === 0 || currentStepIndex === 1) {
+  if (currentStepIndex === 0 || substepIndex === 1) {
     overlayBodyClassName = ''
+  }
+  if (currentStepIndex === 1) {
+    overlayBodyClassName = 'configuration-overlay--body'
   }
 
   return (


### PR DESCRIPTION
Closes #5700 

Adds styling to three telegraf overlays found 
- Inside Telegraf page when creating a new telegraf configuration
- Inside Source page when adding a plugin to an existing configuration
- Inside Source page when adding a plugin to a new configuration

Depending on where user is at in the configuration step (`currentStepIndex` `substepIndex`), pr adds padding to the overlay body. 

Before: 
https://user-images.githubusercontent.com/66275100/189175626-8664e8b2-999b-4767-bb7a-51c19710fd1f.mov

After: 
https://user-images.githubusercontent.com/66275100/189175604-e9bef583-c130-4dcd-a647-952b5e4dac41.mov

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
