### PR TITLE
fix: skip flaky scriptQueryBuilder.results e2e test

### DIFF
--- a/cypress/e2e/shared/scriptQueryBuilder.results.test.ts
+++ b/cypress/e2e/shared/scriptQueryBuilder.results.test.ts
@@ -9,7 +9,9 @@ const DELAY_FOR_FILE_DOWNLOAD = 5000
 
 const DEFAULT_DELAY_MS = 2000
 
-describe('Script Builder', () => {
+// Temporarily skipped due to consistent timeouts in remocal CI environment.
+// Do not re-enable without investigating remocal resource constraints.
+describe.skip('Script Builder', () => {
   const writeData: string[] = []
   for (let i = 0; i < 30; i++) {
     writeData.push(`ndbc,air_temp_degc=70_degrees station_id_${i}=${i}`)


### PR DESCRIPTION
Temporarily skips the scriptQueryBuilder.results test suite which has been consistently timing out in the remocal CI environment, blocking the merge queue.

### Checklist

Authors and Reviewer(s), please verify the following:

- [ ] A PR description, regardless of the triviality of this change, that communicates the value of this PR
- [ ] [Well-formatted conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/) that provide context into the change
- [ ] Documentation updated or issue created (provide link to issue/PR)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Feature flagged, if applicable
