### PR TITLE
feat: make custom time ranges smarter

### DIFF
--- a/src/shared/components/dateRangePicker/NewDatePicker.tsx
+++ b/src/shared/components/dateRangePicker/NewDatePicker.tsx
@@ -77,8 +77,9 @@ const DatePickerMenu: FC<Props> = ({onCollapse, timeRange, timeRangeLabel}) => {
     collapse()
   }
 
+  const durationRegExp = /([0-9]+)(y|mo|w|d|h|ms|s|m|us|µs|ns)$/g
+
   const validateInput = value => {
-    const durationRegExp = /([0-9]+)(y|mo|w|d|h|ms|s|m|us|µs|ns)$/g
     return (
       isValidDatepickerFormat(value) ||
       !!value.match(durationRegExp) ||
@@ -89,7 +90,9 @@ const DatePickerMenu: FC<Props> = ({onCollapse, timeRange, timeRangeLabel}) => {
 
   const handleSetStartDate = event => {
     const value = event.target.value
-    if (validateInput(value)) {
+    if (!value) {
+      setInputStartErrorMessage('from field required')
+    } else if (validateInput(value)) {
       if (inputStartErrorMessage !== NBSP) {
         setInputStartErrorMessage(NBSP)
       }
@@ -183,45 +186,36 @@ const DatePickerMenu: FC<Props> = ({onCollapse, timeRange, timeRangeLabel}) => {
   }
 
   const handleApplyTimeRange = collapse => {
-    // no start or end date
-    if (inputStartDate == null && inputEndDate == null) {
-      setInputStartErrorMessage('from field required')
+    if (
+      !inputStartDate.match(durationRegExp) &&
+      !isNaN(Number(inputStartDate))
+    ) {
+      setInputStartDate(`${inputStartDate}ms`)
+    } else if (validateInput(inputStartDate)) {
+      if (!inputEndDate) {
+        setRange({
+          lower: inputStartDate,
+          upper: 'now()',
+          type: 'custom',
+        })
+        resetCalendar()
+        collapse()
+      } else if (validateInput(inputEndDate)) {
+        setRange({
+          lower: inputStartDate,
+          upper: inputEndDate,
+          type: 'custom',
+        })
+        resetCalendar()
+        collapse()
+      }
     }
-    if (validateInput(inputStartDate) && inputEndDate == null) {
-      setRange({
-        lower: inputStartDate,
-        upper: 'now()',
-        type: 'custom',
-      })
-      resetCalendar()
-      collapse()
-      return
-    }
-    // valid start date, valid end date
-    if (validateInput(inputStartDate) && validateInput(inputEndDate)) {
-      setRange({
-        lower: inputStartDate,
-        upper: inputEndDate,
-        type: 'custom',
-      })
-      resetCalendar()
-      collapse()
-      return
-    }
-    // valid start date, invalid end date
-    if (validateInput(inputStartDate) && !validateInput(inputEndDate)) {
-      setInputEndErrorMessage('Invalid Format')
-      return
-    }
-    // invalid start date, valid end date
-    if (!validateInput(inputStartDate) && validateInput(inputEndDate)) {
+
+    if (!validateInput(inputStartDate)) {
       setInputStartErrorMessage('Invalid Format')
-      return
     }
-    if (!validateInput(inputStartDate) && !validateInput(inputEndDate)) {
-      setInputStartErrorMessage('Invalid Format')
+    if (!validateInput(inputEndDate)) {
       setInputEndErrorMessage('Invalid Format')
-      return
     }
   }
 

--- a/src/shared/components/dateRangePicker/NewDatePicker.tsx
+++ b/src/shared/components/dateRangePicker/NewDatePicker.tsx
@@ -275,12 +275,10 @@ const DatePickerMenu: FC<Props> = ({onCollapse, timeRange, timeRangeLabel}) => {
                 tooltipContents={
                   <>
                     Use a relative duration (now(), -1h, -5m),{'\n'}
-                    absolute time (2022-08-28 14:26:00),{'\n'}
-                    or integer (Unix timestamp in seconds,{'\n'}
-                    like 1567029600).&nbsp;
+                    or absolute time (2022-08-28 14:26:00).
                   </>
                 }
-                tooltipStyle={{maxWidth: 285}}
+                tooltipStyle={{maxWidth: 290}}
               />
             </InputLabel>
             <Form.Element

--- a/src/shared/components/dateRangePicker/NewDatePicker.tsx
+++ b/src/shared/components/dateRangePicker/NewDatePicker.tsx
@@ -186,11 +186,20 @@ const DatePickerMenu: FC<Props> = ({onCollapse, timeRange, timeRangeLabel}) => {
   }
 
   const handleApplyTimeRange = collapse => {
-    if (
-      !inputStartDate.match(durationRegExp) &&
-      !isNaN(Number(inputStartDate))
-    ) {
-      setInputStartDate(`${inputStartDate}ms`)
+    const isInputStartDateDuration =
+      !inputStartDate.match(durationRegExp) && !isNaN(Number(inputStartDate))
+    const isInputEndDateDuration =
+      inputEndDate &&
+      !inputEndDate.match(durationRegExp) &&
+      !isNaN(Number(inputEndDate))
+
+    if (isInputStartDateDuration || isInputEndDateDuration) {
+      if (isInputStartDateDuration) {
+        setInputStartDate(`${inputStartDate}ms`)
+      }
+      if (isInputEndDateDuration) {
+        setInputEndDate(`${inputEndDate}ms`)
+      }
     } else if (validateInput(inputStartDate)) {
       if (!inputEndDate) {
         setRange({

--- a/src/shared/utils/duration.ts
+++ b/src/shared/utils/duration.ts
@@ -9,6 +9,9 @@ import {TIME_RANGE_FORMAT} from 'src/shared/constants/timeRanges'
 import {createDateTimeFormatter} from 'src/utils/datetime/formatters'
 
 export const removeSpacesAndNow = (input: string): string =>
+  input.replace(/\s/g, '').replace(/now\(\)/, '')
+
+export const removeSpacesNowAndMinus = (input: string): string =>
   input.replace(/\s/g, '').replace(/now\(\)-/, '')
 
 export const isDurationWithNowParseable = (lower: string): boolean => {
@@ -17,7 +20,7 @@ export const isDurationWithNowParseable = (lower: string): boolean => {
     return false
   }
   // warning! Using string.match(regex) here instead of regex.test(string) because regex.test() modifies the regex object, and can lead to unexpected behavior
-  const removedLower = removeSpacesAndNow(lower)
+  const removedLower = removeSpacesNowAndMinus(lower)
 
   return !!removedLower.match(durationRegExp)
 }
@@ -126,7 +129,7 @@ export const timeRangeToDuration = (timeRange: TimeRange): string => {
     throw new Error('cannot convert time range to duration')
   }
 
-  return removeSpacesAndNow(timeRange.lower)
+  return removeSpacesNowAndMinus(timeRange.lower)
 }
 
 export const convertTimeRangeToCustom = (

--- a/src/shared/utils/duration.ts
+++ b/src/shared/utils/duration.ts
@@ -8,9 +8,6 @@ import {Duration, DurationUnit} from 'src/types/ast'
 import {TIME_RANGE_FORMAT} from 'src/shared/constants/timeRanges'
 import {createDateTimeFormatter} from 'src/utils/datetime/formatters'
 
-export const removeSpacesAndNow = (input: string): string =>
-  input.replace(/\s/g, '').replace(/now\(\)/, '')
-
 export const removeSpacesNowAndMinus = (input: string): string =>
   input.replace(/\s/g, '').replace(/now\(\)-/, '')
 

--- a/src/timeMachine/selectors/index.test.ts
+++ b/src/timeMachine/selectors/index.test.ts
@@ -1,4 +1,8 @@
-import {getStartTime, getEndTime} from 'src/timeMachine/selectors/index'
+import {
+  getStartTime,
+  getEndTime,
+  handleCustomTime,
+} from 'src/timeMachine/selectors/index'
 import moment from 'moment'
 
 import {
@@ -10,48 +14,174 @@ import {
 const custom = 'custom' as 'custom'
 
 describe('TimeMachine.Selectors.Index', () => {
-  const thirty = moment()
-    .subtract(30, 'days')
-    .subtract(moment().isDST() ? 1 : 0, 'hours') // added to account for DST
-    .valueOf()
-  it(`getStartTime should return ${thirty} when lower is now() - 30d`, () => {
-    expect(getStartTime(pastThirtyDaysTimeRange)).toBeGreaterThanOrEqual(thirty)
+  describe('getStartTime and getEndTime', () => {
+    const thirty = moment()
+      .subtract(30, 'days')
+      .subtract(moment().isDST() ? 1 : 0, 'hours') // added to account for DST
+      .valueOf()
+    it(`getStartTime should return ${thirty} when lower is now() - 30d`, () => {
+      expect(getStartTime(pastThirtyDaysTimeRange)).toBeGreaterThanOrEqual(
+        thirty
+      )
+    })
+
+    const hour = moment().subtract(1, 'hours').valueOf()
+    it(`getStartTime should return ${hour} when lower is now() - 1h`, () => {
+      expect(getStartTime(pastHourTimeRange)).toBeGreaterThanOrEqual(hour)
+    })
+
+    const fifteen = moment().subtract(15, 'minutes').valueOf()
+    it(`getStartTime should return ${hour} when lower is now() - 1h`, () => {
+      expect(getStartTime(pastFifteenMinTimeRange)).toBeGreaterThanOrEqual(
+        fifteen
+      )
+    })
+
+    const date = '2019-01-01'
+    const newYears = new Date(date).valueOf()
+    it(`getStartTime should return ${newYears} when lower is ${date}`, () => {
+      const timeRange = {
+        type: custom,
+        lower: date,
+        upper: date,
+      }
+      expect(getStartTime(timeRange)).toEqual(newYears)
+    })
+
+    it(`getEndTime should return ${newYears} when lower is ${date}`, () => {
+      const timeRange = {
+        type: custom,
+        lower: date,
+        upper: date,
+      }
+      expect(getEndTime(timeRange)).toEqual(newYears)
+    })
+
+    const now = new Date().valueOf()
+    it(`getEndTime should return ${now} when upper is null and lower includes now()`, () => {
+      expect(getEndTime(pastThirtyDaysTimeRange)).toBeGreaterThanOrEqual(now)
+    })
   })
 
-  const hour = moment().subtract(1, 'hours').valueOf()
-  it(`getStartTime should return ${hour} when lower is now() - 1h`, () => {
-    expect(getStartTime(pastHourTimeRange)).toBeGreaterThanOrEqual(hour)
-  })
+  describe('handleCustomTime', () => {
+    const now = new Date()
 
-  const fifteen = moment().subtract(15, 'minutes').valueOf()
-  it(`getStartTime should return ${hour} when lower is now() - 1h`, () => {
-    expect(getStartTime(pastFifteenMinTimeRange)).toBeGreaterThanOrEqual(
-      fifteen
-    )
-  })
+    it('can parse just "now"', () => {
+      expect(handleCustomTime('now()', now)).toEqual(now.getTime())
+    })
 
-  const date = '2019-01-01'
-  const newYears = new Date(date).valueOf()
-  it(`getStartTime should return ${newYears} when lower is ${date}`, () => {
-    const timeRange = {
-      type: custom,
-      lower: date,
-      upper: date,
-    }
-    expect(getStartTime(timeRange)).toEqual(newYears)
-  })
+    it('can parse now() and a duration', () => {
+      const threeDays = 1000 * 60 * 60 * 24 * 3
+      expect(handleCustomTime('now() - 3d', now)).toEqual(
+        now.getTime() - threeDays
+      )
+      expect(handleCustomTime('now() + 3d', now)).toEqual(
+        now.getTime() + threeDays
+      )
 
-  it(`getEndTime should return ${newYears} when lower is ${date}`, () => {
-    const timeRange = {
-      type: custom,
-      lower: date,
-      upper: date,
-    }
-    expect(getEndTime(timeRange)).toEqual(newYears)
-  })
+      const twentyFourHours = 1000 * 60 * 60 * 24
+      expect(handleCustomTime('now() - 24h', now)).toEqual(
+        now.getTime() - twentyFourHours
+      )
+      expect(handleCustomTime('now() + 24h', now)).toEqual(
+        now.getTime() + twentyFourHours
+      )
 
-  const now = new Date().valueOf()
-  it(`getEndTime should return ${now} when upper is null and lower includes now()`, () => {
-    expect(getEndTime(pastThirtyDaysTimeRange)).toBeGreaterThanOrEqual(now)
+      const fifteenMinutes = 1000 * 60 * 15
+      expect(handleCustomTime('now() - 15m', now)).toEqual(
+        now.getTime() - fifteenMinutes
+      )
+      expect(handleCustomTime('now() + 15m', now)).toEqual(
+        now.getTime() + fifteenMinutes
+      )
+
+      const oneMillisecond = 1
+      expect(handleCustomTime('now() - 1ms', now)).toEqual(
+        now.getTime() - oneMillisecond
+      )
+      expect(handleCustomTime('now() + 1ms', now)).toEqual(
+        now.getTime() + oneMillisecond
+      )
+    })
+
+    it('can parse a duration without now()', () => {
+      const threeDays = 1000 * 60 * 60 * 24 * 3
+      expect(handleCustomTime('-3d', now)).toEqual(now.getTime() - threeDays)
+      expect(handleCustomTime('+3d', now)).toEqual(now.getTime() + threeDays)
+
+      const twentyFourHours = 1000 * 60 * 60 * 24
+      expect(handleCustomTime('-24h', now)).toEqual(
+        now.getTime() - twentyFourHours
+      )
+      expect(handleCustomTime('+24h', now)).toEqual(
+        now.getTime() + twentyFourHours
+      )
+
+      const fifteenMinutes = 1000 * 60 * 15
+      expect(handleCustomTime('-15m', now)).toEqual(
+        now.getTime() - fifteenMinutes
+      )
+      expect(handleCustomTime('+15m', now)).toEqual(
+        now.getTime() + fifteenMinutes
+      )
+
+      const oneMillisecond = 1
+      expect(handleCustomTime('-1ms', now)).toEqual(
+        now.getTime() - oneMillisecond
+      )
+      expect(handleCustomTime('+1ms', now)).toEqual(
+        now.getTime() + oneMillisecond
+      )
+    })
+
+    it('can ignore spaces around now and the sign correctly', () => {
+      expect(handleCustomTime(' now()', now)).toEqual(now.getTime())
+      expect(handleCustomTime('now() ', now)).toEqual(now.getTime())
+      expect(handleCustomTime('        now()  ', now)).toEqual(now.getTime())
+
+      const threeDays = 1000 * 60 * 60 * 24 * 3
+      expect(handleCustomTime(' now() -   3d', now)).toEqual(
+        now.getTime() - threeDays
+      )
+      expect(handleCustomTime('now()+   3d   ', now)).toEqual(
+        now.getTime() + threeDays
+      )
+
+      const twentyFourHours = 1000 * 60 * 60 * 24
+      expect(handleCustomTime('-   24h', now)).toEqual(
+        now.getTime() - twentyFourHours
+      )
+      expect(handleCustomTime('           +  24h', now)).toEqual(
+        now.getTime() + twentyFourHours
+      )
+
+      const fifteenMinutes = 1000 * 60 * 15
+      expect(handleCustomTime(' 15m', now)).toEqual(
+        now.getTime() + fifteenMinutes
+      )
+      expect(handleCustomTime('15m          ', now)).toEqual(
+        now.getTime() + fifteenMinutes
+      )
+      expect(handleCustomTime('    15m          ', now)).toEqual(
+        now.getTime() + fifteenMinutes
+      )
+    })
+
+    it('can parse a JavaScript timestamp as a string', () => {
+      let specificTimeString: string = '2022-10-14T20:33:01.433Z'
+      expect(handleCustomTime(specificTimeString, now)).toEqual(
+        new Date(specificTimeString).getTime()
+      )
+
+      specificTimeString = '2022/07/04'
+      expect(handleCustomTime(specificTimeString, now)).toEqual(
+        new Date(specificTimeString).getTime()
+      )
+
+      specificTimeString = '2022-10-06 00:00'
+      expect(handleCustomTime(specificTimeString, now)).toEqual(
+        new Date(specificTimeString).getTime()
+      )
+    })
   })
 })

--- a/src/timeMachine/selectors/index.test.ts
+++ b/src/timeMachine/selectors/index.test.ts
@@ -176,5 +176,16 @@ describe('TimeMachine.Selectors.Index', () => {
         new Date(specificTimeString).getTime()
       )
     })
+
+    it('rejects numbers as invalid time', () => {
+      let numberString = '1666029415'
+      expect(() => handleCustomTime(numberString, now)).toThrowError()
+
+      numberString = '0'
+      expect(() => handleCustomTime(numberString, now)).toThrowError()
+
+      numberString = '-4'
+      expect(() => handleCustomTime(numberString, now)).toThrowError()
+    })
   })
 })

--- a/src/timeMachine/selectors/index.test.ts
+++ b/src/timeMachine/selectors/index.test.ts
@@ -65,13 +65,16 @@ describe('TimeMachine.Selectors.Index', () => {
 
   describe('handleCustomTime', () => {
     const now = new Date()
+    const threeDays = 1000 * 60 * 60 * 24 * 3
+    const twentyFourHours = 1000 * 60 * 60 * 24
+    const fifteenMinutes = 1000 * 60 * 15
+    const oneMillisecond = 1
 
     it('can parse just "now"', () => {
       expect(handleCustomTime('now()', now)).toEqual(now.getTime())
     })
 
     it('can parse now() and a duration', () => {
-      const threeDays = 1000 * 60 * 60 * 24 * 3
       expect(handleCustomTime('now() - 3d', now)).toEqual(
         now.getTime() - threeDays
       )
@@ -79,7 +82,6 @@ describe('TimeMachine.Selectors.Index', () => {
         now.getTime() + threeDays
       )
 
-      const twentyFourHours = 1000 * 60 * 60 * 24
       expect(handleCustomTime('now() - 24h', now)).toEqual(
         now.getTime() - twentyFourHours
       )
@@ -87,7 +89,6 @@ describe('TimeMachine.Selectors.Index', () => {
         now.getTime() + twentyFourHours
       )
 
-      const fifteenMinutes = 1000 * 60 * 15
       expect(handleCustomTime('now() - 15m', now)).toEqual(
         now.getTime() - fifteenMinutes
       )
@@ -95,7 +96,6 @@ describe('TimeMachine.Selectors.Index', () => {
         now.getTime() + fifteenMinutes
       )
 
-      const oneMillisecond = 1
       expect(handleCustomTime('now() - 1ms', now)).toEqual(
         now.getTime() - oneMillisecond
       )
@@ -105,11 +105,9 @@ describe('TimeMachine.Selectors.Index', () => {
     })
 
     it('can parse a duration without now()', () => {
-      const threeDays = 1000 * 60 * 60 * 24 * 3
       expect(handleCustomTime('-3d', now)).toEqual(now.getTime() - threeDays)
       expect(handleCustomTime('+3d', now)).toEqual(now.getTime() + threeDays)
 
-      const twentyFourHours = 1000 * 60 * 60 * 24
       expect(handleCustomTime('-24h', now)).toEqual(
         now.getTime() - twentyFourHours
       )
@@ -117,7 +115,6 @@ describe('TimeMachine.Selectors.Index', () => {
         now.getTime() + twentyFourHours
       )
 
-      const fifteenMinutes = 1000 * 60 * 15
       expect(handleCustomTime('-15m', now)).toEqual(
         now.getTime() - fifteenMinutes
       )
@@ -125,7 +122,6 @@ describe('TimeMachine.Selectors.Index', () => {
         now.getTime() + fifteenMinutes
       )
 
-      const oneMillisecond = 1
       expect(handleCustomTime('-1ms', now)).toEqual(
         now.getTime() - oneMillisecond
       )
@@ -139,7 +135,6 @@ describe('TimeMachine.Selectors.Index', () => {
       expect(handleCustomTime('now() ', now)).toEqual(now.getTime())
       expect(handleCustomTime('        now()  ', now)).toEqual(now.getTime())
 
-      const threeDays = 1000 * 60 * 60 * 24 * 3
       expect(handleCustomTime(' now() -   3d', now)).toEqual(
         now.getTime() - threeDays
       )
@@ -147,7 +142,6 @@ describe('TimeMachine.Selectors.Index', () => {
         now.getTime() + threeDays
       )
 
-      const twentyFourHours = 1000 * 60 * 60 * 24
       expect(handleCustomTime('-   24h', now)).toEqual(
         now.getTime() - twentyFourHours
       )
@@ -155,7 +149,6 @@ describe('TimeMachine.Selectors.Index', () => {
         now.getTime() + twentyFourHours
       )
 
-      const fifteenMinutes = 1000 * 60 * 15
       expect(handleCustomTime(' 15m', now)).toEqual(
         now.getTime() + fifteenMinutes
       )

--- a/src/timeMachine/selectors/index.ts
+++ b/src/timeMachine/selectors/index.ts
@@ -268,8 +268,7 @@ export const getSymbolColumnsSelection = (state: AppState): string[] => {
   There are 2 types of custom time:
   I. Flux duration, including signed and unsigned durations
      examples: -15m, -24h, +3d, 5mo
-  II. JavaScript time: any valid string argument to the `new Date()` constructor
-     examples: '2022-10-14T20:33:01.433Z', '2022/07/04', '2022-10-06 00:00'
+  II. RFC 3339 date format as a string
  */
 export const handleCustomTime = (input: string, now: Date): number => {
   // Flux duration
@@ -295,7 +294,7 @@ export const handleCustomTime = (input: string, now: Date): number => {
     return now.getTime() + durationToMilliseconds(parseDuration(timeInput))
   }
 
-  // JavaScript time stamp for the `new Date()` constructor
+  // RFC 3339 date format as a string
   const timeInputDate = new Date(timeInput)
   if (timeInputDate.toTimeString() === 'Invalid Date') {
     throw new Error(`Unknown custom time: ${timeInput}`)

--- a/src/timeMachine/selectors/index.ts
+++ b/src/timeMachine/selectors/index.ts
@@ -269,9 +269,9 @@ export const getSymbolColumnsSelection = (state: AppState): string[] => {
      examples: -15m, -24h, +3d, 5mo
   II. RFC 3339 date format as a string
  */
-export const handleCustomTime = (input: string, now: Date): number => {
+export const handleCustomTime = (input: string = '', now: Date): number => {
   // Flux duration
-  let timeInput = input ? input.trim() : ''
+  let timeInput = input.trim()
   let isNegativeDuration = false
 
   if (timeInput === 'now()') {
@@ -291,6 +291,11 @@ export const handleCustomTime = (input: string, now: Date): number => {
       return now.getTime() - durationToMilliseconds(parseDuration(timeInput))
     }
     return now.getTime() + durationToMilliseconds(parseDuration(timeInput))
+  }
+
+  // Explicitly reject numbers because Flux's Unix timestamp will be deprecated
+  if (!Number.isNaN(Number(timeInput))) {
+    throw new Error(`Numbered timestamp: ${timeInput} is not supported`)
   }
 
   // RFC 3339 date format as a string

--- a/src/timeMachine/selectors/index.ts
+++ b/src/timeMachine/selectors/index.ts
@@ -24,7 +24,6 @@ import {
   isDurationWithNowParseable,
   millisecondsToDuration,
   parseDuration,
-  removeSpacesAndNow,
   timeRangeToDuration,
 } from 'src/shared/utils/duration'
 
@@ -280,7 +279,7 @@ export const handleCustomTime = (input: string, now: Date): number => {
   }
 
   if (isDurationWithNowParseable(timeInput)) {
-    timeInput = removeSpacesAndNow(timeInput)
+    timeInput = timeInput.replace(/\s/g, '').replace(/now\(\)/, '')
   }
 
   if (timeInput[0] === '-' || timeInput[0] === '+') {

--- a/src/timeMachine/selectors/index.ts
+++ b/src/timeMachine/selectors/index.ts
@@ -19,10 +19,13 @@ import {
   getWindowPeriodFromVariables,
 } from 'src/variables/utils/getWindowVars'
 import {
-  timeRangeToDuration,
-  parseDuration,
   durationToMilliseconds,
+  isDurationParseable,
+  isDurationWithNowParseable,
   millisecondsToDuration,
+  parseDuration,
+  removeSpacesAndNow,
+  timeRangeToDuration,
 } from 'src/shared/utils/duration'
 
 // Selectors
@@ -261,13 +264,53 @@ export const getSymbolColumnsSelection = (state: AppState): string[] => {
   )
 }
 
+/*
+  There are 2 types of custom time:
+  I. Flux duration, including signed and unsigned durations
+     examples: -15m, -24h, +3d, 5mo
+  II. JavaScript time: any valid string argument to the `new Date()` constructor
+     examples: '2022-10-14T20:33:01.433Z', '2022/07/04', '2022-10-06 00:00'
+ */
+export const handleCustomTime = (input: string, now: Date): number => {
+  // Flux duration
+  let timeInput = input ? input.trim() : ''
+  let isNegativeDuration = false
+
+  if (timeInput === 'now()') {
+    return now.getTime()
+  }
+
+  if (isDurationWithNowParseable(timeInput)) {
+    timeInput = removeSpacesAndNow(timeInput)
+  }
+
+  if (timeInput[0] === '-' || timeInput[0] === '+') {
+    isNegativeDuration = timeInput[0] === '-'
+    timeInput = timeInput.slice(1).trim()
+  }
+  if (isDurationParseable(timeInput)) {
+    if (isNegativeDuration) {
+      return now.getTime() - durationToMilliseconds(parseDuration(timeInput))
+    }
+    return now.getTime() + durationToMilliseconds(parseDuration(timeInput))
+  }
+
+  // JavaScript time stamp for the `new Date()` constructor
+  const timeInputDate = new Date(timeInput)
+  if (timeInputDate.toTimeString() === 'Invalid Date') {
+    throw new Error(`Unknown custom time: ${timeInput}`)
+  }
+  return timeInputDate.getTime()
+}
+
 export const getStartTime = (timeRange: TimeRange) => {
   if (!timeRange) {
     return Infinity
   }
+  const now = new Date()
   switch (timeRange.type) {
     case 'custom':
-      return new Date(timeRange.lower).valueOf()
+      return handleCustomTime(timeRange.lower, now)
     case 'selectable-duration': {
       const startTime = new Date()
       startTime.setSeconds(startTime.getSeconds() - timeRange.seconds)
@@ -294,8 +337,9 @@ export const getEndTime = (timeRange: TimeRange): number => {
   if (!timeRange) {
     return null
   }
+  const now = new Date()
   if (timeRange.type === 'custom') {
-    return new Date(timeRange.upper).valueOf()
+    return handleCustomTime(timeRange.upper, now)
   }
   return new Date().valueOf()
 }


### PR DESCRIPTION
Closes #6058 

`NewDatePicker` allows:
- `From` and `To` fields can be Flux syntax
- `From` field cannot be blank and is enforced with input validation
- `To` field can be blank and will be updated with `now()` via auto-injection if it is blank
- numbers are interpreted as Unix timestamps in **seconds** (per Flux specification)
- timestamps must be RFC 3339 format or from clicking the calendar



https://user-images.githubusercontent.com/10736577/196080899-a52da651-5210-4345-bffe-9c0500f785ee.mp4





