### PR TITLE
chore: deflake the first-bucket-selection test

### DIFF
--- a/cypress/e2e/shared/fluxQueryBuilder.test.ts
+++ b/cypress/e2e/shared/fluxQueryBuilder.test.ts
@@ -597,7 +597,10 @@ describe('Script Builder', () => {
 
         cy.log('select bucket')
         selectBucket(bucketName)
-        cy.getByTestID('flux-editor').contains(`from(bucket: "${bucketName}")`)
+        cy.getByTestID('flux-editor').contains(
+          `from(bucket: "${bucketName}")`,
+          {timeout: DELAY_FOR_LSP_SERVER_BOOTUP}
+        )
         cy.getByTestID('flux-editor').should(
           'not.contain',
           DEFAULT_FLUX_EDITOR_TEXT


### PR DESCRIPTION
This test flaked a few times on friday. Add the appropriate timeout (which should have been added in the first place).

## Checklist
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
