### PR TITLE
fix: skip most flaky tests under old qx-team purview.

### DIFF
--- a/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
+++ b/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
@@ -121,7 +121,7 @@ describe('Flows Copy To Clipboard', () => {
     })
   })
 
-  it('Export to Clipboard as Code', () => {
+  it.skip('Export to Clipboard as Code', () => {
     const query = 'buckets()'
 
     createEmptyNotebook()

--- a/cypress/e2e/shared/fluxQueryBuilder.test.ts
+++ b/cypress/e2e/shared/fluxQueryBuilder.test.ts
@@ -509,7 +509,8 @@ describe('Script Builder', () => {
       })
 
       describe('conditions for divergence:', () => {
-        it('diverges when typing in composition block', () => {
+        // only flakes in OSS. But skip for now, debug later.
+        it.skip('diverges when typing in composition block', () => {
           cy.getByTestID('flux-sync--toggle').should('have.class', 'active')
           cy.getByTestID('flux-editor', {timeout: 30000})
           selectSchema()


### PR DESCRIPTION
In an effort to reduce CI pipeline costs, reviewed the top bad actors under notebooks and qx. 
https://app.circleci.com/insights/github/influxdata/monitor-ci/workflows/build/tests?branch=master

* `will allow querying of different data ranges` --> fixed with PR merged 6 days ago.
* `diverges when typing in composition block` --> Qx. skipped for now (future debugging?)
* `Export to Clipboard as Code` --> Notebooks. Likely to be deprecated. Skipped.


## Checklist
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
