### PR TITLE
refactor: fix typo for persistence context

### DIFF
--- a/src/dataExplorer/components/AggregateFunctionSelector.tsx
+++ b/src/dataExplorer/components/AggregateFunctionSelector.tsx
@@ -14,8 +14,8 @@ import SearchableDropdown from 'src/shared/components/SearchableDropdown'
 import {
   AggregateWindow,
   DEFAULT_AGGREGATE_WINDOW,
-  PersistanceContext,
-} from 'src/dataExplorer/context/persistance'
+  PersistenceContext,
+} from 'src/dataExplorer/context/persistence'
 
 // Constants
 import {AGGREGATE_FUNCTIONS} from 'src/timeMachine/constants/queryBuilder'
@@ -25,7 +25,7 @@ import {ComponentStatus} from '@influxdata/clockface'
 
 export const AggregateFunctionsSelector: FC = () => {
   // Contexts
-  const {selection, setSelection} = useContext(PersistanceContext)
+  const {selection, setSelection} = useContext(PersistenceContext)
 
   // State
   const [functionSearchTerm, setFunctionSearchTerm] = useState('')

--- a/src/dataExplorer/components/AggregateWindow.tsx
+++ b/src/dataExplorer/components/AggregateWindow.tsx
@@ -12,8 +12,8 @@ import {FillValuesToggle} from 'src/dataExplorer/components/FillValuesToggle'
 import {
   AggregateWindow,
   DEFAULT_AGGREGATE_WINDOW,
-  PersistanceContext,
-} from 'src/dataExplorer/context/persistance'
+  PersistenceContext,
+} from 'src/dataExplorer/context/persistence'
 
 // Styles
 import './Sidebar.scss'
