### PR TITLE
fix: update zuora url on credit card form

### DIFF
--- a/src/shared/components/CreditCardForm/index.tsx
+++ b/src/shared/components/CreditCardForm/index.tsx
@@ -8,7 +8,7 @@ import {event} from 'src/cloud/utils/reporting'
 import {CreditCardParams, ZuoraClient} from 'src/types'
 
 export const ZUORA_SCRIPT_URL =
-  'https://apisandboxstatic.zuora.com/Resources/libs/hosted/1.3.0/zuora-min.js'
+  'https://static.zuora.com/Resources/libs/hosted/1.3.0/zuora-min.js'
 export const ZUORA_ID = 'zuora_payment'
 
 export interface Props {


### PR DESCRIPTION
We're seeing `502` errors this morning in downloading the zuora credit card form script in certain regions. Per Zuora, they made a change to the Zuora sandbox environment that is causing the error. They've reverted the change, so it should be working now. However, the underlying issue is that we're pulling our Zuora script from their 'API Sandbox' not the copy in prod. 

The zuora-min.js script is identical in both cases (I've confirmed by `diff`ing them locally). But we shouldn't be retrieving this checkout script from the sandbox url.

