### PR TITLE
feat(Identity): use account allowances state to allow org creation

### DIFF
--- a/cypress/e2e/cloud/globalHeaderOrgMenuItems.test.ts
+++ b/cypress/e2e/cloud/globalHeaderOrgMenuItems.test.ts
@@ -29,6 +29,16 @@ describe('FREE: global header menu items test', () => {
     Cypress.Cookies.preserveOnce('sid')
 
     makeQuartzUseIDPEOrgID(idpeOrgID)
+
+    const fixtureName = 'createOrgAllowance'
+    cy.fixture(fixtureName).then(orgCreationAllowances => {
+      cy.intercept(
+        'GET',
+        'api/v2/quartz/allowances/orgs/create',
+        orgCreationAllowances
+      ).as('getAllowancesOrgsCreate')
+    })
+
     cy.visit('/')
   })
 
@@ -66,6 +76,16 @@ describe('PAYG: global header menu items test', () => {
 
   beforeEach(() => {
     makeQuartzUseIDPEOrgID(idpeOrgID, 'pay_as_you_go')
+
+    const fixtureName = 'createOrgAllowancePAYG'
+    cy.fixture(fixtureName).then(orgCreationAllowances => {
+      cy.intercept(
+        'GET',
+        'api/v2/quartz/allowances/orgs/create',
+        orgCreationAllowances
+      ).as('getAllowancesOrgsCreate')
+    })
+
     cy.visit('/')
   })
 
@@ -103,6 +123,16 @@ describe('Contract: global header menu items test', () => {
 
   beforeEach(() => {
     makeQuartzUseIDPEOrgID(idpeOrgID, 'contract')
+
+    const fixtureName = 'createOrgAllowanceContract'
+    cy.fixture(fixtureName).then(orgCreationAllowances => {
+      cy.intercept(
+        'GET',
+        'api/v2/quartz/allowances/orgs/create',
+        orgCreationAllowances
+      ).as('getAllowancesOrgsCreate')
+    })
+
     cy.visit('/')
   })
 

--- a/cypress/e2e/cloud/globalHeaderOrgMenuItems.test.ts
+++ b/cypress/e2e/cloud/globalHeaderOrgMenuItems.test.ts
@@ -4,12 +4,12 @@ const createOrgsFeatureFlags = {
   createDeleteOrgs: true,
 }
 
-const getOrgCreationAllowances = (fixtureName: string) => {
-  cy.fixture(fixtureName).then(orgCreationAllowances => {
+const getOrgCreationAllowance = (fixtureName: string) => {
+  cy.fixture(fixtureName).then(orgCreationAllowance => {
     cy.intercept(
       'GET',
       'api/v2/quartz/allowances/orgs/create',
-      orgCreationAllowances
+      orgCreationAllowance
     ).as('getAllowancesOrgsCreate')
   })
 }
@@ -39,7 +39,7 @@ describe('FREE: global header menu items test', () => {
     Cypress.Cookies.preserveOnce('sid')
 
     makeQuartzUseIDPEOrgID(idpeOrgID)
-    getOrgCreationAllowances('createOrgAllowance')
+    getOrgCreationAllowance('createOrgAllowance')
 
     cy.visit('/')
   })
@@ -78,7 +78,7 @@ describe('PAYG: global header menu items test', () => {
 
   beforeEach(() => {
     makeQuartzUseIDPEOrgID(idpeOrgID, 'pay_as_you_go')
-    getOrgCreationAllowances('createOrgAllowancePAYG')
+    getOrgCreationAllowance('createOrgAllowancePAYG')
 
     cy.visit('/')
   })
@@ -117,7 +117,7 @@ describe('Contract: global header menu items test', () => {
 
   beforeEach(() => {
     makeQuartzUseIDPEOrgID(idpeOrgID, 'contract')
-    getOrgCreationAllowances('createOrgAllowanceContract')
+    getOrgCreationAllowance('createOrgAllowanceContract')
 
     cy.visit('/')
   })

--- a/cypress/e2e/cloud/globalHeaderOrgMenuItems.test.ts
+++ b/cypress/e2e/cloud/globalHeaderOrgMenuItems.test.ts
@@ -4,6 +4,16 @@ const createOrgsFeatureFlags = {
   createDeleteOrgs: true,
 }
 
+const getOrgCreationAllowances = (fixtureName: string) => {
+  cy.fixture(fixtureName).then(orgCreationAllowances => {
+    cy.intercept(
+      'GET',
+      'api/v2/quartz/allowances/orgs/create',
+      orgCreationAllowances
+    ).as('getAllowancesOrgsCreate')
+  })
+}
+
 describe('FREE: global header menu items test', () => {
   let idpeOrgID: string
 
@@ -29,15 +39,7 @@ describe('FREE: global header menu items test', () => {
     Cypress.Cookies.preserveOnce('sid')
 
     makeQuartzUseIDPEOrgID(idpeOrgID)
-
-    const fixtureName = 'createOrgAllowance'
-    cy.fixture(fixtureName).then(orgCreationAllowances => {
-      cy.intercept(
-        'GET',
-        'api/v2/quartz/allowances/orgs/create',
-        orgCreationAllowances
-      ).as('getAllowancesOrgsCreate')
-    })
+    getOrgCreationAllowances('createOrgAllowance')
 
     cy.visit('/')
   })
@@ -76,15 +78,7 @@ describe('PAYG: global header menu items test', () => {
 
   beforeEach(() => {
     makeQuartzUseIDPEOrgID(idpeOrgID, 'pay_as_you_go')
-
-    const fixtureName = 'createOrgAllowancePAYG'
-    cy.fixture(fixtureName).then(orgCreationAllowances => {
-      cy.intercept(
-        'GET',
-        'api/v2/quartz/allowances/orgs/create',
-        orgCreationAllowances
-      ).as('getAllowancesOrgsCreate')
-    })
+    getOrgCreationAllowances('createOrgAllowancePAYG')
 
     cy.visit('/')
   })
@@ -123,15 +117,7 @@ describe('Contract: global header menu items test', () => {
 
   beforeEach(() => {
     makeQuartzUseIDPEOrgID(idpeOrgID, 'contract')
-
-    const fixtureName = 'createOrgAllowanceContract'
-    cy.fixture(fixtureName).then(orgCreationAllowances => {
-      cy.intercept(
-        'GET',
-        'api/v2/quartz/allowances/orgs/create',
-        orgCreationAllowances
-      ).as('getAllowancesOrgsCreate')
-    })
+    getOrgCreationAllowances('createOrgAllowanceContract')
 
     cy.visit('/')
   })

--- a/cypress/fixtures/createOrgAllowance.json
+++ b/cypress/fixtures/createOrgAllowance.json
@@ -1,0 +1,6 @@
+{
+  "orgCreation": {
+    "allowed": false,
+    "availableUpgrade": "pay_as_you_go"
+  }
+}

--- a/cypress/fixtures/createOrgAllowance.json
+++ b/cypress/fixtures/createOrgAllowance.json
@@ -1,6 +1,4 @@
 {
-  "orgCreation": {
-    "allowed": false,
-    "availableUpgrade": "pay_as_you_go"
-  }
+  "allowed": false,
+  "availableUpgrade": "pay_as_you_go"
 }

--- a/cypress/fixtures/createOrgAllowanceContract.json
+++ b/cypress/fixtures/createOrgAllowanceContract.json
@@ -1,0 +1,6 @@
+{
+  "orgCreation": {
+    "allowed": true,
+    "availableUpgrade": "none"
+  }
+}

--- a/cypress/fixtures/createOrgAllowanceContract.json
+++ b/cypress/fixtures/createOrgAllowanceContract.json
@@ -1,6 +1,4 @@
 {
-  "orgCreation": {
-    "allowed": true,
-    "availableUpgrade": "none"
-  }
+  "allowed": true,
+  "availableUpgrade": "none"
 }

--- a/cypress/fixtures/createOrgAllowancePAYG.json
+++ b/cypress/fixtures/createOrgAllowancePAYG.json
@@ -1,0 +1,6 @@
+{
+  "orgCreation": {
+    "allowed": true,
+    "availableUpgrade": "contract"
+  }
+}

--- a/cypress/fixtures/createOrgAllowancePAYG.json
+++ b/cypress/fixtures/createOrgAllowancePAYG.json
@@ -1,6 +1,4 @@
 {
-  "orgCreation": {
-    "allowed": true,
-    "availableUpgrade": "contract"
-  }
+  "allowed": true,
+  "availableUpgrade": "contract"
 }

--- a/cypress/support/Utils.ts
+++ b/cypress/support/Utils.ts
@@ -177,11 +177,14 @@ export const makeQuartzUseIDPEOrgID = (
   })
 
   let fixtureName = 'multiOrgIdentity'
+  let allowanceFixtureName = 'createOrgAllowance'
   if (accountType === 'pay_as_you_go') {
     fixtureName = 'multiOrgIdentityPAYG'
+    allowanceFixtureName = 'createOrgAllowancePAYG'
   }
   if (accountType === 'contract') {
     fixtureName = 'multiOrgIdentityContract'
+    allowanceFixtureName = 'createOrgAllowanceContract'
   }
 
   cy.fixture(fixtureName).then(quartzIdentity => {
@@ -205,5 +208,13 @@ export const makeQuartzUseIDPEOrgID = (
     cy.intercept('GET', 'api/v2/quartz/orgs/*', quartzOrgDetails).as(
       'getQuartzOrgDetails'
     )
+  })
+
+  cy.fixture(allowanceFixtureName).then(orgCreationAllowances => {
+    cy.intercept(
+      'GET',
+      'api/v2/quartz/allowances/orgs/create',
+      orgCreationAllowances
+    ).as('getAllowancesOrgsCreate')
   })
 }

--- a/cypress/support/Utils.ts
+++ b/cypress/support/Utils.ts
@@ -177,14 +177,11 @@ export const makeQuartzUseIDPEOrgID = (
   })
 
   let fixtureName = 'multiOrgIdentity'
-  let allowanceFixtureName = 'createOrgAllowance'
   if (accountType === 'pay_as_you_go') {
     fixtureName = 'multiOrgIdentityPAYG'
-    allowanceFixtureName = 'createOrgAllowancePAYG'
   }
   if (accountType === 'contract') {
     fixtureName = 'multiOrgIdentityContract'
-    allowanceFixtureName = 'createOrgAllowanceContract'
   }
 
   cy.fixture(fixtureName).then(quartzIdentity => {
@@ -208,13 +205,5 @@ export const makeQuartzUseIDPEOrgID = (
     cy.intercept('GET', 'api/v2/quartz/orgs/*', quartzOrgDetails).as(
       'getQuartzOrgDetails'
     )
-  })
-
-  cy.fixture(allowanceFixtureName).then(orgCreationAllowances => {
-    cy.intercept(
-      'GET',
-      'api/v2/quartz/allowances/orgs/create',
-      orgCreationAllowances
-    ).as('getAllowancesOrgsCreate')
   })
 }

--- a/src/identity/allowances/actions/creators/index.ts
+++ b/src/identity/allowances/actions/creators/index.ts
@@ -1,0 +1,21 @@
+// Types
+import {RemoteDataState} from 'src/types'
+
+export const SET_ALLOWANCES = 'SET_ALLOWANCES'
+export const SET_ALLOWANCES_LOADING_STATUS = 'SET_ALLOWANCES_LOADING_STATUS'
+
+export type Actions =
+  | ReturnType<typeof setAllowances>
+  | ReturnType<typeof setAllowancesLoadingStatus>
+
+export const setAllowances = allowances =>
+  ({
+    type: SET_ALLOWANCES,
+    allowances: allowances,
+  } as const)
+
+export const setAllowancesLoadingStatus = (loadingStatus: RemoteDataState) =>
+  ({
+    type: SET_ALLOWANCES_LOADING_STATUS,
+    loadingStatus: loadingStatus,
+  } as const)

--- a/src/identity/allowances/actions/creators/index.ts
+++ b/src/identity/allowances/actions/creators/index.ts
@@ -1,21 +1,24 @@
 // Types
 import {RemoteDataState} from 'src/types'
 
-export const SET_ALLOWANCES = 'SET_ALLOWANCES'
-export const SET_ALLOWANCES_LOADING_STATUS = 'SET_ALLOWANCES_LOADING_STATUS'
+export const SET_ORG_CREATION_ALLOWANCES = 'SET_ORG_CREATION_ALLOWANCES'
+export const SET_ORG_CREATION_ALLOWANCES_STATUS =
+  'SET_ORG_CREATION_ALLOWANCES_STATUS'
 
 export type Actions =
-  | ReturnType<typeof setAllowances>
-  | ReturnType<typeof setAllowancesLoadingStatus>
+  | ReturnType<typeof setOrgCreationAllowances>
+  | ReturnType<typeof setOrgCreationAllowancesStatus>
 
-export const setAllowances = allowances =>
+export const setOrgCreationAllowances = allowances =>
   ({
-    type: SET_ALLOWANCES,
+    type: SET_ORG_CREATION_ALLOWANCES,
     allowances: allowances,
   } as const)
 
-export const setAllowancesLoadingStatus = (loadingStatus: RemoteDataState) =>
+export const setOrgCreationAllowancesStatus = (
+  loadingStatus: RemoteDataState
+) =>
   ({
-    type: SET_ALLOWANCES_LOADING_STATUS,
+    type: SET_ORG_CREATION_ALLOWANCES_STATUS,
     loadingStatus: loadingStatus,
   } as const)

--- a/src/identity/allowances/actions/creators/index.ts
+++ b/src/identity/allowances/actions/creators/index.ts
@@ -1,24 +1,22 @@
 import {OrgCreationAllowance} from 'src/identity/apis/org'
 import {RemoteDataState} from 'src/types'
 
-export const SET_ORG_CREATION_ALLOWANCES = 'SET_ORG_CREATION_ALLOWANCES'
-export const SET_ORG_CREATION_ALLOWANCES_STATUS =
-  'SET_ORG_CREATION_ALLOWANCES_STATUS'
+export const SET_ORG_CREATION_ALLOWANCE = 'SET_ORG_CREATION_ALLOWANCE'
+export const SET_ORG_CREATION_ALLOWANCE_STATUS =
+  'SET_ORG_CREATION_ALLOWANCE_STATUS'
 
-export type Actions =
-  | ReturnType<typeof setOrgCreationAllowances>
-  | ReturnType<typeof setOrgCreationAllowancesStatus>
+export type OrgCreationAllowanceActions =
+  | ReturnType<typeof setOrgCreationAllowance>
+  | ReturnType<typeof setOrgCreationAllowanceStatus>
 
-export const setOrgCreationAllowances = (allowances: OrgCreationAllowance) =>
+export const setOrgCreationAllowance = (allowances: OrgCreationAllowance) =>
   ({
-    type: SET_ORG_CREATION_ALLOWANCES,
+    type: SET_ORG_CREATION_ALLOWANCE,
     allowances: allowances,
   } as const)
 
-export const setOrgCreationAllowancesStatus = (
-  loadingStatus: RemoteDataState
-) =>
+export const setOrgCreationAllowanceStatus = (loadingStatus: RemoteDataState) =>
   ({
-    type: SET_ORG_CREATION_ALLOWANCES_STATUS,
+    type: SET_ORG_CREATION_ALLOWANCE_STATUS,
     loadingStatus: loadingStatus,
   } as const)

--- a/src/identity/allowances/actions/creators/index.ts
+++ b/src/identity/allowances/actions/creators/index.ts
@@ -1,4 +1,4 @@
-// Types
+import {OrgCreationAllowances} from 'src/identity/apis/org'
 import {RemoteDataState} from 'src/types'
 
 export const SET_ORG_CREATION_ALLOWANCES = 'SET_ORG_CREATION_ALLOWANCES'
@@ -9,7 +9,7 @@ export type Actions =
   | ReturnType<typeof setOrgCreationAllowances>
   | ReturnType<typeof setOrgCreationAllowancesStatus>
 
-export const setOrgCreationAllowances = allowances =>
+export const setOrgCreationAllowances = (allowances: OrgCreationAllowances) =>
   ({
     type: SET_ORG_CREATION_ALLOWANCES,
     allowances: allowances,

--- a/src/identity/allowances/actions/creators/index.ts
+++ b/src/identity/allowances/actions/creators/index.ts
@@ -1,4 +1,4 @@
-import {OrgCreationAllowances} from 'src/identity/apis/org'
+import {OrgCreationAllowance} from 'src/identity/apis/org'
 import {RemoteDataState} from 'src/types'
 
 export const SET_ORG_CREATION_ALLOWANCES = 'SET_ORG_CREATION_ALLOWANCES'
@@ -9,7 +9,7 @@ export type Actions =
   | ReturnType<typeof setOrgCreationAllowances>
   | ReturnType<typeof setOrgCreationAllowancesStatus>
 
-export const setOrgCreationAllowances = (allowances: OrgCreationAllowances) =>
+export const setOrgCreationAllowances = (allowances: OrgCreationAllowance) =>
   ({
     type: SET_ORG_CREATION_ALLOWANCES,
     allowances: allowances,

--- a/src/identity/allowances/actions/thunks/index.ts
+++ b/src/identity/allowances/actions/thunks/index.ts
@@ -32,7 +32,7 @@ export const getOrgCreationAllowancesThunk =
     } catch (error) {
       reportErrorThroughHoneyBadger(error, {
         name: 'Failed to fetch org creation Allowances',
-        context: {state: getState()},
+        context: {state: getState().identity},
       })
     }
   }

--- a/src/identity/allowances/actions/thunks/index.ts
+++ b/src/identity/allowances/actions/thunks/index.ts
@@ -3,9 +3,9 @@ import {Dispatch} from 'react'
 
 // Actions
 import {
-  Actions as OrgCreationAllowancesActions,
-  setOrgCreationAllowances,
-  setOrgCreationAllowancesStatus,
+  OrgCreationAllowanceActions,
+  setOrgCreationAllowance,
+  setOrgCreationAllowanceStatus,
 } from 'src/identity/allowances/actions/creators'
 
 // API
@@ -17,21 +17,23 @@ import {GetState, RemoteDataState} from 'src/types'
 // Utils
 import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
 
-type Actions = OrgCreationAllowancesActions
-
 export const getOrgCreationAllowancesThunk =
-  () => async (dispatch: Dispatch<Actions>, getState: GetState) => {
+  () =>
+  async (
+    dispatch: Dispatch<OrgCreationAllowanceActions>,
+    getState: GetState
+  ) => {
     try {
-      dispatch(setOrgCreationAllowancesStatus(RemoteDataState.Loading))
+      dispatch(setOrgCreationAllowanceStatus(RemoteDataState.Loading))
 
       const allowances = await fetchOrgCreationAllowance()
 
-      dispatch(setOrgCreationAllowances(allowances))
+      dispatch(setOrgCreationAllowance(allowances))
 
-      dispatch(setOrgCreationAllowancesStatus(RemoteDataState.Done))
+      dispatch(setOrgCreationAllowanceStatus(RemoteDataState.Done))
     } catch (error) {
       reportErrorThroughHoneyBadger(error, {
-        name: 'Failed to fetch org creation Allowances',
+        name: 'Failed to fetch org creation allowance',
         context: {state: getState().identity},
       })
     }

--- a/src/identity/allowances/actions/thunks/index.ts
+++ b/src/identity/allowances/actions/thunks/index.ts
@@ -3,9 +3,9 @@ import {Dispatch} from 'react'
 
 // Actions
 import {
-  Actions as AllowancesActions,
-  setAllowances,
-  setAllowancesLoadingStatus,
+  Actions as OrgCreationAllowancesActions,
+  setOrgCreationAllowances,
+  setOrgCreationAllowancesStatus,
 } from 'src/identity/allowances/actions/creators'
 
 // API
@@ -17,18 +17,18 @@ import {GetState, RemoteDataState} from 'src/types'
 // Utils
 import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
 
-type Actions = AllowancesActions
+type Actions = OrgCreationAllowancesActions
 
-export const getAllowancesThunk =
+export const getOrgCreationAllowancesThunk =
   () => async (dispatch: Dispatch<Actions>, getState: GetState) => {
     try {
-      dispatch(setAllowancesLoadingStatus(RemoteDataState.Loading))
+      dispatch(setOrgCreationAllowancesStatus(RemoteDataState.Loading))
 
       const allowances = await fetchOrgCreationAllowance()
 
-      dispatch(setAllowances(allowances))
+      dispatch(setOrgCreationAllowances(allowances))
 
-      dispatch(setAllowancesLoadingStatus(RemoteDataState.Done))
+      dispatch(setOrgCreationAllowancesStatus(RemoteDataState.Done))
     } catch (error) {
       reportErrorThroughHoneyBadger(error, {
         name: 'Failed to fetch org creation Allowances',

--- a/src/identity/allowances/actions/thunks/index.ts
+++ b/src/identity/allowances/actions/thunks/index.ts
@@ -1,0 +1,38 @@
+// Libraries
+import {Dispatch} from 'react'
+
+// Actions
+import {
+  Actions as AllowancesActions,
+  setAllowances,
+  setAllowancesLoadingStatus,
+} from 'src/identity/allowances/actions/creators'
+
+// API
+import {fetchOrgCreationAllowance} from 'src/identity/apis/org'
+
+// Types
+import {GetState, RemoteDataState} from 'src/types'
+
+// Utils
+import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
+
+type Actions = AllowancesActions
+
+export const getAllowancesThunk =
+  () => async (dispatch: Dispatch<Actions>, getState: GetState) => {
+    try {
+      dispatch(setAllowancesLoadingStatus(RemoteDataState.Loading))
+
+      const allowances = await fetchOrgCreationAllowance()
+
+      dispatch(setAllowances(allowances))
+
+      dispatch(setAllowancesLoadingStatus(RemoteDataState.Done))
+    } catch (error) {
+      reportErrorThroughHoneyBadger(error, {
+        name: 'Failed to fetch org creation Allowances',
+        context: {state: getState()},
+      })
+    }
+  }

--- a/src/identity/allowances/reducers/index.ts
+++ b/src/identity/allowances/reducers/index.ts
@@ -1,0 +1,38 @@
+// Libraries
+import produce from 'immer'
+
+// Actions
+import {
+  Actions,
+  SET_ALLOWANCES,
+  SET_ALLOWANCES_LOADING_STATUS,
+} from 'src/identity/allowances/actions/creators'
+
+// Types
+import {RemoteDataState} from 'src/types'
+
+export const initialState = {
+  orgCreation: {
+    allowed: false,
+    availableUpgrade: 'none',
+    loadingStatus: RemoteDataState.NotStarted,
+  },
+}
+
+export default (state = initialState, action: Actions) =>
+  produce(state, draftState => {
+    switch (action.type) {
+      case SET_ALLOWANCES: {
+        const {allowed, availableUpgrade} = action.allowances
+
+        draftState.orgCreation.allowed = allowed
+        draftState.orgCreation.availableUpgrade = availableUpgrade
+        return
+      }
+
+      case SET_ALLOWANCES_LOADING_STATUS: {
+        draftState.orgCreation.loadingStatus = action.loadingStatus
+        return
+      }
+    }
+  })

--- a/src/identity/allowances/reducers/index.ts
+++ b/src/identity/allowances/reducers/index.ts
@@ -3,15 +3,23 @@ import produce from 'immer'
 
 // Actions
 import {
-  Actions,
-  SET_ORG_CREATION_ALLOWANCES,
-  SET_ORG_CREATION_ALLOWANCES_STATUS,
+  OrgCreationAllowanceActions,
+  SET_ORG_CREATION_ALLOWANCE,
+  SET_ORG_CREATION_ALLOWANCE_STATUS,
 } from 'src/identity/allowances/actions/creators'
 
 // Types
+import {OrgCreationAllowance} from 'src/identity/apis/org'
 import {RemoteDataState} from 'src/types'
 
-export const initialState = {
+interface AllowanceState {
+  orgCreation: OrgCreationAllowanceState
+}
+export interface OrgCreationAllowanceState extends OrgCreationAllowance {
+  loadingStatus: RemoteDataState
+}
+
+export const initialState: AllowanceState = {
   orgCreation: {
     allowed: false,
     availableUpgrade: 'none',
@@ -19,10 +27,10 @@ export const initialState = {
   },
 }
 
-export default (state = initialState, action: Actions) =>
+export default (state = initialState, action: OrgCreationAllowanceActions) =>
   produce(state, draftState => {
     switch (action.type) {
-      case SET_ORG_CREATION_ALLOWANCES: {
+      case SET_ORG_CREATION_ALLOWANCE: {
         const {allowed, availableUpgrade} = action.allowances
 
         draftState.orgCreation.allowed = allowed
@@ -30,7 +38,7 @@ export default (state = initialState, action: Actions) =>
         return
       }
 
-      case SET_ORG_CREATION_ALLOWANCES_STATUS: {
+      case SET_ORG_CREATION_ALLOWANCE_STATUS: {
         draftState.orgCreation.loadingStatus = action.loadingStatus
         return
       }

--- a/src/identity/allowances/reducers/index.ts
+++ b/src/identity/allowances/reducers/index.ts
@@ -4,8 +4,8 @@ import produce from 'immer'
 // Actions
 import {
   Actions,
-  SET_ALLOWANCES,
-  SET_ALLOWANCES_LOADING_STATUS,
+  SET_ORG_CREATION_ALLOWANCES,
+  SET_ORG_CREATION_ALLOWANCES_STATUS,
 } from 'src/identity/allowances/actions/creators'
 
 // Types
@@ -22,7 +22,7 @@ export const initialState = {
 export default (state = initialState, action: Actions) =>
   produce(state, draftState => {
     switch (action.type) {
-      case SET_ALLOWANCES: {
+      case SET_ORG_CREATION_ALLOWANCES: {
         const {allowed, availableUpgrade} = action.allowances
 
         draftState.orgCreation.allowed = allowed
@@ -30,7 +30,7 @@ export default (state = initialState, action: Actions) =>
         return
       }
 
-      case SET_ALLOWANCES_LOADING_STATUS: {
+      case SET_ORG_CREATION_ALLOWANCES_STATUS: {
         draftState.orgCreation.loadingStatus = action.loadingStatus
         return
       }

--- a/src/identity/apis/auth.ts
+++ b/src/identity/apis/auth.ts
@@ -11,14 +11,14 @@ import {Error as IdpeError, UserResponse as UserResponseIdpe} from 'src/client'
 import {ServerError, UnauthorizedError} from 'src/types/error'
 import {CurrentAccount} from 'src/identity/apis/account'
 import {
-  orgCreationAllowances,
   CurrentOrg,
+  OrgCreationAllowances,
   QuartzOrganizations,
 } from 'src/identity/apis/org'
 
 export interface IdentityState {
   allowances: {
-    orgCreation: orgCreationAllowances
+    orgCreation: OrgCreationAllowances
   }
   currentIdentity: CurrentIdentity
   quartzOrganizations: QuartzOrganizations

--- a/src/identity/apis/auth.ts
+++ b/src/identity/apis/auth.ts
@@ -10,13 +10,19 @@ import {RemoteDataState} from 'src/types'
 import {Error as IdpeError, UserResponse as UserResponseIdpe} from 'src/client'
 import {ServerError, UnauthorizedError} from 'src/types/error'
 import {CurrentAccount} from 'src/identity/apis/account'
-import {CurrentOrg, QuartzOrganizations} from 'src/identity/apis/org'
+import {
+  creatOrgAllowances,
+  CurrentOrg,
+  QuartzOrganizations,
+} from 'src/identity/apis/org'
 
 export interface IdentityState {
+  allowances: {
+    orgCreation: creatOrgAllowances
+  }
   currentIdentity: CurrentIdentity
   quartzOrganizations: QuartzOrganizations
 }
-
 export interface IdentityLoadingStatus {
   identityStatus: RemoteDataState
   billingStatus: RemoteDataState

--- a/src/identity/apis/auth.ts
+++ b/src/identity/apis/auth.ts
@@ -7,18 +7,15 @@ import {CLOUD} from 'src/shared/constants'
 
 // Types
 import {RemoteDataState} from 'src/types'
+import {OrgCreationAllowanceState} from 'src/identity/allowances/reducers'
 import {Error as IdpeError, UserResponse as UserResponseIdpe} from 'src/client'
 import {ServerError, UnauthorizedError} from 'src/types/error'
 import {CurrentAccount} from 'src/identity/apis/account'
-import {
-  CurrentOrg,
-  OrgCreationAllowances,
-  QuartzOrganizations,
-} from 'src/identity/apis/org'
+import {CurrentOrg, QuartzOrganizations} from 'src/identity/apis/org'
 
 export interface IdentityState {
   allowances: {
-    orgCreation: OrgCreationAllowances
+    orgCreation: OrgCreationAllowanceState
   }
   currentIdentity: CurrentIdentity
   quartzOrganizations: QuartzOrganizations

--- a/src/identity/apis/auth.ts
+++ b/src/identity/apis/auth.ts
@@ -11,14 +11,14 @@ import {Error as IdpeError, UserResponse as UserResponseIdpe} from 'src/client'
 import {ServerError, UnauthorizedError} from 'src/types/error'
 import {CurrentAccount} from 'src/identity/apis/account'
 import {
-  creatOrgAllowances,
+  orgCreationAllowances,
   CurrentOrg,
   QuartzOrganizations,
 } from 'src/identity/apis/org'
 
 export interface IdentityState {
   allowances: {
-    orgCreation: creatOrgAllowances
+    orgCreation: orgCreationAllowances
   }
   currentIdentity: CurrentIdentity
   quartzOrganizations: QuartzOrganizations

--- a/src/identity/apis/org.ts
+++ b/src/identity/apis/org.ts
@@ -50,7 +50,7 @@ export type QuartzOrganizations = {
   status?: RemoteDataState
 }
 
-export interface orgCreationAllowances {
+export interface OrgCreationAllowances {
   allowed: boolean
   availableUpgrade: string
   loadingStatus?: RemoteDataState
@@ -139,7 +139,7 @@ export const fetchDefaultAccountDefaultOrg = async (): Promise<
 
 // fetch data regarding whether the user can create new orgs, and associated upgrade options.
 export const fetchOrgCreationAllowance =
-  async (): Promise<orgCreationAllowances> => {
+  async (): Promise<OrgCreationAllowances> => {
     const response = await getAllowancesOrgsCreate({})
 
     if (response.status !== 200) {

--- a/src/identity/apis/org.ts
+++ b/src/identity/apis/org.ts
@@ -50,6 +50,12 @@ export type QuartzOrganizations = {
   status?: RemoteDataState
 }
 
+export interface creatOrgAllowances {
+  allowed: boolean
+  availableUpgrade: string
+  loadingStatus?: RemoteDataState
+}
+
 // create a new organization
 export const createNewOrg = async (
   organizationCreateRequest: OrganizationCreateRequest
@@ -132,17 +138,18 @@ export const fetchDefaultAccountDefaultOrg = async (): Promise<
 }
 
 // fetch data regarding whether the user can create new orgs, and associated upgrade options.
-export const fetchOrgCreationAllowance = async () => {
-  const response = await getAllowancesOrgsCreate({})
+export const fetchOrgCreationAllowance =
+  async (): Promise<creatOrgAllowances> => {
+    const response = await getAllowancesOrgsCreate({})
 
-  if (response.status !== 200) {
-    throw new GenericError(
-      'Failed to determine whether this user can create a new organization.'
-    )
+    if (response.status !== 200) {
+      throw new GenericError(
+        'Failed to determine whether this user can create a new organization.'
+      )
+    }
+
+    return response.data
   }
-
-  return response.data
-}
 
 // fetch the list of organizations associated with a given account ID
 export const fetchOrgsByAccountID = async (

--- a/src/identity/apis/org.ts
+++ b/src/identity/apis/org.ts
@@ -39,6 +39,7 @@ export interface OrgCreationAllowance {
   allowed: boolean
   availableUpgrade: 'contract' | 'none' | 'pay_as_you_go'
 }
+
 export interface QuartzOrganization {
   id: string
   name: string

--- a/src/identity/apis/org.ts
+++ b/src/identity/apis/org.ts
@@ -50,7 +50,7 @@ export type QuartzOrganizations = {
   status?: RemoteDataState
 }
 
-export interface creatOrgAllowances {
+export interface orgCreationAllowances {
   allowed: boolean
   availableUpgrade: string
   loadingStatus?: RemoteDataState
@@ -139,7 +139,7 @@ export const fetchDefaultAccountDefaultOrg = async (): Promise<
 
 // fetch data regarding whether the user can create new orgs, and associated upgrade options.
 export const fetchOrgCreationAllowance =
-  async (): Promise<creatOrgAllowances> => {
+  async (): Promise<orgCreationAllowances> => {
     const response = await getAllowancesOrgsCreate({})
 
     if (response.status !== 200) {

--- a/src/identity/apis/org.ts
+++ b/src/identity/apis/org.ts
@@ -35,6 +35,10 @@ export interface CurrentOrg {
   regionName?: string
 }
 
+export interface OrgCreationAllowance {
+  allowed: boolean
+  availableUpgrade: 'contract' | 'none' | 'pay_as_you_go'
+}
 export interface QuartzOrganization {
   id: string
   name: string
@@ -48,12 +52,6 @@ export interface QuartzOrganization {
 export type QuartzOrganizations = {
   orgs: OrganizationSummaries
   status?: RemoteDataState
-}
-
-export interface OrgCreationAllowances {
-  allowed: boolean
-  availableUpgrade: string
-  loadingStatus?: RemoteDataState
 }
 
 // create a new organization
@@ -139,7 +137,7 @@ export const fetchDefaultAccountDefaultOrg = async (): Promise<
 
 // fetch data regarding whether the user can create new orgs, and associated upgrade options.
 export const fetchOrgCreationAllowance =
-  async (): Promise<OrgCreationAllowances> => {
+  async (): Promise<OrgCreationAllowance> => {
     const response = await getAllowancesOrgsCreate({})
 
     if (response.status !== 200) {

--- a/src/identity/components/GlobalHeader/OrgDropdown.tsx
+++ b/src/identity/components/GlobalHeader/OrgDropdown.tsx
@@ -1,9 +1,9 @@
 // Libraries
 import React, {FC, useEffect} from 'react'
 import {useDispatch, useSelector} from 'react-redux'
-import {IconFont, RemoteDataState} from '@influxdata/clockface'
 
 // Components
+import {IconFont, RemoteDataState} from '@influxdata/clockface'
 import {
   GlobalHeaderDropdown,
   MainMenuItem,
@@ -33,8 +33,9 @@ import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Selectors
 import {
-  selectOrgCreationAllowances,
+  selectOrgCreationAllowance,
   selectOrgCreationAllowancesStatus,
+  selectOrgCreationAvailableUpgrade,
 } from 'src/identity/selectors'
 import {CreateOrganizationMenuItem} from 'src/identity/components/GlobalHeader/GlobalHeaderDropdown/CreateOrganization/MenuItem'
 
@@ -49,18 +50,19 @@ const menuStyle = {width: '250px', padding: '16px'}
 const orgDropdownStyle = {width: 'auto'}
 
 export const OrgDropdown: FC<Props> = ({activeOrg, orgsList}) => {
-  const orgCreationAllowances = useSelector(selectOrgCreationAllowances)
-  const orgCreationAllowanceStatus = useSelector(
+  const orgCreationAllowed = useSelector(selectOrgCreationAllowance)
+  const availableUpgrade = useSelector(selectOrgCreationAvailableUpgrade)
+  const orgCreationAllowancesStatus = useSelector(
     selectOrgCreationAllowancesStatus
   )
 
   const dispatch = useDispatch()
 
   useEffect(() => {
-    if (orgCreationAllowanceStatus === RemoteDataState.NotStarted) {
+    if (orgCreationAllowancesStatus === RemoteDataState.NotStarted) {
       dispatch(getOrgCreationAllowancesThunk())
     }
-  }, [dispatch, orgCreationAllowanceStatus])
+  }, [dispatch, orgCreationAllowancesStatus])
 
   const switchOrg = (org: TypeAheadMenuItem) => {
     event(HeaderNavEvent.OrgSwitch, multiOrgTag, {
@@ -92,8 +94,8 @@ export const OrgDropdown: FC<Props> = ({activeOrg, orgsList}) => {
 
   if (
     isFlagEnabled('createDeleteOrgs') &&
-    !orgCreationAllowances.allowed &&
-    orgCreationAllowances.availableUpgrade !== 'none'
+    !orgCreationAllowed &&
+    availableUpgrade !== 'none'
   ) {
     orgMainMenu.push({
       name: 'Add More Organizations',
@@ -109,7 +111,7 @@ export const OrgDropdown: FC<Props> = ({activeOrg, orgsList}) => {
   }
 
   const additionalHeaderItems = []
-  if (isFlagEnabled('createDeleteOrgs') && orgCreationAllowances.allowed) {
+  if (isFlagEnabled('createDeleteOrgs') && orgCreationAllowed) {
     additionalHeaderItems.push(
       <CreateOrganizationMenuItem key="CreateOrgMenuItem" />
     )

--- a/src/identity/components/GlobalHeader/OrgDropdown.tsx
+++ b/src/identity/components/GlobalHeader/OrgDropdown.tsx
@@ -59,7 +59,10 @@ export const OrgDropdown: FC<Props> = ({activeOrg, orgsList}) => {
   const dispatch = useDispatch()
 
   useEffect(() => {
-    if (orgCreationAllowancesStatus === RemoteDataState.NotStarted) {
+    if (
+      isFlagEnabled('createDeleteOrgs') &&
+      orgCreationAllowancesStatus === RemoteDataState.NotStarted
+    ) {
       dispatch(getOrgCreationAllowancesThunk())
     }
   }, [dispatch, orgCreationAllowancesStatus])

--- a/src/identity/components/GlobalHeader/OrgDropdown.tsx
+++ b/src/identity/components/GlobalHeader/OrgDropdown.tsx
@@ -34,7 +34,7 @@ import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 // Selectors
 import {
   selectOrgCreationAllowance,
-  selectOrgCreationAllowancesStatus,
+  selectOrgCreationAllowanceStatus,
   selectOrgCreationAvailableUpgrade,
 } from 'src/identity/selectors'
 import {CreateOrganizationMenuItem} from 'src/identity/components/GlobalHeader/GlobalHeaderDropdown/CreateOrganization/MenuItem'
@@ -52,8 +52,8 @@ const orgDropdownStyle = {width: 'auto'}
 export const OrgDropdown: FC<Props> = ({activeOrg, orgsList}) => {
   const orgCreationAllowed = useSelector(selectOrgCreationAllowance)
   const availableUpgrade = useSelector(selectOrgCreationAvailableUpgrade)
-  const orgCreationAllowancesStatus = useSelector(
-    selectOrgCreationAllowancesStatus
+  const orgCreationAllowanceStatus = useSelector(
+    selectOrgCreationAllowanceStatus
   )
 
   const dispatch = useDispatch()
@@ -61,11 +61,11 @@ export const OrgDropdown: FC<Props> = ({activeOrg, orgsList}) => {
   useEffect(() => {
     if (
       isFlagEnabled('createDeleteOrgs') &&
-      orgCreationAllowancesStatus === RemoteDataState.NotStarted
+      orgCreationAllowanceStatus === RemoteDataState.NotStarted
     ) {
       dispatch(getOrgCreationAllowancesThunk())
     }
-  }, [dispatch, orgCreationAllowancesStatus])
+  }, [dispatch, orgCreationAllowanceStatus])
 
   const switchOrg = (org: TypeAheadMenuItem) => {
     event(HeaderNavEvent.OrgSwitch, multiOrgTag, {

--- a/src/identity/selectors/index.ts
+++ b/src/identity/selectors/index.ts
@@ -65,10 +65,16 @@ export const selectQuartzOrgsStatus = (
   return state.identity.quartzOrganizations.status
 }
 
-export const selectOrgCreationAllowances = (
+export const selectOrgCreationAllowance = (
   state: AppState
-): AppState['identity']['allowances']['orgCreation'] => {
-  return state.identity.allowances.orgCreation
+): AppState['identity']['allowances']['orgCreation']['allowed'] => {
+  return state.identity.allowances.orgCreation.allowed
+}
+
+export const selectOrgCreationAvailableUpgrade = (
+  state: AppState
+): AppState['identity']['allowances']['orgCreation']['availableUpgrade'] => {
+  return state.identity.allowances.orgCreation.availableUpgrade
 }
 
 export const selectOrgCreationAllowancesStatus = (

--- a/src/identity/selectors/index.ts
+++ b/src/identity/selectors/index.ts
@@ -36,6 +36,22 @@ export const selectOperatorRole = (
   return state.identity.currentIdentity.user.operatorRole
 }
 
+export const selectOrgCreationAllowance = (
+  state: AppState
+): AppState['identity']['allowances']['orgCreation']['allowed'] => {
+  return state.identity.allowances.orgCreation.allowed
+}
+
+export const selectOrgCreationAllowanceStatus = (
+  state: AppState
+): RemoteDataState => state.identity.allowances.orgCreation.loadingStatus
+
+export const selectOrgCreationAvailableUpgrade = (
+  state: AppState
+): AppState['identity']['allowances']['orgCreation']['availableUpgrade'] => {
+  return state.identity.allowances.orgCreation.availableUpgrade
+}
+
 export const selectQuartzIdentityStatus = (state: AppState): RemoteDataState =>
   state.identity.currentIdentity.loadingStatus.identityStatus
 
@@ -64,19 +80,3 @@ export const selectQuartzOrgsStatus = (
 ): AppState['identity']['quartzOrganizations']['status'] => {
   return state.identity.quartzOrganizations.status
 }
-
-export const selectOrgCreationAllowance = (
-  state: AppState
-): AppState['identity']['allowances']['orgCreation']['allowed'] => {
-  return state.identity.allowances.orgCreation.allowed
-}
-
-export const selectOrgCreationAvailableUpgrade = (
-  state: AppState
-): AppState['identity']['allowances']['orgCreation']['availableUpgrade'] => {
-  return state.identity.allowances.orgCreation.availableUpgrade
-}
-
-export const selectOrgCreationAllowancesStatus = (
-  state: AppState
-): RemoteDataState => state.identity.allowances.orgCreation.loadingStatus

--- a/src/identity/selectors/index.ts
+++ b/src/identity/selectors/index.ts
@@ -64,3 +64,13 @@ export const selectQuartzOrgsStatus = (
 ): AppState['identity']['quartzOrganizations']['status'] => {
   return state.identity.quartzOrganizations.status
 }
+
+export const selectOrgCreationAllowances = (
+  state: AppState
+): AppState['identity']['allowances']['orgCreation'] => {
+  return state.identity.allowances.orgCreation
+}
+
+export const selectOrgCreationAllowancesStatus = (
+  state: AppState
+): RemoteDataState => state.identity.allowances.orgCreation.loadingStatus

--- a/src/store/configureStore.ts
+++ b/src/store/configureStore.ts
@@ -60,6 +60,7 @@ import {
 import alertBuilderReducer from 'src/alerting/reducers/alertBuilder'
 import perfReducer from 'src/perf/reducers'
 import quartzOrganizationReducer from 'src/identity/quartzOrganizations/reducers'
+import allowanceReducer from 'src/identity/allowances/reducers'
 
 // Types
 import {AppState, LocalStorage} from 'src/types'
@@ -92,6 +93,7 @@ export const rootReducer = (history: History) => (state, action) => {
     identity: combineReducers({
       currentIdentity: identityReducer,
       quartzOrganizations: quartzOrganizationReducer,
+      allowances: allowanceReducer,
     }),
     flags: flagReducer,
     noteEditor: noteEditorReducer,

--- a/src/store/configureStore.ts
+++ b/src/store/configureStore.ts
@@ -60,7 +60,7 @@ import {
 import alertBuilderReducer from 'src/alerting/reducers/alertBuilder'
 import perfReducer from 'src/perf/reducers'
 import quartzOrganizationReducer from 'src/identity/quartzOrganizations/reducers'
-import allowanceReducer from 'src/identity/allowances/reducers'
+import orgCreationAllowancesReducer from 'src/identity/allowances/reducers'
 
 // Types
 import {AppState, LocalStorage} from 'src/types'
@@ -93,7 +93,7 @@ export const rootReducer = (history: History) => (state, action) => {
     identity: combineReducers({
       currentIdentity: identityReducer,
       quartzOrganizations: quartzOrganizationReducer,
-      allowances: allowanceReducer,
+      allowances: orgCreationAllowancesReducer,
     }),
     flags: flagReducer,
     noteEditor: noteEditorReducer,


### PR DESCRIPTION
Closes #6224 

Pr adds org creation allowance property to the Identity state in redux and uses `state.identity.allowances.orgCreation` to determine whether the user can create organizations.
Pr also refactors code to replace use of `accountType` with  `state.identity.allowances.orgCreation` to determine whether the Upgrade button should be shown in the global header. 

behind `createDeleteOrgs` feature flag
https://user-images.githubusercontent.com/66275100/202481864-032d0b98-a36f-44fe-9485-eb45ec23821d.mov

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
