### PR TITLE
feat(task):  fetch and show script parameters 

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "cy": "CYPRESS_dexUrl=https://$INGRESS_HOST:$PORT_HTTPS CYPRESS_baseUrl=http://localhost:9999 cypress open",
     "cy:dev": "source ../monitor-ci/.env && CYPRESS_dexUrl=CLOUD CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{cloud,shared}/**/*.*'",
     "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_dexUrl=OSS CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{oss,shared}/**/*.*'",
-    "generate": "export SHA=1378c4d5bf380e7f33de3381fa4c8c45b6734e58 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
+    "generate": "export SHA=9d31f38d457c9ddd4fb66a4bdb4ff40f402961ad && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-local-cloud": "export REMOTE=../openapi/ && yarn generate-meta-cloud",
     "generate-meta": "if [ -z \"${CLOUD_URL}\" ]; then yarn generate-meta-oss; else yarn generate-meta-cloud; fi",

--- a/src/scripts/apis/index.ts
+++ b/src/scripts/apis/index.ts
@@ -35,7 +35,6 @@ export const fetchScriptParams = async (scriptID: string): Promise<Params> => {
   if (response.status === 500) {
     throw new ServerError(response.data.message)
   }
-  const scriptParams = response.data as Params
 
-  return scriptParams
+  return response.data
 }

--- a/src/scripts/apis/index.ts
+++ b/src/scripts/apis/index.ts
@@ -3,12 +3,14 @@ import {CLOUD} from 'src/shared/constants'
 
 // Types
 import {ServerError, UnauthorizedError} from 'src/types/error'
-import {Scripts} from 'src/types/scripts'
+import {Scripts, Params} from 'src/types/scripts'
 
 let getScripts
+let getScriptsParams
 
 if (CLOUD) {
   getScripts = require('src/client/scriptsRoutes').getScripts
+  getScriptsParams = require('src/client/scriptsRoutes').getScriptsParams
 }
 
 export const fetchScripts = async (): Promise<Scripts> => {
@@ -22,4 +24,18 @@ export const fetchScripts = async (): Promise<Scripts> => {
   }
 
   return response.data
+}
+
+export const fetchScriptParams = async (scriptID: string): Promise<Params> => {
+  const response = await getScriptsParams({scriptID})
+
+  if (response.status === 401) {
+    throw new UnauthorizedError(response.data.message)
+  }
+  if (response.status === 500) {
+    throw new ServerError(response.data.message)
+  }
+  const scriptParams = response.data as Params
+
+  return scriptParams
 }

--- a/src/shared/copy/notifications/categories/scripts.ts
+++ b/src/shared/copy/notifications/categories/scripts.ts
@@ -26,3 +26,9 @@ export const getScriptsFail = (): Notification => ({
   message:
     'There was an error fetching Scripts. Please try reloading this page',
 })
+
+export const getScriptParamsFail = (): Notification => ({
+  ...defaultErrorNotification,
+  message:
+    'There was an error fetching Script Parameters. Please try reloading this page',
+})

--- a/src/tasks/components/TaskScheduler/ScriptParametersForm.tsx
+++ b/src/tasks/components/TaskScheduler/ScriptParametersForm.tsx
@@ -1,0 +1,90 @@
+// Libraries
+import React, {FC, useEffect, useState} from 'react'
+import {DapperScrollbars, Form, Input} from '@influxdata/clockface'
+
+// Types
+import {Script} from 'src/types/scripts'
+
+// Utils
+import {SafeBlankLink} from 'src/utils/SafeBlankLink'
+
+interface Props {
+  scriptParams: any
+  selectedScript: Script
+}
+
+export const ScriptParametersForm: FC<Props> = ({
+  scriptParams,
+  selectedScript,
+}) => {
+  const [parameters, setParameters] = useState([])
+
+  useEffect(() => {
+    setParameters(scriptParams)
+  }, [scriptParams])
+
+  const UpdateParamValue = (event, paramName) => {
+    let updateparams = [...parameters]
+
+    updateparams = updateparams.map(param => {
+      if (param.name === paramName) {
+        param.value = event.target.value
+        return param
+      } else {
+        return param
+      }
+    })
+    setParameters(updateparams)
+  }
+
+  const paramList = (
+    <>
+      {parameters.map(param => (
+        <Form.Element
+          label={`param.${param.name}`}
+          required={true}
+          key={param.name}
+          className="script-param"
+        >
+          <Input
+            name="name"
+            onChange={event => UpdateParamValue(event, param.name)}
+            value={param.value}
+            testID="script-param-value"
+          />
+        </Form.Element>
+      ))}
+    </>
+  )
+
+  return (
+    <>
+      <div className="create-task-titles script-name">
+        {selectedScript.name}
+      </div>
+      <div className="script-description">
+        <div>Description</div>
+        <p>{selectedScript.description}</p>
+      </div>
+      {scriptParams.length ? (
+        <div className="script-params">
+          <div className="create-task-titles">Set Param Values</div>
+          <p>
+            Params are InfluxDB objects that define runtime variables. You must
+            provide values for params when you invoke a script.{' '}
+            <SafeBlankLink href="https://docs.influxdata.com/influxdb/cloud/query-data/parameterized-queries/">
+              Learn More.
+            </SafeBlankLink>
+          </p>
+          <DapperScrollbars
+            autoHide={true}
+            autoSize={false}
+            style={{width: '100%', minHeight: '500px'}}
+          >
+            <div className="script-params-list">{paramList}</div>
+          </DapperScrollbars>
+        </div>
+      ) : null}
+    </>
+  )
+}

