### PR TITLE
chore: remove multiOrg flag reference from CLI wizard

### DIFF
--- a/src/homepageExperience/containers/CliWizard.tsx
+++ b/src/homepageExperience/containers/CliWizard.tsx
@@ -30,8 +30,6 @@ import {
   HOMEPAGE_NAVIGATION_STEPS_SHORT,
 } from 'src/homepageExperience/utils'
 import {normalizeEventName} from 'src/cloud/utils/reporting'
-import RateLimitAlert from 'src/cloud/components/RateLimitAlert'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 interface State {
   currentStep: number
@@ -175,13 +173,7 @@ export class CliWizard extends PureComponent<{}, State> {
   render() {
     return (
       <Page>
-        <Page.Header fullWidth={false}>
-          {/* Need an empty div so the upgrade button aligns to the right. (Because clockface uses space-between to justifyContent)*/}
-          <div />
-          {!isFlagEnabled('multiOrg') && (
-            <RateLimitAlert location="firstMile.cliWizard" />
-          )}
-        </Page.Header>
+        <Page.Header fullWidth={false} />
         <Page.Contents scrollable={true}>
           <div className="homepage-wizard-container">
             <aside className="homepage-wizard-container--subway">


### PR DESCRIPTION
Connects #4055 

Missed one: there is one more reference to the `multiOrg` flag that needs to be removed (from the CLI wizard).

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable
