### PR TITLE
fix(universalLogin): create a local copy of flag before signout clears it

### DIFF
--- a/src/Logout.tsx
+++ b/src/Logout.tsx
@@ -21,12 +21,8 @@ const Logout: FC = () => {
   const history = useHistory()
   const dispatch = useDispatch()
 
-  let universalLoginFlagValue = false
   useEffect(() => {
-    universalLoginFlagValue = isFlagEnabled('universalLogin')
-  }, [])
-
-  useEffect(() => {
+    const universalLoginFlagValue = isFlagEnabled('universalLogin') ?? false
     const handleSignOut = async () => {
       if (CLOUD) {
         console.warn('universalLoginFlagValue: ', universalLoginFlagValue)

--- a/src/Logout.tsx
+++ b/src/Logout.tsx
@@ -21,10 +21,16 @@ const Logout: FC = () => {
   const history = useHistory()
   const dispatch = useDispatch()
 
+  let universalLoginFlagValue = false
+  useEffect(() => {
+    universalLoginFlagValue = isFlagEnabled('universalLogin')
+  }, [])
+
   useEffect(() => {
     const handleSignOut = async () => {
       if (CLOUD) {
-        if (isFlagEnabled('universalLogin')) {
+        console.warn('universalLoginFlagValue: ', universalLoginFlagValue)
+        if (universalLoginFlagValue) {
           fetch('/api/env/quartz-login-url')
             .then(async response => {
               const quartzUrl = await response.text()


### PR DESCRIPTION
part of https://github.com/influxdata/idpe/issues/15477

When we tried testing the **logout** portion of the universal login feature, i.e. logout should use `quartz` endpoint and not idpe's, we noticed that the code under the flag `universalLogin` inside `Logout.tsx` was never hit.

After some digging this was the issue in summary:

User clicks logout -> flags cleared -> code looks for the flag value and sees it's false (because it was cleared), so it never runs.

the solution is to save a local copy of the flag on component mount, and then use that instead, so we don't have to worry about flags being cleared.

<!-- Describe your proposed changes here. -->
<!-- Including screenshots or visuals is very helpful - a picture is worth a thousand words. -->

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
