### PR TITLE
fix: if no new cert is provided a user should be able to submit

### DIFF
--- a/src/writeData/subscriptions/utils/form.ts
+++ b/src/writeData/subscriptions/utils/form.ts
@@ -237,7 +237,7 @@ const checkNoneSelected = (form: Subscription): boolean =>
   !form.brokerUsername &&
   !form.brokerPassword &&
   !form.brokerCACert &&
-  !form.brokerCACert &&
+  !form.brokerClientCert &&
   !form.brokerClientKey
 
 const checkBasicSelected = (form: Subscription): boolean =>
@@ -245,16 +245,21 @@ const checkBasicSelected = (form: Subscription): boolean =>
   !!form.brokerUsername &&
   (!!form.id || !!form.brokerPassword) // only require a password when a subscription is being created, not edited.
 
-const checkCertificateSelected = (form: Subscription): boolean =>
+const checkCertificateRequiredFields = (form: Subscription): boolean =>
   form.authType === BrokerAuthTypes.Certificate &&
   !!form.brokerCACert &&
+  // you either need to provide both or neither
   ((!!form.brokerClientCert && !!form.brokerClientKey) ||
     (!form.brokerClientCert && !form.brokerClientKey))
+
+const checkCreatingCertificate = (form: Subscription): boolean =>
+  form.authType === BrokerAuthTypes.Certificate && !form.brokerCertCreationDate
 
 export const checkSecurityFields = (form: Subscription): boolean =>
   checkNoneSelected(form) ||
   checkBasicSelected(form) ||
-  checkCertificateSelected(form)
+  !checkCreatingCertificate(form) ||
+  checkCertificateRequiredFields(form)
 
 export const checkRequiredStringFields = (form: Subscription): boolean => {
   if (form.dataFormat !== 'string') {

--- a/src/writeData/subscriptions/utils/form.ts
+++ b/src/writeData/subscriptions/utils/form.ts
@@ -258,8 +258,8 @@ const checkCreatingCertificate = (form: Subscription): boolean =>
 export const checkSecurityFields = (form: Subscription): boolean =>
   checkNoneSelected(form) ||
   checkBasicSelected(form) ||
-  (!checkCreatingCertificate(form) ||
-  checkCertificateRequiredFields(form))
+  !checkCreatingCertificate(form) ||
+  checkCertificateRequiredFields(form)
 
 export const checkRequiredStringFields = (form: Subscription): boolean => {
   if (form.dataFormat !== 'string') {

--- a/src/writeData/subscriptions/utils/form.ts
+++ b/src/writeData/subscriptions/utils/form.ts
@@ -258,8 +258,8 @@ const checkCreatingCertificate = (form: Subscription): boolean =>
 export const checkSecurityFields = (form: Subscription): boolean =>
   checkNoneSelected(form) ||
   checkBasicSelected(form) ||
-  !checkCreatingCertificate(form) ||
-  checkCertificateRequiredFields(form)
+  (!checkCreatingCertificate(form) ||
+  checkCertificateRequiredFields(form))
 
 export const checkRequiredStringFields = (form: Subscription): boolean => {
   if (form.dataFormat !== 'string') {


### PR DESCRIPTION
related https://github.com/influxdata/data-acquisition/issues/532

A user should be able to edit their certificate subscription even if they haven't replaced their certificate 

- [x] updated the required field checks so that if a user doesn't replace the certificate they are able to submit ie brokerCertCreationDate is returned to the ui from the db and if they have cert auth and set to null if they change auth type or hit replace

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
