### PR TITLE
fix: for new yieldless composition, hasMultipleItemsToSync requires to empty keys.

### DIFF
--- a/src/languageSupport/languages/flux/lsp/connection.ts
+++ b/src/languageSupport/languages/flux/lsp/connection.ts
@@ -276,24 +276,36 @@ export class ConnectionManager {
       toAdd.measurement = schema.measurement
     }
     if (!isEqual(schema.fields, previousState.fields)) {
-      toRemove.fields = previousState.fields.filter(
+      const fieldsToRemove = previousState.fields.filter(
         f => !schema.fields.includes(f)
       )
-      toAdd.fields = schema.fields.filter(
+      if (fieldsToRemove.length) {
+        toRemove.fields = fieldsToRemove
+      }
+      const fieldsToAdd = schema.fields.filter(
         f => !previousState.fields.includes(f)
       )
+      if (fieldsToAdd.length) {
+        toAdd.fields = fieldsToAdd
+      }
     }
     if (!isEqual(schema.tagValues, previousState.tagValues)) {
-      toRemove.tagValues = previousState.tagValues.filter(
+      const tagValuesToRemove = previousState.tagValues.filter(
         ({key, value}) =>
           !schema.tagValues.some(pair => pair.value == value && pair.key == key)
       )
-      toAdd.tagValues = schema.tagValues.filter(
+      if (tagValuesToRemove.length) {
+        toRemove.tagValues = tagValuesToRemove
+      }
+      const tagValuesToAdd = schema.tagValues.filter(
         ({key, value}) =>
           !previousState.tagValues.some(
             pair => pair.value == value && pair.key == key
           )
       )
+      if (tagValuesToAdd.length) {
+        toAdd.tagValues = tagValuesToAdd
+      }
     }
 
     return {toAdd, toRemove, shouldDelay}


### PR DESCRIPTION
Issue seen in prod, were fields and tagValues added are not being sent to the LSP.

Reason is because this line, added after the local manual QA:
```
const hasMultipleItemsToSync =
      Object.keys(toAdd).length + Object.keys(toRemove).length > 1
```

Therefore, we cannot add empty `toAdd.fields = []` etc in the diffing method.
Hotfix now. Later PR will add test coverage to prevent regression.


## Checklist
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
