### PR TITLE
fix: tags and fields are pointer objects, so stop resetting with the same pointer to a stateful object.

### DIFF
--- a/src/dataExplorer/context/fields.tsx
+++ b/src/dataExplorer/context/fields.tsx
@@ -50,7 +50,9 @@ export const FieldsProvider: FC<Prop> = ({children, scope}) => {
   const {query: queryAPI} = useContext(QueryContext)
 
   // States
-  const [fields, setFields] = useState<Array<string>>(INITIAL_FIELDS)
+  const [fields, setFields] = useState<Array<string>>(
+    JSON.parse(JSON.stringify(INITIAL_FIELDS))
+  )
   const [loading, setLoading] = useState<RemoteDataState>(
     RemoteDataState.NotStarted
   )
@@ -121,7 +123,7 @@ export const FieldsProvider: FC<Prop> = ({children, scope}) => {
   }
 
   const resetFields = () => {
-    setFields(INITIAL_FIELDS)
+    setFields(JSON.parse(JSON.stringify(INITIAL_FIELDS)))
     setLoading(RemoteDataState.NotStarted)
   }
 

--- a/src/dataExplorer/context/tags.tsx
+++ b/src/dataExplorer/context/tags.tsx
@@ -61,7 +61,9 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
   const {query: queryAPI} = useContext(QueryContext)
 
   // States
-  const [tags, setTags] = useState<Tags>(INITIAL_TAGS)
+  const [tags, setTags] = useState<Tags>(
+    JSON.parse(JSON.stringify(INITIAL_TAGS))
+  )
   const [loadingTagKeys, setLoadingTagKeys] = useState<RemoteDataState>(
     RemoteDataState.NotStarted
   )
@@ -222,7 +224,7 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
   }
 
   const resetTags = () => {
-    setTags(INITIAL_TAGS)
+    setTags(JSON.parse(JSON.stringify(INITIAL_TAGS)))
     setLoadingTagKeys(RemoteDataState.NotStarted)
     setLoadingTagValues(INITIAL_LOADING_TAG_VALUES)
   }


### PR DESCRIPTION
## Bug:
* fields was holding state
* session itself was correctly updating

https://user-images.githubusercontent.com/10232835/191843865-473eea69-58bf-48eb-91e9-2410d82ca0fa.mov

* error disappeared on page reload -- so is the non-session store.
* we were using the same pointer object when resetting fields, and tags. Fixed that code.
