### PR TITLE
chore: correct helpbar styling for new iox

### DIFF
--- a/src/pageLayout/containers/MainNavigation.tsx
+++ b/src/pageLayout/containers/MainNavigation.tsx
@@ -252,9 +252,13 @@ export const MainNavigation: FC = () => {
 
   const location = useLocation()
   useEffect(() => {
-    const helpBarMenu = document.querySelectorAll<HTMLElement>(
+    const linksWithSubMenus = document.querySelectorAll<HTMLElement>(
       '.cf-tree-nav--sub-menu-trigger'
-    )[3]
+    )
+    const lastSubMenu = linksWithSubMenus.length - 1
+
+    const helpBarMenu = linksWithSubMenus[lastSubMenu]
+
     if (!helpBarMenu) {
       return
     }


### PR DESCRIPTION
In testing of what the navbar should look like for new IOx orgs, the helpbar is behaving as expected when collapsed, but not when expanded. The reason is that the expanded style targets the 4th navbar link with submenus (array item `[3]`), but for new iox orgs, there are only 3 navbar links with submenus (because alerts are disabled).

We can set this consistently and dynamically by targeting the _last_ navbar link, rather than a static array index.

Current - TSM (Works)


https://user-images.githubusercontent.com/91283923/215665694-f3037c96-f6ef-47bf-bc6f-2d03e211a6e3.mov



Current - New IOx (Not opening when navbar expanded)

https://user-images.githubusercontent.com/91283923/215665706-44df16cf-a4d0-4486-972d-fcf4345f8e5f.mov




After PR - TSM (Works)

https://user-images.githubusercontent.com/91283923/215665709-3a7af7b3-7dcb-4e2e-abb4-4ed70149ebf6.mov




After PR - New IOx (Works)

https://user-images.githubusercontent.com/91283923/215665719-c7f5fe45-179d-41ce-98db-8069ce72f2e3.mov




### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable
