### PR TITLE
feat(6562): marty release test

### DIFF
--- a/cypress/e2e/cloud/releases.test.ts
+++ b/cypress/e2e/cloud/releases.test.ts
@@ -1,5 +1,7 @@
-import {IOX_SWITCHOVER_CREATION_DATE} from 'src/shared/constants'
 import {Organization} from '../../../src/types'
+
+// webpack bundling error if try importing --> due to imports in the constants file
+const IOX_SWITCHOVER_CREATION_DATE = '2023-01-31T00:00:00Z'
 
 describe('Deprecations per cloud release', () => {
   before(() => {

--- a/cypress/e2e/cloud/releases.test.ts
+++ b/cypress/e2e/cloud/releases.test.ts
@@ -1,0 +1,146 @@
+import {IOX_SWITCHOVER_CREATION_DATE} from 'src/shared/constants'
+import {Organization} from '../../../src/types'
+
+describe('Deprecations per cloud release', () => {
+  before(() => {
+    cy.flush().then(() =>
+      cy.signin().then(() =>
+        cy.isIoxOrg().then(isIox => {
+          cy.skipOn(!isIox)
+          cy.visit('/')
+          cy.getByTestID('home-page--header').should('be.visible')
+        })
+      )
+    )
+  })
+
+  describe('Marty-release', () => {
+    describe('has specific navigation options', () => {
+      beforeEach(() => {
+        cy.signinWithoutUserReprovision()
+      })
+
+      it('depreciated features do not exist', () => {
+        cy.getByTestID('nav-item-flows').should('not.exist')
+        cy.getByTestID('nav-item-alerting').should('not.exist')
+        cy.getByTestID('nav-item-dashboards').should('not.exist')
+        cy.getByTestID('nav-item-tasks').should('not.exist')
+      })
+
+      describe('supported features are still navigable', () => {
+        ;[
+          {navId: 'nav-item-data-explorer', title: 'Data Explorer'},
+          {navId: 'nav-item-load-data', title: 'Load Data'},
+          {navId: 'nav-item-settings', title: 'Settings'},
+        ].forEach(({navId, title}) => {
+          it(`for ${title} page`, () => {
+            cy.getByTestID(navId).should('be.visible').click({force: true})
+            cy.getByTestID('page-title').contains(title)
+          })
+        })
+      })
+
+      describe('nav subItems are navigable based upon selective support', () => {
+        ;[
+          {
+            navId: 'nav-item-load-data',
+            navSubId: 'nav-subitem-sources',
+            tabId: 'sources--tab',
+            supported: true,
+          },
+          {
+            navId: 'nav-item-load-data',
+            navSubId: 'nav-subitem-buckets',
+            tabId: 'buckets--tab',
+            supported: true,
+          },
+          {
+            navId: 'nav-item-load-data',
+            navSubId: 'nav-subitem-telegrafs',
+            tabId: 'telegrafs--tab',
+            supported: true,
+          },
+          {
+            navId: 'nav-item-load-data',
+            navSubId: 'nav-subitem-tokens',
+            tabId: 'tokens--tab',
+            supported: true,
+          },
+          {
+            navId: 'nav-item-load-data',
+            navSubId: 'nav-subitem-subscriptions',
+            tabId: 'subscriptions--tab',
+            supported: false,
+          },
+          {
+            navId: 'nav-item-settings',
+            navSubId: 'nav-subitem-labels',
+            tabId: 'labels--tab',
+            supported: true,
+          },
+          {
+            navId: 'nav-item-settings',
+            navSubId: 'nav-subitem-secrets',
+            tabId: 'secrets--tab',
+            supported: true,
+          },
+          {
+            navId: 'nav-item-settings',
+            navSubId: 'nav-subitem-templates',
+            tabId: 'templates--tab',
+            supported: false,
+          },
+        ].forEach(({navId, navSubId, tabId, supported}) => {
+          it(`${navSubId} is ${
+            supported ? 'supported' : 'not supported'
+          }`, () => {
+            cy.getByTestID(navId).should('be.visible').click({force: true})
+            cy.getByTestID(navSubId).should(supported ? 'exist' : 'not.exist')
+            cy.getByTestID(tabId).should(supported ? 'be.visible' : 'not.exist')
+          })
+        })
+      })
+    })
+
+    // TODO: add any more marty-specific features
+  })
+
+  describe('iox users prior to the Marty-release date', () => {
+    const beforeCutoff = new Date(
+      new Date(IOX_SWITCHOVER_CREATION_DATE) - 10000
+    ).toISOString()
+    beforeEach(() => {
+      cy.intercept('GET', '/api/v2/orgs', req => {
+        req.continue(res => {
+          const orgs = res.body.orgs.map(org => ({
+            ...org,
+            createdAt: beforeCutoff,
+          }))
+          res.body.orgs = orgs
+        })
+      })
+      cy.signinWithoutUserReprovision()
+    })
+
+    it('have everything exist except notebooks', () => {
+      cy.getByTestID('nav-item-flows').should('not.exist')
+
+      cy.getByTestID('nav-item-dashboards').should('exist').click({force: true})
+      cy.getByTestID('page-title').contains('Dashboards')
+
+      cy.getByTestID('nav-item-tasks').should('exist').click({force: true})
+      cy.getByTestID('page-title').contains('Tasks')
+
+      cy.getByTestID('nav-item-alerting').should('exist').click({force: true})
+      cy.getByTestID('page-title').contains('Alerts')
+    })
+
+    it('if pre-existing notebooks --> then notebooks access does exist', () => {
+      cy.get('@org').then(({id}: Organization) =>
+        cy.createNotebook(id).then(() => cy.reload())
+      )
+      cy.getByTestID('nav-item-flows').should('exist').click({force: true})
+      cy.getByTestID('page-title').contains('Notebooks')
+    })
+  })
+})

--- a/cypress/e2e/cloud/releases.test.ts
+++ b/cypress/e2e/cloud/releases.test.ts
@@ -17,16 +17,43 @@ describe('Deprecations per cloud release', () => {
   })
 
   describe('Marty-release', () => {
-    describe('has specific navigation options', () => {
-      beforeEach(() => {
-        cy.signinWithoutUserReprovision()
-      })
+    beforeEach(() => {
+      cy.signinWithoutUserReprovision()
+    })
 
-      it('depreciated features do not exist', () => {
-        cy.getByTestID('nav-item-flows').should('not.exist')
-        cy.getByTestID('nav-item-alerting').should('not.exist')
-        cy.getByTestID('nav-item-dashboards').should('not.exist')
-        cy.getByTestID('nav-item-tasks').should('not.exist')
+    describe('has specific navigation options', () => {
+      describe('depreciated features do not exist', () => {
+        ;[
+          {
+            route: orgID => `orgs/${orgID}/notebooks`,
+            navId: 'nav-item-flows',
+            name: 'notebooks',
+          },
+          {
+            route: orgID => `orgs/${orgID}/alerting`,
+            navId: 'nav-item-alerting',
+            name: 'alerts',
+          },
+          {
+            route: orgID => `orgs/${orgID}/dashboards-list`,
+            navId: 'nav-item-dashboards',
+            name: 'dashboards',
+          },
+          {
+            route: orgID => `orgs/${orgID}/tasks`,
+            navId: 'nav-item-tasks',
+            name: 'tasks',
+          },
+        ].forEach(({route, navId, name}) => {
+          it(`does not permit access to ${name}`, () => {
+            cy.getByTestID(navId).should('not.exist')
+            cy.get<Organization>('@org').then(({id: orgID}: Organization) => {
+              cy.visit(route(orgID))
+              cy.getByTestID('tree-nav').should('be.visible')
+              cy.contains('404: Page Not Found')
+            })
+          })
+        })
       })
 
       describe('supported features are still navigable', () => {
@@ -103,8 +130,6 @@ describe('Deprecations per cloud release', () => {
         })
       })
     })
-
-    // TODO: add any more marty-specific features
   })
 
   describe('iox users prior to the Marty-release date', () => {

--- a/cypress/e2e/shared/dashboardsView.test.ts
+++ b/cypress/e2e/shared/dashboardsView.test.ts
@@ -1,9 +1,6 @@
 import {Organization} from '../../../src/types'
 import {points} from '../../support/commands'
 
-const isIOxOrg = Boolean(Cypress.env('useIox'))
-const isTSMOrg = !isIOxOrg
-
 describe('Dashboard - TSM and pre marty release IOx', () => {
   beforeEach(() => {
     cy.flush()
@@ -539,22 +536,5 @@ describe('Dashboard - TSM and pre marty release IOx', () => {
       cy.getByTestID('tree-nav')
       cy.getByTestID('empty-state--text').should('be.visible')
     })
-  })
-})
-
-describe('Dashboard - post marty release IOx', () => {
-  it('should not show Dashboard', () => {
-    cy.skipOn(isTSMOrg)
-
-    cy.flush()
-    cy.signin()
-    cy.fixture('routes').then(({orgs}) => {
-      cy.get<Organization>('@org').then(({id: orgID}: Organization) => {
-        cy.visit(`${orgs}/${orgID}/dashboards-list`)
-        cy.getByTestID('tree-nav').should('be.visible')
-        cy.getByTestID('nav-item-dashboards').should('not.exist')
-      })
-    })
-    cy.contains('404: Page Not Found')
   })
 })

--- a/src/settings/components/SettingsHeader.tsx
+++ b/src/settings/components/SettingsHeader.tsx
@@ -6,8 +6,8 @@ import {Page} from '@influxdata/clockface'
 class SettingsHeader extends Component {
   public render() {
     return (
-      <Page.Header fullWidth={true}>
-        <Page.Title title="Settings" testID="settings-page--header" />
+      <Page.Header fullWidth={true} testID="settings-page--header">
+        <Page.Title title="Settings" />
       </Page.Header>
     )
   }

--- a/src/shared/selectors/app.ts
+++ b/src/shared/selectors/app.ts
@@ -11,7 +11,6 @@ import {
 import {CLOUD, IOX_SWITCHOVER_CREATION_DATE} from 'src/shared/constants'
 
 import {selectOrgCreationDate, isOrgIOx} from 'src/organizations/selectors'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 export const timeZone = (state: AppState): TimeZone =>
   state.app.persisted.timeZone || ('Local' as TimeZone)
@@ -44,10 +43,6 @@ export const getSubscriptionsCertificateInterest = (state: AppState): boolean =>
 export const selectIsNewIOxOrg = (state: AppState): boolean => {
   if (!CLOUD) {
     return false
-  }
-
-  if (isFlagEnabled('ioxLaunchMock')) {
-    return true
   }
 
   const orgCreationDate = new Date(selectOrgCreationDate(state)).valueOf()

--- a/src/usage/context/usage.tsx
+++ b/src/usage/context/usage.tsx
@@ -226,15 +226,17 @@ export const UsageProvider: FC<Props> = React.memo(({children}) => {
         )
       })
 
-      Promise.all(promises).then(result => {
-        const amount: number = result
-          .reduce((a: number, b) => a + parseFloat(b), 0)
-          .toFixed(2)
-        setCreditUsage({
-          amount,
-          status: RemoteDataState.Done,
+      Promise.all(promises)
+        .then(result => {
+          const amount: number = result
+            .reduce((a: number, b) => a + parseFloat(b), 0)
+            .toFixed(2)
+          setCreditUsage({
+            amount,
+            status: RemoteDataState.Done,
+          })
         })
-      })
+        .catch(err => console.error(err))
     } catch (error) {
       setCreditUsage(prev => ({
         ...prev,


### PR DESCRIPTION
part of #6562 

Since the rest of the e2es are testing UI compatibility with the backend, we also need a specific test for deprecations of each cloud release.

## Evidence of tests passing on iox:
<img width="847" alt="Screen Shot 2023-02-02 at 4 48 07 PM" src="https://user-images.githubusercontent.com/10232835/216483999-0ba5b5f8-284c-44b8-a313-52c3e8d3bb25.png">



## Checklist
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
