### PR TITLE
fix: dont show header on 404 page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,6 +50,8 @@ import {UserAccountProvider} from 'src/accounts/context/userAccount'
 const App: FC = () => {
   const {theme, presentationMode} = useContext(AppSettingContext)
   const currentPage = useSelector((state: AppState) => state.currentPage)
+  const shouldShowCloudHeader =
+    CLOUD && isFlagEnabled('multiOrg') && currentPage !== 'not found'
 
   const appWrapperClass = classnames('', {
     'dashboard-light-mode': currentPage === 'dashboard' && theme === 'light',
@@ -123,7 +125,7 @@ const App: FC = () => {
       <TreeSidebar />
       <Suspense fallback={<PageSpinner />}>
         <Page>
-          {CLOUD && isFlagEnabled('multiOrg') && <GlobalHeader />}
+          {shouldShowCloudHeader && <GlobalHeader />}
           <Switch>
             <Route path="/orgs/new" component={CreateOrgOverlay} />
             <Route path="/orgs/:orgID" component={SetOrg} />

--- a/src/shared/components/NotFound.tsx
+++ b/src/shared/components/NotFound.tsx
@@ -13,10 +13,13 @@ import {
   Panel,
 } from '@influxdata/clockface'
 import React, {useState, FC, useCallback, useEffect, useRef} from 'react'
-import {useSelector} from 'react-redux'
+import {useDispatch, useSelector} from 'react-redux'
 import {useHistory, useLocation} from 'react-router-dom'
 import {getOrg} from 'src/organizations/selectors'
 import {getOrg as fetchOrg} from 'src/organizations/apis'
+
+// Actions
+import {setCurrentPage} from 'src/shared/reducers/currentPage'
 
 // Utils
 import {buildDeepLinkingMap} from 'src/utils/deepLinks'
@@ -135,6 +138,8 @@ const NotFound: FC = () => {
   const location = useLocation()
   const history = useHistory()
   const reduxOrg = useSelector(getOrg)
+  const dispatch = useDispatch()
+
   const org = useRef<Organization>(reduxOrg)
 
   const handleDeepLink = useCallback(async () => {
@@ -168,6 +173,13 @@ const NotFound: FC = () => {
       handleDeepLink()
     }
   }, [handleDeepLink])
+
+  useEffect(() => {
+    dispatch(setCurrentPage('not found'))
+    return () => {
+      dispatch(setCurrentPage('not set'))
+    }
+  }, [dispatch])
 
   if (isFetchingOrg) {
     // don't render anything if this component is actively fetching org id

--- a/src/shared/reducers/currentPage.ts
+++ b/src/shared/reducers/currentPage.ts
@@ -1,4 +1,4 @@
-export type CurrentPage = 'dashboard' | 'not set'
+export type CurrentPage = 'dashboard' | 'not found' | 'not set'
 
 export type Action = ReturnType<typeof setCurrentPage>
 


### PR DESCRIPTION
Closes #5750 

In cloud, the multi-org global header displayed on 404 pages, because it was rendered by the parent of the component containing our React Router routes (SetOrg).

This PR adds another condition for rendering the header: it won't display if the current page is the `not found` page. 

Conveniently, we already have a redux state for this (which is used in dashboards). So detecting the 'not found' page simply requires updating (and cleaning up) that state when the user hits the `Not Found` component.

Before
--

https://user-images.githubusercontent.com/91283923/194159129-70806657-b8d7-410f-8601-446805c046d2.mov



After
--

https://user-images.githubusercontent.com/91283923/194159141-8626a047-8675-4ac2-870e-2758438ba804.mov



### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - NO
