### PR TITLE
chore: add guards to pushing into selected variable array, remove extra reporting

### DIFF
--- a/src/variables/selectors/index.tsx
+++ b/src/variables/selectors/index.tsx
@@ -28,7 +28,6 @@ import {AppState, VariableArgumentType, Variable} from 'src/types'
 
 // Utils
 import {filterUnusedVars} from 'src/shared/utils/filterUnusedVars'
-import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
 
 export const extractVariableEditorName = (state: AppState): string => {
   return state.variableEditor.name

--- a/src/variables/selectors/index.tsx
+++ b/src/variables/selectors/index.tsx
@@ -215,17 +215,11 @@ export const getVariable = (state: AppState, variableID: string): Variable => {
       vari.selected.push(vals[0])
     } catch (err) {
       // Temporary measure to resolve errors relating to pushing into non-extensible object.
-      reportErrorThroughHoneyBadger(err, {
+      console.error({
         name: 'Failed to set selected variable to default, zero-indexed value',
-        context: {
-          identityState: state.identity,
-          resourceState: state.resources,
-          variable: vari,
-          variableType: vari.arguments.type,
-          normalizedVariable: vals,
-          variableLength: vari.selected.length,
-          normalizedVariableLength: vals.length,
-        },
+        error: err,
+        variable: vari,
+        variableType: vari.arguments.type,
       })
     }
   }

--- a/src/variables/selectors/index.tsx
+++ b/src/variables/selectors/index.tsx
@@ -210,16 +210,8 @@ export const getVariable = (state: AppState, variableID: string): Variable => {
   }
 
   if (!vari.selected.length && vals.length) {
-    try {
+    if (Object.isExtensible(vari.selected)) {
       vari.selected.push(vals[0])
-    } catch (err) {
-      // Temporary measure to resolve errors relating to pushing into non-extensible object.
-      console.error({
-        name: 'Failed to set selected variable to default, zero-indexed value',
-        error: err,
-        variable: vari,
-        variableType: vari.arguments.type,
-      })
     }
   }
 


### PR DESCRIPTION
We added more error [reporting to honeybadger](https://github.com/influxdata/ui/pull/5689/) around a code block in `variables` that throws an `object not extensible` error to resolve this [issue](https://github.com/influxdata/ui/issues/5523). We're now getting more detailed error reports, but when the monitor301 dashboard that experiences this error hits it, it hits it 300+ times. We're getting reports of sluggishness on that monitor301 dashboard and the following error, which suggests the network reporting of the error might be overkill. Also, we don't really need it anymore, since we have logs of the error in honeybadger.

This PR does two things. 
- First, it removes the honeybadger reporting added to this block. 
- Second, it attempts to resolve the immediate error by _not_ pushing a default value into the 'selected' variable array if the object isn't extensible.

This is safe to do because this _only_ prevents the error-generating push in the case where the object isn't extensible, which (before we added error handling) would throw an uncaught error.

This is a shallow fix. The root cause of `vari.selected` not being extensible is probably from the assumptions this selector makes about object cloning. Trying to clone an extensible copy of a frozen piece of state, vari, like this selector does: `vari = {...vari}` doesn't work for properties of that object that are themselves objects - those are still going to point to the same reference in memory. Those should probably be _deep_ clones. But I'll save that for another PR since that requires a more substantial rework and probably a feature flag.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - NO
