### PR TITLE
feat(ui): curate client libary list for sql

### DIFF
--- a/src/writeData/components/ClientLibrarySectionSql.tsx
+++ b/src/writeData/components/ClientLibrarySectionSql.tsx
@@ -1,0 +1,86 @@
+// Libraries
+import React, {useContext} from 'react'
+import {useSelector} from 'react-redux'
+import {useHistory} from 'react-router-dom'
+import {ORGS} from 'src/shared/constants/routes'
+import {searchClients} from 'src/writeData'
+
+// Utils
+import {getOrg} from 'src/organizations/selectors'
+import {event} from 'src/cloud/utils/reporting'
+
+// Contexts
+import {WriteDataSearchContext} from 'src/writeData/containers/WriteDataPage'
+
+// Components
+import {
+  SquareGrid,
+  ComponentSize,
+  Heading,
+  HeadingElement,
+  FontWeight,
+} from '@influxdata/clockface'
+import WriteDataItem from 'src/writeData/components/WriteDataItem'
+
+const ClientLibrarySectionSql = () => {
+  const {searchTerm} = useContext(WriteDataSearchContext)
+  const items = searchClients(searchTerm)
+
+  const history = useHistory()
+  const org = useSelector(getOrg)
+
+  const onBoardingItems = {
+    python: 'python',
+  }
+
+  if (!items.length) {
+    return null
+  }
+
+  return (
+    <div
+      className="write-data--section"
+      data-testid="write-data--section client-libraries"
+    >
+      <Heading
+        element={HeadingElement.H2}
+        weight={FontWeight.Regular}
+        style={{marginTop: '24px', marginBottom: '4px'}}
+      >
+        Client Libraries
+      </Heading>
+      <Heading
+        element={HeadingElement.H5}
+        weight={FontWeight.Regular}
+        style={{marginBottom: '24px'}}
+      >
+        Back-end, front-end, and mobile applications
+      </Heading>
+      <SquareGrid cardSize="170px" gutter={ComponentSize.Small}>
+        {items.map(item => {
+          const goto = () => {
+            event('Load data client library clicked', {type: item.name})
+            if (onBoardingItems.hasOwnProperty(`${item.id}`)) {
+              return history.push(
+                `/${ORGS}/${org.id}/new-user-setup/${onBoardingItems[item.id]}`
+              )
+            }
+          }
+          if (onBoardingItems.hasOwnProperty(`${item.id}`)) {
+            return (
+              <WriteDataItem
+                key={item.id}
+                id={item.id}
+                name={item.name}
+                image={item.logo}
+                onClick={goto}
+              />
+            )
+          }
+        })}
+      </SquareGrid>
+    </div>
+  )
+}
+
+export default ClientLibrarySectionSql

--- a/src/writeData/components/WriteDataSections.tsx
+++ b/src/writeData/components/WriteDataSections.tsx
@@ -25,6 +25,7 @@ import {isOrgIOx} from 'src/organizations/selectors'
 
 const WriteDataSections: FC = () => {
   const {searchTerm} = useContext(WriteDataSearchContext)
+  const isIOxOrg = useSelector(isOrgIOx)
   const hasResults =
     !!searchUploads(searchTerm).length ||
     !!searchClients(searchTerm).length ||
@@ -43,7 +44,7 @@ const WriteDataSections: FC = () => {
   return (
     <>
       <FileUploadSection />
-      {useSelector(isOrgIOx) ? (
+      {isIOxOrg ? (
         <ClientLibrarySectionSql />
       ) : (
         <ClientLibrarySection />

--- a/src/writeData/components/WriteDataSections.tsx
+++ b/src/writeData/components/WriteDataSections.tsx
@@ -1,5 +1,6 @@
 // Libraries
 import React, {FC, useContext} from 'react'
+import { useSelector } from 'react-redux'
 
 // Contexts
 import {WriteDataSearchContext} from 'src/writeData/containers/WriteDataPage'
@@ -14,11 +15,13 @@ import {CLOUD} from 'src/shared/constants'
 import {EmptyState, ComponentSize} from '@influxdata/clockface'
 import FileUploadSection from 'src/writeData/components/FileUploadSection'
 import ClientLibrarySection from 'src/writeData/components/ClientLibrarySection'
+import ClientLibrarySectionSql from './ClientLibrarySectionSql'
 import TelegrafPluginSection from 'src/writeData/components/TelegrafPluginSection'
 import CloudNativeSources from 'src/writeData/subscriptions/components/CloudNativeSources'
 
 // Utils
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import { isOrgIOx } from 'src/organizations/selectors'
 
 const WriteDataSections: FC = () => {
   const {searchTerm} = useContext(WriteDataSearchContext)
@@ -40,7 +43,7 @@ const WriteDataSections: FC = () => {
   return (
     <>
       <FileUploadSection />
-      <ClientLibrarySection />
+      {useSelector(isOrgIOx) ? <ClientLibrarySectionSql /> : <ClientLibrarySection />}
       {CLOUD && isFlagEnabled('subscriptionsUI') && <CloudNativeSources />}
       <TelegrafPluginSection />
     </>

--- a/src/writeData/components/WriteDataSections.tsx
+++ b/src/writeData/components/WriteDataSections.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {FC, useContext} from 'react'
-import { useSelector } from 'react-redux'
+import {useSelector} from 'react-redux'
 
 // Contexts
 import {WriteDataSearchContext} from 'src/writeData/containers/WriteDataPage'
@@ -21,7 +21,7 @@ import CloudNativeSources from 'src/writeData/subscriptions/components/CloudNati
 
 // Utils
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
-import { isOrgIOx } from 'src/organizations/selectors'
+import {isOrgIOx} from 'src/organizations/selectors'
 
 const WriteDataSections: FC = () => {
   const {searchTerm} = useContext(WriteDataSearchContext)
@@ -43,7 +43,11 @@ const WriteDataSections: FC = () => {
   return (
     <>
       <FileUploadSection />
-      {useSelector(isOrgIOx) ? <ClientLibrarySectionSql /> : <ClientLibrarySection />}
+      {useSelector(isOrgIOx) ? (
+        <ClientLibrarySectionSql />
+      ) : (
+        <ClientLibrarySection />
+      )}
       {CLOUD && isFlagEnabled('subscriptionsUI') && <CloudNativeSources />}
       <TelegrafPluginSection />
     </>

--- a/src/writeData/components/WriteDataSections.tsx
+++ b/src/writeData/components/WriteDataSections.tsx
@@ -15,7 +15,7 @@ import {CLOUD} from 'src/shared/constants'
 import {EmptyState, ComponentSize} from '@influxdata/clockface'
 import FileUploadSection from 'src/writeData/components/FileUploadSection'
 import ClientLibrarySection from 'src/writeData/components/ClientLibrarySection'
-import ClientLibrarySectionSql from './ClientLibrarySectionSql'
+import ClientLibrarySectionSql from 'src/writeData/components/ClientLibrarySectionSql'
 import TelegrafPluginSection from 'src/writeData/components/TelegrafPluginSection'
 import CloudNativeSources from 'src/writeData/subscriptions/components/CloudNativeSources'
 
@@ -44,11 +44,7 @@ const WriteDataSections: FC = () => {
   return (
     <>
       <FileUploadSection />
-      {isIOxOrg ? (
-        <ClientLibrarySectionSql />
-      ) : (
-        <ClientLibrarySection />
-      )}
+      {isIOxOrg ? <ClientLibrarySectionSql /> : <ClientLibrarySection />}
       {CLOUD && isFlagEnabled('subscriptionsUI') && <CloudNativeSources />}
       <TelegrafPluginSection />
     </>


### PR DESCRIPTION
Curates the client library page for IOx to only show those updated with SQL instructions.

### Checklist

Authors and Reviewer(s), please verify the following:

- [ ] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [ ] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
