### PR TITLE
fix: centralize state and reduce render cycles to derisk component

### DIFF
--- a/src/identity/components/GlobalHeader/GlobalHeaderDropdown/index.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeaderDropdown/index.tsx
@@ -63,7 +63,6 @@ export interface Props extends StandardFunctionProps {
 
 type State = {
   showTypeAheadMenu: boolean
-  selectedItem?: TypeAheadMenuItem
 }
 
 export class GlobalHeaderDropdown extends React.Component<Props, State> {
@@ -71,18 +70,8 @@ export class GlobalHeaderDropdown extends React.Component<Props, State> {
     super(props)
     this.state = {
       showTypeAheadMenu: this.props.onlyRenderSubmenu ?? false,
-      selectedItem: this.props.typeAheadSelectedOption || null,
     }
   }
-
-  componentDidUpdate() {
-    if (this.props.typeAheadSelectedOption !== this.state.selectedItem) {
-      this.setState({
-        selectedItem: this.props.typeAheadSelectedOption,
-      })
-    }
-  }
-
   private dropdownButton = (
     active: boolean,
     onClick: (e: MouseEvent<HTMLElement>) => void
@@ -92,8 +81,8 @@ export class GlobalHeaderDropdown extends React.Component<Props, State> {
       defaultTestID,
       dropdownButtonIcon,
       dropdownButtonSize,
+      typeAheadSelectedOption,
     } = this.props
-    const {selectedItem} = this.state
     return (
       <Dropdown.Button
         active={active}
@@ -103,7 +92,7 @@ export class GlobalHeaderDropdown extends React.Component<Props, State> {
         testID={defaultTestID}
         trailingIcon={dropdownButtonIcon || IconFont.DoubleCaretVertical}
       >
-        {selectedItem?.name || defaultButtonText}
+        {typeAheadSelectedOption?.name || defaultButtonText}
       </Dropdown.Button>
     )
   }
@@ -154,17 +143,17 @@ export class GlobalHeaderDropdown extends React.Component<Props, State> {
   }
 
   private renderTypeAheadMenu = () => {
-    const {typeAheadMenuOptions} = this.props
-    const {selectedItem} = this.state
     const {
       dropdownMenuStyle,
+      typeAheadMenuOptions,
+      typeAheadSelectedOption,
       typeAheadEventPrefix,
       typeAheadInputPlaceholder,
       typeAheadOnSelectOption,
     } = this.props
     return (
       <GlobalHeaderTypeAheadMenu
-        defaultSelectedItem={selectedItem}
+        defaultSelectedItem={typeAheadSelectedOption ?? null}
         onSelectOption={typeAheadOnSelectOption}
         style={dropdownMenuStyle}
         testID={this.props.typeAheadTestID}

--- a/src/shared/contexts/buckets.tsx
+++ b/src/shared/contexts/buckets.tsx
@@ -102,7 +102,7 @@ export const BucketProvider: FC<Props> = ({
         )
       )
     }
-  }, [buckets, loading])
+  }, [buckets, dispatch, loading])
 
   // TODO: load bucket creation limits on org change
   // expose limits to frontend


### PR DESCRIPTION
Closes #5722 

The purpose of this PR is to derisk the `GlobalHeaderDropdown` component by consolidating the state to the parent component, thereby preventing drift between state and the potential callstack exceeded issues moving forward. 

### Investigative Conclusions

Prior to the `multiOrg` and `quartzIdentity` flags being turned on, Notebooks that use the `context/bucket.tsx` file were loading correctly. While this accurate behavior did have some problems, those problems only came to light when the flags were turned on and an infinite render cycle was produced. The cause of that infinite render cycle has been pinpointed to two things:

1. The number of times the `setBuckets` was dispatched to update the reducer state
2. The number of times the `GlobalHeaderDropdown` componentDidUpdate was called.

It appears as though these two state-setting operations were feeding back to one another, so that whenever the `setBuckets` was called, the `GlobalHeaderDropdown` would be updated. That update would then trigger the `context/bucket` to be updated, and so on and so on. 

### Solution

While the [previous PR](https://github.com/influxdata/ui/pull/5716) worked to tighten up when the `setBuckets` call should be dispatched (thereby limiting the render cycles), this PR aims to provide guardrails around the render cycle of the `GlobalHeaderDropdown`. More specifically, it seems as though the main purpose of the `selectedItem` state setting was simply a means of setting a default for the state based on an initial selection. However, in doing so, the potential for state drift between two sources of truth (the parent props and the component state) were manually being managed by a lifecycle method (componentDidUpdate), which would be triggered any time the component updated. What this PR does is centralize the state to the parent as the single source of truth, thereby removing the lifecycle method that was previously being used to centralize updates.

<!-- Describe your proposed changes here. -->
<!-- Including screenshots or visuals is very helpful - a picture is worth a thousand words. -->

### Checklist

Authors and Reviewer(s), please verify the following:

- [ ] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [ ] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
