### PR TITLE
chore: remove refs to quartzMe data shape in onboarding experience

### DIFF
--- a/src/homepageExperience/components/steps/arduino/InitializeClient.tsx
+++ b/src/homepageExperience/components/steps/arduino/InitializeClient.tsx
@@ -24,6 +24,7 @@ import {WriteDataDetailsContext} from 'src/writeData/components/WriteDataDetails
 // Selectors
 import {getOrg} from 'src/organizations/selectors'
 import {getMe} from 'src/me/selectors'
+import {selectCurrentIdentity} from 'src/identity/selectors'
 import {getAllTokensResources} from 'src/resources/selectors'
 
 // Utils
@@ -52,10 +53,11 @@ export const InitializeClient: FC<OwnProps> = ({
 }) => {
   const org = useSelector(getOrg)
   const me = useSelector(getMe)
+  const {org: quartzOrg} = useSelector(selectCurrentIdentity)
+
   const allPermissionTypes = useSelector(getAllTokensResources)
   const dispatch = useDispatch()
-  const url =
-    me.quartzMe?.clusterHost || 'https://us-west-2-1.aws.cloud2.influxdata.com/'
+  const url = quartzOrg.clusterHost || window.location.origin
   const currentAuth = useSelector((state: AppState) => {
     return state.resources.tokens.currentAuth.item
   })

--- a/src/homepageExperience/components/steps/cli/InitializeClient.tsx
+++ b/src/homepageExperience/components/steps/cli/InitializeClient.tsx
@@ -11,6 +11,7 @@ import {
 // Selectors
 import {getOrg} from 'src/organizations/selectors'
 import {getMe} from 'src/me/selectors'
+import {selectCurrentIdentity} from 'src/identity/selectors'
 import {getAllTokensResources} from 'src/resources/selectors'
 
 // Thunks
@@ -60,10 +61,11 @@ export const InitializeClient: FC<OwnProps> = ({
 }) => {
   const org = useSelector(getOrg)
   const me = useSelector(getMe)
+  const {org: quartzOrg} = useSelector(selectCurrentIdentity)
+
   const allPermissionTypes = useSelector(getAllTokensResources)
   const dispatch = useDispatch()
-  const url =
-    me.quartzMe?.clusterHost || 'https://us-west-2-1.aws.cloud2.influxdata.com/'
+  const url = quartzOrg.clusterHost || window.location.origin
   const currentAuth = useSelector((state: AppState) => {
     return state.resources.tokens.currentAuth.item
   })

--- a/src/homepageExperience/components/steps/go/InitializeClient.tsx
+++ b/src/homepageExperience/components/steps/go/InitializeClient.tsx
@@ -4,31 +4,30 @@ import {useSelector} from 'react-redux'
 import CodeSnippet from 'src/shared/components/CodeSnippet'
 import {event} from 'src/cloud/utils/reporting'
 
-import {getMe} from 'src/me/selectors'
+import {selectCurrentIdentity} from 'src/identity/selectors'
 
 const logCopyCodeSnippet = () => {
   event('firstMile.goWizard.initializeClient.code.copied')
 }
 
 export const InitializeClient = () => {
-  const me = useSelector(getMe)
+  const {org} = useSelector(selectCurrentIdentity)
 
-  const url =
-    me.quartzMe?.clusterHost || 'https://us-west-2-1.aws.cloud2.influxdata.com/'
+  const url = org.clusterHost || window.location.origin
 
   const codeSnippet = `package main
 
 import (
-	"os"
+  "os"
 
-	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
-	"github.com/influxdata/influxdb-client-go/v2/api/write"
+  influxdb2 "github.com/influxdata/influxdb-client-go/v2"
+  "github.com/influxdata/influxdb-client-go/v2/api/write"
 )
 
 func main() {
-	token := os.Getenv("INFLUXDB_TOKEN")
-	url := "${url}"
-	client := influxdb2.NewClient(url, token)
+  token := os.Getenv("INFLUXDB_TOKEN")
+  url := "${url}"
+  client := influxdb2.NewClient(url, token)
 }`
 
   return (

--- a/src/homepageExperience/components/steps/nodejs/InitializeClient.tsx
+++ b/src/homepageExperience/components/steps/nodejs/InitializeClient.tsx
@@ -4,17 +4,16 @@ import {useSelector} from 'react-redux'
 import CodeSnippet from 'src/shared/components/CodeSnippet'
 import {event} from 'src/cloud/utils/reporting'
 
-import {getMe} from 'src/me/selectors'
+import {selectCurrentIdentity} from 'src/identity/selectors'
 
 const logCopyCodeSnippet = () => {
   event('firstMile.nodejsWizard.initializeClient.code.copied')
 }
 
 export const InitializeClient = () => {
-  const me = useSelector(getMe)
+  const {org} = useSelector(selectCurrentIdentity)
 
-  const url =
-    me.quartzMe?.clusterHost || 'https://us-west-2-1.aws.cloud2.influxdata.com/'
+  const url = org.clusterHost || window.location.origin
 
   const codeSnippet = `repl.repl.ignoreUndefined=true
 
@@ -33,7 +32,7 @@ const client = new InfluxDB({url, token})`
       </p>
       <CodeSnippet text="node" language="properties" />
       <p style={{marginTop: '40px'}}>
-        Paste the following code after the prompt (>) and press Enter.
+        Paste the following code after the prompt (&gt;) and press Enter.
       </p>
       <CodeSnippet
         text={codeSnippet}

--- a/src/homepageExperience/components/steps/python/InitializeClient.tsx
+++ b/src/homepageExperience/components/steps/python/InitializeClient.tsx
@@ -5,7 +5,7 @@ import CodeSnippet from 'src/shared/components/CodeSnippet'
 import {event} from 'src/cloud/utils/reporting'
 
 import {getOrg} from 'src/organizations/selectors'
-import {getMe} from 'src/me/selectors'
+import {selectCurrentIdentity} from 'src/identity/selectors'
 
 const logCopyCodeSnippet = () => {
   event('firstMile.pythonWizard.initializeClient.code.copied')
@@ -13,10 +13,9 @@ const logCopyCodeSnippet = () => {
 
 export const InitializeClient = () => {
   const org = useSelector(getOrg)
-  const me = useSelector(getMe)
+  const {org: quartzOrg} = useSelector(selectCurrentIdentity)
 
-  const url =
-    me.quartzMe?.clusterHost || 'https://us-west-2-1.aws.cloud2.influxdata.com/'
+  const url = quartzOrg.clusterHost || window.location.origin
 
   const pythonCode = `import influxdb_client, os, time
 from influxdb_client import InfluxDBClient, Point, WritePrecision
@@ -37,7 +36,8 @@ client = influxdb_client.InfluxDBClient(url=url, token=token, org=org)
       </p>
       <CodeSnippet text="python3" language="properties" />
       <p style={{marginTop: '40px'}}>
-        Paste the following code after the prompt (>>>) and press Enter.
+        Paste the following code after the prompt (&gt;&gt;&gt;) and press
+        Enter.
       </p>
       <CodeSnippet
         text={pythonCode}


### PR DESCRIPTION
Connects issue [#4821](https://github.com/influxdata/ui/issues/4821) and PR #5847 

Removes references to the quartzMe data shape from the homepage experience portion of the app.

This is one of several PRs that are going to remove references to the `quartzMe` data shape. The app no longer uses `quartzMe`, but is still referencing properties using the old `quartzMe` selectors (which are populated using a conversion function from the `identity` api). 

All references using the old selector will be removed; then the conversion function that populates the `quartzMe` reducer using the identity data will be removed.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - NO
