### PR TITLE
feat(influxql): add time range into query composition

### DIFF
--- a/src/languageSupport/languages/influxql/connection.ts
+++ b/src/languageSupport/languages/influxql/connection.ts
@@ -15,7 +15,7 @@ import {LspRange} from 'src/languageSupport/languages/agnostic/types'
 
 // Utils
 import {DEFAULT_TIME_RANGE} from 'src/shared/constants/timeRanges'
-import {rangeToInterval as buildTimeRange} from 'src/shared/utils/sqlInterval'
+import {rangeToSQLInterval as buildTimeRange} from 'src/shared/utils/rangeToInterval'
 import {notify} from 'src/shared/actions/notifications'
 import {compositionEnded} from 'src/shared/copy/notifications'
 import {groupedTagValues} from 'src/languageSupport/languages/agnostic/utils'

--- a/src/languageSupport/languages/influxql/connection.ts
+++ b/src/languageSupport/languages/influxql/connection.ts
@@ -15,7 +15,7 @@ import {LspRange} from 'src/languageSupport/languages/agnostic/types'
 
 // Utils
 import {DEFAULT_TIME_RANGE} from 'src/shared/constants/timeRanges'
-import {rangeToSQLInterval as buildTimeRange} from 'src/shared/utils/rangeToInterval'
+import {rangeToInfluxQLInterval as buildTimeRange} from 'src/shared/utils/rangeToInterval'
 import {notify} from 'src/shared/actions/notifications'
 import {compositionEnded} from 'src/shared/copy/notifications'
 import {groupedTagValues} from 'src/languageSupport/languages/agnostic/utils'

--- a/src/languageSupport/languages/influxql/connection.ts
+++ b/src/languageSupport/languages/influxql/connection.ts
@@ -15,9 +15,11 @@ import {LspRange} from 'src/languageSupport/languages/agnostic/types'
 
 // Utils
 import {DEFAULT_TIME_RANGE} from 'src/shared/constants/timeRanges'
+import {rangeToInterval as buildTimeRange} from 'src/shared/utils/sqlInterval'
 import {notify} from 'src/shared/actions/notifications'
 import {compositionEnded} from 'src/shared/copy/notifications'
 import {groupedTagValues} from 'src/languageSupport/languages/agnostic/utils'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 export class ConnectionManager extends AgnosticConnectionManager {
   private _timeRange: TimeRange = DEFAULT_TIME_RANGE
@@ -53,19 +55,18 @@ export class ConnectionManager extends AgnosticConnectionManager {
       groupedTagValues(this._session.tagValues)
     )
       .map(([key, values]) =>
-        values.map((value: string) => `"${key}" = '${value}'`).join(' AND ')
+        values.map((value: string) => `"${key}" = '${value}'`).join(' OR ')
       )
       .join(' AND ')
 
-    // TODO: timestamp
+    const timeRangeExpr = buildTimeRange(this._timeRange)
 
     let whereClause: string[] = []
 
     if (this._session.tagValues.length > 0) {
-      // TODO: add timestamp
-      whereClause = ['WHERE', `(${tagValuesExpr})`]
+      whereClause = ['WHERE', timeRangeExpr, 'AND', `(${tagValuesExpr})`]
     } else {
-      // TODO: add timestamp
+      whereClause = ['WHERE', timeRangeExpr]
     }
 
     composition = composition.concat(whereClause)
@@ -178,7 +179,7 @@ export class ConnectionManager extends AgnosticConnectionManager {
       sessionCb,
       dispatch
     )
-    if (!shouldContinue) {
+    if (!shouldContinue || !isFlagEnabled('schemaComposition')) {
       return
     }
 

--- a/src/languageSupport/languages/sql/connection.ts
+++ b/src/languageSupport/languages/sql/connection.ts
@@ -10,7 +10,7 @@ import {SelectableDurationTimeRange, TimeRange} from 'src/types'
 
 // Utils
 import {DEFAULT_TIME_RANGE} from 'src/shared/constants/timeRanges'
-import {rangeToInterval as buildTimeRange} from 'src/shared/utils/sqlInterval'
+import {rangeToSQLInterval as buildTimeRange} from 'src/shared/utils/rangeToInterval'
 import {notify} from 'src/shared/actions/notifications'
 import {compositionEnded} from 'src/shared/copy/notifications'
 import {groupedTagValues} from 'src/languageSupport/languages/agnostic/utils'

--- a/src/shared/components/dateRangePicker/NewDatePicker.tsx
+++ b/src/shared/components/dateRangePicker/NewDatePicker.tsx
@@ -23,7 +23,7 @@ import {PersistanceContext} from 'src/dataExplorer/context/persistance'
 // Utils
 import {getTimeRangeLabel} from 'src/shared/utils/duration'
 import {isISODate} from 'src/shared/utils/dateTimeUtils'
-import {durationRegExp} from 'src/shared/utils/sqlInterval'
+import {durationRegExp} from 'src/shared/utils/rangeToInterval'
 import {SELECTABLE_TIME_RANGES} from 'src/shared/constants/timeRanges'
 import {useSelector} from 'react-redux'
 import {getTimeZone} from 'src/dashboards/selectors'

--- a/src/shared/utils/rangeToInterval.test.ts
+++ b/src/shared/utils/rangeToInterval.test.ts
@@ -1,12 +1,12 @@
-import {rangeToInterval} from 'src/shared/utils/sqlInterval'
+import {rangeToSQLInterval} from 'src/shared/utils/rangeToInterval'
 import {SELECTABLE_TIME_RANGES} from 'src/shared/constants/timeRanges'
 import {DurationTimeRange} from 'src/types'
 
-describe('rangeToInterval:', () => {
+describe('rangeToSQLInterval:', () => {
   describe('handles selectable timeRanges', () => {
     SELECTABLE_TIME_RANGES.forEach(range => {
       it(`handles ${range.label}`, () => {
-        expect(rangeToInterval(range)).toEqual(range.sql)
+        expect(rangeToSQLInterval(range)).toEqual(range.sql)
       })
     })
   })
@@ -39,7 +39,7 @@ describe('rangeToInterval:', () => {
     ]
     toTest.forEach(({msg, input, expected}) => {
       it(msg, () => {
-        expect(rangeToInterval(input as DurationTimeRange)).toEqual(expected)
+        expect(rangeToSQLInterval(input as DurationTimeRange)).toEqual(expected)
       })
     })
   })
@@ -66,7 +66,7 @@ describe('rangeToInterval:', () => {
     ]
     toTest.forEach(({msg, input, expected}) => {
       it(msg, () => {
-        expect(rangeToInterval(input as DurationTimeRange)).toEqual(expected)
+        expect(rangeToSQLInterval(input as DurationTimeRange)).toEqual(expected)
       })
     })
   })

--- a/src/shared/utils/rangeToInterval.ts
+++ b/src/shared/utils/rangeToInterval.ts
@@ -97,7 +97,7 @@ const convertToInfluxQLTimeSyntax = (upperOrLower: string): string => {
   }
 
   // relative time
-  if (!!upperOrLower.match(durationRegExp)) {
+  if (Boolean(upperOrLower.match(durationRegExp))) {
     const durationIntoPast = upperOrLower.charAt(0) === '-'
     const absoluteTimestamp = upperOrLower.replace(/^-/, '') // -12d6h -> 12d6h
     return `now() ${durationIntoPast ? '-' : '+'} ${absoluteTimestamp}`

--- a/src/types/queries.ts
+++ b/src/types/queries.ts
@@ -31,10 +31,10 @@ export interface SelectableDurationTimeRange {
   duration: string
   type: 'selectable-duration'
   windowPeriod: number
-  // flux range
+  // Flux, InfluxQL range
   lower: SelectableTimeRangeLower
   upper: Nullable<string>
-  // sql range
+  // SQL range
   sql: string
 }
 


### PR DESCRIPTION
Closes #6653

This PR adds the time range from date picker into the InfluxQL query composition. I also add unit tests to cover the utility function that converts UI date picker time range into InfluxQL time syntax.

## After

https://github.com/influxdata/ui/assets/14298407/38b1fa36-55b7-4fe0-b8f1-444739b64b0c


All the work is behind the feature flag `influxqlUI`.

To test on local remocal:

1. create DBRP mappings in your org ([instruction](https://github.com/influxdata/idpe/issues/17205)), and
2. also make sure to turn on the following flags in your browser:
    * `showOldDataExplorerInNewIOx`
    * `schemaComposition`

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
