### PR TITLE
fix: Hide reactivate org button for cancelled accounts

### DIFF
--- a/src/operator/OrgOverlay.tsx
+++ b/src/operator/OrgOverlay.tsx
@@ -4,6 +4,7 @@ import {useHistory, useParams} from 'react-router-dom'
 import {
   ButtonBase,
   ButtonShape,
+  ButtonType,
   Columns,
   ComponentColor,
   ComponentSize,
@@ -56,7 +57,9 @@ const OrgOverlay: FC = () => {
   const {orgID} = useParams<{orgID: string}>()
   const history = useHistory()
   const canReactivateOrg =
-    hasWritePermissions && organization?.state === 'suspended'
+    hasWritePermissions &&
+    organization?.state === 'suspended' &&
+    organization?.account?.type != 'cancelled'
 
   const isIOx =
     organization?.storageType &&
@@ -85,7 +88,6 @@ const OrgOverlay: FC = () => {
 
   const reactivateOrg = async () => {
     await handleReactivateOrg(orgID)
-    history.goBack()
   }
 
   return (
@@ -151,6 +153,7 @@ const OrgOverlay: FC = () => {
                             : ComponentStatus.Default
                         }
                         testID="org-overlay-reactivate-organization--button"
+                        type={ButtonType.Button}
                       >
                         Reactivate Organization
                       </ButtonBase>


### PR DESCRIPTION
Part of #6708 

When an account is canceled, we should not show the reactivate option, even if the org is suspended.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
