### PR TITLE
fix: resolve the overlapping bug in schema list

### DIFF
--- a/src/dataExplorer/components/Schema.scss
+++ b/src/dataExplorer/components/Schema.scss
@@ -54,6 +54,9 @@
   border-left: 1px solid $cf-grey-25;
   padding-left: $cf-space-2xs;
   margin-top: $cf-space-xs;
+  .cf-accordion--body-container--expanded {
+    animation: none;
+  }
 }
 
 .selector-title {


### PR DESCRIPTION
Closes #6600 

This PR fixes the overlapping bug in schema browser

## Before

https://user-images.githubusercontent.com/14298407/221053647-ba76939c-17b1-4e2b-8458-bfc5b942c518.mov


## After


https://user-images.githubusercontent.com/14298407/221053661-623a5455-1d7b-4ae1-a2d5-bf35aecfcf7d.mov




### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
