### PR TITLE
fix: update task test to work with iox pipeline

### DIFF
--- a/cypress/e2e/shared/tasks.test.ts
+++ b/cypress/e2e/shared/tasks.test.ts
@@ -10,6 +10,8 @@ import {Organization} from '../../../src/types'
 const isIOxOrg = Boolean(Cypress.env('useIox'))
 const isTSMOrg = !isIOxOrg
 
+// shouldShowTasks determines whether the flag for 'forcing'
+// the display of tasks in iox orgs should be enabled.
 const setupTest = (shouldShowTasks: boolean = true) => {
   cy.flush()
   cy.signin()

--- a/cypress/e2e/shared/tasks.test.ts
+++ b/cypress/e2e/shared/tasks.test.ts
@@ -10,11 +10,16 @@ import {Organization} from '../../../src/types'
 const isIOxOrg = Boolean(Cypress.env('useIox'))
 const isTSMOrg = !isIOxOrg
 
-const setupTest = ({showTasksInNewIOx = true}) => {
+const setupTest = (showTasksInNewIOx: boolean) => {
   cy.flush()
   cy.signin()
 
-  cy.setFeatureFlags({showTasksInNewIOx})
+  if (showTasksInNewIOx) {
+    cy.setFeatureFlags({showTasksInNewIOx})
+  } else {
+    // By default, show tasks in new iox, whether it's TSM or IOx.
+    cy.setFeatureFlags({showTasksInNewIOx: true})
+  }
 
   cy.get<Organization>('@org')
     .then(({id: orgID}: Organization) => {
@@ -720,7 +725,7 @@ describe('Tasks - TSM', () => {
 describe('Tasks - IOx', () => {
   it('New IOx orgs do not have Tasks', () => {
     cy.skipOn(isTSMOrg)
-    setupTest({showTasksInNewIOx: false})
+    setupTest(false)
     cy.getByTestID('nav-item-tasks').should('not.exist')
     cy.contains('404: Page Not Found')
   })

--- a/cypress/e2e/shared/tasks.test.ts
+++ b/cypress/e2e/shared/tasks.test.ts
@@ -10,15 +10,6 @@ import {Organization} from '../../../src/types'
 const isIOxOrg = Boolean(Cypress.env('useIox'))
 const isTSMOrg = !isIOxOrg
 
-describe('Tasks - IOx', () => {
-  it('New IOx orgs do not have Tasks', () => {
-    cy.skipOn(isTSMOrg)
-    setupTest(false)
-    cy.getByTestID('nav-item-tasks').should('not.exist')
-    cy.contains('404: Page Not Found')
-  })
-})
-
 const setupTest = (showTasksInNewIOx = true) => {
   cy.flush()
   cy.signin()
@@ -52,7 +43,6 @@ const setupTest = (showTasksInNewIOx = true) => {
 
 describe('Tasks - TSM', () => {
   beforeEach(() => {
-    // Skip all tasks tests for IOx orgs, which do not have tasks.
     setupTest()
   })
 
@@ -724,5 +714,14 @@ describe('Tasks - TSM', () => {
         .getByTestID('task-card--name')
         .contains(task.name)
     })
+  })
+})
+
+describe('Tasks - IOx', () => {
+  it('New IOx orgs do not have Tasks', () => {
+    cy.skipOn(isTSMOrg)
+    setupTest(false)
+    cy.getByTestID('nav-item-tasks').should('not.exist')
+    cy.contains('404: Page Not Found')
   })
 })

--- a/cypress/e2e/shared/tasks.test.ts
+++ b/cypress/e2e/shared/tasks.test.ts
@@ -10,16 +10,11 @@ import {Organization} from '../../../src/types'
 const isIOxOrg = Boolean(Cypress.env('useIox'))
 const isTSMOrg = !isIOxOrg
 
-const setupTest = (showTasksInNewIOx: boolean) => {
+const setupTest = (shouldShowTasks: boolean = true) => {
   cy.flush()
   cy.signin()
 
-  if (showTasksInNewIOx) {
-    cy.setFeatureFlags({showTasksInNewIOx})
-  } else {
-    // By default, show tasks in new iox, whether it's TSM or IOx.
-    cy.setFeatureFlags({showTasksInNewIOx: true})
-  }
+  cy.setFeatureFlags({showTasksInNewIOx: shouldShowTasks})
 
   cy.get<Organization>('@org')
     .then(({id: orgID}: Organization) => {
@@ -45,6 +40,17 @@ const setupTest = (showTasksInNewIOx: boolean) => {
       })
     })
 }
+
+describe('Tasks - IOx', () => {
+  it('New IOx orgs do not have Tasks', () => {
+    cy.skipOn(isTSMOrg)
+    const shouldShowTasks = false
+
+    setupTest(shouldShowTasks)
+    cy.getByTestID('nav-item-tasks').should('not.exist')
+    cy.contains('404: Page Not Found')
+  })
+})
 
 describe('Tasks - TSM', () => {
   beforeEach(() => {
@@ -719,14 +725,5 @@ describe('Tasks - TSM', () => {
         .getByTestID('task-card--name')
         .contains(task.name)
     })
-  })
-})
-
-describe('Tasks - IOx', () => {
-  it('New IOx orgs do not have Tasks', () => {
-    cy.skipOn(isTSMOrg)
-    setupTest(false)
-    cy.getByTestID('nav-item-tasks').should('not.exist')
-    cy.contains('404: Page Not Found')
   })
 })

--- a/cypress/e2e/shared/tasks.test.ts
+++ b/cypress/e2e/shared/tasks.test.ts
@@ -7,37 +7,62 @@ import {Organization} from '../../../src/types'
 // will pass without this. However, the chain of actions
 // implemented here replicates what would realistically occur.
 
-describe.skip('Tasks', () => {
-  beforeEach(() => {
-    cy.flush()
-    cy.signin()
-    cy.get<Organization>('@org').then(({id: orgID}: Organization) =>
-      cy
-        .createToken(orgID, 'test token', 'active', [
-          {action: 'write', resource: {type: 'views', orgID}},
-          {action: 'write', resource: {type: 'documents', orgID}},
-          {action: 'write', resource: {type: 'tasks', orgID}},
-        ])
-        .then(({body}) => {
-          cy.wrap(body.token).as('token')
-        })
-    )
+const isIOxOrg = Boolean(Cypress.env('useIox'))
+const isTSMOrg = !isIOxOrg
 
-    cy.fixture('routes').then(({orgs}) => {
-      cy.get<Organization>('@org').then(({id}: Organization) => {
-        cy.visit(`${orgs}/${id}/tasks`)
-        cy.getByTestID('tree-nav')
+describe('Tasks - IOx', () => {
+  it('New IOx orgs do not have Tasks', () => {
+    cy.skipOn(isTSMOrg)
+    setupTest(false)
+    cy.getByTestID('nav-item-tasks').should('not.exist')
+    cy.contains('404: Page Not Found')
+  })
+})
+
+const setupTest = (showTasksInNewIOx = true) => {
+  cy.flush()
+  cy.signin()
+
+  cy.setFeatureFlags({showTasksInNewIOx})
+
+  cy.get<Organization>('@org')
+    .then(({id: orgID}: Organization) => {
+      cy.createToken(orgID, 'test token', 'active', [
+        {action: 'write', resource: {type: 'views', orgID}},
+        {action: 'write', resource: {type: 'documents', orgID}},
+        {action: 'write', resource: {type: 'tasks', orgID}},
+      ]).then(({body}) => {
+        cy.wrap(body.token).as('token')
       })
     })
+    .then(() => {
+      cy.fixture('routes').then(({orgs}) => {
+        cy.get<Organization>('@org').then(({id}: Organization) => {
+          cy.getByTestID('tree-nav').should('be.visible')
+          // Tasks link should appear in nav in TSM orgs.
+          if (isTSMOrg) {
+            cy.getByTestID('nav-item-tasks').should('be.visible').click()
+          } else {
+            cy.visit(`${orgs}/${id}/tasks`)
+          }
+        })
+      })
+    })
+}
+
+describe('Tasks - TSM', () => {
+  beforeEach(() => {
+    // Skip all tasks tests for IOx orgs, which do not have tasks.
+    setupTest()
   })
 
   it('can create a task', () => {
     const taskName = 'Task'
     cy.createTaskFromEmpty(taskName, ({name}) => {
       return `import "influxdata/influxdb/v1"
-v1.tagValues(bucket: "${name}", tag: "_field")
-from(bucket: "${name}")
-   |> range(start: -2m)`
+  v1.tagValues(bucket: "${name}", tag: "_field")
+  from(bucket: "${name}")
+     |> range(start: -2m)`
     })
 
     cy.getByTestID('task-save-btn').click()
@@ -53,7 +78,7 @@ from(bucket: "${name}")
     const taskName = 'Task'
     cy.createTaskFromEmpty(taskName, () => {
       return `import "http" {enter}
-http.post(url: "https://foo.bar/baz", data: bytes(v: "body"))`
+  http.post(url: "https://foo.bar/baz", data: bytes(v: "body"))`
     })
 
     cy.getByTestID('task-save-btn').click()
@@ -68,7 +93,7 @@ http.post(url: "https://foo.bar/baz", data: bytes(v: "body"))`
 
     cy.createTaskFromEmpty(taskName, ({name}) => {
       return `from(bucket: "${name}")
-   |> range(start: -2m)`
+     |> range(start: -2m)`
     })
 
     cy.getByTestID('task-card-cron-btn').click()
@@ -104,12 +129,12 @@ http.post(url: "https://foo.bar/baz", data: bytes(v: "body"))`
     cy.focused()
 
     cy.getByTestID('flux-editor').monacoType(`option task = {
-  name: "Option Test",
-  every: 24h,
-  offset: 20m
-}
-from(bucket: "defbuck")
-  |> range(start: -2m)`)
+    name: "Option Test",
+    every: 24h,
+    offset: 20m
+  }
+  from(bucket: "defbuck")
+    |> range(start: -2m)`)
 
     cy.getByTestID('task-form-name')
       .click()
@@ -427,9 +452,9 @@ from(bucket: "defbuck")
         taskName,
         ({name}) => {
           return `import "influxdata/influxdb/v1"
-  v1.tagValues(bucket: "${name}", tag: "_field")
-  from(bucket: "${name}")
-    |> range(start: -2m)`
+    v1.tagValues(bucket: "${name}", tag: "_field")
+    from(bucket: "${name}")
+      |> range(start: -2m)`
         },
         interval,
         offset

--- a/cypress/e2e/shared/tasks.test.ts
+++ b/cypress/e2e/shared/tasks.test.ts
@@ -10,7 +10,7 @@ import {Organization} from '../../../src/types'
 const isIOxOrg = Boolean(Cypress.env('useIox'))
 const isTSMOrg = !isIOxOrg
 
-const setupTest = (showTasksInNewIOx = true) => {
+const setupTest = ({showTasksInNewIOx = true}) => {
   cy.flush()
   cy.signin()
 
@@ -720,7 +720,7 @@ describe('Tasks - TSM', () => {
 describe('Tasks - IOx', () => {
   it('New IOx orgs do not have Tasks', () => {
     cy.skipOn(isTSMOrg)
-    setupTest(false)
+    setupTest({showTasksInNewIOx: false})
     cy.getByTestID('nav-item-tasks').should('not.exist')
     cy.contains('404: Page Not Found')
   })

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -766,7 +766,7 @@ export const setupUser = (useIox: boolean = false): Cypress.Chainable<any> => {
         Cypress.env('defaultUser', response.body.user.name)
         if (defaultUser) {
           return cy
-            .log(`re-provsioned user ${defaultUser} successfully`)
+            .log(`re-provisioned user ${defaultUser} successfully`)
             .then(() => response)
         } else {
           return cy


### PR DESCRIPTION
Part of #6562 

Updates the tasks tests to work with the IOx pipeline:

(1) If in a TSM org, run the old tasks tests.
(2) If in an IOx org, flip the 'show tasks in iox' flag on so that we simulate the environment for old iox orgs and Tools.
(3) If in an IOx org, also run an extra test to make sure tasks doesn't show for new users.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - no
