### PR TITLE
fix(sql): disable the run button until a measurement is selected

### DIFF
--- a/src/dataExplorer/components/ResultsPane.tsx
+++ b/src/dataExplorer/components/ResultsPane.tsx
@@ -96,6 +96,14 @@ const ResultsPane: FC = () => {
   } else if (language === LanguageType.SQL && !selection.bucket) {
     submitButtonDisabled = true
     disabledTitleText = 'Select a bucket before running script'
+  } else if (
+    language === LanguageType.SQL &&
+    selection.composition.synced && // using composition
+    selection.bucket &&
+    !Boolean(selection.measurement)
+  ) {
+    submitButtonDisabled = true
+    disabledTitleText = 'Select a measurement before running script'
   } else if (language === LanguageType.INFLUXQL && !selection.dbrp) {
     submitButtonDisabled = true
     disabledTitleText =


### PR DESCRIPTION
Closes #6601

I came across the origin issue and found that it is a low hanging fruit. 

This PR disables the run button for SQL script editor until a measurement is selected when the composition sync is on. A message will show up when users hover over the disabled run button. 

## Before

https://github.com/influxdata/ui/assets/14298407/0ec88005-74ec-4999-8eb2-6e80feb5e98b


## After

<img width="1481" alt="Screen Shot 2023-06-07 at 11 07 55 AM" src="https://github.com/influxdata/ui/assets/14298407/5886dbc1-6d50-4166-8a40-c7adea0cf813">

https://github.com/influxdata/ui/assets/14298407/9c03dffc-db70-411f-9ee1-e88673a57b74


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
