### PR TITLE
feat(6341): get basic composition working with yieldless

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "@codingame/monaco-jsonrpc": "^0.3.1",
     "@docsearch/react": "^3.0.0-alpha.37",
     "@influxdata/clockface": "^6.3.9",
-    "@influxdata/flux-lsp-browser": "0.8.36",
+    "@influxdata/flux-lsp-browser": "0.8.38",
     "@influxdata/giraffe": "^2.38.1",
     "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",

--- a/src/languageSupport/languages/flux/lsp/connection.ts
+++ b/src/languageSupport/languages/flux/lsp/connection.ts
@@ -289,7 +289,7 @@ class LspConnectionManager {
       })
     }
 
-    if (toRemove.fields?.length) {
+    if (toRemove?.fields?.length) {
       toRemove.fields.forEach(value =>
         this.inject(ExecuteCommand.CompositionRemoveField, {value})
       )
@@ -299,7 +299,7 @@ class LspConnectionManager {
         this.inject(ExecuteCommand.CompositionAddField, {value})
       )
     }
-    if (toRemove.tagValues?.length) {
+    if (toRemove?.tagValues?.length) {
       toRemove.tagValues.forEach(({key, value}) =>
         this.inject(ExecuteCommand.CompositionRemoveTagValue, {tag: key, value})
       )

--- a/src/languageSupport/languages/flux/lsp/utils.ts
+++ b/src/languageSupport/languages/flux/lsp/utils.ts
@@ -106,7 +106,7 @@ export type ExecuteCommandArgument =
  */
 export type ExecuteCommandT =
   | [ExecuteCommand.CompositionInit, CompositionInitParams]
-  | [ExecuteCommand.CompositionAddMeasurement, CompositionValueParams]
+  | [ExecuteCommand.CompositionSetMeasurement, CompositionValueParams]
   | [ExecuteCommand.CompositionAddField, CompositionValueParams]
   | [ExecuteCommand.CompositionRemoveField, CompositionValueParams]
   | [ExecuteCommand.CompositionAddTagValue, CompositionTagValueParams]
@@ -127,7 +127,7 @@ function validateExecuteCommandPayload([command, arg]: ExecuteCommandT):
   switch (command) {
     case ExecuteCommand.CompositionInit:
       return checkIsString(arg, 'bucket')
-    case ExecuteCommand.CompositionAddMeasurement:
+    case ExecuteCommand.CompositionSetMeasurement:
     case ExecuteCommand.CompositionAddField:
     case ExecuteCommand.CompositionRemoveField:
       return checkIsString(arg, 'value')
@@ -189,7 +189,7 @@ export enum Methods {
  */
 export enum ExecuteCommand {
   CompositionInit = 'fluxComposition/initialize',
-  CompositionAddMeasurement = 'fluxComposition/addMeasurementFilter',
+  CompositionSetMeasurement = 'fluxComposition/setMeasurementFilter',
   CompositionAddField = 'fluxComposition/addFieldFilter',
   CompositionRemoveField = 'fluxComposition/removeFieldFilter',
   CompositionAddTagValue = 'fluxComposition/addTagValueFilter',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1507,10 +1507,10 @@
     "@types/react-window" "^1.8.5"
     react-window "^1.8.7"
 
-"@influxdata/flux-lsp-browser@0.8.36":
-  version "0.8.36"
-  resolved "https://registry.yarnpkg.com/@influxdata/flux-lsp-browser/-/flux-lsp-browser-0.8.36.tgz#953b09f0d6ac027c6b1e834735d48f78af616b73"
-  integrity sha512-jp9jJYQBoaGKX2Z4foPzSEHQHOtBoB/SHfnnLDpmPgN3B80jSq5md1mjgav4if4fnVuzEc+693/hw/CDH3Pbtw==
+"@influxdata/flux-lsp-browser@0.8.38":
+  version "0.8.38"
+  resolved "https://registry.yarnpkg.com/@influxdata/flux-lsp-browser/-/flux-lsp-browser-0.8.38.tgz#371cf06ab85d722688e3468851b8a289788eeab1"
+  integrity sha512-/vRpbFndYmKXZNnULpOyeWwjdEFYPHkoxuTlApYGip8wc7Vz+pjZYCaB+RFOQCddTjf2S7oikyA/dyL0FE6jsg==
 
 "@influxdata/giraffe@^2.38.1":
   version "2.38.1"


### PR DESCRIPTION
Part of https://github.com/influxdata/ui/issues/6334
Closes https://github.com/influxdata/ui/issues/6341

Note: this is part of a chain of PRs.
`staging/yieldless-composition`  <-- 1st PR <-- 2nd PR <-- 3rd PR
The final staging branch will be the merge into master.

#### PR Chain:
1. this PR.
2. https://github.com/influxdata/ui/pull/6374
3. https://github.com/influxdata/ui/pull/6397 where tests finally pass!


## DONE:

Closes #6341  (`FIRST TASK` on the epic, UI side changes).
That^^ issue ticket describes in detail, on why these changes were required.


## Visual Evidence:
Video of current status after UI and flux-lsp `FIRST TASK` changes:

https://user-images.githubusercontent.com/10232835/203626079-946b8ed6-2c4a-47a3-8106-8384306d265b.mov

## Checklist
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable. Is behind `schemaComposition` flag, which I believe is on in prod.
