### PR TITLE
fix: add a loading check prior to setting the buckets

### DIFF
--- a/src/shared/contexts/buckets.tsx
+++ b/src/shared/contexts/buckets.tsx
@@ -91,16 +91,18 @@ export const BucketProvider: FC<Props> = ({
 
   // keep the redux store in sync
   useEffect(() => {
-    dispatch(
-      setBuckets(
-        RemoteDataState.Done,
-        normalize<Bucket, BucketEntities, string[]>(
-          buckets.filter(b => b.type !== 'sample'),
-          arrayOfBuckets
+    if (loading === RemoteDataState.Done) {
+      dispatch(
+        setBuckets(
+          RemoteDataState.Done,
+          normalize<Bucket, BucketEntities, string[]>(
+            buckets.filter(b => b.type !== 'sample'),
+            arrayOfBuckets
+          )
         )
       )
-    )
-  }, [buckets])
+    }
+  }, [buckets, loading])
 
   // TODO: load bucket creation limits on org change
   // expose limits to frontend


### PR DESCRIPTION
Closes #5702 

This PR addresses an issue that was causing Notebooks with a `queryBuilder`, or `metricSelector` to crash when the panel is initialized. More specifically, something with the Multi-org feature being enabled was causing an infinite callstack, the cause of which has still TBD. Adding this check seems to fix the crashing bug. I've verified that this issue does not break the flux query builder (the other usage of the BucketProvider) with the feature flags for multi-org on AND off. I have also verified that the check does not break notebooks with the feature flags on AND off

<!-- Describe your proposed changes here. -->
<!-- Including screenshots or visuals is very helpful - a picture is worth a thousand words. -->

### Checklist

Authors and Reviewer(s), please verify the following:

- [ ] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [ ] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
