### PR TITLE
feat(identity): show deleted org status in orgs list

### DIFF
--- a/src/identity/components/OrganizationListTab/OrgList.tsx
+++ b/src/identity/components/OrganizationListTab/OrgList.tsx
@@ -20,11 +20,11 @@ import {getSortedResources, SortTypes} from 'src/shared/utils/sort'
 
 // Types
 import {Sort} from '@influxdata/clockface'
-import {OrganizationSummaries} from 'src/client/unityRoutes'
+import {QuartzOrganization} from 'src/identity/apis/org'
 
 interface Props {
   currentPage: number
-  filteredOrgs: OrganizationSummaries
+  filteredOrgs: QuartzOrganization[]
   isAtOrgLimit: boolean
   pageHeight: number
   setTotalPages: (action: SetStateAction<number>) => void
@@ -112,6 +112,7 @@ export const OrgList: FC<Props> = ({
           provider={org.provider}
           regionCode={org.regionCode}
           regionName={org.regionName}
+          provisioningStatus={org.provisioningStatus}
         />
       ))}
     </>

--- a/src/identity/components/OrganizationListTab/OrganizationCard.scss
+++ b/src/identity/components/OrganizationListTab/OrganizationCard.scss
@@ -7,6 +7,16 @@
   border-radius: 2px;
 }
 
+.account--organizations-tab-suspended-orgs-card  {
+  margin-top: $cf-space-3xs;
+  margin-bottom: $cf-space-3xs;
+  border-radius: 2px;
+  background-color: #0e0e0e;
+  div:not(:last-child) {
+    opacity: 0.5;
+  }
+}
+
 .account--organizations-tab-orgs-card-cluster-data {
   width: 150px;
 }
@@ -18,7 +28,19 @@
 }
 
 .account-organizations-tab-orgs-card-location-data {
-  width: 240px;
+  width: 200px;
+}
+
+.account-organizations-tab-orgs-status--text {
+  color: $cf-white;
+}
+
+.account-organizations-tab-orgs-card-org-status {
+  width: 150px;
+  .cf-question-mark-tooltip {
+    background-color: $cf-white;
+    color: $cf-grey-5;
+  }
 }
 
 .account--organizations-tab-orgs-card-orgname {

--- a/src/identity/components/OrganizationListTab/OrganizationCard.scss
+++ b/src/identity/components/OrganizationListTab/OrganizationCard.scss
@@ -7,7 +7,7 @@
   border-radius: 2px;
 }
 
