### PR TITLE
build: add css-unicode-loader to convert unicode css into ascii

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "clipboardy": "^2.3.0",
     "cross-env": "^7.0.3",
     "css-loader": "^5.2.7",
+    "css-unicode-loader": "^1.0.3",
     "cypress": "^9.5.2",
     "cypress-file-upload": "^5.0.8",
     "cypress-log-to-output": "^1.1.2",

--- a/webpack.common.ts
+++ b/webpack.common.ts
@@ -98,6 +98,7 @@ module.exports = {
             ? MiniCssExtractPlugin.loader
             : 'style-loader',
           'css-loader',
+          'css-unicode-loader',
           {
             loader: 'sass-loader',
             options: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4465,6 +4465,11 @@ css-tree@^1.1.2, css-tree@^1.1.3:
     mdn-data "2.0.14"
     source-map "^0.6.1"
 
+css-unicode-loader@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/css-unicode-loader/-/css-unicode-loader-1.0.3.tgz#2420a7fc562b95e7f6811c6275436a328593a97a"
+  integrity sha512-mszxqB0LCBO2ixbaz/tAH17iEAXmytUv0j/YXtPxhOi8D8Teh+mOXqmz+DZRtDil5tFx7ltbgw16dUptEw4jOg==
+
 css-what@^5.0.0:
   version "5.1.0"
   resolved "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz"


### PR DESCRIPTION
Closes #4506

First attempt wasn't successful, trying again.

What happens is that when dart-sass builds our scss files into CSS files, it converts ASCII escape sequences like [this icon font styling](https://github.com/influxdata/clockface/blob/master/src/Styles/icon.scss#L31-L33) into their unicode equivalent.

This would normally be fine, but for some reason our `@charset: "UTF-8"` declarations are being stripped or aren't being added correctly (this appears to be another bug in dart-sass). Chromium browsers apparently have a rendering bug where unicode in CSS without a proper `@charset` declaration will sometimes cause the corrupt font bugs shown in the linked issue. 

This fix attempts to sidestep that issue by using a webpack loader that converts the converted unicode characters back into ASCII. [Here's an example](https://github.com/styzhang/css-unicode-loader#example) demonstrating what the output looks like before and after using this plugin.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- ~[ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~
- ~[ ] Feature flagged, if applicable~
