### PR TITLE
chore: remove org count restriction

### DIFF
--- a/cypress/e2e/cloud/userAccounts.test.ts
+++ b/cypress/e2e/cloud/userAccounts.test.ts
@@ -196,11 +196,11 @@ describe('Free account Deletion', () => {
     deleteFreeAccount()
   })
 
-  it('displays a `must remove users` warning when user attempts to delete a free account with multiple users', () => {
+  it('displays a `must remove users` warning when user attempts to delete a free account from an org with multiple users', () => {
     setupTest({
       accountType: 'free',
       orgHasOtherUsers: true,
-      orgCount: 2,
+      orgCount: 1,
     })
     displayRemoveUsersWarning()
   })

--- a/cypress/e2e/cloud/userAccounts.test.ts
+++ b/cypress/e2e/cloud/userAccounts.test.ts
@@ -186,21 +186,21 @@ describe('Free account Deletion', () => {
     cy.url().should('include', `/members`)
   }
 
-  it('allows the user to delete a free account if there is only one org, with only one user', () => {
+  it('allows the user to delete a free account with multiple orgs', () => {
     setupTest({
       accountType: 'free',
       orgHasOtherUsers: false,
-      orgCount: 1,
+      orgCount: 3,
     })
 
     deleteFreeAccount()
   })
 
-  it('displays a `must remove users` warning if trying to delete a free account with a single org, which has multiple users', () => {
+  it('displays a `must remove users` warning when user attempts to delete a free account with multiple users', () => {
     setupTest({
       accountType: 'free',
       orgHasOtherUsers: true,
-      orgCount: 1,
+      orgCount: 2,
     })
     displayRemoveUsersWarning()
   })

--- a/src/accounts/AccountPage.tsx
+++ b/src/accounts/AccountPage.tsx
@@ -51,7 +51,7 @@ const AccountAboutPage: FC = () => {
     setActiveAcctName(activeAccount?.name)
   }, [activeAccount])
 
-  const {user, account} = useSelector(selectCurrentIdentity)
+  const {account} = useSelector(selectCurrentIdentity)
 
   const updateAcctName = (evt: ChangeEvent<HTMLInputElement>) => {
     setActiveAcctName(evt.target.value)
@@ -60,8 +60,7 @@ const AccountAboutPage: FC = () => {
   const onRenameAccountBtnClick = () => {
     handleRenameActiveAccount(activeAccount.id, activeAcctName)
   }
-  const shouldShowDeleteFreeAccountButton =
-    CLOUD && account.type === 'free' && user.orgCount === 1
+  const shouldShowDeleteFreeAccountButton = CLOUD && account.type === 'free'
 
   const showLeaveOrgButton = !isFlagEnabled('createDeleteOrgs')
   const allowSelfRemoval = users.length > 1
@@ -105,9 +104,8 @@ const AccountAboutPage: FC = () => {
 }
 
 const AccountPage: FC = () => {
-  const {account, user} = useSelector(selectCurrentIdentity)
-  const freeAccountWithOneOrg =
-    CLOUD && account.type === 'free' && user.orgCount === 1
+  const {account} = useSelector(selectCurrentIdentity)
+  const freeAccount = CLOUD && account.type === 'free'
 
   return (
     <>
@@ -118,7 +116,7 @@ const AccountPage: FC = () => {
         </UsersProvider>
       </Page>
       <Switch>
-        {freeAccountWithOneOrg && (
+        {freeAccount && (
           <DeleteFreeAccountProvider>
             <Route
               path="/orgs/:orgID/accounts/settings/delete"


### PR DESCRIPTION
Closes #6472 
Pr removes restriction preventing free account deletion if the account has more than one org. 
With this change, users will now be able to delete their accounts regardless of the numbers of orgs associated with the account.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
