### PR TITLE
feat(monitor-ci/402): get remocal-iox e2es passing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ jobs:
     steps:
       - run:
           name: Run monitor-ci tests
-          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="master" UI_BRANCH=${CIRCLE_BRANCH} UI_SHA=${CIRCLE_SHA1} SHA=${CIRCLE_SHA1} RUN_WORKFLOW="build" /run-monitor-ci-tests.bash
+          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="genehynson/iox-on-merge-queue" UI_BRANCH=${CIRCLE_BRANCH} UI_SHA=${CIRCLE_SHA1} SHA=${CIRCLE_SHA1} RUN_WORKFLOW="build" /run-monitor-ci-tests.bash
       - store_artifacts:
           path: monitor-ci/test-artifacts/results/build-oss-image
           destination: test_artifacts/results/build-oss-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ jobs:
     steps:
       - run:
           name: Run monitor-ci tests
-          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="genehynson/iox-on-merge-queue" UI_BRANCH=${CIRCLE_BRANCH} UI_SHA=${CIRCLE_SHA1} SHA=${CIRCLE_SHA1} RUN_WORKFLOW="build" /run-monitor-ci-tests.bash
+          command: API_KEY=${MONITOR_CI_API_KEY} PULL_REQUEST=${CIRCLE_PULL_REQUEST} MONITOR_CI_BRANCH="master" UI_BRANCH=${CIRCLE_BRANCH} UI_SHA=${CIRCLE_SHA1} SHA=${CIRCLE_SHA1} RUN_WORKFLOW="build" /run-monitor-ci-tests.bash
       - store_artifacts:
           path: monitor-ci/test-artifacts/results/build-oss-image
           destination: test_artifacts/results/build-oss-image

