### PR TITLE
chore: update toggle title to "Switch to old Data Explorer"

### DIFF
--- a/cypress/e2e/shared/editor.test.ts
+++ b/cypress/e2e/shared/editor.test.ts
@@ -135,7 +135,8 @@ describe('Editor+LSP communication', () => {
         cy.getByTestID('flux-query-builder-toggle').then($toggle => {
           cy.wrap($toggle).should('be.visible')
           // Switch to Script Editor if not yet
-          if ($toggle.hasClass('active')) { // active means showing the old Data Explorer
+          if ($toggle.hasClass('active')) {
+            // active means showing the old Data Explorer
             // hasClass is a jQuery function
             $toggle.click()
             cy.getByTestID('flux-query-builder--menu').contains('New Script')

--- a/cypress/e2e/shared/editor.test.ts
+++ b/cypress/e2e/shared/editor.test.ts
@@ -134,8 +134,8 @@ describe('Editor+LSP communication', () => {
         cy.getByTestID('tree-nav').should('be.visible')
         cy.getByTestID('flux-query-builder-toggle').then($toggle => {
           cy.wrap($toggle).should('be.visible')
-          // Switch to Flux Query Builder if not yet
-          if (!$toggle.hasClass('active')) {
+          // Switch to Script Editor if not yet
+          if ($toggle.hasClass('active')) { // active means showing the old Data Explorer
             // hasClass is a jQuery function
             $toggle.click()
             cy.getByTestID('flux-query-builder--menu').contains('New Script')

--- a/cypress/e2e/shared/scriptQueryBuilder.flux.test.ts
+++ b/cypress/e2e/shared/scriptQueryBuilder.flux.test.ts
@@ -139,8 +139,8 @@ describe('Script Builder', () => {
         return cy.setFeatureFlags(flags).then(() => {
           cy.getByTestID('flux-query-builder-toggle').then($toggle => {
             cy.wrap($toggle).should('be.visible')
-            // Switch to Flux Query Builder if not yet
-            if (!$toggle.hasClass('active')) {
+            // Switch to Script Editor if not yet
+            if ($toggle.hasClass('active')) { // active means showing the old Data Explorer
               // hasClass is a jQuery function
               $toggle.click()
             }

--- a/cypress/e2e/shared/scriptQueryBuilder.flux.test.ts
+++ b/cypress/e2e/shared/scriptQueryBuilder.flux.test.ts
@@ -140,7 +140,8 @@ describe('Script Builder', () => {
           cy.getByTestID('flux-query-builder-toggle').then($toggle => {
             cy.wrap($toggle).should('be.visible')
             // Switch to Script Editor if not yet
-            if ($toggle.hasClass('active')) { // active means showing the old Data Explorer
+            if ($toggle.hasClass('active')) {
+              // active means showing the old Data Explorer
               // hasClass is a jQuery function
               $toggle.click()
             }

--- a/cypress/e2e/shared/scriptQueryBuilder.results.test.ts
+++ b/cypress/e2e/shared/scriptQueryBuilder.results.test.ts
@@ -128,8 +128,8 @@ describe('Script Builder', () => {
         return cy.setFeatureFlags(flags).then(() => {
           cy.getByTestID('flux-query-builder-toggle').then($toggle => {
             cy.wrap($toggle).should('be.visible')
-            // Switch to Flux Query Builder if not yet
-            if (!$toggle.hasClass('active')) {
+            // Switch to Script Editor if not yet
+            if ($toggle.hasClass('active')) { // active means showing the old Data Explorer
               // hasClass is a jQuery function
               $toggle.click()
             }

--- a/cypress/e2e/shared/scriptQueryBuilder.results.test.ts
+++ b/cypress/e2e/shared/scriptQueryBuilder.results.test.ts
@@ -129,7 +129,8 @@ describe('Script Builder', () => {
           cy.getByTestID('flux-query-builder-toggle').then($toggle => {
             cy.wrap($toggle).should('be.visible')
             // Switch to Script Editor if not yet
-            if ($toggle.hasClass('active')) { // active means showing the old Data Explorer
+            if ($toggle.hasClass('active')) {
+              // active means showing the old Data Explorer
               // hasClass is a jQuery function
               $toggle.click()
             }

--- a/src/dataExplorer/components/DataExplorerPage.tsx
+++ b/src/dataExplorer/components/DataExplorerPage.tsx
@@ -91,9 +91,9 @@ const DataExplorerPageHeader: FC = () => {
       <FlexBox margin={ComponentSize.Large}>
         {isFlagEnabled('newDataExplorer') && (
           <FlexBox margin={ComponentSize.Medium}>
-            <InputLabel>&#10024; Try New Script Editor</InputLabel>
+            <InputLabel>Switch to old Data Explorer</InputLabel>
             <SlideToggle
-              active={fluxQueryBuilder}
+              active={!fluxQueryBuilder}
               onChange={toggleSlider}
               testID="flux-query-builder-toggle"
             />

--- a/src/shared/contexts/app.tsx
+++ b/src/shared/contexts/app.tsx
@@ -60,7 +60,7 @@ const DEFAULT_CONTEXT: AppSettingContextType = {
   timeZone: 'Local' as TimeZone,
   theme: 'dark' as Theme,
   presentationMode: false,
-  fluxQueryBuilder: false,
+  fluxQueryBuilder: true,
   navbarMode: 'collapsed' as NavBarState,
   flowsCTA: {alerts: true, explorer: true, tasks: true} as FlowsCTA,
   subscriptionsCertificateInterest: false,


### PR DESCRIPTION
Closes #6461 

This PR update the toggle title from "Try New Script Editor" to "Switch to old Data Explorer" and reverse the on/off meaning of the toggle to match the name change.

This PR should be merged after we give Customer Success the heads-up when we think the change is going to go live.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
