### PR TITLE
chore: add delay to tasks-searching test

### DIFF
--- a/cypress/e2e/shared/tasks-searching.test.ts
+++ b/cypress/e2e/shared/tasks-searching.test.ts
@@ -120,7 +120,9 @@ describe('When tasks already exist', () => {
       .click()
       .wait(DEFAULT_DELAY_MS)
     cy.getByTestID('inline-labels--popover--dialog').should('be.visible')
-    cy.getByTestID('inline-labels--popover-field').type(`${firstLabel}{enter}`)
+    cy.getByTestID('inline-labels--popover-field')
+      .type(`${firstLabel}{enter}`)
+      .wait(DEFAULT_DELAY_MS)
     cy.getByTestID('overlay--container').should('be.visible')
     cy.getByTestID('create-label-form--submit').click().wait(DEFAULT_DELAY_MS)
 
@@ -129,7 +131,9 @@ describe('When tasks already exist', () => {
       .click()
       .wait(DEFAULT_DELAY_MS)
     cy.getByTestID('inline-labels--popover--dialog').should('be.visible')
-    cy.getByTestID('inline-labels--popover-field').type(`${secondLabel}{enter}`)
+    cy.getByTestID('inline-labels--popover-field')
+      .type(`${secondLabel}{enter}`)
+      .wait(DEFAULT_DELAY_MS)
     cy.getByTestID('overlay--container').should('be.visible')
     cy.getByTestID('create-label-form--submit').click().wait(DEFAULT_DELAY_MS)
 


### PR DESCRIPTION
This adds a wait needed to stop some ongoing flake in one of the tests using the new test runner. See https://github.com/influxdata/ui/pull/6910, https://github.com/influxdata/ui/pull/6911

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable
