### PR TITLE
fix: account for possibility of undefined billingProvider until api call completes

### DIFF
--- a/src/billing/components/BillingPageContents.tsx
+++ b/src/billing/components/BillingPageContents.tsx
@@ -30,15 +30,19 @@ const BillingPageContents: FC = () => {
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
-  if (account?.billingProvider === null) {
+  if (account.billingProvider === undefined) {
+    return null
+  }
+
+  if (account.billingProvider === null) {
     return <BillingFree />
   }
 
-  if (account?.billingProvider !== 'zuora') {
+  if (account.billingProvider !== 'zuora') {
     return <MarketplaceBilling />
   }
 
-  if (account?.type === 'pay_as_you_go') {
+  if (account.type === 'pay_as_you_go') {
     return <BillingPayAsYouGo />
   }
 


### PR DESCRIPTION
Using a free account, a notification appears when clicking to the Account/Billing page about being unable to retrieve the user's marketplace data. There is no marketplace data for a free account. Cause is [UI #5878](https://github.com/influxdata/ui/pull/5878), which pulls the information from the identity state directly, not identity-as-converted-to-quartzMe.

Cause: the conversion utility (and quartzMe itself) set `billingProvider` to `null` by implication if the user doesn't have a billing provider. In `identity`, no billing provider is set by default because it isn't part of that endpoint - you have to wait for a call to /orgs/:orgsId. So there is a period on the account/billing page before the data is fetched where a free account will have a billingProvider of `undefined`, which will pass the `billingProvider !== null` check, and go on to try to retrieve its marketplace billing information (which doesn't exist).

Solution is to explicitly account for _undefined_ as a state of _billingProvider_ until it's retrieved from quartz.

Repro
--
https://user-images.githubusercontent.com/91283923/192356071-539cba9f-63fa-41ea-a592-8fa51be34bf2.mov

Note: This isn't reproduceable in remocal - perhaps because the gap between retrieving the data and rendering is significantly less than prod.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable