### PR TITLE
chore: change orgs icon in accounts dropdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
   "dependencies": {
     "@codingame/monaco-jsonrpc": "^0.3.1",
     "@docsearch/react": "^3.0.0-alpha.37",
-    "@influxdata/clockface": "^6.3.9",
+    "@influxdata/clockface": "^6.3.11",
     "@influxdata/flux-lsp-browser": "0.8.36",
     "@influxdata/giraffe": "^2.38.1",
     "@influxdata/influxdb-templates": "0.9.0",

--- a/src/identity/components/GlobalHeader/AccountDropdown.tsx
+++ b/src/identity/components/GlobalHeader/AccountDropdown.tsx
@@ -60,7 +60,7 @@ export const AccountDropdown: FC<Props> = ({
         },
         {
           name: 'Organizations',
-          iconFont: IconFont.Group,
+          iconFont: IconFont.OrganizationChart,
           href: `/orgs/${activeOrg.id}/accounts/orglist`,
           enabled: isCreateDeleteFlagOn,
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1499,10 +1499,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@influxdata/clockface@^6.3.9":
-  version "6.3.9"
-  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-6.3.9.tgz#8a2046fc7457e40d50b8a16af8b9eadd4480198d"
-  integrity sha512-n5gZiCBXGPXDHbxwqCQ5VYvaqG5WnsOJscTPxG7p9dgf/erUFOMD4+aHH+qZMU/a9QVsJD8hMX7eUqTRkYhVTQ==
+"@influxdata/clockface@^6.3.11":
+  version "6.3.11"
+  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-6.3.11.tgz#89b3e48526afba1420d7b38f635f5645a5b54e30"
+  integrity sha512-+A/xgPCA6rSyqaWh46cwQbu7AL+149c6kA+sHpQMq36YE+W+H7et1Hks3aOHwbnX7pxKhZFtBs0rZ4Cn+LA8mA==
   dependencies:
     "@types/react-window" "^1.8.5"
     react-window "^1.8.7"


### PR DESCRIPTION
Closes #6215 

Updates the Organization List icon in the account dropdown from this:
![Screen Shot 2022-12-13 at 5 23 05 PM](https://user-images.githubusercontent.com/91283923/207457649-ca6868c7-4b16-4922-80b1-e3d72121d637.png)

To what is planned in the multi org figma:
![Screen Shot 2022-12-13 at 5 20 22 PM](https://user-images.githubusercontent.com/91283923/207457249-f02154b8-2a8d-430a-95d3-a4c2d6ea9ce0.png)

This PR also bumps clockface up two versions, to include this icon.

Validate UI Based on Clockface Upgrade:
--

https://user-images.githubusercontent.com/91283923/207457376-b2545de3-4cb1-47fd-b41d-e2a797cc75ba.mov



### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - `createDeleteOrgs`
