### PR TITLE
feat(sub): can specify custom client id

### DIFF
--- a/package.json
+++ b/package.json
@@ -222,6 +222,7 @@
     "s2-geometry": "^1.2.10",
     "ts-jest": "27.0.7",
     "use-local-storage-state": "^9.0.2",
+    "uuid": "^9.0.0",
     "vscode-languageserver-protocol": "^3.16.0",
     "worker-plugin": "^5.0.1",
     "y-websocket": "^1.4.4",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "cy": "CYPRESS_dexUrl=https://$INGRESS_HOST:$PORT_HTTPS CYPRESS_baseUrl=http://localhost:9999 cypress open",
     "cy:dev": "source ../monitor-ci/.env && CYPRESS_dexUrl=CLOUD CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{cloud,shared}/**/*.*'",
     "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_dexUrl=OSS CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{oss,shared}/**/*.*'",
-    "generate": "export SHA=b320a258a7a908662c3f36f73a9e5673d60700d5 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
+    "generate": "export SHA=97ca3ce15361c5f5b5654fd32a20df4a31c45cd7 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-local-cloud": "export REMOTE=../openapi/ && yarn generate-meta-cloud",
     "generate-meta": "if [ -z \"${CLOUD_URL}\" ]; then yarn generate-meta-oss; else yarn generate-meta-cloud; fi",

--- a/src/types/subscriptions.ts
+++ b/src/types/subscriptions.ts
@@ -44,6 +44,7 @@ export interface Subscription {
   brokerCACert?: string
   authType: BrokerAuthTypes
   brokerCertCreationDate?: string
+  clientID?: string
 }
 
 export interface SubscriptionStatus {

--- a/src/writeData/subscriptions/components/BrokerDetails.scss
+++ b/src/writeData/subscriptions/components/BrokerDetails.scss
@@ -71,6 +71,7 @@
   &__example-text {
     font-style: italic;
     color: $cf-grey-55;
+    margin-bottom: $cf-space-m;
   }
   &__creds {
     .cf-form--element {

--- a/src/writeData/subscriptions/components/BrokerForm.scss
+++ b/src/writeData/subscriptions/components/BrokerForm.scss
@@ -1,4 +1,8 @@
 @import '@influxdata/clockface/dist/variables.scss';
+
+.no-margin-bottom {
+  margin-bottom: $cf-space-s !important;
+}
 .create-broker-form {
   float: right;
   width: 75%;
@@ -72,6 +76,7 @@
   &__example-text {
     font-style: italic;
     color: $cf-grey-55;
+    margin-bottom: $cf-space-m;
   }
   &__creds {
     .cf-form--element {

--- a/src/writeData/subscriptions/components/BrokerFormContent.tsx
+++ b/src/writeData/subscriptions/components/BrokerFormContent.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FC, useEffect, useState} from 'react'
+import React, {FC, useEffect, useRef, useState} from 'react'
 
 // Components
 import {
@@ -19,6 +19,9 @@ import {
   AlignItems,
   FlexDirection,
   ComponentStatus,
+  Toggle,
+  InputToggleType,
+  InputLabel,
 } from '@influxdata/clockface'
 import UserInput from 'src/writeData/subscriptions/components/UserInput'
 import CertificateInput from 'src/writeData/subscriptions/components/CertificateInput'
@@ -57,6 +60,10 @@ const BrokerFormContent: FC<Props> = ({
   const mqttProtocol = 'MQTT'
   const protocolList = [mqttProtocol]
   const [protocol, setProtocol] = useState(mqttProtocol)
+  const [useCustomClientID, setUseCustomClientID] = useState(
+    !!formContent.clientID || false
+  )
+  const randomClientID = useRef(crypto.randomUUID())
 
   useEffect(() => {
     updateForm({...formContent, protocol: protocol.toLowerCase()})
@@ -292,6 +299,69 @@ const BrokerFormContent: FC<Props> = ({
                   : ''
               }`}
             </Heading>
+          )}
+          {isFlagEnabled('subscriptionsClientId') && (
+            <>
+              <Form.ValidationElement
+                label="Client ID"
+                value={formContent.brokerHost}
+                required={useCustomClientID}
+                validationFunc={() =>
+                  useCustomClientID &&
+                  handleValidation('Client ID', formContent.clientID)
+                }
+                helpText="We will generate a Client ID for you, but some providers require you use their Client ID. If your provider requires a specific Client ID, the connection will fail without it. Check your provider’s documentation to verify whether you need to use their Client ID."
+                className="no-margin-bottom"
+              >
+                {status => (
+                  <Input
+                    type={InputType.Text}
+                    placeholder={
+                      useCustomClientID
+                        ? 'Enter a client id'
+                        : randomClientID.current
+                    }
+                    name="clientid"
+                    autoFocus={false}
+                    value={formContent.clientID}
+                    onChange={e => {
+                      updateForm({
+                        ...formContent,
+                        clientID: e.target.value,
+                      })
+                    }}
+                    onBlur={() =>
+                      event(
+                        'completed form field',
+                        {formField: 'clientid', step: 'broker'},
+                        {feature: 'subscriptions'}
+                      )
+                    }
+                    status={
+                      edit && useCustomClientID
+                        ? status
+                        : ComponentStatus.Disabled
+                    }
+                    testID={`${className}-broker-form--clientid`}
+                    maxLength={255}
+                  />
+                )}
+              </Form.ValidationElement>
+              <Toggle
+                type={InputToggleType.Checkbox}
+                checked={useCustomClientID}
+                id="clientid-toggle"
+                size={ComponentSize.Small}
+                titleText="Use Custom Client ID"
+                onChange={() => {
+                  setUseCustomClientID(!useCustomClientID)
+                  updateForm({...formContent, clientID: ''})
+                }}
+                disabled={!edit}
+              >
+                <InputLabel>Use Custom Client ID</InputLabel>
+              </Toggle>
+            </>
           )}
         </Grid.Column>
         <Grid.Column widthXS={Columns.Twelve}>

--- a/src/writeData/subscriptions/components/BrokerFormContent.tsx
+++ b/src/writeData/subscriptions/components/BrokerFormContent.tsx
@@ -1,5 +1,6 @@
 // Libraries
 import React, {FC, useEffect, useRef, useState} from 'react'
+import {v4 as uuidv4} from 'uuid'
 
 // Components
 import {
@@ -63,7 +64,7 @@ const BrokerFormContent: FC<Props> = ({
   const [useCustomClientID, setUseCustomClientID] = useState(
     !!formContent.clientID || false
   )
-  const randomClientID = useRef(crypto.randomUUID())
+  const randomClientID = useRef(uuidv4())
 
   useEffect(() => {
     updateForm({...formContent, protocol: protocol.toLowerCase()})

--- a/yarn.lock
+++ b/yarn.lock
@@ -12366,6 +12366,11 @@ uuid@^8.3.2:
   resolved "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
+
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"


### PR DESCRIPTION
Closes https://github.com/influxdata/data-acquisition/issues/464

Users can now specify a custom client ID. Behind feature flag `subscriptionsClientId` (to be created).

https://user-images.githubusercontent.com/6411855/194186021-d32bf918-f1cc-4572-9ca7-fb97b47c7021.mov



### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
