### PR TITLE
fix: support navigation button alignment

### DIFF
--- a/src/pageLayout/containers/MainNavigation.tsx
+++ b/src/pageLayout/containers/MainNavigation.tsx
@@ -293,6 +293,10 @@ export const MainNavigation: FC = () => {
     event('helpBar.contactSupportRequest.overlay.shown')
   }
 
+  const contactSupportLinkElement = () => (
+    <a onClick={handleContactSupportClick} />
+  )
+
   return (
     <TreeNav
       expanded={navbarMode === 'expanded'}
@@ -417,22 +421,7 @@ export const MainNavigation: FC = () => {
               id="contactSupport"
               label="Contact Support"
               testID="nav-subitem-contact-support"
-              linkElement={() => (
-                <button
-                  onClick={handleContactSupportClick}
-                  style={{
-                    background: 'none',
-                    border: 'none',
-                    padding: 0,
-                    color: 'inherit',
-                    textDecoration: 'none',
-                    cursor: 'pointer',
-                    display: 'block',
-                    width: '100%',
-                    textAlign: 'left',
-                  }}
-                ></button>
-              )}
+              linkElement={contactSupportLinkElement}
             />
           )}
           <TreeNav.SubHeading label="Community" />


### PR DESCRIPTION
Corrects indention of the the new Support link to align it with other menu items.

Before (staging)
--
<img width="208" height="54" alt="Screenshot 2025-12-17 at 7 50 33 PM" src="https://github.com/user-attachments/assets/a4f77aba-63c6-4a1f-86b1-e840500a3d2f" />

After
--
<img width="178" height="60" alt="Screenshot 2025-12-17 at 7 50 14 PM" src="https://github.com/user-attachments/assets/e73ce4f1-b609-4d80-8a33-951dca152f61" />




### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable
