### PR TITLE
fix: specify env.ts more specifically for newer node versions

### DIFF
--- a/webpack.common.ts
+++ b/webpack.common.ts
@@ -11,7 +11,7 @@ const {
   STATIC_DIRECTORY,
   BASE_PATH,
   API_BASE_PATH,
-} = require('./src/utils/env')
+} = require('./src/utils/env.ts')
 
 const MONACO_DIR = path.resolve(__dirname, './node_modules/monaco-editor')
 

--- a/webpack.dev.ts
+++ b/webpack.dev.ts
@@ -3,7 +3,7 @@ const mergeDev = require('webpack-merge').merge
 const commonDev = require('./webpack.common.ts')
 const PORT = parseInt(process.env.PORT, 10) || 8080
 const PUBLIC = process.env.PUBLIC || undefined
-const BASE_PATH_DEV = require('./src/utils/env').BASE_PATH
+const BASE_PATH_DEV = require('./src/utils/env.ts').BASE_PATH
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
 
 module.exports = mergeDev(commonDev, {

--- a/webpack.fast.ts
+++ b/webpack.fast.ts
@@ -1,7 +1,7 @@
 // utils
 const common = require('./webpack.common.ts')
 const merge = require('webpack-merge').merge
-const STATIC_DIR = require('./src/utils/env').STATIC_DIRECTORY
+const STATIC_DIR = require('./src/utils/env.ts').STATIC_DIRECTORY
 
 module.exports = merge(common, {
   mode: 'none',

--- a/webpack.lighthouse.ts
+++ b/webpack.lighthouse.ts
@@ -7,7 +7,7 @@ const commonPath = require('path')
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin')
 const TerserJSPlugin = require('terser-webpack-plugin')
 
-const DIRECTORY_STATIC = require('./src/utils/env').STATIC_DIRECTORY
+const DIRECTORY_STATIC = require('./src/utils/env.ts').STATIC_DIRECTORY
 
 module.exports = mergeWebpack(commonWebpack, {
   mode: 'production',

--- a/webpack.prod.ts
+++ b/webpack.prod.ts
@@ -8,7 +8,7 @@ const CssMinimizerPlugin = require('css-minimizer-webpack-plugin')
 const TerserJSPlugin = require('terser-webpack-plugin')
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
 
-const DIRECTORY_STATIC = require('./src/utils/env').STATIC_DIRECTORY
+const DIRECTORY_STATIC = require('./src/utils/env.ts').STATIC_DIRECTORY
 
 module.exports = mergeWebpack(commonWebpack, {
   mode: 'production',


### PR DESCRIPTION
[Module resolution](https://nodejs.org/api/modules.html#loading-ecmascript-modules-using-require) has changed with Node 23.6.0. Node permits importing ESM with require statements, but require statements now require specifying rather than inferring a file extension. This breaks production builds with Node versions >= 23.6.0. Thank you to @philjb for identifying this.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable
