### PR TITLE
chore: resolve flaky nav and notificationRules tests

### DIFF
--- a/cypress/e2e/shared/nav.test.ts
+++ b/cypress/e2e/shared/nav.test.ts
@@ -6,6 +6,7 @@ describe('navigation', () => {
     cy.flush()
     cy.signin()
     cy.visit('/')
+    cy.getByTestID('home-page--header').should('be.visible')
   })
 
   it('can navigate to each page from left nav', () => {
@@ -47,7 +48,7 @@ describe('navigation', () => {
     cy.getByTestID('not-found').should('exist')
     cy.visit('/')
 
-    if (CLOUD) {
+    if (!CLOUD) {
       cy.getByTestID('user-nav').should('exist')
       cy.get<Organization>('@org').then(({id}: Organization) => {
         cy.visit(`/orgs/${id}/not-a-route`)
@@ -136,17 +137,19 @@ describe('navigation', () => {
 
   const exploreTabs = (tabs: string[]) => {
     tabs.forEach(tab => {
-      cy.getByTestID(`${tab}--tab`).click()
+      cy.getByTestID(`${tab}--tab`).should('be.visible').click()
       cy.url().should('contain', tab)
     })
   }
 
   it('can navigate in tabs of settings page', () => {
+    cy.getByTestID('nav-item-settings').should('be.visible')
     cy.clickNavBarItem('nav-item-settings')
     exploreTabs(['templates', 'labels', 'variables'])
   })
 
   it('can navigate in tabs of collapsed alerts page', () => {
+    cy.getByTestID('nav-item-alerting').should('be.visible')
     cy.clickNavBarItem('nav-item-alerting')
     ;['checks', 'endpoints', 'rules'].forEach(tab => {
       cy.getByTestID(`alerting-tab--${tab}`).click()

--- a/cypress/e2e/shared/nav.test.ts
+++ b/cypress/e2e/shared/nav.test.ts
@@ -1,4 +1,5 @@
 import {Organization} from '../../../src/types'
+const CLOUD = Cypress.env('dexUrl') === 'OSS' ? false : true
 
 describe('navigation', () => {
   beforeEach(() => {
@@ -46,13 +47,14 @@ describe('navigation', () => {
     cy.getByTestID('not-found').should('exist')
     cy.visit('/')
 
-    cy.getByTestID('user-nav').should('exist')
-    cy.get<Organization>('@org').then(({id}: Organization) => {
-      cy.visit(`/orgs/${id}/not-a-route`)
-      cy.getByTestID('not-found').should('exist')
-    })
+    if (CLOUD) {
+      cy.getByTestID('user-nav').should('exist')
+      cy.get<Organization>('@org').then(({id}: Organization) => {
+        cy.visit(`/orgs/${id}/not-a-route`)
+        cy.getByTestID('not-found').should('exist')
+      })
 
-    /** \
+      /** \
 
      OSS Only Feature
      // User Nav -- Members
@@ -63,14 +65,14 @@ describe('navigation', () => {
 
      \**/
 
-    // User Nav -- Settings
-    cy.getByTestID('user-nav').click()
-    cy.getByTestID('user-nav-item-about').click()
-    cy.getByTestID('about-page--header').should('exist')
-    const url = Cypress.env('dexUrl') === 'OSS' ? 'about' : 'org-settings'
-    cy.url().should('contain', url)
+      // User Nav -- Settings
+      cy.getByTestID('user-nav').click()
+      cy.getByTestID('user-nav-item-about').click()
+      cy.getByTestID('about-page--header').should('exist')
+      const url = Cypress.env('dexUrl') === 'OSS' ? 'about' : 'org-settings'
+      cy.url().should('contain', url)
 
-    /** \
+      /** \
 
      OSS Only Feature
      // User Nav -- Switch Orgs
@@ -81,7 +83,7 @@ describe('navigation', () => {
 
      \**/
 
-    /** \
+      /** \
 
      OSS Only Feature
      // User Nav -- Create Orgs
@@ -92,7 +94,7 @@ describe('navigation', () => {
 
      \**/
 
-    /** \
+      /** \
 
      OSS Only Feature
      // User Nav -- Log Out
@@ -101,6 +103,7 @@ describe('navigation', () => {
      cy.getByTestID('signin-page').should('exist')
 
      \**/
+    }
   })
 
   it('can navigate in tabs of data page', () => {

--- a/cypress/e2e/shared/notificationRules.test.ts
+++ b/cypress/e2e/shared/notificationRules.test.ts
@@ -720,9 +720,9 @@ describe('NotificationRules', () => {
       })
 
       // Switch to UTC
-      cy.getByTestID('dropdown--button').should('have.text', 'Local').click()
+      cy.getByTestID('timezone-dropdown').should('have.text', 'Local').click()
       cy.getByTitle('UTC').click()
-      cy.getByTestID('dropdown--button').should('have.text', 'UTC')
+      cy.getByTestID('timezone-dropdown').should('have.text', 'UTC')
 
       // compare UTC values
       cy.getByTestID('event-row--field time').then(timestamps => {
@@ -733,9 +733,9 @@ describe('NotificationRules', () => {
       })
 
       // Switch back to Local
-      cy.getByTestID('dropdown--button').click()
+      cy.getByTestID('timezone-dropdown').click()
       cy.getByTitle('Local').click()
-      cy.getByTestID('dropdown--button').should('have.text', 'Local')
+      cy.getByTestID('timezone-dropdown').should('have.text', 'Local')
 
       cy.getByTestID('event-row--field time').then(timestamps => {
         const CurrHours = timestamps


### PR DESCRIPTION
CI runs are frequently flaking on the shared nav and notificationRules tests in cloud. Both after deployment of K8s-idpe PR #12038, which synced remocal flags to current prod flags. 

- In the nav test, it can't find the `user-nav` element. That's expected. In cloud, user-nav doesn't exist anymore, because that functionality is in global header. Fixed this by skipping that portion of the test _only_ when the environment is CLOUD.
- In the notificationRules test, it tries to find the first 'dropdown-button' on the page. Previously, that would've been part of the alerts form. But now there's a dropdown in the page header too, which cypress finds first. Fixed by making the selector appropriately specific, so it targets the dropdown on the _page_.

Not clear why this flakiness only arose after the k8s-idpe PR - we had the same flags toggled on with `cy.setFeatureFlags` before. Maybe the `cy.setFeatureFlags` flag reset wasn't working sometimes, which was letting the test squeak by.

I also added some additional guards to combat test flake generally - there were some places in the test where we weren't checking for DOM element visibility before clicking.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - NO
