### PR TITLE
chore(announcement): fix dev warning

### DIFF
--- a/src/me/components/CloudWidgets.tsx
+++ b/src/me/components/CloudWidgets.tsx
@@ -48,14 +48,14 @@ export const CloudWidgets: FC = () => {
                   Grafana now has a community plugin that enables communication
                   with Flight SQL-compatible databases.
                 </p>
-                <p>
+                <div>
                   What does that mean for you?
                   <ul>
                     <li>InfluxDB 3.0 Support and Compatibility</li>
                     <li>Easy Setup with Grafana Cloud</li>
                     <li>Enhanced Data Querying and Visualization</li>
                   </ul>
-                </p>
+                </div>
               </>
             }
             ctaLink="https://www.influxdata.com/blog/now-available-flight-sql-plugin-grafana/?utm_source=in-app&utm_medium=product&utm_campaign=2023-04-35_blog_flight-sql-plugin-grafana"


### PR DESCRIPTION
I found this warning when I was working on another UI dev work. Seems like a quick fix.

## Before

<img width="1510" alt="Screen Shot 2023-06-07 at 3 09 28 PM" src="https://github.com/influxdata/ui/assets/14298407/122d8b7a-9d12-46bd-880f-834fe1f1671f">


## After

<img width="1508" alt="Screen Shot 2023-06-07 at 3 10 43 PM" src="https://github.com/influxdata/ui/assets/14298407/a9e2930e-d6f9-400a-a009-a1d5170e9856">

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
