### PR TITLE
chore(epic-idpe-17711): add e2e tests and turn on flag `v2privateQueryUI` in tests

### DIFF
--- a/cypress/e2e/cloud/scriptQueryBuilder.influxql.test.ts
+++ b/cypress/e2e/cloud/scriptQueryBuilder.influxql.test.ts
@@ -119,6 +119,7 @@ describe('Script Builder', () => {
   beforeEach(() => {
     cy.scriptsLoginWithFlags({
       influxqlUI: true,
+      v2privateQueryUI: true,
     }).then(() => {
       cy.clearInfluxQLScriptSession()
       cy.getByTestID('editor-sync--toggle')


### PR DESCRIPTION
Closes https://github.com/influxdata/idpe/issues/18029

This PR turns on the flag `v2privateQueryUI` in the e2e tests for SQL and InfluxQL and add CSV download for SQL. 

The existing test cases already cover schema browser, run button, CSV, graphs, and table, so just turning on the feature flag is good enough!

# Tests against IOx passed locally

### SQL

![Screenshot 2023-09-07 at 3 27 52 PM](https://github.com/influxdata/ui/assets/14298407/aad96e21-607a-4ed5-99c6-2da78f7a081e)

![Screenshot 2023-09-07 at 1 19 39 PM](https://github.com/influxdata/ui/assets/14298407/db158679-3fd0-4315-b1b5-d5296c289053)

![Screenshot 2023-09-07 at 1 41 56 PM](https://github.com/influxdata/ui/assets/14298407/78e812fa-a50f-47f3-8707-f7c5076db73f)

### InfluxQL

![Screenshot 2023-09-07 at 2 28 22 PM](https://github.com/influxdata/ui/assets/14298407/70ea47eb-6cae-4c10-8dc5-d2e54b66a976)

![Screenshot 2023-09-07 at 2 02 43 PM](https://github.com/influxdata/ui/assets/14298407/607bc2d4-b0c0-4523-9db3-08682467be38)

![Screenshot 2023-09-07 at 3 51 03 PM](https://github.com/influxdata/ui/assets/14298407/ebb7dbf2-b347-4971-91b4-39c39c2406bc)



### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
