### PR TITLE
fix(sub): card updates, various bug fixes

### DIFF
--- a/src/writeData/subscriptions/components/DetailsSubscriptionPage.scss
+++ b/src/writeData/subscriptions/components/DetailsSubscriptionPage.scss
@@ -17,6 +17,7 @@
         h3 {
           font-size: $cf-space-m;
           line-height: $cf-space-m;
+          overflow-wrap: break-word;
         }
 
         h6 {

--- a/src/writeData/subscriptions/components/JsonParsingForm.tsx
+++ b/src/writeData/subscriptions/components/JsonParsingForm.tsx
@@ -37,7 +37,7 @@ import {event} from 'src/cloud/utils/reporting'
 
 // Styles
 import 'src/writeData/subscriptions/components/JsonParsingForm.scss'
-import ValidationInputWithTooltip from './ValidationInputWithTooltip'
+import ValidationInputWithTooltip from 'src/writeData/subscriptions/components/ValidationInputWithTooltip'
 
 interface Props {
   formContent: Subscription

--- a/src/writeData/subscriptions/components/JsonPathInput.tsx
+++ b/src/writeData/subscriptions/components/JsonPathInput.tsx
@@ -34,7 +34,7 @@ import {
   handleDuplicateFieldTagName,
 } from 'src/writeData/subscriptions/utils/form'
 import {event} from 'src/cloud/utils/reporting'
-import ValidationInputWithTooltip from './ValidationInputWithTooltip'
+import ValidationInputWithTooltip from 'src/writeData/subscriptions/components/ValidationInputWithTooltip'
 
 interface Props {
   name: string

--- a/src/writeData/subscriptions/components/StatusHeader.tsx
+++ b/src/writeData/subscriptions/components/StatusHeader.tsx
@@ -20,8 +20,8 @@ import {
 
 // Types
 import {Subscription} from 'src/types/subscriptions'
-import {SubscriptionListContext} from '../context/subscription.list'
-import SubscriptionErrorsOverlay from './SubscriptionErrorsOverlay'
+import {SubscriptionListContext} from 'src/writeData/subscriptions/context/subscription.list'
+import SubscriptionErrorsOverlay from 'src/writeData/subscriptions/components/SubscriptionErrorsOverlay'
 
 interface Props {
   currentSubscription: Subscription

--- a/src/writeData/subscriptions/components/StringParsingForm.tsx
+++ b/src/writeData/subscriptions/components/StringParsingForm.tsx
@@ -34,7 +34,7 @@ import {
 import 'src/writeData/subscriptions/components/StringParsingForm.scss'
 import {event} from 'src/cloud/utils/reporting'
 import {ComponentStatus} from '@influxdata/clockface'
-import ValidationInputWithTooltip from './ValidationInputWithTooltip'
+import ValidationInputWithTooltip from 'src/writeData/subscriptions/components/ValidationInputWithTooltip'
 
 interface Props {
   formContent: Subscription

--- a/src/writeData/subscriptions/components/StringPatternInput.tsx
+++ b/src/writeData/subscriptions/components/StringPatternInput.tsx
@@ -25,7 +25,7 @@ import {
   REGEX_TOOLTIP,
 } from 'src/writeData/subscriptions/utils/form'
 import {event} from 'src/cloud/utils/reporting'
-import ValidationInputWithTooltip from './ValidationInputWithTooltip'
+import ValidationInputWithTooltip from 'src/writeData/subscriptions/components/ValidationInputWithTooltip'
 
 interface Props {
   name: string

--- a/src/writeData/subscriptions/components/SubscriptionCard.tsx
+++ b/src/writeData/subscriptions/components/SubscriptionCard.tsx
@@ -19,7 +19,7 @@ import {
 
 // Types
 import {Subscription} from 'src/types/subscriptions'
-import {SubscriptionListContext} from '../context/subscription.list'
+import {SubscriptionListContext} from 'src/writeData/subscriptions/context/subscription.list'
 import {LOAD_DATA, SUBSCRIPTIONS} from 'src/shared/constants/routes'
 
 // Utils
@@ -125,9 +125,7 @@ const SubscriptionCard: FC<Props> = ({subscription}) => {
         }}
         testID="subscription-name"
       />
-      <ResourceCard.Description
-        description={`${subscription.brokerHost}:${subscription.brokerPort}/${subscription.topic}`}
-      />
+      <ResourceCard.Description description={`${subscription.description}`} />
       <ResourceCard.Meta>
         {!!bulletins.length ? (
           <Label
@@ -154,7 +152,11 @@ const SubscriptionCard: FC<Props> = ({subscription}) => {
           />
         )}
         <>{subscription.status}</>
+        <>{`${subscription.brokerHost}:${subscription.brokerPort}/${subscription.topic}`}</>
         <>Last Modified: {timeSince}</>
+        <>
+          Last Modified By: {subscription.updatedBy ?? subscription.createdBy}
+        </>
         {subscriptionID}
       </ResourceCard.Meta>
     </ResourceCard>

--- a/src/writeData/subscriptions/components/SubscriptionErrorsOverlay.tsx
+++ b/src/writeData/subscriptions/components/SubscriptionErrorsOverlay.tsx
@@ -16,7 +16,7 @@ import {
 // Styles
 import 'src/writeData/subscriptions/components/SubscriptionErrorsOverlay.scss'
 import {event} from 'src/cloud/utils/reporting'
-import {Bulletin} from '../context/subscription.list'
+import {Bulletin} from 'src/writeData/subscriptions/context/subscription.list'
 
 interface Props {
   bulletins: Bulletin[]

--- a/src/writeData/subscriptions/components/UserInput.tsx
+++ b/src/writeData/subscriptions/components/UserInput.tsx
@@ -15,6 +15,7 @@ import {
 
 // Types
 import {Subscription} from 'src/types/subscriptions'
+import {handleValidation} from 'src/writeData/subscriptions/utils/form'
 
 interface Props {
   formContent: Subscription
@@ -30,47 +31,62 @@ const UserInput: FC<Props> = ({formContent, updateForm, className, edit}) => (
     margin={ComponentSize.Large}
     className={`${className}-broker-form__creds`}
   >
-    <Form.Element label="Username">
-      <Input
-        type={InputType.Text}
-        placeholder="userName"
-        name="username"
-        value={formContent?.brokerUsername ?? ''}
-        onChange={e =>
-          updateForm({
-            ...formContent,
-            brokerUsername: e.target.value,
-          })
-        }
-        testID={`${className}-broker-form--username`}
-        status={
-          edit || className === 'create'
-            ? ComponentStatus.Default
-            : ComponentStatus.Disabled
-        }
-        maxLength={255}
-      />
-    </Form.Element>
-    <Form.Element label="Password">
-      <Input
-        type={InputType.Password}
-        placeholder="*********"
-        name="password"
-        value={formContent?.brokerPassword ?? ''}
-        onChange={e =>
-          updateForm({
-            ...formContent,
-            brokerPassword: e.target.value,
-          })
-        }
-        testID={`${className}-broker-form--password`}
-        status={
-          edit || className === 'create'
-            ? ComponentStatus.Default
-            : ComponentStatus.Disabled
-        }
-      />
-    </Form.Element>
+    <Form.ValidationElement
+      label="Username"
+      required={true}
+      validationFunc={() =>
+        handleValidation('Username', formContent.brokerUsername)
+      }
+      value={formContent.brokerUsername}
+    >
+      {status => (
+        <Input
+          type={InputType.Text}
+          placeholder="username"
+          name="username"
+          value={formContent?.brokerUsername ?? ''}
+          onChange={e =>
+            updateForm({
+              ...formContent,
+              brokerUsername: e.target.value,
+            })
+          }
+          testID={`${className}-broker-form--username`}
+          status={
+            edit || className === 'create' ? status : ComponentStatus.Disabled
+          }
+          maxLength={255}
+        />
+      )}
+    </Form.ValidationElement>
+    <Form.ValidationElement
+      label="Password"
+      required={true}
+      value={formContent.brokerPassword}
+      validationFunc={() =>
+        handleValidation('Password', formContent.brokerPassword)
+      }
+    >
+      {status => (
+        <Input
+          type={InputType.Password}
+          placeholder="*********"
+          name="password"
+          required={true}
+          value={formContent?.brokerPassword ?? ''}
+          onChange={e =>
+            updateForm({
+              ...formContent,
+              brokerPassword: e.target.value,
+            })
+          }
+          testID={`${className}-broker-form--password`}
+          status={
+            edit || className === 'create' ? status : ComponentStatus.Disabled
+          }
+        />
+      )}
+    </Form.ValidationElement>
   </FlexBox>
 )
 export default UserInput

--- a/src/writeData/subscriptions/context/subscription.list.tsx
+++ b/src/writeData/subscriptions/context/subscription.list.tsx
@@ -20,7 +20,7 @@ import {event} from 'src/cloud/utils/reporting'
 import {Subscription} from 'src/types/subscriptions'
 import {RemoteDataState} from 'src/types'
 import {SubscriptionStatus} from 'src/client/subscriptionsRoutes'
-import {getBulletinsFromStatus} from '../utils/form'
+import {getBulletinsFromStatus} from 'src/writeData/subscriptions/utils/form'
 
 export interface SubscriptionListContextType {
   getAll: () => void

--- a/src/writeData/subscriptions/utils/form.ts
+++ b/src/writeData/subscriptions/utils/form.ts
@@ -10,8 +10,8 @@ import {
 } from 'src/types/subscriptions'
 import jsonpath from 'jsonpath'
 import {IconFont} from '@influxdata/clockface'
-import {Bulletin} from '../context/subscription.list'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import {Bulletin} from 'src/writeData/subscriptions/context/subscription.list'
 
 export const DEFAULT_COMPLETED_STEPS = {
   [Steps.BrokerForm]: false,
@@ -262,7 +262,7 @@ export const checkRequiredFields = (form: Subscription): boolean => {
     form.brokerPort &&
     form.topic &&
     form.dataFormat &&
-    form.bucket &&
+    hasBucketSelected(form.bucket) &&
     checkRequiredStringFields(form) &&
     checkRequiredJsonFields(form) &&
     checkSecurityFields(form)
@@ -395,6 +395,9 @@ export const getActiveStep = activeForm => {
   return currentStep
 }
 
+const hasBucketSelected = (bucketName: string | undefined) =>
+  !!bucketName && bucketName !== '<BUCKET>'
+
 export const getFormStatus = (active: Steps, form: Subscription) => {
   return {
     currentStep: active,
@@ -402,9 +405,7 @@ export const getFormStatus = (active: Steps, form: Subscription) => {
     brokerStepCompleted:
       form.name && form.brokerHost && form.brokerPort ? 'true' : 'false',
     subscriptionStepCompleted:
-      form.topic && form.bucket && form.bucket !== '<BUCKET>'
-        ? 'true'
-        : 'false',
+      form.topic && hasBucketSelected(form.bucket) ? 'true' : 'false',
     parsingStepCompleted:
       form.dataFormat &&
       checkRequiredJsonFields(form) &&


### PR DESCRIPTION
Closes https://github.com/influxdata/data-acquisition/issues/408
Closes https://github.com/influxdata/data-acquisition/issues/392

Adds:
- Re-organizes the subscription card, adding the missing Description info and Last Updated By.
- When editing an existing subscription with User/Basic auth, changing the Host field will highlight the password field to indicate it needs to be re-populated.

Fixes various bugs:
- Username and Password should be required fields with validation.
- Save button should check for bucket being selected.
- Relative imports.
- Wrap subscription name so it doesn't run off screen

## Wrapping title

<img width="1321" alt="image" src="https://user-images.githubusercontent.com/6411855/195955151-f2b03e51-f180-4943-95b7-441a90f494b3.png">

## New cards

<img width="1484" alt="image" src="https://user-images.githubusercontent.com/6411855/195955181-81453683-179b-4df5-937a-e36aaa5bb434.png">

## Username/password required:

<img width="1216" alt="image" src="https://user-images.githubusercontent.com/6411855/195955227-40b97fec-0ff1-4a24-ae2f-c568460929ce.png">

## Password required when host changed

<img width="1235" alt="image" src="https://user-images.githubusercontent.com/6411855/195955321-aecc7354-444f-4171-ae97-d6294ad961bc.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
