### PR TITLE
fix(globalHeader): make header work better with small screens

### DIFF
--- a/src/identity/components/GlobalHeader/GlobalHeader.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeader.tsx
@@ -34,7 +34,7 @@ import IdentityUserAvatar from 'src/identity/components/GlobalHeader/IdentityUse
 import RateLimitAlert from 'src/cloud/components/RateLimitAlert'
 
 const caretStyle = {fontSize: '18px', color: InfluxColors.Grey65}
-const rightHandContainerStyle = {width: '700px', marginLeft: 'auto'}
+const rightHandContainerStyle = {marginLeft: 'auto'}
 
 export const GlobalHeader: FC = () => {
   const dispatch = useDispatch()

--- a/src/shared/components/cloud/CloudOnly.scss
+++ b/src/shared/components/cloud/CloudOnly.scss
@@ -99,9 +99,17 @@ button.upgrade-payg--button {
   margin: $cf-marg-c;
 }
 
-@media (max-width: 668px) {
+@media (max-width: 850px) {
   .credit-250-experiment-upgrade-button--text {
     display: none;
+  }
+}
+
+@media (max-width: 700px) {
+  .upgrade-payg--button {
+    .CrownSolid_New {
+      display: none;
+    }
   }
 }
 


### PR DESCRIPTION
Closes [#5779](https://github.com/influxdata/ui/issues/5779)

Hides things of less relevance as screen gets smaller to display the most important parts only, when the available estate is lesser.

https://user-images.githubusercontent.com/18511823/192393608-f6431535-2b9e-496e-bba2-8ffb213f7d8b.mov

<!-- Describe your proposed changes here. -->
<!-- Including screenshots or visuals is very helpful - a picture is worth a thousand words. -->

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
