### PR TITLE
feat(6063): suppport import statements with composition

### DIFF
--- a/cypress/e2e/shared/fluxQueryBuilder.test.ts
+++ b/cypress/e2e/shared/fluxQueryBuilder.test.ts
@@ -491,6 +491,18 @@ describe('Script Builder', () => {
             'disabled'
           )
 
+          cy.log(
+            'does not diverge, when adding import statement outside of block'
+          )
+          cy.getByTestID('flux-toolbar-search--input')
+            .should('exist')
+            .type('schema')
+          cy.getByTestID('flux--fieldsAsCols').should('exist').click()
+          cy.getByTestID('flux-sync--toggle').should(
+            'not.have.class',
+            'disabled'
+          )
+
           cy.log('does diverge, within block')
           cy.getByTestID('flux-editor').monacoType(
             '{enter}{upArrow}{upArrow}{upArrow} // make diverge'

--- a/cypress/e2e/shared/fluxQueryBuilder.test.ts
+++ b/cypress/e2e/shared/fluxQueryBuilder.test.ts
@@ -503,9 +503,14 @@ describe('Script Builder', () => {
             'disabled'
           )
 
+          /// FIXME: Does not work yet, since the LSP response for applyEdit starts at line 0
+          // cy.log(
+          //   'does not diverge, when further modifying block (with imports at top)'
+          // )
+
           cy.log('does diverge, within block')
           cy.getByTestID('flux-editor').monacoType(
-            '{enter}{upArrow}{upArrow}{upArrow} // make diverge'
+            '{enter}{upArrow}{upArrow}{upArrow}{upArrow} // make diverge'
           )
           cy.log('toggle is now disabled')
           cy.getByTestID('flux-sync--toggle').should('have.class', 'disabled')

--- a/cypress/e2e/shared/fluxQueryBuilder.test.ts
+++ b/cypress/e2e/shared/fluxQueryBuilder.test.ts
@@ -496,8 +496,9 @@ describe('Script Builder', () => {
           )
           cy.getByTestID('flux-toolbar-search--input')
             .should('exist')
-            .type('schema')
-          cy.getByTestID('flux--fieldsAsCols').should('exist').click()
+            .type('fieldsAsCols')
+          cy.get('.flux-toolbar--list-item').first().click()
+          cy.getByTestID('flux-editor').contains('import')
           cy.getByTestID('flux-sync--toggle').should(
             'not.have.class',
             'disabled'

--- a/src/languageSupport/languages/flux/lsp/connection.ts
+++ b/src/languageSupport/languages/flux/lsp/connection.ts
@@ -33,12 +33,18 @@ import {event} from 'src/cloud/utils/reporting'
 
 // hardcoded in LSP
 const COMPOSITION_YIELD = '_editor_composition'
-const COMPOSITION_INIT_LINE = 1
+
+const findLastIndex = (arr, fn) =>
+  (arr
+    .map((val, i) => [i, val])
+    .filter(([i, val]) => fn(val, i, arr))
+    .pop() || [-1])[0]
 
 class LspConnectionManager {
   private _worker: Worker
   private _editor: EditorType
   private _model: MonacoTypes.editor.IModel
+  private _snapshot: MonacoTypes.editor.ITextSnapshot
   private _preludeModel: MonacoTypes.editor.IModel
   private _variables: Variable[] = []
   private _compositionStyle: string[] = []
@@ -120,14 +126,19 @@ class LspConnectionManager {
     this._worker.postMessage(msg)
   }
 
-  _getCompositionBlockLines() {
-    const query = this._model.getValue()
-    if (!query.includes(COMPOSITION_YIELD)) {
+  _getCompositionBlockLines(query) {
+    if (!query || !query.includes(COMPOSITION_YIELD)) {
       return null
     }
-    const startLine = COMPOSITION_INIT_LINE
+    const lines = query.split('\n')
+    // monacoEditor line indexing starts at 1..n
     const endLine =
-      query.split('\n').findIndex(line => line.includes(COMPOSITION_YIELD)) + 1
+      lines.findIndex(line => line.includes(COMPOSITION_YIELD)) + 1
+    const startLine =
+      findLastIndex(lines.slice(0, endLine - 1), line =>
+        line.includes('from(')
+      ) + 1
+
     return {startLine, endLine}
   }
 
@@ -153,7 +164,11 @@ class LspConnectionManager {
   }
 
   _editorChangeIsWithinComposition(change) {
-    const compositionBlock = this._getCompositionBlockLines()
+    const compositionBlock = this._getCompositionBlockLines(
+      this._snapshot.read()
+    )
+    this._snapshot = this._model.createSnapshot()
+
     if (!compositionBlock) {
       return false
     }
@@ -195,7 +210,9 @@ class LspConnectionManager {
     })
 
     comments(this._editor, selection => {
-      const compositionBlock = this._getCompositionBlockLines()
+      const compositionBlock = this._getCompositionBlockLines(
+        this._model.getValue()
+      )
       if (!compositionBlock) {
         return
       }
@@ -240,7 +257,9 @@ class LspConnectionManager {
   }
 
   _setEditorBlockStyle(schema: CompositionSelection = this._session) {
-    const compositionBlock = this._getCompositionBlockLines()
+    const compositionBlock = this._getCompositionBlockLines(
+      this._model.getValue()
+    )
 
     const removeAllStyles = !compositionBlock || schema.composition.diverged
 
@@ -399,6 +418,8 @@ class LspConnectionManager {
   }
 
   _initCompositionHandlers() {
+    this._snapshot = this._model.createSnapshot()
+
     // handlers to trigger end composition
     this._setEditorIrreversibleExit()
 

--- a/src/languageSupport/languages/flux/lsp/connection.ts
+++ b/src/languageSupport/languages/flux/lsp/connection.ts
@@ -263,15 +263,15 @@ class LspConnectionManager {
 
     const removeAllStyles = !compositionBlock || schema.composition.diverged
 
-    const compositionSyncStyle = this._compositionSyncStyle(
-      compositionBlock?.startLine,
-      compositionBlock?.endLine,
-      schema.composition.synced
-    )
-
     this._compositionStyle = this._editor.deltaDecorations(
       this._compositionStyle,
-      removeAllStyles ? [] : compositionSyncStyle
+      removeAllStyles
+        ? []
+        : this._compositionSyncStyle(
+            compositionBlock?.startLine,
+            compositionBlock?.endLine,
+            schema.composition.synced
+          )
     )
   }
 


### PR DESCRIPTION
Part of #6063 


## Bug:
* onChange() detect:
  * occurs **after** change is applied.
  * the change object's positional information (range lines), are based on the previous editor value **before the change** was applied
* solution:
  * to really see if change occurred within the composition block, we need to compare to the snapshot editor text from **before** the change.

 ## Vid:

https://user-images.githubusercontent.com/10232835/195953925-6fc436bf-8d5e-40c7-a6d4-cd28dc082716.mov



   

## Checklist
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] ~Feature flagged, if applicable~ Already behind flag.
