### PR TITLE
chore: remove `getOrgIDFromBuckets`

### DIFF
--- a/src/shared/components/TimeSeries.tsx
+++ b/src/shared/components/TimeSeries.tsx
@@ -205,6 +205,7 @@ class TimeSeries extends Component<Props, State> {
       variables,
     } = this.props
     const queries = this.props.queries.filter(({text}) => !!text.trim())
+    const orgID = this.props.match.params.orgID
 
     if (!queries.length) {
       this.setState(defaultState())
@@ -239,8 +240,6 @@ class TimeSeries extends Component<Props, State> {
 
       // Issue new queries
       this.pendingResults = queries.map(({text}) => {
-        const orgID = this.props.match.params.orgID
-
         const windowVars = getWindowVarsFromVariables(text, variables)
         const extern = buildUsedVarsOption(text, variables, windowVars)
 

--- a/src/shared/components/TimeSeries.tsx
+++ b/src/shared/components/TimeSeries.tsx
@@ -20,7 +20,6 @@ import {getRangeVariable} from 'src/variables/utils/getTimeRangeVars'
 import {getWindowVarsFromVariables} from 'src/variables/utils/getWindowVars'
 import {buildUsedVarsOption} from 'src/variables/utils/buildVarsOption'
 import 'intersection-observer'
-import {getOrgIDFromBuckets} from 'src/timeMachine/actions/queries'
 import {hashCode} from 'src/shared/apis/queryCache'
 import {RunQueryPromiseMutex} from 'src/shared/apis/singleQuery'
 import {parseASTIM} from 'src/variables/utils/astim'
@@ -199,7 +198,6 @@ class TimeSeries extends Component<Props, State> {
 
   private reload = async () => {
     const {
-      buckets,
       check,
       isCurrentPageDashboard,
       notify,
@@ -241,8 +239,7 @@ class TimeSeries extends Component<Props, State> {
 
       // Issue new queries
       this.pendingResults = queries.map(({text}) => {
-        const orgID =
-          getOrgIDFromBuckets(text, buckets) || this.props.match.params.orgID
+        const orgID = this.props.match.params.orgID
 
         const windowVars = getWindowVarsFromVariables(text, variables)
         const extern = buildUsedVarsOption(text, variables, windowVars)

--- a/src/timeMachine/actions/queries.ts
+++ b/src/timeMachine/actions/queries.ts
@@ -262,9 +262,6 @@ export const runTimeMachineQuery = (
   event('executeQueries query', {}, {query: queryText})
 
   const orgID = getOrg(state).id
-  if (getOrg(state).id === orgID) {
-    event('orgData_queried')
-  }
 
   const extern = buildUsedVarsOption(queryText, allVariables)
   event('runQuery', {context: 'timeMachine'})
@@ -375,9 +372,6 @@ export const runDownloadQuery = () => async (dispatch, getState: GetState) => {
     event('executeQueries query', {}, {query: queryText})
 
     const orgID = getOrg(state).id
-    if (getOrg(state).id === orgID) {
-      event('orgData_queried')
-    }
 
     const extern = buildUsedVarsOption(queryText, allVariables)
     const url = `${API_BASE_PATH}api/v2/query?${new URLSearchParams({orgID})}`

--- a/src/timeMachine/actions/queries.ts
+++ b/src/timeMachine/actions/queries.ts
@@ -277,6 +277,7 @@ export const executeQueries =
     const executeQueriesStartTime = Date.now()
 
     const state = getState()
+    const orgID = getOrg(state).id
 
     const activeTimeMachine = getActiveTimeMachine(state)
     const queries = activeTimeMachine.view.properties.queries.filter(
@@ -300,8 +301,6 @@ export const executeQueries =
       const startDate = Date.now()
 
       const pendingResults = queries.map(({text}) => {
-        const orgID = getOrg(state).id
-
         const queryID = generateHashedQueryID(text, allVariables, orgID)
         if (isCurrentPageDashboard(state)) {
           // reset any existing matching query in the cache


### PR DESCRIPTION
Closes #6363 

This PR removes the legacy function `getOrgIDFromBuckets`. See the original issue for the reason. 

This PR also removes one of the `parse()` item related to #6447 

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
