### PR TITLE
chore(sub): remove subscriptionsUI flag

### DIFF
--- a/cypress/e2e/cloud/subscriptions.test.ts
+++ b/cypress/e2e/cloud/subscriptions.test.ts
@@ -14,7 +14,6 @@ describe('Subscriptions', () => {
               cy.visit(`${orgs}/${id}/load-data/sources`)
 
               cy.setFeatureFlags({
-                subscriptionsUI: true,
                 multiOrg: true,
               })
 

--- a/src/authorizations/components/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/CustomApiTokenOverlay.tsx
@@ -89,12 +89,8 @@ const CustomApiTokenOverlay: FC<Props> = props => {
         otherResources: {read: false, write: false},
       }
       props.allResources
-        // filter out Subsriptions resource type if the UI is not enabled
         .filter(
-          p =>
-            (p !== ResourceType.Subscriptions ||
-              isFlagEnabled('subscriptionsUI')) &&
-            String(p) !== 'instance'
+          p => p !== ResourceType.Subscriptions && String(p) !== 'instance'
         )
         .forEach(resource => {
           if (resource === ResourceType.Telegrafs) {

--- a/src/authorizations/components/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/CustomApiTokenOverlay.tsx
@@ -47,7 +47,6 @@ import {
   generateDescription,
 } from 'src/authorizations/utils/permissions'
 import {event} from 'src/cloud/utils/reporting'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
 
 interface OwnProps {

--- a/src/authorizations/utils/permissions.ts
+++ b/src/authorizations/utils/permissions.ts
@@ -1,6 +1,5 @@
 import {Permission, ResourceType} from 'src/types'
 import {capitalize} from 'lodash'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 export type PermissionTypes = Permission['resource']['type']
 

--- a/src/authorizations/utils/permissions.ts
+++ b/src/authorizations/utils/permissions.ts
@@ -59,9 +59,7 @@ export const formatResources = resourceNames => {
     item =>
       item !== ResourceType.Buckets &&
       item !== ResourceType.Telegrafs &&
-      // filter out Subsriptions resource type if the UI is not enabled
-      (item !== ResourceType.Subscriptions ||
-        isFlagEnabled('subscriptionsUI')) &&
+      item !== ResourceType.Subscriptions &&
       String(item) !== 'instance'
   )
   resources.sort()

--- a/src/pageLayout/constants/navigationHierarchy.ts
+++ b/src/pageLayout/constants/navigationHierarchy.ts
@@ -80,7 +80,7 @@ export const generateNavItems = (): NavItem[] => {
           testID: 'nav-subitem-subscriptions',
           label: 'Native Subscriptions',
           link: `${orgPrefix}/load-data/subscriptions`,
-          enabled: () => CLOUD && isFlagEnabled('subscriptionsUI'),
+          enabled: () => CLOUD,
         },
         {
           id: 'tokens',

--- a/src/settings/components/LoadDataNavigation.tsx
+++ b/src/settings/components/LoadDataNavigation.tsx
@@ -60,7 +60,7 @@ const LoadDataNavigation: FC<Props> = ({activeTab}) => {
       id: 'subscriptions',
       cloudExclude: false,
       cloudOnly: true,
-      featureFlag: 'subscriptionsUI',
+      featureFlag: null,
     },
     {
       text: 'API Tokens',

--- a/src/shared/containers/SetOrg.tsx
+++ b/src/shared/containers/SetOrg.tsx
@@ -212,19 +212,19 @@ const SetOrg: FC = () => {
             path={`${orgPath}/${LOAD_DATA}/${BUCKETS}`}
             component={BucketsIndex}
           />
-          {CLOUD && isFlagEnabled('subscriptionsUI') && (
+          {CLOUD && (
             <Route
               path={`${orgPath}/${LOAD_DATA}/${SUBSCRIPTIONS}/create`}
               component={CreateSubscriptionForm}
             />
           )}
-          {CLOUD && isFlagEnabled('subscriptionsUI') && (
+          {CLOUD && (
             <Route
               path={`${orgPath}/${LOAD_DATA}/${SUBSCRIPTIONS}/:id`}
               component={DetailsSubscriptionPage}
             />
           )}
-          {CLOUD && isFlagEnabled('subscriptionsUI') && (
+          {CLOUD && (
             <Route
               path={`${orgPath}/${LOAD_DATA}/${SUBSCRIPTIONS}`}
               component={SubscriptionsLanding}

--- a/src/writeData/components/WriteDataSections.tsx
+++ b/src/writeData/components/WriteDataSections.tsx
@@ -41,7 +41,7 @@ const WriteDataSections: FC = () => {
     <>
       <FileUploadSection />
       <ClientLibrarySection />
-      {CLOUD && isFlagEnabled('subscriptionsUI') && <CloudNativeSources />}
+      {CLOUD && <CloudNativeSources />}
       <TelegrafPluginSection />
     </>
   )

--- a/src/writeData/components/WriteDataSections.tsx
+++ b/src/writeData/components/WriteDataSections.tsx
@@ -17,9 +17,6 @@ import ClientLibrarySection from 'src/writeData/components/ClientLibrarySection'
 import TelegrafPluginSection from 'src/writeData/components/TelegrafPluginSection'
 import CloudNativeSources from 'src/writeData/subscriptions/components/CloudNativeSources'
 
-// Utils
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
-
 const WriteDataSections: FC = () => {
   const {searchTerm} = useContext(WriteDataSearchContext)
   const hasResults =


### PR DESCRIPTION
No need for this anymore 🎉  Removes usage of the `subscriptionsUI` flag that was only used to determine if we should display the Native Subscriptions page or not. This flag is enabled everywhere and will remain that way so we can remove it.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
