### PR TITLE
fix: oss validates the slack endpoint for url correctness

### DIFF
--- a/cypress/e2e/shared/notificationEndpoints.test.ts
+++ b/cypress/e2e/shared/notificationEndpoints.test.ts
@@ -13,7 +13,7 @@ describe('Notification Endpoints', () => {
     description: 'interrupt everyone at work',
     status: 'active',
     type: 'slack',
-    url: 'insert.slack.url.here',
+    url: 'http://api.slack.com',
     token: 'plerps',
   }
 
@@ -371,7 +371,7 @@ describe('Notification Endpoints', () => {
           'В литературе, как, впрочем, и других областях искусства, есть статисты, классики и бунтари.',
         status: 'active',
         type: 'slack',
-        url: 'insert.slack.url.here',
+        url: 'http://api.slack.com',
         token: 'plerps',
       },
       {


### PR DESCRIPTION
On notification endpoint creation, OSS parses the url to validate that it is the proper format. These tests failed as a result of that change.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change

