### PR TITLE
chore: conditionally render variables in the UI, correct isNewIOxOrg selector

### DIFF
--- a/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -249,7 +249,7 @@ const mdtp = {
 const mstp = (state: AppState, props: OwnProps) => {
   const dashboard = state.resources.dashboards.byID[props.id]
   const shouldShowTemplates =
-  !selectIsNewIOxOrg(state) || !isFlagEnabled('hideTemplates')
+    !selectIsNewIOxOrg(state) || !isFlagEnabled('hideTemplates')
 
   return {
     dashboard,

--- a/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -249,7 +249,7 @@ const mdtp = {
 const mstp = (state: AppState, props: OwnProps) => {
   const dashboard = state.resources.dashboards.byID[props.id]
   const shouldShowTemplates =
-    !selectIsNewIOxOrg(state) || !isFlagEnabled('hideTemplates')
+    !selectIsNewIOxOrg(state) || isFlagEnabled('showTemplatesInNewIOx')
 
   return {
     dashboard,

--- a/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -32,7 +32,7 @@ import {
 import {resetViews} from 'src/views/actions/creators'
 
 // Selectors
-import {selectShouldShowResource} from 'src/shared/selectors/app'
+import {selectIsNewIOxOrg} from 'src/shared/selectors/app'
 
 // Types
 import {Label, AppState} from 'src/types'
@@ -249,7 +249,7 @@ const mdtp = {
 const mstp = (state: AppState, props: OwnProps) => {
   const dashboard = state.resources.dashboards.byID[props.id]
   const shouldShowTemplates =
-    selectShouldShowResource(state) && !isFlagEnabled('hideTemplates')
+  !selectIsNewIOxOrg(state) || !isFlagEnabled('hideTemplates')
 
   return {
     dashboard,

--- a/src/dataExplorer/components/DataExplorerPage.tsx
+++ b/src/dataExplorer/components/DataExplorerPage.tsx
@@ -28,6 +28,7 @@ import RenamablePageTitle from 'src/pageLayout/components/RenamablePageTitle'
 
 // Selectors
 import {selectIsNewIOxOrg} from 'src/shared/selectors/app'
+import {selectShouldShowNotebooks} from 'src/flows/selectors/flowsSelectors'
 
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
@@ -116,14 +117,14 @@ const DataExplorerPage: FC = () => {
   const showNewExplorer = scriptQueryBuilder && isFlagEnabled('newDataExplorer')
   const history = useHistory()
   const isNewIOxOrg = useSelector(selectIsNewIOxOrg)
+  const showNotebooks = useSelector(selectShouldShowNotebooks)
 
-  const allIOxDeprecateFlagsEnabled =
-    isFlagEnabled('hideTasks') &&
-    isFlagEnabled('hideDashboards') &&
-    isFlagEnabled('hideVariables') &&
-    isFlagEnabled('hideNotebooks')
-
-  const showSaveAsButton = !isNewIOxOrg || !allIOxDeprecateFlagsEnabled
+  const showSaveAsButton =
+    !isNewIOxOrg ||
+    showNotebooks ||
+    isFlagEnabled('showTasksInNewIOx') ||
+    isFlagEnabled('showDashboardsInNewIOx') ||
+    isFlagEnabled('showVariablesInNewIOx')
 
   const hideFlowsCTA = () => {
     setFlowsCTA({explorer: false})

--- a/src/dataExplorer/components/DataExplorerPage.tsx
+++ b/src/dataExplorer/components/DataExplorerPage.tsx
@@ -117,14 +117,13 @@ const DataExplorerPage: FC = () => {
   const history = useHistory()
   const isNewIOxOrg = useSelector(selectIsNewIOxOrg)
 
-  const allIOxDeprecateFlags =
+  const allIOxDeprecateFlagsEnabled =
     isFlagEnabled('hideTasks') &&
     isFlagEnabled('hideDashboards') &&
     isFlagEnabled('hideVariables') &&
     isFlagEnabled('hideNotebooks')
 
-  // show SaveAsButton if org is not new iox org or all iox deprecation feature flags are enabled
-  const showSaveAsButton = !isNewIOxOrg || !allIOxDeprecateFlags
+  const showSaveAsButton = !isNewIOxOrg || !allIOxDeprecateFlagsEnabled
 
   const hideFlowsCTA = () => {
     setFlowsCTA({explorer: false})

--- a/src/dataExplorer/components/DataExplorerPage.tsx
+++ b/src/dataExplorer/components/DataExplorerPage.tsx
@@ -1,6 +1,7 @@
 // Libraries
 import React, {FC, useContext, useEffect} from 'react'
 import {Switch, Route, Link, useHistory} from 'react-router-dom'
+import {useSelector} from 'react-redux'
 
 // Components
 import DataExplorer from 'src/dataExplorer/components/DataExplorer'
@@ -24,6 +25,9 @@ import {AddAnnotationDEOverlay} from 'src/overlays/components/index'
 import {EditAnnotationDEOverlay} from 'src/overlays/components/index'
 import TemplatePage from 'src/dataExplorer/components/resources/TemplatePage'
 import RenamablePageTitle from 'src/pageLayout/components/RenamablePageTitle'
+
+// Selectors
+import {selectIsNewIOxOrg} from 'src/shared/selectors/app'
 
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
@@ -111,6 +115,16 @@ const DataExplorerPage: FC = () => {
   useLoadTimeReporting('DataExplorerPage load start')
   const showNewExplorer = scriptQueryBuilder && isFlagEnabled('newDataExplorer')
   const history = useHistory()
+  const isNewIOxOrg = useSelector(selectIsNewIOxOrg)
+
+  const allIOxDeprecateFlags =
+  isFlagEnabled('hideTasks') &&
+  isFlagEnabled('hideDashboards') &&
+  isFlagEnabled('hideVariables') &&
+  isFlagEnabled('hideNotebooks')
+  
+  // show SaveAsButton if org is not new iox org or all iox deprecation feature flags are enabled
+  const showSaveAsButton = !isNewIOxOrg || !allIOxDeprecateFlags
 
   const hideFlowsCTA = () => {
     setFlowsCTA({explorer: false})
@@ -187,7 +201,7 @@ const DataExplorerPage: FC = () => {
             </Page.ControlBarLeft>
             <Page.ControlBarRight>
               <TimeZoneDropdown />
-              <SaveAsButton />
+              {showSaveAsButton && <SaveAsButton />}
             </Page.ControlBarRight>
           </Page.ControlBar>
         )}

--- a/src/dataExplorer/components/DataExplorerPage.tsx
+++ b/src/dataExplorer/components/DataExplorerPage.tsx
@@ -118,11 +118,11 @@ const DataExplorerPage: FC = () => {
   const isNewIOxOrg = useSelector(selectIsNewIOxOrg)
 
   const allIOxDeprecateFlags =
-  isFlagEnabled('hideTasks') &&
-  isFlagEnabled('hideDashboards') &&
-  isFlagEnabled('hideVariables') &&
-  isFlagEnabled('hideNotebooks')
-  
+    isFlagEnabled('hideTasks') &&
+    isFlagEnabled('hideDashboards') &&
+    isFlagEnabled('hideVariables') &&
+    isFlagEnabled('hideNotebooks')
+
   // show SaveAsButton if org is not new iox org or all iox deprecation feature flags are enabled
   const showSaveAsButton = !isNewIOxOrg || !allIOxDeprecateFlags
 

--- a/src/dataExplorer/components/SaveAsOverlay.tsx
+++ b/src/dataExplorer/components/SaveAsOverlay.tsx
@@ -35,9 +35,9 @@ const SaveAsOverlay: FC = () => {
   const history = useHistory()
   const isNewIOxOrg = useSelector(selectIsNewIOxOrg)
   const shouldShowNotebooks = useSelector(selectShouldShowNotebooks)
-  const shouldShowDashboards = !isNewIOxOrg || !isFlagEnabled('hideDashboards')
-  const shouldShowTasks = !isNewIOxOrg || !isFlagEnabled('hideTasks')
-  const shouldShowVariables = !isNewIOxOrg || !isFlagEnabled('hideVariables')
+  const shouldShowDashboards = !isNewIOxOrg || isFlagEnabled('showDashboardsInNewIOx')
+  const shouldShowTasks = !isNewIOxOrg || isFlagEnabled('showTasksInNewIOx')
+  const shouldShowVariables = !isNewIOxOrg || isFlagEnabled('showVariablesInNewIOx')
 
   const getActiveTab = (): SaveAsOption => {
     if (shouldShowDashboards) {

--- a/src/dataExplorer/components/SaveAsOverlay.tsx
+++ b/src/dataExplorer/components/SaveAsOverlay.tsx
@@ -35,9 +35,11 @@ const SaveAsOverlay: FC = () => {
   const history = useHistory()
   const isNewIOxOrg = useSelector(selectIsNewIOxOrg)
   const shouldShowNotebooks = useSelector(selectShouldShowNotebooks)
-  const shouldShowDashboards = !isNewIOxOrg || isFlagEnabled('showDashboardsInNewIOx')
+  const shouldShowDashboards =
+    !isNewIOxOrg || isFlagEnabled('showDashboardsInNewIOx')
   const shouldShowTasks = !isNewIOxOrg || isFlagEnabled('showTasksInNewIOx')
-  const shouldShowVariables = !isNewIOxOrg || isFlagEnabled('showVariablesInNewIOx')
+  const shouldShowVariables =
+    !isNewIOxOrg || isFlagEnabled('showVariablesInNewIOx')
 
   const getActiveTab = (): SaveAsOption => {
     if (shouldShowDashboards) {
@@ -61,6 +63,7 @@ const SaveAsOverlay: FC = () => {
     event('Data Explorer Save as Menu Changed', {menu: saveAsOption})
   }, [saveAsOption])
 
+  // sets the default tab to be the first tab that is enabled
   let saveAsForm
   if (shouldShowDashboards) {
     saveAsForm = <SaveAsCellForm dismiss={hide} />
@@ -72,6 +75,7 @@ const SaveAsOverlay: FC = () => {
     saveAsForm = <SaveAsNotebookForm dismiss={hide} />
   }
 
+  // displays the correct tab based on the selected tab
   if (shouldShowTasks && saveAsOption === SaveAsOption.Task) {
     saveAsForm = <SaveAsTaskForm dismiss={hide} />
   } else if (shouldShowVariables && saveAsOption === SaveAsOption.Variable) {

--- a/src/dataExplorer/components/SaveAsOverlay.tsx
+++ b/src/dataExplorer/components/SaveAsOverlay.tsx
@@ -35,18 +35,16 @@ const SaveAsOverlay: FC = () => {
   const history = useHistory()
   const isNewIOxOrg = useSelector(selectIsNewIOxOrg)
   const shouldShowNotebooks = useSelector(selectShouldShowNotebooks)
-  const shouldShowDashboards =
-    !isNewIOxOrg || !isFlagEnabled('hideDashboards')
+  const shouldShowDashboards = !isNewIOxOrg || !isFlagEnabled('hideDashboards')
   const shouldShowTasks = !isNewIOxOrg || !isFlagEnabled('hideTasks')
-  const shouldShowVariables =
-    !isNewIOxOrg || !isFlagEnabled('hideVariables')
+  const shouldShowVariables = !isNewIOxOrg || !isFlagEnabled('hideVariables')
 
   const getActiveTab = (): SaveAsOption => {
-    if(shouldShowDashboards) {
+    if (shouldShowDashboards) {
       return SaveAsOption.Dashboard
-    } else if(shouldShowVariables) {
+    } else if (shouldShowVariables) {
       return SaveAsOption.Variable
-    } else if(shouldShowTasks) {
+    } else if (shouldShowTasks) {
       return SaveAsOption.Task
     } else {
       return SaveAsOption.Notebook
@@ -80,7 +78,7 @@ const SaveAsOverlay: FC = () => {
     saveAsForm = <SaveAsVariable onHideOverlay={hide} />
   } else if (shouldShowNotebooks && saveAsOption === SaveAsOption.Notebook) {
     saveAsForm = <SaveAsNotebookForm dismiss={hide} />
-  } 
+  }
 
   return (
     <Overlay visible={true}>

--- a/src/pageLayout/containers/MainNavigation.tsx
+++ b/src/pageLayout/containers/MainNavigation.tsx
@@ -195,7 +195,7 @@ const generateNavItems = (
           testID: 'nav-subitem-templates',
           label: 'Templates',
           link: `/orgs/${orgID}/settings/templates`,
-          enabled: () => !isNewIOxOrg || !isFlagEnabled('hideTemplates')
+          enabled: () => !isNewIOxOrg || !isFlagEnabled('hideTemplates'),
         },
         {
           id: 'labels',

--- a/src/pageLayout/containers/MainNavigation.tsx
+++ b/src/pageLayout/containers/MainNavigation.tsx
@@ -141,7 +141,7 @@ const generateNavItems = (
       shortLabel: 'Boards',
       link: `/orgs/${orgID}/dashboards-list`,
       activeKeywords: ['dashboards', 'dashboards-list'],
-      enabled: () => !isNewIOxOrg || !isFlagEnabled('hideDashboards'),
+      enabled: () => !isNewIOxOrg || isFlagEnabled('showDashboardsInNewIOx'),
     },
     {
       id: 'tasks',
@@ -150,7 +150,7 @@ const generateNavItems = (
       label: 'Tasks',
       link: `/orgs/${orgID}/tasks`,
       activeKeywords: ['tasks'],
-      enabled: () => !isNewIOxOrg || !isFlagEnabled('hideTasks'),
+      enabled: () => !isNewIOxOrg || isFlagEnabled('showTasksInNewIOx'),
     },
     {
       id: 'alerting',
@@ -173,7 +173,7 @@ const generateNavItems = (
           link: `/orgs/${orgID}/alert-history`,
         },
       ],
-      enabled: () => !isNewIOxOrg || !isFlagEnabled('hideAlerts'),
+      enabled: () => !isNewIOxOrg || isFlagEnabled('showAlertsInNewIOx'),
     },
     {
       id: 'settings',
@@ -188,14 +188,14 @@ const generateNavItems = (
           testID: 'nav-subitem-variables',
           label: 'Variables',
           link: `/orgs/${orgID}/settings/variables`,
-          enabled: () => !isNewIOxOrg || !isFlagEnabled('hideVariables'),
+          enabled: () => !isNewIOxOrg || isFlagEnabled('showVariablesInNewIOx'),
         },
         {
           id: 'templates',
           testID: 'nav-subitem-templates',
           label: 'Templates',
           link: `/orgs/${orgID}/settings/templates`,
-          enabled: () => !isNewIOxOrg || !isFlagEnabled('hideTemplates'),
+          enabled: () => !isNewIOxOrg || isFlagEnabled('showTemplatesInNewIOx'),
         },
         {
           id: 'labels',

--- a/src/pageLayout/containers/MainNavigation.tsx
+++ b/src/pageLayout/containers/MainNavigation.tsx
@@ -26,7 +26,7 @@ import {
   selectOperatorRole,
 } from 'src/identity/selectors'
 import {selectShouldShowNotebooks} from 'src/flows/selectors/flowsSelectors'
-import {selectShouldShowResource} from 'src/shared/selectors/app'
+import {selectIsNewIOxOrg} from 'src/shared/selectors/app'
 
 // Types
 import {IdentityUser} from 'src/client/unityRoutes'
@@ -61,7 +61,7 @@ const generateNavItems = (
   orgID: string,
   operatorRole: IdentityUser['operatorRole'],
   shouldShowNotebooks: boolean,
-  shouldShowResource: boolean
+  isNewIOxOrg: boolean
 ): NavItem[] => {
   const navItems: NavItem[] = [
     {
@@ -141,7 +141,7 @@ const generateNavItems = (
       shortLabel: 'Boards',
       link: `/orgs/${orgID}/dashboards-list`,
       activeKeywords: ['dashboards', 'dashboards-list'],
-      enabled: () => shouldShowResource && !isFlagEnabled('hideDashboards'),
+      enabled: () => !isNewIOxOrg || !isFlagEnabled('hideDashboards'),
     },
     {
       id: 'tasks',
@@ -150,7 +150,7 @@ const generateNavItems = (
       label: 'Tasks',
       link: `/orgs/${orgID}/tasks`,
       activeKeywords: ['tasks'],
-      enabled: () => shouldShowResource && !isFlagEnabled('hideTasks'),
+      enabled: () => !isNewIOxOrg || !isFlagEnabled('hideTasks'),
     },
     {
       id: 'alerting',
@@ -173,7 +173,7 @@ const generateNavItems = (
           link: `/orgs/${orgID}/alert-history`,
         },
       ],
-      enabled: () => shouldShowResource && !isFlagEnabled('hideAlerts'),
+      enabled: () => !isNewIOxOrg || !isFlagEnabled('hideAlerts'),
     },
     {
       id: 'settings',
@@ -188,13 +188,14 @@ const generateNavItems = (
           testID: 'nav-subitem-variables',
           label: 'Variables',
           link: `/orgs/${orgID}/settings/variables`,
+          enabled: () => !isNewIOxOrg || !isFlagEnabled('hideVariables'),
         },
         {
           id: 'templates',
           testID: 'nav-subitem-templates',
           label: 'Templates',
           link: `/orgs/${orgID}/settings/templates`,
-          enabled: () => shouldShowResource && !isFlagEnabled('hideTemplates'),
+          enabled: () => !isNewIOxOrg || !isFlagEnabled('hideTemplates')
         },
         {
           id: 'labels',
@@ -245,7 +246,7 @@ export const MainNavigation: FC = () => {
   const accountType = useSelector(selectCurrentAccountType)
   const operatorRole = useSelector(selectOperatorRole)
   const shouldShowNotebooks = useSelector(selectShouldShowNotebooks)
-  const shouldShowResource = useSelector(selectShouldShowResource)
+  const isNewIOxOrg = useSelector(selectIsNewIOxOrg)
 
   const dispatch = useDispatch()
 
@@ -307,7 +308,7 @@ export const MainNavigation: FC = () => {
         org.id,
         operatorRole,
         shouldShowNotebooks,
-        shouldShowResource
+        isNewIOxOrg
       ).map((item: NavItem) => {
         const linkElement = (className: string): JSX.Element => (
           <Link

--- a/src/settings/components/SettingsNavigation.tsx
+++ b/src/settings/components/SettingsNavigation.tsx
@@ -27,7 +27,6 @@ const SettingsNavigation: FC<Props> = ({activeTab}) => {
   const org = useSelector(getOrg)
   const isNewIOxOrg = useSelector(selectIsNewIOxOrg)
 
-
   const handleTabClick = (id: string): void => {
     event('page-nav clicked', {which: `settings--${id}`})
     history.push(`/orgs/${org.id}/settings/${id}`)
@@ -37,22 +36,22 @@ const SettingsNavigation: FC<Props> = ({activeTab}) => {
     {
       text: 'Variables',
       id: 'variables',
-      enabled: !isNewIOxOrg || isFlagEnabled('showVariablesInNewIOx')
+      enabled: !isNewIOxOrg || isFlagEnabled('showVariablesInNewIOx'),
     },
     {
       text: 'Templates',
       id: 'templates',
-      enabled: !isNewIOxOrg || isFlagEnabled('showTemplatesInNewIOx')
+      enabled: !isNewIOxOrg || isFlagEnabled('showTemplatesInNewIOx'),
     },
     {
       text: 'Labels',
       id: 'labels',
-      enabled: true
+      enabled: true,
     },
     {
       text: 'Secrets',
       id: 'secrets',
-      enabled: true
+      enabled: true,
     },
   ].filter(tab => tab.enabled)
 

--- a/src/settings/components/SettingsNavigation.tsx
+++ b/src/settings/components/SettingsNavigation.tsx
@@ -13,6 +13,10 @@ import {TabbedPageTab} from 'src/shared/tabbedPage/TabbedPageTabs'
 //  Selectors
 import {getOrg} from 'src/organizations/selectors'
 import {event} from 'src/cloud/utils/reporting'
+import {selectIsNewIOxOrg} from 'src/shared/selectors/app'
+
+// Utils
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 interface Props {
   activeTab: string
@@ -21,6 +25,8 @@ interface Props {
 const SettingsNavigation: FC<Props> = ({activeTab}) => {
   const history = useHistory()
   const org = useSelector(getOrg)
+  const isNewIOxOrg = useSelector(selectIsNewIOxOrg)
+
 
   const handleTabClick = (id: string): void => {
     event('page-nav clicked', {which: `settings--${id}`})
@@ -31,20 +37,24 @@ const SettingsNavigation: FC<Props> = ({activeTab}) => {
     {
       text: 'Variables',
       id: 'variables',
+      enabled: !isNewIOxOrg || isFlagEnabled('showVariablesInNewIOx')
     },
     {
       text: 'Templates',
       id: 'templates',
+      enabled: !isNewIOxOrg || isFlagEnabled('showTemplatesInNewIOx')
     },
     {
       text: 'Labels',
       id: 'labels',
+      enabled: true
     },
     {
       text: 'Secrets',
       id: 'secrets',
+      enabled: true
     },
-  ]
+  ].filter(tab => tab.enabled)
 
   return (
     <ErrorBoundary>

--- a/src/shared/components/AddResourceDropdown.tsx
+++ b/src/shared/components/AddResourceDropdown.tsx
@@ -15,7 +15,7 @@ import {
 import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
 
 // Selectors
-import {selectShouldShowResource} from 'src/shared/selectors/app'
+import {selectIsNewIOxOrg} from 'src/shared/selectors/app'
 
 // Utils
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
@@ -174,7 +174,7 @@ class AddResourceDropdown extends PureComponent<Props> {
 const mstp = (state: AppState) => {
   return {
     shouldShowTemplates:
-      selectShouldShowResource(state) && !isFlagEnabled('hideTemplates'),
+    !selectIsNewIOxOrg(state) || !isFlagEnabled('hideTemplates'),
   }
 }
 

--- a/src/shared/components/AddResourceDropdown.tsx
+++ b/src/shared/components/AddResourceDropdown.tsx
@@ -174,7 +174,7 @@ class AddResourceDropdown extends PureComponent<Props> {
 const mstp = (state: AppState) => {
   return {
     shouldShowTemplates:
-      !selectIsNewIOxOrg(state) || !isFlagEnabled('hideTemplates'),
+      !selectIsNewIOxOrg(state) || isFlagEnabled('showTemplatesInNewIOx'),
   }
 }
 

--- a/src/shared/components/AddResourceDropdown.tsx
+++ b/src/shared/components/AddResourceDropdown.tsx
@@ -174,7 +174,7 @@ class AddResourceDropdown extends PureComponent<Props> {
 const mstp = (state: AppState) => {
   return {
     shouldShowTemplates:
-    !selectIsNewIOxOrg(state) || !isFlagEnabled('hideTemplates'),
+      !selectIsNewIOxOrg(state) || !isFlagEnabled('hideTemplates'),
   }
 }
 

--- a/src/shared/containers/SetOrg.tsx
+++ b/src/shared/containers/SetOrg.tsx
@@ -129,11 +129,11 @@ const SetOrg: FC = () => {
   }, [orgID, firstOrgID, foundOrg, dispatch, history, orgs.length])
 
   const orgPath = '/orgs/:orgID'
-  const shouldShowTasks = !isNewIOxOrg || !isFlagEnabled('hideTasks')
-  const shouldShowAlerts = !isNewIOxOrg || !isFlagEnabled('hideAlerts')
-  const shouldShowDashboards = !isNewIOxOrg || !isFlagEnabled('hideDashboards')
-  const shouldShowTemplates = !isNewIOxOrg || !isFlagEnabled('hideTemplates')
-  const shouldShowVariables = !isNewIOxOrg || !isFlagEnabled('hideVariables')
+  const shouldShowAlerts = !isNewIOxOrg || isFlagEnabled('showAlertsInNewIOx')
+  const shouldShowDashboards = !isNewIOxOrg || isFlagEnabled('showDashboardsInNewIOx')
+  const shouldShowTasks = !isNewIOxOrg || isFlagEnabled('showTasksInNewIOx')
+  const shouldShowTemplates = !isNewIOxOrg || isFlagEnabled('showTemplatesInNewIOx')
+  const shouldShowVariables = !isNewIOxOrg || isFlagEnabled('showVariablesInNewIOx')
 
   return (
     <PageSpinner loading={loading}>

--- a/src/shared/containers/SetOrg.tsx
+++ b/src/shared/containers/SetOrg.tsx
@@ -92,7 +92,7 @@ import {RemoteDataState} from '@influxdata/clockface'
 // Selectors
 import {getAll} from 'src/resources/selectors'
 import {selectShouldShowNotebooks} from 'src/flows/selectors/flowsSelectors'
-import {selectShouldShowResource} from 'src/shared/selectors/app'
+import {selectIsNewIOxOrg} from 'src/shared/selectors/app'
 
 const SetOrg: FC = () => {
   const [loading, setLoading] = useState(RemoteDataState.Loading)
@@ -101,7 +101,7 @@ const SetOrg: FC = () => {
     getAll<Organization>(state, ResourceType.Orgs)
   )
   const shouldShowNotebooks = useSelector(selectShouldShowNotebooks)
-  const shouldShowResource = useSelector(selectShouldShowResource)
+  const isNewIOxOrg = useSelector(selectIsNewIOxOrg)
 
   const history = useHistory()
   const {orgID} = useParams<{orgID: string}>()
@@ -129,12 +129,13 @@ const SetOrg: FC = () => {
   }, [orgID, firstOrgID, foundOrg, dispatch, history, orgs.length])
 
   const orgPath = '/orgs/:orgID'
-  const shouldShowTasks = shouldShowResource && !isFlagEnabled('hideTasks')
-  const shouldShowAlerts = shouldShowResource && !isFlagEnabled('hideAlerts')
+  const shouldShowTasks = !isNewIOxOrg || !isFlagEnabled('hideTasks')
+  const shouldShowAlerts = !isNewIOxOrg || !isFlagEnabled('hideAlerts')
   const shouldShowDashboards =
-    shouldShowResource && !isFlagEnabled('hideDashboards')
+    !isNewIOxOrg || !isFlagEnabled('hideDashboards')
   const shouldShowTemplates =
-    shouldShowResource && !isFlagEnabled('hideTemplates')
+    !isNewIOxOrg || !isFlagEnabled('hideTemplates')
+  const shouldShowVariables = !isNewIOxOrg || !isFlagEnabled('hideVariables')
 
   return (
     <PageSpinner loading={loading}>
@@ -287,10 +288,12 @@ const SetOrg: FC = () => {
             />
           )}
           {/* Settings */}
+          {shouldShowVariables && (
           <Route
             path={`${orgPath}/${SETTINGS}/${VARIABLES}`}
             component={VariablesIndex}
           />
+          )}
           {shouldShowTemplates && (
             <Route
               path={`${orgPath}/${SETTINGS}/${TEMPLATES}`}

--- a/src/shared/containers/SetOrg.tsx
+++ b/src/shared/containers/SetOrg.tsx
@@ -131,10 +131,8 @@ const SetOrg: FC = () => {
   const orgPath = '/orgs/:orgID'
   const shouldShowTasks = !isNewIOxOrg || !isFlagEnabled('hideTasks')
   const shouldShowAlerts = !isNewIOxOrg || !isFlagEnabled('hideAlerts')
-  const shouldShowDashboards =
-    !isNewIOxOrg || !isFlagEnabled('hideDashboards')
-  const shouldShowTemplates =
-    !isNewIOxOrg || !isFlagEnabled('hideTemplates')
+  const shouldShowDashboards = !isNewIOxOrg || !isFlagEnabled('hideDashboards')
+  const shouldShowTemplates = !isNewIOxOrg || !isFlagEnabled('hideTemplates')
   const shouldShowVariables = !isNewIOxOrg || !isFlagEnabled('hideVariables')
 
   return (
@@ -289,10 +287,10 @@ const SetOrg: FC = () => {
           )}
           {/* Settings */}
           {shouldShowVariables && (
-          <Route
-            path={`${orgPath}/${SETTINGS}/${VARIABLES}`}
-            component={VariablesIndex}
-          />
+            <Route
+              path={`${orgPath}/${SETTINGS}/${VARIABLES}`}
+              component={VariablesIndex}
+            />
           )}
           {shouldShowTemplates && (
             <Route

--- a/src/shared/containers/SetOrg.tsx
+++ b/src/shared/containers/SetOrg.tsx
@@ -130,10 +130,13 @@ const SetOrg: FC = () => {
 
   const orgPath = '/orgs/:orgID'
   const shouldShowAlerts = !isNewIOxOrg || isFlagEnabled('showAlertsInNewIOx')
-  const shouldShowDashboards = !isNewIOxOrg || isFlagEnabled('showDashboardsInNewIOx')
+  const shouldShowDashboards =
+    !isNewIOxOrg || isFlagEnabled('showDashboardsInNewIOx')
   const shouldShowTasks = !isNewIOxOrg || isFlagEnabled('showTasksInNewIOx')
-  const shouldShowTemplates = !isNewIOxOrg || isFlagEnabled('showTemplatesInNewIOx')
-  const shouldShowVariables = !isNewIOxOrg || isFlagEnabled('showVariablesInNewIOx')
+  const shouldShowTemplates =
+    !isNewIOxOrg || isFlagEnabled('showTemplatesInNewIOx')
+  const shouldShowVariables =
+    !isNewIOxOrg || isFlagEnabled('showVariablesInNewIOx')
 
   return (
     <PageSpinner loading={loading}>

--- a/src/shared/selectors/app.ts
+++ b/src/shared/selectors/app.ts
@@ -40,9 +40,9 @@ export const getAllFluxFunctions = (state: AppState): FluxFunction[] =>
 export const getSubscriptionsCertificateInterest = (state: AppState): boolean =>
   state.app.persisted.subscriptionsCertificateInterest || false
 
-export const selectShouldShowResource = (state: AppState): boolean => {
+export const selectIsNewIOxOrg = (state: AppState): boolean => {
   if (!CLOUD) {
-    return true
+    return false
   }
 
   const orgCreationDate = new Date(selectOrgCreationDate(state)).valueOf()
@@ -51,10 +51,9 @@ export const selectShouldShowResource = (state: AppState): boolean => {
 
   const wasCreatedBeforeIOxCutoff = orgCreationDate < ioxCutoffDate
 
-  // In cloud, don't show resource if org is IOx enabled && org is created after iox cutoff date
   if (!wasCreatedBeforeIOxCutoff && isIOxEnabled) {
-    return false
+    return true
   }
 
-  return true
+  return false
 }


### PR DESCRIPTION
Closes #6521 

Pr updates all UI deprecation flags from `hide${Resource}` to `show${Resource}InNewIOx` to show flag overrides deprecation and forces resource to display in new IOx. 

If org is iox enabled, is created after 1/31/23 and feature flag is false 

- Variables will be removed from Nav bar 
- Users wont be able to save queries as Variables in Data Explorer 
- Routing to Variables link will throw a 404

Flow Chart:
<img width="1548" alt="Screen Shot 2023-01-27 at 6 25 27 PM" src="https://user-images.githubusercontent.com/66275100/215229623-17803d94-8f7d-4540-9d75-2c297dc73154.png">

IOx enabled org created after 1/31/23:
https://user-images.githubusercontent.com/66275100/215230493-b53c2d60-332f-4a4e-97f6-ab3f1624e391.mov



### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
