### PR TITLE
chore: wrap users provider around org profile tab

### DIFF
--- a/src/organizations/components/OrgProfileTab/index.tsx
+++ b/src/organizations/components/OrgProfileTab/index.tsx
@@ -20,7 +20,7 @@ import {orgDetailsFetchError} from 'src/shared/copy/notifications'
 import {notify} from 'src/shared/actions/notifications'
 
 // Providers
-import {UsersContext, UsersProvider} from 'src/users/context/users'
+import {UsersContext} from 'src/users/context/users'
 
 // Selectors
 import {getMe} from 'src/me/selectors'
@@ -174,12 +174,10 @@ const OrgProfileTab: FC = () => {
           direction={FlexDirection.Row}
           stretchToFitWidth={true}
         >
-          <UsersProvider>
-            <>
-              {allowSelfRemoval && showLeaveOrgButton && <LeaveOrgButton />}
-              <DeletePanel />
-            </>
-          </UsersProvider>
+          <>
+            {allowSelfRemoval && showLeaveOrgButton && <LeaveOrgButton />}
+            <DeletePanel />
+          </>
         </FlexBox>
       )}
     </FlexBox>

--- a/src/organizations/containers/OrgProfilePage.tsx
+++ b/src/organizations/containers/OrgProfilePage.tsx
@@ -9,6 +9,12 @@ import OrgHeader from 'src/organizations/components/OrgHeader'
 import OrgProfileTab from 'src/organizations/components/OrgProfileTab'
 import RenameOrgOverlay from 'src/organizations/components/RenameOrgOverlay'
 
+// Constants
+import {CLOUD} from 'src/shared/constants'
+
+// Context Providers
+import {UsersProvider} from 'src/users/context/users'
+
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 
@@ -18,7 +24,13 @@ const OrgProfilePage: FC = () => {
       <Page titleTag={pageTitleSuffixer(['Settings', 'Organization'])}>
         <OrgHeader testID="about-page--header" />
         <OrgTabbedPage activeTab="about">
-          <OrgProfileTab />
+          {CLOUD ? (
+            <UsersProvider>
+              <OrgProfileTab />
+            </UsersProvider>
+          ) : (
+            <OrgProfileTab />
+          )}
         </OrgTabbedPage>
       </Page>
       <Switch>


### PR DESCRIPTION
Closes #6511

Resolves issue with org profile tab where "leave org" button doesn't appear to allow user to leave org with other users in it.

The UsersProvider needs to be moved up a level, from within the Org Profile Tab to above the Org Profile Tab to ensure it's possible for the "leave org" button to display.

Before
--
![Screen Shot 2023-01-19 at 5 22 39 PM](https://user-images.githubusercontent.com/91283923/213575859-cd23839f-d8dc-4089-bece-72219e3577c4.png)


After
--
![Screen Shot 2023-01-19 at 5 22 56 PM](https://user-images.githubusercontent.com/91283923/213575867-6bf4f7f1-875e-4029-acf1-3f02229b4961.png)



### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - `multiOrg`
