### PR TITLE
chore: remove references to multiOrg flag in cypress tests

### DIFF
--- a/cypress/e2e/cloud/about.test.ts
+++ b/cypress/e2e/cloud/about.test.ts
@@ -5,17 +5,13 @@ describe.skip('About Page for free users with only 1 user', () => {
   beforeEach(() =>
     cy.flush().then(() =>
       cy.signin().then(() => {
-        cy.setFeatureFlags({
-          multiOrg: true,
-        }).then(() => {
-          cy.get('@org').then(({id}: Organization) => {
-            cy.quartzProvision({
-              accountType: 'free',
-              hasUsers: false,
-            }).then(() => {
-              cy.visit(`/orgs/${id}/org-settings`)
-              cy.getByTestID('about-page--header').should('be.visible')
-            })
+        cy.get('@org').then(({id}: Organization) => {
+          cy.quartzProvision({
+            accountType: 'free',
+            hasUsers: false,
+          }).then(() => {
+            cy.visit(`/orgs/${id}/org-settings`)
+            cy.getByTestID('about-page--header').should('be.visible')
           })
         })
       })
@@ -53,17 +49,13 @@ describe('About Page for free users with multiple users', () => {
   beforeEach(() =>
     cy.flush().then(() =>
       cy.signin().then(() => {
-        cy.setFeatureFlags({
-          multiOrg: true,
-        }).then(() => {
-          cy.get('@org').then(({id}: Organization) => {
-            cy.quartzProvision({
-              accountType: 'free',
-              hasUsers: true,
-            }).then(() => {
-              cy.visit(`/orgs/${id}/org-settings`)
-              cy.getByTestID('about-page--header').should('be.visible')
-            })
+        cy.get('@org').then(({id}: Organization) => {
+          cy.quartzProvision({
+            accountType: 'free',
+            hasUsers: true,
+          }).then(() => {
+            cy.visit(`/orgs/${id}/org-settings`)
+            cy.getByTestID('about-page--header').should('be.visible')
           })
         })
       })
@@ -88,16 +80,12 @@ describe('About Page for PAYG users', () => {
   beforeEach(() =>
     cy.flush().then(() =>
       cy.signin().then(() => {
-        cy.setFeatureFlags({
-          multiOrg: true,
-        }).then(() => {
-          cy.get('@org').then(({id}: Organization) => {
-            cy.quartzProvision({
-              accountType: 'pay_as_you_go',
-            }).then(() => {
-              cy.visit(`/orgs/${id}/org-settings`)
-              cy.getByTestID('about-page--header').should('be.visible')
-            })
+        cy.get('@org').then(({id}: Organization) => {
+          cy.quartzProvision({
+            accountType: 'pay_as_you_go',
+          }).then(() => {
+            cy.visit(`/orgs/${id}/org-settings`)
+            cy.getByTestID('about-page--header').should('be.visible')
           })
         })
       })

--- a/cypress/e2e/cloud/billing.test.ts
+++ b/cypress/e2e/cloud/billing.test.ts
@@ -17,37 +17,33 @@ describe('Billing Page Free Users', () => {
   )
 
   it('should display the free billing page for free users', () => {
-    cy.setFeatureFlags({
-      multiOrg: true,
-    }).then(() => {
-      cy.getByTestID('cloud-upgrade--button').should('be.visible')
-      cy.getByTestID('title-header--name')
-        .should('not.have.value', 'blockedNotificationRules')
-        .and('not.have.value', 'blockedNotificationEndpoints')
-        .and('have.length', 9)
+    cy.getByTestID('cloud-upgrade--button').should('be.visible')
+    cy.getByTestID('title-header--name')
+      .should('not.have.value', 'blockedNotificationRules')
+      .and('not.have.value', 'blockedNotificationEndpoints')
+      .and('have.length', 9)
 
-      const categoryHeaders = [
-        'Max Dashboards',
-        'Max Tasks',
-        'Max Buckets',
-        'Max Retention Seconds',
-        'Max Checks',
-        'Max Notifications',
-        'Reads',
-        'Writes',
-        'Series Cardinality',
-      ]
+    const categoryHeaders = [
+      'Max Dashboards',
+      'Max Tasks',
+      'Max Buckets',
+      'Max Retention Seconds',
+      'Max Checks',
+      'Max Notifications',
+      'Reads',
+      'Writes',
+      'Series Cardinality',
+    ]
 
-      cy.getByTestID('title-header--name').each((child, index) => {
-        expect(child.text().trim()).to.equal(categoryHeaders[index])
-      })
+    cy.getByTestID('title-header--name').each((child, index) => {
+      expect(child.text().trim()).to.equal(categoryHeaders[index])
+    })
 
-      cy.getByTestID('payg-grid--container').scrollIntoView()
-      cy.getByTestID('payg-button--upgrade').should('be.visible').click()
+    cy.getByTestID('payg-grid--container').scrollIntoView()
+    cy.getByTestID('payg-button--upgrade').should('be.visible').click()
 
-      cy.location().should(loc => {
-        expect(loc.pathname).to.eq('/checkout')
-      })
+    cy.location().should(loc => {
+      expect(loc.pathname).to.eq('/checkout')
     })
   })
 })
@@ -56,22 +52,18 @@ describe('Billing Page PAYG Users', () => {
   beforeEach(() =>
     cy.flush().then(() =>
       cy.signin().then(() => {
-        cy.setFeatureFlags({
-          multiOrg: true,
-        }).then(() => {
-          cy.get('@org').then(({id}: Organization) => {
-            cy.quartzProvision({
-              accountType: 'pay_as_you_go',
-            }).then(() => {
-              cy.visit(`/orgs/${id}/billing`)
+        cy.get('@org').then(({id}: Organization) => {
+          cy.quartzProvision({
+            accountType: 'pay_as_you_go',
+          }).then(() => {
+            cy.visit(`/orgs/${id}/billing`)
 
-              cy.getByTestID('billing-page--header').should('be.visible')
-              cy.getByTestID('accounts-billing-tab').should('be.visible')
-              cy.getByTestID('accounts-billing-tab').should(
-                'have.class',
-                'cf-tabs--tab__active'
-              )
-            })
+            cy.getByTestID('billing-page--header').should('be.visible')
+            cy.getByTestID('accounts-billing-tab').should('be.visible')
+            cy.getByTestID('accounts-billing-tab').should(
+              'have.class',
+              'cf-tabs--tab__active'
+            )
           })
         })
       })
@@ -79,147 +71,135 @@ describe('Billing Page PAYG Users', () => {
   )
 
   it('should display the free billing page for PAYG users', () => {
-    cy.setFeatureFlags({
-      multiOrg: true,
-    }).then(() => {
-      // The implication here is that there is no Upgrade Now button
-      cy.get('.cf-page-header--fluid').children().should('have.length', 1)
+    // The implication here is that there is no Upgrade Now button
+    cy.get('.cf-page-header--fluid').children().should('have.length', 1)
 
-      // PAYG section
-      cy.getByTestID('payg-plan--header').contains('Pay As You Go')
+    // PAYG section
+    cy.getByTestID('payg-plan--header').contains('Pay As You Go')
 
-      cy.getByTestID('payg-plan--balance-header').contains('Account Balance')
-      cy.getByTestID('payg-plan--balance-body').contains('10.00')
+    cy.getByTestID('payg-plan--balance-header').contains('Account Balance')
+    cy.getByTestID('payg-plan--balance-body').contains('10.00')
 
-      cy.getByTestID('payg-plan--updated-header').contains('Last Update')
-      cy.getByTestID('payg-plan--updated-body').contains(
-        `${new Date().toLocaleString('default', {
-          month: 'numeric',
-          day: 'numeric',
-          year: 'numeric',
-          hour: 'numeric',
-          minute: '2-digit',
-        })}`
-      )
+    cy.getByTestID('payg-plan--updated-header').contains('Last Update')
+    cy.getByTestID('payg-plan--updated-body').contains(
+      `${new Date().toLocaleString('default', {
+        month: 'numeric',
+        day: 'numeric',
+        year: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+      })}`
+    )
 
-      // Invoices Section
-      cy.getByTestID('past-invoices--header').contains('Past Invoices')
-      cy.getByTestID('invoice-history--row').should('have.length', 2)
+    // Invoices Section
+    cy.getByTestID('past-invoices--header').contains('Past Invoices')
+    cy.getByTestID('invoice-history--row').should('have.length', 2)
 
-      cy.getByTestID('invoice-history--name')
-        .last()
-        .contains('December 2020 Invoice')
-      cy.getByTestID('invoice-history--amount').last().contains('$100.00')
-      cy.getByTestID('invoice-history--status').last().contains('unpaid')
+    cy.getByTestID('invoice-history--name')
+      .last()
+      .contains('December 2020 Invoice')
+    cy.getByTestID('invoice-history--amount').last().contains('$100.00')
+    cy.getByTestID('invoice-history--status').last().contains('unpaid')
 
-      // Sort by date
-      cy.getByTestID('invoice-date--sorter').contains('Invoice Date').click()
+    // Sort by date
+    cy.getByTestID('invoice-date--sorter').contains('Invoice Date').click()
 
-      // Should now be the first item
-      cy.getByTestID('invoice-history--name')
-        .first()
-        .contains('December 2020 Invoice')
+    // Should now be the first item
+    cy.getByTestID('invoice-history--name')
+      .first()
+      .contains('December 2020 Invoice')
 
-      // Sort by amount
-      cy.getByTestID('invoice-amount--sorter').contains('Amount').click()
+    // Sort by amount
+    cy.getByTestID('invoice-amount--sorter').contains('Amount').click()
 
-      cy.getByTestID('invoice-history--amount').first().contains('$10.00')
+    cy.getByTestID('invoice-history--amount').first().contains('$10.00')
 
-      cy.getByTestID('invoice-status--sorter').contains('Status').click()
+    cy.getByTestID('invoice-status--sorter').contains('Status').click()
 
-      cy.getByTestID('invoice-history--status').first().contains('paid')
+    cy.getByTestID('invoice-history--status').first().contains('paid')
 
-      // Payment Method Section
-      cy.getByTestID('payment-method--header').contains('Payment Method')
-      cy.getByTestID('payment-display').contains(
-        'Your current payment card is visa 4242 4242 4242 4242 — Expiring 04/24'
-      )
-      cy.getByTestID('edit-payment--button').click()
-      // TODO: render the zuora form somehow
-      cy.getByTestID('payment-form').should('exist')
+    // Payment Method Section
+    cy.getByTestID('payment-method--header').contains('Payment Method')
+    cy.getByTestID('payment-display').contains(
+      'Your current payment card is visa 4242 4242 4242 4242 — Expiring 04/24'
+    )
+    cy.getByTestID('edit-payment--button').click()
+    // TODO: render the zuora form somehow
+    cy.getByTestID('payment-form').should('exist')
 
-      cy.getByTestID('cancel-change--button').click()
-      cy.getByTestID('payment-form').should('not.exist')
+    cy.getByTestID('cancel-change--button').click()
+    cy.getByTestID('payment-form').should('not.exist')
 
-      // Contact Information Section
-      cy.getByTestID('billing-contact--header').contains('Contact Information')
-      cy.getByTestID('form-label--First Name').contains('First Name')
-      cy.getByTestID('contact-info--Test').contains('Test')
-      cy.getByTestID('form-label--Last Name').contains('Last Name')
-      cy.getByTestID('contact-info--PAYG').contains('PAYG')
-      cy.getByTestID('form-label--Company Name').contains('Company Name')
-      cy.getByTestID('contact-info--InfluxData').contains('InfluxData')
-      cy.getByTestID('form-label--Country').contains('Country')
-      cy.getByTestID('contact-info--USA').contains('USA')
-      cy.getByTestID('form-label--Physical Address').contains(
-        'Physical Address'
-      )
-      cy.getByTestID('contact-info--123 Main St, Apt 2').contains(
-        '123 Main St, Apt 2'
-      )
-      cy.getByTestID('form-label--City').contains('City')
-      cy.getByTestID('contact-info--Los Angeles').contains('Los Angeles')
-      cy.getByTestID('form-label--State (Subdivision)').contains(
-        'State (Subdivision)'
-      )
-      cy.getByTestID('contact-info--California').contains('California')
-      cy.getByTestID('form-label--Postal Code').contains('Postal Code')
-      cy.getByTestID('contact-info--90001').contains('90001')
+    // Contact Information Section
+    cy.getByTestID('billing-contact--header').contains('Contact Information')
+    cy.getByTestID('form-label--First Name').contains('First Name')
+    cy.getByTestID('contact-info--Test').contains('Test')
+    cy.getByTestID('form-label--Last Name').contains('Last Name')
+    cy.getByTestID('contact-info--PAYG').contains('PAYG')
+    cy.getByTestID('form-label--Company Name').contains('Company Name')
+    cy.getByTestID('contact-info--InfluxData').contains('InfluxData')
+    cy.getByTestID('form-label--Country').contains('Country')
+    cy.getByTestID('contact-info--USA').contains('USA')
+    cy.getByTestID('form-label--Physical Address').contains('Physical Address')
+    cy.getByTestID('contact-info--123 Main St, Apt 2').contains(
+      '123 Main St, Apt 2'
+    )
+    cy.getByTestID('form-label--City').contains('City')
+    cy.getByTestID('contact-info--Los Angeles').contains('Los Angeles')
+    cy.getByTestID('form-label--State (Subdivision)').contains(
+      'State (Subdivision)'
+    )
+    cy.getByTestID('contact-info--California').contains('California')
+    cy.getByTestID('form-label--Postal Code').contains('Postal Code')
+    cy.getByTestID('contact-info--90001').contains('90001')
 
-      // Click the edit information button
-      cy.getByTestID('edit-contact--button')
-        .contains('Edit Information')
-        .click()
-      cy.getByTestID('form-input--firstname').clear().type('Salt')
-      cy.getByTestID('form-input--lastname').clear().type('Bae')
-      cy.getByTestID('save-contact--button').click()
+    // Click the edit information button
+    cy.getByTestID('edit-contact--button').contains('Edit Information').click()
+    cy.getByTestID('form-input--firstname').clear().type('Salt')
+    cy.getByTestID('form-input--lastname').clear().type('Bae')
+    cy.getByTestID('save-contact--button').click()
 
-      // Validate that the first and last name are updated
-      cy.getByTestID('contact-info--Salt')
-        .contains('Salt')
-        .and('not.be', 'Test')
-      cy.getByTestID('contact-info--Bae').contains('Bae').and('not.be', 'PAYG')
+    // Validate that the first and last name are updated
+    cy.getByTestID('contact-info--Salt').contains('Salt').and('not.be', 'Test')
+    cy.getByTestID('contact-info--Bae').contains('Bae').and('not.be', 'PAYG')
 
-      // Notification Settings Section
-      cy.getByTestID('notification-settings--header').contains(
-        'Notification Settings'
-      )
-      cy.getByTestID('billing-settings--text').contains('test@influxdata.com')
-      cy.getByTestID('billing-settings--text').contains('$11')
-      cy.getByTestID('notification-settings--button').click()
+    // Notification Settings Section
+    cy.getByTestID('notification-settings--header').contains(
+      'Notification Settings'
+    )
+    cy.getByTestID('billing-settings--text').contains('test@influxdata.com')
+    cy.getByTestID('billing-settings--text').contains('$11')
+    cy.getByTestID('notification-settings--button').click()
 
-      // Toggle the settings off
-      cy.getByTestID('should-notify--toggle').click()
-      cy.getByTestID('save-settings--button').click()
-      cy.getByTestID('billing-settings--text').contains(
-        'Usage Notifications disabled'
-      )
+    // Toggle the settings off
+    cy.getByTestID('should-notify--toggle').click()
+    cy.getByTestID('save-settings--button').click()
+    cy.getByTestID('billing-settings--text').contains(
+      'Usage Notifications disabled'
+    )
 
-      // Notification Settings Section
-      cy.getByTestID('cancel-service--header').contains('Cancel Service')
-      cy.getByTestID('cancel-service--button').click()
-      cy.getByTestID('cancel-overlay--alert').contains(
-        'This action cannot be undone'
-      )
-      // check that the button is disabled
-      cy.getByTestID('cancel-service-confirmation--button').should(
-        'be.disabled'
-      )
-      cy.getByTestID('agree-terms--checkbox').should('not.be.checked')
+    // Notification Settings Section
+    cy.getByTestID('cancel-service--header').contains('Cancel Service')
+    cy.getByTestID('cancel-service--button').click()
+    cy.getByTestID('cancel-overlay--alert').contains(
+      'This action cannot be undone'
+    )
+    // check that the button is disabled
+    cy.getByTestID('cancel-service-confirmation--button').should('be.disabled')
+    cy.getByTestID('agree-terms--checkbox').should('not.be.checked')
 
-      cy.getByTestID('agree-terms--input').click()
-      cy.getByTestID('agree-terms--checkbox').should('be.checked')
-      cy.getByTestID('variable-type-dropdown--button')
-        .click()
-        .then(() => {
-          cy.getByTestID('variable-type-dropdown-USE_CASE_DIFFERENT').click()
-        })
-      cy.getByTestID('cancel-service-confirmation--button')
-        .should('not.be.disabled')
-        .click()
+    cy.getByTestID('agree-terms--input').click()
+    cy.getByTestID('agree-terms--checkbox').should('be.checked')
+    cy.getByTestID('variable-type-dropdown--button')
+      .click()
+      .then(() => {
+        cy.getByTestID('variable-type-dropdown-USE_CASE_DIFFERENT').click()
+      })
+    cy.getByTestID('cancel-service-confirmation--button')
+      .should('not.be.disabled')
+      .click()
 
-      // TLDR; we double confirm here, this is by design. The overlay changes to reflect a new state so this isn't an error in the test
-      cy.getByTestID('cancel-service-confirmation--button').click()
-    })
+    // TLDR; we double confirm here, this is by design. The overlay changes to reflect a new state so this isn't an error in the test
+    cy.getByTestID('cancel-service-confirmation--button').click()
   })
 })

--- a/cypress/e2e/cloud/buckets.test.ts
+++ b/cypress/e2e/cloud/buckets.test.ts
@@ -97,9 +97,7 @@ const testSchemaFiles = (
 
 describe('Explicit Buckets', () => {
   beforeEach(() => {
-    setup(cy).then(() => {
-      cy.setFeatureFlags({multiOrg: true})
-    })
+    setup(cy)
   })
 
   it('can create a bucket with an explicit schema', () => {
@@ -415,9 +413,7 @@ fsRead,field,float`
 
 describe('Buckets', () => {
   beforeEach(() => {
-    setup(cy).then(() => {
-      cy.setFeatureFlags({multiOrg: true})
-    })
+    setup(cy)
   })
 
   it('can sort by name and retention', () => {

--- a/cypress/e2e/cloud/checkout/checkoutinaccessible.test.ts
+++ b/cypress/e2e/cloud/checkout/checkoutinaccessible.test.ts
@@ -2,16 +2,12 @@ describe('Checkout Page should not be accessible for non-free users', () => {
   beforeEach(() =>
     cy.flush().then(() =>
       cy.signin().then(() => {
-        cy.setFeatureFlags({
-          multiOrg: true,
-        }).then(() => {
-          cy.get('@org').then(() => {
-            cy.getByTestID('home-page--header').should('be.visible')
-            cy.quartzProvision({
-              accountType: 'pay_as_you_go',
-            }).then(() => {
-              cy.visit(`/checkout`)
-            })
+        cy.get('@org').then(() => {
+          cy.getByTestID('home-page--header').should('be.visible')
+          cy.quartzProvision({
+            accountType: 'pay_as_you_go',
+          }).then(() => {
+            cy.visit(`/checkout`)
           })
         })
       })

--- a/cypress/e2e/cloud/communityTemplates.test.ts
+++ b/cypress/e2e/cloud/communityTemplates.test.ts
@@ -7,9 +7,7 @@ describe('Community Templates', () => {
         cy.get('@org').then(({id}: Organization) =>
           cy.fixture('routes').then(({orgs}) => {
             cy.visit(`${orgs}/${id}/settings/templates`)
-            cy.getByTestID('tree-nav').then(() => {
-              cy.setFeatureFlags({multiOrg: true})
-            })
+            cy.getByTestID('tree-nav')
           })
         )
       })

--- a/cypress/e2e/cloud/dashboardsView.test.ts
+++ b/cypress/e2e/cloud/dashboardsView.test.ts
@@ -5,9 +5,7 @@ describe('Dashboard', () => {
         cy.fixture('routes').then(({orgs}) => {
           cy.get('@org').then(({id: orgID}: any) => {
             cy.visit(`${orgs}/${orgID}/dashboards-list`)
-            cy.getByTestID('tree-nav').then(() => {
-              cy.setFeatureFlags({multiOrg: true})
-            })
+            cy.getByTestID('tree-nav')
           })
         })
       )

--- a/cypress/e2e/cloud/deepLinks.test.ts
+++ b/cypress/e2e/cloud/deepLinks.test.ts
@@ -3,9 +3,7 @@ import {Organization} from '../../../src/types'
 describe('Deep linking', () => {
   beforeEach(() => {
     cy.flush()
-    cy.signin().then(() => {
-      cy.setFeatureFlags({multiOrg: true})
-    })
+    cy.signin()
   })
 
   // If you're here and the test failure you're looking at is legitimate, it probably means a page

--- a/cypress/e2e/cloud/explorer.test.ts
+++ b/cypress/e2e/cloud/explorer.test.ts
@@ -30,9 +30,6 @@ describe('DataExplorer', () => {
 
   describe('Script Editor', () => {
     beforeEach(() => {
-      cy.setFeatureFlags({
-        multiOrg: true,
-      })
       cy.getByTestID('switch-to-script-editor').should('be.visible').click()
     })
 

--- a/cypress/e2e/cloud/flows.test.ts
+++ b/cypress/e2e/cloud/flows.test.ts
@@ -10,7 +10,6 @@ describe('Flows', () => {
           cy.getByTestID('version-info').should('be.visible')
           cy.getByTestID('nav-item-flows').should('be.visible')
           cy.getByTestID('nav-item-flows').click()
-          cy.setFeatureFlags({multiOrg: true})
         })
       })
     })
@@ -184,77 +183,69 @@ describe('Flows', () => {
   })
 
   it('can use the dynamic flux function selector to build a query', () => {
-    cy.setFeatureFlags({
-      multiOrg: true,
-    }).then(() => {
-      cy.getByTestID('preset-script').first().click()
+    cy.getByTestID('preset-script').first().click()
 
-      cy.get('.view-line').should('be.visible')
+    cy.get('.view-line').should('be.visible')
 
-      cy.get('button[title="Function Reference"]').click()
+    cy.get('button[title="Function Reference"]').click()
 
-      // search for a function
-      cy.getByTestID('flux-toolbar-search--input').click().type('microsecondd') // purposefully misspell "microsecond" so all functions are filtered out
+    // search for a function
+    cy.getByTestID('flux-toolbar-search--input').click().type('microsecondd') // purposefully misspell "microsecond" so all functions are filtered out
 
-      cy.getByTestID('flux-toolbar--list').within(() => {
-        cy.getByTestID('empty-state').should('be.visible')
-      })
-      cy.getByTestID('flux-toolbar-search--input').type('{backspace}')
-
-      cy.get('.flux-toolbar--list-item').should('contain', 'microsecond')
-      cy.get('.flux-toolbar--list-item').should('have.length', 1)
-
-      // hovers over function and see a tooltip
-      cy.get('.flux-toolbar--list-item').trigger('mouseover')
-      cy.getByTestID('flux-docs--microsecond').should('be.visible')
-
-      // inject function into script editor
-      cy.getByTestID('flux--microsecond--inject').click({force: true})
-
-      // At minimium two lines: import and a function call
-      cy.get('.view-line').should('have.length.at.least', 2)
-      cy.get('.view-line').last().contains('microsecond')
+    cy.getByTestID('flux-toolbar--list').within(() => {
+      cy.getByTestID('empty-state').should('be.visible')
     })
+    cy.getByTestID('flux-toolbar-search--input').type('{backspace}')
+
+    cy.get('.flux-toolbar--list-item').should('contain', 'microsecond')
+    cy.get('.flux-toolbar--list-item').should('have.length', 1)
+
+    // hovers over function and see a tooltip
+    cy.get('.flux-toolbar--list-item').trigger('mouseover')
+    cy.getByTestID('flux-docs--microsecond').should('be.visible')
+
+    // inject function into script editor
+    cy.getByTestID('flux--microsecond--inject').click({force: true})
+
+    // At minimium two lines: import and a function call
+    cy.get('.view-line').should('have.length.at.least', 2)
+    cy.get('.view-line').last().contains('microsecond')
   })
 
   it('can use the dynamic flux function search bar to search by package or function name', () => {
-    cy.setFeatureFlags({
-      multiOrg: true,
-    }).then(() => {
-      cy.getByTestID('preset-script').first().click()
+    cy.getByTestID('preset-script').first().click()
 
-      cy.get('.view-line').should('be.visible')
+    cy.get('.view-line').should('be.visible')
 
-      cy.get('button[title="Function Reference"]').click()
+    cy.get('button[title="Function Reference"]').click()
 
-      cy.getByTestID('flux-toolbar-search--input').click().type('filter')
+    cy.getByTestID('flux-toolbar-search--input').click().type('filter')
 
-      cy.getByTestID('flux-toolbar-search--input').click().type('filter')
+    cy.getByTestID('flux-toolbar-search--input').click().type('filter')
 
-      cy.get('.flux-toolbar--search').within(() => {
-        cy.getByTestID('dismiss-button').click()
-      })
-
-      cy.getByTestID('flux-toolbar-search--input')
-        .invoke('val')
-        .then(value => {
-          expect(value).to.equal('')
-        })
-
-      cy.getByTestID('flux-toolbar-search--input').click().type('array')
-
-      cy.getByTestID('flux-toolbar-search--input').click().type('array')
-
-      cy.get('.flux-toolbar--search').within(() => {
-        cy.getByTestID('dismiss-button').click()
-      })
-
-      cy.getByTestID('flux-toolbar-search--input')
-        .invoke('val')
-        .then(value => {
-          expect(value).to.equal('')
-        })
+    cy.get('.flux-toolbar--search').within(() => {
+      cy.getByTestID('dismiss-button').click()
     })
+
+    cy.getByTestID('flux-toolbar-search--input')
+      .invoke('val')
+      .then(value => {
+        expect(value).to.equal('')
+      })
+
+    cy.getByTestID('flux-toolbar-search--input').click().type('array')
+
+    cy.getByTestID('flux-toolbar-search--input').click().type('array')
+
+    cy.get('.flux-toolbar--search').within(() => {
+      cy.getByTestID('dismiss-button').click()
+    })
+
+    cy.getByTestID('flux-toolbar-search--input')
+      .invoke('val')
+      .then(value => {
+        expect(value).to.equal('')
+      })
   })
 })
 
@@ -265,7 +256,6 @@ describe('Flows with newQueryBuilder flag on', () => {
     cy.get('@org').then(({id}: Organization) =>
       cy.fixture('routes').then(({orgs}) => {
         cy.setFeatureFlags({
-          multiOrg: true,
           newQueryBuilder: true,
         }).then(() => {
           cy.visit(`${orgs}/${id}`)

--- a/cypress/e2e/cloud/geoOptions.test.ts
+++ b/cypress/e2e/cloud/geoOptions.test.ts
@@ -4,18 +4,14 @@ describe.skip('DataExplorer - Geo Map Type Customization Options', () => {
   beforeEach(() =>
     cy.flush().then(() =>
       cy.signin().then(() => {
-        cy.signin()
-          .then(() => {
-            cy.setFeatureFlags({multiOrg: true})
-          })
-          .then(() => {
-            cy.get('@org').then(({id}: Organization) => {
-              cy.createMapVariable(id)
-              cy.fixture('routes').then(({orgs, explorer}) => {
-                cy.visit(`${orgs}/${id}${explorer}`)
-              })
+        cy.signin().then(() => {
+          cy.get('@org').then(({id}: Organization) => {
+            cy.createMapVariable(id)
+            cy.fixture('routes').then(({orgs, explorer}) => {
+              cy.visit(`${orgs}/${id}${explorer}`)
             })
           })
+        })
       })
     )
   )

--- a/cypress/e2e/cloud/globalHeader.test.ts
+++ b/cypress/e2e/cloud/globalHeader.test.ts
@@ -1,10 +1,6 @@
 import {makeQuartzUseIDPEOrgID} from 'cypress/support/Utils'
 
 describe('change-account change-org global header', () => {
-  const globalHeaderFeatureFlags = {
-    multiOrg: true,
-  }
-
   let idpeOrgID: string
 
   const interceptPageReload = () => {
@@ -30,7 +26,6 @@ describe('change-account change-org global header', () => {
   before(() => {
     cy.flush().then(() =>
       cy.signin().then(() => {
-        cy.setFeatureFlagsNoNav(globalHeaderFeatureFlags)
         cy.request({
           method: 'GET',
           url: 'api/v2/orgs',

--- a/cypress/e2e/cloud/globalHeaderOrgMenuItems.test.ts
+++ b/cypress/e2e/cloud/globalHeaderOrgMenuItems.test.ts
@@ -1,7 +1,6 @@
 import {makeQuartzUseIDPEOrgID} from 'cypress/support/Utils'
 
 const createOrgsFeatureFlags = {
-  multiOrg: true,
   createDeleteOrgs: true,
 }
 

--- a/cypress/e2e/cloud/helpBar.test.ts
+++ b/cypress/e2e/cloud/helpBar.test.ts
@@ -2,13 +2,11 @@ describe('Help bar support for free account users', () => {
   beforeEach(() =>
     cy.flush().then(() =>
       cy.signin().then(() => {
-        cy.setFeatureFlags({multiOrg: true}).then(() => {
-          cy.get('@org').then(() => {
-            cy.quartzProvision({
-              accountType: 'free',
-            }).then(() => {
-              cy.getByTestID('nav-item-support').should('be.visible')
-            })
+        cy.get('@org').then(() => {
+          cy.quartzProvision({
+            accountType: 'free',
+          }).then(() => {
+            cy.getByTestID('nav-item-support').should('be.visible')
           })
         })
       })
@@ -35,14 +33,12 @@ describe('Help bar support for PAYG users', () => {
   beforeEach(() =>
     cy.flush().then(() =>
       cy.signin().then(() => {
-        cy.setFeatureFlags({multiOrg: true}).then(() => {
-          cy.get('@org').then(() => {
-            cy.quartzProvision({
-              accountType: 'pay_as_you_go',
-            }).then(() => {
-              cy.visit('/')
-              cy.getByTestID('nav-item-support').should('be.visible')
-            })
+        cy.get('@org').then(() => {
+          cy.quartzProvision({
+            accountType: 'pay_as_you_go',
+          }).then(() => {
+            cy.visit('/')
+            cy.getByTestID('nav-item-support').should('be.visible')
           })
         })
       })

--- a/cypress/e2e/cloud/operator.test.ts
+++ b/cypress/e2e/cloud/operator.test.ts
@@ -2,16 +2,14 @@ describe('Operator Page', () => {
   beforeEach(() =>
     cy.flush().then(() =>
       cy.signin().then(() => {
-        cy.setFeatureFlags({multiOrg: true}).then(() => {
-          cy.get('@org').then(() => {
-            cy.getByTestID('home-page--header').should('be.visible')
-            cy.quartzProvision({
-              isOperator: true,
-              operatorRole: 'read-write',
-            }).then(() => {
-              cy.visit(`/operator`)
-              cy.getByTestID('operator-page--title').contains('2.0 Resources')
-            })
+        cy.get('@org').then(() => {
+          cy.getByTestID('home-page--header').should('be.visible')
+          cy.quartzProvision({
+            isOperator: true,
+            operatorRole: 'read-write',
+          }).then(() => {
+            cy.visit(`/operator`)
+            cy.getByTestID('operator-page--title').contains('2.0 Resources')
           })
         })
       })

--- a/cypress/e2e/cloud/operatorRO.test.ts
+++ b/cypress/e2e/cloud/operatorRO.test.ts
@@ -10,7 +10,6 @@ describe('Operator Page', () => {
           }).then(() => {
             cy.reload()
             cy.setFeatureFlags({
-              multiOrg: true,
               operatorRole: true,
             }).then(() => {
               cy.getByTestID('nav-item--operator').click()

--- a/cypress/e2e/cloud/subscriptions.test.ts
+++ b/cypress/e2e/cloud/subscriptions.test.ts
@@ -13,10 +13,6 @@ describe('Subscriptions', () => {
             }).then(() => {
               cy.visit(`${orgs}/${id}/load-data/sources`)
 
-              cy.setFeatureFlags({
-                multiOrg: true,
-              })
-
               cy.getByTestID('subscriptions--tab').should('be.visible')
               cy.intercept('POST', `/api/v2private/broker/subs*`).as(
                 'CreateSubscription'

--- a/cypress/e2e/cloud/usage.test.ts
+++ b/cypress/e2e/cloud/usage.test.ts
@@ -18,7 +18,6 @@ describe('Usage Page Free User No Data', () => {
           }).then(() => {
             cy.visit(`/orgs/${id}/usage`)
             cy.getByTestID('usage-page--header').should('be.visible')
-            cy.setFeatureFlags({multiOrg: true})
           })
         })
       })
@@ -109,7 +108,6 @@ describe('Usage Page PAYG With Data', () => {
           }).then(() => {
             cy.visit(`/orgs/${id}/usage`)
             cy.getByTestID('usage-page--header').should('be.visible')
-            cy.setFeatureFlags({multiOrg: true})
           })
         })
       })

--- a/cypress/e2e/cloud/userAccounts.test.ts
+++ b/cypress/e2e/cloud/userAccounts.test.ts
@@ -5,12 +5,7 @@ const doSetup = cy => {
     cy.signin().then(() => {
       cy.get('@org').then(({id}: Organization) => {
         cy.visit(`/orgs/${id}/accounts/settings`)
-        cy.setFeatureFlags({
-          multiAccount: true,
-          multiOrg: true,
-        }).then(() => {
-          cy.wait(300)
-        })
+        cy.wait(300)
       })
     })
   })

--- a/cypress/e2e/cloud/userProfile.test.ts
+++ b/cypress/e2e/cloud/userProfile.test.ts
@@ -1,8 +1,3 @@
-// Constants
-const userProfileFeatureFlags = {
-  multiOrg: true,
-}
-
 export const singleAccount = [
   {
     id: 1,
@@ -63,12 +58,10 @@ export const setupProfile = (): Promise<any> => {
           })
           cy.visit('/')
           cy.getByTestID('home-page--header').should('be.visible')
-          cy.setFeatureFlags(userProfileFeatureFlags).then(() => {
-            // cy.wait($time) is necessary to consistently ensure sufficient time for the feature flag override.
-            // The flag reset happens via redux, (it's not a network request), so we can't cy.wait($intercepted_route).
-            cy.wait(1200).then(() => {
-              cy.visit('/me/profile')
-            })
+          // cy.wait($time) is necessary to consistently ensure sufficient time for the feature flag override.
+          // The flag reset happens via redux, (it's not a network request), so we can't cy.wait($intercepted_route).
+          cy.wait(1200).then(() => {
+            cy.visit('/me/profile')
           })
         })
       })

--- a/cypress/e2e/cloud/users.test.ts
+++ b/cypress/e2e/cloud/users.test.ts
@@ -4,14 +4,12 @@ describe('Users Page', () => {
   beforeEach(() => {
     cy.flush().then(() =>
       cy.signin().then(() => {
-        cy.setFeatureFlags({multiOrg: true}).then(() => {
-          cy.get('@org').then(({id}: Organization) => {
-            cy.quartzProvision({
-              hasUsers: true,
-            }).then(() => {
-              cy.visit(`/orgs/${id}/members`)
-              cy.getByTestID('users-page--header').should('be.visible')
-            })
+        cy.get('@org').then(({id}: Organization) => {
+          cy.quartzProvision({
+            hasUsers: true,
+          }).then(() => {
+            cy.visit(`/orgs/${id}/members`)
+            cy.getByTestID('users-page--header').should('be.visible')
           })
         })
       })

--- a/cypress/e2e/cloud/zuoraOutage.test.ts
+++ b/cypress/e2e/cloud/zuoraOutage.test.ts
@@ -7,7 +7,6 @@ describe('Billing Page Free Users', () => {
         cy.get('@org').then(() => {
           cy.setFeatureFlags({
             quartzZuoraDisabled: true,
-            multiOrg: true,
           }).then(() => {
             cy.quartzProvision({
               accountType: 'free',
@@ -36,7 +35,6 @@ describe('Billing Page PAYG Users', () => {
           }).then(() => {
             cy.setFeatureFlags({
               quartzZuoraDisabled: true,
-              multiOrg: true,
             }).then(() => {
               cy.wait(1000)
               cy.visit(`/orgs/${id}/billing`)


### PR DESCRIPTION
Connects #4055 

Removes references in `cy.setFeatureFlags` to the `multiOrg` flag, which is no longer present in the UI.

This PR should be reviewed with ?w=1 - otherwise, it's difficult to see what was removed.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - NO
