### PR TITLE
chore: use outline clockface icon `SaveOutline` for save button

### DIFF
--- a/src/dataExplorer/components/FluxQueryBuilder.tsx
+++ b/src/dataExplorer/components/FluxQueryBuilder.tsx
@@ -217,7 +217,7 @@ const FluxQueryBuilder: FC = () => {
                     }
                     text="Save"
                     testID="flux-query-builder--save-script"
-                    icon={IconFont.Save}
+                    icon={IconFont.SaveOutline}
                   />
                 )}
                 {isFlagEnabled('saveAsScript') && resource?.data?.id && (


### PR DESCRIPTION
Part of #6179

This PR is the step two of the above issue. It uses the outlined clockface icon "Save" for the save button in the New Script Editor

## After
<img width="716" alt="Screen Shot 2022-10-28 at 10 35 18 AM" src="https://user-images.githubusercontent.com/14298407/198676840-b8629aaa-67b0-4e5b-8ada-201c5e29af6a.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
~~- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~~
~~- [ ] Feature flagged, if applicable~~
