### PR TITLE
chore: allow free org with non-default allowances to delete org

### DIFF
--- a/cypress/e2e/cloud/about.test.ts
+++ b/cypress/e2e/cloud/about.test.ts
@@ -46,7 +46,13 @@ describe.skip('About Page for free users with only 1 user', () => {
 })
 
 describe('About Page for free users with multiple users', () => {
-  beforeEach(() =>
+  beforeEach(() => {
+    cy.intercept('GET', 'api/v2/quartz/identity', req => {
+      req.continue(res => {
+        res.body.user.orgCount = 1
+        res.send(res.body)
+      })
+    })
     cy.flush().then(() =>
       cy.signin().then(() => {
         cy.get('@org').then(({id}: Organization) => {
@@ -60,7 +66,7 @@ describe('About Page for free users with multiple users', () => {
         })
       })
     )
-  )
+  })
   it('should display the warning and allow users to navigate to the users page when trying to delete when the user has multiple users', () => {
     cy.getByTestID('delete-org--button').should('exist').click()
 

--- a/src/organizations/components/OrgProfileTab/DeletePanel.tsx
+++ b/src/organizations/components/OrgProfileTab/DeletePanel.tsx
@@ -67,15 +67,16 @@ const DeletePanel: FC = () => {
     handleDeleteFreeAccount = handleShowWarning
   }
 
-  const showDeleteButtonInFreeAccount = account.type === 'free'
-  const showDeleteButtonInPaidAccount =
-    isFlagEnabled('createDeleteOrgs') &&
-    (account.type === 'pay_as_you_go' || account.type === 'contract')
+  const showDeleteFreeAccountButton =
+    CLOUD && account.type === 'free' && user.orgCount === 1
+
+  const showDeleteOrgButton =
+    CLOUD && isFlagEnabled('createDeleteOrgs') && !showDeleteFreeAccountButton
 
   return (
     <PageSpinner loading={status}>
       <>
-        {CLOUD && showDeleteButtonInFreeAccount && (
+        {showDeleteFreeAccountButton && (
           <>
             <FlexBox.Child>
               <h4>Delete Organization</h4>
@@ -94,7 +95,7 @@ const DeletePanel: FC = () => {
             </FlexBox.Child>
           </>
         )}
-        {CLOUD && showDeleteButtonInPaidAccount && (
+        {showDeleteOrgButton && (
           <>
             <FlexBox.Child>
               <h4>Delete Organization</h4>

--- a/src/organizations/components/OrgProfileTab/DeletePanel.tsx
+++ b/src/organizations/components/OrgProfileTab/DeletePanel.tsx
@@ -67,16 +67,18 @@ const DeletePanel: FC = () => {
     handleDeleteFreeAccount = handleShowWarning
   }
 
-  const showDeleteFreeAccountButton =
+  const shouldShowDeleteFreeAccountButton =
     CLOUD && account.type === 'free' && user.orgCount === 1
 
-  const showDeleteOrgButton =
-    CLOUD && isFlagEnabled('createDeleteOrgs') && !showDeleteFreeAccountButton
+  const shouldShowDeleteOrgButton =
+    CLOUD &&
+    isFlagEnabled('createDeleteOrgs') &&
+    !shouldShowDeleteFreeAccountButton
 
   return (
     <PageSpinner loading={status}>
       <>
-        {showDeleteFreeAccountButton && (
+        {shouldShowDeleteFreeAccountButton && (
           <>
             <FlexBox.Child>
               <h4>Delete Organization</h4>
@@ -95,7 +97,7 @@ const DeletePanel: FC = () => {
             </FlexBox.Child>
           </>
         )}
-        {showDeleteOrgButton && (
+        {shouldShowDeleteOrgButton && (
           <>
             <FlexBox.Child>
               <h4>Delete Organization</h4>


### PR DESCRIPTION
Closes #6396 

For proof of concept use cases we want the ability to give a user more than one org in a free account - and to be able to delete those orgs. This PR adjusts the logic for the 'delete' buttons on the org settings page.

Old Behavior:
- In a free account, your only "delete" option is to delete the free account. 
- If the `createDeleteOrgs` FF is on, a payg or contract account can delete the currently active org.

New Behavior:
- If you're in a free account with _only one org_, same behavior as before (only option is to delete the free account).
- If the `createDeleteOrgs` FF is on (and you're not in a free account with only one org), you can delete the current org.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - `createDeleteOrgs` (partial)
