### PR TITLE
feat(ui): rename iox to serverless

### DIFF
--- a/src/shared/components/VersionInfo.tsx
+++ b/src/shared/components/VersionInfo.tsx
@@ -13,9 +13,9 @@ import {VERSION, GIT_SHA, CLOUD} from 'src/shared/constants'
 import {isOrgIOx} from 'src/organizations/selectors'
 
 const VersionInfo: FC = () => {
-  const engineName = useSelector(isOrgIOx) ? 'IOx' : 'TSM'
+  const cloudEngine = useSelector(isOrgIOx) ? 'InfluxDB Cloud Serverless' : 'InfluxDB Cloud powered by TSM'
   const engineLink = useSelector(isOrgIOx)
-    ? 'https://docs.influxdata.com/influxdb/cloud-iox/'
+    ? 'https://docs.influxdata.com/influxdb/cloud-serverless/'
     : 'https://docs.influxdata.com/influxdb/latest/reference/internals/storage-engine/#time-structured-merge-tree-tsm'
 
   return (
@@ -23,7 +23,7 @@ const VersionInfo: FC = () => {
       {CLOUD ? (
         <div>
           <SafeBlankLink href={engineLink}>
-            InfluxDB Cloud powered by {engineName}
+            {cloudEngine}
           </SafeBlankLink>
           <br />
           Version {VERSION} {GIT_SHA && <code>({GIT_SHA.slice(0, 7)})</code>}

--- a/src/shared/components/VersionInfo.tsx
+++ b/src/shared/components/VersionInfo.tsx
@@ -13,7 +13,9 @@ import {VERSION, GIT_SHA, CLOUD} from 'src/shared/constants'
 import {isOrgIOx} from 'src/organizations/selectors'
 
 const VersionInfo: FC = () => {
-  const cloudEngine = useSelector(isOrgIOx) ? 'InfluxDB Cloud Serverless' : 'InfluxDB Cloud powered by TSM'
+  const cloudEngine = useSelector(isOrgIOx)
+    ? 'InfluxDB Cloud Serverless'
+    : 'InfluxDB Cloud powered by TSM'
   const engineLink = useSelector(isOrgIOx)
     ? 'https://docs.influxdata.com/influxdb/cloud-serverless/'
     : 'https://docs.influxdata.com/influxdb/latest/reference/internals/storage-engine/#time-structured-merge-tree-tsm'
@@ -22,9 +24,7 @@ const VersionInfo: FC = () => {
     <div className="version-info" data-testid="version-info">
       {CLOUD ? (
         <div>
-          <SafeBlankLink href={engineLink}>
-            {cloudEngine}
-          </SafeBlankLink>
+          <SafeBlankLink href={engineLink}>{cloudEngine}</SafeBlankLink>
           <br />
           Version {VERSION} {GIT_SHA && <code>({GIT_SHA.slice(0, 7)})</code>}
         </div>


### PR DESCRIPTION
Renames "InfluxDB Cloud powered by IOx" to "InfluxDB Cloud Serverless" and updates the docs link to `https://docs.influxdata.com/influxdb/cloud-serverless/`.

![image](https://user-images.githubusercontent.com/11937365/234716818-993220ff-11cc-4a66-9d47-1e4e2d799059.png)

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Feature flagged, if applicable
