### PR TITLE
fix(ui): update slack join link

### DIFF
--- a/cypress/e2e/shared/helpBar.test.ts
+++ b/cypress/e2e/shared/helpBar.test.ts
@@ -48,7 +48,7 @@ describe('Help bar menu sub nav links', () => {
       .within(() => {
         cy.get('a').should($a => {
           expect($a.attr('href'), 'href').to.equal(
-            'https://influxcommunity.slack.com/join/shared_invite/zt-156zm7ult-LcIW2T4TwLYeS8rZbCP1mw#/shared-invite/email'
+            'https://www.influxdata.com/slack'
           )
         })
       })

--- a/src/pageLayout/containers/MainNavigation.tsx
+++ b/src/pageLayout/containers/MainNavigation.tsx
@@ -445,7 +445,7 @@ export const MainNavigation: FC = () => {
             label="InfluxDB Slack"
             testID="nav-subitem-influxdb-slack"
             linkElement={() => (
-              <SafeBlankLink href="https://influxcommunity.slack.com/join/shared_invite/zt-156zm7ult-LcIW2T4TwLYeS8rZbCP1mw#/shared-invite/email" />
+              <SafeBlankLink href="https://www.influxdata.com/slack" />
             )}
           />
           {!isNewIOxOrg && (


### PR DESCRIPTION
Closes #6765

This PR corrects the join Slack link in the UI by removing the specific invite id.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
