### PR TITLE
fix: update load data sources test for iox

### DIFF
--- a/cypress/e2e/shared/loadDataSources.test.ts
+++ b/cypress/e2e/shared/loadDataSources.test.ts
@@ -1,7 +1,6 @@
 import {Organization} from '../../src/types'
 
 const isIOxOrg = Boolean(Cypress.env('useIox'))
-const isTSMOrg = !isIOxOrg
 
 // Library to use when testing client library details view.
 // As of 2/2023, IOx only has one client library - python, which has a wizard.
@@ -200,22 +199,5 @@ describe('Load Data Sources', () => {
     cy.getByTestID('searchable-dropdown--item mymeasurement')
       .contains('mymeasurement')
       .click()
-  })
-})
-
-describe('Load Data Sources - New IOx', () => {
-  it('there is no old data explorer for new iox orgs', () => {
-    cy.skipOn(isTSMOrg)
-    cy.flush()
-    cy.signin()
-    cy.setFeatureFlags({
-      newDataExplorer: true,
-    })
-    cy.get('@org').then(({id}: Organization) =>
-      cy.fixture('routes').then(({orgs}) => {
-        cy.visit(`${orgs}/${id}/load-data/sources`)
-        cy.getByTestID('tree-nav')
-      })
-    )
   })
 })

--- a/cypress/e2e/shared/loadDataSources.test.ts
+++ b/cypress/e2e/shared/loadDataSources.test.ts
@@ -1,13 +1,11 @@
 import {Organization} from '../../src/types'
 
-// Library to use when testing client library details view.
-
 const isIOxOrg = Boolean(Cypress.env('useIox'))
 const isTSMOrg = !isIOxOrg
 
+// Library to use when testing client library details view.
 // As of 2/2023, IOx only has one client library - python, which has a wizard.
 // In TSM, there are more libraries, and it's desirable to test a page both with and without a wizard.
-
 const libraryWithWizard = isIOxOrg ? 'python' : 'arduino'
 const libraryWithoutWizard = 'csharp'
 

--- a/cypress/e2e/shared/loadDataSources.test.ts
+++ b/cypress/e2e/shared/loadDataSources.test.ts
@@ -1,9 +1,24 @@
 import {Organization} from '../../src/types'
 
