### PR TITLE
chore(Dashboards): conditionally show Dashboards in UI

### DIFF
--- a/src/dashboards/selectors/index.ts
+++ b/src/dashboards/selectors/index.ts
@@ -106,21 +106,3 @@ export const hasNoDashboards = (state: AppState): boolean =>
 
 export const getCurrentDashboardId = (state: AppState): string =>
   state.currentDashboard.id
-
-export const selectShouldShowDashboards = (state: AppState): boolean => {
-  if (!CLOUD) {
-    return true
-  }
-
-  const orgCreationDate = new Date(selectOrgCreationDate(state)).valueOf()
-  const ioxCutoffDate = new Date(IOX_SWITCHOVER_CREATION_DATE).valueOf()
-
-  const wasCreatedBeforeIOxCutoff = orgCreationDate < ioxCutoffDate
-
-  // In cloud, don't show alerts if org was created after the IOx cutoff date and feature flag is enabled
-  if (!wasCreatedBeforeIOxCutoff && isFlagEnabled('hideDashboards')) {
-    return false
-  }
-
-  return true
-}

--- a/src/dashboards/selectors/index.ts
+++ b/src/dashboards/selectors/index.ts
@@ -15,15 +15,10 @@ import {
 // Utility
 import {currentContext} from 'src/shared/selectors/currentContext'
 import {getTimezoneOffset} from 'src/dashboards/utils/getTimezoneOffset'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Constants
 import {DEFAULT_TIME_RANGE} from 'src/shared/constants/timeRanges'
 import {timesNeedConverting} from 'src/shared/utils/dateTimeUtils'
-import {CLOUD, IOX_SWITCHOVER_CREATION_DATE} from 'src/shared/constants'
-
-// Selectors
-import {selectOrgCreationDate} from 'src/organizations/selectors'
 
 export const getTimeRange = (state: AppState): TimeRange => {
   const contextID = currentContext(state)

--- a/src/dataExplorer/components/SaveAsOverlay.tsx
+++ b/src/dataExplorer/components/SaveAsOverlay.tsx
@@ -1,7 +1,6 @@
 import React, {FC, useEffect, useState, useCallback} from 'react'
 import {useSelector} from 'react-redux'
 import {useHistory} from 'react-router-dom'
-import {useSelector} from 'react-redux'
 
 // Components
 import SaveAsCellForm from 'src/dataExplorer/components/SaveAsCellForm'
@@ -34,16 +33,19 @@ enum SaveAsOption {
 
 const SaveAsOverlay: FC = () => {
   const history = useHistory()
-  const [saveAsOption, setSaveAsOption] = useState(SaveAsOption.Dashboard)
   const shouldShowResource = useSelector(selectShouldShowResource)
+  const shouldShowNotebooks = useSelector(selectShouldShowNotebooks)
+  const shouldShowDashboards =
+    shouldShowResource && !isFlagEnabled('hideDashboards')
   const shouldShowTasks = shouldShowResource && !isFlagEnabled('hideTasks')
+
+  const [saveAsOption, setSaveAsOption] = useState(
+    shouldShowDashboards ? SaveAsOption.Dashboard : SaveAsOption.Variable
+  )
 
   const hide = useCallback(() => {
     history.goBack()
   }, [history])
-
-  const shouldShowNotebooks = useSelector(selectShouldShowNotebooks)
-  const shouldShowDashboards = useSelector(selectShouldShowDashboards)
 
   useEffect(() => {
     event('Data Explorer Save as Menu Changed', {menu: saveAsOption})
@@ -70,13 +72,15 @@ const SaveAsOverlay: FC = () => {
         <Overlay.Body>
           <Tabs.Container orientation={Orientation.Horizontal}>
             <Tabs alignment={Alignment.Center} size={ComponentSize.Medium}>
-              <Tabs.Tab
-                id={SaveAsOption.Dashboard}
-                text="Dashboard Cell"
-                testID="cell--radio-button"
-                onClick={() => setSaveAsOption(SaveAsOption.Dashboard)}
-                active={saveAsOption === SaveAsOption.Dashboard}
-              />
+              {shouldShowDashboards && (
+                <Tabs.Tab
+                  id={SaveAsOption.Dashboard}
+                  text="Dashboard Cell"
+                  testID="cell--radio-button"
+                  onClick={() => setSaveAsOption(SaveAsOption.Dashboard)}
+                  active={saveAsOption === SaveAsOption.Dashboard}
+                />
+              )}
               {shouldShowTasks && (
                 <Tabs.Tab
                   id={SaveAsOption.Task}

--- a/src/dataExplorer/components/SaveAsOverlay.tsx
+++ b/src/dataExplorer/components/SaveAsOverlay.tsx
@@ -1,6 +1,7 @@
 import React, {FC, useEffect, useState, useCallback} from 'react'
 import {useSelector} from 'react-redux'
 import {useHistory} from 'react-router-dom'
+import {useSelector} from 'react-redux'
 
 // Components
 import SaveAsCellForm from 'src/dataExplorer/components/SaveAsCellForm'
@@ -42,6 +43,7 @@ const SaveAsOverlay: FC = () => {
   }, [history])
 
   const shouldShowNotebooks = useSelector(selectShouldShowNotebooks)
+  const shouldShowDashboards = useSelector(selectShouldShowDashboards)
 
   useEffect(() => {
     event('Data Explorer Save as Menu Changed', {menu: saveAsOption})

--- a/src/pageLayout/containers/MainNavigation.tsx
+++ b/src/pageLayout/containers/MainNavigation.tsx
@@ -141,6 +141,7 @@ const generateNavItems = (
       shortLabel: 'Boards',
       link: `/orgs/${orgID}/dashboards-list`,
       activeKeywords: ['dashboards', 'dashboards-list'],
+      enabled: () => shouldShowDashboards,
     },
     {
       id: 'tasks',
@@ -244,6 +245,7 @@ export const MainNavigation: FC = () => {
   const operatorRole = useSelector(selectOperatorRole)
   const shouldShowNotebooks = useSelector(selectShouldShowNotebooks)
   const shouldShowResource = useSelector(selectShouldShowResource)
+  const shouldShowDashboards = useSelector(selectShouldShowDashboards)
 
   const dispatch = useDispatch()
 

--- a/src/pageLayout/containers/MainNavigation.tsx
+++ b/src/pageLayout/containers/MainNavigation.tsx
@@ -141,7 +141,7 @@ const generateNavItems = (
       shortLabel: 'Boards',
       link: `/orgs/${orgID}/dashboards-list`,
       activeKeywords: ['dashboards', 'dashboards-list'],
-      enabled: () => shouldShowDashboards,
+      enabled: () => shouldShowResource && !isFlagEnabled('hideDashboards'),
     },
     {
       id: 'tasks',
@@ -245,7 +245,6 @@ export const MainNavigation: FC = () => {
   const operatorRole = useSelector(selectOperatorRole)
   const shouldShowNotebooks = useSelector(selectShouldShowNotebooks)
   const shouldShowResource = useSelector(selectShouldShowResource)
-  const shouldShowDashboards = useSelector(selectShouldShowDashboards)
 
   const dispatch = useDispatch()
 

--- a/src/shared/containers/SetOrg.tsx
+++ b/src/shared/containers/SetOrg.tsx
@@ -102,6 +102,7 @@ const SetOrg: FC = () => {
   )
   const shouldShowNotebooks = useSelector(selectShouldShowNotebooks)
   const shouldShowResource = useSelector(selectShouldShowResource)
+  const shouldShowDashboards = useSelector(selectShouldShowDashboards)
 
   const history = useHistory()
   const {orgID} = useParams<{orgID: string}>()
@@ -183,19 +184,25 @@ const SetOrg: FC = () => {
             component={DataExplorerPage}
           />
           {/* Dashboards */}
-          <Route
-            path={`${orgPath}/dashboards-list`}
-            component={DashboardsIndex}
-          />
-          <Route
-            path={`${orgPath}/dashboards/:dashboardID`}
-            component={DashboardContainer}
-          />
-          <Route
-            exact
-            path={`${orgPath}/dashboards`}
-            component={RouteToDashboardList}
-          />
+          {shouldShowDashboards && (
+            <Route
+              path={`${orgPath}/dashboards-list`}
+              component={DashboardsIndex}
+            />
+          )}
+          {shouldShowDashboards && (
+            <Route
+              path={`${orgPath}/dashboards/:dashboardID`}
+              component={DashboardContainer}
+            />
+          )}
+          {shouldShowDashboards && (
+            <Route
+              exact
+              path={`${orgPath}/dashboards`}
+              component={RouteToDashboardList}
+            />
+          )}
           {/* Notebooks  */}
           {shouldShowNotebooks && (
             <Route

--- a/src/shared/containers/SetOrg.tsx
+++ b/src/shared/containers/SetOrg.tsx
@@ -102,7 +102,6 @@ const SetOrg: FC = () => {
   )
   const shouldShowNotebooks = useSelector(selectShouldShowNotebooks)
   const shouldShowResource = useSelector(selectShouldShowResource)
-  const shouldShowDashboards = useSelector(selectShouldShowDashboards)
 
   const history = useHistory()
   const {orgID} = useParams<{orgID: string}>()
@@ -132,6 +131,9 @@ const SetOrg: FC = () => {
   const orgPath = '/orgs/:orgID'
   const shouldShowTasks = shouldShowResource && !isFlagEnabled('hideTasks')
   const shouldShowAlerts = shouldShowResource && !isFlagEnabled('hideAlerts')
+  const shouldShowDashboards =
+    shouldShowResource && !isFlagEnabled('hideDashboards')
+
   return (
     <PageSpinner loading={loading}>
       <Suspense fallback={<PageSpinner />}>


### PR DESCRIPTION
Closes #6519 

Behind feature flag `hideDashboards`
Pr hides Dashboards from CLOUD users whose orgs that are IOx enabled and are created after 1/31/23
For those orgs that meet this requirement, they will no longer see Dashboards in Navigation bar, can no longer use a link to route to Tasks, or save their queries as Dashboards.
<img width="1467" alt="Screen Shot 2023-01-27 at 9 07 22 AM" src="https://user-images.githubusercontent.com/66275100/215119087-8c26208c-8a7c-467e-b428-f0ab68004573.png">


UI demo with feature flag on and off
https://user-images.githubusercontent.com/66275100/215119690-69782052-0d1d-4b55-9eea-36f6498fc42d.mov


Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
