### PR TITLE
test(operator): provide orgid to hit NotFound page

### DIFF
--- a/cypress/e2e/cloud/operator.test.ts
+++ b/cypress/e2e/cloud/operator.test.ts
@@ -1,3 +1,5 @@
+import {Organization} from '../../../src/types'
+
 describe('Operator Page', () => {
   beforeEach(() =>
     cy.flush().then(() =>
@@ -239,12 +241,14 @@ describe('Operator Page should not be accessible for non-operator users', () => 
   beforeEach(() =>
     cy.flush().then(() =>
       cy.signin().then(() => {
-        cy.get('@org').then(() => {
-          cy.getByTestID('home-page--header').should('be.visible')
-          cy.quartzProvision({
-            isOperator: false,
-          }).then(() => {
-            cy.visit(`/operator`)
+        cy.get('@org').then(({id}: Organization) => {
+          cy.fixture('routes').then(({orgs}) => {
+            cy.getByTestID('home-page--header').should('be.visible')
+            cy.quartzProvision({
+              isOperator: false,
+            }).then(() => {
+              cy.visit(`${orgs}/${id}/operator`)
+            })
           })
         })
       })


### PR DESCRIPTION
Closes #6109 


https://user-images.githubusercontent.com/66275100/196504286-754c6408-b301-4abc-8883-51716d38857d.mov

There is a useEffect hook inside `SetOrg.tsx` that redirects user to `/no-orgs` page if `orgID` from url doesn't match any orgs that exist. 
When Operator test is run in circle ci, and it tries to access `/operator`, this useEffect hook intervenes and re-routes page to `/no-orgs` since the url at that instance doesn't have any orgs or orgID. 

Pr tries to fix this by providing an org and org id in the url, so it can properly get routed to `NotFound` page. 


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
