### PR TITLE
feat: add DBRP schema list

### DIFF
--- a/src/dataExplorer/components/BucketSelector.tsx
+++ b/src/dataExplorer/components/BucketSelector.tsx
@@ -15,9 +15,11 @@ import SelectorTitle from 'src/dataExplorer/components/SelectorTitle'
 import {ScriptQueryBuilderContext} from 'src/dataExplorer/context/scriptQueryBuilder'
 import {BucketContext} from 'src/shared/contexts/buckets'
 import {event} from 'src/cloud/utils/reporting'
+import {PersistanceContext} from 'src/dataExplorer/context/persistance'
 
 // Types
 import {RemoteDataState, Bucket} from 'src/types'
+import {LanguageType} from 'src/dataExplorer/components/resources'
 
 const BUCKET_TOOLTIP = `A bucket is a named location where time series data \
 is stored. You can think of a bucket like you would a database in SQL systems.`
@@ -33,6 +35,11 @@ const BucketSelector: FC = () => {
   const {loading, buckets} = useContext(BucketContext)
   const [isSearchActive, setIsSearchActive] = useState(false)
   const [searchTerm, setSearchTerm] = useState('')
+  const {resource} = useContext(PersistanceContext)
+
+  if (resource?.language === LanguageType.INFLUXQL) {
+    return null
+  }
 
   const _buckets = buckets.filter(b =>
     `${b.name}`.toLocaleLowerCase().includes(searchTerm.toLocaleLowerCase())
@@ -164,4 +171,4 @@ const BucketSelector: FC = () => {
   )
 }
 
-export default BucketSelector
+export {BucketSelector}

--- a/src/dataExplorer/components/DBRPSelector.tsx
+++ b/src/dataExplorer/components/DBRPSelector.tsx
@@ -1,5 +1,6 @@
 // Libraries
 import React, {ChangeEvent, FC, useContext, useState} from 'react'
+import {useDispatch} from 'react-redux'
 
 // Contexts
 import {BucketContext} from 'src/shared/contexts/buckets'
@@ -11,6 +12,7 @@ import {PersistanceContext} from 'src/dataExplorer/context/persistance'
 import {RemoteDataState} from 'src/types'
 import {DBRP} from 'src/client'
 import {LanguageType} from 'src/dataExplorer/components/resources'
+import {Notification} from 'src/types/notifications'
 
 // Components
 import SelectorTitle from 'src/dataExplorer/components/SelectorTitle'
@@ -22,6 +24,10 @@ import {
   Input,
   TechnoSpinner,
 } from '@influxdata/clockface'
+
+// Utils
+import {notify} from 'src/shared/actions/notifications'
+import {defaultErrorNotification} from 'src/shared/copy/notifications'
 
 const DROPDOWN_LABEL: string = 'Database/Retention policy'
 const DBRP_TOOLTIP: string = `InfluxQL requires a database and retention policy \
@@ -37,6 +43,7 @@ export const DBRPSelector: FC = () => {
   const [isSearchActive, setIsSearchActive] = useState(false)
   const [searchTerm, setSearchTerm] = useState('')
   const {resource} = useContext(PersistanceContext)
+  const dispatch = useDispatch()
 
   if (resource?.language !== LanguageType.INFLUXQL) {
     return null
@@ -51,11 +58,13 @@ export const DBRPSelector: FC = () => {
     const bucket = buckets.find(b => b.id === dbrp.bucketID)
     if (!bucket) {
       // this should never be happening
-      console.error(
-        `No matching bucket found for ${dbrp.database}/${dbrp.retention_policy}, \
+      const notification: Notification = {
+        ...defaultErrorNotification,
+        message: `No matching bucket found for ${dbrp.database}/${dbrp.retention_policy}, \
         suggest to create a database and retention policy mapping \
-        https://docs.influxdata.com/influxdb/cloud/query-data/influxql/dbrp/`
-      )
+        https://docs.influxdata.com/influxdb/cloud/query-data/influxql/dbrp/`,
+      }
+      dispatch(notify(notification))
     } else {
       selectDBRP(dbrp, bucket)
     }

--- a/src/dataExplorer/components/DBRPSelector.tsx
+++ b/src/dataExplorer/components/DBRPSelector.tsx
@@ -1,0 +1,128 @@
+// Libraries
+import React, {ChangeEvent, FC, useContext, useState} from 'react'
+
+// Contexts
+import {DBRPContext} from 'src/shared/contexts/dbrps'
+
+// Types
+import {RemoteDataState} from 'src/types'
+import {DBRP} from 'src/client'
+
+// Components
+import SelectorTitle from 'src/dataExplorer/components/SelectorTitle'
+import {
+  ComponentSize,
+  Dropdown,
+  DropdownMenuTheme,
+  IconFont,
+  Input,
+  TechnoSpinner,
+} from '@influxdata/clockface'
+
+const DBRP_TOOLTIP = `TODO: test`
+
+export const DBRPSelector: FC = () => {
+  const {loading, dbrps} = useContext(DBRPContext)
+  const [isSearchActive, setIsSearchActive] = useState(false)
+  const [searchTerm, setSearchTerm] = useState('')
+
+  const _dbrps: DBRP[] = dbrps.filter(d =>
+    `${d.database}`.toLocaleLowerCase().includes(searchTerm.toLocaleLowerCase())
+  )
+
+  const handleSearchChange = (e: ChangeEvent<HTMLInputElement>): void => {
+    setSearchTerm(e.target.value)
+  }
+
+  let buttonText = 'Loading DBRPs...'
+  if (loading === RemoteDataState.Done) {
+    buttonText = 'Select...' // TDOD: add selectedDBRP
+  }
+
+  const button = (active: boolean, onClick: any) => (
+    <Dropdown.Button
+      onClick={onClick}
+      active={active}
+      testID="dbrp-selector--dropdown-button"
+    >
+      {buttonText}
+    </Dropdown.Button>
+  )
+
+  if (loading !== RemoteDataState.Done) {
+    return (
+      <div>
+        <SelectorTitle label="DBRP" tooltipContents={DBRP_TOOLTIP} />
+        <Dropdown
+          button={button}
+          menu={onCollapse => (
+            <Dropdown.Menu onCollapse={onCollapse}>
+              <Dropdown.ItemEmpty>
+                <TechnoSpinner
+                  strokeWidth={ComponentSize.Small}
+                  diameterPixels={32}
+                />
+              </Dropdown.ItemEmpty>
+            </Dropdown.Menu>
+          )}
+        />
+      </div>
+    )
+  }
+
+  const body: JSX.Element | JSX.Element[] =
+    _dbrps.length === 0 ? (
+      <Dropdown.ItemEmpty>No DBRPs Found</Dropdown.ItemEmpty>
+    ) : (
+      _dbrps.map(d => {
+        const dbrpMapping = `${d.database}/${d.retention_policy}`
+        return (
+          <Dropdown.Item
+            key={dbrpMapping}
+            value={d}
+            onClick={() => {}} // TODO:
+            // TODO: selected
+            title={dbrpMapping}
+            wrapText={true}
+            testID={`dbrp-selector--dropdown--${dbrpMapping}`}
+          >
+            {dbrpMapping}
+          </Dropdown.Item>
+        )
+      })
+    )
+
+  return (
+    <div>
+      <SelectorTitle label="DBRP" tooltipContents={DBRP_TOOLTIP} />
+      <Dropdown
+        button={button}
+        menu={onCollapse => (
+          <Dropdown.Menu
+            onCollapse={() => {
+              if (isSearchActive === false) {
+                onCollapse()
+              }
+            }}
+            theme={DropdownMenuTheme.Onyx}
+          >
+            <div className="searchable-dropdown--input-container">
+              <Input
+                icon={IconFont.Search_New}
+                onFocus={() => setIsSearchActive(true)}
+                onChange={handleSearchChange}
+                onBlur={() => setIsSearchActive(false)}
+                value={searchTerm}
+                placeholder="Search DBRPs"
+                size={ComponentSize.Small}
+                autoFocus={true}
+                testID="dbrp-selector--search-bar"
+              />
+            </div>
+            {body}
+          </Dropdown.Menu>
+        )}
+      />
+    </div>
+  )
+}

--- a/src/dataExplorer/components/DBRPSelector.tsx
+++ b/src/dataExplorer/components/DBRPSelector.tsx
@@ -23,7 +23,8 @@ import {
   TechnoSpinner,
 } from '@influxdata/clockface'
 
-const DBRP_TOOLTIP = `InfluxQL requires a database and retention policy \
+const DROPDOWN_LABEL: string = 'Database/Retention policy'
+const DBRP_TOOLTIP: string = `InfluxQL requires a database and retention policy \
 (DBRP) combination in order to query data. In InfluxDB Cloud, databases \
 and retention policies have been combined and replaced by InfluxDB buckets. \
 To query InfluxDB Cloud with InfluxQL, the specified DBRP combination \
