### PR TITLE
feat(ui): Add Python SQL onboarding for IOx

### DIFF
--- a/cypress/e2e/cloud/userAccounts.test.ts
+++ b/cypress/e2e/cloud/userAccounts.test.ts
@@ -186,17 +186,17 @@ describe('Free account Deletion', () => {
     cy.url().should('include', `/members`)
   }
 
-  it('allows the user to delete a free account if there is only one org, with only one user', () => {
+  it('allows the user to delete a free account with multiple orgs', () => {
     setupTest({
       accountType: 'free',
       orgHasOtherUsers: false,
-      orgCount: 1,
+      orgCount: 3,
     })
 
     deleteFreeAccount()
   })
 
-  it('displays a `must remove users` warning if trying to delete a free account with a single org, which has multiple users', () => {
+  it('displays a `must remove users` warning when user attempts to delete a free account from an org with multiple users', () => {
     setupTest({
       accountType: 'free',
       orgHasOtherUsers: true,

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "cy": "CYPRESS_dexUrl=https://$INGRESS_HOST:$PORT_HTTPS CYPRESS_baseUrl=http://localhost:9999 cypress open",
     "cy:dev": "source ../monitor-ci/.env && CYPRESS_dexUrl=CLOUD CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{cloud,shared}/**/*.*'",
     "cy:dev-oss": "source ../monitor-ci/.env && CYPRESS_dexUrl=OSS CYPRESS_baseUrl=https://$INGRESS_HOST:$PORT_HTTPS cypress open --config testFiles='{oss,shared}/**/*.*'",
-    "generate": "export SHA=19b89d0e168edb6a27f801c6161f89ead6600401 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
+    "generate": "export SHA=689356a1c8e3dbd4e6ff6783cf81cbb720f8e64a && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-local-cloud": "export REMOTE=../openapi/ && yarn generate-meta-cloud",
     "generate-meta": "if [ -z \"${CLOUD_URL}\" ]; then yarn generate-meta-oss; else yarn generate-meta-cloud; fi",

--- a/src/accounts/AccountPage.tsx
+++ b/src/accounts/AccountPage.tsx
@@ -51,7 +51,7 @@ const AccountAboutPage: FC = () => {
     setActiveAcctName(activeAccount?.name)
   }, [activeAccount])
 
-  const {user, account} = useSelector(selectCurrentIdentity)
+  const {account} = useSelector(selectCurrentIdentity)
 
   const updateAcctName = (evt: ChangeEvent<HTMLInputElement>) => {
     setActiveAcctName(evt.target.value)
@@ -60,8 +60,7 @@ const AccountAboutPage: FC = () => {
   const onRenameAccountBtnClick = () => {
     handleRenameActiveAccount(activeAccount.id, activeAcctName)
   }
-  const shouldShowDeleteFreeAccountButton =
-    CLOUD && account.type === 'free' && user.orgCount === 1
+  const shouldShowDeleteFreeAccountButton = CLOUD && account.type === 'free'
 
   const showLeaveOrgButton = !isFlagEnabled('createDeleteOrgs')
   const allowSelfRemoval = users.length > 1
@@ -105,9 +104,8 @@ const AccountAboutPage: FC = () => {
 }
 
 const AccountPage: FC = () => {
-  const {account, user} = useSelector(selectCurrentIdentity)
-  const freeAccountWithOneOrg =
-    CLOUD && account.type === 'free' && user.orgCount === 1
+  const {account} = useSelector(selectCurrentIdentity)
+  const freeAccount = CLOUD && account.type === 'free'
 
   return (
     <>
@@ -118,7 +116,7 @@ const AccountPage: FC = () => {
         </UsersProvider>
       </Page>
       <Switch>
-        {freeAccountWithOneOrg && (
+        {freeAccount && (
           <DeleteFreeAccountProvider>
             <Route
               path="/orgs/:orgID/accounts/settings/delete"

--- a/src/billing/components/PayAsYouGo/CancelServiceContext.tsx
+++ b/src/billing/components/PayAsYouGo/CancelServiceContext.tsx
@@ -5,16 +5,16 @@ interface Props {
   children: ReactChild
 }
 
-export enum VariableItems {
-  NO_OPTION = '----',
-  USE_CASE_DIFFERENT = "It doesn't work for my use case",
-  SWITCHING_ORGANIZATION = 'I want to join my account to another organization',
+export enum CancelationReasons {
   ALTERNATIVE_PRODUCT = 'I found an alternative product',
+  NONE = '----',
   RE_SIGNUP = 'I want to sign up for a new account using a marketplace option',
+  SWITCHING_ORGANIZATION = 'I want to join my account to another organization',
   TOO_EXPENSIVE = 'It’s too expensive',
-  USABILITY_ISSUE = 'I found Flux hard to use',
-  UNSTABLE_PLATFORM = 'Platform isn’t stable enough',
   UNSUPPORTED_HIGH_CARDINALITY = 'Platform doesn’t support my high Cardinality',
+  UNSTABLE_PLATFORM = 'Platform isn’t stable enough',
+  USABILITY_ISSUE = 'I found Flux hard to use',
+  USE_CASE_DIFFERENT = "It doesn't work for my use case",
   OTHER_REASON = 'Other reason',
 }
 
@@ -23,6 +23,13 @@ const RedirectLocations = {
   RE_SIGNUP: '/cancel',
 }
 const DEFAULT_REDIRECT_LOCATION = '/mkt_cancel'
+
+// Ensures that the default cancelation "reason" is always the key name for the "NONE" enum.
+const getDefaultCancelationReason = () => {
+  return Object.keys(CancelationReasons).filter(
+    reason => CancelationReasons[reason] === CancelationReasons.NONE
+  )[0]
+}
 
 export interface CancelServiceContextType {
   shortSuggestion: string
@@ -45,7 +52,7 @@ export const DEFAULT_CANCEL_SERVICE_CONTEXT: CancelServiceContextType = {
   setShortSuggestion: (_: string) => null,
   suggestions: '',
   setSuggestions: (_: string) => null,
-  reason: 'NO_OPTION',
+  reason: getDefaultCancelationReason(),
   setReason: (_: string) => null,
   canContactForFeedback: false,
   toggleCanContactForFeedback: () => null,
@@ -56,7 +63,7 @@ export const CancelServiceContext = createContext<CancelServiceContextType>(
   DEFAULT_CANCEL_SERVICE_CONTEXT
 )
 
-const CancelServiceProvider: FC<Props> = ({children}) => {
+export const CancelServiceProvider: FC<Props> = ({children}) => {
   const [shortSuggestion, setShortSuggestion] = useState(
     DEFAULT_CANCEL_SERVICE_CONTEXT.shortSuggestion
   )
@@ -101,5 +108,3 @@ const CancelServiceProvider: FC<Props> = ({children}) => {
     </CancelServiceContext.Provider>
   )
 }
-
-export default CancelServiceProvider

--- a/src/billing/components/PayAsYouGo/CancelServiceReasonsForm.tsx
+++ b/src/billing/components/PayAsYouGo/CancelServiceReasonsForm.tsx
@@ -1,5 +1,6 @@
 // Libraries
-import React, {useContext, useMemo} from 'react'
+import React, {FC, useContext, useMemo} from 'react'
+import {useSelector} from 'react-redux'
 
 // Components
 import {
@@ -17,31 +18,49 @@ import {
 } from '@influxdata/clockface'
 
 // Utilities
-import {CancelServiceContext, VariableItems} from './CancelServiceContext'
+import {
+  CancelServiceContext,
+  CancelationReasons,
+} from 'src/billing/components/PayAsYouGo/CancelServiceContext'
 
-// Types
+// Selectors
+import {isOrgIOx} from 'src/organizations/selectors'
 
-function CancelServiceReasonsForm() {
+export const CancelServiceReasonsForm: FC = () => {
   const {
-    shortSuggestion,
-    isShortSuggestionEnabled,
-    suggestions,
-    setShortSuggestionFlag,
-    setShortSuggestion,
-    setSuggestions,
-    reason,
-    setReason,
     canContactForFeedback,
+    isShortSuggestionEnabled,
+    reason,
+    shortSuggestion,
+    suggestions,
+    setReason,
+    setShortSuggestion,
+    setShortSuggestionFlag,
+    setSuggestions,
     toggleCanContactForFeedback,
   } = useContext(CancelServiceContext)
 
+  const orgIsIOx = useSelector(isOrgIOx)
+
+  const generateCancelationReasons = () => {
+    if (orgIsIOx) {
+      return Object.keys(CancelationReasons).filter(
+        reason =>
+          CancelationReasons[reason] !==
+          CancelationReasons.UNSUPPORTED_HIGH_CARDINALITY
+      )
+    }
+
+    return Object.keys(CancelationReasons)
+  }
+
   const isDropdownOptionValid = useMemo(() => {
-    return VariableItems[reason] !== VariableItems.NO_OPTION
+    return CancelationReasons[reason] !== CancelationReasons.NONE
   }, [reason])
 
-  const onChange = (selected: string) => {
+  const onSelectReason = (selected: string) => {
     const isAlternateProductSelected =
-      VariableItems[selected] === VariableItems.ALTERNATIVE_PRODUCT
+      CancelationReasons[selected] === CancelationReasons.ALTERNATIVE_PRODUCT
     if (!isAlternateProductSelected) {
       setShortSuggestion('')
     }
@@ -63,20 +82,20 @@ function CancelServiceReasonsForm() {
               onClick={onClick}
               testID="variable-type-dropdown--button"
             >
-              {VariableItems[reason]}
+              {CancelationReasons[reason]}
             </Dropdown.Button>
           )}
           menu={onCollapse => (
             <Dropdown.Menu onCollapse={onCollapse}>
-              {Object.keys(VariableItems).map(key => (
+              {generateCancelationReasons().map(reason => (
                 <Dropdown.Item
-                  key={key}
-                  id={key}
-                  value={key}
-                  onClick={onChange}
-                  testID={`variable-type-dropdown-${key}`}
+                  key={reason}
+                  id={reason}
+                  value={reason}
+                  onClick={onSelectReason}
+                  testID={`variable-type-dropdown-${reason}`}
                 >
-                  {VariableItems[key]}
+                  {CancelationReasons[reason]}
                 </Dropdown.Item>
               ))}
             </Dropdown.Menu>
@@ -140,5 +159,3 @@ function CancelServiceReasonsForm() {
     </div>
   )
 }
-
-export default CancelServiceReasonsForm

--- a/src/billing/components/PayAsYouGo/CancellationOverlay.tsx
+++ b/src/billing/components/PayAsYouGo/CancellationOverlay.tsx
@@ -1,35 +1,47 @@
 // Libraries
 import React, {FC, useContext, useMemo, useState} from 'react'
+import {useDispatch, useSelector} from 'react-redux'
+
 import {
-  Overlay,
   Alert,
+  Button,
   ComponentColor,
   ComponentSize,
-  IconFont,
-  Button,
   ComponentStatus,
+  IconFont,
+  Overlay,
 } from '@influxdata/clockface'
 
-// Components
-import TermsCancellationOverlay from 'src/billing/components/PayAsYouGo/TermsCancellationOverlay'
+// Overlays
 import ConfirmCancellationOverlay from 'src/billing/components/PayAsYouGo/ConfirmCancellationOverlay'
-import {CancelServiceContext, VariableItems} from './CancelServiceContext'
-import {track} from 'rudder-sdk-js'
-import {event} from 'src/cloud/utils/reporting'
-import {useDispatch, useSelector} from 'react-redux'
+import {TermsCancellationOverlay} from 'src/billing/components/PayAsYouGo/TermsCancellationOverlay'
+import {
+  CancelServiceContext,
+  CancelationReasons,
+} from 'src/billing/components/PayAsYouGo/CancelServiceContext'
+
+// Utils
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
-import {postSignout} from 'src/client'
-import {postCancel} from 'src/client/unityRoutes'
+import {event} from 'src/cloud/utils/reporting'
+import {track} from 'rudder-sdk-js'
 import {getErrorMessage} from 'src/utils/api'
+
+// APIs
+import {postCancel} from 'src/client/unityRoutes'
+import {postSignout} from 'src/client'
+
+// Selectors
+import {selectCurrentIdentity} from 'src/identity/selectors'
+
+// Notifications
 import {accountCancellationError} from 'src/shared/copy/notifications'
 import {notify} from 'src/shared/actions/notifications'
-import {selectCurrentIdentity} from 'src/identity/selectors'
 
 interface Props {
   onHideOverlay: () => void
 }
 
-const CancellationOverlay: FC<Props> = ({onHideOverlay}) => {
+export const CancellationOverlay: FC<Props> = ({onHideOverlay}) => {
   const [hasAgreedToTerms, setHasAgreedToTerms] = useState(false)
   const [hasClickedCancel, setHasClickedCancel] = useState(false)
   const {
@@ -72,7 +84,7 @@ const CancellationOverlay: FC<Props> = ({onHideOverlay}) => {
       email: user.email,
       alternativeProduct: shortSuggestion,
       suggestions,
-      reason: VariableItems[reason],
+      reason: CancelationReasons[reason],
       canContactForFeedback: canContactForFeedback ? 'true' : 'false',
     }
     event('CancelServiceExecuted Event', payload)
@@ -114,7 +126,9 @@ const CancellationOverlay: FC<Props> = ({onHideOverlay}) => {
     // Has Agreed to Terms & Conditions
     // as well as
     // Selected an option from the Reasons Dropdown
-    return hasAgreedToTerms && VariableItems[reason] !== VariableItems.NO_OPTION
+    return (
+      hasAgreedToTerms && CancelationReasons[reason] !== CancelationReasons.NONE
+    )
   }, [hasAgreedToTerms, reason])
 
   return (
@@ -158,5 +172,3 @@ const CancellationOverlay: FC<Props> = ({onHideOverlay}) => {
     </Overlay>
   )
 }
-
-export default CancellationOverlay

--- a/src/billing/components/PayAsYouGo/CancellationPanel.tsx
+++ b/src/billing/components/PayAsYouGo/CancellationPanel.tsx
@@ -1,5 +1,6 @@
 // Libraries
 import React, {FC, useState} from 'react'
+import {useSelector} from 'react-redux'
 import {
   Panel,
   ComponentSize,
@@ -9,14 +10,17 @@ import {
 import {track} from 'rudder-sdk-js'
 
 // Components
-import CancellationOverlay from 'src/billing/components/PayAsYouGo/CancellationOverlay'
+import {CancellationOverlay} from 'src/billing/components/PayAsYouGo/CancellationOverlay'
+
+// Selectors
+import {selectCurrentIdentity} from 'src/identity/selectors'
 
 // Utils
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
-import {useSelector} from 'react-redux'
-import {selectCurrentIdentity} from 'src/identity/selectors'
 import {event} from 'src/cloud/utils/reporting'
-import CancelServiceProvider from './CancelServiceContext'
+
+// Contexts
+import {CancelServiceProvider} from 'src/billing/components/PayAsYouGo/CancelServiceContext'
 
 const CancellationPanel: FC = () => {
   const [isOverlayVisible, setIsOverlayVisible] = useState(false)

--- a/src/billing/components/PayAsYouGo/TermsCancellationOverlay.tsx
+++ b/src/billing/components/PayAsYouGo/TermsCancellationOverlay.tsx
@@ -1,5 +1,5 @@
+// Libraries
 import React, {FC} from 'react'
-
 import {
   ComponentSize,
   FlexBox,
@@ -10,14 +10,16 @@ import {
   InputLabel,
   AlignItems,
 } from '@influxdata/clockface'
-import CancelServiceReasonsForm from './CancelServiceReasonsForm'
+
+// Components
+import {CancelServiceReasonsForm} from 'src/billing/components/PayAsYouGo/CancelServiceReasonsForm'
 
 interface Props {
   hasAgreedToTerms: boolean
   onAgreedToTerms: () => void
 }
 
-const TermsCancellationOverlay: FC<Props> = ({
+export const TermsCancellationOverlay: FC<Props> = ({
   hasAgreedToTerms,
   onAgreedToTerms,
 }) => (
@@ -73,5 +75,3 @@ const TermsCancellationOverlay: FC<Props> = ({
     </FlexBox>
   </div>
 )
-
-export default TermsCancellationOverlay

--- a/src/cloud/components/RateLimitAlert.tsx
+++ b/src/cloud/components/RateLimitAlert.tsx
@@ -16,10 +16,9 @@ import {
   IconFont,
   InfluxColors,
 } from '@influxdata/clockface'
-import {CardinalityLimitAlertContent} from 'src/cloud/components/CardinalityLimitAlertContent'
-import {CloudUpgradeButton} from 'src/shared/components/CloudUpgradeButton'
+
+// Overlays
 import {dismissOverlay, showOverlay} from 'src/overlays/actions/overlays'
-import {UpgradeContent} from 'src/cloud/components/CardinalityLimitAlertContent'
 
 // Utils
 import {
@@ -27,6 +26,11 @@ import {
   extractRateLimitStatus,
 } from 'src/cloud/utils/limits'
 import {event} from 'src/cloud/utils/reporting'
+
+// Components
+import {CardinalityLimitAlertContent} from 'src/cloud/components/CardinalityLimitAlertContent'
+import {CloudUpgradeButton} from 'src/shared/components/CloudUpgradeButton'
+import {UpgradeContent} from 'src/cloud/components/CardinalityLimitAlertContent'
 
 // Constants
 import {CLOUD} from 'src/shared/constants'

--- a/src/dataExplorer/components/DeleteScript.tsx
+++ b/src/dataExplorer/components/DeleteScript.tsx
@@ -12,6 +12,7 @@ import {ResultsContext} from 'src/dataExplorer/context/results'
 import {RemoteDataState} from 'src/types'
 import {QueryContext} from 'src/shared/contexts/query'
 import {SCRIPT_EDITOR_PARAMS} from 'src/dataExplorer/components/resources'
+import {ResultsViewContext} from 'src/dataExplorer/context/resultsView'
 
 let deleteScript
 
@@ -28,6 +29,7 @@ const DeleteScript: FC<Props> = ({onBack, onClose}) => {
   const {resource} = useContext(PersistanceContext)
   const {cancel} = useContext(QueryContext)
   const {setStatus, setResult} = useContext(ResultsContext)
+  const {clear: clearViewOptions} = useContext(ResultsViewContext)
   const history = useHistory()
   const dispatch = useDispatch()
   const org = useSelector(getOrg)
@@ -43,6 +45,7 @@ const DeleteScript: FC<Props> = ({onBack, onClose}) => {
 
         setStatus(RemoteDataState.NotStarted)
         setResult(null)
+        clearViewOptions()
         cancel()
         history.replace(
           `/orgs/${org.id}/data-explorer/from/script${SCRIPT_EDITOR_PARAMS}`

--- a/src/dataExplorer/components/Results.tsx
+++ b/src/dataExplorer/components/Results.tsx
@@ -1,4 +1,11 @@
-import React, {FC, useState, useContext, useMemo, useCallback} from 'react'
+import React, {
+  FC,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
 import {
   FlexBox,
   FlexDirection,
@@ -7,9 +14,21 @@ import {
   IconFont,
   ComponentStatus,
   ComponentColor,
+  SpinnerContainer,
+  TechnoSpinner,
 } from '@influxdata/clockface'
 
-import {RemoteDataState, SimpleTableViewProperties} from 'src/types'
+// Components
+import {SearchWidget} from 'src/shared/components/search_widget/SearchWidget'
+import {
+  View,
+  ViewTypeDropdown,
+  ViewOptions,
+  SUPPORTED_VISUALIZATIONS,
+} from 'src/visualization'
+import {SqlViewOptions} from 'src/dataExplorer/components/SqlViewOptions'
+
+// Contexts
 import {ResultsContext} from 'src/dataExplorer/context/results'
 import {
   ResultsViewContext,
@@ -18,17 +37,16 @@ import {
 import {ChildResultsContext} from 'src/dataExplorer/context/results/childResults'
 import {SidebarContext} from 'src/dataExplorer/context/sidebar'
 import {PersistanceContext} from 'src/dataExplorer/context/persistance'
-import {SearchWidget} from 'src/shared/components/search_widget/SearchWidget'
-import {
-  View,
-  ViewTypeDropdown,
-  ViewOptions,
-  SUPPORTED_VISUALIZATIONS,
-} from 'src/visualization'
+
+// Types
 import {FluxResult} from 'src/types/flows'
+import {RemoteDataState, SimpleTableViewProperties} from 'src/types'
+
+// Utils
+import {bytesFormatter} from 'src/shared/copy/notifications'
 
 import './Results.scss'
-import {bytesFormatter} from 'src/shared/copy/notifications'
+import {LanguageType} from './resources'
 
 const QueryStat: FC = () => {
   const {result} = useContext(ResultsContext)
@@ -154,13 +172,15 @@ const GraphResults: FC = () => {
 
   return (
     <div className="data-explorer-results--view">
-      <View
-        loading={status}
-        properties={view.properties}
-        result={result?.parsed}
-        timeRange={range}
-        hideTimer
-      />
+      <SpinnerContainer loading={status} spinnerComponent={<TechnoSpinner />}>
+        <View
+          loading={status}
+          properties={view.properties}
+          result={result?.parsed}
+          timeRange={range}
+          hideTimer
+        />
+      </SpinnerContainer>
     </div>
   )
 }
@@ -169,7 +189,10 @@ const WrappedOptions: FC = () => {
   // use parent `results` so all metadata is present for the viz options
   const {result} = useContext(ResultsContext)
   const {setResult, setStatus} = useContext(ChildResultsContext)
-  const {view, setView /* setViewOptions*/} = useContext(ResultsViewContext)
+  const {view, setView, selectViewOptions, viewOptions, selectedViewOptions} =
+    useContext(ResultsViewContext)
+  const {resource} = useContext(PersistanceContext)
+  const dataExists = !!result?.parsed
 
   const updateChildResults = useCallback(
     update => {
@@ -184,8 +207,19 @@ const WrappedOptions: FC = () => {
     [setStatus, setResult]
   )
 
-  // TODO: make component with `update={setViewOptions}`, for QxBuilder-specific graph subquery options
-  const subQueryOptions = null
+  if (!dataExists) {
+    return null
+  }
+
+  const subQueryOptions =
+    resource?.language === LanguageType.SQL &&
+    view.state == ViewStateType.Graph ? (
+      <SqlViewOptions
+        selectViewOptions={selectViewOptions}
+        allViewOptions={viewOptions}
+        selectedViewOptions={selectedViewOptions}
+      />
+    ) : null
 
   return (
     <>
@@ -200,14 +234,26 @@ const WrappedOptions: FC = () => {
 }
 
 const GraphHeader: FC = () => {
-  const {view, setView} = useContext(ResultsViewContext)
+  const {view, setView, viewOptions} = useContext(ResultsViewContext)
   const {result} = useContext(ResultsContext)
   const {result: subQueryResult} = useContext(ChildResultsContext)
-  const {launch} = useContext(SidebarContext)
+  const {launch, clear: closeSidebar} = useContext(SidebarContext)
+
+  const dataExists = !!result?.parsed
 
   const launcher = () => {
     launch(<WrappedOptions />)
   }
+  useEffect(() => {
+    if (dataExists) {
+      launcher()
+    }
+  }, [viewOptions])
+  useEffect(() => {
+    if (!dataExists) {
+      closeSidebar()
+    }
+  }, [dataExists])
 
   const updateType = viewType => {
     setView({
@@ -216,7 +262,6 @@ const GraphHeader: FC = () => {
     })
   }
 
-  const dataExists = !!result?.parsed
   const subqueryReturnsData = !!subQueryResult?.parsed
   let titleText = 'Configure Visualization'
   if (!dataExists) {

--- a/src/dataExplorer/components/Results.tsx
+++ b/src/dataExplorer/components/Results.tsx
@@ -7,15 +7,17 @@ import React, {
   useState,
 } from 'react'
 import {
+  Button,
+  ComponentColor,
+  ComponentStatus,
   FlexBox,
   FlexDirection,
-  SelectGroup,
-  Button,
   IconFont,
-  ComponentStatus,
-  ComponentColor,
+  Overlay,
+  SelectGroup,
   SpinnerContainer,
   TechnoSpinner,
+  TextArea,
 } from '@influxdata/clockface'
 
 // Components
@@ -44,6 +46,7 @@ import {RemoteDataState, SimpleTableViewProperties} from 'src/types'
 
 // Utils
 import {bytesFormatter} from 'src/shared/copy/notifications'
+import {sqlAsFlux} from 'src/shared/contexts/query/preprocessing'
 
 import './Results.scss'
 import {LanguageType} from './resources'
@@ -165,6 +168,22 @@ const TableResults: FC<{search: string}> = ({search}) => {
   )
 }
 
+const GraphSubQueryOverlay: FC<{text: string; onClose: () => void}> = ({
+  text,
+  onClose,
+}) => (
+  <Overlay.Container maxWidth={600}>
+    <Overlay.Header title="Subquery for graph data:" onDismiss={onClose} />
+    <Overlay.Body>
+      <TextArea
+        testID="data-explorer-results--graph-subquery"
+        value={text}
+        readOnly
+      />
+    </Overlay.Body>
+  </Overlay.Container>
+)
+
 const GraphResults: FC = () => {
   const {view} = useContext(ResultsViewContext)
   const {result, status} = useContext(ChildResultsContext)
@@ -186,13 +205,21 @@ const GraphResults: FC = () => {
 }
 
 const WrappedOptions: FC = () => {
+  const [showOverlay, setShowOverlay] = useState(false)
+
   // use parent `results` so all metadata is present for the viz options
   const {result} = useContext(ResultsContext)
-  const {setResult, setStatus} = useContext(ChildResultsContext)
+  const {queryModifers, setResult, setStatus} = useContext(ChildResultsContext)
   const {view, setView, selectViewOptions, viewOptions, selectedViewOptions} =
     useContext(ResultsViewContext)
-  const {resource} = useContext(PersistanceContext)
+  const {resource, query: text, selection} = useContext(PersistanceContext)
   const dataExists = !!result?.parsed
+
+  const subquery = useMemo(
+    () => sqlAsFlux(text, selection?.bucket, queryModifers),
+    [text, selection?.bucket, queryModifers]
+  )
+  const seeGraphSubquery = () => setShowOverlay(true)
 
   const updateChildResults = useCallback(
     update => {
@@ -218,11 +245,18 @@ const WrappedOptions: FC = () => {
         selectViewOptions={selectViewOptions}
         allViewOptions={viewOptions}
         selectedViewOptions={selectedViewOptions}
+        seeSubquery={selection?.bucket ? seeGraphSubquery : null}
       />
     ) : null
 
   return (
     <>
+      <Overlay visible={showOverlay}>
+        <GraphSubQueryOverlay
+          text={subquery}
+          onClose={() => setShowOverlay(false)}
+        />
+      </Overlay>
       {subQueryOptions}
       <ViewOptions
         properties={view.properties}

--- a/src/dataExplorer/components/SaveAsScript.tsx
+++ b/src/dataExplorer/components/SaveAsScript.tsx
@@ -37,6 +37,7 @@ import {
   copyToClipboardFailed,
   copyToClipboardSuccess,
 } from 'src/shared/copy/notifications'
+import {ResultsViewContext} from 'src/dataExplorer/context/resultsView'
 interface Props {
   language: LanguageType
   onClose: () => void
@@ -52,6 +53,7 @@ const SaveAsScript: FC<Props> = ({language, onClose, setOverlayType, type}) => {
   const isIoxOrg = useSelector(isOrgIOx)
   const {cancel} = useContext(QueryContext)
   const {setStatus, setResult} = useContext(ResultsContext)
+  const {clear: clearViewOptions} = useContext(ResultsViewContext)
   const [error, setError] = useState<string>()
   // Setting the name to state rather than persisting it to session storage
   // so that we can cancel out of a name change if needed
@@ -96,6 +98,7 @@ const SaveAsScript: FC<Props> = ({language, onClose, setOverlayType, type}) => {
     cancel()
     setStatus(RemoteDataState.NotStarted)
     setResult(null)
+    clearViewOptions()
 
     if (isIoxOrg) {
       history.replace(

--- a/src/dataExplorer/components/SchemaBrowserHeading.tsx
+++ b/src/dataExplorer/components/SchemaBrowserHeading.tsx
@@ -20,18 +20,23 @@ import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {LanguageType} from 'src/dataExplorer/components/resources'
 
 const SchemaBrowserHeading: FC = () => {
-  const {fluxSync, toggleFluxSync} = useContext(ScriptQueryBuilderContext)
+  const {compositionSync, toggleCompositionSync} = useContext(
+    ScriptQueryBuilderContext
+  )
   const {resource} = useContext(PersistanceContext)
 
-  const handleFluxSyncToggle = () => {
-    event('Toggled Flux Sync in schema browser', {active: `${!fluxSync}`})
-    toggleFluxSync(!fluxSync)
+  const handleCompositionSyncToggle = () => {
+    // Note: kept same event naming, so can compare across time. (Even though is Flux and SQL sync.)
+    event('Toggled Flux Sync in schema browser', {
+      active: `${!compositionSync}`,
+    })
+    toggleCompositionSync(!compositionSync)
   }
 
   const tooltipContents = (
     <div>
       <span>
-        Flux Sync autopopulates the script editor to help you start a query.
+        Sync autopopulates the script editor to help you start a query.
       </span>
       <br />
       <br />
@@ -58,8 +63,8 @@ const SchemaBrowserHeading: FC = () => {
       <FlexBox className="editor-sync">
         <SlideToggle
           className="editor-sync--toggle"
-          active={fluxSync}
-          onChange={handleFluxSyncToggle}
+          active={compositionSync}
+          onChange={handleCompositionSyncToggle}
           testID="editor-sync--toggle"
         />
         <InputLabel className="editor-sync--label">

--- a/src/dataExplorer/components/ScriptQueryBuilder.tsx
+++ b/src/dataExplorer/components/ScriptQueryBuilder.tsx
@@ -21,7 +21,10 @@ import {QueryProvider} from 'src/shared/contexts/query'
 import {EditorProvider} from 'src/shared/contexts/editor'
 import {ResultsProvider, ResultsContext} from 'src/dataExplorer/context/results'
 import {ChildResultsProvider} from 'src/dataExplorer/context/results/childResults'
-import {ResultsViewProvider} from 'src/dataExplorer/context/resultsView'
+import {
+  ResultsViewProvider,
+  ResultsViewContext,
+} from 'src/dataExplorer/context/resultsView'
 import {SidebarProvider} from 'src/dataExplorer/context/sidebar'
 import {
   PersistanceProvider,
@@ -59,12 +62,14 @@ const ScriptQueryBuilder: FC = () => {
   const isIoxOrg = useSelector(isOrgIOx)
   const {cancel} = useContext(QueryContext)
   const {setStatus, setResult} = useContext(ResultsContext)
+  const {clear: clearViewOptions} = useContext(ResultsViewContext)
   const org = useSelector(getOrg)
 
   const handleClear = useCallback(() => {
     cancel()
     setStatus(RemoteDataState.NotStarted)
     setResult(null)
+    clearViewOptions()
 
     if (isIoxOrg) {
       history.replace(

--- a/src/dataExplorer/components/SqlViewOptions.scss
+++ b/src/dataExplorer/components/SqlViewOptions.scss
@@ -1,0 +1,11 @@
+@import '@influxdata/clockface/dist/variables.scss';
+
+.sql-view-options {
+  .cf-list {
+    flex: 1 0 !important;
+
+    .selector-list--item {
+      height: $cf-form-xs-height;
+    }
+  }
+}

--- a/src/dataExplorer/components/SqlViewOptions.scss
+++ b/src/dataExplorer/components/SqlViewOptions.scss
@@ -8,4 +8,10 @@
       height: $cf-form-xs-height;
     }
   }
+  .sql-view-options--see-query {
+    padding-top: $cf-form-xs-height;
+    display: flex;
+    justify-content: center;
+    overflow: hidden;
+  }
 }

--- a/src/dataExplorer/components/SqlViewOptions.tsx
+++ b/src/dataExplorer/components/SqlViewOptions.tsx
@@ -1,5 +1,5 @@
 import React, {FC} from 'react'
-import {Columns, Grid} from '@influxdata/clockface'
+import {Columns, Grid, Button, ComponentStatus} from '@influxdata/clockface'
 
 import SelectorList from 'src/timeMachine/components/SelectorList'
 import SelectorTitle from 'src/dataExplorer/components/SelectorTitle'
@@ -11,12 +11,14 @@ interface SqlViewOptionsT {
   selectViewOptions: (_: Partial<ViewOptions>) => void
   allViewOptions: ViewOptions
   selectedViewOptions: ViewOptions
+  seeSubquery: () => void
 }
 
 export const SqlViewOptions: FC<SqlViewOptionsT> = ({
   selectViewOptions,
   allViewOptions,
   selectedViewOptions,
+  seeSubquery,
 }) => {
   const handleSelectedListItem = (propKey, value) => {
     if ((selectedViewOptions[propKey] ?? []).includes(value)) {
@@ -69,6 +71,18 @@ export const SqlViewOptions: FC<SqlViewOptionsT> = ({
               onSelectItem={tagKey => handleSelectedListItem('groupby', tagKey)}
               multiSelect={true}
             />
+            <div className="sql-view-options--see-query">
+              <Button
+                testID="sql-view-options--see-query"
+                text="View graph subquery"
+                status={
+                  !seeSubquery
+                    ? ComponentStatus.Disabled
+                    : ComponentStatus.Valid
+                }
+                onClick={seeSubquery}
+              />
+            </div>
           </Grid.Column>
         </Grid.Row>
       </Grid>

--- a/src/dataExplorer/components/SqlViewOptions.tsx
+++ b/src/dataExplorer/components/SqlViewOptions.tsx
@@ -1,0 +1,77 @@
+import React, {FC} from 'react'
+import {Columns, Grid} from '@influxdata/clockface'
+
+import SelectorList from 'src/timeMachine/components/SelectorList'
+import SelectorTitle from 'src/dataExplorer/components/SelectorTitle'
+import {ViewOptions} from 'src/dataExplorer/context/resultsView'
+
+import './SqlViewOptions.scss'
+
+interface SqlViewOptionsT {
+  selectViewOptions: (_: Partial<ViewOptions>) => void
+  allViewOptions: ViewOptions
+  selectedViewOptions: ViewOptions
+}
+
+export const SqlViewOptions: FC<SqlViewOptionsT> = ({
+  selectViewOptions,
+  allViewOptions,
+  selectedViewOptions,
+}) => {
+  const handleSelectedListItem = (propKey, value) => {
+    if ((selectedViewOptions[propKey] ?? []).includes(value)) {
+      selectViewOptions({
+        [propKey]: selectedViewOptions[propKey].filter(v => v !== value),
+      })
+    } else {
+      selectViewOptions({
+        [propKey]: (selectedViewOptions[propKey] ?? []).concat([value]),
+      })
+    }
+  }
+
+  const groupbyTooltipContents = (
+    <div>
+      <span>Select the GROUPBY used for the graph subquery.</span>
+      <br />
+      <br />
+      <span>
+        Options are based on returned data results (refer to your table
+        columns).
+      </span>
+      <br />
+      <br />
+      <span>
+        By default, the GROUPBY is done on all tagKeys in order to produce a
+        dataseries.
+      </span>
+    </div>
+  )
+
+  return (
+    <div className="view-options sql-view-options">
+      <Grid>
+        <Grid.Row>
+          <Grid.Column
+            widthXS={Columns.Twelve}
+            widthMD={Columns.Six}
+            widthLG={Columns.Four}
+            className="view-options-container"
+          >
+            <h5 className="view-options--header">Query Modifier</h5>
+            <SelectorTitle
+              label="Grouping"
+              tooltipContents={groupbyTooltipContents}
+            />
+            <SelectorList
+              items={allViewOptions?.groupby ?? []}
+              selectedItems={selectedViewOptions?.groupby ?? []}
+              onSelectItem={tagKey => handleSelectedListItem('groupby', tagKey)}
+              multiSelect={true}
+            />
+          </Grid.Column>
+        </Grid.Row>
+      </Grid>
+    </div>
+  )
+}

--- a/src/dataExplorer/context/results/childResults.tsx
+++ b/src/dataExplorer/context/results/childResults.tsx
@@ -49,6 +49,7 @@ const modifiersToApply = (viewOptions: ViewOptions): SqlQueryModifiers => {
 interface ChildResultsContextType {
   status: RemoteDataState
   result: FluxResult
+  readonly queryModifers: SqlQueryModifiers
 
   setStatus: (status: RemoteDataState) => void
   setResult: (result: FluxResult) => void
@@ -57,6 +58,7 @@ interface ChildResultsContextType {
 const DEFAULT_STATE: ChildResultsContextType = {
   status: RemoteDataState.NotStarted,
   result: {} as FluxResult,
+  queryModifers: {} as SqlQueryModifiers,
 
   setStatus: _ => {},
   setResult: _ => {},
@@ -141,6 +143,7 @@ export const ChildResultsProvider: FC = ({children}) => {
       value={{
         status,
         result,
+        queryModifers,
 
         setStatus,
         setResult,

--- a/src/dataExplorer/context/results/childResults.tsx
+++ b/src/dataExplorer/context/results/childResults.tsx
@@ -17,17 +17,33 @@ import {LanguageType} from 'src/dataExplorer/components/resources'
 // Utils
 import {rangeToParam} from 'src/dataExplorer/shared/utils'
 
-const modifiersToApply = (_viewOptions: ViewOptions): SqlQueryModifiers => {
+const modifiersToApply = (viewOptions: ViewOptions): SqlQueryModifiers => {
+  const prepend = []
+  const append = []
+
+  // 1. groupby first
+  if (viewOptions.groupby?.length) {
+    append.push(
+      `|> group(columns: [${viewOptions.groupby
+        .map(columnName => `"${columnName}"`)
+        .join(',')}])`
+    )
+  }
+
+  // 2. smoothing transformation next
   // e.g. to smooth by selected column foo. Rough example.
   const shouldSmooth = false
   if (shouldSmooth) {
-    return {
-      prepend: `import "experimental/polyline"`,
-      append: `|> polyline.rdp(valColumn: "foo", timeColumn: "time")`,
-    }
+    prepend.push(`import "experimental/polyline"`)
+    // append.push(`|> polyline.rdp(valColumn: "foo", timeColumn: "time")`) // TODO
   }
 
-  return null
+  return Boolean(prepend.length + append.length)
+    ? {
+        prepend: prepend.join('\n'),
+        append: append.join('\n'),
+      }
+    : null
 }
 
 interface ChildResultsContextType {
@@ -51,12 +67,13 @@ export const ChildResultsContext =
 
 export const ChildResultsProvider: FC = ({children}) => {
   const [result, setResult] = useState<FluxResult>({} as FluxResult)
+  const [queryModifers, setQueryModifiers] = useState(null)
   const [status, setStatus] = useState<RemoteDataState>(
     RemoteDataState.NotStarted
   )
   const {status: statusFromParent, result: resultFromParent} =
     useContext(ResultsContext)
-  const {viewOptions} = useContext(ResultsViewContext)
+  const {selectedViewOptions: viewOptions} = useContext(ResultsViewContext)
   const {
     query: queryText,
     selection,
@@ -78,10 +95,16 @@ export const ChildResultsProvider: FC = ({children}) => {
       return
     }
 
-    // TODO: tranform functions, based on viewOptions change
-    const sqlQueryModifiers = modifiersToApply(viewOptions)
+    const cannotRunIoxSqlMethod = !selection?.bucket
+    if (cannotRunIoxSqlMethod) {
+      return
+    }
 
-    if (!sqlQueryModifiers) {
+    const sqlQueryModifiers = modifiersToApply(viewOptions)
+    const previousQueryModifiers = queryModifers
+    setQueryModifiers(sqlQueryModifiers)
+
+    if (sqlQueryModifiers === previousQueryModifiers) {
       return
     }
 

--- a/src/dataExplorer/context/resultsView.tsx
+++ b/src/dataExplorer/context/resultsView.tsx
@@ -1,8 +1,17 @@
-import React, {FC, createContext} from 'react'
+import React, {
+  FC,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+} from 'react'
 
 import {useSessionStorage} from 'src/dataExplorer/shared/utils'
 import {ViewProperties, SimpleTableViewProperties} from 'src/types'
 import {SUPPORTED_VISUALIZATIONS} from 'src/visualization'
+import {ResultsContext} from 'src/dataExplorer/context/results'
+
+const NOT_PERMITTED_GROUPBY = ['_result', 'result', '_time', 'time', 'table']
 
 export enum ViewStateType {
   Table = 'table',
@@ -14,31 +23,42 @@ interface View {
   properties: ViewProperties
 }
 
-export interface ViewOptions {}
+export interface ViewOptions {
+  groupby: string[]
+}
 
 interface ResultsViewContextType {
   view: View
   viewOptions: ViewOptions
+  selectedViewOptions: ViewOptions
 
   setView: (view: View) => void
-  setViewOptions: (viewOptions: Object) => void
+  setDefaultViewOptions: (viewOptions: Partial<ViewOptions>) => void
+  selectViewOptions: (viewOptions: Partial<ViewOptions>) => void
+  clear: () => void
 }
+
+const DEFAULT_VIEW_OPTIONS = {groupby: []}
 
 const DEFAULT_STATE: ResultsViewContextType = {
   view: {
     state: ViewStateType.Table,
     properties: SUPPORTED_VISUALIZATIONS['xy'].initial,
   },
-  viewOptions: {}, // TODO -- set default options. Such as all tagKeys for `|> group()`
+  viewOptions: JSON.parse(JSON.stringify(DEFAULT_VIEW_OPTIONS)),
+  selectedViewOptions: JSON.parse(JSON.stringify(DEFAULT_VIEW_OPTIONS)),
 
   setView: _ => {},
-  setViewOptions: _ => {},
+  setDefaultViewOptions: _ => {},
+  selectViewOptions: _ => {},
+  clear: () => {},
 }
 
 export const ResultsViewContext =
   createContext<ResultsViewContextType>(DEFAULT_STATE)
 
 export const ResultsViewProvider: FC = ({children}) => {
+  const {result: resultFromParent} = useContext(ResultsContext)
   const [view, setView] = useSessionStorage('dataExplorer.results', {
     state: ViewStateType.Table,
     properties: {
@@ -47,19 +67,74 @@ export const ResultsViewProvider: FC = ({children}) => {
     } as SimpleTableViewProperties,
   })
 
-  const [viewOptions, setViewOptions] = useSessionStorage(
-    'dataExplorer.resultsOptions',
-    {}
+  // what can be chosen (e.g. the list of all options)
+  const [viewOptionsAll, persistViewOptionsAll] = useSessionStorage(
+    'dataExplorer.resultsOptions.all',
+    DEFAULT_VIEW_OPTIONS
   )
+  const setViewOptionsAll = useCallback(
+    (updatedOptions: Partial<ViewOptions>) => {
+      persistViewOptionsAll({...viewOptionsAll, ...updatedOptions})
+    },
+    [viewOptionsAll]
+  )
+
+  // default options (a.k.a. based on schema)
+  const [defaultViewOptions, persistDefaultViewOptions] = useSessionStorage(
+    'dataExplorer.resultsOptions.default',
+    DEFAULT_VIEW_OPTIONS
+  )
+  const setDefaultViewOptions = useCallback(
+    (updatedOptions: Partial<ViewOptions>) => {
+      persistDefaultViewOptions({...defaultViewOptions, ...updatedOptions})
+    },
+    [defaultViewOptions]
+  )
+
+  // what was chosen (e.g. sublist chosen)
+  const [selectedViewOptions, persistSelectedViewOptions] = useSessionStorage(
+    'dataExplorer.resultsOptions',
+    DEFAULT_VIEW_OPTIONS
+  )
+  const selectViewOptions = useCallback(
+    (updatedOptions: Partial<ViewOptions>) => {
+      persistSelectedViewOptions({...selectedViewOptions, ...updatedOptions})
+    },
+    [selectedViewOptions]
+  )
+
+  const clear = () => {
+    persistViewOptionsAll(DEFAULT_VIEW_OPTIONS)
+    persistDefaultViewOptions(DEFAULT_VIEW_OPTIONS)
+    persistSelectedViewOptions(DEFAULT_VIEW_OPTIONS)
+  }
+
+  useEffect(() => {
+    // if parent query is re-run => decide what to reset in subquery viewOptions
+
+    // reset groupby
+    const excludeFromGroupby = NOT_PERMITTED_GROUPBY
+    const groupby = Object.keys(
+      resultFromParent?.parsed?.table?.columns || {}
+    ).filter(columnName => !excludeFromGroupby.includes(columnName))
+    setViewOptionsAll({groupby})
+    const defaultsWhichExist = defaultViewOptions.groupby.filter(defaultGroup =>
+      groupby.includes(defaultGroup)
+    )
+    selectViewOptions({groupby: defaultsWhichExist})
+  }, [resultFromParent, defaultViewOptions])
 
   return (
     <ResultsViewContext.Provider
       value={{
         view,
-        viewOptions,
+        viewOptions: viewOptionsAll,
+        selectedViewOptions,
 
         setView,
-        setViewOptions,
+        setDefaultViewOptions,
+        selectViewOptions,
+        clear,
       }}
     >
       {children}

--- a/src/dataExplorer/context/scriptQueryBuilder.tsx
+++ b/src/dataExplorer/context/scriptQueryBuilder.tsx
@@ -23,9 +23,9 @@ interface SelectedTagValues {
 }
 
 interface ScriptQueryBuilderContextType {
-  // Flux Sync
-  fluxSync: boolean
-  toggleFluxSync: (synced: boolean) => void
+  // Composition Sync
+  compositionSync: boolean
+  toggleCompositionSync: (synced: boolean) => void
 
   // Schema
   selectedBucket: Bucket
@@ -40,9 +40,9 @@ interface ScriptQueryBuilderContextType {
 }
 
 const DEFAULT_CONTEXT: ScriptQueryBuilderContextType = {
-  // Flux Sync
-  fluxSync: true,
-  toggleFluxSync: _s => {},
+  // Composition Sync
+  compositionSync: true,
+  toggleCompositionSync: _s => {},
 
   // Schema
   selectedBucket: null,
@@ -106,7 +106,7 @@ export const ScriptQueryBuilderProvider: FC = ({children}) => {
     setSelectedTagValues(transformSessionTagValuesToLocal(selection.tagValues))
   }, [selection.tagValues])
 
-  const handleToggleFluxSync = (synced: boolean): void => {
+  const handleCompositionFluxSync = (synced: boolean): void => {
     setSelection({composition: {synced}})
   }
 
@@ -199,9 +199,9 @@ export const ScriptQueryBuilderProvider: FC = ({children}) => {
     () => (
       <ScriptQueryBuilderContext.Provider
         value={{
-          // Flux Sync
-          fluxSync: selection.composition?.synced,
-          toggleFluxSync: handleToggleFluxSync,
+          // Composition Sync
+          compositionSync: selection.composition?.synced,
+          toggleCompositionSync: handleCompositionFluxSync,
 
           // Schema
           selectedBucket: selection.bucket,
@@ -219,7 +219,7 @@ export const ScriptQueryBuilderProvider: FC = ({children}) => {
       </ScriptQueryBuilderContext.Provider>
     ),
     [
-      // Flux Sync
+      // Composition Sync
       selection.composition?.synced,
 
       // Schema

--- a/src/dataExplorer/context/tags.tsx
+++ b/src/dataExplorer/context/tags.tsx
@@ -11,6 +11,7 @@ import {DEFAULT_LIMIT} from 'src/shared/constants/queryBuilder'
 
 // Contexts
 import {QueryContext, QueryScope} from 'src/shared/contexts/query'
+import {ResultsViewContext} from 'src/dataExplorer/context/resultsView'
 
 // Utils
 import {
@@ -57,6 +58,7 @@ interface Prop {
 export const TagsProvider: FC<Prop> = ({children, scope}) => {
   // Contexts
   const {query: queryAPI} = useContext(QueryContext)
+  const {setDefaultViewOptions} = useContext(ResultsViewContext)
 
   // States
   const [tags, setTags] = useState<Tags>(
@@ -132,6 +134,7 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
       setTags(newTags)
       setLoadingTagKeys(RemoteDataState.Done)
       setLoadingTagValues(tagValueStatuses)
+      setDefaultViewOptions({groupby: Object.keys(newTags)})
     } catch (e) {
       console.error(
         `Failed to get tags for measurement: "${measurement}"\n`,

--- a/src/homepageExperience/components/steps/Finish.tsx
+++ b/src/homepageExperience/components/steps/Finish.tsx
@@ -152,7 +152,8 @@ export const Finish = (props: OwnProps) => {
           )}
         </FlexBox>
         {props.wizardEventName !== 'cliWizard' &&
-        props.wizardEventName !== 'arduinoWizard' ? (
+        props.wizardEventName !== 'arduinoWizard' &&
+        props.wizardEventName !== 'pythonSqlWizard' ? (
           <SampleAppCard
             handleNextStepEvent={handleNextStepEvent}
             wizardEventName={props.wizardEventName}

--- a/src/homepageExperience/components/steps/Overview.tsx
+++ b/src/homepageExperience/components/steps/Overview.tsx
@@ -30,11 +30,11 @@ export const Overview: FC<Props> = ({wizard}) => {
       <h1>Hello, Time-Series World!</h1>
       <article>
         <p>Welcome and thanks for checking out InfluxData!</p>
-
         <p>
           In the next 5 minutes, you will set up InfluxData on your machine and
           write and execute some basic queries.
         </p>
+        <p>New to time-series data? Here's a brief video introduction:</p>
         <iframe
           ref={videoFrame}
           width="560"

--- a/src/homepageExperience/components/steps/python/ExecuteQuerySql.tsx
+++ b/src/homepageExperience/components/steps/python/ExecuteQuerySql.tsx
@@ -1,0 +1,84 @@
+import React from 'react'
+import CodeSnippet from 'src/shared/components/CodeSnippet'
+import {event} from 'src/cloud/utils/reporting'
+
+const logCopyCodeSnippet = () => {
+  event('firstMile.pythonWizard.executeQuery.code.copied')
+}
+
+type OwnProps = {
+  bucket: string
+}
+
+export const ExecuteQuerySql = (props: OwnProps) => {
+  const {bucket} = props
+
+  const sqlSnippet = `SELECT *
+FROM 'census'
+WHERE time >= now() - interval '1 hour'
+AND ('bees' IS NOT NULL OR 'ants' IS NOT NULL)`
+
+  const query = `query = """SELECT *
+FROM 'census'
+WHERE time >= now() - interval '24 hours'
+AND ('bees' IS NOT NULL OR 'ants' IS NOT NULL)"""
+
+# Define the query api
+sql_client = client.sql_client(bucket="${bucket}")
+
+# Execute the query
+result = sql_client.query(query)
+result_data = result.read_all()
+
+# Convert the result to a pandas dataframe
+df = result_data.to_pandas()
+df = df.sort_values(by="time")
+print(df)
+`
+
+  const queryPreview = `     ants  bees  location                          time
+  0   NaN  23.0   Klamath 2023-01-18 05:20:46.485256499
+  3  30.0   NaN  Portland 2023-01-18 05:20:47.879847987
+  1   NaN  28.0   Klamath 2023-01-18 05:20:49.126909775
+  4  32.0   NaN  Portland 2023-01-18 05:20:50.636016064
+  2   NaN  29.0   Klamath 2023-01-18 05:20:52.047057410
+  5  40.0   NaN  Portland 2023-01-18 05:20:53.680696168
+`
+
+  return (
+    <>
+      <h1>Execute a SQL Query</h1>
+      <p>
+        Now let's query the data we wrote into the database with SQL. Here is
+        what our query looks like on its own:
+      </p>
+      <CodeSnippet
+        text={sqlSnippet}
+        showCopyControl={false}
+        onCopy={logCopyCodeSnippet}
+        language="sql"
+      />
+      <p>
+        In this query, we are looking for data points within the last 1 hour
+        with a "census" measurement and either "bees" or "ants" fields.
+      </p>
+      <p>
+        Let's use that SQL query in our Python code to show us the results of
+        what we have written. We'll use pandas to format the results into a
+        table.
+      </p>
+      <p>Run the following:</p>
+      <CodeSnippet text={query} onCopy={logCopyCodeSnippet} language="python" />
+      <p>
+        The code snippet above should print out the data you wrote in previous
+        steps. The result should resemble this:
+      </p>
+      <CodeSnippet
+        text={queryPreview}
+        showCopyControl={false}
+        onCopy={logCopyCodeSnippet}
+        language="text"
+      />
+    </>
+  )
+}

--- a/src/homepageExperience/components/steps/python/InstallDependenciesSql.tsx
+++ b/src/homepageExperience/components/steps/python/InstallDependenciesSql.tsx
@@ -1,0 +1,42 @@
+import React, {PureComponent} from 'react'
+import CodeSnippet from 'src/shared/components/CodeSnippet'
+import {SafeBlankLink} from 'src/utils/SafeBlankLink'
+
+import {event} from 'src/cloud/utils/reporting'
+
+export class InstallDependenciesSql extends PureComponent {
+  private logCopyCodeSnippet = () => {
+    event('firstMile.pythonWizard.InstallDependencies.code.copied')
+  }
+  render() {
+    return (
+      <>
+        <h1>Install Dependencies</h1>
+        <p>The first thing you'll need to do is ensure you have{' '}
+          <SafeBlankLink href="https://www.python.org/download/releases/3.0/">
+            Python 3
+          </SafeBlankLink>{' '}
+          installed, this will not work with older versions of Python.</p>
+        <p>
+          Then, install the{' '}
+          <code className="homepage-wizard--code-highlight">
+            influxdb-client
+          </code>{' '}
+          module by running the command below in your terminal:
+        </p>
+        <CodeSnippet
+          text="pip3 install influxdb-client[sql]"
+          onCopy={this.logCopyCodeSnippet}
+          language="properties"
+        />
+        <p>
+          This also comes with{' '}
+          <SafeBlankLink href="https://pandas.pydata.org/">
+            pandas
+          </SafeBlankLink>{' '}
+          which will be helpful for organizing our data output when we query.
+        </p>
+      </>
+    )
+  }
+}

--- a/src/homepageExperience/components/steps/python/InstallDependenciesSql.tsx
+++ b/src/homepageExperience/components/steps/python/InstallDependenciesSql.tsx
@@ -12,11 +12,13 @@ export class InstallDependenciesSql extends PureComponent {
     return (
       <>
         <h1>Install Dependencies</h1>
-        <p>The first thing you'll need to do is ensure you have{' '}
+        <p>
+          The first thing you'll need to do is ensure you have{' '}
           <SafeBlankLink href="https://www.python.org/download/releases/3.0/">
             Python 3
           </SafeBlankLink>{' '}
-          installed, this will not work with older versions of Python.</p>
+          installed, this will not work with older versions of Python.
+        </p>
         <p>
           Then, install the{' '}
           <code className="homepage-wizard--code-highlight">

--- a/src/homepageExperience/components/steps/python/WriteData.tsx
+++ b/src/homepageExperience/components/steps/python/WriteData.tsx
@@ -116,7 +116,10 @@ for value in range(5):
         Once you write this data, you’ll begin to see the confirmation below
       </p>
 
-      <Panel backgroundColor={InfluxColors.Grey15}>
+      <Panel
+        backgroundColor={InfluxColors.Grey15}
+        style={{marginBottom: '24px'}}
+      >
         <Panel.Body>
           <DataListening bucket={selectedBucket.name} />
         </Panel.Body>

--- a/src/homepageExperience/components/steps/python/WriteDataSql.tsx
+++ b/src/homepageExperience/components/steps/python/WriteDataSql.tsx
@@ -1,0 +1,283 @@
+import React, {useContext, useEffect, useState} from 'react'
+import {useDispatch, useSelector} from 'react-redux'
+import {
+  Columns,
+  ComponentSize,
+  Grid,
+  InfluxColors,
+  Panel,
+  Table,
+} from '@influxdata/clockface'
+
+import {SafeBlankLink} from 'src/utils/SafeBlankLink'
+import WriteDataHelperBuckets from 'src/writeData/components/WriteDataHelperBuckets'
+import CodeSnippet from 'src/shared/components/CodeSnippet'
+import {WriteDataDetailsContext} from 'src/writeData/components/WriteDataDetailsContext'
+
+import {getOrg} from 'src/organizations/selectors'
+import DataListening from 'src/homepageExperience/components/DataListening'
+import {getBuckets} from 'src/buckets/actions/thunks'
+import {event} from 'src/cloud/utils/reporting'
+
+const logCopyCodeSnippet = () => {
+  event('firstMile.pythonWizard.writeData.code.copied')
+}
+
+const logDocsOpened = () => {
+  event('firstMile.pythonWizard.writeData.docs.opened')
+}
+
+type OwnProps = {
+  onSelectBucket: (bucketName: string) => void
+}
+
+export const WriteDataSqlComponent = (props: OwnProps) => {
+  const org = useSelector(getOrg)
+  const dispatch = useDispatch()
+  const {onSelectBucket} = props
+
+  useEffect(() => {
+    dispatch(getBuckets())
+  }, [dispatch])
+
+  const {bucket} = useContext(WriteDataDetailsContext)
+
+  const [selectedBucket, setSelectedBucket] = useState(bucket)
+
+  useEffect(() => {
+    setSelectedBucket(bucket)
+    onSelectBucket(bucket.name)
+  }, [bucket, onSelectBucket])
+
+  const codeSnippet = `bucket="${bucket.name}"
+
+# Define the write api
+write_api = client.write_api(write_options=SYNCHRONOUS)
+
+data = {
+  "point1": {
+    "location": "Klamath",
+    "species": "bees",
+    "count": 23,
+  },
+  "point2": {
+    "location": "Portland",
+    "species": "ants",
+    "count": 30,
+  },
+  "point3": {
+    "location": "Klamath",
+    "species": "bees",
+    "count": 28,
+  },
+  "point4": {
+    "location": "Portland",
+    "species": "ants",
+    "count": 32,
+  },
+  "point5": {
+    "location": "Klamath",
+    "species": "bees",
+    "count": 29,
+  },
+  "point6": {
+    "location": "Portland",
+    "species": "ants",
+    "count": 40,
+  },
+}
+
+for key in data:
+  point = (
+    Point("census")
+    .tag("location", data[key]["location"])
+    .field(data[key]["species"], data[key]["count"])
+  )
+  write_api.write(bucket=bucket, org=org, record=point)
+  time.sleep(1) # separate points by 1 second
+
+print("Complete. Return to the InfluxDB UI.")
+`
+
+  return (
+    <>
+      <h1>Write Data</h1>
+      <p>
+        To start writing data, we need a place to store our time-series data.
+        These named storage locations are called{' '}
+        <SafeBlankLink
+          href={`orgs/${org.id}/load-data/buckets`}
+          onClick={logDocsOpened}
+        >
+          buckets.
+        </SafeBlankLink>
+      </p>
+      <p>Please select or create a new bucket:</p>
+      <Panel backgroundColor={InfluxColors.Grey15}>
+        <Panel.Body size={ComponentSize.ExtraSmall}>
+          <Grid>
+            <Grid.Row>
+              <Grid.Column widthSM={Columns.Twelve}>
+                <WriteDataHelperBuckets useSimplifiedBucketForm={true} />
+              </Grid.Column>
+            </Grid.Row>
+          </Grid>
+        </Panel.Body>
+      </Panel>
+      <p style={{marginTop: '24px'}}>
+        For this example, we will be writing to our database this simple insect
+        census data:
+      </p>
+      <Table>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>_time</Table.HeaderCell>
+            <Table.HeaderCell>_measurement</Table.HeaderCell>
+            <Table.HeaderCell>location</Table.HeaderCell>
+            <Table.HeaderCell>_field</Table.HeaderCell>
+            <Table.HeaderCell>_value</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>2023-01-01T00:00:00Z</Table.Cell>
+            <Table.Cell>census</Table.Cell>
+            <Table.Cell>Kalmath</Table.Cell>
+            <Table.Cell>bees</Table.Cell>
+            <Table.Cell>23</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>2023-01-01T00:00:00Z</Table.Cell>
+            <Table.Cell>census</Table.Cell>
+            <Table.Cell>Portland</Table.Cell>
+            <Table.Cell>ants</Table.Cell>
+            <Table.Cell>30</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>2023-01-01T00:00:00Z</Table.Cell>
+            <Table.Cell>census</Table.Cell>
+            <Table.Cell>Kalmath</Table.Cell>
+            <Table.Cell>bees</Table.Cell>
+            <Table.Cell>28</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>2023-01-01T00:00:00Z</Table.Cell>
+            <Table.Cell>census</Table.Cell>
+            <Table.Cell>Portland</Table.Cell>
+            <Table.Cell>ants</Table.Cell>
+            <Table.Cell>32</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>2023-01-01T00:00:00Z</Table.Cell>
+            <Table.Cell>census</Table.Cell>
+            <Table.Cell>Kalmath</Table.Cell>
+            <Table.Cell>bees</Table.Cell>
+            <Table.Cell>29</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>2023-01-01T00:00:00Z</Table.Cell>
+            <Table.Cell>census</Table.Cell>
+            <Table.Cell>Portland</Table.Cell>
+            <Table.Cell>ants</Table.Cell>
+            <Table.Cell>40</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+        <Table.Footer />
+      </Table>
+      <p style={{marginTop: '24px'}}>
+        In this data example, we have some important concepts:
+      </p>
+      <Table>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>Term</Table.HeaderCell>
+            <Table.HeaderCell>Definition</Table.HeaderCell>
+            <Table.HeaderCell>Example Use Case</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>
+              <SafeBlankLink
+                href="https://docs.influxdata.com/influxdb/cloud/reference/glossary/#measurement"
+                onClick={logDocsOpened}
+              >
+                measurement
+              </SafeBlankLink>
+            </Table.Cell>
+            <Table.Cell>
+              Primary filter for the thing you are measuring.
+            </Table.Cell>
+            <Table.Cell>
+              Since we are measuring the sample census of insects, our
+              measurement is "census".
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>
+              <SafeBlankLink
+                href="https://docs.influxdata.com/influxdb/cloud/reference/glossary/#tag"
+                onClick={logDocsOpened}
+              >
+                tag
+              </SafeBlankLink>
+            </Table.Cell>
+            <Table.Cell>
+              Key-value pair to store metadata about your fields.
+            </Table.Cell>
+            <Table.Cell>
+              We are storing the "location" of where each census is taken. Tags
+              are indexed and should generally be bounded (i.e. only a few
+              cities).
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>
+              <SafeBlankLink
+                href="https://docs.influxdata.com/influxdb/cloud/reference/glossary/#field"
+                onClick={logDocsOpened}
+              >
+                field
+              </SafeBlankLink>
+            </Table.Cell>
+            <Table.Cell>
+              Key-value pair that stores the actual data you are measuring.
+            </Table.Cell>
+            <Table.Cell>
+              We are storing the insect "species" and "count" as the key-value
+              pair. Fields are not indexed and can be stored as integers,
+              floats, strings, or booleans.
+            </Table.Cell>
+          </Table.Row>
+        </Table.Body>
+        <Table.Footer />
+      </Table>
+      <p style={{marginTop: '24px'}}>
+        These concepts are important in building your time-series schema. Now,
+        let's write this data into our bucket.
+      </p>
+      <p>Run the following code in your Python shell:</p>
+      <CodeSnippet
+        text={codeSnippet}
+        onCopy={logCopyCodeSnippet}
+        language="python"
+      />
+      <p style={{marginTop: '24px'}}>
+        Once you write this data, you'll begin to see the confirmation below
+      </p>
+
+      <Panel
+        backgroundColor={InfluxColors.Grey15}
+        style={{marginBottom: '24px'}}
+      >
+        <Panel.Body>
+          <DataListening bucket={selectedBucket.name} />
+        </Panel.Body>
+      </Panel>
+    </>
+  )
+}
+
+export const WriteDataSql = props => {
+  return <WriteDataSqlComponent onSelectBucket={props.onSelectBucket} />
+}

--- a/src/homepageExperience/containers/HomepageContainer.tsx
+++ b/src/homepageExperience/containers/HomepageContainer.tsx
@@ -156,18 +156,20 @@ export const HomepageContainer: FC = () => {
                         </div>
                       </Link>
                     </ResourceCard>
-                    <ResourceCard style={cardStyle}>
-                      <Link
-                        to={javaScriptNodeLink}
-                        style={linkStyle}
-                        onClick={logNodeJSWizardClick}
-                      >
-                        <div className="homepage-wizard-language-tile">
-                          <h5>Node.js</h5>
-                          {NodejsIcon}
-                        </div>
-                      </Link>
-                    </ResourceCard>
+                    {!isFlagEnabled('ioxOnboarding') && (
+                      <ResourceCard style={cardStyle}>
+                        <Link
+                          to={javaScriptNodeLink}
+                          style={linkStyle}
+                          onClick={logNodeJSWizardClick}
+                        >
+                          <div className="homepage-wizard-language-tile">
+                            <h5>Node.js</h5>
+                            {NodejsIcon}
+                          </div>
+                        </Link>
+                      </ResourceCard>
+                    )}
                     <ResourceCard style={cardStyle}>
                       <Link
                         to={golangLink}
@@ -180,21 +182,23 @@ export const HomepageContainer: FC = () => {
                         </div>
                       </Link>
                     </ResourceCard>
-                    <ResourceCard style={cardStyle}>
-                      <Link
-                        to={arduinoLink}
-                        style={linkStyle}
-                        onClick={logArduinoWizardClick}
-                      >
-                        <div
-                          className="homepage-wizard-language-tile"
-                          data-testid="homepage-wizard-language-tile--arduino"
+                    {!isFlagEnabled('ioxOnboarding') && (
+                      <ResourceCard style={cardStyle}>
+                        <Link
+                          to={arduinoLink}
+                          style={linkStyle}
+                          onClick={logArduinoWizardClick}
                         >
-                          <h5>Arduino</h5>
-                          {ArduinoIcon}
-                        </div>
-                      </Link>
-                    </ResourceCard>
+                          <div
+                            className="homepage-wizard-language-tile"
+                            data-testid="homepage-wizard-language-tile--arduino"
+                          >
+                            <h5>Arduino</h5>
+                            {ArduinoIcon}
+                          </div>
+                        </Link>
+                      </ResourceCard>
+                    )}
                   </SquareGrid>
                   <FlexBox justifyContent={JustifyContent.FlexStart}>
                     <Link

--- a/src/homepageExperience/utils.ts
+++ b/src/homepageExperience/utils.ts
@@ -6,19 +6,19 @@ export const HOMEPAGE_NAVIGATION_STEPS = [
     glyph: IconFont.BookOutline,
   },
   {
-    name: 'Install\n Dependencies',
+    name: 'Install Dependencies',
     glyph: IconFont.Install,
   },
   {
-    name: 'Tokens',
+    name: 'Get Token',
     glyph: IconFont.CopperCoin,
   },
   {
-    name: 'Initialize\n Client',
+    name: 'Initialize Client',
     glyph: IconFont.CogSolid_New,
   },
   {
-    name: 'Write\n Data',
+    name: 'Write Data',
     glyph: IconFont.Pencil,
   },
   {
@@ -35,29 +35,60 @@ export const HOMEPAGE_NAVIGATION_STEPS = [
   },
 ]
 
+export const HOMEPAGE_NAVIGATION_STEPS_SQL = [
+  {
+    name: 'Overview',
+    glyph: IconFont.BookOutline,
+  },
+  {
+    name: 'Install Dependencies',
+    glyph: IconFont.Install,
+  },
+  {
+    name: 'Get Token',
+    glyph: IconFont.CopperCoin,
+  },
+  {
+    name: 'Initialize Client',
+    glyph: IconFont.CogSolid_New,
+  },
+  {
+    name: 'Write Data',
+    glyph: IconFont.Pencil,
+  },
+  {
+    name: 'Query Data',
+    glyph: IconFont.Play,
+  },
+  {
+    name: 'Finish',
+    glyph: IconFont.StarSmile,
+  },
+]
+
 export const HOMEPAGE_NAVIGATION_STEPS_SHORT = [
   {
     name: 'Overview',
     glyph: IconFont.BookOutline,
   },
   {
-    name: 'Install\n Dependencies',
+    name: 'Install Dependencies',
     glyph: IconFont.Install,
   },
   {
-    name: 'Initialize\n Client',
+    name: 'Initialize Client',
     glyph: IconFont.CogSolid_New,
   },
   {
-    name: 'Write\n Data',
+    name: 'Write Data',
     glyph: IconFont.Pencil,
   },
   {
-    name: 'Execute\n Flux Query',
+    name: 'Execute a\n Flux Query',
     glyph: IconFont.Play,
   },
   {
-    name: 'Execute\n Aggregate',
+    name: 'Execute an\n Aggregate Query',
     glyph: IconFont.Play,
   },
   {
@@ -76,23 +107,23 @@ export const HOMEPAGE_NAVIGATION_STEPS_ARDUINO = [
     glyph: IconFont.Braces,
   },
   {
-    name: 'Install\n Dependencies',
+    name: 'Install Dependencies',
     glyph: IconFont.Install,
   },
   {
-    name: 'Initialize\n Client',
+    name: 'Initialize Client',
     glyph: IconFont.CogSolid_New,
   },
   {
-    name: 'Write\n Data',
+    name: 'Write Data',
     glyph: IconFont.Pencil,
   },
   {
-    name: 'Execute\n Flux Query',
+    name: 'Execute a\n Flux Query',
     glyph: IconFont.Play,
   },
   {
-    name: 'Execute\n Aggregate',
+    name: 'Execute an\n Aggregate Query',
     glyph: IconFont.Play,
   },
   {

--- a/src/organizations/components/OrgProfileTab/index.tsx
+++ b/src/organizations/components/OrgProfileTab/index.tsx
@@ -20,7 +20,7 @@ import {orgDetailsFetchError} from 'src/shared/copy/notifications'
 import {notify} from 'src/shared/actions/notifications'
 
 // Providers
-import {UsersContext, UsersProvider} from 'src/users/context/users'
+import {UsersContext} from 'src/users/context/users'
 
 // Selectors
 import {getMe} from 'src/me/selectors'
@@ -174,12 +174,10 @@ const OrgProfileTab: FC = () => {
           direction={FlexDirection.Row}
           stretchToFitWidth={true}
         >
-          <UsersProvider>
-            <>
-              {allowSelfRemoval && showLeaveOrgButton && <LeaveOrgButton />}
-              <DeletePanel />
-            </>
-          </UsersProvider>
+          <>
+            {allowSelfRemoval && showLeaveOrgButton && <LeaveOrgButton />}
+            <DeletePanel />
+          </>
         </FlexBox>
       )}
     </FlexBox>

--- a/src/organizations/containers/OrgProfilePage.tsx
+++ b/src/organizations/containers/OrgProfilePage.tsx
@@ -9,6 +9,12 @@ import OrgHeader from 'src/organizations/components/OrgHeader'
 import OrgProfileTab from 'src/organizations/components/OrgProfileTab'
 import RenameOrgOverlay from 'src/organizations/components/RenameOrgOverlay'
 
+// Constants
+import {CLOUD} from 'src/shared/constants'
+
+// Context Providers
+import {UsersProvider} from 'src/users/context/users'
+
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 
@@ -18,7 +24,13 @@ const OrgProfilePage: FC = () => {
       <Page titleTag={pageTitleSuffixer(['Settings', 'Organization'])}>
         <OrgHeader testID="about-page--header" />
         <OrgTabbedPage activeTab="about">
-          <OrgProfileTab />
+          {CLOUD ? (
+            <UsersProvider>
+              <OrgProfileTab />
+            </UsersProvider>
+          ) : (
+            <OrgProfileTab />
+          )}
         </OrgTabbedPage>
       </Page>
       <Switch>


### PR DESCRIPTION
This PR adds a new python onboarding experience for IOx users so they can query with SQL from the Python client library. It introduces the new SQL extra for the client library, provides more meaningful write instructions and mock data, and demonstrates querying with SQL and sending to a pandas dataframe.

These changes are behind the `ioxOnboarding` feature flag.

![image](https://user-images.githubusercontent.com/11937365/213608386-c27c43b6-3840-453d-a177-7e8777e48bf9.png)

![image](https://user-images.githubusercontent.com/11937365/213608503-30c62029-1087-41de-be29-373113b60a89.png)

![image](https://user-images.githubusercontent.com/11937365/213608637-7b78ac44-b8a7-4ad0-861f-11963c15385d.png)

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