@@ -22,7 +22,7 @@ const AGGREGATE_WINDOW_TOOLTIP = `test`
 
 const AggregateWindow: FC = () => {
   // Contexts
-  const {selection, setSelection} = useContext(PersistanceContext)
+  const {selection, setSelection} = useContext(PersistenceContext)
 
   const {isOn}: AggregateWindow =
     selection.resultOptions?.aggregateWindow || DEFAULT_AGGREGATE_WINDOW

--- a/src/dataExplorer/components/BucketSelector.tsx
+++ b/src/dataExplorer/components/BucketSelector.tsx
@@ -15,7 +15,7 @@ import SelectorTitle from 'src/dataExplorer/components/SelectorTitle'
 import {ScriptQueryBuilderContext} from 'src/dataExplorer/context/scriptQueryBuilder'
 import {BucketContext} from 'src/shared/contexts/buckets'
 import {event} from 'src/cloud/utils/reporting'
-import {PersistanceContext} from 'src/dataExplorer/context/persistance'
+import {PersistenceContext} from 'src/dataExplorer/context/persistence'
 
 // Types
 import {RemoteDataState, Bucket} from 'src/types'
@@ -35,7 +35,7 @@ const BucketSelector: FC = () => {
   const {loading, buckets} = useContext(BucketContext)
   const [isSearchActive, setIsSearchActive] = useState(false)
   const [searchTerm, setSearchTerm] = useState('')
-  const {resource} = useContext(PersistanceContext)
+  const {resource} = useContext(PersistenceContext)
 
   if (resource?.language === LanguageType.INFLUXQL) {
     return null

--- a/src/dataExplorer/components/ColumnSelector.tsx
+++ b/src/dataExplorer/components/ColumnSelector.tsx
@@ -14,8 +14,8 @@ import SearchableDropdown from 'src/shared/components/SearchableDropdown'
 import {
   AggregateWindow,
   DEFAULT_AGGREGATE_WINDOW,
-  PersistanceContext,
-} from 'src/dataExplorer/context/persistance'
+  PersistenceContext,
+} from 'src/dataExplorer/context/persistence'
 import {ColumnsContext} from 'src/dataExplorer/context/columns'
 
 // Utilities
@@ -26,7 +26,7 @@ import './Sidebar.scss'
 
 export const ColumnSelector: FC = () => {
   // Contexts
-  const {selection, setSelection} = useContext(PersistanceContext)
+  const {selection, setSelection} = useContext(PersistenceContext)
   const {columns, loading, getColumns, resetColumns} =
     useContext(ColumnsContext)
 

--- a/src/dataExplorer/components/DBRPSelector.tsx
+++ b/src/dataExplorer/components/DBRPSelector.tsx
@@ -6,7 +6,7 @@ import {useDispatch} from 'react-redux'
 import {BucketContext} from 'src/shared/contexts/buckets'
 import {DBRPContext} from 'src/shared/contexts/dbrps'
 import {ScriptQueryBuilderContext} from 'src/dataExplorer/context/scriptQueryBuilder'
-import {PersistanceContext} from 'src/dataExplorer/context/persistance'
+import {PersistenceContext} from 'src/dataExplorer/context/persistence'
 
 // Types
 import {RemoteDataState} from 'src/types'
@@ -42,7 +42,7 @@ export const DBRPSelector: FC = () => {
   const {selectedDBRP, selectDBRP} = useContext(ScriptQueryBuilderContext)
   const [isSearchActive, setIsSearchActive] = useState(false)
   const [searchTerm, setSearchTerm] = useState('')
-  const {resource} = useContext(PersistanceContext)
+  const {resource} = useContext(PersistenceContext)
   const dispatch = useDispatch()
 
   if (resource?.language !== LanguageType.INFLUXQL) {

--- a/src/dataExplorer/components/DataExplorerPage.tsx
+++ b/src/dataExplorer/components/DataExplorerPage.tsx
@@ -43,16 +43,16 @@ import {ResourceType} from 'src/types'
 import 'src/shared/components/cta.scss'
 import {AppSettingContext} from 'src/shared/contexts/app'
 import {
-  PersistanceContext,
-  PersistanceProvider,
-} from 'src/dataExplorer/context/persistance'
+  PersistenceContext,
+  PersistenceProvider,
+} from 'src/dataExplorer/context/persistence'
 import {PROJECT_NAME, PROJECT_NAME_PLURAL} from 'src/flows'
 import {SCRIPT_EDITOR_PARAMS} from 'src/dataExplorer/components/resources'
 
 const DataExplorerPageHeader: FC = () => {
   const {scriptQueryBuilder, setScriptQueryBuilder} =
     useContext(AppSettingContext)
-  const {resource, save} = useContext(PersistanceContext)
+  const {resource, save} = useContext(PersistenceContext)
   const isNewIOxOrg = useSelector(selectIsNewIOxOrg)
   const shouldShowDataExplorerToggle =
     !isNewIOxOrg || isFlagEnabled('showOldDataExplorerInNewIOx')
@@ -183,9 +183,9 @@ const DataExplorerPage: FC = () => {
         />
       </Switch>
       <GetResources resources={[ResourceType.Variables]}>
-        <PersistanceProvider>
+        <PersistenceProvider>
           <DataExplorerPageHeader />
-        </PersistanceProvider>
+        </PersistenceProvider>
         {flowsCTA.explorer && (
           <FeatureFlag name="flowsCTA">
             <div className="header-cta--de">

--- a/src/dataExplorer/components/DeleteScript.tsx
+++ b/src/dataExplorer/components/DeleteScript.tsx
@@ -2,7 +2,7 @@ import React, {FC, useContext} from 'react'
 import {Button, ComponentColor, IconFont, Overlay} from '@influxdata/clockface'
 import './SaveAsScript.scss'
 import {CLOUD} from 'src/shared/constants'
-import {PersistanceContext} from 'src/dataExplorer/context/persistance'
+import {PersistenceContext} from 'src/dataExplorer/context/persistence'
 import {useHistory} from 'react-router-dom'
 import {useSelector, useDispatch} from 'react-redux'
 import {getOrg} from 'src/organizations/selectors'
@@ -26,7 +26,7 @@ interface Props {
 }
 
 const DeleteScript: FC<Props> = ({onBack, onClose}) => {
-  const {resource} = useContext(PersistanceContext)
+  const {resource} = useContext(PersistenceContext)
   const {cancel} = useContext(QueryContext)
   const {setStatus, setResult} = useContext(ResultsContext)
   const {clear: clearViewOptions} = useContext(ResultsViewContext)

--- a/src/dataExplorer/components/FieldSelector.tsx
+++ b/src/dataExplorer/components/FieldSelector.tsx
@@ -16,7 +16,7 @@ import SelectorList from 'src/timeMachine/components/SelectorList'
 // Contexts
 import {FieldsContext} from 'src/dataExplorer/context/fields'
 import {ScriptQueryBuilderContext} from 'src/dataExplorer/context/scriptQueryBuilder'
-import {PersistanceContext} from 'src/dataExplorer/context/persistance'
+import {PersistenceContext} from 'src/dataExplorer/context/persistence'
 
 // Types
 import {RemoteDataState} from 'src/types'
@@ -39,7 +39,7 @@ conceptually similar to a non-indexed column and value.`
 const FieldSelector: FC = () => {
   const {fields, loading} = useContext(FieldsContext)
   const {selectField, searchTerm} = useContext(ScriptQueryBuilderContext)
-  const {selection} = useContext(PersistanceContext)
+  const {selection} = useContext(PersistenceContext)
   const [fieldsToShow, setFieldsToShow] = useState([])
 
   const handleSelectField = (field: string) => {

--- a/src/dataExplorer/components/FieldsAsColumns.tsx
+++ b/src/dataExplorer/components/FieldsAsColumns.tsx
@@ -2,14 +2,14 @@ import React, {FC, useCallback, useContext} from 'react'
 
 // Components
 import {ToggleWithLabelTooltip} from 'src/dataExplorer/components/ToggleWithLabelTooltip'
-import {PersistanceContext} from 'src/dataExplorer/context/persistance'
+import {PersistenceContext} from 'src/dataExplorer/context/persistence'
 import {event} from 'src/cloud/utils/reporting'
 
 // Styles
 import './Sidebar.scss'
 
 const FieldsAsColumns: FC = () => {
-  const {selection, setSelection} = useContext(PersistanceContext)
+  const {selection, setSelection} = useContext(PersistenceContext)
 
   const handleToggle = useCallback(() => {
     const value = !selection?.resultOptions?.fieldsAsColumn

--- a/src/dataExplorer/components/FillValuesToggle.tsx
+++ b/src/dataExplorer/components/FillValuesToggle.tsx
@@ -7,14 +7,14 @@ import {ToggleWithLabelTooltip} from 'src/dataExplorer/components/ToggleWithLabe
 import {
   AggregateWindow,
   DEFAULT_AGGREGATE_WINDOW,
-  PersistanceContext,
-} from 'src/dataExplorer/context/persistance'
+  PersistenceContext,
+} from 'src/dataExplorer/context/persistence'
 
 // Styles
 import './Sidebar.scss'
 
 export const FillValuesToggle: FC = () => {
-  const {selection, setSelection} = useContext(PersistanceContext)
+  const {selection, setSelection} = useContext(PersistenceContext)
   const {isOn, createEmpty}: AggregateWindow =
     selection.resultOptions?.aggregateWindow || DEFAULT_AGGREGATE_WINDOW
 

--- a/src/dataExplorer/components/GroupBy.tsx
+++ b/src/dataExplorer/components/GroupBy.tsx
@@ -13,8 +13,8 @@ import {
   DEFAULT_GROUP_OPTIONS,
   GroupType,
   GroupOptions,
-  PersistanceContext,
-} from 'src/dataExplorer/context/persistance'
+  PersistenceContext,
+} from 'src/dataExplorer/context/persistence'
 import {GroupKeysContext} from 'src/dataExplorer/context/groupKeys'
 
 // Utilies
@@ -30,7 +30,7 @@ const DEFAULT_COLUMNS: string[] = ['_measurement', '_field'] // only use this wh
 const GroupBy: FC = () => {
   const {groupKeys, loading, getGroupKeys, resetGroupKeys} =
     useContext(GroupKeysContext)
-  const {selection, setSelection} = useContext(PersistanceContext)
+  const {selection, setSelection} = useContext(PersistenceContext)
   const {type: selectedGroupType, columns: selectedGroupKeys}: GroupOptions =
     selection.resultOptions.group
 

--- a/src/dataExplorer/components/Results.tsx
+++ b/src/dataExplorer/components/Results.tsx
@@ -30,7 +30,7 @@ import {
 } from 'src/dataExplorer/context/resultsView'
 import {ChildResultsContext} from 'src/dataExplorer/context/results/childResults'
 import {SidebarContext} from 'src/dataExplorer/context/sidebar'
-import {PersistanceContext} from 'src/dataExplorer/context/persistance'
+import {PersistenceContext} from 'src/dataExplorer/context/persistence'
 
 // Types
 import {FluxResult} from 'src/types/flows'
@@ -44,7 +44,7 @@ import './Results.scss'
 
 const QueryStat: FC = () => {
   const {result} = useContext(ResultsContext)
-  const {resource} = useContext(PersistanceContext)
+  const {resource} = useContext(PersistenceContext)
 
   const tableColumn = result?.parsed?.table?.getColumn('table') || []
   const lastTableValue = tableColumn[tableColumn.length - 1]
@@ -92,7 +92,7 @@ const EmptyResults: FC = () => {
 
 const TableResults: FC<{search: string}> = ({search}) => {
   const {result, status} = useContext(ResultsContext)
-  const {range, resource} = useContext(PersistanceContext)
+  const {range, resource} = useContext(PersistenceContext)
 
   const res = useMemo(() => {
     if (search.trim() === '' || !result?.parsed) {
@@ -183,7 +183,7 @@ const ErrorResults: FC<{error: string}> = ({error}) => {
 const GraphResults: FC = () => {
   const {view} = useContext(ResultsViewContext)
   const {result, status} = useContext(ChildResultsContext)
-  const {range} = useContext(PersistanceContext)
+  const {range} = useContext(PersistenceContext)
 
   if (result?.error) {
     return <ErrorResults error={result.error} />
@@ -212,7 +212,7 @@ const WrappedOptions: FC = () => {
   const {result} = useContext(ChildResultsContext)
   const {view, setView, selectViewOptions, viewOptions, selectedViewOptions} =
     useContext(ResultsViewContext)
-  const {resource} = useContext(PersistanceContext)
+  const {resource} = useContext(PersistenceContext)
   const graphDataExists = !!result?.parsed
   const parentDataExists = !!parentResult?.parsed
 
@@ -339,7 +339,7 @@ const Results: FC = () => {
   const [search, setSearch] = useState('')
   const {status} = useContext(ResultsContext)
   const {view, setView} = useContext(ResultsViewContext)
-  const {resource} = useContext(PersistanceContext)
+  const {resource} = useContext(PersistenceContext)
 
   let resultView
 

--- a/src/dataExplorer/components/ResultsPane.tsx
+++ b/src/dataExplorer/components/ResultsPane.tsx
@@ -20,11 +20,11 @@ import {useSelector, useDispatch} from 'react-redux'
 import {ResultsContext} from 'src/dataExplorer/context/results'
 import {QueryContext} from 'src/shared/contexts/query'
 import {
-  PersistanceContext,
+  PersistenceContext,
   DEFAULT_FLUX_EDITOR_TEXT,
   DEFAULT_SQL_EDITOR_TEXT,
   DEFAULT_INFLUXQL_EDITOR_TEXT,
-} from 'src/dataExplorer/context/persistance'
+} from 'src/dataExplorer/context/persistence'
 
 // Components
 import {Results} from 'src/dataExplorer/components/Results'
@@ -83,7 +83,7 @@ const ResultsPane: FC = () => {
     range,
     selection,
     resource,
-  } = useContext(PersistanceContext)
+  } = useContext(PersistenceContext)
   const orgID = useSelector(getOrg)?.id
   const language = resource?.language ?? LanguageType.FLUX
   const dispatch = useDispatch()

--- a/src/dataExplorer/components/SaveAsScript.tsx
+++ b/src/dataExplorer/components/SaveAsScript.tsx
@@ -27,7 +27,7 @@ import CopyToClipboard from 'src/shared/components/CopyToClipboard'
 // Contexts
 import {QueryContext} from 'src/shared/contexts/query'
 import {ResultsContext} from 'src/dataExplorer/context/results'
-import {PersistanceContext} from 'src/dataExplorer/context/persistance'
+import {PersistenceContext} from 'src/dataExplorer/context/persistence'
 import {ResultsViewContext} from 'src/dataExplorer/context/resultsView'
 
 // Types
@@ -60,7 +60,7 @@ const SaveAsScript: FC<Props> = ({language, onClose, setOverlayType, type}) => {
   const dispatch = useDispatch()
   const history = useHistory()
   const {hasChanged, resource, setResource, save} =
-    useContext(PersistanceContext)
+    useContext(PersistenceContext)
   const isIoxOrg = useSelector(isOrgIOx)
   const {cancel} = useContext(QueryContext)
   const {setStatus, setResult} = useContext(ResultsContext)

--- a/src/dataExplorer/components/SchemaBrowserHeading.tsx
+++ b/src/dataExplorer/components/SchemaBrowserHeading.tsx
@@ -12,7 +12,7 @@ import SelectorTitle from 'src/dataExplorer/components/SelectorTitle'
 
 // Context
 import {ScriptQueryBuilderContext} from 'src/dataExplorer/context/scriptQueryBuilder'
-import {PersistanceContext} from 'src/dataExplorer/context/persistance'
+import {PersistenceContext} from 'src/dataExplorer/context/persistence'
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'
@@ -23,7 +23,7 @@ const SchemaBrowserHeading: FC = () => {
   const {compositionSync, toggleCompositionSync} = useContext(
     ScriptQueryBuilderContext
   )
-  const {resource} = useContext(PersistanceContext)
+  const {resource} = useContext(PersistenceContext)
 
   const handleCompositionSyncToggle = () => {
     // Note: kept same event naming, so can compare across time. (Even though is Flux and SQL sync.)

--- a/src/dataExplorer/components/ScriptQueryBuilder.tsx
+++ b/src/dataExplorer/components/ScriptQueryBuilder.tsx
@@ -33,9 +33,9 @@ import {
 } from 'src/dataExplorer/context/resultsView'
 import {SidebarProvider} from 'src/dataExplorer/context/sidebar'
 import {
-  PersistanceProvider,
-  PersistanceContext,
-} from 'src/dataExplorer/context/persistance'
+  PersistenceProvider,
+  PersistenceContext,
+} from 'src/dataExplorer/context/persistence'
 import {QueryContext} from 'src/shared/contexts/query'
 import {DBRPContext, DBRPProvider} from 'src/shared/contexts/dbrps'
 
@@ -65,7 +65,7 @@ export enum OverlayType {
 const ScriptQueryBuilder: FC = () => {
   const history = useHistory()
   const {resource, hasChanged, vertical, setVertical, setHasChanged} =
-    useContext(PersistanceContext)
+    useContext(PersistenceContext)
   const [overlayType, setOverlayType] = useState<OverlayType | null>(null)
   const [selectedLanguage, setSelectedLanguage] = useState(
     resource?.language ?? LanguageType.FLUX
@@ -319,11 +319,11 @@ export default () => {
       <ResultsProvider>
         <ResultsViewProvider>
           <DBRPProvider scope={scope}>
-            <PersistanceProvider>
+            <PersistenceProvider>
               <ChildResultsProvider>
                 <ScriptQueryBuilder />
               </ChildResultsProvider>
-            </PersistanceProvider>
+            </PersistenceProvider>
           </DBRPProvider>
         </ResultsViewProvider>
       </ResultsProvider>

--- a/src/dataExplorer/components/Sidebar.tsx
+++ b/src/dataExplorer/components/Sidebar.tsx
@@ -16,7 +16,7 @@ import {
 // Contexts
 import {SidebarContext} from 'src/dataExplorer/context/sidebar'
 import {EditorContext} from 'src/shared/contexts/editor'
-import {PersistanceContext} from 'src/dataExplorer/context/persistance'
+import {PersistenceContext} from 'src/dataExplorer/context/persistence'
 
 // Types
 import {FluxFunction, FluxToolbarFunction} from 'src/types'
@@ -35,7 +35,7 @@ functions, and variables which may be useful when constructing your flux query.`
 const Sidebar: FC = () => {
   const {injectFunction} = useContext(EditorContext)
   const {visible, menu, clear} = useContext(SidebarContext)
-  const {resource} = useContext(PersistanceContext)
+  const {resource} = useContext(PersistenceContext)
 
   const inject = useCallback(
     (fn: FluxFunction | FluxToolbarFunction) => {

--- a/src/dataExplorer/components/WindowPeriod.tsx
+++ b/src/dataExplorer/components/WindowPeriod.tsx
@@ -10,8 +10,8 @@ import {
   AggregateWindow,
   DEFAULT_AGGREGATE_WINDOW,
   DEFAULT_WINDOW_PERIOD,
-  PersistanceContext,
-} from 'src/dataExplorer/context/persistance'
+  PersistenceContext,
+} from 'src/dataExplorer/context/persistence'
 
 // Constants
 import {
@@ -28,7 +28,7 @@ import './Sidebar.scss'
 const WINDOW_PERIOD_TOOLTIP = `test`
 
 export const WindowPeriod: FC = () => {
-  const {selection, setSelection} = useContext(PersistanceContext)
+  const {selection, setSelection} = useContext(PersistenceContext)
   const {
     isOn,
     isAutoWindowPeriod,

--- a/src/dataExplorer/components/resources/TemplatePage.tsx
+++ b/src/dataExplorer/components/resources/TemplatePage.tsx
@@ -9,18 +9,18 @@ import {
   SCRIPT_EDITOR_PARAMS,
 } from 'src/dataExplorer/components/resources'
 import {
-  PersistanceContext,
-  PersistanceProvider,
+  PersistenceContext,
+  PersistenceProvider,
   DEFAULT_FLUX_EDITOR_TEXT,
   DEFAULT_SQL_EDITOR_TEXT,
   DEFAULT_INFLUXQL_EDITOR_TEXT,
-} from 'src/dataExplorer/context/persistance'
+} from 'src/dataExplorer/context/persistence'
 import {LanguageType} from 'src/dataExplorer/components/resources'
 import {getLanguage} from 'src/dataExplorer/shared/utils'
 
 const Template: FC = () => {
   const {setQuery, setHasChanged, setResource, clearCompositionSelection} =
-    useContext(PersistanceContext)
+    useContext(PersistenceContext)
   const params = useParams()[0].split('/')
   const org = useSelector(getOrg)
   const history = useHistory()
@@ -77,7 +77,7 @@ const TemplatePage: FC = () => {
   const org = useSelector(getOrg)
 
   return (
-    <PersistanceProvider>
+    <PersistenceProvider>
       <Switch>
         <Route
           path={`/orgs/${org.id}/data-explorer/from/*`}
@@ -85,7 +85,7 @@ const TemplatePage: FC = () => {
         />
         <Route component={() => <div />} />
       </Switch>
-    </PersistanceProvider>
+    </PersistenceProvider>
   )
 }
 

--- a/src/dataExplorer/components/resources/types/script/index.ts
+++ b/src/dataExplorer/components/resources/types/script/index.ts
@@ -5,7 +5,7 @@ import {
   DEFAULT_FLUX_EDITOR_TEXT,
   DEFAULT_SQL_EDITOR_TEXT,
   DEFAULT_INFLUXQL_EDITOR_TEXT,
-} from 'src/dataExplorer/context/persistance'
+} from 'src/dataExplorer/context/persistence'
 import {LanguageType} from 'src/dataExplorer/components/resources'
 import {getLanguage} from 'src/dataExplorer/shared/utils'
 

--- a/src/dataExplorer/context/persistence.tsx
+++ b/src/dataExplorer/context/persistence.tsx
@@ -136,9 +136,9 @@ const DEFAULT_CONTEXT = {
   save: (_: LanguageType) => Promise.resolve(null),
 }
 
-export const PersistanceContext = createContext<ContextType>(DEFAULT_CONTEXT)
+export const PersistenceContext = createContext<ContextType>(DEFAULT_CONTEXT)
 
-export const PersistanceProvider: FC = ({children}) => {
+export const PersistenceProvider: FC = ({children}) => {
   const isIoxOrg = useSelector(isOrgIOx)
 
   const [horizontal, setHorizontal] = useSessionStorage(
@@ -240,7 +240,7 @@ export const PersistanceProvider: FC = ({children}) => {
   }
 
   return (
-    <PersistanceContext.Provider
+    <PersistenceContext.Provider
       value={{
         hasChanged,
         horizontal,
@@ -263,6 +263,6 @@ export const PersistanceProvider: FC = ({children}) => {
       }}
     >
       {children}
-    </PersistanceContext.Provider>
+    </PersistenceContext.Provider>
   )
 }

--- a/src/dataExplorer/context/results/childResults.tsx
+++ b/src/dataExplorer/context/results/childResults.tsx
@@ -6,7 +6,7 @@ import {
   ResultsViewContext,
   ViewOptions,
 } from 'src/dataExplorer/context/resultsView'
-import {PersistanceContext} from 'src/dataExplorer/context/persistance'
+import {PersistenceContext} from 'src/dataExplorer/context/persistence'
 import {QueryContext, SqlQueryModifiers} from 'src/shared/contexts/query'
 
 // Types
@@ -93,7 +93,7 @@ export const ChildResultsProvider: FC = ({children}) => {
     selection,
     resource,
     range,
-  } = useContext(PersistanceContext)
+  } = useContext(PersistenceContext)
   const {query} = useContext(QueryContext)
 
   useEffect(() => {

--- a/src/dataExplorer/context/scriptQueryBuilder.tsx
+++ b/src/dataExplorer/context/scriptQueryBuilder.tsx
@@ -11,7 +11,7 @@ import React, {
 // Context
 import {MeasurementsContext} from 'src/dataExplorer/context/measurements'
 import {FieldsContext} from 'src/dataExplorer/context/fields'
-import {PersistanceContext} from 'src/dataExplorer/context/persistance'
+import {PersistenceContext} from 'src/dataExplorer/context/persistence'
 import {TagsContext} from 'src/dataExplorer/context/tags'
 import {debouncer} from 'src/dataExplorer/shared/utils'
 // Types
@@ -70,10 +70,10 @@ export const ScriptQueryBuilderProvider: FC = ({children}) => {
   const {getMeasurements} = useContext(MeasurementsContext)
   const {getFields, resetFields} = useContext(FieldsContext)
   const {getTagKeys, resetTags} = useContext(TagsContext)
-  const {selection, setSelection} = useContext(PersistanceContext)
+  const {selection, setSelection} = useContext(PersistenceContext)
 
   // States
-  // This state is a restructed PersistanceContext selection.tagValues
+  // This state is a restructed PersistenceContext selection.tagValues
   // for performance reason. selection.tagValues is the source of true
   const [selectedTagValues, setSelectedTagValues] = useState(
     DEFAULT_SELECTED_TAG_VALUES

--- a/src/languageSupport/languages/agnostic/connection.ts
+++ b/src/languageSupport/languages/agnostic/connection.ts
@@ -4,7 +4,7 @@ import isEqual from 'lodash/isEqual'
 import {
   DEFAULT_SELECTION,
   CompositionSelection,
-} from 'src/dataExplorer/context/persistance'
+} from 'src/dataExplorer/context/persistence'
 
 // Types
 import {EditorType, RecursivePartial} from 'src/types'

--- a/src/languageSupport/languages/flux/lsp/connection.ts
+++ b/src/languageSupport/languages/flux/lsp/connection.ts
@@ -13,7 +13,7 @@ import {RecursivePartial, TagKeyValuePair} from 'src/types'
 import {
   DEFAULT_FLUX_EDITOR_TEXT,
   CompositionSelection,
-} from 'src/dataExplorer/context/persistance'
+} from 'src/dataExplorer/context/persistence'
 
 // LSP methods
 import {

--- a/src/languageSupport/languages/influxql/connection.ts
+++ b/src/languageSupport/languages/influxql/connection.ts
@@ -5,7 +5,7 @@ import {ConnectionManager as AgnosticConnectionManager} from 'src/languageSuppor
 import {
   CompositionSelection,
   DEFAULT_INFLUXQL_EDITOR_TEXT,
-} from 'src/dataExplorer/context/persistance'
+} from 'src/dataExplorer/context/persistence'
 import {
   RecursivePartial,
   SelectableDurationTimeRange,

--- a/src/languageSupport/languages/sql/connection.ts
+++ b/src/languageSupport/languages/sql/connection.ts
@@ -5,7 +5,7 @@ import {LspRange} from 'src/languageSupport/languages/agnostic/types'
 import {
   DEFAULT_SQL_EDITOR_TEXT,
   CompositionSelection,
-} from 'src/dataExplorer/context/persistance'
+} from 'src/dataExplorer/context/persistence'
 import {SelectableDurationTimeRange, TimeRange} from 'src/types'
 
 // Utils

--- a/src/shared/components/FluxMonacoEditor.tsx
+++ b/src/shared/components/FluxMonacoEditor.tsx
@@ -21,7 +21,7 @@ import {ConnectionManager} from 'src/languageSupport/languages/flux/lsp/connecti
 
 // Contexts and State
 import {EditorContext} from 'src/shared/contexts/editor'
-import {PersistanceContext} from 'src/dataExplorer/context/persistance'
+import {PersistenceContext} from 'src/dataExplorer/context/persistence'
 import {scriptQueryBuilder} from 'src/shared/selectors/app'
 import {isOrgIOx} from 'src/organizations/selectors'
 
@@ -65,7 +65,7 @@ const FluxEditorMonaco: FC<Props> = ({
   const connection = useRef<ConnectionManager>(null)
   const {editor, setEditor} = useContext(EditorContext)
   const isScriptQueryBuilder = useSelector(scriptQueryBuilder)
-  const sessionStore = useContext(PersistanceContext)
+  const sessionStore = useContext(PersistenceContext)
   const isIoxOrg = useSelector(isOrgIOx)
   const {path} = useRouteMatch()
   const isInScriptQueryBuilder =

--- a/src/shared/components/InfluxQLMonacoEditor.tsx
+++ b/src/shared/components/InfluxQLMonacoEditor.tsx
@@ -21,7 +21,7 @@ import {registerAutogrow} from 'src/languageSupport/monaco.autogrow'
 import {ConnectionManager} from 'src/languageSupport/languages/influxql/connection'
 
 // Contexts
-import {PersistanceContext} from 'src/dataExplorer/context/persistance'
+import {PersistenceContext} from 'src/dataExplorer/context/persistence'
 
 // Types
 import {OnChangeScript, EditorType} from 'src/types'
@@ -52,7 +52,7 @@ export const InfluxQLMonacoEditor: FC<Props> = ({
 }) => {
   const dispatch = useDispatch()
   const connection = useRef<ConnectionManager>(new ConnectionManager())
-  const sessionStore = useContext(PersistanceContext)
+  const sessionStore = useContext(PersistenceContext)
   const [editor, setEditor] = useState(null)
   const wrapperClassName = classnames('qx-editor--monaco', {
     'qx-editor--monaco__autogrow': autogrow,

--- a/src/shared/components/SqlMonacoEditor.tsx
+++ b/src/shared/components/SqlMonacoEditor.tsx
@@ -22,7 +22,7 @@ import {registerAutogrow} from 'src/languageSupport/monaco.autogrow'
 import {ConnectionManager} from 'src/languageSupport/languages/sql/connection'
 
 // Contexts
-import {PersistanceContext} from 'src/dataExplorer/context/persistance'
+import {PersistenceContext} from 'src/dataExplorer/context/persistence'
 
 // Types
 import {OnChangeScript} from 'src/types/flux'
@@ -52,7 +52,7 @@ const SqlEditorMonaco: FC<Props> = ({
 }) => {
   const dispatch = useDispatch()
   const connection = useRef<ConnectionManager>(new ConnectionManager())
-  const sessionStore = useContext(PersistanceContext)
+  const sessionStore = useContext(PersistenceContext)
   const [editor, setEditor] = useState(null)
   const wrapperClassName = classnames('qx-editor--monaco', {
     'qx-editor--monaco__autogrow': autogrow,

--- a/src/shared/components/dateRangePicker/NewDatePicker.tsx
+++ b/src/shared/components/dateRangePicker/NewDatePicker.tsx
@@ -18,7 +18,7 @@ import {
   Icon,
 } from '@influxdata/clockface'
 import ReactDatePicker from 'react-datepicker'
-import {PersistanceContext} from 'src/dataExplorer/context/persistance'
+import {PersistenceContext} from 'src/dataExplorer/context/persistence'
 
 // Utils
 import {getTimeRangeLabel} from 'src/shared/utils/duration'
@@ -66,7 +66,7 @@ interface Props {
 const DatePickerMenu: FC<Props> = ({onCollapse, timeRange, timeRangeLabel}) => {
   const [isDatePickerOpen, setIsDatePickerOpen] = useState(false)
   const timeZone = useSelector(getTimeZone)
-  const {setRange} = useContext(PersistanceContext)
+  const {setRange} = useContext(PersistenceContext)
 
   const [inputStartDate, setInputStartDate] = useState(timeRange?.lower)
   const [inputEndDate, setInputEndDate] = useState(timeRange?.upper)
@@ -416,7 +416,7 @@ const DatePickerMenu: FC<Props> = ({onCollapse, timeRange, timeRangeLabel}) => {
 
 const DatePicker: FC = () => {
   const timeZone = useSelector(getTimeZone)
-  const {range} = useContext(PersistanceContext)
+  const {range} = useContext(PersistenceContext)
 
   const [timeRange, setTimeRange] = useState(range)
 

--- a/src/visualization/utils/useZoomQuery.ts
+++ b/src/visualization/utils/useZoomQuery.ts
@@ -10,8 +10,8 @@ import {PipeContext} from 'src/flows/context/pipe'
 import {FlowQueryContext} from 'src/flows/context/flow.query'
 import {
   DEFAULT_FLUX_EDITOR_TEXT,
-  PersistanceContext,
-} from 'src/dataExplorer/context/persistance'
+  PersistenceContext,
+} from 'src/dataExplorer/context/persistence'
 
 // Selector
 import {getActiveQueryIndex} from 'src/timeMachine/selectors'
@@ -23,7 +23,7 @@ interface ZoomQueries {
 
 export const useZoomQuery = (queries: DashboardQuery[] = []): ZoomQueries => {
   const activeQueryIndex = useSelector(getActiveQueryIndex)
-  const {query} = useContext(PersistanceContext)
+  const {query} = useContext(PersistenceContext)
   const {id} = useContext(PipeContext)
   const {getPanelQueries} = useContext(FlowQueryContext)
   const queryTexts = queries.map(query => `${query.text}`)


### PR DESCRIPTION
Closes #6649 

This PR fixes typos:
`src/dataExplorer/context/persistance.ts` --> `src/dataExplorer/context/persistence.ts`
`PersistanceContext` --> `PersistenceContext`
`PersistanceProvider` --> `PersistenceProvider`

No new code is added, and nothing was deleted except the typos. 

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
