### PR TITLE
fix: fix variables test to work for IOx

### DIFF
--- a/cypress/e2e/shared/variables.test.ts
+++ b/cypress/e2e/shared/variables.test.ts
@@ -430,5 +430,7 @@ describe('Variables - IOx', () => {
     const shouldShowTasks = false
     setupTest(shouldShowTasks)
     cy.contains('404: Page Not Found')
+    cy.clickNavBarItem('nav-item-settings')
+    cy.getByTestID('variables--tab').should('not.exist')
   })
 })

--- a/cypress/e2e/shared/variables.test.ts
+++ b/cypress/e2e/shared/variables.test.ts
@@ -3,12 +3,12 @@ import {Organization} from '../../../src/types'
 const isIOxOrg = Boolean(Cypress.env('useIox'))
 const isTSMOrg = !isIOxOrg
 
-const setupTest = (shouldShowTasks: boolean = true) => {
+const setupTest = (shouldShowVariables: boolean = true) => {
   cy.flush().then(() =>
     cy.signin().then(() =>
       cy
         .setFeatureFlags({
-          showVariablesInNewIOx: shouldShowTasks,
+          showVariablesInNewIOx: shouldShowVariables,
           schemaComposition: true,
         })
         .then(() =>
@@ -427,8 +427,8 @@ describe('Variables - TSM', () => {
 describe('Variables - IOx', () => {
   it('routes to 404 page when IOx user attempts to access variables', () => {
     cy.skipOn(isTSMOrg)
-    const shouldShowTasks = false
-    setupTest(shouldShowTasks)
+    const shouldShowVariables = false
+    setupTest(shouldShowVariables)
     cy.contains('404: Page Not Found')
     cy.clickNavBarItem('nav-item-settings')
     cy.getByTestID('variables--tab').should('not.exist')

--- a/cypress/e2e/shared/variables.test.ts
+++ b/cypress/e2e/shared/variables.test.ts
@@ -1,11 +1,12 @@
 import {Organization} from '../../../src/types'
 
-const isIOxOrg = Boolean(Cypress.env('ioxUser'))
+const isIOxOrg = Boolean(Cypress.env('useIox'))
 const isTSMOrg = !isIOxOrg
 
-const setupTest = () => {
+const setupTest = (shouldShowTasks: boolean = true) => {
   cy.flush()
   cy.signin()
+  cy.setFeatureFlags({showVariablesInNewIOx: shouldShowTasks})
   cy.get('@org').then(({id}: Organization) => {
     if (isTSMOrg) {
       cy.clickNavBarItem('nav-item-settings')
@@ -428,8 +429,10 @@ describe('Variables - TSM', () => {
 describe('Variables - IOx', () => {
   it('routes to 404 page when IOx user attempts to access variables', () => {
     cy.skipOn(isTSMOrg)
-    setupTest()
-    cy.getByTestID('nav-item-variables').should('not.exist')
+    const shouldShowTasks = false
+    setupTest(shouldShowTasks)
+    cy.clickNavBarItem('nav-item-settings')
+    cy.getByTestID('variables--tab').should('not.exist')
     cy.contains('404: Page Not Found')
   })
 })

--- a/cypress/e2e/shared/variables.test.ts
+++ b/cypress/e2e/shared/variables.test.ts
@@ -27,8 +27,6 @@ const setupTest = (shouldShowTasks: boolean = true) => {
 
 describe('Variables - TSM', () => {
   beforeEach(() => {
-    // Skip all Variables tests for IOx orgs.
-    cy.skipOn(isIOxOrg)
     setupTest()
   })
 
@@ -431,8 +429,6 @@ describe('Variables - IOx', () => {
     cy.skipOn(isTSMOrg)
     const shouldShowTasks = false
     setupTest(shouldShowTasks)
-    cy.clickNavBarItem('nav-item-settings')
-    cy.getByTestID('variables--tab').should('not.exist')
     cy.contains('404: Page Not Found')
   })
 })

--- a/cypress/e2e/shared/variables.test.ts
+++ b/cypress/e2e/shared/variables.test.ts
@@ -4,25 +4,25 @@ const isIOxOrg = Boolean(Cypress.env('useIox'))
 const isTSMOrg = !isIOxOrg
 
 const setupTest = (shouldShowTasks: boolean = true) => {
-  cy.flush()
-  cy.signin()
-  cy.setFeatureFlags({showVariablesInNewIOx: shouldShowTasks})
-  cy.get('@org').then(({id}: Organization) => {
-    if (isTSMOrg) {
-      cy.clickNavBarItem('nav-item-settings')
-      cy.getByTestID('variables--tab').should('be.visible').click()
-      // Double check that the new schemaComposition flag does not interfere.
-      cy.setFeatureFlags({
-        schemaComposition: true,
-      })
-      // cy.wait($time) is necessary to consistently ensure sufficient time for the feature flag override.
-      // The flag reset happens via redux, (it's not a network request), so we can't cy.wait($intercepted_route).
-      cy.wait(1200)
-      cy.location('pathname').should('match', /\/variables$/)
-    } else {
-      cy.visit(`orgs/${id}/settings/variables`)
-    }
-  })
+  cy.flush().then(() =>
+    cy.signin().then(() =>
+      cy
+        .setFeatureFlags({
+          showVariablesInNewIOx: shouldShowTasks,
+          schemaComposition: true,
+        })
+        .then(() =>
+          cy.get('@org').then(({id}: Organization) => {
+            cy.createQueryVariable(id)
+            // cy.wait($time) is necessary to consistently ensure sufficient time for the feature flag override.
+            // The flag reset happens via redux, (it's not a network request), so we can't cy.wait($intercepted_route).
+            cy.visit(`orgs/${id}/settings/variables`)
+            cy.wait(1200)
+            cy.location('pathname').should('match', /\/variables$/)
+          })
+        )
+    )
+  )
 }
 
 describe('Variables - TSM', () => {


### PR DESCRIPTION
Helps with #6562 

Pr updates variables test by making sure test passes for `TSM` and `IOx` utilizing the `showVariablesInNewIOx` feature flag. 
A new test is also added for IOx that checks for a 404 page when routing to `/variables`

<img width="850" alt="var" src="https://user-images.githubusercontent.com/66275100/216443542-e84fe136-694d-451e-8f78-068b338d45c4.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
