### PR TITLE
chore: update clockface to 6.3.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
   "dependencies": {
     "@codingame/monaco-jsonrpc": "^0.3.1",
     "@docsearch/react": "^3.0.0-alpha.37",
-    "@influxdata/clockface": "^6.3.6",
+    "@influxdata/clockface": "^6.3.7",
     "@influxdata/flux-lsp-browser": "0.8.34",
     "@influxdata/giraffe": "^2.36.0",
     "@influxdata/influxdb-templates": "0.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1436,10 +1436,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@influxdata/clockface@^6.3.6":
-  version "6.3.6"
-  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-6.3.6.tgz#11f38e694190f303ecce1217f3474c5c73802ecc"
-  integrity sha512-kBZKNMSKdY8BvYFY0Usu/TSnfd+KWK4Wgy83SAd3np27TrXOiCW+ey1s0VEIZd0CF3bsErxY8yGm8voqH/Zu5Q==
+"@influxdata/clockface@^6.3.7":
+  version "6.3.7"
+  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-6.3.7.tgz#2e886e63748f77fd7243fb2cc4238716df3945d0"
+  integrity sha512-aq+vNb+xmN/zdBEtiO/jpaegde6+Qgo/xXuCWevz62GDMjbIcqaupEGYLHbS2SfhlYsxoK42mPgQVxhjHJrwGA==
   dependencies:
     "@types/react-window" "^1.8.5"
     react-window "^1.8.7"


### PR DESCRIPTION
Update clockface version to 6.3.7 release https://github.com/influxdata/clockface/releases/tag/v6.3.7

This brings in a clockface fix for Save button icon that was mixed with PieChart icon

# Bug
<img width="446" alt="Screen Shot 2022-09-26 at 2 39 53 PM" src="https://user-images.githubusercontent.com/14298407/192365115-cf2ce7a0-2ccf-4738-a9db-83c80de0143e.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
~~- [ ] Documentation updated or issue created (provide link to issue/PR)~~
~~- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~~
~~- [ ] Feature flagged, if applicable~~
