### PR TITLE
chore: do not use a default export for the editor

### DIFF
--- a/src/dataExplorer/components/ResultsPane.tsx
+++ b/src/dataExplorer/components/ResultsPane.tsx
@@ -57,8 +57,10 @@ import {getWindowPeriodVariableFromVariables} from 'src/variables/utils/getWindo
 import {TIME_RANGE_START, TIME_RANGE_STOP} from 'src/variables/constants'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
-const FluxMonacoEditor = lazy(
-  () => import('src/shared/components/FluxMonacoEditor')
+const FluxMonacoEditor = lazy(() =>
+  import('src/shared/components/FluxMonacoEditor').then(module => ({
+    default: module.FluxMonacoEditor,
+  }))
 )
 
 const fakeNotify = notify

--- a/src/flows/pipes/RawFluxEditor/readOnly.tsx
+++ b/src/flows/pipes/RawFluxEditor/readOnly.tsx
@@ -16,8 +16,10 @@ import {PipeContext} from 'src/flows/context/pipe'
 // Styles
 import 'src/flows/pipes/RawFluxEditor/style.scss'
 
-const FluxMonacoEditor = lazy(
-  () => import('src/shared/components/FluxMonacoEditor')
+const FluxMonacoEditor = lazy(() =>
+  import('src/shared/components/FluxMonacoEditor').then(module => ({
+    default: module.FluxMonacoEditor,
+  }))
 )
 
 const Query: FC<PipeProp> = ({Context}) => {

--- a/src/flows/pipes/RawFluxEditor/view.tsx
+++ b/src/flows/pipes/RawFluxEditor/view.tsx
@@ -39,8 +39,10 @@ import {event} from 'src/cloud/utils/reporting'
 import {CLOUD} from 'src/shared/constants'
 import {buildQuery} from 'src/timeMachine/utils/queryBuilder'
 
-const FluxMonacoEditor = lazy(
-  () => import('src/shared/components/FluxMonacoEditor')
+const FluxMonacoEditor = lazy(() =>
+  import('src/shared/components/FluxMonacoEditor').then(module => ({
+    default: module.FluxMonacoEditor,
+  }))
 )
 
 const Query: FC<PipeProp> = ({Context}) => {

--- a/src/shared/components/FluxMonacoEditor.tsx
+++ b/src/shared/components/FluxMonacoEditor.tsx
@@ -50,7 +50,8 @@ interface Props extends EditorProps {
   variables: Variable[]
 }
 
-const FluxEditorMonaco: FC<Props> = ({
+// Monaco editor for editing flux
+export const FluxMonacoEditor: FC<Props> = ({
   script,
   onChangeScript,
   onSubmitScript,
@@ -175,5 +176,3 @@ const FluxEditorMonaco: FC<Props> = ({
     [isIoxOrg, onChangeScript, setEditor, useSchemaComposition, script]
   )
 }
-
-export default FluxEditorMonaco

--- a/src/tasks/components/RunLogRowFlux.tsx
+++ b/src/tasks/components/RunLogRowFlux.tsx
@@ -10,7 +10,7 @@ import {Run} from 'src/types'
 // DateTime
 import {DEFAULT_TIME_FORMAT} from 'src/utils/datetime/constants'
 import {FormattedDateTime} from 'src/utils/datetime/FormattedDateTime'
-import FluxEditorMonaco from 'src/shared/components/FluxMonacoEditor'
+import {FluxMonacoEditor} from 'src/shared/components/FluxMonacoEditor'
 
 interface Props {
   run: Run
@@ -29,7 +29,7 @@ class RunLogRowFlux extends PureComponent<Props> {
         </IndexList.Cell>
         <IndexList.Cell>
           <span className="run-logs--list-flux">
-            <FluxEditorMonaco
+            <FluxMonacoEditor
               script={run.flux}
               variables={[]}
               onChangeScript={() => {}}

--- a/src/tasks/containers/TaskEditPage.tsx
+++ b/src/tasks/containers/TaskEditPage.tsx
@@ -33,8 +33,10 @@ import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 // Types
 import {AppState, TaskOptionKeys, TaskSchedule} from 'src/types'
 
-const FluxMonacoEditor = lazy(
-  () => import('src/shared/components/FluxMonacoEditor')
+const FluxMonacoEditor = lazy(() =>
+  import('src/shared/components/FluxMonacoEditor').then(module => ({
+    default: module.FluxMonacoEditor,
+  }))
 )
 
 type ReduxProps = ConnectedProps<typeof connector>

--- a/src/tasks/containers/TaskPage.tsx
+++ b/src/tasks/containers/TaskPage.tsx
@@ -40,8 +40,10 @@ import {AppState, TaskOptionKeys, TaskSchedule} from 'src/types'
 type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps
 
-const FluxMonacoEditor = lazy(
-  () => import('src/shared/components/FluxMonacoEditor')
+const FluxMonacoEditor = lazy(() =>
+  import('src/shared/components/FluxMonacoEditor').then(module => ({
+    default: module.FluxMonacoEditor,
+  }))
 )
 
 class TaskPage extends PureComponent<Props> {

--- a/src/timeMachine/components/TimeMachineFluxEditor.tsx
+++ b/src/timeMachine/components/TimeMachineFluxEditor.tsx
@@ -24,7 +24,11 @@ import {event} from 'src/cloud/utils/reporting'
 // Types
 import {Variable} from 'src/types'
 
-const FluxEditor = lazy(() => import('src/shared/components/FluxMonacoEditor'))
+const FluxMonacoEditor = lazy(() =>
+  import('src/shared/components/FluxMonacoEditor').then(module => ({
+    default: module.FluxMonacoEditor,
+  }))
+)
 
 const TMFluxEditor: FC<{variables: Variable[]}> = props => {
   const dispatch = useDispatch()
@@ -72,7 +76,7 @@ const TMFluxEditor: FC<{variables: Variable[]}> = props => {
             />
           }
         >
-          <FluxEditor
+          <FluxMonacoEditor
             script={activeQueryText}
             variables={props.variables}
             onChangeScript={handleActiveQuery}

--- a/src/variables/components/VariableArgumentsEditor.tsx
+++ b/src/variables/components/VariableArgumentsEditor.tsx
@@ -13,8 +13,10 @@ import {Form} from '@influxdata/clockface'
 // Types
 import {KeyValueMap, VariableProperties, Variable} from 'src/types'
 
-const FluxMonacoEditor = lazy(
-  () => import('src/shared/components/FluxMonacoEditor')
+const FluxMonacoEditor = lazy(() =>
+  import('src/shared/components/FluxMonacoEditor').then(module => ({
+    default: module.FluxMonacoEditor,
+  }))
 )
 
 interface Props {


### PR DESCRIPTION
This patch removes the default export for the editor. The biggest onus
for making this change is that the prevalence of `lazy` was hiding a lot
of uses of `FluxMonacoEditor` (which was renamed in this patch for
consistency), so it was difficult to trace its usage. By removing the
default export, we had to be explicit in the `lazy` callback to
specify exactly what we want from the import.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable