### PR TITLE
fix: add guidance re usage query count

### DIFF
--- a/cypress/e2e/cloud/usage.test.ts
+++ b/cypress/e2e/cloud/usage.test.ts
@@ -2,7 +2,7 @@ import {Organization} from '../../../src/types'
 
 const statHeaders = [
   'Data In (MB)',
-  'Query Count',
+  'Query Count (Flux Only) ?',
   'Storage (GB-hr)',
   'Data Out (GB)',
 ]

--- a/src/usage/UsageSingleStat.tsx
+++ b/src/usage/UsageSingleStat.tsx
@@ -1,10 +1,18 @@
 // Libraries
 import React, {FC, useContext} from 'react'
-import {Panel, ComponentSize, InfluxColors} from '@influxdata/clockface'
+import {
+  Panel,
+  ComponentSize,
+  InfluxColors,
+  QuestionMarkTooltip,
+} from '@influxdata/clockface'
 
 // Components
 import {View} from 'src/visualization'
 import {UsageContext} from 'src/usage/context/usage'
+
+// Constants
+const QUERY_COUNT_VECTOR_NAME = 'Query Count'
 
 // Types
 import {
@@ -39,6 +47,10 @@ const UsageSingleStat: FC<Props> = ({
     decimalPlaces: {isEnforced: false, digits: 0},
   }
 
+  // Adjusts table properties to warn user that only flux queries are included in the Query Count.
+  const isQueryCount: Boolean = usageVector.name === QUERY_COUNT_VECTOR_NAME
+  const vectorName = isQueryCount ? 'Query Count (Flux Only)' : usageVector.name
+
   const error = fromFluxResult?.table?.columns?.error?.data?.[0]
 
   return (
@@ -51,9 +63,14 @@ const UsageSingleStat: FC<Props> = ({
         size={ComponentSize.ExtraSmall}
         testID="usage-single-stat--header"
       >
-        <h5>{`${usageVector.name} ${
-          usageVector.unit !== '' ? `(${usageVector.unit})` : ''
-        }`}</h5>
+        <h5>
+          {`${vectorName} ${
+            usageVector.unit !== '' ? `(${usageVector.unit})` : ''
+          }`}
+          {isQueryCount && (
+            <QuestionMarkTooltip tooltipContents={queryCountWarning} />
+          )}
+        </h5>
       </Panel.Header>
       <Panel.Body className="panel-body--size" style={{height: 300 / length}}>
         <View
@@ -67,5 +84,9 @@ const UsageSingleStat: FC<Props> = ({
     </Panel>
   )
 }
+
+const queryCountWarning = (
+  <p>SQL and InfluxQL query counts are not displayed.</p>
+)
 
 export default UsageSingleStat


### PR DESCRIPTION
Clarifies that the query count on the C2 usage page reflects flux queries only.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable
