### PR TITLE
chore: refresh org creation allowance after free-checkout

### DIFF
--- a/src/checkout/context/checkout.tsx
+++ b/src/checkout/context/checkout.tsx
@@ -28,11 +28,15 @@ import {getErrorMessage} from 'src/utils/api'
 import {event} from 'src/cloud/utils/reporting'
 
 // Thunks
+import {getOrgCreationAllowancesThunk} from 'src/identity/allowances/actions/thunks'
 import {getQuartzIdentityThunk} from 'src/identity/actions/thunks'
 
 // Selectors
 import {selectCurrentIdentity} from 'src/identity/selectors'
 import {shouldGetCredit250Experience} from 'src/me/selectors'
+
+// Utils
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 export type Props = {
   children: JSX.Element
@@ -311,6 +315,10 @@ export const CheckoutProvider: FC<Props> = React.memo(({children}) => {
         dispatch(notify(submitError()))
       } finally {
         setIsSubmitting(false)
+        // Refresh whether user is allowed to create new orgs after upgrading to PAYG.
+        if (isFlagEnabled('createDeleteOrgs')) {
+          dispatch(getOrgCreationAllowancesThunk())
+        }
       }
     },
     [


### PR DESCRIPTION
Closes #6457 

Calls the thunk for refreshing the organization creation allowance after a user checks out. 

When checking out from free to PAYG, the user's org creation allowance must be updated so that they are immediately able to create additional orgs, up to the PAYG default (3), and increase from the Free default (1).

This is feature flagged because the organization creation allowance is not used unless the `createDeleteOrgs` FF is on.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - `createDeleteOrgs`
