### PR TITLE
build(deps): bump nanoid from 3.2.0 to 3.3.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
     "monaco-editor-webpack-plugin": "^7.0.1",
     "monaco-languageclient": "~0.18.1",
     "monaco-textmate": "^3.0.1",
-    "nanoid": "^3.2.0",
+    "nanoid": "^3.3.8",
     "normalizr": "^3.6.2",
     "onigasm": "^2.2.5",
     "papaparse": "^5.3.2",
@@ -225,6 +225,7 @@
   },
   "resolutions": {
     "auth0-js/**/superagent": "^9.0",
-    "minimatch": "^3.0.5"
+    "minimatch": "^3.0.5",
+    "mocha/**/nanoid": "^3.3.8"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7838,12 +7838,7 @@ mutation-observer@^1.0.3:
   resolved "https://registry.npmjs.org/mutation-observer/-/mutation-observer-1.0.3.tgz"
   integrity sha512-M/O/4rF2h776hV7qGMZUH3utZLO/jK7p8rnNgGkjKUw8zCGjRQPxB8z6+5l8+VjRUQ3dNYu4vjqXYLr+U8ZVNA==
 
-nanoid@3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
-  integrity sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==
-
-nanoid@^3.2.0, nanoid@^3.3.6:
+nanoid@3.3.3, nanoid@^3.3.6, nanoid@^3.3.8:
   version "3.3.8"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.8.tgz#b1be3030bee36aaff18bacb375e5cce521684baf"
   integrity sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==


### PR DESCRIPTION
This fixes `nanoid` more completely for https://github.com/influxdata/ui/security/dependabot/100. https://github.com/influxdata/ui/pull/6986 updated yarn.lock for the `dependencies`. This updates package.json so that `dependencies` will correctly contain 3.3.8 instead of 3.2.0 (but yarn.lock stays the same for this resolution) and updates `resolutions` to use 3.3.8 for 3.3.3 in the `mocha` devDependency.

In terms of runtime effects, there are no changes for prod and we now use 3.3.8 for the `mocha` devDependency.

Closes https://github.com/influxdata/idpe/issues/19022