### PR TITLE
feat(6334): UI responds at acts upon LSP-initiated commands, as a result of new yieldless paradigm.

### DIFF
--- a/src/dataExplorer/components/SchemaBrowserHeading.tsx
+++ b/src/dataExplorer/components/SchemaBrowserHeading.tsx
@@ -19,16 +19,9 @@ import {event} from 'src/cloud/utils/reporting'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {LanguageType} from 'src/dataExplorer/components/resources'
 
-const FLUX_SYNC_DISABLE_TEXT = `Schema Sync is no longer available because the \
-code block has been edited.`
-
 const SchemaBrowserHeading: FC = () => {
   const {fluxSync, toggleFluxSync} = useContext(FluxQueryBuilderContext)
-  const {resource, selection} = useContext(PersistanceContext)
-
-  // Disable means diverged, used to not allow turning on or off the toggle
-  const disableToggle: boolean = selection.composition?.diverged
-  const disableTooltipText = disableToggle ? FLUX_SYNC_DISABLE_TEXT : ''
+  const {resource} = useContext(PersistanceContext)
 
   const handleFluxSyncToggle = () => {
     event('Toggled Flux Sync in schema browser', {active: `${!fluxSync}`})
@@ -69,20 +62,13 @@ const SchemaBrowserHeading: FC = () => {
           active={fluxSync}
           onChange={handleFluxSyncToggle}
           testID="flux-sync--toggle"
-          disabled={disableToggle}
-          tooltipText={disableTooltipText}
         />
         <InputLabel className="flux-sync--label">
-          <div
-            className={`${disableToggle ? 'disabled' : ''}`}
-            title={disableTooltipText}
-          >
-            <SelectorTitle
-              label="Flux Sync"
-              tooltipContents={tooltipContents}
-              icon={IconFont.Sync}
-            />
-          </div>
+          <SelectorTitle
+            label="Flux Sync"
+            tooltipContents={tooltipContents}
+            icon={IconFont.Sync}
+          />
         </InputLabel>
       </FlexBox>
     </FlexBox>

--- a/src/dataExplorer/context/fluxQueryBuilder.tsx
+++ b/src/dataExplorer/context/fluxQueryBuilder.tsx
@@ -74,6 +74,17 @@ export const FluxQueryBuilderProvider: FC = ({children}) => {
   )
   const [searchTerm, setSearchTerm] = useState('')
 
+  const transformSessionTagValuesToLocal = tagValues => {
+    const localTagValues = {} as SelectedTagValues
+    tagValues.forEach((tag: TagKeyValuePair) => {
+      if (!localTagValues[tag.key]) {
+        localTagValues[tag.key] = []
+      }
+      localTagValues[tag.key].push(tag.value)
+    })
+    return localTagValues
+  }
+
   useEffect(() => {
     if (selection.bucket && selection.measurement) {
       // On page refresh, measurements become empty even though
@@ -83,17 +94,17 @@ export const FluxQueryBuilderProvider: FC = ({children}) => {
 
       // On page refresh, re-contruct the state of selectedTagValues
       if (!!selection.tagValues) {
-        const _selectedTagValues = {} as SelectedTagValues
-        selection.tagValues.forEach((tag: TagKeyValuePair) => {
-          if (!_selectedTagValues[tag.key]) {
-            _selectedTagValues[tag.key] = []
-          }
-          _selectedTagValues[tag.key].push(tag.value)
-        })
+        const _selectedTagValues = transformSessionTagValuesToLocal(
+          selection.tagValues
+        )
         setSelectedTagValues(_selectedTagValues)
       }
     }
   }, [selection.bucket])
+
+  useEffect(() => {
+    setSelectedTagValues(transformSessionTagValuesToLocal(selection.tagValues))
+  }, [selection.tagValues])
 
   const handleToggleFluxSync = (synced: boolean): void => {
     setSelection({composition: {synced}})

--- a/src/dataExplorer/context/persistance.tsx
+++ b/src/dataExplorer/context/persistance.tsx
@@ -18,7 +18,6 @@ import {isOrgIOx} from 'src/organizations/selectors'
 
 interface CompositionStatus {
   synced: boolean // true == can modify session's schema
-  diverged: boolean // true == cannot re-sync. (e.g. user has typed in the composition block)
 }
 
 export enum GroupType {
@@ -100,7 +99,6 @@ export const DEFAULT_SELECTION: CompositionSelection = {
   tagValues: [] as TagKeyValuePair[],
   composition: {
     synced: true,
-    diverged: false,
   } as CompositionStatus,
   resultOptions: {
     fieldsAsColumn: false,
@@ -192,10 +190,6 @@ export const PersistanceProvider: FC = ({children}) => {
 
   const setCompositionSelection = useCallback(
     newSelection => {
-      if (selection.composition?.diverged && newSelection.composition?.synced) {
-        // cannot re-sync if diverged
-        return
-      }
       const composition: CompositionStatus = {
         ...(selection.composition || {}),
         ...(newSelection.composition || {}),

--- a/src/languageSupport/languages/flux/lsp/connection.ts
+++ b/src/languageSupport/languages/flux/lsp/connection.ts
@@ -8,7 +8,7 @@ import {EditorType, Variable} from 'src/types'
 import {buildUsedVarsOption} from 'src/variables/utils/buildVarsOption'
 
 // handling schema composition
-import {RecursivePartial} from 'src/types'
+import {RecursivePartial, TagKeyValuePair} from 'src/types'
 import {
   DEFAULT_SELECTION,
   DEFAULT_FLUX_EDITOR_TEXT,

--- a/src/languageSupport/languages/flux/lsp/connection.ts
+++ b/src/languageSupport/languages/flux/lsp/connection.ts
@@ -20,13 +20,17 @@ import {
   didOpen,
   didChange,
   executeCommand,
-  ExecuteCommandArgument,
-  ExecuteCommand,
-  ExecuteCommandT,
 } from 'src/languageSupport/languages/flux/lsp/utils'
-
-// error reporting
-import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
+import {
+  ExecuteCommand,
+  ExecuteCommandArgument,
+  ExecuteCommandT,
+  LspClientRequest,
+  LspClientCommand,
+  ActionItem,
+  ActionItemCommand,
+  LspRange,
+} from 'src/languageSupport/languages/flux/lsp/types'
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'

--- a/src/languageSupport/languages/flux/lsp/connection.ts
+++ b/src/languageSupport/languages/flux/lsp/connection.ts
@@ -417,5 +417,3 @@ class LspConnectionManager {
     this._model.onDidChangeContent(null)
   }
 }
-
-export default LspConnectionManager

--- a/src/languageSupport/languages/flux/lsp/connection.ts
+++ b/src/languageSupport/languages/flux/lsp/connection.ts
@@ -35,7 +35,11 @@ import {
 // Utils
 import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
 import {notify} from 'src/shared/actions/notifications'
-import {compositionEnded, oldSession} from 'src/shared/copy/notifications'
+import {
+  compositionUpdateFailed,
+  compositionEnded,
+  oldSession,
+} from 'src/shared/copy/notifications'
 
 export class ConnectionManager {
   private _worker: Worker
@@ -363,6 +367,9 @@ export class ConnectionManager {
       case LspClientCommand.AlreadyInitialized:
       case LspClientCommand.UpdateComposition:
         this._performActionItems(requestFromLsp.actions)
+        break
+      case LspClientCommand.ExecuteCommandFailed:
+        this._dispatcher(notify(compositionUpdateFailed()))
         break
       case LspClientCommand.CompositionEnded:
         this._setEditorBlockStyle(null)

--- a/src/languageSupport/languages/flux/lsp/monaco.flux.lsp.ts
+++ b/src/languageSupport/languages/flux/lsp/monaco.flux.lsp.ts
@@ -13,7 +13,7 @@ import {
   BrowserMessageWriter,
   createMessageConnection,
 } from 'vscode-jsonrpc/browser'
-import ConnectionManager from 'src/languageSupport/languages/flux/lsp/connection'
+import {ConnectionManager} from 'src/languageSupport/languages/flux/lsp/connection'
 
 // flux language support
 import FLUXLANGID from 'src/languageSupport/languages/flux/monaco.flux.syntax'

--- a/src/languageSupport/languages/flux/lsp/monaco.flux.lsp.ts
+++ b/src/languageSupport/languages/flux/lsp/monaco.flux.lsp.ts
@@ -79,6 +79,7 @@ export function initLspWorker() {
   messageWriter = new BrowserMessageWriter(worker)
   const connection = createMessageConnection(messageReader, messageWriter)
   const languageClient = createLanguageClient(connection)
+  manager.subscribeToConnection(languageClient)
   const disposable = languageClient.start()
   connection.onError(e => handleConnectionError(e))
   connection.onClose(() => {

--- a/src/languageSupport/languages/flux/lsp/types/executeCommand.ts
+++ b/src/languageSupport/languages/flux/lsp/types/executeCommand.ts
@@ -1,0 +1,76 @@
+/**
+ * @typedef {array} ExecuteCommandT
+ * Maps what `arguments` (params) are expected for each executeCommand `command`.
+ * Per the spec:
+ *     https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#executeCommandParams
+ */
+export type ExecuteCommandT =
+  | [ExecuteCommand.CompositionInit, CompositionInitParams]
+  | [ExecuteCommand.CompositionSetMeasurement, CompositionValueParams]
+  | [ExecuteCommand.CompositionAddField, CompositionValueParams]
+  | [ExecuteCommand.CompositionRemoveField, CompositionValueParams]
+  | [ExecuteCommand.CompositionAddTagValue, CompositionTagValueParams]
+  | [ExecuteCommand.CompositionRemoveTagValue, CompositionTagValueParams]
+
+/**
+ * @typedef {enum} ExecuteCommand
+ * Command for the custom work the server can perform.
+ *     * This enum in the string `command` provided here:
+ *         * https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#executeCommandOptions
+ *     * LSP server returns an applyEdit:
+ *         * https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_executeCommand
+ */
+export enum ExecuteCommand {
+  CompositionInit = 'fluxComposition/initialize',
+  CompositionSetMeasurement = 'fluxComposition/setMeasurementFilter',
+  CompositionAddField = 'fluxComposition/addFieldFilter',
+  CompositionRemoveField = 'fluxComposition/removeFieldFilter',
+  CompositionAddTagValue = 'fluxComposition/addTagValueFilter',
+  CompositionRemoveTagValue = 'fluxComposition/removeTagValueFilter',
+}
+
+export type ExecuteCommandArgument =
+  | CompositionInitParams
+  | CompositionValueParams
+
+/**
+ * @typedef {object} ExecuteCommandParams
+ * Base requirement of all ExecuteCommand requests.
+ * @property {string} ExecuteCommandParams.textDocument - TextDocumentItem per spec https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentItem
+ */
+interface ExecuteCommandParams {
+  textDocument: {
+    uri: string
+  }
+}
+
+/**
+ * @typedef {object} CompositionInitParams
+ * @property {string} CompositionInitParams.bucket - bucket name,
+ * @property {string} CompositionInitParams.measurement - measurement name,
+ * @property {string[]} CompositionInitParams.fields - optional prop, an array field names,
+ * @property {string[][]} CompositionInitParams.fields - optional prop, an array of tag key+value pairs
+ */
+export interface CompositionInitParams extends ExecuteCommandParams {
+  bucket: string
+  measurement?: string
+  fields?: string[]
+  tagValues?: string[][]
+}
+
+/**
+ * @typedef {object} CompositionValueParams
+ * @property {string} CompositionValueParams.value - the value in that execute command (e.g. field name, tag key),
+ */
+interface CompositionValueParams extends ExecuteCommandParams {
+  value: string
+}
+
+/**
+ * @typedef {object} CompositionTagValueParams
+ * @property {string}  CompositionTagValueParams.tag - the key in that execute command (e.g. tag key)
+ * @property {string}  CompositionTagValueParams.value - the value in that execute command (e.g. tag value),
+ */
+interface CompositionTagValueParams extends CompositionValueParams {
+  tag: string
+}

--- a/src/languageSupport/languages/flux/lsp/types/index.ts
+++ b/src/languageSupport/languages/flux/lsp/types/index.ts
@@ -1,30 +1,15 @@
-export * from './executeCommand'
-export * from './showMessage'
-
 /**
- * @typedef {enum} Methods
- * What LSP methods are provided per the spec:
- *    * see the `method` in the Request payload:
- *           * https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#requestMessage
- *    * These include the lifecycle methods:
- *           * https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#lifeCycleMessages
- *    * also includes an executeCommand method:
- *           * which is an extensible interface for custom work the server can perform.
+ * "Methods" == per each request sent to the LSP, there is an associated method.
+ *
+ * Special methods:
+ *    * the executeCommand method:
+ *        * we construct this message request in the UI code (not the monaco-editor) --> send to the LSP
+ *        * specific executeCommand structure (per spec) is typed in './executeCommand'
+ *    * the showMessage method:
+ *        * the LSP sends the UI this message request --> UI (not monaco-editor) performs downstream actions.
+ *        * specific showMessage structure (per spec) is typed in './showMessage
  */
-export enum Methods {
-  Initialize = 'initialize',
-  Initialized = 'initialized',
-  CompletionResolve = 'completionItem/resolve',
-  Completion = 'textDocument/completion',
-  Definition = 'textDocument/definition',
-  didChange = 'textDocument/didChange',
-  didOpen = 'textDocument/didOpen',
-  didSave = 'textDocument/didSave',
-  Highlight = 'textDocument/documentHighlight',
-  Symbol = 'textDocument/documentSymbol',
-  FoldingRange = 'textDocument/foldingRange',
-  Hover = 'textDocument/hover',
-  References = 'textDocument/references',
-  Rename = 'textDocument/rename',
-  ExecuteCommand = 'workspace/executeCommand',
-}
+
+export * from './executeCommand'
+export * from './methods'
+export * from './showMessage'

--- a/src/languageSupport/languages/flux/lsp/types/index.ts
+++ b/src/languageSupport/languages/flux/lsp/types/index.ts
@@ -1,0 +1,30 @@
+export * from './executeCommand'
+export * from './showMessage'
+
+/**
+ * @typedef {enum} Methods
+ * What LSP methods are provided per the spec:
+ *    * see the `method` in the Request payload:
+ *           * https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#requestMessage
+ *    * These include the lifecycle methods:
+ *           * https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#lifeCycleMessages
+ *    * also includes an executeCommand method:
+ *           * which is an extensible interface for custom work the server can perform.
+ */
+export enum Methods {
+  Initialize = 'initialize',
+  Initialized = 'initialized',
+  CompletionResolve = 'completionItem/resolve',
+  Completion = 'textDocument/completion',
+  Definition = 'textDocument/definition',
+  didChange = 'textDocument/didChange',
+  didOpen = 'textDocument/didOpen',
+  didSave = 'textDocument/didSave',
+  Highlight = 'textDocument/documentHighlight',
+  Symbol = 'textDocument/documentSymbol',
+  FoldingRange = 'textDocument/foldingRange',
+  Hover = 'textDocument/hover',
+  References = 'textDocument/references',
+  Rename = 'textDocument/rename',
+  ExecuteCommand = 'workspace/executeCommand',
+}

--- a/src/languageSupport/languages/flux/lsp/types/methods.ts
+++ b/src/languageSupport/languages/flux/lsp/types/methods.ts
@@ -1,0 +1,27 @@
+/**
+ * @typedef {enum} Methods
+ * What LSP methods are provided per the spec:
+ *    * see the `method` in the Request payload:
+ *           * https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#requestMessage
+ *    * These include the lifecycle methods:
+ *           * https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#lifeCycleMessages
+ *    * also includes an executeCommand method:
+ *           * which is an extensible interface for custom work the server can perform.
+ */
+export enum Methods {
+  Initialize = 'initialize',
+  Initialized = 'initialized',
+  CompletionResolve = 'completionItem/resolve',
+  Completion = 'textDocument/completion',
+  Definition = 'textDocument/definition',
+  didChange = 'textDocument/didChange',
+  didOpen = 'textDocument/didOpen',
+  didSave = 'textDocument/didSave',
+  Highlight = 'textDocument/documentHighlight',
+  Symbol = 'textDocument/documentSymbol',
+  FoldingRange = 'textDocument/foldingRange',
+  Hover = 'textDocument/hover',
+  References = 'textDocument/references',
+  Rename = 'textDocument/rename',
+  ExecuteCommand = 'workspace/executeCommand', // This method is send with a payload described in './ExecuteCommand'.
+}

--- a/src/languageSupport/languages/flux/lsp/types/showMessage.ts
+++ b/src/languageSupport/languages/flux/lsp/types/showMessage.ts
@@ -21,6 +21,7 @@ export enum LspClientCommand {
   UpdateComposition = 'fluxComposition/compositionState',
   CompositionEnded = 'fluxComposition/compositionEnded',
   CompositionNotFound = 'fluxComposition/compositionNotFound',
+  ExecuteCommandFailed = 'fluxComposition/executeCommandFailed',
   AlreadyInitialized = 'fluxComposition/alreadyInitialized',
 }
 

--- a/src/languageSupport/languages/flux/lsp/types/showMessage.ts
+++ b/src/languageSupport/languages/flux/lsp/types/showMessage.ts
@@ -46,6 +46,7 @@ export enum ActionItemCommand {
 
 export enum LspClientRequestPriority {
   ERROR = 1,
+  WARN = 2,
   INFO = 3,
 }
 

--- a/src/languageSupport/languages/flux/lsp/types/showMessage.ts
+++ b/src/languageSupport/languages/flux/lsp/types/showMessage.ts
@@ -1,0 +1,59 @@
+/**
+ * @typedef {enum} LspClientRequest
+ * LSP server-initiated request, intended for UI response.
+ *    * server request: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_showMessageRequest
+ */
+export interface LspClientRequest {
+  message: LspClientCommand
+  type: LspClientRequestPriority
+  actions: ActionItem[]
+}
+
+/**
+ * @typedef {enum} LspClientCommand
+ * The specific command from the LspServer, provided with the `LspClientRequest`.
+ *    * request parameters `ShowMessageRequestParams`:
+ *        * https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#showMessageRequestParams
+ *    * this enum is the `message` string on the showMessageRequest.
+ *        * provides the general command for the UI client.
+ */
+export enum LspClientCommand {
+  UpdateComposition = 'fluxComposition/compositionState',
+  CompositionEnded = 'fluxComposition/compositionEnded',
+  CompositionNotFound = 'fluxComposition/compositionNotFound',
+  AlreadyInitialized = 'fluxComposition/alreadyInitialized',
+}
+
+/**
+ * @typedef {interface} ActionItems
+ * The specific ActionItems, provided with an LspClientCommand.
+ *    * with each `ShowMessageRequestParams`, an array of `ActionItems` may be provided.
+ *    * the actionItems are a permissive structure, only requiring `title`:
+ *        * https://docs.rs/lsp-types/latest/lsp_types/struct.MessageActionItem.html
+ *        * the resulting json-rpc request message is `{title: <string>, ...otherProps}`
+ */
+export interface ActionItem {
+  title: ActionItemCommand
+  range?: LspRange
+  state?: any
+}
+
+export enum ActionItemCommand {
+  CompositionRange = 'CompositionRange',
+  CompositionState = 'CompositionState',
+}
+
+export enum LspClientRequestPriority {
+  ERROR = 1,
+  INFO = 3,
+}
+
+export interface LspRange {
+  start: LspPosition
+  end: LspPosition
+}
+
+export interface LspPosition {
+  column: number
+  line: number
+}

--- a/src/languageSupport/languages/flux/lsp/utils.ts
+++ b/src/languageSupport/languages/flux/lsp/utils.ts
@@ -2,6 +2,11 @@ import {
   ProtocolRequestType,
   ProtocolNotificationType,
 } from 'vscode-languageserver-protocol'
+import {
+  ExecuteCommand,
+  ExecuteCommandT,
+  Methods,
+} from 'src/languageSupport/languages/flux/lsp/types'
 
 export const makeRequestType = (method: string) => {
   return new ProtocolRequestType<any, any, any, any, any>(method)
@@ -52,66 +57,6 @@ export const didOpen = (uri: string, text: string, version: number) => {
   })
 }
 
-/**
- * @typedef {object} ExecuteCommandParams
- * Base requirement of all ExecuteCommand requests.
- * @property {string} ExecuteCommandParams.textDocument - TextDocumentItem per spec https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentItem
- */
-interface ExecuteCommandParams {
-  textDocument: {
-    uri: string
-  }
-}
-
-/**
- * @typedef {object} CompositionInitParams
- * @property {string} CompositionInitParams.bucket - bucket name,
- * @property {string} CompositionInitParams.measurement - measurement name,
- * @property {string[]} CompositionInitParams.fields - optional prop, an array field names,
- * @property {string[][]} CompositionInitParams.fields - optional prop, an array of tag key+value pairs
- */
-export interface CompositionInitParams extends ExecuteCommandParams {
-  bucket: string
-  measurement?: string
-  fields?: string[]
-  tagValues?: string[][]
-}
-
-/**
- * @typedef {object} CompositionValueParams
- * @property {string} CompositionValueParams.value - the value in that execute command (e.g. field name, tag key),
- */
-interface CompositionValueParams extends ExecuteCommandParams {
-  value: string
-}
-
-/**
- * @typedef {object} CompositionTagValueParams
- * @property {string}  CompositionTagValueParams.tag - the key in that execute command (e.g. tag key)
- * @property {string}  CompositionTagValueParams.value - the value in that execute command (e.g. tag value),
- */
-interface CompositionTagValueParams extends CompositionValueParams {
-  tag: string
-}
-
-export type ExecuteCommandArgument =
-  | CompositionInitParams
-  | CompositionValueParams
-
-/**
- * @typedef {array} ExecuteCommandT
- * Maps what `arguments` (params) are expected for each executeCommand `command`.
- * Per the spec:
- *     https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#executeCommandParams
- */
-export type ExecuteCommandT =
-  | [ExecuteCommand.CompositionInit, CompositionInitParams]
-  | [ExecuteCommand.CompositionSetMeasurement, CompositionValueParams]
-  | [ExecuteCommand.CompositionAddField, CompositionValueParams]
-  | [ExecuteCommand.CompositionRemoveField, CompositionValueParams]
-  | [ExecuteCommand.CompositionAddTagValue, CompositionTagValueParams]
-  | [ExecuteCommand.CompositionRemoveTagValue, CompositionTagValueParams]
-
 function validateExecuteCommandPayload([command, arg]: ExecuteCommandT):
   | boolean
   | never {
@@ -149,49 +94,4 @@ export const executeCommand = (payload: ExecuteCommandT): object | never => {
       workDoneToken: null,
     },
   })
-}
-
-/**
- * @typedef {enum} Methods
- * What LSP methods are provided per the spec:
- *    * see the `method` in the Request payload:
- *           * https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#requestMessage
- *    * These include the lifecycle methods:
- *           * https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#lifeCycleMessages
- *    * also includes an executeCommand method:
- *           * which is an extensible interface for custom work the server can perform.
- */
-export enum Methods {
-  Initialize = 'initialize',
-  Initialized = 'initialized',
-  CompletionResolve = 'completionItem/resolve',
-  Completion = 'textDocument/completion',
-  Definition = 'textDocument/definition',
-  didChange = 'textDocument/didChange',
-  didOpen = 'textDocument/didOpen',
-  didSave = 'textDocument/didSave',
-  Highlight = 'textDocument/documentHighlight',
-  Symbol = 'textDocument/documentSymbol',
-  FoldingRange = 'textDocument/foldingRange',
-  Hover = 'textDocument/hover',
-  References = 'textDocument/references',
-  Rename = 'textDocument/rename',
-  ExecuteCommand = 'workspace/executeCommand',
-}
-
-/**
- * @typedef {enum} ExecuteCommand
- * Command for the custom work the server can perform.
- *     * This enum in the string `command` provided here:
- *         * https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#executeCommandOptions
- *     * LSP server returns an applyEdit:
- *         * https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_executeCommand
- */
-export enum ExecuteCommand {
-  CompositionInit = 'fluxComposition/initialize',
-  CompositionSetMeasurement = 'fluxComposition/setMeasurementFilter',
-  CompositionAddField = 'fluxComposition/addFieldFilter',
-  CompositionRemoveField = 'fluxComposition/removeFieldFilter',
-  CompositionAddTagValue = 'fluxComposition/addTagValueFilter',
-  CompositionRemoveTagValue = 'fluxComposition/removeTagValueFilter',
 }

--- a/src/languageSupport/languages/flux/lsp/worker/flux.worker.ts
+++ b/src/languageSupport/languages/flux/lsp/worker/flux.worker.ts
@@ -1,5 +1,5 @@
 import {Lsp} from '@influxdata/flux-lsp-browser'
-import {Methods} from 'src/languageSupport/languages/flux/lsp/utils'
+import {Methods} from 'src/languageSupport/languages/flux/lsp/types'
 
 const respond = (msg, cb) => {
   try {

--- a/src/shared/components/FluxMonacoEditor.tsx
+++ b/src/shared/components/FluxMonacoEditor.tsx
@@ -17,7 +17,7 @@ import {
   submit,
 } from 'src/languageSupport/languages/flux/monaco.flux.hotkeys'
 import {registerAutogrow} from 'src/languageSupport/monaco.autogrow'
-import ConnectionManager from 'src/languageSupport/languages/flux/lsp/connection'
+import {ConnectionManager} from 'src/languageSupport/languages/flux/lsp/connection'
 
 // Contexts and State
 import {EditorContext} from 'src/shared/contexts/editor'

--- a/src/shared/components/FluxMonacoEditor.tsx
+++ b/src/shared/components/FluxMonacoEditor.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC, useEffect, useRef, useContext, useMemo} from 'react'
-import {useSelector} from 'react-redux'
+import {useDispatch, useSelector} from 'react-redux'
 import {useRouteMatch} from 'react-router-dom'
 import classnames from 'classnames'
 
@@ -61,6 +61,7 @@ const FluxEditorMonaco: FC<Props> = ({
   wrapLines,
   variables,
 }) => {
+  const dispatch = useDispatch()
   const connection = useRef<ConnectionManager>(null)
   const {editor, setEditor} = useContext(EditorContext)
   const isFluxQueryBuilder = useSelector(fluxQueryBuilder)
@@ -84,7 +85,8 @@ const FluxEditorMonaco: FC<Props> = ({
     if (connection.current && useSchemaComposition) {
       connection.current.onSchemaSessionChange(
         sessionStore.selection,
-        sessionStore.setSelection
+        sessionStore.setSelection,
+        dispatch
       )
     }
   }, [

--- a/src/shared/components/MonacoEditor.scss
+++ b/src/shared/components/MonacoEditor.scss
@@ -80,24 +80,4 @@
   .composition-sync--on--last {
     border-bottom: 1px solid $c-pool;
   }
-
-  .composition-sync--off {
-    opacity: 50%;
-    background-color: $cf-grey-35;
-  }
-
-  .composition-sync--off--first {
-    opacity: 50%;
-    border-top: 1px solid $cf-white;
-    // composition sync icon
-    background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M4.82511 4.0427L7.10622 1.6971L5.67243 0.302734L0.0902793 6.0427H16V4.0427H4.82511ZM11.1749 11.9571H0V9.95714H15.9097L10.3275 15.6971L8.89376 14.3027L11.1749 11.9571Z' fill='white'/%3E%3C/svg%3E%0A");
-    background-repeat: no-repeat;
-    background-size: 11px 11px;
-    background-position: $cf-space-3xs $cf-space-3xs;
-  }
-
-  .composition-sync--off--last {
-    opacity: 50%;
-    border-bottom: 1px solid $cf-white;
-  }
 }

--- a/src/shared/contexts/editor/index.tsx
+++ b/src/shared/contexts/editor/index.tsx
@@ -16,7 +16,7 @@ import {
 import {getFluxExample} from 'src/shared/utils/fluxExample'
 
 // LSP
-import LspConnectionManager from 'src/languageSupport/languages/flux/lsp/connection'
+import {ConnectionManager} from 'src/languageSupport/languages/flux/lsp/connection'
 
 // Utils
 import {CLOUD} from 'src/shared/constants'
@@ -25,7 +25,7 @@ export interface EditorContextType {
   editor: EditorType | null
   setEditor: (
     editor: EditorType,
-    conn: React.MutableRefObject<LspConnectionManager>
+    conn: React.MutableRefObject<ConnectionManager>
   ) => void
   inject: (options: InjectionOptions) => void
   injectFunction: (fn, cbToParent) => void

--- a/src/shared/copy/notifications/categories/dashboard.ts
+++ b/src/shared/copy/notifications/categories/dashboard.ts
@@ -145,3 +145,13 @@ export const csvDownloadFailure = (): Notification => ({
   ...defaultErrorNotification,
   message: 'Failed to download csv.',
 })
+
+export const oldSession = (): Notification => ({
+  ...defaultErrorNotification,
+  message: 'Old user session detected. Please create a new script.',
+})
+
+export const compositionEnded = (): Notification => ({
+  ...defaultErrorNotification,
+  message: 'Composition has ended.',
+})

--- a/src/shared/copy/notifications/categories/dashboard.ts
+++ b/src/shared/copy/notifications/categories/dashboard.ts
@@ -151,7 +151,13 @@ export const oldSession = (): Notification => ({
   message: 'Old user session detected. Please create a new script.',
 })
 
+export const compositionUpdateFailed = (): Notification => ({
+  ...defaultErrorNotification,
+  message: 'Composition was not updated. Try again.',
+})
+
 export const compositionEnded = (): Notification => ({
   ...defaultErrorNotification,
-  message: 'Composition has ended.',
+  message:
+    'Composition has ended. Turn on flux sync, to start a new composition.',
 })


### PR DESCRIPTION
Part of https://github.com/influxdata/ui/issues/6334

Note: this is part of a chain of PRs.
`staging/yieldless-composition`  <-- 1st PR <-- 2nd PR <-- 3rd PR
The final staging branch will be the merge into master.


#### PR Chain:
1. https://github.com/influxdata/ui/pull/6344
2. this PR.
3. https://github.com/influxdata/ui/pull/6397 where tests finally pass!

## DONE:

Closes #5926 — trace/intercept lsp requests from the server
Closes #5717, #5305 — build a middleware, or equivalent solution, to prevent composition from getting out of sync with ui
Closes #5925 — surface to user the errors

Each commit gives a rough outline of the item done. ("Rough" because broke up the commits after the fact.). A high level summary is:
* break out the lsp-related types into a submodule. Divided into client-initiated commands (`executeCommand`) versus LspServer-inititiated commands.
* don't use default export for LspConnectionManager
* remove concept of composition divergence, since it no longer applies.
  * e.g. the UI-side no longer detects if a user-action occurs --> which results in divergence
  * instead, the LSP itself decides if it can find the composition, or drop it
* remove any reference/dependent use of the `|> yield()`
* separate out the different pathways (and what to message the LSP) for:
   * page reload (or first load)
   * change to composition
   * new script creation. (In which case the LSP drops the composition indirectly, based on a monaco-client request)
* introduce equivalent replacement (based on minimal needs) for the middleware.
  * this closes a bunch of issues.
  * also messages to the user, when the LspServer has given the current composition state:
     * if fields, tags, etc is not added --> will update the session
     * if composition is dropped --> will (1) turn off flux sync, (2) toast the user, and (3) remove composition styles
     * for each change to editor text --> will update the composition styles (e.g. when lines added within the block)
* debug tagValues     
  * the session store needs to be the src of truth
  * this assume requires the different tagValue store structures, to be mapped to each other.
  * QA'ed locally --> if LSP server does not accept an added tagValue, the middleware listener will correctly  update the UI session.


## Visual evidence:
Basic rules:
* if cannot recognize a previous composition --> start a new one.
  * this most often occurs when a new bucket is selected.
* if the LSP has dropped the composition for any reason --> toast, and turn off flux sync --> prompt user to resync
* tries to reattached composition on page reload  

https://user-images.githubusercontent.com/10232835/207445854-3381245d-de28-4e98-b30a-7d3e4c0bc8b2.mov


## Checklist
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
