### PR TITLE
chore: remove original injection commands

### DIFF
--- a/src/languageSupport/languages/flux/lsp/utils.ts
+++ b/src/languageSupport/languages/flux/lsp/utils.ts
@@ -145,7 +145,6 @@ function validateExecuteCommandPayload([command, arg]: ExecuteCommandT):
     case ExecuteCommand.InjectionMeasurement:
       return checkIsString(arg, 'bucket')
     case ExecuteCommand.InjectTag:
-    case ExecuteCommand.InjectField:
       return checkIsString(arg, 'bucket') && checkIsString(arg, 'name')
     case ExecuteCommand.InjectTagValue:
       return (
@@ -217,7 +216,6 @@ export enum Methods {
  */
 export enum ExecuteCommand {
   InjectionMeasurement = 'injectMeasurementFilter',
-  InjectField = 'injectFieldFilter',
   InjectTag = 'injectTagFilter',
   InjectTagValue = 'injectTagValueFilter',
   CompositionInit = 'fluxComposition/initialize',

--- a/src/languageSupport/languages/flux/lsp/utils.ts
+++ b/src/languageSupport/languages/flux/lsp/utils.ts
@@ -74,8 +74,6 @@ export interface ExecuteCommandInjectTagValue extends ExecuteCommandInjectTag {
   value: string
 }
 
-export type ExecuteCommandInjectField = ExecuteCommandInjectMeasurement
-
 /**
  * @typedef {object} CompositionInitParams
  * @property {string} CompositionInitParams.bucket - bucket name,
@@ -111,7 +109,6 @@ export type ExecuteCommandArgument =
   | ExecuteCommandInjectMeasurement
   | ExecuteCommandInjectTag
   | ExecuteCommandInjectTagValue
-  | ExecuteCommandInjectField
   | CompositionInitParams
   | CompositionValueParams
 
@@ -125,7 +122,6 @@ export type ExecuteCommandT =
   | [ExecuteCommand.InjectionMeasurement, ExecuteCommandInjectMeasurement]
   | [ExecuteCommand.InjectTag, ExecuteCommandInjectTag]
   | [ExecuteCommand.InjectTagValue, ExecuteCommandInjectTagValue]
-  | [ExecuteCommand.InjectField, ExecuteCommandInjectField]
   | [ExecuteCommand.CompositionInit, CompositionInitParams]
   | [ExecuteCommand.CompositionAddMeasurement, CompositionValueParams]
   | [ExecuteCommand.CompositionAddField, CompositionValueParams]

--- a/src/languageSupport/languages/flux/lsp/utils.ts
+++ b/src/languageSupport/languages/flux/lsp/utils.ts
@@ -68,12 +68,6 @@ export interface ExecuteCommandInjectMeasurement extends ExecuteCommandParams {
   bucket: string
 }
 
-export type ExecuteCommandInjectTag = ExecuteCommandInjectMeasurement
-
-export interface ExecuteCommandInjectTagValue extends ExecuteCommandInjectTag {
-  value: string
-}
-
 /**
  * @typedef {object} CompositionInitParams
  * @property {string} CompositionInitParams.bucket - bucket name,
@@ -107,8 +101,6 @@ interface CompositionTagValueParams extends CompositionValueParams {
 
 export type ExecuteCommandArgument =
   | ExecuteCommandInjectMeasurement
-  | ExecuteCommandInjectTag
-  | ExecuteCommandInjectTagValue
   | CompositionInitParams
   | CompositionValueParams
 
@@ -120,8 +112,6 @@ export type ExecuteCommandArgument =
  */
 export type ExecuteCommandT =
   | [ExecuteCommand.InjectionMeasurement, ExecuteCommandInjectMeasurement]
-  | [ExecuteCommand.InjectTag, ExecuteCommandInjectTag]
-  | [ExecuteCommand.InjectTagValue, ExecuteCommandInjectTagValue]
   | [ExecuteCommand.CompositionInit, CompositionInitParams]
   | [ExecuteCommand.CompositionAddMeasurement, CompositionValueParams]
   | [ExecuteCommand.CompositionAddField, CompositionValueParams]
@@ -144,14 +134,6 @@ function validateExecuteCommandPayload([command, arg]: ExecuteCommandT):
   switch (command) {
     case ExecuteCommand.InjectionMeasurement:
       return checkIsString(arg, 'bucket')
-    case ExecuteCommand.InjectTag:
-      return checkIsString(arg, 'bucket') && checkIsString(arg, 'name')
-    case ExecuteCommand.InjectTagValue:
-      return (
-        checkIsString(arg, 'bucket') &&
-        checkIsString(arg, 'name') &&
-        checkIsString(arg, 'value')
-      )
     case ExecuteCommand.CompositionInit:
       return checkIsString(arg, 'bucket')
     case ExecuteCommand.CompositionAddMeasurement:
@@ -216,8 +198,6 @@ export enum Methods {
  */
 export enum ExecuteCommand {
   InjectionMeasurement = 'injectMeasurementFilter',
-  InjectTag = 'injectTagFilter',
-  InjectTagValue = 'injectTagValueFilter',
   CompositionInit = 'fluxComposition/initialize',
   CompositionAddMeasurement = 'fluxComposition/addMeasurementFilter',
   CompositionAddField = 'fluxComposition/addFieldFilter',

--- a/src/languageSupport/languages/flux/lsp/utils.ts
+++ b/src/languageSupport/languages/flux/lsp/utils.ts
@@ -63,11 +63,6 @@ interface ExecuteCommandParams {
   }
 }
 
-export interface ExecuteCommandInjectMeasurement extends ExecuteCommandParams {
-  name: string
-  bucket: string
-}
-
 /**
  * @typedef {object} CompositionInitParams
  * @property {string} CompositionInitParams.bucket - bucket name,
@@ -100,7 +95,6 @@ interface CompositionTagValueParams extends CompositionValueParams {
 }
 
 export type ExecuteCommandArgument =
-  | ExecuteCommandInjectMeasurement
   | CompositionInitParams
   | CompositionValueParams
 
@@ -111,7 +105,6 @@ export type ExecuteCommandArgument =
  *     https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#executeCommandParams
  */
 export type ExecuteCommandT =
-  | [ExecuteCommand.InjectionMeasurement, ExecuteCommandInjectMeasurement]
   | [ExecuteCommand.CompositionInit, CompositionInitParams]
   | [ExecuteCommand.CompositionAddMeasurement, CompositionValueParams]
   | [ExecuteCommand.CompositionAddField, CompositionValueParams]
@@ -132,8 +125,6 @@ function validateExecuteCommandPayload([command, arg]: ExecuteCommandT):
   }
 
   switch (command) {
-    case ExecuteCommand.InjectionMeasurement:
-      return checkIsString(arg, 'bucket')
     case ExecuteCommand.CompositionInit:
       return checkIsString(arg, 'bucket')
     case ExecuteCommand.CompositionAddMeasurement:
@@ -197,7 +188,6 @@ export enum Methods {
  *         * https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_executeCommand
  */
 export enum ExecuteCommand {
-  InjectionMeasurement = 'injectMeasurementFilter',
   CompositionInit = 'fluxComposition/initialize',
   CompositionAddMeasurement = 'fluxComposition/addMeasurementFilter',
   CompositionAddField = 'fluxComposition/addFieldFilter',

--- a/src/shared/contexts/editor/index.tsx
+++ b/src/shared/contexts/editor/index.tsx
@@ -16,14 +16,9 @@ import {
 import {getFluxExample} from 'src/shared/utils/fluxExample'
 
 // LSP
-import {
-  ExecuteCommand,
-  ExecuteCommandArgument,
-} from 'src/languageSupport/languages/flux/lsp/utils'
 import LspConnectionManager from 'src/languageSupport/languages/flux/lsp/connection'
 
 // Utils
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {CLOUD} from 'src/shared/constants'
 
 export interface EditorContextType {
@@ -35,10 +30,6 @@ export interface EditorContextType {
   inject: (options: InjectionOptions) => void
   injectFunction: (fn, cbToParent) => void
   injectVariable: (variableName, cbToParent) => void
-  injectViaLsp: (
-    cmd: ExecuteCommand,
-    data: Omit<ExecuteCommandArgument, 'textDocument'>
-  ) => void
 }
 
 const DEFAULT_CONTEXT: EditorContextType = {
@@ -47,33 +38,16 @@ const DEFAULT_CONTEXT: EditorContextType = {
   inject: _ => {},
   injectFunction: (_, __) => {},
   injectVariable: (_, __) => {},
-  injectViaLsp: (_, __) => {},
 }
 
 export const EditorContext = createContext<EditorContextType>(DEFAULT_CONTEXT)
 
 export const EditorProvider: FC = ({children}) => {
   const [editor, setEditorOnState] = useState<EditorType>(null)
-  const [connection, setConnection] =
-    useState<React.MutableRefObject<LspConnectionManager>>(null)
 
-  const setEditor = (ed, conn) => {
+  const setEditor = ed => {
     setEditorOnState(ed)
-    setConnection(conn)
   }
-
-  const injectViaLsp = useCallback(
-    (cmd, data: Omit<ExecuteCommandArgument, 'textDocument'>) => {
-      try {
-        if (connection?.current && !isFlagEnabled('schemaComposition')) {
-          connection.current.inject(cmd, data)
-        }
-      } catch (e) {
-        console.error(e)
-      }
-    },
-    [editor, connection?.current]
-  )
 
   const inject = useCallback(
     (options: InjectionOptions) => {
@@ -193,7 +167,6 @@ export const EditorProvider: FC = ({children}) => {
         inject,
         injectFunction,
         injectVariable,
-        injectViaLsp,
       }}
     >
       {children}


### PR DESCRIPTION
Part of influxdata/flux-lsp#584

Since we decide to remove the original injection commands in flux lsp, this PR removes the usage of these commands in ui before removing the code in flux lsp. 


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
~~- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~~
~~- [ ] Feature flagged, if applicable~~
