### PR TITLE
feat(ui): add links for superset and grafana docs

### DIFF
--- a/src/homepageExperience/components/HomepageExperience.scss
+++ b/src/homepageExperience/components/HomepageExperience.scss
@@ -70,10 +70,10 @@ h1#first-mile--header {
 .homepage-wizard-next-steps {
   display: flex;
   max-width: 300px;
-  margin-top: 0 !important;
   h4 {
     background: linear-gradient(45deg, #fad9ff 0%, #f0fcff 100%);
     -webkit-background-clip: text;
+    background-clip: text;
     -webkit-text-fill-color: transparent;
 
     display: flex;
@@ -85,7 +85,12 @@ h1#first-mile--header {
     }
   }
 
+  .cf-icon {
+    margin-right: $cf-space-2xs;
+  }
+
   p {
+    color: $cf-grey-95;
     font-size: 14px;
     margin: 0;
     font-style: normal;

--- a/src/homepageExperience/components/steps/DashboardIntegrations.tsx
+++ b/src/homepageExperience/components/steps/DashboardIntegrations.tsx
@@ -1,0 +1,64 @@
+import React, {FC} from 'react'
+
+// Components
+import {
+  AlignItems,
+  ComponentSize,
+  FlexBox,
+  FlexDirection,
+  Icon,
+  IconFont,
+  ResourceCard,
+} from '@influxdata/clockface'
+
+// Utils
+import {SafeBlankLink} from 'src/utils/SafeBlankLink'
+
+type Props = {
+  wizardEventName: string
+  handleNextStepEvent: (wizardEventName: string, nextStepName: string) => void
+}
+
+const DashboardIntegrations: FC<Props> = ({
+  wizardEventName,
+  handleNextStepEvent,
+}) => {
+  return (
+    <FlexBox
+      margin={ComponentSize.Large}
+      alignItems={AlignItems.Stretch}
+      direction={FlexDirection.Row}
+    >
+      <ResourceCard className="homepage-wizard-next-steps">
+        <SafeBlankLink
+          href="https://docs.influxdata.com/influxdb/cloud-iox/visualize-data/superset/"
+          onClick={() =>
+            handleNextStepEvent(wizardEventName, 'supersetIntegration')
+          }
+        >
+          <h4>
+            <Icon glyph={IconFont.DashH} />
+            Integrate with Supserset
+          </h4>
+        </SafeBlankLink>
+        <p>Create dashboards and alerts with Apache Superset.</p>
+      </ResourceCard>
+      <ResourceCard className="homepage-wizard-next-steps">
+        <SafeBlankLink
+          href="https://docs.influxdata.com/influxdb/cloud-iox/visualize-data/grafana/"
+          onClick={() =>
+            handleNextStepEvent(wizardEventName, 'grafanaIntegration')
+          }
+        >
+          <h4>
+            <Icon glyph={IconFont.DashH} />
+            Integrate with Grafana
+          </h4>
+        </SafeBlankLink>
+        <p>Create dashboards and alerts with Grafana.</p>
+      </ResourceCard>
+    </FlexBox>
+  )
+}
+
+export default DashboardIntegrations

--- a/src/homepageExperience/components/steps/Finish.tsx
+++ b/src/homepageExperience/components/steps/Finish.tsx
@@ -1,4 +1,7 @@
 import React, {useEffect} from 'react'
+import confetti from 'canvas-confetti'
+
+// Components
 import {
   AlignItems,
   ComponentSize,
@@ -6,18 +9,17 @@ import {
   FlexDirection,
   ResourceCard,
 } from '@influxdata/clockface'
-
-import confetti from 'canvas-confetti'
-
 import {
   BookIcon,
   CodeTerminalIcon,
 } from 'src/homepageExperience/components/HomepageIcons'
-import {SafeBlankLink} from 'src/utils/SafeBlankLink'
-
-import {event} from 'src/cloud/utils/reporting'
 import FeedbackBar from 'src/homepageExperience/components/FeedbackBar'
 import SampleAppCard from 'src/homepageExperience/components/steps/SampleAppCard'
+import DashboardIntegrations from 'src/homepageExperience/components/steps/DashboardIntegrations'
+
+// Utils
+import {event} from 'src/cloud/utils/reporting'
+import {SafeBlankLink} from 'src/utils/SafeBlankLink'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 type OwnProps = {
@@ -162,6 +164,12 @@ export const Finish = (props: OwnProps) => {
             wizardEventName={props.wizardEventName}
           />
         ) : null}
+        {isFlagEnabled('ioxOnboarding') && (
+          <DashboardIntegrations
+            handleNextStepEvent={handleNextStepEvent}
+            wizardEventName={props.wizardEventName}
+          />
+        )}
       </FlexBox>
     </>
   )


### PR DESCRIPTION
This adds 2 cards to the end of any IOx onboarding flow to link to the docs for integrating with Superset & Grafana.

![image](https://user-images.githubusercontent.com/11937365/215621391-8a5b249d-6dac-49c6-8843-9c23a65da53d.png)

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
