### PR TITLE
Fix ServiceWorker scope with BASE_PATH.

### DIFF
--- a/src/shared/workers/serviceWorker.ts
+++ b/src/shared/workers/serviceWorker.ts
@@ -1,3 +1,5 @@
+import {BASE_PATH} from 'src/shared/constants'
+
 export const registerServiceWorker = (): Promise<ServiceWorkerRegistration> => {
   // Worker -- load prior to page load event, in order to intercept fetch in http/2.
   // see service worker life cycle. https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers
@@ -7,7 +9,7 @@ export const registerServiceWorker = (): Promise<ServiceWorkerRegistration> => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       new URL('../workers/downloadHelper.ts', import.meta.url),
-      {scope: '/api/v2/query'}
+      {scope: `${BASE_PATH}api/v2/query`}
       /* webpackChunkName: "interceptor" */
     )
   }
@@ -25,7 +27,7 @@ export const registerServiceWorkerInfluxQL =
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         new URL('../workers/downloadHelper.ts', import.meta.url),
-        {scope: '/query'}
+        {scope: `${BASE_PATH}query`}
         /* webpackChunkName: "interceptor" */
       )
     }
@@ -43,7 +45,7 @@ export const registerServiceWorkerSQL =
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         new URL('../workers/downloadHelper.ts', import.meta.url),
-        {scope: '/api/v2private/query'}
+        {scope: `${BASE_PATH}api/v2private/query`}
         /* webpackChunkName: "interceptor" */
       )
     }


### PR DESCRIPTION
When BASE_PATH is specified to host UI in subpath, ServiceWorkers refuse to work due to mismatching scope. This can be verified through error logs in Chrome devtools on landing page.

Closes #

<!-- Describe your proposed changes here. -->
<!-- Including screenshots or visuals is very helpful - a picture is worth a thousand words. -->

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
