### PR TITLE
chore: update checks to work with iox

### DIFF
--- a/cypress/e2e/shared/checks.test.ts
+++ b/cypress/e2e/shared/checks.test.ts
@@ -8,26 +8,38 @@ const PAGE_LOAD_SLA = 10000
 const measurement = 'my_meas'
 const field = 'my_field'
 const stringField = 'string_field'
-describe.skip('Checks', () => {
-  beforeEach(() => {
-    cy.flush()
-    cy.signin()
-    cy.writeData([
-      `${measurement} ${field}=0,${stringField}="string1"`,
-      `${measurement} ${field}=1,${stringField}="string2"`,
-    ])
-    // visit the alerting index
-    cy.get<Organization>('@org').then((org: Organization) => {
-      cy.fixture('routes').then(({orgs, alerting}) => {
-        cy.visit(`${orgs}/${org.id}${alerting}`)
-      })
+
+const isIOxOrg = Boolean(Cypress.env('useIox'))
+const isTSMOrg = !isIOxOrg
+
+const setupTest = (shouldShowAlerts: boolean = true) => {
+  cy.flush()
+  cy.signin()
+  cy.setFeatureFlags({showAlertsInNewIOx: shouldShowAlerts})
+
+  cy.writeData([
+    `${measurement} ${field}=0,${stringField}="string1"`,
+    `${measurement} ${field}=1,${stringField}="string2"`,
+  ])
+  // visit the alerting index
+  cy.get<Organization>('@org').then((org: Organization) => {
+    cy.fixture('routes').then(({orgs, alerting}) => {
+      cy.visit(`${orgs}/${org.id}${alerting}`)
     })
+  })
+  if (isTSMOrg) {
     cy.getByTestID('tree-nav')
     cy.get('[data-testid="resource-list--body"]', {
       timeout: PAGE_LOAD_SLA,
     })
     // User can only see all panels at once on large screens
     cy.getByTestID('alerting-tab--checks').click({force: true})
+  }
+}
+
+describe('Checks - TSM', () => {
+  beforeEach(() => {
+    setupTest()
   })
 
   describe('threshold checks', () => {
@@ -1349,5 +1361,16 @@ describe.skip('Checks', () => {
           })
       }
     })
+  })
+})
+
+describe('Checks - IOx', () => {
+  it('routes to 404 page when IOx user attempts to access checks', () => {
+    cy.skipOn(isTSMOrg)
+    const shouldShowAlerts = false
+    setupTest(shouldShowAlerts)
+    cy.contains('404: Page Not Found')
+    cy.clickNavBarItem('nav-item-settings')
+    cy.getByTestID('checks--tab').should('not.exist')
   })
 })

--- a/cypress/e2e/shared/checks.test.ts
+++ b/cypress/e2e/shared/checks.test.ts
@@ -1371,6 +1371,6 @@ describe('Checks - IOx', () => {
     setupTest(shouldShowAlerts)
     cy.contains('404: Page Not Found')
     cy.clickNavBarItem('nav-item-settings')
-    cy.getByTestID('checks--tab').should('not.exist')
+    cy.getByTestID('alerting-tab--checks').should('not.exist')
   })
 })


### PR DESCRIPTION
See #6562 

Pr updates Checks e2e test to make sure it passes for TSM and IOx.
it toggles on `showAlertsInNewIOx` feature flag to force Alerts to show before running tests.
For IOx, it adds a test that checks for a 404 page when routing to the templates page.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
