### PR TITLE
chore: add quartz POST /orgs and GET /clusters routes to API layer

### DIFF
--- a/src/accounts/context/userAccount.tsx
+++ b/src/accounts/context/userAccount.tsx
@@ -22,7 +22,7 @@ import {
   getUserAccounts,
   updateDefaultQuartzAccount,
   updateUserAccount,
-} from 'src/identity/apis/auth'
+} from 'src/identity/apis/account'
 
 // Utils
 import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'

--- a/src/identity/actions/creators/index.ts
+++ b/src/identity/actions/creators/index.ts
@@ -1,5 +1,6 @@
 import {Account} from 'src/client/unityRoutes'
-import {CurrentIdentity, CurrentOrg} from 'src/identity/apis/auth'
+import {CurrentIdentity} from 'src/identity/apis/auth'
+import {CurrentOrg} from 'src/identity/apis/org'
 import {BillingProvider, RemoteDataState} from 'src/types'
 
 export const SET_QUARTZ_IDENTITY = 'SET_QUARTZ_IDENTITY'

--- a/src/identity/actions/thunks/index.ts
+++ b/src/identity/actions/thunks/index.ts
@@ -16,11 +16,9 @@ import {Dispatch} from 'redux'
 type ActionTypes = IdentityActions | NotificationAction
 
 // Utilities
-import {
-  fetchQuartzIdentity,
-  fetchAccountDetails,
-  fetchOrgDetails,
-} from 'src/identity/apis/auth'
+import {fetchQuartzIdentity} from 'src/identity/apis/auth'
+import {fetchAccountDetails} from 'src/identity/apis/account'
+import {fetchOrgDetails} from 'src/identity/apis/org'
 
 // Error Reporting
 import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'

--- a/src/identity/apis/account.ts
+++ b/src/identity/apis/account.ts
@@ -1,0 +1,95 @@
+// APIs
+import {
+  getAccount,
+  getAccounts,
+  patchAccount,
+  putAccountsDefault,
+  Account,
+  IdentityAccount,
+  UserAccount,
+} from 'src/client/unityRoutes'
+
+// Types
+import {
+  GenericError,
+  ServerError,
+  UnauthorizedError,
+  UnprocessableEntityError,
+} from 'src/types/error'
+
+export interface CurrentAccount extends IdentityAccount {
+  billingProvider?: 'zuora' | 'aws' | 'gcm' | 'azure'
+}
+
+// get a list of the user's accounts
+export const getUserAccounts = async (): Promise<UserAccount[]> => {
+  const response = await getAccounts({})
+
+  if (response.status === 401) {
+    throw new UnauthorizedError(response.data.message)
+  }
+  if (response.status === 500) {
+    throw new ServerError(response.data.message)
+  }
+  if (!Array.isArray(response.data)) {
+    throw new GenericError('No account found')
+  }
+
+  return response.data
+}
+
+// fetch more details about one of the user's accounts
+export const fetchAccountDetails = async (
+  accountId: string | number
+): Promise<Account> => {
+  const accountIdString = accountId.toString()
+
+  const response = await getAccount({
+    accountId: accountIdString,
+  })
+
+  if (response.status === 401) {
+    throw new UnauthorizedError(response.data.message)
+  }
+
+  if (response.status === 500) {
+    throw new ServerError(response.data.message)
+  }
+
+  const accountDetails = response.data
+  return accountDetails
+}
+
+// change the user's default account
+export const updateDefaultQuartzAccount = async (
+  accountId: number
+): Promise<void> => {
+  const response = await putAccountsDefault({
+    data: {
+      id: accountId,
+    },
+  })
+
+  if (response.status === 500) {
+    throw new ServerError(response.data.message)
+  }
+
+  // success status code is 204; no response body expected.
+}
+
+// rename the user's current account
+export const updateUserAccount = async (accountId, name) => {
+  const response = await patchAccount({accountId, data: {name}})
+
+  if (response.status === 401) {
+    throw new UnauthorizedError(response.data.message)
+  }
+  if (response.status === 422) {
+    throw new UnprocessableEntityError(response.data.message)
+  }
+  if (response.status === 500) {
+    throw new ServerError(response.data.message)
+  }
+
+  return response.data
+}

