### PR TITLE
chore: boost test coverage composition

### DIFF
--- a/cypress/e2e/shared/fluxQueryBuilder.test.ts
+++ b/cypress/e2e/shared/fluxQueryBuilder.test.ts
@@ -3,10 +3,10 @@ import {Organization} from '../../../src/types'
 const DEFAULT_FLUX_EDITOR_TEXT =
   '// Start by selecting data from the schema browser or typing flux here'
 
-// monaco-editor lazy loads + LspServer comes online
-const DELAY_FOR_LSP_SERVER_ONLINE = 30000
-
-const APPROXIMATE_EDITOR_SET_VALUE_DELAY = 3000
+// These delays are separately loaded in the UI.
+// But cypress checks for them in series...and the LspServer takes longer.
+const DELAY_FOR_LAZY_LOAD_EDITOR = 30000
+const DELAY_FOR_LSP_SERVER_BOOTUP = 30000
 
 const DELAY_FOR_FILE_DOWNLOAD = 5000
 
@@ -63,9 +63,9 @@ describe('Script Builder', () => {
     cy.log('select bucket')
     selectBucket(bucketName)
     cy.getByTestID('flux-editor', {
-      timeout: DELAY_FOR_LSP_SERVER_ONLINE,
+      timeout: DELAY_FOR_LAZY_LOAD_EDITOR,
     }).contains(`from(bucket: "${bucketName}")`, {
-      timeout: APPROXIMATE_EDITOR_SET_VALUE_DELAY,
+      timeout: DELAY_FOR_LSP_SERVER_BOOTUP,
     })
 
     cy.log('select measurement')
@@ -74,9 +74,9 @@ describe('Script Builder', () => {
 
   const confirmSchemaComposition = () => {
     cy.getByTestID('flux-editor', {
-      timeout: DELAY_FOR_LSP_SERVER_ONLINE,
+      timeout: DELAY_FOR_LAZY_LOAD_EDITOR,
     }).contains(`from(bucket: "${bucketName}")`, {
-      timeout: APPROXIMATE_EDITOR_SET_VALUE_DELAY,
+      timeout: DELAY_FOR_LSP_SERVER_BOOTUP,
     })
     cy.getByTestID('flux-editor').contains(
       `|> filter(fn: (r) => r._measurement == "${measurement}")`
@@ -177,7 +177,7 @@ describe('Script Builder', () => {
 
         clearSession()
         cy.getByTestID('flux-sync--toggle').should('have.class', 'active')
-        cy.getByTestID('flux-editor', {timeout: DELAY_FOR_LSP_SERVER_ONLINE})
+        cy.getByTestID('flux-editor', {timeout: DELAY_FOR_LAZY_LOAD_EDITOR})
       })
     })
 
@@ -533,7 +533,7 @@ describe('Script Builder', () => {
       })
 
       it('should clear the editor text and schema browser, with a new script', () => {
-        cy.getByTestID('flux-editor', {timeout: DELAY_FOR_LSP_SERVER_ONLINE})
+        cy.getByTestID('flux-editor', {timeout: DELAY_FOR_LAZY_LOAD_EDITOR})
 
         cy.log('modify schema browser')
         selectSchema()
@@ -604,9 +604,6 @@ describe('Script Builder', () => {
         cy.getByTestID('flux-sync--toggle').should('have.class', 'active')
 
         cy.log('editor text contains the composition')
-        // we set a manual delay for composition initialization
-        // https://github.com/influxdata/ui/blob/e76f934c6af60e24c6356f4e4ce9b067e5a9d0d5/src/languageSupport/languages/flux/lsp/connection.ts#L435-L440
-        cy.wait(3000)
         confirmSchemaComposition()
       })
     })

--- a/cypress/e2e/shared/fluxQueryBuilder.test.ts
+++ b/cypress/e2e/shared/fluxQueryBuilder.test.ts
@@ -6,7 +6,7 @@ const DEFAULT_FLUX_EDITOR_TEXT =
 // These delays are separately loaded in the UI.
 // But cypress checks for them in series...and the LspServer takes longer.
 const DELAY_FOR_LAZY_LOAD_EDITOR = 30000
-const DELAY_FOR_LSP_SERVER_BOOTUP = 30000
+const DELAY_FOR_LSP_SERVER_BOOTUP = 7000
 
 const DELAY_FOR_FILE_DOWNLOAD = 5000
 
@@ -526,6 +526,9 @@ describe('Script Builder', () => {
         cy.log('empty editor text')
         cy.getByTestID('flux-editor').monacoType('{selectAll}{del}')
 
+        cy.log('Ensure LSP is online') // deflake
+        cy.wait(DELAY_FOR_LSP_SERVER_BOOTUP)
+
         cy.log('select bucket and measurement')
         selectSchema()
         confirmSchemaComposition()
@@ -556,6 +559,9 @@ describe('Script Builder', () => {
       it('can contruct a composition with tagValues', () => {
         cy.log('empty editor text')
         cy.getByTestID('flux-editor').monacoType('{selectAll}{del}')
+
+        cy.log('Ensure LSP is online') // deflake
+        cy.wait(DELAY_FOR_LSP_SERVER_BOOTUP)
 
         cy.log('select bucket and measurement')
         selectSchema()

--- a/cypress/e2e/shared/fluxQueryBuilder.test.ts
+++ b/cypress/e2e/shared/fluxQueryBuilder.test.ts
@@ -79,7 +79,7 @@ describe('Script Builder', () => {
       timeout: DELAY_FOR_LSP_SERVER_BOOTUP,
     })
     cy.getByTestID('flux-editor').contains(
-      `|> filter(fn: (r) => r._measurement == "${measurement}")`
+      `fn: (r) => r._measurement == "${measurement}"`
     )
     cy.getByTestID('flux-editor').within(() => {
       cy.get('.composition-sync--on').should('have.length', 3) // three lines
@@ -568,15 +568,8 @@ describe('Script Builder', () => {
       })
 
       it('should not be able to modify the composition when unsynced, yet still modify the saved schema -- which updates the composition when re-synced', () => {
-        cy.log('start with empty editor text')
-        cy.getByTestID('flux-editor', {
-          timeout: DELAY_FOR_LSP_SERVER_ONLINE,
-        }).within(() => {
-          cy.get('textarea.inputarea').should(
-            'have.value',
-            DEFAULT_FLUX_EDITOR_TEXT
-          )
-        })
+        cy.log('empty editor text')
+        cy.getByTestID('flux-editor').monacoType('{selectall}{enter}')
 
         cy.log('turn off sync')
         cy.getByTestID('flux-sync--toggle')
@@ -591,10 +584,7 @@ describe('Script Builder', () => {
         cy.log('editor text is still empty')
         cy.getByTestID('flux-editor').within(() => {
           // selecting bucket will empty the editor text
-          cy.get('textarea.inputarea').should(
-            'have.value',
-            DEFAULT_FLUX_EDITOR_TEXT
-          )
+          cy.get('textarea.inputarea').should('have.value', '\n')
         })
 
         cy.log('turn on sync')

--- a/cypress/e2e/shared/fluxQueryBuilder.test.ts
+++ b/cypress/e2e/shared/fluxQueryBuilder.test.ts
@@ -522,7 +522,7 @@ describe('Script Builder', () => {
     })
 
     describe('basic functionality', () => {
-      it('can contruct a composition with fields', () => {
+      it('can construct a composition with fields', () => {
         cy.log('empty editor text')
         cy.getByTestID('flux-editor').monacoType('{selectAll}{del}')
 
@@ -556,7 +556,7 @@ describe('Script Builder', () => {
         })
       })
 
-      it('can contruct a composition with tagValues', () => {
+      it('can construct a composition with tagValues', () => {
         cy.log('empty editor text')
         cy.getByTestID('flux-editor').monacoType('{selectAll}{del}')
 
@@ -579,6 +579,7 @@ describe('Script Builder', () => {
         )
 
         cy.log('select tagValue --> removes from composition')
+        selectListItem(tagValue, false)
         cy.wait(1000)
         cy.getByTestID('flux-editor').within(() => {
           cy.get('textarea.inputarea').should('not.contain', tagKey)


### PR DESCRIPTION
Need to boost test coverage in schema composition. Already had a regression this week.
Tested with the 20x runs in CI. To help reduce flake.

.

## Improvements to test fixtures:
Broken out per commit:
* make explicit `DELAY_FOR_LAZY_LOAD_EDITOR` versus `DELAY_FOR_LSP_SERVER_BOOTUP`
* debug existing tests
* new tests:
    * LSP composition construct be it's own test case.
    * Include add/remove fields, add/remove tags.
* magic number tuning, to handle slower CI cypress test runs. 😭 


## Checklist
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
