### PR TITLE
chore: re-enable marketo form test

### DIFF
--- a/cypress/e2e/cloud/about.test.ts
+++ b/cypress/e2e/cloud/about.test.ts
@@ -211,12 +211,10 @@ const upgradeAccount = () => {
 
   cy.getByTestID('create-org-form-submit').should('be.visible').click()
 
-  // Disabling this temporarily - 8/14/23 - unblock CI while
-  // tracking down issues with the third-party script.
-  // cy.wait('@marketoResponse').then(res => {
-  //   // If this fails, it likely indicates a need to update MarketoAccountUpgradeOverlay.tsx, or the Marketo form.
-  //   expect(res?.response?.body.formID).to.equal('2826')
-  // })
+  cy.wait('@marketoResponse').then(res => {
+    // If this fails, it likely indicates a need to update MarketoAccountUpgradeOverlay.tsx, or the Marketo form.
+    expect(res?.response?.body.formID).to.equal('2826')
+  })
 
   cy.getByTestID('notification-success')
     .should('be.visible')

--- a/cypress/e2e/cloud/createOrg.test.ts
+++ b/cypress/e2e/cloud/createOrg.test.ts
@@ -69,11 +69,9 @@ const testMarketoForm = () => {
 
   cy.getByTestID('create-org-form-submit').should('be.visible').click()
 
-  // Disabling this temporarily - 8/14/23 - unblock CI while
-  // tracking down issues with the third-party script.
-  // cy.wait('@marketoResponse').then(res => {
-  //   expect(res?.response?.body.formID).to.equal('2826')
-  // })
+  cy.wait('@marketoResponse').then(res => {
+    expect(res?.response?.body.formID).to.equal('2826')
+  })
 
   cy.getByTestID('notification-success')
     .should('be.visible')


### PR DESCRIPTION
Closes #6779 

We've resolved the issues with the marketo form for upgrading to contract (change was on the marketo side). This re-enables the e2e tests that ensure the marketo form is working correctly.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable - NO
