### PR TITLE
fix: resolve incorrect display of 250 credit used

### DIFF
--- a/src/usage/context/usage.tsx
+++ b/src/usage/context/usage.tsx
@@ -218,11 +218,13 @@ export const UsageProvider: FC<Props> = React.memo(({children}) => {
         const currentDate = new Date()
         const secondsWith250Credit =
           currentDate.getTime() - new Date(paygCreditStartDate).getTime()
-        daysWith250Credit = Math.floor(secondsWith250Credit / secondsPerDay)
+        const creditDays = Math.floor(secondsWith250Credit / secondsPerDay)
 
-        if (daysWith250Credit <= 0 || isNaN(daysWith250Credit)) {
+        if (creditDays <= 0 || isNaN(creditDays)) {
           return
         }
+
+        daysWith250Credit = creditDays
       }
 
       vectors.forEach(vector_name => {

--- a/src/usage/context/usage.tsx
+++ b/src/usage/context/usage.tsx
@@ -210,9 +210,20 @@ export const UsageProvider: FC<Props> = React.memo(({children}) => {
       const vectors = ['storage_gb', 'writes_mb', 'reads_gb', 'query_count']
       const promises = []
 
+      const secondsPerDay = 1000 * 3600 * 24
+
+      const currentDate = new Date()
+      const secondsWith250Credit =
+        currentDate.getTime() - new Date(paygCreditStartDate).getTime()
+      const daysWith250Credit = Math.floor(secondsWith250Credit / secondsPerDay)
+
+      if (isNaN(daysWith250Credit)) {
+        return
+      }
+
       vectors.forEach(vector_name => {
         promises.push(
-          getUsage({vector_name, query: {range: `${PAYG_CREDIT_DAYS}d`}}).then(
+          getUsage({vector_name, query: {range: `${daysWith250Credit}d`}}).then(
             resp => {
               if (resp.status !== 200) {
                 throw new Error(resp.data.message)

--- a/src/usage/context/usage.tsx
+++ b/src/usage/context/usage.tsx
@@ -11,6 +11,7 @@ import {
   getUsageVectors,
   getUsageRateLimits,
 } from 'src/client/unityRoutes'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Constants
 import {PAYG_CREDIT_DAYS} from 'src/shared/constants'
@@ -222,8 +223,12 @@ export const UsageProvider: FC<Props> = React.memo(({children}) => {
       }
 
       vectors.forEach(vector_name => {
+        const usageDays = isFlagEnabled('credit250fix')
+          ? daysWith250Credit
+          : PAYG_CREDIT_DAYS
+
         promises.push(
-          getUsage({vector_name, query: {range: `${daysWith250Credit}d`}}).then(
+          getUsage({vector_name, query: {range: `${usageDays}d`}}).then(
             resp => {
               if (resp.status !== 200) {
                 throw new Error(resp.data.message)


### PR DESCRIPTION
This resolves a pending EAR in which the user is seeing a higher amount of 250 PAYG credit usage than expected. It required a backend change linked below so that more timeframes are available for usage queries. This should resolve the issue by scoping the query correctly to the timeframe in which the user has had a 250/30day credit for upgrading to PAYG. 

Deployed behind the `credit250fix` flag for now pending confirmation.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable
