### PR TITLE
chore: conditionally hide templates under certain conditions

### DIFF
--- a/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -31,6 +31,9 @@ import {
 } from 'src/dashboards/actions/thunks'
 import {resetViews} from 'src/views/actions/creators'
 
+// Selectors
+import {selectShouldShowResource} from 'src/shared/selectors/app'
+
 // Types
 import {Label, AppState} from 'src/types'
 
@@ -154,14 +157,16 @@ class DashboardCard extends PureComponent<Props> {
           style={minWidth}
           contents={_ => (
             <List>
-              <List.Item
-                onClick={this.handleExport}
-                size={ComponentSize.Small}
-                style={fontWeight}
-                testID="context-export-dashboard"
-              >
-                Download Template
-              </List.Item>
+              {this.props.shouldShowTemplates && (
+                <List.Item
+                  onClick={this.handleExport}
+                  size={ComponentSize.Small}
+                  style={fontWeight}
+                  testID="context-export-dashboard"
+                >
+                  Download Template
+                </List.Item>
+              )}
               <List.Item
                 onClick={this.handleCloneDashboard}
                 size={ComponentSize.Small}
@@ -243,9 +248,12 @@ const mdtp = {
 
 const mstp = (state: AppState, props: OwnProps) => {
   const dashboard = state.resources.dashboards.byID[props.id]
+  const shouldShowTemplates =
+    selectShouldShowResource(state) && !isFlagEnabled('hideTemplates')
 
   return {
     dashboard,
+    shouldShowTemplates,
   }
 }
 const connector = connect(mstp, mdtp)

--- a/src/pageLayout/containers/MainNavigation.tsx
+++ b/src/pageLayout/containers/MainNavigation.tsx
@@ -194,6 +194,7 @@ const generateNavItems = (
           testID: 'nav-subitem-templates',
           label: 'Templates',
           link: `/orgs/${orgID}/settings/templates`,
+          enabled: () => shouldShowResource && !isFlagEnabled('hideTemplates'),
         },
         {
           id: 'labels',

--- a/src/shared/components/AddResourceDropdown.tsx
+++ b/src/shared/components/AddResourceDropdown.tsx
@@ -14,8 +14,15 @@ import {
 // Actions
 import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
 
+// Selectors
+import {selectShouldShowResource} from 'src/shared/selectors/app'
+
+// Utils
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+
 // Types
 import {LimitStatus} from 'src/cloud/actions/limits'
+import {AppState} from 'src/types'
 
 // Constants
 import {CLOUD} from 'src/shared/constants'
@@ -81,7 +88,9 @@ class AddResourceDropdown extends PureComponent<Props> {
     const importOption = this.importOption
     const newOption = this.newOption
     const templateOption = this.templateOption
-    const fromDashboard = this.props.resourceName === 'Dashboard'
+    const shouldShowTemplateFromDashboard =
+      this.props.resourceName === 'Dashboard' &&
+      this.props.shouldShowTemplates === true
 
     const templateFromDashboard = (
       <Dropdown.Item
@@ -114,7 +123,7 @@ class AddResourceDropdown extends PureComponent<Props> {
       >
         {importOption}
       </Dropdown.Item>,
-      ...(fromDashboard ? [templateFromDashboard] : []),
+      ...(shouldShowTemplateFromDashboard ? [templateFromDashboard] : []),
     ]
 
     return items
@@ -162,11 +171,18 @@ class AddResourceDropdown extends PureComponent<Props> {
   }
 }
 
+const mstp = (state: AppState) => {
+  return {
+    shouldShowTemplates:
+      selectShouldShowResource(state) && !isFlagEnabled('hideTemplates'),
+  }
+}
+
 const mdtp = {
   onShowOverlay: showOverlay,
   onDismissOverlay: dismissOverlay,
 }
 
-const connector = connect(null, mdtp)
+const connector = connect(mstp, mdtp)
 
 export default connector(AddResourceDropdown)

--- a/src/shared/containers/SetOrg.tsx
+++ b/src/shared/containers/SetOrg.tsx
@@ -133,6 +133,8 @@ const SetOrg: FC = () => {
   const shouldShowAlerts = shouldShowResource && !isFlagEnabled('hideAlerts')
   const shouldShowDashboards =
     shouldShowResource && !isFlagEnabled('hideDashboards')
+  const shouldShowTemplates =
+    shouldShowResource && !isFlagEnabled('hideTemplates')
 
   return (
     <PageSpinner loading={loading}>
@@ -289,10 +291,12 @@ const SetOrg: FC = () => {
             path={`${orgPath}/${SETTINGS}/${VARIABLES}`}
             component={VariablesIndex}
           />
-          <Route
-            path={`${orgPath}/${SETTINGS}/${TEMPLATES}`}
-            component={CommunityTemplatesIndex}
-          />
+          {shouldShowTemplates && (
+            <Route
+              path={`${orgPath}/${SETTINGS}/${TEMPLATES}`}
+              component={CommunityTemplatesIndex}
+            />
+          )}
           <Route
             exact
             path={`${orgPath}/${SETTINGS}/${LABELS}`}


### PR DESCRIPTION
Closes #6520

Makes use of the feature flag `hideTemplates`

If the conditions outlined below to hide templates are met:
- Templates navigation option is removed from the Settings sub nav on the main navigation page
- Option to import a dashboard from a template is removed from the Create Dashboard dropdown button
- Option to save a dashboard as a template is removed from the dashboard card on the dashboard list page

Flow chart showing the logical progression (in the order it happens) to determine whether to show templates:
![Screenshot 2023-01-27 at 10 31 06 AM](https://user-images.githubusercontent.com/146112/215124580-a5da527a-34eb-40db-803b-21b7f9e88d27.png)


### Checklist

Authors and Reviewer(s), please verify the following:

- [ ] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [ ] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
