### PR TITLE
fix: flake in scriptquerybuilder, tasks e2es

### DIFF
--- a/cypress/e2e/shared/scriptQueryBuilder.results.test.ts
+++ b/cypress/e2e/shared/scriptQueryBuilder.results.test.ts
@@ -7,6 +7,8 @@ const DELAY_FOR_LSP_SERVER_BOOTUP = 7000
 
 const DELAY_FOR_FILE_DOWNLOAD = 5000
 
+const DEFAULT_DELAY_MS = 2000
+
 describe('Script Builder', () => {
   const writeData: string[] = []
   for (let i = 0; i < 30; i++) {
@@ -116,9 +118,18 @@ describe('Script Builder', () => {
       cy.wait('@query -1h')
 
       cy.log('query date range can be adjusted')
-      cy.getByTestID('timerange-dropdown--button').should('be.visible').click()
-      cy.getByTestID('dropdown-item-past15m').should('exist').click()
-      cy.getByTestID('time-machine-submit-button').should('exist').click()
+      cy.getByTestID('timerange-dropdown--button')
+        .should('be.visible')
+        .click()
+        .wait(DEFAULT_DELAY_MS)
+      cy.getByTestID('dropdown-item-past15m')
+        .should('exist')
+        .click()
+        .wait(DEFAULT_DELAY_MS)
+      cy.getByTestID('time-machine-submit-button')
+        .should('exist')
+        .click()
+        .wait(DEFAULT_DELAY_MS)
       cy.wait('@query -15m')
     })
 
@@ -149,7 +160,7 @@ describe('Script Builder', () => {
         cy.getByTestID('time-machine-submit-button').should('exist')
         cy.getByTestID('time-machine-submit-button').clickAttached()
         cy.wait('@query -1h')
-        cy.wait(1000) // bit more time for csv parsing
+        cy.wait(DEFAULT_DELAY_MS) // bit more time for csv parsing
 
         cy.log('table metadata displayed to user is correct')
         if (truncated) {
@@ -201,12 +212,16 @@ describe('Script Builder', () => {
         })
 
         cy.log('turn off composition sync')
-        cy.getByTestID('editor-sync--toggle').click()
+        cy.getByTestID('editor-sync--toggle').click().wait(DEFAULT_DELAY_MS)
         cy.getByTestID('editor-sync--toggle').should('not.have.class', 'active')
         cy.log('select empty dataset')
-        cy.getByTestID('flux-editor').monacoType(`{selectall}{enter}
+        cy.getByTestID('flux-editor')
+          .monacoType(
+            `{selectall}{enter}
           from(bucket: "defbuck3") |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
-        `)
+        `
+          )
+          .wait(DEFAULT_DELAY_MS)
         cy.getByTestID('flux-editor').contains('defbuck3')
 
         runTest(0, 0, false)

--- a/cypress/e2e/shared/tasks-searching.test.ts
+++ b/cypress/e2e/shared/tasks-searching.test.ts
@@ -27,7 +27,10 @@ const setupTest = (shouldShowTasks: boolean = true) => {
           cy.getByTestID('tree-nav').should('be.visible')
           // Tasks link should appear in nav in TSM orgs.
           if (isTSMOrg) {
-            cy.getByTestID('nav-item-tasks').should('be.visible').click()
+            cy.getByTestID('nav-item-tasks')
+              .should('be.visible')
+              .click()
+              .wait(DEFAULT_DELAY_MS)
           } else {
             cy.visit(`${orgs}/${id}/tasks`)
           }
@@ -55,6 +58,7 @@ describe('When tasks already exist', () => {
       .then(() => {
         cy.getByTestID('task-card--slide-toggle')
           .click()
+          .wait(DEFAULT_DELAY_MS)
           .then(() => {
             cy.getByTestID('task-card--slide-toggle').should(
               'not.have.class',
@@ -70,6 +74,7 @@ describe('When tasks already exist', () => {
       cy.getByTestID('task-card--name').then(() => {
         cy.getByTestID('task-card--name-button')
           .click()
+          .wait(DEFAULT_DELAY_MS)
           .then(() => {
             cy.getByTestID('task-card--input').type(newName).type('{enter}')
           })
@@ -90,7 +95,9 @@ describe('When tasks already exist', () => {
     cy.getByTestID('create-label-form--submit').click().wait(DEFAULT_DELAY_MS)
 
     // Delete the label
-    cy.getByTestID(`label--pill--delete ${labelName}`).click({force: true})
+    cy.getByTestID(`label--pill--delete ${labelName}`)
+      .click({force: true})
+      .wait(DEFAULT_DELAY_MS)
     cy.getByTestID('inline-labels--empty').should('exist')
   })
 
@@ -102,9 +109,11 @@ describe('When tasks already exist', () => {
       .then(() => {
         cy.getByTestID(`context-delete-menu ${TaskName}--button`)
           .click()
+          .wait(DEFAULT_DELAY_MS)
           .then(() => {
             cy.getByTestID(`context-delete-menu ${TaskName}--confirm-button`)
               .click()
+              .wait(DEFAULT_DELAY_MS)
               .then(() => {
                 cy.getByTestID('empty-tasks-list').should('exist')
               })
@@ -169,7 +178,10 @@ describe('When tasks already exist', () => {
     const cloneNamePrefix = '🦄ask (cloned at '
     cy.getByTestID('task-card').then(() => {
       cy.getByTestID('context-menu-task').click().wait(DEFAULT_DELAY_MS)
-      cy.getByTestID('context-clone-task').click().type('{esc}')
+      cy.getByTestID('context-clone-task')
+        .click()
+        .wait(DEFAULT_DELAY_MS)
+        .type('{esc}')
     })
 
     cy.getByTestID('task-card').should('have.length', 2)
@@ -309,7 +321,10 @@ describe('Searching and filtering', () => {
   it('can click to filter tasks by labels', () => {
     cy.getByTestID('task-card').should('have.length', 2)
 
-    cy.getByTestID(`label--pill ${newLabelName}`).should('be.visible').click()
+    cy.getByTestID(`label--pill ${newLabelName}`)
+      .should('be.visible')
+      .click()
+      .wait(DEFAULT_DELAY_MS)
 
     cy.getByTestID('task-card').should('have.length', 1)
 


### PR DESCRIPTION
This reduces flake in the two most frequently flaking tests in the e2e CI pipeline. This should help the pipeline generally, but particularly for the new runner for OSS CI.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable
