### PR TITLE
fix(5316): set upper limit on size of error

### DIFF
--- a/src/dataExplorer/components/Results.scss
+++ b/src/dataExplorer/components/Results.scss
@@ -71,6 +71,8 @@
   background-color: $cf-grey-15;
   width: 100%;
   display: flex;
+  max-height: $cf-space-2xl;
+  overflow-y: scroll;
 
   .cf-icon {
     padding: $cf-space-2xs $cf-space-s;


### PR DESCRIPTION
Closes #5316 

Just some minor styling fixes, so this box has a max height.

https://user-images.githubusercontent.com/10232835/218899140-d1da85dd-f4d0-44b6-88f9-e7218337d8d5.mov




## Checklist
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
