### PR TITLE
fix(script-editor): composition sync should not auto turn off when creating a new script

### DIFF
--- a/src/languageSupport/languages/influxql/connection.ts
+++ b/src/languageSupport/languages/influxql/connection.ts
@@ -138,11 +138,13 @@ export class ConnectionManager extends AgnosticConnectionManager {
   }
 
   _couldBeFromComposition = (change: any): boolean => {
-    // There are two types of change is from composition
-    //  1. removing the DEFAULT_INFLUXQL_EDITOR_TEXT, which happens
-    //     in the onSchemaSessionChange() if statement shouldRemoveDefaultMsg
-    //  2. setting forceMoveMarkers to true manually in _updateComposition()
+    // There are three types of change that are from composition
+    //  1. starting a new script
+    //  2. removing the DEFAULT_INFLUXQL_EDITOR_TEXT, i.e. selecting a bucket on a new script,
+    //     which happens in the onSchemaSessionChange() if statement shouldRemoveDefaultMsg
+    //  3. setting forceMoveMarkers to true manually in _updateComposition()
     return (
+      change.text === DEFAULT_INFLUXQL_EDITOR_TEXT ||
       change.rangeLength === DEFAULT_INFLUXQL_EDITOR_TEXT.length ||
       change.forceMoveMarkers
     )

--- a/src/languageSupport/languages/sql/connection.ts
+++ b/src/languageSupport/languages/sql/connection.ts
@@ -26,7 +26,16 @@ export class ConnectionManager extends AgnosticConnectionManager {
   private _timeRange: TimeRange = DEFAULT_TIME_RANGE
 
   _couldBeFromComposition(change) {
-    return change.forceMoveMarkers == true
+    // There are three types of change that are from composition
+    //  1. starting a new script
+    //  2. removing the DEFAULT_INFLUXQL_EDITOR_TEXT, i.e. selecting a bucket on a new script,
+    //     which happens in the onSchemaSessionChange() if statement shouldRemoveDefaultMsg
+    //  3. setting forceMoveMarkers to true manually in _updateComposition()
+    return (
+      change.text === DEFAULT_SQL_EDITOR_TEXT ||
+      change.rangeLength === DEFAULT_SQL_EDITOR_TEXT.length ||
+      change.forceMoveMarkers
+    )
   }
 
   _editorChangeIsWithinComposition(change) {


### PR DESCRIPTION
Closes #6714

This PR fixes the bug that composition sync should not auto turn off when creating a new script for SQL and InfluxQL

## Before

SQL

https://github.com/influxdata/ui/assets/14298407/dbf8a521-5644-4fc0-8371-1f9ba5dae286


InfluxQL

https://github.com/influxdata/ui/assets/14298407/1e430d84-a708-4e56-bf1a-354874c77a47


## After

SQL

https://github.com/influxdata/ui/assets/14298407/cca9e358-0792-4a91-b650-a3ce3605edea


InfluxQL

https://github.com/influxdata/ui/assets/14298407/7def0e03-68f9-4bd6-a5da-0c51273b5cd8

The fix for SQL will be seen in production, but the fix for InfluxQL is behind the feature flag `influxqlUI`.

To test on local remocal for InfluxQL:

1. create DBRP mappings in your TSM org ([instruction](https://github.com/influxdata/idpe/issues/17205)), and
2. also make sure to turn on the following flags in your browser:
    * `showOldDataExplorerInNewIOx`
    * `schemaComposition`
   
Note that the InfluxQL support is only available on TSM orgs for now, so in order to test SQL and InfluxQL, you need to login using two different user names, i.e. iox username for SQL and tsm username for InfluxQL.


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
