### PR TITLE
fix(sub): password field optional during update

### DIFF
--- a/src/writeData/subscriptions/utils/form.ts
+++ b/src/writeData/subscriptions/utils/form.ts
@@ -243,7 +243,7 @@ const checkNoneSelected = (form: Subscription): boolean =>
 const checkBasicSelected = (form: Subscription): boolean =>
   form.authType === BrokerAuthTypes.User &&
   !!form.brokerUsername &&
-  !!form.brokerPassword
+  (!!form.id || !!form.brokerPassword) // only require a password when a subscription is being created, not edited.
 
 const checkCertificateSelected = (form: Subscription): boolean =>
   form.authType === BrokerAuthTypes.Certificate &&


### PR DESCRIPTION
Closes https://github.com/influxdata/data-acquisition/issues/522

The subscription password field should be required basic auth is selected and a subscription is being created. It should be optional when basic auth is selected and a subscription is being edited. This is because we do not return the password in the API response so the field is empty when the subscription is being edited and that's ok. If the password field remains empty, we [do not include it](https://github.com/influxdata/ui/blob/master/src/writeData/subscriptions/utils/form.ts#L142) in the update API request. The user is still free to edit the password if they like.

Before (save changes is disabled)

<img width="1435" alt="image" src="https://user-images.githubusercontent.com/6411855/190833772-5d7c7ef8-a565-4cce-b70c-76a23b22651f.png">


After (save changes is enabled)

<img width="1438" alt="image" src="https://user-images.githubusercontent.com/6411855/190833754-95b96e10-60d3-4f7d-86ec-40500cf20d5d.png">

Password is not included in the PUT request when field is empty

<img width="357" alt="image" src="https://user-images.githubusercontent.com/6411855/190834302-de5c43c3-5b42-428f-a9b9-909f09dfc996.png">

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
