### PR TITLE
chore: remove invokable link for InfluxQL and SQL scripts

### DIFF
--- a/src/dataExplorer/components/SaveAsScript.tsx
+++ b/src/dataExplorer/components/SaveAsScript.tsx
@@ -196,6 +196,10 @@ const SaveAsScript: FC<Props> = ({language, onClose, setOverlayType, type}) => {
     saveText = 'Update'
   }
 
+  // any language in this array shows the invokable url
+  const shouldShowInvokableURL: boolean =
+    [LanguageType.FLUX].filter(lang => language === lang).length > 0
+
   return (
     <Overlay.Container maxWidth={540}>
       <Overlay.Header title={overlayTitle} onDismiss={handleClose} />
@@ -226,7 +230,7 @@ const SaveAsScript: FC<Props> = ({language, onClose, setOverlayType, type}) => {
             value={resource?.data?.description}
             onChange={handleUpdateDescription}
           />
-          {type === OverlayType.EDIT && (
+          {type === OverlayType.EDIT && shouldShowInvokableURL ? (
             <>
               <InputLabel>Invokable URL</InputLabel>
               <CopyToClipboard
@@ -237,6 +241,7 @@ const SaveAsScript: FC<Props> = ({language, onClose, setOverlayType, type}) => {
                   <Input
                     type={InputType.Text}
                     value={`${window.location.origin}/api/v2/scripts/${resource.data.id}`}
+                    onChange={() => {}} // read-only
                   />
                   <SquareButton
                     testID="copy-to-clipboard--script"
@@ -249,7 +254,7 @@ const SaveAsScript: FC<Props> = ({language, onClose, setOverlayType, type}) => {
                 </div>
               </CopyToClipboard>
             </>
-          )}
+          ) : null}
           {type === OverlayType.EDIT && (
             <Button
               icon={IconFont.Trash_New}


### PR DESCRIPTION
Closes #6565 

This PR removes the invokable link for InfluxQL and SQL scripts. 

Since InfluxQL cannot be saved as a script since the backend is not ready yet, there is no way for users to click on "Edit" button to see the overlay that has the invokable link. Since SQL script is not invokable, I also removed the link from the overlay, and the screenshots below are from SQL scripts. 

## Before

<img width="1508" alt="Screen Shot 2023-02-16 at 1 17 08 PM" src="https://user-images.githubusercontent.com/14298407/219465385-2c41826e-dca9-4546-887a-fea4e6b7a2b3.png">

## After

<img width="1504" alt="Screen Shot 2023-02-16 at 1 16 34 PM" src="https://user-images.githubusercontent.com/14298407/219465373-ed969c91-3a9d-4ff4-903f-c572aa91366d.png">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
