### PR TITLE
fix(6562): dashboard tests passing on iox

### DIFF
--- a/cypress/e2e/cloud/dashboardsView.test.ts
+++ b/cypress/e2e/cloud/dashboardsView.test.ts
@@ -1,13 +1,19 @@
-describe.skip('Dashboard', () => {
+describe('Dashboard', () => {
   beforeEach(() =>
     cy.flush().then(() =>
       cy.signin().then(() =>
-        cy.fixture('routes').then(({orgs}) => {
-          cy.get('@org').then(({id: orgID}: any) => {
-            cy.visit(`${orgs}/${orgID}/dashboards-list`)
-            cy.getByTestID('tree-nav')
+        cy
+          .setFeatureFlags({
+            showDashboardsInNewIOx: true,
           })
-        })
+          .then(() =>
+            cy.fixture('routes').then(({orgs}) => {
+              cy.get('@org').then(({id: orgID}: any) => {
+                cy.visit(`${orgs}/${orgID}/dashboards-list`)
+                cy.getByTestID('tree-nav')
+              })
+            })
+          )
       )
     )
   )
@@ -40,7 +46,7 @@ describe.skip('Dashboard', () => {
     cy.getByTestID('cell--view-empty markdown').contains(markdownImageWarning)
   })
 
-  it.skip('escapes html in markdown editor', () => {
+  it('escapes html in markdown editor', () => {
     cy.get('@org').then(({id: orgID}: any) => {
       cy.createDashboard(orgID).then(({body}) => {
         cy.fixture('routes').then(({orgs}) => {

--- a/cypress/e2e/shared/dashboardsIndex.test.ts
+++ b/cypress/e2e/shared/dashboardsIndex.test.ts
@@ -7,16 +7,27 @@ const dashboardName = 'Bee Happy'
 const dashboardName2 = 'test dashboard'
 const dashSearchName = 'bEE'
 
-describe.skip('Dashboards', () => {
+describe('Dashboards', () => {
   beforeEach(() => {
-    cy.flush()
-    cy.signin()
-    cy.fixture('routes').then(({orgs}) => {
-      cy.get<Organization>('@org').then(({id: orgID}: Organization) => {
-        cy.visit(`${orgs}/${orgID}/dashboards-list`)
-      })
-    })
-    cy.getByTestID('tree-nav')
+    cy.flush().then(() =>
+      cy.signin().then(() =>
+        cy
+          .setFeatureFlags({
+            showDashboardsInNewIOx: true,
+            showVariablesInNewIOx: true,
+          })
+          .then(() => {
+            cy.fixture('routes').then(({orgs}) => {
+              return cy
+                .get<Organization>('@org')
+                .then(({id: orgID}: Organization) => {
+                  cy.visit(`${orgs}/${orgID}/dashboards-list`)
+                })
+            })
+            return cy.getByTestID('tree-nav')
+          })
+      )
+    )
   })
 
   it('empty state should have a header with text and a button to create a dashboard', () => {
@@ -508,8 +519,8 @@ describe.skip('Dashboards', () => {
         cy.getByTestID('search-widget').should('have.value', dashSearchName)
 
         // Navigate Away and come back by clicking on Boards icon
-        cy.getByTestID('nav-item-tasks').click()
-        cy.getByTestID('page-title').contains('Tasks')
+        cy.getByTestID('nav-item-data-explorer').click()
+        cy.getByTestID('page-title').contains('Data Explorer')
         cy.getByTestID('nav-item-dashboards').click()
         cy.getByTestID('search-widget').should('have.value', dashSearchName)
       })

--- a/cypress/e2e/shared/dashboardsRefresh.test.ts
+++ b/cypress/e2e/shared/dashboardsRefresh.test.ts
@@ -1,16 +1,24 @@
 import {Organization} from '../../../src/types'
 import * as moment from 'moment'
 
-describe.skip('Dashboard refresh', () => {
+describe('Dashboard refresh', () => {
   beforeEach(() => {
-    cy.flush()
-    cy.signin()
-    cy.fixture('routes').then(({orgs}) => {
-      cy.get('@org').then((org: Organization) => {
-        cy.visit(`${orgs}/${org.id}/dashboards-list`)
-        cy.getByTestID('tree-nav')
-      })
-    })
+    cy.flush().then(() =>
+      cy.signin().then(() =>
+        cy
+          .setFeatureFlags({
+            showDashboardsInNewIOx: true,
+          })
+          .then(() =>
+            cy.fixture('routes').then(({orgs}) => {
+              cy.get('@org').then((org: Organization) => {
+                cy.visit(`${orgs}/${org.id}/dashboards-list`)
+                cy.getByTestID('tree-nav')
+              })
+            })
+          )
+      )
+    )
   })
 
   describe('Dashboard auto refresh', () => {
@@ -411,6 +419,12 @@ describe.skip('Dashboard refresh', () => {
   })
 
   describe('Dashboard manual refresh', () => {
+    beforeEach(() => {
+      cy.setFeatureFlags({
+        showDashboardsInNewIOx: true,
+        showVariablesInNewIOx: true,
+      })
+    })
     it('can refresh a cell without refreshing the entire dashboard', () => {
       cy.get('@org').then(({id: orgID, name}: Organization) => {
         cy.createDashboard(orgID).then(({body}) => {

--- a/cypress/e2e/shared/dashboardsVariables.test.ts
+++ b/cypress/e2e/shared/dashboardsVariables.test.ts
@@ -34,20 +34,29 @@ const getSelectedVariable =
     return hydratedVarDawg.selected[0]
   }
 
-describe.skip('Dashboard - variable interactions', () => {
+describe('Dashboard - variable interactions', () => {
   beforeEach(() => {
-    cy.flush()
-    cy.signin()
-    cy.fixture('routes').then(({orgs}) => {
-      cy.get<Organization>('@org').then(({id: orgID}: Organization) => {
-        cy.visit(`${orgs}/${orgID}/dashboards-list`)
-        const numLines = 360
-        cy.writeData(points(numLines))
-        cy.createDashboard(orgID).then(({body: dashboard}) => {
-          cy.wrap({dashboard}).as('dashboard')
-        })
-      })
-    })
+    cy.flush().then(() =>
+      cy.signin().then(() =>
+        cy
+          .setFeatureFlags({
+            showDashboardsInNewIOx: true,
+            showVariablesInNewIOx: true,
+          })
+          .then(() =>
+            cy.fixture('routes').then(({orgs}) => {
+              cy.get<Organization>('@org').then(({id: orgID}: Organization) => {
+                cy.visit(`${orgs}/${orgID}/dashboards-list`)
+                const numLines = 360
+                cy.writeData(points(numLines))
+                cy.createDashboard(orgID).then(({body: dashboard}) => {
+                  cy.wrap({dashboard}).as('dashboard')
+                })
+              })
+            })
+          )
+      )
+    )
   })
 
   it('informs user if variables are enabled but not defined', () => {

--- a/cypress/e2e/shared/dashboardsView.test.ts
+++ b/cypress/e2e/shared/dashboardsView.test.ts
@@ -6,19 +6,22 @@ const isTSMOrg = !isIOxOrg
 
 describe('Dashboard - TSM and pre marty release IOx', () => {
   beforeEach(() => {
-    cy.flush()
-    cy.signin()
-    cy.setFeatureFlags({
-      showDashboardsInNewIOx: true,
-      showVariablesInNewIOx: true,
-    }).then(() => {
-      cy.fixture('routes').then(({orgs}) => {
-        cy.get<Organization>('@org').then(({id: orgID}: Organization) => {
-          cy.visit(`${orgs}/${orgID}/dashboards-list`)
-          cy.getByTestID('tree-nav')
-        })
-      })
-    })
+    cy.flush().then(() =>
+      cy.signin().then(() =>
+        cy
+          .setFeatureFlags({
+            showDashboardsInNewIOx: true,
+          })
+          .then(() =>
+            cy.fixture('routes').then(({orgs}) => {
+              cy.get<Organization>('@org').then(({id: orgID}: Organization) => {
+                cy.visit(`${orgs}/${orgID}/dashboards-list`)
+                cy.getByTestID('tree-nav')
+              })
+            })
+          )
+      )
+    )
   })
 
   it("can edit a dashboard's name", () => {


### PR DESCRIPTION
part of #6562 

## Reasoning:
* e2es goals:
    * prevent regressions of any existing code (by internal or external users)
    * to ensure e2e compatibility with the full stack.
       * any exceptions added are about the backend/storage
           * e.g. only tsm supports explicit bucket schema --> use cy.skipOn() as needed
           * e.g. only iox supports SQL --> use cy.skipOn() as needed
* enablement flags are selectively on:
    * which flags are required, explicitly indicates the feature coupling.
    * we could also use this to set ordering of feature deletion (when we eventually get there).
    * e.g. `showDashboardsInNewIOx` + `showVariablesInNewIOx` => dashboards have to be removed, before we can remove variables.

## Evidence of tests passing on iox:

Screenshots from after the rebase onto the proper cypress env vars.

![Screen Shot 2023-02-01 at 4 47 32 PM](https://user-images.githubusercontent.com/10232835/216203360-f91f26ac-3aaa-4e2a-8b0c-90bf7e3383e1.png)
![Screen Shot 2023-02-01 at 4 42 54 PM](https://user-images.githubusercontent.com/10232835/216203363-85453f7a-60a9-4262-8f09-178eab5ce953.png)

![Screen Shot 2023-02-01 at 5 15 50 PM](https://user-images.githubusercontent.com/10232835/216213741-9ec4e229-a500-4494-af1d-cca1b083677d.png)
![Screen Shot 2023-02-01 at 5 11 18 PM](https://user-images.githubusercontent.com/10232835/216213744-db89266c-ae44-4190-b6a1-00ed5d47a2e1.png)
![Screen Shot 2023-02-01 at 4 59 29 PM](https://user-images.githubusercontent.com/10232835/216213746-eae41867-98e2-43f0-9fb6-0fc9e9f132e9.png)





## Checklist
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
