### PR TITLE
chore: increase Monaco editor default size

### DIFF
--- a/src/dataExplorer/context/persistance.tsx
+++ b/src/dataExplorer/context/persistance.tsx
@@ -55,7 +55,7 @@ export const DEFAULT_SCHEMA: SchemaSelection = {
 
 const DEFAULT_CONTEXT = {
   hasChanged: false,
-  horizontal: [0.2],
+  horizontal: [0.5],
   vertical: [0.25, 0.8],
   range: DEFAULT_TIME_RANGE,
   query: '',


### PR DESCRIPTION
Closes #5756

This PR increases the default height size of the Monaco editor so that there is a 50/50 split between the Monaco editor and results panel

## Before
<img width="1506" alt="Screen Shot 2022-09-14 at 2 48 39 PM" src="https://user-images.githubusercontent.com/14298407/190249281-a4658ed2-8601-4765-9c0b-1815a0a099a4.png">

## After
<img width="1508" alt="Screen Shot 2022-09-14 at 2 34 42 PM" src="https://user-images.githubusercontent.com/14298407/190249298-6997a2c4-5e9f-4bc3-bdc6-5c8c08de9bcf.png">

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
~~- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~~
~~- [ ] Feature flagged, if applicable~~
