### PR TITLE
chore: consolidate imports to flux-lsp-browser

### DIFF
--- a/src/flows/pipes/Notification/ExportTask.tsx
+++ b/src/flows/pipes/Notification/ExportTask.tsx
@@ -1,6 +1,9 @@
 import React, {FC, useContext, useCallback} from 'react'
 import {useDispatch} from 'react-redux'
-import {parse, format_from_js_file} from '@influxdata/flux-lsp-browser'
+import {
+  parse,
+  format_from_js_file,
+} from 'src/languageSupport/languages/flux/parser'
 
 // Components
 import ExportTaskButton from 'src/flows/pipes/Schedule/ExportTaskButton'
@@ -94,7 +97,7 @@ ${ENDPOINT_DEFINITIONS[data.endpoint]?.generateImports()}`)
       }, {})
     ).sort((a: ImportDeclaration, b: ImportDeclaration) =>
       b.path.value.toLowerCase().localeCompare(a.path.value.toLowerCase())
-    )
+    ) as ImportDeclaration[]
 
     ast.imports = []
 
@@ -231,7 +234,7 @@ ${ENDPOINT_DEFINITIONS[data.endpoint]?.generateImports()}`)
       }, {})
     ).sort((a: ImportDeclaration, b: ImportDeclaration) =>
       b.path.value.toLowerCase().localeCompare(a.path.value.toLowerCase())
-    )
+    ) as ImportDeclaration[]
 
     ast.imports = []
 

--- a/src/flows/pipes/Notification/view.tsx
+++ b/src/flows/pipes/Notification/view.tsx
@@ -10,7 +10,7 @@ import React, {
   useEffect,
 } from 'react'
 import {useDispatch, useSelector} from 'react-redux'
-import {parse} from '@influxdata/flux-lsp-browser'
+import {parse} from 'src/languageSupport/languages/flux/parser'
 import {
   ComponentStatus,
   Form,

--- a/src/flows/pipes/RawFluxEditor/index.ts
+++ b/src/flows/pipes/RawFluxEditor/index.ts
@@ -1,4 +1,7 @@
-import {parse, format_from_js_file} from '@influxdata/flux-lsp-browser'
+import {
+  parse,
+  format_from_js_file,
+} from 'src/languageSupport/languages/flux/parser'
 import {find} from 'src/shared/contexts/query'
 import View from './view'
 import ReadOnly from './readOnly'

--- a/src/flows/pipes/Schedule/view.tsx
+++ b/src/flows/pipes/Schedule/view.tsx
@@ -10,7 +10,10 @@ import {
   IconFont,
   ComponentSize,
 } from '@influxdata/clockface'
-import {parse, format_from_js_file} from '@influxdata/flux-lsp-browser'
+import {
+  parse,
+  format_from_js_file,
+} from 'src/languageSupport/languages/flux/parser'
 import ExportTaskButton from 'src/flows/pipes/Schedule/ExportTaskButton'
 import {patchTask, TaskUpdateRequest} from 'src/client'
 

--- a/src/flows/pipes/Table/index.ts
+++ b/src/flows/pipes/Table/index.ts
@@ -1,5 +1,8 @@
 import View from './view'
-import {parse, format_from_js_file} from '@influxdata/flux-lsp-browser'
+import {
+  parse,
+  format_from_js_file,
+} from 'src/languageSupport/languages/flux/parser'
 import {parseQuery} from 'src/shared/contexts/query'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 

--- a/src/flows/pipes/Visualization/index.ts
+++ b/src/flows/pipes/Visualization/index.ts
@@ -1,6 +1,6 @@
 import View from './view'
 import './style.scss'
-import {parse} from '@influxdata/flux-lsp-browser'
+import {parse} from 'src/languageSupport/languages/flux/parser'
 import {parseQuery} from 'src/shared/contexts/query'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 

--- a/src/flows/templates/types/task.ts
+++ b/src/flows/templates/types/task.ts
@@ -1,6 +1,9 @@
 import {DEFAULT_TIME_RANGE} from 'src/shared/constants/timeRanges'
 import {AUTOREFRESH_DEFAULT} from 'src/shared/constants'
-import {parse, format_from_js_file} from '@influxdata/flux-lsp-browser'
+import {
+  parse,
+  format_from_js_file,
+} from 'src/languageSupport/languages/flux/parser'
 import {remove} from 'src/shared/contexts/query'
 
 export default register =>

--- a/src/languageSupport/languages/flux/lsp/connection.ts
+++ b/src/languageSupport/languages/flux/lsp/connection.ts
@@ -1,6 +1,6 @@
 import isEqual from 'lodash/isEqual'
 import * as MonacoTypes from 'monaco-editor/esm/vs/editor/editor.api'
-import {format_from_js_file} from '@influxdata/flux-lsp-browser'
+import {format_from_js_file} from 'src/languageSupport/languages/flux/parser'
 
 // handling variables
 import {EditorType, Variable} from 'src/types'

--- a/src/languageSupport/languages/flux/parser/index.ts
+++ b/src/languageSupport/languages/flux/parser/index.ts
@@ -8,7 +8,7 @@ import {
         a node environment (this is only for handling tests). If a test requires a specific AST result
         then you will need to mock that out in the test.
 */
-export const parse = (script): File => {
+export const parse = (script: string): File => {
   if (window) {
     return flux_parse(script)
   } else {
@@ -27,10 +27,10 @@ export const parse = (script): File => {
   }
 }
 
-export const format_from_js_file = (script): string => {
+export const format_from_js_file = (script: File): string => {
   if (window) {
     return flux_format_from_js_file(script)
   } else {
-    return script
+    return ''
   }
 }

--- a/src/shared/contexts/query/preprocessing.ts
+++ b/src/shared/contexts/query/preprocessing.ts
@@ -1,4 +1,7 @@
-import {parse, format_from_js_file} from '@influxdata/flux-lsp-browser'
+import {
+  parse,
+  format_from_js_file,
+} from 'src/languageSupport/languages/flux/parser'
 
 import {propertyTime} from 'src/shared/utils/getMinDurationFromAST'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'

--- a/src/writeData/components/ClientCodeQueryHelper.tsx
+++ b/src/writeData/components/ClientCodeQueryHelper.tsx
@@ -1,9 +1,11 @@
 // Libraries
 import {FC, useEffect, useContext} from 'react'
-import {format_from_js_file} from '@influxdata/flux-lsp-browser'
 
 // Utils
-import {parse} from 'src/languageSupport/languages/flux/parser'
+import {
+  parse,
+  format_from_js_file,
+} from 'src/languageSupport/languages/flux/parser'
 import {find} from 'src/shared/contexts/query'
 import {WriteDataDetailsContext} from 'src/writeData/components/WriteDataDetailsContext'
 


### PR DESCRIPTION
There is currently a shim for both `parse` and `format_from_js_file` for
using those functions in a node environment. However, not all call to
`parse` or `format_from_js_file` use that shim. This patch fixes that.

_Why is this needed?_, you may ask yourself. Well, it's not, but it certainlys
 makes it easier toidentify places that need to be ported over to the
(in progress) async versions of both of those functions. We'll know we
got all the places it's used when we can delete `parse` and
`format_from_js_file` and nothing breaks.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable