### PR TITLE
chore: add flag to simulate new iox org

### DIFF
--- a/src/shared/selectors/app.ts
+++ b/src/shared/selectors/app.ts
@@ -11,6 +11,7 @@ import {
 import {CLOUD, IOX_SWITCHOVER_CREATION_DATE} from 'src/shared/constants'
 
 import {selectOrgCreationDate, isOrgIOx} from 'src/organizations/selectors'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 export const timeZone = (state: AppState): TimeZone =>
   state.app.persisted.timeZone || ('Local' as TimeZone)
@@ -43,6 +44,10 @@ export const getSubscriptionsCertificateInterest = (state: AppState): boolean =>
 export const selectIsNewIOxOrg = (state: AppState): boolean => {
   if (!CLOUD) {
     return false
+  }
+
+  if (isFlagEnabled('ioxLaunchMock')) {
+    return true
   }
 
   const orgCreationDate = new Date(selectOrgCreationDate(state)).valueOf()


### PR DESCRIPTION
Adds a feature flag (local only - not in IDPE or ConfigCat) to simulate the state of being a newly created IOx org. 

This allows an influxer to simulate which portions of the UI are still visible, even if testing from a TSM or pre-cutoff IOx org.

With Flag Off (normal behavior)
--
![Screen Shot 2023-01-30 at 6 03 41 PM](https://user-images.githubusercontent.com/91283923/215616572-064f2f4f-ffc3-40dc-819f-4d4e329bf9e8.png)



With Flag On (show only UI elements presented to new IOx users)
--
![Screen Shot 2023-01-30 at 6 03 48 PM](https://user-images.githubusercontent.com/91283923/215616679-0f24cded-984f-4461-83ac-37e78f504445.png)


![Screen Shot 2023-01-30 at 6 03 56 PM](https://user-images.githubusercontent.com/91283923/215616587-042744df-d247-4c60-a1c6-eb61c2fc1df9.png)

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - `ioxLaunchMock`
