### PR TITLE
fix(globalHeader): Global header typeahead menu item height

### DIFF
--- a/src/identity/components/GlobalHeader/GlobalHeaderDropdown/GlobalHeaderDropdown.scss
+++ b/src/identity/components/GlobalHeader/GlobalHeaderDropdown/GlobalHeaderDropdown.scss
@@ -64,6 +64,7 @@
 .global-header--typeahead-item {
   width: 100%;
   padding-left: 14px;
+  height: 36px;
 }
 
 .line-break {

--- a/src/identity/components/GlobalHeader/GlobalHeaderDropdown/GlobalHeaderTypeAheadMenu.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeaderDropdown/GlobalHeaderTypeAheadMenu.tsx
@@ -29,7 +29,7 @@ type State = {
 }
 
 export class GlobalHeaderTypeAheadMenu extends React.Component<Props, State> {
-  private listItemHeight = 50
+  private listItemHeight = 52
   private maxDropdownHeight = 150
   constructor(props: Props) {
     super(props)

--- a/src/identity/components/GlobalHeader/GlobalHeaderDropdown/GlobalHeaderTypeAheadMenu.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeaderDropdown/GlobalHeaderTypeAheadMenu.tsx
@@ -29,7 +29,7 @@ type State = {
 }
 
 export class GlobalHeaderTypeAheadMenu extends React.Component<Props, State> {
-  private listItemHeight = 52
+  private listItemHeight = 54
   private maxDropdownHeight = 150
   constructor(props: Props) {
     super(props)

--- a/src/identity/components/GlobalHeader/GlobalHeaderDropdown/index.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeaderDropdown/index.tsx
@@ -205,7 +205,7 @@ export class GlobalHeaderDropdown extends React.Component<Props, State> {
                 justifyContent={JustifyContent.SpaceBetween}
                 alignItems={AlignItems.Center}
               >
-                <span className="global-header--align-center">
+                <span className="global-header--main-dropdown-item">
                   {iconEl}
                   {textEl}
                 </span>


### PR DESCRIPTION
Closes [#5778](https://github.com/influxdata/ui/issues/5778)

This PR changes the height of the individual items and forces **all the** items to be 36px (height upon selection) so there is no height changing effect.

It happens in all dropdowns, but we notice it more because of the horizontal dividers we have in the dropdown.

After fix:

https://user-images.githubusercontent.com/18511823/192591107-cd94eb65-8701-4e4b-9d15-84694255275b.mov

<!-- Describe your proposed changes here. -->
<!-- Including screenshots or visuals is very helpful - a picture is worth a thousand words. -->

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
