### PR TITLE
chore: remove quartzMe references from writedata components

### DIFF
--- a/src/identity/selectors/index.ts
+++ b/src/identity/selectors/index.ts
@@ -12,6 +12,12 @@ export const selectCurrentIdentity = (
   return state.identity.currentIdentity
 }
 
+export const selectCurrentAccountType = (
+  state: AppState
+): AppState['identity']['currentIdentity']['account']['type'] => {
+  return state.identity.currentIdentity.account.type
+}
+
 export const selectQuartzIdentityStatus = (state: AppState): RemoteDataState =>
   state.identity.currentIdentity.loadingStatus.identityStatus
 

--- a/src/writeData/components/PluginCreateConfiguration/Footer.tsx
+++ b/src/writeData/components/PluginCreateConfiguration/Footer.tsx
@@ -24,6 +24,7 @@ import {PluginConfigurationStepProps} from 'src/writeData/components/AddPluginTo
 
 // Selectors
 import {getAll} from 'src/resources/selectors'
+import {selectCurrentAccountType} from 'src/identity/selectors'
 
 // Utils
 import {CLOUD} from 'src/shared/constants'
@@ -162,7 +163,8 @@ const mstp = (state: AppState) => {
       steps: {orgID},
     },
   } = state
-  const accountType = state?.identity?.currentIdentity?.account?.type ?? 'free'
+  const accountType = selectCurrentAccountType(state)
+
   let telegrafConfig = null
   if (telegrafConfigID) {
     const telegrafs = getAll<Telegraf>(state, ResourceType.Telegrafs)

--- a/src/writeData/components/PluginCreateConfiguration/Footer.tsx
+++ b/src/writeData/components/PluginCreateConfiguration/Footer.tsx
@@ -24,7 +24,6 @@ import {PluginConfigurationStepProps} from 'src/writeData/components/AddPluginTo
 
 // Selectors
 import {getAll} from 'src/resources/selectors'
-import {getQuartzMe} from 'src/me/selectors'
 
 // Utils
 import {CLOUD} from 'src/shared/constants'
@@ -163,7 +162,7 @@ const mstp = (state: AppState) => {
       steps: {orgID},
     },
   } = state
-  const accountType = getQuartzMe(state)?.accountType ?? 'free'
+  const accountType = state?.identity?.currentIdentity?.account?.type ?? 'free'
   let telegrafConfig = null
   if (telegrafConfigID) {
     const telegrafs = getAll<Telegraf>(state, ResourceType.Telegrafs)

--- a/src/writeData/subscriptions/components/CreateSubscriptionPage.tsx
+++ b/src/writeData/subscriptions/components/CreateSubscriptionPage.tsx
@@ -36,9 +36,12 @@ import {
   StepsStatus,
 } from 'src/types'
 
-// Utils
+// Selectors
 import {getAll} from 'src/resources/selectors'
-import {getQuartzMe, shouldShowUpgradeButton} from 'src/me/selectors'
+import {shouldShowUpgradeButton} from 'src/me/selectors'
+import {selectCurrentIdentity} from 'src/identity/selectors'
+
+// Utils
 import {event} from 'src/cloud/utils/reporting'
 import {
   DEFAULT_COMPLETED_STEPS,
@@ -57,7 +60,7 @@ const CreateSubscriptionPage: FC = () => {
   const {formContent, saveForm, updateForm, loading} = useContext(
     SubscriptionCreateContext
   )
-  const quartzMe = useSelector(getQuartzMe)
+  const identity = useSelector(selectCurrentIdentity)
   const buckets = useSelector((state: AppState) =>
     getAll<Bucket>(state, ResourceType.Buckets).filter(b => b.type === 'user')
   )
@@ -88,10 +91,10 @@ const CreateSubscriptionPage: FC = () => {
   useEffect(() => {
     event(
       'visited creation page',
-      {userAccountType: quartzMe?.accountType ?? 'unknown'},
+      {userAccountType: identity.account.type || 'unknown'},
       {feature: 'subscriptions'}
     )
-  }, [quartzMe?.accountType])
+  }, [identity.account.type])
 
   const handleClick = (step: number) => {
     event(

--- a/src/writeData/subscriptions/components/CreateSubscriptionPage.tsx
+++ b/src/writeData/subscriptions/components/CreateSubscriptionPage.tsx
@@ -39,7 +39,7 @@ import {
 // Selectors
 import {getAll} from 'src/resources/selectors'
 import {shouldShowUpgradeButton} from 'src/me/selectors'
-import {selectCurrentIdentity} from 'src/identity/selectors'
+import {selectCurrentAccountType} from 'src/identity/selectors'
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'
@@ -60,7 +60,7 @@ const CreateSubscriptionPage: FC = () => {
   const {formContent, saveForm, updateForm, loading} = useContext(
     SubscriptionCreateContext
   )
-  const identity = useSelector(selectCurrentIdentity)
+  const accountType = useSelector(selectCurrentAccountType)
   const buckets = useSelector((state: AppState) =>
     getAll<Bucket>(state, ResourceType.Buckets).filter(b => b.type === 'user')
   )
@@ -91,10 +91,10 @@ const CreateSubscriptionPage: FC = () => {
   useEffect(() => {
     event(
       'visited creation page',
-      {userAccountType: identity.account.type || 'unknown'},
+      {userAccountType: accountType},
       {feature: 'subscriptions'}
     )
-  }, [identity.account.type])
+  }, [accountType])
 
   const handleClick = (step: number) => {
     event(


### PR DESCRIPTION
Connects #4821 

Replaces references to the quartzMe state in the `writeData` components with quartzIdentity state.

Video
--
https://user-images.githubusercontent.com/91283923/193696850-659dca39-5c8d-4346-bd74-3e021a4ce40b.mov

https://user-images.githubusercontent.com/91283923/193697329-ce65a6b5-433f-49f6-a1d9-5de838a6c49d.mov



### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable
