### PR TITLE
chore(epic-idpe-17711): use SQL HTTP API to get tag value list

### DIFF
--- a/src/dataExplorer/components/TagSelector.tsx
+++ b/src/dataExplorer/components/TagSelector.tsx
@@ -28,7 +28,7 @@ similar to an indexed column and value.`
 interface TagValuesProps {
   loading: RemoteDataState
   tagKey: string
-  tagValues: string[]
+  tagValues: string[] | number[] | boolean[]
 }
 
 const TagValues: FC<TagValuesProps> = ({loading, tagKey, tagValues}) => {

--- a/src/dataExplorer/context/tags.tsx
+++ b/src/dataExplorer/context/tags.tsx
@@ -174,10 +174,11 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
         LIMIT ${DEFAULT_LIMIT}
       `
       try {
-        const resp = await queryAPI(queryTextSQL, scope, {
+        const queryOptions: QueryOptions = {
           language: LanguageType.SQL, // use SQL to get measurement list
           bucket,
-        } as QueryOptions)
+        }
+        const resp = await queryAPI(queryTextSQL, scope, queryOptions)
         const values = (Object.values(resp.parsed.table?.columns ?? [])[0]
           ?.data ?? []) as string[]
 

--- a/src/dataExplorer/context/tags.tsx
+++ b/src/dataExplorer/context/tags.tsx
@@ -1,6 +1,7 @@
 // Libraries
 import React, {createContext, FC, useContext, useMemo, useState} from 'react'
 import {Bucket, RemoteDataState} from 'src/types'
+import {useSelector} from 'react-redux'
 
 // Constants
 import {
@@ -8,9 +9,10 @@ import {
   CACHING_REQUIRED_START_DATE,
 } from 'src/utils/datetime/constants'
 import {DEFAULT_LIMIT} from 'src/shared/constants/queryBuilder'
+import {LanguageType} from 'src/dataExplorer/components/resources'
 
 // Contexts
-import {QueryContext, QueryScope} from 'src/shared/contexts/query'
+import {QueryContext, QueryOptions, QueryScope} from 'src/shared/contexts/query'
 import {ResultsViewContext} from 'src/dataExplorer/context/resultsView'
 
 // Utils
@@ -21,6 +23,10 @@ import {
   SAMPLE_DATA_SET,
   SEARCH_STRING,
 } from 'src/dataExplorer/shared/utils'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+
+// Selectors
+import {isOrgIOx} from 'src/organizations/selectors'
 
 interface TagsContextType {
   tags: Tags
@@ -56,6 +62,8 @@ interface Prop {
 }
 
 export const TagsProvider: FC<Prop> = ({children, scope}) => {
+  const isIOx = useSelector(isOrgIOx)
+
   // Contexts
   const {query: queryAPI} = useContext(QueryContext)
   const {setDefaultViewOptions} = useContext(ResultsViewContext)
@@ -157,6 +165,41 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
       ...loadingTagValues,
       [tagKey]: RemoteDataState.Loading,
     })
+
+    if (isFlagEnabled('v2privateQueryUI') && isIOx) {
+      const queryTextSQL: string = `
+        SELECT DISTINCT("${tagKey}")
+        FROM "${measurement}"
+        ORDER BY "${tagKey}"
+        LIMIT ${DEFAULT_LIMIT}
+      `
+      try {
+        const resp = await queryAPI(queryTextSQL, scope, {
+          language: LanguageType.SQL, // use SQL to get measurement list
+          bucket,
+        } as QueryOptions)
+        const values = (Object.values(resp.parsed.table?.columns ?? [])[0]
+          ?.data ?? []) as string[]
+
+        // Update the tag key with the corresponding tag values
+        const newTags = {...tags, [tagKey]: values}
+        setTags(newTags)
+        setLoadingTagValues({
+          ...loadingTagValues,
+          [tagKey]: RemoteDataState.Done,
+        })
+      } catch (e) {
+        console.error(
+          `Failed to get tag value for tag key: "${tagKey}"\n`,
+          e.message
+        )
+        setLoadingTagValues({
+          ...loadingTagValues,
+          [tagKey]: RemoteDataState.Error,
+        })
+      }
+      return
+    }
 
     // Simplified version of query from this file:
     //   src/flows/pipes/QueryBuilder/context.tsx

--- a/src/dataExplorer/context/tags.tsx
+++ b/src/dataExplorer/context/tags.tsx
@@ -55,7 +55,7 @@ interface Hash<T> {
   [key: string]: T
 }
 
-type Tags = Record<string, string[]>
+type Tags = Record<string, string[] | number[] | boolean[]>
 
 interface Prop {
   scope: QueryScope
@@ -179,8 +179,8 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
           bucket,
         }
         const resp = await queryAPI(queryTextSQL, scope, queryOptions)
-        const values = (Object.values(resp.parsed.table?.columns ?? [])[0]
-          ?.data ?? []) as string[]
+        const values: string[] | number[] | boolean[] =
+          resp.parsed.table?.columns[tagKey]?.data
 
         // Update the tag key with the corresponding tag values
         const newTags = {...tags, [tagKey]: values}


### PR DESCRIPTION
Part of https://github.com/influxdata/idpe/issues/17981

This PR uses the SQL HTTP API to query tag values

The change is behind the feature flag `v2privateQueryUI` and it is set to false by default

# To test locally

1. Deploy the remocal with the following flag:
    ```
    make deploy-remocal DEPLOY_IOX=true ENABLE_IOX_FLIGHT=true
    ```
2. Then you will see the query for measurement list will send to `/api/v2private/query` in DevTool Network tab

# Before and After

https://github.com/influxdata/ui/assets/14298407/63a6db58-63b4-42ec-b672-f40c834c7b75




### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
