### PR TITLE
feat(sub): validate against duplicate field and tag names

### DIFF
--- a/src/types/subscriptions.ts
+++ b/src/types/subscriptions.ts
@@ -6,6 +6,12 @@ export enum BrokerAuthTypes {
   Certificate = 'certificate',
 }
 
+export enum DataFormatTypes {
+  LineProtocol = 'lineprotocol',
+  JSON = 'json',
+  String = 'string',
+}
+
 export interface Subscription {
   id?: string
   name?: string

--- a/src/writeData/subscriptions/components/BrokerForm.scss
+++ b/src/writeData/subscriptions/components/BrokerForm.scss
@@ -97,3 +97,6 @@
     margin-bottom: 30px;
   }
 }
+.cf-status-indicator {
+  top: unset;
+}

--- a/src/writeData/subscriptions/components/JsonPathInput.tsx
+++ b/src/writeData/subscriptions/components/JsonPathInput.tsx
@@ -31,6 +31,7 @@ import {
   sanitizeType,
   dataTypeList,
   handleAvroValidation,
+  handleDuplicateFieldTagName,
 } from 'src/writeData/subscriptions/utils/form'
 import {event} from 'src/cloud/utils/reporting'
 import ValidationInputWithTooltip from './ValidationInputWithTooltip'
@@ -110,7 +111,8 @@ const JsonPathInput: FC<Props> = ({
                 : formContent.jsonFieldKeys[itemNum].name
               return (
                 handleValidation(name, value) ??
-                handleAvroValidation(name, value)
+                handleAvroValidation(name, value) ??
+                handleDuplicateFieldTagName(value, formContent)
               )
             }}
             placeholder={`${name}_name`.toLowerCase()}

--- a/src/writeData/subscriptions/components/ParsingForm.tsx
+++ b/src/writeData/subscriptions/components/ParsingForm.tsx
@@ -16,7 +16,7 @@ import JsonParsingForm from 'src/writeData/subscriptions/components/JsonParsingF
 import LineProtocolForm from 'src/writeData/subscriptions/components/LineProtocolForm'
 
 // Types
-import {Subscription} from 'src/types/subscriptions'
+import {DataFormatTypes, Subscription} from 'src/types/subscriptions'
 
 // Styles
 import 'src/writeData/subscriptions/components/ParsingForm.scss'
@@ -63,20 +63,20 @@ const ParsingForm: FC<Props> = ({
                 updateForm={updateForm}
                 className="create"
               />
-              {formContent.dataFormat === 'lineprotocol' && (
+              {formContent.dataFormat === DataFormatTypes.LineProtocol && (
                 <LineProtocolForm
                   edit={showUpgradeButton ? false : true}
                   formContent={formContent}
                 />
               )}
-              {formContent.dataFormat === 'json' && (
+              {formContent.dataFormat === DataFormatTypes.JSON && (
                 <JsonParsingForm
                   formContent={formContent}
                   updateForm={updateForm}
                   edit={showUpgradeButton ? false : true}
                 />
               )}
-              {formContent.dataFormat === 'string' && (
+              {formContent.dataFormat === DataFormatTypes.String && (
                 <StringParsingForm
                   formContent={formContent}
                   updateForm={updateForm}

--- a/src/writeData/subscriptions/components/StringPatternInput.tsx
+++ b/src/writeData/subscriptions/components/StringPatternInput.tsx
@@ -21,6 +21,7 @@ import {Subscription} from 'src/types/subscriptions'
 import {
   handleRegexValidation,
   handleValidation,
+  handleDuplicateFieldTagName,
   REGEX_TOOLTIP,
 } from 'src/writeData/subscriptions/utils/form'
 import {event} from 'src/cloud/utils/reporting'
@@ -90,14 +91,15 @@ const StringPatternInput: FC<Props> = ({
           tooltip={`This will become the the ${
             tagType ? 'tag' : 'field'
           }'s key`}
-          validationFunc={() =>
-            handleValidation(
-              `${name}`,
-              tagType
-                ? formContent.stringTags[itemNum].name
-                : formContent.stringFields[itemNum].name
+          validationFunc={() => {
+            const value = tagType
+              ? formContent.stringTags[itemNum].name
+              : formContent.stringFields[itemNum].name
+            return (
+              handleValidation(`${name}`, value) ??
+              handleDuplicateFieldTagName(value, formContent)
             )
-          }
+          }}
           placeholder={`${name}_name`.toLowerCase()}
           onChange={e => {
             let newArr

--- a/src/writeData/subscriptions/utils/form.ts
+++ b/src/writeData/subscriptions/utils/form.ts
@@ -6,6 +6,7 @@ import {
   Steps,
   SubscriptionNavigationModel,
   BrokerAuthTypes,
+  DataFormatTypes,
 } from 'src/types/subscriptions'
 import jsonpath from 'jsonpath'
 import {IconFont} from '@influxdata/clockface'
@@ -72,6 +73,41 @@ export const handleValidation = (
     return `${property} is required`
   }
   return null
+}
+
+export const handleDuplicateFieldTagName = (
+  formVal: string,
+  form: Subscription
+) => {
+  switch (form.dataFormat) {
+    case DataFormatTypes.LineProtocol: {
+      return null
+    }
+    case DataFormatTypes.JSON: {
+      const numMatchingFieldNames = form.jsonFieldKeys.filter(
+        k => k.name === formVal
+      ).length
+      const numMatchingTagNames = form.jsonTagKeys.filter(
+        k => k.name === formVal
+      ).length
+      // formVal already exists in form so expect there to be exactly one
+      return numMatchingFieldNames + numMatchingTagNames > 1
+        ? `'${formVal}' name has already been used, unique column names are required`
+        : null
+    }
+    case DataFormatTypes.String: {
+      const numMatchingFieldNames = form.stringFields.filter(
+        k => k.name === formVal
+      ).length
+      const numMatchingTagNames = form.stringTags.filter(
+        k => k.name === formVal
+      ).length
+      // formVal already exists in form so expect there to be exactly one
+      return numMatchingFieldNames + numMatchingTagNames > 1
+        ? `'${formVal}' name has already been used, unique column names are required`
+        : null
+    }
+  }
 }
 
 export const handleJsonPathValidation = (formVal: string): string | null => {


### PR DESCRIPTION
Closes https://github.com/influxdata/data-acquisition/issues/421

Do not allow duplicate field/tag names.

## Json:

<img width="1239" alt="image" src="https://user-images.githubusercontent.com/6411855/195933401-1579b838-786e-4d4f-abff-5a0e24edaba9.png">

## String:

<img width="1257" alt="image" src="https://user-images.githubusercontent.com/6411855/195933493-65f26a1f-1a31-43f3-b5ff-caa27787f1dc.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
