### PR TITLE
fix(6562): update simple table test on iox

### DIFF
--- a/cypress/e2e/shared/simpleTable.test.ts
+++ b/cypress/e2e/shared/simpleTable.test.ts
@@ -1,26 +1,31 @@
 import {Organization} from '../../../src/types'
 import {points} from '../../support/commands'
 
-describe.skip('simple table interactions', () => {
+describe('simple table interactions', () => {
   const simpleSmall = 'simple-small'
   const simpleLarge = 'simple-large'
   const simpleOverflow = 'simple-overflow'
   beforeEach(() => {
     cy.flush()
     cy.signin()
-    cy.get('@org').then(({id: orgID}: Organization) => {
-      cy.fixture('routes').then(({orgs, explorer}) => {
-        cy.visit(`${orgs}/${orgID}${explorer}`)
+    cy.setFeatureFlags({
+      showOldDataExplorerInNewIOx: true,
+      // showVariablesInNewIOx: true,
+    }).then(() =>
+      cy.get('@org').then(({id: orgID}: Organization) => {
+        cy.fixture('routes').then(({orgs, explorer}) => {
+          cy.visit(`${orgs}/${orgID}${explorer}`)
+        })
+        cy.getByTestID('tree-nav')
+        cy.createBucket(orgID, name, simpleLarge)
+        cy.writeData(points(300), simpleLarge)
+        cy.createBucket(orgID, name, simpleSmall)
+        cy.writeData(points(30), simpleSmall)
+        cy.createBucket(orgID, name, simpleOverflow)
+        cy.writeData(points(31), simpleOverflow)
+        cy.reload()
       })
-      cy.getByTestID('tree-nav')
-      cy.createBucket(orgID, name, simpleLarge)
-      cy.writeData(points(300), simpleLarge)
-      cy.createBucket(orgID, name, simpleSmall)
-      cy.writeData(points(30), simpleSmall)
-      cy.createBucket(orgID, name, simpleOverflow)
-      cy.writeData(points(31), simpleOverflow)
-      cy.reload()
-    })
+    )
   })
 
   it('should render correctly after switching from a dataset with more pages to one with fewer', () => {

--- a/cypress/e2e/shared/simpleTable.test.ts
+++ b/cypress/e2e/shared/simpleTable.test.ts
@@ -10,7 +10,6 @@ describe('simple table interactions', () => {
     cy.signin()
     cy.setFeatureFlags({
       showOldDataExplorerInNewIOx: true,
-      // showVariablesInNewIOx: true,
     }).then(() =>
       cy.get('@org').then(({id: orgID}: Organization) => {
         cy.fixture('routes').then(({orgs, explorer}) => {


### PR DESCRIPTION
Part of #6562

This PR updates the test case for simple table to run in IOx orgs with the feature flag `showOldDataExplorerInNewIOx` on to simulate the environment for old IOx orgs and Tools. Since simple table is a component used in the old and the new data explorer, there is no need to test the unavailability of the component in new IOx org. 

Passing locally:

<img width="558" alt="Screen Shot 2023-02-02 at 3 05 48 PM" src="https://user-images.githubusercontent.com/14298407/216450734-00dfdfe5-db90-4885-abdd-b77eeb3a904c.png">

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
