### PR TITLE
perf(FluxEditor): only send to redux when user has finished typing

### DIFF
--- a/src/timeMachine/components/TimeMachineFluxEditor.tsx
+++ b/src/timeMachine/components/TimeMachineFluxEditor.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FC, lazy, Suspense} from 'react'
+import React, {FC, lazy, Suspense, useState} from 'react'
 import {useSelector, useDispatch} from 'react-redux'
 import {
   RemoteDataState,
@@ -29,10 +29,18 @@ const FluxEditor = lazy(() => import('src/shared/components/FluxMonacoEditor'))
 const TMFluxEditor: FC<{variables: Variable[]}> = props => {
   const dispatch = useDispatch()
   const activeQueryText = useSelector(getActiveQuery).text
+  const [monacoInput, setMonacoInput] = useState(activeQueryText)
+  let userIdleTimer
 
   const handleSetActiveQueryText = React.useCallback(
     (text: string) => {
-      dispatch(setActiveQueryText(text))
+      setMonacoInput(text)
+
+      // only send to redux when the user hasn't typed for one second.
+      clearTimeout(userIdleTimer)
+      userIdleTimer = setTimeout(() => {
+        dispatch(setActiveQueryText(text))
+      }, 1000)
     },
     [dispatch]
   )
@@ -73,7 +81,7 @@ const TMFluxEditor: FC<{variables: Variable[]}> = props => {
           }
         >
           <FluxEditor
-            script={activeQueryText}
+            script={monacoInput}
             variables={props.variables}
             onChangeScript={handleActiveQuery}
             onSubmitScript={handleSubmitQueries}


### PR DESCRIPTION
Closes #


Sending to redux was taking 300ms each query, this becomes really expensive for every keystroke.

I made it so that it only sends it to the redux when user has finished typing. 

https://user-images.githubusercontent.com/18511823/194423461-2470bae9-3cf3-4a85-be27-446a3899ba1c.mov



<!-- Describe your proposed changes here. -->
<!-- Including screenshots or visuals is very helpful - a picture is worth a thousand words. -->

### Checklist

Authors and Reviewer(s), please verify the following:

- [ ] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [ ] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
