### PR TITLE
chore: transition getOrgs to identity selector

### DIFF
--- a/src/operator/utils.ts
+++ b/src/operator/utils.ts
@@ -7,6 +7,12 @@ import {
 
 // Types
 import {OperatorOrgLimits, OperatorRegions} from 'src/types'
+import {IdentityUser} from 'src/client/unityRoutes'
+
+type OperatorRole = IdentityUser['operatorRole'] | null
+
+export const isUserOperator = (operatorRole: OperatorRole): boolean =>
+  operatorRole === 'read-only' || operatorRole === 'read-write'
 
 const updateMaxRetentionWithCallback = (
   limits: OperatorOrgLimits,

--- a/src/shared/containers/GetOrganizations.tsx
+++ b/src/shared/containers/GetOrganizations.tsx
@@ -20,9 +20,8 @@ import RouteToOrg from 'src/shared/containers/RouteToOrg'
 
 // Selectors
 import {getAllOrgs} from 'src/resources/selectors'
-import {getMe, getQuartzMe, getQuartzMeStatus} from 'src/me/selectors'
 import {
-  selectQuartzIdentity,
+  selectCurrentIdentity,
   selectQuartzIdentityStatus,
 } from 'src/identity/selectors'
 
@@ -31,112 +30,95 @@ import {CLOUD} from 'src/shared/constants'
 
 // Utils
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import {isUserOperator} from 'src/operator/utils'
 import {convertStringToEpoch} from 'src/shared/utils/dateTimeUtils'
 import {updateReportingContext} from 'src/cloud/utils/reporting'
 
 // Types
-import {Me} from 'src/client/unityRoutes'
 import {PROJECT_NAME} from 'src/flows'
 import {RemoteDataState} from 'src/types'
 
 // Thunks
 import {getQuartzIdentityThunk} from 'src/identity/actions/thunks'
 
-const canAccessCheckout = (me: Me): boolean => {
-  if (Boolean(me?.isRegionBeta)) {
-    return false
-  }
-  return me?.accountType !== 'pay_as_you_go' && me?.accountType !== 'contract'
-}
-
 const GetOrganizations: FunctionComponent = () => {
-  const {status, org} = useSelector(getAllOrgs)
-  const identity = useSelector(selectQuartzIdentity)
-  const quartzMeStatus = useSelector(getQuartzMeStatus)
-  const quartzMe = useSelector(getQuartzMe)
-  const quartzIdentityStatus = useSelector(selectQuartzIdentityStatus)
-  const {id: meId = '', name: email = ''} = useSelector(getMe)
-  const {account} = identity.currentIdentity
+  const {status: orgLoadingStatus} = useSelector(getAllOrgs)
+
+  // This selector is CLOUD-only. It has default empty values in OSS.
+  const {user, account, org} = useSelector(selectCurrentIdentity)
+  const identityLoadingStatus = useSelector(selectQuartzIdentityStatus)
 
   const dispatch = useDispatch()
 
   // This doesn't require another API call.
   useEffect(() => {
-    if (status === RemoteDataState.NotStarted) {
+    if (orgLoadingStatus === RemoteDataState.NotStarted) {
       dispatch(getOrganizations())
     }
-  }, [dispatch, status]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [dispatch, orgLoadingStatus])
+
+  useEffect(() => {
+    if (CLOUD && identityLoadingStatus === RemoteDataState.NotStarted) {
+      dispatch(getQuartzIdentityThunk())
+    }
+  }, [dispatch, identityLoadingStatus]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (
       CLOUD &&
-      email &&
-      org?.id &&
-      account?.id &&
-      account?.name &&
+      user.id &&
+      user.email &&
+      org.id &&
+      account.id &&
+      account.name &&
       isFlagEnabled('rudderstackReporting')
     ) {
-      identify(meId, {
-        email,
+      identify(user.id, {
+        email: user.email,
         orgID: org.id,
         accountID: account.id,
         accountName: account.name,
       })
     }
-  }, [meId, email, org?.id, account?.id, account?.name])
-
-  useEffect(() => {
-    if (
-      CLOUD &&
-      quartzMeStatus === RemoteDataState.NotStarted &&
-      quartzIdentityStatus === RemoteDataState.NotStarted
-    ) {
-      dispatch(getQuartzIdentityThunk())
-    }
-  }, [quartzMeStatus, quartzIdentityStatus]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [user.id, user.email, org.id, account.id, account.name])
 
   // This doesn't require another API call.
   useEffect(() => {
     if (
+      CLOUD &&
       isFlagEnabled('credit250Experiment') &&
-      quartzMeStatus === RemoteDataState.Done &&
-      status === RemoteDataState.Done
+      identityLoadingStatus === RemoteDataState.Done &&
+      orgLoadingStatus === RemoteDataState.Done
     ) {
-      const {
-        accountType: account_type,
-        accountCreatedAt: account_created_at = '',
-      } = quartzMe
-      const orgId = org?.id ?? ''
       window.dataLayer = window.dataLayer ?? []
       window.dataLayer.push({
         identity: {
-          account_type,
-          account_created_at: convertStringToEpoch(account_created_at),
-          id: meId,
-          email,
-          organization_id: orgId,
+          account_type: account.type,
+          account_created_at: convertStringToEpoch(account.accountCreatedAt),
+          id: user.id,
+          email: user.email,
+          organization_id: org.id,
         },
       })
     }
-  }, [quartzMeStatus, status]) // eslint-disable-line react-hooks/exhaustive-deps
-
-  const isRegionBeta = quartzMe?.isRegionBeta ?? false
-  const accountType = quartzMe?.accountType ?? 'free'
+  }, [identityLoadingStatus, orgLoadingStatus]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (CLOUD) {
       updateReportingContext({
-        'org (hide_upgrade_cta)': `${accountType === 'free' && !isRegionBeta}`,
-        'org (account_type)': accountType,
+        'org (hide_upgrade_cta)': `${
+          account.type === 'free' && account.isUpgradeable === true
+        }`,
+        'org (account_type)': account.type,
       })
     }
-  }, [accountType, isRegionBeta])
+  }, [account.type, account.isUpgradeable])
 
   return (
-    <PageSpinner loading={status}>
+    <PageSpinner loading={orgLoadingStatus}>
       <Suspense fallback={<PageSpinner />}>
         {CLOUD ? (
-          <PageSpinner loading={quartzMeStatus}>
+          <PageSpinner loading={identityLoadingStatus}>
             <Switch>
               <Route path="/no-orgs" component={NoOrgsPage} />
               <Route
@@ -145,10 +127,10 @@ const GetOrganizations: FunctionComponent = () => {
               />
               <Route path="/orgs" component={App} />
               <Route exact path="/" component={RouteToOrg} />
-              {CLOUD && canAccessCheckout(quartzMe) && (
+              {CLOUD && account.isUpgradeable === true && (
                 <Route path="/checkout" component={CheckoutPage} />
               )}
-              {CLOUD && quartzMe?.isOperator && (
+              {CLOUD && isUserOperator(user.operatorRole) && (
                 <Route path="/operator" component={OperatorPage} />
               )}
               <Route component={NotFound} />


### PR DESCRIPTION
Connects #4821 

Removes references to the old quartzMe data shape in the getOrganizations component. Component still uses the same ultimate data source (quartz/identity), but now actually uses the quartzIdentity selector, not the quartzMe selector through which the /identity data is converted.

A prior version of this commit was reverted (#5917 reverts #5910) because it caused issues with the Account/Billing component. 

Root cause was that a previous version of that component could create a render loop. Resolution (#5938) was to split the identity 'loading' state in redux into three states, so that child components don't affect the broader identity state on which the `PageSpinner` in `GetOrganizations` is waiting to load the app. 

That issue is not present here, because `quartzIdentity` has its own state, which is set to `Done` once.

Changes have no impact on app behavior.

Video
--
https://user-images.githubusercontent.com/91283923/193652674-2d4d6e89-3186-4271-85d4-59e18285e335.mov


--


### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - NO
