### PR TITLE
fix(5895): move monaco-editor back to an older version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
     "lodash": "^4.17.21",
     "luxon": "^3.1.1",
     "memoize-one": "^4.0.2",
-    "monaco-editor": "~0.34.0",
+    "monaco-editor": "~0.32.1",
     "monaco-editor-textmate": "^3.0.0",
     "monaco-editor-webpack-plugin": "^7.0.1",
     "monaco-languageclient": "~0.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7784,10 +7784,10 @@ monaco-editor-webpack-plugin@^7.0.1:
   dependencies:
     loader-utils "^2.0.2"
 
-monaco-editor@~0.34.0:
-  version "0.34.0"
-  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.34.0.tgz#b1749870a1f795dbfc4dc03d8e9b646ddcbeefa7"
-  integrity sha512-VF+S5zG8wxfinLKLrWcl4WUizMx+LeJrG4PM/M78OhcwocpV0jiyhX/pG6Q9jIOhrb/ckYi6nHnaR5OojlOZCQ==
+monaco-editor@~0.32.1:
+  version "0.32.1"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.32.1.tgz#75a9bba379a923fd8e9ce99cddcab3a4e7657615"
+  integrity sha512-LUt2wsUvQmEi2tfTOK+tjAPvt7eQ+K5C4rZPr6SeuyzjAuAHrIvlUloTcOiGjZW3fn3a/jFQCONrEJbNOaCqbA==
 
 monaco-languageclient@~0.18.1:
   version "0.18.1"


### PR DESCRIPTION
**NOTE: this will only merge after our additional editor/LSP-related tests go in. To make sure we get no regression of features.**

Closes #5895 

Reason is that the underlying vscode is hitting [this error](https://github.com/microsoft/vscode/blob/c2a3e85d3c60870546a7769333cfe66cfb512a85/src/vs/editor/browser/services/bulkEditService.ts#L32), because it's expecting a  field per [this type definition](https://github.com/microsoft/vscode/blob/main/src/vs/editor/common/languages.ts#L1433), whereas what it's being given is a  field as per an older version of vscode [updated here](https://github.com/microsoft/vscode/commit/f413297170178f16ab218202153b629d59a98be1) in July 2022.

The vscode ecosystem has a bunch of libs which all work together. Monaco-editor itself is still using some vscode libs from a year ago. The last time they upgrade libs, there were various issues that needed to resolved. 

When we version bumped monaco-editor in sept 2022, we got this error. For expediency sake, going to selectively dial back monaco-editor to bring back this feature. (Until we have time to start doing the dependency fixes in monaco-editor, or the maintainers start down that path.)


## Video of working import code action:

https://user-images.githubusercontent.com/10232835/208186763-0a42f2cc-c80f-4b24-aae4-7c15c6e118fd.mov


## Checklist
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
