### PR TITLE
feat(operators): Add Migrate Organization Tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "prettier:fix": "pretty-quick --config .prettierrc.json --write '{src,cypress}/**/*.{ts,tsx}'",
     "tsc": "tsc -p ./tsconfig.json --noEmit --pretty --skipLibCheck",
     "tsc:watch": "yarn tsc --watch",
-    "generate": "export SHA=0eab389b5a8f44a0114d038f5e953632c050b9b9 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
+    "generate": "export SHA=96ac07e89b65d81b5f84ffbc7279e8bf36353ddb && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-local-cloud": "export REMOTE=../openapi/ && yarn generate-meta-cloud",
     "generate-meta": "if [ -z \"${CLOUD_URL}\" ]; then yarn generate-meta-oss; else yarn generate-meta-cloud; fi",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "prettier:fix": "pretty-quick --config .prettierrc.json --write '{src,cypress}/**/*.{ts,tsx}'",
     "tsc": "tsc -p ./tsconfig.json --noEmit --pretty --skipLibCheck",
     "tsc:watch": "yarn tsc --watch",
-    "generate": "export SHA=d05381fbcee0dd5d88833e71057a4af647e0d169 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
+    "generate": "export SHA=0eab389b5a8f44a0114d038f5e953632c050b9b9 && export REMOTE=https://raw.githubusercontent.com/influxdata/openapi/${SHA}/ && yarn generate-meta",
     "generate-local": "export REMOTE=../openapi/ && yarn generate-meta",
     "generate-local-cloud": "export REMOTE=../openapi/ && yarn generate-meta-cloud",
     "generate-meta": "if [ -z \"${CLOUD_URL}\" ]; then yarn generate-meta-oss; else yarn generate-meta-cloud; fi",

