### PR TITLE
feat(idpe-15219): remove pinned items from Tasks

### DIFF
--- a/src/tasks/components/TaskCard.test.tsx
+++ b/src/tasks/components/TaskCard.test.tsx
@@ -30,7 +30,6 @@ const setup = (override = {}) => {
     labels: [], // all labels
     onPinTask: jest.fn(),
     onUnpinTask: jest.fn(),
-    isPinned: false,
     org: {id: 'BUCKSINSIX', name: 'Milwaukee Bucks'},
     me: {
       id: 'FORTHECULTURE',

--- a/src/tasks/components/TaskCard.tsx
+++ b/src/tasks/components/TaskCard.tsx
@@ -3,11 +3,6 @@ import React, {PureComponent, RefObject, createRef} from 'react'
 import {connect, ConnectedProps} from 'react-redux'
 import {withRouter, RouteComponentProps} from 'react-router-dom'
 
-import {
-  deletePinnedItemByParam,
-  updatePinnedItemByParam,
-} from 'src/shared/contexts/pinneditems'
-
 // Components
 import {
   SlideToggle,
@@ -40,12 +35,8 @@ import {Task, Label} from 'src/types'
 // Constants
 import {DEFAULT_TASK_NAME} from 'src/dashboards/constants'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
-import {CLOUD} from 'src/shared/constants'
 
-import {
-  pinnedItemFailure,
-  pinnedItemSuccess,
-} from 'src/shared/copy/notifications'
+// Utils
 import {notify} from 'src/shared/actions/notifications'
 import {downloadTaskTemplate} from 'src/tasks/apis'
 import {event} from 'src/cloud/utils/reporting'
@@ -60,9 +51,6 @@ interface PassedProps {
   onRunTask: (taskID: string) => void
   onUpdate: (name: string, taskID: string) => void
   onFilterChange: (searchTerm: string) => void
-  onPinTask: (taskID: string, name: string) => void
-  onUnpinTask: (taskID: string) => void
-  isPinned: boolean
 }
 
 type ReduxProps = ConnectedProps<typeof connector>
@@ -147,26 +135,12 @@ export class TaskCard extends PureComponent<
     )
   }
 
-  private handlePinTask = () => {
-    const {task, isPinned} = this.props
-
-    if (isPinned) {
-      this.props.onUnpinTask(task.id)
-    } else {
-      this.props.onPinTask(task.id, task.name)
-    }
-  }
-
-  private handleOnDelete = async task => {
+  private handleOnDelete = task => {
     this.props.onDelete(task)
-    try {
-      await deletePinnedItemByParam(task.id)
-    } catch (error) {
-      this.props.sendNotification(pinnedItemFailure(error.message, 'delete'))
-    }
   }
+
   private get contextMenu(): JSX.Element {
-    const {task, onClone, isPinned} = this.props
+    const {task, onClone} = this.props
     const settingsRef: RefObject<HTMLButtonElement> = createRef()
 
     return (
@@ -194,7 +168,7 @@ export class TaskCard extends PureComponent<
           appearance={Appearance.Outline}
           enableDefaultStyles={false}
           style={{minWidth: '112px'}}
-          contents={onHide => (
+          contents={_ => (
             <List>
               <List.Item
                 onClick={this.handleExport}
@@ -230,19 +204,6 @@ export class TaskCard extends PureComponent<
               >
                 Clone
               </List.Item>
-              {isFlagEnabled('pinnedItems') && CLOUD && (
-                <List.Item
-                  onClick={() => {
-                    this.handlePinTask()
-                    onHide()
-                  }}
-                  size={ComponentSize.Small}
-                  style={{fontWeight: 500}}
-                  testID="context-pin-task"
-                >
-                  {isPinned ? 'Unpin' : 'Pin'}
-                </List.Item>
-              )}
             </List>
           )}
           triggerRef={settingsRef}
@@ -302,14 +263,6 @@ export class TaskCard extends PureComponent<
       task: {id},
     } = this.props
     onUpdate(name, id)
-    if (isFlagEnabled('pinnedItems') && CLOUD && this.props.isPinned) {
-      try {
-        updatePinnedItemByParam(id, {name})
-        this.props.sendNotification(pinnedItemSuccess('task', 'updated'))
-      } catch (err) {
-        this.props.sendNotification(pinnedItemFailure(err.message, 'update'))
-      }
-    }
   }
 
   private handleExport = () => {

--- a/src/tasks/containers/TasksPage.test.tsx
+++ b/src/tasks/containers/TasksPage.test.tsx
@@ -60,19 +60,6 @@ jest.mock('src/languageSupport/languages/flux/parser', () => ({
   format_from_js_file: jest.fn(),
 }))
 
-jest.mock('src/shared/contexts/pinneditems', () => ({
-  getPinnedItems: jest.fn(() =>
-    Promise.resolve({
-      json: () => Promise.resolve([]),
-    })
-  ),
-  PinnedItemTypes: {Task: 'task'},
-  addPinnedItem: jest.fn(() => {
-    return new Promise(resolve => resolve())
-  }),
-  deletePinnedItemByParam: jest.fn(() => Promise.resolve()),
-}))
-
 jest.mock('src/client', () => ({
   getTasks: jest.fn(() => {
     return {


### PR DESCRIPTION
Part of https://github.com/influxdata/idpe/issues/15219

Pinned Items are not used on the landing page. But we left in the functionality to pin Tasks. Remove this functionality.


## Vid
Before:
* can pin a task
* but doesn't appear on landing page
* https://user-images.githubusercontent.com/10232835/190507193-01618bca-eb2e-48a1-8263-7e11c6795faa.mov

After:
* cannot pin a task
* https://user-images.githubusercontent.com/10232835/190507198-87a7723e-e02c-489d-88b1-e435edf23861.mov

## Checklist
- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] ~Feature flagged, if applicable~ Feature flag will be removed later, after IDPE epic is complete.
