### PR TITLE
chore: limit graphColorMapping to CLOUD

### DIFF
--- a/src/timeMachine/components/Vis.tsx
+++ b/src/timeMachine/components/Vis.tsx
@@ -34,6 +34,9 @@ import {RemoteDataState, AppState, ViewProperties} from 'src/types'
 import {getActiveTimeRange} from 'src/timeMachine/selectors/index'
 import {setViewProperties} from 'src/timeMachine/actions'
 
+// Constants
+import {CLOUD} from 'src/shared/constants'
+
 type ReduxProps = ConnectedProps<typeof connector>
 type Props = ReduxProps
 
@@ -95,7 +98,7 @@ const TimeMachineVis: FC<Props> = ({
       !!giraffeResult.table.length)
 
   useEffect(() => {
-    if (viewProperties.hasOwnProperty('colors')) {
+    if (CLOUD && viewProperties.hasOwnProperty('colors')) {
       const groupKey = [...giraffeResult.fluxGroupKeyUnion, 'result']
       const [, fillColumnMap] = createGroupIDColumn(
         giraffeResult.table,

--- a/src/visualization/types/Graph/options.tsx
+++ b/src/visualization/types/Graph/options.tsx
@@ -43,7 +43,9 @@ import AxisTicksGenerator from 'src/visualization/components/internal/AxisTicksG
 import {XYViewProperties} from 'src/types'
 import {VisualizationOptionProps} from 'src/visualization'
 
+// Constants
 const {BASE_2, BASE_10} = AXES_SCALE_OPTIONS
+import {CLOUD} from 'src/shared/constants'
 
 interface Props extends VisualizationOptionProps {
   properties: XYViewProperties
@@ -250,19 +252,23 @@ export const GraphOptions: FC<Props> = ({properties, results, update}) => {
             <ColorSchemeDropdown
               value={properties.colors?.filter(c => c.type === 'scale') ?? []}
               onChange={colors => {
-                const [, fillColumnMap] = createGroupIDColumn(
-                  results.table,
-                  groupKey
-                )
-                // the properties that we use to calculate the colors are updated in the next render cycle so we need
-                // to make a new object and override the colors
-                const newProperties = {...properties, colors}
-                const colorMapping = generateSeriesToColorHex(
-                  fillColumnMap,
-                  newProperties
-                )
+                if (CLOUD) {
+                  const [, fillColumnMap] = createGroupIDColumn(
+                    results.table,
+                    groupKey
+                  )
+                  // the properties that we use to calculate the colors are updated in the next render cycle so we need
+                  // to make a new object and override the colors
+                  const newProperties = {...properties, colors}
+                  const colorMapping = generateSeriesToColorHex(
+                    fillColumnMap,
+                    newProperties
+                  )
 
-                update({colors, colorMapping})
+                  update({colors, colorMapping})
+                } else {
+                  update({colors})
+                }
               }}
             />
           </Form.Element>


### PR DESCRIPTION
Part of #6307 

@jeffreyssmith2nd [traced this bug](https://github.com/influxdata/ui/issues/6307#issuecomment-1354806165) to this [PR](https://github.com/influxdata/ui/pull/5233) adding color persistence features (`graphColorMapping`) to UI visualizations. It was part of [this epic](https://github.com/influxdata/ui/pull/3473).

[#5233](https://github.com/influxdata/ui/pull/5233) removed feature flag protection on that feature, resulting in it becoming part of the UI codebase for OSS and Cloud. It's causing serious visualization rendering issues in OSS (but not CLOUD, seemingly). To unblock the OSS team, which has the UI pinned to an older version to resolve this issue, we're going to proceed without the `graphColorMapping` feature in OSS, at least for now, so that OSS doesn't need to stay pinned to an outdated UI. 

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - NO, but only removes color mapping from prospective OSS UI.
