### PR TITLE
feat: remove unnecessary org-details fetch on homepage once isUpgradeable is available

### DIFF
--- a/src/identity/reducers/index.ts
+++ b/src/identity/reducers/index.ts
@@ -34,6 +34,7 @@ export const initialState: CurrentIdentity = {
     type: 'free',
     accountCreatedAt: '',
     paygCreditStartDate: '',
+    isUpgradeable: false,
   },
   status: RemoteDataState.NotStarted,
 }
@@ -47,6 +48,7 @@ export default (state = initialState, action: Actions): CurrentIdentity =>
         // Store account information from /identity in state.
         draftState.account.accountCreatedAt = account.accountCreatedAt
         draftState.account.id = account.id
+        draftState.account.isUpgradeable = account.isUpgradeable
         draftState.account.name = account.name
         draftState.account.paygCreditStartDate = account.paygCreditStartDate
         draftState.account.type = account.type

--- a/src/identity/utils/convertIdentityToMe.ts
+++ b/src/identity/utils/convertIdentityToMe.ts
@@ -20,11 +20,14 @@ export const convertIdentityToMe = (
     accountType: account.type,
     paygCreditStartDate: account.paygCreditStartDate,
     billingProvider: account.billingProvider ? account.billingProvider : null,
+    // isRegionBeta in quartz/me has the opposite value of isUpgradeable.
+    isRegionBeta: account.isUpgradeable
+      ? !Boolean(account.isUpgradeable)
+      : true,
 
     // Organization Data
     clusterHost: org.clusterHost,
     regionCode: org.regionCode ? org.regionCode : null,
-    isRegionBeta: org.isRegionBeta ? org.isRegionBeta : null,
     regionName: org.regionName ? org.regionName : null,
   }
 }

--- a/src/shared/containers/GetOrganizations.tsx
+++ b/src/shared/containers/GetOrganizations.tsx
@@ -32,7 +32,6 @@ import {CLOUD} from 'src/shared/constants'
 // Utils
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {convertStringToEpoch} from 'src/shared/utils/dateTimeUtils'
-import {shouldUseQuartzIdentity} from 'src/identity/utils/shouldUseQuartzIdentity'
 import {updateReportingContext} from 'src/cloud/utils/reporting'
 
 // Types
@@ -41,13 +40,10 @@ import {PROJECT_NAME} from 'src/flows'
 import {RemoteDataState} from 'src/types'
 
 // Thunks
-import {
-  getCurrentOrgDetailsThunk,
-  getQuartzIdentityThunk,
-} from 'src/identity/actions/thunks'
+import {getQuartzIdentityThunk} from 'src/identity/actions/thunks'
 
 const canAccessCheckout = (me: Me): boolean => {
-  if (!!me?.isRegionBeta) {
+  if (Boolean(me?.isRegionBeta)) {
     return false
   }
   return me?.accountType !== 'pay_as_you_go' && me?.accountType !== 'contract'
@@ -63,14 +59,6 @@ const GetOrganizations: FunctionComponent = () => {
   const {account} = identity.currentIdentity
 
   const dispatch = useDispatch()
-
-  const identityOrgId = identity.currentIdentity.org.id
-
-  useEffect(() => {
-    if (identityOrgId && shouldUseQuartzIdentity() && !quartzMe?.isRegionBeta) {
-      dispatch(getCurrentOrgDetailsThunk(identityOrgId))
-    }
-  }, [identityOrgId]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // This doesn't require another API call.
   useEffect(() => {


### PR DESCRIPTION
Closes #4823 

This PR adds the `account.isUpgradeable` property into state, and adjusts the app to pull the user's eligibility to access the checkout page from that property, instead of the old `isRegionBeta` property.

Previously, we needed to make an extra network call (to api/v2/quartz/orgs/:orgId) on the home page after the `identity` upgrade. The reason was that we have a check in `GetOrganizations` (which controls our routes) that denies the user access to the checkout page if they're in a beta cluster (`isRegionBeta`) and therefore shouldn't be able to upgrade their account yet. `identity` didn't have a property on it that corresponded to `isRegionBeta`, so we had to make a separate network call to the orgs/:orgId route to get that data, and confirm whether the user can check out.

`identity.account` now has the `isUpgradeable` property on it. It's a simpler `boolean`, the inverse of `isRegionBeta`, that just answers the question - Can I upgrade my account? If so, `true`, if not, `false`. Since this property is on `identity`, that extra network call isn't required anymore.

Before - Call to /orgs/:orgId
--
https://user-images.githubusercontent.com/91283923/190826474-337c1ec7-05a2-43e2-8526-15d79b188736.mov

After - No call to /orgs/:orgId
--
https://user-images.githubusercontent.com/91283923/190827371-fc0405a9-ec18-4022-b7d4-9513bac4cc92.mov





### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - `quartzIdentity`
