### PR TITLE
fix: split up quartz-identity redux loading state into three states

### DIFF
--- a/src/billing/components/BillingPageContents.tsx
+++ b/src/billing/components/BillingPageContents.tsx
@@ -10,8 +10,14 @@ import BillingFree from 'src/billing/components/Free/Free'
 import BillingPayAsYouGo from 'src/billing/components/PayAsYouGo/PayAsYouGo'
 import MarketplaceBilling from 'src/billing/components/marketplace/MarketplaceBilling'
 
+// Types
+import {RemoteDataState} from 'src/types'
+
 // Utils
-import {selectCurrentIdentity} from 'src/identity/selectors'
+import {
+  selectCurrentIdentity,
+  selectQuartzBillingStatus,
+} from 'src/identity/selectors'
 
 // Thunks
 import {getBillingProviderThunk} from 'src/identity/actions/thunks'
@@ -19,16 +25,17 @@ import {getBillingProviderThunk} from 'src/identity/actions/thunks'
 const BillingPageContents: FC = () => {
   const dispatch = useDispatch()
   const {account} = useSelector(selectCurrentIdentity)
+  const quartzBillingStatus = useSelector(selectQuartzBillingStatus)
 
   useEffect(() => {
     if (!CLOUD) {
       return
     }
 
-    if (!account.billingProvider) {
+    if (quartzBillingStatus === RemoteDataState.NotStarted) {
       dispatch(getBillingProviderThunk())
     }
-  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [dispatch, quartzBillingStatus])
 
   if (account.billingProvider === undefined) {
     return null

--- a/src/identity/actions/creators/index.ts
+++ b/src/identity/actions/creators/index.ts
@@ -5,7 +5,10 @@ import {BillingProvider, RemoteDataState} from 'src/types'
 export const SET_QUARTZ_IDENTITY = 'SET_QUARTZ_IDENTITY'
 export const SET_QUARTZ_IDENTITY_STATUS = 'SET_QUARTZ_IDENTITY_STATUS'
 export const SET_CURRENT_BILLING_PROVIDER = 'SET_CURRENT_BILLING_PROVIDER'
+export const SET_CURRENT_BILLING_PROVIDER_STATUS =
+  'SET_CURRENT_BILLING_PROVIDER_STATUS'
 export const SET_CURRENT_ORG_DETAILS = 'SET_CURRENT_ORG_DETAILS'
+export const SET_CURRENT_ORG_DETAILS_STATUS = 'SET_CURRENT_ORG_DETAILS_STATUS'
 export const SET_CURRENT_IDENTITY_ACCOUNT_NAME =
   'SET_CURRENT_IDENTITY_ACCOUNT_NAME'
 
@@ -13,7 +16,9 @@ export type Actions =
   | ReturnType<typeof setQuartzIdentity>
   | ReturnType<typeof setQuartzIdentityStatus>
   | ReturnType<typeof setCurrentBillingProvider>
+  | ReturnType<typeof setCurrentBillingProviderStatus>
   | ReturnType<typeof setCurrentOrgDetails>
+  | ReturnType<typeof setCurrentOrgDetailsStatus>
   | ReturnType<typeof setCurrentIdentityAccountName>
 
 export const setQuartzIdentity = (identity: CurrentIdentity) =>
@@ -22,10 +27,22 @@ export const setQuartzIdentity = (identity: CurrentIdentity) =>
     identity: identity,
   } as const)
 
+export const setQuartzIdentityStatus = (status: RemoteDataState) =>
+  ({
+    type: SET_QUARTZ_IDENTITY_STATUS,
+    status,
+  } as const)
+
 export const setCurrentBillingProvider = (billingProvider: BillingProvider) =>
   ({
     type: SET_CURRENT_BILLING_PROVIDER,
     billingProvider: billingProvider,
+  } as const)
+
+export const setCurrentBillingProviderStatus = (status: RemoteDataState) =>
+  ({
+    type: SET_CURRENT_BILLING_PROVIDER_STATUS,
+    status,
   } as const)
 
 export const setCurrentOrgDetails = (orgDetails: CurrentOrg) =>
@@ -34,9 +51,9 @@ export const setCurrentOrgDetails = (orgDetails: CurrentOrg) =>
     org: orgDetails,
   } as const)
 
