### PR TITLE
feat: update openAPI SHA and add fetchOrgCreationAllowance to UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "cy": "CYPRESS_dexUrl=https://$INGRESS_HOST:$PORT_HTTPS CYPRESS_baseUrl=http://localhost:9999 cypress open",
     "cy:dev": "source ../monitor-ci/.env && CYPRESS_dexUrl=CLOUD CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{cloud,shared}/**/*.*'",
     "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_dexUrl=OSS CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{oss,shared}/**/*.*'",
-    "generate": "export SHA=f495434ca24ea945785919934e330b3138de03a7 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
+    "generate": "export SHA=4b8c02d04b82958996096a965b2e1c078f031763 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-local-cloud": "export REMOTE=../openapi/ && yarn generate-meta-cloud",
     "generate-meta": "if [ -z \"${CLOUD_URL}\" ]; then yarn generate-meta-oss; else yarn generate-meta-cloud; fi",

--- a/src/identity/apis/org.ts
+++ b/src/identity/apis/org.ts
@@ -2,6 +2,7 @@
 import {
   getAccounts,
   getAccountsOrgs,
+  getAllowancesOrgsCreate,
   getClusters,
   getOrg,
   postOrg,
@@ -115,6 +116,19 @@ export const fetchDefaultAccountDefaultOrg = async (): Promise<
     }
     throw new GenericError('No default account found')
   }
+}
+
+// fetch data regarding whether the user can create new orgs, and associated upgrade options.
+export const fetchOrgCreationAllowance = async () => {
+  const response = await getAllowancesOrgsCreate({})
+
+  if (response.status !== 200) {
+    throw new GenericError(
+      'Failed to determine whether this user can create a new organization.'
+    )
+  }
+
+  return response.data
 }
 
 // fetch the list of organizations associated with a given account ID


### PR DESCRIPTION
Helps with #6121 

Updates the openAPI SHA to pull in the [spec for getAllowancesOrgsCreate](https://github.com/influxdata/openapi/commit/f7cc87286abffcea007df69e74b4162f9f1790b3), and adds it to the UI API layer.

Not used, and AIM hasn't added this endpoint to quartz yet. It will be mocked in quartz-mock so we can proceed with UI development until the endpoint is ready.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - NO - NOT YET USED
