### PR TITLE
chore: filter inactive orgs from global header and user profile

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "cy": "CYPRESS_dexUrl=https://$INGRESS_HOST:$PORT_HTTPS CYPRESS_baseUrl=http://localhost:9999 cypress open",
     "cy:dev": "source ../monitor-ci/.env && CYPRESS_dexUrl=CLOUD CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{cloud,shared}/**/*.*'",
     "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_dexUrl=OSS CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{oss,shared}/**/*.*'",
-    "generate": "export SHA=04ef6af6616ac4f60f596e829098737b8f53e7e0 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
+    "generate": "export SHA=c8f13fab276fa7af3dd925870e493e973e2df93f && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-local-cloud": "export REMOTE=../openapi/ && yarn generate-meta-cloud",
     "generate-meta": "if [ -z \"${CLOUD_URL}\" ]; then yarn generate-meta-oss; else yarn generate-meta-cloud; fi",

--- a/src/identity/apis/org.ts
+++ b/src/identity/apis/org.ts
@@ -51,7 +51,7 @@ export interface QuartzOrganization
 
 export type QuartzOrganizations = {
   orgs: QuartzOrganization[]
-  status?: RemoteDataState
+  status: RemoteDataState
 }
 
 // create a new organization

--- a/src/identity/apis/org.ts
+++ b/src/identity/apis/org.ts
@@ -1,3 +1,6 @@
+// Libraries
+import {omit} from 'lodash'
+
 // API Calls
 import {
   getAccounts,
@@ -7,8 +10,10 @@ import {
   getOrg,
   postOrg,
   putAccountsOrgsDefault,
+  state,
   Organization,
   OrganizationCreateRequest,
+  OrganizationSummaries,
 } from 'src/client/unityRoutes'
 
 // Types
@@ -22,7 +27,6 @@ import {
   UnauthorizedError,
   UnprocessableEntityError,
 } from 'src/types/error'
-import {OrganizationSummaries} from 'src/client/unityRoutes'
 
 export interface CurrentOrg {
   id: string
@@ -40,18 +44,13 @@ export interface OrgCreationAllowance {
   availableUpgrade: 'contract' | 'none' | 'pay_as_you_go'
 }
 
-export interface QuartzOrganization {
-  id: string
-  name: string
-  isActive: boolean
-  isDefault: boolean
-  provider?: string
-  regionCode?: string
-  regionName?: string
+export interface QuartzOrganization
+  extends Omit<OrganizationSummaries[number], 'state'> {
+  provisioningStatus?: state
 }
 
 export type QuartzOrganizations = {
-  orgs: OrganizationSummaries
+  orgs: QuartzOrganization[]
   status?: RemoteDataState
 }
 
@@ -168,7 +167,14 @@ export const fetchOrgsByAccountID = async (
     throw new ServerError(response.data.message)
   }
 
-  return response.data
+  // 'state' property in quartz refers to org provisioning status.
+  const orgs = response.data.map(org => {
+    const provisioningStatus = org.state
+    const formattedOrg = {...omit(org, ['state']), provisioningStatus}
+    return formattedOrg
+  })
+
+  return orgs
 }
 
 // fetch details about one of the user's organizations

--- a/src/identity/components/GlobalHeader/DefaultEntities.tsx
+++ b/src/identity/components/GlobalHeader/DefaultEntities.tsx
@@ -17,4 +17,5 @@ export const emptyOrg: OrganizationSummaries[number] = {
   provider: '',
   regionCode: '',
   regionName: '',
+  state: 'provisioned',
 }

--- a/src/identity/components/GlobalHeader/DefaultEntities.tsx
+++ b/src/identity/components/GlobalHeader/DefaultEntities.tsx
@@ -1,6 +1,6 @@
 // Types
+import {QuartzOrganization} from 'src/identity/apis/org'
 import {UserAccount} from 'src/client/unityRoutes'
-import {OrganizationSummaries} from 'src/client/unityRoutes'
 
 export const emptyAccount: UserAccount = {
   id: 0,
@@ -9,7 +9,7 @@ export const emptyAccount: UserAccount = {
   isDefault: false,
 }
 
-export const emptyOrg: OrganizationSummaries[number] = {
+export const emptyOrg: QuartzOrganization = {
   id: '',
   name: '',
   isActive: false,
@@ -17,5 +17,5 @@ export const emptyOrg: OrganizationSummaries[number] = {
   provider: '',
   regionCode: '',
   regionName: '',
-  state: 'provisioned',
+  provisioningStatus: 'provisioned',
 }

--- a/src/identity/components/GlobalHeader/GlobalHeader.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeader.tsx
@@ -12,37 +12,36 @@ import {
 
 // Selectors and Context
 import {getOrg} from 'src/organizations/selectors'
-import {selectQuartzIdentity} from 'src/identity/selectors'
+import {selectUser, selectQuartzActiveOrgs} from 'src/identity/selectors'
 import {UserAccountContext} from 'src/accounts/context/userAccount'
 
 // Components
 import {AccountDropdown} from 'src/identity/components/GlobalHeader/AccountDropdown'
+import {IdentityUserAvatar} from 'src/identity/components/GlobalHeader/IdentityUserAvatar'
 import {OrgDropdown} from 'src/identity/components/GlobalHeader/OrgDropdown'
+import {RateLimitAlert} from 'src/cloud/components/RateLimitAlert'
 
 // Thunks
 import {getQuartzOrganizationsThunk} from 'src/identity/quartzOrganizations/actions/thunks'
 
-// Styles
-import 'src/identity/components/GlobalHeader/GlobalHeaderStyle.scss'
-
+// Utils
+import {alphaSortSelectedFirst} from 'src/identity/utils/alphaSortSelectedFirst'
 import {
   emptyAccount,
   emptyOrg,
 } from 'src/identity/components/GlobalHeader/DefaultEntities'
-import {alphaSortSelectedFirst} from 'src/identity/utils/alphaSortSelectedFirst'
-import IdentityUserAvatar from 'src/identity/components/GlobalHeader/IdentityUserAvatar'
-import {RateLimitAlert} from 'src/cloud/components/RateLimitAlert'
 
+// Styles
+import 'src/identity/components/GlobalHeader/GlobalHeaderStyle.scss'
 const caretStyle = {fontSize: '18px', color: InfluxColors.Grey65}
 const rightHandContainerStyle = {marginLeft: 'auto'}
 
 export const GlobalHeader: FC = () => {
   const dispatch = useDispatch()
-  const identity = useSelector(selectQuartzIdentity)
-  const {user} = identity.currentIdentity
-  const org = useSelector(getOrg)
 
-  const orgsList = identity.quartzOrganizations.orgs
+  const currentOrg = useSelector(getOrg)
+  const orgsList = useSelector(selectQuartzActiveOrgs)
+  const user = useSelector(selectUser)
   const {userAccounts} = useContext(UserAccountContext)
 
   const accountsList = userAccounts?.length > 0 ? userAccounts : [emptyAccount] // eslint-disable-line react-hooks/exhaustive-deps
@@ -83,7 +82,7 @@ export const GlobalHeader: FC = () => {
 
   const shouldLoadDropdowns = Boolean(activeOrg?.id && activeAccount?.id)
 
-  const shouldLoadAvatar = Boolean(user?.email && org?.id)
+  const shouldLoadAvatar = Boolean(user?.email && currentOrg?.id)
   const avatarFirstName =
     typeof user?.firstName === 'string' ? user.firstName.trim() : ''
   const avatarLastName =
@@ -123,7 +122,7 @@ export const GlobalHeader: FC = () => {
             email={user.email}
             firstName={avatarFirstName}
             lastName={avatarLastName}
-            orgId={org.id}
+            orgId={currentOrg.id}
           />
         )}
       </FlexBox>

--- a/src/identity/components/GlobalHeader/GlobalHeaderDropdown/CreateOrganization/CreateOrganizationOverlay.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeaderDropdown/CreateOrganization/CreateOrganizationOverlay.tsx
@@ -68,7 +68,7 @@ import {
   selectCurrentAccountId,
   selectOrgCreationAllowance,
   selectOrgCreationAllowanceStatus,
-  selectQuartzOrgsContents,
+  selectQuartzOrgs,
   selectQuartzOrgsStatus,
 } from 'src/identity/selectors'
 
@@ -90,7 +90,7 @@ export const CreateOrganizationOverlay: FC = () => {
 
   // Selectors
   const currentAccountId = useSelector(selectCurrentAccountId)
-  const organizations = useSelector(selectQuartzOrgsContents)
+  const organizations = useSelector(selectQuartzOrgs)
   const orgsLoadedStatus = useSelector(selectQuartzOrgsStatus)
   const orgCreationAllowed = useSelector(selectOrgCreationAllowance)
   const orgCreationAllowanceStatus = useSelector(

--- a/src/identity/components/GlobalHeader/IdentityUserAvatar.tsx
+++ b/src/identity/components/GlobalHeader/IdentityUserAvatar.tsx
@@ -31,7 +31,7 @@ type State = {
   isPopoverOpen: boolean
 }
 
-class IdentityUserAvatar extends React.Component<Props, State> {
+export class IdentityUserAvatar extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props)
     this.state = {
@@ -142,5 +142,3 @@ class IdentityUserAvatar extends React.Component<Props, State> {
     )
   }
 }
-
-export default IdentityUserAvatar

--- a/src/identity/components/OrganizationListTab/index.tsx
+++ b/src/identity/components/OrganizationListTab/index.tsx
@@ -24,7 +24,7 @@ import {
   selectOrgCreationAllowance,
   selectOrgCreationAllowanceStatus,
   selectOrgCreationAvailableUpgrade,
-  selectQuartzOrgsContents,
+  selectQuartzOrgs,
   selectQuartzOrgsStatus,
 } from 'src/identity/selectors'
 
@@ -62,11 +62,11 @@ export const OrganizationListTab: FC<Props> = ({pageHeight}) => {
   const availableUpgrade = useSelector(selectOrgCreationAvailableUpgrade)
   const currentAccountId = useSelector(selectCurrentAccountId)
   const isAtOrgLimit = !useSelector(selectOrgCreationAllowance)
-  const orgsInAccount = useSelector(selectQuartzOrgsContents)
-  const orgsLoadedStatus = useSelector(selectQuartzOrgsStatus)
   const orgCreationAllowanceStatus = useSelector(
     selectOrgCreationAllowanceStatus
   )
+  const orgsInAccount = useSelector(selectQuartzOrgs)
+  const orgsLoadedStatus = useSelector(selectQuartzOrgsStatus)
 
   // Component State
   const [currentPage, setCurrentPage] = useState(1)

--- a/src/identity/components/userprofile/UserDefaults.tsx
+++ b/src/identity/components/userprofile/UserDefaults.tsx
@@ -12,7 +12,10 @@ import {
 
 // Selectors and Context
 import {UserAccountContext} from 'src/accounts/context/userAccount'
-import {selectQuartzIdentity, selectQuartzOrgs} from 'src/identity/selectors'
+import {
+  selectQuartzActiveOrgs,
+  selectQuartzIdentity,
+} from 'src/identity/selectors'
 
 // Thunks
 import {updateDefaultOrgThunk} from 'src/identity/quartzOrganizations/actions/thunks'
@@ -46,7 +49,7 @@ export const UserDefaults: FC = () => {
 
   const {defaultAccountId, handleSetDefaultAccount, userAccounts} =
     useContext(UserAccountContext)
-  const quartzOrganizations = useSelector(selectQuartzOrgs)
+  const orgs = useSelector(selectQuartzActiveOrgs)
 
   const identity = useSelector(selectQuartzIdentity)
   const loggedInAccount = identity.currentIdentity.account
@@ -54,8 +57,7 @@ export const UserDefaults: FC = () => {
   const accounts = userAccounts
   const numAccounts = userAccounts ? userAccounts.length : 0
 
-  const orgs = quartzOrganizations.orgs
-  const numOrgs = quartzOrganizations.orgs ? quartzOrganizations.orgs.length : 0
+  const numOrgs = orgs ? orgs.length : 0
 
   const defaultAccount = useMemo(
     () =>
@@ -74,11 +76,11 @@ export const UserDefaults: FC = () => {
 
   useEffect(() => {
     setSelectedAccount(defaultAccount)
-  }, [accounts, defaultAccount])
+  }, [defaultAccount])
 
   useEffect(() => {
     setSelectedOrg(defaultOrg)
-  }, [orgs, defaultOrg])
+  }, [defaultOrg])
 
   const userPickedNewAccount =
     defaultAccount?.id !== selectedAccount?.id && selectedAccount !== null
@@ -141,7 +143,6 @@ export const UserDefaults: FC = () => {
             setSelectedAccount={setSelectedAccount}
           />
         )}
-
         {numOrgs > 1 && (
           <DefaultOrgForm
             accounts={accounts}

--- a/src/identity/quartzOrganizations/mockOrgData.ts
+++ b/src/identity/quartzOrganizations/mockOrgData.ts
@@ -1,6 +1,6 @@
-import {OrganizationSummaries} from 'src/client/unityRoutes'
+import {QuartzOrganization} from 'src/identity/apis/org'
 
-export const mockOrgData: OrganizationSummaries = [
+export const mockOrgData: QuartzOrganization[] = [
   {
     id: '9296169091c64567',
     name: 'Test Co. 1',
@@ -9,7 +9,7 @@ export const mockOrgData: OrganizationSummaries = [
     provider: 'AWS',
     regionCode: 'us-east-1',
     regionName: 'US East (N. Virginia)',
-    state: 'provisioned',
+    provisioningStatus: 'provisioned',
   },
   {
     id: 'a71ced2b8238902b',
@@ -19,7 +19,7 @@ export const mockOrgData: OrganizationSummaries = [
     provider: 'AWS',
     regionCode: 'eu-central-1',
     regionName: 'EU Frankfurt',
-    state: 'provisioned',
+    provisioningStatus: 'provisioned',
   },
   {
     id: 'ac3d3c04b8f1a545',
@@ -29,7 +29,7 @@ export const mockOrgData: OrganizationSummaries = [
     provider: 'AWS',
     regionCode: 'us-east-1-2',
     regionName: 'US East (N. Virginia) 2',
-    state: 'provisioned',
+    provisioningStatus: 'provisioned',
   },
   {
     id: 'fc734484afa0fcac',
@@ -39,7 +39,7 @@ export const mockOrgData: OrganizationSummaries = [
     provider: 'Azure',
     regionCode: 'us-west-2-2',
     regionName: 'US West (Oregon)',
-    state: 'provisioned',
+    provisioningStatus: 'provisioned',
   },
   {
     id: '62cba0af4760ce02',
@@ -49,6 +49,6 @@ export const mockOrgData: OrganizationSummaries = [
     provider: 'Azure',
     regionCode: 'westeurope',
     regionName: 'Amsterdam',
-    state: 'provisioned',
+    provisioningStatus: 'provisioned',
   },
 ]

--- a/src/identity/quartzOrganizations/mockOrgData.ts
+++ b/src/identity/quartzOrganizations/mockOrgData.ts
@@ -1,4 +1,6 @@
-export const mockOrgData = [
+import {OrganizationSummaries} from 'src/client/unityRoutes'
+
+export const mockOrgData: OrganizationSummaries = [
   {
     id: '9296169091c64567',
     name: 'Test Co. 1',
@@ -7,6 +9,7 @@ export const mockOrgData = [
     provider: 'AWS',
     regionCode: 'us-east-1',
     regionName: 'US East (N. Virginia)',
+    state: 'provisioned',
   },
   {
     id: 'a71ced2b8238902b',
@@ -16,6 +19,7 @@ export const mockOrgData = [
     provider: 'AWS',
     regionCode: 'eu-central-1',
     regionName: 'EU Frankfurt',
+    state: 'provisioned',
   },
   {
     id: 'ac3d3c04b8f1a545',
@@ -25,6 +29,7 @@ export const mockOrgData = [
     provider: 'AWS',
     regionCode: 'us-east-1-2',
     regionName: 'US East (N. Virginia) 2',
+    state: 'provisioned',
   },
   {
     id: 'fc734484afa0fcac',
@@ -34,6 +39,7 @@ export const mockOrgData = [
     provider: 'Azure',
     regionCode: 'us-west-2-2',
     regionName: 'US West (Oregon)',
+    state: 'provisioned',
   },
   {
     id: '62cba0af4760ce02',
@@ -43,5 +49,6 @@ export const mockOrgData = [
     provider: 'Azure',
     regionCode: 'westeurope',
     regionName: 'Amsterdam',
+    state: 'provisioned',
   },
 ]

--- a/src/identity/quartzOrganizations/reducers/index.ts
+++ b/src/identity/quartzOrganizations/reducers/index.ts
@@ -1,21 +1,27 @@
-import {QuartzOrganizations} from 'src/identity/apis/org'
+// Actions
 import {
   Actions,
   SET_QUARTZ_ORGANIZATIONS,
   SET_QUARTZ_ORGANIZATIONS_STATUS,
   SET_QUARTZ_DEFAULT_ORG,
 } from 'src/identity/quartzOrganizations/actions/creators'
-import {emptyOrg} from 'src/identity/components/GlobalHeader/DefaultEntities'
+
+// Libraries
 import produce from 'immer'
 
 // Types
-import {OrganizationSummaries} from 'src/client/unityRoutes'
+import {QuartzOrganizations} from 'src/identity/apis/org'
+
+// Mock Data
+import {emptyOrg} from 'src/identity/components/GlobalHeader/DefaultEntities'
+
+// Types
 import {RemoteDataState} from 'src/types'
 
 export const initialState = {
-  orgs: [emptyOrg] as OrganizationSummaries,
+  orgs: [emptyOrg],
   status: RemoteDataState.NotStarted,
-} as QuartzOrganizations
+}
 
 export default (state = initialState, action: Actions): QuartzOrganizations =>
   produce(state, draftState => {

--- a/src/identity/selectors/index.test.ts
+++ b/src/identity/selectors/index.test.ts
@@ -14,7 +14,10 @@ import {cloneDeep} from 'lodash'
 
 const mockState = {
   identity: {
-    quartzOrganizations: {orgs: [emptyOrg], status: RemoteDataState.Done},
+    quartzOrganizations: {
+      orgs: cloneDeep(mockOrgData),
+      status: RemoteDataState.Done,
+    },
   },
 } as AppState
 
@@ -23,7 +26,6 @@ describe('selectQuartzActiveOrgs selector', () => {
 
   beforeEach(() => {
     localState = cloneDeep(mockState)
-    localState.identity.quartzOrganizations.orgs = cloneDeep(mockOrgData)
   })
 
   it('returns an array of length one with the default empty org', () => {
@@ -34,16 +36,16 @@ describe('selectQuartzActiveOrgs selector', () => {
     expect(activeOrgs).toEqual(expect.arrayContaining([emptyOrg]))
   })
 
-  it('returns an array of all orgs a `provisioned` state', () => {
+  it('returns an array of all orgs in a `provisioned` state', () => {
     const activeOrgs = selectQuartzActiveOrgs(localState)
     expect(activeOrgs.length).toBe(5)
     expect(activeOrgs).toEqual(expect.arrayContaining(mockOrgData))
   })
 
   it('returns an array that includes orgs without a state property', () => {
-    localState.identity.quartzOrganizations.orgs[0].state = '' as state // This org should be returned
+    localState.identity.quartzOrganizations.orgs[0].state = '' as state // Return this org
     localState.identity.quartzOrganizations.orgs[1].state =
-      'random property name' as state // This org should not be returned
+      'random new state' as state // Dont return this org
 
     const activeOrgs = selectQuartzActiveOrgs(localState)
 

--- a/src/identity/selectors/index.test.ts
+++ b/src/identity/selectors/index.test.ts
@@ -43,8 +43,9 @@ describe('selectQuartzActiveOrgs selector', () => {
   })
 
   it('returns an array that includes orgs without a state property', () => {
-    localState.identity.quartzOrganizations.orgs[0].state = '' as state // Return this org
-    localState.identity.quartzOrganizations.orgs[1].state =
+    localState.identity.quartzOrganizations.orgs[0].provisioningStatus =
+      '' as state // Return this org
+    localState.identity.quartzOrganizations.orgs[1].provisioningStatus =
       'random new state' as state // Dont return this org
 
     const activeOrgs = selectQuartzActiveOrgs(localState)
@@ -61,8 +62,10 @@ describe('selectQuartzActiveOrgs selector', () => {
   })
 
   it('does not return orgs that are marked as unprovisioned', () => {
-    localState.identity.quartzOrganizations.orgs[0].state = 'suspended'
-    localState.identity.quartzOrganizations.orgs[1].state = 'pending'
+    localState.identity.quartzOrganizations.orgs[0].provisioningStatus =
+      'suspended'
+    localState.identity.quartzOrganizations.orgs[1].provisioningStatus =
+      'pending'
 
     const activeOrgs = selectQuartzActiveOrgs(localState)
 

--- a/src/identity/selectors/index.test.ts
+++ b/src/identity/selectors/index.test.ts
@@ -1,0 +1,72 @@
+// Mocks
+import {emptyOrg} from 'src/identity/components/GlobalHeader/DefaultEntities'
+import {mockOrgData} from 'src/identity/quartzOrganizations/mockOrgData'
+
+// Selectors
+import {selectQuartzActiveOrgs} from 'src/identity/selectors'
+
+// Types
+import {AppState, RemoteDataState} from 'src/types'
+import {state} from 'src/client/unityRoutes'
+
+// Utilities
+import {cloneDeep} from 'lodash'
+
+const mockState = {
+  identity: {
+    quartzOrganizations: {orgs: [emptyOrg], status: RemoteDataState.Done},
+  },
+} as AppState
+
+describe('selectQuartzActiveOrgs selector', () => {
+  let localState: AppState
+
+  beforeEach(() => {
+    localState = cloneDeep(mockState)
+    localState.identity.quartzOrganizations.orgs = cloneDeep(mockOrgData)
+  })
+
+  it('returns an array of length one with the default empty org', () => {
+    localState.identity.quartzOrganizations.orgs = [emptyOrg]
+    const activeOrgs = selectQuartzActiveOrgs(localState)
+
+    expect(activeOrgs.length).toBe(1)
+    expect(activeOrgs).toEqual(expect.arrayContaining([emptyOrg]))
+  })
+
+  it('returns an array of all orgs a `provisioned` state', () => {
+    const activeOrgs = selectQuartzActiveOrgs(localState)
+    expect(activeOrgs.length).toBe(5)
+    expect(activeOrgs).toEqual(expect.arrayContaining(mockOrgData))
+  })
+
+  it('returns an array that includes orgs without a state property', () => {
+    localState.identity.quartzOrganizations.orgs[0].state = '' as state // This org should be returned
+    localState.identity.quartzOrganizations.orgs[1].state =
+      'random property name' as state // This org should not be returned
+
+    const activeOrgs = selectQuartzActiveOrgs(localState)
+
+    expect(activeOrgs.length).toBe(4)
+    expect(activeOrgs.map(org => org.name)).toEqual(
+      expect.arrayContaining([
+        'Test Co. 1',
+        'Test GmbH 3',
+        'Test Inc. 4',
+        'Test SA 5',
+      ])
+    )
+  })
+
+  it('does not return orgs that are marked as unprovisioned', () => {
+    localState.identity.quartzOrganizations.orgs[0].state = 'suspended'
+    localState.identity.quartzOrganizations.orgs[1].state = 'pending'
+
+    const activeOrgs = selectQuartzActiveOrgs(localState)
+
+    expect(activeOrgs.length).toBe(3)
+    expect(activeOrgs.map(org => org.name)).toEqual(
+      expect.arrayContaining(['Test GmbH 3', 'Test Inc. 4', 'Test SA 5'])
+    )
+  })
+})

--- a/src/identity/selectors/index.ts
+++ b/src/identity/selectors/index.ts
@@ -2,16 +2,6 @@
 import {AppState} from 'src/types'
 import {RemoteDataState} from '@influxdata/clockface'
 
-export const selectQuartzIdentity = (state: AppState): AppState['identity'] => {
-  return state.identity
-}
-
-export const selectCurrentIdentity = (
-  state: AppState
-): AppState['identity']['currentIdentity'] => {
-  return state.identity.currentIdentity
-}
-
 export const selectCurrentAccountId = (
   state: AppState
 ): AppState['identity']['currentIdentity']['account']['id'] => {
@@ -22,6 +12,12 @@ export const selectCurrentAccountType = (
   state: AppState
 ): AppState['identity']['currentIdentity']['account']['type'] => {
   return state.identity.currentIdentity.account.type
+}
+
+export const selectCurrentIdentity = (
+  state: AppState
+): AppState['identity']['currentIdentity'] => {
+  return state.identity.currentIdentity
 }
 
 export const selectCurrentOrgId = (
@@ -52,6 +48,18 @@ export const selectOrgCreationAvailableUpgrade = (
   return state.identity.allowances.orgCreation.availableUpgrade
 }
 
+export const selectQuartzActiveOrgs = (
+  state: AppState
+): AppState['identity']['quartzOrganizations']['orgs'] => {
+  return state.identity.quartzOrganizations.orgs.filter(
+    org => !org.state || org.state === 'provisioned'
+  )
+}
+
+export const selectQuartzIdentity = (state: AppState): AppState['identity'] => {
+  return state.identity
+}
+
 export const selectQuartzIdentityStatus = (state: AppState): RemoteDataState =>
   state.identity.currentIdentity.loadingStatus.identityStatus
 
@@ -65,12 +73,6 @@ export const selectQuartzOrgDetailsStatus = (
 
 export const selectQuartzOrgs = (
   state: AppState
-): AppState['identity']['quartzOrganizations'] => {
-  return state.identity.quartzOrganizations
-}
-
-export const selectQuartzOrgsContents = (
-  state: AppState
 ): AppState['identity']['quartzOrganizations']['orgs'] => {
   return state.identity.quartzOrganizations.orgs
 }
@@ -79,4 +81,10 @@ export const selectQuartzOrgsStatus = (
   state: AppState
 ): AppState['identity']['quartzOrganizations']['status'] => {
   return state.identity.quartzOrganizations.status
+}
+
+export const selectUser = (
+  state: AppState
+): AppState['identity']['currentIdentity']['user'] => {
+  return state.identity.currentIdentity.user
 }

--- a/src/identity/selectors/index.ts
+++ b/src/identity/selectors/index.ts
@@ -52,7 +52,7 @@ export const selectQuartzActiveOrgs = (
   state: AppState
 ): AppState['identity']['quartzOrganizations']['orgs'] => {
   return state.identity.quartzOrganizations.orgs.filter(
-    org => !org.state || org.state === 'provisioned'
+    org => !org.provisioningStatus || org.provisioningStatus === 'provisioned'
   )
 }
 


### PR DESCRIPTION
Closes #5935 

The list of all orgs in an account now includes a `state` property to indicate whether each org is `provisioned`, `pending`, or `suspended`. 
![Screen Shot 2022-11-28 at 10 49 59 AM](https://user-images.githubusercontent.com/91283923/204321472-5098ce53-2af2-4679-aa7b-9fcb0d8dd4e7.png)

This PR adds a new selector for provisioned orgs, so that only those organizations are shown in the global app header, and on the profile page for changing default orgs. 

Edit: added unit tests to ensure the `selectQuartzActiveOrg` selector is working as expected.
![Screen Shot 2022-11-28 at 6 28 22 PM](https://user-images.githubusercontent.com/91283923/204402325-1fe501a1-a099-4a98-a1ca-3a889d524141.png)

Unit tests may not be used by CI until [this issue](https://github.com/influxdata/ui/issues/6346) is resolved.


Before
--

https://user-images.githubusercontent.com/91283923/204320736-f96d2e43-d479-47db-bf78-f35bb04c99fc.mov



After
--

https://user-images.githubusercontent.com/91283923/204321084-464266e1-7450-4342-bba9-b69cd0796cad.mov

Quartz-Remocal Testing
--

https://user-images.githubusercontent.com/91283923/204565529-7144eca5-bdd5-42df-811c-cb05fda3037a.mov


### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - NO
