### PR TITLE
fix: correct tests to be handled by faster ci runner

### DIFF
--- a/cypress/e2e/shared/simpleTable.test.ts
+++ b/cypress/e2e/shared/simpleTable.test.ts
@@ -1,6 +1,10 @@
 import {Organization} from '../../../src/types'
 import {points} from '../../support/commands'
 
+const featureFlags = {
+  showOldDataExplorerInNewIOx: true,
+}
+
 describe('simple table interactions', () => {
   const simpleSmall = 'simple-small'
   const simpleLarge = 'simple-large'
@@ -8,9 +12,7 @@ describe('simple table interactions', () => {
   beforeEach(() => {
     cy.flush()
     cy.signin()
-    cy.setFeatureFlags({
-      showOldDataExplorerInNewIOx: true,
-    }).then(() =>
+    cy.setFeatureFlags(featureFlags).then(() =>
       cy.get('@org').then(({id: orgID}: Organization) => {
         cy.fixture('routes').then(({orgs, explorer}) => {
           cy.visit(`${orgs}/${orgID}${explorer}`)
@@ -23,7 +25,7 @@ describe('simple table interactions', () => {
         cy.writeData(points(30), simpleSmall)
         cy.createBucket(orgID, name, simpleOverflow)
         cy.writeData(points(31), simpleOverflow)
-        cy.reload()
+        cy.setFeatureFlags(featureFlags)
       })
     )
   })

--- a/cypress/e2e/shared/tasks-searching.test.ts
+++ b/cypress/e2e/shared/tasks-searching.test.ts
@@ -3,6 +3,8 @@ import {Organization} from '../../../src/types'
 const isIOxOrg = Boolean(Cypress.env('useIox'))
 const isTSMOrg = !isIOxOrg
 
+const DEFAULT_DELAY_MS = 1500
+
 const setupTest = (shouldShowTasks: boolean = true) => {
   cy.flush()
   cy.signin()
@@ -79,13 +81,13 @@ describe('When tasks already exist', () => {
 
     // Add a label
     cy.getByTestID('task-card').within(() => {
-      cy.getByTestID('inline-labels--add').click()
+      cy.getByTestID('inline-labels--add').click().wait(DEFAULT_DELAY_MS)
     })
 
     const labelName = 'l1'
     cy.getByTestID('inline-labels--popover--contents').type(labelName)
-    cy.getByTestID('inline-labels--create-new').click()
-    cy.getByTestID('create-label-form--submit').click()
+    cy.getByTestID('inline-labels--create-new').click().wait(DEFAULT_DELAY_MS)
+    cy.getByTestID('create-label-form--submit').click().wait(DEFAULT_DELAY_MS)
 
     // Delete the label
     cy.getByTestID(`label--pill--delete ${labelName}`).click({force: true})
@@ -114,18 +116,22 @@ describe('When tasks already exist', () => {
     const firstLabel = 'very important task'
     const secondLabel = 'mission critical'
 
-    cy.get('button.cf-button[title="Add labels"]').click()
+    cy.get('button.cf-button[title="Add labels"]')
+      .click()
+      .wait(DEFAULT_DELAY_MS)
     cy.getByTestID('inline-labels--popover--dialog').should('be.visible')
     cy.getByTestID('inline-labels--popover-field').type(`${firstLabel}{enter}`)
     cy.getByTestID('overlay--container').should('be.visible')
-    cy.getByTestID('create-label-form--submit').click()
+    cy.getByTestID('create-label-form--submit').click().wait(DEFAULT_DELAY_MS)
 
     cy.getByTestID('overlay--container').should('not.exist')
-    cy.get('button.cf-button[title="Add labels"]').click()
+    cy.get('button.cf-button[title="Add labels"]')
+      .click()
+      .wait(DEFAULT_DELAY_MS)
     cy.getByTestID('inline-labels--popover--dialog').should('be.visible')
     cy.getByTestID('inline-labels--popover-field').type(`${secondLabel}{enter}`)
     cy.getByTestID('overlay--container').should('be.visible')
-    cy.getByTestID('create-label-form--submit').click()
+    cy.getByTestID('create-label-form--submit').click().wait(DEFAULT_DELAY_MS)
 
     // ensure the two labels are present before cloning
     cy.getByTestID('overlay--container').should('not.exist')
@@ -133,8 +139,8 @@ describe('When tasks already exist', () => {
     cy.getByTestID(`label--pill ${secondLabel}`).should('be.visible')
 
     // clone the task
-    cy.getByTestID('context-menu-task').click()
-    cy.getByTestID('context-clone-task').click()
+    cy.getByTestID('context-menu-task').click().wait(DEFAULT_DELAY_MS)
+    cy.getByTestID('context-clone-task').click().wait(DEFAULT_DELAY_MS)
     cy.getByTestID('task-card--slide-toggle').should('have.length', 2)
     cy.getByTestID(`label--pill ${firstLabel}`).should('have.length', 2)
     cy.getByTestID(`label--pill ${secondLabel}`).should('have.length', 2)
@@ -143,7 +149,10 @@ describe('When tasks already exist', () => {
     cy.getByTestID('task-card--slide-toggle')
       .eq(0)
       .should('have.class', 'active')
-    cy.getByTestID('task-card--slide-toggle').eq(0).click()
+    cy.getByTestID('task-card--slide-toggle')
+      .eq(0)
+      .click()
+      .wait(DEFAULT_DELAY_MS)
 
     // only the clone should be active
     cy.getByTestID('task-card--slide-toggle')
@@ -155,7 +164,7 @@ describe('When tasks already exist', () => {
     // clone a task
     const cloneNamePrefix = '🦄ask (cloned at '
     cy.getByTestID('task-card').then(() => {
-      cy.getByTestID('context-menu-task').click()
+      cy.getByTestID('context-menu-task').click().wait(DEFAULT_DELAY_MS)
       cy.getByTestID('context-clone-task').click().type('{esc}')
     })
 
@@ -198,7 +207,7 @@ describe('When tasks already exist', () => {
     cy.getByTestID('task-form-offset-input').focus().clear().type('10m')
     cy.getByTestID('task-form-offset-input').should('have.value', '10m')
 
-    cy.getByTestID('task-save-btn').click()
+    cy.getByTestID('task-save-btn').click().wait(DEFAULT_DELAY_MS)
 
     // assert changed task name
     cy.getByTestID('task-card--name').contains('Copy task test')

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -911,8 +911,14 @@ export const clearSqlScriptSession = () => {
 }
 
 export const selectScriptBucket = (bucketName: string) => {
-  cy.getByTestID('bucket-selector--dropdown-button').click()
-  cy.getByTestID(`bucket-selector--dropdown--${bucketName}`).click()
+  const MENU_WAIT_DELAY_MS = 1000
+
+  cy.getByTestID('bucket-selector--dropdown-button')
+    .click()
+    .wait(MENU_WAIT_DELAY_MS)
+  cy.getByTestID(`bucket-selector--dropdown--${bucketName}`)
+    .click()
+    .wait(MENU_WAIT_DELAY_MS)
   cy.getByTestID('bucket-selector--dropdown-button').should(
     'contain',
     bucketName
@@ -1510,7 +1516,7 @@ export const setFeatureFlagsNoNav = (flags: FlagMap): Cypress.Chainable => {
     }).as('setFeatureFlagsResponse')
   })
 
-  return cy.wait(0)
+  return cy.wait(1000)
 }
 
 export const createTaskFromEmpty = (


### PR DESCRIPTION
Part of internal AUX team issue. 

Best reviewed with ?w=1 for whitespace changes

This PR resolves several issues with UI e2e tests that cause the tests to fail when running on a different CI runner. Primary issue is that existing runners generated some built-in delay was effectively adding a `.wait()` or `should()` where not present in the code. On the faster runner this is no longer the case.

1. Using `cy.wait`s to handle cases where a `click` did not wait for a corresponding DOM change. _Once this is tested with the new runner, I would prefer to convert `wait`s to asserting on the presence of specific DOM elements if time allows._
2. Using `.first()` to handle cases where later renders generated more than one DOM element matching on the selector when we are only looking for the first one.
3. Cleaned up cases where `cy.reload()` caused a page reload without setting feature flags.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable
