### PR TITLE
fix(ui): update bucket helper

### DIFF
--- a/src/buckets/components/BucketExplainer.tsx
+++ b/src/buckets/components/BucketExplainer.tsx
@@ -1,36 +1,42 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
+import {useSelector} from 'react-redux'
 
 // Components
 import {Panel, Gradients} from '@influxdata/clockface'
 
+// Selectors
+import {isOrgIOx} from 'src/organizations/selectors'
+
 // Constants
 import {DOCS_URL_VERSION} from 'src/shared/constants/fluxFunctions'
 
-const BucketExplainer: FunctionComponent = () => (
-  <Panel gradient={Gradients.PolarExpress} border={true}>
-    <Panel.Header>
-      <h5>What is a Bucket?</h5>
-    </Panel.Header>
-    <Panel.Body>
-      <p>
-        A bucket is a named location where time series data is stored. All
-        buckets have a <b>Retention Policy</b>, a duration of time that each
-        data point persists.
-        <br />
-        <br />
-        Here's{' '}
-        <a
-          href={`https://docs.influxdata.com/influxdb/${DOCS_URL_VERSION}/write-data/`}
-          target="_blank"
-          rel="noreferrer"
-        >
-          how to write data
-        </a>{' '}
-        into your bucket.
-      </p>
-    </Panel.Body>
-  </Panel>
-)
+const BucketExplainer: FunctionComponent = () => {
+  const docsLink = useSelector(isOrgIOx)
+    ? 'https://docs.influxdata.com/influxdb/cloud-serverless/write-data/'
+    : `https://docs.influxdata.com/influxdb/${DOCS_URL_VERSION}/write-data/`
+
+  return (
+    <Panel gradient={Gradients.PolarExpress} border={true}>
+      <Panel.Header>
+        <h5>What is a Bucket?</h5>
+      </Panel.Header>
+      <Panel.Body>
+        <p>
+          A bucket is a named location where time series data is stored. All
+          buckets have a <b>Retention Period</b>, a duration of time that each
+          data point persists.
+          <br />
+          <br />
+          Here's{' '}
+          <a href={docsLink} target="_blank" rel="noreferrer">
+            how to write data
+          </a>{' '}
+          into your bucket.
+        </p>
+      </Panel.Body>
+    </Panel>
+  )
+}
 
 export default BucketExplainer


### PR DESCRIPTION
This PR changes some text on the Buckets helper panel as well as corrects the URL for Serverless.

![image](https://github.com/influxdata/ui/assets/11937365/843a8a1a-09d7-4c86-a1e2-7e42b46afa18)

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Feature flagged, if applicable
