### PR TITLE
chore: add warning if deleting payg or contract org with other users

### DIFF
--- a/src/organizations/components/OrgProfileTab/DeletePanel.tsx
+++ b/src/organizations/components/OrgProfileTab/DeletePanel.tsx
@@ -80,8 +80,17 @@ const DeleteFreeAccountButton: FC = () => {
   const org = useSelector(getOrg)
   const user = useSelector(selectUser)
   const {users} = useContext(UsersContext)
-
   const dispatch = useDispatch()
+
+  const shouldShowUsersWarning = users.length > 1
+
+  const handleClickDeleteFreeAccount = () => {
+    if (shouldShowUsersWarning) {
+      showRemoveUsersWarning()
+    } else {
+      showDeleteFreeAccountOverlay()
+    }
+  }
 
   const showDeleteFreeAccountOverlay = () => {
     const payload = {
@@ -104,9 +113,6 @@ const DeleteFreeAccountButton: FC = () => {
     dispatch(notify(deleteAccountWarning(buttonElement)))
   }
 
-  const handleDeleteAccountFree =
-    users.length > 1 ? showRemoveUsersWarning : showDeleteFreeAccountOverlay
-
   return (
     <>
       <FlexBox.Child>
@@ -121,7 +127,7 @@ const DeleteFreeAccountButton: FC = () => {
           testID="delete-org--button"
           text="Delete"
           icon={IconFont.Trash_New}
-          onClick={handleDeleteAccountFree}
+          onClick={handleClickDeleteFreeAccount}
         />
       </FlexBox.Child>
     </>
@@ -155,9 +161,11 @@ const DeleteOrgButton: FC = () => {
     hidePopup()
   }
 
+  const shouldShowUsersWarning = users.length > 1
+
   const handleSuspendOrg = () => {
     if (orgCanBeSuspended) {
-      if (users.length > 1) {
+      if (shouldShowUsersWarning) {
         const buttonElement: NotificationButtonElement = onDismiss =>
           OrgUsersLink(`/orgs/${org.id}/members`, onDismiss)
         dispatch(notify(deleteOrgWarning(buttonElement)))

--- a/src/shared/components/notifications/NotificationButtons.tsx
+++ b/src/shared/components/notifications/NotificationButtons.tsx
@@ -5,7 +5,7 @@ import {Link} from 'react-router-dom'
 // Types
 import {NotificationDismiss} from 'src/types'
 
-export const getDeleteAccountWarningButton = (
+export const OrgUsersLink = (
   url: string,
   onDismiss: NotificationDismiss
 ): JSX.Element => {

--- a/src/shared/copy/notifications/categories/accounts-users-orgs.ts
+++ b/src/shared/copy/notifications/categories/accounts-users-orgs.ts
@@ -8,6 +8,7 @@ import {FIFTEEN_SECONDS} from 'src/shared/constants'
 import {
   defaultErrorNotification,
   defaultSuccessNotification,
+  defaultWarningNotification,
 } from 'src/shared/copy/notifications'
 
 // Types
@@ -44,6 +45,17 @@ export const accountRenameSuccess = (
   message: `Account "${oldAccountName}" was successfully renamed to "${newAccountName}"`,
 })
 
+export const deleteAccountWarning = (
+  buttonElement: NotificationButtonElement
+): Notification => ({
+  ...defaultWarningNotification,
+  message: `All additional users must be removed from the current organization before this account can be deleted.\n`,
+  buttonElement,
+  styles: {
+    flexWrap: 'wrap',
+  },
+})
+
 export const deleteOrgDelayed = (
   supportLink: NotificationButtonElement
 ): Notification => ({
@@ -68,6 +80,17 @@ export const deleteOrgSuccess = (
 ): Notification => ({
   ...defaultSuccessNotification,
   message: `${orgName} will be deleted from ${accountName}.`,
+})
+
+export const deleteOrgWarning = (
+  buttonElement: NotificationButtonElement
+): Notification => ({
+  ...defaultWarningNotification,
+  message: `All additional users must be removed from this organization before it can be deleted.\n`,
+  buttonElement,
+  styles: {
+    flexWrap: 'wrap',
+  },
 })
 
 export const inviteFailed = (): Notification => ({

--- a/src/shared/copy/notifications/categories/billing-checkout.ts
+++ b/src/shared/copy/notifications/categories/billing-checkout.ts
@@ -1,9 +1,6 @@
 import {Notification} from 'src/types'
 import {FIVE_SECONDS} from 'src/shared/constants/index'
-import {
-  defaultErrorNotification,
-  defaultWarningNotification,
-} from 'src/shared/copy/notifications'
+import {defaultErrorNotification} from 'src/shared/copy/notifications'
 
 // Billing Notifications
 export const updateBillingSettingsError = (message: string): Notification => ({
@@ -78,13 +75,4 @@ export const zuoraParamsGetFailure = (message): Notification => ({
 export const accountSelfDeletionFailed = (): Notification => ({
   ...defaultErrorNotification,
   message: `There was an error deleting the organization, please try again.`,
-})
-
-export const deleteAccountWarning = (buttonElement): Notification => ({
-  ...defaultWarningNotification,
-  message: `All additional users must be removed from the Organization before the account can be deleted.\n`,
-  buttonElement,
-  styles: {
-    flexWrap: 'wrap',
-  },
 })


### PR DESCRIPTION
Helps with #5245

In working on e2e tests for the delete-orgs page, I noted that free account deletion is blocked if there are other users in the current account. Multi-org does not currently notify that there are other users in the org, or require a user to remove the other users in the org before hitting delete.

This PR will (once the feature flag for creating and deleting PAYG/Contract orgs is turned on in prod) make the ability to delete PAYG or contract orgs in the UI contingent on the current user removing the other users from the org. This is easily reverted if removal of the other users in the org is not desirable or required before deletion.

An alternative would be to warn the current user that there are other users in the org, but let them proceed with deletion of the org anyway.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - new features are behind `createDeleteOrgs`.
