### PR TITLE
fix: check equality on the variable selector

### DIFF
--- a/src/timeMachine/components/Queries.tsx
+++ b/src/timeMachine/components/Queries.tsx
@@ -1,4 +1,5 @@
 // Libraries
+import {isEqual} from 'lodash'
 import React, {FC} from 'react'
 import {useSelector, useDispatch} from 'react-redux'
 
@@ -37,7 +38,7 @@ import {
 import {getTimeRange} from 'src/dashboards/selectors'
 
 // Types
-import {TimeRange, AutoRefreshStatus} from 'src/types'
+import {TimeRange, AutoRefreshStatus, Variable} from 'src/types'
 
 type Props = {
   maxHeight: number
@@ -49,7 +50,12 @@ const TimeMachineQueries: FC<Props> = ({maxHeight}) => {
   const {autoRefresh} = useSelector(getActiveTimeMachine)
   const activeQuery = useSelector(getActiveQuery)
   const isInCheckOverlay = useSelector(getIsInCheckOverlay)
-  const variables = useSelector(getAllVariables)
+  // XXX: rockstar (9 Nov 2022) - This provides updates of the exactly the same values, but fails the
+  // === check. This probably indicates a problem higher up the selector chain, but this prevents some
+  // unnecessary re-render activity.
+  const variables = useSelector(getAllVariables, (left: Variable[], right: Variable[]): boolean => {
+    return left.length == right.length && left.every((variable, index) => isEqual(variable, right[index]))
+  })
 
   const handleSetTimeRange = (timeRange: TimeRange) => {
     dispatch(setTimeRange(timeRange))


### PR DESCRIPTION
`useSelector` on the variables was firing on every keystroke from the
editor. While unrelated to why it was firing on every keystroke, it
doesn't have to add to the resulting event chain, e.g. the `useEffect`
in `FluxMonacoEditor` that is executed when variables change.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable