### PR TITLE
fix: prevent decimal places customization from crashing the visualization

### DIFF
--- a/src/visualization/components/internal/DecimalPlaces.tsx
+++ b/src/visualization/components/internal/DecimalPlaces.tsx
@@ -1,0 +1,79 @@
+// Libraries
+import React, {FC, useState} from 'react'
+
+// Components
+import {
+  AutoInput,
+  AutoInputMode,
+  Form,
+  Input,
+  InputType,
+} from '@influxdata/clockface'
+
+// Utils
+import {convertUserInputToNumOrNaN} from 'src/shared/utils/convertUserInput'
+
+// Constants
+import {
+  MIN_DECIMAL_PLACES,
+  MAX_DECIMAL_PLACES,
+} from 'src/visualization/constants'
+
+interface DecimalPlacesProps {
+  isEnforced: boolean
+  digits: number
+  update: (obj: any) => void
+}
+
+export const DecimalPlaces: FC<DecimalPlacesProps> = (
+  props: DecimalPlacesProps
+) => {
+  const {isEnforced, digits, update} = props
+  const [decimalPlaces, setDecimalPlaces] = useState<number | null>(digits)
+
+  const setDigits = (updatedDigits: number | null) => {
+    setDecimalPlaces(updatedDigits)
+    if (!Number.isNaN(updatedDigits)) {
+      update({
+        decimalPlaces: {
+          isEnforced,
+          digits: updatedDigits,
+        },
+      })
+    }
+  }
+
+  const handleChangeMode = (mode: AutoInputMode): void => {
+    if (mode === AutoInputMode.Auto) {
+      setDigits(null)
+    } else {
+      setDigits(2)
+    }
+  }
+
+  return (
+    <Form.Element label="Decimal Places">
+      <AutoInput
+        mode={
+          typeof decimalPlaces === 'number'
+            ? AutoInputMode.Custom
+            : AutoInputMode.Auto
+        }
+        onChangeMode={handleChangeMode}
+        inputComponent={
+          <Input
+            name="decimal-places"
+            placeholder="Enter a number"
+            onChange={event => {
+              setDigits(convertUserInputToNumOrNaN(event))
+            }}
+            value={decimalPlaces}
+            min={MIN_DECIMAL_PLACES}
+            max={MAX_DECIMAL_PLACES}
+            type={InputType.Number}
+          />
+        }
+      />
+    </Form.Element>
+  )
+}

--- a/src/visualization/types/Gauge/index.tsx
+++ b/src/visualization/types/Gauge/index.tsx
@@ -1,6 +1,6 @@
 import icon from './icon'
 import properties from './properties'
-import options from './options'
+import {GaugeOptions} from './options'
 import view from './view'
 
 export default register => {
@@ -10,6 +10,6 @@ export default register => {
     graphic: icon,
     initial: properties,
     component: view,
-    options,
+    options: GaugeOptions,
   })
 }

--- a/src/visualization/types/Gauge/options.tsx
+++ b/src/visualization/types/Gauge/options.tsx
@@ -1,22 +1,12 @@
+// Libraries
 import React, {FC} from 'react'
+import {Columns, Form, Grid, Input} from '@influxdata/clockface'
 
-import {
-  Grid,
-  Columns,
-  Form,
-  AutoInput,
-  AutoInputMode,
-  Input,
-  InputType,
-} from '@influxdata/clockface'
-
+// Components
 import ThresholdsSettings from 'src/visualization/components/internal/ThresholdsSettings'
-import {
-  MIN_DECIMAL_PLACES,
-  MAX_DECIMAL_PLACES,
-} from 'src/visualization/constants'
-import {convertUserInputToNumOrNaN} from 'src/shared/utils/convertUserInput'
+import {DecimalPlaces} from 'src/visualization/components/internal/DecimalPlaces'
 
+// Types
 import {GaugeViewProperties} from 'src/types'
 import {VisualizationOptionProps} from 'src/visualization'
 
@@ -24,118 +14,85 @@ interface Props extends VisualizationOptionProps {
   properties: GaugeViewProperties
 }
 
-const GaugeOptions: FC<Props> = ({properties, update}) => {
-  const setDigits = (digits: number | null) => {
-    update({
-      decimalPlaces: {
-        ...properties.decimalPlaces,
-        digits,
-      },
-    })
-  }
-  const handleChangeMode = (mode: AutoInputMode): void => {
-    if (mode === AutoInputMode.Auto) {
-      setDigits(null)
-    } else {
-      setDigits(2)
-    }
-  }
-
-  return (
-    <Grid>
-      <Grid.Row>
-        <Grid.Column>
-          <Grid.Row>
-            <Grid.Column widthXS={Columns.Six}>
-              <Form.Element label="Value Prefix">
-                <Input
-                  testID="prefix-input"
-                  value={properties.prefix}
-                  onChange={evt => {
-                    update({prefix: evt.target.value})
-                  }}
-                  placeholder="%, MPH, etc."
-                />
-              </Form.Element>
-            </Grid.Column>
-            <Grid.Column widthXS={Columns.Six}>
-              <Form.Element label="Value Suffix">
-                <Input
-                  testID="suffix-input"
-                  value={properties.suffix}
-                  onChange={evt => {
-                    update({suffix: evt.target.value})
-                  }}
-                  placeholder="%, MPH, etc."
-                />
-              </Form.Element>
-            </Grid.Column>
-          </Grid.Row>
-          <Grid.Row>
-            <Grid.Column widthXS={Columns.Six}>
-              <Form.Element label="Axis Prefix">
-                <Input
-                  testID="tick-prefix-input"
-                  value={properties.tickPrefix}
-                  onChange={evt => {
-                    update({tickPrefix: evt.target.value})
-                  }}
-                  placeholder="%, MPH, etc."
-                />
-              </Form.Element>
-            </Grid.Column>
-            <Grid.Column widthXS={Columns.Six}>
-              <Form.Element label="Axis Suffix">
-                <Input
-                  testID="tick-suffix-input"
-                  value={properties.tickSuffix}
-                  onChange={evt => {
-                    update({tickSuffix: evt.target.value})
-                  }}
-                  placeholder="%, MPH, etc."
-                />
-              </Form.Element>
-            </Grid.Column>
-          </Grid.Row>
-          {properties.decimalPlaces && (
-            <Form.Element label="Decimal Places">
-              <AutoInput
-                mode={
-                  properties.decimalPlaces.digits
-                    ? AutoInputMode.Custom
-                    : AutoInputMode.Auto
-                }
-                onChangeMode={handleChangeMode}
-                inputComponent={
-                  <Input
-                    name="decimal-places"
-                    placeholder="Enter a number"
-                    onChange={evt => {
-                      setDigits(convertUserInputToNumOrNaN(evt))
-                    }}
-                    value={properties.decimalPlaces.digits}
-                    min={MIN_DECIMAL_PLACES}
-                    max={MAX_DECIMAL_PLACES}
-                    type={InputType.Number}
-                  />
-                }
+export const GaugeOptions: FC<Props> = ({properties, update}) => (
+  <Grid>
+    <Grid.Row>
+      <Grid.Column>
+        <Grid.Row>
+          <Grid.Column widthXS={Columns.Six}>
+            <Form.Element label="Value Prefix">
+              <Input
+                testID="prefix-input"
+                value={properties.prefix}
+                onChange={evt => {
+                  update({prefix: evt.target.value})
+                }}
+                placeholder="%, MPH, etc."
               />
             </Form.Element>
-          )}
-        </Grid.Column>
-        <Grid.Column widthXS={Columns.Twelve} widthMD={Columns.Six}>
-          <Form.Element label="Colorized Thresholds">
-            <ThresholdsSettings
-              thresholds={properties.colors}
-              onSetThresholds={colors => {
-                update({colors})
-              }}
-            />
-          </Form.Element>
-        </Grid.Column>
-      </Grid.Row>
-    </Grid>
-  )
-}
-
-export default GaugeOptions
+          </Grid.Column>
+          <Grid.Column widthXS={Columns.Six}>
+            <Form.Element label="Value Suffix">
+              <Input
+                testID="suffix-input"
+                value={properties.suffix}
+                onChange={evt => {
+                  update({suffix: evt.target.value})
+                }}
+                placeholder="%, MPH, etc."
+              />
+            </Form.Element>
+          </Grid.Column>
+        </Grid.Row>
+        <Grid.Row>
+          <Grid.Column widthXS={Columns.Six}>
+            <Form.Element label="Axis Prefix">
+              <Input
+                testID="tick-prefix-input"
+                value={properties.tickPrefix}
+                onChange={evt => {
+                  update({tickPrefix: evt.target.value})
+                }}
+                placeholder="%, MPH, etc."
+              />
+            </Form.Element>
+          </Grid.Column>
+          <Grid.Column widthXS={Columns.Six}>
+            <Form.Element label="Axis Suffix">
+              <Input
+                testID="tick-suffix-input"
+                value={properties.tickSuffix}
+                onChange={evt => {
+                  update({tickSuffix: evt.target.value})
+                }}
+                placeholder="%, MPH, etc."
+              />
+            </Form.Element>
+          </Grid.Column>
+        </Grid.Row>
+        {properties.decimalPlaces && (
+          <DecimalPlaces
+            isEnforced={properties?.decimalPlaces?.isEnforced === true}
+            digits={
+              typeof properties?.decimalPlaces?.digits === 'number' ||
+              properties?.decimalPlaces?.digits === null
+                ? properties.decimalPlaces.digits
+                : NaN
+            }
+            update={update}
+          />
+        )}
+      </Grid.Column>
+      <Grid.Column widthXS={Columns.Twelve} widthMD={Columns.Six}>
+        <Form.Element label="Colorized Thresholds">
+          <ThresholdsSettings
+            thresholds={properties.colors}
+            onSetThresholds={colors => {
+              update({colors})
+            }}
+          />
+        </Form.Element>
+      </Grid.Column>
+    </Grid.Row>
+  </Grid>
+)

