### PR TITLE
chore: upgrade node to version 18.12.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ jobs:
     steps:
       - run:
           name: Run monitor-ci tests
-          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="docker_compose_edit" UI_BRANCH=${CIRCLE_BRANCH} UI_SHA=${CIRCLE_SHA1} SHA=${CIRCLE_SHA1} RUN_WORKFLOW="build" /run-monitor-ci-tests.bash
+          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="master" UI_BRANCH=${CIRCLE_BRANCH} UI_SHA=${CIRCLE_SHA1} SHA=${CIRCLE_SHA1} RUN_WORKFLOW="build" /run-monitor-ci-tests.bash
       - store_artifacts:
           path: monitor-ci/test-artifacts/results/build-oss-image
           destination: test_artifacts/results/build-oss-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   unit:
     docker:
-      - image: circleci/golang:1.17-node
+      - image: cimg/go:1.19-node
     working_directory: ~/influxdata/ui
     parallelism: 4
     steps:
@@ -37,7 +37,7 @@ jobs:
             - ~/.cache/yarn
   unit-cloud:
     docker:
-      - image: circleci/golang:1.15-node
+      - image: cimg/go:1.19-node
     working_directory: ~/influxdata/ui
     parallelism: 4
     steps:
@@ -71,7 +71,7 @@ jobs:
             - ~/.cache/yarn
   lint:
     docker:
-      - image: circleci/golang:1.15-node
+      - image: cimg/go:1.19-node
     working_directory: ~/influxdata/ui
     parallelism: 4
     steps:
@@ -104,7 +104,7 @@ jobs:
 
   lint-cloud:
     docker:
-      - image: circleci/golang:1.15-node
+      - image: cimg/go:1.19-node
     working_directory: ~/influxdata/ui
     parallelism: 4
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ jobs:
     steps:
       - run:
           name: Run monitor-ci tests
-          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="master" UI_BRANCH=${CIRCLE_BRANCH} UI_SHA=${CIRCLE_SHA1} SHA=${CIRCLE_SHA1} RUN_WORKFLOW="build" /run-monitor-ci-tests.bash
+          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="docker_compose_edit" UI_BRANCH=${CIRCLE_BRANCH} UI_SHA=${CIRCLE_SHA1} SHA=${CIRCLE_SHA1} RUN_WORKFLOW="build" /run-monitor-ci-tests.bash
       - store_artifacts:
           path: monitor-ci/test-artifacts/results/build-oss-image
           destination: test_artifacts/results/build-oss-image

--- a/docker/Dockerfile.chronograf
+++ b/docker/Dockerfile.chronograf
@@ -1,7 +1,4 @@
-# [jdstrand] lts breaks webpack 4 so temporarily choose a currently supported
-# node alpine release. When we migrate to webpack 5, move back to node:lts
-#FROM node:lts AS base
-FROM node:gallium AS base
+FROM node:lts-alpine AS base
 
 RUN curl --compressed -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.22.4
 

--- a/docker/Dockerfile.chronograf.prod
+++ b/docker/Dockerfile.chronograf.prod
@@ -1,9 +1,4 @@
-# from node lts alpine
-# [jdstrand] lts-alpine breaks webpack 4 so temporarily choose a currently
-# supported node alpine release. When we migrate to webpack 5, move back to
-# node:lts-alpine
-#FROM node:lts-alpine AS repo
-FROM node:16-alpine3.16 AS repo
+FROM node:lts-alpine AS repo
 
 # env vars to configure the system
 

--- a/docker/Dockerfile.cypress
+++ b/docker/Dockerfile.cypress
@@ -1,7 +1,7 @@
 # The cypress image used here is a non-standard slim image
 # and its definition and versions are maintained here:
 # https://github.com/influxdata/cypress-slim
-FROM quay.io/influxdb/cypress-slim:9.5.2-included
+FROM quay.io/influxdb/cypress-slim:9.5.2-included-test
 
 WORKDIR /repo
 

--- a/docker/Dockerfile.cypress
+++ b/docker/Dockerfile.cypress
@@ -1,7 +1,7 @@
 # The cypress image used here is a non-standard slim image
 # and its definition and versions are maintained here:
 # https://github.com/influxdata/cypress-slim
-FROM quay.io/influxdb/cypress-slim:9.5.2-included-test
+FROM quay.io/influxdb/cypress-slim:9.5.2-included
 
 WORKDIR /repo
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "github:influxdata/ui"
   },
   "engines": {
-    "node": ">=14.17.0",
+    "node": ">=18.12.1",
     "yarn": ">=1.16.0"
   },
   "alias": {


### PR DESCRIPTION
closes #4487
PR upgrades node from v14.17 -> v18.12.1 (LTS)


### Checklist

Authors and Reviewer(s), please verify the following:

- [ ] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [ ] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
