### PR TITLE
fix(sub): do not get subs twice

### DIFF
--- a/src/writeData/subscriptions/context/subscription.list.tsx
+++ b/src/writeData/subscriptions/context/subscription.list.tsx
@@ -124,13 +124,10 @@ export const SubscriptionListProvider: FC = ({children}) => {
     }
   }
   const change = useCallback(
-    async (id: string): Promise<void> => {
-      setLoading(RemoteDataState.Loading)
-      if (!subscriptions) {
-        await getAll()
+    (id: string) => {
+      if (subscriptions) {
+        setCurrentID(id)
       }
-      setCurrentID(id)
-      setLoading(RemoteDataState.Done)
     },
     [setCurrentID, subscriptions]
   )


### PR DESCRIPTION
Closes https://github.com/influxdata/data-acquisition/issues/427

When loading the edit page, only call to get subs once via useEffect

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
