### PR TITLE
chore: update accounts and orgs to 7

### DIFF
--- a/cypress/e2e/cloud/operator.test.ts
+++ b/cypress/e2e/cloud/operator.test.ts
@@ -27,9 +27,9 @@ describe('Operator Page', () => {
 
     cy.getByTestID('logout-button').should('exist')
 
-    // preloads 6 accounts
+    // preloads 7 accounts
     cy.getByTestID('table-body').within(() => {
-      cy.getByTestID('table-row').should('have.length', 6)
+      cy.getByTestID('table-row').should('have.length', 7)
     })
 
     // placeholder says filter by email
@@ -48,7 +48,7 @@ describe('Operator Page', () => {
       cy.getByTestID('operator-resource--searchbar').type(knownUser[index])
       cy.wait('@quartzSearchAccounts')
       cy.getByTestID('table-body').within(() => {
-        cy.getByTestID('table-row').should('have.length', index === 0 ? 6 : 1)
+        cy.getByTestID('table-row').should('have.length', index === 0 ? 7 : 1)
       })
     }
 
@@ -84,9 +84,9 @@ describe('Operator Page', () => {
       'cf-tabs--tab__active'
     )
 
-    // preloads 6 organizations
+    // preloads 7 organizations
     cy.getByTestID('table-body').within(() => {
-      cy.getByTestID('table-row').should('have.length', 6)
+      cy.getByTestID('table-row').should('have.length', 7)
     })
 
     // placeholder says filter by id
@@ -181,7 +181,7 @@ describe('Operator Page', () => {
     )
 
     cy.getByTestID('associated-orgs--table-body').within(() => {
-      cy.getByTestID('table-row').should('have.length', 6)
+      cy.getByTestID('table-row').should('have.length', 7)
     })
 
     // Renders the org overlay

--- a/cypress/e2e/cloud/operator.test.ts
+++ b/cypress/e2e/cloud/operator.test.ts
@@ -48,7 +48,7 @@ describe('Operator Page', () => {
       cy.getByTestID('operator-resource--searchbar').type(knownUser[index])
       cy.wait('@quartzSearchAccounts')
       cy.getByTestID('table-body').within(() => {
-        cy.getByTestID('table-row').should('have.length', index === 0 ? 7 : 1)
+        cy.getByTestID('table-row').should('have.length', index === 0 ? 6 : 1)
       })
     }
 

--- a/cypress/e2e/cloud/operatorRO.test.ts
+++ b/cypress/e2e/cloud/operatorRO.test.ts
@@ -38,9 +38,9 @@ describe('Operator Page', () => {
     cy.getByTestID('refless-popover--contents').contains('test@influxdata.com')
     cy.getByTestID('logout-button').should('exist')
 
-    // preloads 6 accounts
+    // preloads 7 accounts
     cy.getByTestID('table-body').within(() => {
-      cy.getByTestID('table-row').should('have.length', 6)
+      cy.getByTestID('table-row').should('have.length', 7)
     })
 
     cy.getByTestID('operator-resource--searchbar').clear()


### PR DESCRIPTION
Quartz-mock was updated to add more test orgs and accounts here https://github.com/influxdata/quartz-mock/pull/51. We need a parallel UI update to permit UI e2es to continue to run.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - NONE
