### PR TITLE
chore: update icon for Open and Save

### DIFF
--- a/src/dataExplorer/components/FluxQueryBuilder.tsx
+++ b/src/dataExplorer/components/FluxQueryBuilder.tsx
@@ -151,7 +151,7 @@ const FluxQueryBuilder: FC = () => {
                     className="flux-query-builder__action-button"
                     onClick={() => setOverlayType(OverlayType.OPEN)}
                     text="Open"
-                    icon={IconFont.Export_New}
+                    icon={IconFont.FolderOpen}
                   />
                 )}
                 {isFlagEnabled('saveAsScript') && (
@@ -164,7 +164,7 @@ const FluxQueryBuilder: FC = () => {
                         : ComponentStatus.Disabled
                     }
                     text="Save"
-                    icon={IconFont.Save}
+                    icon={IconFont.SaveOutline}
                   />
                 )}
               </div>


### PR DESCRIPTION
Closes #5755 

This PR updates two new icons from clockface

## Before
<img width="536" alt="Screen Shot 2022-09-22 at 9 26 17 AM" src="https://user-images.githubusercontent.com/14298407/191773886-3901de42-4fb5-4165-99be-57f82e4f8d21.png">

## After
<img width="568" alt="Screen Shot 2022-09-22 at 9 24 24 AM" src="https://user-images.githubusercontent.com/14298407/191773936-b4eb7826-a656-4d6f-9b42-041ddb02ac1d.png">

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
~~- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~~
~~- [ ] Feature flagged, if applicable~~