--- a/src/tasks/components/TaskScheduler/ScriptParametersForm.tsx
+++ b/src/tasks/components/TaskScheduler/ScriptParametersForm.tsx
@@ -78,7 +78,6 @@ export const ScriptParametersForm: FC<Props> = ({
           </p>
           <DapperScrollbars
             autoHide={true}
-            autoSize={false}
             style={{width: '100%', minHeight: '500px'}}
           >
             <div className="script-params-list">{paramList}</div>

--- a/src/tasks/components/TaskScheduler/TaskIntervalForm.tsx
+++ b/src/tasks/components/TaskScheduler/TaskIntervalForm.tsx
@@ -39,7 +39,7 @@ export const TaskIntervalForm: FC<Props> = props => {
           required={true}
           className="task-form-labels"
         >
-          <div className="schedule-tooltip interval">
+          <div className="schedule-tooltip task-interval">
             <QuestionMarkTooltip
               diameter={15}
               color={ComponentColor.Primary}
@@ -59,12 +59,8 @@ export const TaskIntervalForm: FC<Props> = props => {
         </Form.Element>
       </Grid.Column>
       <Grid.Column widthXS={Columns.Six}>
-        <Form.Element
-          label="Offset"
-          required={true}
-          className="task-form-labels"
-        >
-          <div className="schedule-tooltip offset">
+        <Form.Element label="Offset" className="task-form-labels">
+          <div className="schedule-tooltip task-offset">
             <QuestionMarkTooltip
               diameter={15}
               color={ComponentColor.Primary}

--- a/src/tasks/components/TaskScheduler/TaskScheduler.scss
+++ b/src/tasks/components/TaskScheduler/TaskScheduler.scss
@@ -1,6 +1,6 @@
 .cf-form--footer {
   position: relative;
-  margin-top: 20%;
+  margin-top: 100px;
   justify-content: end;
 }
 
@@ -42,12 +42,12 @@
   position: absolute;
 }
 
-.interval {
+.task-interval {
   left: 51px;
 }
 
-.offset {
-  left: 55px;
+.task-offset {
+  left: 52px;
 }
 
 .cf-input-field:focus,
@@ -58,6 +58,32 @@
 .cf-form--label-text {
   font-weight: 600;
   font-size: 15px;
+}
+
+.form-divider {
+  border-left: 1px solid rgba(220, 220, 220, 0.2);
+  height: 755px;
+}
+
+.cf-col-xs-2 {
+  width: 2%;
+}
+
+.script-params-list {
+  margin-right: 15px;
+}
+
+.script-description {
+  font-weight: 700;
+  margin-top: 10px;
+}
+
+.script-name {
+  margin-top: 12px;
+}
+
+.script-param {
+  margin-top: 5px;
 }
 
 .create-script-btn {

--- a/src/tasks/components/TaskScheduler/TaskScheduler.tsx
+++ b/src/tasks/components/TaskScheduler/TaskScheduler.tsx
@@ -143,8 +143,8 @@ export const TaskScheduler: FC<Props> = ({
                 </Grid.Column>
                 <Grid.Column widthXS={Columns.Five}>
                   <ScriptParametersForm
-                    selectedScript={selectedScript}
                     scriptParams={scriptParams}
+                    selectedScript={selectedScript}
                   />
                 </Grid.Column>
               </>

--- a/src/tasks/components/TaskScheduler/TaskScheduler.tsx
+++ b/src/tasks/components/TaskScheduler/TaskScheduler.tsx
@@ -1,3 +1,4 @@
+// Libraries
 import React, {FC, ChangeEvent, useState} from 'react'
 
 // Components
@@ -14,6 +15,7 @@ import {
   Page,
   SelectGroup,
 } from '@influxdata/clockface'
+import {ScriptParametersForm} from 'src/tasks/components/TaskScheduler/ScriptParametersForm'
 import {ScriptSelector} from 'src/tasks/components/TaskScheduler/ScriptSelector'
 import {TaskIntervalForm} from 'src/tasks/components/TaskScheduler/TaskIntervalForm'
 
@@ -37,6 +39,7 @@ export const TaskScheduler: FC<Props> = ({
   updateInput,
   updateScheduleType,
 }) => {
+  const [scriptParams, setScriptParams] = useState([])
   const [selectedScript, setSelectedScript] = useState<Script>()
 
   const handleChangeScheduleType = (schedule: TaskSchedule): void => {
@@ -60,6 +63,7 @@ export const TaskScheduler: FC<Props> = ({
                 </p>
                 <ScriptSelector
                   selectedScript={selectedScript}
+                  setScriptParams={setScriptParams}
                   setSelectedScript={setSelectedScript}
                 />
                 <div className="schedule-task">
@@ -132,6 +136,19 @@ export const TaskScheduler: FC<Props> = ({
                 </Form.Footer>
               </div>
             </Grid.Column>
+            {selectedScript?.description.trim() && (
+              <>
+                <Grid.Column widthXS={Columns.Two}>
+                  <div className="form-divider"></div>
+                </Grid.Column>
+                <Grid.Column widthXS={Columns.Five}>
+                  <ScriptParametersForm
+                    selectedScript={selectedScript}
+                    scriptParams={scriptParams}
+                  />
+                </Grid.Column>
+              </>
+            )}
           </Grid.Row>
         </Grid>
       </Form>

--- a/src/types/scripts.ts
+++ b/src/types/scripts.ts
@@ -15,3 +15,7 @@ export interface Script {
 }
 
 export type ScriptLanguage = 'flux' | 'sql'
+
+export interface Params {
+  params?: any
+}


### PR DESCRIPTION
Closes #6186 

Behind feature flag `taskUiEnhancements`

By clicking on Scripts from the Select Scripts drop down menu, user can now see all parameters associated with a script. 
Depending on the size of params, user can also scroll and update the values before scheduling a task. 
The information on the right side of the form wont render unless selected script has a description or parameters. 

If an error occurs during fetching of a script/script parameters, user will see a toast notification on the upper right corner of the screen with a message to refresh the page. 

https://user-images.githubusercontent.com/66275100/200961918-4a1233e3-ee8a-4b56-a636-35c59ae855d5.mov

https://user-images.githubusercontent.com/66275100/200964569-f9049907-3380-4e4d-8cc3-a587ddf8f2ac.mov


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
