### PR TITLE
fix(6562): update scriptQueryBuilder on iox

### DIFF
--- a/cypress/e2e/shared/scriptQueryBuilder.flux.test.ts
+++ b/cypress/e2e/shared/scriptQueryBuilder.flux.test.ts
@@ -8,7 +8,7 @@ const DEFAULT_FLUX_EDITOR_TEXT =
 const DELAY_FOR_LAZY_LOAD_EDITOR = 30000
 const DELAY_FOR_LSP_SERVER_BOOTUP = 7000
 
-describe.skip('Script Builder', () => {
+describe('Script Builder', () => {
   const writeData: string[] = []
   for (let i = 0; i < 30; i++) {
     writeData.push(`ndbc,air_temp_degc=70_degrees station_id_${i}=${i}`)
@@ -169,6 +169,7 @@ describe.skip('Script Builder', () => {
   describe('Schema browser, without composition or saveAsScript', () => {
     beforeEach(() => {
       loginWithFlags({
+        showOldDataExplorerInNewIOx: true,
         schemaComposition: false,
         newDataExplorer: true,
         enableFluxInScriptBuilder: true,
@@ -323,6 +324,7 @@ describe.skip('Script Builder', () => {
   describe('Schema Composition', () => {
     beforeEach(() => {
       loginWithFlags({
+        showOldDataExplorerInNewIOx: true,
         schemaComposition: true,
         newDataExplorer: true,
         saveAsScript: true,

--- a/cypress/e2e/shared/scriptQueryBuilder.results.test.ts
+++ b/cypress/e2e/shared/scriptQueryBuilder.results.test.ts
@@ -10,7 +10,7 @@ const DELAY_FOR_LSP_SERVER_BOOTUP = 7000
 
 const DELAY_FOR_FILE_DOWNLOAD = 5000
 
-describe.skip('Script Builder', () => {
+describe('Script Builder', () => {
   const writeData: string[] = []
   for (let i = 0; i < 30; i++) {
     writeData.push(`ndbc,air_temp_degc=70_degrees station_id_${i}=${i}`)
@@ -167,6 +167,7 @@ describe.skip('Script Builder', () => {
 
     beforeEach(() => {
       loginWithFlags({
+        showOldDataExplorerInNewIOx: true,
         schemaComposition: true,
         newDataExplorer: true,
         saveAsScript: true,
@@ -342,6 +343,7 @@ describe.skip('Script Builder', () => {
       describe('for larger payloads', () => {
         beforeEach(() => {
           cy.setFeatureFlags({
+            showOldDataExplorerInNewIOx: true,
             newDataExplorer: true,
             schemaComposition: true,
             dataExplorerCsvLimit: 10000 as any,

--- a/cypress/e2e/shared/scriptQueryBuilder.sql.test.ts
+++ b/cypress/e2e/shared/scriptQueryBuilder.sql.test.ts
@@ -4,7 +4,7 @@ const DEFAULT_SQL_EDITOR_TEXT = '/* Start by typing SQL here */'
 
 const DELAY_FOR_LAZY_LOAD_EDITOR = 30000
 
-describe.skip('Script Builder', () => {
+describe('Script Builder', () => {
   const bucketName = 'defbuck'
   const measurement = 'ndbc'
 
@@ -162,6 +162,7 @@ describe.skip('Script Builder', () => {
   describe('Schema Composition', () => {
     beforeEach(() => {
       loginWithFlags({
+        showOldDataExplorerInNewIOx: true,
         schemaComposition: true,
         newDataExplorer: true,
         saveAsScript: true,


### PR DESCRIPTION
Part of #6562

This PR updates the tests in scriptQueryBuilder

Screenshots for passing locally:

<img width="560" alt="Screen Shot 2023-02-02 at 10 09 50 AM" src="https://user-images.githubusercontent.com/14298407/216384284-0203fda3-34d3-4795-a13b-90c175529329.png">

<img width="556" alt="Screen Shot 2023-02-02 at 11 21 35 AM" src="https://user-images.githubusercontent.com/14298407/216396602-b027fae6-435a-4a82-a528-bc5023b2a06e.png">

The tests in `scriptQueryBuilder.results.test.ts` kept failing locally when I test them all at once, but they pass on individual test:

<img width="560" alt="Screen Shot 2023-02-02 at 1 54 10 PM" src="https://user-images.githubusercontent.com/14298407/216441040-1ab025a6-a705-41e1-856d-f458299e0dca.png">

<img width="559" alt="Screen Shot 2023-02-02 at 2 00 53 PM" src="https://user-images.githubusercontent.com/14298407/216441114-ea4d6f00-1d8d-4fd8-bef8-282c0f5c2b00.png">

<img width="558" alt="Screen Shot 2023-02-02 at 2 20 44 PM" src="https://user-images.githubusercontent.com/14298407/216441120-4e63132e-770b-4827-b9aa-a4e8092e1b59.png">

<img width="559" alt="Screen Shot 2023-02-02 at 2 22 53 PM" src="https://user-images.githubusercontent.com/14298407/216441441-65307998-f6e6-4e53-898a-35abdee5bf2d.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
