### PR TITLE
feat(notebooks): conditionally hide notebooks if specific conditions are met

### DIFF
--- a/cypress/e2e/cloud/flows.test.ts
+++ b/cypress/e2e/cloud/flows.test.ts
@@ -8,6 +8,11 @@ describe('Flows', () => {
         cy.fixture('routes').then(({orgs}) => {
           cy.visit(`${orgs}/${id}`)
           cy.getByTestID('version-info').should('be.visible')
+
+          cy.createNotebook(id).then(() => {
+            cy.reload()
+          })
+
           cy.getByTestID('nav-item-flows').should('be.visible')
           cy.getByTestID('nav-item-flows').click()
         })
@@ -104,7 +109,7 @@ describe('Flows', () => {
 
     cy.clickNavBarItem('nav-item-flows')
 
-    cy.get('.cf-resource-card').should('have.length', 1)
+    cy.get('.cf-resource-card').should('have.length', 2)
 
     cy.getByTestID('resource-editable-name').contains(`${flowName}`)
 
@@ -133,7 +138,7 @@ describe('Flows', () => {
 
     cy.clickNavBarItem('nav-item-flows')
 
-    cy.get('.cf-resource-card').should('have.length', 2)
+    cy.get('.cf-resource-card').should('have.length', 3)
     cy.get('.cf-resource-editable-name').first().contains(flowCloneNamePrefix)
 
     // Delete the cloned flow
@@ -145,7 +150,7 @@ describe('Flows', () => {
     cy.getByTestID('notification-success').should('be.visible')
     cy.getByTestID('notification-success--dismiss').click()
 
-    cy.get('.cf-resource-card').should('have.length', 1)
+    cy.get('.cf-resource-card').should('have.length', 2)
     cy.getByTestID('resource-editable-name').contains(`${flowName}`)
 
     // Clone a flow again
@@ -177,8 +182,8 @@ describe('Flows', () => {
 
     cy.getByTestID('notification-success').should('be.visible')
 
-    cy.get('.cf-resource-card').should('have.length', 1)
-    cy.get('.cf-resource-editable-name').should('have.length', 1)
+    cy.get('.cf-resource-card').should('have.length', 2)
+    cy.get('.cf-resource-editable-name').should('have.length', 2)
     cy.get('.cf-resource-editable-name').contains(`${flowName}`)
   })
 
@@ -260,9 +265,13 @@ describe('Flows with newQueryBuilder flag on', () => {
         }).then(() => {
           cy.visit(`${orgs}/${id}`)
         })
+        cy.createNotebook(id).then(() => {
+          cy.reload()
+        })
       })
     )
     cy.getByTestID('version-info')
+
     cy.getByTestID('nav-item-flows').should('be.visible')
     cy.getByTestID('nav-item-flows').click()
   })
@@ -354,7 +363,7 @@ describe('Flows with newQueryBuilder flag on', () => {
 
     cy.clickNavBarItem('nav-item-flows')
 
-    cy.get('.cf-resource-card').should('have.length', 1)
+    cy.get('.cf-resource-card').should('have.length', 2)
 
     cy.getByTestID('resource-editable-name').contains(`${flowName}`)
 
@@ -383,7 +392,7 @@ describe('Flows with newQueryBuilder flag on', () => {
 
     cy.clickNavBarItem('nav-item-flows')
 
-    cy.get('.cf-resource-card').should('have.length', 2)
+    cy.get('.cf-resource-card').should('have.length', 3)
     cy.get('.cf-resource-editable-name').first().contains(flowCloneNamePrefix)
 
     // Delete the cloned flow
@@ -395,7 +404,7 @@ describe('Flows with newQueryBuilder flag on', () => {
     cy.getByTestID('notification-success').should('be.visible')
     cy.getByTestID('notification-success--dismiss').click()
 
-    cy.get('.cf-resource-card').should('have.length', 1)
+    cy.get('.cf-resource-card').should('have.length', 2)
     cy.getByTestID('resource-editable-name').contains(`${flowName}`)
 
     // Clone a flow again
@@ -427,8 +436,8 @@ describe('Flows with newQueryBuilder flag on', () => {
 
     cy.getByTestID('notification-success').should('be.visible')
 
-    cy.get('.cf-resource-card').should('have.length', 1)
-    cy.get('.cf-resource-editable-name').should('have.length', 1)
+    cy.get('.cf-resource-card').should('have.length', 2)
+    cy.get('.cf-resource-editable-name').should('have.length', 2)
     cy.get('.cf-resource-editable-name').contains(`${flowName}`)
   })
 })

--- a/cypress/e2e/shared/editor.test.ts
+++ b/cypress/e2e/shared/editor.test.ts
@@ -50,10 +50,15 @@ describe('Editor+LSP communication', () => {
       cy.get('@org').then(({id}: Organization) =>
         cy.fixture('routes').then(({orgs}) => {
           cy.visit(`${orgs}/${id}`)
+
+          cy.createNotebook(id).then(() => {
+            cy.reload()
+          })
         })
       )
       // Double check that the new schemaComposition flag does not interfere.
       cy.getByTestID('version-info')
+
       cy.getByTestID('nav-item-flows').should('be.visible')
       cy.getByTestID('nav-item-flows').click()
 

--- a/cypress/e2e/shared/flows.test.ts
+++ b/cypress/e2e/shared/flows.test.ts
@@ -7,6 +7,9 @@ describe('Flows', () => {
     cy.get('@org').then(({id}: Organization) =>
       cy.fixture('routes').then(({orgs}) => {
         cy.visit(`${orgs}/${id}`)
+        cy.createNotebook(id).then(() => {
+          cy.reload()
+        })
       })
     )
     // Double check that the new schemaComposition flag does not interfere.
@@ -246,7 +249,7 @@ describe('Flows', () => {
       })
     )
 
-    cy.get('.cf-resource-card').should('have.length', 1)
+    cy.get('.cf-resource-card').should('have.length', 2)
 
     cy.getByTestID('resource-editable-name').contains(`${flowName}`)
   })
@@ -332,7 +335,7 @@ describe('Flows', () => {
     cy.clickNavBarItem('nav-item-flows')
     cy.getByTestID('tree-nav').should('be.visible')
     cy.getByTestID('resource-editable-name').should('exist')
-    cy.getByTestID('resource-editable-name').click()
+    cy.getByTestID('resource-editable-name').first().click()
 
     // validation and visualization should exist
     cy.getByTestID('simple-table').should('exist')
@@ -427,7 +430,7 @@ describe('Flows', () => {
     cy.clickNavBarItem('nav-item-flows')
     cy.getByTestID('tree-nav').should('be.visible')
     cy.getByTestID('resource-editable-name').should('exist')
-    cy.getByTestID('resource-editable-name').click()
+    cy.getByTestID('resource-editable-name').first().click()
 
     // visualization should exist but not validation
     cy.getByTestID('simple-table').should('not.exist')

--- a/cypress/e2e/shared/flowsAlerts.test.ts
+++ b/cypress/e2e/shared/flowsAlerts.test.ts
@@ -18,6 +18,11 @@ describe('flows alert panel', () => {
           cy.fixture('routes').then(({orgs}) => {
             cy.visit(`${orgs}/${id}`)
             cy.getByTestID('version-info')
+
+            cy.createNotebook(id).then(() => {
+              cy.reload()
+            })
+
             return cy
               .setFeatureFlags({
                 notebooksExp: true,

--- a/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
+++ b/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
@@ -110,6 +110,10 @@ describe('Flows Copy To Clipboard', () => {
       cy.get('@org').then(({id}: Organization) => {
         cy.fixture('routes').then(({orgs}) => {
           cy.visit(`${orgs}/${id}`)
+
+          cy.createNotebook(id).then(() => {
+            cy.reload()
+          })
         })
       })
       cy.getByTestID('tree-nav')

--- a/cypress/e2e/shared/legends.test.ts
+++ b/cypress/e2e/shared/legends.test.ts
@@ -555,6 +555,9 @@ describe('Legends', () => {
       cy.get('@org').then(({id}: Organization) => {
         cy.createMapVariable(id)
         cy.fixture('routes').then(({orgs, notebooks}) => {
+          cy.createNotebook(id).then(() => {
+            cy.reload()
+          })
           cy.visit(`${orgs}/${id}${notebooks}`)
           cy.getByTestID('tree-nav').should('be.visible')
         })

--- a/cypress/e2e/shared/secrets.test.ts
+++ b/cypress/e2e/shared/secrets.test.ts
@@ -120,6 +120,7 @@ describe('Secrets', () => {
       })
     })
   })
+
   describe('usage in notebooks', () => {
     beforeEach(() => {
       cy.flush()
@@ -127,6 +128,9 @@ describe('Secrets', () => {
       cy.get('@org').then(({id}: Organization) =>
         cy.fixture('routes').then(({orgs}) => {
           cy.visit(`${orgs}/${id}`)
+          cy.createNotebook(id).then(() => {
+            cy.reload()
+          })
         })
       )
       cy.getByTestID('version-info')

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -594,6 +594,151 @@ export const createToken = (
   })
 }
 
+export const createNotebook = (
+  orgID,
+  name = 'Default Notebook to pass notebook deprecation checks'
+): Cypress.Chainable<Cypress.Response<any>> => {
+  return cy.request('POST', '/api/v2private/notebooks', {
+    orgID,
+    name,
+    spec: {
+      name,
+      readOnly: false,
+      range: {
+        seconds: 3600,
+        lower: 'now() - 1h',
+        upper: null,
+        label: 'Past 1h',
+        duration: '1h',
+        type: 'selectable-duration',
+        windowPeriod: 10000,
+      },
+      refresh: {
+        status: 'paused',
+        interval: 0,
+        duration: null,
+        inactivityTimeout: 0,
+        infiniteDuration: false,
+        label: '',
+      },
+      pipes: [
+        {
+          type: 'queryBuilder',
+          buckets: [],
+          tags: [
+            {key: '_measurement', values: [], aggregateFunctionType: 'filter'},
+          ],
+          id: 'local_cxjzb8S8Nt6nStkd-MqjF',
+          title: 'Build a Query',
+          visible: true,
+        },
+        {
+          type: 'table',
+          id: 'local_Y7j37pbyZibPmj_ToemAo',
+          title: 'Validate the Data',
+          visible: true,
+        },
+        {
+          type: 'visualization',
+          properties: {
+            type: 'xy',
+            shape: 'chronograf-v2',
+            geom: 'line',
+            xColumn: null,
+            yColumn: null,
+            position: 'overlaid',
+            hoverDimension: 'auto',
+            queries: [
+              {
+                name: '',
+                text: '',
+                editMode: 'builder',
+                builderConfig: {
+                  buckets: [],
+                  tags: [
+                    {
+                      key: '_measurement',
+                      values: [],
+                      aggregateFunctionType: 'filter',
+                    },
+                  ],
+                  functions: [{name: 'mean'}],
+                  aggregateWindow: {period: 'auto', fillValues: false},
+                },
+              },
+            ],
+            colors: [
+              {
+                type: 'scale',
+                hex: '#31C0F6',
+                id: 'VNWzqjV7KpDG7iaMLQ4oS',
+                name: 'Nineteen Eighty Four',
+                value: 0,
+              },
+              {
+                type: 'scale',
+                hex: '#A500A5',
+                id: 'd0V9jZYP1q6-Yn_f8-wRv',
+                name: 'Nineteen Eighty Four',
+                value: 0,
+              },
+              {
+                type: 'scale',
+                hex: '#FF7E27',
+                id: 'wC8pf-gi7KKgzyWKZ76Y9',
+                name: 'Nineteen Eighty Four',
+                value: 0,
+              },
+            ],
+            legendColorizeRows: true,
+            legendOpacity: 1,
+            legendOrientationThreshold: 100000000,
+            staticLegend: {
+              colorizeRows: true,
+              heightRatio: 0,
+              opacity: 1,
+              orientationThreshold: 100000000,
+              show: false,
+              widthRatio: 1,
+            },
+            note: '',
+            showNoteWhenEmpty: false,
+            axes: {
+              x: {
+                bounds: ['', ''],
+                label: '',
+                prefix: '',
+                suffix: '',
+                base: '10',
+                scale: 'linear',
+              },
+              y: {
+                bounds: ['', ''],
+                label: '',
+                prefix: '',
+                suffix: '',
+                base: '10',
+                scale: 'linear',
+              },
+            },
+            generateXAxisTicks: [],
+            generateYAxisTicks: [],
+            xTotalTicks: null,
+            xTickStart: null,
+            xTickStep: null,
+            yTotalTicks: null,
+            yTickStart: null,
+            yTickStep: null,
+          },
+          id: 'local_rFh--ymiiJwXTzeUjZkl9',
+          title: 'Visualize the Result',
+          visible: true,
+        },
+      ],
+    },
+  })
+}
+
 export const setupUser = (useIox: boolean = false): Cypress.Chainable<any> => {
   useIox = Cypress.env('useIox') || useIox
   const defaultUser = Cypress.env('defaultUser')
@@ -1182,6 +1327,9 @@ Cypress.Commands.add('createTask', createTask)
 
 // tokens
 Cypress.Commands.add('createToken', createToken)
+
+// notebooks
+Cypress.Commands.add('createNotebook', createNotebook)
 
 // variables
 Cypress.Commands.add('createQueryVariable', createQueryVariable)

--- a/src/flows/selectors/flowsSelectors.test.ts
+++ b/src/flows/selectors/flowsSelectors.test.ts
@@ -1,0 +1,63 @@
+import {AppState} from 'src/types'
+import {selectShouldShowNotebooks} from 'src/flows/selectors/flowsSelectors'
+
+jest.mock('src/organizations/selectors', () => ({
+  selectOrgCreationDate: jest.fn(),
+}))
+
+import {selectOrgCreationDate} from 'src/organizations/selectors'
+
+describe('selecting whether notebooks should be shown', () => {
+  let fakeState
+  beforeEach(() => {
+    fakeState = {
+      resources: {
+        notebooks: {
+          notebooks: [],
+        },
+      },
+    } as AppState
+  })
+  it('does not show notebooks when the org creation date is after the IOx cutoff date', () => {
+    jest
+      .mocked(selectOrgCreationDate)
+      .mockImplementationOnce(() => '2023-02-01T11:00:00Z')
+
+    expect(selectShouldShowNotebooks(fakeState)).toBeFalsy()
+  })
+
+  it('does not show notebooks when the org creation date is after the IOx cutoff date, even if there are notebooks', () => {
+    jest
+      .mocked(selectOrgCreationDate)
+      .mockImplementationOnce(() => '2023-02-01T11:00:00Z')
+
+    fakeState.resources.notebooks.notebooks = [1, 2, 3]
+    expect(selectShouldShowNotebooks(fakeState)).toBeFalsy()
+  })
+
+  it('does not show notebooks when the org creation date is before the IOx cutoff date, and there are no existing notebooks', () => {
+    jest
+      .mocked(selectOrgCreationDate)
+      .mockImplementationOnce(() => '2020-07-04T11:00:00Z')
+
+    expect(selectShouldShowNotebooks(fakeState)).toBeFalsy()
+  })
+
+  it('does not show notebooks when the org creation date is the exact same as the IOx cutoff date, and there are existing notebooks', () => {
+    jest
+      .mocked(selectOrgCreationDate)
+      .mockImplementationOnce(() => '2023-01-31T00:00:00Z')
+    fakeState.resources.notebooks.notebooks = [1, 2, 3]
+
+    expect(selectShouldShowNotebooks(fakeState)).toBeFalsy()
+  })
+
+  it('shows notebooks when the org creation date is before the IOx cutoff date, and there are existing notebooks', () => {
+    jest
+      .mocked(selectOrgCreationDate)
+      .mockImplementationOnce(() => '2020-07-04T11:00:00Z')
+    fakeState.resources.notebooks.notebooks = [1, 2, 3]
+
+    expect(selectShouldShowNotebooks(fakeState)).toBeTruthy()
+  })
+})

--- a/src/flows/selectors/flowsSelectors.ts
+++ b/src/flows/selectors/flowsSelectors.ts
@@ -1,6 +1,25 @@
 import {Notebook} from 'src/client/notebooksRoutes'
 import {AppState} from 'src/types'
 
+import {IOX_SWITCHOVER_CREATION_DATE} from 'src/shared/constants'
+
+import {selectOrgCreationDate} from 'src/organizations/selectors'
+
 export const selectNotebooks = (state: AppState): Notebook[] => {
   return state.resources.notebooks.notebooks
+}
+
+export const selectShouldShowNotebooks = (state: AppState): boolean => {
+  const orgCreationDate = new Date(selectOrgCreationDate(state)).valueOf()
+  const ioxCutoffDate = new Date(IOX_SWITCHOVER_CREATION_DATE).valueOf()
+
+  const wasCreatedBeforeIOxCutoff = orgCreationDate < ioxCutoffDate
+
+  // Don't show notebooks for any org created after the IOx cutover date
+  if (!wasCreatedBeforeIOxCutoff) {
+    return false
+  }
+
+  // If the org was created before the IOx cutover date, only show notebooks if the account has notebooks
+  return selectNotebooks(state).length > 0
 }

--- a/src/flows/selectors/flowsSelectors.ts
+++ b/src/flows/selectors/flowsSelectors.ts
@@ -1,7 +1,7 @@
 import {Notebook} from 'src/client/notebooksRoutes'
 import {AppState} from 'src/types'
 
-import {IOX_SWITCHOVER_CREATION_DATE} from 'src/shared/constants'
+import {CLOUD, IOX_SWITCHOVER_CREATION_DATE} from 'src/shared/constants'
 
 import {selectOrgCreationDate} from 'src/organizations/selectors'
 
@@ -15,11 +15,15 @@ export const selectShouldShowNotebooks = (state: AppState): boolean => {
 
   const wasCreatedBeforeIOxCutoff = orgCreationDate < ioxCutoffDate
 
-  // Don't show notebooks for any org created after the IOx cutover date
+  if (!CLOUD) {
+    return true
+  }
+
+  // In cloud, don't show notebooks for any org created after the IOx cutover date
   if (!wasCreatedBeforeIOxCutoff) {
     return false
   }
 
-  // If the org was created before the IOx cutover date, only show notebooks if the account has notebooks
+  // In cloud, if the org was created before the IOx cutover date, only show notebooks if the account has notebooks
   return selectNotebooks(state).length > 0
 }

--- a/src/organizations/selectors/index.ts
+++ b/src/organizations/selectors/index.ts
@@ -18,6 +18,12 @@ export const isOrgIOx = (state: AppState): boolean => {
   )
 }
 
+export const selectOrgCreationDate = (state: AppState): string => {
+  const org = getOrg(state)
+
+  return org?.createdAt
+}
+
 export const getOrg = (state: AppState): Organization => {
   return get(state, 'resources.orgs.org', null)
 }

--- a/src/pageLayout/containers/MainNavigation.tsx
+++ b/src/pageLayout/containers/MainNavigation.tsx
@@ -25,6 +25,7 @@ import {
   selectCurrentAccountType,
   selectOperatorRole,
 } from 'src/identity/selectors'
+import {selectShouldShowNotebooks} from 'src/flows/selectors/flowsSelectors'
 
 // Types
 import {IdentityUser} from 'src/client/unityRoutes'
@@ -57,7 +58,8 @@ interface NavSubItem {
 
 const generateNavItems = (
   orgID: string,
-  operatorRole: IdentityUser['operatorRole']
+  operatorRole: IdentityUser['operatorRole'],
+  shouldShowNotebooks: boolean
 ): NavItem[] => {
   const navItems: NavItem[] = [
     {
@@ -120,16 +122,6 @@ const generateNavItems = (
       enabled: () => !isFlagEnabled('leadWithFlows'),
     },
     {
-      id: 'notebook-explorer',
-      testID: 'nav-item-data-explorer',
-      icon: IconFont.GraphLine_New,
-      label: 'Data Explorer',
-      shortLabel: 'Explore',
-      link: `/notebook/from/default`,
-      activeKeywords: ['data-explorer'],
-      enabled: () => isFlagEnabled('leadWithFlows'),
-    },
-    {
       id: 'flows',
       testID: 'nav-item-flows',
       icon: IconFont.BookCode,
@@ -137,6 +129,7 @@ const generateNavItems = (
       shortLabel: 'Books',
       link: `/orgs/${orgID}/notebooks`,
       activeKeywords: ['notebooks', 'notebook/from'],
+      enabled: () => shouldShowNotebooks,
     },
     {
       id: 'dashboards',
@@ -245,6 +238,7 @@ export const MainNavigation: FC = () => {
   const org = useSelector(getOrg)
   const accountType = useSelector(selectCurrentAccountType)
   const operatorRole = useSelector(selectOperatorRole)
+  const shouldShowNotebooks = useSelector(selectShouldShowNotebooks)
 
   const dispatch = useDispatch()
 
@@ -302,65 +296,67 @@ export const MainNavigation: FC = () => {
       userElement={CLOUD ? null : <UserWidget />}
       onToggleClick={handleToggleNavExpansion}
     >
-      {generateNavItems(org.id, operatorRole).map((item: NavItem) => {
-        const linkElement = (className: string): JSX.Element => (
-          <Link
-            to={item.link}
-            className={className}
-            title={item.label}
-            onClick={() => {
-              event('nav clicked', {which: item.id})
-            }}
-          />
-        )
-        return (
-          <TreeNav.Item
-            key={item.id}
-            id={item.id}
-            testID={item.testID}
-            icon={<Icon glyph={item.icon} />}
-            label={item.label}
-            shortLabel={item.shortLabel}
-            active={getNavItemActivation(
-              item.activeKeywords,
-              location.pathname
-            )}
-            linkElement={linkElement}
-          >
-            {Boolean(item.menu) && (
-              <TreeNav.SubMenu>
-                {item.menu.map((menuItem: NavSubItem) => {
-                  const linkElement = (className: string): JSX.Element => (
-                    <Link
-                      to={menuItem.link}
-                      className={className}
-                      onClick={() => {
-                        event('nav clicked', {
-                          which: `${item.id} - ${menuItem.id}`,
-                        })
-                      }}
-                    />
-                  )
+      {generateNavItems(org.id, operatorRole, shouldShowNotebooks).map(
+        (item: NavItem) => {
+          const linkElement = (className: string): JSX.Element => (
+            <Link
+              to={item.link}
+              className={className}
+              title={item.label}
+              onClick={() => {
+                event('nav clicked', {which: item.id})
+              }}
+            />
+          )
+          return (
+            <TreeNav.Item
+              key={item.id}
+              id={item.id}
+              testID={item.testID}
+              icon={<Icon glyph={item.icon} />}
+              label={item.label}
+              shortLabel={item.shortLabel}
+              active={getNavItemActivation(
+                item.activeKeywords,
+                location.pathname
+              )}
+              linkElement={linkElement}
+            >
+              {Boolean(item.menu) && (
+                <TreeNav.SubMenu>
+                  {item.menu.map((menuItem: NavSubItem) => {
+                    const linkElement = (className: string): JSX.Element => (
+                      <Link
+                        to={menuItem.link}
+                        className={className}
+                        onClick={() => {
+                          event('nav clicked', {
+                            which: `${item.id} - ${menuItem.id}`,
+                          })
+                        }}
+                      />
+                    )
 
-                  return (
-                    <TreeNav.SubItem
-                      key={menuItem.id}
-                      id={menuItem.id}
-                      testID={menuItem.testID}
-                      active={getNavItemActivation(
-                        [menuItem.id],
-                        location.pathname
-                      )}
-                      label={menuItem.label}
-                      linkElement={linkElement}
-                    />
-                  )
-                })}
-              </TreeNav.SubMenu>
-            )}
-          </TreeNav.Item>
-        )
-      })}
+                    return (
+                      <TreeNav.SubItem
+                        key={menuItem.id}
+                        id={menuItem.id}
+                        testID={menuItem.testID}
+                        active={getNavItemActivation(
+                          [menuItem.id],
+                          location.pathname
+                        )}
+                        label={menuItem.label}
+                        linkElement={linkElement}
+                      />
+                    )
+                  })}
+                </TreeNav.SubMenu>
+              )}
+            </TreeNav.Item>
+          )
+        }
+      )}
       <TreeNav.Item
         id="support"
         testID="nav-item-support"

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -178,3 +178,5 @@ export const INFLUXDATA_SUPPORT_CONTACT_US = '+1 855-958-1047'
 export const INFLUXDATA_SUPPORT_CONTACT_US_TELEPHONE_LINK = 'tel:+18559581047'
 
 export const TOOLS_URL = 'https://us-east-1-2.aws.cloud2.influxdata.com/'
+
+export const IOX_SWITCHOVER_CREATION_DATE = '2023-01-31T00:00:00Z' // January 31, 2023, 00:00:00 GMT

--- a/src/shared/containers/SetOrg.tsx
+++ b/src/shared/containers/SetOrg.tsx
@@ -63,7 +63,6 @@ import {AppState, Organization, ResourceType} from 'src/types'
 
 // Constants
 import {CLOUD} from 'src/shared/constants'
-import {PROJECT_NAME_PLURAL} from 'src/flows'
 import {
   LOAD_DATA,
   SETTINGS,
@@ -92,6 +91,7 @@ import {RemoteDataState} from '@influxdata/clockface'
 
 // Selectors
 import {getAll} from 'src/resources/selectors'
+import {selectShouldShowNotebooks} from 'src/flows/selectors/flowsSelectors'
 
 const SetOrg: FC = () => {
   const [loading, setLoading] = useState(RemoteDataState.Loading)
@@ -99,6 +99,8 @@ const SetOrg: FC = () => {
   const orgs = useSelector((state: AppState) =>
     getAll<Organization>(state, ResourceType.Orgs)
   )
+  const shouldShowNotebooks = useSelector(selectShouldShowNotebooks)
+
   const history = useHistory()
   const {orgID} = useParams<{orgID: string}>()
 
@@ -165,19 +167,20 @@ const SetOrg: FC = () => {
             path={`${orgPath}/dashboards`}
             component={RouteToDashboardList}
           />
-          {/* Flows  */}
-          <Route
-            path={`${orgPath}/${PROJECT_NAME_PLURAL.toLowerCase()}/:notebookID/versions/:id`}
-            component={VersionPage}
-          />
-          <Route
-            path={`${orgPath}/${PROJECT_NAME_PLURAL.toLowerCase()}/:id`}
-            component={FlowPage}
-          />
-          <Route
-            path={`${orgPath}/${PROJECT_NAME_PLURAL.toLowerCase()}`}
-            component={FlowsIndex}
-          />
+          {/* Notebooks  */}
+          {shouldShowNotebooks && (
+            <Route
+              path={`${orgPath}/notebooks/:notebookID/versions/:id`}
+              component={VersionPage}
+            />
+          )}
+          {shouldShowNotebooks && (
+            <Route path={`${orgPath}/notebooks/:id`} component={FlowPage} />
+          )}
+          {shouldShowNotebooks && (
+            <Route path={`${orgPath}/notebooks`} component={FlowsIndex} />
+          )}
+
           {/* Write Data */}
           <Route
             path={`${orgPath}/${LOAD_DATA}/sources`}

--- a/src/shared/selectors/flags.ts
+++ b/src/shared/selectors/flags.ts
@@ -26,7 +26,6 @@ export const OSS_FLAGS = {
   'notification-endpoint-telegram': false,
   boardWithFlows: false,
   createWithFlows: false,
-  leadWithFlows: false,
 }
 
 export const CLOUD_FLAGS = {
@@ -51,7 +50,6 @@ export const CLOUD_FLAGS = {
   'notification-endpoint-telegram': false,
   boardWithFlows: false,
   createWithFlows: false,
-  leadWithFlows: false,
 }
 
 const getConfigCatFlags = (state: AppState) => state.flags.original || {}


### PR DESCRIPTION
Closes https://github.com/influxdata/idpe/issues/16723

See the above linked ticket for a flowchart describing the logic of showing or hiding notebooks.

Notebooks will be hidden in the UI's navigation and the routes will throw 404s under the following conditions:
- the organization was created on or after January 31, 2023
- the organization was created before January 31, 2023, but has no saved notebooks

All other organizations will show notebooks.

### When the conditions are met, the notebooks route with 404 and the navigation item will be missing
![Screen Shot 2022-12-19 at 4 03 13 PM](https://user-images.githubusercontent.com/146112/208523696-4d758e9a-e6eb-46d1-a896-31bcf0e4ee6f.png)

### The same page as above but with an existing notebook
 ![Screen Shot 2022-12-19 at 4 05 25 PM](https://user-images.githubusercontent.com/146112/208523871-243703ba-94f4-413b-bbcc-536504659e8f.png)

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- ~[ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~
- ~[ ] Feature flagged, if applicable~
