### PR TITLE
fix(influxql): add selected tag keys to `SELECT` statement

### DIFF
--- a/src/dataExplorer/components/DBRPSelector.tsx
+++ b/src/dataExplorer/components/DBRPSelector.tsx
@@ -157,7 +157,7 @@ export const DBRPSelector: FC = () => {
                 onChange={handleSearchChange}
                 onBlur={() => setIsSearchActive(false)}
                 value={searchTerm}
-                placeholder="Search DBRPs"
+                placeholder="Search database/retention policy combinations"
                 size={ComponentSize.Small}
                 autoFocus={true}
                 testID="dbrp-selector--search-bar"

--- a/src/languageSupport/languages/agnostic/utils.test.ts
+++ b/src/languageSupport/languages/agnostic/utils.test.ts
@@ -1,0 +1,53 @@
+import {TagKeyValuePair} from 'src/types'
+import {
+  groupedTagValues,
+  getTagKeys,
+} from 'src/languageSupport/languages/agnostic/utils'
+
+const input: TagKeyValuePair[] = [
+  {key: 'a', value: 'a1'},
+  {key: 'a', value: 'a2'},
+  {key: 'b', value: 'b1'},
+  {key: 'c', value: 'c1'},
+]
+
+const inputOutOfOrder: TagKeyValuePair[] = [
+  {key: 'c', value: 'c2'},
+  {key: 'a', value: 'a1'},
+  {key: 'a', value: 'a3'},
+  {key: 'a', value: 'a2'},
+  {key: 'b', value: 'b1'},
+  {key: 'c', value: 'c1'},
+]
+
+describe('groupedTagValues', () => {
+  it('happy path', () => {
+    const expectResult: {[key: string]: string[]} = {
+      a: ['a1', 'a2'],
+      b: ['b1'],
+      c: ['c1'],
+    }
+    expect(groupedTagValues(input)).toEqual(expectResult)
+  })
+
+  it('key order does not matter, but value order matters', () => {
+    const expectResult: {[key: string]: string[]} = {
+      a: ['a1', 'a3', 'a2'],
+      b: ['b1'],
+      c: ['c2', 'c1'],
+    }
+    expect(groupedTagValues(inputOutOfOrder)).toEqual(expectResult)
+  })
+})
+
+describe('getTagKeys', () => {
+  it('happy path -- return unique keys when some keys are duplicated', () => {
+    const expectResult: string[] = ['a', 'b', 'c']
+    expect(getTagKeys(input)).toEqual(expectResult)
+  })
+
+  it('order matters', () => {
+    const expectResult: string[] = ['c', 'a', 'b']
+    expect(getTagKeys(inputOutOfOrder)).toEqual(expectResult)
+  })
+})

--- a/src/languageSupport/languages/agnostic/utils.ts
+++ b/src/languageSupport/languages/agnostic/utils.ts
@@ -11,3 +11,11 @@ export const groupedTagValues = (
     }),
     {}
   )
+
+export const getTagKeys = (tagValues: TagKeyValuePair[]): string[] => {
+  const tagKeys = new Set<string>()
+  tagValues.forEach((pair: TagKeyValuePair) => {
+    tagKeys.add(pair.key)
+  })
+  return Array.from(tagKeys)
+}

--- a/src/languageSupport/languages/influxql/connection.ts
+++ b/src/languageSupport/languages/influxql/connection.ts
@@ -10,7 +10,6 @@ import {
   RecursivePartial,
   SelectableDurationTimeRange,
   TimeRange,
-  TagKeyValuePair,
 } from 'src/types'
 import {LspRange} from 'src/languageSupport/languages/agnostic/types'
 
@@ -19,28 +18,11 @@ import {DEFAULT_TIME_RANGE} from 'src/shared/constants/timeRanges'
 import {rangeToInfluxQLInterval as buildTimeRange} from 'src/shared/utils/rangeToInterval'
 import {notify} from 'src/shared/actions/notifications'
 import {compositionEnded} from 'src/shared/copy/notifications'
-import {groupedTagValues} from 'src/languageSupport/languages/agnostic/utils'
+import {
+  groupedTagValues,
+  getTagKeys,
+} from 'src/languageSupport/languages/agnostic/utils'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
-
-/*
-  Input:
-  [
-    {key: 'a', value: '1'},
-    {key: 'a', value: '2'},
-    {key: 'b', value: '1'},
-    {key: 'c', value: '1'},
-  ]
-
-  Output:
-  ['a', 'b', 'c']
-*/
-const getTagKeys = (tagValues: TagKeyValuePair[]): string[] => {
-  const tagKeys = new Set<string>()
-  tagValues.forEach((pair: TagKeyValuePair) => {
-    tagKeys.add(pair.key)
-  })
-  return Array.from(tagKeys)
-}
 
 export class ConnectionManager extends AgnosticConnectionManager {
   private _timeRange: TimeRange = DEFAULT_TIME_RANGE

--- a/src/languageSupport/languages/influxql/connection.ts
+++ b/src/languageSupport/languages/influxql/connection.ts
@@ -31,9 +31,11 @@ export class ConnectionManager extends AgnosticConnectionManager {
   } => {
     let lines: number = 1
 
-    const fieldsExpr = this._session.fields.map(f => `"${f}"`).join(', ')
+    const tagKeys = Object.entries(groupedTagValues(this._session.tagValues))
+    console.log({sessionTagKeys: this._session.tagValues, tagKeys, objEntries: Object.keys(this._session.tagValues)})
+    const selectedColumns = this._session.fields.map(f => `"${f}"`).join(', ')
     let composition = [
-      `SELECT ${this._session.fields.length === 0 ? '*' : fieldsExpr}`,
+      `SELECT ${this._session.fields.length === 0 ? '*' : selectedColumns}`,
     ]
 
     const dbrpMeasurement: string[] = []


### PR DESCRIPTION
Closes #6715

This PR adds the selected tag keys to the `SELECT` statement so that the tag keys show up as a column in the result table

## Before

https://github.com/influxdata/ui/assets/14298407/7c163da3-48fa-4b92-bb98-6fa9efeb72a4

## After

https://github.com/influxdata/ui/assets/14298407/d35b8bcb-c4e9-497f-a723-b93e15fd14ea


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
