### PR TITLE
fix: update templates e2e to work with iox

### DIFF
--- a/cypress/e2e/cloud/communityTemplates.test.ts
+++ b/cypress/e2e/cloud/communityTemplates.test.ts
@@ -271,17 +271,16 @@ describe('Community Templates - TSM', () => {
 describe('Community Templates - IOx', () => {
   it('routes to 404 page when IOx user attempts to access Templates', () => {
     cy.skipOn(isTSMOrg)
-
     cy.flush()
     cy.signin()
     cy.fixture('routes').then(({orgs}) => {
       cy.get<Organization>('@org').then(({id}: Organization) => {
         cy.visit(`${orgs}/${id}/settings/templates`)
+        cy.contains('404: Page Not Found')
         cy.getByTestID('tree-nav').should('be.visible')
         cy.clickNavBarItem('nav-item-settings')
         cy.getByTestID('templates--tab').should('not.exist')
       })
     })
-    cy.contains('404: Page Not Found')
   })
 })


### PR DESCRIPTION
Helps with #6562 
Pr updates community templates test to make sure test passes for TSM and IOx. 
it toggles on `showTemplatesInNewIOx` feature flag to force templates to show before running tests. 
For IOx, it adds a test that checks for a 404 page when routing to the templates page. 

<img width="868" alt="Screen Shot 2023-02-02 at 5 43 44 PM" src="https://user-images.githubusercontent.com/66275100/216476314-2ad306e0-00b3-49cb-b8d2-940a8c1b3835.png">

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
