### PR TITLE
chore(flags): remove flag firstMileScrollTop; feature is on

### DIFF
--- a/src/homepageExperience/utils.ts
+++ b/src/homepageExperience/utils.ts
@@ -1,7 +1,5 @@
 import {IconFont} from '@influxdata/clockface'
 
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
-
 export const HOMEPAGE_NAVIGATION_STEPS = [
   {
     name: 'Overview',
@@ -107,13 +105,11 @@ export const HOMEPAGE_NAVIGATION_STEPS_ARDUINO = [
 // Set a timeout of 0 so that this function call gets run after react has a had a chance to update state and
 // re-render on the main thread.
 export const scrollNextPageIntoView = () => {
-  if (isFlagEnabled('firstMileScrollTop')) {
-    setTimeout(() => {
-      document.querySelector('h1').scrollIntoView({
-        behavior: 'smooth',
-        block: 'nearest',
-        inline: 'nearest',
-      })
-    }, 0)
-  }
+  setTimeout(() => {
+    document.querySelector('h1').scrollIntoView({
+      behavior: 'smooth',
+      block: 'nearest',
+      inline: 'nearest',
+    })
+  }, 0)
 }


### PR DESCRIPTION
Removes the confitional around the flag `firstMileScrollTop`, and the flag itself. This turns the feature on completely.

This flag handles an experimental feature in onboarding. When a user scrolls down on a step in the onboarding flow, then goes to another step, the top of the page will be automatically scrolled into view if applicable. At the time of this PR, the feature has been on for almost 3 months.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- ~[ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~
- ~[ ] Feature flagged, if applicable~