-export const setQuartzIdentityStatus = (status: RemoteDataState) =>
+export const setCurrentOrgDetailsStatus = (status: RemoteDataState) =>
   ({
-    type: SET_QUARTZ_IDENTITY_STATUS,
+    type: SET_CURRENT_ORG_DETAILS_STATUS,
     status,
   } as const)
 

--- a/src/identity/actions/thunks/index.ts
+++ b/src/identity/actions/thunks/index.ts
@@ -5,6 +5,8 @@ import {
   setCurrentBillingProvider,
   setQuartzIdentity,
   setQuartzIdentityStatus,
+  setCurrentBillingProviderStatus,
+  setCurrentOrgDetailsStatus,
 } from 'src/identity/actions/creators'
 
 // Types
@@ -34,6 +36,7 @@ export const getQuartzIdentityThunk =
       const quartzIdentity = await fetchQuartzIdentity()
 
       dispatch(setQuartzIdentity(quartzIdentity))
+
       dispatch(setQuartzIdentityStatus(RemoteDataState.Done))
 
       const legacyMe = convertIdentityToMe(quartzIdentity)
@@ -53,7 +56,7 @@ export const getQuartzIdentityThunk =
 export const getBillingProviderThunk =
   () => async (dispatch: Dispatch<ActionTypes>, getState: GetState) => {
     try {
-      dispatch(setQuartzIdentityStatus(RemoteDataState.Loading))
+      dispatch(setCurrentBillingProviderStatus(RemoteDataState.Loading))
 
       const currentState = getState()
       const accountId = currentState.identity.currentIdentity.account.id
@@ -61,7 +64,7 @@ export const getBillingProviderThunk =
       const accountDetails = await fetchAccountDetails(accountId)
 
       dispatch(setCurrentBillingProvider(accountDetails.billingProvider))
-      dispatch(setQuartzIdentityStatus(RemoteDataState.Done))
+      dispatch(setCurrentBillingProviderStatus(RemoteDataState.Done))
       const updatedState = getState()
       const legacyMe = convertIdentityToMe(
         updatedState.identity.currentIdentity
@@ -69,7 +72,7 @@ export const getBillingProviderThunk =
       dispatch(setQuartzMe(legacyMe, RemoteDataState.Done))
       dispatch(setQuartzMeStatus(RemoteDataState.Done))
     } catch (err) {
-      dispatch(setQuartzIdentityStatus(RemoteDataState.Error))
+      dispatch(setCurrentBillingProviderStatus(RemoteDataState.Error))
       dispatch(setQuartzMeStatus(RemoteDataState.Error))
 
       reportErrorThroughHoneyBadger(err, {
@@ -82,12 +85,12 @@ export const getBillingProviderThunk =
 export const getCurrentOrgDetailsThunk =
   (orgId: string) => async (dispatch: any, getState: GetState) => {
     try {
-      dispatch(setQuartzIdentityStatus(RemoteDataState.Loading))
+      dispatch(setCurrentOrgDetailsStatus(RemoteDataState.Loading))
 
       const orgDetails = await fetchOrgDetails(orgId)
 
       dispatch(setCurrentOrgDetails(orgDetails))
-      dispatch(setQuartzIdentityStatus(RemoteDataState.Done))
+      dispatch(setCurrentOrgDetailsStatus(RemoteDataState.Done))
 
       const updatedState = getState()
       const legacyMe = convertIdentityToMe(
@@ -96,7 +99,7 @@ export const getCurrentOrgDetailsThunk =
       dispatch(setQuartzMe(legacyMe, RemoteDataState.Done))
       dispatch(setQuartzMeStatus(RemoteDataState.Done))
     } catch (err) {
-      dispatch(setQuartzIdentityStatus(RemoteDataState.Error))
+      dispatch(setCurrentOrgDetailsStatus(RemoteDataState.Error))
       dispatch(setQuartzMeStatus(RemoteDataState.Error))
 
       reportErrorThroughHoneyBadger(err, {

--- a/src/identity/apis/auth.ts
+++ b/src/identity/apis/auth.ts
@@ -57,11 +57,17 @@ export type QuartzOrganizations = {
   status?: RemoteDataState
 }
 
+export interface IdentityLoadingStatus {
+  identityStatus: RemoteDataState
+  billingStatus: RemoteDataState
+  orgDetailsStatus: RemoteDataState
+}
+
 export interface CurrentIdentity {
   user: IdentityUser
   account: CurrentAccount
   org: CurrentOrg
-  status?: RemoteDataState
+  loadingStatus?: IdentityLoadingStatus
 }
 
 export enum NetworkErrorTypes {

--- a/src/identity/mockUserData.ts
+++ b/src/identity/mockUserData.ts
@@ -1,5 +1,5 @@
 import {CurrentIdentity, CurrentOrg} from 'src/identity/apis/auth'
-import {BillingProvider} from 'src/types'
+import {BillingProvider, RemoteDataState} from 'src/types'
 
 export const mockBillingProviders: BillingProvider[] = [
   'zuora',
@@ -16,6 +16,7 @@ export const mockIdentities: CurrentIdentity[] = [
       name: 'TestCo',
       paygCreditStartDate: null,
       type: 'free',
+      isUpgradeable: true,
     },
     org: {
       clusterHost: 'https://fakehost.fakehost.fake',
@@ -31,6 +32,11 @@ export const mockIdentities: CurrentIdentity[] = [
       operatorRole: null,
       orgCount: 1,
     },
+    loadingStatus: {
+      identityStatus: RemoteDataState.NotStarted,
+      billingStatus: RemoteDataState.NotStarted,
+      orgDetailsStatus: RemoteDataState.NotStarted,
+    },
   },
   {
     account: {
@@ -39,6 +45,7 @@ export const mockIdentities: CurrentIdentity[] = [
       name: 'TestCo 2',
       paygCreditStartDate: null,
       type: 'contract',
+      isUpgradeable: false,
     },
     org: {
       clusterHost: 'https://newhost.newhost.new',
@@ -54,6 +61,11 @@ export const mockIdentities: CurrentIdentity[] = [
       operatorRole: null,
       orgCount: 3,
     },
+    loadingStatus: {
+      identityStatus: RemoteDataState.NotStarted,
+      billingStatus: RemoteDataState.NotStarted,
+      orgDetailsStatus: RemoteDataState.NotStarted,
+    },
   },
   {
     account: {
@@ -62,6 +74,7 @@ export const mockIdentities: CurrentIdentity[] = [
       name: 'Test Name 3',
       paygCreditStartDate: null,
       type: 'pay_as_you_go',
+      isUpgradeable: false,
     },
     org: {
       clusterHost: 'https://testdomain.testdomain.org',
@@ -76,6 +89,11 @@ export const mockIdentities: CurrentIdentity[] = [
       lastName: 'Email',
       operatorRole: null,
       orgCount: 5,
+    },
+    loadingStatus: {
+      identityStatus: RemoteDataState.NotStarted,
+      billingStatus: RemoteDataState.NotStarted,
+      orgDetailsStatus: RemoteDataState.NotStarted,
     },
   },
 ]

--- a/src/identity/quartzOrganizations/actions/thunks/index.ts
+++ b/src/identity/quartzOrganizations/actions/thunks/index.ts
@@ -58,6 +58,8 @@ export const getQuartzOrganizationsThunk =
       const quartzOrganizations = await fetchOrgsByAccountID(accountId)
 
       dispatch(setQuartzOrganizations(quartzOrganizations))
+
+      dispatch(setQuartzOrganizationsStatus(RemoteDataState.Done))
     } catch (err) {
       reportErrorThroughHoneyBadger(err, {
         name: 'Failed to fetch /quartz/orgs/',
@@ -80,13 +82,15 @@ export const updateDefaultOrgThunk =
       dispatch(setQuartzDefaultOrg(newDefaultOrg.id))
 
       const state = getState()
-      const orgStatus = state.identity.currentIdentity.status
+      const orgStatus = state.identity.quartzOrganizations.status
 
       if (orgStatus === RemoteDataState.Error) {
         throw new DefaultOrgStateError(
           OrganizationThunkErrors.DefaultOrgStateError
         )
       }
+
+      dispatch(setQuartzOrganizationsStatus(RemoteDataState.Done))
     } catch (err) {
       reportErrorThroughHoneyBadger(err, {
         name: err.name,

--- a/src/identity/quartzOrganizations/reducers/index.test.ts
+++ b/src/identity/quartzOrganizations/reducers/index.test.ts
@@ -6,6 +6,7 @@ import {initialState} from 'src/identity/quartzOrganizations/reducers'
 import {
   setQuartzDefaultOrg,
   setQuartzOrganizations,
+  setQuartzOrganizationsStatus,
 } from 'src/identity/quartzOrganizations/actions/creators'
 
 // Mocks
@@ -36,10 +37,14 @@ describe('identity reducer for quartz organizations', () => {
       expect(oldState.orgs).toStrictEqual(mockOrgData)
     })
 
-    it('sets a `Done` state when the organization array is loaded into state', () => {
+    it('sets a `Done` state after the organization array is loaded into state', () => {
       const newState = reducer(undefined, setQuartzOrganizations(mockOrgData))
+      const newStateWithUpdatedStatus = reducer(
+        newState,
+        setQuartzOrganizationsStatus(RemoteDataState.Done)
+      )
 
-      expect(newState.status).toEqual(RemoteDataState.Done)
+      expect(newStateWithUpdatedStatus.status).toEqual(RemoteDataState.Done)
     })
   })
 

--- a/src/identity/quartzOrganizations/reducers/index.ts
+++ b/src/identity/quartzOrganizations/reducers/index.ts
@@ -23,8 +23,6 @@ export default (state = initialState, action: Actions): QuartzOrganizations =>
     switch (action.type) {
       case SET_QUARTZ_ORGANIZATIONS: {
         draftState.orgs = action.quartzOrganizations
-        draftState.status = RemoteDataState.Done
-
         return
       }
 

--- a/src/identity/reducers/index.test.ts
+++ b/src/identity/reducers/index.test.ts
@@ -1,3 +1,6 @@
+import {RemoteDataState} from 'src/types'
+import {cloneDeep} from 'lodash'
+
 // Reducer
 import reducer from 'src/identity/reducers'
 import {initialState} from 'src/identity/reducers'
@@ -5,8 +8,11 @@ import {initialState} from 'src/identity/reducers'
 // Actions
 import {
   setQuartzIdentity,
+  setQuartzIdentityStatus,
   setCurrentBillingProvider,
+  setCurrentBillingProviderStatus,
   setCurrentOrgDetails,
+  setCurrentOrgDetailsStatus,
 } from 'src/identity/actions/creators'
 
 // Mocks
@@ -36,6 +42,28 @@ describe('identity reducer', () => {
       expect(actual).toEqual(expectedState)
     })
   })
+
+  it('updates the redux loading state when a status action is dispatched', () => {
+    const identity = cloneDeep(mockIdentities[0])
+
+    // Expect to receive an object containing the mocked identity, with its identity loading status set to 'Done'.
+    const expected = cloneDeep({
+      ...identity,
+      loadingStatus: {
+        identityStatus: RemoteDataState.Done,
+        billingStatus: RemoteDataState.NotStarted,
+        orgDetailsStatus: RemoteDataState.NotStarted,
+      },
+    })
+
+    const updatedIdentity = reducer(undefined, setQuartzIdentity(identity))
+    const actualWithUpdatedStatus = reducer(
+      updatedIdentity,
+      setQuartzIdentityStatus(RemoteDataState.Done)
+    )
+
+    expect(actualWithUpdatedStatus).toEqual(expected)
+  })
 })
 
 describe('billing reducer', () => {
@@ -48,6 +76,36 @@ describe('billing reducer', () => {
       )
       expect(addedProvider.account.billingProvider).toEqual(billingProvider)
     })
+  })
+
+  it('updates the redux loading state when a status action is dispatched', () => {
+    const billingProvider = cloneDeep(mockBillingProviders[0])
+    const addedProvider = reducer(
+      identity,
+      setCurrentBillingProvider(billingProvider)
+    )
+
+    const actualWithUpdatedIdentityStatus = reducer(
+      addedProvider,
+      setQuartzIdentityStatus(RemoteDataState.Done)
+    )
+    const actualWithUpdatedBillingStatus = reducer(
+      actualWithUpdatedIdentityStatus,
+      setCurrentBillingProviderStatus(RemoteDataState.Done)
+    )
+
+    // Expect to receive an object containing the mocked identity, with the new billing provider,
+    // with its identity and billing loading statuses set to "Done."
+    const expected = cloneDeep({
+      ...addedProvider,
+      loadingStatus: {
+        identityStatus: RemoteDataState.Done,
+        billingStatus: RemoteDataState.Done,
+        orgDetailsStatus: RemoteDataState.NotStarted,
+      },
+    })
+
+    expect(actualWithUpdatedBillingStatus).toEqual(expected)
   })
 })
 
@@ -62,5 +120,34 @@ describe('organization reducer', () => {
       }
       expect(newOrg).toEqual(expectedOrg)
     })
+  })
+
+  it('updates the redux loading state when a status action is dispatched', () => {
+    const identityWithUpdatedStatus = reducer(
+      identity,
+      setQuartzIdentityStatus(RemoteDataState.Done)
+    )
+    const newOrg = reducer(
+      identityWithUpdatedStatus,
+      setCurrentOrgDetails(mockOrgDetailsArr[0])
+    )
+    const newOrgWithUpdatedStatus = reducer(
+      newOrg,
+      setCurrentOrgDetailsStatus(RemoteDataState.Done)
+    )
+
+    // Expect to receive an object containing the mocked identity, with the new org details information,
+    // with its identity and org-details loading statuses set to "Done."
+    const expected = cloneDeep({
+      ...identity,
+      org: {...mockOrgDetailsArr[0]},
+      loadingStatus: {
+        identityStatus: RemoteDataState.Done,
+        billingStatus: RemoteDataState.NotStarted,
+        orgDetailsStatus: RemoteDataState.Done,
+      },
+    })
+
+    expect(newOrgWithUpdatedStatus).toEqual(expected)
   })
 })

--- a/src/identity/reducers/index.ts
+++ b/src/identity/reducers/index.ts
@@ -1,7 +1,7 @@
 // Libraries
 import produce from 'immer'
 
-import {CurrentIdentity} from '../apis/auth'
+import {CurrentIdentity} from 'src/identity/apis/auth'
 import {RemoteDataState} from 'src/types'
 
 // Actions
@@ -10,7 +10,9 @@ import {
   SET_QUARTZ_IDENTITY,
   SET_QUARTZ_IDENTITY_STATUS,
   SET_CURRENT_BILLING_PROVIDER,
+  SET_CURRENT_BILLING_PROVIDER_STATUS,
   SET_CURRENT_ORG_DETAILS,
+  SET_CURRENT_ORG_DETAILS_STATUS,
   SET_CURRENT_IDENTITY_ACCOUNT_NAME,
 } from 'src/identity/actions/creators'
 
@@ -37,7 +39,11 @@ export const initialState: CurrentIdentity = {
     paygCreditStartDate: '',
     isUpgradeable: false,
   },
-  status: RemoteDataState.NotStarted,
+  loadingStatus: {
+    identityStatus: RemoteDataState.NotStarted,
+    billingStatus: RemoteDataState.NotStarted,
+    orgDetailsStatus: RemoteDataState.NotStarted,
+  },
 }
 
 export default (state = initialState, action: Actions): CurrentIdentity =>
@@ -67,23 +73,33 @@ export default (state = initialState, action: Actions): CurrentIdentity =>
         draftState.user.lastName = user.lastName
         draftState.user.operatorRole = user.operatorRole
         draftState.user.orgCount = user.orgCount
-
-        draftState = action.identity
-        draftState.status = RemoteDataState.Done
         return
       }
+
       case SET_QUARTZ_IDENTITY_STATUS: {
-        draftState.status = action.status
+        draftState.loadingStatus.identityStatus = action.status
         return
       }
       case SET_CURRENT_BILLING_PROVIDER: {
         draftState.account.billingProvider = action.billingProvider
         return
       }
+
+      case SET_CURRENT_BILLING_PROVIDER_STATUS: {
+        draftState.loadingStatus.billingStatus = action.status
+        return
+      }
+
       case SET_CURRENT_ORG_DETAILS: {
         draftState.org = action.org
         return
       }
+
+      case SET_CURRENT_ORG_DETAILS_STATUS: {
+        draftState.loadingStatus.orgDetailsStatus = action.status
+        return
+      }
+
       case SET_CURRENT_IDENTITY_ACCOUNT_NAME: {
         if (draftState.account.id === action.account.id) {
           draftState.account.name = action.account.name

--- a/src/identity/selectors/index.ts
+++ b/src/identity/selectors/index.ts
@@ -13,7 +13,15 @@ export const selectCurrentIdentity = (
 }
 
 export const selectQuartzIdentityStatus = (state: AppState): RemoteDataState =>
-  state.identity.currentIdentity.status
+  state.identity.currentIdentity.loadingStatus.identityStatus
+
+export const selectQuartzBillingStatus = (state: AppState): RemoteDataState =>
+  state.identity.currentIdentity.loadingStatus.billingStatus
+
+export const selectQuartzOrgDetailsStatus = (
+  state: AppState
+): RemoteDataState =>
+  state.identity.currentIdentity.loadingStatus.orgDetailsStatus
 
 export const selectQuartzOrgs = (
   state: AppState

--- a/src/organizations/components/OrgProfileTab/index.tsx
+++ b/src/organizations/components/OrgProfileTab/index.tsx
@@ -15,13 +15,19 @@ import LabeledData from 'src/organizations/components/OrgProfileTab/LabeledData'
 import CopyableLabeledData from 'src/organizations/components/OrgProfileTab/CopyableLabeledData'
 import DeletePanel from 'src/organizations/components/OrgProfileTab/DeletePanel'
 
+// Types
+import {RemoteDataState} from 'src/types'
+
 // Utils
 import {CLOUD} from 'src/shared/constants'
 
 // Selectors
 import {getMe} from 'src/me/selectors'
 import {getOrg} from 'src/organizations/selectors'
-import {selectCurrentIdentity} from 'src/identity/selectors'
+import {
+  selectCurrentIdentity,
+  selectQuartzOrgDetailsStatus,
+} from 'src/identity/selectors'
 
 // Thunks
 import {getCurrentOrgDetailsThunk} from 'src/identity/actions/thunks'
@@ -33,22 +39,21 @@ const OrgProfileTab: FC = () => {
   const me = useSelector(getMe)
   const org = useSelector(getOrg)
   const {org: quartzOrg} = useSelector(selectCurrentIdentity)
+  const orgDetailsStatus = useSelector(selectQuartzOrgDetailsStatus)
 
   const dispatch = useDispatch()
 
   const identityOrgId = quartzOrg.id
 
   useEffect(() => {
-    if (identityOrgId && CLOUD) {
-      if (
-        !quartzOrg.regionCode ||
-        !quartzOrg.regionName ||
-        !quartzOrg.provider
-      ) {
-        dispatch(getCurrentOrgDetailsThunk(identityOrgId))
-      }
+    if (!CLOUD) {
+      return
     }
-  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+    if (orgDetailsStatus === RemoteDataState.NotStarted) {
+      dispatch(getCurrentOrgDetailsThunk(identityOrgId))
+    }
+  }, [dispatch, orgDetailsStatus, identityOrgId])
 
   const hasIdentityData =
     quartzOrg.provider || quartzOrg.regionCode || quartzOrg.regionName


### PR DESCRIPTION
Closes #5936 

Splits the single redux loading status for `quartzIdentity` into three separate statuses. 

The motivation for this is more fully explained in UI #5917. But basically, [having a single loading status ](https://stackoverflow.com/questions/65849464/react-and-redux-proper-way-to-store-loading-state-in-redux) for all identity-related data increases the risk of a render loop in child components that update aspects of the identity state through calls to other endpoints.

The loading state shouldn't be focused on whether we're in the process of changing the state maintained for the user. Instead, it should answer the question: Did we already get a good response from the endpoint we needed to hit _to load this specific part of the app_ - or do we still need to make another call? 

This allows for a more explicit check in the account/billing and organization settings pages on whether we got the response we expected, rather than an _inferential_ check based on the current value of a property used by the page, which can be intentionally `null`, `undefined`, or `''`.

- identityStatus: User can view `<App />` after quartz/identity loads.
- billingStatus: User can view the Account/Billing tab, after the billing provider loads.
- orgDetailsStatus: User can view the Organization settings page, after the user's organization details (e.g., `regionName`, cloud `provider`) load.

App States after Change
--
https://user-images.githubusercontent.com/91283923/193295803-c1252f3c-e1fe-4370-933d-9c3e27f19807.mov


### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - NO
