### PR TITLE
feat(operators): Add reactivate account button

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "prettier:fix": "pretty-quick --config .prettierrc.json --write '{src,cypress}/**/*.{ts,tsx}'",
     "tsc": "tsc -p ./tsconfig.json --noEmit --pretty --skipLibCheck",
     "tsc:watch": "yarn tsc --watch",
-    "generate": "export SHA=993f6756500aebe47903a3ddaee62f9f75d207c1 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
+    "generate": "export SHA=d05381fbcee0dd5d88833e71057a4af647e0d169 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-local-cloud": "export REMOTE=../openapi/ && yarn generate-meta-cloud",
     "generate-meta": "if [ -z \"${CLOUD_URL}\" ]; then yarn generate-meta-oss; else yarn generate-meta-cloud; fi",

--- a/src/operator/account/AccountView.tsx
+++ b/src/operator/account/AccountView.tsx
@@ -9,6 +9,7 @@ import AssociatedUsersTable from 'src/operator/account/AssociatedUsersTable'
 import ConvertAccountToContractOverlay from 'src/operator/account/ConvertAccountToContractOverlay'
 import CancelAccountOverlay from 'src/operator/account/CancelAccountOverlay'
 import DeleteAccountOverlay from 'src/operator/account/DeleteAccountOverlay'
+import ReactivateAccountOverlay from 'src/operator/account/ReactivateAccountOverlay'
 import AccountViewHeader from 'src/operator/account/AccountViewHeader'
 import AccountGrid from 'src/operator/account/AccountGrid'
 import {AccountContext} from 'src/operator/context/account'
