### PR TITLE
fix(ui): version name and number

### DIFF
--- a/cypress/e2e/cloud/about.test.ts
+++ b/cypress/e2e/cloud/about.test.ts
@@ -222,7 +222,7 @@ const upgradeAccount = () => {
 }
 
 describe('Storage types', () => {
-  it('identifies the storage type as iox in an iox org', () => {
+  it('identifies the storage type as Serverless in an iox org', () => {
     spoofStorageType('iox')
     setupTest({
       accountType: 'pay_as_you_go',
@@ -232,7 +232,7 @@ describe('Storage types', () => {
 
     cy.getByTestID('org-profile--labeled-data').within(() => {
       cy.getByTestID('heading').contains('Storage Type')
-      cy.contains('IOx')
+      cy.contains('Serverless (version 3)')
     })
   })
 
@@ -245,7 +245,7 @@ describe('Storage types', () => {
     })
     cy.getByTestID('org-profile--labeled-data').within(() => {
       cy.getByTestID('heading').contains('Storage Type')
-      cy.contains('TSM')
+      cy.contains('TSM (version 2)')
     })
   })
 })

--- a/src/organizations/components/OrgProfileTab/index.tsx
+++ b/src/organizations/components/OrgProfileTab/index.tsx
@@ -86,8 +86,8 @@ const OrgProfileTab: FC = () => {
   const hasFetchedStorageType = Boolean(storageType)
 
   const storageTypeMap = {
-    iox: 'IOx',
-    tsm: 'TSM',
+    iox: 'Serverless (version 3.x)',
+    tsm: 'TSM (version 2.x)',
   }
 
   const formattedStorageType = storageTypeMap[storageType] || storageType

--- a/src/organizations/components/OrgProfileTab/index.tsx
+++ b/src/organizations/components/OrgProfileTab/index.tsx
@@ -86,8 +86,8 @@ const OrgProfileTab: FC = () => {
   const hasFetchedStorageType = Boolean(storageType)
 
   const storageTypeMap = {
-    iox: 'Serverless (version 3.x)',
-    tsm: 'TSM (version 2.x)',
+    iox: 'Serverless (version 3)',
+    tsm: 'TSM (version 2)',
   }
 
   const formattedStorageType = storageTypeMap[storageType] || storageType

--- a/src/shared/components/VersionInfo.tsx
+++ b/src/shared/components/VersionInfo.tsx
@@ -7,16 +7,21 @@ import VersionInfoOSS from 'src/shared/components/VersionInfoOSS'
 import {SafeBlankLink} from 'src/utils/SafeBlankLink'
 
 // Constants
-import {VERSION, GIT_SHA, CLOUD} from 'src/shared/constants'
+import {GIT_SHA, CLOUD} from 'src/shared/constants'
 
 // Utils
 import {isOrgIOx} from 'src/organizations/selectors'
 
 const VersionInfo: FC = () => {
-  const cloudEngine = useSelector(isOrgIOx)
+  const isIOxOrg = useSelector(isOrgIOx)
+
+  const versionNumber = isIOxOrg
+    ? '3'
+    : '2'
+  const cloudEngine = isIOxOrg
     ? 'InfluxDB Cloud Serverless'
     : 'InfluxDB Cloud powered by TSM'
-  const engineLink = useSelector(isOrgIOx)
+  const engineLink = isIOxOrg
     ? 'https://docs.influxdata.com/influxdb/cloud-serverless/'
     : 'https://docs.influxdata.com/influxdb/latest/reference/internals/storage-engine/#time-structured-merge-tree-tsm'
 
@@ -26,7 +31,7 @@ const VersionInfo: FC = () => {
         <div>
           <SafeBlankLink href={engineLink}>{cloudEngine}</SafeBlankLink>
           <br />
-          Version {VERSION} {GIT_SHA && <code>({GIT_SHA.slice(0, 7)})</code>}
+          Storage Engine Version {versionNumber} {!isIOxOrg && GIT_SHA && <code>({GIT_SHA.slice(0, 7)})</code>}
         </div>
       ) : (
         <VersionInfoOSS />

--- a/src/shared/components/VersionInfo.tsx
+++ b/src/shared/components/VersionInfo.tsx
@@ -15,9 +15,7 @@ import {isOrgIOx} from 'src/organizations/selectors'
 const VersionInfo: FC = () => {
   const isIOxOrg = useSelector(isOrgIOx)
 
-  const versionNumber = isIOxOrg
-    ? '3'
-    : '2'
+  const versionNumber = isIOxOrg ? '3' : '2'
   const cloudEngine = isIOxOrg
     ? 'InfluxDB Cloud Serverless'
     : 'InfluxDB Cloud powered by TSM'
@@ -31,7 +29,8 @@ const VersionInfo: FC = () => {
         <div>
           <SafeBlankLink href={engineLink}>{cloudEngine}</SafeBlankLink>
           <br />
-          Storage Engine Version {versionNumber} {!isIOxOrg && GIT_SHA && <code>({GIT_SHA.slice(0, 7)})</code>}
+          Storage Engine Version {versionNumber}{' '}
+          {!isIOxOrg && GIT_SHA && <code>({GIT_SHA.slice(0, 7)})</code>}
         </div>
       ) : (
         <VersionInfoOSS />


### PR DESCRIPTION
This PR fixes the version number on the home page to reflect the major version of the storage engine (2 or 3). It also updates the Storage Type name on the Organization Settings page.

TSM Org Info:
![image](https://github.com/influxdata/ui/assets/11937365/80998a30-cc95-4433-b0d0-12dcabc5a808)

Serverless Org Info:
![image](https://github.com/influxdata/ui/assets/11937365/d97becda-c982-4127-a041-befa590f4c53)

TSM version number on the home page:
![image](https://github.com/influxdata/ui/assets/11937365/9c07334e-67d1-424a-9c06-b824c941a40c)

Serverless version number on the home page:
![image](https://github.com/influxdata/ui/assets/11937365/358317a2-0788-444f-bca0-044dab1fb820)


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Feature flagged, if applicable
