### PR TITLE
fix: forward errors from save api

### DIFF
--- a/src/dataExplorer/components/FluxQueryBuilder.tsx
+++ b/src/dataExplorer/components/FluxQueryBuilder.tsx
@@ -45,8 +45,7 @@ export enum OverlayType {
 
 const FluxQueryBuilder: FC = () => {
   const history = useHistory()
-  const {hasChanged, query, vertical, setVertical} =
-    useContext(PersistanceContext)
+  const {hasChanged, vertical, setVertical} = useContext(PersistanceContext)
   const [overlayType, setOverlayType] = useState<OverlayType | null>(null)
   const [isOverlayVisible, setIsOverlayVisible] = useState(false)
   const {cancel} = useContext(QueryContext)
@@ -139,11 +138,6 @@ const FluxQueryBuilder: FC = () => {
                   onClick={handleNewScript}
                   text={isFlagEnabled('saveAsScript') ? 'New Script' : 'Clear'}
                   icon={IconFont.Plus_New}
-                  status={
-                    query.length === 0
-                      ? ComponentStatus.Disabled
-                      : ComponentStatus.Default
-                  }
                   testID="flux-query-builder--new-script"
                 />
                 {isFlagEnabled('saveAsScript') && (

--- a/src/dataExplorer/components/SaveAsScript.scss
+++ b/src/dataExplorer/components/SaveAsScript.scss
@@ -1,3 +1,8 @@
 .save-script-overlay__warning-text {
   margin-bottom: 25px;
 }
+
+.save-script--error {
+  display: block;
+  margin: -10px 0 12px 0;
+}

--- a/src/dataExplorer/components/resources/types/script/index.ts
+++ b/src/dataExplorer/components/resources/types/script/index.ts
@@ -58,7 +58,11 @@ export default function script(register) {
             description: data.description,
             script: data.script,
           },
-        }).then(() => {
+        }).then(resp => {
+          if (resp.status !== 201) {
+            throw new Error(resp.data.message)
+          }
+
           return resource
         })
       }
@@ -71,17 +75,17 @@ export default function script(register) {
           language: 'flux',
         },
       }).then(resp => {
-        if (resp.status === 201) {
-          return {
-            ...resource,
-            data: {
-              ...data,
-              id: resp.data.id,
-            },
-          }
+        if (resp.status !== 201) {
+          throw new Error(resp.data.message)
         }
 
-        return resource
+        return {
+          ...resource,
+          data: {
+            ...data,
+            id: resp.data.id,
+          },
+        }
       })
     },
   })


### PR DESCRIPTION
Closes #5836

exposes to the user if the api believes that there's an error with the script they tried to save
a couple of one liners are in there as well that came through, like fixing the text change I missed the last time I was in there and the request that a user should always be able to clear their script