### PR TITLE
chore: use solid clockface icon `Save` for save button

### DIFF
--- a/src/dataExplorer/components/FluxQueryBuilder.tsx
+++ b/src/dataExplorer/components/FluxQueryBuilder.tsx
@@ -217,7 +217,7 @@ const FluxQueryBuilder: FC = () => {
                     }
                     text="Save"
                     testID="flux-query-builder--save-script"
-                    icon={IconFont.SaveOutline}
+                    icon={IconFont.Save}
                   />
                 )}
                 {isFlagEnabled('saveAsScript') && resource?.data?.id && (


### PR DESCRIPTION
Closes #6179 

We switched back to "SaveOutline" icon again in #6195 this morning. The pie chart shows up again in production and in Tools 🫠 Seems like the icon file is mapping the wrong icon image for "SaveOutline"

This PR uses the solid "Save" icon for now until clockface updates the icon file

## After
<img width="507" alt="Screen Shot 2022-10-28 at 2 39 06 PM" src="https://user-images.githubusercontent.com/14298407/198720909-d66e5a02-6825-4709-82e0-e325fb832305.png">



### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
~~- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~~
~~- [ ] Feature flagged, if applicable~~
