### PR TITLE
chore: e2e cleanup

### DIFF
--- a/cypress/e2e/cloud/releases.test.ts
+++ b/cypress/e2e/cloud/releases.test.ts
@@ -1,5 +1,18 @@
 import {Organization} from '../../../src/types'
 
+describe('IOX tests should be running', () => {
+  beforeEach(() => {
+    cy.flush().then(() => cy.signin())
+  })
+
+  it('cypress iox bool matches the storage provisioned', () => {
+    const isIOxOrg = Boolean(Cypress.env('useIox'))
+    cy.isIoxOrg().then(isIox => {
+      expect(isIox).to.equal(isIOxOrg)
+    })
+  })
+})
+
 describe('Deprecations per cloud release', () => {
   before(() => {
     cy.flush().then(() =>

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -107,7 +107,6 @@ Cypress.Commands.add(
 )
 
 // login via the purple OSS screen by typing in username/password
-// this is only used if you're using monitor-ci + DEV_MODE_CLOUD=0
 export const loginViaOSS = (username: string, password: string) => {
   cy.visit('/')
   cy.get('#login').type(username)

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -107,6 +107,7 @@ Cypress.Commands.add(
 )
 
 // login via the purple OSS screen by typing in username/password
+// this is only used if you're using monitor-ci + DEV_MODE_CLOUD=0
 export const loginViaOSS = (username: string, password: string) => {
   cy.visit('/')
   cy.get('#login').type(username)


### PR DESCRIPTION
Add test which will detect if we get provisioning errors again.

Test on iox:
<img width="468" alt="Screen Shot 2023-02-15 at 10 26 06 PM" src="https://user-images.githubusercontent.com/10232835/219286138-89c79dc5-8467-4971-8a1b-63793eb8d109.png">


## Checklist
- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
