### PR TITLE
feat: use quartz, not idpe, for user sessions

### DIFF
--- a/src/Signin.tsx
+++ b/src/Signin.tsx
@@ -32,7 +32,7 @@ import {
 import {RemoteDataState} from 'src/types'
 
 // APIs
-import {fetchLegacyIdentity} from './identity/apis/auth'
+import {fetchIdentity, fetchLegacyIdentity} from './identity/apis/auth'
 
 interface State {
   loading: RemoteDataState
@@ -96,7 +96,12 @@ export class Signin extends PureComponent<Props, State> {
 
   private checkForLogin = async () => {
     try {
-      await fetchLegacyIdentity()
+      if (isFlagEnabled('quartzSession')) {
+        await fetchIdentity()
+      } else {
+        await fetchLegacyIdentity()
+      }
+
       this.setState({auth: true})
       const redirectIsSet = !!getFromLocalStorage('redirectTo')
       if (redirectIsSet) {

--- a/src/identity/apis/auth.ts
+++ b/src/identity/apis/auth.ts
@@ -118,7 +118,7 @@ export const fetchIdentity = async () => {
   if (!CLOUD) {
     return fetchLegacyIdentity()
   }
-  // if we make it to this line we are in cloud and ui unification flag is on
+
   if (isFlagEnabled('quartzIdentity')) {
     return fetchQuartzIdentity()
   }

--- a/src/onboarding/containers/LoginPage.tsx
+++ b/src/onboarding/containers/LoginPage.tsx
@@ -18,7 +18,7 @@ import {fetchIdentity, fetchLegacyIdentity} from 'src/identity/apis/auth'
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
 import LoginPageContents from 'src/onboarding/containers/LoginPageContents'
 import {CLOUD, CLOUD_QUARTZ_URL} from 'src/shared/constants'
-import {isFlagEnabled} from '../../shared/utils/featureFlag'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 const EMPTY_HISTORY_STACK_LENGTH = 2
 

--- a/src/onboarding/containers/LoginPage.tsx
+++ b/src/onboarding/containers/LoginPage.tsx
@@ -12,7 +12,7 @@ import Notifications from 'src/shared/components/notifications/Notifications'
 import {CloudLogoWithCubo} from 'src/onboarding/components/CloudLogoWithCubo'
 
 // APIs
-import {fetchLegacyIdentity} from 'src/identity/apis/auth'
+import {fetchIdentity, fetchLegacyIdentity} from 'src/identity/apis/auth'
 
 // Components
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
@@ -27,7 +27,12 @@ export const LoginPage: FC = () => {
 
   const getSessionValidity = useCallback(async () => {
     try {
-      await fetchLegacyIdentity()
+      if (isFlagEnabled('quartzSession')) {
+        await fetchIdentity()
+      } else {
+        await fetchLegacyIdentity()
+      }
+
       setHasValidSession(true)
     } catch {
       setHasValidSession(false)


### PR DESCRIPTION
Closes #5022 

This PR changes login behavior so that, in Cloud, Quartz (not IDPE) is polled to check for the validity of the user's session. 

New code block is behind the flag `quartzSession` and will be tested in other environments before being enabled in prod.


Old Behavior
--
At login, and every 60 seconds . . . 

Make a `GET` request to `/api/v2/me` (IDPE /me).

New Behavior
--
At login, and every 60 seconds . . . 

OSS
1. No change.

CLOUD
1. `quartzIdentity` enabled? Make `GET` request to `/api/v2/quartz/identity`
2. Otherwise, make `GET` request to `/api/v2/quartz/me`

Notes
- The second option in cloud will be removed soon, as `/quartz/identity` is on in all environments and `/quartz/me` is deprecated, and is slated to be removed from the codebase shortly.
- Once the flag is removed we'll only need to make one call - `fetchIdentity` - as that function contains the logic for distinguishing between CLOUD and non-CLOUD environments.


### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - `quartzSession`
