### PR TITLE
chore: use 0th org as active if none marked active

### DIFF
--- a/src/identity/components/GlobalHeader/GlobalHeader.tsx
+++ b/src/identity/components/GlobalHeader/GlobalHeader.tsx
@@ -71,8 +71,10 @@ export const GlobalHeader: FC = () => {
   }, [accountsList])
 
   useEffect(() => {
-    if (orgsList[0].id !== '') {
-      const currentActiveOrg = orgsList?.find(org => org.isActive === true)
+    if (orgsList.length && orgsList[0].id !== '') {
+      // Currently active org is the one marked "active" by quartz; or if no such org, the first org.
+      const currentActiveOrg =
+        orgsList?.find(org => org.isActive === true) || orgsList[0]
 
       setActiveOrg(currentActiveOrg)
 


### PR DESCRIPTION
Closes #6599 

Fixes a bug where the global header doesn't load if none of the user's organizations are currently marked 'active.' The header needs to know which org is 'active' to list it first in the dropdown. This PR uses the 0th org as a sensible default if none is marked active.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - NO
