### PR TITLE
chore: speed up flux query builder test

### DIFF
--- a/cypress/e2e/shared/fluxQueryBuilder.test.ts
+++ b/cypress/e2e/shared/fluxQueryBuilder.test.ts
@@ -74,6 +74,11 @@ describe('Script Builder', () => {
     })
   }
 
+  Cypress.on('uncaught:exception', (err, _) => {
+    console.error(err)
+    return false
+  })
+
   const loginWithFlags = flags => {
     return cy.signinWithoutUserReprovision().then(() => {
       cy.get('@org').then(({id}: Organization) => {

--- a/cypress/index.d.ts
+++ b/cypress/index.d.ts
@@ -4,6 +4,7 @@ import 'cypress-plugin-tab'
 
 import {
   signin,
+  signinWithoutUserReprovision,
   setupUser,
   createDashboard,
   createCell,
@@ -61,6 +62,7 @@ declare global {
   namespace Cypress {
     interface Chainable {
       signin: typeof signin
+      signinWithoutUserReprovision: typeof signinWithoutUserReprovision
       setupUser: typeof setupUser
       clickAttached: typeof clickAttached
       clickNavBarItem: typeof clickNavBarItem

--- a/src/dataExplorer/components/FluxQueryBuilder.tsx
+++ b/src/dataExplorer/components/FluxQueryBuilder.tsx
@@ -158,6 +158,7 @@ const FluxQueryBuilder: FC = () => {
                         : ComponentStatus.Disabled
                     }
                     text="Save"
+                    testID="flux-query-builder--save-script"
                     icon={IconFont.SaveOutline}
                   />
                 )}


### PR DESCRIPTION
Speed up fluxQueryBuilder test suite, by:
* avoid the re-provisioning of user in the `signin()` method
   * note: still have to do a login before each it() test. 
* add all user mock data only once, in a single `before()` method
* use newScript, rather than sessionStore clearing + page reload
* combined the hotkeys to a single test

Outcome:
<img width="529" alt="Screen Shot 2022-10-18 at 1 20 55 AM" src="https://user-images.githubusercontent.com/10232835/196376465-299212f7-1ef6-4aea-b659-48051e9adc6b.png">
<img width="530" alt="Screen Shot 2022-10-18 at 1 20 38 AM" src="https://user-images.githubusercontent.com/10232835/196376468-6b397f75-5055-40cd-b628-54c822d21058.png">




## Checklist
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] ~Feature flagged, if applicable~ N/A
