### PR TITLE
fix(TreeNav): change notebooks icon from pencil to notebook

### DIFF
--- a/src/pageLayout/constants/navigationHierarchy.ts
+++ b/src/pageLayout/constants/navigationHierarchy.ts
@@ -113,7 +113,7 @@ export const generateNavItems = (): NavItem[] => {
     {
       id: 'flows',
       testID: 'nav-item-flows',
-      icon: IconFont.Pencil,
+      icon: IconFont.BookCode,
       label: PROJECT_NAME_PLURAL,
       shortLabel: PROJECT_NAME_SHORT,
       link: `${orgPrefix}/${PROJECT_NAME_PLURAL.toLowerCase()}`,


### PR DESCRIPTION
Closes #5252

![Screen Shot 2022-09-26 at 12 59 15 PM](https://user-images.githubusercontent.com/146112/192337542-e76faca6-b5f2-480f-bd19-3a914fd1a609.png)

![Screen Shot 2022-09-26 at 12 59 17 PM](https://user-images.githubusercontent.com/146112/192337549-6eac5a0d-fee9-4f0e-9c35-7e672d86c3ce.png)

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- ~[ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~
- ~[ ] Feature flagged, if applicable~
