### PR TITLE
chore: use initLog() in utils, to handle use case when LSP server is not loaded

### DIFF
--- a/src/languageSupport/languages/flux/parser/index.ts
+++ b/src/languageSupport/languages/flux/parser/index.ts
@@ -1,8 +1,12 @@
 import {File} from 'src/types/ast'
 import {
+  initLog,
   parse as flux_parse,
   format_from_js_file as flux_format_from_js_file,
 } from '@influxdata/flux-lsp-browser'
+
+initLog()
+
 /*
   NOTE: This is a work around for flux being generated (from rust) for the browser and jest tests running in
         a node environment (this is only for handling tests). If a test requires a specific AST result


### PR DESCRIPTION

Follow up to https://github.com/influxdata/flux-lsp/issues/618

The LSP wasm [was panicking](https://github.com/influxdata/flux-lsp/issues/618) due to use of a logger which was [not compatible with wasm](https://github.com/influxdata/flux-lsp/pull/619#issue-1485914085). The recent LSP version bump included:
1.  a global wasm logger init whenever the [LSP server was init](https://github.com/influxdata/flux-lsp/pull/619).
     * no UI change required, outside of the version bump
2. the option to [manually init the wasm logger](https://github.com/influxdata/flux-lsp/pull/621), when the LSP utils methods are used without the LSP server being init first
     * this does require calling `initLog()` in the UI, to handle race condition if LSP server is not loaded --> but LSP utils methods are used
     * setting the global logger >1 time, has no negative impact. (Only resulted in console warning [within the LSP tests](https://github.com/influxdata/flux-lsp/blob/0846e86632cbeedb587f1d580cefac6914c7095f/integration/lsp.test.ts#L136-L139).)


## Impact in UI.

We do have a current, frequent bug in the UI where the dashboard fails after a panic occurs in the LSP wasm. As we did not know the root of the panic (and we didn't have any error logs from the wasm), we focused instead on the cascading nature of the variables tie-in with dashboards.

Recently, we became aware of that fact that our lack of logging from wasm in prod (especially during instances of wasm panic) was directly due to our _logging causing the panics_. This is a followup PR to ensure that the global logger is always set.



## Checklist
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