@@ -52,7 +53,7 @@ export const DBRPSelector: FC = () => {
       // this should never be happening
       console.error(
         `No matching bucket found for ${dbrp.database}/${dbrp.retention_policy}, \
-        suggest to create a DBRP mapping \
+        suggest to create a database and retention policy mapping \
         https://docs.influxdata.com/influxdb/cloud/query-data/influxql/dbrp/`
       )
     } else {
@@ -64,9 +65,9 @@ export const DBRPSelector: FC = () => {
     setSearchTerm(e.target.value)
   }
 
-  let buttonText = 'Loading DBRPs...'
+  let buttonText = 'Loading database/retention policy...'
   if (loading === RemoteDataState.Done && !selectedDBRP?.database) {
-    buttonText = 'Select DBRP...'
+    buttonText = 'Select database/retention policy...'
   } else if (loading === RemoteDataState.Done && selectedDBRP?.database) {
     buttonText = `${selectedDBRP.database}/${selectedDBRP.retention_policy}`
   }
@@ -84,7 +85,7 @@ export const DBRPSelector: FC = () => {
   if (loading !== RemoteDataState.Done) {
     return (
       <div>
-        <SelectorTitle label="DBRP" tooltipContents={DBRP_TOOLTIP} />
+        <SelectorTitle label={DROPDOWN_LABEL} tooltipContents={DBRP_TOOLTIP} />
         <Dropdown
           button={button}
           menu={onCollapse => (
@@ -127,7 +128,7 @@ export const DBRPSelector: FC = () => {
 
   return (
     <div>
-      <SelectorTitle label="DBRP" tooltipContents={DBRP_TOOLTIP} />
+      <SelectorTitle label={DROPDOWN_LABEL} tooltipContents={DBRP_TOOLTIP} />
       <Dropdown
         button={button}
         menu={onCollapse => (

--- a/src/dataExplorer/components/DBRPSelector.tsx
+++ b/src/dataExplorer/components/DBRPSelector.tsx
@@ -23,7 +23,11 @@ import {
   TechnoSpinner,
 } from '@influxdata/clockface'
 
-const DBRP_TOOLTIP = `TODO: test`
+const DBRP_TOOLTIP = `InfluxQL requires a database and retention policy \
+(DBRP) combination in order to query data. In InfluxDB Cloud, databases \
+and retention policies have been combined and replaced by InfluxDB buckets. \
+To query InfluxDB Cloud with InfluxQL, the specified DBRP combination \
+must be mapped to a bucket.`
 
 export const DBRPSelector: FC = () => {
   const {loading, dbrps} = useContext(DBRPContext)
@@ -45,10 +49,11 @@ export const DBRPSelector: FC = () => {
     // grab bucket object
     const bucket = buckets.find(b => b.id === dbrp.bucketID)
     if (!bucket) {
-      // TODO: no matching, suggest to ..? (this should never be happening)
-      // eslint-disable-next-line no-console
-      console.log(
-        `no matching bucket for ${dbrp.database}/${dbrp.retention_policy}`
+      // this should never be happening
+      console.error(
+        `No matching bucket found for ${dbrp.database}/${dbrp.retention_policy}, \
+        suggest to create a DBRP mapping \
+        https://docs.influxdata.com/influxdb/cloud/query-data/influxql/dbrp/`
       )
     } else {
       selectDBRP(dbrp, bucket)

--- a/src/dataExplorer/components/DBRPSelector.tsx
+++ b/src/dataExplorer/components/DBRPSelector.tsx
@@ -39,6 +39,7 @@ export const DBRPSelector: FC = () => {
     const bucket = buckets.find(b => b.id === dbrp.bucketID)
     if (!bucket) {
       // TODO: no matching, suggest to ..? (this should never be happening)
+      // eslint-disable-next-line no-console
       console.log(
         `no matching bucket for ${dbrp.database}/${dbrp.retention_policy}`
       )

--- a/src/dataExplorer/components/DBRPSelector.tsx
+++ b/src/dataExplorer/components/DBRPSelector.tsx
@@ -5,10 +5,12 @@ import React, {ChangeEvent, FC, useContext, useState} from 'react'
 import {BucketContext} from 'src/shared/contexts/buckets'
 import {DBRPContext} from 'src/shared/contexts/dbrps'
 import {ScriptQueryBuilderContext} from 'src/dataExplorer/context/scriptQueryBuilder'
+import {PersistanceContext} from 'src/dataExplorer/context/persistance'
 
 // Types
 import {RemoteDataState} from 'src/types'
 import {DBRP} from 'src/client'
+import {LanguageType} from 'src/dataExplorer/components/resources'
 
 // Components
 import SelectorTitle from 'src/dataExplorer/components/SelectorTitle'
@@ -29,6 +31,11 @@ export const DBRPSelector: FC = () => {
   const {selectedDBRP, selectDBRP} = useContext(ScriptQueryBuilderContext)
   const [isSearchActive, setIsSearchActive] = useState(false)
   const [searchTerm, setSearchTerm] = useState('')
+  const {resource} = useContext(PersistanceContext)
+
+  if (resource?.language !== LanguageType.INFLUXQL) {
+    return null
+  }
 
   const _dbrps: DBRP[] = dbrps.filter(d =>
     `${d.database}`.toLocaleLowerCase().includes(searchTerm.toLocaleLowerCase())

--- a/src/dataExplorer/components/Schema.tsx
+++ b/src/dataExplorer/components/Schema.tsx
@@ -4,11 +4,12 @@ import {useSelector} from 'react-redux'
 // Components
 import {DapperScrollbars} from '@influxdata/clockface'
 import {SearchWidget} from 'src/shared/components/search_widget/SearchWidget'
-import BucketSelector from 'src/dataExplorer/components/BucketSelector'
+import {BucketSelector} from 'src/dataExplorer/components/BucketSelector'
 import MeasurementSelector from 'src/dataExplorer/components/MeasurementSelector'
 import FieldSelector from 'src/dataExplorer/components/FieldSelector'
 import TagSelector from 'src/dataExplorer/components/TagSelector'
 import SchemaBrowserHeading from 'src/dataExplorer/components/SchemaBrowserHeading'
+import {DBRPSelector} from 'src/dataExplorer/components/DBRPSelector'
 
 // Context
 import {
@@ -19,6 +20,7 @@ import {BucketProvider} from 'src/shared/contexts/buckets'
 import {MeasurementsProvider} from 'src/dataExplorer/context/measurements'
 import {FieldsProvider} from 'src/dataExplorer/context/fields'
 import {TagsProvider} from 'src/dataExplorer/context/tags'
+import {DBRPProvider} from 'src/shared/contexts/dbrps'
 
 // Types
 import {QueryScope} from 'src/shared/contexts/query'
@@ -35,7 +37,7 @@ const FieldsTags: FC = () => {
 
   useEffect(() => {
     setSearchTerm('')
-  }, [selectedBucket, selectedMeasurement])
+  }, [selectedBucket, selectedMeasurement]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleSearchFieldsTags = (searchTerm: string): void => {
     setSearchTerm(searchTerm)
@@ -58,7 +60,7 @@ const FieldsTags: FC = () => {
         <TagSelector />
       </div>
     )
-  }, [selectedBucket, selectedMeasurement, searchTerm])
+  }, [selectedBucket, selectedMeasurement, searchTerm]) // eslint-disable-line react-hooks/exhaustive-deps
 }
 
 const Schema: FC = () => {
@@ -74,18 +76,24 @@ const Schema: FC = () => {
         <TagsProvider scope={scope}>
           <ScriptQueryBuilderProvider>
             <BucketProvider scope={scope} omitSampleData>
-              <div className="scroll--container">
-                <DapperScrollbars>
-                  <div className="schema-browser" data-testid="schema-browser">
-                    <SchemaBrowserHeading />
-                    <BucketSelector />
-                    <div className="container-side-bar">
-                      <MeasurementSelector />
-                      <FieldsTags />
+              <DBRPProvider scope={scope}>
+                <div className="scroll--container">
+                  <DapperScrollbars>
+                    <div
+                      className="schema-browser"
+                      data-testid="schema-browser"
+                    >
+                      <SchemaBrowserHeading />
+                      <BucketSelector />
+                      <DBRPSelector />
+                      <div className="container-side-bar">
+                        <MeasurementSelector />
+                        <FieldsTags />
+                      </div>
                     </div>
-                  </div>
-                </DapperScrollbars>
-              </div>
+                  </DapperScrollbars>
+                </div>
+              </DBRPProvider>
             </BucketProvider>
           </ScriptQueryBuilderProvider>
         </TagsProvider>
@@ -94,4 +102,4 @@ const Schema: FC = () => {
   )
 }
 
-export default Schema
+export {Schema}

--- a/src/dataExplorer/components/Schema.tsx
+++ b/src/dataExplorer/components/Schema.tsx
@@ -20,7 +20,6 @@ import {BucketProvider} from 'src/shared/contexts/buckets'
 import {MeasurementsProvider} from 'src/dataExplorer/context/measurements'
 import {FieldsProvider} from 'src/dataExplorer/context/fields'
 import {TagsProvider} from 'src/dataExplorer/context/tags'
-import {DBRPProvider} from 'src/shared/contexts/dbrps'
 
 // Types
 import {QueryScope} from 'src/shared/contexts/query'

--- a/src/dataExplorer/components/Schema.tsx
+++ b/src/dataExplorer/components/Schema.tsx
@@ -1,4 +1,4 @@
-import React, {FC, useContext, useEffect, useMemo} from 'react'
+import React, {FC, useCallback, useContext, useEffect, useMemo} from 'react'
 import {useSelector} from 'react-redux'
 
 // Components
@@ -38,9 +38,12 @@ const FieldsTags: FC = () => {
     setSearchTerm('')
   }, [selectedBucket, selectedMeasurement]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  const handleSearchFieldsTags = (searchTerm: string): void => {
-    setSearchTerm(searchTerm)
-  }
+  const handleSearchFieldsTags = useCallback(
+    (searchTerm: string): void => {
+      setSearchTerm(searchTerm)
+    },
+    [setSearchTerm]
+  )
 
   return useMemo(() => {
     if (!selectedBucket || !selectedMeasurement) {
@@ -59,7 +62,7 @@ const FieldsTags: FC = () => {
         <TagSelector />
       </div>
     )
-  }, [selectedBucket, selectedMeasurement, searchTerm]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [selectedBucket, selectedMeasurement, searchTerm, handleSearchFieldsTags])
 }
 
 const Schema: FC = () => {

--- a/src/dataExplorer/components/Schema.tsx
+++ b/src/dataExplorer/components/Schema.tsx
@@ -76,24 +76,20 @@ const Schema: FC = () => {
         <TagsProvider scope={scope}>
           <ScriptQueryBuilderProvider>
             <BucketProvider scope={scope} omitSampleData>
-              <DBRPProvider scope={scope}>
-                <div className="scroll--container">
-                  <DapperScrollbars>
-                    <div
-                      className="schema-browser"
-                      data-testid="schema-browser"
-                    >
-                      <SchemaBrowserHeading />
-                      <BucketSelector />
-                      <DBRPSelector />
-                      <div className="container-side-bar">
-                        <MeasurementSelector />
-                        <FieldsTags />
-                      </div>
+              {/* DBRPProvider is in upstream */}
+              <div className="scroll--container">
+                <DapperScrollbars>
+                  <div className="schema-browser" data-testid="schema-browser">
+                    <SchemaBrowserHeading />
+                    <BucketSelector />
+                    <DBRPSelector />
+                    <div className="container-side-bar">
+                      <MeasurementSelector />
+                      <FieldsTags />
                     </div>
-                  </DapperScrollbars>
-                </div>
-              </DBRPProvider>
+                  </div>
+                </DapperScrollbars>
+              </div>
             </BucketProvider>
           </ScriptQueryBuilderProvider>
         </TagsProvider>

--- a/src/dataExplorer/components/Schema.tsx
+++ b/src/dataExplorer/components/Schema.tsx
@@ -36,6 +36,7 @@ const FieldsTags: FC = () => {
 
   useEffect(() => {
     setSearchTerm('')
+    // setSearchTerm will cause infinite re-rendering if added to the dependency list
   }, [selectedBucket, selectedMeasurement]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleSearchFieldsTags = useCallback(

--- a/src/dataExplorer/components/ScriptQueryBuilder.tsx
+++ b/src/dataExplorer/components/ScriptQueryBuilder.tsx
@@ -33,7 +33,7 @@ import {
 import {LanguageType} from 'src/dataExplorer/components/resources'
 import {ResultsPane} from 'src/dataExplorer/components/ResultsPane'
 import Sidebar from 'src/dataExplorer/components/Sidebar'
-import Schema from 'src/dataExplorer/components/Schema'
+import {Schema} from 'src/dataExplorer/components/Schema'
 import SaveAsScript from 'src/dataExplorer/components/SaveAsScript'
 import {QueryContext} from 'src/shared/contexts/query'
 import {getOrg, isOrgIOx} from 'src/organizations/selectors'

--- a/src/dataExplorer/components/ScriptQueryBuilder.tsx
+++ b/src/dataExplorer/components/ScriptQueryBuilder.tsx
@@ -17,6 +17,12 @@ import {
   Overlay,
   ComponentStatus,
 } from '@influxdata/clockface'
+import {ResultsPane} from 'src/dataExplorer/components/ResultsPane'
+import Sidebar from 'src/dataExplorer/components/Sidebar'
+import {Schema} from 'src/dataExplorer/components/Schema'
+import SaveAsScript from 'src/dataExplorer/components/SaveAsScript'
+
+// Contexts
 import {QueryProvider} from 'src/shared/contexts/query'
 import {EditorProvider} from 'src/shared/contexts/editor'
 import {ResultsProvider, ResultsContext} from 'src/dataExplorer/context/results'
@@ -30,18 +36,20 @@ import {
   PersistanceProvider,
   PersistanceContext,
 } from 'src/dataExplorer/context/persistance'
-import {LanguageType} from 'src/dataExplorer/components/resources'
-import {ResultsPane} from 'src/dataExplorer/components/ResultsPane'
-import Sidebar from 'src/dataExplorer/components/Sidebar'
-import {Schema} from 'src/dataExplorer/components/Schema'
-import SaveAsScript from 'src/dataExplorer/components/SaveAsScript'
 import {QueryContext} from 'src/shared/contexts/query'
+import {DBRPContext, DBRPProvider} from 'src/shared/contexts/dbrps'
+
+// Utilies
 import {getOrg, isOrgIOx} from 'src/organizations/selectors'
-import {RemoteDataState} from 'src/types'
 import {SCRIPT_EDITOR_PARAMS} from 'src/dataExplorer/components/resources'
 import {selectIsNewIOxOrg} from 'src/shared/selectors/app'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {CLOUD} from 'src/shared/constants'
+
+// Types
+import {RemoteDataState} from 'src/types'
+import {QueryScope} from 'src/shared/contexts/query'
+import {LanguageType} from 'src/dataExplorer/components/resources'
 
 // Styles
 import './ScriptQueryBuilder.scss'
@@ -66,6 +74,7 @@ const ScriptQueryBuilder: FC = () => {
   const {cancel} = useContext(QueryContext)
   const {setStatus, setResult} = useContext(ResultsContext)
   const {clear: clearViewOptions} = useContext(ResultsViewContext)
+  const {hasDBRPs} = useContext(DBRPContext)
   const org = useSelector(getOrg)
   const isNewIOxOrg =
     useSelector(selectIsNewIOxOrg) &&
@@ -160,7 +169,7 @@ const ScriptQueryBuilder: FC = () => {
                               {option}
                             </Dropdown.Item>
                           ))}
-                        {isFlagEnabled('influxqlUI') ? (
+                        {isFlagEnabled('influxqlUI') && hasDBRPs() ? (
                           <Dropdown.Item
                             className={`script-dropdown__${LanguageType.INFLUXQL}`}
                             key={LanguageType.INFLUXQL}
@@ -260,16 +269,26 @@ const ScriptQueryBuilder: FC = () => {
   )
 }
 
-export default () => (
-  <QueryProvider>
-    <ResultsProvider>
-      <ResultsViewProvider>
-        <PersistanceProvider>
-          <ChildResultsProvider>
-            <ScriptQueryBuilder />
-          </ChildResultsProvider>
-        </PersistanceProvider>
-      </ResultsViewProvider>
-    </ResultsProvider>
-  </QueryProvider>
-)
+export default () => {
+  const org = useSelector(getOrg)
+  const scope = {
+    org: org.id,
+    region: window.location.origin,
+  } as QueryScope
+
+  return (
+    <QueryProvider>
+      <ResultsProvider>
+        <ResultsViewProvider>
+          <DBRPProvider scope={scope}>
+            <PersistanceProvider>
+              <ChildResultsProvider>
+                <ScriptQueryBuilder />
+              </ChildResultsProvider>
+            </PersistanceProvider>
+          </DBRPProvider>
+        </ResultsViewProvider>
+      </ResultsProvider>
+    </QueryProvider>
+  )
+}

--- a/src/dataExplorer/context/persistance.tsx
+++ b/src/dataExplorer/context/persistance.tsx
@@ -5,6 +5,7 @@ import {useSelector} from 'react-redux'
 // Types
 import {TimeRange, RecursivePartial} from 'src/types'
 import {Bucket, TagKeyValuePair} from 'src/types'
+import {DBRP} from 'src/client'
 
 // Utils
 import {DEFAULT_TIME_RANGE} from 'src/shared/constants/timeRanges'
@@ -64,6 +65,7 @@ interface ResultOptions {
 
 export interface CompositionSelection {
   bucket: Bucket
+  dbrp: DBRP
   measurement: string
   fields: string[]
   tagValues: TagKeyValuePair[]
@@ -94,6 +96,7 @@ interface ContextType {
 
 export const DEFAULT_SELECTION: CompositionSelection = {
   bucket: null,
+  dbrp: null,
   measurement: null,
   fields: [] as string[],
   tagValues: [] as TagKeyValuePair[],

--- a/src/dataExplorer/context/scriptQueryBuilder.tsx
+++ b/src/dataExplorer/context/scriptQueryBuilder.tsx
@@ -16,6 +16,7 @@ import {TagsContext} from 'src/dataExplorer/context/tags'
 import {debouncer} from 'src/dataExplorer/shared/utils'
 // Types
 import {Bucket, TagKeyValuePair} from 'src/types'
+import {DBRP} from 'src/client'
 
 const DEFAULT_SELECTED_TAG_VALUES: SelectedTagValues = {}
 interface SelectedTagValues {
@@ -33,6 +34,7 @@ interface ScriptQueryBuilderContextType {
   selectedTagValues: SelectedTagValues
   searchTerm: string // for searching fields and tags
   selectBucket: (bucket: Bucket) => void
+  selectDBRP: (dbrp: DBRP) => void
   selectMeasurement: (measurement: string) => void
   selectField: (field: string) => void
   selectTagValue: (tagKey: string, tagValue: string) => void
@@ -50,6 +52,7 @@ const DEFAULT_CONTEXT: ScriptQueryBuilderContextType = {
   selectedTagValues: DEFAULT_SELECTED_TAG_VALUES,
   searchTerm: '',
   selectBucket: (_b: Bucket) => {},
+  selectDBRP: (_d: DBRP) => {},
   selectMeasurement: (_m: string) => {},
   selectField: (_f: string) => {},
   selectTagValue: (_k: string, _v: string) => {},
@@ -120,6 +123,19 @@ export const ScriptQueryBuilderProvider: FC = ({children}) => {
 
     // Fetch measurement values
     getMeasurements(bucket)
+  }
+
+  const handleSelectDBRP = (dbrp: DBRP): void => {
+    console.log('handleSelectDBRP', {dbrp})
+    // setSelection({dbrp, measurement: '', fields: [], tagValues: []})
+
+    // Reset measurement, tags, fields, selected tag values
+    resetFields()
+    resetTags()
+    setSelectedTagValues(DEFAULT_SELECTED_TAG_VALUES)
+
+    // Fetch measurement values
+    // TODO: getMeasurements()
   }
 
   const handleSelectMeasurement = (measurement: string): void => {
@@ -209,6 +225,7 @@ export const ScriptQueryBuilderProvider: FC = ({children}) => {
           selectedTagValues,
           searchTerm,
           selectBucket: handleSelectBucket,
+          selectDBRP: handleSelectDBRP,
           selectMeasurement: handleSelectMeasurement,
           selectField: handleSelectField,
           selectTagValue: handleSelectTagValue,

--- a/src/dataExplorer/context/scriptQueryBuilder.tsx
+++ b/src/dataExplorer/context/scriptQueryBuilder.tsx
@@ -30,11 +30,13 @@ interface ScriptQueryBuilderContextType {
 
   // Schema
   selectedBucket: Bucket
+  // only for InfluxQL, a DBRP in InfluxQL is equivalent to a bucket in Flux/SQL
+  selectedDBRP: DBRP
   selectedMeasurement: string
   selectedTagValues: SelectedTagValues
   searchTerm: string // for searching fields and tags
   selectBucket: (bucket: Bucket) => void
-  selectDBRP: (dbrp: DBRP) => void
+  selectDBRP: (dbrp: DBRP, bucket: Bucket) => void
   selectMeasurement: (measurement: string) => void
   selectField: (field: string) => void
   selectTagValue: (tagKey: string, tagValue: string) => void
@@ -48,11 +50,12 @@ const DEFAULT_CONTEXT: ScriptQueryBuilderContextType = {
 
   // Schema
   selectedBucket: null,
+  selectedDBRP: null,
   selectedMeasurement: '',
   selectedTagValues: DEFAULT_SELECTED_TAG_VALUES,
   searchTerm: '',
   selectBucket: (_b: Bucket) => {},
-  selectDBRP: (_d: DBRP) => {},
+  selectDBRP: (_d: DBRP, _b: Bucket) => {},
   selectMeasurement: (_m: string) => {},
   selectField: (_f: string) => {},
   selectTagValue: (_k: string, _v: string) => {},
@@ -125,9 +128,8 @@ export const ScriptQueryBuilderProvider: FC = ({children}) => {
     getMeasurements(bucket)
   }
 
-  const handleSelectDBRP = (dbrp: DBRP): void => {
-    console.log('handleSelectDBRP', {dbrp})
-    // setSelection({dbrp, measurement: '', fields: [], tagValues: []})
+  const handleSelectDBRP = (dbrp: DBRP, bucket: Bucket): void => {
+    setSelection({dbrp, bucket, measurement: '', fields: [], tagValues: []})
 
     // Reset measurement, tags, fields, selected tag values
     resetFields()
@@ -135,7 +137,7 @@ export const ScriptQueryBuilderProvider: FC = ({children}) => {
     setSelectedTagValues(DEFAULT_SELECTED_TAG_VALUES)
 
     // Fetch measurement values
-    // TODO: getMeasurements()
+    getMeasurements(bucket)
   }
 
   const handleSelectMeasurement = (measurement: string): void => {
@@ -221,6 +223,7 @@ export const ScriptQueryBuilderProvider: FC = ({children}) => {
 
           // Schema
           selectedBucket: selection.bucket,
+          selectedDBRP: selection.dbrp,
           selectedMeasurement: selection.measurement,
           selectedTagValues,
           searchTerm,

--- a/src/dataExplorer/context/scriptQueryBuilder.tsx
+++ b/src/dataExplorer/context/scriptQueryBuilder.tsx
@@ -106,7 +106,10 @@ export const ScriptQueryBuilderProvider: FC = ({children}) => {
         setSelectedTagValues(_selectedTagValues)
       }
     }
-  }, [selection.bucket]) // eslint-disable-line react-hooks/exhaustive-deps
+    // pass an empty array ([]) as the dependency list to
+    // run an effect and clean it up only once (on mount and unmount),
+    // https://reactjs.org/docs/hooks-effect.html#tip-optimizing-performance-by-skipping-effects
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     setSelectedTagValues(transformSessionTagValuesToLocal(selection.tagValues))
@@ -238,7 +241,6 @@ export const ScriptQueryBuilderProvider: FC = ({children}) => {
         {children}
       </ScriptQueryBuilderContext.Provider>
     ),
-    /* eslint-disable react-hooks/exhaustive-deps */
     [
       // Composition Sync
       selection.composition?.synced,
@@ -251,6 +253,5 @@ export const ScriptQueryBuilderProvider: FC = ({children}) => {
 
       children,
     ]
-    /* eslint-enable react-hooks/exhaustive-deps */
   )
 }

--- a/src/dataExplorer/context/scriptQueryBuilder.tsx
+++ b/src/dataExplorer/context/scriptQueryBuilder.tsx
@@ -106,7 +106,7 @@ export const ScriptQueryBuilderProvider: FC = ({children}) => {
         setSelectedTagValues(_selectedTagValues)
       }
     }
-  }, [selection.bucket])
+  }, [selection.bucket]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     setSelectedTagValues(transformSessionTagValuesToLocal(selection.tagValues))
@@ -238,6 +238,7 @@ export const ScriptQueryBuilderProvider: FC = ({children}) => {
         {children}
       </ScriptQueryBuilderContext.Provider>
     ),
+    /* eslint-disable react-hooks/exhaustive-deps */
     [
       // Composition Sync
       selection.composition?.synced,
@@ -250,5 +251,6 @@ export const ScriptQueryBuilderProvider: FC = ({children}) => {
 
       children,
     ]
+    /* eslint-enable react-hooks/exhaustive-deps */
   )
 }

--- a/src/shared/contexts/dbrps.tsx
+++ b/src/shared/contexts/dbrps.tsx
@@ -76,6 +76,9 @@ export const DBRPProvider: FC<Props> = ({children, scope}) => {
       // to set local storage to an empty {}
       window.localStorage.setItem(DBRP_LOCAL_STORAGE_KEY, JSON.stringify({}))
     }
+    // pass an empty array ([]) as the dependency list to
+    // run an effect and clean it up only once (on mount and unmount),
+    // https://reactjs.org/docs/hooks-effect.html#tip-optimizing-performance-by-skipping-effects
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const updateCache = (update: any): void => {

--- a/src/shared/contexts/dbrps.tsx
+++ b/src/shared/contexts/dbrps.tsx
@@ -66,7 +66,7 @@ export const DBRPProvider: FC<Props> = ({children, scope}) => {
       // to set local storage to an empty {}
       window.localStorage.setItem(DBRP_LOCAL_STORAGE_KEY, JSON.stringify({}))
     }
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const updateCache = (update: any): void => {
     dbrpCache[cacheKey] = {
@@ -117,6 +117,6 @@ export const DBRPProvider: FC<Props> = ({children, scope}) => {
         {children}
       </DBRPContext.Provider>
     ),
-    [loading, dbrps]
+    [loading, dbrps, children]
   )
 }


### PR DESCRIPTION
Closes #6637 

This PR adds the database / retention policy (DBRP) list for InfluxQL which is the equivalent of bucket list for Flux and SQL. It only allows a user to use InfluxQL in the script editor if the user's org has one or more DBRP mappings AND the org is powered by IOx.

All the work is behind the feature flag `influxqlUI`. 

To test on local remocal:
1) create DBRP mappings in your org ([instruction](https://github.com/influxdata/idpe/issues/17205)), and 
2) also make sure to turn on the following flags in your browser:
* `showOldDataExplorerInNewIOx`
* `newDataExplorer`
* `schemaComposition`

## Before

https://user-images.githubusercontent.com/14298407/223872771-5864b8aa-473f-4096-9efe-6080fa5fc5a5.mov


## After

https://user-images.githubusercontent.com/14298407/224354856-a0442bfb-aea1-4fdb-a10a-5df70130b14d.mov






### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
