### PR TITLE
fix: update Giraffe to improve Simple Table performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "@docsearch/react": "^3.0.0-alpha.37",
     "@influxdata/clockface": "^6.3.0",
     "@influxdata/flux-lsp-browser": "0.8.34",
-    "@influxdata/giraffe": "^2.34.1",
+    "@influxdata/giraffe": "^2.34.2",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",
     "abortcontroller-polyfill": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1438,10 +1438,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/flux-lsp-browser/-/flux-lsp-browser-0.8.34.tgz#9261b193593317b593420fb289a4f2ac95952fbe"
   integrity sha512-c/GytzYDOBVdVG5bXQbKLKMI9lu2vUVKjUUsCLajnbAVHs5zXllfff+ubaNdn1hGFgY/upmjcUpE/gm3FqphoQ==
 
-"@influxdata/giraffe@^2.34.1":
-  version "2.34.1"
-  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.34.1.tgz#793eaece6137eb976c1fe7b2bac019d66ed30b1f"
-  integrity sha512-prbQyAx+iFOHmpv9UxUB7ipO5f7jcnCn5LwH+ocOjkyFqzFbzXAMraIO3mzydIxw4FNGU2CISC/7T+IpxHH4yg==
+"@influxdata/giraffe@^2.34.2":
+  version "2.34.2"
+  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.34.2.tgz#60271c4c0c7f3780f22f32cf58924e4beead32e4"
+  integrity sha512-/bf3NLJ2IpfnOZy2iyNXmvMdhDrI4INcVCegwXyMAXc3cTZKnbpHiYHL0fiR0K3ev0WeNMjAhCuKQfdkbeU60g==
   dependencies:
     merge-images "^2.0.0"
 


### PR DESCRIPTION
Closes #5692 

Update Giraffe to get the latest Simple Table. See https://github.com/influxdata/giraffe/pull/802 for details