-.account--organizations-tab-suspended-orgs-card  {
+.account--organizations-tab-suspended-orgs-card {
   margin-top: $cf-space-3xs;
   margin-bottom: $cf-space-3xs;
   border-radius: 2px;

--- a/src/identity/components/OrganizationListTab/OrganizationCard.scss
+++ b/src/identity/components/OrganizationListTab/OrganizationCard.scss
@@ -1,17 +1,17 @@
 @import '@influxdata/clockface/dist/variables.scss';
 
 .account--organizations-tab-orgs-card {
-  margin-top: $cf-space-3xs;
-  margin-bottom: $cf-space-3xs;
   background-color: $cf-grey-15;
   border-radius: 2px;
+  margin-bottom: $cf-space-3xs;
+  margin-top: $cf-space-3xs;
 }
 
 .account--organizations-tab-suspended-orgs-card {
-  margin-top: $cf-space-3xs;
-  margin-bottom: $cf-space-3xs;
+  background-color: #11121a;
   border-radius: 2px;
-  background-color: #0e0e0e;
+  margin-bottom: $cf-space-3xs;
+  margin-top: $cf-space-3xs;
   div:not(:last-child) {
     opacity: 0.5;
   }
@@ -46,7 +46,7 @@
 .account--organizations-tab-orgs-card-orgname {
   .cf-resource-name--text {
     font-size: $cf-text-base-1;
-    color: $cf-white;
     font-weight: $cf-font-weight--bold;
+    color: $cf-white;
   }
 }

--- a/src/identity/components/OrganizationListTab/OrganizationCard.tsx
+++ b/src/identity/components/OrganizationListTab/OrganizationCard.tsx
@@ -4,6 +4,7 @@ import {
   FlexDirection,
   JustifyContent,
   ResourceCard,
+  QuestionMarkTooltip,
 } from '@influxdata/clockface'
 
 // Styles
@@ -14,6 +15,7 @@ interface OrgCardProps {
   provider: string
   regionCode: string
   regionName: string
+  provisioningStatus: string
 }
 
 export const OrganizationCard: FC<OrgCardProps> = ({
@@ -21,10 +23,32 @@ export const OrganizationCard: FC<OrgCardProps> = ({
   provider,
   regionCode,
   regionName,
+  provisioningStatus,
 }) => {
+
+  const isOrgSuspended = provisioningStatus === 'suspended'
+
+  const tooltipContent = (
+    <p>
+      Organizations can be reactivated within 7 days. Contact support at{' '}
+      <a
+        href="mailto:support@influxdata.com"
+        target="_blank"
+        rel="noreferrer noopener"
+      >
+        support@influxdata.com
+      </a>{' '}
+      to reactivate.
+    </p>
+  )
+
   return (
     <ResourceCard
-      className="account--organizations-tab-orgs-card"
+      className={
+        isOrgSuspended
+          ? 'account--organizations-tab-suspended-orgs-card'
+          : 'account--organizations-tab-orgs-card'
+      }
       direction={FlexDirection.Row}
       justifyContent={JustifyContent.SpaceBetween}
       testID="account--organizations-tab-orgs-card"
@@ -42,6 +66,22 @@ export const OrganizationCard: FC<OrgCardProps> = ({
         </FlexBox>
         <FlexBox className="account-organizations-tab-orgs-card-location-data">
           <b>Location:</b> &nbsp;{regionName}
+        </FlexBox>
+        <FlexBox
+          justifyContent={JustifyContent.SpaceBetween}
+          className="account-organizations-tab-orgs-card-org-status"
+        >
+          {isOrgSuspended && (
+            <>
+              <b className="account-organizations-tab-orgs-status--text">
+                Deletion in progress
+              </b>
+              <QuestionMarkTooltip
+                diameter={15}
+                tooltipContents={tooltipContent}
+              />
+            </>
+          )}
         </FlexBox>
       </ResourceCard.Meta>
     </ResourceCard>

--- a/src/identity/components/OrganizationListTab/OrganizationCard.tsx
+++ b/src/identity/components/OrganizationListTab/OrganizationCard.tsx
@@ -25,7 +25,6 @@ export const OrganizationCard: FC<OrgCardProps> = ({
   regionName,
   provisioningStatus,
 }) => {
-
   const isOrgSuspended = provisioningStatus === 'suspended'
 
   const tooltipContent = (

--- a/src/identity/components/OrganizationListTab/OrganizationCard.tsx
+++ b/src/identity/components/OrganizationListTab/OrganizationCard.tsx
@@ -3,9 +3,12 @@ import {
   FlexBox,
   FlexDirection,
   JustifyContent,
-  ResourceCard,
   QuestionMarkTooltip,
+  ResourceCard,
 } from '@influxdata/clockface'
+
+// Utils
+import {SafeBlankLink} from 'src/utils/SafeBlankLink'
 
 // Styles
 import './OrganizationCard.scss'
@@ -13,33 +16,30 @@ import './OrganizationCard.scss'
 interface OrgCardProps {
   name: string
   provider: string
+  provisioningStatus?: string
   regionCode: string
   regionName: string
-  provisioningStatus: string
 }
+
+const tooltipContent = (
+  <p>
+    Organizations can be reactivated within 7 days of deletion. Contact support
+    at{' '}
+    <SafeBlankLink href="mailto:support@influxdata.com">
+      support@influxdata.com
+    </SafeBlankLink>{' '}
+    to reactivate.
+  </p>
+)
 
 export const OrganizationCard: FC<OrgCardProps> = ({
   name,
   provider,
+  provisioningStatus,
   regionCode,
   regionName,
-  provisioningStatus,
 }) => {
   const isOrgSuspended = provisioningStatus === 'suspended'
-
-  const tooltipContent = (
-    <p>
-      Organizations can be reactivated within 7 days. Contact support at{' '}
-      <a
-        href="mailto:support@influxdata.com"
-        target="_blank"
-        rel="noreferrer noopener"
-      >
-        support@influxdata.com
-      </a>{' '}
-      to reactivate.
-    </p>
-  )
 
   return (
     <ResourceCard


### PR DESCRIPTION
See #5477 

Pr adds unique styling and deletion status indicator for orgs that are in the process of deletion. In addition, for users looking to reactive or recover their org, it adds a tooltip with link to InfluxData support. 
 
<img width="1397" alt="newMulti-org-deletion" src="https://user-images.githubusercontent.com/66275100/206455341-6ea6d9bc-9e20-4b2d-878e-44cd8a78e370.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable `createDeleteOrgs`
