### PR TITLE
fix: enable schema browser when diverged, and fix divergence detection with multiline deletion event.

### DIFF
--- a/cypress/e2e/shared/fluxQueryBuilder.test.ts
+++ b/cypress/e2e/shared/fluxQueryBuilder.test.ts
@@ -28,6 +28,7 @@ describe('Script Builder', () => {
               )
             }
             cy.writeData(writeData, 'defbuck')
+            cy.writeData(writeData, 'defbuck2')
             cy.wait(100)
             cy.getByTestID('flux-query-builder-toggle').then($toggle => {
               cy.wrap($toggle).should('be.visible')
@@ -277,6 +278,15 @@ describe('Script Builder', () => {
 
         cy.log('toggle is now disabled')
         cy.getByTestID('flux-sync--toggle').should('have.class', 'disabled')
+
+        cy.log('can still browse schema while diverged')
+        cy.getByTestID('bucket-selector--dropdown-button').click()
+        cy.getByTestID('bucket-selector--search-bar').type('defbuck2')
+        cy.getByTestID(`bucket-selector--dropdown--defbuck2`).click()
+        cy.getByTestID('bucket-selector--dropdown-button').should(
+          'contain',
+          'defbuck2'
+        )
       })
 
       it('should clear the editor text, and schema browser, with a new script', () => {

--- a/cypress/e2e/shared/fluxQueryBuilder.test.ts
+++ b/cypress/e2e/shared/fluxQueryBuilder.test.ts
@@ -12,23 +12,22 @@ const DEFAULT_SCHEMA = {
 }
 
 describe('Script Builder', () => {
+  const writeData: string[] = []
+  for (let i = 0; i < 30; i++) {
+    writeData.push(`ndbc,air_temp_degc=70_degrees station_id_${i}=${i}`)
+  }
+
   beforeEach(() => {
     cy.flush().then(() => {
       cy.signin().then(() => {
-        cy.get('@org').then(({id}: Organization) => {
+        cy.get('@org').then(({id, name}: Organization) => {
           cy.visit(`/orgs/${id}/data-explorer`)
           cy.getByTestID('tree-nav').should('be.visible')
           cy.setFeatureFlags({
             newDataExplorer: true,
           }).then(() => {
-            const writeData = []
-            for (let i = 0; i < 30; i++) {
-              writeData.push(
-                `ndbc,air_temp_degc=70_degrees station_id_${i}=${i}`
-              )
-            }
+            cy.createBucket(id, name, 'defbuck2')
             cy.writeData(writeData, 'defbuck')
-            cy.writeData(writeData, 'defbuck2')
             cy.wait(100)
             cy.getByTestID('flux-query-builder-toggle').then($toggle => {
               cy.wrap($toggle).should('be.visible')
@@ -192,6 +191,8 @@ describe('Script Builder', () => {
       '// Start by selecting data from the schema browser or typing flux here'
 
     beforeEach(() => {
+      cy.writeData(writeData, 'defbuck2')
+
       window.sessionStorage.setItem(
         'dataExplorer.schema',
         JSON.parse(JSON.stringify(DEFAULT_SCHEMA))
@@ -281,7 +282,6 @@ describe('Script Builder', () => {
 
         cy.log('can still browse schema while diverged')
         cy.getByTestID('bucket-selector--dropdown-button').click()
-        cy.getByTestID('bucket-selector--search-bar').type('defbuck2')
         cy.getByTestID(`bucket-selector--dropdown--defbuck2`).click()
         cy.getByTestID('bucket-selector--dropdown-button').should(
           'contain',

--- a/src/dataExplorer/context/persistance.tsx
+++ b/src/dataExplorer/context/persistance.tsx
@@ -132,7 +132,8 @@ export const PersistanceProvider: FC = ({children}) => {
 
   const setSchemaSelection = useCallback(
     schema => {
-      if (selection.composition?.diverged && schema.composition.synced) {
+      if (selection.composition?.diverged && schema.composition?.synced) {
+        // cannot re-sync if diverged
         return
       }
       const nextState: SchemaSelection = {

--- a/src/languageSupport/languages/flux/lsp/connection.ts
+++ b/src/languageSupport/languages/flux/lsp/connection.ts
@@ -144,11 +144,25 @@ class LspConnectionManager {
       return false
     }
     const {startLine, endLine} = compositionBlock
-    return (
+
+    const changeInBlock =
       change.range.startLineNumber >= startLine &&
-      (change.range.endLineNumber <= endLine ||
-        change.text.includes(COMPOSITION_YIELD))
-    )
+      change.range.endLineNumber <= endLine
+
+    const changeWithCompositionIdentifier =
+      change.text.includes(COMPOSITION_YIELD)
+
+    const isDeletion = change.text == ''
+    let deletionFromBlock = false
+    if (isDeletion) {
+      const linesDeleted =
+        change.range.endLineNumber - change.range.startLineNumber
+      deletionFromBlock =
+        change.range.startLineNumber >= startLine &&
+        change.range.endLineNumber <= endLine + linesDeleted
+    }
+
+    return changeInBlock || changeWithCompositionIdentifier || deletionFromBlock
   }
 
   _setEditorIrreversibleExit() {


### PR DESCRIPTION
Closes #5874 https://github.com/influxdata/ui/issues/5874

## Bug
Found by @barbaranelson . Is actually 2 bugs:
1. edge case when divergence is not detected.
   * a multiline deletion (which changes the size of the composition block) may not be detected as a change within the block
2. on divergence, should still be able to browse the schema
   * this is a NPE which prevents session updates. (`schema.composition.<prop>` will NPE.)
   * also made a test to check for the general use case (of schema browsing after divergence)


Vid of bug. Bugs are show in order:

https://user-images.githubusercontent.com/10232835/191865422-b85c39e8-0b8c-41fc-aab0-3e0be93e5424.mov


## Fixed:

https://user-images.githubusercontent.com/10232835/191866390-0cf7f7a5-ffd4-4804-b972-84ad432a2a51.mov



## Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] ~Feature flagged, if applicable~ N/A
