### PR TITLE
chore: update idpe-quartz sync function for delete-org tests

### DIFF
--- a/cypress/support/Utils.ts
+++ b/cypress/support/Utils.ts
@@ -168,7 +168,9 @@ export function genCurve(args: CurveArgs): string[] {
 
 export const makeQuartzUseIDPEOrgID = (
   idpeOrgID: string,
-  accountType = 'free'
+  accountType = 'free',
+  orgCount = 0,
+  orgSuspendable = false
 ) => {
   cy.fixture('multiOrgAccounts1.json').then(quartzAccounts => {
     cy.intercept('GET', 'api/v2/quartz/accounts', quartzAccounts).as(
@@ -187,6 +189,10 @@ export const makeQuartzUseIDPEOrgID = (
   cy.fixture(fixtureName).then(quartzIdentity => {
     quartzIdentity.org.id = idpeOrgID
 
+    if (orgCount) {
+      quartzIdentity.user.orgCount = orgCount
+    }
+
     cy.intercept('GET', 'api/v2/quartz/identity', quartzIdentity).as(
       'getQuartzIdentity'
     )
@@ -202,6 +208,9 @@ export const makeQuartzUseIDPEOrgID = (
 
   cy.fixture('orgDetails').then(quartzOrgDetails => {
     quartzOrgDetails.id = idpeOrgID
+
+    quartzOrgDetails.isSuspendable = orgSuspendable
+
     cy.intercept('GET', 'api/v2/quartz/orgs/*', quartzOrgDetails).as(
       'getQuartzOrgDetails'
     )


### PR DESCRIPTION
Helps with #5245 

To ensure the tests in [this PR](https://github.com/influxdata/ui/pull/6438) are run 20x against chrome (not just once against all of CI), that PR must contain only updates to test files. 

This PR makes a necessary update to a cypress util that is used to synchronize idpe and quartz-mock for purposes of e2e tests for use in that PR.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - NO
