### PR TITLE
chore: upgrade clockface to 6.3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
   "dependencies": {
     "@codingame/monaco-jsonrpc": "^0.3.1",
     "@docsearch/react": "^3.0.0-alpha.37",
-    "@influxdata/clockface": "^6.3.0",
+    "@influxdata/clockface": "^6.3.5",
     "@influxdata/flux-lsp-browser": "0.8.34",
     "@influxdata/giraffe": "^2.35.0",
     "@influxdata/influxdb-templates": "0.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1429,10 +1429,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@influxdata/clockface@^6.3.0":
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-6.3.0.tgz#92baecff3f9ee23ddf1e44eeb7cb828e6ceba633"
-  integrity sha512-+3tQbgwDtbfhQJa6OnO5lJS8D+1/FFIfpVxTHU4oR/oiebGJAOkuLmB7G7S3a515HL3HNhcy323zkWT3IPBQrQ==
+"@influxdata/clockface@^6.3.5":
+  version "6.3.5"
+  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-6.3.5.tgz#052a7b6022fc8800d65b98576b2d3cade1d3b3e9"
+  integrity sha512-ronbXnqhv00YHiQvHTLWMAy6fduaugv8XPiZveUYWQKhtWDN8OLVjNrdLlN6cyI1jR3v0tRV/G63I0G8/UstPg==
   dependencies:
     "@types/react-window" "^1.8.5"
     react-window "^1.8.7"


### PR DESCRIPTION
Part of #5757 

Update clockface version to 6.3.5 release https://github.com/influxdata/clockface/releases/tag/V6.3.5

This brings in a clockface fix for the draggable resizer component that will be used in new script editor

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
~~- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~~
~~- [ ] Feature flagged, if applicable~~
