### PR TITLE
fix(5901): display of query metadata (table and row counts) in QxBuilder and DataExplorer

### DIFF
--- a/cypress/e2e/shared/fluxQueryBuilder.test.ts
+++ b/cypress/e2e/shared/fluxQueryBuilder.test.ts
@@ -546,7 +546,10 @@ describe('Script Builder', () => {
         })
       })
 
-      it('should clear the editor text and schema browser, with a new script', () => {
+      /// This test is flaky.
+      /// We are getting the black screen of death in CI tests.
+      /// After clicking either: (1) New Script button, or (2) NoSave button.
+      it.skip('should clear the editor text and schema browser, with a new script', () => {
         cy.getByTestID('flux-editor', {timeout: 30000})
 
         cy.log('modify schema browser')

--- a/cypress/e2e/shared/fluxQueryBuilder.test.ts
+++ b/cypress/e2e/shared/fluxQueryBuilder.test.ts
@@ -23,7 +23,6 @@ describe('Script Builder', () => {
 
   const selectBucket = (bucketName: string) => {
     cy.getByTestID('bucket-selector--dropdown-button').click()
-    cy.getByTestID('bucket-selector--search-bar').type(bucketName)
     cy.getByTestID(`bucket-selector--dropdown--${bucketName}`).click()
     cy.getByTestID('bucket-selector--dropdown-button').should(
       'contain',
@@ -118,6 +117,7 @@ describe('Script Builder', () => {
         cy.wait(1200).then(() => {
           cy.reload()
           cy.getByTestID('flux-sync--toggle')
+          cy.getByTestID('flux-editor', {timeout: 30000})
         })
       })
 
@@ -140,7 +140,6 @@ describe('Script Builder', () => {
     })
 
     it('will allow querying of different data ranges', () => {
-      cy.getByTestID('flux-editor', {timeout: 30000})
       selectSchema()
       confirmSchemaComposition()
 
@@ -205,9 +204,7 @@ describe('Script Builder', () => {
       describe('will return 1 table', () => {
         beforeEach(() => {
           const writeData: string[] = []
-          for (let i = 0; i < 30; i++) {
-            writeData.push(`ndbc3,air_temp_degc=70_degrees station_id_=${i}`)
-          }
+          writeData.push(`ndbc3,air_temp_degc=70_degrees station_id=${i}`)
           cy.writeData(writeData, 'defbuck4')
           cy.wait(1200)
         })
@@ -216,7 +213,7 @@ describe('Script Builder', () => {
           cy.log('select dataset with 1 table')
           selectBucket('defbuck4')
 
-          runTest(1, 30, false)
+          runTest(1, 1, false)
         })
       })
 
@@ -554,7 +551,6 @@ describe('Script Builder', () => {
 
         cy.log('modify schema browser')
         selectSchema()
-        confirmSchemaComposition()
 
         cy.log('editor text contains the composition')
         cy.getByTestID('flux-editor').contains(
@@ -562,7 +558,9 @@ describe('Script Builder', () => {
         )
 
         cy.log('click new script, and choose to delete current script')
-        cy.getByTestID('flux-query-builder--new-script').click({force: true})
+        cy.getByTestID('flux-query-builder--new-script')
+          .should('be.visible')
+          .click()
         cy.getByTestID('overlay--container')
           .should('be.visible')
           .within(() => {

--- a/cypress/e2e/shared/fluxQueryBuilder.test.ts
+++ b/cypress/e2e/shared/fluxQueryBuilder.test.ts
@@ -442,6 +442,7 @@ describe('Script Builder', () => {
 
         cy.log('modify schema browser')
         selectSchema()
+        confirmSchemaComposition()
 
         cy.log('editor text contains the composition')
         cy.getByTestID('flux-editor').contains(
@@ -453,7 +454,9 @@ describe('Script Builder', () => {
         cy.getByTestID('overlay--container')
           .should('be.visible')
           .within(() => {
-            cy.getByTestID('flux-query-builder--no-save').click()
+            cy.getByTestID('flux-query-builder--no-save')
+              .should('be.visible')
+              .click()
           })
 
         cy.log('editor text is now empty')

--- a/cypress/e2e/shared/fluxQueryBuilder.test.ts
+++ b/cypress/e2e/shared/fluxQueryBuilder.test.ts
@@ -177,10 +177,7 @@ describe('Script Builder', () => {
         cy.log('table metadata displayed to user is correct')
         if (truncated) {
           cy.getByTestID('query-stat')
-            .should(
-              'contain',
-              'Maximum Display Limit Exceeded, result truncated to'
-            )
+            .should('contain', 'truncated')
             .should('not.contain', 'rows')
             .should('not.contain', 'tables')
         } else {
@@ -546,10 +543,7 @@ describe('Script Builder', () => {
         })
       })
 
-      /// This test is flaky.
-      /// We are getting the black screen of death in CI tests.
-      /// After clicking either: (1) New Script button, or (2) NoSave button.
-      it.skip('should clear the editor text and schema browser, with a new script', () => {
+      it('should clear the editor text and schema browser, with a new script', () => {
         cy.getByTestID('flux-editor', {timeout: 30000})
 
         cy.log('modify schema browser')

--- a/src/dataExplorer/components/Results.tsx
+++ b/src/dataExplorer/components/Results.tsx
@@ -25,6 +25,7 @@ import {FluxResult} from 'src/types/flows'
 
 import './Results.scss'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import {bytesFormatter} from 'src/shared/copy/notifications'
 
 // simplified version migrated from src/flows/pipes/Table/view.tsx
 const QueryStat: FC = () => {
@@ -44,11 +45,19 @@ const QueryStat: FC = () => {
   }
 
   return (
-    <div className="query-stat">
-      <span className="query-stat--bold">{`${tableNum} tables`}</span>
-      <span className="query-stat--bold">{`${
-        result?.parsed?.table?.length || 0
-      } rows`}</span>
+    <div className="query-stat" data-testid="query-stat">
+      {result.truncated ? (
+        <span className="query-stat--bold">{` Maximum Display Limit Exceeded, result truncated to ${bytesFormatter(
+          result.bytes
+        )}`}</span>
+      ) : (
+        <>
+          <span className="query-stat--bold">{`${tableNum} tables`}</span>
+          <span className="query-stat--bold">{`${
+            result?.parsed?.table?.length || 0
+          } rows`}</span>
+        </>
+      )}
     </div>
   )
 }

--- a/src/dataExplorer/components/Results.tsx
+++ b/src/dataExplorer/components/Results.tsx
@@ -31,16 +31,15 @@ const QueryStat: FC = () => {
   const {result} = useContext(ResultsContext)
 
   const tableColumn = result?.parsed?.table?.getColumn('table') || []
-  const lastTableValue = tableColumn[tableColumn.length - 1] || -1
+  const lastTableValue = tableColumn[tableColumn.length - 1]
 
   let tableNum = 0
 
   if (typeof lastTableValue === 'string') {
     tableNum = parseInt(lastTableValue) + 1
   } else if (typeof lastTableValue === 'boolean') {
-    tableNum = lastTableValue ? 1 : 0
-  } else {
-    // number
+    console.error('Cannot extract tableId. Check parsed csv output.')
+  } else if (typeof lastTableValue === 'number') {
     tableNum = lastTableValue + 1
   }
 

--- a/src/dataExplorer/components/Results.tsx
+++ b/src/dataExplorer/components/Results.tsx
@@ -46,10 +46,10 @@ const QueryStat: FC = () => {
 
   return (
     <div className="query-stat" data-testid="query-stat">
-      {result.truncated ? (
-        <span className="query-stat--bold">{` Maximum Display Limit Exceeded, result truncated to ${bytesFormatter(
+      {result?.truncated ? (
+        <span className="query-stat--bold">{`Max. display limit exceeded. Result truncated to ${bytesFormatter(
           result.bytes
-        )}`}</span>
+        )}.`}</span>
       ) : (
         <>
           <span className="query-stat--bold">{`${tableNum} tables`}</span>

--- a/src/dataExplorer/components/ResultsPane.tsx
+++ b/src/dataExplorer/components/ResultsPane.tsx
@@ -138,6 +138,8 @@ const ResultsPane: FC = () => {
           source: text,
           parsed: null,
           error: e.message,
+          truncated: false,
+          bytes: 0,
         })
         event('resultReceived', {status: 'error'})
         setStatus(RemoteDataState.Error)

--- a/src/flows/context/results.tsx
+++ b/src/flows/context/results.tsx
@@ -78,6 +78,8 @@ export const ResultsProvider: FC = ({children}) => {
         results[id] = {
           source: '',
           parsed: null,
+          truncated: false,
+          bytes: 0,
           ...result,
         }
         setResults({...results})

--- a/src/flows/pipes/Table/view.tsx
+++ b/src/flows/pipes/Table/view.tsx
@@ -14,6 +14,7 @@ import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
 
 // Utilities
 import {View} from 'src/visualization'
+import {bytesFormatter} from 'src/shared/copy/notifications'
 
 // Types
 import {RemoteDataState, SimpleTableViewProperties} from 'src/types'
@@ -81,10 +82,18 @@ const QueryStat: FC = () => {
   }
 
   return (
-    <div className="query-stat">
-      <span className="query-stat--bold">{`${queryStat.tableNum} tables`}</span>
-      <span className="query-stat--bold">{`${queryStat.rowNum} rows`}</span>
-      <span className="query-stat--normal">{`${queryStat.processTime} ms`}</span>
+    <div className="query-stat" data-testid="query-stat">
+      {results.truncated ? (
+        <span className="query-stat--bold">{` Maximum Display Limit Exceeded, result truncated to ${bytesFormatter(
+          results.bytes
+        )}`}</span>
+      ) : (
+        <>
+          <span className="query-stat--bold">{`${queryStat.tableNum} tables`}</span>
+          <span className="query-stat--bold">{`${queryStat.rowNum} rows`}</span>
+          <span className="query-stat--normal">{`${queryStat.processTime} ms`}</span>
+        </>
+      )}
     </div>
   )
 }

--- a/src/flows/pipes/Table/view.tsx
+++ b/src/flows/pipes/Table/view.tsx
@@ -44,9 +44,8 @@ const QueryStat: FC = () => {
   if (typeof lastTableValue === 'string') {
     tableNum = parseInt(lastTableValue) + 1
   } else if (typeof lastTableValue === 'boolean') {
-    tableNum = lastTableValue ? 1 : 0
-  } else {
-    // number
+    console.error('Cannot extract tableId. Check parsed csv output.')
+  } else if (typeof lastTableValue === 'number') {
     tableNum = lastTableValue + 1
   }
 

--- a/src/flows/pipes/Table/view.tsx
+++ b/src/flows/pipes/Table/view.tsx
@@ -37,18 +37,7 @@ const QueryStat: FC = () => {
   const {loading, results} = useContext(PipeContext)
   const queryStart = useRef(0)
   const [processTime, setProcessTime] = useState(0)
-  let tableNum = 0
-
-  const tableColumn = results.parsed.table?.getColumn('table') || []
-  const lastTableValue = tableColumn[tableColumn.length - 1]
-
-  if (typeof lastTableValue === 'string') {
-    tableNum = parseInt(lastTableValue) + 1
-  } else if (typeof lastTableValue === 'boolean') {
-    console.error('Cannot extract tableId. Check parsed csv output.')
-  } else if (typeof lastTableValue === 'number') {
-    tableNum = lastTableValue + 1
-  }
+  const [tableNum, setTableNum] = useState(0)
 
   useEffect(() => {
     if (loading === RemoteDataState.Loading) {
@@ -71,6 +60,23 @@ const QueryStat: FC = () => {
     setProcessTime(0)
   }, [loading])
 
+  useEffect(() => {
+    if (loading === RemoteDataState.Loading) {
+      return
+    }
+
+    const tableColumn = results.parsed.table?.getColumn('table') || []
+    const lastTableValue = tableColumn[tableColumn.length - 1]
+
+    if (typeof lastTableValue === 'string') {
+      setTableNum(parseInt(lastTableValue) + 1)
+    } else if (typeof lastTableValue === 'boolean') {
+      console.error('Cannot extract tableId. Check parsed csv output.')
+    } else if (typeof lastTableValue === 'number') {
+      setTableNum(lastTableValue + 1)
+    }
+  }, [loading, results?.parsed])
+
   const queryStat = {
     tableNum,
     rowNum: results.parsed.table?.length || 0,
@@ -83,10 +89,10 @@ const QueryStat: FC = () => {
 
   return (
     <div className="query-stat" data-testid="query-stat">
-      {results.truncated ? (
-        <span className="query-stat--bold">{` Maximum Display Limit Exceeded, result truncated to ${bytesFormatter(
+      {results?.truncated ? (
+        <span className="query-stat--bold">{`Max. display limit exceeded. Result truncated to ${bytesFormatter(
           results.bytes
-        )}`}</span>
+        )}.`}</span>
       ) : (
         <>
           <span className="query-stat--bold">{`${queryStat.tableNum} tables`}</span>

--- a/src/shared/copy/notifications/common.ts
+++ b/src/shared/copy/notifications/common.ts
@@ -13,7 +13,7 @@ import {
 } from 'src/shared/constants/index'
 import {IconFont} from '@influxdata/clockface'
 
-const bytesFormatter = binaryPrefixFormatter({
+export const bytesFormatter = binaryPrefixFormatter({
   suffix: 'B',
   significantDigits: 2,
   trimZeros: true,

--- a/src/types/flows.ts
+++ b/src/types/flows.ts
@@ -87,6 +87,8 @@ export interface FluxResult {
   source: string // the query that was used to generate the flux
   parsed: InternalFromFluxResult // the parsed result
   error?: string // any error that might have happend while fetching
+  truncated: boolean // if parsed data is truncated
+  bytes: number
 }
 
 interface DataLookup<T> {


### PR DESCRIPTION
Closes #5901 

## Done:
* bugs:
  * we got `0 tables` when had 1 table.
    * this is because lastTableValue of 0 || -1  => returned -1, then added +1 to make zero tableCnt
  * clarify when data is truncated with a permanent UI message
    * this means only presenting metadata when not truncated 
* cleanup test suite, before adding new tests:
  * make `selectSchema()`, `selectBucket()`, and `resetSession()` into suite utils
     * that way can use in new tests. 
  * skip flaky test and comment reasons for flake (to later debug in another PR).



## Vid:
new QxBuilder is fixed.


https://user-images.githubusercontent.com/10232835/194426765-3a7f41da-3cc9-4a32-987b-cdd6d0d1ed3a.mov



notebooks gives the truncation message too:

<img width="896" alt="Screen Shot 2022-10-06 at 3 05 05 PM" src="https://user-images.githubusercontent.com/10232835/194427161-1742ca9e-6555-4f49-96c9-e6b82b281967.png">




## Checklist:
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] ~Feature flagged, if applicable~ flags already existing.


## NOT DONE:
**OUT OF SCOPE -- in notebooks.**
Note that the table counts, even when not truncated, in notebooks are not matching the new QxBuilder. This is because we still have a hardcoded limit of 100.

https://user-images.githubusercontent.com/10232835/194425979-c508a364-ed47-4217-8de5-d8d7ccad09a4.mov