--- a/src/identity/apis/auth.ts
+++ b/src/identity/apis/auth.ts
@@ -1,60 +1,20 @@
-// Functions calling API
-import {
-  getAccount,
-  getAccounts,
-  getAccountsOrgs,
-  getIdentity,
-  getOrg,
-  putAccountsDefault,
-  putAccountsOrgsDefault,
-  Account,
-  Identity,
-  IdentityAccount,
-  IdentityUser,
-  Organization,
-  OrganizationSummaries,
-  UserAccount,
-  patchAccount,
-} from 'src/client/unityRoutes'
-
-import {
-  getMe as getMeIdpe,
-  Error as IdpeError,
-  UserResponse as UserResponseIdpe,
-} from 'src/client'
+// APIs
+import {getIdentity, Identity, IdentityUser} from 'src/client/unityRoutes'
+import {getMe as getMeIdpe} from 'src/client'
 
 // Constants
 import {CLOUD} from 'src/shared/constants'
 
 // Types
 import {RemoteDataState} from 'src/types'
-
-// Additional properties of the current account, which are not retrieved from  /quartz/identity.
-export interface CurrentAccount extends IdentityAccount {
-  billingProvider?: 'zuora' | 'aws' | 'gcm' | 'azure'
-}
-
-// Additional properties of the current org, which are not retrieved from /quartz/identity.
-export interface CurrentOrg {
-  id: string
-  clusterHost: string
-  name?: string
-  creationDate?: string
-  description?: string
-  isRegionBeta?: boolean
-  provider?: string
-  regionCode?: string
-  regionName?: string
-}
+import {Error as IdpeError, UserResponse as UserResponseIdpe} from 'src/client'
+import {ServerError, UnauthorizedError} from 'src/types/error'
+import {CurrentAccount} from 'src/identity/apis/account'
+import {CurrentOrg, QuartzOrganizations} from 'src/identity/apis/org'
 
 export interface IdentityState {
   currentIdentity: CurrentIdentity
   quartzOrganizations: QuartzOrganizations
-}
-
-export type QuartzOrganizations = {
-  orgs: OrganizationSummaries
-  status?: RemoteDataState
 }
 
 export interface IdentityLoadingStatus {
@@ -70,53 +30,7 @@ export interface CurrentIdentity {
   loadingStatus?: IdentityLoadingStatus
 }
 
-export enum NetworkErrorTypes {
-  UnauthorizedError = 'UnauthorizedError',
-  NotFoundError = 'NotFoundError',
-  ServerError = 'ServerError',
-  UnprocessableEntity = 'UnprocessableEntity',
-  GenericError = 'GenericError',
-}
-
-// 401 error
-export class UnauthorizedError extends Error {
-  constructor(message) {
-    super(message)
-    this.name = 'UnauthorizedError'
-  }
-}
-
-// 404 error
-export class NotFoundError extends Error {
-  constructor(message) {
-    super(message)
-    this.name = 'NotFoundError'
-  }
-}
-
-// 422 error
-export class UnprocessableEntityError extends Error {
-  constructor(message) {
-    super(message)
-    this.name = 'UnprocessableEntityError'
-  }
-}
-
-// 500 error
-export class ServerError extends Error {
-  constructor(message) {
-    super(message)
-    this.name = 'ServerError'
-  }
-}
-
-export class GenericError extends Error {
-  constructor(message) {
-    super(message)
-    this.name = 'GenericError'
-  }
-}
-
+// fetch the user's identity either using IDPE (in OSS), or quartz (in Cloud)
 export const fetchIdentity = async () => {
   if (!CLOUD) {
     return fetchLegacyIdentity()
@@ -156,171 +70,4 @@ export const fetchLegacyIdentity = async (): Promise<UserResponseIdpe> => {
 
   const user = response.data
   return user
-}
-
-// fetch details about one of the user's accounts
-export const fetchAccountDetails = async (
-  accountId: string | number
-): Promise<Account> => {
-  const accountIdString = accountId.toString()
-
-  const response = await getAccount({
-    accountId: accountIdString,
-  })
-
-  if (response.status === 401) {
-    throw new UnauthorizedError(response.data.message)
-  }
-
-  if (response.status === 500) {
-    throw new ServerError(response.data.message)
-  }
-
-  const accountDetails = response.data
-  return accountDetails
-}
-
-// change the user's default account
-export const updateDefaultQuartzAccount = async (
-  accountId: number
-): Promise<void> => {
-  const response = await putAccountsDefault({
-    data: {
-      id: accountId,
-    },
-  })
-
-  if (response.status === 500) {
-    throw new ServerError(response.data.message)
-  }
-
-  // success status code is 204; no response body expected.
-}
-
-// fetch details about one of the user's organizations
-export const fetchOrgDetails = async (orgId: string): Promise<Organization> => {
-  const response = await getOrg({orgId})
-
-  if (response.status === 401) {
-    throw new UnauthorizedError(response.data.message)
-  }
-
-  if (response.status === 500) {
-    throw new ServerError(response.data.message)
-  }
-
-  const orgDetails = response.data
-  return orgDetails
-}
-
-// fetch the list of organizations associated with a given account ID
-export const fetchOrgsByAccountID = async (
-  accountNum: number
-): Promise<OrganizationSummaries> => {
-  const accountId = accountNum.toString()
-
-  const response = await getAccountsOrgs({
-    accountId,
-  })
-
-  if (response.status === 401) {
-    throw new UnauthorizedError(response.data.message)
-  }
-
-  if (response.status === 500) {
-    throw new ServerError(response.data.message)
-  }
-
-  return response.data
-}
-
-// update the default org for a given account
-export const updateDefaultOrgByAccountID = async ({
-  accountNum,
-  orgId,
-}): Promise<void> => {
-  const accountId = accountNum.toString()
-
-  const response = await putAccountsOrgsDefault({
-    accountId,
-    data: {
-      id: orgId,
-    },
-  })
-
-  if (response.status === 404) {
-    throw new NotFoundError(response.data.message)
-  }
-
-  if (response.status === 422) {
-    throw new UnprocessableEntityError(response.data.message)
-  }
-
-  if (response.status === 500) {
-    throw new ServerError(response.data.message)
-  }
-
-  // success status code is 204; no response body expected.
-}
-
-// fetch user default account's default org
-export const getDefaultAccountDefaultOrg = async (): Promise<
-  OrganizationSummaries[number]
-> => {
-  const response = await getAccounts({})
-
-  if (response.status === 401) {
-    throw new UnauthorizedError(response.data.message)
-  }
-
-  if (response.status === 500) {
-    throw new ServerError(response.data.message)
-  }
-  const {data} = response
-
-  if (Array.isArray(data) && data.length) {
-    const defaultAccount = data.find(account => account.isDefault)
-
-    // fetch default org
-    if (defaultAccount) {
-      const quartzOrg = await fetchOrgsByAccountID(defaultAccount.id)
-      const defaultQuartzOrg =
-        quartzOrg.find(org => org.isDefault) || quartzOrg[0]
-
-      return defaultQuartzOrg
-    }
-    throw new GenericError('No default account found')
-  }
-}
-
-export const getUserAccounts = async (): Promise<UserAccount[]> => {
-  const response = await getAccounts({})
-
-  if (response.status === 401) {
-    throw new UnauthorizedError(response.data.message)
-  }
-  if (response.status === 500) {
-    throw new ServerError(response.data.message)
-  }
-  if (!Array.isArray(response.data)) {
-    throw new GenericError('No account found')
-  }
-
-  return response.data
-}
-
-export const updateUserAccount = async (accountId, name) => {
-  const response = await patchAccount({accountId, data: {name}})
-
-  if (response.status === 401) {
-    throw new UnauthorizedError(response.data.message)
-  }
-  if (response.status === 422) {
-    throw new UnprocessableEntityError(response.data.message)
-  }
-  if (response.status === 500) {
-    throw new ServerError(response.data.message)
-  }
-
-  return response.data
 }

--- a/src/identity/apis/org.ts
+++ b/src/identity/apis/org.ts
@@ -1,0 +1,184 @@
+// API Calls
+import {
+  getAccounts,
+  getAccountsOrgs,
+  getClusters,
+  getOrg,
+  postOrg,
+  putAccountsOrgsDefault,
+  Organization,
+  OrganizationCreateRequest,
+} from 'src/client/unityRoutes'
+
+// Types
+import {RemoteDataState} from 'src/types'
+import {
+  GenericError,
+  NotFoundError,
+  OrgNameConflictError,
+  ServerError,
+  UnauthorizedError,
+  UnprocessableEntityError,
+} from 'src/types/error'
+import {OrganizationSummaries} from 'src/client/unityRoutes'
+
+export interface CurrentOrg {
+  id: string
+  clusterHost: string
+  name?: string
+  creationDate?: string
+  description?: string
+  provider?: string
+  regionCode?: string
+  regionName?: string
+}
+
+export type QuartzOrganizations = {
+  orgs: OrganizationSummaries
+  status?: RemoteDataState
+}
+
+// create a new organization
+export const createNewOrg = async (
+  organizationCreateRequest: OrganizationCreateRequest
+) => {
+  const {orgName, provider, region} = organizationCreateRequest
+
+  const response = await postOrg({
+    data: {
+      orgName,
+      provider,
+      region,
+    },
+  })
+
+  if (response.status === 401) {
+    throw new UnauthorizedError(response.data.message)
+  }
+
+  if (response.status === 409) {
+    throw new OrgNameConflictError(response.data.message)
+  }
+
+  if (response.status === 422) {
+    throw new UnprocessableEntityError(response.data.message)
+  }
+
+  if (response.status === 500) {
+    throw new ServerError(response.data.message)
+  }
+
+  // Status code in response when successfully creating an org is 201.
+  return response.data
+}
+
+// fetch the list of clusters in which an org can be created
+export const fetchClusterList = async () => {
+  const response = await getClusters({})
+
+  if (response.status === 401) {
+    throw new UnauthorizedError(response.data.message)
+  }
+
+  if (response.status === 500) {
+    throw new ServerError(response.data.message)
+  }
+
+  return response.data
+}
+
+// fetch the default org for the default account
+export const getDefaultAccountDefaultOrg = async (): Promise<
+  OrganizationSummaries[number]
+> => {
+  const response = await getAccounts({})
+
+  if (response.status === 401) {
+    throw new UnauthorizedError(response.data.message)
+  }
+
+  if (response.status === 500) {
+    throw new ServerError(response.data.message)
+  }
+  const {data} = response
+
+  if (Array.isArray(data) && data.length) {
+    const defaultAccount = data.find(account => account.isDefault)
+
+    // fetch default org
+    if (defaultAccount) {
+      const quartzOrg = await fetchOrgsByAccountID(defaultAccount.id)
+      const defaultQuartzOrg =
+        quartzOrg.find(org => org.isDefault) || quartzOrg[0]
+
+      return defaultQuartzOrg
+    }
+    throw new GenericError('No default account found')
+  }
+}
+
+// fetch the list of organizations associated with a given account ID
+export const fetchOrgsByAccountID = async (
+  accountNum: number
+): Promise<OrganizationSummaries> => {
+  const accountId = accountNum.toString()
+
+  const response = await getAccountsOrgs({
+    accountId,
+  })
+
+  if (response.status === 401) {
+    throw new UnauthorizedError(response.data.message)
+  }
+
+  if (response.status === 500) {
+    throw new ServerError(response.data.message)
+  }
+
+  return response.data
+}
+
+// fetch details about one of the user's organizations
+export const fetchOrgDetails = async (orgId: string): Promise<Organization> => {
+  const response = await getOrg({orgId})
+
+  if (response.status === 401) {
+    throw new UnauthorizedError(response.data.message)
+  }
+
+  if (response.status === 500) {
+    throw new ServerError(response.data.message)
+  }
+
+  const orgDetails = response.data
+  return orgDetails
+}
+
+// update the default org for a given account
+export const updateDefaultOrgByAccountID = async ({
+  accountNum,
+  orgId,
+}): Promise<void> => {
+  const accountId = accountNum.toString()
+
+  const response = await putAccountsOrgsDefault({
+    accountId,
+    data: {
+      id: orgId,
+    },
+  })
+
+  if (response.status === 404) {
+    throw new NotFoundError(response.data.message)
+  }
+
+  if (response.status === 422) {
+    throw new UnprocessableEntityError(response.data.message)
+  }
+
+  if (response.status === 500) {
+    throw new ServerError(response.data.message)
+  }
+
+  // success status code is 204; no response body expected.
+}

--- a/src/identity/components/userprofile/DefaultOrgForm.tsx
+++ b/src/identity/components/userprofile/DefaultOrgForm.tsx
@@ -19,7 +19,7 @@ import {
 import {UserProfileInput} from 'src/identity/components/userprofile/UserProfileInput'
 
 // Types
-import {CurrentAccount} from 'src/identity/apis/auth'
+import {CurrentAccount} from 'src/identity/apis/account'
 import {OrganizationSummaries, UserAccount} from 'src/client/unityRoutes'
 
 interface Props {

--- a/src/identity/mockUserData.ts
+++ b/src/identity/mockUserData.ts
@@ -1,4 +1,5 @@
-import {CurrentIdentity, CurrentOrg} from 'src/identity/apis/auth'
+import {CurrentIdentity} from 'src/identity/apis/auth'
+import {CurrentOrg} from 'src/identity/apis/org'
 import {BillingProvider, RemoteDataState} from 'src/types'
 
 export const mockBillingProviders: BillingProvider[] = [
@@ -103,7 +104,6 @@ export const mockOrgDetailsArr: CurrentOrg[] = [
     clusterHost: 'https://fakehost.fakehost.fake',
     creationDate: '2022-06-08T16:59:44.827046Z',
     description: null,
-    isRegionBeta: false,
     id: '89d20c01076ba140',
     name: 'fakeemail@influxdata.com',
     provider: 'Azure',
@@ -114,7 +114,6 @@ export const mockOrgDetailsArr: CurrentOrg[] = [
     clusterHost: 'https://newhost.new.new',
     creationDate: '2022-06-10T16:59:44.827046Z',
     description: null,
-    isRegionBeta: true,
     id: '72d20c01076ba120',
     name: 'newemail@influxdata.com',
     provider: 'AWS',
@@ -125,7 +124,6 @@ export const mockOrgDetailsArr: CurrentOrg[] = [
     clusterHost: 'https://oldhost.oldhost.old',
     creationDate: '2022-06-04T16:59:44.827046Z',
     description: null,
-    isRegionBeta: false,
     id: '59d20c01076be140',
     name: 'newemail@influxdata.com',
     provider: 'GCP',
@@ -136,7 +134,6 @@ export const mockOrgDetailsArr: CurrentOrg[] = [
     clusterHost: 'https://temphost.temphost.temp',
     creationDate: '2022-06-02T16:59:44.827046Z',
     description: null,
-    isRegionBeta: true,
     id: '64d20c01076be140',
     name: 'newemail@influxdata.com',
     provider: 'AWS',

--- a/src/identity/quartzOrganizations/actions/thunks/index.ts
+++ b/src/identity/quartzOrganizations/actions/thunks/index.ts
@@ -4,7 +4,7 @@ import {Dispatch} from 'react'
 import {
   fetchOrgsByAccountID,
   updateDefaultOrgByAccountID,
-} from 'src/identity/apis/auth'
+} from 'src/identity/apis/org'
 
 // Actions
 import {

--- a/src/identity/quartzOrganizations/reducers/index.ts
+++ b/src/identity/quartzOrganizations/reducers/index.ts
@@ -1,4 +1,4 @@
-import {QuartzOrganizations} from 'src/identity/apis/auth'
+import {QuartzOrganizations} from 'src/identity/apis/org'
 import {
   Actions,
   SET_QUARTZ_ORGANIZATIONS,

--- a/src/identity/reducers/index.test.ts
+++ b/src/identity/reducers/index.test.ts
@@ -27,7 +27,8 @@ import {omit} from 'lodash'
 
 // Types
 import {BillingProvider} from 'src/types'
-import {CurrentIdentity, CurrentOrg} from 'src/identity/apis/auth'
+import {CurrentIdentity} from 'src/identity/apis/auth'
+import {CurrentOrg} from 'src/identity/apis/org'
 
 describe('identity reducer', () => {
   it('can initialize a default state', () => {

--- a/src/shared/components/NotFound.tsx
+++ b/src/shared/components/NotFound.tsx
@@ -34,7 +34,7 @@ import {Organization} from 'src/types'
 import {CLOUD} from 'src/shared/constants'
 
 // API
-import {getDefaultAccountDefaultOrg} from 'src/identity/apis/auth'
+import {getDefaultAccountDefaultOrg} from 'src/identity/apis/org'
 
 const NotFoundNew: FC = () => (
   <AppWrapper type="funnel" className="page-not-found" testID="not-found">

--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -1,0 +1,55 @@
+export enum NetworkErrorTypes {
+  UnauthorizedError = 'UnauthorizedError', // 401
+  NotFoundError = 'NotFoundError', // 404
+  OrgNameConflictError = 'OrgNameConflictError', // 409
+  UnprocessableEntityError = 'UnprocessableEntity', // 422
+  ServerError = 'ServerError', // 500
+  GenericError = 'GenericError',
+}
+
+// 401 error
+export class UnauthorizedError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'UnauthorizedError'
+  }
+}
+
+// 404 error
+export class NotFoundError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'NotFoundError'
+  }
+}
+
+// 409 error
+export class OrgNameConflictError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'OrgNameConflictError'
+  }
+}
+
+// 422 error
+export class UnprocessableEntityError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'UnprocessableEntityError'
+  }
+}
+
+// 500 error
+export class ServerError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'ServerError'
+  }
+}
+
+export class GenericError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'GenericError'
+  }
+}


### PR DESCRIPTION
Helps with #5932, #5894

Adds UI API layer support for the quartz endpoints for creating orgs (`POST` /orgs) and getting the list of available clusters in which an org can be created (`GET` /clusters).

Matching openAPI specs: [create orgs](https://github.com/influxdata/openapi/blob/master/src/unity/paths/orgs.yml), [get clusters](https://github.com/influxdata/openapi/blob/master/src/unity/paths/clusters.yml).

Refactors /identity/apis into three files for readability: (1) auth.ts (apis related to user's identity); (2) account.ts (apis related to user's account); (3) org.ts (apis related to user's org).

Create Orgs Response
--
In quartz-remocal, we get a `401` as expected, as the default free account cannot create more than one org.
![Screen Shot 2022-10-14 at 5 11 27 PM](https://user-images.githubusercontent.com/91283923/195944682-56eb2376-90a3-4f49-8335-e722a94e941a.png)

Get Clusters Response
--
![Screen Shot 2022-10-14 at 4 23 44 PM](https://user-images.githubusercontent.com/91283923/195938508-b2be5162-3e3d-4d4e-8caa-3309d47bf25c.png)

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable
