### PR TITLE
chore: update Giraffe

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "@docsearch/react": "^3.0.0-alpha.37",
     "@influxdata/clockface": "^6.3.0",
     "@influxdata/flux-lsp-browser": "0.8.34",
-    "@influxdata/giraffe": "^2.34.2",
+    "@influxdata/giraffe": "^2.34.4",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",
     "abortcontroller-polyfill": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1450,10 +1450,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/flux-lsp-browser/-/flux-lsp-browser-0.8.34.tgz#9261b193593317b593420fb289a4f2ac95952fbe"
   integrity sha512-c/GytzYDOBVdVG5bXQbKLKMI9lu2vUVKjUUsCLajnbAVHs5zXllfff+ubaNdn1hGFgY/upmjcUpE/gm3FqphoQ==
 
-"@influxdata/giraffe@^2.34.2":
-  version "2.34.2"
-  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.34.2.tgz#60271c4c0c7f3780f22f32cf58924e4beead32e4"
-  integrity sha512-/bf3NLJ2IpfnOZy2iyNXmvMdhDrI4INcVCegwXyMAXc3cTZKnbpHiYHL0fiR0K3ev0WeNMjAhCuKQfdkbeU60g==
+"@influxdata/giraffe@^2.34.4":
+  version "2.34.4"
+  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.34.4.tgz#d70ab8335eca8ed27d04632dcfb77a14220d105a"
+  integrity sha512-JntdNCTYmfMJZKfC9gkCr+i2VBWSCToqgD64LZmzINHJFmddin2vJcAT8ICb0kMHF3BymEfbhgOLwNbYSiz44g==
   dependencies:
     merge-images "^2.0.0"
 


### PR DESCRIPTION
Part of https://github.com/influxdata/giraffe/issues/805

- memoizes `SimpleTableLayer`
- various fixes to hooks

See https://github.com/influxdata/giraffe/pull/808 for demo
