### PR TITLE
fix: useraccounts tests

### DIFF
--- a/cypress/e2e/cloud/userAccounts.test.ts
+++ b/cypress/e2e/cloud/userAccounts.test.ts
@@ -1,4 +1,3 @@
-import {Organization} from '../../../src/types'
 import {makeQuartzUseIDPEOrgID} from 'cypress/support/Utils'
 
 // This variable stores the current IDPE orgid and syncs it with the quartz-mock orgid.


### PR DESCRIPTION
This fixes the `userAccounts` test, which is currently failing in CI for the following reasons:

1. Flake due to the behavior of the `@ org` alias. This is probably pre-existing.
2. A change in the behavior of influxdata.com itself that affects the trailing slash on the `mkt-cancel` page.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable
