### PR TITLE
chore: remove feature flag `influxqlUI`

### DIFF
--- a/cypress/e2e/cloud/scriptQueryBuilder.influxql.test.ts
+++ b/cypress/e2e/cloud/scriptQueryBuilder.influxql.test.ts
@@ -117,9 +117,7 @@ describe('Script Builder', () => {
   })
 
   beforeEach(() => {
-    cy.scriptsLoginWithFlags({
-      influxqlUI: true,
-    }).then(() => {
+    cy.scriptsLoginWithFlags({}).then(() => {
       cy.clearInfluxQLScriptSession()
       cy.getByTestID('editor-sync--toggle')
       cy.getByTestID('influxql-editor', {timeout: DELAY_FOR_LAZY_LOAD_EDITOR})

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -820,6 +820,12 @@ const setScriptToLanguage = (
   defaultEditorText: string
 ) => {
   return cy.isIoxOrg().then(isIox => {
+    if (lang === 'influxql') {
+      // give cypress some time to set up
+      // database and retetion policy (DBRP) mappings
+      cy.wait(1000)
+    }
+
     // influxql works on both IOx and TSM
     if (isIox || lang === 'influxql') {
       cy.getByTestID('script-query-builder--new-script')

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -820,12 +820,6 @@ const setScriptToLanguage = (
   defaultEditorText: string
 ) => {
   return cy.isIoxOrg().then(isIox => {
-    if (lang === 'influxql') {
-      // give cypress some time to turn on the feature flag `influxqlUI`
-      // this block can be removed after this feature flag is removed
-      cy.wait(1000)
-    }
-
     // influxql works on both IOx and TSM
     if (isIox || lang === 'influxql') {
       cy.getByTestID('script-query-builder--new-script')

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -822,7 +822,7 @@ const setScriptToLanguage = (
   return cy.isIoxOrg().then(isIox => {
     if (lang === 'influxql') {
       // give cypress some time to set up
-      // database and retetion policy (DBRP) mappings
+      // database and retention policy (DBRP) mappings
       cy.wait(1000)
     }
 

--- a/src/dataExplorer/components/SaveAsScript.tsx
+++ b/src/dataExplorer/components/SaveAsScript.tsx
@@ -29,6 +29,7 @@ import {QueryContext} from 'src/shared/contexts/query'
 import {ResultsContext} from 'src/dataExplorer/context/results'
 import {PersistenceContext} from 'src/dataExplorer/context/persistence'
 import {ResultsViewContext} from 'src/dataExplorer/context/resultsView'
+import {DBRPContext} from 'src/shared/contexts/dbrps'
 
 // Types
 import {RemoteDataState} from 'src/types'
@@ -61,6 +62,7 @@ const SaveAsScript: FC<Props> = ({language, onClose, setOverlayType, type}) => {
   const {hasChanged, resource, setResource, save} =
     useContext(PersistenceContext)
   const isIoxOrg = useSelector(isOrgIOx)
+  const {hasDBRPs} = useContext(DBRPContext)
   const {cancel} = useContext(QueryContext)
   const {setStatus, setResult} = useContext(ResultsContext)
   const {clear: clearViewOptions} = useContext(ResultsViewContext)
@@ -110,7 +112,10 @@ const SaveAsScript: FC<Props> = ({language, onClose, setOverlayType, type}) => {
     setResult(null)
     clearViewOptions()
 
-    if (isIoxOrg) {
+    // InfluxQL works on both IOx and TSM, so if an account has
+    // any database and retention policy (DBRP) mappings, the url
+    // should include the parameter `language={}`
+    if (isIoxOrg || hasDBRPs()) {
       history.replace(
         `/orgs/${org.id}/data-explorer/from/script?language=${language}&${SCRIPT_EDITOR_PARAMS}`
       )

--- a/src/dataExplorer/components/SaveAsScript.tsx
+++ b/src/dataExplorer/components/SaveAsScript.tsx
@@ -45,7 +45,6 @@ import {
   copyToClipboardFailed,
   copyToClipboardSuccess,
 } from 'src/shared/copy/notifications'
-import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 import './SaveAsScript.scss'
 
@@ -111,7 +110,7 @@ const SaveAsScript: FC<Props> = ({language, onClose, setOverlayType, type}) => {
     setResult(null)
     clearViewOptions()
 
-    if (isIoxOrg || isFlagEnabled('influxqlUI')) {
+    if (isIoxOrg) {
       history.replace(
         `/orgs/${org.id}/data-explorer/from/script?language=${language}&${SCRIPT_EDITOR_PARAMS}`
       )

--- a/src/dataExplorer/components/ScriptQueryBuilder.tsx
+++ b/src/dataExplorer/components/ScriptQueryBuilder.tsx
@@ -141,7 +141,7 @@ const ScriptQueryBuilder: FC = () => {
             {option}
           </Dropdown.Item>
         ))}
-      {isFlagEnabled('influxqlUI') && hasDBRPs() ? (
+      {hasDBRPs() ? (
         <Dropdown.Item
           className={`script-dropdown__${LanguageType.INFLUXQL}`}
           key={LanguageType.INFLUXQL}
@@ -168,7 +168,7 @@ const ScriptQueryBuilder: FC = () => {
           {option}
         </Dropdown.Item>
       ))}
-      {isFlagEnabled('influxqlUI') && hasDBRPs() ? (
+      {hasDBRPs() ? (
         <Dropdown.Item
           className={`script-dropdown__${LanguageType.INFLUXQL}`}
           key={LanguageType.INFLUXQL}
@@ -196,7 +196,7 @@ const ScriptQueryBuilder: FC = () => {
   )
 
   const tsmNewScriptDropDown =
-    isFlagEnabled('influxqlUI') && hasDBRPs() && CLOUD ? (
+    hasDBRPs() && CLOUD ? (
       <Dropdown
         menu={menuTSM}
         button={button}


### PR DESCRIPTION
Part of https://github.com/influxdata/ui/issues/6800

The feature flag `influxqlUI` has been on in production for two weeks without any issues, so removing it in this PR

<!-- Describe your proposed changes here. -->
<!-- Including screenshots or visuals is very helpful - a picture is worth a thousand words. -->

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
