### PR TITLE
chore(epic-idpe-17711): keep graphs working for SQL by using Flux query

### DIFF
--- a/src/dataExplorer/components/Results.tsx
+++ b/src/dataExplorer/components/Results.tsx
@@ -185,6 +185,18 @@ const GraphResults: FC = () => {
   const {result, status} = useContext(ChildResultsContext)
   const {range} = useContext(PersistenceContext)
 
+  const viewElement = useMemo(() => {
+    return (
+      <View
+        loading={status}
+        properties={view.properties}
+        result={result?.parsed}
+        timeRange={range}
+        hideTimer
+      />
+    )
+  }, [status, view.properties, result?.parsed, range])
+
   if (result?.error) {
     return <ErrorResults error={result.error} />
   }
@@ -195,13 +207,7 @@ const GraphResults: FC = () => {
       data-testid="data-explorer-results--view"
     >
       <SpinnerContainer loading={status} spinnerComponent={<TechnoSpinner />}>
-        <View
-          loading={status}
-          properties={view.properties}
-          result={result?.parsed}
-          timeRange={range}
-          hideTimer
-        />
+        {viewElement}
       </SpinnerContainer>
     </div>
   )

--- a/src/dataExplorer/components/Results.tsx
+++ b/src/dataExplorer/components/Results.tsx
@@ -275,12 +275,12 @@ const NOT_SUPPORTED_GRAPH_TYPES = [
 ]
 const GraphHeader: FC = () => {
   const {view, setView} = useContext(ResultsViewContext)
-  const {result} = useContext(ResultsContext)
   const {result: subQueryResult} = useContext(ChildResultsContext)
   const {launch, clear: closeSidebar} = useContext(SidebarContext)
 
   const dataExists =
-    !!result?.parsed && result.parsed.resultColumnNames.length > 0
+    !!subQueryResult?.parsed &&
+    subQueryResult.parsed.resultColumnNames.length > 0
 
   const launcher = () => {
     launch(<WrappedOptions />)
@@ -292,7 +292,7 @@ const GraphHeader: FC = () => {
     } else {
       closeSidebar()
     }
-  }, [result])
+  }, [subQueryResult])
 
   const updateType = viewType => {
     setView({

--- a/src/dataExplorer/context/results/childResults.tsx
+++ b/src/dataExplorer/context/results/childResults.tsx
@@ -10,8 +10,7 @@ import {PersistenceContext} from 'src/dataExplorer/context/persistence'
 import {QueryContext, SqlQueryModifiers} from 'src/shared/contexts/query'
 
 // Types
-import {FluxResult} from 'src/types/flows'
-import {RemoteDataState} from 'src/types'
+import {RemoteDataState, FluxResult} from 'src/types'
 import {LanguageType} from 'src/dataExplorer/components/resources'
 
 // Utils
@@ -132,6 +131,10 @@ export const ChildResultsProvider: FC = ({children}) => {
         language: resource?.language ?? LanguageType.SQL,
         bucket: selection.bucket,
         sqlQueryModifiers,
+        // keep SQL using the Flux endpoint so that
+        // UI can keep reusing the Giraffe plots
+        // https://github.com/influxdata/idpe/issues/17986#issuecomment-1703346936
+        useFluxEndpoint: true,
       }
     )
       .then(result => {

--- a/src/shared/contexts/query/context.tsx
+++ b/src/shared/contexts/query/context.tsx
@@ -56,6 +56,7 @@ export interface QueryOptions {
   dbrp?: DBRP
   rawBlob?: boolean
   sqlQueryModifiers?: SqlQueryModifiers
+  useFluxEndpoint?: boolean
 }
 
 export interface SqlQueryModifiers {
@@ -145,7 +146,11 @@ const buildQueryRequest = (
     return {url, body, headers}
   }
 
-  if (isFlagEnabled('v2privateQueryUI') && language === LanguageType.SQL) {
+  if (
+    isFlagEnabled('v2privateQueryUI') &&
+    language === LanguageType.SQL &&
+    !options?.useFluxEndpoint
+  ) {
     const url = `${API_BASE_PATH}api/v2private/query?database=${options?.bucket?.name}`
     const body = text
     const headers = {


### PR DESCRIPTION
Closes https://github.com/influxdata/idpe/issues/17986

This PR refactors the code to make the Script Editor (new Data Explorer) always use the Flux query endpoint (`/api/v2/query`) to get data that is used for plotting graphs when user select SQL as the query language. In this way, regardless whether the feature flag `v2privateQueryUI` is on or off, the graphs can work as usual. See the [original issue](https://github.com/influxdata/idpe/issues/17986) for the reason.

# Before

https://github.com/influxdata/ui/assets/14298407/e825319d-c950-42c6-a35f-d75d4fd094dc


# After

https://github.com/influxdata/ui/assets/14298407/fdb54674-ddac-4d87-b523-ec7badec55d5


<!-- Describe your proposed changes here. -->
<!-- Including screenshots or visuals is very helpful - a picture is worth a thousand words. -->

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
