### PR TITLE
chore(sub): go directly to notifications overlay

### DIFF
--- a/src/shared/containers/SetOrg.tsx
+++ b/src/shared/containers/SetOrg.tsx
@@ -219,6 +219,14 @@ const SetOrg: FC = () => {
           )}
           {CLOUD && (
             <Route
+              path={`${orgPath}/${LOAD_DATA}/${SUBSCRIPTIONS}/:id/notifications`}
+              render={props => (
+                <DetailsSubscriptionPage {...props} showNotifications={true} />
+              )}
+            />
+          )}
+          {CLOUD && (
+            <Route
               path={`${orgPath}/${LOAD_DATA}/${SUBSCRIPTIONS}/:id`}
               component={DetailsSubscriptionPage}
             />

--- a/src/writeData/subscriptions/components/BrokerDetails.tsx
+++ b/src/writeData/subscriptions/components/BrokerDetails.tsx
@@ -47,6 +47,7 @@ interface Props {
   saveForm: (any) => void
   setStatus: (any) => void
   onFocus?: () => void
+  showNotifications: boolean
 }
 
 const BrokerDetails: FC<Props> = ({
@@ -58,6 +59,7 @@ const BrokerDetails: FC<Props> = ({
   saveForm,
   setStatus,
   onFocus,
+  showNotifications,
 }) => {
   const history = useHistory()
   const org = useSelector(getOrg)
@@ -89,6 +91,7 @@ const BrokerDetails: FC<Props> = ({
               <StatusHeader
                 currentSubscription={currentSubscription}
                 setStatus={setStatus}
+                showOnLoad={showNotifications}
               />
               <div>
                 <Button

--- a/src/writeData/subscriptions/components/DetailsSubscriptionPage.tsx
+++ b/src/writeData/subscriptions/components/DetailsSubscriptionPage.tsx
@@ -57,7 +57,11 @@ import {
 
 // Contexts
 
-const DetailsSubscriptionPage: FC = () => {
+interface Props {
+  showNotifications: boolean
+}
+
+const DetailsSubscriptionPage: FC<Props> = ({showNotifications}) => {
   const [active, setFormActive] = useState<Steps>(Steps.BrokerForm)
   const {currentSubscription, loading, saveForm, updateForm, setStatus} =
     useContext(SubscriptionUpdateContext)
@@ -145,6 +149,7 @@ const DetailsSubscriptionPage: FC = () => {
               setStatus={setStatus}
               saveForm={saveForm}
               onFocus={() => setFormActive(Steps.BrokerForm)}
+              showNotifications={showNotifications}
             />
             <SubscriptionDetails
               currentSubscription={currentSubscription}
@@ -167,14 +172,18 @@ const DetailsSubscriptionPage: FC = () => {
   )
 }
 
-export default () => (
+const DetailsSubscriptionPageWrapper: FC<Props> = ({showNotifications}) => (
   <AppSettingProvider>
     <SubscriptionListProvider>
       <SubscriptionUpdateProvider>
         <WriteDataDetailsProvider>
-          <DetailsSubscriptionPage />
+          <DetailsSubscriptionPage
+            showNotifications={showNotifications ?? false}
+          />
         </WriteDataDetailsProvider>
       </SubscriptionUpdateProvider>
     </SubscriptionListProvider>
   </AppSettingProvider>
 )
+
+export default DetailsSubscriptionPageWrapper

--- a/src/writeData/subscriptions/components/StatusHeader.tsx
+++ b/src/writeData/subscriptions/components/StatusHeader.tsx
@@ -26,12 +26,17 @@ import SubscriptionErrorsOverlay from './SubscriptionErrorsOverlay'
 interface Props {
   currentSubscription: Subscription
   setStatus: (any) => void
+  showOnLoad: boolean
 }
 
-const StatusHeader: FC<Props> = ({currentSubscription, setStatus}) => {
+const StatusHeader: FC<Props> = ({
+  currentSubscription,
+  setStatus,
+  showOnLoad,
+}) => {
   const {bulletins: allBulletins} = useContext(SubscriptionListContext)
   const bulletins = allBulletins?.[currentSubscription.id] ?? []
-  const [isOverlayVisible, setIsOverlayVisible] = useState<boolean>(false)
+  const [isOverlayVisible, setIsOverlayVisible] = useState<boolean>(showOnLoad)
 
   const handleShowNotifications = useCallback(() => {
     setIsOverlayVisible(true)

--- a/src/writeData/subscriptions/components/SubscriptionCard.tsx
+++ b/src/writeData/subscriptions/components/SubscriptionCard.tsx
@@ -54,6 +54,12 @@ const SubscriptionCard: FC<Props> = ({subscription}) => {
     )
   }, [history, org?.id, subscription?.id])
 
+  const goToSubscriptionDetailsNotifications = useCallback(() => {
+    history.push(
+      `/orgs/${org.id}/${LOAD_DATA}/${SUBSCRIPTIONS}/${subscription.id}/notifications`
+    )
+  }, [history, org?.id, subscription?.id])
+
   const handleCopyAttempt = (
     copiedText: string,
     isSuccessful: boolean
@@ -140,7 +146,7 @@ const SubscriptionCard: FC<Props> = ({subscription}) => {
             description={`${bulletins.length} Notification${
               bulletins.length === 1 ? '' : 's'
             }`}
-            onClick={goToSubscriptionDetails}
+            onClick={goToSubscriptionDetailsNotifications}
             testID="subscription-notifications--label"
           />
         ) : (

--- a/src/writeData/subscriptions/components/SubscriptionErrorsOverlay.tsx
+++ b/src/writeData/subscriptions/components/SubscriptionErrorsOverlay.tsx
@@ -30,9 +30,9 @@ const SubscriptionErrorsOverlay: FC<Props> = ({bulletins, handleClose}) => {
     handleClose()
   }
 
-  let title = `${bulletins.length} Errors Found`
+  let title = `${bulletins.length} Notifications Found`
   if (bulletins.length === 1) {
-    title = `1 Error Found`
+    title = `1 Notifications Found`
   }
 
   return (


### PR DESCRIPTION
Improves the interactions with the subscriptions notifications overlay.

Clicking the pill on the subscriptions card takes you into the subscription detail page AND opens the notifications overlay.

Also changes the verbiage from 'Error' to 'Notification' for consistency.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
