### PR TITLE
chore(maps): make maps use uiproxyd routes instead of mapsd routes

### DIFF
--- a/src/visualization/types/Map/view.tsx
+++ b/src/visualization/types/Map/view.tsx
@@ -11,15 +11,11 @@ import {VisualizationProps} from 'src/visualization'
 import {getGeoCoordinates} from 'src/shared/utils/vis'
 import {event} from 'src/cloud/utils/reporting'
 import {CLOUD} from 'src/shared/constants'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 let getMapToken = null
 
 if (CLOUD) {
-  getMapToken = require('src/client/mapsdRoutes').getMapToken
-  if (isFlagEnabled('uiproxyd')) {
-    getMapToken = require('src/client/uiproxydRoutes').getMapToken
-  }
+  getMapToken = require('src/client/uiproxydRoutes').getUiproxyMapToken
 }
 
 interface Props extends VisualizationProps {


### PR DESCRIPTION
Closes #6160

Connects maps visualizations to `uiproxyd`s version of the `getMapToken` route, rather than `mapsd`s version.

Works locally:
![Screen Shot 2022-10-25 at 11 08 23 AM](https://user-images.githubusercontent.com/146112/197816222-37b88f02-35bc-4d59-a093-844970146b44.png)

You can test the route in cloud environments by going to your cloud instance and logging in, then appending `/api/v2private/uiproxy/mapToken` to the end of the url. You should get a maps token back.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- ~[ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~
- ~[ ] Feature flagged, if applicable~
