### PR TITLE
feat(Logout): use quartz logout endpoint + refactoring login redirect code

### DIFF
--- a/src/Logout.tsx
+++ b/src/Logout.tsx
@@ -7,10 +7,15 @@ import {useHistory} from 'react-router-dom'
 import {postSignout} from 'src/client'
 
 // Constants
-import {CLOUD, CLOUD_SIGNOUT_PATHNAME} from 'src/shared/constants'
+import {
+  CLOUD,
+  CLOUD_LOGOUT_PATH,
+  CLOUD_SIGNOUT_PATHNAME,
+} from 'src/shared/constants'
 
 // Components
 import {reset} from 'src/shared/actions/flags'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 const Logout: FC = () => {
   const history = useHistory()
@@ -19,6 +24,17 @@ const Logout: FC = () => {
   useEffect(() => {
     const handleSignOut = async () => {
       if (CLOUD) {
+        if (isFlagEnabled('universalLogin')) {
+          fetch('/api/env/quartz-login-url')
+            .then(async response => {
+              const quartzUrl = await response.text()
+              const redirectUrl = `${quartzUrl}${CLOUD_LOGOUT_PATH}`
+              console.warn('Redirect to cloud url: ', redirectUrl)
+              window.location.replace(`${redirectUrl}`)
+            })
+            .catch(error => console.error(error))
+          return null
+        }
         const url = new URL(
           `${window.location.origin}${CLOUD_SIGNOUT_PATHNAME}`
         ).href

--- a/src/onboarding/containers/LoginPage.tsx
+++ b/src/onboarding/containers/LoginPage.tsx
@@ -57,20 +57,10 @@ export const LoginPage: FC = () => {
     if (isFlagEnabled('universalLogin')) {
       if (CLOUD) {
         fetch('/api/env/quartz-login-url')
-          .then(response => {
-            response
-              .text()
-              .then(response => {
-                const redirectUrl = response
-                console.warn('Redirect to cloud url: ', redirectUrl)
-                window.location.replace(redirectUrl)
-              })
-              .catch(error => {
-                console.error(
-                  'Failed to fetch /api/env/quartz-login-url',
-                  error
-                )
-              })
+          .then(async response => {
+            const quartzUrl = await response.text()
+            console.warn('Redirect to cloud url: ', quartzUrl)
+            window.location.replace(quartzUrl)
           })
           .catch(error => console.error(error))
         return null


### PR DESCRIPTION
We want to use the quartz endpoint to logout instead.

Note: I used `api/env/quartz-login-url` , it might be confusing at a first glance why it's calling a `login` path to logout. This was just a naming thing, we thought the endpoint will only be used for logging in, but now that we're using it for logging out, I will make follow up changes to rename it to `quartz-url`

 
<!-- Describe your proposed changes here. -->
<!-- Including screenshots or visuals is very helpful - a picture is worth a thousand words. -->

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
