### PR TITLE
chore(client_libs): use ruby client as a resource

### DIFF
--- a/src/writeData/clients/Ruby/executeFull.example
+++ b/src/writeData/clients/Ruby/executeFull.example
@@ -4,16 +4,16 @@ require 'influxdb-client'
 token = '<%= token %>'
 org = '<%= org %>'
 
-client = InfluxDB2::Client.new('<%= server %>', token,
-  precision: InfluxDB2::WritePrecision::NANOSECOND)
+InfluxDB2::Client.use('<%= server %>',
+                      token,
+                      precision: InfluxDB2::WritePrecision::NANOSECOND) do |client|
 
-query = %{<%= query %>}
+    query = %{<%= query %>}
 
-tables = client.create_query_api.query(query: query, org: org)
-tables.each do |_, table|
-  table.records.each do |record|
-    puts "#{record.time} #{record.measurement}: #{record.field}=#{record.value}"
-  end
+    tables = client.create_query_api.query(query: query, org: org)
+    tables.each do |_, table|
+      table.records.each do |record|
+        puts "#{record.time} #{record.measurement}: #{record.field}=#{record.value}"
+      end
+    end
 end
-
-client.close!


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb-client-ruby/pull/127

The **InfluxDB::Client** can be also used as a resource:

```ruby
InfluxDB2::Client.use('https://localhost:8086', 'my-token') do |client|
  client.do_something
end
```

![image](https://user-images.githubusercontent.com/455137/204310083-567b39c8-4819-408c-92fc-02eb5c0917a8.png)


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
