### PR TITLE
fix(6527): have the monaco-editor show sql, not pgsql

### DIFF
--- a/src/languageSupport/languages/sql/monaco.sql.syntax.ts
+++ b/src/languageSupport/languages/sql/monaco.sql.syntax.ts
@@ -2,7 +2,7 @@ import * as pgsql from 'monaco-editor/esm/vs/basic-languages/pgsql/pgsql'
 
 import {MonacoBasicLanguage} from 'src/types'
 
-const LANGID = 'pgsql'
+const LANGID = 'sql'
 
 function addSyntax() {
   monaco.languages.register({

--- a/src/shared/components/SqlMonacoEditor.tsx
+++ b/src/shared/components/SqlMonacoEditor.tsx
@@ -115,7 +115,7 @@ const SqlEditorMonaco: FC<Props> = ({
       <ErrorBoundary>
         <div className={wrapperClassName} data-testid="sql-editor">
           <MonacoEditor
-            language="pgsql"
+            language={SQLLANGID}
             theme={THEME_NAME}
             value={script}
             onChange={onChange}


### PR DESCRIPTION
Closes #6527 

<img width="611" alt="Screen Shot 2023-01-26 at 9 19 15 AM" src="https://user-images.githubusercontent.com/10232835/214905350-774430c1-2189-400d-9786-9a54cf81731e.png">



## Checklist
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
