### PR TITLE
build(deps): bump validator from 13.7.0 to 13.15.23

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -10681,9 +10681,9 @@ v8-to-istanbul@^8.1.0:
     source-map "^0.7.3"
 
 validator@^13.6.0:
-  version "13.7.0"
-  resolved "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz"
-  integrity sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==
+  version "13.15.23"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.15.23.tgz#59a874f84e4594588e3409ab1edbe64e96d0c62d"
+  integrity sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw==
 
 value-equal@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Rebase of https://github.com/influxdata/ui/pull/7109 to pull in CI fixes.

Bumps [validator](https://github.com/validatorjs/validator.js) from 13.7.0 to 13.15.23.
- [Release notes](https://github.com/validatorjs/validator.js/releases)
- [Changelog](https://github.com/validatorjs/validator.js/blob/master/CHANGELOG.md)
- [Commits](https://github.com/validatorjs/validator.js/compare/13.7.0...13.15.23)

---
updated-dependencies:
- dependency-name: validator dependency-version: 13.15.23 dependency-type: indirect ...

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable
