### PR TITLE
feat: make InfluxQL available to TSM orgs

### DIFF
--- a/src/dataExplorer/components/SaveAsScript.tsx
+++ b/src/dataExplorer/components/SaveAsScript.tsx
@@ -1,4 +1,9 @@
+// Libraries
 import React, {FC, useContext, useCallback, ChangeEvent, useState} from 'react'
+import {useHistory} from 'react-router-dom'
+import {useDispatch, useSelector} from 'react-redux'
+
+// Components
 import {
   Button,
   ButtonShape,
@@ -13,30 +18,37 @@ import {
   Overlay,
   SquareButton,
 } from '@influxdata/clockface'
-import {useHistory} from 'react-router-dom'
+import OpenScript from 'src/dataExplorer/components/OpenScript'
+import {DeleteScript} from 'src/dataExplorer/components/DeleteScript'
+import {LanguageType} from 'src/dataExplorer/components/resources'
+import {SCRIPT_EDITOR_PARAMS} from 'src/dataExplorer/components/resources'
+import CopyToClipboard from 'src/shared/components/CopyToClipboard'
+
+// Contexts
 import {QueryContext} from 'src/shared/contexts/query'
 import {ResultsContext} from 'src/dataExplorer/context/results'
 import {PersistanceContext} from 'src/dataExplorer/context/persistance'
+import {ResultsViewContext} from 'src/dataExplorer/context/resultsView'
+
+// Types
 import {RemoteDataState} from 'src/types'
-import './SaveAsScript.scss'
 import {OverlayType} from './ScriptQueryBuilder'
-import {useDispatch, useSelector} from 'react-redux'
+
+// Utils
 import {notify} from 'src/shared/actions/notifications'
 import {
   scriptSaveFail,
   scriptSaveSuccess,
 } from 'src/shared/copy/notifications/categories/scripts'
 import {getOrg, isOrgIOx} from 'src/organizations/selectors'
-import OpenScript from 'src/dataExplorer/components/OpenScript'
-import {DeleteScript} from 'src/dataExplorer/components/DeleteScript'
-import {LanguageType} from 'src/dataExplorer/components/resources'
-import {SCRIPT_EDITOR_PARAMS} from 'src/dataExplorer/components/resources'
-import CopyToClipboard from 'src/shared/components/CopyToClipboard'
 import {
   copyToClipboardFailed,
   copyToClipboardSuccess,
 } from 'src/shared/copy/notifications'
-import {ResultsViewContext} from 'src/dataExplorer/context/resultsView'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+
+import './SaveAsScript.scss'
+
 interface Props {
   language: LanguageType
   onClose: () => void
@@ -99,7 +111,7 @@ const SaveAsScript: FC<Props> = ({language, onClose, setOverlayType, type}) => {
     setResult(null)
     clearViewOptions()
 
-    if (isIoxOrg) {
+    if (isIoxOrg || isFlagEnabled('influxqlUI')) {
       history.replace(
         `/orgs/${org.id}/data-explorer/from/script?language=${language}&${SCRIPT_EDITOR_PARAMS}`
       )

--- a/src/dataExplorer/components/ScriptQueryBuilder.tsx
+++ b/src/dataExplorer/components/ScriptQueryBuilder.tsx
@@ -18,7 +18,7 @@ import {
   ComponentStatus,
 } from '@influxdata/clockface'
 import {ResultsPane} from 'src/dataExplorer/components/ResultsPane'
-import Sidebar from 'src/dataExplorer/components/Sidebar'
+import {Sidebar} from 'src/dataExplorer/components/Sidebar'
 import {Schema} from 'src/dataExplorer/components/Schema'
 import SaveAsScript from 'src/dataExplorer/components/SaveAsScript'
 
@@ -39,7 +39,7 @@ import {
 import {QueryContext} from 'src/shared/contexts/query'
 import {DBRPContext, DBRPProvider} from 'src/shared/contexts/dbrps'
 
-// Utilies
+// Utils
 import {getOrg, isOrgIOx} from 'src/organizations/selectors'
 import {SCRIPT_EDITOR_PARAMS} from 'src/dataExplorer/components/resources'
 import {selectIsNewIOxOrg} from 'src/shared/selectors/app'
@@ -126,6 +126,91 @@ const ScriptQueryBuilder: FC = () => {
   const filterOutFluxInIOx = option =>
     isNewIOxOrg ? option !== LanguageType.FLUX : true
 
+  const menuIOx = (onCollapse: () => void) => (
+    <Dropdown.Menu onCollapse={onCollapse}>
+      {[LanguageType.FLUX, LanguageType.SQL]
+        .filter(filterOutFluxInIOx)
+        .map(option => (
+          <Dropdown.Item
+            className={`script-dropdown__${option}`}
+            key={option}
+            onClick={() => handleSelectDropdown(option)}
+            selected={resource?.language === option}
+            testID={`script-dropdown__${option}`}
+          >
+            {option}
+          </Dropdown.Item>
+        ))}
+      {isFlagEnabled('influxqlUI') && hasDBRPs() ? (
+        <Dropdown.Item
+          className={`script-dropdown__${LanguageType.INFLUXQL}`}
+          key={LanguageType.INFLUXQL}
+          onClick={() => handleSelectDropdown(LanguageType.INFLUXQL)}
+          selected={resource?.language === LanguageType.INFLUXQL}
+          testID={`script-dropdown__${LanguageType.INFLUXQL}`}
+        >
+          {LanguageType.INFLUXQL}
+        </Dropdown.Item>
+      ) : null}
+    </Dropdown.Menu>
+  )
+
+  const menuTSM = (onCollapse: () => void) => (
+    <Dropdown.Menu onCollapse={onCollapse}>
+      {[LanguageType.FLUX].map(option => (
+        <Dropdown.Item
+          className={`script-dropdown__${option}`}
+          key={option}
+          onClick={() => handleSelectDropdown(option)}
+          selected={resource?.language === option}
+          testID={`script-dropdown__${option}`}
+        >
+          {option}
+        </Dropdown.Item>
+      ))}
+      {isFlagEnabled('influxqlUI') && hasDBRPs() ? (
+        <Dropdown.Item
+          className={`script-dropdown__${LanguageType.INFLUXQL}`}
+          key={LanguageType.INFLUXQL}
+          onClick={() => handleSelectDropdown(LanguageType.INFLUXQL)}
+          selected={resource?.language === LanguageType.INFLUXQL}
+          testID={`script-dropdown__${LanguageType.INFLUXQL}`}
+        >
+          {LanguageType.INFLUXQL}
+        </Dropdown.Item>
+      ) : null}
+    </Dropdown.Menu>
+  )
+
+  const button = (active: boolean, onClick) => (
+    <Dropdown.Button
+      active={active}
+      onClick={onClick}
+      testID="script-query-builder--new-script"
+    >
+      <>
+        <Icon glyph={IconFont.Plus_New} />
+        &nbsp;New Script
+      </>
+    </Dropdown.Button>
+  )
+
+  const tsmNewScriptDropDown =
+    isFlagEnabled('influxqlUI') && hasDBRPs() ? (
+      <Dropdown
+        menu={menuTSM}
+        button={button}
+        testID="select-option-dropdown"
+      />
+    ) : (
+      <Button
+        onClick={handleNewScript}
+        text="New Script"
+        icon={IconFont.Plus_New}
+        testID="script-query-builder--new-script"
+      />
+    )
+
   return (
     <EditorProvider>
       <SidebarProvider>
@@ -154,59 +239,12 @@ const ScriptQueryBuilder: FC = () => {
               <div style={{display: 'flex'}}>
                 {isIoxOrg ? (
                   <Dropdown
-                    menu={onCollapse => (
-                      <Dropdown.Menu onCollapse={onCollapse}>
-                        {[LanguageType.FLUX, LanguageType.SQL]
-                          .filter(filterOutFluxInIOx)
-                          .map(option => (
-                            <Dropdown.Item
-                              className={`script-dropdown__${option}`}
-                              key={option}
-                              onClick={() => handleSelectDropdown(option)}
-                              selected={resource?.language === option}
-                              testID={`script-dropdown__${option}`}
-                            >
-                              {option}
-                            </Dropdown.Item>
-                          ))}
-                        {isFlagEnabled('influxqlUI') && hasDBRPs() ? (
-                          <Dropdown.Item
-                            className={`script-dropdown__${LanguageType.INFLUXQL}`}
-                            key={LanguageType.INFLUXQL}
-                            onClick={() =>
-                              handleSelectDropdown(LanguageType.INFLUXQL)
-                            }
-                            selected={
-                              resource?.language === LanguageType.INFLUXQL
-                            }
-                            testID={`script-dropdown__${LanguageType.INFLUXQL}`}
-                          >
-                            {LanguageType.INFLUXQL}
-                          </Dropdown.Item>
-                        ) : null}
-                      </Dropdown.Menu>
-                    )}
-                    button={(active, onClick) => (
-                      <Dropdown.Button
-                        active={active}
-                        onClick={onClick}
-                        testID="script-query-builder--new-script"
-                      >
-                        <>
-                          <Icon glyph={IconFont.Plus_New} />
-                          &nbsp;New Script
-                        </>
-                      </Dropdown.Button>
-                    )}
+                    menu={menuIOx}
+                    button={button}
                     testID="select-option-dropdown"
                   />
                 ) : (
-                  <Button
-                    onClick={handleNewScript}
-                    text="New Script"
-                    icon={IconFont.Plus_New}
-                    testID="script-query-builder--new-script"
-                  />
+                  tsmNewScriptDropDown
                 )}
                 {CLOUD && (
                   <>

--- a/src/dataExplorer/components/Sidebar.tsx
+++ b/src/dataExplorer/components/Sidebar.tsx
@@ -1,5 +1,4 @@
 import React, {FC, useContext, useCallback} from 'react'
-import {useSelector} from 'react-redux'
 
 // Components
 import SelectorTitle from 'src/dataExplorer/components/SelectorTitle'
@@ -18,7 +17,6 @@ import {
 import {SidebarContext} from 'src/dataExplorer/context/sidebar'
 import {EditorContext} from 'src/shared/contexts/editor'
 import {PersistanceContext} from 'src/dataExplorer/context/persistance'
-import {isOrgIOx} from 'src/organizations/selectors'
 
 // Types
 import {FluxFunction, FluxToolbarFunction} from 'src/types'
@@ -38,7 +36,6 @@ const Sidebar: FC = () => {
   const {injectFunction} = useContext(EditorContext)
   const {visible, menu, clear} = useContext(SidebarContext)
   const {resource} = useContext(PersistanceContext)
-  const isIoxOrg = useSelector(isOrgIOx)
 
   const inject = useCallback(
     (fn: FluxFunction | FluxToolbarFunction) => {
@@ -125,7 +122,7 @@ const Sidebar: FC = () => {
       justifyContent={JustifyContent.FlexStart}
       className="container-right-side-bar"
     >
-      {isIoxOrg && shouldNotShowSidebar ? null : (
+      {shouldNotShowSidebar ? null : (
         <>
           {resultOptions}
           {fluxLibrary}
@@ -135,4 +132,4 @@ const Sidebar: FC = () => {
   )
 }
 
-export default Sidebar
+export {Sidebar}


### PR DESCRIPTION
Closes #6652

This PR allows TSM users to use InfluxQL in the script editor if they already have one or more DBRP mappings

All the work is behind the feature flag `influxqlUI`. 

To test on local remocal:
1) create DBRP mappings in your org ([instruction](https://github.com/influxdata/idpe/issues/17205)), and 
2) also make sure to turn on the following flags in your browser:
* `showOldDataExplorerInNewIOx`
* `newDataExplorer`
* `schemaComposition`

## Before

<img width="1494" alt="Screen Shot 2023-03-15 at 10 24 41 AM" src="https://user-images.githubusercontent.com/14298407/225365946-cb7d7e7d-ecde-4e18-b072-39145a861794.png">

## After

<img width="1491" alt="Screen Shot 2023-03-15 at 10 26 05 AM" src="https://user-images.githubusercontent.com/14298407/225366011-9c576bdf-657c-444d-bac3-eb5c1fa31952.png">

https://user-images.githubusercontent.com/14298407/225366054-bd894b5c-a603-4307-991d-c8e26edaa58c.mov


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
