### PR TITLE
Patch 1

### DIFF
--- a/src/writeData/clients/Python/write.1.example
+++ b/src/writeData/clients/Python/write.1.example
@@ -1,3 +1,5 @@
+    write_api = client.write_api(write_options=SYNCHRONOUS)
+    
     point = Point("mem") \
         .tag("host", "host1") \
         .field("used_percent", 23.43234543) \

--- a/src/writeData/clients/Python/write.2.example
+++ b/src/writeData/clients/Python/write.2.example
@@ -1,3 +1,5 @@
+    write_api = client.write_api(write_options=SYNCHRONOUS)
+    
     sequence = ["mem,host=host1 used_percent=23.43234543",
             "mem,host=host1 available_percent=15.856523"]
     write_api.write(bucket, org, sequence)


### PR DESCRIPTION
Closes #

<!-- Describe your proposed changes here. -->
When copying from the Python samples (influxdb-endpoint/orgs/org/load-data/client-libraries/python), Option 2 (data point) and Option 3 (batch sequence) do not include the definition of `write_api` as of now, so Python will complain.

<!-- Including screenshots or visuals is very helpful - a picture is worth a thousand words. -->

### Checklist

Authors and Reviewer(s), please verify the following:

- [ ] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [ ] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
