### PR TITLE
feat: integrate selection with fieldsAsCols

### DIFF
--- a/src/dataExplorer/components/FieldsAsColumns.tsx
+++ b/src/dataExplorer/components/FieldsAsColumns.tsx
@@ -1,22 +1,40 @@
-import React, {FC, useState} from 'react'
+import React, {FC, useCallback, useContext} from 'react'
 
 // Components
 import {ToggleWithLabelTooltip} from 'src/dataExplorer/components/ToggleWithLabelTooltip'
+import {PersistanceContext} from 'src/dataExplorer/context/persistance'
+import {event} from 'src/cloud/utils/reporting'
 
 // Styles
 import './Sidebar.scss'
 
-const FIELDS_AS_COLUMNS_TOOLTIP = `test`
-
 const FieldsAsColumns: FC = () => {
-  const [fieldsAsColumns, setFieldsAsColumns] = useState(false)
+  const {selection, setSelection} = useContext(PersistanceContext)
+
+  const handleToggle = useCallback(() => {
+    const value = !selection?.resultOptions?.fieldsAsColumn
+    event('set fields as columns: ', {value: `${value}`})
+    setSelection({
+      resultOptions: {
+        ...selection.resultOptions,
+        fieldsAsColumn: value,
+      },
+    })
+  }, [selection.resultOptions, setSelection])
 
   return (
     <ToggleWithLabelTooltip
       label="Fields as Columns"
-      active={fieldsAsColumns}
-      onChange={() => setFieldsAsColumns(current => !current)}
-      tooltipContents={FIELDS_AS_COLUMNS_TOOLTIP}
+      active={!!selection?.resultOptions?.fieldsAsColumn}
+      onChange={handleToggle}
+      tooltipContents={
+        <>
+          <code>schema.fieldsAsCols()</code> is a special application of{' '}
+          <code>pivot()</code> that pivots input data on <code>_field</code> and{' '}
+          <code>_time</code> columns to align fields within each input table
+          that have the same timestamp.
+        </>
+      }
     />
   )
 }


### PR DESCRIPTION
Related to #5367

This PR integrates the selection of the `Fields As Columns` toggle with the persistence selection state. However, this PR does not yet integrate with the LSP since that work is currently in flight and has not yet landed. In order for this functionality to be considered code complete, we will need:

1. To allow the toggle setting to update the query text so that prepend `import "influxdata/influxdb/schema"` to the query text when the toggle is on, and remove the import statement when it is off
2. Toggling between the two states should append `|> schema.fieldsAsCols()` to the query text when the toggle is on, and remove the `|> schema.fieldsAsCols()` when it is off
3. Toggling between the two states should cause the query to run

![field-as-cols](https://user-images.githubusercontent.com/19984220/199243061-acab2d46-d06b-4ba0-b5e3-61d3f3be9239.gif)
