### PR TITLE
fix: resolve flakiness in gh test by filling gaps in call to makeQuartzUseIDPEOrgID()

### DIFF
--- a/cypress/e2e/cloud/globalHeader.test.ts
+++ b/cypress/e2e/cloud/globalHeader.test.ts
@@ -21,6 +21,7 @@ describe('change-account change-org global header', () => {
 
     cy.fixture('multiOrgIdentity').then(quartzIdentity => {
       quartzIdentity.org.id = idpeOrgID
+
       cy.intercept('GET', 'api/v2/quartz/identity', quartzIdentity).as(
         'getQuartzIdentity'
       )
@@ -63,6 +64,7 @@ describe('change-account change-org global header', () => {
           method: 'GET',
           url: 'api/v2/orgs',
         }).then(res => {
+          makeQuartzUseIDPEOrgID()
           // Store the IDPE org ID so that it can be cloned when intercepting quartz.
           if (res.body.orgs) {
             idpeOrgID = res.body.orgs[0].id
@@ -74,6 +76,7 @@ describe('change-account change-org global header', () => {
 
   beforeEach(() => {
     // Preserve one session throughout.
+    makeQuartzUseIDPEOrgID()
     Cypress.Cookies.preserveOnce('sid')
     cy.setFeatureFlags(globalHeaderFeatureFlags)
   })
@@ -133,8 +136,9 @@ describe('change-account change-org global header', () => {
       })
 
       it('navigates to the org usage page', () => {
-        cy.getByTestID('globalheader--org-dropdown').should('exist').click()
+        makeQuartzUseIDPEOrgID()
 
+        cy.getByTestID('globalheader--org-dropdown').should('exist').click()
         cy.getByTestID('globalheader--org-dropdown-main').should('be.visible')
         cy.getByTestID('globalheader--org-dropdown-main-Usage')
           .should('be.visible')
@@ -178,6 +182,7 @@ describe('change-account change-org global header', () => {
       })
 
       before(() => {
+        makeQuartzUseIDPEOrgID()
         cy.visit('/')
       })
 


### PR DESCRIPTION
Closes #5869 

The globalheader test requires temporarily syncing the IDPE org id and the quartz-mock org id using `cy.intercept()`. The function that does that should be invoked in every test. There were some gaps that, in local testing, appeared to be providing an opportunity for the `orgs` and `identity` endpoints to get called again, which would reset the synchronization of the IDPE and quartz ids.

Passed 20x firefox, 20x chrome.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - none, but uses `multiOrg` feature flag (`quartzIdentity` is now on everywhere with flag doing no additional work).
