### PR TITLE
feat(operator): Allow operators to cancel accounts

### DIFF
--- a/cypress/e2e/cloud/operator.test.ts
+++ b/cypress/e2e/cloud/operator.test.ts
@@ -150,6 +150,10 @@ describe('Operator Page', () => {
     cy.getByTestID('orgTab').should('not.have.class', 'cf-tabs--tab__active')
 
     // can cancel a payg account
+    cy.intercept('DELETE', '/api/v2/quartz/operator/accounts/*', {
+      statusCode: 204,
+    }).as('quartzDeleteAccount')
+
     cy.getByTestID('account-id')
       .eq(3)
       .within(() => {
@@ -169,13 +173,14 @@ describe('Operator Page', () => {
     cy.getByTestID('account-cancel--button').click()
     cy.getByTestID('cancel-overlay').should('exist')
     cy.getByTestID('cancel-account--confirmation-button').click()
+    cy.wait('@quartzDeleteAccount')
 
     cy.location().should(loc => {
       expect(loc.pathname).to.eq('/operator')
     })
 
     cy.getByTestID('table-body').within(() => {
-      cy.getByTestID('table-row').should('have.length', 6)
+      cy.getByTestID('table-row').should('have.length', 7)
     })
 
     // validates account details page

--- a/cypress/e2e/cloud/operator.test.ts
+++ b/cypress/e2e/cloud/operator.test.ts
@@ -29,7 +29,7 @@ describe('Operator Page', () => {
 
     // preloads 6 accounts
     cy.getByTestID('table-body').within(() => {
-      cy.getByTestID('table-row').should('have.length', 6)
+      cy.getByTestID('table-row').should('have.length', 7)
     })
 
     // placeholder says filter by email
@@ -84,9 +84,9 @@ describe('Operator Page', () => {
       'cf-tabs--tab__active'
     )
 
-    // preloads 6 organizations
+    // preloads 7 organizations
     cy.getByTestID('table-body').within(() => {
-      cy.getByTestID('table-row').should('have.length', 6)
+      cy.getByTestID('table-row').should('have.length', 7)
     })
 
     // placeholder says filter by id
@@ -149,6 +149,36 @@ describe('Operator Page', () => {
     cy.getByTestID('accountTab').should('have.class', 'cf-tabs--tab__active')
     cy.getByTestID('orgTab').should('not.have.class', 'cf-tabs--tab__active')
 
+    // can cancel a payg account
+    cy.getByTestID('account-id')
+      .eq(3)
+      .within(() => {
+        cy.get('a').click()
+      })
+
+    cy.location().should(loc => {
+      expect(loc.pathname).to.eq('/operator/accounts/4')
+    })
+
+    cy.getByTestID('account-cancel--button').should('exist')
+    cy.getByTestID('account-delete--button').should('not.exist')
+    cy.getByTestID('account-convert-to-contract--button').should(
+      'not.be.disabled'
+    )
+
+    cy.getByTestID('account-cancel--button').click()
+    cy.getByTestID('cancel-overlay').should('exist')
+    cy.getByTestID('cancel-account--confirmation-button').click()
+
+    cy.location().should(loc => {
+      expect(loc.pathname).to.eq('/operator')
+    })
+
+    cy.getByTestID('table-body').within(() => {
+      cy.getByTestID('table-row').should('have.length', 6)
+    })
+
+    // validates account details page
     cy.getByTestID('account-id')
       .first()
       .within(() => {
@@ -161,7 +191,7 @@ describe('Operator Page', () => {
 
     cy.getByTestID('account-view--header').contains('operator1 (1)')
     // should not be able to delete undeletable accounts
-    cy.getByTestID('account-delete--button').should('be.disabled')
+    cy.getByTestID('account-delete--button').should('not.exist')
     // should not be able to convert cancelled accounts to contract
     cy.getByTestID('account-convert-to-contract--button').should('be.disabled')
 
@@ -181,7 +211,7 @@ describe('Operator Page', () => {
     )
 
     cy.getByTestID('associated-orgs--table-body').within(() => {
-      cy.getByTestID('table-row').should('have.length', 6)
+      cy.getByTestID('table-row').should('have.length', 7)
     })
 
     // Renders the org overlay
@@ -215,7 +245,7 @@ describe('Operator Page', () => {
     })
 
     // should be able to delete deletable accounts
-    cy.getByTestID('account-delete--button').should('not.be.disabled')
+    cy.getByTestID('account-delete--button').should('exist')
     // should be able to convert free accounts to contract
     cy.getByTestID('account-convert-to-contract--button').should(
       'not.be.disabled'

--- a/cypress/e2e/cloud/operatorRO.test.ts
+++ b/cypress/e2e/cloud/operatorRO.test.ts
@@ -40,7 +40,7 @@ describe('Operator Page', () => {
 
     // preloads 6 accounts
     cy.getByTestID('table-body').within(() => {
-      cy.getByTestID('table-row').should('have.length', 6)
+      cy.getByTestID('table-row').should('have.length', 7)
     })
 
     cy.getByTestID('operator-resource--searchbar').clear()
@@ -74,6 +74,7 @@ describe('Operator Page', () => {
 
     // make sure the buttons don't exist on the page
     cy.getByTestID('account-delete--button').should('not.exist')
+    cy.getByTestID('account-cancel--button').should('not.exist')
     cy.getByTestID('account-convert-to-contract--button').should('not.exist')
     cy.getByTestID('remove-user--button').should('not.exist')
     cy.getByTestID('page-title').should('contain.text', 'operator1 (1)')

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "prettier:fix": "pretty-quick --config .prettierrc.json --write '{src,cypress}/**/*.{ts,tsx}'",
     "tsc": "tsc -p ./tsconfig.json --noEmit --pretty --skipLibCheck",
     "tsc:watch": "yarn tsc --watch",
-    "generate": "export SHA=db14de0d91be00e75eb946d768e88d771b20a2a9 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
+    "generate": "export SHA=cb2c4f0687ba9a4635fcf96d2fd5e76a074059ea && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-local-cloud": "export REMOTE=../openapi/ && yarn generate-meta-cloud",
     "generate-meta": "if [ -z \"${CLOUD_URL}\" ]; then yarn generate-meta-oss; else yarn generate-meta-cloud; fi",

--- a/src/operator/account/AccountView.tsx
+++ b/src/operator/account/AccountView.tsx
@@ -7,6 +7,7 @@ import AppPageHeader from 'src/operator/AppPageHeader'
 import AssociatedOrgsTable from 'src/operator/account/AssociatedOrgsTable'
 import AssociatedUsersTable from 'src/operator/account/AssociatedUsersTable'
 import ConvertAccountToContractOverlay from 'src/operator/account/ConvertAccountToContractOverlay'
+import CancelAccountOverlay from 'src/operator/account/CancelAccountOverlay'
 import DeleteAccountOverlay from 'src/operator/account/DeleteAccountOverlay'
 import AccountViewHeader from 'src/operator/account/AccountViewHeader'
 import AccountGrid from 'src/operator/account/AccountGrid'
@@ -32,6 +33,7 @@ const AccountView: FC = () => {
           <AppPageHeader title={accountTitle} />
           <Page.Contents scrollable={true}>
             <ConvertAccountToContractOverlay />
+            <CancelAccountOverlay />
             <DeleteAccountOverlay />
             <AccountViewHeader />
             <AccountGrid />

--- a/src/operator/account/AccountViewHeader.tsx
+++ b/src/operator/account/AccountViewHeader.tsx
@@ -22,6 +22,8 @@ const AccountViewHeader: FC = () => {
     account,
     setConvertToContractOverlayVisible,
     convertToContractOverlayVisible,
+    setCancelOverlayVisible,
+    cancelOverlayVisible,
     setDeleteOverlayVisible,
     deleteOverlayVisible,
   } = useContext(AccountContext)
@@ -59,19 +61,24 @@ const AccountViewHeader: FC = () => {
           Convert to Contract
         </ButtonBase>
       )}
-      {hasWritePermissions && (
+      {hasWritePermissions && account?.deletable && (
         <ButtonBase
           color={ComponentColor.Danger}
           shape={ButtonShape.Default}
           onClick={() => setDeleteOverlayVisible(!deleteOverlayVisible)}
-          status={
-            account?.deletable
-              ? ComponentStatus.Default
-              : ComponentStatus.Disabled
-          }
           testID="account-delete--button"
         >
           Delete Account
+        </ButtonBase>
+      )}
+      {hasWritePermissions && account?.cancellable && (
+        <ButtonBase
+          color={ComponentColor.Danger}
+          shape={ButtonShape.Default}
+          onClick={() => setCancelOverlayVisible(!cancelOverlayVisible)}
+          testID="account-cancel--button"
+        >
+          Cancel Account
         </ButtonBase>
       )}
     </FlexBox>

--- a/src/operator/account/CancelAccountOverlay.tsx
+++ b/src/operator/account/CancelAccountOverlay.tsx
@@ -1,0 +1,75 @@
+import React, {FC, useContext} from 'react'
+import {
+  Overlay,
+  Gradients,
+  Alert,
+  ComponentColor,
+  IconFont,
+  ButtonBase,
+  ButtonShape,
+} from '@influxdata/clockface'
+import {AccountContext} from 'src/operator/context/account'
+
+const CancelAccountOverlay: FC = () => {
+  const {
+    account,
+    handleDeleteAccount,
+    setCancelOverlayVisible,
+    cancelOverlayVisible,
+  } = useContext(AccountContext)
+
+  const cancelAccount = () => {
+    if (account?.cancellable) {
+      try {
+        handleDeleteAccount()
+      } catch (e) {
+        setCancelOverlayVisible(false)
+      }
+    }
+  }
+
+  const message = `
+    This action will permanently cancel the Account
+    ${account?.id ?? 'N/A'} and all of its organizations. 
+    Users that belong to multiple accounts are still able 
+    to access their other accounts.`
+  return (
+    <Overlay
+      visible={cancelOverlayVisible}
+      renderMaskElement={() => (
+        <Overlay.Mask gradient={Gradients.DangerDark} style={{opacity: 0.5}} />
+      )}
+      testID="cancel-overlay"
+      transitionDuration={0}
+    >
+      <Overlay.Container maxWidth={600}>
+        <Overlay.Header
+          title="Cancel Account"
+          style={{color: '#FFFFFF'}}
+          onDismiss={() => setCancelOverlayVisible(!cancelOverlayVisible)}
+        />
+        <Overlay.Body>
+          <Alert color={ComponentColor.Danger} icon={IconFont.AlertTriangle}>
+            This will prevent users from accessing the account
+          </Alert>
+          <h4 style={{color: '#FFFFFF'}}>
+            <strong>Warning</strong>
+          </h4>
+          {message}
+        </Overlay.Body>
+        <Overlay.Footer>
+          <ButtonBase
+            color={ComponentColor.Danger}
+            shape={ButtonShape.Default}
+            onClick={cancelAccount}
+            testID="cancel-account--confirmation-button"
+          >
+            I understand, cancel account.
+          </ButtonBase>
+        </Overlay.Footer>
+      </Overlay.Container>
+    </Overlay>
+  )
+}
+
+export default CancelAccountOverlay

--- a/src/operator/context/account.tsx
+++ b/src/operator/context/account.tsx
@@ -34,6 +34,8 @@ export interface AccountContextType {
   organizations: OperatorOrg[]
   setConvertToContractOverlayVisible: (vis: boolean) => void
   convertToContractOverlayVisible: boolean
+  setCancelOverlayVisible: (vis: boolean) => void
+  cancelOverlayVisible: boolean
   setDeleteOverlayVisible: (vis: boolean) => void
   deleteOverlayVisible: boolean
 }
@@ -49,6 +51,8 @@ export const DEFAULT_CONTEXT: AccountContextType = {
   organizations: null,
   setConvertToContractOverlayVisible: (_: boolean) => {},
   convertToContractOverlayVisible: false,
+  cancelOverlayVisible: false,
+  setCancelOverlayVisible: (_: boolean) => {},
   setDeleteOverlayVisible: (_: boolean) => {},
   deleteOverlayVisible: false,
 }
@@ -61,6 +65,7 @@ export const AccountProvider: FC<Props> = React.memo(({children}) => {
   const [organizations, setOrganizations] = useState<OperatorOrg[]>(null)
   const [convertToContractOverlayVisible, setConvertToContractOverlayVisible] =
     useState(false)
+  const [cancelOverlayVisible, setCancelOverlayVisible] = useState(false)
   const [deleteOverlayVisible, setDeleteOverlayVisible] = useState(false)
   const [accountStatus, setAccountStatus] = useState(RemoteDataState.NotStarted)
   const [convertStatus, setConvertStatus] = useState(RemoteDataState.NotStarted)
@@ -146,6 +151,8 @@ export const AccountProvider: FC<Props> = React.memo(({children}) => {
         organizations,
         setConvertToContractOverlayVisible,
         convertToContractOverlayVisible,
+        setCancelOverlayVisible,
+        cancelOverlayVisible,
         setDeleteOverlayVisible,
         deleteOverlayVisible,
       }}


### PR DESCRIPTION
This change allows a user to cancel a direct payg account through the operator page.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
