### PR TITLE
fix: java pojo api error code example

### DIFF
--- a/src/writeData/clients/Java/write.2.example
+++ b/src/writeData/clients/Java/write.2.example
@@ -4,7 +4,7 @@ mem.used_percent = 23.43234543;
 mem.time = Instant.now();
 
 WriteApiBlocking writeApi = client.getWriteApiBlocking();
-writeApi.writeRecord(bucket, org, WritePrecision.NS, mem);
+writeApi.writeMeasurement(bucket, org, WritePrecision.NS, mem);
 
 
 


### PR DESCRIPTION

java pojo api error code example

‘writeMeasurement’ should be used, rather than use ‘writeRecord’

<img width="1104" alt="image" src="https://user-images.githubusercontent.com/27751972/202610860-d26957b0-592f-44fd-82d7-e569ce3891dd.png">
<img width="1057" alt="image" src="https://user-images.githubusercontent.com/27751972/202610963-d7188c1d-bbf6-483b-ad3b-c4d72e2f8abb.png">
<img width="1012" alt="image" src="https://user-images.githubusercontent.com/27751972/202611032-16b15932-1372-4cd9-afb3-f36670b7eed1.png">

