### PR TITLE
feat(universalLogin): use unauth-ed api endpoint to fetch login URL

### DIFF
--- a/src/onboarding/containers/LoginPage.tsx
+++ b/src/onboarding/containers/LoginPage.tsx
@@ -56,15 +56,23 @@ export const LoginPage: FC = () => {
   } else {
     if (isFlagEnabled('universalLogin')) {
       if (CLOUD) {
-        fetch('/api/env/quartz-login-url').then(response => {
-          response.text().then((response) => {
-            const redirectUrl = response
-            console.warn('Redirect to cloud url: ', redirectUrl)
-            window.location.replace(redirectUrl)
-          }).catch(error => {
-            console.error("Failed to fetch /api/env/quartz-login-url", error)
+        fetch('/api/env/quartz-login-url')
+          .then(response => {
+            response
+              .text()
+              .then(response => {
+                const redirectUrl = response
+                console.warn('Redirect to cloud url: ', redirectUrl)
+                window.location.replace(redirectUrl)
+              })
+              .catch(error => {
+                console.error(
+                  'Failed to fetch /api/env/quartz-login-url',
+                  error
+                )
+              })
           })
-        }).catch(error => console.error(error))
+          .catch(error => console.error(error))
         return
       }
     }

--- a/src/onboarding/containers/LoginPage.tsx
+++ b/src/onboarding/containers/LoginPage.tsx
@@ -20,13 +20,6 @@ import LoginPageContents from 'src/onboarding/containers/LoginPageContents'
 import {CLOUD} from 'src/shared/constants'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
-let getQuartzLoginUrl
-
-if (CLOUD) {
-  getQuartzLoginUrl =
-    require('src/client/uiproxydRoutes').getUiproxyQuartzLoginUrl
-}
-
 const EMPTY_HISTORY_STACK_LENGTH = 2
 
 export const LoginPage: FC = () => {
@@ -63,13 +56,15 @@ export const LoginPage: FC = () => {
   } else {
     if (isFlagEnabled('universalLogin')) {
       if (CLOUD) {
-        getQuartzLoginUrl({})
-          .then(response => {
-            const redirectUrl = response.data
+        fetch('/api/env/quartz-login-url').then(response => {
+          response.text().then((response) => {
+            const redirectUrl = response
             console.warn('Redirect to cloud url: ', redirectUrl)
             window.location.replace(redirectUrl)
+          }).catch(error => {
+            console.error("Failed to fetch /api/env/quartz-login-url", error)
           })
-          .catch(error => console.error(error))
+        }).catch(error => console.error(error))
         return
       }
     }


### PR DESCRIPTION
Part of https://github.com/influxdata/idpe/issues/15477

Finally, using the unauth-ed version of the API to hopefully close out that issue. Still, want to test it after this merges, hence the "Part of" instead of Closes.

<!-- Describe your proposed changes here. -->
<!-- Including screenshots or visuals is very helpful - a picture is worth a thousand words. -->

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
