### PR TITLE
chore(influxql): support save/load

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "prettier:fix": "pretty-quick --config .prettierrc.json --write '{src,cypress}/**/*.{ts,tsx}'",
     "tsc": "tsc -p ./tsconfig.json --noEmit --pretty --skipLibCheck",
     "tsc:watch": "yarn tsc --watch",
-    "generate": "export SHA=cb2c4f0687ba9a4635fcf96d2fd5e76a074059ea && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
+    "generate": "export SHA=eec3a9ed87d664529e6a5dddad76232ed9e823bf && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-local-cloud": "export REMOTE=../openapi/ && yarn generate-meta-cloud",
     "generate-meta": "if [ -z \"${CLOUD_URL}\" ]; then yarn generate-meta-oss; else yarn generate-meta-cloud; fi",

--- a/src/dataExplorer/components/ScriptQueryBuilder.scss
+++ b/src/dataExplorer/components/ScriptQueryBuilder.scss
@@ -56,6 +56,6 @@
 .script-dropdown__sql {
   text-transform: uppercase;
 }
-.script-dropdown__influxQL {
+.script-dropdown__influxql {
   text-transform: capitalize;
 }

--- a/src/dataExplorer/components/ScriptQueryBuilder.tsx
+++ b/src/dataExplorer/components/ScriptQueryBuilder.tsx
@@ -149,7 +149,7 @@ const ScriptQueryBuilder: FC = () => {
           selected={resource?.language === LanguageType.INFLUXQL}
           testID={`script-dropdown__${LanguageType.INFLUXQL}`}
         >
-          {LanguageType.INFLUXQL}
+          InfluxQL
         </Dropdown.Item>
       ) : null}
     </Dropdown.Menu>
@@ -176,7 +176,7 @@ const ScriptQueryBuilder: FC = () => {
           selected={resource?.language === LanguageType.INFLUXQL}
           testID={`script-dropdown__${LanguageType.INFLUXQL}`}
         >
-          {LanguageType.INFLUXQL}
+          InfluxQL
         </Dropdown.Item>
       ) : null}
     </Dropdown.Menu>

--- a/src/dataExplorer/components/resources/index.ts
+++ b/src/dataExplorer/components/resources/index.ts
@@ -7,7 +7,7 @@ export const SCRIPT_EDITOR_PARAMS = '?fluxScriptEditor'
 export enum LanguageType {
   FLUX = 'flux',
   SQL = 'sql',
-  INFLUXQL = 'influxQL',
+  INFLUXQL = 'influxql',
 }
 export interface ResourceConnectedQuery<T> {
   type: ResourceType

--- a/src/languageSupport/languages/influxql/monaco.influxql.theme.ts
+++ b/src/languageSupport/languages/influxql/monaco.influxql.theme.ts
@@ -1,7 +1,7 @@
 import {MonacoType} from 'src/types'
 import {InfluxColors} from '@influxdata/clockface'
 
-const THEME_NAME = 'influxQLTheme'
+const THEME_NAME = 'influxqlTheme'
 
 function addTheme(monaco: MonacoType) {
   // Using the tokenizer defined in

--- a/src/shared/components/FluxMonacoEditor.tsx
+++ b/src/shared/components/FluxMonacoEditor.tsx
@@ -23,7 +23,6 @@ import {ConnectionManager} from 'src/languageSupport/languages/flux/lsp/connecti
 import {EditorContext} from 'src/shared/contexts/editor'
 import {PersistenceContext} from 'src/dataExplorer/context/persistence'
 import {scriptQueryBuilder} from 'src/shared/selectors/app'
-import {isOrgIOx} from 'src/organizations/selectors'
 
 // Types
 import {OnChangeScript} from 'src/types/flux'
@@ -66,7 +65,6 @@ const FluxEditorMonaco: FC<Props> = ({
   const {editor, setEditor} = useContext(EditorContext)
   const isScriptQueryBuilder = useSelector(scriptQueryBuilder)
   const sessionStore = useContext(PersistenceContext)
-  const isIoxOrg = useSelector(isOrgIOx)
   const {path} = useRouteMatch()
   const isInScriptQueryBuilder =
     isScriptQueryBuilder && path === '/orgs/:orgID/data-explorer'
@@ -166,13 +164,13 @@ const FluxEditorMonaco: FC<Props> = ({
             }}
             editorDidMount={editorDidMount}
           />
-          {isIoxOrg && isInScriptQueryBuilder && (
+          {isInScriptQueryBuilder && (
             <div className="monaco-editor__language">{FLUXLANGID}</div>
           )}
         </div>
       </ErrorBoundary>
     ),
-    [isIoxOrg, onChangeScript, setEditor, useSchemaComposition, script]
+    [onChangeScript, setEditor, useSchemaComposition, script]
   )
 }
 


### PR DESCRIPTION
Closes #6730

This PR is the last piece to support InfluxQL save/load. The backend works (https://github.com/influxdata/idpe/pull/17768 and https://github.com/influxdata/openapi/pull/639) have already been merged. 

## Changes to note
1. Update the OpenAPI SHA to the latest https://github.com/influxdata/openapi/commit/eec3a9ed87d664529e6a5dddad76232ed9e823bf
2. Change the language code to all lowercase `influxql`, which was requested in https://github.com/influxdata/openapi/pull/639#discussion_r1230218119. Now idpe, OpenAPI, and UI are all in consistency using the same language code.
3. Minor fix: show `FLUX` in the script editor for TSM orgs, so that users can differentiate which script editor they are using. 

## Before

<img width="1487" alt="Screen Shot 2023-06-14 at 5 10 27 PM" src="https://github.com/influxdata/ui/assets/14298407/5f90429e-83a3-4f38-85c9-62e74ca3df4a">

<img width="1412" alt="Screen Shot 2023-06-15 at 2 29 28 PM" src="https://github.com/influxdata/ui/assets/14298407/a03f7a10-9d2b-416f-a56e-55a9b28b5c71">


## After

https://github.com/influxdata/ui/assets/14298407/7db99df9-474f-4651-bd6a-4b38ab7ade3b

<img width="1419" alt="Screen Shot 2023-06-15 at 1 59 13 PM" src="https://github.com/influxdata/ui/assets/14298407/d3a2b355-c2cf-4dc0-82ae-9c75f301af74">
 

## To test on local remocal:

All the work is behind the feature flag `influxqlUI`.

1. create DBRP mappings in your org ([instruction](https://github.com/influxdata/idpe/issues/17205)), and
2. also make sure to turn on the following flags in your browser:
    * `influxqlUI`
    * `showOldDataExplorerInNewIOx`
    * `schemaComposition`

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
