### PR TITLE
feat: Add click through announcement feature

### DIFF
--- a/cypress/e2e/cloud/createOrg.test.ts
+++ b/cypress/e2e/cloud/createOrg.test.ts
@@ -156,10 +156,8 @@ const setupTest = (setupParams: SetupParams) => {
         // If a url is specified, start the test at that url.
         if (urlToVisit) {
           cy.visit(`orgs/${idpeOrgID}/` + urlToVisit)
-          cy.disableClickThroughAnnouncement()
         } else {
           cy.visit('/')
-          cy.disableClickThroughAnnouncement()
         }
       })
     })
@@ -229,6 +227,10 @@ describe('Free account', () => {
 })
 
 describe('PAYG account', () => {
+  beforeEach(() => {
+    cy.disableClickThroughAnnouncement()
+  })
+
   it('can create new orgs, if there are orgs left in the quota', () => {
     setupTest({accountType: 'pay_as_you_go', canCreateOrgs: true})
 

--- a/cypress/e2e/cloud/createOrg.test.ts
+++ b/cypress/e2e/cloud/createOrg.test.ts
@@ -156,8 +156,10 @@ const setupTest = (setupParams: SetupParams) => {
         // If a url is specified, start the test at that url.
         if (urlToVisit) {
           cy.visit(`orgs/${idpeOrgID}/` + urlToVisit)
+          cy.disableClickThroughAnnouncement()
         } else {
           cy.visit('/')
+          cy.disableClickThroughAnnouncement()
         }
       })
     })

--- a/cypress/index.d.ts
+++ b/cypress/index.d.ts
@@ -69,6 +69,7 @@ import {
   selectScriptFieldOrTag,
   scriptsLoginWithFlags,
   createScript,
+  disableClickThroughAnnouncement
 } from './support/commands'
 
 declare global {
@@ -145,6 +146,7 @@ declare global {
       selectScriptFieldOrTag: typeof selectScriptFieldOrTag
       scriptsLoginWithFlags: typeof scriptsLoginWithFlags
       createScript: typeof createScript
+      disableClickThroughAnnouncement: typeof disableClickThroughAnnouncement
     }
   }
 }

--- a/cypress/index.d.ts
+++ b/cypress/index.d.ts
@@ -69,7 +69,7 @@ import {
   selectScriptFieldOrTag,
   scriptsLoginWithFlags,
   createScript,
-  disableClickThroughAnnouncement
+  disableClickThroughAnnouncement,
 } from './support/commands'
 
 declare global {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1540,7 +1540,10 @@ export const disableClickThroughAnnouncement = () => {
     display: false,
   }
 
-  localStorage.setItem('clickThroughAnnouncement', JSON.stringify(announcementState))
+  localStorage.setItem(
+    'clickThroughAnnouncement',
+    JSON.stringify(announcementState)
+  )
 }
 
 /* eslint-disable */
@@ -1554,7 +1557,10 @@ Cypress.Commands.add('createCheck', createCheck)
 Cypress.Commands.add('createAlertGroup', createAlertGroup)
 
 // click through announcements
-Cypress.Commands.add('disableClickThroughAnnouncement', disableClickThroughAnnouncement)
+Cypress.Commands.add(
+  'disableClickThroughAnnouncement',
+  disableClickThroughAnnouncement
+)
 
 // assertions
 Cypress.Commands.add('fluxEqual', fluxEqual)

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -11,6 +11,7 @@ import {Bucket, Organization} from '../../src/client'
 import {FlagMap} from 'src/shared/actions/flags'
 import {addTimestampToRecs, addStaggerTimestampToRecs, parseTime} from './Utils'
 import 'cypress-file-upload'
+import 'cypress-localstorage-commands'
 
 const DEX_URL_VAR = 'dexUrl'
 
@@ -1533,6 +1534,15 @@ export const createTaskFromEmpty = (
   cy.getByTestID('task-form-offset-input').type(offset)
 }
 
