### PR TITLE
chore: remove quartzMe references from org pages

### DIFF
--- a/src/organizations/components/DeleteOrgOverlay.tsx
+++ b/src/organizations/components/DeleteOrgOverlay.tsx
@@ -33,8 +33,8 @@ import {
   DeleteOrgContext,
   VariableItems,
 } from 'src/organizations/components/DeleteOrgContext'
-import {getQuartzMe} from 'src/me/selectors'
 import {getOrg} from 'src/organizations/selectors'
+import {selectCurrentIdentity} from 'src/identity/selectors'
 
 const DeleteOrgOverlay: FC = () => {
   const history = useHistory()
@@ -42,14 +42,14 @@ const DeleteOrgOverlay: FC = () => {
   const dispatch = useDispatch()
   const {reason, shortSuggestion, suggestions, getRedirectLocation} =
     useContext(DeleteOrgContext)
-  const quartzMe = useSelector(getQuartzMe)
+  const {user, account} = useSelector(selectCurrentIdentity)
   const org = useSelector(getOrg)
 
   const handleClose = () => {
     const payload = {
       org: org.id,
-      tier: quartzMe?.accountType,
-      email: quartzMe?.email,
+      tier: account.type,
+      email: user.email,
     }
     event('DeleteOrgDismissed Event', payload)
 
@@ -71,8 +71,8 @@ const DeleteOrgOverlay: FC = () => {
   const handleDeleteAccount = async () => {
     const payload = {
       org: org.id,
-      tier: quartzMe?.accountType,
-      email: quartzMe?.email,
+      tier: account.type,
+      email: user.email,
       alternativeProduct: shortSuggestion,
       suggestions,
       reason: VariableItems[reason],

--- a/src/organizations/components/OrgProfileTab/DeletePanel.tsx
+++ b/src/organizations/components/OrgProfileTab/DeletePanel.tsx
@@ -19,13 +19,13 @@ import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {event} from 'src/cloud/utils/reporting'
 
 // Types
-import {getQuartzMe} from 'src/me/selectors'
+import {selectCurrentIdentity} from 'src/identity/selectors'
 import {NotificationButtonElement} from 'src/types'
 
 import 'src/organizations/components/OrgProfileTab/style.scss'
 
 const DeletePanel: FC = () => {
-  const quartzMe = useSelector(getQuartzMe)
+  const {user, account} = useSelector(selectCurrentIdentity)
   const org = useSelector(getOrg)
   const history = useHistory()
   const {status, users} = useContext(UsersContext)
@@ -34,8 +34,8 @@ const DeletePanel: FC = () => {
   const handleShowDeleteOverlay = () => {
     const payload = {
       org: org.id,
-      tier: quartzMe?.accountType,
-      email: quartzMe?.email,
+      tier: account.type,
+      email: user.email,
     }
     event('DeleteOrgInitiation Event', payload)
 
@@ -61,7 +61,7 @@ const DeletePanel: FC = () => {
   return (
     <PageSpinner loading={status}>
       <>
-        {CLOUD && quartzMe?.accountType === 'free' && (
+        {CLOUD && account.type === 'free' && (
           <>
             <FlexBox.Child>
               <h4>Delete Organization</h4>

--- a/src/organizations/components/OrgProfileTab/index.tsx
+++ b/src/organizations/components/OrgProfileTab/index.tsx
@@ -21,7 +21,7 @@ import {CLOUD} from 'src/shared/constants'
 // Selectors
 import {getMe} from 'src/me/selectors'
 import {getOrg} from 'src/organizations/selectors'
-import {selectQuartzIdentity} from 'src/identity/selectors'
+import {selectCurrentIdentity} from 'src/identity/selectors'
 
 // Thunks
 import {getCurrentOrgDetailsThunk} from 'src/identity/actions/thunks'
@@ -32,30 +32,28 @@ import 'src/organizations/components/OrgProfileTab/style.scss'
 const OrgProfileTab: FC = () => {
   const me = useSelector(getMe)
   const org = useSelector(getOrg)
-  const identity = useSelector(selectQuartzIdentity)
+  const {org: quartzOrg} = useSelector(selectCurrentIdentity)
 
   const dispatch = useDispatch()
 
-  const identityOrgId = identity.currentIdentity.org.id
+  const identityOrgId = quartzOrg.id
 
   useEffect(() => {
     if (identityOrgId && CLOUD) {
       if (
-        !me.quartzMe.regionCode ||
-        !me.quartzMe.regionName ||
-        !identity.currentIdentity.org.provider
+        !quartzOrg.regionCode ||
+        !quartzOrg.regionName ||
+        !quartzOrg.provider
       ) {
         dispatch(getCurrentOrgDetailsThunk(identityOrgId))
       }
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
-  const hasSomeQuartzOrgData =
-    identity.currentIdentity.org?.provider ||
-    me.quartzMe?.regionCode ||
-    me.quartzMe?.regionName
+  const hasIdentityData =
+    quartzOrg.provider || quartzOrg.regionCode || quartzOrg.regionName
 
-  const orgProviderExists = !!identity.currentIdentity.org?.provider
+  const orgProviderExists = !!quartzOrg.provider
 
   const OrgProfile = () => (
     <FlexBox.Child
@@ -69,7 +67,7 @@ const OrgProfileTab: FC = () => {
         src={org.name}
         isRenameableOrg={true}
       />
-      {CLOUD && hasSomeQuartzOrgData && (
+      {CLOUD && hasIdentityData && (
         <>
           <FlexBox
             direction={FlexDirection.Row}
@@ -79,23 +77,20 @@ const OrgProfileTab: FC = () => {
             style={orgProviderExists ? {width: '85%'} : {width: '48%'}}
           >
             {orgProviderExists && (
-              <LabeledData
-                label="Cloud Provider"
-                src={identity.currentIdentity.org.provider}
-              />
+              <LabeledData label="Cloud Provider" src={quartzOrg.provider} />
             )}
-            {me.quartzMe?.regionCode && (
-              <LabeledData label="Region" src={me.quartzMe.regionCode} />
+            {quartzOrg.regionCode && (
+              <LabeledData label="Region" src={quartzOrg.regionCode} />
             )}
-            {me.quartzMe?.regionName && (
-              <LabeledData label="Location" src={me.quartzMe.regionName} />
+            {quartzOrg.regionName && (
+              <LabeledData label="Location" src={quartzOrg.regionName} />
             )}
           </FlexBox>
-          {CLOUD && me.quartzMe?.clusterHost && (
+          {CLOUD && quartzOrg.clusterHost && (
             <CopyableLabeledData
               id="clusterUrl"
               label="Cluster URL (Host Name)"
-              src={me.quartzMe.clusterHost}
+              src={quartzOrg.clusterHost}
             />
           )}
         </>

--- a/src/organizations/containers/OrgProfilePage.tsx
+++ b/src/organizations/containers/OrgProfilePage.tsx
@@ -13,14 +13,14 @@ import DeleteOrgOverlay from 'src/organizations/components/DeleteOrgOverlay'
 
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
-import {getQuartzMe} from 'src/me/selectors'
+import {selectCurrentIdentity} from 'src/identity/selectors'
 import DeleteOrgProvider from 'src/organizations/components/DeleteOrgContext'
 
 // Constants
 import {CLOUD} from 'src/shared/constants'
 
 const OrgProfilePage: FC = () => {
-  const quartzMe = useSelector(getQuartzMe)
+  const {account} = useSelector(selectCurrentIdentity)
 
   return (
     <>
@@ -35,7 +35,7 @@ const OrgProfilePage: FC = () => {
           path="/orgs/:orgID/org-settings/rename"
           component={RenameOrgOverlay}
         />
-        {CLOUD && quartzMe?.accountType === 'free' && (
+        {CLOUD && account.type === 'free' && (
           <DeleteOrgProvider>
             <Route
               path="/orgs/:orgID/org-settings/delete"

--- a/src/usage/context/usage.tsx
+++ b/src/usage/context/usage.tsx
@@ -17,13 +17,15 @@ import {PAYG_CREDIT_DAYS} from 'src/shared/constants'
 import {DEFAULT_USAGE_TIME_RANGE} from 'src/shared/constants/timeRanges'
 import {MILLISECONDS_IN_ONE_DAY} from 'src/utils/datetime/constants'
 
+// Selectors
+import {selectCurrentIdentity} from 'src/identity/selectors'
+
 // Types
 import {
   RemoteDataState,
   SelectableDurationTimeRange,
   UsageVector,
 } from 'src/types'
-import {getMe} from 'src/me/selectors'
 
 export type Props = {
   children: JSX.Element
@@ -109,9 +111,10 @@ export const UsageProvider: FC<Props> = React.memo(({children}) => {
   const [timeRange, setTimeRange] = useState<SelectableDurationTimeRange>(
     DEFAULT_USAGE_TIME_RANGE
   )
-  const {quartzMe} = useSelector(getMe)
 
-  const paygCreditStartDate = quartzMe?.paygCreditStartDate ?? ''
+  const {account} = useSelector(selectCurrentIdentity)
+
+  const paygCreditStartDate = account.paygCreditStartDate ?? ''
 
   const creditDaysUsed = useMemo(
     () => calculateCreditDaysUsed(paygCreditStartDate),


### PR DESCRIPTION
Connects #4821 
For other PRs removing this code see #5847, #5876, #5878, #5883

Removes references to the quartzMe data shape on the org profile tab and related pages.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable
