### PR TITLE
chore(5591): tests to ensure composition does not accidentally appear where it shouldn't

### DIFF
--- a/cypress/e2e/shared/editor.test.ts
+++ b/cypress/e2e/shared/editor.test.ts
@@ -50,6 +50,13 @@ describe('Editor+LSP communication', () => {
           cy.visit(`${orgs}/${id}`)
         })
       )
+      // Double check that the new schemaComposition flag does not interfere.
+      cy.setFeatureFlags({
+        schemaComposition: true,
+      })
+      // cy.wait($time) is necessary to consistently ensure sufficient time for the feature flag override.
+      // The flag reset happens via redux, (it's not a network request), so we can't cy.wait($intercepted_route).
+      cy.wait(1200)
       cy.getByTestID('version-info')
       cy.getByTestID('nav-item-flows').should('be.visible')
       cy.getByTestID('nav-item-flows').click()
@@ -77,6 +84,13 @@ describe('Editor+LSP communication', () => {
           cy.getByTestID('tree-nav').should('be.visible')
         })
       })
+      // Double check that the new schemaComposition flag does not interfere.
+      cy.setFeatureFlags({
+        schemaComposition: true,
+      })
+      // cy.wait($time) is necessary to consistently ensure sufficient time for the feature flag override.
+      // The flag reset happens via redux, (it's not a network request), so we can't cy.wait($intercepted_route).
+      cy.wait(1200)
       cy.getByTestID('switch-to-script-editor').should('be.visible').click()
     })
 

--- a/cypress/e2e/shared/editor.test.ts
+++ b/cypress/e2e/shared/editor.test.ts
@@ -30,6 +30,15 @@ describe('Editor+LSP communication', () => {
           .monacoType(`{selectall}{del}`)
       })
     })
+
+    it('does not have a composition block', () => {
+      cy.getByTestID(editorSelector).then(() => {
+        cy.getByTestID('flux-editor', {timeout: 30000}).within(() => {
+          cy.get('#schema-composition-sync-icon').should('have.length', 0)
+          cy.get('.composition-sync').should('have.length', 0)
+        })
+      })
+    })
   }
 
   describe('in Flows:', () => {
@@ -83,6 +92,7 @@ describe('Editor+LSP communication', () => {
         cy.getByTestID('tree-nav').should('be.visible')
         cy.setFeatureFlags({
           newDataExplorer: true,
+          schemaComposition: false,
         }).then(() => {
           // cy.wait($time) is necessary to consistently ensure sufficient time for the feature flag override.
           // The flag reset happens via redux, (it's not a network request), so we can't cy.wait($intercepted_route).

--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -12,6 +12,13 @@ describe('DataExplorer', () => {
         cy.getByTestID('tree-nav').should('be.visible')
       })
     })
+    // Double check that the new schemaComposition flag does not interfere.
+    cy.setFeatureFlags({
+      schemaComposition: true,
+    })
+    // cy.wait($time) is necessary to consistently ensure sufficient time for the feature flag override.
+    // The flag reset happens via redux, (it's not a network request), so we can't cy.wait($intercepted_route).
+    cy.wait(1200)
   })
 
   describe('data-explorer state', () => {

--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -5,13 +5,6 @@ describe('DataExplorer', () => {
   beforeEach(() => {
     cy.flush()
     cy.signin()
-    cy.get('@org').then(({id}: Organization) => {
-      cy.createMapVariable(id)
-      cy.fixture('routes').then(({orgs, explorer}) => {
-        cy.visit(`${orgs}/${id}${explorer}`)
-        cy.getByTestID('tree-nav').should('be.visible')
-      })
-    })
     // Double check that the new schemaComposition flag does not interfere.
     cy.setFeatureFlags({
       schemaComposition: true,
@@ -19,6 +12,13 @@ describe('DataExplorer', () => {
     // cy.wait($time) is necessary to consistently ensure sufficient time for the feature flag override.
     // The flag reset happens via redux, (it's not a network request), so we can't cy.wait($intercepted_route).
     cy.wait(1200)
+    cy.get('@org').then(({id}: Organization) => {
+      cy.createMapVariable(id)
+      cy.fixture('routes').then(({orgs, explorer}) => {
+        cy.visit(`${orgs}/${id}${explorer}`)
+        cy.getByTestID('tree-nav').should('be.visible')
+      })
+    })
   })
 
   describe('data-explorer state', () => {

--- a/cypress/e2e/shared/flows.test.ts
+++ b/cypress/e2e/shared/flows.test.ts
@@ -9,6 +9,13 @@ describe('Flows', () => {
         cy.visit(`${orgs}/${id}`)
       })
     )
+    // Double check that the new schemaComposition flag does not interfere.
+    cy.setFeatureFlags({
+      schemaComposition: true,
+    })
+    // cy.wait($time) is necessary to consistently ensure sufficient time for the feature flag override.
+    // The flag reset happens via redux, (it's not a network request), so we can't cy.wait($intercepted_route).
+    cy.wait(1200)
     cy.getByTestID('version-info')
     cy.getByTestID('nav-item-flows').should('be.visible')
     cy.getByTestID('nav-item-flows').click()

--- a/cypress/e2e/shared/fluxQueryBuilder.test.ts
+++ b/cypress/e2e/shared/fluxQueryBuilder.test.ts
@@ -246,6 +246,13 @@ describe('Script Builder', () => {
       cy.getByTestID('flux-editor').contains(
         `|> yield(name: "_editor_composition")`
       )
+      cy.getByTestID('flux-editor').within(() => {
+        cy.get('#schema-composition-sync-icon', {timeout: 3000}).should(
+          'have.length',
+          1
+        )
+        cy.get('.composition-sync').should('have.length', 2)
+      })
     }
 
     describe('default sync and resetting behavior:', () => {

--- a/cypress/e2e/shared/variables.test.ts
+++ b/cypress/e2e/shared/variables.test.ts
@@ -9,6 +9,13 @@ describe('Variables', () => {
       cy.visit(`orgs/${id}/settings/variables`)
       cy.getByTestID('tree-nav')
     })
+    // Double check that the new schemaComposition flag does not interfere.
+    cy.setFeatureFlags({
+      schemaComposition: true,
+    })
+    // cy.wait($time) is necessary to consistently ensure sufficient time for the feature flag override.
+    // The flag reset happens via redux, (it's not a network request), so we can't cy.wait($intercepted_route).
+    cy.wait(1200)
     cy.location('pathname').should('match', /\/variables$/)
   })
 

--- a/src/shared/components/FluxMonacoEditor.tsx
+++ b/src/shared/components/FluxMonacoEditor.tsx
@@ -69,8 +69,10 @@ const FluxEditorMonaco: FC<Props> = ({
   const isFluxQueryBuilder = useSelector(fluxQueryBuilder)
   const sessionStore = useContext(PersistanceContext)
   const {path} = useRouteMatch()
-  const isNewQxBuilder =
-    isFluxQueryBuilder && path === '/orgs/:orgID/data-explorer'
+  const useSchemaComposition =
+    isFluxQueryBuilder &&
+    path === '/orgs/:orgID/data-explorer' &&
+    isFlagEnabled('schemaComposition')
 
   const wrapperClassName = classnames('flux-editor--monaco', {
     'flux-editor--monaco__autogrow': autogrow,
@@ -81,17 +83,14 @@ const FluxEditorMonaco: FC<Props> = ({
   }, [variables])
 
   useEffect(() => {
-    if (
-      connection.current &&
-      isNewQxBuilder &&
-      isFlagEnabled('schemaComposition')
-    ) {
+    if (connection.current && useSchemaComposition) {
       connection.current.onSchemaSessionChange(
         sessionStore.selection,
         sessionStore.setSelection
       )
     }
   }, [
+    useSchemaComposition,
     connection.current,
     sessionStore?.selection,
     sessionStore?.selection.composition || null,
@@ -160,7 +159,7 @@ const FluxEditorMonaco: FC<Props> = ({
             }}
             editorDidMount={editorDidMount}
           />
-          {isNewQxBuilder && (
+          {useSchemaComposition && (
             <div id={ICON_SYNC_ID} className="sync-bar">
               <Icon glyph={IconFont.Sync} className="sync-icon" />
             </div>
@@ -168,7 +167,7 @@ const FluxEditorMonaco: FC<Props> = ({
         </div>
       </ErrorBoundary>
     ),
-    [onChangeScript, setEditor]
+    [onChangeScript, setEditor, useSchemaComposition]
   )
 }
 


### PR DESCRIPTION
Part of e2e tests #5591 

## Done:
* composition block styling, should not exist in:
   * notebooks
   * old data explorer
   * new QX builder, when feature flag is off
* should only exist:
  * new QX builder, when feature flag is on

## Already Done (not added here):
* normal injection routes, outside of composition, are already tested. Did not need to add those tests.
* injection via schema composition 