### PR TITLE
feat(sql): add `/api/v2private/query` for SQL query

### DIFF
--- a/src/shared/contexts/query/context.tsx
+++ b/src/shared/contexts/query/context.tsx
@@ -260,7 +260,7 @@ export const QueryProvider: FC = ({children}) => {
     const promise = fetch(url, {
       method: 'POST',
       headers,
-      body: JSON.stringify(body),
+      body: typeof body === 'string' ? body : JSON.stringify(body),
       signal: controller.signal,
     })
       .then((res: Response): Promise<RunQueryResult> => {

--- a/src/shared/contexts/query/context.tsx
+++ b/src/shared/contexts/query/context.tsx
@@ -37,6 +37,7 @@ import {DBRP} from 'src/client'
 
 // Utils
 import {addAnnotationToCSV} from 'src/shared/utils/addAnnotationToCSV'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 interface CancelMap {
   [key: string]: () => void
@@ -109,7 +110,7 @@ const buildQueryRequest = (
   options?: QueryOptions
 ): {
   url: string
-  body: RequestBody | null
+  body: RequestBody | null | string
   headers: {
     'Content-Type': string
     'Accept-Encoding': string
@@ -141,6 +142,17 @@ const buildQueryRequest = (
       Accept: 'text/csv',
     }
 
+    return {url, body, headers}
+  }
+
+  if (isFlagEnabled('v2privateQueryUI') && language === LanguageType.SQL) {
+    const url = `${API_BASE_PATH}api/v2private/query?database=${options?.bucket?.name}`
+    const body = text
+    const headers = {
+      'Content-Type': 'application/sql',
+      'Accept-Encoding': 'gzip',
+      Accept: 'text/csv;format=annotated',
+    }
     return {url, body, headers}
   }
 
@@ -222,7 +234,7 @@ const handleQueryResponse = (response, cb) => {
     } catch {
       return {
         type: 'UNKNOWN_ERROR',
-        message: 'Failed to execute Flux query',
+        message: 'Failed to execute query',
       }
     }
   })


### PR DESCRIPTION
Closes influxdata/idpe#17953

This PR is the start of the UI work for [this epic issue](https://github.com/influxdata/idpe/issues/17711). 

This PR adds the path `/api/v2private/query` for SQL queries. When the feature flag is on and the script language is SQL, the query will send to this path instead of being wrapped in `iox.sql()` and sending to `/api/v2/query` in Flux.

The change is behind the feature flag `v2privateQueryUI` and it is set to false by default

To test locally, deploy the remocal with the following flag:
```
make deploy-remocal DEPLOY_IOX=true ENABLE_IOX_FLIGHT=true
```

Then you will see SQL queries will send to `/api/v2private/query` in DevTool Network tab

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
