### PR TITLE
chore: refactor useraccounts to use api layer

### DIFF
--- a/src/accounts/context/userAccount.tsx
+++ b/src/accounts/context/userAccount.tsx
@@ -12,7 +12,6 @@ import {
   accountDefaultSettingSuccess,
   accountRenameError,
   accountRenameSuccess,
-  defaultAccountNotFoundError,
 } from 'src/shared/copy/notifications'
 
 // Utils

--- a/src/accounts/context/userAccount.tsx
+++ b/src/accounts/context/userAccount.tsx
@@ -84,14 +84,14 @@ export const UserAccountProvider: FC<Props> = React.memo(({children}) => {
     try {
       const accounts = await getUserAccounts()
       setUserAccounts(accounts)
-      const defaultAcctArray = accounts.find(acct => acct.isDefault)
+      const defaultAcctArray = accounts.find(acct => acct.isDefault === true)
       if (defaultAcctArray) {
         const defaultId = defaultAcctArray[0].id
         setDefaultAccountId(defaultId)
       }
 
       // isActive: true is for the currently logged in/active account
-      const activeAcctArray = accounts.find(acct => acct.isActive)
+      const activeAcctArray = accounts.find(acct => acct.isActive === true)
       if (activeAcctArray) {
         const activeId = activeAcctArray[0].id
         setActiveAccountId(activeId)
@@ -127,7 +127,7 @@ export const UserAccountProvider: FC<Props> = React.memo(({children}) => {
 
   const handleRenameActiveAccount = useCallback(
     async (accountId, newName) => {
-      const activeAccount = userAccounts.find(acct => acct.isActive)
+      const activeAccount = userAccounts.find(acct => acct.isActive === true)
       try {
         const accountData = await updateUserAccount(accountId, newName)
         event('multiAccount.renameAccount')

--- a/src/accounts/context/userAccount.tsx
+++ b/src/accounts/context/userAccount.tsx
@@ -87,7 +87,6 @@ export const UserAccountProvider: FC<Props> = React.memo(({children}) => {
   const handleGetAccounts = useCallback(async () => {
     try {
       const accounts = await getUserAccounts()
-
       setUserAccounts(accounts)
       const defaultAcctArray = accounts.find(acct => acct.isDefault)
       if (defaultAcctArray) {
@@ -141,7 +140,14 @@ export const UserAccountProvider: FC<Props> = React.memo(({children}) => {
         dispatch(notify(accountRenameSuccess(activeAccount.name, newName)))
 
         activeAccount.name = newName
-        setUserAccounts(userAccounts)
+        const updatedAccounts = userAccounts.map(acct => {
+          if (acct.id === activeAccount.id) {
+            return {...acct, name: accountData.name}
+          }
+
+          return acct
+        })
+        setUserAccounts(updatedAccounts)
 
         if (isFlagEnabled('avatarWidgetMultiAccountInfo')) {
           const name = accountData.name

--- a/src/accounts/context/userAccount.tsx
+++ b/src/accounts/context/userAccount.tsx
@@ -89,15 +89,15 @@ export const UserAccountProvider: FC<Props> = React.memo(({children}) => {
       const accounts = await getUserAccounts()
 
       setUserAccounts(accounts)
-      const defaultAcctArray = accounts.filter(line => line.isDefault)
-      if (defaultAcctArray && defaultAcctArray.length === 1) {
+      const defaultAcctArray = accounts.find(line => line.isDefault)
+      if (defaultAcctArray) {
         const defaultId = defaultAcctArray[0].id
         setDefaultAccountId(defaultId)
       }
 
       // isActive: true is for the currently logged in/active account
-      const activeAcctArray = accounts.filter(line => line.isActive)
-      if (activeAcctArray && activeAcctArray.length === 1) {
+      const activeAcctArray = accounts.find(line => line.isActive)
+      if (activeAcctArray) {
         const activeId = activeAcctArray[0].id
         setActiveAccountId(activeId)
       }

--- a/src/accounts/context/userAccount.tsx
+++ b/src/accounts/context/userAccount.tsx
@@ -15,7 +15,6 @@ import {
 } from 'src/shared/copy/notifications'
 
 // Utils
-import {getAccounts, patchAccount} from 'src/client/unityRoutes'
 
 // Metrics
 import {event} from 'src/cloud/utils/reporting'

--- a/src/accounts/context/userAccount.tsx
+++ b/src/accounts/context/userAccount.tsx
@@ -140,16 +140,8 @@ export const UserAccountProvider: FC<Props> = React.memo(({children}) => {
         event('multiAccount.renameAccount')
         dispatch(notify(accountRenameSuccess(activeAccount.name, newName)))
 
-        // change the name, and reset the active accts:
-        const updatedAccounts = userAccounts.map(acct => {
-          const account = {...acct}
-          if (acct.id === activeAccount.id) {
-            account.name = accountData.name
-          }
-
-          return account
-        })
-        setUserAccounts(updatedAccounts)
+        activeAccount.name = newName
+        setUserAccounts(userAccounts)
 
         if (isFlagEnabled('avatarWidgetMultiAccountInfo')) {
           const name = accountData.name

--- a/src/accounts/context/userAccount.tsx
+++ b/src/accounts/context/userAccount.tsx
@@ -29,7 +29,7 @@ import {MeState} from 'src/me/reducers'
 import {
   getUserAccounts,
   updateDefaultQuartzAccount,
-  updateQuartzAccount,
+  updateUserAccount,
 } from 'src/identity/apis/auth'
 
 export type Props = {
@@ -136,7 +136,7 @@ export const UserAccountProvider: FC<Props> = React.memo(({children}) => {
       const oldName = userAccounts[activeIndex].name
 
       try {
-        const accountData = await updateQuartzAccount(accountId, newName)
+        const accountData = await updateUserAccount(accountId, newName)
         event('multiAccount.renameAccount')
         dispatch(notify(accountRenameSuccess(oldName, newName)))
 

--- a/src/accounts/context/userAccount.tsx
+++ b/src/accounts/context/userAccount.tsx
@@ -98,10 +98,7 @@ export const UserAccountProvider: FC<Props> = React.memo(({children}) => {
       }
     } catch (error) {
       reportErrorThroughHoneyBadger(error, {
-        name: 'UserAccount',
-        context: {
-          message: 'error fetching user accounts',
-        },
+        name: 'failed to retrieve user account data',
       })
     }
   }, [setActiveAccountId, setDefaultAccountId])
@@ -147,9 +144,10 @@ export const UserAccountProvider: FC<Props> = React.memo(({children}) => {
       } catch (error) {
         dispatch(notify(accountRenameError(activeAccount.name)))
         reportErrorThroughHoneyBadger(error, {
-          name: 'UserAccount',
+          name: 'error renaming user account',
           context: {
-            message: 'error renaming user account',
+            accountID: activeAccount.id,
+            accountName: activeAccount.name,
           },
         })
       }

--- a/src/accounts/context/userAccount.tsx
+++ b/src/accounts/context/userAccount.tsx
@@ -130,23 +130,24 @@ export const UserAccountProvider: FC<Props> = React.memo(({children}) => {
 
   const handleRenameActiveAccount = useCallback(
     async (accountId, newName) => {
-      const isActiveAcct = acct => acct.isActive
-      const activeIndex = userAccounts.findIndex(isActiveAcct)
-      const oldName = userAccounts[activeIndex].name
+      const activeAccount = userAccounts.find(acct => acct.isActive)
+      if (!activeAccount) {
+        return
+      }
 
       try {
         const accountData = await updateUserAccount(accountId, newName)
         event('multiAccount.renameAccount')
-        dispatch(notify(accountRenameSuccess(oldName, newName)))
+        dispatch(notify(accountRenameSuccess(activeAccount.name, newName)))
 
         // change the name, and reset the active accts:
-        const updatedAccounts = userAccounts.map((account, idx) => {
-          const acct = {...account}
-          if (idx === activeIndex) {
-            acct.name = accountData.name
+        const updatedAccounts = userAccounts.map(acct => {
+          const account = {...acct}
+          if (acct.id === activeAccount.id) {
+            account.name = accountData.name
           }
 
-          return acct
+          return account
         })
         setUserAccounts(updatedAccounts)
 
@@ -156,7 +157,7 @@ export const UserAccountProvider: FC<Props> = React.memo(({children}) => {
           dispatch(setMe({name, id} as MeState))
         }
       } catch (error) {
-        dispatch(notify(accountRenameError(oldName)))
+        dispatch(notify(accountRenameError(activeAccount.name)))
       }
     },
     [dispatch, userAccounts, setUserAccounts]

--- a/src/accounts/context/userAccount.tsx
+++ b/src/accounts/context/userAccount.tsx
@@ -12,6 +12,7 @@ import {
   accountDefaultSettingSuccess,
   accountRenameError,
   accountRenameSuccess,
+  defaultAccountNotFoundError,
 } from 'src/shared/copy/notifications'
 
 // Utils
@@ -130,10 +131,6 @@ export const UserAccountProvider: FC<Props> = React.memo(({children}) => {
   const handleRenameActiveAccount = useCallback(
     async (accountId, newName) => {
       const activeAccount = userAccounts.find(acct => acct.isActive)
-      if (!activeAccount) {
-        return
-      }
-
       try {
         const accountData = await updateUserAccount(accountId, newName)
         event('multiAccount.renameAccount')

--- a/src/accounts/context/userAccount.tsx
+++ b/src/accounts/context/userAccount.tsx
@@ -139,7 +139,6 @@ export const UserAccountProvider: FC<Props> = React.memo(({children}) => {
         event('multiAccount.renameAccount')
         dispatch(notify(accountRenameSuccess(activeAccount.name, newName)))
 
-        activeAccount.name = newName
         const updatedAccounts = userAccounts.map(acct => {
           if (acct.id === activeAccount.id) {
             return {...acct, name: accountData.name}

--- a/src/accounts/context/userAccount.tsx
+++ b/src/accounts/context/userAccount.tsx
@@ -24,6 +24,9 @@ import {
   updateUserAccount,
 } from 'src/identity/apis/auth'
 
+// Utils
+import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
+
 export type Props = {
   children: JSX.Element
 }
@@ -94,7 +97,12 @@ export const UserAccountProvider: FC<Props> = React.memo(({children}) => {
         setActiveAccountId(activeId)
       }
     } catch (error) {
-      event('multiAccount.retrieveAccounts.error', {error})
+      reportErrorThroughHoneyBadger(error, {
+        name: 'UserAccount',
+        context: {
+          message: 'error fetching user accounts',
+        },
+      })
     }
   }, [setActiveAccountId, setDefaultAccountId])
 
@@ -138,6 +146,12 @@ export const UserAccountProvider: FC<Props> = React.memo(({children}) => {
         setUserAccounts(updatedAccounts)
       } catch (error) {
         dispatch(notify(accountRenameError(activeAccount.name)))
+        reportErrorThroughHoneyBadger(error, {
+          name: 'UserAccount',
+          context: {
+            message: 'error renaming user account',
+          },
+        })
       }
     },
     [dispatch, userAccounts, setUserAccounts]

--- a/src/accounts/context/userAccount.tsx
+++ b/src/accounts/context/userAccount.tsx
@@ -89,14 +89,14 @@ export const UserAccountProvider: FC<Props> = React.memo(({children}) => {
       const accounts = await getUserAccounts()
 
       setUserAccounts(accounts)
-      const defaultAcctArray = accounts.find(line => line.isDefault)
+      const defaultAcctArray = accounts.find(acct => acct.isDefault)
       if (defaultAcctArray) {
         const defaultId = defaultAcctArray[0].id
         setDefaultAccountId(defaultId)
       }
 
       // isActive: true is for the currently logged in/active account
-      const activeAcctArray = accounts.find(line => line.isActive)
+      const activeAcctArray = accounts.find(acct => acct.isActive)
       if (activeAcctArray) {
         const activeId = activeAcctArray[0].id
         setActiveAccountId(activeId)

--- a/src/identity/apis/auth.ts
+++ b/src/identity/apis/auth.ts
@@ -333,11 +333,23 @@ export const getUserAccounts = async (): Promise<UserAccount[]> => {
 }
 
 export const updateUserAccount = async (accountId, name) => {
-  const resp = await patchAccount({accountId, data: {name}})
+  const response = await patchAccount({accountId, data: {name}})
 
-  if (resp.status !== 200) {
+  if (response.status === 401) {
+    throw new UnauthorizedError(response.data.message)
+  }
+  if (response.status === 422) {
+    throw new UnprocessableEntityError(response.data.message)
+  }
+  if (response.status === 500) {
+    throw new ServerError(response.data.message)
+  }
+  if (response.status !== 200) {
     throw new Error(`Account rename update failed`)
   }
+  if (!Array.isArray(response.data)) {
+    throw new GenericError('No account found')
+  }
 
-  return resp.data
+  return response.data
 }

--- a/src/identity/apis/auth.ts
+++ b/src/identity/apis/auth.ts
@@ -347,9 +347,6 @@ export const updateUserAccount = async (accountId, name) => {
   if (response.status !== 200) {
     throw new Error(`Account rename update failed`)
   }
-  if (!Array.isArray(response.data)) {
-    throw new GenericError('No account found')
-  }
 
   return response.data
 }

--- a/src/identity/apis/auth.ts
+++ b/src/identity/apis/auth.ts
@@ -332,7 +332,7 @@ export const getUserAccounts = async (): Promise<UserAccount[]> => {
   return response.data
 }
 
-export const updateQuartzAccount = async (accountId, name) => {
+export const updateUserAccount = async (accountId, name) => {
   const resp = await patchAccount({accountId, data: {name}})
 
   if (resp.status !== 200) {

--- a/src/identity/apis/auth.ts
+++ b/src/identity/apis/auth.ts
@@ -15,6 +15,8 @@ import {
   Me as MeQuartz,
   Organization,
   OrganizationSummaries,
+  UserAccount,
+  patchAccount,
 } from 'src/client/unityRoutes'
 
 import {
@@ -312,4 +314,30 @@ export const getDefaultAccountDefaultOrg = async (): Promise<
     }
     throw new GenericError('No default account found')
   }
+}
+
+export const getUserAccounts = async (): Promise<UserAccount[]> => {
+  const response = await getAccounts({})
+
+  if (response.status === 401) {
+    throw new UnauthorizedError(response.data.message)
+  }
+  if (response.status === 500) {
+    throw new ServerError(response.data.message)
+  }
+  if (!Array.isArray(response.data)) {
+    throw new GenericError('No account found')
+  }
+
+  return response.data
+}
+
+export const updateQuartzAccount = async (accountId, name) => {
+  const resp = await patchAccount({accountId, data: {name}})
+
+  if (resp.status !== 200) {
+    throw new Error(`Account rename update failed`)
+  }
+
+  return resp.data
 }

--- a/src/identity/apis/auth.ts
+++ b/src/identity/apis/auth.ts
@@ -344,9 +344,6 @@ export const updateUserAccount = async (accountId, name) => {
   if (response.status === 500) {
     throw new ServerError(response.data.message)
   }
-  if (response.status !== 200) {
-    throw new Error(`Account rename update failed`)
-  }
 
   return response.data
 }

--- a/src/shared/copy/notifications/categories/accounts-users-orgs.ts
+++ b/src/shared/copy/notifications/categories/accounts-users-orgs.ts
@@ -4,11 +4,6 @@ import {
   defaultSuccessNotification,
 } from 'src/shared/copy/notifications'
 
-export const defaultAccountNotFoundError = (): Notification => ({
-  ...defaultErrorNotification,
-  message: `No default account found.`,
-})
-
 export const accountDefaultSettingError = (
   accountName: string
 ): Notification => ({

--- a/src/shared/copy/notifications/categories/accounts-users-orgs.ts
+++ b/src/shared/copy/notifications/categories/accounts-users-orgs.ts
@@ -4,6 +4,11 @@ import {
   defaultSuccessNotification,
 } from 'src/shared/copy/notifications'
 
+export const defaultAccountNotFoundError = (): Notification => ({
+  ...defaultErrorNotification,
+  message: `No default account found.`,
+})
+
 export const accountDefaultSettingError = (
   accountName: string
 ): Notification => ({


### PR DESCRIPTION
Related: #5029

Refactor user accounts page (UserAccount.tsx) so that `getAccounts` and `patchAccount` from unityroutes are being used by the auth API layer.


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
