### PR TITLE
fix: hardcoded comparison timestamp, prevents CI from running flows tests.

### DIFF
--- a/cypress/e2e/cloud/flows.test.ts
+++ b/cypress/e2e/cloud/flows.test.ts
@@ -8,13 +8,15 @@ describe('Flows', () => {
         cy.fixture('routes').then(({orgs}) => {
           cy.visit(`${orgs}/${id}`)
           cy.getByTestID('version-info').should('be.visible')
-
           cy.createNotebook(id).then(() => {
             cy.reload()
           })
-
-          cy.getByTestID('nav-item-flows').should('be.visible')
-          cy.getByTestID('nav-item-flows').click()
+          cy.setFeatureFlags({
+            showNotebooksForCI: true,
+          }).then(() => {
+            cy.getByTestID('nav-item-flows').should('be.visible')
+            cy.getByTestID('nav-item-flows').click()
+          })
         })
       })
     })

--- a/cypress/e2e/cloud/flows.test.ts
+++ b/cypress/e2e/cloud/flows.test.ts
@@ -264,6 +264,7 @@ describe('Flows with newQueryBuilder flag on', () => {
       cy.fixture('routes').then(({orgs}) => {
         cy.setFeatureFlags({
           newQueryBuilder: true,
+          showNotebooksForCI: true,
         }).then(() => {
           cy.visit(`${orgs}/${id}`)
         })

--- a/cypress/e2e/shared/editor.test.ts
+++ b/cypress/e2e/shared/editor.test.ts
@@ -49,11 +49,10 @@ describe('Editor+LSP communication', () => {
     before(() => {
       cy.flush()
       cy.signin()
-      cy.setFeatureFlags({schemaComposition: true})
+      cy.setFeatureFlags({schemaComposition: true, showNotebooksForCI: true})
       cy.get('@org').then(({id}: Organization) =>
         cy.fixture('routes').then(({orgs}) => {
           cy.visit(`${orgs}/${id}`)
-
           cy.createNotebook(id).then(() => {
             cy.reload()
           })

--- a/cypress/e2e/shared/flows.test.ts
+++ b/cypress/e2e/shared/flows.test.ts
@@ -15,6 +15,7 @@ describe('Flows', () => {
     // Double check that the new schemaComposition flag does not interfere.
     cy.setFeatureFlags({
       schemaComposition: true,
+      showNotebooksForCI: true,
     })
     // cy.wait($time) is necessary to consistently ensure sufficient time for the feature flag override.
     // The flag reset happens via redux, (it's not a network request), so we can't cy.wait($intercepted_route).

--- a/cypress/e2e/shared/flowsAlerts.test.ts
+++ b/cypress/e2e/shared/flowsAlerts.test.ts
@@ -27,6 +27,7 @@ describe('flows alert panel', () => {
               .setFeatureFlags({
                 notebooksExp: true,
                 notebooksNewEndpoints: true,
+                showNotebooksForCI: true,
               })
               .then(() => {
                 cy.getByTestID('nav-item-flows').should('be.visible')

--- a/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
+++ b/cypress/e2e/shared/flowsSidebarExportToClipboard.test.ts
@@ -110,18 +110,21 @@ describe('Flows Copy To Clipboard', () => {
       cy.get('@org').then(({id}: Organization) => {
         cy.fixture('routes').then(({orgs}) => {
           cy.visit(`${orgs}/${id}`)
-
           cy.createNotebook(id).then(() => {
             cy.reload()
           })
         })
       })
-      cy.getByTestID('tree-nav')
+      cy.setFeatureFlags({
+        showNotebooksForCI: true,
+      }).then(() => {
+        cy.getByTestID('tree-nav')
 
-      cy.clickNavBarItem('nav-item-flows')
-      cy.intercept('PATCH', `/api/v2private/notebooks/*`).as(
-        'NotebooksPatchRequest'
-      )
+        cy.clickNavBarItem('nav-item-flows')
+        cy.intercept('PATCH', `/api/v2private/notebooks/*`).as(
+          'NotebooksPatchRequest'
+        )
+      })
     })
   })
 

--- a/cypress/e2e/shared/legends.test.ts
+++ b/cypress/e2e/shared/legends.test.ts
@@ -558,8 +558,12 @@ describe('Legends', () => {
           cy.createNotebook(id).then(() => {
             cy.reload()
           })
-          cy.visit(`${orgs}/${id}${notebooks}`)
-          cy.getByTestID('tree-nav').should('be.visible')
+          cy.setFeatureFlags({
+            showNotebooksForCI: true,
+          }).then(() => {
+            cy.visit(`${orgs}/${id}${notebooks}`)
+            cy.getByTestID('tree-nav').should('be.visible')
+          })
         })
       })
     })

--- a/cypress/e2e/shared/secrets.test.ts
+++ b/cypress/e2e/shared/secrets.test.ts
@@ -128,6 +128,9 @@ describe('Secrets', () => {
       cy.get('@org').then(({id}: Organization) =>
         cy.fixture('routes').then(({orgs}) => {
           cy.visit(`${orgs}/${id}`)
+          cy.setFeatureFlags({
+            showNotebooksForCI: true,
+          })
           cy.createNotebook(id).then(() => {
             cy.reload()
           })

--- a/cypress/index.d.ts
+++ b/cypress/index.d.ts
@@ -31,6 +31,7 @@ import {
   createBucket,
   createScraper,
   createView,
+  createNotebook,
   fluxEqual,
   createTelegraf,
   createToken,
@@ -79,6 +80,7 @@ declare global {
       createDashWithCell: typeof createDashWithCell
       createDashWithViewAndVar: typeof createDashWithViewAndVar
       createView: typeof createView
+      createNotebook: typeof createNotebook
       createOrg: typeof createOrg
       deleteOrg: typeof deleteOrg
       flush: typeof flush

--- a/src/flows/selectors/flowsSelectors.ts
+++ b/src/flows/selectors/flowsSelectors.ts
@@ -4,6 +4,7 @@ import {AppState} from 'src/types'
 import {CLOUD, IOX_SWITCHOVER_CREATION_DATE} from 'src/shared/constants'
 
 import {selectOrgCreationDate} from 'src/organizations/selectors'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 export const selectNotebooks = (state: AppState): Notebook[] => {
   return state.resources.notebooks.notebooks
@@ -20,7 +21,7 @@ export const selectShouldShowNotebooks = (state: AppState): boolean => {
   }
 
   // In cloud, don't show notebooks for any org created after the IOx cutover date
-  if (!wasCreatedBeforeIOxCutoff) {
+  if (!wasCreatedBeforeIOxCutoff && !isFlagEnabled('showNotebooksForCI')) {
     return false
   }
 


### PR DESCRIPTION
## Issue:

First commit is an empty commit, demonstrating the following:
Tests are failing, even with no change to master. 
<img width="443" alt="Screen Shot 2023-01-30 at 6 00 52 PM" src="https://user-images.githubusercontent.com/10232835/215640708-2e82da52-1cb4-4a52-92f6-4d44f23322ce.png">

## Fix:
Provide a flag, used in CI, to override the hardcoded cutoff timestamp.
