### PR TITLE
feat(idpe-15219): remove pinned items from Dashboards

### DIFF
--- a/src/dashboards/components/DashboardHeader.tsx
+++ b/src/dashboards/components/DashboardHeader.tsx
@@ -43,7 +43,7 @@ import {
 
 // Utils
 import {resetQueryCache} from 'src/shared/apis/queryCache'
-import {updatePinnedItemByParam} from 'src/shared/contexts/pinneditems'
+
 // Selectors
 import {getTimeRange} from 'src/dashboards/selectors'
 import {getByID} from 'src/resources/selectors'
@@ -103,7 +103,6 @@ const DashboardHeader: FC<Props> = ({
 
   const handleRenameDashboard = (name: string) => {
     updateDashboard(dashboard.id, {name})
-    updatePinnedItemByParam(dashboard.id, {name})
   }
 
   const handleChooseTimeRange = (timeRange: TimeRange) => {

--- a/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -41,20 +41,8 @@ import {DEFAULT_DASHBOARD_NAME} from 'src/dashboards/constants'
 import {relativeTimestampFormatter} from 'src/shared/utils/relativeTimestampFormatter'
 import {shouldOpenLinkInNewTab} from 'src/utils/crossPlatform'
 import {safeBlankLinkOpen} from 'src/utils/safeBlankLinkOpen'
-
-import {
-  pinnedItemFailure,
-  pinnedItemSuccess,
-} from 'src/shared/copy/notifications'
 import {notify} from 'src/shared/actions/notifications'
-
-import {
-  deletePinnedItemByParam,
-  updatePinnedItemByParam,
-} from 'src/shared/contexts/pinneditems'
-
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
-import {CLOUD} from 'src/shared/constants'
 import {PROJECT_NAME} from 'src/flows'
 
 interface OwnProps {
@@ -64,13 +52,6 @@ interface OwnProps {
   updatedAt: string
   labels: string[]
   onFilterChange: (searchTerm: string) => void
-  onPinDashboard: (
-    dashboardID: string,
-    name: string,
-    description: string
-  ) => void
-  onUnpinDashboard: (DashboardID: string) => void
-  isPinned: boolean
 }
 
 type ReduxProps = ConnectedProps<typeof connector>
@@ -137,30 +118,12 @@ class DashboardCard extends PureComponent<Props> {
     const {id, onUpdateDashboard} = this.props
 
     onUpdateDashboard(id, {name})
-
-    if (isFlagEnabled('pinnedItems') && CLOUD && this.props.isPinned) {
-      try {
-        updatePinnedItemByParam(id, {name})
-        this.props.sendNotification(pinnedItemSuccess('dashboard', 'updated'))
-      } catch (err) {
-        this.props.sendNotification(pinnedItemFailure(err.message, 'update'))
-      }
-    }
   }
 
   private handleCloneDashboard = () => {
     const {id, name, onCloneDashboard} = this.props
 
     onCloneDashboard(id, name)
-  }
-
-  private handlePinDashboard = () => {
-    const {id, name, description, isPinned} = this.props
-    if (isPinned) {
-      this.props.onUnpinDashboard(id)
-    } else {
-      this.props.onPinDashboard(id, name, description)
-    }
   }
 
   private get contextMenu(): JSX.Element {
@@ -189,7 +152,7 @@ class DashboardCard extends PureComponent<Props> {
           appearance={Appearance.Outline}
           enableDefaultStyles={false}
           style={minWidth}
-          contents={onHide => (
+          contents={_ => (
             <List>
               <List.Item
                 onClick={this.handleExport}
@@ -207,19 +170,6 @@ class DashboardCard extends PureComponent<Props> {
               >
                 Clone
               </List.Item>
-              {isFlagEnabled('pinnedItems') && CLOUD && (
-                <List.Item
-                  onClick={() => {
-                    this.handlePinDashboard()
-                    onHide()
-                  }}
-                  size={ComponentSize.Small}
-                  style={fontWeight}
-                  testID="context-pin-dashboard"
-                >
-                  {this.props.isPinned ? 'Unpin' : 'Pin'}
-                </List.Item>
-              )}
             </List>
           )}
           triggerRef={settingsRef}
@@ -228,17 +178,9 @@ class DashboardCard extends PureComponent<Props> {
     )
   }
 
-  private handleDeleteDashboard = async () => {
+  private handleDeleteDashboard = () => {
     const {id, name, onDeleteDashboard} = this.props
     onDeleteDashboard(id, name)
-    if (isFlagEnabled('pinnedItems') && CLOUD && this.props.isPinned) {
-      try {
-        await deletePinnedItemByParam(id)
-        this.props.sendNotification(pinnedItemSuccess('dashboard', 'deleted'))
-      } catch (error) {
-        this.props.sendNotification(pinnedItemFailure(error.message, 'delete'))
-      }
-    }
   }
 
   private handleClickDashboard = event => {
@@ -270,13 +212,6 @@ class DashboardCard extends PureComponent<Props> {
     const {id, onUpdateDashboard} = this.props
 
     onUpdateDashboard(id, {description})
-    if (isFlagEnabled('pinnedItems') && CLOUD && this.props.isPinned) {
-      try {
-        updatePinnedItemByParam(id, {description})
-      } catch (err) {
-        this.props.sendNotification(pinnedItemFailure(err.message, 'update'))
-      }
-    }
   }
 
   private handleAddLabel = (label: Label) => {

--- a/src/dashboards/components/dashboard_index/DashboardCards.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardCards.tsx
@@ -15,28 +15,9 @@ import {LimitStatus} from 'src/cloud/actions/limits'
 import {getMe} from 'src/me/selectors'
 import {getOrg} from 'src/organizations/selectors'
 
-// Contexts
-import {
-  addPinnedItem,
-  deletePinnedItemByParam,
-  PinnedItemTypes,
-} from 'src/shared/contexts/pinneditems'
-
 // Utils
 import {extractDashboardLimits} from 'src/cloud/utils/limits'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
-import {CLOUD} from 'src/shared/constants'
 import {notify} from 'src/shared/actions/notifications'
-
-import {
-  pinnedItemFailure,
-  pinnedItemSuccess,
-} from 'src/shared/copy/notifications'
-
-let getPinnedItems
-if (CLOUD) {
-  getPinnedItems = require('src/shared/contexts/pinneditems').getPinnedItems
-}
 
 interface StateProps {
   limitStatus: LimitStatus['status']
@@ -51,20 +32,12 @@ type ReduxProps = ConnectedProps<typeof connector>
 type Props = OwnProps & StateProps & ReduxProps
 
 class DashboardCards extends PureComponent<Props> {
-  private _isMounted = true
   private _assetLimitAlertStyle = {
     height: 'inherit',
   }
 
   state = {
-    pinnedItems: [],
     dashboardCardHeight: 'inherit',
-  }
-
-  public componentDidMount() {
-    if (isFlagEnabled('pinnedItems') && CLOUD) {
-      this.updatePinnedItems()
-    }
   }
 
   public componentDidUpdate() {
@@ -78,14 +51,8 @@ class DashboardCards extends PureComponent<Props> {
     }
   }
 
-  public componentWillUnmount() {
-    this._isMounted = false
-  }
-
   public render() {
     const {dashboards, onFilterChange} = this.props
-
-    const {pinnedItems} = this.state
 
     return (
       <div className="dashboards-card-grid">
@@ -98,11 +65,6 @@ class DashboardCards extends PureComponent<Props> {
             updatedAt={meta.updatedAt}
             description={description}
             onFilterChange={onFilterChange}
-            onPinDashboard={this.handlePinDashboard}
-            onUnpinDashboard={this.handleUnpinDashboard}
-            isPinned={
-              !!pinnedItems.find(item => item?.metadata.dashboardID === id)
-            }
           />
         ))}
         {this.props.limitStatus === 'exceeded' && (
@@ -117,53 +79,6 @@ class DashboardCards extends PureComponent<Props> {
         )}
       </div>
     )
-  }
-
-  public updatePinnedItems = () => {
-    getPinnedItems()
-      .then(res => {
-        if (this._isMounted) {
-          this.setState(prev => ({...prev, pinnedItems: res}))
-        }
-      })
-      .catch(err => console.error(err))
-  }
-
-  public handlePinDashboard = async (
-    dashboardID: string,
-    name: string,
-    description: string
-  ) => {
-    const {org, me} = this.props
-
-    // add to pinned item list
-    try {
-      await addPinnedItem({
-        orgID: org.id,
-        userID: me.id,
-        metadata: {
-          dashboardID,
-          name,
-          description,
-        },
-        type: PinnedItemTypes.Dashboard,
-      })
-      this.props.sendNotification(pinnedItemSuccess('dashboard', 'added'))
-      this.updatePinnedItems()
-    } catch (err) {
-      this.props.sendNotification(pinnedItemFailure(err.message, 'add'))
-    }
-  }
-
-  public handleUnpinDashboard = async (dashboardID: string) => {
-    // delete from pinned item list
-    try {
-      await deletePinnedItemByParam(dashboardID)
-      this.props.sendNotification(pinnedItemSuccess('dashboard', 'deleted'))
-      this.updatePinnedItems()
-    } catch (err) {
-      this.props.sendNotification(pinnedItemFailure(err.message, 'delete'))
-    }
   }
 }
 


### PR DESCRIPTION
Part of https://github.com/influxdata/idpe/issues/15219

Pinned Items are not used on the landing page. But we left in the functionality to pin Dashboards. Remove this functionality.

## Vid
Before:
* can pin a dashboard
* but doesn't appear on landing page
* https://user-images.githubusercontent.com/10232835/190515588-4ac0126d-1a65-4346-8b05-b2dd574fada7.mov

After:
* cannot pin a dashboard
* https://user-images.githubusercontent.com/10232835/190515641-d21da5c9-124a-4b2c-9e5c-36084016ab91.mov


## Checklist
- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] ~Feature flagged, if applicable~ Feature flag will be removed later, after IDPE epic is complete.
