### PR TITLE
feat(6496): SQL graphing viewOptions: groupby tag keys

### DIFF
--- a/src/dataExplorer/components/DeleteScript.tsx
+++ b/src/dataExplorer/components/DeleteScript.tsx
@@ -12,6 +12,7 @@ import {ResultsContext} from 'src/dataExplorer/context/results'
 import {RemoteDataState} from 'src/types'
 import {QueryContext} from 'src/shared/contexts/query'
 import {SCRIPT_EDITOR_PARAMS} from 'src/dataExplorer/components/resources'
+import {ResultsViewContext} from 'src/dataExplorer/context/resultsView'
 
 let deleteScript
 
@@ -28,6 +29,7 @@ const DeleteScript: FC<Props> = ({onBack, onClose}) => {
   const {resource} = useContext(PersistanceContext)
   const {cancel} = useContext(QueryContext)
   const {setStatus, setResult} = useContext(ResultsContext)
+  const {clear: clearViewOptions} = useContext(ResultsViewContext)
   const history = useHistory()
   const dispatch = useDispatch()
   const org = useSelector(getOrg)
@@ -43,6 +45,7 @@ const DeleteScript: FC<Props> = ({onBack, onClose}) => {
 
         setStatus(RemoteDataState.NotStarted)
         setResult(null)
+        clearViewOptions()
         cancel()
         history.replace(
           `/orgs/${org.id}/data-explorer/from/script${SCRIPT_EDITOR_PARAMS}`

--- a/src/dataExplorer/components/Results.tsx
+++ b/src/dataExplorer/components/Results.tsx
@@ -1,10 +1,10 @@
 import React, {
   FC,
-  useState,
-  useContext,
-  useMemo,
   useCallback,
+  useContext,
   useEffect,
+  useMemo,
+  useState,
 } from 'react'
 import {
   FlexBox,

--- a/src/dataExplorer/components/Results.tsx
+++ b/src/dataExplorer/components/Results.tsx
@@ -192,6 +192,7 @@ const WrappedOptions: FC = () => {
   const {view, setView, selectViewOptions, viewOptions, selectedViewOptions} =
     useContext(ResultsViewContext)
   const {resource} = useContext(PersistanceContext)
+  const dataExists = !!result?.parsed
 
   const updateChildResults = useCallback(
     update => {
@@ -206,8 +207,13 @@ const WrappedOptions: FC = () => {
     [setStatus, setResult]
   )
 
+  if (!dataExists) {
+    return null
+  }
+
   const subQueryOptions =
-    resource?.language === LanguageType.SQL ? (
+    resource?.language === LanguageType.SQL &&
+    view.state == ViewStateType.Graph ? (
       <SqlViewOptions
         selectViewOptions={selectViewOptions}
         allViewOptions={viewOptions}
@@ -231,7 +237,7 @@ const GraphHeader: FC = () => {
   const {view, setView, viewOptions} = useContext(ResultsViewContext)
   const {result} = useContext(ResultsContext)
   const {result: subQueryResult} = useContext(ChildResultsContext)
-  const {launch} = useContext(SidebarContext)
+  const {launch, clear: closeSidebar} = useContext(SidebarContext)
 
   const dataExists = !!result?.parsed
 
@@ -243,6 +249,11 @@ const GraphHeader: FC = () => {
       launcher()
     }
   }, [viewOptions])
+  useEffect(() => {
+    if (!dataExists) {
+      closeSidebar()
+    }
+  }, [dataExists])
 
   const updateType = viewType => {
     setView({

--- a/src/dataExplorer/components/Results.tsx
+++ b/src/dataExplorer/components/Results.tsx
@@ -9,7 +9,17 @@ import {
   ComponentColor,
 } from '@influxdata/clockface'
 
-import {RemoteDataState, SimpleTableViewProperties} from 'src/types'
+// Components
+import {SearchWidget} from 'src/shared/components/search_widget/SearchWidget'
+import {
+  View,
+  ViewTypeDropdown,
+  ViewOptions,
+  SUPPORTED_VISUALIZATIONS,
+} from 'src/visualization'
+import {SqlViewOptions} from 'src/dataExplorer/components/SqlViewOptions'
+
+// Contexts
 import {ResultsContext} from 'src/dataExplorer/context/results'
 import {
   ResultsViewContext,
@@ -18,17 +28,16 @@ import {
 import {ChildResultsContext} from 'src/dataExplorer/context/results/childResults'
 import {SidebarContext} from 'src/dataExplorer/context/sidebar'
 import {PersistanceContext} from 'src/dataExplorer/context/persistance'
-import {SearchWidget} from 'src/shared/components/search_widget/SearchWidget'
-import {
-  View,
-  ViewTypeDropdown,
-  ViewOptions,
-  SUPPORTED_VISUALIZATIONS,
-} from 'src/visualization'
+
+// Types
 import {FluxResult} from 'src/types/flows'
+import {RemoteDataState, SimpleTableViewProperties} from 'src/types'
+
+// Utils
+import {bytesFormatter} from 'src/shared/copy/notifications'
 
 import './Results.scss'
-import {bytesFormatter} from 'src/shared/copy/notifications'
+import {LanguageType} from './resources'
 
 const QueryStat: FC = () => {
   const {result} = useContext(ResultsContext)
@@ -169,7 +178,9 @@ const WrappedOptions: FC = () => {
   // use parent `results` so all metadata is present for the viz options
   const {result} = useContext(ResultsContext)
   const {setResult, setStatus} = useContext(ChildResultsContext)
-  const {view, setView /* setViewOptions*/} = useContext(ResultsViewContext)
+  const {view, setView, selectViewOptions, viewOptions, selectedViewOptions} =
+    useContext(ResultsViewContext)
+  const {resource} = useContext(PersistanceContext)
 
   const updateChildResults = useCallback(
     update => {
@@ -184,8 +195,14 @@ const WrappedOptions: FC = () => {
     [setStatus, setResult]
   )
 
-  // TODO: make component with `update={setViewOptions}`, for QxBuilder-specific graph subquery options
-  const subQueryOptions = null
+  const subQueryOptions =
+    resource?.language === LanguageType.SQL ? (
+      <SqlViewOptions
+        selectViewOptions={selectViewOptions}
+        allViewOptions={viewOptions}
+        selectedViewOptions={selectedViewOptions}
+      />
+    ) : null
 
   return (
     <>

--- a/src/dataExplorer/components/Results.tsx
+++ b/src/dataExplorer/components/Results.tsx
@@ -7,6 +7,8 @@ import {
   IconFont,
   ComponentStatus,
   ComponentColor,
+  SpinnerContainer,
+  TechnoSpinner,
 } from '@influxdata/clockface'
 
 // Components
@@ -163,13 +165,15 @@ const GraphResults: FC = () => {
 
   return (
     <div className="data-explorer-results--view">
-      <View
-        loading={status}
-        properties={view.properties}
-        result={result?.parsed}
-        timeRange={range}
-        hideTimer
-      />
+      <SpinnerContainer loading={status} spinnerComponent={<TechnoSpinner />}>
+        <View
+          loading={status}
+          properties={view.properties}
+          result={result?.parsed}
+          timeRange={range}
+          hideTimer
+        />
+      </SpinnerContainer>
     </div>
   )
 }

--- a/src/dataExplorer/components/Results.tsx
+++ b/src/dataExplorer/components/Results.tsx
@@ -1,4 +1,11 @@
-import React, {FC, useState, useContext, useMemo, useCallback} from 'react'
+import React, {
+  FC,
+  useState,
+  useContext,
+  useMemo,
+  useCallback,
+  useEffect,
+} from 'react'
 import {
   FlexBox,
   FlexDirection,
@@ -221,14 +228,21 @@ const WrappedOptions: FC = () => {
 }
 
 const GraphHeader: FC = () => {
-  const {view, setView} = useContext(ResultsViewContext)
+  const {view, setView, viewOptions} = useContext(ResultsViewContext)
   const {result} = useContext(ResultsContext)
   const {result: subQueryResult} = useContext(ChildResultsContext)
   const {launch} = useContext(SidebarContext)
 
+  const dataExists = !!result?.parsed
+
   const launcher = () => {
     launch(<WrappedOptions />)
   }
+  useEffect(() => {
+    if (dataExists) {
+      launcher()
+    }
+  }, [viewOptions])
 
   const updateType = viewType => {
     setView({
@@ -237,7 +251,6 @@ const GraphHeader: FC = () => {
     })
   }
 
-  const dataExists = !!result?.parsed
   const subqueryReturnsData = !!subQueryResult?.parsed
   let titleText = 'Configure Visualization'
   if (!dataExists) {

--- a/src/dataExplorer/components/SaveAsScript.tsx
+++ b/src/dataExplorer/components/SaveAsScript.tsx
@@ -37,6 +37,7 @@ import {
   copyToClipboardFailed,
   copyToClipboardSuccess,
 } from 'src/shared/copy/notifications'
+import {ResultsViewContext} from 'src/dataExplorer/context/resultsView'
 interface Props {
   language: LanguageType
   onClose: () => void
@@ -52,6 +53,7 @@ const SaveAsScript: FC<Props> = ({language, onClose, setOverlayType, type}) => {
   const isIoxOrg = useSelector(isOrgIOx)
   const {cancel} = useContext(QueryContext)
   const {setStatus, setResult} = useContext(ResultsContext)
+  const {clear: clearViewOptions} = useContext(ResultsViewContext)
   const [error, setError] = useState<string>()
   // Setting the name to state rather than persisting it to session storage
   // so that we can cancel out of a name change if needed
@@ -96,6 +98,7 @@ const SaveAsScript: FC<Props> = ({language, onClose, setOverlayType, type}) => {
     cancel()
     setStatus(RemoteDataState.NotStarted)
     setResult(null)
+    clearViewOptions()
 
     if (isIoxOrg) {
       history.replace(

--- a/src/dataExplorer/components/ScriptQueryBuilder.tsx
+++ b/src/dataExplorer/components/ScriptQueryBuilder.tsx
@@ -21,7 +21,10 @@ import {QueryProvider} from 'src/shared/contexts/query'
 import {EditorProvider} from 'src/shared/contexts/editor'
 import {ResultsProvider, ResultsContext} from 'src/dataExplorer/context/results'
 import {ChildResultsProvider} from 'src/dataExplorer/context/results/childResults'
-import {ResultsViewProvider} from 'src/dataExplorer/context/resultsView'
+import {
+  ResultsViewProvider,
+  ResultsViewContext,
+} from 'src/dataExplorer/context/resultsView'
 import {SidebarProvider} from 'src/dataExplorer/context/sidebar'
 import {
   PersistanceProvider,
@@ -59,12 +62,14 @@ const ScriptQueryBuilder: FC = () => {
   const isIoxOrg = useSelector(isOrgIOx)
   const {cancel} = useContext(QueryContext)
   const {setStatus, setResult} = useContext(ResultsContext)
+  const {clear: clearViewOptions} = useContext(ResultsViewContext)
   const org = useSelector(getOrg)
 
   const handleClear = useCallback(() => {
     cancel()
     setStatus(RemoteDataState.NotStarted)
     setResult(null)
+    clearViewOptions()
 
     if (isIoxOrg) {
       history.replace(

--- a/src/dataExplorer/components/SqlViewOptions.scss
+++ b/src/dataExplorer/components/SqlViewOptions.scss
@@ -1,0 +1,11 @@
+@import '@influxdata/clockface/dist/variables.scss';
+
+.sql-view-options {
+  .cf-list {
+    flex: 1 0 !important;
+
+    .selector-list--item {
+      height: $cf-form-xs-height;
+    }
+  }
+}

--- a/src/dataExplorer/components/SqlViewOptions.tsx
+++ b/src/dataExplorer/components/SqlViewOptions.tsx
@@ -1,7 +1,8 @@
 import React, {FC} from 'react'
-import {Columns, Form, Grid} from '@influxdata/clockface'
+import {Columns, Grid} from '@influxdata/clockface'
 
 import SelectorList from 'src/timeMachine/components/SelectorList'
+import SelectorTitle from 'src/dataExplorer/components/SelectorTitle'
 import {ViewOptions} from 'src/dataExplorer/context/resultsView'
 
 import './SqlViewOptions.scss'
@@ -29,6 +30,24 @@ export const SqlViewOptions: FC<SqlViewOptionsT> = ({
     }
   }
 
+  const groupbyTooltipContents = (
+    <div>
+      <span>Select the GROUPBY used for the graph subquery.</span>
+      <br />
+      <br />
+      <span>
+        Options are based on returned data results (refer to your table
+        columns).
+      </span>
+      <br />
+      <br />
+      <span>
+        By default, the GROUPBY is done on all tagKeys in order to produce a
+        dataseries.
+      </span>
+    </div>
+  )
+
   return (
     <div className="view-options sql-view-options">
       <Grid>
@@ -40,16 +59,16 @@ export const SqlViewOptions: FC<SqlViewOptionsT> = ({
             className="view-options-container"
           >
             <h5 className="view-options--header">Query Modifier</h5>
-            <Form.Element label="Dataseries Grouping">
-              <SelectorList
-                items={allViewOptions?.groupby ?? []}
-                selectedItems={selectedViewOptions?.groupby ?? []}
-                onSelectItem={tagKey =>
-                  handleSelectedListItem('groupby', tagKey)
-                }
-                multiSelect={true}
-              />
-            </Form.Element>
+            <SelectorTitle
+              label="Grouping"
+              tooltipContents={groupbyTooltipContents}
+            />
+            <SelectorList
+              items={allViewOptions?.groupby ?? []}
+              selectedItems={selectedViewOptions?.groupby ?? []}
+              onSelectItem={tagKey => handleSelectedListItem('groupby', tagKey)}
+              multiSelect={true}
+            />
           </Grid.Column>
         </Grid.Row>
       </Grid>

--- a/src/dataExplorer/components/SqlViewOptions.tsx
+++ b/src/dataExplorer/components/SqlViewOptions.tsx
@@ -1,0 +1,58 @@
+import React, {FC} from 'react'
+import {Columns, Form, Grid} from '@influxdata/clockface'
+
+import SelectorList from 'src/timeMachine/components/SelectorList'
+import {ViewOptions} from 'src/dataExplorer/context/resultsView'
+
+import './SqlViewOptions.scss'
+
+interface SqlViewOptionsT {
+  selectViewOptions: (_: Partial<ViewOptions>) => void
+  allViewOptions: ViewOptions
+  selectedViewOptions: ViewOptions
+}
+
+export const SqlViewOptions: FC<SqlViewOptionsT> = ({
+  selectViewOptions,
+  allViewOptions,
+  selectedViewOptions,
+}) => {
+  const handleSelectedListItem = (propKey, value) => {
+    if ((selectedViewOptions[propKey] ?? []).includes(value)) {
+      selectViewOptions({
+        [propKey]: selectedViewOptions[propKey].filter(v => v !== value),
+      })
+    } else {
+      selectViewOptions({
+        [propKey]: (selectedViewOptions[propKey] ?? []).concat([value]),
+      })
+    }
+  }
+
+  return (
+    <div className="view-options sql-view-options">
+      <Grid>
+        <Grid.Row>
+          <Grid.Column
+            widthXS={Columns.Twelve}
+            widthMD={Columns.Six}
+            widthLG={Columns.Four}
+            className="view-options-container"
+          >
+            <h5 className="view-options--header">Query Modifier</h5>
+            <Form.Element label="Dataseries Grouping">
+              <SelectorList
+                items={allViewOptions?.groupby ?? []}
+                selectedItems={selectedViewOptions?.groupby ?? []}
+                onSelectItem={tagKey =>
+                  handleSelectedListItem('groupby', tagKey)
+                }
+                multiSelect={true}
+              />
+            </Form.Element>
+          </Grid.Column>
+        </Grid.Row>
+      </Grid>
+    </div>
+  )
+}

--- a/src/dataExplorer/context/results/childResults.tsx
+++ b/src/dataExplorer/context/results/childResults.tsx
@@ -95,6 +95,11 @@ export const ChildResultsProvider: FC = ({children}) => {
       return
     }
 
+    const cannotRunIoxSqlMethod = !selection?.bucket
+    if (cannotRunIoxSqlMethod) {
+      return
+    }
+
     const sqlQueryModifiers = modifiersToApply(viewOptions)
     const previousQueryModifiers = queryModifers
     setQueryModifiers(sqlQueryModifiers)

--- a/src/dataExplorer/context/resultsView.tsx
+++ b/src/dataExplorer/context/resultsView.tsx
@@ -35,6 +35,7 @@ interface ResultsViewContextType {
   setView: (view: View) => void
   setDefaultViewOptions: (viewOptions: Partial<ViewOptions>) => void
   selectViewOptions: (viewOptions: Partial<ViewOptions>) => void
+  clear: () => void
 }
 
 const DEFAULT_VIEW_OPTIONS = {groupby: []}
@@ -50,6 +51,7 @@ const DEFAULT_STATE: ResultsViewContextType = {
   setView: _ => {},
   setDefaultViewOptions: _ => {},
   selectViewOptions: _ => {},
+  clear: () => {},
 }
 
 export const ResultsViewContext =
@@ -66,40 +68,46 @@ export const ResultsViewProvider: FC = ({children}) => {
   })
 
   // what can be chosen (e.g. the list of all options)
-  const [viewOptionsAll, saveViewOptionsAll] = useSessionStorage(
+  const [viewOptionsAll, persistViewOptionsAll] = useSessionStorage(
     'dataExplorer.resultsOptions.all',
     DEFAULT_VIEW_OPTIONS
   )
   const setViewOptionsAll = useCallback(
     (updatedOptions: Partial<ViewOptions>) => {
-      saveViewOptionsAll({...viewOptionsAll, ...updatedOptions})
+      persistViewOptionsAll({...viewOptionsAll, ...updatedOptions})
     },
     [viewOptionsAll]
   )
 
   // default options (a.k.a. based on schema)
-  const [defaultViewOptions, saveDefaultViewOptions] = useSessionStorage(
+  const [defaultViewOptions, persistDefaultViewOptions] = useSessionStorage(
     'dataExplorer.resultsOptions.default',
     DEFAULT_VIEW_OPTIONS
   )
   const setDefaultViewOptions = useCallback(
     (updatedOptions: Partial<ViewOptions>) => {
-      saveDefaultViewOptions({...defaultViewOptions, ...updatedOptions})
+      persistDefaultViewOptions({...defaultViewOptions, ...updatedOptions})
     },
     [defaultViewOptions]
   )
 
   // what was chosen (e.g. sublist chosen)
-  const [selectedViewOptions, saveSelectedViewOptions] = useSessionStorage(
+  const [selectedViewOptions, persistSelectedViewOptions] = useSessionStorage(
     'dataExplorer.resultsOptions',
     DEFAULT_VIEW_OPTIONS
   )
   const selectViewOptions = useCallback(
     (updatedOptions: Partial<ViewOptions>) => {
-      saveSelectedViewOptions({...selectedViewOptions, ...updatedOptions})
+      persistSelectedViewOptions({...selectedViewOptions, ...updatedOptions})
     },
     [selectedViewOptions]
   )
+
+  const clear = () => {
+    persistViewOptionsAll(DEFAULT_VIEW_OPTIONS)
+    persistDefaultViewOptions(DEFAULT_VIEW_OPTIONS)
+    persistSelectedViewOptions(DEFAULT_VIEW_OPTIONS)
+  }
 
   useEffect(() => {
     // if parent query is re-run => decide what to reset in subquery viewOptions
@@ -126,6 +134,7 @@ export const ResultsViewProvider: FC = ({children}) => {
         setView,
         setDefaultViewOptions,
         selectViewOptions,
+        clear,
       }}
     >
       {children}

--- a/src/dataExplorer/context/resultsView.tsx
+++ b/src/dataExplorer/context/resultsView.tsx
@@ -108,10 +108,10 @@ export const ResultsViewProvider: FC = ({children}) => {
     const excludeFromGroupby = NOT_PERMITTED_GROUPBY
     const groupby = Object.keys(
       resultFromParent?.parsed?.table?.columns || {}
-    ).filter(g => !excludeFromGroupby.includes(g))
+    ).filter(columnName => !excludeFromGroupby.includes(columnName))
     setViewOptionsAll({groupby})
-    const defaultsWhichExist = defaultViewOptions.groupby.filter(g =>
-      groupby.includes(g)
+    const defaultsWhichExist = defaultViewOptions.groupby.filter(defaultGroup =>
+      groupby.includes(defaultGroup)
     )
     selectViewOptions({groupby: defaultsWhichExist})
   }, [resultFromParent, defaultViewOptions])

--- a/src/dataExplorer/context/tags.tsx
+++ b/src/dataExplorer/context/tags.tsx
@@ -58,7 +58,7 @@ interface Prop {
 export const TagsProvider: FC<Prop> = ({children, scope}) => {
   // Contexts
   const {query: queryAPI} = useContext(QueryContext)
-  const {setViewOptions, selectViewOptions} = useContext(ResultsViewContext)
+  const {setDefaultViewOptions} = useContext(ResultsViewContext)
 
   // States
   const [tags, setTags] = useState<Tags>(
@@ -134,8 +134,7 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
       setTags(newTags)
       setLoadingTagKeys(RemoteDataState.Done)
       setLoadingTagValues(tagValueStatuses)
-      setViewOptions({groupby: Object.keys(newTags)})
-      selectViewOptions({groupby: Object.keys(newTags)}) // groupby all tagKeys, as default
+      setDefaultViewOptions({groupby: Object.keys(newTags)})
     } catch (e) {
       console.error(
         `Failed to get tags for measurement: "${measurement}"\n`,

--- a/src/dataExplorer/context/tags.tsx
+++ b/src/dataExplorer/context/tags.tsx
@@ -58,7 +58,7 @@ interface Prop {
 export const TagsProvider: FC<Prop> = ({children, scope}) => {
   // Contexts
   const {query: queryAPI} = useContext(QueryContext)
-  const {setViewOptions} = useContext(ResultsViewContext)
+  const {setViewOptions, selectViewOptions} = useContext(ResultsViewContext)
 
   // States
   const [tags, setTags] = useState<Tags>(
@@ -135,6 +135,7 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
       setLoadingTagKeys(RemoteDataState.Done)
       setLoadingTagValues(tagValueStatuses)
       setViewOptions({groupby: Object.keys(newTags)})
+      selectViewOptions({groupby: Object.keys(newTags)}) // groupby all tagKeys, as default
     } catch (e) {
       console.error(
         `Failed to get tags for measurement: "${measurement}"\n`,

--- a/src/dataExplorer/context/tags.tsx
+++ b/src/dataExplorer/context/tags.tsx
@@ -11,6 +11,7 @@ import {DEFAULT_LIMIT} from 'src/shared/constants/queryBuilder'
 
 // Contexts
 import {QueryContext, QueryScope} from 'src/shared/contexts/query'
+import {ResultsViewContext} from 'src/dataExplorer/context/resultsView'
 
 // Utils
 import {
@@ -57,6 +58,7 @@ interface Prop {
 export const TagsProvider: FC<Prop> = ({children, scope}) => {
   // Contexts
   const {query: queryAPI} = useContext(QueryContext)
+  const {setViewOptions} = useContext(ResultsViewContext)
 
   // States
   const [tags, setTags] = useState<Tags>(
@@ -132,6 +134,7 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
       setTags(newTags)
       setLoadingTagKeys(RemoteDataState.Done)
       setLoadingTagValues(tagValueStatuses)
+      setViewOptions({groupby: Object.keys(newTags)})
     } catch (e) {
       console.error(
         `Failed to get tags for measurement: "${measurement}"\n`,


### PR DESCRIPTION
Part of #6482 
Closes #6496 
Closes #6503

Add ability to groupby tagKeys (a.k.a. into dataSeries) for SQL queries being graphed.

## Qx contract:
* how many queries (network calls) are run:
   * when I change by query viewOptions => re-run the query
   * if I change queryText => have no viewOptions => only 1 query with run (see network tab in vid)
   * if I change queryText => have viewOptions => 2 queries will run (one for table, one for graph)
* how are the groupby options chosen?
   * when produce results => use the table column headers for the groupby options
       * **THIS IS THE SAME CONTRACT** as displaying the table data. You have to re-run the query to produce results. 
   * set the default groupby, to be the tagKeys
        * once we choose the bucket & measurement => we can then know the tagKeys for the default

## Viz evidence: How many queries?

https://user-images.githubusercontent.com/10232835/213072458-f8997199-aa56-4bdd-8f45-2f909c467104.mov

## Viz Evidence: How groupby options chosen?


https://user-images.githubusercontent.com/10232835/213300460-51ccc49c-13e6-4b1c-8710-3aae7f03acd8.mov



## Checklist
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
