### PR TITLE
fix: reposition setfeatureflag function for gh tests

### DIFF
--- a/cypress/e2e/cloud/globalHeader.test.ts
+++ b/cypress/e2e/cloud/globalHeader.test.ts
@@ -30,6 +30,7 @@ describe('change-account change-org global header', () => {
   before(() => {
     cy.flush().then(() =>
       cy.signin().then(() => {
+        cy.setFeatureFlagsNoNav(globalHeaderFeatureFlags)
         cy.request({
           method: 'GET',
           url: 'api/v2/orgs',
@@ -48,7 +49,6 @@ describe('change-account change-org global header', () => {
     // Preserve one session throughout.
     makeQuartzUseIDPEOrgID(idpeOrgID)
     Cypress.Cookies.preserveOnce('sid')
-    cy.setFeatureFlags(globalHeaderFeatureFlags)
   })
 
   afterEach(() => {
@@ -59,7 +59,6 @@ describe('change-account change-org global header', () => {
     it('does not render when API requests to quartz fail', () => {
       mockQuartzOutage()
       interceptPageReload()
-      cy.setFeatureFlags(globalHeaderFeatureFlags)
       cy.visit('/')
       cy.wait('@getQuartzAccounts')
       cy.getByTestID('global-header--container').should('not.exist')
@@ -68,7 +67,6 @@ describe('change-account change-org global header', () => {
     describe('change org dropdown', () => {
       before(() => {
         makeQuartzUseIDPEOrgID(idpeOrgID)
-        cy.setFeatureFlags(globalHeaderFeatureFlags)
         cy.visit('/')
       })
 
@@ -147,7 +145,6 @@ describe('change-account change-org global header', () => {
     describe('change account dropdown', () => {
       beforeEach(() => {
         makeQuartzUseIDPEOrgID(idpeOrgID)
-        cy.setFeatureFlags(globalHeaderFeatureFlags)
       })
 
       before(() => {
@@ -218,7 +215,6 @@ describe('change-account change-org global header', () => {
   describe('user profile avatar', {scrollBehavior: false}, () => {
     before(() => {
       makeQuartzUseIDPEOrgID(idpeOrgID)
-      cy.setFeatureFlags(globalHeaderFeatureFlags)
       cy.visit('/')
     })
 

--- a/cypress/e2e/cloud/globalHeaderOrgMenuItems.test.ts
+++ b/cypress/e2e/cloud/globalHeaderOrgMenuItems.test.ts
@@ -11,6 +11,7 @@ describe('FREE: global header menu items test', () => {
   before(() => {
     cy.flush().then(() =>
       cy.signin().then(() => {
+        cy.setFeatureFlagsNoNav(createOrgsFeatureFlags)
         cy.request({
           method: 'GET',
           url: 'api/v2/orgs',
@@ -19,8 +20,6 @@ describe('FREE: global header menu items test', () => {
           if (res.body.orgs) {
             idpeOrgID = res.body.orgs[0].id
           }
-
-          cy.setFeatureFlags(createOrgsFeatureFlags)
         })
       })
     )
@@ -31,9 +30,7 @@ describe('FREE: global header menu items test', () => {
     Cypress.Cookies.preserveOnce('sid')
 
     makeQuartzUseIDPEOrgID(idpeOrgID)
-    cy.visit('/').then(() => {
-      cy.setFeatureFlags(createOrgsFeatureFlags)
-    })
+    cy.visit('/')
   })
 
   it('has add more organizations in menu items', () => {
@@ -52,6 +49,7 @@ describe('PAYG: global header menu items test', () => {
   before(() => {
     cy.flush().then(() =>
       cy.signin().then(() => {
+        cy.setFeatureFlagsNoNav(createOrgsFeatureFlags)
         cy.request({
           method: 'GET',
           url: 'api/v2/orgs',
@@ -62,7 +60,6 @@ describe('PAYG: global header menu items test', () => {
           }
 
           Cypress.Cookies.preserveOnce('sid')
-          cy.setFeatureFlags(createOrgsFeatureFlags)
         })
       })
     )
@@ -70,9 +67,7 @@ describe('PAYG: global header menu items test', () => {
 
   beforeEach(() => {
     makeQuartzUseIDPEOrgID(idpeOrgID, 'pay_as_you_go')
-    cy.visit('/').then(() => {
-      cy.setFeatureFlags(createOrgsFeatureFlags)
-    })
+    cy.visit('/')
   })
 
   it('PAYG: can check create organization menu item exists', () => {
@@ -91,6 +86,7 @@ describe('Contract: global header menu items test', () => {
   before(() => {
     cy.flush().then(() =>
       cy.signin().then(() => {
+        cy.setFeatureFlagsNoNav(createOrgsFeatureFlags)
         cy.request({
           method: 'GET',
           url: 'api/v2/orgs',
@@ -101,7 +97,6 @@ describe('Contract: global header menu items test', () => {
           }
 
           Cypress.Cookies.preserveOnce('sid')
-          cy.setFeatureFlags(createOrgsFeatureFlags)
         })
       })
     )
@@ -109,9 +104,7 @@ describe('Contract: global header menu items test', () => {
 
   beforeEach(() => {
     makeQuartzUseIDPEOrgID(idpeOrgID, 'contract')
-    cy.visit('/').then(() => {
-      cy.setFeatureFlags(createOrgsFeatureFlags)
-    })
+    cy.visit('/')
   })
 
   it('Contract: can check create organization menu item exists', () => {


### PR DESCRIPTION
Still some flakiness in Global Header Tests. Trying out a fix.


### Checklist

Authors and Reviewer(s), please verify the following:

- [ ] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [ ] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
