### PR TITLE
fix(reporting): guards to prevent accessing null values from useSelector

### DIFF
--- a/src/cloud/components/experiments/GoogleOptimizeExperiment.tsx
+++ b/src/cloud/components/experiments/GoogleOptimizeExperiment.tsx
@@ -36,7 +36,7 @@ export const GoogleOptimizeExperiment: FC<Props> = ({
       getExperimentVariantId(experimentID, activationEvent)
     )
 
-    if (variantID) {
+    if (org && me && variantID) {
       event(
         'optimize.user_variant',
         {},
@@ -48,7 +48,7 @@ export const GoogleOptimizeExperiment: FC<Props> = ({
         }
       )
     }
-  })
+  }, [org, me])
 
   if (variantID) {
     return [original, ...variants][variantID] || original


### PR DESCRIPTION
Closes [#5628](https://github.com/influxdata/ui/issues/5628)

My hypothesis of what was happening: 

`useSelector` is an async operation, and the current config of useEffect hook it runs on `mount` as well as `update`.

Perhaps we don't need to run this on mount, i.e. when the org info isn't retrieved yet. 

We can see these errors in honey-badger occasionally. Seems like a race condition. 

<img width="1208" alt="Screen Shot 2022-09-21 at 12 00 24 PM" src="https://user-images.githubusercontent.com/18511823/191591490-6e2100fa-75e2-4624-b6b9-661d3439203f.png">

<img width="1183" alt="Screen Shot 2022-09-21 at 12 00 12 PM" src="https://user-images.githubusercontent.com/18511823/191591518-48f74eee-d8d7-43c4-a4d0-35760aa9302e.png">

`
<!-- Describe your proposed changes here. -->
<!-- Including screenshots or visuals is very helpful - a picture is worth a thousand words. -->

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
