### PR TITLE
refactor: remove require.context from endpoints

### DIFF
--- a/src/flows/pipes/Notification/endpoints.ts
+++ b/src/flows/pipes/Notification/endpoints.ts
@@ -5,7 +5,29 @@ export const TEST_NOTIFICATION = 'This is a test notification'
 export interface TypeLookup {
   [key: string]: EndpointTypeRegistration
 }
-export const ENDPOINT_DEFINITIONS: TypeLookup = {}
+
+import {Endpoint as AWS} from './endpoints/AWS'
+import {Endpoint as HTTP} from './endpoints/HTTP'
+import {Endpoint as Mailgun} from './endpoints/Mailgun'
+import {Endpoint as Mailjet} from './endpoints/Mailjet'
+import {Endpoint as PagerDuty} from './endpoints/PagerDuty'
+import {Endpoint as SendGrid} from './endpoints/SendGrid'
+import {Endpoint as Slack} from './endpoints/Slack'
+import {Endpoint as Telegram} from './endpoints/Telegram'
+import {Endpoint as Zenoss} from './endpoints/Zenoss'
+
+export const ENDPOINT_DEFINITIONS: TypeLookup = {
+  aws: new AWS(),
+  http: new HTTP(),
+  mailgun: new Mailgun(),
+  mailjet: new Mailjet(),
+  pagerduty: new PagerDuty(),
+  sendgrid: new SendGrid(),
+  slack: new Slack(),
+  telegram: new Telegram(),
+  zenoss: new Zenoss(),
+}
+
 export const ENDPOINT_ORDER = [
   'slack',
   'http',
@@ -22,25 +44,3 @@ export const ENDPOINT_ORDER = [
   'sensu',
   'zenoss',
 ]
-
-// NOTE: this loads in all the modules under the current directory
-// to make it easier to add new types
-const context = require.context(
-  './endpoints',
-  true,
-  /^\.\/([^\/])+\/index\.(ts|tsx)$/
-)
-context.keys().forEach(key => {
-  const module = context(key)
-  module.default((definition: EndpointTypeRegistration) => {
-    if (ENDPOINT_DEFINITIONS.hasOwnProperty(definition.type)) {
-      throw new Error(
-        `Endpoint of type [${definition.type}] has already been registered`
-      )
-    }
-
-    ENDPOINT_DEFINITIONS[definition.type] = {
-      ...definition,
-    }
-  })
-})

--- a/src/flows/pipes/Notification/endpoints/AWS/readOnly.tsx
+++ b/src/flows/pipes/Notification/endpoints/AWS/readOnly.tsx
@@ -9,7 +9,7 @@ import {
 
 import {PipeContext} from 'src/flows/context/pipe'
 
-const ReadOnly: FC = () => {
+export const AWSReadOnly: FC = () => {
   const {data} = useContext(PipeContext)
 
   return (
@@ -80,5 +80,3 @@ const ReadOnly: FC = () => {
     </div>
   )
 }
-
-export default ReadOnly

--- a/src/flows/pipes/Notification/endpoints/AWS/view.tsx
+++ b/src/flows/pipes/Notification/endpoints/AWS/view.tsx
@@ -11,7 +11,7 @@ import {PipeContext} from 'src/flows/context/pipe'
 import {EndpointProps} from 'src/types'
 import SecretsDropdown from 'src/secrets/components/SecretsDropdown'
 
-const View: FC<EndpointProps> = ({createSecret, secrets}) => {
+export const AWS: FC<EndpointProps> = ({createSecret, secrets}) => {
   const {data, update} = useContext(PipeContext)
 
   const updateURL = evt => {
@@ -156,5 +156,3 @@ const View: FC<EndpointProps> = ({createSecret, secrets}) => {
     </div>
   )
 }
-
-export default View

--- a/src/flows/pipes/Notification/endpoints/HTTP/index.ts
+++ b/src/flows/pipes/Notification/endpoints/HTTP/index.ts
@@ -1,114 +1,115 @@
+import {EndpointTypeRegistration} from 'src/types'
+import {HTTPReadOnly} from './readOnly'
+import {HTTP} from './view'
 import {TEST_NOTIFICATION} from 'src/flows/pipes/Notification/endpoints'
-import View from './view'
-import ReadOnly from './readOnly'
 
-export default register => {
-  register({
-    type: 'http',
-    name: 'HTTP Post',
-    data: {
-      auth: 'none',
-      username: '',
-      password: '',
-      token: '',
-      url: 'https://www.example.com/endpoint',
-    },
-    component: View,
-    readOnlyComponent: ReadOnly,
-    generateImports: () =>
-      ['http', 'influxdata/influxdb/secrets', 'json']
-        .map(i => `import "${i}"`)
-        .join('\n'),
-    generateTestImports: () =>
-      ['array', 'http', 'influxdata/influxdb/secrets', 'json']
-        .map(i => `import "${i}"`)
-        .join('\n'),
-    generateQuery: (data, measurement) => {
-      const headers = [['"Content-Type"', '"application/json"']]
-      let prefixSecrets = ''
+export class Endpoint implements EndpointTypeRegistration {
+  type = 'http'
+  name = 'HTTP Post'
+  data = {
+    auth: 'none',
+    username: '',
+    password: '',
+    token: '',
+    url: 'https://www.example.com/endpoint',
+  }
+  component = HTTP
+  readOnlyComponent = HTTPReadOnly
+  generateImports() {
+    return ['http', 'influxdata/influxdb/secrets', 'json']
+      .map(i => `import "${i}"`)
+      .join('\n')
+  }
+  generateTestImports() {
+    return ['array', 'http', 'influxdata/influxdb/secrets', 'json']
+      .map(i => `import "${i}"`)
+      .join('\n')
+  }
+  generateQuery(data, measurement) {
+    const headers = [['"Content-Type"', '"application/json"']]
+    let prefixSecrets = ''
 
-      if (data.auth === 'basic') {
-        headers.push(['Authorization', 'auth'])
-        prefixSecrets = `
-          username = secrets.get(key: "${data.username}")
-          password = secrets.get(key: "${data.password}")
-          auth = http.basicAuth(u: username, p: password)
-        `
-      }
-
-      if (data.auth === 'bearer') {
-        headers.push(['Authorization', `"Bearer \${token}"`])
-        prefixSecrets = `
-          token = secrets.get(key: "${data.token}")
-        `
-      }
-
-      const _headers = headers
-        .reduce((acc, curr) => {
-          acc.push(`${curr[0]}: ${curr[1]}`)
-          return acc
-        }, [])
-        .join(', ')
-
-      const out = `
-        ${prefixSecrets}
-        task_data
-          |> schema["fieldsAsCols"]()
-              |> set(key: "_notebook_link", value: "${window.location.href}")
-          |> filter(fn: ${measurement})
-          |> monitor["check"](
-            data: check,
-            messageFn: messageFn,
-            crit: trigger,
-          )
-          |> filter(fn: trigger)
-          |> keep(columns: ["_value", "_time", "_measurement"])
-          |> limit(n: 1, offset: 0)
-          |> monitor["notify"](data: notification, endpoint: http.endpoint(url: "${data.url}")(
-            mapFn: (r) => {
-                body = {r with _version: 1}
-                return {headers: {${_headers}}, data: json.encode(v: body)}
-          }))
+    if (data.auth === 'basic') {
+      headers.push(['Authorization', 'auth'])
+      prefixSecrets = `
+        username = secrets.get(key: "${data.username}")
+        password = secrets.get(key: "${data.password}")
+        auth = http.basicAuth(u: username, p: password)
       `
-      return out
-    },
-    generateTestQuery: data => {
-      const headers = [['"Content-Type"', '"application/json"']]
-      let prefixSecrets = ''
+    }
 
-      if (data.auth === 'basic') {
-        headers.push(['Authorization', 'auth'])
-        prefixSecrets = `
-          username = secrets.get(key: "${data.username}")
-          password = secrets.get(key: "${data.password}")
-          auth = http.basicAuth(u: username, p: password)
-        `
-      }
+    if (data.auth === 'bearer') {
+      headers.push(['Authorization', `"Bearer \${token}"`])
+      prefixSecrets = `
+        token = secrets.get(key: "${data.token}")
+      `
+    }
 
-      if (data.auth === 'bearer') {
-        headers.push(['Authorization', `"Bearer \${token}"`])
-        prefixSecrets = `
-          token = secrets.get(key: "${data.token}")
-        `
-      }
+    const _headers = headers
+      .reduce((acc, curr) => {
+        acc.push(`${curr[0]}: ${curr[1]}`)
+        return acc
+      }, [])
+      .join(', ')
 
-      const _headers = headers
-        .reduce((acc, curr) => {
-          acc.push(`${curr[0]}: ${curr[1]}`)
-          return acc
-        }, [])
-        .join(', ')
-
-      return `
-        ${prefixSecrets}
-        http.post(
-          url: "${data.url}",
-          headers:  {${_headers}},
-          data: json.encode(v: { msg: "${TEST_NOTIFICATION}"})
+    const out = `
+      ${prefixSecrets}
+      task_data
+        |> schema["fieldsAsCols"]()
+            |> set(key: "_notebook_link", value: "${window.location.href}")
+        |> filter(fn: ${measurement})
+        |> monitor["check"](
+          data: check,
+          messageFn: messageFn,
+          crit: trigger,
         )
-        array.from(rows: [{value: 0}])
-        |> yield(name: "ignore")
+        |> filter(fn: trigger)
+        |> keep(columns: ["_value", "_time", "_measurement"])
+        |> limit(n: 1, offset: 0)
+        |> monitor["notify"](data: notification, endpoint: http.endpoint(url: "${data.url}")(
+          mapFn: (r) => {
+              body = {r with _version: 1}
+              return {headers: {${_headers}}, data: json.encode(v: body)}
+        }))
+    `
+    return out
+  }
+  generateTestQuery(data) {
+    const headers = [['"Content-Type"', '"application/json"']]
+    let prefixSecrets = ''
+
+    if (data.auth === 'basic') {
+      headers.push(['Authorization', 'auth'])
+      prefixSecrets = `
+        username = secrets.get(key: "${data.username}")
+        password = secrets.get(key: "${data.password}")
+        auth = http.basicAuth(u: username, p: password)
       `
-    },
-  })
+    }
+
+    if (data.auth === 'bearer') {
+      headers.push(['Authorization', `"Bearer \${token}"`])
+      prefixSecrets = `
+        token = secrets.get(key: "${data.token}")
+      `
+    }
+
+    const _headers = headers
+      .reduce((acc, curr) => {
+        acc.push(`${curr[0]}: ${curr[1]}`)
+        return acc
+      }, [])
+      .join(', ')
+
+    return `
+      ${prefixSecrets}
+      http.post(
+        url: "${data.url}",
+        headers:  {${_headers}},
+        data: json.encode(v: { msg: "${TEST_NOTIFICATION}"})
+      )
+      array.from(rows: [{value: 0}])
+      |> yield(name: "ignore")
+    `
+  }
 }

--- a/src/flows/pipes/Notification/endpoints/HTTP/readOnly.tsx
+++ b/src/flows/pipes/Notification/endpoints/HTTP/readOnly.tsx
@@ -13,7 +13,7 @@ import {
 
 import {PipeContext} from 'src/flows/context/pipe'
 
-const ReadOnly: FC = () => {
+export const HTTPReadOnly: FC = () => {
   const {data} = useContext(PipeContext)
 
   let submenu
@@ -119,5 +119,3 @@ const ReadOnly: FC = () => {
     </>
   )
 }
-
-export default ReadOnly

--- a/src/flows/pipes/Notification/endpoints/HTTP/view.tsx
+++ b/src/flows/pipes/Notification/endpoints/HTTP/view.tsx
@@ -14,7 +14,7 @@ import SecretsDropdown from 'src/secrets/components/SecretsDropdown'
 import {PipeContext} from 'src/flows/context/pipe'
 import {EndpointProps} from 'src/types'
 
-const View: FC<EndpointProps> = ({createSecret, secrets}) => {
+export const HTTP: FC<EndpointProps> = ({createSecret, secrets}) => {
   const {data, update} = useContext(PipeContext)
 
   const updater = (field, value) => {
@@ -150,5 +150,3 @@ const View: FC<EndpointProps> = ({createSecret, secrets}) => {
     </>
   )
 }
-
-export default View

--- a/src/flows/pipes/Notification/endpoints/Mailgun/index.ts
+++ b/src/flows/pipes/Notification/endpoints/Mailgun/index.ts
@@ -1,94 +1,95 @@
+import {EndpointTypeRegistration} from 'src/types'
+import {MailgunReadOnly} from './readOnly'
+import {Mailgun} from './view'
 import {TEST_NOTIFICATION} from 'src/flows/pipes/Notification/endpoints'
-import View from './view'
-import ReadOnly from './readOnly'
 
-export default register => {
-  register({
-    type: 'mailgun',
-    name: 'Mailgun Email',
-    data: {
-      domain: '',
-      apiKey: '',
-      email: '',
-    },
-    component: View,
-    readOnlyComponent: ReadOnly,
-    generateImports: () =>
-      ['http', 'influxdata/influxdb/secrets']
-        .map(i => `import "${i}"`)
-        .join('\n'),
-    generateTestImports: () =>
-      ['array', 'http', 'influxdata/influxdb/secrets']
-        .map(i => `import "${i}"`)
-        .join('\n'),
-    generateQuery: (data, measurement) => {
-      const subject = encodeURIComponent('InfluxDB Alert')
-      const fromEmail = `mailgun@${data.domain}`
+export class Endpoint implements EndpointTypeRegistration {
+  type = 'mailgun'
+  name = 'Mailgun Email'
+  data = {
+    domain: '',
+    apiKey: '',
+    email: '',
+  }
+  component = Mailgun
+  readOnlyComponent = MailgunReadOnly
+  generateImports() {
+    return ['http', 'influxdata/influxdb/secrets']
+      .map(i => `import "${i}"`)
+      .join('\n')
+  }
+  generateTestImports() {
+    return ['array', 'http', 'influxdata/influxdb/secrets']
+      .map(i => `import "${i}"`)
+      .join('\n')
+  }
+  generateQuery(data, measurement) {
+    const subject = encodeURIComponent('InfluxDB Alert')
+    const fromEmail = `mailgun@${data.domain}`
 
-      return `apiKey = secrets.get(key: "${data.apiKey}")
+    return `apiKey = secrets.get(key: "${data.apiKey}")
 auth = http.basicAuth(u: "api", p: "\${apiKey}")
 
 task_data
-	|> schema["fieldsAsCols"]()
-      |> set(key: "_notebook_link", value: "${window.location.href}")
-  |> filter(fn: ${measurement})
-	|> monitor["check"](
-		data: check,
-		messageFn: messageFn,
-		crit: trigger,
-	)
-  |> filter(fn: trigger)
-  |> keep(columns: ["_value", "_time", "_measurement"])
-  |> limit(n: 1, offset: 0)
-	|> monitor["notify"](
-    data: notification,
-    endpoint: http.endpoint(url: "https://api.mailgun.net/v3/${data.domain}/messages")(
-      mapFn: (r) => {
-        data = strings.joinStr(arr: [
-            "from=${fromEmail}",
-            "to=${data.email}",
-            "subject=${subject}",
-            "text=\${r._message}"
-          ], v: "&"
-        )
-        return {
-          headers: {
-            "Content-Type": "application/x-www-form-urlencoded",
-            "Authorization": "\${auth}"
-          },
-          data: bytes(v: data)
-        }
-      })
-    )`
-    },
-    generateTestQuery: data => {
-      const subject = encodeURIComponent('InfluxDB Alert')
-      const message = encodeURIComponent(TEST_NOTIFICATION)
-      const fromEmail = `mailgun@${data.domain}`
+|> schema["fieldsAsCols"]()
+    |> set(key: "_notebook_link", value: "${window.location.href}")
+|> filter(fn: ${measurement})
+|> monitor["check"](
+  data: check,
+  messageFn: messageFn,
+  crit: trigger,
+)
+|> filter(fn: trigger)
+|> keep(columns: ["_value", "_time", "_measurement"])
+|> limit(n: 1, offset: 0)
+|> monitor["notify"](
+  data: notification,
+  endpoint: http.endpoint(url: "https://api.mailgun.net/v3/${data.domain}/messages")(
+    mapFn: (r) => {
+      data = strings.joinStr(arr: [
+          "from=${fromEmail}",
+          "to=${data.email}",
+          "subject=${subject}",
+          "text=\${r._message}"
+        ], v: "&"
+      )
+      return {
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Authorization": "\${auth}"
+        },
+        data: bytes(v: data)
+      }
+    })
+  )`
+  }
+  generateTestQuery(data) {
+    const subject = encodeURIComponent('InfluxDB Alert')
+    const message = encodeURIComponent(TEST_NOTIFICATION)
+    const fromEmail = `mailgun@${data.domain}`
 
-      return `apiKey = secrets.get(key: "${data.apiKey}")
+    return `apiKey = secrets.get(key: "${data.apiKey}")
 auth = http.basicAuth(u: "api", p: "\${apiKey}")
 url = "https://api.mailgun.net/v3/${data.domain}/messages"
 data = strings.joinStr(arr: [
-  "from=${fromEmail}",
-  "to=${data.email}",
-  "subject=${subject}",
-  "text=${message}"
+"from=${fromEmail}",
+"to=${data.email}",
+"subject=${subject}",
+"text=${message}"
 ], v: "&"
 )
 
 http.post(
-  url: url,
-  headers: {
-    "Content-Type": "application/x-www-form-urlencoded",
-    "Authorization": "\${auth}"
-  },
-  data: bytes(v: data)
+url: url,
+headers: {
+  "Content-Type": "application/x-www-form-urlencoded",
+  "Authorization": "\${auth}"
+},
+data: bytes(v: data)
 )
 
 array.from(rows: [{value: 0}])
-  |> yield(name: "ignore")
+|> yield(name: "ignore")
 `
-    },
-  })
+  }
 }

--- a/src/flows/pipes/Notification/endpoints/Mailgun/readOnly.tsx
+++ b/src/flows/pipes/Notification/endpoints/Mailgun/readOnly.tsx
@@ -9,7 +9,7 @@ import {
 
 import {PipeContext} from 'src/flows/context/pipe'
 
-const ReadOnly: FC = () => {
+export const MailgunReadOnly: FC = () => {
   const {data} = useContext(PipeContext)
 
   return (
@@ -44,5 +44,3 @@ const ReadOnly: FC = () => {
     </div>
   )
 }
-
-export default ReadOnly

--- a/src/flows/pipes/Notification/endpoints/Mailgun/view.tsx
+++ b/src/flows/pipes/Notification/endpoints/Mailgun/view.tsx
@@ -4,7 +4,7 @@ import SecretsDropdown from 'src/secrets/components/SecretsDropdown'
 import {PipeContext} from 'src/flows/context/pipe'
 import {EndpointProps} from 'src/types'
 
-const View: FC<EndpointProps> = ({createSecret, secrets}) => {
+export const Mailgun: FC<EndpointProps> = ({createSecret, secrets}) => {
   const {data, update} = useContext(PipeContext)
 
   const updateDomain = evt => {
@@ -68,5 +68,3 @@ const View: FC<EndpointProps> = ({createSecret, secrets}) => {
     </div>
   )
 }
-
-export default View

--- a/src/flows/pipes/Notification/endpoints/Mailjet/index.ts
+++ b/src/flows/pipes/Notification/endpoints/Mailjet/index.ts
@@ -1,95 +1,100 @@
+import {EndpointTypeRegistration} from 'src/types'
+import {MailjetReadOnly} from './readOnly'
+import {Mailjet} from './view'
 import {TEST_NOTIFICATION} from 'src/flows/pipes/Notification/endpoints'
-import View from './view'
-import ReadOnly from './readOnly'
 
-export default register => {
-  register({
-    type: 'mailjet',
-    name: 'Mailjet Email',
-    data: {
-      url: 'https://api.mailjet.com/v3.1/send',
-      apiKey: '',
-      apiSecret: '',
-      email: '',
-      fromEmail: 'alerts@influxdata.com',
-    },
-    featureFlag: 'notebooksNewEndpoints',
-    component: View,
-    readOnlyComponent: ReadOnly,
-    generateImports: () =>
-      ['http', 'influxdata/influxdb/secrets', 'json']
-        .map(i => `import "${i}"`)
-        .join('\n'),
-    generateTestImports: () =>
-      ['array', 'http', 'influxdata/influxdb/secrets', 'json']
-        .map(i => `import "${i}"`)
-        .join('\n'),
-    generateQuery: (data, measurement) => `task_data
-	|> schema["fieldsAsCols"]()
-      |> set(key: "_notebook_link", value: "${window.location.href}")
-  |> filter(fn: ${measurement})
-  |> monitor["check"](
-		data: check,
-		messageFn: messageFn,
-		crit: trigger,
-	)
-  |> filter(fn: trigger)
-  |> keep(columns: ["_value", "_time", "_measurement"])
-  |> limit(n: 1, offset: 0)
-	|> monitor["notify"](
-    data: notification,
-    endpoint: http.endpoint(url: "${data.url}")(
-      mapFn: (r) => {
-        apiKey = secrets.get(key: "${data.apiKey}")
-        apiSecret = secrets.get(key: "${data.apiSecret}")
-        auth = http.basicAuth(u: apiKey, p: apiSecret)
+export class Endpoint implements EndpointTypeRegistration {
+  type = 'mailjet'
+  name = 'Mailjet Email'
+  data = {
+    url: 'https://api.mailjet.com/v3.1/send',
+    apiKey: '',
+    apiSecret: '',
+    email: '',
+    fromEmail: 'alerts@influxdata.com',
+  }
+  featureFlag = 'notebooksNewEndpoints'
+  component = Mailjet
+  readOnlyComponent = MailjetReadOnly
+  generateImports() {
+    return ['http', 'influxdata/influxdb/secrets', 'json']
+      .map(i => `import "${i}"`)
+      .join('\n')
+  }
+  generateTestImports() {
+    return ['array', 'http', 'influxdata/influxdb/secrets', 'json']
+      .map(i => `import "${i}"`)
+      .join('\n')
+  }
+  generateQuery(data, measurement) {
+    return `task_data
+|> schema["fieldsAsCols"]()
+    |> set(key: "_notebook_link", value: "${window.location.href}")
+|> filter(fn: ${measurement})
+|> monitor["check"](
+  data: check,
+  messageFn: messageFn,
+  crit: trigger,
+)
+|> filter(fn: trigger)
+|> keep(columns: ["_value", "_time", "_measurement"])
+|> limit(n: 1, offset: 0)
+|> monitor["notify"](
+  data: notification,
+  endpoint: http.endpoint(url: "${data.url}")(
+    mapFn: (r) => {
+      apiKey = secrets.get(key: "${data.apiKey}")
+      apiSecret = secrets.get(key: "${data.apiSecret}")
+      auth = http.basicAuth(u: apiKey, p: apiSecret)
 
-        return {
-          headers: {
-            "Content-Type": "application/json",
-            "Authorization": auth
-          },
-          data: json.encode(v: {
-            "Messages": [{
-              "From": {
-                "Email": "${data.fromEmail}"
-              },
-              "To": [{
-                "Email": "${data.email}"
-              }],
-              "Subject": "InfluxDB Alert",
-              "TextPart": r._message
-            }]
-          })
-        }
+      return {
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": auth
+        },
+        data: json.encode(v: {
+          "Messages": [{
+            "From": {
+              "Email": "${data.fromEmail}"
+            },
+            "To": [{
+              "Email": "${data.email}"
+            }],
+            "Subject": "InfluxDB Alert",
+            "TextPart": r._message
+          }]
+        })
       }
-    )
-  )`,
-    generateTestQuery: data => `
-    apiKey = secrets.get(key: "${data.apiKey}")
-    apiSecret = secrets.get(key: "${data.apiSecret}")
-    auth = http.basicAuth(u: apiKey, p: apiSecret)
+    }
+  )
+)`
+  }
+  generateTestQuery(data) {
+    return `
+  apiKey = secrets.get(key: "${data.apiKey}")
+  apiSecret = secrets.get(key: "${data.apiSecret}")
+  auth = http.basicAuth(u: apiKey, p: apiSecret)
 
-    http.post(
-      url: "${data.url}",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": auth
-      },
-      data: json.encode(v: {
-        "Messages": [{
-          "From": {
-            "Email": "${data.fromEmail}"
-          },
-          "To": [{
-            "Email": "${data.email}"
-          }],
-          "Subject": "InfluxDB Alert",
-          "TextPart": "${TEST_NOTIFICATION}"
-        }]
-      }))
+  http.post(
+    url: "${data.url}",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": auth
+    },
+    data: json.encode(v: {
+      "Messages": [{
+        "From": {
+          "Email": "${data.fromEmail}"
+        },
+        "To": [{
+          "Email": "${data.email}"
+        }],
+        "Subject": "InfluxDB Alert",
+        "TextPart": "${TEST_NOTIFICATION}"
+      }]
+    }))
 
-    array.from(rows: [{value: 0}])
-        |> yield(name: "ignore")`,
-  })
+  array.from(rows: [{value: 0}])
+      |> yield(name: "ignore")`
+  }
 }

--- a/src/flows/pipes/Notification/endpoints/Mailjet/readOnly.tsx
+++ b/src/flows/pipes/Notification/endpoints/Mailjet/readOnly.tsx
@@ -9,7 +9,7 @@ import {
 
 import {PipeContext} from 'src/flows/context/pipe'
 
-const ReadOnly: FC = () => {
+export const MailjetReadOnly: FC = () => {
   const {data} = useContext(PipeContext)
 
   return (
@@ -54,5 +54,3 @@ const ReadOnly: FC = () => {
     </div>
   )
 }
-
-export default ReadOnly

--- a/src/flows/pipes/Notification/endpoints/Mailjet/view.tsx
+++ b/src/flows/pipes/Notification/endpoints/Mailjet/view.tsx
@@ -4,7 +4,7 @@ import SecretsDropdown from 'src/secrets/components/SecretsDropdown'
 import {PipeContext} from 'src/flows/context/pipe'
 import {EndpointProps} from 'src/types'
 
-const View: FC<EndpointProps> = ({createSecret, secrets}) => {
+export const Mailjet: FC<EndpointProps> = ({createSecret, secrets}) => {
   const {data, update} = useContext(PipeContext)
 
   const updateAPIKey = val => {
@@ -86,5 +86,3 @@ const View: FC<EndpointProps> = ({createSecret, secrets}) => {
     </div>
   )
 }
-
-export default View

--- a/src/flows/pipes/Notification/endpoints/PagerDuty/index.ts
+++ b/src/flows/pipes/Notification/endpoints/PagerDuty/index.ts
@@ -1,68 +1,73 @@
+import {EndpointTypeRegistration} from 'src/types'
+import {PagerDutyReadOnly} from './readOnly'
+import {PagerDuty} from './view'
 import {TEST_NOTIFICATION} from 'src/flows/pipes/Notification/endpoints'
-import View from './view'
-import ReadOnly from './readOnly'
 
-export default register => {
-  register({
-    type: 'pagerduty',
-    name: 'PagerDuty',
-    data: {
-      url: '',
-      key: '',
-      level: 'warning',
-    },
-    component: View,
-    readOnlyComponent: ReadOnly,
-    generateTestImports: () =>
-      ['array', 'pagerduty', 'influxdata/influxdb/secrets']
-        .map(i => `import "${i}"`)
-        .join('\n'),
-    generateImports: () =>
-      ['pagerduty', 'influxdata/influxdb/secrets']
-        .map(i => `import "${i}"`)
-        .join('\n'),
-    generateQuery: (data, measurement) => `task_data
-	|> schema["fieldsAsCols"]()
-  |> set(key: "_notebook_link", value: "${window.location.href}")
-  |> filter(fn: ${measurement})
-  |> monitor["check"](
-		data: check,
-		messageFn: messageFn,
-    crit: trigger,
-	)
-  |> filter(fn: trigger)
-  |> keep(columns: ["_value", "_time", "_measurement"])
-  |> limit(n: 1, offset: 0)
-	|> monitor["notify"](data: notification, endpoint: pagerduty.endpoint()(mapFn: (r) => ({ r with
-        routingKey: "${data.key}",
-        client: "influxdata",
-        clientURL: "${data.url}",
-        class: r._check_name,
-        group: r["_source_measurement"],
-        severity: pagerduty["severityFromLevel"](level: "${data.level}"),
-        eventAction: pagerduty["actionFromLevel"](level: "${data.level}"),
-        source: notification["_notification_rule_name"],
-        summary: r["_message"],
-        timestamp: time(v: r["_source_timestamp"]),
-  })))`,
-    generateTestQuery: data => `pagerduty.sendEvent(
-      pagerdutyURL: "https://events.pagerduty.com/v2/enqueue",
+export class Endpoint implements EndpointTypeRegistration {
+  type = 'pagerduty'
+  name = 'PagerDuty'
+  data = {
+    url: '',
+    key: '',
+    level: 'warning',
+  }
+  component = PagerDuty
+  readOnlyComponent = PagerDutyReadOnly
+  generateTestImports() {
+    return ['array', 'pagerduty', 'influxdata/influxdb/secrets']
+      .map(i => `import "${i}"`)
+      .join('\n')
+  }
+  generateImports() {
+    return ['pagerduty', 'influxdata/influxdb/secrets']
+      .map(i => `import "${i}"`)
+      .join('\n')
+  }
+  generateQuery(data, measurement) {
+    return `task_data
+|> schema["fieldsAsCols"]()
+|> set(key: "_notebook_link", value: "${window.location.href}")
+|> filter(fn: ${measurement})
+|> monitor["check"](
+  data: check,
+  messageFn: messageFn,
+  crit: trigger,
+)
+|> filter(fn: trigger)
+|> keep(columns: ["_value", "_time", "_measurement"])
+|> limit(n: 1, offset: 0)
+|> monitor["notify"](data: notification, endpoint: pagerduty.endpoint()(mapFn: (r) => ({ r with
       routingKey: "${data.key}",
       client: "influxdata",
       clientURL: "${data.url}",
-      dedupKey: "${new Date().toISOString()}",
-      class: "check_name",
-      group: "test_measurement",
-      severity: "critical",
-      eventAction: "trigger",
-      source: "Notebook Generated Test Notification",
-      component: "example-component",
-      summary: "${TEST_NOTIFICATION}",
-      timestamp: "${new Date().toISOString()}",
-      customDetails: {}
-    )
-    array.from(rows: [{value: 0}])
-      |> yield(name: "ignore")
-    `,
-  })
+      class: r._check_name,
+      group: r["_source_measurement"],
+      severity: pagerduty["severityFromLevel"](level: "${data.level}"),
+      eventAction: pagerduty["actionFromLevel"](level: "${data.level}"),
+      source: notification["_notification_rule_name"],
+      summary: r["_message"],
+      timestamp: time(v: r["_source_timestamp"]),
+})))`
+  }
+  generateTestQuery(data) {
+    return `pagerduty.sendEvent(
+    pagerdutyURL: "https://events.pagerduty.com/v2/enqueue",
+    routingKey: "${data.key}",
+    client: "influxdata",
+    clientURL: "${data.url}",
+    dedupKey: "${new Date().toISOString()}",
+    class: "check_name",
+    group: "test_measurement",
+    severity: "critical",
+    eventAction: "trigger",
+    source: "Notebook Generated Test Notification",
+    component: "example-component",
+    summary: "${TEST_NOTIFICATION}",
+    timestamp: "${new Date().toISOString()}",
+    customDetails: {}
+  )
+  array.from(rows: [{value: 0}])
+    |> yield(name: "ignore")
+  `
+  }
 }

--- a/src/flows/pipes/Notification/endpoints/PagerDuty/readOnly.tsx
+++ b/src/flows/pipes/Notification/endpoints/PagerDuty/readOnly.tsx
@@ -11,7 +11,7 @@ import {
 
 import {PipeContext} from 'src/flows/context/pipe'
 
-const ReadOnly: FC = () => {
+export const PagerDutyReadOnly: FC = () => {
   const {data} = useContext(PipeContext)
 
   return (
@@ -37,5 +37,3 @@ const ReadOnly: FC = () => {
     </FlexBox>
   )
 }
-
-export default ReadOnly

--- a/src/flows/pipes/Notification/endpoints/PagerDuty/view.tsx
+++ b/src/flows/pipes/Notification/endpoints/PagerDuty/view.tsx
@@ -13,7 +13,7 @@ import {PipeContext} from 'src/flows/context/pipe'
 import {getOrg} from 'src/organizations/selectors'
 import {EndpointProps} from 'src/types'
 
-const View: FC<EndpointProps> = () => {
+export const PagerDuty: FC<EndpointProps> = () => {
   const {data, update} = useContext(PipeContext)
   const org = useSelector(getOrg)
 
@@ -62,5 +62,3 @@ const View: FC<EndpointProps> = () => {
     </FlexBox>
   )
 }
-
-export default View

--- a/src/flows/pipes/Notification/endpoints/SendGrid/index.ts
+++ b/src/flows/pipes/Notification/endpoints/SendGrid/index.ts
@@ -1,106 +1,111 @@
+import {EndpointTypeRegistration} from 'src/types'
+import {SendGridReadOnly} from './readOnly'
+import {SendGrid} from './view'
 import {TEST_NOTIFICATION} from 'src/flows/pipes/Notification/endpoints'
-import View from './view'
-import ReadOnly from './readOnly'
 
-export default register => {
-  register({
-    type: 'sendgrid',
-    name: 'SendGrid Email',
-    data: {
-      url: 'https://api.sendgrid.com/v3/mail/send',
-      apiKey: '',
-      email: '',
-      fromEmail: 'alerts@influxdata.com',
-    },
-    featureFlag: 'notebooksNewEndpoints',
-    component: View,
-    readOnlyComponent: ReadOnly,
-    generateImports: () =>
-      ['http', 'influxdata/influxdb/secrets', 'json']
-        .map(i => `import "${i}"`)
-        .join('\n'),
-    generateTestImports: () =>
-      ['array', 'http', 'influxdata/influxdb/secrets', 'json']
-        .map(i => `import "${i}"`)
-        .join('\n'),
-    generateQuery: (data, measurement) => `task_data
-	|> schema["fieldsAsCols"]()
-      |> set(key: "_notebook_link", value: "${window.location.href}")
-  |> filter(fn: ${measurement})
-  |> monitor["check"](
-		data: check,
-		messageFn: messageFn,
-		crit: trigger,
-	)
-  |> filter(fn: trigger)
-  |> keep(columns: ["_value", "_time", "_measurement"])
-  |> limit(n: 1, offset: 0)
-  |> monitor["notify"](
-    data: notification,
-    endpoint: http.endpoint(url: "${data.url}")(
-      mapFn: (r) => {
-        apiKey = secrets.get(key: "${data.apiKey}")
-        return {
-          headers: {
-            "Content-Type": "application/json",
-            "Authorization": "Bearer \${apiKey}"
-          },
-          data: json.encode(v: {
-            "personalizations": [
-              {
-                "to": [
-                  {
-                    "email": "${data.email}"
-                  }
-                ],
-                "subject": "InfluxDB Alert",
-              }
-            ],
-            "from": {
-              "email": "${data.fromEmail}"
-            },
-            "content": [
-              {
-                "type": "text/plain",
-                "value": r._message
-              }
-            ]
-          })
-        }
-      }
-    )
-  )`,
-    generateTestQuery: data => `
-    apiKey = secrets.get(key: "${data.apiKey}")
-    http.post(
-      url: "${data.url}",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": "Bearer \${apiKey}"
-      },
-      data: json.encode(v: {
-        "personalizations": [
-          {
-            "to": [
-              {
-                "email": "${data.email}"
-              }
-            ],
-            "subject": "InfluxDB Alert"
-          }
-        ],
-        "from": {
-          "email": "${data.fromEmail}"
+export class Endpoint implements EndpointTypeRegistration {
+  type = 'sendgrid'
+  name = 'SendGrid Email'
+  data = {
+    url: 'https://api.sendgrid.com/v3/mail/send',
+    apiKey: '',
+    email: '',
+    fromEmail: 'alerts@influxdata.com',
+  }
+  featureFlag = 'notebooksNewEndpoints'
+  component = SendGrid
+  readOnlyComponent = SendGridReadOnly
+  generateImports() {
+    return ['http', 'influxdata/influxdb/secrets', 'json']
+      .map(i => `import "${i}"`)
+      .join('\n')
+  }
+  generateTestImports() {
+    return ['array', 'http', 'influxdata/influxdb/secrets', 'json']
+      .map(i => `import "${i}"`)
+      .join('\n')
+  }
+  generateQuery(data, measurement) {
+    return `task_data
+|> schema["fieldsAsCols"]()
+    |> set(key: "_notebook_link", value: "${window.location.href}")
+|> filter(fn: ${measurement})
+|> monitor["check"](
+  data: check,
+  messageFn: messageFn,
+  crit: trigger,
+)
+|> filter(fn: trigger)
+|> keep(columns: ["_value", "_time", "_measurement"])
+|> limit(n: 1, offset: 0)
+|> monitor["notify"](
+  data: notification,
+  endpoint: http.endpoint(url: "${data.url}")(
+    mapFn: (r) => {
+      apiKey = secrets.get(key: "${data.apiKey}")
+      return {
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": "Bearer \${apiKey}"
         },
-        "content": [
-          {
-            "type": "text/plain",
-            "value": "${TEST_NOTIFICATION}"
-          }
-        ]
-      })
-    )
-    array.from(rows: [{value: 0}])
-        |> yield(name: "ignore")`,
-  })
+        data: json.encode(v: {
+          "personalizations": [
+            {
+              "to": [
+                {
+                  "email": "${data.email}"
+                }
+              ],
+              "subject": "InfluxDB Alert",
+            }
+          ],
+          "from": {
+            "email": "${data.fromEmail}"
+          },
+          "content": [
+            {
+              "type": "text/plain",
+              "value": r._message
+            }
+          ]
+        })
+      }
+    }
+  )
+)`
+  }
+  generateTestQuery(data) {
+    return `
+  apiKey = secrets.get(key: "${data.apiKey}")
+  http.post(
+    url: "${data.url}",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": "Bearer \${apiKey}"
+    },
+    data: json.encode(v: {
+      "personalizations": [
+        {
+          "to": [
+            {
+              "email": "${data.email}"
+            }
+          ],
+          "subject": "InfluxDB Alert"
+        }
+      ],
+      "from": {
+        "email": "${data.fromEmail}"
+      },
+      "content": [
+        {
+          "type": "text/plain",
+          "value": "${TEST_NOTIFICATION}"
+        }
+      ]
+    })
+  )
+  array.from(rows: [{value: 0}])
+      |> yield(name: "ignore")`
+  }
 }

--- a/src/flows/pipes/Notification/endpoints/SendGrid/readOnly.tsx
+++ b/src/flows/pipes/Notification/endpoints/SendGrid/readOnly.tsx
@@ -9,7 +9,7 @@ import {
 
 import {PipeContext} from 'src/flows/context/pipe'
 
-const ReadOnly: FC = () => {
+export const SendGridReadOnly: FC = () => {
   const {data} = useContext(PipeContext)
 
   return (
@@ -45,5 +45,3 @@ const ReadOnly: FC = () => {
     </div>
   )
 }
-
-export default ReadOnly

--- a/src/flows/pipes/Notification/endpoints/SendGrid/view.tsx
+++ b/src/flows/pipes/Notification/endpoints/SendGrid/view.tsx
@@ -4,7 +4,7 @@ import SecretsDropdown from 'src/secrets/components/SecretsDropdown'
 import {PipeContext} from 'src/flows/context/pipe'
 import {EndpointProps} from 'src/types'
 
-const View: FC<EndpointProps> = ({createSecret, secrets}) => {
+export const SendGrid: FC<EndpointProps> = ({createSecret, secrets}) => {
   const {data, update} = useContext(PipeContext)
 
   const updateAPIKey = val => {
@@ -68,5 +68,3 @@ const View: FC<EndpointProps> = ({createSecret, secrets}) => {
     </div>
   )
 }
-
-export default View

--- a/src/flows/pipes/Notification/endpoints/Slack/index.ts
+++ b/src/flows/pipes/Notification/endpoints/Slack/index.ts
@@ -1,50 +1,56 @@
+import {EndpointTypeRegistration} from 'src/types'
+import {SlackReadOnly} from './readOnly'
+import {Slack} from './view'
 import {TEST_NOTIFICATION} from 'src/flows/pipes/Notification/endpoints'
-import View from './view'
-import ReadOnly from './readOnly'
 
-export default register => {
-  register({
-    type: 'slack',
-    name: 'Slack',
-    data: {
-      url: 'https://hooks.slack.com/services/X/X/X',
-      channel: '',
-      color: '#34BB55',
-    },
-    component: View,
-    readOnlyComponent: ReadOnly,
-    generateImports: () => ['slack'].map(i => `import "${i}"`).join('\n'),
-    generateTestImports: () =>
-      ['array', 'slack'].map(i => `import "${i}"`).join('\n'),
-    generateQuery: (data, measurement) => `task_data
-	|> schema["fieldsAsCols"]()
-      |> set(key: "_notebook_link", value: "${window.location.href}")
-  |> filter(fn: ${measurement})
-	|> monitor["check"](
-		data: check,
-		messageFn: messageFn,
-		crit: trigger,
-	)
-  |> filter(fn: trigger)
-  |> keep(columns: ["_value", "_time", "_measurement"])
-  |> limit(n: 1, offset: 0)
-	|> monitor["notify"](
-    data: notification,
-    endpoint: slack["endpoint"](url: "${data.url}")(mapFn: (r) => ({
-      channel: "${data.channel || ''}",
-      text: "\${ r._message }",
-      color: "${data.color || '#34BB55'}"
-    }))
-  )`,
-    generateTestQuery: data => `
-  slack.message(
-    url: "${data.url}",
+export class Endpoint implements EndpointTypeRegistration {
+  type = 'slack'
+  name = 'Slack'
+  data = {
+    url: 'https://hooks.slack.com/services/X/X/X',
+    channel: '',
+    color: '#34BB55',
+  }
+  component = Slack
+  readOnlyComponent = SlackReadOnly
+  generateImports() {
+    return ['slack'].map(i => `import "${i}"`).join('\n')
+  }
+  generateTestImports() {
+    return ['array', 'slack'].map(i => `import "${i}"`).join('\n')
+  }
+  generateQuery(data, measurement) {
+    return `task_data
+|> schema["fieldsAsCols"]()
+    |> set(key: "_notebook_link", value: "${window.location.href}")
+|> filter(fn: ${measurement})
+|> monitor["check"](
+  data: check,
+  messageFn: messageFn,
+  crit: trigger,
+)
+|> filter(fn: trigger)
+|> keep(columns: ["_value", "_time", "_measurement"])
+|> limit(n: 1, offset: 0)
+|> monitor["notify"](
+  data: notification,
+  endpoint: slack["endpoint"](url: "${data.url}")(mapFn: (r) => ({
     channel: "${data.channel || ''}",
-    text: "${TEST_NOTIFICATION}",
+    text: "\${ r._message }",
     color: "${data.color || '#34BB55'}"
-  )
+  }))
+)`
+  }
+  generateTestQuery(data) {
+    return `
+slack.message(
+  url: "${data.url}",
+  channel: "${data.channel || ''}",
+  text: "${TEST_NOTIFICATION}",
+  color: "${data.color || '#34BB55'}"
+)
 
-  array.from(rows: [{value: 0}])
-	|> yield(name: "ignore")`,
-  })
+array.from(rows: [{value: 0}])
+|> yield(name: "ignore")`
+  }
 }

--- a/src/flows/pipes/Notification/endpoints/Slack/readOnly.tsx
+++ b/src/flows/pipes/Notification/endpoints/Slack/readOnly.tsx
@@ -9,7 +9,7 @@ import {
 
 import {PipeContext} from 'src/flows/context/pipe'
 
-const ReadOnly: FC = () => {
+export const SlackReadOnly: FC = () => {
   const {data} = useContext(PipeContext)
 
   return (
@@ -45,5 +45,3 @@ const ReadOnly: FC = () => {
     </div>
   )
 }
-
-export default ReadOnly

--- a/src/flows/pipes/Notification/endpoints/Slack/view.tsx
+++ b/src/flows/pipes/Notification/endpoints/Slack/view.tsx
@@ -17,7 +17,7 @@ import {EndpointProps} from 'src/types'
  */
 const suggestedColors = ['#DC4E58', '#FFB94A', '#2FA74D', '#0098F0', '#8E1FC3']
 
-const View: FC<EndpointProps> = () => {
+export const Slack: FC<EndpointProps> = () => {
   const {data, update} = useContext(PipeContext)
 
   const updateUrl = evt => {
@@ -90,5 +90,3 @@ const View: FC<EndpointProps> = () => {
     </div>
   )
 }
-
-export default View

--- a/src/flows/pipes/Notification/endpoints/Telegram/index.ts
+++ b/src/flows/pipes/Notification/endpoints/Telegram/index.ts
@@ -1,66 +1,71 @@
+import {EndpointTypeRegistration} from 'src/types'
 import {TEST_NOTIFICATION} from 'src/flows/pipes/Notification/endpoints'
-import View from './view'
-import ReadOnly from './readOnly'
+import {TelegramReadOnly} from './readOnly'
+import {Telegram} from './view'
 
-export default register => {
-  register({
-    type: 'telegram',
-    name: 'Telegram',
-    data: {
-      url: 'https://api.telegram.org/bot',
-      channel: '',
-      token: '',
-      parseMode: 'MarkdownV2',
-    },
-    featureFlag: 'notebooksNewEndpoints',
-    component: View,
-    readOnlyComponent: ReadOnly,
-    generateImports: () =>
-      ['contrib/sranka/telegram', 'influxdata/influxdb/secrets']
-        .map(i => `import "${i}"`)
-        .join('\n'),
-    generateTestImports: () =>
-      ['array', 'contrib/sranka/telegram', 'influxdata/influxdb/secrets']
-        .map(i => `import "${i}"`)
-        .join('\n'),
-    generateQuery: (data, measurement) => `task_data
-	|> schema["fieldsAsCols"]()
-      |> set(key: "_notebook_link", value: "${window.location.href}")
-  |> filter(fn: ${measurement})
-	|> monitor["check"](
-		data: check,
-		messageFn: messageFn,
-		crit: trigger,
-	)
-  |> filter(fn: trigger)
-  |> keep(columns: ["_value", "_time", "_measurement"])
-  |> limit(n: 1, offset: 0)
-	|> monitor["notify"](
-    data: notification,
-    endpoint: telegram["endpoint"](
+export class Endpoint implements EndpointTypeRegistration {
+  type = 'telegram'
+  name = 'Telegram'
+  data = {
+    url: 'https://api.telegram.org/bot',
+    channel: '',
+    token: '',
+    parseMode: 'MarkdownV2',
+  }
+  featureFlag = 'notebooksNewEndpoints'
+  component = Telegram
+  readOnlyComponent = TelegramReadOnly
+  generateImports() {
+    return ['contrib/sranka/telegram', 'influxdata/influxdb/secrets']
+      .map(i => `import "${i}"`)
+      .join('\n')
+  }
+  generateTestImports() {
+    return ['array', 'contrib/sranka/telegram', 'influxdata/influxdb/secrets']
+      .map(i => `import "${i}"`)
+      .join('\n')
+  }
+  generateQuery(data, measurement) {
+    return `task_data
+|> schema["fieldsAsCols"]()
+    |> set(key: "_notebook_link", value: "${window.location.href}")
+|> filter(fn: ${measurement})
+|> monitor["check"](
+  data: check,
+  messageFn: messageFn,
+  crit: trigger,
+)
+|> filter(fn: trigger)
+|> keep(columns: ["_value", "_time", "_measurement"])
+|> limit(n: 1, offset: 0)
+|> monitor["notify"](
+  data: notification,
+  endpoint: telegram["endpoint"](
+    url: "${data.url}",
+    token: secrets.get(key: "${data.token}"),
+    parseMode: "${data.parseMode}",
+    disableWebPagePreview: false
+    )(
+      mapFn: (r) => ({
+        channel: "${data.channel}",
+        text: "\${ r._message }",
+        silent: true
+  }))
+)`
+  }
+  generateTestQuery(data) {
+    return `
+    telegram.message(
       url: "${data.url}",
       token: secrets.get(key: "${data.token}"),
       parseMode: "${data.parseMode}",
-      disableWebPagePreview: false
-      )(
-        mapFn: (r) => ({
-          channel: "${data.channel}",
-          text: "\${ r._message }",
-          silent: true
-    }))
-  )`,
-    generateTestQuery: data => `
-      telegram.message(
-        url: "${data.url}",
-        token: secrets.get(key: "${data.token}"),
-        parseMode: "${data.parseMode}",
-        channel: "${data.channel}",
-        text: "${TEST_NOTIFICATION}",
-        disableWebPagePreview: false,
-        silent: true
-      )
+      channel: "${data.channel}",
+      text: "${TEST_NOTIFICATION}",
+      disableWebPagePreview: false,
+      silent: true
+    )
 
-      array.from(rows: [{value: 0}])
-          |> yield(name: "ignore")`,
-  })
+    array.from(rows: [{value: 0}])
+        |> yield(name: "ignore")`
+  }
 }

--- a/src/flows/pipes/Notification/endpoints/Telegram/readOnly.tsx
+++ b/src/flows/pipes/Notification/endpoints/Telegram/readOnly.tsx
@@ -9,7 +9,7 @@ import {
 
 import {PipeContext} from 'src/flows/context/pipe'
 
-const ReadOnly: FC = () => {
+export const TelegramReadOnly: FC = () => {
   const {data} = useContext(PipeContext)
 
   return (
@@ -57,5 +57,3 @@ const ReadOnly: FC = () => {
     </div>
   )
 }
-
-export default ReadOnly

--- a/src/flows/pipes/Notification/endpoints/Telegram/view.tsx
+++ b/src/flows/pipes/Notification/endpoints/Telegram/view.tsx
@@ -4,7 +4,7 @@ import SecretsDropdown from 'src/secrets/components/SecretsDropdown'
 import {EndpointProps} from 'src/types'
 import {PipeContext} from 'src/flows/context/pipe'
 
-const View: FC<EndpointProps> = ({createSecret, secrets}) => {
+export const Telegram: FC<EndpointProps> = ({createSecret, secrets}) => {
   const {data, update} = useContext(PipeContext)
 
   const updateURL = evt => {
@@ -87,5 +87,3 @@ const View: FC<EndpointProps> = ({createSecret, secrets}) => {
     </div>
   )
 }
-
-export default View

--- a/src/flows/pipes/Notification/endpoints/Zenoss/index.ts
+++ b/src/flows/pipes/Notification/endpoints/Zenoss/index.ts
@@ -1,74 +1,79 @@
+import {EndpointTypeRegistration} from 'src/types'
 import {TEST_NOTIFICATION} from 'src/flows/pipes/Notification/endpoints'
-import View from './view'
-import ReadOnly from './readOnly'
+import {ZenossReadOnly} from './readOnly'
+import {Zenoss} from './view'
 
-export default register => {
-  register({
-    type: 'zenoss',
-    name: 'Zenoss',
-    data: {
-      url: 'https://example.zenoss.io:8080/zport/dmd/evconsole_router',
-      username: '',
-      password: '',
-      action: '',
-      method: '',
-      severity: '',
-    },
-    featureFlag: 'notebooksNewEndpoints',
-    component: View,
-    readOnlyComponent: ReadOnly,
-    generateImports: () =>
-      ['contrib/bonitoo-io/zenoss', 'influxdata/influxdb/secrets']
-        .map(i => `import "${i}"`)
-        .join('\n'),
-    generateTestImports: () =>
-      ['array', 'contrib/bonitoo-io/zenoss', 'influxdata/influxdb/secrets']
-        .map(i => `import "${i}"`)
-        .join('\n'),
-    generateQuery: (data, measurement) => `task_data
-	|> schema["fieldsAsCols"]()
-      |> set(key: "_notebook_link", value: "${window.location.href}")
-  |> filter(fn: ${measurement})
-	|> monitor["check"](
-		data: check,
-		messageFn: messageFn,
-		crit: trigger,
-	)
-  |> filter(fn: trigger)
-  |> keep(columns: ["_value", "_time", "_measurement"])
-  |> limit(n: 1, offset: 0)
-	|> monitor["notify"](
-    data: notification,
-    endpoint: zenoss["endpoint"](
-      url: "${data.url}",
-      username: secrets.get(key: "${data.username}"),
-      password: secrets.get(key: "${data.password}"),
-      action: "${data.action}",
-      method: "${data.method}",
-      )(
-        mapFn: (r) => ({
-          message: "\${ r._message }",
-          severity: "${data.severity}",
-          summary: "${data.severity} event for \${ r.host }",
-          device: "\${ r.deviceID }",
-          component: "\${ r.host }",
-          eventClass: "/App",
-          eventClassKey: "",
-          collector: "",
-    }))
-  )`,
-    generateTestQuery: data => `
-    telegram.endpoint(
-      url: "${data.url}",
-      username: secrets.get(key: "${data.username}"),
-      password: secrets.get(key: "${data.password}"),
-      action: "${data.action}",
-      method: "${data.method}",
-      message: "${TEST_NOTIFICATION}",
-      severity: "${data.severity}",
-    )
+export class Endpoint implements EndpointTypeRegistration {
+  type = 'zenoss'
+  name = 'Zenoss'
+  data = {
+    url: 'https://example.zenoss.io:8080/zport/dmd/evconsole_router',
+    username: '',
+    password: '',
+    action: '',
+    method: '',
+    severity: '',
+  }
+  featureFlag = 'notebooksNewEndpoints'
+  component = Zenoss
+  readOnlyComponent = ZenossReadOnly
+  generateImports() {
+    return ['contrib/bonitoo-io/zenoss', 'influxdata/influxdb/secrets']
+      .map(i => `import "${i}"`)
+      .join('\n')
+  }
+  generateTestImports() {
+    return ['array', 'contrib/bonitoo-io/zenoss', 'influxdata/influxdb/secrets']
+      .map(i => `import "${i}"`)
+      .join('\n')
+  }
+  generateQuery(data, measurement) {
+    return `task_data
+|> schema["fieldsAsCols"]()
+    |> set(key: "_notebook_link", value: "${window.location.href}")
+|> filter(fn: ${measurement})
+|> monitor["check"](
+  data: check,
+  messageFn: messageFn,
+  crit: trigger,
+)
+|> filter(fn: trigger)
+|> keep(columns: ["_value", "_time", "_measurement"])
+|> limit(n: 1, offset: 0)
+|> monitor["notify"](
+  data: notification,
+  endpoint: zenoss["endpoint"](
+    url: "${data.url}",
+    username: secrets.get(key: "${data.username}"),
+    password: secrets.get(key: "${data.password}"),
+    action: "${data.action}",
+    method: "${data.method}",
+    )(
+      mapFn: (r) => ({
+        message: "\${ r._message }",
+        severity: "${data.severity}",
+        summary: "${data.severity} event for \${ r.host }",
+        device: "\${ r.deviceID }",
+        component: "\${ r.host }",
+        eventClass: "/App",
+        eventClassKey: "",
+        collector: "",
+  }))
+)`
+  }
+  generateTestQuery(data) {
+    return `
+  telegram.endpoint(
+    url: "${data.url}",
+    username: secrets.get(key: "${data.username}"),
+    password: secrets.get(key: "${data.password}"),
+    action: "${data.action}",
+    method: "${data.method}",
+    message: "${TEST_NOTIFICATION}",
+    severity: "${data.severity}",
+  )
 
-    array.from(rows: [{value: 0}])
-        |> yield(name: "ignore")`,
-  })
+  array.from(rows: [{value: 0}])
+      |> yield(name: "ignore")`
+  }
 }

--- a/src/flows/pipes/Notification/endpoints/Zenoss/readOnly.tsx
+++ b/src/flows/pipes/Notification/endpoints/Zenoss/readOnly.tsx
@@ -8,7 +8,7 @@ import {
 } from '@influxdata/clockface'
 import {PipeContext} from 'src/flows/context/pipe'
 
-const ReadOnly: FC = () => {
+export const ZenossReadOnly: FC = () => {
   const {data} = useContext(PipeContext)
 
   return (
@@ -66,5 +66,3 @@ const ReadOnly: FC = () => {
     </div>
   )
 }
-
-export default ReadOnly

--- a/src/flows/pipes/Notification/endpoints/Zenoss/view.tsx
+++ b/src/flows/pipes/Notification/endpoints/Zenoss/view.tsx
@@ -13,7 +13,7 @@ import SecretsDropdown from 'src/secrets/components/SecretsDropdown'
 import {EndpointProps} from 'src/types'
 import {PipeContext} from 'src/flows/context/pipe'
 
-const View: FC<EndpointProps> = ({createSecret, secrets}) => {
+export const Zenoss: FC<EndpointProps> = ({createSecret, secrets}) => {
   const {data, update} = useContext(PipeContext)
   const severities = ['Critical', 'Warning', 'Info', 'Clear']
 
@@ -158,5 +158,3 @@ const View: FC<EndpointProps> = ({createSecret, secrets}) => {
     </div>
   )
 }
-
-export default View


### PR DESCRIPTION
Part of #5819   

Removes the self-registering pattern that uses `require.context` for Flows Notification Endpoints