### PR TITLE
feat(dashboards): use memoized variables selector

### DIFF
--- a/src/shared/components/cells/Cell.tsx
+++ b/src/shared/components/cells/Cell.tsx
@@ -28,7 +28,7 @@ import {
 } from 'src/types'
 
 // Selectors
-import {getAllVariables} from 'src/variables/selectors'
+import {getAllVariablesMemoized} from 'src/variables/selectors'
 import {getWindowPeriodFromQueryBuilder} from 'src/timeMachine/selectors'
 
 // Constants
@@ -235,7 +235,8 @@ const mstp = (state: AppState, ownProps: OwnProps) => {
     state,
     view?.id
   )
-  const variables = getAllVariables(state)
+  const variables = getAllVariablesMemoized(state)
+
   return {variables, view, windowPeriodFromQueryBuilder}
 }
 

--- a/src/variables/selectors/index.tsx
+++ b/src/variables/selectors/index.tsx
@@ -1,5 +1,6 @@
 // Libraries
 import {get} from 'lodash'
+import {createSelector} from 'reselect'
 
 // Utils
 import {getActiveQuery} from 'src/timeMachine/selectors'
@@ -15,6 +16,7 @@ import {
   WINDOW_PERIOD,
 } from 'src/variables/constants'
 import {currentContext} from 'src/shared/selectors/currentContext'
+import {getCurrentDashboardId} from 'src/dashboards/selectors/'
 
 // Types
 import {
@@ -136,6 +138,34 @@ export const getAllVariables = (
     .filter(v => !!v)
   return vars
 }
+
+const getAllVariableIds = createSelector(
+  state => state,
+  getCurrentDashboardId,
+  (state, currentDashboardId) => {
+    return getUserVariableNames(state, currentDashboardId).concat([
+      TIME_RANGE_START,
+      TIME_RANGE_STOP,
+      WINDOW_PERIOD,
+    ])
+  }
+)
+
+export const getAllVariablesMemoized = createSelector(
+  state => state,
+  getAllVariableIds,
+  (state, allVariableIds) => {
+    const variables = []
+    for (const variableId of allVariableIds) {
+      const variable = getVariable(state, variableId)
+      if (variable) {
+        variables.push(variable)
+      }
+    }
+
+    return variables
+  }
+)
 
 export const getAllVariablesForZoomRequery = (
   state: AppState,


### PR DESCRIPTION
Co-authored-by: Sahas Chitlange chitlangesahas@gmail.com

Helps with #6017

Memoize the `getAllVariables` selector for use in dashboard cells. On a dashboard with 5 cells, this reduces calls to the `getVariables` selector from 39 => 9, for a reduction of 77%. 

| Selector                | Call Count | Table Cell Count |
|-------------------------|------------|------------------|
| getAllVariables | 39         | 5                |
| getAllVariablesMemoized | 9          | 5                |

The results are even more dramatic on a dashboard with 10 cells (2x cells). 160 calls => 15 calls or 91%

| Selector                | Call Count | Table Cell Count |
|-------------------------|------------|------------------|
| getAllVariables         | 160        | 10               |
| getAllVariablesMemoized | 15         | 10               |

### Before (5 cells)
![before](https://user-images.githubusercontent.com/146112/194559497-d9560569-3d08-48eb-8077-bd80cefd1eaa.png)

### After (5 cells)
![after](https://user-images.githubusercontent.com/146112/194559509-35aa03d1-f5d1-42ad-b205-06ac494634c8.png)

### Before (10 cells)
![before](https://user-images.githubusercontent.com/146112/194587661-74b7d054-8666-4b62-a173-9bdc6ec345b4.png)

### After (10 cells)
![after](https://user-images.githubusercontent.com/146112/194587688-526e18a7-4034-4ef7-82e6-cbc7352b3d2e.png)

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- ~[ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~
- ~[ ] Feature flagged, if applicable~
