### PR TITLE
fix(NewDatePicker): utilize local vs. UTC time zone

### DIFF
--- a/cypress/e2e/shared/scriptQueryBuilder.datePicker.test.ts
+++ b/cypress/e2e/shared/scriptQueryBuilder.datePicker.test.ts
@@ -70,7 +70,8 @@ describe('Date Picker', () => {
   })
 
   it('can set a custom time', () => {
-    const startTime = '2023-02-08 00:00'
+    const startTimeString: string = '2023-02-08 00:00'
+    const startTimeDate: Date = new Date(startTimeString)
 
     cy.getByTestID('timerange-dropdown--button').should('be.visible').click()
 
@@ -88,7 +89,7 @@ describe('Date Picker', () => {
     cy.getByTestID('daterange--apply-btn').should('be.disabled')
 
     cy.log('valid input removes the error')
-    cy.getByTestID('date-picker--input--from').clear().type(startTime)
+    cy.getByTestID('date-picker--input--from').clear().type(startTimeString)
     cy.getByTestID('date-picker--input--from--error').should('not.exist')
 
     cy.log(
@@ -102,7 +103,7 @@ describe('Date Picker', () => {
     cy.getByTestID('daterange--apply-btn').should('be.enabled').click()
     cy.getByTestID('timerange-dropdown--button')
       .should('be.visible')
-      .contains(startTime)
+      .contains(startTimeString)
 
     cy.log(
       'when time zone is Local, SQL composition should use standard UTC timestamp'
@@ -110,7 +111,7 @@ describe('Date Picker', () => {
     cy.getByTestID('sql-editor').within(() => {
       cy.get('textarea.inputarea').should(
         'contain.value',
-        `2023-02-08T06:00:00.000Z` // local time 00:00 equals standard UTD time 06:00
+        startTimeDate.toISOString()
       )
     })
 
@@ -120,11 +121,11 @@ describe('Date Picker', () => {
     cy.getByTestID('timerange-dropdown--button').should('be.visible').click()
     cy.getByTestID('timezone-dropdown').should('be.visible').click()
     cy.getByTestID('dropdown-item').should('be.visible').contains('UTC').click()
-    cy.getByTestID('date-picker--input--from').clear().type(startTime)
+    cy.getByTestID('date-picker--input--from').clear().type(startTimeString)
     cy.getByTestID('daterange--apply-btn').should('be.enabled').click()
     cy.getByTestID('timerange-dropdown--button')
       .should('be.visible')
-      .contains(startTime)
+      .contains(startTimeString)
 
     cy.log(
       'when time zone is UTC, SQL composition should use standard UTC timestamp'

--- a/cypress/e2e/shared/scriptQueryBuilder.datePicker.test.ts
+++ b/cypress/e2e/shared/scriptQueryBuilder.datePicker.test.ts
@@ -15,8 +15,7 @@ describe('Date Picker', () => {
       schemaComposition: true,
     }).then(() => {
       cy.clearSqlScriptSession()
-      cy.getByTestID('editor-sync--toggle').should('be.enabled')
-      // TODO(chunchun): assert toggle is active
+      cy.getByTestID('editor-sync--toggle').should('have.class', 'active')
     })
   })
 
@@ -70,9 +69,8 @@ describe('Date Picker', () => {
       .contains(validDuration)
   })
 
-  it('can set a custom time', () => {
+  it.only('can set a custom time', () => {
     const startTime = '2023-02-08 00:00'
-    // const sqlTimestampRegex = "time >= timestamp '2023-02-08T00:00:00.000Z'"
 
     cy.getByTestID('timerange-dropdown--button').should('be.visible').click()
 
@@ -109,12 +107,12 @@ describe('Date Picker', () => {
     cy.log(
       'SQL composition should use standard UTC timestamp regardless of timezone'
     )
-    // cy.getByTestID('sql-editor').within(() => {
-    //   cy.get('textarea.inputarea').should(
-    //     'contain',
-    //     new RegExp(sqlTimestampRegex, 'g')
-    //   )
-    // })
+    cy.getByTestID('sql-editor').within(() => {
+      cy.get('textarea.inputarea').should(
+        'contain.value',
+        `2023-02-08T06:00:00.000Z` // local time 00:00 equals standard UTD time 06:00
+      )
+    })
     // UTC time
     cy.getByTestID('timerange-dropdown--button').should('be.visible').click()
     cy.getByTestID('timezone-dropdown').should('be.visible').click()
@@ -124,12 +122,12 @@ describe('Date Picker', () => {
     cy.getByTestID('timerange-dropdown--button')
       .should('be.visible')
       .contains(startTime)
-    // cy.getByTestID('sql-editor').within(() => {
-    //   cy.get('textarea.inputarea').should(
-    //     'contain',
-    //     new RegExp(sqlTimestampRegex, 'g')
-    //   )
-    // })
+    cy.getByTestID('sql-editor').within(() => {
+      cy.get('textarea.inputarea').should(
+        'contain.value',
+        `2023-02-08T00:00:00.000Z`
+      )
+    })
     cy.getByTestID('date-picker--menu').should('not.exist')
 
     cy.log(

--- a/cypress/e2e/shared/scriptQueryBuilder.datePicker.test.ts
+++ b/cypress/e2e/shared/scriptQueryBuilder.datePicker.test.ts
@@ -1,4 +1,4 @@
-import {Organization} from '../../../src/types'
+// import {Organization} from '../../../src/types'
 
 // There are many different versions of date picker in UI.
 // This file covers the test for src/shared/components/dateRangePicker/NewDatePicker.tsx
@@ -7,7 +7,7 @@ describe('Date Picker', () => {
   before(() =>
     cy.flush().then(() =>
       cy.signin().then(() =>
-        cy.get('@org').then(({orgID}: Organization) => {
+        cy.get('@org').then(() => {
           // TODO(chunchun): write data?
         })
       )
@@ -26,14 +26,12 @@ describe('Date Picker', () => {
 
   it.only('should be able to select a duration', () => {
     cy.getByTestID('date-picker--menu').should('not.exist')
-    cy.getByTestID('timerange-dropdown--button')
-      .should('be.visible')
-      .click()
+    cy.getByTestID('timerange-dropdown--button').should('be.visible').click()
 
     cy.log('select a duration')
     cy.getByTestID('dropdown-item-past15m').click()
     cy.getByTestID('date-picker--menu').should('not.exist')
-    
+
     cy.log('dropdown button should display the selected duation')
     cy.getByTestID('timerange-dropdown--button')
       .should('be.visible')
@@ -45,12 +43,12 @@ describe('Date Picker', () => {
     cy.getByTestID('date-picker--input--from')
       .should('be.visible')
       .should('have.value', '-15m')
-    
+
     cy.log('input field "To" should show "now()"')
     cy.getByTestID('date-picker--input--to')
       .should('be.visible')
       .should('have.value', 'now()')
-    
+
     cy.log('SQL composition should add the right expression for time')
   })
 

--- a/cypress/e2e/shared/scriptQueryBuilder.datePicker.test.ts
+++ b/cypress/e2e/shared/scriptQueryBuilder.datePicker.test.ts
@@ -69,7 +69,7 @@ describe('Date Picker', () => {
       .contains(validDuration)
   })
 
-  it.only('can set a custom time', () => {
+  it('can set a custom time', () => {
     const startTime = '2023-02-08 00:00'
 
     cy.getByTestID('timerange-dropdown--button').should('be.visible').click()
@@ -92,9 +92,8 @@ describe('Date Picker', () => {
     cy.getByTestID('date-picker--input--from--error').should('not.exist')
 
     cy.log(
-      'dropdown button should display the custome time regardless of timezone'
+      'when time zone is Local, dropdown button should display the custome time'
     )
-    // Local time
     cy.getByTestID('timezone-dropdown').should('be.visible').click()
     cy.getByTestID('dropdown-item')
       .should('be.visible')
@@ -104,8 +103,9 @@ describe('Date Picker', () => {
     cy.getByTestID('timerange-dropdown--button')
       .should('be.visible')
       .contains(startTime)
+
     cy.log(
-      'SQL composition should use standard UTC timestamp regardless of timezone'
+      'when time zone is Local, SQL composition should use standard UTC timestamp'
     )
     cy.getByTestID('sql-editor').within(() => {
       cy.get('textarea.inputarea').should(
@@ -113,7 +113,10 @@ describe('Date Picker', () => {
         `2023-02-08T06:00:00.000Z` // local time 00:00 equals standard UTD time 06:00
       )
     })
-    // UTC time
+
+    cy.log(
+      'when time zone is UTC, dropdown button should display the custome time'
+    )
     cy.getByTestID('timerange-dropdown--button').should('be.visible').click()
     cy.getByTestID('timezone-dropdown').should('be.visible').click()
     cy.getByTestID('dropdown-item').should('be.visible').contains('UTC').click()
@@ -122,6 +125,10 @@ describe('Date Picker', () => {
     cy.getByTestID('timerange-dropdown--button')
       .should('be.visible')
       .contains(startTime)
+
+    cy.log(
+      'when time zone is UTC, SQL composition should use standard UTC timestamp'
+    )
     cy.getByTestID('sql-editor').within(() => {
       cy.get('textarea.inputarea').should(
         'contain.value',
@@ -129,9 +136,5 @@ describe('Date Picker', () => {
       )
     })
     cy.getByTestID('date-picker--menu').should('not.exist')
-
-    cy.log(
-      'flux query variables should set to standard UTC time to the backend regardless of timezone'
-    )
   })
 })

--- a/cypress/e2e/shared/scriptQueryBuilder.datePicker.test.ts
+++ b/cypress/e2e/shared/scriptQueryBuilder.datePicker.test.ts
@@ -70,9 +70,9 @@ describe('Date Picker', () => {
       .contains(validDuration)
   })
 
-  it.only('can set a custom time', () => {
+  it('can set a custom time', () => {
     const startTime = '2023-02-08 00:00'
-    const sqlTimestampRegex = "time >= timestamp '2023-02-08T00:00:00.000Z'"
+    // const sqlTimestampRegex = "time >= timestamp '2023-02-08T00:00:00.000Z'"
 
     cy.getByTestID('timerange-dropdown--button').should('be.visible').click()
 

--- a/cypress/e2e/shared/scriptQueryBuilder.datePicker.test.ts
+++ b/cypress/e2e/shared/scriptQueryBuilder.datePicker.test.ts
@@ -1,0 +1,84 @@
+import {Organization} from '../../../src/types'
+
+// There are many different versions of date picker in UI.
+// This file covers the test for src/shared/components/dateRangePicker/NewDatePicker.tsx
+
+describe('Date Picker', () => {
+  before(() =>
+    cy.flush().then(() =>
+      cy.signin().then(() =>
+        cy.get('@org').then(({orgID}: Organization) => {
+          // TODO(chunchun): write data?
+        })
+      )
+    )
+  )
+
+  beforeEach(() => {
+    cy.scriptsLoginWithFlags({
+      schemaComposition: true,
+    }).then(() => {
+      cy.clearSqlScriptSession()
+      cy.getByTestID('editor-sync--toggle').should('be.visible')
+      // TODO(chunchun): assert toggle is active
+    })
+  })
+
+  it.only('should be able to select a duration', () => {
+    cy.getByTestID('date-picker--menu').should('not.exist')
+    cy.getByTestID('timerange-dropdown--button')
+      .should('be.visible')
+      .click()
+
+    cy.log('select a duration')
+    cy.getByTestID('dropdown-item-past15m').click()
+    cy.getByTestID('date-picker--menu').should('not.exist')
+    
+    cy.log('dropdown button should display the selected duation')
+    cy.getByTestID('timerange-dropdown--button')
+      .should('be.visible')
+      .contains('Past 15m')
+      .should('have.length', 1)
+      .click()
+
+    cy.log('input field "From" should show the corresponding duration')
+    cy.getByTestID('date-picker--input--from')
+      .should('be.visible')
+      .should('have.value', '-15m')
+    
+    cy.log('input field "To" should show "now()"')
+    cy.getByTestID('date-picker--input--to')
+      .should('be.visible')
+      .should('have.value', 'now()')
+    
+    cy.log('SQL composition should add the right expression for time')
+  })
+
+  it('shoule be able to set a duration', () => {
+    cy.log('error on empty start date')
+
+    cy.log('error on duration expression')
+
+    cy.log('should error when invalud durations are input')
+  })
+
+  it('should be able to select or set a custom time', () => {
+    cy.log('should be able to select start times and stop times')
+
+    cy.log('should not submitting when stop times are before start times')
+
+    cy.log('should error when invalid times are input')
+
+    cy.log(
+      'dropdown button display time should match with the input custome time regardless of timezone'
+    )
+
+    cy.log(
+      'flux query variables should set to standard UTC time to the backend regardless of timezone'
+    )
+
+    cy.log(
+      'SQL composition should use standard UTC timestamp regardless of timezone'
+    )
+  })
+})

--- a/cypress/e2e/shared/scriptQueryBuilder.datePicker.test.ts
+++ b/cypress/e2e/shared/scriptQueryBuilder.datePicker.test.ts
@@ -2,11 +2,7 @@
 // This file covers the test for src/shared/components/dateRangePicker/NewDatePicker.tsx
 
 describe('Date Picker', () => {
-  before(() =>
-    cy.flush().then(() =>
-      cy.signin()
-    )
-  )
+  before(() => cy.flush().then(() => cy.signin()))
 
   beforeEach(() => {
     cy.scriptsLoginWithFlags({

--- a/cypress/e2e/shared/scriptQueryBuilder.results.test.ts
+++ b/cypress/e2e/shared/scriptQueryBuilder.results.test.ts
@@ -112,10 +112,7 @@ describe('Script Builder', () => {
       cy.wait('@query -1h')
 
       cy.log('query date range can be adjusted')
-      cy.getByTestID('timerange-dropdown').within(() => {
-        cy.getByTestID('dropdown--button').should('exist')
-        cy.getByTestID('dropdown--button').clickAttached()
-      })
+      cy.getByTestID('timerange-dropdown--button').should('be.visible').click()
       cy.getByTestID('dropdown-item-past15m').should('exist').click()
       cy.getByTestID('time-machine-submit-button').should('exist').click()
       cy.wait('@query -15m')
@@ -136,10 +133,9 @@ describe('Script Builder', () => {
         truncated: boolean
       ) => {
         cy.log('confirm on 1hr')
-        cy.getByTestID('timerange-dropdown').within(() => {
-          cy.getByTestID('dropdown--button').should('exist')
-          cy.getByTestID('dropdown--button').clickAttached()
-        })
+        cy.getByTestID('timerange-dropdown--button')
+          .should('be.visible')
+          .click()
         cy.getByTestID('dropdown-item-past1h').should('exist')
         cy.getByTestID('dropdown-item-past1h').clickAttached()
         cy.getByTestID('time-machine-submit-button').should('exist')

--- a/docker/Dockerfile.chronograf.prod
+++ b/docker/Dockerfile.chronograf.prod
@@ -52,7 +52,7 @@ RUN apk \
 # makes big steps like yarn install expensive
 RUN yarn install --production=false && \
     yarn generate && \
-    $(npm bin)/webpack --config ./webpack.${WEBPACK_FILE}.ts && \
+    npm exec --package=webpack -- webpack --config ./webpack.${WEBPACK_FILE}.ts && \
     rm -rf ./node_modules
 
 RUN mkdir /includes

--- a/src/shared/components/dateRangePicker/NewDatePicker.tsx
+++ b/src/shared/components/dateRangePicker/NewDatePicker.tsx
@@ -219,6 +219,8 @@ const DatePickerMenu: FC<Props> = ({onCollapse, timeRange, timeRangeLabel}) => {
         setInputEndDate(`${inputEndDate}ms`)
       }
     } else if (validateInput(inputStartDate)) {
+      // persist custom time in ISO format:
+      // 'YYYY-MM-DDTHH:mm:ss.sssZ', i.e. UTC time zone
       let lower: string = inputStartDate
       if (isValidDatepickerFormat(inputStartDate)) {
         const date =

--- a/src/shared/components/dateRangePicker/NewDatePicker.tsx
+++ b/src/shared/components/dateRangePicker/NewDatePicker.tsx
@@ -23,6 +23,7 @@ import {PersistanceContext} from 'src/dataExplorer/context/persistance'
 // Utils
 import {getTimeRangeLabel} from 'src/shared/utils/duration'
 import {isISODate} from 'src/shared/utils/dateTimeUtils'
+import {durationRegExp} from 'src/shared/utils/sqlInterval'
 import {SELECTABLE_TIME_RANGES} from 'src/shared/constants/timeRanges'
 import {useSelector} from 'react-redux'
 import {getTimeZone} from 'src/dashboards/selectors'
@@ -102,8 +103,6 @@ const DatePickerMenu: FC<Props> = ({onCollapse, timeRange, timeRangeLabel}) => {
     setRange(selectedTimeRange)
     collapse()
   }
-
-  const durationRegExp = /([0-9]+)(y|mo|w|d|h|ms|s|m|us|µs|ns)$/g
 
   const validateInput = (value: string) => {
     return (

--- a/src/shared/components/dateRangePicker/NewDatePicker.tsx
+++ b/src/shared/components/dateRangePicker/NewDatePicker.tsx
@@ -120,6 +120,9 @@ const DatePickerMenu: FC<Props> = ({onCollapse, timeRange, timeRangeLabel}) => {
 
   const handleSelectDate = (dates): void => {
     const [start, end] = dates
+    // The ReactDatePicker forces the timezone to be the Local timezone,
+    // so when our app in in UTC mode, to make the datepicker respect that timezone,
+    // we have to manually manipulate the Local time and add the offset so that it displays the correct UTC time in the picker
     if (timeZone === 'UTC') {
       if (start) {
         start.setMinutes(start.getMinutes() + start.getTimezoneOffset())

--- a/src/shared/components/dateRangePicker/NewDatePicker.tsx
+++ b/src/shared/components/dateRangePicker/NewDatePicker.tsx
@@ -179,6 +179,16 @@ const DatePickerMenu: FC<Props> = ({onCollapse, timeRange, timeRangeLabel}) => {
         .join(':')
       endInput = `${dateParts} ${timeParts}`
     }
+
+    // the start and end date should be valid by now
+    // remove any error message if there is any
+    if (inputStartErrorMessage !== NBSP) {
+      setInputStartErrorMessage(NBSP)
+    }
+    if (inputEndErrorMessage !== NBSP) {
+      setInputEndErrorMessage(NBSP)
+    }
+
     setInputStartDate(startInput)
     setInputEndDate(endInput)
   }
@@ -335,7 +345,11 @@ const DatePickerMenu: FC<Props> = ({onCollapse, timeRange, timeRangeLabel}) => {
                 </div>
               </Input>
             </Form.Element>
-            <Form.Element label="To" errorMessage={inputEndErrorMessage}>
+            <Form.Element
+              className="date-picker--form"
+              label="To"
+              errorMessage={inputEndErrorMessage}
+            >
               <Input
                 className="date-picker__input"
                 onChange={handleSetEndDate}

--- a/src/shared/components/dateRangePicker/NewDatePicker.tsx
+++ b/src/shared/components/dateRangePicker/NewDatePicker.tsx
@@ -105,10 +105,10 @@ const DatePickerMenu: FC<Props> = ({onCollapse, timeRange, timeRangeLabel}) => {
 
   const durationRegExp = /([0-9]+)(y|mo|w|d|h|ms|s|m|us|µs|ns)$/g
 
-  const validateInput = value => {
+  const validateInput = (value: string) => {
     return (
       isValidDatepickerFormat(value) ||
-      !!value.match(durationRegExp) ||
+      !!value?.match(durationRegExp) ||
       value === 'now()' ||
       isNaN(Number(value)) === false
     )
@@ -335,7 +335,7 @@ const DatePickerMenu: FC<Props> = ({onCollapse, timeRange, timeRangeLabel}) => {
                     : ComponentStatus.Error
                 }
                 type={InputType.Text}
-                value={convertToDisplayFormat(inputStartDate, timeZone)}
+                value={convertToDisplayFormat(inputStartDate, timeZone) ?? ''}
               >
                 <div
                   className="date-picker--calendar-icon"
@@ -355,7 +355,7 @@ const DatePickerMenu: FC<Props> = ({onCollapse, timeRange, timeRangeLabel}) => {
                     : ComponentStatus.Error
                 }
                 type={InputType.Text}
-                value={convertToDisplayFormat(inputEndDate, timeZone)}
+                value={convertToDisplayFormat(inputEndDate, timeZone) ?? ''}
               >
                 <div
                   className="date-picker--calendar-icon"

--- a/src/shared/components/dateRangePicker/NewDatePicker.tsx
+++ b/src/shared/components/dateRangePicker/NewDatePicker.tsx
@@ -146,17 +146,6 @@ const DatePickerMenu: FC<Props> = ({onCollapse, timeRange, timeRangeLabel}) => {
 
   const handleSelectDate = (dates): void => {
     const [start, end] = dates
-    // The ReactDatePicker forces the timezone to be the Local timezone,
-    // so when our app in in UTC mode, to make the datepicker respect
-    // that timezone, we have to manually manipulate the Local time
-    if (timeZone === 'UTC') {
-      if (start) {
-        start.setMinutes(start.getMinutes() + start.getTimezoneOffset())
-      }
-      if (end) {
-        end.setMinutes(end.getMinutes() + end.getTimezoneOffset())
-      }
-    }
     setDateRange([start, end])
     let startInput = start
     let endInput = end

--- a/src/shared/components/dateRangePicker/NewDatePicker.tsx
+++ b/src/shared/components/dateRangePicker/NewDatePicker.tsx
@@ -283,7 +283,10 @@ const DatePickerMenu: FC<Props> = ({onCollapse, timeRange, timeRangeLabel}) => {
       <FlexBox direction={FlexDirection.Row} alignItems={AlignItems.Stretch}>
         {isDatePickerOpen && (
           <div className="react-datepicker-ignore-onclickoutside date-picker--calendar-dropdown">
-            <div className="date-picker__select-date-picker range-picker--date-pickers">
+            <div
+              className="date-picker__select-date-picker range-picker--date-pickers"
+              data-testid="date-picker__select-date-picker"
+            >
               <InputLabel className="date-picker--label__calendar">
                 Calendar
               </InputLabel>
@@ -342,6 +345,7 @@ const DatePickerMenu: FC<Props> = ({onCollapse, timeRange, timeRangeLabel}) => {
                 <div
                   className="date-picker--calendar-icon"
                   onClick={handleOpenCalendar}
+                  data-testid="date-picker--calendar-icon"
                 >
                   <Icon glyph={IconFont.Calendar} />
                 </div>

--- a/src/shared/components/dateRangePicker/NewDatePicker.tsx
+++ b/src/shared/components/dateRangePicker/NewDatePicker.tsx
@@ -278,6 +278,7 @@ const DatePickerMenu: FC<Props> = ({onCollapse, timeRange, timeRangeLabel}) => {
       }}
       className="date-picker--menu"
       maxHeight={367}
+      testID="date-picker--menu"
     >
       <FlexBox direction={FlexDirection.Row} alignItems={AlignItems.Stretch}>
         {isDatePickerOpen && (
@@ -336,6 +337,7 @@ const DatePickerMenu: FC<Props> = ({onCollapse, timeRange, timeRangeLabel}) => {
                 }
                 type={InputType.Text}
                 value={convertToDisplayFormat(inputStartDate, timeZone) ?? ''}
+                testID="date-picker--input--from"
               >
                 <div
                   className="date-picker--calendar-icon"
@@ -360,6 +362,7 @@ const DatePickerMenu: FC<Props> = ({onCollapse, timeRange, timeRangeLabel}) => {
                 }
                 type={InputType.Text}
                 value={convertToDisplayFormat(inputEndDate, timeZone) ?? ''}
+                testID="date-picker--input--to"
               >
                 <div
                   className="date-picker--calendar-icon"
@@ -452,6 +455,7 @@ const DatePicker: FC = () => {
           active={active}
           onClick={onClick}
           icon={IconFont.Clock_New}
+          testID="timerange-dropdown--button"
         >
           {timeRangeLabel}
         </Dropdown.Button>

--- a/src/shared/utils/sqlInterval.test.ts
+++ b/src/shared/utils/sqlInterval.test.ts
@@ -43,13 +43,13 @@ describe('rangeToInterval:', () => {
       })
     })
   })
-  describe('handles timestamp timeRanges', () => {
+  describe('handles timestamp timeRanges in ISO format', () => {
     const toTest = [
       {
-        msg: 'when provided without timezones',
+        msg: 'timestamps with upper and lower bounds',
         input: {
-          lower: '2023-01-03 00:00Z',
-          upper: '2023-01-04 23:59Z',
+          lower: '2023-01-03T00:00:00.000Z',
+          upper: '2023-01-04T23:59:00.000Z',
           type: 'custom',
         },
         expected: `time >= timestamp '2023-01-03T00:00:00.000Z' AND time <= timestamp '2023-01-04T23:59:00.000Z'`,
@@ -57,22 +57,12 @@ describe('rangeToInterval:', () => {
       {
         msg: 'for timestamps without upper bounds',
         input: {
-          lower: '2023-01-03 00:00Z',
+          lower: '2023-01-03T00:00:00.000Z',
           upper: null,
           type: 'custom',
         },
         expected: `time >= timestamp '2023-01-03T00:00:00.000Z' AND time <= now()`,
       },
-      // TODO -- this is what the new datePicker places in persistence context. No timezone. Will Fail.
-      // {
-      //   msg: 'for timestamps without upper bounds',
-      //   input: {
-      //     lower: '2023-01-03 00:00',
-      //     upper: null,
-      //     type: 'custom',
-      //   },
-      //   expected: `time >= timestamp '2023-01-03T08:00:00.000Z' AND time <= now()`,
-      // },
     ]
     toTest.forEach(({msg, input, expected}) => {
       it(msg, () => {

--- a/src/shared/utils/sqlInterval.ts
+++ b/src/shared/utils/sqlInterval.ts
@@ -1,7 +1,7 @@
 import {TimeRange} from 'src/types'
 import {DEFAULT_TIME_RANGE} from 'src/shared/constants/timeRanges'
 
-const durationExpr = /^(\-)?(([0-9]+)(y|mo|w|d|h|ms|s|m|us|µs|ns))+$/g
+export const durationRegExp = /^(\-)?(([0-9]+)(y|mo|w|d|h|ms|s|m|us|µs|ns))+$/g
 const singleDuration = /(([0-9]+)(y|mo|w|d|h|ms|s|m|us|µs|ns))/g
 const nanosecondDuration = /(([0-9]+)(ns))/g
 const microsecondDuration = /(([0-9,\.]+)(\W?)(microsecond))/g
@@ -10,7 +10,7 @@ const convertToInterval = (upperOrLower: string) => {
   if (upperOrLower == null || upperOrLower == 'now()') {
     return 'now()'
   }
-  if (!!upperOrLower.match(durationExpr)) {
+  if (!!upperOrLower.match(durationRegExp)) {
     const durationIntoPast = upperOrLower.trim()[0] == '-'
     let interval = [
       ...upperOrLower


### PR DESCRIPTION
Closes #6451 

This PR persists the custom time range in UTC time zone with ISO format for the new date picker. Then the input form converts and displays the time according to the time zone that's selected by users. 

## Before

https://user-images.githubusercontent.com/14298407/215828719-73c89995-53d8-43a2-9765-9545052bde6f.mov

## After

https://user-images.githubusercontent.com/14298407/215828298-fac53073-8a0f-4383-995d-189c01fa0fe3.mov



### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
