### PR TITLE
fix: fix shared/explorer test with overwrite, rather than append request header in downloadhelper

### DIFF
--- a/src/shared/workers/downloadHelper.ts
+++ b/src/shared/workers/downloadHelper.ts
@@ -33,7 +33,7 @@ self.addEventListener('fetch', function (event: any) {
     for (const [headerType, headerValue] of event.request.headers) {
       switch (headerType) {
         case 'content-type':
-          headers.append('Content-Type', 'application/json')
+          headers.set('Content-Type', 'application/json')
           break
         case 'accept':
           headers.append('Accept', '*/*')


### PR DESCRIPTION
We're seeing CI test failures in remocal-ui-test-firefox-1-tsm-shared/explorer that seem tied to recent changes to the csv downloader and explorer test. There's a service worker that appends a new content-type header. Proper behavior is to set rather than append the content-type header. 

The cred goes to @hoorayimhelping for tracking this down.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable
