### PR TITLE
chore: add ability to use Iox org in tests

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -597,18 +597,17 @@ export const createToken = (
 export const setupUser = (useIox: boolean = false): Cypress.Chainable<any> => {
   useIox = Cypress.env('useIox') || useIox
   const defaultUser = Cypress.env('defaultUser')
-  let params = ''
+  const params = new URLSearchParams()
+  if (defaultUser) {
+    params.set('user', defaultUser)
+  }
   if (useIox) {
-    params = defaultUser
-      ? `?user=${defaultUser}&orgSuffix=ioxlighthouse`
-      : '?orgSuffix=ioxlighthouse'
-  } else {
-    params = defaultUser ? `?user=${defaultUser}` : ''
+    params.set('orgSuffix', 'ioxlighthouse')
   }
   return cy
     .request({
       method: 'GET',
-      url: `/debug/provision${params}`,
+      url: `/debug/provision${params.toString()}`,
     })
     .then(response => {
       if (response.status === 200) {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -595,6 +595,7 @@ export const createToken = (
 }
 
 export const setupUser = (useIox: boolean = false): Cypress.Chainable<any> => {
+  useIox = Cypress.env('useIox') || useIox
   const defaultUser = Cypress.env('defaultUser')
   let params = ''
   if (useIox) {
@@ -602,7 +603,7 @@ export const setupUser = (useIox: boolean = false): Cypress.Chainable<any> => {
       ? `?user=${defaultUser}&orgSuffix=ioxlighthouse`
       : '?orgSuffix=ioxlighthouse'
   } else {
-    params = defaultUser ? `?user=${defaultUser}` : '?'
+    params = defaultUser ? `?user=${defaultUser}` : ''
   }
   return cy
     .request({

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -607,7 +607,7 @@ export const setupUser = (useIox: boolean = false): Cypress.Chainable<any> => {
   return cy
     .request({
       method: 'GET',
-      url: `/debug/provision${params.toString()}`,
+      url: `/debug/provision?${params.toString()}`,
     })
     .then(response => {
       if (response.status === 200) {


### PR DESCRIPTION
Allows for testing with iox from cypress tests.

Passing `useIox: true` in `cy.signin` is one way to run a single test against Iox. Setting env var `CYPRESS_useIox=true` will run all the tests against Iox.

This PR does not change existing testing behavior, it just allows for customization in future PRs.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
