### PR TITLE
chore: update typescript to 4.0.2

### DIFF
--- a/jestSetup.ts
+++ b/jestSetup.ts
@@ -57,7 +57,7 @@ class Worker {
   }
 }
 
-window.Worker = Worker
+window.Worker = Worker as any
 
 // cleans up state between @testing-library/react tests
 afterEach(() => {

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "ts-loader": "^5.3.3",
     "ts-node": "^10.9.1",
     "tslib": "^2.4.0",
-    "typescript": "3.8.3",
+    "typescript": "4.0.2",
     "webpack": "^4.46.0",
     "webpack-bundle-analyzer": "^4.6.1",
     "webpack-cli": "^4.10.0",

--- a/src/checks/components/CheckHistory.tsx
+++ b/src/checks/components/CheckHistory.tsx
@@ -35,7 +35,7 @@ const CheckHistory: FC = () => {
     ruleIDs: null,
   }))
   const org = useSelector(getOrg)
-  const {checkID} = useParams()
+  const {checkID} = useParams<{checkID: string}>()
   const loadRows = useMemo(
     () => options => loadStatuses(org.id, options),
     [org.id]

--- a/src/checks/reducers/checks.test.ts
+++ b/src/checks/reducers/checks.test.ts
@@ -154,7 +154,7 @@ describe('checksReducer', () => {
       const id = CHECK_FIXTURE_1.id
 
       initialState.byID[id] = {
-        ...(CHECK_FIXTURE_1 as Check),
+        ...(CHECK_FIXTURE_1 as unknown as Check),
         status: RemoteDataState.Done,
         activeStatus: 'active',
       }

--- a/src/notifications/endpoints/components/EndpointOptions.tsx
+++ b/src/notifications/endpoints/components/EndpointOptions.tsx
@@ -29,11 +29,12 @@ const EndpointOptions: FC<Props> = ({
 }) => {
   switch (endpoint.type) {
     case 'slack': {
-      const {url} = endpoint as SlackNotificationEndpoint
+      const {url} = endpoint as unknown as SlackNotificationEndpoint
       return <EndpointOptionsSlack url={url} onChange={onChange} />
     }
     case 'pagerduty': {
-      const {clientURL, routingKey} = endpoint as PagerDutyNotificationEndpoint
+      const {clientURL, routingKey} =
+        endpoint as unknown as PagerDutyNotificationEndpoint
       return (
         <EndpointOptionsPagerDuty
           clientURL={clientURL}
@@ -43,7 +44,8 @@ const EndpointOptions: FC<Props> = ({
       )
     }
     case 'telegram': {
-      const {token, channel} = endpoint as TelegramNotificationEndpoint
+      const {token, channel} =
+        endpoint as unknown as TelegramNotificationEndpoint
       return (
         <EndpointOptionsTelegram
           token={token}
@@ -61,7 +63,7 @@ const EndpointOptions: FC<Props> = ({
         method,
         authMethod,
         contentTemplate,
-      } = endpoint as HTTPNotificationEndpoint
+      } = endpoint as unknown as HTTPNotificationEndpoint
       return (
         <EndpointOptionsHTTP
           onChange={onChange}

--- a/src/notifications/endpoints/components/EndpointOverlay.reducer.ts
+++ b/src/notifications/endpoints/components/EndpointOverlay.reducer.ts
@@ -1,7 +1,5 @@
-import {omit} from 'lodash'
-
 // Types
-import {NotificationEndpoint, NotificationEndpointBase} from 'src/types'
+import {NotificationEndpoint} from 'src/types'
 import {DEFAULT_ENDPOINT_URLS} from 'src/alerting/constants'
 
 export type Action =
@@ -23,18 +21,39 @@ export const reducer = (
     case 'UPDATE_ENDPOINT_TYPE': {
       const {endpoint} = action
       if (state.type != endpoint.type) {
-        const baseProps: NotificationEndpointBase = omit(endpoint, [
-          'url',
-          'token',
-          'username',
-          'password',
-          'method',
-          'authMethod',
-          'contentTemplate',
-          'headers',
-          'clientURL',
-          'routingKey',
-        ]) as NotificationEndpoint
+        const baseProps: any = {
+          ...endpoint,
+        }
+        if (baseProps?.url) {
+          delete baseProps.url
+        }
+        if (baseProps?.token) {
+          delete baseProps.token
+        }
+        if (baseProps?.username) {
+          delete baseProps.username
+        }
+        if (baseProps?.password) {
+          delete baseProps.password
+        }
+        if (baseProps?.method) {
+          delete baseProps.method
+        }
+        if (baseProps?.authMethod) {
+          delete baseProps.authMethod
+        }
+        if (baseProps?.contentTemplate) {
+          delete baseProps.contentTemplate
+        }
+        if (baseProps?.headers) {
+          delete baseProps.headers
+        }
+        if (baseProps?.clientURL) {
+          delete baseProps.clientURL
+        }
+        if (baseProps?.routingKey) {
+          delete baseProps.routingKey
+        }
 
         switch (endpoint.type) {
           case 'pagerduty':

--- a/src/types/alerting.ts
+++ b/src/types/alerting.ts
@@ -62,7 +62,7 @@ type RuleOverrides = {status: RemoteDataState; activeStatus: TaskStatusType}
 
 // GenRule is the shape of a NotificationRule from the server -- before any UI specific fields are added or modified
 export type GenRule = GRule
-export type NotificationRule = GenRule & RuleOverrides
+export type NotificationRule = Omit<GenRule, 'status'> & RuleOverrides
 
 export type StatusRuleDraft = WithClientID<StatusRule>
 

--- a/src/writeData/containers/ClientLibrariesPage.tsx
+++ b/src/writeData/containers/ClientLibrariesPage.tsx
@@ -66,7 +66,7 @@ export const CodeSampleBlock: FC<SampleProps> = ({name, sample, onCopy}) => {
 }
 
 const ClientLibrariesPage: FC = () => {
-  const {contentID} = useParams()
+  const {contentID} = useParams<{contentID: string}>()
   const def = CLIENT_DEFINITIONS[contentID]
 
   const thumbnail = (

--- a/webpack.dev.ts
+++ b/webpack.dev.ts
@@ -1,21 +1,20 @@
-export {}
-const path = require('path')
-const merge = require('webpack-merge')
-const common = require('./webpack.common.ts')
+const pathDev = require('path')
+const mergeDev = require('webpack-merge')
+const commonDev = require('./webpack.common.ts')
 const PORT = parseInt(process.env.PORT, 10) || 8080
 const PUBLIC = process.env.PUBLIC || undefined
-const {BASE_PATH} = require('./src/utils/env')
-const BundleAnalyzerPlugin = require('webpack-bundle-analyzer')
-  .BundleAnalyzerPlugin
+const BASE_PATH_DEV = require('./src/utils/env').BASE_PATH
+const BundleAnalyzerPlugin =
+  require('webpack-bundle-analyzer').BundleAnalyzerPlugin
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
 
-const webpack = require('webpack')
+const webpackDev = require('webpack')
 
-module.exports = merge(common, {
+module.exports = mergeDev(commonDev, {
   mode: 'development',
   devtool: 'cheap-inline-source-map',
   output: {
-    path: path.join(__dirname, 'build'),
+    path: pathDev.join(__dirname, 'build'),
     filename: '[name].js',
   },
   watchOptions: {
@@ -39,7 +38,7 @@ module.exports = merge(common, {
     },
     webSocketServer: {
       options: {
-        path: `${BASE_PATH}hmr`,
+        path: `${BASE_PATH_DEV}hmr`,
       },
     },
     client: {
@@ -50,7 +49,7 @@ module.exports = merge(common, {
       },
       webSocketURL: {
         hostname: '0.0.0.0',
-        pathname: `${BASE_PATH}hmr`,
+        pathname: `${BASE_PATH_DEV}hmr`,
         port: 443,
       },
     },
@@ -62,8 +61,8 @@ module.exports = merge(common, {
         devServer: false, // don't block UI compilation on TS errors
       },
     }),
-    new webpack.DllReferencePlugin({
-      context: path.join(__dirname, 'build'),
+    new webpackDev.DllReferencePlugin({
+      context: pathDev.join(__dirname, 'build'),
       manifest: require('./build/vendor-manifest.json'),
     }),
     new BundleAnalyzerPlugin({

--- a/webpack.fast.ts
+++ b/webpack.fast.ts
@@ -1,14 +1,11 @@
-export {}
-
 // utils
 const common = require('./webpack.common.ts')
 const merge = require('webpack-merge')
-
-const {STATIC_DIRECTORY} = require('./src/utils/env')
+const STATIC_DIR = require('./src/utils/env').STATIC_DIRECTORY
 
 module.exports = merge(common, {
   mode: 'none',
   output: {
-    filename: `${STATIC_DIRECTORY}[contenthash:10].js`,
+    filename: `${STATIC_DIR}[contenthash:10].js`,
   },
 })

--- a/webpack.lighthouse.ts
+++ b/webpack.lighthouse.ts
@@ -1,21 +1,19 @@
-export {}
-
 // utils
-const common = require('./webpack.common.ts')
-const merge = require('webpack-merge')
-const path = require('path')
+const commonWebpack = require('./webpack.common.ts')
+const mergeWebpack = require('webpack-merge')
+const commonPath = require('path')
 
 // Plugins
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin')
 const TerserJSPlugin = require('terser-webpack-plugin')
 
-const {STATIC_DIRECTORY} = require('./src/utils/env')
+const DIRECTORY_STATIC = require('./src/utils/env').STATIC_DIRECTORY
 
-module.exports = merge(common, {
+module.exports = mergeWebpack(commonWebpack, {
   mode: 'production',
   devtool: 'source-map',
   output: {
-    filename: `${STATIC_DIRECTORY}[contenthash:10].js`,
+    filename: `${DIRECTORY_STATIC}[contenthash:10].js`,
   },
   module: {
     rules: [
@@ -24,8 +22,8 @@ module.exports = merge(common, {
         enforce: 'pre', // this forces this rule to run first.
         use: ['source-map-loader'],
         include: [
-          path.resolve(__dirname, 'node_modules/@influxdata/giraffe'),
-          path.resolve(__dirname, 'node_modules/@influxdata/clockface'),
+          commonPath.resolve(__dirname, 'node_modules/@influxdata/giraffe'),
+          commonPath.resolve(__dirname, 'node_modules/@influxdata/clockface'),
         ],
       },
     ],

--- a/webpack.prod.ts
+++ b/webpack.prod.ts
@@ -1,22 +1,20 @@
-export {}
-
 // utils
-const common = require('./webpack.common.ts')
-const merge = require('webpack-merge')
-const path = require('path')
+const commonWebpack = require('./webpack.common.ts')
+const mergeWebpack = require('webpack-merge')
+const commonPath = require('path')
 
 // Plugins
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin')
 const TerserJSPlugin = require('terser-webpack-plugin')
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
 
-const {STATIC_DIRECTORY} = require('./src/utils/env')
+const DIRECTORY_STATIC = require('./src/utils/env').STATIC_DIRECTORY
 
-module.exports = merge(common, {
+module.exports = mergeWebpack(commonWebpack, {
   mode: 'production',
   devtool: 'source-map',
   output: {
-    filename: `${STATIC_DIRECTORY}[contenthash:10].js`,
+    filename: `${DIRECTORY_STATIC}[contenthash:10].js`,
   },
   module: {
     rules: [
@@ -25,8 +23,8 @@ module.exports = merge(common, {
         enforce: 'pre', // this forces this rule to run first.
         use: ['source-map-loader'],
         include: [
-          path.resolve(__dirname, 'node_modules/@influxdata/giraffe'),
-          path.resolve(__dirname, 'node_modules/@influxdata/clockface'),
+          commonPath.resolve(__dirname, 'node_modules/@influxdata/giraffe'),
+          commonPath.resolve(__dirname, 'node_modules/@influxdata/clockface'),
         ],
       },
     ],

--- a/webpack.vendor.ts
+++ b/webpack.vendor.ts
@@ -1,9 +1,8 @@
-export {}
-const webpack = require('webpack')
-const path = require('path')
+const webpackVendor = require('webpack')
+const pathVendor = require('path')
 const {dependencies} = require('./package.json')
-const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin')
-const {STATIC_DIRECTORY} = require('./src/utils/env')
+const MonacoWebpackPluginVendor = require('monaco-editor-webpack-plugin')
+const STATIC_DIRECTORY_VENDOR = require('./src/utils/env').STATIC_DIRECTORY
 
 // only dll infrequently updated dependencies
 const vendor = Object.keys(dependencies).filter(
@@ -13,7 +12,10 @@ const vendor = Object.keys(dependencies).filter(
     !d.includes('monaco-editor-webpack-plugin')
 )
 
-const MONACO_DIR = path.resolve(__dirname, './node_modules/monaco-editor')
+const MONACO_DIR_VENDOR = pathVendor.resolve(
+  __dirname,
+  './node_modules/monaco-editor'
+)
 
 module.exports = {
   context: __dirname,
@@ -23,7 +25,7 @@ module.exports = {
   },
   resolve: {
     alias: {
-      vscode: path.resolve(
+      vscode: pathVendor.resolve(
         './node_modules/monaco-languageclient/lib/vscode-compatibility'
       ),
     },
@@ -40,7 +42,7 @@ module.exports = {
     setImmediate: true,
   },
   output: {
-    path: path.join(__dirname, 'build'),
+    path: pathVendor.join(__dirname, 'build'),
     filename: '[name].bundle.js',
     library: '[name]',
   },
@@ -48,12 +50,12 @@ module.exports = {
     rules: [
       {
         test: /\.css$/,
-        include: MONACO_DIR,
+        include: MONACO_DIR_VENDOR,
         use: ['style-loader', 'css-loader'],
       },
       {
         test: /\.m?js$/,
-        include: MONACO_DIR,
+        include: MONACO_DIR_VENDOR,
         use: {
           loader: 'babel-loader',
           options: {
@@ -73,13 +75,13 @@ module.exports = {
     ],
   },
   plugins: [
-    new webpack.DllPlugin({
+    new webpackVendor.DllPlugin({
       name: '[name]',
-      path: path.join(__dirname, 'build', '[name]-manifest.json'),
+      path: pathVendor.join(__dirname, 'build', '[name]-manifest.json'),
     }),
-    new MonacoWebpackPlugin({
+    new MonacoWebpackPluginVendor({
       languages: ['json', 'markdown'],
-      filename: `${STATIC_DIRECTORY}[name].worker.[contenthash].js`,
+      filename: `${STATIC_DIRECTORY_VENDOR}[name].worker.[contenthash].js`,
       globalAPI: true,
     }),
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -12088,10 +12088,10 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
+  integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
 
 uglify-js@3.4.x:
   version "3.4.10"


### PR DESCRIPTION
This PR is related to some ongoing work to update our dependencies. The initiative behind this change was prompted by some TS issues that arose with some updates to transition our LSP work to WebWorkers. That work has been staled in our pipeline due to TS mismatches between the dependency being introduced and the TS dependency we're currently pinned to. For context, those changes can be found [here](https://github.com/influxdata/ui/pull/6253).

### Reviewer Note

This is a POC to see if bumping TS to 4.X resolves the TS issues we're seeing in the pipeline here:

#6253

### Process

The jump from 3.8.3 -> 3.9.2 resulted in a few TS errors surrounding implicit `never` types that were being assigned to merged / overriding types. Since our TS types are generated with generic `type: string` associations, the TS compiler can't differentiate between certain generic endpoint / alerting types and was causing TS errors. The solution here was to override the default to `any` prior to assigning the specific `type`. While I'm typically against typecasting in general, the lift required here seems too heavy to massage given that the parts of the app these TS issues were originating from haven't changed in a while and likely won't be touched for some time. 

The jump from 3.9.2 -> 4.0.2 resulted in the explicit type declaration for the `useParams` usage in `CheckHistory.tsx` and `ClientLibraryPages.tsx` 