### PR TITLE
feat: 'remove users first' block on deleting orgs in payg/contract accounts

### DIFF
--- a/cypress/e2e/cloud/about.test.ts
+++ b/cypress/e2e/cloud/about.test.ts
@@ -162,6 +162,14 @@ const displayRemoveUsersWarning = () => {
   cy.url().should('include', `/members`)
 }
 
+const displayOtherUsersWarning = () => {
+  cy.getByTestID('delete-org--button').should('be.visible').click()
+  cy.get('.org-delete-overlay--warning-message').within(() => {
+    cy.contains('a', 'users in this organization').click()
+    cy.url().should('include', `/members`)
+  })
+}
+
 const upgradeAccount = () => {
   cy.getByTestID('delete-org--button').should('be.visible').click()
   cy.getByTestID('popover--dialog')
@@ -252,7 +260,7 @@ describe('PAYG Account', () => {
     createOrg('pay_as_you_go')
   })
 
-  it('displays the `remove other users` popup if there are other orgs in the account, but the current org has other users in it', () => {
+  it('when deleting an org with multiple users in a multi-org payg account, delete org overlay shows how many other users the org has and clicking it takes user to /members page', () => {
     setupTest({
       accountType: 'pay_as_you_go',
       canCreateOrgs: false,
@@ -260,7 +268,7 @@ describe('PAYG Account', () => {
       orgIsSuspendable: true,
     })
 
-    displayRemoveUsersWarning()
+    displayOtherUsersWarning()
   })
 
   it('allows the user to delete an org if there are other orgs in the account, and they are the only user in the current org', () => {
@@ -298,7 +306,7 @@ describe('Contract Account', () => {
     createOrg('contract')
   })
 
-  it('displays the `remove other users` popup if there are other orgs in the account, but the current org has other users in it', () => {
+  it('when deleting an org with multiple users in a multi-org contract account, delete org overlay shows how many other users the org has and clicking it takes user to /members page ', () => {
     setupTest({
       accountType: 'contract',
       canCreateOrgs: false,
@@ -306,7 +314,7 @@ describe('Contract Account', () => {
       orgIsSuspendable: true,
     })
 
-    displayRemoveUsersWarning()
+    displayOtherUsersWarning()
   })
 
   it('allows the user to delete an org if there are other orgs in the account, and they are the only user in the current org', () => {

--- a/src/organizations/components/OrgProfileTab/DeletePanel.tsx
+++ b/src/organizations/components/OrgProfileTab/DeletePanel.tsx
@@ -11,7 +11,6 @@ import {
   PopoverInteraction,
   PopoverPosition,
 } from '@influxdata/clockface'
-import {OrgUsersLink} from 'src/shared/components/notifications/NotificationButtons'
 import PageSpinner from 'src/perf/components/PageSpinner'
 
 // Contexts
@@ -25,17 +24,10 @@ import {
   selectOrgSuspendable,
 } from 'src/identity/selectors'
 
-// Notifications
-import {deleteOrgWarning} from 'src/shared/copy/notifications'
-import {notify} from 'src/shared/actions/notifications'
-
 // Constants
 import {CLOUD} from 'src/shared/constants'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {dismissOverlay, showOverlay} from 'src/overlays/actions/overlays'
-
-// Types
-import {NotificationButtonElement} from 'src/types'
 
 // Styles
 import 'src/organizations/components/OrgProfileTab/style.scss'
@@ -84,21 +76,13 @@ const DeleteOrgButton: FC = () => {
     hidePopup()
   }
 
-  const shouldShowUsersWarning = users.length > 1
-
   const handleSuspendOrg = () => {
     if (orgCanBeSuspended) {
-      if (shouldShowUsersWarning) {
-        const buttonElement: NotificationButtonElement = onDismiss =>
-          OrgUsersLink(`/orgs/${org.id}/members`, onDismiss)
-        dispatch(notify(deleteOrgWarning(buttonElement)))
-      } else {
-        dispatch(
-          showOverlay('suspend-org-in-paid-account', null, () =>
-            dispatch(dismissOverlay())
-          )
+      dispatch(
+        showOverlay('suspend-org-in-paid-account', {users: users.length}, () =>
+          dispatch(dismissOverlay())
         )
-      }
+      )
     }
   }
 

--- a/src/organizations/components/OrgProfileTab/DeletePanel.tsx
+++ b/src/organizations/components/OrgProfileTab/DeletePanel.tsx
@@ -20,6 +20,7 @@ import {UsersContext} from 'src/users/context/users'
 // Selectors
 import {getOrg} from 'src/organizations/selectors'
 import {
+  selectCurrentAccount,
   selectCurrentIdentity,
   selectOrgCreationAllowance,
   selectOrgSuspendable,
@@ -65,7 +66,7 @@ const DeleteOrgButton: FC = () => {
   const orgCanBeSuspended = useSelector(selectOrgSuspendable)
   const canCreateOrgs = useSelector(selectOrgCreationAllowance)
   const {users} = useContext(UsersContext)
-  const {account} = useSelector(selectCurrentIdentity)
+  const account = useSelector(selectCurrentAccount)
 
   const popoverRef = useRef()
 
@@ -86,11 +87,11 @@ const DeleteOrgButton: FC = () => {
   }
 
   // only show warning for free accounts with multiple users
-  const shouldShowUsersWarning = account.type === 'free' && users.length > 1
+  const freeAccountWithOtherUsers = account.type === 'free' && users.length > 1
 
   const handleSuspendOrg = () => {
     if (orgCanBeSuspended) {
-      if (shouldShowUsersWarning) {
+      if (freeAccountWithOtherUsers) {
         const buttonElement: NotificationButtonElement = onDismiss =>
           OrgUsersLink(`/orgs/${org.id}/members`, onDismiss)
         dispatch(notify(deleteOrgWarning(buttonElement)))
@@ -98,7 +99,7 @@ const DeleteOrgButton: FC = () => {
         dispatch(
           showOverlay(
             'suspend-org-in-paid-account',
-            {users: users.length},
+            {userCount: users.length || 0},
             () => dispatch(dismissOverlay())
           )
         )

--- a/src/organizations/components/OrgProfileTab/SuspendPaidOrgOverlay.tsx
+++ b/src/organizations/components/OrgProfileTab/SuspendPaidOrgOverlay.tsx
@@ -160,12 +160,12 @@ export const SuspendPaidOrgOverlay: FC = () => {
         >
           You will be able to recover this organization's data for up to 7 days
           by contacting support. It will be unrecoverable afterwards.
-          {params.users > 0 && (
+          {params.userCount > 1 && (
             <>
               <br />
               <br />
               <Link to={`/orgs/${org.id}/members`} onClick={onClickCancel}>
-                {params.users} users in this organization
+                {params.userCount} users in this organization
               </Link>{' '}
               will lose access to all organization data immediately.
             </>

--- a/src/organizations/components/OrgProfileTab/SuspendPaidOrgOverlay.tsx
+++ b/src/organizations/components/OrgProfileTab/SuspendPaidOrgOverlay.tsx
@@ -1,6 +1,8 @@
 // Libraries
 import React, {FC, useContext, useState} from 'react'
 import {useDispatch, useSelector} from 'react-redux'
+import {Link} from 'react-router-dom'
+
 import {
   Alert,
   AlignItems,
@@ -77,7 +79,7 @@ export const SuspendPaidOrgOverlay: FC = () => {
   const org = useSelector(selectCurrentOrg)
   const user = useSelector(selectUser)
   const dispatch = useDispatch()
-  const {onClose} = useContext(OverlayContext)
+  const {onClose, params} = useContext(OverlayContext)
 
   const [deleteButtonStatus, setDeleteButtonStatus] = useState(
     ComponentStatus.Disabled
@@ -142,7 +144,7 @@ export const SuspendPaidOrgOverlay: FC = () => {
   return (
     <Overlay.Container
       className="org-delete-overlay"
-      maxWidth={600}
+      maxWidth={750}
       testID="create-org-overlay--container"
     >
       <Overlay.Header
@@ -158,6 +160,12 @@ export const SuspendPaidOrgOverlay: FC = () => {
         >
           You will be able to recover this organization's data for up to 7 days
           by contacting support. It will be unrecoverable afterwards.
+          <br />
+          <br />
+          <Link to={`/orgs/${org.id}/members`} onClick={onClickCancel}>
+            {params.users} users in this organization
+          </Link>{' '}
+          will lose access to all organization data immediately.
         </Alert>
         <br />
         <ul>

--- a/src/organizations/components/OrgProfileTab/SuspendPaidOrgOverlay.tsx
+++ b/src/organizations/components/OrgProfileTab/SuspendPaidOrgOverlay.tsx
@@ -160,12 +160,16 @@ export const SuspendPaidOrgOverlay: FC = () => {
         >
           You will be able to recover this organization's data for up to 7 days
           by contacting support. It will be unrecoverable afterwards.
-          <br />
-          <br />
-          <Link to={`/orgs/${org.id}/members`} onClick={onClickCancel}>
-            {params.users} users in this organization
-          </Link>{' '}
-          will lose access to all organization data immediately.
+          {params.users > 0 && (
+            <>
+              <br />
+              <br />
+              <Link to={`/orgs/${org.id}/members`} onClick={onClickCancel}>
+                {params.users} users in this organization
+              </Link>{' '}
+              will lose access to all organization data immediately.
+            </>
+          )}
         </Alert>
         <br />
         <ul>


### PR DESCRIPTION
Closes #6450 

Currently in the UI, if a non free account user tries to delete an org with multiple users associated with it, the deletion process gets blocked by a notification warning user to remove other users first before deleting the org. 
Pr removes this block (notification) and instead display the delete org overlay that allows user to delete org. The number of users associated with the org will now be shown inside the overlay, and when clicked, user will be redirected to the members page as shown in the demo below. 

<img width="1392" alt="Screen Shot 2023-01-09 at 4 36 58 PM" src="https://user-images.githubusercontent.com/66275100/211422180-ebd2c74a-6180-4923-9171-368baf2221a7.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
