### PR TITLE
chore: fix broken checkout test and related form validation issue

### DIFF
--- a/cypress/e2e/cloud/checkout/checkoutpage.test.ts
+++ b/cypress/e2e/cloud/checkout/checkoutpage.test.ts
@@ -27,135 +27,127 @@ describe('Checkout Page Works', () => {
   )
 
   it('should render the checkout page and allow for pointing and clicking', () => {
-    cy.setFeatureFlagsNoNav({
-      multiOrg: true,
-    }).then(() => {
-      const email = 'asalem@influxdata.com'
-      const limit = 10
-      const numberError = 'Please enter a value of 1 or greater'
-      const genericError = 'This is a required field'
+    const email = 'asalem@influxdata.com'
+    const limit = 10
+    const numberError = 'Please enter a value of 1 or greater'
+    const genericError = 'This is a required field'
 
-      cy.getByTestID('shouldNotify--checkbox--input').should('be.checked')
+    cy.getByTestID('shouldNotify--checkbox--input').should('be.checked')
 
-      resetInputs()
+    resetInputs()
 
-      // Click Upgrade
-      cy.getByTestID('checkout-upgrade--button').click()
+    // Click Upgrade
+    cy.getByTestID('checkout-upgrade--button').click()
 
-      // Check all errors are visible
-      cy.getByTestID('balanceThreshold--input').scrollIntoView()
-      cy.getByTestID('balanceThreshold--form-element-error').should(
-        'be.visible'
-      )
-      cy.getByTestID('balanceThreshold--form-element-error').contains(
-        genericError
-      )
-      cy.getByTestID('notifyEmail--form-element-error').should('be.visible')
-      cy.getByTestID('notifyEmail--form-element-error').contains(genericError)
+    // Check all errors are visible
+    cy.getByTestID('balanceThreshold--input').scrollIntoView()
+    cy.getByTestID('balanceThreshold--form-element-error').should('be.visible')
+    cy.getByTestID('balanceThreshold--form-element-error').contains(
+      genericError
+    )
+    cy.getByTestID('notifyEmail--form-element-error').should('be.visible')
+    cy.getByTestID('notifyEmail--form-element-error').contains(genericError)
 
-      // Check balance threshold specific error should exist
-      cy.getByTestID('balanceThreshold--input').clear().type('0')
-      cy.getByTestID('balanceThreshold--form-element-error').contains(
-        numberError
-      )
+    // Check balance threshold specific error should exist
+    cy.getByTestID('balanceThreshold--input').clear().type('0')
+    cy.getByTestID('balanceThreshold--form-element-error').contains(numberError)
 
-      cy.getByTestID('notifyEmail--input').clear().type(email)
-      cy.getByTestID('balanceThreshold--input').clear().type(`${limit}`)
+    cy.getByTestID('notifyEmail--input').clear().type(email)
+    cy.getByTestID('balanceThreshold--input').clear().type(`${limit}`)
 
-      // Check all errors are gone
-      cy.getByTestID('balanceThreshold--form-element-error').should('not.exist')
-      cy.getByTestID('notifyEmail--form-element-error').should('not.exist')
+    // Check all errors are gone
+    cy.getByTestID('balanceThreshold--form-element-error').should('not.exist')
+    cy.getByTestID('notifyEmail--form-element-error').should('not.exist')
 
-      // Uncheck Checkbox
-      cy.getByTestID('shouldNotify--checkbox').click()
-      cy.getByTestID('shouldNotify--checkbox--input').should('not.be.checked')
+    // Uncheck Checkbox
+    cy.getByTestID('shouldNotify--checkbox').click()
+    cy.getByTestID('shouldNotify--checkbox--input').should('not.be.checked')
 
-      // Email and limit should still be present after toggling the notifications checkbox
-      cy.getByTestID('shouldNotify--checkbox').click()
-      cy.getByTestID('shouldNotify--checkbox--input').should('be.checked')
-      cy.getByTestID('notifyEmail--input').should('have.value', email)
-      cy.getByTestID('balanceThreshold--input').should('have.value', limit)
+    // Email and limit should still be present after toggling the notifications checkbox
+    cy.getByTestID('shouldNotify--checkbox').click()
+    cy.getByTestID('shouldNotify--checkbox--input').should('be.checked')
+    cy.getByTestID('notifyEmail--input').should('have.value', email)
+    cy.getByTestID('balanceThreshold--input').should('have.value', limit)
 
-      // should render US Billing Address
+    // should render US Billing Address
+    const error = 'This is a required field'
+
+    // Check defaults
+    resetInputs()
+    cy.getByTestID('country--dropdown')
+      .get('.cf-dropdown--selected')
+      .contains('United States')
+    cy.getByTestID('usSubdivision--dropdown')
+      .get('.cf-dropdown--selected')
+      .contains('Alabama')
+
+    cy.getByTestID('checkout-upgrade--button').click()
+
+    cy.getByTestID('city--form-element-error').should('be.visible')
+    cy.getByTestID('city--form-element-error').contains(error)
+    cy.getByTestID('postalCode--form-element-error').should('be.visible')
+    cy.getByTestID('postalCode--form-element-error').contains(error)
+
+    cy.getByTestID('city--input').type('Blacksburg')
+    cy.getByTestID('postalCode--input').type('24060')
+    cy.getByTestID('street1--input').type('Street1 Address')
+    cy.getByTestID('street2--input').type('Street2 Address')
+
+    cy.getByTestID('city--form-element-error').should('not.exist')
+    cy.getByTestID('postalCode--form-element-error').should('not.exist')
+
+    const cases = [
+      {country: 'Canada', state: 'Province'},
+      {country: 'India', state: 'State / Province / Region'},
+    ]
+    cases.forEach(item => {
+      const city = 'TestCity'
       const error = 'This is a required field'
 
-      // Check defaults
       resetInputs()
       cy.getByTestID('country--dropdown')
-        .get('.cf-dropdown--selected')
-        .contains('United States')
-      cy.getByTestID('usSubdivision--dropdown')
-        .get('.cf-dropdown--selected')
-        .contains('Alabama')
+        .click()
+        .getByTestID('dropdown-item')
+        .contains(item.country)
+        .then(i => {
+          i[0].click()
+        })
 
+      // Validate correct country is currently selected
+      cy.getByTestID('country--dropdown')
+        .get('.cf-dropdown--selected')
+        .contains(item.country)
+
+      // Check US State equivalent
+      cy.getByTestID('intlSubdivision--form-element')
+        .get('.cf-form--label-text')
+        .contains(item.state)
+      cy.getByTestID('intlSubdivision--input')
+        .should('be.visible')
+        .should('have.value', '')
+
+      // Click Upgrade Button
       cy.getByTestID('checkout-upgrade--button').click()
 
+      // Check required fields show error
       cy.getByTestID('city--form-element-error').should('be.visible')
       cy.getByTestID('city--form-element-error').contains(error)
-      cy.getByTestID('postalCode--form-element-error').should('be.visible')
-      cy.getByTestID('postalCode--form-element-error').contains(error)
 
-      cy.getByTestID('city--input').type('Blacksburg')
-      cy.getByTestID('postalCode--input').type('24060')
-      cy.getByTestID('street1--input').type('Street1 Address')
-      cy.getByTestID('street2--input').type('Street2 Address')
+      cy.getByTestID('city--input').type(city).should('have.value', city)
 
+      // Click Upgrade Button
+      cy.getByTestID('checkout-upgrade--button').click()
+
+      // Check no errors are visible for billing address form
       cy.getByTestID('city--form-element-error').should('not.exist')
-      cy.getByTestID('postalCode--form-element-error').should('not.exist')
+    })
 
-      const cases = [
-        {country: 'Canada', state: 'Province'},
-        {country: 'India', state: 'State / Province / Region'},
-      ]
-      cases.forEach(item => {
-        const city = 'TestCity'
-        const error = 'This is a required field'
+    // Click Cancel Button
+    cy.getByTestID('checkout-cancel--button').click()
 
-        resetInputs()
-        cy.getByTestID('country--dropdown')
-          .click()
-          .getByTestID('dropdown-item')
-          .contains(item.country)
-          .then(i => {
-            i[0].click()
-          })
-
-        // Validate correct country is currently selected
-        cy.getByTestID('country--dropdown')
-          .get('.cf-dropdown--selected')
-          .contains(item.country)
-
-        // Check US State equivalent
-        cy.getByTestID('intlSubdivision--form-element')
-          .get('.cf-form--label-text')
-          .contains(item.state)
-        cy.getByTestID('intlSubdivision--input')
-          .should('be.visible')
-          .should('have.value', '')
-
-        // Click Upgrade Button
-        cy.getByTestID('checkout-upgrade--button').click()
-
-        // Check required fields show error
-        cy.getByTestID('city--form-element-error').should('be.visible')
-        cy.getByTestID('city--form-element-error').contains(error)
-
-        cy.getByTestID('city--input').type(city).should('have.value', city)
-
-        // Click Upgrade Button
-        cy.getByTestID('checkout-upgrade--button').click()
-
-        // Check no errors are visible for billing address form
-        cy.getByTestID('city--form-element-error').should('not.exist')
-      })
-
-      // Click Cancel Button
-      cy.getByTestID('checkout-cancel--button').click()
-
-      cy.get('@org').then((org: Organization) => {
-        cy.location().should(loc => {
-          expect(loc.pathname).to.include(`/orgs/${org.id}`)
-        })
+    cy.get('@org').then((org: Organization) => {
+      cy.location().should(loc => {
+        expect(loc.pathname).to.include(`/orgs/${org.id}`)
       })
     })
   })

--- a/src/checkout/shared/FormInput.tsx
+++ b/src/checkout/shared/FormInput.tsx
@@ -51,7 +51,6 @@ const FormInput: FC<Props> = ({label, required, id, ...args}) => {
     >
       <Input
         id={id}
-        required={required}
         value={inputs[id]}
         onChange={handleChange}
         testID={`${id}--input`}


### PR DESCRIPTION
Needs to be reviewed with `?w=1` - otherwise makes it look like more lines are changed. Should see this.

![Screen Shot 2022-10-14 at 4 53 49 PM](https://user-images.githubusercontent.com/91283923/195942152-60494300-3e24-412e-9042-c207530d691f.png)


This PR started as an effort to remove a flag toggle from the checkout test. Making edits to that individual test - or even making no changes to the test - resulted in a CI test failure, which didn't make sense. The cause is that the test was already broken, but wasn't being run by our CI pipeline (unless you made edits to this test specifically) because it was in a separate subfolder that wasn't being run by the test runner.

This PR resolves the first part of the issue by fixing the broken test, by removing the `required` from an `<Input />` tag. The `required` was supposed to be present only in the parent component, as having `required` in the child component prevents the form `onSubmit` from running, which prevents the checkout validation from working correctly. I will make a second PR moving the test into the correct folder.

Here's the way the test behaves before (broken form).
--
https://user-images.githubusercontent.com/91283923/195872495-77aa44b1-c32c-452e-8ddb-56ab48d4e15f.mov

Here's the way the test behaves now.
--
https://user-images.githubusercontent.com/91283923/195872600-0bc6e789-cda5-4c96-b19a-ea3b016f5430.mov

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - NO
