### PR TITLE
feat(operator): Add Org `DeleteOn` and Account `CancelledAt` dates

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "prettier:fix": "pretty-quick --config .prettierrc.json --write '{src,cypress}/**/*.{ts,tsx}'",
     "tsc": "tsc -p ./tsconfig.json --noEmit --pretty --skipLibCheck",
     "tsc:watch": "yarn tsc --watch",
-    "generate": "export SHA=eec3a9ed87d664529e6a5dddad76232ed9e823bf && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
+    "generate": "export SHA=993f6756500aebe47903a3ddaee62f9f75d207c1 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-local-cloud": "export REMOTE=../openapi/ && yarn generate-meta-cloud",
     "generate-meta": "if [ -z \"${CLOUD_URL}\" ]; then yarn generate-meta-oss; else yarn generate-meta-cloud; fi",

--- a/src/operator/OrgOverlay.tsx
+++ b/src/operator/OrgOverlay.tsx
@@ -91,6 +91,7 @@ const OrgOverlay: FC = () => {
   const deleteOn = organization?.deleteOn
     ? new Date(organization?.deleteOn)
     : null
+  const hasDeleteDate = Boolean(deleteOn)
 
   return (
     <Overlay
@@ -187,7 +188,7 @@ const OrgOverlay: FC = () => {
                       Delete On
                     </label>
                     <p>
-                      {organization?.state === 'suspended' && deleteOn
+                      {organization?.state === 'suspended' && hasDeleteDate
                         ? `${deleteOn.toLocaleTimeString()} ${deleteOn.toDateString()}`
                         : 'N/A'}
                     </p>

--- a/src/operator/OrgOverlay.tsx
+++ b/src/operator/OrgOverlay.tsx
@@ -88,6 +88,10 @@ const OrgOverlay: FC = () => {
     history.goBack()
   }
 
+  const deleteOn = organization?.deleteOn
+    ? new Date(organization?.deleteOn)
+    : null
+
   return (
     <Overlay
       visible={true}
@@ -169,6 +173,24 @@ const OrgOverlay: FC = () => {
                       Account Type
                     </label>
                     <p>{organization?.account?.type ?? ''}</p>
+                  </Grid.Column>
+                </Grid.Row>
+                <Grid.Row>
+                  <Grid.Column widthMD={Columns.Four}>
+                    <label className="org-overlay-detail--text">
+                      Organization State
+                    </label>
+                    <p>{organization?.state ?? ''}</p>
+                  </Grid.Column>
+                  <Grid.Column widthMD={Columns.Four}>
+                    <label className="org-overlay-detail--text">
+                      Delete On
+                    </label>
+                    <p>
+                      {organization?.state === 'suspended' && deleteOn
+                        ? `${deleteOn.toLocaleTimeString()} ${deleteOn.toDateString()}`
+                        : 'N/A'}
+                    </p>
                   </Grid.Column>
                 </Grid.Row>
                 <SpinnerContainer

--- a/src/operator/account/AccountGrid.tsx
+++ b/src/operator/account/AccountGrid.tsx
@@ -23,6 +23,7 @@ const AccountGrid: FC = () => {
   const cancelledAt = account?.cancelledAt
     ? new Date(account?.cancelledAt)
     : null
+  const hasCancelledAt = Boolean(cancelledAt)
 
   return (
     <FlexBox
@@ -54,7 +55,7 @@ const AccountGrid: FC = () => {
         <AccountField
           header="Cancelled At"
           body={
-            account.type === 'cancelled' && cancelledAt
+            account.type === 'cancelled' && hasCancelledAt
               ? `${cancelledAt.toLocaleTimeString()} ${cancelledAt.toDateString()}`
               : 'N/A'
           }

--- a/src/operator/account/AccountGrid.tsx
+++ b/src/operator/account/AccountGrid.tsx
@@ -20,6 +20,10 @@ const AccountGrid: FC = () => {
     return account?.marketplaceSubscription?.subscriberId ?? 'N/A'
   }
 
+  const cancelledAt = account?.cancelledAt
+    ? new Date(account?.cancelledAt)
+    : null
+
   return (
     <FlexBox
       direction={FlexDirection.Row}
@@ -46,6 +50,15 @@ const AccountGrid: FC = () => {
           header="Cloud Provider"
           body={organizations?.[0]?.provider ?? 'N/A'}
           testID="cloud-provider"
+        />
+        <AccountField
+          header="Cancelled At"
+          body={
+            account.type === 'cancelled' && cancelledAt
+              ? `${cancelledAt.toLocaleTimeString()} ${cancelledAt.toDateString()}`
+              : 'N/A'
+          }
+          testID="cancelled-at"
         />
       </FlexBox>
       <FlexBox


### PR DESCRIPTION
Quartz now optionally includes the date an account was cancelled as well as the date a suspended org will be deleted on. We're going to show these in the UI.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
