### PR TITLE
Variable name fix in python tutorial

### DIFF
--- a/src/homepageExperience/components/steps/python/InitializeClient.tsx
+++ b/src/homepageExperience/components/steps/python/InitializeClient.tsx
@@ -25,7 +25,7 @@ token = os.environ.get("INFLUXDB_TOKEN")
 org = "${org.name}"
 url = "${url}"
 
-write_client = influxdb_client.InfluxDBClient(url=url, token=token, org=org)
+client = influxdb_client.InfluxDBClient(url=url, token=token, org=org)
 `
 
   return (


### PR DESCRIPTION
This PR replaces `write_client` to `client`, because subsequent tutorials refer to the object as such.

The single change in varname is in the "code snippet" of the python tutorial InitializeClient at `src/homepageExperience/components/steps/python/InitializeClient.tsx`.

This is consistent with all code snippets in the subsequent examples.