### PR TITLE
feat(6106): pgsql support in monaco-editor

### DIFF
--- a/src/dataExplorer/components/ResultsPane.tsx
+++ b/src/dataExplorer/components/ResultsPane.tsx
@@ -52,7 +52,7 @@ import {getWindowPeriodVariableFromVariables} from 'src/variables/utils/getWindo
 // Constants
 import {TIME_RANGE_START, TIME_RANGE_STOP} from 'src/variables/constants'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
-import SqlEditorMonaco from 'src/shared/components/SqlMonacoEditor'
+import {SqlEditorMonaco} from 'src/shared/components/SqlMonacoEditor'
 
 const FluxMonacoEditor = lazy(
   () => import('src/shared/components/FluxMonacoEditor')

--- a/src/dataExplorer/components/ResultsPane.tsx
+++ b/src/dataExplorer/components/ResultsPane.tsx
@@ -39,6 +39,7 @@ import NewDatePicker from 'src/shared/components/dateRangePicker/NewDatePicker'
 
 // Types
 import {TimeRange} from 'src/types'
+import {LanguageType} from 'src/dataExplorer/components/resources'
 
 // Utils
 import {getRangeVariable} from 'src/variables/utils/getTimeRangeVars'
@@ -51,6 +52,7 @@ import {getWindowPeriodVariableFromVariables} from 'src/variables/utils/getWindo
 // Constants
 import {TIME_RANGE_START, TIME_RANGE_STOP} from 'src/variables/constants'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import SqlEditorMonaco from 'src/shared/components/SqlMonacoEditor'
 
 const FluxMonacoEditor = lazy(
   () => import('src/shared/components/FluxMonacoEditor')
@@ -197,13 +199,20 @@ const ResultsPane: FC = () => {
                   />
                 }
               >
-                <FluxMonacoEditor
-                  language={resource?.language}
-                  variables={variables}
-                  script={text}
-                  onChangeScript={setQuery}
-                  onSubmitScript={submit}
-                />
+                {resource?.language == LanguageType.SQL ? (
+                  <SqlEditorMonaco
+                    script={text}
+                    onChangeScript={setQuery}
+                    onSubmitScript={submit}
+                  />
+                ) : (
+                  <FluxMonacoEditor
+                    variables={variables}
+                    script={text}
+                    onChangeScript={setQuery}
+                    onSubmitScript={submit}
+                  />
+                )}
               </Suspense>
             </div>
           </div>

--- a/src/flows/pipes/Notification/NotificationMonacoEditor.tsx
+++ b/src/flows/pipes/Notification/NotificationMonacoEditor.tsx
@@ -12,7 +12,7 @@ import THEME_NAME from 'src/languageSupport/languages/flux/monaco.flux.theme'
 import {EditorType} from 'src/types'
 import {OnChangeScript} from 'src/types/flux'
 
-import 'src/shared/components/FluxMonacoEditor.scss'
+import 'src/shared/components/MonacoEditor.scss'
 
 interface Props {
   setEditorInstance?: (editor: EditorType) => void

--- a/src/flows/pipes/RawFluxEditor/style.scss
+++ b/src/flows/pipes/RawFluxEditor/style.scss
@@ -21,7 +21,7 @@
 }
 
 .flow-panel--body {
-  .flux-editor--monaco {
+  .qx-editor--monaco {
     height: 100%;
     position: static;
   }

--- a/src/languageSupport/languages/sql/monaco.sql.hotkeys.ts
+++ b/src/languageSupport/languages/sql/monaco.sql.hotkeys.ts
@@ -1,0 +1,7 @@
+import {EditorType} from 'src/types'
+
+export function submit(editor: EditorType, submitFn: () => any) {
+  editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, () => {
+    submitFn()
+  })
+}

--- a/src/languageSupport/languages/sql/monaco.sql.syntax.ts
+++ b/src/languageSupport/languages/sql/monaco.sql.syntax.ts
@@ -1,0 +1,23 @@
+import * as pgsql from 'monaco-editor/esm/vs/basic-languages/pgsql/pgsql'
+
+import {MonacoBasicLanguage} from 'src/types'
+
+const LANGID = 'pgsql'
+
+function addSyntax() {
+  monaco.languages.register({
+    id: LANGID,
+  })
+  monaco.languages.setMonarchTokensProvider(
+    LANGID,
+    (pgsql as MonacoBasicLanguage).language
+  )
+  monaco.languages.setLanguageConfiguration(
+    LANGID,
+    (pgsql as MonacoBasicLanguage).conf
+  )
+}
+
+addSyntax()
+
+export default LANGID

--- a/src/languageSupport/languages/sql/monaco.sql.syntax.ts
+++ b/src/languageSupport/languages/sql/monaco.sql.syntax.ts
@@ -20,4 +20,4 @@ function addSyntax() {
 
 addSyntax()
 
-export default LANGID
+export {LANGID}

--- a/src/languageSupport/languages/sql/monaco.sql.theme.ts
+++ b/src/languageSupport/languages/sql/monaco.sql.theme.ts
@@ -1,0 +1,74 @@
+import {MonacoType} from 'src/types'
+import {InfluxColors} from '@influxdata/clockface'
+
+const THEME_NAME = 'sqlTheme'
+
+function addTheme(monaco: MonacoType) {
+  // Using monaco-editor pgsql tokenizer.
+  // Example tokens: https://github.com/microsoft/monaco-editor/blob/136ce723f73b8bd284565c0b7d6d851b52161015/src/basic-languages/pgsql/pgsql.test.ts
+  monaco.editor.defineTheme(THEME_NAME, {
+    base: 'vs-dark',
+    inherit: false,
+    rules: [
+      {
+        token: 'delimiter.square.sql',
+        foreground: '#6BDFFF',
+      },
+      {
+        token: 'delimiter.parenthesis.sql',
+        foreground: '#6BDFFF',
+      },
+      {
+        token: 'delimiter.sql',
+        foreground: '#6BDFFF',
+      },
+      {
+        token: 'identifier.sql',
+        foreground: '#7CE490',
+      },
+      {
+        token: 'comment.quote.sql',
+        foreground: '#676978',
+      },
+      {
+        token: 'comment.sql',
+        foreground: '#676978',
+      },
+      {
+        token: 'keyword.sql',
+        foreground: '#9394FF',
+      },
+      {
+        token: 'operator.sql',
+        foreground: '#FFB6A0',
+      },
+      {
+        token: 'number.sql',
+        foreground: '#6BDFFF',
+      },
+      {
+        token: 'string.sql',
+        foreground: '#7CE490',
+      },
+      {
+        token: 'identifier.quote.sql',
+        foreground: '#7CE490',
+      },
+    ],
+    colors: {
+      'editor.foreground': '#F8F8F8',
+      'editor.background': InfluxColors.Grey15,
+      'editorGutter.background': InfluxColors.Grey15,
+      'editor.selectionBackground': '#353640',
+      'editorLineNumber.foreground': '#666978',
+      'editor.lineHighlightBackground': '#353640',
+      'editorCursor.foreground': '#ffffff',
+      'editorActiveLineNumber.foreground': '#bec2cc',
+      'minimap.background': InfluxColors.Grey15,
+    },
+  })
+}
+
+addTheme(monaco)
+
+export default THEME_NAME

--- a/src/languageSupport/languages/sql/monaco.sql.theme.ts
+++ b/src/languageSupport/languages/sql/monaco.sql.theme.ts
@@ -71,4 +71,4 @@ function addTheme(monaco: MonacoType) {
 
 addTheme(monaco)
 
-export default THEME_NAME
+export {THEME_NAME}

--- a/src/shared/components/FluxMonacoEditor.tsx
+++ b/src/shared/components/FluxMonacoEditor.tsx
@@ -9,6 +9,7 @@ import MonacoEditor from 'react-monaco-editor'
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
 
 // LSP
+import FLUXLANGID from 'src/languageSupport/languages/flux/monaco.flux.syntax'
 import THEME_NAME from 'src/languageSupport/languages/flux/monaco.flux.theme'
 import {setupForReactMonacoEditor} from 'src/languageSupport/languages/flux/lsp/monaco.flux.lsp'
 import {
@@ -31,11 +32,8 @@ import {editor as monacoEditor} from 'monaco-editor'
 
 import './FluxMonacoEditor.scss'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
-import {LanguageType} from 'src/dataExplorer/components/resources'
-
 export interface EditorProps {
   script?: string
-  language?: LanguageType
   onChangeScript: OnChangeScript
   onSubmitScript?: () => void
   autogrow?: boolean
@@ -53,7 +51,6 @@ interface Props extends EditorProps {
 }
 
 const FluxEditorMonaco: FC<Props> = ({
-  language = LanguageType.FLUX,
   script,
   onChangeScript,
   onSubmitScript,
@@ -146,7 +143,7 @@ const FluxEditorMonaco: FC<Props> = ({
       <ErrorBoundary>
         <div className={wrapperClassName} data-testid="flux-editor">
           <MonacoEditor
-            language={language}
+            language={FLUXLANGID}
             theme={THEME_NAME}
             value={script}
             onChange={onChange}
@@ -170,19 +167,12 @@ const FluxEditorMonaco: FC<Props> = ({
           {isFlagEnabled('uiSqlSupport') &&
             isIoxOrg &&
             isInFluxQueryBuilder && (
-              <div className="monaco-editor__language">{language}</div>
+              <div className="monaco-editor__language">{FLUXLANGID}</div>
             )}
         </div>
       </ErrorBoundary>
     ),
-    [
-      isIoxOrg,
-      language,
-      onChangeScript,
-      setEditor,
-      useSchemaComposition,
-      script,
-    ]
+    [isIoxOrg, onChangeScript, setEditor, useSchemaComposition, script]
   )
 }
 

--- a/src/shared/components/FluxMonacoEditor.tsx
+++ b/src/shared/components/FluxMonacoEditor.tsx
@@ -30,7 +30,7 @@ import {OnChangeScript} from 'src/types/flux'
 import {EditorType, Variable} from 'src/types'
 import {editor as monacoEditor} from 'monaco-editor'
 
-import './FluxMonacoEditor.scss'
+import './MonacoEditor.scss'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 export interface EditorProps {
   script?: string
@@ -72,8 +72,8 @@ const FluxEditorMonaco: FC<Props> = ({
   const useSchemaComposition =
     isInFluxQueryBuilder && isFlagEnabled('schemaComposition')
 
-  const wrapperClassName = classnames('flux-editor--monaco', {
-    'flux-editor--monaco__autogrow': autogrow,
+  const wrapperClassName = classnames('qx-editor--monaco', {
+    'qx-editor--monaco__autogrow': autogrow,
   })
 
   useEffect(() => {

--- a/src/shared/components/MarkdownMonacoEditor.tsx
+++ b/src/shared/components/MarkdownMonacoEditor.tsx
@@ -12,7 +12,7 @@ import {registerAutogrow} from 'src/languageSupport/monaco.autogrow'
 // Types
 import {EditorType} from 'src/types'
 
-import './FluxMonacoEditor.scss'
+import './MonacoEditor.scss'
 
 import {EditorProps} from 'src/shared/components/FluxMonacoEditor'
 

--- a/src/shared/components/MonacoEditor.scss
+++ b/src/shared/components/MonacoEditor.scss
@@ -60,7 +60,7 @@
   }
 }
 
-.flux-editor--monaco {
+.qx-editor--monaco {
   position: relative;
   overflow: hidden;
 

--- a/src/shared/components/SqlMonacoEditor.tsx
+++ b/src/shared/components/SqlMonacoEditor.tsx
@@ -1,0 +1,115 @@
+// Libraries
+import React, {FC, useEffect, useState, useMemo} from 'react'
+import classnames from 'classnames'
+
+// Components
+import MonacoEditor from 'react-monaco-editor'
+import ErrorBoundary from 'src/shared/components/ErrorBoundary'
+
+// LSP
+import SQLLANGID from 'src/languageSupport/languages/sql/monaco.sql.syntax'
+import THEME_NAME from 'src/languageSupport/languages/sql/monaco.sql.theme'
+import {submit} from 'src/languageSupport/languages/sql/monaco.sql.hotkeys'
+import {registerAutogrow} from 'src/languageSupport/monaco.autogrow'
+
+// Types
+import {OnChangeScript} from 'src/types/flux'
+import {EditorType} from 'src/types'
+import {editor as monacoEditor} from 'monaco-editor'
+
+// DLW FIXME: need another styling
+import './FluxMonacoEditor.scss'
+
+export interface Props {
+  script?: string
+  onChangeScript: OnChangeScript
+  onSubmitScript: () => void
+  autogrow?: boolean
+  readOnly?: boolean
+  autofocus?: boolean
+  wrapLines?: 'off' | 'on' | 'bounded'
+}
+
+const SqlEditorMonaco: FC<Props> = ({
+  script,
+  onChangeScript,
+  onSubmitScript,
+  autogrow,
+  readOnly,
+  autofocus,
+  wrapLines,
+}) => {
+  const [editor, setEditor] = useState(null)
+  const wrapperClassName = classnames('flux-editor--monaco', {
+    'flux-editor--monaco__autogrow': autogrow,
+  })
+
+  useEffect(() => {
+    if (!editor) {
+      return
+    }
+    submit(editor, () => {
+      if (onSubmitScript) {
+        onSubmitScript()
+      }
+    })
+  }, [editor, onSubmitScript])
+
+  const editorDidMount = (editor: EditorType) => {
+    setEditor(editor)
+
+    if (autogrow) {
+      registerAutogrow(editor)
+    }
+
+    monacoEditor.remeasureFonts()
+
+    if (autofocus && !readOnly && !editor.hasTextFocus()) {
+      const model = editor.getModel()
+      editor.setPosition({
+        lineNumber: model.getLineCount(),
+        column: model.getLineLength(model.getLineCount()) + 1,
+      })
+      editor.focus()
+    }
+  }
+
+  const onChange = (text: string) => {
+    onChangeScript(text)
+  }
+
+  return useMemo(
+    () => (
+      <ErrorBoundary>
+        <div className={wrapperClassName} data-testid="sql-editor">
+          <MonacoEditor
+            language="pgsql"
+            theme={THEME_NAME}
+            value={script}
+            onChange={onChange}
+            options={{
+              fontSize: 13,
+              fontFamily: '"IBMPlexMono", monospace',
+              cursorWidth: 2,
+              lineNumbersMinChars: 4,
+              lineDecorationsWidth: 0,
+              minimap: {
+                renderCharacters: false,
+              },
+              overviewRulerBorder: false,
+              automaticLayout: true,
+              readOnly: readOnly || false,
+              wordWrap: wrapLines ?? 'off',
+              scrollBeyondLastLine: false,
+            }}
+            editorDidMount={editorDidMount}
+          />
+          <div className="monaco-editor__language">{SQLLANGID}</div>
+        </div>
+      </ErrorBoundary>
+    ),
+    [onChangeScript, script]
+  )
+}
+
+export default SqlEditorMonaco

--- a/src/shared/components/SqlMonacoEditor.tsx
+++ b/src/shared/components/SqlMonacoEditor.tsx
@@ -111,4 +111,4 @@ const SqlEditorMonaco: FC<Props> = ({
   )
 }
 
-export default SqlEditorMonaco
+export {SqlEditorMonaco}

--- a/src/shared/components/SqlMonacoEditor.tsx
+++ b/src/shared/components/SqlMonacoEditor.tsx
@@ -7,8 +7,8 @@ import MonacoEditor from 'react-monaco-editor'
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
 
 // LSP
-import SQLLANGID from 'src/languageSupport/languages/sql/monaco.sql.syntax'
-import THEME_NAME from 'src/languageSupport/languages/sql/monaco.sql.theme'
+import {LANGID as SQLLANGID} from 'src/languageSupport/languages/sql/monaco.sql.syntax'
+import {THEME_NAME} from 'src/languageSupport/languages/sql/monaco.sql.theme'
 import {submit} from 'src/languageSupport/languages/sql/monaco.sql.hotkeys'
 import {registerAutogrow} from 'src/languageSupport/monaco.autogrow'
 

--- a/src/shared/components/SqlMonacoEditor.tsx
+++ b/src/shared/components/SqlMonacoEditor.tsx
@@ -17,8 +17,7 @@ import {OnChangeScript} from 'src/types/flux'
 import {EditorType} from 'src/types'
 import {editor as monacoEditor} from 'monaco-editor'
 
-// DLW FIXME: need another styling
-import './FluxMonacoEditor.scss'
+import './MonacoEditor.scss'
 
 export interface Props {
   script?: string
@@ -40,8 +39,8 @@ const SqlEditorMonaco: FC<Props> = ({
   wrapLines,
 }) => {
   const [editor, setEditor] = useState(null)
-  const wrapperClassName = classnames('flux-editor--monaco', {
-    'flux-editor--monaco__autogrow': autogrow,
+  const wrapperClassName = classnames('qx-editor--monaco', {
+    'qx-editor--monaco__autogrow': autogrow,
   })
 
   useEffect(() => {

--- a/src/shared/components/TomlMonacoEditor.tsx
+++ b/src/shared/components/TomlMonacoEditor.tsx
@@ -7,7 +7,7 @@ import THEME_NAME from 'src/languageSupport/languages/toml/monaco.toml.theme'
 import TOMLLANGID from 'src/languageSupport/languages/toml/monaco.toml.syntax'
 import {OnChangeScript, EditorType, CursorEvent, KeyboardEvent} from 'src/types'
 
-import './FluxMonacoEditor.scss'
+import './MonacoEditor.scss'
 
 interface Position {
   line: number

--- a/src/timeMachine/components/TimeMachineFluxEditor.scss
+++ b/src/timeMachine/components/TimeMachineFluxEditor.scss
@@ -22,12 +22,12 @@
   display: flex;
 }
 
-.flux-editor--monaco {
+.qx-editor--monaco {
   position: absolute;
   width: 100%;
   height: 100%;
 
-  &.flux-editor--monaco__autogrow {
+  &.qx-editor--monaco__autogrow {
     position: initial;
     top: initial;
     left: initial;
@@ -37,7 +37,7 @@
 }
 
 .time-machine-editor--embedded {
-  @extend .flux-editor--monaco;
+  @extend .qx-editor--monaco;
   border-radius: $cf-radius;
   border: $cf-border solid $cf-grey-25;
   overflow: hidden;

--- a/src/types/monaco.ts
+++ b/src/types/monaco.ts
@@ -7,3 +7,7 @@ export type CursorEvent = allMonaco.editor.ICursorPositionChangedEvent
 export type KeyboardEvent = allMonaco.IKeyboardEvent
 export type MonacoRange = allMonaco.Range
 export type MonacoSelectionRange = allMonaco.Selection
+export interface MonacoBasicLanguage {
+  conf: allMonaco.languages.LanguageConfiguration
+  language: allMonaco.languages.IMonarchLanguage
+}


### PR DESCRIPTION
Closes #6106 

## Done:
* Provide the monaco-editor with pgsql specific:
  * syntax tokenizer
  * theme/coloring of that syntax
  * submit hotkey
* Decided to provide separate root editor because:
  * we already provide editor components per language (e.g. toml, markdown, python, flux, etc)
  * will need a separate LSP connection anyways.  

## Theme:

@juliajames12 -- I am guessing these styles will need updated colors. Took a guess based upon colors used in the flux editor.

![Screen Shot 2022-10-24 at 7 36 28 PM](https://user-images.githubusercontent.com/10232835/197669767-624c5f95-a6db-457b-9897-9b77c7b12876.png)



## Checklist
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable. `uiSqlSupport`
