### PR TITLE
fix(helpBar): target correct DOM element

### DIFF
--- a/cypress/e2e/cloud/helpBar.test.ts
+++ b/cypress/e2e/cloud/helpBar.test.ts
@@ -1,4 +1,4 @@
-describe.skip('Help bar support for free account users', () => {
+describe('Help bar support for free account users', () => {
   beforeEach(() =>
     cy.flush().then(() =>
       cy.signin().then(() => {
@@ -15,7 +15,7 @@ describe.skip('Help bar support for free account users', () => {
   it('displays important links for free account users', () => {
     cy.getByTestID('nav-item-support')
       .get('.cf-tree-nav--sub-menu-trigger')
-      .eq(3)
+      .last()
       .trigger('mouseover')
     cy.getByTestID('nav-subitem-contact-support')
       .eq(1) // clockface duplicates tree-nav test ids so index specification is required
@@ -29,7 +29,7 @@ describe.skip('Help bar support for free account users', () => {
   })
 })
 
-describe.skip('Help bar support for PAYG users', () => {
+describe('Help bar support for PAYG users', () => {
   beforeEach(() =>
     cy.flush().then(() =>
       cy.signin().then(() => {
@@ -52,7 +52,7 @@ describe.skip('Help bar support for PAYG users', () => {
 
     cy.getByTestID('nav-item-support')
       .get('.cf-tree-nav--sub-menu-trigger')
-      .eq(3)
+      .last()
       .trigger('mouseover')
     cy.getByTestID('nav-subitem-contact-support')
       .eq(1) // clockface duplicates tree-nav test ids so index specification is required


### PR DESCRIPTION
See #6562 

Because navigation items are few in number in IOx orgs compared to tsm, test needed to be updated to target the correct element to properly trigger the popover that displays help bar sub menu items. 

<img width="844" alt="Screen Shot 2023-02-06 at 9 08 30 AM" src="https://user-images.githubusercontent.com/66275100/217008924-82093063-96eb-45cb-bc93-28e06e031fda.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
