### PR TITLE
chore: remove feature flag `v2privateQueryUI`

### DIFF
--- a/cypress/e2e/cloud/scriptQueryBuilder.influxql.test.ts
+++ b/cypress/e2e/cloud/scriptQueryBuilder.influxql.test.ts
@@ -119,7 +119,6 @@ describe('Script Builder', () => {
   beforeEach(() => {
     cy.scriptsLoginWithFlags({
       influxqlUI: true,
-      v2privateQueryUI: true,
     }).then(() => {
       cy.clearInfluxQLScriptSession()
       cy.getByTestID('editor-sync--toggle')

--- a/cypress/e2e/shared/scriptQueryBuilder.sql.test.ts
+++ b/cypress/e2e/shared/scriptQueryBuilder.sql.test.ts
@@ -83,9 +83,7 @@ describe('Script Builder', () => {
   })
 
   beforeEach(() => {
-    cy.scriptsLoginWithFlags({
-      v2privateQueryUI: true,
-    }).then(() => {
+    cy.scriptsLoginWithFlags({}).then(() => {
       cy.clearSqlScriptSession()
       cy.getByTestID('editor-sync--toggle')
       cy.getByTestID('sql-editor', {timeout: DELAY_FOR_LAZY_LOAD_EDITOR})

--- a/src/dataExplorer/components/ResultsPane.tsx
+++ b/src/dataExplorer/components/ResultsPane.tsx
@@ -45,12 +45,8 @@ import {event} from 'src/cloud/utils/reporting'
 import {notify} from 'src/shared/actions/notifications'
 import {getWindowPeriodVariableFromVariables} from 'src/variables/utils/getWindowVars'
 import {csvDownloadFailure} from 'src/shared/copy/notifications'
-import {
-  sqlAsFlux,
-  updateWindowPeriod,
-} from 'src/shared/contexts/query/preprocessing'
+import {updateWindowPeriod} from 'src/shared/contexts/query/preprocessing'
 import {rangeToParam} from 'src/dataExplorer/shared/utils'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Constants
 import {TIME_RANGE_START, TIME_RANGE_STOP} from 'src/variables/constants'
@@ -128,25 +124,14 @@ const ResultsPane: FC = () => {
 
       switch (language) {
         case LanguageType.SQL:
-          if (isFlagEnabled('v2privateQueryUI')) {
-            url = `${API_BASE_PATH}api/v2private/query?database=${selection.bucket?.name}`
-            // the `\n` character is interpreted by the browser as a line break
-            // so replacing the `\n` char with empty space to keep query in correct syntax
-            inputValue = text.replace(/\n/g, ' ')
-            // Intentionally keep the `break` inside the if statement;
-            // Otherwide, users cannot download csv for SQL queries when
-            // the feature flag is not enabled
-            break
-          }
-        // If the flag is not enabled, each SQL query actually will be wrapped
-        // inside a Flux query `iox.sql()`, and the if statement will be false,
-        // so we want the logic to fall to the next case LanguageType.FLUX
+          url = `${API_BASE_PATH}api/v2private/query?database=${selection.bucket?.name}`
+          // the `\n` character is interpreted by the browser as a line break
+          // so replacing the `\n` char with empty space to keep query in correct syntax
+          inputValue = text.replace(/\n/g, ' ')
+          break
         case LanguageType.FLUX:
           url = `${API_BASE_PATH}api/v2/query?${new URLSearchParams({orgID})}`
-          const query =
-            language == LanguageType.SQL
-              ? sqlAsFlux(text, selection.bucket)
-              : text
+          const query = text
           const extern = updateWindowPeriod(
             query,
             {

--- a/src/dataExplorer/context/fields.tsx
+++ b/src/dataExplorer/context/fields.tsx
@@ -24,7 +24,6 @@ import {
   SEARCH_STRING,
   sanitizeSQLSearchTerm,
 } from 'src/dataExplorer/shared/utils'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Selectors
 import {isOrgIOx} from 'src/organizations/selectors'
@@ -77,7 +76,7 @@ export const FieldsProvider: FC<Prop> = ({children, scope}) => {
 
     setLoading(RemoteDataState.Loading)
 
-    if (isFlagEnabled('v2privateQueryUI') && isIOx) {
+    if (isIOx) {
       // user input is sanitized to avoid SQL injection
       const sanitized = sanitizeSQLSearchTerm(searchTerm)
       const queryTextSQL: string = `

--- a/src/dataExplorer/context/measurements.tsx
+++ b/src/dataExplorer/context/measurements.tsx
@@ -22,7 +22,6 @@ import {
   SAMPLE_DATA_SET,
   sanitizeSQLSearchTerm,
 } from 'src/dataExplorer/shared/utils'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Selectors
 import {isOrgIOx} from 'src/organizations/selectors'
@@ -64,7 +63,7 @@ export const MeasurementsProvider: FC<Prop> = ({children, scope}) => {
 
     setLoading(RemoteDataState.Loading)
 
-    if (isFlagEnabled('v2privateQueryUI') && isIOx) {
+    if (isIOx) {
       // user input is sanitized to avoid SQL injection
       const sanitized = sanitizeSQLSearchTerm(searchTerm)
       const queryTextSQL: string = `

--- a/src/dataExplorer/context/tags.tsx
+++ b/src/dataExplorer/context/tags.tsx
@@ -24,7 +24,6 @@ import {
   SEARCH_STRING,
   sanitizeSQLSearchTerm,
 } from 'src/dataExplorer/shared/utils'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Selectors
 import {isOrgIOx} from 'src/organizations/selectors'
@@ -91,7 +90,7 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
 
     setLoadingTagKeys(RemoteDataState.Loading)
 
-    if (isFlagEnabled('v2privateQueryUI') && isIOx) {
+    if (isIOx) {
       // user input is sanitized to avoid SQL injection
       const sanitized = sanitizeSQLSearchTerm(searchTerm)
       const queryTextSQL: string = `
@@ -211,7 +210,7 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
       [tagKey]: RemoteDataState.Loading,
     })
 
-    if (isFlagEnabled('v2privateQueryUI') && isIOx) {
+    if (isIOx) {
       const queryTextSQL: string = `
         SELECT DISTINCT("${tagKey}")
         FROM "${measurement}"

--- a/src/shared/components/CSVExportButton.tsx
+++ b/src/shared/components/CSVExportButton.tsx
@@ -13,7 +13,6 @@ import {AppState} from 'src/types'
 import {LanguageType} from 'src/dataExplorer/components/resources'
 
 // Utils
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 type PropsFromRedux = ConnectedProps<typeof connector>
 
@@ -80,7 +79,7 @@ class CSVExportButton extends PureComponent<Props, State> {
       )
     }
 
-    if (isFlagEnabled('v2privateQueryUI') && props.workerRegistrationSQL) {
+    if (props.workerRegistrationSQL) {
       ;(props.workerRegistrationSQL as Promise<ServiceWorkerRegistration>).then(
         registrationResult => {
           if (registrationResult.active.state == 'activated') {
@@ -103,7 +102,6 @@ class CSVExportButton extends PureComponent<Props, State> {
 
   public render() {
     if (
-      isFlagEnabled('v2privateQueryUI') &&
       this.props.language === LanguageType.SQL &&
       !this.state.browserSupportsDownloadSQL
     ) {

--- a/src/shared/contexts/query/context.tsx
+++ b/src/shared/contexts/query/context.tsx
@@ -37,7 +37,6 @@ import {DBRP} from 'src/client'
 
 // Utils
 import {addAnnotationToCSV} from 'src/shared/utils/addAnnotationToCSV'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 interface CancelMap {
   [key: string]: () => void
@@ -146,11 +145,7 @@ const buildQueryRequest = (
     return {url, body, headers}
   }
 
-  if (
-    isFlagEnabled('v2privateQueryUI') &&
-    language === LanguageType.SQL &&
-    !options?.useFluxEndpoint
-  ) {
+  if (language === LanguageType.SQL && !options?.useFluxEndpoint) {
     const url = `${API_BASE_PATH}api/v2private/query?database=${options?.bucket?.name}`
     const body = text
     const headers = {


### PR DESCRIPTION
Part of https://github.com/influxdata/idpe/issues/18016

`v2privateQueryUI` has been on in production for two weeks and it's working without issues. This PR removes the feature flag `v2privateQueryUI` in UI.



<!-- Describe your proposed changes here. -->
<!-- Including screenshots or visuals is very helpful - a picture is worth a thousand words. -->

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
