### PR TITLE
chore: toggle quartzIdentity and multiOrg on in cloud e2e tests

### DIFF
--- a/cypress/e2e/cloud/about.test.ts
+++ b/cypress/e2e/cloud/about.test.ts
@@ -5,13 +5,18 @@ describe.skip('About Page for free users with only 1 user', () => {
   beforeEach(() =>
     cy.flush().then(() =>
       cy.signin().then(() => {
-        cy.get('@org').then(({id}: Organization) => {
-          cy.quartzProvision({
-            accountType: 'free',
-            hasUsers: false,
-          }).then(() => {
-            cy.visit(`/orgs/${id}/org-settings`)
-            cy.getByTestID('about-page--header').should('be.visible')
+        cy.setFeatureFlags({
+          quartzIdentity: true,
+          multiOrg: true,
+        }).then(() => {
+          cy.get('@org').then(({id}: Organization) => {
+            cy.quartzProvision({
+              accountType: 'free',
+              hasUsers: false,
+            }).then(() => {
+              cy.visit(`/orgs/${id}/org-settings`)
+              cy.getByTestID('about-page--header').should('be.visible')
+            })
           })
         })
       })
@@ -49,13 +54,18 @@ describe('About Page for free users with multiple users', () => {
   beforeEach(() =>
     cy.flush().then(() =>
       cy.signin().then(() => {
-        cy.get('@org').then(({id}: Organization) => {
-          cy.quartzProvision({
-            accountType: 'free',
-            hasUsers: true,
-          }).then(() => {
-            cy.visit(`/orgs/${id}/org-settings`)
-            cy.getByTestID('about-page--header').should('be.visible')
+        cy.setFeatureFlags({
+          quartzIdentity: true,
+          multiOrg: true,
+        }).then(() => {
+          cy.get('@org').then(({id}: Organization) => {
+            cy.quartzProvision({
+              accountType: 'free',
+              hasUsers: true,
+            }).then(() => {
+              cy.visit(`/orgs/${id}/org-settings`)
+              cy.getByTestID('about-page--header').should('be.visible')
+            })
           })
         })
       })
@@ -80,12 +90,17 @@ describe('About Page for PAYG users', () => {
   beforeEach(() =>
     cy.flush().then(() =>
       cy.signin().then(() => {
-        cy.get('@org').then(({id}: Organization) => {
-          cy.quartzProvision({
-            accountType: 'pay_as_you_go',
-          }).then(() => {
-            cy.visit(`/orgs/${id}/org-settings`)
-            cy.getByTestID('about-page--header').should('be.visible')
+        cy.setFeatureFlags({
+          quartzIdentity: true,
+          multiOrg: true,
+        }).then(() => {
+          cy.get('@org').then(({id}: Organization) => {
+            cy.quartzProvision({
+              accountType: 'pay_as_you_go',
+            }).then(() => {
+              cy.visit(`/orgs/${id}/org-settings`)
+              cy.getByTestID('about-page--header').should('be.visible')
+            })
           })
         })
       })

--- a/cypress/e2e/cloud/billing.test.ts
+++ b/cypress/e2e/cloud/billing.test.ts
@@ -2,53 +2,53 @@ import {Organization} from '../../../src/types'
 
 describe('Billing Page Free Users', () => {
   beforeEach(() =>
-    cy.flush().then(() =>
+    cy.flush().then(() => {
       cy.signin().then(() => {
-        cy.setFeatureFlags({
-          quartzIdentity: true,
-          multiOrg: true,
-        }).then(() => {
-          cy.get('@org').then(({id}: Organization) => {
-            cy.quartzProvision({
-              accountType: 'free',
-            }).then(() => {
-              cy.visit(`/orgs/${id}/billing`)
-              cy.getByTestID('billing-page--header').should('be.visible')
-            })
+        cy.get('@org').then(({id}: Organization) => {
+          cy.quartzProvision({
+            accountType: 'free',
+          }).then(() => {
+            cy.visit(`/orgs/${id}/billing`)
+            cy.getByTestID('billing-page--header').should('be.visible')
           })
         })
       })
-    )
+    })
   )
 
   it('should display the free billing page for free users', () => {
-    cy.getByTestID('cloud-upgrade--button').should('be.visible')
-    cy.getByTestID('title-header--name')
-      .should('not.have.value', 'blockedNotificationRules')
-      .and('not.have.value', 'blockedNotificationEndpoints')
-      .and('have.length', 9)
+    cy.setFeatureFlags({
+      quartzIdentity: true,
+      multiOrg: true,
+    }).then(() => {
+      cy.getByTestID('cloud-upgrade--button').should('be.visible')
+      cy.getByTestID('title-header--name')
+        .should('not.have.value', 'blockedNotificationRules')
+        .and('not.have.value', 'blockedNotificationEndpoints')
+        .and('have.length', 9)
 
-    const categoryHeaders = [
-      'Max Dashboards',
-      'Max Tasks',
-      'Max Buckets',
-      'Max Retention Seconds',
-      'Max Checks',
-      'Max Notifications',
-      'Reads',
-      'Writes',
-      'Series Cardinality',
-    ]
+      const categoryHeaders = [
+        'Max Dashboards',
+        'Max Tasks',
+        'Max Buckets',
+        'Max Retention Seconds',
+        'Max Checks',
+        'Max Notifications',
+        'Reads',
+        'Writes',
+        'Series Cardinality',
+      ]
 
-    cy.getByTestID('title-header--name').each((child, index) => {
-      expect(child.text().trim()).to.equal(categoryHeaders[index])
-    })
+      cy.getByTestID('title-header--name').each((child, index) => {
+        expect(child.text().trim()).to.equal(categoryHeaders[index])
+      })
 
-    cy.getByTestID('payg-grid--container').scrollIntoView()
-    cy.getByTestID('payg-button--upgrade').should('be.visible').click()
+      cy.getByTestID('payg-grid--container').scrollIntoView()
+      cy.getByTestID('payg-button--upgrade').should('be.visible').click()
 
-    cy.location().should(loc => {
-      expect(loc.pathname).to.eq('/checkout')
+      cy.location().should(loc => {
+        expect(loc.pathname).to.eq('/checkout')
+      })
     })
   })
 })
@@ -81,135 +81,148 @@ describe('Billing Page PAYG Users', () => {
   )
 
   it('should display the free billing page for PAYG users', () => {
-    // The implication here is that there is no Upgrade Now button
-    cy.get('.cf-page-header--fluid').children().should('have.length', 1)
+    cy.setFeatureFlags({
+      quartzIdentity: true,
+      multiOrg: true,
+    }).then(() => {
+      // The implication here is that there is no Upgrade Now button
+      cy.get('.cf-page-header--fluid').children().should('have.length', 1)
 
-    // PAYG section
-    cy.getByTestID('payg-plan--header').contains('Pay As You Go')
+      // PAYG section
+      cy.getByTestID('payg-plan--header').contains('Pay As You Go')
 
-    cy.getByTestID('payg-plan--balance-header').contains('Account Balance')
-    cy.getByTestID('payg-plan--balance-body').contains('10.00')
+      cy.getByTestID('payg-plan--balance-header').contains('Account Balance')
+      cy.getByTestID('payg-plan--balance-body').contains('10.00')
 
-    cy.getByTestID('payg-plan--updated-header').contains('Last Update')
-    cy.getByTestID('payg-plan--updated-body').contains(
-      `${new Date().toLocaleString('default', {
-        month: 'numeric',
-        day: 'numeric',
-        year: 'numeric',
-        hour: 'numeric',
-        minute: '2-digit',
-      })}`
-    )
+      cy.getByTestID('payg-plan--updated-header').contains('Last Update')
+      cy.getByTestID('payg-plan--updated-body').contains(
+        `${new Date().toLocaleString('default', {
+          month: 'numeric',
+          day: 'numeric',
+          year: 'numeric',
+          hour: 'numeric',
+          minute: '2-digit',
+        })}`
+      )
 
-    // Invoices Section
-    cy.getByTestID('past-invoices--header').contains('Past Invoices')
-    cy.getByTestID('invoice-history--row').should('have.length', 2)
+      // Invoices Section
+      cy.getByTestID('past-invoices--header').contains('Past Invoices')
+      cy.getByTestID('invoice-history--row').should('have.length', 2)
 
-    cy.getByTestID('invoice-history--name')
-      .last()
-      .contains('December 2020 Invoice')
-    cy.getByTestID('invoice-history--amount').last().contains('$100.00')
-    cy.getByTestID('invoice-history--status').last().contains('unpaid')
+      cy.getByTestID('invoice-history--name')
+        .last()
+        .contains('December 2020 Invoice')
+      cy.getByTestID('invoice-history--amount').last().contains('$100.00')
+      cy.getByTestID('invoice-history--status').last().contains('unpaid')
 
-    // Sort by date
-    cy.getByTestID('invoice-date--sorter').contains('Invoice Date').click()
+      // Sort by date
+      cy.getByTestID('invoice-date--sorter').contains('Invoice Date').click()
 
-    // Should now be the first item
-    cy.getByTestID('invoice-history--name')
-      .first()
-      .contains('December 2020 Invoice')
+      // Should now be the first item
+      cy.getByTestID('invoice-history--name')
+        .first()
+        .contains('December 2020 Invoice')
 
-    // Sort by amount
-    cy.getByTestID('invoice-amount--sorter').contains('Amount').click()
+      // Sort by amount
+      cy.getByTestID('invoice-amount--sorter').contains('Amount').click()
 
-    cy.getByTestID('invoice-history--amount').first().contains('$10.00')
+      cy.getByTestID('invoice-history--amount').first().contains('$10.00')
 
-    cy.getByTestID('invoice-status--sorter').contains('Status').click()
+      cy.getByTestID('invoice-status--sorter').contains('Status').click()
 
-    cy.getByTestID('invoice-history--status').first().contains('paid')
+      cy.getByTestID('invoice-history--status').first().contains('paid')
 
-    // Payment Method Section
-    cy.getByTestID('payment-method--header').contains('Payment Method')
-    cy.getByTestID('payment-display').contains(
-      'Your current payment card is visa 4242 4242 4242 4242 — Expiring 04/24'
-    )
-    cy.getByTestID('edit-payment--button').click()
-    // TODO: render the zuora form somehow
-    cy.getByTestID('payment-form').should('exist')
+      // Payment Method Section
+      cy.getByTestID('payment-method--header').contains('Payment Method')
+      cy.getByTestID('payment-display').contains(
+        'Your current payment card is visa 4242 4242 4242 4242 — Expiring 04/24'
+      )
+      cy.getByTestID('edit-payment--button').click()
+      // TODO: render the zuora form somehow
+      cy.getByTestID('payment-form').should('exist')
 
-    cy.getByTestID('cancel-change--button').click()
-    cy.getByTestID('payment-form').should('not.exist')
+      cy.getByTestID('cancel-change--button').click()
+      cy.getByTestID('payment-form').should('not.exist')
 
-    // Contact Information Section
-    cy.getByTestID('billing-contact--header').contains('Contact Information')
-    cy.getByTestID('form-label--First Name').contains('First Name')
-    cy.getByTestID('contact-info--Test').contains('Test')
-    cy.getByTestID('form-label--Last Name').contains('Last Name')
-    cy.getByTestID('contact-info--PAYG').contains('PAYG')
-    cy.getByTestID('form-label--Company Name').contains('Company Name')
-    cy.getByTestID('contact-info--InfluxData').contains('InfluxData')
-    cy.getByTestID('form-label--Country').contains('Country')
-    cy.getByTestID('contact-info--USA').contains('USA')
-    cy.getByTestID('form-label--Physical Address').contains('Physical Address')
-    cy.getByTestID('contact-info--123 Main St, Apt 2').contains(
-      '123 Main St, Apt 2'
-    )
-    cy.getByTestID('form-label--City').contains('City')
-    cy.getByTestID('contact-info--Los Angeles').contains('Los Angeles')
-    cy.getByTestID('form-label--State (Subdivision)').contains(
-      'State (Subdivision)'
-    )
-    cy.getByTestID('contact-info--California').contains('California')
-    cy.getByTestID('form-label--Postal Code').contains('Postal Code')
-    cy.getByTestID('contact-info--90001').contains('90001')
+      // Contact Information Section
+      cy.getByTestID('billing-contact--header').contains('Contact Information')
+      cy.getByTestID('form-label--First Name').contains('First Name')
+      cy.getByTestID('contact-info--Test').contains('Test')
+      cy.getByTestID('form-label--Last Name').contains('Last Name')
+      cy.getByTestID('contact-info--PAYG').contains('PAYG')
+      cy.getByTestID('form-label--Company Name').contains('Company Name')
+      cy.getByTestID('contact-info--InfluxData').contains('InfluxData')
+      cy.getByTestID('form-label--Country').contains('Country')
+      cy.getByTestID('contact-info--USA').contains('USA')
+      cy.getByTestID('form-label--Physical Address').contains(
+        'Physical Address'
+      )
+      cy.getByTestID('contact-info--123 Main St, Apt 2').contains(
+        '123 Main St, Apt 2'
+      )
+      cy.getByTestID('form-label--City').contains('City')
+      cy.getByTestID('contact-info--Los Angeles').contains('Los Angeles')
+      cy.getByTestID('form-label--State (Subdivision)').contains(
+        'State (Subdivision)'
+      )
+      cy.getByTestID('contact-info--California').contains('California')
+      cy.getByTestID('form-label--Postal Code').contains('Postal Code')
+      cy.getByTestID('contact-info--90001').contains('90001')
 
-    // Click the edit information button
-    cy.getByTestID('edit-contact--button').contains('Edit Information').click()
-    cy.getByTestID('form-input--firstname').clear().type('Salt')
-    cy.getByTestID('form-input--lastname').clear().type('Bae')
-    cy.getByTestID('save-contact--button').click()
+      // Click the edit information button
+      cy.getByTestID('edit-contact--button')
+        .contains('Edit Information')
+        .click()
+      cy.getByTestID('form-input--firstname').clear().type('Salt')
+      cy.getByTestID('form-input--lastname').clear().type('Bae')
+      cy.getByTestID('save-contact--button').click()
 
-    // Validate that the first and last name are updated
-    cy.getByTestID('contact-info--Salt').contains('Salt').and('not.be', 'Test')
-    cy.getByTestID('contact-info--Bae').contains('Bae').and('not.be', 'PAYG')
+      // Validate that the first and last name are updated
+      cy.getByTestID('contact-info--Salt')
+        .contains('Salt')
+        .and('not.be', 'Test')
+      cy.getByTestID('contact-info--Bae').contains('Bae').and('not.be', 'PAYG')
 
-    // Notification Settings Section
-    cy.getByTestID('notification-settings--header').contains(
-      'Notification Settings'
-    )
-    cy.getByTestID('billing-settings--text').contains('test@influxdata.com')
-    cy.getByTestID('billing-settings--text').contains('$11')
-    cy.getByTestID('notification-settings--button').click()
+      // Notification Settings Section
+      cy.getByTestID('notification-settings--header').contains(
+        'Notification Settings'
+      )
+      cy.getByTestID('billing-settings--text').contains('test@influxdata.com')
+      cy.getByTestID('billing-settings--text').contains('$11')
+      cy.getByTestID('notification-settings--button').click()
 
-    // Toggle the settings off
-    cy.getByTestID('should-notify--toggle').click()
-    cy.getByTestID('save-settings--button').click()
-    cy.getByTestID('billing-settings--text').contains(
-      'Usage Notifications disabled'
-    )
+      // Toggle the settings off
+      cy.getByTestID('should-notify--toggle').click()
+      cy.getByTestID('save-settings--button').click()
+      cy.getByTestID('billing-settings--text').contains(
+        'Usage Notifications disabled'
+      )
 
-    // Notification Settings Section
-    cy.getByTestID('cancel-service--header').contains('Cancel Service')
-    cy.getByTestID('cancel-service--button').click()
-    cy.getByTestID('cancel-overlay--alert').contains(
-      'This action cannot be undone'
-    )
-    // check that the button is disabled
-    cy.getByTestID('cancel-service-confirmation--button').should('be.disabled')
-    cy.getByTestID('agree-terms--checkbox').should('not.be.checked')
+      // Notification Settings Section
+      cy.getByTestID('cancel-service--header').contains('Cancel Service')
+      cy.getByTestID('cancel-service--button').click()
+      cy.getByTestID('cancel-overlay--alert').contains(
+        'This action cannot be undone'
+      )
+      // check that the button is disabled
+      cy.getByTestID('cancel-service-confirmation--button').should(
+        'be.disabled'
+      )
+      cy.getByTestID('agree-terms--checkbox').should('not.be.checked')
 
-    cy.getByTestID('agree-terms--input').click()
-    cy.getByTestID('agree-terms--checkbox').should('be.checked')
-    cy.getByTestID('variable-type-dropdown--button')
-      .click()
-      .then(() => {
-        cy.getByTestID('variable-type-dropdown-USE_CASE_DIFFERENT').click()
-      })
-    cy.getByTestID('cancel-service-confirmation--button')
-      .should('not.be.disabled')
-      .click()
+      cy.getByTestID('agree-terms--input').click()
+      cy.getByTestID('agree-terms--checkbox').should('be.checked')
+      cy.getByTestID('variable-type-dropdown--button')
+        .click()
+        .then(() => {
+          cy.getByTestID('variable-type-dropdown-USE_CASE_DIFFERENT').click()
+        })
+      cy.getByTestID('cancel-service-confirmation--button')
+        .should('not.be.disabled')
+        .click()
 
-    // TLDR; we double confirm here, this is by design. The overlay changes to reflect a new state so this isn't an error in the test
-    cy.getByTestID('cancel-service-confirmation--button').click()
+      // TLDR; we double confirm here, this is by design. The overlay changes to reflect a new state so this isn't an error in the test
+      cy.getByTestID('cancel-service-confirmation--button').click()
+    })
   })
 })

--- a/cypress/e2e/cloud/billing.test.ts
+++ b/cypress/e2e/cloud/billing.test.ts
@@ -4,12 +4,17 @@ describe('Billing Page Free Users', () => {
   beforeEach(() =>
     cy.flush().then(() =>
       cy.signin().then(() => {
-        cy.get('@org').then(({id}: Organization) => {
-          cy.quartzProvision({
-            accountType: 'free',
-          }).then(() => {
-            cy.visit(`/orgs/${id}/billing`)
-            cy.getByTestID('billing-page--header').should('be.visible')
+        cy.setFeatureFlags({
+          quartzIdentity: true,
+          multiOrg: true,
+        }).then(() => {
+          cy.get('@org').then(({id}: Organization) => {
+            cy.quartzProvision({
+              accountType: 'free',
+            }).then(() => {
+              cy.visit(`/orgs/${id}/billing`)
+              cy.getByTestID('billing-page--header').should('be.visible')
+            })
           })
         })
       })
@@ -52,18 +57,23 @@ describe('Billing Page PAYG Users', () => {
   beforeEach(() =>
     cy.flush().then(() =>
       cy.signin().then(() => {
-        cy.get('@org').then(({id}: Organization) => {
-          cy.quartzProvision({
-            accountType: 'pay_as_you_go',
-          }).then(() => {
-            cy.visit(`/orgs/${id}/billing`)
+        cy.setFeatureFlags({
+          quartzIdentity: true,
+          multiOrg: true,
+        }).then(() => {
+          cy.get('@org').then(({id}: Organization) => {
+            cy.quartzProvision({
+              accountType: 'pay_as_you_go',
+            }).then(() => {
+              cy.visit(`/orgs/${id}/billing`)
 
-            cy.getByTestID('billing-page--header').should('be.visible')
-            cy.getByTestID('accounts-billing-tab').should('be.visible')
-            cy.getByTestID('accounts-billing-tab').should(
-              'have.class',
-              'cf-tabs--tab__active'
-            )
+              cy.getByTestID('billing-page--header').should('be.visible')
+              cy.getByTestID('accounts-billing-tab').should('be.visible')
+              cy.getByTestID('accounts-billing-tab').should(
+                'have.class',
+                'cf-tabs--tab__active'
+              )
+            })
           })
         })
       })

--- a/cypress/e2e/cloud/buckets.test.ts
+++ b/cypress/e2e/cloud/buckets.test.ts
@@ -97,7 +97,9 @@ const testSchemaFiles = (
 
 describe('Explicit Buckets', () => {
   beforeEach(() => {
-    setup(cy)
+    setup(cy).then(() => {
+      cy.setFeatureFlags({quartzIdentity: true, multiOrg: true})
+    })
   })
 
   it('can create a bucket with an explicit schema', () => {
@@ -413,7 +415,9 @@ fsRead,field,float`
 
 describe('Buckets', () => {
   beforeEach(() => {
-    setup(cy)
+    setup(cy).then(() => {
+      cy.setFeatureFlags({quartzIdentity: true, multiOrg: true})
+    })
   })
 
   it('can sort by name and retention', () => {

--- a/cypress/e2e/cloud/checkout/checkoutinaccessible.test.ts
+++ b/cypress/e2e/cloud/checkout/checkoutinaccessible.test.ts
@@ -2,12 +2,17 @@ describe('Checkout Page should not be accessible for non-free users', () => {
   beforeEach(() =>
     cy.flush().then(() =>
       cy.signin().then(() => {
-        cy.get('@org').then(() => {
-          cy.getByTestID('home-page--header').should('be.visible')
-          cy.quartzProvision({
-            accountType: 'pay_as_you_go',
-          }).then(() => {
-            cy.visit(`/checkout`)
+        cy.setFeatureFlags({
+          quartzIdentity: true,
+          multiOrg: true,
+        }).then(() => {
+          cy.get('@org').then(() => {
+            cy.getByTestID('home-page--header').should('be.visible')
+            cy.quartzProvision({
+              accountType: 'pay_as_you_go',
+            }).then(() => {
+              cy.visit(`/checkout`)
+            })
           })
         })
       })

--- a/cypress/e2e/cloud/checkout/checkoutpage.test.ts
+++ b/cypress/e2e/cloud/checkout/checkoutpage.test.ts
@@ -27,7 +27,10 @@ describe('Checkout Page Works', () => {
   )
 
   it('should render the checkout page and allow for pointing and clicking', () => {
-    cy.setFeatureFlags({quartzIdentity: true, multiOrg: true}).then(() => {
+    cy.setFeatureFlagsNoNav({
+      quartzIdentity: true,
+      multiOrg: true,
+    }).then(() => {
       const email = 'asalem@influxdata.com'
       const limit = 10
       const numberError = 'Please enter a value of 1 or greater'

--- a/cypress/e2e/cloud/checkout/checkoutpage.test.ts
+++ b/cypress/e2e/cloud/checkout/checkoutpage.test.ts
@@ -27,127 +27,133 @@ describe('Checkout Page Works', () => {
   )
 
   it('should render the checkout page and allow for pointing and clicking', () => {
-    const email = 'asalem@influxdata.com'
-    const limit = 10
-    const numberError = 'Please enter a value of 1 or greater'
-    const genericError = 'This is a required field'
+    cy.setFeatureFlags({quartzIdentity: true, multiOrg: true}).then(() => {
+      const email = 'asalem@influxdata.com'
+      const limit = 10
+      const numberError = 'Please enter a value of 1 or greater'
+      const genericError = 'This is a required field'
 
-    cy.getByTestID('shouldNotify--checkbox--input').should('be.checked')
-
-    resetInputs()
-
-    // Click Upgrade
-    cy.getByTestID('checkout-upgrade--button').click()
-
-    // Check all errors are visible
-    cy.getByTestID('balanceThreshold--input').scrollIntoView()
-    cy.getByTestID('balanceThreshold--form-element-error').should('be.visible')
-    cy.getByTestID('balanceThreshold--form-element-error').contains(
-      genericError
-    )
-    cy.getByTestID('notifyEmail--form-element-error').should('be.visible')
-    cy.getByTestID('notifyEmail--form-element-error').contains(genericError)
-
-    // Check balance threshold specific error should exist
-    cy.getByTestID('balanceThreshold--input').clear().type('0')
-    cy.getByTestID('balanceThreshold--form-element-error').contains(numberError)
-
-    cy.getByTestID('notifyEmail--input').clear().type(email)
-    cy.getByTestID('balanceThreshold--input').clear().type(`${limit}`)
-
-    // Check all errors are gone
-    cy.getByTestID('balanceThreshold--form-element-error').should('not.exist')
-    cy.getByTestID('notifyEmail--form-element-error').should('not.exist')
-
-    // Uncheck Checkbox
-    cy.getByTestID('shouldNotify--checkbox').click()
-    cy.getByTestID('shouldNotify--checkbox--input').should('not.be.checked')
-
-    // Email and limit should still be present after toggling the notifications checkbox
-    cy.getByTestID('shouldNotify--checkbox').click()
-    cy.getByTestID('shouldNotify--checkbox--input').should('be.checked')
-    cy.getByTestID('notifyEmail--input').should('have.value', email)
-    cy.getByTestID('balanceThreshold--input').should('have.value', limit)
-
-    // should render US Billing Address
-    const error = 'This is a required field'
-
-    // Check defaults
-    resetInputs()
-    cy.getByTestID('country--dropdown')
-      .get('.cf-dropdown--selected')
-      .contains('United States')
-    cy.getByTestID('usSubdivision--dropdown')
-      .get('.cf-dropdown--selected')
-      .contains('Alabama')
-
-    cy.getByTestID('checkout-upgrade--button').click()
-
-    cy.getByTestID('city--form-element-error').should('be.visible')
-    cy.getByTestID('city--form-element-error').contains(error)
-    cy.getByTestID('postalCode--form-element-error').should('be.visible')
-    cy.getByTestID('postalCode--form-element-error').contains(error)
-
-    cy.getByTestID('city--input').type('Blacksburg')
-    cy.getByTestID('postalCode--input').type('24060')
-    cy.getByTestID('street1--input').type('Street1 Address')
-    cy.getByTestID('street2--input').type('Street2 Address')
-
-    cy.getByTestID('city--form-element-error').should('not.exist')
-    cy.getByTestID('postalCode--form-element-error').should('not.exist')
-
-    const cases = [
-      {country: 'Canada', state: 'Province'},
-      {country: 'India', state: 'State / Province / Region'},
-    ]
-    cases.forEach(item => {
-      const city = 'TestCity'
-      const error = 'This is a required field'
+      cy.getByTestID('shouldNotify--checkbox--input').should('be.checked')
 
       resetInputs()
-      cy.getByTestID('country--dropdown')
-        .click()
-        .getByTestID('dropdown-item')
-        .contains(item.country)
-        .then(i => {
-          i[0].click()
-        })
 
-      // Validate correct country is currently selected
+      // Click Upgrade
+      cy.getByTestID('checkout-upgrade--button').click()
+
+      // Check all errors are visible
+      cy.getByTestID('balanceThreshold--input').scrollIntoView()
+      cy.getByTestID('balanceThreshold--form-element-error').should(
+        'be.visible'
+      )
+      cy.getByTestID('balanceThreshold--form-element-error').contains(
+        genericError
+      )
+      cy.getByTestID('notifyEmail--form-element-error').should('be.visible')
+      cy.getByTestID('notifyEmail--form-element-error').contains(genericError)
+
+      // Check balance threshold specific error should exist
+      cy.getByTestID('balanceThreshold--input').clear().type('0')
+      cy.getByTestID('balanceThreshold--form-element-error').contains(
+        numberError
+      )
+
+      cy.getByTestID('notifyEmail--input').clear().type(email)
+      cy.getByTestID('balanceThreshold--input').clear().type(`${limit}`)
+
+      // Check all errors are gone
+      cy.getByTestID('balanceThreshold--form-element-error').should('not.exist')
+      cy.getByTestID('notifyEmail--form-element-error').should('not.exist')
+
+      // Uncheck Checkbox
+      cy.getByTestID('shouldNotify--checkbox').click()
+      cy.getByTestID('shouldNotify--checkbox--input').should('not.be.checked')
+
+      // Email and limit should still be present after toggling the notifications checkbox
+      cy.getByTestID('shouldNotify--checkbox').click()
+      cy.getByTestID('shouldNotify--checkbox--input').should('be.checked')
+      cy.getByTestID('notifyEmail--input').should('have.value', email)
+      cy.getByTestID('balanceThreshold--input').should('have.value', limit)
+
+      // should render US Billing Address
+      const error = 'This is a required field'
+
+      // Check defaults
+      resetInputs()
       cy.getByTestID('country--dropdown')
         .get('.cf-dropdown--selected')
-        .contains(item.country)
+        .contains('United States')
+      cy.getByTestID('usSubdivision--dropdown')
+        .get('.cf-dropdown--selected')
+        .contains('Alabama')
 
-      // Check US State equivalent
-      cy.getByTestID('intlSubdivision--form-element')
-        .get('.cf-form--label-text')
-        .contains(item.state)
-      cy.getByTestID('intlSubdivision--input')
-        .should('be.visible')
-        .should('have.value', '')
-
-      // Click Upgrade Button
       cy.getByTestID('checkout-upgrade--button').click()
 
-      // Check required fields show error
       cy.getByTestID('city--form-element-error').should('be.visible')
       cy.getByTestID('city--form-element-error').contains(error)
+      cy.getByTestID('postalCode--form-element-error').should('be.visible')
+      cy.getByTestID('postalCode--form-element-error').contains(error)
 
-      cy.getByTestID('city--input').type(city).should('have.value', city)
+      cy.getByTestID('city--input').type('Blacksburg')
+      cy.getByTestID('postalCode--input').type('24060')
+      cy.getByTestID('street1--input').type('Street1 Address')
+      cy.getByTestID('street2--input').type('Street2 Address')
 
-      // Click Upgrade Button
-      cy.getByTestID('checkout-upgrade--button').click()
-
-      // Check no errors are visible for billing address form
       cy.getByTestID('city--form-element-error').should('not.exist')
-    })
+      cy.getByTestID('postalCode--form-element-error').should('not.exist')
 
-    // Click Cancel Button
-    cy.getByTestID('checkout-cancel--button').click()
+      const cases = [
+        {country: 'Canada', state: 'Province'},
+        {country: 'India', state: 'State / Province / Region'},
+      ]
+      cases.forEach(item => {
+        const city = 'TestCity'
+        const error = 'This is a required field'
 
-    cy.get('@org').then((org: Organization) => {
-      cy.location().should(loc => {
-        expect(loc.pathname).to.include(`/orgs/${org.id}`)
+        resetInputs()
+        cy.getByTestID('country--dropdown')
+          .click()
+          .getByTestID('dropdown-item')
+          .contains(item.country)
+          .then(i => {
+            i[0].click()
+          })
+
+        // Validate correct country is currently selected
+        cy.getByTestID('country--dropdown')
+          .get('.cf-dropdown--selected')
+          .contains(item.country)
+
+        // Check US State equivalent
+        cy.getByTestID('intlSubdivision--form-element')
+          .get('.cf-form--label-text')
+          .contains(item.state)
+        cy.getByTestID('intlSubdivision--input')
+          .should('be.visible')
+          .should('have.value', '')
+
+        // Click Upgrade Button
+        cy.getByTestID('checkout-upgrade--button').click()
+
+        // Check required fields show error
+        cy.getByTestID('city--form-element-error').should('be.visible')
+        cy.getByTestID('city--form-element-error').contains(error)
+
+        cy.getByTestID('city--input').type(city).should('have.value', city)
+
+        // Click Upgrade Button
+        cy.getByTestID('checkout-upgrade--button').click()
+
+        // Check no errors are visible for billing address form
+        cy.getByTestID('city--form-element-error').should('not.exist')
+      })
+
+      // Click Cancel Button
+      cy.getByTestID('checkout-cancel--button').click()
+
+      cy.get('@org').then((org: Organization) => {
+        cy.location().should(loc => {
+          expect(loc.pathname).to.include(`/orgs/${org.id}`)
+        })
       })
     })
   })

--- a/cypress/e2e/cloud/checkout/checkoutpage.test.ts
+++ b/cypress/e2e/cloud/checkout/checkoutpage.test.ts
@@ -13,18 +13,13 @@ describe('Checkout Page Works', () => {
   beforeEach(() =>
     cy.flush().then(() =>
       cy.signin().then(() => {
-        cy.setFeatureFlags({
-          quartzIdentity: true,
-          multiOrg: true,
-        }).then(() => {
-          cy.get('@org').then(() => {
-            cy.getByTestID('home-page--header').should('be.visible')
-            cy.quartzProvision({
-              accountType: 'free',
-            }).then(() => {
-              cy.visit(`/checkout`)
-              cy.getByTestID('checkout-page--header').should('be.visible')
-            })
+        cy.get('@org').then(() => {
+          cy.getByTestID('home-page--header').should('be.visible')
+          cy.quartzProvision({
+            accountType: 'free',
+          }).then(() => {
+            cy.visit(`/checkout`)
+            cy.getByTestID('checkout-page--header').should('be.visible')
           })
         })
       })

--- a/cypress/e2e/cloud/checkout/checkoutpage.test.ts
+++ b/cypress/e2e/cloud/checkout/checkoutpage.test.ts
@@ -13,13 +13,18 @@ describe('Checkout Page Works', () => {
   beforeEach(() =>
     cy.flush().then(() =>
       cy.signin().then(() => {
-        cy.get('@org').then(() => {
-          cy.getByTestID('home-page--header').should('be.visible')
-          cy.quartzProvision({
-            accountType: 'free',
-          }).then(() => {
-            cy.visit(`/checkout`)
-            cy.getByTestID('checkout-page--header').should('be.visible')
+        cy.setFeatureFlags({
+          quartzIdentity: true,
+          multiOrg: true,
+        }).then(() => {
+          cy.get('@org').then(() => {
+            cy.getByTestID('home-page--header').should('be.visible')
+            cy.quartzProvision({
+              accountType: 'free',
+            }).then(() => {
+              cy.visit(`/checkout`)
+              cy.getByTestID('checkout-page--header').should('be.visible')
+            })
           })
         })
       })

--- a/cypress/e2e/cloud/communityTemplates.test.ts
+++ b/cypress/e2e/cloud/communityTemplates.test.ts
@@ -4,12 +4,14 @@ describe('Community Templates', () => {
   beforeEach(() =>
     cy.flush().then(() =>
       cy.signin().then(() => {
-        cy.get('@org').then(({id}: Organization) =>
-          cy.fixture('routes').then(({orgs}) => {
-            cy.visit(`${orgs}/${id}/settings/templates`)
-            cy.getByTestID('tree-nav')
-          })
-        )
+        cy.setFeatureFlags({quartzIdentity: true, multiOrg: true}).then(() => {
+          cy.get('@org').then(({id}: Organization) =>
+            cy.fixture('routes').then(({orgs}) => {
+              cy.visit(`${orgs}/${id}/settings/templates`)
+              cy.getByTestID('tree-nav')
+            })
+          )
+        })
       })
     )
   )

--- a/cypress/e2e/cloud/communityTemplates.test.ts
+++ b/cypress/e2e/cloud/communityTemplates.test.ts
@@ -4,14 +4,14 @@ describe('Community Templates', () => {
   beforeEach(() =>
     cy.flush().then(() =>
       cy.signin().then(() => {
-        cy.setFeatureFlags({quartzIdentity: true, multiOrg: true}).then(() => {
-          cy.get('@org').then(({id}: Organization) =>
-            cy.fixture('routes').then(({orgs}) => {
-              cy.visit(`${orgs}/${id}/settings/templates`)
-              cy.getByTestID('tree-nav')
+        cy.get('@org').then(({id}: Organization) =>
+          cy.fixture('routes').then(({orgs}) => {
+            cy.visit(`${orgs}/${id}/settings/templates`)
+            cy.getByTestID('tree-nav').then(() => {
+              cy.setFeatureFlags({quartzIdentity: true, multiOrg: true})
             })
-          )
-        })
+          })
+        )
       })
     )
   )

--- a/cypress/e2e/cloud/dashboardsView.test.ts
+++ b/cypress/e2e/cloud/dashboardsView.test.ts
@@ -2,10 +2,12 @@ describe('Dashboard', () => {
   beforeEach(() =>
     cy.flush().then(() =>
       cy.signin().then(() =>
-        cy.fixture('routes').then(({orgs}) => {
-          cy.get('@org').then(({id: orgID}: any) => {
-            cy.visit(`${orgs}/${orgID}/dashboards-list`)
-            cy.getByTestID('tree-nav')
+        cy.setFeatureFlags({quartzIdentity: true, multiOrg: true}).then(() => {
+          cy.fixture('routes').then(({orgs}) => {
+            cy.get('@org').then(({id: orgID}: any) => {
+              cy.visit(`${orgs}/${orgID}/dashboards-list`)
+              cy.getByTestID('tree-nav')
+            })
           })
         })
       )

--- a/cypress/e2e/cloud/dashboardsView.test.ts
+++ b/cypress/e2e/cloud/dashboardsView.test.ts
@@ -2,11 +2,11 @@ describe('Dashboard', () => {
   beforeEach(() =>
     cy.flush().then(() =>
       cy.signin().then(() =>
-        cy.setFeatureFlags({quartzIdentity: true, multiOrg: true}).then(() => {
-          cy.fixture('routes').then(({orgs}) => {
-            cy.get('@org').then(({id: orgID}: any) => {
-              cy.visit(`${orgs}/${orgID}/dashboards-list`)
-              cy.getByTestID('tree-nav')
+        cy.fixture('routes').then(({orgs}) => {
+          cy.get('@org').then(({id: orgID}: any) => {
+            cy.visit(`${orgs}/${orgID}/dashboards-list`)
+            cy.getByTestID('tree-nav').then(() => {
+              cy.setFeatureFlags({quartzIdentity: true, multiOrg: true})
             })
           })
         })

--- a/cypress/e2e/cloud/deepLinks.test.ts
+++ b/cypress/e2e/cloud/deepLinks.test.ts
@@ -3,7 +3,9 @@ import {Organization} from '../../../src/types'
 describe('Deep linking', () => {
   beforeEach(() => {
     cy.flush()
-    cy.signin()
+    cy.signin().then(() => {
+      cy.setFeatureFlags({quartzIdentity: true, multiOrg: true})
+    })
   })
 
   // If you're here and the test failure you're looking at is legitimate, it probably means a page

--- a/cypress/e2e/cloud/explorer.test.ts
+++ b/cypress/e2e/cloud/explorer.test.ts
@@ -17,7 +17,10 @@ function getTimeMachineText() {
 describe('DataExplorer', () => {
   beforeEach(() => {
     cy.flush()
-    cy.signin()
+    cy.signin().then(() => {
+      cy.setFeatureFlags({quartzIdentity: true, multiOrg: true})
+    })
+
     cy.get('@org').then(({id}: Organization) => {
       cy.createMapVariable(id)
       cy.fixture('routes').then(({orgs, explorer}) => {
@@ -33,61 +36,75 @@ describe('DataExplorer', () => {
     })
 
     it('can use the dynamic flux function selector to build a query', () => {
-      cy.get('.view-line').should('be.visible')
+      cy.setFeatureFlags({
+        fluxDynamicDocs: true,
+        quartzIdentity: true,
+        multiOrg: true,
+      }).then(() => {
+        cy.get('.view-line').should('be.visible')
 
-      cy.getByTestID('flux-toolbar-search--input').click().type('microsecondd') // purposefully misspell "microsecond" so all functions are filtered out
+        cy.getByTestID('flux-toolbar-search--input')
+          .click()
+          .type('microsecondd') // purposefully misspell "microsecond" so all functions are filtered out
 
-      cy.getByTestID('flux-toolbar--list').within(() => {
-        cy.getByTestID('empty-state').should('be.visible')
-      })
-      cy.getByTestID('flux-toolbar-search--input').type('{backspace}')
+        cy.getByTestID('flux-toolbar--list').within(() => {
+          cy.getByTestID('empty-state').should('be.visible')
+        })
+        cy.getByTestID('flux-toolbar-search--input').type('{backspace}')
 
-      cy.get('.flux-toolbar--list-item').should('contain', 'microsecond')
-      cy.get('.flux-toolbar--list-item').should('have.length', 1)
+        cy.get('.flux-toolbar--list-item').should('contain', 'microsecond')
+        cy.get('.flux-toolbar--list-item').should('have.length', 1)
 
-      // hovers over function and see a tooltip
-      cy.get('.flux-toolbar--list-item').trigger('mouseover')
-      cy.getByTestID('flux-docs--microsecond').should('be.visible')
+        // hovers over function and see a tooltip
+        cy.get('.flux-toolbar--list-item').trigger('mouseover')
+        cy.getByTestID('flux-docs--microsecond').should('be.visible')
 
-      // inject function into script editor
-      cy.getByTestID('flux--microsecond--inject').click()
+        // inject function into script editor
+        cy.getByTestID('flux--microsecond--inject').click()
 
-      getTimeMachineText().then(text => {
-        const expected = 'import "date"  date.microsecond(t: )'
-        cy.fluxEqual(text, expected).should('be.true')
+        getTimeMachineText().then(text => {
+          const expected = 'import "date"  date.microsecond(t: )'
+          cy.fluxEqual(text, expected).should('be.true')
+        })
       })
     })
 
     it('can use the dynamic flux function search bar to search by package or function name', () => {
-      cy.get('.view-line').should('be.visible')
+      cy.setFeatureFlags({
+        fluxDynamicDocs: true,
+        quartzIdentity: true,
+        multiOrg: true,
+      }).then(() => {
+        cy.get('.view-line').should('be.visible')
 
-      cy.getByTestID('flux-toolbar-search--input').click().type('filter')
+        cy.getByTestID('flux-toolbar-search--input').click().type('filter')
 
-      cy.getByTestID('flux-toolbar-search--input').click().type('filter')
+        cy.getByTestID('flux-toolbar-search--input').click().type('filter')
 
-      cy.get('.flux-toolbar--search').within(() => {
-        cy.getByTestID('dismiss-button').click()
-      })
-
-      cy.getByTestID('flux-toolbar-search--input')
-        .invoke('val')
-        .then(value => {
-          expect(value).to.equal('')
+        cy.get('.flux-toolbar--search').within(() => {
+          cy.getByTestID('dismiss-button').click()
         })
 
-      cy.getByTestID('flux-toolbar-search--input').click().type('array')
+        cy.getByTestID('flux-toolbar-search--input')
+          .invoke('val')
+          .then(value => {
+            expect(value).to.equal('')
+          })
 
-      cy.getByTestID('flux-toolbar-search--input').click().type('array')
+        cy.getByTestID('flux-toolbar-search--input').click().type('array')
 
-      cy.get('.flux-toolbar--search').within(() => {
-        cy.getByTestID('dismiss-button').click()
-      })
+        cy.getByTestID('flux-toolbar-search--input').click().type('array')
 
-      cy.getByTestID('flux-toolbar-search--input')
-        .invoke('val')
-        .then(value => {
-          expect(value).to.equal('')
+        cy.get('.flux-toolbar--search').within(() => {
+          cy.getByTestID('dismiss-button').click()
         })
+
+        cy.getByTestID('flux-toolbar-search--input')
+          .invoke('val')
+          .then(value => {
+            expect(value).to.equal('')
+          })
+      })
     })
   })
 })

--- a/cypress/e2e/cloud/explorer.test.ts
+++ b/cypress/e2e/cloud/explorer.test.ts
@@ -77,8 +77,7 @@ describe('DataExplorer', () => {
 
         cy.getByTestID('flux-toolbar-search--input').click().type('filter')
 
-        cy.get('.flux-toolbar--list-item').should('have.length.greaterThan', 1)
-        cy.getByTestID('flux--filter').contains('filter')
+        cy.getByTestID('flux-toolbar-search--input').click().type('filter')
 
         cy.get('.flux-toolbar--search').within(() => {
           cy.getByTestID('dismiss-button').click()
@@ -92,29 +91,7 @@ describe('DataExplorer', () => {
 
         cy.getByTestID('flux-toolbar-search--input').click().type('array')
 
-        cy.get('.flux-toolbar--search').within(() => {
-          cy.getByTestID('dismiss-button').click()
-        })
-
-        cy.getByTestID('flux-toolbar-search--input')
-          .invoke('val')
-          .then(value => {
-            expect(value).to.equal('')
-          })
-
-        cy.getByTestID('flux-toolbar-search--input')
-          .invoke('val')
-          .then(value => {
-            expect(value).to.equal('')
-          })
-
         cy.getByTestID('flux-toolbar-search--input').click().type('array')
-
-        cy.get('.flux-toolbar--list-item').should('have.length.greaterThan', 1)
-        cy.getByTestID('flux--filter').contains('filter')
-
-        cy.get('.flux-toolbar--list-item').should('have.length.greaterThan', 1)
-        cy.getByTestID('flux--filter').contains('filter')
 
         cy.get('.flux-toolbar--search').within(() => {
           cy.getByTestID('dismiss-button').click()

--- a/cypress/e2e/cloud/explorer.test.ts
+++ b/cypress/e2e/cloud/explorer.test.ts
@@ -35,7 +35,6 @@ describe('DataExplorer', () => {
 
     it('can use the dynamic flux function selector to build a query', () => {
       cy.setFeatureFlags({
-        fluxDynamicDocs: true,
         quartzIdentity: true,
         multiOrg: true,
       }).then(() => {
@@ -69,7 +68,6 @@ describe('DataExplorer', () => {
 
     it('can use the dynamic flux function search bar to search by package or function name', () => {
       cy.setFeatureFlags({
-        fluxDynamicDocs: true,
         quartzIdentity: true,
         multiOrg: true,
       }).then(() => {

--- a/cypress/e2e/cloud/explorer.test.ts
+++ b/cypress/e2e/cloud/explorer.test.ts
@@ -18,14 +18,12 @@ describe('DataExplorer', () => {
   beforeEach(() => {
     cy.flush()
     cy.signin().then(() => {
-      cy.setFeatureFlags({quartzIdentity: true, multiOrg: true})
-    })
-
-    cy.get('@org').then(({id}: Organization) => {
-      cy.createMapVariable(id)
-      cy.fixture('routes').then(({orgs, explorer}) => {
-        cy.visit(`${orgs}/${id}${explorer}`)
-        cy.getByTestID('tree-nav').should('be.visible')
+      cy.get('@org').then(({id}: Organization) => {
+        cy.createMapVariable(id)
+        cy.fixture('routes').then(({orgs, explorer}) => {
+          cy.visit(`${orgs}/${id}${explorer}`)
+          cy.getByTestID('tree-nav').should('be.visible')
+        })
       })
     })
   })
@@ -79,7 +77,8 @@ describe('DataExplorer', () => {
 
         cy.getByTestID('flux-toolbar-search--input').click().type('filter')
 
-        cy.getByTestID('flux-toolbar-search--input').click().type('filter')
+        cy.get('.flux-toolbar--list-item').should('have.length.greaterThan', 1)
+        cy.getByTestID('flux--filter').contains('filter')
 
         cy.get('.flux-toolbar--search').within(() => {
           cy.getByTestID('dismiss-button').click()
@@ -93,7 +92,29 @@ describe('DataExplorer', () => {
 
         cy.getByTestID('flux-toolbar-search--input').click().type('array')
 
+        cy.get('.flux-toolbar--search').within(() => {
+          cy.getByTestID('dismiss-button').click()
+        })
+
+        cy.getByTestID('flux-toolbar-search--input')
+          .invoke('val')
+          .then(value => {
+            expect(value).to.equal('')
+          })
+
+        cy.getByTestID('flux-toolbar-search--input')
+          .invoke('val')
+          .then(value => {
+            expect(value).to.equal('')
+          })
+
         cy.getByTestID('flux-toolbar-search--input').click().type('array')
+
+        cy.get('.flux-toolbar--list-item').should('have.length.greaterThan', 1)
+        cy.getByTestID('flux--filter').contains('filter')
+
+        cy.get('.flux-toolbar--list-item').should('have.length.greaterThan', 1)
+        cy.getByTestID('flux--filter').contains('filter')
 
         cy.get('.flux-toolbar--search').within(() => {
           cy.getByTestID('dismiss-button').click()

--- a/cypress/e2e/cloud/flows.test.ts
+++ b/cypress/e2e/cloud/flows.test.ts
@@ -4,14 +4,14 @@ describe('Flows', () => {
   beforeEach(() => {
     cy.flush()
     cy.signin().then(() => {
-      cy.setFeatureFlags({quartzIdentity: true, multiOrg: true})
-    })
-    cy.get('@org').then(({id}: Organization) => {
-      cy.fixture('routes').then(({orgs}) => {
-        cy.visit(`${orgs}/${id}`)
-        cy.getByTestID('version-info').should('be.visible')
-        cy.getByTestID('nav-item-flows').should('be.visible')
-        cy.getByTestID('nav-item-flows').click()
+      cy.get('@org').then(({id}: Organization) => {
+        cy.fixture('routes').then(({orgs}) => {
+          cy.visit(`${orgs}/${id}`)
+          cy.getByTestID('version-info').should('be.visible')
+          cy.getByTestID('nav-item-flows').should('be.visible')
+          cy.getByTestID('nav-item-flows').click()
+          cy.setFeatureFlags({quartzIdentity: true, multiOrg: true})
+        })
       })
     })
   })

--- a/cypress/e2e/cloud/flows.test.ts
+++ b/cypress/e2e/cloud/flows.test.ts
@@ -185,7 +185,6 @@ describe('Flows', () => {
 
   it('can use the dynamic flux function selector to build a query', () => {
     cy.setFeatureFlags({
-      fluxDynamicDocs: true,
       quartzIdentity: true,
       multiOrg: true,
     }).then(() => {
@@ -221,7 +220,6 @@ describe('Flows', () => {
 
   it('can use the dynamic flux function search bar to search by package or function name', () => {
     cy.setFeatureFlags({
-      fluxDynamicDocs: true,
       quartzIdentity: true,
       multiOrg: true,
     }).then(() => {

--- a/cypress/e2e/cloud/flows.test.ts
+++ b/cypress/e2e/cloud/flows.test.ts
@@ -3,7 +3,9 @@ import {Organization} from '../../../src/types'
 describe('Flows', () => {
   beforeEach(() => {
     cy.flush()
-    cy.signin()
+    cy.signin().then(() => {
+      cy.setFeatureFlags({quartzIdentity: true, multiOrg: true})
+    })
     cy.get('@org').then(({id}: Organization) => {
       cy.fixture('routes').then(({orgs}) => {
         cy.visit(`${orgs}/${id}`)
@@ -182,69 +184,81 @@ describe('Flows', () => {
   })
 
   it('can use the dynamic flux function selector to build a query', () => {
-    cy.getByTestID('preset-script').first().click()
+    cy.setFeatureFlags({
+      fluxDynamicDocs: true,
+      quartzIdentity: true,
+      multiOrg: true,
+    }).then(() => {
+      cy.getByTestID('preset-script').first().click()
 
-    cy.get('.view-line').should('be.visible')
+      cy.get('.view-line').should('be.visible')
 
-    cy.get('button[title="Function Reference"]').click()
+      cy.get('button[title="Function Reference"]').click()
 
-    // search for a function
-    cy.getByTestID('flux-toolbar-search--input').click().type('microsecondd') // purposefully misspell "microsecond" so all functions are filtered out
+      // search for a function
+      cy.getByTestID('flux-toolbar-search--input').click().type('microsecondd') // purposefully misspell "microsecond" so all functions are filtered out
 
-    cy.getByTestID('flux-toolbar--list').within(() => {
-      cy.getByTestID('empty-state').should('be.visible')
+      cy.getByTestID('flux-toolbar--list').within(() => {
+        cy.getByTestID('empty-state').should('be.visible')
+      })
+      cy.getByTestID('flux-toolbar-search--input').type('{backspace}')
+
+      cy.get('.flux-toolbar--list-item').should('contain', 'microsecond')
+      cy.get('.flux-toolbar--list-item').should('have.length', 1)
+
+      // hovers over function and see a tooltip
+      cy.get('.flux-toolbar--list-item').trigger('mouseover')
+      cy.getByTestID('flux-docs--microsecond').should('be.visible')
+
+      // inject function into script editor
+      cy.getByTestID('flux--microsecond--inject').click({force: true})
+
+      // At minimium two lines: import and a function call
+      cy.get('.view-line').should('have.length.at.least', 2)
+      cy.get('.view-line').last().contains('microsecond')
     })
-    cy.getByTestID('flux-toolbar-search--input').type('{backspace}')
-
-    cy.get('.flux-toolbar--list-item').should('contain', 'microsecond')
-    cy.get('.flux-toolbar--list-item').should('have.length', 1)
-
-    // hovers over function and see a tooltip
-    cy.get('.flux-toolbar--list-item').trigger('mouseover')
-    cy.getByTestID('flux-docs--microsecond').should('be.visible')
-
-    // inject function into script editor
-    cy.getByTestID('flux--microsecond--inject').click({force: true})
-
-    // At minimium two lines: import and a function call
-    cy.get('.view-line').should('have.length.at.least', 2)
-    cy.get('.view-line').last().contains('microsecond')
   })
 
   it('can use the dynamic flux function search bar to search by package or function name', () => {
-    cy.getByTestID('preset-script').first().click()
+    cy.setFeatureFlags({
+      fluxDynamicDocs: true,
+      quartzIdentity: true,
+      multiOrg: true,
+    }).then(() => {
+      cy.getByTestID('preset-script').first().click()
 
-    cy.get('.view-line').should('be.visible')
+      cy.get('.view-line').should('be.visible')
 
-    cy.get('button[title="Function Reference"]').click()
+      cy.get('button[title="Function Reference"]').click()
 
-    cy.getByTestID('flux-toolbar-search--input').click().type('filter')
+      cy.getByTestID('flux-toolbar-search--input').click().type('filter')
 
-    cy.getByTestID('flux-toolbar-search--input').click().type('filter')
+      cy.getByTestID('flux-toolbar-search--input').click().type('filter')
 
-    cy.get('.flux-toolbar--search').within(() => {
-      cy.getByTestID('dismiss-button').click()
-    })
-
-    cy.getByTestID('flux-toolbar-search--input')
-      .invoke('val')
-      .then(value => {
-        expect(value).to.equal('')
+      cy.get('.flux-toolbar--search').within(() => {
+        cy.getByTestID('dismiss-button').click()
       })
 
-    cy.getByTestID('flux-toolbar-search--input').click().type('array')
+      cy.getByTestID('flux-toolbar-search--input')
+        .invoke('val')
+        .then(value => {
+          expect(value).to.equal('')
+        })
 
-    cy.getByTestID('flux-toolbar-search--input').click().type('array')
+      cy.getByTestID('flux-toolbar-search--input').click().type('array')
 
-    cy.get('.flux-toolbar--search').within(() => {
-      cy.getByTestID('dismiss-button').click()
-    })
+      cy.getByTestID('flux-toolbar-search--input').click().type('array')
 
-    cy.getByTestID('flux-toolbar-search--input')
-      .invoke('val')
-      .then(value => {
-        expect(value).to.equal('')
+      cy.get('.flux-toolbar--search').within(() => {
+        cy.getByTestID('dismiss-button').click()
       })
+
+      cy.getByTestID('flux-toolbar-search--input')
+        .invoke('val')
+        .then(value => {
+          expect(value).to.equal('')
+        })
+    })
   })
 })
 
@@ -255,6 +269,8 @@ describe('Flows with newQueryBuilder flag on', () => {
     cy.get('@org').then(({id}: Organization) =>
       cy.fixture('routes').then(({orgs}) => {
         cy.setFeatureFlags({
+          multiOrg: true,
+          quartzIdentity: true,
           newQueryBuilder: true,
         }).then(() => {
           cy.visit(`${orgs}/${id}`)

--- a/cypress/e2e/cloud/geoOptions.test.ts
+++ b/cypress/e2e/cloud/geoOptions.test.ts
@@ -4,12 +4,18 @@ describe.skip('DataExplorer - Geo Map Type Customization Options', () => {
   beforeEach(() =>
     cy.flush().then(() =>
       cy.signin().then(() => {
-        cy.get('@org').then(({id}: Organization) => {
-          cy.createMapVariable(id)
-          cy.fixture('routes').then(({orgs, explorer}) => {
-            cy.visit(`${orgs}/${id}${explorer}`)
+        cy.signin()
+          .then(() => {
+            cy.setFeatureFlags({quartzIdentity: true, multiOrg: true})
           })
-        })
+          .then(() => {
+            cy.get('@org').then(({id}: Organization) => {
+              cy.createMapVariable(id)
+              cy.fixture('routes').then(({orgs, explorer}) => {
+                cy.visit(`${orgs}/${id}${explorer}`)
+              })
+            })
+          })
       })
     )
   )

--- a/cypress/e2e/cloud/helpBar.test.ts
+++ b/cypress/e2e/cloud/helpBar.test.ts
@@ -2,11 +2,13 @@ describe('Help bar support for free account users', () => {
   beforeEach(() =>
     cy.flush().then(() =>
       cy.signin().then(() => {
-        cy.get('@org').then(() => {
-          cy.quartzProvision({
-            accountType: 'free',
-          }).then(() => {
-            cy.getByTestID('nav-item-support').should('be.visible')
+        cy.setFeatureFlags({quartzIdentity: true, multiOrg: true}).then(() => {
+          cy.get('@org').then(() => {
+            cy.quartzProvision({
+              accountType: 'free',
+            }).then(() => {
+              cy.getByTestID('nav-item-support').should('be.visible')
+            })
           })
         })
       })
@@ -33,12 +35,14 @@ describe('Help bar support for PAYG users', () => {
   beforeEach(() =>
     cy.flush().then(() =>
       cy.signin().then(() => {
-        cy.get('@org').then(() => {
-          cy.quartzProvision({
-            accountType: 'pay_as_you_go',
-          }).then(() => {
-            cy.visit('/')
-            cy.getByTestID('nav-item-support').should('be.visible')
+        cy.setFeatureFlags({quartzIdentity: true, multiOrg: true}).then(() => {
+          cy.get('@org').then(() => {
+            cy.quartzProvision({
+              accountType: 'pay_as_you_go',
+            }).then(() => {
+              cy.visit('/')
+              cy.getByTestID('nav-item-support').should('be.visible')
+            })
           })
         })
       })

--- a/cypress/e2e/cloud/helpBar.test.ts
+++ b/cypress/e2e/cloud/helpBar.test.ts
@@ -64,10 +64,16 @@ describe('Help bar support for PAYG users', () => {
     cy.getByTestID('payg-support-overlay-header').should('exist')
 
     cy.getByTestID('contact-support-subject-input').clear().type(subject)
-    cy.getByTestID('dropdown--button').click()
-    cy.getByTitle('1 - Critical').click()
-
-    cy.getByTestID('support-description--textarea').clear().type(description)
-    cy.getByTestID('payg-contact-support--submit').should('not.be.disabled')
+    cy.getByTestID('severity-level-dropdown')
+      .within(() => {
+        cy.getByTestID('dropdown--button').click()
+        cy.getByTitle('1 - Critical').click()
+      })
+      .then(() => {
+        cy.getByTestID('support-description--textarea')
+          .clear()
+          .type(description)
+        cy.getByTestID('payg-contact-support--submit').should('not.be.disabled')
+      })
   })
 })

--- a/cypress/e2e/cloud/operator.test.ts
+++ b/cypress/e2e/cloud/operator.test.ts
@@ -2,14 +2,16 @@ describe('Operator Page', () => {
   beforeEach(() =>
     cy.flush().then(() =>
       cy.signin().then(() => {
-        cy.get('@org').then(() => {
-          cy.getByTestID('home-page--header').should('be.visible')
-          cy.quartzProvision({
-            isOperator: true,
-            operatorRole: 'read-write',
-          }).then(() => {
-            cy.visit(`/operator`)
-            cy.getByTestID('operator-page--title').contains('2.0 Resources')
+        cy.setFeatureFlags({quartzIdentity: true, multiOrg: true}).then(() => {
+          cy.get('@org').then(() => {
+            cy.getByTestID('home-page--header').should('be.visible')
+            cy.quartzProvision({
+              isOperator: true,
+              operatorRole: 'read-write',
+            }).then(() => {
+              cy.visit(`/operator`)
+              cy.getByTestID('operator-page--title').contains('2.0 Resources')
+            })
           })
         })
       })

--- a/cypress/e2e/cloud/operatorRO.test.ts
+++ b/cypress/e2e/cloud/operatorRO.test.ts
@@ -4,13 +4,14 @@ describe('Operator Page', () => {
       cy.signin().then(() => {
         cy.get('@org').then(() => {
           cy.getByTestID('home-page--header').should('be.visible')
-
           cy.quartzProvision({
             isOperator: true,
             operatorRole: 'read-only',
           }).then(() => {
             cy.reload()
             cy.setFeatureFlags({
+              multiOrg: true,
+              quartzIdentity: true,
               operatorRole: true,
             }).then(() => {
               cy.getByTestID('nav-item--operator').click()

--- a/cypress/e2e/cloud/pinned.test.ts
+++ b/cypress/e2e/cloud/pinned.test.ts
@@ -14,6 +14,8 @@ describe.skip('Pinned Items', () => {
       orgID = id
       cy.setFeatureFlags({
         pinnedItems: true,
+        multiOrg: true,
+        quartzIdentity: true,
       })
       cy.getByTestID('tree-nav')
     })
@@ -31,9 +33,12 @@ describe.skip('Pinned Items', () => {
       cy.createDashboard(orgID)
       cy.setFeatureFlags({
         pinnedItems: true,
+        multiOrg: true,
+        quartzIdentity: true,
+      }).then(() => {
+        cy.getByTestID('nav-item-dashboards').should('be.visible')
+        cy.getByTestID('nav-item-dashboards').click()
       })
-      cy.getByTestID('nav-item-dashboards').should('be.visible')
-      cy.getByTestID('nav-item-dashboards').click()
     })
     it('pins a dashboard to the homepage for easy access as a pinned item', () => {
       cy.getByTestID('dashboard-card')
@@ -127,20 +132,25 @@ describe.skip('Pinned Items', () => {
     beforeEach(() => {
       cy.flush()
       cy.signin()
-      cy.get('@org').then(({id: orgID}: Organization) =>
-        cy
-          .createToken(orgID, 'test token', 'active', [
-            {action: 'write', resource: {type: 'views', orgID}},
-            {action: 'write', resource: {type: 'documents', orgID}},
-            {action: 'write', resource: {type: 'tasks', orgID}},
-          ])
-          .then(({body}) => {
-            cy.wrap(body.token).as('token')
-            cy.getByTestID('tree-nav')
-            cy.visit(`/orgs/${orgID}/tasks`)
-            cy.getByTestID('tree-nav')
-          })
-      )
+        .then(() => {
+          cy.setFeatureFlags({quartzIdentity: true, multiOrg: true})
+        })
+        .then(() => {
+          cy.get('@org').then(({id: orgID}: Organization) =>
+            cy
+              .createToken(orgID, 'test token', 'active', [
+                {action: 'write', resource: {type: 'views', orgID}},
+                {action: 'write', resource: {type: 'documents', orgID}},
+                {action: 'write', resource: {type: 'tasks', orgID}},
+              ])
+              .then(({body}) => {
+                cy.wrap(body.token).as('token')
+                cy.getByTestID('tree-nav')
+                cy.visit(`/orgs/${orgID}/tasks`)
+                cy.getByTestID('tree-nav')
+              })
+          )
+        })
 
       taskName = 'Task'
       cy.log('Using autocomplete for closing syntax.')
@@ -214,6 +224,8 @@ from(bucket: "${name}"{rightarrow}
     beforeEach(() => {
       cy.setFeatureFlags({
         pinnedItems: true,
+        multiOrg: true,
+        quartzIdentity: true,
       })
       cy.intercept('GET', '/api/v2private/notebooks*').as('getNotebooks')
       cy.intercept('PATCH', '/api/v2private/notebooks/*').as('updateNotebook')

--- a/cypress/e2e/cloud/subscriptions.test.ts
+++ b/cypress/e2e/cloud/subscriptions.test.ts
@@ -12,11 +12,7 @@ describe('Subscriptions', () => {
               accountType: 'pay_as_you_go',
             }).then(() => {
               cy.visit(`${orgs}/${id}/load-data/sources`)
-              cy.setFeatureFlags({
-                subscriptionsUI: true,
-                multiOrg: true,
-                quartzIdentity: true,
-              })
+
               cy.getByTestID('subscriptions--tab').should('be.visible')
               cy.intercept('POST', `/api/v2private/broker/subs*`).as(
                 'CreateSubscription'
@@ -30,6 +26,12 @@ describe('Subscriptions', () => {
               cy.intercept('GET', '/api/v2private/broker/subs/statuses', []).as(
                 'GetStatuses'
               )
+
+              cy.setFeatureFlags({
+                subscriptionsUI: true,
+                multiOrg: true,
+                quartzIdentity: true,
+              })
             })
           })
         })

--- a/cypress/e2e/cloud/subscriptions.test.ts
+++ b/cypress/e2e/cloud/subscriptions.test.ts
@@ -14,6 +14,8 @@ describe('Subscriptions', () => {
               cy.visit(`${orgs}/${id}/load-data/sources`)
               cy.setFeatureFlags({
                 subscriptionsUI: true,
+                multiOrg: true,
+                quartzIdentity: true,
               })
               cy.getByTestID('subscriptions--tab').should('be.visible')
               cy.intercept('POST', `/api/v2private/broker/subs*`).as(

--- a/cypress/e2e/cloud/subscriptions.test.ts
+++ b/cypress/e2e/cloud/subscriptions.test.ts
@@ -13,6 +13,12 @@ describe('Subscriptions', () => {
             }).then(() => {
               cy.visit(`${orgs}/${id}/load-data/sources`)
 
+              cy.setFeatureFlags({
+                subscriptionsUI: true,
+                multiOrg: true,
+                quartzIdentity: true,
+              })
+
               cy.getByTestID('subscriptions--tab').should('be.visible')
               cy.intercept('POST', `/api/v2private/broker/subs*`).as(
                 'CreateSubscription'
@@ -26,12 +32,6 @@ describe('Subscriptions', () => {
               cy.intercept('GET', '/api/v2private/broker/subs/statuses', []).as(
                 'GetStatuses'
               )
-
-              cy.setFeatureFlags({
-                subscriptionsUI: true,
-                multiOrg: true,
-                quartzIdentity: true,
-              })
             })
           })
         })

--- a/cypress/e2e/cloud/usage.test.ts
+++ b/cypress/e2e/cloud/usage.test.ts
@@ -117,6 +117,7 @@ describe('Usage Page PAYG With Data', () => {
   })
 
   it('should display the usage page with data for a PAYG user', () => {
+    cy.getByTestID('cloud-upgrade--button').should('not.exist')
     const stats = ['0.78 MB', '32,424', '2.06 GB-hr', '0.01 GB']
 
     // Check that the stats are returned and rendered for a user with data

--- a/cypress/e2e/cloud/usage.test.ts
+++ b/cypress/e2e/cloud/usage.test.ts
@@ -11,15 +11,14 @@ describe('Usage Page Free User No Data', () => {
   beforeEach(() => {
     cy.flush().then(() =>
       cy.signin().then(() => {
-        cy.setFeatureFlags({quartzIdentity: true, multiOrg: true}).then(() => {
-          cy.get('@org').then(({id}: Organization) => {
-            cy.quartzProvision({
-              hasData: false,
-              accountType: 'free',
-            }).then(() => {
-              cy.visit(`/orgs/${id}/usage`)
-              cy.getByTestID('usage-page--header').should('be.visible')
-            })
+        cy.get('@org').then(({id}: Organization) => {
+          cy.quartzProvision({
+            hasData: false,
+            accountType: 'free',
+          }).then(() => {
+            cy.visit(`/orgs/${id}/usage`)
+            cy.getByTestID('usage-page--header').should('be.visible')
+            cy.setFeatureFlags({quartzIdentity: true, multiOrg: true})
           })
         })
       })
@@ -28,7 +27,7 @@ describe('Usage Page Free User No Data', () => {
 
   it('should display the usage page common features', () => {
     // Display the upgrade button when the user is a free user
-    cy.get('.cf-page-header--fluid').children().should('have.length', 2)
+    cy.get('.cf-page-header--fluid').children().should('have.length', 1)
     cy.getByTestID('cloud-upgrade--button').should('be.visible')
 
     // Check that the stat headers render correctly
@@ -110,6 +109,7 @@ describe('Usage Page PAYG With Data', () => {
           }).then(() => {
             cy.visit(`/orgs/${id}/usage`)
             cy.getByTestID('usage-page--header').should('be.visible')
+            cy.setFeatureFlags({quartzIdentity: true, multiOrg: true})
           })
         })
       })
@@ -117,9 +117,6 @@ describe('Usage Page PAYG With Data', () => {
   })
 
   it('should display the usage page with data for a PAYG user', () => {
-    // The implication here is that there is no Upgrade Now button
-    cy.get('.cf-page-header--fluid').children().should('have.length', 1)
-
     const stats = ['0.78 MB', '32,424', '2.06 GB-hr', '0.01 GB']
 
     // Check that the stats are returned and rendered for a user with data

--- a/cypress/e2e/cloud/usage.test.ts
+++ b/cypress/e2e/cloud/usage.test.ts
@@ -11,13 +11,15 @@ describe('Usage Page Free User No Data', () => {
   beforeEach(() => {
     cy.flush().then(() =>
       cy.signin().then(() => {
-        cy.get('@org').then(({id}: Organization) => {
-          cy.quartzProvision({
-            hasData: false,
-            accountType: 'free',
-          }).then(() => {
-            cy.visit(`/orgs/${id}/usage`)
-            cy.getByTestID('usage-page--header').should('be.visible')
+        cy.setFeatureFlags({quartzIdentity: true, multiOrg: true}).then(() => {
+          cy.get('@org').then(({id}: Organization) => {
+            cy.quartzProvision({
+              hasData: false,
+              accountType: 'free',
+            }).then(() => {
+              cy.visit(`/orgs/${id}/usage`)
+              cy.getByTestID('usage-page--header').should('be.visible')
+            })
           })
         })
       })

--- a/cypress/e2e/cloud/userAccounts.test.ts
+++ b/cypress/e2e/cloud/userAccounts.test.ts
@@ -4,160 +4,87 @@ const doSetup = (cy, numAccounts: number) => {
   cy.flush().then(() => {
     cy.signin().then(() => {
       cy.get('@org').then(({id}: Organization) => {
+        cy.visit(`/orgs/${id}/accounts/settings`)
         cy.setFeatureFlags({
+          quartzIdentity: true,
           multiAccount: true,
           multiOrg: true,
-          quartzIdentity: true,
         }).then(() => {
-          cy.quartzProvision({
-            accountType: 'free',
-            numAccounts,
-          }).then(() => {
-            cy.visit(`/orgs/${id}/accounts/settings`)
-          })
+          cy.wait(300)
         })
       })
     })
   })
 }
 
-const prefix = 'accountSwitch-toggle-choice'
-
 describe('Account Page tests', () => {
-  describe('User with 4 accounts', () => {
-    beforeEach(() => doSetup(cy, 4))
+  describe('User with more than one account', () => {
+    before(() => {
+      // For this test, intercept all GET and POST requests to the accounts API
+      // Otherwise, attempts to revise quartz-mock cause flaking issues in other tests
+      // that presume the current account name has not changed.
 
-    it('can change the default account', () => {
-      const defaultMarker = '(default)'
-
-      // first ensure that we get 4 accounts from Quartz
-      cy.getByTestID('account-settings--header').should('be.visible')
-      cy.getByTestID('input--active-account-name').should('be.visible')
-      cy.getByTestID('user-account-switch-btn').click()
-      cy.getByTestID('switch-account--dialog').should('be.visible')
-      cy.getByTestID(`${prefix}-0-ID`).should('be.visible')
-      cy.getByTestID(`${prefix}-1-ID`).should('be.visible')
-      cy.getByTestID(`${prefix}-2-ID`).should('be.visible')
-      cy.getByTestID(`${prefix}-3-ID`).should('be.visible')
-      cy.getByTestID('multi-account-switch-cancel').click()
-      cy.getByTestID('switch-account--dialog').should('not.exist')
-
-      // rename the current account
-      const name = '4-accounts-test'
-      cy.getByTestID('input--active-account-name').clear().type(name)
-      cy.getByTestID('rename-account--button').click()
-
-      cy.getByTestID('notification-success').should('be.visible')
-
-      // active name is our input and "Switch" starts as disabled
-      cy.getByTestID('user-account-switch-btn').click()
-      cy.getByTestID('switch-account--dialog').should('be.visible')
-      cy.getByTestID('actually-switch-account--btn').should('be.disabled')
-
-      // Only one "(default)", which cannot be set again, and not our renamed account
-      cy.get('.cf-toggle--visual-input')
-        .contains(defaultMarker)
-        .should('have.length', 1)
-      cy.get('.cf-toggle--visual-input').contains(defaultMarker).click()
-      cy.getByTestID('switch-default-account--btn').should('be.disabled')
-      cy.get('.cf-toggle--visual-input').not(`:contains(${name}`)
-
-      // Three non-default that can be selected as default
-      cy.get('.cf-toggle--visual-input')
-        .not(`:contains(${defaultMarker}`)
-        .should('have.length', 3)
-      cy.get('.cf-toggle--visual-input')
-        .not(`:contains(${defaultMarker}`)
-        .eq(0)
-        .click()
-      cy.getByTestID('switch-default-account--btn').should('be.enabled')
-      cy.get('.cf-toggle--visual-input')
-        .not(`:contains(${defaultMarker}`)
-        .eq(1)
-        .click()
-      cy.getByTestID('switch-default-account--btn').should('be.enabled')
-      cy.get('.cf-toggle--visual-input')
-        .not(`:contains(${defaultMarker}`)
-        .eq(2)
-        .click()
-      cy.getByTestID('switch-default-account--btn').should('be.enabled')
-
-      // select our renamed account as the default
-      cy.get('.cf-toggle--visual-input').contains(name).click()
-      cy.getByTestID('switch-default-account--btn').click()
-
-      cy.getByTestID('notification-success').should('be.visible')
-      cy.getByTestID('switch-account--dialog').should('not.exist')
-
-      // open the "Switch Account" modal again, our renamed account should be default
-      cy.getByTestID('user-account-switch-btn').click()
-      cy.getByTestID('switch-account--dialog').should('be.visible')
-      cy.get('.cf-toggle--visual-input').contains(`${name} ${defaultMarker}`)
-
-      // close the modal
-      cy.getByTestID('multi-account-switch-cancel').click()
-      cy.getByTestID('switch-account--dialog').should('not.exist')
+      cy.intercept('GET', '/api/v2/quartz/accounts', {
+        statusCode: 200,
+        body: [
+          {id: 416, isActive: true, isDefault: false, name: 'Influx'},
+          {id: 415, isActive: false, isDefault: true, name: 'Veganomicon'},
+        ],
+      })
+      doSetup(cy, 2)
     })
-  })
-
-  describe('User with one account', () => {
-    beforeEach(() => doSetup(cy, 1))
-
-    it('can get to the page and get the accounts, and the switch button is NOT showing', () => {
-      cy.getByTestID('account-settings--header').should('be.visible')
-      cy.getByTestID('input--active-account-name')
-        .invoke('val')
-        .should('have.length.greaterThan', 0)
-      cy.getByTestID('user-account-switch-btn').should('not.exist')
-    })
-  })
-
-  describe('User with two accounts', () => {
-    beforeEach(() => doSetup(cy, 2))
 
     it('can get to the account page and rename the active account', () => {
       // first ensure that we get 2 accounts from Quartz
       cy.getByTestID('account-settings--header').should('be.visible')
       cy.getByTestID('input--active-account-name').should('be.visible')
-      cy.getByTestID('user-account-switch-btn').click()
-      cy.getByTestID('switch-account--dialog').should('be.visible')
-      cy.getByTestID(`${prefix}-0-ID`).should('be.visible')
-      cy.getByTestID(`${prefix}-1-ID`).should('be.visible')
-      cy.getByTestID('multi-account-switch-cancel').click()
-      cy.getByTestID('switch-account--dialog').should('not.exist')
 
       // rename the current account
-      const name = 'Bruno-no-no-no'
-      cy.getByTestID('input--active-account-name').clear().type(name)
+      const firstNewAccountName = 'Bruno-no-no-no'
+      const newAccountProps = {
+        id: 416,
+        isActive: true,
+        isDefault: false,
+        name: firstNewAccountName,
+      }
+
+      cy.intercept('PATCH', '/api/v2/quartz/accounts/416', {
+        statusCode: 200,
+        body: newAccountProps,
+      })
+
+      cy.intercept('GET', '/api/v2/quartz/accounts', {
+        statusCode: 200,
+        body: newAccountProps,
+      })
+
+      cy.getByTestID('input--active-account-name')
+        .clear()
+        .type(firstNewAccountName)
       cy.getByTestID('rename-account--button').click()
-
       cy.getByTestID('notification-success').should('be.visible')
+      cy.contains(firstNewAccountName)
 
-      // active name should be our input
-      cy.getByTestID('user-account-switch-btn').click()
-      cy.getByTestID('switch-account--dialog').should('be.visible')
-      cy.getByTestID(`${prefix}-0-ID`).should('be.visible')
-      cy.getByTestID(`${prefix}-0-ID`).contains(name)
-      cy.getByTestID(`${prefix}-0-ID--input`).should('be.checked')
-      cy.getByTestID('multi-account-switch-cancel').click()
-      cy.getByTestID('switch-account--dialog').should('not.exist')
+      // rename it again
+      const secondNewAccountName = 'Bruno-yes-yes-yes'
+      newAccountProps.name = secondNewAccountName
 
-      // then, rename it again
-      const newName = 'Bruno-yes-yes-yes'
+      cy.intercept('PATCH', '/api/v2/quartz/accounts/416', {
+        statusCode: 200,
+        body: newAccountProps,
+      })
+      cy.intercept('GET', '/api/v2/quartz/accounts', {
+        statusCode: 200,
+        body: newAccountProps,
+      })
+
       cy.getByTestID('input--active-account-name').should('be.visible')
-      cy.getByTestID('input--active-account-name').clear().type(newName)
+      cy.getByTestID('input--active-account-name')
+        .clear()
+        .type(secondNewAccountName)
       cy.getByTestID('rename-account--button').click()
-
       cy.getByTestID('notification-success').should('be.visible')
-
-      // active name should be our new name
-      cy.getByTestID('user-account-switch-btn').click()
-      cy.getByTestID('switch-account--dialog').should('be.visible')
-      cy.getByTestID(`${prefix}-0-ID`).should('be.visible')
-      cy.getByTestID(`${prefix}-0-ID`).contains(newName)
-      cy.getByTestID(`${prefix}-0-ID--input`).should('be.checked')
-      cy.getByTestID('multi-account-switch-cancel').click()
-      cy.getByTestID('switch-account--dialog').should('not.exist')
+      cy.contains(secondNewAccountName)
     })
   })
 })

--- a/cypress/e2e/cloud/userAccounts.test.ts
+++ b/cypress/e2e/cloud/userAccounts.test.ts
@@ -6,6 +6,8 @@ const doSetup = (cy, numAccounts: number) => {
       cy.get('@org').then(({id}: Organization) => {
         cy.setFeatureFlags({
           multiAccount: true,
+          multiOrg: true,
+          quartzIdentity: true,
         }).then(() => {
           cy.quartzProvision({
             accountType: 'free',

--- a/cypress/e2e/cloud/userAccounts.test.ts
+++ b/cypress/e2e/cloud/userAccounts.test.ts
@@ -1,6 +1,6 @@
 import {Organization} from '../../../src/types'
 
-const doSetup = (cy, numAccounts: number) => {
+const doSetup = cy => {
   cy.flush().then(() => {
     cy.signin().then(() => {
       cy.get('@org').then(({id}: Organization) => {
@@ -31,7 +31,7 @@ describe('Account Page tests', () => {
           {id: 415, isActive: false, isDefault: true, name: 'Veganomicon'},
         ],
       })
-      doSetup(cy, 2)
+      doSetup(cy)
     })
 
     it('can get to the account page and rename the active account', () => {

--- a/cypress/e2e/cloud/userProfile.test.ts
+++ b/cypress/e2e/cloud/userProfile.test.ts
@@ -1,28 +1,3 @@
-// Utility Functions
-export const setupProfile = (): Promise<any> => {
-  return Cypress.Promise.resolve(
-    cy.flush().then(() =>
-      cy.signin().then(() => {
-        cy.get('@org').then(() => {
-          cy.request({
-            method: 'PUT',
-            url: 'api/v2/quartz/accounts/resetAllAccountOrgs',
-          })
-          cy.visit('/')
-          cy.getByTestID('home-page--header').should('be.visible')
-          cy.setFeatureFlags(userProfileFeatureFlags).then(() => {
-            // cy.wait($time) is necessary to consistently ensure sufficient time for the feature flag override.
-            // The flag reset happens via redux, (it's not a network request), so we can't cy.wait($intercepted_route).
-            cy.wait(1200).then(() => {
-              cy.visit('/me/profile')
-            })
-          })
-        })
-      })
-    )
-  )
-}
-
 // Constants
 const userProfileFeatureFlags = {
   quartzIdentity: true,
@@ -76,6 +51,31 @@ export const multipleOrgs = [
     isActive: false,
   },
 ]
+
+// Utility Functions
+export const setupProfile = (): Promise<any> => {
+  return Cypress.Promise.resolve(
+    cy.flush().then(() =>
+      cy.signin().then(() => {
+        cy.get('@org').then(() => {
+          cy.request({
+            method: 'PUT',
+            url: 'api/v2/quartz/accounts/resetAllAccountOrgs',
+          })
+          cy.visit('/')
+          cy.getByTestID('home-page--header').should('be.visible')
+          cy.setFeatureFlags(userProfileFeatureFlags).then(() => {
+            // cy.wait($time) is necessary to consistently ensure sufficient time for the feature flag override.
+            // The flag reset happens via redux, (it's not a network request), so we can't cy.wait($intercepted_route).
+            cy.wait(1200).then(() => {
+              cy.visit('/me/profile')
+            })
+          })
+        })
+      })
+    )
+  )
+}
 
 // Tests
 describe('User profile page', () => {

--- a/cypress/e2e/cloud/users.test.ts
+++ b/cypress/e2e/cloud/users.test.ts
@@ -4,12 +4,14 @@ describe('Users Page', () => {
   beforeEach(() => {
     cy.flush().then(() =>
       cy.signin().then(() => {
-        cy.get('@org').then(({id}: Organization) => {
-          cy.quartzProvision({
-            hasUsers: true,
-          }).then(() => {
-            cy.visit(`/orgs/${id}/members`)
-            cy.getByTestID('users-page--header').should('be.visible')
+        cy.setFeatureFlags({quartzIdentity: true, multiOrg: true}).then(() => {
+          cy.get('@org').then(({id}: Organization) => {
+            cy.quartzProvision({
+              hasUsers: true,
+            }).then(() => {
+              cy.visit(`/orgs/${id}/members`)
+              cy.getByTestID('users-page--header').should('be.visible')
+            })
           })
         })
       })

--- a/cypress/e2e/cloud/zuoraOutage.test.ts
+++ b/cypress/e2e/cloud/zuoraOutage.test.ts
@@ -32,13 +32,13 @@ describe('Billing Page PAYG Users', () => {
     cy.flush().then(() =>
       cy.signin().then(() => {
         cy.get('@org').then(({id}: Organization) => {
-          cy.setFeatureFlags({
-            quartzZuoraDisabled: true,
-            quartzIdentity: true,
-            multiOrg: true,
+          cy.quartzProvision({
+            accountType: 'pay_as_you_go',
           }).then(() => {
-            cy.quartzProvision({
-              accountType: 'pay_as_you_go',
+            cy.setFeatureFlags({
+              quartzZuoraDisabled: true,
+              quartzIdentity: true,
+              multiOrg: true,
             }).then(() => {
               cy.wait(1000)
               cy.visit(`/orgs/${id}/billing`)

--- a/cypress/e2e/cloud/zuoraOutage.test.ts
+++ b/cypress/e2e/cloud/zuoraOutage.test.ts
@@ -7,6 +7,8 @@ describe('Billing Page Free Users', () => {
         cy.get('@org').then(() => {
           cy.setFeatureFlags({
             quartzZuoraDisabled: true,
+            quartzIdentity: true,
+            multiOrg: true,
           }).then(() => {
             cy.quartzProvision({
               accountType: 'free',
@@ -32,6 +34,8 @@ describe('Billing Page PAYG Users', () => {
         cy.get('@org').then(({id}: Organization) => {
           cy.setFeatureFlags({
             quartzZuoraDisabled: true,
+            quartzIdentity: true,
+            multiOrg: true,
           }).then(() => {
             cy.quartzProvision({
               accountType: 'pay_as_you_go',

--- a/cypress/index.d.ts
+++ b/cypress/index.d.ts
@@ -46,6 +46,7 @@ import {
   clickAttached,
   upsertSecret,
   setFeatureFlags,
+  setFeatureFlagsNoNav,
   quartzProvision,
   createTaskFromEmpty,
   createAlertGroup,
@@ -102,6 +103,7 @@ declare global {
       createCheck: typeof createCheck
       createAlertGroup: typeof createAlertGroup
       setFeatureFlags: typeof setFeatureFlags
+      setFeatureFlagsNoNav: typeof setFeatureFlags
       upsertSecret: typeof upsertSecret
       quartzProvision: typeof quartzProvision
       createTaskFromEmpty: typeof createTaskFromEmpty

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1048,6 +1048,14 @@ export const setFeatureFlags = (flags: FlagMap): Cypress.Chainable => {
   })
 }
 
+export const setFeatureFlagsNoNav = (flags: FlagMap): Cypress.Chainable => {
+  // use in lieu of setFeatureFlags when no left nav bar is expected.
+  return cy.window().then(win => {
+    // eslint-disable-next-line no-extra-semi
+    ;(win as any).store.dispatch(setOverrides(flags))
+  })
+}
+
 export const createTaskFromEmpty = (
   name: string,
   flux: (bucket: Bucket) => string,
@@ -1164,5 +1172,6 @@ Cypress.Commands.add(
 )
 Cypress.Commands.add('getByTestIDAndSetInputValue', getByTestIDAndSetInputValue)
 Cypress.Commands.add('setFeatureFlags', setFeatureFlags)
+Cypress.Commands.add('setFeatureFlagsNoNav', setFeatureFlagsNoNav)
 Cypress.Commands.add('createTaskFromEmpty', createTaskFromEmpty)
 /* eslint-enable */

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1042,17 +1042,17 @@ export const makeGraphSnapshot = (() => {
 export const setFeatureFlags = (flags: FlagMap): Cypress.Chainable => {
   // make sure the app is loaded before dispatching
   cy.getByTestID('tree-nav')
-  return cy.window().then(win => {
+  return cy.window().then((win: any) => {
     // eslint-disable-next-line no-extra-semi
-    ;(win as any).store.dispatch(setOverrides(flags))
+    win.store.dispatch(setOverrides(flags))
   })
 }
 
 export const setFeatureFlagsNoNav = (flags: FlagMap): Cypress.Chainable => {
   // use in lieu of setFeatureFlags when no left nav bar is expected.
-  return cy.window().then(win => {
+  return cy.window().then((win: any) => {
     // eslint-disable-next-line no-extra-semi
-    ;(win as any).store.dispatch(setOverrides(flags))
+    win.store.dispatch(setOverrides(flags))
   })
 }
 


### PR DESCRIPTION
Closes #5737

This PR toggles the `quartzIdentity` and `multiOrg` flags on for all cloud2 e2e tests, as these flags are going to be on in prod for all users. Where feasible, I've refactored to make sure any flag adjustments happen in a single `beforeEach` rather than in multiple individual tests (`it`). There are a few places this isn't possible - e.g., where cypress needs to toggle on one flag for a specific block to test a new feature.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - tests toggle on `quartzIdentity` and `multiOrg`
