### PR TITLE
feat: add email and comment fields to marketo account upgrade form

### DIFF
--- a/src/identity/components/MarketoAccountUpgradeOverlay.scss
+++ b/src/identity/components/MarketoAccountUpgradeOverlay.scss
@@ -5,8 +5,15 @@
 }
 
 .marketo-upgrade-account-overlay--body {
+  font-size: $cf-text-base-1;
+
   p {
     font-size: $cf-text-base-1;
     margin-block-start: 0px;
   }
+}
+
+.marketo-account-upgrade-form--userinput {
+  margin-top: $cf-space-2xs;
+  font-weight: 400;
 }

--- a/src/identity/components/MarketoAccountUpgradeOverlay.scss
+++ b/src/identity/components/MarketoAccountUpgradeOverlay.scss
@@ -14,6 +14,6 @@
 }
 
 .marketo-account-upgrade-form--userinput {
-  margin-top: $cf-space-2xs;
   font-weight: 400;
+  margin-top: $cf-space-2xs;
 }

--- a/src/identity/components/MarketoAccountUpgradeOverlay.tsx
+++ b/src/identity/components/MarketoAccountUpgradeOverlay.tsx
@@ -5,6 +5,8 @@ import {
   Button,
   ComponentColor,
   ComponentStatus,
+  Input,
+  InputType,
   Overlay,
 } from '@influxdata/clockface'
 
@@ -62,6 +64,11 @@ enum MarketoError {
   ScriptRuntimeError = 'ScriptRuntimeError',
 }
 
+interface MarketoFormElement extends Element {
+  readOnly: boolean
+  disabled: boolean
+}
+
 // If marketo isn't working, still need the user to have some means of contacting sales.
 const SalesFormLink = (): JSX.Element => {
   return (
@@ -85,11 +92,26 @@ export const MarketoAccountUpgradeOverlay: FC = () => {
 
   const [scriptHasLoaded, setScriptHasLoaded] = useState(false)
   const [formHasLoaded, setFormHasLoaded] = useState(false)
+  const [formComment, setFormComment] = useState('')
 
   const handleCloseOverlay = () => {
     // Deleting marketo object guards against inconsistent behavior if user closes then re-opens the overlay.
     delete window.MktoForms2
     onClose()
+  }
+
+  const handleComment = (evt: React.ChangeEvent<HTMLInputElement>) => {
+    if (window.MktoForms2.getForm) {
+      try {
+        window.MktoForms2.getForm(MARKETO_FORM_ID).setValues({
+          Marketing_Notes__c: evt.target.value,
+        })
+      } catch (err) {
+        // Don't use honeybadger in onChange function - otherwise errors will spam our alerts.
+        console.error('Unable to locate marketo form.')
+      }
+    }
+    setFormComment(evt.target.value)
   }
 
   const handleError = useCallback(
@@ -135,8 +157,9 @@ export const MarketoAccountUpgradeOverlay: FC = () => {
             const marketoForm = window.MktoForms2
             if (marketoForm) {
               // Autofill the form with the current user and account id.
+
               marketoForm.getForm(MARKETO_FORM_ID).setValues({
-                Quartz_User_ID__c: parseInt(user.id),
+                Email: user.email,
                 Quartz_Account_ID__c: accountId,
               })
 
@@ -145,10 +168,17 @@ export const MarketoAccountUpgradeOverlay: FC = () => {
                 form.onSuccess(() => false)
               })
 
-              document.querySelectorAll('input').forEach(input => {
-                input.readOnly = true
-                input.disabled = true
-              })
+              document
+                .querySelectorAll('input, textarea, button')
+                .forEach((input: MarketoFormElement) => {
+                  if (
+                    input.className.includes('mktoField') ||
+                    input.className.includes('mktoButton')
+                  ) {
+                    input.readOnly = true
+                    input.disabled = true
+                  }
+                })
 
               setFormHasLoaded(true)
             }
@@ -202,11 +232,20 @@ export const MarketoAccountUpgradeOverlay: FC = () => {
           Click 'Contact Sales', and an InfluxData team member will reach out to
           you.
         </p>
-        <br />
         <form
           id={`mktoForm_${MARKETO_FORM_ID.toString()}`}
           className="marketo-account-upgrade--form"
         />
+        Comments
+        <Input
+          name="Upgrade Account Comments"
+          placeholder="Please provide any comments for our sales team"
+          autoFocus={true}
+          type={InputType.Text}
+          className="marketo-account-upgrade-form--userinput"
+          onChange={handleComment}
+          value={formComment}
+        ></Input>
       </Overlay.Body>
       <Overlay.Footer>
         <Button

--- a/src/identity/components/MarketoAccountUpgradeOverlay.tsx
+++ b/src/identity/components/MarketoAccountUpgradeOverlay.tsx
@@ -65,8 +65,8 @@ enum MarketoError {
 }
 
 interface MarketoFormElement extends Element {
-  readOnly: boolean
   disabled: boolean
+  readOnly: boolean
 }
 
 // If marketo isn't working, still need the user to have some means of contacting sales.
@@ -238,12 +238,12 @@ export const MarketoAccountUpgradeOverlay: FC = () => {
         />
         Comments
         <Input
-          name="Upgrade Account Comments"
-          placeholder="Please provide any comments for our sales team"
           autoFocus={true}
-          type={InputType.Text}
           className="marketo-account-upgrade-form--userinput"
+          name="Upgrade Account Comments"
           onChange={handleComment}
+          placeholder="Please provide any comments for our sales team"
+          type={InputType.Text}
           value={formComment}
         ></Input>
       </Overlay.Body>


### PR DESCRIPTION
Connects #6206 

This PR implements the UI side of changes by sales to the Marketo form to add user email and a comments field. This data is needed to associate submissions of the form with a specific user/account combination.

https://user-images.githubusercontent.com/91283923/205763653-5e63fae6-4da4-4d29-a8e6-5cdd451cfafd.mov


### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - `createDeleteOrgs`
