### PR TITLE
chore(sql-composition): guard against null pointer exception

### DIFF
--- a/src/languageSupport/languages/sql/connection.ts
+++ b/src/languageSupport/languages/sql/connection.ts
@@ -154,7 +154,7 @@ export class ConnectionManager extends AgnosticConnectionManager {
     return {
       composition: composition.join('\n'),
       lines,
-      lenLastLine: composition[composition.length - 1].length,
+      lenLastLine: composition[composition.length - 1]?.length ?? 0,
     }
   }
 


### PR DESCRIPTION
I stumbled on this while playing around with SQL queries. I don't know what I did to get the app in this state. It might be transient, because when I go to the same page in a new tab/window, everything works. It's only in the existing tab I have that this crash happens. It's been very difficult to re-trigger it, but it seems to be related to having an empty `WHERE` clause and then removing all keys from the clause.

Regardless, if I ran into it, it means it's probably possible for a user to run into it, so I added this fix, which causes the crash not to happen locally.

![Screenshot 2023-01-11 at 4 50 54 PM](https://user-images.githubusercontent.com/146112/211926004-7ba2caad-b49d-4144-bf95-3a5ab2fd722c.png)



### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- ~[ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~
- ~[ ] Feature flagged, if applicable~
