### PR TITLE
fix: pin to node image with node16

### DIFF
--- a/docker/Dockerfile.chronograf
+++ b/docker/Dockerfile.chronograf
@@ -1,4 +1,4 @@
-FROM node:lts AS base
+FROM node:lts-gallium AS base
 
 RUN curl --compressed -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.22.4
 

--- a/docker/Dockerfile.chronograf.prod
+++ b/docker/Dockerfile.chronograf.prod
@@ -1,5 +1,5 @@
 # from node lts alpine
-FROM node:lts-alpine AS repo
+FROM node:lts-alpine3.14 AS repo
 
 # env vars to configure the system
 


### PR DESCRIPTION
`node:lts` is now using node18 which has a requirement for OpenSSL v3 which requires Webpack 5. 

https://stackoverflow.com/questions/69665222/node-js-17-0-1-gatsby-error-digital-envelope-routinesunsupported-err-os

Until we can upgrade to Webpack 5, we will need to stay on a node16 image.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
