### PR TITLE
fix: change expected acct endpoint response to single object

### DIFF
--- a/src/accounts/context/userAccount.tsx
+++ b/src/accounts/context/userAccount.tsx
@@ -84,16 +84,16 @@ export const UserAccountProvider: FC<Props> = React.memo(({children}) => {
     try {
       const accounts = await getUserAccounts()
       setUserAccounts(accounts)
-      const defaultAcctArray = accounts.find(acct => acct.isDefault === true)
-      if (defaultAcctArray) {
-        const defaultId = defaultAcctArray[0].id
+      const defaultAcct = accounts.find(acct => acct.isDefault === true)
+      if (typeof defaultAcct === 'object' && defaultAcct.hasOwnProperty('id')) {
+        const defaultId = defaultAcct.id
         setDefaultAccountId(defaultId)
       }
 
       // isActive: true is for the currently logged in/active account
-      const activeAcctArray = accounts.find(acct => acct.isActive === true)
-      if (activeAcctArray) {
-        const activeId = activeAcctArray[0].id
+      const activeAcct = accounts.find(acct => acct.isActive === true)
+      if (typeof activeAcct === 'object' && activeAcct.hasOwnProperty('id')) {
+        const activeId = activeAcct.id
         setActiveAccountId(activeId)
       }
     } catch (error) {


### PR DESCRIPTION
We are seeing some new error reporting after PR #5773 . Root cause is that refactor changed a `filter()` to a `find()`, which is going to return an `undefined` or single `object` from the array of objects, as opposed to an array containing a single object.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - NO
