### PR TITLE
fix(6609): deflake scripts crud test, by making scripts fixture via network calls

### DIFF
--- a/cypress/e2e/cloud/scriptQueryBuilder.scriptsCrud.test.ts
+++ b/cypress/e2e/cloud/scriptQueryBuilder.scriptsCrud.test.ts
@@ -67,24 +67,20 @@ describe('Script Builder -- scripts crud on cloud', () => {
 
     before(() => {
       cy.scriptsLoginWithFlags({}).then(() => {
-        cy.switchToDataExplorer('new')
-        cy.getByTestID('flux-editor', {timeout: DELAY_FOR_LAZY_LOAD_EDITOR})
-        cy.clearFluxScriptSession()
-        saveScript(
-          `from(bucket: "defbuck") |> range(start: v.timeRangeStart, stop: v.timeRangeStop)`,
-          scriptName
+        cy.createScript(
+          scriptName,
+          `from(bucket: "defbuck") |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+          |> yield(name: "${scriptName}")`
         )
-        cy.clearFluxScriptSession()
-        cy.wait(DELAY_FOR_UPDATE)
-        saveScript(
-          `from(bucket: "defbuck") |> range(start: v.timeRangeStart, stop: v.timeRangeStop)`,
-          anotherScriptName
+        cy.createScript(
+          anotherScriptName,
+          `from(bucket: "defbuck") |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+          |> yield(name: "${anotherScriptName}")`
         )
-        cy.clearFluxScriptSession()
-        cy.wait(DELAY_FOR_UPDATE)
-        saveScript(
-          `from(bucket: "defbuck") |> range(start: v.timeRangeStart, stop: v.timeRangeStop)`,
-          scriptToDelete
+        cy.createScript(
+          scriptToDelete,
+          `from(bucket: "defbuck") |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+          |> yield(name: "${scriptToDelete}")`
         )
       })
     })
@@ -97,8 +93,7 @@ describe('Script Builder -- scripts crud on cloud', () => {
       })
     })
 
-    // Flaky test https://github.com/influxdata/ui/issues/6609
-    it.skip('can search existing scripts, and open new one', () => {
+    it('can search existing scripts, and open new one', () => {
       cy.getByTestID('script-query-builder--open-script')
         .should('be.visible')
         .click()

--- a/cypress/index.d.ts
+++ b/cypress/index.d.ts
@@ -65,6 +65,7 @@ import {
   selectScriptMeasurement,
   selectScriptFieldOrTag,
   scriptsLoginWithFlags,
+  createScript,
 } from './support/commands'
 
 declare global {
@@ -137,6 +138,7 @@ declare global {
       selectScriptMeasurement: typeof selectScriptMeasurement
       selectScriptFieldOrTag: typeof selectScriptFieldOrTag
       scriptsLoginWithFlags: typeof scriptsLoginWithFlags
+      createScript: typeof createScript
     }
   }
 }

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -923,6 +923,19 @@ export const switchToDataExplorer = (typ: 'new' | 'old') => {
   })
 }
 
+export const createScript = (
+  name: string,
+  script: string,
+  language = 'flux'
+): Cypress.Chainable<Cypress.Response<any>> => {
+  return cy.request('POST', '/api/v2/scripts', {
+    description: 'words',
+    name,
+    script,
+    language,
+  })
+}
+
 export const scriptsLoginWithFlags = (flags): Cypress.Chainable<any> => {
   return cy.signinWithoutUserReprovision().then(() => {
     return cy.get('@org').then(({id}: Organization) => {
@@ -1563,6 +1576,7 @@ Cypress.Commands.add('selectScriptBucket', selectScriptBucket)
 Cypress.Commands.add('selectScriptMeasurement', selectScriptMeasurement)
 Cypress.Commands.add('selectScriptFieldOrTag', selectScriptFieldOrTag)
 Cypress.Commands.add('scriptsLoginWithFlags', scriptsLoginWithFlags)
+Cypress.Commands.add('createScript', createScript)
 
 // variables
 Cypress.Commands.add('createQueryVariable', createQueryVariable)


### PR DESCRIPTION
Part of #6609 

On iox:

<img width="465" alt="Screen Shot 2023-02-14 at 12 21 08 PM" src="https://user-images.githubusercontent.com/10232835/218853839-7305e022-4e21-4ea4-894f-86372a5e95c8.png">


## Checklist
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