+export const disableClickThroughAnnouncement = () => {
+  const announcementState = {
+    announcementID: 'payg-pricing-increase-announcement',
+    display: false,
+  }
+
+  localStorage.setItem('clickThroughAnnouncement', JSON.stringify(announcementState))
+}
+
 /* eslint-disable */
 // notification endpoints
 Cypress.Commands.add('createEndpoint', createEndpoint)
@@ -1542,6 +1552,9 @@ Cypress.Commands.add('createRule', createRule)
 Cypress.Commands.add('createCheck', createCheck)
 // alert group
 Cypress.Commands.add('createAlertGroup', createAlertGroup)
+
+// click through announcements
+Cypress.Commands.add('disableClickThroughAnnouncement', disableClickThroughAnnouncement)
 
 // assertions
 Cypress.Commands.add('fluxEqual', fluxEqual)

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -11,7 +11,6 @@ import {Bucket, Organization} from '../../src/client'
 import {FlagMap} from 'src/shared/actions/flags'
 import {addTimestampToRecs, addStaggerTimestampToRecs, parseTime} from './Utils'
 import 'cypress-file-upload'
-import 'cypress-localstorage-commands'
 
 const DEX_URL_VAR = 'dexUrl'
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1539,7 +1539,7 @@ export const disableClickThroughAnnouncement = () => {
     display: false,
   }
 
-  localStorage.setItem(
+  window.localStorage.setItem(
     'clickThroughAnnouncement',
     JSON.stringify(announcementState)
   )

--- a/src/billing/components/PayAsYouGo/PayAsYouGo.tsx
+++ b/src/billing/components/PayAsYouGo/PayAsYouGo.tsx
@@ -1,4 +1,8 @@
+// Libraries
 import React, {FC} from 'react'
+import {useSelector} from 'react-redux'
+
+// Components
 import {
   AlignItems,
   ComponentSize,
@@ -7,8 +11,6 @@ import {
   Panel,
   ResourceList,
 } from '@influxdata/clockface'
-
-// Components
 import PlanTypePanel from 'src/billing/components/PayAsYouGo/PlanTypePanel'
 import PaymentPanel from 'src/billing/components/PaymentInfo/PaymentPanel'
 import BillingContactInfo from 'src/billing/components/BillingContactInfo'
@@ -17,35 +19,45 @@ import CancellationPanel from 'src/billing/components/PayAsYouGo/CancellationPan
 import NotificationPanel from 'src/billing/components/PayAsYouGo/NotificationPanel'
 import InvoiceLoadingWrapper from 'src/billing/components/AssetLoading/InvoiceWrapper'
 import BillingInfoWrapper from 'src/billing/components/AssetLoading/BillingInfoWrapper'
+import {PricingAlert} from 'src/billing/components/PayAsYouGo/PricingAlert'
 
-const BillingPayAsYouGo: FC = () => (
-  <FlexBox
-    direction={FlexDirection.Column}
-    alignItems={AlignItems.Stretch}
-    margin={ComponentSize.Small}
-  >
-    <BillingInfoWrapper>
-      <>
-        <PlanTypePanel />
-        <Panel>
-          <Panel.Header testID="past-invoices--header">
-            <h4>Past Invoices</h4>
-          </Panel.Header>
-          <Panel.Body>
-            <ResourceList>
-              <InvoiceLoadingWrapper>
-                <InvoiceHistory />
-              </InvoiceLoadingWrapper>
-            </ResourceList>
-          </Panel.Body>
-        </Panel>
-        <PaymentPanel />
-        <BillingContactInfo />
-      </>
-    </BillingInfoWrapper>
-    <NotificationPanel />
-    <CancellationPanel />
-  </FlexBox>
-)
+// Utils
+import {selectCurrentIdentity} from 'src/identity/selectors'
+
+const BillingPayAsYouGo: FC = () => {
+  const {account} = useSelector(selectCurrentIdentity)
+  const directSignup = account.billingProvider === 'zuora'
+
+  return (
+    <FlexBox
+      direction={FlexDirection.Column}
+      alignItems={AlignItems.Stretch}
+      margin={ComponentSize.Small}
+    >
+      <BillingInfoWrapper>
+        <>
+          {directSignup && <PricingAlert />}
+          <PlanTypePanel />
+          <Panel>
+            <Panel.Header testID="past-invoices--header">
+              <h4>Past Invoices</h4>
+            </Panel.Header>
+            <Panel.Body>
+              <ResourceList>
+                <InvoiceLoadingWrapper>
+                  <InvoiceHistory />
+                </InvoiceLoadingWrapper>
+              </ResourceList>
+            </Panel.Body>
+          </Panel>
+          <PaymentPanel />
+          <BillingContactInfo />
+        </>
+      </BillingInfoWrapper>
+      <NotificationPanel />
+      <CancellationPanel />
+    </FlexBox>
+  )
+}
 
 export default BillingPayAsYouGo

--- a/src/billing/components/PayAsYouGo/PayAsYouGo.tsx
+++ b/src/billing/components/PayAsYouGo/PayAsYouGo.tsx
@@ -26,7 +26,7 @@ import {selectCurrentIdentity} from 'src/identity/selectors'
 
 const BillingPayAsYouGo: FC = () => {
   const {account} = useSelector(selectCurrentIdentity)
-  const directSignup = account.billingProvider === 'zuora'
+  const isdDirectSignup = account.billingProvider === 'zuora'
 
   return (
     <FlexBox
@@ -36,7 +36,7 @@ const BillingPayAsYouGo: FC = () => {
     >
       <BillingInfoWrapper>
         <>
-          {directSignup && <PricingAlert />}
+          {isdDirectSignup && <PricingAlert />}
           <PlanTypePanel />
           <Panel>
             <Panel.Header testID="past-invoices--header">

--- a/src/billing/components/PayAsYouGo/PayAsYouGo.tsx
+++ b/src/billing/components/PayAsYouGo/PayAsYouGo.tsx
@@ -26,7 +26,7 @@ import {selectCurrentIdentity} from 'src/identity/selectors'
 
 const BillingPayAsYouGo: FC = () => {
   const {account} = useSelector(selectCurrentIdentity)
-  const isdDirectSignup = account.billingProvider === 'zuora'
+  const isDirectSignup = account.billingProvider === 'zuora'
 
   return (
     <FlexBox
@@ -36,7 +36,7 @@ const BillingPayAsYouGo: FC = () => {
     >
       <BillingInfoWrapper>
         <>
-          {isdDirectSignup && <PricingAlert />}
+          {isDirectSignup && <PricingAlert />}
           <PlanTypePanel />
           <Panel>
             <Panel.Header testID="past-invoices--header">

--- a/src/billing/components/PayAsYouGo/PricingAlert.tsx
+++ b/src/billing/components/PayAsYouGo/PricingAlert.tsx
@@ -26,6 +26,12 @@ export const PricingAlert: React.FC = () => {
   const org = useSelector(selectCurrentOrg)
   const user = useSelector(selectUser)
 
+  const encodedSubect = encodeURI('PAYG Pricing Increase')
+  const encodedBody = encodeURI(`User ID: ${user.email}
+Org ID: ${org.id}
+
+Please describe your inquiry here.`)
+
   const handleContactUsClick = () => {
     event(`pricingAnnouncementBanner.contactUs.clicked`)
   }
@@ -42,8 +48,8 @@ export const PricingAlert: React.FC = () => {
           your usage-based pricing. Please feel free to{' '}
           <SafeBlankLink
             href={`mailto:payg-price-change@influxdata.com?
-            &subject=PAYG%20price%20change%20inquiry
-            &body=User%20ID:%20${user.email}%0D%0AOrg%20ID:%20${org.id}%0D%0A%0D%0APlease%20describe%20your%20inquiry%20here.`}
+            &subject=${encodedSubect}
+            &body=${encodedBody}`}
             onClick={handleContactUsClick}
           >
             contact us

--- a/src/billing/components/PayAsYouGo/PricingAlert.tsx
+++ b/src/billing/components/PayAsYouGo/PricingAlert.tsx
@@ -26,7 +26,7 @@ export const PricingAlert: React.FC = () => {
   const org = useSelector(selectCurrentOrg)
   const user = useSelector(selectUser)
 
-  const encodedSubect = encodeURI('PAYG Pricing Increase')
+  const encodedSubject = encodeURI('PAYG Pricing Increase')
   const encodedBody = encodeURI(`User ID: ${user.email}
 Org ID: ${org.id}
 
@@ -48,7 +48,7 @@ Please describe your inquiry here.`)
           your usage-based pricing. Please feel free to{' '}
           <SafeBlankLink
             href={`mailto:payg-price-change@influxdata.com?
-            &subject=${encodedSubect}
+            &subject=${encodedSubject}
             &body=${encodedBody}`}
             onClick={handleContactUsClick}
           >

--- a/src/billing/components/PayAsYouGo/PricingAlert.tsx
+++ b/src/billing/components/PayAsYouGo/PricingAlert.tsx
@@ -1,0 +1,66 @@
+// Libraries
+import React, {useEffect} from 'react'
+import {useSelector} from 'react-redux'
+
+// Components
+import {
+  Alert,
+  FlexBox,
+  IconFont,
+  ComponentColor,
+  ComponentSize,
+} from '@influxdata/clockface'
+import {SafeBlankLink} from 'src/utils/SafeBlankLink'
+
+// Utils
+import {event} from 'src/cloud/utils/reporting'
+
+// Selectors
+import {selectCurrentOrg, selectUser} from 'src/identity/selectors'
+
+export const PricingAlert: React.FC = () => {
+  useEffect(() => {
+    event(`pricingAnnouncementBanner.displayed`)
+  }, [])
+
+  const org = useSelector(selectCurrentOrg)
+  const user = useSelector(selectUser)
+
+  const handleContactUsClick = () => {
+    event(`pricingAnnouncementBanner.contactUs.clicked`)
+  }
+
+  const handlePricingAnnouncementClick = () => {
+    event(`pricingAnnouncementBanner.details.clicked`)
+  }
+
+  return (
+    <Alert icon={IconFont.AlertTriangle} color={ComponentColor.Primary}>
+      <FlexBox margin={ComponentSize.Medium}>
+        <FlexBox.Child grow={1} shrink={0}>
+          Starting on <b>December 1, 2023</b> there will be an increase in to
+          your usage-based pricing. Please feel free to{' '}
+          <SafeBlankLink
+            href={`mailto:payg-price-change@influxdata.com?
+            &subject=PAYG%20price%20change%20inquiry
+            &body=User%20ID:%20${user.email}%0D%0AOrg%20ID:%20${org.id}%0D%0A%0D%0APlease%20describe%20your%20inquiry%20here.`}
+            onClick={handleContactUsClick}
+          >
+            contact us
+          </SafeBlankLink>{' '}
+          with questions or refer to our website for additional information.
+        </FlexBox.Child>
+        <FlexBox.Child grow={0} shrink={0}>
+          <SafeBlankLink
+            href="https://www.influxdata.com/influxdb-pricing"
+            onClick={handlePricingAnnouncementClick}
+          >
+            <div className="cf-button cf-button-xs cf-button-primary">
+              <span className="cf-button-label">View Pricing Changes</span>
+            </div>
+          </SafeBlankLink>
+        </FlexBox.Child>
+      </FlexBox>
+    </Alert>
+  )
+}

--- a/src/homepageExperience/ClickThroughAnnouncementHandler.tsx
+++ b/src/homepageExperience/ClickThroughAnnouncementHandler.tsx
@@ -44,11 +44,11 @@ export const ClickThroughAnnouncementHandler: FC = () => {
   useEffect(() => {
     // Current Announcement: PAYG Pricing Increase
     // Audience: Cloud, Pay As You Go, Direct Signups
-    const paygAccount = account.type === 'pay_as_you_go'
-    const directSignup = account.billingProvider === 'zuora'
-    const audience = CLOUD && paygAccount && directSignup
+    const isPaygAccount = account.type === 'pay_as_you_go'
+    const isDirectSignup = account.billingProvider === 'zuora'
+    const isTargetAudience = CLOUD && isPaygAccount && isDirectSignup
 
-    if (audience) {
+    if (isTargetAudience) {
       setCurrentAnnouncement('payg-pricing-increase-announcement')
 
       if (announcementState['display']) {

--- a/src/homepageExperience/ClickThroughAnnouncementHandler.tsx
+++ b/src/homepageExperience/ClickThroughAnnouncementHandler.tsx
@@ -1,0 +1,67 @@
+// Libraries
+import {FC, useEffect} from 'react'
+import {useSelector, useDispatch} from 'react-redux'
+import {useLocalStorageState} from 'use-local-storage-state'
+
+// Selectors
+import {selectCurrentIdentity} from 'src/identity/selectors'
+
+// Utils
+import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
+
+// Constants
+import {CLOUD} from 'src/shared/constants'
+
+export const ClickThroughAnnouncementHandler: FC = () => {
+  const dispatch = useDispatch()
+  const {account} = useSelector(selectCurrentIdentity)
+
+  const [announcementState, setAnnouncementState] = useLocalStorageState(
+    'clickThroughAnnouncement',
+    {
+      announcementID: '',
+      display: true,
+    }
+  )
+
+  const setCurrentAnnouncement = (announcementID: string): void => {
+    if (announcementState['announcementID'] !== announcementID) {
+      setAnnouncementState({
+        announcementID: announcementID,
+        display: true,
+      })
+    }
+  }
+
+  const handleDismissAnnouncement = (): void => {
+    setAnnouncementState(prevState => ({
+      ...prevState,
+      display: false,
+    }))
+    dismissOverlay()
+  }
+
+  useEffect(() => {
+    // Current Announcement: PAYG Pricing Increase
+    // Audience: Cloud, Pay As You Go, Direct Signups
+    const paygAccount = account.type === 'pay_as_you_go'
+    const directSignup = account.billingProvider === 'zuora'
+    const audience = CLOUD && paygAccount && directSignup
+
+    if (audience) {
+      setCurrentAnnouncement('payg-pricing-increase-announcement')
+
+      if (announcementState['display']) {
+        dispatch(
+          showOverlay(
+            'click-through-announcement',
+            null,
+            handleDismissAnnouncement
+          )
+        )
+      }
+    }
+  }, [announcementState])
+
+  return null
+}

--- a/src/homepageExperience/ClickThroughAnnouncementHandler.tsx
+++ b/src/homepageExperience/ClickThroughAnnouncementHandler.tsx
@@ -9,9 +9,6 @@ import {selectCurrentIdentity} from 'src/identity/selectors'
 // Utils
 import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
 
-// Constants
-import {CLOUD} from 'src/shared/constants'
-
 export const ClickThroughAnnouncementHandler: FC = () => {
   const dispatch = useDispatch()
   const {account} = useSelector(selectCurrentIdentity)
@@ -43,10 +40,10 @@ export const ClickThroughAnnouncementHandler: FC = () => {
 
   useEffect(() => {
     // Current Announcement: PAYG Pricing Increase
-    // Audience: Cloud, Pay As You Go, Direct Signups
+    // Audience: Pay As You Go & Direct Signups
     const isPaygAccount = account.type === 'pay_as_you_go'
     const isDirectSignup = account.billingProvider === 'zuora'
-    const isTargetAudience = CLOUD && isPaygAccount && isDirectSignup
+    const isTargetAudience = isPaygAccount && isDirectSignup
 
     if (isTargetAudience) {
       setCurrentAnnouncement('payg-pricing-increase-announcement')

--- a/src/homepageExperience/containers/HomepageContainer.tsx
+++ b/src/homepageExperience/containers/HomepageContainer.tsx
@@ -10,6 +10,9 @@ import {ClickThroughAnnouncementHandler} from 'src/homepageExperience/ClickThrou
 // Utils
 import {isOrgIOx} from 'src/organizations/selectors'
 
+// Constants
+import {CLOUD} from 'src/shared/constants'
+
 export const HomepageContainer: FC = () => {
   const homepageContents = useSelector(isOrgIOx) ? (
     <HomepageContents />
@@ -20,7 +23,7 @@ export const HomepageContainer: FC = () => {
   return (
     <>
       {homepageContents}
-      <ClickThroughAnnouncementHandler />
+      {CLOUD && <ClickThroughAnnouncementHandler />}
     </>
   )
 }

--- a/src/homepageExperience/containers/HomepageContainer.tsx
+++ b/src/homepageExperience/containers/HomepageContainer.tsx
@@ -5,6 +5,7 @@ import {useSelector} from 'react-redux'
 // Components
 import {HomepageContents} from 'src/homepageExperience/containers/HomepageContents'
 import {HomepageContentsTSM} from 'src/homepageExperience/containers/HomepageContentsTSM'
+import {ClickThroughAnnouncementHandler} from 'src/homepageExperience/ClickThroughAnnouncementHandler'
 
 // Utils
 import {isOrgIOx} from 'src/organizations/selectors'
@@ -16,5 +17,10 @@ export const HomepageContainer: FC = () => {
     <HomepageContentsTSM />
   )
 
-  return <>{homepageContents}</>
+  return (
+    <>
+      {homepageContents}
+      <ClickThroughAnnouncementHandler />
+    </>
+  )
 }

--- a/src/me/components/ClickThroughAnnouncementOverlay.tsx
+++ b/src/me/components/ClickThroughAnnouncementOverlay.tsx
@@ -1,0 +1,101 @@
+// Libraries
+import React, {useEffect} from 'react'
+import {useSelector} from 'react-redux'
+
+// Components
+import {Overlay, Button, ComponentColor} from '@influxdata/clockface'
+import {SafeBlankLink} from 'src/utils/SafeBlankLink'
+
+// Utils
+import {event} from 'src/cloud/utils/reporting'
+
+// Selectors
+import {selectCurrentOrg, selectUser} from 'src/identity/selectors'
+
+interface ClickThroughAnnouncementOverlayProps {
+  onClose: () => void
+}
+
+export const ClickThroughAnnouncementOverlay: React.FC<
+  ClickThroughAnnouncementOverlayProps
+> = ({onClose}) => {
+  useEffect(() => {
+    event(`pricingClickThroughAnnouncement.displayed`)
+  }, [])
+
+  const org = useSelector(selectCurrentOrg)
+  const user = useSelector(selectUser)
+
+  const handlePricingAnnouncementClick = () => {
+    event(`pricingClickThroughAnnouncement.details.clicked`)
+  }
+
+  const handleContactUsClick = () => {
+    event(`pricingClickThroughAnnouncement.contactUs.clicked`)
+  }
+
+  const handleAcknowledgeClick = () => {
+    event(`pricingClickThroughAnnouncement.acknowledge.clicked`)
+    onClose()
+  }
+
+  return (
+    <Overlay visible={true}>
+      <Overlay.Container>
+        <Overlay.Header title="Notice: Your Plan Pricing is Changing" />
+        <Overlay.Body>
+          <p>
+            Starting on <strong>December 1, 2023</strong> there will be an
+            increase in to your usage-based pricing.
+          </p>
+          <p>
+            Your monthly charges will continue to be based on your actual
+            consumption of the four billable usage vectors: Data In, Query
+            Count, Storage and Data Out. This is unchanged. However, unit
+            pricing for two of these vectors will be increased beginning{' '}
+            <strong>December 1, 2023</strong>:
+          </p>
+          <ul>
+            <li>
+              Data In will increase from $0.002 to $0.0025 per MB ingested
+            </li>
+            <li>
+              Query Count will increase from $0.01 to $0.012 per 100 executed
+            </li>
+          </ul>
+          <p>
+            This increase to your total monthly charges will depend on the
+            specific distribution of your workload across the billable vectors.
+            Most customers will experience an increase between 14% - 24%.
+          </p>
+          <p>
+            Please feel free to{' '}
+            <SafeBlankLink
+              href={`mailto:payg-price-change@influxdata.com?
+                &subject=PAYG%20price%20change%20inquiry
+                &body=User%20ID:%20${user.email}%0D%0AOrg%20ID:%20${org.id}%0D%0A%0D%0APlease%20describe%20your%20inquiry%20here.`}
+              onClick={handleContactUsClick}
+            >
+              contact us
+            </SafeBlankLink>{' '}
+            with questions or refer to our website for{' '}
+            <SafeBlankLink
+              href="https://www.influxdata.com/influxdb-pricing"
+              onClick={handlePricingAnnouncementClick}
+            >
+              additional information
+            </SafeBlankLink>
+            .
+          </p>
+        </Overlay.Body>
+        <Overlay.Footer>
+          <Button
+            text="Acknowledge"
+            color={ComponentColor.Primary}
+            onClick={handleAcknowledgeClick}
+          />
+        </Overlay.Footer>
+      </Overlay.Container>
+    </Overlay>
+  )
+}

--- a/src/me/components/ClickThroughAnnouncementOverlay.tsx
+++ b/src/me/components/ClickThroughAnnouncementOverlay.tsx
@@ -26,6 +26,12 @@ export const ClickThroughAnnouncementOverlay: React.FC<
   const org = useSelector(selectCurrentOrg)
   const user = useSelector(selectUser)
 
+  const encodedSubect = encodeURI('PAYG Pricing Increase')
+  const encodedBody = encodeURI(`User ID: ${user.email}
+Org ID: ${org.id}
+
+Please describe your inquiry here.`)
+
   const handlePricingAnnouncementClick = () => {
     event(`pricingClickThroughAnnouncement.details.clicked`)
   }
@@ -72,8 +78,8 @@ export const ClickThroughAnnouncementOverlay: React.FC<
             Please feel free to{' '}
             <SafeBlankLink
               href={`mailto:payg-price-change@influxdata.com?
-                &subject=PAYG%20price%20change%20inquiry
-                &body=User%20ID:%20${user.email}%0D%0AOrg%20ID:%20${org.id}%0D%0A%0D%0APlease%20describe%20your%20inquiry%20here.`}
+              &subject=${encodedSubect}
+              &body=${encodedBody}`}
               onClick={handleContactUsClick}
             >
               contact us

--- a/src/me/components/ClickThroughAnnouncementOverlay.tsx
+++ b/src/me/components/ClickThroughAnnouncementOverlay.tsx
@@ -26,7 +26,7 @@ export const ClickThroughAnnouncementOverlay: React.FC<
   const org = useSelector(selectCurrentOrg)
   const user = useSelector(selectUser)
 
-  const encodedSubect = encodeURI('PAYG Pricing Increase')
+  const encodedSubject = encodeURI('PAYG Pricing Increase')
   const encodedBody = encodeURI(`User ID: ${user.email}
 Org ID: ${org.id}
 
@@ -78,7 +78,7 @@ Please describe your inquiry here.`)
             Please feel free to{' '}
             <SafeBlankLink
               href={`mailto:payg-price-change@influxdata.com?
-              &subject=${encodedSubect}
+              &subject=${encodedSubject}
               &body=${encodedBody}`}
               onClick={handleContactUsClick}
             >

--- a/src/overlays/components/OverlayController.tsx
+++ b/src/overlays/components/OverlayController.tsx
@@ -49,6 +49,7 @@ import {MarketoAccountUpgradeOverlay} from 'src/identity/components/MarketoAccou
 import {SuspendPaidOrgOverlay} from 'src/organizations/components/OrgProfileTab/SuspendPaidOrgOverlay'
 import {ReplaceCertificateOverlay} from 'src/writeData/subscriptions/components/CertificateInput'
 import {RemoveMemberOverlay} from 'src/users/components/RemoveMemberOverlay'
+import {ClickThroughAnnouncementOverlay} from 'src/me/components/ClickThroughAnnouncementOverlay'
 
 // Actions
 import {dismissOverlay} from 'src/overlays/actions/overlays'
@@ -188,6 +189,11 @@ export const OverlayController: FunctionComponent = () => {
         break
       case 'remove-member':
         activeOverlay.current = <RemoveMemberOverlay />
+        break
+      case 'click-through-announcement':
+        activeOverlay.current = (
+          <ClickThroughAnnouncementOverlay onClose={onClose} />
+        )
         break
       default:
         activeOverlay.current = null

--- a/src/overlays/reducers/overlays.ts
+++ b/src/overlays/reducers/overlays.ts
@@ -40,6 +40,7 @@ export type OverlayID =
   | 'marketo-upgrade-account-overlay'
   | 'suspend-org-in-paid-account'
   | 'remove-member'
+  | 'click-through-announcement'
 
 export interface OverlayState {
   id: OverlayID | null

--- a/src/shared/containers/GetOrganizations.tsx
+++ b/src/shared/containers/GetOrganizations.tsx
@@ -23,6 +23,7 @@ import {getAllOrgs} from 'src/resources/selectors'
 import {
   selectCurrentIdentity,
   selectQuartzIdentityStatus,
+  selectQuartzBillingStatus,
 } from 'src/identity/selectors'
 
 // Constants
@@ -40,6 +41,7 @@ import {RemoteDataState} from 'src/types'
 // Thunks
 import {getQuartzIdentityThunk} from 'src/identity/actions/thunks'
 import {getNotebooks} from 'src/flows/actions/flowsThunks'
+import {getBillingProviderThunk} from 'src/identity/actions/thunks'
 
 const GetOrganizations: FunctionComponent = () => {
   const {status: orgLoadingStatus} = useSelector(getAllOrgs)
@@ -47,6 +49,7 @@ const GetOrganizations: FunctionComponent = () => {
   // This selector is CLOUD-only. It has default empty values in OSS.
   const {user, account, org} = useSelector(selectCurrentIdentity)
   const identityLoadingStatus = useSelector(selectQuartzIdentityStatus)
+  const quartzBillingStatus = useSelector(selectQuartzBillingStatus)
 
   const dispatch = useDispatch()
 
@@ -61,6 +64,12 @@ const GetOrganizations: FunctionComponent = () => {
       dispatch(getQuartzIdentityThunk())
     }
   }, [dispatch, identityLoadingStatus]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (CLOUD && quartzBillingStatus === RemoteDataState.NotStarted) {
+      dispatch(getBillingProviderThunk())
+    }
+  }, [dispatch, quartzBillingStatus])
 
   useEffect(() => {
     if (


### PR DESCRIPTION
This PR adds a new feature to Serverless, the click-through announcement. It is used for important announcements that users must see and includes event tracking for interacting with the announcement component.

The first announcement is for the PAYG pricing increase. There is also a banner on the billing page regarding this announcement. Both of these are limited to direct signup PAYG users.

<img width="1840" alt="image" src="https://github.com/influxdata/ui/assets/11937365/84261180-7d52-49ed-812a-844068a21c2f">

<img width="1433" alt="image" src="https://github.com/influxdata/ui/assets/11937365/d5bdfc21-8af1-473b-a062-31bf16f91ba4">

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Feature flagged, if applicable
