### PR TITLE
feat: add storage type to org profile page

### DIFF
--- a/cypress/e2e/cloud/about.test.ts
+++ b/cypress/e2e/cloud/about.test.ts
@@ -7,6 +7,17 @@ const deleteOrgsFeatureFlags = {
 // This variable stores the current IDPE orgid and syncs it with the quartz-mock orgid.
 let idpeOrgID: string
 
+type StorageTypes = 'iox' | 'tsm'
+
+const spoofStorageType = (storageType: StorageTypes) => {
+  cy.intercept('GET', 'api/v2/orgs', req => {
+    req.continue(res => {
+      res.body.orgs[0].defaultStorageType = storageType
+      res.send(res)
+    })
+  })
+}
+
 const getOrgCreationAllowance = (allowanceFixture: string) => {
   cy.intercept('GET', 'api/v2/quartz/allowances/orgs/create', {
     fixture: allowanceFixture,
@@ -202,6 +213,35 @@ const upgradeAccount = () => {
     .should('be.visible')
     .contains('Your account upgrade inquiry has been submitted.')
 }
+
+describe('Storage types', () => {
+  it('identifies the storage type as iox in an iox org', () => {
+    spoofStorageType('iox')
+    setupTest({
+      accountType: 'pay_as_you_go',
+      canCreateOrgs: true,
+      orgHasOtherUsers: false,
+    })
+
+    cy.getByTestID('org-profile--labeled-data').within(() => {
+      cy.getByTestID('heading').contains('Storage Type')
+      cy.contains('IOx')
+    })
+  })
+
+  it('identifies the storage type as tsm in a tsm org', () => {
+    spoofStorageType('tsm')
+    setupTest({
+      accountType: 'contract',
+      canCreateOrgs: false,
+      orgHasOtherUsers: true,
+    })
+    cy.getByTestID('org-profile--labeled-data').within(() => {
+      cy.getByTestID('heading').contains('Storage Type')
+      cy.contains('TSM')
+    })
+  })
+})
 
 describe('Free account', () => {
   it('displays a `must remove users` warning if trying to delete an org with multiple users in a multi-org free account', () => {

--- a/cypress/e2e/cloud/about.test.ts
+++ b/cypress/e2e/cloud/about.test.ts
@@ -1,4 +1,5 @@
 import {makeQuartzUseIDPEOrgID} from 'cypress/support/Utils'
+import {Organization} from 'src/client'
 
 const deleteOrgsFeatureFlags = {
   createDeleteOrgs: true,
@@ -7,9 +8,7 @@ const deleteOrgsFeatureFlags = {
 // This variable stores the current IDPE orgid and syncs it with the quartz-mock orgid.
 let idpeOrgID: string
 
-type StorageTypes = 'iox' | 'tsm'
-
-const spoofStorageType = (storageType: StorageTypes) => {
+const spoofStorageType = (storageType: Organization['defaultStorageType']) => {
   cy.intercept('GET', 'api/v2/orgs', req => {
     req.continue(res => {
       res.body.orgs[0].defaultStorageType = storageType

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "cy": "CYPRESS_dexUrl=https://$INGRESS_HOST:$PORT_HTTPS CYPRESS_baseUrl=http://localhost:9999 cypress open",
     "cy:dev": "source ../monitor-ci/.env && CYPRESS_dexUrl=CLOUD CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{cloud,shared}/**/*.*'",
     "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_dexUrl=OSS CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{oss,shared}/**/*.*'",
-    "generate": "export SHA=00a445641ae596ea69e9cb74fd774bf92b9a2175 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
+    "generate": "export SHA=19b89d0e168edb6a27f801c6161f89ead6600401 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-local-cloud": "export REMOTE=../openapi/ && yarn generate-meta-cloud",
     "generate-meta": "if [ -z \"${CLOUD_URL}\" ]; then yarn generate-meta-oss; else yarn generate-meta-cloud; fi",

--- a/src/organizations/components/OrgProfileTab/index.tsx
+++ b/src/organizations/components/OrgProfileTab/index.tsx
@@ -47,8 +47,9 @@ const OrgProfileTab: FC = () => {
   const org = useSelector(getOrg)
   const quartzOrg = useSelector(selectCurrentOrg)
   const storageType = org?.defaultStorageType
-  const dispatch = useDispatch()
   const {users} = useContext(UsersContext)
+
+  const dispatch = useDispatch()
 
   // Data about the user's organization is intentionally re-fetched when this component mounts again.
   const [orgDetailsStatus, setOrgDetailsStatus] = useState(
@@ -89,7 +90,7 @@ const OrgProfileTab: FC = () => {
     tsm: 'TSM',
   }
 
-  const capitalizedStorageType =
+  const formattedStorageType =
     storageTypeMap[storageType.toLowerCase()] || storageType
 
   const OrgProfile = () => (
@@ -118,7 +119,7 @@ const OrgProfileTab: FC = () => {
             <LabeledData label="Region" src={quartzOrg.regionCode} />
             <LabeledData label="Location" src={quartzOrg.regionName} />
             {hasFetchedStorageType && (
-              <LabeledData label="Storage Type" src={capitalizedStorageType} />
+              <LabeledData label="Storage Type" src={formattedStorageType} />
             )}
           </FlexBox>
           <CopyableLabeledData

--- a/src/organizations/components/OrgProfileTab/index.tsx
+++ b/src/organizations/components/OrgProfileTab/index.tsx
@@ -38,7 +38,6 @@ import {CLOUD} from 'src/shared/constants'
 
 // Utils
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
-import {isOrgIOx} from 'src/organizations/selectors'
 
 // Styles
 import 'src/organizations/components/OrgProfileTab/style.scss'
@@ -46,7 +45,6 @@ import 'src/organizations/components/OrgProfileTab/style.scss'
 const OrgProfileTab: FC = () => {
   const me = useSelector(getMe)
   const org = useSelector(getOrg)
-  const storageType = useSelector(isOrgIOx) ? 'IOx' : 'TSM'
   const quartzOrg = useSelector(selectCurrentOrg)
   const dispatch = useDispatch()
   const {users} = useContext(UsersContext)
@@ -83,6 +81,7 @@ const OrgProfileTab: FC = () => {
   const allowSelfRemoval = users.length > 1
   const showLeaveOrgButton = isFlagEnabled('createDeleteOrgs')
   const hasFetchedOrgDetails = orgDetailsStatus === RemoteDataState.Done
+  const hasFetchedStorageType = Boolean(org?.defaultStorageType)
 
   const OrgProfile = () => (
     <FlexBox.Child
@@ -109,7 +108,9 @@ const OrgProfileTab: FC = () => {
             <LabeledData label="Cloud Provider" src={quartzOrg.provider} />
             <LabeledData label="Region" src={quartzOrg.regionCode} />
             <LabeledData label="Location" src={quartzOrg.regionName} />
-            <LabeledData label="Storage Type" src={storageType} />
+            {hasFetchedStorageType && (
+              <LabeledData label="Storage Type" src={org.defaultStorageType} />
+            )}
           </FlexBox>
           <CopyableLabeledData
             id="clusterUrl"

--- a/src/organizations/components/OrgProfileTab/index.tsx
+++ b/src/organizations/components/OrgProfileTab/index.tsx
@@ -38,6 +38,7 @@ import {CLOUD} from 'src/shared/constants'
 
 // Utils
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import {isOrgIOx} from 'src/organizations/selectors'
 
 // Styles
 import 'src/organizations/components/OrgProfileTab/style.scss'
@@ -45,6 +46,7 @@ import 'src/organizations/components/OrgProfileTab/style.scss'
 const OrgProfileTab: FC = () => {
   const me = useSelector(getMe)
   const org = useSelector(getOrg)
+  const storageType = useSelector(isOrgIOx) ? 'IOx' : 'TSM'
   const quartzOrg = useSelector(selectCurrentOrg)
   const dispatch = useDispatch()
   const {users} = useContext(UsersContext)
@@ -107,6 +109,7 @@ const OrgProfileTab: FC = () => {
             <LabeledData label="Cloud Provider" src={quartzOrg.provider} />
             <LabeledData label="Region" src={quartzOrg.regionCode} />
             <LabeledData label="Location" src={quartzOrg.regionName} />
+            <LabeledData label="Storage Type" src={storageType} />
           </FlexBox>
           <CopyableLabeledData
             id="clusterUrl"

--- a/src/organizations/components/OrgProfileTab/index.tsx
+++ b/src/organizations/components/OrgProfileTab/index.tsx
@@ -90,8 +90,7 @@ const OrgProfileTab: FC = () => {
     tsm: 'TSM',
   }
 
-  const formattedStorageType =
-    storageTypeMap[storageType.toLowerCase()] || storageType
+  const formattedStorageType = storageTypeMap[storageType] || storageType
 
   const OrgProfile = () => (
     <FlexBox.Child

--- a/src/organizations/components/OrgProfileTab/index.tsx
+++ b/src/organizations/components/OrgProfileTab/index.tsx
@@ -46,6 +46,7 @@ const OrgProfileTab: FC = () => {
   const me = useSelector(getMe)
   const org = useSelector(getOrg)
   const quartzOrg = useSelector(selectCurrentOrg)
+  const storageType = org?.defaultStorageType
   const dispatch = useDispatch()
   const {users} = useContext(UsersContext)
 
@@ -81,7 +82,15 @@ const OrgProfileTab: FC = () => {
   const allowSelfRemoval = users.length > 1
   const showLeaveOrgButton = isFlagEnabled('createDeleteOrgs')
   const hasFetchedOrgDetails = orgDetailsStatus === RemoteDataState.Done
-  const hasFetchedStorageType = Boolean(org?.defaultStorageType)
+  const hasFetchedStorageType = Boolean(storageType)
+
+  const storageTypeMap = {
+    iox: 'IOx',
+    tsm: 'TSM',
+  }
+
+  const capitalizedStorageType =
+    storageTypeMap[storageType.toLowerCase()] || storageType
 
   const OrgProfile = () => (
     <FlexBox.Child
@@ -109,7 +118,7 @@ const OrgProfileTab: FC = () => {
             <LabeledData label="Region" src={quartzOrg.regionCode} />
             <LabeledData label="Location" src={quartzOrg.regionName} />
             {hasFetchedStorageType && (
-              <LabeledData label="Storage Type" src={org.defaultStorageType} />
+              <LabeledData label="Storage Type" src={capitalizedStorageType} />
             )}
           </FlexBox>
           <CopyableLabeledData

--- a/src/organizations/selectors/index.ts
+++ b/src/organizations/selectors/index.ts
@@ -5,7 +5,7 @@ import {get} from 'lodash'
 import {AppState, Organization} from 'src/types'
 
 interface OrganizationWithStorageType extends Organization {
-  defaultStorageType?: string
+  defaultStorageType?: 'tsm' | 'iox'
 }
 
 export const isOrgIOx = (state: AppState): boolean => {

--- a/src/organizations/selectors/index.ts
+++ b/src/organizations/selectors/index.ts
@@ -4,12 +4,8 @@ import {get} from 'lodash'
 // Types
 import {AppState, Organization} from 'src/types'
 
-interface OrganizationWithStorageType extends Organization {
-  defaultStorageType?: 'tsm' | 'iox'
-}
-
 export const isOrgIOx = (state: AppState): boolean => {
-  const org: OrganizationWithStorageType = getOrg(state)
+  const org: Organization = getOrg(state)
 
   return Boolean(
     org &&


### PR DESCRIPTION
Closes [AIM #7058](https://github.com/influxdata/quartz/issues/7058)

Adds display on the org profile page to disclose whether the current org is an iox or a tsm org. Adds associated cloud2 e2e test.

![Screen Shot 2023-01-05 at 6 18 42 PM](https://user-images.githubusercontent.com/91283923/210898574-ddf02963-1577-4ab8-a5ad-43599e5c7301.png)


### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - NO
