### PR TITLE
chore: remove refs to quartzMe shape in account and billing

### DIFF
--- a/src/accounts/CancellationOverlay.tsx
+++ b/src/accounts/CancellationOverlay.tsx
@@ -1,5 +1,6 @@
 // Libraries
 import React, {FC, useContext, useMemo, useState} from 'react'
+import {useDispatch, useSelector} from 'react-redux'
 import {
   Overlay,
   Alert,
@@ -16,17 +17,23 @@ import {
   CancelServiceContext,
   VariableItems,
 } from 'src/billing/components/PayAsYouGo/CancelServiceContext'
-import {track} from 'rudder-sdk-js'
-import {event} from 'src/cloud/utils/reporting'
-import {useDispatch, useSelector} from 'react-redux'
-import {getQuartzMe} from 'src/me/selectors'
-import {getOrg} from 'src/organizations/selectors'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
-import {postSignout} from 'src/client'
-import {postCancel} from 'src/client/unityRoutes'
-import {getErrorMessage} from 'src/utils/api'
+
+// Selectors
+import {selectCurrentIdentity} from 'src/identity/selectors'
+
+// Notifications
 import {accountCancellationError} from 'src/shared/copy/notifications'
 import {notify} from 'src/shared/actions/notifications'
+
+// Utils
+import {event} from 'src/cloud/utils/reporting'
+import {getErrorMessage} from 'src/utils/api'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import {track} from 'rudder-sdk-js'
+
+// Routes
+import {postSignout} from 'src/client'
+import {postCancel} from 'src/client/unityRoutes'
 
 interface Props {
   onHideOverlay: () => void
@@ -42,9 +49,9 @@ const CancellationOverlay: FC<Props> = ({onHideOverlay}) => {
     shortSuggestion,
     getRedirectLocation,
   } = useContext(CancelServiceContext)
-  const quartzMe = useSelector(getQuartzMe)
-  const org = useSelector(getOrg)
   const dispatch = useDispatch()
+
+  const {user, account, org} = useSelector(selectCurrentIdentity)
 
   const handleCancelAccount = async () => {
     try {
@@ -69,8 +76,8 @@ const CancellationOverlay: FC<Props> = ({onHideOverlay}) => {
 
     const payload = {
       org: org.id,
-      tier: quartzMe?.accountType,
-      email: quartzMe?.email,
+      tier: account.type,
+      email: user.email,
       alternativeProduct: shortSuggestion,
       suggestions,
       reason: VariableItems[reason],
@@ -97,8 +104,8 @@ const CancellationOverlay: FC<Props> = ({onHideOverlay}) => {
   const handleDismiss = () => {
     const payload = {
       org: org.id,
-      tier: quartzMe?.accountType,
-      email: quartzMe?.email,
+      tier: account.type,
+      email: user.email,
     }
     event('CancelServiceDismissed Event', payload)
 

--- a/src/billing/components/BillingPageContents.tsx
+++ b/src/billing/components/BillingPageContents.tsx
@@ -11,34 +11,34 @@ import BillingPayAsYouGo from 'src/billing/components/PayAsYouGo/PayAsYouGo'
 import MarketplaceBilling from 'src/billing/components/marketplace/MarketplaceBilling'
 
 // Utils
-import {getQuartzMe} from 'src/me/selectors'
+import {selectCurrentIdentity} from 'src/identity/selectors'
 
 // Thunks
 import {getBillingProviderThunk} from 'src/identity/actions/thunks'
 
 const BillingPageContents: FC = () => {
   const dispatch = useDispatch()
-  const quartzMe = useSelector(getQuartzMe)
+  const {account} = useSelector(selectCurrentIdentity)
 
   useEffect(() => {
     if (!CLOUD) {
       return
     }
 
-    if (!quartzMe.billingProvider) {
+    if (!account.billingProvider) {
       dispatch(getBillingProviderThunk())
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
-  if (quartzMe?.billingProvider === null) {
+  if (account?.billingProvider === null) {
     return <BillingFree />
   }
 
-  if (quartzMe?.billingProvider !== 'zuora') {
+  if (account?.billingProvider !== 'zuora') {
     return <MarketplaceBilling />
   }
 
-  if (quartzMe?.accountType === 'pay_as_you_go') {
+  if (account?.type === 'pay_as_you_go') {
     return <BillingPayAsYouGo />
   }
 

--- a/src/billing/components/PayAsYouGo/CancellationOverlay.tsx
+++ b/src/billing/components/PayAsYouGo/CancellationOverlay.tsx
@@ -17,14 +17,13 @@ import {CancelServiceContext, VariableItems} from './CancelServiceContext'
 import {track} from 'rudder-sdk-js'
 import {event} from 'src/cloud/utils/reporting'
 import {useDispatch, useSelector} from 'react-redux'
-import {getQuartzMe} from 'src/me/selectors'
-import {getOrg} from 'src/organizations/selectors'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {postSignout} from 'src/client'
 import {postCancel} from 'src/client/unityRoutes'
 import {getErrorMessage} from 'src/utils/api'
 import {accountCancellationError} from 'src/shared/copy/notifications'
 import {notify} from 'src/shared/actions/notifications'
+import {selectCurrentIdentity} from 'src/identity/selectors'
 
 interface Props {
   onHideOverlay: () => void
@@ -40,9 +39,10 @@ const CancellationOverlay: FC<Props> = ({onHideOverlay}) => {
     shortSuggestion,
     getRedirectLocation,
   } = useContext(CancelServiceContext)
-  const quartzMe = useSelector(getQuartzMe)
-  const org = useSelector(getOrg)
+
   const dispatch = useDispatch()
+
+  const {user, account, org} = useSelector(selectCurrentIdentity)
 
   const handleCancelAccount = async () => {
     try {
@@ -68,8 +68,8 @@ const CancellationOverlay: FC<Props> = ({onHideOverlay}) => {
 
     const payload = {
       org: org.id,
-      tier: quartzMe?.accountType,
-      email: quartzMe?.email,
+      tier: account.type,
+      email: user.email,
       alternativeProduct: shortSuggestion,
       suggestions,
       reason: VariableItems[reason],
@@ -96,8 +96,8 @@ const CancellationOverlay: FC<Props> = ({onHideOverlay}) => {
   const handleDismiss = () => {
     const payload = {
       org: org.id,
-      tier: quartzMe?.accountType,
-      email: quartzMe?.email,
+      tier: account.type,
+      email: user.email,
     }
     event('CancelServiceDismissed Event', payload)
 

--- a/src/billing/components/PayAsYouGo/CancellationPanel.tsx
+++ b/src/billing/components/PayAsYouGo/CancellationPanel.tsx
@@ -14,21 +14,19 @@ import CancellationOverlay from 'src/billing/components/PayAsYouGo/CancellationO
 // Utils
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {useSelector} from 'react-redux'
-import {getQuartzMe} from 'src/me/selectors'
-import {getOrg} from 'src/organizations/selectors'
+import {selectCurrentIdentity} from 'src/identity/selectors'
 import {event} from 'src/cloud/utils/reporting'
 import CancelServiceProvider from './CancelServiceContext'
 
 const CancellationPanel: FC = () => {
   const [isOverlayVisible, setIsOverlayVisible] = useState(false)
-  const quartzMe = useSelector(getQuartzMe)
-  const org = useSelector(getOrg)
+  const {account, org, user} = useSelector(selectCurrentIdentity)
 
   const handleCancelService = () => {
     const payload = {
       org: org.id,
-      tier: quartzMe?.accountType,
-      email: quartzMe?.email,
+      tier: account.type,
+      email: user.email,
     }
     event('CancelServiceInitiation Event', payload)
 

--- a/src/billing/context/billing.tsx
+++ b/src/billing/context/billing.tsx
@@ -14,7 +14,6 @@ import {
   putSettingsNotifications,
   putBillingContact,
 } from 'src/client/unityRoutes'
-import {getQuartzMe} from 'src/me/selectors'
 import {
   getBillingInfoError,
   getBillingSettingsError,
@@ -43,6 +42,9 @@ import {
 } from 'src/types'
 import {CreditCardParams} from 'src/types/billing'
 import {getErrorMessage} from 'src/utils/api'
+
+// Selectors
+import {selectCurrentIdentity} from 'src/identity/selectors'
 
 export type Props = {
   children: JSX.Element
@@ -110,15 +112,16 @@ export const BillingContext =
 export const BillingProvider: FC<Props> = React.memo(({children}) => {
   const dispatch = useDispatch()
 
+  const {user} = useSelector(selectCurrentIdentity)
+
   const [zuoraParamsStatus, setZuoraParamsStatus] = useState(
     RemoteDataState.NotStarted
   )
   const [zuoraParams, setZuoraParams] =
     useState<CreditCardParams>(EMPTY_ZUORA_PARAMS)
 
-  const me = useSelector(getQuartzMe)
   const [billingSettings, setBillingSettings] = useState({
-    notifyEmail: me?.email ?? '', // sets the default to the user's registered email
+    notifyEmail: user.email, // sets the default to the user's registered email
     balanceThreshold: BALANCE_THRESHOLD_DEFAULT, // set the default to the minimum balance threshold
     isNotify: true,
   })


### PR DESCRIPTION
Connects #4821 
For other PRs removing this code see #5847, #5876

Removes references to the quartzMe data shape in the account and billing pages.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable
