### PR TITLE
fix(6240): have Sidebar container always render

### DIFF
--- a/src/dataExplorer/components/FluxQueryBuilder.tsx
+++ b/src/dataExplorer/components/FluxQueryBuilder.tsx
@@ -220,10 +220,7 @@ const FluxQueryBuilder: FC = () => {
               <ResultsPane />
             </DraggableResizer.Panel>
             <DraggableResizer.Panel isCollapsible={true}>
-              {isFlagEnabled('uiSqlSupport') &&
-              resource?.language === LanguageType.SQL ? null : (
-                <Sidebar />
-              )}
+              <Sidebar />
             </DraggableResizer.Panel>
           </DraggableResizer>
         </FlexBox>

--- a/src/dataExplorer/components/Sidebar.tsx
+++ b/src/dataExplorer/components/Sidebar.tsx
@@ -16,9 +16,11 @@ import {
 // Contexts
 import {SidebarContext} from 'src/dataExplorer/context/sidebar'
 import {EditorContext} from 'src/shared/contexts/editor'
+import {PersistanceContext} from 'src/dataExplorer/context/persistance'
 
 // Types
 import {FluxFunction, FluxToolbarFunction} from 'src/types'
+import {LanguageType} from 'src/dataExplorer/components/resources'
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'
@@ -33,6 +35,7 @@ functions, and variables which may be useful when constructing your flux query.`
 const Sidebar: FC = () => {
   const {injectFunction} = useContext(EditorContext)
   const {visible, menu, clear} = useContext(SidebarContext)
+  const {resource} = useContext(PersistanceContext)
 
   const inject = useCallback(
     (fn: FluxFunction | FluxToolbarFunction) => {
@@ -114,8 +117,13 @@ const Sidebar: FC = () => {
       justifyContent={JustifyContent.FlexStart}
       className="container-right-side-bar"
     >
-      {resultOptions}
-      {fluxLibrary}
+      {isFlagEnabled('uiSqlSupport') &&
+      resource?.language === LanguageType.SQL ? null : (
+        <>
+          {resultOptions}
+          {fluxLibrary}
+        </>
+      )}
     </FlexBox>
   )
 }


### PR DESCRIPTION
Closes influxdata/ui#6240 

Sidebar container is used for other launched menus (such as graph customize). Have the sidebar container always exist, and only remove flux-specific sidebar menus when in SQL mode.


https://user-images.githubusercontent.com/10232835/200433616-3fbdd867-ace2-4627-a040-c0c933c12492.mov



### Checklist
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] ~Feature flagged, if applicable~ already done.
