### PR TITLE
fix: remove unused endpoints

### DIFF
--- a/src/flows/components/header/index.tsx
+++ b/src/flows/components/header/index.tsx
@@ -56,14 +56,16 @@ const FlowHeader: FC = () => {
   const dispatch = useDispatch()
 
   useEffect(() => {
-    getNotebooksShare({query: {orgID: '', notebookID: flow.id}})
-      .then(res => {
-        if (!!res?.data?.[0]) {
-          // TODO: handle there being multiple links?
-          setShare({id: res.data[0].id, accessID: res.data[0].accessID})
-        }
-      })
-      .catch(err => console.error('failed to get notebook share', err))
+    if (CLOUD) {
+      getNotebooksShare({query: {orgID: '', notebookID: flow.id}})
+        .then(res => {
+          if (!!res?.data?.[0]) {
+            // TODO: handle there being multiple links?
+            setShare({id: res.data[0].id, accessID: res.data[0].accessID})
+          }
+        })
+        .catch(err => console.error('failed to get notebook share', err))
+    }
   }, [flow.id])
 
   const handleSave = useCallback(

--- a/src/flows/context/version.publish.tsx
+++ b/src/flows/context/version.publish.tsx
@@ -31,6 +31,7 @@ import {getErrorMessage} from 'src/utils/api'
 
 // Types
 import {RemoteDataState} from 'src/types'
+import {CLOUD} from '../../shared/constants'
 
 interface ContextType {
   handlePublish: () => void
@@ -88,7 +89,9 @@ export const VersionPublishProvider: FC = ({children}) => {
   }, [flow.id, notebookID])
 
   useEffect(() => {
-    handleGetNotebookVersions()
+    if (CLOUD) {
+      handleGetNotebookVersions()
+    }
   }, [handleGetNotebookVersions])
 
   const handlePublish = useCallback(async () => {


### PR DESCRIPTION
Closes [Issue](https://github.com/orgs/influxdata/projects/108/views/1?groupedBy%5BcolumnId%5D=Status&pane=issue&itemId=132504243&issue=influxdata%7Cui%7C7080)

- Apis still being called after 2 unused buttons have been removed after [Fixing this issue](https://github.com/influxdata/ui/pull/7008#issuecomment-3367281468)
- I tried to hard-code the `CLOUD` variable to `true`, but the UI won't work.

1. Before the fix.

https://github.com/user-attachments/assets/c880daed-7796-4f71-8da5-66bf2d5e37ab

2. After the fix.


https://github.com/user-attachments/assets/6d7080c6-41f6-41f1-abf1-f5896ac6f3f7


### Checklist

Authors and Reviewer(s), please verify the following:

- [x] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [x] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [x] Documentation updated or issue created (provide link to issue/PR)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] Feature flagged, if applicable
