### PR TITLE
chore: use solid clockface icon `Save` for save button

### DIFF
--- a/src/dataExplorer/components/FluxQueryBuilder.tsx
+++ b/src/dataExplorer/components/FluxQueryBuilder.tsx
@@ -217,7 +217,7 @@ const FluxQueryBuilder: FC = () => {
                     }
                     text="Save"
                     testID="flux-query-builder--save-script"
-                    icon={IconFont.SaveOutline}
+                    icon={IconFont.Save}
                   />
                 )}
                 {isFlagEnabled('saveAsScript') && resource?.data?.id && (


### PR DESCRIPTION
Part of #6179 

This PR uses the solid clockface icon "Save" for the save button in the New Script Editor

## After
<img width="385" alt="Screen Shot 2022-10-27 at 3 05 40 PM" src="https://user-images.githubusercontent.com/14298407/198388023-a929e3c1-2daf-4e9d-a1b1-8f4b513f98f5.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
~~- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~~
~~- [ ] Feature flagged, if applicable~~
