### PR TITLE
chore: pin to supported node 16 image

### DIFF
--- a/docker/Dockerfile.chronograf
+++ b/docker/Dockerfile.chronograf
@@ -1,4 +1,7 @@
-FROM node:lts-gallium AS base
+# [jdstrand] lts breaks webpack 4 so temporarily choose a currently supported
+# node alpine release. When we migrate to webpack 5, move back to node:lts
+#FROM node:lts AS base
+FROM node:gallium AS base
 
 RUN curl --compressed -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.22.4
 

--- a/docker/Dockerfile.chronograf.prod
+++ b/docker/Dockerfile.chronograf.prod
@@ -1,5 +1,9 @@
 # from node lts alpine
-FROM node:lts-alpine3.14 AS repo
+# [jdstrand] lts-alpine breaks webpack 4 so temporarily choose a currently
+# supported node alpine release. When we migrate to webpack 5, move back to
+# node:lts-alpine
+#FROM node:lts-alpine AS repo
+FROM node:16-alpine3.16 AS repo
 
 # env vars to configure the system
 


### PR DESCRIPTION
node:lts-alpine and node:lts break webpack 4 so temporarily choose a currently supported node release that uses node 16. When we migrate to webpack 5, move back to node:lts-alpine and node:lts.

Dockerfile.chronograf would ideally use node:lts, but choose node:gallium for now, both of which are Debian based.

Dockerfile.chronograf.prod would ideally use node:lts-alpine, but choose node:16-alpine3.16 for now, both of which are alpine 3.16 based.

Note: node 16 is also an LTS release and both node:gallium and node:16-alpine3.16 are listed as still supported.

References:
- https://nodejs.org/ar/blog/announcements/nodejs16-eol/
- https://hub.docker.com/_/node.

Successfully built both with:
* `docker build -f ./docker/Dockerfile.chronograf .`
* `docker build -f ./docker/Dockerfile.chronograf.prod .`

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change