### PR TITLE
fix: only one /accounts call on app load

### DIFF
--- a/src/accounts/context/userAccount.tsx
+++ b/src/accounts/context/userAccount.tsx
@@ -91,7 +91,6 @@ export const UserAccountProvider: FC<Props> = React.memo(({children}) => {
         setDefaultAccountId(defaultId)
       }
 
-      // isActive: true is for the currently logged in/active account
       const activeAcct = accounts.find(acct => acct.isActive === true)
       if (typeof activeAcct === 'object' && activeAcct.hasOwnProperty('id')) {
         const activeId = activeAcct.id
@@ -111,7 +110,19 @@ export const UserAccountProvider: FC<Props> = React.memo(({children}) => {
     const accountName = getAccountNameById(newDefaultAcctId)
 
     try {
+      const oldDefaultAcctId = defaultAccountId
+
       await updateDefaultQuartzAccount(newDefaultAcctId)
+
+      userAccounts.forEach(account => {
+        if (account.id === oldDefaultAcctId) {
+          account.isDefault = false
+        }
+        if (account.id === newDefaultAcctId) {
+          account.isDefault = true
+        }
+      })
+
       setDefaultAccountId(newDefaultAcctId)
 
       if (!setDefaultAccountOptions?.disablePopUps) {
@@ -159,7 +170,7 @@ export const UserAccountProvider: FC<Props> = React.memo(({children}) => {
 
   useEffect(() => {
     handleGetAccounts()
-  }, [handleGetAccounts, defaultAccountId, activeAccountId])
+  }, [handleGetAccounts])
 
   return (
     <UserAccountContext.Provider

--- a/src/accounts/context/userAccount.tsx
+++ b/src/accounts/context/userAccount.tsx
@@ -1,6 +1,7 @@
 // Libraries
 import React, {FC, useCallback, useEffect, useState} from 'react'
 import {useDispatch} from 'react-redux'
+import {cloneDeep} from 'lodash'
 
 // Types
 import {UserAccount} from 'src/client/unityRoutes'
@@ -114,7 +115,9 @@ export const UserAccountProvider: FC<Props> = React.memo(({children}) => {
 
       await updateDefaultQuartzAccount(newDefaultAcctId)
 
-      userAccounts.forEach(account => {
+      const accountsClone = cloneDeep(userAccounts)
+
+      accountsClone.forEach(account => {
         if (account.id === oldDefaultAcctId) {
           account.isDefault = false
         }
@@ -122,8 +125,8 @@ export const UserAccountProvider: FC<Props> = React.memo(({children}) => {
           account.isDefault = true
         }
       })
-
       setDefaultAccountId(newDefaultAcctId)
+      setUserAccounts(accountsClone)
 
       if (!setDefaultAccountOptions?.disablePopUps) {
         dispatch(notify(accountDefaultSettingSuccess(accountName)))

--- a/src/identity/components/userprofile/UserDefaults.tsx
+++ b/src/identity/components/userprofile/UserDefaults.tsx
@@ -44,7 +44,8 @@ import 'src/identity/components/userprofile/UserProfile.scss'
 export const UserDefaults: FC = () => {
   const dispatch = useDispatch()
 
-  const {userAccounts, handleSetDefaultAccount} = useContext(UserAccountContext)
+  const {defaultAccountId, userAccounts, handleSetDefaultAccount} =
+    useContext(UserAccountContext)
   const quartzOrganizations = useSelector(selectQuartzOrgs)
 
   const identity = useSelector(selectQuartzIdentity)
@@ -58,8 +59,10 @@ export const UserDefaults: FC = () => {
 
   const defaultAccount = useMemo(
     () =>
-      accounts ? accounts.find(el => el.isDefault === true) : emptyAccount,
-    [accounts]
+      accounts
+        ? accounts.find(acct => acct.id === defaultAccountId)
+        : emptyAccount,
+    [accounts, defaultAccountId]
   )
   const defaultOrg = useMemo(
     () => (orgs ? orgs.find(el => el.isDefault === true) : emptyOrg),

--- a/src/identity/components/userprofile/UserDefaults.tsx
+++ b/src/identity/components/userprofile/UserDefaults.tsx
@@ -44,7 +44,7 @@ import 'src/identity/components/userprofile/UserProfile.scss'
 export const UserDefaults: FC = () => {
   const dispatch = useDispatch()
 
-  const {defaultAccountId, userAccounts, handleSetDefaultAccount} =
+  const {defaultAccountId, handleSetDefaultAccount, userAccounts} =
     useContext(UserAccountContext)
   const quartzOrganizations = useSelector(selectQuartzOrgs)
 


### PR DESCRIPTION
Closes #6336 

On initial load, the app hits the /accounts endpoint three times. This PR reduces it to one call.

Root cause is a `useEffect` hook that has been hanging out in the user account context. The hook calls a function (`handleGetAccounts`) that fetches from `/accounts` on initial app load, or when there is a change in the value of the user's `defaultAccountId` or `activeAccountId`. Since `handleGetAccounts` itself sets the `defaultAccountId` and `activeAccountId` based on the array the endpoint returns, we end up with three API calls: (1) when the context loads; (2) when the context sets the default account id based on the response; (3) when the context sets the active account id based on the response.

There's no need for the `defaultAccountId` dependency because the user's new default org can be changed cheaply without the need for any api call by simply setting the value of the accounts array to a clone of the accounts array with the new default org setting. There's no need for the `activeAccountId` dependency for that reason, but also because the `activeAccount` never changes until the app reloads (active account changes are handled by quartz redirect).

Ultimately (and we have tickets for this), it'd be cleaner for Redux to be used here, not context. But for now, this will reduce loadtimes and number of calls to quartz without the need for a broader refactor of UI code, given more pressing needs.

Before
--

https://user-images.githubusercontent.com/91283923/203167318-30b0e473-faab-4495-92f7-b55147499203.mov

After
--

https://user-images.githubusercontent.com/91283923/203167325-dbdd16c3-6a1b-4d9f-b767-96579d7c8f01.mov



### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - NO
