### PR TITLE
chore: RateLimitAlert - cardinality alerts only in non-iox orgs

### DIFF
--- a/cypress/fixtures/multiOrgIdentityContract.json
+++ b/cypress/fixtures/multiOrgIdentityContract.json
@@ -19,6 +19,7 @@
     "name": "Influx",
     "type": "contract",
     "accountCreatedAt": "Tue Jun 01 2022 08:49:14 GMT-0400 (Eastern Daylight Time)",
-    "billing_provider": "gcm"
+    "billing_provider": "gcm",
+    "isUpgradeable": true
   }
 }

--- a/cypress/fixtures/multiOrgIdentityPAYG.json
+++ b/cypress/fixtures/multiOrgIdentityPAYG.json
@@ -19,6 +19,7 @@
     "name": "Influx",
     "type": "pay_as_you_go",
     "accountCreatedAt": "Tue Jun 01 2022 08:49:14 GMT-0400 (Eastern Daylight Time)",
-    "billing_provider": "aws"
+    "billing_provider": "aws",
+    "isUpgradeable": true
   }
 }

--- a/src/cloud/components/CardinalityLimitAlertContent.tsx
+++ b/src/cloud/components/CardinalityLimitAlertContent.tsx
@@ -4,10 +4,10 @@ import {useDispatch, useSelector} from 'react-redux'
 import classnames from 'classnames'
 import {
   Button,
-  FlexBox,
-  ComponentSize,
-  JustifyContent,
   ComponentColor,
+  ComponentSize,
+  FlexBox,
+  JustifyContent,
 } from '@influxdata/clockface'
 
 // Components
