### PR TITLE
fix: sql graph optimizations, handling various edge cases with data returned

### DIFF
--- a/cypress/e2e/shared/editor.test.ts
+++ b/cypress/e2e/shared/editor.test.ts
@@ -127,6 +127,7 @@ describe('Editor+LSP communication', () => {
         newDataExplorer: true,
         schemaComposition: false,
         saveAsScript: true,
+        enableFluxInScriptBuilder: true,
       })
       cy.get('@org').then(({id}: Organization) => {
         cy.visit(`/orgs/${id}/data-explorer`)

--- a/cypress/e2e/shared/scriptQueryBuilder.flux.test.ts
+++ b/cypress/e2e/shared/scriptQueryBuilder.flux.test.ts
@@ -171,6 +171,7 @@ describe('Script Builder', () => {
       loginWithFlags({
         schemaComposition: false,
         newDataExplorer: true,
+        enableFluxInScriptBuilder: true,
       }).then(() => {
         cy.getByTestID('editor-sync--toggle').should('not.exist')
         cy.getByTestID('script-query-builder--menu').contains('New Script')
@@ -325,6 +326,7 @@ describe('Script Builder', () => {
         schemaComposition: true,
         newDataExplorer: true,
         saveAsScript: true,
+        enableFluxInScriptBuilder: true,
       }).then(() => {
         clearSession()
         cy.getByTestID('editor-sync--toggle')

--- a/cypress/e2e/shared/scriptQueryBuilder.results.test.ts
+++ b/cypress/e2e/shared/scriptQueryBuilder.results.test.ts
@@ -170,6 +170,7 @@ describe('Script Builder', () => {
         schemaComposition: true,
         newDataExplorer: true,
         saveAsScript: true,
+        enableFluxInScriptBuilder: true,
       }).then(() => {
         cy.get('@org').then(({id: orgID}: Organization) => {
           route = `/orgs/${orgID}/data-explorer`

--- a/src/dataExplorer/components/ScriptQueryBuilder.tsx
+++ b/src/dataExplorer/components/ScriptQueryBuilder.tsx
@@ -68,7 +68,8 @@ const ScriptQueryBuilder: FC = () => {
   const org = useSelector(getOrg)
   const isNewIOxOrg =
     useSelector(selectIsNewIOxOrg) &&
-    !isFlagEnabled('showOldDataExplorerInNewIOx')
+    !isFlagEnabled('showOldDataExplorerInNewIOx') &&
+    !isFlagEnabled('enableFluxInScriptBuilder')
 
   const handleClear = useCallback(() => {
     cancel()
@@ -226,7 +227,7 @@ const ScriptQueryBuilder: FC = () => {
               <ResultsPane />
             </DraggableResizer.Panel>
             <DraggableResizer.Panel isCollapsible={true}>
-              {!isNewIOxOrg && <Sidebar />}
+              <Sidebar />
             </DraggableResizer.Panel>
           </DraggableResizer>
         </FlexBox>


### PR DESCRIPTION
Asap fixes for UI changes request today, as well as things which broke in the past few days with the last minute marty-related commits.

## Fixes for graph results
* flux language still needs to be available for CI tests, especially new scripts crud tests (to be merged shortly) and the iox-only tests which are not currently running.
* The graph optimization sidebar needs to be open:
    * when using SQL
    * when graph subquery results are nothing --> due to query optimization parameters chosen by the user.
         * in this case, surface a useful message to the user
         * also surface any graph subquery errors --> in the graph area.
*  The graph optimization sidebar should be closed, if and only if:
    * there are no results from the parent query. 

## Vid:

Showing the various use cases of:
* no data from parent query
* data from parent query, but not from subquery
* giving feedback to the user


https://user-images.githubusercontent.com/10232835/215892919-39ed5dd8-14f3-4a2b-b4ee-9008e65f7da3.mov




# Checklist
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
