### PR TITLE
chore: add quartz getClusters to API layer

### DIFF
--- a/src/identity/apis/createOrg.ts
+++ b/src/identity/apis/createOrg.ts
@@ -1,0 +1,19 @@
+// API Calls
+import {getClusters} from 'src/client/unityRoutes'
+
+// Types
+import {UnauthorizedError, ServerError} from 'src/identity/apis/auth'
+
+export const fetchClusterList = async () => {
+  const response = await getClusters({})
+
+  if (response.status === 401) {
+    throw new UnauthorizedError(response.data.message)
+  }
+
+  if (response.status === 500) {
+    throw new ServerError(response.data.message)
+  }
+
+  return response.data
+}


### PR DESCRIPTION
Helps with #5932 

Adds UI API layer support for the quartz /clusters endpoint. This retrieves the list of clusters available to the user, so that they can be made available as options when creating a new org.

Not used anywhere yet.

Matching openAPI spec [here](https://github.com/influxdata/openapi/blob/master/src/unity/paths/clusters.yml).

Proof (response from endpoint)
-
![Screen Shot 2022-10-14 at 4 23 44 PM](https://user-images.githubusercontent.com/91283923/195938508-b2be5162-3e3d-4d4e-8caa-3309d47bf25c.png)


### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable
