### PR TITLE
feat(sub): add enable SSL toggle

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "cy": "CYPRESS_dexUrl=https://$INGRESS_HOST:$PORT_HTTPS CYPRESS_baseUrl=http://localhost:9999 cypress open",
     "cy:dev": "source ../monitor-ci/.env && CYPRESS_dexUrl=CLOUD CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{cloud,shared}/**/*.*'",
     "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_dexUrl=OSS CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{oss,shared}/**/*.*'",
-    "generate": "export SHA=97ca3ce15361c5f5b5654fd32a20df4a31c45cd7 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
+    "generate": "export SHA=f495434ca24ea945785919934e330b3138de03a7 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-local-cloud": "export REMOTE=../openapi/ && yarn generate-meta-cloud",
     "generate-meta": "if [ -z \"${CLOUD_URL}\" ]; then yarn generate-meta-oss; else yarn generate-meta-cloud; fi",

--- a/src/types/me.ts
+++ b/src/types/me.ts
@@ -1,2 +1,2 @@
 export {MeState} from 'src/me/reducers'
-export {AccountType, Me} from 'src/client/unityRoutes'
+export {AccountType} from 'src/client/unityRoutes'

--- a/src/types/subscriptions.ts
+++ b/src/types/subscriptions.ts
@@ -45,6 +45,7 @@ export interface Subscription {
   authType: BrokerAuthTypes
   brokerCertCreationDate?: string
   clientID?: string
+  useSSL: boolean
 }
 
 export interface SubscriptionStatus {

--- a/src/writeData/subscriptions/components/BrokerForm.scss
+++ b/src/writeData/subscriptions/components/BrokerForm.scss
@@ -96,4 +96,7 @@
     margin: 0 12px;
     margin-bottom: 30px;
   }
+  &__ssl-text {
+    margin-left: $cf-space-s;
+  }
 }

--- a/src/writeData/subscriptions/components/BrokerFormContent.tsx
+++ b/src/writeData/subscriptions/components/BrokerFormContent.tsx
@@ -284,7 +284,7 @@ const BrokerFormContent: FC<Props> = ({
               )}
             </Form.ValidationElement>
           </FlexBox>
-          {isFlagEnabled('subscriptionsClientId') && (
+          {isFlagEnabled('subscriptionsSSLSupport') && (
             <FlexBox
               direction={FlexDirection.Row}
               alignItems={AlignItems.Center}

--- a/src/writeData/subscriptions/components/BrokerFormContent.tsx
+++ b/src/writeData/subscriptions/components/BrokerFormContent.tsx
@@ -23,6 +23,7 @@ import {
   Toggle,
   InputToggleType,
   InputLabel,
+  SlideToggle,
 } from '@influxdata/clockface'
 import UserInput from 'src/writeData/subscriptions/components/UserInput'
 import CertificateInput from 'src/writeData/subscriptions/components/CertificateInput'
@@ -283,17 +284,40 @@ const BrokerFormContent: FC<Props> = ({
               )}
             </Form.ValidationElement>
           </FlexBox>
+          {isFlagEnabled('subscriptionsClientId') && (
+            <FlexBox
+              direction={FlexDirection.Row}
+              alignItems={AlignItems.Center}
+              margin={ComponentSize.Medium}
+              className="static-toggle"
+            >
+              <SlideToggle
+                active={formContent.useSSL}
+                onChange={() => {
+                  updateForm({
+                    ...formContent,
+                    useSSL: !formContent.useSSL,
+                  })
+                }}
+                disabled={!edit}
+                size={ComponentSize.Medium}
+              />
+              <Heading
+                element={HeadingElement.H4}
+                weight={FontWeight.Regular}
+                className={`${className}-broker-form__ssl-text`}
+              >
+                Enable SSL
+              </Heading>
+            </FlexBox>
+          )}
           {showHostPortExampleText && (
             <Heading
               element={HeadingElement.H5}
               weight={FontWeight.Regular}
               className={`${className}-broker-form__example-text`}
             >
-              {getSchemaFromProtocol(
-                formContent.protocol,
-                isFlagEnabled('subscriptionsCertificateSupport') &&
-                  formContent.authType === BrokerAuthTypes.Certificate
-              )}
+              {getSchemaFromProtocol(formContent.protocol, formContent)}
               {`${formContent.brokerHost}:${
                 !!formContent.brokerPort && !isNaN(formContent.brokerPort)
                   ? formContent.brokerPort
@@ -445,6 +469,7 @@ const BrokerFormContent: FC<Props> = ({
                   brokerUsername: null,
                   brokerPassword: null,
                   authType: BrokerAuthTypes.Certificate,
+                  useSSL: true,
                 })
               }}
               value="certificate"

--- a/src/writeData/subscriptions/context/subscription.create.tsx
+++ b/src/writeData/subscriptions/context/subscription.create.tsx
@@ -76,6 +76,7 @@ export const DEFAULT_CONTEXT: SubscriptionCreateContextType = {
     },
     bucket: 'nifi',
     timestampPrecision: 'NS',
+    useSSL: false,
   },
   updateForm: () => {},
   loading: RemoteDataState.NotStarted,

--- a/src/writeData/subscriptions/context/subscription.update.tsx
+++ b/src/writeData/subscriptions/context/subscription.update.tsx
@@ -94,6 +94,7 @@ export const DEFAULT_CONTEXT: SubscriptionUpdateContextType = {
     },
     bucket: 'nifi',
     timestampPrecision: 'NS',
+    useSSL: false,
   },
   updateForm: () => {},
   loading: RemoteDataState.NotStarted,

--- a/src/writeData/subscriptions/utils/form.ts
+++ b/src/writeData/subscriptions/utils/form.ts
@@ -10,6 +10,7 @@ import {
 import jsonpath from 'jsonpath'
 import {IconFont} from '@influxdata/clockface'
 import {Bulletin} from '../context/subscription.list'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 export const DEFAULT_COMPLETED_STEPS = {
   [Steps.BrokerForm]: false,
@@ -468,10 +469,18 @@ export const handleAvroValidation = (property: string, value: string) => {
     : null
 }
 
-export const getSchemaFromProtocol = (protocol: string, isSecure: boolean) => {
+export const getSchemaFromProtocol = (
+  protocol: string,
+  formContent: Subscription
+) => {
+  const usingCertAuth =
+    isFlagEnabled('subscriptionsCertificateSupport') &&
+    formContent.authType === BrokerAuthTypes.Certificate
+  const usingSSL =
+    isFlagEnabled('subscriptionsSSLSupport') && formContent.useSSL
   switch (protocol.toLowerCase()) {
     case 'mqtt': {
-      return `mqtt${isSecure ? 's' : ''}://`
+      return `mqtt${usingCertAuth || usingSSL ? 's' : ''}://`
     }
     default: {
       return 'tcp://'


### PR DESCRIPTION
Closes https://github.com/influxdata/data-acquisition/issues/560

Adds an `Enable SSL` toggle to the subscriptions form. If checked, this sets `useSSL: true` in the api request. 

If "Certificate" auth type is chosen, the `Enable SSL` toggle is automatically flipped. 

If the `Enable SSL` toggle is enabled, the protocol preview changes from `mqtt://...` to `mqtts://...`

Behind flag `subscriptionsSSLSupport`

## Disabled

<img width="1234" alt="image" src="https://user-images.githubusercontent.com/6411855/195948411-aef19f69-9035-4cc1-828e-57234870193d.png">


## Enabled

<img width="1264" alt="image" src="https://user-images.githubusercontent.com/6411855/195947674-b10597ed-42a7-4915-bddd-0733fe2cd9ea.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
