### PR TITLE
feat: add e2e tests for the account/orgslist page

### DIFF
--- a/cypress/e2e/cloud/org-list.test.ts
+++ b/cypress/e2e/cloud/org-list.test.ts
@@ -38,8 +38,12 @@ const testSearchTerm = (searchTerm: string, expectedResults: string[]) => {
 }
 
 describe('Account / Organizations Tab', () => {
-  beforeEach(() => {
+  before(() => {
     setupTest()
+  })
+
+  beforeEach(() => {
+    Cypress.Cookies.preserveOnce('sid')
   })
 
   it('displays a paginated list of provisioned and suspended organizations in the current account', () => {
@@ -78,6 +82,11 @@ describe('Account / Organizations Tab', () => {
       .click()
 
     cy.url().should('include', 'orglist?page=2')
+
+    cy.getByTestID('pagination-item')
+      .should('have.length', 2)
+      .contains('1')
+      .click()
   })
 
   it('searches the organizations in the current account', () => {
@@ -97,6 +106,8 @@ describe('Account / Organizations Tab', () => {
 
     // Search by human-readable location
     testSearchTerm('Amsterdam', ['Suspended Organization', 'Test Org 4'])
+
+    cy.getByTestID('search-widget').should('be.visible').clear()
   })
 
   it('sorts the organizations in the current account', () => {

--- a/cypress/e2e/cloud/org-list.test.ts
+++ b/cypress/e2e/cloud/org-list.test.ts
@@ -73,11 +73,6 @@ describe('Account / Organizations Tab', () => {
         .should('have.attr', 'href', 'mailto:support@influxdata.com')
     })
 
-    cy.getByTestID('account--organizations-tab-orgs-card').should(
-      'have.length',
-      9
-    )
-
     cy.getByTestID('pagination-item')
       .should('have.length', 2)
       .contains('2')

--- a/cypress/e2e/cloud/org-list.test.ts
+++ b/cypress/e2e/cloud/org-list.test.ts
@@ -44,6 +44,8 @@ describe('Account / Organizations Tab', () => {
 
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('sid')
+    // Resolves issue with misidentifying the first org card when the DOM is updated.
+    cy.wait(500)
   })
 
   it('displays a paginated list of provisioned and suspended organizations in the current account', () => {

--- a/cypress/e2e/cloud/org-list.test.ts
+++ b/cypress/e2e/cloud/org-list.test.ts
@@ -1,0 +1,115 @@
+const setupTest = () => {
+  cy.flush().then(() =>
+    cy.signin().then(() => {
+      cy.get('@org').then(({id}) => {
+        cy.setFeatureFlags({createDeleteOrgs: true})
+        cy.visit(`/orgs/${id}/accounts/orglist`)
+      })
+    })
+  )
+}
+
+const filterSearchTerm = (sortMethod: string, firstResult: string) => {
+  cy.getByTestID('resource-sorter--button').should('be.visible').click()
+
+  cy.contains(sortMethod).click()
+
+  cy.getByTestID('account--organizations-tab-orgs-card')
+    .first()
+    .contains(firstResult)
+}
+
+const testSearchTerm = (searchTerm: string, expectedResults: string[]) => {
+  const expectedLength = expectedResults.length
+
+  cy.getByTestID('search-widget')
+    .should('be.visible')
+    .clear()
+    .click()
+    .type(searchTerm)
+
+  cy.getByTestID('account--organizations-tab-orgs-card')
+    .should('have.length', expectedLength)
+    .within(() => {
+      expectedResults.forEach(result => {
+        cy.contains(result)
+      })
+    })
+}
+
+describe('Account / Organizations Tab', () => {
+  beforeEach(() => {
+    setupTest()
+  })
+
+  it('displays a paginated list of provisioned and suspended organizations in the current account', () => {
+    cy.getByTestID('account--organizations-tab-orgs-card')
+      .first()
+      .should('be.visible')
+      .and('have.class', 'account--organizations-tab-orgs-card')
+      .contains('Pending Organization')
+
+    cy.get('.account--organizations-tab-suspended-orgs-card')
+      .should('have.length', 1)
+      .and('be.visible')
+      .within(() => {
+        cy.getByTestID('question-mark-tooltip').click()
+        cy.contains('Deletion in progress')
+      })
+
+    cy.getByTestID('question-mark-tooltip--tooltip--dialog').contains(
+      'Organizations can be reactivated within 7 days of deletion.'
+    )
+
+    cy.getByTestID('question-mark-tooltip--tooltip--dialog').within(() => {
+      cy.get('a')
+        .contains('support@influxdata.com')
+        .should('have.attr', 'href', 'mailto:support@influxdata.com')
+    })
+
+    cy.getByTestID('account--organizations-tab-orgs-card').should(
+      'have.length',
+      9
+    )
+
+    cy.getByTestID('pagination-item')
+      .should('have.length', 2)
+      .contains('2')
+      .click()
+
+    cy.url().should('include', 'orglist?page=2')
+  })
+
+  it('searches the organizations in the current account', () => {
+    // Search by name
+    testSearchTerm('Test Org 0', ['Test Org 0'])
+
+    // Search by cloud provider
+    testSearchTerm('Azure', [
+      'Suspended Organization',
+      'Test Org 3',
+      'Test Org 4',
+      'Test Org 5',
+    ])
+
+    // Search by region code
+    testSearchTerm('us-west', ['Test Org 3', 'Test Org 9'])
+
+    // Search by human-readable location
+    testSearchTerm('Amsterdam', ['Suspended Organization', 'Test Org 4'])
+  })
+
+  it('sorts the organizations in the current account', () => {
+    filterSearchTerm('Name (A ➞ Z)', 'Pending Organization')
+    filterSearchTerm('Name (Z ➞ A)', 'Test Org 9')
+
+    filterSearchTerm('Cloud Provider (A ➞ Z)', 'Pending Organization')
+    filterSearchTerm('Cloud Provider (Z ➞ A)', 'Test Org 6')
+
+    filterSearchTerm('Region (A ➞ Z)', 'Test Org 5')
+    filterSearchTerm('Region (Z ➞ A)', 'Suspended Organization')
+
+    filterSearchTerm('Location (A ➞ Z)', 'Suspended Organization')
+    filterSearchTerm('Location (Z ➞ A)', 'Test Org 5')
+  })
+})


### PR DESCRIPTION
Closes #5245 

Adds end to end tests for the Account Page - Org List tab.


https://user-images.githubusercontent.com/91283923/209964623-9d5a70c9-ff04-4506-9386-1c31f41cdfc1.mov



### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - `createDeleteOrgs`