--- a/src/visualization/types/SingleStat/index.tsx
+++ b/src/visualization/types/SingleStat/index.tsx
@@ -1,6 +1,6 @@
 import icon from './icon'
 import properties from './properties'
-import options from './options'
+import {SingleStatOptions} from './options'
 import view from './view'
 
 export default register => {
@@ -10,6 +10,6 @@ export default register => {
     graphic: icon,
     component: view,
     initial: properties,
-    options,
+    options: SingleStatOptions,
   })
 }

--- a/src/visualization/types/SingleStat/options.tsx
+++ b/src/visualization/types/SingleStat/options.tsx
@@ -2,28 +2,24 @@
 import React, {FC, useCallback} from 'react'
 import {
   ButtonShape,
+  Columns,
   Form,
   Grid,
   Input,
   SelectGroup,
-  Columns,
-  InputType,
-  AutoInput,
-  AutoInputMode,
 } from '@influxdata/clockface'
 
-// Utils
-import {
-  MIN_DECIMAL_PLACES,
-  MAX_DECIMAL_PLACES,
-} from 'src/visualization/constants'
-import {convertUserInputToNumOrNaN} from 'src/shared/utils/convertUserInput'
+// Components
 import ThresholdsSettings from 'src/visualization/components/internal/ThresholdsSettings'
+import {DecimalPlaces} from 'src/visualization/components/internal/DecimalPlaces'
+
+// Constants
 import {
   THRESHOLD_TYPE_TEXT,
   THRESHOLD_TYPE_BG,
 } from 'src/shared/constants/thresholds'
 
+// Types
 import {SingleStatViewProperties, Color} from 'src/types'
 import {VisualizationOptionProps} from 'src/visualization'
 
@@ -31,23 +27,7 @@ interface Props extends VisualizationOptionProps {
   properties: SingleStatViewProperties
 }
 
-const SingleStatOptions: FC<Props> = ({properties, update}) => {
-  const setDigits = (digits: number | null) => {
-    update({
-      decimalPlaces: {
-        ...properties.decimalPlaces,
-        digits,
-      },
-    })
-  }
-  const handleChangeMode = (mode: AutoInputMode): void => {
-    if (mode === AutoInputMode.Auto) {
-      setDigits(null)
-    } else {
-      setDigits(2)
-    }
-  }
-
+export const SingleStatOptions: FC<Props> = ({properties, update}) => {
   const setColors = (colors: Color[]): void => {
     update({colors})
   }
@@ -106,29 +86,16 @@ const SingleStatOptions: FC<Props> = ({properties, update}) => {
           </Grid.Row>
         </Grid.Column>
         <Grid.Column widthXS={Columns.Twelve} widthMD={Columns.Six}>
-          <Form.Element label="Decimal Places">
-            <AutoInput
-              mode={
-                typeof properties.decimalPlaces.digits === 'number'
-                  ? AutoInputMode.Custom
-                  : AutoInputMode.Auto
-              }
-              onChangeMode={handleChangeMode}
-              inputComponent={
-                <Input
-                  name="decimal-places"
-                  placeholder="Enter a number"
-                  onChange={evt => {
-                    setDigits(convertUserInputToNumOrNaN(evt))
-                  }}
-                  value={properties.decimalPlaces.digits}
-                  min={MIN_DECIMAL_PLACES}
-                  max={MAX_DECIMAL_PLACES}
-                  type={InputType.Number}
-                />
-              }
-            />
-          </Form.Element>
+          <DecimalPlaces
+            isEnforced={properties?.decimalPlaces?.isEnforced === true}
+            digits={
+              typeof properties?.decimalPlaces?.digits === 'number' ||
+              properties?.decimalPlaces?.digits === null
+                ? properties.decimalPlaces.digits
+                : NaN
+            }
+            update={update}
+          />
         </Grid.Column>
         <Grid.Column widthXS={Columns.Twelve} widthMD={Columns.Six}>
           <Form.Element label="Colorized Thresholds">
@@ -166,5 +133,3 @@ const SingleStatOptions: FC<Props> = ({properties, update}) => {
     </Grid>
   )
 }
-
-export default SingleStatOptions

--- a/src/visualization/types/SingleStatWithLine/index.tsx
+++ b/src/visualization/types/SingleStatWithLine/index.tsx
@@ -1,6 +1,6 @@
 import icon from './icon'
 import properties from './properties'
-import options from './options'
+import {SingleStatWithLineOptions} from './options'
 import view from './view'
 
 export default register => {
@@ -10,6 +10,6 @@ export default register => {
     graphic: icon,
     initial: properties,
     component: view,
-    options,
+    options: SingleStatWithLineOptions,
   })
 }

--- a/src/visualization/types/SingleStatWithLine/options.tsx
+++ b/src/visualization/types/SingleStatWithLine/options.tsx
@@ -1,26 +1,23 @@
 // Libraries
 import React, {FC, useCallback} from 'react'
 import {
-  Input,
-  InputType,
-  Grid,
+  ButtonShape,
   Columns,
+  ComponentSize,
+  ComponentStatus,
+  Dropdown,
+  FlexBox,
   Form,
+  Grid,
+  Input,
+  InputLabel,
   SelectDropdown,
   SelectGroup,
-  Dropdown,
-  ComponentStatus,
-  ButtonShape,
-  AutoInput,
-  AutoInputMode,
-  FlexBox,
-  ComponentSize,
   SlideToggle,
-  InputLabel,
 } from '@influxdata/clockface'
+import {DecimalPlaces} from 'src/visualization/components/internal/DecimalPlaces'
 
 // Utils
-import {convertUserInputToNumOrNaN} from 'src/shared/utils/convertUserInput'
 import {
   FORMAT_OPTIONS,
   resolveTimeFormat,
@@ -44,11 +41,7 @@ import {VisualizationOptionProps} from 'src/visualization'
 
 // Constants
 import AutoDomainInput from 'src/shared/components/AutoDomainInput'
-import {
-  AXES_SCALE_OPTIONS,
-  MIN_DECIMAL_PLACES,
-  MAX_DECIMAL_PLACES,
-} from 'src/visualization/constants'
+import {AXES_SCALE_OPTIONS} from 'src/visualization/constants'
 import {
   THRESHOLD_TYPE_TEXT,
   THRESHOLD_TYPE_BG,
@@ -60,7 +53,7 @@ interface Props extends VisualizationOptionProps {
   properties: LinePlusSingleStatProperties
 }
 
-const SingleStatWithLineOptions: FC<Props> = ({
+export const SingleStatWithLineOptions: FC<Props> = ({
   properties,
   results,
   update,
@@ -110,21 +103,6 @@ const SingleStatWithLineOptions: FC<Props> = ({
     updateAxis('y', {bounds})
   }
 
-  const setDigits = (digits: number | null) => {
-    update({
-      decimalPlaces: {
-        ...properties.decimalPlaces,
-        digits,
-      },
-    })
-  }
-  const handleChangeMode = (mode: AutoInputMode): void => {
-    if (mode === AutoInputMode.Auto) {
-      setDigits(null)
-    } else {
-      setDigits(2)
-    }
-  }
   const setColors = (colors: Color[]): void => {
     if (colors[0]?.type === 'scale') {
       update({
@@ -460,29 +438,16 @@ const SingleStatWithLineOptions: FC<Props> = ({
           </Grid.Row>
         </Grid.Column>
         <Grid.Column widthXS={Columns.Twelve} widthMD={Columns.Six}>
-          <Form.Element label="Decimal Places">
-            <AutoInput
-              mode={
-                typeof properties.decimalPlaces.digits === 'number'
-                  ? AutoInputMode.Custom
-                  : AutoInputMode.Auto
-              }
-              onChangeMode={handleChangeMode}
-              inputComponent={
-                <Input
-                  name="decimal-places"
-                  placeholder="Enter a number"
-                  onChange={evt => {
-                    setDigits(convertUserInputToNumOrNaN(evt))
-                  }}
-                  value={properties.decimalPlaces.digits}
-                  min={MIN_DECIMAL_PLACES}
-                  max={MAX_DECIMAL_PLACES}
-                  type={InputType.Number}
-                />
-              }
-            />
-          </Form.Element>
+          <DecimalPlaces
+            isEnforced={properties?.decimalPlaces?.isEnforced === true}
+            digits={
+              typeof properties?.decimalPlaces?.digits === 'number' ||
+              properties?.decimalPlaces?.digits === null
+                ? properties.decimalPlaces.digits
+                : NaN
+            }
+            update={update}
+          />
         </Grid.Column>
         <Grid.Column widthXS={Columns.Twelve} widthMD={Columns.Six}>
           <Form.Element label="Colorized Thresholds">
@@ -538,5 +503,3 @@ const SingleStatWithLineOptions: FC<Props> = ({
     </Grid>
   )
 }
-
-export default SingleStatWithLineOptions

--- a/src/visualization/types/Table/index.tsx
+++ b/src/visualization/types/Table/index.tsx
@@ -1,6 +1,6 @@
 import icon from './icon'
 import properties from './properties'
-import options from './options'
+import {TableViewOptions} from './options'
 import view from './view'
 
 export default register => {
@@ -10,6 +10,6 @@ export default register => {
     graphic: icon,
     initial: properties,
     component: view,
-    options,
+    options: TableViewOptions,
   })
 }

--- a/src/visualization/types/Table/options.tsx
+++ b/src/visualization/types/Table/options.tsx
@@ -1,53 +1,53 @@
+// Libraries
 import React, {FC, useMemo, useCallback} from 'react'
 import HTML5Backend from 'react-dnd-html5-backend'
 import {DndProvider} from 'react-dnd'
-
 import {
-  Input,
-  InputType,
-  InputLabel,
-  Grid,
-  Columns,
-  Dropdown,
-  Form,
-  SelectGroup,
-  SelectDropdown,
   ButtonShape,
+  Columns,
+  ComponentSize,
+  Dropdown,
+  EmptyState,
   FlexBox,
   FlexDirection,
-  ComponentSize,
+  Form,
+  Grid,
+  InputLabel,
+  SelectDropdown,
+  SelectGroup,
   SlideToggle,
-  AutoInput,
-  AutoInputMode,
-  EmptyState,
 } from '@influxdata/clockface'
 
+// Components
+import DraggableColumn from 'src/shared/components/draggable_column/DraggableColumn'
+import ThresholdsSettings from 'src/visualization/components/internal/ThresholdsSettings'
+import {DecimalPlaces} from 'src/visualization/components/internal/DecimalPlaces'
+
+// Utils
 import {
   FORMAT_OPTIONS,
   resolveTimeFormat,
 } from 'src/visualization/utils/timeFormat'
+import {move} from 'src/shared/utils/move'
+
+// Constants
 import {
   THRESHOLD_TYPE_TEXT,
   THRESHOLD_TYPE_BG,
 } from 'src/shared/constants/thresholds'
-import DraggableColumn from 'src/shared/components/draggable_column/DraggableColumn'
+
+// Types
 import {TableViewProperties, FieldOption} from 'src/types'
 import {VisualizationOptionProps} from 'src/visualization'
-import {
-  MIN_DECIMAL_PLACES,
-  MAX_DECIMAL_PLACES,
-} from 'src/visualization/constants'
-import {convertUserInputToNumOrNaN} from 'src/shared/utils/convertUserInput'
-import ThresholdsSettings from 'src/visualization/components/internal/ThresholdsSettings'
-import {move} from 'src/shared/utils/move'
 
+// Styles
 import './options.scss'
 
 interface Props extends VisualizationOptionProps {
   properties: TableViewProperties
 }
 
-const TableViewOptions: FC<Props> = ({properties, results, update}) => {
+export const TableViewOptions: FC<Props> = ({properties, results, update}) => {
   const existing = (properties.fieldOptions || []).reduce((prev, curr) => {
     prev[curr.internalName] = curr
     return prev
@@ -64,29 +64,6 @@ const TableViewOptions: FC<Props> = ({properties, results, update}) => {
       }
     })
   const fieldOptions = Object.keys(existing).map(e => existing[e])
-
-  const setDigits = useCallback(
-    (digits: number | null) => {
-      update({
-        decimalPlaces: {
-          ...properties.decimalPlaces,
-          digits,
-        },
-      })
-    },
-    [update, properties.decimalPlaces]
-  )
-
-  const handleChangeMode = useCallback(
-    (mode: AutoInputMode): void => {
-      if (mode === AutoInputMode.Auto) {
-        setDigits(null)
-      } else {
-        setDigits(2)
-      }
-    },
-    [setDigits]
-  )
 
   const updateTableOptions = useCallback(
     tableOptions => {
@@ -244,29 +221,16 @@ const TableViewOptions: FC<Props> = ({properties, results, update}) => {
               }}
             />
           </Form.Element>
-          <Form.Element label="Decimal Places">
-            <AutoInput
-              mode={
-                typeof properties.decimalPlaces.digits === 'number'
-                  ? AutoInputMode.Custom
-                  : AutoInputMode.Auto
-              }
-              onChangeMode={handleChangeMode}
-              inputComponent={
-                <Input
-                  name="decimal-places"
-                  placeholder="Enter a number"
-                  onChange={evt => {
-                    setDigits(convertUserInputToNumOrNaN(evt))
-                  }}
-                  value={properties.decimalPlaces.digits}
-                  min={MIN_DECIMAL_PLACES}
-                  max={MAX_DECIMAL_PLACES}
-                  type={InputType.Number}
-                />
-              }
-            />
-          </Form.Element>
+          <DecimalPlaces
+            isEnforced={properties?.decimalPlaces?.isEnforced === true}
+            digits={
+              typeof properties?.decimalPlaces?.digits === 'number' ||
+              properties?.decimalPlaces?.digits === null
+                ? properties.decimalPlaces.digits
+                : NaN
+            }
+            update={update}
+          />
           <h5 className="view-options--header">Colorized Thresholds</h5>
           <ThresholdsSettings
             thresholds={properties.colors}
@@ -343,5 +307,3 @@ const TableViewOptions: FC<Props> = ({properties, results, update}) => {
     </Grid>
   )
 }
-
-export default TableViewOptions


### PR DESCRIPTION
Closes #5977  

- adds a new component `DecimalPlaces` to handle the customization of decimal places
- prevents the visualization from crashing while changing the input for decimal places
- updates the visualization only upon valid input

Note: `DecimalPlaces` was added to Table's options as a placeholder to replace the customization's previous incarnation. Table does not actually adjust any decimal places at the moment. This visualization is slated for a major design overhaul or possibly deletion (and folded into a different table-like visualization.)


https://user-images.githubusercontent.com/10736577/194127600-96bbf10d-1459-41e0-9275-d10b35a367b2.mp4