--- a/src/operator/MigrateOrg.tsx
+++ b/src/operator/MigrateOrg.tsx
@@ -1,0 +1,83 @@
+import {
+  AlignItems,
+  Button,
+  ButtonType,
+  ComponentColor,
+  ComponentSize,
+  ComponentStatus,
+  FlexBox,
+  FlexDirection,
+  Form,
+  Input,
+} from '@influxdata/clockface'
+import React, {ChangeEvent, FC, useContext, useState} from 'react'
+import {OverlayContext} from 'src/operator/context/overlay'
+import {OperatorAccount, getOperatorAccount} from 'src/client/unityRoutes'
+import MigrateOrgOverlay from './MigrateOrgOverlay'
+
+const MigrateOrg: FC = () => {
+  const {organization, setMigrateOverlayVisible} = useContext(OverlayContext)
+  const [toAccountId, setToAccountId] = useState('')
+  const [toAccount, setToAccount] = useState<OperatorAccount>(null)
+
+  const changeToAccountId = (event: ChangeEvent<HTMLInputElement>) => {
+    setToAccountId(event.target.value)
+  }
+
+  const submit = async () => {
+    if (toAccountId === '') {
+      return
+    }
+
+    try {
+      const resp = await getOperatorAccount({accountId: toAccountId})
+      if (resp.status !== 200) {
+        return
+      }
+      setToAccount(resp.data)
+      setMigrateOverlayVisible(true)
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  const canSubmit = toAccountId !== ''
+
+  return organization?.state !== 'provisioned' ? (
+    <></>
+  ) : (
+    <>
+      <MigrateOrgOverlay toAccount={toAccount} />
+      <h4 data-testid="migrate-org--title">Migrate Org to another Account</h4>
+      <Form onSubmit={submit}>
+        <FlexBox
+          direction={FlexDirection.Row}
+          alignItems={AlignItems.FlexStart}
+          margin={ComponentSize.Large}
+        >
+          <Input
+            placeholder="Account ID to migrate resources to"
+            inputStyle={{width: '400px'}}
+            style={{width: 'auto'}}
+            value={toAccountId}
+            onChange={changeToAccountId}
+            testID="accounts-migrate--account-id"
+          />
+          <Button
+            text="migrate"
+            color={ComponentColor.Primary}
+            type={ButtonType.Submit}
+            testID="accounts-migrate--button"
+            className="accounts-migrate--button"
+            active={canSubmit}
+            status={
+              canSubmit ? ComponentStatus.Default : ComponentStatus.Disabled
+            }
+          />
+        </FlexBox>
+      </Form>
+    </>
+  )
+}
+
+export default MigrateOrg

--- a/src/operator/MigrateOrg.tsx
+++ b/src/operator/MigrateOrg.tsx
@@ -13,12 +13,16 @@ import {
 import React, {ChangeEvent, FC, useContext, useState} from 'react'
 import {OverlayContext} from 'src/operator/context/overlay'
 import {OperatorAccount, getOperatorAccount} from 'src/client/unityRoutes'
-import MigrateOrgOverlay from './MigrateOrgOverlay'
+import {MigrateOrgOverlay} from './MigrateOrgOverlay'
+import {useDispatch} from 'react-redux'
+import {notify} from 'src/shared/actions/notifications'
+import {getAccountError} from 'src/shared/copy/notifications'
 
-const MigrateOrg: FC = () => {
+export const MigrateOrg: FC = () => {
   const {organization, setMigrateOverlayVisible} = useContext(OverlayContext)
   const [toAccountId, setToAccountId] = useState('')
   const [toAccount, setToAccount] = useState<OperatorAccount>(null)
+  const dispatch = useDispatch()
 
   const changeToAccountId = (event: ChangeEvent<HTMLInputElement>) => {
     setToAccountId(event.target.value)
@@ -32,6 +36,7 @@ const MigrateOrg: FC = () => {
     try {
       const resp = await getOperatorAccount({accountId: toAccountId})
       if (resp.status !== 200) {
+        dispatch(notify(getAccountError(toAccountId)))
         return
       }
       setToAccount(resp.data)
@@ -79,5 +84,3 @@ const MigrateOrg: FC = () => {
     </>
   )
 }
-
-export default MigrateOrg

--- a/src/operator/MigrateOrgOverlay.tsx
+++ b/src/operator/MigrateOrgOverlay.tsx
@@ -1,0 +1,92 @@
+import React, {FC, useContext} from 'react'
+import {
+  Alert,
+  ButtonBase,
+  ButtonShape,
+  ComponentColor,
+  ComponentStatus,
+  Gradients,
+  IconFont,
+  Overlay,
+  RemoteDataState,
+} from '@influxdata/clockface'
+import {OperatorAccount} from 'src/client/unityRoutes'
+import {OverlayContext} from './context/overlay'
+
+interface Props {
+  toAccount: OperatorAccount
+}
+
+const MigrateOrgOverlay: FC<Props> = ({toAccount}) => {
+  const {
+    organization,
+    migrateOverlayVisible,
+    setMigrateOverlayVisible,
+    handleMigrateOrg,
+    migrateStatus,
+  } = useContext(OverlayContext)
+
+  const migrateOrg = () => {
+    try {
+      handleMigrateOrg(organization.idpeId, toAccount.id.toString())
+    } catch (e) {
+      setMigrateOverlayVisible(false)
+    }
+  }
+
+  const message = `
+    This action will migrate the following organization and users 
+    from ${organization.account.id ?? 'N/A'} to 
+    ${toAccount?.name} (${toAccount?.id})`
+
+  const active = migrateStatus === RemoteDataState.NotStarted
+
+  return (
+    <Overlay
+      visible={migrateOverlayVisible}
+      renderMaskElement={() => (
+        <Overlay.Mask gradient={Gradients.DangerDark} style={{opacity: 0.5}} />
+      )}
+      testID="migrate-overlay"
+      transitionDuration={0}
+    >
+      <Overlay.Container maxWidth={600}>
+        <Overlay.Header
+          title="Migrate Organization"
+          style={{color: '#FFFFFF'}}
+          onDismiss={() => setMigrateOverlayVisible(false)}
+        />
+        <Overlay.Body>
+          <Alert color={ComponentColor.Danger} icon={IconFont.AlertTriangle}>
+            This action cannot be undone
+          </Alert>
+          <h4 style={{color: '#FFFFFF'}}>
+            <strong>Warning</strong>
+          </h4>
+          {message}
+          <br />
+          <strong>Organizations:</strong>
+          <ul>
+            <li>
+              {organization.name ?? 'N/A'} ({organization.idpeId})
+            </li>
+          </ul>
+        </Overlay.Body>
+        <Overlay.Footer>
+          <ButtonBase
+            color={ComponentColor.Primary}
+            shape={ButtonShape.Default}
+            onClick={migrateOrg}
+            testID="migrate-organization--confirmation-button"
+            active={active}
+            status={active ? ComponentStatus.Default : ComponentStatus.Disabled}
+          >
+            I understand, migrate the organization
+          </ButtonBase>
+        </Overlay.Footer>
+      </Overlay.Container>
+    </Overlay>
+  )
+}
+
+export default MigrateOrgOverlay

--- a/src/operator/MigrateOrgOverlay.tsx
+++ b/src/operator/MigrateOrgOverlay.tsx
@@ -19,11 +19,11 @@ interface Props {
 
 const MigrateOrgOverlay: FC<Props> = ({toAccount}) => {
   const {
-    organization,
-    migrateOverlayVisible,
-    setMigrateOverlayVisible,
     handleMigrateOrg,
+    migrateOverlayVisible,
     migrateStatus,
+    organization,
+    setMigrateOverlayVisible,
   } = useContext(OverlayContext)
 
   const migrateOrg = () => {
@@ -89,4 +89,4 @@ const MigrateOrgOverlay: FC<Props> = ({toAccount}) => {
   )
 }
 
-export default MigrateOrgOverlay
+export {MigrateOrgOverlay}

--- a/src/operator/OrgOverlay.tsx
+++ b/src/operator/OrgOverlay.tsx
@@ -34,12 +34,12 @@ import LimitsField from 'src/operator/LimitsField'
 
 // Constants
 import {TOOLS_URL} from 'src/shared/constants'
-import MigrateOrg from './MigrateOrg'
+import {MigrateOrg} from './MigrateOrg'
 
 const viewUsageButtonStyles = {marginRight: '12px'}
 const reactivateOrgButtonStyles = {marginTop: '8px'}
 
-const OrgOverlay: FC = () => {
+export const OrgOverlay: FC = () => {
   const {
     limits,
     limitsStatus,
@@ -399,5 +399,3 @@ const OrgOverlay: FC = () => {
     </Overlay>
   )
 }
-
-export default OrgOverlay

--- a/src/operator/OrgOverlay.tsx
+++ b/src/operator/OrgOverlay.tsx
@@ -34,6 +34,7 @@ import LimitsField from 'src/operator/LimitsField'
 
 // Constants
 import {TOOLS_URL} from 'src/shared/constants'
+import MigrateOrg from './MigrateOrg'
 
 const viewUsageButtonStyles = {marginRight: '12px'}
 const reactivateOrgButtonStyles = {marginTop: '8px'}
@@ -357,6 +358,11 @@ const OrgOverlay: FC = () => {
                         limits={limits}
                         onChangeLimits={setLimits}
                       />
+                    </Grid.Column>
+                  </Grid.Row>
+                  <Grid.Row>
+                    <Grid.Column widthMD={Columns.Twelve}>
+                      <MigrateOrg />
                     </Grid.Column>
                   </Grid.Row>
                 </SpinnerContainer>

--- a/src/operator/OrgOverlayWrapper.tsx
+++ b/src/operator/OrgOverlayWrapper.tsx
@@ -1,6 +1,6 @@
 import React, {FC} from 'react'
 import OverlayProvider from 'src/operator/context/overlay'
-import OrgOverlay from 'src/operator/OrgOverlay'
+import {OrgOverlay} from 'src/operator/OrgOverlay'
 
 const OrgOverlayWrapper: FC = () => (
   <OverlayProvider>

--- a/src/operator/account/AccountView.tsx
+++ b/src/operator/account/AccountView.tsx
@@ -14,7 +14,7 @@ import AccountViewHeader from 'src/operator/account/AccountViewHeader'
 import AccountGrid from 'src/operator/account/AccountGrid'
 import {AccountContext} from 'src/operator/context/account'
 import PageSpinner from 'src/perf/components/PageSpinner'
-import MigrateOrgsTool from './MigrateOrgs'
+import {MigrateOrgsTool} from './MigrateOrgs'
 
 const AccountView: FC = () => {
   const {account, accountStatus} = useContext(AccountContext)

--- a/src/operator/account/AccountView.tsx
+++ b/src/operator/account/AccountView.tsx
@@ -14,6 +14,7 @@ import AccountViewHeader from 'src/operator/account/AccountViewHeader'
 import AccountGrid from 'src/operator/account/AccountGrid'
 import {AccountContext} from 'src/operator/context/account'
 import PageSpinner from 'src/perf/components/PageSpinner'
+import MigrateOrgsTool from './MigrateOrgs'
 
 const AccountView: FC = () => {
   const {account, accountStatus} = useContext(AccountContext)
@@ -45,6 +46,7 @@ const AccountView: FC = () => {
               Associated Organizations
             </h2>
             <AssociatedOrgsTable />
+            <MigrateOrgsTool />
           </Page.Contents>
         </Page>
       </AppWrapper>

--- a/src/operator/account/MigrateOrgs.tsx
+++ b/src/operator/account/MigrateOrgs.tsx
@@ -8,9 +8,7 @@ import {
   FlexBox,
   FlexDirection,
   Form,
-  InfluxColors,
   Input,
-  Label,
 } from '@influxdata/clockface'
 import React, {ChangeEvent, FC, useContext, useState} from 'react'
 import {AccountContext} from '../context/account'
@@ -59,17 +57,15 @@ export const MigrateOrgsTool: FC = () => {
         Migrate Organizations and Users
       </h2>
       <Form onSubmit={submit}>
+        <Form.Label
+          id="accounts-migrate--account-id-label"
+          label="Please enter an Account ID to migrate to:"
+        />
         <FlexBox
           direction={FlexDirection.Row}
           alignItems={AlignItems.FlexStart}
           margin={ComponentSize.Large}
         >
-          <Label
-            id="accounts-migrate--account-id-label"
-            name="Please enter an Account ID to migrate to:"
-            description="Please enter an Account ID to migrate to:"
-            color={InfluxColors.Grey25}
-          />
           <Input
             placeholder="Account ID to migrate resources to"
             inputStyle={{width: '400px'}}

--- a/src/operator/account/MigrateOrgs.tsx
+++ b/src/operator/account/MigrateOrgs.tsx
@@ -8,17 +8,23 @@ import {
   FlexBox,
   FlexDirection,
   Form,
+  InfluxColors,
   Input,
+  Label,
 } from '@influxdata/clockface'
 import React, {ChangeEvent, FC, useContext, useState} from 'react'
 import {AccountContext} from '../context/account'
-import MigrateOrgsOverlay from './MigrateOrgsOverlay'
+import {MigrateOrgsOverlay} from './MigrateOrgsOverlay'
 import {OperatorAccount, getOperatorAccount} from 'src/client/unityRoutes'
+import {useDispatch} from 'react-redux'
+import {notify} from 'src/shared/actions/notifications'
+import {getAccountError} from 'src/shared/copy/notifications'
 
-const MigrateOrgsTool: FC = () => {
+export const MigrateOrgsTool: FC = () => {
   const {account, setMigrateOverlayVisible} = useContext(AccountContext)
   const [toAccountId, setToAccountId] = useState('')
   const [toAccount, setToAccount] = useState<OperatorAccount>(null)
+  const dispatch = useDispatch()
 
   const changeToAccountId = (event: ChangeEvent<HTMLInputElement>) => {
     setToAccountId(event.target.value)
@@ -32,6 +38,7 @@ const MigrateOrgsTool: FC = () => {
     try {
       const resp = await getOperatorAccount({accountId: toAccountId})
       if (resp.status !== 200) {
+        dispatch(notify(getAccountError(toAccountId)))
         return
       }
       setToAccount(resp.data)
@@ -57,6 +64,12 @@ const MigrateOrgsTool: FC = () => {
           alignItems={AlignItems.FlexStart}
           margin={ComponentSize.Large}
         >
+          <Label
+            id="accounts-migrate--account-id-label"
+            name="Please enter an Account ID to migrate to:"
+            description="Please enter an Account ID to migrate to:"
+            color={InfluxColors.Grey25}
+          />
           <Input
             placeholder="Account ID to migrate resources to"
             inputStyle={{width: '400px'}}
@@ -81,5 +94,3 @@ const MigrateOrgsTool: FC = () => {
     </>
   )
 }
-
-export default MigrateOrgsTool

--- a/src/operator/account/MigrateOrgs.tsx
+++ b/src/operator/account/MigrateOrgs.tsx
@@ -1,0 +1,85 @@
+import {
+  AlignItems,
+  Button,
+  ButtonType,
+  ComponentColor,
+  ComponentSize,
+  ComponentStatus,
+  FlexBox,
+  FlexDirection,
+  Form,
+  Input,
+} from '@influxdata/clockface'
+import React, {ChangeEvent, FC, useContext, useState} from 'react'
+import {AccountContext} from '../context/account'
+import MigrateOrgsOverlay from './MigrateOrgsOverlay'
+import {OperatorAccount, getOperatorAccount} from 'src/client/unityRoutes'
+
+const MigrateOrgsTool: FC = () => {
+  const {account, setMigrateOverlayVisible} = useContext(AccountContext)
+  const [toAccountId, setToAccountId] = useState('')
+  const [toAccount, setToAccount] = useState<OperatorAccount>(null)
+
+  const changeToAccountId = (event: ChangeEvent<HTMLInputElement>) => {
+    setToAccountId(event.target.value)
+  }
+
+  const submit = async () => {
+    if (toAccountId === '') {
+      return
+    }
+
+    try {
+      const resp = await getOperatorAccount({accountId: toAccountId})
+      if (resp.status !== 200) {
+        return
+      }
+      setToAccount(resp.data)
+      setMigrateOverlayVisible(true)
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  const canSubmit = toAccountId !== ''
+
+  return account.type === 'cancelled' ? (
+    <></>
+  ) : (
+    <>
+      <MigrateOrgsOverlay toAccount={toAccount} />
+      <h2 data-testid="migrate-resources--title">
+        Migrate Organizations and Users
+      </h2>
+      <Form onSubmit={submit}>
+        <FlexBox
+          direction={FlexDirection.Row}
+          alignItems={AlignItems.FlexStart}
+          margin={ComponentSize.Large}
+        >
+          <Input
+            placeholder="Account ID to migrate resources to"
+            inputStyle={{width: '400px'}}
+            style={{width: 'auto'}}
+            value={toAccountId}
+            onChange={changeToAccountId}
+            testID="accounts-migrate--account-id"
+          />
+          <Button
+            text="migrate"
+            color={ComponentColor.Primary}
+            type={ButtonType.Submit}
+            testID="accounts-migrate--button"
+            className="accounts-migrate--button"
+            active={canSubmit}
+            status={
+              canSubmit ? ComponentStatus.Default : ComponentStatus.Disabled
+            }
+          />
+        </FlexBox>
+      </Form>
+    </>
+  )
+}
+
+export default MigrateOrgsTool

--- a/src/operator/account/MigrateOrgsOverlay.tsx
+++ b/src/operator/account/MigrateOrgsOverlay.tsx
@@ -17,14 +17,14 @@ interface Props {
   toAccount: OperatorAccount
 }
 
-const MigrateOrgsOverlay: FC<Props> = ({toAccount}) => {
+export const MigrateOrgsOverlay: FC<Props> = ({toAccount}) => {
   const {
     account,
     organizations,
-    migrateStatus,
     handleMigrateOrgs,
-    setMigrateOverlayVisible,
     migrateOverlayVisible,
+    migrateStatus,
+    setMigrateOverlayVisible,
   } = useContext(AccountContext)
 
   const migrateAccountOrgs = () => {
@@ -101,5 +101,3 @@ const MigrateOrgsOverlay: FC<Props> = ({toAccount}) => {
     </Overlay>
   )
 }
-
-export default MigrateOrgsOverlay

--- a/src/operator/account/MigrateOrgsOverlay.tsx
+++ b/src/operator/account/MigrateOrgsOverlay.tsx
@@ -1,0 +1,105 @@
+import React, {FC, useContext} from 'react'
+import {
+  Alert,
+  ButtonBase,
+  ButtonShape,
+  ComponentColor,
+  ComponentStatus,
+  Gradients,
+  IconFont,
+  Overlay,
+  RemoteDataState,
+} from '@influxdata/clockface'
+import {AccountContext} from 'src/operator/context/account'
+import {OperatorAccount} from 'src/client/unityRoutes'
+
+interface Props {
+  toAccount: OperatorAccount
+}
+
+const MigrateOrgsOverlay: FC<Props> = ({toAccount}) => {
+  const {
+    account,
+    organizations,
+    migrateStatus,
+    handleMigrateOrgs,
+    setMigrateOverlayVisible,
+    migrateOverlayVisible,
+  } = useContext(AccountContext)
+
+  const migrateAccountOrgs = () => {
+    if (account?.type !== 'cancelled') {
+      try {
+        handleMigrateOrgs(toAccount.id.toString())
+      } catch (e) {
+        setMigrateOverlayVisible(false)
+      }
+    }
+  }
+
+  const message = `
+    This action will migrate the following organizations and users 
+    from ${account?.name ?? 'N/A'} (${account?.id ?? 'N/A'}) into 
+    ${toAccount?.name} (${toAccount?.id})`
+
+  const active = migrateStatus === RemoteDataState.NotStarted
+
+  return (
+    <Overlay
+      visible={migrateOverlayVisible}
+      renderMaskElement={() => (
+        <Overlay.Mask gradient={Gradients.DangerDark} style={{opacity: 0.5}} />
+      )}
+      testID="migrate-overlay"
+      transitionDuration={0}
+    >
+      <Overlay.Container maxWidth={600}>
+        <Overlay.Header
+          title="Migrate Account Organizations"
+          style={{color: '#FFFFFF'}}
+          onDismiss={() => setMigrateOverlayVisible(false)}
+        />
+        <Overlay.Body>
+          <Alert color={ComponentColor.Danger} icon={IconFont.AlertTriangle}>
+            This action cannot be undone
+          </Alert>
+          <h4 style={{color: '#FFFFFF'}}>
+            <strong>Warning</strong>
+          </h4>
+          {message}
+          <br />
+          <strong>Organizations:</strong>
+          <ul>
+            {organizations.map(o => (
+              <li key={o.id}>
+                {o.name ?? 'N/A'} ({o.idpeId})
+              </li>
+            ))}
+          </ul>
+          <strong>Users:</strong>
+          <ul>
+            {account.users.map(u => (
+              <li key={u.id}>
+                {u.firstName} {u.lastName} ({u.email ?? 'N/A'})
+              </li>
+            ))}
+          </ul>
+        </Overlay.Body>
+        <Overlay.Footer>
+          <ButtonBase
+            color={ComponentColor.Primary}
+            shape={ButtonShape.Default}
+            onClick={migrateAccountOrgs}
+            testID="migrate-account--confirmation-button"
+            active={active}
+            status={active ? ComponentStatus.Default : ComponentStatus.Disabled}
+          >
+            I understand, run migration.
+          </ButtonBase>
+        </Overlay.Footer>
+      </Overlay.Container>
+    </Overlay>
+  )
+}
+
+export default MigrateOrgsOverlay

--- a/src/operator/context/account.tsx
+++ b/src/operator/context/account.tsx
@@ -193,8 +193,8 @@ export const AccountProvider: FC<Props> = React.memo(({children}) => {
           throw new Error(resp.data.message)
         }
 
-        setMigrateOverlayVisible(false)
         setMigrateStatus(RemoteDataState.Done)
+        setMigrateOverlayVisible(false)
         history.push(`/operator/accounts/${toAccountId}`)
       } catch (error) {
         console.error({error})

--- a/src/shared/copy/notifications/categories/operator.ts
+++ b/src/shared/copy/notifications/categories/operator.ts
@@ -31,6 +31,15 @@ export const reactivateOrgError = (id: string): Notification => ({
   message: `Could not reactivate organization with ID ${id}`,
 })
 
+export const migrateOrgError = (
+  id: string,
+  accountId: string
+): Notification => ({
+  ...defaultErrorNotification,
+  duration: FIVE_SECONDS,
+  message: `Could not migrate organization with ID ${id} to the account with id ${accountId}`,
+})
+
 export const getLimitsError = (id: string): Notification => ({
   ...defaultErrorNotification,
   duration: FIVE_SECONDS,
@@ -77,6 +86,12 @@ export const reactivateAccountError = (id: string): Notification => ({
   ...defaultErrorNotification,
   duration: FIVE_SECONDS,
   message: `Failed to reactivate the account with the ID ${id}, please try again.`,
+})
+
+export const migrateAccountError = (id: string): Notification => ({
+  ...defaultErrorNotification,
+  duration: FIVE_SECONDS,
+  message: `Failed to migrate the organizations from the account with the ID ${id}, please try again.`,
 })
 
 export const removeUserAccountError = (id: string): Notification => ({


### PR DESCRIPTION
Allows operators to migrate all of an account's organizations or a specific organization to a different account.

![image](https://github.com/influxdata/ui/assets/31899323/d86f9e68-6796-4e01-ab2a-2a5c30640841)


### Checklist

Authors and Reviewer(s), please verify the following:

- [ ] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [ ] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
