### PR TITLE
fix(6562): add featureFlag to test to turn on dashboards

### DIFF
--- a/cypress/e2e/shared/annotations.band.test.ts
+++ b/cypress/e2e/shared/annotations.band.test.ts
@@ -10,7 +10,7 @@ import {
   RANGE_ANNOTATION_TEXT,
 } from '../util/annotationsSetup'
 
-describe.skip('The Annotations UI functionality on a band plot graph type', () => {
+describe('The Annotations UI functionality on a band plot graph type', () => {
   const bandSuffix = 'band'
 
   beforeEach(() => setupData(cy, bandSuffix))

--- a/cypress/e2e/shared/annotations.range.test.ts
+++ b/cypress/e2e/shared/annotations.range.test.ts
@@ -12,7 +12,7 @@ import * as moment from 'moment'
 
 import {DEFAULT_TIME_FORMAT} from '../../../src/utils/datetime/constants'
 
-describe.skip('Annotations, but in a different test suite', () => {
+describe('Annotations, but in a different test suite', () => {
   beforeEach(() => setupData(cy))
 
   describe('administrative functions like the tests being on and off', () => {

--- a/cypress/e2e/shared/annotations.singlestat.test.ts
+++ b/cypress/e2e/shared/annotations.singlestat.test.ts
@@ -10,7 +10,7 @@ import {
   RANGE_ANNOTATION_TEXT,
 } from '../util/annotationsSetup'
 
-describe.skip('The Annotations UI functionality on a graph + single stat graph type', () => {
+describe('The Annotations UI functionality on a graph + single stat graph type', () => {
   const singleStatSuffix = 'line-plus-single-stat'
 
   beforeEach(() => setupData(cy, singleStatSuffix))

--- a/cypress/e2e/shared/annotations.xy.test.ts
+++ b/cypress/e2e/shared/annotations.xy.test.ts
@@ -10,7 +10,7 @@ import {
   RANGE_ANNOTATION_TEXT,
 } from '../util/annotationsSetup'
 
-describe.skip('The Annotations UI functionality, on a graph (xy line) graph type', () => {
+describe('The Annotations UI functionality, on a graph (xy line) graph type', () => {
   beforeEach(() => setupData(cy))
 
   it('can create an annotation on the xy line graph', () => {

--- a/cypress/e2e/util/annotationsSetup.ts
+++ b/cypress/e2e/util/annotationsSetup.ts
@@ -10,63 +10,65 @@ export const EDIT_RANGE_ANNOTATION_TEXT =
 export const setupData = (cy: Cypress.Chainable, plotTypeSuffix = '') =>
   cy.flush().then(() =>
     cy.signin().then(() =>
-      cy.get('@org').then(({id: orgID, name}: Organization) =>
-        cy.createDashboard(orgID).then(({body}) =>
-          cy.fixture('routes').then(({orgs}) => {
-            cy.visit(`${orgs}/${orgID}/dashboards/${body.id}`)
-            return cy.then(() => {
-              cy.createBucket(orgID, name, 'devbucket')
-              /*
+      cy.setFeatureFlags({showDashboardsInNewIOx: true}).then(() =>
+        cy.get('@org').then(({id: orgID, name}: Organization) =>
+          cy.createDashboard(orgID).then(({body}) =>
+            cy.fixture('routes').then(({orgs}) => {
+              cy.visit(`${orgs}/${orgID}/dashboards/${body.id}`)
+              return cy.then(() => {
+                cy.createBucket(orgID, name, 'devbucket')
+                /*
                 note:
                   graph types vary in the presentation of the line
                   for example, "Graph" presents a line less steep than "Graph + Single Stat"
                   use enough points and a time difference that works for all graph types
                   10 points and 5 minute time difference works well
               */
-              cy.writeData(points(10, 600_000), 'devbucket')
+                cy.writeData(points(10, 600_000), 'devbucket')
 
-              // make a dashboard cell
-              cy.getByTestID('add-cell--button').click()
-              cy.getByTestID('selector-list devbucket').should(
-                'have.length.of.at.least',
-                1
-              )
-              cy.getByTestID('selector-list devbucket').click()
+                // make a dashboard cell
+                cy.getByTestID('add-cell--button').click()
+                cy.getByTestID('selector-list devbucket').should(
+                  'have.length.of.at.least',
+                  1
+                )
+                cy.getByTestID('selector-list devbucket').click()
 
-              cy.getByTestID('selector-list m').should(
-                'have.length.of.at.least',
-                1
-              )
-              cy.getByTestID('selector-list m').clickAttached()
+                cy.getByTestID('selector-list m').should(
+                  'have.length.of.at.least',
+                  1
+                )
+                cy.getByTestID('selector-list m').clickAttached()
 
-              cy.getByTestID('selector-list v').should(
-                'have.length.of.at.least',
-                1
-              )
-              cy.getByTestID('selector-list v').clickAttached()
+                cy.getByTestID('selector-list v').should(
+                  'have.length.of.at.least',
+                  1
+                )
+                cy.getByTestID('selector-list v').clickAttached()
 
-              if (plotTypeSuffix) {
-                cy.getByTestID('view-type--dropdown').click()
-                cy.getByTestID(`view-type--${plotTypeSuffix}`).click()
-              }
+                if (plotTypeSuffix) {
+                  cy.getByTestID('view-type--dropdown').click()
+                  cy.getByTestID(`view-type--${plotTypeSuffix}`).click()
+                }
 
-              cy.getByTestID(`selector-list tv1`).should(
-                'have.length.of.at.least',
-                1
-              )
-              cy.getByTestID(`selector-list tv1`).clickAttached()
+                cy.getByTestID(`selector-list tv1`).should(
+                  'have.length.of.at.least',
+                  1
+                )
+                cy.getByTestID(`selector-list tv1`).clickAttached()
 
-              cy.getByTestID('time-machine-submit-button').click()
+                cy.getByTestID('time-machine-submit-button').click()
 
-              cy.getByTestID('page-title').click()
-              cy.getByTestID('renamable-page-title--input')
-                .clear()
-                .type('blah{enter}')
-              cy.getByTestID('save-cell--button').click()
+                cy.getByTestID('page-title').click()
+                cy.getByTestID('renamable-page-title--input')
+                  .clear()
+                  .type('blah{enter}')
+                cy.getByTestID('save-cell--button').click()
 
-              cy.getByTestID('toggle-annotations-controls').click()
+                cy.getByTestID('toggle-annotations-controls').click()
+              })
             })
-          })
+          )
         )
       )
     )


### PR DESCRIPTION
part of #6562 

Annotations tests are working on iox.
![Screen Shot 2023-02-06 at 3 39 21 PM](https://user-images.githubusercontent.com/10232835/217111874-1ac54e54-5d33-4401-9dd8-7e8a5debab25.png)
![Screen Shot 2023-02-06 at 3 36 44 PM](https://user-images.githubusercontent.com/10232835/217111878-68e83337-f4b3-4505-9980-230cd91a798d.png)
![Screen Shot 2023-02-06 at 3 33 02 PM](https://user-images.githubusercontent.com/10232835/217111880-5f4f30f0-152d-4891-bad9-3aaff5588f74.png)


![Screen Shot 2023-02-06 at 3 30 27 PM](https://user-images.githubusercontent.com/10232835/217111881-20c00358-4e51-4b19-8488-f6694dc8e8cb.png)


## Checklist
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
