### PR TITLE
fix(UniversalLogin): handle redirectTo upon auth failure

### DIFF
--- a/src/onboarding/containers/CloudLoginPage.tsx
+++ b/src/onboarding/containers/CloudLoginPage.tsx
@@ -67,8 +67,7 @@ export const CloudLoginPage: FC = () => {
               // if there is a redirectTo, parse the pathname from redirect location
               const redirectToUrl = new URL(redirectTo).pathname
               pathname = redirectToUrl ?? ''
-            }
-            catch {
+            } catch {
               // else, use current location's pathname
               pathname = window.location.pathname ?? ''
             }

--- a/src/onboarding/containers/CloudLoginPage.tsx
+++ b/src/onboarding/containers/CloudLoginPage.tsx
@@ -59,7 +59,19 @@ export const CloudLoginPage: FC = () => {
         fetch('/api/env/quartz-login-url')
           .then(async response => {
             const quartzUrl = await response.text()
-            const pathname = window.location.pathname ?? ''
+            const redirectTo = new URLSearchParams(window.location.search).get(
+              'redirectTo'
+            )
+            let pathname
+            try {
+              // if there is a redirectTo, parse the pathname from redirect location
+              const redirectToUrl = new URL(redirectTo).pathname
+              pathname = redirectToUrl ?? ''
+            }
+            catch {
+              // else, use current location's pathname
+              pathname = window.location.pathname ?? ''
+            }
             const redirectUrl = quartzUrl + pathname
             console.warn('Redirect to cloud url: ', redirectUrl)
             window.location.replace(redirectUrl)


### PR DESCRIPTION
Part of [#6217](https://github.com/influxdata/ui/issues/6217)

When testing https://github.com/influxdata/ui/pull/6238 I found that when there is an auth failure, we use `redirectTo` to bring the user back to where they started. Since `redirectTo` is a param, it doesn't get added to the `pathname` by just using the default `location.pathname`.

I added some extra logic to append the redirectTo's pathname to the quartz path.



<!-- Describe your proposed changes here. -->
<!-- Including screenshots or visuals is very helpful - a picture is worth a thousand words. -->

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
