### PR TITLE
chore(epic-idpe-17711): update csv download to path `/api/v2private/query`

### DIFF
--- a/jestSetup.ts
+++ b/jestSetup.ts
@@ -41,6 +41,7 @@ jest.mock('src/languageSupport/languages/flux/lspUtils', () => ({
 jest.mock('src/shared/workers/serviceWorker', () => ({
   registerServiceWorker: jest.fn(),
   registerServiceWorkerInfluxQL: jest.fn(),
+  registerServiceWorkerSQL: jest.fn(),
 }))
 
 class Worker {

--- a/src/dashboards/selectors/index.test.ts
+++ b/src/dashboards/selectors/index.test.ts
@@ -117,6 +117,7 @@ describe('Dashboards.Selector', () => {
         subscriptionsCertificateInterest: false,
         workerRegistration: null,
         workerRegistrationInfluxQL: null,
+        registerServiceWorkerSQL: null,
       },
     }
 
@@ -144,6 +145,7 @@ describe('Dashboards.Selector', () => {
         subscriptionsCertificateInterest: false,
         workerRegistration: null,
         workerRegistrationInfluxQL: null,
+        registerServiceWorkerSQL: null,
       },
     }
 
@@ -179,6 +181,7 @@ describe('Dashboards.Selector', () => {
         subscriptionsCertificateInterest: false,
         workerRegistration: null,
         workerRegistrationInfluxQL: null,
+        registerServiceWorkerSQL: null,
       },
     }
 
@@ -214,6 +217,7 @@ describe('Dashboards.Selector', () => {
         subscriptionsCertificateInterest: false,
         workerRegistration: null,
         workerRegistrationInfluxQL: null,
+        registerServiceWorkerSQL: null,
       },
     }
 
@@ -245,6 +249,7 @@ describe('Dashboards.Selector', () => {
         subscriptionsCertificateInterest: false,
         workerRegistration: null,
         workerRegistrationInfluxQL: null,
+        registerServiceWorkerSQL: null,
       },
     }
 

--- a/src/dashboards/selectors/index.test.ts
+++ b/src/dashboards/selectors/index.test.ts
@@ -117,7 +117,7 @@ describe('Dashboards.Selector', () => {
         subscriptionsCertificateInterest: false,
         workerRegistration: null,
         workerRegistrationInfluxQL: null,
-        registerServiceWorkerSQL: null,
+        workerRegistrationSQL: null,
       },
     }
 
@@ -145,7 +145,7 @@ describe('Dashboards.Selector', () => {
         subscriptionsCertificateInterest: false,
         workerRegistration: null,
         workerRegistrationInfluxQL: null,
-        registerServiceWorkerSQL: null,
+        workerRegistrationSQL: null,
       },
     }
 
@@ -181,7 +181,7 @@ describe('Dashboards.Selector', () => {
         subscriptionsCertificateInterest: false,
         workerRegistration: null,
         workerRegistrationInfluxQL: null,
-        registerServiceWorkerSQL: null,
+        workerRegistrationSQL: null,
       },
     }
 
@@ -217,7 +217,7 @@ describe('Dashboards.Selector', () => {
         subscriptionsCertificateInterest: false,
         workerRegistration: null,
         workerRegistrationInfluxQL: null,
-        registerServiceWorkerSQL: null,
+        workerRegistrationSQL: null,
       },
     }
 
@@ -249,7 +249,7 @@ describe('Dashboards.Selector', () => {
         subscriptionsCertificateInterest: false,
         workerRegistration: null,
         workerRegistrationInfluxQL: null,
-        registerServiceWorkerSQL: null,
+        workerRegistrationSQL: null,
       },
     }
 

--- a/src/dataExplorer/components/ResultsPane.tsx
+++ b/src/dataExplorer/components/ResultsPane.tsx
@@ -18,7 +18,7 @@ import {useSelector, useDispatch} from 'react-redux'
 
 // Contexts
 import {ResultsContext} from 'src/dataExplorer/context/results'
-import {QueryContext, QueryOptions} from 'src/shared/contexts/query'
+import {QueryContext} from 'src/shared/contexts/query'
 import {
   PersistenceContext,
   DEFAULT_FLUX_EDITOR_TEXT,

--- a/src/dataExplorer/components/ResultsPane.tsx
+++ b/src/dataExplorer/components/ResultsPane.tsx
@@ -133,10 +133,14 @@ const ResultsPane: FC = () => {
             // the `\n` character is interpreted by the browser as a line break
             // so replacing the `\n` char with empty space to keep query in correct syntax
             inputValue = text.replace(/\n/g, ' ')
+            // Intentionally keep the `break` inside the if statement;
+            // Otherwide, users cannot download csv for SQL queries when
+            // the feature flag is not enabled
             break
           }
-        // if the flag is not enabled, fall back
-        // to use the following Flux method
+        // If the flag is not enabled, each SQL query actually will be wrapped
+        // inside a Flux query `iox.sql()`, and the if statement will be false,
+        // so we want the logic to fall to the next case LanguageType.FLUX
         case LanguageType.FLUX:
           url = `${API_BASE_PATH}api/v2/query?${new URLSearchParams({orgID})}`
           const query =

--- a/src/mockState.tsx
+++ b/src/mockState.tsx
@@ -38,6 +38,7 @@ export const localState: LocalStorage = {
       subscriptionsCertificateInterest: false,
       workerRegistration: null,
       workerRegistrationInfluxQL: null,
+      workerRegistrationSQL: null,
     },
   },
   flags: {

--- a/src/shared/actions/app.ts
+++ b/src/shared/actions/app.ts
@@ -14,6 +14,7 @@ export enum ActionTypes {
   SetSubscriptionsCertificateInterest = 'SET_SUB_CERT_INTEREST',
   SetWorkerRegistration = 'SET_WORKER_REGISTRATION',
   SetWorkerRegistrationInfluxQL = 'SET_WORKER_REGISTRATION_INFLUXQL',
+  SetWorkerRegistrationSQL = 'SET_WORKER_REGISTRATION_SQL',
 }
 
 export type Action =
@@ -29,6 +30,7 @@ export type Action =
   | ReturnType<typeof setSubscriptionsCertificateInterest>
   | ReturnType<typeof setWorkerRegistration>
   | ReturnType<typeof setWorkerRegistrationInfluxQL>
+  | ReturnType<typeof setWorkerRegistrationSQL>
 
 // ephemeral state action creators
 
@@ -103,4 +105,12 @@ export const setWorkerRegistrationInfluxQL = (
   ({
     type: ActionTypes.SetWorkerRegistrationInfluxQL,
     payload: {workerRegistrationInfluxQL},
+  } as const)
+
+export const setWorkerRegistrationSQL = (
+  workerRegistrationSQL: Promise<ServiceWorkerRegistration>
+) =>
+  ({
+    type: ActionTypes.SetWorkerRegistrationSQL,
+    payload: {workerRegistrationSQL},
   } as const)

--- a/src/shared/contexts/app.tsx
+++ b/src/shared/contexts/app.tsx
@@ -12,6 +12,7 @@ import {
   setSubscriptionsCertificateInterest as setSubscriptionsCertificateInterestAction,
   setWorkerRegistration,
   setWorkerRegistrationInfluxQL,
+  setWorkerRegistrationSQL,
 } from 'src/shared/actions/app'
 import {
   timeZone as timeZoneFromState,
@@ -29,15 +30,22 @@ import {presentationMode as presentationModeCopy} from 'src/shared/copy/notifica
 import {AppState, TimeZone, Theme, NavBarState, FlowsCTA} from 'src/types'
 import {event} from 'src/cloud/utils/reporting'
 
-let workerRegistration, workerRegistrationInfluxQL
+let workerRegistration, workerRegistrationInfluxQL, workerRegistrationSQL
 import(
   /* webpackPreload: true */
   /* webpackChunkName: "setup-interceptor" */
   'src/shared/workers/serviceWorker'
-).then(({registerServiceWorker, registerServiceWorkerInfluxQL}) => {
-  workerRegistration = registerServiceWorker()
-  workerRegistrationInfluxQL = registerServiceWorkerInfluxQL()
-})
+).then(
+  ({
+    registerServiceWorker,
+    registerServiceWorkerInfluxQL,
+    registerServiceWorkerSQL,
+  }) => {
+    workerRegistration = registerServiceWorker()
+    workerRegistrationInfluxQL = registerServiceWorkerInfluxQL()
+    workerRegistrationSQL = registerServiceWorkerSQL()
+  }
+)
 
 interface AppSettingContextType {
   timeZone: TimeZone
@@ -49,6 +57,7 @@ interface AppSettingContextType {
   subscriptionsCertificateInterest: boolean
   workerRegistration: Promise<ServiceWorkerRegistration>
   workerRegistrationInfluxQL: Promise<ServiceWorkerRegistration>
+  workerRegistrationSQL: Promise<ServiceWorkerRegistration>
 
   setTimeZone: (zone: TimeZone) => void
   setTheme: (theme: Theme) => void
@@ -69,6 +78,7 @@ const DEFAULT_CONTEXT: AppSettingContextType = {
   subscriptionsCertificateInterest: false,
   workerRegistration,
   workerRegistrationInfluxQL,
+  workerRegistrationSQL,
 
   setTimeZone: (_zone: TimeZone) => {},
   setTheme: (_theme: Theme) => {},
@@ -159,6 +169,10 @@ export const AppSettingProvider: FC = ({children}) => {
     dispatch(setWorkerRegistrationInfluxQL(workerRegistrationInfluxQL))
   }, [workerRegistrationInfluxQL])
 
+  useEffect(() => {
+    dispatch(setWorkerRegistrationSQL(workerRegistrationSQL))
+  }, [workerRegistrationSQL])
+
   return (
     <AppSettingContext.Provider
       value={{
@@ -171,6 +185,7 @@ export const AppSettingProvider: FC = ({children}) => {
         subscriptionsCertificateInterest,
         workerRegistration,
         workerRegistrationInfluxQL,
+        workerRegistrationSQL,
 
         setTimeZone,
         setTheme,

--- a/src/shared/reducers/app.test.ts
+++ b/src/shared/reducers/app.test.ts
@@ -27,6 +27,7 @@ describe('Shared.Reducers.appReducer', () => {
       subscriptionsCertificateInterest: false,
       workerRegistration: null,
       workerRegistrationInfluxQL: null,
+      workerRegistrationSQL: null,
     },
   }
 

--- a/src/shared/reducers/app.ts
+++ b/src/shared/reducers/app.ts
@@ -21,6 +21,7 @@ export interface AppState {
     subscriptionsCertificateInterest: boolean
     workerRegistration: Promise<ServiceWorkerRegistration>
     workerRegistrationInfluxQL: Promise<ServiceWorkerRegistration>
+    workerRegisterationSQL: Promise<ServiceWorkerRegistration>
   }
 }
 
@@ -40,6 +41,7 @@ const initialState: AppState = {
     subscriptionsCertificateInterest: false,
     workerRegistration: null,
     workerRegistrationInfluxQL: null,
+    workerRegisterationSQL: null,
   },
 }
 
@@ -141,6 +143,13 @@ const appPersistedReducer = (
       return {
         ...state,
         workerRegistrationInfluxQL: action.payload.workerRegistrationInfluxQL,
+      }
+    }
+
+    case ActionTypes.SetWorkerRegistrationSQL: {
+      return {
+        ...state,
+        workerRegisterationSQL: action.payload.workerRegistrationSQL,
       }
     }
 

--- a/src/shared/reducers/app.ts
+++ b/src/shared/reducers/app.ts
@@ -21,7 +21,7 @@ export interface AppState {
     subscriptionsCertificateInterest: boolean
     workerRegistration: Promise<ServiceWorkerRegistration>
     workerRegistrationInfluxQL: Promise<ServiceWorkerRegistration>
-    workerRegisterationSQL: Promise<ServiceWorkerRegistration>
+    workerRegistrationSQL: Promise<ServiceWorkerRegistration>
   }
 }
 
@@ -41,7 +41,7 @@ const initialState: AppState = {
     subscriptionsCertificateInterest: false,
     workerRegistration: null,
     workerRegistrationInfluxQL: null,
-    workerRegisterationSQL: null,
+    workerRegistrationSQL: null,
   },
 }
 
@@ -149,7 +149,7 @@ const appPersistedReducer = (
     case ActionTypes.SetWorkerRegistrationSQL: {
       return {
         ...state,
-        workerRegisterationSQL: action.payload.workerRegistrationSQL,
+        workerRegistrationSQL: action.payload.workerRegistrationSQL,
       }
     }
 

--- a/src/shared/workers/downloadHelper.ts
+++ b/src/shared/workers/downloadHelper.ts
@@ -29,14 +29,20 @@ self.addEventListener('fetch', function (event: any) {
   )
   const pathname: string = new URL(event.request.url).pathname
   if (
-    (pathname === '/api/v2/query' || pathname === '/query') &&
+    (pathname === '/api/v2/query' ||
+      pathname === '/query' ||
+      pathname === '/api/v2private/query') &&
     contentType === 'application/x-www-form-urlencoded'
   ) {
     const headers = new Headers()
     for (const [headerType, headerValue] of event.request.headers) {
       switch (headerType) {
         case 'content-type':
-          headers.set('Content-Type', 'application/json')
+          if (pathname === '/api/v2private/query') {
+            headers.set('Content-Type', 'application/sql')
+          } else {
+            headers.set('Content-Type', 'application/json')
+          }
           break
         case 'accept':
           headers.append('Accept', '*/*')

--- a/src/shared/workers/downloadHelper.ts
+++ b/src/shared/workers/downloadHelper.ts
@@ -45,7 +45,11 @@ self.addEventListener('fetch', function (event: any) {
           }
           break
         case 'accept':
-          headers.append('Accept', '*/*')
+          if (pathname === '/api/v2private/query') {
+            headers.append('Accept', 'text/csv;format=annotated')
+          } else {
+            headers.append('Accept', '*/*')
+          }
           break
         default:
           headers.append(headerType, headerValue)

--- a/src/shared/workers/serviceWorker.ts
+++ b/src/shared/workers/serviceWorker.ts
@@ -32,3 +32,21 @@ export const registerServiceWorkerInfluxQL =
 
     return workerRegistrationInfluxQL
   }
+
+export const registerServiceWorkerSQL =
+  (): Promise<ServiceWorkerRegistration> => {
+    // Worker -- load prior to page load event, in order to intercept fetch in http/2.
+    // see service worker life cycle. https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers
+    let workerRegistrationSQL = null
+    if ('serviceWorker' in navigator) {
+      workerRegistrationSQL = navigator.serviceWorker.register(
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        new URL('../workers/downloadHelper.ts', import.meta.url),
+        {scope: '/api/v2private/query'}
+        /* webpackChunkName: "interceptor" */
+      )
+    }
+
+    return workerRegistrationSQL
+  }


### PR DESCRIPTION
Closes https://github.com/influxdata/idpe/issues/18001

This PR routes the CSV download for SQL through the HTTP path `/api/v2private/query`. In addition, a service worker for scope `/api/v2private/query` is also added to make the feature complete.

The backend work (https://github.com/influxdata/idpe/pull/18054) is already merged

The change is behind the feature flag `v2privateQueryUI` and it is set to false by default

# To test locally

1. Deploy the remocal with the following flag:
    ```
    make deploy-remocal DEPLOY_IOX=true ENABLE_IOX_FLIGHT=true
    ```
2. Then you will see the query for measurement list will send to `/api/v2private/query` in DevTool Network tab

# After

Customers won't notice any difference before and after the change

https://github.com/influxdata/ui/assets/14298407/fc01d6fc-5c63-4702-8f07-c2a694a2388c



### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
