### PR TITLE
chore: conditionally show old Data Explorer 

### DIFF
--- a/src/dataExplorer/components/DataExplorerPage.tsx
+++ b/src/dataExplorer/components/DataExplorerPage.tsx
@@ -52,7 +52,7 @@ const DataExplorerPageHeader: FC = () => {
     useContext(AppSettingContext)
   const {resource, save} = useContext(PersistanceContext)
   const isNewIOxOrg = useSelector(selectIsNewIOxOrg)
-  const showDataExplorerToggle =
+  const shouldShowDataExplorerToggle =
     isFlagEnabled('newDataExplorer') &&
     (!isNewIOxOrg || isFlagEnabled('showOldDataExplorerInNewIOx'))
 
@@ -100,7 +100,7 @@ const DataExplorerPageHeader: FC = () => {
     >
       {pageTitle}
       <FlexBox margin={ComponentSize.Large}>
-        {showDataExplorerToggle && (
+        {shouldShowDataExplorerToggle && (
           <FlexBox margin={ComponentSize.Medium}>
             <InputLabel>Switch to old Data Explorer</InputLabel>
             <SlideToggle
@@ -123,13 +123,13 @@ const DataExplorerPage: FC = () => {
   const isNewIOxOrg =
     useSelector(selectIsNewIOxOrg) &&
     !isFlagEnabled('showOldDataExplorerInNewIOx')
-  const showNotebooks = useSelector(selectShouldShowNotebooks)
-  const showNewExplorer =
+  const shouldShowNotebooks = useSelector(selectShouldShowNotebooks)
+  const shouldShowNewExplorer =
     (scriptQueryBuilder && isFlagEnabled('newDataExplorer')) || isNewIOxOrg
 
-  const showSaveAsButton =
+  const shouldShowSaveAsButton =
     !isNewIOxOrg ||
-    showNotebooks ||
+    shouldShowNotebooks ||
     isFlagEnabled('showTasksInNewIOx') ||
     isFlagEnabled('showDashboardsInNewIOx') ||
     isFlagEnabled('showVariablesInNewIOx')
@@ -201,7 +201,7 @@ const DataExplorerPage: FC = () => {
             </div>
           </FeatureFlag>
         )}
-        {!showNewExplorer && (
+        {!shouldShowNewExplorer && (
           <Page.ControlBar fullWidth={true}>
             <Page.ControlBarLeft>
               <ViewTypeDropdown />
@@ -209,13 +209,13 @@ const DataExplorerPage: FC = () => {
             </Page.ControlBarLeft>
             <Page.ControlBarRight>
               <TimeZoneDropdown />
-              {showSaveAsButton && <SaveAsButton />}
+              {shouldShowSaveAsButton && <SaveAsButton />}
             </Page.ControlBarRight>
           </Page.ControlBar>
         )}
         <Page.Contents fullWidth={true} scrollable={false}>
-          {!showNewExplorer && <DataExplorer />}
-          {showNewExplorer && <ScriptQueryBuilder />}
+          {!shouldShowNewExplorer && <DataExplorer />}
+          {shouldShowNewExplorer && <ScriptQueryBuilder />}
         </Page.Contents>
       </GetResources>
     </Page>

--- a/src/dataExplorer/components/DataExplorerPage.tsx
+++ b/src/dataExplorer/components/DataExplorerPage.tsx
@@ -51,6 +51,10 @@ const DataExplorerPageHeader: FC = () => {
   const {scriptQueryBuilder, setScriptQueryBuilder} =
     useContext(AppSettingContext)
   const {resource, save} = useContext(PersistanceContext)
+  const isNewIOxOrg = useSelector(selectIsNewIOxOrg)
+  const showBothDataExplorers =
+    !isNewIOxOrg || isFlagEnabled('showOldDataExplorerInNewIOx')
+
   const history = useHistory()
 
   const toggleSlider = () => {
@@ -70,7 +74,9 @@ const DataExplorerPageHeader: FC = () => {
     save(resource?.language)
   }
 
-  const showNewExplorer = scriptQueryBuilder && isFlagEnabled('newDataExplorer')
+  const showNewExplorer =
+    (scriptQueryBuilder && isFlagEnabled('newDataExplorer')) ||
+    showBothDataExplorers
 
   let pageTitle = <Page.Title title="Data Explorer" />
 
@@ -95,7 +101,7 @@ const DataExplorerPageHeader: FC = () => {
     >
       {pageTitle}
       <FlexBox margin={ComponentSize.Large}>
-        {isFlagEnabled('newDataExplorer') && (
+        {showBothDataExplorers && isFlagEnabled('newDataExplorer') && (
           <FlexBox margin={ComponentSize.Medium}>
             <InputLabel>Switch to old Data Explorer</InputLabel>
             <SlideToggle
@@ -114,10 +120,14 @@ const DataExplorerPage: FC = () => {
   const {flowsCTA, scriptQueryBuilder, setFlowsCTA} =
     useContext(AppSettingContext)
   useLoadTimeReporting('DataExplorerPage load start')
-  const showNewExplorer = scriptQueryBuilder && isFlagEnabled('newDataExplorer')
   const history = useHistory()
   const isNewIOxOrg = useSelector(selectIsNewIOxOrg)
   const showNotebooks = useSelector(selectShouldShowNotebooks)
+  const onlyShowNewDataExplorer =
+    isNewIOxOrg && !isFlagEnabled('showOldDataExplorerInNewIOx')
+  const showNewExplorer =
+    (scriptQueryBuilder && isFlagEnabled('newDataExplorer')) ||
+    onlyShowNewDataExplorer
 
   const showSaveAsButton =
     !isNewIOxOrg ||

--- a/src/dataExplorer/components/DataExplorerPage.tsx
+++ b/src/dataExplorer/components/DataExplorerPage.tsx
@@ -52,8 +52,9 @@ const DataExplorerPageHeader: FC = () => {
     useContext(AppSettingContext)
   const {resource, save} = useContext(PersistanceContext)
   const isNewIOxOrg = useSelector(selectIsNewIOxOrg)
-  const showBothDataExplorers =
-    !isNewIOxOrg || isFlagEnabled('showOldDataExplorerInNewIOx')
+  const showDataExplorerToggle =
+    isFlagEnabled('newDataExplorer') &&
+    (!isNewIOxOrg || isFlagEnabled('showOldDataExplorerInNewIOx'))
 
   const history = useHistory()
 
@@ -74,9 +75,7 @@ const DataExplorerPageHeader: FC = () => {
     save(resource?.language)
   }
 
-  const showNewExplorer =
-    (scriptQueryBuilder && isFlagEnabled('newDataExplorer')) ||
-    showBothDataExplorers
+  const showNewExplorer = scriptQueryBuilder && isFlagEnabled('newDataExplorer')
 
   let pageTitle = <Page.Title title="Data Explorer" />
 
@@ -101,7 +100,7 @@ const DataExplorerPageHeader: FC = () => {
     >
       {pageTitle}
       <FlexBox margin={ComponentSize.Large}>
-        {showBothDataExplorers && isFlagEnabled('newDataExplorer') && (
+        {showDataExplorerToggle && (
           <FlexBox margin={ComponentSize.Medium}>
             <InputLabel>Switch to old Data Explorer</InputLabel>
             <SlideToggle
@@ -121,13 +120,12 @@ const DataExplorerPage: FC = () => {
     useContext(AppSettingContext)
   useLoadTimeReporting('DataExplorerPage load start')
   const history = useHistory()
-  const isNewIOxOrg = useSelector(selectIsNewIOxOrg)
+  const isNewIOxOrg =
+    useSelector(selectIsNewIOxOrg) &&
+    !isFlagEnabled('showOldDataExplorerInNewIOx')
   const showNotebooks = useSelector(selectShouldShowNotebooks)
-  const onlyShowNewDataExplorer =
-    isNewIOxOrg && !isFlagEnabled('showOldDataExplorerInNewIOx')
   const showNewExplorer =
-    (scriptQueryBuilder && isFlagEnabled('newDataExplorer')) ||
-    onlyShowNewDataExplorer
+    (scriptQueryBuilder && isFlagEnabled('newDataExplorer')) || isNewIOxOrg
 
   const showSaveAsButton =
     !isNewIOxOrg ||

--- a/src/dataExplorer/components/ScriptQueryBuilder.tsx
+++ b/src/dataExplorer/components/ScriptQueryBuilder.tsx
@@ -39,6 +39,8 @@ import {QueryContext} from 'src/shared/contexts/query'
 import {getOrg, isOrgIOx} from 'src/organizations/selectors'
 import {RemoteDataState} from 'src/types'
 import {SCRIPT_EDITOR_PARAMS} from 'src/dataExplorer/components/resources'
+import {selectIsNewIOxOrg} from 'src/shared/selectors/app'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Styles
 import './ScriptQueryBuilder.scss'
@@ -64,6 +66,7 @@ const ScriptQueryBuilder: FC = () => {
   const {setStatus, setResult} = useContext(ResultsContext)
   const {clear: clearViewOptions} = useContext(ResultsViewContext)
   const org = useSelector(getOrg)
+  const isNewIOxOrg = useSelector(selectIsNewIOxOrg)
 
   const handleClear = useCallback(() => {
     cancel()
@@ -135,17 +138,32 @@ const ScriptQueryBuilder: FC = () => {
                   <Dropdown
                     menu={onCollapse => (
                       <Dropdown.Menu onCollapse={onCollapse}>
-                        {[LanguageType.FLUX, LanguageType.SQL].map(option => (
+                        {isNewIOxOrg &&
+                        !isFlagEnabled('showOldDataExplorerInNewIOx') ? (
                           <Dropdown.Item
-                            className={`script-dropdown__${option}`}
-                            key={option}
-                            onClick={() => handleSelectDropdown(option)}
-                            selected={resource?.language === option}
-                            testID={`script-dropdown__${option}`}
+                            className="script-dropdown__LanguageType.SQL"
+                            key={LanguageType.SQL}
+                            onClick={() =>
+                              handleSelectDropdown(LanguageType.SQL)
+                            }
+                            selected={resource?.language === LanguageType.SQL}
+                            testID="script-dropdown__LanguageType.SQL"
                           >
-                            {option}
+                            {LanguageType.SQL.toLocaleUpperCase()}
                           </Dropdown.Item>
-                        ))}
+                        ) : (
+                          [LanguageType.FLUX, LanguageType.SQL].map(option => (
+                            <Dropdown.Item
+                              className={`script-dropdown__${option}`}
+                              key={option}
+                              onClick={() => handleSelectDropdown(option)}
+                              selected={resource?.language === option}
+                              testID={`script-dropdown__${option}`}
+                            >
+                              {option}
+                            </Dropdown.Item>
+                          ))
+                        )}
                       </Dropdown.Menu>
                     )}
                     button={(active, onClick) => (
@@ -216,7 +234,10 @@ const ScriptQueryBuilder: FC = () => {
               <ResultsPane />
             </DraggableResizer.Panel>
             <DraggableResizer.Panel isCollapsible={true}>
-              <Sidebar />
+              {isNewIOxOrg &&
+              !isFlagEnabled('showOldDataExplorerInNewIOx') ? null : (
+                <Sidebar />
+              )}
             </DraggableResizer.Panel>
           </DraggableResizer>
         </FlexBox>

--- a/src/dataExplorer/components/ScriptQueryBuilder.tsx
+++ b/src/dataExplorer/components/ScriptQueryBuilder.tsx
@@ -66,7 +66,9 @@ const ScriptQueryBuilder: FC = () => {
   const {setStatus, setResult} = useContext(ResultsContext)
   const {clear: clearViewOptions} = useContext(ResultsViewContext)
   const org = useSelector(getOrg)
-  const isNewIOxOrg = useSelector(selectIsNewIOxOrg)
+  const isNewIOxOrg =
+    useSelector(selectIsNewIOxOrg) &&
+    !isFlagEnabled('showOldDataExplorerInNewIOx')
 
   const handleClear = useCallback(() => {
     cancel()
@@ -108,6 +110,9 @@ const ScriptQueryBuilder: FC = () => {
     }
   }, [handleClear, hasChanged])
 
+  const filterOutFluxInIOx = option =>
+    isNewIOxOrg ? option !== LanguageType.FLUX : true
+
   return (
     <EditorProvider>
       <SidebarProvider>
@@ -138,21 +143,9 @@ const ScriptQueryBuilder: FC = () => {
                   <Dropdown
                     menu={onCollapse => (
                       <Dropdown.Menu onCollapse={onCollapse}>
-                        {isNewIOxOrg &&
-                        !isFlagEnabled('showOldDataExplorerInNewIOx') ? (
-                          <Dropdown.Item
-                            className="script-dropdown__LanguageType.SQL"
-                            key={LanguageType.SQL}
-                            onClick={() =>
-                              handleSelectDropdown(LanguageType.SQL)
-                            }
-                            selected={resource?.language === LanguageType.SQL}
-                            testID="script-dropdown__LanguageType.SQL"
-                          >
-                            {LanguageType.SQL.toLocaleUpperCase()}
-                          </Dropdown.Item>
-                        ) : (
-                          [LanguageType.FLUX, LanguageType.SQL].map(option => (
+                        {[LanguageType.FLUX, LanguageType.SQL]
+                          .filter(filterOutFluxInIOx)
+                          .map(option => (
                             <Dropdown.Item
                               className={`script-dropdown__${option}`}
                               key={option}
@@ -162,8 +155,7 @@ const ScriptQueryBuilder: FC = () => {
                             >
                               {option}
                             </Dropdown.Item>
-                          ))
-                        )}
+                          ))}
                       </Dropdown.Menu>
                     )}
                     button={(active, onClick) => (
@@ -234,10 +226,7 @@ const ScriptQueryBuilder: FC = () => {
               <ResultsPane />
             </DraggableResizer.Panel>
             <DraggableResizer.Panel isCollapsible={true}>
-              {isNewIOxOrg &&
-              !isFlagEnabled('showOldDataExplorerInNewIOx') ? null : (
-                <Sidebar />
-              )}
+              {!isNewIOxOrg && <Sidebar />}
             </DraggableResizer.Panel>
           </DraggableResizer>
         </FlexBox>


### PR DESCRIPTION
Closes #6522 


For CLOUD IOx enabled users who's org is created after 1/31/23, the following items are hidden 

-  the `switch to old Data Explorer` toggle in the top right corner of the UI
- the old Data Explorer page 
- The flux functions inside the New Query Builder 
- the `flux` option in the New Script drop down button inside New Query Builder

When `showOldDataExplorerInNewIOx` feature flag is flipped on, new IOx users will be able to access both old Data Explorer and New Query Builder just like TSM users

Logic flow chart:
<img width="1606" alt="Screen Shot 2023-01-30 at 3 09 26 PM" src="https://user-images.githubusercontent.com/66275100/215595653-b4f06829-c6ba-4c29-bada-69c952cccd72.png">

UI Demo: new IOx org when feature flag is on and off
https://user-images.githubusercontent.com/66275100/215594720-bf33947f-009e-46da-bdf4-9a0d9c7ae016.mov
UI Demo: non-IOx org when feature flag is on and off
https://user-images.githubusercontent.com/66275100/215604792-01f5ec40-d0c4-4a54-ace7-01445de8968c.mov


Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
