### PR TITLE
fix: remove validation on flux before persistance

### DIFF
--- a/cypress/e2e/cloud/scriptQueryBuilder.scriptsCrud.test.ts
+++ b/cypress/e2e/cloud/scriptQueryBuilder.scriptsCrud.test.ts
@@ -49,17 +49,7 @@ describe('Script Builder -- scripts crud on cloud', () => {
       })
     })
 
-    it('will not save an invalid flux query', () => {
-      attemptSaveScript('invalid query')
-      cy.log('should notify user of an error')
-      cy.getByTestID('notification-error--dismiss').should('be.visible')
-      cy.log('modal will stay open')
-      cy.getByTestID('overlay--container').within(() => {
-        cy.getByTestID('script-query-builder--cancel').should('be.visible')
-      })
-    })
-
-    it('will save a valid flux query', () => {
+    it('will save a flux query', () => {
       saveScript(
         'from(bucket: "defbuck") |> range(start: v.timeRangeStart, stop: v.timeRangeStop)'
       )

--- a/src/dataExplorer/components/resources/index.ts
+++ b/src/dataExplorer/components/resources/index.ts
@@ -1,6 +1,6 @@
 import {ReactNode} from 'react'
 import {ResourceType} from 'src/types/resources'
-import scriptResourceRegistration from 'src/dataExplorer/components/resources/types/script'
+import {scriptResourceRegistration} from 'src/dataExplorer/components/resources/types/script'
 
 export const SCRIPT_EDITOR_PARAMS = '?fluxScriptEditor'
 

--- a/src/dataExplorer/components/resources/types/script/index.ts
+++ b/src/dataExplorer/components/resources/types/script/index.ts
@@ -16,7 +16,7 @@ const {getScript, patchScript, postScript} = CLOUD
       postScript: false,
     }
 
-export default () => {
+export const scriptResourceRegistration = () => {
   return {
     type: ResourceType.Scripts,
     editor,

--- a/src/dataExplorer/context/persistance.tsx
+++ b/src/dataExplorer/context/persistance.tsx
@@ -15,7 +15,6 @@ import {
   ResourceConnectedQuery,
 } from 'src/dataExplorer/components/resources'
 import {isOrgIOx} from 'src/organizations/selectors'
-import {isValidFlux} from 'src/languageSupport/languages/flux/lspUtils'
 
 interface CompositionStatus {
   synced: boolean // true == can modify session's schema
@@ -220,12 +219,6 @@ export const PersistanceProvider: FC = ({children}) => {
     ]
   )
 
-  const buildMockStringifiedExtern = () => {
-    // Only used for validation. Not persisted.
-    // Note: new dataExplorer (a.k.a. scripts builder) only uses these variables
-    return `option v = {timeRangeStart: -1h, timeRangeStop: now()}`
-  }
-
   const save = (language: LanguageType) => {
     if (!resource || !RESOURCES[resource.type]) {
       return Promise.resolve(null)
@@ -233,16 +226,6 @@ export const PersistanceProvider: FC = ({children}) => {
 
     resource.flux = query
     resource.language = language
-
-    const externForValidation = buildMockStringifiedExtern()
-    if (
-      language === LanguageType.FLUX &&
-      !isValidFlux(`${externForValidation}\n${query}`)
-    ) {
-      return Promise.reject(
-        'Invalid flux script. Please check your query text.'
-      )
-    }
 
     return RESOURCES[resource.type].persist(resource).then(data => {
       handleSetResource(data)


### PR DESCRIPTION
Fix https://github.com/influxdata/EAR/issues/3937

Users cannot save complicated flux queries even though the queries can be executed and show graphs. See the [EAR issue comment](https://github.com/influxdata/EAR/issues/3937#issuecomment-1422913489) for the finding. 

This PR is a quick fix that removes the validation on flux so that users can save scripts regardless if that's valid or not. This gives users a way to save any work in progress flux quires and/or complicated flux queries. 

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
