### PR TITLE
fix: update to latest giraffe to fix font issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "@docsearch/react": "^3.0.0-alpha.37",
     "@influxdata/clockface": "^6.3.0",
     "@influxdata/flux-lsp-browser": "0.8.34",
-    "@influxdata/giraffe": "^2.34.4",
+    "@influxdata/giraffe": "^2.35.0",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",
     "abortcontroller-polyfill": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1450,10 +1450,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/flux-lsp-browser/-/flux-lsp-browser-0.8.34.tgz#9261b193593317b593420fb289a4f2ac95952fbe"
   integrity sha512-c/GytzYDOBVdVG5bXQbKLKMI9lu2vUVKjUUsCLajnbAVHs5zXllfff+ubaNdn1hGFgY/upmjcUpE/gm3FqphoQ==
 
-"@influxdata/giraffe@^2.34.4":
-  version "2.34.4"
-  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.34.4.tgz#d70ab8335eca8ed27d04632dcfb77a14220d105a"
-  integrity sha512-JntdNCTYmfMJZKfC9gkCr+i2VBWSCToqgD64LZmzINHJFmddin2vJcAT8ICb0kMHF3BymEfbhgOLwNbYSiz44g==
+"@influxdata/giraffe@^2.35.0":
+  version "2.35.0"
+  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.35.0.tgz#2d3ff63926020410ad6fff66ebbfb322ec399c75"
+  integrity sha512-P63MeApxf3ydUYk51X7pZRPu5Tu+GZ6brDYugEBQ3J6fYarkQTyG8NY2ZpSxfjfoW2IPPkum4XRzpZKviehnbQ==
   dependencies:
     merge-images "^2.0.0"
 


### PR DESCRIPTION
Closes #1673
Closes #2629

Closes https://github.com/influxdata/giraffe/issues/811

Pulls in the latest giraffe which adds the following fixes:

- fixes font sanitizer console warnings
- Gauge and SingleStat/SingleStat with Line graphs now use Proxima Nova instead of the default system serif font

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- ~[ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~
- ~[ ] Feature flagged, if applicable~
