### PR TITLE
fix: move cross axis syncining into a separate hook

### DIFF
--- a/src/visualization/utils/useVisDomainSettings.ts
+++ b/src/visualization/utils/useVisDomainSettings.ts
@@ -277,21 +277,24 @@ export const useZoomRequeryXDomainSettings = (args: ZoomRequeryArgs) => {
   //      - the time range has changed
   useEffect(() => {
     if (
-      !timeRange ||
-      (!preZoomResult &&
-        (isNotEqual(preZoomDomain, domain) ||
-          (timeRange && isNotEqual(timeRange, selectedTimeRange))))
+      !preZoomResult &&
+      (isNotEqual(preZoomDomain, domain) ||
+        (timeRange && isNotEqual(timeRange, selectedTimeRange)))
     ) {
       setSelectedTimeRange(timeRange)
       setDomain(preZoomDomain)
     }
   }, [domain, preZoomDomain, preZoomResult, selectedTimeRange, timeRange])
 
+  // send back the window period if it is the time axis, otherwise
+  //   cross syncing - time axis zoom changes the limits of the value axis
   useEffect(() => {
     if (timeRange) {
       transmitWindowPeriod(windowPeriod)
+    } else {
+      setDomain(preZoomDomain)
     }
-  }, [timeRange, transmitWindowPeriod, windowPeriod])
+  }, [preZoomDomain, timeRange, transmitWindowPeriod, windowPeriod])
 
   // Suppresses adaptive zoom feature; must come after all hooks
   if (
@@ -455,21 +458,24 @@ export const useZoomRequeryYDomainSettings = (args: ZoomRequeryArgs) => {
   //      - the time range has changed
   useEffect(() => {
     if (
-      !timeRange ||
-      (!preZoomResult &&
-        (isNotEqual(preZoomDomain, domain) ||
-          (timeRange && isNotEqual(timeRange, selectedTimeRange))))
+      !preZoomResult &&
+      (isNotEqual(preZoomDomain, domain) ||
+        (timeRange && isNotEqual(timeRange, selectedTimeRange)))
     ) {
       setSelectedTimeRange(timeRange)
       setDomain(preZoomDomain)
     }
   }, [domain, preZoomDomain, preZoomResult, selectedTimeRange, timeRange])
 
+  // send back the window period if it is the time axis, otherwise
+  //   cross syncing - time axis zoom changes the limits of the value axis
   useEffect(() => {
     if (timeRange) {
       transmitWindowPeriod(windowPeriod)
+    } else {
+      setDomain(preZoomDomain)
     }
-  }, [timeRange, transmitWindowPeriod, windowPeriod])
+  }, [preZoomDomain, timeRange, transmitWindowPeriod, windowPeriod])
 
   // Suppresses adaptive zoom feature; must come after all hooks
   if (


### PR DESCRIPTION
Closes EAR 3724

The problem: syncing an axis has many conditions and not all of them worked. One hook was trying to do too much. Cross-axis syncing, which is when a user zooms and the re-query affects the limits of the data (the domain) of the other axis, was not properly updated. We move this into another hook that conveniently has the the proper conditional in place.

The fix: 
- zooming in on the value axis simply adjusts to the selected domain
- zooming in on the time axis will adjust the time axis (working as before), and also the value axis when new limits are found

Here is a video of the fix. Zoom re-query works. Zooming in on the value works, again.

https://user-images.githubusercontent.com/10736577/199049847-09511caa-aba2-47a9-a0eb-1150a5b71495.mp4


