### PR TITLE
chore: remove data acquisition from codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,3 @@
 # Changes to any file in this repo require approval from a member of the InfluxData ui-team
 
 *   @influxdata/ui-team @influxdata/ecommerce
-/src/writeData/subscriptions/ @influxdata/data-acquisition
-/src/types/subscriptions.ts @influxdata/data-acquisition


### PR DESCRIPTION
Removes the Data Acquisition team from the codeowners file, since 2/3 of the team is gone and the sole remaining member is working in other domains. 
