### PR TITLE
fix: prevent recursion in task regex

### DIFF
--- a/cypress/e2e/shared/tasks.test.ts
+++ b/cypress/e2e/shared/tasks.test.ts
@@ -132,13 +132,18 @@ describe('Tasks - TSM', () => {
 
     cy.focused()
 
-    cy.getByTestID('flux-editor').monacoType(`option task = {
+    cy.getByTestID('flux-editor')
+      .monacoType(
+        `option task = {
     name: "Option Test",
     every: 24h,
     offset: 20m
   }
   from(bucket: "defbuck")
-    |> range(start: -2m)`)
+    |> range(start: -2m)`
+      )
+      // Fix bug with monaco error inserting an extra } here.
+      .monacoType('{backSpace}')
 
     cy.getByTestID('task-form-name')
       .click()

--- a/src/tasks/containers/TaskPage.tsx
+++ b/src/tasks/containers/TaskPage.tsx
@@ -145,7 +145,9 @@ class TaskPage extends PureComponent<Props> {
     // if the script has a pre-defined option task = {}
     // we want the taskOptions to take precedence over what is provided in the script
     // currently we delete that part of the script
-    script = script.replace(new RegExp('option\\s+task\\s+=\\s+{(.|\\s)*}'), '')
+
+    const removeTaskOptionsRegex = /option\s+task\s+=\s+{(\s|\S)*?}/
+    script = script.replace(removeTaskOptionsRegex, '')
 
     if (!isValidFlux(script)) {
       this.props.invalidFlux()


### PR DESCRIPTION
Users are hitting an error trying to save [this data migration task](https://docs.influxdata.com/influxdb/cloud/migrate-data/migrate-cloud-to-cloud/#migration-flux-script) in the Cloud2 UI. This PR fixes it by preventing a recursive loop caused by regex.

Before
--
https://user-images.githubusercontent.com/91283923/222728028-b6ed6e0b-ae00-4c78-927a-bcd4d444faf4.mov




After
--
https://user-images.githubusercontent.com/91283923/222728017-289e6b4f-0a32-44ab-a0f0-b271d0d04a0d.mov


Cause
--

The following regex on the "create task" page was intended to ensure that what the user selects for the task name and frequency in the panel on the left-hand side of the page takes precedence over any definition of the task name and frequency in the script.

`script = script.replace(new RegExp('option\\s+task\\s+=\\s+{(.|\\s)*}'), '')`

In other words, "Delete the part of the script that says: `option task = { whatever is in between these brackets }`".

The problem is that the capturing group `(.|\s)*` causes catastrophic backtracking. It's looking for a match of any number of appearances of any _whitespace_ character (`\s`) OR _any_ character (`.`), the overlap of which results in excessive recursion. What we need is a check for "any whitespace character or any non-whitespace character until the closing bracket."

The fix makes these changes:
1. Instead of looking for "any character or any whitespace character" (these two conditions overlap), look for "any whitespace or non-whitespace character" before the closing bracket. 
2. Compile the expression [when the script is loaded, rather than at runtime, since the regex is static](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions).

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - NO
