### PR TITLE
feat(buckets): don't show explicit schema when an iox org creates a bucket

### DIFF
--- a/src/buckets/components/createBucketForm/CreateBucketOverlay.tsx
+++ b/src/buckets/components/createBucketForm/CreateBucketOverlay.tsx
@@ -1,5 +1,6 @@
 // Libraries
 import React, {FC, useContext} from 'react'
+import {useSelector} from 'react-redux'
 
 // Components
 import {Overlay} from '@influxdata/clockface'
@@ -11,9 +12,15 @@ import {OverlayContext} from 'src/overlays/components/OverlayController'
 // Constants
 import {getBucketOverlayWidth} from 'src/buckets/constants'
 
+// Selectors
+import {isOrgIOx} from 'src/organizations/selectors'
+
 const CreateBucketOverlay: FC = () => {
   const {onClose, params} = useContext(OverlayContext)
-  const useSimplifiedBucketForm = params?.useSimplifiedBucketForm
+  const isIOx = useSelector(isOrgIOx)
+
+  // IOx currently doesn't have the capability to handle explicit schemas
+  const useSimplifiedBucketForm = isIOx ? true : params?.useSimplifiedBucketForm
   const callbackAfterBucketCreation = params?.callbackAfterBucketCreation
 
   return (


### PR DESCRIPTION
Closes #6057

Doesn't show the explicit bucket accordion when creating a bucket in an IOx org.

Also tested (but not shown): Bucket creation in first mile onboarding remains unchanged

**Bucket creation for an org that isn't IOx**
![Screen Shot 2022-10-26 at 9 12 17 AM](https://user-images.githubusercontent.com/146112/198044791-7c2969c7-4f09-4389-8a14-2f12f3f1124b.png)

**Bucket creation for an org that is IOx**
![Screen Shot 2022-10-26 at 9 12 25 AM](https://user-images.githubusercontent.com/146112/198044805-181a2ad4-3e4f-43d4-ac53-6c2af359e36d.png)


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- ~[ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~
- ~[ ] Feature flagged, if applicable~
