### PR TITLE
feat(ui): add request poc panel

### DIFF
--- a/src/pageLayout/components/RequestPocWidget.scss
+++ b/src/pageLayout/components/RequestPocWidget.scss
@@ -1,0 +1,32 @@
+@import '@influxdata/clockface/dist/variables.scss';
+
+.nav-item-poc--contents {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: $cf-space-s;
+  text-align: center;
+  background: rgba(241, 241, 243, 0.05);
+
+  .cf-button {
+    margin-top: $cf-space-s;
+  }
+}
+
+.nav-item-poc {
+  margin-top: auto !important;
+
+  + .nav-item-support {
+    margin-top: $cf-space-s !important;
+  }
+}
+
+.cf-popover {
+  .nav-item-poc--contents {
+    background: transparent;
+    padding: 0;
+    font-weight: normal;
+    width: 220px;
+  }
+}

--- a/src/pageLayout/components/RequestPocWidget.tsx
+++ b/src/pageLayout/components/RequestPocWidget.tsx
@@ -1,0 +1,61 @@
+// Libraries
+import React, {FC} from 'react'
+
+// Components
+import {
+  Button,
+  ComponentColor,
+  Icon,
+  IconFont,
+  TreeNav,
+} from '@influxdata/clockface'
+
+// Utils
+import {event} from 'src/cloud/utils/reporting'
+import {safeBlankLinkOpen} from 'src/utils/safeBlankLinkOpen'
+
+// Styles
+import 'src/pageLayout/components/RequestPocWidget.scss'
+
+interface Props {
+  expanded: boolean
+}
+
+export const RequestPocWidget: FC<Props> = ({expanded}) => {
+  const handleRequestPocClick = () => {
+    event('nav.requestPOC.clicked')
+    safeBlankLinkOpen('https://www.influxdata.com/proof-of-concept/')
+  }
+
+  const contents = (
+    <div className="nav-item-poc--contents">
+      <span>
+        This is a rate limited environment. Want to test the performance and
+        scalability of your workload?
+      </span>
+      <Button
+        icon={IconFont.Flask}
+        text="Request a POC"
+        color={ComponentColor.Primary}
+        onClick={handleRequestPocClick}
+      />
+    </div>
+  )
+
+  if (expanded) {
+    return <div className="nav-item-poc">{contents}</div>
+  } else {
+    return (
+      <TreeNav.Item
+        id="nav-item-poc"
+        testID="nav-item-poc"
+        icon={<Icon glyph={IconFont.Flask} />}
+        label="Request a POC"
+        shortLabel="POC"
+        className="nav-item-poc"
+      >
+        <TreeNav.SubMenu>{contents}</TreeNav.SubMenu>
+      </TreeNav.Item>
+    )
+  }
+}

--- a/src/pageLayout/containers/MainNavigation.scss
+++ b/src/pageLayout/containers/MainNavigation.scss
@@ -1,3 +1,24 @@
-.helpBarStyle {
+@import '@influxdata/clockface/dist/variables.scss';
+
+.nav-item-support {
   margin-top: auto !important;
+}
+
+.nav-item-poc {
+  background: rgba(241, 241, 243, 0.05);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: $cf-space-s;
+  text-align: center;
+  margin-top: auto;
+
+  .cf-button {
+    margin-top: $cf-space-s;
+  }
+
+  + .nav-item-support {
+    margin-top: $cf-space-s !important;
+  }
 }

--- a/src/pageLayout/containers/MainNavigation.scss
+++ b/src/pageLayout/containers/MainNavigation.scss
@@ -1,24 +1,3 @@
-@import '@influxdata/clockface/dist/variables.scss';
-
 .nav-item-support {
   margin-top: auto !important;
-}
-
-.nav-item-poc {
-  background: rgba(241, 241, 243, 0.05);
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  padding: $cf-space-s;
-  text-align: center;
-  margin-top: auto;
-
-  .cf-button {
-    margin-top: $cf-space-s;
-  }
-
-  + .nav-item-support {
-    margin-top: $cf-space-s !important;
-  }
 }

--- a/src/pageLayout/containers/MainNavigation.tsx
+++ b/src/pageLayout/containers/MainNavigation.tsx
@@ -4,16 +4,10 @@ import {Link, useLocation} from 'react-router-dom'
 import {useDispatch, useSelector} from 'react-redux'
 
 // Components
-import {
-  Button,
-  ComponentColor,
-  Icon,
-  IconFont,
-  PopoverPosition,
-  TreeNav,
-} from '@influxdata/clockface'
+import {Icon, IconFont, PopoverPosition, TreeNav} from '@influxdata/clockface'
 import UserWidget from 'src/pageLayout/components/UserWidget'
 import NavHeader from 'src/pageLayout/components/NavHeader'
+import {RequestPocWidget} from '../components/RequestPocWidget'
 
 // Constants
 import {CLOUD} from 'src/shared/constants'
@@ -25,7 +19,6 @@ import {event} from 'src/cloud/utils/reporting'
 import {SafeBlankLink} from 'src/utils/SafeBlankLink'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {isUserOperator} from 'src/operator/utils'
-import {safeBlankLinkOpen} from 'src/utils/safeBlankLinkOpen'
 
 // Selectors
 import {getOrg, isOrgIOx} from 'src/organizations/selectors'
@@ -310,11 +303,6 @@ export const MainNavigation: FC = () => {
     event('helpBar.contactSupportRequest.overlay.shown')
   }
 
-  const handleRequestPocClick = () => {
-    event('nav.requestPOC.clicked')
-    safeBlankLinkOpen('https://www.influxdata.com/proof-of-concept/')
-  }
-
   return (
     <TreeNav
       expanded={navbarMode === 'expanded'}
@@ -387,18 +375,7 @@ export const MainNavigation: FC = () => {
         )
       })}
       {accountType === 'free' && (
-        <div className="nav-item-poc">
-          <span>
-            This is a rate limited environment. Want to test the performance and
-            scalability of your workload?
-          </span>
-          <Button
-            icon={IconFont.Flask}
-            text="Request a POC"
-            color={ComponentColor.Primary}
-            onClick={handleRequestPocClick}
-          />
-        </div>
+        <RequestPocWidget expanded={navbarMode === 'expanded'} />
       )}
       <TreeNav.Item
         id="support"

--- a/src/pageLayout/containers/MainNavigation.tsx
+++ b/src/pageLayout/containers/MainNavigation.tsx
@@ -249,6 +249,8 @@ export const MainNavigation: FC = () => {
   const shouldShowNotebooks = useSelector(selectShouldShowNotebooks)
   const isNewIOxOrg = useSelector(selectIsNewIOxOrg)
   const isIOxOrg = useSelector(isOrgIOx)
+  const showPocRequest =
+    accountType === 'free' && isFlagEnabled('navbarPocRequest')
 
   const dispatch = useDispatch()
 
@@ -374,7 +376,7 @@ export const MainNavigation: FC = () => {
           </TreeNav.Item>
         )
       })}
-      {accountType === 'free' && (
+      {showPocRequest && (
         <RequestPocWidget expanded={navbarMode === 'expanded'} />
       )}
       <TreeNav.Item

--- a/src/pageLayout/containers/MainNavigation.tsx
+++ b/src/pageLayout/containers/MainNavigation.tsx
@@ -25,6 +25,7 @@ import {event} from 'src/cloud/utils/reporting'
 import {SafeBlankLink} from 'src/utils/SafeBlankLink'
 import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 import {isUserOperator} from 'src/operator/utils'
+import {safeBlankLinkOpen} from 'src/utils/safeBlankLinkOpen'
 
 // Selectors
 import {getOrg, isOrgIOx} from 'src/organizations/selectors'
@@ -311,8 +312,7 @@ export const MainNavigation: FC = () => {
 
   const handleRequestPocClick = () => {
     event('nav.requestPOC.clicked')
-    const newTab = window.open('https://www.influxdata.com/proof-of-concept/')
-    newTab.focus()
+    safeBlankLinkOpen('https://www.influxdata.com/proof-of-concept/')
   }
 
   return (

--- a/src/pageLayout/containers/MainNavigation.tsx
+++ b/src/pageLayout/containers/MainNavigation.tsx
@@ -4,7 +4,14 @@ import {Link, useLocation} from 'react-router-dom'
 import {useDispatch, useSelector} from 'react-redux'
 
 // Components
-import {Icon, IconFont, PopoverPosition, TreeNav} from '@influxdata/clockface'
+import {
+  Button,
+  ComponentColor,
+  Icon,
+  IconFont,
+  PopoverPosition,
+  TreeNav,
+} from '@influxdata/clockface'
 import UserWidget from 'src/pageLayout/components/UserWidget'
 import NavHeader from 'src/pageLayout/components/NavHeader'
 
@@ -302,6 +309,12 @@ export const MainNavigation: FC = () => {
     event('helpBar.contactSupportRequest.overlay.shown')
   }
 
+  const handleRequestPocClick = () => {
+    event('nav.requestPOC.clicked')
+    const newTab = window.open('https://www.influxdata.com/proof-of-concept/')
+    newTab.focus()
+  }
+
   return (
     <TreeNav
       expanded={navbarMode === 'expanded'}
@@ -373,13 +386,27 @@ export const MainNavigation: FC = () => {
           </TreeNav.Item>
         )
       })}
+      {accountType === 'free' && (
+        <div className="nav-item-poc">
+          <span>
+            This is a rate limited environment. Want to test the performance and
+            scalability of your workload?
+          </span>
+          <Button
+            icon={IconFont.Flask}
+            text="Request a POC"
+            color={ComponentColor.Primary}
+            onClick={handleRequestPocClick}
+          />
+        </div>
+      )}
       <TreeNav.Item
         id="support"
         testID="nav-item-support"
         icon={<Icon glyph={IconFont.QuestionMark_Outline} />}
         label="Help &amp; Support"
         shortLabel="Support"
-        className="helpBarStyle"
+        className="nav-item-support"
       >
         <TreeNav.SubMenu position={PopoverPosition.ToTheRight}>
           <TreeNav.SubHeading label="Support" />


### PR DESCRIPTION
This PR adds a panel to the nav bar to encourage free account users to request a POC instead of running performance tests in Serverless.

#### Expanded
![image](https://github.com/influxdata/ui/assets/11937365/6953220b-1c18-4e61-8cd3-02cf53b32d71)

#### Collapsed
![image](https://github.com/influxdata/ui/assets/11937365/6ecdab58-cf8d-4ebf-9884-04c2cc0d3d40)


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Feature flagged, if applicable
