### PR TITLE
feat: add menuitems for create org and add more orgs to global header

### DIFF
--- a/cypress/e2e/cloud/globalHeader.test.ts
+++ b/cypress/e2e/cloud/globalHeader.test.ts
@@ -1,3 +1,5 @@
+import {makeQuartzUseIDPEOrgID} from 'cypress/support/Utils'
+
 describe('change-account change-org global header', () => {
   const globalHeaderFeatureFlags = {
     multiOrg: true,
@@ -9,37 +11,6 @@ describe('change-account change-org global header', () => {
     cy.intercept('GET', 'api/v2/orgs').as('getOrgs')
     cy.intercept('GET', 'api/v2/flags').as('getFlags')
     cy.intercept('GET', 'api/v2/quartz/accounts/**/orgs').as('getQuartzOrgs')
-  }
-
-  const makeQuartzUseIDPEOrgID = () => {
-    cy.fixture('multiOrgAccounts1.json').then(quartzAccounts => {
-      cy.intercept('GET', 'api/v2/quartz/accounts', quartzAccounts).as(
-        'getQuartzAccounts'
-      )
-    })
-
-    cy.fixture('multiOrgIdentity').then(quartzIdentity => {
-      quartzIdentity.org.id = idpeOrgID
-
-      cy.intercept('GET', 'api/v2/quartz/identity', quartzIdentity).as(
-        'getQuartzIdentity'
-      )
-    })
-
-    cy.fixture('multiOrgOrgs1').then(quartzOrgs => {
-      quartzOrgs[0].id = idpeOrgID
-
-      cy.intercept('GET', 'api/v2/quartz/accounts/**/orgs', quartzOrgs).as(
-        'getQuartzOrgs'
-      )
-    })
-
-    cy.fixture('orgDetails').then(quartzOrgDetails => {
-      quartzOrgDetails.id = idpeOrgID
-      cy.intercept('GET', 'api/v2/quartz/orgs/*', quartzOrgDetails).as(
-        'getQuartzOrgDetails'
-      )
-    })
   }
 
   const mockQuartzOutage = () => {
@@ -63,7 +34,7 @@ describe('change-account change-org global header', () => {
           method: 'GET',
           url: 'api/v2/orgs',
         }).then(res => {
-          makeQuartzUseIDPEOrgID()
+          makeQuartzUseIDPEOrgID(idpeOrgID)
           // Store the IDPE org ID so that it can be cloned when intercepting quartz.
           if (res.body.orgs) {
             idpeOrgID = res.body.orgs[0].id
@@ -75,7 +46,7 @@ describe('change-account change-org global header', () => {
 
   beforeEach(() => {
     // Preserve one session throughout.
-    makeQuartzUseIDPEOrgID()
+    makeQuartzUseIDPEOrgID(idpeOrgID)
     Cypress.Cookies.preserveOnce('sid')
     cy.setFeatureFlags(globalHeaderFeatureFlags)
   })
@@ -97,13 +68,13 @@ describe('change-account change-org global header', () => {
 
     describe('change org dropdown', () => {
       before(() => {
-        makeQuartzUseIDPEOrgID()
+        makeQuartzUseIDPEOrgID(idpeOrgID)
         cy.setFeatureFlags(globalHeaderFeatureFlags)
         cy.visit('/')
       })
 
       it('navigates to the org settings page', () => {
-        makeQuartzUseIDPEOrgID()
+        makeQuartzUseIDPEOrgID(idpeOrgID)
         cy.getByTestID('globalheader--org-dropdown')
           .should('be.visible')
           .click()
@@ -119,7 +90,7 @@ describe('change-account change-org global header', () => {
       })
 
       it('navigates to the org members page', () => {
-        makeQuartzUseIDPEOrgID()
+        makeQuartzUseIDPEOrgID(idpeOrgID)
         cy.getByTestID('globalheader--org-dropdown')
           .should('be.visible')
           .click()
@@ -135,7 +106,7 @@ describe('change-account change-org global header', () => {
       })
 
       it('navigates to the org usage page', () => {
-        makeQuartzUseIDPEOrgID()
+        makeQuartzUseIDPEOrgID(idpeOrgID)
 
         cy.getByTestID('globalheader--org-dropdown').should('exist').click()
         cy.getByTestID('globalheader--org-dropdown-main').should('be.visible')
@@ -149,7 +120,7 @@ describe('change-account change-org global header', () => {
       })
 
       it('can change change the active org', () => {
-        makeQuartzUseIDPEOrgID()
+        makeQuartzUseIDPEOrgID(idpeOrgID)
         cy.getByTestID('globalheader--org-dropdown').should('exist').click()
 
         cy.getByTestID('globalheader--org-dropdown-main').should('be.visible')
@@ -176,17 +147,17 @@ describe('change-account change-org global header', () => {
 
     describe('change account dropdown', () => {
       beforeEach(() => {
-        makeQuartzUseIDPEOrgID()
+        makeQuartzUseIDPEOrgID(idpeOrgID)
         cy.setFeatureFlags(globalHeaderFeatureFlags)
       })
 
       before(() => {
-        makeQuartzUseIDPEOrgID()
+        makeQuartzUseIDPEOrgID(idpeOrgID)
         cy.visit('/')
       })
 
       it('navigates to the account settings page', () => {
-        makeQuartzUseIDPEOrgID()
+        makeQuartzUseIDPEOrgID(idpeOrgID)
         cy.getByTestID('globalheader--account-dropdown').should('exist').click()
 
         cy.getByTestID('globalheader--account-dropdown-main').should(
@@ -201,7 +172,7 @@ describe('change-account change-org global header', () => {
       })
 
       it('navigates to the account billing page', () => {
-        makeQuartzUseIDPEOrgID()
+        makeQuartzUseIDPEOrgID(idpeOrgID)
         cy.getByTestID('globalheader--account-dropdown').should('exist').click()
 
         cy.getByTestID('globalheader--account-dropdown-main').should(
@@ -218,7 +189,7 @@ describe('change-account change-org global header', () => {
       })
 
       it('can change change the active account', () => {
-        makeQuartzUseIDPEOrgID()
+        makeQuartzUseIDPEOrgID(idpeOrgID)
         cy.getByTestID('globalheader--account-dropdown').should('exist').click()
 
         cy.getByTestID('globalheader--account-dropdown-main').should(
@@ -247,13 +218,13 @@ describe('change-account change-org global header', () => {
 
   describe('user profile avatar', {scrollBehavior: false}, () => {
     before(() => {
-      makeQuartzUseIDPEOrgID()
+      makeQuartzUseIDPEOrgID(idpeOrgID)
       cy.setFeatureFlags(globalHeaderFeatureFlags)
       cy.visit('/')
     })
 
     it('navigates to the `user profile` page', () => {
-      makeQuartzUseIDPEOrgID()
+      makeQuartzUseIDPEOrgID(idpeOrgID)
       cy.getByTestID('global-header--user-avatar').should('be.visible').click()
 
       cy.getByTestID('global-header--user-popover-profile-button')
@@ -266,7 +237,7 @@ describe('change-account change-org global header', () => {
     })
 
     it('allows the user to log out', () => {
-      makeQuartzUseIDPEOrgID()
+      makeQuartzUseIDPEOrgID(idpeOrgID)
       cy.getByTestID('global-header--user-avatar').should('be.visible').click()
 
       // Logout can't be handled in the test, and redirects to a 404 that

--- a/cypress/e2e/cloud/globalHeaderOrgMenuItems.test.ts
+++ b/cypress/e2e/cloud/globalHeaderOrgMenuItems.test.ts
@@ -1,6 +1,6 @@
 import {makeQuartzUseIDPEOrgID} from 'cypress/support/Utils'
 
-const globalHeaderFeatureFlags = {
+const createOrgsFeatureFlags = {
   multiOrg: true,
   createDeleteOrgs: true,
 }
@@ -27,7 +27,7 @@ describe('FREE: global header menu items test', () => {
   beforeEach(() => {
     // Preserve one session throughout.
     Cypress.Cookies.preserveOnce('sid')
-    cy.setFeatureFlags(globalHeaderFeatureFlags)
+    cy.setFeatureFlags(createOrgsFeatureFlags)
     makeQuartzUseIDPEOrgID(idpeOrgID)
     cy.visit('/')
   })
@@ -36,9 +36,9 @@ describe('FREE: global header menu items test', () => {
     cy.getByTestID('globalheader--org-dropdown').should('exist').click()
 
     cy.getByTestID('globalheader--org-dropdown-main').should('be.visible')
-    cy.getByTestID('globalheader--org-dropdown-main--contents')
-      .contains('Add More Organizations')
-      .should('be.visible')
+    cy.getByTestID(
+      'globalheader--org-dropdown-main-Add More Organizations'
+    ).should('be.visible')
   })
 })
 
@@ -58,7 +58,7 @@ describe('PAYG: global header menu items test', () => {
           }
 
           Cypress.Cookies.preserveOnce('sid')
-          cy.setFeatureFlags(globalHeaderFeatureFlags)
+          cy.setFeatureFlags(createOrgsFeatureFlags)
         })
       })
     )
@@ -73,8 +73,45 @@ describe('PAYG: global header menu items test', () => {
     cy.getByTestID('globalheader--org-dropdown').should('exist').click()
 
     cy.getByTestID('globalheader--org-dropdown-main').should('be.visible')
-    cy.getByTestID('globalheader--org-dropdown-main--contents')
-      .contains('Create Organization')
-      .should('be.visible')
+    cy.getByTestID(
+      'global-header--main-dropdown-item-Create Organization'
+    ).should('be.visible')
+  })
+})
+
+describe('Contract: global header menu items test', () => {
+  let idpeOrgID: string
+
+  before(() => {
+    cy.flush().then(() =>
+      cy.signin().then(() => {
+        cy.request({
+          method: 'GET',
+          url: 'api/v2/orgs',
+        }).then(res => {
+          // Store the IDPE org ID so that it can be cloned when intercepting quartz.
+          if (res.body.orgs) {
+            idpeOrgID = res.body.orgs[0].id
+          }
+
+          Cypress.Cookies.preserveOnce('sid')
+          cy.setFeatureFlags(createOrgsFeatureFlags)
+        })
+      })
+    )
+  })
+
+  beforeEach(() => {
+    makeQuartzUseIDPEOrgID(idpeOrgID, 'contract')
+    cy.visit('/')
+  })
+
+  it('Contract: can check create organization menu item exists', () => {
+    cy.getByTestID('globalheader--org-dropdown').should('exist').click()
+
+    cy.getByTestID('globalheader--org-dropdown-main').should('be.visible')
+    cy.getByTestID(
+      'global-header--main-dropdown-item-Create Organization'
+    ).should('be.visible')
   })
 })

--- a/cypress/e2e/cloud/globalHeaderOrgMenuItems.test.ts
+++ b/cypress/e2e/cloud/globalHeaderOrgMenuItems.test.ts
@@ -1,0 +1,80 @@
+import {makeQuartzUseIDPEOrgID} from 'cypress/support/Utils'
+
+const globalHeaderFeatureFlags = {
+  multiOrg: true,
+  createDeleteOrgs: true,
+}
+
+describe('FREE: global header menu items test', () => {
+  let idpeOrgID: string
+
+  before(() => {
+    cy.flush().then(() =>
+      cy.signin().then(() => {
+        cy.request({
+          method: 'GET',
+          url: 'api/v2/orgs',
+        }).then(res => {
+          // Store the IDPE org ID so that it can be cloned when intercepting quartz.
+          if (res.body.orgs) {
+            idpeOrgID = res.body.orgs[0].id
+          }
+        })
+      })
+    )
+  })
+
+  beforeEach(() => {
+    // Preserve one session throughout.
+    Cypress.Cookies.preserveOnce('sid')
+    cy.setFeatureFlags(globalHeaderFeatureFlags)
+    makeQuartzUseIDPEOrgID(idpeOrgID)
+    cy.visit('/')
+  })
+
+  it('has add more organizations in menu items', () => {
+    cy.getByTestID('globalheader--org-dropdown').should('exist').click()
+
+    cy.getByTestID('globalheader--org-dropdown-main').should('be.visible')
+    cy.getByTestID('globalheader--org-dropdown-main--contents')
+      .contains('Add More Organizations')
+      .should('be.visible')
+  })
+})
+
+describe('PAYG: global header menu items test', () => {
+  let idpeOrgID: string
+
+  before(() => {
+    cy.flush().then(() =>
+      cy.signin().then(() => {
+        cy.request({
+          method: 'GET',
+          url: 'api/v2/orgs',
+        }).then(res => {
+          // Store the IDPE org ID so that it can be cloned when intercepting quartz.
+          if (res.body.orgs) {
+            idpeOrgID = res.body.orgs[0].id
+          }
+
+          Cypress.Cookies.preserveOnce('sid')
+          cy.setFeatureFlags(globalHeaderFeatureFlags)
+        })
+      })
+    )
+  })
+
+  beforeEach(() => {
+    makeQuartzUseIDPEOrgID(idpeOrgID, 'pay_as_you_go')
+    cy.visit('/')
+  })
+
+  it('PAYG: can check create organization menu item exists', () => {
+    cy.getByTestID('globalheader--org-dropdown').should('exist').click()
+
+    cy.getByTestID('globalheader--org-dropdown-main').should('be.visible')
+    cy.getByTestID('globalheader--org-dropdown-main--contents')
+      .contains('Create Organization')
+      .should('be.visible')
+  })
+})

--- a/cypress/fixtures/multiOrgIdentityContract.json
+++ b/cypress/fixtures/multiOrgIdentityContract.json
@@ -1,0 +1,24 @@
+{
+  "user": {
+    "id": "03b0f952abf7e5ce",
+    "email": "test@influxdata.com",
+    "firstName": "Marty",
+    "lastName": "McFly",
+    "operatorRole": null,
+    "accountCount": 2,
+    "orgCount": 20
+  },
+  "org": {
+    "id": "a12eb3c74e6c3azc",
+    "name": "Test Organization",
+    "clusterHost": "https://us-west1.iamzuora.cloud2.influxdata.com"
+  },
+
+  "account": {
+    "id": 416,
+    "name": "Influx",
+    "type": "contract",
+    "accountCreatedAt": "Tue Jun 01 2022 08:49:14 GMT-0400 (Eastern Daylight Time)",
+    "billing_provider": "gcm"
+  }
+}

--- a/cypress/fixtures/multiOrgIdentityPAYG.json
+++ b/cypress/fixtures/multiOrgIdentityPAYG.json
@@ -1,0 +1,24 @@
+{
+  "user": {
+    "id": "03b0f952abf7e5ce",
+    "email": "test@influxdata.com",
+    "firstName": "Marty",
+    "lastName": "McFly",
+    "operatorRole": null,
+    "accountCount": 2,
+    "orgCount": 20
+  },
+  "org": {
+    "id": "a12eb3c74e6c3azc",
+    "name": "Test Organization",
+    "clusterHost": "https://us-west1.iamzuora.cloud2.influxdata.com"
+  },
+
+  "account": {
+    "id": 416,
+    "name": "Influx",
+    "type": "pay_as_you_go",
+    "accountCreatedAt": "Tue Jun 01 2022 08:49:14 GMT-0400 (Eastern Daylight Time)",
+    "billing_provider": "aws"
+  }
+}

--- a/cypress/support/Utils.ts
+++ b/cypress/support/Utils.ts
@@ -180,6 +180,10 @@ export const makeQuartzUseIDPEOrgID = (
   if (accountType === 'pay_as_you_go') {
     fixtureName = 'multiOrgIdentityPAYG'
   }
+  if (accountType === 'contract') {
+    fixtureName = 'multiOrgIdentityContract'
+  }
+
   cy.fixture(fixtureName).then(quartzIdentity => {
     quartzIdentity.org.id = idpeOrgID
 

--- a/cypress/support/Utils.ts
+++ b/cypress/support/Utils.ts
@@ -165,3 +165,41 @@ export function genCurve(args: CurveArgs): string[] {
 
   return result
 }
+
+export const makeQuartzUseIDPEOrgID = (
+  idpeOrgID: string,
+  accountType = 'free'
+) => {
+  cy.fixture('multiOrgAccounts1.json').then(quartzAccounts => {
+    cy.intercept('GET', 'api/v2/quartz/accounts', quartzAccounts).as(
+      'getQuartzAccounts'
+    )
+  })
+
+  let fixtureName = 'multiOrgIdentity'
+  if (accountType === 'pay_as_you_go') {
+    fixtureName = 'multiOrgIdentityPAYG'
+  }
+  cy.fixture(fixtureName).then(quartzIdentity => {
+    quartzIdentity.org.id = idpeOrgID
+
+    cy.intercept('GET', 'api/v2/quartz/identity', quartzIdentity).as(
+      'getQuartzIdentity'
+    )
+  })
+
+  cy.fixture('multiOrgOrgs1').then(quartzOrgs => {
+    quartzOrgs[0].id = idpeOrgID
+
+    cy.intercept('GET', 'api/v2/quartz/accounts/**/orgs', quartzOrgs).as(
+      'getQuartzOrgs'
+    )
+  })
+
+  cy.fixture('orgDetails').then(quartzOrgDetails => {
+    quartzOrgDetails.id = idpeOrgID
+    cy.intercept('GET', 'api/v2/quartz/orgs/*', quartzOrgDetails).as(
+      'getQuartzOrgDetails'
+    )
+  })
+}

--- a/src/identity/apis/auth.ts
+++ b/src/identity/apis/auth.ts
@@ -322,9 +322,5 @@ export const updateUserAccount = async (accountId, name) => {
     throw new ServerError(response.data.message)
   }
 
-  // TODO: Remove the following line of code when this PR(https://github.com/influxdata/quartz/issues/6846) is done
-  //       Instead return response.data.
-  const data = {...response.data, id: Number(response.data.id)}
-
-  return data
+  return response.data
 }

--- a/src/identity/components/GlobalHeader/GlobalHeaderDropdown/CreateOrganization/MenuItem.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeaderDropdown/CreateOrganization/MenuItem.tsx
@@ -18,14 +18,16 @@ export const CreateOrganizationMenuItem: FC = () => {
     //       Add create organization functionality with modal, error handling and redirect to new organization
   }
 
+  const title = 'Create Organization'
   return (
     <Dropdown.Item
       onClick={handleCreateOrg}
       className="global-header--create-org-button"
+      testID={`global-header--main-dropdown-item-${title}`}
     >
       <FlexBox alignItems={AlignItems.Center}>
         <Icon glyph={IconFont.Plus_New} className="button-icon" />
-        <span>Create Organization</span>
+        <span>{title}</span>
       </FlexBox>
     </Dropdown.Item>
   )

--- a/src/identity/components/GlobalHeader/GlobalHeaderDropdown/CreateOrganization/MenuItem.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeaderDropdown/CreateOrganization/MenuItem.tsx
@@ -10,7 +10,7 @@ import {
   IconFont,
 } from '@influxdata/clockface'
 
-const CreateOrganizationMenuItem: FC = () => {
+export const CreateOrganizationMenuItem: FC = () => {
   const handleCreateOrg = () => {
     // TODO: Enable this when #5899 is worked on
     // event('globalheader_createOrg_menuItem_clicked')
@@ -30,4 +30,3 @@ const CreateOrganizationMenuItem: FC = () => {
     </Dropdown.Item>
   )
 }
-export default CreateOrganizationMenuItem

--- a/src/identity/components/GlobalHeader/GlobalHeaderDropdown/CreateOrganization/MenuItem.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeaderDropdown/CreateOrganization/MenuItem.tsx
@@ -1,0 +1,33 @@
+// Libraries
+import React, {FC} from 'react'
+
+// Components
+import {
+  AlignItems,
+  Dropdown,
+  FlexBox,
+  Icon,
+  IconFont,
+} from '@influxdata/clockface'
+
+const CreateOrganizationMenuItem: FC = () => {
+  const handleCreateOrg = () => {
+    // TODO: Enable this when #5899 is worked on
+    // event('globalheader_createOrg_menuItem_clicked')
+    // TODO: Remove this comment when you are working on https://github.com/influxdata/ui/issues/5899
+    //       Add create organization functionality with modal, error handling and redirect to new organization
+  }
+
+  return (
+    <Dropdown.Item
+      onClick={handleCreateOrg}
+      className="global-header--create-org-button"
+    >
+      <FlexBox alignItems={AlignItems.Center}>
+        <Icon glyph={IconFont.Plus_New} className="button-icon" />
+        <span>Create Organization</span>
+      </FlexBox>
+    </Dropdown.Item>
+  )
+}
+export default CreateOrganizationMenuItem

--- a/src/identity/components/GlobalHeader/GlobalHeaderDropdown/GlobalHeaderDropdown.scss
+++ b/src/identity/components/GlobalHeader/GlobalHeaderDropdown/GlobalHeaderDropdown.scss
@@ -72,6 +72,11 @@
   background-color: rgba(241, 241, 243, 0.1);
 }
 
+.section-break {
+  margin: 10px 0;
+  background-color: rgba(241, 241, 243, 0.1);
+}
+
 .upgrade-payg-add-org--button {
   @include gradient-diag-up($c-rainforest, $c-pool);
 

--- a/src/identity/components/GlobalHeader/GlobalHeaderDropdown/GlobalHeaderDropdown.scss
+++ b/src/identity/components/GlobalHeader/GlobalHeaderDropdown/GlobalHeaderDropdown.scss
@@ -71,3 +71,17 @@
   margin: 6px 0;
   background-color: rgba(241, 241, 243, 0.1);
 }
+
+.upgrade-payg-add-org--button {
+  @include gradient-diag-up($c-rainforest, $c-pool);
+
+  > a {
+    > span.button-icon {
+      color: white;
+    }
+
+    > span.button-icon + span {
+      font-weight: bold;
+    }
+  }
+}

--- a/src/identity/components/GlobalHeader/GlobalHeaderDropdown/GlobalHeaderDropdown.scss
+++ b/src/identity/components/GlobalHeader/GlobalHeaderDropdown/GlobalHeaderDropdown.scss
@@ -72,12 +72,8 @@
   background-color: rgba(241, 241, 243, 0.1);
 }
 
-.section-break {
-  margin: 10px 0;
-  background-color: rgba(241, 241, 243, 0.1);
-}
-
 .upgrade-payg-add-org--button {
+  margin: 6px 0;
   @include gradient-diag-up($c-rainforest, $c-pool);
 
   > a {

--- a/src/identity/components/GlobalHeader/GlobalHeaderDropdown/index.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeaderDropdown/index.tsx
@@ -151,20 +151,17 @@ export class GlobalHeaderDropdown extends React.Component<Props, State> {
 
   private renderMainMenuOptions = (onCollapse: VoidFunction) => {
     const {mainMenuOptions} = this.props
-    return (
-      <div>
-        {mainMenuOptions.reduce((prev, curr) => {
-          if (curr?.showDivider) {
-            prev.push(
-              <hr key={`SectionBreak ${curr.name}`} className="section-break" />
-            )
-          }
-          prev.push(this.getMainMenuOption(curr, onCollapse))
+    const options = []
+    mainMenuOptions.forEach(option => {
+      if (option.showDivider) {
+        options.push(
+          <hr key={`SectionBreak ${option.name}`} className="line-break" />
+        )
+      }
+      options.push(this.getMainMenuOption(option, onCollapse))
+    })
 
-          return prev
-        }, [])}
-      </div>
-    )
+    return options
   }
 
   private renderTypeAheadMenu = () => {

--- a/src/identity/components/GlobalHeader/GlobalHeaderDropdown/index.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeaderDropdown/index.tsx
@@ -33,6 +33,7 @@ export interface MainMenuItem {
   iconFont: string
   href: string
   className?: string
+  showDivider?: boolean
 }
 
 export interface TypeAheadMenuItem {
@@ -114,42 +115,54 @@ export class GlobalHeaderDropdown extends React.Component<Props, State> {
     this.setState({showTypeAheadMenu: !showTypeAheadMenu})
   }
 
+  private getMainMenuOption = (
+    menuItem: MainMenuItem,
+    onCollapse: VoidFunction
+  ) => {
+    const iconEl = <Icon glyph={menuItem.iconFont} className="button-icon" />
+    const textEl = <span>{menuItem.name}</span>
+    const addMoreOrgsClassNames = classNames(
+      'global-header--main-dropdown-item',
+      menuItem.className ?? ''
+    )
+    return (
+      <div
+        onClick={this.sendMainMenuEvent(menuItem.name)}
+        key={`eventWrapper.${menuItem.name}`}
+      >
+        <Dropdown.LinkItem
+          className={addMoreOrgsClassNames}
+          key={menuItem.name}
+          testID={`${this.props.mainMenuTestID}-${menuItem.name}`}
+          selected={false}
+        >
+          <Link
+            to={menuItem.href}
+            className="global-header--main-dropdown-item-link"
+            onClick={onCollapse}
+          >
+            {iconEl}
+            {textEl}
+          </Link>
+        </Dropdown.LinkItem>
+      </div>
+    )
+  }
+
   private renderMainMenuOptions = (onCollapse: VoidFunction) => {
     const {mainMenuOptions} = this.props
     return (
       <div>
-        {mainMenuOptions.map(menuItem => {
-          const iconEl = (
-            <Icon glyph={menuItem.iconFont} className="button-icon" />
-          )
-          const textEl = <span>{menuItem.name}</span>
-          const addMoreOrgsClassNames = classNames(
-            'global-header--main-dropdown-item',
-            menuItem.className ?? ''
-          )
-          return (
-            <div
-              onClick={this.sendMainMenuEvent(menuItem.name)}
-              key={`eventWrapper.${menuItem.name}`}
-            >
-              <Dropdown.LinkItem
-                className={addMoreOrgsClassNames}
-                key={menuItem.name}
-                testID={`${this.props.mainMenuTestID}-${menuItem.name}`}
-                selected={false}
-              >
-                <Link
-                  to={menuItem.href}
-                  className="global-header--main-dropdown-item-link"
-                  onClick={onCollapse}
-                >
-                  {iconEl}
-                  {textEl}
-                </Link>
-              </Dropdown.LinkItem>
-            </div>
-          )
-        })}
+        {mainMenuOptions.reduce((prev, curr) => {
+          if (curr?.showDivider) {
+            prev.push(
+              <hr key={`SectionBreak ${curr.name}`} className="section-break" />
+            )
+          }
+          prev.push(this.getMainMenuOption(curr, onCollapse))
+
+          return prev
+        }, [])}
       </div>
     )
   }

--- a/src/identity/components/GlobalHeader/GlobalHeaderDropdown/index.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeaderDropdown/index.tsx
@@ -1,6 +1,7 @@
 // Libraries
 import React, {MouseEvent} from 'react'
 import {Link} from 'react-router-dom'
+import classNames from 'classnames'
 
 // Components
 import {
@@ -14,12 +15,12 @@ import {
   JustifyContent,
   StandardFunctionProps,
 } from '@influxdata/clockface'
+import GlobalHeaderTypeAheadMenu from 'src/identity/components/GlobalHeader/GlobalHeaderDropdown/GlobalHeaderTypeAheadMenu'
 
 // Styles
-import './GlobalHeaderDropdown.scss'
+import 'src/identity/components/GlobalHeader/GlobalHeaderDropdown/GlobalHeaderDropdown.scss'
 
 // Types
-import GlobalHeaderTypeAheadMenu from 'src/identity/components/GlobalHeader/GlobalHeaderDropdown/GlobalHeaderTypeAheadMenu'
 
 // Eventing
 import {
@@ -33,6 +34,7 @@ export interface MainMenuItem {
   name: string
   iconFont: string
   href: string
+  className?: string
 }
 
 export interface TypeAheadMenuItem {
@@ -60,6 +62,7 @@ export interface Props extends StandardFunctionProps {
   typeAheadOnSelectOption?: (item: TypeAheadMenuItem | null) => void
   typeAheadSelectedOption?: TypeAheadMenuItem
   typeAheadTestID?: string
+  additionalHeaderItems?: JSX.Element[]
 }
 
 type State = {
@@ -122,13 +125,17 @@ export class GlobalHeaderDropdown extends React.Component<Props, State> {
             <Icon glyph={menuItem.iconFont} className="button-icon" />
           )
           const textEl = <span>{menuItem.name}</span>
+          const addMoreOrgsClassNames = classNames(
+            'global-header--main-dropdown-item',
+            menuItem.className ?? ''
+          )
           return (
             <div
               onClick={this.sendMainMenuEvent(menuItem.name)}
               key={`eventWrapper.${menuItem.name}`}
             >
               <Dropdown.LinkItem
-                className="global-header--main-dropdown-item"
+                className={addMoreOrgsClassNames}
                 key={menuItem.name}
                 testID={`${this.props.mainMenuTestID}-${menuItem.name}`}
                 selected={false}
@@ -178,6 +185,7 @@ export class GlobalHeaderDropdown extends React.Component<Props, State> {
       mainMenuHeaderText,
       onlyRenderSubmenu = false,
       typeAheadMenuOptions,
+      additionalHeaderItems = [],
     } = this.props
     const {showTypeAheadMenu} = this.state
 
@@ -188,6 +196,14 @@ export class GlobalHeaderDropdown extends React.Component<Props, State> {
         className="button-icon"
       />
     )
+    const showSwitchOrgItem =
+      !onlyRenderSubmenu && typeAheadMenuOptions.length > 1
+    const showAdditionalHeaderItems =
+      !onlyRenderSubmenu &&
+      !showTypeAheadMenu &&
+      additionalHeaderItems.length > 0
+    const showDivider = showSwitchOrgItem || showAdditionalHeaderItems
+
     return (
       <Dropdown.Menu
         style={dropdownMenuStyle}
@@ -195,8 +211,8 @@ export class GlobalHeaderDropdown extends React.Component<Props, State> {
         testID={this.props.mainMenuTestID}
       >
         {/* Multi-org UI tickets #4051 and #4047, when user only has 1 account or 1 org, switch button is disabled */}
-        {!onlyRenderSubmenu && typeAheadMenuOptions.length > 1 && (
-          <>
+        <>
+          {showSwitchOrgItem && (
             <Dropdown.Item
               onClick={this.toggleShowTypeAheadMenu}
               className="global-header--switch-button"
@@ -218,9 +234,10 @@ export class GlobalHeaderDropdown extends React.Component<Props, State> {
                 )}
               </FlexBox>
             </Dropdown.Item>
-            <hr className="line-break" />
-          </>
-        )}
+          )}
+          {showAdditionalHeaderItems && additionalHeaderItems}
+          {showDivider && <hr className="line-break" />}
+        </>
         {showTypeAheadMenu
           ? this.renderTypeAheadMenu()
           : this.renderMainMenuOptions(onCollapse)}

--- a/src/identity/components/GlobalHeader/GlobalHeaderDropdown/index.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeaderDropdown/index.tsx
@@ -18,7 +18,7 @@ import {
 import GlobalHeaderTypeAheadMenu from 'src/identity/components/GlobalHeader/GlobalHeaderDropdown/GlobalHeaderTypeAheadMenu'
 
 // Styles
-import 'src/identity/components/GlobalHeader/GlobalHeaderDropdown/GlobalHeaderDropdown.scss'
+import './GlobalHeaderDropdown.scss'
 
 // Types
 

--- a/src/identity/components/GlobalHeader/GlobalHeaderDropdown/index.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeaderDropdown/index.tsx
@@ -20,8 +20,6 @@ import GlobalHeaderTypeAheadMenu from 'src/identity/components/GlobalHeader/Glob
 // Styles
 import './GlobalHeaderDropdown.scss'
 
-// Types
-
 // Eventing
 import {
   MainMenuEventPrefix,

--- a/src/identity/components/GlobalHeader/OrgDropdown.tsx
+++ b/src/identity/components/GlobalHeader/OrgDropdown.tsx
@@ -78,6 +78,7 @@ export const OrgDropdown: FC<Props> = ({activeOrg, orgsList}) => {
       iconFont: IconFont.CrownSolid_New,
       href: '/checkout',
       className: 'upgrade-payg-add-org--button',
+      showDivider: true,
     })
   }
 

--- a/src/identity/components/GlobalHeader/OrgDropdown.tsx
+++ b/src/identity/components/GlobalHeader/OrgDropdown.tsx
@@ -39,7 +39,7 @@ interface Props {
   orgsList: OrganizationSummaries
 }
 
-const menuStyle = {width: '250px'}
+const menuStyle = {width: '250px', padding: '16px'}
 const orgDropdownStyle = {width: 'auto'}
 
 export const OrgDropdown: FC<Props> = ({activeOrg, orgsList}) => {

--- a/src/identity/components/GlobalHeader/OrgDropdown.tsx
+++ b/src/identity/components/GlobalHeader/OrgDropdown.tsx
@@ -5,6 +5,7 @@ import {IconFont} from '@influxdata/clockface'
 // Components
 import {
   GlobalHeaderDropdown,
+  MainMenuItem,
   TypeAheadMenuItem,
 } from 'src/identity/components/GlobalHeader/GlobalHeaderDropdown'
 
@@ -23,6 +24,14 @@ import {
 } from 'src/identity/events/multiOrgEvents'
 import {event} from 'src/cloud/utils/reporting'
 
+// Utils
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+
+// Selectors
+import {useSelector} from 'react-redux'
+import {selectCurrentAccountType} from 'src/identity/selectors'
+import CreateOrganizationMenuItem from 'src/identity/components/GlobalHeader/GlobalHeaderDropdown/CreateOrganization/MenuItem'
+
 type OrgSummaryItem = OrganizationSummaries[number]
 
 interface Props {
@@ -34,6 +43,7 @@ const menuStyle = {width: '250px'}
 const orgDropdownStyle = {width: 'auto'}
 
 export const OrgDropdown: FC<Props> = ({activeOrg, orgsList}) => {
+  const accountType = useSelector(selectCurrentAccountType)
   const switchOrg = (org: TypeAheadMenuItem) => {
     event(HeaderNavEvent.OrgSwitch, multiOrgTag, {
       oldOrgID: activeOrg.id,
@@ -44,7 +54,7 @@ export const OrgDropdown: FC<Props> = ({activeOrg, orgsList}) => {
     window.location.href = `${CLOUD_URL}/orgs/${org.id}`
   }
 
-  const orgMainMenu = [
+  const orgMainMenu: MainMenuItem[] = [
     {
       name: 'Settings',
       iconFont: IconFont.CogSolid_New,
@@ -62,8 +72,27 @@ export const OrgDropdown: FC<Props> = ({activeOrg, orgsList}) => {
     },
   ]
 
+  if (isFlagEnabled('createDeleteOrgs') && accountType === 'free') {
+    orgMainMenu.push({
+      name: 'Add More Organizations',
+      iconFont: IconFont.CrownSolid_New,
+      href: '/checkout',
+      className: 'upgrade-payg-add-org--button',
+    })
+  }
+
   const sendDropdownClickEvent = () => {
     event(HeaderNavEvent.OrgDropdownClick, multiOrgTag)
+  }
+
+  const additionalHeaderItems = []
+  if (
+    isFlagEnabled('createDeleteOrgs') &&
+    (accountType === 'contract' || accountType === 'pay_as_you_go')
+  ) {
+    additionalHeaderItems.push(
+      <CreateOrganizationMenuItem key="CreateOrgMenuItem" />
+    )
   }
 
   return (
@@ -83,6 +112,7 @@ export const OrgDropdown: FC<Props> = ({activeOrg, orgsList}) => {
         typeAheadOnSelectOption={switchOrg}
         typeAheadSelectedOption={activeOrg}
         typeAheadTestID="globalheader--org-dropdown-typeahead"
+        additionalHeaderItems={additionalHeaderItems}
       />
     </div>
   )

--- a/src/identity/components/GlobalHeader/OrgDropdown.tsx
+++ b/src/identity/components/GlobalHeader/OrgDropdown.tsx
@@ -30,7 +30,7 @@ import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 // Selectors
 import {useSelector} from 'react-redux'
 import {selectCurrentAccountType} from 'src/identity/selectors'
-import CreateOrganizationMenuItem from 'src/identity/components/GlobalHeader/GlobalHeaderDropdown/CreateOrganization/MenuItem'
+import {CreateOrganizationMenuItem} from 'src/identity/components/GlobalHeader/GlobalHeaderDropdown/CreateOrganization/MenuItem'
 
 type OrgSummaryItem = OrganizationSummaries[number]
 


### PR DESCRIPTION
Closes #5898 

This work is behind `createDeleteOrgs` feature flag.

Add menu items in Global Header.
**For FREE accounts, add `Add More Organizations` menu-item:** which redirects to `/checkout`
![image](https://user-images.githubusercontent.com/1637395/192877516-77acd7ba-e34c-4bf0-986a-2ec71dd1afbc.png)

**For PAYG and Contract accounts, add `Create Organization` menu-item:**
![image](https://user-images.githubusercontent.com/1637395/192877841-af3b3c4d-748c-451e-8ae6-284674bab275.png)
When you click on `Create Organization`, it's supposed to show a modal and that work is slated for #5899 

More details on mockups are to be found here: https://www.figma.com/file/fvVSKwnepmRWvzFlIxCWCe/Multi-org?node-id=1961%3A18426



### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
