### PR TITLE
chore: remove feature flag `newDataExplorer`

### DIFF
--- a/cypress/e2e/cloud/explorer.test.ts
+++ b/cypress/e2e/cloud/explorer.test.ts
@@ -22,20 +22,14 @@ describe('DataExplorer', () => {
   beforeEach(() => {
     cy.mockIsCloud2Org().then(() =>
       cy.signinWithoutUserReprovision().then(() =>
-        cy
-          .setFeatureFlags({
-            newDataExplorer: true,
+        cy.get('@org').then(({id}: Organization) => {
+          return cy.fixture('routes').then(({orgs, explorer}) => {
+            cy.visit(`${orgs}/${id}${explorer}`)
+            cy.getByTestID('tree-nav').should('be.visible')
+            cy.switchToDataExplorer('old')
+            cy.getByTestID('switch-to-script-editor').should('exist')
           })
-          .then(() =>
-            cy.get('@org').then(({id}: Organization) => {
-              return cy.fixture('routes').then(({orgs, explorer}) => {
-                cy.visit(`${orgs}/${id}${explorer}`)
-                cy.getByTestID('tree-nav').should('be.visible')
-                cy.switchToDataExplorer('old')
-                cy.getByTestID('switch-to-script-editor').should('exist')
-              })
-            })
-          )
+        })
       )
     )
   })

--- a/cypress/e2e/cloud/globalHeader.test.ts
+++ b/cypress/e2e/cloud/globalHeader.test.ts
@@ -195,6 +195,7 @@ describe('global header', () => {
       // Alert will appear in global header on any page (like data explorer)
       // that has <LimitChecker />, which displays cardinality alerts.
       cy.visit(`/orgs/${idpeOrgID}/data-explorer`)
+      cy.switchToDataExplorer('old')
     }
 
     it('shows a cardinality limit alert for TSM orgs if cardinality limits are exceeded', () => {

--- a/cypress/e2e/oss/explorer.test.ts
+++ b/cypress/e2e/oss/explorer.test.ts
@@ -26,19 +26,13 @@ describe('DataExplorer', () => {
   beforeEach(() => {
     cy.flush().then(() =>
       cy.signin().then(() =>
-        cy
-          .setFeatureFlags({
-            newDataExplorer: true,
+        cy.get('@org').then(({id}: Organization) => {
+          cy.fixture('routes').then(({orgs, explorer}) => {
+            cy.visit(`${orgs}/${id}${explorer}`)
+            cy.getByTestID('tree-nav').should('be.visible')
+            cy.switchToDataExplorer('old')
           })
-          .then(() =>
-            cy.get('@org').then(({id}: Organization) => {
-              cy.fixture('routes').then(({orgs, explorer}) => {
-                cy.visit(`${orgs}/${id}${explorer}`)
-                cy.getByTestID('tree-nav').should('be.visible')
-                cy.switchToDataExplorer('old')
-              })
-            })
-          )
+        })
       )
     )
   })

--- a/cypress/e2e/shared/editor.test.ts
+++ b/cypress/e2e/shared/editor.test.ts
@@ -101,7 +101,6 @@ describe('Editor+LSP communication', () => {
       cy.flush()
       cy.signin()
       cy.setFeatureFlags({
-        newDataExplorer: true,
         saveAsScript: true,
         enableFluxInScriptBuilder: true,
       })

--- a/cypress/e2e/shared/explorer.queries.graphs.test.ts
+++ b/cypress/e2e/shared/explorer.queries.graphs.test.ts
@@ -23,6 +23,7 @@ describe('writing queries and making graphs using Data Explorer', () => {
                 route = `${orgs}/${id}${explorer}`
                 cy.visit(route)
                 cy.getByTestID('tree-nav').should('be.visible')
+                cy.switchToDataExplorer('old')
               })
             })
           })

--- a/cypress/e2e/shared/explorer.queries.graphs.test.ts
+++ b/cypress/e2e/shared/explorer.queries.graphs.test.ts
@@ -303,6 +303,7 @@ describe('writing queries and making graphs using Data Explorer', () => {
       cy.get<Organization>('@org').then(({id, name}) => {
         cy.createBucket(id, name, 'newBucket')
       })
+      cy.reload()
       cy.get<string>('@defaultBucketListSelector').then(
         (defaultBucketListSelector: string) => {
           cy.getByTestID(defaultBucketListSelector).should('be.visible')

--- a/cypress/e2e/shared/explorer.saving.test.ts
+++ b/cypress/e2e/shared/explorer.saving.test.ts
@@ -19,6 +19,7 @@ describe('Data Explorer saving', () => {
               cy.fixture('routes').then(({orgs}) => {
                 cy.visit(`${orgs}/${id}/data-explorer`)
                 cy.getByTestID('tree-nav').should('be.visible')
+                cy.switchToDataExplorer('old')
               })
             })
           })

--- a/cypress/e2e/shared/explorer.test.ts
+++ b/cypress/e2e/shared/explorer.test.ts
@@ -21,6 +21,7 @@ describe('Data Explorer - general functionality - TSM', () => {
                 route = `${orgs}/${id}${explorer}`
                 cy.visit(route)
                 cy.getByTestID('tree-nav').should('be.visible')
+                cy.switchToDataExplorer('old')
               })
             })
           })

--- a/cypress/e2e/shared/explorer.timerange.test.ts
+++ b/cypress/e2e/shared/explorer.timerange.test.ts
@@ -13,6 +13,7 @@ describe('Data Explorer Time Range', () => {
               cy.fixture('routes').then(({orgs}) => {
                 cy.visit(`${orgs}/${id}/data-explorer`)
                 cy.getByTestID('tree-nav').should('be.visible')
+                cy.switchToDataExplorer('old')
               })
             })
           )

--- a/cypress/e2e/shared/explorerVisualizations.test.ts
+++ b/cypress/e2e/shared/explorerVisualizations.test.ts
@@ -34,7 +34,6 @@ describe('visualizations', () => {
       cy.signinWithoutUserReprovision().then(() =>
         cy
           .setFeatureFlags({
-            newDataExplorer: true,
             showVariablesInNewIOx: true,
           })
           .then(() => {

--- a/cypress/e2e/shared/legends.test.ts
+++ b/cypress/e2e/shared/legends.test.ts
@@ -38,6 +38,7 @@ describe('Legends', () => {
         cy.fixture('routes').then(({orgs, explorer}) => {
           cy.visit(`${orgs}/${id}${explorer}`)
           cy.getByTestID('tree-nav').should('be.visible')
+          cy.switchToDataExplorer('old')
         })
       })
     })

--- a/cypress/e2e/shared/loadDataSources.test.ts
+++ b/cypress/e2e/shared/loadDataSources.test.ts
@@ -12,9 +12,6 @@ describe('Load Data Sources', () => {
   beforeEach(() => {
     cy.flush()
     cy.signin()
-    cy.setFeatureFlags({
-      newDataExplorer: true,
-    })
     cy.get('@org').then(({id}: Organization) =>
       cy.fixture('routes').then(({orgs}) => {
         cy.visit(`${orgs}/${id}/load-data/sources`)

--- a/cypress/e2e/shared/queryBuilder.test.ts
+++ b/cypress/e2e/shared/queryBuilder.test.ts
@@ -36,12 +36,15 @@ describe('The Query Builder', () => {
   })
 
   describe('from the Data Explorer', () => {
-    it('creates a query, edits it to add another field, then views its results with pride and satisfaction', () => {
+    beforeEach(() => {
       cy.get('@org').then((org: Organization) => {
         cy.visit(`orgs/${org.id}/data-explorer`)
         cy.getByTestID('tree-nav')
+        cy.switchToDataExplorer('old')
       })
+    })
 
+    it('creates a query, edits it to add another field, then views its results with pride and satisfaction', () => {
       cy.contains('mem').click('right') // users sometimes click in random spots
       cy.contains('active').click('bottomLeft')
 
@@ -101,11 +104,6 @@ describe('The Query Builder', () => {
     })
 
     it('when it creates a query, the query has an aggregate window, clicking around aggregate window selections work', () => {
-      cy.get('@org').then((org: Organization) => {
-        cy.visit(`orgs/${org.id}/data-explorer`)
-        cy.getByTestID('tree-nav')
-      })
-
       cy.contains('mem').click('right') // users sometimes click in random spots
       cy.contains('active').click('bottomLeft')
 
@@ -143,11 +141,6 @@ describe('The Query Builder', () => {
     })
 
     it('can create a bucket from the buckets list', () => {
-      cy.get('@org').then((org: Organization) => {
-        cy.visit(`orgs/${org.id}/data-explorer`)
-        cy.getByTestID('tree-nav')
-      })
-
       const newBucketName = '٩(｡•́‿•̀｡)۶'
 
       cy.getByTestID('selector-list add-bucket').click()
@@ -169,6 +162,7 @@ describe('The Query Builder', () => {
       cy.get('@org').then((org: Organization) => {
         cy.visit(`orgs/${org.id}/data-explorer`)
         cy.getByTestID('tree-nav')
+        cy.switchToDataExplorer('old')
       })
 
       cy.contains('mem').click('left')

--- a/cypress/e2e/shared/scriptQueryBuilder.results.test.ts
+++ b/cypress/e2e/shared/scriptQueryBuilder.results.test.ts
@@ -234,7 +234,6 @@ describe('Script Builder', () => {
       describe('for larger payloads', () => {
         beforeEach(() => {
           cy.setFeatureFlags({
-            newDataExplorer: true,
             enableFluxInScriptBuilder: true,
             dataExplorerCsvLimit: 10000 as any,
           })

--- a/cypress/e2e/shared/simpleTable.test.ts
+++ b/cypress/e2e/shared/simpleTable.test.ts
@@ -14,6 +14,7 @@ describe('simple table interactions', () => {
       cy.get('@org').then(({id: orgID}: Organization) => {
         cy.fixture('routes').then(({orgs, explorer}) => {
           cy.visit(`${orgs}/${orgID}${explorer}`)
+          cy.switchToDataExplorer('old')
         })
         cy.getByTestID('tree-nav')
         cy.createBucket(orgID, name, simpleLarge)

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -943,7 +943,6 @@ export const scriptsLoginWithFlags = (flags): Cypress.Chainable<any> => {
         .setFeatureFlags({
           showOldDataExplorerInNewIOx: false,
           schemaComposition: true,
-          newDataExplorer: true,
           saveAsScript: true,
           enableFluxInScriptBuilder: true,
           ...flags,

--- a/src/dataExplorer/components/DataExplorerPage.tsx
+++ b/src/dataExplorer/components/DataExplorerPage.tsx
@@ -55,8 +55,7 @@ const DataExplorerPageHeader: FC = () => {
   const {resource, save} = useContext(PersistanceContext)
   const isNewIOxOrg = useSelector(selectIsNewIOxOrg)
   const shouldShowDataExplorerToggle =
-    isFlagEnabled('newDataExplorer') &&
-    (!isNewIOxOrg || isFlagEnabled('showOldDataExplorerInNewIOx'))
+    !isNewIOxOrg || isFlagEnabled('showOldDataExplorerInNewIOx')
 
   const history = useHistory()
   const dispatch = useDispatch()
@@ -84,11 +83,9 @@ const DataExplorerPageHeader: FC = () => {
     })
   }
 
-  const showNewExplorer = scriptQueryBuilder && isFlagEnabled('newDataExplorer')
-
   let pageTitle = <Page.Title title="Data Explorer" />
 
-  if (showNewExplorer && resource?.data?.hasOwnProperty('name')) {
+  if (scriptQueryBuilder && resource?.data?.hasOwnProperty('name')) {
     pageTitle = (
       <RenamablePageTitle
         onRename={handleRename}
@@ -103,7 +100,7 @@ const DataExplorerPageHeader: FC = () => {
     <Page.Header
       fullWidth={true}
       className={`${
-        showNewExplorer ? 'script-query-builder' : 'data-explorer'
+        scriptQueryBuilder ? 'script-query-builder' : 'data-explorer'
       }--header`}
       testID="data-explorer--header"
     >
@@ -133,8 +130,7 @@ const DataExplorerPage: FC = () => {
     useSelector(selectIsNewIOxOrg) &&
     !isFlagEnabled('showOldDataExplorerInNewIOx')
   const shouldShowNotebooks = useSelector(selectShouldShowNotebooks)
-  const shouldShowNewExplorer =
-    (scriptQueryBuilder && isFlagEnabled('newDataExplorer')) || isNewIOxOrg
+  const shouldShowNewExplorer = scriptQueryBuilder || isNewIOxOrg
 
   const shouldShowSaveAsButton =
     !useSelector(selectIsNewIOxOrg) ||


### PR DESCRIPTION
Closes #6544 

The feature flag `newDataExplorer` has been on for more than 6 months and working fine without any issue. This PR removes this feature flag in UI. Note that the majority of the code change is in cypress e2e test.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
