### PR TITLE
fix: re-enable sync off styling, for composition

### DIFF
--- a/cypress/e2e/shared/fluxQueryBuilder.test.ts
+++ b/cypress/e2e/shared/fluxQueryBuilder.test.ts
@@ -638,13 +638,30 @@ describe('Script Builder', () => {
         cy.log('starts as synced')
         cy.getByTestID('flux-sync--toggle').should('have.class', 'active')
 
-        cy.log('sync toggles on and off')
+        cy.log('empty editor text')
+        cy.getByTestID('flux-editor').monacoType('{selectAll}{del}')
+
+        cy.log('Ensure LSP is online') // deflake
+        cy.wait(DELAY_FOR_LSP_SERVER_BOOTUP)
+
+        cy.log('make a composition')
+        selectSchema()
+        confirmSchemaComposition()
+
+        cy.log('sync toggles on and off, with matching styles')
+        cy.get('.composition-sync--on').should('have.length', 3)
+        cy.get('.composition-sync--off').should('have.length', 0)
         cy.getByTestID('flux-sync--toggle')
           .should('have.class', 'active')
           .click()
           .should('not.have.class', 'active')
+        cy.get('.composition-sync--on').should('have.length', 0)
+        cy.get('.composition-sync--off').should('have.length', 3)
+        cy.getByTestID('flux-sync--toggle')
           .click()
           .should('have.class', 'active')
+        cy.get('.composition-sync--on').should('have.length', 3)
+        cy.get('.composition-sync--off').should('have.length', 0)
 
         cy.log('turn off flux sync')
         cy.getByTestID('flux-sync--toggle')

--- a/src/shared/components/MonacoEditor.scss
+++ b/src/shared/components/MonacoEditor.scss
@@ -80,4 +80,24 @@
   .composition-sync--on--last {
     border-bottom: 1px solid $c-pool;
   }
+
+  .composition-sync--off {
+    opacity: 50%;
+    background-color: $cf-grey-35;
+  }
+
+  .composition-sync--off--first {
+    opacity: 50%;
+    border-top: 1px solid $cf-white;
+    // composition sync icon
+    background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M4.82511 4.0427L7.10622 1.6971L5.67243 0.302734L0.0902793 6.0427H16V4.0427H4.82511ZM11.1749 11.9571H0V9.95714H15.9097L10.3275 15.6971L8.89376 14.3027L11.1749 11.9571Z' fill='white'/%3E%3C/svg%3E%0A");
+    background-repeat: no-repeat;
+    background-size: 11px 11px;
+    background-position: $cf-space-3xs $cf-space-3xs;
+  }
+
+  .composition-sync--off--last {
+    opacity: 50%;
+    border-bottom: 1px solid $cf-white;
+  }
 }


### PR DESCRIPTION
When we merged the yieldless work, we forgot that there is still a use case for composition-off styling. As the user can still toggle the composition sync on/off, and need a visual indicator.

## Bug:
Working -- Composition could be sync'ed on/off.
Not working -- the styling was not appropriately updating to match.

## Fix:
Toggling styling, whenever sync is toggled.

Still enable the LSP to overwrite the styling. (e.g. in the video, you can see the dropped composition at the end --> which removes the style completely and turns off sync.)


https://user-images.githubusercontent.com/10232835/208490906-aa31b06e-0f23-47bd-864c-80d98cc2c010.mov


## Checklist
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
