### PR TITLE
feat(6482): Message separately if graph subquery hits limit

### DIFF
--- a/src/dataExplorer/components/Results.tsx
+++ b/src/dataExplorer/components/Results.tsx
@@ -299,6 +299,16 @@ const GraphHeader: FC = () => {
     titleText = 'Graph customization options returned no data'
   }
 
+  const GraphQueryStat = () => (
+    <div className="query-stat" data-testid="query-stat">
+      {subQueryResult?.truncated ? (
+        <span className="query-stat--bold">{`Max. display limit exceeded. Result truncated to ${bytesFormatter(
+          subQueryResult.bytes
+        )}.`}</span>
+      ) : null}
+    </div>
+  )
+
   return (
     <>
       <ViewTypeDropdown
@@ -315,6 +325,7 @@ const GraphHeader: FC = () => {
         titleText={titleText}
         className="de-config-visualization-button"
       />
+      <GraphQueryStat />
     </>
   )
 }

--- a/src/dataExplorer/components/SqlViewOptions.tsx
+++ b/src/dataExplorer/components/SqlViewOptions.tsx
@@ -41,6 +41,11 @@ export const SqlViewOptions: FC<SqlViewOptionsT> = ({
     }
   }
 
+  const handleSmoothingRangeSlider = event =>
+    selectViewOptions({
+      smoothing: {percentageRetained: parseInt(event.target.value)},
+    })
+
   const groupbyTooltipContents = (
     <div>
       <span>Select the GROUPBY used for the graph subquery.</span>
@@ -132,11 +137,7 @@ export const SqlViewOptions: FC<SqlViewOptionsT> = ({
               min={5}
               max={100}
               step={5}
-              onChange={event =>
-                selectViewOptions({
-                  smoothing: {percentageRetained: parseInt(event.target.value)},
-                })
-              }
+              onChange={handleSmoothingRangeSlider}
               labelPrefix="retained "
               labelSuffix="%"
             />

--- a/src/dataExplorer/components/SqlViewOptions.tsx
+++ b/src/dataExplorer/components/SqlViewOptions.tsx
@@ -5,6 +5,7 @@ import {
   ComponentStatus,
   FlexBox,
   Grid,
+  RangeSlider,
   SlideToggle,
 } from '@influxdata/clockface'
 
@@ -125,6 +126,19 @@ export const SqlViewOptions: FC<SqlViewOptionsT> = ({
               }
               multiSelect={false}
               disabled={!selectedViewOptions?.smoothing?.applied}
+            />
+            <RangeSlider
+              value={selectedViewOptions?.smoothing?.percentageRetained}
+              min={5}
+              max={100}
+              step={5}
+              onChange={event =>
+                selectViewOptions({
+                  smoothing: {percentageRetained: parseInt(event.target.value)},
+                })
+              }
+              labelPrefix="retained "
+              labelSuffix="%"
             />
             <div className="sql-view-options--see-query">
               <Button

--- a/src/dataExplorer/context/results/childResults.tsx
+++ b/src/dataExplorer/context/results/childResults.tsx
@@ -35,8 +35,16 @@ const modifiersToApply = (viewOptions: ViewOptions): SqlQueryModifiers => {
     viewOptions.smoothing?.columns?.length > 0 && viewOptions.smoothing?.applied
   if (shouldSmooth) {
     prepend.push(`import "experimental/polyline"`)
+    // will error if give 100.0 --> so instead do 99.9
+    const percentage = Number(
+      viewOptions.smoothing.percentageRetained ?? 50
+    ).toFixed(1)
     append.push(
-      `|> polyline.rdp(valColumn: "${viewOptions.smoothing.columns[0]}", timeColumn: "time")`
+      `|> polyline.rdp(
+        valColumn: "${viewOptions.smoothing.columns[0]}",
+        timeColumn: "${viewOptions.smoothing.timeColumn ?? 'time'}",
+        retention: ${percentage === '100.0' ? '99.9' : percentage}
+      )`
     )
   }
 

--- a/src/dataExplorer/context/resultsView.tsx
+++ b/src/dataExplorer/context/resultsView.tsx
@@ -8,16 +8,21 @@ import React, {
 } from 'react'
 import {useDispatch} from 'react-redux'
 
-import {useSessionStorage} from 'src/dataExplorer/shared/utils'
+// Components & Contexts
+import {SUPPORTED_VISUALIZATIONS} from 'src/visualization'
+import {ResultsContext} from 'src/dataExplorer/context/results'
+
+// Types & Constants
 import {
   RecursivePartial,
   SimpleTableViewProperties,
   ViewProperties,
 } from 'src/types'
-import {SUPPORTED_VISUALIZATIONS} from 'src/visualization'
-import {ResultsContext} from 'src/dataExplorer/context/results'
+
+// Utils
 import {notify} from 'src/shared/actions/notifications'
 import {trySmoothingData} from 'src/shared/copy/notifications'
+import {useSessionStorage} from 'src/dataExplorer/shared/utils'
 
 const DEFAULT_TIME_COLUMN = '_time' // unpivoted data
 const DEFAULT_DATA_COLUMN = '_value' // unpivoted data
@@ -48,6 +53,8 @@ export interface ViewOptions {
   smoothing: {
     columns: string[] // currently `|> polyling.rdp()` is applied to a single column, but is not a fundamental requirement
     applied: boolean
+    percentageRetained: number
+    timeColumn: string
   }
 }
 
@@ -76,7 +83,12 @@ interface ResultsViewContextType {
 
 const DEFAULT_VIEW_OPTIONS: ViewOptions = {
   groupby: [],
-  smoothing: {columns: [], applied: true},
+  smoothing: {
+    columns: [],
+    applied: true,
+    percentageRetained: 50,
+    timeColumn: 'time',
+  },
 }
 
 const DEFAULT_STATE: ResultsViewContextType = {
@@ -274,11 +286,12 @@ export const ResultsViewProvider: FC = ({children}) => {
     const numericColumns = getNumericSelectorColumns()
     // initial selection
     const defaultSmoothingColumn = defineDefaultUnpivotedColumn(numericColumns)
+    const timeColumn = defineTimeColumn()
 
     return {
       all: {smoothing: {columns: numericColumns}},
       selected: {
-        smoothing: {columns: [defaultSmoothingColumn]},
+        smoothing: {columns: [defaultSmoothingColumn], timeColumn},
       },
     }
   }


### PR DESCRIPTION
Part of #6482 

The table view tab shows the raw output of the SQL query.
The graph view tab shows the graph subquery, based on QueryModifiers chosen on the upper right sidebar.

In this PR, we add the ability to adjust the amount of data retained when using the data smoothing. Since the graph subquery is separate from the raw table query, we also implemented a separate message when the graph subquery had truncated data.


The net result:
The user can slide down to retain fewer data points (in the smoothing) --> resulting in the entire timespace being retained for all dataseries. (Versus the raw table data still being truncated.)


## DONE:
* add slider to data smoothing, such that can retain more vs less data points
* surface separate msg when data is truncated, based on the graph subquery
    * this is different than the table truncation message. 
Such that the user can see when adding more/less data points --> results in truncation of the graph subquery.



## Visual proof -- have separate truncation messages:
Table view shows full QueryStat (including table & row counts).
Graph view shows only the "truncated message".

https://user-images.githubusercontent.com/10232835/213330216-f1c87424-0729-4a22-ba57-e17785dea83a.mov


## Visual proof -- the slider adjusts the number of point retained, which impacts whether or not the truncation limit is hit:
(Note: this was done with artificially lowered data limits.)

https://user-images.githubusercontent.com/10232835/214391534-4698961e-69f2-47e4-a0e6-04790fceee06.mov





## Checklist
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
