### PR TITLE
feat(taskScheduler): fetch and list scripts

### DIFF
--- a/src/scripts/apis/index.ts
+++ b/src/scripts/apis/index.ts
@@ -3,22 +3,7 @@ import {CLOUD} from 'src/shared/constants'
 
 // Types
 import {ServerError, UnauthorizedError} from 'src/types/error'
-export interface Scripts {
-  scripts?: Script[]
-}
-export interface Script {
-  readonly id?: string
-  name: string
-  description?: string
-  orgID: string
-  script: string
-  language?: ScriptLanguage
-  url?: string
-  readonly createdAt?: string
-  readonly updatedAt?: string
-  labels?: string[]
-}
-export type ScriptLanguage = 'flux' | 'sql'
+import {Scripts} from 'src/types/scripts'
 
 let getScripts
 

--- a/src/scripts/apis/index.ts
+++ b/src/scripts/apis/index.ts
@@ -1,0 +1,18 @@
+// APIs
+import {getScripts, Scripts} from 'src/client/scriptsRoutes'
+
+// Types
+import {ServerError, UnauthorizedError} from 'src/types/error'
+
+export const fetchScripts = async (): Promise<Scripts> => {
+  const response = await getScripts({query: {limit: 250}})
+
+  if (response.status === 401) {
+    throw new UnauthorizedError(response.data.message)
+  }
+  if (response.status === 500) {
+    throw new ServerError(response.data.message)
+  }
+  const scripts = response.data as Scripts
+  return scripts
+}

--- a/src/scripts/apis/index.ts
+++ b/src/scripts/apis/index.ts
@@ -1,8 +1,31 @@
-// APIs
-import {getScripts, Scripts} from 'src/client/scriptsRoutes'
-
 // Types
 import {ServerError, UnauthorizedError} from 'src/types/error'
+
+// Constants
+import {CLOUD} from 'src/shared/constants'
+
+export interface Scripts {
+  scripts?: Script[]
+}
+export interface Script {
+  readonly id?: string
+  name: string
+  description?: string
+  orgID: string
+  script: string
+  language?: ScriptLanguage
+  url?: string
+  readonly createdAt?: string
+  readonly updatedAt?: string
+  labels?: string[]
+}
+export type ScriptLanguage = 'flux' | 'sql'
+
+let getScripts
+
+if (CLOUD) {
+  getScripts = require('src/client/scriptsRoutes').getScripts
+}
 
 export const fetchScripts = async (): Promise<Scripts> => {
   const response = await getScripts({query: {limit: 250}})

--- a/src/scripts/apis/index.ts
+++ b/src/scripts/apis/index.ts
@@ -20,6 +20,6 @@ export const fetchScripts = async (): Promise<Scripts> => {
   if (response.status === 500) {
     throw new ServerError(response.data.message)
   }
-  const scripts = response.data as Scripts
-  return scripts
+
+  return response.data
 }

--- a/src/scripts/apis/index.ts
+++ b/src/scripts/apis/index.ts
@@ -1,9 +1,8 @@
-// Types
-import {ServerError, UnauthorizedError} from 'src/types/error'
-
 // Constants
 import {CLOUD} from 'src/shared/constants'
 
+// Types
+import {ServerError, UnauthorizedError} from 'src/types/error'
 export interface Scripts {
   scripts?: Script[]
 }

--- a/src/shared/copy/notifications/categories/scripts.ts
+++ b/src/shared/copy/notifications/categories/scripts.ts
@@ -20,3 +20,8 @@ export const deleteScriptFail = (scriptName: string): Notification => ({
   ...defaultErrorNotification,
   message: `${scriptName} failed to delete`,
 })
+
+export const getScriptsFail = (): Notification => ({
+  ...defaultErrorNotification,
+  message: 'There was an error fetching Scripts. Please try reloading this page',
+})

--- a/src/shared/copy/notifications/categories/scripts.ts
+++ b/src/shared/copy/notifications/categories/scripts.ts
@@ -23,5 +23,6 @@ export const deleteScriptFail = (scriptName: string): Notification => ({
 
 export const getScriptsFail = (): Notification => ({
   ...defaultErrorNotification,
-  message: 'There was an error fetching Scripts. Please try reloading this page',
+  message:
+    'There was an error fetching Scripts. Please try reloading this page',
 })

--- a/src/tasks/components/TaskScheduler/ScriptSelector.tsx
+++ b/src/tasks/components/TaskScheduler/ScriptSelector.tsx
@@ -63,7 +63,7 @@ export const ScriptSelector: FC<Props> = ({
     getScripts()
   }, [dispatch])
 
-  const filteredScripts = () =>
+  const filterScripts = () =>
     scripts.filter(script =>
       script.name.toLocaleLowerCase().includes(searchTerm.toLocaleLowerCase())
     )
@@ -102,9 +102,10 @@ export const ScriptSelector: FC<Props> = ({
   }
 
   if (scriptsLoadingStatus === RemoteDataState.Done) {
+    const filteredScripts = filterScripts()
     scriptsList = (
       <>
-        {filteredScripts().map(script => (
+        {filteredScripts.map(script => (
           <Dropdown.Item
             key={script.id}
             value={script.name}
@@ -116,18 +117,20 @@ export const ScriptSelector: FC<Props> = ({
         ))}
       </>
     )
-    if (!filteredScripts().length && searchTerm) {
-      scriptsList = (
-        <EmptyState>
-          <p>{`No Scripts match "${searchTerm}"`}</p>
-        </EmptyState>
-      )
-    } else if (!filteredScripts().length && !searchTerm) {
-      scriptsList = (
-        <EmptyState>
-          <p>No Scripts found</p>
-        </EmptyState>
-      )
+    if (!filteredScripts.length) {
+      if (searchTerm) {
+        scriptsList = (
+          <EmptyState>
+            <p>{`No Scripts match "${searchTerm}"`}</p>
+          </EmptyState>
+        )
+      } else {
+        scriptsList = (
+          <EmptyState>
+            <p>No Scripts found</p>
+          </EmptyState>
+        )
+      }
     }
   }
 

--- a/src/tasks/components/TaskScheduler/ScriptSelector.tsx
+++ b/src/tasks/components/TaskScheduler/ScriptSelector.tsx
@@ -1,32 +1,139 @@
-import React, {FC} from 'react'
+// Libraries
+import React, {FC, ChangeEvent, useEffect, useState} from 'react'
+import {useDispatch} from 'react-redux'
 import {useHistory, useParams} from 'react-router-dom'
+
+// Components
 import {
   ComponentSize,
   Dropdown,
+  EmptyState,
   Form,
   IconFont,
   Input,
+  RemoteDataState,
+  TechnoSpinner,
 } from '@influxdata/clockface'
+
+// APIs
+import {fetchScripts} from 'src/scripts/apis/index'
+import {Script} from 'src/client/scriptsRoutes'
+
+// Notifications
+import {getScriptsFail} from 'src/shared/copy/notifications/categories/scripts'
+import {notify} from 'src/shared/actions/notifications'
 
 // Utils
 import {SafeBlankLink} from 'src/utils/SafeBlankLink'
 
-export const ScriptSelector: FC = () => {
+interface Props {
+  selectedScript: Script
+  setSelectedScript: (script: Script) => void
+}
+
+export const ScriptSelector: FC<Props> = ({
+  selectedScript,
+  setSelectedScript,
+}) => {
+  const [scripts, setScripts] = useState<Script[]>([])
+  const [searchTerm, setSearchTerm] = useState('')
+  const [scriptsLoadingStatus, setScriptsLoadingStatus] = useState(
+    RemoteDataState.NotStarted
+  )
+  const dispatch = useDispatch()
   const {orgID} = useParams<{orgID: string}>()
   const history = useHistory()
+
   const fluxScriptEditorLink = `/orgs/${orgID}/data-explorer?fluxScriptEditor`
+
+  useEffect(() => {
+    setScriptsLoadingStatus(RemoteDataState.Loading)
+    const getScripts = async () => {
+      try {
+        const scripts = await fetchScripts()
+        setScripts(scripts.scripts)
+        setScriptsLoadingStatus(RemoteDataState.Done)
+      } catch (error) {
+        setScriptsLoadingStatus(RemoteDataState.Error)
+        dispatch(notify(getScriptsFail()))
+      }
+    }
+    getScripts()
+  }, [dispatch])
+
+  const filteredScripts = () =>
+    scripts.filter(script =>
+      script.name.toLocaleLowerCase().includes(searchTerm.toLocaleLowerCase())
+    )
+
+  const searchForTerm = (event: ChangeEvent<HTMLInputElement>) => {
+    setSearchTerm(event.target.value)
+  }
 
   const openScriptEditor = () => {
     history.push(`/orgs/${orgID}/data-explorer?fluxScriptEditor`)
   }
 
-  const createScriptInEditor = (
-    <Dropdown.Item onClick={openScriptEditor}>
-      + Create Script in Editor
-    </Dropdown.Item>
-  )
+  const handleSelectScript = script => {
+    setSelectedScript(script)
+  }
 
-  const dropdownButtonText = 'Select a Script'
+  let scriptsList
+
+  if (
+    scriptsLoadingStatus === RemoteDataState.NotStarted ||
+    scriptsLoadingStatus === RemoteDataState.Loading
+  ) {
+    scriptsList = (
+      <div>
+        <TechnoSpinner strokeWidth={ComponentSize.Small} diameterPixels={32} />
+      </div>
+    )
+  }
+
+  if (scriptsLoadingStatus === RemoteDataState.Error) {
+    scriptsList = (
+      <div>
+        <p>Could not get scripts</p>
+      </div>
+    )
+  }
+
+  if (scriptsLoadingStatus === RemoteDataState.Done) {
+    scriptsList = (
+      <>
+        {filteredScripts().map(script => (
+          <Dropdown.Item
+            key={script.id}
+            value={script.name}
+            onClick={() => handleSelectScript(script)}
+            selected={script.name === selectedScript?.name}
+          >
+            {script.name}
+          </Dropdown.Item>
+        ))}
+      </>
+    )
+    if (!filteredScripts().length && searchTerm) {
+      scriptsList = (
+        <EmptyState>
+          <p>{`No Scripts match "${searchTerm}"`}</p>
+        </EmptyState>
+      )
+    } else if (!filteredScripts().length && !searchTerm) {
+      scriptsList = (
+        <EmptyState>
+          <p>No Scripts found</p>
+        </EmptyState>
+      )
+    }
+  }
+
+  let dropdownButtonText = 'Select a Script'
+
+  if (scriptsLoadingStatus === RemoteDataState.Done && selectedScript?.name) {
+    dropdownButtonText = selectedScript.name
+  }
 
   return (
     <div className="select-script">
@@ -34,11 +141,7 @@ export const ScriptSelector: FC = () => {
       <Form.Element label="Script" required={true} className="script-dropdown">
         <Dropdown
           button={(active, onClick) => (
-            <Dropdown.Button
-              active={active}
-              onClick={onClick}
-              testID="variable-type-dropdown--button"
-            >
+            <Dropdown.Button active={active} onClick={onClick}>
               {dropdownButtonText}
             </Dropdown.Button>
           )}
@@ -47,12 +150,18 @@ export const ScriptSelector: FC = () => {
               <Input
                 size={ComponentSize.Small}
                 icon={IconFont.Search_New}
-                value=""
+                value={searchTerm}
                 placeholder="Search Scripts..."
-                onChange={() => {}}
+                onChange={searchForTerm}
               />
               <Dropdown.Menu onCollapse={onCollapse}>
-                {createScriptInEditor}
+                <Dropdown.Item
+                  onClick={openScriptEditor}
+                  className="create-script-btn"
+                >
+                  + Create Script in Editor
+                </Dropdown.Item>
+                {scriptsList}
               </Dropdown.Menu>
             </>
           )}

--- a/src/tasks/components/TaskScheduler/ScriptSelector.tsx
+++ b/src/tasks/components/TaskScheduler/ScriptSelector.tsx
@@ -17,11 +17,13 @@ import {
 
 // APIs
 import {fetchScripts} from 'src/scripts/apis/index'
-import {Script} from 'src/client/scriptsRoutes'
 
 // Notifications
 import {getScriptsFail} from 'src/shared/copy/notifications/categories/scripts'
 import {notify} from 'src/shared/actions/notifications'
+
+// Types
+import {Script} from 'src/types/scripts'
 
 // Utils
 import {SafeBlankLink} from 'src/utils/SafeBlankLink'

--- a/src/tasks/components/TaskScheduler/TaskScheduler.scss
+++ b/src/tasks/components/TaskScheduler/TaskScheduler.scss
@@ -59,3 +59,7 @@
   font-weight: 600;
   font-size: 15px;
 }
+
+.create-script-btn {
+  color: #00a3ff;
+}

--- a/src/tasks/components/TaskScheduler/TaskScheduler.tsx
+++ b/src/tasks/components/TaskScheduler/TaskScheduler.tsx
@@ -1,4 +1,4 @@
-import React, {FC, ChangeEvent} from 'react'
+import React, {FC, ChangeEvent, useState} from 'react'
 
 // Components
 import {
@@ -19,6 +19,7 @@ import {TaskIntervalForm} from 'src/tasks/components/TaskScheduler/TaskIntervalF
 
 // Utils
 import {SafeBlankLink} from 'src/utils/SafeBlankLink'
+import {Script} from 'src/client/scriptsRoutes'
 
 // Types
 import {TaskOptions, TaskSchedule} from 'src/types'
@@ -36,6 +37,8 @@ export const TaskScheduler: FC<Props> = ({
   updateInput,
   updateScheduleType,
 }) => {
+  const [selectedScript, setSelectedScript] = useState<Script>()
+
   const handleChangeScheduleType = (schedule: TaskSchedule): void => {
     updateScheduleType(schedule)
   }
@@ -55,7 +58,10 @@ export const TaskScheduler: FC<Props> = ({
                     Learn More.
                   </SafeBlankLink>{' '}
                 </p>
-                <ScriptSelector />
+                <ScriptSelector
+                  selectedScript={selectedScript}
+                  setSelectedScript={setSelectedScript}
+                />
                 <div className="schedule-task">
                   <div className="create-task-titles">Schedule the Task</div>
                   <p>

--- a/src/tasks/components/TaskScheduler/TaskScheduler.tsx
+++ b/src/tasks/components/TaskScheduler/TaskScheduler.tsx
@@ -19,9 +19,9 @@ import {TaskIntervalForm} from 'src/tasks/components/TaskScheduler/TaskIntervalF
 
 // Utils
 import {SafeBlankLink} from 'src/utils/SafeBlankLink'
-import {Script} from 'src/client/scriptsRoutes'
 
 // Types
+import {Script} from 'src/types/scripts'
 import {TaskOptions, TaskSchedule} from 'src/types'
 
 import 'src/tasks/components/TaskScheduler/TaskScheduler.scss'

--- a/src/tasks/containers/TaskPage.tsx
+++ b/src/tasks/containers/TaskPage.tsx
@@ -13,6 +13,9 @@ import TaskForm from 'src/tasks/components/TaskForm'
 import TaskHeader from 'src/tasks/components/TaskHeader'
 import {TaskScheduler} from 'src/tasks/components/TaskScheduler/TaskScheduler'
 
+// Constants
+import {CLOUD} from 'src/shared/constants'
+
 // Actions and Selectors
 import {
   setNewScript,
@@ -59,7 +62,7 @@ class TaskPage extends PureComponent<Props> {
 
   public render(): JSX.Element {
     const {newScript, taskOptions} = this.props
-    const shouldShowNewTasksUI = isFlagEnabled('tasksUiEnhancements')
+    const shouldShowNewTasksUI = isFlagEnabled('tasksUiEnhancements') && CLOUD
 
     return (
       <Page titleTag={pageTitleSuffixer(['Create Task'])}>

--- a/src/types/scripts.ts
+++ b/src/types/scripts.ts
@@ -1,0 +1,17 @@
+export interface Scripts {
+  scripts?: Script[]
+}
+export interface Script {
+  readonly id?: string
+  name: string
+  description?: string
+  orgID: string
+  script: string
+  language?: ScriptLanguage
+  url?: string
+  readonly createdAt?: string
+  readonly updatedAt?: string
+  labels?: string[]
+}
+
+export type ScriptLanguage = 'flux' | 'sql'


### PR DESCRIPTION
Part of #6186 

Behind `tasksUiEnchancements` feature flag

For new Task create page, pr adds functionality to the Select Script drop down and search bar. 
Upon page load, ScriptSelector will fetch scripts and display them inside the dropdown component. User can filter through scripts by typing inside the search bar. 
Upcoming Pr will introduce the next step - showing parameters, description, and name of script on the right side of the page when a script is clicked. 

https://user-images.githubusercontent.com/66275100/200870805-f25f74bf-45c6-40d7-87c1-8c2ec5a49d60.mov



### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