@@ -35,6 +36,7 @@ const AccountView: FC = () => {
             <ConvertAccountToContractOverlay />
             <CancelAccountOverlay />
             <DeleteAccountOverlay />
+            <ReactivateAccountOverlay />
             <AccountViewHeader />
             <AccountGrid />
             <h2 data-testid="associated-users--title">Associated Users</h2>

--- a/src/operator/account/AccountViewHeader.tsx
+++ b/src/operator/account/AccountViewHeader.tsx
@@ -25,7 +25,9 @@ const AccountViewHeader: FC = () => {
     setCancelOverlayVisible,
     cancelOverlayVisible,
     setDeleteOverlayVisible,
+    setReactivateOverlayVisible,
     deleteOverlayVisible,
+    reactivateOverlayVisible,
   } = useContext(AccountContext)
   const {hasWritePermissions} = useContext(OperatorContext)
   const canConvertToContract =
@@ -59,6 +61,16 @@ const AccountViewHeader: FC = () => {
           testID="account-convert-to-contract--button"
         >
           Convert to Contract
+        </ButtonBase>
+      )}
+      {hasWritePermissions && account?.reactivatable && (
+        <ButtonBase
+          color={ComponentColor.Primary}
+          shape={ButtonShape.Default}
+          onClick={() => setReactivateOverlayVisible(!reactivateOverlayVisible)}
+          testID="account-reactivate--button"
+        >
+          Reactivate Account
         </ButtonBase>
       )}
       {hasWritePermissions && account?.deletable && (

--- a/src/operator/account/AccountViewHeader.tsx
+++ b/src/operator/account/AccountViewHeader.tsx
@@ -27,7 +27,6 @@ const AccountViewHeader: FC = () => {
     setDeleteOverlayVisible,
     setReactivateOverlayVisible,
     deleteOverlayVisible,
-    reactivateOverlayVisible,
   } = useContext(AccountContext)
   const {hasWritePermissions} = useContext(OperatorContext)
   const canConvertToContract =
@@ -67,7 +66,7 @@ const AccountViewHeader: FC = () => {
         <ButtonBase
           color={ComponentColor.Primary}
           shape={ButtonShape.Default}
-          onClick={() => setReactivateOverlayVisible(!reactivateOverlayVisible)}
+          onClick={() => setReactivateOverlayVisible(true)}
           testID="account-reactivate--button"
         >
           Reactivate Account

--- a/src/operator/account/ReactivateAccountOverlay.tsx
+++ b/src/operator/account/ReactivateAccountOverlay.tsx
@@ -20,7 +20,7 @@ const ReactivateAccountOverlay: FC = () => {
   } = useContext(AccountContext)
 
   const reactivateAccount = () => {
-    if (account?.deletable) {
+    if (account?.reactivatable) {
       try {
         handleReactivateAccount()
       } catch (e) {

--- a/src/operator/account/ReactivateAccountOverlay.tsx
+++ b/src/operator/account/ReactivateAccountOverlay.tsx
@@ -60,7 +60,7 @@ const ReactivateAccountOverlay: FC = () => {
           {message}
           <ol>
             {organizations.map(o => (
-              <li>{o.name} ?? 'N/A' </li>
+              <li key={o.id}>{o.name} ?? 'N/A' </li>
             ))}
           </ol>
         </Overlay.Body>

--- a/src/operator/account/ReactivateAccountOverlay.tsx
+++ b/src/operator/account/ReactivateAccountOverlay.tsx
@@ -58,11 +58,11 @@ const ReactivateAccountOverlay: FC = () => {
             <strong>Warning</strong>
           </h4>
           {message}
-          <ol>
+          <ul>
             {organizations.map(o => (
-              <li key={o.id}>{o.name} ?? 'N/A' </li>
+              <li key={o.id}>{o.name ?? 'N/A'} </li>
             ))}
-          </ol>
+          </ul>
         </Overlay.Body>
         <Overlay.Footer>
           <ButtonBase

--- a/src/operator/account/ReactivateAccountOverlay.tsx
+++ b/src/operator/account/ReactivateAccountOverlay.tsx
@@ -1,0 +1,82 @@
+import React, {FC, useContext} from 'react'
+import {
+  Overlay,
+  Gradients,
+  Alert,
+  ComponentColor,
+  IconFont,
+  ButtonBase,
+  ButtonShape,
+} from '@influxdata/clockface'
+import {AccountContext} from 'src/operator/context/account'
+
+const ReactivateAccountOverlay: FC = () => {
+  const {
+    account,
+    organizations,
+    handleReactivateAccount,
+    setReactivateOverlayVisible,
+    reactivateOverlayVisible,
+  } = useContext(AccountContext)
+
+  const reactivateAccount = () => {
+    if (account?.deletable) {
+      try {
+        handleReactivateAccount()
+      } catch (e) {
+        setReactivateOverlayVisible(false)
+      }
+    }
+  }
+
+  const message = `
+    This action will reactivate the Account
+    ${account?.id ?? 'N/A'} and unsuspend the organizations:`
+
+  return (
+    <Overlay
+      visible={reactivateOverlayVisible}
+      renderMaskElement={() => (
+        <Overlay.Mask gradient={Gradients.DangerDark} style={{opacity: 0.5}} />
+      )}
+      testID="reactivate-overlay"
+      transitionDuration={0}
+    >
+      <Overlay.Container maxWidth={600}>
+        <Overlay.Header
+          title="Reactivate Account"
+          style={{color: '#FFFFFF'}}
+          onDismiss={() =>
+            setReactivateOverlayVisible(!reactivateOverlayVisible)
+          }
+        />
+        <Overlay.Body>
+          <Alert color={ComponentColor.Danger} icon={IconFont.AlertTriangle}>
+            This action cannot be undone
+          </Alert>
+          <h4 style={{color: '#FFFFFF'}}>
+            <strong>Warning</strong>
+          </h4>
+          {message}
+          <ol>
+            {organizations.map(o => (
+              <li>{o.name} ?? 'N/A' </li>
+            ))}
+          </ol>
+        </Overlay.Body>
+        <Overlay.Footer>
+          <ButtonBase
+            color={ComponentColor.Danger}
+            shape={ButtonShape.Default}
+            onClick={reactivateAccount}
+            testID="reactivate-account--confirmation-button"
+          >
+            I understand, reactivate account.
+          </ButtonBase>
+        </Overlay.Footer>
+      </Overlay.Container>
+    </Overlay>
+  )
+}
+
+export default ReactivateAccountOverlay

--- a/src/operator/account/ReactivateAccountOverlay.tsx
+++ b/src/operator/account/ReactivateAccountOverlay.tsx
@@ -4,9 +4,11 @@ import {
   ButtonBase,
   ButtonShape,
   ComponentColor,
+  ComponentStatus,
   Gradients,
   IconFont,
   Overlay,
+  RemoteDataState,
 } from '@influxdata/clockface'
 import {AccountContext} from 'src/operator/context/account'
 
@@ -14,6 +16,7 @@ const ReactivateAccountOverlay: FC = () => {
   const {
     account,
     organizations,
+    reactivateStatus,
     handleReactivateAccount,
     setReactivateOverlayVisible,
     reactivateOverlayVisible,
@@ -32,6 +35,8 @@ const ReactivateAccountOverlay: FC = () => {
   const message = `
     This action will reactivate the Account
     ${account?.id ?? 'N/A'} and unsuspend the organizations:`
+
+  const active = reactivateStatus === RemoteDataState.NotStarted
 
   return (
     <Overlay
@@ -66,10 +71,12 @@ const ReactivateAccountOverlay: FC = () => {
         </Overlay.Body>
         <Overlay.Footer>
           <ButtonBase
-            color={ComponentColor.Danger}
+            color={ComponentColor.Primary}
             shape={ButtonShape.Default}
             onClick={reactivateAccount}
             testID="reactivate-account--confirmation-button"
+            active={active}
+            status={active ? ComponentStatus.Default : ComponentStatus.Disabled}
           >
             I understand, reactivate account.
           </ButtonBase>

--- a/src/operator/account/ReactivateAccountOverlay.tsx
+++ b/src/operator/account/ReactivateAccountOverlay.tsx
@@ -51,9 +51,7 @@ const ReactivateAccountOverlay: FC = () => {
         <Overlay.Header
           title="Reactivate Account"
           style={{color: '#FFFFFF'}}
-          onDismiss={() =>
-            setReactivateOverlayVisible(!reactivateOverlayVisible)
-          }
+          onDismiss={() => setReactivateOverlayVisible(false)}
         />
         <Overlay.Body>
           <Alert color={ComponentColor.Danger} icon={IconFont.AlertTriangle}>

--- a/src/operator/account/ReactivateAccountOverlay.tsx
+++ b/src/operator/account/ReactivateAccountOverlay.tsx
@@ -1,12 +1,12 @@
 import React, {FC, useContext} from 'react'
 import {
-  Overlay,
-  Gradients,
   Alert,
-  ComponentColor,
-  IconFont,
   ButtonBase,
   ButtonShape,
+  ComponentColor,
+  Gradients,
+  IconFont,
+  Overlay,
 } from '@influxdata/clockface'
 import {AccountContext} from 'src/operator/context/account'
 

--- a/src/operator/context/account.tsx
+++ b/src/operator/context/account.tsx
@@ -6,6 +6,7 @@ import {useDispatch} from 'react-redux'
 // Utils
 import {
   patchOperatorAccountsConvert,
+  patchOperatorAccountsReactivate,
   deleteOperatorAccount,
   getOperatorAccount,
 } from 'src/client/unityRoutes'
@@ -14,6 +15,7 @@ import {
   getAccountError,
   convertAccountError,
   deleteAccountError,
+  reactivateAccountError,
 } from 'src/shared/copy/notifications'
 
 // Types
@@ -28,9 +30,11 @@ export interface AccountContextType {
   accountStatus: RemoteDataState
   convertStatus: RemoteDataState
   deleteStatus: RemoteDataState
+  reactivateStatus: RemoteDataState
   handleConvertAccountToContract: (contractStartDate: string) => void
   handleDeleteAccount: () => void
   handleGetAccount: () => void
+  handleReactivateAccount: () => void
   organizations: OperatorOrg[]
   setConvertToContractOverlayVisible: (vis: boolean) => void
   convertToContractOverlayVisible: boolean
@@ -38,6 +42,8 @@ export interface AccountContextType {
   cancelOverlayVisible: boolean
   setDeleteOverlayVisible: (vis: boolean) => void
   deleteOverlayVisible: boolean
+  setReactivateOverlayVisible: (vis: boolean) => void
+  reactivateOverlayVisible: boolean
 }
 
 export const DEFAULT_CONTEXT: AccountContextType = {
@@ -45,16 +51,20 @@ export const DEFAULT_CONTEXT: AccountContextType = {
   accountStatus: RemoteDataState.NotStarted,
   convertStatus: RemoteDataState.NotStarted,
   deleteStatus: RemoteDataState.NotStarted,
+  reactivateStatus: RemoteDataState.NotStarted,
   handleConvertAccountToContract: () => {},
   handleDeleteAccount: () => {},
   handleGetAccount: () => {},
+  handleReactivateAccount: () => {},
   organizations: null,
   setConvertToContractOverlayVisible: (_: boolean) => {},
   convertToContractOverlayVisible: false,
-  cancelOverlayVisible: false,
   setCancelOverlayVisible: (_: boolean) => {},
   setDeleteOverlayVisible: (_: boolean) => {},
+  setReactivateOverlayVisible: (_: boolean) => {},
+  cancelOverlayVisible: false,
   deleteOverlayVisible: false,
+  reactivateOverlayVisible: false,
 }
 
 export const AccountContext =
@@ -67,9 +77,14 @@ export const AccountProvider: FC<Props> = React.memo(({children}) => {
     useState(false)
   const [cancelOverlayVisible, setCancelOverlayVisible] = useState(false)
   const [deleteOverlayVisible, setDeleteOverlayVisible] = useState(false)
+  const [reactivateOverlayVisible, setReactivateOverlayVisible] =
+    useState(false)
   const [accountStatus, setAccountStatus] = useState(RemoteDataState.NotStarted)
   const [convertStatus, setConvertStatus] = useState(RemoteDataState.NotStarted)
   const [deleteStatus, setDeleteStatus] = useState(RemoteDataState.NotStarted)
+  const [reactivateStatus, setReactivateStatus] = useState(
+    RemoteDataState.NotStarted
+  )
 
   const {accountID} = useParams<{accountID: string}>()
   const history = useHistory()
@@ -138,6 +153,21 @@ export const AccountProvider: FC<Props> = React.memo(({children}) => {
     }
   }, [dispatch, history, accountID])
 
+  const handleReactivateAccount = useCallback(async () => {
+    try {
+      setReactivateStatus(RemoteDataState.Loading)
+      const resp = await patchOperatorAccountsReactivate({accountId: accountID})
+      if (resp.status !== 200) {
+        throw new Error(resp.data.message)
+      }
+      setReactivateStatus(RemoteDataState.Done)
+      history.push('/operator')
+    } catch (error) {
+      console.error({error})
+      dispatch(notify(reactivateAccountError(accountID)))
+    }
+  }, [dispatch, history, accountID])
+
   return (
     <AccountContext.Provider
       value={{
@@ -145,9 +175,11 @@ export const AccountProvider: FC<Props> = React.memo(({children}) => {
         accountStatus,
         convertStatus,
         deleteStatus,
+        reactivateStatus,
         handleConvertAccountToContract,
         handleDeleteAccount,
         handleGetAccount,
+        handleReactivateAccount,
         organizations,
         setConvertToContractOverlayVisible,
         convertToContractOverlayVisible,
@@ -155,6 +187,8 @@ export const AccountProvider: FC<Props> = React.memo(({children}) => {
         cancelOverlayVisible,
         setDeleteOverlayVisible,
         deleteOverlayVisible,
+        setReactivateOverlayVisible,
+        reactivateOverlayVisible,
       }}
     >
       {children}

--- a/src/shared/copy/notifications/categories/operator.ts
+++ b/src/shared/copy/notifications/categories/operator.ts
@@ -73,6 +73,12 @@ export const deleteAccountError = (id: string): Notification => ({
   message: `Failed to delete the account with the ID ${id}, please try again.`,
 })
 
+export const reactivateAccountError = (id: string): Notification => ({
+  ...defaultErrorNotification,
+  duration: FIVE_SECONDS,
+  message: `Failed to reactivate the account with the ID ${id}, please try again.`,
+})
+
 export const removeUserAccountError = (id: string): Notification => ({
   ...defaultErrorNotification,
   duration: FIVE_SECONDS,


### PR DESCRIPTION
When an account is canceled and has suspended organization(s), it can be reactivated.

<img width="460" alt="image" src="https://github.com/influxdata/ui/assets/31899323/5afc1218-88d6-4c73-80c7-f509bea6c5e5">

<img width="643" alt="image" src="https://github.com/influxdata/ui/assets/31899323/1f2fc0dd-12ae-43b5-bd03-9e29bda47480">


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
