### PR TITLE
chore: remove feature flag `uiSqlSupport`

### DIFF
--- a/src/dataExplorer/components/FluxQueryBuilder.tsx
+++ b/src/dataExplorer/components/FluxQueryBuilder.tsx
@@ -66,7 +66,7 @@ const FluxQueryBuilder: FC = () => {
     setStatus(RemoteDataState.NotStarted)
     setResult(null)
 
-    if (isFlagEnabled('uiSqlSupport') && isIoxOrg) {
+    if (isIoxOrg) {
       history.replace(
         `/orgs/${org.id}/data-explorer/from/script?language=${selectedLanguage}&${SCRIPT_EDITOR_PARAMS}`
       )
@@ -132,7 +132,7 @@ const FluxQueryBuilder: FC = () => {
               justifyContent={JustifyContent.SpaceBetween}
             >
               <div style={{display: 'flex'}}>
-                {isFlagEnabled('uiSqlSupport') && isIoxOrg ? (
+                {isIoxOrg ? (
                   <Dropdown
                     menu={onCollapse => (
                       <Dropdown.Menu onCollapse={onCollapse}>

--- a/src/dataExplorer/components/ResultsPane.tsx
+++ b/src/dataExplorer/components/ResultsPane.tsx
@@ -24,6 +24,7 @@ import {
   Icon,
   ComponentColor,
 } from '@influxdata/clockface'
+import {useSelector} from 'react-redux'
 
 // Contexts
 import {ResultsContext} from 'src/dataExplorer/components/ResultsContext'
@@ -33,6 +34,7 @@ import {
   DEFAULT_FLUX_EDITOR_TEXT,
   DEFAULT_SQL_EDITOR_TEXT,
 } from 'src/dataExplorer/context/persistance'
+import {isOrgIOx} from 'src/organizations/selectors'
 
 // Components
 import Results from 'src/dataExplorer/components/Results'
@@ -119,6 +121,7 @@ const ResultsPane: FC = () => {
     selection,
     resource,
   } = useContext(PersistanceContext)
+  const isIoxOrg = useSelector(isOrgIOx)
   const [csvDownloadCancelID, setCancelId] = useState(null)
   const language = resource?.language ?? LanguageType.FLUX
 
@@ -283,8 +286,7 @@ const ResultsPane: FC = () => {
                   color={ComponentColor.Danger}
                 />
               )}
-              {isFlagEnabled('uiSqlSupport') &&
-              resource?.language === LanguageType.SQL ? null : (
+              {isIoxOrg && resource?.language === LanguageType.SQL ? null : (
                 <NewDatePicker />
               )}
               <SubmitQueryButton

--- a/src/dataExplorer/components/ResultsPane.tsx
+++ b/src/dataExplorer/components/ResultsPane.tsx
@@ -34,7 +34,6 @@ import {
   DEFAULT_FLUX_EDITOR_TEXT,
   DEFAULT_SQL_EDITOR_TEXT,
 } from 'src/dataExplorer/context/persistance'
-import {isOrgIOx} from 'src/organizations/selectors'
 
 // Components
 import Results from 'src/dataExplorer/components/Results'
@@ -48,6 +47,7 @@ import {TimeRange} from 'src/types'
 import {LanguageType} from 'src/dataExplorer/components/resources'
 
 // Utils
+import {isOrgIOx} from 'src/organizations/selectors'
 import {getRangeVariable} from 'src/variables/utils/getTimeRangeVars'
 import {downloadBlob} from 'src/shared/utils/download'
 import {event} from 'src/cloud/utils/reporting'

--- a/src/dataExplorer/components/ResultsPane.tsx
+++ b/src/dataExplorer/components/ResultsPane.tsx
@@ -57,7 +57,6 @@ import {getWindowPeriodVariableFromVariables} from 'src/variables/utils/getWindo
 
 // Constants
 import {TIME_RANGE_START, TIME_RANGE_STOP} from 'src/variables/constants'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 const FluxMonacoEditor = lazy(
   () => import('src/shared/components/FluxMonacoEditor')

--- a/src/dataExplorer/components/SaveAsScript.tsx
+++ b/src/dataExplorer/components/SaveAsScript.tsx
@@ -98,7 +98,7 @@ const SaveAsScript: FC<Props> = ({language, onClose, setOverlayType, type}) => {
     setStatus(RemoteDataState.NotStarted)
     setResult(null)
 
-    if (isFlagEnabled('uiSqlSupport') && isIoxOrg) {
+    if (isIoxOrg) {
       history.replace(
         `/orgs/${org.id}/data-explorer/from/script?language=${language}&${SCRIPT_EDITOR_PARAMS}`
       )

--- a/src/dataExplorer/components/SaveAsScript.tsx
+++ b/src/dataExplorer/components/SaveAsScript.tsx
@@ -31,7 +31,6 @@ import {getOrg, isOrgIOx} from 'src/organizations/selectors'
 import OpenScript from 'src/dataExplorer/components/OpenScript'
 import {DeleteScript} from 'src/dataExplorer/components/DeleteScript'
 import {LanguageType} from 'src/dataExplorer/components/resources'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {SCRIPT_EDITOR_PARAMS} from 'src/dataExplorer/components/resources'
 import CopyToClipboard from 'src/shared/components/CopyToClipboard'
 import {

--- a/src/dataExplorer/components/Sidebar.tsx
+++ b/src/dataExplorer/components/Sidebar.tsx
@@ -1,4 +1,5 @@
 import React, {FC, useContext, useCallback} from 'react'
+import {useSelector} from 'react-redux'
 
 // Components
 import SelectorTitle from 'src/dataExplorer/components/SelectorTitle'
@@ -17,6 +18,7 @@ import {
 import {SidebarContext} from 'src/dataExplorer/context/sidebar'
 import {EditorContext} from 'src/shared/contexts/editor'
 import {PersistanceContext} from 'src/dataExplorer/context/persistance'
+import {isOrgIOx} from 'src/organizations/selectors'
 
 // Types
 import {FluxFunction, FluxToolbarFunction} from 'src/types'
@@ -36,6 +38,7 @@ const Sidebar: FC = () => {
   const {injectFunction} = useContext(EditorContext)
   const {visible, menu, clear} = useContext(SidebarContext)
   const {resource} = useContext(PersistanceContext)
+  const isIoxOrg = useSelector(isOrgIOx)
 
   const inject = useCallback(
     (fn: FluxFunction | FluxToolbarFunction) => {
@@ -117,8 +120,7 @@ const Sidebar: FC = () => {
       justifyContent={JustifyContent.FlexStart}
       className="container-right-side-bar"
     >
-      {isFlagEnabled('uiSqlSupport') &&
-      resource?.language === LanguageType.SQL ? null : (
+      {isIoxOrg && resource?.language === LanguageType.SQL ? null : (
         <>
           {resultOptions}
           {fluxLibrary}

--- a/src/dataExplorer/context/persistance.tsx
+++ b/src/dataExplorer/context/persistance.tsx
@@ -1,4 +1,8 @@
+// Libraries
 import React, {FC, createContext, useCallback} from 'react'
+import {useSelector} from 'react-redux'
+
+// Types
 import {TimeRange, RecursivePartial} from 'src/types'
 import {DEFAULT_TIME_RANGE} from 'src/shared/constants/timeRanges'
 import {useSessionStorage} from 'src/dataExplorer/shared/utils'
@@ -8,6 +12,9 @@ import {
   RESOURCES,
   ResourceConnectedQuery,
 } from 'src/dataExplorer/components/resources'
+
+// Utils
+import {isOrgIOx} from 'src/organizations/selectors'
 
 interface CompositionStatus {
   synced: boolean // true == can modify session's schema
@@ -111,7 +118,7 @@ const DEFAULT_CONTEXT = {
   horizontal: [0.5],
   vertical: [0.25, 0.8],
   range: DEFAULT_TIME_RANGE,
-  query: DEFAULT_FLUX_EDITOR_TEXT,
+  query: '',
   resource: null,
   selection: JSON.parse(JSON.stringify(DEFAULT_SELECTION)),
 
@@ -129,6 +136,8 @@ const DEFAULT_CONTEXT = {
 export const PersistanceContext = createContext<ContextType>(DEFAULT_CONTEXT)
 
 export const PersistanceProvider: FC = ({children}) => {
+  const isIoxOrg = useSelector(isOrgIOx)
+
   const [horizontal, setHorizontal] = useSessionStorage(
     'dataExplorer.resize.horizontal',
     [...DEFAULT_CONTEXT.horizontal]
@@ -143,7 +152,7 @@ export const PersistanceProvider: FC = ({children}) => {
   )
   const [query, setQuery] = useSessionStorage(
     'dataExplorer.query',
-    DEFAULT_CONTEXT.query
+    isIoxOrg ? DEFAULT_SQL_EDITOR_TEXT : DEFAULT_FLUX_EDITOR_TEXT
   )
   const [range, setRange] = useSessionStorage(
     'dataExplorer.range',
@@ -152,7 +161,7 @@ export const PersistanceProvider: FC = ({children}) => {
   const [resource, setResource] = useSessionStorage('dataExplorer.resource', {
     type: 'scripts',
     flux: '',
-    language: LanguageType.FLUX,
+    language: isIoxOrg ? LanguageType.SQL : LanguageType.FLUX,
     data: {},
   })
   const [selection, setSelection] = useSessionStorage(

--- a/src/shared/components/FluxMonacoEditor.tsx
+++ b/src/shared/components/FluxMonacoEditor.tsx
@@ -164,11 +164,9 @@ const FluxEditorMonaco: FC<Props> = ({
             }}
             editorDidMount={editorDidMount}
           />
-          {isFlagEnabled('uiSqlSupport') &&
-            isIoxOrg &&
-            isInFluxQueryBuilder && (
-              <div className="monaco-editor__language">{FLUXLANGID}</div>
-            )}
+          {isIoxOrg && isInFluxQueryBuilder && (
+            <div className="monaco-editor__language">{FLUXLANGID}</div>
+          )}
         </div>
       </ErrorBoundary>
     ),


### PR DESCRIPTION
Part of influxdata/idpe#16468
Close #6314 

Since the feature flag `uiSqlSupport` has been turned on for more than a week and the UI behind this feature flag has been stable, this PR removes this flag and makes SQL support to be enabled by default for IOx customers in UI. After this PR is merged, I'll remove the feature flag from idpe.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
~~- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~~
~~- [ ] Feature flagged, if applicable~~
