### PR TITLE
fix(6562): update explorer to work with iox

### DIFF
--- a/cypress/e2e/cloud/explorer.test.ts
+++ b/cypress/e2e/cloud/explorer.test.ts
@@ -14,18 +14,23 @@ function getTimeMachineText() {
     .invoke('text')
 }
 
-describe.skip('DataExplorer', () => {
+describe('DataExplorer', () => {
   beforeEach(() => {
-    cy.flush()
-    cy.signin().then(() => {
-      cy.get('@org').then(({id}: Organization) => {
-        cy.createMapVariable(id)
-        cy.fixture('routes').then(({orgs, explorer}) => {
-          cy.visit(`${orgs}/${id}${explorer}`)
-          cy.getByTestID('tree-nav').should('be.visible')
-        })
+    cy.flush().then(() =>
+      cy.signin().then(() => {
+        cy.setFeatureFlags({
+          showOldDataExplorerInNewIOx: true,
+        }).then(() =>
+          cy.get('@org').then(({id}: Organization) => {
+            cy.createMapVariable(id)
+            cy.fixture('routes').then(({orgs, explorer}) => {
+              cy.visit(`${orgs}/${id}${explorer}`)
+              cy.getByTestID('tree-nav').should('be.visible')
+            })
+          })
+        )
       })
-    })
+    )
   })
 
   describe('Script Editor', () => {

--- a/cypress/e2e/shared/explorer.queries.graphs.test.ts
+++ b/cypress/e2e/shared/explorer.queries.graphs.test.ts
@@ -1,26 +1,31 @@
 import {Organization} from '../../../src/types'
 
-describe.skip('writing queries and making graphs using Data Explorer', () => {
+describe('writing queries and making graphs using Data Explorer', () => {
   let route: string
 
   beforeEach(() => {
-    cy.flush()
-    cy.signin()
-    // Double check that the new schemaComposition flag does not interfere.
-    cy.setFeatureFlags({
-      schemaComposition: true,
-    })
-    // cy.wait($time) is necessary to consistently ensure sufficient time for the feature flag override.
-    // The flag reset happens via redux, (it's not a network request), so we can't cy.wait($intercepted_route).
-    cy.wait(1200)
-    cy.get('@org').then(({id}: Organization) => {
-      cy.createMapVariable(id)
-      cy.fixture('routes').then(({orgs, explorer}) => {
-        route = `${orgs}/${id}${explorer}`
-        cy.visit(route)
-        cy.getByTestID('tree-nav').should('be.visible')
-      })
-    })
+    cy.flush().then(() =>
+      cy.signin().then(() =>
+        cy.setFeatureFlags({
+          showOldDataExplorerInNewIOx: true,
+          showTasksInNewIOx: true,
+          showVariablesInNewIOx: true,
+          schemaComposition: true, // Double check that the new schemaComposition flag does not interfere.
+        }).then(() => {
+          // cy.wait($time) is necessary to consistently ensure sufficient time for the feature flag override.
+          // The flag reset happens via redux, (it's not a network request), so we can't cy.wait($intercepted_route).
+          cy.wait(1200)
+          cy.get('@org').then(({id}: Organization) => {
+            cy.createMapVariable(id)
+            cy.fixture('routes').then(({orgs, explorer}) => {
+              route = `${orgs}/${id}${explorer}`
+              cy.visit(route)
+              cy.getByTestID('tree-nav').should('be.visible')
+            })
+          })
+        })
+      )
+    )
   })
 
   describe('numeric input in graphs', () => {
@@ -169,13 +174,6 @@ describe.skip('writing queries and making graphs using Data Explorer', () => {
     })
 
     it('shows the empty state when the query returns no results', () => {
-      cy.isIoxOrg().then(isIox => {
-        // iox uses `${orgId}_${bucketId}` for a namespace_id
-        // And gives a namespace_id failure if no data is written yet.
-        // https://github.com/influxdata/monitor-ci/issues/402#issuecomment-1362368473
-        cy.skipOn(isIox)
-      })
-
       cy.getByTestID('time-machine--bottom').within(() => {
         cy.getByTestID('flux-editor').should('be.visible')
           .monacoType(`from(bucket: "defbuck")

--- a/cypress/e2e/shared/explorer.queries.graphs.test.ts
+++ b/cypress/e2e/shared/explorer.queries.graphs.test.ts
@@ -6,24 +6,26 @@ describe('writing queries and making graphs using Data Explorer', () => {
   beforeEach(() => {
     cy.flush().then(() =>
       cy.signin().then(() =>
-        cy.setFeatureFlags({
-          showOldDataExplorerInNewIOx: true,
-          showTasksInNewIOx: true,
-          showVariablesInNewIOx: true,
-          schemaComposition: true, // Double check that the new schemaComposition flag does not interfere.
-        }).then(() => {
-          // cy.wait($time) is necessary to consistently ensure sufficient time for the feature flag override.
-          // The flag reset happens via redux, (it's not a network request), so we can't cy.wait($intercepted_route).
-          cy.wait(1200)
-          cy.get('@org').then(({id}: Organization) => {
-            cy.createMapVariable(id)
-            cy.fixture('routes').then(({orgs, explorer}) => {
-              route = `${orgs}/${id}${explorer}`
-              cy.visit(route)
-              cy.getByTestID('tree-nav').should('be.visible')
+        cy
+          .setFeatureFlags({
+            showOldDataExplorerInNewIOx: true,
+            showTasksInNewIOx: true,
+            showVariablesInNewIOx: true,
+            schemaComposition: true, // Double check that the new schemaComposition flag does not interfere.
+          })
+          .then(() => {
+            // cy.wait($time) is necessary to consistently ensure sufficient time for the feature flag override.
+            // The flag reset happens via redux, (it's not a network request), so we can't cy.wait($intercepted_route).
+            cy.wait(1200)
+            cy.get('@org').then(({id}: Organization) => {
+              cy.createMapVariable(id)
+              cy.fixture('routes').then(({orgs, explorer}) => {
+                route = `${orgs}/${id}${explorer}`
+                cy.visit(route)
+                cy.getByTestID('tree-nav').should('be.visible')
+              })
             })
           })
-        })
       )
     )
   })

--- a/src/timeMachine/components/TagSelector.tsx
+++ b/src/timeMachine/components/TagSelector.tsx
@@ -260,7 +260,7 @@ class TagSelector extends PureComponent<Props> {
 
     if (valuesStatus === RemoteDataState.Done && !values.length) {
       return (
-        <BuilderCard.Empty>
+        <BuilderCard.Empty testID="empty-tag-keys">
           No values found <small>in the current time range</small>
         </BuilderCard.Empty>
       )


### PR DESCRIPTION
Part of #6562 

This PR updates two tests related to the old data explorer to work with iox. Since these two tests are sub-tests of the old data explorer test, there is no need to add test on 404 page for new IOx orgs because it will be covered in `shared/explorer.test.ts`

cloud/explorer.test.ts
  * `showOldDataExplorerInNewIOx`
  * `showDashboardsInNewIOx`

shared/explorer.queries.graphs.test.ts
  * `showOldDataExplorerInNewIOx`
  * `showTasksInNewIOx`
  * `showVariablesInNewIOx`

Passing locally:

<img width="559" alt="Screen Shot 2023-02-03 at 1 25 04 PM" src="https://user-images.githubusercontent.com/14298407/216689996-623fe09c-209d-4797-b653-d9c35efeb406.png">

Browser crashed when I tested `explorer.queries.graphs.test.ts` locally, so I split the test and they all passed:

<img width="560" alt="Screen Shot 2023-02-03 at 2 18 37 PM" src="https://user-images.githubusercontent.com/14298407/216704942-28650ff4-4791-45a1-8120-d0a01578587e.png">

<img width="562" alt="Screen Shot 2023-02-03 at 2 44 35 PM" src="https://user-images.githubusercontent.com/14298407/216707289-a549ac39-6849-4057-9db5-18ab0dd31aa6.png">

<img width="556" alt="Screen Shot 2023-02-03 at 2 57 48 PM" src="https://user-images.githubusercontent.com/14298407/216709340-3a168b95-05a5-4973-b1f3-5e5d29796b7e.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
