### PR TITLE
chore(ui): update docs links to use redirect url

### DIFF
--- a/src/cloud/components/CardinalityLimitAlertContent.tsx
+++ b/src/cloud/components/CardinalityLimitAlertContent.tsx
@@ -136,7 +136,7 @@ export const CardinalityLimitAlertContent: FC<Props> = ({
     return (
       <UpgradeContent
         className={cardinalityLimitAlertContentClass}
-        link="https://docs.influxdata.com/influxdb/v2.0/write-data/best-practices/resolve-high-cardinality/"
+        link="https://docs.influxdata.com/influxdb/latest/write-data/best-practices/resolve-high-cardinality/"
         location={location}
         type="series cardinality"
       />
@@ -149,7 +149,7 @@ export const CardinalityLimitAlertContent: FC<Props> = ({
     >
       <span>
         Data in has stopped because you've hit the{' '}
-        <SafeBlankLink href="https://docs.influxdata.com/influxdb/v2.0/write-data/best-practices/resolve-high-cardinality/">
+        <SafeBlankLink href="https://docs.influxdata.com/influxdb/latest/write-data/best-practices/resolve-high-cardinality/">
           series cardinality
         </SafeBlankLink>{' '}
         limit. Let's get it flowing again.

--- a/src/cloud/components/RateLimitAlert.tsx
+++ b/src/cloud/components/RateLimitAlert.tsx
@@ -80,7 +80,7 @@ export const RateLimitAlert: FC<Props> = ({alertOnly, className, location}) => {
               '',
               <UpgradeContent
                 type="write"
-                link="https://docs.influxdata.com/influxdb/v2.0/write-data/best-practices/optimize-writes/"
+                link="https://docs.influxdata.com/influxdb/latest/write-data/best-practices/optimize-writes/"
                 className="flex-upgrade-content"
               />
             )

--- a/src/dataLoaders/components/verifyStep/DataListening.tsx
+++ b/src/dataLoaders/components/verifyStep/DataListening.tsx
@@ -78,7 +78,7 @@ class DataListening extends PureComponent<Props, State> {
         bucket={this.props.bucket}
         countDownSeconds={this.state.secondsLeft}
       >
-        <SafeBlankLink href="https://docs.influxdata.com/telegraf/latest/administration/troubleshooting/">
+        <SafeBlankLink href="https://docs.influxdata.com/telegraf/latest/configure_plugins/troubleshoot/">
           Telegraf Troubleshooting
         </SafeBlankLink>
       </ConnectionInformation>

--- a/src/homepageExperience/components/steps/Finish.tsx
+++ b/src/homepageExperience/components/steps/Finish.tsx
@@ -113,7 +113,7 @@ export const Finish = (props: OwnProps) => {
         >
           <ResourceCard className="homepage-wizard-next-steps">
             <SafeBlankLink
-              href="https://docs.influxdata.com/influxdb/v2.2/reference/key-concepts/"
+              href="https://docs.influxdata.com/influxdb/latest/reference/key-concepts/"
               onClick={() =>
                 handleNextStepEvent(wizardEventName, 'keyConcepts')
               }

--- a/src/homepageExperience/components/steps/arduino/ExecuteQuery.tsx
+++ b/src/homepageExperience/components/steps/arduino/ExecuteQuery.tsx
@@ -99,7 +99,7 @@ export const ExecuteQuery = (props: OwnProps) => {
         Now let's query the data we wrote into the database. We use the Flux
         scripting language to query data.{' '}
         <SafeBlankLink
-          href="https://docs.influxdata.com/influxdb/v2.2/reference/syntax/flux/"
+          href="https://docs.influxdata.com/influxdb/latest/reference/syntax/flux/"
           onClick={() =>
             event('firstMile.arduinoWizard.documentation.link.clicked')
           }

--- a/src/homepageExperience/components/steps/cli/ExecuteQuery.tsx
+++ b/src/homepageExperience/components/steps/cli/ExecuteQuery.tsx
@@ -54,7 +54,7 @@ export const ExecuteQuery = (props: OwnProps) => {
         Now let's query the data we wrote into the database. We use the Flux
         scripting language to query data.{' '}
         <SafeBlankLink
-          href="https://docs.influxdata.com/influxdb/v2.2/reference/syntax/flux/"
+          href="https://docs.influxdata.com/influxdb/latest/reference/syntax/flux/"
           onClick={() =>
             event('firstMile.cliWizard.documentation.link.clicked')
           }

--- a/src/homepageExperience/components/steps/cli/WriteData.tsx
+++ b/src/homepageExperience/components/steps/cli/WriteData.tsx
@@ -115,7 +115,7 @@ export const WriteDataComponent = (props: OwnProps) => {
           <p>
             The sample file is an Annotated CSV. The InfluxDB CLI supports both
             annotated and standard CSV formats.{' '}
-            <SafeBlankLink href="https://docs.influxdata.com/influxdb/v2.2/reference/syntax/annotated-csv/">
+            <SafeBlankLink href="https://docs.influxdata.com/influxdb/latest/reference/syntax/annotated-csv/">
               Annotated CSVs
             </SafeBlankLink>{' '}
             contain metadata about the data types in the file, which allows for
@@ -183,7 +183,7 @@ export const WriteDataComponent = (props: OwnProps) => {
           <p>
             The sample file is an Annotated CSV. The InfluxDB CLI supports both
             annotated and standard CSV formats.{' '}
-            <SafeBlankLink href="https://docs.influxdata.com/influxdb/v2.2/reference/syntax/annotated-csv/">
+            <SafeBlankLink href="https://docs.influxdata.com/influxdb/latest/reference/syntax/annotated-csv/">
               Annotated CSVs
             </SafeBlankLink>{' '}
             contain metadata about the data types in the file, which allows for

--- a/src/homepageExperience/components/steps/go/WriteData.tsx
+++ b/src/homepageExperience/components/steps/go/WriteData.tsx
@@ -103,14 +103,14 @@ for value := 0; value < 5; value++ {
         In the above code snippet, we define five data points and write each one
         to InfluxDB. Each of the 5 points we write has a{' '}
         <SafeBlankLink
-          href="https://docs.influxdata.com/influxdb/v1.8/concepts/glossary/#field-key"
+          href="https://docs.influxdata.com/influxdb/latest/reference/glossary/#field-key"
           onClick={logDocsOpened}
         >
           field
         </SafeBlankLink>{' '}
         and a{' '}
         <SafeBlankLink
-          href="https://docs.influxdata.com/influxdb/v1.8/concepts/glossary/#tag-key"
+          href="https://docs.influxdata.com/influxdb/latest/reference/glossary/#tag-key"
           onClick={logDocsOpened}
         >
           tag

--- a/src/homepageExperience/components/steps/nodejs/WriteData.tsx
+++ b/src/homepageExperience/components/steps/nodejs/WriteData.tsx
@@ -102,14 +102,14 @@ for (let i = 0; i < 5; i++) {
         In the above code snippet, we define five data points and write each one
         to InfluxDB. Each of the 5 points we write has a{' '}
         <SafeBlankLink
-          href="https://docs.influxdata.com/influxdb/v1.8/concepts/glossary/#field-key"
+          href="https://docs.influxdata.com/influxdb/latest/reference/glossary/#field-key"
           onClick={logDocsOpened}
         >
           field
         </SafeBlankLink>{' '}
         and a{' '}
         <SafeBlankLink
-          href="https://docs.influxdata.com/influxdb/v1.8/concepts/glossary/#tag-key"
+          href="https://docs.influxdata.com/influxdb/latest/reference/glossary/#tag-key"
           onClick={logDocsOpened}
         >
           tag

--- a/src/homepageExperience/components/steps/python/WriteData.tsx
+++ b/src/homepageExperience/components/steps/python/WriteData.tsx
@@ -98,14 +98,14 @@ for value in range(5):
         In the above code snippet, we define five data points and write each one
         to InfluxDB. Each of the 5 points we write has a{' '}
         <SafeBlankLink
-          href="https://docs.influxdata.com/influxdb/v1.8/concepts/glossary/#field-key"
+          href="https://docs.influxdata.com/influxdb/latest/reference/glossary/#field-key"
           onClick={logDocsOpened}
         >
           field
         </SafeBlankLink>{' '}
         and a{' '}
         <SafeBlankLink
-          href="https://docs.influxdata.com/influxdb/v1.8/concepts/glossary/#tag-key"
+          href="https://docs.influxdata.com/influxdb/latest/reference/glossary/#tag-key"
           onClick={logDocsOpened}
         >
           tag

--- a/src/shared/components/VersionInfo.tsx
+++ b/src/shared/components/VersionInfo.tsx
@@ -15,8 +15,8 @@ import {isOrgIOx} from 'src/organizations/selectors'
 const VersionInfo: FC = () => {
   const engineName = useSelector(isOrgIOx) ? 'IOx' : 'TSM'
   const engineLink = useSelector(isOrgIOx)
-    ? 'http://docs.influxdata.com/influxdb/cloud-iox/'
-    : 'https://docs.influxdata.com/influxdb/v2.6/reference/internals/storage-engine/'
+    ? 'https://docs.influxdata.com/influxdb/cloud-iox/'
+    : 'https://docs.influxdata.com/influxdb/latest/reference/internals/storage-engine/#time-structured-merge-tree-tsm'
 
   return (
     <div className="version-info" data-testid="version-info">

--- a/src/shared/constants/fluxFunctions.ts
+++ b/src/shared/constants/fluxFunctions.ts
@@ -2538,7 +2538,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     package: 'experimental/http',
     desc: 'Submits an HTTP GET request to the specified URL and returns the HTTP status code, response body, and response headers.',
     example:
-      'http.get(url: "https://docs.influxdata.com/influxdb/v2.0/", headers: {foo: "bar"})',
+      'http.get(url: "https://docs.influxdata.com/influxdb/latest/", headers: {foo: "bar"})',
     category: 'Miscellaneous',
     link: `https://docs.influxdata.com/influxdb/${DOCS_URL_VERSION}/reference/flux/stdlib/experimental/http/get/`,
   },

--- a/src/writeData/components/PluginCreateConfiguration/Customize.tsx
+++ b/src/writeData/components/PluginCreateConfiguration/Customize.tsx
@@ -45,7 +45,7 @@ const AgentOutputNotification: FC<AgentOutputNotificationProps> = props => (
         <span className="plugin-create-configuration--popover-contents">
           The agent settings configures Telegraf across all plugins. Read{' '}
           <a
-            href="https://docs.influxdata.com/telegraf/latest/administration/configuration/#agent-configuration"
+            href="https://docs.influxdata.com/telegraf/latest/configuration/#agent-configuration"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/src/writeData/components/fileUploads/CSV.md
+++ b/src/writeData/components/fileUploads/CSV.md
@@ -1,4 +1,4 @@
-For more detailed and up to date information check out the [Annotated CSV Documentation](https://docs.influxdata.com/influxdb/v2.0/reference/syntax/annotated-csv/).
+For more detailed and up to date information check out the [Annotated CSV Documentation](https://docs.influxdata.com/influxdb/latest/reference/syntax/annotated-csv/).
 
 For ingesting custom CSV files into InfluxDB, we recommend you use the [`influx write` command](https://docs.influxdata.com/influxdb/cloud/reference/cli/influx/write/) in the InfluxDB Command Line Interface (CLI).
 

--- a/src/writeData/components/telegrafPlugins/dcos.md
+++ b/src/writeData/components/telegrafPlugins/dcos.md
@@ -10,14 +10,14 @@ create a high number of series which, when unchecked, can cause high load on
 your database.
 
 - Use the
-  [measurement filtering](https://docs.influxdata.com/telegraf/latest/administration/configuration/#measurement-filtering)
+  [measurement filtering](https://docs.influxdata.com/telegraf/latest/configuration/#metric-filtering)
   options to exclude unneeded tags.
 - Write to a database with an appropriate
-  [retention policy](https://docs.influxdata.com/influxdb/latest/guides/downsampling_and_retention/).
+  [retention policy](https://docs.influxdata.com/influxdb/latest/reference/internals/data-retention/).
 - Consider using the
-  [Time Series Index](https://docs.influxdata.com/influxdb/latest/concepts/time-series-index/).
+  [Time Series Index](https://docs.influxdata.com/influxdb/latest/reference/internals/storage-engine/#time-series-index-tsi).
 - Monitor your databases
-  [series cardinality](https://docs.influxdata.com/influxdb/latest/query_language/spec/#show-cardinality).
+  [series cardinality](https://docs.influxdata.com/influxdb/latest/reference/syntax/influxql/spec/#show-cardinality).
 
 ## Configuration
 

--- a/src/writeData/components/telegrafPlugins/http.md
+++ b/src/writeData/components/telegrafPlugins/http.md
@@ -83,7 +83,7 @@ configuration.
 
 This example output was taken from [this instructional article][1].
 
-[1]: https://docs.influxdata.com/telegraf/v1.21/guides/using_http/
+[1]: https://docs.influxdata.com/telegraf/latest/configure_plugins/input_plugins/using_http/
 
 ```shell
 citibike,station_id=4703 eightd_has_available_keys=false,is_installed=1,is_renting=1,is_returning=1,legacy_id="4703",num_bikes_available=6,num_bikes_disabled=2,num_docks_available=26,num_docks_disabled=0,num_ebikes_available=0,station_status="active" 1641505084000000000

--- a/src/writeData/components/telegrafPlugins/influxdb_listener.md
+++ b/src/writeData/components/telegrafPlugins/influxdb_listener.md
@@ -82,5 +82,5 @@ Metrics are created from InfluxDB Line Protocol in the request body.
 curl -i -XPOST 'http://localhost:8186/write' --data-binary 'cpu_load_short,host=server01,region=us-west value=0.64 1434055562000000000'
 ```
 
-[influxdb_http_api]: https://docs.influxdata.com/influxdb/v1.8/guides/write_data/
+[influxdb_http_api]: https://docs.influxdata.com/influxdb/latest/write_data/
 [http_listener_v2]: /plugins/inputs/http_listener_v2/README.md

--- a/src/writeData/components/telegrafPlugins/kapacitor.md
+++ b/src/writeData/components/telegrafPlugins/kapacitor.md
@@ -115,7 +115,7 @@ The total number of Kapacitor tasks.
 ## kapacitor_alert
 
 The `kapacitor_alert` measurement stores fields with information related to
-[Kapacitor alerts](https://docs.influxdata.com/kapacitor/v1.5/working/alerts/).
+[Kapacitor alerts](https://docs.influxdata.com/kapacitor/latest/working/alerts/).
 
 ### notification-dropped
 

--- a/src/writeData/components/telegrafPlugins/kube_inventory.md
+++ b/src/writeData/components/telegrafPlugins/kube_inventory.md
@@ -350,7 +350,7 @@ kubernetes_statefulset,namespace=default,selector_select1=s1,statefulset_name=et
 ```
 
 [metric filtering]: https://github.com/influxdata/telegraf/blob/master/docs/CONFIGURATION.md#metric-filtering
-[retention policy]: https://docs.influxdata.com/influxdb/latest/guides/downsampling_and_retention/
-[tsi]: https://docs.influxdata.com/influxdb/latest/concepts/time-series-index/
-[series cardinality]: https://docs.influxdata.com/influxdb/latest/query_language/spec/#show-cardinality
+[retention policy]: https://docs.influxdata.com/influxdb/latest/reference/internals/data-retention/
+[tsi]: https://docs.influxdata.com/influxdb/latest/reference/internals/storage-engine/#time-series-index-tsi
+[series cardinality]: https://docs.influxdata.com/influxdb/latest/reference/syntax/influxql/spec/#show-cardinality
 [influx-docs]: https://docs.influxdata.com/influxdb/latest/

--- a/src/writeData/components/telegrafPlugins/kubernetes.md
+++ b/src/writeData/components/telegrafPlugins/kubernetes.md
@@ -158,9 +158,9 @@ kubernetes_system_container
 ```
 
 [metric filtering]: https://github.com/influxdata/telegraf/blob/master/docs/CONFIGURATION.md#metric-filtering
-[retention policy]: https://docs.influxdata.com/influxdb/latest/guides/downsampling_and_retention/
-[tsi]: https://docs.influxdata.com/influxdb/latest/concepts/time-series-index/
-[series cardinality]: https://docs.influxdata.com/influxdb/latest/query_language/spec/#show-cardinality
+[retention policy]: https://docs.influxdata.com/influxdb/latest/reference/internals/data-retention/
+[tsi]: https://docs.influxdata.com/influxdb/latest/reference/internals/storage-engine/#time-series-index-tsi
+[series cardinality]: https://docs.influxdata.com/influxdb/latest/reference/syntax/influxql/spec/#show-cardinality
 [influx-docs]: https://docs.influxdata.com/influxdb/latest/
 [k8s-telegraf]: https://www.influxdata.com/blog/monitoring-kubernetes-architecture/
 [telegraf]: https://github.com/helm/charts/tree/master/stable/telegraf

--- a/src/writeData/components/telegrafPlugins/net.md
+++ b/src/writeData/components/telegrafPlugins/net.md
@@ -66,7 +66,7 @@ second for all interfaces in the last hour. The query uses the [derivative
 function][deriv] which calculates the rate of change between subsequent field
 values.
 
-[deriv]: https://docs.influxdata.com/influxdb/v1.2/query_language/functions#derivative
+[deriv]: https://docs.influxdata.com/influxdb/latest/query-data/influxql/functions/transformations/#derivative
 
 ```sql
 SELECT derivative(first(bytes_recv), 1s) as "download bytes/sec", derivative(first(bytes_sent), 1s) as "upload bytes/sec" FROM net WHERE time > now() - 1h AND interface != 'all' GROUP BY time(10s), interface fill(0);

--- a/src/writeData/components/telegrafPlugins/passenger.md
+++ b/src/writeData/components/telegrafPlugins/passenger.md
@@ -11,15 +11,15 @@ cause high load on your database.  You can use the following techniques to
 manage your series cardinality:
 
 - Use the
-  [measurement filtering](https://docs.influxdata.com/telegraf/latest/administration/configuration/#measurement-filtering)
+  [measurement filtering](https://docs.influxdata.com/telegraf/latest/configuration/#metric-filtering)
   options to exclude unneeded tags.  In some environments, you may wish to use
   `tagexclude` to remove the `pid` and `process_group_id` tags.
 - Write to a database with an appropriate
-  [retention policy](https://docs.influxdata.com/influxdb/latest/guides/downsampling_and_retention/).
+  [retention policy](https://docs.influxdata.com/influxdb/latest/reference/internals/data-retention/).
 - Consider using the
-  [Time Series Index](https://docs.influxdata.com/influxdb/latest/concepts/time-series-index/).
+  [Time Series Index](https://docs.influxdata.com/influxdb/latest/reference/internals/storage-engine/#time-series-index-tsi).
 - Monitor your databases
-  [series cardinality](https://docs.influxdata.com/influxdb/latest/query_language/spec/#show-cardinality).
+  [series cardinality](https://docs.influxdata.com/influxdb/latest/reference/syntax/influxql/spec/#show-cardinality).
 
 ## Configuration
 

--- a/src/writeData/components/telegrafPlugins/sflow.md
+++ b/src/writeData/components/telegrafPlugins/sflow.md
@@ -113,8 +113,8 @@ This sflow implementation was built from the reference document
 [sflow.org/sflow_version_5.txt](sflow_version_5)
 
 [metric filtering]: https://github.com/influxdata/telegraf/blob/master/docs/CONFIGURATION.md#metric-filtering
-[retention policy]: https://docs.influxdata.com/influxdb/latest/guides/downsampling_and_retention/
-[tsi]: https://docs.influxdata.com/influxdb/latest/concepts/time-series-index/
-[series cardinality]: https://docs.influxdata.com/influxdb/latest/query_language/spec/#show-cardinality
+[retention policy]: https://docs.influxdata.com/influxdb/latest/reference/internals/data-retention/
+[tsi]: https://docs.influxdata.com/influxdb/latest/reference/internals/storage-engine/#time-series-index-tsi
+[series cardinality]: https://docs.influxdata.com/influxdb/latest/reference/syntax/influxql/spec/#show-cardinality
 [influx-docs]: https://docs.influxdata.com/influxdb/latest/
 [sflow_version_5]: https://sflow.org/sflow_version_5.txt


### PR DESCRIPTION
This PR updates the static version docs link to use the redirect URL that gets the latest version. It also addresses some dead docs links and replaces them with working links.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
