### PR TITLE
chore: remove quartzSession flag

### DIFF
--- a/cypress/e2e/cloud/globalHeader.test.ts
+++ b/cypress/e2e/cloud/globalHeader.test.ts
@@ -3,26 +3,6 @@ import {makeQuartzUseIDPEOrgID} from 'cypress/support/Utils'
 describe('change-account change-org global header', () => {
   let idpeOrgID: string
 
-  const interceptPageReload = () => {
-    cy.intercept('GET', 'api/v2/orgs').as('getOrgs')
-    cy.intercept('GET', 'api/v2/flags').as('getFlags')
-    cy.intercept('GET', 'api/v2/quartz/accounts/**/orgs').as('getQuartzOrgs')
-  }
-
-  const mockQuartzOutage = () => {
-    const quartzFailure = {
-      statusCode: 503,
-      body: 'Service Unavailable',
-    }
-
-    cy.intercept('GET', 'api/v2/quartz/identity', quartzFailure).as(
-      'getQuartzIdentity'
-    )
-    cy.intercept('GET', 'api/v2/quartz/accounts', quartzFailure).as(
-      'getQuartzAccounts'
-    )
-  }
-
   before(() => {
     cy.flush().then(() =>
       cy.signin().then(() => {
@@ -51,14 +31,6 @@ describe('change-account change-org global header', () => {
   })
 
   describe('global change-account and change-org header', () => {
-    it('does not render when API requests to quartz fail', () => {
-      mockQuartzOutage()
-      interceptPageReload()
-      cy.visit('/')
-      cy.wait('@getQuartzAccounts')
-      cy.getByTestID('global-header--container').should('not.exist')
-    })
-
     describe('change org dropdown', () => {
       before(() => {
         makeQuartzUseIDPEOrgID(idpeOrgID)

--- a/src/Authenticate.tsx
+++ b/src/Authenticate.tsx
@@ -102,7 +102,7 @@ class AuthenticateUnconnected extends PureComponent<Props, State> {
 
   private fetchMe = async () => {
     try {
-      if (isFlagEnabled('quartzSession')) {
+      if (CLOUD) {
         await this.props.getQuartzIdentityThunkNoErrorHandling()
         // TODO: completing https://github.com/influxdata/ui/issues/5826 will make this
         // line unnecessary
@@ -123,7 +123,7 @@ class AuthenticateUnconnected extends PureComponent<Props, State> {
 
   private authenticate = async () => {
     try {
-      if (isFlagEnabled('quartzSession')) {
+      if (CLOUD) {
         await fetchIdentity()
       } else {
         await fetchLegacyIdentity()

--- a/src/onboarding/containers/CloudLoginPage.tsx
+++ b/src/onboarding/containers/CloudLoginPage.tsx
@@ -12,7 +12,7 @@ import Notifications from 'src/shared/components/notifications/Notifications'
 import {CloudLogoWithCubo} from 'src/onboarding/components/CloudLogoWithCubo'
 
 // APIs
-import {fetchIdentity, fetchLegacyIdentity} from 'src/identity/apis/auth'
+import {fetchIdentity} from 'src/identity/apis/auth'
 
 // Components
 import ErrorBoundary from 'src/shared/components/ErrorBoundary'
@@ -27,11 +27,7 @@ export const CloudLoginPage: FC = () => {
 
   const getSessionValidity = useCallback(async () => {
     try {
-      if (isFlagEnabled('quartzSession')) {
-        await fetchIdentity()
-      } else {
-        await fetchLegacyIdentity()
-      }
+      await fetchIdentity()
 
       setHasValidSession(true)
     } catch {


### PR DESCRIPTION
Helps with #5771

Removes the `quartzSession` feature flag from the UI, which controls the use of quartz in lieu of IDPE for authentication. This has been on in all cloud environments without issue since 10/14 so no change in behavior is expected.

`quartzSession` is a flag for which auth is not required, so it is retrieved from the `/api/v2private/flags` endpoint and used in prod before the first authentication request is made.

Proof
--
Separately tested this in quartz-remocal to ensure no change in behavior.

Login unaffected
--
https://user-images.githubusercontent.com/91283923/208174937-2cd7f46a-ff68-4428-852f-f30be0c76ed7.mov

API Calls
--
![Screen Shot 2022-12-16 at 2 30 55 PM](https://user-images.githubusercontent.com/91283923/208175096-b2c222ff-ef16-4aad-adc8-113c0beee0dd.png)

There is still a call to api/v2/me for now - but it's not being used for auth. That's the thunk call that is still required by certain parts of the app until we can more meaningfully untangle some of the cloud functionality from what's required in oss.

App Testing
--

https://user-images.githubusercontent.com/91283923/208175166-895622d3-ce68-4d7b-a902-69ff4eb3992d.mov





### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable
