### PR TITLE
chore: fix cardinality messaging in line protocol provider

### DIFF
--- a/src/buckets/components/context/lineProtocol.tsx
+++ b/src/buckets/components/context/lineProtocol.tsx
@@ -7,7 +7,7 @@ import {postWrite} from 'src/client'
 import {getErrorMessage} from 'src/utils/api'
 
 // Selectors
-import {getOrg} from 'src/organizations/selectors'
+import {getOrg, isOrgIOx} from 'src/organizations/selectors'
 
 // Types
 import {RemoteDataState, LineProtocolTab, WritePrecision} from 'src/types'
@@ -55,6 +55,7 @@ export const LineProtocolProvider: FC<Props> = React.memo(({children}) => {
   const [writeError, setWriteError] = useState('')
 
   const org = useSelector(getOrg).name
+  const orgIsIOx = useSelector(isOrgIOx)
 
   const handleResetLineProtocol = () => {
     setBody('')
@@ -71,22 +72,6 @@ export const LineProtocolProvider: FC<Props> = React.memo(({children}) => {
    *  change in newest api (since the hash was last updated in 9/2021):
    *     * error 429 (too many requests) is in CLOUD and not in OSS
    *     * error 403 was removed, added error 404 (not found)
-   *
-   *  for error 429 which exists in only CLOUD:
-   *    doing the 'as any' cast away from the type because: safest way; this error code will never happen in OSS;
-   *    so the clause will never be activated, and the user still gets the proper error when in CLOUD.
-   *
-   *    other strategies not implemented here, with reasoning:
-   *
-   *    1) not removing the clause and drop down to the generic error
-   *          because then the user doesn't get a good error message
-   *    2) bad code smell: add it to oss for code purposes, knowing it will never be called
-   *    3) can't do an IF CLOUD b/c the code just ISN'T THERE; the type (PostWriteResult) exists in both
-   *       cloud and oss and is different in each environment
-   *
-   *       for local testing, need to check out the open api repo, make sure it is named "openapi" (the default name) and
-   *       is present in the same directory as the ui repo,
-   *       and then run "yarn generate-local" in the ui repo to generate the OSS (not the cloud) files.
    */
   const writeLineProtocol = useCallback(
     async (bucket: string) => {
@@ -102,7 +87,15 @@ export const LineProtocolProvider: FC<Props> = React.memo(({children}) => {
           // here is the cast:
         } else if ((resp.status as any) === 429) {
           setWriteStatus(RemoteDataState.Error)
-          setWriteError('Failed due to plan limits: read cardinality reached')
+          if (orgIsIOx) {
+            setWriteError(
+              'This request exceeded the read or write limits for your plan'
+            )
+          } else {
+            setWriteError(
+              'This request exceeded the read, write, or cardinality limits for your plan'
+            )
+          }
         } else if (resp.status === 404) {
           const error =
             getErrorMessage(resp) || 'Endpoint not Found; Failed to write data'
@@ -163,5 +156,3 @@ export const LineProtocolProvider: FC<Props> = React.memo(({children}) => {
     </LineProtocolContext.Provider>
   )
 })
-
-export default LineProtocolProvider

--- a/src/buckets/components/lineProtocol/configure/LineProtocolTabs.tsx
+++ b/src/buckets/components/lineProtocol/configure/LineProtocolTabs.tsx
@@ -5,13 +5,13 @@ import React, {useContext, FC} from 'react'
 import PrecisionDropdown from 'src/buckets/components/lineProtocol/configure/PrecisionDropdown'
 import TabSelector from 'src/buckets/components/lineProtocol/configure/TabSelector'
 import TabBody from 'src/buckets/components/lineProtocol/configure/TabBody'
-import StatusIndicator from 'src/buckets/components/lineProtocol/verify/StatusIndicator'
+import {StatusIndicator} from 'src/buckets/components/lineProtocol/verify/StatusIndicator'
 import {LineProtocolContext} from 'src/buckets/components/context/lineProtocol'
 
 // Types
 import {RemoteDataState} from 'src/types'
 
-const LineProtocolTabs: FC = () => {
+export const LineProtocolTabs: FC = () => {
   const {writeStatus} = useContext(LineProtocolContext)
 
   if (writeStatus !== RemoteDataState.NotStarted) {
@@ -28,5 +28,3 @@ const LineProtocolTabs: FC = () => {
     </>
   )
 }
-
-export default LineProtocolTabs

--- a/src/buckets/components/lineProtocol/verify/StatusIndicator.tsx
+++ b/src/buckets/components/lineProtocol/verify/StatusIndicator.tsx
@@ -40,9 +40,8 @@ const className = status =>
     error: status === RemoteDataState.Error,
   })
 
-const StatusIndicator: FC = () => {
+export const StatusIndicator: FC = () => {
   const {writeStatus, writeError} = useContext(LineProtocolContext)
-
   return (
     <div className="line-protocol--spinner">
       <p data-testid="line-protocol--status" className={className(status)}>
@@ -55,5 +54,3 @@ const StatusIndicator: FC = () => {
     </div>
   )
 }
-
-export default StatusIndicator

--- a/src/writeData/components/fileUploads/UploadDataDetailsView.tsx
+++ b/src/writeData/components/fileUploads/UploadDataDetailsView.tsx
@@ -12,7 +12,7 @@ import CodeSnippet, {
 } from 'src/shared/components/CodeSnippet'
 import GetResources from 'src/resources/components/GetResources'
 import CsvMethod from 'src/writeData/components/fileUploads/CsvMethod'
-import LineProtocolTabs from 'src/buckets/components/lineProtocol/configure/LineProtocolTabs'
+import {LineProtocolTabs} from 'src/buckets/components/lineProtocol/configure/LineProtocolTabs'
 import {MarkdownRenderer} from 'src/shared/components/views/MarkdownRenderer'
 
 // Constants

--- a/src/writeData/containers/FileUploadsPage.tsx
+++ b/src/writeData/containers/FileUploadsPage.tsx
@@ -3,7 +3,7 @@ import React, {FC} from 'react'
 
 // Components
 import UploadDataDetailsView from 'src/writeData/components/fileUploads/UploadDataDetailsView'
-import LineProtocolProvider from 'src/buckets/components/context/lineProtocol'
+import {LineProtocolProvider} from 'src/buckets/components/context/lineProtocol'
 
 const FileUploadsPage: FC = () => (
   <LineProtocolProvider>


### PR DESCRIPTION
Helps with AIM [7046](https://github.com/influxdata/quartz/issues/7046)

The line protocol context manages error messages that are shown when an attempt to upload a document in line-protocol format fails. One example is 'Failed due to plan limits: read cardinality reached' when the `postWrite` endpoint returns a `429` status code in Cloud2. 

IOx orgs don't have cardinality. But more broadly, the error message isn't right because the `429` from that endpoint isn't identifying a cardinality exceedance specifically. See the [openapi spec](https://github.com/influxdata/openapi/blob/master/src/common/paths/write.yml). The `429` is just a rate-limit code for exceeding plan limits. In TSM that can be read, write, or cardinality; in IOx, read or write. This makes the error messages reflect that.

Before (TSM or IOx)
--
![Screen Shot 2023-01-18 at 10 06 50 AM](https://user-images.githubusercontent.com/91283923/213208894-9a49e427-74e0-4c94-907f-81a5f9d2f78a.png)


After (IOx)
--
![Screen Shot 2023-01-18 at 10 13 57 AM](https://user-images.githubusercontent.com/91283923/213209169-ca099bb4-2160-45a0-a5b8-954806375e14.png)

After (TSM)
--
![Screen Shot 2023-01-18 at 10 20 53 AM](https://user-images.githubusercontent.com/91283923/213211432-0f1b8694-0b6b-47d3-888d-d85e24ed970c.png)



### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - NO
