### PR TITLE
feat(6482): show graph subquery to  user

### DIFF
--- a/src/dataExplorer/components/Results.tsx
+++ b/src/dataExplorer/components/Results.tsx
@@ -7,16 +7,16 @@ import React, {
   useState,
 } from 'react'
 import {
+  Button,
+  ComponentColor,
+  ComponentStatus,
   FlexBox,
   FlexDirection,
-  SelectGroup,
-  Button,
   IconFont,
-  ComponentStatus,
-  ComponentColor,
+  Overlay,
+  SelectGroup,
   SpinnerContainer,
   TechnoSpinner,
-  Overlay,
   TextArea,
 } from '@influxdata/clockface'
 

--- a/src/dataExplorer/components/SqlViewOptions.scss
+++ b/src/dataExplorer/components/SqlViewOptions.scss
@@ -8,4 +8,10 @@
       height: $cf-form-xs-height;
     }
   }
+  .sql-view-options--see-query {
+    padding-top: $cf-form-xs-height;
+    display: flex;
+    justify-content: center;
+    overflow: hidden;
+  }
 }

--- a/src/dataExplorer/components/SqlViewOptions.tsx
+++ b/src/dataExplorer/components/SqlViewOptions.tsx
@@ -1,5 +1,5 @@
 import React, {FC} from 'react'
-import {Columns, Grid} from '@influxdata/clockface'
+import {Columns, Grid, Button, ComponentStatus} from '@influxdata/clockface'
 
 import SelectorList from 'src/timeMachine/components/SelectorList'
 import SelectorTitle from 'src/dataExplorer/components/SelectorTitle'
@@ -11,12 +11,14 @@ interface SqlViewOptionsT {
   selectViewOptions: (_: Partial<ViewOptions>) => void
   allViewOptions: ViewOptions
   selectedViewOptions: ViewOptions
+  seeSubquery: () => void
 }
 
 export const SqlViewOptions: FC<SqlViewOptionsT> = ({
   selectViewOptions,
   allViewOptions,
   selectedViewOptions,
+  seeSubquery,
 }) => {
   const handleSelectedListItem = (propKey, value) => {
     if ((selectedViewOptions[propKey] ?? []).includes(value)) {
@@ -69,6 +71,18 @@ export const SqlViewOptions: FC<SqlViewOptionsT> = ({
               onSelectItem={tagKey => handleSelectedListItem('groupby', tagKey)}
               multiSelect={true}
             />
+            <div className="sql-view-options--see-query">
+              <Button
+                testID="sql-view-options--see-query"
+                text="View graph subquery"
+                status={
+                  !seeSubquery
+                    ? ComponentStatus.Disabled
+                    : ComponentStatus.Valid
+                }
+                onClick={seeSubquery}
+              />
+            </div>
           </Grid.Column>
         </Grid.Row>
       </Grid>

--- a/src/dataExplorer/context/results/childResults.tsx
+++ b/src/dataExplorer/context/results/childResults.tsx
@@ -49,6 +49,7 @@ const modifiersToApply = (viewOptions: ViewOptions): SqlQueryModifiers => {
 interface ChildResultsContextType {
   status: RemoteDataState
   result: FluxResult
+  readonly queryModifers: SqlQueryModifiers
 
   setStatus: (status: RemoteDataState) => void
   setResult: (result: FluxResult) => void
@@ -57,6 +58,7 @@ interface ChildResultsContextType {
 const DEFAULT_STATE: ChildResultsContextType = {
   status: RemoteDataState.NotStarted,
   result: {} as FluxResult,
+  queryModifers: {} as SqlQueryModifiers,
 
   setStatus: _ => {},
   setResult: _ => {},
@@ -141,6 +143,7 @@ export const ChildResultsProvider: FC = ({children}) => {
       value={{
         status,
         result,
+        queryModifers,
 
         setStatus,
         setResult,


### PR DESCRIPTION
Part of #6482 

Provide the ability to see the "magic" (a.k.a. the subquery) used to populate the graph data.
Place the subquery next to the options which populate the subquery.

Note: as per [this spike](https://github.com/influxdata/ui/issues/6085#issuecomment-1380974158), we decided to:
* keep the table data as the src of truth ("this is what your SQL returns")
* have the graph data be the explorer mode


## Viz:

https://user-images.githubusercontent.com/10232835/213326893-3d170fe0-4271-4b07-90f7-95b632634caa.mov



## Checklist
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
