### PR TITLE
chore: add webkit prefix to fix user dropdown blur in safari

### DIFF
--- a/src/identity/components/GlobalHeader/UserPopoverStyles.scss
+++ b/src/identity/components/GlobalHeader/UserPopoverStyles.scss
@@ -25,6 +25,7 @@
   background: rgba(241, 241, 243, 0.1);
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
   backdrop-filter: blur(42px);
+  -webkit-backdrop-filter: blur(42px);
   border-radius: 2px;
   transition: visibility 0.1s ease-in-out;
 


### PR DESCRIPTION
Closes #5873 

In Safari, the blurred background of the user profile dropdown was not working. 

In Chrome and Firefox, it looks like this.
![Screen Shot 2022-10-06 at 10 18 23 AM](https://user-images.githubusercontent.com/91283923/194337230-cb4b229a-4a5a-4964-ab67-fdd4f947956f.png)

In Safari, it looks like this:
![Screen Shot 2022-10-06 at 10 17 35 AM](https://user-images.githubusercontent.com/91283923/194337061-608028dc-e228-42d8-b4c2-983ef666ce0c.png)

The cause is that, for Reasons&trade;, `backdrop-filter` is supported in Safari only as `-webkit-backdrop-filter`.
![Screen Shot 2022-10-06 at 10 21 04 AM](https://user-images.githubusercontent.com/91283923/194337915-c31b40d4-f882-4bee-9727-c9c0f3e1d940.png)

After the fix, the dropdown looks like this in Safari:
![Screen Shot 2022-10-06 at 10 22 51 AM](https://user-images.githubusercontent.com/91283923/194338467-4c7339e8-bce9-4a60-93ec-e366e0561a17.png)
![Screen Shot 2022-10-06 at 10 23 01 AM](https://user-images.githubusercontent.com/91283923/194338529-543d7245-3ffc-4e2f-9d72-eb615889aef5.png)


### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - NO
