### PR TITLE
feat(5340): use default editorText in script editor

### DIFF
--- a/cypress/e2e/shared/editor.test.ts
+++ b/cypress/e2e/shared/editor.test.ts
@@ -9,6 +9,7 @@ describe('Editor+LSP communication', () => {
       cy.getByTestID(editorSelector).then(() => {
         cy.getByTestID('flux-editor', {timeout: 30000})
           .should('be.visible')
+          .monacoType('{selectall} {backspace}')
           .monacoType('foo |> bar')
           .within(() => {
             cy.get('.squiggly-error', {timeout: 30000}).should('be.visible')

--- a/cypress/e2e/shared/fluxQueryBuilder.test.ts
+++ b/cypress/e2e/shared/fluxQueryBuilder.test.ts
@@ -195,7 +195,7 @@ describe('Script Builder', () => {
         'dataExplorer.schema',
         JSON.parse(JSON.stringify(DEFAULT_SCHEMA))
       )
-      window.sessionStorage.setItem('dataExplorer.query', '')
+      window.sessionStorage.setItem('dataExplorer.query', DEFAULT_EDITOR_TEXT)
 
       cy.setFeatureFlags({
         schemaComposition: true,

--- a/cypress/e2e/shared/fluxQueryBuilder.test.ts
+++ b/cypress/e2e/shared/fluxQueryBuilder.test.ts
@@ -187,12 +187,15 @@ describe('Script Builder', () => {
   })
 
   describe('Schema Composition', () => {
+    const DEFAULT_EDITOR_TEXT =
+      '// Start by selecting data from the schema browser or typing flux here'
+
     beforeEach(() => {
       window.sessionStorage.setItem(
         'dataExplorer.schema',
         JSON.parse(JSON.stringify(DEFAULT_SCHEMA))
       )
-      window.sessionStorage.setItem('dataExplorer.query', '')
+      window.sessionStorage.setItem('dataExplorer.query', DEFAULT_EDITOR_TEXT)
 
       cy.setFeatureFlags({
         schemaComposition: true,
@@ -300,7 +303,7 @@ describe('Script Builder', () => {
 
         cy.log('editor text is now empty')
         cy.getByTestID('flux-editor').within(() => {
-          cy.get('textarea.inputarea').should('have.value', '')
+          cy.get('textarea.inputarea').should('have.value', DEFAULT_EDITOR_TEXT)
         })
 
         cy.log('schema browser has been cleared')
@@ -312,7 +315,7 @@ describe('Script Builder', () => {
       it('should not be able to modify the composition when unsynced, yet still modify the saved schema -- which updates the composition when re-synced', () => {
         cy.log('start with empty editor text')
         cy.getByTestID('flux-editor', {timeout: 30000}).within(() => {
-          cy.get('textarea.inputarea').should('have.value', '')
+          cy.get('textarea.inputarea').should('have.value', DEFAULT_EDITOR_TEXT)
         })
 
         cy.log('turn off sync')
@@ -326,6 +329,7 @@ describe('Script Builder', () => {
 
         cy.log('editor text is still empty')
         cy.getByTestID('flux-editor').within(() => {
+          // selecting bucket will empty the editor text
           cy.get('textarea.inputarea').should('have.value', '')
         })
 

--- a/cypress/e2e/shared/fluxQueryBuilder.test.ts
+++ b/cypress/e2e/shared/fluxQueryBuilder.test.ts
@@ -195,7 +195,7 @@ describe('Script Builder', () => {
         'dataExplorer.schema',
         JSON.parse(JSON.stringify(DEFAULT_SCHEMA))
       )
-      window.sessionStorage.setItem('dataExplorer.query', DEFAULT_EDITOR_TEXT)
+      window.sessionStorage.setItem('dataExplorer.query', '')
 
       cy.setFeatureFlags({
         schemaComposition: true,

--- a/src/dataExplorer/components/FluxQueryBuilder.tsx
+++ b/src/dataExplorer/components/FluxQueryBuilder.tsx
@@ -23,6 +23,7 @@ import {SidebarProvider} from 'src/dataExplorer/context/sidebar'
 import {
   PersistanceProvider,
   PersistanceContext,
+  DEFAULT_EDITOR_TEXT,
 } from 'src/dataExplorer/context/persistance'
 import ResultsPane from 'src/dataExplorer/components/ResultsPane'
 import Sidebar from 'src/dataExplorer/components/Sidebar'
@@ -45,7 +46,7 @@ export enum OverlayType {
 
 const FluxQueryBuilder: FC = () => {
   const history = useHistory()
-  const {hasChanged, query, vertical, setVertical} =
+  const {hasChanged, query, setQuery, vertical, setVertical} =
     useContext(PersistanceContext)
   const [overlayType, setOverlayType] = useState<OverlayType | null>(null)
   const [isOverlayVisible, setIsOverlayVisible] = useState(false)
@@ -56,6 +57,7 @@ const FluxQueryBuilder: FC = () => {
   const handleClear = () => {
     cancel()
     setStatus(RemoteDataState.NotStarted)
+    setQuery(DEFAULT_EDITOR_TEXT)
     setResult(null)
 
     history.replace(`/orgs/${org.id}/data-explorer/from/script`)

--- a/src/dataExplorer/components/FluxQueryBuilder.tsx
+++ b/src/dataExplorer/components/FluxQueryBuilder.tsx
@@ -23,7 +23,6 @@ import {SidebarProvider} from 'src/dataExplorer/context/sidebar'
 import {
   PersistanceProvider,
   PersistanceContext,
-  DEFAULT_EDITOR_TEXT,
 } from 'src/dataExplorer/context/persistance'
 import ResultsPane from 'src/dataExplorer/components/ResultsPane'
 import Sidebar from 'src/dataExplorer/components/Sidebar'
@@ -46,7 +45,7 @@ export enum OverlayType {
 
 const FluxQueryBuilder: FC = () => {
   const history = useHistory()
-  const {hasChanged, query, setQuery, vertical, setVertical} =
+  const {hasChanged, query, vertical, setVertical} =
     useContext(PersistanceContext)
   const [overlayType, setOverlayType] = useState<OverlayType | null>(null)
   const [isOverlayVisible, setIsOverlayVisible] = useState(false)
@@ -57,7 +56,6 @@ const FluxQueryBuilder: FC = () => {
   const handleClear = () => {
     cancel()
     setStatus(RemoteDataState.NotStarted)
-    setQuery(DEFAULT_EDITOR_TEXT)
     setResult(null)
 
     history.replace(`/orgs/${org.id}/data-explorer/from/script`)

--- a/src/dataExplorer/components/SaveAsScript.tsx
+++ b/src/dataExplorer/components/SaveAsScript.tsx
@@ -12,7 +12,10 @@ import {
 import {useHistory} from 'react-router-dom'
 import {QueryContext} from 'src/shared/contexts/query'
 import {ResultsContext} from 'src/dataExplorer/components/ResultsContext'
-import {PersistanceContext} from 'src/dataExplorer/context/persistance'
+import {
+  DEFAULT_EDITOR_TEXT,
+  PersistanceContext,
+} from 'src/dataExplorer/context/persistance'
 import {RemoteDataState} from 'src/types'
 import './SaveAsScript.scss'
 import {CLOUD} from 'src/shared/constants'
@@ -34,8 +37,14 @@ interface Props {
 const SaveAsScript: FC<Props> = ({onClose, type}) => {
   const dispatch = useDispatch()
   const history = useHistory()
-  const {hasChanged, resource, setResource, save} =
-    useContext(PersistanceContext)
+  const {
+    hasChanged,
+    resource,
+    setResource,
+    setQuery,
+    clearSchemaSelection,
+    save,
+  } = useContext(PersistanceContext)
   const {cancel} = useContext(QueryContext)
   const {setStatus, setResult} = useContext(ResultsContext)
   const org = useSelector(getOrg)
@@ -79,6 +88,8 @@ const SaveAsScript: FC<Props> = ({onClose, type}) => {
   const clear = useCallback(() => {
     cancel()
     setStatus(RemoteDataState.NotStarted)
+    clearSchemaSelection()
+    setQuery(DEFAULT_EDITOR_TEXT)
     setResult(null)
 
     history.replace(`/orgs/${org.id}/data-explorer/from/script`)

--- a/src/dataExplorer/components/SaveAsScript.tsx
+++ b/src/dataExplorer/components/SaveAsScript.tsx
@@ -12,10 +12,7 @@ import {
 import {useHistory} from 'react-router-dom'
 import {QueryContext} from 'src/shared/contexts/query'
 import {ResultsContext} from 'src/dataExplorer/components/ResultsContext'
-import {
-  DEFAULT_EDITOR_TEXT,
-  PersistanceContext,
-} from 'src/dataExplorer/context/persistance'
+import {PersistanceContext} from 'src/dataExplorer/context/persistance'
 import {RemoteDataState} from 'src/types'
 import './SaveAsScript.scss'
 import {CLOUD} from 'src/shared/constants'
@@ -37,14 +34,8 @@ interface Props {
 const SaveAsScript: FC<Props> = ({onClose, type}) => {
   const dispatch = useDispatch()
   const history = useHistory()
-  const {
-    hasChanged,
-    resource,
-    setResource,
-    setQuery,
-    clearSchemaSelection,
-    save,
-  } = useContext(PersistanceContext)
+  const {hasChanged, resource, setResource, clearSchemaSelection, save} =
+    useContext(PersistanceContext)
   const {cancel} = useContext(QueryContext)
   const {setStatus, setResult} = useContext(ResultsContext)
   const org = useSelector(getOrg)
@@ -89,7 +80,6 @@ const SaveAsScript: FC<Props> = ({onClose, type}) => {
     cancel()
     setStatus(RemoteDataState.NotStarted)
     clearSchemaSelection()
-    setQuery(DEFAULT_EDITOR_TEXT)
     setResult(null)
 
     history.replace(`/orgs/${org.id}/data-explorer/from/script`)

--- a/src/dataExplorer/components/resources/TemplatePage.tsx
+++ b/src/dataExplorer/components/resources/TemplatePage.tsx
@@ -9,7 +9,6 @@ import {RESOURCES} from 'src/dataExplorer/components/resources'
 import {
   PersistanceContext,
   PersistanceProvider,
-  DEFAULT_EDITOR_TEXT,
 } from 'src/dataExplorer/context/persistance'
 
 const Template: FC = () => {
@@ -36,7 +35,6 @@ const Template: FC = () => {
 
     setLoading(RemoteDataState.Loading)
     clearSchemaSelection()
-    setQuery(DEFAULT_EDITOR_TEXT)
     setResource(null)
 
     RESOURCES[params[0]].init.apply(this, params.slice(1)).then(data => {

--- a/src/dataExplorer/components/resources/TemplatePage.tsx
+++ b/src/dataExplorer/components/resources/TemplatePage.tsx
@@ -9,6 +9,7 @@ import {RESOURCES} from 'src/dataExplorer/components/resources'
 import {
   PersistanceContext,
   PersistanceProvider,
+  DEFAULT_EDITOR_TEXT,
 } from 'src/dataExplorer/context/persistance'
 
 const Template: FC = () => {
@@ -35,7 +36,7 @@ const Template: FC = () => {
 
     setLoading(RemoteDataState.Loading)
     clearSchemaSelection()
-    setQuery('')
+    setQuery(DEFAULT_EDITOR_TEXT)
     setResource(null)
 
     RESOURCES[params[0]].init.apply(this, params.slice(1)).then(data => {

--- a/src/dataExplorer/components/resources/TemplatePage.tsx
+++ b/src/dataExplorer/components/resources/TemplatePage.tsx
@@ -9,6 +9,7 @@ import {RESOURCES} from 'src/dataExplorer/components/resources'
 import {
   PersistanceContext,
   PersistanceProvider,
+  DEFAULT_EDITOR_TEXT,
 } from 'src/dataExplorer/context/persistance'
 
 const Template: FC = () => {
@@ -35,6 +36,7 @@ const Template: FC = () => {
 
     setLoading(RemoteDataState.Loading)
     clearSchemaSelection()
+    setQuery(DEFAULT_EDITOR_TEXT)
     setResource(null)
 
     RESOURCES[params[0]].init.apply(this, params.slice(1)).then(data => {

--- a/src/dataExplorer/components/resources/types/script/index.ts
+++ b/src/dataExplorer/components/resources/types/script/index.ts
@@ -1,9 +1,7 @@
 import {ResourceType} from 'src/types/resources'
 import editor from './editor'
 import {CLOUD} from 'src/shared/constants'
-
-export const DEFAULT_EDITOR_TEXT =
-  '// Start by selecting data from the schema browser or typing flux here'
+import {DEFAULT_EDITOR_TEXT} from 'src/dataExplorer/context/persistance'
 
 const {getScript, patchScript, postScript} = CLOUD
   ? require('src/client/scriptsRoutes')

--- a/src/dataExplorer/components/resources/types/script/index.ts
+++ b/src/dataExplorer/components/resources/types/script/index.ts
@@ -1,6 +1,7 @@
 import {ResourceType} from 'src/types/resources'
 import editor from './editor'
 import {CLOUD} from 'src/shared/constants'
+import {DEFAULT_EDITOR_TEXT} from 'src/dataExplorer/context/persistance'
 
 const {getScript, patchScript, postScript} = CLOUD
   ? require('src/client/scriptsRoutes')
@@ -18,7 +19,7 @@ export default function script(register) {
       if (!id || !CLOUD) {
         return Promise.resolve({
           type: ResourceType.Scripts,
-          flux: '',
+          flux: DEFAULT_EDITOR_TEXT,
           data: {},
         })
       }
@@ -36,7 +37,7 @@ export default function script(register) {
 
         return {
           type: ResourceType.Scripts,
-          flux: '',
+          flux: DEFAULT_EDITOR_TEXT,
           data: {},
         }
       })

--- a/src/dataExplorer/components/resources/types/script/index.ts
+++ b/src/dataExplorer/components/resources/types/script/index.ts
@@ -1,7 +1,9 @@
 import {ResourceType} from 'src/types/resources'
 import editor from './editor'
 import {CLOUD} from 'src/shared/constants'
-import {DEFAULT_EDITOR_TEXT} from 'src/dataExplorer/context/persistance'
+
+export const DEFAULT_EDITOR_TEXT =
+  '// Start by selecting data from the schema browser or typing flux here'
 
 const {getScript, patchScript, postScript} = CLOUD
   ? require('src/client/scriptsRoutes')

--- a/src/dataExplorer/context/fluxQueryBuilder.tsx
+++ b/src/dataExplorer/context/fluxQueryBuilder.tsx
@@ -11,8 +11,10 @@ import React, {
 // Context
 import {MeasurementsContext} from 'src/dataExplorer/context/measurements'
 import {FieldsContext} from 'src/dataExplorer/context/fields'
-import {PersistanceContext} from 'src/dataExplorer/context/persistance'
-import {DEFAULT_EDITOR_TEXT} from 'src/dataExplorer/components/resources/types/script'
+import {
+  PersistanceContext,
+  DEFAULT_EDITOR_TEXT,
+} from 'src/dataExplorer/context/persistance'
 import {TagsContext} from 'src/dataExplorer/context/tags'
 import {EditorContext} from 'src/shared/contexts/editor'
 

--- a/src/dataExplorer/context/fluxQueryBuilder.tsx
+++ b/src/dataExplorer/context/fluxQueryBuilder.tsx
@@ -11,7 +11,10 @@ import React, {
 // Context
 import {MeasurementsContext} from 'src/dataExplorer/context/measurements'
 import {FieldsContext} from 'src/dataExplorer/context/fields'
-import {PersistanceContext} from 'src/dataExplorer/context/persistance'
+import {
+  DEFAULT_EDITOR_TEXT,
+  PersistanceContext,
+} from 'src/dataExplorer/context/persistance'
 import {TagsContext} from 'src/dataExplorer/context/tags'
 import {EditorContext} from 'src/shared/contexts/editor'
 
@@ -85,7 +88,8 @@ export const FluxQueryBuilderProvider: FC = ({children}) => {
   const {getFields, resetFields} = useContext(FieldsContext)
   const {getTagKeys, resetTags} = useContext(TagsContext)
   const {injectViaLsp} = useContext(EditorContext)
-  const {selection, setSelection} = useContext(PersistanceContext)
+  const {query, setQuery, selection, setSelection} =
+    useContext(PersistanceContext)
 
   // States
   // This state is a restructed PersistanceContext selection.tagValues
@@ -121,6 +125,11 @@ export const FluxQueryBuilderProvider: FC = ({children}) => {
   }
 
   const handleSelectBucket = (bucket: Bucket): void => {
+    // first time selecting bucket --> remove if default message
+    if (query == DEFAULT_EDITOR_TEXT) {
+      setQuery('')
+    }
+
     setSelection({bucket, measurement: '', fields: [], tagValues: []})
 
     // Reset measurement, tags, fields, selected tag values

--- a/src/dataExplorer/context/fluxQueryBuilder.tsx
+++ b/src/dataExplorer/context/fluxQueryBuilder.tsx
@@ -11,10 +11,8 @@ import React, {
 // Context
 import {MeasurementsContext} from 'src/dataExplorer/context/measurements'
 import {FieldsContext} from 'src/dataExplorer/context/fields'
-import {
-  DEFAULT_EDITOR_TEXT,
-  PersistanceContext,
-} from 'src/dataExplorer/context/persistance'
+import {PersistanceContext} from 'src/dataExplorer/context/persistance'
+import {DEFAULT_EDITOR_TEXT} from 'src/dataExplorer/components/resources/types/script'
 import {TagsContext} from 'src/dataExplorer/context/tags'
 import {EditorContext} from 'src/shared/contexts/editor'
 

--- a/src/dataExplorer/context/persistance.tsx
+++ b/src/dataExplorer/context/persistance.tsx
@@ -53,12 +53,15 @@ export const DEFAULT_SCHEMA: SchemaSelection = {
   },
 }
 
+export const DEFAULT_EDITOR_TEXT =
+  '// Start by selecting data from the schema browser or typing flux here'
+
 const DEFAULT_CONTEXT = {
   hasChanged: false,
   horizontal: [0.5],
   vertical: [0.25, 0.8],
   range: DEFAULT_TIME_RANGE,
-  query: '',
+  query: DEFAULT_EDITOR_TEXT,
   resource: null,
   selection: JSON.parse(JSON.stringify(DEFAULT_SCHEMA)),
 

--- a/src/dataExplorer/context/persistance.tsx
+++ b/src/dataExplorer/context/persistance.tsx
@@ -53,12 +53,15 @@ export const DEFAULT_SCHEMA: SchemaSelection = {
   },
 }
 
+export const DEFAULT_EDITOR_TEXT =
+  '// Start by selecting data from the schema browser or typing flux here'
+
 const DEFAULT_CONTEXT = {
   hasChanged: false,
   horizontal: [0.5],
   vertical: [0.25, 0.8],
   range: DEFAULT_TIME_RANGE,
-  query: '',
+  query: DEFAULT_EDITOR_TEXT,
   resource: null,
   selection: JSON.parse(JSON.stringify(DEFAULT_SCHEMA)),
 
@@ -98,7 +101,7 @@ export const PersistanceProvider: FC = ({children}) => {
   )
   const [resource, setResource] = useSessionStorage('dataExplorer.resource', {
     type: 'scripts',
-    flux: '',
+    flux: DEFAULT_EDITOR_TEXT,
     data: {},
   })
   const [selection, setSelection] = useSessionStorage(

--- a/src/dataExplorer/context/persistance.tsx
+++ b/src/dataExplorer/context/persistance.tsx
@@ -53,15 +53,12 @@ export const DEFAULT_SCHEMA: SchemaSelection = {
   },
 }
 
-export const DEFAULT_EDITOR_TEXT =
-  '// Start by selecting data from the schema browser or typing flux here'
-
 const DEFAULT_CONTEXT = {
   hasChanged: false,
   horizontal: [0.5],
   vertical: [0.25, 0.8],
   range: DEFAULT_TIME_RANGE,
-  query: DEFAULT_EDITOR_TEXT,
+  query: '',
   resource: null,
   selection: JSON.parse(JSON.stringify(DEFAULT_SCHEMA)),
 
@@ -101,7 +98,7 @@ export const PersistanceProvider: FC = ({children}) => {
   )
   const [resource, setResource] = useSessionStorage('dataExplorer.resource', {
     type: 'scripts',
-    flux: DEFAULT_EDITOR_TEXT,
+    flux: '',
     data: {},
   })
   const [selection, setSelection] = useSessionStorage(

--- a/src/shared/components/FluxMonacoEditor.tsx
+++ b/src/shared/components/FluxMonacoEditor.tsx
@@ -167,7 +167,7 @@ const FluxEditorMonaco: FC<Props> = ({
         </div>
       </ErrorBoundary>
     ),
-    [onChangeScript, setEditor, useSchemaComposition]
+    [onChangeScript, setEditor, useSchemaComposition, script]
   )
 }
 


### PR DESCRIPTION
Closes #5340 

## DONE:
* in new QX script editor:
  * Use default text for:
    * default session query string
    * clear() methods to reset the session
    * default query string in script resource
  * Could have tried doing the minimum (change only the default script resource). But decided to make all reference the proper default, to avoid any current/future races.
  * Is not feature flagged since the description is accurate with, or without, the new features in the QX script editor.
* Default message does NOT appear in:
  * notebooks
  * old data explorer. 

## Video:

https://user-images.githubusercontent.com/10232835/189738763-27194a58-4a62-4537-8306-1ec5955bbeed.mov

