### PR TITLE
chore(epic-idpe-17711): only show table stat for Flux

### DIFF
--- a/src/dataExplorer/components/Results.tsx
+++ b/src/dataExplorer/components/Results.tsx
@@ -67,9 +67,9 @@ const QueryStat: FC = () => {
         )}.`}</span>
       ) : (
         <>
-          {resource?.language === LanguageType.INFLUXQL ? null : (
+          {resource?.language === LanguageType.FLUX ? (
             <span className="query-stat--bold">{`${tableNum} tables`}</span>
-          )}
+          ) : null}
           <span className="query-stat--bold">{`${
             result?.parsed?.table?.length || 0
           } rows`}</span>


### PR DESCRIPTION
Part of https://github.com/influxdata/idpe/issues/17986

This PR updates the query statistics to only show number of tables for Flux. Number of tables is a Flux concept, and it doesn't apply to SQL and InfluxQL, so removing it

# Before
<img width="757" alt="Screenshot 2023-08-25 at 1 51 07 PM" src="https://github.com/influxdata/ui/assets/14298407/e67f50cf-8afd-4742-8ad0-bf634e7c89bb">

# After
<img width="759" alt="Screenshot 2023-08-25 at 1 51 54 PM" src="https://github.com/influxdata/ui/assets/14298407/0d639419-f5ba-4174-85e7-a5056129e57c">

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
