### PR TITLE
chore(deps): bump influxdata/influxdb-templates from 0.9.0 to 0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "@influxdata/clockface": "^6.3.11",
     "@influxdata/flux-lsp-browser": "0.8.40",
     "@influxdata/giraffe": "^2.38.1",
-    "@influxdata/influxdb-templates": "0.9.0",
+    "@influxdata/influxdb-templates": "0.11.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",
     "abortcontroller-polyfill": "^1.3.0",
     "auth0-js": "^9.19.1",


### PR DESCRIPTION
Updates the influxdb-template version to pull in quick start template that has names for all the cells. This avoids seeing "Name this cell" for the unnamed cells.

Currently, when an OSS user chooses to quick-start, a dashboard is created, but the names of the cells are not set in the template and so the user sees "Name this template":

![image](https://github.com/influxdata/ui/assets/6453401/aa6fef7b-1399-4c22-ae54-8502b4248de8)


With the new version, the following shows:

![image](https://github.com/influxdata/ui/assets/6453401/053a56ac-4889-46de-94b9-ad03e4360f07)

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
