### PR TITLE
chore: remove remaining refers to flux in the composition sync

### DIFF
--- a/src/dataExplorer/components/SchemaBrowserHeading.tsx
+++ b/src/dataExplorer/components/SchemaBrowserHeading.tsx
@@ -20,18 +20,23 @@ import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {LanguageType} from 'src/dataExplorer/components/resources'
 
 const SchemaBrowserHeading: FC = () => {
-  const {fluxSync, toggleFluxSync} = useContext(ScriptQueryBuilderContext)
+  const {compositionSync, toggleCompositionSync} = useContext(
+    ScriptQueryBuilderContext
+  )
   const {resource} = useContext(PersistanceContext)
 
-  const handleFluxSyncToggle = () => {
-    event('Toggled Flux Sync in schema browser', {active: `${!fluxSync}`})
-    toggleFluxSync(!fluxSync)
+  const handleCompositionSyncToggle = () => {
+    // Note: kept same event naming, so can compare across time. (Even though is Flux and SQL sync.)
+    event('Toggled Flux Sync in schema browser', {
+      active: `${!compositionSync}`,
+    })
+    toggleCompositionSync(!compositionSync)
   }
 
   const tooltipContents = (
     <div>
       <span>
-        Flux Sync autopopulates the script editor to help you start a query.
+        Sync autopopulates the script editor to help you start a query.
       </span>
       <br />
       <br />
@@ -58,8 +63,8 @@ const SchemaBrowserHeading: FC = () => {
       <FlexBox className="editor-sync">
         <SlideToggle
           className="editor-sync--toggle"
-          active={fluxSync}
-          onChange={handleFluxSyncToggle}
+          active={compositionSync}
+          onChange={handleCompositionSyncToggle}
           testID="editor-sync--toggle"
         />
         <InputLabel className="editor-sync--label">

--- a/src/dataExplorer/context/scriptQueryBuilder.tsx
+++ b/src/dataExplorer/context/scriptQueryBuilder.tsx
@@ -23,9 +23,9 @@ interface SelectedTagValues {
 }
 
 interface ScriptQueryBuilderContextType {
-  // Flux Sync
-  fluxSync: boolean
-  toggleFluxSync: (synced: boolean) => void
+  // Composition Sync
+  compositionSync: boolean
+  toggleCompositionSync: (synced: boolean) => void
 
   // Schema
   selectedBucket: Bucket
@@ -40,9 +40,9 @@ interface ScriptQueryBuilderContextType {
 }
 
 const DEFAULT_CONTEXT: ScriptQueryBuilderContextType = {
-  // Flux Sync
-  fluxSync: true,
-  toggleFluxSync: _s => {},
+  // Composition Sync
+  compositionSync: true,
+  toggleCompositionSync: _s => {},
 
   // Schema
   selectedBucket: null,
@@ -106,7 +106,7 @@ export const ScriptQueryBuilderProvider: FC = ({children}) => {
     setSelectedTagValues(transformSessionTagValuesToLocal(selection.tagValues))
   }, [selection.tagValues])
 
-  const handleToggleFluxSync = (synced: boolean): void => {
+  const handleCompositionFluxSync = (synced: boolean): void => {
     setSelection({composition: {synced}})
   }
 
@@ -199,9 +199,9 @@ export const ScriptQueryBuilderProvider: FC = ({children}) => {
     () => (
       <ScriptQueryBuilderContext.Provider
         value={{
-          // Flux Sync
-          fluxSync: selection.composition?.synced,
-          toggleFluxSync: handleToggleFluxSync,
+          // Composition Sync
+          compositionSync: selection.composition?.synced,
+          toggleCompositionSync: handleCompositionFluxSync,
 
           // Schema
           selectedBucket: selection.bucket,
@@ -219,7 +219,7 @@ export const ScriptQueryBuilderProvider: FC = ({children}) => {
       </ScriptQueryBuilderContext.Provider>
     ),
     [
-      // Flux Sync
+      // Composition Sync
       selection.composition?.synced,
 
       // Schema


### PR DESCRIPTION
A bit more cleanup.
Remove remaining references to "flux sync", in what is actually "composition sync".


## Checklist
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
