### PR TITLE
chore(org): handle 403 error for postOrg

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "cy": "CYPRESS_dexUrl=https://$INGRESS_HOST:$PORT_HTTPS CYPRESS_baseUrl=http://localhost:9999 cypress open",
     "cy:dev": "source ../monitor-ci/.env && CYPRESS_dexUrl=CLOUD CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{cloud,shared}/**/*.*'",
     "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_dexUrl=OSS CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{oss,shared}/**/*.*'",
-    "generate": "export SHA=1378c4d5bf380e7f33de3381fa4c8c45b6734e58 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
+    "generate": "export SHA=9d31f38d457c9ddd4fb66a4bdb4ff40f402961ad && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-local-cloud": "export REMOTE=../openapi/ && yarn generate-meta-cloud",
     "generate-meta": "if [ -z \"${CLOUD_URL}\" ]; then yarn generate-meta-oss; else yarn generate-meta-cloud; fi",

--- a/src/identity/apis/org.ts
+++ b/src/identity/apis/org.ts
@@ -14,6 +14,7 @@ import {
 // Types
 import {RemoteDataState} from 'src/types'
 import {
+  ForbiddenError,
   GenericError,
   NotFoundError,
   OrgNameConflictError,
@@ -65,6 +66,10 @@ export const createNewOrg = async (
 
   if (response.status === 401) {
     throw new UnauthorizedError(response.data.message)
+  }
+
+  if (response.status === 403) {
+    throw new ForbiddenError(response.data.message)
   }
 
   if (response.status === 409) {

--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -1,5 +1,6 @@
 export enum NetworkErrorTypes {
   UnauthorizedError = 'UnauthorizedError', // 401
+  ForbiddenError = 'ForbiddenError', // 403
   NotFoundError = 'NotFoundError', // 404
   OrgNameConflictError = 'OrgNameConflictError', // 409
   UnprocessableEntityError = 'UnprocessableEntity', // 422
@@ -12,6 +13,14 @@ export class UnauthorizedError extends Error {
   constructor(message) {
     super(message)
     this.name = 'UnauthorizedError'
+  }
+}
+
+// 403 error
+export class ForbiddenError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'ForbiddenError'
   }
 }
 


### PR DESCRIPTION
Closes #6292 

Pr updates openAPI SHA and updates postOrg call to handle 403 response 

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
