### PR TITLE
feat: on creating last org in account, user gets an upgrade notification

### DIFF
--- a/src/identity/allowances/actions/thunks/index.ts
+++ b/src/identity/allowances/actions/thunks/index.ts
@@ -31,10 +31,13 @@ export const getOrgCreationAllowancesThunk =
       dispatch(setOrgCreationAllowance(allowances))
 
       dispatch(setOrgCreationAllowanceStatus(RemoteDataState.Done))
+
+      return allowances.allowed
     } catch (error) {
       reportErrorThroughHoneyBadger(error, {
         name: 'Failed to fetch org creation allowance',
         context: {state: getState().identity},
       })
+      return false
     }
   }

--- a/src/identity/components/GlobalHeader/GlobalHeaderDropdown/CreateOrganization/CreateOrgInput.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeaderDropdown/CreateOrganization/CreateOrgInput.tsx
@@ -1,4 +1,4 @@
-import React, {FC, useState} from 'react'
+import React, {FC} from 'react'
 import {
   ComponentSize,
   ComponentStatus,
@@ -25,12 +25,7 @@ export const CreateOrgInput: FC<Props> = ({
   orgName,
   validationMsg,
 }) => {
-  const [userTouchedFormInput, setUserTouchedFormInput] = useState(false)
-
   const handleInputChange = (evt: React.ChangeEvent<HTMLInputElement>) => {
-    if (!userTouchedFormInput) {
-      setUserTouchedFormInput(true)
-    }
     handleValidateOrgName(evt.target.value)
   }
 

--- a/src/shared/copy/notifications/categories/accounts-users-orgs.ts
+++ b/src/shared/copy/notifications/categories/accounts-users-orgs.ts
@@ -1,8 +1,17 @@
-import {Notification} from 'src/types'
+// Libraries
+import {IconFont} from '@influxdata/clockface'
+
+// Constants
+import {FIFTEEN_SECONDS} from 'src/shared/constants'
+
+// Notifications
 import {
   defaultErrorNotification,
   defaultSuccessNotification,
 } from 'src/shared/copy/notifications'
+
+// Types
+import {Notification, NotificationStyle} from 'src/types'
 
 export const accountDefaultSettingError = (
   accountName: string
@@ -99,6 +108,15 @@ export const orgEditFailed = (): Notification => ({
 export const orgEditSuccess = (): Notification => ({
   ...defaultSuccessNotification,
   message: 'Organization was successfully updated',
+})
+
+export const orgQuotaReached = (): Notification => ({
+  ...defaultSuccessNotification,
+  style: NotificationStyle.Primary,
+  styles: {maxWidth: '360px'},
+  icon: IconFont.Info_New,
+  duration: FIFTEEN_SECONDS,
+  message: `You've reached the organization quota for this account. Upgrade to add more organizations.`,
 })
 
 export const orgRenameFailed = (orgName): Notification => ({


### PR DESCRIPTION
Closes #6267 

This PR adds a notification and associated business logic so that, after a user creates a new org, the allowances endpoint is re-queried. If the response indicates no more orgs can be created in the account, it sends the user a notification indicating that they have hit their organization quota. Design is per [this figma].(https://www.figma.com/file/fvVSKwnepmRWvzFlIxCWCe/Multi-org?node-id=1961%3A18041&t=5XorbJgkM9q43DnN-0).

https://user-images.githubusercontent.com/91283923/203148438-4e562358-7126-44de-8845-b8267eab80ed.mov



### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - `createDeleteOrgs`
