### PR TITLE
fix(5886): FluxEditor hotkey submit should not use memoized version of script

### DIFF
--- a/src/dataExplorer/components/ResultsPane.tsx
+++ b/src/dataExplorer/components/ResultsPane.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FC, lazy, Suspense, useContext} from 'react'
+import React, {FC, lazy, Suspense, useContext, useCallback} from 'react'
 import {
   DraggableResizer,
   Orientation,
@@ -121,7 +121,7 @@ const ResultsPane: FC = () => {
     })
   }
 
-  const submit = () => {
+  const submit = useCallback(() => {
     setStatus(RemoteDataState.Loading)
     query(text, {
       vars: rangeToParam(range),
@@ -142,7 +142,7 @@ const ResultsPane: FC = () => {
         event('resultReceived', {status: 'error'})
         setStatus(RemoteDataState.Error)
       })
-  }
+  }, [text])
 
   const timeVars = [
     getRangeVariable(TIME_RANGE_START, range),

--- a/src/shared/components/FluxMonacoEditor.tsx
+++ b/src/shared/components/FluxMonacoEditor.tsx
@@ -62,7 +62,7 @@ const FluxEditorMonaco: FC<Props> = ({
   variables,
 }) => {
   const connection = useRef<ConnectionManager>(null)
-  const {setEditor} = useContext(EditorContext)
+  const {editor, setEditor} = useContext(EditorContext)
   const isFluxQueryBuilder = useSelector(fluxQueryBuilder)
   const sessionStore = useContext(PersistanceContext)
   const {path} = useRouteMatch()
@@ -94,6 +94,17 @@ const FluxEditorMonaco: FC<Props> = ({
     sessionStore?.setSelection,
   ])
 
+  useEffect(() => {
+    if (!editor) {
+      return
+    }
+    submit(editor, () => {
+      if (onSubmitScript) {
+        onSubmitScript()
+      }
+    })
+  }, [editor, onSubmitScript])
+
   const editorDidMount = (editor: EditorType) => {
     connection.current = setupForReactMonacoEditor(editor)
     connection.current.updatePreludeModel(variables)
@@ -104,11 +115,6 @@ const FluxEditorMonaco: FC<Props> = ({
     }
 
     comments(editor)
-    submit(editor, () => {
-      if (onSubmitScript) {
-        onSubmitScript()
-      }
-    })
 
     if (autogrow) {
       registerAutogrow(editor)


### PR DESCRIPTION
Closes #5886 

## Bug:
* outdated, memoized query sent via hotkey submit.
* vid:


https://user-images.githubusercontent.com/10232835/192363924-3e9fb6ae-8c1f-4cc6-89c5-9f1894b55884.mov




## Fixed:

https://user-images.githubusercontent.com/10232835/192363842-c328383f-13e2-4fff-9b64-a6d4734e4bfe.mov



 
## Checklist
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] ~Feature flagged, if applicable~ N/A
