### PR TITLE
feat: add ui eventing for multi-org phase 2

### DIFF
--- a/src/identity/components/GlobalHeader/GlobalHeaderDropdown/CreateOrganization/CreateOrganizationOverlay.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeaderDropdown/CreateOrganization/CreateOrganizationOverlay.tsx
@@ -260,7 +260,7 @@ export const CreateOrganizationOverlay: FC = () => {
             dispatch(notify(quartzOrgQuotaReached()))
           }
 
-          event(CreateOrgOverlayEvent.OrgCreationSuccess, multiOrgTag, {
+          event(CreateOrgOverlayEvent.OrgCreated, multiOrgTag, {
             newOrgID: newOrg.id,
             newOrgName: newOrg.name,
             oldOrgID: currentOrgId,
@@ -281,11 +281,6 @@ export const CreateOrganizationOverlay: FC = () => {
       } else {
         setNetworkErrorMsg(OrgOverlayNetworkError.DefaultError)
       }
-
-      event(CreateOrgOverlayEvent.OrgCreationFail, multiOrgTag, {
-        oldOrgID: currentOrgId,
-      })
-
       setCreateOrgButtonStatus(ComponentStatus.Error)
     }
   }

--- a/src/identity/components/GlobalHeader/GlobalHeaderDropdown/CreateOrganization/CreateOrganizationOverlay.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeaderDropdown/CreateOrganization/CreateOrganizationOverlay.tsx
@@ -110,7 +110,6 @@ const SwitchToNewOrgButton = (
   newOrg: CreatedOrg,
   currentOrgId
 ): JSX.Element => {
-
   const handleEventing = () => {
     event(CreateOrgOverlayEvent.SwitchToNewOrg, multiOrgTag, {
       currentOrgId,

--- a/src/identity/components/GlobalHeader/GlobalHeaderDropdown/CreateOrganization/CreateOrganizationOverlay.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeaderDropdown/CreateOrganization/CreateOrganizationOverlay.tsx
@@ -218,13 +218,13 @@ export const CreateOrganizationOverlay: FC = () => {
 
   const createNewOrgPopup = (
     newOrg: CreatedOrg,
-    handleEventing: () => void
+    handleSwitchToNewOrgEvent: () => void
   ) => {
     const newOrgUrl = `${CLOUD_URL}/orgs/${newOrg.id}`
 
     const switchToOrgLink =
       newOrg.provisioningStatus === 'provisioned'
-        ? () => SwitchToNewOrgButton(newOrgUrl, handleEventing)
+        ? () => SwitchToNewOrgButton(newOrgUrl, handleSwitchToNewOrgEvent)
         : null
 
     dispatch(notify(quartzOrgCreateSuccess(newOrg.name, switchToOrgLink)))

--- a/src/identity/components/GlobalHeader/GlobalHeaderDropdown/CreateOrganization/CreateOrganizationOverlay.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeaderDropdown/CreateOrganization/CreateOrganizationOverlay.tsx
@@ -105,7 +105,10 @@ const switchToNewOrgButtonStyle = {
   cursor: 'pointer',
 }
 
-const SwitchToNewOrgButton = (url: string, handleClick: () => void): JSX.Element => {
+const SwitchToNewOrgButton = (
+  url: string,
+  handleClick: () => void
+): JSX.Element => {
   return (
     <a
       href={url}
@@ -213,7 +216,10 @@ export const CreateOrganizationOverlay: FC = () => {
     retrieveClusters()
   }, [])
 
-  const createNewOrgPopup = (newOrg: CreatedOrg, handleEventing: () => void) => {
+  const createNewOrgPopup = (
+    newOrg: CreatedOrg,
+    handleEventing: () => void
+  ) => {
     const newOrgUrl = `${CLOUD_URL}/orgs/${newOrg.id}`
 
     const switchToOrgLink =

--- a/src/identity/components/GlobalHeader/GlobalHeaderDropdown/CreateOrganization/CreateOrganizationOverlay.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeaderDropdown/CreateOrganization/CreateOrganizationOverlay.tsx
@@ -94,7 +94,10 @@ import {SafeBlankLink} from 'src/utils/SafeBlankLink'
 
 // Eventing
 import {event} from 'src/cloud/utils/reporting'
-import {CreateOrgOverlayEvent, multiOrgTag} from 'src/identity/events/multiOrgEvents'
+import {
+  CreateOrgOverlayEvent,
+  multiOrgTag,
+} from 'src/identity/events/multiOrgEvents'
 
 const switchToNewOrgButtonStyle = {
   color: 'black',
@@ -102,17 +105,25 @@ const switchToNewOrgButtonStyle = {
   cursor: 'pointer',
 }
 
-const SwitchToNewOrgButton = (url: string, newOrg: CreatedOrg, currentOrgId): JSX.Element => {
+const SwitchToNewOrgButton = (
+  url: string,
+  newOrg: CreatedOrg,
+  currentOrgId
+): JSX.Element => {
+
+  const handleEventing = () => {
+    event(CreateOrgOverlayEvent.SwitchToNewOrg, multiOrgTag, {
+      currentOrgId,
+      createdOrgId: newOrg.id,
+      createdOrgName: newOrg.name,
+    })
+  }
   return (
     <a
       href={url}
       data-testid="go-to-new-org--link"
       style={switchToNewOrgButtonStyle}
-      onClick={() => event(CreateOrgOverlayEvent.SwitchToNewOrg, multiOrgTag, {
-        currentOrgId,
-        createdOrgId: newOrg.id,
-        createdOrgName: newOrg.name,
-      })}
+      onClick={handleEventing}
     >
       Switch to new org.
     </a>
@@ -271,9 +282,9 @@ export const CreateOrganizationOverlay: FC = () => {
       }
 
       event(CreateOrgOverlayEvent.OrgCreationFail, multiOrgTag, {
-        currentOrgId
+        currentOrgId,
       })
-      
+
       setCreateOrgButtonStatus(ComponentStatus.Error)
     }
   }

--- a/src/identity/components/GlobalHeader/GlobalHeaderDropdown/CreateOrganization/MenuItem.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeaderDropdown/CreateOrganization/MenuItem.tsx
@@ -20,10 +20,7 @@ import {
 } from 'src/identity/selectors'
 
 // Eventing
-import {
-  HeaderNavEvent,
-  multiOrgTag,
-} from 'src/identity/events/multiOrgEvents'
+import {HeaderNavEvent, multiOrgTag} from 'src/identity/events/multiOrgEvents'
 import {event} from 'src/cloud/utils/reporting'
 
 export const CreateOrganizationMenuItem: FC = () => {

--- a/src/identity/components/GlobalHeader/GlobalHeaderDropdown/CreateOrganization/MenuItem.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeaderDropdown/CreateOrganization/MenuItem.tsx
@@ -13,10 +13,7 @@ import {
 import {dismissOverlay, showOverlay} from 'src/overlays/actions/overlays'
 
 // Selectors
-import {
-  selectCurrentAccount,
-  selectUser,
-} from 'src/identity/selectors'
+import {selectCurrentAccount, selectUser} from 'src/identity/selectors'
 
 // Eventing
 import {HeaderNavEvent, multiOrgTag} from 'src/identity/events/multiOrgEvents'

--- a/src/identity/components/GlobalHeader/GlobalHeaderDropdown/CreateOrganization/MenuItem.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeaderDropdown/CreateOrganization/MenuItem.tsx
@@ -14,8 +14,7 @@ import {dismissOverlay, showOverlay} from 'src/overlays/actions/overlays'
 
 // Selectors
 import {
-  selectCurrentAccountId,
-  selectCurrentAccountType,
+  selectCurrentAccount,
   selectUser,
 } from 'src/identity/selectors'
 
@@ -26,14 +25,14 @@ import {event} from 'src/cloud/utils/reporting'
 export const CreateOrganizationMenuItem: FC = () => {
   const dispatch = useDispatch()
   const user = useSelector(selectUser)
-  const accountId = useSelector(selectCurrentAccountId)
-  const accountType = useSelector(selectCurrentAccountType)
+  const account = useSelector(selectCurrentAccount)
 
   const handleCreateOrg = () => {
     event(HeaderNavEvent.CreateOrgClick, multiOrgTag, {
       userId: user.id,
-      accountId,
-      accountType,
+      accountId: account.id,
+      accountName: account.name,
+      accountType: account.type,
     })
     dispatch(
       showOverlay('create-organization', null, () => dispatch(dismissOverlay()))

--- a/src/identity/components/GlobalHeader/GlobalHeaderDropdown/CreateOrganization/MenuItem.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeaderDropdown/CreateOrganization/MenuItem.tsx
@@ -1,5 +1,6 @@
 // Libraries
 import React, {FC} from 'react'
+import {useDispatch, useSelector} from 'react-redux'
 import {
   AlignItems,
   Dropdown,
@@ -7,14 +8,36 @@ import {
   Icon,
   IconFont,
 } from '@influxdata/clockface'
-import {useDispatch} from 'react-redux'
 
 // Components
 import {dismissOverlay, showOverlay} from 'src/overlays/actions/overlays'
 
+// Selectors
+import {
+  selectCurrentAccountId,
+  selectCurrentAccountType,
+  selectUser,
+} from 'src/identity/selectors'
+
+// Eventing
+import {
+  HeaderNavEvent,
+  multiOrgTag,
+} from 'src/identity/events/multiOrgEvents'
+import {event} from 'src/cloud/utils/reporting'
+
 export const CreateOrganizationMenuItem: FC = () => {
   const dispatch = useDispatch()
+  const user = useSelector(selectUser)
+  const accountId = useSelector(selectCurrentAccountId)
+  const accountType = useSelector(selectCurrentAccountType)
+
   const handleCreateOrg = () => {
+    event(HeaderNavEvent.CreateOrgClick, multiOrgTag, {
+      userId: user.id,
+      accountId,
+      accountType,
+    })
     dispatch(
       showOverlay('create-organization', null, () => dispatch(dismissOverlay()))
     )

--- a/src/identity/components/GlobalHeader/OrgDropdown.tsx
+++ b/src/identity/components/GlobalHeader/OrgDropdown.tsx
@@ -33,9 +33,12 @@ import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Selectors
 import {
+  selectCurrentAccountId,
+  selectCurrentAccountType,
   selectOrgCreationAllowance,
   selectOrgCreationAllowanceStatus,
   selectOrgCreationAvailableUpgrade,
+  selectUser,
 } from 'src/identity/selectors'
 import {CreateOrganizationMenuItem} from 'src/identity/components/GlobalHeader/GlobalHeaderDropdown/CreateOrganization/MenuItem'
 import {dismissOverlay, showOverlay} from 'src/overlays/actions/overlays'
@@ -56,10 +59,18 @@ export const OrgDropdown: FC<Props> = ({activeOrg, orgsList}) => {
   const orgCreationAllowanceStatus = useSelector(
     selectOrgCreationAllowanceStatus
   )
+  const user = useSelector(selectUser)
+  const accountId = useSelector(selectCurrentAccountId)
+  const accountType = useSelector(selectCurrentAccountType)
 
   const dispatch = useDispatch()
 
   const openMarketoOverlay = () => {
+    event(HeaderNavEvent.UpgradeButtonClick, multiOrgTag, {
+      userId: user.id,
+      accountId,
+      accountType,
+    })
     dispatch(
       showOverlay('marketo-upgrade-account-overlay', null, () =>
         dispatch(dismissOverlay())

--- a/src/identity/components/GlobalHeader/OrgDropdown.tsx
+++ b/src/identity/components/GlobalHeader/OrgDropdown.tsx
@@ -33,8 +33,7 @@ import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Selectors
 import {
-  selectCurrentAccountId,
-  selectCurrentAccountType,
+  selectCurrentAccount,
   selectOrgCreationAllowance,
   selectOrgCreationAllowanceStatus,
   selectOrgCreationAvailableUpgrade,
@@ -60,16 +59,16 @@ export const OrgDropdown: FC<Props> = ({activeOrg, orgsList}) => {
     selectOrgCreationAllowanceStatus
   )
   const user = useSelector(selectUser)
-  const accountId = useSelector(selectCurrentAccountId)
-  const accountType = useSelector(selectCurrentAccountType)
+  const account = useSelector(selectCurrentAccount)
 
   const dispatch = useDispatch()
 
   const openMarketoOverlay = () => {
     event(HeaderNavEvent.UpgradeButtonClick, multiOrgTag, {
+      accountId: account.id,
+      accountName: account.name,
+      accountType: account.type,
       userId: user.id,
-      accountId,
-      accountType,
     })
     dispatch(
       showOverlay('marketo-upgrade-account-overlay', null, () =>

--- a/src/identity/components/MarketoAccountUpgradeOverlay.tsx
+++ b/src/identity/components/MarketoAccountUpgradeOverlay.tsx
@@ -14,7 +14,11 @@ import {
 import {OverlayContext} from 'src/overlays/components/OverlayController'
 
 // Selectors
-import {selectCurrentAccountId, selectUser} from 'src/identity/selectors'
+import {
+  selectCurrentAccountId,
+  selectCurrentAccountType,
+  selectUser,
+} from 'src/identity/selectors'
 
 // Error Reporting
 import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
@@ -28,6 +32,13 @@ import {
 
 // Utils
 import {notify} from 'src/shared/actions/notifications'
+
+// Eventing
+import {
+  AccountUpgradeOverlay,
+  multiOrgTag,
+} from 'src/identity/events/multiOrgEvents'
+import {event} from 'src/cloud/utils/reporting'
 
 // Styles
 import './MarketoAccountUpgradeOverlay.scss'
@@ -70,13 +81,26 @@ interface MarketoFormElement extends Element {
 }
 
 // If marketo isn't working, still need the user to have some means of contacting sales.
-const SalesFormLink = (): JSX.Element => {
+const SalesFormLink: FC = () => {
+  const user = useSelector(selectUser)
+  const accountId = useSelector(selectCurrentAccountId)
+  const accountType = useSelector(selectCurrentAccountType)
+
+  const handleEventing = () => {
+    event(AccountUpgradeOverlay.SalesFormLinkClick, multiOrgTag, {
+      userId: user.id,
+      accountId,
+      accountType,
+    })
+  }
+
   return (
     <a
       data-testid="use-sales-form--link"
       href={BACKUP_CONTACT_SALES_LINK}
       target="_blank"
       style={popupLinkStyle}
+      onClick={handleEventing}
     >
       Click here to contact sales.
     </a>
@@ -89,6 +113,7 @@ export const MarketoAccountUpgradeOverlay: FC = () => {
 
   const user = useSelector(selectUser)
   const accountId = useSelector(selectCurrentAccountId)
+  const accountType = useSelector(selectCurrentAccountType)
 
   const [scriptHasLoaded, setScriptHasLoaded] = useState(false)
   const [formHasLoaded, setFormHasLoaded] = useState(false)
@@ -99,7 +124,6 @@ export const MarketoAccountUpgradeOverlay: FC = () => {
     delete window.MktoForms2
     onClose()
   }
-
   const handleComment = (evt: React.ChangeEvent<HTMLInputElement>) => {
     if (window.MktoForms2.getForm) {
       try {
@@ -137,9 +161,19 @@ export const MarketoAccountUpgradeOverlay: FC = () => {
     try {
       window.MktoForms2.getForm(MARKETO_FORM_ID).submit()
       dispatch(notify(marketoFormSubmitSuccess()))
+      event(AccountUpgradeOverlay.MarketoAccountUpgradeSuccess, multiOrgTag, {
+        userId: user.id,
+        accountId,
+        accountType,
+      })
       onClose()
     } catch (err) {
       handleError(MarketoError.FormSubmitError, err)
+      event(AccountUpgradeOverlay.MarketoAccountUpgradeSuccess, multiOrgTag, {
+        userId: user.id,
+        accountId,
+        accountType,
+      })
     }
   }
 

--- a/src/identity/components/MarketoAccountUpgradeOverlay.tsx
+++ b/src/identity/components/MarketoAccountUpgradeOverlay.tsx
@@ -16,6 +16,7 @@ import {OverlayContext} from 'src/overlays/components/OverlayController'
 // Selectors
 import {
   selectCurrentAccountId,
+  selectCurrentAccountName,
   selectCurrentAccountType,
   selectUser,
 } from 'src/identity/selectors'
@@ -84,12 +85,14 @@ interface MarketoFormElement extends Element {
 const SalesFormLink = () => {
   const user = useSelector(selectUser)
   const accountId = useSelector(selectCurrentAccountId)
+  const accountName = useSelector(selectCurrentAccountName)
   const accountType = useSelector(selectCurrentAccountType)
 
   const handleEventing = () => {
     event(AccountUpgradeOverlay.SalesFormLinkClick, multiOrgTag, {
       userId: user.id,
       accountId,
+      accountName,
       accountType,
     })
   }
@@ -113,6 +116,7 @@ export const MarketoAccountUpgradeOverlay: FC = () => {
 
   const user = useSelector(selectUser)
   const accountId = useSelector(selectCurrentAccountId)
+  const accountName = useSelector(selectCurrentAccountName)
   const accountType = useSelector(selectCurrentAccountType)
 
   const [scriptHasLoaded, setScriptHasLoaded] = useState(false)
@@ -161,19 +165,15 @@ export const MarketoAccountUpgradeOverlay: FC = () => {
     try {
       window.MktoForms2.getForm(MARKETO_FORM_ID).submit()
       dispatch(notify(marketoFormSubmitSuccess()))
-      event(AccountUpgradeOverlay.MarketoAccountUpgradeSuccess, multiOrgTag, {
-        userId: user.id,
+      event(AccountUpgradeOverlay.MarketoAccountUpgrade, multiOrgTag, {
         accountId,
+        accountName,
         accountType,
+        userId: user.id,
       })
       onClose()
     } catch (err) {
       handleError(MarketoError.FormSubmitError, err)
-      event(AccountUpgradeOverlay.MarketoAccountUpgradeFail, multiOrgTag, {
-        userId: user.id,
-        accountId,
-        accountType,
-      })
     }
   }
 

--- a/src/identity/components/MarketoAccountUpgradeOverlay.tsx
+++ b/src/identity/components/MarketoAccountUpgradeOverlay.tsx
@@ -81,7 +81,7 @@ interface MarketoFormElement extends Element {
 }
 
 // If marketo isn't working, still need the user to have some means of contacting sales.
-const SalesFormLink: FC = () => {
+const SalesFormLink = () => {
   const user = useSelector(selectUser)
   const accountId = useSelector(selectCurrentAccountId)
   const accountType = useSelector(selectCurrentAccountType)
@@ -169,7 +169,7 @@ export const MarketoAccountUpgradeOverlay: FC = () => {
       onClose()
     } catch (err) {
       handleError(MarketoError.FormSubmitError, err)
-      event(AccountUpgradeOverlay.MarketoAccountUpgradeSuccess, multiOrgTag, {
+      event(AccountUpgradeOverlay.MarketoAccountUpgradeFail, multiOrgTag, {
         userId: user.id,
         accountId,
         accountType,

--- a/src/identity/components/OrganizationListTab/OrgBannerPanel.tsx
+++ b/src/identity/components/OrganizationListTab/OrgBannerPanel.tsx
@@ -14,7 +14,7 @@ import {availableUpgrade} from 'src/client/unityRoutes'
 import {dismissOverlay, showOverlay} from 'src/overlays/actions/overlays'
 
 // Selectors
-import {selectCurrentAccountId} from 'src/identity/selectors'
+import {selectCurrentAccountId, selectCurrentAccountName} from 'src/identity/selectors'
 
 // Eventing
 import {multiOrgTag, OrgListEvent} from 'src/identity/events/multiOrgEvents'
@@ -36,11 +36,13 @@ export const OrgBannerPanel: FC<OrgAllowance> = ({
   const dispatch = useDispatch()
   const history = useHistory()
   const accountId = useSelector(selectCurrentAccountId)
+  const accountName = useSelector(selectCurrentAccountName)
 
   const handleUpgradeAccount = () => {
     event(OrgListEvent.UpgradeAccount, multiOrgTag, {
       availableUpgrade,
       accountId,
+      accountName,
     })
 
     if (availableUpgrade === 'pay_as_you_go') {

--- a/src/identity/components/OrganizationListTab/OrgBannerPanel.tsx
+++ b/src/identity/components/OrganizationListTab/OrgBannerPanel.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC} from 'react'
-import {useDispatch} from 'react-redux'
+import {useDispatch, useSelector} from 'react-redux'
 import {useHistory} from 'react-router-dom'
 import {BannerPanel, FlexBox, Gradients, IconFont} from '@influxdata/clockface'
 
@@ -12,6 +12,16 @@ import {availableUpgrade} from 'src/client/unityRoutes'
 
 // Utils
 import {dismissOverlay, showOverlay} from 'src/overlays/actions/overlays'
+
+// Selectors
+import {selectCurrentAccountId} from 'src/identity/selectors'
+
+// Eventing 
+import {
+  multiOrgTag,
+  OrgListEvent
+} from 'src/identity/events/multiOrgEvents'
+import {event} from 'src/cloud/utils/reporting'
 
 interface OrgAllowance {
   availableUpgrade: availableUpgrade
@@ -28,8 +38,14 @@ export const OrgBannerPanel: FC<OrgAllowance> = ({
 }) => {
   const dispatch = useDispatch()
   const history = useHistory()
+  const accountId = useSelector(selectCurrentAccountId)
 
   const handleUpgradeAccount = () => {
+    event(OrgListEvent.UpgradeAccount, multiOrgTag, {
+      availableUpgrade,
+      accountId
+    })
+    
     if (availableUpgrade === 'pay_as_you_go') {
       history.push(`/checkout`)
     } else {

--- a/src/identity/components/OrganizationListTab/OrgBannerPanel.tsx
+++ b/src/identity/components/OrganizationListTab/OrgBannerPanel.tsx
@@ -14,7 +14,10 @@ import {availableUpgrade} from 'src/client/unityRoutes'
 import {dismissOverlay, showOverlay} from 'src/overlays/actions/overlays'
 
 // Selectors
-import {selectCurrentAccountId, selectCurrentAccountName} from 'src/identity/selectors'
+import {
+  selectCurrentAccountId,
+  selectCurrentAccountName,
+} from 'src/identity/selectors'
 
 // Eventing
 import {multiOrgTag, OrgListEvent} from 'src/identity/events/multiOrgEvents'

--- a/src/identity/components/OrganizationListTab/OrgBannerPanel.tsx
+++ b/src/identity/components/OrganizationListTab/OrgBannerPanel.tsx
@@ -16,11 +16,8 @@ import {dismissOverlay, showOverlay} from 'src/overlays/actions/overlays'
 // Selectors
 import {selectCurrentAccountId} from 'src/identity/selectors'
 
-// Eventing 
-import {
-  multiOrgTag,
-  OrgListEvent
-} from 'src/identity/events/multiOrgEvents'
+// Eventing
+import {multiOrgTag, OrgListEvent} from 'src/identity/events/multiOrgEvents'
 import {event} from 'src/cloud/utils/reporting'
 
 interface OrgAllowance {
@@ -43,9 +40,9 @@ export const OrgBannerPanel: FC<OrgAllowance> = ({
   const handleUpgradeAccount = () => {
     event(OrgListEvent.UpgradeAccount, multiOrgTag, {
       availableUpgrade,
-      accountId
+      accountId,
     })
-    
+
     if (availableUpgrade === 'pay_as_you_go') {
       history.push(`/checkout`)
     } else {

--- a/src/identity/events/multiOrgEvents.ts
+++ b/src/identity/events/multiOrgEvents.ts
@@ -18,19 +18,19 @@ export enum HeaderNavEvent {
 }
 
 export enum CreateOrgOverlayEvent {
-  OrgCreationSuccess = 'headerNav.orgDropdown.createOrgsuccess',
-  OrgCreationFail = 'headerNav.orgDropdown.createOrgfail',
-  SwitchToNewOrg = 'headerNav.createOrganization.switchToNewOrgClicked',
+  OrgCreationSuccess = 'headerNav.createOrgOverlay.creationSuccess',
+  OrgCreationFail = 'headerNav.createOrgOverlay.creationFail',
+  SwitchToNewOrg = 'headerNav.createOrg.switchedToNewOrg',
 }
 
 export enum DeleteOrgOverlay {
-  DeleteOrgFail = 'userProfile.orgsTab.deleteOrgFailed',
-  DeleteOrgSuccess = 'userProfile.orgsTab.deleteOrgSuccess',
+  DeleteOrgFail = 'userProfile.orgProfileTab.orgDeletionFailed',
+  DeleteOrgSuccess = 'userProfile.orgProfileTab.orgDeletionSuccess',
 }
 
 export enum AccountUpgradeOverlay {
-  MarketoAccountUpgradeFail = 'userProfile.marketoAccountUpgradeForm.submitFail',
-  MarketoAccountUpgradeSuccess = 'userProfile.marketoAccountUpgradeForm.submitSuccess',
+  MarketoAccountUpgradeFail = 'userProfile.marketoAccountUpgradeForm.submissionFail',
+  MarketoAccountUpgradeSuccess = 'userProfile.marketoAccountUpgradeForm.submissionSuccess',
   SalesFormLinkClick = 'userProfile.marketoAccountUpgradeForm.salesFormLinkClicked',
 }
 

--- a/src/identity/events/multiOrgEvents.ts
+++ b/src/identity/events/multiOrgEvents.ts
@@ -8,8 +8,7 @@ export enum AccountUpgradeOverlay {
 }
 
 export enum CreateOrgOverlayEvent {
-  OrgCreationSuccess = 'headerNav.createOrgOverlay.creationSuccess',
-  OrgCreationFail = 'headerNav.createOrgOverlay.creationFail',
+  OrgCreated = 'headerNav.createOrgOverlay.orgCreated',
   SwitchToNewOrg = 'headerNav.createOrgOverlay.switchedToNewOrg',
 }
 

--- a/src/identity/events/multiOrgEvents.ts
+++ b/src/identity/events/multiOrgEvents.ts
@@ -2,59 +2,44 @@ export const multiOrgTag = {
   initiative: 'multiOrg',
 }
 
-export enum HeaderNavEvent {
-  AccountDropdownClick = 'headerNav.accountDropdown.clicked',
-  AccountSwitch = 'headerNav.accountDropdown.accountSwitched',
-
-  OrgDropdownClick = 'headerNav.orgDropdown.clicked',
-  OrgSwitch = 'headerNav.orgDropdown.orgSwitched',
-
-  UserAvatarClick = 'headerNav.userAvatarIcon.clicked',
-  UserProfileClick = 'headerNav.userAvatarProfile.clicked',
-  UserLogoutClick = 'headerNav.userAvatarLogOut.clicked',
-
-  CreateOrgClick = 'headerNav.createOrg.clicked',
-  UpgradeButtonClick = 'headerNav.upgradeButton.clicked',
+export enum AccountUpgradeOverlay {
+  MarketoAccountUpgrade = 'userProfile.marketoAccountUpgrade.formSubmitted',
+  SalesFormLinkClick = 'userProfile.marketoAccountUpgrade.salesFormLinkClicked',
 }
 
 export enum CreateOrgOverlayEvent {
   OrgCreationSuccess = 'headerNav.createOrgOverlay.creationSuccess',
   OrgCreationFail = 'headerNav.createOrgOverlay.creationFail',
-  SwitchToNewOrg = 'headerNav.createOrg.switchedToNewOrg',
+  SwitchToNewOrg = 'headerNav.createOrgOverlay.switchedToNewOrg',
 }
 
 export enum DeleteOrgOverlay {
-  DeleteOrgFail = 'userProfile.orgProfileTab.orgDeletionFailed',
-  DeleteOrgSuccess = 'userProfile.orgProfileTab.orgDeletionSuccess',
+  DeleteOrg = 'userProfile.orgProfileTab.orgDeleted',
 }
 
-export enum AccountUpgradeOverlay {
-  MarketoAccountUpgradeFail = 'userProfile.marketoAccountUpgradeForm.submissionFail',
-  MarketoAccountUpgradeSuccess = 'userProfile.marketoAccountUpgradeForm.submissionSuccess',
-  SalesFormLinkClick = 'userProfile.marketoAccountUpgradeForm.salesFormLinkClicked',
+export enum HeaderNavEvent {
+  AccountDropdownClick = 'headerNav.accountDropdown.clicked',
+  AccountSwitch = 'headerNav.accountDropdown.accountSwitched',
+
+  CreateOrgClick = 'headerNav.createOrg.clicked',
+  OrgDropdownClick = 'headerNav.orgDropdown.clicked',
+  OrgSwitch = 'headerNav.orgDropdown.orgSwitched',
+  
+  UpgradeButtonClick = 'headerNav.upgradeButton.clicked',
+  UserAvatarClick = 'headerNav.userAvatarIcon.clicked',
+  UserProfileClick = 'headerNav.userAvatarProfile.clicked',
+  UserLogoutClick = 'headerNav.userAvatarLogOut.clicked',
+}
+
+export enum MainMenuEventPrefix {
+  ChangeDefaultAccount = 'userProfile.defaultAccountDropdown',
+  ChangeDefaultOrg = 'userProfile.defaultOrgDropdown',
+  SwitchOrg = 'headerNav.org',
+  SwitchAccount = 'headerNav.account',
 }
 
 export enum OrgListEvent {
   UpgradeAccount = 'accountSettings.orgsTab.upgradeBannerClicked',
-}
-
-export enum UserProfileEvent {
-  DefaultAccountChange = 'userProfile.defaultAccountDropdown.defaultAccountChanged',
-  DefaultOrgChange = 'userProfile.defaultOrgDropdown.defaultOrgChanged',
-}
-
-export enum UserProfileEventPrefix {
-  Default = 'userProfile.default',
-  Account = 'Account',
-  Organization = 'Org',
-}
-
-export enum MainMenuEventPrefix {
-  SwitchOrg = 'headerNav.org',
-  SwitchAccount = 'headerNav.account',
-
-  ChangeDefaultOrg = 'userProfile.defaultOrgDropdown',
-  ChangeDefaultAccount = 'userProfile.defaultAccountDropdown',
 }
 
 export enum TypeAheadEventPrefix {
@@ -63,4 +48,15 @@ export enum TypeAheadEventPrefix {
 
   UserProfileSearchAccount = 'userProfile.defaultAccountDropdown',
   UserProfileSearchOrg = 'userProfile.defaultOrgDropdown',
+}
+
+export enum UserProfileEvent {
+  DefaultAccountChange = 'userProfile.defaultAccountDropdown.defaultAccountChanged',
+  DefaultOrgChange = 'userProfile.defaultOrgDropdown.defaultOrgChanged',
+}
+
+export enum UserProfileEventPrefix {
+  Account = 'Account',
+  Default = 'userProfile.default',
+  Organization = 'Org',
 }

--- a/src/identity/events/multiOrgEvents.ts
+++ b/src/identity/events/multiOrgEvents.ts
@@ -12,6 +12,30 @@ export enum HeaderNavEvent {
   UserAvatarClick = 'headerNav.userAvatarIcon.clicked',
   UserProfileClick = 'headerNav.userAvatarProfile.clicked',
   UserLogoutClick = 'headerNav.userAvatarLogOut.clicked',
+
+  CreateOrgClick = 'headerNav.createOrg.clicked',
+  UpgradeButtonClick = 'headerNav.upgradeButton.clicked',
+}
+
+export enum CreateOrgOverlayEvent {
+  OrgCreationSuccess = 'headerNav.orgDropdown.createOrgsuccess',
+  OrgCreationFail = 'headerNav.orgDropdown.createOrgfail',
+  SwitchToNewOrg = 'headerNav.createOrganization.switchToNewOrgClicked'
+}
+
+export enum DeleteOrgOverlay {
+  DeleteOrgFail = 'userProfile.orgsTab.deleteOrgFailed',
+  DeleteOrgSuccess = 'userProfile.orgsTab.deleteOrgSuccess',
+}
+
+export enum AccountUpgradeOverlay {
+  MarketoAccountUpgradeFail = 'userProfile.marketoAccountUpgradeForm.submitFail',
+  MarketoAccountUpgradeSuccess = 'userProfile.marketoAccountUpgradeForm.submitSuccess',
+  SalesFormLinkClick = 'userProfile.marketoAccountUpgradeForm.salesFormLinkClicked',
+}
+
+export enum OrgListEvent {
+  UpgradeAccount = 'accountSettings.orgsTab.upgradeBannerClicked'
 }
 
 export enum UserProfileEvent {

--- a/src/identity/events/multiOrgEvents.ts
+++ b/src/identity/events/multiOrgEvents.ts
@@ -24,7 +24,7 @@ export enum HeaderNavEvent {
   CreateOrgClick = 'headerNav.createOrg.clicked',
   OrgDropdownClick = 'headerNav.orgDropdown.clicked',
   OrgSwitch = 'headerNav.orgDropdown.orgSwitched',
-  
+
   UpgradeButtonClick = 'headerNav.upgradeButton.clicked',
   UserAvatarClick = 'headerNav.userAvatarIcon.clicked',
   UserProfileClick = 'headerNav.userAvatarProfile.clicked',

--- a/src/identity/events/multiOrgEvents.ts
+++ b/src/identity/events/multiOrgEvents.ts
@@ -20,7 +20,7 @@ export enum HeaderNavEvent {
 export enum CreateOrgOverlayEvent {
   OrgCreationSuccess = 'headerNav.orgDropdown.createOrgsuccess',
   OrgCreationFail = 'headerNav.orgDropdown.createOrgfail',
-  SwitchToNewOrg = 'headerNav.createOrganization.switchToNewOrgClicked'
+  SwitchToNewOrg = 'headerNav.createOrganization.switchToNewOrgClicked',
 }
 
 export enum DeleteOrgOverlay {
@@ -35,7 +35,7 @@ export enum AccountUpgradeOverlay {
 }
 
 export enum OrgListEvent {
-  UpgradeAccount = 'accountSettings.orgsTab.upgradeBannerClicked'
+  UpgradeAccount = 'accountSettings.orgsTab.upgradeBannerClicked',
 }
 
 export enum UserProfileEvent {

--- a/src/identity/selectors/index.ts
+++ b/src/identity/selectors/index.ts
@@ -14,6 +14,12 @@ export const selectCurrentAccountId = (
   return state.identity.currentIdentity.account.id
 }
 
+export const selectCurrentAccountName = (
+  state: AppState
+): AppState['identity']['currentIdentity']['account']['name'] => {
+  return state.identity.currentIdentity.account.name
+}
+
 export const selectCurrentAccountType = (
   state: AppState
 ): AppState['identity']['currentIdentity']['account']['type'] => {

--- a/src/organizations/components/OrgProfileTab/DeletePaidOrgOverlay.tsx
+++ b/src/organizations/components/OrgProfileTab/DeletePaidOrgOverlay.tsx
@@ -39,6 +39,13 @@ import {notify} from 'src/shared/actions/notifications'
 import {OverlayContext} from 'src/overlays/components/OverlayController'
 import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
 
+// Eventing 
+import {
+  DeleteOrgOverlay,
+  multiOrgTag
+} from 'src/identity/events/multiOrgEvents'
+import {event} from 'src/cloud/utils/reporting'
+
 // Styles
 import './DeletePaidOrgOverlay.scss'
 
@@ -107,6 +114,12 @@ export const DeletePaidOrgOverlay: FC = () => {
       .then(() => {
         clearTimeout(responseTimer)
         dispatch(notify(deleteOrgSuccess(org.name, account.name)))
+        event(DeleteOrgOverlay.DeleteOrgSuccess, multiOrgTag, {
+          userId: org.id,
+          orgName: org.name, 
+          accountName: account.name,
+          accountId: account.id
+        })
         setTimeout(() => {
           onClose()
           window.location.href = CLOUD_URL
@@ -115,6 +128,12 @@ export const DeletePaidOrgOverlay: FC = () => {
       .catch(err => {
         clearTimeout(responseTimer)
         dispatch(notify(deleteOrgFailed(SupportLink, org.name)))
+        event(DeleteOrgOverlay.DeleteOrgFail, multiOrgTag, {
+          userId: org.id,
+          orgName: org.name,
+          accountName: account.name,
+          accountId: account.id
+        })
         reportErrorThroughHoneyBadger(err, {
           name: 'Org deletion failed',
           context: {

--- a/src/organizations/components/OrgProfileTab/DeletePaidOrgOverlay.tsx
+++ b/src/organizations/components/OrgProfileTab/DeletePaidOrgOverlay.tsx
@@ -111,11 +111,12 @@ export const DeletePaidOrgOverlay: FC = () => {
       .then(() => {
         clearTimeout(responseTimer)
         dispatch(notify(deleteOrgSuccess(org.name, account.name)))
-        event(DeleteOrgOverlay.DeleteOrgSuccess, multiOrgTag, {
-          userId: org.id,
-          orgName: org.name,
-          accountType: account.type,
+        event(DeleteOrgOverlay.DeleteOrg, multiOrgTag, {
           accountId: account.id,
+          accoutnName: account.name,
+          accountType: account.type,
+          orgName: org.name,
+          userId: org.id,
         })
         setTimeout(() => {
           onClose()
@@ -125,12 +126,6 @@ export const DeletePaidOrgOverlay: FC = () => {
       .catch(err => {
         clearTimeout(responseTimer)
         dispatch(notify(deleteOrgFailed(SupportLink, org.name)))
-        event(DeleteOrgOverlay.DeleteOrgFail, multiOrgTag, {
-          userId: org.id,
-          orgName: org.name,
-          accountType: account.type,
-          accountId: account.id,
-        })
         reportErrorThroughHoneyBadger(err, {
           name: 'Org deletion failed',
           context: {

--- a/src/organizations/components/OrgProfileTab/DeletePaidOrgOverlay.tsx
+++ b/src/organizations/components/OrgProfileTab/DeletePaidOrgOverlay.tsx
@@ -39,11 +39,8 @@ import {notify} from 'src/shared/actions/notifications'
 import {OverlayContext} from 'src/overlays/components/OverlayController'
 import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
 
-// Eventing 
-import {
-  DeleteOrgOverlay,
-  multiOrgTag
-} from 'src/identity/events/multiOrgEvents'
+// Eventing
+import {DeleteOrgOverlay, multiOrgTag} from 'src/identity/events/multiOrgEvents'
 import {event} from 'src/cloud/utils/reporting'
 
 // Styles
@@ -116,9 +113,9 @@ export const DeletePaidOrgOverlay: FC = () => {
         dispatch(notify(deleteOrgSuccess(org.name, account.name)))
         event(DeleteOrgOverlay.DeleteOrgSuccess, multiOrgTag, {
           userId: org.id,
-          orgName: org.name, 
+          orgName: org.name,
           accountName: account.name,
-          accountId: account.id
+          accountId: account.id,
         })
         setTimeout(() => {
           onClose()
@@ -132,7 +129,7 @@ export const DeletePaidOrgOverlay: FC = () => {
           userId: org.id,
           orgName: org.name,
           accountName: account.name,
-          accountId: account.id
+          accountId: account.id,
         })
         reportErrorThroughHoneyBadger(err, {
           name: 'Org deletion failed',

--- a/src/organizations/components/OrgProfileTab/DeletePaidOrgOverlay.tsx
+++ b/src/organizations/components/OrgProfileTab/DeletePaidOrgOverlay.tsx
@@ -114,7 +114,7 @@ export const DeletePaidOrgOverlay: FC = () => {
         event(DeleteOrgOverlay.DeleteOrgSuccess, multiOrgTag, {
           userId: org.id,
           orgName: org.name,
-          accountName: account.name,
+          accountType: account.type,
           accountId: account.id,
         })
         setTimeout(() => {
@@ -128,7 +128,7 @@ export const DeletePaidOrgOverlay: FC = () => {
         event(DeleteOrgOverlay.DeleteOrgFail, multiOrgTag, {
           userId: org.id,
           orgName: org.name,
-          accountName: account.name,
+          accountType: account.type,
           accountId: account.id,
         })
         reportErrorThroughHoneyBadger(err, {


### PR DESCRIPTION
Closes #5707 

Pr adds UI eventing for multi org phase 2 features 
All events introduced in this pr are documented [here](https://influxdb.atlassian.net/wiki/spaces/IPO/pages/2530574337/UI+Eventing+Dictionary). 

Events fire...
- [x] when new org is created
- [x] when new org failes to create 
- [x] when user clicks on `create organization` button of the header nav
- [x] when user switches to newly created org by clicking on `switch org` pop up
- [x] when user successfully deletes an org
- [x] when user submits Marketo account upgrade form
- [x] when user clicks on the contact sales link after Marketo upgrade account form fails to submit
- [x] when user clicks on the `upgrade` button found in the header nav drop down

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
