### PR TITLE
chore(CsvMethod): move runQuery api into its own layer

### DIFF
--- a/src/writeData/apis/index.ts
+++ b/src/writeData/apis/index.ts
@@ -1,0 +1,31 @@
+// Utils
+import {getErrorMessage} from 'src/utils/api'
+import {runQuery} from 'src/shared/apis/query'
+
+// Types
+import {RemoteDataState} from 'src/types'
+
+export const handleRunQuery = async (
+  orgID: string,
+  query: string,
+  extern: any,
+  controller: AbortController,
+  setUploadState: (RemoteDataState: RemoteDataState) => void,
+  setUploadError: (string: string) => void
+): Promise<void> => {
+  const response = await runQuery(orgID, query, extern, controller).promise
+
+  if (response.type === 'SUCCESS') {
+    setUploadState(RemoteDataState.Done)
+    return
+  }
+  if (response.type === 'RATE_LIMIT_ERROR') {
+    setUploadState(RemoteDataState.Error)
+    setUploadError('Failed due to plan limits: read cardinality reached')
+    return
+  }
+  if (response.type === 'UNKNOWN_ERROR') {
+    const error = getErrorMessage(response)
+    throw new Error(error)
+  }
+}

--- a/src/writeData/components/fileUploads/CsvMethod.tsx
+++ b/src/writeData/components/fileUploads/CsvMethod.tsx
@@ -83,7 +83,7 @@ const CsvMethod: FC = () => {
   )
 
   const uploadCsv = useCallback(
-    (csv: string, bucket: string) => {
+    async (csv: string, bucket: string) => {
       setUploadState(RemoteDataState.Loading)
       controller.current = new AbortController()
       try {
@@ -91,7 +91,7 @@ const CsvMethod: FC = () => {
           csv.from(csv: ${JSON.stringify(csv)})
           |> to(bucket: "${bucket}")`
 
-        handleRunQuery(
+        await handleRunQuery(
           org?.id,
           query,
           undefined,


### PR DESCRIPTION
Closes #5815 

Pr refactors `uploadCsv` function inside `CsvMethod.tsx` by moving the `runQuery` api call into its own file. 
This improves code readability and organization by making the component less cluttered. 

Here is a video demonstrating user uploading an annotated csv and a non-annotated csv using this branch. 
usability of this feature has not been affected by the refactor. 

https://user-images.githubusercontent.com/66275100/191065222-d157cdb2-3184-4b5c-b36e-81906d5230a3.mov


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
