### PR TITLE
chore: remove fluxInjectSecrets flag

### DIFF
--- a/cypress/e2e/shared/secrets.test.ts
+++ b/cypress/e2e/shared/secrets.test.ts
@@ -123,9 +123,6 @@ describe('Secrets', () => {
   describe('usage in notebooks', () => {
     beforeEach(() => {
       cy.flush()
-      cy.setFeatureFlags({
-        fluxInjectSecrets: true,
-      })
       cy.signin()
       cy.get('@org').then(({id}: Organization) =>
         cy.fixture('routes').then(({orgs}) => {

--- a/src/flows/pipes/RawFluxEditor/view.tsx
+++ b/src/flows/pipes/RawFluxEditor/view.tsx
@@ -79,20 +79,18 @@ const Query: FC<PipeProp> = ({Context}) => {
   }, [id])
 
   useEffect(() => {
-    if (isFlagEnabled('fluxInjectSecrets')) {
-      register(id, [
-        {
-          title: 'RawFluxEditor actions',
-          actions: [
-            {
-              title: 'Inject Secret',
-              disable: () => false,
-              menu: <SecretsList inject={inject} cbOnInject={updateText} />,
-            },
-          ],
-        },
-      ])
-    }
+    register(id, [
+      {
+        title: 'RawFluxEditor actions',
+        actions: [
+          {
+            title: 'Inject Secret',
+            disable: () => false,
+            menu: <SecretsList inject={inject} cbOnInject={updateText} />,
+          },
+        ],
+      },
+    ])
   }, [id, inject])
 
   const updateText = useCallback(


### PR DESCRIPTION
Remove the feature flag for `fluxInjectSecrets`.
Has been on in prod since 2022.02.02.