### PR TITLE
fix: resolve flaky about test 

### DIFF
--- a/cypress/e2e/shared/about.test.ts
+++ b/cypress/e2e/shared/about.test.ts
@@ -1,10 +1,18 @@
 import {Organization} from '../../../src/types'
 
 describe('About Page', () => {
+  const apiOrgPath =
+    Cypress.env('dexUrl') === 'OSS' ? '/api/v2/orgs/*' : '/api/v2/quartz/orgs/*'
+  const CLOUD = Cypress.env('dexUrl') === 'OSS' ? false : true
+
   beforeEach(() => {
     cy.flush()
     cy.signin()
 
+    cy.intercept('GET', apiOrgPath).as('getOrg')
+    cy.intercept('GET', `${apiOrgPath}/users`).as('getOrgUsers')
+    cy.intercept('GET', `${apiOrgPath}/invites`).as('getOrgInvites')
+    cy.intercept('PATCH', apiOrgPath).as('patchOrg')
     cy.get('@org').then((org: Organization) => {
       cy.visit(`/orgs/${org.id}/org-settings`)
       cy.getByTestID('about-page--header').should('be.visible')
@@ -12,17 +20,22 @@ describe('About Page', () => {
   })
 
   it('should display everything correctly', () => {
-    cy.getByTestID('common-ids--panel').within(() => {
-      cy.getByTestID('code-snippet--userid').should('exist')
-      cy.getByTestID('copy-btn--userid').should('not.be.disabled')
+    if (CLOUD) {
+      cy.wait('@getOrg')
+      cy.wait('@getOrgUsers')
+      cy.wait('@getOrgInvites')
+    }
+    cy.getByTestID('code-snippet--userid').should('be.visible')
+    cy.getByTestID('copy-btn--userid').should('not.be.disabled')
 
-      cy.getByTestID('code-snippet--orgid').should('exist')
-      cy.getByTestID('copy-btn--orgid').should('not.be.disabled')
-    })
+    cy.getByTestID('code-snippet--orgid').should('be.visible')
+    cy.getByTestID('copy-btn--orgid').should('not.be.disabled')
 
-    cy.getByTestID('organization-profile--panel').within(() => {
-      cy.getByTestID('rename-org--button').click()
-    })
+    if (CLOUD) {
+      cy.getByTestID('org-profile--panel').contains('Cloud Provider')
+    }
+
+    cy.getByTestID('rename-org--button').should('be.visible').click()
 
     cy.getByTestID('danger-confirmation--button').click()
     cy.getByTestID('form--element-error').should('not.exist')
@@ -41,10 +54,6 @@ describe('About Page', () => {
 
     const newOrgName = `hard@knock.life${Math.random()}`
 
-    const patchOrgPath =
-      Cypress.env('dexUrl') === 'OSS' ? 'api/v2/orgs/*' : 'api/v2/quartz/orgs/*'
-
-    cy.intercept('PATCH', patchOrgPath).as('patchOrg')
     cy.getByTestID('create-org-name-input').type(newOrgName)
     cy.getByTestID('rename-org-submit--button')
       .should('not.be.disabled')


### PR DESCRIPTION
The shared `about` test in the Cloud CI run has gone flaky in firefox. In firefox, the org Rename button is deemed visible, but on click, it's deemed detached from the DOM. 

Underlying cause is the `useEffect` hook in this component. This page requires a separate network call in cloud to retrieve additional information about the user's org. The cypress test verifies that the rename button is visible, but the panel re-renders on response from the new network call, which causes cypress to find the previously identified element detached from the DOM.

Credit to @TCL735 for the more comprehensive fix here, which explicitly waits for the response from that network call in cloud before checking for the rename button.

Repro:
--

https://user-images.githubusercontent.com/91283923/191995187-d050890b-e0b1-48d4-8c06-44f089856a7a.mov

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable
