### PR TITLE
chore: remove cardinality option from cancel service context if org type is iox

### DIFF
--- a/src/billing/components/PayAsYouGo/CancelServiceContext.tsx
+++ b/src/billing/components/PayAsYouGo/CancelServiceContext.tsx
@@ -5,16 +5,16 @@ interface Props {
   children: ReactChild
 }
 
-export enum VariableItems {
-  NO_OPTION = '----',
-  USE_CASE_DIFFERENT = "It doesn't work for my use case",
-  SWITCHING_ORGANIZATION = 'I want to join my account to another organization',
+export enum CancelationReasons {
   ALTERNATIVE_PRODUCT = 'I found an alternative product',
+  NONE = '----',
   RE_SIGNUP = 'I want to sign up for a new account using a marketplace option',
+  SWITCHING_ORGANIZATION = 'I want to join my account to another organization',
   TOO_EXPENSIVE = 'It’s too expensive',
-  USABILITY_ISSUE = 'I found Flux hard to use',
-  UNSTABLE_PLATFORM = 'Platform isn’t stable enough',
   UNSUPPORTED_HIGH_CARDINALITY = 'Platform doesn’t support my high Cardinality',
+  UNSTABLE_PLATFORM = 'Platform isn’t stable enough',
+  USABILITY_ISSUE = 'I found Flux hard to use',
+  USE_CASE_DIFFERENT = "It doesn't work for my use case",
   OTHER_REASON = 'Other reason',
 }
 
@@ -23,6 +23,13 @@ const RedirectLocations = {
   RE_SIGNUP: '/cancel',
 }
 const DEFAULT_REDIRECT_LOCATION = '/mkt_cancel'
+
+// Ensures that the default cancelation "reason" is always the key name for the "NONE" enum.
+const getDefaultCancelationReason = () => {
+  return Object.keys(CancelationReasons).filter(
+    reason => CancelationReasons[reason] === CancelationReasons.NONE
+  )[0]
+}
 
 export interface CancelServiceContextType {
   shortSuggestion: string
@@ -45,7 +52,7 @@ export const DEFAULT_CANCEL_SERVICE_CONTEXT: CancelServiceContextType = {
   setShortSuggestion: (_: string) => null,
   suggestions: '',
   setSuggestions: (_: string) => null,
-  reason: 'NO_OPTION',
+  reason: getDefaultCancelationReason(),
   setReason: (_: string) => null,
   canContactForFeedback: false,
   toggleCanContactForFeedback: () => null,
@@ -56,7 +63,7 @@ export const CancelServiceContext = createContext<CancelServiceContextType>(
   DEFAULT_CANCEL_SERVICE_CONTEXT
 )
 
-const CancelServiceProvider: FC<Props> = ({children}) => {
+export const CancelServiceProvider: FC<Props> = ({children}) => {
   const [shortSuggestion, setShortSuggestion] = useState(
     DEFAULT_CANCEL_SERVICE_CONTEXT.shortSuggestion
   )
@@ -101,5 +108,3 @@ const CancelServiceProvider: FC<Props> = ({children}) => {
     </CancelServiceContext.Provider>
   )
 }
-
-export default CancelServiceProvider

--- a/src/billing/components/PayAsYouGo/CancelServiceReasonsForm.tsx
+++ b/src/billing/components/PayAsYouGo/CancelServiceReasonsForm.tsx
@@ -1,5 +1,6 @@
 // Libraries
-import React, {useContext, useMemo} from 'react'
+import React, {FC, useContext, useMemo} from 'react'
+import {useSelector} from 'react-redux'
 
 // Components
 import {
@@ -17,31 +18,49 @@ import {
 } from '@influxdata/clockface'
 
 // Utilities
-import {CancelServiceContext, VariableItems} from './CancelServiceContext'
+import {
+  CancelServiceContext,
+  CancelationReasons,
+} from 'src/billing/components/PayAsYouGo/CancelServiceContext'
 
-// Types
+// Selectors
+import {isOrgIOx} from 'src/organizations/selectors'
 
-function CancelServiceReasonsForm() {
+export const CancelServiceReasonsForm: FC = () => {
   const {
-    shortSuggestion,
-    isShortSuggestionEnabled,
-    suggestions,
-    setShortSuggestionFlag,
-    setShortSuggestion,
-    setSuggestions,
-    reason,
-    setReason,
     canContactForFeedback,
+    isShortSuggestionEnabled,
+    reason,
+    shortSuggestion,
+    suggestions,
+    setReason,
+    setShortSuggestion,
+    setShortSuggestionFlag,
+    setSuggestions,
     toggleCanContactForFeedback,
   } = useContext(CancelServiceContext)
 
+  const orgIsIOx = useSelector(isOrgIOx)
+
+  const generateCancelationReasons = () => {
+    if (orgIsIOx) {
+      return Object.keys(CancelationReasons).filter(
+        reason =>
+          CancelationReasons[reason] !==
+          CancelationReasons.UNSUPPORTED_HIGH_CARDINALITY
+      )
+    }
+
+    return Object.keys(CancelationReasons)
+  }
+
   const isDropdownOptionValid = useMemo(() => {
-    return VariableItems[reason] !== VariableItems.NO_OPTION
+    return CancelationReasons[reason] !== CancelationReasons.NONE
   }, [reason])
 
-  const onChange = (selected: string) => {
+  const onSelectReason = (selected: string) => {
     const isAlternateProductSelected =
-      VariableItems[selected] === VariableItems.ALTERNATIVE_PRODUCT
+      CancelationReasons[selected] === CancelationReasons.ALTERNATIVE_PRODUCT
     if (!isAlternateProductSelected) {
       setShortSuggestion('')
     }
@@ -63,20 +82,20 @@ function CancelServiceReasonsForm() {
               onClick={onClick}
               testID="variable-type-dropdown--button"
             >
-              {VariableItems[reason]}
+              {CancelationReasons[reason]}
             </Dropdown.Button>
           )}
           menu={onCollapse => (
             <Dropdown.Menu onCollapse={onCollapse}>
-              {Object.keys(VariableItems).map(key => (
+              {generateCancelationReasons().map(reason => (
                 <Dropdown.Item
-                  key={key}
-                  id={key}
-                  value={key}
-                  onClick={onChange}
-                  testID={`variable-type-dropdown-${key}`}
+                  key={reason}
+                  id={reason}
+                  value={reason}
+                  onClick={onSelectReason}
+                  testID={`variable-type-dropdown-${reason}`}
                 >
-                  {VariableItems[key]}
+                  {CancelationReasons[reason]}
                 </Dropdown.Item>
               ))}
             </Dropdown.Menu>
@@ -140,5 +159,3 @@ function CancelServiceReasonsForm() {
     </div>
   )
 }
-
-export default CancelServiceReasonsForm

--- a/src/billing/components/PayAsYouGo/CancellationOverlay.tsx
+++ b/src/billing/components/PayAsYouGo/CancellationOverlay.tsx
@@ -1,35 +1,47 @@
 // Libraries
 import React, {FC, useContext, useMemo, useState} from 'react'
+import {useDispatch, useSelector} from 'react-redux'
+
 import {
-  Overlay,
   Alert,
+  Button,
   ComponentColor,
   ComponentSize,
-  IconFont,
-  Button,
   ComponentStatus,
+  IconFont,
+  Overlay,
 } from '@influxdata/clockface'
 
-// Components
-import TermsCancellationOverlay from 'src/billing/components/PayAsYouGo/TermsCancellationOverlay'
+// Overlays
 import ConfirmCancellationOverlay from 'src/billing/components/PayAsYouGo/ConfirmCancellationOverlay'
-import {CancelServiceContext, VariableItems} from './CancelServiceContext'
-import {track} from 'rudder-sdk-js'
-import {event} from 'src/cloud/utils/reporting'
-import {useDispatch, useSelector} from 'react-redux'
+import {TermsCancellationOverlay} from 'src/billing/components/PayAsYouGo/TermsCancellationOverlay'
+import {
+  CancelServiceContext,
+  CancelationReasons,
+} from 'src/billing/components/PayAsYouGo/CancelServiceContext'
+
+// Utils
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
-import {postSignout} from 'src/client'
-import {postCancel} from 'src/client/unityRoutes'
+import {event} from 'src/cloud/utils/reporting'
+import {track} from 'rudder-sdk-js'
 import {getErrorMessage} from 'src/utils/api'
+
+// APIs
+import {postCancel} from 'src/client/unityRoutes'
+import {postSignout} from 'src/client'
+
+// Selectors
+import {selectCurrentIdentity} from 'src/identity/selectors'
+
+// Notifications
 import {accountCancellationError} from 'src/shared/copy/notifications'
 import {notify} from 'src/shared/actions/notifications'
-import {selectCurrentIdentity} from 'src/identity/selectors'
 
 interface Props {
   onHideOverlay: () => void
 }
 
-const CancellationOverlay: FC<Props> = ({onHideOverlay}) => {
+export const CancellationOverlay: FC<Props> = ({onHideOverlay}) => {
   const [hasAgreedToTerms, setHasAgreedToTerms] = useState(false)
   const [hasClickedCancel, setHasClickedCancel] = useState(false)
   const {
@@ -72,7 +84,7 @@ const CancellationOverlay: FC<Props> = ({onHideOverlay}) => {
       email: user.email,
       alternativeProduct: shortSuggestion,
       suggestions,
-      reason: VariableItems[reason],
+      reason: CancelationReasons[reason],
       canContactForFeedback: canContactForFeedback ? 'true' : 'false',
     }
     event('CancelServiceExecuted Event', payload)
@@ -114,7 +126,9 @@ const CancellationOverlay: FC<Props> = ({onHideOverlay}) => {
     // Has Agreed to Terms & Conditions
     // as well as
     // Selected an option from the Reasons Dropdown
-    return hasAgreedToTerms && VariableItems[reason] !== VariableItems.NO_OPTION
+    return (
+      hasAgreedToTerms && CancelationReasons[reason] !== CancelationReasons.NONE
+    )
   }, [hasAgreedToTerms, reason])
 
   return (
@@ -158,5 +172,3 @@ const CancellationOverlay: FC<Props> = ({onHideOverlay}) => {
     </Overlay>
   )
 }
-
-export default CancellationOverlay

--- a/src/billing/components/PayAsYouGo/CancellationPanel.tsx
+++ b/src/billing/components/PayAsYouGo/CancellationPanel.tsx
@@ -1,5 +1,6 @@
 // Libraries
 import React, {FC, useState} from 'react'
+import {useSelector} from 'react-redux'
 import {
   Panel,
   ComponentSize,
@@ -9,14 +10,17 @@ import {
 import {track} from 'rudder-sdk-js'
 
 // Components
-import CancellationOverlay from 'src/billing/components/PayAsYouGo/CancellationOverlay'
+import {CancellationOverlay} from 'src/billing/components/PayAsYouGo/CancellationOverlay'
+
+// Selectors
+import {selectCurrentIdentity} from 'src/identity/selectors'
 
 // Utils
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
-import {useSelector} from 'react-redux'
-import {selectCurrentIdentity} from 'src/identity/selectors'
 import {event} from 'src/cloud/utils/reporting'
-import CancelServiceProvider from './CancelServiceContext'
+
+// Contexts
+import {CancelServiceProvider} from 'src/billing/components/PayAsYouGo/CancelServiceContext'
 
 const CancellationPanel: FC = () => {
   const [isOverlayVisible, setIsOverlayVisible] = useState(false)

--- a/src/billing/components/PayAsYouGo/TermsCancellationOverlay.tsx
+++ b/src/billing/components/PayAsYouGo/TermsCancellationOverlay.tsx
@@ -1,5 +1,5 @@
+// Libraries
 import React, {FC} from 'react'
-
 import {
   ComponentSize,
   FlexBox,
@@ -10,14 +10,16 @@ import {
   InputLabel,
   AlignItems,
 } from '@influxdata/clockface'
-import CancelServiceReasonsForm from './CancelServiceReasonsForm'
+
+// Components
+import {CancelServiceReasonsForm} from 'src/billing/components/PayAsYouGo/CancelServiceReasonsForm'
 
 interface Props {
   hasAgreedToTerms: boolean
   onAgreedToTerms: () => void
 }
 
-const TermsCancellationOverlay: FC<Props> = ({
+export const TermsCancellationOverlay: FC<Props> = ({
   hasAgreedToTerms,
   onAgreedToTerms,
 }) => (
@@ -73,5 +75,3 @@ const TermsCancellationOverlay: FC<Props> = ({
     </FlexBox>
   </div>
 )
-
-export default TermsCancellationOverlay

--- a/src/cloud/components/RateLimitAlert.tsx
+++ b/src/cloud/components/RateLimitAlert.tsx
@@ -16,10 +16,9 @@ import {
   IconFont,
   InfluxColors,
 } from '@influxdata/clockface'
-import {CardinalityLimitAlertContent} from 'src/cloud/components/CardinalityLimitAlertContent'
-import {CloudUpgradeButton} from 'src/shared/components/CloudUpgradeButton'
+
+// Overlays
 import {dismissOverlay, showOverlay} from 'src/overlays/actions/overlays'
-import {UpgradeContent} from 'src/cloud/components/CardinalityLimitAlertContent'
 
 // Utils
 import {
@@ -27,6 +26,11 @@ import {
   extractRateLimitStatus,
 } from 'src/cloud/utils/limits'
 import {event} from 'src/cloud/utils/reporting'
+
+// Components
+import {CardinalityLimitAlertContent} from 'src/cloud/components/CardinalityLimitAlertContent'
+import {CloudUpgradeButton} from 'src/shared/components/CloudUpgradeButton'
+import {UpgradeContent} from 'src/cloud/components/CardinalityLimitAlertContent'
 
 // Constants
 import {CLOUD} from 'src/shared/constants'


### PR DESCRIPTION
Helps with [AIM 7046](https://github.com/influxdata/quartz/issues/7046)

When canceling service in PAYG, the user is presented with options to identify why they're leaving. This PR drops the cardinality 'reason' if the org is iox (since cardinality wouldn't be a reason).

The remaining changes reflect some tidying up and readability improvements.

Not IOx Org
--
<img width="1342" alt="Screen Shot 2023-01-17 at 5 38 30 PM" src="https://user-images.githubusercontent.com/91283923/213027903-d448a48b-b941-42e2-b981-e24d050d189e.png">

IOx Org
--
<img width="1444" alt="Screen Shot 2023-01-17 at 6 06 35 PM" src="https://user-images.githubusercontent.com/91283923/213032052-fde64ed3-abbb-4409-b0ac-09551de101ea.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - NO
