### PR TITLE
fix: Settings page sends user to settings/labels in new iox orgs

### DIFF
--- a/cypress/e2e/shared/dashboardsIndex.test.ts
+++ b/cypress/e2e/shared/dashboardsIndex.test.ts
@@ -315,6 +315,7 @@ describe('Dashboards', () => {
       // visit another page
       cy.getByTestID('tree-nav')
       cy.contains('Settings').click({force: true})
+      cy.getByTestID('variables--tab').click()
       cy.contains("Looks like there aren't any Variables, why not create one?")
       // return to dashboards page
       cy.contains('Dashboards').click()

--- a/src/pageLayout/containers/MainNavigation.tsx
+++ b/src/pageLayout/containers/MainNavigation.tsx
@@ -180,7 +180,7 @@ const generateNavItems = (
       testID: 'nav-item-settings',
       icon: IconFont.CogOutline_New,
       label: 'Settings',
-      link: `/orgs/${orgID}/settings/variables`,
+      link: `/orgs/${orgID}/settings`,
       activeKeywords: ['settings'],
       menu: [
         {

--- a/src/shared/containers/SetOrg.tsx
+++ b/src/shared/containers/SetOrg.tsx
@@ -313,7 +313,7 @@ const SetOrg: FC = () => {
           <Route
             exact
             path={`${orgPath}/${SETTINGS}`}
-            component={VariablesIndex}
+            component={isNewIOxOrg ? LabelsIndex : VariablesIndex}
           />
           {/* Users - route has multiple paths to ensure backwards compatibility while https://github.com/influxdata/ui/issues/5396 is being worked on*/}
           {CLOUD && (

--- a/src/shared/containers/SetOrg.tsx
+++ b/src/shared/containers/SetOrg.tsx
@@ -313,7 +313,7 @@ const SetOrg: FC = () => {
           <Route
             exact
             path={`${orgPath}/${SETTINGS}`}
-            component={isNewIOxOrg ? LabelsIndex : VariablesIndex}
+            component={LabelsIndex}
           />
           {/* Users - route has multiple paths to ensure backwards compatibility while https://github.com/influxdata/ui/issues/5396 is being worked on*/}
           {CLOUD && (


### PR DESCRIPTION
In local testing, if I simulate the conditions of being a new IOx org, clicking the settings link gives me a 404. The reason is that the link is still hardcoded to send the user to variables by default, which won't exist for new IOx orgs.

Solution is to send the user to labels by default if it's a new IOx org.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable
