### PR TITLE
feat(6117): add search to groupby in result options

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
   "dependencies": {
     "@codingame/monaco-jsonrpc": "^0.3.1",
     "@docsearch/react": "^3.0.0-alpha.37",
-    "@influxdata/clockface": "^6.3.8",
+    "@influxdata/clockface": "^6.3.9",
     "@influxdata/flux-lsp-browser": "0.8.36",
     "@influxdata/giraffe": "^2.38.1",
     "@influxdata/influxdb-templates": "0.9.0",

--- a/src/dataExplorer/components/GroupBy.tsx
+++ b/src/dataExplorer/components/GroupBy.tsx
@@ -116,6 +116,8 @@ const GroupBy: FC = () => {
           selectedOptions={
             !selection.bucket || !selection.measurement ? [] : selectedGroupKeys
           }
+          isSearchable={true}
+          searchbarInputPlaceholder="Search the group keys"
           onSelect={handleSelectGroupKey}
           emptyText="Select group column values"
           buttonStatus={toComponentStatus(loading)}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1436,10 +1436,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@influxdata/clockface@^6.3.8":
-  version "6.3.8"
-  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-6.3.8.tgz#34d690a5b82a4b024376229dfbe1c2c52353db5b"
-  integrity sha512-Ie9mJQKaYymB0OW62b7O9Uzg5pKDPAwusJOaagFp6q2KboXZieEUQydkExGP/39FXyyaqpQBSoUBPm5xyF9Low==
+"@influxdata/clockface@^6.3.9":
+  version "6.3.9"
+  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-6.3.9.tgz#8a2046fc7457e40d50b8a16af8b9eadd4480198d"
+  integrity sha512-n5gZiCBXGPXDHbxwqCQ5VYvaqG5WnsOJscTPxG7p9dgf/erUFOMD4+aHH+qZMU/a9QVsJD8hMX7eUqTRkYhVTQ==
   dependencies:
     "@types/react-window" "^1.8.5"
     react-window "^1.8.7"


### PR DESCRIPTION
Closes #6117 

Clockface component was updated to have the searchable dropdown options.
Now can use this feature in the groupby keys, for ResultOptions.


https://user-images.githubusercontent.com/10232835/200436452-5b0c3a3f-0132-44d5-a1c2-d963570c7abc.mov



### Checklist
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] ~Feature flagged, if applicable~ use the `resultOptions` feature flag.
