### PR TITLE
chore: Replace `honeybadger-js` with `honeybadger-io/js`

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
   "dependencies": {
     "@codingame/monaco-jsonrpc": "^0.3.1",
     "@docsearch/react": "^3.0.0-alpha.37",
+    "@honeybadger-io/js": "^6.9.3",
     "@influxdata/clockface": "^6.3.11",
     "@influxdata/flux-lsp-browser": "0.8.40",
     "@influxdata/giraffe": "^2.38.1",
@@ -177,7 +178,6 @@
     "deep-object-diff": "^1.1.0",
     "fix-date": "^1.1.6",
     "history": "^4.7.2",
-    "honeybadger-js": "^1.0.2",
     "html2canvas": "^1.4.1",
     "immer": "^9.0.15",
     "intersection-observer": "^0.12.2",

--- a/src/dashboards/components/NoteEditorPreview.test.tsx
+++ b/src/dashboards/components/NoteEditorPreview.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-jest.mock('honeybadger-js', () => {
+jest.mock('@honeybadger-io/js', () => {
   return {
     configure: jest.fn(),
     notify: jest.fn(),

--- a/src/me/actions/thunks/index.ts
+++ b/src/me/actions/thunks/index.ts
@@ -1,5 +1,5 @@
 // Libraries
-import HoneyBadger from 'honeybadger-js'
+import HoneyBadger from '@honeybadger-io/js'
 import {Dispatch} from 'react'
 
 // Functions making API calls

--- a/src/organizations/actions/creators.ts
+++ b/src/organizations/actions/creators.ts
@@ -1,5 +1,5 @@
 // Libraries
-import HoneyBadger from 'honeybadger-js'
+import HoneyBadger from '@honeybadger-io/js'
 import {NormalizedSchema} from 'normalizr'
 
 // Types

--- a/src/shared/utils/errors.ts
+++ b/src/shared/utils/errors.ts
@@ -1,5 +1,5 @@
 import {ErrorInfo} from 'react'
-import HoneyBadger from 'honeybadger-js'
+import HoneyBadger from '@honeybadger-io/js'
 import {
   CLOUD,
   GIT_SHA,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1481,6 +1481,23 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
+"@honeybadger-io/core@^6.6.0":
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/@honeybadger-io/core/-/core-6.6.0.tgz#a18782ffdb4b8bdc0c36076bd330fb6c6ada1060"
+  integrity sha512-B5X05huAsDs7NJOYm4bwHf2v0tMuTjBWLfumHH9DCblq8E1XrujlbbNkIdEHlzc01K9oAXuvsaBwVkE7G5+aLQ==
+  dependencies:
+    json-nd "^1.0.0"
+    stacktrace-parser "^0.1.10"
+
+"@honeybadger-io/js@^6.9.3":
+  version "6.9.3"
+  resolved "https://registry.yarnpkg.com/@honeybadger-io/js/-/js-6.9.3.tgz#0e7c60d602934765e44228974122031e5da66141"
+  integrity sha512-Un5WFiJ9anpnKKHYINvCTkXiIK18gILbiwJjJWKxio3Tc1HHmF7/GoSxoK4QUok5jpk1ja7Fi2FiG/YCqk+Bog==
+  dependencies:
+    "@honeybadger-io/core" "^6.6.0"
+    "@types/aws-lambda" "^8.10.89"
+    "@types/express" "^4.17.13"
+
 "@humanwhocodes/config-array@^0.10.4":
   version "0.10.4"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.10.4.tgz#01e7366e57d2ad104feea63e72248f22015c520c"
@@ -1530,10 +1547,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/influxdb-templates/-/influxdb-templates-0.11.0.tgz#872d7b71aa9b578c7ec194368deaa7b568790d1a"
   integrity sha512-aUvnP3HlEC4/3SnD4GBrtesLRZQPrBJOP4VA/0K63gnuEXO8k0/zBMpNVJOQqM+1tS/ZOmMhGpg3moQxAtwPcg==
 
-"@influxdata/oats@0.5.3":
-  version "0.5.3"
-  resolved "https://registry.npmjs.org/@influxdata/oats/-/oats-0.5.3.tgz"
-  integrity sha512-OG3kr6p5U+wpa2qny+Cu8CBqHJne9mKEC5ux4JJTnk1eQnfAtNv+DGdz0QH+Ouz/8cqjl2erkPx6RPMGmUYMeA==
+"@influxdata/oats@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@influxdata/oats/-/oats-0.7.0.tgz#dd3d94a7b8d42a5d8dbedf4e2ccdb097dd9563f4"
+  integrity sha512-i78Y0svY0H9nYo1YZ0KzTV4KO6mj+jItTJcUgZq8/y6TJlexE3wma9qpG2lxzwj1LGBSogTjfUWVYdRUm2m05Q==
   dependencies:
     commander "^2.20.0"
     humps "^2.0.1"
@@ -1964,6 +1981,11 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/asap/-/asap-2.0.0.tgz#d529e9608c83499a62ae08c871c5e62271aa2963"
   integrity sha512-upIS0Gt9Mc8eEpCbYMZ1K8rhNosfKUtimNcINce+zLwJF5UpM3Vv7yz3S5l/1IX+DxTa8lTkUjqynvjRXyJzsg==
+
+"@types/aws-lambda@^8.10.89":
+  version "8.10.140"
+  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.140.tgz#617534c437f3cb9bda3e6661c25e9a1510ae9f2d"
+  integrity sha512-4Dh3dk2TUcbdfHrX0Al90mNGJDvA9NBiTQPzbrjGi/dLxzKCGOYgT8YQ47jUKNFALkAJAadifq0pzyjIUlhVhg==
 
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.14":
   version "7.1.19"
@@ -5709,11 +5731,6 @@ hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-
   dependencies:
     react-is "^16.7.0"
 
-honeybadger-js@^1.0.2:
-  version "1.0.4"
-  resolved "https://registry.npmjs.org/honeybadger-js/-/honeybadger-js-1.0.4.tgz"
-  integrity sha512-bqVVTODgzgOdvC+Pur0HHhTtMMo3FI+h0Y7hNzWAJY/bPFSJQfEy1X8YHcZ1gO8HkSrTvg+lIx5UANHNmfbIhg==
-
 hpack.js@^2.1.6:
   version "2.1.6"
   resolved "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz"
@@ -6968,6 +6985,11 @@ jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
   integrity sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=
+
+json-nd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-nd/-/json-nd-1.0.0.tgz#e52283b7ee3f5e6f9920f668c94044bda912120c"
+  integrity sha512-8TIp0HZAY0VVrwRQJJPb4+nOTSPoOWZeEKBTLizUfQO4oym5Fc/MKqN8vEbLCxcyxDf2vwNxOQ1q84O49GWPyQ==
 
 json-parse-even-better-errors@^2.3.0, json-parse-even-better-errors@^2.3.1:
   version "2.3.1"
@@ -9681,6 +9703,13 @@ stackblur-canvas@^2.0.0:
   resolved "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.5.0.tgz"
   integrity sha512-EeNzTVfj+1In7aSLPKDD03F/ly4RxEuF/EX0YcOG0cKoPXs+SLZxDawQbexQDBzwROs4VKLWTOaZQlZkGBFEIQ==
 
+stacktrace-parser@^0.1.10:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/stacktrace-parser/-/stacktrace-parser-0.1.10.tgz#29fb0cae4e0d0b85155879402857a1639eb6051a"
+  integrity sha512-KJP1OCML99+8fhOHxwwzyWrlUuVX5GQ0ZpJTd1DFXhdkrvg1szxfHhawXUZ3g9TkXORQd4/WG68jMlQZ2p8wlg==
+  dependencies:
+    type-fest "^0.7.1"
+
 static-eval@2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/static-eval/-/static-eval-2.0.2.tgz#2d1759306b1befa688938454c546b7871f806a42"
@@ -10214,6 +10243,11 @@ type-fest@^0.21.3:
   version "0.21.3"
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
+
+type-fest@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.7.1.tgz#8dda65feaf03ed78f0a3f9678f1869147f7c5c48"
+  integrity sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==
 
 type-is@~1.6.18:
   version "1.6.18"


### PR DESCRIPTION
Part of [#1980](https://github.com/influxdata/quartz/issues/7619)

This is based on honeybadger's migration guide here: https://docs.honeybadger.io/lib/javascript/support/upgrading-to-v3/

### Checklist

Authors and Reviewer(s), please verify the following:

- [ ] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [ ] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
