### PR TITLE
chore: add double quotations to database and retention policy names

### DIFF
--- a/src/languageSupport/languages/influxql/connection.ts
+++ b/src/languageSupport/languages/influxql/connection.ts
@@ -39,8 +39,8 @@ export class ConnectionManager extends AgnosticConnectionManager {
     const dbrpMeasurement: string[] = []
     if (this._session.dbrp) {
       dbrpMeasurement.push(
-        this._session.dbrp.database,
-        this._session.dbrp.retention_policy
+        `"${this._session.dbrp.database}"`,
+        `"${this._session.dbrp.retention_policy}"`
       )
     }
     if (this._session.measurement) {


### PR DESCRIPTION
Closes #6724

Fix a minor bug in InfluxQL composition sync -- add double quotations around database name and retention policy name which are called identifiers in InfluxQL. 

Recommendation from [InfluxQL doc](https://docs.influxdata.com/influxdb/cloud/query-data/influxql/explore-data/select/#quoting):

> [Identifiers](https://docs.influxdata.com/influxdb/cloud/reference/syntax/influxql/spec/#identifiers) must be double quoted if they contain characters other than [A-z,0-9,_], begin with a digit, or are an [InfluxQL keyword](https://github.com/influxdata/influxql/blob/master/README.md#keywords). While not always necessary, we recommend that you double quote identifiers.



## Before

https://github.com/influxdata/ui/assets/14298407/f13290ac-cec1-4ce3-bbd7-d21cfdf89296


## After


https://github.com/influxdata/ui/assets/14298407/30aad137-a9f6-4e5f-b441-58b3520a6245



All the work is behind the feature flag `influxqlUI`.

To test on local remocal:

1. create DBRP mappings in your org ([instruction](https://github.com/influxdata/idpe/issues/17205)), and
2. also make sure to turn on the following flags in your browser:
    * `showOldDataExplorerInNewIOx`
    * `schemaComposition`

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
