### PR TITLE
feat(notebooks): add actions, thunks, reducer, selector for checking if org has notebooks

### DIFF
--- a/src/flows/actions/flowsActions.ts
+++ b/src/flows/actions/flowsActions.ts
@@ -1,0 +1,10 @@
+import {Notebook} from 'src/client/notebooksRoutes'
+
+export const SET_NOTEBOOKS = 'SET_NOTEBOOKS'
+
+export type Actions = ReturnType<typeof setNotebooks>
+
+export const setNotebooks = (notebooks: Notebook[]) => ({
+  type: SET_NOTEBOOKS,
+  notebooks,
+})

--- a/src/flows/actions/flowsThunks.ts
+++ b/src/flows/actions/flowsThunks.ts
@@ -1,0 +1,22 @@
+import {Dispatch} from 'redux'
+
+import {Notebook} from 'src/client/notebooksRoutes'
+
+import {getNotebooks as fetchNotebooks} from 'src/client/notebooksRoutes'
+import {setNotebooks} from 'src/flows/actions/flowsActions'
+
+export const getNotebooks =
+  (orgID: string) => async (dispatch: Dispatch<any>) => {
+    try {
+      const response = await fetchNotebooks({query: {orgID}})
+
+      if (response.status !== 200) {
+        throw new Error()
+      }
+
+      dispatch(setNotebooks(response.data.flows))
+    } catch {
+      const emptyNotebooks = [] as Notebook[]
+      dispatch(setNotebooks(emptyNotebooks))
+    }
+  }

--- a/src/flows/reducers/flowsReducer.ts
+++ b/src/flows/reducers/flowsReducer.ts
@@ -1,0 +1,24 @@
+import {Notebook} from 'src/client/notebooksRoutes'
+import {Actions, SET_NOTEBOOKS} from 'src/flows/actions/flowsActions'
+
+export interface NotebooksState {
+  notebooks: Notebook[]
+}
+
+const INITIAL_STATE = {
+  notebooks: [],
+}
+
+export const flowsReducer = (
+  state = INITIAL_STATE,
+  action: Actions
+): NotebooksState => {
+  switch (action.type) {
+    case SET_NOTEBOOKS: {
+      return {...state, notebooks: action.notebooks}
+    }
+    default: {
+      return state
+    }
+  }
+}

--- a/src/flows/selectors/flowsSelectors.ts
+++ b/src/flows/selectors/flowsSelectors.ts
@@ -1,0 +1,6 @@
+import {Notebook} from 'src/client/notebooksRoutes'
+import {AppState} from 'src/types'
+
+export const selectNotebooks = (state: AppState): Notebook[] => {
+  return state.resources.notebooks.notebooks
+}

--- a/src/shared/containers/GetOrganizations.tsx
+++ b/src/shared/containers/GetOrganizations.tsx
@@ -39,6 +39,7 @@ import {RemoteDataState} from 'src/types'
 
 // Thunks
 import {getQuartzIdentityThunk} from 'src/identity/actions/thunks'
+import {getNotebooks} from 'src/flows/actions/flowsThunks'
 
 const GetOrganizations: FunctionComponent = () => {
   const {status: orgLoadingStatus} = useSelector(getAllOrgs)
@@ -49,7 +50,6 @@ const GetOrganizations: FunctionComponent = () => {
 
   const dispatch = useDispatch()
 
-  // This doesn't require another API call.
   useEffect(() => {
     if (orgLoadingStatus === RemoteDataState.NotStarted) {
       dispatch(getOrganizations())
@@ -91,6 +91,12 @@ const GetOrganizations: FunctionComponent = () => {
       })
     }
   }, [account.type, account.isUpgradeable])
+
+  useEffect(() => {
+    if (CLOUD && org?.id) {
+      dispatch(getNotebooks(org.id))
+    }
+  }, [org.id])
 
   return (
     <PageSpinner loading={orgLoadingStatus}>

--- a/src/store/configureStore.ts
+++ b/src/store/configureStore.ts
@@ -61,6 +61,7 @@ import alertBuilderReducer from 'src/alerting/reducers/alertBuilder'
 import perfReducer from 'src/perf/reducers'
 import quartzOrganizationReducer from 'src/identity/quartzOrganizations/reducers'
 import orgCreationAllowancesReducer from 'src/identity/allowances/reducers'
+import {flowsReducer} from 'src/flows/reducers/flowsReducer'
 
 // Types
 import {AppState, LocalStorage} from 'src/types'
@@ -110,6 +111,7 @@ export const rootReducer = (history: History) => (state, action) => {
       endpoints: endpointsReducer,
       labels: labelsReducer,
       members: membersReducer,
+      notebooks: flowsReducer,
       orgs: orgsReducer,
       rules: rulesReducer,
       scrapers: scrapersReducer,

--- a/src/types/resources.ts
+++ b/src/types/resources.ts
@@ -21,6 +21,8 @@ import {
   Subscription,
 } from 'src/types'
 
+import {NotebooksState} from 'src/flows/reducers/flowsReducer'
+
 export enum ResourceType {
   Authorizations = 'tokens',
   Buckets = 'buckets',
@@ -31,6 +33,7 @@ export enum ResourceType {
   Labels = 'labels',
   Orgs = 'orgs',
   Members = 'members',
+  Notebooks = 'notebooks',
   NotificationRules = 'rules',
   NotificationEndpoints = 'endpoints',
   Plugins = 'plugins',
@@ -90,6 +93,7 @@ export interface ResourceState {
   [ResourceType.Dashboards]: DashboardsState
   [ResourceType.Labels]: NormalizedState<Label>
   [ResourceType.Members]: NormalizedState<Member>
+  [ResourceType.Notebooks]: NotebooksState
   [ResourceType.Orgs]: OrgsState
   [ResourceType.Scrapers]: NormalizedState<Scraper>
   [ResourceType.Secrets]: NormalizedState<Secret>


### PR DESCRIPTION
Connects: https://github.com/influxdata/idpe/issues/16723

- Creates the redux machinery to store a list of notebooks in redux state for simple checking if an org has notebooks.
- Calls the thunk in `GetOrganizations` after `org.id` is retreived. This makes a request across the wire and stores notebooks in redux state
- Nothing is currently done with the notebooks in state, that will come in a future PR

This doesn't use the existing flows context in order to avoid wrapping most of the appliction in the flows provider, which seems an odd thing to do when deprecating a feature. This also avoids potentially re-rendering of the entire application (since `GetOrganizations` is a component that is at the root of nearly every other component in the application) when a single thing in flows is updated.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- ~[ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~
- ~[ ] Feature flagged, if applicable~
