### PR TITLE
chore: separate the feature flag

### DIFF
--- a/src/shared/apis/query.ts
+++ b/src/shared/apis/query.ts
@@ -105,7 +105,7 @@ const processSuccessResponse = async (
   let read = await reader.read()
 
   const BYTE_LIMIT =
-    getFlagValue('dataExplorerCsvLimit') ?? FLUX_RESPONSE_BYTES_LIMIT
+    getFlagValue('increaseCsvLimit') ?? FLUX_RESPONSE_BYTES_LIMIT
 
   while (!read.done) {
     const text = decoder.decode(read.value)

--- a/src/shared/contexts/query.tsx
+++ b/src/shared/contexts/query.tsx
@@ -26,6 +26,7 @@ import {resultTooLarge} from 'src/shared/copy/notifications'
 import {CancellationError, File} from 'src/types'
 import {RunQueryResult} from 'src/shared/apis/query'
 import {event} from 'src/cloud/utils/reporting'
+import {PROJECT_NAME} from 'src/flows'
 
 interface CancelMap {
   [key: string]: () => void
@@ -588,8 +589,13 @@ export const QueryProvider: FC = ({children}) => {
           let didTruncate = false
           let read = await reader.read()
 
-          const BYTE_LIMIT =
+          let BYTE_LIMIT =
             getFlagValue('increaseCsvLimit') ?? FLUX_RESPONSE_BYTES_LIMIT
+
+          if (!window.location.pathname.includes(PROJECT_NAME.toLowerCase())) {
+            BYTE_LIMIT =
+              getFlagValue('dataExplorerCsvLimit') ?? FLUX_RESPONSE_BYTES_LIMIT
+          }
 
           while (!read.done) {
             const text = decoder.decode(read.value)


### PR DESCRIPTION
Closes #5939

Separates the CSV Limit flag for data explorer and the new schema browser