### PR TITLE
fix: wait for focus on monacotype support cmd

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -100,6 +100,7 @@ Cypress.Commands.add(
     return cy.wrap(subject).within(() => {
       cy.get('.monaco-editor .view-line:last')
         .click({force: true})
+        .wait(200)
         .focused()
         .type(text, {force, delay})
     })


### PR DESCRIPTION
Adds a minor wait to the `monacoType` support command used in numerous tests to combat flake where the element is not focused in time.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable
