### PR TITLE
feat(ui): add mqtt eol overlay and alert banner

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1535,8 +1535,8 @@ export const createTaskFromEmpty = (
 
 export const disableClickThroughAnnouncement = () => {
   const announcementState = {
-    announcementID: 'payg-pricing-increase-announcement',
-    display: false,
+    mqttEolClickThroughAnnouncement: 'dismissed',
+    pricingClickThroughAnnouncement: 'dismissed',
   }
 
   window.localStorage.setItem(

--- a/src/homepageExperience/ClickThroughAnnouncementHandler.tsx
+++ b/src/homepageExperience/ClickThroughAnnouncementHandler.tsx
@@ -11,7 +11,7 @@ import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {event} from 'src/cloud/utils/reporting'
 
-enum AnnouncementID {
+export enum AnnouncementID {
   MqttEol = 'mqttEolClickThroughAnnouncement',
   PriceIncrease = 'pricingClickThroughAnnouncement',
 }

--- a/src/homepageExperience/ClickThroughAnnouncementHandler.tsx
+++ b/src/homepageExperience/ClickThroughAnnouncementHandler.tsx
@@ -8,6 +8,8 @@ import {selectCurrentIdentity} from 'src/identity/selectors'
 
 // Utils
 import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
+import {event} from 'src/cloud/utils/reporting'
 
 export const ClickThroughAnnouncementHandler: FC = () => {
   const dispatch = useDispatch()
@@ -15,48 +17,66 @@ export const ClickThroughAnnouncementHandler: FC = () => {
 
   const [announcementState, setAnnouncementState] = useLocalStorageState(
     'clickThroughAnnouncement',
-    {
-      announcementID: '',
-      display: true,
-    }
+    {}
   )
 
-  const setCurrentAnnouncement = (announcementID: string): void => {
-    if (announcementState['announcementID'] !== announcementID) {
-      setAnnouncementState({
-        announcementID: announcementID,
-        display: true,
-      })
+  const initAnnouncement = (announcementID: string): void => {
+    if (!announcementState[announcementID]) {
+      setAnnouncementState(prevState => ({
+        ...prevState,
+        [announcementID]: 'display',
+      }))
     }
   }
 
-  const handleDismissAnnouncement = (): void => {
-    setAnnouncementState(prevState => ({
-      ...prevState,
-      display: false,
-    }))
+  const handleDismissAnnouncement = (announcementID: string): void => {
     dismissOverlay()
+    event(`${announcementID}.dismissed`)
+    setTimeout(() => {
+      setAnnouncementState(prevState => ({
+        ...prevState,
+        [announcementID]: 'dismissed',
+      }))
+    }, 1000)
+  }
+
+  const handleDisplayAnnouncement = (announcementID: string): void => {
+    initAnnouncement(announcementID)
+
+    if (announcementState[announcementID] === 'display') {
+      const overlayParams = {
+        announcementID,
+      }
+      dispatch(
+        showOverlay('click-through-announcement', overlayParams, () =>
+          handleDismissAnnouncement(announcementID)
+        )
+      )
+    }
   }
 
   useEffect(() => {
-    // Current Announcement: PAYG Pricing Increase
-    // Audience: Pay As You Go & Direct Signups
+    // MQTT Audience: Cloud users with MQTT feature flag enabled
+    const mqttAnnouncementID = 'mqttEolClickThroughAnnouncement'
+    const isMqttAudience = isFlagEnabled('subscriptionsUI')
+
+    // PAYG Pricing Increase Audience: Pay As You Go & Direct Signups
+    const priceIncreaseAnnouncementID = 'pricingClickThroughAnnouncement'
     const isPaygAccount = account.type === 'pay_as_you_go'
     const isDirectSignup = account.billingProvider === 'zuora'
-    const isTargetAudience = isPaygAccount && isDirectSignup
+    const isPriceIncreaseAudience = isPaygAccount && isDirectSignup
 
-    if (isTargetAudience) {
-      setCurrentAnnouncement('payg-pricing-increase-announcement')
-
-      if (announcementState['display']) {
-        dispatch(
-          showOverlay(
-            'click-through-announcement',
-            null,
-            handleDismissAnnouncement
-          )
-        )
-      }
+    // Sequentially display announcements in order of priority
+    if (
+      isMqttAudience &&
+      announcementState[mqttAnnouncementID] !== 'dismissed'
+    ) {
+      handleDisplayAnnouncement(mqttAnnouncementID)
+    } else if (
+      isPriceIncreaseAudience &&
+      announcementState[priceIncreaseAnnouncementID] !== 'dismissed'
+    ) {
+      handleDisplayAnnouncement(priceIncreaseAnnouncementID)
     }
   }, [announcementState])
 

--- a/src/me/components/ClickThroughAnnouncementOverlay.tsx
+++ b/src/me/components/ClickThroughAnnouncementOverlay.tsx
@@ -9,6 +9,7 @@ import {MqttEolAnnouncement} from 'src/me/components/announcements/MqttEolAnnoun
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'
+import {AnnouncementID} from 'src/homepageExperience/ClickThroughAnnouncementHandler'
 
 // Selectors
 import {getOverlayParams} from 'src/overlays/selectors'
@@ -41,7 +42,7 @@ export const ClickThroughAnnouncementOverlay: FC<
 
   const announcementContents = (): JSX.Element => {
     switch (announcementID) {
-      case 'pricingClickThroughAnnouncement':
+      case AnnouncementID.PriceIncrease:
         return (
           <PaygPriceIncreaseAnnouncement
             handleAcknowledgeClick={handleAcknowledgeClick}
@@ -49,7 +50,7 @@ export const ClickThroughAnnouncementOverlay: FC<
             handleDetailsClick={handleDetailsClick}
           />
         )
-      case 'mqttEolClickThroughAnnouncement':
+      case AnnouncementID.MqttEol:
         return (
           <MqttEolAnnouncement
             handleAcknowledgeClick={handleAcknowledgeClick}

--- a/src/me/components/ClickThroughAnnouncementOverlay.tsx
+++ b/src/me/components/ClickThroughAnnouncementOverlay.tsx
@@ -1,107 +1,69 @@
 // Libraries
-import React, {useEffect} from 'react'
+import React, {FC, useEffect} from 'react'
 import {useSelector} from 'react-redux'
 
 // Components
-import {Overlay, Button, ComponentColor} from '@influxdata/clockface'
-import {SafeBlankLink} from 'src/utils/SafeBlankLink'
+import {Overlay} from '@influxdata/clockface'
+import {PaygPriceIncreaseAnnouncement} from 'src/me/components/announcements/PaygPriceIncreaseAnnouncement'
+import {MqttEolAnnouncement} from 'src/me/components/announcements/MqttEolAnnouncement'
 
 // Utils
 import {event} from 'src/cloud/utils/reporting'
 
 // Selectors
-import {selectCurrentOrg, selectUser} from 'src/identity/selectors'
+import {getOverlayParams} from 'src/overlays/selectors'
 
 interface ClickThroughAnnouncementOverlayProps {
   onClose: () => void
 }
 
-export const ClickThroughAnnouncementOverlay: React.FC<
+export const ClickThroughAnnouncementOverlay: FC<
   ClickThroughAnnouncementOverlayProps
 > = ({onClose}) => {
+  const {announcementID} = useSelector(getOverlayParams)
+
   useEffect(() => {
-    event(`pricingClickThroughAnnouncement.displayed`)
+    event(`${announcementID}.displayed`)
   }, [])
 
-  const org = useSelector(selectCurrentOrg)
-  const user = useSelector(selectUser)
-
-  const encodedSubject = encodeURI('PAYG Pricing Increase')
-  const encodedBody = encodeURI(`User ID: ${user.email}
-Org ID: ${org.id}
-
-Please describe your inquiry here.`)
-
-  const handlePricingAnnouncementClick = () => {
-    event(`pricingClickThroughAnnouncement.details.clicked`)
+  const handleDetailsClick = () => {
+    event(`${announcementID}.details.clicked`)
   }
 
   const handleContactUsClick = () => {
-    event(`pricingClickThroughAnnouncement.contactUs.clicked`)
+    event(`${announcementID}.contactUs.clicked`)
   }
 
   const handleAcknowledgeClick = () => {
-    event(`pricingClickThroughAnnouncement.acknowledge.clicked`)
+    event(`${announcementID}.acknowledge.clicked`)
     onClose()
+  }
+
+  const announcementContents = (): JSX.Element => {
+    switch (announcementID) {
+      case 'pricingClickThroughAnnouncement':
+        return (
+          <PaygPriceIncreaseAnnouncement
+            handleAcknowledgeClick={handleAcknowledgeClick}
+            handleContactUsClick={handleContactUsClick}
+            handleDetailsClick={handleDetailsClick}
+          />
+        )
+      case 'mqttEolClickThroughAnnouncement':
+        return (
+          <MqttEolAnnouncement
+            handleAcknowledgeClick={handleAcknowledgeClick}
+            handleDetailsClick={handleDetailsClick}
+          />
+        )
+      default:
+        return null
+    }
   }
 
   return (
     <Overlay visible={true}>
-      <Overlay.Container>
-        <Overlay.Header title="Notice: Your Plan Pricing is Changing" />
-        <Overlay.Body>
-          <p>
-            Starting on <strong>December 1, 2023</strong> there will be an
-            increase in to your usage-based pricing.
-          </p>
-          <p>
-            Your monthly charges will continue to be based on your actual
-            consumption of the four billable usage vectors: Data In, Query
-            Count, Storage and Data Out. This is unchanged. However, unit
-            pricing for two of these vectors will be increased beginning{' '}
-            <strong>December 1, 2023</strong>:
-          </p>
-          <ul>
-            <li>
-              Data In will increase from $0.002 to $0.0025 per MB ingested
-            </li>
-            <li>
-              Query Count will increase from $0.01 to $0.012 per 100 executed
-            </li>
-          </ul>
-          <p>
-            This increase to your total monthly charges will depend on the
-            specific distribution of your workload across the billable vectors.
-            Most customers will experience an increase between 14% - 24%.
-          </p>
-          <p>
-            Please feel free to{' '}
-            <SafeBlankLink
-              href={`mailto:payg-price-change@influxdata.com?
-              &subject=${encodedSubject}
-              &body=${encodedBody}`}
-              onClick={handleContactUsClick}
-            >
-              contact us
-            </SafeBlankLink>{' '}
-            with questions or refer to our website for{' '}
-            <SafeBlankLink
-              href="https://www.influxdata.com/influxdb-pricing"
-              onClick={handlePricingAnnouncementClick}
-            >
-              additional information
-            </SafeBlankLink>
-            .
-          </p>
-        </Overlay.Body>
-        <Overlay.Footer>
-          <Button
-            text="Acknowledge"
-            color={ComponentColor.Primary}
-            onClick={handleAcknowledgeClick}
-          />
-        </Overlay.Footer>
-      </Overlay.Container>
+      <Overlay.Container>{announcementContents()}</Overlay.Container>
     </Overlay>
   )
 }

--- a/src/me/components/announcements/MqttEolAnnouncement.tsx
+++ b/src/me/components/announcements/MqttEolAnnouncement.tsx
@@ -1,0 +1,151 @@
+// Libraries
+import React, {FC} from 'react'
+
+// Components
+import {Accordion, Overlay, Button, ComponentColor} from '@influxdata/clockface'
+import {SafeBlankLink} from 'src/utils/SafeBlankLink'
+
+interface MqttEolAnnouncementProps {
+  handleAcknowledgeClick: () => void
+  handleDetailsClick: () => void
+}
+
+export const MqttEolAnnouncement: FC<MqttEolAnnouncementProps> = ({
+  handleAcknowledgeClick,
+  handleDetailsClick,
+}) => {
+  return (
+    <>
+      <Overlay.Header title="Deprecation Notice: MQTT Native Collector" />
+      <Overlay.Body>
+        <p>
+          The Native Collector - MQTT feature is being deprecated and will stop
+          functioning on <strong>April 30, 2024</strong>.
+        </p>
+        <p>
+          Please refer to the FAQ below for more details and guidance on
+          alternate solutions currently available.
+        </p>
+        <Accordion>
+          <Accordion.AccordionHeader>
+            <span>
+              <strong>Q: </strong>What is the Native Collector - MQTT Feature?
+            </span>
+          </Accordion.AccordionHeader>
+          <Accordion.AccordionBodyItem>
+            <span>
+              <strong>A: </strong>The Native Collector - MQTT feature was
+              introduced in InfluxDB Cloud in 2022 as a way to ingest data
+              directly from MQTT sources into InfluxDB Cloud. This feature has
+              been removed and is no longer available to new customers or
+              existing customers who have not been using it. It was only
+              available to a limited number of existing customers who were
+              actively using it.
+            </span>
+          </Accordion.AccordionBodyItem>
+        </Accordion>
+        <Accordion>
+          <Accordion.AccordionHeader>
+            <span>
+              <strong>Q: </strong>Why is this feature being EOLed?
+            </span>
+          </Accordion.AccordionHeader>
+          <Accordion.AccordionBodyItem>
+            <span>
+              <strong>A: </strong>The adoption of this feature was lower than
+              anticipated given most customers continued to use Telegraf,
+              InfluxData's data collection agent, which provides more features
+              for MQTT ingestion than this feature did. After a thorough
+              assessment, we determined that our customers can have a similar -
+              and superior - experience with the MQTT Consumer Telegraf Input
+              Plugin.
+            </span>
+          </Accordion.AccordionBodyItem>
+        </Accordion>
+        <Accordion>
+          <Accordion.AccordionHeader>
+            <span>
+              <strong>Q: </strong>What alternatives are available in light of
+              this EOL announcement?
+            </span>
+          </Accordion.AccordionHeader>
+          <Accordion.AccordionBodyItem>
+            <span>
+              <strong>A: </strong>We recommend using the MQTT Consumer Telegraf
+              Input Plugin as an alternative to the Native Collector - MQTT
+              feature. It's free to use and is available for download{' '}
+              <SafeBlankLink
+                href="https://www.influxdata.com/integration/mqtt-telegraf-consumer/"
+                onClick={handleDetailsClick}
+              >
+                here
+              </SafeBlankLink>
+              . Telegraf is InfluxData's very popular open source data
+              collection agent with 300+ plugins, including MQTT.
+            </span>
+          </Accordion.AccordionBodyItem>
+        </Accordion>
+        <Accordion>
+          <Accordion.AccordionHeader>
+            <span>
+              <strong>Q: </strong>What are the expected next steps?
+            </span>
+          </Accordion.AccordionHeader>
+          <Accordion.AccordionBodyItem>
+            <span>
+              <strong>A: </strong>The Native Collector - MQTT feature will
+              continue to work and function until{' '}
+              <strong>April 30th, 2024</strong>. We will not be doing any new
+              product development or enhancements to the feature in the
+              meantime. After the EOL date, it will be decommissioned and any
+              MQTT subscriptions that you have made will no longer receive and
+              ingest data into InfluxDB.
+            </span>
+          </Accordion.AccordionBodyItem>
+        </Accordion>
+        <Accordion>
+          <Accordion.AccordionHeader>
+            <span>
+              <strong>Q: </strong>Will I lose any data already ingested?
+            </span>
+          </Accordion.AccordionHeader>
+          <Accordion.AccordionBodyItem>
+            <span>
+              <strong>A: </strong>No, already ingested data will not be affected
+              by this change.
+            </span>
+          </Accordion.AccordionBodyItem>
+        </Accordion>
+        <Accordion>
+          <Accordion.AccordionHeader>
+            <span>
+              <strong>Q: </strong>Where can I get more information on using
+              Telegraf as a replacement for Native Collector - MQTT?
+            </span>
+          </Accordion.AccordionHeader>
+          <Accordion.AccordionBodyItem>
+            <span>
+              <strong>A: </strong>You can obtain more information about using
+              Telegraf with MQTT and download the MQTT Consumer Telegraf Input
+              Plugin{' '}
+              <SafeBlankLink
+                href="https://www.influxdata.com/integration/mqtt-telegraf-consumer/"
+                onClick={handleDetailsClick}
+              >
+                here
+              </SafeBlankLink>
+              .
+            </span>
+          </Accordion.AccordionBodyItem>
+        </Accordion>
+      </Overlay.Body>
+      <Overlay.Footer>
+        <Button
+          text="Acknowledge"
+          color={ComponentColor.Primary}
+          onClick={handleAcknowledgeClick}
+        />
+      </Overlay.Footer>
+    </>
+  )
+}

--- a/src/me/components/announcements/PaygPriceIncreaseAnnouncement.tsx
+++ b/src/me/components/announcements/PaygPriceIncreaseAnnouncement.tsx
@@ -1,0 +1,85 @@
+// Libraries
+import React, {FC} from 'react'
+import {useSelector} from 'react-redux'
+
+// Components
+import {Overlay, Button, ComponentColor} from '@influxdata/clockface'
+import {SafeBlankLink} from 'src/utils/SafeBlankLink'
+
+// Selectors
+import {selectCurrentOrg, selectUser} from 'src/identity/selectors'
+
+interface PaygPriceIncreaseAnnouncementProps {
+  handleDetailsClick: () => void
+  handleContactUsClick: () => void
+  handleAcknowledgeClick: () => void
+}
+
+export const PaygPriceIncreaseAnnouncement: FC<
+  PaygPriceIncreaseAnnouncementProps
+> = ({handleDetailsClick, handleContactUsClick, handleAcknowledgeClick}) => {
+  const org = useSelector(selectCurrentOrg)
+  const user = useSelector(selectUser)
+
+  const encodedSubject = encodeURI('PAYG Pricing Increase')
+  const encodedBody = encodeURI(`User ID: ${user.email}
+Org ID: ${org.id}
+
+Please describe your inquiry here.`)
+
+  return (
+    <>
+      <Overlay.Header title="Notice: Your Plan Pricing is Changing" />
+      <Overlay.Body>
+        <p>
+          Starting on <strong>December 1, 2023</strong> there will be an
+          increase in to your usage-based pricing.
+        </p>
+        <p>
+          Your monthly charges will continue to be based on your actual
+          consumption of the four billable usage vectors: Data In, Query Count,
+          Storage and Data Out. This is unchanged. However, unit pricing for two
+          of these vectors will be increased beginning{' '}
+          <strong>December 1, 2023</strong>:
+        </p>
+        <ul>
+          <li>Data In will increase from $0.002 to $0.0025 per MB ingested</li>
+          <li>
+            Query Count will increase from $0.01 to $0.012 per 100 executed
+          </li>
+        </ul>
+        <p>
+          This increase to your total monthly charges will depend on the
+          specific distribution of your workload across the billable vectors.
+          Most customers will experience an increase between 14% - 24%.
+        </p>
+        <p>
+          Please feel free to{' '}
+          <SafeBlankLink
+            href={`mailto:payg-price-change@influxdata.com?
+                &subject=${encodedSubject}
+                &body=${encodedBody}`}
+            onClick={handleContactUsClick}
+          >
+            contact us
+          </SafeBlankLink>{' '}
+          with questions or refer to our website for{' '}
+          <SafeBlankLink
+            href="https://www.influxdata.com/influxdb-pricing"
+            onClick={handleDetailsClick}
+          >
+            additional information
+          </SafeBlankLink>
+          .
+        </p>
+      </Overlay.Body>
+      <Overlay.Footer>
+        <Button
+          text="Acknowledge"
+          color={ComponentColor.Primary}
+          onClick={handleAcknowledgeClick}
+        />
+      </Overlay.Footer>
+    </>
+  )
+}

--- a/src/writeData/subscriptions/components/MqttEolAlert.tsx
+++ b/src/writeData/subscriptions/components/MqttEolAlert.tsx
@@ -1,0 +1,59 @@
+// Libraries
+import React, {FC, useEffect} from 'react'
+import {useDispatch} from 'react-redux'
+
+// Components
+import {
+  Alert,
+  Button,
+  FlexBox,
+  IconFont,
+  ComponentColor,
+  ComponentSize,
+} from '@influxdata/clockface'
+
+// Utils
+import {event} from 'src/cloud/utils/reporting'
+import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
+
+export const MqttEolAlert: FC = () => {
+  const dispatch = useDispatch()
+
+  useEffect(() => {
+    event(`mqttEolAnnouncementBanner.displayed`)
+  }, [])
+
+  const handleDetailsClick = () => {
+    event(`mqttEolAnnouncementBanner.details.clicked`)
+    const overlayParams = {
+      announcementID: 'mqttEolClickThroughAnnouncement',
+    }
+    dispatch(
+      showOverlay('click-through-announcement', overlayParams, () =>
+        dismissOverlay()
+      )
+    )
+  }
+
+  return (
+    <Alert
+      icon={IconFont.AlertTriangle}
+      color={ComponentColor.Primary}
+      className="mqtt-alert"
+    >
+      <FlexBox margin={ComponentSize.Medium}>
+        <FlexBox.Child grow={1} shrink={0}>
+          Important Notice: The Native Collector - MQTT feature is being
+          deprecated and will stop functioning on <b>April 30th, 2024</b>.
+        </FlexBox.Child>
+        <FlexBox.Child grow={0} shrink={0}>
+          <Button
+            text="Learn More"
+            color={ComponentColor.Primary}
+            onClick={handleDetailsClick}
+          />
+        </FlexBox.Child>
+      </FlexBox>
+    </Alert>
+  )
+}

--- a/src/writeData/subscriptions/components/MqttEolAlert.tsx
+++ b/src/writeData/subscriptions/components/MqttEolAlert.tsx
@@ -15,6 +15,7 @@ import {
 // Utils
 import {event} from 'src/cloud/utils/reporting'
 import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
+import {AnnouncementID} from 'src/homepageExperience/ClickThroughAnnouncementHandler'
 
 export const MqttEolAlert: FC = () => {
   const dispatch = useDispatch()
@@ -26,7 +27,7 @@ export const MqttEolAlert: FC = () => {
   const handleDetailsClick = () => {
     event(`mqttEolAnnouncementBanner.details.clicked`)
     const overlayParams = {
-      announcementID: 'mqttEolClickThroughAnnouncement',
+      announcementID: AnnouncementID.MqttEol,
     }
     dispatch(
       showOverlay('click-through-announcement', overlayParams, () =>

--- a/src/writeData/subscriptions/components/SubscriptionsLanding.scss
+++ b/src/writeData/subscriptions/components/SubscriptionsLanding.scss
@@ -13,3 +13,7 @@
     padding: 0;
   }
 }
+
+.mqtt-alert {
+  margin-bottom: $cf-space-l;
+}

--- a/src/writeData/subscriptions/components/SubscriptionsLanding.tsx
+++ b/src/writeData/subscriptions/components/SubscriptionsLanding.tsx
@@ -21,6 +21,7 @@ import {SortTypes} from 'src/shared/utils/sort'
 import {SearchWidget} from 'src/shared/components/search_widget/SearchWidget'
 import ResourceSortDropdown from 'src/shared/components/resource_sort_dropdown/ResourceSortDropdown'
 import LoadDataTabbedPage from 'src/settings/components/LoadDataTabbedPage'
+import {MqttEolAlert} from 'src/writeData/subscriptions/components/MqttEolAlert'
 
 // Contexts
 import {
@@ -113,6 +114,7 @@ const SubscriptionsLanding: FC = () => {
     >
       <LoadDataHeader />
       <LoadDataTabbedPage activeTab="subscriptions">
+        <MqttEolAlert />
         <SpinnerContainer
           spinnerComponent={<TechnoSpinner />}
           loading={loading}


### PR DESCRIPTION
Closes #6828 

This PR updates the click-through announcement overlay feature to be able to handle multiple sequential announcements. It also adds an announcement for the MQTT end-of-life. It adds a click-through overlay to the home page and a permanent alert banner on the Subscriptions page.

Alert Banner
<img width="1728" alt="Screenshot 2023-11-01 at 10 27 23 AM" src="https://github.com/influxdata/ui/assets/11937365/e8cdf3c0-c1b8-4b3f-b69c-33b234872d12">

Click-Through Overlay
<img width="1728" alt="Screenshot 2023-11-01 at 10 26 50 AM" src="https://github.com/influxdata/ui/assets/11937365/8f79cc35-c90c-44b0-b44d-b9f03fbf5dd6">

Click-Through Overlay with Open FAQ Sections (scrolls)
<img width="1728" alt="Screenshot 2023-11-01 at 10 27 08 AM" src="https://github.com/influxdata/ui/assets/11937365/68a2704d-854d-43c7-a4d0-53385e92e86a">

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Feature flagged, if applicable
