### PR TITLE
chore: adjust task card and filter appearance based on design input

### DIFF
--- a/src/identity/components/OrganizationListTab/OrgList.tsx
+++ b/src/identity/components/OrganizationListTab/OrgList.tsx
@@ -9,11 +9,11 @@ import {OrganizationCard} from 'src/identity/components/OrganizationListTab/Orga
 // Constants
 import {GLOBAL_HEADER_HEIGHT} from 'src/identity/components/GlobalHeader/constants'
 const DEFAULT_BANNER_HEIGHT = 60
-const DEFAULT_ORG_CARD_HEIGHT = 105
+const DEFAULT_ORG_CARD_HEIGHT = 72
 const DEFAULT_PAGINATION_NAV_HEIGHT = 72
 const DEFAULT_SEARCH_WIDGET_HEIGHT = 60
 const DEFAULT_TABS_HEIGHT = 40
-const DEFAULT_TOTAL_MARGIN_HEIGHT = 60
+const DEFAULT_TOTAL_MARGIN_HEIGHT = 80
 
 // Utils
 import {getSortedResources, SortTypes} from 'src/shared/utils/sort'

--- a/src/identity/components/OrganizationListTab/OrganizationCard.scss
+++ b/src/identity/components/OrganizationListTab/OrganizationCard.scss
@@ -1,8 +1,8 @@
 @import '@influxdata/clockface/dist/variables.scss';
 
 .account--organizations-tab-orgs-card {
-  margin-top: $cf-space-2xs;
-  margin-bottom: $cf-space-2xs;
+  margin-top: $cf-space-3xs;
+  margin-bottom: $cf-space-3xs;
   background-color: $cf-grey-15;
   border-radius: 2px;
 }
@@ -22,7 +22,9 @@
 }
 
 .account--organizations-tab-orgs-card-orgname {
-  font-size: $cf-text-base-1;
-  color: $cf-white;
-  font-weight: $cf-font-weight--bold;
+  .cf-resource-name--text {
+    font-size: $cf-text-base-1;
+    color: $cf-white;
+    font-weight: $cf-font-weight--bold;
+  }
 }

--- a/src/identity/components/OrganizationListTab/OrganizationCard.tsx
+++ b/src/identity/components/OrganizationListTab/OrganizationCard.tsx
@@ -1,5 +1,10 @@
 import React, {FC} from 'react'
-import {FlexBox, JustifyContent, ResourceCard} from '@influxdata/clockface'
+import {
+  FlexBox,
+  FlexDirection,
+  JustifyContent,
+  ResourceCard,
+} from '@influxdata/clockface'
 
 // Styles
 import './OrganizationCard.scss'
@@ -20,6 +25,7 @@ export const OrganizationCard: FC<OrgCardProps> = ({
   return (
     <ResourceCard
       className="account--organizations-tab-orgs-card"
+      direction={FlexDirection.Row}
       justifyContent={JustifyContent.SpaceBetween}
       testID="account--organizations-tab-orgs-card"
     >
@@ -29,13 +35,13 @@ export const OrganizationCard: FC<OrgCardProps> = ({
       ></ResourceCard.Name>
       <ResourceCard.Meta>
         <FlexBox className="account--organizations-tab-orgs-card-cluster-data">
-          Cloud Provider: {provider}
+          <b>Cloud Provider:</b> &nbsp;{provider}
         </FlexBox>
         <FlexBox className="account--organizations-tab-orgs-card-cluster-data">
-          Region: {regionCode}
+          <b>Region:</b> &nbsp;{regionCode}
         </FlexBox>
         <FlexBox className="account-organizations-tab-orgs-card-location-data">
-          Location: {regionName}
+          <b>Location:</b> &nbsp;{regionName}
         </FlexBox>
       </ResourceCard.Meta>
     </ResourceCard>

--- a/src/identity/components/OrganizationListTab/index.tsx
+++ b/src/identity/components/OrganizationListTab/index.tsx
@@ -41,7 +41,7 @@ import {BucketSortKey} from 'src/shared/components/resource_sort_dropdown/genera
 import {QuartzOrganization} from 'src/identity/apis/org'
 import {RemoteDataState, ResourceType, SortTypes} from 'src/types'
 
-const searchKeys = ['name']
+const searchKeys = ['name', 'provider', 'regionCode', 'regionName']
 
 const FilterOrgs = FilterListContainer<QuartzOrganization>()
 
@@ -232,12 +232,14 @@ export const OrganizationListTab: FC<Props> = ({pageHeight}) => {
           )}
         </FilterOrgs>
       </ResourceList>
-      <PaginationNav.PaginationNav
-        currentPage={currentPage}
-        onChange={handleChangePage}
-        pageRangeOffset={1}
-        totalPages={totalPages}
-      />
+      {totalPages > 1 && (
+        <PaginationNav.PaginationNav
+          currentPage={currentPage}
+          onChange={handleChangePage}
+          pageRangeOffset={1}
+          totalPages={totalPages}
+        />
+      )}
     </>
   )
 }


### PR DESCRIPTION
Closes #6223 

1. Reverts organization list cards back to their original design based on further design feedback (thin cards - all data on one line).
2. Searching in the text box now allows for searching not only by name, but also by provider, region, and location.

Also adjusted pagination tab so that (consistent with figma) it doesn't display when there is one page or fewer of 'results' from the user's search.

Before Changes
--
![Screen Shot 2022-10-25 at 5 58 01 PM](https://user-images.githubusercontent.com/91283923/200883508-3ee3757e-0d99-4a7c-a7cc-686fccc322f8.png)


Uses the Original Org Card Design 
--
https://user-images.githubusercontent.com/91283923/200882252-352f2c1a-e076-4edf-ba8e-7eb1a774bb77.mov

Adds More Filtering Options
--

https://user-images.githubusercontent.com/91283923/200882512-eeea781c-b5c5-48d1-88fc-a8466a1b06f3.mov



No Pagination Displayed When There is Only One Page of Results
--
![Screen Shot 2022-11-09 at 11 12 23 AM](https://user-images.githubusercontent.com/91283923/200882530-59f36d4b-e4c1-4092-82e3-a8c9311a31e1.png)



### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - `createDeleteOrgs`
