### PR TITLE
feat(ui): cloud dedicated promo and css tweaks

### DIFF
--- a/src/homepageExperience/components/OptionAccordion/OptionAccordion.scss
+++ b/src/homepageExperience/components/OptionAccordion/OptionAccordion.scss
@@ -14,15 +14,7 @@
 }
 
 .option-accordion-header--icon {
-  background-color: $cf-grey-15;
-  display: inline-flex;
-  align-self: stretch;
-  align-items: center;
-  justify-content: center;
-
-  .cf-icon {
-    font-size: $cf-text-base-5;
-  }
+  display: none;
 }
 
 .option-accordion-header--content {
@@ -38,6 +30,12 @@
   color: $cf-grey-75;
 }
 
+.option-accordion-element--content {
+  flex-shrink: 0;
+  width: 100%;
+  margin-bottom: $cf-space-2xs;
+}
+
 .option-accordion-element--description {
   color: $cf-grey-55;
 }
@@ -50,6 +48,16 @@
 .option-accordion-element {
   display: inline-flex;
   justify-content: space-between;
+  position: relative;
+  flex-wrap: wrap;
+
+  .option-accordion--dropdown {
+    flex-wrap: wrap;
+
+    .cf-flex-box--child {
+      margin-bottom: $cf-space-2xs;
+    }
+  }
 }
 
 .option-accordion--dropdown {
@@ -57,5 +65,39 @@
 
   .cf-dropdown--button {
     min-width: $cf-space-3xl;
+  }
+}
+
+@media screen and (min-width: $cf-grid--breakpoint-md) {
+  .option-accordion-element--content {
+    flex-shrink: 1;
+    width: auto;
+    margin-bottom: auto;
+  }
+
+  .option-accordion-element {
+    flex-wrap: nowrap;
+
+    .option-accordion--dropdown {
+      flex-wrap: nowrap;
+
+      .cf-flex-box--child {
+        margin-bottom: 0;
+      }
+    }
+  }
+}
+
+@media screen and (min-width: $cf-grid--breakpoint-md) {
+  .option-accordion-header--icon {
+    background-color: $cf-grey-15;
+    display: inline-flex;
+    align-self: stretch;
+    align-items: center;
+    justify-content: center;
+
+    .cf-icon {
+      font-size: $cf-text-base-5;
+    }
   }
 }

--- a/src/homepageExperience/containers/HomepageContents.scss
+++ b/src/homepageExperience/containers/HomepageContents.scss
@@ -1,0 +1,3 @@
+.home-page--accordion-container {
+  width: 100%;
+}

--- a/src/homepageExperience/containers/HomepageContents.tsx
+++ b/src/homepageExperience/containers/HomepageContents.tsx
@@ -27,6 +27,9 @@ import {AddDataAccordion} from 'src/homepageExperience/components/OptionAccordio
 import {QueryDataAccordion} from 'src/homepageExperience/components/OptionAccordion/QueryDataAccordion'
 import {VisualizeAccordion} from 'src/homepageExperience/components/OptionAccordion/VisualizeAccordion'
 
+// Styles
+import 'src/homepageExperience/containers/HomepageContents.scss'
+
 export const HomepageContents: FC = () => {
   return (
     <Page titleTag={pageTitleSuffixer(['Get Started'])}>
@@ -42,7 +45,7 @@ export const HomepageContents: FC = () => {
       <Page.Contents fullWidth={false} scrollable={true}>
         <Grid>
           <Grid.Row>
-            <Grid.Column widthSM={Columns.Eight} widthMD={Columns.Nine}>
+            <Grid.Column widthSM={Columns.Eight}>
               <FlexBox
                 direction={FlexDirection.Column}
                 margin={ComponentSize.Large}
@@ -58,7 +61,7 @@ export const HomepageContents: FC = () => {
                     What would you like to do?
                   </Heading>
                 </FlexBox.Child>
-                <FlexBox.Child>
+                <FlexBox.Child className="home-page--accordion-container">
                   <ManageDatabasesAccordion />
                   <AddDataAccordion />
                   <QueryDataAccordion />
@@ -66,7 +69,7 @@ export const HomepageContents: FC = () => {
                 </FlexBox.Child>
               </FlexBox>
             </Grid.Column>
-            <Grid.Column widthSM={Columns.Four} widthMD={Columns.Three}>
+            <Grid.Column widthSM={Columns.Four}>
               {CLOUD ? (
                 <UsageProvider>
                   <CloudWidgets />

--- a/src/me/components/AnnouncementBlock.scss
+++ b/src/me/components/AnnouncementBlock.scss
@@ -1,5 +1,9 @@
 @import '@influxdata/clockface/dist/variables.scss';
 
+.announcement-center {
+  margin-top: $cf-space-m;
+}
+
 .announcement-block {
   .cf-panel {
     background-color: transparent;
@@ -11,7 +15,7 @@
     justify-content: flex-start;
     align-self: stretch;
     align-items: center;
-    color: $cf-grey-45;
+    color: $cf-grey-35;
 
     .announcement-block--type-icon {
       font-size: $cf-text-base-1;
@@ -49,11 +53,17 @@
     }
 
     .announcement-block--panel-body {
-      color: $cf-grey-45;
+      color: $cf-grey-55;
     }
 
     .announcement-block--panel-footer {
       border: none;
     }
+  }
+}
+
+@media screen and (min-width: $cf-grid--breakpoint-sm) {
+  .announcement-center {
+    margin-top: 0;
   }
 }

--- a/src/me/components/AnnouncementBlock.tsx
+++ b/src/me/components/AnnouncementBlock.tsx
@@ -9,6 +9,7 @@ import {
   HeadingElement,
   Icon,
   IconFont,
+  InfluxColors,
   JustifyContent,
   Panel,
 } from '@influxdata/clockface'
@@ -26,6 +27,7 @@ interface OwnProps {
   ctaText?: string
   date?: string
   icon?: IconFont
+  iconColor?: InfluxColors | string
   image?: JSX.Element
   title?: string
 }
@@ -36,6 +38,7 @@ export const AnnouncementBlock: FC<OwnProps> = ({
   ctaText,
   date,
   icon = IconFont.Star,
+  iconColor,
   image,
   title,
 }) => {
@@ -46,7 +49,11 @@ export const AnnouncementBlock: FC<OwnProps> = ({
   return (
     <FlexBox direction={FlexDirection.Row} className="announcement-block">
       <FlexBox.Child basis={0} grow={0} className="announcement-block--type">
-        <Icon glyph={icon} className="announcement-block--type-icon" />
+        <Icon
+          glyph={icon}
+          className="announcement-block--type-icon"
+          style={iconColor && {color: iconColor}}
+        />
         <div className="announcement-block--date">{date}</div>
       </FlexBox.Child>
       <FlexBox.Child basis={0} grow={1}>

--- a/src/me/components/AnnouncementCenter.tsx
+++ b/src/me/components/AnnouncementCenter.tsx
@@ -15,6 +15,7 @@ interface OwnProps {
 export const AnnouncementCenter: FC<OwnProps> = (props: OwnProps) => {
   return (
     <FlexBox
+      className="announcement-center"
       direction={FlexDirection.Column}
       alignItems={AlignItems.Stretch}
       margin={ComponentSize.Medium}

--- a/src/me/components/BlogFeed.scss
+++ b/src/me/components/BlogFeed.scss
@@ -1,4 +1,10 @@
-.announcement-block--more-blogs {
+@import '@influxdata/clockface/dist/variables.scss';
+
+.blog-feed--section-header {
+  margin-top: $cf-space-m;
+}
+
+.blog-feed--more-blogs {
   width: 100%;
   display: inline-flex;
   justify-content: flex-end;

--- a/src/me/components/BlogFeed.tsx
+++ b/src/me/components/BlogFeed.tsx
@@ -108,7 +108,12 @@ export const BlogFeed: FC = () => {
         loading={jsonData ? RemoteDataState.Done : RemoteDataState.Loading}
         spinnerComponent={<TechnoSpinner />}
       >
-        <Heading element={HeadingElement.H3}>Latest Blogs</Heading>
+        <Heading
+          element={HeadingElement.H3}
+          className="blog-feed--section-header"
+        >
+          Latest Blogs
+        </Heading>
         {jsonData &&
           jsonData.items.slice(0, 2).map(item => (
             <AnnouncementBlock
@@ -129,7 +134,7 @@ export const BlogFeed: FC = () => {
               ctaLink={item.url}
             />
           ))}
-        <div className="announcement-block--more-blogs">
+        <div className="blog-feed--more-blogs">
           <SafeBlankLink
             href="https://www.influxdata.com/blog/"
             onClick={handleMoreBlogsClick}

--- a/src/me/components/CloudWidgets.tsx
+++ b/src/me/components/CloudWidgets.tsx
@@ -14,6 +14,7 @@ import {
   AlignItems,
   Heading,
   HeadingElement,
+  InfluxColors,
 } from '@influxdata/clockface'
 import {AnnouncementCenter} from 'src/me/components/AnnouncementCenter'
 import {AnnouncementBlock} from 'src/me/components/AnnouncementBlock'
@@ -24,6 +25,7 @@ import VersionInfo from 'src/shared/components/VersionInfo'
 
 // Utils
 import {isOrgIOx} from 'src/organizations/selectors'
+import {SafeBlankLink} from 'src/utils/SafeBlankLink'
 
 export const CloudWidgets: FC = () => {
   const {paygCreditEnabled} = useContext(UsageContext)
@@ -44,21 +46,26 @@ export const CloudWidgets: FC = () => {
             body={
               <>
                 <p>
-                  InfluxDB Cloud is now powered by the new{' '}
-                  <strong>IOx High-Performance Time-Series Engine</strong>. What
-                  does this mean for you?
+                  Get the high performance of InfluxDB serverless in a
+                  single-tenant service with InfluxDB Cloud Dedicated. It lets
+                  you <strong>isolate your data</strong>,{' '}
+                  <strong>customize configurations</strong>,{' '}
+                  <strong>enable regulatory</strong> or{' '}
+                  <strong>data residency requirements</strong>, and{' '}
+                  <strong>ensure the capacity you need</strong> is always
+                  available.
                 </p>
-                <ul>
-                  <li>Improved performance</li>
-                  <li>Native support for SQL</li>
-                  <li>Unlimited series cardinality</li>
-                  <li>Low-cost cloud object storage</li>
-                </ul>
+                <p>
+                  <SafeBlankLink href="https://www.influxdata.com/contact-sales-cloud-dedicated/?utm_source=in-app&utm_medium=product&utm_campaign=2023-05-23_Webinar_Introducing-InfluxDB-Cloud-Dedicated">
+                    Join our webinar
+                  </SafeBlankLink>{' '}
+                  on May 23, 2023 8:00 am PT / 3:00 pm GMT to learn more.
+                </p>
               </>
             }
-            ctaLink="https://www.influxdata.com/cloud-iox-faq/"
-            ctaText="Learn more"
-            title="New time-series engine for InfluxDB"
+            ctaLink="https://www.influxdata.com/blog/introducing-influxdb-3-0/?utm_source=in-app&utm_medium=product&utm_campaign=2023-04-26_blog_Introducing-3-0_global"
+            iconColor={InfluxColors.Chartreuse}
+            title="Introducing InfluxDB Cloud Dedicated"
           />
           <BlogFeed />
         </AnnouncementCenter>


### PR DESCRIPTION
Swaps the announcement to one about Cloud Dedicated. Also adds some CSS tweaks for better responsiveness.

<img width="1840" alt="image" src="https://user-images.githubusercontent.com/11937365/235265673-ded8cdb2-706b-4267-a0d2-80aa8a31d7e6.png">

### Checklist

Authors and Reviewer(s), please verify the following:

- [ ] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [ ] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Feature flagged, if applicable
