### PR TITLE
fix: combat flake on two most frequently flaking e2es

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,6 +1,6 @@
 {
   "retries": {
-    "runMode": 2,
+    "runMode": 3,
     "openMode": 0
   },
   "numTestsKeptInMemory": 25,

--- a/cypress/e2e/shared/scriptQueryBuilder.results.test.ts
+++ b/cypress/e2e/shared/scriptQueryBuilder.results.test.ts
@@ -106,7 +106,8 @@ describe('Script Builder', () => {
       })
     })
 
-    it('will allow querying of different data ranges', () => {
+    // Temporarily disabled due to excess flake. Do not re-enable without rewriting this test.
+    it.skip('will allow querying of different data ranges', () => {
       cy.log('Ensure LSP is online') // deflake
       cy.wait(DELAY_FOR_LSP_SERVER_BOOTUP)
 

--- a/cypress/e2e/shared/tasks-searching.test.ts
+++ b/cypress/e2e/shared/tasks-searching.test.ts
@@ -121,7 +121,8 @@ describe('When tasks already exist', () => {
       })
   })
 
-  it('can clone a task and activate just the cloned one', () => {
+  // Skipped as too flaky - reintroduce only after rewriting.
+  it.skip('can clone a task and activate just the cloned one', () => {
     const firstLabel = 'very important task'
     const secondLabel = 'mission critical'
 


### PR DESCRIPTION
This PR is part of ongoing work on using a different CI runner and reducing test flake. Based on review in CircleCI, we still have two tests that flake consistently. This PR makes two proposals:

1. Add an additional allowed retry as a fallback for flaky tests.
2. Disable one of the test cases for the two most significantly flaking e2es. After significant work trying to de-flake these suites, on these particular tests we have reached the point where the benefit has been outweighed by the detrimental CI impact. The test would be more efficient to rewrite at a stage when these pages are modified in the future.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable
