### PR TITLE
chore: remove repeated org state from operator org details

### DIFF
--- a/src/operator/OrgOverlay.tsx
+++ b/src/operator/OrgOverlay.tsx
@@ -183,12 +183,6 @@ export const OrgOverlay: FC = () => {
                 <Grid.Row>
                   <Grid.Column widthMD={Columns.Four}>
                     <label className="org-overlay-detail--text">
-                      Organization State
-                    </label>
-                    <p>{organization?.state ?? ''}</p>
-                  </Grid.Column>
-                  <Grid.Column widthMD={Columns.Four}>
-                    <label className="org-overlay-detail--text">
                       Delete On
                     </label>
                     <p>


### PR DESCRIPTION
Closes #6745 

The org details overlay on the operator page has a second copy of the 'organization state' field. This removes it.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable
