### PR TITLE
feat: add basic Result Options

### DIFF
--- a/src/dataExplorer/components/Aggregate.tsx
+++ b/src/dataExplorer/components/Aggregate.tsx
@@ -1,0 +1,24 @@
+import React, {FC, useState} from 'react'
+
+// Components
+import {ToggleWithLabelTooltip} from 'src/dataExplorer/components/ToggleWithLabelTooltip'
+
+// Styles
+import './Sidebar.scss'
+
+const AGGREGATE_TOOLTIP = `test`
+
+const Aggregate: FC = () => {
+  const [aggregate, setAggregate] = useState(false)
+
+  return (
+    <ToggleWithLabelTooltip
+      label="Aggregate"
+      active={aggregate}
+      onChange={() => setAggregate(current => !current)}
+      tooltipContents={AGGREGATE_TOOLTIP}
+    />
+  )
+}
+
+export {Aggregate}

--- a/src/dataExplorer/components/FieldsAsColumns.tsx
+++ b/src/dataExplorer/components/FieldsAsColumns.tsx
@@ -1,0 +1,7 @@
+import React, {FC} from 'react'
+
+const FieldsAsColumns: FC = () => {
+  return <div>fields as columns</div>
+}
+
+export {FieldsAsColumns}

--- a/src/dataExplorer/components/FieldsAsColumns.tsx
+++ b/src/dataExplorer/components/FieldsAsColumns.tsx
@@ -1,7 +1,24 @@
-import React, {FC} from 'react'
+import React, {FC, useState} from 'react'
+
+// Components
+import {ToggleWithLabelTooltip} from 'src/dataExplorer/components/ToggleWithLabelTooltip'
+
+// Styles
+import './Sidebar.scss'
+
+const FIELDS_AS_COLUMNS_TOOLTIP = `test`
 
 const FieldsAsColumns: FC = () => {
-  return <div>fields as columns</div>
+  const [fieldsAsColumnsActive, setFieldsAsColumnsActive] = useState(false)
+
+  return (
+    <ToggleWithLabelTooltip
+      label="Fields as Columns"
+      active={fieldsAsColumnsActive}
+      onChange={() => setFieldsAsColumnsActive(current => !current)}
+      tooltipContents={FIELDS_AS_COLUMNS_TOOLTIP}
+    />
+  )
 }
 
 export {FieldsAsColumns}

