### PR TITLE
chore: re-add subscriptionsUI flag

### DIFF
--- a/cypress/e2e/cloud/subscriptions.test.ts
+++ b/cypress/e2e/cloud/subscriptions.test.ts
@@ -13,6 +13,8 @@ describe('Subscriptions', () => {
             }).then(() => {
               cy.visit(`${orgs}/${id}/load-data/sources`)
 
+              cy.setFeatureFlags({subscriptionsUI: true})
+
               cy.getByTestID('subscriptions--tab').should('be.visible')
               cy.intercept('POST', `/api/v2private/broker/subs*`).as(
                 'CreateSubscription'

--- a/src/authorizations/components/CustomApiTokenOverlay.tsx
+++ b/src/authorizations/components/CustomApiTokenOverlay.tsx
@@ -47,6 +47,7 @@ import {
   generateDescription,
 } from 'src/authorizations/utils/permissions'
 import {event} from 'src/cloud/utils/reporting'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
 
 interface OwnProps {
@@ -100,9 +101,14 @@ const CustomApiTokenOverlay: FC<Props> = props => {
       const perms = {
         otherResources: {read: false, write: false},
       }
+
       allResources
+        // filter out Subsriptions resource type if the UI is not enabled
         .filter(
-          p => p !== ResourceType.Subscriptions && String(p) !== 'instance'
+          resource =>
+            (resource !== ResourceType.Subscriptions ||
+              isFlagEnabled('subscriptionsUI')) &&
+            String(resource) !== 'instance'
         )
         .forEach(resource => {
           if (resource === ResourceType.Telegrafs) {

--- a/src/authorizations/utils/permissions.ts
+++ b/src/authorizations/utils/permissions.ts
@@ -1,5 +1,6 @@
 import {Permission, ResourceType} from 'src/types'
 import {capitalize} from 'lodash'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 export type PermissionTypes = Permission['resource']['type']
 
@@ -58,7 +59,9 @@ export const formatResources = resourceNames => {
     item =>
       item !== ResourceType.Buckets &&
       item !== ResourceType.Telegrafs &&
-      item !== ResourceType.Subscriptions &&
+      // filter out Subsriptions resource type if the UI is not enabled
+      (item !== ResourceType.Subscriptions ||
+        isFlagEnabled('subscriptionsUI')) &&
       String(item) !== 'instance'
   )
   resources.sort()

--- a/src/homepageExperience/containers/HomepageContainer.tsx
+++ b/src/homepageExperience/containers/HomepageContainer.tsx
@@ -37,6 +37,7 @@ import './HomepageContainer.scss'
 import {event} from 'src/cloud/utils/reporting'
 import UsageProvider from 'src/usage/context/usage'
 import Resources from 'src/me/components/Resources'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Selectors
 import {getOrg} from 'src/organizations/selectors'
@@ -205,31 +206,33 @@ export const HomepageContainer: FC = () => {
                     </Link>
                   </FlexBox>
                   <hr style={{marginTop: '8px'}} />
-                  <Link
-                    to={mqttPageLink}
-                    style={linkStyle}
-                    onClick={logMQTTButtonClick}
-                  >
-                    <div
-                      className="homepage-write-data-tile"
-                      data-testid="homepage-wizard-tile--mqtt"
+                  {isFlagEnabled('subscriptionsUI') && (
+                    <Link
+                      to={mqttPageLink}
+                      style={linkStyle}
+                      onClick={logMQTTButtonClick}
                     >
-                      <div className="tile-icon-text-wrapper">
-                        <div className="icon">{MQTTIcon}</div>
-                        <div>
-                          <h4>Native MQTT</h4>
-                          <h6>
-                            Connect to your MQTT subscription in the cloud.
-                          </h6>
+                      <div
+                        className="homepage-write-data-tile"
+                        data-testid="homepage-wizard-tile--mqtt"
+                      >
+                        <div className="tile-icon-text-wrapper">
+                          <div className="icon">{MQTTIcon}</div>
+                          <div>
+                            <h4>Native MQTT</h4>
+                            <h6>
+                              Connect to your MQTT subscription in the cloud.
+                            </h6>
+                          </div>
                         </div>
-                      </div>
 
-                      <Icon
-                        glyph={IconFont.ArrowRight_New}
-                        className="arrow-button"
-                      />
-                    </div>
-                  </Link>
+                        <Icon
+                          glyph={IconFont.ArrowRight_New}
+                          className="arrow-button"
+                        />
+                      </div>
+                    </Link>
+                  )}
                   <Link
                     to={cliPageLink}
                     style={linkStyle}

--- a/src/pageLayout/constants/navigationHierarchy.ts
+++ b/src/pageLayout/constants/navigationHierarchy.ts
@@ -82,7 +82,7 @@ export const generateNavItems = (
           testID: 'nav-subitem-subscriptions',
           label: 'Native Subscriptions',
           link: `${orgPrefix}/load-data/subscriptions`,
-          enabled: () => CLOUD,
+          enabled: () => CLOUD && isFlagEnabled('subscriptionsUI'),
         },
         {
           id: 'tokens',

--- a/src/settings/components/LoadDataNavigation.tsx
+++ b/src/settings/components/LoadDataNavigation.tsx
@@ -60,7 +60,7 @@ const LoadDataNavigation: FC<Props> = ({activeTab}) => {
       id: 'subscriptions',
       cloudExclude: false,
       cloudOnly: true,
-      featureFlag: null,
+      featureFlag: 'subscriptionsUI',
     },
     {
       text: 'API Tokens',

--- a/src/shared/containers/SetOrg.tsx
+++ b/src/shared/containers/SetOrg.tsx
@@ -217,13 +217,13 @@ const SetOrg: FC = () => {
             path={`${orgPath}/${LOAD_DATA}/${BUCKETS}`}
             component={BucketsIndex}
           />
-          {CLOUD && (
+          {CLOUD && isFlagEnabled('subscriptionsUI') && (
             <Route
               path={`${orgPath}/${LOAD_DATA}/${SUBSCRIPTIONS}/create`}
               component={CreateSubscriptionForm}
             />
           )}
-          {CLOUD && (
+          {CLOUD && isFlagEnabled('subscriptionsUI') && (
             <Route
               path={`${orgPath}/${LOAD_DATA}/${SUBSCRIPTIONS}/:id/notifications`}
               render={props => (
@@ -237,7 +237,7 @@ const SetOrg: FC = () => {
               component={DetailsSubscriptionPage}
             />
           )}
-          {CLOUD && (
+          {CLOUD && isFlagEnabled('subscriptionsUI') && (
             <Route
               path={`${orgPath}/${LOAD_DATA}/${SUBSCRIPTIONS}`}
               component={SubscriptionsLanding}

--- a/src/writeData/components/WriteDataSections.tsx
+++ b/src/writeData/components/WriteDataSections.tsx
@@ -17,6 +17,9 @@ import ClientLibrarySection from 'src/writeData/components/ClientLibrarySection'
 import TelegrafPluginSection from 'src/writeData/components/TelegrafPluginSection'
 import CloudNativeSources from 'src/writeData/subscriptions/components/CloudNativeSources'
 
+// Utils
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+
 const WriteDataSections: FC = () => {
   const {searchTerm} = useContext(WriteDataSearchContext)
   const hasResults =
@@ -38,7 +41,7 @@ const WriteDataSections: FC = () => {
     <>
       <FileUploadSection />
       <ClientLibrarySection />
-      {CLOUD && <CloudNativeSources />}
+      {CLOUD && isFlagEnabled('subscriptionsUI') && <CloudNativeSources />}
       <TelegrafPluginSection />
     </>
   )


### PR DESCRIPTION
Closes https://github.com/influxdata/idpe/issues/16722

Wraps the MQTT feature in the `subscriptionsUI` feature flag by reverting the commit that removed it.
Adds the feature flag check to the homepage link to MQTT

**MQTT homepage with flag on**
![with1](https://user-images.githubusercontent.com/146112/207410981-b7c7f33b-c264-45dd-9a4d-4a289910ade7.png)
**MQTT homepage with flag off**
![without1](https://user-images.githubusercontent.com/146112/207410989-8c9eaef3-5cb6-4cd6-b4df-5f4ff7f575df.png)

**Homepage and nav with flag on**
![with-nav](https://user-images.githubusercontent.com/146112/207411303-5bfddee5-6494-482c-8898-43654d7a088f.png)
**Homepage and nav with flag off**
![without-nav](https://user-images.githubusercontent.com/146112/207411315-784e3bae-2ecf-4ddd-a15d-546f0a07f6a1.png)

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- ~[ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~
- [x] Feature flagged, if applicable
