### PR TITLE
fix(6562): update explorer visualization to work with iox

### DIFF
--- a/cypress/e2e/shared/explorerVisualizations.test.ts
+++ b/cypress/e2e/shared/explorerVisualizations.test.ts
@@ -17,19 +17,27 @@ const VIS_TYPES = [
 ]
 const NUM_POINTS = 360
 
-describe.skip('visualizations', () => {
+describe('visualizations', () => {
   beforeEach(() => {
-    cy.flush()
-    cy.signin()
-
-    cy.get('@org').then(({id}: Organization) => {
-      cy.createMapVariable(id)
-      cy.fixture('routes').then(({orgs, explorer}) => {
-        cy.visit(`${orgs}/${id}${explorer}`)
-      })
-    })
-    cy.writeData(points(NUM_POINTS))
-    cy.getByTestID('time-machine--bottom')
+    cy.flush().then(() =>
+      cy.signin().then(() =>
+        cy
+          .setFeatureFlags({
+            showOldDataExplorerInNewIOx: true,
+            showVariablesInNewIOx: true,
+          })
+          .then(() => {
+            cy.get('@org').then(({id}: Organization) => {
+              cy.createMapVariable(id)
+              cy.fixture('routes').then(({orgs, explorer}) => {
+                cy.visit(`${orgs}/${id}${explorer}`)
+              })
+            })
+            cy.writeData(points(NUM_POINTS))
+            cy.getByTestID('time-machine--bottom')
+          })
+      )
+    )
   })
 
   describe('empty states', () => {


### PR DESCRIPTION
Part of #6562 

This PR updates the old data explorer visualization to work with iox by turning on feature flags `showOldDataExplorerInNewIOx` and `showVariablesInNewIOx`. Since visualization is a component used in the old data explorer, there is no need to add test on 404 page for new IOx orgs because it will be covered in `shared/explorer.test.ts`

Passing locally:
<img width="558" alt="Screen Shot 2023-02-03 at 2 01 41 PM" src="https://user-images.githubusercontent.com/14298407/216701073-252fe51b-f49d-4054-90e2-ac317c287ac0.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
