### PR TITLE
feat(ui): Add Blogs to Homepage

### DIFF
--- a/src/me/components/AnnouncementBlock.scss
+++ b/src/me/components/AnnouncementBlock.scss
@@ -7,24 +7,49 @@
 
   .announcement-block--type {
     display: inline-flex;
+    flex-direction: column;
+    justify-content: flex-start;
     align-self: stretch;
-    align-items: flex-start;
+    align-items: center;
+    color: $cf-grey-45;
 
     .announcement-block--type-icon {
-      color: $cf-grey-55;
       font-size: $cf-text-base-1;
       margin-top: $cf-space-2xs;
+      display: block;
+    }
+
+    .announcement-block--date {
+      display: block;
+      text-align: center;
+      font-size: $cf-text-base--1;
+      line-height: $cf-text-base-1;
+      margin-top: $cf-space-2xs;
+      text-transform: uppercase;
+      font-weight: bold;
     }
   }
 
   .announcement-block--panel {
     .announcement-block--panel-header {
       padding: $cf-space-2xs;
-      color: $cf-grey-95;
+
+      h4 {
+        color: $cf-grey-85;
+
+        a:link,
+        a:visited {
+          color: $cf-grey-85;
+        }
+
+        a:hover {
+          color: $c-laser;
+        }
+      }
     }
 
     .announcement-block--panel-body {
-      color: $cf-grey-55;
+      color: $cf-grey-45;
     }
 
     .announcement-block--panel-footer {

--- a/src/me/components/AnnouncementBlock.tsx
+++ b/src/me/components/AnnouncementBlock.tsx
@@ -2,8 +2,6 @@ import React, {FC} from 'react'
 
 // Components
 import {
-  ButtonShape,
-  ComponentColor,
   ComponentSize,
   FlexBox,
   FlexDirection,
@@ -12,10 +10,12 @@ import {
   Icon,
   IconFont,
   JustifyContent,
-  LinkButton,
-  LinkTarget,
   Panel,
 } from '@influxdata/clockface'
+import {SafeBlankLink} from 'src/utils/SafeBlankLink'
+
+// Utils
+import {event} from 'src/cloud/utils/reporting'
 
 // Styles
 import 'src/me/components/AnnouncementBlock.scss'
@@ -24,6 +24,7 @@ interface OwnProps {
   body?: string | JSX.Element
   ctaLink?: string
   ctaText?: string
+  date?: string
   icon?: IconFont
   image?: JSX.Element
   title?: string
@@ -33,14 +34,20 @@ const AnnouncementBlock: FC<OwnProps> = ({
   body,
   ctaLink,
   ctaText,
+  date,
   icon = IconFont.Star,
   image,
   title,
 }) => {
+  const handleCtaClick = () => {
+    event(`announcementBlock.${title}.clicked`)
+  }
+
   return (
     <FlexBox direction={FlexDirection.Row} className="announcement-block">
       <FlexBox.Child basis={0} grow={0} className="announcement-block--type">
         <Icon glyph={icon} className="announcement-block--type-icon" />
+        <div className="announcement-block--date">{date}</div>
       </FlexBox.Child>
       <FlexBox.Child basis={0} grow={1}>
         <Panel
@@ -52,7 +59,13 @@ const AnnouncementBlock: FC<OwnProps> = ({
             className="announcement-block--panel-header"
           >
             {image}
-            <Heading element={HeadingElement.H4}>{title}</Heading>
+            <Heading element={HeadingElement.H4}>
+              {ctaLink ? (
+                <SafeBlankLink href={ctaLink}>{title}</SafeBlankLink>
+              ) : (
+                {title}
+              )}
+            </Heading>
           </Panel.Header>
           <Panel.Body
             size={ComponentSize.ExtraSmall}
@@ -66,15 +79,11 @@ const AnnouncementBlock: FC<OwnProps> = ({
               size={ComponentSize.ExtraSmall}
               className="announcement-block--panel-footer"
             >
-              <LinkButton
-                text={ctaText}
-                titleText={ctaText}
-                href={ctaLink}
-                target={LinkTarget.Blank}
-                size={ComponentSize.ExtraSmall}
-                shape={ButtonShape.Default}
-                color={ComponentColor.Tertiary}
-              />
+              <SafeBlankLink href={ctaLink} onClick={handleCtaClick}>
+                <div className="cf-button cf-button-xs cf-button-tertiary">
+                  <span className="cf-button-label">{ctaText}</span>
+                </div>
+              </SafeBlankLink>
             </Panel.Footer>
           )}
         </Panel>

--- a/src/me/components/BlogFeed.scss
+++ b/src/me/components/BlogFeed.scss
@@ -1,0 +1,5 @@
+.announcement-block--more-blogs {
+  width: 100%;
+  display: inline-flex;
+  justify-content: flex-end;
+}

--- a/src/me/components/BlogFeed.tsx
+++ b/src/me/components/BlogFeed.tsx
@@ -1,0 +1,145 @@
+// Libraries
+import React, {FC, useState, useEffect} from 'react'
+import moment from 'moment'
+
+// Components
+import {
+  Heading,
+  HeadingElement,
+  IconFont,
+  RemoteDataState,
+  SpinnerContainer,
+  TechnoSpinner,
+} from '@influxdata/clockface'
+import AnnouncementBlock from 'src/me/components/AnnouncementBlock'
+import {SafeBlankLink} from 'src/utils/SafeBlankLink'
+
+// Utils
+import {event} from 'src/cloud/utils/reporting'
+
+// Styles
+import 'src/me/components/BlogFeed.scss'
+
+// Expected structure of blog JSON data
+interface Author {
+  name: string
+  url: string
+  avatar?: string
+}
+
+interface BlogItem {
+  url: string
+  title: string
+  content_text: string
+  date_published: string
+  date_modified: string
+  authors?: Author[]
+  author: Author
+  tags: string[]
+  attachments: {
+    url: string
+    mime_type: string
+    title: string
+    size_in_bytes: number
+    duration_in_seconds: number
+  }[]
+}
+
+interface BlogFeedData {
+  version: string
+  title: string
+  home_page_url: string
+  feed_url: string
+  description: string
+  items: BlogItem[]
+  language: string
+}
+
+export const BlogFeed: FC = () => {
+  const [jsonData, setJsonData] = useState<BlogFeedData | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const abortController = new AbortController()
+
+    const fetchData = () => {
+      fetch('https://www.influxdata.com/blog/feed.json', {
+        signal: abortController.signal,
+        body: null,
+        method: 'GET',
+        mode: 'cors',
+      })
+        .then(response => {
+          if (!response.ok) {
+            throw new Error(
+              `Network response was not ok: ${response.statusText}`
+            )
+          }
+          return response.json()
+        })
+        .then((data: BlogFeedData) => {
+          setJsonData(data)
+        })
+        .catch(error => {
+          if (error.name === 'AbortError') {
+            return
+          }
+          setError(error.message)
+          console.error('Error fetching JSON data:', error)
+        })
+    }
+
+    fetchData()
+
+    return () => {
+      abortController.abort()
+    }
+  }, [])
+
+  const handleMoreBlogsClick = () => {
+    event('announcementBlock.moreBlogs.clicked')
+  }
+
+  if (error) {
+    return null
+  } else {
+    return (
+      <SpinnerContainer
+        loading={jsonData ? RemoteDataState.Done : RemoteDataState.Loading}
+        spinnerComponent={<TechnoSpinner />}
+      >
+        <Heading element={HeadingElement.H3}>Latest Blogs</Heading>
+        {jsonData &&
+          jsonData.items.slice(0, 2).map(item => (
+            <AnnouncementBlock
+              key={item.url}
+              icon={IconFont.Text_New}
+              date={moment(item.date_published).format(
+                `MMM
+              DD`
+              )}
+              body={
+                <p>
+                  {item.content_text}
+                  {` `}
+                  <SafeBlankLink href={item.url}>read more</SafeBlankLink>
+                </p>
+              }
+              title={item.title}
+              ctaLink={item.url}
+            />
+          ))}
+        <div className="announcement-block--more-blogs">
+          <SafeBlankLink
+            href="https://www.influxdata.com/blog/"
+            onClick={handleMoreBlogsClick}
+          >
+            <div className="cf-button cf-button-xs cf-button-tertiary">
+              <span className="cf-button-label">more blogs</span>
+            </div>
+          </SafeBlankLink>
+        </div>
+      </SpinnerContainer>
+    )
+  }
+}

--- a/src/me/components/Resources.tsx
+++ b/src/me/components/Resources.tsx
@@ -15,8 +15,9 @@ import {
   Heading,
   HeadingElement,
 } from '@influxdata/clockface'
-import AnnouncementCenter from './AnnouncementCenter'
-import AnnouncementBlock from './AnnouncementBlock'
+import AnnouncementCenter from 'src/me/components/AnnouncementCenter'
+import AnnouncementBlock from 'src/me/components/AnnouncementBlock'
+import {BlogFeed} from 'src/me/components/BlogFeed'
 import UsagePanel from 'src/me/components/UsagePanel'
 import DocSearchWidget from 'src/me/components/DocSearchWidget'
 import VersionInfo from 'src/shared/components/VersionInfo'
@@ -59,6 +60,7 @@ const ResourceLists: FC = () => {
             ctaText="Learn more"
             title="New time-series engine for InfluxDB"
           />
+          <BlogFeed />
         </AnnouncementCenter>
       ) : (
         <DocSearchWidget />


### PR DESCRIPTION
This PR brings a feed of the latest blog posts into the UI. The blogs are listed under the "What's New" section under the announcements. If the blogs fail to load, only the announcements are shown.

This is part of an effort to present users with pertinent information to help them make use of the platform. The devrels are writing good blog content about how to use the new database and much of that content isn't seen by current users and isn't in our documentation.

![image](https://user-images.githubusercontent.com/11937365/234713263-e897bd95-58ad-4b1d-bc97-6721642f37c9.png)

### Checklist

Authors and Reviewer(s), please verify the following:

- [ ] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [ ] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Feature flagged, if applicable
