### PR TITLE
feat: add multi-query support for Adaptive Zoom

### DIFF
--- a/src/shared/apis/queryCache.ts
+++ b/src/shared/apis/queryCache.ts
@@ -5,7 +5,10 @@ import {sortBy} from 'lodash'
 import {asAssignment, getAllVariables} from 'src/variables/selectors'
 import {buildUsedVarsOption} from 'src/variables/utils/buildVarsOption'
 import {filterUnusedVarsBasedOnQuery} from 'src/shared/utils/filterUnusedVars'
-import {getWindowVarsFromVariables} from 'src/variables/utils/getWindowVars'
+import {
+  getWindowVarsFromVariables,
+  normalizeWindowPeriodVariableForZoomRequery,
+} from 'src/variables/utils/getWindowVars'
 
 // Types
 import {
@@ -210,7 +213,9 @@ const hasWindowVars = (variables: VariableAssignment[]): boolean =>
 export const getCachedResultsOrRunQuery = (
   orgID: string,
   query: string,
-  allVars: Variable[]
+  allVars: Variable[],
+  isAdaptiveZoom: boolean = false,
+  adaptiveWindowPeriod: number = 0
 ): CancelBox<RunQueryResult> => {
   const {queryID, variables, hashedVariables} = calculateHashedVariables(
     allVars,
@@ -236,7 +241,12 @@ export const getCachedResultsOrRunQuery = (
   let windowVars = []
 
   if (hasWindowVars(variableAssignments) === false) {
-    windowVars = getWindowVarsFromVariables(query, variables)
+    windowVars = isAdaptiveZoom
+      ? normalizeWindowPeriodVariableForZoomRequery(
+          getWindowVarsFromVariables(query, variables),
+          adaptiveWindowPeriod
+        )
+      : getWindowVarsFromVariables(query, variables)
   }
 
   // otherwise query & set results

--- a/src/visualization/types/Band/view.tsx
+++ b/src/visualization/types/Band/view.tsx
@@ -125,15 +125,18 @@ const BandPlot: FC<Props> = ({
     [result.table, yColumn]
   )
 
-  const zoomQuery = useZoomQuery(properties)
+  const {activeQueryIndex, queries: zoomQueries} = useZoomQuery(
+    properties.queries
+  )
 
   const [xDomain, onSetXDomain, onResetXDomain] = useZoomRequeryXDomainSettings(
     {
+      activeQueryIndex,
       adaptiveZoomHide: properties.adaptiveZoomHide,
       data: resultState.table.getColumn(xColumn, 'number'),
       parsedResult: resultState,
       preZoomResult,
-      query: zoomQuery,
+      queries: zoomQueries,
       setPreZoomResult,
       setRequeryStatus,
       setResult: setResultState,
@@ -145,11 +148,12 @@ const BandPlot: FC<Props> = ({
 
   const [yDomain, onSetYDomain, onResetYDomain] = useZoomRequeryYDomainSettings(
     {
+      activeQueryIndex,
       adaptiveZoomHide: properties.adaptiveZoomHide,
       data: memoizedYColumnData,
       parsedResult: resultState,
       preZoomResult,
-      query: zoomQuery,
+      queries: zoomQueries,
       setPreZoomResult,
       setRequeryStatus,
       setResult: setResultState,

--- a/src/visualization/types/Graph/view.tsx
+++ b/src/visualization/types/Graph/view.tsx
@@ -172,15 +172,18 @@ const XYPlot: FC<Props> = ({
     properties.position,
   ])
 
-  const zoomQuery = useZoomQuery(properties)
+  const {activeQueryIndex, queries: zoomQueries} = useZoomQuery(
+    properties.queries
+  )
 
   const [xDomain, onSetXDomain, onResetXDomain] = useZoomRequeryXDomainSettings(
     {
+      activeQueryIndex,
       adaptiveZoomHide: properties.adaptiveZoomHide,
       data: resultState.table.getColumn(xColumn, 'number'),
       parsedResult: resultState,
       preZoomResult,
-      query: zoomQuery,
+      queries: zoomQueries,
       setPreZoomResult,
       setRequeryStatus,
       setResult: setResultState,
@@ -192,11 +195,12 @@ const XYPlot: FC<Props> = ({
 
   const [yDomain, onSetYDomain, onResetYDomain] = useZoomRequeryYDomainSettings(
     {
+      activeQueryIndex,
       adaptiveZoomHide: properties.adaptiveZoomHide,
       data: memoizedYColumnData,
       parsedResult: resultState,
       preZoomResult,
-      query: zoomQuery,
+      queries: zoomQueries,
       setPreZoomResult,
       setRequeryStatus,
       setResult: setResultState,

--- a/src/visualization/types/Scatter/view.tsx
+++ b/src/visualization/types/Scatter/view.tsx
@@ -70,15 +70,18 @@ const ScatterPlot: FunctionComponent<Props> = ({
   const tooltipColorize = properties.legendColorizeRows
   const tooltipOrientationThreshold = properties.legendOrientationThreshold
 
-  const zoomQuery = useZoomQuery(properties)
+  const {activeQueryIndex, queries: zoomQueries} = useZoomQuery(
+    properties.queries
+  )
 
   const [xDomain, onSetXDomain, onResetXDomain] = useZoomRequeryXDomainSettings(
     {
+      activeQueryIndex,
       adaptiveZoomHide: properties.adaptiveZoomHide,
       data: resultState.table.getColumn(xColumn, 'number'),
       parsedResult: resultState,
       preZoomResult,
-      query: zoomQuery,
+      queries: zoomQueries,
       setPreZoomResult,
       setRequeryStatus,
       setResult: setResultState,
@@ -90,11 +93,12 @@ const ScatterPlot: FunctionComponent<Props> = ({
 
   const [yDomain, onSetYDomain, onResetYDomain] = useZoomRequeryYDomainSettings(
     {
+      activeQueryIndex,
       adaptiveZoomHide: properties.adaptiveZoomHide,
       data: resultState.table.getColumn(yColumn, 'number'),
       parsedResult: resultState,
       preZoomResult,
-      query: zoomQuery,
+      queries: zoomQueries,
       setPreZoomResult,
       setRequeryStatus,
       setResult: setResultState,

--- a/src/visualization/types/SingleStatWithLine/view.tsx
+++ b/src/visualization/types/SingleStatWithLine/view.tsx
@@ -158,15 +158,18 @@ const SingleStatWithLine: FC<Props> = ({
     properties.position,
   ])
 
-  const zoomQuery = useZoomQuery(properties)
+  const {activeQueryIndex, queries: zoomQueries} = useZoomQuery(
+    properties.queries
+  )
 
   const [xDomain, onSetXDomain, onResetXDomain] = useZoomRequeryXDomainSettings(
     {
+      activeQueryIndex,
       adaptiveZoomHide: properties.adaptiveZoomHide,
       data: resultState.table.getColumn(xColumn, 'number'),
       parsedResult: resultState,
       preZoomResult,
-      query: zoomQuery,
+      queries: zoomQueries,
       setPreZoomResult,
       setRequeryStatus,
       setResult: setResultState,
@@ -178,11 +181,12 @@ const SingleStatWithLine: FC<Props> = ({
 
   const [yDomain, onSetYDomain, onResetYDomain] = useZoomRequeryYDomainSettings(
     {
+      activeQueryIndex,
       adaptiveZoomHide: properties.adaptiveZoomHide,
       data: memoizedYColumnData,
       parsedResult: resultState,
       preZoomResult,
-      query: zoomQuery,
+      queries: zoomQueries,
       setPreZoomResult,
       setRequeryStatus,
       setResult: setResultState,

--- a/src/visualization/utils/useVisDomainSettings.ts
+++ b/src/visualization/utils/useVisDomainSettings.ts
@@ -271,10 +271,10 @@ export const useZoomRequeryXDomainSettings = (args: ZoomRequeryArgs) => {
   }, [domain]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // sync preZoomDomain and domain:
-  //   if it is the value axis (not time)
-  //   only when not zoomed in
-  //     - if they are different, or
-  //     - if it is the time axis and the time range has changed
+  //   if it is the value axis (not time), or
+  //   if it is the time axis only when not zoomed in, and
+  //      - they are different, or
+  //      - the time range has changed
   useEffect(() => {
     if (
       !timeRange ||
@@ -449,10 +449,10 @@ export const useZoomRequeryYDomainSettings = (args: ZoomRequeryArgs) => {
   }, [domain]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // sync preZoomDomain and domain:
-  //   if it is the value axis (not time)
-  //   only when not zoomed in
-  //     - if they are different, or
-  //     - if it is the time axis and the time range has changed
+  //   if it is the value axis (not time), or
+  //   if it is the time axis only when not zoomed in, and
+  //      - they are different, or
+  //      - the time range has changed
   useEffect(() => {
     if (
       !timeRange ||

--- a/src/visualization/utils/useVisDomainSettings.ts
+++ b/src/visualization/utils/useVisDomainSettings.ts
@@ -270,14 +270,17 @@ export const useZoomRequeryXDomainSettings = (args: ZoomRequeryArgs) => {
     }
   }, [domain]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // sync preZoomDomain and domain only when not zoomed in
-  //   - if they are different, or
-  //   - if it is the time axis and the time range has changed
+  // sync preZoomDomain and domain:
+  //   if it is the value axis (not time)
+  //   only when not zoomed in
+  //     - if they are different, or
+  //     - if it is the time axis and the time range has changed
   useEffect(() => {
     if (
-      !preZoomResult &&
-      (isNotEqual(preZoomDomain, domain) ||
-        (timeRange && isNotEqual(timeRange, selectedTimeRange)))
+      !timeRange ||
+      (!preZoomResult &&
+        (isNotEqual(preZoomDomain, domain) ||
+          (timeRange && isNotEqual(timeRange, selectedTimeRange))))
     ) {
       setSelectedTimeRange(timeRange)
       setDomain(preZoomDomain)
@@ -445,14 +448,17 @@ export const useZoomRequeryYDomainSettings = (args: ZoomRequeryArgs) => {
     }
   }, [domain]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // sync preZoomDomain and domain only when not zoomed in
-  //   - if they are different, or
-  //   - if it is the time axis and the time range has changed
+  // sync preZoomDomain and domain:
+  //   if it is the value axis (not time)
+  //   only when not zoomed in
+  //     - if they are different, or
+  //     - if it is the time axis and the time range has changed
   useEffect(() => {
     if (
-      !preZoomResult &&
-      (isNotEqual(preZoomDomain, domain) ||
-        (timeRange && isNotEqual(timeRange, selectedTimeRange)))
+      !timeRange ||
+      (!preZoomResult &&
+        (isNotEqual(preZoomDomain, domain) ||
+          (timeRange && isNotEqual(timeRange, selectedTimeRange))))
     ) {
       setSelectedTimeRange(timeRange)
       setDomain(preZoomDomain)

--- a/src/visualization/utils/useVisDomainSettings.ts
+++ b/src/visualization/utils/useVisDomainSettings.ts
@@ -215,7 +215,7 @@ export const useZoomRequeryXDomainSettings = (args: ZoomRequeryArgs) => {
   const [windowPeriod, setWindowPeriod] = useState<number>(
     normalizeWindowPeriodForZoomRequery(
       getWindowPeriodFromVariables(
-        activeQueryIndex >= 0 ? queries[activeQueryIndex] : '',
+        queries?.[activeQueryIndex] ?? '',
         variables
       ),
       timeRange,
@@ -390,7 +390,7 @@ export const useZoomRequeryYDomainSettings = (args: ZoomRequeryArgs) => {
   const [windowPeriod, setWindowPeriod] = useState<number>(
     normalizeWindowPeriodForZoomRequery(
       getWindowPeriodFromVariables(
-        activeQueryIndex >= 0 ? queries[activeQueryIndex] : '',
+        queries?.[activeQueryIndex] ?? '',
         variables
       ),
       timeRange,

--- a/src/visualization/utils/useVisDomainSettings.ts
+++ b/src/visualization/utils/useVisDomainSettings.ts
@@ -5,7 +5,10 @@ import {NumericColumnData, fromFlux} from '@influxdata/giraffe'
 import {isEqual} from 'lodash'
 
 // API
-import {runQuery, RunQueryResult} from 'src/shared/apis/query'
+import {
+  getCachedResultsOrRunQuery,
+  resetQueryCacheByQuery,
+} from 'src/shared/apis/queryCache'
 
 // Selectors
 import {getOrg} from 'src/organizations/selectors'
@@ -15,18 +18,16 @@ import {getAllVariablesForZoomRequery} from 'src/variables/selectors'
 // Utils
 import {useOneWayState} from 'src/shared/utils/useOneWayState'
 import {extent} from 'src/shared/utils/vis'
-import {buildUsedVarsOption} from 'src/variables/utils/buildVarsOption'
 import {event} from 'src/cloud/utils/reporting'
 import {
   getWindowPeriodFromVariables,
-  getWindowVarsFromVariables,
   normalizeWindowPeriodForZoomRequery,
-  normalizeWindowPeriodVariableForZoomRequery,
 } from 'src/variables/utils/getWindowVars'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Types
 import {AppState, InternalFromFluxResult, TimeRange} from 'src/types'
+import {RunQueryResult} from 'src/shared/apis/query'
 import {RemoteDataState} from '@influxdata/clockface'
 
 /*
@@ -143,11 +144,12 @@ export const useVisYDomainSettings = (
 }
 
 interface ZoomRequeryArgs {
+  activeQueryIndex: number
   adaptiveZoomHide: boolean
   data: NumericColumnData | string[]
   parsedResult: InternalFromFluxResult
   preZoomResult: InternalFromFluxResult
-  query: string
+  queries: string[]
   setPreZoomResult: Function
   setRequeryStatus: Function
   setResult: Function
@@ -161,11 +163,12 @@ const isNotEqual = (firstValue: any, secondValue: any): boolean =>
 
 export const useZoomRequeryXDomainSettings = (args: ZoomRequeryArgs) => {
   const {
+    activeQueryIndex,
     adaptiveZoomHide,
     data,
     parsedResult,
     preZoomResult,
-    query,
+    queries,
     setPreZoomResult,
     setRequeryStatus,
     setResult,
@@ -211,7 +214,7 @@ export const useZoomRequeryXDomainSettings = (args: ZoomRequeryArgs) => {
 
   const [windowPeriod, setWindowPeriod] = useState<number>(
     normalizeWindowPeriodForZoomRequery(
-      getWindowPeriodFromVariables(query, variables),
+      getWindowPeriodFromVariables(queries[activeQueryIndex], variables),
       timeRange,
       domain,
       data
@@ -220,7 +223,7 @@ export const useZoomRequeryXDomainSettings = (args: ZoomRequeryArgs) => {
 
   useEffect(() => {
     const updatedWindowPeriod = normalizeWindowPeriodForZoomRequery(
-      getWindowPeriodFromVariables(query, variables),
+      getWindowPeriodFromVariables(queries[activeQueryIndex], variables),
       timeRange,
       domain,
       data
@@ -230,30 +233,33 @@ export const useZoomRequeryXDomainSettings = (args: ZoomRequeryArgs) => {
       setWindowPeriod(updatedWindowPeriod)
 
       if (isNotEqual(preZoomDomain, domain)) {
-        const zoomQueryWindowVariable =
-          normalizeWindowPeriodVariableForZoomRequery(
-            getWindowVarsFromVariables(query, variables),
-            updatedWindowPeriod
-          )
-
-        const extern = buildUsedVarsOption(
-          query,
-          variables,
-          zoomQueryWindowVariable
-        )
-
         setRequeryStatus(RemoteDataState.Loading)
-        runQuery(orgId, query, extern).promise.then(
-          (result: RunQueryResult) => {
-            if (result?.type === 'SUCCESS') {
-              setRequeryStatus(RemoteDataState.Done)
-              if (result?.csv?.trim().length > 0) {
-                setResult(fromFlux(result.csv))
+        Promise.all(
+          queries.map(query => {
+            resetQueryCacheByQuery(query, variables)
+            return getCachedResultsOrRunQuery(
+              orgId,
+              query,
+              variables,
+              isFlagEnabled('zoomRequery') && !adaptiveZoomHide,
+              updatedWindowPeriod
+            ).promise.then((result: RunQueryResult) => {
+              if (result.type === 'SUCCESS') {
+                return result.csv?.trim()
+              } else {
+                return ''
               }
-            } else {
-              setRequeryStatus(RemoteDataState.Error)
+            })
+          })
+        ).then(
+          pendingResults => {
+            const combinedResults = pendingResults.join('\n\n')
+            if (combinedResults.trim().length > 0) {
+              setResult(fromFlux(combinedResults))
             }
-          }
+            setRequeryStatus(RemoteDataState.Done)
+          },
+          () => setRequeryStatus(RemoteDataState.Error)
         )
       }
     }
@@ -317,11 +323,12 @@ export const useZoomRequeryXDomainSettings = (args: ZoomRequeryArgs) => {
 
 export const useZoomRequeryYDomainSettings = (args: ZoomRequeryArgs) => {
   const {
+    activeQueryIndex,
     adaptiveZoomHide,
     data,
     parsedResult,
     preZoomResult,
-    query,
+    queries,
     setPreZoomResult,
     setRequeryStatus,
     setResult,
@@ -372,7 +379,7 @@ export const useZoomRequeryYDomainSettings = (args: ZoomRequeryArgs) => {
 
   const [windowPeriod, setWindowPeriod] = useState<number>(
     normalizeWindowPeriodForZoomRequery(
-      getWindowPeriodFromVariables(query, variables),
+      getWindowPeriodFromVariables(queries[activeQueryIndex], variables),
       timeRange,
       domain,
       data
@@ -381,7 +388,7 @@ export const useZoomRequeryYDomainSettings = (args: ZoomRequeryArgs) => {
 
   useEffect(() => {
     const updatedWindowPeriod = normalizeWindowPeriodForZoomRequery(
-      getWindowPeriodFromVariables(query, variables),
+      getWindowPeriodFromVariables(queries[activeQueryIndex], variables),
       timeRange,
       domain,
       data
@@ -391,30 +398,33 @@ export const useZoomRequeryYDomainSettings = (args: ZoomRequeryArgs) => {
       setWindowPeriod(updatedWindowPeriod)
 
       if (isNotEqual(preZoomDomain, domain)) {
-        const zoomQueryWindowVariable =
-          normalizeWindowPeriodVariableForZoomRequery(
-            getWindowVarsFromVariables(query, variables),
-            updatedWindowPeriod
-          )
-
-        const extern = buildUsedVarsOption(
-          query,
-          variables,
-          zoomQueryWindowVariable
-        )
-
         setRequeryStatus(RemoteDataState.Loading)
-        runQuery(orgId, query, extern).promise.then(
-          (result: RunQueryResult) => {
-            if (result?.type === 'SUCCESS') {
-              setRequeryStatus(RemoteDataState.Done)
-              if (result?.csv?.trim().length > 0) {
-                setResult(fromFlux(result.csv))
+        Promise.all(
+          queries.map(query => {
+            resetQueryCacheByQuery(query, variables)
+            return getCachedResultsOrRunQuery(
+              orgId,
+              query,
+              variables,
+              isFlagEnabled('zoomRequery') && !adaptiveZoomHide,
+              updatedWindowPeriod
+            ).promise.then((result: RunQueryResult) => {
+              if (result.type === 'SUCCESS') {
+                return result.csv?.trim()
+              } else {
+                return ''
               }
-            } else {
-              setRequeryStatus(RemoteDataState.Error)
+            })
+          })
+        ).then(
+          pendingResults => {
+            const combinedResults = pendingResults.join('\n\n')
+            if (combinedResults.trim().length > 0) {
+              setResult(fromFlux(combinedResults))
             }
-          }
+            setRequeryStatus(RemoteDataState.Done)
+          },
+          () => setRequeryStatus(RemoteDataState.Error)
         )
       }
     }

--- a/src/visualization/utils/useVisDomainSettings.ts
+++ b/src/visualization/utils/useVisDomainSettings.ts
@@ -214,7 +214,10 @@ export const useZoomRequeryXDomainSettings = (args: ZoomRequeryArgs) => {
 
   const [windowPeriod, setWindowPeriod] = useState<number>(
     normalizeWindowPeriodForZoomRequery(
-      getWindowPeriodFromVariables(queries[activeQueryIndex], variables),
+      getWindowPeriodFromVariables(
+        activeQueryIndex >= 0 ? queries[activeQueryIndex] : '',
+        variables
+      ),
       timeRange,
       domain,
       data
@@ -222,45 +225,47 @@ export const useZoomRequeryXDomainSettings = (args: ZoomRequeryArgs) => {
   )
 
   useEffect(() => {
-    const updatedWindowPeriod = normalizeWindowPeriodForZoomRequery(
-      getWindowPeriodFromVariables(queries[activeQueryIndex], variables),
-      timeRange,
-      domain,
-      data
-    )
+    if (queries.length && activeQueryIndex >= 0) {
+      const updatedWindowPeriod = normalizeWindowPeriodForZoomRequery(
+        getWindowPeriodFromVariables(queries[activeQueryIndex], variables),
+        timeRange,
+        domain,
+        data
+      )
 
-    if (isNotEqual(windowPeriod, updatedWindowPeriod)) {
-      setWindowPeriod(updatedWindowPeriod)
+      if (isNotEqual(windowPeriod, updatedWindowPeriod)) {
+        setWindowPeriod(updatedWindowPeriod)
 
-      if (isNotEqual(preZoomDomain, domain)) {
-        setRequeryStatus(RemoteDataState.Loading)
-        Promise.all(
-          queries.map(query => {
-            resetQueryCacheByQuery(query, variables)
-            return getCachedResultsOrRunQuery(
-              orgId,
-              query,
-              variables,
-              isFlagEnabled('zoomRequery') && !adaptiveZoomHide,
-              updatedWindowPeriod
-            ).promise.then((result: RunQueryResult) => {
-              if (result.type === 'SUCCESS') {
-                return result.csv?.trim()
-              } else {
-                return ''
-              }
+        if (isNotEqual(preZoomDomain, domain)) {
+          setRequeryStatus(RemoteDataState.Loading)
+          Promise.all(
+            queries.map(query => {
+              resetQueryCacheByQuery(query, variables)
+              return getCachedResultsOrRunQuery(
+                orgId,
+                query,
+                variables,
+                isFlagEnabled('zoomRequery') && !adaptiveZoomHide,
+                updatedWindowPeriod
+              ).promise.then((result: RunQueryResult) => {
+                if (result.type === 'SUCCESS') {
+                  return result.csv ?? ''
+                } else {
+                  return ''
+                }
+              })
             })
-          })
-        ).then(
-          pendingResults => {
-            const combinedResults = pendingResults.join('\n\n')
-            if (combinedResults.trim().length > 0) {
-              setResult(fromFlux(combinedResults))
-            }
-            setRequeryStatus(RemoteDataState.Done)
-          },
-          () => setRequeryStatus(RemoteDataState.Error)
-        )
+          ).then(
+            pendingResults => {
+              const combinedResults = pendingResults.join('\n\n')
+              if (combinedResults.trim().length > 0) {
+                setResult(fromFlux(combinedResults))
+              }
+              setRequeryStatus(RemoteDataState.Done)
+            },
+            () => setRequeryStatus(RemoteDataState.Error)
+          )
+        }
       }
     }
   }, [domain]) // eslint-disable-line react-hooks/exhaustive-deps
@@ -286,7 +291,12 @@ export const useZoomRequeryXDomainSettings = (args: ZoomRequeryArgs) => {
   }, [timeRange, transmitWindowPeriod, windowPeriod])
 
   // Suppresses adaptive zoom feature; must come after all hooks
-  if (!isFlagEnabled('zoomRequery') || adaptiveZoomHide) {
+  if (
+    !isFlagEnabled('zoomRequery') ||
+    adaptiveZoomHide ||
+    queries.length === 0 ||
+    activeQueryIndex < 0
+  ) {
     const setVisXDomain = (domain: NumericColumnData) => {
       setPreZoomDomain(domain)
       event('plot.zoom_in.xAxis', {zoomRequery: 'false'})
@@ -379,7 +389,10 @@ export const useZoomRequeryYDomainSettings = (args: ZoomRequeryArgs) => {
 
   const [windowPeriod, setWindowPeriod] = useState<number>(
     normalizeWindowPeriodForZoomRequery(
-      getWindowPeriodFromVariables(queries[activeQueryIndex], variables),
+      getWindowPeriodFromVariables(
+        activeQueryIndex >= 0 ? queries[activeQueryIndex] : '',
+        variables
+      ),
       timeRange,
       domain,
       data
@@ -387,45 +400,47 @@ export const useZoomRequeryYDomainSettings = (args: ZoomRequeryArgs) => {
   )
 
   useEffect(() => {
-    const updatedWindowPeriod = normalizeWindowPeriodForZoomRequery(
-      getWindowPeriodFromVariables(queries[activeQueryIndex], variables),
-      timeRange,
-      domain,
-      data
-    )
+    if (queries.length && activeQueryIndex >= 0) {
+      const updatedWindowPeriod = normalizeWindowPeriodForZoomRequery(
+        getWindowPeriodFromVariables(queries[activeQueryIndex], variables),
+        timeRange,
+        domain,
+        data
+      )
 
-    if (isNotEqual(windowPeriod, updatedWindowPeriod)) {
-      setWindowPeriod(updatedWindowPeriod)
+      if (isNotEqual(windowPeriod, updatedWindowPeriod)) {
+        setWindowPeriod(updatedWindowPeriod)
 
-      if (isNotEqual(preZoomDomain, domain)) {
-        setRequeryStatus(RemoteDataState.Loading)
-        Promise.all(
-          queries.map(query => {
-            resetQueryCacheByQuery(query, variables)
-            return getCachedResultsOrRunQuery(
-              orgId,
-              query,
-              variables,
-              isFlagEnabled('zoomRequery') && !adaptiveZoomHide,
-              updatedWindowPeriod
-            ).promise.then((result: RunQueryResult) => {
-              if (result.type === 'SUCCESS') {
-                return result.csv?.trim()
-              } else {
-                return ''
-              }
+        if (isNotEqual(preZoomDomain, domain)) {
+          setRequeryStatus(RemoteDataState.Loading)
+          Promise.all(
+            queries.map(query => {
+              resetQueryCacheByQuery(query, variables)
+              return getCachedResultsOrRunQuery(
+                orgId,
+                query,
+                variables,
+                isFlagEnabled('zoomRequery') && !adaptiveZoomHide,
+                updatedWindowPeriod
+              ).promise.then((result: RunQueryResult) => {
+                if (result.type === 'SUCCESS') {
+                  return result.csv ?? ''
+                } else {
+                  return ''
+                }
+              })
             })
-          })
-        ).then(
-          pendingResults => {
-            const combinedResults = pendingResults.join('\n\n')
-            if (combinedResults.trim().length > 0) {
-              setResult(fromFlux(combinedResults))
-            }
-            setRequeryStatus(RemoteDataState.Done)
-          },
-          () => setRequeryStatus(RemoteDataState.Error)
-        )
+          ).then(
+            pendingResults => {
+              const combinedResults = pendingResults.join('\n\n')
+              if (combinedResults.trim().length > 0) {
+                setResult(fromFlux(combinedResults))
+              }
+              setRequeryStatus(RemoteDataState.Done)
+            },
+            () => setRequeryStatus(RemoteDataState.Error)
+          )
+        }
       }
     }
   }, [domain]) // eslint-disable-line react-hooks/exhaustive-deps
@@ -451,7 +466,12 @@ export const useZoomRequeryYDomainSettings = (args: ZoomRequeryArgs) => {
   }, [timeRange, transmitWindowPeriod, windowPeriod])
 
   // Suppresses adaptive zoom feature; must come after all hooks
-  if (!isFlagEnabled('zoomRequery') || adaptiveZoomHide) {
+  if (
+    !isFlagEnabled('zoomRequery') ||
+    adaptiveZoomHide ||
+    queries.length === 0 ||
+    activeQueryIndex < 0
+  ) {
     const setVisYDomain = (domain: NumericColumnData | string) => {
       setPreZoomDomain(domain)
       event('plot.zoom_in.yAxis', {zoomRequery: 'false'})

--- a/src/visualization/utils/useZoomQuery.ts
+++ b/src/visualization/utils/useZoomQuery.ts
@@ -1,26 +1,47 @@
 // Libraries
 import {useContext} from 'react'
+import {useSelector} from 'react-redux'
+
+// Types
+import {DashboardQuery} from 'src/types'
 
 // Context
 import {PipeContext} from 'src/flows/context/pipe'
 import {FlowQueryContext} from 'src/flows/context/flow.query'
 import {PersistanceContext} from 'src/dataExplorer/context/persistance'
 
-export const useZoomQuery = (properties): string => {
+// Selector
+import {getActiveQueryIndex} from 'src/timeMachine/selectors'
+
+interface ZoomQueries {
+  activeQueryIndex: number
+  queries: string[]
+}
+
+export const useZoomQuery = (queries: DashboardQuery[] = []): ZoomQueries => {
+  const activeQueryIndex = useSelector(getActiveQueryIndex)
   const {query} = useContext(PersistanceContext)
   const {id} = useContext(PipeContext)
   const {getPanelQueries} = useContext(FlowQueryContext)
-  const queryTextFromProperties = properties?.queries?.[0]?.text ?? ''
-
-  let zoomQuery = ''
+  const queryTexts = queries.map(query => `${query.text}`) ?? ['']
 
   if (id) {
-    zoomQuery = getPanelQueries(id)?.visual ?? ''
-  } else if (queryTextFromProperties) {
-    zoomQuery = queryTextFromProperties
-  } else {
-    zoomQuery = query
+    // Notebooks
+    return {
+      activeQueryIndex: 0,
+      queries: [getPanelQueries(id)?.visual ?? ''],
+    }
   }
-
-  return zoomQuery
+  if (queryTexts) {
+    // Old Data Explorer & Dashboard Cells
+    return {
+      activeQueryIndex,
+      queries: queryTexts,
+    }
+  }
+  // New Data Explorer
+  return {
+    activeQueryIndex: 0,
+    queries: [query],
+  }
 }

--- a/src/visualization/utils/useZoomQuery.ts
+++ b/src/visualization/utils/useZoomQuery.ts
@@ -8,7 +8,10 @@ import {DashboardQuery} from 'src/types'
 // Context
 import {PipeContext} from 'src/flows/context/pipe'
 import {FlowQueryContext} from 'src/flows/context/flow.query'
-import {PersistanceContext} from 'src/dataExplorer/context/persistance'
+import {
+  DEFAULT_EDITOR_TEXT,
+  PersistanceContext,
+} from 'src/dataExplorer/context/persistance'
 
 // Selector
 import {getActiveQueryIndex} from 'src/timeMachine/selectors'
@@ -23,25 +26,38 @@ export const useZoomQuery = (queries: DashboardQuery[] = []): ZoomQueries => {
   const {query} = useContext(PersistanceContext)
   const {id} = useContext(PipeContext)
   const {getPanelQueries} = useContext(FlowQueryContext)
-  const queryTexts = queries.map(query => `${query.text}`) ?? ['']
+  const queryTexts = queries.map(query => `${query.text}`)
+  const isQueryTextsEmpty =
+    queryTexts.length === 0 ||
+    queryTexts.every(query => query.trim().length === 0)
 
+  // Notebooks
   if (id) {
-    // Notebooks
     return {
       activeQueryIndex: 0,
       queries: [getPanelQueries(id)?.visual ?? ''],
     }
   }
-  if (queryTexts) {
-    // Old Data Explorer & Dashboard Cells
+
+  // Old Data Explorer & Dashboard Cells
+  if (!isQueryTextsEmpty) {
     return {
       activeQueryIndex,
       queries: queryTexts,
     }
   }
+
   // New Data Explorer
+  if (query.trim() !== DEFAULT_EDITOR_TEXT) {
+    return {
+      activeQueryIndex: 0,
+      queries: [query],
+    }
+  }
+
+  // Default - no queries found
   return {
-    activeQueryIndex: 0,
-    queries: [query],
+    activeQueryIndex: -1,
+    queries: [],
   }
 }

--- a/src/visualization/utils/useZoomQuery.ts
+++ b/src/visualization/utils/useZoomQuery.ts
@@ -9,7 +9,7 @@ import {DashboardQuery} from 'src/types'
 import {PipeContext} from 'src/flows/context/pipe'
 import {FlowQueryContext} from 'src/flows/context/flow.query'
 import {
-  DEFAULT_EDITOR_TEXT,
+  DEFAULT_FLUX_EDITOR_TEXT,
   PersistanceContext,
 } from 'src/dataExplorer/context/persistance'
 
@@ -48,7 +48,7 @@ export const useZoomQuery = (queries: DashboardQuery[] = []): ZoomQueries => {
   }
 
   // New Data Explorer
-  if (query.trim() !== DEFAULT_EDITOR_TEXT) {
+  if (query.trim() !== DEFAULT_FLUX_EDITOR_TEXT) {
     return {
       activeQueryIndex: 0,
       queries: [query],


### PR DESCRIPTION
Closes #5956  
Closes #6134  

- Adds multi-query support for Adaptive Zoom in Data Explorer and Dashboard Cells.
- Disables Adaptive Zoom whenever queries cannot be found, such as on the `/usage` page

https://user-images.githubusercontent.com/10736577/196830215-10b9c534-c055-41be-9929-3e8f4a796047.mp4

