### PR TITLE
Use same var name as other setup instruction segments.

### DIFF
--- a/src/homepageExperience/components/steps/python/InitializeClient.tsx
+++ b/src/homepageExperience/components/steps/python/InitializeClient.tsx
@@ -25,7 +25,7 @@ token = os.environ.get("INFLUXDB_TOKEN")
 org = "${org.name}"
 url = "${url}"
 
-write_client = influxdb_client.InfluxDBClient(url=url, token=token, org=org)
+client = influxdb_client.InfluxDBClient(url=url, token=token, org=org)
 `
 
   return (


### PR DESCRIPTION
Closes #

The Python setup steps use `write_client` in the initialization step and `client` everywhere else. This makes them all use `client` instead.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [ ] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ x] Feature flagged, if applicable
