### PR TITLE
feat(ui): tableau instructions

### DIFF
--- a/cypress/e2e/shared/helpBar.test.ts
+++ b/cypress/e2e/shared/helpBar.test.ts
@@ -12,7 +12,7 @@ describe('Help bar menu sub nav links', () => {
         cy.get('a').should($a => {
           expect($a.attr('href'), 'href').to.be.oneOf([
             'https://docs.influxdata.com/',
-            'https://docs.influxdata.com/influxdb/cloud-iox/',
+            'https://docs.influxdata.com/influxdb/cloud-serverless/',
           ])
         })
       })

--- a/src/homepageExperience/components/OptionAccordion/AddDataAccordion.tsx
+++ b/src/homepageExperience/components/OptionAccordion/AddDataAccordion.tsx
@@ -153,7 +153,7 @@ export const AddDataAccordion: FC = () => {
               return (
                 <OptionLink
                   title="View API Docs"
-                  href="https://docs.influxdata.com/influxdb/cloud-iox/api/#operation/PostWrite"
+                  href="https://docs.influxdata.com/influxdb/cloud-serverless/api/#operation/PostWrite"
                   onClick={handleAPIClick}
                 />
               )
@@ -166,7 +166,7 @@ export const AddDataAccordion: FC = () => {
               return (
                 <OptionLink
                   title="View CLI Docs"
-                  href="https://docs.influxdata.com/influxdb/cloud-iox/write-data/csv/influx-cli/"
+                  href="https://docs.influxdata.com/influxdb/cloud-serverless/write-data/csv/influx-cli/"
                   onClick={handleCLIClick}
                 />
               )

--- a/src/homepageExperience/components/OptionAccordion/ManageDatabasesAccordion.tsx
+++ b/src/homepageExperience/components/OptionAccordion/ManageDatabasesAccordion.tsx
@@ -77,7 +77,7 @@ export const ManageDatabasesAccordion: FC = () => {
             cta={() => {
               return (
                 <OptionLink
-                  href="https://docs.influxdata.com/influxdb/cloud-iox/admin/buckets/create-bucket/?t=InfluxDB+API"
+                  href="https://docs.influxdata.com/influxdb/cloud-serverless/admin/buckets/create-bucket/?t=InfluxDB+API"
                   onClick={handleAPIClick}
                   title="View API Docs"
                 />
@@ -90,7 +90,7 @@ export const ManageDatabasesAccordion: FC = () => {
             cta={() => {
               return (
                 <OptionLink
-                  href="https://docs.influxdata.com/influxdb/cloud-iox/admin/buckets/create-bucket/?t=influx+CLI"
+                  href="https://docs.influxdata.com/influxdb/cloud-serverless/admin/buckets/create-bucket/?t=influx+CLI"
                   onClick={handleCLIClick}
                   title="View CLI Docs"
                 />

--- a/src/homepageExperience/components/OptionAccordion/QueryDataAccordion.tsx
+++ b/src/homepageExperience/components/OptionAccordion/QueryDataAccordion.tsx
@@ -130,7 +130,7 @@ export const QueryDataAccordion: FC = () => {
               return (
                 <OptionLink
                   title="View API Docs"
-                  href="https://docs.influxdata.com/influxdb/cloud-iox/reference/api/"
+                  href="https://docs.influxdata.com/influxdb/cloud-serverless/reference/api/"
                   onClick={handleAPIClick}
                 />
               )

--- a/src/homepageExperience/components/OptionAccordion/VisualizeAccordion.tsx
+++ b/src/homepageExperience/components/OptionAccordion/VisualizeAccordion.tsx
@@ -25,6 +25,10 @@ export const VisualizeAccordion: FC = () => {
     event(`homeOptions.${optionId}.supersetDocs.clicked`)
   }
 
+  const handleTableauClick = () => {
+    event(`homeOptions.${optionId}.tableauDocs.clicked`)
+  }
+
   return (
     <OptionAccordion
       headerIcon={IconFont.GraphLine_New}
@@ -41,7 +45,7 @@ export const VisualizeAccordion: FC = () => {
               return (
                 <OptionLink
                   title="View Pandas Docs"
-                  href="https://docs.influxdata.com/influxdb/cloud-iox/query-data/tools/pandas/"
+                  href="https://docs.influxdata.com/influxdb/cloud-serverless/process-data/tools/pandas/"
                   onClick={handlePandasClick}
                 />
               )
@@ -52,7 +56,7 @@ export const VisualizeAccordion: FC = () => {
               <>
                 Grafana{' '}
                 <strong className="option-accordion--tag">
-                  New Cloud Plugin
+                  New cloud plugin available
                 </strong>
               </>
             }
@@ -61,7 +65,7 @@ export const VisualizeAccordion: FC = () => {
               return (
                 <OptionLink
                   title="View Grafana Docs"
-                  href="https://docs.influxdata.com/influxdb/cloud-iox/query-data/tools/grafana/"
+                  href="https://docs.influxdata.com/influxdb/cloud-serverless/process-data/visualize/grafana/"
                   onClick={handleGrafanaClick}
                 />
               )
@@ -74,8 +78,21 @@ export const VisualizeAccordion: FC = () => {
               return (
                 <OptionLink
                   title="View Superset Docs"
-                  href="https://docs.influxdata.com/influxdb/cloud-iox/query-data/tools/superset/"
+                  href="https://docs.influxdata.com/influxdb/cloud-serverless/process-data/visualize/superset/"
                   onClick={handleSupersetClick}
+                />
+              )
+            }}
+          />
+          <OptionAccordionElement
+            elementTitle="Tableau"
+            elementDescription="Set up Tableau to visualize and alert on your data."
+            cta={() => {
+              return (
+                <OptionLink
+                  title="View Tableau Docs"
+                  href="https://docs.influxdata.com/influxdb/cloud-serverless/process-data/visualize/tableau/"
+                  onClick={handleTableauClick}
                 />
               )
             }}

--- a/src/homepageExperience/components/steps/DashboardIntegrations.tsx
+++ b/src/homepageExperience/components/steps/DashboardIntegrations.tsx
@@ -31,7 +31,7 @@ const DashboardIntegrations: FC<Props> = ({
     >
       <ResourceCard className="homepage-wizard-next-steps">
         <SafeBlankLink
-          href="https://docs.influxdata.com/influxdb/cloud-iox/visualize-data/superset/"
+          href="https://docs.influxdata.com/influxdb/cloud-serverless/process-data/visualize/superset/"
           onClick={() =>
             handleNextStepEvent(wizardEventName, 'supersetIntegration')
           }
@@ -45,7 +45,7 @@ const DashboardIntegrations: FC<Props> = ({
       </ResourceCard>
       <ResourceCard className="homepage-wizard-next-steps">
         <SafeBlankLink
-          href="https://docs.influxdata.com/influxdb/cloud-iox/visualize-data/grafana/"
+          href="https://docs.influxdata.com/influxdb/cloud-serverless/process-data/visualize/grafana/"
           onClick={() =>
             handleNextStepEvent(wizardEventName, 'grafanaIntegration')
           }

--- a/src/homepageExperience/components/steps/Finish.tsx
+++ b/src/homepageExperience/components/steps/Finish.tsx
@@ -124,17 +124,36 @@ export const Finish = (props: OwnProps) => {
           alignItems={AlignItems.Stretch}
           direction={FlexDirection.Row}
         >
-          <ResourceCard className="homepage-wizard-next-steps">
-            <SafeBlankLink
-              href="https://docs.influxdata.com/influxdb/latest/reference/key-concepts/"
-              onClick={() =>
-                handleNextStepEvent(wizardEventName, 'keyConcepts')
-              }
-            >
-              <h4>{BookIcon}Key Concepts</h4>
-            </SafeBlankLink>
-            <p>Learn about important concepts for writing time-series data.</p>
-          </ResourceCard>
+          {isFlagEnabled('ioxOnboarding') ? (
+            <ResourceCard className="homepage-wizard-next-steps">
+              <SafeBlankLink
+                href="https://docs.influxdata.com/influxdb/cloud-serverless/write-data/best-practices/"
+                onClick={() =>
+                  handleNextStepEvent(wizardEventName, 'bestPractices')
+                }
+              >
+                <h4>{BookIcon}Best Practices</h4>
+              </SafeBlankLink>
+              <p>
+                Learn about the best practices for writing time-series data into
+                InfluxDB.
+              </p>
+            </ResourceCard>
+          ) : (
+            <ResourceCard className="homepage-wizard-next-steps">
+              <SafeBlankLink
+                href="https://docs.influxdata.com/influxdb/latest/reference/key-concepts/"
+                onClick={() =>
+                  handleNextStepEvent(wizardEventName, 'keyConcepts')
+                }
+              >
+                <h4>{BookIcon}Key Concepts</h4>
+              </SafeBlankLink>
+              <p>
+                Learn about important concepts for writing time-series data.
+              </p>
+            </ResourceCard>
+          )}
           {!isFlagEnabled('ioxOnboarding') && (
             <ResourceCard className="homepage-wizard-next-steps">
               <SafeBlankLink

--- a/src/pageLayout/containers/MainNavigation.tsx
+++ b/src/pageLayout/containers/MainNavigation.tsx
@@ -278,7 +278,7 @@ export const MainNavigation: FC = () => {
   const isContractCustomer = accountType === 'contract'
 
   const docslink = isIOxOrg
-    ? 'https://docs.influxdata.com/influxdb/cloud-iox/'
+    ? 'https://docs.influxdata.com/influxdb/cloud-serverless/'
     : 'https://docs.influxdata.com/'
 
   const handleToggleNavExpansion = (): void => {

--- a/src/telegrafs/components/TelegrafExplainer.tsx
+++ b/src/telegrafs/components/TelegrafExplainer.tsx
@@ -29,7 +29,7 @@ const TelegrafExplainer: FunctionComponent<Props> = ({
   bodySize,
 }) => {
   const docsUrl = useSelector(isOrgIOx)
-    ? `https://docs.influxdata.com/influxdb/cloud-iox/write-data/use-telegraf/`
+    ? `https://docs.influxdata.com/influxdb/cloud-serverless/write-data/use-telegraf/`
     : `https://docs.influxdata.com/influxdb/${DOCS_URL_VERSION}/write-data/no-code/use-telegraf/`
 
   return (


### PR DESCRIPTION
This PR adds a Tableau docs link. It also updates all the docs links from `cloud-iox` to `cloud-serverless`. In doing so it fixes some broken links. Lastly, it replaces the "Key Concepts" link at the end of the onboarding flows with a "Best Practices" link because the previous links to TSM documentation.

<img width="1840" alt="image" src="https://github.com/influxdata/ui/assets/11937365/6293968e-aba1-440e-a6ab-d52ef5cc0604">

<img width="1840" alt="image" src="https://github.com/influxdata/ui/assets/11937365/15ca22ae-35b8-4588-9a6f-c2c3556a3d1e">

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Feature flagged, if applicable
