### PR TITLE
feat: make descriptions optional

### DIFF
--- a/src/dataExplorer/components/SaveAsScript.tsx
+++ b/src/dataExplorer/components/SaveAsScript.tsx
@@ -190,8 +190,7 @@ const SaveAsScript: FC<Props> = ({onClose, type}) => {
           <Button
             color={ComponentColor.Primary}
             status={
-              (resource?.data?.name?.length ?? 0) === 0 ||
-              (resource?.data?.description?.length ?? 0) === 0
+              (resource?.data?.name?.length ?? 0) === 0
                 ? ComponentStatus.Disabled
                 : ComponentStatus.Default
             }

--- a/src/dataExplorer/components/resources/types/script/index.ts
+++ b/src/dataExplorer/components/resources/types/script/index.ts
@@ -55,7 +55,7 @@ export default function script(register) {
           scriptID: data.id,
           data: {
             name: data.name,
-            description: data.description,
+            description: data?.description || ' ',
             script: data.script,
           },
         }).then(resp => {
@@ -70,7 +70,7 @@ export default function script(register) {
       return postScript({
         data: {
           name: data.name,
-          description: data.description,
+          description: data?.description || ' ',
           script: data.script,
           language: 'flux',
         },


### PR DESCRIPTION
Closes #5943 

Due to API limitations, we will need to always send a description with the outgoing payload so that the API doesn't respond with an error. More specifically, the current API infrastructure doesn't allow for users to send partial updates to the API, nor does it allow for null values to be sent. As such, if we want to make the description field optional, we first need to:

1. Remove the restrictions for descriptions to allow for saving if no description exists
2. Add a default `' '` to send with the payload if a falsy value is sent over the wire (in this case being `null`, `undefined` or `''`)