### PR TITLE
fix: remove cloud branding and support link from OSS 404 page

### DIFF
--- a/src/shared/components/NotFound.tsx
+++ b/src/shared/components/NotFound.tsx
@@ -39,6 +39,7 @@ import {fetchDefaultAccountDefaultOrg} from 'src/identity/apis/org'
 const NotFoundNew: FC = () => (
   <AppWrapper type="funnel" className="page-not-found" testID="not-found">
     <FunnelPage enableGraphic={true} className="page-not-found-funnel">
+      {CLOUD &&
       <FlexBox
         direction={FlexDirection.Row}
         margin={ComponentSize.Large}
@@ -48,6 +49,7 @@ const NotFoundNew: FC = () => (
         <LogoWithCubo />
         <GetInfluxButton />
       </FlexBox>
+      }
       <FlexBox
         className="page-not-found-content"
         direction={FlexDirection.Column}
@@ -70,6 +72,7 @@ const NotFoundNew: FC = () => (
           className="page-not-found-panel-content"
           margin={ComponentSize.Small}
         >
+          {CLOUD &&
           <FlexBoxChild className="page-not-found-panel-section">
             <div className="page-not-found-panel-title">Not a URL issue?</div>
             <div>
@@ -87,6 +90,7 @@ const NotFoundNew: FC = () => (
               </span>
             </div>
           </FlexBoxChild>
+          }
           <FlexBoxChild className="page-not-found-panel-section">
             <div className="page-not-found-panel-title">
               Have more feedback?

--- a/src/shared/components/NotFound.tsx
+++ b/src/shared/components/NotFound.tsx
@@ -39,17 +39,17 @@ import {fetchDefaultAccountDefaultOrg} from 'src/identity/apis/org'
 const NotFoundNew: FC = () => (
   <AppWrapper type="funnel" className="page-not-found" testID="not-found">
     <FunnelPage enableGraphic={true} className="page-not-found-funnel">
-      {CLOUD &&
-      <FlexBox
-        direction={FlexDirection.Row}
-        margin={ComponentSize.Large}
-        stretchToFitWidth={true}
-        justifyContent={JustifyContent.SpaceBetween}
-      >
-        <LogoWithCubo />
-        <GetInfluxButton />
-      </FlexBox>
-      }
+      {CLOUD && (
+        <FlexBox
+          direction={FlexDirection.Row}
+          margin={ComponentSize.Large}
+          stretchToFitWidth={true}
+          justifyContent={JustifyContent.SpaceBetween}
+        >
+          <LogoWithCubo />
+          <GetInfluxButton />
+        </FlexBox>
+      )}
       <FlexBox
         className="page-not-found-content"
         direction={FlexDirection.Column}
@@ -72,25 +72,25 @@ const NotFoundNew: FC = () => (
           className="page-not-found-panel-content"
           margin={ComponentSize.Small}
         >
-          {CLOUD &&
-          <FlexBoxChild className="page-not-found-panel-section">
-            <div className="page-not-found-panel-title">Not a URL issue?</div>
-            <div>
-              <span>
-                The webpage you were trying to reach may have been removed or
-                your access to this page may have expired.&nbsp;
-                {/* Add rel options to avoid "tabnapping" */}
-                <a
-                  href="mailto:support@influxdata.com"
-                  target="_blank"
-                  rel="noreferrer noopener"
-                >
-                  Contact InfluxData Support
-                </a>
-              </span>
-            </div>
-          </FlexBoxChild>
-          }
+          {CLOUD && (
+            <FlexBoxChild className="page-not-found-panel-section">
+              <div className="page-not-found-panel-title">Not a URL issue?</div>
+              <div>
+                <span>
+                  The webpage you were trying to reach may have been removed or
+                  your access to this page may have expired.&nbsp;
+                  {/* Add rel options to avoid "tabnapping" */}
+                  <a
+                    href="mailto:support@influxdata.com"
+                    target="_blank"
+                    rel="noreferrer noopener"
+                  >
+                    Contact InfluxData Support
+                  </a>
+                </span>
+              </div>
+            </FlexBoxChild>
+          )}
           <FlexBoxChild className="page-not-found-panel-section">
             <div className="page-not-found-panel-title">
               Have more feedback?


### PR DESCRIPTION
<!-- Describe your proposed changes here. -->
<!-- Including screenshots or visuals is very helpful - a picture is worth a thousand words. -->

The current 404 page is the same as Cloud:
<img width="1580" alt="Screenshot 2023-03-07 at 14 01 28" src="https://user-images.githubusercontent.com/26460069/223524375-21d5a1b4-a18b-4a08-8e8b-6f3e5cf925b1.png">

However we don't want users directed to support, and don't want cloud branding. The updated page addresses that:
<img width="1580" alt="Screenshot 2023-03-07 at 13 59 53" src="https://user-images.githubusercontent.com/26460069/223524568-77ca5507-6f1b-4e09-ad74-f309dc551a1f.png">

### Checklist

Authors and Reviewer(s), please verify the following:

- [ ] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [ ] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
