### PR TITLE
feat: add operator token to onboarding wizard

### DIFF
--- a/src/onboarding/actions/index.ts
+++ b/src/onboarding/actions/index.ts
@@ -20,6 +20,7 @@ export type Action =
   | SetStepStatus
   | SetOrganizationID
   | SetBucketID
+  | SetToken
 
 interface SetSetupParams {
   type: 'SET_SETUP_PARAMS'
@@ -69,6 +70,16 @@ export const setBucketID = (bucketID: string): SetBucketID => ({
   payload: {bucketID},
 })
 
+interface SetToken {
+  type: 'SET_OPERATOR_TOKEN'
+  payload: {token: string}
+}
+
+export const setToken = (token: string): SetToken => ({
+  type: 'SET_OPERATOR_TOKEN',
+  payload: {token},
+})
+
 export const setupAdmin =
   (params: OnboardingRequest): AppThunk<Promise<boolean>> =>
   async dispatch => {
@@ -79,6 +90,8 @@ export const setupAdmin =
       if (response.status !== 201) {
         throw new Error(response.data.message)
       }
+
+      dispatch(setToken(response.data.auth.token))
 
       const {id: orgID} = response.data.org
       const {id: bucketID} = response.data.bucket

--- a/src/onboarding/actions/index.ts
+++ b/src/onboarding/actions/index.ts
@@ -5,6 +5,8 @@ import {get} from 'lodash'
 import {StepStatus} from 'src/shared/constants/wizard'
 import {SetupSuccess, SetupError} from 'src/shared/copy/notifications'
 
+import {CLOUD} from 'src/shared/constants'
+
 // Actions
 import {notify} from 'src/shared/actions/notifications'
 
@@ -91,7 +93,9 @@ export const setupAdmin =
         throw new Error(response.data.message)
       }
 
-      dispatch(setToken(response.data.auth.token))
+      if (!CLOUD) {
+        dispatch(setToken(response.data.auth.token))
+      }
 
       const {id: orgID} = response.data.org
       const {id: bucketID} = response.data.bucket

--- a/src/onboarding/components/CompletionStep.test.tsx
+++ b/src/onboarding/components/CompletionStep.test.tsx
@@ -15,6 +15,7 @@ const setup = (override = {}) => {
     ...defaultOnboardingStepProps,
     orgID: '',
     bucketID: '',
+    token: '',
     ...override,
   }
 

--- a/src/onboarding/components/CompletionStep.tsx
+++ b/src/onboarding/components/CompletionStep.tsx
@@ -74,22 +74,24 @@ class CompletionStep extends PureComponent<Props> {
           <DapperScrollbars autoHide={false}>
             <div className="wizard-step--scroll-content">
               <h3 className="wizard-step--title">You are ready to go!</h3>
-              <FlexBox
-                direction={FlexDirection.Column}
-                margin={ComponentSize.Large}
-                alignItems={AlignItems.Stretch}
-              >
-                <Alert
-                  icon={IconFont.AlertTriangle}
-                  color={ComponentColor.Primary}
+              {CLOUD && (
+                <FlexBox
+                  direction={FlexDirection.Column}
+                  margin={ComponentSize.Large}
+                  alignItems={AlignItems.Stretch}
                 >
-                  <p>Make sure to copy your operator API token now.</p>
-                  This token enables superuser privileges like creating users,
-                  orgs, etc. You won't be able to see it again!
-                </Alert>
+                  <Alert
+                    icon={IconFont.AlertTriangle}
+                    color={ComponentColor.Primary}
+                  >
+                    <p>Make sure to copy your operator API token now.</p>
+                    This token enables superuser privileges like creating users,
+                    orgs, etc. You won't be able to see it again!
+                  </Alert>
 
-                <CodeSnippet text={this.props.token} type="Token" />
-              </FlexBox>
+                  <CodeSnippet text={this.props.token} type="Token" />
+                </FlexBox>
+              )}
               <h5 className="wizard-step--sub-title">
                 Your InfluxDB has 1 organization, 1 user, and 1 bucket.
               </h5>

--- a/src/onboarding/components/CompletionStep.tsx
+++ b/src/onboarding/components/CompletionStep.tsx
@@ -7,6 +7,15 @@ import ResourceFetcher from 'src/shared/components/resource_fetcher'
 import CompletionAdvancedButton from 'src/onboarding/components/CompletionAdvancedButton'
 import CompletionQuickStartButton from 'src/onboarding/components/CompletionQuickStartButton'
 
+import {
+  FlexBox,
+  Alert,
+  IconFont,
+  AlignItems,
+  FlexDirection,
+} from '@influxdata/clockface'
+import CodeSnippet from 'src/shared/components/CodeSnippet'
+
 // Constants
 import {
   QuickstartScraperCreationSuccess,
@@ -43,6 +52,7 @@ if (!CLOUD) {
 interface Props extends OnboardingStepProps {
   orgID: string
   bucketID: string
+  token: string
 }
 
 @ErrorHandling
@@ -64,6 +74,22 @@ class CompletionStep extends PureComponent<Props> {
           <DapperScrollbars autoHide={false}>
             <div className="wizard-step--scroll-content">
               <h3 className="wizard-step--title">You are ready to go!</h3>
+              <FlexBox
+                direction={FlexDirection.Column}
+                margin={ComponentSize.Large}
+                alignItems={AlignItems.Stretch}
+              >
+                <Alert
+                  icon={IconFont.AlertTriangle}
+                  color={ComponentColor.Primary}
+                >
+                  <p>Make sure to copy your operator API token now.</p>
+                  This token enables superuser privileges like creating users,
+                  orgs, etc. You won't be able to see it again!
+                </Alert>
+
+                <CodeSnippet text={this.props.token} type="Token" />
+              </FlexBox>
               <h5 className="wizard-step--sub-title">
                 Your InfluxDB has 1 organization, 1 user, and 1 bucket.
               </h5>

--- a/src/onboarding/components/CompletionStep.tsx
+++ b/src/onboarding/components/CompletionStep.tsx
@@ -74,7 +74,7 @@ class CompletionStep extends PureComponent<Props> {
           <DapperScrollbars autoHide={false}>
             <div className="wizard-step--scroll-content">
               <h3 className="wizard-step--title">You are ready to go!</h3>
-              {CLOUD && (
+              {!CLOUD && (
                 <FlexBox
                   direction={FlexDirection.Column}
                   margin={ComponentSize.Large}

--- a/src/onboarding/components/OnboardingStepSwitcher.tsx
+++ b/src/onboarding/components/OnboardingStepSwitcher.tsx
@@ -18,6 +18,7 @@ interface Props {
   onSetupAdmin: any
   orgID: string
   bucketID: string
+  token: string
 }
 
 @ErrorHandling
@@ -27,6 +28,7 @@ class OnboardingStepSwitcher extends PureComponent<Props> {
       currentStepIndex,
       orgID,
       bucketID,
+      token,
       onboardingStepProps,
       onSetupAdmin,
     } = this.props
@@ -42,6 +44,7 @@ class OnboardingStepSwitcher extends PureComponent<Props> {
         return (
           <CompletionStep
             {...onboardingStepProps}
+            token={token}
             orgID={orgID}
             bucketID={bucketID}
           />

--- a/src/onboarding/containers/OnboardingWizard.tsx
+++ b/src/onboarding/containers/OnboardingWizard.tsx
@@ -66,8 +66,14 @@ class OnboardingWizard extends PureComponent<Props> {
   }
 
   public render() {
-    const {currentStepIndex, orgID, bucketID, setupParams, onSetupAdmin} =
-      this.props
+    const {
+      currentStepIndex,
+      orgID,
+      bucketID,
+      token,
+      setupParams,
+      onSetupAdmin,
+    } = this.props
 
     return (
       <WizardFullScreen>
@@ -81,6 +87,7 @@ class OnboardingWizard extends PureComponent<Props> {
               onSetupAdmin={onSetupAdmin}
               orgID={orgID}
               bucketID={bucketID}
+              token={token}
             />
           </div>
         </div>
@@ -148,12 +155,13 @@ class OnboardingWizard extends PureComponent<Props> {
 }
 
 const mstp = ({
-  onboarding: {stepStatuses, setupParams, orgID, bucketID},
+  onboarding: {stepStatuses, setupParams, orgID, bucketID, token},
 }: AppState) => ({
   stepStatuses,
   setupParams,
   orgID,
   bucketID,
+  token,
 })
 
 const mdtp = {

--- a/src/onboarding/reducers/index.ts
+++ b/src/onboarding/reducers/index.ts
@@ -10,6 +10,7 @@ export interface OnboardingState {
   setupParams: OnboardingRequest
   orgID: string
   bucketID: string
+  token: string
 }
 
 const INITIAL_STATE: OnboardingState = {
@@ -17,6 +18,7 @@ const INITIAL_STATE: OnboardingState = {
   setupParams: null,
   orgID: '',
   bucketID: '',
+  token: '',
 }
 
 export default (state = INITIAL_STATE, action: Action): OnboardingState => {
@@ -31,6 +33,8 @@ export default (state = INITIAL_STATE, action: Action): OnboardingState => {
       return {...state, orgID: action.payload.orgID}
     case 'SET_ONBOARDING_BUCKET_ID':
       return {...state, bucketID: action.payload.bucketID}
+    case 'SET_OPERATOR_TOKEN':
+      return {...state, token: action.payload.token}
     default:
       return state
   }


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/24082

<!-- Describe your proposed changes here. -->
<!-- Including screenshots or visuals is very helpful - a picture is worth a thousand words. -->

After updating the UI in OSS, we lost the ability to see the operator token after creation. This causes a lot of headache and confusion for users.

I have simply added the token to the final page in the onboarding wizard.

![image](https://user-images.githubusercontent.com/26460069/224732923-491771f5-092f-4daa-bb9b-5cbbcc01cef8.png)


### Checklist

Authors and Reviewer(s), please verify the following:

- [ ] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [ ] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
