### PR TITLE
chore: fix garden project name

### DIFF
--- a/project.garden.yml
+++ b/project.garden.yml
@@ -1,5 +1,5 @@
 kind: Project
-name: idpe
+name: ui
 environments:
   - name: dev
     variables:


### PR DESCRIPTION
Small fix to rename the project name in garden metadata as it is shown in some places and can be confusing.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
