### PR TITLE
chore: change mkt_cancel refs to mkt-cancel

### DIFF
--- a/cypress/e2e/cloud/userAccounts.test.ts
+++ b/cypress/e2e/cloud/userAccounts.test.ts
@@ -169,7 +169,7 @@ describe('Free account Deletion', () => {
               .click()
           })
         cy.location().should(loc => {
-          expect(loc.href).to.eq(`https://www.influxdata.com/mkt_cancel/`)
+          expect(loc.href).to.eq(`https://www.influxdata.com/mkt-cancel/`)
         })
       })
   }

--- a/src/accounts/context/DeleteFreeAccountContext.tsx
+++ b/src/accounts/context/DeleteFreeAccountContext.tsx
@@ -47,7 +47,7 @@ const RedirectLocations = {
   SWITCHING_ORGANIZATION: '/org_cancel',
   RE_SIGNUP: '/cancel',
 }
-const DEFAULT_REDIRECT_LOCATION = '/mkt_cancel'
+const DEFAULT_REDIRECT_LOCATION = '/mkt-cancel'
 
 export const DeleteFreeAccountContext =
   createContext<DeleteFreeAccountContextType>(
@@ -69,7 +69,7 @@ export const DeleteFreeAccountProvider: FC<Props> = ({children}) => {
   )
 
   const getRedirectLocation = () => {
-    const uri = RedirectLocations[reason] ?? '/mkt_cancel'
+    const uri = RedirectLocations[reason] ?? '/mkt-cancel'
 
     return `https://www.influxdata.com${uri}`
   }

--- a/src/billing/components/PayAsYouGo/CancelServiceContext.tsx
+++ b/src/billing/components/PayAsYouGo/CancelServiceContext.tsx
@@ -22,7 +22,7 @@ const RedirectLocations = {
   SWITCHING_ORGANIZATION: '/org_cancel',
   RE_SIGNUP: '/cancel',
 }
-const DEFAULT_REDIRECT_LOCATION = '/mkt_cancel'
+const DEFAULT_REDIRECT_LOCATION = '/mkt-cancel'
 
 // Ensures that the default cancelation "reason" is always the key name for the "NONE" enum.
 const getDefaultCancelationReason = () => {
@@ -83,7 +83,7 @@ export const CancelServiceProvider: FC<Props> = ({children}) => {
   }
 
   const getRedirectLocation = () => {
-    const uri = RedirectLocations[reason] ?? '/mkt_cancel'
+    const uri = RedirectLocations[reason] ?? '/mkt-cancel'
 
     return `https://www.influxdata.com${uri}`
   }


### PR DESCRIPTION
Closes #6758 

The user accounts e2e test is failing because changes were made to the structure of some of the pages on our website. The CMS appears not to support underscores so the `mkt_cancel` page was moved to `mkt-cancel`. A redirect was added from the URL including the underscore, but it still causes our e2e tests to fail because it expects the user in that test to end on a url including `mkt_cancel`, not `mkt-cancel`.

This changes the references in the user accounts test and the UI from `mkt_cancel` to `mkt-cancel` so that the user is directed to the new page instead of relying on the redirect.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable
