### PR TITLE
chore: reduce flake on create-org button test

### DIFF
--- a/cypress/e2e/cloud/globalHeaderOrgMenuItems.test.ts
+++ b/cypress/e2e/cloud/globalHeaderOrgMenuItems.test.ts
@@ -19,6 +19,8 @@ describe('FREE: global header menu items test', () => {
           if (res.body.orgs) {
             idpeOrgID = res.body.orgs[0].id
           }
+
+          cy.setFeatureFlags(createOrgsFeatureFlags)
         })
       })
     )
@@ -27,9 +29,11 @@ describe('FREE: global header menu items test', () => {
   beforeEach(() => {
     // Preserve one session throughout.
     Cypress.Cookies.preserveOnce('sid')
-    cy.setFeatureFlags(createOrgsFeatureFlags)
+
     makeQuartzUseIDPEOrgID(idpeOrgID)
-    cy.visit('/')
+    cy.visit('/').then(() => {
+      cy.setFeatureFlags(createOrgsFeatureFlags)
+    })
   })
 
   it('has add more organizations in menu items', () => {
@@ -66,7 +70,9 @@ describe('PAYG: global header menu items test', () => {
 
   beforeEach(() => {
     makeQuartzUseIDPEOrgID(idpeOrgID, 'pay_as_you_go')
-    cy.visit('/')
+    cy.visit('/').then(() => {
+      cy.setFeatureFlags(createOrgsFeatureFlags)
+    })
   })
 
   it('PAYG: can check create organization menu item exists', () => {
@@ -103,7 +109,9 @@ describe('Contract: global header menu items test', () => {
 
   beforeEach(() => {
     makeQuartzUseIDPEOrgID(idpeOrgID, 'contract')
-    cy.visit('/')
+    cy.visit('/').then(() => {
+      cy.setFeatureFlags(createOrgsFeatureFlags)
+    })
   })
 
   it('Contract: can check create organization menu item exists', () => {


### PR DESCRIPTION
Reduces flake on the create-org button test in PR #5923  by ensuring that the feature flag override happens after `cy.visit()`.



### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - No - e2e tests.
