### PR TITLE
fix: update retention rule for CLOUD and OSS

### DIFF
--- a/src/buckets/components/createBucketForm/UpdateBucketOverlay.tsx
+++ b/src/buckets/components/createBucketForm/UpdateBucketOverlay.tsx
@@ -1,13 +1,13 @@
 // Libraries
 import React, {
-  ChangeEvent,
-  FormEvent,
   FunctionComponent,
-  useCallback,
   useEffect,
   useState,
+  ChangeEvent,
+  FormEvent,
+  useCallback,
 } from 'react'
-import {useHistory, useParams} from 'react-router-dom'
+import {useParams, useHistory} from 'react-router-dom'
 import {useDispatch, useSelector} from 'react-redux'
 import {get} from 'lodash'
 

--- a/src/buckets/components/createBucketForm/UpdateBucketOverlay.tsx
+++ b/src/buckets/components/createBucketForm/UpdateBucketOverlay.tsx
@@ -154,7 +154,7 @@ const UpdateBucketOverlay: FunctionComponent = () => {
       if (CLOUD) {
         setBucketDraft({
           ...bucketDraft,
-          retentionRules: undefined
+          retentionRules: undefined,
         })
         return
       }
@@ -163,7 +163,6 @@ const UpdateBucketOverlay: FunctionComponent = () => {
         ...bucketDraft,
         retentionRules: [{everySeconds: 0}],
       })
-
     }
   }
 

--- a/src/buckets/components/createBucketForm/UpdateBucketOverlay.tsx
+++ b/src/buckets/components/createBucketForm/UpdateBucketOverlay.tsx
@@ -1,13 +1,13 @@
 // Libraries
 import React, {
-  FunctionComponent,
-  useEffect,
-  useState,
   ChangeEvent,
   FormEvent,
+  FunctionComponent,
   useCallback,
+  useEffect,
+  useState,
 } from 'react'
-import {useParams, useHistory} from 'react-router-dom'
+import {useHistory, useParams} from 'react-router-dom'
 import {useDispatch, useSelector} from 'react-redux'
 import {get} from 'lodash'
 
@@ -151,10 +151,19 @@ const UpdateBucketOverlay: FunctionComponent = () => {
         ],
       })
     } else {
+      if (CLOUD) {
+        setBucketDraft({
+          ...bucketDraft,
+          retentionRules: undefined
+        })
+        return
+      }
+
       setBucketDraft({
         ...bucketDraft,
-        retentionRules: [],
+        retentionRules: [{everySeconds: 0}],
       })
+
     }
   }
 

--- a/src/buckets/components/createBucketForm/UpdateBucketOverlay.tsx
+++ b/src/buckets/components/createBucketForm/UpdateBucketOverlay.tsx
@@ -151,17 +151,9 @@ const UpdateBucketOverlay: FunctionComponent = () => {
         ],
       })
     } else {
-      if (CLOUD) {
-        setBucketDraft({
-          ...bucketDraft,
-          retentionRules: undefined,
-        })
-        return
-      }
-
       setBucketDraft({
         ...bucketDraft,
-        retentionRules: [{everySeconds: 0}],
+        retentionRules: CLOUD ? [] : [{everySeconds: 0}],
       })
     }
   }


### PR DESCRIPTION
Closes #1607

Fix the bug when updating the retention period of buckets:
-  Before fix: set a retention period, eg. 1 hour, then change to never -> the retention period is still 1 hour
-  After fix: set a retention period, eg. 1 hour, then change to never -> the retention period changes to never

The recorded screen is the result when update in OSS:

https://github.com/user-attachments/assets/88c03b7a-06fb-4f68-a66b-62bddf8217b8

The image is the result  when update in CLOUD:

Note: I have to mock the variable CLOUD because I don't know how to run the CLOUD in my local. In the captured screen the retentionRules in the payload is not exists when send to the backend like ui team suggested
<img width="1440" alt="Screenshot 2025-02-25 at 15 14 05" src="https://github.com/user-attachments/assets/9c2ca679-8ff9-4430-87a6-7a7b54a593a1" />


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
