### PR TITLE
fix(6562): update shared dashboardsView on iox

### DIFF
--- a/cypress/e2e/shared/dashboardsView.test.ts
+++ b/cypress/e2e/shared/dashboardsView.test.ts
@@ -1,20 +1,25 @@
 import {Organization} from '../../../src/types'
 import {points} from '../../support/commands'
 
-describe('Dashboard', () => {
-  beforeEach(() => {
-    cy.flush()
-    cy.signin()
-    cy.isIoxOrg().then(isIoxOrg => {
-      cy.skipOn(isIoxOrg)
+const isIOxOrg = Boolean(Cypress.env('ioxUser'))
+const isTSMOrg = !isIOxOrg
 
-      cy.fixture('routes').then(({orgs}) => {
-        cy.get<Organization>('@org').then(({id: orgID}: Organization) => {
-          cy.visit(`${orgs}/${orgID}/dashboards-list`)
-          cy.getByTestID('tree-nav')
-        })
-      })
+const setupTest = () => {
+  cy.flush()
+  cy.signin()
+  cy.fixture('routes').then(({orgs}) => {
+    cy.get<Organization>('@org').then(({id: orgID}: Organization) => {
+      cy.visit(`${orgs}/${orgID}/dashboards-list`)
+      cy.getByTestID('tree-nav')
     })
+  })
+}
+
+describe('Dashboard - TSM', () => {
+  beforeEach(() => {
+    cy.skipOn(isIOxOrg)
+
+    setupTest()
   })
 
   it("can edit a dashboard's name", () => {
@@ -535,5 +540,14 @@ describe('Dashboard', () => {
       cy.getByTestID('tree-nav')
       cy.getByTestID('empty-state--text').should('be.visible')
     })
+  })
+})
+
+describe('Dashboard - IOx', () => {
+  it('should not show Dashboard', () => {
+    cy.skipOn(isTSMOrg)
+
+    setupTest()
+    cy.contains('404: Page Not Found')
   })
 })

--- a/cypress/e2e/shared/dashboardsView.test.ts
+++ b/cypress/e2e/shared/dashboardsView.test.ts
@@ -1,25 +1,24 @@
 import {Organization} from '../../../src/types'
 import {points} from '../../support/commands'
 
-const isIOxOrg = Boolean(Cypress.env('ioxUser'))
+const isIOxOrg = Boolean(Cypress.env('useIox'))
 const isTSMOrg = !isIOxOrg
 
-const setupTest = () => {
-  cy.flush()
-  cy.signin()
-  cy.fixture('routes').then(({orgs}) => {
-    cy.get<Organization>('@org').then(({id: orgID}: Organization) => {
-      cy.visit(`${orgs}/${orgID}/dashboards-list`)
-      cy.getByTestID('tree-nav')
-    })
-  })
-}
-
-describe('Dashboard - TSM', () => {
+describe('Dashboard - TSM and pre marty release IOx', () => {
   beforeEach(() => {
-    cy.skipOn(isIOxOrg)
-
-    setupTest()
+    cy.flush()
+    cy.signin()
+    cy.setFeatureFlags({
+      showDashboardsInNewIOx: true,
+      showVariablesInNewIOx: true,
+    }).then(() => {
+      cy.fixture('routes').then(({orgs}) => {
+        cy.get<Organization>('@org').then(({id: orgID}: Organization) => {
+          cy.visit(`${orgs}/${orgID}/dashboards-list`)
+          cy.getByTestID('tree-nav')
+        })
+      })
+    })
   })
 
   it("can edit a dashboard's name", () => {
@@ -543,11 +542,18 @@ describe('Dashboard - TSM', () => {
   })
 })
 
-describe('Dashboard - IOx', () => {
+describe('Dashboard - post marty release IOx', () => {
   it('should not show Dashboard', () => {
     cy.skipOn(isTSMOrg)
 
-    setupTest()
+    cy.flush()
+    cy.signin()
+    cy.fixture('routes').then(({orgs}) => {
+      cy.get<Organization>('@org').then(({id: orgID}: Organization) => {
+        cy.visit(`${orgs}/${orgID}/dashboards-list`)
+        cy.getByTestID('tree-nav')
+      })
+    })
     cy.contains('404: Page Not Found')
   })
 })

--- a/cypress/e2e/shared/dashboardsView.test.ts
+++ b/cypress/e2e/shared/dashboardsView.test.ts
@@ -1,14 +1,18 @@
 import {Organization} from '../../../src/types'
 import {points} from '../../support/commands'
 
-describe.skip('Dashboard', () => {
+describe('Dashboard', () => {
   beforeEach(() => {
     cy.flush()
     cy.signin()
-    cy.fixture('routes').then(({orgs}) => {
-      cy.get<Organization>('@org').then(({id: orgID}: Organization) => {
-        cy.visit(`${orgs}/${orgID}/dashboards-list`)
-        cy.getByTestID('tree-nav')
+    cy.isIoxOrg().then(isIoxOrg => {
+      cy.skipOn(isIoxOrg)
+
+      cy.fixture('routes').then(({orgs}) => {
+        cy.get<Organization>('@org').then(({id: orgID}: Organization) => {
+          cy.visit(`${orgs}/${orgID}/dashboards-list`)
+          cy.getByTestID('tree-nav')
+        })
       })
     })
   })

--- a/cypress/e2e/shared/dashboardsView.test.ts
+++ b/cypress/e2e/shared/dashboardsView.test.ts
@@ -551,7 +551,8 @@ describe('Dashboard - post marty release IOx', () => {
     cy.fixture('routes').then(({orgs}) => {
       cy.get<Organization>('@org').then(({id: orgID}: Organization) => {
         cy.visit(`${orgs}/${orgID}/dashboards-list`)
-        cy.getByTestID('tree-nav')
+        cy.getByTestID('tree-nav').should('be.visible')
+        cy.getByTestID('nav-item-dashboards').should('not.exist')
       })
     })
     cy.contains('404: Page Not Found')


### PR DESCRIPTION
Part of #6562

This PR updates the shared dashboardsView tests to make sure:

1. If in a TSM org, run the tests for dashboardsView 
2. If in an IOx org:
    * with the feature flags on (`showDashboardsInNewIOx` and `showVariablesInNewIOx`) to simulate the environment for old IOx orgs and Tools, run the tests for dashboardsView
    * with the feature flags off (by default) to simulate new IOx org, new users shouldn't see dashboards button and page

Screenshots of this PR passing locally. Two tests kept crashing the browser, so I tested them separately.

<img width="553" alt="tests 1" src="https://user-images.githubusercontent.com/14298407/216365450-68d55de7-b541-46f9-9747-1743efdf58da.png">

<img width="558" alt="tests 2" src="https://user-images.githubusercontent.com/14298407/216365467-7ff1a153-2614-4d88-8b25-9806c7a30f0f.png">

<img width="555" alt="tests 3" src="https://user-images.githubusercontent.com/14298407/216365480-0c9cb88e-2c1c-4867-a10a-4d73470c2985.png">

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
