### PR TITLE
chore: pin cypress-circleci-reporter in tests

### DIFF
--- a/docker/Dockerfile.cypress
+++ b/docker/Dockerfile.cypress
@@ -7,6 +7,7 @@ WORKDIR /repo
 
 COPY ./package.json .
 
+# Pin to 0.3.0 pending update to cypress-slim image.
 RUN yarn add cypress-circleci-reporter@0.3.0
 
 COPY ./cypress.json ./cypress.json


### PR DESCRIPTION
In recent CI runs, our Cypress docker build fails at the following line:
```
RUN yarn add cypress-circleci-reporter
```

The cause is a recent update to cypress-circleci-reporter that pulls in a new release of `xmlbuilder2`, which is incompatible with our Node configuration in CI. As this pertains to CI only, and should be obviated by a broader Cypress upgrade, the proposed solution here is to pin to the 0.3 version of cypress-circleci-reporter.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable
