### PR TITLE
fix(6562): editor test on iox

### DIFF
--- a/cypress/e2e/shared/editor.test.ts
+++ b/cypress/e2e/shared/editor.test.ts
@@ -6,7 +6,7 @@ const DEFAULT_FLUX_EDITOR_TEXT =
 // to see list of monaco-editor widgets to check:
 // document.querySelectorAll('[widgetid]')
 
-describe.skip('Editor+LSP communication', () => {
+describe('Editor+LSP communication', () => {
   const runTest = editorSelector => {
     it('receives LSP-triggered server events', () => {
       cy.getByTestID(editorSelector).then(() => {
@@ -82,6 +82,7 @@ describe.skip('Editor+LSP communication', () => {
       cy.signin()
       cy.setFeatureFlags({
         schemaComposition: true,
+        showOldDataExplorerInNewIOx: true,
       })
       cy.get('@org').then(({id}: Organization) => {
         cy.createMapVariable(id)
@@ -132,17 +133,23 @@ describe.skip('Editor+LSP communication', () => {
       cy.get('@org').then(({id}: Organization) => {
         cy.visit(`/orgs/${id}/data-explorer`)
         cy.getByTestID('tree-nav').should('be.visible')
-        cy.getByTestID('script-query-builder-toggle').then($toggle => {
-          cy.wrap($toggle).should('be.visible')
-          // Switch to Script Editor if not yet
-          if ($toggle.hasClass('active')) {
-            // active means showing the old Data Explorer
-            // hasClass is a jQuery function
-            $toggle.click()
-            cy.getByTestID('script-query-builder--menu').contains('New Script')
+        cy.isIoxOrg().then(isIox => {
+          if (!isIox) {
+            cy.getByTestID('script-query-builder-toggle').then($toggle => {
+              cy.wrap($toggle).should('be.visible')
+              // Switch to Script Editor if not yet
+              if ($toggle.hasClass('active')) {
+                // active means showing the old Data Explorer
+                // hasClass is a jQuery function
+                $toggle.click()
+                cy.getByTestID('script-query-builder--menu').contains(
+                  'New Script'
+                )
+              }
+            })
           }
-          return setScriptToFlux()
         })
+        return setScriptToFlux()
       })
     })
 


### PR DESCRIPTION
Part of #6562 

iox, passing locally:
<img width="521" alt="Screen Shot 2023-01-31 at 5 58 01 PM" src="https://user-images.githubusercontent.com/10232835/215928148-2a418018-70c7-4415-8c20-22ee9cf4b521.png">



## Checklist
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
