### PR TITLE
chore: update notification rules test for iox

### DIFF
--- a/cypress/e2e/shared/notificationRules.test.ts
+++ b/cypress/e2e/shared/notificationRules.test.ts
@@ -10,6 +10,8 @@ import {
 import {Bucket} from '../../../src/client'
 import {calcNanoTimestamp} from '../../support/Utils'
 
+const isTSMOrg = !Boolean(Cypress.env('useIox'))
+
 describe('NotificationRules', () => {
   const name1 = 'Slack 1'
   const name2 = 'Slack 2'
@@ -36,20 +38,6 @@ describe('NotificationRules', () => {
       })
     })
   })
-
-  // describe('When a rule does not exist', () => {
-  //   it('should route the user to the alerting index page', () => {
-  //     const nonexistentID = '04984be058066088'
-
-  //     // visiting the rules edit overlay
-  //     cy.get<Organization>('@org').then(({id}: Organization) => {
-  //       cy.fixture('routes').then(({orgs, alerting, rules}) => {
-  //         cy.visit(`${orgs}/${id}${alerting}${rules}/${nonexistentID}/edit`)
-  //         cy.url().should('include', `${orgs}/${id}${alerting}`)
-  //       })
-  //     })
-  //   })
-  // })
 
   describe('numeric input validation in Theshold Checks', () => {
     beforeEach(() => {
@@ -1112,6 +1100,23 @@ describe('NotificationRules', () => {
             cy.getByTestID('context-delete-task--confirm-button').click()
             cy.getByTestID(`rule-card ${newName}`).should('not.exist')
           })
+      })
+    })
+  })
+})
+
+describe('New IOx orgs', () => {
+  it('Alerts are not present for new IOx orgs', () => {
+    cy.skipOn(isTSMOrg)
+    cy.flush()
+    cy.signin()
+    // visit the alerting index
+    cy.get<Organization>('@org').then(({id}: Organization) => {
+      cy.fixture('routes').then(({orgs, alerting}) => {
+        cy.getByTestID('tree-nav')
+        cy.getByTestID('nav-item-alerting').should('not.exist')
+        cy.visit(`${orgs}/${id}${alerting}`)
+        cy.contains('404: Page Not Found')
       })
     })
   })

--- a/cypress/e2e/shared/notificationRules.test.ts
+++ b/cypress/e2e/shared/notificationRules.test.ts
@@ -10,7 +10,7 @@ import {
 import {Bucket} from '../../../src/client'
 import {calcNanoTimestamp} from '../../support/Utils'
 
-describe.skip('NotificationRules', () => {
+describe('NotificationRules', () => {
   const name1 = 'Slack 1'
   const name2 = 'Slack 2'
   const name3 = 'Slack 3'
@@ -18,6 +18,7 @@ describe.skip('NotificationRules', () => {
   beforeEach(() => {
     cy.flush()
     cy.signin()
+    cy.setFeatureFlags({showAlertsInNewIOx: true})
     cy.get<Organization>('@org').then(({id}: Organization) => {
       // create the notification endpoints
       cy.fixture('endpoints').then(({slack}) => {
@@ -36,19 +37,19 @@ describe.skip('NotificationRules', () => {
     })
   })
 
-  describe('When a rule does not exist', () => {
-    it('should route the user to the alerting index page', () => {
-      const nonexistentID = '04984be058066088'
+  // describe('When a rule does not exist', () => {
+  //   it('should route the user to the alerting index page', () => {
+  //     const nonexistentID = '04984be058066088'
 
-      // visitng the rules edit overlay
-      cy.get<Organization>('@org').then(({id}: Organization) => {
-        cy.fixture('routes').then(({orgs, alerting, rules}) => {
-          cy.visit(`${orgs}/${id}${alerting}${rules}/${nonexistentID}/edit`)
-          cy.url().should('include', `${orgs}/${id}${alerting}`)
-        })
-      })
-    })
-  })
+  //     // visiting the rules edit overlay
+  //     cy.get<Organization>('@org').then(({id}: Organization) => {
+  //       cy.fixture('routes').then(({orgs, alerting, rules}) => {
+  //         cy.visit(`${orgs}/${id}${alerting}${rules}/${nonexistentID}/edit`)
+  //         cy.url().should('include', `${orgs}/${id}${alerting}`)
+  //       })
+  //     })
+  //   })
+  // })
 
   describe('numeric input validation in Theshold Checks', () => {
     beforeEach(() => {


### PR DESCRIPTION
Part of #6562 

Updates the notification rules (alerts) test for iox. Adds a test for the absence of alerts in new IOx orgs.

Removes the buggy test for 'what to do when you manually try to navigate to an alert identifier that doesn't exist'. In remocal, it creates difficult-to-trace auth issues with subsequent tests. It also isn't providing value, as it's a quirky edge case for a feature that doesn't exist prospectively in Cloud2 iox.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - NO
