### PR TITLE
fix: remove indentation of active org name

### DIFF
--- a/src/identity/components/OrganizationListTab/OrganizationCard.scss
+++ b/src/identity/components/OrganizationListTab/OrganizationCard.scss
@@ -49,6 +49,7 @@
     font-weight: $cf-font-weight--bold;
     color: $cf-white;
   }
+  margin-left: 0 !important;
 }
 
 .account--organizations-tab-active-org {
@@ -57,7 +58,7 @@
   border-width: 5px;
   color: $c-rainforest;
   display: inline-block;
-  left: 14px;
+  left: 9px;
   margin-top: 6px;
   position: absolute;
 }


### PR DESCRIPTION
fix to remove a small indentation of active org name in the org list page. 

Before 
<img width="291" alt="Screen Shot 2022-12-09 at 11 43 15 AM" src="https://user-images.githubusercontent.com/66275100/206761219-ab9bca4f-361f-42d8-a5b7-be3a46a40518.png">

After
<img width="329" alt="Screen Shot 2022-12-09 at 11 42 42 AM" src="https://user-images.githubusercontent.com/66275100/206761144-56d3d1bc-db2f-4110-b5d6-bd7b6b047b67.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
