### PR TITLE
feat(ui): add engine version and announcement for IOx

### DIFF
--- a/src/homepageExperience/containers/HomepageContainer.tsx
+++ b/src/homepageExperience/containers/HomepageContainer.tsx
@@ -284,27 +284,13 @@ export const HomepageContainer: FC = () => {
                   </Link>
                 </FlexBox>
               </Grid.Column>
-              <Grid.Column
-                widthSM={Columns.Four}
-                widthMD={Columns.Three}
-                style={{marginTop: '-8px'}}
-              >
+              <Grid.Column widthSM={Columns.Four} widthMD={Columns.Three}>
                 {CLOUD ? (
                   <UsageProvider>
-                    <Resources
-                      style={{
-                        backgroundColor: InfluxColors.Grey5,
-                        paddingRight: 0,
-                      }}
-                    />
+                    <Resources />
                   </UsageProvider>
                 ) : (
-                  <Resources
-                    style={{
-                      backgroundColor: InfluxColors.Grey5,
-                      paddingRight: 0,
-                    }}
-                  />
+                  <Resources />
                 )}
               </Grid.Column>
             </Grid.Row>

--- a/src/me/components/AnnouncementBlock.tsx
+++ b/src/me/components/AnnouncementBlock.tsx
@@ -1,0 +1,47 @@
+import React, {FC} from 'react'
+
+// Components
+import {
+  ButtonShape,
+  ComponentSize,
+  Heading,
+  HeadingElement,
+  JustifyContent,
+  LinkButton,
+  LinkTarget,
+  Panel,
+} from '@influxdata/clockface'
+
+interface OwnProps {
+  image?: JSX.Element
+  title?: string
+  body?: string | JSX.Element
+  ctaText?: string
+  ctaLink?: string
+}
+
+const AnnouncementBlock: FC<OwnProps> = (props: OwnProps) => {
+  return (
+    <Panel>
+      <Panel.Header>
+        {props.image}
+        <Heading element={HeadingElement.H3}>{props.title}</Heading>
+      </Panel.Header>
+      <Panel.Body>{props.body}</Panel.Body>
+      {props.ctaText && props.ctaLink && (
+        <Panel.Footer justifyContent={JustifyContent.FlexEnd}>
+          <LinkButton
+            text={props.ctaText}
+            titleText={props.ctaText}
+            href={props.ctaLink}
+            target={LinkTarget.Blank}
+            size={ComponentSize.ExtraSmall}
+            shape={ButtonShape.Default}
+          />
+        </Panel.Footer>
+      )}
+    </Panel>
+  )
+}
+
+export default AnnouncementBlock

--- a/src/me/components/AnnouncementCenter.tsx
+++ b/src/me/components/AnnouncementCenter.tsx
@@ -1,0 +1,27 @@
+import React, {FC} from 'react'
+
+// Components
+import {
+  AlignItems,
+  ComponentSize,
+  FlexBox,
+  FlexDirection,
+} from '@influxdata/clockface'
+
+interface OwnProps {
+  children?: JSX.Element | JSX.Element[]
+}
+
+const AnnouncementCenter: FC<OwnProps> = (props: OwnProps) => {
+  return (
+    <FlexBox
+      direction={FlexDirection.Column}
+      alignItems={AlignItems.Stretch}
+      margin={ComponentSize.Medium}
+    >
+      {props.children}
+    </FlexBox>
+  )
+}
+
+export default AnnouncementCenter

--- a/src/me/components/DocSearchWidget.tsx
+++ b/src/me/components/DocSearchWidget.tsx
@@ -1,5 +1,6 @@
 // Libraries
 import React, {FC} from 'react'
+import {useSelector} from 'react-redux'
 
 // Components
 import DocSearch, {DocSearchType} from 'src/shared/search/DocSearch'
@@ -10,7 +11,9 @@ import {DOCS_URL_VERSION} from 'src/shared/constants/fluxFunctions'
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'
+import {isOrgIOx} from 'src/organizations/selectors'
 
+// Styles
 import 'src/me/components/DocSearchWidget.scss'
 
 const supportLinks = [
@@ -72,24 +75,30 @@ const DocSearchWidget: FC = () => {
   return (
     <div className="WidgetSearch">
       <DocSearch type={DocSearchType.Widget} />
-      <p className="WidgetHelperText">Press CTRL + M on any page to search</p>
-      <div className="useful-links">
-        <h4 style={{textTransform: 'uppercase'}}>Useful Links</h4>
-        <ul className="docslinks-list">
-          {supportLinks.map(({link, title, eventName}) => (
-            <li key={title}>
-              <a
-                href={link}
-                target="_blank"
-                rel="noreferrer"
-                onClick={() => handleEventing(eventName)}
-              >
-                {title}
-              </a>
-            </li>
-          ))}
-        </ul>
-      </div>
+      {!useSelector(isOrgIOx) && (
+        <>
+          <p className="WidgetHelperText">
+            Press CTRL + M on any page to search
+          </p>
+          <div className="useful-links">
+            <h4 style={{textTransform: 'uppercase'}}>Useful Links</h4>
+            <ul className="docslinks-list">
+              {supportLinks.map(({link, title, eventName}) => (
+                <li key={title}>
+                  <a
+                    href={link}
+                    target="_blank"
+                    rel="noreferrer"
+                    onClick={() => handleEventing(eventName)}
+                  >
+                    {title}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </>
+      )}
     </div>
   )
 }

--- a/src/me/components/Resources.tsx
+++ b/src/me/components/Resources.tsx
@@ -1,27 +1,28 @@
 // Libraries
-import React, {CSSProperties, FC, memo, useContext} from 'react'
-import {
-  Panel,
-  FlexBox,
-  FlexDirection,
-  ComponentSize,
-  AlignItems,
-} from '@influxdata/clockface'
+import React, {FC, memo, useContext} from 'react'
+import {useSelector} from 'react-redux'
 
 // Utils
 import {CLOUD} from 'src/shared/constants'
 import {UsageContext} from 'src/usage/context/usage'
 
 // Components
+import {
+  FlexBox,
+  FlexDirection,
+  ComponentSize,
+  AlignItems,
+} from '@influxdata/clockface'
+import AnnouncementCenter from './AnnouncementCenter'
+import AnnouncementBlock from './AnnouncementBlock'
 import UsagePanel from 'src/me/components/UsagePanel'
 import DocSearchWidget from 'src/me/components/DocSearchWidget'
 import VersionInfo from 'src/shared/components/VersionInfo'
 
-type OwnProps = {
-  style?: CSSProperties
-}
+// Utils
+import {isOrgIOx} from 'src/organizations/selectors'
 
-const ResourceLists: FC<OwnProps> = (props: OwnProps) => {
+const ResourceLists: FC = () => {
   const {paygCreditEnabled} = useContext(UsageContext)
 
   return (
@@ -29,19 +30,36 @@ const ResourceLists: FC<OwnProps> = (props: OwnProps) => {
       direction={FlexDirection.Column}
       alignItems={AlignItems.Stretch}
       stretchToFitWidth={true}
-      margin={ComponentSize.Small}
+      stretchToFitHeight={true}
+      margin={ComponentSize.Large}
     >
-      <Panel testID="documentation--panel">
-        <Panel.Body style={props.style}>
-          <DocSearchWidget />
-        </Panel.Body>
-      </Panel>
+      <DocSearchWidget />
+      {useSelector(isOrgIOx) && (
+        <AnnouncementCenter>
+          <AnnouncementBlock
+            title="New time-series engine for InfluxDB"
+            body={
+              <>
+                <p>
+                  InfluxDB Cloud is now powered by the new{' '}
+                  <strong>IOx High-Performance Time-Series Engine</strong>. What
+                  does this mean for you?
+                </p>
+                <ul>
+                  <li>Improved performance</li>
+                  <li>Native support for SQL</li>
+                  <li>Unlimited series cardinality</li>
+                  <li>Low-cost cloud object storage</li>
+                </ul>
+              </>
+            }
+            ctaText="Learn more"
+            ctaLink="https://www.influxdata.com/blog/influxdb-cloud-announces-new-time-series-engine/"
+          />
+        </AnnouncementCenter>
+      )}
       {CLOUD && paygCreditEnabled && <UsagePanel />}
-      <Panel>
-        <Panel.Footer style={props.style}>
-          <VersionInfo />
-        </Panel.Footer>
-      </Panel>
+      <VersionInfo />
     </FlexBox>
   )
 }

--- a/src/shared/components/VersionInfo.scss
+++ b/src/shared/components/VersionInfo.scss
@@ -4,6 +4,9 @@
 */
 
 .version-info {
+  border-top: 2px solid $cf-grey-25;
+  padding-top: $cf-space-l;
+  padding-bottom: $cf-space-l;
   color: $cf-grey-55;
   text-align: center;
 }

--- a/src/shared/components/VersionInfo.tsx
+++ b/src/shared/components/VersionInfo.tsx
@@ -1,43 +1,38 @@
 // Libraries
-import React, {PureComponent} from 'react'
+import React, {FC} from 'react'
+import {useSelector} from 'react-redux'
 
 // Components
 import VersionInfoOSS from 'src/shared/components/VersionInfoOSS'
+import {SafeBlankLink} from 'src/utils/SafeBlankLink'
 
 // Constants
 import {VERSION, GIT_SHA, CLOUD} from 'src/shared/constants'
 
-interface Props {
-  widthPixels?: number
-}
+// Utils
+import {isOrgIOx} from 'src/organizations/selectors'
 
-class VersionInfo extends PureComponent<Props> {
-  public render() {
-    return (
-      <div
-        className="version-info"
-        style={this.style}
-        data-testid="version-info"
-      >
-        <p>
-          {CLOUD ? (
-            <>
-              Version {VERSION}{' '}
-              {GIT_SHA && <code>({GIT_SHA.slice(0, 7)})</code>}
-            </>
-          ) : (
-            <VersionInfoOSS />
-          )}
-        </p>
-      </div>
-    )
-  }
+const VersionInfo: FC = () => {
+  const engineName = useSelector(isOrgIOx) ? 'IOx' : 'TSM'
+  const engineLink = useSelector(isOrgIOx)
+    ? 'http://docs.influxdata.com/influxdb/cloud-iox/'
+    : 'https://docs.influxdata.com/influxdb/v2.6/reference/internals/storage-engine/'
 
-  private get style() {
-    if (this.props.widthPixels) {
-      return {width: `${this.props.widthPixels}px`}
-    }
-  }
+  return (
+    <div className="version-info" data-testid="version-info">
+      {CLOUD ? (
+        <div>
+          <SafeBlankLink href={engineLink}>
+            InfluxDB Cloud powered by {engineName}
+          </SafeBlankLink>
+          <br />
+          Version {VERSION} {GIT_SHA && <code>({GIT_SHA.slice(0, 7)})</code>}
+        </div>
+      ) : (
+        <VersionInfoOSS />
+      )}
+    </div>
+  )
 }
 
 export default VersionInfo


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/6533

Adds engine version (TSM/IOx) along with version number. Replaces useful links section with announcement block for IOx.

![image](https://user-images.githubusercontent.com/11937365/215218521-cdfd7c1f-e0cb-42bf-9aff-3c278652efef.png)

### Checklist

Authors and Reviewer(s), please verify the following:

- [ ] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [ ] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
