### PR TITLE
fix(rudderstack): update version to remove initial app flicker

### DIFF
--- a/package.json
+++ b/package.json
@@ -218,7 +218,7 @@
     "redux-thunk": "^2.3.0",
     "remark-external-links": "8.0.0",
     "reselect": "^4.1.6",
-    "rudder-sdk-js": "^1.0.16",
+    "rudder-sdk-js": "^2.14.0",
     "s2-geometry": "^1.2.10",
     "ts-jest": "27.0.7",
     "use-local-storage-state": "^9.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10761,10 +10761,10 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rudder-sdk-js@^1.0.16:
-  version "1.2.10"
-  resolved "https://registry.npmjs.org/rudder-sdk-js/-/rudder-sdk-js-1.2.10.tgz"
-  integrity sha512-+2PJ2R3f4FtgvZNhWvO7d/my377uKwOYJPS+kIVnHt5/4fopRDP0eeZ1ZGWAaabJptbvsOz/VGSJC7bV+BPdgg==
+rudder-sdk-js@^2.14.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/rudder-sdk-js/-/rudder-sdk-js-2.14.0.tgz#9149ba38997544e6ce028d9dfb44039e67c86362"
+  integrity sha512-88+U7Z2Z/rsFHyPwsSSX/ciIYv7KHQqPp628QNASYyVJQ+nJREe87Y2StpsdU7lLfMYmjjP3c6R4ipKyZeen6Q==
 
 run-parallel@^1.1.9:
   version "1.2.0"


### PR DESCRIPTION
Closes [#5624](https://github.com/influxdata/ui/issues/5624)

The [version](https://github.com/rudderlabs/rudder-sdk-js/blob/production/CHANGELOG.md#v1016---2021-03-24) we're currently using is from `2021-03-24`, there are some changes that went in here that mention [anti-flicker ](https://github.com/rudderlabs/rudder-sdk-js/pull/379/commits/9d3a557a334efc532ccf5ab23d3e2196ab3014c4) so I thought i'd try updating the version as a try at fix. 

Seems to work.


### Before:

https://user-images.githubusercontent.com/146112/187999253-a65190ea-a8df-41b8-abf6-6a48ece46a0d.mov


### After:

https://user-images.githubusercontent.com/18511823/191373378-3b70f02a-cd5d-4743-9282-e599776051c9.mov





<!-- Describe your proposed changes here. -->
<!-- Including screenshots or visuals is very helpful - a picture is worth a thousand words. -->

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
