### PR TITLE
fix: mock network requests in e2es for dashboardsView

### DIFF
--- a/cypress/e2e/cloud/dashboardsView.test.ts
+++ b/cypress/e2e/cloud/dashboardsView.test.ts
@@ -19,6 +19,10 @@ describe('Dashboard', () => {
   )
 
   it('does not render image tags in markdown preview', () => {
+    cy.intercept('GET', 'https://influxdata.com/feedback-fill-icon.svg', {
+      fixture: 'feedback-fill-icon.svg',
+    })
+
     cy.get('@org').then(({id: orgID}: any) => {
       cy.createDashboard(orgID).then(({body}) => {
         cy.fixture('routes').then(({orgs}) => {
@@ -31,8 +35,7 @@ describe('Dashboard', () => {
     // Note cell
     const markdownImageWarning =
       "We don't support images in markdown for security purposes"
-    const noteText =
-      '![](https://icatcare.org/app/uploads/2018/07/Thinking-of-getting-a-cat.png)'
+    const noteText = '![](https://influxdata.com/feedback-fill-icon.svg)'
 
     cy.getByTestID('add-note--button').click()
     cy.getByTestID('note-editor--overlay').within(() => {
@@ -47,6 +50,10 @@ describe('Dashboard', () => {
   })
 
   it('escapes html in markdown editor', () => {
+    cy.intercept('GET', 'https://influxdata.com/feedback-fill-icon.svg', {
+      fixture: 'feedback-fill-icon.svg',
+    })
+
     cy.get('@org').then(({id: orgID}: any) => {
       cy.createDashboard(orgID).then(({body}) => {
         cy.fixture('routes').then(({orgs}) => {
@@ -58,7 +65,7 @@ describe('Dashboard', () => {
 
     // Note cell
     const noteText =
-      "<img src='https://icatcare.org/app/uploads/2018/07/Thinking-of-getting-a-cat.png'/>"
+      "<img src='https://influxdata.com/feedback-fill-icon.svg'/>"
 
     cy.getByTestID('add-note--button').click()
     cy.getByTestID('note-editor--overlay').within(() => {

--- a/cypress/e2e/oss/dashboardsView.test.ts
+++ b/cypress/e2e/oss/dashboardsView.test.ts
@@ -13,6 +13,10 @@ describe('Dashboard', () => {
   )
 
   it('does render image tags in markdown preview', () => {
+    cy.intercept('GET', 'https://influxdata.com/feedback-fill-icon.svg', {
+      fixture: 'feedback-fill-icon.svg',
+    })
+
     cy.get('@org').then(({id: orgID}: any) => {
       cy.createDashboard(orgID).then(({body}) => {
         cy.fixture('routes').then(({orgs}) => {
@@ -23,8 +27,7 @@ describe('Dashboard', () => {
     })
 
     // Note cell
-    const noteText =
-      '![](https://icatcare.org/app/uploads/2018/07/Thinking-of-getting-a-cat.png)'
+    const noteText = '![](https://influxdata.com/feedback-fill-icon.svg)'
 
     cy.getByTestID('add-note--button').click()
     cy.getByTestID('note-editor--overlay').within(() => {

--- a/cypress/fixtures/feedback-fill-icon.svg
+++ b/cypress/fixtures/feedback-fill-icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path fill="none" d="M0 0h24v24H0z"/><path d="M6.455 19L2 22.5V4a1 1 0 0 1 1-1h18a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1H6.455zM11 13v2h2v-2h-2zm0-6v5h2V7h-2z"/></svg>


### PR DESCRIPTION
This fixes a failing e2e test which appears to be reliant on the reachability of an external image asset. Replaced with a fixture using a small SVG that is already part of the assets in the repository, as the content of the image is not relevant to the test.

### Checklist

Authors and Reviewer(s), please verify the following:

- [X] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [X] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [X] Documentation updated or issue created (provide link to issue/PR)
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Feature flagged, if applicable
