### PR TITLE
fix(ui): remove mentions of TSM-specific limits for Serverless users

### DIFF
--- a/src/billing/components/Free/OrgLimits.tsx
+++ b/src/billing/components/Free/OrgLimits.tsx
@@ -104,6 +104,15 @@ export const OrgLimits: FC = () => {
           )
         }
 
+        // The 'dashboards', 'tasks', 'checks', and 'rules' limits are not applicable to orgs using IOx.
+        if (orgUsesIOx) {
+          const hiddenLimits = ['dashboards', 'tasks', 'checks', 'rules']
+
+          if (hiddenLimits.includes(limitName)) {
+            return null
+          }
+        }
+
         // By default, any 'limit' is a single object literal containing one limitStatus.
         return (
           <LimitCard

--- a/src/billing/components/Free/PAYGConversion.tsx
+++ b/src/billing/components/Free/PAYGConversion.tsx
@@ -67,15 +67,17 @@ export const Credit250PAYGConversion: FC = () => {
           <ul className="credit-250-conversion-panel--benefits">
             <li>Unlimited buckets to store your data</li>
             <li>Unlimited storage retention</li>
-            <li>Unlimited dashboards</li>
-            <li>Unlimited tasks</li>
-            <li>Unlimited alert checks and notification rules</li>
-            <li>HTTP and PagerDuty notifications</li>
             {!orgUsesIOx && (
-              <li>
-                Up to {Intl.NumberFormat().format(CARDINALITY_LIMIT)} series
-                cardinality
-              </li>
+              <>
+                <li>Unlimited dashboards</li>
+                <li>Unlimited tasks</li>
+                <li>Unlimited alert checks and notification rules</li>
+                <li>HTTP and PagerDuty notifications</li>
+                <li>
+                  Up to {Intl.NumberFormat().format(CARDINALITY_LIMIT)} series
+                  cardinality
+                </li>
+              </>
             )}
           </ul>
         </div>
@@ -121,15 +123,18 @@ export const PAYGConversion: FC = () => {
                     <ul className="conversion-panel--benefits">
                       <li>Unlimited buckets to store your data</li>
                       <li>Unlimited storage retention</li>
-                      <li>Unlimited dashboards</li>
-                      <li>Unlimited tasks</li>
-                      <li>Unlimited alert checks and notification rules</li>
-                      <li>HTTP and PagerDuty notifications</li>
                       {!orgUsesIOx && (
-                        <li>
-                          Up to {Intl.NumberFormat().format(CARDINALITY_LIMIT)}{' '}
-                          series cardinality
-                        </li>
+                        <>
+                          <li>Unlimited dashboards</li>
+                          <li>Unlimited tasks</li>
+                          <li>Unlimited alert checks and notification rules</li>
+                          <li>HTTP and PagerDuty notifications</li>
+                          <li>
+                            Up to{' '}
+                            {Intl.NumberFormat().format(CARDINALITY_LIMIT)}{' '}
+                            series cardinality
+                          </li>
+                        </>
                       )}
                     </ul>
                   </div>

--- a/src/operator/OrgOverlay.tsx
+++ b/src/operator/OrgOverlay.tsx
@@ -65,7 +65,7 @@ export const OrgOverlay: FC = () => {
   const isIOx =
     organization?.storageType &&
     organization.storageType.toLowerCase() === 'iox'
-  const canSeeCardinalityLimits = !isIOx
+  const canSeeTsmLimits = !isIOx
 
   useEffect(() => {
     handleGetLimits(orgID)
@@ -223,7 +223,7 @@ export const OrgOverlay: FC = () => {
                         onChangeLimits={setLimits}
                       />
                     </Grid.Column>
-                    {canSeeCardinalityLimits && (
+                    {canSeeTsmLimits && (
                       <Grid.Column widthMD={Columns.Four}>
                         <Form.Label label="Series Cardinality" />
                         <LimitsField
@@ -265,45 +265,49 @@ export const OrgOverlay: FC = () => {
                         onChangeLimits={setLimits}
                       />
                     </Grid.Column>
-                    <Grid.Column widthMD={Columns.Four}>
-                      <Form.Label label="Max Notifications" />
-                      <LimitsField
-                        type={InputType.Number}
-                        name="notificationRule.maxNotifications"
-                        limits={limits}
-                        onChangeLimits={setLimits}
-                      />
-                    </Grid.Column>
+                    {canSeeTsmLimits && (
+                      <Grid.Column widthMD={Columns.Four}>
+                        <Form.Label label="Max Notifications" />
+                        <LimitsField
+                          type={InputType.Number}
+                          name="notificationRule.maxNotifications"
+                          limits={limits}
+                          onChangeLimits={setLimits}
+                        />
+                      </Grid.Column>
+                    )}
                   </Grid.Row>
-                  <Grid.Row>
-                    <Grid.Column widthMD={Columns.Four}>
-                      <Form.Label label="Max Dashboards" />
-                      <LimitsField
-                        type={InputType.Number}
-                        name="dashboard.maxDashboards"
-                        limits={limits}
-                        onChangeLimits={setLimits}
-                      />
-                    </Grid.Column>
-                    <Grid.Column widthMD={Columns.Four}>
-                      <Form.Label label="Max Tasks" />
-                      <LimitsField
-                        type={InputType.Number}
-                        name="task.maxTasks"
-                        limits={limits}
-                        onChangeLimits={setLimits}
-                      />
-                    </Grid.Column>
-                    <Grid.Column widthMD={Columns.Four}>
-                      <Form.Label label="Max Checks" />
-                      <LimitsField
-                        type={InputType.Number}
-                        name="check.maxChecks"
-                        limits={limits}
-                        onChangeLimits={setLimits}
-                      />
-                    </Grid.Column>
-                  </Grid.Row>
+                  {canSeeTsmLimits && (
+                    <Grid.Row>
+                      <Grid.Column widthMD={Columns.Four}>
+                        <Form.Label label="Max Dashboards" />
+                        <LimitsField
+                          type={InputType.Number}
+                          name="dashboard.maxDashboards"
+                          limits={limits}
+                          onChangeLimits={setLimits}
+                        />
+                      </Grid.Column>
+                      <Grid.Column widthMD={Columns.Four}>
+                        <Form.Label label="Max Tasks" />
+                        <LimitsField
+                          type={InputType.Number}
+                          name="task.maxTasks"
+                          limits={limits}
+                          onChangeLimits={setLimits}
+                        />
+                      </Grid.Column>
+                      <Grid.Column widthMD={Columns.Four}>
+                        <Form.Label label="Max Checks" />
+                        <LimitsField
+                          type={InputType.Number}
+                          name="check.maxChecks"
+                          limits={limits}
+                          onChangeLimits={setLimits}
+                        />
+                      </Grid.Column>
+                    </Grid.Row>
+                  )}
                   {limits?.timeout && (
                     <Grid.Row>
                       <Grid.Column widthMD={Columns.Four}>


### PR DESCRIPTION
This PR removes the mention of TSM-specific limits for Serverless users.
![image](https://github.com/influxdata/ui/assets/11937365/fd524ecc-f4a5-49d4-82a6-451909a8016c)

### Checklist

Authors and Reviewer(s), please verify the following:

- [ ] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [ ] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Feature flagged, if applicable
