### PR TITLE
feat(influxql): add csv download

### DIFF
--- a/jestSetup.ts
+++ b/jestSetup.ts
@@ -40,6 +40,7 @@ jest.mock('src/languageSupport/languages/flux/lspUtils', () => ({
 
 jest.mock('src/shared/workers/serviceWorker', () => ({
   registerServiceWorker: jest.fn(),
+  registerServiceWorkerInfluxQL: jest.fn(),
 }))
 
 class Worker {

--- a/src/dashboards/selectors/index.test.ts
+++ b/src/dashboards/selectors/index.test.ts
@@ -116,6 +116,7 @@ describe('Dashboards.Selector', () => {
         flowsCTA: {explorer: true, alerts: true, tasks: true},
         subscriptionsCertificateInterest: false,
         workerRegistration: null,
+        workerRegistrationInfluxQL: null,
       },
     }
 
@@ -142,6 +143,7 @@ describe('Dashboards.Selector', () => {
         flowsCTA: {explorer: true, alerts: true, tasks: true},
         subscriptionsCertificateInterest: false,
         workerRegistration: null,
+        workerRegistrationInfluxQL: null,
       },
     }
 
@@ -176,6 +178,7 @@ describe('Dashboards.Selector', () => {
         flowsCTA: {explorer: true, alerts: true, tasks: true},
         subscriptionsCertificateInterest: false,
         workerRegistration: null,
+        workerRegistrationInfluxQL: null,
       },
     }
 
@@ -210,6 +213,7 @@ describe('Dashboards.Selector', () => {
         flowsCTA: {explorer: true, alerts: true, tasks: true},
         subscriptionsCertificateInterest: false,
         workerRegistration: null,
+        workerRegistrationInfluxQL: null,
       },
     }
 
@@ -240,6 +244,7 @@ describe('Dashboards.Selector', () => {
         flowsCTA: {explorer: true, alerts: true, tasks: true},
         subscriptionsCertificateInterest: false,
         workerRegistration: null,
+        workerRegistrationInfluxQL: null,
       },
     }
 

--- a/src/dataExplorer/components/ResultsPane.tsx
+++ b/src/dataExplorer/components/ResultsPane.tsx
@@ -119,9 +119,33 @@ const ResultsPane: FC = () => {
   }
 
   const downloadByServiceWorker = () => {
-    // TODO (chunchun): https://github.com/influxdata/ui/issues/6704
     if (language === LanguageType.INFLUXQL) {
-      console.error('csv download for InfluxQL is not implemented')
+      try {
+        event('runQuery.downloadCSV.influxql', {context: 'query experience'})
+
+        const params = new URLSearchParams({
+          db: selection.dbrp?.database,
+          q: text,
+        })
+        if (selection.dbrp?.retention_policy) {
+          params.set('rp', selection.dbrp?.retention_policy)
+        }
+        const url = `${API_BASE_PATH}query?${params}`
+        const hiddenForm = document.createElement('form')
+        hiddenForm.setAttribute('id', 'downloadDiv')
+        hiddenForm.setAttribute('style', 'display: none;')
+        hiddenForm.setAttribute('method', 'post')
+        hiddenForm.setAttribute('action', url)
+
+        const input = document.createElement('input')
+        input.setAttribute('name', 'data')
+        input.setAttribute('value', '')
+        hiddenForm.appendChild(input)
+        document.body.appendChild(hiddenForm)
+        hiddenForm.submit()
+      } catch (error) {
+        dispatch(notify(csvDownloadFailure()))
+      }
       return
     }
 
@@ -277,12 +301,10 @@ const ResultsPane: FC = () => {
               margin={ComponentSize.Small}
             >
               <QueryTime />
-              {resource?.language === LanguageType.INFLUXQL ? null : (
-                <CSVExportButton
-                  disabled={submitButtonDisabled}
-                  download={downloadByServiceWorker}
-                />
-              )}
+              <CSVExportButton
+                disabled={submitButtonDisabled}
+                download={downloadByServiceWorker}
+              />
               <NewDatePicker />
               <SubmitQueryButton
                 className="submit-btn"

--- a/src/dataExplorer/components/ResultsPane.tsx
+++ b/src/dataExplorer/components/ResultsPane.tsx
@@ -119,71 +119,61 @@ const ResultsPane: FC = () => {
   }
 
   const downloadByServiceWorker = () => {
-    if (language === LanguageType.INFLUXQL) {
-      try {
-        event('runQuery.downloadCSV.influxql', {context: 'query experience'})
-
-        const params = new URLSearchParams({
-          db: selection.dbrp?.database,
-          q: text,
-        })
-        if (selection.dbrp?.retention_policy) {
-          params.set('rp', selection.dbrp?.retention_policy)
-        }
-        const url = `${API_BASE_PATH}query?${params}`
-        const hiddenForm = document.createElement('form')
-        hiddenForm.setAttribute('id', 'downloadDiv')
-        hiddenForm.setAttribute('style', 'display: none;')
-        hiddenForm.setAttribute('method', 'post')
-        hiddenForm.setAttribute('action', url)
-
-        const input = document.createElement('input')
-        input.setAttribute('name', 'data')
-        input.setAttribute('value', '')
-        hiddenForm.appendChild(input)
-        document.body.appendChild(hiddenForm)
-        hiddenForm.submit()
-      } catch (error) {
-        dispatch(notify(csvDownloadFailure()))
-      }
-      return
-    }
+    event(`runQuery.downloadCSV`, {context: `query experience: ${language}`})
 
     try {
-      event('runQuery.downloadCSV', {context: 'query experience'})
+      let url: string = ''
+      let inputValue: string = ''
 
-      const url = `${API_BASE_PATH}api/v2/query?${new URLSearchParams({orgID})}`
+      switch (language) {
+        case LanguageType.FLUX:
+        case LanguageType.SQL:
+          url = `${API_BASE_PATH}api/v2/query?${new URLSearchParams({orgID})}`
+          const query =
+            language == LanguageType.SQL
+              ? sqlAsFlux(text, selection.bucket)
+              : text
+          const extern = updateWindowPeriod(
+            query,
+            {
+              vars: rangeToParam(range),
+            },
+            'ast'
+          )
+          inputValue = JSON.stringify({
+            query,
+            extern,
+            dialect: {annotations: ['group', 'datatype', 'default']},
+          })
+          break
+        case LanguageType.INFLUXQL:
+          const params = new URLSearchParams({
+            db: selection.dbrp?.database,
+            q: text,
+          })
+          if (selection.dbrp?.retention_policy) {
+            params.set('rp', selection.dbrp?.retention_policy)
+          }
+          url = `${API_BASE_PATH}query?${params}`
+          break
+        default:
+          throw new Error(`Language not supported - ${language}`)
+      }
+
       const hiddenForm = document.createElement('form')
       hiddenForm.setAttribute('id', 'downloadDiv')
       hiddenForm.setAttribute('style', 'display: none;')
       hiddenForm.setAttribute('method', 'post')
       hiddenForm.setAttribute('action', url)
 
-      const query =
-        language == LanguageType.SQL ? sqlAsFlux(text, selection.bucket) : text
-      const extern = updateWindowPeriod(
-        query,
-        {
-          vars: rangeToParam(range),
-        },
-        'ast'
-      )
-
       const input = document.createElement('input')
       input.setAttribute('name', 'data')
-      input.setAttribute(
-        'value',
-        JSON.stringify({
-          query,
-          extern,
-          dialect: {annotations: ['group', 'datatype', 'default']},
-        })
-      )
+      input.setAttribute('value', inputValue)
       hiddenForm.appendChild(input)
       document.body.appendChild(hiddenForm)
       hiddenForm.submit()
     } catch (error) {
-      dispatch(notify(csvDownloadFailure()))
+      dispatch(notify(csvDownloadFailure(error)))
     }
   }
 

--- a/src/dataExplorer/components/ResultsPane.tsx
+++ b/src/dataExplorer/components/ResultsPane.tsx
@@ -302,6 +302,7 @@ const ResultsPane: FC = () => {
             >
               <QueryTime />
               <CSVExportButton
+                language={language}
                 disabled={submitButtonDisabled}
                 download={downloadByServiceWorker}
               />

--- a/src/mockState.tsx
+++ b/src/mockState.tsx
@@ -37,6 +37,7 @@ export const localState: LocalStorage = {
       flowsCTA: {alerts: true, explorer: true, tasks: true},
       subscriptionsCertificateInterest: false,
       workerRegistration: null,
+      workerRegistrationInfluxQL: null,
     },
   },
   flags: {

--- a/src/shared/actions/app.ts
+++ b/src/shared/actions/app.ts
@@ -13,6 +13,7 @@ export enum ActionTypes {
   Noop = 'NOOP',
   SetSubscriptionsCertificateInterest = 'SET_SUB_CERT_INTEREST',
   SetWorkerRegistration = 'SET_WORKER_REGISTRATION',
+  SetWorkerRegistrationInfluxQL = 'SET_WORKER_REGISTRATION_INFLUXQL',
 }
 
 export type Action =
@@ -27,6 +28,7 @@ export type Action =
   | ReturnType<typeof setFlowsCTA>
   | ReturnType<typeof setSubscriptionsCertificateInterest>
   | ReturnType<typeof setWorkerRegistration>
+  | ReturnType<typeof setWorkerRegistrationInfluxQL>
 
 // ephemeral state action creators
 
@@ -93,4 +95,12 @@ export const setWorkerRegistration = (
   ({
     type: ActionTypes.SetWorkerRegistration,
     payload: {workerRegistration},
+  } as const)
+
+export const setWorkerRegistrationInfluxQL = (
+  workerRegistrationInfluxQL: Promise<ServiceWorkerRegistration>
+) =>
+  ({
+    type: ActionTypes.SetWorkerRegistrationInfluxQL,
+    payload: {workerRegistrationInfluxQL},
   } as const)

--- a/src/shared/contexts/app.tsx
+++ b/src/shared/contexts/app.tsx
@@ -11,6 +11,7 @@ import {
   setFlowsCTA as setFlowsCTAAction,
   setSubscriptionsCertificateInterest as setSubscriptionsCertificateInterestAction,
   setWorkerRegistration,
+  setWorkerRegistrationInfluxQL,
 } from 'src/shared/actions/app'
 import {
   timeZone as timeZoneFromState,
@@ -28,14 +29,15 @@ import {presentationMode as presentationModeCopy} from 'src/shared/copy/notifica
 import {AppState, TimeZone, Theme, NavBarState, FlowsCTA} from 'src/types'
 import {event} from 'src/cloud/utils/reporting'
 
-let workerRegistration
+let workerRegistration, workerRegistrationInfluxQL
 import(
   /* webpackPreload: true */
   /* webpackChunkName: "setup-interceptor" */
   'src/shared/workers/serviceWorker'
-).then(
-  ({registerServiceWorker}) => (workerRegistration = registerServiceWorker())
-)
+).then(({registerServiceWorker, registerServiceWorkerInfluxQL}) => {
+  workerRegistration = registerServiceWorker()
+  workerRegistrationInfluxQL = registerServiceWorkerInfluxQL()
+})
 
 interface AppSettingContextType {
   timeZone: TimeZone
@@ -46,6 +48,7 @@ interface AppSettingContextType {
   flowsCTA: FlowsCTA
   subscriptionsCertificateInterest: boolean
   workerRegistration: Promise<ServiceWorkerRegistration>
+  workerRegistrationInfluxQL: Promise<ServiceWorkerRegistration>
 
   setTimeZone: (zone: TimeZone) => void
   setTheme: (theme: Theme) => void
@@ -65,6 +68,7 @@ const DEFAULT_CONTEXT: AppSettingContextType = {
   flowsCTA: {alerts: true, explorer: true, tasks: true} as FlowsCTA,
   subscriptionsCertificateInterest: false,
   workerRegistration,
+  workerRegistrationInfluxQL,
 
   setTimeZone: (_zone: TimeZone) => {},
   setTheme: (_theme: Theme) => {},
@@ -151,6 +155,10 @@ export const AppSettingProvider: FC = ({children}) => {
     dispatch(setWorkerRegistration(workerRegistration))
   }, [workerRegistration])
 
+  useEffect(() => {
+    dispatch(setWorkerRegistrationInfluxQL(workerRegistrationInfluxQL))
+  }, [workerRegistrationInfluxQL])
+
   return (
     <AppSettingContext.Provider
       value={{
@@ -162,6 +170,7 @@ export const AppSettingProvider: FC = ({children}) => {
         flowsCTA,
         subscriptionsCertificateInterest,
         workerRegistration,
+        workerRegistrationInfluxQL,
 
         setTimeZone,
         setTheme,

--- a/src/shared/copy/notifications/categories/dashboard.ts
+++ b/src/shared/copy/notifications/categories/dashboard.ts
@@ -141,9 +141,9 @@ export const copyQueryFailure = (cellName: string = ''): Notification => {
   }
 }
 
-export const csvDownloadFailure = (): Notification => ({
+export const csvDownloadFailure = (msg: string = ''): Notification => ({
   ...defaultErrorNotification,
-  message: 'Failed to download csv.',
+  message: `Failed to download csv. ${msg}`,
 })
 
 export const oldSession = (): Notification => ({

--- a/src/shared/reducers/app.test.ts
+++ b/src/shared/reducers/app.test.ts
@@ -26,6 +26,7 @@ describe('Shared.Reducers.appReducer', () => {
       flowsCTA: {explorer: true, tasks: true, alerts: true},
       subscriptionsCertificateInterest: false,
       workerRegistration: null,
+      workerRegistrationInfluxQL: null,
     },
   }
 

--- a/src/shared/reducers/app.ts
+++ b/src/shared/reducers/app.ts
@@ -20,6 +20,7 @@ export interface AppState {
     flowsCTA: FlowsCTA
     subscriptionsCertificateInterest: boolean
     workerRegistration: Promise<ServiceWorkerRegistration>
+    workerRegistrationInfluxQL: Promise<ServiceWorkerRegistration>
   }
 }
 
@@ -38,6 +39,7 @@ const initialState: AppState = {
     flowsCTA: {explorer: true, tasks: true, alerts: true},
     subscriptionsCertificateInterest: false,
     workerRegistration: null,
+    workerRegistrationInfluxQL: null,
   },
 }
 
@@ -132,6 +134,13 @@ const appPersistedReducer = (
       return {
         ...state,
         workerRegistration: action.payload.workerRegistration,
+      }
+    }
+
+    case ActionTypes.SetWorkerRegistrationInfluxQL: {
+      return {
+        ...state,
+        workerRegistrationInfluxQL: action.payload.workerRegistrationInfluxQL,
       }
     }
 

--- a/src/shared/workers/downloadHelper.ts
+++ b/src/shared/workers/downloadHelper.ts
@@ -24,10 +24,13 @@
 */
 
 self.addEventListener('fetch', function (event: any) {
-  const contentType = (event.request.headers as Headers).get('Content-Type')
+  const contentType: string = (event.request.headers as Headers).get(
+    'Content-Type'
+  )
+  const pathname: string = new URL(event.request.url).pathname
   if (
-    new URL(event.request.url).pathname == '/query' &&
-    contentType == 'application/x-www-form-urlencoded'
+    (pathname === '/api/v2/query' || pathname === '/query') &&
+    contentType === 'application/x-www-form-urlencoded'
   ) {
     const headers = new Headers()
     for (const [headerType, headerValue] of event.request.headers) {

--- a/src/shared/workers/downloadHelper.ts
+++ b/src/shared/workers/downloadHelper.ts
@@ -26,7 +26,7 @@
 self.addEventListener('fetch', function (event: any) {
   const contentType = (event.request.headers as Headers).get('Content-Type')
   if (
-    new URL(event.request.url).pathname == '/api/v2/query' &&
+    new URL(event.request.url).pathname == '/query' &&
     contentType == 'application/x-www-form-urlencoded'
   ) {
     const headers = new Headers()

--- a/src/shared/workers/serviceWorker.ts
+++ b/src/shared/workers/serviceWorker.ts
@@ -7,11 +7,28 @@ export const registerServiceWorker = (): Promise<ServiceWorkerRegistration> => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       new URL('../workers/downloadHelper.ts', import.meta.url),
-      // {scope: '/api/v2/query'}
-      {scope: '/query'}
+      {scope: '/api/v2/query'}
       /* webpackChunkName: "interceptor" */
     )
   }
 
   return workerRegistration
 }
+
+export const registerServiceWorkerInfluxQL =
+  (): Promise<ServiceWorkerRegistration> => {
+    // Worker -- load prior to page load event, in order to intercept fetch in http/2.
+    // see service worker life cycle. https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers
+    let workerRegistrationInfluxQL = null
+    if ('serviceWorker' in navigator) {
+      workerRegistrationInfluxQL = navigator.serviceWorker.register(
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        new URL('../workers/downloadHelper.ts', import.meta.url),
+        {scope: '/query'}
+        /* webpackChunkName: "interceptor" */
+      )
+    }
+
+    return workerRegistrationInfluxQL
+  }

--- a/src/shared/workers/serviceWorker.ts
+++ b/src/shared/workers/serviceWorker.ts
@@ -7,7 +7,8 @@ export const registerServiceWorker = (): Promise<ServiceWorkerRegistration> => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       new URL('../workers/downloadHelper.ts', import.meta.url),
-      {scope: '/api/v2/query'}
+      // {scope: '/api/v2/query'}
+      {scope: '/query'}
       /* webpackChunkName: "interceptor" */
     )
   }

--- a/src/timeMachine/components/Queries.tsx
+++ b/src/timeMachine/components/Queries.tsx
@@ -38,6 +38,7 @@ import {getTimeRange} from 'src/dashboards/selectors'
 
 // Types
 import {TimeRange, AutoRefreshStatus} from 'src/types'
+import {LanguageType} from 'src/dataExplorer/components/resources'
 
 type Props = {
   maxHeight: number
@@ -97,7 +98,10 @@ const TimeMachineQueries: FC<Props> = ({maxHeight}) => {
           <RawDataToggle />
           {!isInCheckOverlay && (
             <>
-              <CSVExportButton disabled={activeQuery.text === ''} />
+              <CSVExportButton
+                disabled={activeQuery.text === ''}
+                language={LanguageType.FLUX}
+              />
               <TimeMachineRefreshDropdown />
               <TimeRangeDropdown
                 timeRange={timeRange}


### PR DESCRIPTION
Closes #6704

This PR adds CSV download to the InfluxQL script editor. In addition, a service worker for scope `/query` is also added to make the feature complete. 

If you wonder why the UI uses service worker to download csv file, [here](https://github.com/influxdata/ui/blob/9c77358d8d75e2c7bff59203db4324471d93506a/src/shared/workers/downloadHelper.ts#L2-L23) is a good explanation. The TL;DR summary is that service worker can perform tasks in the background, which makes downloading large csv file fast and not blocking other UI interactions. 

The backend work (https://github.com/influxdata/idpe/pull/17737) is already merged.

## Before

<img width="1500" alt="Screen Shot 2023-06-09 at 4 39 03 PM" src="https://github.com/influxdata/ui/assets/14298407/fec1e290-5afb-4ec9-8bce-c873f570cf5a">


## After

https://github.com/influxdata/ui/assets/14298407/e210d453-5aac-4fb3-92a4-761f62e50e9b




All the work is behind the feature flag `influxqlUI`.

To test on local remocal:

1. create DBRP mappings in your org ([instruction](https://github.com/influxdata/idpe/issues/17205)), and
2. also make sure to turn on the following flags in your browser:
    * `showOldDataExplorerInNewIOx`
    * `schemaComposition`

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
