### PR TITLE
chore: remove quartzMe references from operator pages

### DIFF
--- a/src/identity/selectors/index.ts
+++ b/src/identity/selectors/index.ts
@@ -6,6 +6,12 @@ export const selectQuartzIdentity = (state: AppState): AppState['identity'] => {
   return state.identity
 }
 
+export const selectCurrentIdentity = (
+  state: AppState
+): AppState['identity']['currentIdentity'] => {
+  return state.identity.currentIdentity
+}
+
 export const selectQuartzIdentityStatus = (state: AppState): RemoteDataState =>
   state.identity.currentIdentity.status
 

--- a/src/operator/OperatorNav.tsx
+++ b/src/operator/OperatorNav.tsx
@@ -24,7 +24,7 @@ const OperatorNav: FC = () => {
       hideEvent={PopoverInteraction.Click}
       contents={() => (
         <>
-          <p>{user.email ?? ''}</p>
+          <p>{user.email}</p>
           <Link to="/logout" data-testid="logout-button">
             Logout
           </Link>

--- a/src/operator/OperatorNav.tsx
+++ b/src/operator/OperatorNav.tsx
@@ -10,11 +10,13 @@ import {
 } from '@influxdata/clockface'
 import {Link} from 'react-router-dom'
 
-// Utils
-import {getQuartzMe} from 'src/me/selectors'
+// Selectors
+import {selectCurrentIdentity} from 'src/identity/selectors'
 
 const OperatorNav: FC = () => {
-  const operator = useSelector(getQuartzMe)
+  const currentIdentity = useSelector(selectCurrentIdentity)
+  const {user} = currentIdentity
+
   return (
     <ReflessPopover
       position={PopoverPosition.ToTheLeft}
@@ -22,7 +24,7 @@ const OperatorNav: FC = () => {
       hideEvent={PopoverInteraction.Click}
       contents={() => (
         <>
-          <p>{operator?.email ?? ''}</p>
+          <p>{user.email ?? ''}</p>
           <Link to="/logout" data-testid="logout-button">
             Logout
           </Link>

--- a/src/operator/context/operator.tsx
+++ b/src/operator/context/operator.tsx
@@ -12,7 +12,7 @@ import {
   OperatorProvidersResponse,
 } from 'src/client/unityRoutes'
 import {getAccountsError, getOrgsError} from 'src/shared/copy/notifications'
-import {getQuartzMe} from 'src/me/selectors'
+import {selectCurrentIdentity} from 'src/identity/selectors'
 
 // Types
 import {
@@ -91,7 +91,8 @@ export const OperatorProvider: FC<Props> = React.memo(({children}) => {
     DEFAULT_CONTEXT.providerInfo
   )
   const dispatch = useDispatch()
-  const quartzMe = useSelector(getQuartzMe)
+  const currentIdentity = useSelector(selectCurrentIdentity)
+  const {user} = currentIdentity
 
   const [organizations, setOrganizations] = useState<OperatorOrg[]>([])
 
@@ -188,8 +189,7 @@ export const OperatorProvider: FC<Props> = React.memo(({children}) => {
     status = RemoteDataState.Loading
   }
 
-  const hasWritePermissions =
-    quartzMe.isOperator && quartzMe?.operatorRole === 'read-write'
+  const hasWritePermissions = user.operatorRole === 'read-write'
 
   return (
     <OperatorContext.Provider


### PR DESCRIPTION
Connects #4821 
For other PRs removing this code see #5847, #5876, #5878

Removes references to the quartzMe data shape on operator-related pages.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable
