### PR TITLE
feat(aim): Add Reactivate Org Button

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "cy": "CYPRESS_dexUrl=https://$INGRESS_HOST:$PORT_HTTPS CYPRESS_baseUrl=http://localhost:9999 cypress open",
     "cy:dev": "source ../monitor-ci/.env && CYPRESS_dexUrl=CLOUD CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{cloud,shared}/**/*.*'",
     "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_dexUrl=OSS CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{oss,shared}/**/*.*'",
-    "generate": "export SHA=c8f13fab276fa7af3dd925870e493e973e2df93f && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
+    "generate": "export SHA=66183531c4681177eec11759a912c736af2d48e4 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-local-cloud": "export REMOTE=../openapi/ && yarn generate-meta-cloud",
     "generate-meta": "if [ -z \"${CLOUD_URL}\" ]; then yarn generate-meta-oss; else yarn generate-meta-cloud; fi",

--- a/src/operator/OrgOverlay.tsx
+++ b/src/operator/OrgOverlay.tsx
@@ -34,6 +34,9 @@ import LimitsField from 'src/operator/LimitsField'
 // Constants
 import {TOOLS_URL} from 'src/shared/constants'
 
+const viewUsageButtonStyles = {marginRight: '12px'}
+const reactivateOrgButtonStyles = {marginTop: '8px'}
+
 const OrgOverlay: FC = () => {
   const {
     limits,
@@ -120,7 +123,7 @@ const OrgOverlay: FC = () => {
                       text="View Usage Dashboard"
                       target={LinkTarget.Blank}
                       className="overlay-button--link"
-                      style={{marginRight: '12px'}}
+                      style={viewUsageButtonStyles}
                       href={`${TOOLS_URL}orgs/5d59ccc5163fc318/dashboards/0988da0fd78a7003?vars%5Borgid%5D=${orgID}`}
                     />
                     {canReactivateOrg && (
@@ -129,7 +132,7 @@ const OrgOverlay: FC = () => {
                         shape={ButtonShape.Default}
                         size={ComponentSize.Medium}
                         onClick={reactivateOrg}
-                        style={{marginTop: '8px'}}
+                        style={reactivateOrgButtonStyles}
                         status={
                           reactivateOrgStatus === RemoteDataState.Loading
                             ? ComponentStatus.Disabled

--- a/src/operator/OrgOverlay.tsx
+++ b/src/operator/OrgOverlay.tsx
@@ -40,9 +40,11 @@ const OrgOverlay: FC = () => {
     limitsStatus,
     handleGetLimits,
     handleGetOrg,
+    handleReactivateOrg,
     handleUpdateLimits,
     organization,
     orgStatus,
+    reactivateOrgStatus,
     setLimits,
     updateLimitStatus,
   } = useContext(OverlayContext)
@@ -50,6 +52,8 @@ const OrgOverlay: FC = () => {
 
   const {orgID} = useParams<{orgID: string}>()
   const history = useHistory()
+  const canReactivateOrg =
+    hasWritePermissions && organization?.state === 'suspended'
 
   useEffect(() => {
     handleGetLimits(orgID)
@@ -69,6 +73,11 @@ const OrgOverlay: FC = () => {
       // If an error occurs the operator will be notified when the API function fails
       return
     }
+  }
+
+  const reactivateOrg = async () => {
+    await handleReactivateOrg(orgID)
+    history.goBack()
   }
 
   return (
@@ -111,8 +120,26 @@ const OrgOverlay: FC = () => {
                       text="View Usage Dashboard"
                       target={LinkTarget.Blank}
                       className="overlay-button--link"
+                      style={{marginRight: '12px'}}
                       href={`${TOOLS_URL}orgs/5d59ccc5163fc318/dashboards/0988da0fd78a7003?vars%5Borgid%5D=${orgID}`}
                     />
+                    {canReactivateOrg && (
+                      <ButtonBase
+                        color={ComponentColor.Primary}
+                        shape={ButtonShape.Default}
+                        size={ComponentSize.Medium}
+                        onClick={reactivateOrg}
+                        style={{marginTop: '8px'}}
+                        status={
+                          reactivateOrgStatus === RemoteDataState.Loading
+                            ? ComponentStatus.Disabled
+                            : ComponentStatus.Default
+                        }
+                        testID="org-overlay-reactivate-organization--button"
+                      >
+                        Reactivate Organization
+                      </ButtonBase>
+                    )}
                   </Grid.Column>
                 </Grid.Row>
                 <Grid.Row>

--- a/src/operator/context/overlay.tsx
+++ b/src/operator/context/overlay.tsx
@@ -6,6 +6,7 @@ import {useDispatch} from 'react-redux'
 import {
   getOperatorOrgsLimits,
   getOperatorOrg,
+  postOperatorOrgsReactivate,
   putOperatorOrgsLimits,
 } from 'src/client/unityRoutes'
 import {notify} from 'src/shared/actions/notifications'
@@ -14,6 +15,8 @@ import {
   getLimitsError,
   updateLimitsError,
   updateLimitsSuccess,
+  reactivateOrgError,
+  reactivateOrgSuccess,
 } from 'src/shared/copy/notifications'
 import {toDisplayLimits} from 'src/operator/utils'
 
@@ -30,9 +33,11 @@ export interface OverlayContextType {
   limitsStatus: RemoteDataState
   handleGetLimits: (id: string) => void
   handleGetOrg: (id: string) => void
+  handleReactivateOrg: (id: string) => void
   handleUpdateLimits: (id: string, limits: OperatorOrgLimits) => void
   organization: OperatorOrg
   orgStatus: RemoteDataState
+  reactivateOrgStatus: RemoteDataState
   setLimits: (_: OperatorOrgLimits) => void
   updateLimitStatus: RemoteDataState
 }
@@ -40,11 +45,13 @@ export interface OverlayContextType {
 export const DEFAULT_CONTEXT: OverlayContextType = {
   handleGetLimits: (_: string) => {},
   handleGetOrg: (_: string) => {},
+  handleReactivateOrg: (_id: string) => {},
   handleUpdateLimits: (_id: string, _limits: OperatorOrgLimits) => {},
   limits: null,
   limitsStatus: RemoteDataState.NotStarted,
   organization: null,
   orgStatus: RemoteDataState.NotStarted,
+  reactivateOrgStatus: RemoteDataState.NotStarted,
   setLimits: (_: OperatorOrgLimits) => {},
   updateLimitStatus: RemoteDataState.NotStarted,
 }
@@ -55,6 +62,9 @@ export const OverlayContext =
 export const OverlayProvider: FC<Props> = React.memo(({children}) => {
   const [limits, setLimits] = useState(null)
   const [limitsStatus, setLimitsStatus] = useState(RemoteDataState.NotStarted)
+  const [reactivateOrgStatus, setReactivateOrgStatus] = useState(
+    RemoteDataState.NotStarted
+  )
   const [updateLimitStatus, setUpdateLimitStatus] = useState(
     RemoteDataState.NotStarted
   )
@@ -109,6 +119,21 @@ export const OverlayProvider: FC<Props> = React.memo(({children}) => {
     [dispatch]
   )
 
+  const handleReactivateOrg = useCallback(
+    async (id: string) => {
+      try {
+        setReactivateOrgStatus(RemoteDataState.Loading)
+        await postOperatorOrgsReactivate({orgId: id})
+        setReactivateOrgStatus(RemoteDataState.Done)
+        dispatch(notify(reactivateOrgSuccess(id)))
+      } catch (error) {
+        console.error(error)
+        dispatch(notify(reactivateOrgError(id)))
+      }
+    },
+    [dispatch]
+  )
+
   const handleUpdateLimits = useCallback(
     async (id: string, updatedLimits: OperatorOrgLimits) => {
       try {
@@ -129,11 +154,13 @@ export const OverlayProvider: FC<Props> = React.memo(({children}) => {
       value={{
         handleGetLimits,
         handleGetOrg,
+        handleReactivateOrg,
         handleUpdateLimits,
         limits,
         limitsStatus,
         organization,
         orgStatus,
+        reactivateOrgStatus,
         setLimits,
         updateLimitStatus,
       }}

--- a/src/shared/copy/notifications/categories/operator.ts
+++ b/src/shared/copy/notifications/categories/operator.ts
@@ -19,6 +19,18 @@ export const getOrgError = (id: string): Notification => ({
   message: `Could not find organization with ID ${id}`,
 })
 
+export const reactivateOrgSuccess = (id: string): Notification => ({
+  ...defaultSuccessNotification,
+  duration: FIVE_SECONDS,
+  message: `Successfully reactivated organization with the ID ${id}`,
+})
+
+export const reactivateOrgError = (id: string): Notification => ({
+  ...defaultErrorNotification,
+  duration: FIVE_SECONDS,
+  message: `Could not reactivate organization with ID ${id}`,
+})
+
 export const getLimitsError = (id: string): Notification => ({
   ...defaultErrorNotification,
   duration: FIVE_SECONDS,


### PR DESCRIPTION
Part of influxdata/quartz#6866

As part of Multi-Org, this adds a button to the operator UI to reactivate a suspended organization. This is only available to PAYG organizations that are suspended, but have not yet been deleted.

I made a fix to the OpenAPI Spec, hence the SHA change: https://github.com/influxdata/openapi/pull/620

![image](https://user-images.githubusercontent.com/31899323/204612843-7950de59-c57c-4851-b5b3-3be57d11f013.png)
![image](https://user-images.githubusercontent.com/31899323/204617349-e5469c05-cea2-40ff-8a45-c5f751ad316a.png)


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
