### PR TITLE
fix(6562): update query builder to work with iox

### DIFF
--- a/cypress/e2e/shared/queryBuilder.test.ts
+++ b/cypress/e2e/shared/queryBuilder.test.ts
@@ -13,17 +13,26 @@ const generateRandomSixDigitNumber = () => {
   return Number(digits.join(''))
 }
 
-describe.skip('The Query Builder', () => {
+describe('The Query Builder', () => {
   beforeEach(() => {
-    cy.flush()
-    cy.signin()
-    cy.writeData([
-      `mem,host=thrillbo-swaggins active=${generateRandomSixDigitNumber()}`,
-      `mem,host=thrillbo-swaggins cached=${generateRandomSixDigitNumber()}`,
+    cy.flush().then(() =>
+      cy.signin().then(() =>
+        cy
+          .setFeatureFlags({
+            showOldDataExplorerInNewIOx: true,
+            showDashboardsInNewIOx: true,
+          })
+          .then(() =>
+            cy.writeData([
+              `mem,host=thrillbo-swaggins active=${generateRandomSixDigitNumber()}`,
+              `mem,host=thrillbo-swaggins cached=${generateRandomSixDigitNumber()}`,
 
-      `mem,host=thrillbo-swaggins active=${generateRandomSixDigitNumber()}`,
-      `mem,host=thrillbo-swaggins cached=${generateRandomSixDigitNumber()}`,
-    ])
+              `mem,host=thrillbo-swaggins active=${generateRandomSixDigitNumber()}`,
+              `mem,host=thrillbo-swaggins cached=${generateRandomSixDigitNumber()}`,
+            ])
+          )
+      )
+    )
   })
 
   describe('from the Data Explorer', () => {


### PR DESCRIPTION
Part of #6562

This PR updates the query builder to work with iox by turning on feature flags `showOldDataExplorerInNewIOx` and `showDashboardsInNewIOx`. Since query builder is a component used in the old data explorer, there is no need to add test on 404 page for new IOx orgs since it will be covered in `shared/explorer.test.ts`

Test pass locally:
<img width="560" alt="Screen Shot 2023-02-03 at 11 23 04 AM" src="https://user-images.githubusercontent.com/14298407/216669594-2e20267c-6ee2-46c7-b07e-6fa89d0260e4.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
