### PR TITLE
chore: remove `newQueryBuilder` in new script editor

### DIFF
--- a/src/dataExplorer/components/Schema.tsx
+++ b/src/dataExplorer/components/Schema.tsx
@@ -73,7 +73,7 @@ const Schema: FC = () => {
       <FieldsProvider scope={scope}>
         <TagsProvider scope={scope}>
           <FluxQueryBuilderProvider>
-            <BucketProvider scope={scope} omitSampleData>
+            <BucketProvider scope={scope}>
               <div className="scroll--container">
                 <DapperScrollbars>
                   <div className="schema-browser" data-testid="schema-browser">

--- a/src/dataExplorer/components/Schema.tsx
+++ b/src/dataExplorer/components/Schema.tsx
@@ -73,7 +73,7 @@ const Schema: FC = () => {
       <FieldsProvider scope={scope}>
         <TagsProvider scope={scope}>
           <FluxQueryBuilderProvider>
-            <BucketProvider scope={scope}>
+            <BucketProvider scope={scope} omitSampleData>
               <div className="scroll--container">
                 <DapperScrollbars>
                   <div className="schema-browser" data-testid="schema-browser">

--- a/src/dataExplorer/context/fields.tsx
+++ b/src/dataExplorer/context/fields.tsx
@@ -18,7 +18,6 @@ import {
   IMPORT_STRINGS,
   IMPORT_INFLUX_SCHEMA,
   SAMPLE_DATA_SET,
-  FROM_BUCKET,
   SEARCH_STRING,
 } from 'src/dataExplorer/shared/utils'
 

--- a/src/dataExplorer/context/fields.tsx
+++ b/src/dataExplorer/context/fields.tsx
@@ -13,7 +13,6 @@ import {DEFAULT_LIMIT} from 'src/shared/constants/queryBuilder'
 import {QueryContext, QueryScope} from 'src/shared/contexts/query'
 
 // Utils
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {
   IMPORT_REGEXP,
   IMPORT_STRINGS,
@@ -93,7 +92,7 @@ export const FieldsProvider: FC<Prop> = ({children, scope}) => {
       |> limit(n: ${DEFAULT_LIMIT})
     `
 
-    if (bucket.type !== 'sample' && isFlagEnabled('newQueryBuilder')) {
+    if (bucket.type !== 'sample') {
       _source = `${IMPORT_REGEXP}${IMPORT_INFLUX_SCHEMA}${IMPORT_STRINGS}`
       queryText = `${_source}
         schema.measurementFieldKeys(

--- a/src/dataExplorer/context/fields.tsx
+++ b/src/dataExplorer/context/fields.tsx
@@ -73,15 +73,10 @@ export const FieldsProvider: FC<Prop> = ({children, scope}) => {
     //   They are fetched dynamically from csv.
     //   Here is the source code for handling sample data:
     //   https://github.com/influxdata/flux/blob/master/stdlib/influxdata/influxdb/sample/sample.flux
-    //   That is why _source and query script for sample data is different
-    let _source = IMPORT_REGEXP
-    if (bucket.type === 'sample') {
-      _source += SAMPLE_DATA_SET(bucket.id)
-    } else {
-      _source += FROM_BUCKET(bucket.name)
-    }
-
-    let queryText = `${_source}
+    //   That is why the source and query script for sample data is different
+    const queryText =
+      bucket.type === 'sample'
+        ? `${IMPORT_REGEXP}${SAMPLE_DATA_SET(bucket.id)}
       |> range(start: -100y, stop: now())
       |> filter(fn: (r) => (r["_measurement"] == "${measurement}"))
       |> keep(columns: ["_field"])
@@ -91,22 +86,18 @@ export const FieldsProvider: FC<Prop> = ({children, scope}) => {
       |> sort()
       |> limit(n: ${DEFAULT_LIMIT})
     `
-
-    if (bucket.type !== 'sample') {
-      _source = `${IMPORT_REGEXP}${IMPORT_INFLUX_SCHEMA}${IMPORT_STRINGS}`
-      queryText = `${_source}
-        schema.measurementFieldKeys(
-          bucket: "${bucket.name}",
-          measurement: "${measurement}",
-          start: ${CACHING_REQUIRED_START_DATE},
-          stop: ${CACHING_REQUIRED_END_DATE},
-        )
-        ${searchTerm ? SEARCH_STRING(searchTerm) : ''}
-        |> map(fn: (r) => ({r with lowercase: strings.toLower(v: r._value)}))
-        |> sort(columns: ["lowercase"])
-        |> limit(n: ${DEFAULT_LIMIT})
-      `
-    }
+        : `${IMPORT_REGEXP}${IMPORT_INFLUX_SCHEMA}${IMPORT_STRINGS}
+      schema.measurementFieldKeys(
+        bucket: "${bucket.name}",
+        measurement: "${measurement}",
+        start: ${CACHING_REQUIRED_START_DATE},
+        stop: ${CACHING_REQUIRED_END_DATE},
+      )
+      ${searchTerm ? SEARCH_STRING(searchTerm) : ''}
+      |> map(fn: (r) => ({r with lowercase: strings.toLower(v: r._value)}))
+      |> sort(columns: ["lowercase"])
+      |> limit(n: ${DEFAULT_LIMIT})
+    `
 
     try {
       const resp = await queryAPI(queryText, scope)

--- a/src/dataExplorer/context/measurements.tsx
+++ b/src/dataExplorer/context/measurements.tsx
@@ -15,7 +15,6 @@ import {QueryContext, QueryScope} from 'src/shared/contexts/query'
 import {Bucket, RemoteDataState} from 'src/types'
 
 // Utils
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {
   IMPORT_STRINGS,
   IMPORT_INFLUX_SCHEMA,
@@ -76,7 +75,7 @@ export const MeasurementsProvider: FC<Prop> = ({children, scope}) => {
       |> limit(n: ${DEFAULT_LIMIT})
     `
 
-    if (bucket.type !== 'sample' && isFlagEnabled('newQueryBuilder')) {
+    if (bucket.type !== 'sample') {
       _source = `${IMPORT_STRINGS}${IMPORT_INFLUX_SCHEMA}`
       queryText = `${_source}
         schema.measurements(

--- a/src/dataExplorer/context/tags.tsx
+++ b/src/dataExplorer/context/tags.tsx
@@ -13,7 +13,6 @@ import {DEFAULT_LIMIT} from 'src/shared/constants/queryBuilder'
 import {QueryContext, QueryScope} from 'src/shared/contexts/query'
 
 // Utils
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {
   IMPORT_REGEXP,
   IMPORT_STRINGS,
@@ -104,7 +103,7 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
       |> limit(n: ${DEFAULT_LIMIT})
     `
 
-    if (bucket.type !== 'sample' && isFlagEnabled('newQueryBuilder')) {
+    if (bucket.type !== 'sample') {
       _source = `${IMPORT_REGEXP}${IMPORT_INFLUX_SCHEMA}${IMPORT_STRINGS}`
       queryText = `${_source}
         schema.measurementTagKeys(
@@ -185,7 +184,7 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
       |> limit(n: ${DEFAULT_LIMIT})
     `
 
-    if (bucket.type !== 'sample' && isFlagEnabled('newQueryBuilder')) {
+    if (bucket.type !== 'sample') {
       _source = `${IMPORT_STRINGS}${IMPORT_INFLUX_SCHEMA}`
       queryText = `${_source}
         schema.measurementTagValues(

--- a/src/dataExplorer/context/tags.tsx
+++ b/src/dataExplorer/context/tags.tsx
@@ -18,7 +18,6 @@ import {
   IMPORT_STRINGS,
   IMPORT_INFLUX_SCHEMA,
   SAMPLE_DATA_SET,
-  FROM_BUCKET,
   SEARCH_STRING,
 } from 'src/dataExplorer/shared/utils'
 
@@ -83,14 +82,9 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
 
     // Simplified version of query from this file:
     //   src/flows/pipes/QueryBuilder/context.tsx
-    let _source = IMPORT_REGEXP
-    if (bucket.type === 'sample') {
-      _source += SAMPLE_DATA_SET(bucket.id)
-    } else {
-      _source += FROM_BUCKET(bucket.name)
-    }
-
-    let queryText = `${_source}
+    const queryText =
+      bucket.type === 'sample'
+        ? `${SAMPLE_DATA_SET(bucket.id)}
       |> range(start: -100y, stop: now())
       |> filter(fn: (r) => true)
       |> keys()
@@ -102,24 +96,20 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
       |> sort()
       |> limit(n: ${DEFAULT_LIMIT})
     `
-
-    if (bucket.type !== 'sample') {
-      _source = `${IMPORT_REGEXP}${IMPORT_INFLUX_SCHEMA}${IMPORT_STRINGS}`
-      queryText = `${_source}
-        schema.measurementTagKeys(
-          bucket: "${bucket.name}",
-          measurement: "${measurement}",
-          start: ${CACHING_REQUIRED_START_DATE},
-          stop: ${CACHING_REQUIRED_END_DATE},
-        )
-        |> filter(fn: (r) => r._value != "_measurement" and r._value != "_field")
-        |> filter(fn: (r) => r._value != "_start" and r._value != "_stop")
-        ${searchTerm ? SEARCH_STRING(searchTerm) : ''}
-        |> map(fn: (r) => ({r with lowercase: strings.toLower(v: r._value)}))
-        |> sort(columns: ["lowercase"])
-        |> limit(n: ${DEFAULT_LIMIT})
-      `
-    }
+        : `${IMPORT_REGEXP}${IMPORT_INFLUX_SCHEMA}${IMPORT_STRINGS}
+      schema.measurementTagKeys(
+        bucket: "${bucket.name}",
+        measurement: "${measurement}",
+        start: ${CACHING_REQUIRED_START_DATE},
+        stop: ${CACHING_REQUIRED_END_DATE},
+      )
+      |> filter(fn: (r) => r._value != "_measurement" and r._value != "_field")
+      |> filter(fn: (r) => r._value != "_start" and r._value != "_stop")
+      ${searchTerm ? SEARCH_STRING(searchTerm) : ''}
+      |> map(fn: (r) => ({r with lowercase: strings.toLower(v: r._value)}))
+      |> sort(columns: ["lowercase"])
+      |> limit(n: ${DEFAULT_LIMIT})
+    `
 
     const newTags: Tags = {}
     try {
@@ -167,14 +157,9 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
 
     // Simplified version of query from this file:
     //   src/flows/pipes/QueryBuilder/context.tsx
-    let _source = ''
-    if (bucket.type === 'sample') {
-      _source += SAMPLE_DATA_SET(bucket.id)
-    } else {
-      _source += FROM_BUCKET(bucket.name)
-    }
-
-    let queryText = `${_source}
+    const queryText =
+      bucket.type === 'sample'
+        ? `${SAMPLE_DATA_SET(bucket.id)}
       |> range(start: -100y, stop: now())
       |> filter(fn: (r) => (r["_measurement"] == "${measurement}"))
       |> keep(columns: ["${tagKey}"])
@@ -183,22 +168,18 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
       |> sort()
       |> limit(n: ${DEFAULT_LIMIT})
     `
-
-    if (bucket.type !== 'sample') {
-      _source = `${IMPORT_STRINGS}${IMPORT_INFLUX_SCHEMA}`
-      queryText = `${_source}
-        schema.measurementTagValues(
-          bucket: "${bucket.name}",
-          measurement: "${measurement}",
-          tag: "${tagKey}",
-          start: ${CACHING_REQUIRED_START_DATE},
-          stop: ${CACHING_REQUIRED_END_DATE},
-        )
-        |> map(fn: (r) => ({r with lowercase: strings.toLower(v: r._value)}))
-        |> sort(columns: ["lowercase"])
-        |> limit(n: ${DEFAULT_LIMIT})
-      `
-    }
+        : `${IMPORT_STRINGS}${IMPORT_INFLUX_SCHEMA}
+      schema.measurementTagValues(
+        bucket: "${bucket.name}",
+        measurement: "${measurement}",
+        tag: "${tagKey}",
+        start: ${CACHING_REQUIRED_START_DATE},
+        stop: ${CACHING_REQUIRED_END_DATE},
+      )
+      |> map(fn: (r) => ({r with lowercase: strings.toLower(v: r._value)}))
+      |> sort(columns: ["lowercase"])
+      |> limit(n: ${DEFAULT_LIMIT})
+    `
 
     try {
       const resp = await queryAPI(queryText, scope)


### PR DESCRIPTION
Closes #6201 

Since the feature flag `newQueryBuilder` was originally created for the query builder in the old Data Explorer and Notebooks, there is no need to check for this flag in new Script Editor. So the main purpose of this PR is to remove the logic check in if statements for `isFlagEnabled('newQueryBuilder')`. I also refactored the code to remove un-used variables.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
~~- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~~
~~- [ ] Feature flagged, if applicable~~
