### PR TITLE
chore: update notificationEndpoints test to work with iox

### DIFF
--- a/cypress/e2e/shared/notificationEndpoints.test.ts
+++ b/cypress/e2e/shared/notificationEndpoints.test.ts
@@ -5,7 +5,7 @@ import {
   Organization,
 } from '../../../src/types'
 
-describe.skip('Notification Endpoints', () => {
+describe('Notification Endpoints', () => {
   const endpoint: GenEndpoint = {
     orgID: '',
     name: 'Pre-Created Endpoint',
@@ -20,6 +20,9 @@ describe.skip('Notification Endpoints', () => {
   beforeEach(() => {
     cy.flush()
     cy.signin()
+    cy.setFeatureFlags({
+      showAlertsInNewIOx: true,
+    })
     cy.get<Organization>('@org').then(({id}: Organization) =>
       cy.fixture('routes').then(({orgs, alerting}) => {
         cy.createEndpoint({


### PR DESCRIPTION
See #6562 

Pr adds `showAlertsInNewIOx` featureFlag to test to turn on Alerts in NotificationEndpoints test.

<img width="852" alt="Screen Shot 2023-02-08 at 8 55 42 AM" src="https://user-images.githubusercontent.com/66275100/217566308-fc69fd6c-f247-4ee2-a7b4-cbcaeb070745.png">


<!-- Describe your proposed changes here. -->
<!-- Including screenshots or visuals is very helpful - a picture is worth a thousand words. -->

### Checklist

Authors and Reviewer(s), please verify the following:

- [ ] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [ ] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
