### PR TITLE
perf: reduce jank in graph options sliders

### DIFF
--- a/src/visualization/components/internal/HoverLegend.tsx
+++ b/src/visualization/components/internal/HoverLegend.tsx
@@ -1,8 +1,5 @@
 // Libraries
-import React, {ChangeEvent, FC, useState} from 'react'
-
-// Utils
-import {convertUserInputToNumOrNaN} from 'src/shared/utils/convertUserInput'
+import React, {FC, useState} from 'react'
 
 // Components
 import {
@@ -85,7 +82,7 @@ const HoverLegendToggle: FC<HoverLegendToggleProps> = ({
   const {
     handleSetHoverLegendHide,
     handleSetOrientation,
-    handleSetOpacity,
+    setOpacity,
     handleSetColorization,
   } = handlers
 
@@ -145,7 +142,7 @@ const HoverLegendToggle: FC<HoverLegendToggleProps> = ({
               />
               <OpacitySlider
                 legendOpacity={legendOpacity}
-                handleSetOpacity={handleSetOpacity}
+                setOpacity={setOpacity}
                 testID="hover-legend-opacity-slider"
               />
               <ColorizeRowsToggle
@@ -199,10 +196,8 @@ const HoverLegend: FC<HoverLegendProps> = ({properties, update}) => {
     // which is less intricate than Giraffe's
   }
 
-  const handleSetOpacity = (e: ChangeEvent<HTMLInputElement>): void => {
-    const value = convertUserInputToNumOrNaN(e)
-
-    if (isNaN(value) || value < LEGEND_OPACITY_MINIMUM) {
+  const setOpacity = (opacity: number): void => {
+    if (isNaN(opacity) || opacity < LEGEND_OPACITY_MINIMUM) {
       update({
         legendOpacity: LEGEND_OPACITY_MAXIMUM,
       })
@@ -212,11 +207,11 @@ const HoverLegend: FC<HoverLegendProps> = ({properties, update}) => {
       })
     } else {
       update({
-        legendOpacity: value,
+        legendOpacity: opacity,
       })
       event(`${eventPrefix}.opacity`, {
         type: properties.type,
-        opacity: value,
+        opacity,
       })
     }
   }
@@ -238,7 +233,7 @@ const HoverLegend: FC<HoverLegendProps> = ({properties, update}) => {
       handlers={{
         handleSetHoverLegendHide,
         handleSetOrientation,
-        handleSetOpacity,
+        setOpacity,
         handleSetColorization,
       }}
     />
@@ -254,7 +249,7 @@ const HoverLegend: FC<HoverLegendProps> = ({properties, update}) => {
       />
       <OpacitySlider
         legendOpacity={legendOpacity}
-        handleSetOpacity={handleSetOpacity}
+        setOpacity={setOpacity}
         testID="hover-legend-opacity-slider"
       />
       <ColorizeRowsToggle

--- a/src/visualization/components/internal/LegendOptions.tsx
+++ b/src/visualization/components/internal/LegendOptions.tsx
@@ -134,7 +134,7 @@ export const OrientationToggle: FC<OrientationToggleProps> = ({
   )
 }
 
-export const OpacitySlider: FC<OpacitySliderProps> = (props) => {
+export const OpacitySlider: FC<OpacitySliderProps> = props => {
   let validOpacity = LEGEND_OPACITY_DEFAULT
   if (
     typeof props.legendOpacity === 'number' &&

--- a/src/visualization/components/internal/LegendOptions.tsx
+++ b/src/visualization/components/internal/LegendOptions.tsx
@@ -1,5 +1,6 @@
 // Libraries
-import React, {ChangeEvent, FC} from 'react'
+import React, {FC, useCallback, useState} from 'react'
+import {debounce} from 'lodash'
 
 // Components
 import {
@@ -33,6 +34,9 @@ import {event} from 'src/cloud/utils/reporting'
 // Styles
 import 'src/visualization/components/internal/LegendOptions.scss'
 
+// Utils
+import {convertUserInputToNumOrNaN} from 'src/shared/utils/convertUserInput'
+
 interface OrientationToggleProps {
   eventName: string
   graphType: string
@@ -44,7 +48,7 @@ interface OrientationToggleProps {
 
 interface OpacitySliderProps {
   legendOpacity: number
-  handleSetOpacity: (event: ChangeEvent<HTMLInputElement>) => void
+  setOpacity: (value: number) => void
   testID?: string
 }
 
@@ -130,34 +134,37 @@ export const OrientationToggle: FC<OrientationToggleProps> = ({
   )
 }
 
-export const OpacitySlider: FC<OpacitySliderProps> = ({
-  legendOpacity,
-  handleSetOpacity,
-  testID = 'opacity-slider',
-}) => {
+export const OpacitySlider: FC<OpacitySliderProps> = (props) => {
   let validOpacity = LEGEND_OPACITY_DEFAULT
   if (
-    typeof legendOpacity === 'number' &&
-    legendOpacity === legendOpacity &&
-    legendOpacity >= LEGEND_OPACITY_MINIMUM &&
-    legendOpacity <= LEGEND_OPACITY_MAXIMUM
+    typeof props.legendOpacity === 'number' &&
+    props.legendOpacity === props.legendOpacity &&
+    props.legendOpacity >= LEGEND_OPACITY_MINIMUM &&
+    props.legendOpacity <= LEGEND_OPACITY_MAXIMUM
   ) {
-    validOpacity = legendOpacity
+    validOpacity = props.legendOpacity
   }
-  const percentLegendOpacity = (validOpacity * 100).toFixed(0)
+  const [opacity, setOpacity] = useState(validOpacity)
+  const setOpacityDebounced = useCallback(debounce(props.setOpacity, 350), [])
+
+  const percentLegendOpacity = (opacity * 100).toFixed(0)
 
   return (
     <Form.Element
       className="legend-opacity-slider"
       label={`Opacity: ${percentLegendOpacity}%`}
-      testID={testID}
+      testID={props.testID}
     >
       <RangeSlider
         max={LEGEND_OPACITY_MAXIMUM}
         min={LEGEND_OPACITY_MINIMUM}
         step={LEGEND_OPACITY_STEP}
-        value={validOpacity}
-        onChange={handleSetOpacity}
+        value={opacity}
+        onChange={evt => {
+          const value = convertUserInputToNumOrNaN(evt)
+          setOpacity(value)
+          setOpacityDebounced(value)
+        }}
         hideLabels={true}
       />
     </Form.Element>

--- a/src/visualization/types/Graph/options.tsx
+++ b/src/visualization/types/Graph/options.tsx
@@ -1,5 +1,6 @@
 // Libraries
-import React, {FC, useMemo} from 'react'
+import React, {FC, useCallback, useMemo, useState} from 'react'
+import {debounce} from 'lodash'
 import {
   ButtonShape,
   Columns,
@@ -49,6 +50,15 @@ interface Props extends VisualizationOptionProps {
 }
 
 export const GraphOptions: FC<Props> = ({properties, results, update}) => {
+  const [yAxisLabel, setYAxisLabel] = useState(properties.axes.y.label)
+  const [yAxisPrefix, setYAxisPrefix] = useState(properties.axes.y.prefix)
+  const [yAxisSuffix, setYAxisSuffix] = useState(properties.axes.y.suffix)
+
+  const groupKey = useMemo(
+    () => [...results.fluxGroupKeyUnion, 'result'],
+    [results]
+  )
+
   const numericColumns = (results?.table?.columnKeys || []).filter(key => {
     if (key === 'result' || key === 'table') {
       return false
@@ -58,11 +68,6 @@ export const GraphOptions: FC<Props> = ({properties, results, update}) => {
 
     return columnType === 'time' || columnType === 'number'
   })
-
-  const groupKey = useMemo(
-    () => [...results.fluxGroupKeyUnion, 'result'],
-    [results]
-  )
 
   const xColumn = defaultXColumn(results?.table, properties.xColumn)
   const yColumn = defaultYColumn(results?.table, properties.yColumn)
@@ -93,6 +98,8 @@ export const GraphOptions: FC<Props> = ({properties, results, update}) => {
       },
     })
   }
+
+  const updateAxisDebounced = useCallback(debounce(updateAxis, 200), [properties])
 
   const handleSetYDomain = (yDomain: [number, number]): void => {
     let bounds: [string | null, string | null]
@@ -339,9 +346,15 @@ export const GraphOptions: FC<Props> = ({properties, results, update}) => {
           <h5 className="view-options--header">Y-Axis</h5>
           <Form.Element label="Y Axis Label">
             <Input
-              value={properties.axes.y.label}
-              onChange={evt => {
-                updateAxis('y', {label: evt.target.value})
+              value={yAxisLabel}
+              onKeyPress={event => {
+                if (event.code === 'Enter') {
+                  updateAxis('y', {label: yAxisLabel})
+                }
+              }}
+              onChange={event => {
+                setYAxisLabel(event.target.value)
+                updateAxisDebounced('y', {label: event.target.value})
               }}
             />
           </Form.Element>
@@ -389,9 +402,15 @@ export const GraphOptions: FC<Props> = ({properties, results, update}) => {
             <Grid.Column widthXS={Columns.Six}>
               <Form.Element label="Y Axis Prefix">
                 <Input
-                  value={properties.axes.y.prefix}
-                  onChange={evt => {
-                    updateAxis('y', {prefix: evt.target.value})
+                  value={yAxisPrefix}
+                  onKeyPress={event => {
+                    if (event.code === 'Enter') {
+                      updateAxis('y', {prefix: yAxisPrefix})
+                    }
+                  }}
+                  onChange={event => {
+                    setYAxisPrefix(event.target.value)
+                    updateAxisDebounced('y', {prefix: event.target.value})
                   }}
                 />
               </Form.Element>
@@ -399,9 +418,15 @@ export const GraphOptions: FC<Props> = ({properties, results, update}) => {
             <Grid.Column widthXS={Columns.Six}>
               <Form.Element label="Y Axis Suffix">
                 <Input
-                  value={properties.axes.y.suffix}
-                  onChange={evt => {
-                    updateAxis('y', {suffix: evt.target.value})
+                  value={yAxisSuffix}
+                  onKeyPress={event => {
+                    if (event.code === 'Enter') {
+                      updateAxis('y', {suffix: yAxisSuffix})
+                    }
+                  }}
+                  onChange={event => {
+                    setYAxisSuffix(event.target.value)
+                    updateAxisDebounced('y', {suffix: event.target.value})
                   }}
                 />
               </Form.Element>

--- a/src/visualization/types/Graph/options.tsx
+++ b/src/visualization/types/Graph/options.tsx
@@ -99,7 +99,9 @@ export const GraphOptions: FC<Props> = ({properties, results, update}) => {
     })
   }
 
-  const updateAxisDebounced = useCallback(debounce(updateAxis, 200), [properties])
+  const updateAxisDebounced = useCallback(debounce(updateAxis, 200), [
+    properties,
+  ])
 
   const handleSetYDomain = (yDomain: [number, number]): void => {
     let bounds: [string | null, string | null]


### PR DESCRIPTION
Closes #6283

### The problem
Jankiness was caused by updating the redux store every time an input in the options panel changed. In text boxes: every keystroke. In sliders: every time the slider was moved. We'd dispatch an action, which would update the redux store, which would cause re-renders which would make the UI appear sluggish.

https://user-images.githubusercontent.com/146112/200597573-90d80871-86c2-4f90-94e5-f7dea7621421.mov


### The fix
Store these changes in local component state, then debounce the call to update redux state so that the visualization will be updated after the input stops.


https://user-images.githubusercontent.com/146112/200598326-7e465d5e-b387-4cde-9f07-c418a017c614.mov

### Tested in:

- [x] Existing dashboard cell
- [x] New dashboard cell
- [x] Data explorer Classic™
- [x] New notebook
- [x] Existing notebook
- [x] New query builder experience

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
