### PR TITLE
build(lsp): upgrade flux-lsp to 0.8.36

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "@codingame/monaco-jsonrpc": "^0.3.1",
     "@docsearch/react": "^3.0.0-alpha.37",
     "@influxdata/clockface": "^6.3.8",
-    "@influxdata/flux-lsp-browser": "0.8.35",
+    "@influxdata/flux-lsp-browser": "0.8.36",
     "@influxdata/giraffe": "^2.38.1",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1444,10 +1444,10 @@
     "@types/react-window" "^1.8.5"
     react-window "^1.8.7"
 
-"@influxdata/flux-lsp-browser@0.8.35":
-  version "0.8.35"
-  resolved "https://registry.yarnpkg.com/@influxdata/flux-lsp-browser/-/flux-lsp-browser-0.8.35.tgz#ed92117d46f297bacf6aec7e7ace451d55bdff79"
-  integrity sha512-d/zlUAx+O67aTBVNIr0XznuDl2jkGELlahRL2OIPOawfnAkNNREuC8iMhov8dq+Bw9d5w+mT041UKzhxZXl1Kg==
+"@influxdata/flux-lsp-browser@0.8.36":
+  version "0.8.36"
+  resolved "https://registry.yarnpkg.com/@influxdata/flux-lsp-browser/-/flux-lsp-browser-0.8.36.tgz#953b09f0d6ac027c6b1e834735d48f78af616b73"
+  integrity sha512-jp9jJYQBoaGKX2Z4foPzSEHQHOtBoB/SHfnnLDpmPgN3B80jSq5md1mjgav4if4fnVuzEc+693/hw/CDH3Pbtw==
 
 "@influxdata/giraffe@^2.38.1":
   version "2.38.1"


### PR DESCRIPTION
Part of #5949 

Bump `flux-lsp` version to have multi tag values support