### PR TITLE
fix(5912): query with updated/latest time range

### DIFF
--- a/src/dataExplorer/components/ResultsPane.tsx
+++ b/src/dataExplorer/components/ResultsPane.tsx
@@ -142,7 +142,7 @@ const ResultsPane: FC = () => {
         event('resultReceived', {status: 'error'})
         setStatus(RemoteDataState.Error)
       })
-  }, [text])
+  }, [text, range])
 
   const timeVars = [
     getRangeVariable(TIME_RANGE_START, range),


### PR DESCRIPTION
Closes #5912 

Fixing a bug I accidentally introduced yesterday (while fixing an unrelated bug).

Daterange updates is now being included in the extern payload:

https://user-images.githubusercontent.com/10232835/192630723-b5ac6587-6209-4d6e-8239-21a13eb91089.mov



## Checklist
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] ~Feature flagged, if applicable~ N/A.
