### PR TITLE
feat(aim): Hide Cardinality for iOX Orgs

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "cy": "CYPRESS_dexUrl=https://$INGRESS_HOST:$PORT_HTTPS CYPRESS_baseUrl=http://localhost:9999 cypress open",
     "cy:dev": "source ../monitor-ci/.env && CYPRESS_dexUrl=CLOUD CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{cloud,shared}/**/*.*'",
     "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_dexUrl=OSS CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{oss,shared}/**/*.*'",
-    "generate": "export SHA=fe5b50d055054530257b42ad7600eb8b4d247332 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
+    "generate": "export SHA=b18f46ff9dbc89193e2eaecc91248597a8ae4c9d && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-local-cloud": "export REMOTE=../openapi/ && yarn generate-meta-cloud",
     "generate-meta": "if [ -z \"${CLOUD_URL}\" ]; then yarn generate-meta-oss; else yarn generate-meta-cloud; fi",

--- a/src/operator/OrgOverlay.tsx
+++ b/src/operator/OrgOverlay.tsx
@@ -57,7 +57,7 @@ const OrgOverlay: FC = () => {
   const history = useHistory()
   const canReactivateOrg =
     hasWritePermissions && organization?.state === 'suspended'
-  const isIOx = organization?.storageType == 'iox'
+  const isIOx = organization?.storageType.toLowerCase() === 'iox'
   const canSeeCardinalityLimits = !isIOx
 
   useEffect(() => {

--- a/src/operator/OrgOverlay.tsx
+++ b/src/operator/OrgOverlay.tsx
@@ -57,7 +57,8 @@ const OrgOverlay: FC = () => {
   const history = useHistory()
   const canReactivateOrg =
     hasWritePermissions && organization?.state === 'suspended'
-  const canSeeCardinalityLimits = organization?.storageType == 'tsm'
+  const isIOx = organization?.storageType == 'iox'
+  const canSeeCardinalityLimits = !isIOx
 
   useEffect(() => {
     handleGetLimits(orgID)

--- a/src/operator/OrgOverlay.tsx
+++ b/src/operator/OrgOverlay.tsx
@@ -57,6 +57,7 @@ const OrgOverlay: FC = () => {
   const history = useHistory()
   const canReactivateOrg =
     hasWritePermissions && organization?.state === 'suspended'
+  const canSeeCardinalityLimits = organization?.storageType == 'tsm'
 
   useEffect(() => {
     handleGetLimits(orgID)
@@ -176,15 +177,17 @@ const OrgOverlay: FC = () => {
                         onChangeLimits={setLimits}
                       />
                     </Grid.Column>
-                    <Grid.Column widthMD={Columns.Four}>
-                      <Form.Label label="Series Cardinality" />
-                      <LimitsField
-                        type={InputType.Number}
-                        name="rate.cardinality"
-                        limits={limits}
-                        onChangeLimits={setLimits}
-                      />
-                    </Grid.Column>
+                    {canSeeCardinalityLimits && (
+                      <Grid.Column widthMD={Columns.Four}>
+                        <Form.Label label="Series Cardinality" />
+                        <LimitsField
+                          type={InputType.Number}
+                          name="rate.cardinality"
+                          limits={limits}
+                          onChangeLimits={setLimits}
+                        />
+                      </Grid.Column>
+                    )}
                   </Grid.Row>
                   <Grid.Row>
                     <Grid.Column widthMD={Columns.Four}>

--- a/src/operator/OrgOverlay.tsx
+++ b/src/operator/OrgOverlay.tsx
@@ -57,7 +57,9 @@ const OrgOverlay: FC = () => {
   const history = useHistory()
   const canReactivateOrg =
     hasWritePermissions && organization?.state === 'suspended'
-  const isIOx = organization?.storageType.toLowerCase() === 'iox'
+  const isIOx =
+    organization?.storageType &&
+    organization.storageType.toLowerCase() === 'iox'
   const canSeeCardinalityLimits = !isIOx
 
   useEffect(() => {


### PR DESCRIPTION
Removes the cardinality limit from the UI for iOX-enabled organizations. This will require a new SHA pending influxdata/openapi#625.

![image](https://user-images.githubusercontent.com/31899323/208729139-d8d543af-f9de-4c4e-a7a6-56c6d005fbfe.png)


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
