### PR TITLE
fix(csvMethod): update rate limit error msg for iox

### DIFF
--- a/src/alerting/utils/activity.ts
+++ b/src/alerting/utils/activity.ts
@@ -10,6 +10,7 @@ import {MONITORING_BUCKET} from 'src/alerting/constants'
 import {CancelBox, CheckIDsMap, StatusRow} from 'src/types'
 import {RunQueryResult} from 'src/shared/apis/query'
 import {LoadRowsOptions, Row} from 'src/types'
+import {RunQueryResponse} from 'src/types/queries'
 
 export const runAlertsActivityQuery = (
   orgID: string,
@@ -50,7 +51,7 @@ export const processResponse = ({
   cancel,
 }: CancelBox<RunQueryResult>): CancelBox<Row[]> => {
   const promise = queryPromise.then<Row[]>(resp => {
-    if (resp.type !== 'SUCCESS') {
+    if (resp.type !== RunQueryResponse.SUCCESS) {
       return Promise.reject(new Error(resp.message))
     }
 

--- a/src/alerting/utils/history.ts
+++ b/src/alerting/utils/history.ts
@@ -16,6 +16,7 @@ import {MONITORING_BUCKET} from 'src/alerting/constants'
 
 // Types
 import {State as EventViewerState} from 'src/eventViewer/components/EventViewer.reducer'
+import {RunQueryResponse} from 'src/types/queries'
 
 import {
   CancelBox,
@@ -145,7 +146,7 @@ export const processResponse = ({
   cancel,
 }: CancelBox<RunQueryResult>): CancelBox<Row[]> => {
   const promise = queryPromise.then<Row[]>(resp => {
-    if (resp.type !== 'SUCCESS') {
+    if (resp.type !== RunQueryResponse.SUCCESS) {
       return Promise.reject(new Error(resp.message))
     }
 

--- a/src/alerting/utils/statusEvents.ts
+++ b/src/alerting/utils/statusEvents.ts
@@ -8,8 +8,9 @@ import {MONITORING_BUCKET} from 'src/alerting/constants'
 
 // Types
 import {CancelBox, StatusRow, File} from 'src/types'
-import {RunQueryResult} from 'src/shared/apis/query'
 import {Row} from 'src/types'
+import {RunQueryResult} from 'src/shared/apis/query'
+import {RunQueryResponse} from 'src/types/queries'
 
 export const runStatusesQuery = (
   orgID: string,
@@ -46,7 +47,7 @@ export const processStatusesResponse = ({
   cancel,
 }: CancelBox<RunQueryResult>): CancelBox<Row[][]> => {
   const promise = queryPromise.then<Row[][]>(resp => {
-    if (resp.type !== 'SUCCESS') {
+    if (resp.type !== RunQueryResponse.SUCCESS) {
       return Promise.reject(new Error(resp.message))
     }
 

--- a/src/shared/components/TimeSeries.tsx
+++ b/src/shared/components/TimeSeries.tsx
@@ -45,6 +45,7 @@ import {
   CancelBox,
 } from 'src/types'
 import {event} from 'src/cloud/utils/reporting'
+import {RunQueryResponse} from 'src/types/queries'
 
 interface QueriesState {
   files: string[] | null
@@ -278,12 +279,12 @@ class TimeSeries extends Component<Props, State> {
       const duration = Date.now() - startTime
 
       for (const result of results) {
-        if (result.type === 'UNKNOWN_ERROR') {
+        if (result.type === RunQueryResponse.UNKNOWN_ERROR) {
           errorMessage = result.message
           throw new Error(result.message)
         }
 
-        if (result.type === 'RATE_LIMIT_ERROR') {
+        if (result.type === RunQueryResponse.RATE_LIMIT_ERROR) {
           errorMessage = result.message
           notify(rateLimitReached(result.retryAfter))
 

--- a/src/shared/utils/dataListening.ts
+++ b/src/shared/utils/dataListening.ts
@@ -1,5 +1,9 @@
+// Utils
 import {runQuery} from 'src/shared/apis/query'
 import {LoadingState} from 'src/shared/components/DataListening/ConnectionInformation'
+
+// Types
+import {RunQueryResponse} from 'src/types/queries'
 
 export const TIMEOUT_MILLISECONDS = 60000
 export const TIMER_WAIT = 1000
@@ -41,7 +45,7 @@ export const checkForData = async (orgID, bucket): Promise<LoadingState> => {
   try {
     const result = await runQuery(orgID, script).promise
 
-    if (result.type !== 'SUCCESS') {
+    if (result.type !== RunQueryResponse.SUCCESS) {
       throw new Error(result.message)
     }
 

--- a/src/timeMachine/apis/queryBuilder.ts
+++ b/src/timeMachine/apis/queryBuilder.ts
@@ -20,6 +20,7 @@ import {DEFAULT_LIMIT} from 'src/shared/constants/queryBuilder'
 import {TimeRange, BuilderConfig} from 'src/types'
 import {CancelBox} from 'src/types/promises'
 import {pastThirtyDaysTimeRange} from 'src/shared/constants/timeRanges'
+import {RunQueryResponse} from 'src/types/queries'
 
 const DEFAULT_TIME_RANGE: TimeRange = pastThirtyDaysTimeRange
 
@@ -155,7 +156,7 @@ export function extractBoxedCol(
   colName: string
 ): CancelBox<string[]> {
   const promise = resp.promise.then<string[]>(result => {
-    if (result.type !== 'SUCCESS') {
+    if (result.type !== RunQueryResponse.SUCCESS) {
       return Promise.reject(new Error(result.message))
     }
 

--- a/src/types/queries.ts
+++ b/src/types/queries.ts
@@ -49,3 +49,9 @@ export interface CustomTimeRange {
   upper: string
   type: 'custom'
 }
+
+export enum RunQueryResponse {
+  SUCCESS = 'SUCCESS',
+  RATE_LIMIT_ERROR = 'RATE_LIMIT_ERROR',
+  UNKNOWN_ERROR = 'UNKNOWN_ERROR',
+}

--- a/src/variables/utils/ValueFetcher.ts
+++ b/src/variables/utils/ValueFetcher.ts
@@ -16,6 +16,7 @@ import {
   Variable,
 } from 'src/types'
 import {CancelBox} from 'src/types/promises'
+import {RunQueryResponse} from 'src/types/queries'
 
 const cacheKey = (
   url: string,
@@ -104,7 +105,7 @@ export class DefaultValueFetcher implements ValueFetcher {
     event('runQuery', {context: 'variables'})
 
     const promise = request.promise.then(result => {
-      if (result.type !== 'SUCCESS') {
+      if (result.type !== RunQueryResponse.SUCCESS) {
         return Promise.reject(result.message)
       }
 

--- a/src/writeData/components/fileUploads/CsvMethod.tsx
+++ b/src/writeData/components/fileUploads/CsvMethod.tsx
@@ -32,6 +32,12 @@ import {notify} from 'src/shared/actions/notifications'
 // Types
 import {RemoteDataState} from 'src/types'
 
+enum Response {
+  SUCCESS = 'SUCCESS',
+  RATE_LIMIT_ERROR = 'RATE_LIMIT_ERROR',
+  UNKNOWN_ERROR = 'UNKNOWN_ERROR',
+}
+
 export const CsvMethod: FC = () => {
   const [uploadState, setUploadState] = useState(RemoteDataState.NotStarted)
   const [uploadError, setUploadError] = useState('')
@@ -97,11 +103,11 @@ export const CsvMethod: FC = () => {
           controller.current
         ).promise
 
-        if (resp.type === 'SUCCESS') {
+        if (resp.type === Response.SUCCESS) {
           setUploadState(RemoteDataState.Done)
           return
         }
-        if (resp.type === 'RATE_LIMIT_ERROR') {
+        if (resp.type === Response.RATE_LIMIT_ERROR) {
           setUploadState(RemoteDataState.Error)
           if (orgIsIOx) {
             setUploadError(
@@ -109,12 +115,12 @@ export const CsvMethod: FC = () => {
             )
           } else {
             setUploadError(
-              'Failed due to plan limits: read cardinality reached'
+              'Failed due to request exceeding read, write, or cardinality limits of plan'
             )
           }
           return
         }
-        if (resp.type === 'UNKNOWN_ERROR') {
+        if (resp.type === Response.UNKNOWN_ERROR) {
           const error = getErrorMessage(resp)
           throw new Error(error)
         }

--- a/src/writeData/components/fileUploads/CsvMethod.tsx
+++ b/src/writeData/components/fileUploads/CsvMethod.tsx
@@ -18,7 +18,7 @@ import StatusIndicator from 'src/buckets/components/csvUploader/StatusIndicator'
 // Utils
 import {event} from 'src/cloud/utils/reporting'
 import {getErrorMessage} from 'src/utils/api'
-import {getOrg} from 'src/organizations/selectors'
+import {getOrg, isOrgIOx} from 'src/organizations/selectors'
 import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
 import {runQuery} from 'src/shared/apis/query'
 
@@ -32,7 +32,7 @@ import {notify} from 'src/shared/actions/notifications'
 // Types
 import {RemoteDataState} from 'src/types'
 
-const CsvMethod: FC = () => {
+export const CsvMethod: FC = () => {
   const [uploadState, setUploadState] = useState(RemoteDataState.NotStarted)
   const [uploadError, setUploadError] = useState('')
 
@@ -40,6 +40,7 @@ const CsvMethod: FC = () => {
   const orgId = useSelector(getOrg)?.id
   const history = useHistory()
   const org = useSelector(getOrg)
+  const orgIsIOx = useSelector(isOrgIOx)
 
   const dispatch = useDispatch()
 
@@ -102,7 +103,13 @@ const CsvMethod: FC = () => {
         }
         if (resp.type === 'RATE_LIMIT_ERROR') {
           setUploadState(RemoteDataState.Error)
-          setUploadError('Failed due to plan limits: read cardinality reached')
+          if (orgIsIOx) {
+            setUploadError('Failed due to plan limits')
+          } else {
+            setUploadError(
+              'Failed due to plan limits: read cardinality reached'
+            )
+          }
           return
         }
         if (resp.type === 'UNKNOWN_ERROR') {
@@ -113,7 +120,7 @@ const CsvMethod: FC = () => {
         handleError(error)
       }
     },
-    [handleError, org?.id]
+    [handleError, org?.id, orgIsIOx]
   )
 
   const handleSeeUploadedData = () => {
@@ -173,5 +180,3 @@ const CsvMethod: FC = () => {
     </Panel>
   )
 }
-
-export default CsvMethod

--- a/src/writeData/components/fileUploads/CsvMethod.tsx
+++ b/src/writeData/components/fileUploads/CsvMethod.tsx
@@ -21,6 +21,7 @@ import {getErrorMessage} from 'src/utils/api'
 import {getOrg, isOrgIOx} from 'src/organizations/selectors'
 import {reportErrorThroughHoneyBadger} from 'src/shared/utils/errors'
 import {runQuery} from 'src/shared/apis/query'
+import {RunQueryResponse} from 'src/types/queries'
 
 // Selectors
 import {
@@ -31,12 +32,6 @@ import {notify} from 'src/shared/actions/notifications'
 
 // Types
 import {RemoteDataState} from 'src/types'
-
-enum Response {
-  SUCCESS = 'SUCCESS',
-  RATE_LIMIT_ERROR = 'RATE_LIMIT_ERROR',
-  UNKNOWN_ERROR = 'UNKNOWN_ERROR',
-}
 
 export const CsvMethod: FC = () => {
   const [uploadState, setUploadState] = useState(RemoteDataState.NotStarted)
@@ -103,11 +98,11 @@ export const CsvMethod: FC = () => {
           controller.current
         ).promise
 
-        if (resp.type === Response.SUCCESS) {
+        if (resp.type === RunQueryResponse.SUCCESS) {
           setUploadState(RemoteDataState.Done)
           return
         }
-        if (resp.type === Response.RATE_LIMIT_ERROR) {
+        if (resp.type === RunQueryResponse.RATE_LIMIT_ERROR) {
           setUploadState(RemoteDataState.Error)
           if (orgIsIOx) {
             setUploadError(
@@ -120,7 +115,7 @@ export const CsvMethod: FC = () => {
           }
           return
         }
-        if (resp.type === Response.UNKNOWN_ERROR) {
+        if (resp.type === RunQueryResponse.UNKNOWN_ERROR) {
           const error = getErrorMessage(resp)
           throw new Error(error)
         }

--- a/src/writeData/components/fileUploads/CsvMethod.tsx
+++ b/src/writeData/components/fileUploads/CsvMethod.tsx
@@ -104,7 +104,9 @@ export const CsvMethod: FC = () => {
         if (resp.type === 'RATE_LIMIT_ERROR') {
           setUploadState(RemoteDataState.Error)
           if (orgIsIOx) {
-            setUploadError('Failed due to plan limits')
+            setUploadError(
+              'Failed due to request exceeding read or write limits of plan'
+            )
           } else {
             setUploadError(
               'Failed due to plan limits: read cardinality reached'

--- a/src/writeData/components/fileUploads/UploadDataDetailsView.tsx
+++ b/src/writeData/components/fileUploads/UploadDataDetailsView.tsx
@@ -11,7 +11,7 @@ import CodeSnippet, {
   Provider as TemplateProvider,
 } from 'src/shared/components/CodeSnippet'
 import GetResources from 'src/resources/components/GetResources'
-import CsvMethod from 'src/writeData/components/fileUploads/CsvMethod'
+import {CsvMethod} from 'src/writeData/components/fileUploads/CsvMethod'
 import {LineProtocolTabs} from 'src/buckets/components/lineProtocol/configure/LineProtocolTabs'
 import {MarkdownRenderer} from 'src/shared/components/views/MarkdownRenderer'
 


### PR DESCRIPTION
Part of [#7046](https://github.com/influxdata/quartz/issues/7046)

Pr removes cardinality reference inside CsvMethod component for IOx orgs and refactors files calling `runQuery` endpoint to use a predefined set of response types. 


iox: 
<img width="1301" alt="Screen Shot 2023-01-20 at 9 22 30 AM" src="https://user-images.githubusercontent.com/66275100/213735023-fea32a51-2f32-4304-8d2a-e50a423dafea.png">

tsm: 
<img width="1490" alt="tsm" src="https://user-images.githubusercontent.com/66275100/213735005-422366be-5c07-4717-977a-9079f90bb1f5.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [ ] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [ ] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
