### PR TITLE
style: remove the corner radius of the Monaco editor and Results panel

### DIFF
--- a/src/dataExplorer/components/FluxQueryBuilder.scss
+++ b/src/dataExplorer/components/FluxQueryBuilder.scss
@@ -26,9 +26,8 @@
 
 .flux-query-builder--menu {
   padding: $cf-space-2xs 0;
-  margin-bottom: $cf-space-s;
-  border-top: 1px solid $cf-grey-15;
-  border-bottom: 1px solid $cf-grey-15;
+  border-top: 2px solid $cf-grey-15;
+  border-bottom: 2px solid $cf-grey-15;
 }
 
 .flux-query-builder__action-button {

--- a/src/dataExplorer/components/FluxQueryBuilder.scss
+++ b/src/dataExplorer/components/FluxQueryBuilder.scss
@@ -25,7 +25,7 @@
 }
 
 .flux-query-builder--menu {
-  padding: $cf-space-2xs 0;
+  padding: $cf-space-xs 0;
   border-top: 2px solid $cf-grey-15;
   border-bottom: 2px solid $cf-grey-15;
 }

--- a/src/dataExplorer/components/Results.scss
+++ b/src/dataExplorer/components/Results.scss
@@ -1,12 +1,9 @@
 @import '@influxdata/clockface/dist/variables.scss';
 
-$cf-radius-lg: $cf-radius + 4px;
-
 .data-explorer-results {
   height: 100%;
   width: 100%;
   position: absolute;
-  border-radius: $cf-radius-lg;
   border: 2px solid transparent;
   background-color: $cf-grey-15;
   padding: $cf-space-2xs;
@@ -66,17 +63,11 @@ $cf-radius-lg: $cf-radius + 4px;
   position: absolute;
   width: 100%;
   height: 100%;
-
-  .monaco-editor,
-  .monaco-editor > div:first-of-type {
-    border-radius: $cf-radius-lg;
-  }
 }
 
 .data-explorer--error-gutter {
   color: $c-fire;
   background-color: $cf-grey-15;
-  border-radius: $cf-radius-lg;
   width: 100%;
   display: flex;
 

--- a/src/dataExplorer/components/Schema.scss
+++ b/src/dataExplorer/components/Schema.scss
@@ -10,6 +10,7 @@
 
 .schema-browser {
   padding-right: $cf-space-xs;
+  padding-top: $cf-space-2xs;
 
   .cf-dropdown-divider {
     color: $cf-grey-55;

--- a/src/dataExplorer/components/Sidebar.scss
+++ b/src/dataExplorer/components/Sidebar.scss
@@ -1,7 +1,8 @@
 @import '@influxdata/clockface/dist/variables.scss';
 
 .container-right-side-bar {
-  margin-left: $cf-space-s;
+  margin-left: $cf-space-xs;
+  padding-top: $cf-space-2xs;
   width: inherit;
   overflow-x: hidden;
   height: 100%;
@@ -10,6 +11,10 @@
 
   .flux-toolbar {
     flex-direction: column;
+  }
+
+  .flux-toolbar--search {
+    padding: 0;
   }
 }
 


### PR DESCRIPTION
Closes #5765 

This PR updates styles on 1) the corner radius of the Monaco editor and Results panel, 2) the padding below the menu heading

## Before
<img width="1500" alt="Screen Shot 2022-09-15 at 9 17 12 AM" src="https://user-images.githubusercontent.com/14298407/190428685-b8536953-6674-419e-818d-4866caa2a37b.png">

## After
<img width="1503" alt="Screen Shot 2022-09-15 at 9 15 36 AM" src="https://user-images.githubusercontent.com/14298407/190428706-90dfbc30-aa49-497e-b279-d9cb97036bec.png">

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
~~- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~~
~~- [ ] Feature flagged, if applicable~~
