### PR TITLE
fix(EAR-3809): Start service worker prior to page load.

### DIFF
--- a/src/mockState.tsx
+++ b/src/mockState.tsx
@@ -36,6 +36,7 @@ export const localState: LocalStorage = {
       },
       flowsCTA: {alerts: true, explorer: true, tasks: true},
       subscriptionsCertificateInterest: false,
+      workerRegistration: null,
     },
   },
   flags: {

--- a/src/shared/actions/app.ts
+++ b/src/shared/actions/app.ts
@@ -12,6 +12,7 @@ export enum ActionTypes {
   SetFlowsCTA = 'SET_FLOWS_CTA',
   Noop = 'NOOP',
   SetSubscriptionsCertificateInterest = 'SET_SUB_CERT_INTEREST',
+  SetWorkerRegistration = 'SET_WORKER_REGISTRATION',
 }
 
 export type Action =
@@ -25,6 +26,7 @@ export type Action =
   | ReturnType<typeof setVersionInfo>
   | ReturnType<typeof setFlowsCTA>
   | ReturnType<typeof setSubscriptionsCertificateInterest>
+  | ReturnType<typeof setWorkerRegistration>
 
 // ephemeral state action creators
 
@@ -83,4 +85,12 @@ export const setFlowsCTA = (flowsCTA: FlowsCTA) =>
 export const setSubscriptionsCertificateInterest = () =>
   ({
     type: ActionTypes.SetSubscriptionsCertificateInterest,
+  } as const)
+
+export const setWorkerRegistration = (
+  workerRegistration: Promise<ServiceWorkerRegistration>
+) =>
+  ({
+    type: ActionTypes.SetWorkerRegistration,
+    payload: {workerRegistration},
   } as const)

--- a/src/shared/components/CSVExportButton.tsx
+++ b/src/shared/components/CSVExportButton.tsx
@@ -12,11 +12,6 @@ import {runDownloadQuery} from 'src/timeMachine/actions/queries'
 // Types
 import {AppState} from 'src/types'
 
-// Worker
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import downloadWorker from 'worker-plugin/loader!../workers/downloadHelper'
-
 type Props = ConnectedProps<typeof connector>
 
 interface State {
@@ -28,8 +23,8 @@ class CSVExportButton extends PureComponent<Props, State> {
     super(props)
     this.state = {browserSupportsDownload: false}
 
-    if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register(downloadWorker).then(
+    if (props.workerRegistration) {
+      ;(props.workerRegistration as Promise<ServiceWorkerRegistration>).then(
         () => this.setState({browserSupportsDownload: true}),
         function (err) {
           console.error(
@@ -81,7 +76,7 @@ const mstp = (state: AppState) => {
   const activeQueryText = getActiveQuery(state).text
   const disabled = activeQueryText === ''
 
-  return {disabled}
+  return {disabled, workerRegistration: state.app.persisted.workerRegistration}
 }
 
 const mdtp = {

--- a/src/shared/reducers/app.ts
+++ b/src/shared/reducers/app.ts
@@ -19,6 +19,7 @@ export interface AppState {
     versionInfo: VersionInfo
     flowsCTA: FlowsCTA
     subscriptionsCertificateInterest: boolean
+    workerRegistration: Promise<ServiceWorkerRegistration>
   }
 }
 
@@ -36,6 +37,7 @@ const initialState: AppState = {
     versionInfo: {version: '', commit: ''},
     flowsCTA: {explorer: true, tasks: true, alerts: true},
     subscriptionsCertificateInterest: false,
+    workerRegistration: null,
   },
 }
 
@@ -123,6 +125,13 @@ const appPersistedReducer = (
       return {
         ...state,
         subscriptionsCertificateInterest: true,
+      }
+    }
+
+    case ActionTypes.SetWorkerRegistration: {
+      return {
+        ...state,
+        workerRegistration: action.payload.workerRegistration,
       }
     }
 


### PR DESCRIPTION
May close https://github.com/influxdata/EAR/issues/3809.

The service worker is running in prod, but not intercepting fetch requests. Per mdn service work lifecycle docs, service worker should be registered prior to page load -- to ensure is properly set.

## Debugging evidence, from prod:
**Check in prod (new tools), after Bill's fix was promoted.**

Bug is still occurring:

![Screen Shot 2022-12-06 at 11 08 29 AM](https://user-images.githubusercontent.com/10232835/206003601-bd8f2aaf-79f4-4d0a-89d3-9b0f7fc5ad43.png)


Can see service work is loaded and listening to events. (On inspect, confirmed in proper worker.)

![Screen Shot 2022-12-06 at 11 08 52 AM](https://user-images.githubusercontent.com/10232835/206003741-f00ac6df-c293-4c07-8ee2-2f719518c59b.png)

Outgoing csv download network calls (prior to service worker intercept), look the same in remocal (where no bug) versus in prod (where is bug). Only substantial difference the http protocol being used.

![in_remocal](https://user-images.githubusercontent.com/10232835/206005251-b13df1ca-d22e-495d-8668-1cfd89942ad3.png)


![in_prod](https://user-images.githubusercontent.com/10232835/206005657-cb613aeb-92e1-46e2-a8c1-e6de037de748.png)

## Attempted fix
Was not able to find a smoking gun on what is causing the service worker to not intercept requests in prod. However, did find documents stating that if the service work is running (and listening) but not intercepting -- then make sure the service worker is running prior to page load. (See mdn docs for [service worker life cycle](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers#basic_architecture).) So this is an experiment, which will either (a) have no impact, or (b) fix the issue.

## Checklist
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
