### PR TITLE
chore: upgrade y-websocket to 1.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -225,7 +225,7 @@
     "use-local-storage-state": "^9.0.2",
     "vscode-languageserver-protocol": "^3.16.0",
     "worker-plugin": "^5.0.1",
-    "y-websocket": "^1.4.3",
+    "y-websocket": "^1.4.4",
     "yjs": "^13.5.36"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12931,10 +12931,10 @@ y-protocols@^1.0.5:
   dependencies:
     lib0 "^0.2.42"
 
-y-websocket@^1.4.3:
-  version "1.4.3"
-  resolved "https://registry.npmjs.org/y-websocket/-/y-websocket-1.4.3.tgz"
-  integrity sha512-VobyJaAoyWIETETNZragnTpL7kcJr8a/CIUQP6DfXcQ4v0UmZUuANdsPsbmMjDsEeUECVFRhHauxpDtRhYqkaQ==
+y-websocket@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/y-websocket/-/y-websocket-1.4.4.tgz#d1750b6395fbe2f99cdabac97d3cd8d8de3fee6f"
+  integrity sha512-5G6FyqHosiiUBm2kMllOK5SP3uoyxgca9uq67iVPE44SW1sx66/fbU5S9RxhHBvn/WZh3rTf7GE7gr0h4rQb3Q==
   dependencies:
     lib0 "^0.2.42"
     lodash.debounce "^4.0.8"


### PR DESCRIPTION
Running `yarn outdated` yielded a list of outdated packages.
Exhaustive list [HERE](https://docs.google.com/spreadsheets/d/1g1ie5AdCwbqRnErLIa8j9b9V_POqSTxToWm_MYxz7b0/edit#gid=0)

update `y-websocket` to 1.4.4.
Customer shouldn't see any impact from this change.


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
