### PR TITLE
chore: disallow default exports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
       jsx: true,
     },
   },
-  plugins: ['@typescript-eslint', 'react', 'jest'],
+  plugins: ['@typescript-eslint', 'react', 'jest', 'import'],
   env: {
     browser: true,
     es6: true,
@@ -77,6 +77,7 @@ module.exports = {
     '@typescript-eslint/restrict-template-expressions': 'off',
     curly: ['error', 'all'],
     'getter-return': 'off',
+    'import/no-default-export': ['error'],
     'jest/no-focused-tests': ['error'],
     'jest/no-large-snapshots': ['error', {maxSize: 0}], // no shapshots please
     'no-case-declarations': 'off',

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "cypress-plugin-tab": "^1.0.5",
     "eslint": "^8.23.0",
     "eslint-config-prettier": "^8.5.0",
+    "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jest": "^27.0.1",
     "eslint-plugin-react": "^7.31.1",
     "eslint-plugin-react-hooks": "^4.6.0",

--- a/src/billing/components/Free/PAYGConversion.tsx
+++ b/src/billing/components/Free/PAYGConversion.tsx
@@ -16,7 +16,7 @@ import {
 import {useHistory} from 'react-router-dom'
 
 // Components
-import CloudUpgradeButton from 'src/shared/components/CloudUpgradeButton'
+import {CloudUpgradeButton} from 'src/shared/components/CloudUpgradeButton'
 import {GoogleOptimizeExperiment} from 'src/cloud/components/experiments/GoogleOptimizeExperiment'
 
 // Utils

--- a/src/cloud/components/AssetLimitAlert.tsx
+++ b/src/cloud/components/AssetLimitAlert.tsx
@@ -14,7 +14,7 @@ import {
   HeadingElement,
   AlignItems,
 } from '@influxdata/clockface'
-import CloudUpgradeButton from 'src/shared/components/CloudUpgradeButton'
+import {CloudUpgradeButton} from 'src/shared/components/CloudUpgradeButton'
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'

--- a/src/cloud/components/AssetLimitOverlay.tsx
+++ b/src/cloud/components/AssetLimitOverlay.tsx
@@ -12,7 +12,7 @@ import {
 } from '@influxdata/clockface'
 
 // Components
-import CloudUpgradeButton from 'src/shared/components/CloudUpgradeButton'
+import {CloudUpgradeButton} from 'src/shared/components/CloudUpgradeButton'
 
 // Utils
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'

--- a/src/cloud/components/RateLimitAlert.tsx
+++ b/src/cloud/components/RateLimitAlert.tsx
@@ -16,7 +16,7 @@ import {
   Button,
   ComponentColor,
 } from '@influxdata/clockface'
-import CloudUpgradeButton from 'src/shared/components/CloudUpgradeButton'
+import {CloudUpgradeButton} from 'src/shared/components/CloudUpgradeButton'
 
 // Utils
 import {

--- a/src/cloud/components/RateLimitAlertContent.tsx
+++ b/src/cloud/components/RateLimitAlertContent.tsx
@@ -11,7 +11,7 @@ import {
 } from '@influxdata/clockface'
 
 // Components
-import CloudUpgradeButton from 'src/shared/components/CloudUpgradeButton'
+import {CloudUpgradeButton} from 'src/shared/components/CloudUpgradeButton'
 import {GoogleOptimizeExperiment} from 'src/cloud/components/experiments/GoogleOptimizeExperiment'
 
 // Actions

--- a/src/flows/components/panel/PanelQueryOverlay.tsx
+++ b/src/flows/components/panel/PanelQueryOverlay.tsx
@@ -9,8 +9,8 @@ import ClientCodeCopyPage from 'src/writeData/components/ClientCodeCopyPage'
 import {CLIENT_DEFINITIONS} from 'src/writeData'
 
 // Utils
-import ClientCodeQueryHelper from 'src/writeData/components/ClientCodeQueryHelper'
-import WriteDataDetailsProvider from 'src/writeData/components/WriteDataDetailsContext'
+import {ClientCodeQueryHelper} from 'src/writeData/components/ClientCodeQueryHelper'
+import {WriteDataDetailsProvider} from 'src/writeData/components/WriteDataDetailsContext'
 import {Provider as TemplateProvider} from 'src/shared/components/CodeSnippet'
 import {FlowQueryContext} from 'src/flows/context/flow.query'
 import {PopupContext} from 'src/flows/context/popup'

--- a/src/homepageExperience/containers/ArduinoWizard.tsx
+++ b/src/homepageExperience/containers/ArduinoWizard.tsx
@@ -22,7 +22,7 @@ import {InstallDependencies} from 'src/homepageExperience/components/steps/ardui
 import {Overview} from 'src/homepageExperience/components/steps/Overview'
 import {PrepareIde} from 'src/homepageExperience/components/steps/arduino/PrepareIde'
 import {WriteData} from 'src/homepageExperience/components/steps/arduino/WriteData'
-import WriteDataDetailsContextProvider from 'src/writeData/components/WriteDataDetailsContext'
+import {WriteDataDetailsProvider as WriteDataDetailsContextProvider} from 'src/writeData/components/WriteDataDetailsContext'
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'

--- a/src/homepageExperience/containers/CliWizard.tsx
+++ b/src/homepageExperience/containers/CliWizard.tsx
@@ -21,7 +21,7 @@ import {InitializeClient} from 'src/homepageExperience/components/steps/cli/Init
 import {InstallDependencies} from 'src/homepageExperience/components/steps/cli/InstallDependencies'
 import {Overview} from 'src/homepageExperience/components/steps/Overview'
 import {WriteData} from 'src/homepageExperience/components/steps/cli/WriteData'
-import WriteDataDetailsContextProvider from 'src/writeData/components/WriteDataDetailsContext'
+import {WriteDataDetailsProvider as WriteDataDetailsContextProvider} from 'src/writeData/components/WriteDataDetailsContext'
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'

--- a/src/homepageExperience/containers/GoWizard.tsx
+++ b/src/homepageExperience/containers/GoWizard.tsx
@@ -18,7 +18,7 @@ import {WriteData} from 'src/homepageExperience/components/steps/go/WriteData'
 import {ExecuteQuery} from 'src/homepageExperience/components/steps/go/ExecuteQuery'
 import {Finish} from 'src/homepageExperience/components/steps/Finish'
 import {ExecuteAggregateQuery} from 'src/homepageExperience/components/steps/go/ExecuteAggregateQuery'
-import WriteDataDetailsContextProvider from 'src/writeData/components/WriteDataDetailsContext'
+import {WriteDataDetailsProvider as WriteDataDetailsContextProvider} from 'src/writeData/components/WriteDataDetailsContext'
 import {normalizeEventName} from 'src/cloud/utils/reporting'
 
 import {GoIcon} from 'src/homepageExperience/components/HomepageIcons'

--- a/src/homepageExperience/containers/NodejsWizard.tsx
+++ b/src/homepageExperience/containers/NodejsWizard.tsx
@@ -18,7 +18,7 @@ import {WriteData} from 'src/homepageExperience/components/steps/nodejs/WriteDat
 import {ExecuteQuery} from 'src/homepageExperience/components/steps/nodejs/ExecuteQuery'
 import {Finish} from 'src/homepageExperience/components/steps/Finish'
 import {ExecuteAggregateQuery} from 'src/homepageExperience/components/steps/nodejs/ExecuteAggregateQuery'
-import WriteDataDetailsContextProvider from 'src/writeData/components/WriteDataDetailsContext'
+import {WriteDataDetailsProvider as WriteDataDetailsContextProvider} from 'src/writeData/components/WriteDataDetailsContext'
 import {normalizeEventName} from 'src/cloud/utils/reporting'
 
 import {NodejsIcon} from 'src/homepageExperience/components/HomepageIcons'

--- a/src/homepageExperience/containers/PythonWizard.tsx
+++ b/src/homepageExperience/containers/PythonWizard.tsx
@@ -10,7 +10,7 @@ import {
   SubwayNav,
 } from '@influxdata/clockface'
 
-import WriteDataDetailsContextProvider from 'src/writeData/components/WriteDataDetailsContext'
+import {WriteDataDetailsProvider as WriteDataDetailsContextProvider} from 'src/writeData/components/WriteDataDetailsContext'
 
 import {InstallDependencies} from 'src/homepageExperience/components/steps/python/InstallDependencies'
 import {Overview} from 'src/homepageExperience/components/steps/Overview'

--- a/src/shared/components/CloudUpgradeButton.tsx
+++ b/src/shared/components/CloudUpgradeButton.tsx
@@ -32,7 +32,7 @@ interface OwnProps {
   size?: ComponentSize
 }
 
-const CloudUpgradeButton: FC<OwnProps> = ({
+export const CloudUpgradeButton: FC<OwnProps> = ({
   buttonText = 'Upgrade Now',
   className,
   metric,
@@ -96,5 +96,3 @@ const CloudUpgradeButton: FC<OwnProps> = ({
   }
   return null
 }
-
-export default CloudUpgradeButton

--- a/src/support/components/FreeAccountSupportOverlay.tsx
+++ b/src/support/components/FreeAccountSupportOverlay.tsx
@@ -4,7 +4,7 @@ import {useSelector} from 'react-redux'
 
 // Components
 import {Icon, IconFont, List, Overlay} from '@influxdata/clockface'
-import CloudUpgradeButton from 'src/shared/components/CloudUpgradeButton'
+import {CloudUpgradeButton} from 'src/shared/components/CloudUpgradeButton'
 
 // Contexts
 import {OverlayContext} from 'src/overlays/components/OverlayController'

--- a/src/writeData/components/ClientCodeQueryHelper.tsx
+++ b/src/writeData/components/ClientCodeQueryHelper.tsx
@@ -41,7 +41,7 @@ const getBucketsFromAST = (ast: File) => {
   ).map(node => node?.arguments[0]?.properties[0]?.value.value)
 }
 
-const ClientCodeQueryHelper: FC<Props> = ({clientQuery, contentID}) => {
+export const ClientCodeQueryHelper: FC<Props> = ({clientQuery, contentID}) => {
   const def = CLIENT_DEFINITIONS[contentID]
   const {changeBucket, changeQuery} = useContext(WriteDataDetailsContext)
 
@@ -69,5 +69,3 @@ const ClientCodeQueryHelper: FC<Props> = ({clientQuery, contentID}) => {
 
   return null
 }
-
-export default ClientCodeQueryHelper

--- a/src/writeData/components/WriteDataDetailsContext.tsx
+++ b/src/writeData/components/WriteDataDetailsContext.tsx
@@ -40,7 +40,7 @@ export const DEFAULT_WRITE_DATA_DETAILS_CONTEXT: WriteDataDetailsContextType = {
 }
 export const WriteDataDetailsContext =
   createContext<WriteDataDetailsContextType>(DEFAULT_WRITE_DATA_DETAILS_CONTEXT)
-const WriteDataDetailsProvider: FC = ({children}) => {
+export const WriteDataDetailsProvider: FC = ({children}) => {
   const {variables, update} = useContext(TemplateContext)
   const buckets = useSelector((state: AppState) =>
     getAll<Bucket>(state, ResourceType.Buckets).filter(b => b.type === 'user')
@@ -130,4 +130,3 @@ const WriteDataDetailsProvider: FC = ({children}) => {
     </WriteDataDetailsContext.Provider>
   )
 }
-export default WriteDataDetailsProvider

--- a/src/writeData/components/fileUploads/UploadDataDetailsView.tsx
+++ b/src/writeData/components/fileUploads/UploadDataDetailsView.tsx
@@ -6,7 +6,7 @@ import {Panel, InfluxColors, ComponentSize} from '@influxdata/clockface'
 // Components
 import {Page} from '@influxdata/clockface'
 import WriteDataHelperBuckets from 'src/writeData/components/WriteDataHelperBuckets'
-import WriteDataDetailsContextProvider from 'src/writeData/components/WriteDataDetailsContext'
+import {WriteDataDetailsProvider as WriteDataDetailsContextProvider} from 'src/writeData/components/WriteDataDetailsContext'
 import CodeSnippet, {
   Provider as TemplateProvider,
 } from 'src/shared/components/CodeSnippet'

--- a/src/writeData/containers/ClientLibrariesPage.tsx
+++ b/src/writeData/containers/ClientLibrariesPage.tsx
@@ -18,7 +18,7 @@ import placeholderLogo from 'src/writeData/graphics/placeholderLogo.svg'
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 import GetResources from 'src/resources/components/GetResources'
-import WriteDataDetailsContextProvider from 'src/writeData/components/WriteDataDetailsContext'
+import {WriteDataDetailsProvider as WriteDataDetailsContextProvider} from 'src/writeData/components/WriteDataDetailsContext'
 import WriteDataHelper from 'src/writeData/components/WriteDataHelper'
 import CodeSnippet, {
   Provider as TemplateProvider,
@@ -26,7 +26,7 @@ import CodeSnippet, {
 
 // Styles
 import 'src/writeData/components/WriteDataDetailsView.scss'
-import ClientCodeQueryHelper from '../components/ClientCodeQueryHelper'
+import {ClientCodeQueryHelper} from '../components/ClientCodeQueryHelper'
 
 const codeRenderer: any = (props: any): any => (
   <CodeSnippet text={props.value} label={props.language} />

--- a/src/writeData/containers/TelegrafPluginsPage.tsx
+++ b/src/writeData/containers/TelegrafPluginsPage.tsx
@@ -7,7 +7,7 @@ import {Page} from '@influxdata/clockface'
 import CodeSnippet, {
   Provider as TemplateProvider,
 } from 'src/shared/components/CodeSnippet'
-import WriteDataDetailsContextProvider from 'src/writeData/components/WriteDataDetailsContext'
+import {WriteDataDetailsProvider as WriteDataDetailsContextProvider} from 'src/writeData/components/WriteDataDetailsContext'
 import {AddPluginToConfigurationCTA} from 'src/writeData/components/AddPluginToConfiguration'
 import GetResources from 'src/resources/components/GetResources'
 

--- a/src/writeData/subscriptions/components/BrokerDetails.tsx
+++ b/src/writeData/subscriptions/components/BrokerDetails.tsx
@@ -21,8 +21,8 @@ import {
   ComponentSize,
   JustifyContent,
 } from '@influxdata/clockface'
-import StatusHeader from 'src/writeData/subscriptions/components/StatusHeader'
-import BrokerFormContent from 'src/writeData/subscriptions/components/BrokerFormContent'
+import {StatusHeader} from 'src/writeData/subscriptions/components/StatusHeader'
+import {BrokerFormContent} from 'src/writeData/subscriptions/components/BrokerFormContent'
 
 // Utils
 import {getOrg} from 'src/organizations/selectors'

--- a/src/writeData/subscriptions/components/BrokerForm.tsx
+++ b/src/writeData/subscriptions/components/BrokerForm.tsx
@@ -19,8 +19,8 @@ import {
   FlexDirection,
   JustifyContent,
 } from '@influxdata/clockface'
-import BrokerFormContent from 'src/writeData/subscriptions/components/BrokerFormContent'
-import CloudUpgradeButton from 'src/shared/components/CloudUpgradeButton'
+import {BrokerFormContent} from 'src/writeData/subscriptions/components/BrokerFormContent'
+import {CloudUpgradeButton} from 'src/shared/components/CloudUpgradeButton'
 
 // Utils
 import {getOrg} from 'src/organizations/selectors'
@@ -52,7 +52,7 @@ interface Props {
   showUpgradeButton: boolean
 }
 
-const BrokerForm: FC<Props> = ({
+export const BrokerForm: FC<Props> = ({
   formContent,
   updateForm,
   saveForm,
@@ -201,4 +201,3 @@ const BrokerForm: FC<Props> = ({
     )
   )
 }
-export default BrokerForm

--- a/src/writeData/subscriptions/components/BrokerFormContent.tsx
+++ b/src/writeData/subscriptions/components/BrokerFormContent.tsx
@@ -20,7 +20,7 @@ import {
   FlexDirection,
   ComponentStatus,
 } from '@influxdata/clockface'
-import UserInput from 'src/writeData/subscriptions/components/UserInput'
+import {UserInput} from 'src/writeData/subscriptions/components/UserInput'
 import CertificateInput from 'src/writeData/subscriptions/components/CertificateInput'
 
 // Utils
@@ -48,7 +48,7 @@ interface Props {
   edit: boolean
 }
 
-const BrokerFormContent: FC<Props> = ({
+export const BrokerFormContent: FC<Props> = ({
   updateForm,
   formContent,
   className,
@@ -403,5 +403,3 @@ const BrokerFormContent: FC<Props> = ({
     </Grid>
   )
 }
-
-export default BrokerFormContent

--- a/src/writeData/subscriptions/components/CertificateInput.tsx
+++ b/src/writeData/subscriptions/components/CertificateInput.tsx
@@ -22,7 +22,7 @@ import {
   ClickOutside,
 } from '@influxdata/clockface'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
-import TextAreaWithLabel from 'src/writeData/subscriptions/components/TextAreaWithLabel'
+import {TextAreaWithLabel} from 'src/writeData/subscriptions/components/TextAreaWithLabel'
 import {event} from 'src/cloud/utils/reporting'
 import {useDispatch} from 'react-redux'
 import {dismissOverlay, showOverlay} from 'src/overlays/actions/overlays'

--- a/src/writeData/subscriptions/components/CreateSubscriptionPage.tsx
+++ b/src/writeData/subscriptions/components/CreateSubscriptionPage.tsx
@@ -9,9 +9,9 @@ import {
   SubwayNav,
   TechnoSpinner,
 } from '@influxdata/clockface'
-import BrokerForm from 'src/writeData/subscriptions/components/BrokerForm'
-import ParsingForm from 'src/writeData/subscriptions/components/ParsingForm'
-import SubscriptionForm from 'src/writeData/subscriptions/components/SubscriptionForm'
+import {BrokerForm} from 'src/writeData/subscriptions/components/BrokerForm'
+import {ParsingForm} from 'src/writeData/subscriptions/components/ParsingForm'
+import {SubscriptionForm} from 'src/writeData/subscriptions/components/SubscriptionForm'
 import GetResources from 'src/resources/components/GetResources'
 
 // Graphics
@@ -23,7 +23,7 @@ import {
   SubscriptionCreateProvider,
 } from 'src/writeData/subscriptions/context/subscription.create'
 import {WriteDataDetailsContext} from 'src/writeData/components/WriteDataDetailsContext'
-import WriteDataDetailsProvider from 'src/writeData/components/WriteDataDetailsContext'
+import {WriteDataDetailsProvider} from 'src/writeData/components/WriteDataDetailsContext'
 import {AppSettingProvider} from 'src/shared/contexts/app'
 
 // Types

--- a/src/writeData/subscriptions/components/DetailsSubscriptionPage.tsx
+++ b/src/writeData/subscriptions/components/DetailsSubscriptionPage.tsx
@@ -21,7 +21,7 @@ import {
   SubscriptionUpdateContext,
 } from 'src/writeData/subscriptions/context/subscription.update'
 import {WriteDataDetailsContext} from 'src/writeData/components/WriteDataDetailsContext'
-import WriteDataDetailsProvider from 'src/writeData/components/WriteDataDetailsContext'
+import {WriteDataDetailsProvider} from 'src/writeData/components/WriteDataDetailsContext'
 import {
   SubscriptionListContext,
   SubscriptionListProvider,

--- a/src/writeData/subscriptions/components/EmptySubscriptionState.tsx
+++ b/src/writeData/subscriptions/components/EmptySubscriptionState.tsx
@@ -19,7 +19,7 @@ import {
   ComponentStatus,
 } from '@influxdata/clockface'
 
-const EmptySubscriptionState: FC = () => {
+export const EmptySubscriptionState: FC = () => {
   const org = useSelector(getOrg)
   const history = useHistory()
   return (
@@ -42,5 +42,3 @@ const EmptySubscriptionState: FC = () => {
     </EmptyState>
   )
 }
-
-export default EmptySubscriptionState

--- a/src/writeData/subscriptions/components/JsonParsingForm.tsx
+++ b/src/writeData/subscriptions/components/JsonParsingForm.tsx
@@ -37,7 +37,7 @@ import {event} from 'src/cloud/utils/reporting'
 
 // Styles
 import 'src/writeData/subscriptions/components/JsonParsingForm.scss'
-import ValidationInputWithTooltip from './ValidationInputWithTooltip'
+import {ValidationInputWithTooltip} from './ValidationInputWithTooltip'
 
 interface Props {
   formContent: Subscription

--- a/src/writeData/subscriptions/components/JsonPathInput.tsx
+++ b/src/writeData/subscriptions/components/JsonPathInput.tsx
@@ -33,7 +33,7 @@ import {
   handleAvroValidation,
 } from 'src/writeData/subscriptions/utils/form'
 import {event} from 'src/cloud/utils/reporting'
-import ValidationInputWithTooltip from './ValidationInputWithTooltip'
+import {ValidationInputWithTooltip} from './ValidationInputWithTooltip'
 
 interface Props {
   name: string

--- a/src/writeData/subscriptions/components/ParsingDetails.tsx
+++ b/src/writeData/subscriptions/components/ParsingDetails.tsx
@@ -4,7 +4,7 @@ import React, {FC} from 'react'
 // Components
 import {Grid, Form, Overlay} from '@influxdata/clockface'
 import LineProtocolForm from 'src/writeData/subscriptions/components/LineProtocolForm'
-import StringParsingForm from 'src/writeData/subscriptions/components/StringParsingForm'
+import {StringParsingForm} from 'src/writeData/subscriptions/components/StringParsingForm'
 import JsonParsingForm from 'src/writeData/subscriptions/components/JsonParsingForm'
 import ParsingDetailsEdit from 'src/writeData/subscriptions/components/ParsingDetailsEdit'
 import ParsingDetailsReadOnly from 'src/writeData/subscriptions/components/ParsingDetailsReadOnly'

--- a/src/writeData/subscriptions/components/ParsingForm.tsx
+++ b/src/writeData/subscriptions/components/ParsingForm.tsx
@@ -11,7 +11,7 @@ import {
   FontWeight,
 } from '@influxdata/clockface'
 import ParsingDetailsEdit from 'src/writeData/subscriptions/components/ParsingDetailsEdit'
-import StringParsingForm from 'src/writeData/subscriptions/components/StringParsingForm'
+import {StringParsingForm} from 'src/writeData/subscriptions/components/StringParsingForm'
 import JsonParsingForm from 'src/writeData/subscriptions/components/JsonParsingForm'
 import LineProtocolForm from 'src/writeData/subscriptions/components/LineProtocolForm'
 
@@ -28,7 +28,7 @@ interface Props {
   showUpgradeButton: boolean
 }
 
-const ParsingForm: FC<Props> = ({
+export const ParsingForm: FC<Props> = ({
   formContent,
   updateForm,
   onFocus,
@@ -90,4 +90,3 @@ const ParsingForm: FC<Props> = ({
       </Form>
     </div>
   )
-export default ParsingForm

--- a/src/writeData/subscriptions/components/StatusHeader.tsx
+++ b/src/writeData/subscriptions/components/StatusHeader.tsx
@@ -28,7 +28,7 @@ interface Props {
   setStatus: (any) => void
 }
 
-const StatusHeader: FC<Props> = ({currentSubscription, setStatus}) => {
+export const StatusHeader: FC<Props> = ({currentSubscription, setStatus}) => {
   const {bulletins: allBulletins} = useContext(SubscriptionListContext)
   const bulletins = allBulletins?.[currentSubscription.id] ?? []
   const [isOverlayVisible, setIsOverlayVisible] = useState<boolean>(false)
@@ -127,5 +127,3 @@ const StatusHeader: FC<Props> = ({currentSubscription, setStatus}) => {
     </>
   )
 }
-
-export default StatusHeader

--- a/src/writeData/subscriptions/components/StringParsingForm.tsx
+++ b/src/writeData/subscriptions/components/StringParsingForm.tsx
@@ -18,7 +18,7 @@ import {
   InputLabel,
   SlideToggle,
 } from '@influxdata/clockface'
-import StringPatternInput from 'src/writeData/subscriptions/components/StringPatternInput'
+import {StringPatternInput} from 'src/writeData/subscriptions/components/StringPatternInput'
 
 // Types
 import {Subscription, PrecisionTypes} from 'src/types/subscriptions'
@@ -34,7 +34,7 @@ import {
 import 'src/writeData/subscriptions/components/StringParsingForm.scss'
 import {event} from 'src/cloud/utils/reporting'
 import {ComponentStatus} from '@influxdata/clockface'
-import ValidationInputWithTooltip from './ValidationInputWithTooltip'
+import {ValidationInputWithTooltip} from './ValidationInputWithTooltip'
 
 interface Props {
   formContent: Subscription
@@ -42,7 +42,11 @@ interface Props {
   edit: boolean
 }
 
-const StringParsingForm: FC<Props> = ({formContent, updateForm, edit}) => {
+export const StringParsingForm: FC<Props> = ({
+  formContent,
+  updateForm,
+  edit,
+}) => {
   const ruleList = ['field', 'tag']
   const [rule, setRule] = useState('')
   const [useStaticMeasurement, setUseStaticMeasurement] = useState(
@@ -370,5 +374,3 @@ const StringParsingForm: FC<Props> = ({formContent, updateForm, edit}) => {
     </div>
   )
 }
-
-export default StringParsingForm

--- a/src/writeData/subscriptions/components/StringPatternInput.tsx
+++ b/src/writeData/subscriptions/components/StringPatternInput.tsx
@@ -24,7 +24,7 @@ import {
   REGEX_TOOLTIP,
 } from 'src/writeData/subscriptions/utils/form'
 import {event} from 'src/cloud/utils/reporting'
-import ValidationInputWithTooltip from './ValidationInputWithTooltip'
+import {ValidationInputWithTooltip} from './ValidationInputWithTooltip'
 
 interface Props {
   name: string
@@ -34,7 +34,7 @@ interface Props {
   edit: boolean
 }
 
-const StringPatternInput: FC<Props> = ({
+export const StringPatternInput: FC<Props> = ({
   name,
   formContent,
   updateForm,
@@ -192,5 +192,3 @@ const StringPatternInput: FC<Props> = ({
     </div>
   )
 }
-
-export default StringPatternInput

--- a/src/writeData/subscriptions/components/SubscriptionForm.tsx
+++ b/src/writeData/subscriptions/components/SubscriptionForm.tsx
@@ -26,7 +26,7 @@ interface Props {
   showUpgradeButton: boolean
 }
 
-const SubscriptionForm: FC<Props> = ({
+export const SubscriptionForm: FC<Props> = ({
   formContent,
   updateForm,
   buckets,
@@ -74,5 +74,3 @@ const SubscriptionForm: FC<Props> = ({
     )
   )
 }
-
-export default SubscriptionForm

--- a/src/writeData/subscriptions/components/SubscriptionsLanding.tsx
+++ b/src/writeData/subscriptions/components/SubscriptionsLanding.tsx
@@ -14,8 +14,8 @@ import {
   SpinnerContainer,
   TechnoSpinner,
 } from '@influxdata/clockface'
-import EmptySubscriptionState from 'src/writeData/subscriptions/components/EmptySubscriptionState'
-import SubscriptionsList from 'src/writeData/subscriptions/components/SubscriptionsList'
+import {EmptySubscriptionState} from 'src/writeData/subscriptions/components/EmptySubscriptionState'
+import {SubscriptionsList} from 'src/writeData/subscriptions/components/SubscriptionsList'
 import LoadDataHeader from 'src/settings/components/LoadDataHeader'
 import {SortTypes} from 'src/shared/utils/sort'
 import SearchWidget from 'src/shared/components/search_widget/SearchWidget'

--- a/src/writeData/subscriptions/components/SubscriptionsList.tsx
+++ b/src/writeData/subscriptions/components/SubscriptionsList.tsx
@@ -11,12 +11,10 @@ interface Props {
   subscriptions: Subscription[]
 }
 
-const SubscriptionsList: FC<Props> = ({subscriptions}) => (
+export const SubscriptionsList: FC<Props> = ({subscriptions}) => (
   <div className="subscriptions-list">
     {subscriptions.map((s, key) => (
       <SubscriptionCard key={key} subscription={s} />
     ))}
   </div>
 )
-
-export default SubscriptionsList

--- a/src/writeData/subscriptions/components/TextAreaWithLabel.tsx
+++ b/src/writeData/subscriptions/components/TextAreaWithLabel.tsx
@@ -26,7 +26,7 @@ type Props = OwnProps & TextAreaProps
 
 const DEFAULT_VALIDATION_FUNC: ValidationFunction = _ => ''
 
-const TextAreaWithLabel: FC<Props> = ({
+export const TextAreaWithLabel: FC<Props> = ({
   label,
   description,
   value,
@@ -82,5 +82,3 @@ const TextAreaWithLabel: FC<Props> = ({
     </FlexBox>
   )
 }
-
-export default TextAreaWithLabel

--- a/src/writeData/subscriptions/components/UserInput.tsx
+++ b/src/writeData/subscriptions/components/UserInput.tsx
@@ -23,7 +23,12 @@ interface Props {
   edit: boolean
 }
 
-const UserInput: FC<Props> = ({formContent, updateForm, className, edit}) => (
+export const UserInput: FC<Props> = ({
+  formContent,
+  updateForm,
+  className,
+  edit,
+}) => (
   <FlexBox
     alignItems={AlignItems.FlexStart}
     direction={FlexDirection.Row}
@@ -73,4 +78,3 @@ const UserInput: FC<Props> = ({formContent, updateForm, className, edit}) => (
     </Form.Element>
   </FlexBox>
 )
-export default UserInput

--- a/src/writeData/subscriptions/components/ValidationInputWithTooltip.tsx
+++ b/src/writeData/subscriptions/components/ValidationInputWithTooltip.tsx
@@ -31,7 +31,7 @@ interface Props {
   width?: string
 }
 
-const ValidationInputWithTooltip: FC<Props> = ({
+export const ValidationInputWithTooltip: FC<Props> = ({
   label,
   value,
   required,
@@ -84,5 +84,3 @@ const ValidationInputWithTooltip: FC<Props> = ({
     </Form.ValidationElement>
   </div>
 )
-
-export default ValidationInputWithTooltip

--- a/src/writeData/subscriptions/context/subscription.create.tsx
+++ b/src/writeData/subscriptions/context/subscription.create.tsx
@@ -153,5 +153,3 @@ export const SubscriptionCreateProvider: FC = ({children}) => {
     </SubscriptionCreateContext.Provider>
   )
 }
-
-export default SubscriptionCreateProvider

--- a/src/writeData/subscriptions/context/subscription.list.tsx
+++ b/src/writeData/subscriptions/context/subscription.list.tsx
@@ -156,5 +156,3 @@ export const SubscriptionListProvider: FC = ({children}) => {
     </SubscriptionListContext.Provider>
   )
 }
-
-export default SubscriptionListProvider

--- a/src/writeData/subscriptions/context/subscription.update.tsx
+++ b/src/writeData/subscriptions/context/subscription.update.tsx
@@ -198,5 +198,3 @@ export const SubscriptionUpdateProvider: FC = ({children}) => {
     </SubscriptionUpdateContext.Provider>
   )
 }
-
-export default SubscriptionUpdateProvider

--- a/yarn.lock
+++ b/yarn.lock
@@ -2021,6 +2021,11 @@
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
 
+"@types/json5@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
+  integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
+
 "@types/lodash@^4.14.177":
   version "4.14.178"
   resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.178.tgz"
@@ -2955,7 +2960,7 @@ array-includes@^3.1.3:
     get-intrinsic "^1.1.1"
     is-string "^1.0.7"
 
-array-includes@^3.1.5:
+array-includes@^3.1.4, array-includes@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.5.tgz#2c320010db8d31031fd2a5f6b3bbd4b1aad31bdb"
   integrity sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==
@@ -2987,6 +2992,16 @@ array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
+
+array.prototype.flat@^1.2.5:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz#0b0c1567bf57b38b56b4c97b8aa72ab45e4adc7b"
+  integrity sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.19.2"
+    es-shim-unscopables "^1.0.0"
 
 array.prototype.flatmap@^1.3.0:
   version "1.3.0"
@@ -4687,7 +4702,7 @@ dayjs@^1.10.4:
   resolved "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz"
   integrity sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig==
 
-debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
+debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -4708,7 +4723,7 @@ debug@4, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2:
   dependencies:
     ms "2.1.2"
 
-debug@^3.1.0:
+debug@^3.1.0, debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
@@ -5283,6 +5298,40 @@ eslint-config-prettier@^8.5.0:
   version "8.5.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz#5a81680ec934beca02c7b1a61cf8ca34b66feab1"
   integrity sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==
+
+eslint-import-resolver-node@^0.3.6:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz#4048b958395da89668252001dbd9eca6b83bacbd"
+  integrity sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==
+  dependencies:
+    debug "^3.2.7"
+    resolve "^1.20.0"
+
+eslint-module-utils@^2.7.3:
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.7.4.tgz#4f3e41116aaf13a20792261e61d3a2e7e0583974"
+  integrity sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==
+  dependencies:
+    debug "^3.2.7"
+
+eslint-plugin-import@^2.26.0:
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz#f812dc47be4f2b72b478a021605a59fc6fe8b88b"
+  integrity sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==
+  dependencies:
+    array-includes "^3.1.4"
+    array.prototype.flat "^1.2.5"
+    debug "^2.6.9"
+    doctrine "^2.1.0"
+    eslint-import-resolver-node "^0.3.6"
+    eslint-module-utils "^2.7.3"
+    has "^1.0.3"
+    is-core-module "^2.8.1"
+    is-glob "^4.0.3"
+    minimatch "^3.1.2"
+    object.values "^1.1.5"
+    resolve "^1.22.0"
+    tsconfig-paths "^3.14.1"
 
 eslint-plugin-jest@^27.0.1:
   version "27.0.4"
@@ -6928,6 +6977,13 @@ is-core-module@^2.2.0:
   version "2.8.0"
   resolved "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz"
   integrity sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==
+  dependencies:
+    has "^1.0.3"
+
+is-core-module@^2.8.1, is-core-module@^2.9.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.10.0.tgz#9012ede0a91c69587e647514e1d5277019e728ed"
+  integrity sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==
   dependencies:
     has "^1.0.3"
 
@@ -9456,7 +9512,7 @@ path-key@^3.0.0, path-key@^3.1.0:
   resolved "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-path-parse@^1.0.6:
+path-parse@^1.0.6, path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
@@ -10682,6 +10738,15 @@ resolve@^1.14.2, resolve@^1.20.0, resolve@^1.9.0:
     is-core-module "^2.2.0"
     path-parse "^1.0.6"
 
+resolve@^1.22.0:
+  version "1.22.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
+  integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
+  dependencies:
+    is-core-module "^2.9.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
 resolve@^2.0.0-next.3:
   version "2.0.0-next.3"
   resolved "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.3.tgz"
@@ -11505,6 +11570,11 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   dependencies:
     ansi-regex "^5.0.1"
 
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+  integrity sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==
+
 strip-bom@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz"
@@ -11607,6 +11677,11 @@ supports-hyperlinks@^2.0.0:
   dependencies:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
+
+supports-preserve-symlinks-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
+  integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
 svg-pathdata@^6.0.3:
   version "6.0.3"
@@ -11977,6 +12052,16 @@ ts-node@^10.9.1:
     make-error "^1.1.1"
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
+
+tsconfig-paths@^3.14.1:
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz#ba0734599e8ea36c862798e920bcf163277b137a"
+  integrity sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==
+  dependencies:
+    "@types/json5" "^0.0.29"
+    json5 "^1.0.1"
+    minimist "^1.2.6"
+    strip-bom "^3.0.0"
 
 tslib@^1.8.1:
   version "1.14.1"


### PR DESCRIPTION
This patch disallows `export default ...` in lint and forces it to
error.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable