### PR TITLE
fix(Authenticate.tsx): call idpe/me to maintain backwards compatibility

### DIFF
--- a/src/Authenticate.tsx
+++ b/src/Authenticate.tsx
@@ -104,6 +104,9 @@ class AuthenticateUnconnected extends PureComponent<Props, State> {
     try {
       if (isFlagEnabled('quartzSession')) {
         await this.props.getQuartzIdentityThunkNoErrorHandling()
+        // TODO: completing https://github.com/influxdata/ui/issues/5826 will make this
+        // line unnecessary
+        await this.props.getIdpeMeThunk()
       } else {
         await this.props.getIdpeMeThunk()
       }


### PR DESCRIPTION
This fixes a bug found in prod that was temporarily fixed by flipping a feature flag off.

This PR https://github.com/influxdata/ui/pull/6038 broke some functionality to the API which required a user id when the component making the request to the api used the legacy method (ipde me vs quartz identity) of retreiving the user id. This adds the call back in until https://github.com/influxdata/ui/issues/5826 can be addressed.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- ~[ ] Documentation updated or issue created (provide link to issue/PR)~
- ~[ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~
- ~[ ] Feature flagged, if applicable~
