### PR TITLE
fix: make storage_gb calculation match pricing info

### DIFF
--- a/src/usage/context/usage.tsx
+++ b/src/usage/context/usage.tsx
@@ -179,11 +179,11 @@ export const UsageProvider: FC<Props> = React.memo(({children}) => {
     // Credit usage: $250 - (
     //   (sum of 30-day writes * $0.002) +
     //   (sum of 30-day query count * $0.01 / 100) +
-    //   (sum of 30-day query storage * $0.02) +
+    //   (sum of 30-day query storage * $0.002) +
     //   (sum of 30-day data out * $0.09)
     //  )
     const vectors = {
-      storage_gb: v => v * 0.02,
+      storage_gb: v => v * 0.002,
       writes_mb: v => v * 0.002,
       reads_gb: v => v * 0.09,
       query_count: v => (v * 0.01) / 100,


### PR DESCRIPTION
The `storage_gb` calculation didn't match what the pricing information is on our website. Update it to match.

<img width="497" alt="image" src="https://user-images.githubusercontent.com/146112/189443031-98d97ad1-adf7-44d0-8351-00446fde5619.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- ~[ ] Documentation updated or issue created (provide link to issue/PR)~
- ~[ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~
- ~[ ] Feature flagged, if applicable~
