### PR TITLE
chore: no query if payg credit not enabled, no queries over 30d

### DIFF
--- a/src/usage/context/usage.tsx
+++ b/src/usage/context/usage.tsx
@@ -203,34 +203,37 @@ export const UsageProvider: FC<Props> = React.memo(({children}) => {
   }
 
   const handleGetCreditUsage = useCallback(() => {
-    try {
-      setCreditUsage(prev => ({
-        ...prev,
-        status: RemoteDataState.Loading,
-      }))
-      const vectors = ['storage_gb', 'writes_mb', 'reads_gb', 'query_count']
-      const promises = []
+    if (paygCreditEnabled) {
+      try {
+        setCreditUsage(prev => ({
+          ...prev,
+          status: RemoteDataState.Loading,
+        }))
+        const vectors = ['storage_gb', 'writes_mb', 'reads_gb', 'query_count']
+        const promises = []
 
-      let daysWith250Credit = PAYG_CREDIT_DAYS
+        let daysWith250Credit = PAYG_CREDIT_DAYS
 
-      if (isFlagEnabled('credit250fix')) {
-        const secondsPerDay = 1000 * 3600 * 24
-        const currentDate = new Date()
-        const secondsWith250Credit =
-          currentDate.getTime() - new Date(paygCreditStartDate).getTime()
-        const creditDays = Math.floor(secondsWith250Credit / secondsPerDay)
+        if (isFlagEnabled('credit250fix')) {
+          const secondsPerDay = 1000 * 3600 * 24
+          const currentDate = new Date()
+          const secondsWith250Credit =
+            currentDate.getTime() - new Date(paygCreditStartDate).getTime()
+          const creditDays = Math.floor(secondsWith250Credit / secondsPerDay)
 
-        if (creditDays <= 0 || isNaN(creditDays)) {
-          return
+          if (creditDays <= 0 || isNaN(creditDays)) {
+            throw new Error('invalid number of credit days')
+          }
+
+          daysWith250Credit = creditDays
         }
 
-        daysWith250Credit = creditDays
-      }
-
-      vectors.forEach(vector_name => {
-        promises.push(
-          getUsage({vector_name, query: {range: `${daysWith250Credit}d`}}).then(
-            resp => {
+        vectors.forEach(vector_name => {
+          promises.push(
+            getUsage({
+              vector_name,
+              query: {range: `${daysWith250Credit}d`},
+            }).then(resp => {
               if (resp.status !== 200) {
                 throw new Error(resp.data.message)
               }
@@ -238,29 +241,29 @@ export const UsageProvider: FC<Props> = React.memo(({children}) => {
               return new Promise(resolve =>
                 resolve(getComputedUsage(vector_name, resp.data))
               )
-            }
+            })
           )
-        )
-      })
-
-      Promise.all(promises)
-        .then(result => {
-          const amount: number = result
-            .reduce((a: number, b) => a + parseFloat(b), 0)
-            .toFixed(2)
-          setCreditUsage({
-            amount,
-            status: RemoteDataState.Done,
-          })
         })
-        .catch(err => console.error(err))
-    } catch (error) {
-      setCreditUsage(prev => ({
-        ...prev,
-        status: RemoteDataState.Done,
-      }))
+
+        Promise.all(promises)
+          .then(result => {
+            const amount: number = result
+              .reduce((a: number, b) => a + parseFloat(b), 0)
+              .toFixed(2)
+            setCreditUsage({
+              amount,
+              status: RemoteDataState.Done,
+            })
+          })
+          .catch(err => console.error(err))
+      } catch (error) {
+        setCreditUsage(prev => ({
+          ...prev,
+          status: RemoteDataState.Done,
+        }))
+      }
     }
-  }, [])
+  }, [paygCreditEnabled])
 
   useEffect(() => {
     handleGetCreditUsage()


### PR DESCRIPTION
Two fixes related to https://github.com/influxdata/ui/pull/6650:

(1) The existing useeffect hooks were making requests to the quartz api for usage to compute 250 credit participation even _after_ 30 days had expired, which is unnecessary. Now, a query is only made when the user is within 30-day credit window.

(2) Need to throw an error on an invalid (or 0) computation of credit days, which will set the shown credit usage back to the default (0).

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - `credit250fix`
