### PR TITLE
chore: fix parallel code ownership of ui repo by ui and aim

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,5 @@
 # Changes to any file in this repo require approval from a member of the InfluxData ui-team
 
-*   @influxdata/ui-team
-*   @influxdata/ecommerce
+*   @influxdata/ui-team @influxdata/ecommerce
 /src/writeData/subscriptions/ @influxdata/data-acquisition
 /src/types/subscriptions.ts @influxdata/data-acquisition


### PR DESCRIPTION
This corrects a syntax issue with #6318. The CODEOWNERS syntax requires teams with parallel code ownership status to be listed on the same line (not subsequent lines - [otherwise the later line takes precedence). ](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-file-location)This is causing ecommerce but not the UI team to be tagged on UI PR approvals.

What we want is this:
![Screen Shot 2022-11-16 at 3 59 03 PM](https://user-images.githubusercontent.com/91283923/202292966-38af4524-6fda-44a1-af92-d85a745ea2ba.png)


### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - NO
