### PR TITLE
feat: add organization list tab to account page

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "cy": "CYPRESS_dexUrl=https://$INGRESS_HOST:$PORT_HTTPS CYPRESS_baseUrl=http://localhost:9999 cypress open",
     "cy:dev": "source ../monitor-ci/.env && CYPRESS_dexUrl=CLOUD CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{cloud,shared}/**/*.*'",
     "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_dexUrl=OSS CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{oss,shared}/**/*.*'",
-    "generate": "export SHA=b561645e05716036f071a43df0bf2a81ad32be90 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
+    "generate": "export SHA=1378c4d5bf380e7f33de3381fa4c8c45b6734e58 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-local-cloud": "export REMOTE=../openapi/ && yarn generate-meta-cloud",
     "generate-meta": "if [ -z \"${CLOUD_URL}\" ]; then yarn generate-meta-oss; else yarn generate-meta-cloud; fi",

--- a/src/accounts/AccountPage.tsx
+++ b/src/accounts/AccountPage.tsx
@@ -105,7 +105,7 @@ const AccountAboutPage: FC = () => {
   const showDeactivateAccountSection = isFlagEnabled('freeAccountCancellation')
 
   return (
-    <AccountTabContainer activeTab="about">
+    <AccountTabContainer activeTab="settings">
       <>
         <h4
           data-testid="account-settings--header"

--- a/src/accounts/AccountTabContainer.scss
+++ b/src/accounts/AccountTabContainer.scss
@@ -1,0 +1,3 @@
+.account-page--tab-contents {
+  padding-top: 0px !important;
+}

--- a/src/accounts/AccountTabContainer.tsx
+++ b/src/accounts/AccountTabContainer.tsx
@@ -9,6 +9,9 @@ import {Tabs, Orientation, Page} from '@influxdata/clockface'
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
+// Style
+import './AccountTabContainer.scss'
+
 interface Props {
   activeTab: string
 }
@@ -22,7 +25,9 @@ class AccountTabContainer extends PureComponent<Props> {
       <Page.Contents fullWidth={true} scrollable={true}>
         <Tabs.Container orientation={Orientation.Horizontal}>
           <AccountTabs activeTab={activeTab} />
-          <Tabs.TabContents>{children}</Tabs.TabContents>
+          <Tabs.TabContents className="account-page--tab-contents">
+            {children}
+          </Tabs.TabContents>
         </Tabs.Container>
       </Page.Contents>
     )

--- a/src/accounts/AccountTabs.tsx
+++ b/src/accounts/AccountTabs.tsx
@@ -1,28 +1,25 @@
 // Libraries
 import React, {FC} from 'react'
-import {useSelector} from 'react-redux'
 import {Link} from 'react-router-dom'
+import {useSelector} from 'react-redux'
 
 // Components
-import {Tabs, Orientation, ComponentSize} from '@influxdata/clockface'
+import {ComponentSize, Orientation, Tabs} from '@influxdata/clockface'
 
 // Utils
 import {getOrg} from 'src/organizations/selectors'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 interface Props {
   activeTab: string
 }
 
 interface AccountPageTab {
-  text: string
   id: string
+  enabled: boolean
   link: string
   testID: string
-}
-
-enum Tab {
-  Billing = 'billing',
-  About = 'about',
+  text: string
 }
 
 const AccountTabs: FC<Props> = ({activeTab}) => {
@@ -30,37 +27,48 @@ const AccountTabs: FC<Props> = ({activeTab}) => {
 
   const tabs: AccountPageTab[] = [
     {
-      text: 'Settings',
-      id: Tab.About,
-      testID: 'accounts-setting-tab',
+      id: 'settings',
       link: `/orgs/${orgID}/accounts/settings`,
+      enabled: true,
+      testID: 'accounts-setting-tab',
+      text: 'Settings',
     },
     {
-      text: 'Billing',
-      id: Tab.Billing,
-      testID: 'accounts-billing-tab',
+      id: 'organizations',
+      enabled: isFlagEnabled('createDeleteOrgs'),
+      link: `/orgs/${orgID}/accounts/orglist`,
+      testID: 'accounts-orglist-tab',
+      text: 'Organizations',
+    },
+    {
+      id: 'billing',
+      enabled: true,
       link: `/orgs/${orgID}/billing`,
+      testID: 'accounts-billing-tab',
+      text: 'Billing',
     },
   ]
 
   return (
     <Tabs orientation={Orientation.Horizontal} size={ComponentSize.Large}>
-      {tabs.map(tabInfo => {
-        const isActive = tabInfo.id === activeTab
+      {tabs
+        .filter(tab => tab.enabled)
+        .map(tab => {
+          const isActive = tab.id === activeTab
 
-        return (
-          <Tabs.Tab
-            key={tabInfo.id}
-            text={tabInfo.text}
-            id={tabInfo.id}
-            linkElement={className => (
-              <Link to={tabInfo.link} className={className} />
-            )}
-            testID={tabInfo.testID}
-            active={isActive}
-          />
-        )
-      })}
+          return (
+            <Tabs.Tab
+              key={tab.id}
+              text={tab.text}
+              id={tab.id}
+              linkElement={className => (
+                <Link to={tab.link} className={className} />
+              )}
+              testID={tab.testID}
+              active={isActive}
+            />
+          )
+        })}
     </Tabs>
   )
 }

--- a/src/annotations/components/AnnotationsTab.tsx
+++ b/src/annotations/components/AnnotationsTab.tsx
@@ -10,9 +10,9 @@ import {
   Grid,
   Sort,
 } from '@influxdata/clockface'
-import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
+import {SearchWidget} from 'src/shared/components/search_widget/SearchWidget'
 import TabbedPageHeader from 'src/shared/components/tabbed_page/TabbedPageHeader'
-import Filter from 'src/shared/components/FilterList'
+import {FilterListContainer} from 'src/shared/components/FilterList'
 import GetResources from 'src/resources/components/GetResources'
 
 import {AnnotationsList} from 'src/annotations/components/AnnotationsList'
@@ -28,7 +28,7 @@ import {SortTypes} from 'src/shared/utils/sort'
 // Thunks
 import {fetchAndSetAnnotationStreams} from 'src/annotations/actions/thunks'
 
-const FilterList = Filter<AnnotationStream>()
+const FilterList = FilterListContainer<AnnotationStream>()
 
 interface AnnotationsTabEmptyStateProps {
   searchTerm?: string

--- a/src/authorizations/components/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/CustomApiTokenOverlay.tsx
@@ -25,7 +25,7 @@ import {
   ComponentStatus,
 } from '@influxdata/clockface'
 import ResourceAccordion from 'src/authorizations/components/ResourceAccordion'
-import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
+import {SearchWidget} from 'src/shared/components/search_widget/SearchWidget'
 
 // Contexts
 import {OverlayContext} from 'src/overlays/components/OverlayController'

--- a/src/authorizations/components/EditResourceAccordion.tsx
+++ b/src/authorizations/components/EditResourceAccordion.tsx
@@ -8,7 +8,7 @@ import {ResourceAccordionHeader} from 'src/authorizations/components/ResourceAcc
 import {IndividualAccordionBody} from 'src/authorizations/components/IndividualAccordionBody'
 import {AllAccordionBody} from './AllAccordionBody'
 import {formatResources} from 'src/authorizations/utils/permissions'
-import FilterList from 'src/shared/components/FilterList'
+import {FilterListContainer} from 'src/shared/components/FilterList'
 
 // Types
 import {Resource} from 'src/client'
@@ -17,7 +17,7 @@ interface Props {
   searchTerm: string
 }
 
-const Filter = FilterList<Resource>()
+const Filter = FilterListContainer<Resource>()
 export class EditResourceAccordion extends Component<Props> {
   public render() {
     const {permissions} = this.props

--- a/src/authorizations/components/EditTokenOverlay.tsx
+++ b/src/authorizations/components/EditTokenOverlay.tsx
@@ -19,7 +19,7 @@ import {
   ComponentStatus,
 } from '@influxdata/clockface'
 import {EditResourceAccordion} from 'src/authorizations/components/EditResourceAccordion'
-import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
+import {SearchWidget} from 'src/shared/components/search_widget/SearchWidget'
 
 // Types
 import {Authorization, ResourceType} from 'src/types'

--- a/src/authorizations/components/ResourceAccordion.tsx
+++ b/src/authorizations/components/ResourceAccordion.tsx
@@ -10,7 +10,7 @@ import {Accordion, DapperScrollbars} from '@influxdata/clockface'
 import {ResourceAccordionHeader} from 'src/authorizations/components/ResourceAccordionHeader'
 import {AllAccordionBody} from 'src/authorizations/components/AllAccordionBody'
 import {IndividualAccordionBody} from 'src/authorizations/components/IndividualAccordionBody'
-import FilterList from 'src/shared/components/FilterList'
+import {FilterListContainer} from 'src/shared/components/FilterList'
 
 // Types
 import {Resource} from 'src/client'
@@ -27,7 +27,7 @@ interface OwnProps {
   searchTerm: string
 }
 
-const Filter = FilterList<Resource>()
+const Filter = FilterListContainer<Resource>()
 
 class ResourceAccordion extends Component<OwnProps> {
   public render() {

--- a/src/authorizations/components/TokensTab.tsx
+++ b/src/authorizations/components/TokensTab.tsx
@@ -16,9 +16,9 @@ import {
   Sort,
   Toggle,
 } from '@influxdata/clockface'
-import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
+import {SearchWidget} from 'src/shared/components/search_widget/SearchWidget'
 import TokenList from 'src/authorizations/components/TokenList'
-import FilterList from 'src/shared/components/FilterList'
+import {FilterListContainer} from 'src/shared/components/FilterList'
 import TabbedPageHeader from 'src/shared/components/tabbed_page/TabbedPageHeader'
 import GenerateTokenDropdown from 'src/authorizations/components/GenerateTokenDropdown'
 import ResourceSortDropdown from 'src/shared/components/resource_sort_dropdown/ResourceSortDropdown'
@@ -74,7 +74,7 @@ type SortKey = keyof Authorization
 type ReduxProps = ConnectedProps<typeof connector>
 type Props = StateProps & RouteComponentProps<{orgID: string}> & ReduxProps
 
-const FilterAuthorizations = FilterList<Authorization>()
+const FilterAuthorizations = FilterListContainer<Authorization>()
 
 class TokensTab extends PureComponent<Props, State> {
   private paginationRef: RefObject<HTMLDivElement>

--- a/src/buckets/components/BucketsTab.tsx
+++ b/src/buckets/components/BucketsTab.tsx
@@ -13,9 +13,9 @@ import {
   Grid,
   Sort,
 } from '@influxdata/clockface'
-import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
+import {SearchWidget} from 'src/shared/components/search_widget/SearchWidget'
 import TabbedPageHeader from 'src/shared/components/tabbed_page/TabbedPageHeader'
-import FilterList from 'src/shared/components/FilterList'
+import {FilterListContainer} from 'src/shared/components/FilterList'
 import BucketList from 'src/buckets/components/BucketList'
 import AssetLimitAlert from 'src/cloud/components/AssetLimitAlert'
 import BucketExplainer from 'src/buckets/components/BucketExplainer'
@@ -60,7 +60,7 @@ type Props = ReduxProps
 const DEFAULT_PAGINATION_CONTROL_HEIGHT = 62
 const DEFAULT_TAB_NAVIGATION_HEIGHT = 62
 
-const FilterBuckets = FilterList<Bucket>()
+const FilterBuckets = FilterListContainer<Bucket>()
 
 @ErrorHandling
 class BucketsTab extends PureComponent<Props, State> {

--- a/src/checks/components/CheckCards.tsx
+++ b/src/checks/components/CheckCards.tsx
@@ -3,7 +3,7 @@ import React, {FunctionComponent} from 'react'
 
 // Components
 import CheckCard from 'src/checks/components/CheckCard'
-import FilterList from 'src/shared/components/FilterList'
+import {FilterListContainer} from 'src/shared/components/FilterList'
 import {
   EmptyState,
   ResourceList,
@@ -19,7 +19,7 @@ import {
 import {Check} from 'src/types'
 import {ComponentSize} from '@influxdata/clockface'
 
-const FilterChecks = FilterList<Check>()
+const FilterChecks = FilterListContainer<Check>()
 
 interface Props {
   checks: Check[]

--- a/src/cloud/containers/index.tsx
+++ b/src/cloud/containers/index.tsx
@@ -1,0 +1,9 @@
+import {lazy} from 'react'
+
+export const OrganizationList = lazy(() =>
+  import(
+    'src/identity/components/OrganizationListTab/OrganizationListTabContainer'
+  ).then(module => ({
+    default: module.OrganizationListTabContainer,
+  }))
+)

--- a/src/cloud/notifications/account-settings-notifications.ts
+++ b/src/cloud/notifications/account-settings-notifications.ts
@@ -1,0 +1,7 @@
+import {Notification} from 'src/types'
+import {defaultErrorNotification} from 'src/shared/copy/notifications'
+
+export const fetchOrgAllowanceFailed = (): Notification => ({
+  ...defaultErrorNotification,
+  message: `Cannot determine whether more organizations can be created in this account.`,
+})

--- a/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
@@ -16,8 +16,8 @@ import {
   SpinnerContainer,
   TechnoSpinner,
 } from '@influxdata/clockface'
-import FilterList from 'src/shared/components/FilterList'
-import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
+import {FilterListContainer} from 'src/shared/components/FilterList'
+import {SearchWidget} from 'src/shared/components/search_widget/SearchWidget'
 import AddResourceDropdown from 'src/shared/components/AddResourceDropdown'
 import GetAssetLimits from 'src/cloud/components/GetAssetLimits'
 import ResourceSortDropdown from 'src/shared/components/resource_sort_dropdown/ResourceSortDropdown'
@@ -51,7 +51,7 @@ interface State {
   searchTerm: string
 }
 
-const FilterDashboards = FilterList<Dashboard>()
+const FilterDashboards = FilterListContainer<Dashboard>()
 
 @ErrorHandling
 class DashboardIndex extends PureComponent<Props, State> {

--- a/src/dataExplorer/components/Results.tsx
+++ b/src/dataExplorer/components/Results.tsx
@@ -13,7 +13,7 @@ import {RemoteDataState, SimpleTableViewProperties} from 'src/types'
 import {ResultsContext} from 'src/dataExplorer/components/ResultsContext'
 import {SidebarContext} from 'src/dataExplorer/context/sidebar'
 import {PersistanceContext} from 'src/dataExplorer/context/persistance'
-import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
+import {SearchWidget} from 'src/shared/components/search_widget/SearchWidget'
 import TimeZoneDropdown from 'src/shared/components/TimeZoneDropdown'
 import {
   View,

--- a/src/dataExplorer/components/Schema.tsx
+++ b/src/dataExplorer/components/Schema.tsx
@@ -3,7 +3,7 @@ import {useSelector} from 'react-redux'
 
 // Components
 import {DapperScrollbars} from '@influxdata/clockface'
-import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
+import {SearchWidget} from 'src/shared/components/search_widget/SearchWidget'
 import BucketSelector from 'src/dataExplorer/components/BucketSelector'
 import MeasurementSelector from 'src/dataExplorer/components/MeasurementSelector'
 import FieldSelector from 'src/dataExplorer/components/FieldSelector'

--- a/src/flows/components/FlowsIndex.tsx
+++ b/src/flows/components/FlowsIndex.tsx
@@ -13,7 +13,7 @@ import {
 } from '@influxdata/clockface'
 import {FlowListContext, FlowListProvider} from 'src/flows/context/flow.list'
 import FlowCards from 'src/flows/components/FlowCards'
-import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
+import {SearchWidget} from 'src/shared/components/search_widget/SearchWidget'
 import ResourceSortDropdown from 'src/shared/components/resource_sort_dropdown/ResourceSortDropdown'
 import {SortTypes} from 'src/shared/utils/sort'
 import PresetFlows from 'src/flows/components/PresetFlows'

--- a/src/flows/pipes/RawFluxEditor/SecretsList.tsx
+++ b/src/flows/pipes/RawFluxEditor/SecretsList.tsx
@@ -10,7 +10,7 @@ import {
   IconFont,
   JustifyContent,
 } from '@influxdata/clockface'
-import FilterList from 'src/shared/components/FilterList/FilterList'
+import {FilterList} from 'src/shared/components/FilterList/FilterList'
 import InjectSecretOption from 'src/shared/components/FilterList/InjectionOption'
 import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
 

--- a/src/flows/pipes/Table/view.tsx
+++ b/src/flows/pipes/Table/view.tsx
@@ -10,7 +10,7 @@ import React, {
 import {Icon, IconFont} from '@influxdata/clockface'
 
 // Components
-import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
+import {SearchWidget} from 'src/shared/components/search_widget/SearchWidget'
 
 // Utilities
 import {View} from 'src/visualization'

--- a/src/identity/apis/org.ts
+++ b/src/identity/apis/org.ts
@@ -34,6 +34,16 @@ export interface CurrentOrg {
   regionName?: string
 }
 
+export interface QuartzOrganization {
+  id: string
+  name: string
+  isActive: boolean
+  isDefault: boolean
+  provider?: string
+  regionCode?: string
+  regionName?: string
+}
+
 export type QuartzOrganizations = {
   orgs: OrganizationSummaries
   status?: RemoteDataState

--- a/src/identity/apis/org.ts
+++ b/src/identity/apis/org.ts
@@ -34,11 +34,6 @@ export interface CurrentOrg {
   regionName?: string
 }
 
-export interface OrgAllowanceResponse {
-  allowed: boolean
-  availableUpgrade: 'contract' | 'none' | 'pay_as_you_go'
-}
-
 export interface QuartzOrganization {
   id: string
   name: string

--- a/src/identity/apis/org.ts
+++ b/src/identity/apis/org.ts
@@ -34,6 +34,11 @@ export interface CurrentOrg {
   regionName?: string
 }
 
+export interface OrgAllowanceResponse {
+  allowed: boolean
+  availableUpgrade: 'contract' | 'none' | 'pay_as_you_go'
+}
+
 export interface QuartzOrganization {
   id: string
   name: string
@@ -47,11 +52,6 @@ export interface QuartzOrganization {
 export type QuartzOrganizations = {
   orgs: OrganizationSummaries
   status?: RemoteDataState
-}
-
-export interface OrgAllowanceResponse {
-  allowed: boolean
-  availableUpgrade: 'contract' | 'none' | 'pay_as_you_go'
 }
 
 // create a new organization

--- a/src/identity/apis/org.ts
+++ b/src/identity/apis/org.ts
@@ -49,6 +49,11 @@ export type QuartzOrganizations = {
   status?: RemoteDataState
 }
 
+export interface OrgAllowanceResponse {
+  allowed: boolean
+  availableUpgrade: 'contract' | 'none' | 'pay_as_you_go'
+}
+
 // create a new organization
 export const createNewOrg = async (
   organizationCreateRequest: OrganizationCreateRequest

--- a/src/identity/components/GlobalHeader/AccountDropdown.tsx
+++ b/src/identity/components/GlobalHeader/AccountDropdown.tsx
@@ -51,6 +51,11 @@ export const AccountDropdown: FC<Props> = ({
       href: `/orgs/${activeOrg.id}/accounts/settings`,
     },
     {
+      name: 'Organizations',
+      iconFont: IconFont.Group,
+      href: `/orgs/{activeOrg.id}/accounts/orgslist`,
+    },
+    {
       name: 'Billing',
       iconFont: IconFont.Bill,
       href: `/orgs/${activeOrg.id}/billing`,

--- a/src/identity/components/GlobalHeader/AccountDropdown.tsx
+++ b/src/identity/components/GlobalHeader/AccountDropdown.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FC} from 'react'
+import React, {FC, useMemo} from 'react'
 import {IconFont} from '@influxdata/clockface'
 
 // Types
@@ -34,6 +34,9 @@ import {
 // Constants
 import {CLOUD_URL} from 'src/shared/constants'
 
+// Utils
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+
 export const AccountDropdown: FC<Props> = ({
   accountsList,
   activeAccount,
@@ -44,23 +47,32 @@ export const AccountDropdown: FC<Props> = ({
     name: activeAccount.name,
   }
 
-  const accountMainMenu = [
-    {
-      name: 'Settings',
-      iconFont: IconFont.CogSolid_New,
-      href: `/orgs/${activeOrg.id}/accounts/settings`,
-    },
-    {
-      name: 'Organizations',
-      iconFont: IconFont.Group,
-      href: `/orgs/{activeOrg.id}/accounts/orgslist`,
-    },
-    {
-      name: 'Billing',
-      iconFont: IconFont.Bill,
-      href: `/orgs/${activeOrg.id}/billing`,
-    },
-  ]
+  const isCreateDeleteFlagOn = isFlagEnabled('createDeleteOrgs')
+
+  const accountMainMenu = useMemo(
+    () =>
+      [
+        {
+          name: 'Settings',
+          iconFont: IconFont.CogSolid_New,
+          href: `/orgs/${activeOrg.id}/accounts/settings`,
+          enabled: true,
+        },
+        {
+          name: 'Organizations',
+          iconFont: IconFont.Group,
+          href: `/orgs/${activeOrg.id}/accounts/orglist`,
+          enabled: isCreateDeleteFlagOn,
+        },
+        {
+          name: 'Billing',
+          iconFont: IconFont.Bill,
+          href: `/orgs/${activeOrg.id}/billing`,
+          enabled: true,
+        },
+      ].filter(menuOption => menuOption.enabled),
+    [activeOrg.id, isCreateDeleteFlagOn]
+  )
 
   // Quartz handles switching accounts by having the user hit this URL.
   const switchAccount = (account: TypeAheadMenuItem) => {

--- a/src/identity/components/OrganizationListTab/NoOrgsState.tsx
+++ b/src/identity/components/OrganizationListTab/NoOrgsState.tsx
@@ -1,0 +1,12 @@
+import React, {FC} from 'react'
+import {ComponentSize, EmptyState} from '@influxdata/clockface'
+
+export const NoOrgsState: FC = () => {
+  return (
+    <EmptyState size={ComponentSize.Medium}>
+      <EmptyState.Text>
+        No <b>organizations</b> matching those search criteria were found.
+      </EmptyState.Text>
+    </EmptyState>
+  )
+}

--- a/src/identity/components/OrganizationListTab/OrgBannerPanel.scss
+++ b/src/identity/components/OrganizationListTab/OrgBannerPanel.scss
@@ -1,0 +1,27 @@
+@import '@influxdata/clockface/dist/variables.scss';
+
+.account-settings-page-org-tab--upgrade-banner {
+  .account-settings-page-org-tab--upgrade-banner-text {
+    font-weight: 700;
+    font-size: $cf-text-base-0;
+    padding: $cf-space-3xs;
+  }
+
+  .account-settings-page-org-tab--quota-limit-link {
+    text-decoration: underline;
+    color: $cf-white;
+  }
+
+  .cf-banner-panel--icon {
+    display: flex;
+    width: $cf-space-m;
+  }
+
+  .cf-icon.Info_New:before {
+    font-size: $cf-space-s;
+  }
+
+  .cf-panel {
+    border-radius: 4px;
+  }
+}

--- a/src/identity/components/OrganizationListTab/OrgBannerPanel.scss
+++ b/src/identity/components/OrganizationListTab/OrgBannerPanel.scss
@@ -2,7 +2,7 @@
 
 .account-settings-page-org-tab--upgrade-banner {
   .account-settings-page-org-tab--upgrade-banner-text {
-    font-weight: 700;
+    font-weight: $cf-font-weight--bold;
     font-size: $cf-text-base-0;
     padding: $cf-space-3xs;
   }

--- a/src/identity/components/OrganizationListTab/OrgBannerPanel.tsx
+++ b/src/identity/components/OrganizationListTab/OrgBannerPanel.tsx
@@ -10,7 +10,7 @@ import './OrgBannerPanel.scss'
 import {CLOUD_URL} from 'src/shared/constants'
 
 // Selectors
-import {selectOrgId} from 'src/identity/selectors'
+import {selectCurrentOrgId} from 'src/identity/selectors'
 
 // Types
 import {OrgAllowance} from 'src/identity/components/OrganizationListTab'
@@ -19,7 +19,7 @@ export const OrgBannerPanel: FC<OrgAllowance> = ({
   availableUpgrade,
   isAtOrgLimit,
 }) => {
-  const orgId = useSelector(selectOrgId)
+  const orgId = useSelector(selectCurrentOrgId)
 
   let upgradePage = '/'
 

--- a/src/identity/components/OrganizationListTab/OrgBannerPanel.tsx
+++ b/src/identity/components/OrganizationListTab/OrgBannerPanel.tsx
@@ -1,0 +1,36 @@
+import React, {FC} from 'react'
+import {BannerPanel, FlexBox, Gradients, IconFont} from '@influxdata/clockface'
+import './OrgBannerPanel.scss'
+
+interface Props {
+  isAtOrgLimit: boolean
+  canUpgrade: boolean
+}
+
+export const OrgBannerPanel: FC<Props> = (isAtOrgLimit, canUpgrade) => {
+  return (
+    <BannerPanel
+      className="account-settings-page-org-tab--upgrade-banner"
+      gradient={Gradients.PolarExpress}
+      hideMobileIcon={true}
+      icon={IconFont.Info_New}
+    >
+      <FlexBox className="account-settings-page-org-tab--upgrade-banner-text">
+        {isAtOrgLimit && (
+          <>You've reached the organization quota for this account. &nbsp;</>
+        )}
+        {isAtOrgLimit && canUpgrade && (
+          <>
+            <a
+              href="/"
+              className="account-settings-page-org-tab--quota-limit-link"
+            >
+              Upgrade
+            </a>
+            &nbsp;to add more organizations
+          </>
+        )}
+      </FlexBox>
+    </BannerPanel>
+  )
+}

--- a/src/identity/components/OrganizationListTab/OrgBannerPanel.tsx
+++ b/src/identity/components/OrganizationListTab/OrgBannerPanel.tsx
@@ -1,13 +1,37 @@
+// Libraries
 import React, {FC} from 'react'
+import {useSelector} from 'react-redux'
 import {BannerPanel, FlexBox, Gradients, IconFont} from '@influxdata/clockface'
+
+// Styles
 import './OrgBannerPanel.scss'
 
+// Constants
+import {CLOUD_URL} from 'src/shared/constants'
+
+// Selectors
+import {selectOrgId} from 'src/identity/selectors'
+
+// Types
+import {OrgAllowanceResponse} from 'src/identity/apis/org'
+
 interface Props {
-  isAtOrgLimit: boolean
-  canUpgrade: boolean
+  isAtOrgLimit: OrgAllowanceResponse['allowed']
+  availableUpgrade: OrgAllowanceResponse['availableUpgrade']
 }
 
-export const OrgBannerPanel: FC<Props> = (isAtOrgLimit, canUpgrade) => {
+export const OrgBannerPanel: FC<Props> = (isAtOrgLimit, availableUpgrade) => {
+  const orgId = useSelector(selectOrgId)
+
+  let upgradePage: string
+
+  if (availableUpgrade === 'pay_as_you_go') {
+    upgradePage = `${CLOUD_URL}/orgs/${orgId}`
+  } else {
+    // If availableUpgrade is contract, need to use marketo form once complete. See https://github.com/influxdata/ui/issues/6206.
+    upgradePage = '/'
+  }
+
   return (
     <BannerPanel
       className="account-settings-page-org-tab--upgrade-banner"
@@ -19,10 +43,10 @@ export const OrgBannerPanel: FC<Props> = (isAtOrgLimit, canUpgrade) => {
         {isAtOrgLimit && (
           <>You've reached the organization quota for this account. &nbsp;</>
         )}
-        {isAtOrgLimit && canUpgrade && (
+        {isAtOrgLimit && availableUpgrade !== 'none' && (
           <>
             <a
-              href="/"
+              href={upgradePage}
               className="account-settings-page-org-tab--quota-limit-link"
             >
               Upgrade

--- a/src/identity/components/OrganizationListTab/OrgBannerPanel.tsx
+++ b/src/identity/components/OrganizationListTab/OrgBannerPanel.tsx
@@ -13,23 +13,18 @@ import {CLOUD_URL} from 'src/shared/constants'
 import {selectOrgId} from 'src/identity/selectors'
 
 // Types
-import {OrgAllowanceResponse} from 'src/identity/apis/org'
+import {OrgAllowance} from 'src/identity/components/OrganizationListTab'
 
-interface Props {
-  isAtOrgLimit: OrgAllowanceResponse['allowed']
-  availableUpgrade: OrgAllowanceResponse['availableUpgrade']
-}
-
-export const OrgBannerPanel: FC<Props> = (isAtOrgLimit, availableUpgrade) => {
+export const OrgBannerPanel: FC<OrgAllowance> = ({
+  availableUpgrade,
+  isAtOrgLimit,
+}) => {
   const orgId = useSelector(selectOrgId)
 
-  let upgradePage: string
+  let upgradePage = '/'
 
   if (availableUpgrade === 'pay_as_you_go') {
     upgradePage = `${CLOUD_URL}/orgs/${orgId}/checkout`
-  } else {
-    // If availableUpgrade is contract, need to use marketo form once complete. See https://github.com/influxdata/ui/issues/6206.
-    upgradePage = '/'
   }
 
   return (

--- a/src/identity/components/OrganizationListTab/OrgBannerPanel.tsx
+++ b/src/identity/components/OrganizationListTab/OrgBannerPanel.tsx
@@ -26,7 +26,7 @@ export const OrgBannerPanel: FC<Props> = (isAtOrgLimit, availableUpgrade) => {
   let upgradePage: string
 
   if (availableUpgrade === 'pay_as_you_go') {
-    upgradePage = `${CLOUD_URL}/orgs/${orgId}`
+    upgradePage = `${CLOUD_URL}/orgs/${orgId}/checkout`
   } else {
     // If availableUpgrade is contract, need to use marketo form once complete. See https://github.com/influxdata/ui/issues/6206.
     upgradePage = '/'

--- a/src/identity/components/OrganizationListTab/OrgList.tsx
+++ b/src/identity/components/OrganizationListTab/OrgList.tsx
@@ -8,6 +8,12 @@ import {OrganizationCard} from 'src/identity/components/OrganizationListTab/Orga
 
 // Constants
 import {GLOBAL_HEADER_HEIGHT} from 'src/identity/components/GlobalHeader/constants'
+const DEFAULT_BANNER_HEIGHT = 60
+const DEFAULT_ORG_CARD_HEIGHT = 105
+const DEFAULT_PAGINATION_NAV_HEIGHT = 72
+const DEFAULT_SEARCH_WIDGET_HEIGHT = 60
+const DEFAULT_TABS_HEIGHT = 40
+const DEFAULT_TOTAL_MARGIN_HEIGHT = 60
 
 // Utils
 import {getSortedResources, SortTypes} from 'src/shared/utils/sort'
@@ -46,26 +52,28 @@ export const OrgList: FC<Props> = ({
   )
 
   // Org List Pagination Calculations
-  const tabsHeight = document.querySelector('cf-tabs')?.clientHeight ?? 40
+  const tabsHeight =
+    document.querySelector('cf-tabs')?.clientHeight ?? DEFAULT_TABS_HEIGHT
 
   const quotaBannerHeight = isAtOrgLimit
     ? document.querySelector('.account-settings-page-org-tab--upgrade-banner')
-        ?.clientHeight || 60
+        ?.clientHeight || DEFAULT_BANNER_HEIGHT
     : 0
 
   const searchWidgetHeight =
     document.querySelector(
       '.account-settings-page-org-tab--sort-dropdown-container'
-    )?.clientHeight ?? 60
+    )?.clientHeight ?? DEFAULT_SEARCH_WIDGET_HEIGHT
 
   const orgCardHeight =
     document.querySelector('.account--organizations-tab-orgs-card')
-      ?.clientHeight ?? 105
+      ?.clientHeight ?? DEFAULT_ORG_CARD_HEIGHT
 
   const paginationNavHeight =
-    document.querySelector('.cf-pagination')?.clientHeight ?? 72
+    document.querySelector('.cf-pagination')?.clientHeight ??
+    DEFAULT_PAGINATION_NAV_HEIGHT
 
-  const marginHeight = 60
+  const marginHeight = DEFAULT_TOTAL_MARGIN_HEIGHT
 
   const orgCardsContainerHeight =
     pageHeight -
@@ -80,8 +88,8 @@ export const OrgList: FC<Props> = ({
     Math.floor(orgCardsContainerHeight / orgCardHeight),
     1
   )
-  const firstOrgOnPage = totalOrgsPerPage * (currentPage - 1)
-  const lastOrgOnPage = totalOrgsPerPage * currentPage
+  const firstOrgOnPage = (currentPage - 1) * totalOrgsPerPage
+  const lastOrgOnPage = totalOrgsPerPage * currentPage - 1
 
   useEffect(() => {
     const totalPages = Math.ceil(sortedOrgs.length / totalOrgsPerPage) || 1
@@ -89,7 +97,7 @@ export const OrgList: FC<Props> = ({
     setTotalPages(totalPages)
   }, [sortedOrgs.length, setTotalPages, totalOrgsPerPage])
 
-  const paginatedOrgs = sortedOrgs.slice(firstOrgOnPage, lastOrgOnPage)
+  const paginatedOrgs = sortedOrgs.slice(firstOrgOnPage, lastOrgOnPage + 1)
 
   if (paginatedOrgs.length === 0) {
     return <NoOrgsState />

--- a/src/identity/components/OrganizationListTab/OrgList.tsx
+++ b/src/identity/components/OrganizationListTab/OrgList.tsx
@@ -1,0 +1,111 @@
+// Libraries
+import React, {FC, SetStateAction, useEffect} from 'react'
+import memoizeOne from 'memoize-one'
+
+// Components
+import {NoOrgsState} from 'src/identity/components/OrganizationListTab/NoOrgsState'
+import {OrganizationCard} from 'src/identity/components/OrganizationListTab/OrganizationCard'
+
+// Constants
+import {GLOBAL_HEADER_HEIGHT} from 'src/identity/components/GlobalHeader/constants'
+
+// Utils
+import {getSortedResources, SortTypes} from 'src/shared/utils/sort'
+
+// Types
+import {Sort} from '@influxdata/clockface'
+import {OrganizationSummaries} from 'src/client/unityRoutes'
+
+interface Props {
+  currentPage: number
+  filteredOrgs: OrganizationSummaries
+  isAtOrgLimit: boolean
+  pageHeight: number
+  setTotalPages: (action: SetStateAction<number>) => void
+  sortDirection: Sort
+  sortKey: string
+}
+
+export const OrgList: FC<Props> = ({
+  currentPage,
+  filteredOrgs,
+  isAtOrgLimit,
+  pageHeight,
+  setTotalPages,
+  sortDirection,
+  sortKey,
+}) => {
+  const memGetSortedResources =
+    memoizeOne<typeof getSortedResources>(getSortedResources)
+
+  const sortedOrgs = memGetSortedResources(
+    filteredOrgs,
+    sortKey,
+    sortDirection,
+    SortTypes.String
+  )
+
+  // Org List Pagination Calculations
+  const tabsHeight = document.querySelector('cf-tabs')?.clientHeight ?? 40
+
+  const quotaBannerHeight = isAtOrgLimit
+    ? document.querySelector('.account-settings-page-org-tab--upgrade-banner')
+        ?.clientHeight || 60
+    : 0
+
+  const searchWidgetHeight =
+    document.querySelector(
+      '.account-settings-page-org-tab--sort-dropdown-container'
+    )?.clientHeight ?? 60
+
+  const orgCardHeight =
+    document.querySelector('.account--organizations-tab-orgs-card')
+      ?.clientHeight ?? 105
+
+  const paginationNavHeight =
+    document.querySelector('.cf-pagination')?.clientHeight ?? 72
+
+  const marginHeight = 60
+
+  const orgCardsContainerHeight =
+    pageHeight -
+    tabsHeight -
+    GLOBAL_HEADER_HEIGHT -
+    quotaBannerHeight -
+    searchWidgetHeight -
+    paginationNavHeight -
+    marginHeight
+
+  const totalOrgsPerPage = Math.max(
+    Math.floor(orgCardsContainerHeight / orgCardHeight),
+    1
+  )
+  const firstOrgOnPage = totalOrgsPerPage * (currentPage - 1)
+  const lastOrgOnPage = totalOrgsPerPage * currentPage
+
+  useEffect(() => {
+    const totalPages = Math.ceil(sortedOrgs.length / totalOrgsPerPage) || 1
+
+    setTotalPages(totalPages)
+  }, [sortedOrgs.length, setTotalPages, totalOrgsPerPage])
+
+  const paginatedOrgs = sortedOrgs.slice(firstOrgOnPage, lastOrgOnPage)
+
+  if (paginatedOrgs.length === 0) {
+    return <NoOrgsState />
+  }
+
+  return (
+    <>
+      {paginatedOrgs.map(org => (
+        <OrganizationCard
+          key={org.id}
+          name={org.name}
+          provider={org.provider}
+          regionCode={org.regionCode}
+          regionName={org.regionName}
+        />
+      ))}
+    </>
+  )
+}

--- a/src/identity/components/OrganizationListTab/OrganizationCard.scss
+++ b/src/identity/components/OrganizationListTab/OrganizationCard.scss
@@ -1,0 +1,28 @@
+@import '@influxdata/clockface/dist/variables.scss';
+
+.account--organizations-tab-orgs-card {
+  margin-top: $cf-space-2xs;
+  margin-bottom: $cf-space-2xs;
+  background-color: $cf-grey-15;
+  border-radius: 2px;
+}
+
+.account--organizations-tab-orgs-card-cluster-data {
+  width: 150px;
+}
+
+.account--organizations-tab-orgs-card-container {
+  display: flex;
+  justify-content: flex-end;
+  width: 90%;
+}
+
+.account-organizations-tab-orgs-card-location-data {
+  width: 240px;
+}
+
+.account--organizations-tab-orgs-card-orgname {
+  font-size: $cf-text-base-1;
+  color: $cf-white;
+  font-weight: 700;
+}

--- a/src/identity/components/OrganizationListTab/OrganizationCard.scss
+++ b/src/identity/components/OrganizationListTab/OrganizationCard.scss
@@ -24,5 +24,5 @@
 .account--organizations-tab-orgs-card-orgname {
   font-size: $cf-text-base-1;
   color: $cf-white;
-  font-weight: 700;
+  font-weight: $cf-font-weight--bold;
 }

--- a/src/identity/components/OrganizationListTab/OrganizationCard.tsx
+++ b/src/identity/components/OrganizationListTab/OrganizationCard.tsx
@@ -28,15 +28,15 @@ export const OrganizationCard: FC<OrgCardProps> = ({
         className="account--organizations-tab-orgs-card-orgname"
       ></ResourceCard.Name>
       <ResourceCard.Meta>
-        <FlexBox.Child className="account--organizations-tab-orgs-card-cluster-data">
+        <FlexBox className="account--organizations-tab-orgs-card-cluster-data">
           Cloud Provider: {provider}
-        </FlexBox.Child>
-        <FlexBox.Child className="account--organizations-tab-orgs-card-cluster-data">
+        </FlexBox>
+        <FlexBox className="account--organizations-tab-orgs-card-cluster-data">
           Region: {regionCode}
-        </FlexBox.Child>
-        <FlexBox.Child className="account-organizations-tab-orgs-card-location-data">
+        </FlexBox>
+        <FlexBox className="account-organizations-tab-orgs-card-location-data">
           Location: {regionName}
-        </FlexBox.Child>
+        </FlexBox>
       </ResourceCard.Meta>
     </ResourceCard>
   )

--- a/src/identity/components/OrganizationListTab/OrganizationCard.tsx
+++ b/src/identity/components/OrganizationListTab/OrganizationCard.tsx
@@ -1,0 +1,43 @@
+import React, {FC} from 'react'
+import {FlexBox, JustifyContent, ResourceCard} from '@influxdata/clockface'
+
+// Styles
+import './OrganizationCard.scss'
+
+interface OrgCardProps {
+  name: string
+  provider: string
+  regionCode: string
+  regionName: string
+}
+
+export const OrganizationCard: FC<OrgCardProps> = ({
+  name,
+  provider,
+  regionCode,
+  regionName,
+}) => {
+  return (
+    <ResourceCard
+      className="account--organizations-tab-orgs-card"
+      justifyContent={JustifyContent.SpaceBetween}
+      testID="account--organizations-tab-orgs-card"
+    >
+      <ResourceCard.Name
+        name={name}
+        className="account--organizations-tab-orgs-card-orgname"
+      ></ResourceCard.Name>
+      <ResourceCard.Meta>
+        <FlexBox.Child className="account--organizations-tab-orgs-card-cluster-data">
+          Cloud Provider: {provider}
+        </FlexBox.Child>
+        <FlexBox.Child className="account--organizations-tab-orgs-card-cluster-data">
+          Region: {regionCode}
+        </FlexBox.Child>
+        <FlexBox.Child className="account-organizations-tab-orgs-card-location-data">
+          Location: {regionName}
+        </FlexBox.Child>
+      </ResourceCard.Meta>
+    </ResourceCard>
+  )
+}

--- a/src/identity/components/OrganizationListTab/OrganizationListTab.scss
+++ b/src/identity/components/OrganizationListTab/OrganizationListTab.scss
@@ -1,0 +1,13 @@
+.account-settings-page-org-tab--searchwidget-container {
+  width: 400px;
+  padding: 0px 12px 10px 12px;
+  margin-bottom: 20px;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.account-settings-page-org-tab--sort-dropdown-container {
+  width: 280px;
+  padding: 0px 12px 10px 12px;
+  margin-bottom: 20px;
+}

--- a/src/identity/components/OrganizationListTab/OrganizationListTabContainer.tsx
+++ b/src/identity/components/OrganizationListTab/OrganizationListTabContainer.tsx
@@ -14,10 +14,11 @@ import {Page} from '@influxdata/clockface'
 import {OrganizationListTab} from 'src/identity/components/OrganizationListTab'
 
 const autoSizerStyle = {height: '100%', width: '100%'}
+const titleTag = pageTitleSuffixer(['Account Organization List Page'])
 
 export const OrganizationListTabContainer: FC = () => {
   return (
-    <Page titleTag={pageTitleSuffixer(['Account Organization List Page'])}>
+    <Page titleTag={titleTag}>
       <AutoSizer style={autoSizerStyle}>
         {({height}) => {
           return (

--- a/src/identity/components/OrganizationListTab/OrganizationListTabContainer.tsx
+++ b/src/identity/components/OrganizationListTab/OrganizationListTabContainer.tsx
@@ -1,19 +1,19 @@
 // Libraries
 import React, {FC} from 'react'
 import {AutoSizer} from 'react-virtualized'
+import {Page} from '@influxdata/clockface'
 
 // Components
 import AccountHeader from 'src/accounts/AccountHeader'
 import AccountTabContainer from 'src/accounts/AccountTabContainer'
+import {OrganizationListTab} from 'src/identity/components/OrganizationListTab'
 
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 
-// Style
-import {Page} from '@influxdata/clockface'
-import {OrganizationListTab} from 'src/identity/components/OrganizationListTab'
-
+// Styles
 const autoSizerStyle = {height: '100%', width: '100%'}
+
 const titleTag = pageTitleSuffixer(['Account Organization List Page'])
 
 export const OrganizationListTabContainer: FC = () => {

--- a/src/identity/components/OrganizationListTab/OrganizationListTabContainer.tsx
+++ b/src/identity/components/OrganizationListTab/OrganizationListTabContainer.tsx
@@ -1,0 +1,35 @@
+// Libraries
+import React, {FC} from 'react'
+import {AutoSizer} from 'react-virtualized'
+
+// Components
+import AccountHeader from 'src/accounts/AccountHeader'
+import AccountTabContainer from 'src/accounts/AccountTabContainer'
+
+// Utils
+import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
+
+// Style
+import {Page} from '@influxdata/clockface'
+import {OrganizationListTab} from 'src/identity/components/OrganizationListTab'
+
+const autoSizerStyle = {height: '100%', width: '100%'}
+
+export const OrganizationListTabContainer: FC = () => {
+  return (
+    <Page titleTag={pageTitleSuffixer(['Account Organization List Page'])}>
+      <AutoSizer style={autoSizerStyle}>
+        {({height}) => {
+          return (
+            <>
+              <AccountHeader testID="account-page--header" />
+              <AccountTabContainer activeTab="organizations">
+                <OrganizationListTab pageHeight={height} />
+              </AccountTabContainer>
+            </>
+          )
+        }}
+      </AutoSizer>
+    </Page>
+  )
+}

--- a/src/identity/components/OrganizationListTab/index.tsx
+++ b/src/identity/components/OrganizationListTab/index.tsx
@@ -18,6 +18,7 @@ import {SearchWidget} from 'src/shared/components/search_widget/SearchWidget'
 // API
 import {fetchOrgCreationAllowance} from 'src/identity/apis/org'
 import {getQuartzOrganizationsThunk} from 'src/identity/quartzOrganizations/actions/thunks'
+import {OrgAllowanceResponse} from 'src/identity/apis/org'
 
 // Selectors
 import {
@@ -49,8 +50,14 @@ interface Props {
   pageHeight: number
 }
 
-const defaultOrgAllowance = {
-  canUpgrade: false,
+interface OrgAllowance {
+  availableUpgrade: OrgAllowanceResponse['availableUpgrade']
+  isAtOrgLimit: OrgAllowanceResponse['allowed']
+  status: RemoteDataState
+}
+
+const defaultOrgAllowance: OrgAllowance = {
+  availableUpgrade: 'none',
   isAtOrgLimit: false,
   status: RemoteDataState.NotStarted,
 }
@@ -125,10 +132,10 @@ export const OrganizationListTab: FC<Props> = ({pageHeight}) => {
   useEffect(() => {
     const checkOrgCreationAllowance = async () => {
       try {
-        const {allowed, upgradesAvailable} = await fetchOrgCreationAllowance()
+        const {allowed, availableUpgrade} = await fetchOrgCreationAllowance()
 
         const newOrgAllowance = {
-          canUpgrade: upgradesAvailable,
+          availableUpgrade: availableUpgrade,
           isAtOrgLimit: !allowed,
           status: RemoteDataState.Done,
         }
@@ -204,7 +211,7 @@ export const OrganizationListTab: FC<Props> = ({pageHeight}) => {
       {orgAllowance.isAtOrgLimit && (
         <OrgBannerPanel
           isAtOrgLimit={orgAllowance.isAtOrgLimit}
-          canUpgrade={orgAllowance.canUpgrade}
+          availableUpgrade={orgAllowance.availableUpgrade}
         />
       )}
       <ResourceList>

--- a/src/identity/components/OrganizationListTab/index.tsx
+++ b/src/identity/components/OrganizationListTab/index.tsx
@@ -1,0 +1,237 @@
+// Libraries
+import React, {FC, useCallback, useEffect, useState} from 'react'
+import {useDispatch, useSelector} from 'react-redux'
+import {
+  FlexBox,
+  FlexDirection,
+  ResourceList,
+  PaginationNav,
+  Sort,
+} from '@influxdata/clockface'
+
+// Components
+import {FilterListContainer} from 'src/shared/components/FilterList'
+import {OrgBannerPanel} from 'src/identity/components/OrganizationListTab/OrgBannerPanel'
+import {OrgList} from 'src/identity/components/OrganizationListTab/OrgList'
+import {SearchWidget} from 'src/shared/components/search_widget/SearchWidget'
+
+// API
+import {fetchOrgCreationAllowance} from 'src/identity/apis/org'
+import {getQuartzOrganizationsThunk} from 'src/identity/quartzOrganizations/actions/thunks'
+
+// Selectors
+import {
+  selectCurrentAccountId,
+  selectQuartzOrgsContents,
+  selectQuartzOrgsStatus,
+} from 'src/identity/selectors'
+
+// Constants
+import ResourceSortDropdown from 'src/shared/components/resource_sort_dropdown/ResourceSortDropdown'
+
+// Notifications
+import {fetchOrgAllowanceFailed} from 'src/cloud/notifications/account-settings-notifications'
+import {notify} from 'src/shared/actions/notifications'
+
+// Style
+import './OrganizationListTab.scss'
+
+// Types
+import {BucketSortKey} from 'src/shared/components/resource_sort_dropdown/generateSortItems'
+import {QuartzOrganization} from 'src/identity/apis/org'
+import {RemoteDataState, ResourceType, SortTypes} from 'src/types'
+
+const searchKeys = ['name']
+
+const FilterOrgs = FilterListContainer<QuartzOrganization>()
+
+interface Props {
+  pageHeight: number
+}
+
+const defaultOrgAllowance = {
+  canUpgrade: false,
+  isAtOrgLimit: false,
+  status: RemoteDataState.NotStarted,
+}
+
+const defaultNameSort = {
+  sortKey: 'name',
+  sortDirection: Sort.Ascending,
+  sortType: SortTypes.String,
+}
+
+export const OrganizationListTab: FC<Props> = ({pageHeight}) => {
+  const dispatch = useDispatch()
+
+  // Selectors
+  const currentAccountId = useSelector(selectCurrentAccountId)
+  const orgsInAccount = useSelector(selectQuartzOrgsContents)
+  const orgsLoadedStatus = useSelector(selectQuartzOrgsStatus)
+
+  // Component State
+  const [currentPage, setCurrentPage] = useState(1)
+  const [searchTerm, setSearchTerm] = useState('')
+  const [sortMethod, setSortMethod] = useState(defaultNameSort)
+  const [totalPages, setTotalPages] = useState(1)
+  const [orgAllowance, setOrgAllowance] = useState(defaultOrgAllowance)
+
+  const memoizedSetTotalPages = useCallback(page => {
+    setTotalPages(page)
+  }, [])
+
+  // Event Handlers
+  const handleChangePage = (page: number) => {
+    const validatedPage = Math.min(page, totalPages)
+    setCurrentPage(validatedPage)
+    const url = new URL(location.href)
+    url.searchParams.set('page', validatedPage.toString())
+    history.replaceState(null, '', url.toString())
+  }
+
+  const handleFilterOrgs = (searchTerm: string) => {
+    const url = new URL(location.href)
+    url.searchParams.set('searchTerm', searchTerm)
+    history.replaceState(null, '', url.toString())
+    setSearchTerm(searchTerm)
+    handleChangePage(1)
+  }
+
+  const handleSortOrgs = (
+    newSortKey: BucketSortKey,
+    newSortDirection: Sort
+  ) => {
+    const url = new URL(location.href)
+    url.searchParams.set('sortKey', newSortKey)
+    url.searchParams.set('sortDirection', newSortDirection)
+    history.replaceState(null, '', url.toString())
+
+    setSortMethod({
+      sortKey: newSortKey,
+      sortDirection: newSortDirection,
+      sortType: SortTypes.String,
+    })
+    handleChangePage(1)
+  }
+
+  // Load the orgs in the current account, if not yet loaded.
+  useEffect(() => {
+    if (orgsLoadedStatus === RemoteDataState.NotStarted) {
+      dispatch(getQuartzOrganizationsThunk(currentAccountId))
+    }
+  }, [currentAccountId, dispatch, orgsLoadedStatus])
+
+  // Determine whether to display the 'Upgrade' banner.
+  useEffect(() => {
+    const checkOrgCreationAllowance = async () => {
+      try {
+        const {allowed, upgradesAvailable} = await fetchOrgCreationAllowance()
+
+        const newOrgAllowance = {
+          canUpgrade: upgradesAvailable,
+          isAtOrgLimit: !allowed,
+          status: RemoteDataState.Done,
+        }
+
+        setOrgAllowance(newOrgAllowance)
+      } catch (err) {
+        setOrgAllowance({...defaultOrgAllowance, status: RemoteDataState.Error})
+
+        dispatch(notify(fetchOrgAllowanceFailed()))
+      }
+    }
+
+    if (orgAllowance.status === RemoteDataState.NotStarted) {
+      checkOrgCreationAllowance()
+    }
+  }, [dispatch, orgAllowance.status])
+
+  // Load search, sort, and pagination settings from URL search params.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const urlSearchTerm = params.get('searchTerm')
+    const urlSortDirection = params.get('sortDirection') as Sort
+    const urlSortKey = params.get('sortKey')
+
+    const validSortDirections = [Sort.Ascending, Sort.Descending, Sort.None]
+
+    if (urlSearchTerm) {
+      setSearchTerm(urlSearchTerm)
+    }
+
+    if (
+      urlSortDirection &&
+      urlSortKey &&
+      validSortDirections.includes(urlSortDirection)
+    ) {
+      setSortMethod({
+        sortKey: urlSortKey,
+        sortDirection: urlSortDirection,
+        sortType: SortTypes.String,
+      })
+    }
+  }, [])
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const urlPageNumber = parseInt(params.get('page'), 10)
+
+    if (typeof urlPageNumber === 'number' && urlPageNumber > 0) {
+      setCurrentPage(Math.min(urlPageNumber, totalPages))
+    }
+  }, [totalPages])
+
+  return (
+    <>
+      <FlexBox direction={FlexDirection.Row}>
+        <FlexBox className="account-settings-page-org-tab--searchwidget-container">
+          <SearchWidget
+            placeholderText="Search organizations"
+            onSearch={handleFilterOrgs}
+            searchTerm={searchTerm}
+          ></SearchWidget>
+        </FlexBox>
+        <FlexBox className="account-settings-page-org-tab--sort-dropdown-container">
+          <ResourceSortDropdown
+            resourceType={ResourceType.Orgs}
+            sortDirection={sortMethod.sortDirection}
+            sortKey={sortMethod.sortKey}
+            sortType={SortTypes.String}
+            onSelect={handleSortOrgs}
+          />
+        </FlexBox>
+      </FlexBox>
+      {orgAllowance.isAtOrgLimit && (
+        <OrgBannerPanel
+          isAtOrgLimit={orgAllowance.isAtOrgLimit}
+          canUpgrade={orgAllowance.canUpgrade}
+        />
+      )}
+      <ResourceList>
+        <FilterOrgs
+          searchTerm={searchTerm}
+          searchKeys={searchKeys}
+          list={orgsInAccount}
+        >
+          {filteredOrgs => (
+            <OrgList
+              currentPage={currentPage}
+              isAtOrgLimit={orgAllowance.isAtOrgLimit}
+              filteredOrgs={filteredOrgs}
+              pageHeight={pageHeight}
+              setTotalPages={memoizedSetTotalPages}
+              sortDirection={sortMethod.sortDirection}
+              sortKey={sortMethod.sortKey}
+            />
+          )}
+        </FilterOrgs>
+      </ResourceList>
+      <PaginationNav.PaginationNav
+        currentPage={currentPage}
+        onChange={handleChangePage}
+        pageRangeOffset={1}
+        totalPages={totalPages}
+      />
+    </>
+  )
+}

--- a/src/identity/components/OrganizationListTab/index.tsx
+++ b/src/identity/components/OrganizationListTab/index.tsx
@@ -4,8 +4,8 @@ import {useDispatch, useSelector} from 'react-redux'
 import {
   FlexBox,
   FlexDirection,
-  ResourceList,
   PaginationNav,
+  ResourceList,
   Sort,
 } from '@influxdata/clockface'
 

--- a/src/identity/components/OrganizationListTab/index.tsx
+++ b/src/identity/components/OrganizationListTab/index.tsx
@@ -18,7 +18,6 @@ import {SearchWidget} from 'src/shared/components/search_widget/SearchWidget'
 // API
 import {fetchOrgCreationAllowance} from 'src/identity/apis/org'
 import {getQuartzOrganizationsThunk} from 'src/identity/quartzOrganizations/actions/thunks'
-import {OrgAllowanceResponse} from 'src/identity/apis/org'
 
 // Selectors
 import {
@@ -46,14 +45,14 @@ const searchKeys = ['name']
 
 const FilterOrgs = FilterListContainer<QuartzOrganization>()
 
-interface Props {
-  pageHeight: number
+export interface OrgAllowance {
+  availableUpgrade: string
+  isAtOrgLimit: boolean
+  status?: RemoteDataState
 }
 
-interface OrgAllowance {
-  availableUpgrade: OrgAllowanceResponse['availableUpgrade']
-  isAtOrgLimit: OrgAllowanceResponse['allowed']
-  status: RemoteDataState
+interface Props {
+  pageHeight: number
 }
 
 const defaultOrgAllowance: OrgAllowance = {
@@ -191,14 +190,14 @@ export const OrganizationListTab: FC<Props> = ({pageHeight}) => {
   return (
     <>
       <FlexBox direction={FlexDirection.Row}>
-        <FlexBox className="account-settings-page-org-tab--searchwidget-container">
+        <FlexBox.Child className="account-settings-page-org-tab--searchwidget-container">
           <SearchWidget
             placeholderText="Search organizations"
             onSearch={handleFilterOrgs}
             searchTerm={searchTerm}
           ></SearchWidget>
-        </FlexBox>
-        <FlexBox className="account-settings-page-org-tab--sort-dropdown-container">
+        </FlexBox.Child>
+        <FlexBox.Child className="account-settings-page-org-tab--sort-dropdown-container">
           <ResourceSortDropdown
             resourceType={ResourceType.Orgs}
             sortDirection={sortMethod.sortDirection}
@@ -206,7 +205,7 @@ export const OrganizationListTab: FC<Props> = ({pageHeight}) => {
             sortType={SortTypes.String}
             onSelect={handleSortOrgs}
           />
-        </FlexBox>
+        </FlexBox.Child>
       </FlexBox>
       {orgAllowance.isAtOrgLimit && (
         <OrgBannerPanel

--- a/src/identity/selectors/index.ts
+++ b/src/identity/selectors/index.ts
@@ -30,6 +30,12 @@ export const selectOperatorRole = (
   return state.identity.currentIdentity.user.operatorRole
 }
 
+export const selectOrgId = (
+  state: AppState
+): AppState['identity']['currentIdentity']['org']['id'] => {
+  return state.identity.currentIdentity.org.id
+}
+
 export const selectQuartzIdentityStatus = (state: AppState): RemoteDataState =>
   state.identity.currentIdentity.loadingStatus.identityStatus
 

--- a/src/identity/selectors/index.ts
+++ b/src/identity/selectors/index.ts
@@ -12,6 +12,12 @@ export const selectCurrentIdentity = (
   return state.identity.currentIdentity
 }
 
+export const selectCurrentAccountId = (
+  state: AppState
+): AppState['identity']['currentIdentity']['account']['id'] => {
+  return state.identity.currentIdentity.account.id
+}
+
 export const selectCurrentAccountType = (
   state: AppState
 ): AppState['identity']['currentIdentity']['account']['type'] => {
@@ -39,4 +45,16 @@ export const selectQuartzOrgs = (
   state: AppState
 ): AppState['identity']['quartzOrganizations'] => {
   return state.identity.quartzOrganizations
+}
+
+export const selectQuartzOrgsContents = (
+  state: AppState
+): AppState['identity']['quartzOrganizations']['orgs'] => {
+  return state.identity.quartzOrganizations.orgs
+}
+
+export const selectQuartzOrgsStatus = (
+  state: AppState
+): AppState['identity']['quartzOrganizations']['status'] => {
+  return state.identity.quartzOrganizations.status
 }

--- a/src/identity/selectors/index.ts
+++ b/src/identity/selectors/index.ts
@@ -24,16 +24,16 @@ export const selectCurrentAccountType = (
   return state.identity.currentIdentity.account.type
 }
 
+export const selectCurrentOrgId = (
+  state: AppState
+): AppState['identity']['currentIdentity']['org']['id'] => {
+  return state.identity.currentIdentity.org.id
+}
+
 export const selectOperatorRole = (
   state: AppState
 ): AppState['identity']['currentIdentity']['user']['operatorRole'] => {
   return state.identity.currentIdentity.user.operatorRole
-}
-
-export const selectOrgId = (
-  state: AppState
-): AppState['identity']['currentIdentity']['org']['id'] => {
-  return state.identity.currentIdentity.org.id
 }
 
 export const selectQuartzIdentityStatus = (state: AppState): RemoteDataState =>

--- a/src/labels/components/LabelsTab.tsx
+++ b/src/labels/components/LabelsTab.tsx
@@ -4,11 +4,11 @@ import {connect, ConnectedProps} from 'react-redux'
 
 // Components
 import {Button, EmptyState} from '@influxdata/clockface'
-import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
+import {SearchWidget} from 'src/shared/components/search_widget/SearchWidget'
 import CreateLabelOverlay from 'src/labels/components/CreateLabelOverlay'
 import TabbedPageHeader from 'src/shared/components/tabbed_page/TabbedPageHeader'
 import LabelList from 'src/labels/components/LabelList'
-import FilterList from 'src/shared/components/FilterList'
+import {FilterListContainer} from 'src/shared/components/FilterList'
 import ResourceSortDropdown from 'src/shared/components/resource_sort_dropdown/ResourceSortDropdown'
 
 // Actions
@@ -45,7 +45,7 @@ interface State {
 type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps
 
-const FilterLabels = FilterList<Label>()
+const FilterLabels = FilterListContainer<Label>()
 @ErrorHandling
 class Labels extends PureComponent<Props, State> {
   constructor(props) {

--- a/src/members/components/Members.tsx
+++ b/src/members/components/Members.tsx
@@ -7,9 +7,9 @@ import {connect, ConnectedProps} from 'react-redux'
 // Components
 import TabbedPageHeader from 'src/shared/components/tabbed_page/TabbedPageHeader'
 import {EmptyState, Sort} from '@influxdata/clockface'
-import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
+import {SearchWidget} from 'src/shared/components/search_widget/SearchWidget'
 import MemberList from 'src/members/components/MemberList'
-import FilterList from 'src/shared/components/FilterList'
+import {FilterListContainer} from 'src/shared/components/FilterList'
 
 // Actions
 import {deleteMember} from 'src/members/actions/thunks'
@@ -34,7 +34,7 @@ interface State {
 
 type SortKey = keyof Member
 
-const FilterMembers = FilterList<Member>()
+const FilterMembers = FilterListContainer<Member>()
 
 class Members extends PureComponent<Props, State> {
   constructor(props) {

--- a/src/notifications/endpoints/components/EndpointCards.tsx
+++ b/src/notifications/endpoints/components/EndpointCards.tsx
@@ -4,7 +4,7 @@ import React, {FC} from 'react'
 // Components
 import EndpointCard from 'src/notifications/endpoints/components/EndpointCard'
 import {EmptyState, ResourceList, ComponentSize} from '@influxdata/clockface'
-import FilterList from 'src/shared/components/FilterList'
+import {FilterListContainer} from 'src/shared/components/FilterList'
 
 // Types
 import {NotificationEndpoint} from 'src/types'
@@ -15,7 +15,7 @@ interface Props {
   searchTerm: string
 }
 
-const FilterEndpoints = FilterList<NotificationEndpoint>()
+const FilterEndpoints = FilterListContainer<NotificationEndpoint>()
 
 const EndpointCards: FC<Props> = ({endpoints, searchTerm}) => {
   const cards = endpoints =>

--- a/src/notifications/rules/components/RuleCards.tsx
+++ b/src/notifications/rules/components/RuleCards.tsx
@@ -4,7 +4,7 @@ import React, {FC} from 'react'
 // Components
 import NotificationRuleCard from 'src/notifications/rules/components/RuleCard'
 import {EmptyState, ResourceList} from '@influxdata/clockface'
-import FilterList from 'src/shared/components/FilterList'
+import {FilterListContainer} from 'src/shared/components/FilterList'
 
 // Types
 import {NotificationRuleDraft} from 'src/types'
@@ -15,7 +15,7 @@ interface Props {
   searchTerm: string
 }
 
-const FilterRules = FilterList<NotificationRuleDraft>()
+const FilterRules = FilterListContainer<NotificationRuleDraft>()
 
 const NotificationRuleCards: FC<Props> = ({rules, searchTerm}) => {
   const cards = rules =>

--- a/src/scrapers/components/Scrapers.tsx
+++ b/src/scrapers/components/Scrapers.tsx
@@ -6,11 +6,11 @@ import {isEmpty} from 'lodash'
 
 // Components
 import {Button, EmptyState, Sort} from '@influxdata/clockface'
-import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
+import {SearchWidget} from 'src/shared/components/search_widget/SearchWidget'
 import TabbedPageHeader from 'src/shared/components/tabbed_page/TabbedPageHeader'
 import ScraperList from 'src/scrapers/components/ScraperList'
 import NoBucketsWarning from 'src/buckets/components/NoBucketsWarning'
-import FilterList from 'src/shared/components/FilterList'
+import {FilterListContainer} from 'src/shared/components/FilterList'
 import ResourceSortDropdown from 'src/shared/components/resource_sort_dropdown/ResourceSortDropdown'
 
 // Actions
@@ -44,7 +44,7 @@ interface State {
   sortType: SortTypes
 }
 
-const FilterScrapers = FilterList<Scraper>()
+const FilterScrapers = FilterListContainer<Scraper>()
 
 @ErrorHandling
 class Scrapers extends PureComponent<Props, State> {

--- a/src/secrets/components/SecretsTab.tsx
+++ b/src/secrets/components/SecretsTab.tsx
@@ -11,10 +11,10 @@ import {
   IconFont,
   Sort,
 } from '@influxdata/clockface'
-import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
+import {SearchWidget} from 'src/shared/components/search_widget/SearchWidget'
 import TabbedPageHeader from 'src/shared/components/tabbed_page/TabbedPageHeader'
 import SecretsList from 'src/secrets/components/SecretsList'
-import FilterList from 'src/shared/components/FilterList'
+import {FilterListContainer} from 'src/shared/components/FilterList'
 import ResourceSortDropdown from 'src/shared/components/resource_sort_dropdown/ResourceSortDropdown'
 import GetResources from 'src/resources/components/GetResources'
 import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
@@ -38,7 +38,7 @@ const SecretsTab: FC = () => {
   const dispatch = useDispatch()
 
   const secrets = useSelector(getAllSecrets)
-  const FilterSecrets = FilterList<Secret>()
+  const FilterSecrets = FilterListContainer<Secret>()
 
   const handleFilterChange = (searchTerm: string) => {
     setSearchTerm(searchTerm)

--- a/src/shared/components/DynamicFunctionsList.tsx
+++ b/src/shared/components/DynamicFunctionsList.tsx
@@ -3,10 +3,10 @@ import {useDispatch, useSelector} from 'react-redux'
 import {DapperScrollbars} from '@influxdata/clockface'
 
 // Components
-import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
+import {SearchWidget} from 'src/shared/components/search_widget/SearchWidget'
 import {FluxFunction} from 'src/types/shared'
 import Fn from 'src/shared/components/FilterList/InjectionOption'
-import FilterList from 'src/shared/components/FilterList/FilterList'
+import {FilterList} from 'src/shared/components/FilterList/FilterList'
 import FluxDocsTooltipContent from 'src/shared/components/functions/perFunction/FluxDocsTooltipContent'
 
 // Actions

--- a/src/shared/components/Filter.test.tsx
+++ b/src/shared/components/Filter.test.tsx
@@ -1,7 +1,7 @@
 import React, {Component} from 'react'
 import {renderWithRedux} from 'src/mockState'
 
-import FilterList from 'src/shared/components/FilterList'
+import {FilterListContainer} from 'src/shared/components/FilterList'
 
 const resources = {resources: {labels: {byID: {}, allIDs: []}}}
 
@@ -14,7 +14,7 @@ function setup<T>(override?, stateOverride = resources) {
     ...override,
   }
 
-  const Filter = FilterList<T>()
+  const Filter = FilterListContainer<T>()
 
   return renderWithRedux(
     <Filter {...props}>

--- a/src/shared/components/Filter.tsx
+++ b/src/shared/components/Filter.tsx
@@ -35,9 +35,7 @@ const EMPTY_ARRAY_BRACKETS = /\[\]?\./
  *  "user.name" (exact) or "authors[].name" (inexact)
  *
  */
-export default class FilterList<T extends Resource> extends PureComponent<
-  Props<T>
-> {
+export class FilterList<T extends Resource> extends PureComponent<Props<T>> {
   private collator: Intl.Collator
 
   public constructor(props) {

--- a/src/shared/components/FilterList.tsx
+++ b/src/shared/components/FilterList.tsx
@@ -2,7 +2,7 @@
 import {connect} from 'react-redux'
 
 // Components
-import FilterList, {StateProps, OwnProps} from 'src/shared/components/Filter'
+import {FilterList, StateProps, OwnProps} from 'src/shared/components/Filter'
 
 import {AppState} from 'src/types'
 
@@ -12,7 +12,7 @@ const mstp = (state: AppState) => {
 
 // Typing a generic connected component proved to be tricky:
 // https://github.com/piotrwitek/react-redux-typescript-guide/issues/55
-export default function FilterListContainer<T>() {
+export function FilterListContainer<T>() {
   return connect<StateProps>(mstp)(
     FilterList as new (props: OwnProps<T>) => FilterList<T>
   )

--- a/src/shared/components/FilterList/FilterList.tsx
+++ b/src/shared/components/FilterList/FilterList.tsx
@@ -5,7 +5,7 @@ import {
   ComponentSize,
   DapperScrollbars,
 } from '@influxdata/clockface'
-import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
+import {SearchWidget} from 'src/shared/components/search_widget/SearchWidget'
 
 type Item = Record<string, any>
 
@@ -19,7 +19,7 @@ interface Props {
   setEventSearchTerm?: (searchTerm: string) => void
 }
 
-const FilterList: FC<Props> = ({
+export const FilterList: FC<Props> = ({
   extractor,
   items,
   placeholder,
@@ -78,5 +78,3 @@ const FilterList: FC<Props> = ({
     [list, setSearch]
   )
 }
-
-export default FilterList

--- a/src/shared/components/GroupedFunctionsList.tsx
+++ b/src/shared/components/GroupedFunctionsList.tsx
@@ -8,7 +8,7 @@ import {
 import {FLUX_FUNCTIONS} from 'src/shared/constants/fluxFunctions'
 import {FluxToolbarFunction} from 'src/types/shared'
 import Fn from 'src/shared/components/FilterList/InjectionOption'
-import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
+import {SearchWidget} from 'src/shared/components/search_widget/SearchWidget'
 import FunctionTooltipContent from 'src/shared/components/functions/perFunction/FunctionToolTipContent'
 
 interface Props {

--- a/src/shared/components/resource_sort_dropdown/generateSortItems.ts
+++ b/src/shared/components/resource_sort_dropdown/generateSortItems.ts
@@ -254,6 +254,59 @@ export const generateSortItems = (
           sortDirection: Sort.Descending,
         },
       ]
+
+    case ResourceType.Orgs:
+      return [
+        {
+          label: 'Name (A ➞ Z)',
+          sortKey: 'name',
+          sortDirection: Sort.Ascending,
+          sortType: SortTypes.String,
+        },
+        {
+          label: 'Name (Z ➞ A)',
+          sortKey: 'name',
+          sortDirection: Sort.Descending,
+          sortType: SortTypes.String,
+        },
+        {
+          label: 'Cloud Provider (A ➞ Z)',
+          sortKey: 'provider',
+          sortDirection: Sort.Ascending,
+          sortType: SortTypes.String,
+        },
+        {
+          label: 'Cloud Provider (Z ➞ A)',
+          sortKey: 'provider',
+          sortDirection: Sort.Descending,
+          sortType: SortTypes.String,
+        },
+        {
+          label: 'Region (A ➞ Z)',
+          sortKey: 'regionCode',
+          sortDirection: Sort.Ascending,
+          sortType: SortTypes.String,
+        },
+        {
+          label: 'Region (Z ➞ A)',
+          sortKey: 'regionCode',
+          sortDirection: Sort.Descending,
+          sortType: SortTypes.String,
+        },
+        {
+          label: 'Location (A ➞ Z)',
+          sortKey: 'regionName',
+          sortDirection: Sort.Ascending,
+          sortType: SortTypes.String,
+        },
+        {
+          label: 'Location (Z ➞ A)',
+          sortKey: 'regionName',
+          sortDirection: Sort.Descending,
+          sortType: SortTypes.String,
+        },
+      ]
+
     case ResourceType.Telegrafs:
       return [
         {

--- a/src/shared/components/search_widget/SearchWidget.tsx
+++ b/src/shared/components/search_widget/SearchWidget.tsx
@@ -76,7 +76,7 @@ export class SearchWidget extends Component<Props, State> {
           onChange={this.handleChange}
           onBlur={this.handleBlur}
           testID={testID}
-          className="search-widget-input "
+          className="search-widget-input"
           tabIndex={tabIndex}
           onClear={this.clear}
           autoFocus={autoFocus}

--- a/src/shared/components/search_widget/SearchWidget.tsx
+++ b/src/shared/components/search_widget/SearchWidget.tsx
@@ -28,7 +28,7 @@ interface State {
 }
 
 @ErrorHandling
-class SearchWidget extends Component<Props, State> {
+export class SearchWidget extends Component<Props, State> {
   public static defaultProps = {
     widthPixels: 440,
     placeholderText: 'Search...',
@@ -76,7 +76,7 @@ class SearchWidget extends Component<Props, State> {
           onChange={this.handleChange}
           onBlur={this.handleBlur}
           testID={testID}
-          className="search-widget-input"
+          className="search-widget-input "
           tabIndex={tabIndex}
           onClear={this.clear}
           autoFocus={autoFocus}
@@ -102,5 +102,3 @@ class SearchWidget extends Component<Props, State> {
     this.setState({searchTerm: ''}, this.handleSearch)
   }
 }
-
-export default SearchWidget

--- a/src/shared/containers/SetOrg.tsx
+++ b/src/shared/containers/SetOrg.tsx
@@ -6,6 +6,7 @@ import {Route, Switch, useHistory, useParams} from 'react-router-dom'
 // Components
 import {CommunityTemplatesIndex} from 'src/templates/containers/CommunityTemplatesIndex'
 import PageSpinner from 'src/perf/components/PageSpinner'
+
 import {
   AlertHistoryIndex,
   AlertingIndex,
@@ -50,7 +51,12 @@ import {
   DetailsSubscriptionPage,
   GoWizard,
 } from 'src/shared/containers'
+import {OrganizationList} from 'src/cloud/containers'
+
 import {UserProfilePage} from 'src/identity/components/userprofile/UserProfilePage'
+
+// Utils
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Types
 import {AppState, Organization, ResourceType} from 'src/types'
@@ -287,6 +293,13 @@ const SetOrg: FC = () => {
             <Route
               path={`${orgPath}/accounts/settings`}
               component={UserAccountPage}
+            />
+          )}
+          {/* list of organizations in the user's current CLOUD account */}
+          {CLOUD && isFlagEnabled('createDeleteOrgs') && (
+            <Route
+              path={`${orgPath}/accounts/orglist`}
+              component={OrganizationList}
             />
           )}
           {/* Homepage / First Mile */}

--- a/src/tasks/components/TasksHeader.tsx
+++ b/src/tasks/components/TasksHeader.tsx
@@ -15,7 +15,7 @@ import {
   IconFont,
 } from '@influxdata/clockface'
 import AddResourceDropdown from 'src/shared/components/AddResourceDropdown'
-import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
+import {SearchWidget} from 'src/shared/components/search_widget/SearchWidget'
 import ResourceSortDropdown from 'src/shared/components/resource_sort_dropdown/ResourceSortDropdown'
 
 // Utils

--- a/src/tasks/containers/TasksPage.tsx
+++ b/src/tasks/containers/TasksPage.tsx
@@ -9,7 +9,7 @@ import {Page, SpinnerContainer, TechnoSpinner} from '@influxdata/clockface'
 import TasksHeader from 'src/tasks/components/TasksHeader'
 import TasksList from 'src/tasks/components/TasksList'
 import {ErrorHandling} from 'src/shared/decorators/errors'
-import FilterList from 'src/shared/components/FilterList'
+import {FilterListContainer} from 'src/shared/components/FilterList'
 import GetAssetLimits from 'src/cloud/components/GetAssetLimits'
 import AssetLimitAlert from 'src/cloud/components/AssetLimitAlert'
 
@@ -60,7 +60,7 @@ interface State {
   sortType: SortTypes
 }
 
-const Filter = FilterList<Task>()
+const Filter = FilterListContainer<Task>()
 
 @ErrorHandling
 class TasksPage extends PureComponent<Props, State> {

--- a/src/telegrafs/components/CollectorList.tsx
+++ b/src/telegrafs/components/CollectorList.tsx
@@ -5,7 +5,7 @@ import {connect, ConnectedProps} from 'react-redux'
 // Components
 import {ResourceList} from '@influxdata/clockface'
 import CollectorRow from 'src/telegrafs/components/CollectorCard'
-import FilterList from 'src/shared/components/FilterList'
+import {FilterListContainer} from 'src/shared/components/FilterList'
 
 // Types
 import {Sort} from '@influxdata/clockface'
@@ -84,7 +84,7 @@ type FilteredOwnProps = OwnProps & {
 
 type FilteredProps = Props & FilteredOwnProps
 
-const FilterTelegrafs = FilterList<Telegraf>()
+const FilterTelegrafs = FilterListContainer<Telegraf>()
 class FilteredCollectorList extends PureComponent<FilteredProps> {
   render() {
     const {

--- a/src/telegrafs/components/Collectors.tsx
+++ b/src/telegrafs/components/Collectors.tsx
@@ -16,7 +16,7 @@ import {
   ComponentColor,
   ComponentStatus,
 } from '@influxdata/clockface'
-import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
+import {SearchWidget} from 'src/shared/components/search_widget/SearchWidget'
 import TabbedPageHeader from 'src/shared/components/tabbed_page/TabbedPageHeader'
 import {FilteredList} from 'src/telegrafs/components/CollectorList'
 import TelegrafExplainer from 'src/telegrafs/components/TelegrafExplainer'

--- a/src/users/components/UserList.tsx
+++ b/src/users/components/UserList.tsx
@@ -8,7 +8,7 @@ import UserListItem from 'src/users/components/UserListItem'
 import InviteListItem from 'src/users/components/InviteListItem'
 
 // Utils
-import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
+import {SearchWidget} from 'src/shared/components/search_widget/SearchWidget'
 import {filter} from 'src/users/utils/filter'
 
 const UserList: FC = () => {

--- a/src/variables/components/VariablesTab.tsx
+++ b/src/variables/components/VariablesTab.tsx
@@ -9,10 +9,10 @@ import {getVariables} from 'src/variables/selectors'
 
 // Components
 import {EmptyState} from '@influxdata/clockface'
-import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
+import {SearchWidget} from 'src/shared/components/search_widget/SearchWidget'
 import TabbedPageHeader from 'src/shared/components/tabbed_page/TabbedPageHeader'
 import VariableList from 'src/variables/components/VariableList'
-import Filter from 'src/shared/components/FilterList'
+import {FilterListContainer} from 'src/shared/components/FilterList'
 import AddResourceDropdown from 'src/shared/components/AddResourceDropdown'
 import ResourceSortDropdown from 'src/shared/components/resource_sort_dropdown/ResourceSortDropdown'
 import GetResources from 'src/resources/components/GetResources'
@@ -35,7 +35,7 @@ interface State {
   sortType: SortTypes
 }
 
-const FilterList = Filter<Variable>()
+const FilterList = FilterListContainer<Variable>()
 
 class VariablesTab extends PureComponent<Props, State> {
   public state: State = {

--- a/src/writeData/components/WriteDataSearchBar.tsx
+++ b/src/writeData/components/WriteDataSearchBar.tsx
@@ -6,7 +6,7 @@ import {WriteDataSearchContext} from 'src/writeData/containers/WriteDataPage'
 
 // Components
 import {ComponentSize} from '@influxdata/clockface'
-import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
+import {SearchWidget} from 'src/shared/components/search_widget/SearchWidget'
 
 const WriteDataSearchBar: FC = () => {
   const {searchTerm, setSearchTerm} = useContext(WriteDataSearchContext)

--- a/src/writeData/subscriptions/components/SubscriptionsLanding.tsx
+++ b/src/writeData/subscriptions/components/SubscriptionsLanding.tsx
@@ -18,7 +18,7 @@ import EmptySubscriptionState from 'src/writeData/subscriptions/components/Empty
 import SubscriptionsList from 'src/writeData/subscriptions/components/SubscriptionsList'
 import LoadDataHeader from 'src/settings/components/LoadDataHeader'
 import {SortTypes} from 'src/shared/utils/sort'
-import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
+import {SearchWidget} from 'src/shared/components/search_widget/SearchWidget'
 import ResourceSortDropdown from 'src/shared/components/resource_sort_dropdown/ResourceSortDropdown'
 import LoadDataTabbedPage from 'src/settings/components/LoadDataTabbedPage'
 


### PR DESCRIPTION
Closes #5934 
Closes #6205 

Adds a new tab to the "accounts" section that contains a list of all organizations in the user's current account. The user can search organizations by name and/or filter by name, cloud provider, region code, and location.

This feature is behind the `createDeleteOrgs` flag.

Total 'Files Changed' count is due to removing default exports from components relied on in the PR.

Browsing an Organization List
--

https://user-images.githubusercontent.com/91283923/198732118-0b936ef4-ad87-401d-9023-853e3d8459dd.mov

Sorting by Name, Cloud Provider, RegionCode, and Location
--

https://user-images.githubusercontent.com/91283923/198732243-a1153a40-6178-40e4-a87c-dfa1849d5d5f.mov

Filtering By Organization Name
--

https://user-images.githubusercontent.com/91283923/198732319-205351b9-fa8b-421f-9576-ac2f73c20959.mov

Automatic Table Resizing
--

https://user-images.githubusercontent.com/91283923/198732600-ddcbf351-8800-4c59-9b73-269efaba03b6.mov

Page preserves & uses pagination, filters, and sorts from URL parameters
--

https://user-images.githubusercontent.com/91283923/198732751-d0ba9afc-9388-4b20-a212-fe29c9e78047.mov




### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - `createDeleteOrgs`
