### PR TITLE
feat: add createNewOrg and fetchClusters to API layer

### DIFF
--- a/src/accounts/context/userAccount.tsx
+++ b/src/accounts/context/userAccount.tsx
@@ -19,7 +19,7 @@ import {event} from 'src/cloud/utils/reporting'
 
 // API
 import {
-  getUserAccounts,
+  fetchUserAccounts,
   updateDefaultQuartzAccount,
   updateUserAccount,
 } from 'src/identity/apis/account'
@@ -83,7 +83,7 @@ export const UserAccountProvider: FC<Props> = React.memo(({children}) => {
 
   const handleGetAccounts = useCallback(async () => {
     try {
-      const accounts = await getUserAccounts()
+      const accounts = await fetchUserAccounts()
       setUserAccounts(accounts)
       const defaultAcct = accounts.find(acct => acct.isDefault === true)
       if (typeof defaultAcct === 'object' && defaultAcct.hasOwnProperty('id')) {

--- a/src/identity/apis/account.ts
+++ b/src/identity/apis/account.ts
@@ -22,7 +22,7 @@ export interface CurrentAccount extends IdentityAccount {
 }
 
 // get a list of the user's accounts
-export const getUserAccounts = async (): Promise<UserAccount[]> => {
+export const fetchUserAccounts = async (): Promise<UserAccount[]> => {
   const response = await getAccounts({})
 
   if (response.status === 401) {

--- a/src/shared/components/NotFound.tsx
+++ b/src/shared/components/NotFound.tsx
@@ -34,7 +34,7 @@ import {Organization} from 'src/types'
 import {CLOUD} from 'src/shared/constants'
 
 // API
-import {getDefaultAccountDefaultOrg} from 'src/identity/apis/org'
+import {fetchDefaultAccountDefaultOrg} from 'src/identity/apis/org'
 
 const NotFoundNew: FC = () => (
   <AppWrapper type="funnel" className="page-not-found" testID="not-found">
@@ -147,7 +147,7 @@ const NotFound: FC = () => {
       if (CLOUD) {
         try {
           setIsFetchingOrg(true)
-          const defaultQuartzOrg = await getDefaultAccountDefaultOrg()
+          const defaultQuartzOrg = await fetchDefaultAccountDefaultOrg()
           org.current = defaultQuartzOrg
         } catch {
           history.push(`/no-orgs`)

--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -1,6 +1,7 @@
 export enum NetworkErrorTypes {
   UnauthorizedError = 'UnauthorizedError', // 401
   NotFoundError = 'NotFoundError', // 404
+  OrgNameConflictError = 'OrgNameConflictError', // 409
   UnprocessableEntityError = 'UnprocessableEntity', // 422
   ServerError = 'ServerError', // 500
   GenericError = 'GenericError',
@@ -19,6 +20,14 @@ export class NotFoundError extends Error {
   constructor(message) {
     super(message)
     this.name = 'NotFoundError'
+  }
+}
+
+// 409 Error
+export class OrgNameConflictError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'OrgNameConflictError'
   }
 }
 


### PR DESCRIPTION
Helps with #5932, #5894

Adds UI API layer support for the quartz endpoints for creating orgs (`POST` /orgs) and getting the list of available clusters in which an org can be created (`GET` /clusters).

Matching openAPI specs: [create orgs](https://github.com/influxdata/openapi/blob/master/src/unity/paths/orgs.yml), [get clusters](https://github.com/influxdata/openapi/blob/master/src/unity/paths/clusters.yml).

Create Orgs Response
--
In quartz-remocal, we get a `401` as expected, as the default free account cannot create more than one org.
![Screen Shot 2022-10-14 at 5 11 27 PM](https://user-images.githubusercontent.com/91283923/195944682-56eb2376-90a3-4f49-8335-e722a94e941a.png)

Get Clusters Response
--
![Screen Shot 2022-10-14 at 4 23 44 PM](https://user-images.githubusercontent.com/91283923/195938508-b2be5162-3e3d-4d4e-8caa-3309d47bf25c.png)

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable
