### PR TITLE
fix(EAR-3809): explicitly set service worker scope

### DIFF
--- a/src/shared/components/CSVExportButton.tsx
+++ b/src/shared/components/CSVExportButton.tsx
@@ -25,7 +25,18 @@ class CSVExportButton extends PureComponent<Props, State> {
 
     if (props.workerRegistration) {
       ;(props.workerRegistration as Promise<ServiceWorkerRegistration>).then(
-        () => this.setState({browserSupportsDownload: true}),
+        registrationResult => {
+          // ready() promise never resolves, if main thread does not detect worker.
+          navigator.serviceWorker.ready.then(() => {
+            if (registrationResult.active.state == 'activated') {
+              this.setState({browserSupportsDownload: true})
+            } else {
+              console.error(
+                'Main thread says worker is ready, but the worker itself is reporting not active.'
+              )
+            }
+          })
+        },
         function (err) {
           console.error(
             'Feature not available, because ServiceWorker registration failed: ',

--- a/src/shared/components/CSVExportButton.tsx
+++ b/src/shared/components/CSVExportButton.tsx
@@ -26,16 +26,13 @@ class CSVExportButton extends PureComponent<Props, State> {
     if (props.workerRegistration) {
       ;(props.workerRegistration as Promise<ServiceWorkerRegistration>).then(
         registrationResult => {
-          // ready() promise never resolves, if main thread does not detect worker.
-          navigator.serviceWorker.ready.then(() => {
-            if (registrationResult.active.state == 'activated') {
-              this.setState({browserSupportsDownload: true})
-            } else {
-              console.error(
-                'Main thread says worker is ready, but the worker itself is reporting not active.'
-              )
-            }
-          })
+          if (registrationResult.active.state == 'activated') {
+            this.setState({browserSupportsDownload: true})
+          } else {
+            console.error(
+              'Feature not available, because ServiceWorker is registered but inactive.'
+            )
+          }
         },
         function (err) {
           console.error(

--- a/src/shared/contexts/app.tsx
+++ b/src/shared/contexts/app.tsx
@@ -28,9 +28,14 @@ import {presentationMode as presentationModeCopy} from 'src/shared/copy/notifica
 import {AppState, TimeZone, Theme, NavBarState, FlowsCTA} from 'src/types'
 import {event} from 'src/cloud/utils/reporting'
 
-import {registerServiceWorker} from 'src/shared/workers/serviceWorker'
-
-const workerRegistration = registerServiceWorker()
+let workerRegistration
+import(
+  /* webpackPreload: true */
+  /* webpackChunkName: "setup-interceptor" */
+  'src/shared/workers/serviceWorker'
+).then(
+  ({registerServiceWorker}) => (workerRegistration = registerServiceWorker())
+)
 
 interface AppSettingContextType {
   timeZone: TimeZone

--- a/src/shared/workers/downloadHelper.ts
+++ b/src/shared/workers/downloadHelper.ts
@@ -67,3 +67,10 @@ self.addEventListener('fetch', function (event: any) {
     event.respondWith(fetch(event.request))
   }
 })
+
+/// Have the latest version register (including updated registration settings).
+self.addEventListener('activate', event => {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  event.waitUntil(clients.claim())
+})

--- a/src/shared/workers/serviceWorker.ts
+++ b/src/shared/workers/serviceWorker.ts
@@ -6,7 +6,8 @@ export const registerServiceWorker = (): Promise<ServiceWorkerRegistration> => {
     workerRegistration = navigator.serviceWorker.register(
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
-      new URL('../workers/downloadHelper.ts', import.meta.url)
+      new URL('../workers/downloadHelper.ts', import.meta.url),
+      {scope: location.hostname}
     )
   }
 

--- a/src/shared/workers/serviceWorker.ts
+++ b/src/shared/workers/serviceWorker.ts
@@ -7,7 +7,8 @@ export const registerServiceWorker = (): Promise<ServiceWorkerRegistration> => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       new URL('../workers/downloadHelper.ts', import.meta.url),
-      {scope: `${location.hostname}/api/v2/query`}
+      {scope: '/api/v2/query'}
+      /* webpackChunkName: "interceptor" */
     )
   }
 

--- a/src/shared/workers/serviceWorker.ts
+++ b/src/shared/workers/serviceWorker.ts
@@ -7,7 +7,7 @@ export const registerServiceWorker = (): Promise<ServiceWorkerRegistration> => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       new URL('../workers/downloadHelper.ts', import.meta.url),
-      {scope: location.hostname}
+      {scope: `${location.hostname}/api/v2/query`}
     )
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,6 @@
     "noImplicitUseStrict": false,
     "noUnusedParameters": true,
     "noUnusedLocals": true,
-    "removeComments": true,
     "importHelpers": true,
     "noLib": false,
     "noEmitHelpers": true,

--- a/webpack.fast.ts
+++ b/webpack.fast.ts
@@ -7,5 +7,10 @@ module.exports = merge(common, {
   mode: 'none',
   output: {
     filename: `${STATIC_DIR}[contenthash:10].js`,
+    chunkFilename: pathData => {
+      return ['interceptor', 'setup-interceptor'].includes(pathData.chunk.name)
+        ? '[contenthash:10].js'
+        : `${STATIC_DIR}[contenthash:10].js`
+    },
   },
 })

--- a/webpack.prod.ts
+++ b/webpack.prod.ts
@@ -15,6 +15,11 @@ module.exports = mergeWebpack(commonWebpack, {
   devtool: 'source-map',
   output: {
     filename: `${DIRECTORY_STATIC}[contenthash:10].js`,
+    chunkFilename: pathData => {
+      return ['interceptor', 'setup-interceptor'].includes(pathData.chunk.name)
+        ? '[contenthash:10].js'
+        : `${DIRECTORY_STATIC}[contenthash:10].js`
+    },
   },
   module: {
     rules: [


### PR DESCRIPTION
Closes https://github.com/influxdata/EAR/issues/3809.

Upon registration the service worker takes [the scope ](https://web.dev/service-worker-lifecycle/#scope-and-control)(by default) of its path. In the webpack dev build, that is `<origin>/`. In the prod build, that is `<origin>/static`. The network intercepts only work within that path; meaning a fetch `<scope>/restOfRequestPath`.

## Done:
* explicitly set the scope, when registering the worker.
    * `{scope: '/api/v2/query'}` which is relative to the current scope
* browser security only allows scope narrowing, not broadening, of the resource path.
    * What this means is that:
        * the script registering the worker must the served from `<origin>/<filename>`  , not `<origin>/static/<filename>`.
        * the script of the worker worker itself must also be`<origin>/<filename>`  , not `<origin>/static/<filename>`.
        * Then the service worker will successfully register, and can access the scope from `<origin>/`.
    * How done:
        * webpack still does `<origin>/static/<filename>` for all other assets. Except for chunks explicitly named as setup-interceptor and interceptor => those are not nested under the static scope.
        * This required the use of webpack magic comments, therefore I had to remove the typescript compilation stripping of comments. However, the webpack minification rules still include comment stripping.
        * ran prod build locally to check; confirmed only those assessed are non-static. And the service worker is fully functional.
* some future proofing:
    * if you do already have an older service worker registered (in browser console: `navigator.serviceWorker.getRegistrations()`), you want to make sure the updated worker (with the proper scope) is claiming the network traffic for this path. Used [Clients.claim()](https://developer.mozilla.org/en-US/docs/Web/API/Clients/claim) to handle this use case.

## Visual evidence:
<img width="734" alt="Screen Shot 2022-12-07 at 10 44 10 PM" src="https://user-images.githubusercontent.com/10232835/206380528-5149899e-d427-475b-836d-1168d68a3848.png">



## Checklist
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
