### PR TITLE
feat(schemaBrowser): add read-only property

### DIFF
--- a/src/dataExplorer/components/FieldSelector.tsx
+++ b/src/dataExplorer/components/FieldSelector.tsx
@@ -36,7 +36,11 @@ const FIELD_TOOLTIP = `Fields and Field Values are non-indexed \
 key values pairs within a measurement. For SQL users, this is \
 conceptually similar to a non-indexed column and value.`
 
-const FieldSelector: FC = () => {
+interface Props {
+  readOnly?: boolean
+}
+
+const FieldSelector: FC<Props> = ({readOnly = false}) => {
   const {fields, loading} = useContext(FieldsContext)
   const {selectField, searchTerm} = useContext(FluxQueryBuilderContext)
   const {selection} = useContext(PersistanceContext)
@@ -83,7 +87,17 @@ const FieldSelector: FC = () => {
       </div>
     )
   } else if (loading === RemoteDataState.Done && fieldsToShow.length) {
-    if (isFlagEnabled('schemaComposition')) {
+    if (readOnly) {
+      list = fieldsToShow.map(field => (
+        <dd
+          key={field}
+          className="field-selector--list-item--readonly"
+          data-testid="field-selector--list-item--readonly"
+        >
+          <code>{field}</code>
+        </dd>
+      ))
+    } else if (isFlagEnabled('schemaComposition')) {
       list = (
         <SelectorList
           items={fieldsToShow}

--- a/src/dataExplorer/components/FieldSelector.tsx
+++ b/src/dataExplorer/components/FieldSelector.tsx
@@ -20,6 +20,7 @@ import {PersistanceContext} from 'src/dataExplorer/context/persistance'
 
 // Types
 import {RemoteDataState} from 'src/types'
+import {LanguageType} from 'src/dataExplorer/components/resources'
 
 // Syles
 import './Schema.scss'
@@ -36,14 +37,10 @@ const FIELD_TOOLTIP = `Fields and Field Values are non-indexed \
 key values pairs within a measurement. For SQL users, this is \
 conceptually similar to a non-indexed column and value.`
 
-interface Props {
-  readOnly?: boolean
-}
-
-const FieldSelector: FC<Props> = ({readOnly = false}) => {
+const FieldSelector: FC = () => {
   const {fields, loading} = useContext(FieldsContext)
   const {selectField, searchTerm} = useContext(FluxQueryBuilderContext)
-  const {selection} = useContext(PersistanceContext)
+  const {selection, resource} = useContext(PersistanceContext)
   const [fieldsToShow, setFieldsToShow] = useState([])
 
   const handleSelectField = (field: string) => {
@@ -87,7 +84,8 @@ const FieldSelector: FC<Props> = ({readOnly = false}) => {
       </div>
     )
   } else if (loading === RemoteDataState.Done && fieldsToShow.length) {
-    if (readOnly) {
+    if (resource?.data?.language === LanguageType.SQL) {
+      // readOnly
       list = fieldsToShow.map(field => (
         <dd
           key={field}

--- a/src/dataExplorer/components/Schema.scss
+++ b/src/dataExplorer/components/Schema.scss
@@ -104,6 +104,28 @@
   text-overflow: ellipsis;
 }
 
+.field-selector--list-item--readonly,
+.tag-selector-value--list-item--readonly {
+  padding: $cf-space-2xs;
+  height: $cf-form-xs-height;
+  line-height: $cf-form-xs-height;
+  font-family: $cf-code-font;
+  font-weight: $cf-font-weight--regular;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  > code {
+    font-size: $cf-form-sm-font;
+    border-radius: $cf-radius-sm;
+    padding: 0 $cf-space-2xs;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: $cf-grey-85;
+  }
+}
+
 .field-selector--list-item--selectable,
 .tag-selector-value--list-item--selectable {
   padding: $cf-space-2xs;

--- a/src/dataExplorer/components/Schema.tsx
+++ b/src/dataExplorer/components/Schema.tsx
@@ -11,7 +11,6 @@ import TagSelector from 'src/dataExplorer/components/TagSelector'
 import SchemaBrowserHeading from 'src/dataExplorer/components/SchemaBrowserHeading'
 
 // Context
-import {PersistanceContext} from 'src/dataExplorer/context/persistance'
 import {
   FluxQueryBuilderContext,
   FluxQueryBuilderProvider,
@@ -23,7 +22,6 @@ import {TagsProvider} from 'src/dataExplorer/context/tags'
 
 // Types
 import {QueryScope} from 'src/shared/contexts/query'
-import {LanguageType} from 'src/dataExplorer/components/resources'
 
 // Utils
 import {getOrg} from 'src/organizations/selectors'
@@ -32,7 +30,6 @@ import {getOrg} from 'src/organizations/selectors'
 import './Schema.scss'
 
 const FieldsTags: FC = () => {
-  const {resource} = useContext(PersistanceContext)
   const {selectedBucket, selectedMeasurement, searchTerm, setSearchTerm} =
     useContext(FluxQueryBuilderContext)
 
@@ -57,10 +54,8 @@ const FieldsTags: FC = () => {
           searchTerm={searchTerm}
           testID="field-tag-key-search-bar"
         />
-        <FieldSelector
-          readOnly={resource?.data?.language === LanguageType.SQL}
-        />
-        <TagSelector readOnly={resource?.data?.language === LanguageType.SQL} />
+        <FieldSelector />
+        <TagSelector />
       </div>
     )
   }, [selectedBucket, selectedMeasurement, searchTerm])

--- a/src/dataExplorer/components/Schema.tsx
+++ b/src/dataExplorer/components/Schema.tsx
@@ -11,6 +11,7 @@ import TagSelector from 'src/dataExplorer/components/TagSelector'
 import SchemaBrowserHeading from 'src/dataExplorer/components/SchemaBrowserHeading'
 
 // Context
+import {PersistanceContext} from 'src/dataExplorer/context/persistance'
 import {
   FluxQueryBuilderContext,
   FluxQueryBuilderProvider,
@@ -22,6 +23,7 @@ import {TagsProvider} from 'src/dataExplorer/context/tags'
 
 // Types
 import {QueryScope} from 'src/shared/contexts/query'
+import {LanguageType} from 'src/dataExplorer/components/resources'
 
 // Utils
 import {getOrg} from 'src/organizations/selectors'
@@ -30,6 +32,7 @@ import {getOrg} from 'src/organizations/selectors'
 import './Schema.scss'
 
 const FieldsTags: FC = () => {
+  const {resource} = useContext(PersistanceContext)
   const {selectedBucket, selectedMeasurement, searchTerm, setSearchTerm} =
     useContext(FluxQueryBuilderContext)
 
@@ -54,8 +57,10 @@ const FieldsTags: FC = () => {
           searchTerm={searchTerm}
           testID="field-tag-key-search-bar"
         />
-        <FieldSelector />
-        <TagSelector />
+        <FieldSelector
+          readOnly={resource?.data?.language === LanguageType.SQL}
+        />
+        <TagSelector readOnly={resource?.data?.language === LanguageType.SQL} />
       </div>
     )
   }, [selectedBucket, selectedMeasurement, searchTerm])

--- a/src/dataExplorer/components/TagSelector.tsx
+++ b/src/dataExplorer/components/TagSelector.tsx
@@ -9,9 +9,11 @@ import SelectorList from 'src/timeMachine/components/SelectorList'
 // Contexts
 import {FluxQueryBuilderContext} from 'src/dataExplorer/context/fluxQueryBuilder'
 import {TagsContext} from 'src/dataExplorer/context/tags'
+import {PersistanceContext} from 'src/dataExplorer/context/persistance'
 
 // Types
 import {RemoteDataState} from 'src/types'
+import {LanguageType} from 'src/dataExplorer/components/resources'
 
 // Utils
 import {
@@ -29,15 +31,9 @@ interface TagValuesProps {
   loading: RemoteDataState
   tagKey: string
   tagValues: string[]
-  readOnly?: boolean
 }
 
-const TagValues: FC<TagValuesProps> = ({
-  loading,
-  tagKey,
-  tagValues,
-  readOnly = false,
-}) => {
+const TagValues: FC<TagValuesProps> = ({loading, tagKey, tagValues}) => {
   const {
     selectedBucket,
     selectedMeasurement,
@@ -45,6 +41,7 @@ const TagValues: FC<TagValuesProps> = ({
     selectTagValue,
     searchTerm,
   } = useContext(FluxQueryBuilderContext)
+  const {resource} = useContext(PersistanceContext)
   const {getTagValues} = useContext(TagsContext)
   const [valuesToShow, setValuesToShow] = useState([])
 
@@ -88,7 +85,8 @@ const TagValues: FC<TagValuesProps> = ({
       </div>
     )
   } else if (loading === RemoteDataState.Done && valuesToShow.length) {
-    if (readOnly) {
+    if (resource?.data?.language === LanguageType.SQL) {
+      // readOnly
       list = valuesToShow.map(value => (
         <dd
           key={value}
@@ -161,11 +159,7 @@ const TagValues: FC<TagValuesProps> = ({
   }, [list, selectedTagValues])
 }
 
-interface TagSelectorProps {
-  readOnly?: boolean
-}
-
-const TagSelector: FC<TagSelectorProps> = ({readOnly = false}) => {
+const TagSelector: FC = () => {
   const {tags, loadingTagKeys, loadingTagValues} = useContext(TagsContext)
 
   const tagKeys: string[] = Object.keys(tags)
@@ -189,7 +183,6 @@ const TagSelector: FC<TagSelectorProps> = ({readOnly = false}) => {
             tagKey={key}
             tagValues={tags[key]}
             loading={loadingTagValues[key]}
-            readOnly={readOnly}
           />
         </div>
       )

--- a/src/dataExplorer/components/TagSelector.tsx
+++ b/src/dataExplorer/components/TagSelector.tsx
@@ -25,13 +25,19 @@ const TAG_KEYS_TOOLTIP = `Tags and Tag Values are indexed key values \
 pairs within a measurement. For SQL users, this is conceptually \
 similar to an indexed column and value.`
 
-interface Prop {
+interface TagValuesProps {
   loading: RemoteDataState
   tagKey: string
   tagValues: string[]
+  readOnly?: boolean
 }
 
-const TagValues: FC<Prop> = ({loading, tagKey, tagValues}) => {
+const TagValues: FC<TagValuesProps> = ({
+  loading,
+  tagKey,
+  tagValues,
+  readOnly = false,
+}) => {
   const {
     selectedBucket,
     selectedMeasurement,
@@ -82,7 +88,17 @@ const TagValues: FC<Prop> = ({loading, tagKey, tagValues}) => {
       </div>
     )
   } else if (loading === RemoteDataState.Done && valuesToShow.length) {
-    if (isFlagEnabled('schemaComposition')) {
+    if (readOnly) {
+      list = valuesToShow.map(value => (
+        <dd
+          key={value}
+          className="tag-selector-value--list-item--readonly"
+          data-testid="tag-selector-value--list-item--readonly"
+        >
+          <code>{value}</code>
+        </dd>
+      ))
+    } else if (isFlagEnabled('schemaComposition')) {
       list = (
         <SelectorList
           items={valuesToShow}
@@ -145,7 +161,11 @@ const TagValues: FC<Prop> = ({loading, tagKey, tagValues}) => {
   }, [list, selectedTagValues])
 }
 
-const TagSelector: FC = () => {
+interface TagSelectorProps {
+  readOnly?: boolean
+}
+
+const TagSelector: FC<TagSelectorProps> = ({readOnly = false}) => {
   const {tags, loadingTagKeys, loadingTagValues} = useContext(TagsContext)
 
   const tagKeys: string[] = Object.keys(tags)
@@ -169,6 +189,7 @@ const TagSelector: FC = () => {
             tagKey={key}
             tagValues={tags[key]}
             loading={loadingTagValues[key]}
+            readOnly={readOnly}
           />
         </div>
       )

--- a/src/dataExplorer/components/resources/index.ts
+++ b/src/dataExplorer/components/resources/index.ts
@@ -36,3 +36,8 @@ export const RESOURCES: Resources = {}
     }
   })
 })
+
+export enum LanguageType {
+  FLUX = 'flux',
+  SQL = 'sql',
+}


### PR DESCRIPTION
Close #6103 

This PR adds read-only property to schema browser, specifically to field selector and tag selector. ~~This is to prepare for SQL editing once the SQL option is available.~~ The readOnly is derived from `resource.data.language`

## After
<img width="447" alt="Screen Shot 2022-10-20 at 10 12 25 AM" src="https://user-images.githubusercontent.com/14298407/196988197-c5d3a136-bb49-4d8f-afc3-0260d35277c9.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
~~- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~~
- [x] Feature flagged, if applicable
