### PR TITLE
feat: add adaptive zoom to Graph + Single Stat

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "@docsearch/react": "^3.0.0-alpha.37",
     "@influxdata/clockface": "^6.3.7",
     "@influxdata/flux-lsp-browser": "0.8.35",
-    "@influxdata/giraffe": "^2.36.0",
+    "@influxdata/giraffe": "^2.37.0",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",
     "abortcontroller-polyfill": "^1.3.0",

--- a/src/visualization/types/SingleStatWithLine/options.tsx
+++ b/src/visualization/types/SingleStatWithLine/options.tsx
@@ -1,5 +1,5 @@
+// Libraries
 import React, {FC, useCallback} from 'react'
-
 import {
   Input,
   InputType,
@@ -19,12 +19,7 @@ import {
   InputLabel,
 } from '@influxdata/clockface'
 
-import AutoDomainInput from 'src/shared/components/AutoDomainInput'
-import {
-  AXES_SCALE_OPTIONS,
-  MIN_DECIMAL_PLACES,
-  MAX_DECIMAL_PLACES,
-} from 'src/visualization/constants'
+// Utils
 import {convertUserInputToNumOrNaN} from 'src/shared/utils/convertUserInput'
 import {
   FORMAT_OPTIONS,
@@ -35,10 +30,10 @@ import {
   defaultYColumn,
   parseYBounds,
 } from 'src/shared/utils/vis'
-import {
-  THRESHOLD_TYPE_TEXT,
-  THRESHOLD_TYPE_BG,
-} from 'src/shared/constants/thresholds'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+
+// Components
+import {AdaptiveZoomToggle} from 'src/visualization/components/internal/AdaptiveZoomOption'
 import ColorSchemeDropdown from 'src/visualization/components/internal/ColorSchemeDropdown'
 import AxisTicksGenerator from 'src/visualization/components/internal/AxisTicksGenerator'
 import ThresholdsSettings from 'src/visualization/components/internal/ThresholdsSettings'
@@ -46,6 +41,18 @@ import HoverLegend from 'src/visualization/components/internal/HoverLegend'
 import StaticLegend from 'src/visualization/components/internal/StaticLegend'
 import {LinePlusSingleStatProperties, Color} from 'src/types'
 import {VisualizationOptionProps} from 'src/visualization'
+
+// Constants
+import AutoDomainInput from 'src/shared/components/AutoDomainInput'
+import {
+  AXES_SCALE_OPTIONS,
+  MIN_DECIMAL_PLACES,
+  MAX_DECIMAL_PLACES,
+} from 'src/visualization/constants'
+import {
+  THRESHOLD_TYPE_TEXT,
+  THRESHOLD_TYPE_BG,
+} from 'src/shared/constants/thresholds'
 
 const {BASE_2, BASE_10} = AXES_SCALE_OPTIONS
 
@@ -200,6 +207,20 @@ const SingleStatWithLineOptions: FC<Props> = ({
               }
             />
           </Form.Element>
+          {isFlagEnabled('zoomRequery') && (
+            <AdaptiveZoomToggle
+              adaptiveZoomHide={properties.adaptiveZoomHide}
+              type={properties.type}
+              update={update}
+            />
+          )}
+        </Grid.Column>
+        <Grid.Column
+          widthXS={Columns.Twelve}
+          widthMD={Columns.Six}
+          widthLG={Columns.Four}
+        >
+          <h5 className="view-options--header">Options</h5>
           <Form.Element label="Time Format">
             <SelectDropdown
               options={FORMAT_OPTIONS.map(option => option.text)}
@@ -209,13 +230,6 @@ const SingleStatWithLineOptions: FC<Props> = ({
               }}
             />
           </Form.Element>
-        </Grid.Column>
-        <Grid.Column
-          widthXS={Columns.Twelve}
-          widthMD={Columns.Six}
-          widthLG={Columns.Four}
-        >
-          <h5 className="view-options--header">Options</h5>
           <Form.Element label="Line Colors">
             <ColorSchemeDropdown
               value={properties.colors.filter(c => c.type === 'scale')}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1449,10 +1449,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/flux-lsp-browser/-/flux-lsp-browser-0.8.35.tgz#ed92117d46f297bacf6aec7e7ace451d55bdff79"
   integrity sha512-d/zlUAx+O67aTBVNIr0XznuDl2jkGELlahRL2OIPOawfnAkNNREuC8iMhov8dq+Bw9d5w+mT041UKzhxZXl1Kg==
 
-"@influxdata/giraffe@^2.36.0":
-  version "2.36.0"
-  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.36.0.tgz#8dcffa66a8cc497c3bc5d0c9e001d745244cb899"
-  integrity sha512-AMBtb9lOc9VXiTc8JBlbFe+PwyRBX8X+SvS9NRMSzrttWB6Anddy6H2mL34swbpCGreNhuElNT5GPj5ePwDFqw==
+"@influxdata/giraffe@^2.37.0":
+  version "2.37.0"
+  resolved "https://registry.yarnpkg.com/@influxdata/giraffe/-/giraffe-2.37.0.tgz#a4e06aed4d10dc85067feb79830ff31037175161"
+  integrity sha512-XTGC9fo6g70pbwgD9XV0Yvi1JHMGypI8CR3UAg7nJGq5MgbCgo9nzLaxvilKdcvngrQGCzARvw+ixawfIUHrJg==
   dependencies:
     merge-images "^2.0.0"
 


### PR DESCRIPTION
Closes #5922 

- adds the adaptive zoom feature to Graph + Single Stat
- disables the text selection of the single stat when it appears with a line graph


https://user-images.githubusercontent.com/10736577/193708925-e120a401-7086-4dbf-ab7b-b6e32dbefca7.mp4