--- a/src/dataExplorer/components/FieldsAsColumns.tsx
+++ b/src/dataExplorer/components/FieldsAsColumns.tsx
@@ -9,13 +9,13 @@ import './Sidebar.scss'
 const FIELDS_AS_COLUMNS_TOOLTIP = `test`
 
 const FieldsAsColumns: FC = () => {
-  const [fieldsAsColumnsActive, setFieldsAsColumnsActive] = useState(false)
+  const [fieldsAsColumns, setFieldsAsColumns] = useState(false)
 
   return (
     <ToggleWithLabelTooltip
       label="Fields as Columns"
-      active={fieldsAsColumnsActive}
-      onChange={() => setFieldsAsColumnsActive(current => !current)}
+      active={fieldsAsColumns}
+      onChange={() => setFieldsAsColumns(current => !current)}
       tooltipContents={FIELDS_AS_COLUMNS_TOOLTIP}
     />
   )

--- a/src/dataExplorer/components/GroupBy.tsx
+++ b/src/dataExplorer/components/GroupBy.tsx
@@ -9,13 +9,13 @@ import './Sidebar.scss'
 const GROUP_TOOLTIP = `test`
 
 const GroupBy: FC = () => {
-  const [groupActive, setGroupActive] = useState(false)
+  const [group, setGroup] = useState(false)
 
   return (
     <ToggleWithLabelTooltip
       label="Group"
-      active={groupActive}
-      onChange={() => setGroupActive(current => !current)}
+      active={group}
+      onChange={() => setGroup(current => !current)}
       tooltipContents={GROUP_TOOLTIP}
     />
   )

--- a/src/dataExplorer/components/GroupBy.tsx
+++ b/src/dataExplorer/components/GroupBy.tsx
@@ -1,0 +1,24 @@
+import React, {FC, useState} from 'react'
+
+// Components
+import {ToggleWithLabelTooltip} from 'src/dataExplorer/components/ToggleWithLabelTooltip'
+
+// Styles
+import './Sidebar.scss'
+
+const GROUP_TOOLTIP = `test`
+
+const GroupBy: FC = () => {
+  const [groupActive, setGroupActive] = useState(false)
+
+  return (
+    <ToggleWithLabelTooltip
+      label="Group"
+      active={groupActive}
+      onChange={() => setGroupActive(current => !current)}
+      tooltipContents={GROUP_TOOLTIP}
+    />
+  )
+}
+
+export {GroupBy}

--- a/src/dataExplorer/components/ResultOptions.tsx
+++ b/src/dataExplorer/components/ResultOptions.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react'
+import React, {FC, useState} from 'react'
 
 // Components
 import {
@@ -13,17 +13,42 @@ import SelectorTitle from 'src/dataExplorer/components/SelectorTitle'
 import './Sidebar.scss'
 
 const TOOLTIP_CONTENT = {
-  FIELDS_AS_COLUMNS: `Tooltip content for Fields as Columns`,
+  FIELDS_AS_COLUMNS: `test`,
+  GROUP: `test`,
 }
 
-const ResultOptions = () => {
-  const [fieldsAsColumnsOn, setFieldsAsColumnsOn] = useState(false)
+interface ToggleWithLabelToolTipProps {
+  active: boolean
+  onChange: () => void
+  label: string
+  tooltipContents?: string | JSX.Element
+}
+
+const ToggleWithLabelToolTip: FC<ToggleWithLabelToolTipProps> = ({
+  active,
+  onChange,
+  label,
+  tooltipContents = '',
+}) => {
+  return (
+    <FlexBox>
+      <SlideToggle active={active} onChange={onChange} />
+      <InputLabel>
+        <SelectorTitle label={label} tooltipContents={tooltipContents} />
+      </InputLabel>
+    </FlexBox>
+  )
+}
+
+const ResultOptions: FC = () => {
+  const [fieldsAsColumnsActive, setFieldsAsColumnsActive] = useState(false)
+  const [groupActive, setGroupActive] = useState(false)
 
   const fieldsAsColumns = (
     <FlexBox>
       <SlideToggle
-        active={fieldsAsColumnsOn}
-        onChange={() => setFieldsAsColumnsOn(current => !current)}
+        active={fieldsAsColumnsActive}
+        onChange={() => setFieldsAsColumnsActive(current => !current)}
       />
       <InputLabel>
         <SelectorTitle
@@ -34,12 +59,22 @@ const ResultOptions = () => {
     </FlexBox>
   )
 
+  const group = (
+    <ToggleWithLabelToolTip
+      active={groupActive}
+      onChange={() => setGroupActive(current => !current)}
+      label="Group"
+      tooltipContents={TOOLTIP_CONTENT.GROUP}
+    />
+  )
+
   return (
     <Accordion className="result-options" expanded={true}>
       <Accordion.AccordionHeader className="result-options--header">
         Result Options
       </Accordion.AccordionHeader>
       {fieldsAsColumns}
+      {group}
     </Accordion>
   )
 }

--- a/src/dataExplorer/components/ResultOptions.tsx
+++ b/src/dataExplorer/components/ResultOptions.tsx
@@ -81,7 +81,6 @@ const ResultOptions: FC = () => {
       {fieldsAsColumns}
       {group}
       {aggregate}
-      <hr className="divider" />
     </Accordion>
   )
 }

--- a/src/dataExplorer/components/ResultOptions.tsx
+++ b/src/dataExplorer/components/ResultOptions.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+
+const ResultOptions = () => {
+  console.log('test result options')
+  return <div>Result Options</div>
+}
+
+export {ResultOptions}

--- a/src/dataExplorer/components/ResultOptions.tsx
+++ b/src/dataExplorer/components/ResultOptions.tsx
@@ -3,29 +3,21 @@ import React, {FC, useState} from 'react'
 // Components
 import {Accordion} from '@influxdata/clockface'
 import {ToggleWithLabelTooltip} from 'src/dataExplorer/components/ToggleWithLabelTooltip'
+import {FieldsAsColumns} from 'src/dataExplorer/components/FieldsAsColumns'
 
 // Style
 import './Sidebar.scss'
 
 const TOOLTIP_CONTENT = {
-  FIELDS_AS_COLUMNS: `test`,
   GROUP: `test`,
   AGGREGATE: `test`,
 }
 
 const ResultOptions: FC = () => {
-  const [fieldsAsColumnsActive, setFieldsAsColumnsActive] = useState(false)
   const [groupActive, setGroupActive] = useState(false)
   const [aggregateActive, setAggregateActive] = useState(false)
 
-  const fieldsAsColumns = (
-    <ToggleWithLabelTooltip
-      label="Fields as Columns"
-      active={fieldsAsColumnsActive}
-      onChange={() => setFieldsAsColumnsActive(current => !current)}
-      tooltipContents={TOOLTIP_CONTENT.FIELDS_AS_COLUMNS}
-    />
-  )
+  const fieldsAsColumns = <FieldsAsColumns />
 
   const group = (
     <ToggleWithLabelTooltip

--- a/src/dataExplorer/components/ResultOptions.tsx
+++ b/src/dataExplorer/components/ResultOptions.tsx
@@ -47,18 +47,12 @@ const ResultOptions: FC = () => {
   const [aggregateActive, setAggregateActive] = useState(false)
 
   const fieldsAsColumns = (
-    <FlexBox>
-      <SlideToggle
-        active={fieldsAsColumnsActive}
-        onChange={() => setFieldsAsColumnsActive(current => !current)}
-      />
-      <InputLabel>
-        <SelectorTitle
-          label="Fields as Columns"
-          tooltipContents={TOOLTIP_CONTENT.FIELDS_AS_COLUMNS}
-        />
-      </InputLabel>
-    </FlexBox>
+    <ToggleWithLabelToolTip
+      label="Fields as Columns"
+      active={fieldsAsColumnsActive}
+      onChange={() => setFieldsAsColumnsActive(current => !current)}
+      tooltipContents={TOOLTIP_CONTENT.FIELDS_AS_COLUMNS}
+    />
   )
 
   const group = (

--- a/src/dataExplorer/components/ResultOptions.tsx
+++ b/src/dataExplorer/components/ResultOptions.tsx
@@ -15,19 +15,20 @@ import './Sidebar.scss'
 const TOOLTIP_CONTENT = {
   FIELDS_AS_COLUMNS: `test`,
   GROUP: `test`,
+  AGGREGATE: `test`,
 }
 
 interface ToggleWithLabelToolTipProps {
+  label: string
   active: boolean
   onChange: () => void
-  label: string
   tooltipContents?: string | JSX.Element
 }
 
 const ToggleWithLabelToolTip: FC<ToggleWithLabelToolTipProps> = ({
+  label,
   active,
   onChange,
-  label,
   tooltipContents = '',
 }) => {
   return (
@@ -43,6 +44,7 @@ const ToggleWithLabelToolTip: FC<ToggleWithLabelToolTipProps> = ({
 const ResultOptions: FC = () => {
   const [fieldsAsColumnsActive, setFieldsAsColumnsActive] = useState(false)
   const [groupActive, setGroupActive] = useState(false)
+  const [aggregateActive, setAggregateActive] = useState(false)
 
   const fieldsAsColumns = (
     <FlexBox>
@@ -61,10 +63,19 @@ const ResultOptions: FC = () => {
 
   const group = (
     <ToggleWithLabelToolTip
+      label="Group"
       active={groupActive}
       onChange={() => setGroupActive(current => !current)}
-      label="Group"
       tooltipContents={TOOLTIP_CONTENT.GROUP}
+    />
+  )
+
+  const aggregate = (
+    <ToggleWithLabelToolTip
+      label="Aggregate"
+      active={aggregateActive}
+      onChange={() => setAggregateActive(current => !current)}
+      tooltipContents={TOOLTIP_CONTENT.AGGREGATE}
     />
   )
 
@@ -75,6 +86,7 @@ const ResultOptions: FC = () => {
       </Accordion.AccordionHeader>
       {fieldsAsColumns}
       {group}
+      {aggregate}
     </Accordion>
   )
 }

--- a/src/dataExplorer/components/ResultOptions.tsx
+++ b/src/dataExplorer/components/ResultOptions.tsx
@@ -1,30 +1,15 @@
-import React, {FC, useState} from 'react'
+import React, {FC} from 'react'
 
 // Components
 import {Accordion} from '@influxdata/clockface'
-import {ToggleWithLabelTooltip} from 'src/dataExplorer/components/ToggleWithLabelTooltip'
 import {FieldsAsColumns} from 'src/dataExplorer/components/FieldsAsColumns'
 import {GroupBy} from 'src/dataExplorer/components/GroupBy'
+import {Aggregate} from 'src/dataExplorer/components/Aggregate'
 
 // Style
 import './Sidebar.scss'
 
-const TOOLTIP_CONTENT = {
-  AGGREGATE: `test`,
-}
-
 const ResultOptions: FC = () => {
-  const [aggregateActive, setAggregateActive] = useState(false)
-
-  const aggregate = (
-    <ToggleWithLabelTooltip
-      label="Aggregate"
-      active={aggregateActive}
-      onChange={() => setAggregateActive(current => !current)}
-      tooltipContents={TOOLTIP_CONTENT.AGGREGATE}
-    />
-  )
-
   return (
     <Accordion className="result-options" expanded={true}>
       <Accordion.AccordionHeader className="result-options--header">
@@ -32,7 +17,7 @@ const ResultOptions: FC = () => {
       </Accordion.AccordionHeader>
       <FieldsAsColumns />
       <GroupBy />
-      {aggregate}
+      <Aggregate />
     </Accordion>
   )
 }

--- a/src/dataExplorer/components/ResultOptions.tsx
+++ b/src/dataExplorer/components/ResultOptions.tsx
@@ -32,9 +32,9 @@ const ToggleWithLabelToolTip: FC<ToggleWithLabelToolTipProps> = ({
   tooltipContents = '',
 }) => {
   return (
-    <FlexBox>
+    <FlexBox className="toggle-with-label-tooltip">
       <SlideToggle active={active} onChange={onChange} />
-      <InputLabel>
+      <InputLabel className="toggle-with-label-tooltip--label">
         <SelectorTitle label={label} tooltipContents={tooltipContents} />
       </InputLabel>
     </FlexBox>
@@ -81,6 +81,7 @@ const ResultOptions: FC = () => {
       {fieldsAsColumns}
       {group}
       {aggregate}
+      <hr className="divider" />
     </Accordion>
   )
 }

--- a/src/dataExplorer/components/ResultOptions.tsx
+++ b/src/dataExplorer/components/ResultOptions.tsx
@@ -1,8 +1,21 @@
 import React from 'react'
 
+// Components
+import {Accordion} from '@influxdata/clockface'
+
+// Style
+import './Sidebar.scss'
+
 const ResultOptions = () => {
   console.log('test result options')
-  return <div>Result Options</div>
+  return (
+    <Accordion className="result-options" expanded={true}>
+      <Accordion.AccordionHeader className="result-options--header">
+        Result Options
+      </Accordion.AccordionHeader>
+      items
+    </Accordion>
+  )
 }
 
 export {ResultOptions}

--- a/src/dataExplorer/components/ResultOptions.tsx
+++ b/src/dataExplorer/components/ResultOptions.tsx
@@ -1,19 +1,45 @@
-import React from 'react'
+import React, {useState} from 'react'
 
 // Components
-import {Accordion} from '@influxdata/clockface'
+import {
+  Accordion,
+  FlexBox,
+  InputLabel,
+  SlideToggle,
+} from '@influxdata/clockface'
+import SelectorTitle from 'src/dataExplorer/components/SelectorTitle'
 
 // Style
 import './Sidebar.scss'
 
+const TOOLTIP_CONTENT = {
+  FIELDS_AS_COLUMNS: `Tooltip content for Fields as Columns`,
+}
+
 const ResultOptions = () => {
-  console.log('test result options')
+  const [fieldsAsColumnsOn, setFieldsAsColumnsOn] = useState(false)
+
+  const fieldsAsColumns = (
+    <FlexBox>
+      <SlideToggle
+        active={fieldsAsColumnsOn}
+        onChange={() => setFieldsAsColumnsOn(current => !current)}
+      />
+      <InputLabel>
+        <SelectorTitle
+          label="Fields as Columns"
+          tooltipContents={TOOLTIP_CONTENT.FIELDS_AS_COLUMNS}
+        />
+      </InputLabel>
+    </FlexBox>
+  )
+
   return (
     <Accordion className="result-options" expanded={true}>
       <Accordion.AccordionHeader className="result-options--header">
         Result Options
       </Accordion.AccordionHeader>
-      items
+      {fieldsAsColumns}
     </Accordion>
   )
 }

--- a/src/dataExplorer/components/ResultOptions.tsx
+++ b/src/dataExplorer/components/ResultOptions.tsx
@@ -4,29 +4,17 @@ import React, {FC, useState} from 'react'
 import {Accordion} from '@influxdata/clockface'
 import {ToggleWithLabelTooltip} from 'src/dataExplorer/components/ToggleWithLabelTooltip'
 import {FieldsAsColumns} from 'src/dataExplorer/components/FieldsAsColumns'
+import {GroupBy} from 'src/dataExplorer/components/GroupBy'
 
 // Style
 import './Sidebar.scss'
 
 const TOOLTIP_CONTENT = {
-  GROUP: `test`,
   AGGREGATE: `test`,
 }
 
 const ResultOptions: FC = () => {
-  const [groupActive, setGroupActive] = useState(false)
   const [aggregateActive, setAggregateActive] = useState(false)
-
-  const fieldsAsColumns = <FieldsAsColumns />
-
-  const group = (
-    <ToggleWithLabelTooltip
-      label="Group"
-      active={groupActive}
-      onChange={() => setGroupActive(current => !current)}
-      tooltipContents={TOOLTIP_CONTENT.GROUP}
-    />
-  )
 
   const aggregate = (
     <ToggleWithLabelTooltip
@@ -42,8 +30,8 @@ const ResultOptions: FC = () => {
       <Accordion.AccordionHeader className="result-options--header">
         Result Options
       </Accordion.AccordionHeader>
-      {fieldsAsColumns}
-      {group}
+      <FieldsAsColumns />
+      <GroupBy />
       {aggregate}
     </Accordion>
   )

--- a/src/dataExplorer/components/ResultOptions.tsx
+++ b/src/dataExplorer/components/ResultOptions.tsx
@@ -1,13 +1,8 @@
 import React, {FC, useState} from 'react'
 
 // Components
-import {
-  Accordion,
-  FlexBox,
-  InputLabel,
-  SlideToggle,
-} from '@influxdata/clockface'
-import SelectorTitle from 'src/dataExplorer/components/SelectorTitle'
+import {Accordion} from '@influxdata/clockface'
+import {ToggleWithLabelTooltip} from 'src/dataExplorer/components/ToggleWithLabelTooltip'
 
 // Style
 import './Sidebar.scss'
@@ -18,36 +13,13 @@ const TOOLTIP_CONTENT = {
   AGGREGATE: `test`,
 }
 
-interface ToggleWithLabelToolTipProps {
-  label: string
-  active: boolean
-  onChange: () => void
-  tooltipContents?: string | JSX.Element
-}
-
-const ToggleWithLabelToolTip: FC<ToggleWithLabelToolTipProps> = ({
-  label,
-  active,
-  onChange,
-  tooltipContents = '',
-}) => {
-  return (
-    <FlexBox className="toggle-with-label-tooltip">
-      <SlideToggle active={active} onChange={onChange} />
-      <InputLabel className="toggle-with-label-tooltip--label">
-        <SelectorTitle label={label} tooltipContents={tooltipContents} />
-      </InputLabel>
-    </FlexBox>
-  )
-}
-
 const ResultOptions: FC = () => {
   const [fieldsAsColumnsActive, setFieldsAsColumnsActive] = useState(false)
   const [groupActive, setGroupActive] = useState(false)
   const [aggregateActive, setAggregateActive] = useState(false)
 
   const fieldsAsColumns = (
-    <ToggleWithLabelToolTip
+    <ToggleWithLabelTooltip
       label="Fields as Columns"
       active={fieldsAsColumnsActive}
       onChange={() => setFieldsAsColumnsActive(current => !current)}
@@ -56,7 +28,7 @@ const ResultOptions: FC = () => {
   )
 
   const group = (
-    <ToggleWithLabelToolTip
+    <ToggleWithLabelTooltip
       label="Group"
       active={groupActive}
       onChange={() => setGroupActive(current => !current)}
@@ -65,7 +37,7 @@ const ResultOptions: FC = () => {
   )
 
   const aggregate = (
-    <ToggleWithLabelToolTip
+    <ToggleWithLabelTooltip
       label="Aggregate"
       active={aggregateActive}
       onChange={() => setAggregateActive(current => !current)}

--- a/src/dataExplorer/components/Sidebar.scss
+++ b/src/dataExplorer/components/Sidebar.scss
@@ -16,20 +16,6 @@
   left: 0;
   right: 0;
 
-  .result-options {
-    padding-top: $cf-space-2xs;
-
-    .result-options--header {
-      background-color: transparent;
-      min-height: 0;
-      padding: 0;
-    }
-  }
-
-  .result-options .cf-accordion--icon {
-    color: gray;
-  }
-
   .flux-library-original {
     height: calc(
       100% - 30px
@@ -43,6 +29,18 @@
       padding: 0;
     }
   }
+}
+
+.result-options--header,
+.flux-library--header {
+  background-color: transparent;
+  min-height: 0;
+  padding: 0;
+}
+
+.result-options .cf-accordion--icon,
+.flux-library .cf-accordion--icon {
+  color: gray;
 }
 
 .flux-builder-sidebar--buttons {

--- a/src/dataExplorer/components/Sidebar.scss
+++ b/src/dataExplorer/components/Sidebar.scss
@@ -27,14 +27,14 @@
   // make sure DraggableResizer collapses correctly
   // and DapperScrollbars shows up
   position: absolute;
-  overflow-x: hidden;
+  overflow: hidden;
   top: 0;
   bottom: 0;
   left: 0;
   right: 0;
 
   .flux-library-original {
-    height: calc(100% - 30px); // remove the ugly white scroll bar
+    height: 100%; // show flux function list
 
     .flux-toolbar {
       flex-direction: column;
@@ -92,7 +92,7 @@
   }
 
   .cf-accordion--body-container {
-    height: calc(100% - 40px); // remove the ugly white scroll bar
+    height: 100%; // show flux function list
   }
 
   .flux-toolbar {

--- a/src/dataExplorer/components/Sidebar.scss
+++ b/src/dataExplorer/components/Sidebar.scss
@@ -80,7 +80,9 @@
   }
 
   .cf-accordion--body-container {
-    height: calc(100% - 40px); // this is due to a scrollbar issue where the height of the button above it makes the 100% height unreachable: https://github.com/influxdata/ui/issues/2474
+    height: calc(
+      100% - 40px
+    ); // this is due to a scrollbar issue where the height of the button above it makes the 100% height unreachable: https://github.com/influxdata/ui/issues/2474
   }
 
   .flux-toolbar {
@@ -93,7 +95,9 @@
 }
 
 .flux-library-original {
-  height: calc(100% - 30px); // this is due to a scrollbar issue where the height of the button above it makes the 100% height unreachable: https://github.com/influxdata/ui/issues/2474
+  height: calc(
+    100% - 30px
+  ); // this is due to a scrollbar issue where the height of the button above it makes the 100% height unreachable: https://github.com/influxdata/ui/issues/2474
 
   .flux-toolbar {
     flex-direction: column;

--- a/src/dataExplorer/components/Sidebar.scss
+++ b/src/dataExplorer/components/Sidebar.scss
@@ -16,12 +16,18 @@
   left: 0;
   right: 0;
 
-  .flux-toolbar {
-    flex-direction: column;
-  }
+  .container-flux-library {
+    height: calc(
+      100% - 30px
+    ); // this is due to a scrollbar issue where the height of the button above it makes the 100% height unreachable: https://github.com/influxdata/ui/issues/2474
 
-  .flux-toolbar--search {
-    padding: 0;
+    .flux-toolbar {
+      flex-direction: column;
+    }
+
+    .flux-toolbar--search {
+      padding: 0;
+    }
   }
 }
 

--- a/src/dataExplorer/components/Sidebar.scss
+++ b/src/dataExplorer/components/Sidebar.scss
@@ -47,7 +47,7 @@
   margin-bottom: $cf-space-2xs;
 
   .cf-accordion {
-    margin-bottom: $cf-space-2xs;
+    margin-bottom: $cf-space-xs;
   }
 }
 
@@ -58,7 +58,7 @@
   }
 
   .toggle-with-label-tooltip {
-    padding-top: $cf-space-s;
+    padding: $cf-space-2xs 0;
   }
 
   .toggle-with-label-tooltip--label {

--- a/src/dataExplorer/components/Sidebar.scss
+++ b/src/dataExplorer/components/Sidebar.scss
@@ -10,6 +10,13 @@
   }
 }
 
+@mixin accordion-header-uppercase {
+  .cf-accordion--header--content {
+    font-weight: 700;
+    text-transform: uppercase;
+  }
+}
+
 .container-right-side-bar {
   margin-left: $cf-space-xs;
   padding-top: $cf-space-2xs;
@@ -27,9 +34,7 @@
   right: 0;
 
   .flux-library-original {
-    height: calc(
-      100% - 30px
-    ); // remove the ugly white scroll bar
+    height: calc(100% - 30px); // remove the ugly white scroll bar
 
     .flux-toolbar {
       flex-direction: column;
@@ -54,6 +59,7 @@
 .result-options {
   .result-options--header {
     @include transparent-accordion;
+    @include accordion-header-uppercase;
     padding: $cf-space-2xs 0;
   }
 
@@ -72,20 +78,21 @@
 .flux-library--container {
   width: 100%;
 }
+
 .flux-library {
   height: 100%;
 
   .flux-library--header {
     @include transparent-accordion;
+    @include accordion-header-uppercase;
+
     .selector-title {
       padding: $cf-space-2xs 0;
     }
   }
 
   .cf-accordion--body-container {
-    height: calc(
-      100% - 40px
-    ); // remove the ugly white scroll bar
+    height: calc(100% - 40px); // remove the ugly white scroll bar
   }
 
   .flux-toolbar {

--- a/src/dataExplorer/components/Sidebar.scss
+++ b/src/dataExplorer/components/Sidebar.scss
@@ -43,6 +43,12 @@
 
 .result-options--container {
   width: 100%;
+  border-bottom: 2px solid $cf-grey-25;
+  margin-bottom: $cf-space-2xs;
+
+  .cf-accordion {
+    margin-bottom: $cf-space-2xs;
+  }
 }
 
 .result-options {
@@ -60,10 +66,6 @@
     .selector-title {
       padding-bottom: 0;
     }
-  }
-
-  .divider {
-    border-bottom: 2px solid $cf-grey-25;
   }
 }
 

--- a/src/dataExplorer/components/Sidebar.scss
+++ b/src/dataExplorer/components/Sidebar.scss
@@ -1,5 +1,15 @@
 @import '@influxdata/clockface/dist/variables.scss';
 
+@mixin transparent-accordion {
+  background-color: transparent;
+  min-height: 0;
+  padding: 0;
+
+  .cf-accordion--icon {
+    color: grey;
+  }
+}
+
 .container-right-side-bar {
   margin-left: $cf-space-xs;
   padding-top: $cf-space-2xs;
@@ -31,8 +41,15 @@
   }
 }
 
-.result-options--flex-child {
+.result-options--container {
   width: 100%;
+}
+
+.result-options {
+  .result-options--header {
+    @include transparent-accordion;
+    padding: $cf-space-2xs 0;
+  }
 
   .toggle-with-label-tooltip {
     padding-top: $cf-space-s;
@@ -50,16 +67,13 @@
   }
 }
 
-.result-options--header,
-.flux-library--header {
-  background-color: transparent;
-  min-height: 0;
-  padding: 0;
-}
-
-.result-options .cf-accordion--icon,
-.flux-library .cf-accordion--icon {
-  color: gray;
+.flux-library {
+  .flux-library--header {
+    @include transparent-accordion;
+    .selector-title {
+      padding: $cf-space-2xs 0;
+    }
+  }
 }
 
 .flux-builder-sidebar--buttons {

--- a/src/dataExplorer/components/Sidebar.scss
+++ b/src/dataExplorer/components/Sidebar.scss
@@ -31,6 +31,10 @@
   }
 }
 
+.result-options--flex-child {
+  width: 100%;
+}
+
 .result-options--header,
 .flux-library--header {
   background-color: transparent;

--- a/src/dataExplorer/components/Sidebar.scss
+++ b/src/dataExplorer/components/Sidebar.scss
@@ -29,7 +29,7 @@
   .flux-library-original {
     height: calc(
       100% - 30px
-    ); // this is due to a scrollbar issue where the height of the button above it makes the 100% height unreachable: https://github.com/influxdata/ui/issues/2474
+    ); // remove the ugly white scroll bar
 
     .flux-toolbar {
       flex-direction: column;
@@ -69,12 +69,31 @@
   }
 }
 
+.flux-library--container {
+  width: 100%;
+}
 .flux-library {
+  height: 100%;
+
   .flux-library--header {
     @include transparent-accordion;
     .selector-title {
       padding: $cf-space-2xs 0;
     }
+  }
+
+  .cf-accordion--body-container {
+    height: calc(
+      100% - 40px
+    ); // remove the ugly white scroll bar
+  }
+
+  .flux-toolbar {
+    flex-direction: column;
+  }
+
+  .flux-toolbar--search {
+    padding: 0;
   }
 }
 

--- a/src/dataExplorer/components/Sidebar.scss
+++ b/src/dataExplorer/components/Sidebar.scss
@@ -33,6 +33,21 @@
 
 .result-options--flex-child {
   width: 100%;
+
+  .toggle-with-label-tooltip {
+    padding-top: $cf-space-s;
+  }
+
+  .toggle-with-label-tooltip--label {
+    padding-left: $cf-space-2xs;
+    .selector-title {
+      padding-bottom: 0;
+    }
+  }
+
+  .divider {
+    border-bottom: 2px solid $cf-grey-25;
+  }
 }
 
 .result-options--header,

--- a/src/dataExplorer/components/Sidebar.scss
+++ b/src/dataExplorer/components/Sidebar.scss
@@ -32,18 +32,6 @@
   bottom: 0;
   left: 0;
   right: 0;
-
-  .flux-library-original {
-    height: 100%; // show flux function list
-
-    .flux-toolbar {
-      flex-direction: column;
-    }
-
-    .flux-toolbar--search {
-      padding: 0;
-    }
-  }
 }
 
 .result-options--container {
@@ -92,8 +80,20 @@
   }
 
   .cf-accordion--body-container {
-    height: 100%; // show flux function list
+    height: calc(100% - 40px); // this is due to a scrollbar issue where the height of the button above it makes the 100% height unreachable: https://github.com/influxdata/ui/issues/2474
   }
+
+  .flux-toolbar {
+    flex-direction: column;
+  }
+
+  .flux-toolbar--search {
+    padding: 0;
+  }
+}
+
+.flux-library-original {
+  height: calc(100% - 30px); // this is due to a scrollbar issue where the height of the button above it makes the 100% height unreachable: https://github.com/influxdata/ui/issues/2474
 
   .flux-toolbar {
     flex-direction: column;

--- a/src/dataExplorer/components/Sidebar.scss
+++ b/src/dataExplorer/components/Sidebar.scss
@@ -16,7 +16,21 @@
   left: 0;
   right: 0;
 
-  .container-flux-library {
+  .result-options {
+    padding-top: $cf-space-2xs;
+
+    .result-options--header {
+      background-color: transparent;
+      min-height: 0;
+      padding: 0;
+    }
+  }
+
+  .result-options .cf-accordion--icon {
+    color: gray;
+  }
+
+  .flux-library-original {
     height: calc(
       100% - 30px
     ); // this is due to a scrollbar issue where the height of the button above it makes the 100% height unreachable: https://github.com/influxdata/ui/issues/2474

--- a/src/dataExplorer/components/Sidebar.tsx
+++ b/src/dataExplorer/components/Sidebar.tsx
@@ -82,7 +82,7 @@ const Sidebar: FC = () => {
   }
 
   const resultOptions = isFlagEnabled('resultOptions') ? (
-    <FlexBox.Child>
+    <FlexBox.Child className="result-options--flex-child">
       <ResultOptions />
     </FlexBox.Child>
   ) : null

--- a/src/dataExplorer/components/Sidebar.tsx
+++ b/src/dataExplorer/components/Sidebar.tsx
@@ -82,7 +82,7 @@ const Sidebar: FC = () => {
   }
 
   const resultOptions = isFlagEnabled('resultOptions') ? (
-    <FlexBox.Child className="result-options--flex-child">
+    <FlexBox.Child className="result-options--container">
       <ResultOptions />
     </FlexBox.Child>
   ) : null

--- a/src/dataExplorer/components/Sidebar.tsx
+++ b/src/dataExplorer/components/Sidebar.tsx
@@ -75,6 +75,12 @@ const Sidebar: FC = () => {
     )
   }
 
+  const resultOptions = isFlagEnabled('resultOptions') ? (
+    <FlexBox.Child>
+      <ResultOptions />
+    </FlexBox.Child>
+  ) : null
+
   let browser = <Functions onSelect={inject} />
 
   if (CLOUD) {
@@ -84,7 +90,7 @@ const Sidebar: FC = () => {
   const fluxLibrary = isFlagEnabled('resultOptions') ? (
     <FlexBox.Child>
       <Accordion className="flux-library" expanded={true}>
-        <Accordion.AccordionHeader>
+        <Accordion.AccordionHeader className="flux-library--header">
           <SelectorTitle label="Flux library" tooltipContents={TOOLTIP} />
         </Accordion.AccordionHeader>
         {browser}
@@ -98,12 +104,6 @@ const Sidebar: FC = () => {
       </div>
     </FlexBox.Child>
   )
-
-  const resultOptions = isFlagEnabled('resultOptions') ? (
-    <FlexBox.Child>
-      <ResultOptions />
-    </FlexBox.Child>
-  ) : null
 
   return (
     <FlexBox

--- a/src/dataExplorer/components/Sidebar.tsx
+++ b/src/dataExplorer/components/Sidebar.tsx
@@ -91,7 +91,7 @@ const Sidebar: FC = () => {
   ) : null
 
   const fluxLibrary = isFlagEnabled('resultOptions') ? (
-    <FlexBox.Child>
+    <FlexBox.Child className="flux-library--container">
       <Accordion className="flux-library" expanded={true}>
         <Accordion.AccordionHeader className="flux-library--header">
           <SelectorTitle label="Flux library" tooltipContents={TOOLTIP} />
@@ -100,7 +100,7 @@ const Sidebar: FC = () => {
       </Accordion>
     </FlexBox.Child>
   ) : (
-    <FlexBox.Child>
+    <FlexBox.Child className="flux-library--container">
       <div className="flux-library-original">
         <SelectorTitle label="Flux library" tooltipContents={TOOLTIP} />
         {browser}

--- a/src/dataExplorer/components/Sidebar.tsx
+++ b/src/dataExplorer/components/Sidebar.tsx
@@ -6,6 +6,7 @@ import Functions from 'src/shared/components/GroupedFunctionsList'
 import DynamicFunctions from 'src/shared/components/DynamicFunctionsList'
 import {ResultOptions} from 'src/dataExplorer/components/ResultOptions'
 import {
+  Accordion,
   DapperScrollbars,
   FlexBox,
   FlexDirection,
@@ -45,12 +46,6 @@ const Sidebar: FC = () => {
     [injectFunction]
   )
 
-  let browser = <Functions onSelect={inject} />
-
-  if (CLOUD) {
-    browser = <DynamicFunctions onSelect={inject} />
-  }
-
   if (!visible && !menu) {
     return null
   }
@@ -80,9 +75,24 @@ const Sidebar: FC = () => {
     )
   }
 
-  const fluxLibrary = (
+  let browser = <Functions onSelect={inject} />
+
+  if (CLOUD) {
+    browser = <DynamicFunctions onSelect={inject} />
+  }
+
+  const fluxLibrary = isFlagEnabled('resultOptions') ? (
     <FlexBox.Child>
-      <div className="container-flux-library">
+      <Accordion className="flux-library" expanded={true}>
+        <Accordion.AccordionHeader>
+          <SelectorTitle label="Flux library" tooltipContents={TOOLTIP} />
+        </Accordion.AccordionHeader>
+        {browser}
+      </Accordion>
+    </FlexBox.Child>
+  ) : (
+    <FlexBox.Child>
+      <div className="flux-library-original">
         <SelectorTitle label="Flux library" tooltipContents={TOOLTIP} />
         {browser}
       </div>

--- a/src/dataExplorer/components/Sidebar.tsx
+++ b/src/dataExplorer/components/Sidebar.tsx
@@ -46,6 +46,12 @@ const Sidebar: FC = () => {
     [injectFunction]
   )
 
+  let browser = <Functions onSelect={inject} />
+
+  if (CLOUD) {
+    browser = <DynamicFunctions onSelect={inject} />
+  }
+
   if (!visible && !menu) {
     return null
   }
@@ -80,12 +86,6 @@ const Sidebar: FC = () => {
       <ResultOptions />
     </FlexBox.Child>
   ) : null
-
-  let browser = <Functions onSelect={inject} />
-
-  if (CLOUD) {
-    browser = <DynamicFunctions onSelect={inject} />
-  }
 
   const fluxLibrary = isFlagEnabled('resultOptions') ? (
     <FlexBox.Child>

--- a/src/dataExplorer/components/Sidebar.tsx
+++ b/src/dataExplorer/components/Sidebar.tsx
@@ -82,7 +82,10 @@ const Sidebar: FC = () => {
   }
 
   const resultOptions = isFlagEnabled('resultOptions') ? (
-    <FlexBox.Child className="result-options--container">
+    <FlexBox.Child
+      className="result-options--container"
+      style={{flex: '0 0 0px'}}
+    >
       <ResultOptions />
     </FlexBox.Child>
   ) : null

--- a/src/dataExplorer/components/Sidebar.tsx
+++ b/src/dataExplorer/components/Sidebar.tsx
@@ -1,10 +1,16 @@
 import React, {FC, useContext, useCallback} from 'react'
-import {DapperScrollbars} from '@influxdata/clockface'
 
 // Components
 import SelectorTitle from 'src/dataExplorer/components/SelectorTitle'
 import Functions from 'src/shared/components/GroupedFunctionsList'
 import DynamicFunctions from 'src/shared/components/DynamicFunctionsList'
+import {ResultOptions} from 'src/dataExplorer/components/ResultOptions'
+import {
+  DapperScrollbars,
+  FlexBox,
+  FlexDirection,
+  JustifyContent,
+} from '@influxdata/clockface'
 
 // Contexts
 import {SidebarContext} from 'src/dataExplorer/context/sidebar'
@@ -16,6 +22,7 @@ import {FluxFunction, FluxToolbarFunction} from 'src/types'
 // Utils
 import {event} from 'src/cloud/utils/reporting'
 import {CLOUD} from 'src/shared/constants'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 import './Sidebar.scss'
 
@@ -74,13 +81,30 @@ const Sidebar: FC = () => {
   }
 
   const fluxLibrary = (
-    <div className="container-flux-library">
-      <SelectorTitle label="Flux library" tooltipContents={TOOLTIP} />
-      {browser}
-    </div>
+    <FlexBox.Child>
+      <div className="container-flux-library">
+        <SelectorTitle label="Flux library" tooltipContents={TOOLTIP} />
+        {browser}
+      </div>
+    </FlexBox.Child>
   )
 
-  return <div className="container-right-side-bar">{fluxLibrary}</div>
+  const resultOptions = isFlagEnabled('resultOptions') ? (
+    <FlexBox.Child>
+      <ResultOptions />
+    </FlexBox.Child>
+  ) : null
+
+  return (
+    <FlexBox
+      direction={FlexDirection.Column}
+      justifyContent={JustifyContent.FlexStart}
+      className="container-right-side-bar"
+    >
+      {resultOptions}
+      {fluxLibrary}
+    </FlexBox>
+  )
 }
 
 export default Sidebar

--- a/src/dataExplorer/components/Sidebar.tsx
+++ b/src/dataExplorer/components/Sidebar.tsx
@@ -73,12 +73,14 @@ const Sidebar: FC = () => {
     )
   }
 
-  return (
-    <div className="container-right-side-bar">
+  const fluxLibrary = (
+    <div className="container-flux-library">
       <SelectorTitle label="Flux library" tooltipContents={TOOLTIP} />
       {browser}
     </div>
   )
+
+  return <div className="container-right-side-bar">{fluxLibrary}</div>
 }
 
 export default Sidebar

--- a/src/dataExplorer/components/ToggleWithLabelTooltip.tsx
+++ b/src/dataExplorer/components/ToggleWithLabelTooltip.tsx
@@ -1,0 +1,33 @@
+import React, {FC} from 'react'
+
+// Components
+import {FlexBox, InputLabel, SlideToggle} from '@influxdata/clockface'
+import SelectorTitle from 'src/dataExplorer/components/SelectorTitle'
+
+// Styles
+import './Sidebar.scss'
+
+interface ToggleWithLabelTooltipProps {
+  label: string
+  active: boolean
+  onChange: () => void
+  tooltipContents?: string | JSX.Element
+}
+
+const ToggleWithLabelTooltip: FC<ToggleWithLabelTooltipProps> = ({
+  label,
+  active,
+  onChange,
+  tooltipContents = '',
+}) => {
+  return (
+    <FlexBox className="toggle-with-label-tooltip">
+      <SlideToggle active={active} onChange={onChange} />
+      <InputLabel className="toggle-with-label-tooltip--label">
+        <SelectorTitle label={label} tooltipContents={tooltipContents} />
+      </InputLabel>
+    </FlexBox>
+  )
+}
+
+export {ToggleWithLabelTooltip}


### PR DESCRIPTION
Closes #5976 

This PR adds basic structure of the Result Options in new Script Editor so that the future work of fields as columns, group, and aggregate can be done independently. 

This work is behind the feature flag `resultOptions`

## After

https://user-images.githubusercontent.com/14298407/194126338-a9ed9a52-2349-4291-9c45-3c1af64503c8.mov


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
~~- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~~
- [x] Feature flagged, if applicable
