### PR TITLE
fix: add caching to color visualization calculation

### DIFF
--- a/src/visualization/utils/colorMappingUtils.ts
+++ b/src/visualization/utils/colorMappingUtils.ts
@@ -155,9 +155,9 @@ export const generateSeriesToColorHex = (
   columnGroupMap,
   properties: XYViewProperties
 ) => {
+  const cache = {}
   const seriesToColorHex = {}
-  const cgMap = {...columnGroupMap}
-  cgMap.mappings.forEach((graphLine, colorIndex) => {
+  columnGroupMap.mappings.forEach((graphLine, colorIndex) => {
     const id = getSeriesId(graphLine, columnGroupMap.columnKeys)
     let colors
     if (Array.isArray(properties.colors) && properties.colors.length) {
@@ -168,9 +168,21 @@ export const generateSeriesToColorHex = (
       colors = DEFAULT_LINE_COLORS
     }
     const colorsHexArray = colors.map(value => value.hex)
-    const fillScale = getNominalColorScale(columnGroupMap, colorsHexArray)
+    const key = colorsHexArray.join('')
+    let fillScale
+    if (cache[key]) {
+      fillScale = cache[key]
+    } else {
+      /**
+       * this is an expensive operation to perform, so we want to cache the result and use the returned function
+       * Since the size of the columnGroupMap is the same in the context of each function, we can rely upon the
+       * colorsHexArray as our unique key identifier and rely upon that for caching the reuslts
+       */
+      fillScale = getNominalColorScale(columnGroupMap, colorsHexArray)
+      cache[key] = fillScale
+    }
     seriesToColorHex[id] = fillScale(colorIndex)
   })
 
-  return {...seriesToColorHex}
+  return seriesToColorHex
 }


### PR DESCRIPTION
In pursuing some performance diagnostics for SimpleTable, I noticed that the Line Plot really struggled with queries that returned a disparate set of results. More specifically, the following query would seize the browser and in some cases, crash it:

```
from(bucket: "sample_bucket")
    |> range(start: -1h)
```

After a lengthy diagnosis, I was able to narrow down the the latency to this particular line:

https://github.com/influxdata/ui/blob/master/src/visualization/utils/colorMappingUtils.ts#L171

While I did make attempts to speed the operation of the `createNominalColorScale` method, each individual part in it runs fairly quickly (about 1-3ms per operation, depending on which one). The slowness comes in the aggregation of those operations. Upon further inspection, it looks we're performing the operation multiple times with the same values, hence the caching.

Here is a screenshot of the performance differences with the caching vs without:

**CACHING**
![Screen Shot 2022-09-21 at 1 35 02 PM](https://user-images.githubusercontent.com/19984220/191606395-53f1aec3-7d88-4fae-aaa8-01dd279f9386.png)

**WITHOUT CACHING**
![Screen Shot 2022-09-21 at 1 36 40 PM](https://user-images.githubusercontent.com/19984220/191606404-d818d9c3-2a6c-4701-9234-ab5f9159561c.png)

### Steps to Reproduce
To reproduce the slowness, all you need to do is run query above. Pull down these changes and see the performance differences. Crank up the timerange to test the limits




