### PR TITLE
chore: backport dependabot updates from master

### DIFF
--- a/package.json
+++ b/package.json
@@ -225,6 +225,7 @@
   },
   "resolutions": {
     "auth0-js/**/superagent": "^9.0",
-    "minimatch": "^3.0.5"
+    "minimatch": "^3.0.5",
+    "mocha/**/nanoid": "^3.3.8"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7838,12 +7838,7 @@ mutation-observer@^1.0.3:
   resolved "https://registry.npmjs.org/mutation-observer/-/mutation-observer-1.0.3.tgz"
   integrity sha512-M/O/4rF2h776hV7qGMZUH3utZLO/jK7p8rnNgGkjKUw8zCGjRQPxB8z6+5l8+VjRUQ3dNYu4vjqXYLr+U8ZVNA==
 
-nanoid@3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
-  integrity sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==
-
-nanoid@^3.2.0, nanoid@^3.3.6:
+nanoid@3.3.3, nanoid@^3.2.0, nanoid@^3.3.6, nanoid@^3.3.8:
   version "3.3.8"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.8.tgz#b1be3030bee36aaff18bacb375e5cce521684baf"
   integrity sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5363,9 +5363,9 @@ flatted@^3.1.0:
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
 follow-redirects@^1.0.0:
-  version "1.15.4"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.4.tgz#cdc7d308bf6493126b17ea2191ea0ccf3e535adf"
-  integrity sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==
+  version "1.15.6"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
+  integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
 
 forever-agent@~0.6.1:
   version "0.6.1"


### PR DESCRIPTION
Closes: https://github.com/influxdata/edge/issues/779.

This addresses two stray dependabot alerts:
* build(deps): bump follow-redirects from 1.15.4 to 1.15.6 (Based on https://github.com/influxdata/ui/pull/6872)
* build(deps): bump nanoid from 3.2.0 and 3.3.3 to 3.3.8 (Adjust mocha/**/nanoid resolution to use ^3.3.8 from https://github.com/influxdata/ui/commit/9f138ec14f9765411eaa1685e2993ba317c62ebb in master)
