### PR TITLE
feat: add a copy to clipboard mechanism for the invokable url

### DIFF
--- a/src/dataExplorer/components/DataExplorerPage.tsx
+++ b/src/dataExplorer/components/DataExplorerPage.tsx
@@ -44,7 +44,7 @@ import {SCRIPT_EDITOR_PARAMS} from 'src/dataExplorer/components/resources'
 
 const DataExplorerPageHeader: FC = () => {
   const {fluxQueryBuilder, setFluxQueryBuilder} = useContext(AppSettingContext)
-  const {resource, setResource} = useContext(PersistanceContext)
+  const {resource, save} = useContext(PersistanceContext)
   const history = useHistory()
 
   const toggleSlider = () => {
@@ -60,13 +60,8 @@ const DataExplorerPageHeader: FC = () => {
   }
 
   const handleRename = (name: string) => {
-    setResource({
-      ...resource,
-      data: {
-        ...resource.data,
-        name,
-      },
-    })
+    resource.data.name = name
+    save(resource?.language)
   }
 
   const showNewExplorer = fluxQueryBuilder && isFlagEnabled('newDataExplorer')
@@ -74,18 +69,14 @@ const DataExplorerPageHeader: FC = () => {
   let pageTitle = <Page.Title title="Data Explorer" />
 
   if (showNewExplorer && resource?.data?.hasOwnProperty('name')) {
-    if (resource?.data?.type === ResourceType.Scripts) {
-      pageTitle = <Page.Title title={resource?.data?.name ?? ''} />
-    } else {
-      pageTitle = (
-        <RenamablePageTitle
-          onRename={handleRename}
-          name={resource?.data?.name || ''}
-          placeholder="Untitled Script"
-          maxLength={100}
-        />
-      )
-    }
+    pageTitle = (
+      <RenamablePageTitle
+        onRename={handleRename}
+        name={resource?.data?.name || ''}
+        placeholder="Untitled Script"
+        maxLength={100}
+      />
+    )
   }
 
   return (

--- a/src/dataExplorer/components/SaveAsScript.scss
+++ b/src/dataExplorer/components/SaveAsScript.scss
@@ -23,5 +23,22 @@
 }
 
 .edit-overlay__delete-script {
-  margin-top: 16px;
+  margin-top: $cf-space-s;
+}
+
+.invokable-script__url {
+  display: flex;
+  justify-content: space-between;
+
+  input {
+    pointer-events: none;
+  }
+
+  input:hover {
+    cursor: pointer;
+  }
+}
+
+.script-description__input {
+  margin-bottom: $cf-space-s;
 }


### PR DESCRIPTION
Closes #6141

This PR adds some conditional logic to the SaveOverlay to allow for users to copy to clipboard their specific invokable script URL. This PR also updates the renaming logic in the DataExplorerPage & the SaveOverlay. Whereas previously, renaming the script would persist the name change in local storage, it is now making an explicit save to the API based on user input when the makes those changes. In the case of the SaveOverlay, those changes are stored locally until the user explicitly saves / updates their script so that those changes aren't persisted to the database or localstorage until the user actually saves them. This fixes a bug where the previous implementation was storing the temporary changes in local storage and was not persisting the data in the database, leading to a confusing UX 


![invokable-url](https://user-images.githubusercontent.com/19984220/199721000-c65dfffc-7fed-43e3-a91c-24b123901118.gif)
