### PR TITLE
fix: keep flux in sync when select a new measurement with existing fields and tag values selection

### DIFF
--- a/src/languageSupport/languages/flux/lsp/connection.ts
+++ b/src/languageSupport/languages/flux/lsp/connection.ts
@@ -397,7 +397,7 @@ export class ConnectionManager {
         if (shouldRemoveDefaultMsg) {
           this._removeDefaultAndUpdateLsp(() => this._initLspComposition(toAdd))
         } else {
-          this._initLspComposition(toAdd)
+          this._updateLsp(toAdd, toRemove)
         }
         break
       case 'false|false|true':

--- a/src/languageSupport/languages/flux/lsp/connection.ts
+++ b/src/languageSupport/languages/flux/lsp/connection.ts
@@ -393,11 +393,17 @@ export class ConnectionManager {
         this._first_load = false
         break
       case 'false|true|true':
-        // re-sync just turned on.
+        // 1) re-sync just turned on or
+        // 2) measurement selection is changed when fields
+        //    and/or tag values were previously selected
+        if (!toAdd.bucket) {
+          // bucket is needed for initialization
+          toAdd.bucket = schema.bucket
+        }
         if (shouldRemoveDefaultMsg) {
           this._removeDefaultAndUpdateLsp(() => this._initLspComposition(toAdd))
         } else {
-          this._updateLsp(toAdd, toRemove)
+          this._initLspComposition(toAdd)
         }
         break
       case 'false|false|true':


### PR DESCRIPTION
Closes #6429 

This PR fixes a bug in flux composition that upon a new measurement selection on an existing flux composition, the LSP went out of sync with the UI. 

## Before

https://user-images.githubusercontent.com/14298407/210408168-83e08512-acdc-4871-a90a-e83a33ebfc28.mov


## After

https://user-images.githubusercontent.com/14298407/210430599-63b18454-2fef-4aad-bac8-a6e29bf9d7ed.mov




### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
