### PR TITLE
chore: remove ability to use quartzMe

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,7 +39,6 @@ import {AppState} from 'src/types'
 // Utils
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {CLOUD} from 'src/shared/constants'
-import {shouldUseQuartzIdentity} from 'src/identity/utils/shouldUseQuartzIdentity'
 import {executeVWO} from 'src/utils/vwo'
 
 // Styles
@@ -122,9 +121,7 @@ const App: FC = () => {
       <TreeNav />
       <Suspense fallback={<PageSpinner />}>
         <Page>
-          {CLOUD && isFlagEnabled('multiOrg') && shouldUseQuartzIdentity() && (
-            <GlobalHeaderContainer />
-          )}
+          {CLOUD && isFlagEnabled('multiOrg') && <GlobalHeaderContainer />}
           <Switch>
             <Route path="/orgs/new" component={CreateOrgOverlay} />
             <Route path="/orgs/:orgID" component={SetOrg} />

--- a/src/billing/components/BillingPageContents.tsx
+++ b/src/billing/components/BillingPageContents.tsx
@@ -15,7 +15,6 @@ import {getQuartzMe} from 'src/me/selectors'
 
 // Thunks
 import {getBillingProviderThunk} from 'src/identity/actions/thunks'
-import {shouldUseQuartzIdentity} from 'src/identity/utils/shouldUseQuartzIdentity'
 
 const BillingPageContents: FC = () => {
   const dispatch = useDispatch()
@@ -26,7 +25,7 @@ const BillingPageContents: FC = () => {
       return
     }
 
-    if (shouldUseQuartzIdentity() && !quartzMe.billingProvider) {
+    if (!quartzMe.billingProvider) {
       dispatch(getBillingProviderThunk())
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps

--- a/src/identity/actions/thunks/index.ts
+++ b/src/identity/actions/thunks/index.ts
@@ -22,21 +22,12 @@ import {
   fetchOrgDetails,
 } from 'src/identity/apis/auth'
 import {convertIdentityToMe} from 'src/identity/utils/convertIdentityToMe'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
-
-// Thunks
-import {getQuartzMeThunk} from 'src/me/actions/thunks'
 
 // Error Reporting
 import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
 
 export const getQuartzIdentityThunk =
   () => async (dispatch: Dispatch<any>, getState: GetState) => {
-    if (!isFlagEnabled('quartzIdentity')) {
-      dispatch(getQuartzMeThunk())
-      return
-    }
-
     try {
       dispatch(setQuartzIdentityStatus(RemoteDataState.Loading))
 

--- a/src/identity/apis/auth.ts
+++ b/src/identity/apis/auth.ts
@@ -4,7 +4,6 @@ import {
   getAccounts,
   getAccountsOrgs,
   getIdentity,
-  getMe as getMeQuartz,
   getOrg,
   putAccountsDefault,
   putAccountsOrgsDefault,
@@ -12,7 +11,6 @@ import {
   Identity,
   IdentityAccount,
   IdentityUser,
-  Me as MeQuartz,
   Organization,
   OrganizationSummaries,
   UserAccount,
@@ -24,9 +22,6 @@ import {
   Error as IdpeError,
   UserResponse as UserResponseIdpe,
 } from 'src/client'
-
-// Feature Flag Check
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Constants
 import {CLOUD} from 'src/shared/constants'
@@ -121,11 +116,7 @@ export const fetchIdentity = async () => {
     return fetchLegacyIdentity()
   }
 
-  if (isFlagEnabled('quartzIdentity')) {
-    return fetchQuartzIdentity()
-  }
-
-  return fetchQuartzMe()
+  return fetchQuartzIdentity()
 }
 
 // fetch user identity from /quartz/identity.
@@ -134,26 +125,6 @@ export const fetchQuartzIdentity = async (): Promise<Identity> => {
 
   if (response.status === 401) {
     throw new UnauthorizedError(response.data.message)
-  }
-
-  if (response.status === 500) {
-    throw new ServerError(response.data.message)
-  }
-
-  const user = response.data
-  return user
-}
-
-// fetch user identity from /quartz/me.
-export const fetchQuartzMe = async (): Promise<MeQuartz> => {
-  const response = await getMeQuartz({})
-
-  if (response.status === 401) {
-    throw new UnauthorizedError(response.data.message)
-  }
-
-  if (response.status === 404) {
-    throw new NotFoundError(response.data.message)
   }
 
   if (response.status === 500) {

--- a/src/identity/utils/shouldUseQuartzIdentity.ts
+++ b/src/identity/utils/shouldUseQuartzIdentity.ts
@@ -1,5 +1,0 @@
-import {CLOUD} from 'src/shared/constants'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
-
-export const shouldUseQuartzIdentity = (): boolean =>
-  CLOUD && isFlagEnabled('quartzIdentity')

--- a/src/me/actions/thunks/index.ts
+++ b/src/me/actions/thunks/index.ts
@@ -9,20 +9,13 @@ import {getMe as getIdpeMe} from 'src/client'
 import {gaEvent, updateReportingContext} from 'src/cloud/utils/reporting'
 
 // Actions
-import {
-  setMe,
-  setQuartzMe,
-  setQuartzMeStatus,
-  Actions as MeActions,
-} from 'src/me/actions/creators'
+import {setMe} from 'src/me/actions/creators'
 
 // Reducers
 import {MeState} from 'src/me/reducers'
 
 // Types
-import {RemoteDataState} from 'src/types'
 import {Actions} from 'src/me/actions/creators'
-import {fetchQuartzMe} from 'src/identity/apis/auth'
 
 export const getIdpeMeThunk = () => async (dispatch: Dispatch<Actions>) => {
   try {
@@ -49,18 +42,5 @@ export const getIdpeMeThunk = () => async (dispatch: Dispatch<Actions>) => {
     dispatch(setMe(user as MeState))
   } catch (error) {
     console.error(error)
-  }
-}
-
-export const getQuartzMeThunk = () => async (dispatch: Dispatch<MeActions>) => {
-  try {
-    dispatch(setQuartzMeStatus(RemoteDataState.Loading))
-
-    const quartzMe = await fetchQuartzMe()
-
-    dispatch(setQuartzMe(quartzMe, RemoteDataState.Done))
-  } catch (error) {
-    console.error(error)
-    dispatch(setQuartzMeStatus(RemoteDataState.Error))
   }
 }

--- a/src/organizations/components/OrgProfileTab/index.tsx
+++ b/src/organizations/components/OrgProfileTab/index.tsx
@@ -17,7 +17,6 @@ import DeletePanel from 'src/organizations/components/OrgProfileTab/DeletePanel'
 
 // Utils
 import {CLOUD} from 'src/shared/constants'
-import {shouldUseQuartzIdentity} from 'src/identity/utils/shouldUseQuartzIdentity'
 
 // Selectors
 import {getMe} from 'src/me/selectors'
@@ -40,7 +39,7 @@ const OrgProfileTab: FC = () => {
   const identityOrgId = identity.currentIdentity.org.id
 
   useEffect(() => {
-    if (identityOrgId && shouldUseQuartzIdentity()) {
+    if (identityOrgId && CLOUD) {
       if (
         !me.quartzMe.regionCode ||
         !me.quartzMe.regionName ||

--- a/src/shared/components/NotFound.tsx
+++ b/src/shared/components/NotFound.tsx
@@ -21,7 +21,6 @@ import {getOrg as fetchOrg} from 'src/organizations/apis'
 // Utils
 import {buildDeepLinkingMap} from 'src/utils/deepLinks'
 import {event} from 'src/cloud/utils/reporting'
-import {shouldUseQuartzIdentity} from 'src/identity/utils/shouldUseQuartzIdentity'
 
 // Components
 import LogoWithCubo from 'src/checkout/LogoWithCubo'
@@ -140,7 +139,7 @@ const NotFound: FC = () => {
 
   const handleDeepLink = useCallback(async () => {
     if (!org.current) {
-      if (shouldUseQuartzIdentity()) {
+      if (CLOUD) {
         try {
           setIsFetchingOrg(true)
           const defaultQuartzOrg = await getDefaultAccountDefaultOrg()

--- a/src/shared/containers/SetOrg.tsx
+++ b/src/shared/containers/SetOrg.tsx
@@ -87,7 +87,6 @@ import {RemoteDataState} from '@influxdata/clockface'
 
 // Selectors
 import {getAll} from 'src/resources/selectors'
-import {shouldUseQuartzIdentity} from 'src/identity/utils/shouldUseQuartzIdentity'
 
 const SetOrg: FC = () => {
   const [loading, setLoading] = useState(RemoteDataState.Loading)
@@ -318,7 +317,7 @@ const SetOrg: FC = () => {
             />
           )}
           {/* User Profile Page */}
-          {CLOUD && shouldUseQuartzIdentity() && isFlagEnabled('multiOrg') && (
+          {CLOUD && isFlagEnabled('multiOrg') && (
             <Route
               exact
               path="/orgs/:orgId/user/profile"

--- a/src/support/components/PayGSupportOverlay.tsx
+++ b/src/support/components/PayGSupportOverlay.tsx
@@ -26,13 +26,10 @@ import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
 import {OverlayContext} from 'src/overlays/components/OverlayController'
 
 // Selectors
-import {getOrg} from 'src/organizations/selectors'
-import {getQuartzMe} from 'src/me/selectors'
 import {selectQuartzIdentity} from 'src/identity/selectors'
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'
-import {shouldUseQuartzIdentity} from 'src/identity/utils/shouldUseQuartzIdentity'
 
 // API
 import {createSfdcSupportCase} from 'src/shared/apis/sfdc'
@@ -68,9 +65,6 @@ const PayGSupportOverlay: FC<OwnProps> = () => {
   const quartzIdentity = useSelector(selectQuartzIdentity)
   const {user: identityUser, org: identityOrg} = quartzIdentity.currentIdentity
 
-  const quartzMe = useSelector(getQuartzMe)
-  const quartzOrg = useSelector(getOrg)
-
   const [subject, setSubject] = useState('')
   const [severity, setSeverity] = useState('3 - Standard')
   const [description, setDescription] = useState('')
@@ -100,20 +94,10 @@ const PayGSupportOverlay: FC<OwnProps> = () => {
   }
 
   const handleSubmit = async () => {
-    let userID: string, userEmail: string, orgName: string, orgID: string
-
-    if (shouldUseQuartzIdentity()) {
-      userID = identityUser.id
-      userEmail = identityUser.email
-      orgName = identityOrg.name
-      orgID = identityOrg.id
-    } else {
-      // Optional chaining operator needed because quartzMe's initial reducer state is null.
-      userID = quartzMe?.id
-      userEmail = quartzMe?.email
-      orgName = quartzOrg?.name
-      orgID = quartzOrg?.id
-    }
+    const userID = identityUser.id
+    const userEmail = identityUser.email
+    const orgName = identityOrg.name
+    const orgID = identityOrg.id
 
     const descriptionWithOrgId = `${description} \n\n [Org Name: ${orgName}] [Org Id: ${orgID}]`
     const translatedSeverity = translateSeverityLevelForSfdc(severity)


### PR DESCRIPTION
Connects #4821 

The `quartzIdentity` flag - which makes the UI use `/quartz/identity` instead of `/quartz/me` to support the development of the multiOrg epic - has been on in prod without issue since July 13. Any conditionals in the UI that use `quartz/me` as a fallback for `/identity` are no longer necessary.

There are 5 steps to getting rid of all references to quartzMe.

1. Remove the conditional checks in the UI that made quartzIdentity used over quartzMe when the flag was on. Also remove any related thunks and API calls. (THIS PR)

NOTE: This doesn't have any effect in prod since the flag is on everywhere. It _DOES_ have an immediate effect on the UI e2e tests, which try to hit /quartz/me until `cy.setFeatureFlags` turns `quartzIdentity` on.

2. Remove the _conversion_ functions in the UI that make the app use `/identity` in the same data shape as `/quartz/me`.

Instead, the UI should be referencing the `state.identity.currentIdentity` state directly.

3. Remove /quartz/me from quartz-mock since it is no longer used.

4. Remove the flag settings in the e2e tests that reference /identity.

5. Remove the feature flag in ConfigCat and IDPE.

UI After Removal
--

https://user-images.githubusercontent.com/91283923/191611819-78252eec-39d1-4725-8b76-4c54cdffc62e.mov



### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - NO - reflects removal of quartzIdentity flag.
