### PR TITLE
ci: update circleci config so it properly recurses all files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
           name: parallel jest tests
           command: |
             set +e
+            shopt -s globstar
             TESTFILES=$(circleci tests glob "src/**/*.test.ts*" | circleci tests split --split-by=timings)
             npx yarn test:circleci $TESTFILES
       - store_test_results:
@@ -57,6 +58,7 @@ jobs:
           name: parallel jest tests
           command: |
             set +e
+            shopt -s globstar
             TESTFILES=$(circleci tests glob "src/**/*.test.ts*" | circleci tests split --split-by=timings)
             npx yarn test:circleci $TESTFILES
       - store_test_results:
@@ -94,6 +96,7 @@ jobs:
           name: parallel eslint
           command: |
             set +e
+            shopt -s globstar
             TESTFILES=$(circleci tests glob "src/**/*.ts*" "cypress/**/*.ts*" | circleci tests split --split-by=filesize)
             yarn eslint:circleci $TESTFILES
       - save_cache:
@@ -127,6 +130,7 @@ jobs:
           name: parallel eslint
           command: |
             set +e
+            shopt -s globstar
             TESTFILES=$(circleci tests glob "src/**/*.ts*" "cypress/**/*.ts*" | circleci tests split --split-by=filesize)
             yarn eslint:circleci $TESTFILES
       - save_cache:


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/6346

Add `shopt -s globstar` to circleci's config so that it can explicitly get the correct glob to run all tests.

### Local:
```sh
Test Suites: 1 skipped, 168 passed, 168 of 169 total
Tests:       35 skipped, 954 passed, 989 total
```

### CI (there are four parallel jobs running):
```sh
Test Suites: 43 passed, 43 total
Tests:       22 skipped, 235 passed, 257 total
```
```sh
Test Suites: 42 passed, 42 total
Tests:       1 skipped, 258 passed, 259 total
```
```sh
Test Suites: 42 passed, 42 total
Tests:       1 skipped, 247 passed, 248 total
```
```sh
Test Suites: 1 skipped, 41 passed, 41 of 42 total
Tests:       11 skipped, 214 passed, 225 total
```
## Comparing

### Totals from CI
```sh
Test Suites: 1 skipped, 168 passed,  168 of 169 total
Tests:       35 skipped, 954 passed, 989 total
```
### Local:
```sh
Test Suites: 1 skipped, 168 passed, 168 of 169 total
Tests:       35 skipped, 954 passed, 989 total
```



### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- ~[ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)~
- ~[ ] Feature flagged, if applicable~
