### PR TITLE
fix(about): target parent element to access content

### DIFF
--- a/cypress/e2e/shared/about.test.ts
+++ b/cypress/e2e/shared/about.test.ts
@@ -32,7 +32,7 @@ describe('About Page', () => {
     cy.getByTestID('copy-btn--orgid').should('not.be.disabled')
 
     if (CLOUD) {
-      cy.getByTestID('org-profile--panel').contains('Cloud Provider')
+      cy.getByTestID('org-profile--labeled_data').contains('Cloud Provider')
     }
 
     cy.getByTestID('rename-org--button').should('be.visible').click()

--- a/cypress/e2e/shared/about.test.ts
+++ b/cypress/e2e/shared/about.test.ts
@@ -32,7 +32,7 @@ describe('About Page', () => {
     cy.getByTestID('copy-btn--orgid').should('not.be.disabled')
 
     if (CLOUD) {
-      cy.getByTestID('org-profile--labeled_data').contains('Cloud Provider')
+      cy.getByTestID('org-profile--labeled-data').contains('Cloud Provider')
     }
 
     cy.getByTestID('rename-org--button').should('be.visible').click()

--- a/src/organizations/components/OrgProfileTab/index.tsx
+++ b/src/organizations/components/OrgProfileTab/index.tsx
@@ -80,7 +80,7 @@ const OrgProfileTab: FC = () => {
             justifyContent={JustifyContent.SpaceBetween}
             stretchToFitWidth={true}
             style={orgProviderExists ? {width: '85%'} : {width: '48%'}}
-            testID="org-profile--labeled_data"
+            testID="org-profile--labeled-data"
           >
             {orgProviderExists && (
               <LabeledData label="Cloud Provider" src={quartzOrg.provider} />

--- a/src/organizations/components/OrgProfileTab/index.tsx
+++ b/src/organizations/components/OrgProfileTab/index.tsx
@@ -80,6 +80,7 @@ const OrgProfileTab: FC = () => {
             justifyContent={JustifyContent.SpaceBetween}
             stretchToFitWidth={true}
             style={orgProviderExists ? {width: '85%'} : {width: '48%'}}
+            testID="org-profile--labeled_data"
           >
             {orgProviderExists && (
               <LabeledData label="Cloud Provider" src={quartzOrg.provider} />


### PR DESCRIPTION
Part of #6109 

Pr fixes a flaky test  in shared folder -  `about` e2e test. 
Flakiness is caused by failure to find text content `Cloud Provider` within DOM element. 

Fix: target direct parent element of text content.
<img width="605" alt="Screen Shot 2022-10-18 at 10 19 04 AM" src="https://user-images.githubusercontent.com/66275100/196473935-7193e591-304c-4967-8bdc-3892aa061801.png">

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
