### PR TITLE
chore: remove multiorg phase2 feat flag

### DIFF
--- a/cypress/e2e/cloud/about.test.ts
+++ b/cypress/e2e/cloud/about.test.ts
@@ -1,10 +1,6 @@
 import {makeQuartzUseIDPEOrgID} from 'cypress/support/Utils'
 import {Organization} from 'src/client'
 
-const deleteOrgsFeatureFlags = {
-  createDeleteOrgs: true,
-}
-
 // This variable stores the current IDPE orgid and syncs it with the quartz-mock orgid.
 let idpeOrgID: string
 
@@ -34,7 +30,6 @@ interface SetupParams {
 const setupTest = (setupParams: SetupParams) => {
   cy.flush().then(() =>
     cy.signin().then(() => {
-      cy.setFeatureFlags(deleteOrgsFeatureFlags)
       cy.request({
         method: 'GET',
         url: 'api/v2/orgs',

--- a/cypress/e2e/cloud/createOrg.test.ts
+++ b/cypress/e2e/cloud/createOrg.test.ts
@@ -1,9 +1,5 @@
 import {makeQuartzUseIDPEOrgID} from 'cypress/support/Utils'
 
-const createOrgsFeatureFlags = {
-  createDeleteOrgs: true,
-}
-
 const newOrgName = 'A New Org'
 
 // This variable stores the current IDPE orgid and syncs it with the quartz-mock orgid.
@@ -113,7 +109,6 @@ interface SetupParams {
 const setupTest = (setupParams: SetupParams) => {
   cy.flush().then(() =>
     cy.signin().then(() => {
-      cy.setFeatureFlags(createOrgsFeatureFlags)
       cy.request({
         method: 'GET',
         url: 'api/v2/orgs',

--- a/cypress/e2e/cloud/deepLinks.test.ts
+++ b/cypress/e2e/cloud/deepLinks.test.ts
@@ -7,7 +7,6 @@ describe('Deep linking', () => {
   beforeEach(() => {
     cy.flush()
     cy.signin()
-    cy.setFeatureFlags({createDeleteOrgs: true})
     cy.request({
       method: 'GET',
       url: 'api/v2/orgs',

--- a/cypress/e2e/cloud/org-list.test.ts
+++ b/cypress/e2e/cloud/org-list.test.ts
@@ -2,7 +2,6 @@ const setupTest = () => {
   cy.flush().then(() =>
     cy.signin().then(() => {
       cy.get('@org').then(({id}) => {
-        cy.setFeatureFlags({createDeleteOrgs: true})
         cy.visit(`/orgs/${id}/accounts/orglist`)
       })
     })

--- a/src/accounts/AccountPage.tsx
+++ b/src/accounts/AccountPage.tsx
@@ -12,10 +12,9 @@ import {
   InputType,
   Page,
 } from '@influxdata/clockface'
-import {LeaveOrgButton} from 'src/organizations/components/OrgProfileTab/LeaveOrg'
 
 // Context
-import {UsersContext, UsersProvider} from 'src/users/context/users'
+import {UsersProvider} from 'src/users/context/users'
 import {DeleteFreeAccountButton} from 'src/accounts/DeleteFreeAccount'
 import {DeleteFreeAccountOverlay} from 'src/accounts/DeleteFreeAccountOverlay'
 
@@ -26,7 +25,6 @@ import {selectCurrentIdentity} from 'src/identity/selectors'
 import {CLOUD} from 'src/shared/constants'
 
 // Utils
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 import {UserAccountContext} from 'src/accounts/context/userAccount'
 import AccountTabContainer from 'src/accounts/AccountTabContainer'
@@ -48,7 +46,6 @@ const AccountAboutPage: FC = () => {
     userAccounts,
   } = useContext(UserAccountContext)
 
-  const {users} = useContext(UsersContext)
   const activeAccount =
     userAccounts && userAccounts.filter(acct => acct.isActive)[0]
   const [activeAcctName, setActiveAcctName] = useState(activeAccount?.name)
@@ -76,9 +73,6 @@ const AccountAboutPage: FC = () => {
     CLOUD && accountDetails?.isDeletable
   )
 
-  const showLeaveOrgButton = !isFlagEnabled('createDeleteOrgs')
-  const allowSelfRemoval = users.length > 1
-
   return (
     <AccountTabContainer activeTab="settings">
       <>
@@ -105,12 +99,6 @@ const AccountAboutPage: FC = () => {
             text="Save"
           />
         </FlexBox>
-        {allowSelfRemoval && showLeaveOrgButton && (
-          <>
-            <hr className="account-settings--divider" />
-            <LeaveOrgButton />
-          </>
-        )}
         {shouldShowDeleteFreeAccountButton && <DeleteFreeAccountButton />}
       </>
     </AccountTabContainer>

--- a/src/accounts/AccountTabs.tsx
+++ b/src/accounts/AccountTabs.tsx
@@ -8,7 +8,9 @@ import {ComponentSize, Orientation, Tabs} from '@influxdata/clockface'
 
 // Utils
 import {getOrg} from 'src/organizations/selectors'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+
+// Constants
+import {CLOUD} from 'src/shared/constants'
 
 interface Props {
   activeTab: string
@@ -35,7 +37,7 @@ const AccountTabs: FC<Props> = ({activeTab}) => {
     },
     {
       id: 'organizations',
-      enabled: isFlagEnabled('createDeleteOrgs'),
+      enabled: CLOUD,
       link: `/orgs/${orgID}/accounts/orglist`,
       testID: 'accounts-orglist-tab',
       text: 'Organizations',

--- a/src/checkout/context/checkout.tsx
+++ b/src/checkout/context/checkout.tsx
@@ -35,8 +35,8 @@ import {getQuartzIdentityThunk} from 'src/identity/actions/thunks'
 import {selectCurrentIdentity} from 'src/identity/selectors'
 import {shouldGetCredit250Experience} from 'src/me/selectors'
 
-// Utils
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+// Constants
+import {CLOUD} from 'src/shared/constants'
 
 export type Props = {
   children: JSX.Element
@@ -316,7 +316,7 @@ export const CheckoutProvider: FC<Props> = React.memo(({children}) => {
       } finally {
         setIsSubmitting(false)
         // Refresh whether user is allowed to create new orgs after upgrading to PAYG.
-        if (isFlagEnabled('createDeleteOrgs')) {
+        if (CLOUD) {
           dispatch(getOrgCreationAllowancesThunk())
         }
       }

--- a/src/identity/components/GlobalHeader/AccountDropdown.tsx
+++ b/src/identity/components/GlobalHeader/AccountDropdown.tsx
@@ -34,9 +34,6 @@ import {
 // Constants
 import {CLOUD_URL} from 'src/shared/constants'
 
-// Utils
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
-
 export const AccountDropdown: FC<Props> = ({
   accountsList,
   activeAccount,
@@ -47,31 +44,25 @@ export const AccountDropdown: FC<Props> = ({
     name: activeAccount.name,
   }
 
-  const isCreateDeleteFlagOn = isFlagEnabled('createDeleteOrgs')
-
   const accountMainMenu = useMemo(
-    () =>
-      [
-        {
-          name: 'Settings',
-          iconFont: IconFont.CogSolid_New,
-          href: `/orgs/${activeOrg.id}/accounts/settings`,
-          enabled: true,
-        },
-        {
-          name: 'Organizations',
-          iconFont: IconFont.OrganizationChart,
-          href: `/orgs/${activeOrg.id}/accounts/orglist`,
-          enabled: isCreateDeleteFlagOn,
-        },
-        {
-          name: 'Billing',
-          iconFont: IconFont.Bill,
-          href: `/orgs/${activeOrg.id}/billing`,
-          enabled: true,
-        },
-      ].filter(menuOption => menuOption.enabled),
-    [activeOrg.id, isCreateDeleteFlagOn]
+    () => [
+      {
+        name: 'Settings',
+        iconFont: IconFont.CogSolid_New,
+        href: `/orgs/${activeOrg.id}/accounts/settings`,
+      },
+      {
+        name: 'Organizations',
+        iconFont: IconFont.OrganizationChart,
+        href: `/orgs/${activeOrg.id}/accounts/orglist`,
+      },
+      {
+        name: 'Billing',
+        iconFont: IconFont.Bill,
+        href: `/orgs/${activeOrg.id}/billing`,
+      },
+    ],
+    [activeOrg.id]
   )
 
   // Quartz handles switching accounts by having the user hit this URL.

--- a/src/identity/components/GlobalHeader/OrgDropdown.tsx
+++ b/src/identity/components/GlobalHeader/OrgDropdown.tsx
@@ -14,7 +14,7 @@ import {
 import {OrganizationSummaries} from 'src/client/unityRoutes'
 
 // Constants
-import {CLOUD_URL} from 'src/shared/constants'
+import {CLOUD, CLOUD_URL} from 'src/shared/constants'
 
 // Eventing
 import {
@@ -27,9 +27,6 @@ import {event} from 'src/cloud/utils/reporting'
 
 // Thunks
 import {getOrgCreationAllowancesThunk} from 'src/identity/allowances/actions/thunks'
-
-// Utils
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Selectors
 import {
@@ -78,10 +75,7 @@ export const OrgDropdown: FC<Props> = ({activeOrg, orgsList}) => {
   }
 
   useEffect(() => {
-    if (
-      isFlagEnabled('createDeleteOrgs') &&
-      orgCreationAllowanceStatus === RemoteDataState.NotStarted
-    ) {
+    if (CLOUD && orgCreationAllowanceStatus === RemoteDataState.NotStarted) {
       dispatch(getOrgCreationAllowancesThunk())
     }
   }, [dispatch, orgCreationAllowanceStatus])
@@ -115,7 +109,6 @@ export const OrgDropdown: FC<Props> = ({activeOrg, orgsList}) => {
   ]
 
   if (
-    isFlagEnabled('createDeleteOrgs') &&
     !orgCreationAllowed &&
     (availableUpgrade === 'pay_as_you_go' || availableUpgrade === 'contract')
   ) {
@@ -140,7 +133,7 @@ export const OrgDropdown: FC<Props> = ({activeOrg, orgsList}) => {
   }
 
   const additionalHeaderItems = []
-  if (isFlagEnabled('createDeleteOrgs') && orgCreationAllowed) {
+  if (orgCreationAllowed) {
     additionalHeaderItems.push(
       <CreateOrganizationMenuItem key="CreateOrgMenuItem" />
     )

--- a/src/organizations/components/OrgProfileTab/DeletePanel.tsx
+++ b/src/organizations/components/OrgProfileTab/DeletePanel.tsx
@@ -28,7 +28,6 @@ import {
 
 // Constants
 import {CLOUD} from 'src/shared/constants'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {dismissOverlay, showOverlay} from 'src/overlays/actions/overlays'
 
 // Notifications
@@ -48,8 +47,7 @@ export const DeletePanel: FC = () => {
   const {user, account} = useSelector(selectCurrentIdentity)
 
   const freeAccountWithOneOrg = account.type === 'free' && user.orgCount === 1
-  const shouldShowDeleteOrgButton =
-    CLOUD && isFlagEnabled('createDeleteOrgs') && !freeAccountWithOneOrg
+  const shouldShowDeleteOrgButton = CLOUD && !freeAccountWithOneOrg
 
   return (
     <PageSpinner loading={status}>

--- a/src/organizations/components/OrgProfileTab/index.tsx
+++ b/src/organizations/components/OrgProfileTab/index.tsx
@@ -36,9 +36,6 @@ import {RemoteDataState} from 'src/types'
 // Constants
 import {CLOUD} from 'src/shared/constants'
 
-// Utils
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
-
 // Styles
 import 'src/organizations/components/OrgProfileTab/style.scss'
 
@@ -81,7 +78,6 @@ const OrgProfileTab: FC = () => {
   }, [dispatch, orgDetailsStatus, quartzOrg.id])
 
   const allowSelfRemoval = users.length > 1
-  const showLeaveOrgButton = isFlagEnabled('createDeleteOrgs')
   const hasFetchedOrgDetails = orgDetailsStatus === RemoteDataState.Done
   const hasFetchedStorageType = Boolean(storageType)
 
@@ -175,7 +171,7 @@ const OrgProfileTab: FC = () => {
           stretchToFitWidth={true}
         >
           <>
-            {allowSelfRemoval && showLeaveOrgButton && <LeaveOrgButton />}
+            {allowSelfRemoval && <LeaveOrgButton />}
             <DeletePanel />
           </>
         </FlexBox>

--- a/src/shared/containers/SetOrg.tsx
+++ b/src/shared/containers/SetOrg.tsx
@@ -345,7 +345,7 @@ const SetOrg: FC = () => {
             />
           )}
           {/* list of organizations in the user's current CLOUD account */}
-          {CLOUD && isFlagEnabled('createDeleteOrgs') && (
+          {CLOUD && (
             <Route
               path={`${orgPath}/accounts/orglist`}
               component={OrganizationList}


### PR DESCRIPTION
Part of #5243

Removes the feature flag associated with multiorg phase two (creating and deleting orgs). After this PR, the flag still needs to be removed from IDPE, and then configcat.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - NO
