### PR TITLE
fix: update legends test for iox

### DIFF
--- a/src/dataExplorer/components/DataExplorerPage.tsx
+++ b/src/dataExplorer/components/DataExplorerPage.tsx
@@ -15,11 +15,11 @@ import {
   InputLabel,
   SlideToggle,
 } from '@influxdata/clockface'
-import SaveAsButton from 'src/dataExplorer/components/SaveAsButton'
+import {SaveAsButton} from 'src/dataExplorer/components/SaveAsButton'
 import VisOptionsButton from 'src/timeMachine/components/VisOptionsButton'
 import GetResources from 'src/resources/components/GetResources'
 import TimeZoneDropdown from 'src/shared/components/TimeZoneDropdown'
-import SaveAsOverlay from 'src/dataExplorer/components/SaveAsOverlay'
+import {SaveAsOverlay} from 'src/dataExplorer/components/SaveAsOverlay'
 import ViewTypeDropdown from 'src/timeMachine/components/ViewTypeDropdown'
 import {AddAnnotationDEOverlay} from 'src/overlays/components/index'
 import {EditAnnotationDEOverlay} from 'src/overlays/components/index'
@@ -137,7 +137,7 @@ const DataExplorerPage: FC = () => {
     (scriptQueryBuilder && isFlagEnabled('newDataExplorer')) || isNewIOxOrg
 
   const shouldShowSaveAsButton =
-    !isNewIOxOrg ||
+    !useSelector(selectIsNewIOxOrg) ||
     shouldShowNotebooks ||
     isFlagEnabled('showTasksInNewIOx') ||
     isFlagEnabled('showDashboardsInNewIOx') ||

--- a/src/dataExplorer/components/SaveAsButton.test.tsx
+++ b/src/dataExplorer/components/SaveAsButton.test.tsx
@@ -4,7 +4,7 @@ import {screen} from '@testing-library/react'
 import {renderWithReduxAndRouter} from 'src/mockState'
 
 // Components
-import SaveAsButton from 'src/dataExplorer/components/SaveAsButton'
+import {SaveAsButton} from 'src/dataExplorer/components/SaveAsButton'
 
 const setup = () => {
   renderWithReduxAndRouter(<SaveAsButton />)

--- a/src/dataExplorer/components/SaveAsButton.tsx
+++ b/src/dataExplorer/components/SaveAsButton.tsx
@@ -5,7 +5,7 @@ import {useHistory, useLocation} from 'react-router-dom'
 // Components
 import {IconFont, Button, ComponentColor} from '@influxdata/clockface'
 
-const SaveAsButton: FC = () => {
+export const SaveAsButton: FC = () => {
   const history = useHistory()
   const {pathname} = useLocation()
 
@@ -24,5 +24,3 @@ const SaveAsButton: FC = () => {
     />
   )
 }
-
-export default SaveAsButton

--- a/src/dataExplorer/components/SaveAsOverlay.tsx
+++ b/src/dataExplorer/components/SaveAsOverlay.tsx
@@ -31,7 +31,7 @@ enum SaveAsOption {
   Variable = 'variable',
 }
 
-const SaveAsOverlay: FC = () => {
+export const SaveAsOverlay: FC = () => {
   const history = useHistory()
   const isNewIOxOrg = useSelector(selectIsNewIOxOrg)
   const shouldShowNotebooks = useSelector(selectShouldShowNotebooks)
@@ -139,5 +139,3 @@ const SaveAsOverlay: FC = () => {
     </Overlay>
   )
 }
-
-export default SaveAsOverlay


### PR DESCRIPTION
Part of #6562 

This PR:
1. Updates the legends tests to work with IOx.
2. Unskips tests that weren't being run due to Cypress firefox compatibility issues (we only test Chrome now).
3. Fixes a bug where a new iox user with access to old data explorer but none of the other features could still see the 'Save As' button, even if there was nowhere to save the query.


### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - NO
