### PR TITLE
chore: no cardinality on orglimits page if org is iox; simplify limits

### DIFF
--- a/src/billing/components/Free/FreePanel.tsx
+++ b/src/billing/components/Free/FreePanel.tsx
@@ -1,6 +1,6 @@
 import React, {FC} from 'react'
 import {Panel} from '@influxdata/clockface'
-import OrgLimits from 'src/billing/components/Free/OrgLimits'
+import {OrgLimits} from 'src/billing/components/Free/OrgLimits'
 import {Credit250PAYGConversion} from 'src/billing/components/Free/PAYGConversion'
 
 export const FreePanel: FC = () => (

--- a/src/billing/components/Free/PAYGConversion.tsx
+++ b/src/billing/components/Free/PAYGConversion.tsx
@@ -2,21 +2,24 @@
 import React, {FC} from 'react'
 import {useSelector} from 'react-redux'
 import {
-  Panel,
-  ComponentSize,
+  Button,
+  Columns,
   ComponentColor,
+  ComponentSize,
+  FontWeight,
   Gradients,
   Grid,
-  Columns,
   Heading,
   HeadingElement,
-  FontWeight,
-  Button,
+  Panel,
 } from '@influxdata/clockface'
 import {useHistory} from 'react-router-dom'
 
 // Components
 import {CloudUpgradeButton} from 'src/shared/components/CloudUpgradeButton'
+
+// Selectors
+import {isOrgIOx} from 'src/organizations/selectors'
 
 // Utils
 import {shouldGetCredit250Experience} from 'src/me/selectors'
@@ -26,6 +29,7 @@ const CARDINALITY_LIMIT = 1_000_000
 
 export const Credit250PAYGConversion: FC = () => {
   const isCredit250ExperienceActive = useSelector(shouldGetCredit250Experience)
+  const orgUsesIOx = useSelector(isOrgIOx)
 
   const credit250Experience = (
     <Grid className="credit-250-conversion-panel" key="1">
@@ -67,10 +71,12 @@ export const Credit250PAYGConversion: FC = () => {
             <li>Unlimited tasks</li>
             <li>Unlimited alert checks and notification rules</li>
             <li>HTTP and PagerDuty notifications</li>
-            <li>
-              Up to {Intl.NumberFormat().format(CARDINALITY_LIMIT)} series
-              cardinality
-            </li>
+            {!orgUsesIOx && (
+              <li>
+                Up to {Intl.NumberFormat().format(CARDINALITY_LIMIT)} series
+                cardinality
+              </li>
+            )}
           </ul>
         </div>
       </Grid.Column>
@@ -85,6 +91,7 @@ export const Credit250PAYGConversion: FC = () => {
 
 export const PAYGConversion: FC = () => {
   const history = useHistory()
+  const orgUsesIOx = useSelector(isOrgIOx)
 
   const handleClick = () => {
     history.push('/checkout')
@@ -118,10 +125,12 @@ export const PAYGConversion: FC = () => {
                       <li>Unlimited tasks</li>
                       <li>Unlimited alert checks and notification rules</li>
                       <li>HTTP and PagerDuty notifications</li>
-                      <li>
-                        Up to {Intl.NumberFormat().format(CARDINALITY_LIMIT)}{' '}
-                        series cardinality
-                      </li>
+                      {!orgUsesIOx && (
+                        <li>
+                          Up to {Intl.NumberFormat().format(CARDINALITY_LIMIT)}{' '}
+                          series cardinality
+                        </li>
+                      )}
                     </ul>
                   </div>
                 </div>


### PR DESCRIPTION
Helps with [AIM 7046](https://github.com/influxdata/quartz/issues/7046)

Removes cardinality references from the org limits page when an org is an iox org. Adds corresponding test.

This component needed a refactor because it was too complicated, and the variable names obscured what it was doing. It renders 9 limit cards. The reason it was confusing is that the data from the api comes in three different formats, so different render logic is needed for the buckets limits, rate limits, and other limits. 

This goes partway to simplifying it for the next person. The better fix would be to change the data shape, but that would require some heavier lifting in other components.

Not an IOx Org
--
![Screen Shot 2023-01-12 at 10 42 00 AM](https://user-images.githubusercontent.com/91283923/212114122-4588714d-bd54-4733-acbb-449f965e561e.png)




An IOx Org
--
![Screen Shot 2023-01-12 at 10 51 00 AM](https://user-images.githubusercontent.com/91283923/212116743-1b4d7aa3-2db3-420b-b549-d43242157c38.png)





### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - NO
