### PR TITLE
feat(ui): add deployments option accordion

### DIFF
--- a/src/homepageExperience/components/OptionAccordion/DeployAccordion.tsx
+++ b/src/homepageExperience/components/OptionAccordion/DeployAccordion.tsx
@@ -1,0 +1,80 @@
+// Libraries
+import React, {FC} from 'react'
+
+// Components
+import {IconFont, InfluxColors} from '@influxdata/clockface'
+import {OptionAccordion} from 'src/homepageExperience/components/OptionAccordion/OptionAccordion'
+import {OptionAccordionElement} from 'src/homepageExperience/components/OptionAccordion/OptionAccordionElement'
+import {OptionLink} from './OptionLink'
+
+// Utils
+import {event} from 'src/cloud/utils/reporting'
+
+export const DeployAccordion: FC = () => {
+  const optionId = 'deployInstance'
+
+  const handleServerlessClick = () => {
+    event(`homeOptions.${optionId}.serverless.clicked`)
+  }
+
+  const handleDedicatedClick = () => {
+    event(`homeOptions.${optionId}.dedicated.clicked`)
+  }
+
+  const handleClusteredClick = () => {
+    event(`homeOptions.${optionId}.clustered.clicked`)
+  }
+
+  return (
+    <OptionAccordion
+      headerIcon={IconFont.Cube}
+      headerIconColor={InfluxColors.Star}
+      headerTitle="Deploy"
+      headerDescription="Run InfluxDB where you need it."
+      optionId="deployInstance"
+      bodyContent={
+        <>
+          <OptionAccordionElement
+            elementTitle="Cloud Serverless"
+            elementDescription="A fully managed, elastic, multi-tenant service best for smaller workloads."
+            cta={() => {
+              return (
+                <OptionLink
+                  title="Learn More"
+                  href="https://docs.influxdata.com/influxdb/cloud-serverless/"
+                  onClick={handleServerlessClick}
+                />
+              )
+            }}
+          />
+          <OptionAccordionElement
+            elementTitle="Cloud Dedicated"
+            elementDescription="A fully managed, single-tenant service for high volume production workloads."
+            cta={() => {
+              return (
+                <OptionLink
+                  title="Learn More"
+                  href="https://docs.influxdata.com/influxdb/cloud-dedicated/"
+                  onClick={handleDedicatedClick}
+                />
+              )
+            }}
+          />
+          <OptionAccordionElement
+            elementTitle="Clustered"
+            elementDescription="A self-managed database for on-premises or private cloud deployments."
+            cta={() => {
+              return (
+                <OptionLink
+                  title="Learn More"
+                  href="https://docs.influxdata.com/influxdb/clustered/"
+                  onClick={handleClusteredClick}
+                />
+              )
+            }}
+          />
+        </>
+      }
+    />
+  )
+}

--- a/src/homepageExperience/containers/HomepageContents.tsx
+++ b/src/homepageExperience/containers/HomepageContents.tsx
@@ -31,6 +31,7 @@ import {AddDataAccordion} from 'src/homepageExperience/components/OptionAccordio
 import {QueryDataAccordion} from 'src/homepageExperience/components/OptionAccordion/QueryDataAccordion'
 import {VisualizeAccordion} from 'src/homepageExperience/components/OptionAccordion/VisualizeAccordion'
 import {DeployAccordion} from 'src/homepageExperience/components/OptionAccordion/DeployAccordion'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 // Styles
 import 'src/homepageExperience/containers/HomepageContents.scss'
@@ -38,6 +39,7 @@ import 'src/homepageExperience/containers/HomepageContents.scss'
 export const HomepageContents: FC = () => {
   const {account} = useSelector(selectCurrentIdentity)
   const freeAccount = CLOUD && account.type === 'free'
+  const showDeployAccordion = freeAccount && isFlagEnabled('deployAccordion')
 
   return (
     <Page titleTag={pageTitleSuffixer(['Get Started'])}>
@@ -74,7 +76,7 @@ export const HomepageContents: FC = () => {
                   <AddDataAccordion />
                   <QueryDataAccordion />
                   <VisualizeAccordion />
-                  {freeAccount && <DeployAccordion />}
+                  {showDeployAccordion && <DeployAccordion />}
                 </FlexBox.Child>
               </FlexBox>
             </Grid.Column>

--- a/src/homepageExperience/containers/HomepageContents.tsx
+++ b/src/homepageExperience/containers/HomepageContents.tsx
@@ -26,6 +26,7 @@ import {ManageDatabasesAccordion} from 'src/homepageExperience/components/Option
 import {AddDataAccordion} from 'src/homepageExperience/components/OptionAccordion/AddDataAccordion'
 import {QueryDataAccordion} from 'src/homepageExperience/components/OptionAccordion/QueryDataAccordion'
 import {VisualizeAccordion} from 'src/homepageExperience/components/OptionAccordion/VisualizeAccordion'
+import {DeployAccordion} from 'src/homepageExperience/components/OptionAccordion/DeployAccordion'
 
 // Styles
 import 'src/homepageExperience/containers/HomepageContents.scss'
@@ -66,6 +67,7 @@ export const HomepageContents: FC = () => {
                   <AddDataAccordion />
                   <QueryDataAccordion />
                   <VisualizeAccordion />
+                  <DeployAccordion />
                 </FlexBox.Child>
               </FlexBox>
             </Grid.Column>

--- a/src/homepageExperience/containers/HomepageContents.tsx
+++ b/src/homepageExperience/containers/HomepageContents.tsx
@@ -1,5 +1,6 @@
 // Libraries
 import React, {FC} from 'react'
+import {useSelector} from 'react-redux'
 
 // Components
 import {
@@ -19,6 +20,9 @@ import {CloudWidgets} from 'src/me/components/CloudWidgets'
 // Constants
 import {CLOUD} from 'src/shared/constants'
 
+// Selectors
+import {selectCurrentIdentity} from 'src/identity/selectors'
+
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
 import UsageProvider from 'src/usage/context/usage'
@@ -32,6 +36,9 @@ import {DeployAccordion} from 'src/homepageExperience/components/OptionAccordion
 import 'src/homepageExperience/containers/HomepageContents.scss'
 
 export const HomepageContents: FC = () => {
+  const {account} = useSelector(selectCurrentIdentity)
+  const freeAccount = CLOUD && account.type === 'free'
+
   return (
     <Page titleTag={pageTitleSuffixer(['Get Started'])}>
       <Page.Header fullWidth={true}>
@@ -67,7 +74,7 @@ export const HomepageContents: FC = () => {
                   <AddDataAccordion />
                   <QueryDataAccordion />
                   <VisualizeAccordion />
-                  <DeployAccordion />
+                  {freeAccount && <DeployAccordion />}
                 </FlexBox.Child>
               </FlexBox>
             </Grid.Column>


### PR DESCRIPTION
This adds a new accordion to the homepage with links to information about the deployment options. This is only shown to users on a free account.

<img width="945" alt="image" src="https://github.com/influxdata/ui/assets/11937365/05ed3aa3-5233-4d10-98fd-bb5236f13cba">

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Feature flagged, if applicable
