### PR TITLE
fix(5809): test and debug composition divergence with hotkeys.

### DIFF
--- a/cypress/e2e/shared/fluxQueryBuilder.test.ts
+++ b/cypress/e2e/shared/fluxQueryBuilder.test.ts
@@ -367,17 +367,6 @@ describe('Script Builder', () => {
           cy.getByTestID('flux-sync--toggle').should('have.class', 'disabled')
         })
 
-        it('deleting the entire composition block, does NOT diverge; still able to create next composition', () => {
-          cy.getByTestID('flux-sync--toggle').should('have.class', 'active')
-          cy.getByTestID('flux-editor', {timeout: 30000})
-          selectSchema()
-          confirmSchemaComposition()
-          cy.getByTestID('flux-editor').monacoType('{selectall}{backspace}')
-
-          cy.log('sync is still active')
-          cy.getByTestID('flux-sync--toggle').should('have.class', 'active')
-        })
-
         describe('using hotkeys:', () => {
           const runTest = (hotKeyCombo: string) => {
             cy.getByTestID('flux-sync--toggle').should('have.class', 'active')

--- a/cypress/e2e/shared/fluxQueryBuilder.test.ts
+++ b/cypress/e2e/shared/fluxQueryBuilder.test.ts
@@ -62,7 +62,7 @@ describe('Script Builder', () => {
     })
   }
 
-  before(() => {
+  beforeEach(() => {
     cy.flush().then(() => {
       cy.signin().then(() => {
         cy.get('@org').then(({id, name}: Organization) => {

--- a/cypress/e2e/shared/fluxQueryBuilder.test.ts
+++ b/cypress/e2e/shared/fluxQueryBuilder.test.ts
@@ -62,7 +62,7 @@ describe('Script Builder', () => {
     })
   }
 
-  beforeEach(() => {
+  before(() => {
     cy.flush().then(() => {
       cy.signin().then(() => {
         cy.get('@org').then(({id, name}: Organization) => {

--- a/src/languageSupport/languages/flux/lsp/connection.ts
+++ b/src/languageSupport/languages/flux/lsp/connection.ts
@@ -135,6 +135,10 @@ class LspConnectionManager {
     })
   }
 
+  /// XXX: wiedld (27 Sep 2022) -- This heuristic is wrong.
+  /// We currently have no way to detect when a change is due to an applyEdit from the LSP.
+  /// versus other changes in the same range, with the same `|> yield(name: "_editor_composition")` included.
+  /// one example is the undo [cmd+z], which "looks" exactly like the previous applyEdit.
   _editorChangeIsFromLsp(change) {
     return change.text?.includes('|> yield(name: "_editor_composition")')
   }

--- a/src/languageSupport/languages/flux/lsp/connection.ts
+++ b/src/languageSupport/languages/flux/lsp/connection.ts
@@ -13,6 +13,7 @@ import {
   SchemaSelection,
 } from 'src/dataExplorer/context/persistance'
 import {CompositionInitParams} from 'src/languageSupport/languages/flux/lsp/utils'
+import {comments} from 'src/languageSupport/languages/flux/monaco.flux.hotkeys'
 
 // LSP methods
 import {
@@ -174,6 +175,22 @@ class LspConnectionManager {
       )
       if (shouldDiverge && !this._session.composition.diverged) {
         event('Schema composition diverged - disable Flux Sync toggle')
+        this._callbackSetSession({
+          composition: {synced: false, diverged: true},
+        })
+      }
+    })
+
+    comments(this._editor, selection => {
+      const compositionBlock = this._getCompositionBlockLines()
+      if (!compositionBlock) {
+        return
+      }
+      const {startLine, endLine} = compositionBlock
+      if (
+        selection.startLineNumber >= startLine &&
+        selection.endLineNumber <= endLine
+      ) {
         this._callbackSetSession({
           composition: {synced: false, diverged: true},
         })

--- a/src/languageSupport/languages/flux/monaco.flux.hotkeys.ts
+++ b/src/languageSupport/languages/flux/monaco.flux.hotkeys.ts
@@ -1,4 +1,4 @@
-import {EditorType} from 'src/types'
+import {EditorType, MonacoSelectionRange} from 'src/types'
 
 export const toggleCommenting = (s: string, isTogglingOn: boolean) => {
   if (isTogglingOn) {
@@ -9,7 +9,10 @@ export const toggleCommenting = (s: string, isTogglingOn: boolean) => {
 
 export const isCommented = (s: string) => !!s.match(/^\s*(\/\/(.*)$)/g)
 
-export function comments(editor: EditorType) {
+export function comments(
+  editor: EditorType,
+  cb: (x: MonacoSelectionRange) => void = _ => {}
+) {
   editor.addAction({
     // An unique identifier of the contributed action.
     id: 'toggle-comment',
@@ -48,6 +51,8 @@ export function comments(editor: EditorType) {
           ? positionColumn + 3
           : positionColumn - 3,
       })
+
+      cb(selection)
 
       return null
     },

--- a/src/types/monaco.ts
+++ b/src/types/monaco.ts
@@ -6,3 +6,4 @@ export type EditorType = allMonaco.editor.IStandaloneCodeEditor
 export type CursorEvent = allMonaco.editor.ICursorPositionChangedEvent
 export type KeyboardEvent = allMonaco.IKeyboardEvent
 export type MonacoRange = allMonaco.Range
+export type MonacoSelectionRange = allMonaco.Selection


### PR DESCRIPTION
Closes #5809 


## Bug:
* we found one example where hotkeys were not triggering the composition divergence, while editing the composition block.
  * bug found: commenting out --> was not diverging. 
* goal of this PR is to test the suite of default hotkeys:
  * to make sure we diverge properly.
  * fix it when we don't.


## Approach:
* what we care about per hotkey action, is if there is:
   1. a code change triggered (resulting in a monaco-editor change object).
   2. the change occurs in the composition block .
* since our code is checking the outcomes (e.g. the change object), we can write a test per class of change.
  * hotkey action classes:
    * add lines
    * remove lines
    * move lines, without impacting line counts
    * mutate lines in place.
  * we wrote general test cases for all of these^^, except for the mutate-in-place changes.
* mutate-in-place changes:
  * two flavors, position-specific and non-specific.
  * for positional-specific:
       * we can detect the position of the cursor at the moment of hotkey triggering.
       * e.g. commenting lines
  * for non-specific:
       * we can only look at the monaco-editor change object, which we are already doing.
          * then we use heuristics to determine if the change object is triggered by the LSP-applyEdits.
       * we can have cases where the hotkey action looks exactly like an LSP-applyEdit change.
          * e.g. undo/redo
          *  for now, we cannot handle those.

## Vid:
Commenting out --> now diverges.

https://user-images.githubusercontent.com/10232835/192909443-fad0690c-e511-4b2f-8c66-17e91274911c.mov


## Caveats:
We get diminishing returns pretty quickly, since a lot of our detection of "did this change in the composition block?" relies upon:
* our current approach to identifying the composition block. Meaning, we take line 1 --> line yield.
* trying to diff between LSP applyEdits (w/ composition ownership), versus user changes.

The user can pretty easily make a change which complete destroys our detection using these^^ two factors. We have hardcoded in most of the general cases, but covering all the edge cases is messy. Plus we plan to update the definition of "what is a composition block" and remove the diverge detection, within Q4.



## Checklist
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] ~Feature flagged, if applicable~  N/A
