### PR TITLE
chore(client_libs): Swift client uses new modern async/await pattern

### DIFF
--- a/src/writeData/clients/Swift/description.md
+++ b/src/writeData/clients/Swift/description.md
@@ -10,6 +10,10 @@ import PackageDescription
 
 let package = Package(
     name: "MyPackage",
+    platforms: [
+        .macOS(.v12),
+        .iOS(.v15)
+    ],
     dependencies: [
         .package(name: "influxdb-client-swift", url: "https://github.com/influxdata/influxdb-client-swift", from: "1.4.0"),
     ],

--- a/src/writeData/clients/Swift/execute.example
+++ b/src/writeData/clients/Swift/execute.example
@@ -1,23 +1,6 @@
 let query = """
             <%= query %>"""
 
-client.queryAPI.query(query: query, org: org) { response, error in
-  // Error response
-  if let error = error {
-    print("Error:\n\n\(error)")
-  }
-
-  // Success response
-  if let response = response {
-
-    print("\nSuccess response...\n")
-    do {
-      try response.forEach { record in
-        print("\t\(record.values["_field"]!): \(record.values["_value"]!)")
-      }
-    } catch {
-       print("Error:\n\n\(error)")
-    }
-  }
-}
+let records = try await client.queryAPI.query(query: query, org: org)
+try records.forEach { print(" > \($0.values["_field"]!): \($0.values["_value"]!)") }
 

--- a/src/writeData/clients/Swift/executeFull.example
+++ b/src/writeData/clients/Swift/executeFull.example
@@ -3,7 +3,7 @@ import InfluxDBSwift
 
 @main
 class Example {
-    static func main() {
+    static func main() async throws {
 
         let url = "<%= server %>"
         let token = "<%= token %>"
@@ -15,29 +15,15 @@ class Example {
                     <%= query %>
                     """
 
-        client.queryAPI.query(query: query, org: org) { response, error in
-          // Error response
-          if let error = error {
-            print("Error:\n\n\(error)")
-          }
-
-          // Success response
-          if let response = response {
-
-            do {
-              try response.forEach { record in
-                let time = record.values["_time"]!
-                let measurement = record.values["_measurement"]!
-                let field = record.values["_field"]!
-                let value = record.values["_value"]!
-                return print("\(time) \(measurement): \(field)=\(value)")
-              }
-            } catch {
-               print("Error:\n\n\(error)")
-            }
-          }
-
-          client.close()
+        let records = try await client.queryAPI.query(query: query, org: org)
+        try records.forEach {
+          let time = $0.values["_time"]!
+          let measurement = $0.values["_measurement"]!
+          let field = $0.values["_field"]!
+          let value = $0.values["_value"]!
+          print("\(time) \(measurement): \(field)=\(value)")
         }
+
+        client.close()
     }
 }

--- a/src/writeData/clients/Swift/initialize.example
+++ b/src/writeData/clients/Swift/initialize.example
@@ -3,7 +3,7 @@ import InfluxDBSwift
 
 @main
 class Example {
-    static func main() {
+    static func main() async throws {
 
         let url = "<%= server %>"
         let token = ProcessInfo.processInfo.environment["INFLUX_TOKEN"]!

--- a/src/writeData/clients/Swift/write.0.example
+++ b/src/writeData/clients/Swift/write.0.example
@@ -1,14 +1,4 @@
 let recordString = "demo,type=string value=1i"
 
-client.makeWriteAPI().write(bucket: bucket, org: org, record: recordString) { result, error in
-    // For handle error
-    if let error = error {
-        print("Error:\n\n\(error)")
-    }
-
-    // For Success write
-    if result != nil {
-        print("Successfully written data:\n\n\(recordString)")
-    }
-}
+try await client.makeWriteAPI().write(bucket: bucket, org: org, record: recordString)
 

--- a/src/writeData/clients/Swift/write.1.example
+++ b/src/writeData/clients/Swift/write.1.example
@@ -4,15 +4,5 @@ let recordPoint = InfluxDBClient
         .addField(key: "value", value: .int(2))
         .time(time: .date(Date()))
 
-client.makeWriteAPI().write(bucket: bucket, org: org, points: [recordPoint]) { result, error in
-    // For handle error
-    if let error = error {
-        print("Error:\n\n\(error)")
-    }
-
-    // For Success write
-    if result != nil {
-        print("Successfully written data:\n\n\([recordPoint])")
-    }
-}
+try await client.makeWriteAPI().write(bucket: bucket, org: org, points: [recordPoint])
 

--- a/src/writeData/clients/Swift/write.2.example
+++ b/src/writeData/clients/Swift/write.2.example
@@ -1,15 +1,5 @@
 let recordTuple: InfluxDBClient.Point.Tuple
         = (measurement: "demo", tags: ["type": "tuple"], fields: ["value": .int(3)], time: nil)
 
-client.makeWriteAPI().write(bucket: bucket, org: org, tuple: recordTuple) { result, error in
-    // For handle error
-    if let error = error {
-        print("Error:\n\n\(error)")
-    }
-
-    // For Success write
-    if result != nil {
-        print("Successfully written data:\n\n\(recordTuple)")
-    }
-}
+try await client.makeWriteAPI().write(bucket: bucket, org: org, tuple: recordTuple)
 


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb-client-swift/issues/58

This PR changes code examples for `Swift` library to use new modern `async/await` pattern (instead of callbacks) which was introduced by https://github.com/influxdata/influxdb-client-swift/pull/49:
```swift
let query = """
                from(bucket: "\(self.bucket)")
                    |> range(start: -10m)
                    |> filter(fn: (r) => r["_measurement"] == "cpu")
                    |> filter(fn: (r) => r["cpu"] == "cpu-total")
                    |> filter(fn: (r) => r["_field"] == "usage_user" or r["_field"] == "usage_system")
                    |> last()
                """

print("\nQuery to execute:\n\(query)\n")
let records = try await client.queryAPI.query(query: query)
```

Updated UI:

![image](https://user-images.githubusercontent.com/455137/195301050-4af83b24-0832-4b46-a690-a56b1154dc23.png)


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
