### PR TITLE
chore(deps): bump influxdata/influxdb-templates from 0.11.0 to 0.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "@influxdata/clockface": "^6.3.11",
     "@influxdata/flux-lsp-browser": "0.8.40",
     "@influxdata/giraffe": "^2.38.1",
-    "@influxdata/influxdb-templates": "0.11.0",
+    "@influxdata/influxdb-templates": "0.12.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",
     "abortcontroller-polyfill": "^1.3.0",
     "auth0-js": "^9.19.1",


### PR DESCRIPTION
Related to https://github.com/influxdata/edge/issues/751

This PR updates `influxdb-templates` to the latest version, which includes security updates for the `rollup` dependency.

### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