@@ -30,11 +30,11 @@ interface Props {
 }
 
 interface UpgradeProps {
-  type: string
-  link: string
   className?: string
-  limitText?: string
   location?: string
+  limitText?: string
+  link: string
+  type: string
 }
 
 interface UpgradeMessageProps {
@@ -90,9 +90,10 @@ export const UpgradeContent: FC<UpgradeProps> = ({
   return (
     <div className={`${className} rate-alert--content__free`}>
       <FlexBox
-        justifyContent={JustifyContent.SpaceBetween}
         className="rate-alert--button"
+        justifyContent={JustifyContent.SpaceBetween}
         stretchToFitWidth={true}
+        testID="rate-alert--banner"
       >
         <UpgradeMessage
           {...{isCredit250ExperienceActive, limitText, link, type}}
@@ -115,30 +116,37 @@ export const UpgradeContent: FC<UpgradeProps> = ({
   )
 }
 
-export const RateLimitAlertContent: FC<Props> = ({className, location}) => {
+export const CardinalityLimitAlertContent: FC<Props> = ({
+  className,
+  location,
+}) => {
   const dispatch = useDispatch()
   const showUpgradeButton = useSelector(shouldShowUpgradeButton)
-  const rateLimitAlertContentClass = classnames('rate-alert--content', {
+  const cardinalityLimitAlertContentClass = classnames('rate-alert--content', {
     [`${className}`]: className,
   })
 
   const handleShowOverlay = () => {
-    dispatch(showOverlay('rate-limit', null, () => dispatch(dismissOverlay)))
+    dispatch(
+      showOverlay('cardinality-limit', null, () => dispatch(dismissOverlay))
+    )
   }
 
   if (showUpgradeButton) {
     return (
       <UpgradeContent
-        type="series cardinality"
+        className={cardinalityLimitAlertContentClass}
         link="https://docs.influxdata.com/influxdb/v2.0/write-data/best-practices/resolve-high-cardinality/"
-        className={rateLimitAlertContentClass}
         location={location}
+        type="series cardinality"
       />
     )
   }
 
   return (
-    <div className={`${rateLimitAlertContentClass} rate-alert--content__payg`}>
+    <div
+      className={`${cardinalityLimitAlertContentClass} rate-alert--content__payg`}
+    >
       <span>
         Data in has stopped because you've hit the{' '}
         <SafeBlankLink href="https://docs.influxdata.com/influxdb/v2.0/write-data/best-practices/resolve-high-cardinality/">

--- a/src/cloud/components/CardinalityLimitOverlay.tsx
+++ b/src/cloud/components/CardinalityLimitOverlay.tsx
@@ -31,7 +31,7 @@ type ReduxProps = ConnectedProps<typeof connector>
 
 type Props = OwnProps & ReduxProps
 
-const RateLimitOverlay: FC<Props> = ({onClose, orgID}) => {
+const CardinalityLimitOverlayUnconnected: FC<Props> = ({onClose, orgID}) => {
   const history = useHistory()
   const [showForm, toggleShowForm] = useState<boolean>(false)
 
@@ -118,4 +118,6 @@ const mstp = (state: AppState) => {
 
 const connector = connect(mstp)
 
-export default connector(RateLimitOverlay)
+export const CardinalityLimitOverlay = connector(
+  CardinalityLimitOverlayUnconnected
+)

--- a/src/cloud/components/RateLimitAlert.tsx
+++ b/src/cloud/components/RateLimitAlert.tsx
@@ -5,18 +5,21 @@ import classnames from 'classnames'
 
 // Components
 import {
-  FlexBox,
-  FlexDirection,
   AlignItems,
-  ComponentSize,
-  IconFont,
-  Gradients,
-  InfluxColors,
   BannerPanel,
   Button,
   ComponentColor,
+  ComponentSize,
+  FlexBox,
+  FlexDirection,
+  Gradients,
+  IconFont,
+  InfluxColors,
 } from '@influxdata/clockface'
+import {CardinalityLimitAlertContent} from 'src/cloud/components/CardinalityLimitAlertContent'
 import {CloudUpgradeButton} from 'src/shared/components/CloudUpgradeButton'
+import {dismissOverlay, showOverlay} from 'src/overlays/actions/overlays'
+import {UpgradeContent} from 'src/cloud/components/CardinalityLimitAlertContent'
 
 // Utils
 import {
@@ -28,9 +31,7 @@ import {event} from 'src/cloud/utils/reporting'
 // Constants
 import {CLOUD} from 'src/shared/constants'
 
-// Types
-import {RateLimitAlertContent} from 'src/cloud/components/RateLimitAlertContent'
-
+// Notifications
 import {notify} from 'src/shared/actions/notifications'
 import {writeLimitReached} from 'src/shared/copy/notifications'
 
@@ -39,9 +40,9 @@ import {
   shouldGetCredit250Experience,
   shouldShowUpgradeButton,
 } from 'src/me/selectors'
-import {dismissOverlay, showOverlay} from 'src/overlays/actions/overlays'
-import {UpgradeContent} from 'src/cloud/components/RateLimitAlertContent'
+import {isOrgIOx} from 'src/organizations/selectors'
 
+// Styles
 import './RateLimitAlert.scss'
 
 interface Props {
@@ -57,6 +58,7 @@ export const RateLimitAlert: FC<Props> = ({alertOnly, className, location}) => {
   const status = useSelector(extractRateLimitStatus)
   const showUpgrade = useSelector(shouldShowUpgradeButton)
   const isCredit250ExperienceActive = useSelector(shouldGetCredit250Experience)
+  const orgIsIOx = useSelector(isOrgIOx)
 
   const dispatch = useDispatch()
 
@@ -104,7 +106,12 @@ export const RateLimitAlert: FC<Props> = ({alertOnly, className, location}) => {
   })
 
   // banner panel for cardinality limit exceeded
-  if (CLOUD && status === 'exceeded' && resources.includes('cardinality')) {
+  if (
+    CLOUD &&
+    !orgIsIOx &&
+    status === 'exceeded' &&
+    resources.includes('cardinality')
+  ) {
     return (
       <FlexBox
         direction={FlexDirection.Column}
@@ -120,7 +127,7 @@ export const RateLimitAlert: FC<Props> = ({alertOnly, className, location}) => {
           textColor={InfluxColors.Yeti}
           style={bannerStyle}
         >
-          <RateLimitAlertContent />
+          <CardinalityLimitAlertContent />
         </BannerPanel>
       </FlexBox>
     )

--- a/src/me/selectors/index.ts
+++ b/src/me/selectors/index.ts
@@ -15,4 +15,4 @@ export const shouldGetCredit250Experience = (state: AppState): boolean => {
 }
 
 export const shouldShowUpgradeButton = (state: AppState): boolean =>
-  state.identity.currentIdentity.account.isUpgradeable === true
+  state.identity.currentIdentity.account.isUpgradeable

--- a/src/overlays/components/OverlayController.tsx
+++ b/src/overlays/components/OverlayController.tsx
@@ -23,7 +23,7 @@ import TelegrafUIRefreshWizard from 'src/dataLoaders/components/collectorsWizard
 import OrgSwitcherOverlay from 'src/pageLayout/components/OrgSwitcherOverlay'
 import CreateBucketOverlay from 'src/buckets/components/createBucketForm/CreateBucketOverlay'
 import {AssetLimitOverlay} from 'src/cloud/components/AssetLimitOverlay'
-import RateLimitOverlay from 'src/cloud/components/RateLimitOverlay'
+import {CardinalityLimitOverlay} from 'src/cloud/components/CardinalityLimitOverlay'
 import WriteLimitOverlay from 'src/cloud/components/WriteLimitOverlay'
 import {AddAnnotationOverlay} from 'src/annotations/components/AddAnnotationOverlay'
 import {ShowBucketSchemaOverlay} from 'src/buckets/components/schemaOverlay/ShowBucketSchemaOverlay'
@@ -117,8 +117,8 @@ export const OverlayController: FunctionComponent = () => {
       case 'asset-limit':
         activeOverlay.current = <AssetLimitOverlay onClose={onClose} />
         break
-      case 'rate-limit':
-        activeOverlay.current = <RateLimitOverlay onClose={onClose} />
+      case 'cardinality-limit':
+        activeOverlay.current = <CardinalityLimitOverlay onClose={onClose} />
         break
       case 'write-limit':
         activeOverlay.current = <WriteLimitOverlay />

--- a/src/overlays/reducers/overlays.ts
+++ b/src/overlays/reducers/overlays.ts
@@ -20,7 +20,7 @@ export type OverlayID =
   | 'switch-organizations'
   | 'create-bucket'
   | 'asset-limit'
-  | 'rate-limit'
+  | 'cardinality-limit'
   | 'write-limit'
   | 'create-annotation-stream'
   | 'update-annotation-stream'

--- a/src/usage/RateLimits.tsx
+++ b/src/usage/RateLimits.tsx
@@ -1,8 +1,8 @@
 // Libraries
 import React, {FC, useContext} from 'react'
 import {
-  ComponentSize,
   AlignItems,
+  ComponentSize,
   FlexDirection,
   Panel,
 } from '@influxdata/clockface'
@@ -11,7 +11,11 @@ import {
 import UsageXYGraph from 'src/usage/UsageXYGraph'
 import {UsageContext} from 'src/usage/context/usage'
 
-const RateLimits: FC = () => {
+const headingStyle = {
+  lineHeight: '40px',
+}
+
+export const RateLimits: FC = () => {
   const {rateLimits, rateLimitsStatus, timeRange} = useContext(UsageContext)
 
   return (
@@ -19,7 +23,7 @@ const RateLimits: FC = () => {
       <Panel.Header className="rate-limits-header--timerange">
         <h4
           data-testid="rate-limits-header--timerange"
-          style={{lineHeight: '40px'}}
+          style={headingStyle}
         >{`Rate Limits ${timeRange.label}`}</h4>
       </Panel.Header>
       <Panel.Body
@@ -40,5 +44,3 @@ const RateLimits: FC = () => {
     </Panel>
   )
 }
-
-export default RateLimits

--- a/src/usage/UsagePage.tsx
+++ b/src/usage/UsagePage.tsx
@@ -3,7 +3,7 @@ import React, {FC} from 'react'
 import {Page} from '@influxdata/clockface'
 
 // Components
-import UsageToday from 'src/usage/UsageToday'
+import {UsageToday} from 'src/usage/UsageToday'
 import OrgHeader from 'src/organizations/components/OrgHeader'
 import OrgTabbedPage from 'src/organizations/components/OrgTabbedPage'
 

--- a/src/usage/UsageToday.tsx
+++ b/src/usage/UsageToday.tsx
@@ -10,11 +10,11 @@ import {
 // Components
 import UsageProvider from 'src/usage/context/usage'
 import UsageResults from 'src/usage/UsageResults'
-import RateLimits from 'src/usage/RateLimits'
+import {RateLimits} from 'src/usage/RateLimits'
 import BillingStatsPanel from 'src/usage/BillingStatsPanel'
 import UsageTimeRangeDropdown from 'src/usage/UsageTimeRangeDropdown'
 
-const UsageToday: FC = () => (
+export const UsageToday: FC = () => (
   <FlexBox
     alignItems={AlignItems.Stretch}
     direction={FlexDirection.Column}
@@ -30,5 +30,3 @@ const UsageToday: FC = () => (
     </UsageProvider>
   </FlexBox>
 )
-
-export default UsageToday


### PR DESCRIPTION
Helps with [AIM 7046](https://github.com/influxdata/quartz/issues/7046)

Eliminates ability to generate a cardinality rate limit alert if org is iox.

Hit Cardinality Limit - TSM - Account is Upgradeable (Banner Has Upgrade Button)
--
![Screen Shot 2023-01-12 at 3 22 48 PM](https://user-images.githubusercontent.com/91283923/212367462-702e5c9c-247f-4691-8798-f1da283c5c65.png)

Hit Cardinality Limit - TSM - Account Not Upgradeable (Banner Has No Upgrade Button, only "Inspect Series Cardinality")
--
![Screen Shot 2023-01-12 at 3 24 33 PM](https://user-images.githubusercontent.com/91283923/212367738-a0badb8e-4af8-49b2-8eca-fb2e6cd8b5c6.png)

Hit Cardinality Limit - TSM - Account Not Upgradeable (Inspect Series Cardinality Overlay)
--
![Screen Shot 2023-01-12 at 3 24 55 PM](https://user-images.githubusercontent.com/91283923/212370127-546c0f76-ac90-4ea7-8702-1cce0b0a738b.png)


The Limit Does Not Exist - IOx
--
![Screen Shot 2023-01-12 at 3 23 03 PM](https://user-images.githubusercontent.com/91283923/212367701-ec0b63fd-b196-4ea7-90c3-a1fe0ff9345e.png)




### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - NO
