### PR TITLE
feat(6334): update tests to handle yieldless composition

### DIFF
--- a/cypress/e2e/shared/fluxQueryBuilder.test.ts
+++ b/cypress/e2e/shared/fluxQueryBuilder.test.ts
@@ -558,7 +558,8 @@ describe('Script Builder', () => {
         cy.getByTestID('flux-sync--toggle').should('not.have.class', 'active')
 
         cy.log('modify schema browser')
-        selectSchema()
+        selectBucket(bucketName)
+        selectMeasurement(measurement)
 
         cy.log('editor text is still empty')
         cy.getByTestID('flux-editor').within(() => {

--- a/cypress/e2e/shared/fluxQueryBuilder.test.ts
+++ b/cypress/e2e/shared/fluxQueryBuilder.test.ts
@@ -56,6 +56,9 @@ describe('Script Builder', () => {
   const selectSchema = () => {
     cy.log('select bucket')
     selectBucket(bucketName)
+    cy.getByTestID('flux-editor').contains(`from(bucket: "${bucketName}")`, {
+      timeout: 30000,
+    })
 
     cy.log('select measurement')
     selectMeasurement(measurement)
@@ -64,16 +67,12 @@ describe('Script Builder', () => {
   const confirmSchemaComposition = () => {
     cy.getByTestID('flux-editor', {timeout: 30000})
       // we set a manual delay on page load, for composition initialization
-      // https://github.com/influxdata/ui/blob/e76f934c6af60e24c6356f4e4ce9b067e5a9d0d5/src/languageSupport/languages/flux/lsp/connection.ts#L435-L440
       .contains(`from(bucket: "${bucketName}")`, {timeout: 30000})
     cy.getByTestID('flux-editor').contains(
       `|> filter(fn: (r) => r._measurement == "${measurement}")`
     )
-    cy.getByTestID('flux-editor').contains(
-      `|> yield(name: "_editor_composition")`
-    )
     cy.getByTestID('flux-editor').within(() => {
-      cy.get('.composition-sync--on').should('have.length', 4) // four lines
+      cy.get('.composition-sync--on').should('have.length', 3) // three lines
     })
   }
 
@@ -93,6 +92,11 @@ describe('Script Builder', () => {
             DEFAULT_FLUX_EDITOR_TEXT
           )
         })
+      }
+    })
+    cy.getByTestID('flux-sync--toggle').then($toggle => {
+      if (!$toggle.hasClass('active')) {
+        $toggle.click()
       }
     })
   }
@@ -271,7 +275,7 @@ describe('Script Builder', () => {
         cy.log('select dataset with 1 table')
         selectBucket('defbuck4')
         cy.getByTestID('flux-editor').contains(`from(bucket: "defbuck4")`, {
-          timeout: 3000,
+          timeout: 5000,
         })
         cy.getByTestID('data-explorer--csv-download').should('be.disabled')
         selectMeasurement('ndbc_1table')
@@ -303,7 +307,7 @@ describe('Script Builder', () => {
           cy.log('select larger dataset')
           selectBucket('defbuck4')
           cy.getByTestID('flux-editor').contains(`from(bucket: "defbuck4")`, {
-            timeout: 3000,
+            timeout: 5000,
           })
           cy.getByTestID('data-explorer--csv-download').should('be.disabled')
           selectMeasurement('ndbc_big')
@@ -494,130 +498,13 @@ describe('Script Builder', () => {
           .click()
           .should('have.class', 'active')
 
-        cy.log('can diverge from sync')
-        selectSchema()
-        confirmSchemaComposition()
-        cy.getByTestID('flux-editor').monacoType(
-          '{upArrow}{upArrow} // make diverge'
-        )
+        cy.log('turn off flux sync')
+        cy.getByTestID('flux-sync--toggle')
+          .click()
+          .should('not.have.class', 'active')
 
-        cy.log('toggle is now disabled')
-        cy.getByTestID('flux-sync--toggle').should('have.class', 'disabled')
-
-        cy.log('can still browse schema while diverged')
+        cy.log('can still browse schema while not synced')
         selectBucket('defbuck2')
-      })
-
-      describe('conditions for divergence:', () => {
-        // only flakes in OSS. But skip for now, debug later.
-        it.skip('diverges when typing in composition block', () => {
-          cy.getByTestID('flux-sync--toggle').should('have.class', 'active')
-          cy.getByTestID('flux-editor', {timeout: 30000})
-          selectSchema()
-          confirmSchemaComposition()
-
-          cy.log('does not diverge when outside block')
-          cy.getByTestID('flux-editor').monacoType('// will not diverge')
-          cy.getByTestID('flux-sync--toggle').should(
-            'not.have.class',
-            'disabled'
-          )
-
-          cy.log(
-            'does not diverge, when adding import statement outside of block'
-          )
-          cy.getByTestID('flux-toolbar-search--input')
-            .should('exist')
-            .type('fieldsAsCols')
-          cy.get('.flux-toolbar--list-item').first().click()
-          cy.getByTestID('flux-editor').contains('import')
-          cy.getByTestID('flux-sync--toggle').should(
-            'not.have.class',
-            'disabled'
-          )
-
-          /// FIXME: Does not work yet, since the LSP response for applyEdit starts at line 0
-          // cy.log(
-          //   'does not diverge, when further modifying block (with imports at top)'
-          // )
-
-          cy.log('does diverge, within block')
-          cy.getByTestID('flux-editor')
-            .should('exist')
-            .monacoType(
-              '{enter}{upArrow}{upArrow}{upArrow}{upArrow} // make diverge'
-            )
-          cy.log('toggle is now disabled')
-          cy.getByTestID('flux-sync--toggle').should('have.class', 'disabled')
-        })
-
-        it('using hotkeys:', () => {
-          const runTest = (hotKeyCombo: string) => {
-            cy.getByTestID('flux-sync--toggle').should('have.class', 'active')
-            cy.getByTestID('flux-editor', {timeout: 30000})
-            selectSchema()
-            confirmSchemaComposition()
-
-            cy.log('does not diverge when outside block')
-            cy.getByTestID('flux-editor').monacoType(`foo ${hotKeyCombo}`)
-            cy.getByTestID('flux-sync--toggle').should(
-              'not.have.class',
-              'disabled'
-            )
-
-            cy.log('does diverge, within block')
-            cy.getByTestID('flux-editor').monacoType(
-              `{upArrow}{upArrow}{upArrow} ${hotKeyCombo}`
-            )
-            cy.log('toggle is now disabled')
-            cy.getByTestID('flux-sync--toggle').should('have.class', 'disabled')
-
-            cy.log('clear session')
-            clearSession()
-          }
-
-          cy.log('diverges when commenting line')
-          runTest('{cmd}/')
-
-          cy.log('diverges when adding lines')
-          runTest('{shift+alt+downArrow}')
-
-          cy.log('diverges when removing lines')
-          runTest('{cmd+x}')
-
-          cy.log('diverges when moving lines')
-          runTest('{alt+downArrow}')
-        })
-
-        /// XXX: wiedld (27 Sep 2022) -- we have no way to delineate btwn the LSP applyEdit,
-        /// and the undo action applyEdit.
-        /// Either we disable the undo/redo hotkeys, or accept this edge case bug.
-        it.skip('diverges when using undo hotkeys, to undo composition block change', () => {
-          cy.getByTestID('flux-sync--toggle').should('have.class', 'active')
-          cy.getByTestID('flux-editor', {timeout: 30000})
-          selectSchema()
-          confirmSchemaComposition()
-
-          cy.log('make a change, via schema composition')
-          const newMeasurement = 'ndbc2'
-          cy.getByTestID('measurement-selector--dropdown-button').click()
-          cy.getByTestID(`searchable-dropdown--item ${newMeasurement}`)
-            .should('be.visible')
-            .click()
-          cy.getByTestID('measurement-selector--dropdown-button').should(
-            'contain',
-            newMeasurement
-          )
-          cy.getByTestID('flux-editor').contains(
-            `|> filter(fn: (r) => r._measurement == "${newMeasurement}")`
-          )
-
-          cy.log('use undo hotkey')
-          cy.getByTestID('flux-editor').monacoType('{cmd+z}')
-
-          cy.log('toggle is now disabled')
-          cy.getByTestID('flux-sync--toggle').should('have.class', 'disabled')
-        })
       })
 
       it('should clear the editor text and schema browser, with a new script', () => {
@@ -627,9 +514,7 @@ describe('Script Builder', () => {
         selectSchema()
 
         cy.log('editor text contains the composition')
-        cy.getByTestID('flux-editor').contains(
-          `|> yield(name: "_editor_composition")`
-        )
+        confirmSchemaComposition()
 
         cy.log('click new script, and choose to delete current script')
         cy.getByTestID('flux-query-builder--new-script')

--- a/src/languageSupport/languages/flux/lsp/connection.ts
+++ b/src/languageSupport/languages/flux/lsp/connection.ts
@@ -334,7 +334,7 @@ export class ConnectionManager {
       // since this._diffSchemaChange() can set the model
       // we need the executeCommand to be issued after the model update
       if (shouldDelay) {
-        setTimeout(() => this._updateLsp(toAdd, toRemove), 1500)
+        setTimeout(() => this._updateLsp(toAdd, toRemove), 3000)
       } else {
         this._updateLsp(toAdd, toRemove)
       }
@@ -378,7 +378,10 @@ export class ConnectionManager {
         break
       case LspClientCommand.CompositionEnded:
         this._setEditorBlockStyle(null)
-        this._setSessionSync(false)
+        if (this._model.getValue() != DEFAULT_FLUX_EDITOR_TEXT) {
+          // lost the flux sync. Note: ignore when this occurs during `New Script`.
+          this._setSessionSync(false)
+        }
         this._dispatcher(notify(compositionEnded()))
         break
       case LspClientCommand.CompositionNotFound:

--- a/src/languageSupport/languages/flux/lsp/connection.ts
+++ b/src/languageSupport/languages/flux/lsp/connection.ts
@@ -321,7 +321,9 @@ export class ConnectionManager {
       previousState
     )
 
-    if (this._first_load) {
+    const multipleItemsToSync =
+      Object.keys(toAdd).length + Object.keys(toRemove).length > 1
+    if (this._first_load || multipleItemsToSync) {
       this._first_load = false
       setTimeout(
         () => this._initLspComposition(toAdd),

--- a/src/languageSupport/languages/flux/lsp/connection.ts
+++ b/src/languageSupport/languages/flux/lsp/connection.ts
@@ -42,6 +42,7 @@ import {
 } from 'src/shared/copy/notifications'
 
 const APPROXIMATE_LSP_STARTUP_DELAY = 3000
+const APPROXIMATE_EDITOR_SET_VALUE_DELAY = 3000
 
 export class ConnectionManager {
   private _worker: Worker
@@ -321,9 +322,9 @@ export class ConnectionManager {
       previousState
     )
 
-    const multipleItemsToSync =
+    const hasMultipleItemsToSync =
       Object.keys(toAdd).length + Object.keys(toRemove).length > 1
-    if (this._first_load || multipleItemsToSync) {
+    if (this._first_load || hasMultipleItemsToSync) {
       this._first_load = false
       setTimeout(
         () => this._initLspComposition(toAdd),
@@ -336,7 +337,10 @@ export class ConnectionManager {
       // since this._diffSchemaChange() can set the model
       // we need the executeCommand to be issued after the model update
       if (shouldDelay) {
-        setTimeout(() => this._updateLsp(toAdd, toRemove), 3000)
+        setTimeout(
+          () => this._updateLsp(toAdd, toRemove),
+          APPROXIMATE_EDITOR_SET_VALUE_DELAY
+        )
       } else {
         this._updateLsp(toAdd, toRemove)
       }
@@ -380,7 +384,7 @@ export class ConnectionManager {
         break
       case LspClientCommand.CompositionEnded:
         this._setEditorBlockStyle(null)
-        if (this._model.getValue() != DEFAULT_FLUX_EDITOR_TEXT) {
+        if (this._model.getValue() !== DEFAULT_FLUX_EDITOR_TEXT) {
           // lost the flux sync. Note: ignore when this occurs during `New Script`.
           this._setSessionSync(false)
         }


### PR DESCRIPTION
Part of https://github.com/influxdata/ui/issues/6334

Note: this is part of a chain of PRs.
`staging/yieldless-composition`  <-- 1st PR <-- 2nd PR <-- 3rd PR
The final staging branch will be the merge into master.


#### PR Chain:
1. https://github.com/influxdata/ui/pull/6344
2. https://github.com/influxdata/ui/pull/6374
3. this PR.

## DONE:

Update tests to handle yieldless composition. This includes:
* remove any references to `|> yield()` transformation
* remove the concept of composition divergence. (Since this no longer exists.)
* handle slightly different timings, in how the stateful composition works.



## Checklist
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable.
