### PR TITLE
chore: add deeplink for multiorg phase 2

### DIFF
--- a/cypress/e2e/cloud/deepLinks.test.ts
+++ b/cypress/e2e/cloud/deepLinks.test.ts
@@ -1,9 +1,24 @@
 import {Organization} from '../../../src/types'
+import {makeQuartzUseIDPEOrgID} from 'cypress/support/Utils'
+
+let idpeOrgID: string
 
 describe('Deep linking', () => {
   beforeEach(() => {
     cy.flush()
     cy.signin()
+    cy.setFeatureFlags({createDeleteOrgs: true})
+    cy.request({
+      method: 'GET',
+      url: 'api/v2/orgs',
+    }).then(res => {
+      // Store the IDPE org ID so that it can be cloned when intercepting quartz.
+      if (res.body.orgs) {
+        idpeOrgID = res.body.orgs[0].id
+      }
+
+      makeQuartzUseIDPEOrgID(idpeOrgID)
+    })
   })
 
   // If you're here and the test failure you're looking at is legitimate, it probably means a page
@@ -71,6 +86,9 @@ describe('Deep linking', () => {
 
       cy.visit('/me/notebooks')
       cy.location('pathname').should('eq', `/orgs/${org.id}/notebooks`)
+
+      cy.visit('/me/orglist')
+      cy.location('pathname').should('eq', `/orgs/${org.id}/accounts/orglist`)
 
       cy.visit('/me/profile')
       cy.location('pathname').should('eq', `/orgs/${org.id}/user/profile`)

--- a/src/utils/deepLinks.ts
+++ b/src/utils/deepLinks.ts
@@ -19,6 +19,7 @@ export const buildDeepLinkingMap = (orgId: string) => ({
   '/me/nodejsclient': `/orgs/${orgId}/load-data/client-libraries/javascript-node`,
   [`/me/${PROJECT_NAME_PLURAL.toLowerCase()}`]: `/orgs/${orgId}/${PROJECT_NAME_PLURAL.toLowerCase()}`,
   '/me/notebooks': `/orgs/${orgId}/${PROJECT_NAME_PLURAL.toLowerCase()}`,
+  '/me/orglist': `/orgs/${orgId}/accounts/orglist`,
   '/me/profile': `/orgs/${orgId}/user/profile`,
   '/me/pythonclient': `/orgs/${orgId}/load-data/client-libraries/python`,
   '/me/secrets': `/orgs/${orgId}/settings/secrets`,


### PR DESCRIPTION
Closes #5244 

Multiorg phase 2 added an "organization list" tab to the Accounts page so that users can browse the statuses of all organizations in the current account. This adds a deeplink to that page.

This also adds an intercept to ensure the link actually works properly - since e2e tests run against the mock, we need to intercept the real IDPE org ID and make the mock use that ID.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - `createDeleteOrgs`
