### PR TITLE
chore: remove quartzIdentity flag from e2e tests

### DIFF
--- a/cypress/e2e/cloud/about.test.ts
+++ b/cypress/e2e/cloud/about.test.ts
@@ -6,7 +6,6 @@ describe.skip('About Page for free users with only 1 user', () => {
     cy.flush().then(() =>
       cy.signin().then(() => {
         cy.setFeatureFlags({
-          quartzIdentity: true,
           multiOrg: true,
         }).then(() => {
           cy.get('@org').then(({id}: Organization) => {
@@ -55,7 +54,6 @@ describe('About Page for free users with multiple users', () => {
     cy.flush().then(() =>
       cy.signin().then(() => {
         cy.setFeatureFlags({
-          quartzIdentity: true,
           multiOrg: true,
         }).then(() => {
           cy.get('@org').then(({id}: Organization) => {
@@ -91,7 +89,6 @@ describe('About Page for PAYG users', () => {
     cy.flush().then(() =>
       cy.signin().then(() => {
         cy.setFeatureFlags({
-          quartzIdentity: true,
           multiOrg: true,
         }).then(() => {
           cy.get('@org').then(({id}: Organization) => {

--- a/cypress/e2e/cloud/billing.test.ts
+++ b/cypress/e2e/cloud/billing.test.ts
@@ -18,7 +18,6 @@ describe('Billing Page Free Users', () => {
 
   it('should display the free billing page for free users', () => {
     cy.setFeatureFlags({
-      quartzIdentity: true,
       multiOrg: true,
     }).then(() => {
       cy.getByTestID('cloud-upgrade--button').should('be.visible')
@@ -58,7 +57,6 @@ describe('Billing Page PAYG Users', () => {
     cy.flush().then(() =>
       cy.signin().then(() => {
         cy.setFeatureFlags({
-          quartzIdentity: true,
           multiOrg: true,
         }).then(() => {
           cy.get('@org').then(({id}: Organization) => {
@@ -82,7 +80,6 @@ describe('Billing Page PAYG Users', () => {
 
   it('should display the free billing page for PAYG users', () => {
     cy.setFeatureFlags({
-      quartzIdentity: true,
       multiOrg: true,
     }).then(() => {
       // The implication here is that there is no Upgrade Now button

--- a/cypress/e2e/cloud/buckets.test.ts
+++ b/cypress/e2e/cloud/buckets.test.ts
@@ -98,7 +98,7 @@ const testSchemaFiles = (
 describe('Explicit Buckets', () => {
   beforeEach(() => {
     setup(cy).then(() => {
-      cy.setFeatureFlags({quartzIdentity: true, multiOrg: true})
+      cy.setFeatureFlags({multiOrg: true})
     })
   })
 
@@ -416,7 +416,7 @@ fsRead,field,float`
 describe('Buckets', () => {
   beforeEach(() => {
     setup(cy).then(() => {
-      cy.setFeatureFlags({quartzIdentity: true, multiOrg: true})
+      cy.setFeatureFlags({multiOrg: true})
     })
   })
 

--- a/cypress/e2e/cloud/checkout/checkoutinaccessible.test.ts
+++ b/cypress/e2e/cloud/checkout/checkoutinaccessible.test.ts
@@ -3,7 +3,6 @@ describe('Checkout Page should not be accessible for non-free users', () => {
     cy.flush().then(() =>
       cy.signin().then(() => {
         cy.setFeatureFlags({
-          quartzIdentity: true,
           multiOrg: true,
         }).then(() => {
           cy.get('@org').then(() => {

--- a/cypress/e2e/cloud/checkout/checkoutpage.test.ts
+++ b/cypress/e2e/cloud/checkout/checkoutpage.test.ts
@@ -28,7 +28,6 @@ describe('Checkout Page Works', () => {
 
   it('should render the checkout page and allow for pointing and clicking', () => {
     cy.setFeatureFlagsNoNav({
-      quartzIdentity: true,
       multiOrg: true,
     }).then(() => {
       const email = 'asalem@influxdata.com'

--- a/cypress/e2e/cloud/communityTemplates.test.ts
+++ b/cypress/e2e/cloud/communityTemplates.test.ts
@@ -8,7 +8,7 @@ describe('Community Templates', () => {
           cy.fixture('routes').then(({orgs}) => {
             cy.visit(`${orgs}/${id}/settings/templates`)
             cy.getByTestID('tree-nav').then(() => {
-              cy.setFeatureFlags({quartzIdentity: true, multiOrg: true})
+              cy.setFeatureFlags({multiOrg: true})
             })
           })
         )

--- a/cypress/e2e/cloud/dashboardsView.test.ts
+++ b/cypress/e2e/cloud/dashboardsView.test.ts
@@ -6,7 +6,7 @@ describe('Dashboard', () => {
           cy.get('@org').then(({id: orgID}: any) => {
             cy.visit(`${orgs}/${orgID}/dashboards-list`)
             cy.getByTestID('tree-nav').then(() => {
-              cy.setFeatureFlags({quartzIdentity: true, multiOrg: true})
+              cy.setFeatureFlags({multiOrg: true})
             })
           })
         })

--- a/cypress/e2e/cloud/deepLinks.test.ts
+++ b/cypress/e2e/cloud/deepLinks.test.ts
@@ -4,7 +4,7 @@ describe('Deep linking', () => {
   beforeEach(() => {
     cy.flush()
     cy.signin().then(() => {
-      cy.setFeatureFlags({quartzIdentity: true, multiOrg: true})
+      cy.setFeatureFlags({multiOrg: true})
     })
   })
 

--- a/cypress/e2e/cloud/explorer.test.ts
+++ b/cypress/e2e/cloud/explorer.test.ts
@@ -35,7 +35,6 @@ describe('DataExplorer', () => {
 
     it('can use the dynamic flux function selector to build a query', () => {
       cy.setFeatureFlags({
-        quartzIdentity: true,
         multiOrg: true,
       }).then(() => {
         cy.get('.view-line').should('be.visible')
@@ -68,7 +67,6 @@ describe('DataExplorer', () => {
 
     it('can use the dynamic flux function search bar to search by package or function name', () => {
       cy.setFeatureFlags({
-        quartzIdentity: true,
         multiOrg: true,
       }).then(() => {
         cy.get('.view-line').should('be.visible')

--- a/cypress/e2e/cloud/flows.test.ts
+++ b/cypress/e2e/cloud/flows.test.ts
@@ -10,7 +10,7 @@ describe('Flows', () => {
           cy.getByTestID('version-info').should('be.visible')
           cy.getByTestID('nav-item-flows').should('be.visible')
           cy.getByTestID('nav-item-flows').click()
-          cy.setFeatureFlags({quartzIdentity: true, multiOrg: true})
+          cy.setFeatureFlags({multiOrg: true})
         })
       })
     })
@@ -185,7 +185,6 @@ describe('Flows', () => {
 
   it('can use the dynamic flux function selector to build a query', () => {
     cy.setFeatureFlags({
-      quartzIdentity: true,
       multiOrg: true,
     }).then(() => {
       cy.getByTestID('preset-script').first().click()
@@ -220,7 +219,6 @@ describe('Flows', () => {
 
   it('can use the dynamic flux function search bar to search by package or function name', () => {
     cy.setFeatureFlags({
-      quartzIdentity: true,
       multiOrg: true,
     }).then(() => {
       cy.getByTestID('preset-script').first().click()
@@ -268,7 +266,6 @@ describe('Flows with newQueryBuilder flag on', () => {
       cy.fixture('routes').then(({orgs}) => {
         cy.setFeatureFlags({
           multiOrg: true,
-          quartzIdentity: true,
           newQueryBuilder: true,
         }).then(() => {
           cy.visit(`${orgs}/${id}`)

--- a/cypress/e2e/cloud/geoOptions.test.ts
+++ b/cypress/e2e/cloud/geoOptions.test.ts
@@ -6,7 +6,7 @@ describe.skip('DataExplorer - Geo Map Type Customization Options', () => {
       cy.signin().then(() => {
         cy.signin()
           .then(() => {
-            cy.setFeatureFlags({quartzIdentity: true, multiOrg: true})
+            cy.setFeatureFlags({multiOrg: true})
           })
           .then(() => {
             cy.get('@org').then(({id}: Organization) => {

--- a/cypress/e2e/cloud/globalHeader.test.ts
+++ b/cypress/e2e/cloud/globalHeader.test.ts
@@ -1,6 +1,5 @@
 describe('change-account change-org global header', () => {
   const globalHeaderFeatureFlags = {
-    quartzIdentity: true,
     multiOrg: true,
   }
 

--- a/cypress/e2e/cloud/helpBar.test.ts
+++ b/cypress/e2e/cloud/helpBar.test.ts
@@ -2,7 +2,7 @@ describe('Help bar support for free account users', () => {
   beforeEach(() =>
     cy.flush().then(() =>
       cy.signin().then(() => {
-        cy.setFeatureFlags({quartzIdentity: true, multiOrg: true}).then(() => {
+        cy.setFeatureFlags({multiOrg: true}).then(() => {
           cy.get('@org').then(() => {
             cy.quartzProvision({
               accountType: 'free',
@@ -35,7 +35,7 @@ describe('Help bar support for PAYG users', () => {
   beforeEach(() =>
     cy.flush().then(() =>
       cy.signin().then(() => {
-        cy.setFeatureFlags({quartzIdentity: true, multiOrg: true}).then(() => {
+        cy.setFeatureFlags({multiOrg: true}).then(() => {
           cy.get('@org').then(() => {
             cy.quartzProvision({
               accountType: 'pay_as_you_go',

--- a/cypress/e2e/cloud/operator.test.ts
+++ b/cypress/e2e/cloud/operator.test.ts
@@ -2,7 +2,7 @@ describe('Operator Page', () => {
   beforeEach(() =>
     cy.flush().then(() =>
       cy.signin().then(() => {
-        cy.setFeatureFlags({quartzIdentity: true, multiOrg: true}).then(() => {
+        cy.setFeatureFlags({multiOrg: true}).then(() => {
           cy.get('@org').then(() => {
             cy.getByTestID('home-page--header').should('be.visible')
             cy.quartzProvision({

--- a/cypress/e2e/cloud/operatorRO.test.ts
+++ b/cypress/e2e/cloud/operatorRO.test.ts
@@ -11,7 +11,6 @@ describe('Operator Page', () => {
             cy.reload()
             cy.setFeatureFlags({
               multiOrg: true,
-              quartzIdentity: true,
               operatorRole: true,
             }).then(() => {
               cy.getByTestID('nav-item--operator').click()

--- a/cypress/e2e/cloud/subscriptions.test.ts
+++ b/cypress/e2e/cloud/subscriptions.test.ts
@@ -16,7 +16,6 @@ describe('Subscriptions', () => {
               cy.setFeatureFlags({
                 subscriptionsUI: true,
                 multiOrg: true,
-                quartzIdentity: true,
               })
 
               cy.getByTestID('subscriptions--tab').should('be.visible')

--- a/cypress/e2e/cloud/usage.test.ts
+++ b/cypress/e2e/cloud/usage.test.ts
@@ -18,7 +18,7 @@ describe('Usage Page Free User No Data', () => {
           }).then(() => {
             cy.visit(`/orgs/${id}/usage`)
             cy.getByTestID('usage-page--header').should('be.visible')
-            cy.setFeatureFlags({quartzIdentity: true, multiOrg: true})
+            cy.setFeatureFlags({multiOrg: true})
           })
         })
       })
@@ -109,7 +109,7 @@ describe('Usage Page PAYG With Data', () => {
           }).then(() => {
             cy.visit(`/orgs/${id}/usage`)
             cy.getByTestID('usage-page--header').should('be.visible')
-            cy.setFeatureFlags({quartzIdentity: true, multiOrg: true})
+            cy.setFeatureFlags({multiOrg: true})
           })
         })
       })

--- a/cypress/e2e/cloud/userAccounts.test.ts
+++ b/cypress/e2e/cloud/userAccounts.test.ts
@@ -6,7 +6,6 @@ const doSetup = cy => {
       cy.get('@org').then(({id}: Organization) => {
         cy.visit(`/orgs/${id}/accounts/settings`)
         cy.setFeatureFlags({
-          quartzIdentity: true,
           multiAccount: true,
           multiOrg: true,
         }).then(() => {

--- a/cypress/e2e/cloud/userProfile.test.ts
+++ b/cypress/e2e/cloud/userProfile.test.ts
@@ -1,6 +1,5 @@
 // Constants
 const userProfileFeatureFlags = {
-  quartzIdentity: true,
   multiOrg: true,
 }
 

--- a/cypress/e2e/cloud/users.test.ts
+++ b/cypress/e2e/cloud/users.test.ts
@@ -4,7 +4,7 @@ describe('Users Page', () => {
   beforeEach(() => {
     cy.flush().then(() =>
       cy.signin().then(() => {
-        cy.setFeatureFlags({quartzIdentity: true, multiOrg: true}).then(() => {
+        cy.setFeatureFlags({multiOrg: true}).then(() => {
           cy.get('@org').then(({id}: Organization) => {
             cy.quartzProvision({
               hasUsers: true,

--- a/cypress/e2e/cloud/zuoraOutage.test.ts
+++ b/cypress/e2e/cloud/zuoraOutage.test.ts
@@ -7,7 +7,6 @@ describe('Billing Page Free Users', () => {
         cy.get('@org').then(() => {
           cy.setFeatureFlags({
             quartzZuoraDisabled: true,
-            quartzIdentity: true,
             multiOrg: true,
           }).then(() => {
             cy.quartzProvision({
@@ -37,7 +36,6 @@ describe('Billing Page PAYG Users', () => {
           }).then(() => {
             cy.setFeatureFlags({
               quartzZuoraDisabled: true,
-              quartzIdentity: true,
               multiOrg: true,
             }).then(() => {
               cy.wait(1000)

--- a/cypress/index.d.ts
+++ b/cypress/index.d.ts
@@ -103,7 +103,7 @@ declare global {
       createCheck: typeof createCheck
       createAlertGroup: typeof createAlertGroup
       setFeatureFlags: typeof setFeatureFlags
-      setFeatureFlagsNoNav: typeof setFeatureFlags
+      setFeatureFlagsNoNav: typeof setFeatureFlagsNoNav
       upsertSecret: typeof upsertSecret
       quartzProvision: typeof quartzProvision
       createTaskFromEmpty: typeof createTaskFromEmpty


### PR DESCRIPTION
Connects #4821

The UI no longer references or takes any action based on the quartzIdentity flag (all cloud paths use /quartz/identity over /quartz/me). So it can be removed from the flag toggle in our e2e tests.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - NO 
