### PR TITLE
chore: document in code the tech debt behind the LSP worker buffer.

### DIFF
--- a/src/languageSupport/languages/flux/lsp/worker/flux.worker.ts
+++ b/src/languageSupport/languages/flux/lsp/worker/flux.worker.ts
@@ -17,7 +17,7 @@ const respond = (msg, cb) => {
 /**
  * Reasons for this buffer:
  *    * loading times for the monaco-editor client, versus LSP server
- *    * the required ordering of bootup-messages btwn these two, + the UI messages.
+ *    * the required ordering of bootup-messages between these two, + the UI messages.
  *
  * Details:
  *    * First, the loading of workers:
@@ -36,8 +36,7 @@ const respond = (msg, cb) => {
  *          3. monaco-editor request for didOpen file.
  *                * this is the flux query file.
  *                * triggered on callback after ConnectionManager is instantiated.
- *      * since the LSP worker takes awhile to boot up:
- *            * this buffer ensures that these^^ messages are received by the LSP in order.
+ *      * since the LSP worker takes a while to boot up, this buffer ensures that the messages are received by the LSP in order.
  *
  * If we boot up the LSP server entirely first, before the monaco-editor is loaded, we could hypothetically eliminate this buffer.
  * But it would substantially increase our load time, and trickle into CI test timings and variable parsing (in dashboard) etc.

--- a/src/languageSupport/languages/flux/lsp/worker/flux.worker.ts
+++ b/src/languageSupport/languages/flux/lsp/worker/flux.worker.ts
@@ -14,6 +14,34 @@ const respond = (msg, cb) => {
   }
 }
 
+/**
+ * Reasons for this buffer:
+ *    * loading times for the monaco-editor client, versus LSP server
+ *    * the required ordering of bootup-messages btwn these two, + the UI messages.
+ *
+ * Details:
+ *    * First, the loading of workers:
+ *        * we lazy load the monaco-editor, including that lib's own worker, which takes time.
+ *        * concurrently, we also load the LSP server thread, since that takes even longer to come online.
+ *    * Next, these messages must occur in order:
+ *          1. monaco-editor request initializing handshake (a.k.a. mutual capabilities).
+ *          2. UI request for didOpen for variables file (Prelude file).
+ *                * reason for order requirement:
+ *                     * monaco-editor creates new FileID (new model objects) in order
+ *                     * LSP assesses these files in order of the model ID
+ *                     * LSP needs to know variable assignments first. `option v = {foo: bar}` before use of foo.
+ *                * how solved:
+ *                     * after monaco-editor initialize, it calls the ConnectionManager constructor.
+ *                     * constructor() --> make prelude file/model.
+ *          3. monaco-editor request for didOpen file.
+ *                * this is the flux query file.
+ *                * triggered on callback after ConnectionManager is instantiated.
+ *      * since the LSP worker takes awhile to boot up:
+ *            * this buffer ensures that these^^ messages are received by the LSP in order.
+ *
+ * If we boot up the LSP server entirely first, before the monaco-editor is loaded, we could hypothetically eliminate this buffer.
+ * But it would substantially increase our load time, and trickle into CI test timings and variable parsing (in dashboard) etc.
+ */
 class Buffer {
   private _i = 0
   private _o = 0


### PR DESCRIPTION
Since this topic keeps coming up in conversation, decided to document in code. For our future selves.
The current time and ordering dependencies of how the LSP server boots up.


### Checklist
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
