### PR TITLE
fix(python): unmatched paren and influxql syntax:

### DIFF
--- a/src/homepageExperience/components/steps/python/ExecuteAggregateQuerySql.tsx
+++ b/src/homepageExperience/components/steps/python/ExecuteAggregateQuerySql.tsx
@@ -21,14 +21,14 @@ export const ExecuteAggregateQuerySql = (props: OwnProps) => {
 
   const sqlSnippet = `SELECT mean(count)
 FROM 'census'
-WHERE time > now() - '10m'`
+WHERE time > now() - 10m`
 
   const querySnippet = `query = """SELECT mean(count)
 FROM 'census'
-WHERE time > now() - '10m'"""
+WHERE time > now() - 10m"""
 
 # Execute the query
-table = client.query(query=query, database="${bucket}", language='influxql') )
+table = client.query(query=query, database="${bucket}", language="influxql")
 
 # Convert to dataframe
 df = table.to_pandas().sort_values(by="time")

--- a/src/homepageExperience/components/steps/python/ExecuteAggregateQuerySql.tsx
+++ b/src/homepageExperience/components/steps/python/ExecuteAggregateQuerySql.tsx
@@ -20,11 +20,11 @@ export const ExecuteAggregateQuerySql = (props: OwnProps) => {
   const {bucket} = props
 
   const sqlSnippet = `SELECT mean(count)
-FROM 'census'
+FROM "census"
 WHERE time > now() - 10m`
 
   const querySnippet = `query = """SELECT mean(count)
-FROM 'census'
+FROM "census"
 WHERE time > now() - 10m"""
 
 # Execute the query


### PR DESCRIPTION
Closes #6831 

- Remove unmatched closing paren.
- Remove quotes from InfluxQL duration. Durations aren't strings. If using SQL, the interval expression ('10 minutes') would be a string.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