--- a/cypress/e2e/cloud/buckets.test.ts
+++ b/cypress/e2e/cloud/buckets.test.ts
@@ -101,6 +101,10 @@ describe('Explicit Buckets', () => {
   })
 
   it('can create a bucket with an explicit schema', () => {
+    // TODO: iox is not yet supporting explicit schema.
+    cy.isIoxOrg().then(isIox => {
+      cy.skipOn(isIox)
+    })
     cy.getByTestID('Create Bucket').click()
     cy.getByTestID('overlay--container').within(() => {
       cy.getByInputName('name').type('explicit-bucket-test')
@@ -155,15 +159,22 @@ describe('Explicit Buckets', () => {
     cy.getByTestID('overlay--container').within(() => {
       cy.getByInputName('name').type('implicit-bucket-test')
 
-      cy.getByTestID('schemaBucketToggle').click()
+      // TODO: iox is not yet supporting explicit schema.
+      cy.isIoxOrg().then(isIox => {
+        if (!isIox) {
+          cy.getByTestID('schemaBucketToggle').click()
 
-      // check that it is there; but don't click on it; leave it as implicit:
-      cy.getByTestID('explicit-bucket-schema-choice-ID').should('be.visible')
+          // check that it is there; but don't click on it; leave it as implicit:
+          cy.getByTestID('explicit-bucket-schema-choice-ID').should(
+            'be.visible'
+          )
 
-      // implicit button should be selected by default:
-      cy.getByTestID('implicit-bucket-schema-choice-ID--input').should(
-        'be.checked'
-      )
+          // implicit button should be selected by default:
+          cy.getByTestID('implicit-bucket-schema-choice-ID--input').should(
+            'be.checked'
+          )
+        }
+      })
 
       // measurement schema section should NOT be showing at this time
       // (b/c it only shows if explicit is set)
@@ -201,6 +212,10 @@ describe('Explicit Buckets', () => {
   })
 
   it('should be able to create an explicit bucket using one schema file', function () {
+    // TODO: iox is not yet supporting explicit schema.
+    cy.isIoxOrg().then(isIox => {
+      cy.skipOn(isIox)
+    })
     const schemaName = 'only one schema'
     const filename = 'validSchema1.json'
 
@@ -254,6 +269,10 @@ describe('Explicit Buckets', () => {
   })
 
   it('should be able to create an explicit bucket and add json schema file during editing', function () {
+    // TODO: iox is not yet supporting explicit schema.
+    cy.isIoxOrg().then(isIox => {
+      cy.skipOn(isIox)
+    })
     const origFileContents = `[{"name":"time","type":"timestamp"},
         {"name":"fsWrite","type":"field","dataType":"float"} ]`
 
@@ -282,6 +301,10 @@ describe('Explicit Buckets', () => {
   })
 
   it('should be able to create an explicit bucket and add csv schema file during editing', function () {
+    // TODO: iox is not yet supporting explicit schema.
+    cy.isIoxOrg().then(isIox => {
+      cy.skipOn(isIox)
+    })
     const origFileContents = `name,type,dataType
 time,timestamp,
 host,tag,
@@ -305,6 +328,10 @@ fsRead,field,float`
   })
 
   it('should be able to create an explicit bucket and update the existing schema file during editing', function () {
+    // TODO: iox is not yet supporting explicit schema.
+    cy.isIoxOrg().then(isIox => {
+      cy.skipOn(isIox)
+    })
     cy.getByTestID('Create Bucket').click()
     cy.getByTestID('create-bucket-form').should('be.visible')
     cy.getByTestID('bucket-form-name').type(bucketName)

--- a/cypress/e2e/shared/checks.test.ts
+++ b/cypress/e2e/shared/checks.test.ts
@@ -226,17 +226,25 @@ describe('Checks', () => {
   })
 
   it('can create and filter checks', () => {
-    cy.get<Organization>('@org').then((org: Organization) => {
-      cy.intercept('POST', `/api/v2/query?orgID=${org.id}`, req => {
-        if (req.body.query.includes('_measurement')) {
-          req.alias = 'measurementQuery'
+    cy.get<Organization>('@org').then(({id: orgID}: Organization) => {
+      cy.intercept(
+        'POST',
+        `/api/v2/query?${new URLSearchParams({orgID})}`,
+        req => {
+          if (req.body.query.includes('_measurement')) {
+            req.alias = 'measurementQuery'
+          }
         }
-      })
-      cy.intercept('POST', `/api/v2/query?orgID=${org.id}`, req => {
-        if (req.body.query.includes('distinct(column: "_field")')) {
-          req.alias = 'fieldQuery'
+      )
+      cy.intercept(
+        'POST',
+        `/api/v2/query?${new URLSearchParams({orgID})}`,
+        req => {
+          if (req.body.query.includes('distinct(column: "_field")')) {
+            req.alias = 'fieldQuery'
+          }
         }
-      })
+      )
       cy.get<string>('@defaultBucketListSelector').then(
         (defaultBucketListSelector: string) => {
           cy.log('create first check')
@@ -265,16 +273,24 @@ describe('Checks', () => {
           cy.getByTestID('overlay').should('not.exist')
 
           // create a second check
-          cy.intercept('POST', `/api/v2/query?orgID=${org.id}`, req => {
-            if (req.body.query.includes('distinct(column: "_field")')) {
-              req.alias = 'fieldQueryBeta'
+          cy.intercept(
+            'POST',
+            `/api/v2/query?${new URLSearchParams({orgID})}`,
+            req => {
+              if (req.body.query.includes('distinct(column: "_field")')) {
+                req.alias = 'fieldQueryBeta'
+              }
             }
-          })
-          cy.intercept('POST', `/api/v2/query?orgID=${org.id}`, req => {
-            if (req.body.query.includes('_measurement')) {
-              req.alias = 'measurementQueryBeta'
+          )
+          cy.intercept(
+            'POST',
+            `/api/v2/query?${new URLSearchParams({orgID})}`,
+            req => {
+              if (req.body.query.includes('_measurement')) {
+                req.alias = 'measurementQueryBeta'
+              }
             }
-          })
+          )
           // bust the /query cache
           cy.reload()
 

--- a/cypress/e2e/shared/checks.test.ts
+++ b/cypress/e2e/shared/checks.test.ts
@@ -421,6 +421,13 @@ describe('Checks', () => {
     })
 
     it('deadman checks should render a table for non-numeric fields', () => {
+      cy.isIoxOrg().then(isIox => {
+        // iox uses `${orgId}_${bucketId}` for a namespace_id
+        // And gives a namespace_id failure if no data is written yet.
+        // https://github.com/influxdata/monitor-ci/issues/402#issuecomment-1362368473
+        cy.skipOn(isIox)
+      })
+
       cy.intercept('POST', '/api/v2/query?*', req => {
         if (req.body.query.includes('_measurement')) {
           req.alias = 'measurementQuery'
@@ -589,6 +596,13 @@ describe('Checks', () => {
     })
 
     it('ensures the history page has a graph after check creation confirmation', () => {
+      cy.isIoxOrg().then(isIox => {
+        // iox uses `${orgId}_${bucketId}` for a namespace_id
+        // And gives a namespace_id failure if no data is written yet.
+        // https://github.com/influxdata/monitor-ci/issues/402#issuecomment-1362368473
+        cy.skipOn(isIox)
+      })
+
       cy.getByTestID('context-menu-task').click()
       cy.getByTestID('context-history-task').click()
       cy.getByTestID('giraffe-axes').should('be.visible')

--- a/cypress/e2e/shared/dashboardsRefresh.test.ts
+++ b/cypress/e2e/shared/dashboardsRefresh.test.ts
@@ -73,10 +73,14 @@ describe('Dashboard refresh', () => {
     })
 
     it('can enable the auto refresh process, then manually stop the process via the dropdown', done => {
-      cy.get<Organization>('@org').then((org: Organization) => {
-        cy.intercept('POST', `/api/v2/query?orgID=${org.id}`, req => {
-          req.alias = 'refreshQuery'
-        })
+      cy.get<Organization>('@org').then(({id: orgID}: Organization) => {
+        cy.intercept(
+          'POST',
+          `/api/v2/query?${new URLSearchParams({orgID})}`,
+          req => {
+            req.alias = 'refreshQuery'
+          }
+        )
         cy.getByTestID('enable-auto-refresh-button').click()
         cy.getByTestID('auto-refresh-input').clear().type('2s', {force: true})
         cy.getByTestID('refresh-form-activate-button').click({force: true})
@@ -94,7 +98,7 @@ describe('Dashboard refresh', () => {
     })
 
     it('can timeout on a preset timeout selected by the user', done => {
-      cy.get<Organization>('@org').then((org: Organization) => {
+      cy.get<Organization>('@org').then(({id: orgID}: Organization) => {
         cy.getByTestID('enable-auto-refresh-button').click()
         cy.getByTestID('auto-refresh-input')
           .clear()
@@ -109,9 +113,13 @@ describe('Dashboard refresh', () => {
         })
         cy.getByTestID('refresh-form-activate-button').click()
 
-        cy.intercept('POST', `/api/v2/query?orgID=${org.id}`, req => {
-          req.alias = 'refreshQuery'
-        })
+        cy.intercept(
+          'POST',
+          `/api/v2/query?${new URLSearchParams({orgID})}`,
+          req => {
+            req.alias = 'refreshQuery'
+          }
+        )
 
         cy.wait('@refreshQuery')
         cy.wait('@refreshQuery')
@@ -125,7 +133,7 @@ describe('Dashboard refresh', () => {
     })
 
     it('does not refresh if user edits cell, until user comes back, and then continues', () => {
-      cy.get<Organization>('@org').then((org: Organization) => {
+      cy.get<Organization>('@org').then(({id: orgID}: Organization) => {
         cy.getByTestID('enable-auto-refresh-button').click()
         cy.getByTestID('auto-refresh-input')
           .clear()
@@ -138,9 +146,13 @@ describe('Dashboard refresh', () => {
             .type(`${jumpAheadTime('00:00:10')}`, {force: true})
           cy.getByTestID('daterange--apply-btn').click()
         })
-        cy.intercept('POST', `/api/v2/query?orgID=${org.id}`, req => {
-          req.alias = 'refreshQuery'
-        })
+        cy.intercept(
+          'POST',
+          `/api/v2/query?${new URLSearchParams({orgID})}`,
+          req => {
+            req.alias = 'refreshQuery'
+          }
+        )
 
         cy.getByTestID('refresh-form-activate-button').click()
 
@@ -163,7 +175,7 @@ describe('Dashboard refresh', () => {
       })
     })
     it('can timeout on a preset inactivity timeout', done => {
-      cy.get<Organization>('@org').then((org: Organization) => {
+      cy.get<Organization>('@org').then(({id: orgID}: Organization) => {
         cy.getByTestID('enable-auto-refresh-button').contains(
           'SET AUTO REFRESH',
           {matchCase: false}
@@ -181,9 +193,13 @@ describe('Dashboard refresh', () => {
             .type(`${jumpAheadTime('00:00:08')}`, {force: true})
           cy.getByTestID('daterange--apply-btn').click()
         })
-        cy.intercept('POST', `/api/v2/query?orgID=${org.id}`, req => {
-          req.alias = 'refreshQuery'
-        })
+        cy.intercept(
+          'POST',
+          `/api/v2/query?${new URLSearchParams({orgID})}`,
+          req => {
+            req.alias = 'refreshQuery'
+          }
+        )
 
         cy.getByTestID('refresh-form-activate-button').click()
 
@@ -270,16 +286,24 @@ describe('Dashboard refresh', () => {
         cy.getByTestID('flux-editor').monacoType(query2)
         cy.getByTestID('save-cell--button').click()
 
-        cy.intercept('POST', `/api/v2/query?orgID=${orgID}`, req => {
-          if (req.body.query === query1) {
-            req.alias = 'firstCellQuery'
+        cy.intercept(
+          'POST',
+          `/api/v2/query?${new URLSearchParams({orgID})}`,
+          req => {
+            if (req.body.query === query1) {
+              req.alias = 'firstCellQuery'
+            }
           }
-        })
-        cy.intercept('POST', `/api/v2/query?orgID=${orgID}`, req => {
-          if (req.body.query === query2) {
-            req.alias = 'secondCellQuery'
+        )
+        cy.intercept(
+          'POST',
+          `/api/v2/query?${new URLSearchParams({orgID})}`,
+          req => {
+            if (req.body.query === query2) {
+              req.alias = 'secondCellQuery'
+            }
           }
-        })
+        )
         cy.getByTestID('cell blah').within(() => {
           cy.getByTestID('giraffe-inner-plot')
           cy.getByTestID('cell-context--toggle').last().click()
@@ -353,15 +377,19 @@ describe('Dashboard refresh', () => {
         cy.getByTestID('flux-editor').monacoType(query2)
         cy.getByTestID('save-cell--button').click()
 
-        cy.intercept('POST', `/api/v2/query?orgID=${orgID}`, req => {
-          if (req.body.query === query1) {
-            // This will only fire when the first cell is unpaused AND it then gets refreshed as part of auto refresh loop, indicating successful operation
-            done()
+        cy.intercept(
+          'POST',
+          `/api/v2/query?${new URLSearchParams({orgID})}`,
+          req => {
+            if (req.body.query === query1) {
+              // This will only fire when the first cell is unpaused AND it then gets refreshed as part of auto refresh loop, indicating successful operation
+              done()
+            }
+            if (req.body.query === query2) {
+              req.alias = 'secondCellQuery'
+            }
           }
-          if (req.body.query === query2) {
-            req.alias = 'secondCellQuery'
-          }
-        })
+        )
         cy.getByTestID('cell blah').within(() => {
           cy.getByTestID('giraffe-inner-plot')
           cy.getByTestID('cell-context--toggle').last().click()
@@ -441,14 +469,18 @@ describe('Dashboard refresh', () => {
           cy.getByTestID('giraffe-inner-plot')
         })
 
-        cy.intercept('POST', `/api/v2/query?orgID=${orgID}`, req => {
-          if (req.body.query === query1) {
-            req.alias = 'refreshCellQuery'
+        cy.intercept(
+          'POST',
+          `/api/v2/query?${new URLSearchParams({orgID})}`,
+          req => {
+            if (req.body.query === query1) {
+              req.alias = 'refreshCellQuery'
+            }
+            if (req.body.query === query2) {
+              throw new Error('Refreshed the wrong cell')
+            }
           }
-          if (req.body.query === query2) {
-            throw new Error('Refreshed the wrong cell')
-          }
-        })
+        )
         cy.getByTestID('cell blah').within(() => {
           cy.getByTestID('giraffe-inner-plot')
           cy.getByTestID('cell-context--toggle').last().click()
@@ -516,14 +548,18 @@ describe('Dashboard refresh', () => {
           cy.getByTestID('giraffe-inner-plot')
         })
 
-        cy.intercept('POST', `/api/v2/query?orgID=${orgID}`, req => {
-          if (req.body.query === query1) {
-            req.alias = 'refreshCellQuery'
+        cy.intercept(
+          'POST',
+          `/api/v2/query?${new URLSearchParams({orgID})}`,
+          req => {
+            if (req.body.query === query1) {
+              req.alias = 'refreshCellQuery'
+            }
+            if (req.body.query === query2) {
+              req.alias = 'refreshSecondQuery'
+            }
           }
-          if (req.body.query === query2) {
-            req.alias = 'refreshSecondQuery'
-          }
-        })
+        )
 
         cy.getByTestID('autorefresh-dropdown-refresh').click()
         cy.wait('@refreshCellQuery')

--- a/cypress/e2e/shared/editor.test.ts
+++ b/cypress/e2e/shared/editor.test.ts
@@ -1,5 +1,8 @@
 import {Organization} from '../../../src/types'
 
+const DEFAULT_FLUX_EDITOR_TEXT =
+  '// Start by selecting data from the schema browser or typing flux here'
+
 // to see list of monaco-editor widgets to check:
 // document.querySelectorAll('[widgetid]')
 
@@ -96,12 +99,33 @@ describe('Editor+LSP communication', () => {
   })
 
   describe('in Script Editor', () => {
+    const setScriptToFlux = () => {
+      return cy.isIoxOrg().then(isIox => {
+        if (isIox) {
+          cy.getByTestID('query-builder--new-script')
+            .should('be.visible')
+            .click()
+          cy.getByTestID('script-dropdown__flux').should('be.visible').click()
+          cy.getByTestID('overlay--container').within(() => {
+            cy.getByTestID('flux-query-builder--no-save').click({force: true})
+          })
+        }
+        return cy.getByTestID('flux-editor').within(() => {
+          cy.get('textarea.inputarea').should(
+            'have.value',
+            DEFAULT_FLUX_EDITOR_TEXT
+          )
+        })
+      })
+    }
+
     before(() => {
       cy.flush()
       cy.signin()
       cy.setFeatureFlags({
         newDataExplorer: true,
         schemaComposition: false,
+        saveAsScript: true,
       })
       cy.get('@org').then(({id}: Organization) => {
         cy.visit(`/orgs/${id}/data-explorer`)
@@ -114,6 +138,7 @@ describe('Editor+LSP communication', () => {
             $toggle.click()
             cy.getByTestID('flux-query-builder--menu').contains('New Script')
           }
+          return setScriptToFlux()
         })
       })
     })

--- a/cypress/e2e/shared/editor.test.ts
+++ b/cypress/e2e/shared/editor.test.ts
@@ -107,7 +107,9 @@ describe('Editor+LSP communication', () => {
             .click()
           cy.getByTestID('script-dropdown__flux').should('be.visible').click()
           cy.getByTestID('overlay--container').within(() => {
-            cy.getByTestID('flux-query-builder--no-save').click({force: true})
+            cy.getByTestID('flux-query-builder--no-save')
+              .should('be.visible')
+              .click()
           })
         }
         return cy.getByTestID('flux-editor').within(() => {

--- a/cypress/e2e/shared/explorer.queries.graphs.test.ts
+++ b/cypress/e2e/shared/explorer.queries.graphs.test.ts
@@ -169,6 +169,13 @@ describe('writing queries and making graphs using Data Explorer', () => {
     })
 
     it('shows the empty state when the query returns no results', () => {
+      cy.isIoxOrg().then(isIox => {
+        // iox uses `${orgId}_${bucketId}` for a namespace_id
+        // And gives a namespace_id failure if no data is written yet.
+        // https://github.com/influxdata/monitor-ci/issues/402#issuecomment-1362368473
+        cy.skipOn(isIox)
+      })
+
       cy.getByTestID('time-machine--bottom').within(() => {
         cy.getByTestID('flux-editor').should('be.visible')
           .monacoType(`from(bucket: "defbuck")

--- a/cypress/e2e/shared/scriptQueryBuilder.results.test.ts
+++ b/cypress/e2e/shared/scriptQueryBuilder.results.test.ts
@@ -279,6 +279,13 @@ describe('Script Builder', () => {
       })
 
       it('will return 0 tables and 0 rows, for an empty dataset', () => {
+        cy.isIoxOrg().then(isIox => {
+          // iox uses `${orgId}_${bucketId}` for a namespace_id
+          // And gives a namespace_id failure if no data is written yet.
+          // https://github.com/influxdata/monitor-ci/issues/402#issuecomment-1362368473
+          cy.skipOn(isIox)
+        })
+
         cy.log('turn off composition sync')
         cy.getByTestID('flux-sync--toggle').click()
         cy.getByTestID('flux-sync--toggle').should('not.have.class', 'active')

--- a/cypress/e2e/shared/scriptQueryBuilder.results.test.ts
+++ b/cypress/e2e/shared/scriptQueryBuilder.results.test.ts
@@ -202,7 +202,6 @@ describe('Script Builder', () => {
 
     describe('data completeness', () => {
       const downloadsDirectory = Cypress.config('downloadsFolder')
-      const browser = Cypress.config('browser')
 
       const validateCsv = (csv: string, tableCnt: number) => {
         cy.wrap(csv)
@@ -250,12 +249,6 @@ describe('Script Builder', () => {
         cy.intercept('POST', '/api/v2/query?*', req => {
           req.redirect(route)
         }).as('queryDownloadCSV')
-
-        // TODO: debug intermittent failures which occur 30% of the time
-        // in firefox only, in the CI only, and only when no data is returned
-        if (browser.name.toLowerCase() != 'chrome') {
-          return
-        }
 
         cy.getByTestID('csv-download-button').should('not.be.disabled').click()
 

--- a/cypress/e2e/shared/scriptQueryBuilder.results.test.ts
+++ b/cypress/e2e/shared/scriptQueryBuilder.results.test.ts
@@ -16,19 +16,16 @@ describe('Script Builder', () => {
     writeData.push(`ndbc,air_temp_degc=70_degrees station_id_${i}=${i}`)
     writeData.push(`ndbc2,air_temp_degc=70_degrees station_id_${i}=${i}`)
   }
-  const writeDataMoar: string[] = []
-  for (let i = 0; i < 500; i++) {
-    writeDataMoar.push(
+  const writeDataMoar: Array<string[]> = [[], [], [], []]
+  const numOfUniqueColumns = 198 // 200 - 2
+  for (let i = 0; i < numOfUniqueColumns; i++) {
+    writeDataMoar[0]?.push(
       `ndbc_big,air_temp_degc=70_degrees station_id_A${i}=${i}`
     )
-    writeDataMoar.push(
-      `ndbc_big,air_temp_degc=70_degrees station_id_B${i}=${i}`
-    )
-    writeDataMoar.push(
-      `ndbc_big,air_temp_degc=70_degrees station_id_C${i}=${i}`
-    )
-    writeDataMoar.push(
-      `ndbc_big,air_temp_degc=70_degrees station_id_C${i}=${i + 500}`
+    writeDataMoar[1]?.push(
+      `ndbc_big,air_temp_degc=70_degrees station_id_A${i}=${
+        i + numOfUniqueColumns
+      }`
     )
   }
 
@@ -344,7 +341,7 @@ describe('Script Builder', () => {
             `|> filter(fn: (r) => r._measurement == "ndbc_big")`
           )
 
-          runTest(3 * 500, 4 * 500, true)
+          runTest(numOfUniqueColumns, 2 * numOfUniqueColumns, true)
         })
       })
     })

--- a/cypress/e2e/shared/scriptQueryBuilder.results.test.ts
+++ b/cypress/e2e/shared/scriptQueryBuilder.results.test.ts
@@ -157,22 +157,26 @@ describe('Script Builder', () => {
         schemaComposition: true,
         newDataExplorer: true,
       }).then(() => {
-        cy.get('@org').then(({id}: Organization) => {
-          route = `/orgs/${id}/data-explorer`
-          cy.intercept('POST', `/api/v2/query?orgID=${id}`, req => {
-            const {extern} = req.body
-            if (
-              extern?.body[0]?.location?.source ==
-              `option v =  {  timeRangeStart: -1h,\n  timeRangeStop: now()}`
-            ) {
-              req.alias = 'query -1h'
-            } else if (
-              extern?.body[0]?.location?.source ==
-              `option v =  {  timeRangeStart: -15m,\n  timeRangeStop: now()}`
-            ) {
-              req.alias = 'query -15m'
+        cy.get('@org').then(({id: orgID}: Organization) => {
+          route = `/orgs/${orgID}/data-explorer`
+          cy.intercept(
+            'POST',
+            `/api/v2/query?${new URLSearchParams({orgID})}`,
+            req => {
+              const {extern} = req.body
+              if (
+                extern?.body[0]?.location?.source ==
+                `option v =  {  timeRangeStart: -1h,\n  timeRangeStop: now()}`
+              ) {
+                req.alias = 'query -1h'
+              } else if (
+                extern?.body[0]?.location?.source ==
+                `option v =  {  timeRangeStart: -15m,\n  timeRangeStop: now()}`
+              ) {
+                req.alias = 'query -15m'
+              }
             }
-          })
+          )
         })
 
         clearSession()

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -988,14 +988,21 @@ export const writeLPDataFromFile = (
   })
 }
 
+// Longer SLA on finding all elements, will resolve slower load times with our CI remocal deployed with tsm & iox orgs.
+const LOAD_SLA = 30000
+
 // DOM node getters
 export const getByTestID = (
   dataTest: string,
-  options?: Partial<
+  requestedOptions?: Partial<
     Cypress.Loggable & Cypress.Timeoutable & Cypress.Withinable & Cypress.Shadow
   >
 ): Cypress.Chainable => {
-  return cy.get(`[data-testid="${dataTest}"]`, options)
+  const options = requestedOptions ?? {}
+  return cy.get(`[data-testid="${dataTest}"]`, {
+    ...options,
+    ...{timeout: Math.max(LOAD_SLA, options.timeout ?? 0)},
+  })
 }
 
 export const getByTestIDHead = (

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -226,6 +226,14 @@ export const wrapDefaultPassword = (): Cypress.Chainable => {
   return cy.wrap(password).as('defaultPassword')
 }
 
+export const isIoxOrg = (): Cypress.Chainable<Cypress.Response<any>> => {
+  return cy.get('@org').then(({defaultStorageType}: Organization) => {
+    return Boolean(
+      defaultStorageType && defaultStorageType.toLowerCase() === 'iox'
+    )
+  })
+}
+
 export const createDashboard = (
   orgID?: string,
   name: string = 'test dashboard'
@@ -1304,6 +1312,7 @@ Cypress.Commands.add(
   'wrapEnvironmentVariablesForOss',
   wrapEnvironmentVariablesForOss
 )
+Cypress.Commands.add('isIoxOrg', isIoxOrg)
 
 // navigation bar
 Cypress.Commands.add('clickNavBarItem', clickNavBarItem)

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -882,7 +882,11 @@ export const writeData = (
       const bucketToUse = namedBucket ?? bucket.name
       return cy.request({
         method: 'POST',
-        url: '/api/v2/write?org=' + org.name + '&bucket=' + bucketToUse,
+        url:
+          '/api/v2/write?' +
+          new URLSearchParams({orgID: org.id}) +
+          '&bucket=' +
+          bucketToUse,
         body: lines.join('\n'),
       })
     })

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -29,9 +29,8 @@ Cypress.on('uncaught:exception', (err, _) => {
   )
 })
 
-export const signin = (
-  useIox: boolean = false
-): Cypress.Chainable<Cypress.Response<any>> => {
+export const signin = (): Cypress.Chainable<Cypress.Response<any>> => {
+  const useIox = Boolean(Cypress.env('ioxUser'))
   return cy.setupUser(useIox).then((response: any) => {
     wrapDefaultUser()
       .then(() => wrapDefaultPassword())

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -18,6 +18,7 @@ import './commands'
 
 import 'cypress-pipe'
 import 'cypress-plugin-tab'
+import '@cypress/skip-test/support'
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@babel/plugin-transform-runtime": "^7.19.6",
     "@babel/preset-env": "^7.20.2",
     "@babel/runtime": "^7.20.6",
+    "@cypress/skip-test": "^2.6.1",
     "@influxdata/oats": "0.5.3",
     "@testing-library/dom": "^8.17.1",
     "@testing-library/jest-dom": "^5.16.5",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test:e2e:all": "yarn test:e2e:clean && yarn test:e2e; yarn test:e2e:report;",
     "test:e2e:kind": "CYPRESS_dexUrl=http://dex-twodotoh.a.influxcloud.dev.local CYPRESS_baseUrl=https://twodotoh.a.influxcloud.dev.local CYPRESS_password=password cypress open --browser chrome --config chromeWebSecurity=false",
     "test:e2e:remocal": "CYPRESS_dexUrl=https://dex-${NS}.remocal.influxdev.co CYPRESS_baseUrl=https://${NS}.remocal.influxdev.co CYPRESS_password=password cypress open --browser chrome --config chromeWebSecurity=false",
+    "test:e2e:remocal:iox": "CYPRESS_ioxUser=true yarn test:e2e:remocal",
     "test:circleci": "yarn run test:ci --runInBand",
     "test:ci": "JEST_JUNIT_OUTPUT_DIR=\"./coverage\" jest --ci --coverage",
     "lint": "yarn tsc && yarn prettier && yarn eslint",

--- a/src/dataExplorer/components/FluxQueryBuilder.tsx
+++ b/src/dataExplorer/components/FluxQueryBuilder.tsx
@@ -142,6 +142,7 @@ const FluxQueryBuilder: FC = () => {
                             key={option}
                             onClick={() => handleSelectDropdown(option)}
                             selected={resource?.language === option}
+                            testID={`script-dropdown__${option}`}
                           >
                             {option}
                           </Dropdown.Item>
@@ -149,7 +150,11 @@ const FluxQueryBuilder: FC = () => {
                       </Dropdown.Menu>
                     )}
                     button={(active, onClick) => (
-                      <Dropdown.Button active={active} onClick={onClick}>
+                      <Dropdown.Button
+                        active={active}
+                        onClick={onClick}
+                        testID="query-builder--new-script"
+                      >
                         <>
                           <Icon glyph={IconFont.Plus_New} />
                           &nbsp;New Script

--- a/src/shared/contexts/buckets.tsx
+++ b/src/shared/contexts/buckets.tsx
@@ -124,9 +124,9 @@ export const BucketProvider: FC<Props> = ({
     }
 
     fetch(
-      `${scope?.region}/api/v2/buckets?limit=${CLOUD ? -1 : 100}&orgID=${
-        scope?.org
-      }`,
+      `${scope?.region}/api/v2/buckets?limit=${
+        CLOUD ? -1 : 100
+      }&${new URLSearchParams({orgID: scope?.org})}`,
       {
         method: 'GET',
         headers,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1432,6 +1432,11 @@
     tunnel-agent "^0.6.0"
     uuid "^8.3.2"
 
+"@cypress/skip-test@^2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@cypress/skip-test/-/skip-test-2.6.1.tgz#44a4bc4c2b2e369a7661177c9b38e50d417a36ea"
+  integrity sha512-X+ibefBiuOmC5gKG91wRIT0/OqXeETYvu7zXktjZ3yLeO186Y8ia0K7/gQUpAwuUi28DuqMd1+7tBQVtPkzbPA==
+
 "@cypress/xvfb@^1.2.4":
   version "1.2.4"
   resolved "https://registry.npmjs.org/@cypress/xvfb/-/xvfb-1.2.4.tgz"


### PR DESCRIPTION
Part of https://github.com/influxdata/monitor-ci/issues/402

## BEFORE MERGE
~Revert the 1st commit, so we point to monitor-ci master branch.~ DONE. Reverted.
Then the remocal-iox e2es will only run (on merge queue) once the other 2 PRs in k8s-idpe and monitor-ci are merged.


## Done:
**Basic upgrade to fixtures:**
* handle conditional testing scenarios, based on "if iox":
   * new command `cy.isIoxOrg()`
      * should be used in cypress chainable, such as `return cy.isIoxOrg().then(isIox => { //do stuff })`
   * new test support via `@cypress/skip-test`
      * main commands are `cy.skipOn(boolean)` and `cy.onlyOn(boolean)` 
* be able to run your iox e2es locally.
   * `test:e2e:remocal:iox` 

**Specific modification in tests, in order to handle iox:**
* handle remocal-iox setup nuances:
    * orgIDs which need to be escaped (e.g. the CI remocal-iox org)
    * Handle slightly longer page loads (& maybe network too?) when using remocal deployed with iox & tsm backends.
         * Add a longer `timeout: LOAD_SLA` as the default when using cy.getByTestID().
         * Note: this is **NOT** related to TTBR on data, nor other cluster setup delays.
             * tested/confirmed by extending that period to 10 minutes. 
* handle iox temporary limitations:
    * iox has a limit of 200 unique fields per write
         * update fluxQueryBuilder test fixture to match limit.   
   * iox read queries fail [when no data is written yet](https://github.com/influxdata/monitor-ci/issues/402#issuecomment-1362368473). 
        * temporarily skip tests (on iox only) for these use cases:
           * Results table expects 0 tables and 0 rows.
           * _monitoring bucket is empty, because the created check has not been triggered yet.
           * Data explorer queries were no data is in the bucket yet.
    * iox currently has no explicit schemas
        * skip tests for now.

 
## Checklist
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
