### PR TITLE
feat: limit the time period used in tag values queries

### DIFF
--- a/cypress/e2e/shared/scriptQueryBuilder.results.test.ts
+++ b/cypress/e2e/shared/scriptQueryBuilder.results.test.ts
@@ -63,7 +63,7 @@ describe('Script Builder', () => {
             'defbuck4'
           )
           writeDataMoar.forEach(data => {
-            if ((data, length > 0)) {
+            if (data.length > 0) {
               cy.writeData(data, 'defbuck4')
             }
           })

--- a/cypress/e2e/shared/scriptQueryBuilder.results.test.ts
+++ b/cypress/e2e/shared/scriptQueryBuilder.results.test.ts
@@ -62,7 +62,7 @@ describe('Script Builder', () => {
             [`ndbc_1table,air_temp_degc=70_degrees station_id=1`],
             'defbuck4'
           )
-          writeDataMoar.forEach(data => {if (data,length > 0) cy.writeData(data, 'defbuck4')})
+          writeDataMoar.forEach(data => {if (data,length > 0) {cy.writeData(data, 'defbuck4')}})
         })
       })
     })

--- a/cypress/e2e/shared/scriptQueryBuilder.results.test.ts
+++ b/cypress/e2e/shared/scriptQueryBuilder.results.test.ts
@@ -62,7 +62,11 @@ describe('Script Builder', () => {
             [`ndbc_1table,air_temp_degc=70_degrees station_id=1`],
             'defbuck4'
           )
-          writeDataMoar.forEach(data => {if (data,length > 0) {cy.writeData(data, 'defbuck4')}})
+          writeDataMoar.forEach(data => {
+            if ((data, length > 0)) {
+              cy.writeData(data, 'defbuck4')
+            }
+          })
         })
       })
     })

--- a/cypress/e2e/shared/scriptQueryBuilder.results.test.ts
+++ b/cypress/e2e/shared/scriptQueryBuilder.results.test.ts
@@ -62,7 +62,7 @@ describe('Script Builder', () => {
             [`ndbc_1table,air_temp_degc=70_degrees station_id=1`],
             'defbuck4'
           )
-          writeDataMoar.forEach(data => cy.writeData(data, 'defbuck4'))
+          writeDataMoar.forEach(data => {if (data,length > 0) cy.writeData(data, 'defbuck4')})
         })
       })
     })

--- a/src/dataExplorer/context/tags.tsx
+++ b/src/dataExplorer/context/tags.tsx
@@ -8,7 +8,7 @@ import {
   CACHING_REQUIRED_END_DATE,
   CACHING_REQUIRED_START_DATE,
 } from 'src/utils/datetime/constants'
-import {DEFAULT_LIMIT} from 'src/shared/constants/queryBuilder'
+import {DEFAULT_INTERVAL, DEFAULT_LIMIT} from 'src/shared/constants/queryBuilder'
 import {LanguageType} from 'src/dataExplorer/components/resources'
 
 // Contexts
@@ -214,6 +214,7 @@ export const TagsProvider: FC<Prop> = ({children, scope}) => {
       const queryTextSQL: string = `
         SELECT DISTINCT("${tagKey}")
         FROM "${measurement}"
+        WHERE time < NOW() AND time >= NOW() - INTERVAL '${DEFAULT_INTERVAL}'
         ORDER BY "${tagKey}"
         LIMIT ${DEFAULT_LIMIT}
       `

--- a/src/dataExplorer/context/tags.tsx
+++ b/src/dataExplorer/context/tags.tsx
@@ -8,7 +8,10 @@ import {
   CACHING_REQUIRED_END_DATE,
   CACHING_REQUIRED_START_DATE,
 } from 'src/utils/datetime/constants'
-import {DEFAULT_INTERVAL, DEFAULT_LIMIT} from 'src/shared/constants/queryBuilder'
+import {
+  DEFAULT_INTERVAL,
+  DEFAULT_LIMIT,
+} from 'src/shared/constants/queryBuilder'
 import {LanguageType} from 'src/dataExplorer/components/resources'
 
 // Contexts

--- a/src/shared/constants/queryBuilder.ts
+++ b/src/shared/constants/queryBuilder.ts
@@ -1,1 +1,2 @@
 export const DEFAULT_LIMIT = 1000
+export const DEFAULT_INTERVAL = '1 day'


### PR DESCRIPTION
Add a time interval limit when populating a tag values menu, this is to avoid the need to process the entire measurement.

Closes #

<!-- Describe your proposed changes here. -->
<!-- Including screenshots or visuals is very helpful - a picture is worth a thousand words. -->

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