-describe.skip('Load Data Sources', () => {
+// Library to use when testing client library details view.
+
+const isIOxOrg = Boolean(Cypress.env('useIox'))
+const isTSMOrg = !isIOxOrg
+
+// As of 2/2023, IOx only has one client library - python, which has a wizard.
+// In TSM, there are more libraries, and it's desirable to test a page both with and without a wizard.
+
+const libraryWithWizard = isIOxOrg ? 'python' : 'arduino'
+const libraryWithoutWizard = 'csharp'
+
+describe('Load Data Sources', () => {
   beforeEach(() => {
     cy.flush()
     cy.signin()
+    cy.setFeatureFlags({
+      newDataExplorer: true,
+      showOldDataExplorerInNewIOx: true,
+    })
     cy.get('@org').then(({id}: Organization) =>
       cy.fixture('routes').then(({orgs}) => {
         cy.visit(`${orgs}/${id}/load-data/sources`)
@@ -13,9 +28,14 @@ describe.skip('Load Data Sources', () => {
   })
 
   it('navigates to Client Library details view and renders details without a wizard', () => {
+    // Skip this test in IOx because as of 2/2023, there is only one library (python), which has a wizard.
+    cy.skipOn(isIOxOrg)
+
     cy.getByTestID('write-data--section client-libraries').within(() => {
       cy.getByTestID('square-grid').within(() => {
-        cy.getByTestIDSubStr('load-data-item csharp').first().click()
+        cy.getByTestIDSubStr(`load-data-item ${libraryWithoutWizard}`)
+          .first()
+          .click()
       })
     })
 
@@ -28,10 +48,9 @@ describe.skip('Load Data Sources', () => {
   })
 
   it('navigates to Client Library details view and renders a wizard', () => {
-    const libaryWithWizard = 'Arduino'
     cy.getByTestID('write-data--section client-libraries').within(() => {
       cy.getByTestID('square-grid').within(() => {
-        cy.getByTestIDSubStr(`load-data-item ${libaryWithWizard.toLowerCase()}`)
+        cy.getByTestIDSubStr(`load-data-item ${libraryWithWizard}`)
           .first()
           .click()
       })
@@ -42,7 +61,11 @@ describe.skip('Load Data Sources', () => {
     contentNav.children().should('exist')
 
     const titleElement = cy.get('.subway-navigation-title-text')
-    titleElement.contains(libaryWithWizard)
+
+    const capitalizedLibraryWithWizard =
+      libraryWithWizard[0].toUpperCase() + libraryWithWizard.slice(1)
+
+    titleElement.contains(capitalizedLibraryWithWizard)
   })
 
   it('navigates to Telegraf Plugin details view and render it with essentials', () => {
@@ -73,7 +96,7 @@ describe.skip('Load Data Sources', () => {
   })
 
   // TODO(ariel): address these skipped tests later https://github.com/influxdata/ui/issues/3394
-  it.skip('can write data to buckets', () => {
+  it('can write data to buckets', () => {
     // writing a well-formed line is accepted
     cy.getByTestID('load-data-item lp').click()
     cy.getByTestID('Enter Manually').click()
@@ -109,7 +132,7 @@ describe.skip('Load Data Sources', () => {
     cy.getByTestID('line-protocol--status').contains('Success')
   })
 
-  it.skip('upload a file and write data', () => {
+  it('upload a file and write data', () => {
     cy.getByTestID('load-data-item lp').click()
     cy.getByTestID('Upload File').click()
 
@@ -152,32 +175,49 @@ describe.skip('Load Data Sources', () => {
     cy.getByTestID('lp-close--button').click()
 
     // navigate to data explorer to see data
+    // use new data explorer, since old data explorer is being deprecated
     cy.getByTestID('nav-item-data-explorer').click({force: true})
+
+    cy.getByTestID('script-query-builder-toggle').click()
+
     cy.getByTestID('timerange-dropdown').click()
-    cy.getByTestID('dropdown-item-customtimerange').click()
 
     // time range start
-    cy.getByTestID('timerange--input')
+    cy.get('.date-picker__input')
       .first()
       .clear()
       .type('2020-08-06 00:00:00.000')
 
     // time range stop
-    cy.getByTestID('timerange--input')
-      .last()
-      .clear()
-      .type('2020-08-08 00:00:00.000')
+    cy.get('.date-picker__input').last().clear().type('2020-08-08 00:00:00.000')
 
     cy.getByTestID('daterange--apply-btn').click()
 
-    // TODO replace this with proper health checks
     cy.wait(1000)
-    cy.get<string>('@defaultBucketListSelector').then(
-      (defaultBucketListSelector: string) => {
-        cy.getByTestID(defaultBucketListSelector).click()
-      }
-    )
+    cy.getByTestID('bucket-selector--dropdown-button').click()
+    cy.getByTestID('bucket-selector--dropdown--defbuck').click()
+
     // mymeasurement comes from fixtures/data.txt
-    cy.getByTestID('selector-list mymeasurement').should('exist')
+    cy.getByTestID('measurement-selector--dropdown-button').click()
+    cy.getByTestID('searchable-dropdown--item mymeasurement')
+      .contains('mymeasurement')
+      .click()
+  })
+})
+
+describe('Load Data Sources - New IOx', () => {
+  it('there is no old data explorer for new iox orgs', () => {
+    cy.skipOn(isTSMOrg)
+    cy.flush()
+    cy.signin()
+    cy.setFeatureFlags({
+      newDataExplorer: true,
+    })
+    cy.get('@org').then(({id}: Organization) =>
+      cy.fixture('routes').then(({orgs}) => {
+        cy.visit(`${orgs}/${id}/load-data/sources`)
+        cy.getByTestID('tree-nav')
+      })
+    )
   })
 })


### PR DESCRIPTION
Part of #6562 

Updates the load data sources test to be compatible with both the TSM and IOx pipeline.

There was a 'write data' test in here that had been skipped even before the IOx release. Unskipped and updated it so that it works with the combination of the load data page and new data explorer.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - NO
