### PR TITLE
fix: subs all certs fields required

### DIFF
--- a/src/writeData/subscriptions/components/CertificateInput.tsx
+++ b/src/writeData/subscriptions/components/CertificateInput.tsx
@@ -83,6 +83,7 @@ const NewCertificateInput: FC<OwnProps> = ({updateForm, subscription}) => {
         placeholder={CertificatePlaceholders.clientKey}
         value={subscription?.brokerClientKey ?? ''}
         rows={4}
+        required
       />
       <TextAreaWithLabel
         name="CertificateAuthority"
@@ -91,6 +92,7 @@ const NewCertificateInput: FC<OwnProps> = ({updateForm, subscription}) => {
         value={subscription?.brokerClientCert ?? ''}
         placeholder={CertificatePlaceholders.clientCert}
         rows={4}
+        required
       />
     </FlexBox>
   )

--- a/src/writeData/subscriptions/utils/form.ts
+++ b/src/writeData/subscriptions/utils/form.ts
@@ -247,10 +247,7 @@ const checkBasicSelected = (form: Subscription): boolean =>
 
 const checkCertificateRequiredFields = (form: Subscription): boolean =>
   form.authType === BrokerAuthTypes.Certificate &&
-  !!form.brokerCACert &&
-  // you either need to provide both or neither
-  ((!!form.brokerClientCert && !!form.brokerClientKey) ||
-    (!form.brokerClientCert && !form.brokerClientKey))
+  (!!form.brokerCACert && !!form.brokerClientCert && !!form.brokerClientKey)
 
 const checkCreatingCertificate = (form: Subscription): boolean =>
   form.authType === BrokerAuthTypes.Certificate && !form.brokerCertCreationDate

--- a/src/writeData/subscriptions/utils/form.ts
+++ b/src/writeData/subscriptions/utils/form.ts
@@ -247,7 +247,9 @@ const checkBasicSelected = (form: Subscription): boolean =>
 
 const checkCertificateRequiredFields = (form: Subscription): boolean =>
   form.authType === BrokerAuthTypes.Certificate &&
-  (!!form.brokerCACert && !!form.brokerClientCert && !!form.brokerClientKey)
+  !!form.brokerCACert &&
+  !!form.brokerClientCert &&
+  !!form.brokerClientKey
 
 const checkCreatingCertificate = (form: Subscription): boolean =>
   form.authType === BrokerAuthTypes.Certificate && !form.brokerCertCreationDate


### PR DESCRIPTION
Closes https://github.com/influxdata/data-acquisition/issues/551

If a user selects cert auth (currently feature flagged) all three fields are required.

<img width="996" alt="Screen Shot 2022-09-26 at 2 19 11 PM" src="https://user-images.githubusercontent.com/38860767/192351183-546cc31c-b172-41ef-8423-e500df48abf3.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
