### PR TITLE
chore: remove ecommerce from codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # Changes to any file in this repo require approval from a member of the InfluxData ui-team
 
-*   @influxdata/ui-team @influxdata/ecommerce
+*   @influxdata/ui-team


### PR DESCRIPTION
Removes ecommerce team from codeowners. 

This was added as a failsafe around vacations and at a point where it wasn't clear how many ui engineers would be around to approve PRs, but no longer necessary and the extra ping to the former ecommerce team isn't worth the disruption.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - no
